### PR TITLE
Add Windows support for daemon IPC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,4 +47,4 @@ jobs:
         run: go test -race ./...
 
       - name: Build
-        run: go build -o no-mistakes ./cmd/no-mistakes
+        run: go build ./cmd/no-mistakes

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -77,6 +77,10 @@ func setupTestRepo(t *testing.T) string {
 		p := paths.WithRoot(nmHome)
 		_, _ = daemon.IsRunning(p)
 		_ = daemon.Stop(p)
+		// On Windows, the daemon may hold file locks briefly after stopping.
+		if runtime.GOOS == "windows" {
+			time.Sleep(500 * time.Millisecond)
+		}
 	})
 
 	return repoDir

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -21,6 +22,13 @@ import (
 )
 
 func init() {
+	if os.Getenv("NM_HOOK_HELPER") == "1" {
+		if err := newRootCmd().Execute(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
 	if os.Getenv("NM_DAEMON") != "1" || os.Getenv("NM_TEST_START_DAEMON") != "1" {
 		return
 	}
@@ -221,6 +229,10 @@ func TestInitAlreadyInitialized(t *testing.T) {
 }
 
 func TestInitRollsBackWhenDaemonStartFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows IPC does not use Unix socket path limits")
+	}
+
 	repoDir := setupTestRepo(t)
 	nmHome := filepath.Join(t.TempDir(), strings.Repeat("a", 160))
 	t.Setenv("NM_HOME", nmHome)

--- a/internal/cli/daemon_cmd.go
+++ b/internal/cli/daemon_cmd.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/kunchenguid/no-mistakes/internal/daemon"
+	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
 	"github.com/spf13/cobra"
 )
@@ -17,6 +18,52 @@ func newDaemonCmd() *cobra.Command {
 	cmd.AddCommand(newDaemonStartCmd())
 	cmd.AddCommand(newDaemonStopCmd())
 	cmd.AddCommand(newDaemonStatusCmd())
+	cmd.AddCommand(newDaemonNotifyPushCmd())
+
+	return cmd
+}
+
+func newDaemonNotifyPushCmd() *cobra.Command {
+	var gate string
+	var ref string
+	var oldSHA string
+	var newSHA string
+
+	cmd := &cobra.Command{
+		Use:    "notify-push",
+		Short:  "Notify daemon about a git push",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			p, err := paths.New()
+			if err != nil {
+				return err
+			}
+
+			client, err := ipc.Dial(p.Socket())
+			if err != nil {
+				return fmt.Errorf("connect to daemon: %w", err)
+			}
+			defer client.Close()
+
+			var result ipc.PushReceivedResult
+			return client.Call(ipc.MethodPushReceived, &ipc.PushReceivedParams{
+				Gate: gate,
+				Ref:  ref,
+				Old:  oldSHA,
+				New:  newSHA,
+			}, &result)
+		},
+	}
+
+	cmd.Flags().StringVar(&gate, "gate", "", "bare repo path that received the push")
+	cmd.Flags().StringVar(&ref, "ref", "", "git ref name")
+	cmd.Flags().StringVar(&oldSHA, "old", "", "previous commit SHA")
+	cmd.Flags().StringVar(&newSHA, "new", "", "new commit SHA")
+	_ = cmd.MarkFlagRequired("gate")
+	_ = cmd.MarkFlagRequired("ref")
+	_ = cmd.MarkFlagRequired("old")
+	_ = cmd.MarkFlagRequired("new")
 
 	return cmd
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -9,7 +9,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"sync"
-	"syscall"
 
 	"github.com/kunchenguid/no-mistakes/internal/config"
 	"github.com/kunchenguid/no-mistakes/internal/db"
@@ -97,7 +96,7 @@ func RunWithOptions(p *paths.Paths, d *db.DB, stepFactory StepFactory) error {
 
 	// Handle OS signals
 	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigCh, daemonSignals()...)
 	defer signal.Stop(sigCh)
 	go func() {
 		select {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -112,6 +112,7 @@ func RunWithOptions(p *paths.Paths, d *db.DB, stepFactory StepFactory) error {
 	if err := srv.Serve(socketPath); err != nil {
 		return fmt.Errorf("serve: %w", err)
 	}
+	doShutdown("listener closed")
 
 	// Clean up socket file only if we still own the PID file.
 	// A new daemon may have already replaced the socket.

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -506,6 +507,14 @@ func gitOutput(t *testing.T, dir string, args ...string) string {
 
 func writeMockClaude(t *testing.T, dir string) string {
 	t.Helper()
+	if runtime.GOOS == "windows" {
+		path := filepath.Join(dir, "claude.bat")
+		script := "@echo off\r\necho {\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"structured_output\":{\"findings\":[],\"summary\":\"clean\"}}\r\n"
+		if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
 	path := filepath.Join(dir, "claude")
 	script := `#!/bin/sh
 printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"structured_output":{"findings":[],"summary":"clean"}}'

--- a/internal/daemon/signals_unix.go
+++ b/internal/daemon/signals_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"os"
+	"syscall"
+)
+
+func daemonSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+}

--- a/internal/daemon/signals_windows.go
+++ b/internal/daemon/signals_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package daemon
+
+import "os"
+
+func daemonSignals() []os.Signal {
+	return []os.Signal{os.Interrupt}
+}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -16,6 +16,7 @@ func initTestRepo(t *testing.T) string {
 	run(t, dir, "git", "init")
 	run(t, dir, "git", "config", "user.email", "test@test.com")
 	run(t, dir, "git", "config", "user.name", "Test")
+	run(t, dir, "git", "config", "core.autocrlf", "false")
 	writeFile(t, filepath.Join(dir, "README.md"), "# test\n")
 	run(t, dir, "git", "add", ".")
 	run(t, dir, "git", "commit", "-m", "initial")

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -334,6 +334,7 @@ func TestWorktreeAddAndRemove(t *testing.T) {
 	if err := InitBare(ctx, bare); err != nil {
 		t.Fatal(err)
 	}
+	run(t, bare, "git", "config", "core.autocrlf", "false")
 	run(t, src, "git", "remote", "add", "bare", bare)
 	run(t, src, "git", "push", "bare", "HEAD:refs/heads/main")
 

--- a/internal/git/hook.go
+++ b/internal/git/hook.go
@@ -22,6 +22,9 @@ func postReceiveHookScript(command string) string {
 # no-mistakes post-receive hook
 # Notify daemon of push. Non-blocking - push always succeeds.
 NM_BIN=` + shellSingleQuote(command) + `
+if [ ! -x "$NM_BIN" ]; then
+  NM_BIN="$(command -v no-mistakes 2>/dev/null || echo no-mistakes)"
+fi
 while read oldrev newrev refname; do
   NM_HOOK_HELPER=1 "$NM_BIN" daemon notify-push \
     --gate "$(pwd)" \

--- a/internal/git/hook.go
+++ b/internal/git/hook.go
@@ -3,28 +3,39 @@ package git
 import (
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // PostReceiveHookScript returns the shell script for the post-receive hook.
-// The hook notifies the daemon of a push via Unix socket. It never blocks
-// the push — notification failures are silently ignored.
+// The hook notifies the daemon via the CLI so it works across platforms.
+// It never blocks the push - notification failures are silently ignored.
 func PostReceiveHookScript() string {
+	exe, err := os.Executable()
+	if err != nil {
+		exe = "no-mistakes"
+	}
+	return postReceiveHookScript(exe)
+}
+
+func postReceiveHookScript(command string) string {
 	return `#!/bin/sh
 # no-mistakes post-receive hook
-# Notify daemon of push. Non-blocking — push always succeeds.
-SOCKET="${NM_HOME:-$HOME/.no-mistakes}/socket"
-json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr -d '\n\r\t'; }
+# Notify daemon of push. Non-blocking - push always succeeds.
+NM_BIN=` + shellSingleQuote(command) + `
 while read oldrev newrev refname; do
-  if [ -S "$SOCKET" ]; then
-    gate=$(json_escape "$(pwd)")
-    ref=$(json_escape "$refname")
-    printf '{"method":"push_received","params":{"gate":"%s","ref":"%s","old":"%s","new":"%s"}}\n' \
-      "$gate" "$ref" "$oldrev" "$newrev" | nc -U "$SOCKET" >/dev/null 2>&1 || true
-  fi
+  NM_HOOK_HELPER=1 "$NM_BIN" daemon notify-push \
+    --gate "$(pwd)" \
+    --ref "$refname" \
+    --old "$oldrev" \
+    --new "$newrev" >/dev/null 2>&1 || true
 done
 printf '%s\n' 'no-mistakes: pipeline started. Run ` + "`no-mistakes`" + ` to review.' >&2
 exit 0
 `
+}
+
+func shellSingleQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }
 
 // InstallPostReceiveHook writes the post-receive hook script into

--- a/internal/git/hook.go
+++ b/internal/git/hook.go
@@ -22,7 +22,7 @@ func postReceiveHookScript(command string) string {
 # no-mistakes post-receive hook
 # Notify daemon of push. Non-blocking - push always succeeds.
 NM_BIN=` + shellSingleQuote(command) + `
-if [ ! -x "$NM_BIN" ]; then
+if [ ! -f "$NM_BIN" ]; then
   NM_BIN="$(command -v no-mistakes 2>/dev/null || echo no-mistakes)"
 fi
 while read oldrev newrev refname; do

--- a/internal/git/hook_test.go
+++ b/internal/git/hook_test.go
@@ -59,6 +59,35 @@ func TestPostReceiveHookScript(t *testing.T) {
 	}
 }
 
+func TestShellSingleQuote(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plain", "/usr/bin/no-mistakes", "'/usr/bin/no-mistakes'"},
+		{"spaces", "/opt/No Mistakes/bin", "'/opt/No Mistakes/bin'"},
+		{"single_quote", "/opt/it's/bin", "'/opt/it'\"'\"'s/bin'"},
+		{"multiple_quotes", "a'b'c", "'a'\"'\"'b'\"'\"'c'"},
+		{"empty", "", "''"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shellSingleQuote(tt.input)
+			if got != tt.want {
+				t.Errorf("shellSingleQuote(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPostReceiveHookScriptWithQuotedPath(t *testing.T) {
+	script := postReceiveHookScript("/opt/it's here/no-mistakes")
+	if !strings.Contains(script, "NM_BIN='/opt/it'\"'\"'s here/no-mistakes'") {
+		t.Fatal("hook should correctly escape single quotes in the executable path")
+	}
+}
+
 func TestInstallPostReceiveHook(t *testing.T) {
 	ctx := context.Background()
 	bare := filepath.Join(t.TempDir(), "test.git")

--- a/internal/git/hook_test.go
+++ b/internal/git/hook_test.go
@@ -4,27 +4,21 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
 
 func TestPostReceiveHookScript(t *testing.T) {
-	script := PostReceiveHookScript()
+	script := postReceiveHookScript("/opt/No Mistakes/no-mistakes")
 
 	// should be a shell script
 	if !strings.HasPrefix(script, "#!/bin/sh\n") {
 		t.Fatal("hook should start with #!/bin/sh")
 	}
 
-	// should reference the socket path with NM_HOME support
-	if !strings.Contains(script, "NM_HOME") {
-		t.Fatal("hook should respect NM_HOME env var")
-	}
-	if !strings.Contains(script, "$HOME/.no-mistakes") {
-		t.Fatal("hook should reference default .no-mistakes path")
-	}
-	if !strings.Contains(script, "/socket") {
-		t.Fatal("hook should reference socket")
+	if !strings.Contains(script, "NM_BIN='/opt/No Mistakes/no-mistakes'") {
+		t.Fatal("hook should embed the no-mistakes executable path")
 	}
 
 	// should read oldrev newrev refname
@@ -32,12 +26,20 @@ func TestPostReceiveHookScript(t *testing.T) {
 		t.Fatal("hook should read ref update args")
 	}
 
-	// should send JSON-RPC push_received
-	if !strings.Contains(script, "push_received") {
-		t.Fatal("hook should send push_received method")
+	if !strings.Contains(script, "--gate \"$(pwd)\"") {
+		t.Fatal("hook should pass the gate path as a flag")
 	}
-	if !strings.Contains(script, "nc -U \"$SOCKET\" >/dev/null 2>&1 || true") {
-		t.Fatal("hook should suppress nc output so pushes stay clean")
+	if !strings.Contains(script, "daemon notify-push") {
+		t.Fatal("hook should invoke the CLI notify subcommand")
+	}
+	if strings.Contains(script, "nc -U") {
+		t.Fatal("hook should not depend on netcat")
+	}
+	if !strings.Contains(script, "\"$NM_BIN\" daemon notify-push") {
+		t.Fatal("hook should execute the embedded binary path")
+	}
+	if !strings.Contains(script, ">/dev/null 2>&1 || true") {
+		t.Fatal("hook should suppress notifier output so pushes stay clean")
 	}
 
 	// should print user-facing message to stderr
@@ -74,7 +76,7 @@ func TestInstallPostReceiveHook(t *testing.T) {
 	}
 
 	// verify executable permission
-	if info.Mode()&0o111 == 0 {
+	if runtime.GOOS != "windows" && info.Mode()&0o111 == 0 {
 		t.Fatalf("hook should be executable, got mode %v", info.Mode())
 	}
 
@@ -83,7 +85,11 @@ func TestInstallPostReceiveHook(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(content) != PostReceiveHookScript() {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != postReceiveHookScript(exe) {
 		t.Fatal("hook content doesn't match template")
 	}
 }

--- a/internal/git/hook_test.go
+++ b/internal/git/hook_test.go
@@ -38,6 +38,9 @@ func TestPostReceiveHookScript(t *testing.T) {
 	if !strings.Contains(script, "\"$NM_BIN\" daemon notify-push") {
 		t.Fatal("hook should execute the embedded binary path")
 	}
+	if !strings.Contains(script, "command -v no-mistakes") {
+		t.Fatal("hook should fall back to PATH when baked-in path doesn't exist")
+	}
 	if !strings.Contains(script, ">/dev/null 2>&1 || true") {
 		t.Fatal("hook should suppress notifier output so pushes stay clean")
 	}

--- a/internal/ipc/client.go
+++ b/internal/ipc/client.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-// Client connects to the IPC server over a Unix socket.
+// Client connects to the IPC server over the platform transport.
 type Client struct {
 	conn    net.Conn
 	encoder *json.Encoder
@@ -17,7 +17,7 @@ type Client struct {
 	mu      sync.Mutex // serializes calls on a single connection
 }
 
-// Dial connects to the IPC server at the given Unix socket path.
+// Dial connects to the IPC server at the given endpoint path.
 func Dial(socketPath string) (*Client, error) {
 	conn, err := dial(socketPath)
 	if err != nil {

--- a/internal/ipc/client.go
+++ b/internal/ipc/client.go
@@ -19,7 +19,7 @@ type Client struct {
 
 // Dial connects to the IPC server at the given Unix socket path.
 func Dial(socketPath string) (*Client, error) {
-	conn, err := net.Dial("unix", socketPath)
+	conn, err := dial(socketPath)
 	if err != nil {
 		return nil, fmt.Errorf("dial ipc: %w", err)
 	}
@@ -85,7 +85,7 @@ func (c *Client) Close() error {
 // Returns an event channel, a cancel function (to stop and clean up), and an error.
 // The channel is closed when the run completes, the connection drops, or cancel is called.
 func Subscribe(socketPath string, params *SubscribeParams) (<-chan Event, func(), error) {
-	conn, err := net.Dial("unix", socketPath)
+	conn, err := dial(socketPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("dial ipc: %w", err)
 	}

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -81,6 +81,7 @@ func (s *Server) Serve(socketPath string) error {
 				return nil
 			default:
 				if errors.Is(err, net.ErrClosed) {
+					s.Close()
 					s.wg.Wait()
 					return nil
 				}

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -6,9 +6,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net"
-	"os"
 	"sync"
-	"syscall"
 )
 
 // HandlerFunc processes a JSON-RPC request and returns a result or error.
@@ -57,17 +55,10 @@ func (s *Server) HandleStream(method string, fn StreamHandlerFunc) {
 	s.streamHandlers[method] = fn
 }
 
-// Serve starts listening on the given Unix socket path.
+// Serve starts listening on the given IPC endpoint path.
 // It blocks until Close is called, then returns nil.
 func (s *Server) Serve(socketPath string) error {
-	// remove stale socket file
-	os.Remove(socketPath)
-
-	// Set restrictive umask so the socket is created with 0600 permissions,
-	// avoiding a TOCTOU window between Listen and Chmod.
-	oldMask := syscall.Umask(0077)
-	ln, err := net.Listen("unix", socketPath)
-	syscall.Umask(oldMask)
+	ln, err := listen(socketPath)
 	if err != nil {
 		return err
 	}

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net"
 	"sync"
@@ -62,7 +63,9 @@ func (s *Server) Serve(socketPath string) error {
 	if err != nil {
 		return err
 	}
+	s.mu.Lock()
 	s.listener = ln
+	s.mu.Unlock()
 
 	go func() {
 		<-s.done
@@ -77,6 +80,10 @@ func (s *Server) Serve(socketPath string) error {
 				s.wg.Wait()
 				return nil
 			default:
+				if errors.Is(err, net.ErrClosed) {
+					s.wg.Wait()
+					return nil
+				}
 				slog.Error("accept connection", "error", err)
 				continue
 			}
@@ -94,6 +101,18 @@ func (s *Server) Close() {
 	s.closeOnce.Do(func() {
 		close(s.done)
 	})
+}
+
+// CloseListener closes the underlying listener without signaling server
+// shutdown. This causes Accept to return net.ErrClosed, which the server
+// detects and exits cleanly.
+func (s *Server) CloseListener() {
+	s.mu.RLock()
+	ln := s.listener
+	s.mu.RUnlock()
+	if ln != nil {
+		ln.Close()
+	}
 }
 
 func (s *Server) handleConn(conn net.Conn) {

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -18,7 +18,7 @@ type HandlerFunc func(ctx context.Context, params json.RawMessage) (interface{},
 // the handler should return.
 type StreamHandlerFunc func(ctx context.Context, params json.RawMessage, send func(interface{}) error) error
 
-// Server listens on a Unix socket and dispatches JSON-RPC requests.
+// Server listens on an IPC endpoint and dispatches JSON-RPC requests.
 type Server struct {
 	mu             sync.RWMutex
 	handlers       map[string]HandlerFunc

--- a/internal/ipc/server_test.go
+++ b/internal/ipc/server_test.go
@@ -276,7 +276,7 @@ func TestServerClose(t *testing.T) {
 }
 
 func TestDialNonexistentSocket(t *testing.T) {
-	_, err := ipc.Dial("/tmp/nonexistent-test-socket-12345.sock")
+	_, err := ipc.Dial(filepath.Join(t.TempDir(), "nonexistent.sock"))
 	if err == nil {
 		t.Error("expected error dialing nonexistent socket")
 	}

--- a/internal/ipc/server_test.go
+++ b/internal/ipc/server_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -320,10 +319,7 @@ func TestStreamHandler(t *testing.T) {
 	conn.Close()
 
 	// Use raw connection to test streaming.
-	rawConn, err := net.Dial("unix", sock)
-	if err != nil {
-		t.Fatalf("raw dial: %v", err)
-	}
+	rawConn := rawDial(t, sock)
 	defer rawConn.Close()
 
 	encoder := json.NewEncoder(rawConn)
@@ -395,10 +391,7 @@ func TestServerInvalidJSON(t *testing.T) {
 	startServer(t, sock)
 
 	// Send invalid JSON and verify parse error response.
-	conn, err := net.Dial("unix", sock)
-	if err != nil {
-		t.Fatalf("dial: %v", err)
-	}
+	conn := rawDial(t, sock)
 	defer conn.Close()
 
 	// Write invalid JSON.
@@ -531,10 +524,7 @@ func TestSubscribeMalformedEvent(t *testing.T) {
 
 	// Start a fresh minimal server with raw socket control.
 	sock = socketPath(t)
-	ln, err := net.Listen("unix", sock)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ln := rawListen(t, sock)
 	defer ln.Close()
 
 	go func() {
@@ -598,10 +588,7 @@ func TestSubscribeConnectionClosedBeforeResponse(t *testing.T) {
 	os.Remove(sock)
 
 	// Start a raw server that closes connection immediately after accept.
-	ln, err := net.Listen("unix", sock)
-	if err != nil {
-		t.Fatal(err)
-	}
+	ln := rawListen(t, sock)
 	defer ln.Close()
 
 	go func() {
@@ -617,7 +604,7 @@ func TestSubscribeConnectionClosedBeforeResponse(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	_, _, err = ipc.Subscribe(sock, &ipc.SubscribeParams{RunID: "r1"})
+	_, _, err := ipc.Subscribe(sock, &ipc.SubscribeParams{RunID: "r1"})
 	if err == nil {
 		t.Fatal("expected error when connection closed before response")
 	}
@@ -635,10 +622,7 @@ func TestServerEmptyLine(t *testing.T) {
 	})
 
 	// Connect raw and send an empty line, then a valid request.
-	conn, err := net.Dial("unix", sock)
-	if err != nil {
-		t.Fatalf("dial: %v", err)
-	}
+	conn := rawDial(t, sock)
 	defer conn.Close()
 
 	// Send empty line first.

--- a/internal/ipc/server_test.go
+++ b/internal/ipc/server_test.go
@@ -433,6 +433,41 @@ func TestCallWithNilResult(t *testing.T) {
 	}
 }
 
+func TestServerExitsWhenListenerClosed(t *testing.T) {
+	sock := socketPath(t)
+	srv := ipc.NewServer()
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Serve(sock) }()
+
+	// Wait for server to be ready.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		c, err := ipc.Dial(sock)
+		if err == nil {
+			c.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Simulate the listener being closed externally (e.g. tokenListener
+	// self-close on Windows after too many accept errors) by removing the
+	// socket file and dialing to confirm the server is up, then closing
+	// the server's listener via Close. But we want to test that the server
+	// exits even without s.Close() being called. Instead, we close the
+	// underlying listener by calling srv.CloseListener().
+	srv.CloseListener()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("Serve returned unexpected error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("server did not exit after listener was closed")
+	}
+}
+
 func TestServerDoubleClose(t *testing.T) {
 	sock := socketPath(t)
 	srv := ipc.NewServer()

--- a/internal/ipc/test_transport_unix_test.go
+++ b/internal/ipc/test_transport_unix_test.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package ipc_test
+
+import (
+	"net"
+	"os"
+	"testing"
+)
+
+func rawDial(t *testing.T, endpoint string) net.Conn {
+	t.Helper()
+	conn, err := net.Dial("unix", endpoint)
+	if err != nil {
+		t.Fatalf("raw dial: %v", err)
+	}
+	return conn
+}
+
+func rawListen(t *testing.T, endpoint string) net.Listener {
+	t.Helper()
+	_ = os.Remove(endpoint)
+	ln, err := net.Listen("unix", endpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ln
+}

--- a/internal/ipc/test_transport_windows_test.go
+++ b/internal/ipc/test_transport_windows_test.go
@@ -61,7 +61,10 @@ func (l *tokenStripListener) Accept() (net.Conn, error) {
 		return nil, err
 	}
 	r := bufio.NewReader(conn)
-	r.ReadString('\n') // consume token line
+	if _, err := r.ReadString('\n'); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("read auth token: %w", err)
+	}
 	return &testBufferedConn{Conn: conn, r: r}, nil
 }
 

--- a/internal/ipc/test_transport_windows_test.go
+++ b/internal/ipc/test_transport_windows_test.go
@@ -18,7 +18,7 @@ func rawDial(t *testing.T, endpoint string) net.Conn {
 		t.Fatalf("read endpoint: %v", err)
 	}
 	lines := strings.SplitN(string(data), "\n", 3)
-	if len(lines) < 2 {
+	if len(lines) < 3 {
 		t.Fatalf("invalid endpoint file")
 	}
 	addr := strings.TrimSpace(lines[0])

--- a/internal/ipc/test_transport_windows_test.go
+++ b/internal/ipc/test_transport_windows_test.go
@@ -3,6 +3,8 @@
 package ipc_test
 
 import (
+	"bufio"
+	"fmt"
 	"net"
 	"os"
 	"strings"
@@ -11,13 +13,23 @@ import (
 
 func rawDial(t *testing.T, endpoint string) net.Conn {
 	t.Helper()
-	addr, err := os.ReadFile(endpoint)
+	data, err := os.ReadFile(endpoint)
 	if err != nil {
 		t.Fatalf("read endpoint: %v", err)
 	}
-	conn, err := net.Dial("tcp", strings.TrimSpace(string(addr)))
+	lines := strings.SplitN(string(data), "\n", 3)
+	if len(lines) < 2 {
+		t.Fatalf("invalid endpoint file")
+	}
+	addr := strings.TrimSpace(lines[0])
+	token := strings.TrimSpace(lines[1])
+	conn, err := net.Dial("tcp", addr)
 	if err != nil {
 		t.Fatalf("raw dial: %v", err)
+	}
+	if _, err := fmt.Fprintf(conn, "%s\n", token); err != nil {
+		conn.Close()
+		t.Fatalf("send token: %v", err)
 	}
 	return conn
 }
@@ -29,9 +41,35 @@ func rawListen(t *testing.T, endpoint string) net.Listener {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(endpoint, []byte(ln.Addr().String()), 0o600); err != nil {
+	content := fmt.Sprintf("%s\ntest-token\n%d", ln.Addr().String(), os.Getpid())
+	if err := os.WriteFile(endpoint, []byte(content), 0o600); err != nil {
 		ln.Close()
 		t.Fatal(err)
 	}
-	return ln
+	return &tokenStripListener{Listener: ln}
+}
+
+// tokenStripListener wraps a net.Listener to auto-consume the auth token
+// line sent by dial(), so test server goroutines see requests directly.
+type tokenStripListener struct {
+	net.Listener
+}
+
+func (l *tokenStripListener) Accept() (net.Conn, error) {
+	conn, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	r := bufio.NewReader(conn)
+	r.ReadString('\n') // consume token line
+	return &testBufferedConn{Conn: conn, r: r}, nil
+}
+
+type testBufferedConn struct {
+	net.Conn
+	r *bufio.Reader
+}
+
+func (c *testBufferedConn) Read(p []byte) (int, error) {
+	return c.r.Read(p)
 }

--- a/internal/ipc/test_transport_windows_test.go
+++ b/internal/ipc/test_transport_windows_test.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+package ipc_test
+
+import (
+	"net"
+	"os"
+	"strings"
+	"testing"
+)
+
+func rawDial(t *testing.T, endpoint string) net.Conn {
+	t.Helper()
+	addr, err := os.ReadFile(endpoint)
+	if err != nil {
+		t.Fatalf("read endpoint: %v", err)
+	}
+	conn, err := net.Dial("tcp", strings.TrimSpace(string(addr)))
+	if err != nil {
+		t.Fatalf("raw dial: %v", err)
+	}
+	return conn
+}
+
+func rawListen(t *testing.T, endpoint string) net.Listener {
+	t.Helper()
+	_ = os.Remove(endpoint)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(endpoint, []byte(ln.Addr().String()), 0o600); err != nil {
+		ln.Close()
+		t.Fatal(err)
+	}
+	return ln
+}

--- a/internal/ipc/transport_unix.go
+++ b/internal/ipc/transport_unix.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+package ipc
+
+import (
+	"net"
+	"os"
+	"syscall"
+)
+
+func listen(endpoint string) (net.Listener, error) {
+	_ = os.Remove(endpoint)
+	oldMask := syscall.Umask(0o077)
+	ln, err := net.Listen("unix", endpoint)
+	syscall.Umask(oldMask)
+	return ln, err
+}
+
+func dial(endpoint string) (net.Conn, error) {
+	return net.Dial("unix", endpoint)
+}

--- a/internal/ipc/transport_windows.go
+++ b/internal/ipc/transport_windows.go
@@ -3,10 +3,15 @@
 package ipc
 
 import (
+	"bufio"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 	"strings"
+	"syscall"
 )
 
 func listen(endpoint string) (net.Listener, error) {
@@ -15,21 +20,100 @@ func listen(endpoint string) (net.Listener, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := os.WriteFile(endpoint, []byte(ln.Addr().String()), 0o600); err != nil {
+	token, err := generateToken()
+	if err != nil {
 		ln.Close()
 		return nil, err
 	}
-	return ln, nil
+	content := fmt.Sprintf("%s\n%s\n%d", ln.Addr().String(), token, os.Getpid())
+	if err := os.WriteFile(endpoint, []byte(content), 0o600); err != nil {
+		ln.Close()
+		return nil, err
+	}
+	return &tokenListener{Listener: ln, token: token}, nil
 }
 
 func dial(endpoint string) (net.Conn, error) {
-	addr, err := os.ReadFile(endpoint)
+	data, err := os.ReadFile(endpoint)
 	if err != nil {
 		return nil, err
 	}
-	target := strings.TrimSpace(string(addr))
-	if target == "" {
-		return nil, fmt.Errorf("empty ipc endpoint")
+	lines := strings.SplitN(string(data), "\n", 3)
+	if len(lines) < 3 {
+		return nil, fmt.Errorf("invalid ipc endpoint file")
 	}
-	return net.Dial("tcp", target)
+	addr := strings.TrimSpace(lines[0])
+	token := strings.TrimSpace(lines[1])
+	pidStr := strings.TrimSpace(lines[2])
+	if addr == "" || token == "" {
+		return nil, fmt.Errorf("invalid ipc endpoint file")
+	}
+	if pid, err := strconv.Atoi(pidStr); err == nil && !processAlive(pid) {
+		return nil, fmt.Errorf("daemon process %d is no longer running", pid)
+	}
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := fmt.Fprintf(conn, "%s\n", token); err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("send auth token: %w", err)
+	}
+	return conn, nil
+}
+
+func generateToken() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// tokenListener wraps a net.Listener to verify auth tokens on accepted connections.
+// Connections that fail to present the correct token are silently closed.
+type tokenListener struct {
+	net.Listener
+	token string
+}
+
+func (tl *tokenListener) Accept() (net.Conn, error) {
+	for {
+		conn, err := tl.Listener.Accept()
+		if err != nil {
+			return nil, err
+		}
+		r := bufio.NewReader(conn)
+		line, err := r.ReadString('\n')
+		if err != nil {
+			conn.Close()
+			continue
+		}
+		if strings.TrimSpace(line) != tl.token {
+			conn.Close()
+			continue
+		}
+		return &bufferedConn{Conn: conn, r: r}, nil
+	}
+}
+
+// bufferedConn wraps a net.Conn so that bytes already buffered by a
+// bufio.Reader are available for subsequent reads.
+type bufferedConn struct {
+	net.Conn
+	r *bufio.Reader
+}
+
+func (bc *bufferedConn) Read(p []byte) (int, error) {
+	return bc.r.Read(p)
+}
+
+func processAlive(pid int) bool {
+	const processQueryLimitedInformation = 0x1000
+	h, err := syscall.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	syscall.CloseHandle(h)
+	return true
 }

--- a/internal/ipc/transport_windows.go
+++ b/internal/ipc/transport_windows.go
@@ -102,11 +102,13 @@ func (tl *tokenListener) Accept() (net.Conn, error) {
 		line, err := r.ReadString('\n')
 		if err != nil {
 			conn.Close()
+			time.Sleep(50 * time.Millisecond)
 			continue
 		}
 		conn.SetReadDeadline(time.Time{})
 		if strings.TrimSpace(line) != tl.token {
 			conn.Close()
+			time.Sleep(50 * time.Millisecond)
 			continue
 		}
 		return &bufferedConn{Conn: conn, r: r}, nil

--- a/internal/ipc/transport_windows.go
+++ b/internal/ipc/transport_windows.go
@@ -5,6 +5,7 @@ package ipc
 import (
 	"bufio"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
 	"net"
@@ -150,7 +151,7 @@ func (tl *tokenListener) authenticate(conn net.Conn) {
 		return
 	}
 	conn.SetReadDeadline(time.Time{})
-	if strings.TrimSpace(line) != tl.token {
+	if subtle.ConstantTimeCompare([]byte(strings.TrimSpace(line)), []byte(tl.token)) != 1 {
 		conn.Close()
 		return
 	}
@@ -173,7 +174,6 @@ func (tl *tokenListener) Accept() (net.Conn, error) {
 
 func (tl *tokenListener) Close() error {
 	tl.closeOnce.Do(func() { close(tl.done) })
-	os.Remove(tl.endpoint)
 	return tl.Listener.Close()
 }
 

--- a/internal/ipc/transport_windows.go
+++ b/internal/ipc/transport_windows.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -85,34 +86,64 @@ func generateToken() (string, error) {
 }
 
 // tokenListener wraps a net.Listener to verify auth tokens on accepted connections.
-// Connections that fail to present the correct token are silently closed.
+// Auth is performed in per-connection goroutines so that slow or invalid
+// connections do not block acceptance of other clients.
 type tokenListener struct {
 	net.Listener
-	token string
+	token     string
+	connCh    chan net.Conn
+	done      chan struct{}
+	startOnce sync.Once
+	closeOnce sync.Once
+}
+
+func (tl *tokenListener) start() {
+	tl.connCh = make(chan net.Conn)
+	tl.done = make(chan struct{})
+	go func() {
+		defer close(tl.connCh)
+		for {
+			raw, err := tl.Listener.Accept()
+			if err != nil {
+				return
+			}
+			go tl.authenticate(raw)
+		}
+	}()
+}
+
+func (tl *tokenListener) authenticate(conn net.Conn) {
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	r := bufio.NewReader(conn)
+	line, err := r.ReadString('\n')
+	if err != nil {
+		conn.Close()
+		return
+	}
+	conn.SetReadDeadline(time.Time{})
+	if strings.TrimSpace(line) != tl.token {
+		conn.Close()
+		return
+	}
+	select {
+	case tl.connCh <- &bufferedConn{Conn: conn, r: r}:
+	case <-tl.done:
+		conn.Close()
+	}
 }
 
 func (tl *tokenListener) Accept() (net.Conn, error) {
-	for {
-		conn, err := tl.Listener.Accept()
-		if err != nil {
-			return nil, err
-		}
-		conn.SetReadDeadline(time.Now().Add(5 * time.Second))
-		r := bufio.NewReader(conn)
-		line, err := r.ReadString('\n')
-		if err != nil {
-			conn.Close()
-			time.Sleep(50 * time.Millisecond)
-			continue
-		}
-		conn.SetReadDeadline(time.Time{})
-		if strings.TrimSpace(line) != tl.token {
-			conn.Close()
-			time.Sleep(50 * time.Millisecond)
-			continue
-		}
-		return &bufferedConn{Conn: conn, r: r}, nil
+	tl.startOnce.Do(tl.start)
+	conn, ok := <-tl.connCh
+	if !ok {
+		return nil, net.ErrClosed
 	}
+	return conn, nil
+}
+
+func (tl *tokenListener) Close() error {
+	tl.closeOnce.Do(func() { close(tl.done) })
+	return tl.Listener.Close()
 }
 
 // bufferedConn wraps a net.Conn so that bytes already buffered by a

--- a/internal/ipc/transport_windows.go
+++ b/internal/ipc/transport_windows.go
@@ -1,0 +1,35 @@
+//go:build windows
+
+package ipc
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strings"
+)
+
+func listen(endpoint string) (net.Listener, error) {
+	_ = os.Remove(endpoint)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+	if err := os.WriteFile(endpoint, []byte(ln.Addr().String()), 0o600); err != nil {
+		ln.Close()
+		return nil, err
+	}
+	return ln, nil
+}
+
+func dial(endpoint string) (net.Conn, error) {
+	addr, err := os.ReadFile(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	target := strings.TrimSpace(string(addr))
+	if target == "" {
+		return nil, fmt.Errorf("empty ipc endpoint")
+	}
+	return net.Dial("tcp", target)
+}

--- a/internal/ipc/transport_windows.go
+++ b/internal/ipc/transport_windows.go
@@ -174,6 +174,7 @@ func (tl *tokenListener) Accept() (net.Conn, error) {
 
 func (tl *tokenListener) Close() error {
 	tl.closeOnce.Do(func() { close(tl.done) })
+	os.Remove(tl.endpoint)
 	return tl.Listener.Close()
 }
 

--- a/internal/ipc/transport_windows.go
+++ b/internal/ipc/transport_windows.go
@@ -29,13 +29,20 @@ func listen(endpoint string) (net.Listener, error) {
 		return nil, err
 	}
 	content := fmt.Sprintf("%s\n%s\n%d", ln.Addr().String(), token, os.Getpid())
-	if err := os.WriteFile(endpoint, []byte(content), 0o600); err != nil {
+	tmpFile := endpoint + ".tmp"
+	if err := os.WriteFile(tmpFile, []byte(content), 0o600); err != nil {
 		ln.Close()
 		return nil, err
 	}
-	if err := restrictFileACL(endpoint); err != nil {
+	if err := restrictFileACL(tmpFile); err != nil {
+		os.Remove(tmpFile)
 		ln.Close()
 		return nil, fmt.Errorf("restrict endpoint file ACL: %w", err)
+	}
+	if err := os.Rename(tmpFile, endpoint); err != nil {
+		os.Remove(tmpFile)
+		ln.Close()
+		return nil, fmt.Errorf("rename endpoint file: %w", err)
 	}
 	return &tokenListener{Listener: ln, token: token}, nil
 }

--- a/internal/ipc/transport_windows.go
+++ b/internal/ipc/transport_windows.go
@@ -12,6 +12,9 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
+
+	"golang.org/x/sys/windows"
 )
 
 func listen(endpoint string) (net.Listener, error) {
@@ -29,6 +32,10 @@ func listen(endpoint string) (net.Listener, error) {
 	if err := os.WriteFile(endpoint, []byte(content), 0o600); err != nil {
 		ln.Close()
 		return nil, err
+	}
+	if err := restrictFileACL(endpoint); err != nil {
+		ln.Close()
+		return nil, fmt.Errorf("restrict endpoint file ACL: %w", err)
 	}
 	return &tokenListener{Listener: ln, token: token}, nil
 }
@@ -83,12 +90,14 @@ func (tl *tokenListener) Accept() (net.Conn, error) {
 		if err != nil {
 			return nil, err
 		}
+		conn.SetReadDeadline(time.Now().Add(5 * time.Second))
 		r := bufio.NewReader(conn)
 		line, err := r.ReadString('\n')
 		if err != nil {
 			conn.Close()
 			continue
 		}
+		conn.SetReadDeadline(time.Time{})
 		if strings.TrimSpace(line) != tl.token {
 			conn.Close()
 			continue
@@ -106,6 +115,42 @@ type bufferedConn struct {
 
 func (bc *bufferedConn) Read(p []byte) (int, error) {
 	return bc.r.Read(p)
+}
+
+func restrictFileACL(path string) error {
+	token, err := windows.OpenCurrentProcessToken()
+	if err != nil {
+		return err
+	}
+	defer token.Close()
+
+	user, err := token.GetTokenUser()
+	if err != nil {
+		return err
+	}
+
+	access := []windows.EXPLICIT_ACCESS{{
+		AccessPermissions: windows.GENERIC_ALL,
+		AccessMode:        windows.SET_ACCESS,
+		Inheritance:       windows.NO_INHERITANCE,
+		Trustee: windows.TRUSTEE{
+			TrusteeForm:  windows.TRUSTEE_IS_SID,
+			TrusteeType:  windows.TRUSTEE_IS_USER,
+			TrusteeValue: windows.TrusteeValueFromSID(user.User.Sid),
+		},
+	}}
+
+	acl, err := windows.ACLFromEntries(access, nil)
+	if err != nil {
+		return err
+	}
+
+	return windows.SetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION,
+		nil, nil, acl, nil,
+	)
 }
 
 func processAlive(pid int) bool {

--- a/internal/ipc/transport_windows.go
+++ b/internal/ipc/transport_windows.go
@@ -101,7 +101,6 @@ func (tl *tokenListener) start() {
 	tl.connCh = make(chan net.Conn)
 	tl.done = make(chan struct{})
 	go func() {
-		defer close(tl.connCh)
 		for {
 			raw, err := tl.Listener.Accept()
 			if err != nil {
@@ -134,11 +133,12 @@ func (tl *tokenListener) authenticate(conn net.Conn) {
 
 func (tl *tokenListener) Accept() (net.Conn, error) {
 	tl.startOnce.Do(tl.start)
-	conn, ok := <-tl.connCh
-	if !ok {
+	select {
+	case conn := <-tl.connCh:
+		return conn, nil
+	case <-tl.done:
 		return nil, net.ErrClosed
 	}
-	return conn, nil
 }
 
 func (tl *tokenListener) Close() error {

--- a/internal/ipc/transport_windows.go
+++ b/internal/ipc/transport_windows.go
@@ -48,6 +48,7 @@ func listen(endpoint string) (net.Listener, error) {
 	return &tokenListener{
 		Listener: ln,
 		token:    token,
+		endpoint: endpoint,
 		connCh:   make(chan net.Conn),
 		done:     make(chan struct{}),
 	}, nil
@@ -96,6 +97,7 @@ func generateToken() (string, error) {
 type tokenListener struct {
 	net.Listener
 	token     string
+	endpoint  string
 	connCh    chan net.Conn
 	done      chan struct{}
 	startOnce sync.Once
@@ -106,6 +108,8 @@ func (tl *tokenListener) start() {
 	go func() {
 		backoff := time.Duration(0)
 		const maxBackoff = time.Second
+		const maxConsecutiveErrors = 64
+		consecutiveErrors := 0
 		for {
 			raw, err := tl.Listener.Accept()
 			if err != nil {
@@ -113,6 +117,11 @@ func (tl *tokenListener) start() {
 				case <-tl.done:
 					return
 				default:
+				}
+				consecutiveErrors++
+				if consecutiveErrors >= maxConsecutiveErrors {
+					tl.Close()
+					return
 				}
 				if backoff == 0 {
 					backoff = 5 * time.Millisecond
@@ -126,6 +135,7 @@ func (tl *tokenListener) start() {
 				continue
 			}
 			backoff = 0
+			consecutiveErrors = 0
 			go tl.authenticate(raw)
 		}
 	}()
@@ -163,6 +173,7 @@ func (tl *tokenListener) Accept() (net.Conn, error) {
 
 func (tl *tokenListener) Close() error {
 	tl.closeOnce.Do(func() { close(tl.done) })
+	os.Remove(tl.endpoint)
 	return tl.Listener.Close()
 }
 

--- a/internal/ipc/transport_windows.go
+++ b/internal/ipc/transport_windows.go
@@ -45,7 +45,12 @@ func listen(endpoint string) (net.Listener, error) {
 		ln.Close()
 		return nil, fmt.Errorf("rename endpoint file: %w", err)
 	}
-	return &tokenListener{Listener: ln, token: token}, nil
+	return &tokenListener{
+		Listener: ln,
+		token:    token,
+		connCh:   make(chan net.Conn),
+		done:     make(chan struct{}),
+	}, nil
 }
 
 func dial(endpoint string) (net.Conn, error) {
@@ -98,12 +103,11 @@ type tokenListener struct {
 }
 
 func (tl *tokenListener) start() {
-	tl.connCh = make(chan net.Conn)
-	tl.done = make(chan struct{})
 	go func() {
 		for {
 			raw, err := tl.Listener.Accept()
 			if err != nil {
+				tl.closeOnce.Do(func() { close(tl.done) })
 				return
 			}
 			go tl.authenticate(raw)

--- a/internal/ipc/transport_windows.go
+++ b/internal/ipc/transport_windows.go
@@ -104,12 +104,28 @@ type tokenListener struct {
 
 func (tl *tokenListener) start() {
 	go func() {
+		backoff := time.Duration(0)
+		const maxBackoff = time.Second
 		for {
 			raw, err := tl.Listener.Accept()
 			if err != nil {
-				tl.closeOnce.Do(func() { close(tl.done) })
-				return
+				select {
+				case <-tl.done:
+					return
+				default:
+				}
+				if backoff == 0 {
+					backoff = 5 * time.Millisecond
+				} else {
+					backoff *= 2
+					if backoff > maxBackoff {
+						backoff = maxBackoff
+					}
+				}
+				time.Sleep(backoff)
+				continue
 			}
+			backoff = 0
 			go tl.authenticate(raw)
 		}
 	}()

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -7,57 +7,61 @@ import (
 )
 
 func TestWithRoot(t *testing.T) {
-	p := WithRoot("/tmp/nm-test")
+	root := filepath.Join("tmp", "nm-test")
+	p := WithRoot(root)
 
-	if got := p.Root(); got != "/tmp/nm-test" {
-		t.Errorf("Root() = %q, want %q", got, "/tmp/nm-test")
+	if got := p.Root(); got != root {
+		t.Errorf("Root() = %q, want %q", got, root)
 	}
-	if got := p.DB(); got != "/tmp/nm-test/state.sqlite" {
-		t.Errorf("DB() = %q, want %q", got, "/tmp/nm-test/state.sqlite")
+	if got := p.DB(); got != filepath.Join(root, "state.sqlite") {
+		t.Errorf("DB() = %q, want %q", got, filepath.Join(root, "state.sqlite"))
 	}
-	if got := p.Socket(); got != "/tmp/nm-test/socket" {
-		t.Errorf("Socket() = %q, want %q", got, "/tmp/nm-test/socket")
+	if got := p.Socket(); got != filepath.Join(root, "socket") {
+		t.Errorf("Socket() = %q, want %q", got, filepath.Join(root, "socket"))
 	}
-	if got := p.PIDFile(); got != "/tmp/nm-test/daemon.pid" {
-		t.Errorf("PIDFile() = %q, want %q", got, "/tmp/nm-test/daemon.pid")
+	if got := p.PIDFile(); got != filepath.Join(root, "daemon.pid") {
+		t.Errorf("PIDFile() = %q, want %q", got, filepath.Join(root, "daemon.pid"))
 	}
-	if got := p.ConfigFile(); got != "/tmp/nm-test/config.yaml" {
-		t.Errorf("ConfigFile() = %q, want %q", got, "/tmp/nm-test/config.yaml")
+	if got := p.ConfigFile(); got != filepath.Join(root, "config.yaml") {
+		t.Errorf("ConfigFile() = %q, want %q", got, filepath.Join(root, "config.yaml"))
 	}
 }
 
 func TestRepoPaths(t *testing.T) {
-	p := WithRoot("/tmp/nm-test")
+	root := filepath.Join("tmp", "nm-test")
+	p := WithRoot(root)
 
-	if got := p.ReposDir(); got != "/tmp/nm-test/repos" {
+	if got := p.ReposDir(); got != filepath.Join(root, "repos") {
 		t.Errorf("ReposDir() = %q", got)
 	}
-	if got := p.RepoDir("abc123"); got != "/tmp/nm-test/repos/abc123.git" {
+	if got := p.RepoDir("abc123"); got != filepath.Join(root, "repos", "abc123.git") {
 		t.Errorf("RepoDir() = %q", got)
 	}
 }
 
 func TestWorktreePaths(t *testing.T) {
-	p := WithRoot("/tmp/nm-test")
+	root := filepath.Join("tmp", "nm-test")
+	p := WithRoot(root)
 
-	if got := p.WorktreesDir(); got != "/tmp/nm-test/worktrees" {
+	if got := p.WorktreesDir(); got != filepath.Join(root, "worktrees") {
 		t.Errorf("WorktreesDir() = %q", got)
 	}
-	if got := p.WorktreeDir("repo1", "run1"); got != "/tmp/nm-test/worktrees/repo1/run1" {
+	if got := p.WorktreeDir("repo1", "run1"); got != filepath.Join(root, "worktrees", "repo1", "run1") {
 		t.Errorf("WorktreeDir() = %q", got)
 	}
 }
 
 func TestLogPaths(t *testing.T) {
-	p := WithRoot("/tmp/nm-test")
+	root := filepath.Join("tmp", "nm-test")
+	p := WithRoot(root)
 
-	if got := p.LogsDir(); got != "/tmp/nm-test/logs" {
+	if got := p.LogsDir(); got != filepath.Join(root, "logs") {
 		t.Errorf("LogsDir() = %q", got)
 	}
-	if got := p.RunLogDir("run1"); got != "/tmp/nm-test/logs/run1" {
+	if got := p.RunLogDir("run1"); got != filepath.Join(root, "logs", "run1") {
 		t.Errorf("RunLogDir() = %q", got)
 	}
-	if got := p.DaemonLog(); got != "/tmp/nm-test/logs/daemon.log" {
+	if got := p.DaemonLog(); got != filepath.Join(root, "logs", "daemon.log") {
 		t.Errorf("DaemonLog() = %q", got)
 	}
 }

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
@@ -70,7 +71,12 @@ func hasBlockingFindings(items []Finding) bool {
 // runShellCommand executes a shell command and returns stdout+stderr, exit code, and error.
 // A non-zero exit code is not treated as an error — only exec failures return error.
 func runShellCommand(ctx context.Context, dir, cmdStr string) (string, int, error) {
-	cmd := exec.CommandContext(ctx, "sh", "-c", cmdStr)
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.CommandContext(ctx, "cmd.exe", "/c", cmdStr)
+	} else {
+		cmd = exec.CommandContext(ctx, "sh", "-c", cmdStr)
+	}
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1628,6 +1628,26 @@ func prependPATH(t *testing.T, binDir string) {
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
+// fakeCLIBinDir creates a temporary directory for fake CLI binaries.
+// Unlike t.TempDir(), cleanup tolerates file locks from recently-executed
+// binaries on Windows (which prevent immediate deletion).
+func fakeCLIBinDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "fakecli")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		for i := 0; i < 10; i++ {
+			if err := os.RemoveAll(dir); err == nil {
+				return
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
+	})
+	return dir
+}
+
 // linkTestBinary creates a hard link (or copy) of the current test binary
 // with the given name in binDir. On Windows, .exe is appended.
 func linkTestBinary(t *testing.T, binDir, name string) {
@@ -1656,7 +1676,7 @@ func linkTestBinary(t *testing.T, binDir, name string) {
 // The binary records all invocations to a log file and responds based on subcommand.
 func fakeGH(t *testing.T, prViewURL string) (binDir string, logFile string) {
 	t.Helper()
-	binDir = t.TempDir()
+	binDir = fakeCLIBinDir(t)
 	logFile = filepath.Join(t.TempDir(), "gh.log")
 	linkTestBinary(t, binDir, "gh")
 	t.Setenv("FAKE_CLI_MODE", "gh")
@@ -1826,7 +1846,7 @@ func TestPRStep_UsesAgentGeneratedTitleAndBody(t *testing.T) {
 
 func fakeGlab(t *testing.T, mrViewJSON string) (binDir string, logFile string) {
 	t.Helper()
-	binDir = t.TempDir()
+	binDir = fakeCLIBinDir(t)
 	logFile = filepath.Join(t.TempDir(), "glab.log")
 	linkTestBinary(t, binDir, "glab")
 	t.Setenv("FAKE_CLI_MODE", "glab")
@@ -3117,7 +3137,7 @@ func TestReviewStep_FixMode_RequiresPreviousFindings(t *testing.T) {
 // commands (pr view --json state, pr checks --json, pr view --json comments).
 func fakeBabysitGH(t *testing.T, state, checksJSON, commentsJSON string) string {
 	t.Helper()
-	binDir := t.TempDir()
+	binDir := fakeCLIBinDir(t)
 	linkTestBinary(t, binDir, "gh")
 	t.Setenv("FAKE_CLI_MODE", "babysit-gh")
 	t.Setenv("FAKE_CLI_STATE", state)
@@ -3128,7 +3148,7 @@ func fakeBabysitGH(t *testing.T, state, checksJSON, commentsJSON string) string 
 
 func fakeBabysitGHNoChecks(t *testing.T) string {
 	t.Helper()
-	binDir := t.TempDir()
+	binDir := fakeCLIBinDir(t)
 	linkTestBinary(t, binDir, "gh")
 	t.Setenv("FAKE_CLI_MODE", "babysit-gh-nochecks")
 	return binDir

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -922,7 +922,11 @@ func TestLintStep_PassingCommand(t *testing.T) {
 func TestLintStep_FailingCommand(t *testing.T) {
 	dir := t.TempDir()
 	ag := &mockAgent{name: "test"}
-	sctx := newTestContext(t, ag, dir, "abc", "def", config.Commands{Lint: "echo 'lint error'; exit 1"})
+	lintCmd := "echo 'lint error'; exit 1"
+	if runtime.GOOS == "windows" {
+		lintCmd = "echo lint error & exit /b 1"
+	}
+	sctx := newTestContext(t, ag, dir, "abc", "def", config.Commands{Lint: lintCmd})
 
 	step := &LintStep{}
 	outcome, err := step.Execute(sctx)

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1255,7 +1255,9 @@ func TestPushStep_RunsFormatCommandBeforeCommit(t *testing.T) {
 	markerPath := filepath.Join(dir, ".format-ran")
 	var formatCmd string
 	if runtime.GOOS == "windows" {
-		formatCmd = fmt.Sprintf("type nul > \"%s\"", markerPath)
+		bat := filepath.Join(dir, "fmt.bat")
+		os.WriteFile(bat, []byte(fmt.Sprintf("@copy nul \"%s\" >nul\r\n", markerPath)), 0o755)
+		formatCmd = bat
 	} else {
 		formatCmd = fmt.Sprintf("touch %s", markerPath)
 	}
@@ -1543,15 +1545,23 @@ exit 1
 `, logFile, prViewURL, prViewURL)
 
 	batScript := fmt.Sprintf("@echo off\r\necho %%* >> \"%s\"\r\n", logFile)
-	batScript += "if \"%1\"==\"auth\" if \"%2\"==\"status\" exit /b 0\r\n"
+	batScript += "if not \"%1\"==\"pr\" goto :chkauth\r\n"
 	if prViewURL != "" {
-		batScript += fmt.Sprintf("if \"%%1\"==\"pr\" if \"%%2\"==\"view\" (\r\n  echo %s\r\n  exit /b 0\r\n)\r\n", prViewURL)
+		batScript += fmt.Sprintf("if \"%%2\"==\"view\" goto :prview\r\n")
 	} else {
-		batScript += "if \"%1\"==\"pr\" if \"%2\"==\"view\" exit /b 1\r\n"
+		batScript += "if \"%2\"==\"view\" exit /b 1\r\n"
 	}
-	batScript += "if \"%1\"==\"pr\" if \"%2\"==\"edit\" exit /b 0\r\n"
-	batScript += "if \"%1\"==\"pr\" if \"%2\"==\"create\" (\r\n  echo https://github.com/test/repo/pull/99\r\n  exit /b 0\r\n)\r\n"
+	batScript += "if \"%2\"==\"edit\" exit /b 0\r\n"
+	batScript += "if \"%2\"==\"create\" goto :prcreate\r\n"
+	batScript += "goto :fail\r\n"
+	batScript += ":chkauth\r\n"
+	batScript += "if \"%1\"==\"auth\" if \"%2\"==\"status\" exit /b 0\r\n"
+	batScript += ":fail\r\n"
 	batScript += "exit /b 1\r\n"
+	if prViewURL != "" {
+		batScript += fmt.Sprintf(":prview\r\necho %s\r\nexit /b 0\r\n", prViewURL)
+	}
+	batScript += ":prcreate\r\necho https://github.com/test/repo/pull/99\r\nexit /b 0\r\n"
 
 	writeFakeScript(t, binDir, "gh", shScript, batScript)
 	return binDir, logFile
@@ -1746,20 +1756,28 @@ exit 1
 `, logFile, mrViewJSON, mrViewJSON)
 
 	batScript := fmt.Sprintf("@echo off\r\necho %%* >> \"%s\"\r\n", logFile)
-	batScript += "if \"%1\"==\"auth\" if \"%2\"==\"status\" exit /b 0\r\n"
+	batScript += "if not \"%1\"==\"mr\" goto :chkauth\r\n"
 	if mrViewJSON != "" {
-		// Write the JSON to a temp file and type it, since batch heredocs don't exist.
 		jsonFile := filepath.Join(binDir, "mrview.json")
 		if err := os.WriteFile(jsonFile, []byte(mrViewJSON), 0o644); err != nil {
 			t.Fatal(err)
 		}
-		batScript += fmt.Sprintf("if \"%%1\"==\"mr\" if \"%%2\"==\"view\" (\r\n  type \"%s\"\r\n  exit /b 0\r\n)\r\n", jsonFile)
+		batScript += fmt.Sprintf("if \"%%2\"==\"view\" goto :mrview\r\n")
 	} else {
-		batScript += "if \"%1\"==\"mr\" if \"%2\"==\"view\" exit /b 1\r\n"
+		batScript += "if \"%2\"==\"view\" exit /b 1\r\n"
 	}
-	batScript += "if \"%1\"==\"mr\" if \"%2\"==\"update\" exit /b 0\r\n"
-	batScript += "if \"%1\"==\"mr\" if \"%2\"==\"create\" (\r\n  echo https://gitlab.com/test/repo/-/merge_requests/99\r\n  exit /b 0\r\n)\r\n"
+	batScript += "if \"%2\"==\"update\" exit /b 0\r\n"
+	batScript += "if \"%2\"==\"create\" goto :mrcreate\r\n"
+	batScript += "goto :fail\r\n"
+	batScript += ":chkauth\r\n"
+	batScript += "if \"%1\"==\"auth\" if \"%2\"==\"status\" exit /b 0\r\n"
+	batScript += ":fail\r\n"
 	batScript += "exit /b 1\r\n"
+	if mrViewJSON != "" {
+		jsonFile := filepath.Join(binDir, "mrview.json")
+		batScript += fmt.Sprintf(":mrview\r\ntype \"%s\"\r\nexit /b 0\r\n", jsonFile)
+	}
+	batScript += ":mrcreate\r\necho https://gitlab.com/test/repo/-/merge_requests/99\r\nexit /b 0\r\n"
 
 	writeFakeScript(t, binDir, "glab", shScript, batScript)
 	return binDir, logFile

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -21,6 +21,137 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
+// TestMain handles fake CLI dispatch when the test binary is invoked as gh/glab.
+func TestMain(m *testing.M) {
+	if mode := os.Getenv("FAKE_CLI_MODE"); mode != "" {
+		handleFakeCLI(mode)
+		return
+	}
+	os.Exit(m.Run())
+}
+
+func handleFakeCLI(mode string) {
+	args := os.Args[1:]
+	logFile := os.Getenv("FAKE_CLI_LOG")
+
+	if logFile != "" {
+		f, _ := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if f != nil {
+			fmt.Fprintln(f, strings.Join(args, " "))
+			f.Close()
+		}
+	}
+
+	switch mode {
+	case "gh":
+		fakeGHHandler(args)
+	case "glab":
+		fakeGlabHandler(args)
+	case "babysit-gh":
+		fakeBabysitGHHandler(args)
+	case "babysit-gh-nochecks":
+		fakeBabysitGHNoChecksHandler(args)
+	default:
+		os.Exit(1)
+	}
+}
+
+func fakeGHHandler(args []string) {
+	prURL := os.Getenv("FAKE_CLI_PR_URL")
+	if len(args) >= 2 && args[0] == "auth" && args[1] == "status" {
+		os.Exit(0)
+	}
+	if len(args) >= 2 && args[0] == "pr" && args[1] == "view" {
+		if prURL != "" {
+			fmt.Println(prURL)
+			os.Exit(0)
+		}
+		os.Exit(1)
+	}
+	if len(args) >= 2 && args[0] == "pr" && args[1] == "edit" {
+		os.Exit(0)
+	}
+	if len(args) >= 2 && args[0] == "pr" && args[1] == "create" {
+		fmt.Println("https://github.com/test/repo/pull/99")
+		os.Exit(0)
+	}
+	os.Exit(1)
+}
+
+func fakeGlabHandler(args []string) {
+	mrViewJSON := os.Getenv("FAKE_CLI_MR_VIEW_JSON")
+	if len(args) >= 2 && args[0] == "auth" && args[1] == "status" {
+		os.Exit(0)
+	}
+	if len(args) >= 2 && args[0] == "mr" && args[1] == "view" {
+		if mrViewJSON != "" {
+			fmt.Println(mrViewJSON)
+			os.Exit(0)
+		}
+		os.Exit(1)
+	}
+	if len(args) >= 2 && args[0] == "mr" && args[1] == "update" {
+		os.Exit(0)
+	}
+	if len(args) >= 2 && args[0] == "mr" && args[1] == "create" {
+		fmt.Println("https://gitlab.com/test/repo/-/merge_requests/99")
+		os.Exit(0)
+	}
+	os.Exit(1)
+}
+
+func fakeBabysitGHHandler(args []string) {
+	state := os.Getenv("FAKE_CLI_STATE")
+	checksJSON := os.Getenv("FAKE_CLI_CHECKS")
+	commentsJSON := os.Getenv("FAKE_CLI_COMMENTS")
+	joined := strings.Join(args, " ")
+
+	if len(args) >= 2 && args[0] == "auth" && args[1] == "status" {
+		os.Exit(0)
+	}
+	if strings.Contains(joined, "pr view") && strings.Contains(joined, "--json state") {
+		fmt.Println(state)
+		os.Exit(0)
+	}
+	if strings.Contains(joined, "pr checks") {
+		fmt.Println(checksJSON)
+		os.Exit(0)
+	}
+	if strings.Contains(joined, "pr view") && strings.Contains(joined, "--json comments") {
+		fmt.Println(commentsJSON)
+		os.Exit(0)
+	}
+	if strings.Contains(joined, "pr comment") {
+		os.Exit(0)
+	}
+	if strings.Contains(joined, "run view") {
+		fmt.Println("error log output")
+		os.Exit(0)
+	}
+	os.Exit(1)
+}
+
+func fakeBabysitGHNoChecksHandler(args []string) {
+	joined := strings.Join(args, " ")
+
+	if len(args) >= 2 && args[0] == "auth" && args[1] == "status" {
+		os.Exit(0)
+	}
+	if strings.Contains(joined, "pr checks") {
+		fmt.Fprintln(os.Stderr, "no checks reported on the 'feature/e2e' branch")
+		os.Exit(1)
+	}
+	if strings.Contains(joined, "pr view") && strings.Contains(joined, "--json state") {
+		fmt.Println("OPEN")
+		os.Exit(0)
+	}
+	if strings.Contains(joined, "pr view") && strings.Contains(joined, "--json comments") {
+		fmt.Println("[]")
+		os.Exit(0)
+	}
+	os.Exit(1)
+}
+
 // --- mock agent ---
 
 type mockAgent struct {
@@ -1497,73 +1628,40 @@ func prependPATH(t *testing.T, binDir string) {
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
-// writeFakeScript writes a shell script (Unix) or batch file (Windows) to binDir.
-// name is the binary name without extension (e.g. "gh"). On Windows, a .bat
-// extension is appended automatically.
-func writeFakeScript(t *testing.T, binDir, name, shScript, batScript string) {
+// linkTestBinary creates a hard link (or copy) of the current test binary
+// with the given name in binDir. On Windows, .exe is appended.
+func linkTestBinary(t *testing.T, binDir, name string) {
 	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if runtime.GOOS == "windows" {
-		p := filepath.Join(binDir, name+".bat")
-		if err := os.WriteFile(p, []byte(batScript), 0o755); err != nil {
-			t.Fatal(err)
+		name += ".exe"
+	}
+	dst := filepath.Join(binDir, name)
+	if err := os.Link(exe, dst); err != nil {
+		// Fallback to copy if hard link fails (cross-device, etc.)
+		data, readErr := os.ReadFile(exe)
+		if readErr != nil {
+			t.Fatal(readErr)
 		}
-	} else {
-		p := filepath.Join(binDir, name)
-		if err := os.WriteFile(p, []byte(shScript), 0o755); err != nil {
+		if err := os.WriteFile(dst, data, 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}
 }
 
-// fakeGH creates a mock gh script in a temp dir and returns the dir (for PATH prepending).
-// The script records all invocations to a log file and responds based on subcommand.
+// fakeGH creates a mock gh binary in a temp dir and returns the dir (for PATH prepending).
+// The binary records all invocations to a log file and responds based on subcommand.
 func fakeGH(t *testing.T, prViewURL string) (binDir string, logFile string) {
 	t.Helper()
 	binDir = t.TempDir()
 	logFile = filepath.Join(t.TempDir(), "gh.log")
-
-	shScript := fmt.Sprintf(`#!/bin/sh
-echo "$@" >> %s
-if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
-  exit 0
-fi
-if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
-  if [ "%s" != "" ]; then
-    echo "%s"
-    exit 0
-  fi
-  exit 1
-fi
-if [ "$1" = "pr" ] && [ "$2" = "edit" ]; then
-  exit 0
-fi
-if [ "$1" = "pr" ] && [ "$2" = "create" ]; then
-  echo "https://github.com/test/repo/pull/99"
-  exit 0
-fi
-exit 1
-`, logFile, prViewURL, prViewURL)
-
-	batScript := fmt.Sprintf("@echo off\r\necho %%* >> \"%s\"\r\n", logFile)
-	batScript += "if not \"%1\"==\"pr\" goto :chkauth\r\n"
-	if prViewURL != "" {
-		batScript += fmt.Sprintf("if \"%%2\"==\"view\" goto :prview\r\n")
-	} else {
-		batScript += "if \"%2\"==\"view\" exit /b 1\r\n"
-	}
-	batScript += "if \"%2\"==\"edit\" exit /b 0\r\n"
-	batScript += "if \"%2\"==\"create\" goto :prcreate\r\n"
-	batScript += "goto :fail\r\n"
-	batScript += ":chkauth\r\n"
-	batScript += "if \"%1\"==\"auth\" if \"%2\"==\"status\" exit /b 0\r\n"
-	batScript += ":fail\r\n"
-	batScript += "exit /b 1\r\n"
-	if prViewURL != "" {
-		batScript += fmt.Sprintf(":prview\r\necho %s\r\nexit /b 0\r\n", prViewURL)
-	}
-	batScript += ":prcreate\r\necho https://github.com/test/repo/pull/99\r\nexit /b 0\r\n"
-
-	writeFakeScript(t, binDir, "gh", shScript, batScript)
+	linkTestBinary(t, binDir, "gh")
+	t.Setenv("FAKE_CLI_MODE", "gh")
+	t.Setenv("FAKE_CLI_LOG", logFile)
+	t.Setenv("FAKE_CLI_PR_URL", prViewURL)
 	return binDir, logFile
 }
 
@@ -1730,56 +1828,10 @@ func fakeGlab(t *testing.T, mrViewJSON string) (binDir string, logFile string) {
 	t.Helper()
 	binDir = t.TempDir()
 	logFile = filepath.Join(t.TempDir(), "glab.log")
-
-	shScript := fmt.Sprintf(`#!/bin/sh
-echo "$@" >> %s
-if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
-  exit 0
-fi
-if [ "$1" = "mr" ] && [ "$2" = "view" ]; then
-  if [ '%s' != '' ]; then
-    cat <<'EOF'
-%s
-EOF
-    exit 0
-  fi
-  exit 1
-fi
-if [ "$1" = "mr" ] && [ "$2" = "update" ]; then
-  exit 0
-fi
-if [ "$1" = "mr" ] && [ "$2" = "create" ]; then
-  echo "https://gitlab.com/test/repo/-/merge_requests/99"
-  exit 0
-fi
-exit 1
-`, logFile, mrViewJSON, mrViewJSON)
-
-	batScript := fmt.Sprintf("@echo off\r\necho %%* >> \"%s\"\r\n", logFile)
-	batScript += "if not \"%1\"==\"mr\" goto :chkauth\r\n"
-	if mrViewJSON != "" {
-		jsonFile := filepath.Join(binDir, "mrview.json")
-		if err := os.WriteFile(jsonFile, []byte(mrViewJSON), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		batScript += fmt.Sprintf("if \"%%2\"==\"view\" goto :mrview\r\n")
-	} else {
-		batScript += "if \"%2\"==\"view\" exit /b 1\r\n"
-	}
-	batScript += "if \"%2\"==\"update\" exit /b 0\r\n"
-	batScript += "if \"%2\"==\"create\" goto :mrcreate\r\n"
-	batScript += "goto :fail\r\n"
-	batScript += ":chkauth\r\n"
-	batScript += "if \"%1\"==\"auth\" if \"%2\"==\"status\" exit /b 0\r\n"
-	batScript += ":fail\r\n"
-	batScript += "exit /b 1\r\n"
-	if mrViewJSON != "" {
-		jsonFile := filepath.Join(binDir, "mrview.json")
-		batScript += fmt.Sprintf(":mrview\r\ntype \"%s\"\r\nexit /b 0\r\n", jsonFile)
-	}
-	batScript += ":mrcreate\r\necho https://gitlab.com/test/repo/-/merge_requests/99\r\nexit /b 0\r\n"
-
-	writeFakeScript(t, binDir, "glab", shScript, batScript)
+	linkTestBinary(t, binDir, "glab")
+	t.Setenv("FAKE_CLI_MODE", "glab")
+	t.Setenv("FAKE_CLI_LOG", logFile)
+	t.Setenv("FAKE_CLI_MR_VIEW_JSON", mrViewJSON)
 	return binDir, logFile
 }
 
@@ -2306,7 +2358,7 @@ func TestBabysitStep_TimeoutDoesNotSleepPastDeadline(t *testing.T) {
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Run.PRURL = &prURL
-	sctx.Config.BabysitTimeout = 150 * time.Millisecond
+	sctx.Config.BabysitTimeout = 2 * time.Second
 
 	step := &BabysitStep{}
 	started := time.Now()
@@ -2317,7 +2369,7 @@ func TestBabysitStep_TimeoutDoesNotSleepPastDeadline(t *testing.T) {
 	if outcome.NeedsApproval {
 		t.Error("expected no approval when timeout expires")
 	}
-	if elapsed := time.Since(started); elapsed > time.Second {
+	if elapsed := time.Since(started); elapsed > 10*time.Second {
 		t.Fatalf("babysit step exceeded timeout budget: %v", elapsed)
 	}
 }
@@ -3066,127 +3118,19 @@ func TestReviewStep_FixMode_RequiresPreviousFindings(t *testing.T) {
 func fakeBabysitGH(t *testing.T, state, checksJSON, commentsJSON string) string {
 	t.Helper()
 	binDir := t.TempDir()
-
-	shScript := fmt.Sprintf(`#!/bin/sh
-ARGS="$*"
-if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
-  exit 0
-fi
-# pr view --json state --jq .state
-if echo "$ARGS" | grep -q "pr view.*--json state"; then
-  echo "%s"
-  exit 0
-fi
-# pr checks --json
-if echo "$ARGS" | grep -q "pr checks"; then
-  cat << 'CHECKS_EOF'
-%s
-CHECKS_EOF
-  exit 0
-fi
-# pr view --json comments --jq .comments
-if echo "$ARGS" | grep -q "pr view.*--json comments"; then
-  cat << 'COMMENTS_EOF'
-%s
-COMMENTS_EOF
-  exit 0
-fi
-# pr comment (reply to addressed comments)
-if echo "$ARGS" | grep -q "pr comment"; then
-  exit 0
-fi
-# run view (CI logs)
-if echo "$ARGS" | grep -q "run view"; then
-  echo "error log output"
-  exit 0
-fi
-exit 1
-`, state, checksJSON, commentsJSON)
-
-	// Write JSON data to files for batch to use via type command.
-	checksFile := filepath.Join(binDir, "checks.json")
-	if err := os.WriteFile(checksFile, []byte(checksJSON), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	commentsFile := filepath.Join(binDir, "comments.json")
-	if err := os.WriteFile(commentsFile, []byte(commentsJSON), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	// On Windows, use findstr to match arg patterns.
-	batScript := "@echo off\r\n"
-	batScript += "setlocal\r\n"
-	batScript += "set \"ARGS=%*\"\r\n"
-	batScript += "if \"%1\"==\"auth\" if \"%2\"==\"status\" exit /b 0\r\n"
-	// pr view --json state
-	batScript += "echo %ARGS% | findstr /c:\"pr view\" >nul 2>&1 || goto :notstate\r\n"
-	batScript += "echo %ARGS% | findstr /c:\"--json state\" >nul 2>&1 || goto :notstate\r\n"
-	batScript += fmt.Sprintf("echo %s\r\nexit /b 0\r\n", state)
-	batScript += ":notstate\r\n"
-	// pr checks
-	batScript += "echo %ARGS% | findstr /c:\"pr checks\" >nul 2>&1 || goto :notchecks\r\n"
-	batScript += fmt.Sprintf("type \"%s\"\r\nexit /b 0\r\n", checksFile)
-	batScript += ":notchecks\r\n"
-	// pr view --json comments
-	batScript += "echo %ARGS% | findstr /c:\"pr view\" >nul 2>&1 || goto :notcomments\r\n"
-	batScript += "echo %ARGS% | findstr /c:\"--json comments\" >nul 2>&1 || goto :notcomments\r\n"
-	batScript += fmt.Sprintf("type \"%s\"\r\nexit /b 0\r\n", commentsFile)
-	batScript += ":notcomments\r\n"
-	// pr comment
-	batScript += "echo %ARGS% | findstr /c:\"pr comment\" >nul 2>&1 || goto :notcomment\r\n"
-	batScript += "exit /b 0\r\n"
-	batScript += ":notcomment\r\n"
-	// run view
-	batScript += "echo %ARGS% | findstr /c:\"run view\" >nul 2>&1 || goto :notrunview\r\n"
-	batScript += "echo error log output\r\nexit /b 0\r\n"
-	batScript += ":notrunview\r\n"
-	batScript += "exit /b 1\r\n"
-
-	writeFakeScript(t, binDir, "gh", shScript, batScript)
+	linkTestBinary(t, binDir, "gh")
+	t.Setenv("FAKE_CLI_MODE", "babysit-gh")
+	t.Setenv("FAKE_CLI_STATE", state)
+	t.Setenv("FAKE_CLI_CHECKS", checksJSON)
+	t.Setenv("FAKE_CLI_COMMENTS", commentsJSON)
 	return binDir
 }
 
 func fakeBabysitGHNoChecks(t *testing.T) string {
 	t.Helper()
 	binDir := t.TempDir()
-	shScript := `#!/bin/sh
-ARGS="$*"
-if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
-  exit 0
-fi
-if echo "$ARGS" | grep -q "pr checks"; then
-  echo "no checks reported on the 'feature/e2e' branch" >&2
-  exit 1
-fi
-if echo "$ARGS" | grep -q "pr view.*--json state"; then
-  echo "OPEN"
-  exit 0
-fi
-if echo "$ARGS" | grep -q "pr view.*--json comments"; then
-  echo '[]'
-  exit 0
-fi
-echo "unexpected gh args: $ARGS" >&2
-exit 1
-`
-	batScript := "@echo off\r\n"
-	batScript += "setlocal\r\n"
-	batScript += "set \"ARGS=%*\"\r\n"
-	batScript += "if \"%1\"==\"auth\" if \"%2\"==\"status\" exit /b 0\r\n"
-	batScript += "echo %ARGS% | findstr /c:\"pr checks\" >nul 2>&1 || goto :notchecks\r\n"
-	batScript += "echo no checks reported on the 'feature/e2e' branch >&2\r\nexit /b 1\r\n"
-	batScript += ":notchecks\r\n"
-	batScript += "echo %ARGS% | findstr /c:\"pr view\" >nul 2>&1 || goto :notstate\r\n"
-	batScript += "echo %ARGS% | findstr /c:\"--json state\" >nul 2>&1 || goto :notstate\r\n"
-	batScript += "echo OPEN\r\nexit /b 0\r\n"
-	batScript += ":notstate\r\n"
-	batScript += "echo %ARGS% | findstr /c:\"pr view\" >nul 2>&1 || goto :notcomments\r\n"
-	batScript += "echo %ARGS% | findstr /c:\"--json comments\" >nul 2>&1 || goto :notcomments\r\n"
-	batScript += "echo []\r\nexit /b 0\r\n"
-	batScript += ":notcomments\r\n"
-	batScript += "echo unexpected gh args: %ARGS% >&2\r\nexit /b 1\r\n"
-
-	writeFakeScript(t, binDir, "gh", shScript, batScript)
+	linkTestBinary(t, binDir, "gh")
+	t.Setenv("FAKE_CLI_MODE", "babysit-gh-nochecks")
 	return binDir
 }
 
@@ -3324,7 +3268,7 @@ func TestBabysitStep_CIFailureAutoFix(t *testing.T) {
 
 	// Use a context with short timeout: after auto-fix completes, the poll
 	// sleep (30s) will be interrupted by context deadline, exiting the loop.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	sctx.Ctx = ctx
 
@@ -3518,7 +3462,7 @@ func TestBabysitStep_AddressCommentsInFixMode_OnlySelectedComments(t *testing.T)
 	sctx.PreviousFindings = `{"findings":[{"id":"IC_200","severity":"info","description":"@alice: Rename this function"}],"summary":"1 PR comment(s) to review"}`
 	sctx.Config.BabysitTimeout = 30 * time.Second
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	sctx.Ctx = ctx
 
@@ -3584,7 +3528,7 @@ func TestBabysitStep_AddressCommentsInFixMode(t *testing.T) {
 
 	// Use a context with short timeout: after addressing comments and entering
 	// the poll loop, the sleep will be interrupted by context deadline.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	sctx.Ctx = ctx
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -1248,7 +1249,12 @@ func TestPushStep_RunsFormatCommandBeforeCommit(t *testing.T) {
 
 	// Use a format command that writes a marker file to prove it ran
 	markerPath := filepath.Join(dir, ".format-ran")
-	formatCmd := fmt.Sprintf("touch %s", markerPath)
+	var formatCmd string
+	if runtime.GOOS == "windows" {
+		formatCmd = fmt.Sprintf("type nul > \"%s\"", markerPath)
+	} else {
+		formatCmd = fmt.Sprintf("touch %s", markerPath)
+	}
 
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{Format: formatCmd})
@@ -1479,6 +1485,30 @@ func TestPRStep_GhNotAvailable(t *testing.T) {
 	}
 }
 
+// prependPATH prepends binDir to PATH using the platform-specific separator.
+func prependPATH(t *testing.T, binDir string) {
+	t.Helper()
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// writeFakeScript writes a shell script (Unix) or batch file (Windows) to binDir.
+// name is the binary name without extension (e.g. "gh"). On Windows, a .bat
+// extension is appended automatically.
+func writeFakeScript(t *testing.T, binDir, name, shScript, batScript string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		p := filepath.Join(binDir, name+".bat")
+		if err := os.WriteFile(p, []byte(batScript), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		p := filepath.Join(binDir, name)
+		if err := os.WriteFile(p, []byte(shScript), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
 // fakeGH creates a mock gh script in a temp dir and returns the dir (for PATH prepending).
 // The script records all invocations to a log file and responds based on subcommand.
 func fakeGH(t *testing.T, prViewURL string) (binDir string, logFile string) {
@@ -1486,7 +1516,7 @@ func fakeGH(t *testing.T, prViewURL string) (binDir string, logFile string) {
 	binDir = t.TempDir()
 	logFile = filepath.Join(t.TempDir(), "gh.log")
 
-	script := fmt.Sprintf(`#!/bin/sh
+	shScript := fmt.Sprintf(`#!/bin/sh
 echo "$@" >> %s
 if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
   exit 0
@@ -1508,10 +1538,18 @@ fi
 exit 1
 `, logFile, prViewURL, prViewURL)
 
-	ghPath := filepath.Join(binDir, "gh")
-	if err := os.WriteFile(ghPath, []byte(script), 0o755); err != nil {
-		t.Fatal(err)
+	batScript := fmt.Sprintf("@echo off\r\necho %%* >> \"%s\"\r\n", logFile)
+	batScript += "if \"%1\"==\"auth\" if \"%2\"==\"status\" exit /b 0\r\n"
+	if prViewURL != "" {
+		batScript += fmt.Sprintf("if \"%%1\"==\"pr\" if \"%%2\"==\"view\" (\r\n  echo %s\r\n  exit /b 0\r\n)\r\n", prViewURL)
+	} else {
+		batScript += "if \"%1\"==\"pr\" if \"%2\"==\"view\" exit /b 1\r\n"
 	}
+	batScript += "if \"%1\"==\"pr\" if \"%2\"==\"edit\" exit /b 0\r\n"
+	batScript += "if \"%1\"==\"pr\" if \"%2\"==\"create\" (\r\n  echo https://github.com/test/repo/pull/99\r\n  exit /b 0\r\n)\r\n"
+	batScript += "exit /b 1\r\n"
+
+	writeFakeScript(t, binDir, "gh", shScript, batScript)
 	return binDir, logFile
 }
 
@@ -1519,7 +1557,7 @@ func TestPRStep_UpdatesExistingPR(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	binDir, logFile := fakeGH(t, "https://github.com/test/repo/pull/42")
-	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	prependPATH(t, binDir)
 
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
@@ -1574,7 +1612,7 @@ func TestPRStep_ZeroBaseSHA(t *testing.T) {
 	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
 
 	binDir, logFile := fakeGH(t, "")
-	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	prependPATH(t, binDir)
 
 	ag := &mockAgent{name: "test"}
 	zeroSHA := "0000000000000000000000000000000000000000"
@@ -1601,7 +1639,7 @@ func TestPRStep_CreatesNewPR(t *testing.T) {
 
 	// No existing PR — pr view returns exit 1
 	binDir, logFile := fakeGH(t, "")
-	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	prependPATH(t, binDir)
 
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
@@ -1639,7 +1677,7 @@ func TestPRStep_UsesAgentGeneratedTitleAndBody(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	binDir, logFile := fakeGH(t, "")
-	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	prependPATH(t, binDir)
 
 	ag := &mockAgent{
 		name: "test",
@@ -1679,7 +1717,7 @@ func fakeGlab(t *testing.T, mrViewJSON string) (binDir string, logFile string) {
 	binDir = t.TempDir()
 	logFile = filepath.Join(t.TempDir(), "glab.log")
 
-	script := fmt.Sprintf(`#!/bin/sh
+	shScript := fmt.Sprintf(`#!/bin/sh
 echo "$@" >> %s
 if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
   exit 0
@@ -1703,10 +1741,23 @@ fi
 exit 1
 `, logFile, mrViewJSON, mrViewJSON)
 
-	glabPath := filepath.Join(binDir, "glab")
-	if err := os.WriteFile(glabPath, []byte(script), 0o755); err != nil {
-		t.Fatal(err)
+	batScript := fmt.Sprintf("@echo off\r\necho %%* >> \"%s\"\r\n", logFile)
+	batScript += "if \"%1\"==\"auth\" if \"%2\"==\"status\" exit /b 0\r\n"
+	if mrViewJSON != "" {
+		// Write the JSON to a temp file and type it, since batch heredocs don't exist.
+		jsonFile := filepath.Join(binDir, "mrview.json")
+		if err := os.WriteFile(jsonFile, []byte(mrViewJSON), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		batScript += fmt.Sprintf("if \"%%1\"==\"mr\" if \"%%2\"==\"view\" (\r\n  type \"%s\"\r\n  exit /b 0\r\n)\r\n", jsonFile)
+	} else {
+		batScript += "if \"%1\"==\"mr\" if \"%2\"==\"view\" exit /b 1\r\n"
 	}
+	batScript += "if \"%1\"==\"mr\" if \"%2\"==\"update\" exit /b 0\r\n"
+	batScript += "if \"%1\"==\"mr\" if \"%2\"==\"create\" (\r\n  echo https://gitlab.com/test/repo/-/merge_requests/99\r\n  exit /b 0\r\n)\r\n"
+	batScript += "exit /b 1\r\n"
+
+	writeFakeScript(t, binDir, "glab", shScript, batScript)
 	return binDir, logFile
 }
 
@@ -1714,7 +1765,7 @@ func TestPRStep_GitLabCreatesNewMR(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	binDir, logFile := fakeGlab(t, "")
-	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	prependPATH(t, binDir)
 
 	ag := &mockAgent{
 		name: "test",
@@ -1788,7 +1839,7 @@ func TestPRStep_ExistingBranchUsesMergeBaseCommitLog(t *testing.T) {
 	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
 
 	binDir, logFile := fakeGH(t, "")
-	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	prependPATH(t, binDir)
 
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContextWithDBRecords(t, ag, dir, oldRemoteSHA, headSHA, config.Commands{})
@@ -2227,7 +2278,7 @@ func TestBabysitStep_TimeoutDoesNotSleepPastDeadline(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	binDir := fakeBabysitGH(t, "OPEN", "[]", "[]")
-	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	prependPATH(t, binDir)
 
 	prURL := "https://github.com/test/repo/pull/42"
 	ag := &mockAgent{name: "test"}
@@ -2994,8 +3045,7 @@ func fakeBabysitGH(t *testing.T, state, checksJSON, commentsJSON string) string 
 	t.Helper()
 	binDir := t.TempDir()
 
-	// Escape double quotes in JSON for embedding in shell script.
-	script := fmt.Sprintf(`#!/bin/sh
+	shScript := fmt.Sprintf(`#!/bin/sh
 ARGS="$*"
 if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
   exit 0
@@ -3031,17 +3081,53 @@ fi
 exit 1
 `, state, checksJSON, commentsJSON)
 
-	ghPath := filepath.Join(binDir, "gh")
-	if err := os.WriteFile(ghPath, []byte(script), 0o755); err != nil {
+	// Write JSON data to files for batch to use via type command.
+	checksFile := filepath.Join(binDir, "checks.json")
+	if err := os.WriteFile(checksFile, []byte(checksJSON), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	commentsFile := filepath.Join(binDir, "comments.json")
+	if err := os.WriteFile(commentsFile, []byte(commentsJSON), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// On Windows, use findstr to match arg patterns.
+	batScript := "@echo off\r\n"
+	batScript += "setlocal\r\n"
+	batScript += "set \"ARGS=%*\"\r\n"
+	batScript += "if \"%1\"==\"auth\" if \"%2\"==\"status\" exit /b 0\r\n"
+	// pr view --json state
+	batScript += "echo %ARGS% | findstr /c:\"pr view\" >nul 2>&1 || goto :notstate\r\n"
+	batScript += "echo %ARGS% | findstr /c:\"--json state\" >nul 2>&1 || goto :notstate\r\n"
+	batScript += fmt.Sprintf("echo %s\r\nexit /b 0\r\n", state)
+	batScript += ":notstate\r\n"
+	// pr checks
+	batScript += "echo %ARGS% | findstr /c:\"pr checks\" >nul 2>&1 || goto :notchecks\r\n"
+	batScript += fmt.Sprintf("type \"%s\"\r\nexit /b 0\r\n", checksFile)
+	batScript += ":notchecks\r\n"
+	// pr view --json comments
+	batScript += "echo %ARGS% | findstr /c:\"pr view\" >nul 2>&1 || goto :notcomments\r\n"
+	batScript += "echo %ARGS% | findstr /c:\"--json comments\" >nul 2>&1 || goto :notcomments\r\n"
+	batScript += fmt.Sprintf("type \"%s\"\r\nexit /b 0\r\n", commentsFile)
+	batScript += ":notcomments\r\n"
+	// pr comment
+	batScript += "echo %ARGS% | findstr /c:\"pr comment\" >nul 2>&1 || goto :notcomment\r\n"
+	batScript += "exit /b 0\r\n"
+	batScript += ":notcomment\r\n"
+	// run view
+	batScript += "echo %ARGS% | findstr /c:\"run view\" >nul 2>&1 || goto :notrunview\r\n"
+	batScript += "echo error log output\r\nexit /b 0\r\n"
+	batScript += ":notrunview\r\n"
+	batScript += "exit /b 1\r\n"
+
+	writeFakeScript(t, binDir, "gh", shScript, batScript)
 	return binDir
 }
 
 func fakeBabysitGHNoChecks(t *testing.T) string {
 	t.Helper()
 	binDir := t.TempDir()
-	script := `#!/bin/sh
+	shScript := `#!/bin/sh
 ARGS="$*"
 if [ "$1" = "auth" ] && [ "$2" = "status" ]; then
   exit 0
@@ -3061,10 +3147,24 @@ fi
 echo "unexpected gh args: $ARGS" >&2
 exit 1
 `
-	ghPath := filepath.Join(binDir, "gh")
-	if err := os.WriteFile(ghPath, []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	batScript := "@echo off\r\n"
+	batScript += "setlocal\r\n"
+	batScript += "set \"ARGS=%*\"\r\n"
+	batScript += "if \"%1\"==\"auth\" if \"%2\"==\"status\" exit /b 0\r\n"
+	batScript += "echo %ARGS% | findstr /c:\"pr checks\" >nul 2>&1 || goto :notchecks\r\n"
+	batScript += "echo no checks reported on the 'feature/e2e' branch >&2\r\nexit /b 1\r\n"
+	batScript += ":notchecks\r\n"
+	batScript += "echo %ARGS% | findstr /c:\"pr view\" >nul 2>&1 || goto :notstate\r\n"
+	batScript += "echo %ARGS% | findstr /c:\"--json state\" >nul 2>&1 || goto :notstate\r\n"
+	batScript += "echo OPEN\r\nexit /b 0\r\n"
+	batScript += ":notstate\r\n"
+	batScript += "echo %ARGS% | findstr /c:\"pr view\" >nul 2>&1 || goto :notcomments\r\n"
+	batScript += "echo %ARGS% | findstr /c:\"--json comments\" >nul 2>&1 || goto :notcomments\r\n"
+	batScript += "echo []\r\nexit /b 0\r\n"
+	batScript += ":notcomments\r\n"
+	batScript += "echo unexpected gh args: %ARGS% >&2\r\nexit /b 1\r\n"
+
+	writeFakeScript(t, binDir, "gh", shScript, batScript)
 	return binDir
 }
 
@@ -3072,7 +3172,7 @@ func TestBabysitStep_PRMergedExitsEarly(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	binDir := fakeBabysitGH(t, "MERGED", "[]", "[]")
-	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	prependPATH(t, binDir)
 
 	prURL := "https://github.com/test/repo/pull/42"
 	ag := &mockAgent{name: "test"}
@@ -3108,7 +3208,7 @@ func TestBabysitStep_PRClosedExitsEarly(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	binDir := fakeBabysitGH(t, "CLOSED", "[]", "[]")
-	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	prependPATH(t, binDir)
 
 	prURL := "https://github.com/test/repo/pull/42"
 	ag := &mockAgent{name: "test"}
@@ -3142,7 +3242,7 @@ func TestBabysitStep_PRClosedExitsEarly(t *testing.T) {
 
 func TestBabysitStep_GetCIChecksNoChecksReported(t *testing.T) {
 	binDir := fakeBabysitGHNoChecks(t)
-	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	prependPATH(t, binDir)
 
 	step := &BabysitStep{}
 	checks, err := step.getCIChecks(context.Background(), t.TempDir(), "42")
@@ -3180,7 +3280,7 @@ func TestBabysitStep_CIFailureAutoFix(t *testing.T) {
 
 	checksJSON := `[{"name":"build","status":"COMPLETED","conclusion":"success"},{"name":"test","status":"COMPLETED","conclusion":"failure"}]`
 	binDir := fakeBabysitGH(t, "OPEN", checksJSON, "[]")
-	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	prependPATH(t, binDir)
 
 	agentCalled := false
 	ag := &mockAgent{
@@ -3253,7 +3353,7 @@ func TestBabysitStep_NewCommentsPausesForApproval(t *testing.T) {
 
 	commentsJSON := `[{"id":"IC_100","author":{"login":"reviewer"},"body":"Please fix the naming","createdAt":"2026-01-01T00:00:00Z","url":"https://github.com/test/repo/pull/42#comment-100"}]`
 	binDir := fakeBabysitGH(t, "OPEN", "[]", commentsJSON)
-	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	prependPATH(t, binDir)
 
 	prURL := "https://github.com/test/repo/pull/42"
 	ag := &mockAgent{name: "test"}
@@ -3311,7 +3411,7 @@ func TestBabysitStep_AllChecksPassingExitsCleanly(t *testing.T) {
 
 	checksJSON := `[{"name":"build","state":"SUCCESS","bucket":"pass"},{"name":"test","state":"SUCCESS","bucket":"pass"}]`
 	binDir := fakeBabysitGH(t, "OPEN", checksJSON, "[]")
-	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	prependPATH(t, binDir)
 
 	prURL := "https://github.com/test/repo/pull/42"
 	ag := &mockAgent{name: "test"}
@@ -3371,7 +3471,7 @@ func TestBabysitStep_AddressCommentsInFixMode_OnlySelectedComments(t *testing.T)
 		{"id":"IC_201","author":{"login":"bob"},"body":"Add more tests","createdAt":"2026-01-01T00:00:01Z","url":"https://github.com/test/repo/pull/42#comment-201"}
 	]`
 	binDir := fakeBabysitGH(t, "OPEN", "[]", commentsJSON)
-	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	prependPATH(t, binDir)
 
 	ag := &mockAgent{
 		name: "test",
@@ -3439,7 +3539,7 @@ func TestBabysitStep_AddressCommentsInFixMode(t *testing.T) {
 
 	commentsJSON := `[{"id":"IC_200","author":{"login":"alice"},"body":"Rename this function","createdAt":"2026-01-01T00:00:00Z","url":"https://github.com/test/repo/pull/42#comment-200"}]`
 	binDir := fakeBabysitGH(t, "OPEN", "[]", commentsJSON)
-	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	prependPATH(t, binDir)
 
 	agentCalled := false
 	ag := &mockAgent{


### PR DESCRIPTION
## Summary
- Add a Windows IPC transport (`transport_windows.go`) that replaces Unix domain sockets with loopback TCP + token-based authentication, including file ACL lockdown, constant-time token comparison, stale-PID detection, and atomic endpoint file writes to prevent TOCTOU races
- Replace the `nc -U` (netcat) based post-receive hook with a portable `daemon notify-push` CLI subcommand, so hooks work on Windows without Unix socket tooling
- Factor platform-specific signal handling into build-tagged files (`signals_unix.go`, `signals_windows.go`)
- Harden the IPC server with `CloseListener()`, `net.ErrClosed` detection, accept-error backoff, and daemon auto-shutdown when the listener closes
- Make CI (`ci.yml`) cross-compile and test on `windows-latest`, and fix portable path assertions in tests

## Test plan
- [ ] `go test -race ./...` passes on Linux, macOS, and Windows
- [ ] CI matrix now includes `windows-latest` - verify the new workflow run is green
- [ ] `daemon notify-push` subcommand connects to the daemon and delivers push events
- [ ] Post-receive hook embeds the correct binary path and falls back to `$PATH` when the baked-in path is missing
- [ ] Windows IPC rejects connections with invalid tokens and cleans up on accept-error storms (64 consecutive failures trigger self-close)
- [ ] Server exits cleanly when its listener is closed externally (`TestServerExitsWhenListenerClosed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)