### PR TITLE
fix: generate default global config on first daemon start

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -95,6 +95,21 @@ func (c *Config) AgentPath() string {
 	return string(c.Agent)
 }
 
+// EnsureDefaultGlobalConfig writes the default config file at path if it does
+// not already exist. Failures are logged at debug level and silently ignored.
+func EnsureDefaultGlobalConfig(path string) {
+	if _, err := os.Stat(path); err == nil {
+		return
+	}
+	if mkErr := os.MkdirAll(filepath.Dir(path), 0o755); mkErr != nil {
+		slog.Debug("failed to create config directory", "path", filepath.Dir(path), "error", mkErr)
+		return
+	}
+	if wErr := os.WriteFile(path, []byte(defaultConfigYAML), 0o644); wErr != nil {
+		slog.Debug("failed to write default config", "path", path, "error", wErr)
+	}
+}
+
 // LoadGlobal reads global config from path. Returns defaults if file doesn't exist.
 func LoadGlobal(path string) (*GlobalConfig, error) {
 	cfg := &GlobalConfig{
@@ -106,11 +121,6 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			if mkErr := os.MkdirAll(filepath.Dir(path), 0o755); mkErr != nil {
-				slog.Debug("failed to create config directory", "path", filepath.Dir(path), "error", mkErr)
-			} else if wErr := os.WriteFile(path, []byte(defaultConfigYAML), 0o644); wErr != nil {
-				slog.Debug("failed to write default config", "path", path, "error", wErr)
-			}
 			return cfg, nil
 		}
 		return nil, fmt.Errorf("read global config: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,6 +100,9 @@ func (c *Config) AgentPath() string {
 func EnsureDefaultGlobalConfig(path string) {
 	if _, err := os.Stat(path); err == nil {
 		return
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		slog.Debug("failed to stat config path", "path", path, "error", err)
+		return
 	}
 	if mkErr := os.MkdirAll(filepath.Dir(path), 0o755); mkErr != nil {
 		slog.Debug("failed to create config directory", "path", filepath.Dir(path), "error", mkErr)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,6 +53,26 @@ type Config struct {
 	IgnorePatterns    []string
 }
 
+// defaultConfigYAML is the template written when no global config file exists.
+const defaultConfigYAML = `# no-mistakes global configuration
+
+# Agent to use for code generation
+# Options: claude, codex, rovodev, opencode
+agent: claude
+
+# Maximum time to babysit a run before timing out
+babysit_timeout: "4h"
+
+# Log level for daemon output
+# Options: debug, info, warn, error
+log_level: info
+
+# Override agent binary paths (optional)
+# agent_path_override:
+#   claude: /usr/local/bin/claude
+#   codex: /opt/codex
+`
+
 // defaultBinary maps agent names to their default binary names.
 var defaultBinary = map[types.AgentName]string{
 	types.AgentClaude:   "claude",
@@ -86,6 +106,9 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
+			if mkErr := os.MkdirAll(filepath.Dir(path), 0o755); mkErr == nil {
+				_ = os.WriteFile(path, []byte(defaultConfigYAML), 0o644)
+			}
 			return cfg, nil
 		}
 		return nil, fmt.Errorf("read global config: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -106,10 +106,10 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			if mkErr := os.MkdirAll(filepath.Dir(path), 0o755); mkErr == nil {
-				if wErr := os.WriteFile(path, []byte(defaultConfigYAML), 0o644); wErr != nil {
-					slog.Debug("failed to write default config", "path", path, "error", wErr)
-				}
+			if mkErr := os.MkdirAll(filepath.Dir(path), 0o755); mkErr != nil {
+				slog.Debug("failed to create config directory", "path", filepath.Dir(path), "error", mkErr)
+			} else if wErr := os.WriteFile(path, []byte(defaultConfigYAML), 0o644); wErr != nil {
+				slog.Debug("failed to write default config", "path", path, "error", wErr)
 			}
 			return cfg, nil
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -107,7 +107,9 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			if mkErr := os.MkdirAll(filepath.Dir(path), 0o755); mkErr == nil {
-				_ = os.WriteFile(path, []byte(defaultConfigYAML), 0o644)
+				if wErr := os.WriteFile(path, []byte(defaultConfigYAML), 0o644); wErr != nil {
+					slog.Debug("failed to write default config", "path", path, "error", wErr)
+				}
 			}
 			return cfg, nil
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -27,6 +28,83 @@ func TestLoadGlobal_Defaults(t *testing.T) {
 	}
 	if len(cfg.AgentPathOverride) != 0 {
 		t.Errorf("agent_path_override = %v, want empty", cfg.AgentPathOverride)
+	}
+}
+
+func TestLoadGlobal_CreatesDefaultFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	cfg, err := LoadGlobal(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should return defaults
+	if cfg.Agent != types.AgentClaude {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentClaude)
+	}
+	if cfg.BabysitTimeout != 4*time.Hour {
+		t.Errorf("babysit_timeout = %v, want %v", cfg.BabysitTimeout, 4*time.Hour)
+	}
+
+	// File should now exist with commented defaults
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("config file not created: %v", err)
+	}
+	content := string(data)
+	for _, want := range []string{
+		"agent: claude",
+		"babysit_timeout:",
+		"log_level: info",
+		"# agent_path_override:",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("default config missing %q", want)
+		}
+	}
+}
+
+func TestLoadGlobal_CreatedConfigIsLoadable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	// First call creates the file
+	if _, err := LoadGlobal(path); err != nil {
+		t.Fatalf("unexpected error on create: %v", err)
+	}
+
+	// Second call loads the created file - proves the YAML is valid
+	cfg, err := LoadGlobal(path)
+	if err != nil {
+		t.Fatalf("unexpected error on reload: %v", err)
+	}
+	if cfg.Agent != types.AgentClaude {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentClaude)
+	}
+	if cfg.BabysitTimeout != 4*time.Hour {
+		t.Errorf("babysit_timeout = %v, want %v", cfg.BabysitTimeout, 4*time.Hour)
+	}
+	if cfg.LogLevel != "info" {
+		t.Errorf("log_level = %q, want %q", cfg.LogLevel, "info")
+	}
+}
+
+func TestLoadGlobal_CreatesParentDirs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "subdir", "config.yaml")
+
+	cfg, err := LoadGlobal(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Agent != types.AgentClaude {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentClaude)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("config file not created in nested dir: %v", err)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -76,6 +76,25 @@ func TestEnsureDefaultGlobalConfig_CreatedConfigIsLoadable(t *testing.T) {
 	}
 }
 
+func TestEnsureDefaultGlobalConfig_DoesNotOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	custom := "agent: codex\nlog_level: debug\n"
+	if err := os.WriteFile(path, []byte(custom), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	EnsureDefaultGlobalConfig(path)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+	if string(data) != custom {
+		t.Errorf("config was overwritten:\ngot:  %q\nwant: %q", string(data), custom)
+	}
+}
+
 func TestEnsureDefaultGlobalConfig_CreatesParentDirs(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "subdir", "config.yaml")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -95,6 +95,29 @@ func TestEnsureDefaultGlobalConfig_DoesNotOverwrite(t *testing.T) {
 	}
 }
 
+func TestEnsureDefaultGlobalConfig_SkipsOnStatPermissionError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("agent: codex\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0o000); err != nil {
+		t.Skip("cannot restrict directory permissions")
+	}
+	t.Cleanup(func() { os.Chmod(dir, 0o755) })
+
+	EnsureDefaultGlobalConfig(path)
+
+	os.Chmod(dir, 0o755)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+	if string(data) != "agent: codex\n" {
+		t.Errorf("config was overwritten despite stat permission error:\ngot:  %q\nwant: %q", string(data), "agent: codex\n")
+	}
+}
+
 func TestEnsureDefaultGlobalConfig_CreatesParentDirs(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "subdir", "config.yaml")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/types"
+	"gopkg.in/yaml.v3"
 )
 
 func TestLoadGlobal_Defaults(t *testing.T) {
@@ -31,24 +32,12 @@ func TestLoadGlobal_Defaults(t *testing.T) {
 	}
 }
 
-func TestLoadGlobal_CreatesDefaultFile(t *testing.T) {
+func TestEnsureDefaultGlobalConfig_CreatesFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
 
-	cfg, err := LoadGlobal(path)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	EnsureDefaultGlobalConfig(path)
 
-	// Should return defaults
-	if cfg.Agent != types.AgentClaude {
-		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentClaude)
-	}
-	if cfg.BabysitTimeout != 4*time.Hour {
-		t.Errorf("babysit_timeout = %v, want %v", cfg.BabysitTimeout, 4*time.Hour)
-	}
-
-	// File should now exist with commented defaults
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("config file not created: %v", err)
@@ -66,16 +55,12 @@ func TestLoadGlobal_CreatesDefaultFile(t *testing.T) {
 	}
 }
 
-func TestLoadGlobal_CreatedConfigIsLoadable(t *testing.T) {
+func TestEnsureDefaultGlobalConfig_CreatedConfigIsLoadable(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
 
-	// First call creates the file
-	if _, err := LoadGlobal(path); err != nil {
-		t.Fatalf("unexpected error on create: %v", err)
-	}
+	EnsureDefaultGlobalConfig(path)
 
-	// Second call loads the created file - proves the YAML is valid
 	cfg, err := LoadGlobal(path)
 	if err != nil {
 		t.Fatalf("unexpected error on reload: %v", err)
@@ -91,20 +76,28 @@ func TestLoadGlobal_CreatedConfigIsLoadable(t *testing.T) {
 	}
 }
 
-func TestLoadGlobal_CreatesParentDirs(t *testing.T) {
+func TestEnsureDefaultGlobalConfig_CreatesParentDirs(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "subdir", "config.yaml")
 
-	cfg, err := LoadGlobal(path)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if cfg.Agent != types.AgentClaude {
-		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentClaude)
-	}
+	EnsureDefaultGlobalConfig(path)
 
 	if _, err := os.Stat(path); err != nil {
 		t.Errorf("config file not created in nested dir: %v", err)
+	}
+}
+
+func TestLoadGlobal_DoesNotCreateFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	_, err := LoadGlobal(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := os.Stat(path); err == nil {
+		t.Error("LoadGlobal should not create config file")
 	}
 }
 
@@ -400,6 +393,27 @@ func TestAgentPath_DefaultBinaries(t *testing.T) {
 		if got := cfg.AgentPath(); got != tt.want {
 			t.Errorf("AgentPath() for %q = %q, want %q", tt.agent, got, tt.want)
 		}
+	}
+}
+
+func TestDefaultConfigYAML_MatchesGoDefaults(t *testing.T) {
+	var raw globalConfigRaw
+	if err := yaml.Unmarshal([]byte(defaultConfigYAML), &raw); err != nil {
+		t.Fatalf("defaultConfigYAML is not valid YAML: %v", err)
+	}
+
+	if raw.Agent != types.AgentClaude {
+		t.Errorf("YAML agent = %q, Go default = %q", raw.Agent, types.AgentClaude)
+	}
+	d, err := time.ParseDuration(raw.BabysitTimeout)
+	if err != nil {
+		t.Fatalf("YAML babysit_timeout %q is not a valid duration: %v", raw.BabysitTimeout, err)
+	}
+	if d != 4*time.Hour {
+		t.Errorf("YAML babysit_timeout = %v, Go default = %v", d, 4*time.Hour)
+	}
+	if raw.LogLevel != "info" {
+		t.Errorf("YAML log_level = %q, Go default = %q", raw.LogLevel, "info")
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -28,7 +28,8 @@ func Run() error {
 		return fmt.Errorf("create directories: %w", err)
 	}
 
-	// Load global config and initialize structured logger.
+	// Ensure default config exists, then load it.
+	config.EnsureDefaultGlobalConfig(p.ConfigFile())
 	globalCfg, err := config.LoadGlobal(p.ConfigFile())
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -258,8 +258,6 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 		}
 	}()
 
-	// Ensure default config exists, then load it.
-	config.EnsureDefaultGlobalConfig(m.paths.ConfigFile())
 	globalCfg, err := config.LoadGlobal(m.paths.ConfigFile())
 	if err != nil {
 		m.db.UpdateRunError(run.ID, fmt.Sprintf("load config: %s", err))

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -258,7 +258,8 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 		}
 	}()
 
-	// Load config.
+	// Ensure default config exists, then load it.
+	config.EnsureDefaultGlobalConfig(m.paths.ConfigFile())
 	globalCfg, err := config.LoadGlobal(m.paths.ConfigFile())
 	if err != nil {
 		m.db.UpdateRunError(run.ID, fmt.Sprintf("load config: %s", err))


### PR DESCRIPTION
## Summary
- Add `EnsureDefaultGlobalConfig` that writes a commented config template when no global config file exists, with safe no-op behavior on permission errors or pre-existing files.
- Extract default-config generation out of `LoadGlobal` so loading remains a pure read with no filesystem side effects.
- Call `EnsureDefaultGlobalConfig` once at daemon startup before loading config.
- Remove a redundant `LoadGlobal` call in `RunManager.startRun`.
- Log `MkdirAll` and `WriteFile` errors at debug level instead of silently discarding them.

## Test plan
- `TestEnsureDefaultGlobalConfig_CreatesFile` - template is written with expected keys
- `TestEnsureDefaultGlobalConfig_CreatedConfigIsLoadable` - generated file round-trips through `LoadGlobal`
- `TestEnsureDefaultGlobalConfig_DoesNotOverwrite` - existing config is preserved
- `TestEnsureDefaultGlobalConfig_SkipsOnStatPermissionError` - non-ErrNotExist stat errors are handled gracefully
- `TestEnsureDefaultGlobalConfig_CreatesParentDirs` - intermediate directories are created
- `TestLoadGlobal_DoesNotCreateFile` - `LoadGlobal` no longer writes to disk
- `TestDefaultConfigYAML_MatchesGoDefaults` - YAML template stays in sync with Go default values