### PR TITLE
fix(opencode): correct text streaming for review snapshots

### DIFF
--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -414,14 +414,19 @@ func parseOpencodeSSE(r io.Reader, state *opencodeStreamState) error {
 						phase = p.Metadata.OpenAI.Phase
 					}
 					existing := state.textParts[p.ID]
+					chunk := p.Text
 					if existing != nil {
+						if strings.HasPrefix(p.Text, existing.text) {
+							chunk = p.Text[len(existing.text):]
+						}
+						existing.text = p.Text
 						existing.phase = phase
 					} else {
 						state.textParts[p.ID] = &opencodeTextPart{text: p.Text, phase: phase}
 					}
 					state.updateText(p.Text, phase)
-					if state.onChunk != nil && p.Text != "" {
-						state.onChunk(p.Text)
+					if state.onChunk != nil && chunk != "" {
+						state.onChunk(chunk)
 					}
 				}
 				if p.Type == "step-finish" && p.MessageID != "" && p.Tokens != nil {

--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -418,6 +418,8 @@ func parseOpencodeSSE(r io.Reader, state *opencodeStreamState) error {
 					if existing != nil {
 						if strings.HasPrefix(p.Text, existing.text) {
 							chunk = p.Text[len(existing.text):]
+						} else if p.Text != existing.text {
+							chunk = p.Text
 						}
 						existing.text = p.Text
 						existing.phase = phase

--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -401,9 +401,7 @@ func parseOpencodeSSE(r io.Reader, state *opencodeStreamState) error {
 				part.text += props.Delta
 				state.updateText(part.text, part.phase)
 				if state.onChunk != nil {
-					if d := strings.TrimSpace(props.Delta); d != "" {
-						state.onChunk(d)
-					}
+					state.onChunk(props.Delta)
 				}
 			}
 
@@ -422,6 +420,9 @@ func parseOpencodeSSE(r io.Reader, state *opencodeStreamState) error {
 						state.textParts[p.ID] = &opencodeTextPart{text: p.Text, phase: phase}
 					}
 					state.updateText(p.Text, phase)
+					if state.onChunk != nil && p.Text != "" {
+						state.onChunk(p.Text)
+					}
 				}
 				if p.Type == "step-finish" && p.MessageID != "" && p.Tokens != nil {
 					state.usageByMsg[p.MessageID] = opencodeTokensToUsage(p.Tokens)

--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -399,7 +399,12 @@ func parseOpencodeSSE(r io.Reader, state *opencodeStreamState) error {
 					state.textParts[props.PartID] = part
 				}
 				part.text += props.Delta
-				state.emitText(props.PartID, part.text, part.phase)
+				state.updateText(part.text, part.phase)
+				if state.onChunk != nil {
+					if d := strings.TrimSpace(props.Delta); d != "" {
+						state.onChunk(d)
+					}
+				}
 			}
 
 		case "message.part.updated":
@@ -416,7 +421,7 @@ func parseOpencodeSSE(r io.Reader, state *opencodeStreamState) error {
 					} else {
 						state.textParts[p.ID] = &opencodeTextPart{text: p.Text, phase: phase}
 					}
-					state.emitText(p.ID, p.Text, phase)
+					state.updateText(p.Text, phase)
 				}
 				if p.Type == "step-finish" && p.MessageID != "" && p.Tokens != nil {
 					state.usageByMsg[p.MessageID] = opencodeTokensToUsage(p.Tokens)
@@ -448,7 +453,7 @@ func parseOpencodeSSE(r io.Reader, state *opencodeStreamState) error {
 	return nil
 }
 
-func (s *opencodeStreamState) emitText(partID, text, phase string) {
+func (s *opencodeStreamState) updateText(text, phase string) {
 	trimmed := strings.TrimSpace(text)
 	if trimmed == "" {
 		return
@@ -456,8 +461,5 @@ func (s *opencodeStreamState) emitText(partID, text, phase string) {
 	s.lastText = text
 	if phase == "final_answer" {
 		s.lastFinalText = text
-	}
-	if s.onChunk != nil {
-		s.onChunk(trimmed)
 	}
 }

--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -414,7 +414,7 @@ func parseOpencodeSSE(r io.Reader, state *opencodeStreamState) error {
 						phase = p.Metadata.OpenAI.Phase
 					}
 					existing := state.textParts[p.ID]
-					chunk := p.Text
+					chunk := ""
 					if existing != nil {
 						if strings.HasPrefix(p.Text, existing.text) {
 							chunk = p.Text[len(existing.text):]
@@ -423,6 +423,7 @@ func parseOpencodeSSE(r io.Reader, state *opencodeStreamState) error {
 						existing.phase = phase
 					} else {
 						state.textParts[p.ID] = &opencodeTextPart{text: p.Text, phase: phase}
+						chunk = p.Text
 					}
 					state.updateText(p.Text, phase)
 					if state.onChunk != nil && chunk != "" {

--- a/internal/agent/opencode_test.go
+++ b/internal/agent/opencode_test.go
@@ -100,8 +100,8 @@ data: {"payload":{"type":"session.idle"}}
 	if chunks[0] != "hello" {
 		t.Errorf("expected first chunk 'hello', got %q", chunks[0])
 	}
-	if chunks[1] != "hello world" {
-		t.Errorf("expected second chunk 'hello world', got %q", chunks[1])
+	if chunks[1] != "world" {
+		t.Errorf("expected second chunk 'world', got %q", chunks[1])
 	}
 	if state.lastText != "hello world" {
 		t.Errorf("expected lastText 'hello world', got %q", state.lastText)

--- a/internal/agent/opencode_test.go
+++ b/internal/agent/opencode_test.go
@@ -213,7 +213,7 @@ data: {"payload":{"type":"session.idle"}}
 	}
 }
 
-func TestParseOpencodeSSE_PartUpdated_NonPrefixSnapshotDoesNotEmitDuplicateChunk(t *testing.T) {
+func TestParseOpencodeSSE_PartUpdated_NonPrefixSnapshotStreamsCorrectedText(t *testing.T) {
 	input := `data: {"payload":{"type":"message.part.delta","properties":{"sessionID":"s1","field":"text","partID":"p1","delta":"hello world"}}}
 
 data: {"payload":{"type":"message.part.updated","properties":{"sessionID":"s1","part":{"id":"p1","type":"text","text":"hello there"}}}}
@@ -233,11 +233,14 @@ data: {"payload":{"type":"session.idle"}}
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(chunks) != 1 {
-		t.Fatalf("expected 1 chunk, got %d: %v", len(chunks), chunks)
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks, got %d: %v", len(chunks), chunks)
 	}
 	if chunks[0] != "hello world" {
 		t.Errorf("expected original delta chunk 'hello world', got %q", chunks[0])
+	}
+	if chunks[1] != "hello there" {
+		t.Errorf("expected corrected chunk 'hello there', got %q", chunks[1])
 	}
 	if state.lastText != "hello there" {
 		t.Errorf("expected lastText 'hello there', got %q", state.lastText)

--- a/internal/agent/opencode_test.go
+++ b/internal/agent/opencode_test.go
@@ -97,14 +97,40 @@ data: {"payload":{"type":"session.idle"}}
 	if len(chunks) != 2 {
 		t.Fatalf("expected 2 chunks, got %d: %v", len(chunks), chunks)
 	}
-	if chunks[0] != "hello" {
-		t.Errorf("expected first chunk 'hello', got %q", chunks[0])
+	if chunks[0] != "hello " {
+		t.Errorf("expected first chunk 'hello ', got %q", chunks[0])
 	}
 	if chunks[1] != "world" {
 		t.Errorf("expected second chunk 'world', got %q", chunks[1])
 	}
 	if state.lastText != "hello world" {
 		t.Errorf("expected lastText 'hello world', got %q", state.lastText)
+	}
+}
+
+func TestParseOpencodeSSE_PartUpdated_TextStreamsChunk(t *testing.T) {
+	input := `data: {"payload":{"type":"message.part.updated","properties":{"sessionID":"s1","part":{"id":"p1","type":"text","text":"streamed text"}}}}
+
+data: {"payload":{"type":"session.idle"}}
+
+`
+	state := &opencodeStreamState{
+		sessionID:  "s1",
+		textParts:  make(map[string]*opencodeTextPart),
+		usageByMsg: make(map[string]TokenUsage),
+	}
+	var chunks []string
+	state.onChunk = func(text string) { chunks = append(chunks, text) }
+
+	err := parseOpencodeSSE(strings.NewReader(input), state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d: %v", len(chunks), chunks)
+	}
+	if chunks[0] != "streamed text" {
+		t.Errorf("expected streamed chunk 'streamed text', got %q", chunks[0])
 	}
 }
 

--- a/internal/agent/opencode_test.go
+++ b/internal/agent/opencode_test.go
@@ -134,6 +134,85 @@ data: {"payload":{"type":"session.idle"}}
 	}
 }
 
+func TestParseOpencodeSSE_PartUpdatedAfterDelta_StreamsOnlySuffix(t *testing.T) {
+	input := `data: {"payload":{"type":"message.part.delta","properties":{"sessionID":"s1","field":"text","partID":"p1","delta":"hello"}}}
+
+data: {"payload":{"type":"message.part.updated","properties":{"sessionID":"s1","part":{"id":"p1","type":"text","text":"hello world"}}}}
+
+data: {"payload":{"type":"session.idle"}}
+
+`
+	state := &opencodeStreamState{
+		sessionID:  "s1",
+		textParts:  make(map[string]*opencodeTextPart),
+		usageByMsg: make(map[string]TokenUsage),
+	}
+	var chunks []string
+	state.onChunk = func(text string) { chunks = append(chunks, text) }
+
+	err := parseOpencodeSSE(strings.NewReader(input), state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks, got %d: %v", len(chunks), chunks)
+	}
+	if chunks[0] != "hello" {
+		t.Errorf("expected first chunk 'hello', got %q", chunks[0])
+	}
+	if chunks[1] != " world" {
+		t.Errorf("expected suffix chunk ' world', got %q", chunks[1])
+	}
+	if state.lastText != "hello world" {
+		t.Errorf("expected lastText 'hello world', got %q", state.lastText)
+	}
+	if got := state.textParts["p1"]; got == nil || got.text != "hello world" {
+		t.Fatalf("expected cached part text 'hello world', got %#v", got)
+	}
+}
+
+func TestParseOpencodeSSE_DeltaAfterUpdated_AppendsFromLatestText(t *testing.T) {
+	input := `data: {"payload":{"type":"message.part.updated","properties":{"sessionID":"s1","part":{"id":"p1","type":"text","text":"hello"}}}}
+
+data: {"payload":{"type":"message.part.updated","properties":{"sessionID":"s1","part":{"id":"p1","type":"text","text":"hello world"}}}}
+
+data: {"payload":{"type":"message.part.delta","properties":{"sessionID":"s1","field":"text","partID":"p1","delta":"!"}}}
+
+data: {"payload":{"type":"session.idle"}}
+
+`
+	state := &opencodeStreamState{
+		sessionID:  "s1",
+		textParts:  make(map[string]*opencodeTextPart),
+		usageByMsg: make(map[string]TokenUsage),
+	}
+	var chunks []string
+	state.onChunk = func(text string) { chunks = append(chunks, text) }
+
+	err := parseOpencodeSSE(strings.NewReader(input), state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 3 {
+		t.Fatalf("expected 3 chunks, got %d: %v", len(chunks), chunks)
+	}
+	if chunks[0] != "hello" {
+		t.Errorf("expected first chunk 'hello', got %q", chunks[0])
+	}
+	if chunks[1] != " world" {
+		t.Errorf("expected second chunk ' world', got %q", chunks[1])
+	}
+	if chunks[2] != "!" {
+		t.Errorf("expected third chunk '!', got %q", chunks[2])
+	}
+	if state.lastText != "hello world!" {
+		t.Errorf("expected lastText 'hello world!', got %q", state.lastText)
+	}
+	if got := state.textParts["p1"]; got == nil || got.text != "hello world!" {
+		t.Fatalf("expected cached part text 'hello world!', got %#v", got)
+	}
+}
+
 func TestParseOpencodeSSE_PartUpdated_Text(t *testing.T) {
 	input := `data: {"payload":{"type":"message.part.updated","properties":{"sessionID":"s1","part":{"id":"p1","type":"text","text":"final text","metadata":{"openai":{"phase":"final_answer"}}}}}}
 

--- a/internal/agent/opencode_test.go
+++ b/internal/agent/opencode_test.go
@@ -213,6 +213,40 @@ data: {"payload":{"type":"session.idle"}}
 	}
 }
 
+func TestParseOpencodeSSE_PartUpdated_NonPrefixSnapshotDoesNotEmitDuplicateChunk(t *testing.T) {
+	input := `data: {"payload":{"type":"message.part.delta","properties":{"sessionID":"s1","field":"text","partID":"p1","delta":"hello world"}}}
+
+data: {"payload":{"type":"message.part.updated","properties":{"sessionID":"s1","part":{"id":"p1","type":"text","text":"hello there"}}}}
+
+data: {"payload":{"type":"session.idle"}}
+
+`
+	state := &opencodeStreamState{
+		sessionID:  "s1",
+		textParts:  make(map[string]*opencodeTextPart),
+		usageByMsg: make(map[string]TokenUsage),
+	}
+	var chunks []string
+	state.onChunk = func(text string) { chunks = append(chunks, text) }
+
+	err := parseOpencodeSSE(strings.NewReader(input), state)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk, got %d: %v", len(chunks), chunks)
+	}
+	if chunks[0] != "hello world" {
+		t.Errorf("expected original delta chunk 'hello world', got %q", chunks[0])
+	}
+	if state.lastText != "hello there" {
+		t.Errorf("expected lastText 'hello there', got %q", state.lastText)
+	}
+	if got := state.textParts["p1"]; got == nil || got.text != "hello there" {
+		t.Fatalf("expected cached part text 'hello there', got %#v", got)
+	}
+}
+
 func TestParseOpencodeSSE_PartUpdated_Text(t *testing.T) {
 	input := `data: {"payload":{"type":"message.part.updated","properties":{"sessionID":"s1","part":{"id":"p1","type":"text","text":"final text","metadata":{"openai":{"phase":"final_answer"}}}}}}
 


### PR DESCRIPTION
{"title":"fix(opencode): correct text streaming for review snapshots","body":"## Summary\n- fix OpenCode text streaming state so replacement chunks are handled correctly across the full review stream\n- avoid duplicate replacement chunks and stream corrective snapshots more reliably in `internal/agent/opencode.go`\n- add and expand tests covering the OpenCode text streaming behavior\n\n## Testing\n- Added/updated `internal/agent/opencode_test.go`\n- Test execution not provided in the branch context"}