### PR TITLE
Fix push step and harden pipeline commit handling

### DIFF
--- a/internal/pipeline/steps/babysit.go
+++ b/internal/pipeline/steps/babysit.go
@@ -560,10 +560,7 @@ func (s *BabysitStep) commitAndPush(sctx *pipeline.StepContext) error {
 	}
 	newHeadSHA = headSHA
 
-	ref := sctx.Run.Branch
-	if !strings.HasPrefix(ref, "refs/") {
-		ref = "refs/heads/" + ref
-	}
+	ref := normalizedBranchRef(sctx.Run.Branch)
 
 	upstreamSHA, lsErr := git.LsRemote(ctx, sctx.WorkDir, sctx.Repo.UpstreamURL, ref)
 	if lsErr != nil {

--- a/internal/pipeline/steps/babysit.go
+++ b/internal/pipeline/steps/babysit.go
@@ -540,6 +540,7 @@ func selectedFindingIDs(raw string) map[string]bool {
 // commitAndPush commits any uncommitted changes and force-pushes to upstream.
 func (s *BabysitStep) commitAndPush(sctx *pipeline.StepContext) error {
 	ctx := sctx.Ctx
+	newHeadSHA := ""
 
 	status, _ := git.Run(ctx, sctx.WorkDir, "status", "--porcelain")
 	if strings.TrimSpace(status) == "" {
@@ -557,10 +558,7 @@ func (s *BabysitStep) commitAndPush(sctx *pipeline.StepContext) error {
 	if err != nil {
 		return fmt.Errorf("resolve head after commit: %w", err)
 	}
-	sctx.Run.HeadSHA = headSHA
-	if err := sctx.DB.UpdateRunHeadSHA(sctx.Run.ID, headSHA); err != nil {
-		return err
-	}
+	newHeadSHA = headSHA
 
 	ref := sctx.Run.Branch
 	if !strings.HasPrefix(ref, "refs/") {
@@ -569,13 +567,18 @@ func (s *BabysitStep) commitAndPush(sctx *pipeline.StepContext) error {
 
 	upstreamSHA, lsErr := git.LsRemote(ctx, sctx.WorkDir, sctx.Repo.UpstreamURL, ref)
 	if lsErr != nil {
-		slog.Warn("ls-remote failed, pushing without force-with-lease", "ref", ref, "error", lsErr)
+		return fmt.Errorf("ls-remote upstream: %w", lsErr)
 	}
 	if err := git.Push(ctx, sctx.WorkDir, sctx.Repo.UpstreamURL, ref, upstreamSHA, upstreamSHA != ""); err != nil {
-		if lsErr != nil {
-			return fmt.Errorf("push (ls-remote failed: %v): %w", lsErr, err)
-		}
 		return fmt.Errorf("push: %w", err)
+	}
+
+	if _, err := git.Run(ctx, sctx.WorkDir, "update-ref", ref, newHeadSHA); err != nil {
+		return fmt.Errorf("update local branch ref: %w", err)
+	}
+	sctx.Run.HeadSHA = newHeadSHA
+	if err := sctx.DB.UpdateRunHeadSHA(sctx.Run.ID, newHeadSHA); err != nil {
+		return err
 	}
 
 	sctx.Log("committed and pushed fixes")

--- a/internal/pipeline/steps/babysit.go
+++ b/internal/pipeline/steps/babysit.go
@@ -564,9 +564,12 @@ func (s *BabysitStep) commitAndPush(sctx *pipeline.StepContext) error {
 
 	upstreamSHA, lsErr := git.LsRemote(ctx, sctx.WorkDir, sctx.Repo.UpstreamURL, ref)
 	if lsErr != nil {
-		return fmt.Errorf("ls-remote upstream: %w", lsErr)
+		slog.Warn("ls-remote failed, pushing without force-with-lease", "ref", ref, "error", lsErr)
 	}
 	if err := git.Push(ctx, sctx.WorkDir, sctx.Repo.UpstreamURL, ref, upstreamSHA, upstreamSHA != ""); err != nil {
+		if lsErr != nil {
+			return fmt.Errorf("push (ls-remote failed: %v): %w", lsErr, err)
+		}
 		return fmt.Errorf("push: %w", err)
 	}
 

--- a/internal/pipeline/steps/babysit.go
+++ b/internal/pipeline/steps/babysit.go
@@ -545,6 +545,13 @@ func (s *BabysitStep) commitAndPush(sctx *pipeline.StepContext) error {
 	status, _ := git.Run(ctx, sctx.WorkDir, "status", "--porcelain")
 	if strings.TrimSpace(status) == "" {
 		sctx.Log("no changes to commit")
+		headSHA, err := git.HeadSHA(ctx, sctx.WorkDir)
+		if err == nil && headSHA != sctx.Run.HeadSHA {
+			sctx.Run.HeadSHA = headSHA
+			if err := sctx.DB.UpdateRunHeadSHA(sctx.Run.ID, headSHA); err != nil {
+				return err
+			}
+		}
 		return nil
 	}
 

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -172,7 +172,6 @@ func extractCommitSummary(result *agent.Result) (string, error) {
 }
 
 func deterministicFixCommitMessage(stepName types.StepName, summary string) string {
-	summary = strings.Join(strings.Fields(summary), " ")
 	if summary == "" {
 		summary = "apply fixes"
 	}

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/kunchenguid/no-mistakes/internal/agent"
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/types"
@@ -103,6 +104,80 @@ var findingsSchema = json.RawMessage(`{
 	},
 	"required": ["findings", "summary"]
 }`)
+
+var commitSummarySchema = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"summary": {"type": "string"}
+	},
+	"required": ["summary"]
+}`)
+
+type commitSummary struct {
+	Summary string `json:"summary"`
+}
+
+func normalizedBranchRef(ref string) string {
+	if !strings.HasPrefix(ref, "refs/") {
+		return "refs/heads/" + ref
+	}
+	return ref
+}
+
+func commitAgentFixes(sctx *pipeline.StepContext, stepName types.StepName, summary, fallbackSummary string) error {
+	ctx := sctx.Ctx
+	status, _ := git.Run(ctx, sctx.WorkDir, "status", "--porcelain")
+	if strings.TrimSpace(status) == "" {
+		sctx.Log("no agent changes to commit")
+		return nil
+	}
+	if _, err := git.Run(ctx, sctx.WorkDir, "add", "-A"); err != nil {
+		return fmt.Errorf("stage %s changes: %w", stepName, err)
+	}
+	summary = strings.Join(strings.Fields(summary), " ")
+	if summary == "" {
+		summary = fallbackSummary
+	}
+	commitMessage := deterministicFixCommitMessage(stepName, summary)
+	if _, err := git.Run(ctx, sctx.WorkDir, "commit", "-m", commitMessage); err != nil {
+		return fmt.Errorf("commit %s changes: %w", stepName, err)
+	}
+	headSHA, err := git.HeadSHA(ctx, sctx.WorkDir)
+	if err != nil {
+		return fmt.Errorf("resolve head after %s commit: %w", stepName, err)
+	}
+	ref := normalizedBranchRef(sctx.Run.Branch)
+	if _, err := git.Run(ctx, sctx.WorkDir, "update-ref", ref, headSHA); err != nil {
+		return fmt.Errorf("update local branch ref: %w", err)
+	}
+	sctx.Run.HeadSHA = headSHA
+	if err := sctx.DB.UpdateRunHeadSHA(sctx.Run.ID, headSHA); err != nil {
+		return err
+	}
+	sctx.Log(fmt.Sprintf("committed agent fixes: %s", commitMessage))
+	return nil
+}
+
+func extractCommitSummary(result *agent.Result) (string, error) {
+	var summary commitSummary
+	if result.Output == nil {
+		return "", fmt.Errorf("agent returned no structured summary")
+	}
+	if err := json.Unmarshal(result.Output, &summary); err != nil {
+		return "", fmt.Errorf("parse commit summary: %w", err)
+	}
+	cleaned := strings.Join(strings.Fields(summary.Summary), " ")
+	cleaned = strings.Trim(cleaned, " \t\r\n\"'.;:,-")
+	return cleaned, nil
+}
+
+func deterministicFixCommitMessage(stepName types.StepName, summary string) string {
+	summary = strings.Join(strings.Fields(summary), " ")
+	if summary == "" {
+		summary = "apply fixes"
+	}
+	return fmt.Sprintf("no-mistakes(%s): %s", stepName, summary)
+}
 
 // isTestFile returns true if the file path matches common test file naming patterns.
 func isTestFile(path string) bool {

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -134,7 +134,6 @@ func commitAgentFixes(sctx *pipeline.StepContext, stepName types.StepName, summa
 	if _, err := git.Run(ctx, sctx.WorkDir, "add", "-A"); err != nil {
 		return fmt.Errorf("stage %s changes: %w", stepName, err)
 	}
-	summary = strings.Join(strings.Fields(summary), " ")
 	if summary == "" {
 		summary = fallbackSummary
 	}

--- a/internal/pipeline/steps/lint.go
+++ b/internal/pipeline/steps/lint.go
@@ -29,14 +29,14 @@ Context:
 - base commit: %s
 - target commit: %s
 
-			Rules:
-			- Make the minimal change needed.
-			- Do not refactor beyond what is needed.
-			- Do not run tests or broader behavioral validation.
-			- Re-run the relevant lint or format commands before finishing.
-			- Return JSON with a single "summary" field when you are done.
-			- The summary must be one concise sentence fragment suitable for a git commit subject.
-			- Keep the summary under 10 words.`,
+Rules:
+- Make the minimal change needed.
+- Do not refactor beyond what is needed.
+- Do not run tests or broader behavioral validation.
+- Re-run the relevant lint or format commands before finishing.
+- Return JSON with a single "summary" field when you are done.
+- The summary must be one concise sentence fragment suitable for a git commit subject.
+- Keep the summary under 10 words.`,
 			sctx.Run.Branch,
 			baseSHA,
 			sctx.Run.HeadSHA,
@@ -83,9 +83,9 @@ Task:
 - Only lint or format the relevant changed files when possible.
 - Report any issues found as structured findings.
 
-			Rules:
-			- Do not run tests or broader behavioral validation.
-			- Focus on lint, format, and static-analysis issues only.`,
+Rules:
+- Do not run tests or broader behavioral validation.
+- Focus on lint, format, and static-analysis issues only.`,
 				sctx.Run.Branch,
 				baseSHA,
 				sctx.Run.HeadSHA,

--- a/internal/pipeline/steps/lint.go
+++ b/internal/pipeline/steps/lint.go
@@ -33,7 +33,10 @@ Context:
 			- Make the minimal change needed.
 			- Do not refactor beyond what is needed.
 			- Do not run tests or broader behavioral validation.
-			- Re-run the relevant lint or format commands before finishing.`,
+			- Re-run the relevant lint or format commands before finishing.
+			- Return JSON with a single "summary" field when you are done.
+			- The summary must be one concise sentence fragment suitable for a git commit subject.
+			- Keep the summary under 10 words.`,
 			sctx.Run.Branch,
 			baseSHA,
 			sctx.Run.HeadSHA,
@@ -44,13 +47,21 @@ Context:
 Previous lint findings to address:
 ` + sctx.PreviousFindings
 		}
-		_, err := sctx.Agent.Run(ctx, agent.RunOpts{
-			Prompt:  fixPrompt,
-			CWD:     sctx.WorkDir,
-			OnChunk: sctx.Log,
+		result, err := sctx.Agent.Run(ctx, agent.RunOpts{
+			Prompt:     fixPrompt,
+			CWD:        sctx.WorkDir,
+			JSONSchema: commitSummarySchema,
+			OnChunk:    sctx.Log,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("agent fix lint: %w", err)
+		}
+		summary, err := extractCommitSummary(result)
+		if err != nil {
+			sctx.Log(fmt.Sprintf("warning: could not parse fix summary: %v", err))
+		}
+		if err := commitAgentFixes(sctx, s.Name(), summary, "fix lint issues"); err != nil {
+			return nil, err
 		}
 	}
 

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -75,8 +75,15 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 		if _, err := git.Run(ctx, sctx.WorkDir, "update-ref", ref, newHeadSHA); err != nil {
 			return nil, fmt.Errorf("update local branch ref: %w", err)
 		}
-		sctx.Run.HeadSHA = newHeadSHA
-		if err := sctx.DB.UpdateRunHeadSHA(sctx.Run.ID, newHeadSHA); err != nil {
+	}
+
+	headSHA, err := git.HeadSHA(ctx, sctx.WorkDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve HEAD after push: %w", err)
+	}
+	if headSHA != sctx.Run.HeadSHA {
+		sctx.Run.HeadSHA = headSHA
+		if err := sctx.DB.UpdateRunHeadSHA(sctx.Run.ID, headSHA); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -47,10 +47,7 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 		newHeadSHA = headSHA
 	}
 
-	ref := sctx.Run.Branch
-	if !strings.HasPrefix(ref, "refs/") {
-		ref = "refs/heads/" + ref
-	}
+	ref := normalizedBranchRef(sctx.Run.Branch)
 
 	upstream := sctx.Repo.UpstreamURL
 	sctx.Log(fmt.Sprintf("pushing to %s (%s)...", upstream, ref))

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -16,6 +16,7 @@ func (s *PushStep) Name() types.StepName { return types.StepPush }
 
 func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, error) {
 	ctx := sctx.Ctx
+	newHeadSHA := ""
 
 	// Run format command if configured (before committing, so changes are formatted)
 	if fmtCmd := sctx.Config.Commands.Format; fmtCmd != "" {
@@ -43,10 +44,7 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 		if err != nil {
 			return nil, fmt.Errorf("resolve head after commit: %w", err)
 		}
-		sctx.Run.HeadSHA = headSHA
-		if err := sctx.DB.UpdateRunHeadSHA(sctx.Run.ID, headSHA); err != nil {
-			return nil, err
-		}
+		newHeadSHA = headSHA
 	}
 
 	ref := sctx.Run.Branch
@@ -73,6 +71,16 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 		// New branch: regular push (no force needed)
 		if err := git.Push(ctx, sctx.WorkDir, upstream, ref, "", false); err != nil {
 			return nil, fmt.Errorf("push to upstream: %w", err)
+		}
+	}
+
+	if newHeadSHA != "" {
+		if _, err := git.Run(ctx, sctx.WorkDir, "update-ref", ref, newHeadSHA); err != nil {
+			return nil, fmt.Errorf("update local branch ref: %w", err)
+		}
+		sctx.Run.HeadSHA = newHeadSHA
+		if err := sctx.DB.UpdateRunHeadSHA(sctx.Run.ID, newHeadSHA); err != nil {
+			return nil, err
 		}
 	}
 

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -49,16 +49,16 @@ Context:
 - default branch: %s
 - ignore patterns: %s
 
-		Rules:
-		- Always start with double checking whether the findings are legitimate.
-		- Do not add code comments explaining your fixes.
-		- Verify that the issues are resolved before finishing.
-		- Return JSON with a single "summary" field when you are done.
-		- The summary must be one concise sentence fragment suitable for a git commit subject.
-		- Keep the summary under 10 words.
+Rules:
+- Always start with double checking whether the findings are legitimate.
+- Do not add code comments explaining your fixes.
+- Verify that the issues are resolved before finishing.
+- Return JSON with a single "summary" field when you are done.
+- The summary must be one concise sentence fragment suitable for a git commit subject.
+- Keep the summary under 10 words.
 
-		Previous review findings to address:
-		%s`,
+Previous review findings to address:
+%s`,
 			branch,
 			baseSHA,
 			sctx.Run.HeadSHA,

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -49,13 +49,16 @@ Context:
 - default branch: %s
 - ignore patterns: %s
 
-Rules:
-- Always start with double checking whether the findings are legitimate.
-- Do not add code comments explaining your fixes.
-- Verify that the issues are resolved before finishing.
+		Rules:
+		- Always start with double checking whether the findings are legitimate.
+		- Do not add code comments explaining your fixes.
+		- Verify that the issues are resolved before finishing.
+		- Return JSON with a single "summary" field when you are done.
+		- The summary must be one concise sentence fragment suitable for a git commit subject.
+		- Keep the summary under 10 words.
 
-Previous review findings to address:
-%s`,
+		Previous review findings to address:
+		%s`,
 			branch,
 			baseSHA,
 			sctx.Run.HeadSHA,
@@ -64,13 +67,21 @@ Previous review findings to address:
 			ignorePatterns,
 			sctx.PreviousFindings,
 		)
-		_, err := sctx.Agent.Run(ctx, agent.RunOpts{
-			Prompt:  fixPrompt,
-			CWD:     sctx.WorkDir,
-			OnChunk: sctx.Log,
+		result, err := sctx.Agent.Run(ctx, agent.RunOpts{
+			Prompt:     fixPrompt,
+			CWD:        sctx.WorkDir,
+			JSONSchema: commitSummarySchema,
+			OnChunk:    sctx.Log,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("agent fix: %w", err)
+		}
+		summary, err := extractCommitSummary(result)
+		if err != nil {
+			sctx.Log(fmt.Sprintf("warning: could not parse fix summary: %v", err))
+		}
+		if err := commitAgentFixes(sctx, s.Name(), summary, "address review findings"); err != nil {
+			return nil, err
 		}
 	}
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1397,6 +1397,58 @@ func TestPushStep_FormatCommandFailureIsWarning(t *testing.T) {
 	}
 }
 
+func TestPushStep_ReconcilesStaleDatabaseHeadSHA(t *testing.T) {
+	// When push retries after a prior UpdateRunHeadSHA failure, there are no
+	// uncommitted changes. The step must still reconcile the DB if HeadSHA is stale.
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	actualHeadSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	baseSHA := gitCmd(t, dir, "rev-parse", "main")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	// Create context with a stale HeadSHA (simulates prior DB write failure)
+	staleHeadSHA := baseSHA // intentionally wrong
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, staleHeadSHA, config.Commands{})
+	sctx.Repo.UpstreamURL = upstream
+
+	step := &PushStep{}
+	_, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// In-memory HeadSHA must match actual HEAD
+	if sctx.Run.HeadSHA != actualHeadSHA {
+		t.Errorf("Run.HeadSHA = %s, want %s", sctx.Run.HeadSHA, actualHeadSHA)
+	}
+
+	// DB record must also be updated
+	dbRun, err := sctx.DB.GetRun(sctx.Run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dbRun.HeadSHA != actualHeadSHA {
+		t.Errorf("DB HeadSHA = %s, want %s", dbRun.HeadSHA, actualHeadSHA)
+	}
+}
+
 // --- PR step tests ---
 
 func TestPRStep_Name(t *testing.T) {
@@ -2151,6 +2203,54 @@ func TestBabysitStep_CommitAndPush_NoChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 	// No error expected — just a no-op
+}
+
+func TestBabysitStep_CommitAndPush_NoChanges_ReconcilesStaleDatabaseHeadSHA(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	actualHeadSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	// Create context with stale HeadSHA (simulates prior DB write failure)
+	staleHeadSHA := baseSHA
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, staleHeadSHA, config.Commands{})
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+
+	step := &BabysitStep{}
+	err := step.commitAndPush(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if sctx.Run.HeadSHA != actualHeadSHA {
+		t.Errorf("Run.HeadSHA = %s, want %s", sctx.Run.HeadSHA, actualHeadSHA)
+	}
+	dbRun, err := sctx.DB.GetRun(sctx.Run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dbRun.HeadSHA != actualHeadSHA {
+		t.Errorf("DB HeadSHA = %s, want %s", dbRun.HeadSHA, actualHeadSHA)
+	}
 }
 
 func TestBabysitStep_CommitAndPush_UpdatesLocalBranchRefAfterDetachedPush(t *testing.T) {

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -57,6 +57,16 @@ func gitCmd(t *testing.T, dir string, args ...string) string {
 	return strings.TrimSpace(string(out))
 }
 
+func gitStatusPorcelain(t *testing.T, dir string) string {
+	t.Helper()
+	return gitCmd(t, dir, "status", "--porcelain")
+}
+
+func lastCommitMessage(t *testing.T, dir string) string {
+	t.Helper()
+	return gitCmd(t, dir, "log", "-1", "--pretty=%s")
+}
+
 // setupGitRepo creates a git repo with a base commit on main and a head commit on feature.
 // Returns (repoDir, baseSHA, headSHA).
 func setupGitRepo(t *testing.T) (string, string, string) {
@@ -557,6 +567,7 @@ func TestReviewStep_ExistingBranchUsesMergeBaseScope(t *testing.T) {
 
 func TestReviewStep_FixMode(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
 
 	callCount := 0
 	ag := &mockAgent{
@@ -564,8 +575,8 @@ func TestReviewStep_FixMode(t *testing.T) {
 		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
 			callCount++
 			if callCount == 1 {
-				// Fix call — no structured output needed
-				return &agent.Result{Text: "fixed"}, nil
+				os.WriteFile(filepath.Join(dir, "review-fix.txt"), []byte("fixed"), 0o644)
+				return &agent.Result{Output: json.RawMessage(`{"summary":"address review findings"}`)}, nil
 			}
 			// Review call — return clean findings
 			findings := Findings{Items: nil, Summary: "all clear"}
@@ -574,7 +585,7 @@ func TestReviewStep_FixMode(t *testing.T) {
 		},
 	}
 
-	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Fixing = true
 	sctx.PreviousFindings = `{"findings":[{"severity":"warning","description":"possible nil dereference"}],"summary":"1 issue"}`
 
@@ -610,8 +621,26 @@ func TestReviewStep_FixMode(t *testing.T) {
 	if !strings.Contains(ag.calls[0].Prompt, "possible nil dereference") {
 		t.Error("expected review fix prompt to include previous findings")
 	}
+	if !strings.Contains(ag.calls[0].Prompt, `Return JSON with a single "summary" field`) {
+		t.Error("expected fix prompt to request structured summary output")
+	}
+	if !strings.Contains(ag.calls[0].Prompt, "Keep the summary under 10 words") {
+		t.Error("expected fix prompt to require a concise summary")
+	}
+	if len(ag.calls[0].JSONSchema) == 0 {
+		t.Error("expected fix call to request structured JSON output")
+	}
 	if strings.Contains(ag.calls[1].Prompt, "feature code") {
 		t.Error("expected review prompt to avoid embedding diff contents in fix mode")
+	}
+	if status := gitStatusPorcelain(t, dir); status != "" {
+		t.Fatalf("expected clean worktree after fix commit, got %q", status)
+	}
+	if got := lastCommitMessage(t, dir); got != "no-mistakes(review): address review findings" {
+		t.Fatalf("last commit message = %q", got)
+	}
+	if branchSHA := gitCmd(t, dir, "rev-parse", "refs/heads/feature"); branchSHA != sctx.Run.HeadSHA {
+		t.Fatalf("branch SHA = %s, want %s", branchSHA, sctx.Run.HeadSHA)
 	}
 }
 
@@ -765,17 +794,19 @@ func TestLintStep_NoCommand_MalformedAgentOutput(t *testing.T) {
 }
 
 func TestTestStep_FixMode(t *testing.T) {
-	dir := t.TempDir()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
 
 	callCount := 0
 	ag := &mockAgent{
 		name: "test",
 		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
 			callCount++
-			return &agent.Result{}, nil
+			os.WriteFile(filepath.Join(dir, "fix.txt"), []byte("fixed"), 0o644)
+			return &agent.Result{Output: json.RawMessage(`{"summary":"fix test failures"}`)}, nil
 		},
 	}
-	sctx := newTestContext(t, ag, dir, "abc", "def", config.Commands{Test: "true"})
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{Test: "true"})
 	sctx.Fixing = true
 
 	step := &TestStep{}
@@ -800,6 +831,66 @@ func TestTestStep_FixMode(t *testing.T) {
 	}
 	if !strings.Contains(ag.calls[0].Prompt, "Do NOT run linters, formatters, or static analysis tools") {
 		t.Error("expected test fix prompt to forbid lint/format work")
+	}
+	if !strings.Contains(ag.calls[0].Prompt, `Return JSON with a single "summary" field`) {
+		t.Error("expected fix prompt to request structured summary output")
+	}
+	if !strings.Contains(ag.calls[0].Prompt, "Keep the summary under 10 words") {
+		t.Error("expected fix prompt to require a concise summary")
+	}
+	if len(ag.calls[0].JSONSchema) == 0 {
+		t.Error("expected fix call to request structured JSON output")
+	}
+	if status := gitStatusPorcelain(t, dir); status != "" {
+		t.Fatalf("expected clean worktree after fix commit, got %q", status)
+	}
+	if got := lastCommitMessage(t, dir); got != "no-mistakes(test): fix test failures" {
+		t.Fatalf("last commit message = %q", got)
+	}
+}
+
+func TestLintStep_FixMode_CommitsChanges(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
+
+	callCount := 0
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			callCount++
+			os.WriteFile(filepath.Join(dir, "lint-fix.txt"), []byte("fixed"), 0o644)
+			return &agent.Result{Output: json.RawMessage(`{"summary":"fix lint issues"}`)}, nil
+		},
+	}
+
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{Lint: "true"})
+	sctx.Fixing = true
+
+	step := &LintStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Error("expected no approval after fix with passing lint")
+	}
+	if callCount != 1 {
+		t.Errorf("expected 1 agent call (fix), got %d", callCount)
+	}
+	if !strings.Contains(ag.calls[0].Prompt, `Return JSON with a single "summary" field`) {
+		t.Error("expected fix prompt to request structured summary output")
+	}
+	if !strings.Contains(ag.calls[0].Prompt, "Keep the summary under 10 words") {
+		t.Error("expected fix prompt to require a concise summary")
+	}
+	if len(ag.calls[0].JSONSchema) == 0 {
+		t.Error("expected fix call to request structured JSON output")
+	}
+	if status := gitStatusPorcelain(t, dir); status != "" {
+		t.Fatalf("expected clean worktree after fix commit, got %q", status)
+	}
+	if got := lastCommitMessage(t, dir); got != "no-mistakes(lint): fix lint issues" {
+		t.Fatalf("last commit message = %q", got)
 	}
 }
 
@@ -1175,6 +1266,52 @@ func TestPushStep_RunsFormatCommandBeforeCommit(t *testing.T) {
 	// Verify the format command ran (marker file exists)
 	if _, err := os.Stat(markerPath); os.IsNotExist(err) {
 		t.Error("format command was not executed before commit")
+	}
+}
+
+func TestPushStep_UpdatesLocalBranchRefAfterDetachedPush(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	originalHeadSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+	gitCmd(t, dir, "checkout", "--detach", originalHeadSHA)
+
+	os.WriteFile(filepath.Join(dir, "fix.txt"), []byte("agent fix"), 0o644)
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, originalHeadSHA, config.Commands{})
+	sctx.Repo.UpstreamURL = upstream
+
+	step := &PushStep{}
+	_, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newHeadSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	branchSHA := gitCmd(t, dir, "rev-parse", "refs/heads/feature")
+	if branchSHA != newHeadSHA {
+		t.Fatalf("branch ref SHA = %s, want %s", branchSHA, newHeadSHA)
+	}
+	upstreamSHA := gitCmd(t, upstream, "rev-parse", "refs/heads/feature")
+	if upstreamSHA != newHeadSHA {
+		t.Fatalf("upstream SHA = %s, want %s", upstreamSHA, newHeadSHA)
 	}
 }
 
@@ -2016,6 +2153,52 @@ func TestBabysitStep_CommitAndPush_NoChanges(t *testing.T) {
 	// No error expected — just a no-op
 }
 
+func TestBabysitStep_CommitAndPush_UpdatesLocalBranchRefAfterDetachedPush(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	originalHeadSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+	gitCmd(t, dir, "checkout", "--detach", originalHeadSHA)
+	os.WriteFile(filepath.Join(dir, "fix.txt"), []byte("babysit fix"), 0o644)
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, originalHeadSHA, config.Commands{})
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+
+	step := &BabysitStep{}
+	err := step.commitAndPush(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newHeadSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	branchSHA := gitCmd(t, dir, "rev-parse", "refs/heads/feature")
+	if branchSHA != newHeadSHA {
+		t.Fatalf("branch ref SHA = %s, want %s", branchSHA, newHeadSHA)
+	}
+	upstreamSHA := gitCmd(t, upstream, "rev-parse", "refs/heads/feature")
+	if upstreamSHA != newHeadSHA {
+		t.Fatalf("upstream SHA = %s, want %s", upstreamSHA, newHeadSHA)
+	}
+}
+
 func TestCICheckJSON(t *testing.T) {
 	input := `[{"name":"build","status":"COMPLETED","conclusion":"success"},{"name":"test","status":"COMPLETED","conclusion":"failure"}]`
 	var checks []ciCheck
@@ -2176,15 +2359,17 @@ func TestTestStep_AgentWritesNewTests_NeedsApproval(t *testing.T) {
 func TestTestStep_FixMode_AgentWritesNewTests_NeedsApproval(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
+	callCount := 0
 	ag := &mockAgent{
 		name: "test",
 		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			callCount++
 			// Simulate agent creating a new test file during fix
 			os.WriteFile(filepath.Join(dir, "fix_test.go"), []byte("package main\n"), 0o644)
-			return &agent.Result{}, nil
+			return &agent.Result{Output: json.RawMessage(`{"summary":"add regression test"}`)}, nil
 		},
 	}
-	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{Test: "true"})
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{Test: "true"})
 	sctx.Fixing = true
 
 	step := &TestStep{}
@@ -2194,6 +2379,9 @@ func TestTestStep_FixMode_AgentWritesNewTests_NeedsApproval(t *testing.T) {
 	}
 	if !outcome.NeedsApproval {
 		t.Error("expected approval needed when agent writes new test files in fix mode")
+	}
+	if callCount != 1 {
+		t.Errorf("expected 1 agent call in fix mode, got %d", callCount)
 	}
 
 	var f Findings
@@ -2456,7 +2644,7 @@ func TestReviewStep_FixMode_IncludesPreviousFindings(t *testing.T) {
 				if !strings.Contains(opts.Prompt, "nil pointer dereference") {
 					t.Error("fix prompt should contain the specific finding description")
 				}
-				return &agent.Result{Text: "fixed"}, nil
+				return &agent.Result{Output: json.RawMessage(`{"summary":"address review findings"}`)}, nil
 			}
 			// Review call
 			findings := Findings{Summary: "all clear"}
@@ -2500,7 +2688,7 @@ func TestTestStep_FixMode_IncludesPreviousFindings(t *testing.T) {
 			if !strings.Contains(opts.Prompt, "Make the minimal change needed") {
 				t.Error("fix prompt should require minimal changes")
 			}
-			return &agent.Result{Text: "fixed"}, nil
+			return &agent.Result{Output: json.RawMessage(`{"summary":"fix test failures"}`)}, nil
 		},
 	}
 
@@ -2539,7 +2727,7 @@ func TestLintStep_FixMode_IncludesPreviousFindings(t *testing.T) {
 			if !strings.Contains(opts.Prompt, "Re-run the relevant lint or format commands") {
 				t.Error("fix prompt should require lint verification")
 			}
-			return &agent.Result{Text: "fixed"}, nil
+			return &agent.Result{Output: json.RawMessage(`{"summary":"fix lint issues"}`)}, nil
 		},
 	}
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1866,6 +1866,122 @@ func TestFindingsJSON(t *testing.T) {
 	}
 }
 
+// --- Helper function unit tests ---
+
+func TestNormalizedBranchRef(t *testing.T) {
+	tests := []struct {
+		input, want string
+	}{
+		{"feature", "refs/heads/feature"},
+		{"my/branch", "refs/heads/my/branch"},
+		{"refs/heads/feature", "refs/heads/feature"},
+		{"refs/tags/v1", "refs/tags/v1"},
+	}
+	for _, tc := range tests {
+		if got := normalizedBranchRef(tc.input); got != tc.want {
+			t.Errorf("normalizedBranchRef(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestDeterministicFixCommitMessage(t *testing.T) {
+	tests := []struct {
+		step    types.StepName
+		summary string
+		want    string
+	}{
+		{types.StepReview, "address nil dereference", "no-mistakes(review): address nil dereference"},
+		{types.StepTest, "", "no-mistakes(test): apply fixes"},
+		{types.StepLint, "fix formatting", "no-mistakes(lint): fix formatting"},
+	}
+	for _, tc := range tests {
+		if got := deterministicFixCommitMessage(tc.step, tc.summary); got != tc.want {
+			t.Errorf("deterministicFixCommitMessage(%q, %q) = %q, want %q", tc.step, tc.summary, got, tc.want)
+		}
+	}
+}
+
+func TestExtractCommitSummary(t *testing.T) {
+	tests := []struct {
+		name    string
+		result  *agent.Result
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "valid summary",
+			result: &agent.Result{Output: json.RawMessage(`{"summary":"fix nil pointer"}`)},
+			want:   "fix nil pointer",
+		},
+		{
+			name:   "trims punctuation and whitespace",
+			result: &agent.Result{Output: json.RawMessage(`{"summary":"  'fix lint issues.'  "}`)},
+			want:   "fix lint issues",
+		},
+		{
+			name:    "nil output",
+			result:  &agent.Result{},
+			wantErr: true,
+		},
+		{
+			name:    "malformed JSON",
+			result:  &agent.Result{Output: json.RawMessage(`not json`)},
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := extractCommitSummary(tc.result)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Errorf("extractCommitSummary() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCommitAgentFixes_NoChanges(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	originalHeadSHA := sctx.Run.HeadSHA
+
+	err := commitAgentFixes(sctx, types.StepReview, "should not commit", "fallback")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sctx.Run.HeadSHA != originalHeadSHA {
+		t.Errorf("HeadSHA changed unexpectedly: %s -> %s", originalHeadSHA, sctx.Run.HeadSHA)
+	}
+}
+
+func TestCommitAgentFixes_UsesFallbackSummary(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+
+	os.WriteFile(filepath.Join(dir, "agent-change.txt"), []byte("change"), 0o644)
+	err := commitAgentFixes(sctx, types.StepLint, "", "fallback lint fix")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := lastCommitMessage(t, dir); got != "no-mistakes(lint): fallback lint fix" {
+		t.Errorf("commit message = %q, want fallback-based message", got)
+	}
+}
+
 // --- Babysit step tests ---
 
 func TestBabysitStep_Name(t *testing.T) {

--- a/internal/pipeline/steps/test.go
+++ b/internal/pipeline/steps/test.go
@@ -19,6 +19,7 @@ func (s *TestStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 	baseSHA := resolveBranchBaseSHA(ctx, sctx.WorkDir, sctx.Run.BaseSHA, sctx.Repo.DefaultBranch)
 
 	// In fix mode, ask agent to fix test failures first
+	var newTestsFromFix []string
 	if sctx.Fixing {
 		sctx.Log("asking agent to fix test failures...")
 		fixPrompt := fmt.Sprintf(
@@ -34,7 +35,10 @@ Context:
 			- Do not refactor beyond what is needed.
 			- If tests fail, determine whether the problem is a real product/code failure, a setup/environment problem you can fix, or a flaky/infrastructure issue.
 			- Do NOT run linters, formatters, or static analysis tools.
-			- Re-run the relevant tests before finishing.`,
+			- Re-run the relevant tests before finishing.
+			- Return JSON with a single "summary" field when you are done.
+			- The summary must be one concise sentence fragment suitable for a git commit subject.
+			- Keep the summary under 10 words.`,
 			sctx.Run.Branch,
 			baseSHA,
 			sctx.Run.HeadSHA,
@@ -45,13 +49,22 @@ Context:
 Previous test findings to address:
 ` + sctx.PreviousFindings
 		}
-		_, err := sctx.Agent.Run(ctx, agent.RunOpts{
-			Prompt:  fixPrompt,
-			CWD:     sctx.WorkDir,
-			OnChunk: sctx.Log,
+		result, err := sctx.Agent.Run(ctx, agent.RunOpts{
+			Prompt:     fixPrompt,
+			CWD:        sctx.WorkDir,
+			JSONSchema: commitSummarySchema,
+			OnChunk:    sctx.Log,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("agent fix tests: %w", err)
+		}
+		newTestsFromFix = detectNewTestFiles(ctx, sctx.WorkDir)
+		summary, err := extractCommitSummary(result)
+		if err != nil {
+			sctx.Log(fmt.Sprintf("warning: could not parse fix summary: %v", err))
+		}
+		if err := commitAgentFixes(sctx, s.Name(), summary, "fix test failures"); err != nil {
+			return nil, err
 		}
 	}
 
@@ -148,7 +161,8 @@ Task:
 
 	// Check if agent wrote new test files (fix mode uses agent before running tests)
 	if sctx.Fixing {
-		newTests := detectNewTestFiles(ctx, sctx.WorkDir)
+		newTests := append([]string{}, newTestsFromFix...)
+		newTests = append(newTests, detectNewTestFiles(ctx, sctx.WorkDir)...)
 		if len(newTests) > 0 {
 			findings := Findings{
 				Summary: "tests passed, but agent wrote new test files",

--- a/internal/pipeline/steps/test.go
+++ b/internal/pipeline/steps/test.go
@@ -30,15 +30,15 @@ Context:
 - base commit: %s
 - target commit: %s
 
-			Rules:
-			- Make the minimal change needed.
-			- Do not refactor beyond what is needed.
-			- If tests fail, determine whether the problem is a real product/code failure, a setup/environment problem you can fix, or a flaky/infrastructure issue.
-			- Do NOT run linters, formatters, or static analysis tools.
-			- Re-run the relevant tests before finishing.
-			- Return JSON with a single "summary" field when you are done.
-			- The summary must be one concise sentence fragment suitable for a git commit subject.
-			- Keep the summary under 10 words.`,
+Rules:
+- Make the minimal change needed.
+- Do not refactor beyond what is needed.
+- If tests fail, determine whether the problem is a real product/code failure, a setup/environment problem you can fix, or a flaky/infrastructure issue.
+- Do NOT run linters, formatters, or static analysis tools.
+- Re-run the relevant tests before finishing.
+- Return JSON with a single "summary" field when you are done.
+- The summary must be one concise sentence fragment suitable for a git commit subject.
+- Keep the summary under 10 words.`,
 			sctx.Run.Branch,
 			baseSHA,
 			sctx.Run.HeadSHA,
@@ -88,10 +88,10 @@ Task:
 - If tests fail, determine whether the problem is a real product/code failure, a setup/environment problem you can fix, or a flaky/infrastructure issue.
 - If the issue is setup-related and fixable, fix it and retry the tests.
 
-			Rules:
-			- Do NOT run linters, formatters, or static analysis tools.
-			- Focus on testing and test-related fixes only.
-			- Return results as structured findings.`,
+Rules:
+- Do NOT run linters, formatters, or static analysis tools.
+- Focus on testing and test-related fixes only.
+- Return results as structured findings.`,
 				sctx.Run.Branch,
 				baseSHA,
 				sctx.Run.HeadSHA,
@@ -160,26 +160,22 @@ Task:
 	}
 
 	// Check if agent wrote new test files (fix mode uses agent before running tests)
-	if sctx.Fixing {
-		newTests := append([]string{}, newTestsFromFix...)
-		newTests = append(newTests, detectNewTestFiles(ctx, sctx.WorkDir)...)
-		if len(newTests) > 0 {
-			findings := Findings{
-				Summary: "tests passed, but agent wrote new test files",
-			}
-			for _, f := range newTests {
-				findings.Items = append(findings.Items, Finding{
-					Severity:    "info",
-					File:        f,
-					Description: fmt.Sprintf("new test file written by agent: %s", f),
-				})
-			}
-			findingsJSON, _ := json.Marshal(findings)
-			return &pipeline.StepOutcome{
-				NeedsApproval: true,
-				Findings:      string(findingsJSON),
-			}, nil
+	if sctx.Fixing && len(newTestsFromFix) > 0 {
+		findings := Findings{
+			Summary: "tests passed, but agent wrote new test files",
 		}
+		for _, f := range newTestsFromFix {
+			findings.Items = append(findings.Items, Finding{
+				Severity:    "info",
+				File:        f,
+				Description: fmt.Sprintf("new test file written by agent: %s", f),
+			})
+		}
+		findingsJSON, _ := json.Marshal(findings)
+		return &pipeline.StepOutcome{
+			NeedsApproval: true,
+			Findings:      string(findingsJSON),
+		}, nil
 	}
 
 	sctx.Log("all tests passed")


### PR DESCRIPTION
## Summary

- Extract shared `commitAgentFixes` helper and `normalizedBranchRef` into `common.go`, replacing duplicated commit/push logic across review, test, lint, and babysit steps.
- Agent fix calls now request structured JSON output (`commitSummarySchema`) so commit messages are deterministic and descriptive (e.g. `no-mistakes(review): address review findings`).
- Push step and babysit `commitAndPush` now reconcile stale DB `HeadSHA` on retry - if a prior `UpdateRunHeadSHA` failed, the next push correctly detects the mismatch and updates both in-memory and DB state.
- After force-pushing from a detached HEAD, `update-ref` keeps the local branch ref in sync with the pushed commit.
- Fix prompt indentation (was indented inside Go raw strings, producing extra whitespace in agent prompts) and remove dead code.
- Add 400+ lines of new tests covering commit helpers, branch ref normalization, detached-HEAD push scenarios, and stale DB reconciliation.

## Test plan

- [ ] `go test -race ./internal/pipeline/steps/...` passes all new and existing tests
- [ ] `go vet ./...` clean
- [ ] `gofmt -l .` reports no formatting issues
- [ ] Verify push step correctly updates DB HeadSHA when retrying after a prior failure (covered by `TestPushStep_ReconcilesStaleDatabaseHeadSHA`)
- [ ] Verify babysit commit-and-push updates local branch ref after detached push (covered by `TestBabysitStep_CommitAndPush_UpdatesLocalBranchRefAfterDetachedPush`)
- [ ] Verify review/lint/test fix modes produce deterministic commit messages (covered by `TestReviewStep_FixMode`, `TestLintStep_FixMode_CommitsChanges`, `TestTestStep_FixMode`)