### PR TITLE
fix(tui): stabilize babysit panel layout and status context

### DIFF
--- a/internal/pipeline/steps/babysit.go
+++ b/internal/pipeline/steps/babysit.go
@@ -250,6 +250,7 @@ func (s *BabysitStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome
 			if !hasPendingChecks(checks) {
 				if len(checks) == 0 && elapsed < s.gracePeriod() {
 					// CI checks may not be registered yet, keep polling
+					sctx.Log("no CI checks reported yet, waiting for checks to register...")
 				} else {
 					checksReadyToExit = true
 					if len(checks) == 0 {

--- a/internal/pipeline/steps/babysit.go
+++ b/internal/pipeline/steps/babysit.go
@@ -250,7 +250,6 @@ func (s *BabysitStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome
 			if !hasPendingChecks(checks) {
 				if len(checks) == 0 && elapsed < s.gracePeriod() {
 					// CI checks may not be registered yet, keep polling
-					sctx.Log("no CI checks reported yet, waiting for checks to register...")
 				} else {
 					checksReadyToExit = true
 					if len(checks) == 0 {

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -3767,6 +3767,38 @@ func TestBabysitStep_EmptyChecksWaitsDuringGracePeriod(t *testing.T) {
 	}
 }
 
+func TestBabysitStep_LogsWaitingForChecksDuringGracePeriod(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	binDir := fakeBabysitGH(t, "OPEN", "[]")
+	prependPATH(t, binDir)
+
+	prURL := "https://github.com/test/repo/pull/42"
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Run.PRURL = &prURL
+	sctx.Config.BabysitTimeout = 5 * time.Second
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+
+	step := &BabysitStep{checksGracePeriod: 50 * time.Millisecond, pollIntervalOverride: 10 * time.Millisecond}
+	if _, err := step.Execute(sctx); err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	for _, l := range logs {
+		if strings.Contains(l, "waiting for checks to register") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected grace-period waiting log, got: %v", logs)
+	}
+}
+
 func TestBabysitStep_NonEmptyPassingChecksExitImmediately(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -258,7 +258,10 @@ func (m Model) View() string {
 			cursor = m.findingCursor[step.StepName]
 			selected = m.findingSelections[step.StepName]
 		}
-		babysitHeight := m.height
+		babysitHeight := -1
+		if m.height > 0 {
+			babysitHeight = m.height
+		}
 		if contentBudget >= 0 {
 			babysitHeight = contentBudget
 		}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -258,7 +258,11 @@ func (m Model) View() string {
 			cursor = m.findingCursor[step.StepName]
 			selected = m.findingSelections[step.StepName]
 		}
-		appendExtraSection(renderBabysitViewWithSelection(m.run, m.steps, findings, m.logs, rightWidth, m.height, cursor, selected))
+		babysitHeight := m.height
+		if contentBudget >= 0 {
+			babysitHeight = contentBudget
+		}
+		appendExtraSection(renderBabysitViewWithSelection(m.run, m.steps, findings, m.logs, rightWidth, babysitHeight, cursor, selected))
 	} else if !m.showHelp {
 		if step := awaitingStep(m.steps); step != nil {
 			// Generic findings or diff for non-babysit steps awaiting approval.

--- a/internal/tui/babysit.go
+++ b/internal/tui/babysit.go
@@ -102,6 +102,13 @@ func renderBabysitViewWithSelection(run *ipc.RunInfo, steps []ipc.StepResultInfo
 	contentWidth := boxWidth - 4 // account for box border + padding
 
 	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
+	if run != nil && run.PRURL != nil && *run.PRURL != "" {
+		prText, _ := cutText(shortPRLabel(*run.PRURL), contentWidth)
+		b.WriteString(dimStyle.Render(prText) + "\n")
+	} else if num := extractPRFromLogs(logs); num != "" {
+		prText, _ := cutText("PR #"+num, contentWidth)
+		b.WriteString(dimStyle.Render(prText) + "\n")
+	}
 
 	// State indicator.
 	status := babysitStepStatus(steps)

--- a/internal/tui/babysit.go
+++ b/internal/tui/babysit.go
@@ -89,7 +89,7 @@ func parseBabysitActivity(logs []string) babysitActivity {
 // renderBabysitView renders the babysit-specific monitoring view.
 // Shown instead of generic findings when the babysit step is active.
 func renderBabysitView(run *ipc.RunInfo, steps []ipc.StepResultInfo, findings string, logs []string, width int) string {
-	return renderBabysitViewWithSelection(run, steps, findings, logs, width, 0, 0, nil)
+	return renderBabysitViewWithSelection(run, steps, findings, logs, width, -1, 0, nil)
 }
 
 func renderBabysitViewWithSelection(run *ipc.RunInfo, steps []ipc.StepResultInfo, findings string, logs []string, width int, height int, cursor int, selected map[string]bool) string {
@@ -141,7 +141,7 @@ func renderBabysitViewWithSelection(run *ipc.RunInfo, steps []ipc.StepResultInfo
 
 	// Log tail during monitoring.
 	// Dynamically fill available height: subtract box borders and fixed content lines.
-	if len(logs) > 0 && height > 0 {
+	if len(logs) > 0 && height >= 0 {
 		// Count fixed lines already written above.
 		fixedLines := 2 // box top + bottom borders
 		fixedLines += lipgloss.Height(b.String())

--- a/internal/tui/babysit.go
+++ b/internal/tui/babysit.go
@@ -103,16 +103,6 @@ func renderBabysitViewWithSelection(run *ipc.RunInfo, steps []ipc.StepResultInfo
 
 	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
 
-	// PR info - try run.PRURL first, then parse from logs.
-	// Truncated to fit inside the box.
-	if run != nil && run.PRURL != nil && *run.PRURL != "" {
-		prText := "PR: " + *run.PRURL
-		prText, _ = cutText(prText, contentWidth)
-		b.WriteString(dimStyle.Render(prText) + "\n")
-	} else if num := extractPRFromLogs(logs); num != "" {
-		b.WriteString(dimStyle.Render("PR #"+num) + "\n")
-	}
-
 	// State indicator.
 	status := babysitStepStatus(steps)
 	activity := parseBabysitActivity(logs)
@@ -143,18 +133,26 @@ func renderBabysitViewWithSelection(run *ipc.RunInfo, steps []ipc.StepResultInfo
 	}
 
 	// Log tail during monitoring.
-	// Adaptive line count: 5 for height >= 30, 3 for 20-29, hidden for < 20.
-	logLines := 5
-	if height > 0 && height < 30 {
-		logLines = 3
-	}
-	if height > 0 && height < 20 {
-		logLines = 0
-	}
+	// Dynamically fill available height: subtract box borders and fixed content lines.
+	if len(logs) > 0 && height > 0 {
+		// Count fixed lines already written above.
+		fixedLines := 2 // box top + bottom borders
+		fixedLines += lipgloss.Height(b.String())
+		fixedLines++ // blank line before log tail
 
-	if len(logs) > 0 && logLines > 0 {
+		logLines := height - fixedLines
+		if logLines < 1 {
+			logLines = 1
+		}
+
 		b.WriteString("\n")
 		for _, line := range renderLogTail(logs, contentWidth, logLines) {
+			b.WriteString(line + "\n")
+		}
+	} else if len(logs) > 0 {
+		// No height info - show a reasonable default.
+		b.WriteString("\n")
+		for _, line := range renderLogTail(logs, contentWidth, 10) {
 			b.WriteString(line + "\n")
 		}
 	}

--- a/internal/tui/babysit.go
+++ b/internal/tui/babysit.go
@@ -149,12 +149,14 @@ func renderBabysitViewWithSelection(run *ipc.RunInfo, steps []ipc.StepResultInfo
 
 		logLines := height - fixedLines
 		if logLines < 1 {
-			logLines = 1
+			logLines = 0
 		}
 
-		b.WriteString("\n")
-		for _, line := range renderLogTail(logs, contentWidth, logLines) {
-			b.WriteString(line + "\n")
+		if logLines > 0 {
+			b.WriteString("\n")
+			for _, line := range renderLogTail(logs, contentWidth, logLines) {
+				b.WriteString(line + "\n")
+			}
 		}
 	} else if len(logs) > 0 {
 		// No height info - show a reasonable default.

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1750,20 +1750,18 @@ func TestRenderBabysitView_Monitoring(t *testing.T) {
 	if !strings.Contains(out, "Monitoring") {
 		t.Error("expected monitoring state")
 	}
-	if !strings.Contains(out, "PR #42") {
-		t.Error("expected PR number from logs")
-	}
 }
 
-func TestRenderBabysitView_WithPRURL(t *testing.T) {
+func TestRenderBabysitView_NoPRURL(t *testing.T) {
+	// PR URL should not appear in babysit panel - it's shown persistently in the footer.
 	run := testRunWithBabysit()
 	run.PRURL = ptr("https://github.com/user/repo/pull/99")
 	run.Steps[5].Status = types.StepStatusRunning
 
 	out := renderBabysitView(run, run.Steps, "", nil, 80)
 
-	if !strings.Contains(out, "https://github.com/user/repo/pull/99") {
-		t.Error("expected full PR URL")
+	if strings.Contains(out, "https://github.com/user/repo/pull/99") {
+		t.Error("expected no PR URL in babysit panel - shown in footer instead")
 	}
 }
 
@@ -2188,19 +2186,12 @@ func TestRenderBabysitView_ContentInsideBox(t *testing.T) {
 
 	out := stripANSI(renderBabysitView(run, run.Steps, "", logs, 80))
 
-	// PR info and state should be inside box borders.
-	foundPR := false
+	// State should be inside box borders.
 	foundState := false
 	for _, line := range strings.Split(out, "\n") {
-		if strings.Contains(line, "PR #42") && strings.Contains(line, "│") {
-			foundPR = true
-		}
 		if strings.Contains(line, "Monitoring") && strings.Contains(line, "│") {
 			foundState = true
 		}
-	}
-	if !foundPR {
-		t.Error("expected PR info inside box borders")
 	}
 	if !foundState {
 		t.Error("expected state indicator inside box borders")
@@ -2985,8 +2976,41 @@ func TestModel_View_NoStandaloneLogBoxDuringBabysit(t *testing.T) {
 
 // --- Babysit adaptive log tail ---
 
-func TestRenderBabysitView_LogTailCompact(t *testing.T) {
-	// At height 25 (compact terminal), babysit log tail should show only 3 lines, not 5.
+func TestRenderBabysitView_LogTailFillsAvailableHeight(t *testing.T) {
+	// Log tail should dynamically fill available height, not use hardcoded line counts.
+	lipgloss.SetColorProfile(termenv.ANSI)
+	run := testRunWithBabysit()
+	run.Steps[5].Status = types.StepStatusRunning
+
+	manyLogs := []string{"babysitting PR #42 (timeout: 4h)..."}
+	for i := 1; i <= 30; i++ {
+		manyLogs = append(manyLogs, fmt.Sprintf("log-line-%d", i))
+	}
+
+	// With height=20, more logs should show than with height=10.
+	tall := stripANSI(renderBabysitViewWithSelection(run, run.Steps, "", manyLogs, 80, 20, 0, nil))
+	short := stripANSI(renderBabysitViewWithSelection(run, run.Steps, "", manyLogs, 80, 10, 0, nil))
+
+	countLogLines := func(s string) int {
+		n := 0
+		for _, line := range strings.Split(s, "\n") {
+			if strings.Contains(line, "log-line-") {
+				n++
+			}
+		}
+		return n
+	}
+
+	tallCount := countLogLines(tall)
+	shortCount := countLogLines(short)
+
+	if tallCount <= shortCount {
+		t.Errorf("expected more log lines with height=20 (%d) than height=10 (%d)", tallCount, shortCount)
+	}
+}
+
+func TestRenderBabysitView_LogTailTinyStillShowsSome(t *testing.T) {
+	// Even with very small height, at least 1 log line should show.
 	lipgloss.SetColorProfile(termenv.ANSI)
 	run := testRunWithBabysit()
 	run.Steps[5].Status = types.StepStatusRunning
@@ -2994,76 +3018,45 @@ func TestRenderBabysitView_LogTailCompact(t *testing.T) {
 		"babysitting PR #42 (timeout: 4h)...",
 		"line1",
 		"line2",
-		"line3",
-		"line4",
-		"line5",
-		"line6",
-	}
-
-	out := stripANSI(renderBabysitViewWithSelection(run, run.Steps, "", logs, 80, 25, 0, nil))
-
-	// Should show last 3 lines (line4, line5, line6) but not line2, line3 (which 5-line tail would include).
-	if !strings.Contains(out, "line6") {
-		t.Errorf("expected last log line 'line6' in compact babysit view, got:\n%s", out)
-	}
-	if !strings.Contains(out, "line4") {
-		t.Errorf("expected 'line4' (3rd from end) in compact babysit view, got:\n%s", out)
-	}
-	// line2 would appear with 5-line tail but NOT with 3-line tail.
-	if strings.Contains(out, "line2") {
-		t.Errorf("expected 'line2' to be trimmed in compact babysit view (3 lines max), got:\n%s", out)
-	}
-}
-
-func TestRenderBabysitView_LogTailHiddenTiny(t *testing.T) {
-	// At height < 20 (tiny terminal), babysit log tail should be hidden entirely.
-	lipgloss.SetColorProfile(termenv.ANSI)
-	run := testRunWithBabysit()
-	run.Steps[5].Status = types.StepStatusRunning
-	logs := []string{
-		"babysitting PR #42 (timeout: 4h)...",
-		"polling CI status...",
 		"all checks passing",
 	}
 
-	out := stripANSI(renderBabysitViewWithSelection(run, run.Steps, "", logs, 80, 15, 0, nil))
+	out := stripANSI(renderBabysitViewWithSelection(run, run.Steps, "", logs, 80, 8, 0, nil))
 
-	// Log tail lines should NOT appear in tiny terminal - only state indicator should show.
-	if strings.Contains(out, "polling CI status") {
-		t.Error("expected no log tail in tiny terminal (height=15)")
-	}
-	if strings.Contains(out, "all checks passing") {
-		t.Error("expected no log tail in tiny terminal (height=15)")
+	if !strings.Contains(out, "all checks passing") {
+		t.Error("expected at least the last log line even in tiny terminal")
 	}
 }
 
-func TestRenderBabysitView_LogTailNormalShowsFive(t *testing.T) {
-	// At height >= 30, babysit log tail should show 5 lines.
-	// At compact height (25), it should show only 3.
-	// This test verifies the difference by comparing both outputs.
+func TestRenderBabysitView_LogTailScalesWithHeight(t *testing.T) {
+	// Larger height should show more log lines.
 	lipgloss.SetColorProfile(termenv.ANSI)
 	run := testRunWithBabysit()
 	run.Steps[5].Status = types.StepStatusRunning
-	logs := []string{
-		"babysitting PR #42 (timeout: 4h)...",
-		"line1",
-		"line2",
-		"line3",
-		"line4",
-		"line5",
-		"line6",
+
+	manyLogs := []string{"babysitting PR #42 (timeout: 4h)..."}
+	for i := 1; i <= 50; i++ {
+		manyLogs = append(manyLogs, fmt.Sprintf("log-%d", i))
 	}
 
-	normal := stripANSI(renderBabysitViewWithSelection(run, run.Steps, "", logs, 80, 40, 0, nil))
-	compact := stripANSI(renderBabysitViewWithSelection(run, run.Steps, "", logs, 80, 25, 0, nil))
+	tall := stripANSI(renderBabysitViewWithSelection(run, run.Steps, "", manyLogs, 80, 40, 0, nil))
+	compact := stripANSI(renderBabysitViewWithSelection(run, run.Steps, "", manyLogs, 80, 15, 0, nil))
 
-	// Normal should show line2 (5th from end).
-	if !strings.Contains(normal, "line2") {
-		t.Errorf("expected 'line2' in normal (height=40) babysit view, got:\n%s", normal)
+	countLogLines := func(s string) int {
+		n := 0
+		for _, line := range strings.Split(s, "\n") {
+			if strings.Contains(line, "log-") {
+				n++
+			}
+		}
+		return n
 	}
-	// Compact should NOT show line2 (only 3 lines from end).
-	if strings.Contains(compact, "line2") {
-		t.Errorf("expected 'line2' to be trimmed in compact (height=25) babysit view, got:\n%s", compact)
+
+	tallCount := countLogLines(tall)
+	compactCount := countLogLines(compact)
+
+	if tallCount <= compactCount {
+		t.Errorf("expected more log lines at height=40 (%d) than height=15 (%d)", tallCount, compactCount)
 	}
 }
 
@@ -4934,7 +4927,8 @@ func TestPipelineView_ShortErrorNotTruncated(t *testing.T) {
 	}
 }
 
-func TestRenderBabysitView_LongPRURLTruncated(t *testing.T) {
+func TestRenderBabysitView_NoPRURLInPanel(t *testing.T) {
+	// PR URL should not appear in babysit panel regardless of length.
 	lipgloss.SetColorProfile(termenv.Ascii)
 	run := testRunWithBabysit()
 	longURL := "https://github.com/some-very-long-organization-name/some-very-long-repository-name-that-goes-on-and-on/pull/12345"
@@ -4943,20 +4937,8 @@ func TestRenderBabysitView_LongPRURLTruncated(t *testing.T) {
 
 	result := stripANSI(renderBabysitView(run, run.Steps, "", nil, 80))
 
-	// No line should exceed the box width (80).
-	for _, line := range strings.Split(result, "\n") {
-		if line == "" {
-			continue
-		}
-		w := lipgloss.Width(line)
-		if w > 80 {
-			t.Errorf("babysit PR URL line exceeds box width (%d > 80): %s", w, line)
-		}
-	}
-
-	// The full long URL should NOT appear in the output.
-	if strings.Contains(result, longURL) {
-		t.Error("expected long PR URL to be truncated to fit box content width")
+	if strings.Contains(result, "PR:") {
+		t.Error("expected no PR URL in babysit panel - shown in footer instead")
 	}
 }
 
@@ -4986,7 +4968,8 @@ func TestRenderBabysitView_LongLastEventTruncated(t *testing.T) {
 	}
 }
 
-func TestRenderBabysitView_ShortPRURLNotTruncated(t *testing.T) {
+func TestRenderBabysitView_NoPRURLEvenShort(t *testing.T) {
+	// Even short PR URLs should not appear in babysit panel.
 	lipgloss.SetColorProfile(termenv.Ascii)
 	run := testRunWithBabysit()
 	shortURL := "https://github.com/user/repo/pull/99"
@@ -4995,9 +4978,8 @@ func TestRenderBabysitView_ShortPRURLNotTruncated(t *testing.T) {
 
 	result := stripANSI(renderBabysitView(run, run.Steps, "", nil, 80))
 
-	// Short PR URL should appear in full.
-	if !strings.Contains(result, shortURL) {
-		t.Error("expected short PR URL to appear in full")
+	if strings.Contains(result, shortURL) {
+		t.Error("expected no PR URL in babysit panel - shown in footer instead")
 	}
 }
 

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -3027,6 +3027,26 @@ func TestRenderBabysitView_LogTailTinyStillShowsSome(t *testing.T) {
 	}
 }
 
+func TestRenderBabysitView_ZeroHeightOmitsLogTail(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.ANSI)
+	run := testRunWithBabysit()
+	run.Steps[5].Status = types.StepStatusRunning
+	logs := []string{
+		"babysitting PR #42 (timeout: 4h)...",
+		"polling CI status...",
+		"all checks passing",
+	}
+
+	out := stripANSI(renderBabysitViewWithSelection(run, run.Steps, "", logs, 80, 0, 0, nil))
+
+	if !strings.Contains(out, "Monitoring CI checks") {
+		t.Fatalf("expected babysit status to remain visible, got:\n%s", out)
+	}
+	if strings.Contains(out, "polling CI status") || strings.Contains(out, "all checks passing") {
+		t.Fatalf("expected zero-height babysit view to omit log tail, got:\n%s", out)
+	}
+}
+
 func TestModel_View_BabysitShortTerminalKeepsStatusPanel(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.Ascii)
 

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -3020,10 +3020,39 @@ func TestRenderBabysitView_LogTailTinyStillShowsSome(t *testing.T) {
 		"all checks passing",
 	}
 
-	out := stripANSI(renderBabysitViewWithSelection(run, run.Steps, "", logs, 80, 8, 0, nil))
+	out := stripANSI(renderBabysitViewWithSelection(run, run.Steps, "", logs, 80, 10, 0, nil))
 
 	if !strings.Contains(out, "all checks passing") {
 		t.Error("expected at least the last log line even in tiny terminal")
+	}
+}
+
+func TestModel_View_BabysitShortTerminalKeepsStatusPanel(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.Ascii)
+
+	run := testRunWithBabysit()
+	run.Steps[5].Status = types.StepStatusRunning
+	run.PRURL = ptr("https://github.com/kunchenguid/no-mistakes/pull/42")
+
+	m := NewModel("/tmp/sock", nil, run)
+	m.width = 80
+	m.height = 17
+	m.logs = []string{
+		"line1",
+		"line2",
+		"all checks passing",
+	}
+
+	view := stripANSI(m.View())
+
+	if got := lipgloss.Height(view); got > m.height {
+		t.Fatalf("expected rendered view height <= terminal height (%d), got %d\n%s", m.height, got, view)
+	}
+	if !strings.Contains(view, "Babysit") {
+		t.Fatalf("expected babysit section to remain visible in short terminal\n%s", view)
+	}
+	if !strings.Contains(view, "Monitoring CI checks") {
+		t.Fatalf("expected babysit status panel to remain visible in short terminal\n%s", view)
 	}
 }
 

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1752,16 +1752,15 @@ func TestRenderBabysitView_Monitoring(t *testing.T) {
 	}
 }
 
-func TestRenderBabysitView_NoPRURL(t *testing.T) {
-	// PR URL should not appear in babysit panel - it's shown persistently in the footer.
+func TestRenderBabysitView_ShowsPRContextFromURL(t *testing.T) {
 	run := testRunWithBabysit()
 	run.PRURL = ptr("https://github.com/user/repo/pull/99")
 	run.Steps[5].Status = types.StepStatusRunning
 
-	out := renderBabysitView(run, run.Steps, "", nil, 80)
+	out := stripANSI(renderBabysitView(run, run.Steps, "", nil, 80))
 
-	if strings.Contains(out, "https://github.com/user/repo/pull/99") {
-		t.Error("expected no PR URL in babysit panel - shown in footer instead")
+	if !strings.Contains(out, "PR #99") {
+		t.Fatalf("expected babysit panel to show PR context, got: %s", out)
 	}
 }
 
@@ -4927,8 +4926,7 @@ func TestPipelineView_ShortErrorNotTruncated(t *testing.T) {
 	}
 }
 
-func TestRenderBabysitView_NoPRURLInPanel(t *testing.T) {
-	// PR URL should not appear in babysit panel regardless of length.
+func TestRenderBabysitView_ShowsShortPRContextInPanel(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.Ascii)
 	run := testRunWithBabysit()
 	longURL := "https://github.com/some-very-long-organization-name/some-very-long-repository-name-that-goes-on-and-on/pull/12345"
@@ -4937,8 +4935,11 @@ func TestRenderBabysitView_NoPRURLInPanel(t *testing.T) {
 
 	result := stripANSI(renderBabysitView(run, run.Steps, "", nil, 80))
 
-	if strings.Contains(result, "PR:") {
-		t.Error("expected no PR URL in babysit panel - shown in footer instead")
+	if !strings.Contains(result, "PR #12345") {
+		t.Fatalf("expected babysit panel to show short PR context, got: %s", result)
+	}
+	if strings.Contains(result, longURL) {
+		t.Fatal("expected babysit panel to avoid rendering the full PR URL")
 	}
 }
 
@@ -4968,18 +4969,21 @@ func TestRenderBabysitView_LongLastEventTruncated(t *testing.T) {
 	}
 }
 
-func TestRenderBabysitView_NoPRURLEvenShort(t *testing.T) {
-	// Even short PR URLs should not appear in babysit panel.
+func TestRenderBabysitView_ShowsPRContextWhenFooterWouldHideIt(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.Ascii)
 	run := testRunWithBabysit()
 	shortURL := "https://github.com/user/repo/pull/99"
 	run.PRURL = &shortURL
 	run.Steps[5].Status = types.StepStatusRunning
 
-	result := stripANSI(renderBabysitView(run, run.Steps, "", nil, 80))
+	footer := stripANSI(renderFooter(false, false, false, &shortURL, 20))
+	if strings.Contains(footer, "PR #99") {
+		t.Fatalf("expected narrow footer to hide PR context, got: %s", footer)
+	}
 
-	if strings.Contains(result, shortURL) {
-		t.Error("expected no PR URL in babysit panel - shown in footer instead")
+	result := stripANSI(renderBabysitView(run, run.Steps, "", nil, 20))
+	if !strings.Contains(result, "PR #99") {
+		t.Fatalf("expected babysit panel to retain PR context in narrow width, got: %s", result)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Restore PR context inside the babysit panel so the monitored PR remains identifiable even when narrow layouts hide footer details.
- Fix babysit height budgeting so cramped terminals degrade to a minimal status-only panel instead of expanding past the allotted space and disappearing.
- Refine babysit status and log rendering, including the grace-period state, with targeted test updates; pipeline review flagged only low-risk UI issues that were auto-fixed.

## Pipeline

✅ **Rebase** - passed
⚠️ **Review** - low risk - _"The change is narrowly scoped to babysit-panel rendering and targeted test coverage, and I did not find a material regression or merge-blocking risk in the modified code."_
✅ **Test** - passed
✅ **Lint** - passed

<details>
<summary>Review details</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/tui/babysit.go:95` - This renderer no longer shows any PR identifier inside the babysit panel and relies on the footer instead, but `renderFooter` drops the PR URL/label when the terminal is narrow. In those layouts the babysit screen can lose all PR context, so users cannot tell which PR is being monitored.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `internal/tui/babysit.go:151` - `logLines` is forced to at least 1 even when the remaining height is already exhausted. Because `Model.View` now passes the post-layout `contentBudget` into this renderer, the babysit box can grow past its allotted space and be dropped entirely by `appendExtraSection` on short terminals; allow a 0-line tail when `height <= fixedLines` so the status panel still renders.

**Round 3** (auto-fix) - found 2 issues (1 warning, 1 info)
- ⚠️ `internal/tui/babysit.go:161` - When `Model.View` passes a real height budget of `0` for a cramped layout, this branch treats it as "no height info" and renders a default 10-line log tail. That can make the babysit box exceed the remaining budget and disappear entirely instead of degrading to a minimal status-only panel.
- ℹ️ `internal/pipeline/steps/babysit.go:251` - Dropping the "waiting for checks to register" log message makes the initial grace-period state silent when GitHub has not published any checks yet, so the babysit panel loses its only explicit signal that it is still polling rather than stalled.

**Round 4** (auto-fix) - found 0 issues

</details>
