### PR TITLE
fix(tui): preserve and flush review log output

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -945,14 +945,16 @@ func (m *Model) applyEvent(event ipc.Event) {
 
 	case ipc.EventLogChunk:
 		if event.Content != nil && *event.Content != "" {
+			if m.logPartial != "" && len(m.logs) > 0 && m.logs[len(m.logs)-1] == m.logPartial {
+				m.logs = m.logs[:len(m.logs)-1]
+			}
+
 			text := m.logPartial + *event.Content
 			m.logPartial = ""
 
 			if !strings.HasSuffix(text, "\n") {
-				// No trailing newline - the last segment is a partial line.
 				idx := strings.LastIndex(text, "\n")
 				if idx == -1 {
-					// Entire chunk is partial - buffer it, nothing to commit.
 					m.logPartial = text
 					text = ""
 				} else {
@@ -965,7 +967,9 @@ func (m *Model) applyEvent(event ipc.Event) {
 				lines := strings.Split(strings.TrimRight(text, "\n"), "\n")
 				m.logs = append(m.logs, lines...)
 			}
-			// Keep last 100 lines to bound memory.
+			if m.logPartial != "" {
+				m.logs = append(m.logs, m.logPartial)
+			}
 			if len(m.logs) > 100 {
 				m.logs = m.logs[len(m.logs)-100:]
 			}
@@ -984,6 +988,10 @@ func (m *Model) updateStepStatus(name types.StepName, status types.StepStatus) {
 
 func (m *Model) flushPartialLog() {
 	if m.logPartial == "" {
+		return
+	}
+	if len(m.logs) > 0 && m.logs[len(m.logs)-1] == m.logPartial {
+		m.logPartial = ""
 		return
 	}
 	m.logs = append(m.logs, m.logPartial)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -54,6 +54,7 @@ type Model struct {
 	findingSelections map[types.StepName]map[string]bool // step name → finding ID → selected
 	findingCursor     map[types.StepName]int             // step name → current finding cursor
 	logs              []string
+	logPartial        string // buffered partial line (no trailing newline yet)
 
 	// Timing.
 	stepStartTimes map[types.StepName]time.Time // when each step started running
@@ -97,7 +98,7 @@ func NewModel(socketPath string, client *ipc.Client, run *ipc.RunInfo) Model {
 		}
 		// Seed start times from DB so elapsed time can be computed on re-attach.
 		if s.StartedAt != nil && s.DurationMS == nil {
-			m.stepStartTimes[s.StepName] = time.UnixMilli(*s.StartedAt)
+			m.stepStartTimes[s.StepName] = time.Unix(*s.StartedAt, 0)
 		}
 	}
 	return m
@@ -942,8 +943,26 @@ func (m *Model) applyEvent(event ipc.Event) {
 
 	case ipc.EventLogChunk:
 		if event.Content != nil && *event.Content != "" {
-			lines := strings.Split(strings.TrimRight(*event.Content, "\n"), "\n")
-			m.logs = append(m.logs, lines...)
+			text := m.logPartial + *event.Content
+			m.logPartial = ""
+
+			if !strings.HasSuffix(text, "\n") {
+				// No trailing newline - the last segment is a partial line.
+				idx := strings.LastIndex(text, "\n")
+				if idx == -1 {
+					// Entire chunk is partial - buffer it, nothing to commit.
+					m.logPartial = text
+					text = ""
+				} else {
+					m.logPartial = text[idx+1:]
+					text = text[:idx+1]
+				}
+			}
+
+			if text != "" {
+				lines := strings.Split(strings.TrimRight(text, "\n"), "\n")
+				m.logs = append(m.logs, lines...)
+			}
 			// Keep last 100 lines to bound memory.
 			if len(m.logs) > 100 {
 				m.logs = m.logs[len(m.logs)-100:]

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -897,6 +897,7 @@ func (m *Model) applyEvent(event ipc.Event) {
 		if event.Error != nil {
 			m.run.Error = event.Error
 		}
+		m.flushPartialLog()
 		m.done = true
 
 	case ipc.EventStepStarted:
@@ -908,6 +909,7 @@ func (m *Model) applyEvent(event ipc.Event) {
 
 	case ipc.EventStepCompleted:
 		m.err = nil
+		m.flushPartialLog()
 		if event.StepName != nil && event.Status != nil {
 			m.updateStepStatus(*event.StepName, types.StepStatus(*event.Status))
 		}
@@ -977,6 +979,17 @@ func (m *Model) updateStepStatus(name types.StepName, status types.StepStatus) {
 			m.steps[i].Status = status
 			return
 		}
+	}
+}
+
+func (m *Model) flushPartialLog() {
+	if m.logPartial == "" {
+		return
+	}
+	m.logs = append(m.logs, m.logPartial)
+	m.logPartial = ""
+	if len(m.logs) > 100 {
+		m.logs = m.logs[len(m.logs)-100:]
 	}
 }
 

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -7333,3 +7333,71 @@ func TestModel_ApplyEvent_LogChunk_MixedPartialAndComplete(t *testing.T) {
 		t.Errorf("expected %q, got %q", "partial end", m.logs[1])
 	}
 }
+
+func TestModel_ApplyEvent_LogChunk_FlushesPartialOnStepCompleted(t *testing.T) {
+	run := testRun()
+	m := NewModel("/tmp/sock", nil, run)
+
+	m.applyEvent(ipc.Event{
+		Type:    ipc.EventLogChunk,
+		RunID:   run.ID,
+		Content: ptr("last line without newline"),
+	})
+
+	m.applyEvent(ipc.Event{
+		Type:     ipc.EventStepCompleted,
+		RunID:    run.ID,
+		StepName: ptr(types.StepName("review")),
+		Status:   ptr(string(types.StepStatusCompleted)),
+	})
+
+	if len(m.logs) != 1 {
+		t.Fatalf("expected 1 log line, got %d: %v", len(m.logs), m.logs)
+	}
+	if m.logs[0] != "last line without newline" {
+		t.Fatalf("expected flushed log line, got %q", m.logs[0])
+	}
+	if m.logPartial != "" {
+		t.Fatalf("expected partial log buffer to be cleared, got %q", m.logPartial)
+	}
+
+	m.applyEvent(ipc.Event{
+		Type:    ipc.EventLogChunk,
+		RunID:   run.ID,
+		Content: ptr("next line\n"),
+	})
+
+	if len(m.logs) != 2 {
+		t.Fatalf("expected 2 log lines, got %d: %v", len(m.logs), m.logs)
+	}
+	if m.logs[1] != "next line" {
+		t.Fatalf("expected independent next line, got %q", m.logs[1])
+	}
+}
+
+func TestModel_ApplyEvent_LogChunk_FlushesPartialOnRunCompleted(t *testing.T) {
+	run := testRun()
+	m := NewModel("/tmp/sock", nil, run)
+
+	m.applyEvent(ipc.Event{
+		Type:    ipc.EventLogChunk,
+		RunID:   run.ID,
+		Content: ptr("trailing output"),
+	})
+
+	m.applyEvent(ipc.Event{
+		Type:   ipc.EventRunCompleted,
+		RunID:  run.ID,
+		Status: ptr(string(types.RunCompleted)),
+	})
+
+	if len(m.logs) != 1 {
+		t.Fatalf("expected 1 log line, got %d: %v", len(m.logs), m.logs)
+	}
+	if m.logs[0] != "trailing output" {
+		t.Fatalf("expected flushed log line, got %q", m.logs[0])
+	}
+	if m.logPartial != "" {
+		t.Fatalf("expected partial log buffer to be cleared, got %q", m.logPartial)
+	}
+}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -7280,11 +7280,33 @@ func TestModel_ApplyEvent_LogChunk_PartialLines(t *testing.T) {
 		RunID:   run.ID,
 		Content: ptr("hello "),
 	})
+
+	if len(m.logs) != 1 {
+		t.Fatalf("expected partial line to be visible, got %d: %v", len(m.logs), m.logs)
+	}
+	if m.logs[0] != "hello " {
+		t.Fatalf("expected visible partial %q, got %q", "hello ", m.logs[0])
+	}
+	if m.logPartial != "hello " {
+		t.Fatalf("expected buffered partial %q, got %q", "hello ", m.logPartial)
+	}
+
 	m.applyEvent(ipc.Event{
 		Type:    ipc.EventLogChunk,
 		RunID:   run.ID,
 		Content: ptr("world"),
 	})
+
+	if len(m.logs) != 1 {
+		t.Fatalf("expected updated partial line to remain visible, got %d: %v", len(m.logs), m.logs)
+	}
+	if m.logs[0] != "hello world" {
+		t.Fatalf("expected visible partial %q, got %q", "hello world", m.logs[0])
+	}
+	if m.logPartial != "hello world" {
+		t.Fatalf("expected buffered partial %q, got %q", "hello world", m.logPartial)
+	}
+
 	m.applyEvent(ipc.Event{
 		Type:    ipc.EventLogChunk,
 		RunID:   run.ID,
@@ -7311,12 +7333,18 @@ func TestModel_ApplyEvent_LogChunk_MixedPartialAndComplete(t *testing.T) {
 		Content: ptr("line1\npartial"),
 	})
 
-	// Should have committed "line1" and buffered "partial".
-	if len(m.logs) != 1 {
-		t.Fatalf("expected 1 committed line, got %d: %v", len(m.logs), m.logs)
+	// Should have committed "line1" and kept the partial visible.
+	if len(m.logs) != 2 {
+		t.Fatalf("expected 2 visible lines, got %d: %v", len(m.logs), m.logs)
 	}
 	if m.logs[0] != "line1" {
 		t.Errorf("expected %q, got %q", "line1", m.logs[0])
+	}
+	if m.logs[1] != "partial" {
+		t.Errorf("expected %q, got %q", "partial", m.logs[1])
+	}
+	if m.logPartial != "partial" {
+		t.Fatalf("expected buffered partial %q, got %q", "partial", m.logPartial)
 	}
 
 	// Completing the partial line.

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -5377,8 +5377,9 @@ func TestModel_View_ReattachAwaitingApprovalShowsDuration(t *testing.T) {
 
 	view := stripANSI(m.View())
 
-	// Should show ~15s elapsed time even though we re-attached (no EventStepStarted received).
-	if !strings.Contains(view, "15.") && !strings.Contains(view, "14.9") && !strings.Contains(view, "15.0") && !strings.Contains(view, "15.1") {
+	// StartedAt is seeded from Unix seconds, so sub-second truncation plus render delay
+	// can round this re-attach duration up to 16.0s on slower CI runners.
+	if !strings.Contains(view, "15.") && !strings.Contains(view, "14.9") && !strings.Contains(view, "15.0") && !strings.Contains(view, "15.1") && !strings.Contains(view, "16.0") {
 		t.Errorf("expected re-attached awaiting approval step to show ~15s elapsed, got:\n%s", view)
 	}
 }

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -5308,7 +5308,7 @@ func TestModel_ApplyEvent_StepCompletedNoDurationWithoutStartTime(t *testing.T) 
 // start times seeded into stepStartTimes so elapsed time can be computed.
 func TestNewModel_SeedsStartTimesFromStartedAt(t *testing.T) {
 	configureTUIColors()
-	startedAt := time.Now().Add(-10 * time.Second).UnixMilli()
+	startedAt := time.Now().Add(-10 * time.Second).Unix()
 	run := testRun()
 	run.Steps[0].Status = types.StepStatusAwaitingApproval
 	run.Steps[0].StartedAt = &startedAt
@@ -5366,7 +5366,7 @@ func TestModel_View_FixReviewShowsElapsedTime(t *testing.T) {
 // computed from StartedAt in the initial run data.
 func TestModel_View_ReattachAwaitingApprovalShowsDuration(t *testing.T) {
 	configureTUIColors()
-	startedAt := time.Now().Add(-15 * time.Second).UnixMilli()
+	startedAt := time.Now().Add(-15 * time.Second).Unix()
 	run := testRun()
 	run.Steps[0].Status = types.StepStatusAwaitingApproval
 	run.Steps[0].StartedAt = &startedAt
@@ -7230,5 +7230,106 @@ func TestModel_View_LogBoxStaysSmallWhenFindingsPresent(t *testing.T) {
 	if logContentLines > 5 {
 		t.Errorf("expected log box to stay <=5 lines when findings present, got %d\nview:\n%s",
 			logContentLines, plain)
+	}
+}
+
+func TestNewModel_ReattachStartedAtUsesUnixSeconds(t *testing.T) {
+	configureTUIColors()
+	run := testRun()
+	// Simulate a running step that started 3 seconds ago, with StartedAt stored
+	// as Unix seconds (as db.now() returns).
+	startedAt := time.Now().Add(-3 * time.Second).Unix()
+	run.Steps[0].Status = types.StepStatusRunning
+	run.Steps[0].StartedAt = &startedAt
+
+	m := NewModel("", nil, run)
+	m.width = 80
+	m.height = 40
+
+	view := stripANSI(m.View())
+
+	// The elapsed time should be approximately 3 seconds, not billions.
+	// If the bug exists (UnixMilli instead of Unix), it would show ~1.7 billion seconds.
+	if strings.Contains(view, "1774") || strings.Contains(view, "17742") {
+		t.Errorf("step duration looks like a raw unix timestamp, re-attach used UnixMilli instead of Unix:\n%s", view)
+	}
+	// Should show a reasonable elapsed time (under 10 seconds, not billions).
+	// Extract the duration from the Review line.
+	for _, line := range strings.Split(view, "\n") {
+		if strings.Contains(line, "Review") {
+			// Duration should be small (a few seconds), not a timestamp.
+			if !strings.Contains(line, "s") {
+				t.Errorf("expected Review line to contain a duration, got: %q", line)
+			}
+			// Should NOT contain any absurdly large number.
+			if strings.Contains(line, "17742") {
+				t.Errorf("duration still looks like a unix timestamp: %q", line)
+			}
+			break
+		}
+	}
+}
+
+func TestModel_ApplyEvent_LogChunk_PartialLines(t *testing.T) {
+	run := testRun()
+	m := NewModel("/tmp/sock", nil, run)
+
+	// Simulate streaming chunks without trailing newlines (like OpenCode SSE deltas).
+	m.applyEvent(ipc.Event{
+		Type:    ipc.EventLogChunk,
+		RunID:   run.ID,
+		Content: ptr("hello "),
+	})
+	m.applyEvent(ipc.Event{
+		Type:    ipc.EventLogChunk,
+		RunID:   run.ID,
+		Content: ptr("world"),
+	})
+	m.applyEvent(ipc.Event{
+		Type:    ipc.EventLogChunk,
+		RunID:   run.ID,
+		Content: ptr("\n"),
+	})
+
+	// "hello world" should be a single log line, not three separate lines.
+	if len(m.logs) != 1 {
+		t.Fatalf("expected 1 log line, got %d: %v", len(m.logs), m.logs)
+	}
+	if m.logs[0] != "hello world" {
+		t.Errorf("expected %q, got %q", "hello world", m.logs[0])
+	}
+}
+
+func TestModel_ApplyEvent_LogChunk_MixedPartialAndComplete(t *testing.T) {
+	run := testRun()
+	m := NewModel("/tmp/sock", nil, run)
+
+	// A chunk that has a complete line and a partial one.
+	m.applyEvent(ipc.Event{
+		Type:    ipc.EventLogChunk,
+		RunID:   run.ID,
+		Content: ptr("line1\npartial"),
+	})
+
+	// Should have committed "line1" and buffered "partial".
+	if len(m.logs) != 1 {
+		t.Fatalf("expected 1 committed line, got %d: %v", len(m.logs), m.logs)
+	}
+	if m.logs[0] != "line1" {
+		t.Errorf("expected %q, got %q", "line1", m.logs[0])
+	}
+
+	// Completing the partial line.
+	m.applyEvent(ipc.Event{
+		Type:    ipc.EventLogChunk,
+		RunID:   run.ID,
+		Content: ptr(" end\n"),
+	})
+
+	if len(m.logs) != 2 {
+		t.Fatalf("expected 2 log lines, got %d: %v", len(m.logs), m.logs)
+	}
+	if m.logs[1] != "partial end" {
+		t.Errorf("expected %q, got %q", "partial end", m.logs[1])
 	}
 }


### PR DESCRIPTION
## Summary
- improve TUI review log handling so partial log lines remain visible instead of being dropped
- flush buffered log output when review execution completes
- add coverage for log buffering behavior and start time seeding in TUI tests