### PR TITLE
feat(pr): surface pull request URLs in pipeline events and TUI

### DIFF
--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -216,6 +216,7 @@ type Event struct {
 	Findings   *string         `json:"findings,omitempty"`    // JSON-encoded findings for step_completed events
 	Diff       *string         `json:"diff,omitempty"`        // unified diff for fix_review events
 	DurationMS *int64          `json:"duration_ms,omitempty"` // execution-only duration for step events
+	PRURL      *string         `json:"pr_url,omitempty"`      // PR URL for run_updated/run_completed events
 }
 
 // --- Helpers ---

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -200,6 +200,12 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			}
 		}
 
+		// If the step produced a PR URL, propagate it to the run and emit an update.
+		if outcome.PRURL != "" {
+			run.PRURL = &outcome.PRURL
+			e.emitRunEvent(ipc.EventRunUpdated, run, repo)
+		}
+
 		if !outcome.NeedsApproval {
 			// Step completed without needing approval
 			break
@@ -362,14 +368,16 @@ func (e *Executor) failRun(run *db.Run, repo *db.Repo, err error, ctxs ...contex
 
 func (e *Executor) emitRunEvent(eventType ipc.EventType, run *db.Run, repo *db.Repo) {
 	status := string(run.Status)
-	e.onEvent(ipc.Event{
+	event := ipc.Event{
 		Type:   eventType,
 		RunID:  run.ID,
 		RepoID: repo.ID,
 		Status: &status,
 		Branch: &run.Branch,
 		Error:  run.Error,
-	})
+		PRURL:  run.PRURL,
+	}
+	e.onEvent(event)
 }
 
 func (e *Executor) emitStepEvent(eventType ipc.EventType, run *db.Run, repo *db.Repo, stepName types.StepName, status string) {

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -1881,3 +1881,44 @@ func writeTestFile(t *testing.T, dir, name, content string) {
 		t.Fatal(err)
 	}
 }
+
+func TestExecutor_StepOutcomePRURL_EmitsRunUpdated(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	prURL := "https://github.com/test/repo/pull/99"
+	prStep := &mockStep{
+		name:    types.StepPR,
+		outcome: &StepOutcome{ExitCode: 0, PRURL: prURL},
+	}
+	steps := []Step{newPassStep(types.StepReview), prStep}
+
+	exec := NewExecutor(database, p, nil, nil, steps, nil)
+	events := collectEvents(exec)
+
+	err := exec.Execute(context.Background(), run, repo, workDir)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// Should have a run_updated event with the PRURL after the PR step.
+	found := false
+	for _, e := range events.all() {
+		if e.Type == ipc.EventRunUpdated && e.PRURL != nil && *e.PRURL == prURL {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected a run_updated event with PRURL after PR step")
+	}
+
+	// The run_completed event should also carry the PRURL.
+	completedEvent := events.findRunEvent(ipc.EventRunCompleted)
+	if completedEvent == nil {
+		t.Fatal("expected run_completed event")
+	}
+	if completedEvent.PRURL == nil || *completedEvent.PRURL != prURL {
+		t.Errorf("expected run_completed PRURL %q, got %v", prURL, completedEvent.PRURL)
+	}
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -30,6 +30,7 @@ type StepOutcome struct {
 	AutoFixable   bool
 	Findings      string // JSON findings for TUI display (optional)
 	ExitCode      int    // process exit code (0 = success)
+	PRURL         string // PR/MR URL if this step created or found one
 }
 
 // Step is the interface that each pipeline step implements.

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -106,7 +106,7 @@ func (s *PRStep) executeGitHubPR(sctx *pipeline.StepContext, branch string, cont
 			if err := sctx.DB.UpdateRunPRURL(sctx.Run.ID, prURL); err != nil {
 				slog.Warn("failed to persist PR URL", "run", sctx.Run.ID, "url", prURL, "err", err)
 			}
-			return &pipeline.StepOutcome{}, nil
+			return &pipeline.StepOutcome{PRURL: prURL}, nil
 		}
 	}
 
@@ -131,7 +131,7 @@ func (s *PRStep) executeGitHubPR(sctx *pipeline.StepContext, branch string, cont
 		slog.Warn("failed to persist PR URL", "run", sctx.Run.ID, "url", prURL, "err", err)
 	}
 
-	return &pipeline.StepOutcome{}, nil
+	return &pipeline.StepOutcome{PRURL: prURL}, nil
 }
 
 func (s *PRStep) executeGitLabMR(sctx *pipeline.StepContext, branch string, content prContent) (*pipeline.StepOutcome, error) {
@@ -152,7 +152,7 @@ func (s *PRStep) executeGitLabMR(sctx *pipeline.StepContext, branch string, cont
 			if err := sctx.DB.UpdateRunPRURL(sctx.Run.ID, mrURL); err != nil {
 				slog.Warn("failed to persist PR URL", "run", sctx.Run.ID, "url", mrURL, "err", err)
 			}
-			return &pipeline.StepOutcome{}, nil
+			return &pipeline.StepOutcome{PRURL: mrURL}, nil
 		}
 	}
 
@@ -176,7 +176,7 @@ func (s *PRStep) executeGitLabMR(sctx *pipeline.StepContext, branch string, cont
 		}
 	}
 	sctx.Log(fmt.Sprintf("created merge request: %s", mrURL))
-	return &pipeline.StepOutcome{}, nil
+	return &pipeline.StepOutcome{PRURL: mrURL}, nil
 }
 
 func extractSCMURL(raw []byte) string {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -191,7 +191,11 @@ func (m Model) View() string {
 	}
 	actionBar := renderActionBar(m.steps, showSelectionActions, allowFix, m.showDiff, selectedCount, totalCount, m.confirmAbort, hasDiff)
 
-	footer := renderFooter(m.done, m.showHelp, m.confirmAbort)
+	var prURL *string
+	if m.run != nil {
+		prURL = m.run.PRURL
+	}
+	footer := renderFooter(m.done, m.showHelp, m.confirmAbort, prURL, m.width)
 	contentBudget := -1
 	if m.height > 0 {
 		baseSections := []string{}
@@ -446,7 +450,7 @@ func renderErrorBox(err error, width int) string {
 	return renderBox("Error", errContent.String(), boxWidth)
 }
 
-func renderFooter(done bool, showHelp bool, confirmAbort bool) string {
+func renderFooter(done bool, showHelp bool, confirmAbort bool, prURL *string, width int) string {
 	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
 	boldKey := lipgloss.NewStyle().Bold(true)
 	qLabel := "detach"
@@ -457,16 +461,54 @@ func renderFooter(done bool, showHelp bool, confirmAbort bool) string {
 	if showHelp {
 		helpLabel = "close"
 	}
-	footer := "  " + boldKey.Render("q") + " " + dimStyle.Render(qLabel)
+	left := "  " + boldKey.Render("q") + " " + dimStyle.Render(qLabel)
 	if !done {
 		xLabel := "abort"
 		if confirmAbort {
 			xLabel = "again to abort"
 		}
-		footer += "  " + boldKey.Render("x") + " " + dimStyle.Render(xLabel)
+		left += "  " + boldKey.Render("x") + " " + dimStyle.Render(xLabel)
 	}
-	footer += "  " + boldKey.Render("?") + " " + dimStyle.Render(helpLabel)
-	return footer
+	left += "  " + boldKey.Render("?") + " " + dimStyle.Render(helpLabel)
+
+	if prURL == nil || *prURL == "" {
+		return left
+	}
+
+	leftWidth := lipgloss.Width(left)
+	// Try full URL first (clickable in terminals), fall back to short form.
+	prText := *prURL
+	available := width - leftWidth - 4 // 4 = leading + trailing padding
+	if available < len(prText) {
+		prText = shortPRLabel(*prURL)
+	}
+	if available < len(prText) {
+		return left
+	}
+	right := dimStyle.Render(prText) + "  "
+	gap := width - leftWidth - lipgloss.Width(right)
+	if gap < 1 {
+		return left
+	}
+	return left + strings.Repeat(" ", gap) + right
+}
+
+// shortPRLabel extracts a compact label like "PR #42" from a PR URL.
+func shortPRLabel(url string) string {
+	// GitHub: .../pull/42, GitLab: .../merge_requests/42
+	for _, prefix := range []string{"/pull/", "/merge_requests/"} {
+		if idx := strings.LastIndex(url, prefix); idx >= 0 {
+			num := url[idx+len(prefix):]
+			if num != "" {
+				label := "PR"
+				if prefix == "/merge_requests/" {
+					label = "MR"
+				}
+				return label + " #" + num
+			}
+		}
+	}
+	return url
 }
 
 func joinSections(sections []string, gap string) string {
@@ -888,6 +930,9 @@ func (m *Model) applyEvent(event ipc.Event) {
 		if event.Status != nil {
 			m.run.Status = types.RunStatus(*event.Status)
 		}
+		if event.PRURL != nil {
+			m.run.PRURL = event.PRURL
+		}
 
 	case ipc.EventRunCompleted:
 		m.err = nil
@@ -896,6 +941,9 @@ func (m *Model) applyEvent(event ipc.Event) {
 		}
 		if event.Error != nil {
 			m.run.Error = event.Error
+		}
+		if event.PRURL != nil {
+			m.run.PRURL = event.PRURL
 		}
 		m.flushPartialLog()
 		m.done = true

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -425,6 +425,88 @@ func TestModel_ApplyEvent_RunCompleted_FailedStoresError(t *testing.T) {
 	}
 }
 
+func TestModel_ApplyEvent_RunUpdated_PRURL(t *testing.T) {
+	run := testRun()
+	m := NewModel("/tmp/sock", nil, run)
+
+	prURL := "https://github.com/test/repo/pull/42"
+	m.applyEvent(ipc.Event{
+		Type:   ipc.EventRunUpdated,
+		RunID:  run.ID,
+		Status: ptr(string(types.RunRunning)),
+		PRURL:  &prURL,
+	})
+
+	if m.run.PRURL == nil || *m.run.PRURL != prURL {
+		t.Errorf("expected run PRURL %q, got %v", prURL, m.run.PRURL)
+	}
+}
+
+func TestModel_ApplyEvent_RunCompleted_PRURL(t *testing.T) {
+	run := testRun()
+	m := NewModel("/tmp/sock", nil, run)
+
+	prURL := "https://github.com/test/repo/pull/42"
+	m.applyEvent(ipc.Event{
+		Type:   ipc.EventRunCompleted,
+		RunID:  run.ID,
+		Status: ptr(string(types.RunCompleted)),
+		PRURL:  &prURL,
+	})
+
+	if m.run.PRURL == nil || *m.run.PRURL != prURL {
+		t.Errorf("expected run PRURL %q, got %v", prURL, m.run.PRURL)
+	}
+}
+
+func TestRenderFooter_WithPRURL_FullURL(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.Ascii)
+	prURL := "https://github.com/test/repo/pull/42"
+	footer := renderFooter(true, false, false, &prURL, 80)
+	stripped := stripANSI(footer)
+
+	if !strings.Contains(stripped, prURL) {
+		t.Errorf("expected footer to contain full URL %q, got: %s", prURL, stripped)
+	}
+}
+
+func TestRenderFooter_WithoutPRURL(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.Ascii)
+	footer := renderFooter(false, false, false, nil, 80)
+	stripped := stripANSI(footer)
+
+	if strings.Contains(stripped, "PR") {
+		t.Errorf("expected no PR in footer, got: %s", stripped)
+	}
+}
+
+func TestRenderFooter_PRURL_FallsBackToShortForm(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.Ascii)
+	prURL := "https://github.com/test/repo/pull/42"
+	// Narrow width - should fall back to "PR #42" instead of full URL
+	footer := renderFooter(true, false, false, &prURL, 40)
+	stripped := stripANSI(footer)
+
+	if !strings.Contains(stripped, "PR #42") {
+		t.Errorf("expected footer to contain PR #42, got: %s", stripped)
+	}
+	if strings.Contains(stripped, "https://") {
+		t.Errorf("expected short form, not full URL at narrow width, got: %s", stripped)
+	}
+}
+
+func TestRenderFooter_PRURL_HiddenWhenTooNarrow(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.Ascii)
+	prURL := "https://github.com/test/repo/pull/42"
+	// Extremely narrow - not even short form fits
+	footer := renderFooter(true, false, false, &prURL, 20)
+	stripped := stripANSI(footer)
+
+	if strings.Contains(stripped, "PR") {
+		t.Errorf("expected no PR at extremely narrow width, got: %s", stripped)
+	}
+}
+
 func TestModel_ApplyEvent_LogChunk(t *testing.T) {
 	run := testRun()
 	m := NewModel("/tmp/sock", nil, run)


### PR DESCRIPTION
## Summary
- add PR URL support to the pipeline event/protocol flow so pull request creation can pass the created URL through execution state
- update the PR step and TUI app to store and display the PR URL in the UI
- add coverage for executor propagation and TUI behavior around PR URL handling

## Testing
- added or updated unit tests in `internal/pipeline/executor_test.go`
- added or updated unit tests in `internal/tui/tui_test.go`