### PR TITLE
feat(rebase): add scoped auto-fix support for rebase conflicts

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,6 +53,7 @@ type AutoFixRaw struct {
 	Test    *int `yaml:"test"`
 	Review  *int `yaml:"review"`
 	Babysit *int `yaml:"babysit"`
+	Rebase  *int `yaml:"rebase"`
 }
 
 // AutoFix holds resolved per-step auto-fix attempt limits.
@@ -62,6 +63,7 @@ type AutoFix struct {
 	Test    int
 	Review  int
 	Babysit int
+	Rebase  int
 }
 
 // Config is the merged result of global + per-repo configuration.
@@ -96,6 +98,7 @@ log_level: info
 
 # Maximum auto-fix attempts per step (0 = disabled, requires manual approval)
 auto_fix:
+  rebase: 3
   lint: 3
   test: 3
   review: 3
@@ -229,6 +232,7 @@ func autoFixDefaults() AutoFix {
 		Test:    3,
 		Review:  3,
 		Babysit: 3,
+		Rebase:  3,
 	}
 }
 
@@ -246,6 +250,9 @@ func applyAutoFixOverrides(dst *AutoFix, src *AutoFixRaw) {
 	if src.Babysit != nil {
 		dst.Babysit = *src.Babysit
 	}
+	if src.Rebase != nil {
+		dst.Rebase = *src.Rebase
+	}
 }
 
 // AutoFixLimit returns the max auto-fix attempts for a given step.
@@ -260,6 +267,8 @@ func (c *Config) AutoFixLimit(step types.StepName) int {
 		return c.AutoFix.Review
 	case types.StepBabysit:
 		return c.AutoFix.Babysit
+	case types.StepRebase:
+		return c.AutoFix.Rebase
 	default:
 		return 0
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,7 +98,7 @@ log_level: info
 
 # Maximum auto-fix attempts per step (0 = disabled, requires manual approval)
 auto_fix:
-  rebase: 3
+  rebase: 0
   lint: 3
   test: 3
   review: 3
@@ -232,7 +232,7 @@ func autoFixDefaults() AutoFix {
 		Test:    3,
 		Review:  3,
 		Babysit: 3,
-		Rebase:  3,
+		Rebase:  0,
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -470,6 +470,9 @@ func TestDefaultConfigYAML_MatchesGoDefaults(t *testing.T) {
 	if raw.AutoFix.Babysit == nil || *raw.AutoFix.Babysit != defaults.Babysit {
 		t.Errorf("YAML auto_fix.babysit = %v, Go default = %d", raw.AutoFix.Babysit, defaults.Babysit)
 	}
+	if raw.AutoFix.Rebase == nil || *raw.AutoFix.Rebase != defaults.Rebase {
+		t.Errorf("YAML auto_fix.rebase = %v, Go default = %d", raw.AutoFix.Rebase, defaults.Rebase)
+	}
 }
 
 func TestLoadGlobal_AutoFixDefaults(t *testing.T) {
@@ -479,7 +482,7 @@ func TestLoadGlobal_AutoFixDefaults(t *testing.T) {
 	}
 	// AutoFix should be nil (unset) in GlobalConfig
 	if cfg.AutoFix.Lint != nil || cfg.AutoFix.Test != nil || cfg.AutoFix.Review != nil ||
-		cfg.AutoFix.Babysit != nil {
+		cfg.AutoFix.Babysit != nil || cfg.AutoFix.Rebase != nil {
 		t.Errorf("expected all AutoFix fields to be nil for defaults, got %+v", cfg.AutoFix)
 	}
 }
@@ -578,6 +581,9 @@ func TestMerge_AutoFixDefaults(t *testing.T) {
 	if cfg.AutoFix.Babysit != 3 {
 		t.Errorf("babysit = %d, want 3", cfg.AutoFix.Babysit)
 	}
+	if cfg.AutoFix.Rebase != 3 {
+		t.Errorf("rebase = %d, want 3", cfg.AutoFix.Rebase)
+	}
 }
 
 func TestMerge_AutoFixGlobalOverridesDefaults(t *testing.T) {
@@ -600,6 +606,9 @@ func TestMerge_AutoFixGlobalOverridesDefaults(t *testing.T) {
 	}
 	if cfg.AutoFix.Babysit != 0 {
 		t.Errorf("babysit = %d, want 0 (global override)", cfg.AutoFix.Babysit)
+	}
+	if cfg.AutoFix.Rebase != 3 {
+		t.Errorf("rebase = %d, want 3 (default, no override)", cfg.AutoFix.Rebase)
 	}
 }
 
@@ -631,7 +640,7 @@ func TestMerge_AutoFixRepoOverridesGlobal(t *testing.T) {
 
 func TestAutoFixLimit(t *testing.T) {
 	cfg := &Config{
-		AutoFix: AutoFix{Lint: 5, Test: 2, Review: 0, Babysit: 3},
+		AutoFix: AutoFix{Lint: 5, Test: 2, Review: 0, Babysit: 3, Rebase: 4},
 	}
 	tests := []struct {
 		step types.StepName
@@ -641,9 +650,9 @@ func TestAutoFixLimit(t *testing.T) {
 		{types.StepTest, 2},
 		{types.StepReview, 0},
 		{types.StepBabysit, 3},
+		{types.StepRebase, 4},
 		{types.StepPush, 0},
 		{types.StepPR, 0},
-		{types.StepRebase, 0},
 	}
 	for _, tt := range tests {
 		got := cfg.AutoFixLimit(tt.step)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -581,8 +581,8 @@ func TestMerge_AutoFixDefaults(t *testing.T) {
 	if cfg.AutoFix.Babysit != 3 {
 		t.Errorf("babysit = %d, want 3", cfg.AutoFix.Babysit)
 	}
-	if cfg.AutoFix.Rebase != 3 {
-		t.Errorf("rebase = %d, want 3", cfg.AutoFix.Rebase)
+	if cfg.AutoFix.Rebase != 0 {
+		t.Errorf("rebase = %d, want 0", cfg.AutoFix.Rebase)
 	}
 }
 
@@ -607,8 +607,8 @@ func TestMerge_AutoFixGlobalOverridesDefaults(t *testing.T) {
 	if cfg.AutoFix.Babysit != 0 {
 		t.Errorf("babysit = %d, want 0 (global override)", cfg.AutoFix.Babysit)
 	}
-	if cfg.AutoFix.Rebase != 3 {
-		t.Errorf("rebase = %d, want 3 (default, no override)", cfg.AutoFix.Rebase)
+	if cfg.AutoFix.Rebase != 0 {
+		t.Errorf("rebase = %d, want 0 (default, no override)", cfg.AutoFix.Rebase)
 	}
 }
 

--- a/internal/pipeline/steps/rebase.go
+++ b/internal/pipeline/steps/rebase.go
@@ -48,33 +48,24 @@ func (s *RebaseStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome,
 		return updateHeadSHA(ctx, sctx)
 	}
 
-	// Normal mode: try all rebases, accumulate conflict findings
-	var allFindings []Finding
-	var allSummaries []string
+	// Normal mode: try all rebases, track which targets had conflicts
+	var conflictTargets []string
 	for _, target := range targets {
-		outcome, err := tryRebase(ctx, sctx, target)
+		hadConflict, err := tryRebase(ctx, sctx, target)
 		if err != nil {
 			return nil, err
 		}
-		if outcome != nil && outcome.Findings != "" {
-			var f Findings
-			if json.Unmarshal([]byte(outcome.Findings), &f) == nil {
-				allFindings = append(allFindings, f.Items...)
-				if f.Summary != "" {
-					allSummaries = append(allSummaries, f.Summary)
-				}
-			}
+		if hadConflict {
+			conflictTargets = append(conflictTargets, target)
 		}
 	}
 
-	if len(allFindings) > 0 {
-		combined := Findings{
-			Items:   allFindings,
-			Summary: strings.Join(allSummaries, "; "),
-		}
-		findingsJSON, _ := json.Marshal(combined)
+	if len(conflictTargets) > 0 {
+		summary := fmt.Sprintf("conflict rebasing onto %s", strings.Join(conflictTargets, ", "))
+		findingsJSON, _ := json.Marshal(Findings{Summary: summary})
 		return &pipeline.StepOutcome{
 			NeedsApproval: true,
+			AutoFixable:   true,
 			Findings:      string(findingsJSON),
 		}, nil
 	}
@@ -94,35 +85,28 @@ func rebaseTargets(branch, defaultBranch string) []string {
 	return targets
 }
 
-// tryRebase attempts a rebase onto targetRef. Returns nil outcome on success,
-// or a StepOutcome with conflict findings if conflicts are detected.
-func tryRebase(ctx context.Context, sctx *pipeline.StepContext, targetRef string) (*pipeline.StepOutcome, error) {
+// tryRebase attempts a rebase onto targetRef. Returns true if there were
+// conflicts (rebase is aborted), false on success or skip.
+func tryRebase(ctx context.Context, sctx *pipeline.StepContext, targetRef string) (bool, error) {
 	skip, err := shouldSkipRebase(ctx, sctx, targetRef)
 	if err != nil {
-		return nil, err
+		return false, err
 	}
 	if skip {
-		return nil, nil
+		return false, nil
 	}
 
 	sctx.Log(fmt.Sprintf("rebasing onto %s...", targetRef))
 	if _, err := git.Run(ctx, sctx.WorkDir, "rebase", targetRef); err != nil {
-		// Check for conflict files before aborting
-		conflictFiles := conflictingFiles(ctx, sctx.WorkDir)
+		isConflict := rebaseInProgress(ctx, sctx.WorkDir)
 		_, _ = git.Run(ctx, sctx.WorkDir, "rebase", "--abort")
 
-		if len(conflictFiles) == 0 {
-			return nil, fmt.Errorf("rebase onto %s: %w", targetRef, err)
+		if !isConflict {
+			return false, fmt.Errorf("rebase onto %s: %w", targetRef, err)
 		}
-
-		findings := buildConflictFindings(targetRef, conflictFiles)
-		findingsJSON, _ := json.Marshal(findings)
-		return &pipeline.StepOutcome{
-			NeedsApproval: true,
-			Findings:      string(findingsJSON),
-		}, nil
+		return true, nil
 	}
-	return nil, nil
+	return false, nil
 }
 
 // rebaseWithAgent performs a rebase and uses the agent to resolve any conflicts.
@@ -140,21 +124,17 @@ func rebaseWithAgent(ctx context.Context, sctx *pipeline.StepContext, targetRef 
 		return nil
 	}
 
-	conflictFiles := conflictingFiles(ctx, sctx.WorkDir)
-	if len(conflictFiles) == 0 {
+	if !rebaseInProgress(ctx, sctx.WorkDir) {
 		_, _ = git.Run(ctx, sctx.WorkDir, "rebase", "--abort")
-		return fmt.Errorf("rebase onto %s failed (no conflict files detected)", targetRef)
+		return fmt.Errorf("rebase onto %s failed (no conflicts detected)", targetRef)
 	}
-	sctx.Log(fmt.Sprintf("conflicts detected in %d file(s), asking agent to resolve...", len(conflictFiles)))
+	sctx.Log("conflicts detected, asking agent to resolve...")
 
 	prompt := fmt.Sprintf(
 		`Resolve git rebase conflicts. The rebase of the current branch onto %s has conflicts.
 
-Conflicting files:
-%s
-
 Instructions:
-- Edit each conflicting file to resolve the conflict markers (<<<<<<< ======= >>>>>>>).
+- Find all conflicting files and resolve the conflict markers (<<<<<<< ======= >>>>>>>).
 - After resolving each file, stage it with: git add <file>
 - After all conflicts are resolved, run: git rebase --continue
 - If additional conflicts arise during rebase --continue, resolve those too.
@@ -163,7 +143,6 @@ Instructions:
 - Return JSON with a single "summary" field describing what you resolved.
 - Keep the summary under 10 words.`,
 		targetRef,
-		strings.Join(conflictFiles, "\n"),
 	)
 	if sctx.PreviousFindings != "" {
 		prompt += "\n\nPrevious findings:\n" + sctx.PreviousFindings
@@ -237,38 +216,6 @@ func rebaseInProgress(ctx context.Context, workDir string) bool {
 		}
 	}
 	return false
-}
-
-// conflictingFiles returns the list of files with merge conflicts in the working tree.
-func conflictingFiles(ctx context.Context, workDir string) []string {
-	out, err := git.Run(ctx, workDir, "diff", "--name-only", "--diff-filter=U")
-	if err != nil {
-		return nil
-	}
-	var files []string
-	for _, f := range strings.Split(out, "\n") {
-		f = strings.TrimSpace(f)
-		if f != "" {
-			files = append(files, f)
-		}
-	}
-	return files
-}
-
-// buildConflictFindings creates a Findings struct from conflict information.
-func buildConflictFindings(targetRef string, files []string) Findings {
-	items := make([]Finding, len(files))
-	for i, f := range files {
-		items[i] = Finding{
-			Severity:    "error",
-			File:        f,
-			Description: fmt.Sprintf("merge conflict during rebase onto %s", targetRef),
-		}
-	}
-	return Findings{
-		Items:   items,
-		Summary: fmt.Sprintf("%d file(s) with merge conflicts rebasing onto %s", len(files), targetRef),
-	}
 }
 
 // updateHeadSHA syncs the run's head SHA after rebase.

--- a/internal/pipeline/steps/rebase.go
+++ b/internal/pipeline/steps/rebase.go
@@ -50,19 +50,27 @@ func (s *RebaseStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome,
 
 	// Normal mode: try all rebases, track which targets had conflicts
 	var conflictTargets []string
+	var conflictFindings []Finding
 	for _, target := range targets {
-		hadConflict, err := tryRebase(ctx, sctx, target)
+		conflictFiles, err := tryRebase(ctx, sctx, target)
 		if err != nil {
 			return nil, err
 		}
-		if hadConflict {
+		if len(conflictFiles) > 0 {
 			conflictTargets = append(conflictTargets, target)
+			for _, file := range conflictFiles {
+				conflictFindings = append(conflictFindings, Finding{
+					Severity:    "warning",
+					File:        file,
+					Description: fmt.Sprintf("merge conflict rebasing onto %s", target),
+				})
+			}
 		}
 	}
 
 	if len(conflictTargets) > 0 {
 		summary := fmt.Sprintf("conflict rebasing onto %s", strings.Join(conflictTargets, ", "))
-		findingsJSON, _ := json.Marshal(Findings{Summary: summary})
+		findingsJSON, _ := json.Marshal(Findings{Items: dedupeRebaseFindings(conflictFindings), Summary: summary})
 		return &pipeline.StepOutcome{
 			NeedsApproval: true,
 			AutoFixable:   true,
@@ -85,28 +93,28 @@ func rebaseTargets(branch, defaultBranch string) []string {
 	return targets
 }
 
-// tryRebase attempts a rebase onto targetRef. Returns true if there were
-// conflicts (rebase is aborted), false on success or skip.
-func tryRebase(ctx context.Context, sctx *pipeline.StepContext, targetRef string) (bool, error) {
+// tryRebase attempts a rebase onto targetRef. Returns conflicted files when the
+// rebase stops on merge conflicts. The rebase is aborted before returning.
+func tryRebase(ctx context.Context, sctx *pipeline.StepContext, targetRef string) ([]string, error) {
 	skip, err := shouldSkipRebase(ctx, sctx, targetRef)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 	if skip {
-		return false, nil
+		return nil, nil
 	}
 
 	sctx.Log(fmt.Sprintf("rebasing onto %s...", targetRef))
 	if _, err := git.Run(ctx, sctx.WorkDir, "rebase", targetRef); err != nil {
-		isConflict := rebaseInProgress(ctx, sctx.WorkDir)
+		conflictFiles := rebaseConflictFiles(ctx, sctx.WorkDir)
 		_, _ = git.Run(ctx, sctx.WorkDir, "rebase", "--abort")
 
-		if !isConflict {
-			return false, fmt.Errorf("rebase onto %s: %w", targetRef, err)
+		if len(conflictFiles) == 0 {
+			return nil, fmt.Errorf("rebase onto %s: %w", targetRef, err)
 		}
-		return true, nil
+		return conflictFiles, nil
 	}
-	return false, nil
+	return nil, nil
 }
 
 // rebaseWithAgent performs a rebase and uses the agent to resolve any conflicts.
@@ -124,7 +132,7 @@ func rebaseWithAgent(ctx context.Context, sctx *pipeline.StepContext, targetRef 
 		return nil
 	}
 
-	if !rebaseInProgress(ctx, sctx.WorkDir) {
+	if len(rebaseConflictFiles(ctx, sctx.WorkDir)) == 0 {
 		_, _ = git.Run(ctx, sctx.WorkDir, "rebase", "--abort")
 		return fmt.Errorf("rebase onto %s failed (no conflicts detected)", targetRef)
 	}
@@ -216,6 +224,39 @@ func rebaseInProgress(ctx context.Context, workDir string) bool {
 		}
 	}
 	return false
+}
+
+func rebaseConflictFiles(ctx context.Context, workDir string) []string {
+	out, err := git.Run(ctx, workDir, "diff", "--name-only", "--diff-filter=U")
+	if err != nil {
+		return nil
+	}
+	var files []string
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		files = append(files, line)
+	}
+	return files
+}
+
+func dedupeRebaseFindings(findings []Finding) []Finding {
+	if len(findings) < 2 {
+		return findings
+	}
+	seen := make(map[string]bool, len(findings))
+	filtered := make([]Finding, 0, len(findings))
+	for _, finding := range findings {
+		key := finding.File + "\x00" + finding.Description
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		filtered = append(filtered, finding)
+	}
+	return filtered
 }
 
 // updateHeadSHA syncs the run's head SHA after rebase.

--- a/internal/pipeline/steps/rebase.go
+++ b/internal/pipeline/steps/rebase.go
@@ -137,9 +137,13 @@ func rebaseWithAgent(ctx context.Context, sctx *pipeline.StepContext, targetRef 
 		return fmt.Errorf("rebase onto %s failed (no conflicts detected)", targetRef)
 	}
 	sctx.Log("conflicts detected, asking agent to resolve...")
+	conflictFiles := rebaseConflictFiles(ctx, sctx.WorkDir)
 
 	prompt := fmt.Sprintf(
 		`Resolve git rebase conflicts. The rebase of the current branch onto %s has conflicts.
+
+Current conflicted files:
+- %s
 
 Instructions:
 - Find all conflicting files and resolve the conflict markers (<<<<<<< ======= >>>>>>>).
@@ -151,6 +155,7 @@ Instructions:
 - Return JSON with a single "summary" field describing what you resolved.
 - Keep the summary under 10 words.`,
 		targetRef,
+		strings.Join(conflictFiles, "\n- "),
 	)
 	if sctx.PreviousFindings != "" {
 		prompt += "\n\nPrevious findings:\n" + sctx.PreviousFindings

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -748,7 +748,7 @@ func TestRebaseStep_FixModeCallsAgent(t *testing.T) {
 	sctx.Run.Branch = "refs/heads/feature"
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Fixing = true
-	sctx.PreviousFindings = `{"findings":[{"severity":"error","file":"shared.txt","description":"merge conflict"}]}`
+	sctx.PreviousFindings = `{"findings":[{"severity":"warning","file":"other.txt","description":"merge conflict rebasing onto origin/feature"}]}`
 
 	step := &RebaseStep{}
 	outcome, err := step.Execute(sctx)
@@ -763,6 +763,9 @@ func TestRebaseStep_FixModeCallsAgent(t *testing.T) {
 	}
 	if !strings.Contains(ag.calls[0].Prompt, "shared.txt") {
 		t.Error("expected agent prompt to mention conflicting file")
+	}
+	if strings.Contains(ag.calls[0].Prompt, "other.txt") && !strings.Contains(ag.calls[0].Prompt, "Current conflicted files") {
+		t.Fatalf("expected prompt to scope fixes using current conflicted files, got: %s", ag.calls[0].Prompt)
 	}
 	// Verify rebase completed - feature is now ahead of origin/main
 	mergeBase := gitCmd(t, dir, "merge-base", "HEAD", "origin/main")

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -529,11 +529,14 @@ func TestRebaseStep_ConflictReturnsFindings(t *testing.T) {
 	if !outcome.NeedsApproval {
 		t.Fatal("expected NeedsApproval for conflict")
 	}
+	if !outcome.AutoFixable {
+		t.Fatal("expected AutoFixable for conflict")
+	}
 	if outcome.Findings == "" {
 		t.Fatal("expected findings for conflict")
 	}
-	if !strings.Contains(outcome.Findings, "shared.txt") {
-		t.Errorf("expected findings to mention conflicting file, got: %s", outcome.Findings)
+	if !strings.Contains(outcome.Findings, "origin/main") {
+		t.Errorf("expected findings to mention conflict target, got: %s", outcome.Findings)
 	}
 	// Verify repo is clean (rebase was aborted)
 	status := gitStatusPorcelain(t, dir)
@@ -598,8 +601,11 @@ func TestRebaseStep_ConflictTriesAllTargets(t *testing.T) {
 	if !outcome.NeedsApproval {
 		t.Fatal("expected NeedsApproval for conflict")
 	}
-	if !strings.Contains(outcome.Findings, "shared.txt") {
-		t.Errorf("expected findings to mention shared.txt, got: %s", outcome.Findings)
+	if !outcome.AutoFixable {
+		t.Fatal("expected AutoFixable for conflict")
+	}
+	if !strings.Contains(outcome.Findings, "origin/feature") {
+		t.Errorf("expected findings to mention conflict target, got: %s", outcome.Findings)
 	}
 
 	// The non-conflicting rebase onto origin/main should have succeeded

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -626,6 +626,64 @@ func TestRebaseStep_ConflictTriesAllTargets(t *testing.T) {
 	}
 }
 
+func TestRebaseStep_ConflictFindingsIncludeFiles(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	os.WriteFile(filepath.Join(dir, "shared.txt"), []byte("base\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "base commit")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "shared.txt"), []byte("feature change\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature change")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	gitCmd(t, dir, "checkout", "main")
+	os.WriteFile(filepath.Join(dir, "shared.txt"), []byte("main change\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "main conflict")
+	gitCmd(t, dir, "push", "origin", "main")
+	gitCmd(t, dir, "checkout", "feature")
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Repo.UpstreamURL = upstream
+
+	step := &RebaseStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	findings, err := types.ParseFindingsJSON(outcome.Findings)
+	if err != nil {
+		t.Fatalf("parse findings: %v", err)
+	}
+	if len(findings.Items) == 0 {
+		t.Fatal("expected conflicted files in findings")
+	}
+	if findings.Items[0].File != "shared.txt" {
+		t.Fatalf("first finding file = %q, want shared.txt", findings.Items[0].File)
+	}
+	if findings.Items[0].Severity != "warning" {
+		t.Fatalf("first finding severity = %q, want warning", findings.Items[0].Severity)
+	}
+	if !strings.Contains(findings.Items[0].Description, "origin/main") {
+		t.Fatalf("expected finding description to mention target, got %q", findings.Items[0].Description)
+	}
+}
+
 func TestRebaseStep_FixModeCallsAgent(t *testing.T) {
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
@@ -760,6 +818,62 @@ func TestRebaseStep_FixModeNonConflictFailureReturnsError(t *testing.T) {
 	}
 	if len(ag.calls) != 0 {
 		t.Errorf("expected 0 agent calls for non-conflict failure, got %d", len(ag.calls))
+	}
+}
+
+func TestRebaseStep_NonConflictFailureWithRebaseMetadataReturnsError(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	os.WriteFile(filepath.Join(dir, "a.txt"), []byte("base\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "base commit")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "b.txt"), []byte("feature\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature change")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	gitCmd(t, dir, "checkout", "main")
+	os.WriteFile(filepath.Join(dir, "c.txt"), []byte("main\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "main advance")
+	gitCmd(t, dir, "push", "origin", "main")
+	gitCmd(t, dir, "checkout", "feature")
+
+	os.WriteFile(filepath.Join(dir, "b.txt"), []byte("dirty\n"), 0o644)
+	rebaseMergeDir := gitCmd(t, dir, "rev-parse", "--git-path", "rebase-merge")
+	if err := os.MkdirAll(rebaseMergeDir, 0o755); err != nil {
+		t.Fatalf("mkdir rebase metadata: %v", err)
+	}
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Repo.UpstreamURL = upstream
+
+	step := &RebaseStep{}
+	outcome, err := step.Execute(sctx)
+	if err == nil {
+		t.Fatal("expected error for non-conflict rebase failure")
+	}
+	if outcome != nil {
+		t.Fatalf("expected no outcome on error, got %#v", outcome)
+	}
+	if len(ag.calls) != 0 {
+		t.Fatalf("expected 0 agent calls, got %d", len(ag.calls))
+	}
+	if strings.Contains(gitStatusPorcelain(t, dir), "UU") {
+		t.Fatal("expected no unmerged files")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add config and pipeline support for rebase auto-fix so rebase conflicts can flow into targeted fix rounds when explicitly enabled.
- Preserve conflicted-file findings and tighten conflict classification so follow-up fixes stay scoped to the active rebase target and non-conflict rebase stops are not misrouted.
- Keep manual approval as the default safety posture for rebase handling while retaining the new auto-fix path for opt-in use.

✅ low: The change is narrowly scoped to rebase conflict handling and config plumbing, and the updated behavior is covered by targeted tests without exposing clear merge-blocking regressions in the changed code.

## Pipeline

Updates from `git push no-mistakes`

✅ **Rebase** - passed
🔧 **Review** - 2 issues found → auto-fixed
✅ **Test** - passed
✅ **Lint** - passed

<details>
<summary>Review details</summary>

**Round 1** - found 2 warnings
- ⚠️ `internal/pipeline/steps/rebase.go:65` - The approval payload now contains only a summary and no per-file findings. That removes the conflicted file list from the UI and from `PreviousFindings`, so a later rebase fix run no longer gets concrete file targets unless the agent rediscovers them itself.
- ⚠️ `internal/pipeline/steps/rebase.go:101` - `rebaseInProgress` is now the only signal used to classify a failed rebase as a conflict. Git also keeps a rebase in progress for non-conflict stops such as empty commits or edit/exec pauses, so those failures will be mislabeled as merge conflicts and routed into the auto-fix flow with the wrong remediation.

**Round 2** (auto-fix) - found 2 warnings
- ⚠️ `internal/config/config.go:235` - `autoFixDefaults` now enables rebase auto-fix by default (`Rebase: 3`), which changes the safety posture from manual approval to agent-driven history rewriting for every repo unless users opt out. If this feature is meant to be available but not automatic, default it to `0` and require explicit opt-in.
- ⚠️ `internal/pipeline/steps/rebase.go:145` - The fix prompt no longer passes the current conflicted file list to the agent. In runs that detect conflicts on multiple rebase targets, `PreviousFindings` can include files from other targets, so the active fix round is now less scoped and can push the agent toward editing files that are not part of the current rebase. Pass `rebaseConflictFiles(...)` into the prompt again to keep each round target-specific.

**Round 3** (auto-fix) - found 0 issues

</details>
