### PR TITLE
Fix review UI: add risk assessment, simplify icons, dedupe box rendering

### DIFF
--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -207,6 +207,7 @@ var reviewFindingsSchema = json.RawMessage(`{
 	},
 	"required": ["findings", "risk_level", "risk_rationale"]
 }`)
+
 // isTestFile returns true if the file path matches common test file naming patterns.
 func isTestFile(path string) bool {
 	base := filepath.Base(path)

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -183,6 +183,30 @@ func deterministicFixCommitMessage(stepName types.StepName, summary string) stri
 	return fmt.Sprintf("no-mistakes(%s): %s", stepName, summary)
 }
 
+// reviewFindingsSchema is the JSON schema for structured review output with risk assessment.
+// Field order matters for chain-of-thought: findings first, then risk level, then rationale.
+var reviewFindingsSchema = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"findings": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"id": {"type": "string"},
+					"severity": {"type": "string", "enum": ["error", "warning", "info"]},
+					"file": {"type": "string"},
+					"line": {"type": "integer"},
+					"description": {"type": "string"}
+				},
+				"required": ["severity", "description"]
+			}
+		},
+		"risk_level": {"type": "string", "enum": ["low", "medium", "high"]},
+		"risk_rationale": {"type": "string"}
+	},
+	"required": ["findings", "risk_level", "risk_rationale"]
+}`)
 // isTestFile returns true if the file path matches common test file naming patterns.
 func isTestFile(path string) bool {
 	base := filepath.Base(path)

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -124,7 +124,7 @@ Previous review findings to address:
 	// Ask agent to review
 	sctx.Log("reviewing changes...")
 	prompt := fmt.Sprintf(
-		`Review the code changes and return structured findings.
+		`Review the code changes and return structured findings with a risk assessment.
 
 Context:
 - branch: %s
@@ -146,7 +146,13 @@ Rules:
 - Be concise and actionable. No generic advice like "add more tests" or "improve docs".
 - Only comment on things that genuinely matter.
 - Do NOT report styling, formatting, linting, compilation, or type-checking issues.
-- If the change is clean, return an empty findings array.`,
+- If the change is clean, return an empty findings array.
+
+Risk assessment (after listing all findings):
+- Set risk_level to "low" if the change is well-bounded, mostly cosmetic, or straightforward with little ambiguity.
+- Set risk_level to "medium" if the change has room to improve but is safe to merge first with concerns addressed as follow-ups.
+- Set risk_level to "high" if the change should not be merged without explicit human approval - it is fundamental, risky, ambiguous, or has strong negative signals.
+- Provide a one-sentence risk_rationale explaining why you chose that risk level.`,
 		branch,
 		baseSHA,
 		sctx.Run.HeadSHA,
@@ -158,7 +164,7 @@ Rules:
 	result, err := sctx.Agent.Run(ctx, agent.RunOpts{
 		Prompt:     prompt,
 		CWD:        sctx.WorkDir,
-		JSONSchema: findingsSchema,
+		JSONSchema: reviewFindingsSchema,
 		OnChunk:    sctx.Log,
 	})
 	if err != nil {

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -2904,6 +2904,30 @@ func TestFilterDiff_MultiplePatterns(t *testing.T) {
 	}
 }
 
+func TestReviewFindingsSchema_ValidJSON(t *testing.T) {
+	if !json.Valid(reviewFindingsSchema) {
+		t.Errorf("reviewFindingsSchema is not valid JSON: %s", string(reviewFindingsSchema))
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(reviewFindingsSchema, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	required, ok := parsed["required"].([]interface{})
+	if !ok {
+		t.Fatal("expected 'required' array in schema")
+	}
+	want := map[string]bool{"findings": false, "risk_level": false, "risk_rationale": false}
+	for _, r := range required {
+		s, _ := r.(string)
+		want[s] = true
+	}
+	for field, found := range want {
+		if !found {
+			t.Errorf("missing required field %q in schema", field)
+		}
+	}
+}
+
 func TestReviewStep_IgnorePatterns(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 

--- a/internal/tui/DESIGN.md
+++ b/internal/tui/DESIGN.md
@@ -141,6 +141,6 @@ Or when the pipeline is still running: `q detach`
 
 | Severity | Icon | Color |
 |----------|------|-------|
-| Error | `●` | red |
-| Warning | `▲` | yellow |
-| Info | `○` | blue |
+| Error | `E` | red |
+| Warning | `W` | yellow |
+| Info | `I` | blue |

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -286,7 +286,7 @@ func (m Model) View() string {
 				if contentBudget >= 0 {
 					boxHeight = contentBudget
 				}
-				appendExtraSection(renderFindingsBoxForHeight(raw, rightWidth, cursor, m.findingSelections[step.StepName], boxHeight, label, len(m.findingItems(step.StepName))))
+				appendExtraSection(renderFindingsBoxForHeight(raw, rightWidth, cursor, m.findingSelections[step.StepName], boxHeight))
 			}
 		}
 	}
@@ -339,7 +339,7 @@ func (m Model) View() string {
 	return joinSections(sections, sectionGap)
 }
 
-func renderFindingsBoxForHeight(raw string, width int, cursor int, selected map[string]bool, boxHeight int, label string, totalItems int) string {
+func renderFindingsBoxForHeight(raw string, width int, cursor int, selected map[string]bool, boxHeight int) string {
 	if boxHeight > 0 && boxHeight < 3 {
 		return ""
 	}
@@ -351,10 +351,25 @@ func renderFindingsBoxForHeight(raw string, width int, cursor int, selected map[
 	if boxHeight > 0 {
 		contentHeight = boxHeight - 2
 	}
-	title := "Findings - " + label
-	if totalItems > 0 {
-		title += fmt.Sprintf(" (%d/%d)", cursor+1, totalItems)
+
+	// Build styled title: "Findings - E 2 W 2 I 2" with colorized severity counts.
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ansiCyan))
+	styledTitle := titleStyle.Render("Findings")
+	if f, err := parseFindings(raw); err == nil && f != nil {
+		counts := map[string]int{}
+		for _, item := range f.Items {
+			counts[item.Severity]++
+		}
+		if len(counts) > 0 {
+			styledTitle += titleStyle.Render(" -")
+			for _, sev := range []string{"error", "warning", "info"} {
+				if c, ok := counts[sev]; ok {
+					styledTitle += " " + severityStyle(sev).Render(fmt.Sprintf("%s %d", severityIcon(sev), c))
+				}
+			}
+		}
 	}
+
 	contentWidth := boxWidth - 4
 	if contentWidth < 1 {
 		contentWidth = 1
@@ -369,7 +384,7 @@ func renderFindingsBoxForHeight(raw string, width int, cursor int, selected map[
 	if rendered == "" {
 		return ""
 	}
-	return renderBoxWithFooter(title, rendered, boxWidth, scrollFooter)
+	return renderBoxWithStyledTitle(styledTitle, rendered, boxWidth, scrollFooter)
 }
 
 func renderLogBox(logs []string, width int, logLines int, remainingBudget int) string {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -352,20 +352,23 @@ func renderFindingsBoxForHeight(raw string, width int, cursor int, selected map[
 		contentHeight = boxHeight - 2
 	}
 
+	f, err := parseFindings(raw)
+	if err != nil || f == nil {
+		return ""
+	}
+
 	// Build styled title: "Findings - E 2 W 2 I 2" with colorized severity counts.
 	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ansiCyan))
 	styledTitle := titleStyle.Render("Findings")
-	if f, err := parseFindings(raw); err == nil && f != nil {
-		counts := map[string]int{}
-		for _, item := range f.Items {
-			counts[item.Severity]++
-		}
-		if len(counts) > 0 {
-			styledTitle += titleStyle.Render(" -")
-			for _, sev := range []string{"error", "warning", "info"} {
-				if c, ok := counts[sev]; ok {
-					styledTitle += " " + severityStyle(sev).Render(fmt.Sprintf("%s %d", severityIcon(sev), c))
-				}
+	counts := map[string]int{}
+	for _, item := range f.Items {
+		counts[item.Severity]++
+	}
+	if len(counts) > 0 {
+		styledTitle += titleStyle.Render(" -")
+		for _, sev := range []string{"error", "warning", "info"} {
+			if c, ok := counts[sev]; ok {
+				styledTitle += " " + severityStyle(sev).Render(fmt.Sprintf("%s %d", severityIcon(sev), c))
 			}
 		}
 	}
@@ -377,9 +380,9 @@ func renderFindingsBoxForHeight(raw string, width int, cursor int, selected map[
 	var rendered string
 	var scrollFooter string
 	if contentHeight > 0 {
-		rendered, scrollFooter = renderFindingsWithSelectionHeight(raw, contentWidth, cursor, selected, contentHeight)
+		rendered, scrollFooter = renderParsedFindingsHeight(f, contentWidth, cursor, selected, contentHeight)
 	} else {
-		rendered, scrollFooter = renderFindingsWithSelection(raw, contentWidth, cursor, selected, 0)
+		rendered, scrollFooter = renderParsedFindingsViewport(f, contentWidth, cursor, selected, 0)
 	}
 	if rendered == "" {
 		return ""

--- a/internal/tui/box.go
+++ b/internal/tui/box.go
@@ -96,6 +96,48 @@ func renderBoxWithFooter(title, content string, width int, footer string) string
 	return topBorder + "\n" + strings.Join(lines, "\n") + "\n" + renderBottomBorder(width, footer)
 }
 
+// renderBoxWithStyledTitle renders a box with a pre-styled title and optional footer.
+// Unlike renderBoxWithFooter, the title is used as-is (caller handles styling).
+func renderBoxWithStyledTitle(styledTitle string, content string, width int, footer string) string {
+	if width < 6 {
+		width = 6
+	}
+
+	borderColor := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
+
+	// Top border.
+	titleWidth := lipgloss.Width(styledTitle)
+	fillWidth := width - 5 - titleWidth
+	if fillWidth < 1 {
+		fillWidth = 1
+	}
+	topBorder := borderColor.Render("╭─ ") + styledTitle + " " + borderColor.Render(strings.Repeat("─", fillWidth)+"╮")
+
+	// Content width.
+	contentWidth := width - 4
+	if contentWidth < 1 {
+		contentWidth = 1
+	}
+
+	// Content lines.
+	var lines []string
+	contentLines := strings.Split(content, "\n")
+	if len(contentLines) > 0 && contentLines[len(contentLines)-1] == "" {
+		contentLines = contentLines[:len(contentLines)-1]
+	}
+	for _, cl := range contentLines {
+		visWidth := lipgloss.Width(cl)
+		pad := contentWidth - visWidth
+		if pad < 0 {
+			pad = 0
+		}
+		line := borderColor.Render("│") + " " + cl + strings.Repeat(" ", pad) + " " + borderColor.Render("│")
+		lines = append(lines, line)
+	}
+
+	return topBorder + "\n" + strings.Join(lines, "\n") + "\n" + renderBottomBorder(width, footer)
+}
+
 // renderBottomBorder renders a bottom border, optionally embedding a footer hint.
 func renderBottomBorder(width int, footer string) string {
 	borderColor := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))

--- a/internal/tui/box.go
+++ b/internal/tui/box.go
@@ -9,91 +9,15 @@ import (
 // renderBox renders content inside a rounded-border box with a styled title
 // embedded in the top border, per DESIGN.md Boxed Sections spec.
 func renderBox(title, content string, width int) string {
-	if width < 6 {
-		width = 6
-	}
-
-	borderColor := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
 	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ansiCyan))
-
-	// Top border: ╭─ Title ──────────────╮
-	titleRendered := titleStyle.Render(title)
-	titleWidth := lipgloss.Width(titleRendered)
-	// Account for: ╭─ [space] title [space] ─...╮ = 5 + titleWidth + fillWidth
-	fillWidth := width - 5 - titleWidth
-	if fillWidth < 1 {
-		fillWidth = 1
-	}
-	topBorder := borderColor.Render("╭─ ") + titleRendered + " " + borderColor.Render(strings.Repeat("─", fillWidth)+"╮")
-
-	// Content width: total minus 2 borders minus 2 padding chars.
-	contentWidth := width - 4
-	if contentWidth < 1 {
-		contentWidth = 1
-	}
-
-	// Content lines: │ content │
-	var lines []string
-	contentLines := strings.Split(content, "\n")
-	// Remove trailing empty line if present.
-	if len(contentLines) > 0 && contentLines[len(contentLines)-1] == "" {
-		contentLines = contentLines[:len(contentLines)-1]
-	}
-	for _, cl := range contentLines {
-		visWidth := lipgloss.Width(cl)
-		pad := contentWidth - visWidth
-		if pad < 0 {
-			pad = 0
-		}
-		line := borderColor.Render("│") + " " + cl + strings.Repeat(" ", pad) + " " + borderColor.Render("│")
-		lines = append(lines, line)
-	}
-
-	return topBorder + "\n" + strings.Join(lines, "\n") + "\n" + renderBottomBorder(width, "")
+	return renderBoxWithStyledTitle(titleStyle.Render(title), content, width, "")
 }
 
 // renderBoxWithFooter renders a box with an optional hint embedded in the bottom border.
 // Per DESIGN.md Diff View: ╰──── ↓ 23 more lines (j/k) ─────────────╯
 func renderBoxWithFooter(title, content string, width int, footer string) string {
-	if width < 6 {
-		width = 6
-	}
-
-	borderColor := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
 	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ansiCyan))
-
-	// Top border.
-	titleRendered := titleStyle.Render(title)
-	titleWidth := lipgloss.Width(titleRendered)
-	fillWidth := width - 5 - titleWidth
-	if fillWidth < 1 {
-		fillWidth = 1
-	}
-	topBorder := borderColor.Render("╭─ ") + titleRendered + " " + borderColor.Render(strings.Repeat("─", fillWidth)+"╮")
-
-	// Content width.
-	contentWidth := width - 4
-	if contentWidth < 1 {
-		contentWidth = 1
-	}
-
-	// Content lines.
-	var lines []string
-	contentLines := strings.Split(content, "\n")
-	if len(contentLines) > 0 && contentLines[len(contentLines)-1] == "" {
-		contentLines = contentLines[:len(contentLines)-1]
-	}
-	for _, cl := range contentLines {
-		visWidth := lipgloss.Width(cl)
-		pad := contentWidth - visWidth
-		if pad < 0 {
-			pad = 0
-		}
-		line := borderColor.Render("│") + " " + cl + strings.Repeat(" ", pad) + " " + borderColor.Render("│")
-		lines = append(lines, line)
-	}
-
-	return topBorder + "\n" + strings.Join(lines, "\n") + "\n" + renderBottomBorder(width, footer)
+	return renderBoxWithStyledTitle(titleStyle.Render(title), content, width, footer)
 }
 
 // renderBoxWithStyledTitle renders a box with a pre-styled title and optional footer.

--- a/internal/tui/review.go
+++ b/internal/tui/review.go
@@ -30,13 +30,27 @@ func parseFindings(raw string) (*findings, error) {
 func severityIcon(severity string) string {
 	switch severity {
 	case "error":
-		return "●"
+		return "E"
 	case "warning":
-		return "▲"
+		return "W"
 	case "info":
-		return "○"
+		return "I"
 	default:
 		return "·"
+	}
+}
+
+// riskLevelStyle returns the lipgloss style for a risk level.
+func riskLevelStyle(level string) lipgloss.Style {
+	switch strings.ToLower(level) {
+	case "low":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color(ansiGreen))
+	case "medium":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color(ansiYellow))
+	case "high":
+		return lipgloss.NewStyle().Foreground(lipgloss.Color(ansiRed))
+	default:
+		return lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
 	}
 }
 
@@ -213,7 +227,7 @@ func renderFindingsRange(f *findings, width int, cursor int, selected map[string
 	if f == nil {
 		return "", ""
 	}
-	if len(f.Items) == 0 && f.Summary == "" {
+	if len(f.Items) == 0 && f.Summary == "" && f.RiskLevel == "" {
 		return "", ""
 	}
 	if start < 0 {
@@ -228,28 +242,25 @@ func renderFindingsRange(f *findings, width int, cursor int, selected map[string
 
 	var b strings.Builder
 
-	// Summary line.
-	if f.Summary != "" {
+	// Risk assessment (review step) or summary fallback (lint/test steps).
+	if f.RiskLevel != "" {
+		boldStyle := lipgloss.NewStyle().Bold(true)
+		rStyle := riskLevelStyle(f.RiskLevel)
+		prefix := boldStyle.Render("Risk:") + " " + rStyle.Render(strings.ToUpper(f.RiskLevel))
+		if f.RiskRationale != "" {
+			dashSep := " - "
+			prefixWidth := lipgloss.Width(prefix) + len(dashSep)
+			rationale := wrapIndentedText(f.RiskRationale, width, prefixWidth)
+			rationale = strings.TrimLeft(rationale, " ")
+			b.WriteString(prefix + dashSep + rationale)
+		} else {
+			b.WriteString(prefix)
+		}
+		b.WriteString("\n")
+	} else if f.Summary != "" {
 		summaryStyle := lipgloss.NewStyle().Bold(true)
 		b.WriteString(summaryStyle.Render(wrapIndentedText(f.Summary, width, 0)))
 		b.WriteString("\n")
-	}
-
-	// Count by severity.
-	counts := map[string]int{}
-	for _, item := range f.Items {
-		counts[item.Severity]++
-	}
-	if len(counts) > 0 {
-		var parts []string
-		for _, sev := range []string{"error", "warning", "info"} {
-			if c, ok := counts[sev]; ok {
-				style := severityStyle(sev)
-				parts = append(parts, style.Render(fmt.Sprintf("%s %d %s", severityIcon(sev), c, sev)))
-			}
-		}
-		b.WriteString(strings.Join(parts, "  "))
-		b.WriteString("\n\n")
 	}
 
 	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
@@ -324,6 +335,34 @@ func renderFindingsRange(f *findings, width int, cursor int, selected map[string
 		scrollFooter = fmt.Sprintf("↑ %d above (j/k)", start)
 	}
 
+	// Selection count by severity when not all findings are selected.
+	if selected != nil && len(f.Items) > 0 {
+		selCounts := map[string]int{}
+		for _, item := range f.Items {
+			if selected[item.ID] {
+				selCounts[item.Severity]++
+			}
+		}
+		totalSelected := 0
+		for _, c := range selCounts {
+			totalSelected += c
+		}
+		if totalSelected < len(f.Items) {
+			var selParts []string
+			for _, sev := range []string{"error", "warning", "info"} {
+				if c, ok := selCounts[sev]; ok && c > 0 {
+					selParts = append(selParts, severityStyle(sev).Render(fmt.Sprintf("%s %d", severityIcon(sev), c)))
+				}
+			}
+			selText := strings.Join(selParts, " ") + " selected"
+			if scrollFooter != "" {
+				scrollFooter += "  ·  " + selText
+			} else {
+				scrollFooter = selText
+			}
+		}
+	}
+
 	return b.String(), scrollFooter
 }
 
@@ -346,7 +385,7 @@ func renderFindingsWithSelectionHeight(raw string, width int, cursor int, select
 	if err != nil || f == nil {
 		return "", ""
 	}
-	if len(f.Items) == 0 && f.Summary == "" {
+	if len(f.Items) == 0 && f.Summary == "" && f.RiskLevel == "" {
 		return "", ""
 	}
 	if maxLines <= 0 {
@@ -403,7 +442,7 @@ func renderFindingsWithSelection(raw string, width int, cursor int, selected map
 		return "", ""
 	}
 
-	if len(f.Items) == 0 && f.Summary == "" {
+	if len(f.Items) == 0 && f.Summary == "" && f.RiskLevel == "" {
 		return "", ""
 	}
 

--- a/internal/tui/review.go
+++ b/internal/tui/review.go
@@ -354,11 +354,13 @@ func renderFindingsRange(f *findings, width int, cursor int, selected map[string
 					selParts = append(selParts, severityStyle(sev).Render(fmt.Sprintf("%s %d", severityIcon(sev), c)))
 				}
 			}
-			selText := strings.Join(selParts, " ") + " selected"
-			if scrollFooter != "" {
-				scrollFooter += "  ·  " + selText
-			} else {
-				scrollFooter = selText
+			if len(selParts) > 0 {
+				selText := strings.Join(selParts, " ") + " selected"
+				if scrollFooter != "" {
+					scrollFooter += "  ·  " + selText
+				} else {
+					scrollFooter = selText
+				}
 			}
 		}
 	}
@@ -383,6 +385,13 @@ func trimRenderedLines(s string, maxLines int) string {
 func renderFindingsWithSelectionHeight(raw string, width int, cursor int, selected map[string]bool, maxLines int) (string, string) {
 	f, err := parseFindings(raw)
 	if err != nil || f == nil {
+		return "", ""
+	}
+	return renderParsedFindingsHeight(f, width, cursor, selected, maxLines)
+}
+
+func renderParsedFindingsHeight(f *findings, width int, cursor int, selected map[string]bool, maxLines int) (string, string) {
+	if f == nil {
 		return "", ""
 	}
 	if len(f.Items) == 0 && f.Summary == "" && f.RiskLevel == "" {
@@ -441,7 +450,13 @@ func renderFindingsWithSelection(raw string, width int, cursor int, selected map
 	if err != nil || f == nil {
 		return "", ""
 	}
+	return renderParsedFindingsViewport(f, width, cursor, selected, maxVisible)
+}
 
+func renderParsedFindingsViewport(f *findings, width int, cursor int, selected map[string]bool, maxVisible int) (string, string) {
+	if f == nil {
+		return "", ""
+	}
 	if len(f.Items) == 0 && f.Summary == "" && f.RiskLevel == "" {
 		return "", ""
 	}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -823,6 +823,24 @@ func TestRenderFindings_SelectionFooter_NilSelected(t *testing.T) {
 	}
 }
 
+func TestRenderFindings_SelectionFooter_AllDeselected(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.ANSI)
+	raw := `{"findings":[
+		{"id":"f1","severity":"error","description":"err"},
+		{"id":"f2","severity":"warning","description":"warn"}
+	],"summary":"2 issues"}`
+
+	// All deselected: selected map present but no IDs true.
+	selected := map[string]bool{"f1": false, "f2": false}
+	_, footer := renderFindingsWithSelection(raw, 80, 0, selected, 0)
+	plain := stripANSI(footer)
+
+	// Should not show "selected" at all when nothing is selected.
+	if strings.Contains(plain, "selected") {
+		t.Errorf("should not show selection footer when all deselected, got: %q", plain)
+	}
+}
+
 func TestRenderFindings_WithFindings(t *testing.T) {
 	raw := `{"findings":[
 		{"severity":"error","file":"main.go","line":10,"description":"nil pointer dereference"},

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -677,6 +677,20 @@ func TestParseFindings_Valid(t *testing.T) {
 	}
 }
 
+func TestParseFindings_WithRiskAssessment(t *testing.T) {
+	raw := `{"findings":[{"severity":"error","description":"bug"}],"risk_level":"high","risk_rationale":"Critical bug."}`
+	f, err := parseFindings(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.RiskLevel != "high" {
+		t.Errorf("expected risk_level 'high', got %q", f.RiskLevel)
+	}
+	if f.RiskRationale != "Critical bug." {
+		t.Errorf("expected risk_rationale, got %q", f.RiskRationale)
+	}
+}
+
 func TestParseFindings_InvalidJSON(t *testing.T) {
 	_, err := parseFindings("{bad json")
 	if err == nil {
@@ -689,9 +703,9 @@ func TestSeverityIcon(t *testing.T) {
 		severity string
 		icon     string
 	}{
-		{"error", "●"},
-		{"warning", "▲"},
-		{"info", "○"},
+		{"error", "E"},
+		{"warning", "W"},
+		{"info", "I"},
 		{"unknown", "·"},
 	}
 	for _, tt := range tests {
@@ -722,6 +736,93 @@ func TestRenderFindings_SummaryOnly(t *testing.T) {
 	}
 }
 
+func TestRenderFindings_RiskAssessment(t *testing.T) {
+	raw := `{"findings":[{"severity":"error","file":"main.go","line":10,"description":"nil pointer"}],"risk_level":"high","risk_rationale":"Critical concurrency bug could cause data corruption."}`
+	got := renderFindings(raw, 80)
+	plain := stripANSI(got)
+
+	// Should show "Risk: HIGH" instead of a summary.
+	if !strings.Contains(plain, "Risk: HIGH") {
+		t.Errorf("expected 'Risk: HIGH' in output, got:\n%s", plain)
+	}
+	// Should include rationale.
+	if !strings.Contains(plain, "Critical concurrency bug") {
+		t.Errorf("expected risk rationale in output, got:\n%s", plain)
+	}
+}
+
+func TestRenderFindings_RiskAssessmentLow(t *testing.T) {
+	raw := `{"findings":[{"severity":"info","description":"minor style issue"}],"risk_level":"low","risk_rationale":"Straightforward cosmetic change."}`
+	got := renderFindings(raw, 80)
+	plain := stripANSI(got)
+
+	if !strings.Contains(plain, "Risk: LOW") {
+		t.Errorf("expected 'Risk: LOW' in output, got:\n%s", plain)
+	}
+}
+
+func TestRenderFindings_RiskOverridesSummary(t *testing.T) {
+	// When both risk_level and summary are present, risk takes precedence.
+	raw := `{"findings":[{"severity":"warning","description":"check this"}],"summary":"1 issue found","risk_level":"medium","risk_rationale":"Moderate impact."}`
+	got := renderFindings(raw, 80)
+	plain := stripANSI(got)
+
+	if !strings.Contains(plain, "Risk: MEDIUM") {
+		t.Errorf("expected risk assessment, got:\n%s", plain)
+	}
+	if strings.Contains(plain, "1 issue found") {
+		t.Errorf("summary should not appear when risk assessment is present, got:\n%s", plain)
+	}
+}
+
+func TestRenderFindings_SelectionFooter(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.ANSI)
+	raw := `{"findings":[
+		{"id":"f1","severity":"error","file":"a.go","line":1,"description":"err"},
+		{"id":"f2","severity":"warning","file":"b.go","line":2,"description":"warn"},
+		{"id":"f3","severity":"info","file":"c.go","line":3,"description":"note"}
+	],"summary":"3 issues"}`
+
+	// When some findings are deselected, footer should show selected counts.
+	selected := map[string]bool{"f1": true, "f3": true} // f2 (warning) deselected
+	_, footer := renderFindingsWithSelection(raw, 80, 0, selected, 0)
+	plain := stripANSI(footer)
+
+	if !strings.Contains(plain, "E 1 I 1 selected") {
+		t.Errorf("expected selection footer 'E 1 I 1 selected', got: %q", plain)
+	}
+}
+
+func TestRenderFindings_SelectionFooter_AllSelected(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.ANSI)
+	raw := `{"findings":[
+		{"id":"f1","severity":"error","description":"err"},
+		{"id":"f2","severity":"warning","description":"warn"}
+	],"summary":"2 issues"}`
+
+	// When all are selected, no selection footer.
+	selected := map[string]bool{"f1": true, "f2": true}
+	_, footer := renderFindingsWithSelection(raw, 80, 0, selected, 0)
+
+	if strings.Contains(stripANSI(footer), "selected") {
+		t.Errorf("should not show selection footer when all selected, got: %q", footer)
+	}
+}
+
+func TestRenderFindings_SelectionFooter_NilSelected(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.ANSI)
+	raw := `{"findings":[
+		{"id":"f1","severity":"error","description":"err"}
+	],"summary":"1 issue"}`
+
+	// nil selected means all selected (default state).
+	_, footer := renderFindingsWithSelection(raw, 80, 0, nil, 0)
+
+	if strings.Contains(stripANSI(footer), "selected") {
+		t.Errorf("should not show selection footer when selected is nil, got: %q", footer)
+	}
+}
+
 func TestRenderFindings_WithFindings(t *testing.T) {
 	raw := `{"findings":[
 		{"severity":"error","file":"main.go","line":10,"description":"nil pointer dereference"},
@@ -736,16 +837,7 @@ func TestRenderFindings_WithFindings(t *testing.T) {
 		t.Error("expected summary")
 	}
 
-	// Severity counts present.
-	if !strings.Contains(got, "1 error") {
-		t.Error("expected error count")
-	}
-	if !strings.Contains(got, "1 warning") {
-		t.Error("expected warning count")
-	}
-	if !strings.Contains(got, "1 info") {
-		t.Error("expected info count")
-	}
+	// Severity counts are in the box title now, not the body.
 
 	// File references.
 	if !strings.Contains(got, "main.go:10") {
@@ -2544,7 +2636,7 @@ func TestDiffBoxTitle_IncludesStepName(t *testing.T) {
 	}
 }
 
-func TestFindingsBoxTitle_IncludesStepName(t *testing.T) {
+func TestFindingsBoxTitle_ShowsSeverityCounts(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.ANSI)
 	run := testRun()
 	run.Steps[0].Status = types.StepStatusCompleted
@@ -2558,9 +2650,9 @@ func TestFindingsBoxTitle_IncludesStepName(t *testing.T) {
 	view := m.View()
 	plain := stripANSI(view)
 
-	// The findings box title should include the step name, e.g. "Findings - Test".
-	if !strings.Contains(plain, "Findings - Test") {
-		t.Errorf("expected findings box title to include step name 'Findings - Test', got:\n%s", plain)
+	// The findings box title should show severity counts, e.g. "Findings - E 1".
+	if !strings.Contains(plain, "Findings - E 1") {
+		t.Errorf("expected findings box title with severity counts 'Findings - E 1', got:\n%s", plain)
 	}
 }
 
@@ -2660,32 +2752,33 @@ func TestRenderFindings_ViewportScrollUpIndicator(t *testing.T) {
 	}
 }
 
-func TestFindingsBoxTitle_ShowsPositionIndicator(t *testing.T) {
+func TestFindingsBoxTitle_MultipleSeverities(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.ANSI)
 	run := testRun()
 	run.Steps[0].Status = types.StepStatusCompleted
 	run.Steps[1].Status = types.StepStatusAwaitingApproval
 
-	findingsJSON := makeManyFindings(10)
+	findingsJSON := `{"summary":"issues","items":[
+		{"id":"f1","severity":"error","file":"a.go","line":1,"description":"err"},
+		{"id":"f2","severity":"warning","file":"b.go","line":2,"description":"warn"},
+		{"id":"f3","severity":"warning","file":"c.go","line":3,"description":"warn2"}
+	]}`
 	m := NewModel("/tmp/sock", nil, run)
 	m.width = 80
 	m.height = 40
 	m.stepFindings[types.StepTest] = findingsJSON
 	m.resetFindingSelection(types.StepTest)
 
-	// Move cursor to 3rd item (index 2).
-	m.findingCursor[types.StepTest] = 2
-
 	view := m.View()
 	plain := stripANSI(view)
 
-	// The findings box title should show position: "Findings - Test (3/10)".
-	if !strings.Contains(plain, "Findings - Test (3/10)") {
-		t.Errorf("expected findings box title with position '(3/10)', got:\n%s", plain)
+	// Title should show counts per severity: "Findings - E 1 W 2".
+	if !strings.Contains(plain, "Findings - E 1 W 2") {
+		t.Errorf("expected findings box title with 'Findings - E 1 W 2', got:\n%s", plain)
 	}
 }
 
-func TestFindingsBoxTitle_PositionUpdatesWithCursor(t *testing.T) {
+func TestFindingsBoxTitle_NoCursorPosition(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.ANSI)
 	run := testRun()
 	run.Steps[0].Status = types.StepStatusAwaitingApproval
@@ -2697,42 +2790,16 @@ func TestFindingsBoxTitle_PositionUpdatesWithCursor(t *testing.T) {
 	m.stepFindings[types.StepReview] = findingsJSON
 	m.resetFindingSelection(types.StepReview)
 
-	// Cursor at first item (index 0) -> should show (1/5).
-	m.findingCursor[types.StepReview] = 0
+	// Title should show severity counts, not cursor position.
+	m.findingCursor[types.StepReview] = 2
 	view := m.View()
 	plain := stripANSI(view)
-	if !strings.Contains(plain, "(1/5)") {
-		t.Errorf("expected position (1/5) at cursor 0, got:\n%s", plain)
+	if !strings.Contains(plain, "Findings - W 5") {
+		t.Errorf("expected 'Findings - W 5' in title, got:\n%s", plain)
 	}
-
-	// Cursor at last item (index 4) -> should show (5/5).
-	m.findingCursor[types.StepReview] = 4
-	view = m.View()
-	plain = stripANSI(view)
-	if !strings.Contains(plain, "(5/5)") {
-		t.Errorf("expected position (5/5) at cursor 4, got:\n%s", plain)
-	}
-}
-
-func TestFindingsBoxTitle_SingleFinding(t *testing.T) {
-	lipgloss.SetColorProfile(termenv.ANSI)
-	run := testRun()
-	run.Steps[0].Status = types.StepStatusCompleted
-	run.Steps[1].Status = types.StepStatusAwaitingApproval
-
-	findingsJSON := `{"summary":"one issue","items":[{"id":"f1","severity":"error","file":"foo.go","line":1,"description":"bad"}]}`
-	m := NewModel("/tmp/sock", nil, run)
-	m.width = 80
-	m.height = 40
-	m.stepFindings[types.StepTest] = findingsJSON
-	m.resetFindingSelection(types.StepTest)
-
-	view := m.View()
-	plain := stripANSI(view)
-
-	// Single finding: should show (1/1).
-	if !strings.Contains(plain, "(1/1)") {
-		t.Errorf("expected position (1/1) for single finding, got:\n%s", plain)
+	// Should NOT contain old-style position indicator.
+	if strings.Contains(plain, "(3/5)") {
+		t.Errorf("title should not contain cursor position indicator, got:\n%s", plain)
 	}
 }
 
@@ -4556,7 +4623,7 @@ func TestRenderFindingsWithSelection_TruncatedGutterPreservesSeverityIcon(t *tes
 	if !strings.Contains(result, "[x]") {
 		t.Error("expected checkbox to survive truncation")
 	}
-	if !strings.Contains(result, "●") {
+	if !strings.Contains(result, "E") {
 		t.Error("expected severity icon to survive truncation")
 	}
 }
@@ -4670,8 +4737,8 @@ func TestStaleShowDiff_FindingsVisibleAfterStepTransition(t *testing.T) {
 	})
 
 	view := stripANSI(m.View())
-	if !strings.Contains(view, "Findings - Test") {
-		t.Errorf("expected 'Findings - Test' box to be visible, got:\n%s", view)
+	if !strings.Contains(view, "Findings -") {
+		t.Errorf("expected findings box to be visible, got:\n%s", view)
 	}
 }
 
@@ -6039,12 +6106,12 @@ func TestRenderFindings_FocusedSeverityIconNotDim(t *testing.T) {
 	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
 
 	// Focused severity icon should NOT be dim-styled.
-	if strings.Contains(content, dimStyle.Render("●")) {
+	if strings.Contains(content, dimStyle.Render("E")) {
 		t.Error("focused finding severity icon should not be dim-styled")
 	}
 	// The colored icon should still be present.
 	errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiRed))
-	if !strings.Contains(content, errStyle.Render("●")) {
+	if !strings.Contains(content, errStyle.Render("E")) {
 		t.Error("focused finding severity icon should be styled with its severity color")
 	}
 }
@@ -6063,13 +6130,13 @@ func TestRenderFindings_UnfocusedSeverityIconDim(t *testing.T) {
 
 	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
 
-	// Unfocused severity icon (▲ for warning) should be dim-styled.
-	if !strings.Contains(content, dimStyle.Render("▲")) {
+	// Unfocused severity icon (W for warning) should be dim-styled.
+	if !strings.Contains(content, dimStyle.Render("W")) {
 		t.Error("unfocused finding severity icon should be dim-styled")
 	}
 	// The colored warning icon should NOT appear for unfocused findings.
 	warnStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiYellow))
-	if strings.Contains(content, warnStyle.Render("▲")) {
+	if strings.Contains(content, warnStyle.Render("W")) {
 		t.Error("unfocused finding severity icon should not use its severity color")
 	}
 }
@@ -6087,21 +6154,21 @@ func TestRenderFindings_FocusChangesSeverityIconStyle(t *testing.T) {
 	errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiRed))
 	warnStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiYellow))
 
-	// Cursor at 0: f1 focused (colored ●), f2 unfocused (dim ▲).
+	// Cursor at 0: f1 focused (colored E), f2 unfocused (dim W).
 	content0, _ := renderFindingsWithSelection(raw, 80, 0, selected, 0)
-	if !strings.Contains(content0, errStyle.Render("●")) {
+	if !strings.Contains(content0, errStyle.Render("E")) {
 		t.Error("with cursor=0, error icon should be colored red")
 	}
-	if !strings.Contains(content0, dimStyle.Render("▲")) {
+	if !strings.Contains(content0, dimStyle.Render("W")) {
 		t.Error("with cursor=0, warning icon should be dim")
 	}
 
-	// Cursor at 1: f2 focused (colored ▲), f1 unfocused (dim ●).
+	// Cursor at 1: f2 focused (colored W), f1 unfocused (dim E).
 	content1, _ := renderFindingsWithSelection(raw, 80, 1, selected, 0)
-	if !strings.Contains(content1, dimStyle.Render("●")) {
+	if !strings.Contains(content1, dimStyle.Render("E")) {
 		t.Error("with cursor=1, error icon should be dim")
 	}
-	if !strings.Contains(content1, warnStyle.Render("▲")) {
+	if !strings.Contains(content1, warnStyle.Render("W")) {
 		t.Error("with cursor=1, warning icon should be colored yellow")
 	}
 }
@@ -6505,64 +6572,7 @@ func TestModel_View_HelpOverlay_NoEscBackOutsideDiffMode(t *testing.T) {
 	}
 }
 
-func TestSeverityCountBadges_IncludeSeverityIcons(t *testing.T) {
-	lipgloss.SetColorProfile(termenv.ANSI)
-
-	raw := `{"summary":"Found issues","items":[
-		{"id":"f1","severity":"error","file":"a.go","line":1,"description":"bad"},
-		{"id":"f2","severity":"error","file":"b.go","line":2,"description":"bad2"},
-		{"id":"f3","severity":"warning","file":"c.go","line":3,"description":"warn"}
-	]}`
-	selected := map[string]bool{"f1": true, "f2": true, "f3": true}
-	content, _ := renderFindingsWithSelection(raw, 80, 0, selected, 0)
-	plain := stripANSI(content)
-
-	// Error count should include the error severity icon ●
-	if !strings.Contains(plain, "● 2 error") {
-		t.Errorf("severity count should include ● icon before error count, got:\n%s", plain)
-	}
-	// Warning count should include the warning severity icon ▲
-	if !strings.Contains(plain, "▲ 1 warning") {
-		t.Errorf("severity count should include ▲ icon before warning count, got:\n%s", plain)
-	}
-}
-
-func TestSeverityCountBadges_InfoIconIncluded(t *testing.T) {
-	lipgloss.SetColorProfile(termenv.ANSI)
-
-	raw := `{"summary":"Check results","items":[
-		{"id":"f1","severity":"info","file":"a.go","line":1,"description":"note"},
-		{"id":"f2","severity":"info","file":"b.go","line":2,"description":"note2"}
-	]}`
-	selected := map[string]bool{"f1": true, "f2": true}
-	content, _ := renderFindingsWithSelection(raw, 80, 0, selected, 0)
-	plain := stripANSI(content)
-
-	// Info count should include the info severity icon ○
-	if !strings.Contains(plain, "○ 2 info") {
-		t.Errorf("severity count should include ○ icon before info count, got:\n%s", plain)
-	}
-}
-
-func TestSeverityCountBadges_AllThreeSeverities(t *testing.T) {
-	lipgloss.SetColorProfile(termenv.ANSI)
-
-	raw := `{"summary":"Mixed","items":[
-		{"id":"f1","severity":"error","file":"a.go","line":1,"description":"err"},
-		{"id":"f2","severity":"warning","file":"b.go","line":2,"description":"warn"},
-		{"id":"f3","severity":"info","file":"c.go","line":3,"description":"note"}
-	]}`
-	selected := map[string]bool{"f1": true, "f2": true, "f3": true}
-	content, _ := renderFindingsWithSelection(raw, 80, 0, selected, 0)
-	plain := stripANSI(content)
-
-	// All three severity icons should appear in the count line
-	for _, expected := range []string{"● 1 error", "▲ 1 warning", "○ 1 info"} {
-		if !strings.Contains(plain, expected) {
-			t.Errorf("severity count should include %q, got:\n%s", expected, plain)
-		}
-	}
-}
+// Severity count badges tests removed - counts are now in the box title, not body.
 
 // --- Space toggle auto-advance tests ---
 
@@ -6756,7 +6766,7 @@ func TestModel_View_WideLayoutPlacesPipelineBesideFindings(t *testing.T) {
 	m.height = 40
 
 	view := m.View()
-	if !strings.Contains(stripANSI(view), "Findings - Review") {
+	if !strings.Contains(stripANSI(view), "Findings -") {
 		t.Fatalf("expected findings box in view, got:\n%s", stripANSI(view))
 	}
 	if !hasParallelBoxRow(view) {

--- a/internal/types/findings.go
+++ b/internal/types/findings.go
@@ -16,14 +16,18 @@ type Finding struct {
 
 // Findings is the structured findings payload exchanged across pipeline, IPC, and TUI.
 type Findings struct {
-	Items   []Finding `json:"findings"`
-	Summary string    `json:"summary"`
+	Items         []Finding `json:"findings"`
+	Summary       string    `json:"summary"`
+	RiskLevel     string    `json:"risk_level,omitempty"`
+	RiskRationale string    `json:"risk_rationale,omitempty"`
 }
 
 type findingsWire struct {
-	Items   []Finding `json:"findings"`
-	Legacy  []Finding `json:"items"`
-	Summary string    `json:"summary"`
+	Items         []Finding `json:"findings"`
+	Legacy        []Finding `json:"items"`
+	Summary       string    `json:"summary"`
+	RiskLevel     string    `json:"risk_level"`
+	RiskRationale string    `json:"risk_rationale"`
 }
 
 // ParseFindingsJSON decodes findings JSON, accepting both current and legacy item keys.
@@ -36,7 +40,7 @@ func ParseFindingsJSON(raw string) (Findings, error) {
 	if len(items) == 0 && len(wire.Legacy) > 0 {
 		items = wire.Legacy
 	}
-	return Findings{Items: items, Summary: wire.Summary}, nil
+	return Findings{Items: items, Summary: wire.Summary, RiskLevel: wire.RiskLevel, RiskRationale: wire.RiskRationale}, nil
 }
 
 // NormalizeFindings assigns deterministic IDs to findings that do not have one yet.
@@ -59,7 +63,7 @@ func FilterFindings(findings Findings, ids []string) Findings {
 	for _, id := range ids {
 		selected[id] = true
 	}
-	filtered := Findings{Summary: findings.Summary}
+	filtered := Findings{Summary: findings.Summary, RiskLevel: findings.RiskLevel, RiskRationale: findings.RiskRationale}
 	for _, item := range findings.Items {
 		if selected[item.ID] {
 			filtered.Items = append(filtered.Items, item)

--- a/internal/types/findings_test.go
+++ b/internal/types/findings_test.go
@@ -1,0 +1,77 @@
+package types
+
+import "testing"
+
+func TestParseFindingsJSON_RiskFields(t *testing.T) {
+	raw := `{"findings":[{"severity":"error","description":"bug"}],"risk_level":"high","risk_rationale":"Critical bug."}`
+	f, err := ParseFindingsJSON(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.RiskLevel != "high" {
+		t.Errorf("RiskLevel = %q, want %q", f.RiskLevel, "high")
+	}
+	if f.RiskRationale != "Critical bug." {
+		t.Errorf("RiskRationale = %q, want %q", f.RiskRationale, "Critical bug.")
+	}
+	if len(f.Items) != 1 {
+		t.Fatalf("Items count = %d, want 1", len(f.Items))
+	}
+}
+
+func TestParseFindingsJSON_NoRiskFields(t *testing.T) {
+	raw := `{"findings":[{"severity":"info","description":"note"}],"summary":"ok"}`
+	f, err := ParseFindingsJSON(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.RiskLevel != "" {
+		t.Errorf("RiskLevel = %q, want empty", f.RiskLevel)
+	}
+	if f.RiskRationale != "" {
+		t.Errorf("RiskRationale = %q, want empty", f.RiskRationale)
+	}
+	if f.Summary != "ok" {
+		t.Errorf("Summary = %q, want %q", f.Summary, "ok")
+	}
+}
+
+func TestFilterFindings_PreservesRiskFields(t *testing.T) {
+	f := Findings{
+		Items: []Finding{
+			{ID: "f1", Severity: "error", Description: "bad"},
+			{ID: "f2", Severity: "warning", Description: "warn"},
+		},
+		Summary:       "2 issues",
+		RiskLevel:     "medium",
+		RiskRationale: "Some risk.",
+	}
+	filtered := FilterFindings(f, []string{"f1"})
+	if filtered.RiskLevel != "medium" {
+		t.Errorf("RiskLevel = %q, want %q", filtered.RiskLevel, "medium")
+	}
+	if filtered.RiskRationale != "Some risk." {
+		t.Errorf("RiskRationale = %q, want %q", filtered.RiskRationale, "Some risk.")
+	}
+	if len(filtered.Items) != 1 {
+		t.Fatalf("Items count = %d, want 1", len(filtered.Items))
+	}
+	if filtered.Items[0].ID != "f1" {
+		t.Errorf("filtered item ID = %q, want %q", filtered.Items[0].ID, "f1")
+	}
+}
+
+func TestFilterFindings_EmptyIDs(t *testing.T) {
+	f := Findings{
+		Items:         []Finding{{ID: "f1", Severity: "error", Description: "bad"}},
+		RiskLevel:     "low",
+		RiskRationale: "Safe.",
+	}
+	filtered := FilterFindings(f, []string{})
+	if len(filtered.Items) != 1 {
+		t.Errorf("expected all items returned for empty IDs, got %d", len(filtered.Items))
+	}
+	if filtered.RiskLevel != "low" {
+		t.Errorf("RiskLevel = %q, want %q", filtered.RiskLevel, "low")
+	}
+}


### PR DESCRIPTION
## Summary

- Add risk assessment (`risk_level`, `risk_rationale`) to the review step schema and types, displayed as a colored "Risk: HIGH/MEDIUM/LOW" line in the findings panel
- Replace Unicode severity icons (`●`, `▲`, `○`) with plain letters (`E`, `W`, `I`) for better terminal compatibility
- Move severity counts into the findings box title (e.g., "Findings - E 2 W 1") instead of showing step name + cursor position
- Add a selection footer that shows per-severity counts when not all findings are selected
- Consolidate `renderBox`/`renderBoxWithFooter` into a shared `renderBoxWithStyledTitle`, removing duplicated border-drawing code
- Extract `renderParsedFindingsHeight`/`renderParsedFindingsViewport` so callers with pre-parsed findings skip redundant JSON parsing

## Test plan

- [x] `TestReviewFindingsSchema_ValidJSON` validates the new schema includes `risk_level` and `risk_rationale` as required fields
- [x] `TestParseFindings_WithRiskAssessment` verifies parsing of risk fields from JSON
- [x] `TestRenderFindings_RiskAssessment`, `_RiskAssessmentLow`, `_RiskOverridesSummary` cover risk display and precedence over summary
- [x] `TestRenderFindings_SelectionFooter*` tests cover selection count footer for partial, full, nil, and empty selection states
- [x] `TestFindingsBoxTitle_ShowsSeverityCounts` and `_MultipleSeverities` verify the new title format
- [x] Updated icon assertions across existing tests (`TestSeverityIcon`, truncation, focus/unfocus styling)
- [x] `go test -race ./...` passes