### PR TITLE
fix(babysit): remove PR comment handling, keep CI-only monitoring

### DIFF
--- a/internal/pipeline/steps/babysit.go
+++ b/internal/pipeline/steps/babysit.go
@@ -20,10 +20,8 @@ import (
 
 const defaultChecksGracePeriod = 60 * time.Second
 
-// BabysitStep monitors CI and PR comments after PR creation,
-// auto-fixing CI failures and presenting PR comments for human selection.
+// BabysitStep monitors CI checks after PR creation, auto-fixing failures.
 type BabysitStep struct {
-	seenComments         map[string]bool
 	lastFixedChecks      string        // sorted check names from last fix attempt, to avoid re-fixing
 	checksGracePeriod    time.Duration // minimum wait before trusting empty CI checks (0 = default 60s)
 	pollIntervalOverride time.Duration // if set, overrides computed poll interval (for testing)
@@ -45,17 +43,6 @@ type ciCheck struct {
 	Conclusion string `json:"conclusion"` // legacy fake-test field
 	State      string `json:"state"`      // gh CLI field
 	Bucket     string `json:"bucket"`     // gh CLI field: pass|fail|pending|skipping|cancel
-}
-
-// prComment represents a comment on a PR from gh pr view --json comments.
-type prComment struct {
-	ID     string `json:"id"`
-	Author struct {
-		Login string `json:"login"`
-	} `json:"author"`
-	Body      string `json:"body"`
-	CreatedAt string `json:"createdAt"`
-	URL       string `json:"url"`
 }
 
 // extractPRNumber extracts the PR number from a GitHub PR URL.
@@ -126,34 +113,6 @@ func failingCheckNames(checks []ciCheck) []string {
 	return names
 }
 
-// commentsToFindings converts PR comments to the findings format for TUI display.
-func commentsToFindings(comments []prComment) Findings {
-	var items []Finding
-	for _, c := range comments {
-		items = append(items, Finding{
-			ID:          c.ID,
-			Severity:    "info",
-			Description: fmt.Sprintf("@%s: %s", c.Author.Login, truncate(c.Body, 200)),
-		})
-	}
-	return Findings{
-		Items:   items,
-		Summary: fmt.Sprintf("%d PR comment(s) to review", len(comments)),
-	}
-}
-
-// truncate shortens a string to maxLen runes, adding "..." if truncated.
-func truncate(s string, maxLen int) string {
-	runes := []rune(s)
-	if len(runes) <= maxLen {
-		return s
-	}
-	if maxLen <= 3 {
-		return string(runes[:maxLen])
-	}
-	return string(runes[:maxLen-3]) + "..."
-}
-
 func (s *BabysitStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, error) {
 	ctx := sctx.Ctx
 	if err := ctx.Err(); err != nil {
@@ -174,11 +133,6 @@ func (s *BabysitStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome
 	if !scm.AuthConfigured(ctx, provider, sctx.WorkDir) {
 		sctx.Log("skipping babysit: gh CLI is not authenticated")
 		return &pipeline.StepOutcome{}, nil
-	}
-
-	// Initialize seen comments tracking
-	if s.seenComments == nil {
-		s.seenComments = make(map[string]bool)
 	}
 
 	// Get PR URL from run record
@@ -202,13 +156,6 @@ func (s *BabysitStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome
 	prNumber, err := extractPRNumber(prURL)
 	if err != nil {
 		return nil, fmt.Errorf("extract PR number: %w", err)
-	}
-
-	// If in fix mode, address comments then resume polling
-	if sctx.Fixing {
-		if err := s.addressComments(sctx, prNumber); err != nil {
-			sctx.Log(fmt.Sprintf("warning: could not address comments: %v", err))
-		}
 	}
 
 	timeout := sctx.Config.BabysitTimeout
@@ -278,25 +225,6 @@ func (s *BabysitStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome
 			}
 		}
 
-		// Check for new PR comments — pause for human selection
-		comments, err := s.getNewComments(ctx, sctx.WorkDir, prNumber)
-		if err != nil {
-			sctx.Log(fmt.Sprintf("warning: could not check comments: %v", err))
-		} else if len(comments) > 0 {
-			sctx.Log(fmt.Sprintf("found %d new PR comment(s)", len(comments)))
-			// Mark all as seen
-			for _, c := range comments {
-				s.seenComments[c.ID] = true
-			}
-			// Return with findings for TUI display
-			findings := commentsToFindings(comments)
-			findingsJSON, _ := json.Marshal(findings)
-			return &pipeline.StepOutcome{
-				NeedsApproval: true,
-				Findings:      string(findingsJSON),
-			}, nil
-		}
-
 		if checksReadyToExit {
 			sctx.Log(checksSummary)
 			return &pipeline.StepOutcome{}, nil
@@ -346,30 +274,6 @@ func (s *BabysitStep) getCIChecks(ctx context.Context, workDir, prNumber string)
 		return nil, fmt.Errorf("parse CI checks: %w", err)
 	}
 	return checks, nil
-}
-
-// getNewComments fetches PR comments and returns only unseen ones.
-func (s *BabysitStep) getNewComments(ctx context.Context, workDir, prNumber string) ([]prComment, error) {
-	cmd := exec.CommandContext(ctx, "gh", "pr", "view", prNumber, "--json", "comments", "--jq", ".comments")
-	cmd.Dir = workDir
-	out, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("gh pr comments: %w", err)
-	}
-
-	var comments []prComment
-	if err := json.Unmarshal(out, &comments); err != nil {
-		return nil, fmt.Errorf("parse PR comments: %w", err)
-	}
-
-	// Filter to only new (unseen) comments
-	var newComments []prComment
-	for _, c := range comments {
-		if !s.seenComments[c.ID] {
-			newComments = append(newComments, c)
-		}
-	}
-	return newComments, nil
 }
 
 // autoFixCI runs the agent to fix CI failures, then commits and pushes.
@@ -449,111 +353,6 @@ CI logs:
 	}
 
 	return s.commitAndPush(sctx)
-}
-
-// addressComments runs the agent to address PR comments, then commits, pushes, and replies.
-func (s *BabysitStep) addressComments(sctx *pipeline.StepContext, prNumber string) error {
-	ctx := sctx.Ctx
-	baseSHA := resolveBranchBaseSHA(ctx, sctx.WorkDir, sctx.Run.BaseSHA, sctx.Repo.DefaultBranch)
-	selected := selectedFindingIDs(sctx.PreviousFindings)
-
-	// Build prompt from the selected comments that triggered the approval pause.
-	cmd := exec.CommandContext(ctx, "gh", "pr", "view", prNumber, "--json", "comments", "--jq", ".comments")
-	cmd.Dir = sctx.WorkDir
-	out, err := cmd.Output()
-	if err != nil {
-		return fmt.Errorf("fetch comments: %w", err)
-	}
-
-	var comments []prComment
-	if err := json.Unmarshal(out, &comments); err != nil {
-		return fmt.Errorf("parse PR comments: %w", err)
-	}
-
-	var commentText string
-	for _, c := range comments {
-		if !s.seenComments[c.ID] {
-			continue
-		}
-		if len(selected) > 0 && !selected[c.ID] {
-			continue
-		}
-		commentText += fmt.Sprintf("@%s:\n%s\n\n", c.Author.Login, c.Body)
-	}
-
-	if commentText == "" {
-		sctx.Log("no comments to address")
-		return nil
-	}
-
-	prompt := fmt.Sprintf(
-		`Address the following PR review comments by making the requested changes.
-
-Context:
-- branch: %s
-- base commit: %s
-- target commit: %s
-- PR number: %s
-
-		Rules:
-		- Make the minimal change needed.
-		- Do not refactor beyond what is needed.
-		- Do not add comments explaining your fixes.
-		- Verify any directly relevant commands before finishing.
-
-		Comments to address:
-		%s`,
-		sctx.Run.Branch,
-		baseSHA,
-		sctx.Run.HeadSHA,
-		prNumber,
-		commentText,
-	)
-
-	sctx.Log("running agent to address PR comments...")
-	_, err = sctx.Agent.Run(ctx, agent.RunOpts{
-		Prompt:  prompt,
-		CWD:     sctx.WorkDir,
-		OnChunk: sctx.Log,
-	})
-	if err != nil {
-		return fmt.Errorf("agent address comments: %w", err)
-	}
-
-	if err := s.commitAndPush(sctx); err != nil {
-		return err
-	}
-
-	// Reply to addressed comments (best-effort)
-	headSHA, err := git.HeadSHA(ctx, sctx.WorkDir)
-	if err != nil {
-		slog.Warn("failed to get head SHA for reply comment", "error", err)
-	}
-	if headSHA != "" {
-		replyCmd := exec.CommandContext(ctx, "gh", "pr", "comment", prNumber,
-			"--body", fmt.Sprintf("Addressed in %s", headSHA))
-		replyCmd.Dir = sctx.WorkDir
-		replyCmd.Run() // best-effort, don't fail on reply error
-	}
-
-	return nil
-}
-
-func selectedFindingIDs(raw string) map[string]bool {
-	if raw == "" {
-		return nil
-	}
-	findings, err := types.ParseFindingsJSON(raw)
-	if err != nil {
-		return nil
-	}
-	selected := make(map[string]bool, len(findings.Items))
-	for _, item := range findings.Items {
-		if item.ID != "" {
-			selected[item.ID] = true
-		}
-	}
-	return selected
 }
 
 // commitAndPush commits any uncommitted changes and force-pushes to upstream.

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -103,7 +103,6 @@ func fakeGlabHandler(args []string) {
 func fakeBabysitGHHandler(args []string) {
 	state := os.Getenv("FAKE_CLI_STATE")
 	checksJSON := os.Getenv("FAKE_CLI_CHECKS")
-	commentsJSON := os.Getenv("FAKE_CLI_COMMENTS")
 	joined := strings.Join(args, " ")
 
 	if len(args) >= 2 && args[0] == "auth" && args[1] == "status" {
@@ -115,13 +114,6 @@ func fakeBabysitGHHandler(args []string) {
 	}
 	if strings.Contains(joined, "pr checks") {
 		fmt.Println(checksJSON)
-		os.Exit(0)
-	}
-	if strings.Contains(joined, "pr view") && strings.Contains(joined, "--json comments") {
-		fmt.Println(commentsJSON)
-		os.Exit(0)
-	}
-	if strings.Contains(joined, "pr comment") {
 		os.Exit(0)
 	}
 	if strings.Contains(joined, "run view") {
@@ -143,10 +135,6 @@ func fakeBabysitGHNoChecksHandler(args []string) {
 	}
 	if strings.Contains(joined, "pr view") && strings.Contains(joined, "--json state") {
 		fmt.Println("OPEN")
-		os.Exit(0)
-	}
-	if strings.Contains(joined, "pr view") && strings.Contains(joined, "--json comments") {
-		fmt.Println("[]")
 		os.Exit(0)
 	}
 	os.Exit(1)
@@ -2257,58 +2245,6 @@ func TestFailingCheckNames(t *testing.T) {
 	}
 }
 
-func TestCommentsToFindings(t *testing.T) {
-	comments := []prComment{
-		{ID: "1", Body: "Please fix the null check"},
-		{ID: "2", Body: "LGTM"},
-	}
-	comments[0].Author.Login = "alice"
-	comments[1].Author.Login = "bob"
-
-	findings := commentsToFindings(comments)
-	if len(findings.Items) != 2 {
-		t.Fatalf("expected 2 findings, got %d", len(findings.Items))
-	}
-	if findings.Items[0].Severity != "info" {
-		t.Errorf("severity = %s, want info", findings.Items[0].Severity)
-	}
-	if !strings.Contains(findings.Items[0].Description, "@alice") {
-		t.Error("expected finding to contain @alice")
-	}
-	if !strings.Contains(findings.Items[0].Description, "null check") {
-		t.Error("expected finding to contain comment body")
-	}
-	if findings.Summary != "2 PR comment(s) to review" {
-		t.Errorf("summary = %q, want '2 PR comment(s) to review'", findings.Summary)
-	}
-}
-
-func TestTruncate(t *testing.T) {
-	tests := []struct {
-		name   string
-		input  string
-		maxLen int
-		want   string
-	}{
-		{"short", "hello", 10, "hello"},
-		{"exact", "hello", 5, "hello"},
-		{"long", "hello world", 8, "hello..."},
-		{"very short max", "hello", 3, "hel"},
-		{"empty", "", 5, ""},
-		// Multi-byte rune handling: truncate should count runes, not bytes
-		{"multibyte exact", "日本語AB", 5, "日本語AB"},
-		{"multibyte truncated", "日本語ABCD", 5, "日本..."},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := truncate(tt.input, tt.maxLen)
-			if got != tt.want {
-				t.Errorf("truncate(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestBabysitStep_NoPRURL(t *testing.T) {
 	dir := t.TempDir()
 	ag := &mockAgent{name: "test"}
@@ -2374,7 +2310,7 @@ func TestBabysitStep_ContextCancelled(t *testing.T) {
 func TestBabysitStep_TimeoutDoesNotSleepPastDeadline(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
-	binDir := fakeBabysitGH(t, "OPEN", "[]", "[]")
+	binDir := fakeBabysitGH(t, "OPEN", "[]")
 	prependPATH(t, binDir)
 
 	prURL := "https://github.com/test/repo/pull/42"
@@ -2578,23 +2514,6 @@ func TestCICheckJSON(t *testing.T) {
 	names := failingCheckNames(checks)
 	if len(names) != 1 || names[0] != "test" {
 		t.Errorf("failingCheckNames = %v, want [test]", names)
-	}
-}
-
-func TestPRCommentJSON(t *testing.T) {
-	input := `[{"id":"IC_123","author":{"login":"reviewer"},"body":"Please fix this","createdAt":"2026-01-01T00:00:00Z","url":"https://github.com/test/repo/pull/1#comment-123"}]`
-	var comments []prComment
-	if err := json.Unmarshal([]byte(input), &comments); err != nil {
-		t.Fatal(err)
-	}
-	if len(comments) != 1 {
-		t.Fatalf("expected 1 comment, got %d", len(comments))
-	}
-	if comments[0].Author.Login != "reviewer" {
-		t.Errorf("author = %s, want reviewer", comments[0].Author.Login)
-	}
-	if comments[0].Body != "Please fix this" {
-		t.Errorf("body = %s, want 'Please fix this'", comments[0].Body)
 	}
 }
 
@@ -3162,14 +3081,13 @@ func TestReviewStep_FixMode_RequiresPreviousFindings(t *testing.T) {
 
 // fakeBabysitGH creates a fake gh binary that responds to babysit-related
 // commands (pr view --json state, pr checks --json, pr view --json comments).
-func fakeBabysitGH(t *testing.T, state, checksJSON, commentsJSON string) string {
+func fakeBabysitGH(t *testing.T, state, checksJSON string) string {
 	t.Helper()
 	binDir := fakeCLIBinDir(t)
 	linkTestBinary(t, binDir, "gh")
 	t.Setenv("FAKE_CLI_MODE", "babysit-gh")
 	t.Setenv("FAKE_CLI_STATE", state)
 	t.Setenv("FAKE_CLI_CHECKS", checksJSON)
-	t.Setenv("FAKE_CLI_COMMENTS", commentsJSON)
 	return binDir
 }
 
@@ -3184,7 +3102,7 @@ func fakeBabysitGHNoChecks(t *testing.T) string {
 func TestBabysitStep_PRMergedExitsEarly(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
-	binDir := fakeBabysitGH(t, "MERGED", "[]", "[]")
+	binDir := fakeBabysitGH(t, "MERGED", "[]")
 	prependPATH(t, binDir)
 
 	prURL := "https://github.com/test/repo/pull/42"
@@ -3220,7 +3138,7 @@ func TestBabysitStep_PRMergedExitsEarly(t *testing.T) {
 func TestBabysitStep_PRClosedExitsEarly(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
-	binDir := fakeBabysitGH(t, "CLOSED", "[]", "[]")
+	binDir := fakeBabysitGH(t, "CLOSED", "[]")
 	prependPATH(t, binDir)
 
 	prURL := "https://github.com/test/repo/pull/42"
@@ -3292,7 +3210,7 @@ func TestBabysitStep_CIFailureAutoFix(t *testing.T) {
 	gitCmd(t, dir, "push", "origin", "feature")
 
 	checksJSON := `[{"name":"build","status":"COMPLETED","conclusion":"success"},{"name":"test","status":"COMPLETED","conclusion":"failure"}]`
-	binDir := fakeBabysitGH(t, "OPEN", checksJSON, "[]")
+	binDir := fakeBabysitGH(t, "OPEN", checksJSON)
 	prependPATH(t, binDir)
 
 	agentCalled := false
@@ -3361,69 +3279,11 @@ func TestBabysitStep_CIFailureAutoFix(t *testing.T) {
 	}
 }
 
-func TestBabysitStep_NewCommentsPausesForApproval(t *testing.T) {
-	dir, baseSHA, headSHA := setupGitRepo(t)
-
-	commentsJSON := `[{"id":"IC_100","author":{"login":"reviewer"},"body":"Please fix the naming","createdAt":"2026-01-01T00:00:00Z","url":"https://github.com/test/repo/pull/42#comment-100"}]`
-	binDir := fakeBabysitGH(t, "OPEN", "[]", commentsJSON)
-	prependPATH(t, binDir)
-
-	prURL := "https://github.com/test/repo/pull/42"
-	ag := &mockAgent{name: "test"}
-	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
-	sctx.Run.PRURL = &prURL
-	sctx.Config.BabysitTimeout = 10 * time.Second
-
-	var logs []string
-	sctx.Log = func(s string) { logs = append(logs, s) }
-
-	step := &BabysitStep{}
-	outcome, err := step.Execute(sctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !outcome.NeedsApproval {
-		t.Error("expected approval needed for new PR comments")
-	}
-	if outcome.Findings == "" {
-		t.Error("expected findings with comment details")
-	}
-
-	// Verify findings contain the comment
-	var findings Findings
-	if err := json.Unmarshal([]byte(outcome.Findings), &findings); err != nil {
-		t.Fatal(err)
-	}
-	if len(findings.Items) != 1 {
-		t.Fatalf("expected 1 finding, got %d", len(findings.Items))
-	}
-	if findings.Items[0].ID != "IC_100" {
-		t.Fatalf("expected comment ID to be used as finding ID, got %q", findings.Items[0].ID)
-	}
-	if !strings.Contains(findings.Items[0].Description, "reviewer") {
-		t.Errorf("expected reviewer in finding, got: %s", findings.Items[0].Description)
-	}
-	if !strings.Contains(findings.Items[0].Description, "naming") {
-		t.Errorf("expected comment body in finding, got: %s", findings.Items[0].Description)
-	}
-
-	foundCommentLog := false
-	for _, l := range logs {
-		if strings.Contains(l, "new PR comment") {
-			foundCommentLog = true
-			break
-		}
-	}
-	if !foundCommentLog {
-		t.Errorf("expected new comment log, got: %v", logs)
-	}
-}
-
 func TestBabysitStep_AllChecksPassingExitsCleanly(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	checksJSON := `[{"name":"build","state":"SUCCESS","bucket":"pass"},{"name":"test","state":"SUCCESS","bucket":"pass"}]`
-	binDir := fakeBabysitGH(t, "OPEN", checksJSON, "[]")
+	binDir := fakeBabysitGH(t, "OPEN", checksJSON)
 	prependPATH(t, binDir)
 
 	prURL := "https://github.com/test/repo/pull/42"
@@ -3460,7 +3320,7 @@ func TestBabysitStep_EmptyChecksWaitsDuringGracePeriod(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	// Fake gh returns OPEN state, empty checks, no comments
-	binDir := fakeBabysitGH(t, "OPEN", "[]", "[]")
+	binDir := fakeBabysitGH(t, "OPEN", "[]")
 	prependPATH(t, binDir)
 
 	prURL := "https://github.com/test/repo/pull/42"
@@ -3508,7 +3368,7 @@ func TestBabysitStep_NonEmptyPassingChecksExitImmediately(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	checksJSON := `[{"name":"build","state":"SUCCESS","bucket":"pass"}]`
-	binDir := fakeBabysitGH(t, "OPEN", checksJSON, "[]")
+	binDir := fakeBabysitGH(t, "OPEN", checksJSON)
 	prependPATH(t, binDir)
 
 	prURL := "https://github.com/test/repo/pull/42"
@@ -3543,168 +3403,6 @@ func TestBabysitStep_NonEmptyPassingChecksExitImmediately(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected 'all CI checks passed' log, got: %v", logs)
-	}
-}
-
-func TestBabysitStep_AddressCommentsInFixMode_OnlySelectedComments(t *testing.T) {
-	upstream := t.TempDir()
-	gitCmd(t, upstream, "init", "--bare")
-
-	dir := t.TempDir()
-	gitCmd(t, dir, "init")
-	gitCmd(t, dir, "config", "user.name", "test")
-	gitCmd(t, dir, "config", "user.email", "test@test.com")
-	gitCmd(t, dir, "checkout", "-b", "main")
-	os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644)
-	gitCmd(t, dir, "add", "-A")
-	gitCmd(t, dir, "commit", "-m", "initial")
-	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
-	gitCmd(t, dir, "remote", "add", "origin", upstream)
-	gitCmd(t, dir, "push", "origin", "main")
-
-	gitCmd(t, dir, "checkout", "-b", "feature")
-	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
-	gitCmd(t, dir, "add", "-A")
-	gitCmd(t, dir, "commit", "-m", "feature")
-	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
-	gitCmd(t, dir, "push", "origin", "feature")
-
-	commentsJSON := `[
-		{"id":"IC_200","author":{"login":"alice"},"body":"Rename this function","createdAt":"2026-01-01T00:00:00Z","url":"https://github.com/test/repo/pull/42#comment-200"},
-		{"id":"IC_201","author":{"login":"bob"},"body":"Add more tests","createdAt":"2026-01-01T00:00:01Z","url":"https://github.com/test/repo/pull/42#comment-201"}
-	]`
-	passingChecks := `[{"name":"build","state":"SUCCESS","bucket":"pass"}]`
-	binDir := fakeBabysitGH(t, "OPEN", passingChecks, commentsJSON)
-	prependPATH(t, binDir)
-
-	ag := &mockAgent{
-		name: "test",
-		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
-			os.WriteFile(filepath.Join(opts.CWD, "comment-fix.txt"), []byte("fixed"), 0o644)
-			if !strings.Contains(opts.Prompt, "Rename this function") {
-				t.Fatalf("expected selected comment in agent prompt, got: %s", opts.Prompt)
-			}
-			if strings.Contains(opts.Prompt, "Add more tests") {
-				t.Fatalf("did not expect unselected comment in agent prompt, got: %s", opts.Prompt)
-			}
-			return &agent.Result{}, nil
-		},
-	}
-
-	prURL := "https://github.com/test/repo/pull/42"
-	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
-	sctx.Run.PRURL = &prURL
-	sctx.Repo.UpstreamURL = upstream
-	sctx.Run.Branch = "refs/heads/feature"
-	sctx.Fixing = true
-	sctx.PreviousFindings = `{"findings":[{"id":"IC_200","severity":"info","description":"@alice: Rename this function"}],"summary":"1 PR comment(s) to review"}`
-	sctx.Config.BabysitTimeout = 30 * time.Second
-
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-	sctx.Ctx = ctx
-
-	step := &BabysitStep{
-		seenComments: map[string]bool{"IC_200": true, "IC_201": true},
-	}
-
-	outcome, err := step.Execute(sctx)
-	if err != nil {
-		t.Fatalf("expected clean exit after addressing comments, got: %v", err)
-	}
-	if outcome.NeedsApproval {
-		t.Fatal("expected no approval after selected comments are addressed")
-	}
-}
-
-func TestBabysitStep_AddressCommentsInFixMode(t *testing.T) {
-	// Set up upstream bare repo for push
-	upstream := t.TempDir()
-	gitCmd(t, upstream, "init", "--bare")
-
-	dir := t.TempDir()
-	gitCmd(t, dir, "init")
-	gitCmd(t, dir, "config", "user.name", "test")
-	gitCmd(t, dir, "config", "user.email", "test@test.com")
-	gitCmd(t, dir, "checkout", "-b", "main")
-	os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644)
-	gitCmd(t, dir, "add", "-A")
-	gitCmd(t, dir, "commit", "-m", "initial")
-	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
-	gitCmd(t, dir, "remote", "add", "origin", upstream)
-	gitCmd(t, dir, "push", "origin", "main")
-
-	gitCmd(t, dir, "checkout", "-b", "feature")
-	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
-	gitCmd(t, dir, "add", "-A")
-	gitCmd(t, dir, "commit", "-m", "feature")
-	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
-	gitCmd(t, dir, "push", "origin", "feature")
-
-	commentsJSON := `[{"id":"IC_200","author":{"login":"alice"},"body":"Rename this function","createdAt":"2026-01-01T00:00:00Z","url":"https://github.com/test/repo/pull/42#comment-200"}]`
-	passingChecks := `[{"name":"build","state":"SUCCESS","bucket":"pass"}]`
-	binDir := fakeBabysitGH(t, "OPEN", passingChecks, commentsJSON)
-	prependPATH(t, binDir)
-
-	agentCalled := false
-	ag := &mockAgent{
-		name: "test",
-		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
-			agentCalled = true
-			// Agent fixes by creating a file
-			os.WriteFile(filepath.Join(opts.CWD, "comment-fix.txt"), []byte("fixed"), 0o644)
-			return &agent.Result{}, nil
-		},
-	}
-
-	prURL := "https://github.com/test/repo/pull/42"
-	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
-	sctx.Run.PRURL = &prURL
-	sctx.Repo.UpstreamURL = upstream
-	sctx.Run.Branch = "refs/heads/feature"
-	sctx.Fixing = true
-	sctx.Config.BabysitTimeout = 30 * time.Second
-
-	// Use a context with short timeout: after addressing comments and entering
-	// the poll loop, the sleep will be interrupted by context deadline.
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-	sctx.Ctx = ctx
-
-	// Pre-populate seenComments to simulate comments from previous Execute
-	step := &BabysitStep{
-		seenComments: map[string]bool{"IC_200": true},
-	}
-
-	var logs []string
-	sctx.Log = func(s string) { logs = append(logs, s) }
-
-	outcome, err := step.Execute(sctx)
-	if err != nil {
-		t.Fatalf("expected clean exit after addressing comments, got: %v", err)
-	}
-	if outcome.NeedsApproval {
-		t.Fatal("expected no approval after addressed comments and clean CI")
-	}
-	if !agentCalled {
-		t.Error("expected agent to be called for comment addressing")
-	}
-
-	// Verify agent prompt includes the comment text
-	if len(ag.calls) == 0 {
-		t.Fatal("expected agent call")
-	}
-	if !strings.Contains(ag.calls[0].Prompt, "Rename this function") {
-		t.Errorf("expected comment body in agent prompt, got: %s", ag.calls[0].Prompt)
-	}
-	if !strings.Contains(ag.calls[0].Prompt, "Make the minimal change needed") {
-		t.Error("expected comment-fix prompt to require minimal changes")
-	}
-	if !strings.Contains(ag.calls[0].Prompt, "Do not refactor beyond what is needed") {
-		t.Error("expected comment-fix prompt to forbid broader refactors")
-	}
-	if !strings.Contains(ag.calls[0].Prompt, "Do not add comments explaining your fixes") {
-		t.Error("expected comment-fix prompt to forbid explanatory comments")
 	}
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -243,12 +243,7 @@ func (m Model) View() string {
 			cursor = m.findingCursor[step.StepName]
 			selected = m.findingSelections[step.StepName]
 		}
-		status := babysitStepStatus(m.steps)
-		if contentBudget >= 0 && (status == types.StepStatusAwaitingApproval || status == types.StepStatusFixReview) {
-			appendExtraSection(renderBabysitApprovalViewForHeight(m.run, m.steps, findings, m.logs, rightWidth, contentBudget, cursor, selected))
-		} else {
-			appendExtraSection(renderBabysitViewWithSelection(m.run, m.steps, findings, m.logs, rightWidth, m.height, cursor, selected))
-		}
+		appendExtraSection(renderBabysitViewWithSelection(m.run, m.steps, findings, m.logs, rightWidth, m.height, cursor, selected))
 	} else if !m.showHelp {
 		if step := awaitingStep(m.steps); step != nil {
 			// Generic findings or diff for non-babysit steps awaiting approval.

--- a/internal/tui/babysit.go
+++ b/internal/tui/babysit.go
@@ -9,14 +9,12 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
-// isBabysitActive returns true if the babysit step is currently active
-// (running, fixing, or awaiting approval).
+// isBabysitActive returns true if the babysit step is currently running.
 func isBabysitActive(steps []ipc.StepResultInfo) bool {
 	for _, s := range steps {
 		if s.StepName == types.StepBabysit {
 			switch s.Status {
-			case types.StepStatusRunning, types.StepStatusFixing,
-				types.StepStatusAwaitingApproval, types.StepStatusFixReview:
+			case types.StepStatusRunning:
 				return true
 			}
 		}
@@ -77,8 +75,6 @@ func parseBabysitActivity(logs []string) babysitActivity {
 			a.LastEvent = line
 		case strings.Contains(line, "babysitting PR"):
 			a.LastEvent = line
-		case strings.Contains(line, "comment"):
-			a.LastEvent = line
 		case strings.Contains(line, "PR has been merged"):
 			a.LastEvent = line
 		case strings.Contains(line, "PR has been closed"):
@@ -130,14 +126,8 @@ func renderBabysitViewWithSelection(run *ipc.RunInfo, steps []ipc.StepResultInfo
 			b.WriteString(style.Render("\u2699 Auto-fixing CI failures...") + "\n")
 		} else {
 			style := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiGreen))
-			b.WriteString(style.Render("◉ Monitoring CI and PR comments...") + "\n")
+			b.WriteString(style.Render("◉ Monitoring CI checks...") + "\n")
 		}
-	case types.StepStatusFixing:
-		style := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBlue))
-		b.WriteString(style.Render("⚙ Agent addressing PR comments...") + "\n")
-	case types.StepStatusAwaitingApproval, types.StepStatusFixReview:
-		style := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiYellow))
-		b.WriteString(style.Render("⏸ New PR comments - review below") + "\n")
 	}
 
 	// CI auto-fix count.
@@ -152,9 +142,8 @@ func renderBabysitViewWithSelection(run *ipc.RunInfo, steps []ipc.StepResultInfo
 		b.WriteString(dimStyle.Render(eventText) + "\n")
 	}
 
-	// Log tail during monitoring (non-approval) states.
+	// Log tail during monitoring.
 	// Adaptive line count: 5 for height >= 30, 3 for 20-29, hidden for < 20.
-	isApproval := status == types.StepStatusAwaitingApproval || status == types.StepStatusFixReview
 	logLines := 5
 	if height > 0 && height < 30 {
 		logLines = 3
@@ -163,112 +152,13 @@ func renderBabysitViewWithSelection(run *ipc.RunInfo, steps []ipc.StepResultInfo
 		logLines = 0
 	}
 
-	if !isApproval && len(logs) > 0 && logLines > 0 {
+	if len(logs) > 0 && logLines > 0 {
 		b.WriteString("\n")
 		for _, line := range renderLogTail(logs, contentWidth, logLines) {
 			b.WriteString(line + "\n")
 		}
 	}
-	var itemCount int
-	if isApproval && findings != "" {
-		if f, err := parseFindings(findings); err == nil && f != nil {
-			itemCount = len(f.Items)
-		}
-		// Compute viewport size from available height.
-		// Reserve ~10 lines for babysit header content (PR info, state, activity, box border).
-		maxVisible := 0
-		if height > 0 {
-			findingsHeight := height - 25 // reserve for pipeline, babysit header, box borders, footer
-			if findingsHeight > 6 {
-				maxVisible = findingsHeight / 3 // ~3 lines per finding
-			}
-		}
-		rendered, scrollFooter := renderFindingsWithSelection(findings, contentWidth, cursor, selected, maxVisible)
-		if rendered != "" {
-			b.WriteString("\n")
-			b.WriteString(rendered)
-			// Babysit findings are nested inside the babysit box, so inline the scroll footer.
-			if scrollFooter != "" {
-				dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
-				b.WriteString("\n")
-				b.WriteString(dimStyle.Render(scrollFooter))
-				b.WriteString("\n")
-			}
-		}
-	}
 
-	title := "Babysit"
-	if itemCount > 0 {
-		title += fmt.Sprintf(" (%d/%d)", cursor+1, itemCount)
-	}
-	return renderBox(title, b.String(), boxWidth)
+	return renderBox("Babysit", b.String(), boxWidth)
 }
 
-func renderBabysitApprovalViewForHeight(run *ipc.RunInfo, steps []ipc.StepResultInfo, findings string, logs []string, width int, boxHeight int, cursor int, selected map[string]bool) string {
-	if boxHeight > 0 && boxHeight < 3 {
-		return ""
-	}
-	if boxHeight <= 0 {
-		return renderBabysitViewWithSelection(run, steps, findings, logs, width, 0, cursor, selected)
-	}
-
-	boxWidth := width
-	if boxWidth < 20 {
-		boxWidth = 80
-	}
-	contentWidth := boxWidth - 4
-	contentBudget := boxHeight - 2
-	if contentBudget <= 0 {
-		return ""
-	}
-
-	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
-	activity := parseBabysitActivity(logs)
-
-	var lines []string
-	if run != nil && run.PRURL != nil && *run.PRURL != "" {
-		prText := "PR: " + *run.PRURL
-		prText, _ = cutText(prText, contentWidth)
-		lines = append(lines, dimStyle.Render(prText))
-	} else if num := extractPRFromLogs(logs); num != "" {
-		lines = append(lines, dimStyle.Render("PR #"+num))
-	}
-	lines = append(lines, "")
-	statusStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiYellow))
-	lines = append(lines, statusStyle.Render("⏸ New PR comments - review below"))
-	if activity.CIFixes > 0 {
-		lines = append(lines, dimStyle.Render(fmt.Sprintf("CI auto-fixes: %d", activity.CIFixes)))
-	}
-	if activity.LastEvent != "" {
-		eventText := "Latest: " + activity.LastEvent
-		eventText, _ = cutText(eventText, contentWidth)
-		lines = append(lines, dimStyle.Render(eventText))
-	}
-
-	header := strings.Join(lines, "\n")
-	remaining := contentBudget - lipgloss.Height(header)
-	content := header
-
-	itemCount := 0
-	if f, err := parseFindings(findings); err == nil && f != nil {
-		itemCount = len(f.Items)
-	}
-	if findings != "" && remaining > 1 {
-		rendered, scrollFooter := renderFindingsWithSelectionHeight(findings, contentWidth, cursor, selected, remaining-1)
-		if scrollFooter != "" && remaining > 2 {
-			rendered, scrollFooter = renderFindingsWithSelectionHeight(findings, contentWidth, cursor, selected, remaining-2)
-		}
-		if rendered != "" {
-			content += "\n" + rendered
-			if scrollFooter != "" {
-				content += "\n" + dimStyle.Render(scrollFooter)
-			}
-		}
-	}
-
-	title := "Babysit"
-	if itemCount > 0 {
-		title += fmt.Sprintf(" (%d/%d)", cursor+1, itemCount)
-	}
-	return renderBox(title, content, boxWidth)
-}

--- a/internal/tui/babysit.go
+++ b/internal/tui/babysit.go
@@ -161,4 +161,3 @@ func renderBabysitViewWithSelection(run *ipc.RunInfo, steps []ipc.StepResultInfo
 
 	return renderBox("Babysit", b.String(), boxWidth)
 }
-

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1506,24 +1506,6 @@ func TestIsBabysitActive(t *testing.T) {
 		t.Error("expected true when babysit is running")
 	}
 
-	// Fixing → active.
-	run.Steps[5].Status = types.StepStatusFixing
-	if !isBabysitActive(run.Steps) {
-		t.Error("expected true when babysit is fixing")
-	}
-
-	// Awaiting approval → active.
-	run.Steps[5].Status = types.StepStatusAwaitingApproval
-	if !isBabysitActive(run.Steps) {
-		t.Error("expected true when babysit is awaiting approval")
-	}
-
-	// Fix review → active.
-	run.Steps[5].Status = types.StepStatusFixReview
-	if !isBabysitActive(run.Steps) {
-		t.Error("expected true when babysit is in fix review")
-	}
-
 	// Completed → not active.
 	run.Steps[5].Status = types.StepStatusCompleted
 	if isBabysitActive(run.Steps) {
@@ -1722,46 +1704,6 @@ func TestRenderBabysitView_AutoFixing(t *testing.T) {
 	}
 }
 
-func TestRenderBabysitView_FixingComments(t *testing.T) {
-	run := testRunWithBabysit()
-	run.Steps[5].Status = types.StepStatusFixing
-
-	out := renderBabysitView(run, run.Steps, "", nil, 80)
-
-	if !strings.Contains(out, "addressing PR comments") {
-		t.Error("expected addressing comments state")
-	}
-}
-
-func TestRenderBabysitView_AwaitingWithFindings(t *testing.T) {
-	run := testRunWithBabysit()
-	run.Steps[5].Status = types.StepStatusAwaitingApproval
-	findings := `{"findings":[{"severity":"info","description":"@alice: Please add more tests"}],"summary":"1 PR comment(s) to review"}`
-
-	out := renderBabysitView(run, run.Steps, findings, nil, 80)
-
-	if !strings.Contains(out, "review below") {
-		t.Error("expected review prompt")
-	}
-	if !strings.Contains(out, "1 PR comment(s) to review") {
-		t.Error("expected findings summary")
-	}
-	if !strings.Contains(out, "Please add more tests") {
-		t.Error("expected comment content in findings")
-	}
-}
-
-func TestRenderBabysitView_AwaitingNoFindings(t *testing.T) {
-	run := testRunWithBabysit()
-	run.Steps[5].Status = types.StepStatusAwaitingApproval
-
-	out := renderBabysitView(run, run.Steps, "", nil, 80)
-
-	if !strings.Contains(out, "review below") {
-		t.Error("expected review prompt even without findings")
-	}
-}
-
 func TestRenderBabysitView_LastActivity(t *testing.T) {
 	run := testRunWithBabysit()
 	run.Steps[5].Status = types.StepStatusRunning
@@ -1794,23 +1736,6 @@ func TestModel_View_BabysitViewWhenActive(t *testing.T) {
 	}
 	if !strings.Contains(view, "Monitoring") {
 		t.Error("expected monitoring state in model output")
-	}
-}
-
-func TestModel_View_BabysitAwaitingShowsFindings(t *testing.T) {
-	run := testRunWithBabysit()
-	m := NewModel("/tmp/sock", nil, run)
-	m.steps = run.Steps
-	m.steps[5].Status = types.StepStatusAwaitingApproval
-	m.stepFindings[types.StepBabysit] = `{"findings":[{"severity":"info","description":"@bob: fix the typo"}],"summary":"1 comment"}`
-
-	view := m.View()
-
-	if !strings.Contains(stripANSI(view), "Babysit") {
-		t.Error("expected babysit box title")
-	}
-	if !strings.Contains(view, "fix the typo") {
-		t.Error("expected comment finding in babysit view")
 	}
 }
 
@@ -2908,23 +2833,6 @@ func TestDiffBoxTitle_NoPositionWhenAllVisible(t *testing.T) {
 
 // --- Babysit box title position indicator tests ---
 
-func TestRenderBabysitView_TitleShowsPositionWhenFindings(t *testing.T) {
-	lipgloss.SetColorProfile(termenv.ANSI)
-	run := testRunWithBabysit()
-	run.Steps[5].Status = types.StepStatusAwaitingApproval
-	findings := `{"findings":[
-		{"id":"f1","severity":"info","description":"comment 1"},
-		{"id":"f2","severity":"info","description":"comment 2"},
-		{"id":"f3","severity":"info","description":"comment 3"}
-	],"summary":"3 comments"}`
-
-	out := stripANSI(renderBabysitViewWithSelection(run, run.Steps, findings, nil, 80, 0, 1, nil))
-
-	if !strings.Contains(out, "Babysit (2/3)") {
-		t.Errorf("expected position indicator 'Babysit (2/3)' in title, got:\n%s", out)
-	}
-}
-
 func TestRenderBabysitView_TitleNoPositionWithoutFindings(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.ANSI)
 	run := testRunWithBabysit()
@@ -2941,59 +2849,6 @@ func TestRenderBabysitView_TitleNoPositionWithoutFindings(t *testing.T) {
 	}
 	if strings.Contains(titleLine, "(") {
 		t.Errorf("expected no position indicator when no findings, got: %s", titleLine)
-	}
-}
-
-func TestRenderBabysitView_PositionUpdatesWithCursor(t *testing.T) {
-	lipgloss.SetColorProfile(termenv.ANSI)
-	run := testRunWithBabysit()
-	run.Steps[5].Status = types.StepStatusAwaitingApproval
-	findings := `{"findings":[
-		{"id":"f1","severity":"info","description":"c1"},
-		{"id":"f2","severity":"info","description":"c2"},
-		{"id":"f3","severity":"info","description":"c3"},
-		{"id":"f4","severity":"info","description":"c4"},
-		{"id":"f5","severity":"info","description":"c5"}
-	],"summary":"5 comments"}`
-
-	// Cursor at start.
-	out1 := stripANSI(renderBabysitViewWithSelection(run, run.Steps, findings, nil, 80, 0, 0, nil))
-	if !strings.Contains(out1, "Babysit (1/5)") {
-		t.Errorf("expected 'Babysit (1/5)' at start, got:\n%s", out1)
-	}
-
-	// Cursor at end.
-	out2 := stripANSI(renderBabysitViewWithSelection(run, run.Steps, findings, nil, 80, 0, 4, nil))
-	if !strings.Contains(out2, "Babysit (5/5)") {
-		t.Errorf("expected 'Babysit (5/5)' at end, got:\n%s", out2)
-	}
-}
-
-func TestModel_View_BabysitFindingsViewportApplied(t *testing.T) {
-	lipgloss.SetColorProfile(termenv.ANSI)
-	run := testRunWithBabysit()
-	m := NewModel("/tmp/sock", nil, run)
-	m.steps = run.Steps
-	m.steps[5].Status = types.StepStatusAwaitingApproval
-
-	// Create 10 findings.
-	var items []string
-	for i := 1; i <= 10; i++ {
-		items = append(items, fmt.Sprintf(`{"id":"f%d","severity":"info","description":"comment %d"}`, i, i))
-	}
-	m.stepFindings[types.StepBabysit] = `{"findings":[` + strings.Join(items, ",") + `],"summary":"10 comments"}`
-	m.resetFindingSelection(types.StepBabysit)
-
-	// Set a terminal height that forces viewport (height - 25 reserve = 15, /3 = 5 max visible).
-	m.width = 80
-	m.height = 40
-
-	view := stripANSI(m.View())
-
-	// With height=30, not all 10 findings should be visible.
-	// Verify scroll indicators appear.
-	if !strings.Contains(view, "more below") {
-		t.Errorf("expected '↓ N more below' scroll indicator when findings overflow viewport, got:\n%s", view)
 	}
 }
 
@@ -3015,29 +2870,6 @@ func TestRenderBabysitView_LogTailDuringMonitoring(t *testing.T) {
 	}
 	if !strings.Contains(out, "all checks passing") {
 		t.Errorf("expected log tail line 'all checks passing' inside babysit box, got:\n%s", out)
-	}
-}
-
-func TestRenderBabysitView_NoLogTailDuringApproval(t *testing.T) {
-	lipgloss.SetColorProfile(termenv.ANSI)
-	run := testRunWithBabysit()
-	run.Steps[5].Status = types.StepStatusAwaitingApproval
-	logs := []string{
-		"babysitting PR #42 (timeout: 4h)...",
-		"polling CI status...",
-		"all checks passing",
-	}
-	findings := `{"findings":[{"severity":"info","description":"@bob: fix the typo"}],"summary":"1 comment"}`
-
-	out := stripANSI(renderBabysitViewWithSelection(run, run.Steps, findings, logs, 80, 0, 0, nil))
-
-	// During approval, log tail should NOT appear - findings take priority.
-	if strings.Contains(out, "polling CI status") {
-		t.Error("expected no log tail lines inside babysit box during approval state")
-	}
-	// But findings should still show.
-	if !strings.Contains(out, "fix the typo") {
-		t.Error("expected findings to still show during approval")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Remove all PR comment detection, display, and auto-addressing logic from the babysit pipeline step
- Strip the comment-related approval/fix-mode TUI rendering paths (approval view, finding selection for comments, "Agent addressing PR comments" states)
- Simplify the babysit TUI to only monitor CI checks and auto-fix CI failures
- Remove ~800 lines of dead code and associated tests

## Test plan

- [ ] `go test -race ./internal/pipeline/steps/...` passes with updated `fakeBabysitGH` signature (no `commentsJSON` param)
- [ ] `go test -race ./internal/tui/...` passes after removing comment-related TUI tests
- [ ] `go vet ./...` and `gofmt -l .` clean
- [ ] Full suite: `go test -race ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)