### PR TITLE
fix(pr): improve risk summary output and remove hardcoded repo link

### DIFF
--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -258,7 +258,7 @@ Diff stat:
 					content.Title = "chore: " + content.Title
 				}
 				if riskLine != "" {
-					content.Body += "\n\n" + riskLine
+					content.Body += "\n\n## Risk Assessment\n\n" + riskLine
 				}
 				content.Body = appendPipelineSection(content.Body, pipelineMD)
 				return content, nil
@@ -324,7 +324,7 @@ func fallbackPRContent(branch, commitLog, pipelineMD, riskLine string) prContent
 		body = fmt.Sprintf("## Summary\n\n- %s", title)
 	}
 	if riskLine != "" {
-		body += "\n\n" + riskLine
+		body += "\n\n## Risk Assessment\n\n" + riskLine
 	}
 	body = appendPipelineSection(body, pipelineMD)
 	return prContent{

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -45,7 +45,7 @@ func BuildPipelineSummary(steps []*db.StepResult, rounds map[string][]*db.StepRo
 	}
 
 	var b strings.Builder
-	b.WriteString("## Pipeline\n\nUpdates from `git push no-mistakes`\n\n")
+	b.WriteString("## Pipeline\n\nUpdates from [`git push no-mistakes`](https://github.com/kunchenguid/no-mistakes)\n\n")
 	for _, line := range statusLines {
 		b.WriteString(line)
 		b.WriteString("\n")
@@ -190,12 +190,20 @@ func extractRiskLine(steps []*db.StepResult, rounds map[string][]*db.StepRound) 
 		}
 
 		emoji := riskEmoji(src.RiskLevel)
+		label := capitalizeRisk(src.RiskLevel)
 		if src.RiskRationale != "" {
-			return fmt.Sprintf("%s %s: %s", emoji, src.RiskLevel, src.RiskRationale)
+			return fmt.Sprintf("%s %s: %s", emoji, label, src.RiskRationale)
 		}
-		return fmt.Sprintf("%s %s", emoji, src.RiskLevel)
+		return fmt.Sprintf("%s %s", emoji, label)
 	}
 	return ""
+}
+
+func capitalizeRisk(level string) string {
+	if level == "" {
+		return level
+	}
+	return strings.ToUpper(level[:1]) + level[1:]
 }
 
 func riskEmoji(level string) string {

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -45,7 +45,7 @@ func BuildPipelineSummary(steps []*db.StepResult, rounds map[string][]*db.StepRo
 	}
 
 	var b strings.Builder
-	b.WriteString("## Pipeline\n\nUpdates from [`git push no-mistakes`](https://github.com/kunchenguid/no-mistakes)\n\n")
+	b.WriteString("## Pipeline\n\nUpdates from `git push no-mistakes`\n\n")
 	for _, line := range statusLines {
 		b.WriteString(line)
 		b.WriteString("\n")

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -24,7 +24,7 @@ func TestBuildPipelineSummary_AllClean(t *testing.T) {
 	if !strings.Contains(md, "## Pipeline") {
 		t.Error("missing Pipeline heading")
 	}
-	if !strings.Contains(md, "Updates from `git push no-mistakes`") {
+	if !strings.Contains(md, "Updates from [`git push no-mistakes`](https://github.com/kunchenguid/no-mistakes)") {
 		t.Error("missing pipeline tagline")
 	}
 	// Clean steps should show checkmark
@@ -53,8 +53,8 @@ func TestBuildPipelineSummary_ReviewWithRisk(t *testing.T) {
 	if !strings.Contains(md, "⚠️ **Review** - 1 warning") {
 		t.Errorf("expected findings count in review line, got:\n%s", md)
 	}
-	if !strings.Contains(risk, "low") || !strings.Contains(risk, "straightforward refactor") {
-		t.Errorf("expected risk line with level and rationale, got: %q", risk)
+	if !strings.Contains(risk, "Low") || !strings.Contains(risk, "straightforward refactor") {
+		t.Errorf("expected risk line with capitalized level and rationale, got: %q", risk)
 	}
 	if !strings.Contains(risk, "✅") {
 		t.Errorf("expected checkmark emoji for low risk, got: %q", risk)
@@ -241,6 +241,9 @@ func TestBuildPipelineSummary_ReviewUsesFinalCleanState(t *testing.T) {
 	if !strings.Contains(risk, "follow-up fixes reduced risk") {
 		t.Errorf("expected final rationale in risk, got: %q", risk)
 	}
+	if !strings.Contains(risk, "Low") {
+		t.Errorf("expected capitalized Low in risk, got: %q", risk)
+	}
 	if !strings.Contains(risk, "✅") {
 		t.Errorf("expected checkmark for low risk, got: %q", risk)
 	}
@@ -265,8 +268,8 @@ func TestBuildPipelineSummary_ReviewShowsWarningForUnresolvedRiskWithoutFindings
 	if strings.Contains(md, "✅ **Review** - passed") {
 		t.Errorf("did not expect passed review status for medium risk, got:\n%s", md)
 	}
-	if !strings.Contains(risk, "medium") || !strings.Contains(risk, "touches critical error handling") {
-		t.Errorf("expected risk line with medium level, got: %q", risk)
+	if !strings.Contains(risk, "Medium") || !strings.Contains(risk, "touches critical error handling") {
+		t.Errorf("expected risk line with capitalized medium level, got: %q", risk)
 	}
 	if !strings.Contains(risk, "⚠️") {
 		t.Errorf("expected warning emoji for medium risk, got: %q", risk)
@@ -363,8 +366,8 @@ func TestBuildPipelineSummary_FindingSeverityEmoji(t *testing.T) {
 	if !strings.Contains(md, "ℹ️") {
 		t.Errorf("expected info emoji in details, got:\n%s", md)
 	}
-	if !strings.Contains(risk, "high") || !strings.Contains(risk, "critical bug found") {
-		t.Errorf("expected risk line with high level, got: %q", risk)
+	if !strings.Contains(risk, "High") || !strings.Contains(risk, "critical bug found") {
+		t.Errorf("expected risk line with capitalized high level, got: %q", risk)
 	}
 	if !strings.Contains(risk, "🚨") {
 		t.Errorf("expected error emoji for high risk, got: %q", risk)

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -24,8 +24,11 @@ func TestBuildPipelineSummary_AllClean(t *testing.T) {
 	if !strings.Contains(md, "## Pipeline") {
 		t.Error("missing Pipeline heading")
 	}
-	if !strings.Contains(md, "Updates from [`git push no-mistakes`](https://github.com/kunchenguid/no-mistakes)") {
+	if !strings.Contains(md, "Updates from `git push no-mistakes`") {
 		t.Error("missing pipeline tagline")
+	}
+	if strings.Contains(md, "https://github.com/kunchenguid/no-mistakes") {
+		t.Error("did not expect hardcoded repository link in pipeline tagline")
 	}
 	// Clean steps should show checkmark
 	if !strings.Contains(md, "✅") {

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -2179,8 +2179,8 @@ func TestPRStep_CreatesNewPR(t *testing.T) {
 	if !strings.Contains(ghLog, "--title chore: add feature --body") {
 		t.Fatalf("expected fallback PR title to use conventional commit format, got:\n%s", ghLog)
 	}
-	if !strings.Contains(ghLog, "add feature\n\n⚠️ medium: touches critical error handling") {
-		t.Fatalf("expected fallback PR body to append risk note outside summary content, got:\n%s", ghLog)
+	if !strings.Contains(ghLog, "add feature\n\n## Risk Assessment\n\n⚠️ Medium: touches critical error handling") {
+		t.Fatalf("expected fallback PR body to append risk note under Risk Assessment heading, got:\n%s", ghLog)
 	}
 
 	// Verify PR URL was stored
@@ -2239,8 +2239,8 @@ func TestPRStep_UsesAgentGeneratedTitleAndBody(t *testing.T) {
 	if !strings.Contains(ghLog, "keep branch status readable") {
 		t.Fatalf("expected generated PR body in gh call, got:\n%s", ghLog)
 	}
-	if !strings.Contains(ghLog, "fix footer truncation\n\n⚠️ medium: touches critical error handling") {
-		t.Fatalf("expected risk note to be separated from generated summary list, got:\n%s", ghLog)
+	if !strings.Contains(ghLog, "fix footer truncation\n\n## Risk Assessment\n\n⚠️ Medium: touches critical error handling") {
+		t.Fatalf("expected risk note under Risk Assessment heading, got:\n%s", ghLog)
 	}
 	if strings.Contains(ghLog, "--title feature") {
 		t.Fatalf("expected PR title to avoid raw branch name, got:\n%s", ghLog)


### PR DESCRIPTION
## Summary
- Add a risk assessment section to generated PR summaries and capitalize risk levels so reviewer-facing output is clearer and easier to scan.
- Remove the hardcoded repository link from the review update text so PR bodies do not point at the wrong repo in forks, private repos, or other environments.

## Risk Assessment

✅ Low: The change is narrowly scoped to PR markdown formatting and label capitalization, and the updated behavior is covered by targeted tests that passed.

## Pipeline

Updates from [`git push no-mistakes`](https://github.com/kunchenguid/no-mistakes)

✅ **Rebase** - passed
🔧 **Review** - 1 issue found → auto-fixed
✅ **Test** - passed
✅ **Lint** - passed

<details>
<summary>Review details</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/pipeline/steps/prsummary.go:48` - The new pipeline tagline hardcodes `https://github.com/kunchenguid/no-mistakes` into every generated PR body, so runs in forks, private repos, or non-GitHub environments will now point reviewers at the tool's source repo instead of the repository under review. Keep this text plain or derive the correct repo URL from runtime context before linking it.

**Round 2** (auto-fix) - found 0 issues

</details>
