### PR TITLE
feat(pipeline): add PR summary step and harden findings reporting

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -644,6 +644,135 @@ func TestRecoverStaleRunsMarksStepsFailed(t *testing.T) {
 	}
 }
 
+func TestStepRoundInsertAndGet(t *testing.T) {
+	d := openTestDB(t)
+	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")
+	run, _ := d.InsertRun(repo.ID, "feature", "abc", "def")
+	step, _ := d.InsertStepResult(run.ID, types.StepReview)
+
+	findings := `{"findings":[{"id":"review-1","severity":"warning","description":"unused var"}],"summary":"1 issue"}`
+	r, err := d.InsertStepRound(step.ID, 1, "initial", &findings, 1200)
+	if err != nil {
+		t.Fatalf("insert round: %v", err)
+	}
+	if r.ID == "" {
+		t.Fatal("expected non-empty ID")
+	}
+	if r.StepResultID != step.ID {
+		t.Errorf("step_result_id = %q, want %q", r.StepResultID, step.ID)
+	}
+	if r.Round != 1 {
+		t.Errorf("round = %d, want 1", r.Round)
+	}
+	if r.Trigger != "initial" {
+		t.Errorf("trigger = %q, want %q", r.Trigger, "initial")
+	}
+	if r.FindingsJSON == nil || *r.FindingsJSON != findings {
+		t.Errorf("findings = %v, want %q", r.FindingsJSON, findings)
+	}
+	if r.DurationMS != 1200 {
+		t.Errorf("duration_ms = %d, want 1200", r.DurationMS)
+	}
+	if r.CreatedAt == 0 {
+		t.Error("expected non-zero created_at")
+	}
+}
+
+func TestStepRoundNullFindings(t *testing.T) {
+	d := openTestDB(t)
+	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")
+	run, _ := d.InsertRun(repo.ID, "feature", "abc", "def")
+	step, _ := d.InsertStepResult(run.ID, types.StepTest)
+
+	r, err := d.InsertStepRound(step.ID, 1, "initial", nil, 500)
+	if err != nil {
+		t.Fatalf("insert round: %v", err)
+	}
+	if r.FindingsJSON != nil {
+		t.Errorf("findings = %v, want nil", r.FindingsJSON)
+	}
+}
+
+func TestGetRoundsByStep(t *testing.T) {
+	d := openTestDB(t)
+	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")
+	run, _ := d.InsertRun(repo.ID, "feature", "abc", "def")
+	step, _ := d.InsertStepResult(run.ID, types.StepLint)
+
+	findings1 := `{"findings":[{"id":"lint-1","severity":"error","description":"missing check"}],"summary":"1 error"}`
+	d.InsertStepRound(step.ID, 1, "initial", &findings1, 800)
+	d.InsertStepRound(step.ID, 2, "auto_fix", nil, 600)
+
+	rounds, err := d.GetRoundsByStep(step.ID)
+	if err != nil {
+		t.Fatalf("get rounds: %v", err)
+	}
+	if len(rounds) != 2 {
+		t.Fatalf("got %d rounds, want 2", len(rounds))
+	}
+	if rounds[0].Round != 1 {
+		t.Errorf("first round = %d, want 1", rounds[0].Round)
+	}
+	if rounds[0].Trigger != "initial" {
+		t.Errorf("first trigger = %q, want initial", rounds[0].Trigger)
+	}
+	if rounds[0].FindingsJSON == nil {
+		t.Fatal("expected non-nil findings on round 1")
+	}
+	if rounds[1].Round != 2 {
+		t.Errorf("second round = %d, want 2", rounds[1].Round)
+	}
+	if rounds[1].Trigger != "auto_fix" {
+		t.Errorf("second trigger = %q, want auto_fix", rounds[1].Trigger)
+	}
+	if rounds[1].FindingsJSON != nil {
+		t.Errorf("expected nil findings on round 2, got %v", rounds[1].FindingsJSON)
+	}
+}
+
+func TestGetRoundsByStepEmpty(t *testing.T) {
+	d := openTestDB(t)
+	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")
+	run, _ := d.InsertRun(repo.ID, "feature", "abc", "def")
+	step, _ := d.InsertStepResult(run.ID, types.StepPush)
+
+	rounds, err := d.GetRoundsByStep(step.ID)
+	if err != nil {
+		t.Fatalf("get rounds: %v", err)
+	}
+	if len(rounds) != 0 {
+		t.Errorf("got %d rounds, want 0", len(rounds))
+	}
+}
+
+func TestStepRoundCascadeDelete(t *testing.T) {
+	d := openTestDB(t)
+	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")
+	run, _ := d.InsertRun(repo.ID, "feature", "abc", "def")
+	step, _ := d.InsertStepResult(run.ID, types.StepReview)
+	d.InsertStepRound(step.ID, 1, "initial", nil, 100)
+
+	// Deleting repo should cascade to runs -> step_results -> step_rounds
+	if err := d.DeleteRepo(repo.ID); err != nil {
+		t.Fatalf("delete repo: %v", err)
+	}
+	rounds, err := d.GetRoundsByStep(step.ID)
+	if err != nil {
+		t.Fatalf("get rounds after cascade: %v", err)
+	}
+	if len(rounds) != 0 {
+		t.Errorf("got %d rounds after cascade delete, want 0", len(rounds))
+	}
+}
+
+func TestOpenCreatesStepRoundsTable(t *testing.T) {
+	d := openTestDB(t)
+	var count int
+	if err := d.sql.QueryRow("SELECT count(*) FROM step_rounds").Scan(&count); err != nil {
+		t.Fatalf("step_rounds table missing: %v", err)
+	}
+}
+
 func TestRecoverStaleRunsNoStaleRuns(t *testing.T) {
 	d := openTestDB(t)
 	repo, _ := d.InsertRepo("/home/user/project3", "git@github.com:user/project3.git", "main")

--- a/internal/db/round.go
+++ b/internal/db/round.go
@@ -1,0 +1,56 @@
+package db
+
+import "fmt"
+
+// StepRound represents one execution round within a pipeline step.
+type StepRound struct {
+	ID           string
+	StepResultID string
+	Round        int
+	Trigger      string  // "initial", "auto_fix", "user_fix"
+	FindingsJSON *string // nullable - findings produced by this round
+	DurationMS   int64
+	CreatedAt    int64
+}
+
+// InsertStepRound creates a new round record for a step result.
+func (d *DB) InsertStepRound(stepResultID string, round int, trigger string, findingsJSON *string, durationMS int64) (*StepRound, error) {
+	r := &StepRound{
+		ID:           newID(),
+		StepResultID: stepResultID,
+		Round:        round,
+		Trigger:      trigger,
+		FindingsJSON: findingsJSON,
+		DurationMS:   durationMS,
+		CreatedAt:    now(),
+	}
+	_, err := d.sql.Exec(
+		`INSERT INTO step_rounds (id, step_result_id, round, trigger_type, findings_json, duration_ms, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		r.ID, r.StepResultID, r.Round, r.Trigger, r.FindingsJSON, r.DurationMS, r.CreatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("insert step round: %w", err)
+	}
+	return r, nil
+}
+
+// GetRoundsByStep returns all rounds for a step result, ordered by round number.
+func (d *DB) GetRoundsByStep(stepResultID string) ([]*StepRound, error) {
+	rows, err := d.sql.Query(
+		`SELECT id, step_result_id, round, trigger_type, findings_json, duration_ms, created_at FROM step_rounds WHERE step_result_id = ? ORDER BY round`,
+		stepResultID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get rounds by step: %w", err)
+	}
+	defer rows.Close()
+	var rounds []*StepRound
+	for rows.Next() {
+		r := &StepRound{}
+		if err := rows.Scan(&r.ID, &r.StepResultID, &r.Round, &r.Trigger, &r.FindingsJSON, &r.DurationMS, &r.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan step round: %w", err)
+		}
+		rounds = append(rounds, r)
+	}
+	return rounds, rows.Err()
+}

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -36,4 +36,14 @@ CREATE TABLE IF NOT EXISTS step_results (
     started_at    INTEGER,
     completed_at  INTEGER
 );
+
+CREATE TABLE IF NOT EXISTS step_rounds (
+    id             TEXT PRIMARY KEY,
+    step_result_id TEXT NOT NULL REFERENCES step_results(id) ON DELETE CASCADE,
+    round          INTEGER NOT NULL,
+    trigger_type   TEXT NOT NULL,
+    findings_json  TEXT,
+    duration_ms    INTEGER NOT NULL,
+    created_at     INTEGER NOT NULL
+);
 `

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -174,12 +174,16 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 		autoFixLimit = e.config.AutoFixLimit(stepName)
 	}
 	autoFixAttempts := 0
+	roundNum := 0
+	nextTrigger := "initial"
 
 	// Execute with possible fix loop
 	for {
 		outcome, err := step.Execute(sctx)
+		roundNum++
+		roundDuration := time.Since(phaseStart).Milliseconds()
 		if err != nil {
-			durationMS := executionMS + time.Since(phaseStart).Milliseconds()
+			durationMS := executionMS + roundDuration
 			if dbErr := e.db.FailStep(sr.ID, err.Error(), durationMS); dbErr != nil {
 				slog.Warn("failed to mark step as failed in db", "step", stepName, "error", dbErr)
 			}
@@ -198,6 +202,15 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			if dbErr := e.db.ClearStepFindings(sr.ID); dbErr != nil {
 				slog.Warn("failed to clear step findings in db", "step", stepName, "error", dbErr)
 			}
+		}
+
+		// Persist this execution round.
+		var findingsPtr *string
+		if outcome.Findings != "" {
+			findingsPtr = &outcome.Findings
+		}
+		if _, dbErr := e.db.InsertStepRound(sr.ID, roundNum, nextTrigger, findingsPtr, roundDuration); dbErr != nil {
+			slog.Warn("failed to insert step round", "step", stepName, "round", roundNum, "error", dbErr)
 		}
 
 		// If the step produced a PR URL, propagate it to the run and emit an update.
@@ -223,6 +236,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			phaseStart = time.Now()
 			sctx.Fixing = true
 			sctx.PreviousFindings = outcome.Findings
+			nextTrigger = "auto_fix"
 			continue
 		}
 
@@ -302,6 +316,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFixing), "", "", "", nil)
 			sctx.Fixing = true
 			sctx.PreviousFindings = filterFindingsJSON(outcome.Findings, response.findingIDs)
+			nextTrigger = "user_fix"
 			slog.Info("step fix requested, re-executing", "step", stepName)
 			continue // loop back to step.Execute
 		}

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
+	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/scm"
@@ -204,7 +205,18 @@ func (s *PRStep) buildPRContent(sctx *pipeline.StepContext, branch, baseSHA stri
 	commitLog, _ := git.Log(ctx, sctx.WorkDir, baseSHA, sctx.Run.HeadSHA)
 	diffStat, _ := git.Run(ctx, sctx.WorkDir, "diff", "--stat", baseSHA+".."+sctx.Run.HeadSHA)
 
-	prompt := fmt.Sprintf(`Draft a pull request title and description for the full branch delta.
+	// Build the deterministic pipeline section from step rounds.
+	pipelineMD := s.buildPipelineSection(sctx)
+
+	// Build pipeline context for the agent prompt so it can reference findings in the summary.
+	pipelineContext := ""
+	if pipelineMD != "" {
+		pipelineContext = fmt.Sprintf(`
+Pipeline results (reference these naturally in the summary if relevant):
+%s`, pipelineMD)
+	}
+
+	prompt := fmt.Sprintf(`Draft a pull request title and summary for the full branch delta.
 
 Context:
 - branch: %s
@@ -215,14 +227,14 @@ Context:
 Rules:
 - Cover the full branch delta, not just the latest commit.
 - Title must use conventional commit format: "type(scope): description" or "type: description". Valid types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert. Scope is optional. Do not capitalize the type. Do not use the raw branch name.
-- Body: GitHub-flavored markdown with a short summary and testing section.
+- Body: a "## Summary" section in GitHub-flavored markdown. 1-3 concise bullet points describing what changed and why. If the pipeline flagged anything notable (risk, findings, auto-fixes), mention it briefly. Do not include a Testing section - pipeline results are appended separately.
 - Do not invent tests or behavior.
 
 Commit history:
 %s
 
 Diff stat:
-%s`, branch, baseSHA, sctx.Run.HeadSHA, sctx.Repo.DefaultBranch, commitLog, diffStat)
+%s%s`, branch, baseSHA, sctx.Run.HeadSHA, sctx.Repo.DefaultBranch, commitLog, diffStat, pipelineContext)
 
 	result, err := sctx.Agent.Run(ctx, agent.RunOpts{
 		Prompt:     prompt,
@@ -232,7 +244,7 @@ Diff stat:
 	})
 	if err != nil {
 		slog.Warn("agent failed for PR content, using fallback", "error", err)
-		return fallbackPRContent(branch, commitLog), nil
+		return fallbackPRContent(branch, commitLog, pipelineMD), nil
 	}
 
 	var content prContent
@@ -245,15 +257,46 @@ Diff stat:
 					slog.Warn("agent PR title is not conventional commit format, prepending chore:", "title", content.Title)
 					content.Title = "chore: " + content.Title
 				}
+				content.Body = appendPipelineSection(content.Body, pipelineMD)
 				return content, nil
 			}
 		}
 	}
 
-	return fallbackPRContent(branch, commitLog), nil
+	return fallbackPRContent(branch, commitLog, pipelineMD), nil
 }
 
-func fallbackPRContent(branch, commitLog string) prContent {
+// buildPipelineSection queries step results and rounds from the DB and
+// produces the deterministic pipeline markdown section.
+func (s *PRStep) buildPipelineSection(sctx *pipeline.StepContext) string {
+	steps, err := sctx.DB.GetStepsByRun(sctx.Run.ID)
+	if err != nil {
+		slog.Warn("failed to query step results for pipeline summary", "error", err)
+		return ""
+	}
+
+	rounds := make(map[string][]*db.StepRound, len(steps))
+	for _, sr := range steps {
+		r, err := sctx.DB.GetRoundsByStep(sr.ID)
+		if err != nil {
+			slog.Warn("failed to query rounds for step", "step", sr.StepName, "error", err)
+			continue
+		}
+		rounds[sr.ID] = r
+	}
+
+	return BuildPipelineSummary(steps, rounds)
+}
+
+// appendPipelineSection appends the pipeline markdown after the agent's body.
+func appendPipelineSection(body, pipelineMD string) string {
+	if pipelineMD == "" {
+		return body
+	}
+	return body + "\n\n" + pipelineMD
+}
+
+func fallbackPRContent(branch, commitLog, pipelineMD string) prContent {
 	title := ""
 	for _, line := range strings.Split(commitLog, "\n") {
 		line = strings.TrimSpace(line)
@@ -273,12 +316,13 @@ func fallbackPRContent(branch, commitLog string) prContent {
 	} else if !isConventionalTitle(title) {
 		title = "chore: " + title
 	}
-	body := strings.TrimSpace(commitLog)
-	if body == "" {
-		body = "Not run"
+	body := fmt.Sprintf("## Summary\n\n%s", strings.TrimSpace(commitLog))
+	if body == "## Summary\n\n" {
+		body = fmt.Sprintf("## Summary\n\n- %s", title)
 	}
+	body = appendPipelineSection(body, pipelineMD)
 	return prContent{
 		Title: title,
-		Body:  fmt.Sprintf("## Summary\n\n- %s\n\n## Testing\n\n- %s", title, body),
+		Body:  body,
 	}
 }

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -85,6 +85,7 @@ func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, deta
 	hadFindings := initialFindings != nil && len(initialFindings.Items) > 0
 	hasFinalFindings := finalFindings != nil && len(finalFindings.Items) > 0
 	hasAnyRoundFindings := roundsHaveFindings(rounds)
+	hasRoundDetails := roundsNeedDetail(rounds)
 	hadAnyFindings := hadFindings || hasFinalFindings || hasAnyRoundFindings
 	wasFixed := hadFindings && len(rounds) > 1 && !hasFinalFindings
 
@@ -95,7 +96,11 @@ func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, deta
 
 	// For test/lint/rebase: determine emoji and result text.
 	if !hadAnyFindings {
-		return fmt.Sprintf("✅ **%s** - passed", name), ""
+		detail := ""
+		if hasRoundDetails {
+			detail = buildRoundsDetail(name, rounds)
+		}
+		return fmt.Sprintf("✅ **%s** - passed", name), detail
 	}
 
 	if wasFixed {
@@ -114,7 +119,7 @@ func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, deta
 	count := countFindingsBySeverity(currentFindings)
 	line := fmt.Sprintf("⚠️ **%s** - %s", name, count)
 	detail := ""
-	if hasAnyRoundFindings {
+	if hasRoundDetails {
 		detail = buildRoundsDetail(name, rounds)
 	}
 	return line, detail
@@ -136,9 +141,9 @@ func buildReviewEntry(name string, finalFindings, initialFindings *types.Finding
 
 	hasInitialFindings := initialFindings != nil && len(initialFindings.Items) > 0
 	hasFinalFindings := finalFindings != nil && len(finalFindings.Items) > 0
-	hasHistoricalFindings := hasInitialFindings || roundsHaveFindings(rounds)
+	hasHistoricalFindings := hasInitialFindings || roundsNeedDetail(rounds)
 	emoji := "✅"
-	if hasFinalFindings {
+	if hasFinalFindings || riskLevel == "medium" || riskLevel == "high" {
 		emoji = "⚠️"
 	}
 
@@ -167,6 +172,26 @@ func roundsHaveFindings(rounds []*db.StepRound) bool {
 		f, err := types.ParseFindingsJSON(*r.FindingsJSON)
 		if err != nil {
 			continue
+		}
+		if len(f.Items) > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+func roundsNeedDetail(rounds []*db.StepRound) bool {
+	for _, r := range rounds {
+		if r.FindingsJSON == nil {
+			continue
+		}
+		if _, err := types.ParseFindingsJSON(*r.FindingsJSON); err != nil {
+			return true
+		}
+		f, err := types.ParseFindingsJSON(*r.FindingsJSON)
+		if err != nil {
+			return true
 		}
 		if len(f.Items) > 0 {
 			return true
@@ -241,7 +266,7 @@ func buildRoundsDetail(name string, rounds []*db.StepRound) string {
 
 		findings, err := types.ParseFindingsJSON(*r.FindingsJSON)
 		if err != nil {
-			b.WriteString(fmt.Sprintf("**Round %d**%s - %s\n\n", r.Round, triggerLabel, findings.Summary))
+			b.WriteString(fmt.Sprintf("**Round %d**%s - failed to parse findings\n\n", r.Round, triggerLabel))
 			continue
 		}
 

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -68,9 +68,11 @@ func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, deta
 
 	// Parse the final findings on the step result (last state).
 	var finalFindings *types.Findings
+	finalFindingsParsed := sr.FindingsJSON == nil
 	if sr.FindingsJSON != nil {
 		if f, err := types.ParseFindingsJSON(*sr.FindingsJSON); err == nil {
 			finalFindings = &f
+			finalFindingsParsed = true
 		}
 	}
 
@@ -88,11 +90,12 @@ func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, deta
 	hasRoundParseFailure := roundsHaveParseFailure(rounds)
 	hasRoundDetails := roundsNeedDetail(rounds)
 	hadAnyFindings := hadFindings || hasFinalFindings || hasAnyRoundFindings
-	wasFixed := hadFindings && len(rounds) > 1 && !hasFinalFindings
+	hasUnreadableFinalFindings := sr.FindingsJSON != nil && !finalFindingsParsed
+	wasFixed := hadFindings && len(rounds) > 1 && !hasUnreadableFinalFindings && !hasFinalFindings
 
 	// Special handling for review step - risk level is the primary signal.
 	if sr.StepName == types.StepReview {
-		return buildReviewEntry(name, finalFindings, initialFindings, rounds)
+		return buildReviewEntry(name, finalFindings, initialFindings, rounds, hasUnreadableFinalFindings)
 	}
 
 	// For test/lint/rebase: determine emoji and result text.
@@ -105,6 +108,14 @@ func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, deta
 	}
 
 	if hasRoundParseFailure && !hadAnyFindings {
+		detail := ""
+		if hasRoundDetails {
+			detail = buildRoundsDetail(name, rounds)
+		}
+		return fmt.Sprintf("⚠️ **%s** - findings unavailable", name), detail
+	}
+
+	if hasUnreadableFinalFindings {
 		detail := ""
 		if hasRoundDetails {
 			detail = buildRoundsDetail(name, rounds)
@@ -134,10 +145,10 @@ func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, deta
 	return line, detail
 }
 
-func buildReviewEntry(name string, finalFindings, initialFindings *types.Findings, rounds []*db.StepRound) (string, string) {
+func buildReviewEntry(name string, finalFindings, initialFindings *types.Findings, rounds []*db.StepRound, hasUnreadableFinalFindings bool) (string, string) {
 	// Determine risk level and rationale from whichever findings have them.
 	src := finalFindings
-	if src == nil {
+	if src == nil && !hasUnreadableFinalFindings {
 		src = initialFindings
 	}
 
@@ -158,7 +169,9 @@ func buildReviewEntry(name string, finalFindings, initialFindings *types.Finding
 	}
 
 	var line string
-	if riskLevel != "" {
+	if hasUnreadableFinalFindings {
+		line = fmt.Sprintf("%s **%s** - findings unavailable", emoji, name)
+	} else if riskLevel != "" {
 		line = fmt.Sprintf("%s **%s** - %s risk", emoji, name, riskLevel)
 		if rationale != "" {
 			line += fmt.Sprintf(` - _"%s"_`, rationale)

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -84,6 +84,8 @@ func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, deta
 
 	hadFindings := initialFindings != nil && len(initialFindings.Items) > 0
 	hasFinalFindings := finalFindings != nil && len(finalFindings.Items) > 0
+	hasAnyRoundFindings := roundsHaveFindings(rounds)
+	hadAnyFindings := hadFindings || hasFinalFindings || hasAnyRoundFindings
 	wasFixed := hadFindings && len(rounds) > 1 && !hasFinalFindings
 
 	// Special handling for review step - risk level is the primary signal.
@@ -92,7 +94,7 @@ func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, deta
 	}
 
 	// For test/lint/rebase: determine emoji and result text.
-	if !hadFindings {
+	if !hadAnyFindings {
 		return fmt.Sprintf("✅ **%s** - passed", name), ""
 	}
 
@@ -111,7 +113,10 @@ func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, deta
 	// Had findings and the final state still contains them - approved as-is.
 	count := countFindingsBySeverity(currentFindings)
 	line := fmt.Sprintf("⚠️ **%s** - %s", name, count)
-	detail := buildRoundsDetail(name, rounds)
+	detail := ""
+	if hasAnyRoundFindings {
+		detail = buildRoundsDetail(name, rounds)
+	}
 	return line, detail
 }
 
@@ -129,9 +134,11 @@ func buildReviewEntry(name string, finalFindings, initialFindings *types.Finding
 		rationale = src.RiskRationale
 	}
 
-	hasFindings := initialFindings != nil && len(initialFindings.Items) > 0
+	hasInitialFindings := initialFindings != nil && len(initialFindings.Items) > 0
+	hasFinalFindings := finalFindings != nil && len(finalFindings.Items) > 0
+	hasHistoricalFindings := hasInitialFindings || roundsHaveFindings(rounds)
 	emoji := "✅"
-	if hasFindings {
+	if hasFinalFindings {
 		emoji = "⚠️"
 	}
 
@@ -146,10 +153,27 @@ func buildReviewEntry(name string, finalFindings, initialFindings *types.Finding
 	}
 
 	detail := ""
-	if hasFindings {
+	if hasHistoricalFindings {
 		detail = buildRoundsDetail(name, rounds)
 	}
 	return line, detail
+}
+
+func roundsHaveFindings(rounds []*db.StepRound) bool {
+	for _, r := range rounds {
+		if r.FindingsJSON == nil {
+			continue
+		}
+		f, err := types.ParseFindingsJSON(*r.FindingsJSON)
+		if err != nil {
+			continue
+		}
+		if len(f.Items) > 0 {
+			return true
+		}
+	}
+
+	return false
 }
 
 func buildFixResultText(rounds []*db.StepRound) string {

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -85,6 +85,7 @@ func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, deta
 	hadFindings := initialFindings != nil && len(initialFindings.Items) > 0
 	hasFinalFindings := finalFindings != nil && len(finalFindings.Items) > 0
 	hasAnyRoundFindings := roundsHaveFindings(rounds)
+	hasRoundParseFailure := roundsHaveParseFailure(rounds)
 	hasRoundDetails := roundsNeedDetail(rounds)
 	hadAnyFindings := hadFindings || hasFinalFindings || hasAnyRoundFindings
 	wasFixed := hadFindings && len(rounds) > 1 && !hasFinalFindings
@@ -95,12 +96,20 @@ func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, deta
 	}
 
 	// For test/lint/rebase: determine emoji and result text.
-	if !hadAnyFindings {
+	if !hadAnyFindings && !hasRoundParseFailure {
 		detail := ""
 		if hasRoundDetails {
 			detail = buildRoundsDetail(name, rounds)
 		}
 		return fmt.Sprintf("✅ **%s** - passed", name), detail
+	}
+
+	if hasRoundParseFailure && !hadAnyFindings {
+		detail := ""
+		if hasRoundDetails {
+			detail = buildRoundsDetail(name, rounds)
+		}
+		return fmt.Sprintf("⚠️ **%s** - findings unavailable", name), detail
 	}
 
 	if wasFixed {
@@ -142,8 +151,9 @@ func buildReviewEntry(name string, finalFindings, initialFindings *types.Finding
 	hasInitialFindings := initialFindings != nil && len(initialFindings.Items) > 0
 	hasFinalFindings := finalFindings != nil && len(finalFindings.Items) > 0
 	hasHistoricalFindings := hasInitialFindings || roundsNeedDetail(rounds)
+	hasRoundParseFailure := roundsHaveParseFailure(rounds)
 	emoji := "✅"
-	if hasFinalFindings || riskLevel == "medium" || riskLevel == "high" {
+	if hasFinalFindings || hasRoundParseFailure || riskLevel == "medium" || riskLevel == "high" {
 		emoji = "⚠️"
 	}
 
@@ -153,6 +163,8 @@ func buildReviewEntry(name string, finalFindings, initialFindings *types.Finding
 		if rationale != "" {
 			line += fmt.Sprintf(` - _"%s"_`, rationale)
 		}
+	} else if hasRoundParseFailure {
+		line = fmt.Sprintf("%s **%s** - findings unavailable", emoji, name)
 	} else {
 		line = fmt.Sprintf("%s **%s** - passed", emoji, name)
 	}
@@ -174,6 +186,19 @@ func roundsHaveFindings(rounds []*db.StepRound) bool {
 			continue
 		}
 		if len(f.Items) > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+func roundsHaveParseFailure(rounds []*db.StepRound) bool {
+	for _, r := range rounds {
+		if r.FindingsJSON == nil {
+			continue
+		}
+		if _, err := types.ParseFindingsJSON(*r.FindingsJSON); err != nil {
 			return true
 		}
 	}

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -83,7 +83,8 @@ func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, deta
 	}
 
 	hadFindings := initialFindings != nil && len(initialFindings.Items) > 0
-	wasFixed := hadFindings && len(rounds) > 1
+	hasFinalFindings := finalFindings != nil && len(finalFindings.Items) > 0
+	wasFixed := hadFindings && len(rounds) > 1 && !hasFinalFindings
 
 	// Special handling for review step - risk level is the primary signal.
 	if sr.StepName == types.StepReview {
@@ -102,8 +103,13 @@ func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, deta
 		return line, detail
 	}
 
-	// Had findings but only 1 round - approved as-is.
-	count := countFindingsBySeverity(initialFindings)
+	currentFindings := initialFindings
+	if hasFinalFindings {
+		currentFindings = finalFindings
+	}
+
+	// Had findings and the final state still contains them - approved as-is.
+	count := countFindingsBySeverity(currentFindings)
 	line := fmt.Sprintf("⚠️ **%s** - %s", name, count)
 	detail := buildRoundsDetail(name, rounds)
 	return line, detail

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -164,7 +164,7 @@ func buildReviewEntry(name string, finalFindings, initialFindings *types.Finding
 	hasHistoricalFindings := hasInitialFindings || roundsNeedDetail(rounds)
 	hasRoundParseFailure := roundsHaveParseFailure(rounds)
 	emoji := "✅"
-	if hasFinalFindings || hasRoundParseFailure || riskLevel == "medium" || riskLevel == "high" {
+	if hasFinalFindings || hasUnreadableFinalFindings || hasRoundParseFailure || riskLevel == "medium" || riskLevel == "high" {
 		emoji = "⚠️"
 	}
 

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -1,0 +1,307 @@
+package steps
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// summarySteps are the steps we include in the pipeline summary.
+// Push, PR, and Babysit are operational - not interesting for the PR reader.
+var summarySteps = map[types.StepName]bool{
+	types.StepRebase: true,
+	types.StepReview: true,
+	types.StepTest:   true,
+	types.StepLint:   true,
+}
+
+// BuildPipelineSummary produces a deterministic markdown section from step results and rounds.
+func BuildPipelineSummary(steps []*db.StepResult, rounds map[string][]*db.StepRound) string {
+	if len(steps) == 0 {
+		return ""
+	}
+
+	var statusLines []string
+	var detailBlocks []string
+
+	for _, sr := range steps {
+		if !summarySteps[sr.StepName] {
+			continue
+		}
+		stepRounds := rounds[sr.ID]
+		line, detail := buildStepEntry(sr, stepRounds)
+		if line != "" {
+			statusLines = append(statusLines, line)
+		}
+		if detail != "" {
+			detailBlocks = append(detailBlocks, detail)
+		}
+	}
+
+	if len(statusLines) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("## Pipeline\n\n")
+	for _, line := range statusLines {
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+
+	for _, detail := range detailBlocks {
+		b.WriteString("\n")
+		b.WriteString(detail)
+	}
+
+	return b.String()
+}
+
+func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, detailBlock string) {
+	name := stepDisplayName(sr.StepName)
+
+	if sr.Status == types.StepStatusSkipped {
+		return fmt.Sprintf("⏭️ **%s** - skipped", name), ""
+	}
+
+	// Parse the final findings on the step result (last state).
+	var finalFindings *types.Findings
+	if sr.FindingsJSON != nil {
+		if f, err := types.ParseFindingsJSON(*sr.FindingsJSON); err == nil {
+			finalFindings = &f
+		}
+	}
+
+	// Parse initial round findings (round 1) for the full story.
+	var initialFindings *types.Findings
+	if len(rounds) > 0 && rounds[0].FindingsJSON != nil {
+		if f, err := types.ParseFindingsJSON(*rounds[0].FindingsJSON); err == nil {
+			initialFindings = &f
+		}
+	}
+
+	hadFindings := initialFindings != nil && len(initialFindings.Items) > 0
+	wasFixed := hadFindings && len(rounds) > 1
+
+	// Special handling for review step - risk level is the primary signal.
+	if sr.StepName == types.StepReview {
+		return buildReviewEntry(name, finalFindings, initialFindings, rounds)
+	}
+
+	// For test/lint/rebase: determine emoji and result text.
+	if !hadFindings {
+		return fmt.Sprintf("✅ **%s** - passed", name), ""
+	}
+
+	if wasFixed {
+		result := buildFixResultText(rounds)
+		line := fmt.Sprintf("🔧 **%s** - %s", name, result)
+		detail := buildRoundsDetail(name, rounds)
+		return line, detail
+	}
+
+	// Had findings but only 1 round - approved as-is.
+	count := countFindingsBySeverity(initialFindings)
+	line := fmt.Sprintf("⚠️ **%s** - %s", name, count)
+	detail := buildRoundsDetail(name, rounds)
+	return line, detail
+}
+
+func buildReviewEntry(name string, finalFindings, initialFindings *types.Findings, rounds []*db.StepRound) (string, string) {
+	// Determine risk level and rationale from whichever findings have them.
+	src := finalFindings
+	if src == nil {
+		src = initialFindings
+	}
+
+	riskLevel := ""
+	rationale := ""
+	if src != nil {
+		riskLevel = src.RiskLevel
+		rationale = src.RiskRationale
+	}
+
+	hasFindings := initialFindings != nil && len(initialFindings.Items) > 0
+	emoji := "✅"
+	if hasFindings {
+		emoji = "⚠️"
+	}
+
+	var line string
+	if riskLevel != "" {
+		line = fmt.Sprintf("%s **%s** - %s risk", emoji, name, riskLevel)
+		if rationale != "" {
+			line += fmt.Sprintf(` - _"%s"_`, rationale)
+		}
+	} else {
+		line = fmt.Sprintf("%s **%s** - passed", emoji, name)
+	}
+
+	detail := ""
+	if hasFindings {
+		detail = buildRoundsDetail(name, rounds)
+	}
+	return line, detail
+}
+
+func buildFixResultText(rounds []*db.StepRound) string {
+	// Count findings in round 1.
+	var initialCount int
+	if len(rounds) > 0 && rounds[0].FindingsJSON != nil {
+		if f, err := types.ParseFindingsJSON(*rounds[0].FindingsJSON); err == nil {
+			initialCount = len(f.Items)
+		}
+	}
+
+	// Categorize fix rounds.
+	autoFixRounds := 0
+	userFixRounds := 0
+	for _, r := range rounds[1:] {
+		switch r.Trigger {
+		case "auto_fix":
+			autoFixRounds++
+		case "user_fix":
+			userFixRounds++
+		}
+	}
+
+	noun := "issue"
+	if initialCount != 1 {
+		noun = "issues"
+	}
+
+	parts := []string{fmt.Sprintf("%d %s found", initialCount, noun)}
+
+	if autoFixRounds > 0 && userFixRounds > 0 {
+		parts = append(parts, fmt.Sprintf("auto-fixed (%d) + user-fixed (%d)", autoFixRounds, userFixRounds))
+	} else if autoFixRounds > 0 {
+		parts = append(parts, "auto-fixed")
+	} else if userFixRounds > 0 {
+		parts = append(parts, "user-fixed")
+	}
+
+	return strings.Join(parts, " → ")
+}
+
+func buildRoundsDetail(name string, rounds []*db.StepRound) string {
+	if len(rounds) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("<details>\n<summary>%s details</summary>\n\n", name))
+
+	for _, r := range rounds {
+		triggerLabel := ""
+		switch r.Trigger {
+		case "initial":
+			triggerLabel = ""
+		case "auto_fix":
+			triggerLabel = " (auto-fix)"
+		case "user_fix":
+			triggerLabel = " (user-fix)"
+		}
+
+		if r.FindingsJSON == nil {
+			b.WriteString(fmt.Sprintf("**Round %d**%s - passed ✅\n\n", r.Round, triggerLabel))
+			continue
+		}
+
+		findings, err := types.ParseFindingsJSON(*r.FindingsJSON)
+		if err != nil {
+			b.WriteString(fmt.Sprintf("**Round %d**%s - %s\n\n", r.Round, triggerLabel, findings.Summary))
+			continue
+		}
+
+		count := countFindingsBySeverity(&findings)
+		b.WriteString(fmt.Sprintf("**Round %d**%s - found %s\n", r.Round, triggerLabel, count))
+
+		for _, f := range findings.Items {
+			emoji := severityEmoji(f.Severity)
+			loc := ""
+			if f.File != "" {
+				loc = fmt.Sprintf("`%s", f.File)
+				if f.Line > 0 {
+					loc += fmt.Sprintf(":%d", f.Line)
+				}
+				loc += "` - "
+			}
+			b.WriteString(fmt.Sprintf("- %s %s%s\n", emoji, loc, f.Description))
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("</details>\n")
+	return b.String()
+}
+
+func countFindingsBySeverity(findings *types.Findings) string {
+	if findings == nil || len(findings.Items) == 0 {
+		return "0 issues"
+	}
+
+	counts := map[string]int{}
+	for _, f := range findings.Items {
+		counts[f.Severity]++
+	}
+
+	total := len(findings.Items)
+	noun := "issue"
+	if total != 1 {
+		noun = "issues"
+	}
+
+	// If all same severity, just show count + severity.
+	if len(counts) == 1 {
+		for sev, n := range counts {
+			noun := sev
+			if n != 1 {
+				noun += "s"
+			}
+			return fmt.Sprintf("%d %s", n, noun)
+		}
+	}
+
+	// Mixed severities: "3 issues (1 error, 2 warnings)"
+	var parts []string
+	for _, sev := range []string{"error", "warning", "info"} {
+		if n, ok := counts[sev]; ok {
+			label := sev
+			if n != 1 {
+				label += "s"
+			}
+			parts = append(parts, fmt.Sprintf("%d %s", n, label))
+		}
+	}
+	return fmt.Sprintf("%d %s (%s)", total, noun, strings.Join(parts, ", "))
+}
+
+func severityEmoji(severity string) string {
+	switch severity {
+	case "error":
+		return "🚨"
+	case "warning":
+		return "⚠️"
+	case "info":
+		return "ℹ️"
+	default:
+		return "-"
+	}
+}
+
+func stepDisplayName(name types.StepName) string {
+	switch name {
+	case types.StepRebase:
+		return "Rebase"
+	case types.StepReview:
+		return "Review"
+	case types.StepTest:
+		return "Test"
+	case types.StepLint:
+		return "Lint"
+	default:
+		return string(name)
+	}
+}

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -287,6 +287,12 @@ func TestBuildPipelineSummary_ShowsParseFailureForInvalidRoundFindings(t *testin
 	if !strings.Contains(md, "failed to parse findings") {
 		t.Errorf("expected parse failure message for invalid round findings, got:\n%s", md)
 	}
+	if strings.Contains(md, "✅ **Test** - passed") {
+		t.Errorf("did not expect passed status when round findings cannot be parsed, got:\n%s", md)
+	}
+	if !strings.Contains(md, "⚠️ **Test** - findings unavailable") {
+		t.Errorf("expected warning status when round findings cannot be parsed, got:\n%s", md)
+	}
 	if strings.Contains(md, "**Round 1** - \n") {
 		t.Errorf("did not expect blank round summary for invalid round findings, got:\n%s", md)
 	}

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -348,6 +348,21 @@ func TestBuildPipelineSummary_ReviewDoesNotReuseInitialRiskWhenFinalUnreadable(t
 	}
 }
 
+func TestBuildPipelineSummary_ReviewUnreadableFinalFindingsWithoutRoundsUsesWarningEmoji(t *testing.T) {
+	invalidFinalFindings := `{"findings":[`
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepReview, Status: types.StepStatusCompleted, FindingsJSON: &invalidFinalFindings},
+	}
+	md := BuildPipelineSummary(steps, map[string][]*db.StepRound{"s1": nil})
+
+	if !strings.Contains(md, "⚠️ **Review** - findings unavailable") {
+		t.Errorf("expected warning emoji for unreadable final review findings without rounds, got:\n%s", md)
+	}
+	if strings.Contains(md, "✅ **Review** - findings unavailable") {
+		t.Errorf("did not expect passed emoji for unreadable final review findings without rounds, got:\n%s", md)
+	}
+}
+
 func TestBuildPipelineSummary_FindingSeverityEmoji(t *testing.T) {
 	findings := `{"findings":[{"id":"review-1","severity":"error","description":"critical bug"},{"id":"review-2","severity":"warning","description":"minor issue"},{"id":"review-3","severity":"info","description":"suggestion"}],"summary":"3 findings","risk_level":"high","risk_rationale":"critical bug found"}`
 	steps := []*db.StepResult{

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -115,6 +115,31 @@ func TestBuildPipelineSummary_MultiRoundWithUserFix(t *testing.T) {
 	}
 }
 
+func TestBuildPipelineSummary_MultiRoundStillFailing(t *testing.T) {
+	findings1 := `{"findings":[{"id":"lint-1","severity":"error","file":"pkg/foo.go","line":18,"description":"unused import"},{"id":"lint-2","severity":"warning","file":"pkg/bar.go","line":35,"description":"missing error check"}],"summary":"2 issues"}`
+	findings2 := `{"findings":[{"id":"lint-2","severity":"warning","file":"pkg/bar.go","line":35,"description":"missing error check"}],"summary":"1 issue"}`
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepLint, Status: types.StepStatusCompleted, FindingsJSON: &findings2},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {
+			{Round: 1, Trigger: "initial", FindingsJSON: &findings1, DurationMS: 800},
+			{Round: 2, Trigger: "auto_fix", FindingsJSON: &findings2, DurationMS: 600},
+		},
+	}
+	md := BuildPipelineSummary(steps, rounds)
+
+	if strings.Contains(md, "auto-fixed") {
+		t.Errorf("did not expect fixed status when final round still has findings, got:\n%s", md)
+	}
+	if !strings.Contains(md, "⚠️ **Lint** - 1 warning") {
+		t.Errorf("expected final findings count in status line, got:\n%s", md)
+	}
+	if !strings.Contains(md, "Round 2") || !strings.Contains(md, "missing error check") {
+		t.Errorf("expected final round details to remain visible, got:\n%s", md)
+	}
+}
+
 func TestBuildPipelineSummary_SkippedStep(t *testing.T) {
 	steps := []*db.StepResult{
 		{ID: "s1", StepName: types.StepReview, Status: types.StepStatusSkipped},

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -298,6 +298,56 @@ func TestBuildPipelineSummary_ShowsParseFailureForInvalidRoundFindings(t *testin
 	}
 }
 
+func TestBuildPipelineSummary_DoesNotClaimFixedWhenFinalFindingsUnreadable(t *testing.T) {
+	initialFindings := `{"findings":[{"id":"lint-1","severity":"warning","description":"still broken"}],"summary":"1 issue"}`
+	invalidFinalFindings := `{"findings":[`
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepLint, Status: types.StepStatusCompleted, FindingsJSON: &invalidFinalFindings},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {
+			{Round: 1, Trigger: "initial", FindingsJSON: &initialFindings, DurationMS: 800},
+			{Round: 2, Trigger: "auto_fix", FindingsJSON: &invalidFinalFindings, DurationMS: 600},
+		},
+	}
+	md := BuildPipelineSummary(steps, rounds)
+
+	if strings.Contains(md, "🔧 **Lint**") {
+		t.Errorf("did not expect fixed status when final findings are unreadable, got:\n%s", md)
+	}
+	if !strings.Contains(md, "⚠️ **Lint** - findings unavailable") {
+		t.Errorf("expected unavailable status when final findings are unreadable, got:\n%s", md)
+	}
+	if !strings.Contains(md, "failed to parse findings") {
+		t.Errorf("expected parse failure details for unreadable final findings, got:\n%s", md)
+	}
+}
+
+func TestBuildPipelineSummary_ReviewDoesNotReuseInitialRiskWhenFinalUnreadable(t *testing.T) {
+	initialFindings := `{"findings":[{"id":"review-1","severity":"warning","description":"risky change"}],"summary":"1 warning","risk_level":"medium","risk_rationale":"initial risk rationale"}`
+	invalidFinalFindings := `{"findings":[`
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepReview, Status: types.StepStatusCompleted, FindingsJSON: &invalidFinalFindings},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {
+			{Round: 1, Trigger: "initial", FindingsJSON: &initialFindings, DurationMS: 1000},
+			{Round: 2, Trigger: "user_fix", FindingsJSON: &invalidFinalFindings, DurationMS: 700},
+		},
+	}
+	md := BuildPipelineSummary(steps, rounds)
+
+	if !strings.Contains(md, "⚠️ **Review** - findings unavailable") {
+		t.Errorf("expected unavailable review status when final findings are unreadable, got:\n%s", md)
+	}
+	if strings.Contains(md, "medium risk") || strings.Contains(md, "initial risk rationale") {
+		t.Errorf("did not expect stale risk details when final findings are unreadable, got:\n%s", md)
+	}
+	if !strings.Contains(md, "failed to parse findings") {
+		t.Errorf("expected parse failure details for unreadable final review findings, got:\n%s", md)
+	}
+}
+
 func TestBuildPipelineSummary_FindingSeverityEmoji(t *testing.T) {
 	findings := `{"findings":[{"id":"review-1","severity":"error","description":"critical bug"},{"id":"review-2","severity":"warning","description":"minor issue"},{"id":"review-3","severity":"info","description":"suggestion"}],"summary":"3 findings","risk_level":"high","risk_rationale":"critical bug found"}`
 	steps := []*db.StepResult{

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -140,6 +140,32 @@ func TestBuildPipelineSummary_MultiRoundStillFailing(t *testing.T) {
 	}
 }
 
+func TestBuildPipelineSummary_UsesFinalFindingsWithoutInitialRoundData(t *testing.T) {
+	finalFindings := `{"findings":[{"id":"test-1","severity":"error","file":"pkg/handler_test.go","line":42,"description":"expected 429 got 200"}],"summary":"1 failure"}`
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepTest, Status: types.StepStatusCompleted, FindingsJSON: &finalFindings},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {
+			{Round: 1, Trigger: "initial", DurationMS: 1000},
+		},
+	}
+	md := BuildPipelineSummary(steps, rounds)
+
+	if strings.Contains(md, "passed") {
+		t.Errorf("did not expect passed status when step result still has findings, got:\n%s", md)
+	}
+	if !strings.Contains(md, "⚠️ **Test** - 1 error") {
+		t.Errorf("expected final findings count in status line, got:\n%s", md)
+	}
+	if strings.Contains(md, "<details>") {
+		t.Errorf("did not expect details block without round findings data, got:\n%s", md)
+	}
+	if strings.Contains(md, "Round 1") {
+		t.Errorf("did not expect round details without round findings data, got:\n%s", md)
+	}
+}
+
 func TestBuildPipelineSummary_SkippedStep(t *testing.T) {
 	steps := []*db.StepResult{
 		{ID: "s1", StepName: types.StepReview, Status: types.StepStatusSkipped},
@@ -196,6 +222,37 @@ func TestBuildPipelineSummary_ReviewApprovedWithWarnings(t *testing.T) {
 	}
 	if !strings.Contains(md, "medium risk") {
 		t.Errorf("expected 'medium risk' in output, got:\n%s", md)
+	}
+}
+
+func TestBuildPipelineSummary_ReviewUsesFinalCleanState(t *testing.T) {
+	initialFindings := `{"findings":[{"id":"review-1","severity":"warning","description":"risky change"}],"summary":"1 warning","risk_level":"medium","risk_rationale":"initial risk rationale"}`
+	finalFindings := `{"findings":[],"summary":"clean","risk_level":"low","risk_rationale":"follow-up fixes reduced risk"}`
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepReview, Status: types.StepStatusCompleted, FindingsJSON: &finalFindings},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {
+			{Round: 1, Trigger: "initial", FindingsJSON: &initialFindings, DurationMS: 1000},
+			{Round: 2, Trigger: "user_fix", FindingsJSON: &finalFindings, DurationMS: 700},
+		},
+	}
+	md := BuildPipelineSummary(steps, rounds)
+
+	if !strings.Contains(md, "✅ **Review** - low risk") {
+		t.Errorf("expected clean final review status, got:\n%s", md)
+	}
+	if strings.Contains(md, "⚠️ **Review**") {
+		t.Errorf("did not expect warning emoji after final clean review, got:\n%s", md)
+	}
+	if strings.Contains(md, "initial risk rationale") {
+		t.Errorf("did not expect stale initial rationale, got:\n%s", md)
+	}
+	if !strings.Contains(md, "follow-up fixes reduced risk") {
+		t.Errorf("expected final rationale in output, got:\n%s", md)
+	}
+	if !strings.Contains(md, "Round 2") {
+		t.Errorf("expected review details to remain visible for multi-round review, got:\n%s", md)
 	}
 }
 

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -1,0 +1,218 @@
+package steps
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+func TestBuildPipelineSummary_AllClean(t *testing.T) {
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepReview, Status: types.StepStatusCompleted},
+		{ID: "s2", StepName: types.StepTest, Status: types.StepStatusCompleted},
+		{ID: "s3", StepName: types.StepLint, Status: types.StepStatusCompleted},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {{Round: 1, Trigger: "initial", DurationMS: 500}},
+		"s2": {{Round: 1, Trigger: "initial", DurationMS: 300}},
+		"s3": {{Round: 1, Trigger: "initial", DurationMS: 200}},
+	}
+	md := BuildPipelineSummary(steps, rounds)
+
+	if !strings.Contains(md, "## Pipeline") {
+		t.Error("missing Pipeline heading")
+	}
+	// Clean steps should show checkmark
+	if !strings.Contains(md, "✅") {
+		t.Error("expected checkmark for clean steps")
+	}
+	// Clean run should have no <details> blocks
+	if strings.Contains(md, "<details>") {
+		t.Error("clean run should not have details blocks")
+	}
+}
+
+func TestBuildPipelineSummary_ReviewWithRisk(t *testing.T) {
+	findings := `{"findings":[{"id":"review-1","severity":"warning","file":"cmd/main.go","line":10,"description":"potential nil deref"}],"summary":"1 warning","risk_level":"low","risk_rationale":"straightforward refactor with no behavioral changes"}`
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepReview, Status: types.StepStatusCompleted, FindingsJSON: &findings},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 1000}},
+	}
+	md := BuildPipelineSummary(steps, rounds)
+
+	if !strings.Contains(md, "low risk") {
+		t.Errorf("expected 'low risk' in output, got:\n%s", md)
+	}
+	if !strings.Contains(md, "straightforward refactor") {
+		t.Errorf("expected risk rationale in output, got:\n%s", md)
+	}
+	// Review with findings should have a details block
+	if !strings.Contains(md, "<details>") {
+		t.Errorf("expected details block for review findings, got:\n%s", md)
+	}
+	if !strings.Contains(md, "potential nil deref") {
+		t.Errorf("expected finding description in details, got:\n%s", md)
+	}
+}
+
+func TestBuildPipelineSummary_AutoFix(t *testing.T) {
+	findings1 := `{"findings":[{"id":"lint-1","severity":"error","file":"pkg/foo.go","line":18,"description":"unused import"},{"id":"lint-2","severity":"warning","file":"pkg/bar.go","line":35,"description":"missing error check"}],"summary":"2 issues"}`
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepLint, Status: types.StepStatusCompleted},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {
+			{Round: 1, Trigger: "initial", FindingsJSON: &findings1, DurationMS: 800},
+			{Round: 2, Trigger: "auto_fix", DurationMS: 600},
+		},
+	}
+	md := BuildPipelineSummary(steps, rounds)
+
+	// Should show wrench emoji for auto-fixed
+	if !strings.Contains(md, "🔧") {
+		t.Errorf("expected wrench emoji for auto-fixed step, got:\n%s", md)
+	}
+	// Status line should mention auto-fixed
+	if !strings.Contains(md, "auto-fixed") {
+		t.Errorf("expected 'auto-fixed' in status line, got:\n%s", md)
+	}
+	// Should have details with round info
+	if !strings.Contains(md, "Round 1") {
+		t.Errorf("expected 'Round 1' in details, got:\n%s", md)
+	}
+	if !strings.Contains(md, "Round 2") {
+		t.Errorf("expected 'Round 2' in details, got:\n%s", md)
+	}
+	if !strings.Contains(md, "unused import") {
+		t.Errorf("expected finding description in round 1 details, got:\n%s", md)
+	}
+}
+
+func TestBuildPipelineSummary_MultiRoundWithUserFix(t *testing.T) {
+	findings1 := `{"findings":[{"id":"test-1","severity":"error","file":"pkg/handler_test.go","line":42,"description":"expected 429 got 200"},{"id":"test-2","severity":"error","file":"pkg/handler_test.go","line":78,"description":"context deadline exceeded"}],"summary":"2 failures"}`
+	findings2 := `{"findings":[{"id":"test-2","severity":"error","file":"pkg/handler_test.go","line":78,"description":"context deadline exceeded"}],"summary":"1 failure"}`
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepTest, Status: types.StepStatusCompleted},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {
+			{Round: 1, Trigger: "initial", FindingsJSON: &findings1, DurationMS: 1000},
+			{Round: 2, Trigger: "auto_fix", FindingsJSON: &findings2, DurationMS: 900},
+			{Round: 3, Trigger: "user_fix", DurationMS: 700},
+		},
+	}
+	md := BuildPipelineSummary(steps, rounds)
+
+	if !strings.Contains(md, "Round 3") {
+		t.Errorf("expected 3 rounds in details, got:\n%s", md)
+	}
+	if !strings.Contains(md, "user-fix") || !strings.Contains(md, "auto-fix") {
+		t.Errorf("expected both fix types mentioned, got:\n%s", md)
+	}
+}
+
+func TestBuildPipelineSummary_SkippedStep(t *testing.T) {
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepReview, Status: types.StepStatusSkipped},
+		{ID: "s2", StepName: types.StepTest, Status: types.StepStatusCompleted},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {},
+		"s2": {{Round: 1, Trigger: "initial", DurationMS: 300}},
+	}
+	md := BuildPipelineSummary(steps, rounds)
+
+	if !strings.Contains(md, "⏭️") {
+		t.Errorf("expected skip emoji for skipped step, got:\n%s", md)
+	}
+	if !strings.Contains(md, "skipped") {
+		t.Errorf("expected 'skipped' text for skipped step, got:\n%s", md)
+	}
+}
+
+func TestBuildPipelineSummary_ExcludesPushPRBabysit(t *testing.T) {
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepReview, Status: types.StepStatusCompleted},
+		{ID: "s2", StepName: types.StepPush, Status: types.StepStatusCompleted},
+		{ID: "s3", StepName: types.StepPR, Status: types.StepStatusCompleted},
+		{ID: "s4", StepName: types.StepBabysit, Status: types.StepStatusCompleted},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {{Round: 1, Trigger: "initial", DurationMS: 500}},
+		"s2": {{Round: 1, Trigger: "initial", DurationMS: 100}},
+		"s3": {{Round: 1, Trigger: "initial", DurationMS: 200}},
+		"s4": {{Round: 1, Trigger: "initial", DurationMS: 300}},
+	}
+	md := BuildPipelineSummary(steps, rounds)
+
+	// Push, PR, and Babysit should not appear in the summary
+	if strings.Contains(md, "**Push**") || strings.Contains(md, "**PR**") || strings.Contains(md, "**Babysit**") {
+		t.Errorf("should not include push/pr/babysit steps, got:\n%s", md)
+	}
+}
+
+func TestBuildPipelineSummary_ReviewApprovedWithWarnings(t *testing.T) {
+	findings := `{"findings":[{"id":"review-1","severity":"warning","description":"risky change"}],"summary":"1 warning","risk_level":"medium","risk_rationale":"changes error handling in critical path"}`
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepReview, Status: types.StepStatusCompleted, FindingsJSON: &findings},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 1000}},
+	}
+	md := BuildPipelineSummary(steps, rounds)
+
+	// Review with findings approved as-is should show warning emoji
+	if !strings.Contains(md, "⚠️") {
+		t.Errorf("expected warning emoji for review with findings, got:\n%s", md)
+	}
+	if !strings.Contains(md, "medium risk") {
+		t.Errorf("expected 'medium risk' in output, got:\n%s", md)
+	}
+}
+
+func TestBuildPipelineSummary_FindingSeverityEmoji(t *testing.T) {
+	findings := `{"findings":[{"id":"review-1","severity":"error","description":"critical bug"},{"id":"review-2","severity":"warning","description":"minor issue"},{"id":"review-3","severity":"info","description":"suggestion"}],"summary":"3 findings","risk_level":"high","risk_rationale":"critical bug found"}`
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepReview, Status: types.StepStatusCompleted, FindingsJSON: &findings},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 1000}},
+	}
+	md := BuildPipelineSummary(steps, rounds)
+
+	if !strings.Contains(md, "🚨") {
+		t.Errorf("expected error emoji in details, got:\n%s", md)
+	}
+	if !strings.Contains(md, "ℹ️") {
+		t.Errorf("expected info emoji in details, got:\n%s", md)
+	}
+}
+
+func TestBuildPipelineSummary_EmptySteps(t *testing.T) {
+	md := BuildPipelineSummary(nil, nil)
+	if md != "" {
+		t.Errorf("expected empty string for nil steps, got: %q", md)
+	}
+}
+
+func TestBuildPipelineSummary_RebaseWithConflicts(t *testing.T) {
+	findings := `{"findings":[{"id":"rebase-1","severity":"warning","file":"pkg/foo.go","description":"merge conflict resolved by agent"}],"summary":"1 conflict resolved"}`
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepRebase, Status: types.StepStatusCompleted, FindingsJSON: &findings},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 2000}},
+	}
+	md := BuildPipelineSummary(steps, rounds)
+
+	if !strings.Contains(md, "**Rebase**") {
+		t.Errorf("expected Rebase in output, got:\n%s", md)
+	}
+	if !strings.Contains(md, "conflict") {
+		t.Errorf("expected conflict mention in output, got:\n%s", md)
+	}
+}

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -256,6 +256,42 @@ func TestBuildPipelineSummary_ReviewUsesFinalCleanState(t *testing.T) {
 	}
 }
 
+func TestBuildPipelineSummary_ReviewShowsWarningForUnresolvedRiskWithoutFindings(t *testing.T) {
+	findings := `{"findings":[],"summary":"clean","risk_level":"medium","risk_rationale":"touches critical error handling"}`
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepReview, Status: types.StepStatusCompleted, FindingsJSON: &findings},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 1000}},
+	}
+	md := BuildPipelineSummary(steps, rounds)
+
+	if !strings.Contains(md, "⚠️ **Review** - medium risk") {
+		t.Errorf("expected warning status for medium risk review without findings, got:\n%s", md)
+	}
+	if strings.Contains(md, "✅ **Review**") {
+		t.Errorf("did not expect passed emoji for medium risk review, got:\n%s", md)
+	}
+}
+
+func TestBuildPipelineSummary_ShowsParseFailureForInvalidRoundFindings(t *testing.T) {
+	invalidFindings := `{"findings":[`
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepTest, Status: types.StepStatusCompleted},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &invalidFindings, DurationMS: 1000}},
+	}
+	md := BuildPipelineSummary(steps, rounds)
+
+	if !strings.Contains(md, "failed to parse findings") {
+		t.Errorf("expected parse failure message for invalid round findings, got:\n%s", md)
+	}
+	if strings.Contains(md, "**Round 1** - \n") {
+		t.Errorf("did not expect blank round summary for invalid round findings, got:\n%s", md)
+	}
+}
+
 func TestBuildPipelineSummary_FindingSeverityEmoji(t *testing.T) {
 	findings := `{"findings":[{"id":"review-1","severity":"error","description":"critical bug"},{"id":"review-2","severity":"warning","description":"minor issue"},{"id":"review-3","severity":"info","description":"suggestion"}],"summary":"3 findings","risk_level":"high","risk_rationale":"critical bug found"}`
 	steps := []*db.StepResult{

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -3936,7 +3936,7 @@ func TestFallbackPRContent_ConventionalTitle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			content := fallbackPRContent(tt.branch, tt.commitLog)
+			content := fallbackPRContent(tt.branch, tt.commitLog, "")
 			if !isConventionalTitle(content.Title) {
 				t.Errorf("fallback title %q is not conventional commit format", content.Title)
 			}


### PR DESCRIPTION
## Summary
- Add a dedicated PR summary pipeline step that builds a branch-level summary from persisted step results and rounds, including new DB support and coverage for the summary flow.
- Fix PR summary status reporting so review, test, lint, and rebase results reflect the latest round instead of stale or partially fixed state.
- Handle malformed or unreadable findings more defensively so the summary surfaces unavailable data instead of incorrectly reporting success; pipeline review still flagged medium risk around partial DB write failures causing inaccurate PR metadata.

## Pipeline

✅ **Rebase** - passed
⚠️ **Review** - medium risk - _"The change is well-scoped and tested, but the new summary path can publish inaccurate PR metadata if its new DB writes only partially succeed."_
✅ **Test** - passed
✅ **Lint** - passed

<details>
<summary>Review details</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/pipeline/steps/prsummary.go:98` - Any non-review step with more than one round is labeled as fixed, and `buildFixResultText` then reports `auto-fixed`/`user-fixed` based only on trigger counts. If a fix round still returns findings and the user approves that state, the generated PR summary will falsely claim the issues were fixed instead of still present; base the status on the final round's findings, not just the existence of extra rounds.

**Round 2** (auto-fix) - found 2 warnings
- ⚠️ `internal/pipeline/steps/prsummary.go:132` - `buildReviewEntry` derives the review status from the initial round only, so a review that was fixed and re-run clean still renders as `⚠️ ... risk` using the stale initial rationale. Base the emoji/risk text on the final findings when a later round cleared the review issues.
- ⚠️ `internal/pipeline/steps/prsummary.go:95` - Non-review steps are treated as `passed` whenever round 1 has no parseable findings, even if `step_results.findings_json` still contains final findings. Because round inserts/query failures are only logged upstream, a transient DB issue can make the PR summary silently report clean test/lint/rebase results while findings actually remain.

**Round 3** (auto-fix) - found 2 warnings
- ⚠️ `internal/pipeline/steps/prsummary.go:140` - `buildReviewEntry` chooses the green checkmark solely from whether the final findings array is empty. If review returns `risk_level: "medium"` or `"high"` with no explicit findings, the PR summary will still read as passed, which downplays the reviewer's stated risk.
- ⚠️ `internal/pipeline/steps/prsummary.go:242` - When a round's `findings_json` cannot be parsed, the fallback path prints `findings.Summary` from the zero value, so that round renders with an empty message. This silently hides historical review/test/lint output instead of surfacing the parse failure or any recoverable context.

**Round 4** (auto-fix) - found 1 warning
- ⚠️ `internal/pipeline/steps/prsummary.go:98` - Malformed `findings_json` in any stored round still falls into the `passed` branch because parse failures only trigger `roundsNeedDetail`, not `hadAnyFindings`; the PR summary can therefore show a green status line while the details block says it could not parse findings. Treat parse failures as an unknown/warning state instead of success.

**Round 5** (user-fix) - found 2 warnings
- ⚠️ `internal/pipeline/steps/prsummary.go:91` - `wasFixed` treats any later round with unparseable findings as "fixed" because it only checks that `finalFindings` is absent. If the last auto-fix/user-fix round writes malformed JSON, the PR summary will incorrectly claim the step was fixed instead of surfacing findings as unavailable.
- ⚠️ `internal/pipeline/steps/prsummary.go:139` - The review summary falls back to `initialFindings` whenever the final review payload cannot be parsed, so a malformed last round can display a stale `risk_level` and rationale from round 1. Prefer reporting the review findings as unavailable once the latest state is unreadable.

**Round 6** (user-fix) - found 1 warning
- ⚠️ `internal/pipeline/steps/prsummary.go:167` - `buildReviewEntry` does not treat `hasUnreadableFinalFindings` as a warning signal when choosing the emoji, so if the final review payload is malformed and round rows are missing (for example because round persistence failed), the PR can render `✅ Review - findings unavailable`, which is contradictory and masks a broken review result.

**Round 7** (user-fix) - found 2 issues (1 warning, 1 info)
- ⚠️ `internal/pipeline/executor.go:197` - The new PR pipeline summary depends on both `step_results.findings_json` and `step_rounds`, but these are persisted as separate best-effort writes. If either DB update fails, the run continues and `BuildPipelineSummary` can silently generate stale or contradictory PR status/history; these writes should be transactional or treated as step-failing.
- ℹ️ `internal/pipeline/steps/pr.go:319` - The fallback PR body now dumps raw `git log` lines directly under `## Summary`, so any agent failure produces a non-bulleted summary with commit SHAs instead of the concise human-readable summary required by the prompt. Converting commit subjects into bullets would keep fallback PRs readable.

</details>
