### PR TITLE
fix: gate human review and make push banner ASCII-safe

### DIFF
--- a/internal/git/hook.go
+++ b/internal/git/hook.go
@@ -33,13 +33,13 @@ while read oldrev newrev refname; do
     --new "$newrev" >/dev/null 2>&1 || true
 done
 cat >&2 <<'BANNER'
-` + "\033[36m" + `_  _ ____    _  _ _ ____ ___ ____ _  _ ____ ____
+_  _ ____    _  _ _ ____ ___ ____ _  _ ____ ____
 |\ | |  |    |\/| | [__   |  |__| |_/  |___ [__
-| \| |__|    |  | | ___]  |  |  | | \_ |___ ___]` + "\033[0m" + `
+| \| |__|    |  | | ___]  |  |  | | \_ |___ ___]
 
-  ` + "\033[32m" + `✓` + "\033[0m" + ` Pipeline started
+  * Pipeline started
 
-  ` + "\033[90m" + `Run` + "\033[0m" + ` ` + "\033[1m" + `no-mistakes` + "\033[0m" + ` ` + "\033[90m" + `to review.` + "\033[0m" + `
+  Run no-mistakes to review.
 BANNER
 exit 0
 `

--- a/internal/git/hook.go
+++ b/internal/git/hook.go
@@ -32,7 +32,15 @@ while read oldrev newrev refname; do
     --old "$oldrev" \
     --new "$newrev" >/dev/null 2>&1 || true
 done
-printf '%s\n' 'Pipeline started. Run no-mistakes to review.' >&2
+cat >&2 <<'BANNER'
+` + "\033[36m" + `_  _ ____    _  _ _ ____ ___ ____ _  _ ____ ____
+|\ | |  |    |\/| | [__   |  |__| |_/  |___ [__
+| \| |__|    |  | | ___]  |  |  | | \_ |___ ___]` + "\033[0m" + `
+
+  ` + "\033[32m" + `✓` + "\033[0m" + ` Pipeline started
+
+  ` + "\033[90m" + `Run` + "\033[0m" + ` ` + "\033[1m" + `no-mistakes` + "\033[0m" + ` ` + "\033[90m" + `to review.` + "\033[0m" + `
+BANNER
 exit 0
 `
 }

--- a/internal/git/hook_test.go
+++ b/internal/git/hook_test.go
@@ -45,12 +45,9 @@ func TestPostReceiveHookScript(t *testing.T) {
 		t.Fatal("hook should suppress notifier output so pushes stay clean")
 	}
 
-	// should print plain user-facing message to stderr
+	// should print styled banner with ASCII art to stderr
 	if !strings.Contains(script, ">&2") {
 		t.Fatal("hook should print message to stderr")
-	}
-	if strings.Contains(script, "\033[") {
-		t.Fatal("hook should not include ANSI escape sequences")
 	}
 	if !strings.Contains(script, "Pipeline started") {
 		t.Fatal("hook should print pipeline started message")
@@ -58,8 +55,8 @@ func TestPostReceiveHookScript(t *testing.T) {
 	if !strings.Contains(script, "no-mistakes") {
 		t.Fatal("hook should mention the command name")
 	}
-	if strings.Contains(script, "|__| |_/") {
-		t.Fatal("hook should not contain ASCII art banner")
+	if !strings.Contains(script, "|__| |_/") {
+		t.Fatal("hook should contain ASCII art banner")
 	}
 
 	// should exit 0 (never block push)

--- a/internal/git/hook_test.go
+++ b/internal/git/hook_test.go
@@ -45,7 +45,7 @@ func TestPostReceiveHookScript(t *testing.T) {
 		t.Fatal("hook should suppress notifier output so pushes stay clean")
 	}
 
-	// should print styled banner with ASCII art to stderr
+	// should print plain ASCII banner to stderr
 	if !strings.Contains(script, ">&2") {
 		t.Fatal("hook should print message to stderr")
 	}
@@ -57,6 +57,12 @@ func TestPostReceiveHookScript(t *testing.T) {
 	}
 	if !strings.Contains(script, "|__| |_/") {
 		t.Fatal("hook should contain ASCII art banner")
+	}
+	if strings.Contains(script, "\033[") {
+		t.Fatal("hook banner should not include ANSI escapes")
+	}
+	if strings.Contains(script, "✓") {
+		t.Fatal("hook banner should stay ASCII-only")
 	}
 
 	// should exit 0 (never block push)

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -219,25 +219,33 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			e.emitRunEvent(ipc.EventRunUpdated, run, repo)
 		}
 
-		if !outcome.NeedsApproval {
-			// Step completed without needing approval
-			break
+		// Check if auto-fix should be attempted.
+		// Only auto-fix findings that don't require human review.
+		// This runs before the NeedsApproval check so that all severity
+		// levels (including "info") get a chance at automatic fixing.
+		if outcome.AutoFixable && autoFixLimit > 0 && autoFixAttempts < autoFixLimit {
+			fixableFindings := autoFixableFindingsJSON(outcome.Findings)
+			if fixableFindings != "" {
+				autoFixAttempts++
+				slog.Info("auto-fixing step", "step", stepName, "attempt", autoFixAttempts, "max", autoFixLimit)
+				executionMS += time.Since(phaseStart).Milliseconds()
+				if dbErr := e.db.UpdateStepStatus(sr.ID, types.StepStatusFixing); dbErr != nil {
+					slog.Warn("failed to update step status in db", "step", stepName, "status", "fixing", "error", dbErr)
+				}
+				e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFixing), "", "", "", nil)
+				phaseStart = time.Now()
+				sctx.Fixing = true
+				sctx.PreviousFindings = fixableFindings
+				nextTrigger = "auto_fix"
+				continue
+			}
 		}
 
-		// Check if auto-fix should be attempted
-		if outcome.AutoFixable && autoFixLimit > 0 && autoFixAttempts < autoFixLimit {
-			autoFixAttempts++
-			slog.Info("auto-fixing step", "step", stepName, "attempt", autoFixAttempts, "max", autoFixLimit)
-			executionMS += time.Since(phaseStart).Milliseconds()
-			if dbErr := e.db.UpdateStepStatus(sr.ID, types.StepStatusFixing); dbErr != nil {
-				slog.Warn("failed to update step status in db", "step", stepName, "status", "fixing", "error", dbErr)
-			}
-			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFixing), "", "", "", nil)
-			phaseStart = time.Now()
-			sctx.Fixing = true
-			sctx.PreviousFindings = outcome.Findings
-			nextTrigger = "auto_fix"
-			continue
+		if !outcome.NeedsApproval {
+			// Step completed without needing approval.
+			// Any remaining info-only or human-review-only findings
+			// are acceptable and don't block the pipeline.
+			break
 		}
 
 		// Freeze execution timer before entering approval wait.

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -241,7 +241,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			}
 		}
 
-		if !outcome.NeedsApproval {
+		if !outcome.NeedsApproval && !hasHumanReviewFindingsJSON(outcome.Findings) {
 			// Step completed without needing approval.
 			// Any remaining info-only or human-review-only findings
 			// are acceptable and don't block the pipeline.

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -1965,6 +1965,160 @@ func TestExecutor_DoesNotAutoFixManualApprovalOutcome(t *testing.T) {
 	}
 }
 
+func TestExecutor_AutoFixInfoFindings(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	cfg := &config.Config{AutoFix: config.AutoFix{Review: 3}}
+
+	callCount := 0
+	step := &adaptiveCallStep{
+		name: types.StepReview,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			callCount++
+			if callCount == 1 {
+				// Info findings that are auto-fixable (not blocking, but fixable)
+				return &StepOutcome{
+					NeedsApproval: false,
+					AutoFixable:   true,
+					Findings:      `{"findings":[{"severity":"info","description":"could simplify"}],"summary":"1 suggestion"}`,
+				}, nil
+			}
+			// After auto-fix, step passes clean
+			if !sctx.Fixing {
+				t.Error("expected Fixing to be true on auto-fix re-execution")
+			}
+			return &StepOutcome{}, nil
+		},
+	}
+
+	exec := NewExecutor(database, p, cfg, nil, []Step{step}, nil)
+
+	err := exec.Execute(context.Background(), run, repo, workDir)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if callCount != 2 {
+		t.Errorf("expected 2 calls (initial + auto-fix), got %d", callCount)
+	}
+}
+
+func TestExecutor_AutoFixSkipsHumanReviewFindings(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	cfg := &config.Config{AutoFix: config.AutoFix{Review: 3}}
+
+	callCount := 0
+	step := &adaptiveCallStep{
+		name: types.StepReview,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			callCount++
+			// All findings require human review - auto-fix should not trigger
+			return &StepOutcome{
+				NeedsApproval: true,
+				AutoFixable:   true,
+				Findings:      `{"findings":[{"severity":"warning","description":"design choice","requires_human_review":true}],"summary":"1 issue"}`,
+			}, nil
+		},
+	}
+
+	exec := NewExecutor(database, p, cfg, nil, []Step{step}, nil)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- exec.Execute(context.Background(), run, repo, workDir)
+	}()
+
+	// Should go straight to user approval without auto-fix
+	waitForStepStatus(t, database, run.ID, types.StepReview, types.StepStatusAwaitingApproval)
+
+	if callCount != 1 {
+		t.Fatalf("expected 1 call (no auto-fix for human-review findings), got %d", callCount)
+	}
+
+	exec.Respond(types.StepReview, types.ActionApprove, nil)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("executor timed out")
+	}
+}
+
+func TestExecutor_AutoFixMixedFindings(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	cfg := &config.Config{AutoFix: config.AutoFix{Review: 3}}
+
+	callCount := 0
+	step := &adaptiveCallStep{
+		name: types.StepReview,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			callCount++
+			if callCount == 1 {
+				// Mix: one auto-fixable, one requires human review
+				return &StepOutcome{
+					NeedsApproval: true,
+					AutoFixable:   true,
+					Findings: `{"findings":[
+						{"id":"review-1","severity":"error","description":"bug"},
+						{"id":"review-2","severity":"warning","description":"design choice","requires_human_review":true}
+					],"summary":"2 issues","risk_level":"medium","risk_rationale":"mixed"}`,
+				}, nil
+			}
+			// After auto-fix: verify only fixable finding was sent
+			if sctx.PreviousFindings == "" {
+				t.Error("expected PreviousFindings")
+			}
+			parsed, _ := types.ParseFindingsJSON(sctx.PreviousFindings)
+			if len(parsed.Items) != 1 {
+				t.Errorf("expected 1 fixable finding passed to fix, got %d", len(parsed.Items))
+			}
+			if len(parsed.Items) > 0 && parsed.Items[0].Description != "bug" {
+				t.Errorf("expected fixable finding 'bug', got %q", parsed.Items[0].Description)
+			}
+			// Return only the human-review finding remaining
+			return &StepOutcome{
+				NeedsApproval: true,
+				AutoFixable:   true,
+				Findings:      `{"findings":[{"id":"review-2","severity":"warning","description":"design choice","requires_human_review":true}],"summary":"1 issue"}`,
+			}, nil
+		},
+	}
+
+	exec := NewExecutor(database, p, cfg, nil, []Step{step}, nil)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- exec.Execute(context.Background(), run, repo, workDir)
+	}()
+
+	// After auto-fixing the bug, only human-review finding remains.
+	// No more fixable findings, so falls through to user approval.
+	waitForStepStatus(t, database, run.ID, types.StepReview, types.StepStatusFixReview)
+
+	if callCount != 2 {
+		t.Errorf("expected 2 calls (initial + 1 auto-fix), got %d", callCount)
+	}
+
+	exec.Respond(types.StepReview, types.ActionApprove, nil)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("executor timed out")
+	}
+}
+
 // --- helper types ---
 
 // adaptiveCallStep allows custom Execute logic via a function.

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -2050,6 +2050,42 @@ func TestExecutor_AutoFixSkipsHumanReviewFindings(t *testing.T) {
 	}
 }
 
+func TestExecutor_HumanReviewFindingsRequireApprovalWithoutNeedsApprovalFlag(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	step := &adaptiveCallStep{
+		name: types.StepReview,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			return &StepOutcome{
+				NeedsApproval: false,
+				AutoFixable:   true,
+				Findings:      `{"findings":[{"severity":"info","description":"design choice","requires_human_review":true}],"summary":"1 issue"}`,
+			}, nil
+		},
+	}
+
+	exec := NewExecutor(database, p, &config.Config{AutoFix: config.AutoFix{Review: 3}}, nil, []Step{step}, nil)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- exec.Execute(context.Background(), run, repo, workDir)
+	}()
+
+	waitForStepStatus(t, database, run.ID, types.StepReview, types.StepStatusAwaitingApproval)
+
+	exec.Respond(types.StepReview, types.ActionApprove, nil)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("executor timed out")
+	}
+}
+
 func TestExecutor_AutoFixMixedFindings(t *testing.T) {
 	database, p, run, repo := setupTest(t)
 	workDir := t.TempDir()

--- a/internal/pipeline/findings.go
+++ b/internal/pipeline/findings.go
@@ -198,6 +198,17 @@ func autoFixableFindingsJSON(raw string) string {
 	return fixableRaw
 }
 
+func hasHumanReviewFindingsJSON(raw string) bool {
+	if raw == "" {
+		return false
+	}
+	findings, err := types.ParseFindingsJSON(raw)
+	if err != nil {
+		return false
+	}
+	return types.HasHumanReviewFindings(findings)
+}
+
 func filterFindingsJSON(raw string, ids []string) string {
 	if raw == "" || len(ids) == 0 {
 		return raw

--- a/internal/pipeline/findings.go
+++ b/internal/pipeline/findings.go
@@ -4,6 +4,7 @@ import "github.com/kunchenguid/no-mistakes/internal/types"
 
 func findingKey(item types.Finding) types.Finding {
 	item.ID = ""
+	item.RequiresHumanReview = false
 	return item
 }
 
@@ -176,6 +177,25 @@ func retainMatchingFindingsJSON(existingRaw, keepRaw string) string {
 		return ""
 	}
 	return filteredRaw
+}
+
+func autoFixableFindingsJSON(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	findings, err := types.ParseFindingsJSON(raw)
+	if err != nil {
+		return raw
+	}
+	fixable := types.AutoFixableFindings(findings)
+	if len(fixable.Items) == 0 {
+		return ""
+	}
+	fixableRaw, err := types.MarshalFindingsJSON(fixable)
+	if err != nil {
+		return raw
+	}
+	return fixableRaw
 }
 
 func filterFindingsJSON(raw string, ids []string) string {

--- a/internal/pipeline/findings_test.go
+++ b/internal/pipeline/findings_test.go
@@ -74,6 +74,37 @@ func TestRetainMatchingFindingsJSON_DoesNotKeepDistinctDuplicateLines(t *testing
 	}
 }
 
+func TestAutoFixableFindingsJSON_FiltersHumanReview(t *testing.T) {
+	raw := `{"findings":[{"id":"review-1","severity":"error","description":"bug"},{"id":"review-2","severity":"warning","description":"design choice","requires_human_review":true},{"id":"review-3","severity":"warning","description":"missing check"}],"risk_level":"medium","risk_rationale":"Mixed."}`
+
+	fixableRaw := autoFixableFindingsJSON(raw)
+	fixable, err := types.ParseFindingsJSON(fixableRaw)
+	if err != nil {
+		t.Fatalf("parse auto-fixable findings: %v", err)
+	}
+	if len(fixable.Items) != 2 {
+		t.Fatalf("expected 2 findings, got %d", len(fixable.Items))
+	}
+	if fixable.Items[0].ID != "review-1" || fixable.Items[1].ID != "review-3" {
+		t.Fatalf("unexpected findings: %#v", fixable.Items)
+	}
+}
+
+func TestAutoFixableFindingsJSON_AllHumanReview(t *testing.T) {
+	raw := `{"findings":[{"id":"review-1","severity":"warning","description":"choice","requires_human_review":true}],"risk_level":"high","risk_rationale":"Needs review."}`
+
+	fixableRaw := autoFixableFindingsJSON(raw)
+	if fixableRaw != "" {
+		t.Fatalf("expected empty string for all-human-review findings, got %q", fixableRaw)
+	}
+}
+
+func TestAutoFixableFindingsJSON_EmptyInput(t *testing.T) {
+	if got := autoFixableFindingsJSON(""); got != "" {
+		t.Fatalf("expected empty string for empty input, got %q", got)
+	}
+}
+
 func TestMergeFindingsJSON_DeduplicatesShiftedUniqueDismissedFinding(t *testing.T) {
 	existingRaw := `{"findings":[{"id":"dismissed-1","severity":"warning","file":"internal/pipeline/findings.go","line":42,"description":"still unresolved"}],"summary":"1 finding"}`
 	additionalRaw := `{"findings":[{"id":"dismissed-2","severity":"warning","file":"internal/pipeline/findings.go","line":57,"description":"still unresolved"}],"summary":"1 finding"}`

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -197,7 +197,8 @@ var reviewFindingsSchema = json.RawMessage(`{
 					"severity": {"type": "string", "enum": ["error", "warning", "info"]},
 					"file": {"type": "string"},
 					"line": {"type": "integer"},
-					"description": {"type": "string"}
+					"description": {"type": "string"},
+					"requires_human_review": {"type": "boolean"}
 				},
 				"required": ["severity", "description"]
 			}

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -140,7 +140,8 @@ Context:
 Task:
 - Read the relevant history and diff yourself.
 - focus only on changed code.
-- Analyze for bugs, risks, simplification opportunities, and documentation gaps.
+- Analyze for bugs, risks, code simplification opportunities, and documentation gaps.
+- "Simplification" means reducing code complexity through non-functional refactoring (e.g. deduplication, clearer control flow). It does NOT mean removing features, changing product behavior, or stripping intentional user-facing output.
 - Treat security issues, performance regressions, breaking changes, and insufficient error handling as risks.
 
 Rules:
@@ -150,6 +151,7 @@ Rules:
 - Only comment on things that genuinely matter.
 - Do NOT report styling, formatting, linting, compilation, or type-checking issues.
 - If the change is clean, return an empty findings array.
+- Set requires_human_review to true ONLY when the finding questions an intentional design or product decision (e.g. "this feature/output/behavior seems unnecessary"). The bar is high - most findings about correctness, error handling, security, performance, and mechanical code quality should be false. When in doubt, default to false.
 
 Risk assessment (after listing all findings):
 - Set risk_level to "low" if the change is well-bounded, mostly cosmetic, or straightforward with little ambiguity.
@@ -189,7 +191,7 @@ Risk assessment (after listing all findings):
 
 	return &pipeline.StepOutcome{
 		NeedsApproval: needsApproval,
-		AutoFixable:   needsApproval,
+		AutoFixable:   len(findings.Items) > 0,
 		Findings:      string(findingsJSON),
 	}, nil
 }

--- a/internal/types/findings.go
+++ b/internal/types/findings.go
@@ -107,6 +107,15 @@ func AutoFixableFindings(findings Findings) Findings {
 	return result
 }
 
+func HasHumanReviewFindings(findings Findings) bool {
+	for _, item := range findings.Items {
+		if item.RequiresHumanReview {
+			return true
+		}
+	}
+	return false
+}
+
 func summarizeSelectedFindings(count int) string {
 	switch count {
 	case 0:

--- a/internal/types/findings.go
+++ b/internal/types/findings.go
@@ -7,11 +7,12 @@ import (
 
 // Finding represents a single review, test, lint, or PR comment finding.
 type Finding struct {
-	ID          string `json:"id,omitempty"`
-	Severity    string `json:"severity"`
-	File        string `json:"file,omitempty"`
-	Line        int    `json:"line,omitempty"`
-	Description string `json:"description"`
+	ID                  string `json:"id,omitempty"`
+	Severity            string `json:"severity"`
+	File                string `json:"file,omitempty"`
+	Line                int    `json:"line,omitempty"`
+	Description         string `json:"description"`
+	RequiresHumanReview bool   `json:"requires_human_review,omitempty"`
 }
 
 // Findings is the structured findings payload exchanged across pipeline, IPC, and TUI.
@@ -87,6 +88,19 @@ func ExcludeFindings(findings Findings, ids []string) Findings {
 	result := Findings{Summary: findings.Summary, RiskLevel: findings.RiskLevel, RiskRationale: findings.RiskRationale}
 	for _, item := range findings.Items {
 		if !excluded[item.ID] {
+			result.Items = append(result.Items, item)
+		}
+	}
+	return result
+}
+
+// AutoFixableFindings returns a new Findings containing only items where
+// RequiresHumanReview is false. These are safe for automatic fixing without
+// user involvement.
+func AutoFixableFindings(findings Findings) Findings {
+	result := Findings{Summary: findings.Summary, RiskLevel: findings.RiskLevel, RiskRationale: findings.RiskRationale}
+	for _, item := range findings.Items {
+		if !item.RequiresHumanReview {
 			result.Items = append(result.Items, item)
 		}
 	}

--- a/internal/types/findings_test.go
+++ b/internal/types/findings_test.go
@@ -124,3 +124,66 @@ func TestFilterFindings_EmptyIDs(t *testing.T) {
 		t.Errorf("RiskLevel = %q, want %q", filtered.RiskLevel, "low")
 	}
 }
+
+func TestParseFindingsJSON_RequiresHumanReview(t *testing.T) {
+	raw := `{"findings":[{"severity":"warning","description":"design choice","requires_human_review":true},{"severity":"error","description":"bug"}],"risk_level":"medium","risk_rationale":"Mixed."}`
+	f, err := ParseFindingsJSON(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Items) != 2 {
+		t.Fatalf("Items count = %d, want 2", len(f.Items))
+	}
+	if !f.Items[0].RequiresHumanReview {
+		t.Error("Items[0].RequiresHumanReview = false, want true")
+	}
+	if f.Items[1].RequiresHumanReview {
+		t.Error("Items[1].RequiresHumanReview = true, want false")
+	}
+}
+
+func TestAutoFixableFindings_FiltersOutHumanReview(t *testing.T) {
+	f := Findings{
+		Items: []Finding{
+			{ID: "f1", Severity: "error", Description: "bug", RequiresHumanReview: false},
+			{ID: "f2", Severity: "warning", Description: "design choice", RequiresHumanReview: true},
+			{ID: "f3", Severity: "warning", Description: "missing check", RequiresHumanReview: false},
+		},
+		RiskLevel: "medium",
+	}
+	fixable := AutoFixableFindings(f)
+	if len(fixable.Items) != 2 {
+		t.Fatalf("Items count = %d, want 2", len(fixable.Items))
+	}
+	if fixable.Items[0].ID != "f1" {
+		t.Errorf("Items[0].ID = %q, want %q", fixable.Items[0].ID, "f1")
+	}
+	if fixable.Items[1].ID != "f3" {
+		t.Errorf("Items[1].ID = %q, want %q", fixable.Items[1].ID, "f3")
+	}
+}
+
+func TestAutoFixableFindings_AllHumanReview(t *testing.T) {
+	f := Findings{
+		Items: []Finding{
+			{ID: "f1", Severity: "warning", Description: "choice", RequiresHumanReview: true},
+		},
+	}
+	fixable := AutoFixableFindings(f)
+	if len(fixable.Items) != 0 {
+		t.Errorf("Items count = %d, want 0", len(fixable.Items))
+	}
+}
+
+func TestAutoFixableFindings_NoneHumanReview(t *testing.T) {
+	f := Findings{
+		Items: []Finding{
+			{ID: "f1", Severity: "error", Description: "bug"},
+			{ID: "f2", Severity: "warning", Description: "issue"},
+		},
+	}
+	fixable := AutoFixableFindings(f)
+	if len(fixable.Items) != 2 {
+		t.Errorf("Items count = %d, want 2", len(fixable.Items))
+	}
+}


### PR DESCRIPTION
## Summary
- Address review follow-ups from `git push no-mistakes` by treating remaining `requires_human_review` findings as approval-required so the pipeline pauses instead of completing without user review.
- Replace the push success banner with a plain ASCII-safe message so post-receive output stays portable in non-TTY and non-UTF-8 environments.
- Add findings and executor coverage to lock in the human-review gating behavior and the updated push messaging path.

✅ low: The change is narrowly scoped to review finding metadata, approval gating, and a user-facing hook banner, and the updated behavior is covered by focused tests without obvious regressions in the changed code.

## Pipeline

Updates from `git push no-mistakes`

✅ **Rebase** - passed
🔧 **Review** - 2 issues found → auto-fixed
✅ **Test** - passed
✅ **Lint** - passed

<details>
<summary>Review details</summary>

**Round 1** - found 2 issues (1 error, 1 warning)
- 🚨 `internal/pipeline/executor.go:244` - `requires_human_review` is not wired into approval gating, so an `info` review finding marked for human review is filtered out of auto-fix and then falls through this `!outcome.NeedsApproval` branch, completing the step without ever pausing for the user. Treat any remaining `requires_human_review` finding as approval-required before breaking.
- ⚠️ `internal/git/hook.go:40` - The new push banner is not actually ASCII-safe: it prints a Unicode checkmark and raw ANSI color escapes unconditionally, which can render as mojibake or noisy escape bytes in non-UTF-8/non-TTY push environments. If this message needs to be portable, keep it plain ASCII or gate the styled banner on TTY support.

**Round 2** (auto-fix) - found 0 issues

</details>
