### PR TITLE
fix(tui): clamp babysit pipeline height in stacked layout

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -27,6 +27,12 @@ const (
 	responsiveLeftMinWidth   = 38
 	responsiveLeftMaxWidth   = 48
 	responsiveRightMinWidth  = 48
+
+	// cappedPipelineHeight is the height passed to renderPipelineView when
+	// an overlay (help) is active in non-responsive (stacked) layout.
+	// Kept below 30 to suppress connector lines and save vertical space
+	// for the overlay that stacks below.
+	cappedPipelineHeight = 29
 )
 
 func (e errMsg) Error() string { return e.err.Error() }
@@ -177,8 +183,8 @@ func (m Model) View() string {
 	// Compute elapsed times for running steps so they display live durations.
 	pipelineSteps := m.stepsWithRunningElapsed()
 	pipelineHeight := m.height
-	if (m.showHelp || hasBabysit) && (pipelineHeight == 0 || pipelineHeight >= 30) {
-		pipelineHeight = 29
+	if !useResponsiveLayout && (m.showHelp || hasBabysit) && (pipelineHeight == 0 || pipelineHeight >= 30) {
+		pipelineHeight = cappedPipelineHeight
 	}
 	pipelineView := renderPipelineView(m.run, pipelineSteps, leftWidth, m.spinnerFrame, pipelineHeight)
 	banner := renderOutcomeBanner(m.run, m.steps)

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -7496,3 +7496,32 @@ func TestPipelineConnectors_NotSuppressedDuringBabysit(t *testing.T) {
 		}
 	}
 }
+
+func TestPipelineConnectors_SuppressedDuringBabysitInStackedLayout(t *testing.T) {
+	// When babysit is active in stacked layout, the pipeline height should be
+	// capped so the babysit panel still has room below it.
+	configureTUIColors()
+	run := testRunWithBabysit()
+	for i := range run.Steps {
+		run.Steps[i].Status = types.StepStatusCompleted
+		dur := int64(1000)
+		run.Steps[i].DurationMS = &dur
+	}
+	run.Steps[len(run.Steps)-1].Status = types.StepStatusRunning
+	run.Steps[len(run.Steps)-1].DurationMS = nil
+
+	m := NewModel("", nil, run)
+	m.width = 80 // narrow enough to force stacked layout
+	m.height = 50
+
+	view := stripANSI(m.View())
+	expectedPipeline := stripANSI(renderPipelineView(run, m.stepsWithRunningElapsed(), m.width, 0, cappedPipelineHeight))
+	uncappedPipeline := stripANSI(renderPipelineView(run, m.stepsWithRunningElapsed(), m.width, 0, m.height))
+
+	if !strings.Contains(view, expectedPipeline) {
+		t.Fatalf("expected stacked babysit layout to use capped pipeline height %d\nview:\n%s\nexpected pipeline:\n%s", cappedPipelineHeight, view, expectedPipeline)
+	}
+	if strings.Contains(view, uncappedPipeline) {
+		t.Fatalf("expected stacked babysit layout to avoid uncapped pipeline height %d", m.height)
+	}
+}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -7430,3 +7430,69 @@ func TestModel_ApplyEvent_LogChunk_FlushesPartialOnRunCompleted(t *testing.T) {
 		t.Fatalf("expected partial log buffer to be cleared, got %q", m.logPartial)
 	}
 }
+
+func TestPipelineConnectors_NotSuppressedDuringBabysit(t *testing.T) {
+	// When babysit is active in responsive layout (wide terminal), the pipeline
+	// height should not be capped, so connector lines between steps are preserved.
+	// Previously, the cap applied regardless of layout mode, which suppressed
+	// connectors even when the babysit view was in the right column and didn't
+	// compete for vertical space.
+	configureTUIColors()
+	run := testRunWithBabysit()
+	for i := range run.Steps {
+		run.Steps[i].Status = types.StepStatusCompleted
+		dur := int64(1000)
+		run.Steps[i].DurationMS = &dur
+	}
+	run.Steps[len(run.Steps)-1].Status = types.StepStatusRunning
+	run.Steps[len(run.Steps)-1].DurationMS = nil
+
+	m := NewModel("", nil, run)
+	m.width = 120 // wide enough for responsive layout
+	m.height = 50
+
+	view := m.View()
+	plain := stripANSI(view)
+
+	// Render pipeline directly with height=50 as a baseline.
+	leftWidth, _ := responsiveColumnWidths(m.width)
+	baseline := stripANSI(renderPipelineView(run, run.Steps, leftWidth, 0, 50))
+	baselineConnectors := 0
+	for _, line := range strings.Split(baseline, "\n") {
+		if strings.Count(line, "│") >= 3 {
+			baselineConnectors++
+		}
+	}
+	if baselineConnectors == 0 {
+		t.Fatalf("baseline pipeline with height=50 should show connectors:\n%s", baseline)
+	}
+
+	// The full view should also contain connector lines.
+	// In responsive layout, the pipeline (left column) renders with the real
+	// terminal height, not a capped value.
+	if !strings.Contains(plain, baseline) {
+		// The pipeline should be identical to the baseline (uncapped).
+		// Check for connectors by verifying step lines are not adjacent.
+		stepLabels := []string{"Review", "Test", "Lint", "Push", "PR"}
+		lines := strings.Split(plain, "\n")
+		adjacentSteps := 0
+		for i := 0; i < len(lines)-1; i++ {
+			hasLabel := false
+			nextHasLabel := false
+			for _, label := range stepLabels {
+				if strings.Contains(lines[i], label) {
+					hasLabel = true
+				}
+				if strings.Contains(lines[i+1], label) {
+					nextHasLabel = true
+				}
+			}
+			if hasLabel && nextHasLabel {
+				adjacentSteps++
+			}
+		}
+		if adjacentSteps > 0 {
+			t.Errorf("expected connector lines between steps in responsive layout during babysit, but %d step pairs are adjacent.\nview:\n%s", adjacentSteps, plain)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- limit the pipeline pane height during babysit when the TUI is using the stacked layout so it fits within the available viewport
- add regression coverage for stacked babysit height behavior in `internal/tui/tui_test.go`

## Testing
- Not run (not provided in request)