### PR TITLE
feat(tui): manage terminal titles across run lifecycle

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -729,7 +729,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch key {
 	case "q", "ctrl+c":
 		m.quitting = true
-		return m, tea.Quit
+		return m, tea.Sequence(tea.SetWindowTitle(""), tea.Quit)
 
 	case "?":
 		m.showHelp = !m.showHelp

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -87,6 +87,7 @@ func NewModel(socketPath string, client *ipc.Client, run *ipc.RunInfo) Model {
 		client:            client,
 		runID:             run.ID,
 		run:               run,
+		done:              run.Status == types.RunCompleted || run.Status == types.RunFailed || run.Status == types.RunCancelled,
 		steps:             run.Steps,
 		stepFindings:      make(map[types.StepName]string),
 		stepDiffs:         make(map[types.StepName]string),

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -157,9 +157,46 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// terminalTitle returns the current terminal title string based on run state.
+func (m Model) terminalTitle() string {
+	prefix := "no-mistakes: "
+
+	// Terminal states.
+	if m.done || m.run == nil {
+		switch {
+		case m.run == nil:
+			return prefix + "Pending"
+		case m.run.Status == types.RunCompleted:
+			return prefix + "✓ Completed"
+		case m.run.Status == types.RunFailed:
+			return prefix + "✗ Failed"
+		case m.run.Status == types.RunCancelled:
+			return prefix + "✗ Cancelled"
+		}
+	}
+
+	// Find the most relevant active step.
+	for _, s := range m.steps {
+		icon := stepStatusIcon(s.Status)
+		switch s.Status {
+		case types.StepStatusRunning, types.StepStatusFixing:
+			return prefix + icon + " " + stepLabel(s.StepName)
+		case types.StepStatusAwaitingApproval, types.StepStatusFixReview:
+			return prefix + icon + " " + stepLabel(s.StepName)
+		}
+	}
+
+	return prefix + "Pending"
+}
+
+// setTerminalTitle returns the OSC escape sequence to set the terminal title.
+func setTerminalTitle(title string) string {
+	return "\033]2;" + title + "\007"
+}
+
 func (m Model) View() string {
 	if m.quitting {
-		return ""
+		return setTerminalTitle("")
 	}
 
 	showSelectionActions, allowFix, selectedCount, totalCount := m.awaitingActionState()
@@ -353,7 +390,7 @@ func (m Model) View() string {
 	}
 	sections = append(sections, extraSections...)
 	sections = append(sections, footer)
-	return joinSections(sections, sectionGap)
+	return setTerminalTitle(m.terminalTitle()) + joinSections(sections, sectionGap)
 }
 
 func renderFindingsBoxForHeight(raw string, width int, cursor int, selected map[string]bool, boxHeight int) string {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -196,7 +196,7 @@ func setTerminalTitle(title string) string {
 
 func (m Model) View() string {
 	if m.quitting {
-		return setTerminalTitle("")
+		return ""
 	}
 
 	showSelectionActions, allowFix, selectedCount, totalCount := m.awaitingActionState()
@@ -378,7 +378,7 @@ func (m Model) View() string {
 		}
 		rightSections = append(rightSections, extraSections...)
 		columns := renderResponsiveColumns(joinSections(leftSections, sectionGap), joinSections(rightSections, sectionGap), leftWidth, rightWidth, responsiveLayoutGap)
-		return joinSections([]string{columns, footer}, sectionGap)
+		return setTerminalTitle(m.terminalTitle()) + joinSections([]string{columns, footer}, sectionGap)
 	}
 
 	sections := []string{pipelineView}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -554,6 +555,40 @@ func TestModel_HandleKey_Quit(t *testing.T) {
 	}
 	if cmd == nil {
 		t.Error("expected quit command")
+	}
+}
+
+func TestModel_HandleKey_QuitClearsTerminalTitle(t *testing.T) {
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusRunning
+	m := NewModel("/tmp/sock", nil, run)
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	if cmd == nil {
+		t.Fatal("expected quit command")
+	}
+
+	msg := cmd()
+	if fmt.Sprintf("%T", msg) != "tea.sequenceMsg" {
+		t.Fatalf("expected sequence message, got %T", msg)
+	}
+
+	cmds := reflect.ValueOf(msg)
+	if cmds.Len() != 2 {
+		t.Fatalf("expected 2 quit commands, got %d", cmds.Len())
+	}
+
+	titleCmd, ok := cmds.Index(0).Interface().(tea.Cmd)
+	if !ok {
+		t.Fatalf("expected first sequence entry to be tea.Cmd, got %T", cmds.Index(0).Interface())
+	}
+
+	titleMsg := titleCmd()
+	if fmt.Sprintf("%T", titleMsg) != "tea.setWindowTitleMsg" {
+		t.Fatalf("expected title reset message, got %T", titleMsg)
+	}
+	if fmt.Sprint(titleMsg) != "" {
+		t.Fatalf("expected blank title reset, got %q", fmt.Sprint(titleMsg))
 	}
 }
 

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -7654,6 +7654,16 @@ func TestTerminalTitle_Completed(t *testing.T) {
 	}
 }
 
+func TestTerminalTitle_ReattachCompletedRun(t *testing.T) {
+	run := testRun()
+	run.Status = types.RunCompleted
+	m := NewModel("/tmp/sock", nil, run)
+	title := m.terminalTitle()
+	if title != "no-mistakes: ✓ Completed" {
+		t.Errorf("expected 'no-mistakes: ✓ Completed', got %q", title)
+	}
+}
+
 func TestTerminalTitle_Failed(t *testing.T) {
 	run := testRun()
 	run.Status = types.RunFailed

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -7607,3 +7607,111 @@ func TestPipelineConnectors_SuppressedDuringBabysitInStackedLayout(t *testing.T)
 		t.Fatalf("expected stacked babysit layout to avoid uncapped pipeline height %d", m.height)
 	}
 }
+
+func TestTerminalTitle_AllPending(t *testing.T) {
+	m := NewModel("/tmp/sock", nil, testRun())
+	title := m.terminalTitle()
+	if title != "no-mistakes: Pending" {
+		t.Errorf("expected 'no-mistakes: Pending', got %q", title)
+	}
+}
+
+func TestTerminalTitle_RunningStep(t *testing.T) {
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusRunning
+	m := NewModel("/tmp/sock", nil, run)
+	title := m.terminalTitle()
+	// Should show the spinner prefix and the running step label.
+	if !strings.Contains(title, "Review") {
+		t.Errorf("expected title to contain 'Review', got %q", title)
+	}
+	if !strings.HasPrefix(title, "no-mistakes: ") {
+		t.Errorf("expected title to start with 'no-mistakes: ', got %q", title)
+	}
+}
+
+func TestTerminalTitle_AwaitingApproval(t *testing.T) {
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusAwaitingApproval
+	m := NewModel("/tmp/sock", nil, run)
+	title := m.terminalTitle()
+	if !strings.Contains(title, "Review") {
+		t.Errorf("expected title to contain 'Review', got %q", title)
+	}
+	if !strings.Contains(title, "⏸") {
+		t.Errorf("expected title to contain pause icon, got %q", title)
+	}
+}
+
+func TestTerminalTitle_Completed(t *testing.T) {
+	run := testRun()
+	run.Status = types.RunCompleted
+	m := NewModel("/tmp/sock", nil, run)
+	m.done = true
+	title := m.terminalTitle()
+	if title != "no-mistakes: ✓ Completed" {
+		t.Errorf("expected 'no-mistakes: ✓ Completed', got %q", title)
+	}
+}
+
+func TestTerminalTitle_Failed(t *testing.T) {
+	run := testRun()
+	run.Status = types.RunFailed
+	m := NewModel("/tmp/sock", nil, run)
+	m.done = true
+	title := m.terminalTitle()
+	if title != "no-mistakes: ✗ Failed" {
+		t.Errorf("expected 'no-mistakes: ✗ Failed', got %q", title)
+	}
+}
+
+func TestTerminalTitle_Cancelled(t *testing.T) {
+	run := testRun()
+	run.Status = types.RunCancelled
+	m := NewModel("/tmp/sock", nil, run)
+	m.done = true
+	title := m.terminalTitle()
+	if title != "no-mistakes: ✗ Cancelled" {
+		t.Errorf("expected 'no-mistakes: ✗ Cancelled', got %q", title)
+	}
+}
+
+func TestTerminalTitle_FixingStep(t *testing.T) {
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusCompleted
+	run.Steps[1].Status = types.StepStatusFixing
+	m := NewModel("/tmp/sock", nil, run)
+	title := m.terminalTitle()
+	if !strings.Contains(title, "Test") {
+		t.Errorf("expected title to contain 'Test', got %q", title)
+	}
+}
+
+func TestView_ContainsTerminalTitleEscape(t *testing.T) {
+	configureTUIColors()
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusRunning
+	m := NewModel("/tmp/sock", nil, run)
+	m.width = 80
+	m.height = 40
+	view := m.View()
+	// The view should start with the OSC title-setting escape sequence.
+	if !strings.HasPrefix(view, "\033]2;no-mistakes: ") {
+		t.Errorf("expected view to start with OSC title escape, got prefix: %q", view[:min(len(view), 40)])
+	}
+	if !strings.Contains(view, "\007") {
+		t.Error("expected view to contain BEL terminator for OSC sequence")
+	}
+}
+
+func TestView_QuittingResetsTerminalTitle(t *testing.T) {
+	configureTUIColors()
+	run := testRun()
+	m := NewModel("/tmp/sock", nil, run)
+	m.quitting = true
+	view := m.View()
+	// When quitting, should emit the reset sequence to restore the title.
+	if !strings.Contains(view, "\033]2;\007") {
+		t.Errorf("expected quitting view to reset terminal title, got: %q", view)
+	}
+}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -7704,14 +7704,29 @@ func TestView_ContainsTerminalTitleEscape(t *testing.T) {
 	}
 }
 
-func TestView_QuittingResetsTerminalTitle(t *testing.T) {
+func TestView_ResponsiveLayoutContainsTerminalTitleEscape(t *testing.T) {
+	configureTUIColors()
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusRunning
+	m := NewModel("/tmp/sock", nil, run)
+	m.width = 120
+	m.height = 40
+	view := m.View()
+	if !strings.HasPrefix(view, "\033]2;no-mistakes: ") {
+		t.Errorf("expected responsive view to start with OSC title escape, got prefix: %q", view[:min(len(view), 40)])
+	}
+	if !strings.Contains(view, "\007") {
+		t.Error("expected responsive view to contain BEL terminator for OSC sequence")
+	}
+}
+
+func TestView_QuittingDoesNotBlankTerminalTitle(t *testing.T) {
 	configureTUIColors()
 	run := testRun()
 	m := NewModel("/tmp/sock", nil, run)
 	m.quitting = true
 	view := m.View()
-	// When quitting, should emit the reset sequence to restore the title.
-	if !strings.Contains(view, "\033]2;\007") {
-		t.Errorf("expected quitting view to reset terminal title, got: %q", view)
+	if strings.Contains(view, "\033]2;") {
+		t.Errorf("expected quitting view to avoid sending a terminal title sequence, got: %q", view)
 	}
 }


### PR DESCRIPTION
{"title":"feat(tui): manage terminal titles across run lifecycle","body":"## Summary\n- Add terminal title support in the TUI so active runs surface their state directly in the terminal/tab title.\n- Fix title updates across responsive layouts and completed reattachments so finished runs show the correct state immediately instead of staying pending until another event arrives.\n- Clear the custom title on quit; pipeline review marked the change low risk and the auto-fixes addressed the earlier title-update and cleanup warnings."}

## Pipeline

✅ **Rebase** - passed
⚠️ **Review** - low risk - _"The change is narrowly scoped to terminal-title rendering and quit cleanup in the TUI, and the added tests cover the main state transitions and reattach behavior with little evidence of merge-blocking risk."_
✅ **Test** - passed
✅ **Lint** - passed

<details>
<summary>Review details</summary>

**Round 1** - found 2 warnings
- ⚠️ `internal/tui/app.go:381` - The responsive-layout return path skips `setTerminalTitle(...)`, so on wider terminals the feature silently does nothing and the title only updates in stacked layout. Prefix the responsive branch's returned view with the same OSC sequence used below.
- ⚠️ `internal/tui/app.go:199` - On quit, the code sends `OSC 2` with an empty title, which blanks the user's terminal/tab title instead of restoring the previous shell title. Either preserve and restore the prior title or avoid sending a reset sequence on exit.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `internal/tui/app.go:165` - `terminalTitle` only returns completed/failed/cancelled titles when `m.done` is already true, but `NewModel` does not derive `done` from the initial run state. Re-attaching to an already finished run will therefore show `no-mistakes: Pending` until another event arrives; key this off `m.run.Status` directly or initialize `done` from the incoming run.

**Round 3** (auto-fix) - found 1 warning
- ⚠️ `internal/tui/app.go:382` - The new OSC 2 title update is one-way: the TUI sets a custom terminal title on every render, but there is no matching restore or clear when the program detaches/quits, so terminals that persist titles will be left showing the last run state after exit.

**Round 4** (auto-fix) - found 0 issues

</details>
