### PR TITLE
feat(rebase): agent-assisted conflict resolution and execution-only step duration

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -453,7 +453,7 @@ func TestFailStep(t *testing.T) {
 	run, _ := d.InsertRun(repo.ID, "feature", "abc", "def")
 	step, _ := d.InsertStepResult(run.ID, types.StepReview)
 
-	if err := d.FailStep(step.ID, "agent crashed"); err != nil {
+	if err := d.FailStep(step.ID, "agent crashed", 1500); err != nil {
 		t.Fatalf("fail step: %v", err)
 	}
 	got, _ := d.GetStepResult(step.ID)
@@ -462,6 +462,9 @@ func TestFailStep(t *testing.T) {
 	}
 	if got.Error == nil || *got.Error != "agent crashed" {
 		t.Errorf("error = %v, want %q", got.Error, "agent crashed")
+	}
+	if got.DurationMS == nil || *got.DurationMS != 1500 {
+		t.Errorf("duration_ms = %v, want 1500", got.DurationMS)
 	}
 }
 

--- a/internal/db/step.go
+++ b/internal/db/step.go
@@ -107,14 +107,23 @@ func (d *DB) CompleteStep(id string, exitCode int, durationMS int64, logPath str
 	return nil
 }
 
-// FailStep marks a step as failed with an error message.
-func (d *DB) FailStep(id string, errMsg string) error {
+// FailStep marks a step as failed with an error message and duration.
+func (d *DB) FailStep(id string, errMsg string, durationMS int64) error {
 	_, err := d.sql.Exec(
-		`UPDATE step_results SET status = ?, error = ?, completed_at = ? WHERE id = ?`,
-		types.StepStatusFailed, errMsg, now(), id,
+		`UPDATE step_results SET status = ?, error = ?, duration_ms = ?, completed_at = ? WHERE id = ?`,
+		types.StepStatusFailed, errMsg, durationMS, now(), id,
 	)
 	if err != nil {
 		return fmt.Errorf("fail step: %w", err)
+	}
+	return nil
+}
+
+// SetStepDuration sets the execution-only duration on a step result.
+func (d *DB) SetStepDuration(id string, durationMS int64) error {
+	_, err := d.sql.Exec(`UPDATE step_results SET duration_ms = ? WHERE id = ?`, durationMS, id)
+	if err != nil {
+		return fmt.Errorf("set step duration: %w", err)
 	}
 	return nil
 }

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -204,17 +204,18 @@ const (
 
 // Event is a real-time update sent to subscribers.
 type Event struct {
-	Type     EventType       `json:"type"`
-	RunID    string          `json:"run_id"`
-	RepoID   string          `json:"repo_id"`
-	StepName *types.StepName `json:"step_name,omitempty"`
-	Status   *string         `json:"status,omitempty"`
-	Error    *string         `json:"error,omitempty"`
-	Stream   *string         `json:"stream,omitempty"`
-	Content  *string         `json:"content,omitempty"`
-	Branch   *string         `json:"branch,omitempty"`
-	Findings *string         `json:"findings,omitempty"` // JSON-encoded findings for step_completed events
-	Diff     *string         `json:"diff,omitempty"`     // unified diff for fix_review events
+	Type       EventType       `json:"type"`
+	RunID      string          `json:"run_id"`
+	RepoID     string          `json:"repo_id"`
+	StepName   *types.StepName `json:"step_name,omitempty"`
+	Status     *string         `json:"status,omitempty"`
+	Error      *string         `json:"error,omitempty"`
+	Stream     *string         `json:"stream,omitempty"`
+	Content    *string         `json:"content,omitempty"`
+	Branch     *string         `json:"branch,omitempty"`
+	Findings   *string         `json:"findings,omitempty"`    // JSON-encoded findings for step_completed events
+	Diff       *string         `json:"diff,omitempty"`        // unified diff for fix_review events
+	DurationMS *int64          `json:"duration_ms,omitempty"` // execution-only duration for step events
 }
 
 // --- Helpers ---

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -139,7 +139,9 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 	}
 	e.emitStepEvent(ipc.EventStepStarted, run, repo, stepName, string(types.StepStatusRunning))
 
-	started := time.Now()
+	// Track execution-only time, excluding approval wait periods.
+	phaseStart := time.Now()
+	var executionMS int64
 
 	// Open log file for persistent step logging
 	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
@@ -161,6 +163,9 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			e.emitLogChunk(run, repo, stepName, text)
 			fmt.Fprintln(logFile, text)
 		},
+		LogFile: func(text string) {
+			fmt.Fprintln(logFile, text)
+		},
 	}
 
 	// Determine auto-fix limit for this step
@@ -174,10 +179,11 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 	for {
 		outcome, err := step.Execute(sctx)
 		if err != nil {
-			if dbErr := e.db.FailStep(sr.ID, err.Error()); dbErr != nil {
+			durationMS := executionMS + time.Since(phaseStart).Milliseconds()
+			if dbErr := e.db.FailStep(sr.ID, err.Error(), durationMS); dbErr != nil {
 				slog.Warn("failed to mark step as failed in db", "step", stepName, "error", dbErr)
 			}
-			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFailed), "", "", err.Error())
+			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFailed), "", "", err.Error(), &durationMS)
 			return fmt.Errorf("step %s failed: %w", stepName, err)
 		}
 
@@ -212,6 +218,9 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			continue
 		}
 
+		// Freeze execution timer before entering approval wait.
+		executionMS += time.Since(phaseStart).Milliseconds()
+
 		// Determine approval status: fix_review after a fix cycle, awaiting_approval otherwise
 		approvalStatus := types.StepStatusAwaitingApproval
 		var diffText string
@@ -225,51 +234,56 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			}
 		}
 
-		// Step needs approval - wait for user action
+		// Step needs approval - store execution-only duration and wait for user action.
 		if dbErr := e.db.UpdateStepStatus(sr.ID, approvalStatus); dbErr != nil {
 			slog.Warn("failed to update step status in db", "step", stepName, "status", approvalStatus, "error", dbErr)
 		}
-		e.emitStepEventWithFindingsAndDiff(ipc.EventStepCompleted, run, repo, stepName, string(approvalStatus), outcome.Findings, diffText)
+		if dbErr := e.db.SetStepDuration(sr.ID, executionMS); dbErr != nil {
+			slog.Warn("failed to set step duration in db", "step", stepName, "error", dbErr)
+		}
+		e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(approvalStatus), outcome.Findings, diffText, "", &executionMS)
 
 		response, err := e.waitForApproval(ctx, stepName)
 		if err != nil {
-			if dbErr := e.db.FailStep(sr.ID, err.Error()); dbErr != nil {
+			if dbErr := e.db.FailStep(sr.ID, err.Error(), executionMS); dbErr != nil {
 				slog.Warn("failed to mark step as failed in db", "step", stepName, "error", dbErr)
 			}
-			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFailed), "", "", err.Error())
+			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFailed), "", "", err.Error(), &executionMS)
 			return fmt.Errorf("step %s: waiting for approval: %w", stepName, err)
 		}
 
 		switch response.action {
 		case types.ActionApprove:
-			// Approved - break out of fix loop
+			// Approved - execution already frozen in executionMS, reset phaseStart
+			// so the done label computes no additional elapsed.
+			phaseStart = time.Now()
 			goto done
 
 		case types.ActionSkip:
 			// Skip - mark step skipped and return (not an error)
-			durationMS := time.Since(started).Milliseconds()
-			if err := e.db.CompleteStep(sr.ID, finalExitCode, durationMS, logPath); err != nil {
+			if err := e.db.CompleteStep(sr.ID, finalExitCode, executionMS, logPath); err != nil {
 				return fmt.Errorf("complete step %s (skip): %w", stepName, err)
 			}
 			if dbErr := e.db.UpdateStepStatus(sr.ID, types.StepStatusSkipped); dbErr != nil {
 				slog.Warn("failed to update step status in db", "step", stepName, "status", "skipped", "error", dbErr)
 			}
-			e.emitStepEvent(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusSkipped))
+			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusSkipped), "", "", "", &executionMS)
 			return nil
 
 		case types.ActionAbort:
-			if dbErr := e.db.FailStep(sr.ID, "aborted by user"); dbErr != nil {
+			if dbErr := e.db.FailStep(sr.ID, "aborted by user", executionMS); dbErr != nil {
 				slog.Warn("failed to mark step as failed in db", "step", stepName, "error", dbErr)
 			}
-			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFailed), "", "", "aborted by user")
+			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFailed), "", "", "aborted by user", &executionMS)
 			return fmt.Errorf("step %s: aborted by user", stepName)
 
 		case types.ActionFix:
-			// Fix - mark step as fixing, re-execute with previous findings
+			// Fix - mark step as fixing, resume execution timer, re-execute.
+			phaseStart = time.Now()
 			if dbErr := e.db.UpdateStepStatus(sr.ID, types.StepStatusFixing); dbErr != nil {
 				slog.Warn("failed to update step status in db", "step", stepName, "status", "fixing", "error", dbErr)
 			}
-			e.emitStepEvent(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFixing))
+			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFixing), "", "", "", &executionMS)
 			sctx.Fixing = true
 			sctx.PreviousFindings = filterFindingsJSON(outcome.Findings, response.findingIDs)
 			slog.Info("step fix requested, re-executing", "step", stepName)
@@ -278,12 +292,12 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 	}
 
 done:
-	// Mark step completed with timing
-	durationMS := time.Since(started).Milliseconds()
+	// Mark step completed with execution-only timing.
+	durationMS := executionMS + time.Since(phaseStart).Milliseconds()
 	if err := e.db.CompleteStep(sr.ID, finalExitCode, durationMS, logPath); err != nil {
 		return fmt.Errorf("complete step %s: %w", stepName, err)
 	}
-	e.emitStepEvent(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusCompleted))
+	e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusCompleted), "", "", "", &durationMS)
 	return nil
 }
 
@@ -361,16 +375,17 @@ func (e *Executor) emitStepEventWithFindings(eventType ipc.EventType, run *db.Ru
 }
 
 func (e *Executor) emitStepEventWithFindingsAndDiff(eventType ipc.EventType, run *db.Run, repo *db.Repo, stepName types.StepName, status string, findings string, diff string) {
-	e.emitStepEventWithFindingsDiffAndError(eventType, run, repo, stepName, status, findings, diff, "")
+	e.emitStepEventWithFindingsDiffAndError(eventType, run, repo, stepName, status, findings, diff, "", nil)
 }
 
-func (e *Executor) emitStepEventWithFindingsDiffAndError(eventType ipc.EventType, run *db.Run, repo *db.Repo, stepName types.StepName, status string, findings string, diff string, errMsg string) {
+func (e *Executor) emitStepEventWithFindingsDiffAndError(eventType ipc.EventType, run *db.Run, repo *db.Repo, stepName types.StepName, status string, findings string, diff string, errMsg string, durationMS *int64) {
 	event := ipc.Event{
-		Type:     eventType,
-		RunID:    run.ID,
-		RepoID:   repo.ID,
-		StepName: &stepName,
-		Status:   &status,
+		Type:       eventType,
+		RunID:      run.ID,
+		RepoID:     repo.ID,
+		StepName:   &stepName,
+		Status:     &status,
+		DurationMS: durationMS,
 	}
 	if errMsg != "" {
 		event.Error = &errMsg

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -209,10 +209,12 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 		if outcome.AutoFixable && autoFixLimit > 0 && autoFixAttempts < autoFixLimit {
 			autoFixAttempts++
 			slog.Info("auto-fixing step", "step", stepName, "attempt", autoFixAttempts, "max", autoFixLimit)
+			executionMS += time.Since(phaseStart).Milliseconds()
 			if dbErr := e.db.UpdateStepStatus(sr.ID, types.StepStatusFixing); dbErr != nil {
 				slog.Warn("failed to update step status in db", "step", stepName, "status", "fixing", "error", dbErr)
 			}
-			e.emitStepEvent(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFixing))
+			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFixing), "", "", "", &executionMS)
+			phaseStart = time.Now()
 			sctx.Fixing = true
 			sctx.PreviousFindings = outcome.Findings
 			continue

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -236,6 +236,14 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			}
 		}
 
+		// Mark executor as ready to receive approval before updating DB or
+		// emitting events, so that callers who poll the DB status can
+		// immediately call Respond once they see it.
+		e.mu.Lock()
+		e.waiting = true
+		e.waitingStep = stepName
+		e.mu.Unlock()
+
 		// Step needs approval - store execution-only duration and wait for user action.
 		if dbErr := e.db.UpdateStepStatus(sr.ID, approvalStatus); dbErr != nil {
 			slog.Warn("failed to update step status in db", "step", stepName, "status", approvalStatus, "error", dbErr)
@@ -304,12 +312,8 @@ done:
 }
 
 // waitForApproval blocks until a user action arrives or context is cancelled.
+// The caller must set e.waiting and e.waitingStep before calling this method.
 func (e *Executor) waitForApproval(ctx context.Context, stepName types.StepName) (approvalResponse, error) {
-	e.mu.Lock()
-	e.waiting = true
-	e.waitingStep = stepName
-	e.mu.Unlock()
-
 	defer func() {
 		e.mu.Lock()
 		e.waiting = false

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -213,7 +213,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			if dbErr := e.db.UpdateStepStatus(sr.ID, types.StepStatusFixing); dbErr != nil {
 				slog.Warn("failed to update step status in db", "step", stepName, "status", "fixing", "error", dbErr)
 			}
-			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFixing), "", "", "", &executionMS)
+			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFixing), "", "", "", nil)
 			phaseStart = time.Now()
 			sctx.Fixing = true
 			sctx.PreviousFindings = outcome.Findings
@@ -285,7 +285,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			if dbErr := e.db.UpdateStepStatus(sr.ID, types.StepStatusFixing); dbErr != nil {
 				slog.Warn("failed to update step status in db", "step", stepName, "status", "fixing", "error", dbErr)
 			}
-			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFixing), "", "", "", &executionMS)
+			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFixing), "", "", "", nil)
 			sctx.Fixing = true
 			sctx.PreviousFindings = filterFindingsJSON(outcome.Findings, response.findingIDs)
 			slog.Info("step fix requested, re-executing", "step", stepName)

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -301,6 +301,28 @@ func TestExecutor_StepError_FailsRun(t *testing.T) {
 	}
 }
 
+func TestExecutor_FailedStepRecordsDuration(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	steps := []Step{
+		newFailStep(types.StepReview, fmt.Errorf("review crashed")),
+	}
+
+	exec := NewExecutor(database, p, nil, nil, steps, nil)
+
+	err := exec.Execute(context.Background(), run, repo, workDir)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	// Failed step should still have duration_ms recorded.
+	dbSteps, _ := database.GetStepsByRun(run.ID)
+	if dbSteps[0].DurationMS == nil {
+		t.Error("expected failed step to have duration_ms recorded, got nil")
+	}
+}
+
 func TestExecutor_ApprovalApprove(t *testing.T) {
 	database, p, run, repo := setupTest(t)
 	workDir := t.TempDir()
@@ -366,6 +388,71 @@ func TestExecutor_ApprovalApprove(t *testing.T) {
 
 	// Should have awaiting_approval event
 	_ = events // events collected for verification
+}
+
+func TestExecutor_ApprovalDurationExcludesWaitTime(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	steps := []Step{
+		newApprovalStep(types.StepReview, `{"findings":[{"severity":"error","description":"bug"}],"summary":"1 issue"}`),
+	}
+
+	exec := NewExecutor(database, p, nil, nil, steps, nil)
+	events := collectEvents(exec)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- exec.Execute(context.Background(), run, repo, workDir)
+	}()
+
+	waitForStepStatus(t, database, run.ID, types.StepReview, types.StepStatusAwaitingApproval)
+
+	// Duration should be stored in DB while awaiting approval (execution-only time).
+	dbSteps, _ := database.GetStepsByRun(run.ID)
+	if dbSteps[0].DurationMS == nil {
+		t.Fatal("expected duration_ms to be set on awaiting_approval step")
+	}
+	execDuration := *dbSteps[0].DurationMS
+
+	// Simulate user taking time to review.
+	time.Sleep(200 * time.Millisecond)
+
+	exec.Respond(types.StepReview, types.ActionApprove, nil)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("executor timed out")
+	}
+
+	// Final duration should not include the 200ms+ approval wait time.
+	dbSteps, _ = database.GetStepsByRun(run.ID)
+	finalDuration := *dbSteps[0].DurationMS
+	if finalDuration > execDuration+100 {
+		t.Errorf("final duration %dms should not significantly exceed pre-approval duration %dms (approval wait should be excluded)", finalDuration, execDuration)
+	}
+
+	// The EventStepCompleted event for awaiting_approval should carry duration.
+	awaitingEvent := events.findLast(ipc.EventStepCompleted, string(types.StepStatusAwaitingApproval))
+	if awaitingEvent == nil {
+		t.Fatal("expected awaiting_approval step_completed event")
+	}
+	if awaitingEvent.DurationMS == nil {
+		t.Error("expected awaiting_approval event to carry DurationMS")
+	}
+
+	// The final completed event should also carry duration.
+	completedEvent := events.findLast(ipc.EventStepCompleted, string(types.StepStatusCompleted))
+	if completedEvent == nil {
+		t.Fatal("expected completed step_completed event")
+	}
+	if completedEvent.DurationMS == nil {
+		t.Error("expected completed event to carry DurationMS")
+	}
 }
 
 func TestExecutor_ApprovalApprovePreservesExitCode(t *testing.T) {

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -688,14 +688,8 @@ func TestExecutor_FixEmitsDiffAndFixReviewStatus(t *testing.T) {
 	// Send fix action
 	exec.Respond(types.StepReview, types.ActionFix, nil)
 
-	// After fix: step should reach fix_review
-	waitForStepStatus(t, database, run.ID, types.StepReview, types.StepStatusFixReview)
-
 	// Find the fix_review event
-	fixEvent := events.findLast(ipc.EventStepCompleted, string(types.StepStatusFixReview))
-	if fixEvent == nil {
-		t.Fatal("expected step_completed event with fix_review status")
-	}
+	fixEvent := waitForEvent(t, events, ipc.EventStepCompleted, string(types.StepStatusFixReview))
 
 	// Verify diff is included in the event
 	if fixEvent.Diff == nil || *fixEvent.Diff == "" {
@@ -805,13 +799,9 @@ func TestExecutor_FixReviewNoChanges(t *testing.T) {
 
 	waitForStepStatus(t, database, run.ID, types.StepReview, types.StepStatusAwaitingApproval)
 	exec.Respond(types.StepReview, types.ActionFix, nil)
-	waitForStepStatus(t, database, run.ID, types.StepReview, types.StepStatusFixReview)
 
 	// No changes made — diff should not be in event
-	fixEvent := events.findLast(ipc.EventStepCompleted, string(types.StepStatusFixReview))
-	if fixEvent == nil {
-		t.Fatal("expected fix_review event")
-	}
+	fixEvent := waitForEvent(t, events, ipc.EventStepCompleted, string(types.StepStatusFixReview))
 	if fixEvent.Diff != nil {
 		t.Error("expected no diff when agent made no changes")
 	}
@@ -1794,6 +1784,20 @@ type adaptiveCallStep struct {
 func (a *adaptiveCallStep) Name() types.StepName { return a.name }
 func (a *adaptiveCallStep) Execute(sctx *StepContext) (*StepOutcome, error) {
 	return a.fn(sctx)
+}
+
+// waitForEvent polls the event collector until an event with the given type and status appears.
+func waitForEvent(t *testing.T, ec *eventCollector, eventType ipc.EventType, status string) *ipc.Event {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if e := ec.findLast(eventType, status); e != nil {
+			return e
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("event %s with status %q not found within timeout", eventType, status)
+	return nil
 }
 
 // waitForStepStatus polls the DB until a step reaches the expected status.

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -674,10 +674,7 @@ func TestExecutor_FixEmitsDiffAndFixReviewStatus(t *testing.T) {
 	waitForStepStatus(t, database, run.ID, types.StepReview, types.StepStatusAwaitingApproval)
 
 	// Verify initial event has awaiting_approval status
-	initialEvent := events.find(ipc.EventStepCompleted, types.StepReview)
-	if initialEvent == nil {
-		t.Fatal("expected step_completed event for review")
-	}
+	initialEvent := waitForStepEvent(t, events, ipc.EventStepCompleted, types.StepReview)
 	if initialEvent.Status == nil || *initialEvent.Status != string(types.StepStatusAwaitingApproval) {
 		t.Errorf("expected awaiting_approval status, got %v", initialEvent.Status)
 	}
@@ -891,8 +888,8 @@ func TestExecutor_AssignsFindingIDsBeforePersistingAndEmitting(t *testing.T) {
 
 	waitForStepStatus(t, database, run.ID, types.StepReview, types.StepStatusAwaitingApproval)
 
-	paused := events.find(ipc.EventStepCompleted, types.StepReview)
-	if paused == nil || paused.Findings == nil {
+	paused := waitForStepEvent(t, events, ipc.EventStepCompleted, types.StepReview)
+	if paused.Findings == nil {
 		t.Fatal("expected paused step event with findings")
 	}
 
@@ -1784,6 +1781,20 @@ type adaptiveCallStep struct {
 func (a *adaptiveCallStep) Name() types.StepName { return a.name }
 func (a *adaptiveCallStep) Execute(sctx *StepContext) (*StepOutcome, error) {
 	return a.fn(sctx)
+}
+
+// waitForStepEvent polls the event collector until an event with the given type and step name appears.
+func waitForStepEvent(t *testing.T, ec *eventCollector, eventType ipc.EventType, stepName types.StepName) *ipc.Event {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if e := ec.find(eventType, stepName); e != nil {
+			return e
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("event %s for step %s not found within timeout", eventType, stepName)
+	return nil
 }
 
 // waitForEvent polls the event collector until an event with the given type and status appears.

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -18,7 +18,8 @@ type StepContext struct {
 	Agent            agent.Agent
 	Config           *config.Config
 	DB               *db.DB
-	Log              func(string) // streaming log callback
+	Log              func(string) // streaming log callback (user-visible + file)
+	LogFile          func(string) // file-only log callback (not shown to user)
 	Fixing           bool         // true when re-executing after a "fix" action
 	PreviousFindings string       // JSON findings from the previous execution (set during fix loop)
 }

--- a/internal/pipeline/steps/rebase.go
+++ b/internal/pipeline/steps/rebase.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
@@ -203,6 +204,9 @@ func rebaseInProgress(ctx context.Context, workDir string) bool {
 		p, err := git.Run(ctx, workDir, "rev-parse", "--git-path", dir)
 		if err != nil {
 			continue
+		}
+		if !filepath.IsAbs(p) {
+			p = filepath.Join(workDir, p)
 		}
 		if _, err := os.Stat(p); err == nil {
 			return true

--- a/internal/pipeline/steps/rebase.go
+++ b/internal/pipeline/steps/rebase.go
@@ -2,9 +2,12 @@ package steps
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
+	"github.com/kunchenguid/no-mistakes/internal/agent"
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/types"
@@ -25,25 +28,223 @@ func (s *RebaseStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome,
 
 	sctx.Log("fetching latest upstream state...")
 	if err := git.FetchRemoteBranch(ctx, sctx.WorkDir, "origin", defaultBranch); err != nil {
-		sctx.Log(fmt.Sprintf("warning: could not fetch origin/%s: %v", defaultBranch, err))
+		sctx.LogFile(fmt.Sprintf("warning: could not fetch origin/%s: %v", defaultBranch, err))
 	}
 	if branch != "" && branch != defaultBranch {
 		if err := git.FetchRemoteBranch(ctx, sctx.WorkDir, "origin", branch); err != nil {
-			sctx.Log(fmt.Sprintf("warning: could not fetch origin/%s: %v", branch, err))
+			sctx.LogFile(fmt.Sprintf("warning: could not fetch origin/%s: %v", branch, err))
 		}
 	}
 
-	if branch != "" && branch != defaultBranch {
-		if err := rebaseOntoIfPresent(ctx, sctx, "origin/"+branch); err != nil {
+	targets := rebaseTargets(branch, defaultBranch)
+
+	if sctx.Fixing {
+		for _, target := range targets {
+			if err := rebaseWithAgent(ctx, sctx, target); err != nil {
+				return nil, err
+			}
+		}
+		return updateHeadSHA(ctx, sctx)
+	}
+
+	// Normal mode: try rebases, return findings on conflict
+	for _, target := range targets {
+		outcome, err := tryRebase(ctx, sctx, target)
+		if err != nil {
 			return nil, err
 		}
+		if outcome != nil {
+			return outcome, nil
+		}
+	}
+
+	return updateHeadSHA(ctx, sctx)
+}
+
+// rebaseTargets returns the ordered list of refs to rebase onto.
+func rebaseTargets(branch, defaultBranch string) []string {
+	var targets []string
+	if branch != "" && branch != defaultBranch {
+		targets = append(targets, "origin/"+branch)
 	}
 	if branch != defaultBranch {
-		if err := rebaseOntoIfPresent(ctx, sctx, "origin/"+defaultBranch); err != nil {
-			return nil, err
-		}
+		targets = append(targets, "origin/"+defaultBranch)
+	}
+	return targets
+}
+
+// tryRebase attempts a rebase onto targetRef. Returns nil outcome on success,
+// or a StepOutcome with conflict findings if conflicts are detected.
+func tryRebase(ctx context.Context, sctx *pipeline.StepContext, targetRef string) (*pipeline.StepOutcome, error) {
+	skip, err := shouldSkipRebase(ctx, sctx, targetRef)
+	if err != nil {
+		return nil, err
+	}
+	if skip {
+		return nil, nil
 	}
 
+	sctx.Log(fmt.Sprintf("rebasing onto %s...", targetRef))
+	if _, err := git.Run(ctx, sctx.WorkDir, "rebase", targetRef); err != nil {
+		// Check for conflict files before aborting
+		conflictFiles := conflictingFiles(ctx, sctx.WorkDir)
+		_, _ = git.Run(ctx, sctx.WorkDir, "rebase", "--abort")
+
+		if len(conflictFiles) == 0 {
+			return nil, fmt.Errorf("rebase onto %s: %w", targetRef, err)
+		}
+
+		findings := buildConflictFindings(targetRef, conflictFiles)
+		findingsJSON, _ := json.Marshal(findings)
+		return &pipeline.StepOutcome{
+			NeedsApproval: true,
+			Findings:      string(findingsJSON),
+		}, nil
+	}
+	return nil, nil
+}
+
+// rebaseWithAgent performs a rebase and uses the agent to resolve any conflicts.
+func rebaseWithAgent(ctx context.Context, sctx *pipeline.StepContext, targetRef string) error {
+	skip, err := shouldSkipRebase(ctx, sctx, targetRef)
+	if err != nil {
+		return err
+	}
+	if skip {
+		return nil
+	}
+
+	sctx.Log(fmt.Sprintf("rebasing onto %s...", targetRef))
+	if _, err := git.Run(ctx, sctx.WorkDir, "rebase", targetRef); err == nil {
+		return nil
+	}
+
+	conflictFiles := conflictingFiles(ctx, sctx.WorkDir)
+	sctx.Log(fmt.Sprintf("conflicts detected in %d file(s), asking agent to resolve...", len(conflictFiles)))
+
+	prompt := fmt.Sprintf(
+		`Resolve git rebase conflicts. The rebase of the current branch onto %s has conflicts.
+
+Conflicting files:
+%s
+
+Instructions:
+- Edit each conflicting file to resolve the conflict markers (<<<<<<< ======= >>>>>>>).
+- After resolving each file, stage it with: git add <file>
+- After all conflicts are resolved, run: git rebase --continue
+- If additional conflicts arise during rebase --continue, resolve those too.
+- Do not modify any files that don't have conflicts.
+- Preserve the intent of both the current branch changes and the upstream changes.
+- Return JSON with a single "summary" field describing what you resolved.
+- Keep the summary under 10 words.`,
+		targetRef,
+		strings.Join(conflictFiles, "\n"),
+	)
+	if sctx.PreviousFindings != "" {
+		prompt += "\n\nPrevious findings:\n" + sctx.PreviousFindings
+	}
+
+	_, err = sctx.Agent.Run(ctx, agent.RunOpts{
+		Prompt:     prompt,
+		CWD:        sctx.WorkDir,
+		JSONSchema: commitSummarySchema,
+		OnChunk:    sctx.Log,
+	})
+	if err != nil {
+		_, _ = git.Run(ctx, sctx.WorkDir, "rebase", "--abort")
+		return fmt.Errorf("agent resolve conflicts: %w", err)
+	}
+
+	// Verify rebase completed (no rebase still in progress)
+	if rebaseInProgress(ctx, sctx.WorkDir) {
+		_, _ = git.Run(ctx, sctx.WorkDir, "rebase", "--abort")
+		return fmt.Errorf("agent did not complete the rebase")
+	}
+
+	return nil
+}
+
+// shouldSkipRebase checks whether a rebase onto targetRef can be skipped.
+// Returns true if targetRef doesn't exist, is already merged, or can be fast-forwarded.
+func shouldSkipRebase(ctx context.Context, sctx *pipeline.StepContext, targetRef string) (bool, error) {
+	if _, err := git.Run(ctx, sctx.WorkDir, "rev-parse", "--verify", targetRef); err != nil {
+		return true, nil
+	}
+	localSHA, err := git.HeadSHA(ctx, sctx.WorkDir)
+	if err != nil {
+		return false, fmt.Errorf("get local head: %w", err)
+	}
+	targetSHA, err := git.Run(ctx, sctx.WorkDir, "rev-parse", targetRef)
+	if err != nil {
+		return false, fmt.Errorf("get target head %s: %w", targetRef, err)
+	}
+	if localSHA == targetSHA {
+		sctx.Log(fmt.Sprintf("already up-to-date with %s", targetRef))
+		return true, nil
+	}
+	if _, err := git.Run(ctx, sctx.WorkDir, "merge-base", "--is-ancestor", targetRef, "HEAD"); err == nil {
+		sctx.Log(fmt.Sprintf("already ahead of %s", targetRef))
+		return true, nil
+	}
+	if _, err := git.Run(ctx, sctx.WorkDir, "merge-base", "--is-ancestor", "HEAD", targetRef); err == nil {
+		sctx.Log(fmt.Sprintf("fast-forwarding to %s", targetRef))
+		if _, err := git.Run(ctx, sctx.WorkDir, "reset", "--hard", targetRef); err != nil {
+			return false, fmt.Errorf("fast-forward to %s: %w", targetRef, err)
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+// rebaseInProgress returns true if a git rebase is currently in progress.
+// Uses git rev-parse --git-path which works for both regular repos and worktrees.
+func rebaseInProgress(ctx context.Context, workDir string) bool {
+	for _, dir := range []string{"rebase-merge", "rebase-apply"} {
+		p, err := git.Run(ctx, workDir, "rev-parse", "--git-path", dir)
+		if err != nil {
+			continue
+		}
+		if _, err := os.Stat(p); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// conflictingFiles returns the list of files with merge conflicts in the working tree.
+func conflictingFiles(ctx context.Context, workDir string) []string {
+	out, err := git.Run(ctx, workDir, "diff", "--name-only", "--diff-filter=U")
+	if err != nil {
+		return nil
+	}
+	var files []string
+	for _, f := range strings.Split(out, "\n") {
+		f = strings.TrimSpace(f)
+		if f != "" {
+			files = append(files, f)
+		}
+	}
+	return files
+}
+
+// buildConflictFindings creates a Findings struct from conflict information.
+func buildConflictFindings(targetRef string, files []string) Findings {
+	items := make([]Finding, len(files))
+	for i, f := range files {
+		items[i] = Finding{
+			Severity:    "error",
+			File:        f,
+			Description: fmt.Sprintf("merge conflict during rebase onto %s", targetRef),
+		}
+	}
+	return Findings{
+		Items:   items,
+		Summary: fmt.Sprintf("%d file(s) with merge conflicts rebasing onto %s", len(files), targetRef),
+	}
+}
+
+// updateHeadSHA syncs the run's head SHA after rebase.
+func updateHeadSHA(ctx context.Context, sctx *pipeline.StepContext) (*pipeline.StepOutcome, error) {
 	headSHA, err := git.HeadSHA(ctx, sctx.WorkDir)
 	if err != nil {
 		return nil, fmt.Errorf("resolve head after rebase: %w", err)
@@ -55,44 +256,7 @@ func (s *RebaseStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome,
 		}
 		sctx.Log(fmt.Sprintf("updated head SHA to %s", shortSHA(headSHA)))
 	}
-
 	return &pipeline.StepOutcome{}, nil
-}
-
-func rebaseOntoIfPresent(ctx context.Context, sctx *pipeline.StepContext, targetRef string) error {
-	if _, err := git.Run(ctx, sctx.WorkDir, "rev-parse", "--verify", targetRef); err != nil {
-		return nil
-	}
-	localSHA, err := git.HeadSHA(ctx, sctx.WorkDir)
-	if err != nil {
-		return fmt.Errorf("get local head: %w", err)
-	}
-	targetSHA, err := git.Run(ctx, sctx.WorkDir, "rev-parse", targetRef)
-	if err != nil {
-		return fmt.Errorf("get target head %s: %w", targetRef, err)
-	}
-	if localSHA == targetSHA {
-		sctx.Log(fmt.Sprintf("already up-to-date with %s", targetRef))
-		return nil
-	}
-	if _, err := git.Run(ctx, sctx.WorkDir, "merge-base", "--is-ancestor", targetRef, "HEAD"); err == nil {
-		sctx.Log(fmt.Sprintf("already ahead of %s", targetRef))
-		return nil
-	}
-	if _, err := git.Run(ctx, sctx.WorkDir, "merge-base", "--is-ancestor", "HEAD", targetRef); err == nil {
-		sctx.Log(fmt.Sprintf("fast-forwarding to %s", targetRef))
-		if _, err := git.Run(ctx, sctx.WorkDir, "reset", "--hard", targetRef); err != nil {
-			return fmt.Errorf("fast-forward to %s: %w", targetRef, err)
-		}
-		return nil
-	}
-
-	sctx.Log(fmt.Sprintf("rebasing onto %s...", targetRef))
-	if _, err := git.Run(ctx, sctx.WorkDir, "rebase", targetRef); err != nil {
-		_, _ = git.Run(ctx, sctx.WorkDir, "rebase", "--abort")
-		return fmt.Errorf("rebase onto %s: %w", targetRef, err)
-	}
-	return nil
 }
 
 func shortSHA(sha string) string {

--- a/internal/pipeline/steps/rebase.go
+++ b/internal/pipeline/steps/rebase.go
@@ -48,15 +48,35 @@ func (s *RebaseStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome,
 		return updateHeadSHA(ctx, sctx)
 	}
 
-	// Normal mode: try rebases, return findings on conflict
+	// Normal mode: try all rebases, accumulate conflict findings
+	var allFindings []Finding
+	var allSummaries []string
 	for _, target := range targets {
 		outcome, err := tryRebase(ctx, sctx, target)
 		if err != nil {
 			return nil, err
 		}
-		if outcome != nil {
-			return outcome, nil
+		if outcome != nil && outcome.Findings != "" {
+			var f Findings
+			if json.Unmarshal([]byte(outcome.Findings), &f) == nil {
+				allFindings = append(allFindings, f.Items...)
+				if f.Summary != "" {
+					allSummaries = append(allSummaries, f.Summary)
+				}
+			}
 		}
+	}
+
+	if len(allFindings) > 0 {
+		combined := Findings{
+			Items:   allFindings,
+			Summary: strings.Join(allSummaries, "; "),
+		}
+		findingsJSON, _ := json.Marshal(combined)
+		return &pipeline.StepOutcome{
+			NeedsApproval: true,
+			Findings:      string(findingsJSON),
+		}, nil
 	}
 
 	return updateHeadSHA(ctx, sctx)

--- a/internal/pipeline/steps/rebase.go
+++ b/internal/pipeline/steps/rebase.go
@@ -121,6 +121,10 @@ func rebaseWithAgent(ctx context.Context, sctx *pipeline.StepContext, targetRef 
 	}
 
 	conflictFiles := conflictingFiles(ctx, sctx.WorkDir)
+	if len(conflictFiles) == 0 {
+		_, _ = git.Run(ctx, sctx.WorkDir, "rebase", "--abort")
+		return fmt.Errorf("rebase onto %s failed (no conflict files detected)", targetRef)
+	}
 	sctx.Log(fmt.Sprintf("conflicts detected in %d file(s), asking agent to resolve...", len(conflictFiles)))
 
 	prompt := fmt.Sprintf(

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -669,6 +669,7 @@ func TestRebaseStep_FixModeCallsAgent(t *testing.T) {
 			cmd.Env = append(os.Environ(),
 				"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
 				"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+				"GIT_EDITOR=true",
 			)
 			if out, err := cmd.CombinedOutput(); err != nil {
 				return nil, fmt.Errorf("git rebase --continue: %s: %w", out, err)

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -633,6 +633,55 @@ func TestRebaseStep_FixModeCallsAgent(t *testing.T) {
 	}
 }
 
+func TestRebaseStep_FixModeNonConflictFailureReturnsError(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	os.WriteFile(filepath.Join(dir, "a.txt"), []byte("base\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "base commit")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "b.txt"), []byte("feature\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature change")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	// Advance main so rebase is needed
+	gitCmd(t, dir, "checkout", "main")
+	os.WriteFile(filepath.Join(dir, "c.txt"), []byte("main\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "main advance")
+	gitCmd(t, dir, "push", "origin", "main")
+	gitCmd(t, dir, "checkout", "feature")
+
+	// Dirty the working tree so rebase fails without conflict
+	os.WriteFile(filepath.Join(dir, "b.txt"), []byte("dirty\n"), 0o644)
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Fixing = true
+
+	step := &RebaseStep{}
+	_, err := step.Execute(sctx)
+	if err == nil {
+		t.Fatal("expected error for non-conflict rebase failure")
+	}
+	if len(ag.calls) != 0 {
+		t.Errorf("expected 0 agent calls for non-conflict failure, got %d", len(ag.calls))
+	}
+}
+
 func TestRebaseStep_LogFileNotVisibleToUser(t *testing.T) {
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -285,6 +285,7 @@ func newTestContext(t *testing.T, ag agent.Agent, workDir, baseSHA, headSHA stri
 		Config:  &config.Config{Agent: types.AgentClaude, Commands: cmds},
 		DB:      database,
 		Log:     func(s string) {},
+		LogFile: func(s string) {},
 	}
 }
 
@@ -481,6 +482,210 @@ func TestRebaseStep_RebasesOntoDefaultBranch(t *testing.T) {
 	}
 	if stored == nil || stored.HeadSHA != sctx.Run.HeadSHA {
 		t.Fatalf("stored head SHA = %v, want %s", stored, sctx.Run.HeadSHA)
+	}
+}
+
+func TestRebaseStep_ConflictReturnsFindings(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	os.WriteFile(filepath.Join(dir, "shared.txt"), []byte("base content\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "base commit")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	// Feature branch: modify shared.txt
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "shared.txt"), []byte("feature change\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature change")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	// Main branch: conflicting change to shared.txt
+	gitCmd(t, dir, "checkout", "main")
+	os.WriteFile(filepath.Join(dir, "shared.txt"), []byte("main change\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "main conflict")
+	gitCmd(t, dir, "push", "origin", "main")
+	gitCmd(t, dir, "checkout", "feature")
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Repo.UpstreamURL = upstream
+
+	step := &RebaseStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected NeedsApproval for conflict")
+	}
+	if outcome.Findings == "" {
+		t.Fatal("expected findings for conflict")
+	}
+	if !strings.Contains(outcome.Findings, "shared.txt") {
+		t.Errorf("expected findings to mention conflicting file, got: %s", outcome.Findings)
+	}
+	// Verify repo is clean (rebase was aborted)
+	status := gitStatusPorcelain(t, dir)
+	if status != "" {
+		t.Fatalf("expected clean worktree after abort, got: %s", status)
+	}
+	// Verify no agent calls in detection mode
+	if len(ag.calls) != 0 {
+		t.Errorf("expected 0 agent calls, got %d", len(ag.calls))
+	}
+}
+
+func TestRebaseStep_FixModeCallsAgent(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	os.WriteFile(filepath.Join(dir, "shared.txt"), []byte("base content\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "base commit")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "shared.txt"), []byte("feature change\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature change")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	gitCmd(t, dir, "checkout", "main")
+	os.WriteFile(filepath.Join(dir, "shared.txt"), []byte("main change\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "main conflict")
+	gitCmd(t, dir, "push", "origin", "main")
+	gitCmd(t, dir, "checkout", "feature")
+
+	// Agent simulates resolving conflicts: resolve file, git add, git rebase --continue
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			// Resolve the conflict by writing the merged content
+			os.WriteFile(filepath.Join(dir, "shared.txt"), []byte("resolved content\n"), 0o644)
+			cmd := exec.Command("git", "add", "shared.txt")
+			cmd.Dir = dir
+			cmd.Env = append(os.Environ(),
+				"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+				"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+			)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				return nil, fmt.Errorf("git add: %s: %w", out, err)
+			}
+			cmd = exec.Command("git", "rebase", "--continue")
+			cmd.Dir = dir
+			cmd.Env = append(os.Environ(),
+				"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test.com",
+				"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test.com",
+			)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				return nil, fmt.Errorf("git rebase --continue: %s: %w", out, err)
+			}
+			return &agent.Result{
+				Output: json.RawMessage(`{"summary":"resolve merge conflict in shared.txt"}`),
+			}, nil
+		},
+	}
+
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Fixing = true
+	sctx.PreviousFindings = `{"findings":[{"severity":"error","file":"shared.txt","description":"merge conflict"}]}`
+
+	step := &RebaseStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Fatal("expected no approval after successful fix")
+	}
+	if len(ag.calls) != 1 {
+		t.Fatalf("expected 1 agent call, got %d", len(ag.calls))
+	}
+	if !strings.Contains(ag.calls[0].Prompt, "shared.txt") {
+		t.Error("expected agent prompt to mention conflicting file")
+	}
+	// Verify rebase completed - feature is now ahead of origin/main
+	mergeBase := gitCmd(t, dir, "merge-base", "HEAD", "origin/main")
+	originMain := gitCmd(t, dir, "rev-parse", "origin/main")
+	if mergeBase != originMain {
+		t.Fatalf("merge-base = %s, want origin/main %s", mergeBase, originMain)
+	}
+}
+
+func TestRebaseStep_LogFileNotVisibleToUser(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	os.WriteFile(filepath.Join(dir, "f.txt"), []byte("content\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "init")
+	sha := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	// Feature branch with no upstream ref (will trigger fetch warning)
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "f2.txt"), []byte("feature\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, sha, headSHA, config.Commands{})
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Repo.UpstreamURL = upstream
+
+	var userLogs []string
+	var fileLogs []string
+	sctx.Log = func(s string) { userLogs = append(userLogs, s) }
+	sctx.LogFile = func(s string) { fileLogs = append(fileLogs, s) }
+
+	step := &RebaseStep{}
+	_, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Fetch warnings should go to file only, not user
+	for _, log := range userLogs {
+		if strings.Contains(log, "could not fetch") {
+			t.Errorf("fetch warning leaked to user logs: %s", log)
+		}
+	}
+	hasFileWarning := false
+	for _, log := range fileLogs {
+		if strings.Contains(log, "could not fetch") {
+			hasFileWarning = true
+		}
+	}
+	if !hasFileWarning {
+		t.Error("expected fetch warning in file logs")
 	}
 }
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -546,6 +546,80 @@ func TestRebaseStep_ConflictReturnsFindings(t *testing.T) {
 	}
 }
 
+func TestRebaseStep_ConflictTriesAllTargets(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	os.WriteFile(filepath.Join(dir, "shared.txt"), []byte("base\n"), 0o644)
+	os.WriteFile(filepath.Join(dir, "other.txt"), []byte("base\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "base commit")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	// Create feature branch, push it to origin
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "shared.txt"), []byte("feature-origin\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature origin change")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	// Diverge local feature from origin/feature (conflicting change to shared.txt)
+	gitCmd(t, dir, "reset", "--soft", "HEAD~1")
+	os.WriteFile(filepath.Join(dir, "shared.txt"), []byte("feature-local\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature local change")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	// Advance main with a non-conflicting change, push
+	gitCmd(t, dir, "checkout", "main")
+	os.WriteFile(filepath.Join(dir, "other.txt"), []byte("main update\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "main non-conflicting update")
+	gitCmd(t, dir, "push", "origin", "main")
+	gitCmd(t, dir, "checkout", "feature")
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Repo.UpstreamURL = upstream
+
+	step := &RebaseStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected NeedsApproval for conflict")
+	}
+	if !strings.Contains(outcome.Findings, "shared.txt") {
+		t.Errorf("expected findings to mention shared.txt, got: %s", outcome.Findings)
+	}
+
+	// The non-conflicting rebase onto origin/main should have succeeded
+	logOutput := gitCmd(t, dir, "log", "--oneline", "--all")
+	if !strings.Contains(logOutput, "main non-conflicting update") {
+		t.Log("git log:\n" + logOutput)
+	}
+	// Verify HEAD includes the main update (rebase onto origin/main applied)
+	headLog := gitCmd(t, dir, "log", "--oneline")
+	if !strings.Contains(headLog, "main non-conflicting update") {
+		t.Errorf("expected HEAD to include the origin/main rebase; git log:\n%s", headLog)
+	}
+
+	// Verify worktree is clean
+	status := gitStatusPorcelain(t, dir)
+	if status != "" {
+		t.Fatalf("expected clean worktree, got: %s", status)
+	}
+}
+
 func TestRebaseStep_FixModeCallsAgent(t *testing.T) {
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -87,13 +87,17 @@ func NewModel(socketPath string, client *ipc.Client, run *ipc.RunInfo) Model {
 		findingCursor:     make(map[types.StepName]int),
 		stepStartTimes:    make(map[types.StepName]time.Time),
 	}
-	// Populate findings from initial step data (for re-attach scenarios).
+	// Populate findings and start times from initial step data (for re-attach scenarios).
 	for _, s := range run.Steps {
 		if s.FindingsJSON != nil && *s.FindingsJSON != "" {
 			m.stepFindings[s.StepName] = *s.FindingsJSON
 			if s.Status == types.StepStatusAwaitingApproval || s.Status == types.StepStatusFixReview {
 				m.resetFindingSelection(s.StepName)
 			}
+		}
+		// Seed start times from DB so elapsed time can be computed on re-attach.
+		if s.StartedAt != nil && s.DurationMS == nil {
+			m.stepStartTimes[s.StepName] = time.UnixMilli(*s.StartedAt)
 		}
 	}
 	return m
@@ -569,7 +573,8 @@ func (m Model) stepsWithRunningElapsed() []ipc.StepResultInfo {
 			continue
 		}
 		switch steps[i].Status {
-		case types.StepStatusRunning, types.StepStatusFixing:
+		case types.StepStatusRunning, types.StepStatusFixing,
+			types.StepStatusAwaitingApproval, types.StepStatusFixReview:
 			if startTime, ok := m.stepStartTimes[steps[i].StepName]; ok {
 				elapsed := int64(time.Since(startTime).Milliseconds())
 				steps[i].DurationMS = &elapsed
@@ -908,10 +913,12 @@ func (m *Model) applyEvent(event ipc.Event) {
 		if event.StepName != nil && event.Error != nil {
 			m.setStepError(*event.StepName, event.Error)
 		}
-		// Compute and persist final duration from tracked start time so the
-		// completed step continues to display its elapsed time.
+		// Persist duration so the step continues to display its elapsed time.
+		// Prefer the event's execution-only duration; fall back to local timing.
 		if event.StepName != nil {
-			if startTime, ok := m.stepStartTimes[*event.StepName]; ok {
+			if event.DurationMS != nil {
+				m.setStepDuration(*event.StepName, event.DurationMS)
+			} else if startTime, ok := m.stepStartTimes[*event.StepName]; ok {
 				elapsed := int64(time.Since(startTime).Milliseconds())
 				m.setStepDuration(*event.StepName, &elapsed)
 			}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -915,7 +915,8 @@ func (m *Model) applyEvent(event ipc.Event) {
 		}
 		// Persist duration so the step continues to display its elapsed time.
 		// Prefer the event's execution-only duration; fall back to local timing.
-		if event.StepName != nil {
+		// Skip for "fixing" status so stepsWithRunningElapsed keeps the timer ticking.
+		if event.StepName != nil && (event.Status == nil || types.StepStatus(*event.Status) != types.StepStatusFixing) {
 			if event.DurationMS != nil {
 				m.setStepDuration(*event.StepName, event.DurationMS)
 			} else if startTime, ok := m.stepStartTimes[*event.StepName]; ok {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -5420,6 +5420,33 @@ func TestModel_ApplyEvent_StepCompletedPrefersEventDuration(t *testing.T) {
 	t.Fatal("Review step not found")
 }
 
+func TestModel_FixingEventDoesNotFreezeDuration(t *testing.T) {
+	configureTUIColors()
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusRunning
+
+	m := NewModel("", nil, run)
+	m.stepStartTimes[types.StepReview] = time.Now().Add(-5 * time.Second)
+
+	fixingStatus := string(types.StepStatusFixing)
+	stepName := types.StepReview
+	m.applyEvent(ipc.Event{
+		Type:     ipc.EventStepCompleted,
+		StepName: &stepName,
+		Status:   &fixingStatus,
+	})
+
+	for _, s := range m.steps {
+		if s.StepName == types.StepReview {
+			if s.DurationMS != nil {
+				t.Errorf("expected DurationMS to remain nil during fixing so timer keeps ticking, got %d", *s.DurationMS)
+			}
+			return
+		}
+	}
+	t.Fatal("Review step not found")
+}
+
 func TestRenderDiff_BlankLineBetweenFiles(t *testing.T) {
 	// Multi-file diff should have a blank line before the second file header.
 	raw := `diff --git a/foo.go b/foo.go

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -5304,6 +5304,122 @@ func TestModel_ApplyEvent_StepCompletedNoDurationWithoutStartTime(t *testing.T) 
 	t.Fatal("Review step not found in model steps")
 }
 
+// Test: When re-attaching, steps with StartedAt but no DurationMS get their
+// start times seeded into stepStartTimes so elapsed time can be computed.
+func TestNewModel_SeedsStartTimesFromStartedAt(t *testing.T) {
+	configureTUIColors()
+	startedAt := time.Now().Add(-10 * time.Second).UnixMilli()
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusAwaitingApproval
+	run.Steps[0].StartedAt = &startedAt
+
+	m := NewModel("", nil, run)
+
+	st, ok := m.stepStartTimes[types.StepReview]
+	if !ok {
+		t.Fatal("expected stepStartTimes to contain entry for Review step on re-attach")
+	}
+	// The seeded time should be approximately 10 seconds ago.
+	elapsed := time.Since(st)
+	if elapsed < 9*time.Second || elapsed > 12*time.Second {
+		t.Errorf("expected start time ~10s ago, got %v ago", elapsed)
+	}
+}
+
+// Test: stepsWithRunningElapsed computes elapsed time for AwaitingApproval steps.
+func TestModel_View_AwaitingApprovalShowsElapsedTime(t *testing.T) {
+	configureTUIColors()
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusAwaitingApproval
+
+	m := NewModel("", nil, run)
+	m.width = 80
+	m.height = 40
+	m.stepStartTimes[types.StepReview] = time.Now().Add(-7 * time.Second)
+
+	view := stripANSI(m.View())
+
+	if !strings.Contains(view, "7.0s") && !strings.Contains(view, "7.1s") && !strings.Contains(view, "6.9s") {
+		t.Errorf("expected awaiting approval step to show ~7.0s elapsed time, got:\n%s", view)
+	}
+}
+
+// Test: stepsWithRunningElapsed computes elapsed time for FixReview steps.
+func TestModel_View_FixReviewShowsElapsedTime(t *testing.T) {
+	configureTUIColors()
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusFixReview
+
+	m := NewModel("", nil, run)
+	m.width = 80
+	m.height = 40
+	m.stepStartTimes[types.StepReview] = time.Now().Add(-4 * time.Second)
+
+	view := stripANSI(m.View())
+
+	if !strings.Contains(view, "4.0s") && !strings.Contains(view, "4.1s") && !strings.Contains(view, "3.9s") {
+		t.Errorf("expected fix review step to show ~4.0s elapsed time, got:\n%s", view)
+	}
+}
+
+// Test: Re-attach scenario - step is awaiting approval, TUI connects and shows duration
+// computed from StartedAt in the initial run data.
+func TestModel_View_ReattachAwaitingApprovalShowsDuration(t *testing.T) {
+	configureTUIColors()
+	startedAt := time.Now().Add(-15 * time.Second).UnixMilli()
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusAwaitingApproval
+	run.Steps[0].StartedAt = &startedAt
+
+	m := NewModel("", nil, run)
+	m.width = 80
+	m.height = 40
+
+	view := stripANSI(m.View())
+
+	// Should show ~15s elapsed time even though we re-attached (no EventStepStarted received).
+	if !strings.Contains(view, "15.") && !strings.Contains(view, "14.9") && !strings.Contains(view, "15.0") && !strings.Contains(view, "15.1") {
+		t.Errorf("expected re-attached awaiting approval step to show ~15s elapsed, got:\n%s", view)
+	}
+}
+
+// Test: When EventStepCompleted carries DurationMS, it takes precedence over
+// the computed elapsed time from stepStartTimes.
+func TestModel_ApplyEvent_StepCompletedPrefersEventDuration(t *testing.T) {
+	configureTUIColors()
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusRunning
+
+	m := NewModel("", nil, run)
+	// Record a start time 10 seconds ago.
+	m.stepStartTimes[types.StepReview] = time.Now().Add(-10 * time.Second)
+
+	// Event carries execution-only duration of 2 seconds (excluding approval wait).
+	completedStatus := string(types.StepStatusCompleted)
+	stepName := types.StepReview
+	eventDuration := int64(2000)
+	m.applyEvent(ipc.Event{
+		Type:       ipc.EventStepCompleted,
+		StepName:   &stepName,
+		Status:     &completedStatus,
+		DurationMS: &eventDuration,
+	})
+
+	for _, s := range m.steps {
+		if s.StepName == types.StepReview {
+			if s.DurationMS == nil {
+				t.Fatal("expected DurationMS to be set")
+			}
+			// Should use event's 2000ms, not the computed ~10000ms.
+			if *s.DurationMS != 2000 {
+				t.Errorf("expected DurationMS = 2000 (from event), got %d", *s.DurationMS)
+			}
+			return
+		}
+	}
+	t.Fatal("Review step not found")
+}
+
 func TestRenderDiff_BlankLineBetweenFiles(t *testing.T) {
 	// Multi-file diff should have a blank line before the second file header.
 	raw := `diff --git a/foo.go b/foo.go


### PR DESCRIPTION
## Summary

- **Rebase conflict detection and resolution**: The rebase step now detects merge conflicts, aborts cleanly, and reports per-file conflict findings. In fix mode, an agent is invoked to resolve conflicts automatically (edit files, `git add`, `git rebase --continue`). Adds `tryRebase`, `rebaseWithAgent`, `shouldSkipRebase`, `rebaseInProgress`, `conflictingFiles`, and `buildConflictFindings` helpers. Conflicts against multiple targets (origin/branch + origin/main) are tried independently and findings are accumulated.
- **Execution-only duration tracking**: Step duration now excludes approval wait time. The executor freezes the timer before entering approval wait and resumes it on fix. `FailStep` now records duration. New `SetStepDuration` DB method persists execution time while awaiting approval. IPC events carry a `DurationMS` field so the TUI can display accurate timing.
- **TUI elapsed time improvements**: `stepsWithRunningElapsed` now computes elapsed time for `AwaitingApproval` and `FixReview` statuses. Re-attach seeds `stepStartTimes` from `StartedAt` in initial run data. Event-carried duration takes precedence over locally computed elapsed time. Timer keeps ticking during "fixing" transitions.
- **File-only logging**: New `LogFile` callback on `StepContext` for messages that should be persisted to the log file but not shown to the user (e.g., fetch warnings).

## Test plan

- [x] `TestExecutor_FailedStepRecordsDuration` - failed steps record duration_ms
- [x] `TestExecutor_ApprovalDurationExcludesWaitTime` - approval wait excluded from duration
- [x] `TestRebaseStep_ConflictReturnsFindings` - conflicts produce findings with file names
- [x] `TestRebaseStep_ConflictTriesAllTargets` - non-conflicting target still applied when another conflicts
- [x] `TestRebaseStep_FixModeCallsAgent` - agent resolves conflicts in fix mode
- [x] `TestRebaseStep_FixModeNonConflictFailureReturnsError` - non-conflict rebase failure returns error without agent
- [x] `TestRebaseStep_LogFileNotVisibleToUser` - fetch warnings go to file log only
- [x] `TestNewModel_SeedsStartTimesFromStartedAt` - re-attach seeds start times
- [x] `TestModel_View_AwaitingApprovalShowsElapsedTime` - awaiting approval shows elapsed
- [x] `TestModel_View_FixReviewShowsElapsedTime` - fix review shows elapsed
- [x] `TestModel_View_ReattachAwaitingApprovalShowsDuration` - re-attach shows duration
- [x] `TestModel_ApplyEvent_StepCompletedPrefersEventDuration` - event duration takes precedence
- [x] `TestFailStep` updated for new `durationMS` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)