### PR TITLE
feat(review): add configurable auto-fix retries and manual babysit fixes

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ type GlobalConfig struct {
 	AgentPathOverride map[string]string `yaml:"agent_path_override"`
 	BabysitTimeout    time.Duration     `yaml:"-"`
 	LogLevel          string            `yaml:"log_level"`
+	AutoFix           AutoFixRaw
 }
 
 // globalConfigRaw is the on-disk YAML representation with duration as string.
@@ -27,6 +28,7 @@ type globalConfigRaw struct {
 	AgentPathOverride map[string]string `yaml:"agent_path_override"`
 	BabysitTimeout    string            `yaml:"babysit_timeout"`
 	LogLevel          string            `yaml:"log_level"`
+	AutoFix           AutoFixRaw        `yaml:"auto_fix"`
 }
 
 // RepoConfig represents .no-mistakes.yaml in a repo root.
@@ -34,6 +36,7 @@ type RepoConfig struct {
 	Agent          types.AgentName `yaml:"agent"`
 	Commands       Commands        `yaml:"commands"`
 	IgnorePatterns []string        `yaml:"ignore_patterns"`
+	AutoFix        AutoFixRaw      `yaml:"auto_fix"`
 }
 
 // Commands holds optional per-repo command overrides.
@@ -41,6 +44,24 @@ type Commands struct {
 	Lint   string `yaml:"lint"`
 	Test   string `yaml:"test"`
 	Format string `yaml:"format"`
+}
+
+// AutoFixRaw is the YAML representation of auto-fix config.
+// Pointer fields distinguish "not set" (nil) from "set to 0" (disabled).
+type AutoFixRaw struct {
+	Lint    *int `yaml:"lint"`
+	Test    *int `yaml:"test"`
+	Review  *int `yaml:"review"`
+	Babysit *int `yaml:"babysit"`
+}
+
+// AutoFix holds resolved per-step auto-fix attempt limits.
+// A value of 0 means auto-fix is disabled (requires manual approval).
+type AutoFix struct {
+	Lint    int
+	Test    int
+	Review  int
+	Babysit int
 }
 
 // Config is the merged result of global + per-repo configuration.
@@ -51,6 +72,7 @@ type Config struct {
 	LogLevel          string
 	Commands          Commands
 	IgnorePatterns    []string
+	AutoFix           AutoFix
 }
 
 // defaultConfigYAML is the template written when no global config file exists.
@@ -71,6 +93,13 @@ log_level: info
 # agent_path_override:
 #   claude: /usr/local/bin/claude
 #   codex: /opt/codex
+
+# Maximum auto-fix attempts per step (0 = disabled, requires manual approval)
+auto_fix:
+  lint: 3
+  test: 3
+  review: 3
+  babysit: 3
 `
 
 // defaultBinary maps agent names to their default binary names.
@@ -150,6 +179,7 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 	if raw.LogLevel != "" {
 		cfg.LogLevel = raw.LogLevel
 	}
+	cfg.AutoFix = raw.AutoFix
 
 	return cfg, nil
 }
@@ -192,9 +222,56 @@ func ParseLogLevel(level string) slog.Level {
 	}
 }
 
+// autoFixDefaults returns the default auto-fix configuration.
+func autoFixDefaults() AutoFix {
+	return AutoFix{
+		Lint:    3,
+		Test:    3,
+		Review:  3,
+		Babysit: 3,
+	}
+}
+
+// applyAutoFixOverrides applies non-nil raw values onto resolved defaults.
+func applyAutoFixOverrides(dst *AutoFix, src *AutoFixRaw) {
+	if src.Lint != nil {
+		dst.Lint = *src.Lint
+	}
+	if src.Test != nil {
+		dst.Test = *src.Test
+	}
+	if src.Review != nil {
+		dst.Review = *src.Review
+	}
+	if src.Babysit != nil {
+		dst.Babysit = *src.Babysit
+	}
+}
+
+// AutoFixLimit returns the max auto-fix attempts for a given step.
+// Steps without auto-fix support return 0.
+func (c *Config) AutoFixLimit(step types.StepName) int {
+	switch step {
+	case types.StepLint:
+		return c.AutoFix.Lint
+	case types.StepTest:
+		return c.AutoFix.Test
+	case types.StepReview:
+		return c.AutoFix.Review
+	case types.StepBabysit:
+		return c.AutoFix.Babysit
+	default:
+		return 0
+	}
+}
+
 // Merge combines global and per-repo config. Per-repo agent overrides global
 // when non-empty. Commands and ignore patterns come from repo config only.
 func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
+	af := autoFixDefaults()
+	applyAutoFixOverrides(&af, &global.AutoFix)
+	applyAutoFixOverrides(&af, &repo.AutoFix)
+
 	cfg := &Config{
 		Agent:             global.Agent,
 		AgentPathOverride: global.AgentPathOverride,
@@ -202,6 +279,7 @@ func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 		LogLevel:          global.LogLevel,
 		Commands:          repo.Commands,
 		IgnorePatterns:    repo.IgnorePatterns,
+		AutoFix:           af,
 	}
 
 	if repo.Agent != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -457,6 +457,200 @@ func TestDefaultConfigYAML_MatchesGoDefaults(t *testing.T) {
 	if raw.LogLevel != "info" {
 		t.Errorf("YAML log_level = %q, Go default = %q", raw.LogLevel, "info")
 	}
+	defaults := autoFixDefaults()
+	if raw.AutoFix.Lint == nil || *raw.AutoFix.Lint != defaults.Lint {
+		t.Errorf("YAML auto_fix.lint = %v, Go default = %d", raw.AutoFix.Lint, defaults.Lint)
+	}
+	if raw.AutoFix.Test == nil || *raw.AutoFix.Test != defaults.Test {
+		t.Errorf("YAML auto_fix.test = %v, Go default = %d", raw.AutoFix.Test, defaults.Test)
+	}
+	if raw.AutoFix.Review == nil || *raw.AutoFix.Review != defaults.Review {
+		t.Errorf("YAML auto_fix.review = %v, Go default = %d", raw.AutoFix.Review, defaults.Review)
+	}
+	if raw.AutoFix.Babysit == nil || *raw.AutoFix.Babysit != defaults.Babysit {
+		t.Errorf("YAML auto_fix.babysit = %v, Go default = %d", raw.AutoFix.Babysit, defaults.Babysit)
+	}
+}
+
+func TestLoadGlobal_AutoFixDefaults(t *testing.T) {
+	cfg, err := LoadGlobal("/nonexistent/config.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// AutoFix should be nil (unset) in GlobalConfig
+	if cfg.AutoFix.Lint != nil || cfg.AutoFix.Test != nil || cfg.AutoFix.Review != nil ||
+		cfg.AutoFix.Babysit != nil {
+		t.Errorf("expected all AutoFix fields to be nil for defaults, got %+v", cfg.AutoFix)
+	}
+}
+
+func TestLoadGlobal_AutoFixFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	data := `auto_fix:
+  lint: 5
+  test: 0
+  review: 2
+  babysit: 1
+`
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadGlobal(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.AutoFix.Lint == nil || *cfg.AutoFix.Lint != 5 {
+		t.Errorf("lint = %v, want 5", cfg.AutoFix.Lint)
+	}
+	if cfg.AutoFix.Test == nil || *cfg.AutoFix.Test != 0 {
+		t.Errorf("test = %v, want 0", cfg.AutoFix.Test)
+	}
+	if cfg.AutoFix.Review == nil || *cfg.AutoFix.Review != 2 {
+		t.Errorf("review = %v, want 2", cfg.AutoFix.Review)
+	}
+	if cfg.AutoFix.Babysit == nil || *cfg.AutoFix.Babysit != 1 {
+		t.Errorf("babysit = %v, want 1", cfg.AutoFix.Babysit)
+	}
+}
+
+func TestLoadGlobal_AutoFixPartial(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	data := `auto_fix:
+  lint: 1
+`
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadGlobal(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.AutoFix.Lint == nil || *cfg.AutoFix.Lint != 1 {
+		t.Errorf("lint = %v, want 1", cfg.AutoFix.Lint)
+	}
+	// Unset fields should remain nil
+	if cfg.AutoFix.Test != nil {
+		t.Errorf("test = %v, want nil", cfg.AutoFix.Test)
+	}
+}
+
+func TestLoadRepo_AutoFixFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".no-mistakes.yaml")
+	data := `auto_fix:
+  review: 0
+  babysit: 2
+`
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadRepo(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.AutoFix.Review == nil || *cfg.AutoFix.Review != 0 {
+		t.Errorf("review = %v, want 0", cfg.AutoFix.Review)
+	}
+	if cfg.AutoFix.Babysit == nil || *cfg.AutoFix.Babysit != 2 {
+		t.Errorf("babysit = %v, want 2", cfg.AutoFix.Babysit)
+	}
+}
+
+func TestMerge_AutoFixDefaults(t *testing.T) {
+	global := &GlobalConfig{Agent: types.AgentClaude, BabysitTimeout: 4 * time.Hour, LogLevel: "info"}
+	repo := &RepoConfig{}
+
+	cfg := Merge(global, repo)
+	if cfg.AutoFix.Lint != 3 {
+		t.Errorf("lint = %d, want 3", cfg.AutoFix.Lint)
+	}
+	if cfg.AutoFix.Test != 3 {
+		t.Errorf("test = %d, want 3", cfg.AutoFix.Test)
+	}
+	if cfg.AutoFix.Review != 3 {
+		t.Errorf("review = %d, want 3", cfg.AutoFix.Review)
+	}
+	if cfg.AutoFix.Babysit != 3 {
+		t.Errorf("babysit = %d, want 3", cfg.AutoFix.Babysit)
+	}
+}
+
+func TestMerge_AutoFixGlobalOverridesDefaults(t *testing.T) {
+	five := 5
+	zero := 0
+	global := &GlobalConfig{
+		Agent:          types.AgentClaude,
+		BabysitTimeout: 4 * time.Hour,
+		LogLevel:       "info",
+		AutoFix:        AutoFixRaw{Lint: &five, Babysit: &zero},
+	}
+	repo := &RepoConfig{}
+
+	cfg := Merge(global, repo)
+	if cfg.AutoFix.Lint != 5 {
+		t.Errorf("lint = %d, want 5 (global override)", cfg.AutoFix.Lint)
+	}
+	if cfg.AutoFix.Test != 3 {
+		t.Errorf("test = %d, want 3 (default)", cfg.AutoFix.Test)
+	}
+	if cfg.AutoFix.Babysit != 0 {
+		t.Errorf("babysit = %d, want 0 (global override)", cfg.AutoFix.Babysit)
+	}
+}
+
+func TestMerge_AutoFixRepoOverridesGlobal(t *testing.T) {
+	five := 5
+	one := 1
+	zero := 0
+	global := &GlobalConfig{
+		Agent:          types.AgentClaude,
+		BabysitTimeout: 4 * time.Hour,
+		LogLevel:       "info",
+		AutoFix:        AutoFixRaw{Lint: &five},
+	}
+	repo := &RepoConfig{
+		AutoFix: AutoFixRaw{Lint: &one, Review: &zero},
+	}
+
+	cfg := Merge(global, repo)
+	if cfg.AutoFix.Lint != 1 {
+		t.Errorf("lint = %d, want 1 (repo override)", cfg.AutoFix.Lint)
+	}
+	if cfg.AutoFix.Review != 0 {
+		t.Errorf("review = %d, want 0 (repo override)", cfg.AutoFix.Review)
+	}
+	if cfg.AutoFix.Test != 3 {
+		t.Errorf("test = %d, want 3 (default, no override)", cfg.AutoFix.Test)
+	}
+}
+
+func TestAutoFixLimit(t *testing.T) {
+	cfg := &Config{
+		AutoFix: AutoFix{Lint: 5, Test: 2, Review: 0, Babysit: 3},
+	}
+	tests := []struct {
+		step types.StepName
+		want int
+	}{
+		{types.StepLint, 5},
+		{types.StepTest, 2},
+		{types.StepReview, 0},
+		{types.StepBabysit, 3},
+		{types.StepPush, 0},
+		{types.StepPR, 0},
+		{types.StepRebase, 0},
+	}
+	for _, tt := range tests {
+		got := cfg.AutoFixLimit(tt.step)
+		if got != tt.want {
+			t.Errorf("AutoFixLimit(%q) = %d, want %d", tt.step, got, tt.want)
+		}
+	}
 }
 
 func TestParseLogLevel(t *testing.T) {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -459,6 +459,10 @@ func setupTestGitRepo(t *testing.T, p *paths.Paths, d *db.DB, repoID string) (*d
 	if err := os.WriteFile(filepath.Join(workDir, "test.txt"), []byte("hello"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	// Disable auto-fix so approval-based tests pause immediately.
+	if err := os.WriteFile(filepath.Join(workDir, ".no-mistakes.yaml"), []byte("auto_fix:\n  lint: 0\n  test: 0\n  review: 0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	gitCmd(t, workDir, "add", ".")
 	gitCmd(t, workDir, "commit", "-m", "initial")
 

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -200,7 +200,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 		}
 
 		// Check if auto-fix should be attempted
-		if autoFixLimit > 0 && autoFixAttempts < autoFixLimit {
+		if outcome.AutoFixable && autoFixLimit > 0 && autoFixAttempts < autoFixLimit {
 			autoFixAttempts++
 			slog.Info("auto-fixing step", "step", stepName, "attempt", autoFixAttempts, "max", autoFixLimit)
 			if dbErr := e.db.UpdateStepStatus(sr.ID, types.StepStatusFixing); dbErr != nil {

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -163,6 +163,13 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 		},
 	}
 
+	// Determine auto-fix limit for this step
+	autoFixLimit := 0
+	if e.config != nil {
+		autoFixLimit = e.config.AutoFixLimit(stepName)
+	}
+	autoFixAttempts := 0
+
 	// Execute with possible fix loop
 	for {
 		outcome, err := step.Execute(sctx)
@@ -192,6 +199,19 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			break
 		}
 
+		// Check if auto-fix should be attempted
+		if autoFixLimit > 0 && autoFixAttempts < autoFixLimit {
+			autoFixAttempts++
+			slog.Info("auto-fixing step", "step", stepName, "attempt", autoFixAttempts, "max", autoFixLimit)
+			if dbErr := e.db.UpdateStepStatus(sr.ID, types.StepStatusFixing); dbErr != nil {
+				slog.Warn("failed to update step status in db", "step", stepName, "status", "fixing", "error", dbErr)
+			}
+			e.emitStepEvent(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFixing))
+			sctx.Fixing = true
+			sctx.PreviousFindings = outcome.Findings
+			continue
+		}
+
 		// Determine approval status: fix_review after a fix cycle, awaiting_approval otherwise
 		approvalStatus := types.StepStatusAwaitingApproval
 		var diffText string
@@ -205,7 +225,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			}
 		}
 
-		// Step needs approval — wait for user action
+		// Step needs approval - wait for user action
 		if dbErr := e.db.UpdateStepStatus(sr.ID, approvalStatus); dbErr != nil {
 			slog.Warn("failed to update step status in db", "step", stepName, "status", approvalStatus, "error", dbErr)
 		}
@@ -222,11 +242,11 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 
 		switch response.action {
 		case types.ActionApprove:
-			// Approved — break out of fix loop
+			// Approved - break out of fix loop
 			goto done
 
 		case types.ActionSkip:
-			// Skip — mark step skipped and return (not an error)
+			// Skip - mark step skipped and return (not an error)
 			durationMS := time.Since(started).Milliseconds()
 			if err := e.db.CompleteStep(sr.ID, finalExitCode, durationMS, logPath); err != nil {
 				return fmt.Errorf("complete step %s (skip): %w", stepName, err)
@@ -245,7 +265,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			return fmt.Errorf("step %s: aborted by user", stepName)
 
 		case types.ActionFix:
-			// Fix — mark step as fixing, re-execute with previous findings
+			// Fix - mark step as fixing, re-execute with previous findings
 			if dbErr := e.db.UpdateStepStatus(sr.ID, types.StepStatusFixing); dbErr != nil {
 				slog.Warn("failed to update step status in db", "step", stepName, "status", "fixing", "error", dbErr)
 			}

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kunchenguid/no-mistakes/internal/config"
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
@@ -1433,6 +1434,217 @@ func TestExecutor_LogFileMultipleSteps(t *testing.T) {
 	// Review log should NOT contain test message
 	if strings.Contains(string(reviewLog), "test message") {
 		t.Error("review log should not contain test message")
+	}
+}
+
+func TestExecutor_AutoFixTriggersWithoutApproval(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	// Config with auto-fix enabled for review (max 3 attempts)
+	cfg := &config.Config{AutoFix: config.AutoFix{Review: 3}}
+
+	callCount := 0
+	step := &adaptiveCallStep{
+		name: types.StepReview,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			callCount++
+			if callCount == 1 {
+				return &StepOutcome{
+					NeedsApproval: true,
+					Findings:      `{"findings":[{"severity":"error","description":"bug"}],"summary":"1 issue"}`,
+				}, nil
+			}
+			// After auto-fix, verify Fixing is set
+			if !sctx.Fixing {
+				t.Error("expected Fixing to be true on auto-fix re-execution")
+			}
+			if sctx.PreviousFindings == "" {
+				t.Error("expected PreviousFindings to be set on auto-fix")
+			}
+			return &StepOutcome{}, nil
+		},
+	}
+
+	exec := NewExecutor(database, p, cfg, nil, []Step{step}, nil)
+
+	err := exec.Execute(context.Background(), run, repo, workDir)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if callCount != 2 {
+		t.Errorf("expected step called 2 times (initial + auto-fix), got %d", callCount)
+	}
+
+	updated, _ := database.GetRun(run.ID)
+	if updated.Status != types.RunCompleted {
+		t.Errorf("expected run status %q, got %q", types.RunCompleted, updated.Status)
+	}
+}
+
+func TestExecutor_AutoFixRespectsMaxAttempts(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	// Config with auto-fix limited to 2 attempts for lint
+	cfg := &config.Config{AutoFix: config.AutoFix{Lint: 2}}
+
+	callCount := 0
+	step := &adaptiveCallStep{
+		name: types.StepLint,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			callCount++
+			// Always return NeedsApproval to exhaust auto-fix attempts
+			return &StepOutcome{
+				NeedsApproval: true,
+				Findings:      `{"findings":[{"severity":"warning","description":"style issue"}],"summary":"lint issue"}`,
+			}, nil
+		},
+	}
+
+	exec := NewExecutor(database, p, cfg, nil, []Step{step}, nil)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- exec.Execute(context.Background(), run, repo, workDir)
+	}()
+
+	// After 2 auto-fix attempts fail, should fall back to manual approval
+	// 1 initial + 2 auto-fix = 3 calls, then waits for approval
+	// Status is fix_review since auto-fix cycles ran (sctx.Fixing was true)
+	waitForStepStatus(t, database, run.ID, types.StepLint, types.StepStatusFixReview)
+
+	if callCount != 3 {
+		t.Errorf("expected 3 calls (1 initial + 2 auto-fix), got %d", callCount)
+	}
+
+	// Now approve manually to finish
+	exec.Respond(types.StepLint, types.ActionApprove, nil)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("executor timed out")
+	}
+}
+
+func TestExecutor_AutoFixDisabledWithZero(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	// Config with auto-fix disabled for review
+	cfg := &config.Config{AutoFix: config.AutoFix{Review: 0}}
+
+	callCount := 0
+	step := &adaptiveCallStep{
+		name: types.StepReview,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			callCount++
+			return &StepOutcome{
+				NeedsApproval: true,
+				Findings:      `{"findings":[{"severity":"error","description":"bug"}],"summary":"1 issue"}`,
+			}, nil
+		},
+	}
+
+	exec := NewExecutor(database, p, cfg, nil, []Step{step}, nil)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- exec.Execute(context.Background(), run, repo, workDir)
+	}()
+
+	// Should immediately wait for approval (no auto-fix)
+	waitForStepStatus(t, database, run.ID, types.StepReview, types.StepStatusAwaitingApproval)
+
+	if callCount != 1 {
+		t.Errorf("expected 1 call (no auto-fix), got %d", callCount)
+	}
+
+	exec.Respond(types.StepReview, types.ActionApprove, nil)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("executor timed out")
+	}
+}
+
+func TestExecutor_AutoFixNilConfigUsesDefaults(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	// nil config - executor should not panic and should use no auto-fix (backwards compat)
+	callCount := 0
+	step := &adaptiveCallStep{
+		name: types.StepReview,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			callCount++
+			return &StepOutcome{
+				NeedsApproval: true,
+				Findings:      `{"findings":[{"severity":"error","description":"bug"}],"summary":"1 issue"}`,
+			}, nil
+		},
+	}
+
+	exec := NewExecutor(database, p, nil, nil, []Step{step}, nil)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- exec.Execute(context.Background(), run, repo, workDir)
+	}()
+
+	// With nil config, should wait for approval
+	waitForStepStatus(t, database, run.ID, types.StepReview, types.StepStatusAwaitingApproval)
+
+	if callCount != 1 {
+		t.Errorf("expected 1 call (nil config, no auto-fix), got %d", callCount)
+	}
+
+	exec.Respond(types.StepReview, types.ActionAbort, nil)
+	<-done
+}
+
+func TestExecutor_AutoFixEmitsEvents(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	cfg := &config.Config{AutoFix: config.AutoFix{Lint: 1}}
+
+	callCount := 0
+	step := &adaptiveCallStep{
+		name: types.StepLint,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			callCount++
+			if callCount == 1 {
+				return &StepOutcome{
+					NeedsApproval: true,
+					Findings:      `{"findings":[{"severity":"warning","description":"issue"}],"summary":"1 issue"}`,
+				}, nil
+			}
+			return &StepOutcome{}, nil
+		},
+	}
+
+	exec := NewExecutor(database, p, cfg, nil, []Step{step}, nil)
+	events := collectEvents(exec)
+
+	err := exec.Execute(context.Background(), run, repo, workDir)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// Should have a fixing status event from auto-fix
+	fixingEvent := events.findLast(ipc.EventStepCompleted, string(types.StepStatusFixing))
+	if fixingEvent == nil {
+		t.Error("expected step_completed event with fixing status during auto-fix")
 	}
 }
 

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -1452,6 +1452,7 @@ func TestExecutor_AutoFixTriggersWithoutApproval(t *testing.T) {
 			if callCount == 1 {
 				return &StepOutcome{
 					NeedsApproval: true,
+					AutoFixable:   true,
 					Findings:      `{"findings":[{"severity":"error","description":"bug"}],"summary":"1 issue"}`,
 				}, nil
 			}
@@ -1498,6 +1499,7 @@ func TestExecutor_AutoFixRespectsMaxAttempts(t *testing.T) {
 			// Always return NeedsApproval to exhaust auto-fix attempts
 			return &StepOutcome{
 				NeedsApproval: true,
+				AutoFixable:   true,
 				Findings:      `{"findings":[{"severity":"warning","description":"style issue"}],"summary":"lint issue"}`,
 			}, nil
 		},
@@ -1626,6 +1628,7 @@ func TestExecutor_AutoFixEmitsEvents(t *testing.T) {
 			if callCount == 1 {
 				return &StepOutcome{
 					NeedsApproval: true,
+					AutoFixable:   true,
 					Findings:      `{"findings":[{"severity":"warning","description":"issue"}],"summary":"1 issue"}`,
 				}, nil
 			}
@@ -1645,6 +1648,51 @@ func TestExecutor_AutoFixEmitsEvents(t *testing.T) {
 	fixingEvent := events.findLast(ipc.EventStepCompleted, string(types.StepStatusFixing))
 	if fixingEvent == nil {
 		t.Error("expected step_completed event with fixing status during auto-fix")
+	}
+}
+
+func TestExecutor_DoesNotAutoFixManualApprovalOutcome(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	cfg := &config.Config{AutoFix: config.AutoFix{Test: 3}}
+
+	callCount := 0
+	step := &adaptiveCallStep{
+		name: types.StepTest,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			callCount++
+			return &StepOutcome{
+				NeedsApproval: true,
+				Findings:      `{"findings":[{"severity":"info","description":"new test file written by agent: agent_test.go"}],"summary":"tests passed, but agent wrote new test files"}`,
+			}, nil
+		},
+	}
+
+	exec := NewExecutor(database, p, cfg, nil, []Step{step}, nil)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- exec.Execute(context.Background(), run, repo, workDir)
+	}()
+
+	waitForStepStatus(t, database, run.ID, types.StepTest, types.StepStatusAwaitingApproval)
+
+	if callCount != 1 {
+		t.Fatalf("expected 1 call for manual approval outcome, got %d", callCount)
+	}
+
+	if err := exec.Respond(types.StepTest, types.ActionApprove, nil); err != nil {
+		t.Fatalf("respond error: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("executor timed out")
 	}
 }
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -25,7 +25,8 @@ type StepContext struct {
 
 // StepOutcome is the result of executing a pipeline step.
 type StepOutcome struct {
-	NeedsApproval bool   // whether the step pauses for user action
+	NeedsApproval bool // whether the step pauses for user action
+	AutoFixable   bool
 	Findings      string // JSON findings for TUI display (optional)
 	ExitCode      int    // process exit code (0 = success)
 }

--- a/internal/pipeline/steps/babysit.go
+++ b/internal/pipeline/steps/babysit.go
@@ -23,6 +23,7 @@ const defaultChecksGracePeriod = 60 * time.Second
 // BabysitStep monitors CI checks after PR creation, auto-fixing failures.
 type BabysitStep struct {
 	lastFixedChecks      string        // sorted check names from last fix attempt, to avoid re-fixing
+	ciFixAttempts        int           // number of CI auto-fix attempts made
 	checksGracePeriod    time.Duration // minimum wait before trusting empty CI checks (0 = default 60s)
 	pollIntervalOverride time.Duration // if set, overrides computed poll interval (for testing)
 }
@@ -192,7 +193,8 @@ func (s *BabysitStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome
 			return &pipeline.StepOutcome{}, nil
 		}
 
-		// Check CI status — auto-fix failures (no approval needed)
+		// Check CI status - auto-fix failures when configured
+		ciFixLimit := sctx.Config.AutoFix.Babysit
 		checks, err := s.getCIChecks(ctx, sctx.WorkDir, prNumber)
 		if err != nil {
 			sctx.Log(fmt.Sprintf("warning: could not check CI: %v", err))
@@ -200,10 +202,15 @@ func (s *BabysitStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome
 			failing := failingCheckNames(checks)
 			sort.Strings(failing)
 			fixKey := strings.Join(failing, ",")
-			if fixKey == s.lastFixedChecks {
+			if ciFixLimit <= 0 {
+				sctx.Log(fmt.Sprintf("CI failures detected: %s - auto-fix disabled, waiting for manual intervention...", strings.Join(failing, ", ")))
+			} else if s.ciFixAttempts >= ciFixLimit {
+				sctx.Log(fmt.Sprintf("CI failures detected: %s - max auto-fix attempts (%d) reached, waiting for manual intervention...", strings.Join(failing, ", "), ciFixLimit))
+			} else if fixKey == s.lastFixedChecks {
 				sctx.Log("fix already attempted for these failures, waiting for CI re-run...")
 			} else {
-				sctx.Log(fmt.Sprintf("CI failures detected: %s - auto-fixing...", strings.Join(failing, ", ")))
+				s.ciFixAttempts++
+				sctx.Log(fmt.Sprintf("CI failures detected: %s - auto-fixing (attempt %d/%d)...", strings.Join(failing, ", "), s.ciFixAttempts, ciFixLimit))
 				if err := s.autoFixCI(sctx, prNumber, failing); err != nil {
 					sctx.Log(fmt.Sprintf("warning: CI auto-fix failed: %v", err))
 				} else {

--- a/internal/pipeline/steps/babysit.go
+++ b/internal/pipeline/steps/babysit.go
@@ -114,6 +114,21 @@ func failingCheckNames(checks []ciCheck) []string {
 	return names
 }
 
+func ciFailureOutcome(failing []string, summary string) *pipeline.StepOutcome {
+	findings := Findings{Summary: summary}
+	for _, name := range failing {
+		findings.Items = append(findings.Items, Finding{
+			Severity:    "warning",
+			Description: fmt.Sprintf("CI check failing: %s", name),
+		})
+	}
+	findingsJSON, _ := json.Marshal(findings)
+	return &pipeline.StepOutcome{
+		NeedsApproval: true,
+		Findings:      string(findingsJSON),
+	}
+}
+
 func (s *BabysitStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, error) {
 	ctx := sctx.Ctx
 	if err := ctx.Err(); err != nil {
@@ -204,8 +219,10 @@ func (s *BabysitStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome
 			fixKey := strings.Join(failing, ",")
 			if ciFixLimit <= 0 {
 				sctx.Log(fmt.Sprintf("CI failures detected: %s - auto-fix disabled, waiting for manual intervention...", strings.Join(failing, ", ")))
+				return ciFailureOutcome(failing, "CI failures require manual intervention"), nil
 			} else if s.ciFixAttempts >= ciFixLimit {
 				sctx.Log(fmt.Sprintf("CI failures detected: %s - max auto-fix attempts (%d) reached, waiting for manual intervention...", strings.Join(failing, ", "), ciFixLimit))
+				return ciFailureOutcome(failing, "CI failures still present after auto-fix attempts"), nil
 			} else if fixKey == s.lastFixedChecks {
 				sctx.Log("fix already attempted for these failures, waiting for CI re-run...")
 			} else {

--- a/internal/pipeline/steps/babysit.go
+++ b/internal/pipeline/steps/babysit.go
@@ -181,6 +181,7 @@ func (s *BabysitStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome
 
 	sctx.Log(fmt.Sprintf("babysitting PR #%s (timeout: %s)...", prNumber, timeout))
 	started := time.Now()
+	manualFixAttempted := false
 
 	for {
 		checksReadyToExit := false
@@ -217,7 +218,17 @@ func (s *BabysitStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome
 			failing := failingCheckNames(checks)
 			sort.Strings(failing)
 			fixKey := strings.Join(failing, ",")
-			if ciFixLimit <= 0 {
+			if sctx.Fixing && !manualFixAttempted {
+				manualFixAttempted = true
+				sctx.Log(fmt.Sprintf("CI failures detected: %s - manual fix requested...", strings.Join(failing, ", ")))
+				if err := s.autoFixCI(sctx, prNumber, failing); err != nil {
+					sctx.Log(fmt.Sprintf("warning: CI manual fix failed: %v", err))
+				} else {
+					s.lastFixedChecks = fixKey
+				}
+			} else if sctx.Fixing && fixKey == s.lastFixedChecks {
+				sctx.Log("fix already attempted for these failures, waiting for CI re-run...")
+			} else if ciFixLimit <= 0 {
 				sctx.Log(fmt.Sprintf("CI failures detected: %s - auto-fix disabled, waiting for manual intervention...", strings.Join(failing, ", ")))
 				return ciFailureOutcome(failing, "CI failures require manual intervention"), nil
 			} else if s.ciFixAttempts >= ciFixLimit {

--- a/internal/pipeline/steps/babysit.go
+++ b/internal/pipeline/steps/babysit.go
@@ -245,17 +245,19 @@ func (s *BabysitStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome
 					s.lastFixedChecks = fixKey
 				}
 			}
-		} else if !hasPendingChecks(checks) {
+		} else {
 			s.lastFixedChecks = ""
-			if len(checks) == 0 && elapsed < s.gracePeriod() {
-				// CI checks may not be registered yet, keep polling
-				sctx.Log("no CI checks reported yet, waiting for checks to register...")
-			} else {
-				checksReadyToExit = true
-				if len(checks) == 0 {
-					checksSummary = "no CI checks reported, babysit complete"
+			if !hasPendingChecks(checks) {
+				if len(checks) == 0 && elapsed < s.gracePeriod() {
+					// CI checks may not be registered yet, keep polling
+					sctx.Log("no CI checks reported yet, waiting for checks to register...")
 				} else {
-					checksSummary = "all CI checks passed"
+					checksReadyToExit = true
+					if len(checks) == 0 {
+						checksSummary = "no CI checks reported, babysit complete"
+					} else {
+						checksSummary = "all CI checks passed"
+					}
 				}
 			}
 		}

--- a/internal/pipeline/steps/lint.go
+++ b/internal/pipeline/steps/lint.go
@@ -110,6 +110,7 @@ Rules:
 		findingsJSON, _ := json.Marshal(findings)
 		return &pipeline.StepOutcome{
 			NeedsApproval: needsApproval,
+			AutoFixable:   needsApproval,
 			Findings:      string(findingsJSON),
 		}, nil
 	}
@@ -134,6 +135,7 @@ Rules:
 		findingsJSON, _ := json.Marshal(findings)
 		return &pipeline.StepOutcome{
 			NeedsApproval: true,
+			AutoFixable:   true,
 			Findings:      string(findingsJSON),
 			ExitCode:      exitCode,
 		}, nil

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -185,6 +185,7 @@ Risk assessment (after listing all findings):
 
 	return &pipeline.StepOutcome{
 		NeedsApproval: needsApproval,
+		AutoFixable:   needsApproval,
 		Findings:      string(findingsJSON),
 	}, nil
 }

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -3564,10 +3564,15 @@ func TestBabysitStep_CIAutoFixDisabledWithZero(t *testing.T) {
 	step := &BabysitStep{
 		pollIntervalOverride: 100 * time.Millisecond, // fast polling for test
 	}
-	_, err := step.Execute(sctx)
-	// Should exit cleanly via babysit timeout (polling without fixing)
+	outcome, err := step.Execute(sctx)
 	if err != nil {
-		t.Fatalf("expected clean exit from babysit timeout, got: %v", err)
+		t.Fatalf("expected approval outcome, got error: %v", err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected approval needed when babysit auto-fix is disabled")
+	}
+	if outcome.AutoFixable {
+		t.Fatal("expected manual intervention outcome to be non-auto-fixable")
 	}
 
 	// Agent should NOT have been called
@@ -3635,19 +3640,21 @@ func TestBabysitStep_CIAutoFixLimitExhausted(t *testing.T) {
 	sctx.Config.BabysitTimeout = 30 * time.Second
 	sctx.Config.AutoFix = config.AutoFix{Babysit: 1} // only 1 attempt allowed
 
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-	sctx.Ctx = ctx
-
 	var logs []string
 	sctx.Log = func(s string) { logs = append(logs, s) }
 
 	step := &BabysitStep{
 		pollIntervalOverride: 100 * time.Millisecond, // fast polling for test
 	}
-	_, err := step.Execute(sctx)
-	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("expected context.DeadlineExceeded, got: %v", err)
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatalf("expected approval outcome, got error: %v", err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected approval needed when babysit auto-fix limit is exhausted")
+	}
+	if outcome.AutoFixable {
+		t.Fatal("expected exhausted babysit outcome to be non-auto-fixable")
 	}
 
 	// Agent should have been called exactly once (limit is 1)

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -3230,6 +3230,7 @@ func TestBabysitStep_CIFailureAutoFix(t *testing.T) {
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "refs/heads/feature"
 	sctx.Config.BabysitTimeout = 30 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{Babysit: 3}
 
 	// Use a context with short timeout: after auto-fix completes, the poll
 	// sleep (30s) will be interrupted by context deadline, exiting the loop.
@@ -3538,5 +3539,131 @@ func TestFallbackPRContent_ConventionalTitle(t *testing.T) {
 				t.Errorf("fallback title %q is not conventional commit format", content.Title)
 			}
 		})
+	}
+}
+
+func TestBabysitStep_CIAutoFixDisabledWithZero(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	checksJSON := `[{"name":"build","state":"SUCCESS","bucket":"pass"},{"name":"test","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`
+	binDir := fakeBabysitGH(t, "OPEN", checksJSON)
+	prependPATH(t, binDir)
+
+	ag := &mockAgent{name: "test"}
+
+	prURL := "https://github.com/test/repo/pull/42"
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Run.PRURL = &prURL
+	sctx.Config.BabysitTimeout = 5 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{Babysit: 0} // disabled
+	sctx.Config.BabysitTimeout = 3 * time.Second
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+
+	step := &BabysitStep{
+		pollIntervalOverride: 100 * time.Millisecond, // fast polling for test
+	}
+	_, err := step.Execute(sctx)
+	// Should exit cleanly via babysit timeout (polling without fixing)
+	if err != nil {
+		t.Fatalf("expected clean exit from babysit timeout, got: %v", err)
+	}
+
+	// Agent should NOT have been called
+	if len(ag.calls) > 0 {
+		t.Errorf("expected no agent calls when babysit_ci=0, got %d", len(ag.calls))
+	}
+
+	// Should log that auto-fix is disabled
+	foundDisabled := false
+	for _, l := range logs {
+		if strings.Contains(l, "auto-fix disabled") {
+			foundDisabled = true
+			break
+		}
+	}
+	if !foundDisabled {
+		t.Errorf("expected 'auto-fix disabled' in logs, got: %v", logs)
+	}
+}
+
+func TestBabysitStep_CIAutoFixLimitExhausted(t *testing.T) {
+	// Set up upstream bare repo for push
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	checksJSON := `[{"name":"test","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`
+	binDir := fakeBabysitGH(t, "OPEN", checksJSON)
+	prependPATH(t, binDir)
+
+	fixCount := 0
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			fixCount++
+			// Agent "fixes" but the check will keep failing (same checksJSON)
+			os.WriteFile(filepath.Join(opts.CWD, fmt.Sprintf("fix-%d.txt", fixCount)), []byte("fixed"), 0o644)
+			return &agent.Result{}, nil
+		},
+	}
+
+	prURL := "https://github.com/test/repo/pull/42"
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Run.PRURL = &prURL
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Config.BabysitTimeout = 30 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{Babysit: 1} // only 1 attempt allowed
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	sctx.Ctx = ctx
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+
+	step := &BabysitStep{
+		pollIntervalOverride: 100 * time.Millisecond, // fast polling for test
+	}
+	_, err := step.Execute(sctx)
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded, got: %v", err)
+	}
+
+	// Agent should have been called exactly once (limit is 1)
+	if fixCount != 1 {
+		t.Errorf("expected 1 auto-fix attempt (limit=1), got %d", fixCount)
+	}
+
+	// Should log that max attempts reached on subsequent poll
+	foundExhausted := false
+	for _, l := range logs {
+		if strings.Contains(l, "max auto-fix attempts") {
+			foundExhausted = true
+			break
+		}
+	}
+	if !foundExhausted {
+		t.Errorf("expected 'max auto-fix attempts' in logs, got: %v", logs)
 	}
 }

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -3890,7 +3890,7 @@ func TestBabysitStep_FixMode_ManualInterventionRunsCIFix(t *testing.T) {
 	sctx.Fixing = true
 	sctx.PreviousFindings = string(findingsJSON)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	sctx.Ctx = ctx
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -3674,3 +3674,84 @@ func TestBabysitStep_CIAutoFixLimitExhausted(t *testing.T) {
 		t.Errorf("expected 'max auto-fix attempts' in logs, got: %v", logs)
 	}
 }
+
+func TestBabysitStep_FixMode_ManualInterventionRunsCIFix(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	checksJSON := `[{"name":"test","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`
+	binDir := fakeBabysitGH(t, "OPEN", checksJSON)
+	prependPATH(t, binDir)
+
+	fixCount := 0
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			fixCount++
+			os.WriteFile(filepath.Join(opts.CWD, "manual-fix.txt"), []byte("fixed"), 0o644)
+			return &agent.Result{Output: json.RawMessage(`{"summary":"fix failing CI"}`)}, nil
+		},
+	}
+
+	findingsJSON, err := json.Marshal(Findings{
+		Summary: "CI failures require manual intervention",
+		Items: []Finding{{
+			ID:          "review-1",
+			Severity:    "warning",
+			Description: "CI check failing: test",
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prURL := "https://github.com/test/repo/pull/42"
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Run.PRURL = &prURL
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Config.BabysitTimeout = 30 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{Babysit: 0}
+	sctx.Fixing = true
+	sctx.PreviousFindings = string(findingsJSON)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	sctx.Ctx = ctx
+
+	step := &BabysitStep{
+		pollIntervalOverride: 100 * time.Millisecond,
+	}
+	_, err = step.Execute(sctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context deadline exceeded after manual CI fix attempt, got %v", err)
+	}
+	if fixCount != 1 {
+		t.Fatalf("expected 1 manual CI fix attempt, got %d", fixCount)
+	}
+	if len(ag.calls) != 1 {
+		t.Fatalf("expected 1 agent call, got %d", len(ag.calls))
+	}
+	if !strings.Contains(ag.calls[0].Prompt, "failing checks: test") {
+		t.Fatalf("expected failing check name in fix prompt, got: %s", ag.calls[0].Prompt)
+	}
+}

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -49,6 +50,8 @@ func handleFakeCLI(mode string) {
 		fakeGlabHandler(args)
 	case "babysit-gh":
 		fakeBabysitGHHandler(args)
+	case "babysit-gh-seq":
+		fakeBabysitGHSequenceHandler(args)
 	case "babysit-gh-nochecks":
 		fakeBabysitGHNoChecksHandler(args)
 	default:
@@ -114,6 +117,54 @@ func fakeBabysitGHHandler(args []string) {
 	}
 	if strings.Contains(joined, "pr checks") {
 		fmt.Println(checksJSON)
+		os.Exit(0)
+	}
+	if strings.Contains(joined, "run view") {
+		fmt.Println("error log output")
+		os.Exit(0)
+	}
+	os.Exit(1)
+}
+
+func fakeBabysitGHSequenceHandler(args []string) {
+	state := os.Getenv("FAKE_CLI_STATE")
+	checksPath := os.Getenv("FAKE_CLI_CHECKS_PATH")
+	indexPath := os.Getenv("FAKE_CLI_CHECKS_INDEX_PATH")
+	joined := strings.Join(args, " ")
+
+	if len(args) >= 2 && args[0] == "auth" && args[1] == "status" {
+		os.Exit(0)
+	}
+	if strings.Contains(joined, "pr view") && strings.Contains(joined, "--json state") {
+		fmt.Println(state)
+		os.Exit(0)
+	}
+	if strings.Contains(joined, "pr checks") {
+		data, err := os.ReadFile(checksPath)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		entries := strings.Split(strings.TrimSpace(string(data)), "\n")
+		if len(entries) == 0 || entries[0] == "" {
+			fmt.Println("[]")
+			os.Exit(0)
+		}
+
+		index := 0
+		if rawIndex, err := os.ReadFile(indexPath); err == nil {
+			if parsed, err := strconv.Atoi(strings.TrimSpace(string(rawIndex))); err == nil {
+				index = parsed
+			}
+		}
+		if index >= len(entries) {
+			index = len(entries) - 1
+		}
+		if err := os.WriteFile(indexPath, []byte(strconv.Itoa(index+1)), 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		fmt.Println(entries[index])
 		os.Exit(0)
 	}
 	if strings.Contains(joined, "run view") {
@@ -3091,6 +3142,28 @@ func fakeBabysitGH(t *testing.T, state, checksJSON string) string {
 	return binDir
 }
 
+func fakeBabysitGHSequence(t *testing.T, state string, checks []string) string {
+	t.Helper()
+	binDir := fakeCLIBinDir(t)
+	linkTestBinary(t, binDir, "gh")
+
+	checksPath := filepath.Join(t.TempDir(), "checks.txt")
+	indexPath := filepath.Join(t.TempDir(), "checks-index.txt")
+
+	if err := os.WriteFile(checksPath, []byte(strings.Join(checks, "\n")), 0o644); err != nil {
+		t.Fatalf("write checks sequence: %v", err)
+	}
+	if err := os.WriteFile(indexPath, []byte("0"), 0o644); err != nil {
+		t.Fatalf("write checks index: %v", err)
+	}
+
+	t.Setenv("FAKE_CLI_MODE", "babysit-gh-seq")
+	t.Setenv("FAKE_CLI_STATE", state)
+	t.Setenv("FAKE_CLI_CHECKS_PATH", checksPath)
+	t.Setenv("FAKE_CLI_CHECKS_INDEX_PATH", indexPath)
+	return binDir
+}
+
 func fakeBabysitGHNoChecks(t *testing.T) string {
 	t.Helper()
 	binDir := fakeCLIBinDir(t)
@@ -3672,6 +3745,89 @@ func TestBabysitStep_CIAutoFixLimitExhausted(t *testing.T) {
 	}
 	if !foundExhausted {
 		t.Errorf("expected 'max auto-fix attempts' in logs, got: %v", logs)
+	}
+}
+
+func TestBabysitStep_CIAutoFixRetriesAfterChecksRerun(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	checksSequence := []string{
+		`[{"name":"test","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`,
+		`[{"name":"test","status":"IN_PROGRESS","bucket":"pending"}]`,
+		`[{"name":"test","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`,
+		`[{"name":"test","status":"IN_PROGRESS","bucket":"pending"}]`,
+		`[{"name":"test","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`,
+	}
+	binDir := fakeBabysitGHSequence(t, "OPEN", checksSequence)
+	prependPATH(t, binDir)
+
+	fixCount := 0
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			fixCount++
+			os.WriteFile(filepath.Join(opts.CWD, fmt.Sprintf("fix-%d.txt", fixCount)), []byte("fixed"), 0o644)
+			return &agent.Result{}, nil
+		},
+	}
+
+	prURL := "https://github.com/test/repo/pull/42"
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Run.PRURL = &prURL
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Config.BabysitTimeout = 10 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{Babysit: 2}
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+
+	step := &BabysitStep{
+		pollIntervalOverride: 50 * time.Millisecond,
+	}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatalf("expected approval outcome after retries, got error: %v", err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected approval after exhausting rerun-backed retries")
+	}
+	if outcome.AutoFixable {
+		t.Fatal("expected exhausted babysit outcome to be non-auto-fixable")
+	}
+	if fixCount != 2 {
+		t.Fatalf("expected 2 auto-fix attempts after reruns, got %d", fixCount)
+	}
+
+	foundExhausted := false
+	for _, l := range logs {
+		if strings.Contains(l, "max auto-fix attempts (2) reached") {
+			foundExhausted = true
+			break
+		}
+	}
+	if !foundExhausted {
+		t.Fatalf("expected max-attempts log after rerun-backed retries, got: %v", logs)
 	}
 }
 

--- a/internal/pipeline/steps/test.go
+++ b/internal/pipeline/steps/test.go
@@ -115,11 +115,13 @@ Rules:
 		}
 
 		needsApproval := hasBlockingFindings(findings.Items)
+		autoFixable := needsApproval
 
 		// Check if agent wrote new test files
 		newTests := detectNewTestFiles(ctx, sctx.WorkDir)
 		if len(newTests) > 0 {
 			needsApproval = true
+			autoFixable = false
 			for _, f := range newTests {
 				findings.Items = append(findings.Items, Finding{
 					Severity:    "info",
@@ -132,6 +134,7 @@ Rules:
 		findingsJSON, _ := json.Marshal(findings)
 		return &pipeline.StepOutcome{
 			NeedsApproval: needsApproval,
+			AutoFixable:   autoFixable,
 			Findings:      string(findingsJSON),
 		}, nil
 	}
@@ -156,6 +159,7 @@ Rules:
 		findingsJSON, _ := json.Marshal(findings)
 		return &pipeline.StepOutcome{
 			NeedsApproval: true,
+			AutoFixable:   true,
 			Findings:      string(findingsJSON),
 			ExitCode:      exitCode,
 		}, nil


### PR DESCRIPTION
## Summary
- add configurable auto-fix controls with per-step retry limits in pipeline config and execution
- separate auto-fix gating from manual approvals so babysit can apply manual CI fixes when enabled
- reset babysit retry state after reruns and expand test coverage around config, executor, and babysit flows