### PR TITLE
feat(cli): add styled output for interactive and non-interactive commands

### DIFF
--- a/cmd/no-mistakes/main.go
+++ b/cmd/no-mistakes/main.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"log/slog"
 	"os"
 
 	"github.com/kunchenguid/no-mistakes/internal/cli"
 	"github.com/kunchenguid/no-mistakes/internal/daemon"
+	"github.com/kunchenguid/no-mistakes/internal/paths"
 	"github.com/kunchenguid/no-mistakes/internal/update"
 )
 
@@ -28,5 +31,24 @@ func main() {
 
 	update.MaybeNotifyAndCheck(os.Args[1:], os.Stderr)
 
+	// Redirect slog to a file for interactive CLI commands so logs never
+	// leak into user-facing output. The daemon process sets up its own
+	// file-based logger before reaching this point.
+	slog.SetDefault(slog.New(slog.NewTextHandler(cliLogWriter(), nil)))
+
 	cli.Execute()
+}
+
+// cliLogWriter returns a writer for CLI logs. Falls back to io.Discard
+// if the log file cannot be opened (e.g. before first init).
+func cliLogWriter() io.Writer {
+	p, err := paths.New()
+	if err != nil {
+		return io.Discard
+	}
+	f, err := os.OpenFile(p.CLILog(), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return io.Discard
+	}
+	return f
 }

--- a/cmd/no-mistakes/main_test.go
+++ b/cmd/no-mistakes/main_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCLILogWriterReturnsDiscardWhenLogsDirMissing(t *testing.T) {
+	nmHome := t.TempDir()
+	t.Setenv("NM_HOME", nmHome)
+
+	w := cliLogWriter()
+	if _, err := w.Write([]byte("hello\n")); err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(nmHome, "logs", "cli.log")); !os.IsNotExist(err) {
+		t.Fatalf("cli.log should not be created when logs dir is missing, stat err = %v", err)
+	}
+
+	if c, ok := w.(io.Closer); ok {
+		_ = c.Close()
+	}
+}
+
+func TestCLILogWriterAppendsToFileWhenLogsDirExists(t *testing.T) {
+	nmHome := t.TempDir()
+	t.Setenv("NM_HOME", nmHome)
+
+	logsDir := filepath.Join(nmHome, "logs")
+	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	w := cliLogWriter()
+	if _, err := w.Write([]byte("hello\n")); err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+	if c, ok := w.(io.Closer); ok {
+		if err := c.Close(); err != nil {
+			t.Fatalf("Close returned error: %v", err)
+		}
+	}
+
+	b, err := os.ReadFile(filepath.Join(logsDir, "cli.log"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(b) != "hello\n" {
+		t.Fatalf("cli.log contents = %q, want %q", string(b), "hello\n")
+	}
+}

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -82,9 +82,9 @@ func printNoActiveRun(w io.Writer, d *db.DB, repoID string) {
 			if len(shown) > recentRunsLimit {
 				shown = shown[:recentRunsLimit]
 			}
-			fmt.Fprintln(w, "No active run.")
+			fmt.Fprintf(w, "  %s\n", sDim.Render("No active run."))
 			fmt.Fprintln(w)
-			fmt.Fprintln(w, "Recent runs:")
+			fmt.Fprintf(w, "  %s\n", sCyan.Render("Recent runs"))
 			for _, r := range shown {
 				sha := r.HeadSHA
 				if len(sha) > 8 {
@@ -95,19 +95,19 @@ func printNoActiveRun(w io.Writer, d *db.DB, repoID string) {
 				if r.PRURL != nil {
 					pr = fmt.Sprintf("  %s", *r.PRURL)
 				}
-				fmt.Fprintf(w, "  %-12s %-20s %s  %s%s\n", r.Status, r.Branch, sha, age, pr)
+				fmt.Fprintf(w, "  %-12s %-20s %s  %s%s\n", runStatusStyle(r.Status), r.Branch, sDim.Render(sha), sDim.Render(age), pr)
 			}
 			if len(runs) > recentRunsLimit {
-				fmt.Fprintf(w, "  (%d more — run 'no-mistakes runs' to see all)\n", len(runs)-recentRunsLimit)
+				fmt.Fprintf(w, "  %s\n", sDim.Render(fmt.Sprintf("(%d more - run 'no-mistakes runs' to see all)", len(runs)-recentRunsLimit)))
 			}
 			fmt.Fprintln(w)
-			fmt.Fprintln(w, "Start a new pipeline:")
-			fmt.Fprintln(w, "  git push no-mistakes <branch>")
+			fmt.Fprintf(w, "  %s\n", sDim.Render("Start a new pipeline:"))
+			fmt.Fprintf(w, "  %s\n", sBold.Render("git push no-mistakes <branch>"))
 			return
 		}
 	}
-	fmt.Fprintln(w, "No active run. Push through the gate to start a pipeline:")
-	fmt.Fprintln(w, "  git push no-mistakes <branch>")
+	fmt.Fprintf(w, "  %s\n", sDim.Render("No active run. Push through the gate to start a pipeline:"))
+	fmt.Fprintf(w, "  %s\n", sBold.Render("git push no-mistakes <branch>"))
 }
 
 func formatAge(unixSec int64) string {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/kunchenguid/no-mistakes/internal/buildinfo"
 	"github.com/kunchenguid/no-mistakes/internal/daemon"
 	"github.com/kunchenguid/no-mistakes/internal/db"
@@ -19,6 +20,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/muesli/termenv"
 )
 
 func init() {
@@ -144,6 +146,18 @@ func TestRootHelp(t *testing.T) {
 	}
 	if !strings.Contains(out, "update") {
 		t.Errorf("help output should list update command, got: %s", out)
+	}
+}
+
+func TestSetColorProfileForOutputUsesAsciiForNonTTY(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	defer lipgloss.SetColorProfile(prev)
+
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	setColorProfileForOutput(new(bytes.Buffer))
+
+	if lipgloss.ColorProfile() != termenv.Ascii {
+		t.Fatalf("ColorProfile = %v, want %v", lipgloss.ColorProfile(), termenv.Ascii)
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -174,6 +174,12 @@ func TestInitAndEject(t *testing.T) {
 	if !strings.Contains(out, "git push no-mistakes") {
 		t.Errorf("init output should contain push instructions, got: %s", out)
 	}
+	if !strings.Contains(out, "|__| |_/") {
+		t.Errorf("init output should contain ASCII art banner, got: %s", out)
+	}
+	if !strings.Contains(out, "Gate initialized") {
+		t.Errorf("init output should contain success message, got: %s", out)
+	}
 
 	// Verify the no-mistakes remote was added.
 	cmd := exec.Command("git", "remote", "get-url", "no-mistakes")
@@ -203,8 +209,11 @@ daemonStarted:
 	if err != nil {
 		t.Fatalf("eject failed: %v\noutput: %s", err, out)
 	}
-	if !strings.Contains(out, "ejected") {
-		t.Errorf("eject output should say 'ejected', got: %s", out)
+	if !strings.Contains(out, "Gate removed") {
+		t.Errorf("eject output should say 'Gate removed', got: %s", out)
+	}
+	if !strings.Contains(out, resolved) {
+		t.Errorf("eject output should contain repo path %q, got: %s", resolved, out)
 	}
 
 	// Remote should be gone.
@@ -499,8 +508,8 @@ func TestDaemonStatusRunning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("daemon status failed: %v\noutput: %s", err, out)
 	}
-	if !strings.Contains(out, "daemon running (pid") {
-		t.Errorf("expected 'daemon running (pid N)', got: %s", out)
+	if !strings.Contains(out, "daemon running") {
+		t.Errorf("expected 'daemon running', got: %s", out)
 	}
 }
 
@@ -625,7 +634,7 @@ func TestRerunStartsPipelineForCurrentBranch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("rerun failed: %v\noutput: %s", err, out)
 	}
-	if !strings.Contains(out, "rerun started") {
+	if !strings.Contains(out, "Rerun started") {
 		t.Fatalf("expected rerun started output, got: %s", out)
 	}
 

--- a/internal/cli/daemon_cmd.go
+++ b/internal/cli/daemon_cmd.go
@@ -83,7 +83,7 @@ func newDaemonStartCmd() *cobra.Command {
 			if err := daemon.Start(p); err != nil {
 				return err
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), "daemon started")
+			fmt.Fprintf(cmd.OutOrStdout(), "  %s daemon started\n", sGreen.Render("✓"))
 			return nil
 		},
 	}
@@ -101,7 +101,7 @@ func newDaemonStopCmd() *cobra.Command {
 			if err := daemon.Stop(p); err != nil {
 				return err
 			}
-			fmt.Fprintln(cmd.OutOrStdout(), "daemon stopped")
+			fmt.Fprintf(cmd.OutOrStdout(), "  %s daemon stopped\n", sGreen.Render("✓"))
 			return nil
 		},
 	}
@@ -123,12 +123,12 @@ func newDaemonStatusCmd() *cobra.Command {
 			if alive {
 				pid, _ := daemon.ReadPID(p)
 				if pid > 0 {
-					fmt.Fprintf(cmd.OutOrStdout(), "daemon running (pid %d)\n", pid)
+					fmt.Fprintf(cmd.OutOrStdout(), "  %s daemon running %s\n", sGreen.Render("●"), sDim.Render(fmt.Sprintf("(pid %d)", pid)))
 				} else {
-					fmt.Fprintln(cmd.OutOrStdout(), "daemon running")
+					fmt.Fprintf(cmd.OutOrStdout(), "  %s daemon running\n", sGreen.Render("●"))
 				}
 			} else {
-				fmt.Fprintln(cmd.OutOrStdout(), "daemon not running")
+				fmt.Fprintf(cmd.OutOrStdout(), "  %s daemon not running\n", sDim.Render("○"))
 			}
 			return nil
 		},

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/daemon"
 	"github.com/kunchenguid/no-mistakes/internal/db"
@@ -20,51 +21,63 @@ func newDoctorCmd() *cobra.Command {
 			w := cmd.OutOrStdout()
 			allOK := true
 
+			ok := func(label, detail string) {
+				fmt.Fprintf(w, "  %s %s  %s\n", sGreen.Render("✓"), sDim.Render(label), detail)
+			}
+			warn := func(label, detail string) {
+				fmt.Fprintf(w, "  %s %s  %s\n", sYellow.Render("–"), sDim.Render(label), detail)
+			}
+			fail := func(label, detail string) {
+				fmt.Fprintf(w, "  %s %s  %s\n", sRed.Render("✗"), sDim.Render(label), detail)
+			}
+
+			fmt.Fprintf(w, "  %s\n", sCyan.Render("System"))
+
 			// 1. Check git.
 			if _, err := exec.LookPath("git"); err != nil {
-				fmt.Fprintf(w, "  git:            not found\n")
+				fail("git           ", "not found")
 				allOK = false
 			} else {
 				out, err := exec.Command("git", "--version").Output()
 				if err != nil {
-					fmt.Fprintf(w, "  git:            error (%v)\n", err)
+					fail("git           ", fmt.Sprintf("error (%v)", err))
 					allOK = false
 				} else {
-					fmt.Fprintf(w, "  git:            %s", out)
+					ok("git           ", strings.TrimSpace(string(out)))
 				}
 			}
 
 			// 2. Check gh CLI (optional but useful for PR/babysit steps).
 			if _, err := exec.LookPath("gh"); err != nil {
-				fmt.Fprintf(w, "  gh:             not found (optional, needed for PR/babysit)\n")
+				warn("gh            ", "not found "+sDim.Render("(optional, needed for PR/babysit)"))
 			} else {
-				fmt.Fprintf(w, "  gh:             ok\n")
+				ok("gh            ", "ok")
 			}
 
 			// 3. Check data directory.
 			p, err := paths.New()
 			if err != nil {
-				fmt.Fprintf(w, "  data directory: error resolving paths (%v)\n", err)
+				fail("data directory", fmt.Sprintf("error resolving paths (%v)", err))
 				allOK = false
 			} else if _, err := os.Stat(p.Root()); os.IsNotExist(err) {
-				fmt.Fprintf(w, "  data directory: not found (%s)\n", p.Root())
+				fail("data directory", fmt.Sprintf("not found (%s)", p.Root()))
 				allOK = false
 			} else {
-				fmt.Fprintf(w, "  data directory: %s\n", p.Root())
+				ok("data directory", p.Root())
 			}
 
 			// 4. Check database.
 			if p != nil {
 				if _, err := os.Stat(p.DB()); os.IsNotExist(err) {
-					fmt.Fprintf(w, "  database:       not found (will be created on first use)\n")
+					warn("database      ", "not found "+sDim.Render("(will be created on first use)"))
 				} else {
 					d, err := db.Open(p.DB())
 					if err != nil {
-						fmt.Fprintf(w, "  database:       error (%v)\n", err)
+						fail("database      ", fmt.Sprintf("error (%v)", err))
 						allOK = false
 					} else {
 						d.Close()
-						fmt.Fprintf(w, "  database:       ok\n")
+						ok("database      ", "ok")
 					}
 				}
 			}
@@ -73,9 +86,9 @@ func newDoctorCmd() *cobra.Command {
 			if p != nil {
 				alive, _ := daemon.IsRunning(p)
 				if alive {
-					fmt.Fprintf(w, "  daemon:         running\n")
+					ok("daemon        ", "running")
 				} else {
-					fmt.Fprintf(w, "  daemon:         stopped\n")
+					warn("daemon        ", "stopped")
 				}
 			}
 
@@ -89,17 +102,20 @@ func newDoctorCmd() *cobra.Command {
 				{"rovodev", "acli"},
 				{"opencode", "opencode"},
 			}
-			fmt.Fprintf(w, "\nagent binaries:\n")
+			fmt.Fprintln(w)
+			fmt.Fprintf(w, "  %s\n", sCyan.Render("Agents"))
 			for _, a := range agents {
+				label := fmt.Sprintf("%-14s", a.name)
 				if path, err := exec.LookPath(a.binary); err != nil {
-					fmt.Fprintf(w, "  %-14s  not found\n", a.name+":")
+					warn(label, "not found")
 				} else {
-					fmt.Fprintf(w, "  %-14s  %s\n", a.name+":", path)
+					ok(label, path)
 				}
 			}
 
 			if !allOK {
-				fmt.Fprintf(w, "\nsome checks failed\n")
+				fmt.Fprintln(w)
+				fmt.Fprintf(w, "  %s\n", sRed.Render("some checks failed"))
 			}
 
 			return nil

--- a/internal/cli/eject.go
+++ b/internal/cli/eject.go
@@ -21,11 +21,16 @@ and removes the repo record from the database.`,
 			}
 			defer d.Close()
 
-			if err := gate.Eject(cmd.Context(), d, p, "."); err != nil {
+			repo, err := gate.Eject(cmd.Context(), d, p, ".")
+			if err != nil {
 				return fmt.Errorf("eject: %w", err)
 			}
 
-			fmt.Fprintln(cmd.OutOrStdout(), "ejected no-mistakes gate")
+			w := cmd.OutOrStdout()
+			fmt.Fprintf(w, "  %s Gate removed\n", sGreen.Render("✓"))
+			fmt.Fprintln(w)
+			fmt.Fprintf(w, "  %s  %s\n", sDim.Render("  repo"), repo.WorkingPath)
+			fmt.Fprintf(w, "  %s  %s\n", sDim.Render("remote"), repo.UpstreamURL)
 			return nil
 		},
 	}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -8,6 +8,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const banner = `_  _ ____    _  _ _ ____ ___ ____ _  _ ____ ____
+|\ | |  |    |\/| | [__   |  |__| |_/  |___ [__
+| \| |__|    |  | | ___]  |  |  | | \_ |___ ___]`
+
 func newInitCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "init",
@@ -29,16 +33,23 @@ Run this from inside a git repository that has an "origin" remote.`,
 				return fmt.Errorf("init: %w", err)
 			}
 			if err := daemon.EnsureDaemon(p); err != nil {
-				if ejectErr := gate.Eject(cmd.Context(), d, p, "."); ejectErr != nil {
+				if _, ejectErr := gate.Eject(cmd.Context(), d, p, "."); ejectErr != nil {
 					return fmt.Errorf("start daemon: %w, rollback init: %v", err, ejectErr)
 				}
 				return fmt.Errorf("start daemon: %w", err)
 			}
 
-			fmt.Fprintf(cmd.OutOrStdout(), "initialized gate for %s\n", repo.WorkingPath)
-			fmt.Fprintf(cmd.OutOrStdout(), "  remote: no-mistakes → %s\n", p.RepoDir(repo.ID))
-			fmt.Fprintf(cmd.OutOrStdout(), "  upstream: %s\n", repo.UpstreamURL)
-			fmt.Fprintf(cmd.OutOrStdout(), "\nPush through the gate with: git push no-mistakes <branch>\n")
+			w := cmd.OutOrStdout()
+			fmt.Fprintln(w, sCyan.Render(banner))
+			fmt.Fprintln(w)
+			fmt.Fprintf(w, "  %s Gate initialized\n", sGreen.Render("✓"))
+			fmt.Fprintln(w)
+			fmt.Fprintf(w, "  %s  %s\n", sDim.Render("  repo"), repo.WorkingPath)
+			fmt.Fprintf(w, "  %s  no-mistakes → %s\n", sDim.Render("  gate"), p.RepoDir(repo.ID))
+			fmt.Fprintf(w, "  %s  %s\n", sDim.Render("remote"), repo.UpstreamURL)
+			fmt.Fprintln(w)
+			fmt.Fprintf(w, "  %s\n", sDim.Render("Push through the gate with:"))
+			fmt.Fprintf(w, "  %s\n", sBold.Render("git push no-mistakes <branch>"))
 			return nil
 		},
 	}

--- a/internal/cli/rerun.go
+++ b/internal/cli/rerun.go
@@ -50,7 +50,7 @@ func newRerunCmd() *cobra.Command {
 				return fmt.Errorf("rerun pipeline: %w", err)
 			}
 
-			fmt.Fprintf(cmd.OutOrStdout(), "rerun started for %s: %s\n", branch, result.RunID)
+			fmt.Fprintf(cmd.OutOrStdout(), "  %s Rerun started for %s %s\n", sGreen.Render("✓"), branch, sDim.Render(result.RunID))
 			return nil
 		},
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4,12 +4,18 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/kunchenguid/no-mistakes/internal/buildinfo"
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
 )
+
+func init() {
+	lipgloss.SetColorProfile(termenv.ANSI)
+}
 
 // Execute runs the root CLI command.
 func Execute() {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/charmbracelet/lipgloss"
@@ -12,10 +13,6 @@ import (
 	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
 )
-
-func init() {
-	lipgloss.SetColorProfile(termenv.ANSI)
-}
 
 // Execute runs the root CLI command.
 func Execute() {
@@ -30,6 +27,9 @@ func newRootCmd() *cobra.Command {
 		Use:     "no-mistakes",
 		Short:   "Local Git proxy that validates code before pushing upstream",
 		Version: buildinfo.String(),
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			setColorProfileForOutput(cmd.OutOrStdout())
+		},
 		// Silence cobra's default error/usage printing — we handle it ourselves.
 		SilenceErrors: true,
 		SilenceUsage:  true,
@@ -50,6 +50,10 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(newDoctorCmd())
 
 	return cmd
+}
+
+func setColorProfileForOutput(w io.Writer) {
+	lipgloss.SetColorProfile(termenv.NewOutput(w).EnvColorProfile())
 }
 
 // findRepo looks up the repo for the current directory. If the working

--- a/internal/cli/runs.go
+++ b/internal/cli/runs.go
@@ -2,8 +2,10 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"time"
 
+	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/spf13/cobra"
 )
 
@@ -34,8 +36,8 @@ func newRunsCmd() *cobra.Command {
 			w := cmd.OutOrStdout()
 
 			if len(runs) == 0 {
-				fmt.Fprintln(w, "no runs yet. Push through the gate to start a pipeline:")
-				fmt.Fprintln(w, "  git push no-mistakes <branch>")
+				fmt.Fprintf(w, "  %s\n", sDim.Render("no runs yet. Push through the gate to start a pipeline:"))
+				fmt.Fprintf(w, "  %s\n", sBold.Render("git push no-mistakes <branch>"))
 				return nil
 			}
 
@@ -46,21 +48,11 @@ func newRunsCmd() *cobra.Command {
 			}
 
 			for _, r := range shown {
-				ts := time.Unix(r.CreatedAt, 0).Format("2006-01-02 15:04")
-				sha := r.HeadSHA
-				if len(sha) > 8 {
-					sha = sha[:8]
-				}
-				status := string(r.Status)
-				pr := ""
-				if r.PRURL != nil {
-					pr = fmt.Sprintf("  %s", *r.PRURL)
-				}
-				fmt.Fprintf(w, "%-12s %-20s %s  %s%s\n", status, r.Branch, sha, ts, pr)
+				printRunLine(w, r)
 			}
 
 			if len(runs) > len(shown) {
-				fmt.Fprintf(w, "\n(%d more runs, use --limit to see more)\n", len(runs)-len(shown))
+				fmt.Fprintf(w, "\n  %s\n", sDim.Render(fmt.Sprintf("(%d more runs, use --limit to see more)", len(runs)-len(shown))))
 			}
 
 			return nil
@@ -69,4 +61,17 @@ func newRunsCmd() *cobra.Command {
 
 	cmd.Flags().IntVar(&limit, "limit", 10, "maximum number of runs to display")
 	return cmd
+}
+
+func printRunLine(w io.Writer, r *db.Run) {
+	ts := time.Unix(r.CreatedAt, 0).Format("2006-01-02 15:04")
+	sha := r.HeadSHA
+	if len(sha) > 8 {
+		sha = sha[:8]
+	}
+	pr := ""
+	if r.PRURL != nil {
+		pr = fmt.Sprintf("  %s", *r.PRURL)
+	}
+	fmt.Fprintf(w, "  %-12s %-20s %s  %s%s\n", runStatusStyle(r.Status), r.Branch, sDim.Render(sha), sDim.Render(ts), pr)
 }

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -29,16 +29,16 @@ func newStatusCmd() *cobra.Command {
 				return nil
 			}
 
-			fmt.Fprintf(w, "repo:     %s\n", repo.WorkingPath)
-			fmt.Fprintf(w, "upstream: %s\n", repo.UpstreamURL)
-			fmt.Fprintf(w, "gate:     %s\n", p.RepoDir(repo.ID))
+			fmt.Fprintf(w, "  %s  %s\n", sDim.Render("  repo:"), repo.WorkingPath)
+			fmt.Fprintf(w, "  %s  %s\n", sDim.Render("remote:"), repo.UpstreamURL)
+			fmt.Fprintf(w, "  %s  %s\n", sDim.Render("  gate:"), p.RepoDir(repo.ID))
 
 			// Check daemon status.
 			alive, _ := daemon.IsRunning(p)
 			if alive {
-				fmt.Fprintf(w, "daemon:   running\n")
+				fmt.Fprintf(w, "  %s  %s %s\n", sDim.Render("daemon:"), sGreen.Render("●"), "running")
 			} else {
-				fmt.Fprintf(w, "daemon:   stopped\n")
+				fmt.Fprintf(w, "  %s  %s %s\n", sDim.Render("daemon:"), sDim.Render("○"), "stopped")
 			}
 
 			// Check for active run.
@@ -47,14 +47,17 @@ func newStatusCmd() *cobra.Command {
 				return fmt.Errorf("check active run: %w", err)
 			}
 			if activeRun != nil {
-				fmt.Fprintf(w, "\nactive run:\n")
-				fmt.Fprintf(w, "  id:     %s\n", activeRun.ID)
-				fmt.Fprintf(w, "  branch: %s\n", activeRun.Branch)
-				fmt.Fprintf(w, "  status: %s\n", activeRun.Status)
-				fmt.Fprintf(w, "  head:   %s\n", activeRun.HeadSHA[:minLen(len(activeRun.HeadSHA), 8)])
-				fmt.Fprintf(w, "  started: %s\n", time.Unix(activeRun.CreatedAt, 0).Format(time.DateTime))
+				fmt.Fprintln(w)
+				fmt.Fprintf(w, "  %s\n", sCyan.Render("Active run"))
+				sha := activeRun.HeadSHA[:minLen(len(activeRun.HeadSHA), 8)]
+				ts := time.Unix(activeRun.CreatedAt, 0).Format(time.DateTime)
+				fmt.Fprintf(w, "  %s  %s\n", sDim.Render("     id:"), activeRun.ID)
+				fmt.Fprintf(w, "  %s  %s\n", sDim.Render(" branch:"), activeRun.Branch)
+				fmt.Fprintf(w, "  %s  %s\n", sDim.Render(" status:"), runStatusStyle(activeRun.Status))
+				fmt.Fprintf(w, "  %s  %s\n", sDim.Render("   head:"), sDim.Render(sha))
+				fmt.Fprintf(w, "  %s  %s\n", sDim.Render("started:"), sDim.Render(ts))
 			} else {
-				fmt.Fprintf(w, "\nno active run\n")
+				fmt.Fprintf(w, "\n  %s\n", sDim.Render("no active run"))
 			}
 
 			return nil

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -39,8 +39,8 @@ func TestStatusInitialized(t *testing.T) {
 	if !strings.Contains(out, "repo:") {
 		t.Errorf("status output should contain repo info, got: %s", out)
 	}
-	if !strings.Contains(out, "upstream:") {
-		t.Errorf("status output should contain upstream info, got: %s", out)
+	if !strings.Contains(out, "remote:") {
+		t.Errorf("status output should contain remote info, got: %s", out)
 	}
 	if !strings.Contains(out, "daemon:") {
 		t.Errorf("status output should contain daemon status, got: %s", out)
@@ -103,8 +103,8 @@ func TestStatusWithActiveRun(t *testing.T) {
 	}
 
 	// Should show active run section.
-	if !strings.Contains(out, "active run:") {
-		t.Errorf("expected 'active run:' section, got: %s", out)
+	if !strings.Contains(out, "Active run") {
+		t.Errorf("expected 'Active run' section, got: %s", out)
 	}
 	if !strings.Contains(out, "feature/auth") {
 		t.Errorf("expected branch 'feature/auth', got: %s", out)

--- a/internal/cli/style.go
+++ b/internal/cli/style.go
@@ -1,0 +1,31 @@
+package cli
+
+import (
+	"github.com/charmbracelet/lipgloss"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+var (
+	sRed    = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
+	sGreen  = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+	sYellow = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
+	sBlue   = lipgloss.NewStyle().Foreground(lipgloss.Color("4"))
+	sCyan   = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
+	sDim    = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	sBold   = lipgloss.NewStyle().Bold(true)
+)
+
+// runStatusStyle returns a styled string for the given run status.
+func runStatusStyle(status types.RunStatus) string {
+	s := string(status)
+	switch status {
+	case types.RunCompleted:
+		return sGreen.Render(s)
+	case types.RunFailed:
+		return sRed.Render(s)
+	case types.RunRunning:
+		return sBlue.Render(s)
+	default:
+		return sDim.Render(s)
+	}
+}

--- a/internal/cli/style_output_test.go
+++ b/internal/cli/style_output_test.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"bytes"
+	"regexp"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+var ansiEscapeRE = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func TestStyledCommandOutputDoesNotEmitANSIForNonTTY(t *testing.T) {
+	setupTestRepo(t)
+
+	out, err := executeCmd("doctor")
+	if err != nil {
+		t.Fatalf("doctor failed: %v\noutput: %s", err, out)
+	}
+	if ansiEscapeRE.MatchString(out) {
+		t.Fatalf("doctor output should not include ANSI escape sequences, got: %q", out)
+	}
+
+	out, err = executeCmd("daemon", "status")
+	if err != nil {
+		t.Fatalf("daemon status failed: %v\noutput: %s", err, out)
+	}
+	if ansiEscapeRE.MatchString(out) {
+		t.Fatalf("daemon status output should not include ANSI escape sequences, got: %q", out)
+	}
+
+	setColorProfileForOutput(new(bytes.Buffer))
+	buf := new(bytes.Buffer)
+	printRunLine(buf, &db.Run{Branch: "feature", HeadSHA: "1234567890", Status: types.RunCompleted})
+	if ansiEscapeRE.MatchString(buf.String()) {
+		t.Fatalf("run line output should not include ANSI escape sequences, got: %q", buf.String())
+	}
+
+}

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -95,21 +95,21 @@ func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Re
 // Eject removes the no-mistakes gate from the repo at workDir.
 // It removes the remote, deletes the bare repo and worktrees,
 // and deletes the repo record from the database.
-func Eject(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) error {
+func Eject(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Repo, error) {
 	// Find git root (resolves symlinks for consistency on macOS).
 	gitRoot, err := git.FindGitRoot(workDir)
 	if err != nil {
-		return fmt.Errorf("find git root: %w", err)
+		return nil, fmt.Errorf("find git root: %w", err)
 	}
 	absRoot := gitRoot
 
 	// Look up repo in DB.
 	repo, err := d.GetRepoByPath(absRoot)
 	if err != nil {
-		return fmt.Errorf("get repo: %w", err)
+		return nil, fmt.Errorf("get repo: %w", err)
 	}
 	if repo == nil {
-		return fmt.Errorf("not initialized for %s", absRoot)
+		return nil, fmt.Errorf("not initialized for %s", absRoot)
 	}
 
 	// Remove remote from working repo (non-fatal).
@@ -125,9 +125,9 @@ func Eject(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) error 
 
 	// Delete repo record (cascades to runs + steps).
 	if err := d.DeleteRepo(repo.ID); err != nil {
-		return fmt.Errorf("delete repo record: %w", err)
+		return nil, fmt.Errorf("delete repo record: %w", err)
 	}
 
 	slog.Info("gate ejected", "repo_id", repo.ID, "path", absRoot)
-	return nil
+	return repo, nil
 }

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -279,7 +279,7 @@ func TestEject(t *testing.T) {
 		t.Fatalf("init: %v", err)
 	}
 
-	if err := Eject(ctx, d, p, workDir); err != nil {
+	if _, err := Eject(ctx, d, p, workDir); err != nil {
 		t.Fatalf("eject: %v", err)
 	}
 
@@ -326,7 +326,7 @@ func TestEjectCleansUpWorktrees(t *testing.T) {
 		t.Fatalf("create worktree dir: %v", err)
 	}
 
-	if err := Eject(ctx, d, p, workDir); err != nil {
+	if _, err := Eject(ctx, d, p, workDir); err != nil {
 		t.Fatalf("eject: %v", err)
 	}
 
@@ -350,7 +350,7 @@ func TestEjectNotInitialized(t *testing.T) {
 	}
 	d := openTestDB(t, p)
 
-	err := Eject(context.Background(), d, p, work)
+	_, err := Eject(context.Background(), d, p, work)
 	if err == nil {
 		t.Fatal("expected error when not initialized")
 	}

--- a/internal/git/hook.go
+++ b/internal/git/hook.go
@@ -18,8 +18,6 @@ func PostReceiveHookScript() string {
 }
 
 func postReceiveHookScript(command string) string {
-	// ANSI escape codes for styling (follows DESIGN.md color roles).
-	// Cyan (36) = accent, Green (32) = success, Bright black (90) = muted, Bold (1).
 	return `#!/bin/sh
 # no-mistakes post-receive hook
 # Notify daemon of push. Non-blocking - push always succeeds.
@@ -34,15 +32,7 @@ while read oldrev newrev refname; do
     --old "$oldrev" \
     --new "$newrev" >/dev/null 2>&1 || true
 done
-cat >&2 <<'BANNER'
-` + "\033[36m" + `_  _ ____    _  _ _ ____ ___ ____ _  _ ____ ____
-|\ | |  |    |\/| | [__   |  |__| |_/  |___ [__
-| \| |__|    |  | | ___]  |  |  | | \_ |___ ___]` + "\033[0m" + `
-
-  ` + "\033[32m" + `✓` + "\033[0m" + ` Pipeline started
-
-  ` + "\033[90m" + `Run` + "\033[0m" + ` ` + "\033[1m" + `no-mistakes` + "\033[0m" + ` ` + "\033[90m" + `to review.` + "\033[0m" + `
-BANNER
+printf '%s\n' 'Pipeline started. Run no-mistakes to review.' >&2
 exit 0
 `
 }

--- a/internal/git/hook.go
+++ b/internal/git/hook.go
@@ -18,6 +18,8 @@ func PostReceiveHookScript() string {
 }
 
 func postReceiveHookScript(command string) string {
+	// ANSI escape codes for styling (follows DESIGN.md color roles).
+	// Cyan (36) = accent, Green (32) = success, Bright black (90) = muted, Bold (1).
 	return `#!/bin/sh
 # no-mistakes post-receive hook
 # Notify daemon of push. Non-blocking - push always succeeds.
@@ -32,7 +34,15 @@ while read oldrev newrev refname; do
     --old "$oldrev" \
     --new "$newrev" >/dev/null 2>&1 || true
 done
-printf '%s\n' 'no-mistakes: pipeline started. Run ` + "`no-mistakes`" + ` to review.' >&2
+cat >&2 <<'BANNER'
+` + "\033[36m" + `_  _ ____    _  _ _ ____ ___ ____ _  _ ____ ____
+|\ | |  |    |\/| | [__   |  |__| |_/  |___ [__
+| \| |__|    |  | | ___]  |  |  | | \_ |___ ___]` + "\033[0m" + `
+
+  ` + "\033[32m" + `✓` + "\033[0m" + ` Pipeline started
+
+  ` + "\033[90m" + `Run` + "\033[0m" + ` ` + "\033[1m" + `no-mistakes` + "\033[0m" + ` ` + "\033[90m" + `to review.` + "\033[0m" + `
+BANNER
 exit 0
 `
 }

--- a/internal/git/hook_test.go
+++ b/internal/git/hook_test.go
@@ -45,12 +45,18 @@ func TestPostReceiveHookScript(t *testing.T) {
 		t.Fatal("hook should suppress notifier output so pushes stay clean")
 	}
 
-	// should print user-facing message to stderr
-	if !strings.Contains(script, "no-mistakes") && !strings.Contains(script, ">&2") {
+	// should print styled user-facing message to stderr
+	if !strings.Contains(script, ">&2") {
 		t.Fatal("hook should print message to stderr")
 	}
-	if !strings.Contains(script, "printf '%s\\n' 'no-mistakes: pipeline started. Run `no-mistakes` to review.' >&2") {
-		t.Fatal("hook should print a literal backticked command without command substitution")
+	if !strings.Contains(script, "|__| |_/") {
+		t.Fatal("hook should contain ASCII art banner")
+	}
+	if !strings.Contains(script, "Pipeline started") {
+		t.Fatal("hook should print pipeline started message")
+	}
+	if !strings.Contains(script, "no-mistakes") {
+		t.Fatal("hook should mention the command name")
 	}
 
 	// should exit 0 (never block push)

--- a/internal/git/hook_test.go
+++ b/internal/git/hook_test.go
@@ -45,18 +45,21 @@ func TestPostReceiveHookScript(t *testing.T) {
 		t.Fatal("hook should suppress notifier output so pushes stay clean")
 	}
 
-	// should print styled user-facing message to stderr
+	// should print plain user-facing message to stderr
 	if !strings.Contains(script, ">&2") {
 		t.Fatal("hook should print message to stderr")
 	}
-	if !strings.Contains(script, "|__| |_/") {
-		t.Fatal("hook should contain ASCII art banner")
+	if strings.Contains(script, "\033[") {
+		t.Fatal("hook should not include ANSI escape sequences")
 	}
 	if !strings.Contains(script, "Pipeline started") {
 		t.Fatal("hook should print pipeline started message")
 	}
 	if !strings.Contains(script, "no-mistakes") {
 		t.Fatal("hook should mention the command name")
+	}
+	if strings.Contains(script, "|__| |_/") {
+		t.Fatal("hook should not contain ASCII art banner")
 	}
 
 	// should exit 0 (never block push)

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -53,6 +53,7 @@ func (p *Paths) RunLogDir(runID string) string {
 	return filepath.Join(p.root, "logs", runID)
 }
 func (p *Paths) DaemonLog() string { return filepath.Join(p.root, "logs", "daemon.log") }
+func (p *Paths) CLILog() string    { return filepath.Join(p.root, "logs", "cli.log") }
 
 // EnsureDirs creates all required directories under root.
 func (p *Paths) EnsureDirs() error {


### PR DESCRIPTION
## Summary
- add shared CLI output styling and wire it into command entrypoints so terminal-facing output is more consistent
- update command flows such as `doctor`, `runs`, `status`, `attach`, `init`, and daemon-related paths to use the new styled output behavior
- cover the new output paths with CLI and command tests, including non-interactive styling regressions

## Testing
- Not run in this drafting context.