### PR TITLE
fix(prsummary): preserve risk visibility in PR summaries

### DIFF
--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -258,7 +258,7 @@ Diff stat:
 					content.Title = "chore: " + content.Title
 				}
 				if riskLine != "" {
-					content.Body += "\n" + riskLine
+					content.Body += "\n\n" + riskLine
 				}
 				content.Body = appendPipelineSection(content.Body, pipelineMD)
 				return content, nil
@@ -324,7 +324,7 @@ func fallbackPRContent(branch, commitLog, pipelineMD, riskLine string) prContent
 		body = fmt.Sprintf("## Summary\n\n- %s", title)
 	}
 	if riskLine != "" {
-		body += "\n" + riskLine
+		body += "\n\n" + riskLine
 	}
 	body = appendPipelineSection(body, pipelineMD)
 	return prContent{

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -206,7 +206,7 @@ func (s *PRStep) buildPRContent(sctx *pipeline.StepContext, branch, baseSHA stri
 	diffStat, _ := git.Run(ctx, sctx.WorkDir, "diff", "--stat", baseSHA+".."+sctx.Run.HeadSHA)
 
 	// Build the deterministic pipeline section from step rounds.
-	pipelineMD := s.buildPipelineSection(sctx)
+	pipelineMD, riskLine := s.buildPipelineSection(sctx)
 
 	// Build pipeline context for the agent prompt so it can reference findings in the summary.
 	pipelineContext := ""
@@ -227,7 +227,7 @@ Context:
 Rules:
 - Cover the full branch delta, not just the latest commit.
 - Title must use conventional commit format: "type(scope): description" or "type: description". Valid types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert. Scope is optional. Do not capitalize the type. Do not use the raw branch name.
-- Body: a "## Summary" section in GitHub-flavored markdown. 1-3 concise bullet points describing what changed and why. If the pipeline flagged anything notable (risk, findings, auto-fixes), mention it briefly. Do not include a Testing section - pipeline results are appended separately.
+- Body: a "## Summary" section in GitHub-flavored markdown. 1-3 concise bullet points describing what changed and why. Do not include a Testing section - pipeline results are appended separately.
 - Do not invent tests or behavior.
 
 Commit history:
@@ -244,7 +244,7 @@ Diff stat:
 	})
 	if err != nil {
 		slog.Warn("agent failed for PR content, using fallback", "error", err)
-		return fallbackPRContent(branch, commitLog, pipelineMD), nil
+		return fallbackPRContent(branch, commitLog, pipelineMD, riskLine), nil
 	}
 
 	var content prContent
@@ -257,22 +257,25 @@ Diff stat:
 					slog.Warn("agent PR title is not conventional commit format, prepending chore:", "title", content.Title)
 					content.Title = "chore: " + content.Title
 				}
+				if riskLine != "" {
+					content.Body += "\n" + riskLine
+				}
 				content.Body = appendPipelineSection(content.Body, pipelineMD)
 				return content, nil
 			}
 		}
 	}
 
-	return fallbackPRContent(branch, commitLog, pipelineMD), nil
+	return fallbackPRContent(branch, commitLog, pipelineMD, riskLine), nil
 }
 
 // buildPipelineSection queries step results and rounds from the DB and
 // produces the deterministic pipeline markdown section.
-func (s *PRStep) buildPipelineSection(sctx *pipeline.StepContext) string {
+func (s *PRStep) buildPipelineSection(sctx *pipeline.StepContext) (string, string) {
 	steps, err := sctx.DB.GetStepsByRun(sctx.Run.ID)
 	if err != nil {
 		slog.Warn("failed to query step results for pipeline summary", "error", err)
-		return ""
+		return "", ""
 	}
 
 	rounds := make(map[string][]*db.StepRound, len(steps))
@@ -296,7 +299,7 @@ func appendPipelineSection(body, pipelineMD string) string {
 	return body + "\n\n" + pipelineMD
 }
 
-func fallbackPRContent(branch, commitLog, pipelineMD string) prContent {
+func fallbackPRContent(branch, commitLog, pipelineMD, riskLine string) prContent {
 	title := ""
 	for _, line := range strings.Split(commitLog, "\n") {
 		line = strings.TrimSpace(line)
@@ -319,6 +322,9 @@ func fallbackPRContent(branch, commitLog, pipelineMD string) prContent {
 	body := fmt.Sprintf("## Summary\n\n%s", strings.TrimSpace(commitLog))
 	if body == "## Summary\n\n" {
 		body = fmt.Sprintf("## Summary\n\n- %s", title)
+	}
+	if riskLine != "" {
+		body += "\n" + riskLine
 	}
 	body = appendPipelineSection(body, pipelineMD)
 	return prContent{

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -18,9 +18,9 @@ var summarySteps = map[types.StepName]bool{
 }
 
 // BuildPipelineSummary produces a deterministic markdown section from step results and rounds.
-func BuildPipelineSummary(steps []*db.StepResult, rounds map[string][]*db.StepRound) string {
+func BuildPipelineSummary(steps []*db.StepResult, rounds map[string][]*db.StepRound) (string, string) {
 	if len(steps) == 0 {
-		return ""
+		return "", ""
 	}
 
 	var statusLines []string
@@ -41,11 +41,11 @@ func BuildPipelineSummary(steps []*db.StepResult, rounds map[string][]*db.StepRo
 	}
 
 	if len(statusLines) == 0 {
-		return ""
+		return "", ""
 	}
 
 	var b strings.Builder
-	b.WriteString("## Pipeline\n\n")
+	b.WriteString("## Pipeline\n\nUpdates from `git push no-mistakes`\n\n")
 	for _, line := range statusLines {
 		b.WriteString(line)
 		b.WriteString("\n")
@@ -56,7 +56,8 @@ func BuildPipelineSummary(steps []*db.StepResult, rounds map[string][]*db.StepRo
 		b.WriteString(detail)
 	}
 
-	return b.String()
+	riskLine := extractRiskLine(steps, rounds)
+	return b.String(), riskLine
 }
 
 func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, detailBlock string) {
@@ -93,12 +94,15 @@ func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, deta
 	hasUnreadableFinalFindings := sr.FindingsJSON != nil && !finalFindingsParsed
 	wasFixed := hadFindings && len(rounds) > 1 && !hasUnreadableFinalFindings && !hasFinalFindings
 
-	// Special handling for review step - risk level is the primary signal.
-	if sr.StepName == types.StepReview {
-		return buildReviewEntry(name, finalFindings, initialFindings, rounds, hasUnreadableFinalFindings)
+	// Unreadable final findings - can't make claims about the outcome.
+	if hasUnreadableFinalFindings {
+		detail := ""
+		if hasRoundDetails {
+			detail = buildRoundsDetail(name, rounds)
+		}
+		return fmt.Sprintf("⚠️ **%s** - findings unavailable", name), detail
 	}
 
-	// For test/lint/rebase: determine emoji and result text.
 	if !hadAnyFindings && !hasRoundParseFailure {
 		detail := ""
 		if hasRoundDetails {
@@ -108,14 +112,6 @@ func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, deta
 	}
 
 	if hasRoundParseFailure && !hadAnyFindings {
-		detail := ""
-		if hasRoundDetails {
-			detail = buildRoundsDetail(name, rounds)
-		}
-		return fmt.Sprintf("⚠️ **%s** - findings unavailable", name), detail
-	}
-
-	if hasUnreadableFinalFindings {
 		detail := ""
 		if hasRoundDetails {
 			detail = buildRoundsDetail(name, rounds)
@@ -145,48 +141,56 @@ func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, deta
 	return line, detail
 }
 
-func buildReviewEntry(name string, finalFindings, initialFindings *types.Findings, rounds []*db.StepRound, hasUnreadableFinalFindings bool) (string, string) {
-	// Determine risk level and rationale from whichever findings have them.
-	src := finalFindings
-	if src == nil && !hasUnreadableFinalFindings {
-		src = initialFindings
-	}
-
-	riskLevel := ""
-	rationale := ""
-	if src != nil {
-		riskLevel = src.RiskLevel
-		rationale = src.RiskRationale
-	}
-
-	hasInitialFindings := initialFindings != nil && len(initialFindings.Items) > 0
-	hasFinalFindings := finalFindings != nil && len(finalFindings.Items) > 0
-	hasHistoricalFindings := hasInitialFindings || roundsNeedDetail(rounds)
-	hasRoundParseFailure := roundsHaveParseFailure(rounds)
-	emoji := "✅"
-	if hasFinalFindings || hasUnreadableFinalFindings || hasRoundParseFailure || riskLevel == "medium" || riskLevel == "high" {
-		emoji = "⚠️"
-	}
-
-	var line string
-	if hasUnreadableFinalFindings {
-		line = fmt.Sprintf("%s **%s** - findings unavailable", emoji, name)
-	} else if riskLevel != "" {
-		line = fmt.Sprintf("%s **%s** - %s risk", emoji, name, riskLevel)
-		if rationale != "" {
-			line += fmt.Sprintf(` - _"%s"_`, rationale)
+func extractRiskLine(steps []*db.StepResult, rounds map[string][]*db.StepRound) string {
+	for _, sr := range steps {
+		if sr.StepName != types.StepReview {
+			continue
 		}
-	} else if hasRoundParseFailure {
-		line = fmt.Sprintf("%s **%s** - findings unavailable", emoji, name)
-	} else {
-		line = fmt.Sprintf("%s **%s** - passed", emoji, name)
-	}
 
-	detail := ""
-	if hasHistoricalFindings {
-		detail = buildRoundsDetail(name, rounds)
+		var finalFindings *types.Findings
+		hasUnreadableFinal := false
+		if sr.FindingsJSON != nil {
+			if f, err := types.ParseFindingsJSON(*sr.FindingsJSON); err == nil {
+				finalFindings = &f
+			} else {
+				hasUnreadableFinal = true
+			}
+		}
+
+		src := finalFindings
+		if src == nil && !hasUnreadableFinal {
+			stepRounds := rounds[sr.ID]
+			if len(stepRounds) > 0 && stepRounds[0].FindingsJSON != nil {
+				if f, err := types.ParseFindingsJSON(*stepRounds[0].FindingsJSON); err == nil {
+					src = &f
+				}
+			}
+		}
+
+		if src == nil || src.RiskLevel == "" {
+			return ""
+		}
+
+		emoji := riskEmoji(src.RiskLevel)
+		if src.RiskRationale != "" {
+			return fmt.Sprintf("%s %s: %s", emoji, src.RiskLevel, src.RiskRationale)
+		}
+		return fmt.Sprintf("%s %s", emoji, src.RiskLevel)
 	}
-	return line, detail
+	return ""
+}
+
+func riskEmoji(level string) string {
+	switch level {
+	case "low":
+		return "✅"
+	case "medium":
+		return "⚠️"
+	case "high":
+		return "🚨"
+	default:
+		return "ℹ️"
+	}
 }
 
 func roundsHaveFindings(rounds []*db.StepRound) bool {

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -93,6 +93,16 @@ func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, deta
 	hadAnyFindings := hadFindings || hasFinalFindings || hasAnyRoundFindings
 	hasUnreadableFinalFindings := sr.FindingsJSON != nil && !finalFindingsParsed
 	wasFixed := hadFindings && len(rounds) > 1 && !hasUnreadableFinalFindings && !hasFinalFindings
+	riskLevel := ""
+	if sr.StepName == types.StepReview {
+		src := finalFindings
+		if src == nil && !hasUnreadableFinalFindings {
+			src = initialFindings
+		}
+		if src != nil {
+			riskLevel = src.RiskLevel
+		}
+	}
 
 	// Unreadable final findings - can't make claims about the outcome.
 	if hasUnreadableFinalFindings {
@@ -101,6 +111,14 @@ func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, deta
 			detail = buildRoundsDetail(name, rounds)
 		}
 		return fmt.Sprintf("⚠️ **%s** - findings unavailable", name), detail
+	}
+
+	if sr.StepName == types.StepReview && (riskLevel == "medium" || riskLevel == "high") && !hadAnyFindings {
+		detail := ""
+		if hasRoundDetails {
+			detail = buildRoundsDetail(name, rounds)
+		}
+		return fmt.Sprintf("%s **%s** - %s risk", riskEmoji(riskLevel), name, riskLevel), detail
 	}
 
 	if !hadAnyFindings && !hasRoundParseFailure {

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -19,10 +19,13 @@ func TestBuildPipelineSummary_AllClean(t *testing.T) {
 		"s2": {{Round: 1, Trigger: "initial", DurationMS: 300}},
 		"s3": {{Round: 1, Trigger: "initial", DurationMS: 200}},
 	}
-	md := BuildPipelineSummary(steps, rounds)
+	md, risk := BuildPipelineSummary(steps, rounds)
 
 	if !strings.Contains(md, "## Pipeline") {
 		t.Error("missing Pipeline heading")
+	}
+	if !strings.Contains(md, "Updates from `git push no-mistakes`") {
+		t.Error("missing pipeline tagline")
 	}
 	// Clean steps should show checkmark
 	if !strings.Contains(md, "✅") {
@@ -31,6 +34,9 @@ func TestBuildPipelineSummary_AllClean(t *testing.T) {
 	// Clean run should have no <details> blocks
 	if strings.Contains(md, "<details>") {
 		t.Error("clean run should not have details blocks")
+	}
+	if risk != "" {
+		t.Errorf("expected empty risk for clean run, got: %q", risk)
 	}
 }
 
@@ -42,13 +48,16 @@ func TestBuildPipelineSummary_ReviewWithRisk(t *testing.T) {
 	rounds := map[string][]*db.StepRound{
 		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 1000}},
 	}
-	md := BuildPipelineSummary(steps, rounds)
+	md, risk := BuildPipelineSummary(steps, rounds)
 
-	if !strings.Contains(md, "low risk") {
-		t.Errorf("expected 'low risk' in output, got:\n%s", md)
+	if !strings.Contains(md, "⚠️ **Review** - 1 warning") {
+		t.Errorf("expected findings count in review line, got:\n%s", md)
 	}
-	if !strings.Contains(md, "straightforward refactor") {
-		t.Errorf("expected risk rationale in output, got:\n%s", md)
+	if !strings.Contains(risk, "low") || !strings.Contains(risk, "straightforward refactor") {
+		t.Errorf("expected risk line with level and rationale, got: %q", risk)
+	}
+	if !strings.Contains(risk, "✅") {
+		t.Errorf("expected checkmark emoji for low risk, got: %q", risk)
 	}
 	// Review with findings should have a details block
 	if !strings.Contains(md, "<details>") {
@@ -70,7 +79,7 @@ func TestBuildPipelineSummary_AutoFix(t *testing.T) {
 			{Round: 2, Trigger: "auto_fix", DurationMS: 600},
 		},
 	}
-	md := BuildPipelineSummary(steps, rounds)
+	md, _ := BuildPipelineSummary(steps, rounds)
 
 	// Should show wrench emoji for auto-fixed
 	if !strings.Contains(md, "🔧") {
@@ -105,7 +114,7 @@ func TestBuildPipelineSummary_MultiRoundWithUserFix(t *testing.T) {
 			{Round: 3, Trigger: "user_fix", DurationMS: 700},
 		},
 	}
-	md := BuildPipelineSummary(steps, rounds)
+	md, _ := BuildPipelineSummary(steps, rounds)
 
 	if !strings.Contains(md, "Round 3") {
 		t.Errorf("expected 3 rounds in details, got:\n%s", md)
@@ -127,7 +136,7 @@ func TestBuildPipelineSummary_MultiRoundStillFailing(t *testing.T) {
 			{Round: 2, Trigger: "auto_fix", FindingsJSON: &findings2, DurationMS: 600},
 		},
 	}
-	md := BuildPipelineSummary(steps, rounds)
+	md, _ := BuildPipelineSummary(steps, rounds)
 
 	if strings.Contains(md, "auto-fixed") {
 		t.Errorf("did not expect fixed status when final round still has findings, got:\n%s", md)
@@ -150,7 +159,7 @@ func TestBuildPipelineSummary_UsesFinalFindingsWithoutInitialRoundData(t *testin
 			{Round: 1, Trigger: "initial", DurationMS: 1000},
 		},
 	}
-	md := BuildPipelineSummary(steps, rounds)
+	md, _ := BuildPipelineSummary(steps, rounds)
 
 	if strings.Contains(md, "passed") {
 		t.Errorf("did not expect passed status when step result still has findings, got:\n%s", md)
@@ -175,7 +184,7 @@ func TestBuildPipelineSummary_SkippedStep(t *testing.T) {
 		"s1": {},
 		"s2": {{Round: 1, Trigger: "initial", DurationMS: 300}},
 	}
-	md := BuildPipelineSummary(steps, rounds)
+	md, _ := BuildPipelineSummary(steps, rounds)
 
 	if !strings.Contains(md, "⏭️") {
 		t.Errorf("expected skip emoji for skipped step, got:\n%s", md)
@@ -198,7 +207,7 @@ func TestBuildPipelineSummary_ExcludesPushPRBabysit(t *testing.T) {
 		"s3": {{Round: 1, Trigger: "initial", DurationMS: 200}},
 		"s4": {{Round: 1, Trigger: "initial", DurationMS: 300}},
 	}
-	md := BuildPipelineSummary(steps, rounds)
+	md, _ := BuildPipelineSummary(steps, rounds)
 
 	// Push, PR, and Babysit should not appear in the summary
 	if strings.Contains(md, "**Push**") || strings.Contains(md, "**PR**") || strings.Contains(md, "**Babysit**") {
@@ -214,14 +223,17 @@ func TestBuildPipelineSummary_ReviewApprovedWithWarnings(t *testing.T) {
 	rounds := map[string][]*db.StepRound{
 		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 1000}},
 	}
-	md := BuildPipelineSummary(steps, rounds)
+	md, risk := BuildPipelineSummary(steps, rounds)
 
-	// Review with findings approved as-is should show warning emoji
-	if !strings.Contains(md, "⚠️") {
-		t.Errorf("expected warning emoji for review with findings, got:\n%s", md)
+	// Review with findings should show findings count like other steps
+	if !strings.Contains(md, "⚠️ **Review** - 1 warning") {
+		t.Errorf("expected findings count in review line, got:\n%s", md)
 	}
-	if !strings.Contains(md, "medium risk") {
-		t.Errorf("expected 'medium risk' in output, got:\n%s", md)
+	if !strings.Contains(risk, "medium") || !strings.Contains(risk, "changes error handling") {
+		t.Errorf("expected risk line with level and rationale, got: %q", risk)
+	}
+	if !strings.Contains(risk, "⚠️") {
+		t.Errorf("expected warning emoji for medium risk, got: %q", risk)
 	}
 }
 
@@ -237,19 +249,22 @@ func TestBuildPipelineSummary_ReviewUsesFinalCleanState(t *testing.T) {
 			{Round: 2, Trigger: "user_fix", FindingsJSON: &finalFindings, DurationMS: 700},
 		},
 	}
-	md := BuildPipelineSummary(steps, rounds)
+	md, risk := BuildPipelineSummary(steps, rounds)
 
-	if !strings.Contains(md, "✅ **Review** - low risk") {
-		t.Errorf("expected clean final review status, got:\n%s", md)
+	if !strings.Contains(md, "🔧 **Review**") {
+		t.Errorf("expected fixed review status, got:\n%s", md)
 	}
-	if strings.Contains(md, "⚠️ **Review**") {
-		t.Errorf("did not expect warning emoji after final clean review, got:\n%s", md)
+	if !strings.Contains(md, "user-fixed") {
+		t.Errorf("expected user-fixed in review line, got:\n%s", md)
 	}
-	if strings.Contains(md, "initial risk rationale") {
-		t.Errorf("did not expect stale initial rationale, got:\n%s", md)
+	if strings.Contains(risk, "initial risk rationale") {
+		t.Errorf("did not expect stale initial rationale in risk, got: %q", risk)
 	}
-	if !strings.Contains(md, "follow-up fixes reduced risk") {
-		t.Errorf("expected final rationale in output, got:\n%s", md)
+	if !strings.Contains(risk, "follow-up fixes reduced risk") {
+		t.Errorf("expected final rationale in risk, got: %q", risk)
+	}
+	if !strings.Contains(risk, "✅") {
+		t.Errorf("expected checkmark for low risk, got: %q", risk)
 	}
 	if !strings.Contains(md, "Round 2") {
 		t.Errorf("expected review details to remain visible for multi-round review, got:\n%s", md)
@@ -264,13 +279,18 @@ func TestBuildPipelineSummary_ReviewShowsWarningForUnresolvedRiskWithoutFindings
 	rounds := map[string][]*db.StepRound{
 		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 1000}},
 	}
-	md := BuildPipelineSummary(steps, rounds)
+	md, risk := BuildPipelineSummary(steps, rounds)
 
-	if !strings.Contains(md, "⚠️ **Review** - medium risk") {
-		t.Errorf("expected warning status for medium risk review without findings, got:\n%s", md)
+	// No findings means passed in the pipeline line
+	if !strings.Contains(md, "✅ **Review** - passed") {
+		t.Errorf("expected passed review status when no findings, got:\n%s", md)
 	}
-	if strings.Contains(md, "✅ **Review**") {
-		t.Errorf("did not expect passed emoji for medium risk review, got:\n%s", md)
+	// Risk is reported separately
+	if !strings.Contains(risk, "medium") || !strings.Contains(risk, "touches critical error handling") {
+		t.Errorf("expected risk line with medium level, got: %q", risk)
+	}
+	if !strings.Contains(risk, "⚠️") {
+		t.Errorf("expected warning emoji for medium risk, got: %q", risk)
 	}
 }
 
@@ -282,7 +302,7 @@ func TestBuildPipelineSummary_ShowsParseFailureForInvalidRoundFindings(t *testin
 	rounds := map[string][]*db.StepRound{
 		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &invalidFindings, DurationMS: 1000}},
 	}
-	md := BuildPipelineSummary(steps, rounds)
+	md, _ := BuildPipelineSummary(steps, rounds)
 
 	if !strings.Contains(md, "failed to parse findings") {
 		t.Errorf("expected parse failure message for invalid round findings, got:\n%s", md)
@@ -310,7 +330,7 @@ func TestBuildPipelineSummary_DoesNotClaimFixedWhenFinalFindingsUnreadable(t *te
 			{Round: 2, Trigger: "auto_fix", FindingsJSON: &invalidFinalFindings, DurationMS: 600},
 		},
 	}
-	md := BuildPipelineSummary(steps, rounds)
+	md, _ := BuildPipelineSummary(steps, rounds)
 
 	if strings.Contains(md, "🔧 **Lint**") {
 		t.Errorf("did not expect fixed status when final findings are unreadable, got:\n%s", md)
@@ -335,13 +355,13 @@ func TestBuildPipelineSummary_ReviewDoesNotReuseInitialRiskWhenFinalUnreadable(t
 			{Round: 2, Trigger: "user_fix", FindingsJSON: &invalidFinalFindings, DurationMS: 700},
 		},
 	}
-	md := BuildPipelineSummary(steps, rounds)
+	md, risk := BuildPipelineSummary(steps, rounds)
 
 	if !strings.Contains(md, "⚠️ **Review** - findings unavailable") {
 		t.Errorf("expected unavailable review status when final findings are unreadable, got:\n%s", md)
 	}
-	if strings.Contains(md, "medium risk") || strings.Contains(md, "initial risk rationale") {
-		t.Errorf("did not expect stale risk details when final findings are unreadable, got:\n%s", md)
+	if risk != "" {
+		t.Errorf("expected empty risk when final findings are unreadable, got: %q", risk)
 	}
 	if !strings.Contains(md, "failed to parse findings") {
 		t.Errorf("expected parse failure details for unreadable final review findings, got:\n%s", md)
@@ -353,13 +373,16 @@ func TestBuildPipelineSummary_ReviewUnreadableFinalFindingsWithoutRoundsUsesWarn
 	steps := []*db.StepResult{
 		{ID: "s1", StepName: types.StepReview, Status: types.StepStatusCompleted, FindingsJSON: &invalidFinalFindings},
 	}
-	md := BuildPipelineSummary(steps, map[string][]*db.StepRound{"s1": nil})
+	md, risk := BuildPipelineSummary(steps, map[string][]*db.StepRound{"s1": nil})
 
 	if !strings.Contains(md, "⚠️ **Review** - findings unavailable") {
 		t.Errorf("expected warning emoji for unreadable final review findings without rounds, got:\n%s", md)
 	}
 	if strings.Contains(md, "✅ **Review** - findings unavailable") {
 		t.Errorf("did not expect passed emoji for unreadable final review findings without rounds, got:\n%s", md)
+	}
+	if risk != "" {
+		t.Errorf("expected empty risk when final findings are unreadable, got: %q", risk)
 	}
 }
 
@@ -371,7 +394,7 @@ func TestBuildPipelineSummary_FindingSeverityEmoji(t *testing.T) {
 	rounds := map[string][]*db.StepRound{
 		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 1000}},
 	}
-	md := BuildPipelineSummary(steps, rounds)
+	md, risk := BuildPipelineSummary(steps, rounds)
 
 	if !strings.Contains(md, "🚨") {
 		t.Errorf("expected error emoji in details, got:\n%s", md)
@@ -379,12 +402,21 @@ func TestBuildPipelineSummary_FindingSeverityEmoji(t *testing.T) {
 	if !strings.Contains(md, "ℹ️") {
 		t.Errorf("expected info emoji in details, got:\n%s", md)
 	}
+	if !strings.Contains(risk, "high") || !strings.Contains(risk, "critical bug found") {
+		t.Errorf("expected risk line with high level, got: %q", risk)
+	}
+	if !strings.Contains(risk, "🚨") {
+		t.Errorf("expected error emoji for high risk, got: %q", risk)
+	}
 }
 
 func TestBuildPipelineSummary_EmptySteps(t *testing.T) {
-	md := BuildPipelineSummary(nil, nil)
+	md, risk := BuildPipelineSummary(nil, nil)
 	if md != "" {
 		t.Errorf("expected empty string for nil steps, got: %q", md)
+	}
+	if risk != "" {
+		t.Errorf("expected empty risk for nil steps, got: %q", risk)
 	}
 }
 
@@ -396,7 +428,7 @@ func TestBuildPipelineSummary_RebaseWithConflicts(t *testing.T) {
 	rounds := map[string][]*db.StepRound{
 		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 2000}},
 	}
-	md := BuildPipelineSummary(steps, rounds)
+	md, _ := BuildPipelineSummary(steps, rounds)
 
 	if !strings.Contains(md, "**Rebase**") {
 		t.Errorf("expected Rebase in output, got:\n%s", md)

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -281,11 +281,12 @@ func TestBuildPipelineSummary_ReviewShowsWarningForUnresolvedRiskWithoutFindings
 	}
 	md, risk := BuildPipelineSummary(steps, rounds)
 
-	// No findings means passed in the pipeline line
-	if !strings.Contains(md, "✅ **Review** - passed") {
-		t.Errorf("expected passed review status when no findings, got:\n%s", md)
+	if !strings.Contains(md, "⚠️ **Review** - medium risk") {
+		t.Errorf("expected medium-risk review status when no findings, got:\n%s", md)
 	}
-	// Risk is reported separately
+	if strings.Contains(md, "✅ **Review** - passed") {
+		t.Errorf("did not expect passed review status for medium risk, got:\n%s", md)
+	}
 	if !strings.Contains(risk, "medium") || !strings.Contains(risk, "touches critical error handling") {
 		t.Errorf("expected risk line with medium level, got: %q", risk)
 	}

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -3968,7 +3968,7 @@ func TestFallbackPRContent_ConventionalTitle(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			content := fallbackPRContent(tt.branch, tt.commitLog, "")
+			content := fallbackPRContent(tt.branch, tt.commitLog, "", "")
 			if !isConventionalTitle(content.Title) {
 				t.Errorf("fallback title %q is not conventional commit format", content.Title)
 			}

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -2215,6 +2215,47 @@ func TestPRStep_UsesAgentGeneratedTitleAndBody(t *testing.T) {
 	}
 }
 
+func TestPRStep_AppendsRiskOutsideSummaryList(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	binDir, logFile := fakeGH(t, "")
+	prependPATH(t, binDir)
+
+	findings := `{"findings":[],"summary":"clean","risk_level":"medium","risk_rationale":"touches critical error handling"}`
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			payload := json.RawMessage(`{"title":"fix: improve pipeline header UX","body":"## Summary\n\n- keep branch status readable\n- fix footer truncation"}`)
+			return &agent.Result{Output: payload}, nil
+		},
+	}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	reviewStep, err := sctx.DB.InsertStepResult(sctx.Run.ID, types.StepReview)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sctx.DB.UpdateStepStatus(reviewStep.ID, types.StepStatusCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if err := sctx.DB.SetStepFindings(reviewStep.ID, findings); err != nil {
+		t.Fatal(err)
+	}
+
+	step := &PRStep{}
+	if _, err := step.Execute(sctx); err != nil {
+		t.Fatal(err)
+	}
+
+	logData, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ghLog := string(logData)
+	if !strings.Contains(ghLog, "fix footer truncation\n\n⚠️ medium: touches critical error handling") {
+		t.Fatalf("expected risk note to be separated from summary list, got:\n%s", ghLog)
+	}
+}
+
 func fakeGlab(t *testing.T, mrViewJSON string) (binDir string, logFile string) {
 	t.Helper()
 	binDir = fakeCLIBinDir(t)
@@ -3973,6 +4014,14 @@ func TestFallbackPRContent_ConventionalTitle(t *testing.T) {
 				t.Errorf("fallback title %q is not conventional commit format", content.Title)
 			}
 		})
+	}
+}
+
+func TestFallbackPRContent_AppendsRiskOutsideSummaryList(t *testing.T) {
+	content := fallbackPRContent("fix/risk", "abc123 fix pipeline risk rendering", "", "⚠️ medium: touches critical error handling")
+
+	if !strings.Contains(content.Body, "abc123 fix pipeline risk rendering\n\n⚠️ medium: touches critical error handling") {
+		t.Fatalf("expected risk note to be separated from summary content, got:\n%s", content.Body)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add explicit PR-summary risk line handling so review risk levels are surfaced in the generated PR body instead of getting lost in summary rendering
- restore review-step status semantics so medium/high risk is still visible even when there are no findings, preserving the pipeline's primary risk signal
- fix PR body formatting so the risk note renders as a separate line rather than merging into the last `## Summary` bullet; this addresses the review warnings auto-fixed in the second pipeline round

## Pipeline

✅ **Rebase** - passed
✅ **Review** - low risk - _"The change is narrowly scoped to PR summary rendering, preserves existing behavior in the surrounding pipeline flow, and is covered by focused tests for the new risk-line handling."_
✅ **Test** - passed
✅ **Lint** - passed

<details>
<summary>Review details</summary>

**Round 1** - found 2 warnings
- ⚠️ `internal/pipeline/steps/prsummary.go:106` - `buildStepEntry` now marks a review step as `passed` whenever there are no findings, even if the review still reports `risk_level: medium` or `high`. That regresses the previous behavior where review risk was the primary signal, and it makes the pipeline section look green while the change is still explicitly risky.
- ⚠️ `internal/pipeline/steps/pr.go:260` - The new risk text is appended with only a single newline, so for the expected `## Summary` bullet list it renders as a continuation of the last bullet instead of a separate risk note. That can hide the only visible risk signal in the final PR body; the same issue is repeated in `fallbackPRContent` at line 326.

**Round 2** (auto-fix) - found 0 issues

</details>
