### PR TITLE
refactor(ci): rename babysit step with compatibility aliases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ Safest local verification sequence after non-trivial changes:
 - `cmd/no-mistakes`: process entrypoint
 - `internal/cli`: cobra commands and CLI wiring
 - `internal/daemon`: background daemon and run management
-- `internal/pipeline` and `internal/pipeline/steps`: orchestration plus review/test/lint/push/PR/babysit steps
+- `internal/pipeline` and `internal/pipeline/steps`: orchestration plus review/test/lint/push/PR/CI steps
 - `internal/agent`: Claude, Codex, Rovo Dev, and OpenCode integrations
 - `internal/git`, `internal/ipc`, `internal/config`, `internal/db`, `internal/paths`, `internal/types`: shared infrastructure
 - `internal/tui`: terminal UI

--- a/README.md
+++ b/README.md
@@ -175,8 +175,16 @@ agent_path_override:
   rovodev: /usr/local/bin/acli
   opencode: /usr/local/bin/opencode
 
-# How long the CI step polls checks and PR comments.
+# How long the CI step monitors GitHub checks before timing out.
 ci_timeout: "4h"
+
+# Optional auto-fix attempt limits per step (0 = require approval).
+# auto_fix:
+#   rebase: 0
+#   lint: 3
+#   test: 3
+#   review: 3
+#   ci: 3
 
 # debug | info | warn | error
 log_level: "info"
@@ -211,6 +219,7 @@ ignore_patterns:
 - Repo `agent` overrides global `agent`.
 - `commands` and `ignore_patterns` are repo-only.
 - Missing global config defaults to `agent: claude`, `ci_timeout: 4h`, `log_level: info`.
+- `ci_timeout` replaces `babysit_timeout`, and `auto_fix.ci` replaces `auto_fix.babysit`; legacy keys are still accepted for existing configs.
 - `agent_path_override` changes which binary path is launched for a given agent.
 - Default binaries are `claude`, `codex`, `acli` for `rovodev`, and `opencode`.
 - If `commands.test` is empty, the agent detects and runs relevant tests itself.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You already have CI, but it usually wakes up after the branch is upstream. You a
 
 - **Push with intent** - `origin` stays untouched, and `no-mistakes` becomes the explicit path for gated pushes.
 - **Agent-agnostic** - use `claude`, `codex`, `rovodev`, or `opencode`, with per-repo overrides if different codebases want different tools.
-- **Human stays in charge** - review, test, lint, PR, and babysit steps can pause for approval instead of auto-shipping surprises.
+- **Human stays in charge** - review, test, lint, PR, and CI steps can pause for approval instead of auto-shipping surprises.
 
 ## Quick Start
 
@@ -83,7 +83,7 @@ make build
 make install
 ```
 
-You will also need `git`, one supported agent binary, and `gh` if you want PR creation and babysitting.
+You will also need `git`, one supported agent binary, and `gh` if you want PR creation and CI monitoring.
 
 To update an existing install in place:
 
@@ -116,7 +116,7 @@ no-mistakes update
        │                                                    │ lint                │
        │                                                    │ push                │
        │                                                    │ pr                  │
-       │                                                    │ babysit             │
+       │                                                    │ ci                  │
        │                                                    └──────────┬──────────┘
        │                                                               │
        └──────────────────────────────────────────────────────────────► │ upstream
@@ -125,7 +125,7 @@ no-mistakes update
 
 - **Named remote** - `origin` is never hijacked. If you want the gate, you push to `no-mistakes` on purpose.
 - **Disposable worktrees** - each run happens in its own detached worktree, so the daemon can inspect and modify safely before pushing upstream.
-- **Fixed pipeline** - this is opinionated on purpose: `review -> test -> lint -> push -> pr -> babysit`.
+- **Fixed pipeline** - this is opinionated on purpose: `review -> test -> lint -> push -> pr -> ci`.
 - **Local state** - metadata lives under `~/.no-mistakes/` by default, or `${NM_HOME}` if you want to relocate it.
 
 ## CLI Reference
@@ -175,8 +175,8 @@ agent_path_override:
   rovodev: /usr/local/bin/acli
   opencode: /usr/local/bin/opencode
 
-# How long the babysit step polls CI and PR comments.
-babysit_timeout: "4h"
+# How long the CI step polls checks and PR comments.
+ci_timeout: "4h"
 
 # debug | info | warn | error
 log_level: "info"
@@ -210,7 +210,7 @@ ignore_patterns:
 
 - Repo `agent` overrides global `agent`.
 - `commands` and `ignore_patterns` are repo-only.
-- Missing global config defaults to `agent: claude`, `babysit_timeout: 4h`, `log_level: info`.
+- Missing global config defaults to `agent: claude`, `ci_timeout: 4h`, `log_level: info`.
 - `agent_path_override` changes which binary path is launched for a given agent.
 - Default binaries are `claude`, `codex`, `acli` for `rovodev`, and `opencode`.
 - If `commands.test` is empty, the agent detects and runs relevant tests itself.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -47,9 +47,9 @@ func newDoctorCmd() *cobra.Command {
 				}
 			}
 
-			// 2. Check gh CLI (optional but useful for PR/babysit steps).
+			// 2. Check gh CLI (optional but useful for PR/CI steps).
 			if _, err := exec.LookPath("gh"); err != nil {
-				warn("gh            ", "not found "+sDim.Render("(optional, needed for PR/babysit)"))
+				warn("gh            ", "not found "+sDim.Render("(optional, needed for PR/CI)"))
 			} else {
 				ok("gh            ", "ok")
 			}

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -56,7 +56,7 @@ func TestDoctorSystemSectionReportsMissingGitAndDataDirFailures(t *testing.T) {
 		"git",
 		"not found",
 		"gh",
-		"optional, needed for PR/babysit",
+		"optional, needed for PR/CI",
 		"data directory",
 		nmHome,
 		"database",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,7 @@ type globalConfigRaw struct {
 	Agent             types.AgentName   `yaml:"agent"`
 	AgentPathOverride map[string]string `yaml:"agent_path_override"`
 	CITimeout         string            `yaml:"ci_timeout"`
+	BabysitTimeout    string            `yaml:"babysit_timeout"`
 	LogLevel          string            `yaml:"log_level"`
 	AutoFix           AutoFixRaw        `yaml:"auto_fix"`
 }
@@ -49,11 +50,12 @@ type Commands struct {
 // AutoFixRaw is the YAML representation of auto-fix config.
 // Pointer fields distinguish "not set" (nil) from "set to 0" (disabled).
 type AutoFixRaw struct {
-	Lint   *int `yaml:"lint"`
-	Test   *int `yaml:"test"`
-	Review *int `yaml:"review"`
-	CI     *int `yaml:"ci"`
-	Rebase *int `yaml:"rebase"`
+	Lint    *int `yaml:"lint"`
+	Test    *int `yaml:"test"`
+	Review  *int `yaml:"review"`
+	CI      *int `yaml:"ci"`
+	Babysit *int `yaml:"babysit"`
+	Rebase  *int `yaml:"rebase"`
 }
 
 // AutoFix holds resolved per-step auto-fix attempt limits.
@@ -172,15 +174,22 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 	if raw.AgentPathOverride != nil {
 		cfg.AgentPathOverride = raw.AgentPathOverride
 	}
-	if raw.CITimeout != "" {
-		d, err := time.ParseDuration(raw.CITimeout)
+	timeoutValue := raw.CITimeout
+	if timeoutValue == "" {
+		timeoutValue = raw.BabysitTimeout
+	}
+	if timeoutValue != "" {
+		d, err := time.ParseDuration(timeoutValue)
 		if err != nil {
-			return nil, fmt.Errorf("parse ci_timeout %q: %w", raw.CITimeout, err)
+			return nil, fmt.Errorf("parse ci_timeout %q: %w", timeoutValue, err)
 		}
 		cfg.CITimeout = d
 	}
 	if raw.LogLevel != "" {
 		cfg.LogLevel = raw.LogLevel
+	}
+	if raw.AutoFix.CI == nil {
+		raw.AutoFix.CI = raw.AutoFix.Babysit
 	}
 	cfg.AutoFix = raw.AutoFix
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -213,6 +213,9 @@ func LoadRepo(dir string) (*RepoConfig, error) {
 	if err := yaml.Unmarshal(data, cfg); err != nil {
 		return nil, fmt.Errorf("parse repo config: %w", err)
 	}
+	if cfg.AutoFix.CI == nil {
+		cfg.AutoFix.CI = cfg.AutoFix.Babysit
+	}
 
 	return cfg, nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,7 +17,7 @@ import (
 type GlobalConfig struct {
 	Agent             types.AgentName   `yaml:"agent"`
 	AgentPathOverride map[string]string `yaml:"agent_path_override"`
-	BabysitTimeout    time.Duration     `yaml:"-"`
+	CITimeout         time.Duration     `yaml:"-"`
 	LogLevel          string            `yaml:"log_level"`
 	AutoFix           AutoFixRaw
 }
@@ -26,7 +26,7 @@ type GlobalConfig struct {
 type globalConfigRaw struct {
 	Agent             types.AgentName   `yaml:"agent"`
 	AgentPathOverride map[string]string `yaml:"agent_path_override"`
-	BabysitTimeout    string            `yaml:"babysit_timeout"`
+	CITimeout         string            `yaml:"ci_timeout"`
 	LogLevel          string            `yaml:"log_level"`
 	AutoFix           AutoFixRaw        `yaml:"auto_fix"`
 }
@@ -49,28 +49,28 @@ type Commands struct {
 // AutoFixRaw is the YAML representation of auto-fix config.
 // Pointer fields distinguish "not set" (nil) from "set to 0" (disabled).
 type AutoFixRaw struct {
-	Lint    *int `yaml:"lint"`
-	Test    *int `yaml:"test"`
-	Review  *int `yaml:"review"`
-	Babysit *int `yaml:"babysit"`
-	Rebase  *int `yaml:"rebase"`
+	Lint   *int `yaml:"lint"`
+	Test   *int `yaml:"test"`
+	Review *int `yaml:"review"`
+	CI     *int `yaml:"ci"`
+	Rebase *int `yaml:"rebase"`
 }
 
 // AutoFix holds resolved per-step auto-fix attempt limits.
 // A value of 0 means auto-fix is disabled (requires manual approval).
 type AutoFix struct {
-	Lint    int
-	Test    int
-	Review  int
-	Babysit int
-	Rebase  int
+	Lint   int
+	Test   int
+	Review int
+	CI     int
+	Rebase int
 }
 
 // Config is the merged result of global + per-repo configuration.
 type Config struct {
 	Agent             types.AgentName
 	AgentPathOverride map[string]string
-	BabysitTimeout    time.Duration
+	CITimeout         time.Duration
 	LogLevel          string
 	Commands          Commands
 	IgnorePatterns    []string
@@ -84,8 +84,8 @@ const defaultConfigYAML = `# no-mistakes global configuration
 # Options: claude, codex, rovodev, opencode
 agent: claude
 
-# Maximum time to babysit a run before timing out
-babysit_timeout: "4h"
+# Maximum time to monitor CI before timing out
+ci_timeout: "4h"
 
 # Log level for daemon output
 # Options: debug, info, warn, error
@@ -102,7 +102,7 @@ auto_fix:
   lint: 3
   test: 3
   review: 3
-  babysit: 3
+  ci: 3
 `
 
 // defaultBinary maps agent names to their default binary names.
@@ -148,9 +148,9 @@ func EnsureDefaultGlobalConfig(path string) {
 // LoadGlobal reads global config from path. Returns defaults if file doesn't exist.
 func LoadGlobal(path string) (*GlobalConfig, error) {
 	cfg := &GlobalConfig{
-		Agent:          types.AgentClaude,
-		BabysitTimeout: 4 * time.Hour,
-		LogLevel:       "info",
+		Agent:     types.AgentClaude,
+		CITimeout: 4 * time.Hour,
+		LogLevel:  "info",
 	}
 
 	data, err := os.ReadFile(path)
@@ -172,12 +172,12 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 	if raw.AgentPathOverride != nil {
 		cfg.AgentPathOverride = raw.AgentPathOverride
 	}
-	if raw.BabysitTimeout != "" {
-		d, err := time.ParseDuration(raw.BabysitTimeout)
+	if raw.CITimeout != "" {
+		d, err := time.ParseDuration(raw.CITimeout)
 		if err != nil {
-			return nil, fmt.Errorf("parse babysit_timeout %q: %w", raw.BabysitTimeout, err)
+			return nil, fmt.Errorf("parse ci_timeout %q: %w", raw.CITimeout, err)
 		}
-		cfg.BabysitTimeout = d
+		cfg.CITimeout = d
 	}
 	if raw.LogLevel != "" {
 		cfg.LogLevel = raw.LogLevel
@@ -228,11 +228,11 @@ func ParseLogLevel(level string) slog.Level {
 // autoFixDefaults returns the default auto-fix configuration.
 func autoFixDefaults() AutoFix {
 	return AutoFix{
-		Lint:    3,
-		Test:    3,
-		Review:  3,
-		Babysit: 3,
-		Rebase:  0,
+		Lint:   3,
+		Test:   3,
+		Review: 3,
+		CI:     3,
+		Rebase: 0,
 	}
 }
 
@@ -247,8 +247,8 @@ func applyAutoFixOverrides(dst *AutoFix, src *AutoFixRaw) {
 	if src.Review != nil {
 		dst.Review = *src.Review
 	}
-	if src.Babysit != nil {
-		dst.Babysit = *src.Babysit
+	if src.CI != nil {
+		dst.CI = *src.CI
 	}
 	if src.Rebase != nil {
 		dst.Rebase = *src.Rebase
@@ -265,8 +265,8 @@ func (c *Config) AutoFixLimit(step types.StepName) int {
 		return c.AutoFix.Test
 	case types.StepReview:
 		return c.AutoFix.Review
-	case types.StepBabysit:
-		return c.AutoFix.Babysit
+	case types.StepCI:
+		return c.AutoFix.CI
 	case types.StepRebase:
 		return c.AutoFix.Rebase
 	default:
@@ -284,7 +284,7 @@ func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 	cfg := &Config{
 		Agent:             global.Agent,
 		AgentPathOverride: global.AgentPathOverride,
-		BabysitTimeout:    global.BabysitTimeout,
+		CITimeout:         global.CITimeout,
 		LogLevel:          global.LogLevel,
 		Commands:          repo.Commands,
 		IgnorePatterns:    repo.IgnorePatterns,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -229,6 +229,41 @@ func TestLoadGlobal_InvalidDuration(t *testing.T) {
 	}
 }
 
+func TestLoadGlobal_LegacyBabysitTimeout(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(`babysit_timeout: "90m"`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadGlobal(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.CITimeout != 90*time.Minute {
+		t.Fatalf("ci_timeout = %v, want %v", cfg.CITimeout, 90*time.Minute)
+	}
+}
+
+func TestLoadGlobal_LegacyAutoFixBabysit(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("auto_fix:\n  babysit: 0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadGlobal(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.AutoFix.CI == nil {
+		t.Fatal("ci auto-fix override was not loaded")
+	}
+	if *cfg.AutoFix.CI != 0 {
+		t.Fatalf("ci auto-fix = %d, want 0", *cfg.AutoFix.CI)
+	}
+}
+
 func TestLoadRepo_Defaults(t *testing.T) {
 	// Non-existent directory or no .no-mistakes.yaml
 	cfg, err := LoadRepo("/nonexistent/dir")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -21,8 +21,8 @@ func TestLoadGlobal_Defaults(t *testing.T) {
 	if cfg.Agent != types.AgentClaude {
 		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentClaude)
 	}
-	if cfg.BabysitTimeout != 4*time.Hour {
-		t.Errorf("babysit_timeout = %v, want %v", cfg.BabysitTimeout, 4*time.Hour)
+	if cfg.CITimeout != 4*time.Hour {
+		t.Errorf("ci_timeout = %v, want %v", cfg.CITimeout, 4*time.Hour)
 	}
 	if cfg.LogLevel != "info" {
 		t.Errorf("log_level = %q, want %q", cfg.LogLevel, "info")
@@ -45,7 +45,7 @@ func TestEnsureDefaultGlobalConfig_CreatesFile(t *testing.T) {
 	content := string(data)
 	for _, want := range []string{
 		"agent: claude",
-		"babysit_timeout:",
+		"ci_timeout:",
 		"log_level: info",
 		"# agent_path_override:",
 	} {
@@ -68,8 +68,8 @@ func TestEnsureDefaultGlobalConfig_CreatedConfigIsLoadable(t *testing.T) {
 	if cfg.Agent != types.AgentClaude {
 		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentClaude)
 	}
-	if cfg.BabysitTimeout != 4*time.Hour {
-		t.Errorf("babysit_timeout = %v, want %v", cfg.BabysitTimeout, 4*time.Hour)
+	if cfg.CITimeout != 4*time.Hour {
+		t.Errorf("ci_timeout = %v, want %v", cfg.CITimeout, 4*time.Hour)
 	}
 	if cfg.LogLevel != "info" {
 		t.Errorf("log_level = %q, want %q", cfg.LogLevel, "info")
@@ -150,7 +150,7 @@ func TestLoadGlobal_FromFile(t *testing.T) {
 agent_path_override:
   claude: /usr/local/bin/claude
   codex: /opt/codex
-babysit_timeout: "2h30m"
+ci_timeout: "2h30m"
 log_level: "debug"
 `
 	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
@@ -164,8 +164,8 @@ log_level: "debug"
 	if cfg.Agent != types.AgentCodex {
 		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentCodex)
 	}
-	if cfg.BabysitTimeout != 2*time.Hour+30*time.Minute {
-		t.Errorf("babysit_timeout = %v, want %v", cfg.BabysitTimeout, 2*time.Hour+30*time.Minute)
+	if cfg.CITimeout != 2*time.Hour+30*time.Minute {
+		t.Errorf("ci_timeout = %v, want %v", cfg.CITimeout, 2*time.Hour+30*time.Minute)
 	}
 	if cfg.LogLevel != "debug" {
 		t.Errorf("log_level = %q, want %q", cfg.LogLevel, "debug")
@@ -195,8 +195,8 @@ func TestLoadGlobal_PartialOverride(t *testing.T) {
 	if cfg.Agent != types.AgentOpenCode {
 		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentOpenCode)
 	}
-	if cfg.BabysitTimeout != 4*time.Hour {
-		t.Errorf("babysit_timeout = %v, want %v (should be default)", cfg.BabysitTimeout, 4*time.Hour)
+	if cfg.CITimeout != 4*time.Hour {
+		t.Errorf("ci_timeout = %v, want %v (should be default)", cfg.CITimeout, 4*time.Hour)
 	}
 	if cfg.LogLevel != "info" {
 		t.Errorf("log_level = %q, want %q (should be default)", cfg.LogLevel, "info")
@@ -219,7 +219,7 @@ func TestLoadGlobal_InvalidYAML(t *testing.T) {
 func TestLoadGlobal_InvalidDuration(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
-	if err := os.WriteFile(path, []byte(`babysit_timeout: "not-a-duration"`), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(`ci_timeout: "not-a-duration"`), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -335,9 +335,9 @@ func TestLoadRepo_InvalidYAML(t *testing.T) {
 
 func TestMerge_GlobalOnly(t *testing.T) {
 	global := &GlobalConfig{
-		Agent:          types.AgentClaude,
-		BabysitTimeout: 4 * time.Hour,
-		LogLevel:       "info",
+		Agent:     types.AgentClaude,
+		CITimeout: 4 * time.Hour,
+		LogLevel:  "info",
 	}
 	repo := &RepoConfig{}
 
@@ -345,8 +345,8 @@ func TestMerge_GlobalOnly(t *testing.T) {
 	if cfg.Agent != types.AgentClaude {
 		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentClaude)
 	}
-	if cfg.BabysitTimeout != 4*time.Hour {
-		t.Errorf("babysit_timeout = %v", cfg.BabysitTimeout)
+	if cfg.CITimeout != 4*time.Hour {
+		t.Errorf("ci_timeout = %v", cfg.CITimeout)
 	}
 }
 
@@ -354,7 +354,7 @@ func TestMerge_RepoOverridesAgent(t *testing.T) {
 	global := &GlobalConfig{
 		Agent:             types.AgentClaude,
 		AgentPathOverride: map[string]string{"claude": "/usr/bin/claude"},
-		BabysitTimeout:    4 * time.Hour,
+		CITimeout:         4 * time.Hour,
 		LogLevel:          "info",
 	}
 	repo := &RepoConfig{
@@ -374,16 +374,16 @@ func TestMerge_RepoOverridesAgent(t *testing.T) {
 	if cfg.Commands.Test != "make test" {
 		t.Errorf("test = %q", cfg.Commands.Test)
 	}
-	if cfg.BabysitTimeout != 4*time.Hour {
-		t.Errorf("babysit_timeout = %v", cfg.BabysitTimeout)
+	if cfg.CITimeout != 4*time.Hour {
+		t.Errorf("ci_timeout = %v", cfg.CITimeout)
 	}
 }
 
 func TestMerge_RepoDoesNotOverrideWhenEmpty(t *testing.T) {
 	global := &GlobalConfig{
-		Agent:          types.AgentRovoDev,
-		BabysitTimeout: 2 * time.Hour,
-		LogLevel:       "debug",
+		Agent:     types.AgentRovoDev,
+		CITimeout: 2 * time.Hour,
+		LogLevel:  "debug",
 	}
 	repo := &RepoConfig{
 		// Agent is empty — should not override
@@ -438,12 +438,12 @@ func TestDefaultConfigYAML_MatchesGoDefaults(t *testing.T) {
 	if raw.Agent != types.AgentClaude {
 		t.Errorf("YAML agent = %q, Go default = %q", raw.Agent, types.AgentClaude)
 	}
-	d, err := time.ParseDuration(raw.BabysitTimeout)
+	d, err := time.ParseDuration(raw.CITimeout)
 	if err != nil {
-		t.Fatalf("YAML babysit_timeout %q is not a valid duration: %v", raw.BabysitTimeout, err)
+		t.Fatalf("YAML ci_timeout %q is not a valid duration: %v", raw.CITimeout, err)
 	}
 	if d != 4*time.Hour {
-		t.Errorf("YAML babysit_timeout = %v, Go default = %v", d, 4*time.Hour)
+		t.Errorf("YAML ci_timeout = %v, Go default = %v", d, 4*time.Hour)
 	}
 	if raw.LogLevel != "info" {
 		t.Errorf("YAML log_level = %q, Go default = %q", raw.LogLevel, "info")
@@ -458,8 +458,8 @@ func TestDefaultConfigYAML_MatchesGoDefaults(t *testing.T) {
 	if raw.AutoFix.Review == nil || *raw.AutoFix.Review != defaults.Review {
 		t.Errorf("YAML auto_fix.review = %v, Go default = %d", raw.AutoFix.Review, defaults.Review)
 	}
-	if raw.AutoFix.Babysit == nil || *raw.AutoFix.Babysit != defaults.Babysit {
-		t.Errorf("YAML auto_fix.babysit = %v, Go default = %d", raw.AutoFix.Babysit, defaults.Babysit)
+	if raw.AutoFix.CI == nil || *raw.AutoFix.CI != defaults.CI {
+		t.Errorf("YAML auto_fix.ci = %v, Go default = %d", raw.AutoFix.CI, defaults.CI)
 	}
 	if raw.AutoFix.Rebase == nil || *raw.AutoFix.Rebase != defaults.Rebase {
 		t.Errorf("YAML auto_fix.rebase = %v, Go default = %d", raw.AutoFix.Rebase, defaults.Rebase)
@@ -473,7 +473,7 @@ func TestLoadGlobal_AutoFixDefaults(t *testing.T) {
 	}
 	// AutoFix should be nil (unset) in GlobalConfig
 	if cfg.AutoFix.Lint != nil || cfg.AutoFix.Test != nil || cfg.AutoFix.Review != nil ||
-		cfg.AutoFix.Babysit != nil || cfg.AutoFix.Rebase != nil {
+		cfg.AutoFix.CI != nil || cfg.AutoFix.Rebase != nil {
 		t.Errorf("expected all AutoFix fields to be nil for defaults, got %+v", cfg.AutoFix)
 	}
 }
@@ -485,7 +485,7 @@ func TestLoadGlobal_AutoFixFromFile(t *testing.T) {
   lint: 5
   test: 0
   review: 2
-  babysit: 1
+  ci: 1
 `
 	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
 		t.Fatal(err)
@@ -504,8 +504,8 @@ func TestLoadGlobal_AutoFixFromFile(t *testing.T) {
 	if cfg.AutoFix.Review == nil || *cfg.AutoFix.Review != 2 {
 		t.Errorf("review = %v, want 2", cfg.AutoFix.Review)
 	}
-	if cfg.AutoFix.Babysit == nil || *cfg.AutoFix.Babysit != 1 {
-		t.Errorf("babysit = %v, want 1", cfg.AutoFix.Babysit)
+	if cfg.AutoFix.CI == nil || *cfg.AutoFix.CI != 1 {
+		t.Errorf("ci =%v, want 1", cfg.AutoFix.CI)
 	}
 }
 
@@ -537,7 +537,7 @@ func TestLoadRepo_AutoFixFromFile(t *testing.T) {
 	path := filepath.Join(dir, ".no-mistakes.yaml")
 	data := `auto_fix:
   review: 0
-  babysit: 2
+  ci: 2
 `
 	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
 		t.Fatal(err)
@@ -550,13 +550,13 @@ func TestLoadRepo_AutoFixFromFile(t *testing.T) {
 	if cfg.AutoFix.Review == nil || *cfg.AutoFix.Review != 0 {
 		t.Errorf("review = %v, want 0", cfg.AutoFix.Review)
 	}
-	if cfg.AutoFix.Babysit == nil || *cfg.AutoFix.Babysit != 2 {
-		t.Errorf("babysit = %v, want 2", cfg.AutoFix.Babysit)
+	if cfg.AutoFix.CI == nil || *cfg.AutoFix.CI != 2 {
+		t.Errorf("ci =%v, want 2", cfg.AutoFix.CI)
 	}
 }
 
 func TestMerge_AutoFixDefaults(t *testing.T) {
-	global := &GlobalConfig{Agent: types.AgentClaude, BabysitTimeout: 4 * time.Hour, LogLevel: "info"}
+	global := &GlobalConfig{Agent: types.AgentClaude, CITimeout: 4 * time.Hour, LogLevel: "info"}
 	repo := &RepoConfig{}
 
 	cfg := Merge(global, repo)
@@ -569,8 +569,8 @@ func TestMerge_AutoFixDefaults(t *testing.T) {
 	if cfg.AutoFix.Review != 3 {
 		t.Errorf("review = %d, want 3", cfg.AutoFix.Review)
 	}
-	if cfg.AutoFix.Babysit != 3 {
-		t.Errorf("babysit = %d, want 3", cfg.AutoFix.Babysit)
+	if cfg.AutoFix.CI != 3 {
+		t.Errorf("ci =%d, want 3", cfg.AutoFix.CI)
 	}
 	if cfg.AutoFix.Rebase != 0 {
 		t.Errorf("rebase = %d, want 0", cfg.AutoFix.Rebase)
@@ -581,10 +581,10 @@ func TestMerge_AutoFixGlobalOverridesDefaults(t *testing.T) {
 	five := 5
 	zero := 0
 	global := &GlobalConfig{
-		Agent:          types.AgentClaude,
-		BabysitTimeout: 4 * time.Hour,
-		LogLevel:       "info",
-		AutoFix:        AutoFixRaw{Lint: &five, Babysit: &zero},
+		Agent:     types.AgentClaude,
+		CITimeout: 4 * time.Hour,
+		LogLevel:  "info",
+		AutoFix:   AutoFixRaw{Lint: &five, CI: &zero},
 	}
 	repo := &RepoConfig{}
 
@@ -595,8 +595,8 @@ func TestMerge_AutoFixGlobalOverridesDefaults(t *testing.T) {
 	if cfg.AutoFix.Test != 3 {
 		t.Errorf("test = %d, want 3 (default)", cfg.AutoFix.Test)
 	}
-	if cfg.AutoFix.Babysit != 0 {
-		t.Errorf("babysit = %d, want 0 (global override)", cfg.AutoFix.Babysit)
+	if cfg.AutoFix.CI != 0 {
+		t.Errorf("ci =%d, want 0 (global override)", cfg.AutoFix.CI)
 	}
 	if cfg.AutoFix.Rebase != 0 {
 		t.Errorf("rebase = %d, want 0 (default, no override)", cfg.AutoFix.Rebase)
@@ -608,10 +608,10 @@ func TestMerge_AutoFixRepoOverridesGlobal(t *testing.T) {
 	one := 1
 	zero := 0
 	global := &GlobalConfig{
-		Agent:          types.AgentClaude,
-		BabysitTimeout: 4 * time.Hour,
-		LogLevel:       "info",
-		AutoFix:        AutoFixRaw{Lint: &five},
+		Agent:     types.AgentClaude,
+		CITimeout: 4 * time.Hour,
+		LogLevel:  "info",
+		AutoFix:   AutoFixRaw{Lint: &five},
 	}
 	repo := &RepoConfig{
 		AutoFix: AutoFixRaw{Lint: &one, Review: &zero},
@@ -631,7 +631,7 @@ func TestMerge_AutoFixRepoOverridesGlobal(t *testing.T) {
 
 func TestAutoFixLimit(t *testing.T) {
 	cfg := &Config{
-		AutoFix: AutoFix{Lint: 5, Test: 2, Review: 0, Babysit: 3, Rebase: 4},
+		AutoFix: AutoFix{Lint: 5, Test: 2, Review: 0, CI: 3, Rebase: 4},
 	}
 	tests := []struct {
 		step types.StepName
@@ -640,7 +640,7 @@ func TestAutoFixLimit(t *testing.T) {
 		{types.StepLint, 5},
 		{types.StepTest, 2},
 		{types.StepReview, 0},
-		{types.StepBabysit, 3},
+		{types.StepCI, 3},
 		{types.StepRebase, 4},
 		{types.StepPush, 0},
 		{types.StepPR, 0},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -590,6 +590,25 @@ func TestLoadRepo_AutoFixFromFile(t *testing.T) {
 	}
 }
 
+func TestLoadRepo_LegacyAutoFixBabysit(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".no-mistakes.yaml")
+	if err := os.WriteFile(path, []byte("auto_fix:\n  babysit: 0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadRepo(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.AutoFix.CI == nil {
+		t.Fatal("ci auto-fix override was not loaded")
+	}
+	if *cfg.AutoFix.CI != 0 {
+		t.Fatalf("ci auto-fix = %d, want 0", *cfg.AutoFix.CI)
+	}
+}
+
 func TestMerge_AutoFixDefaults(t *testing.T) {
 	global := &GlobalConfig{Agent: types.AgentClaude, CITimeout: 4 * time.Hour, LogLevel: "info"}
 	repo := &RepoConfig{}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -40,6 +40,36 @@ func TestOpenCreatesSchema(t *testing.T) {
 	}
 }
 
+func TestGetStepResult_LegacyBabysitStepName(t *testing.T) {
+	d := openTestDB(t)
+	repo, err := d.InsertRepo("/tmp/repo", "git@github.com:test/repo.git", "main")
+	if err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+	run, err := d.InsertRun(repo.ID, "feature", "abc123", "def456")
+	if err != nil {
+		t.Fatalf("insert run: %v", err)
+	}
+	_, err = d.sql.Exec(
+		`INSERT INTO step_results (id, run_id, step_name, step_order, status) VALUES (?, ?, ?, ?, ?)`,
+		"step1", run.ID, "babysit", 7, types.StepStatusPending,
+	)
+	if err != nil {
+		t.Fatalf("insert legacy step result: %v", err)
+	}
+
+	step, err := d.GetStepResult("step1")
+	if err != nil {
+		t.Fatalf("get step result: %v", err)
+	}
+	if step == nil {
+		t.Fatal("expected step result")
+	}
+	if step.StepName != types.StepCI {
+		t.Fatalf("step name = %q, want %q", step.StepName, types.StepCI)
+	}
+}
+
 func TestRepoInsertAndGet(t *testing.T) {
 	d := openTestDB(t)
 	repo, err := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -20,8 +20,8 @@ import (
 
 const defaultChecksGracePeriod = 60 * time.Second
 
-// BabysitStep monitors CI checks after PR creation, auto-fixing failures.
-type BabysitStep struct {
+// CIStep monitors CI checks after PR creation, auto-fixing failures.
+type CIStep struct {
 	lastFixedChecks      string        // sorted check names from last fix attempt, to avoid re-fixing
 	ciFixAttempts        int           // number of CI auto-fix attempts made
 	checksGracePeriod    time.Duration // minimum wait before trusting empty CI checks (0 = default 60s)
@@ -30,9 +30,9 @@ type BabysitStep struct {
 	now                  func() time.Time
 }
 
-func (s *BabysitStep) Name() types.StepName { return types.StepBabysit }
+func (s *CIStep) Name() types.StepName { return types.StepCI }
 
-func (s *BabysitStep) gracePeriod() time.Duration {
+func (s *CIStep) gracePeriod() time.Duration {
 	if s.checksGracePeriod > 0 {
 		return s.checksGracePeriod
 	}
@@ -66,7 +66,7 @@ func extractPRNumber(prURL string) (string, error) {
 	return num, nil
 }
 
-// pollInterval returns the polling interval based on elapsed time since babysit started.
+// pollInterval returns the polling interval based on elapsed time since CI monitoring started.
 // 30s for first 5min, 60s for 5-15min, 120s after.
 func pollInterval(elapsed time.Duration) time.Duration {
 	switch {
@@ -131,7 +131,7 @@ func ciFailureOutcome(failing []string, summary string) *pipeline.StepOutcome {
 	}
 }
 
-func (s *BabysitStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, error) {
+func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, error) {
 	ctx := sctx.Ctx
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -141,15 +141,15 @@ func (s *BabysitStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome
 		provider = scm.DetectProvider(*sctx.Run.PRURL)
 	}
 	if provider != scm.ProviderGitHub {
-		sctx.Log(fmt.Sprintf("skipping babysit: provider %s is not supported yet", provider))
+		sctx.Log(fmt.Sprintf("skipping CI: provider %s is not supported yet", provider))
 		return &pipeline.StepOutcome{}, nil
 	}
 	if !scm.CLIAvailable(provider) {
-		sctx.Log("skipping babysit: gh CLI is not installed")
+		sctx.Log("skipping CI: gh CLI is not installed")
 		return &pipeline.StepOutcome{}, nil
 	}
 	if !scm.AuthConfigured(ctx, provider, sctx.WorkDir) {
-		sctx.Log("skipping babysit: gh CLI is not authenticated")
+		sctx.Log("skipping CI: gh CLI is not authenticated")
 		return &pipeline.StepOutcome{}, nil
 	}
 
@@ -167,7 +167,7 @@ func (s *BabysitStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome
 		}
 	}
 	if prURL == "" {
-		sctx.Log("no PR URL found, skipping babysit")
+		sctx.Log("no PR URL found, skipping CI")
 		return &pipeline.StepOutcome{}, nil
 	}
 
@@ -176,12 +176,12 @@ func (s *BabysitStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome
 		return nil, fmt.Errorf("extract PR number: %w", err)
 	}
 
-	timeout := sctx.Config.BabysitTimeout
+	timeout := sctx.Config.CITimeout
 	if timeout == 0 {
 		timeout = 4 * time.Hour
 	}
 
-	sctx.Log(fmt.Sprintf("babysitting PR #%s (timeout: %s)...", prNumber, timeout))
+	sctx.Log(fmt.Sprintf("monitoring CI for PR #%s (timeout: %s)...", prNumber, timeout))
 	now := s.now
 	if now == nil {
 		now = time.Now
@@ -199,11 +199,11 @@ func (s *BabysitStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome
 
 		elapsed := now().Sub(started)
 		if elapsed >= timeout {
-			sctx.Log("babysit timeout reached")
+			sctx.Log("CI timeout reached")
 			return &pipeline.StepOutcome{}, nil
 		}
 
-		// Check PR state (merged/closed → exit)
+		// Check PR state (merged/closed -> exit)
 		state, err := s.getPRState(ctx, sctx.WorkDir, prNumber)
 		if err != nil {
 			sctx.Log(fmt.Sprintf("warning: could not check PR state: %v", err))
@@ -216,7 +216,7 @@ func (s *BabysitStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome
 		}
 
 		// Check CI status - auto-fix failures when configured
-		ciFixLimit := sctx.Config.AutoFix.Babysit
+		ciFixLimit := sctx.Config.AutoFix.CI
 		checks, err := s.getCIChecks(ctx, sctx.WorkDir, prNumber)
 		if err != nil {
 			sctx.Log(fmt.Sprintf("warning: could not check CI: %v", err))
@@ -260,7 +260,7 @@ func (s *BabysitStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome
 				} else {
 					checksReadyToExit = true
 					if len(checks) == 0 {
-						checksSummary = "no CI checks reported, babysit complete"
+						checksSummary = "no CI checks reported, CI monitoring complete"
 					} else {
 						checksSummary = "all CI checks passed"
 					}
@@ -300,7 +300,7 @@ func (s *BabysitStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome
 }
 
 // getPRState returns the PR state (OPEN, MERGED, CLOSED).
-func (s *BabysitStep) getPRState(ctx context.Context, workDir, prNumber string) (string, error) {
+func (s *CIStep) getPRState(ctx context.Context, workDir, prNumber string) (string, error) {
 	cmd := exec.CommandContext(ctx, "gh", "pr", "view", prNumber, "--json", "state", "--jq", ".state")
 	cmd.Dir = workDir
 	out, err := cmd.Output()
@@ -311,7 +311,7 @@ func (s *BabysitStep) getPRState(ctx context.Context, workDir, prNumber string) 
 }
 
 // getCIChecks fetches CI check results for a PR.
-func (s *BabysitStep) getCIChecks(ctx context.Context, workDir, prNumber string) ([]ciCheck, error) {
+func (s *CIStep) getCIChecks(ctx context.Context, workDir, prNumber string) ([]ciCheck, error) {
 	cmd := exec.CommandContext(ctx, "gh", "pr", "checks", prNumber, "--json", "name,state,bucket")
 	cmd.Dir = workDir
 	out, err := cmd.CombinedOutput()
@@ -329,7 +329,7 @@ func (s *BabysitStep) getCIChecks(ctx context.Context, workDir, prNumber string)
 }
 
 // autoFixCI runs the agent to fix CI failures, then commits and pushes.
-func (s *BabysitStep) autoFixCI(sctx *pipeline.StepContext, prNumber string, failingNames []string) error {
+func (s *CIStep) autoFixCI(sctx *pipeline.StepContext, prNumber string, failingNames []string) error {
 	ctx := sctx.Ctx
 	baseSHA := resolveBranchBaseSHA(ctx, sctx.WorkDir, sctx.Run.BaseSHA, sctx.Repo.DefaultBranch)
 
@@ -408,7 +408,7 @@ CI logs:
 }
 
 // commitAndPush commits any uncommitted changes and force-pushes to upstream.
-func (s *BabysitStep) commitAndPush(sctx *pipeline.StepContext) error {
+func (s *CIStep) commitAndPush(sctx *pipeline.StepContext) error {
 	ctx := sctx.Ctx
 	newHeadSHA := ""
 
@@ -426,9 +426,9 @@ func (s *BabysitStep) commitAndPush(sctx *pipeline.StepContext) error {
 	}
 
 	if _, err := git.Run(ctx, sctx.WorkDir, "add", "-A"); err != nil {
-		return fmt.Errorf("stage babysit changes: %w", err)
+		return fmt.Errorf("stage CI changes: %w", err)
 	}
-	if _, err := git.Run(ctx, sctx.WorkDir, "commit", "-m", "no-mistakes: apply babysit fixes"); err != nil {
+	if _, err := git.Run(ctx, sctx.WorkDir, "commit", "-m", "no-mistakes: apply CI fixes"); err != nil {
 		return fmt.Errorf("commit: %w", err)
 	}
 	headSHA, err := git.HeadSHA(ctx, sctx.WorkDir)

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -360,6 +360,6 @@ func AllSteps() []pipeline.Step {
 		&LintStep{},
 		&PushStep{},
 		&PRStep{},
-		&BabysitStep{},
+		&CIStep{},
 	}
 }

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -9,7 +9,7 @@ import (
 )
 
 // summarySteps are the steps we include in the pipeline summary.
-// Push, PR, and Babysit are operational - not interesting for the PR reader.
+// Push, PR, and CI are operational - not interesting for the PR reader.
 var summarySteps = map[types.StepName]bool{
 	types.StepRebase: true,
 	types.StepReview: true,

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -197,12 +197,12 @@ func TestBuildPipelineSummary_SkippedStep(t *testing.T) {
 	}
 }
 
-func TestBuildPipelineSummary_ExcludesPushPRBabysit(t *testing.T) {
+func TestBuildPipelineSummary_ExcludesPushPRCI(t *testing.T) {
 	steps := []*db.StepResult{
 		{ID: "s1", StepName: types.StepReview, Status: types.StepStatusCompleted},
 		{ID: "s2", StepName: types.StepPush, Status: types.StepStatusCompleted},
 		{ID: "s3", StepName: types.StepPR, Status: types.StepStatusCompleted},
-		{ID: "s4", StepName: types.StepBabysit, Status: types.StepStatusCompleted},
+		{ID: "s4", StepName: types.StepCI, Status: types.StepStatusCompleted},
 	}
 	rounds := map[string][]*db.StepRound{
 		"s1": {{Round: 1, Trigger: "initial", DurationMS: 500}},
@@ -212,9 +212,9 @@ func TestBuildPipelineSummary_ExcludesPushPRBabysit(t *testing.T) {
 	}
 	md, _ := BuildPipelineSummary(steps, rounds)
 
-	// Push, PR, and Babysit should not appear in the summary
-	if strings.Contains(md, "**Push**") || strings.Contains(md, "**PR**") || strings.Contains(md, "**Babysit**") {
-		t.Errorf("should not include push/pr/babysit steps, got:\n%s", md)
+	// Push, PR, and CI should not appear in the summary
+	if strings.Contains(md, "**Push**") || strings.Contains(md, "**PR**") || strings.Contains(md, "**CI**") {
+		t.Errorf("should not include push/pr/ci steps, got:\n%s", md)
 	}
 }
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -48,12 +48,12 @@ func handleFakeCLI(mode string) {
 		fakeGHHandler(args)
 	case "glab":
 		fakeGlabHandler(args)
-	case "babysit-gh":
-		fakeBabysitGHHandler(args)
-	case "babysit-gh-seq":
-		fakeBabysitGHSequenceHandler(args)
-	case "babysit-gh-nochecks":
-		fakeBabysitGHNoChecksHandler(args)
+	case "ci-gh":
+		fakeCIGHHandler(args)
+	case "ci-gh-seq":
+		fakeCIGHSequenceHandler(args)
+	case "ci-gh-nochecks":
+		fakeCIGHNoChecksHandler(args)
 	default:
 		os.Exit(1)
 	}
@@ -103,7 +103,7 @@ func fakeGlabHandler(args []string) {
 	os.Exit(1)
 }
 
-func fakeBabysitGHHandler(args []string) {
+func fakeCIGHHandler(args []string) {
 	state := os.Getenv("FAKE_CLI_STATE")
 	checksJSON := os.Getenv("FAKE_CLI_CHECKS")
 	joined := strings.Join(args, " ")
@@ -126,7 +126,7 @@ func fakeBabysitGHHandler(args []string) {
 	os.Exit(1)
 }
 
-func fakeBabysitGHSequenceHandler(args []string) {
+func fakeCIGHSequenceHandler(args []string) {
 	state := os.Getenv("FAKE_CLI_STATE")
 	checksPath := os.Getenv("FAKE_CLI_CHECKS_PATH")
 	indexPath := os.Getenv("FAKE_CLI_CHECKS_INDEX_PATH")
@@ -174,7 +174,7 @@ func fakeBabysitGHSequenceHandler(args []string) {
 	os.Exit(1)
 }
 
-func fakeBabysitGHNoChecksHandler(args []string) {
+func fakeCIGHNoChecksHandler(args []string) {
 	joined := strings.Join(args, " ")
 
 	if len(args) >= 2 && args[0] == "auth" && args[1] == "status" {
@@ -373,7 +373,7 @@ func TestAllSteps(t *testing.T) {
 	if len(steps) != 7 {
 		t.Fatalf("AllSteps() returned %d steps, want 7", len(steps))
 	}
-	expected := []types.StepName{types.StepRebase, types.StepReview, types.StepTest, types.StepLint, types.StepPush, types.StepPR, types.StepBabysit}
+	expected := []types.StepName{types.StepRebase, types.StepReview, types.StepTest, types.StepLint, types.StepPush, types.StepPR, types.StepCI}
 	for i, s := range steps {
 		if s.Name() != expected[i] {
 			t.Errorf("step %d name = %s, want %s", i, s.Name(), expected[i])
@@ -2413,9 +2413,9 @@ func TestCommitAgentFixes_UsesFallbackSummary(t *testing.T) {
 	}
 }
 
-// --- Babysit step tests ---
+// --- CI step tests ---
 
-func TestBabysitStep_PendingChecksUseAdaptivePollIntervals(t *testing.T) {
+func TestCIStep_PendingChecksUseAdaptivePollIntervals(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	checksSequence := []string{
@@ -2424,20 +2424,20 @@ func TestBabysitStep_PendingChecksUseAdaptivePollIntervals(t *testing.T) {
 		`[{"name":"build","state":"PENDING","bucket":"pending"}]`,
 		`[{"name":"build","state":"SUCCESS","bucket":"pass"}]`,
 	}
-	binDir := fakeBabysitGHSequence(t, "OPEN", checksSequence)
+	binDir := fakeCIGHSequence(t, "OPEN", checksSequence)
 	prependPATH(t, binDir)
 
 	prURL := "https://github.com/test/repo/pull/42"
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Run.PRURL = &prURL
-	sctx.Config.BabysitTimeout = 20 * time.Minute
+	sctx.Config.CITimeout = 20 * time.Minute
 
 	started := time.Date(2026, time.January, 1, 12, 0, 0, 0, time.UTC)
 	current := started
 	var waits []time.Duration
 
-	step := &BabysitStep{
+	step := &CIStep{
 		now: func() time.Time { return current },
 		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
 			waits = append(waits, interval)
@@ -2474,13 +2474,13 @@ func TestBabysitStep_PendingChecksUseAdaptivePollIntervals(t *testing.T) {
 	}
 }
 
-func TestBabysitStep_NoPRURL(t *testing.T) {
+func TestCIStep_NoPRURL(t *testing.T) {
 	dir := t.TempDir()
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, "abc", "def", config.Commands{})
 	sctx.Run.PRURL = nil
 
-	step := &BabysitStep{}
+	step := &CIStep{}
 	outcome, err := step.Execute(sctx)
 	if err != nil {
 		t.Fatal(err)
@@ -2490,10 +2490,10 @@ func TestBabysitStep_NoPRURL(t *testing.T) {
 	}
 }
 
-func TestBabysitStep_InvalidPRURLReturnsError(t *testing.T) {
+func TestCIStep_InvalidPRURLReturnsError(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
-	binDir := fakeBabysitGH(t, "OPEN", "[]")
+	binDir := fakeCIGH(t, "OPEN", "[]")
 	prependPATH(t, binDir)
 
 	prURL := "https://github.com/test/repo/pull/42/files"
@@ -2501,7 +2501,7 @@ func TestBabysitStep_InvalidPRURLReturnsError(t *testing.T) {
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Run.PRURL = &prURL
 
-	step := &BabysitStep{}
+	step := &CIStep{}
 	_, err := step.Execute(sctx)
 	if err == nil {
 		t.Fatal("expected error for invalid PR URL")
@@ -2514,7 +2514,7 @@ func TestBabysitStep_InvalidPRURLReturnsError(t *testing.T) {
 	}
 }
 
-func TestBabysitStep_NonGitHubSkips(t *testing.T) {
+func TestCIStep_NonGitHubSkips(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 	prURL := "https://gitlab.com/test/repo/-/merge_requests/42"
 	ag := &mockAgent{name: "test"}
@@ -2525,32 +2525,32 @@ func TestBabysitStep_NonGitHubSkips(t *testing.T) {
 	var logs []string
 	sctx.Log = func(s string) { logs = append(logs, s) }
 
-	step := &BabysitStep{}
+	step := &CIStep{}
 	outcome, err := step.Execute(sctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if outcome.NeedsApproval {
-		t.Fatal("expected babysit skip for non-GitHub provider")
+		t.Fatal("expected CI skip for non-GitHub provider")
 	}
-	if len(logs) == 0 || !strings.Contains(logs[0], "skipping babysit") {
+	if len(logs) == 0 || !strings.Contains(logs[0], "skipping CI") {
 		t.Fatalf("expected skip log, got: %v", logs)
 	}
 }
 
-func TestBabysitStep_ContextCancelled(t *testing.T) {
+func TestCIStep_ContextCancelled(t *testing.T) {
 	dir := t.TempDir()
 	ag := &mockAgent{name: "test"}
 	prURL := "https://github.com/test/repo/pull/1"
 	sctx := newTestContext(t, ag, dir, "abc", "def", config.Commands{})
 	sctx.Run.PRURL = &prURL
-	sctx.Config.BabysitTimeout = time.Hour
+	sctx.Config.CITimeout = time.Hour
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately
 	sctx.Ctx = ctx
 
-	step := &BabysitStep{}
+	step := &CIStep{}
 	_, err := step.Execute(sctx)
 	if err == nil {
 		t.Fatal("expected error from cancelled context")
@@ -2560,23 +2560,23 @@ func TestBabysitStep_ContextCancelled(t *testing.T) {
 	}
 }
 
-func TestBabysitStep_TimeoutDoesNotSleepPastDeadline(t *testing.T) {
+func TestCIStep_TimeoutDoesNotSleepPastDeadline(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
-	binDir := fakeBabysitGH(t, "OPEN", "[]")
+	binDir := fakeCIGH(t, "OPEN", "[]")
 	prependPATH(t, binDir)
 
 	prURL := "https://github.com/test/repo/pull/42"
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Run.PRURL = &prURL
-	sctx.Config.BabysitTimeout = 2 * time.Second
+	sctx.Config.CITimeout = 2 * time.Second
 
 	started := time.Unix(1700000000, 0)
 	now := started
 	var intervals []time.Duration
 
-	step := &BabysitStep{
+	step := &CIStep{
 		now: func() time.Time {
 			return now
 		},
@@ -2601,7 +2601,7 @@ func TestBabysitStep_TimeoutDoesNotSleepPastDeadline(t *testing.T) {
 	}
 }
 
-func TestBabysitStep_CommitAndPush(t *testing.T) {
+func TestCIStep_CommitAndPush(t *testing.T) {
 	// Set up upstream bare repo
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
@@ -2627,14 +2627,14 @@ func TestBabysitStep_CommitAndPush(t *testing.T) {
 	gitCmd(t, dir, "push", "origin", "feature")
 
 	// Add uncommitted changes
-	os.WriteFile(filepath.Join(dir, "fix.txt"), []byte("babysit fix"), 0o644)
+	os.WriteFile(filepath.Join(dir, "fix.txt"), []byte("ci fix"), 0o644)
 
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "refs/heads/feature"
 
-	step := &BabysitStep{}
+	step := &CIStep{}
 	err := step.commitAndPush(sctx)
 	if err != nil {
 		t.Fatal(err)
@@ -2643,11 +2643,11 @@ func TestBabysitStep_CommitAndPush(t *testing.T) {
 	// Verify the commit and push happened
 	upstreamSHA := gitCmd(t, upstream, "rev-parse", "refs/heads/feature")
 	if upstreamSHA == headSHA {
-		t.Error("upstream should have a new commit with babysit fixes")
+		t.Error("upstream should have a new commit with CI fixes")
 	}
 }
 
-func TestBabysitStep_CommitAndPush_NoChanges(t *testing.T) {
+func TestCIStep_CommitAndPush_NoChanges(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	ag := &mockAgent{name: "test"}
@@ -2655,7 +2655,7 @@ func TestBabysitStep_CommitAndPush_NoChanges(t *testing.T) {
 	sctx.Repo.UpstreamURL = "dummy"
 	sctx.Run.Branch = "refs/heads/feature"
 
-	step := &BabysitStep{}
+	step := &CIStep{}
 	err := step.commitAndPush(sctx)
 	if err != nil {
 		t.Fatal(err)
@@ -2663,7 +2663,7 @@ func TestBabysitStep_CommitAndPush_NoChanges(t *testing.T) {
 	// No error expected — just a no-op
 }
 
-func TestBabysitStep_CommitAndPush_NoChanges_ReconcilesStaleDatabaseHeadSHA(t *testing.T) {
+func TestCIStep_CommitAndPush_NoChanges_ReconcilesStaleDatabaseHeadSHA(t *testing.T) {
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -2693,7 +2693,7 @@ func TestBabysitStep_CommitAndPush_NoChanges_ReconcilesStaleDatabaseHeadSHA(t *t
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "refs/heads/feature"
 
-	step := &BabysitStep{}
+	step := &CIStep{}
 	err := step.commitAndPush(sctx)
 	if err != nil {
 		t.Fatal(err)
@@ -2711,7 +2711,7 @@ func TestBabysitStep_CommitAndPush_NoChanges_ReconcilesStaleDatabaseHeadSHA(t *t
 	}
 }
 
-func TestBabysitStep_CommitAndPush_UpdatesLocalBranchRefAfterDetachedPush(t *testing.T) {
+func TestCIStep_CommitAndPush_UpdatesLocalBranchRefAfterDetachedPush(t *testing.T) {
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -2734,14 +2734,14 @@ func TestBabysitStep_CommitAndPush_UpdatesLocalBranchRefAfterDetachedPush(t *tes
 	originalHeadSHA := gitCmd(t, dir, "rev-parse", "HEAD")
 	gitCmd(t, dir, "push", "origin", "feature")
 	gitCmd(t, dir, "checkout", "--detach", originalHeadSHA)
-	os.WriteFile(filepath.Join(dir, "fix.txt"), []byte("babysit fix"), 0o644)
+	os.WriteFile(filepath.Join(dir, "fix.txt"), []byte("ci fix"), 0o644)
 
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, originalHeadSHA, config.Commands{})
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "refs/heads/feature"
 
-	step := &BabysitStep{}
+	step := &CIStep{}
 	err := step.commitAndPush(sctx)
 	if err != nil {
 		t.Fatal(err)
@@ -3233,21 +3233,21 @@ func TestReviewStep_DismissedFindingsSanitizesPromptContent(t *testing.T) {
 	}
 }
 
-// --- babysit Execute tests ---
+// --- CI Execute tests ---
 
-// fakeBabysitGH creates a fake gh binary that responds to babysit-related
+// fakeCIGH creates a fake gh binary that responds to CI-related
 // commands (pr view --json state, pr checks --json, pr view --json comments).
-func fakeBabysitGH(t *testing.T, state, checksJSON string) string {
+func fakeCIGH(t *testing.T, state, checksJSON string) string {
 	t.Helper()
 	binDir := fakeCLIBinDir(t)
 	linkTestBinary(t, binDir, "gh")
-	t.Setenv("FAKE_CLI_MODE", "babysit-gh")
+	t.Setenv("FAKE_CLI_MODE", "ci-gh")
 	t.Setenv("FAKE_CLI_STATE", state)
 	t.Setenv("FAKE_CLI_CHECKS", checksJSON)
 	return binDir
 }
 
-func fakeBabysitGHSequence(t *testing.T, state string, checks []string) string {
+func fakeCIGHSequence(t *testing.T, state string, checks []string) string {
 	t.Helper()
 	binDir := fakeCLIBinDir(t)
 	linkTestBinary(t, binDir, "gh")
@@ -3262,37 +3262,37 @@ func fakeBabysitGHSequence(t *testing.T, state string, checks []string) string {
 		t.Fatalf("write checks index: %v", err)
 	}
 
-	t.Setenv("FAKE_CLI_MODE", "babysit-gh-seq")
+	t.Setenv("FAKE_CLI_MODE", "ci-gh-seq")
 	t.Setenv("FAKE_CLI_STATE", state)
 	t.Setenv("FAKE_CLI_CHECKS_PATH", checksPath)
 	t.Setenv("FAKE_CLI_CHECKS_INDEX_PATH", indexPath)
 	return binDir
 }
 
-func fakeBabysitGHNoChecks(t *testing.T) string {
+func fakeCIGHNoChecks(t *testing.T) string {
 	t.Helper()
 	binDir := fakeCLIBinDir(t)
 	linkTestBinary(t, binDir, "gh")
-	t.Setenv("FAKE_CLI_MODE", "babysit-gh-nochecks")
+	t.Setenv("FAKE_CLI_MODE", "ci-gh-nochecks")
 	return binDir
 }
 
-func TestBabysitStep_PRMergedExitsEarly(t *testing.T) {
+func TestCIStep_PRMergedExitsEarly(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
-	binDir := fakeBabysitGH(t, "MERGED", "[]")
+	binDir := fakeCIGH(t, "MERGED", "[]")
 	prependPATH(t, binDir)
 
 	prURL := "https://github.com/test/repo/pull/42"
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Run.PRURL = &prURL
-	sctx.Config.BabysitTimeout = 10 * time.Second
+	sctx.Config.CITimeout = 10 * time.Second
 
 	var logs []string
 	sctx.Log = func(s string) { logs = append(logs, s) }
 
-	step := &BabysitStep{}
+	step := &CIStep{}
 	outcome, err := step.Execute(sctx)
 	if err != nil {
 		t.Fatal(err)
@@ -3313,22 +3313,22 @@ func TestBabysitStep_PRMergedExitsEarly(t *testing.T) {
 	}
 }
 
-func TestBabysitStep_PRClosedExitsEarly(t *testing.T) {
+func TestCIStep_PRClosedExitsEarly(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
-	binDir := fakeBabysitGH(t, "CLOSED", "[]")
+	binDir := fakeCIGH(t, "CLOSED", "[]")
 	prependPATH(t, binDir)
 
 	prURL := "https://github.com/test/repo/pull/42"
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Run.PRURL = &prURL
-	sctx.Config.BabysitTimeout = 10 * time.Second
+	sctx.Config.CITimeout = 10 * time.Second
 
 	var logs []string
 	sctx.Log = func(s string) { logs = append(logs, s) }
 
-	step := &BabysitStep{}
+	step := &CIStep{}
 	outcome, err := step.Execute(sctx)
 	if err != nil {
 		t.Fatal(err)
@@ -3349,11 +3349,11 @@ func TestBabysitStep_PRClosedExitsEarly(t *testing.T) {
 	}
 }
 
-func TestBabysitStep_GetCIChecksNoChecksReported(t *testing.T) {
-	binDir := fakeBabysitGHNoChecks(t)
+func TestCIStep_GetCIChecksNoChecksReported(t *testing.T) {
+	binDir := fakeCIGHNoChecks(t)
 	prependPATH(t, binDir)
 
-	step := &BabysitStep{}
+	step := &CIStep{}
 	checks, err := step.getCIChecks(context.Background(), t.TempDir(), "42")
 	if err != nil {
 		t.Fatalf("expected no error when gh reports no checks, got: %v", err)
@@ -3363,7 +3363,7 @@ func TestBabysitStep_GetCIChecksNoChecksReported(t *testing.T) {
 	}
 }
 
-func TestBabysitStep_CIFailureAutoFix(t *testing.T) {
+func TestCIStep_CIFailureAutoFix(t *testing.T) {
 	// Set up upstream bare repo for push
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
@@ -3388,7 +3388,7 @@ func TestBabysitStep_CIFailureAutoFix(t *testing.T) {
 	gitCmd(t, dir, "push", "origin", "feature")
 
 	checksJSON := `[{"name":"build","status":"COMPLETED","conclusion":"success"},{"name":"test","status":"COMPLETED","conclusion":"failure"}]`
-	binDir := fakeBabysitGH(t, "OPEN", checksJSON)
+	binDir := fakeCIGH(t, "OPEN", checksJSON)
 	prependPATH(t, binDir)
 
 	agentCalled := false
@@ -3407,8 +3407,8 @@ func TestBabysitStep_CIFailureAutoFix(t *testing.T) {
 	sctx.Run.PRURL = &prURL
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "refs/heads/feature"
-	sctx.Config.BabysitTimeout = 30 * time.Second
-	sctx.Config.AutoFix = config.AutoFix{Babysit: 3}
+	sctx.Config.CITimeout = 30 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{CI: 3}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -3418,7 +3418,7 @@ func TestBabysitStep_CIFailureAutoFix(t *testing.T) {
 	sctx.Log = func(s string) { logs = append(logs, s) }
 
 	pollCount := 0
-	step := &BabysitStep{
+	step := &CIStep{
 		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
 			pollCount++
 			if pollCount == 2 {
@@ -3452,27 +3452,27 @@ func TestBabysitStep_CIFailureAutoFix(t *testing.T) {
 	}
 }
 
-func TestBabysitStep_AllChecksPassingExitsCleanly(t *testing.T) {
+func TestCIStep_AllChecksPassingExitsCleanly(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	checksSequence := []string{
 		`[{"name":"build","state":"PENDING","bucket":"pending"}]`,
 		`[{"name":"build","state":"SUCCESS","bucket":"pass"},{"name":"test","state":"SUCCESS","bucket":"pass"}]`,
 	}
-	binDir := fakeBabysitGHSequence(t, "OPEN", checksSequence)
+	binDir := fakeCIGHSequence(t, "OPEN", checksSequence)
 	prependPATH(t, binDir)
 
 	prURL := "https://github.com/test/repo/pull/42"
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Run.PRURL = &prURL
-	sctx.Config.BabysitTimeout = 10 * time.Second
+	sctx.Config.CITimeout = 10 * time.Second
 
 	var logs []string
 	sctx.Log = func(s string) { logs = append(logs, s) }
 
 	pollCount := 0
-	step := &BabysitStep{
+	step := &CIStep{
 		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
 			pollCount++
 			return nil
@@ -3501,18 +3501,18 @@ func TestBabysitStep_AllChecksPassingExitsCleanly(t *testing.T) {
 	}
 }
 
-func TestBabysitStep_EmptyChecksWaitsDuringGracePeriod(t *testing.T) {
+func TestCIStep_EmptyChecksWaitsDuringGracePeriod(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	// Fake gh returns OPEN state, empty checks, no comments
-	binDir := fakeBabysitGH(t, "OPEN", "[]")
+	binDir := fakeCIGH(t, "OPEN", "[]")
 	prependPATH(t, binDir)
 
 	prURL := "https://github.com/test/repo/pull/42"
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Run.PRURL = &prURL
-	sctx.Config.BabysitTimeout = 5 * time.Second
+	sctx.Config.CITimeout = 5 * time.Second
 
 	var logs []string
 	sctx.Log = func(s string) { logs = append(logs, s) }
@@ -3521,7 +3521,7 @@ func TestBabysitStep_EmptyChecksWaitsDuringGracePeriod(t *testing.T) {
 	current := started
 	var waits []time.Duration
 
-	step := &BabysitStep{
+	step := &CIStep{
 		checksGracePeriod:    200 * time.Millisecond,
 		pollIntervalOverride: 75 * time.Millisecond,
 		now:                  func() time.Time { return current },
@@ -3539,7 +3539,7 @@ func TestBabysitStep_EmptyChecksWaitsDuringGracePeriod(t *testing.T) {
 		t.Error("expected no approval needed")
 	}
 	if elapsed := current.Sub(started); elapsed < 200*time.Millisecond {
-		t.Errorf("babysit exited in %v, expected to wait at least 200ms grace period", elapsed)
+		t.Errorf("CI exited in %v, expected to wait at least 200ms grace period", elapsed)
 	}
 	if len(waits) != 3 {
 		t.Fatalf("expected 3 grace-period waits, got %v", waits)
@@ -3549,41 +3549,41 @@ func TestBabysitStep_EmptyChecksWaitsDuringGracePeriod(t *testing.T) {
 			t.Fatalf("expected 75ms waits during grace period, got %v", waits)
 		}
 	}
-	// Should exit via grace period expiry, not babysit timeout
+	// Should exit via grace period expiry, not CI timeout
 	for _, l := range logs {
-		if strings.Contains(l, "babysit timeout reached") {
-			t.Fatal("expected exit via grace period expiry, not babysit timeout")
+		if strings.Contains(l, "CI timeout reached") {
+			t.Fatal("expected exit via grace period expiry, not CI timeout")
 		}
 	}
 	found := false
 	for _, l := range logs {
-		if strings.Contains(l, "babysit complete") {
+		if strings.Contains(l, "CI monitoring complete") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Fatalf("expected 'babysit complete' log, got: %v", logs)
+		t.Fatalf("expected 'CI monitoring complete' log, got: %v", logs)
 	}
 }
 
-func TestBabysitStep_LogsWaitingForChecksDuringGracePeriod(t *testing.T) {
+func TestCIStep_LogsWaitingForChecksDuringGracePeriod(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
-	binDir := fakeBabysitGH(t, "OPEN", "[]")
+	binDir := fakeCIGH(t, "OPEN", "[]")
 	prependPATH(t, binDir)
 
 	prURL := "https://github.com/test/repo/pull/42"
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Run.PRURL = &prURL
-	sctx.Config.BabysitTimeout = 5 * time.Second
+	sctx.Config.CITimeout = 5 * time.Second
 
 	var logs []string
 	sctx.Log = func(s string) { logs = append(logs, s) }
 
 	current := time.Date(2026, time.January, 1, 12, 0, 0, 0, time.UTC)
-	step := &BabysitStep{
+	step := &CIStep{
 		checksGracePeriod:    50 * time.Millisecond,
 		pollIntervalOverride: 10 * time.Millisecond,
 		now:                  func() time.Time { return current },
@@ -3608,24 +3608,24 @@ func TestBabysitStep_LogsWaitingForChecksDuringGracePeriod(t *testing.T) {
 	}
 }
 
-func TestBabysitStep_NonEmptyPassingChecksExitImmediately(t *testing.T) {
+func TestCIStep_NonEmptyPassingChecksExitImmediately(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	checksJSON := `[{"name":"build","state":"SUCCESS","bucket":"pass"}]`
-	binDir := fakeBabysitGH(t, "OPEN", checksJSON)
+	binDir := fakeCIGH(t, "OPEN", checksJSON)
 	prependPATH(t, binDir)
 
 	prURL := "https://github.com/test/repo/pull/42"
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Run.PRURL = &prURL
-	sctx.Config.BabysitTimeout = 10 * time.Second
+	sctx.Config.CITimeout = 10 * time.Second
 
 	var logs []string
 	sctx.Log = func(s string) { logs = append(logs, s) }
 
 	// Even with a long grace period, non-empty passing checks should exit immediately
-	step := &BabysitStep{checksGracePeriod: 10 * time.Second}
+	step := &CIStep{checksGracePeriod: 10 * time.Second}
 	started := time.Now()
 	outcome, err := step.Execute(sctx)
 	elapsed := time.Since(started)
@@ -3722,7 +3722,7 @@ func TestPRStep_AgentScopedBreakingTitlePassesThrough(t *testing.T) {
 	}
 }
 
-func TestBabysitStep_CIAutoFixDisabledWithZero(t *testing.T) {
+func TestCIStep_CIAutoFixDisabledWithZero(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	checksJSON := `[
@@ -3731,7 +3731,7 @@ func TestBabysitStep_CIAutoFixDisabledWithZero(t *testing.T) {
 		{"name":"lint","status":"COMPLETED","conclusion":"action_required"},
 		{"name":"deploy","status":"COMPLETED","conclusion":"neutral"}
 	]`
-	binDir := fakeBabysitGH(t, "OPEN", checksJSON)
+	binDir := fakeCIGH(t, "OPEN", checksJSON)
 	prependPATH(t, binDir)
 
 	ag := &mockAgent{name: "test"}
@@ -3739,15 +3739,15 @@ func TestBabysitStep_CIAutoFixDisabledWithZero(t *testing.T) {
 	prURL := "https://github.com/test/repo/pull/42"
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Run.PRURL = &prURL
-	sctx.Config.BabysitTimeout = 5 * time.Second
-	sctx.Config.AutoFix = config.AutoFix{Babysit: 0} // disabled
-	sctx.Config.BabysitTimeout = 3 * time.Second
+	sctx.Config.CITimeout = 5 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{CI: 0} // disabled
+	sctx.Config.CITimeout = 3 * time.Second
 
 	var logs []string
 	sctx.Log = func(s string) { logs = append(logs, s) }
 
 	pollCount := 0
-	step := &BabysitStep{
+	step := &CIStep{
 		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
 			pollCount++
 			return nil
@@ -3758,7 +3758,7 @@ func TestBabysitStep_CIAutoFixDisabledWithZero(t *testing.T) {
 		t.Fatalf("expected approval outcome, got error: %v", err)
 	}
 	if !outcome.NeedsApproval {
-		t.Fatal("expected approval needed when babysit auto-fix is disabled")
+		t.Fatal("expected approval needed when CI auto-fix is disabled")
 	}
 	if outcome.AutoFixable {
 		t.Fatal("expected manual intervention outcome to be non-auto-fixable")
@@ -3783,7 +3783,7 @@ func TestBabysitStep_CIAutoFixDisabledWithZero(t *testing.T) {
 
 	// Agent should NOT have been called
 	if len(ag.calls) > 0 {
-		t.Errorf("expected no agent calls when babysit_ci=0, got %d", len(ag.calls))
+		t.Errorf("expected no agent calls when ci=0, got %d", len(ag.calls))
 	}
 
 	// Should log that auto-fix is disabled
@@ -3799,7 +3799,7 @@ func TestBabysitStep_CIAutoFixDisabledWithZero(t *testing.T) {
 	}
 }
 
-func TestBabysitStep_CIAutoFixLimitExhausted(t *testing.T) {
+func TestCIStep_CIAutoFixLimitExhausted(t *testing.T) {
 	// Set up upstream bare repo for push
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
@@ -3824,7 +3824,7 @@ func TestBabysitStep_CIAutoFixLimitExhausted(t *testing.T) {
 	gitCmd(t, dir, "push", "origin", "feature")
 
 	checksJSON := `[{"name":"test","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`
-	binDir := fakeBabysitGH(t, "OPEN", checksJSON)
+	binDir := fakeCIGH(t, "OPEN", checksJSON)
 	prependPATH(t, binDir)
 
 	fixCount := 0
@@ -3843,14 +3843,14 @@ func TestBabysitStep_CIAutoFixLimitExhausted(t *testing.T) {
 	sctx.Run.PRURL = &prURL
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "refs/heads/feature"
-	sctx.Config.BabysitTimeout = 30 * time.Second
-	sctx.Config.AutoFix = config.AutoFix{Babysit: 1} // only 1 attempt allowed
+	sctx.Config.CITimeout = 30 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{CI: 1} // only 1 attempt allowed
 
 	var logs []string
 	sctx.Log = func(s string) { logs = append(logs, s) }
 
 	pollCount := 0
-	step := &BabysitStep{
+	step := &CIStep{
 		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
 			pollCount++
 			return nil
@@ -3861,10 +3861,10 @@ func TestBabysitStep_CIAutoFixLimitExhausted(t *testing.T) {
 		t.Fatalf("expected approval outcome, got error: %v", err)
 	}
 	if !outcome.NeedsApproval {
-		t.Fatal("expected approval needed when babysit auto-fix limit is exhausted")
+		t.Fatal("expected approval needed when CI auto-fix limit is exhausted")
 	}
 	if outcome.AutoFixable {
-		t.Fatal("expected exhausted babysit outcome to be non-auto-fixable")
+		t.Fatal("expected exhausted CI outcome to be non-auto-fixable")
 	}
 
 	// Agent should have been called exactly once (limit is 1)
@@ -3888,7 +3888,7 @@ func TestBabysitStep_CIAutoFixLimitExhausted(t *testing.T) {
 	}
 }
 
-func TestBabysitStep_CIAutoFixRetriesAfterChecksRerun(t *testing.T) {
+func TestCIStep_CIAutoFixRetriesAfterChecksRerun(t *testing.T) {
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -3918,7 +3918,7 @@ func TestBabysitStep_CIAutoFixRetriesAfterChecksRerun(t *testing.T) {
 		`[{"name":"test","status":"IN_PROGRESS","bucket":"pending"}]`,
 		`[{"name":"test","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`,
 	}
-	binDir := fakeBabysitGHSequence(t, "OPEN", checksSequence)
+	binDir := fakeCIGHSequence(t, "OPEN", checksSequence)
 	prependPATH(t, binDir)
 
 	fixCount := 0
@@ -3936,14 +3936,14 @@ func TestBabysitStep_CIAutoFixRetriesAfterChecksRerun(t *testing.T) {
 	sctx.Run.PRURL = &prURL
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "refs/heads/feature"
-	sctx.Config.BabysitTimeout = 10 * time.Second
-	sctx.Config.AutoFix = config.AutoFix{Babysit: 2}
+	sctx.Config.CITimeout = 10 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{CI: 2}
 
 	var logs []string
 	sctx.Log = func(s string) { logs = append(logs, s) }
 
 	pollCount := 0
-	step := &BabysitStep{
+	step := &CIStep{
 		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
 			pollCount++
 			return nil
@@ -3957,7 +3957,7 @@ func TestBabysitStep_CIAutoFixRetriesAfterChecksRerun(t *testing.T) {
 		t.Fatal("expected approval after exhausting rerun-backed retries")
 	}
 	if outcome.AutoFixable {
-		t.Fatal("expected exhausted babysit outcome to be non-auto-fixable")
+		t.Fatal("expected exhausted CI outcome to be non-auto-fixable")
 	}
 	if fixCount != 2 {
 		t.Fatalf("expected 2 auto-fix attempts after reruns, got %d", fixCount)
@@ -3978,7 +3978,7 @@ func TestBabysitStep_CIAutoFixRetriesAfterChecksRerun(t *testing.T) {
 	}
 }
 
-func TestBabysitStep_FixMode_ManualInterventionRunsCIFix(t *testing.T) {
+func TestCIStep_FixMode_ManualInterventionRunsCIFix(t *testing.T) {
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -4002,7 +4002,7 @@ func TestBabysitStep_FixMode_ManualInterventionRunsCIFix(t *testing.T) {
 	gitCmd(t, dir, "push", "origin", "feature")
 
 	checksJSON := `[{"name":"test","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`
-	binDir := fakeBabysitGH(t, "OPEN", checksJSON)
+	binDir := fakeCIGH(t, "OPEN", checksJSON)
 	prependPATH(t, binDir)
 
 	fixCount := 0
@@ -4032,8 +4032,8 @@ func TestBabysitStep_FixMode_ManualInterventionRunsCIFix(t *testing.T) {
 	sctx.Run.PRURL = &prURL
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "refs/heads/feature"
-	sctx.Config.BabysitTimeout = 30 * time.Second
-	sctx.Config.AutoFix = config.AutoFix{Babysit: 0}
+	sctx.Config.CITimeout = 30 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{CI: 0}
 	sctx.Fixing = true
 	sctx.PreviousFindings = string(findingsJSON)
 
@@ -4042,7 +4042,7 @@ func TestBabysitStep_FixMode_ManualInterventionRunsCIFix(t *testing.T) {
 	sctx.Ctx = ctx
 
 	pollCount := 0
-	step := &BabysitStep{
+	step := &CIStep{
 		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
 			pollCount++
 			if pollCount == 2 {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -215,7 +215,7 @@ func (m Model) View() string {
 	}
 
 	showSelectionActions, allowFix, selectedCount, totalCount := m.awaitingActionState()
-	hasBabysit := isBabysitActive(m.steps)
+	hasCI := isCIActive(m.steps)
 	compact := m.height > 0 && m.height < 24
 	sectionGap := "\n\n"
 	sectionGapHeight := 2
@@ -235,7 +235,7 @@ func (m Model) View() string {
 	// Compute elapsed times for running steps so they display live durations.
 	pipelineSteps := m.stepsWithRunningElapsed()
 	pipelineHeight := m.height
-	if !useResponsiveLayout && (m.showHelp || hasBabysit) && (pipelineHeight == 0 || pipelineHeight >= 30) {
+	if !useResponsiveLayout && (m.showHelp || hasCI) && (pipelineHeight == 0 || pipelineHeight >= 30) {
 		pipelineHeight = cappedPipelineHeight
 	}
 	pipelineView := renderPipelineView(m.run, pipelineSteps, leftWidth, m.spinnerFrame, pipelineHeight)
@@ -300,8 +300,8 @@ func (m Model) View() string {
 		appendExtraSection(renderErrorBox(m.err, rightWidth))
 	}
 
-	// Babysit-specific view when babysit step is active.
-	if !m.showHelp && hasBabysit {
+	// CI-specific view when CI step is active.
+	if !m.showHelp && hasCI {
 		findings := ""
 		cursor := 0
 		var selected map[string]bool
@@ -310,17 +310,17 @@ func (m Model) View() string {
 			cursor = m.findingCursor[step.StepName]
 			selected = m.findingSelections[step.StepName]
 		}
-		babysitHeight := -1
+		ciHeight := -1
 		if m.height > 0 {
-			babysitHeight = m.height
+			ciHeight = m.height
 		}
 		if contentBudget >= 0 {
-			babysitHeight = contentBudget
+			ciHeight = contentBudget
 		}
-		appendExtraSection(renderBabysitViewWithSelection(m.run, m.steps, findings, m.logs, rightWidth, babysitHeight, cursor, selected))
+		appendExtraSection(renderCIViewWithSelection(m.run, m.steps, findings, m.logs, rightWidth, ciHeight, cursor, selected))
 	} else if !m.showHelp {
 		if step := awaitingStep(m.steps); step != nil {
-			// Generic findings or diff for non-babysit steps awaiting approval.
+			// Generic findings or diff for non-CI steps awaiting approval.
 			label := stepLabel(step.StepName)
 			if m.showDiff {
 				if raw, ok := m.stepDiffs[step.StepName]; ok && raw != "" {
@@ -364,7 +364,7 @@ func (m Model) View() string {
 	// In responsive layout with no other right-column content, expand to
 	// fill the remaining vertical budget so the log panel matches the
 	// pipeline panel height. Otherwise use compact defaults.
-	// Also hidden when babysit is active (log context integrated into babysit box).
+	// Also hidden when CI is active (log context integrated into CI box).
 	logLines := 5
 	if useResponsiveLayout && !m.showHelp && contentBudget > 0 && len(extraSections) == 0 {
 		logLines = contentBudget - 2 // subtract box borders
@@ -377,7 +377,7 @@ func (m Model) View() string {
 	if m.height > 0 && m.height < 20 {
 		logLines = 0
 	}
-	if len(m.logs) > 0 && logLines > 0 && !hasBabysit {
+	if len(m.logs) > 0 && logLines > 0 && !hasCI {
 		appendExtraSection(renderLogBox(m.logs, rightWidth, logLines, contentBudget))
 	}
 
@@ -608,7 +608,7 @@ func joinSections(sections []string, gap string) string {
 }
 
 func hasResponsiveSidebarContent(m Model) bool {
-	if m.err != nil || m.showHelp || isBabysitActive(m.steps) {
+	if m.err != nil || m.showHelp || isCIActive(m.steps) {
 		return true
 	}
 	if awaitingStep(m.steps) != nil {

--- a/internal/tui/ci.go
+++ b/internal/tui/ci.go
@@ -9,10 +9,10 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
-// isBabysitActive returns true if the babysit step is currently running.
-func isBabysitActive(steps []ipc.StepResultInfo) bool {
+// isCIActive returns true if the CI step is currently running.
+func isCIActive(steps []ipc.StepResultInfo) bool {
 	for _, s := range steps {
-		if s.StepName == types.StepBabysit {
+		if s.StepName == types.StepCI {
 			switch s.Status {
 			case types.StepStatusRunning:
 				return true
@@ -22,18 +22,18 @@ func isBabysitActive(steps []ipc.StepResultInfo) bool {
 	return false
 }
 
-// babysitStepStatus returns the current status of the babysit step.
-func babysitStepStatus(steps []ipc.StepResultInfo) types.StepStatus {
+// ciStepStatus returns the current status of the CI step.
+func ciStepStatus(steps []ipc.StepResultInfo) types.StepStatus {
 	for _, s := range steps {
-		if s.StepName == types.StepBabysit {
+		if s.StepName == types.StepCI {
 			return s.Status
 		}
 	}
 	return types.StepStatusPending
 }
 
-// extractPRFromLogs extracts the PR number from babysit log messages.
-// Looks for the "babysitting PR #42" pattern. Returns empty if not found.
+// extractPRFromLogs extracts the PR number from CI log messages.
+// Looks for the "monitoring CI for PR #42" pattern. Returns empty if not found.
 func extractPRFromLogs(logs []string) string {
 	for _, line := range logs {
 		if idx := strings.Index(line, "PR #"); idx >= 0 {
@@ -51,16 +51,16 @@ func extractPRFromLogs(logs []string) string {
 	return ""
 }
 
-// babysitActivity summarizes what the babysit step has been doing based on logs.
-type babysitActivity struct {
+// ciActivity summarizes what the CI step has been doing based on logs.
+type ciActivity struct {
 	CIFixes    int
 	AutoFixing bool
 	LastEvent  string
 }
 
-// parseBabysitActivity extracts structured activity from babysit log messages.
-func parseBabysitActivity(logs []string) babysitActivity {
-	var a babysitActivity
+// parseCIActivity extracts structured activity from CI log messages.
+func parseCIActivity(logs []string) ciActivity {
+	var a ciActivity
 	for _, line := range logs {
 		switch {
 		case strings.Contains(line, "CI failures detected"):
@@ -73,26 +73,26 @@ func parseBabysitActivity(logs []string) babysitActivity {
 		case strings.Contains(line, "running agent to fix CI"):
 			a.AutoFixing = true
 			a.LastEvent = line
-		case strings.Contains(line, "babysitting PR"):
+		case strings.Contains(line, "monitoring CI for PR"):
 			a.LastEvent = line
 		case strings.Contains(line, "PR has been merged"):
 			a.LastEvent = line
 		case strings.Contains(line, "PR has been closed"):
 			a.LastEvent = line
-		case strings.Contains(line, "babysit timeout"):
+		case strings.Contains(line, "CI timeout"):
 			a.LastEvent = line
 		}
 	}
 	return a
 }
 
-// renderBabysitView renders the babysit-specific monitoring view.
-// Shown instead of generic findings when the babysit step is active.
-func renderBabysitView(run *ipc.RunInfo, steps []ipc.StepResultInfo, findings string, logs []string, width int) string {
-	return renderBabysitViewWithSelection(run, steps, findings, logs, width, -1, 0, nil)
+// renderCIView renders the CI-specific monitoring view.
+// Shown instead of generic findings when the CI step is active.
+func renderCIView(run *ipc.RunInfo, steps []ipc.StepResultInfo, findings string, logs []string, width int) string {
+	return renderCIViewWithSelection(run, steps, findings, logs, width, -1, 0, nil)
 }
 
-func renderBabysitViewWithSelection(run *ipc.RunInfo, steps []ipc.StepResultInfo, findings string, logs []string, width int, height int, cursor int, selected map[string]bool) string {
+func renderCIViewWithSelection(run *ipc.RunInfo, steps []ipc.StepResultInfo, findings string, logs []string, width int, height int, cursor int, selected map[string]bool) string {
 	var b strings.Builder
 
 	boxWidth := width
@@ -111,8 +111,8 @@ func renderBabysitViewWithSelection(run *ipc.RunInfo, steps []ipc.StepResultInfo
 	}
 
 	// State indicator.
-	status := babysitStepStatus(steps)
-	activity := parseBabysitActivity(logs)
+	status := ciStepStatus(steps)
+	activity := parseCIActivity(logs)
 
 	b.WriteString("\n")
 
@@ -166,5 +166,5 @@ func renderBabysitViewWithSelection(run *ipc.RunInfo, steps []ipc.StepResultInfo
 		}
 	}
 
-	return renderBox("Babysit", b.String(), boxWidth)
+	return renderBox("CI", b.String(), boxWidth)
 }

--- a/internal/tui/pipeline.go
+++ b/internal/tui/pipeline.go
@@ -93,8 +93,8 @@ func stepLabel(name types.StepName) string {
 		return "Push"
 	case types.StepPR:
 		return "PR"
-	case types.StepBabysit:
-		return "Babysit"
+	case types.StepCI:
+		return "CI"
 	default:
 		return string(name)
 	}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -73,7 +73,7 @@ func TestStepLabel(t *testing.T) {
 		{types.StepLint, "Lint"},
 		{types.StepPush, "Push"},
 		{types.StepPR, "PR"},
-		{types.StepBabysit, "Babysit"},
+		{types.StepCI, "CI"},
 	}
 	for _, tt := range tests {
 		if got := stepLabel(tt.name); got != tt.label {
@@ -1669,56 +1669,56 @@ func TestRenderPipelineView_DiffKey(t *testing.T) {
 	}
 }
 
-// --- Babysit view tests ---
+// --- CI view tests ---
 
-func testRunWithBabysit() *ipc.RunInfo {
+func testRunWithCI() *ipc.RunInfo {
 	run := testRun()
 	run.Steps = append(run.Steps, ipc.StepResultInfo{
-		ID: "s6", StepName: types.StepBabysit, StepOrder: 6, Status: types.StepStatusPending,
+		ID: "s6", StepName: types.StepCI, StepOrder: 6, Status: types.StepStatusPending,
 	})
 	return run
 }
 
-func TestIsBabysitActive(t *testing.T) {
-	run := testRunWithBabysit()
+func TestIsCIActive(t *testing.T) {
+	run := testRunWithCI()
 
 	// Pending → not active.
-	if isBabysitActive(run.Steps) {
-		t.Error("expected false when babysit is pending")
+	if isCIActive(run.Steps) {
+		t.Error("expected false when CI is pending")
 	}
 
 	// Running → active.
 	run.Steps[5].Status = types.StepStatusRunning
-	if !isBabysitActive(run.Steps) {
-		t.Error("expected true when babysit is running")
+	if !isCIActive(run.Steps) {
+		t.Error("expected true when CI is running")
 	}
 
 	// Completed → not active.
 	run.Steps[5].Status = types.StepStatusCompleted
-	if isBabysitActive(run.Steps) {
-		t.Error("expected false when babysit is completed")
+	if isCIActive(run.Steps) {
+		t.Error("expected false when CI is completed")
 	}
 }
 
-func TestIsBabysitActive_NoBabysitStep(t *testing.T) {
-	run := testRun() // no babysit step
-	if isBabysitActive(run.Steps) {
-		t.Error("expected false when no babysit step exists")
+func TestIsCIActive_NoCIStep(t *testing.T) {
+	run := testRun() // no CI step
+	if isCIActive(run.Steps) {
+		t.Error("expected false when no CI step exists")
 	}
 }
 
-func TestBabysitStepStatus(t *testing.T) {
-	run := testRunWithBabysit()
+func TestCIStepStatus(t *testing.T) {
+	run := testRunWithCI()
 	run.Steps[5].Status = types.StepStatusRunning
 
-	if got := babysitStepStatus(run.Steps); got != types.StepStatusRunning {
+	if got := ciStepStatus(run.Steps); got != types.StepStatusRunning {
 		t.Errorf("expected running, got %s", got)
 	}
 }
 
-func TestBabysitStepStatus_NoBabysitStep(t *testing.T) {
+func TestCIStepStatus_NoCIStep(t *testing.T) {
 	run := testRun()
-	if got := babysitStepStatus(run.Steps); got != types.StepStatusPending {
+	if got := ciStepStatus(run.Steps); got != types.StepStatusPending {
 		t.Errorf("expected pending (default), got %s", got)
 	}
 }
@@ -1730,15 +1730,15 @@ func TestExtractPRFromLogs(t *testing.T) {
 		want string
 	}{
 		{
-			name: "standard babysit message",
-			logs: []string{"babysitting PR #42 (timeout: 4h)..."},
+			name: "standard CI message",
+			logs: []string{"monitoring CI for PR #42 (timeout: 4h)..."},
 			want: "42",
 		},
 		{
 			name: "multiple logs",
 			logs: []string{
 				"some other log",
-				"babysitting PR #123 (timeout: 4h)...",
+				"monitoring CI for PR #123 (timeout: 4h)...",
 				"CI failures detected",
 			},
 			want: "123",
@@ -1763,24 +1763,24 @@ func TestExtractPRFromLogs(t *testing.T) {
 	}
 }
 
-func TestParseBabysitActivity(t *testing.T) {
+func TestParseCIActivity(t *testing.T) {
 	t.Run("empty logs", func(t *testing.T) {
-		a := parseBabysitActivity(nil)
+		a := parseCIActivity(nil)
 		if a.CIFixes != 0 || a.AutoFixing || a.LastEvent != "" {
 			t.Error("expected zero activity for empty logs")
 		}
 	})
 
 	t.Run("polling", func(t *testing.T) {
-		a := parseBabysitActivity([]string{"babysitting PR #42 (timeout: 4h)..."})
+		a := parseCIActivity([]string{"monitoring CI for PR #42 (timeout: 4h)..."})
 		if a.LastEvent == "" {
 			t.Error("expected last event set")
 		}
 	})
 
 	t.Run("ci failure detected", func(t *testing.T) {
-		a := parseBabysitActivity([]string{
-			"babysitting PR #42 (timeout: 4h)...",
+		a := parseCIActivity([]string{
+			"monitoring CI for PR #42 (timeout: 4h)...",
 			"CI failures detected: test — auto-fixing...",
 		})
 		if a.CIFixes != 1 {
@@ -1792,7 +1792,7 @@ func TestParseBabysitActivity(t *testing.T) {
 	})
 
 	t.Run("ci fix completed", func(t *testing.T) {
-		a := parseBabysitActivity([]string{
+		a := parseCIActivity([]string{
 			"CI failures detected: test — auto-fixing...",
 			"running agent to fix CI failures...",
 			"committed and pushed fixes",
@@ -1806,7 +1806,7 @@ func TestParseBabysitActivity(t *testing.T) {
 	})
 
 	t.Run("multiple ci fixes", func(t *testing.T) {
-		a := parseBabysitActivity([]string{
+		a := parseCIActivity([]string{
 			"CI failures detected: test",
 			"committed and pushed fixes",
 			"CI failures detected: lint",
@@ -1818,8 +1818,8 @@ func TestParseBabysitActivity(t *testing.T) {
 	})
 
 	t.Run("pr merged", func(t *testing.T) {
-		a := parseBabysitActivity([]string{
-			"babysitting PR #42 (timeout: 4h)...",
+		a := parseCIActivity([]string{
+			"monitoring CI for PR #42 (timeout: 4h)...",
 			"PR has been merged!",
 		})
 		if !strings.Contains(a.LastEvent, "merged") {
@@ -1828,57 +1828,57 @@ func TestParseBabysitActivity(t *testing.T) {
 	})
 
 	t.Run("pr closed", func(t *testing.T) {
-		a := parseBabysitActivity([]string{"PR has been closed"})
+		a := parseCIActivity([]string{"PR has been closed"})
 		if !strings.Contains(a.LastEvent, "closed") {
 			t.Error("expected closed as last event")
 		}
 	})
 
 	t.Run("timeout", func(t *testing.T) {
-		a := parseBabysitActivity([]string{"babysit timeout reached"})
+		a := parseCIActivity([]string{"CI timeout reached"})
 		if !strings.Contains(a.LastEvent, "timeout") {
 			t.Error("expected timeout as last event")
 		}
 	})
 }
 
-func TestRenderBabysitView_Monitoring(t *testing.T) {
-	run := testRunWithBabysit()
+func TestRenderCIView_Monitoring(t *testing.T) {
+	run := testRunWithCI()
 	run.Steps[5].Status = types.StepStatusRunning
-	logs := []string{"babysitting PR #42 (timeout: 4h)..."}
+	logs := []string{"monitoring CI for PR #42 (timeout: 4h)..."}
 
-	out := renderBabysitView(run, run.Steps, "", logs, 80)
+	out := renderCIView(run, run.Steps, "", logs, 80)
 
-	if !strings.Contains(stripANSI(out), "Babysit") {
-		t.Error("expected Babysit box title")
+	if !strings.Contains(stripANSI(out), "CI") {
+		t.Error("expected CI box title")
 	}
 	if !strings.Contains(out, "Monitoring") {
 		t.Error("expected monitoring state")
 	}
 }
 
-func TestRenderBabysitView_ShowsPRContextFromURL(t *testing.T) {
-	run := testRunWithBabysit()
+func TestRenderCIView_ShowsPRContextFromURL(t *testing.T) {
+	run := testRunWithCI()
 	run.PRURL = ptr("https://github.com/user/repo/pull/99")
 	run.Steps[5].Status = types.StepStatusRunning
 
-	out := stripANSI(renderBabysitView(run, run.Steps, "", nil, 80))
+	out := stripANSI(renderCIView(run, run.Steps, "", nil, 80))
 
 	if !strings.Contains(out, "PR #99") {
-		t.Fatalf("expected babysit panel to show PR context, got: %s", out)
+		t.Fatalf("expected CI panel to show PR context, got: %s", out)
 	}
 }
 
-func TestRenderBabysitView_AutoFixing(t *testing.T) {
-	run := testRunWithBabysit()
+func TestRenderCIView_AutoFixing(t *testing.T) {
+	run := testRunWithCI()
 	run.Steps[5].Status = types.StepStatusRunning
 	logs := []string{
-		"babysitting PR #42 (timeout: 4h)...",
+		"monitoring CI for PR #42 (timeout: 4h)...",
 		"CI failures detected: test — auto-fixing...",
 		"running agent to fix CI failures...",
 	}
 
-	out := renderBabysitView(run, run.Steps, "", logs, 80)
+	out := renderCIView(run, run.Steps, "", logs, 80)
 
 	if !strings.Contains(out, "Auto-fixing CI") {
 		t.Error("expected auto-fixing state indicator")
@@ -1888,15 +1888,15 @@ func TestRenderBabysitView_AutoFixing(t *testing.T) {
 	}
 }
 
-func TestRenderBabysitView_LastActivity(t *testing.T) {
-	run := testRunWithBabysit()
+func TestRenderCIView_LastActivity(t *testing.T) {
+	run := testRunWithCI()
 	run.Steps[5].Status = types.StepStatusRunning
 	logs := []string{
-		"babysitting PR #42 (timeout: 4h)...",
+		"monitoring CI for PR #42 (timeout: 4h)...",
 		"committed and pushed fixes",
 	}
 
-	out := renderBabysitView(run, run.Steps, "", logs, 80)
+	out := renderCIView(run, run.Steps, "", logs, 80)
 
 	if !strings.Contains(out, "Latest:") {
 		t.Error("expected latest activity line")
@@ -1906,41 +1906,41 @@ func TestRenderBabysitView_LastActivity(t *testing.T) {
 	}
 }
 
-func TestModel_View_BabysitViewWhenActive(t *testing.T) {
-	run := testRunWithBabysit()
+func TestModel_View_CIViewWhenActive(t *testing.T) {
+	run := testRunWithCI()
 	m := NewModel("/tmp/sock", nil, run)
 	m.steps = run.Steps
 	m.steps[5].Status = types.StepStatusRunning
-	m.logs = []string{"babysitting PR #42 (timeout: 4h)..."}
+	m.logs = []string{"monitoring CI for PR #42 (timeout: 4h)..."}
 
 	view := m.View()
 
-	if !strings.Contains(stripANSI(view), "Babysit") {
-		t.Error("expected babysit box in model output")
+	if !strings.Contains(stripANSI(view), "CI") {
+		t.Error("expected CI box in model output")
 	}
 	if !strings.Contains(view, "Monitoring") {
 		t.Error("expected monitoring state in model output")
 	}
 }
 
-func TestModel_View_NonBabysitStepUsesGenericFindings(t *testing.T) {
-	run := testRun() // no babysit step
+func TestModel_View_NonCIStepUsesGenericFindings(t *testing.T) {
+	run := testRun() // no CI step
 	m := NewModel("/tmp/sock", nil, run)
 	m.steps[0].Status = types.StepStatusAwaitingApproval
 	m.stepFindings[types.StepReview] = `{"findings":[{"severity":"error","description":"critical bug"}],"summary":"1 issue"}`
 
 	view := m.View()
 
-	// Should use generic findings, not babysit view.
-	// Check that no "Babysit" titled box appears (only Pipeline/Findings boxes).
-	hasBabysitBox := false
+	// Should use generic findings, not CI view.
+	// Check that no "CI" titled box appears (only Pipeline/Findings boxes).
+	hasCIBox := false
 	for _, line := range strings.Split(stripANSI(view), "\n") {
-		if strings.Contains(line, "╭") && strings.Contains(line, "Babysit") {
-			hasBabysitBox = true
+		if strings.Contains(line, "╭") && strings.Contains(line, "CI") {
+			hasCIBox = true
 		}
 	}
-	if hasBabysitBox {
-		t.Error("expected generic findings view, not babysit box")
+	if hasCIBox {
+		t.Error("expected generic findings view, not CI box")
 	}
 	if !strings.Contains(view, "critical bug") {
 		t.Error("expected generic findings content")
@@ -2239,23 +2239,23 @@ func TestModel_View_FindingsInBox(t *testing.T) {
 	}
 }
 
-func TestRenderBabysitView_WrappedInBox(t *testing.T) {
-	run := testRunWithBabysit()
+func TestRenderCIView_WrappedInBox(t *testing.T) {
+	run := testRunWithCI()
 	run.Steps[5].Status = types.StepStatusRunning
-	logs := []string{"babysitting PR #42 (timeout: 4h)..."}
+	logs := []string{"monitoring CI for PR #42 (timeout: 4h)..."}
 
-	out := stripANSI(renderBabysitView(run, run.Steps, "", logs, 80))
+	out := stripANSI(renderCIView(run, run.Steps, "", logs, 80))
 
-	// Should be wrapped in a box with "Babysit" title per DESIGN.md.
+	// Should be wrapped in a box with "CI" title per DESIGN.md.
 	lines := strings.Split(out, "\n")
 	if len(lines) == 0 {
 		t.Fatal("expected non-empty output")
 	}
-	if !strings.Contains(lines[0], "Babysit") {
-		t.Errorf("expected 'Babysit' title in top border, got %q", lines[0])
+	if !strings.Contains(lines[0], "CI") {
+		t.Errorf("expected 'CI' title in top border, got %q", lines[0])
 	}
 	if !strings.Contains(lines[0], "╭") {
-		t.Error("expected rounded top-left corner in babysit box")
+		t.Error("expected rounded top-left corner in CI box")
 	}
 	// Should have rounded bottom corner.
 	hasBottom := false
@@ -2266,29 +2266,29 @@ func TestRenderBabysitView_WrappedInBox(t *testing.T) {
 		}
 	}
 	if !hasBottom {
-		t.Error("expected rounded bottom border in babysit box")
+		t.Error("expected rounded bottom border in CI box")
 	}
 }
 
-func TestRenderBabysitView_NoRedundantHeader(t *testing.T) {
-	// The box title "Babysit" replaces the old "◉ Babysit Monitor" header.
-	run := testRunWithBabysit()
+func TestRenderCIView_NoRedundantHeader(t *testing.T) {
+	// The box title "CI" replaces the old "◉ CI Monitor" header.
+	run := testRunWithCI()
 	run.Steps[5].Status = types.StepStatusRunning
-	logs := []string{"babysitting PR #42 (timeout: 4h)..."}
+	logs := []string{"monitoring CI for PR #42 (timeout: 4h)..."}
 
-	out := stripANSI(renderBabysitView(run, run.Steps, "", logs, 80))
+	out := stripANSI(renderCIView(run, run.Steps, "", logs, 80))
 
-	if strings.Contains(out, "Babysit Monitor") {
-		t.Error("expected no redundant 'Babysit Monitor' header - box title handles it")
+	if strings.Contains(out, "CI Monitor") {
+		t.Error("expected no redundant 'CI Monitor' header - box title handles it")
 	}
 }
 
-func TestRenderBabysitView_ContentInsideBox(t *testing.T) {
-	run := testRunWithBabysit()
+func TestRenderCIView_ContentInsideBox(t *testing.T) {
+	run := testRunWithCI()
 	run.Steps[5].Status = types.StepStatusRunning
-	logs := []string{"babysitting PR #42 (timeout: 4h)..."}
+	logs := []string{"monitoring CI for PR #42 (timeout: 4h)..."}
 
-	out := stripANSI(renderBabysitView(run, run.Steps, "", logs, 80))
+	out := stripANSI(renderCIView(run, run.Steps, "", logs, 80))
 
 	// State should be inside box borders.
 	foundState := false
@@ -2302,26 +2302,26 @@ func TestRenderBabysitView_ContentInsideBox(t *testing.T) {
 	}
 }
 
-func TestModel_View_BabysitViewInBox(t *testing.T) {
-	run := testRunWithBabysit()
+func TestModel_View_CIViewInBox(t *testing.T) {
+	run := testRunWithCI()
 	m := NewModel("/tmp/sock", nil, run)
 	m.steps = run.Steps
 	m.steps[5].Status = types.StepStatusRunning
-	m.logs = []string{"babysitting PR #42 (timeout: 4h)..."}
+	m.logs = []string{"monitoring CI for PR #42 (timeout: 4h)..."}
 	m.width = 80
 
 	view := stripANSI(m.View())
 
-	// The babysit section should be in a box with "Babysit" title.
-	hasBabysitBox := false
+	// The CI section should be in a box with "CI" title.
+	hasCIBox := false
 	for _, line := range strings.Split(view, "\n") {
-		if strings.Contains(line, "╭") && strings.Contains(line, "Babysit") && !strings.Contains(line, "Pipeline") {
-			hasBabysitBox = true
+		if strings.Contains(line, "╭") && strings.Contains(line, "CI") && !strings.Contains(line, "Pipeline") {
+			hasCIBox = true
 			break
 		}
 	}
-	if !hasBabysitBox {
-		t.Error("expected 'Babysit' titled box in full model view")
+	if !hasCIBox {
+		t.Error("expected 'CI' titled box in full model view")
 	}
 }
 
@@ -2374,8 +2374,8 @@ func TestModel_View_OneBlankLineBetweenSections(t *testing.T) {
 	}
 }
 
-// Spacing between Pipeline and Babysit boxes should also have 1 blank line.
-func TestModel_View_OneBlankLineBetweenPipelineAndBabysit(t *testing.T) {
+// Spacing between Pipeline and CI boxes should also have 1 blank line.
+func TestModel_View_OneBlankLineBetweenPipelineAndCI(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.Ascii)
 	defer lipgloss.SetColorProfile(termenv.ANSI)
 
@@ -2384,12 +2384,12 @@ func TestModel_View_OneBlankLineBetweenPipelineAndBabysit(t *testing.T) {
 		Status: types.RunRunning,
 		Steps: []ipc.StepResultInfo{
 			{ID: "s1", StepName: types.StepReview, StepOrder: 1, Status: types.StepStatusCompleted},
-			{ID: "s2", StepName: types.StepBabysit, StepOrder: 2, Status: types.StepStatusRunning},
+			{ID: "s2", StepName: types.StepCI, StepOrder: 2, Status: types.StepStatusRunning},
 		},
 	}
 	m := NewModel("/tmp/sock", nil, run)
 	m.width = 60
-	m.logs = []string{"babysitting PR #42"}
+	m.logs = []string{"monitoring CI for PR #42"}
 
 	view := m.View()
 	plain := stripANSI(view)
@@ -2988,92 +2988,92 @@ func TestDiffBoxTitle_NoPositionWhenAllVisible(t *testing.T) {
 	}
 }
 
-// --- Babysit box title position indicator tests ---
+// --- CI box title position indicator tests ---
 
-func TestRenderBabysitView_TitleNoPositionWithoutFindings(t *testing.T) {
+func TestRenderCIView_TitleNoPositionWithoutFindings(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.ANSI)
-	run := testRunWithBabysit()
+	run := testRunWithCI()
 	run.Steps[5].Status = types.StepStatusRunning
-	logs := []string{"babysitting PR #42 (timeout: 4h)..."}
+	logs := []string{"monitoring CI for PR #42 (timeout: 4h)..."}
 
-	out := stripANSI(renderBabysitView(run, run.Steps, "", logs, 80))
+	out := stripANSI(renderCIView(run, run.Steps, "", logs, 80))
 	lines := strings.Split(out, "\n")
 
-	// Title should be just "Babysit" without any position indicator.
+	// Title should be just "CI" without any position indicator.
 	titleLine := lines[0]
-	if !strings.Contains(titleLine, "Babysit") {
-		t.Error("expected Babysit in title")
+	if !strings.Contains(titleLine, "CI") {
+		t.Error("expected CI in title")
 	}
 	if strings.Contains(titleLine, "(") {
 		t.Errorf("expected no position indicator when no findings, got: %s", titleLine)
 	}
 }
 
-func TestRenderBabysitView_LogTailDuringMonitoring(t *testing.T) {
+func TestRenderCIView_LogTailDuringMonitoring(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.ANSI)
-	run := testRunWithBabysit()
+	run := testRunWithCI()
 	run.Steps[5].Status = types.StepStatusRunning
 	logs := []string{
-		"babysitting PR #42 (timeout: 4h)...",
+		"monitoring CI for PR #42 (timeout: 4h)...",
 		"polling CI status...",
 		"all checks passing",
 	}
 
-	out := stripANSI(renderBabysitView(run, run.Steps, "", logs, 80))
+	out := stripANSI(renderCIView(run, run.Steps, "", logs, 80))
 
-	// Log tail lines should appear inside the babysit box during monitoring.
+	// Log tail lines should appear inside the CI box during monitoring.
 	if !strings.Contains(out, "polling CI status") {
-		t.Errorf("expected log tail line 'polling CI status' inside babysit box, got:\n%s", out)
+		t.Errorf("expected log tail line 'polling CI status' inside CI box, got:\n%s", out)
 	}
 	if !strings.Contains(out, "all checks passing") {
-		t.Errorf("expected log tail line 'all checks passing' inside babysit box, got:\n%s", out)
+		t.Errorf("expected log tail line 'all checks passing' inside CI box, got:\n%s", out)
 	}
 }
 
-func TestModel_View_NoStandaloneLogBoxDuringBabysit(t *testing.T) {
+func TestModel_View_NoStandaloneLogBoxDuringCI(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.ANSI)
-	run := testRunWithBabysit()
+	run := testRunWithCI()
 	m := NewModel("/tmp/sock", nil, run)
 	m.steps = run.Steps
 	m.steps[5].Status = types.StepStatusRunning
-	m.logs = []string{"babysitting PR #42", "polling CI", "checks passing"}
+	m.logs = []string{"monitoring CI for PR #42", "polling CI", "checks passing"}
 	m.width = 80
 
 	view := stripANSI(m.View())
 
-	// The standalone Log box should NOT appear when babysit is active.
+	// The standalone Log box should NOT appear when CI is active.
 	hasStandaloneLogBox := false
 	for _, line := range strings.Split(view, "\n") {
-		if strings.Contains(line, "╭") && strings.Contains(line, "Log") && !strings.Contains(line, "Babysit") {
+		if strings.Contains(line, "╭") && strings.Contains(line, "Log") && !strings.Contains(line, "CI") {
 			hasStandaloneLogBox = true
 		}
 	}
 	if hasStandaloneLogBox {
-		t.Error("expected no standalone Log box when babysit is active - logs should be inside babysit box")
+		t.Error("expected no standalone Log box when CI is active - logs should be inside CI box")
 	}
 
-	// But log content should still be visible (inside babysit box).
+	// But log content should still be visible (inside CI box).
 	if !strings.Contains(view, "checks passing") {
-		t.Error("expected log content to appear inside babysit box")
+		t.Error("expected log content to appear inside CI box")
 	}
 }
 
-// --- Babysit adaptive log tail ---
+// --- CI adaptive log tail ---
 
-func TestRenderBabysitView_LogTailFillsAvailableHeight(t *testing.T) {
+func TestRenderCIView_LogTailFillsAvailableHeight(t *testing.T) {
 	// Log tail should dynamically fill available height, not use hardcoded line counts.
 	lipgloss.SetColorProfile(termenv.ANSI)
-	run := testRunWithBabysit()
+	run := testRunWithCI()
 	run.Steps[5].Status = types.StepStatusRunning
 
-	manyLogs := []string{"babysitting PR #42 (timeout: 4h)..."}
+	manyLogs := []string{"monitoring CI for PR #42 (timeout: 4h)..."}
 	for i := 1; i <= 30; i++ {
 		manyLogs = append(manyLogs, fmt.Sprintf("log-line-%d", i))
 	}
 
 	// With height=20, more logs should show than with height=10.
-	tall := stripANSI(renderBabysitViewWithSelection(run, run.Steps, "", manyLogs, 80, 20, 0, nil))
-	short := stripANSI(renderBabysitViewWithSelection(run, run.Steps, "", manyLogs, 80, 10, 0, nil))
+	tall := stripANSI(renderCIViewWithSelection(run, run.Steps, "", manyLogs, 80, 20, 0, nil))
+	short := stripANSI(renderCIViewWithSelection(run, run.Steps, "", manyLogs, 80, 10, 0, nil))
 
 	countLogLines := func(s string) int {
 		n := 0
@@ -3093,49 +3093,49 @@ func TestRenderBabysitView_LogTailFillsAvailableHeight(t *testing.T) {
 	}
 }
 
-func TestRenderBabysitView_LogTailTinyStillShowsSome(t *testing.T) {
+func TestRenderCIView_LogTailTinyStillShowsSome(t *testing.T) {
 	// Even with very small height, at least 1 log line should show.
 	lipgloss.SetColorProfile(termenv.ANSI)
-	run := testRunWithBabysit()
+	run := testRunWithCI()
 	run.Steps[5].Status = types.StepStatusRunning
 	logs := []string{
-		"babysitting PR #42 (timeout: 4h)...",
+		"monitoring CI for PR #42 (timeout: 4h)...",
 		"line1",
 		"line2",
 		"all checks passing",
 	}
 
-	out := stripANSI(renderBabysitViewWithSelection(run, run.Steps, "", logs, 80, 10, 0, nil))
+	out := stripANSI(renderCIViewWithSelection(run, run.Steps, "", logs, 80, 10, 0, nil))
 
 	if !strings.Contains(out, "all checks passing") {
 		t.Error("expected at least the last log line even in tiny terminal")
 	}
 }
 
-func TestRenderBabysitView_ZeroHeightOmitsLogTail(t *testing.T) {
+func TestRenderCIView_ZeroHeightOmitsLogTail(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.ANSI)
-	run := testRunWithBabysit()
+	run := testRunWithCI()
 	run.Steps[5].Status = types.StepStatusRunning
 	logs := []string{
-		"babysitting PR #42 (timeout: 4h)...",
+		"monitoring CI for PR #42 (timeout: 4h)...",
 		"polling CI status...",
 		"all checks passing",
 	}
 
-	out := stripANSI(renderBabysitViewWithSelection(run, run.Steps, "", logs, 80, 0, 0, nil))
+	out := stripANSI(renderCIViewWithSelection(run, run.Steps, "", logs, 80, 0, 0, nil))
 
 	if !strings.Contains(out, "Monitoring CI checks") {
-		t.Fatalf("expected babysit status to remain visible, got:\n%s", out)
+		t.Fatalf("expected CI status to remain visible, got:\n%s", out)
 	}
 	if strings.Contains(out, "polling CI status") || strings.Contains(out, "all checks passing") {
-		t.Fatalf("expected zero-height babysit view to omit log tail, got:\n%s", out)
+		t.Fatalf("expected zero-height CI view to omit log tail, got:\n%s", out)
 	}
 }
 
-func TestModel_View_BabysitShortTerminalKeepsStatusPanel(t *testing.T) {
+func TestModel_View_CIShortTerminalKeepsStatusPanel(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.Ascii)
 
-	run := testRunWithBabysit()
+	run := testRunWithCI()
 	run.Steps[5].Status = types.StepStatusRunning
 	run.PRURL = ptr("https://github.com/kunchenguid/no-mistakes/pull/42")
 
@@ -3153,27 +3153,27 @@ func TestModel_View_BabysitShortTerminalKeepsStatusPanel(t *testing.T) {
 	if got := lipgloss.Height(view); got > m.height {
 		t.Fatalf("expected rendered view height <= terminal height (%d), got %d\n%s", m.height, got, view)
 	}
-	if !strings.Contains(view, "Babysit") {
-		t.Fatalf("expected babysit section to remain visible in short terminal\n%s", view)
+	if !strings.Contains(view, "CI") {
+		t.Fatalf("expected CI section to remain visible in short terminal\n%s", view)
 	}
 	if !strings.Contains(view, "Monitoring CI checks") {
-		t.Fatalf("expected babysit status panel to remain visible in short terminal\n%s", view)
+		t.Fatalf("expected CI status panel to remain visible in short terminal\n%s", view)
 	}
 }
 
-func TestRenderBabysitView_LogTailScalesWithHeight(t *testing.T) {
+func TestRenderCIView_LogTailScalesWithHeight(t *testing.T) {
 	// Larger height should show more log lines.
 	lipgloss.SetColorProfile(termenv.ANSI)
-	run := testRunWithBabysit()
+	run := testRunWithCI()
 	run.Steps[5].Status = types.StepStatusRunning
 
-	manyLogs := []string{"babysitting PR #42 (timeout: 4h)..."}
+	manyLogs := []string{"monitoring CI for PR #42 (timeout: 4h)..."}
 	for i := 1; i <= 50; i++ {
 		manyLogs = append(manyLogs, fmt.Sprintf("log-%d", i))
 	}
 
-	tall := stripANSI(renderBabysitViewWithSelection(run, run.Steps, "", manyLogs, 80, 40, 0, nil))
-	compact := stripANSI(renderBabysitViewWithSelection(run, run.Steps, "", manyLogs, 80, 15, 0, nil))
+	tall := stripANSI(renderCIViewWithSelection(run, run.Steps, "", manyLogs, 80, 40, 0, nil))
+	compact := stripANSI(renderCIViewWithSelection(run, run.Steps, "", manyLogs, 80, 15, 0, nil))
 
 	countLogLines := func(s string) int {
 		n := 0
@@ -4554,15 +4554,15 @@ func TestModel_View_LogShortLinesNotTruncated(t *testing.T) {
 	}
 }
 
-func TestRenderBabysitView_LogLongLinesWrapped(t *testing.T) {
+func TestRenderCIView_LogLongLinesWrapped(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.Ascii)
-	run := testRunWithBabysit()
+	run := testRunWithCI()
 	run.Steps[5].Status = types.StepStatusRunning
-	longLog := "babysitting PR #42 (timeout: 4h)..."
+	longLog := "monitoring CI for PR #42 (timeout: 4h)..."
 	longLog2 := "running " + strings.Repeat("y", 200)
 	logs := []string{longLog, longLog2}
 
-	result := stripANSI(renderBabysitView(run, run.Steps, "", logs, 80))
+	result := stripANSI(renderCIView(run, run.Steps, "", logs, 80))
 
 	// No line should exceed the box width (80).
 	for _, line := range strings.Split(result, "\n") {
@@ -4571,12 +4571,12 @@ func TestRenderBabysitView_LogLongLinesWrapped(t *testing.T) {
 		}
 		w := lipgloss.Width(line)
 		if w > 80 {
-			t.Errorf("babysit log line exceeds box width (%d > 80): %s", w, line)
+			t.Errorf("CI log line exceeds box width (%d > 80): %s", w, line)
 		}
 	}
 
 	if got := strings.Count(result, "y"); got < 200 {
-		t.Errorf("expected wrapped babysit log output to preserve all 200 y characters, got %d", got)
+		t.Errorf("expected wrapped CI log output to preserve all 200 y characters, got %d", got)
 	}
 }
 
@@ -5017,31 +5017,31 @@ func TestPipelineView_ShortErrorNotTruncated(t *testing.T) {
 	}
 }
 
-func TestRenderBabysitView_ShowsShortPRContextInPanel(t *testing.T) {
+func TestRenderCIView_ShowsShortPRContextInPanel(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.Ascii)
-	run := testRunWithBabysit()
+	run := testRunWithCI()
 	longURL := "https://github.com/some-very-long-organization-name/some-very-long-repository-name-that-goes-on-and-on/pull/12345"
 	run.PRURL = &longURL
 	run.Steps[5].Status = types.StepStatusRunning
 
-	result := stripANSI(renderBabysitView(run, run.Steps, "", nil, 80))
+	result := stripANSI(renderCIView(run, run.Steps, "", nil, 80))
 
 	if !strings.Contains(result, "PR #12345") {
-		t.Fatalf("expected babysit panel to show short PR context, got: %s", result)
+		t.Fatalf("expected CI panel to show short PR context, got: %s", result)
 	}
 	if strings.Contains(result, longURL) {
-		t.Fatal("expected babysit panel to avoid rendering the full PR URL")
+		t.Fatal("expected CI panel to avoid rendering the full PR URL")
 	}
 }
 
-func TestRenderBabysitView_LongLastEventTruncated(t *testing.T) {
+func TestRenderCIView_LongLastEventTruncated(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.Ascii)
-	run := testRunWithBabysit()
+	run := testRunWithCI()
 	run.Steps[5].Status = types.StepStatusRunning
-	longEvent := "babysitting PR #42 with a very long description " + strings.Repeat("z", 200)
+	longEvent := "monitoring CI for PR #42 with a very long description " + strings.Repeat("z", 200)
 	logs := []string{longEvent}
 
-	result := stripANSI(renderBabysitView(run, run.Steps, "", logs, 80))
+	result := stripANSI(renderCIView(run, run.Steps, "", logs, 80))
 
 	// No line should exceed the box width (80).
 	for _, line := range strings.Split(result, "\n") {
@@ -5050,7 +5050,7 @@ func TestRenderBabysitView_LongLastEventTruncated(t *testing.T) {
 		}
 		w := lipgloss.Width(line)
 		if w > 80 {
-			t.Errorf("babysit LastEvent line exceeds box width (%d > 80): %s", w, line)
+			t.Errorf("CI LastEvent line exceeds box width (%d > 80): %s", w, line)
 		}
 	}
 
@@ -5060,16 +5060,16 @@ func TestRenderBabysitView_LongLastEventTruncated(t *testing.T) {
 	}
 }
 
-func TestRenderBabysitView_ShowsPRContext(t *testing.T) {
+func TestRenderCIView_ShowsPRContext(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.Ascii)
-	run := testRunWithBabysit()
+	run := testRunWithCI()
 	shortURL := "https://github.com/user/repo/pull/99"
 	run.PRURL = &shortURL
 	run.Steps[5].Status = types.StepStatusRunning
 
-	result := stripANSI(renderBabysitView(run, run.Steps, "", nil, 60))
+	result := stripANSI(renderCIView(run, run.Steps, "", nil, 60))
 	if !strings.Contains(result, "PR #99") {
-		t.Fatalf("expected babysit panel to show PR context, got: %s", result)
+		t.Fatalf("expected CI panel to show PR context, got: %s", result)
 	}
 }
 
@@ -7604,14 +7604,14 @@ func TestModel_ApplyEvent_LogChunk_FlushesPartialOnRunCompleted(t *testing.T) {
 	}
 }
 
-func TestPipelineConnectors_NotSuppressedDuringBabysit(t *testing.T) {
-	// When babysit is active in responsive layout (wide terminal), the pipeline
+func TestPipelineConnectors_NotSuppressedDuringCI(t *testing.T) {
+	// When CI is active in responsive layout (wide terminal), the pipeline
 	// height should not be capped, so connector lines between steps are preserved.
 	// Previously, the cap applied regardless of layout mode, which suppressed
-	// connectors even when the babysit view was in the right column and didn't
+	// connectors even when the CI view was in the right column and didn't
 	// compete for vertical space.
 	configureTUIColors()
-	run := testRunWithBabysit()
+	run := testRunWithCI()
 	for i := range run.Steps {
 		run.Steps[i].Status = types.StepStatusCompleted
 		dur := int64(1000)
@@ -7665,16 +7665,16 @@ func TestPipelineConnectors_NotSuppressedDuringBabysit(t *testing.T) {
 			}
 		}
 		if adjacentSteps > 0 {
-			t.Errorf("expected connector lines between steps in responsive layout during babysit, but %d step pairs are adjacent.\nview:\n%s", adjacentSteps, plain)
+			t.Errorf("expected connector lines between steps in responsive layout during CI, but %d step pairs are adjacent.\nview:\n%s", adjacentSteps, plain)
 		}
 	}
 }
 
-func TestPipelineConnectors_SuppressedDuringBabysitInStackedLayout(t *testing.T) {
-	// When babysit is active in stacked layout, the pipeline height should be
-	// capped so the babysit panel still has room below it.
+func TestPipelineConnectors_SuppressedDuringCIInStackedLayout(t *testing.T) {
+	// When CI is active in stacked layout, the pipeline height should be
+	// capped so the CI panel still has room below it.
 	configureTUIColors()
-	run := testRunWithBabysit()
+	run := testRunWithCI()
 	for i := range run.Steps {
 		run.Steps[i].Status = types.StepStatusCompleted
 		dur := int64(1000)
@@ -7692,10 +7692,10 @@ func TestPipelineConnectors_SuppressedDuringBabysitInStackedLayout(t *testing.T)
 	uncappedPipeline := stripANSI(renderPipelineView(run, m.stepsWithRunningElapsed(), m.width, 0, m.height))
 
 	if !strings.Contains(view, expectedPipeline) {
-		t.Fatalf("expected stacked babysit layout to use capped pipeline height %d\nview:\n%s\nexpected pipeline:\n%s", cappedPipelineHeight, view, expectedPipeline)
+		t.Fatalf("expected stacked CI layout to use capped pipeline height %d\nview:\n%s\nexpected pipeline:\n%s", cappedPipelineHeight, view, expectedPipeline)
 	}
 	if strings.Contains(view, uncappedPipeline) {
-		t.Fatalf("expected stacked babysit layout to avoid uncapped pipeline height %d", m.height)
+		t.Fatalf("expected stacked CI layout to avoid uncapped pipeline height %d", m.height)
 	}
 }
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,5 +1,11 @@
 package types
 
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+)
+
 // RunStatus represents the lifecycle state of a pipeline run.
 type RunStatus string
 
@@ -28,6 +34,42 @@ const (
 	StepPR     StepName = "pr"
 	StepCI     StepName = "ci"
 )
+
+func normalizeStepName(s StepName) StepName {
+	if s == "babysit" {
+		return StepCI
+	}
+	return s
+}
+
+func (s *StepName) UnmarshalJSON(data []byte) error {
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*s = normalizeStepName(StepName(raw))
+	return nil
+}
+
+func (s *StepName) Scan(src any) error {
+	switch v := src.(type) {
+	case string:
+		*s = normalizeStepName(StepName(v))
+		return nil
+	case []byte:
+		*s = normalizeStepName(StepName(v))
+		return nil
+	case nil:
+		*s = ""
+		return nil
+	default:
+		return fmt.Errorf("scan StepName from %T", src)
+	}
+}
+
+func (s StepName) Value() (driver.Value, error) {
+	return string(s), nil
+}
 
 // StepOrder returns the fixed execution order for a step (1-indexed).
 func (s StepName) Order() int {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -20,13 +20,13 @@ const (
 type StepName string
 
 const (
-	StepRebase  StepName = "rebase"
-	StepReview  StepName = "review"
-	StepTest    StepName = "test"
-	StepLint    StepName = "lint"
-	StepPush    StepName = "push"
-	StepPR      StepName = "pr"
-	StepBabysit StepName = "babysit"
+	StepRebase StepName = "rebase"
+	StepReview StepName = "review"
+	StepTest   StepName = "test"
+	StepLint   StepName = "lint"
+	StepPush   StepName = "push"
+	StepPR     StepName = "pr"
+	StepCI     StepName = "ci"
 )
 
 // StepOrder returns the fixed execution order for a step (1-indexed).
@@ -44,7 +44,7 @@ func (s StepName) Order() int {
 		return 5
 	case StepPR:
 		return 6
-	case StepBabysit:
+	case StepCI:
 		return 7
 	default:
 		return 0
@@ -53,7 +53,7 @@ func (s StepName) Order() int {
 
 // AllSteps returns all pipeline steps in execution order.
 func AllSteps() []StepName {
-	return []StepName{StepRebase, StepReview, StepTest, StepLint, StepPush, StepPR, StepBabysit}
+	return []StepName{StepRebase, StepReview, StepTest, StepLint, StepPush, StepPR, StepCI}
 }
 
 // StepStatus represents the lifecycle state of a pipeline step.

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -8,7 +8,7 @@ func TestAllStepsOrder(t *testing.T) {
 		t.Fatalf("expected 7 steps, got %d", len(steps))
 	}
 
-	expected := []StepName{StepRebase, StepReview, StepTest, StepLint, StepPush, StepPR, StepBabysit}
+	expected := []StepName{StepRebase, StepReview, StepTest, StepLint, StepPush, StepPR, StepCI}
 	for i, s := range steps {
 		if s != expected[i] {
 			t.Errorf("step[%d] = %q, want %q", i, s, expected[i])
@@ -27,7 +27,7 @@ func TestStepNameOrder(t *testing.T) {
 		{StepLint, 4},
 		{StepPush, 5},
 		{StepPR, 6},
-		{StepBabysit, 7},
+		{StepCI, 7},
 		{StepName("unknown"), 0},
 	}
 

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -1,6 +1,9 @@
 package types
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
 
 func TestAllStepsOrder(t *testing.T) {
 	steps := AllSteps()
@@ -35,5 +38,15 @@ func TestStepNameOrder(t *testing.T) {
 		if got := tt.step.Order(); got != tt.want {
 			t.Errorf("%q.Order() = %d, want %d", tt.step, got, tt.want)
 		}
+	}
+}
+
+func TestStepNameUnmarshalJSON_LegacyBabysit(t *testing.T) {
+	var step StepName
+	if err := json.Unmarshal([]byte(`"babysit"`), &step); err != nil {
+		t.Fatalf("unmarshal step name: %v", err)
+	}
+	if step != StepCI {
+		t.Fatalf("step = %q, want %q", step, StepCI)
 	}
 }


### PR DESCRIPTION
## Summary
- Rename the user-facing and internal `babysit` pipeline step to `ci` across the CLI, TUI, pipeline wiring, and persisted step handling to make the workflow naming clearer.
- Preserve backward compatibility for existing configs and stored data by continuing to accept legacy `babysit_timeout`, `auto_fix.babysit`, and legacy step-name aliases during load and runtime.
- Update `README.md` and related diagnostics to document the `ci` naming, clarify `ci_timeout`, and note the supported legacy config keys during the transition.

✅ low: The change is narrowly scoped to renaming `babysit` to `ci` while preserving config and persisted step-name compatibility, and the modified logic appears behaviorally equivalent to the prior implementation.

## Pipeline

Updates from `git push no-mistakes`

✅ **Rebase** - passed
🔧 **Review** - 2 issues found → auto-fixed
✅ **Test** - passed
✅ **Lint** - passed

<details>
<summary>Review details</summary>

**Round 1** - found 2 issues (1 error, 1 warning)
- 🚨 `internal/config/config.go:55` - Renaming `auto_fix.babysit` to `auto_fix.ci` without an alias silently re-enables CI auto-fixing for existing configs. Any user who previously set `auto_fix.babysit: 0` will now fall back to the default of 3 attempts, which can trigger unexpected agent edits, commits, and pushes after upgrade.
- ⚠️ `internal/config/config.go:29` - `LoadGlobal` now only reads `ci_timeout`, so existing `babysit_timeout` settings are ignored and silently replaced with the 4h default. This is a user-visible config break with no migration path or warning.

**Round 2** (auto-fix) - found 2 issues (1 error, 1 warning)
- 🚨 `internal/config/config.go:259` - Legacy `auto_fix.babysit` is only aliased in `LoadGlobal`; repo-level `.no-mistakes.yaml` values still land in `AutoFixRaw.Babysit` and are ignored here, so existing repos that disabled babysit auto-fix will silently fall back to the default `ci` limit of 3 and may start auto-committing/pushing CI fixes.
- ⚠️ `internal/types/types.go:29` - Changing the serialized step name from `babysit` to `ci` changes the persisted/API contract without a read-time compatibility shim. Existing `step_results.step_name='babysit'` rows or in-flight IPC payloads will no longer match `types.StepCI`, which can break resumed runs and CI-specific UI handling after upgrade.

**Round 3** (auto-fix) - found 0 issues

</details>
