### PR TITLE
feat(tui): add open PR action

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -2,6 +2,8 @@ package tui
 
 import (
 	"fmt"
+	"os/exec"
+	"runtime"
 	"strings"
 	"time"
 
@@ -529,27 +531,27 @@ func renderFooter(done bool, showHelp bool, confirmAbort bool, prURL *string, wi
 		left += "  " + boldKey.Render("x") + " " + dimStyle.Render(xLabel)
 	}
 	left += "  " + boldKey.Render("?") + " " + dimStyle.Render(helpLabel)
+	if prURL != nil && *prURL != "" {
+		left += "  " + boldKey.Render("o") + " " + dimStyle.Render("open PR")
+	}
+	return left
+}
 
-	if prURL == nil || *prURL == "" {
-		return left
+// openBrowserCmd returns a tea.Cmd that opens the given URL in the default browser.
+func openBrowserCmd(url string) tea.Cmd {
+	return func() tea.Msg {
+		var cmd *exec.Cmd
+		switch runtime.GOOS {
+		case "darwin":
+			cmd = exec.Command("open", url)
+		case "windows":
+			cmd = exec.Command("cmd", "/c", "start", url)
+		default:
+			cmd = exec.Command("xdg-open", url)
+		}
+		_ = cmd.Start()
+		return nil
 	}
-
-	leftWidth := lipgloss.Width(left)
-	// Try full URL first (clickable in terminals), fall back to short form.
-	prText := *prURL
-	available := width - leftWidth - 4 // 4 = leading + trailing padding
-	if available < len(prText) {
-		prText = shortPRLabel(*prURL)
-	}
-	if available < len(prText) {
-		return left
-	}
-	right := dimStyle.Render(prText) + "  "
-	gap := width - leftWidth - lipgloss.Width(right)
-	if gap < 1 {
-		return left
-	}
-	return left + strings.Repeat(" ", gap) + right
 }
 
 // shortPRLabel extracts a compact label like "PR #42" from a PR URL.
@@ -895,6 +897,11 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, m.respondCmd(types.ActionFix)
 	case "s":
 		return m, m.respondCmd(types.ActionSkip)
+	case "o":
+		if m.run != nil && m.run.PRURL != nil && *m.run.PRURL != "" {
+			return m, openBrowserCmd(*m.run.PRURL)
+		}
+		return m, nil
 	case "x":
 		if m.done || m.run == nil {
 			return m, nil

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -535,10 +535,26 @@ func renderFooter(done bool, showHelp bool, confirmAbort bool, prURL *string, wi
 		left += "  " + boldKey.Render("x") + " " + dimStyle.Render(xLabel)
 	}
 	left += "  " + boldKey.Render("?") + " " + dimStyle.Render(helpLabel)
-	if prURL != nil && *prURL != "" {
-		left += "  " + boldKey.Render("o") + " " + dimStyle.Render("open PR")
+	if prURL == nil || *prURL == "" {
+		return left
 	}
-	return left
+
+	left += "  " + boldKey.Render("o") + " " + dimStyle.Render("open PR")
+	leftWidth := lipgloss.Width(left)
+	prText := *prURL
+	available := width - leftWidth - 4
+	if available < len(prText) {
+		prText = shortPRLabel(*prURL)
+	}
+	if available < len(prText) {
+		return left
+	}
+	right := dimStyle.Render(prText) + "  "
+	gap := width - leftWidth - lipgloss.Width(right)
+	if gap < 1 {
+		return left
+	}
+	return left + strings.Repeat(" ", gap) + right
 }
 
 // openBrowserCmd returns a tea.Cmd that opens the given URL in the default browser.
@@ -557,7 +573,9 @@ func openBrowserCmd(url string) tea.Cmd {
 			name = "xdg-open"
 			args = []string{url}
 		}
-		_ = runBrowserCommand(name, args...)
+		if err := runBrowserCommand(name, args...); err != nil {
+			return errMsg{fmt.Errorf("open PR: %w", err)}
+		}
 		return nil
 	}
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -560,23 +560,22 @@ func renderFooter(done bool, showHelp bool, confirmAbort bool, prURL *string, wi
 // openBrowserCmd returns a tea.Cmd that opens the given URL in the default browser.
 func openBrowserCmd(url string) tea.Cmd {
 	return func() tea.Msg {
-		var name string
-		var args []string
-		switch runtime.GOOS {
-		case "darwin":
-			name = "open"
-			args = []string{url}
-		case "windows":
-			name = "cmd"
-			args = []string{"/c", "start", url}
-		default:
-			name = "xdg-open"
-			args = []string{url}
-		}
+		name, args := browserCommandSpec(runtime.GOOS, url)
 		if err := runBrowserCommand(name, args...); err != nil {
 			return errMsg{fmt.Errorf("open PR: %w", err)}
 		}
 		return nil
+	}
+}
+
+func browserCommandSpec(goos, url string) (string, []string) {
+	switch goos {
+	case "darwin":
+		return "open", []string{url}
+	case "windows":
+		return "rundll32", []string{"url.dll,FileProtocolHandler", url}
+	default:
+		return "xdg-open", []string{url}
 	}
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -37,6 +37,10 @@ const (
 	cappedPipelineHeight = 29
 )
 
+var runBrowserCommand = func(name string, args ...string) error {
+	return exec.Command(name, args...).Run()
+}
+
 func (e errMsg) Error() string { return e.err.Error() }
 
 // connectedMsg signals that the event subscription is ready.
@@ -540,16 +544,20 @@ func renderFooter(done bool, showHelp bool, confirmAbort bool, prURL *string, wi
 // openBrowserCmd returns a tea.Cmd that opens the given URL in the default browser.
 func openBrowserCmd(url string) tea.Cmd {
 	return func() tea.Msg {
-		var cmd *exec.Cmd
+		var name string
+		var args []string
 		switch runtime.GOOS {
 		case "darwin":
-			cmd = exec.Command("open", url)
+			name = "open"
+			args = []string{url}
 		case "windows":
-			cmd = exec.Command("cmd", "/c", "start", url)
+			name = "cmd"
+			args = []string{"/c", "start", url}
 		default:
-			cmd = exec.Command("xdg-open", url)
+			name = "xdg-open"
+			args = []string{url}
 		}
-		_ = cmd.Start()
+		_ = runBrowserCommand(name, args...)
 		return nil
 	}
 }

--- a/internal/tui/pipeline.go
+++ b/internal/tui/pipeline.go
@@ -405,6 +405,9 @@ func renderHelpOverlay(width int, run *ipc.RunInfo, hasAwaitingStep bool, showDi
 		footerEntries = append(footerEntries, helpEntry{"x x", "abort pipeline"})
 	}
 	footerEntries = append(footerEntries, helpEntry{"?", "close help"})
+	if run != nil && run.PRURL != nil && *run.PRURL != "" {
+		footerEntries = append(footerEntries, helpEntry{"o", "open PR in browser"})
+	}
 	content.WriteString(renderEntries(footerEntries))
 
 	return renderBox("Help", content.String(), width)

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -549,6 +549,19 @@ func TestOpenBrowserCmd_ReturnsErrMsgOnFailure(t *testing.T) {
 	}
 }
 
+func TestBrowserCommandSpec_WindowsUsesRundll32(t *testing.T) {
+	name, args := browserCommandSpec("windows", "https://example.com/pull/1?foo=1&bar=2")
+
+	if name != "rundll32" {
+		t.Fatalf("expected rundll32 launcher, got %q", name)
+	}
+
+	wantArgs := []string{"url.dll,FileProtocolHandler", "https://example.com/pull/1?foo=1&bar=2"}
+	if !reflect.DeepEqual(args, wantArgs) {
+		t.Fatalf("unexpected args: got %v want %v", args, wantArgs)
+	}
+}
+
 func TestModel_ApplyEvent_LogChunk(t *testing.T) {
 	run := testRun()
 	m := NewModel("/tmp/sock", nil, run)

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -497,6 +497,37 @@ func TestRenderFooter_PRURL_ActionShownAtNarrowWidth(t *testing.T) {
 	}
 }
 
+func TestOpenBrowserCmd_WaitsForBrowserCommand(t *testing.T) {
+	original := runBrowserCommand
+	t.Cleanup(func() {
+		runBrowserCommand = original
+	})
+
+	called := false
+	finished := false
+	runBrowserCommand = func(name string, args ...string) error {
+		called = true
+		time.Sleep(50 * time.Millisecond)
+		finished = true
+		return nil
+	}
+
+	start := time.Now()
+	msg := openBrowserCmd("https://example.com")()
+	if msg != nil {
+		t.Fatalf("expected nil msg, got %#v", msg)
+	}
+	if !called {
+		t.Fatal("expected browser command to be invoked")
+	}
+	if !finished {
+		t.Fatal("expected browser command to finish before return")
+	}
+	if elapsed := time.Since(start); elapsed < 50*time.Millisecond {
+		t.Fatalf("expected command to block until completion, returned after %v", elapsed)
+	}
+}
+
 func TestModel_ApplyEvent_LogChunk(t *testing.T) {
 	run := testRun()
 	m := NewModel("/tmp/sock", nil, run)

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -460,14 +460,18 @@ func TestModel_ApplyEvent_RunCompleted_PRURL(t *testing.T) {
 	}
 }
 
-func TestRenderFooter_WithPRURL_FullURL(t *testing.T) {
+func TestRenderFooter_WithPRURL_ShowsOpenAction(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.Ascii)
 	prURL := "https://github.com/test/repo/pull/42"
 	footer := renderFooter(true, false, false, &prURL, 80)
 	stripped := stripANSI(footer)
 
-	if !strings.Contains(stripped, prURL) {
-		t.Errorf("expected footer to contain full URL %q, got: %s", prURL, stripped)
+	if !strings.Contains(stripped, "o") || !strings.Contains(stripped, "open PR") {
+		t.Errorf("expected footer to contain 'o open PR' action, got: %s", stripped)
+	}
+	// Should NOT show the full URL anymore
+	if strings.Contains(stripped, "https://") {
+		t.Errorf("expected footer to not contain full URL, got: %s", stripped)
 	}
 }
 
@@ -476,35 +480,20 @@ func TestRenderFooter_WithoutPRURL(t *testing.T) {
 	footer := renderFooter(false, false, false, nil, 80)
 	stripped := stripANSI(footer)
 
-	if strings.Contains(stripped, "PR") {
-		t.Errorf("expected no PR in footer, got: %s", stripped)
+	if strings.Contains(stripped, "open PR") {
+		t.Errorf("expected no open PR action in footer, got: %s", stripped)
 	}
 }
 
-func TestRenderFooter_PRURL_FallsBackToShortForm(t *testing.T) {
+func TestRenderFooter_PRURL_ActionShownAtNarrowWidth(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.Ascii)
 	prURL := "https://github.com/test/repo/pull/42"
-	// Narrow width - should fall back to "PR #42" instead of full URL
+	// Even at narrow width, "open PR" action should appear
 	footer := renderFooter(true, false, false, &prURL, 40)
 	stripped := stripANSI(footer)
 
-	if !strings.Contains(stripped, "PR #42") {
-		t.Errorf("expected footer to contain PR #42, got: %s", stripped)
-	}
-	if strings.Contains(stripped, "https://") {
-		t.Errorf("expected short form, not full URL at narrow width, got: %s", stripped)
-	}
-}
-
-func TestRenderFooter_PRURL_HiddenWhenTooNarrow(t *testing.T) {
-	lipgloss.SetColorProfile(termenv.Ascii)
-	prURL := "https://github.com/test/repo/pull/42"
-	// Extremely narrow - not even short form fits
-	footer := renderFooter(true, false, false, &prURL, 20)
-	stripped := stripANSI(footer)
-
-	if strings.Contains(stripped, "PR") {
-		t.Errorf("expected no PR at extremely narrow width, got: %s", stripped)
+	if !strings.Contains(stripped, "open PR") {
+		t.Errorf("expected footer to contain 'open PR' action, got: %s", stripped)
 	}
 }
 
@@ -5053,21 +5042,16 @@ func TestRenderBabysitView_LongLastEventTruncated(t *testing.T) {
 	}
 }
 
-func TestRenderBabysitView_ShowsPRContextWhenFooterWouldHideIt(t *testing.T) {
+func TestRenderBabysitView_ShowsPRContext(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.Ascii)
 	run := testRunWithBabysit()
 	shortURL := "https://github.com/user/repo/pull/99"
 	run.PRURL = &shortURL
 	run.Steps[5].Status = types.StepStatusRunning
 
-	footer := stripANSI(renderFooter(false, false, false, &shortURL, 20))
-	if strings.Contains(footer, "PR #99") {
-		t.Fatalf("expected narrow footer to hide PR context, got: %s", footer)
-	}
-
-	result := stripANSI(renderBabysitView(run, run.Steps, "", nil, 20))
+	result := stripANSI(renderBabysitView(run, run.Steps, "", nil, 60))
 	if !strings.Contains(result, "PR #99") {
-		t.Fatalf("expected babysit panel to retain PR context in narrow width, got: %s", result)
+		t.Fatalf("expected babysit panel to show PR context, got: %s", result)
 	}
 }
 

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -559,6 +560,47 @@ func TestBrowserCommandSpec_WindowsUsesRundll32(t *testing.T) {
 	wantArgs := []string{"url.dll,FileProtocolHandler", "https://example.com/pull/1?foo=1&bar=2"}
 	if !reflect.DeepEqual(args, wantArgs) {
 		t.Fatalf("unexpected args: got %v want %v", args, wantArgs)
+	}
+}
+
+func TestModel_Update_OpenPRKeyRunsBrowserCommand(t *testing.T) {
+	original := runBrowserCommand
+	t.Cleanup(func() {
+		runBrowserCommand = original
+	})
+
+	prURL := "https://github.com/test/repo/pull/42"
+	run := testRun()
+	run.PRURL = &prURL
+	m := NewModel("/tmp/sock", nil, run)
+
+	called := false
+	var gotName string
+	var gotArgs []string
+	runBrowserCommand = func(name string, args ...string) error {
+		called = true
+		gotName = name
+		gotArgs = append([]string(nil), args...)
+		return nil
+	}
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'o'}})
+	if cmd == nil {
+		t.Fatal("expected browser open command")
+	}
+	if msg := cmd(); msg != nil {
+		t.Fatalf("expected nil msg, got %#v", msg)
+	}
+	if !called {
+		t.Fatal("expected browser launcher to be called")
+	}
+
+	wantName, wantArgs := browserCommandSpec(runtime.GOOS, prURL)
+	if gotName != wantName {
+		t.Fatalf("unexpected command name: got %q want %q", gotName, wantName)
+	}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		t.Fatalf("unexpected command args: got %v want %v", gotArgs, wantArgs)
 	}
 }
 
@@ -7101,6 +7143,21 @@ func TestHelpOverlay_ShowsRunContext(t *testing.T) {
 	}
 	if !strings.Contains(result, run.ID) {
 		t.Fatalf("expected help overlay to show pipeline ID, got:\n%s", result)
+	}
+}
+
+func TestHelpOverlay_ShowsOpenPRActionWhenPRURLPresent(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.Ascii)
+	run := testRun()
+	prURL := "https://github.com/test/repo/pull/42"
+	run.PRURL = &prURL
+
+	result := stripANSI(renderHelpOverlay(80, run, true, false, true, false))
+	if !strings.Contains(result, "open PR in browser") {
+		t.Fatalf("expected help overlay to include PR browser action, got:\n%s", result)
+	}
+	if !strings.Contains(result, "o") {
+		t.Fatalf("expected help overlay to include 'o' keybinding, got:\n%s", result)
 	}
 }
 

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -469,9 +470,8 @@ func TestRenderFooter_WithPRURL_ShowsOpenAction(t *testing.T) {
 	if !strings.Contains(stripped, "o") || !strings.Contains(stripped, "open PR") {
 		t.Errorf("expected footer to contain 'o open PR' action, got: %s", stripped)
 	}
-	// Should NOT show the full URL anymore
-	if strings.Contains(stripped, "https://") {
-		t.Errorf("expected footer to not contain full URL, got: %s", stripped)
+	if !strings.Contains(stripped, prURL) {
+		t.Errorf("expected footer to contain full PR URL, got: %s", stripped)
 	}
 }
 
@@ -525,6 +525,27 @@ func TestOpenBrowserCmd_WaitsForBrowserCommand(t *testing.T) {
 	}
 	if elapsed := time.Since(start); elapsed < 50*time.Millisecond {
 		t.Fatalf("expected command to block until completion, returned after %v", elapsed)
+	}
+}
+
+func TestOpenBrowserCmd_ReturnsErrMsgOnFailure(t *testing.T) {
+	original := runBrowserCommand
+	t.Cleanup(func() {
+		runBrowserCommand = original
+	})
+
+	wantErr := errors.New("launcher missing")
+	runBrowserCommand = func(name string, args ...string) error {
+		return wantErr
+	}
+
+	msg := openBrowserCmd("https://example.com")()
+	errMsg, ok := msg.(errMsg)
+	if !ok {
+		t.Fatalf("expected errMsg, got %#v", msg)
+	}
+	if !errors.Is(errMsg.err, wantErr) {
+		t.Fatalf("expected error %v, got %v", wantErr, errMsg.err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add a TUI action to open the pull request directly from the main view, making it faster to jump from pipeline output to the PR.
- Harden browser launching across platforms by waiting for launcher completion where needed, surfacing launch errors in the UI, preserving the visible PR URL for headless environments, and fixing Windows `start` handling for URLs with shell-sensitive characters.
- Extend targeted TUI coverage for the new PR action and launcher behavior; pipeline review finished at low risk after auto-fixes addressed the flagged browser-launch issues.

## Pipeline

✅ **Rebase** - passed
✅ **Review** - low risk - _"The change is narrowly scoped to adding a PR-open action in the TUI, and the updated behavior and platform-specific launcher path are covered by targeted tests without exposing material correctness, security, or compatibility risks."_
✅ **Test** - passed
✅ **Lint** - passed

<details>
<summary>Review details</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/tui/app.go:552` - `openBrowserCmd` calls `cmd.Start()` and never waits on the child process, so each `o` press can leave a short-lived `open`/`xdg-open`/`start` helper unreaped until the TUI exits; run the command to completion or wait in a goroutine and surface launch errors.

**Round 2** (auto-fix) - found 2 warnings
- ⚠️ `internal/tui/app.go:560` - Browser-launch failures are discarded with `_ = runBrowserCommand(...)`, so on systems without `open`/`xdg-open` support or with a failed launcher the `o` action becomes a silent no-op. Surface the error in the TUI so users know the PR was not opened.
- ⚠️ `internal/tui/app.go:538` - This change removes the visible PR URL from the footer and replaces it with a local browser action only. In SSH, container, CI, or other headless sessions where a local browser cannot be launched, users lose the only always-visible way to access the PR link from the main view.

**Round 3** (auto-fix) - found 2 warnings
- ⚠️ `internal/tui/app.go:561` - `openBrowserCmd` now runs the browser launcher synchronously via `exec.Command(...).Run()`, so pressing `o` blocks the Bubble Tea event loop until the child process exits. On slower or wrapper-based launchers such as some `xdg-open` setups, that can freeze the TUI and delay pipeline updates or quit handling while the browser command is running.
- ⚠️ `internal/tui/app.go:571` - The Windows branch uses `cmd /c start <url>` without the empty title argument or escaping, which is brittle for URLs containing `&`, `^`, or quotes because `cmd.exe` will parse them as shell syntax. That can cause the PR action to open the wrong target or fail entirely on valid URLs with query parameters.

**Round 4** (auto-fix) - found 0 issues

</details>
