### PR TITLE
feat(db): prefer active run for the current branch

### DIFF
--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -1,12 +1,14 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/daemon"
 	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/tui"
 	"github.com/spf13/cobra"
@@ -56,9 +58,12 @@ func attachRun(w io.Writer, runID string) error {
 	} else {
 		repoID = repo.ID
 
-		// Get active run for this repo.
+		// Detect current branch to prefer runs on the same branch.
+		branch, _ := git.CurrentBranch(context.Background(), ".")
+
+		// Get active run for this repo, preferring the current branch.
 		var result ipc.GetActiveRunResult
-		if err := client.Call(ipc.MethodGetActiveRun, &ipc.GetActiveRunParams{RepoID: repo.ID}, &result); err != nil {
+		if err := client.Call(ipc.MethodGetActiveRun, &ipc.GetActiveRunParams{RepoID: repo.ID, Branch: branch}, &result); err != nil {
 			return fmt.Errorf("get active run: %w", err)
 		}
 		run = result.Run

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -42,7 +42,7 @@ func newStatusCmd() *cobra.Command {
 			}
 
 			// Check for active run.
-			activeRun, err := d.GetActiveRun(repo.ID)
+			activeRun, err := d.GetActiveRun(repo.ID, "")
 			if err != nil {
 				return fmt.Errorf("check active run: %w", err)
 			}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -226,7 +226,7 @@ func registerHandlers(srv *ipc.Server, mgr *RunManager, d *db.DB, shutdown func(
 		if err := json.Unmarshal(params, &p); err != nil {
 			return nil, fmt.Errorf("invalid params: %w", err)
 		}
-		run, err := d.GetActiveRun(p.RepoID)
+		run, err := d.GetActiveRun(p.RepoID, p.Branch)
 		if err != nil {
 			return nil, fmt.Errorf("get active run: %w", err)
 		}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -248,6 +248,58 @@ func TestGetActiveRunHandler(t *testing.T) {
 	}
 }
 
+func TestGetActiveRunHandlerPrefersRequestedBranch(t *testing.T) {
+	p, d := startTestDaemon(t)
+
+	repo, err := d.InsertRepoWithID("test-repo-branch", "/tmp/test-repo-branch", "https://github.com/test/repo-branch", "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runA, err := d.InsertRun(repo.ID, "feature-a", "aaa", "000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	runB, err := d.InsertRun(repo.ID, "feature-b", "bbb", "000")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client, err := ipc.Dial(p.Socket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	var result ipc.GetActiveRunResult
+	if err := client.Call(ipc.MethodGetActiveRun, &ipc.GetActiveRunParams{RepoID: repo.ID, Branch: "feature-a"}, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Run == nil {
+		t.Fatal("expected active run for requested branch")
+	}
+	if result.Run.ID != runA.ID {
+		t.Fatalf("active run id = %q, want %q", result.Run.ID, runA.ID)
+	}
+
+	var fallback ipc.GetActiveRunResult
+	if err := client.Call(ipc.MethodGetActiveRun, &ipc.GetActiveRunParams{RepoID: repo.ID, Branch: "missing-branch"}, &fallback); err != nil {
+		t.Fatal(err)
+	}
+	if fallback.Run == nil {
+		t.Fatal("expected fallback active run")
+	}
+	if fallback.Run.ID != runB.ID {
+		t.Fatalf("fallback active run id = %q, want %q", fallback.Run.ID, runB.ID)
+	}
+	if fallback.Run.Branch != "feature-b" {
+		t.Fatalf("fallback active run branch = %q, want %q", fallback.Run.Branch, "feature-b")
+	}
+	if fallback.Run.ID == runA.ID {
+		t.Fatal("expected fallback to prefer newest run when branch is missing")
+	}
+}
+
 func TestGetRunNotFound(t *testing.T) {
 	p, _ := startTestDaemon(t)
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -241,7 +241,7 @@ func TestActiveRun(t *testing.T) {
 	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")
 
 	// no active run initially
-	active, err := d.GetActiveRun(repo.ID)
+	active, err := d.GetActiveRun(repo.ID, "")
 	if err != nil {
 		t.Fatalf("get active run: %v", err)
 	}
@@ -250,16 +250,61 @@ func TestActiveRun(t *testing.T) {
 	}
 
 	run, _ := d.InsertRun(repo.ID, "feature", "abc", "def")
-	active, _ = d.GetActiveRun(repo.ID)
+	active, _ = d.GetActiveRun(repo.ID, "")
 	if active == nil || active.ID != run.ID {
 		t.Fatal("expected active run matching inserted run")
 	}
 
 	// after completing, no active run
 	d.UpdateRunStatus(run.ID, types.RunCompleted)
-	active, _ = d.GetActiveRun(repo.ID)
+	active, _ = d.GetActiveRun(repo.ID, "")
 	if active != nil {
 		t.Fatal("expected nil after completing run")
+	}
+}
+
+func TestActiveRunPrefersBranch(t *testing.T) {
+	d := openTestDB(t)
+	repo, _ := d.InsertRepo("/home/user/branchpref", "git@github.com:user/branchpref.git", "main")
+
+	// Create two active runs on different branches.
+	runA, _ := d.InsertRun(repo.ID, "feature-a", "aaa", "000")
+	runB, _ := d.InsertRun(repo.ID, "feature-b", "bbb", "000")
+
+	// Without branch hint, newest (runB) wins.
+	active, err := d.GetActiveRun(repo.ID, "")
+	if err != nil {
+		t.Fatalf("get active run: %v", err)
+	}
+	if active == nil || active.ID != runB.ID {
+		t.Fatalf("expected newest run %q, got %v", runB.ID, active)
+	}
+
+	// With branch hint "feature-a", the older matching run wins.
+	active, err = d.GetActiveRun(repo.ID, "feature-a")
+	if err != nil {
+		t.Fatalf("get active run with branch: %v", err)
+	}
+	if active == nil || active.ID != runA.ID {
+		t.Fatalf("expected branch-matching run %q, got %q", runA.ID, active.ID)
+	}
+
+	// With branch hint "feature-b", runB is returned.
+	active, err = d.GetActiveRun(repo.ID, "feature-b")
+	if err != nil {
+		t.Fatalf("get active run with branch: %v", err)
+	}
+	if active == nil || active.ID != runB.ID {
+		t.Fatalf("expected branch-matching run %q, got %q", runB.ID, active.ID)
+	}
+
+	// With branch hint for a non-existent branch, falls back to newest.
+	active, err = d.GetActiveRun(repo.ID, "feature-c")
+	if err != nil {
+		t.Fatalf("get active run with unknown branch: %v", err)
+	}
+	if active == nil || active.ID != runB.ID {
+		t.Fatalf("expected fallback to newest run %q, got %q", runB.ID, active.ID)
 	}
 }
 

--- a/internal/db/run.go
+++ b/internal/db/run.go
@@ -80,10 +80,12 @@ func (d *DB) GetRunsByRepo(repoID string) ([]*Run, error) {
 }
 
 // GetActiveRun returns the currently active run (pending or running) for a repo, if any.
-func (d *DB) GetActiveRun(repoID string) (*Run, error) {
+// When branch is non-empty, runs matching that branch are preferred; otherwise
+// falls back to the most recently created active run.
+func (d *DB) GetActiveRun(repoID, branch string) (*Run, error) {
 	r := &Run{}
 	err := d.sql.QueryRow(
-		`SELECT id, repo_id, branch, head_sha, base_sha, status, pr_url, error, created_at, updated_at FROM runs WHERE repo_id = ? AND status IN ('pending', 'running') ORDER BY created_at DESC LIMIT 1`, repoID,
+		`SELECT id, repo_id, branch, head_sha, base_sha, status, pr_url, error, created_at, updated_at FROM runs WHERE repo_id = ? AND status IN ('pending', 'running') ORDER BY (branch = ?) DESC, created_at DESC, id DESC LIMIT 1`, repoID, branch,
 	).Scan(&r.ID, &r.RepoID, &r.Branch, &r.HeadSHA, &r.BaseSHA, &r.Status, &r.PRURL, &r.Error, &r.CreatedAt, &r.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -75,8 +75,10 @@ type GetRunsParams struct {
 }
 
 // GetActiveRunParams requests the active run for a repo.
+// When Branch is set, runs on that branch are preferred.
 type GetActiveRunParams struct {
 	RepoID string `json:"repo_id"`
+	Branch string `json:"branch,omitempty"`
 }
 
 // RerunParams requests a new run for the latest gate head on a branch.


### PR DESCRIPTION
## Summary
- prefer the active run that matches the current branch when selecting runs, improving attach and status behavior in multi-branch workflows
- wire branch information through the daemon and IPC layers so branch-aware run detection works end to end
- add daemon and database test coverage for branch-aware active run selection

## Testing
- Added coverage in `internal/daemon/daemon_test.go`
- Added coverage in `internal/db/db_test.go`