### PR TITLE
Fix test step to handle empty findings when all tests pass

### DIFF
--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -867,6 +867,9 @@ func TestTestStep_NoCommand_AgentDetects(t *testing.T) {
 	if !strings.Contains(ag.calls[0].Prompt, "branch: refs/heads/feature") {
 		t.Error("expected prompt to include branch metadata")
 	}
+	if !strings.Contains(ag.calls[0].Prompt, "empty findings array") {
+		t.Error("expected prompt to instruct agent to return empty findings when tests pass")
+	}
 }
 
 func TestTestStep_NoCommand_MalformedAgentOutput(t *testing.T) {

--- a/internal/pipeline/steps/test.go
+++ b/internal/pipeline/steps/test.go
@@ -91,7 +91,9 @@ Task:
 Rules:
 - Do NOT run linters, formatters, or static analysis tools.
 - Focus on testing and test-related fixes only.
-- Return results as structured findings.`,
+- Only report actionable findings: test failures, unfixable setup issues, or flaky tests you identified.
+- Do NOT report passing tests (whether existing or new), test counts, coverage summaries, or other non-actionable information.
+- If all tests pass and there are no issues, return an empty findings array.`,
 				sctx.Run.Branch,
 				baseSHA,
 				sctx.Run.HeadSHA,


### PR DESCRIPTION
## Summary
- Refine the test step's agent prompt to only report actionable findings (failures, setup issues, flaky tests) and explicitly return an empty findings array when all tests pass
- Previously the prompt asked for "structured findings" without guidance on the passing case, which could produce noisy non-actionable output

## Test plan
- [x] Existing test `TestTestStep_NoCommand_AgentDetects` extended to assert the prompt includes the empty findings instruction
- [x] `go test -race ./internal/pipeline/steps/...`