### PR TITLE
Add configurable grace period before exiting on empty CI checks

### DIFF
--- a/internal/pipeline/steps/babysit.go
+++ b/internal/pipeline/steps/babysit.go
@@ -18,14 +18,24 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
+const defaultChecksGracePeriod = 60 * time.Second
+
 // BabysitStep monitors CI and PR comments after PR creation,
 // auto-fixing CI failures and presenting PR comments for human selection.
 type BabysitStep struct {
-	seenComments    map[string]bool
-	lastFixedChecks string // sorted check names from last fix attempt, to avoid re-fixing
+	seenComments      map[string]bool
+	lastFixedChecks   string        // sorted check names from last fix attempt, to avoid re-fixing
+	checksGracePeriod time.Duration // minimum wait before trusting empty CI checks (0 = default 60s)
 }
 
 func (s *BabysitStep) Name() types.StepName { return types.StepBabysit }
+
+func (s *BabysitStep) gracePeriod() time.Duration {
+	if s.checksGracePeriod > 0 {
+		return s.checksGracePeriod
+	}
+	return defaultChecksGracePeriod
+}
 
 // ciCheck represents a CI check result from gh pr checks --json.
 type ciCheck struct {
@@ -254,11 +264,16 @@ func (s *BabysitStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome
 			}
 		} else if !hasPendingChecks(checks) {
 			s.lastFixedChecks = ""
-			checksReadyToExit = true
-			if len(checks) == 0 {
-				checksSummary = "no CI checks reported, babysit complete"
+			if len(checks) == 0 && elapsed < s.gracePeriod() {
+				// CI checks may not be registered yet, keep polling
+				sctx.Log("no CI checks reported yet, waiting for checks to register...")
 			} else {
-				checksSummary = "all CI checks passed"
+				checksReadyToExit = true
+				if len(checks) == 0 {
+					checksSummary = "no CI checks reported, babysit complete"
+				} else {
+					checksSummary = "all CI checks passed"
+				}
 			}
 		}
 

--- a/internal/pipeline/steps/babysit.go
+++ b/internal/pipeline/steps/babysit.go
@@ -23,9 +23,10 @@ const defaultChecksGracePeriod = 60 * time.Second
 // BabysitStep monitors CI and PR comments after PR creation,
 // auto-fixing CI failures and presenting PR comments for human selection.
 type BabysitStep struct {
-	seenComments      map[string]bool
-	lastFixedChecks   string        // sorted check names from last fix attempt, to avoid re-fixing
-	checksGracePeriod time.Duration // minimum wait before trusting empty CI checks (0 = default 60s)
+	seenComments         map[string]bool
+	lastFixedChecks      string        // sorted check names from last fix attempt, to avoid re-fixing
+	checksGracePeriod    time.Duration // minimum wait before trusting empty CI checks (0 = default 60s)
+	pollIntervalOverride time.Duration // if set, overrides computed poll interval (for testing)
 }
 
 func (s *BabysitStep) Name() types.StepName { return types.StepBabysit }
@@ -302,7 +303,10 @@ func (s *BabysitStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome
 		}
 
 		// Sleep for poll interval
-		interval := pollInterval(time.Since(started))
+		interval := s.pollIntervalOverride
+		if interval == 0 {
+			interval = pollInterval(time.Since(started))
+		}
 		remaining := timeout - time.Since(started)
 		if remaining < interval {
 			interval = remaining

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -3445,7 +3445,7 @@ func TestBabysitStep_EmptyChecksWaitsDuringGracePeriod(t *testing.T) {
 	var logs []string
 	sctx.Log = func(s string) { logs = append(logs, s) }
 
-	step := &BabysitStep{checksGracePeriod: 200 * time.Millisecond}
+	step := &BabysitStep{checksGracePeriod: 200 * time.Millisecond, pollIntervalOverride: 10 * time.Millisecond}
 	started := time.Now()
 	outcome, err := step.Execute(sctx)
 	elapsed := time.Since(started)
@@ -3459,16 +3459,21 @@ func TestBabysitStep_EmptyChecksWaitsDuringGracePeriod(t *testing.T) {
 	if elapsed < 200*time.Millisecond {
 		t.Errorf("babysit exited in %v, expected to wait at least 200ms grace period", elapsed)
 	}
-	// Should eventually exit with the "no CI checks" message
+	// Should exit via grace period expiry, not babysit timeout
+	for _, l := range logs {
+		if strings.Contains(l, "babysit timeout reached") {
+			t.Fatal("expected exit via grace period expiry, not babysit timeout")
+		}
+	}
 	found := false
 	for _, l := range logs {
-		if strings.Contains(l, "no CI checks reported") {
+		if strings.Contains(l, "babysit complete") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Fatalf("expected 'no CI checks reported' log, got: %v", logs)
+		t.Fatalf("expected 'babysit complete' log, got: %v", logs)
 	}
 }
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -3429,6 +3429,91 @@ func TestBabysitStep_AllChecksPassingExitsCleanly(t *testing.T) {
 	}
 }
 
+func TestBabysitStep_EmptyChecksWaitsDuringGracePeriod(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	// Fake gh returns OPEN state, empty checks, no comments
+	binDir := fakeBabysitGH(t, "OPEN", "[]", "[]")
+	prependPATH(t, binDir)
+
+	prURL := "https://github.com/test/repo/pull/42"
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Run.PRURL = &prURL
+	sctx.Config.BabysitTimeout = 5 * time.Second
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+
+	step := &BabysitStep{checksGracePeriod: 200 * time.Millisecond}
+	started := time.Now()
+	outcome, err := step.Execute(sctx)
+	elapsed := time.Since(started)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Error("expected no approval needed")
+	}
+	// Must have waited at least the grace period before exiting
+	if elapsed < 200*time.Millisecond {
+		t.Errorf("babysit exited in %v, expected to wait at least 200ms grace period", elapsed)
+	}
+	// Should eventually exit with the "no CI checks" message
+	found := false
+	for _, l := range logs {
+		if strings.Contains(l, "no CI checks reported") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected 'no CI checks reported' log, got: %v", logs)
+	}
+}
+
+func TestBabysitStep_NonEmptyPassingChecksExitImmediately(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	checksJSON := `[{"name":"build","state":"SUCCESS","bucket":"pass"}]`
+	binDir := fakeBabysitGH(t, "OPEN", checksJSON, "[]")
+	prependPATH(t, binDir)
+
+	prURL := "https://github.com/test/repo/pull/42"
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Run.PRURL = &prURL
+	sctx.Config.BabysitTimeout = 10 * time.Second
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+
+	// Even with a long grace period, non-empty passing checks should exit immediately
+	step := &BabysitStep{checksGracePeriod: 10 * time.Second}
+	started := time.Now()
+	outcome, err := step.Execute(sctx)
+	elapsed := time.Since(started)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Error("expected no approval needed")
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("non-empty passing checks should exit quickly, took %v", elapsed)
+	}
+	found := false
+	for _, l := range logs {
+		if strings.Contains(l, "all CI checks passed") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected 'all CI checks passed' log, got: %v", logs)
+	}
+}
+
 func TestBabysitStep_AddressCommentsInFixMode_OnlySelectedComments(t *testing.T) {
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
@@ -3456,7 +3541,8 @@ func TestBabysitStep_AddressCommentsInFixMode_OnlySelectedComments(t *testing.T)
 		{"id":"IC_200","author":{"login":"alice"},"body":"Rename this function","createdAt":"2026-01-01T00:00:00Z","url":"https://github.com/test/repo/pull/42#comment-200"},
 		{"id":"IC_201","author":{"login":"bob"},"body":"Add more tests","createdAt":"2026-01-01T00:00:01Z","url":"https://github.com/test/repo/pull/42#comment-201"}
 	]`
-	binDir := fakeBabysitGH(t, "OPEN", "[]", commentsJSON)
+	passingChecks := `[{"name":"build","state":"SUCCESS","bucket":"pass"}]`
+	binDir := fakeBabysitGH(t, "OPEN", passingChecks, commentsJSON)
 	prependPATH(t, binDir)
 
 	ag := &mockAgent{
@@ -3524,7 +3610,8 @@ func TestBabysitStep_AddressCommentsInFixMode(t *testing.T) {
 	gitCmd(t, dir, "push", "origin", "feature")
 
 	commentsJSON := `[{"id":"IC_200","author":{"login":"alice"},"body":"Rename this function","createdAt":"2026-01-01T00:00:00Z","url":"https://github.com/test/repo/pull/42#comment-200"}]`
-	binDir := fakeBabysitGH(t, "OPEN", "[]", commentsJSON)
+	passingChecks := `[{"name":"build","state":"SUCCESS","bucket":"pass"}]`
+	binDir := fakeBabysitGH(t, "OPEN", passingChecks, commentsJSON)
 	prependPATH(t, binDir)
 
 	agentCalled := false


### PR DESCRIPTION
## Summary

- The babysit step previously exited immediately when `gh pr checks` returned no checks, which caused premature exits when CI checks hadn't registered yet (race condition with GitHub).
- Adds a configurable grace period (default 60s) that keeps polling when zero checks are reported, only exiting after the grace period expires.
- Non-empty passing checks still exit immediately - the grace period only applies to the empty-checks case.
- Adds `pollIntervalOverride` field for deterministic test timing.
- Fixes two existing tests (`AddressCommentsInFixMode`, `AddressCommentsInFixMode_OnlySelectedComments`) that relied on empty checks to trigger the exit path - they now use passing checks instead, which is the intended flow.

## Test plan

- [x] `TestBabysitStep_EmptyChecksWaitsDuringGracePeriod` - verifies polling continues for at least the grace period when no checks are registered
- [x] `TestBabysitStep_NonEmptyPassingChecksExitImmediately` - verifies non-empty passing checks still exit without waiting for the grace period
- [x] Existing babysit tests updated to use passing checks instead of empty checks for comment-handling flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)