### PR TITLE
fix(tui): preserve help and action bar space with responsive logs

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -287,10 +287,14 @@ func (m Model) View() string {
 	}
 
 	// Log tail in a box - adaptive line count based on terminal height.
-	// height >= 30: 5 lines, height 20-29: 3 lines, height < 20: hidden.
+	// In responsive layout with no other right-column content, expand to
+	// fill the remaining vertical budget so the log panel matches the
+	// pipeline panel height. Otherwise use compact defaults.
 	// Also hidden when babysit is active (log context integrated into babysit box).
 	logLines := 5
-	if m.height > 0 && m.height < 30 {
+	if useResponsiveLayout && contentBudget > 0 && len(extraSections) == 0 {
+		logLines = contentBudget - 2 // subtract box borders
+	} else if m.height > 0 && m.height < 30 {
 		logLines = 3
 	}
 	if m.height > 0 && m.height < 20 {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -294,6 +294,9 @@ func (m Model) View() string {
 	logLines := 5
 	if useResponsiveLayout && !m.showHelp && contentBudget > 0 && len(extraSections) == 0 {
 		logLines = contentBudget - 2 // subtract box borders
+		if actionBar != "" {
+			logLines -= sectionGapHeight
+		}
 	} else if m.height > 0 && m.height < 30 {
 		logLines = 3
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -292,7 +292,7 @@ func (m Model) View() string {
 	// pipeline panel height. Otherwise use compact defaults.
 	// Also hidden when babysit is active (log context integrated into babysit box).
 	logLines := 5
-	if useResponsiveLayout && contentBudget > 0 && len(extraSections) == 0 {
+	if useResponsiveLayout && !m.showHelp && contentBudget > 0 && len(extraSections) == 0 {
 		logLines = contentBudget - 2 // subtract box borders
 	} else if m.height > 0 && m.height < 30 {
 		logLines = 3

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -6944,3 +6944,68 @@ func TestHelpOverlay_SelectionDescriptionsAligned(t *testing.T) {
 		}
 	}
 }
+
+func TestModel_View_LogBoxExpandsToFillRightColumn(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.Ascii)
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusRunning
+	m := NewModel("/tmp/sock", nil, run)
+	m.width = 140
+	m.height = 40
+
+	// Add many log lines so the log box has room to expand.
+	for i := 0; i < 20; i++ {
+		m.logs = append(m.logs, fmt.Sprintf("log line %d", i))
+	}
+
+	view := m.View()
+	plain := stripANSI(view)
+
+	// Count log content lines inside the Log box (lines containing "log line").
+	logContentLines := 0
+	for _, line := range strings.Split(plain, "\n") {
+		if strings.Contains(line, "log line") {
+			logContentLines++
+		}
+	}
+
+	// With height=40, the log box should expand well beyond the old 5-line cap.
+	if logContentLines <= 5 {
+		t.Errorf("expected log box to expand beyond 5 lines in responsive layout, got %d content lines\nview:\n%s",
+			logContentLines, plain)
+	}
+}
+
+func TestModel_View_LogBoxStaysSmallWhenFindingsPresent(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.Ascii)
+	findings := `{"findings":[{"severity":"error","description":"test finding","id":"f1","file":"foo.go","line":1}],"summary":"1 issue"}`
+	run := &ipc.RunInfo{
+		ID: "run-001", RepoID: "repo-001", Branch: "main", HeadSHA: "abc12345",
+		BaseSHA: "000000", Status: types.RunRunning,
+		Steps: []ipc.StepResultInfo{
+			{ID: "s1", StepName: types.StepReview, StepOrder: 1, Status: types.StepStatusAwaitingApproval, FindingsJSON: &findings},
+			{ID: "s2", StepName: types.StepTest, StepOrder: 2, Status: types.StepStatusPending},
+		},
+	}
+	m := NewModel("/tmp/sock", nil, run)
+	m.width = 140
+	m.height = 40
+	for i := 0; i < 20; i++ {
+		m.logs = append(m.logs, fmt.Sprintf("log line %d", i))
+	}
+
+	view := m.View()
+	plain := stripANSI(view)
+
+	// When findings are present, the log box should stay small (<=5 lines).
+	logContentLines := 0
+	for _, line := range strings.Split(plain, "\n") {
+		if strings.Contains(line, "log line") {
+			logContentLines++
+		}
+	}
+	if logContentLines > 5 {
+		t.Errorf("expected log box to stay <=5 lines when findings present, got %d\nview:\n%s",
+			logContentLines, plain)
+	}
+}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -4068,7 +4068,7 @@ func TestModel_View_ShortTerminalDoesNotOverflowHeight(t *testing.T) {
 
 	m := NewModel("/tmp/sock", nil, run)
 	m.width = 80
-	m.height = 20
+	m.height = 18
 	view := stripANSI(m.View())
 
 	if got := lipgloss.Height(view); got > m.height {
@@ -6862,8 +6862,10 @@ func TestModel_View_OneBlankLineBetweenLogAndHelp(t *testing.T) {
 }
 
 func TestModel_View_ResponsiveLayoutKeepsHelpVisibleWithLogs(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	defer lipgloss.SetColorProfile(prev)
+
 	lipgloss.SetColorProfile(termenv.Ascii)
-	defer lipgloss.SetColorProfile(termenv.ANSI)
 
 	run := &ipc.RunInfo{
 		ID: "run-001", RepoID: "repo-001", Branch: "main", HeadSHA: "abc12345",
@@ -6892,8 +6894,10 @@ func TestModel_View_ResponsiveLayoutKeepsHelpVisibleWithLogs(t *testing.T) {
 }
 
 func TestModel_View_ResponsiveLayoutReservesGapBeforeLogBox(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	defer lipgloss.SetColorProfile(prev)
+
 	lipgloss.SetColorProfile(termenv.Ascii)
-	defer lipgloss.SetColorProfile(termenv.ANSI)
 
 	run := &ipc.RunInfo{
 		ID: "run-001", RepoID: "repo-001", Branch: "main", HeadSHA: "abc12345",

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -7016,6 +7016,9 @@ func TestHelpOverlay_SelectionDescriptionsAligned(t *testing.T) {
 }
 
 func TestModel_View_LogBoxExpandsToFillRightColumn(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	defer lipgloss.SetColorProfile(prev)
+
 	lipgloss.SetColorProfile(termenv.Ascii)
 	run := testRun()
 	run.Steps[0].Status = types.StepStatusRunning
@@ -7047,6 +7050,9 @@ func TestModel_View_LogBoxExpandsToFillRightColumn(t *testing.T) {
 }
 
 func TestModel_View_LogBoxStaysSmallWhenFindingsPresent(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	defer lipgloss.SetColorProfile(prev)
+
 	lipgloss.SetColorProfile(termenv.Ascii)
 	findings := `{"findings":[{"severity":"error","description":"test finding","id":"f1","file":"foo.go","line":1}],"summary":"1 issue"}`
 	run := &ipc.RunInfo{

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -6861,6 +6861,36 @@ func TestModel_View_OneBlankLineBetweenLogAndHelp(t *testing.T) {
 	}
 }
 
+func TestModel_View_ResponsiveLayoutKeepsHelpVisibleWithLogs(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.Ascii)
+	defer lipgloss.SetColorProfile(termenv.ANSI)
+
+	run := &ipc.RunInfo{
+		ID: "run-001", RepoID: "repo-001", Branch: "main", HeadSHA: "abc12345",
+		BaseSHA: "000000", Status: types.RunRunning,
+		Steps: []ipc.StepResultInfo{
+			{ID: "s1", StepName: types.StepReview, StepOrder: 1, Status: types.StepStatusRunning},
+		},
+	}
+	m := NewModel("/tmp/sock", nil, run)
+	m.width = 120
+	m.height = 40
+	m.logs = make([]string, 40)
+	for i := range m.logs {
+		m.logs[i] = fmt.Sprintf("log line %02d", i)
+	}
+	m.showHelp = true
+
+	view := stripANSI(m.View())
+
+	if !strings.Contains(view, "Help") {
+		t.Fatalf("expected help overlay to remain visible in responsive layout with logs, got:\n%s", view)
+	}
+	if !strings.Contains(view, "close help") {
+		t.Fatalf("expected help overlay content in responsive layout with logs, got:\n%s", view)
+	}
+}
+
 // Test: footer should have consistent spacing (1 blank line) after any preceding section.
 func TestModel_View_ConsistentFooterSpacing(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.Ascii)

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -4068,7 +4068,7 @@ func TestModel_View_ShortTerminalDoesNotOverflowHeight(t *testing.T) {
 
 	m := NewModel("/tmp/sock", nil, run)
 	m.width = 80
-	m.height = 18
+	m.height = 20
 	view := stripANSI(m.View())
 
 	if got := lipgloss.Height(view); got > m.height {
@@ -6888,6 +6888,46 @@ func TestModel_View_ResponsiveLayoutKeepsHelpVisibleWithLogs(t *testing.T) {
 	}
 	if !strings.Contains(view, "close help") {
 		t.Fatalf("expected help overlay content in responsive layout with logs, got:\n%s", view)
+	}
+}
+
+func TestModel_View_ResponsiveLayoutReservesGapBeforeLogBox(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.Ascii)
+	defer lipgloss.SetColorProfile(termenv.ANSI)
+
+	run := &ipc.RunInfo{
+		ID: "run-001", RepoID: "repo-001", Branch: "main", HeadSHA: "abc12345",
+		BaseSHA: "000000", Status: types.RunRunning,
+		Steps: []ipc.StepResultInfo{
+			{ID: "s1", StepName: types.StepReview, StepOrder: 1, Status: types.StepStatusAwaitingApproval},
+		},
+	}
+	m := NewModel("/tmp/sock", nil, run)
+	m.width = 120
+	m.height = 20
+	m.logs = make([]string, 40)
+	for i := range m.logs {
+		m.logs[i] = fmt.Sprintf("log line %02d", i)
+	}
+
+	view := stripANSI(m.View())
+	if !strings.Contains(view, "q detach") {
+		t.Fatalf("expected footer to remain visible, got:\n%s", view)
+	}
+	if !strings.Contains(view, "approve") {
+		t.Fatalf("expected action bar to remain visible, got:\n%s", view)
+	}
+	if !strings.Contains(view, "Log") {
+		t.Fatalf("expected log box to remain visible, got:\n%s", view)
+	}
+	if strings.Contains(view, "log line 26") {
+		t.Fatalf("expected responsive log box to reserve one line for the action-bar separator, got:\n%s", view)
+	}
+	if !strings.Contains(view, "log line 27") {
+		t.Fatalf("expected responsive log box to keep the newest lines after reserving the separator, got:\n%s", view)
+	}
+	if !hasParallelBoxRow(view) {
+		t.Fatalf("expected responsive layout with side-by-side columns, got:\n%s", view)
 	}
 }
 


### PR DESCRIPTION
## Summary
- adjust TUI log box height handling so responsive logs keep the help text visible and reserve space for the action bar
- add and tighten TUI coverage around log height boundaries, test isolation, and lipgloss color profile handling

## Testing
- added and updated `internal/tui/tui_test.go` coverage for responsive log height behavior and TUI test isolation