### PR TITLE
feat(document): add document pipeline step and tighten autofix review handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You already have CI, but it usually wakes up after the branch is upstream. You a
 
 - **Push with intent** - `origin` stays untouched, and `no-mistakes` becomes the explicit path for gated pushes.
 - **Agent-agnostic** - use `claude`, `codex`, `rovodev`, or `opencode`, with per-repo overrides if different codebases want different tools.
-- **Human stays in charge** - review, test, lint, PR, and CI steps can pause for approval instead of auto-shipping surprises.
+- **Human stays in charge** - review, test, document, lint, PR, and CI steps can pause for approval instead of auto-shipping surprises.
 
 ## Quick Start
 
@@ -113,6 +113,7 @@ no-mistakes update
        │                                                    │ Pipeline            │
        │                                                    │ review              │
        │                                                    │ test                │
+       │                                                    │ document            │
        │                                                    │ lint                │
        │                                                    │ push                │
        │                                                    │ pr                  │
@@ -125,7 +126,7 @@ no-mistakes update
 
 - **Named remote** - `origin` is never hijacked. If you want the gate, you push to `no-mistakes` on purpose.
 - **Disposable worktrees** - each run happens in its own detached worktree, so the daemon can inspect and modify safely before pushing upstream.
-- **Fixed pipeline** - this is opinionated on purpose: `review -> test -> lint -> push -> pr -> ci`.
+- **Fixed pipeline** - this is opinionated on purpose: `review -> test -> document -> lint -> push -> pr -> ci`.
 - **Local state** - metadata lives under `~/.no-mistakes/` by default, or `${NM_HOME}` if you want to relocate it.
 
 ## CLI Reference
@@ -188,6 +189,15 @@ ci_timeout: "4h"
 
 # debug | info | warn | error
 log_level: "info"
+
+# Maximum auto-fix attempts per step (0 = disabled, requires manual approval)
+auto_fix:
+  rebase: 0
+  lint: 3
+  test: 3
+  review: 3
+  document: 0
+  ci: 3
 ```
 
 ### Repo config
@@ -208,10 +218,15 @@ commands:
   # Optional formatter run before the push step commits agent fixes.
   format: "gofmt -w ."
 
-# Ignore these paths during the review step.
+# Ignore these paths during review and documentation checks.
 ignore_patterns:
   - "*.generated.go"
   - "vendor/**"
+
+# Optional per-repo auto-fix overrides.
+auto_fix:
+  review: 3
+  document: 0
 ```
 
 ### Precedence and defaults
@@ -220,11 +235,13 @@ ignore_patterns:
 - `commands` and `ignore_patterns` are repo-only.
 - Missing global config defaults to `agent: claude`, `ci_timeout: 4h`, `log_level: info`.
 - `ci_timeout` replaces `babysit_timeout`, and `auto_fix.ci` replaces `auto_fix.babysit`; legacy keys are still accepted for existing configs.
+- `auto_fix` can be set globally or per repo. Defaults are `rebase: 0`, `lint: 3`, `test: 3`, `review: 3`, `document: 0`, `ci: 3`.
 - `agent_path_override` changes which binary path is launched for a given agent.
 - Default binaries are `claude`, `codex`, `acli` for `rovodev`, and `opencode`.
 - If `commands.test` is empty, the agent detects and runs relevant tests itself.
 - If `commands.lint` is empty, the agent detects and runs lint/format checks itself.
 - If `commands.format` is empty, no formatter is run automatically.
+- `auto_fix.document: 0` keeps documentation changes approval-gated by default.
 
 ### Ignore pattern rules
 

--- a/README.md
+++ b/README.md
@@ -235,13 +235,13 @@ auto_fix:
 - `commands` and `ignore_patterns` are repo-only.
 - Missing global config defaults to `agent: claude`, `ci_timeout: 4h`, `log_level: info`.
 - `ci_timeout` replaces `babysit_timeout`, and `auto_fix.ci` replaces `auto_fix.babysit`; legacy keys are still accepted for existing configs.
-- `auto_fix` can be set globally or per repo. Defaults are `rebase: 0`, `lint: 3`, `test: 3`, `review: 3`, `document: 0`, `ci: 3`.
+- `auto_fix` can be set globally or per repo. All steps default to `3`.
 - `agent_path_override` changes which binary path is launched for a given agent.
 - Default binaries are `claude`, `codex`, `acli` for `rovodev`, and `opencode`.
 - If `commands.test` is empty, the agent detects and runs relevant tests itself.
 - If `commands.lint` is empty, the agent detects and runs lint/format checks itself.
 - If `commands.format` is empty, no formatter is run automatically.
-- `auto_fix.document: 0` keeps documentation changes approval-gated by default.
+- All `auto_fix` steps default to `3`. Set a step to `0` to require manual approval.
 
 ### Ignore pattern rules
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ no-mistakes update
 
 - **Named remote** - `origin` is never hijacked. If you want the gate, you push to `no-mistakes` on purpose.
 - **Disposable worktrees** - each run happens in its own detached worktree, so the daemon can inspect and modify safely before pushing upstream.
-- **Fixed pipeline** - this is opinionated on purpose: `review -> test -> document -> lint -> push -> pr -> ci`.
+- **Fixed pipeline** - this is opinionated on purpose: `review -> test -> document -> lint -> push -> pr -> ci`. The `document` step checks whether README/docs/comments need updates for the code you changed.
 - **Local state** - metadata lives under `~/.no-mistakes/` by default, or `${NM_HOME}` if you want to relocate it.
 
 ## CLI Reference
@@ -185,6 +185,7 @@ ci_timeout: "4h"
 #   lint: 3
 #   test: 3
 #   review: 3
+#   document: 3
 #   ci: 3
 
 # debug | info | warn | error

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -102,7 +102,7 @@ log_level: info
 
 # Maximum auto-fix attempts per step (0 = disabled, requires manual approval)
 auto_fix:
-  rebase: 3
+  rebase: 0
   lint: 3
   test: 3
   review: 3
@@ -248,7 +248,7 @@ func autoFixDefaults() AutoFix {
 		Review:   3,
 		Document: 3,
 		CI:       3,
-		Rebase:   3,
+		Rebase:   0,
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -102,11 +102,11 @@ log_level: info
 
 # Maximum auto-fix attempts per step (0 = disabled, requires manual approval)
 auto_fix:
-  rebase: 0
+  rebase: 3
   lint: 3
   test: 3
   review: 3
-  document: 0
+  document: 3
   ci: 3
 `
 
@@ -246,9 +246,9 @@ func autoFixDefaults() AutoFix {
 		Lint:     3,
 		Test:     3,
 		Review:   3,
-		Document: 0,
+		Document: 3,
 		CI:       3,
-		Rebase:   0,
+		Rebase:   3,
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,22 +50,24 @@ type Commands struct {
 // AutoFixRaw is the YAML representation of auto-fix config.
 // Pointer fields distinguish "not set" (nil) from "set to 0" (disabled).
 type AutoFixRaw struct {
-	Lint    *int `yaml:"lint"`
-	Test    *int `yaml:"test"`
-	Review  *int `yaml:"review"`
-	CI      *int `yaml:"ci"`
-	Babysit *int `yaml:"babysit"`
-	Rebase  *int `yaml:"rebase"`
+	Lint     *int `yaml:"lint"`
+	Test     *int `yaml:"test"`
+	Review   *int `yaml:"review"`
+	Document *int `yaml:"document"`
+	CI       *int `yaml:"ci"`
+	Babysit  *int `yaml:"babysit"`
+	Rebase   *int `yaml:"rebase"`
 }
 
 // AutoFix holds resolved per-step auto-fix attempt limits.
 // A value of 0 means auto-fix is disabled (requires manual approval).
 type AutoFix struct {
-	Lint   int
-	Test   int
-	Review int
-	CI     int
-	Rebase int
+	Lint     int
+	Test     int
+	Review   int
+	Document int
+	CI       int
+	Rebase   int
 }
 
 // Config is the merged result of global + per-repo configuration.
@@ -104,6 +106,7 @@ auto_fix:
   lint: 3
   test: 3
   review: 3
+  document: 0
   ci: 3
 `
 
@@ -240,11 +243,12 @@ func ParseLogLevel(level string) slog.Level {
 // autoFixDefaults returns the default auto-fix configuration.
 func autoFixDefaults() AutoFix {
 	return AutoFix{
-		Lint:   3,
-		Test:   3,
-		Review: 3,
-		CI:     3,
-		Rebase: 0,
+		Lint:     3,
+		Test:     3,
+		Review:   3,
+		Document: 0,
+		CI:       3,
+		Rebase:   0,
 	}
 }
 
@@ -258,6 +262,9 @@ func applyAutoFixOverrides(dst *AutoFix, src *AutoFixRaw) {
 	}
 	if src.Review != nil {
 		dst.Review = *src.Review
+	}
+	if src.Document != nil {
+		dst.Document = *src.Document
 	}
 	if src.CI != nil {
 		dst.CI = *src.CI
@@ -277,6 +284,8 @@ func (c *Config) AutoFixLimit(step types.StepName) int {
 		return c.AutoFix.Test
 	case types.StepReview:
 		return c.AutoFix.Review
+	case types.StepDocument:
+		return c.AutoFix.Document
 	case types.StepCI:
 		return c.AutoFix.CI
 	case types.StepRebase:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -632,8 +632,8 @@ func TestMerge_AutoFixDefaults(t *testing.T) {
 	if cfg.AutoFix.CI != 3 {
 		t.Errorf("ci = %d, want 3", cfg.AutoFix.CI)
 	}
-	if cfg.AutoFix.Rebase != 3 {
-		t.Errorf("rebase = %d, want 3", cfg.AutoFix.Rebase)
+	if cfg.AutoFix.Rebase != 0 {
+		t.Errorf("rebase = %d, want 0", cfg.AutoFix.Rebase)
 	}
 }
 
@@ -658,8 +658,8 @@ func TestMerge_AutoFixGlobalOverridesDefaults(t *testing.T) {
 	if cfg.AutoFix.CI != 0 {
 		t.Errorf("ci =%d, want 0 (global override)", cfg.AutoFix.CI)
 	}
-	if cfg.AutoFix.Rebase != 3 {
-		t.Errorf("rebase = %d, want 3 (default, no override)", cfg.AutoFix.Rebase)
+	if cfg.AutoFix.Rebase != 0 {
+		t.Errorf("rebase = %d, want 0 (default, no override)", cfg.AutoFix.Rebase)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -626,14 +626,14 @@ func TestMerge_AutoFixDefaults(t *testing.T) {
 	if cfg.AutoFix.Review != 3 {
 		t.Errorf("review = %d, want 3", cfg.AutoFix.Review)
 	}
-	if cfg.AutoFix.Document != 0 {
-		t.Errorf("document = %d, want 0", cfg.AutoFix.Document)
+	if cfg.AutoFix.Document != 3 {
+		t.Errorf("document = %d, want 3", cfg.AutoFix.Document)
 	}
 	if cfg.AutoFix.CI != 3 {
 		t.Errorf("ci = %d, want 3", cfg.AutoFix.CI)
 	}
-	if cfg.AutoFix.Rebase != 0 {
-		t.Errorf("rebase = %d, want 0", cfg.AutoFix.Rebase)
+	if cfg.AutoFix.Rebase != 3 {
+		t.Errorf("rebase = %d, want 3", cfg.AutoFix.Rebase)
 	}
 }
 
@@ -658,8 +658,8 @@ func TestMerge_AutoFixGlobalOverridesDefaults(t *testing.T) {
 	if cfg.AutoFix.CI != 0 {
 		t.Errorf("ci =%d, want 0 (global override)", cfg.AutoFix.CI)
 	}
-	if cfg.AutoFix.Rebase != 0 {
-		t.Errorf("rebase = %d, want 0 (default, no override)", cfg.AutoFix.Rebase)
+	if cfg.AutoFix.Rebase != 3 {
+		t.Errorf("rebase = %d, want 3 (default, no override)", cfg.AutoFix.Rebase)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -493,6 +493,9 @@ func TestDefaultConfigYAML_MatchesGoDefaults(t *testing.T) {
 	if raw.AutoFix.Review == nil || *raw.AutoFix.Review != defaults.Review {
 		t.Errorf("YAML auto_fix.review = %v, Go default = %d", raw.AutoFix.Review, defaults.Review)
 	}
+	if raw.AutoFix.Document == nil || *raw.AutoFix.Document != defaults.Document {
+		t.Errorf("YAML auto_fix.document = %v, Go default = %d", raw.AutoFix.Document, defaults.Document)
+	}
 	if raw.AutoFix.CI == nil || *raw.AutoFix.CI != defaults.CI {
 		t.Errorf("YAML auto_fix.ci = %v, Go default = %d", raw.AutoFix.CI, defaults.CI)
 	}
@@ -508,7 +511,7 @@ func TestLoadGlobal_AutoFixDefaults(t *testing.T) {
 	}
 	// AutoFix should be nil (unset) in GlobalConfig
 	if cfg.AutoFix.Lint != nil || cfg.AutoFix.Test != nil || cfg.AutoFix.Review != nil ||
-		cfg.AutoFix.CI != nil || cfg.AutoFix.Rebase != nil {
+		cfg.AutoFix.Document != nil || cfg.AutoFix.CI != nil || cfg.AutoFix.Rebase != nil {
 		t.Errorf("expected all AutoFix fields to be nil for defaults, got %+v", cfg.AutoFix)
 	}
 }
@@ -623,8 +626,11 @@ func TestMerge_AutoFixDefaults(t *testing.T) {
 	if cfg.AutoFix.Review != 3 {
 		t.Errorf("review = %d, want 3", cfg.AutoFix.Review)
 	}
+	if cfg.AutoFix.Document != 0 {
+		t.Errorf("document = %d, want 0", cfg.AutoFix.Document)
+	}
 	if cfg.AutoFix.CI != 3 {
-		t.Errorf("ci =%d, want 3", cfg.AutoFix.CI)
+		t.Errorf("ci = %d, want 3", cfg.AutoFix.CI)
 	}
 	if cfg.AutoFix.Rebase != 0 {
 		t.Errorf("rebase = %d, want 0", cfg.AutoFix.Rebase)
@@ -685,7 +691,7 @@ func TestMerge_AutoFixRepoOverridesGlobal(t *testing.T) {
 
 func TestAutoFixLimit(t *testing.T) {
 	cfg := &Config{
-		AutoFix: AutoFix{Lint: 5, Test: 2, Review: 0, CI: 3, Rebase: 4},
+		AutoFix: AutoFix{Lint: 5, Test: 2, Review: 0, Document: 1, CI: 3, Rebase: 4},
 	}
 	tests := []struct {
 		step types.StepName
@@ -694,6 +700,7 @@ func TestAutoFixLimit(t *testing.T) {
 		{types.StepLint, 5},
 		{types.StepTest, 2},
 		{types.StepReview, 0},
+		{types.StepDocument, 1},
 		{types.StepCI, 3},
 		{types.StepRebase, 4},
 		{types.StepPush, 0},

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -357,6 +357,7 @@ func AllSteps() []pipeline.Step {
 		&RebaseStep{},
 		&ReviewStep{},
 		&TestStep{},
+		&DocumentStep{},
 		&LintStep{},
 		&PushStep{},
 		&PRStep{},

--- a/internal/pipeline/steps/document.go
+++ b/internal/pipeline/steps/document.go
@@ -1,15 +1,8 @@
 package steps
 
 import (
-	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
-	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
@@ -43,17 +36,75 @@ type documentVerdict struct {
 func (s *DocumentStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, error) {
 	ctx := sctx.Ctx
 	baseSHA := resolveBranchBaseSHA(ctx, sctx.WorkDir, sctx.Run.BaseSHA, sctx.Repo.DefaultBranch)
-	var fixBaseline map[string]documentSnapshotEntry
+
+	ignorePatterns := "none"
+	if len(sctx.Config.IgnorePatterns) > 0 {
+		ignorePatterns = strings.Join(sctx.Config.IgnorePatterns, ", ")
+	}
+
+	// In fix mode, ask the agent to apply documentation updates first
 	if sctx.Fixing {
-		var err error
-		fixBaseline, err = captureDocumentWorktreeSnapshot(ctx, sctx.WorkDir)
+		if sctx.PreviousFindings == "" {
+			return nil, fmt.Errorf("document fix requires previous findings")
+		}
+		sctx.Log("asking agent to update documentation...")
+		fixPrompt := fmt.Sprintf(
+			`Update any project documentation that needs to reflect the code changes.
+
+Context:
+- branch: %s
+- base commit: %s
+- target commit: %s
+- default branch: %s
+- ignore patterns: %s
+
+Task:
+- Read the relevant diff and changed files yourself before editing.
+- Update only the documentation directly affected by the change.
+- Keep updates minimal and match the existing documentation style.
+
+Rules:
+- Only edit documentation files or doc comments.
+- Do not change executable code or tests.
+- Return JSON with a single "summary" field when you are done.
+- The summary must be one concise sentence fragment suitable for a git commit subject.
+- Keep the summary under 10 words.
+
+Previous documentation findings to address:
+%s`,
+			sctx.Run.Branch,
+			baseSHA,
+			sctx.Run.HeadSHA,
+			sctx.Repo.DefaultBranch,
+			ignorePatterns,
+			sctx.PreviousFindings,
+		)
+		result, err := sctx.Agent.Run(ctx, agent.RunOpts{
+			Prompt:     fixPrompt,
+			CWD:        sctx.WorkDir,
+			JSONSchema: commitSummarySchema,
+			OnChunk:    sctx.Log,
+		})
 		if err != nil {
+			return nil, fmt.Errorf("agent document fix: %w", err)
+		}
+		summary, err := extractCommitSummary(result)
+		if err != nil {
+			sctx.Log(fmt.Sprintf("warning: could not parse fix summary: %v", err))
+		}
+		if err := commitAgentFixes(sctx, s.Name(), summary, "update documentation"); err != nil {
 			return nil, err
 		}
 	}
 
 	// Check whether there are any changed files.
-	changedFiles, err := git.Run(ctx, sctx.WorkDir, "diff", "--name-only", baseSHA+".."+sctx.Run.HeadSHA)
+	var diffArgs []string
+	if sctx.Fixing {
+		diffArgs = []string{"diff", "--name-only", baseSHA}
+	} else {
+		diffArgs = []string{"diff", "--name-only", baseSHA + ".." + sctx.Run.HeadSHA}
+	}
+	changedFiles, err := git.Run(ctx, sctx.WorkDir, diffArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("get changed files: %w", err)
 	}
@@ -62,12 +113,8 @@ func (s *DocumentStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcom
 		return &pipeline.StepOutcome{}, nil
 	}
 
+	// Assess documentation state
 	sctx.Log("checking documentation...")
-
-	ignorePatterns := "none"
-	if len(sctx.Config.IgnorePatterns) > 0 {
-		ignorePatterns = strings.Join(sctx.Config.IgnorePatterns, ", ")
-	}
 
 	prompt := fmt.Sprintf(
 		`Review the code changes and determine whether project documentation needs to be updated.
@@ -119,441 +166,33 @@ Rules:
 
 	// Parse verdict
 	var verdict documentVerdict
-	var verdictErr error
 	if result.Output != nil {
 		if err := json.Unmarshal(result.Output, &verdict); err != nil {
 			sctx.Log("could not parse structured output, requiring approval")
-			verdictErr = err
-			verdict = documentVerdict{Verdict: "skipped", Summary: result.Text}
+			verdict = documentVerdict{Verdict: "updated", Summary: result.Text}
 		}
 	}
 
-	if !sctx.Fixing && verdictErr != nil {
-		findings := Findings{
+	needsApproval := verdict.Verdict == "updated"
+	findings := Findings{}
+	if needsApproval {
+		findings = Findings{
 			Items: []Finding{{
 				Severity:    "warning",
 				Description: verdict.Summary,
 			}},
 			Summary: verdict.Summary,
 		}
-		findingsJSON, _ := json.Marshal(findings)
-		sctx.Log(fmt.Sprintf("document verdict: malformed output - %s", verdict.Summary))
-		return &pipeline.StepOutcome{
-			NeedsApproval: true,
-			AutoFixable:   true,
-			Findings:      string(findingsJSON),
-		}, nil
 	}
 
-	if !sctx.Fixing && verdict.Verdict == "updated" {
-		findings := Findings{
-			Items: []Finding{{
-				Severity:    "warning",
-				Description: verdict.Summary,
-			}},
-			Summary: verdict.Summary,
-		}
-		findingsJSON, _ := json.Marshal(findings)
-		sctx.Log(fmt.Sprintf("document verdict: %s - %s", verdict.Verdict, verdict.Summary))
-		return &pipeline.StepOutcome{
-			NeedsApproval: true,
-			AutoFixable:   true,
-			Findings:      string(findingsJSON),
-		}, nil
-	}
-
-	if sctx.Fixing {
-		outcome, err := s.applyDocumentationUpdates(sctx, baseSHA, verdictErr, fixBaseline)
-		if err != nil {
-			return nil, err
-		}
-		if outcome != nil {
-			return outcome, nil
-		}
-	}
-
+	findingsJSON, _ := json.Marshal(findings)
 	sctx.Log(fmt.Sprintf("document verdict: %s - %s", verdict.Verdict, verdict.Summary))
 
-	return &pipeline.StepOutcome{}, nil
-}
-
-func (s *DocumentStep) applyDocumentationUpdates(sctx *pipeline.StepContext, baseSHA string, initialVerdictErr error, baseline map[string]documentSnapshotEntry) (*pipeline.StepOutcome, error) {
-	ctx := sctx.Ctx
-	if initialVerdictErr != nil {
-		outcome, err := malformedDocumentFixOutcome(ctx, sctx.WorkDir, baseline)
-		if err != nil {
-			return nil, err
-		}
-		if outcome != nil {
-			return outcome, nil
-		}
-	}
-
-	ignorePatterns := "none"
-	if len(sctx.Config.IgnorePatterns) > 0 {
-		ignorePatterns = strings.Join(sctx.Config.IgnorePatterns, ", ")
-	}
-
-	prompt := fmt.Sprintf(
-		`Update any project documentation that needs to reflect the code changes.
-
-Context:
-- branch: %s
-- base commit: %s
-- target commit: %s
-- default branch: %s
-- ignore patterns: %s
-
-Task:
-- Read the relevant diff and changed files yourself before editing.
-- Update only the documentation directly affected by the change.
-- Keep updates minimal and match the existing documentation style.
-
-Rules:
-- Only edit documentation files or doc comments.
-- Do not change executable code or tests.
-- Return JSON with "verdict" ("updated" or "skipped"), "summary", and optional "details" when finished.`,
-		sctx.Run.Branch,
-		baseSHA,
-		sctx.Run.HeadSHA,
-		sctx.Repo.DefaultBranch,
-		ignorePatterns,
-	)
-	if sctx.PreviousFindings != "" {
-		prompt += "\n\nPrevious documentation findings to address:\n" + sctx.PreviousFindings
-	}
-
-	result, err := sctx.Agent.Run(ctx, agent.RunOpts{
-		Prompt:     prompt,
-		CWD:        sctx.WorkDir,
-		JSONSchema: documentVerdictSchema,
-		OnChunk:    sctx.Log,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("agent document fix: %w", err)
-	}
-
-	var verdict documentVerdict
-	if result.Output != nil {
-		if err := json.Unmarshal(result.Output, &verdict); err != nil {
-			sctx.Log("could not parse structured output, treating as skipped")
-			return malformedDocumentFixOutcome(ctx, sctx.WorkDir, baseline)
-		}
-	}
-
-	changes, err := detectDocumentWorktreeChanges(ctx, sctx.WorkDir, baseline)
-	if err != nil {
-		return nil, err
-	}
-
-	if verdict.Verdict != "updated" {
-		if len(changes) == 0 {
-			return nil, nil
-		}
-		findingsJSON, _ := json.Marshal(documentFixChangedFilesFindings(
-			fmt.Sprintf("document step changed files but returned verdict %q", verdict.Verdict),
-			fmt.Sprintf("document step changed files but returned verdict %q", verdict.Verdict),
-			changes,
-		))
-		return &pipeline.StepOutcome{
-			NeedsApproval: true,
-			Findings:      string(findingsJSON),
-		}, nil
-	}
-
-	for _, change := range changes {
-		if change.Preexisting {
-			findingsJSON, _ := json.Marshal(documentFixChangedFilesFindings(
-				"document step modified preexisting worktree changes",
-				"document step modified preexisting worktree changes",
-				changes,
-			))
-			return &pipeline.StepOutcome{
-				NeedsApproval: true,
-				Findings:      string(findingsJSON),
-			}, nil
-		}
-	}
-	if len(changes) == 0 {
-		return nil, nil
-	}
-
-	findings, err := detectOutOfScopeDocumentEdits(ctx, sctx.WorkDir, changes)
-	if err != nil {
-		return nil, err
-	}
-	if len(findings.Items) > 0 {
-		findingsJSON, _ := json.Marshal(findings)
-		return &pipeline.StepOutcome{
-			NeedsApproval: true,
-			Findings:      string(findingsJSON),
-		}, nil
-	}
-
-	if err := commitDocumentFixes(sctx, verdict.Summary, changes); err != nil {
-		return nil, err
-	}
-	return nil, nil
-}
-
-type documentSnapshotEntry struct {
-	Exists bool
-	Hash   string
-}
-
-type documentWorktreeChange struct {
-	Path        string
-	Preexisting bool
-}
-
-func detectOutOfScopeDocumentEdits(ctx context.Context, workDir string, changes []documentWorktreeChange) (Findings, error) {
-	findings := Findings{Summary: "document step produced out-of-scope edits"}
-	for _, change := range changes {
-		path := change.Path
-		if path == "" || isDocumentationPath(path) {
-			continue
-		}
-		status, err := git.Run(ctx, workDir, "status", "--porcelain", "--untracked-files=all", "--", path)
-		if err != nil {
-			return Findings{}, fmt.Errorf("list document edits: %w", err)
-		}
-		_, untracked := parseFirstPorcelainPath(status)
-		if untracked {
-			findings.Items = append(findings.Items, Finding{
-				Severity:    "warning",
-				File:        path,
-				Description: "document step modified non-documentation content",
-			})
-			continue
-		}
-		diff, err := git.Run(ctx, workDir, "diff", "HEAD", "--", path)
-		if err != nil {
-			return Findings{}, fmt.Errorf("diff document edit %s: %w", path, err)
-		}
-		if isDocCommentOnlyDiff(path, diff) {
-			continue
-		}
-		findings.Items = append(findings.Items, Finding{
-			Severity:    "warning",
-			File:        path,
-			Description: "document step modified non-documentation content",
-		})
-	}
-	if len(findings.Items) == 0 {
-		findings.Summary = ""
-	}
-	return findings, nil
-}
-
-func captureDocumentWorktreeSnapshot(ctx context.Context, workDir string) (map[string]documentSnapshotEntry, error) {
-	status, err := git.Run(ctx, workDir, "status", "--porcelain", "--untracked-files=all")
-	if err != nil {
-		return nil, fmt.Errorf("list document edits: %w", err)
-	}
-	paths := collectPorcelainPaths(status)
-	snapshot := make(map[string]documentSnapshotEntry, len(paths))
-	for _, path := range paths {
-		entry, err := readDocumentSnapshotEntry(workDir, path)
-		if err != nil {
-			return nil, err
-		}
-		snapshot[path] = entry
-	}
-	return snapshot, nil
-}
-
-func detectDocumentWorktreeChanges(ctx context.Context, workDir string, baseline map[string]documentSnapshotEntry) ([]documentWorktreeChange, error) {
-	status, err := git.Run(ctx, workDir, "status", "--porcelain", "--untracked-files=all")
-	if err != nil {
-		return nil, fmt.Errorf("list document edits: %w", err)
-	}
-	afterPaths := collectPorcelainPaths(status)
-	afterSet := make(map[string]struct{}, len(afterPaths))
-	changes := make([]documentWorktreeChange, 0, len(afterPaths)+len(baseline))
-	for _, path := range afterPaths {
-		afterSet[path] = struct{}{}
-		before, existedBefore := baseline[path]
-		after, err := readDocumentSnapshotEntry(workDir, path)
-		if err != nil {
-			return nil, err
-		}
-		if !existedBefore || before != after {
-			changes = append(changes, documentWorktreeChange{Path: path, Preexisting: existedBefore})
-		}
-	}
-	for path := range baseline {
-		if _, ok := afterSet[path]; ok {
-			continue
-		}
-		changes = append(changes, documentWorktreeChange{Path: path, Preexisting: true})
-	}
-	sort.Slice(changes, func(i, j int) bool {
-		return changes[i].Path < changes[j].Path
-	})
-	return changes, nil
-}
-
-func readDocumentSnapshotEntry(workDir, path string) (documentSnapshotEntry, error) {
-	absolutePath := filepath.Join(workDir, filepath.FromSlash(path))
-	data, err := os.ReadFile(absolutePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return documentSnapshotEntry{}, nil
-		}
-		return documentSnapshotEntry{}, fmt.Errorf("read %s: %w", path, err)
-	}
-	hash := sha256.Sum256(data)
-	return documentSnapshotEntry{Exists: true, Hash: hex.EncodeToString(hash[:])}, nil
-}
-
-func collectPorcelainPaths(status string) []string {
-	seen := map[string]struct{}{}
-	paths := []string{}
-	for _, line := range strings.Split(status, "\n") {
-		path, _ := parsePorcelainPath(line)
-		if path == "" {
-			continue
-		}
-		if _, ok := seen[path]; ok {
-			continue
-		}
-		seen[path] = struct{}{}
-		paths = append(paths, path)
-	}
-	sort.Strings(paths)
-	return paths
-}
-
-func documentFixChangedFilesFindings(summary, description string, changes []documentWorktreeChange) Findings {
-	findings := Findings{Summary: summary}
-	for _, change := range changes {
-		findings.Items = append(findings.Items, Finding{
-			Severity:    "warning",
-			File:        change.Path,
-			Description: description,
-		})
-	}
-	return findings
-}
-
-func commitDocumentFixes(sctx *pipeline.StepContext, summary string, changes []documentWorktreeChange) error {
-	ctx := sctx.Ctx
-	stepName := types.StepDocument
-	paths := make([]string, 0, len(changes))
-	for _, change := range changes {
-		paths = append(paths, change.Path)
-	}
-	if len(paths) == 0 {
-		sctx.Log("no agent changes to commit")
-		return nil
-	}
-	addArgs := append([]string{"add", "--"}, paths...)
-	if _, err := git.Run(ctx, sctx.WorkDir, addArgs...); err != nil {
-		return fmt.Errorf("stage %s changes: %w", stepName, err)
-	}
-	if summary == "" {
-		summary = "update documentation"
-	}
-	commitMessage := deterministicFixCommitMessage(stepName, summary)
-	commitArgs := append([]string{"commit", "-m", commitMessage, "--"}, paths...)
-	if _, err := git.Run(ctx, sctx.WorkDir, commitArgs...); err != nil {
-		return fmt.Errorf("commit %s changes: %w", stepName, err)
-	}
-	headSHA, err := git.HeadSHA(ctx, sctx.WorkDir)
-	if err != nil {
-		return fmt.Errorf("resolve head after %s commit: %w", stepName, err)
-	}
-	ref := normalizedBranchRef(sctx.Run.Branch)
-	if _, err := git.Run(ctx, sctx.WorkDir, "update-ref", ref, headSHA); err != nil {
-		return fmt.Errorf("update local branch ref: %w", err)
-	}
-	sctx.Run.HeadSHA = headSHA
-	if err := sctx.DB.UpdateRunHeadSHA(sctx.Run.ID, headSHA); err != nil {
-		return err
-	}
-	sctx.Log(fmt.Sprintf("committed agent fixes: %s", commitMessage))
-	return nil
-}
-
-func isDocumentationPath(path string) bool {
-	clean := filepath.ToSlash(strings.TrimSpace(path))
-	if clean == "" {
-		return false
-	}
-	base := filepath.Base(clean)
-	upperBase := strings.ToUpper(base)
-	if strings.HasPrefix(clean, "docs/") {
-		return true
-	}
-	if upperBase == "README" || strings.HasPrefix(upperBase, "README.") {
-		return true
-	}
-	for _, name := range []string{"CHANGELOG", "CONTRIBUTING", "LICENSE"} {
-		if upperBase == name || strings.HasPrefix(upperBase, name+".") {
-			return true
-		}
-	}
-	for _, ext := range []string{".md", ".mdx", ".rst", ".adoc"} {
-		if strings.HasSuffix(strings.ToLower(base), ext) {
-			return true
-		}
-	}
-	return false
-}
-
-func malformedDocumentFixOutcome(ctx context.Context, workDir string, baseline map[string]documentSnapshotEntry) (*pipeline.StepOutcome, error) {
-	changes, err := detectDocumentWorktreeChanges(ctx, workDir, baseline)
-	if err != nil {
-		return nil, err
-	}
-	if len(changes) == 0 {
-		return nil, nil
-	}
-	findings := documentFixChangedFilesFindings(
-		"document step changed files but returned malformed structured output",
-		"document step changed files but returned malformed structured output",
-		changes,
-	)
-	findingsJSON, _ := json.Marshal(findings)
 	return &pipeline.StepOutcome{
-		NeedsApproval: true,
+		NeedsApproval: needsApproval,
+		AutoFixable:   len(findings.Items) > 0,
 		Findings:      string(findingsJSON),
 	}, nil
-}
-
-func parseFirstPorcelainPath(status string) (string, bool) {
-	for _, line := range strings.Split(status, "\n") {
-		path, untracked := parsePorcelainPath(line)
-		if path != "" {
-			return path, untracked
-		}
-	}
-	return "", false
-}
-
-func parsePorcelainPath(line string) (string, bool) {
-	line = strings.TrimRight(line, "\r")
-	var path string
-	switch {
-	case strings.HasPrefix(line, "?? "):
-		path = strings.TrimSpace(line[3:])
-	case len(line) >= 4 && line[2] == ' ':
-		path = strings.TrimSpace(line[3:])
-	case len(line) >= 3 && line[1] == ' ':
-		path = strings.TrimSpace(line[2:])
-	default:
-		return "", false
-	}
-	if path == "" {
-		return "", false
-	}
-	if idx := strings.LastIndex(path, " -> "); idx >= 0 {
-		path = path[idx+4:]
-	}
-	if unquoted, err := strconv.Unquote(path); err == nil {
-		path = unquoted
-	}
-	return path, strings.HasPrefix(line, "??")
 }
 
 func hasNonIgnoredDocumentChanges(changedFiles string, ignorePatterns []string) bool {
@@ -574,27 +213,4 @@ func hasNonIgnoredDocumentChanges(changedFiles string, ignorePatterns []string) 
 		}
 	}
 	return false
-}
-
-func isDocCommentOnlyDiff(path, diff string) bool {
-	if !strings.HasSuffix(strings.ToLower(path), ".go") {
-		return false
-	}
-	for _, line := range strings.Split(diff, "\n") {
-		if strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---") || strings.HasPrefix(line, "@@") {
-			continue
-		}
-		if len(line) == 0 || (line[0] != '+' && line[0] != '-') {
-			continue
-		}
-		text := strings.TrimSpace(line[1:])
-		if text == "" {
-			continue
-		}
-		if strings.HasPrefix(text, "//") || strings.HasPrefix(text, "/*") || strings.HasPrefix(text, "*") || strings.HasPrefix(text, "*/") {
-			continue
-		}
-		return false
-	}
-	return true
 }

--- a/internal/pipeline/steps/document.go
+++ b/internal/pipeline/steps/document.go
@@ -2,9 +2,13 @@ package steps
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
@@ -38,6 +42,14 @@ type documentVerdict struct {
 func (s *DocumentStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, error) {
 	ctx := sctx.Ctx
 	baseSHA := resolveBranchBaseSHA(ctx, sctx.WorkDir, sctx.Run.BaseSHA, sctx.Repo.DefaultBranch)
+	var fixBaseline map[string]documentSnapshotEntry
+	if sctx.Fixing {
+		var err error
+		fixBaseline, err = captureDocumentWorktreeSnapshot(ctx, sctx.WorkDir)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	// Check whether there are any changed files.
 	changedFiles, err := git.Run(ctx, sctx.WorkDir, "diff", "--name-only", baseSHA+".."+sctx.Run.HeadSHA)
@@ -133,7 +145,7 @@ Rules:
 	}
 
 	if sctx.Fixing {
-		outcome, err := s.applyDocumentationUpdates(sctx, baseSHA, verdictErr)
+		outcome, err := s.applyDocumentationUpdates(sctx, baseSHA, verdictErr, fixBaseline)
 		if err != nil {
 			return nil, err
 		}
@@ -147,10 +159,10 @@ Rules:
 	return &pipeline.StepOutcome{}, nil
 }
 
-func (s *DocumentStep) applyDocumentationUpdates(sctx *pipeline.StepContext, baseSHA string, initialVerdictErr error) (*pipeline.StepOutcome, error) {
+func (s *DocumentStep) applyDocumentationUpdates(sctx *pipeline.StepContext, baseSHA string, initialVerdictErr error, baseline map[string]documentSnapshotEntry) (*pipeline.StepOutcome, error) {
 	ctx := sctx.Ctx
 	if initialVerdictErr != nil {
-		outcome, err := malformedDocumentFixOutcome(ctx, sctx.WorkDir)
+		outcome, err := malformedDocumentFixOutcome(ctx, sctx.WorkDir, baseline)
 		if err != nil {
 			return nil, err
 		}
@@ -207,15 +219,48 @@ Rules:
 	if result.Output != nil {
 		if err := json.Unmarshal(result.Output, &verdict); err != nil {
 			sctx.Log("could not parse structured output, treating as skipped")
-			return malformedDocumentFixOutcome(ctx, sctx.WorkDir)
+			return malformedDocumentFixOutcome(ctx, sctx.WorkDir, baseline)
 		}
 	}
 
+	changes, err := detectDocumentWorktreeChanges(ctx, sctx.WorkDir, baseline)
+	if err != nil {
+		return nil, err
+	}
+
 	if verdict.Verdict != "updated" {
+		if len(changes) == 0 {
+			return nil, nil
+		}
+		findingsJSON, _ := json.Marshal(documentFixChangedFilesFindings(
+			fmt.Sprintf("document step changed files but returned verdict %q", verdict.Verdict),
+			fmt.Sprintf("document step changed files but returned verdict %q", verdict.Verdict),
+			changes,
+		))
+		return &pipeline.StepOutcome{
+			NeedsApproval: true,
+			Findings:      string(findingsJSON),
+		}, nil
+	}
+
+	for _, change := range changes {
+		if change.Preexisting {
+			findingsJSON, _ := json.Marshal(documentFixChangedFilesFindings(
+				"document step modified preexisting worktree changes",
+				"document step modified preexisting worktree changes",
+				changes,
+			))
+			return &pipeline.StepOutcome{
+				NeedsApproval: true,
+				Findings:      string(findingsJSON),
+			}, nil
+		}
+	}
+	if len(changes) == 0 {
 		return nil, nil
 	}
 
-	findings, err := detectOutOfScopeDocumentEdits(ctx, sctx.WorkDir)
+	findings, err := detectOutOfScopeDocumentEdits(ctx, sctx.WorkDir, changes)
 	if err != nil {
 		return nil, err
 	}
@@ -227,24 +272,34 @@ Rules:
 		}, nil
 	}
 
-	if err := commitAgentFixes(sctx, s.Name(), verdict.Summary, "update documentation"); err != nil {
+	if err := commitDocumentFixes(sctx, verdict.Summary, changes); err != nil {
 		return nil, err
 	}
 	return nil, nil
 }
 
-func detectOutOfScopeDocumentEdits(ctx context.Context, workDir string) (Findings, error) {
-	status, err := git.Run(ctx, workDir, "status", "--porcelain", "--untracked-files=all")
-	if err != nil {
-		return Findings{}, fmt.Errorf("list document edits: %w", err)
-	}
+type documentSnapshotEntry struct {
+	Exists bool
+	Hash   string
+}
 
+type documentWorktreeChange struct {
+	Path        string
+	Preexisting bool
+}
+
+func detectOutOfScopeDocumentEdits(ctx context.Context, workDir string, changes []documentWorktreeChange) (Findings, error) {
 	findings := Findings{Summary: "document step produced out-of-scope edits"}
-	for _, line := range strings.Split(status, "\n") {
-		path, untracked := parsePorcelainPath(line)
+	for _, change := range changes {
+		path := change.Path
 		if path == "" || isDocumentationPath(path) {
 			continue
 		}
+		status, err := git.Run(ctx, workDir, "status", "--porcelain", "--untracked-files=all", "--", path)
+		if err != nil {
+			return Findings{}, fmt.Errorf("list document edits: %w", err)
+		}
+		_, untracked := parseFirstPorcelainPath(status)
 		if untracked {
 			findings.Items = append(findings.Items, Finding{
 				Severity:    "warning",
@@ -270,6 +325,136 @@ func detectOutOfScopeDocumentEdits(ctx context.Context, workDir string) (Finding
 		findings.Summary = ""
 	}
 	return findings, nil
+}
+
+func captureDocumentWorktreeSnapshot(ctx context.Context, workDir string) (map[string]documentSnapshotEntry, error) {
+	status, err := git.Run(ctx, workDir, "status", "--porcelain", "--untracked-files=all")
+	if err != nil {
+		return nil, fmt.Errorf("list document edits: %w", err)
+	}
+	paths := collectPorcelainPaths(status)
+	snapshot := make(map[string]documentSnapshotEntry, len(paths))
+	for _, path := range paths {
+		entry, err := readDocumentSnapshotEntry(workDir, path)
+		if err != nil {
+			return nil, err
+		}
+		snapshot[path] = entry
+	}
+	return snapshot, nil
+}
+
+func detectDocumentWorktreeChanges(ctx context.Context, workDir string, baseline map[string]documentSnapshotEntry) ([]documentWorktreeChange, error) {
+	status, err := git.Run(ctx, workDir, "status", "--porcelain", "--untracked-files=all")
+	if err != nil {
+		return nil, fmt.Errorf("list document edits: %w", err)
+	}
+	afterPaths := collectPorcelainPaths(status)
+	afterSet := make(map[string]struct{}, len(afterPaths))
+	changes := make([]documentWorktreeChange, 0, len(afterPaths)+len(baseline))
+	for _, path := range afterPaths {
+		afterSet[path] = struct{}{}
+		before, existedBefore := baseline[path]
+		after, err := readDocumentSnapshotEntry(workDir, path)
+		if err != nil {
+			return nil, err
+		}
+		if !existedBefore || before != after {
+			changes = append(changes, documentWorktreeChange{Path: path, Preexisting: existedBefore})
+		}
+	}
+	for path := range baseline {
+		if _, ok := afterSet[path]; ok {
+			continue
+		}
+		changes = append(changes, documentWorktreeChange{Path: path, Preexisting: true})
+	}
+	sort.Slice(changes, func(i, j int) bool {
+		return changes[i].Path < changes[j].Path
+	})
+	return changes, nil
+}
+
+func readDocumentSnapshotEntry(workDir, path string) (documentSnapshotEntry, error) {
+	absolutePath := filepath.Join(workDir, filepath.FromSlash(path))
+	data, err := os.ReadFile(absolutePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return documentSnapshotEntry{}, nil
+		}
+		return documentSnapshotEntry{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	hash := sha256.Sum256(data)
+	return documentSnapshotEntry{Exists: true, Hash: hex.EncodeToString(hash[:])}, nil
+}
+
+func collectPorcelainPaths(status string) []string {
+	seen := map[string]struct{}{}
+	paths := []string{}
+	for _, line := range strings.Split(status, "\n") {
+		path, _ := parsePorcelainPath(line)
+		if path == "" {
+			continue
+		}
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func documentFixChangedFilesFindings(summary, description string, changes []documentWorktreeChange) Findings {
+	findings := Findings{Summary: summary}
+	for _, change := range changes {
+		findings.Items = append(findings.Items, Finding{
+			Severity:    "warning",
+			File:        change.Path,
+			Description: description,
+		})
+	}
+	return findings
+}
+
+func commitDocumentFixes(sctx *pipeline.StepContext, summary string, changes []documentWorktreeChange) error {
+	ctx := sctx.Ctx
+	stepName := types.StepDocument
+	paths := make([]string, 0, len(changes))
+	for _, change := range changes {
+		paths = append(paths, change.Path)
+	}
+	if len(paths) == 0 {
+		sctx.Log("no agent changes to commit")
+		return nil
+	}
+	addArgs := append([]string{"add", "--"}, paths...)
+	if _, err := git.Run(ctx, sctx.WorkDir, addArgs...); err != nil {
+		return fmt.Errorf("stage %s changes: %w", stepName, err)
+	}
+	if summary == "" {
+		summary = "update documentation"
+	}
+	commitMessage := deterministicFixCommitMessage(stepName, summary)
+	commitArgs := append([]string{"commit", "-m", commitMessage, "--"}, paths...)
+	if _, err := git.Run(ctx, sctx.WorkDir, commitArgs...); err != nil {
+		return fmt.Errorf("commit %s changes: %w", stepName, err)
+	}
+	headSHA, err := git.HeadSHA(ctx, sctx.WorkDir)
+	if err != nil {
+		return fmt.Errorf("resolve head after %s commit: %w", stepName, err)
+	}
+	ref := normalizedBranchRef(sctx.Run.Branch)
+	if _, err := git.Run(ctx, sctx.WorkDir, "update-ref", ref, headSHA); err != nil {
+		return fmt.Errorf("update local branch ref: %w", err)
+	}
+	sctx.Run.HeadSHA = headSHA
+	if err := sctx.DB.UpdateRunHeadSHA(sctx.Run.ID, headSHA); err != nil {
+		return err
+	}
+	sctx.Log(fmt.Sprintf("committed agent fixes: %s", commitMessage))
+	return nil
 }
 
 func isDocumentationPath(path string) bool {
@@ -298,26 +483,34 @@ func isDocumentationPath(path string) bool {
 	return false
 }
 
-func malformedDocumentFixOutcome(ctx context.Context, workDir string) (*pipeline.StepOutcome, error) {
-	status, err := git.Run(ctx, workDir, "status", "--porcelain", "--untracked-files=all")
+func malformedDocumentFixOutcome(ctx context.Context, workDir string, baseline map[string]documentSnapshotEntry) (*pipeline.StepOutcome, error) {
+	changes, err := detectDocumentWorktreeChanges(ctx, workDir, baseline)
 	if err != nil {
-		return nil, fmt.Errorf("check document fix status: %w", err)
+		return nil, err
 	}
-	if strings.TrimSpace(status) == "" {
+	if len(changes) == 0 {
 		return nil, nil
 	}
-	findings := Findings{
-		Items: []Finding{{
-			Severity:    "warning",
-			Description: "document step changed files but returned malformed structured output",
-		}},
-		Summary: "document step changed files but returned malformed structured output",
-	}
+	findings := documentFixChangedFilesFindings(
+		"document step changed files but returned malformed structured output",
+		"document step changed files but returned malformed structured output",
+		changes,
+	)
 	findingsJSON, _ := json.Marshal(findings)
 	return &pipeline.StepOutcome{
 		NeedsApproval: true,
 		Findings:      string(findingsJSON),
 	}, nil
+}
+
+func parseFirstPorcelainPath(status string) (string, bool) {
+	for _, line := range strings.Split(status, "\n") {
+		path, untracked := parsePorcelainPath(line)
+		if path != "" {
+			return path, untracked
+		}
+	}
+	return "", false
 }
 
 func parsePorcelainPath(line string) (string, bool) {

--- a/internal/pipeline/steps/document.go
+++ b/internal/pipeline/steps/document.go
@@ -1,8 +1,10 @@
 package steps
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
@@ -92,6 +94,9 @@ Previous documentation findings to address:
 		if err != nil {
 			sctx.Log(fmt.Sprintf("warning: could not parse fix summary: %v", err))
 		}
+		if err := ensureDocumentOnlyFixes(ctx, sctx.WorkDir); err != nil {
+			return nil, err
+		}
 		if err := commitAgentFixes(sctx, s.Name(), summary, "update documentation"); err != nil {
 			return nil, err
 		}
@@ -166,7 +171,9 @@ Rules:
 
 	// Parse verdict
 	var verdict documentVerdict
-	if result.Output != nil {
+	if result.Output == nil {
+		verdict = documentVerdict{Verdict: "updated", Summary: fallbackDocumentSummary(result.Text)}
+	} else {
 		if err := json.Unmarshal(result.Output, &verdict); err != nil {
 			sctx.Log("could not parse structured output, requiring approval")
 			verdict = documentVerdict{Verdict: "updated", Summary: result.Text}
@@ -213,4 +220,121 @@ func hasNonIgnoredDocumentChanges(changedFiles string, ignorePatterns []string) 
 		}
 	}
 	return false
+}
+
+type gitStatusEntry struct {
+	path      string
+	untracked bool
+	status    string
+}
+
+func ensureDocumentOnlyFixes(ctx context.Context, workDir string) error {
+	status, err := git.Run(ctx, workDir, "status", "--porcelain")
+	if err != nil {
+		return fmt.Errorf("inspect document fixes: %w", err)
+	}
+	for _, entry := range parseGitStatus(status) {
+		if isDocumentationPath(entry.path) {
+			continue
+		}
+		if entry.untracked {
+			return fmt.Errorf("document step produced non-document edits in %s", entry.path)
+		}
+		diff, err := git.Run(ctx, workDir, "diff", "--no-color", "--unified=0", "HEAD", "--", entry.path)
+		if err != nil {
+			return fmt.Errorf("inspect document diff for %s: %w", entry.path, err)
+		}
+		if !diffContainsOnlyCommentChanges(entry.path, diff) {
+			return fmt.Errorf("document step produced non-document edits in %s", entry.path)
+		}
+	}
+	return nil
+}
+
+func parseGitStatus(status string) []gitStatusEntry {
+	var entries []gitStatusEntry
+	for _, line := range strings.Split(status, "\n") {
+		if len(line) < 4 {
+			continue
+		}
+		path := strings.TrimSpace(line[3:])
+		if idx := strings.LastIndex(path, " -> "); idx >= 0 {
+			path = path[idx+4:]
+		}
+		entries = append(entries, gitStatusEntry{
+			path:      path,
+			untracked: line[:2] == "??",
+			status:    line[:2],
+		})
+	}
+	return entries
+}
+
+func isDocumentationPath(path string) bool {
+	clean := filepath.ToSlash(strings.TrimSpace(path))
+	if clean == "" {
+		return false
+	}
+	if strings.HasPrefix(clean, "docs/") || strings.HasPrefix(clean, "doc/") {
+		return true
+	}
+	base := strings.ToLower(filepath.Base(clean))
+	if strings.HasPrefix(base, "readme") || strings.HasPrefix(base, "changelog") || strings.HasPrefix(base, "contributing") {
+		return true
+	}
+	switch strings.ToLower(filepath.Ext(base)) {
+	case ".md", ".mdx", ".rst", ".adoc":
+		return true
+	default:
+		return false
+	}
+}
+
+func diffContainsOnlyCommentChanges(path, diff string) bool {
+	prefixes := commentPrefixes(filepath.Ext(path))
+	if len(prefixes) == 0 {
+		return false
+	}
+	for _, line := range strings.Split(diff, "\n") {
+		if line == "" || strings.HasPrefix(line, "diff --git ") || strings.HasPrefix(line, "index ") || strings.HasPrefix(line, "--- ") || strings.HasPrefix(line, "+++ ") || strings.HasPrefix(line, "@@") || strings.HasPrefix(line, `\\`) {
+			continue
+		}
+		if line[0] != '+' && line[0] != '-' {
+			continue
+		}
+		trimmed := strings.TrimSpace(line[1:])
+		if trimmed == "" {
+			continue
+		}
+		matched := false
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(trimmed, prefix) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
+}
+
+func commentPrefixes(ext string) []string {
+	switch strings.ToLower(ext) {
+	case ".go", ".js", ".jsx", ".ts", ".tsx", ".java", ".rs", ".c", ".cc", ".cpp", ".h", ".hpp":
+		return []string{"//", "/*", "*", "*/"}
+	case ".py", ".rb", ".sh", ".bash", ".zsh", ".yaml", ".yml":
+		return []string{"#"}
+	default:
+		return nil
+	}
+}
+
+func fallbackDocumentSummary(text string) string {
+	cleaned := strings.TrimSpace(text)
+	if cleaned == "" {
+		return "agent returned no structured output"
+	}
+	return cleaned
 }

--- a/internal/pipeline/steps/document.go
+++ b/internal/pipeline/steps/document.go
@@ -106,9 +106,11 @@ Rules:
 
 	// Parse verdict
 	var verdict documentVerdict
+	var verdictErr error
 	if result.Output != nil {
 		if err := json.Unmarshal(result.Output, &verdict); err != nil {
 			sctx.Log("could not parse structured output, treating as skipped")
+			verdictErr = err
 			verdict = documentVerdict{Verdict: "skipped", Summary: result.Text}
 		}
 	}
@@ -131,7 +133,7 @@ Rules:
 	}
 
 	if sctx.Fixing {
-		outcome, err := s.applyDocumentationUpdates(sctx, baseSHA)
+		outcome, err := s.applyDocumentationUpdates(sctx, baseSHA, verdictErr)
 		if err != nil {
 			return nil, err
 		}
@@ -145,8 +147,18 @@ Rules:
 	return &pipeline.StepOutcome{}, nil
 }
 
-func (s *DocumentStep) applyDocumentationUpdates(sctx *pipeline.StepContext, baseSHA string) (*pipeline.StepOutcome, error) {
+func (s *DocumentStep) applyDocumentationUpdates(sctx *pipeline.StepContext, baseSHA string, initialVerdictErr error) (*pipeline.StepOutcome, error) {
 	ctx := sctx.Ctx
+	if initialVerdictErr != nil {
+		outcome, err := malformedDocumentFixOutcome(ctx, sctx.WorkDir)
+		if err != nil {
+			return nil, err
+		}
+		if outcome != nil {
+			return outcome, nil
+		}
+	}
+
 	ignorePatterns := "none"
 	if len(sctx.Config.IgnorePatterns) > 0 {
 		ignorePatterns = strings.Join(sctx.Config.IgnorePatterns, ", ")
@@ -195,7 +207,7 @@ Rules:
 	if result.Output != nil {
 		if err := json.Unmarshal(result.Output, &verdict); err != nil {
 			sctx.Log("could not parse structured output, treating as skipped")
-			verdict = documentVerdict{Verdict: "skipped", Summary: result.Text}
+			return malformedDocumentFixOutcome(ctx, sctx.WorkDir)
 		}
 	}
 
@@ -222,15 +234,23 @@ Rules:
 }
 
 func detectOutOfScopeDocumentEdits(ctx context.Context, workDir string) (Findings, error) {
-	changedFiles, err := git.Run(ctx, workDir, "diff", "--name-only", "HEAD")
+	status, err := git.Run(ctx, workDir, "status", "--porcelain", "--untracked-files=all")
 	if err != nil {
 		return Findings{}, fmt.Errorf("list document edits: %w", err)
 	}
 
 	findings := Findings{Summary: "document step produced out-of-scope edits"}
-	for _, path := range strings.Split(changedFiles, "\n") {
-		path = strings.TrimSpace(path)
+	for _, line := range strings.Split(status, "\n") {
+		path, untracked := parsePorcelainPath(line)
 		if path == "" || isDocumentationPath(path) {
+			continue
+		}
+		if untracked {
+			findings.Items = append(findings.Items, Finding{
+				Severity:    "warning",
+				File:        path,
+				Description: "document step modified non-documentation content",
+			})
 			continue
 		}
 		diff, err := git.Run(ctx, workDir, "diff", "HEAD", "--", path)
@@ -270,12 +290,56 @@ func isDocumentationPath(path string) bool {
 			return true
 		}
 	}
-	for _, ext := range []string{".md", ".mdx", ".rst", ".adoc", ".txt"} {
+	for _, ext := range []string{".md", ".mdx", ".rst", ".adoc"} {
 		if strings.HasSuffix(strings.ToLower(base), ext) {
 			return true
 		}
 	}
 	return false
+}
+
+func malformedDocumentFixOutcome(ctx context.Context, workDir string) (*pipeline.StepOutcome, error) {
+	status, err := git.Run(ctx, workDir, "status", "--porcelain", "--untracked-files=all")
+	if err != nil {
+		return nil, fmt.Errorf("check document fix status: %w", err)
+	}
+	if strings.TrimSpace(status) == "" {
+		return nil, nil
+	}
+	findings := Findings{
+		Items: []Finding{{
+			Severity:    "warning",
+			Description: "document step changed files but returned malformed structured output",
+		}},
+		Summary: "document step changed files but returned malformed structured output",
+	}
+	findingsJSON, _ := json.Marshal(findings)
+	return &pipeline.StepOutcome{
+		NeedsApproval: true,
+		Findings:      string(findingsJSON),
+	}, nil
+}
+
+func parsePorcelainPath(line string) (string, bool) {
+	line = strings.TrimRight(line, "\r")
+	var path string
+	switch {
+	case strings.HasPrefix(line, "?? "):
+		path = strings.TrimSpace(line[3:])
+	case len(line) >= 4 && line[2] == ' ':
+		path = strings.TrimSpace(line[3:])
+	case len(line) >= 3 && line[1] == ' ':
+		path = strings.TrimSpace(line[2:])
+	default:
+		return "", false
+	}
+	if path == "" {
+		return "", false
+	}
+	if idx := strings.LastIndex(path, " -> "); idx >= 0 {
+		path = path[idx+4:]
+	}
+	return path, strings.HasPrefix(line, "??")
 }
 
 func isDocCommentOnlyDiff(path, diff string) bool {

--- a/internal/pipeline/steps/document.go
+++ b/internal/pipeline/steps/document.go
@@ -1,0 +1,127 @@
+package steps
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/kunchenguid/no-mistakes/internal/agent"
+	"github.com/kunchenguid/no-mistakes/internal/git"
+	"github.com/kunchenguid/no-mistakes/internal/pipeline"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// DocumentStep updates project documentation to reflect code changes.
+type DocumentStep struct{}
+
+func (s *DocumentStep) Name() types.StepName { return types.StepDocument }
+
+// documentVerdictSchema is the JSON schema for the document step's structured output.
+var documentVerdictSchema = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"verdict": {"type": "string", "enum": ["updated", "skipped"]},
+		"summary": {"type": "string"},
+		"details": {"type": "string"}
+	},
+	"required": ["verdict", "summary"]
+}`)
+
+type documentVerdict struct {
+	Verdict string `json:"verdict"`
+	Summary string `json:"summary"`
+	Details string `json:"details,omitempty"`
+}
+
+func (s *DocumentStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, error) {
+	ctx := sctx.Ctx
+	baseSHA := resolveBranchBaseSHA(ctx, sctx.WorkDir, sctx.Run.BaseSHA, sctx.Repo.DefaultBranch)
+
+	// Check whether there are any changed files.
+	changedFiles, err := git.Run(ctx, sctx.WorkDir, "diff", "--name-only", baseSHA+".."+sctx.Run.HeadSHA)
+	if err != nil {
+		return nil, fmt.Errorf("get changed files: %w", err)
+	}
+	if strings.TrimSpace(changedFiles) == "" {
+		sctx.Log("no changes to document")
+		return &pipeline.StepOutcome{}, nil
+	}
+
+	sctx.Log("updating documentation...")
+
+	ignorePatterns := "none"
+	if len(sctx.Config.IgnorePatterns) > 0 {
+		ignorePatterns = strings.Join(sctx.Config.IgnorePatterns, ", ")
+	}
+
+	prompt := fmt.Sprintf(
+		`Review the code changes and update any project documentation that needs to reflect the changes.
+
+Context:
+- branch: %s
+- base commit: %s
+- target commit: %s
+- default branch: %s
+- ignore patterns: %s
+
+Task:
+
+1. Understand the change
+   - Read the diff and changed files to understand what was added, modified, or removed.
+   - Identify the intent and scope of the change (new feature, API change, config change, behavioral change, etc.).
+
+2. Identify documentation that needs updating
+   - Look for existing documentation files in the project: README.md, docs/, doc comments, config examples, etc.
+   - Determine which docs are affected by the change. Common cases:
+     - New or changed public APIs - update API docs, doc comments, or usage examples
+     - New features or behaviors - update README or relevant guide
+     - Changed configuration - update config docs or examples
+     - Removed functionality - remove or update stale references
+
+3. Make documentation updates
+   - Update only the documentation that is directly affected by this change.
+   - Keep updates minimal and accurate - do not rewrite docs that are already correct.
+   - Match the existing documentation style and conventions of the project.
+   - If no documentation updates are needed (e.g., internal refactoring, test-only changes), skip.
+
+Rules:
+- Do NOT change any source code - only update documentation files and doc comments.
+- Do NOT create new documentation files unless the change clearly warrants it (e.g., a major new feature with no existing docs).
+- Return JSON with "verdict" ("updated" or "skipped"), "summary" (brief description of what was updated and why), and optional "details".`,
+		sctx.Run.Branch,
+		baseSHA,
+		sctx.Run.HeadSHA,
+		sctx.Repo.DefaultBranch,
+		ignorePatterns,
+	)
+
+	result, err := sctx.Agent.Run(ctx, agent.RunOpts{
+		Prompt:     prompt,
+		CWD:        sctx.WorkDir,
+		JSONSchema: documentVerdictSchema,
+		OnChunk:    sctx.Log,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("agent document: %w", err)
+	}
+
+	// Parse verdict
+	var verdict documentVerdict
+	if result.Output != nil {
+		if err := json.Unmarshal(result.Output, &verdict); err != nil {
+			sctx.Log("could not parse structured output, treating as skipped")
+			verdict = documentVerdict{Verdict: "skipped", Summary: result.Text}
+		}
+	}
+
+	// Commit any doc changes the agent made
+	if verdict.Verdict == "updated" {
+		if err := commitAgentFixes(sctx, s.Name(), verdict.Summary, "update documentation"); err != nil {
+			return nil, err
+		}
+	}
+
+	sctx.Log(fmt.Sprintf("document verdict: %s - %s", verdict.Verdict, verdict.Summary))
+
+	return &pipeline.StepOutcome{}, nil
+}

--- a/internal/pipeline/steps/document.go
+++ b/internal/pipeline/steps/document.go
@@ -183,6 +183,10 @@ Rules:
 			sctx.Log("could not parse structured output, requiring approval")
 			verdict = documentVerdict{Verdict: "updated", Summary: fallbackDocumentSummary(result.Text)}
 			requiresHumanReview = true
+		} else if verdict.Verdict != "updated" && verdict.Verdict != "skipped" {
+			sctx.Log("invalid structured output verdict, requiring approval")
+			verdict = documentVerdict{Verdict: "updated", Summary: fallbackDocumentSummary(verdict.Summary)}
+			requiresHumanReview = true
 		}
 	}
 
@@ -299,10 +303,11 @@ func isDocumentationPath(path string) bool {
 }
 
 func diffContainsOnlyCommentChanges(path, diff string) bool {
-	prefixes := commentPrefixes(filepath.Ext(path))
-	if len(prefixes) == 0 {
+	style := commentStyleFor(filepath.Ext(path))
+	if len(style.linePrefixes) == 0 && !style.block {
 		return false
 	}
+	inBlock := false
 	for _, line := range strings.Split(diff, "\n") {
 		if line == "" || strings.HasPrefix(line, "diff --git ") || strings.HasPrefix(line, "index ") || strings.HasPrefix(line, "--- ") || strings.HasPrefix(line, "+++ ") || strings.HasPrefix(line, "@@") || strings.HasPrefix(line, `\\`) {
 			continue
@@ -315,11 +320,14 @@ func diffContainsOnlyCommentChanges(path, diff string) bool {
 			continue
 		}
 		matched := false
-		for _, prefix := range prefixes {
+		for _, prefix := range style.linePrefixes {
 			if strings.HasPrefix(trimmed, prefix) {
 				matched = true
 				break
 			}
+		}
+		if !matched && style.block {
+			matched, inBlock = matchBlockCommentLine(trimmed, inBlock)
 		}
 		if !matched {
 			return false
@@ -328,15 +336,30 @@ func diffContainsOnlyCommentChanges(path, diff string) bool {
 	return true
 }
 
-func commentPrefixes(ext string) []string {
+type commentStyle struct {
+	linePrefixes []string
+	block        bool
+}
+
+func commentStyleFor(ext string) commentStyle {
 	switch strings.ToLower(ext) {
 	case ".go", ".js", ".jsx", ".ts", ".tsx", ".java", ".rs", ".c", ".cc", ".cpp", ".h", ".hpp":
-		return []string{"//", "/*", "*", "*/"}
+		return commentStyle{linePrefixes: []string{"//"}, block: true}
 	case ".py", ".rb", ".sh", ".bash", ".zsh", ".yaml", ".yml":
-		return []string{"#"}
+		return commentStyle{linePrefixes: []string{"#"}}
 	default:
-		return nil
+		return commentStyle{}
 	}
+}
+
+func matchBlockCommentLine(line string, inBlock bool) (bool, bool) {
+	if inBlock {
+		return true, strings.Count(line, "/*") >= strings.Count(line, "*/")
+	}
+	if !strings.Contains(line, "/*") {
+		return false, false
+	}
+	return true, strings.Count(line, "/*") > strings.Count(line, "*/")
 }
 
 func fallbackDocumentSummary(text string) string {

--- a/internal/pipeline/steps/document.go
+++ b/internal/pipeline/steps/document.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
@@ -56,7 +57,7 @@ func (s *DocumentStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcom
 	if err != nil {
 		return nil, fmt.Errorf("get changed files: %w", err)
 	}
-	if strings.TrimSpace(changedFiles) == "" {
+	if !hasNonIgnoredDocumentChanges(changedFiles, sctx.Config.IgnorePatterns) {
 		sctx.Log("no changes to document")
 		return &pipeline.StepOutcome{}, nil
 	}
@@ -121,10 +122,27 @@ Rules:
 	var verdictErr error
 	if result.Output != nil {
 		if err := json.Unmarshal(result.Output, &verdict); err != nil {
-			sctx.Log("could not parse structured output, treating as skipped")
+			sctx.Log("could not parse structured output, requiring approval")
 			verdictErr = err
 			verdict = documentVerdict{Verdict: "skipped", Summary: result.Text}
 		}
+	}
+
+	if !sctx.Fixing && verdictErr != nil {
+		findings := Findings{
+			Items: []Finding{{
+				Severity:    "warning",
+				Description: verdict.Summary,
+			}},
+			Summary: verdict.Summary,
+		}
+		findingsJSON, _ := json.Marshal(findings)
+		sctx.Log(fmt.Sprintf("document verdict: malformed output - %s", verdict.Summary))
+		return &pipeline.StepOutcome{
+			NeedsApproval: true,
+			AutoFixable:   true,
+			Findings:      string(findingsJSON),
+		}, nil
 	}
 
 	if !sctx.Fixing && verdict.Verdict == "updated" {
@@ -532,7 +550,30 @@ func parsePorcelainPath(line string) (string, bool) {
 	if idx := strings.LastIndex(path, " -> "); idx >= 0 {
 		path = path[idx+4:]
 	}
+	if unquoted, err := strconv.Unquote(path); err == nil {
+		path = unquoted
+	}
 	return path, strings.HasPrefix(line, "??")
+}
+
+func hasNonIgnoredDocumentChanges(changedFiles string, ignorePatterns []string) bool {
+	for _, path := range strings.Split(changedFiles, "\n") {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		ignored := false
+		for _, pattern := range ignorePatterns {
+			if matchIgnorePattern(path, pattern) {
+				ignored = true
+				break
+			}
+		}
+		if !ignored {
+			return true
+		}
+	}
+	return false
 }
 
 func isDocCommentOnlyDiff(path, diff string) bool {

--- a/internal/pipeline/steps/document.go
+++ b/internal/pipeline/steps/document.go
@@ -170,13 +170,19 @@ Rules:
 	}
 
 	// Parse verdict
-	var verdict documentVerdict
+	var (
+		verdict             documentVerdict
+		requiresHumanReview bool
+	)
 	if result.Output == nil {
+		sctx.Log("missing structured output, requiring approval")
 		verdict = documentVerdict{Verdict: "updated", Summary: fallbackDocumentSummary(result.Text)}
+		requiresHumanReview = true
 	} else {
 		if err := json.Unmarshal(result.Output, &verdict); err != nil {
 			sctx.Log("could not parse structured output, requiring approval")
-			verdict = documentVerdict{Verdict: "updated", Summary: result.Text}
+			verdict = documentVerdict{Verdict: "updated", Summary: fallbackDocumentSummary(result.Text)}
+			requiresHumanReview = true
 		}
 	}
 
@@ -185,8 +191,9 @@ Rules:
 	if needsApproval {
 		findings = Findings{
 			Items: []Finding{{
-				Severity:    "warning",
-				Description: verdict.Summary,
+				Severity:            "warning",
+				Description:         verdict.Summary,
+				RequiresHumanReview: requiresHumanReview,
 			}},
 			Summary: verdict.Summary,
 		}
@@ -194,10 +201,11 @@ Rules:
 
 	findingsJSON, _ := json.Marshal(findings)
 	sctx.Log(fmt.Sprintf("document verdict: %s - %s", verdict.Verdict, verdict.Summary))
+	autoFixable := len(types.AutoFixableFindings(findings).Items) > 0
 
 	return &pipeline.StepOutcome{
 		NeedsApproval: needsApproval,
-		AutoFixable:   len(findings.Items) > 0,
+		AutoFixable:   autoFixable,
 		Findings:      string(findingsJSON),
 	}, nil
 }

--- a/internal/pipeline/steps/document.go
+++ b/internal/pipeline/steps/document.go
@@ -1,8 +1,10 @@
 package steps
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
@@ -47,7 +49,7 @@ func (s *DocumentStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcom
 		return &pipeline.StepOutcome{}, nil
 	}
 
-	sctx.Log("updating documentation...")
+	sctx.Log("checking documentation...")
 
 	ignorePatterns := "none"
 	if len(sctx.Config.IgnorePatterns) > 0 {
@@ -55,7 +57,7 @@ func (s *DocumentStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcom
 	}
 
 	prompt := fmt.Sprintf(
-		`Review the code changes and update any project documentation that needs to reflect the changes.
+		`Review the code changes and determine whether project documentation needs to be updated.
 
 Context:
 - branch: %s
@@ -78,15 +80,12 @@ Task:
      - Changed configuration - update config docs or examples
      - Removed functionality - remove or update stale references
 
-3. Make documentation updates
-   - Update only the documentation that is directly affected by this change.
-   - Keep updates minimal and accurate - do not rewrite docs that are already correct.
-   - Match the existing documentation style and conventions of the project.
-   - If no documentation updates are needed (e.g., internal refactoring, test-only changes), skip.
+3. Decide whether documentation updates are needed
+	- If the change requires doc updates, return verdict "updated" with a concise summary of what should change.
+	- If no documentation updates are needed (e.g., internal refactoring, test-only changes), return verdict "skipped".
 
 Rules:
-- Do NOT change any source code - only update documentation files and doc comments.
-- Do NOT create new documentation files unless the change clearly warrants it (e.g., a major new feature with no existing docs).
+- Do NOT make any file changes in this mode.
 - Return JSON with "verdict" ("updated" or "skipped"), "summary" (brief description of what was updated and why), and optional "details".`,
 		sctx.Run.Branch,
 		baseSHA,
@@ -114,14 +113,190 @@ Rules:
 		}
 	}
 
-	// Commit any doc changes the agent made
-	if verdict.Verdict == "updated" {
-		if err := commitAgentFixes(sctx, s.Name(), verdict.Summary, "update documentation"); err != nil {
+	if !sctx.Fixing && verdict.Verdict == "updated" {
+		findings := Findings{
+			Items: []Finding{{
+				Severity:    "warning",
+				Description: verdict.Summary,
+			}},
+			Summary: verdict.Summary,
+		}
+		findingsJSON, _ := json.Marshal(findings)
+		sctx.Log(fmt.Sprintf("document verdict: %s - %s", verdict.Verdict, verdict.Summary))
+		return &pipeline.StepOutcome{
+			NeedsApproval: true,
+			AutoFixable:   true,
+			Findings:      string(findingsJSON),
+		}, nil
+	}
+
+	if sctx.Fixing {
+		outcome, err := s.applyDocumentationUpdates(sctx, baseSHA)
+		if err != nil {
 			return nil, err
+		}
+		if outcome != nil {
+			return outcome, nil
 		}
 	}
 
 	sctx.Log(fmt.Sprintf("document verdict: %s - %s", verdict.Verdict, verdict.Summary))
 
 	return &pipeline.StepOutcome{}, nil
+}
+
+func (s *DocumentStep) applyDocumentationUpdates(sctx *pipeline.StepContext, baseSHA string) (*pipeline.StepOutcome, error) {
+	ctx := sctx.Ctx
+	ignorePatterns := "none"
+	if len(sctx.Config.IgnorePatterns) > 0 {
+		ignorePatterns = strings.Join(sctx.Config.IgnorePatterns, ", ")
+	}
+
+	prompt := fmt.Sprintf(
+		`Update any project documentation that needs to reflect the code changes.
+
+Context:
+- branch: %s
+- base commit: %s
+- target commit: %s
+- default branch: %s
+- ignore patterns: %s
+
+Task:
+- Read the relevant diff and changed files yourself before editing.
+- Update only the documentation directly affected by the change.
+- Keep updates minimal and match the existing documentation style.
+
+Rules:
+- Only edit documentation files or doc comments.
+- Do not change executable code or tests.
+- Return JSON with "verdict" ("updated" or "skipped"), "summary", and optional "details" when finished.`,
+		sctx.Run.Branch,
+		baseSHA,
+		sctx.Run.HeadSHA,
+		sctx.Repo.DefaultBranch,
+		ignorePatterns,
+	)
+	if sctx.PreviousFindings != "" {
+		prompt += "\n\nPrevious documentation findings to address:\n" + sctx.PreviousFindings
+	}
+
+	result, err := sctx.Agent.Run(ctx, agent.RunOpts{
+		Prompt:     prompt,
+		CWD:        sctx.WorkDir,
+		JSONSchema: documentVerdictSchema,
+		OnChunk:    sctx.Log,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("agent document fix: %w", err)
+	}
+
+	var verdict documentVerdict
+	if result.Output != nil {
+		if err := json.Unmarshal(result.Output, &verdict); err != nil {
+			sctx.Log("could not parse structured output, treating as skipped")
+			verdict = documentVerdict{Verdict: "skipped", Summary: result.Text}
+		}
+	}
+
+	if verdict.Verdict != "updated" {
+		return nil, nil
+	}
+
+	findings, err := detectOutOfScopeDocumentEdits(ctx, sctx.WorkDir)
+	if err != nil {
+		return nil, err
+	}
+	if len(findings.Items) > 0 {
+		findingsJSON, _ := json.Marshal(findings)
+		return &pipeline.StepOutcome{
+			NeedsApproval: true,
+			Findings:      string(findingsJSON),
+		}, nil
+	}
+
+	if err := commitAgentFixes(sctx, s.Name(), verdict.Summary, "update documentation"); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func detectOutOfScopeDocumentEdits(ctx context.Context, workDir string) (Findings, error) {
+	changedFiles, err := git.Run(ctx, workDir, "diff", "--name-only", "HEAD")
+	if err != nil {
+		return Findings{}, fmt.Errorf("list document edits: %w", err)
+	}
+
+	findings := Findings{Summary: "document step produced out-of-scope edits"}
+	for _, path := range strings.Split(changedFiles, "\n") {
+		path = strings.TrimSpace(path)
+		if path == "" || isDocumentationPath(path) {
+			continue
+		}
+		diff, err := git.Run(ctx, workDir, "diff", "HEAD", "--", path)
+		if err != nil {
+			return Findings{}, fmt.Errorf("diff document edit %s: %w", path, err)
+		}
+		if isDocCommentOnlyDiff(path, diff) {
+			continue
+		}
+		findings.Items = append(findings.Items, Finding{
+			Severity:    "warning",
+			File:        path,
+			Description: "document step modified non-documentation content",
+		})
+	}
+	if len(findings.Items) == 0 {
+		findings.Summary = ""
+	}
+	return findings, nil
+}
+
+func isDocumentationPath(path string) bool {
+	clean := filepath.ToSlash(strings.TrimSpace(path))
+	if clean == "" {
+		return false
+	}
+	base := filepath.Base(clean)
+	upperBase := strings.ToUpper(base)
+	if strings.HasPrefix(clean, "docs/") {
+		return true
+	}
+	if upperBase == "README" || strings.HasPrefix(upperBase, "README.") {
+		return true
+	}
+	for _, name := range []string{"CHANGELOG", "CONTRIBUTING", "LICENSE"} {
+		if upperBase == name || strings.HasPrefix(upperBase, name+".") {
+			return true
+		}
+	}
+	for _, ext := range []string{".md", ".mdx", ".rst", ".adoc", ".txt"} {
+		if strings.HasSuffix(strings.ToLower(base), ext) {
+			return true
+		}
+	}
+	return false
+}
+
+func isDocCommentOnlyDiff(path, diff string) bool {
+	if !strings.HasSuffix(strings.ToLower(path), ".go") {
+		return false
+	}
+	for _, line := range strings.Split(diff, "\n") {
+		if strings.HasPrefix(line, "+++") || strings.HasPrefix(line, "---") || strings.HasPrefix(line, "@@") {
+			continue
+		}
+		if len(line) == 0 || (line[0] != '+' && line[0] != '-') {
+			continue
+		}
+		text := strings.TrimSpace(line[1:])
+		if text == "" {
+			continue
+		}
+		if strings.HasPrefix(text, "//") || strings.HasPrefix(text, "/*") || strings.HasPrefix(text, "*") || strings.HasPrefix(text, "*/") {
+			continue
+		}
+		return false
+	}
+	return true
 }

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -140,14 +140,14 @@ Context:
 Task:
 - Read the relevant history and diff yourself.
 - focus only on changed code.
-- Analyze for bugs, risks, code simplification opportunities, and documentation gaps.
+- Analyze for bugs, risks, and code simplification opportunities.
 - "Simplification" means reducing code complexity through non-functional refactoring (e.g. deduplication, clearer control flow). It does NOT mean removing features, changing product behavior, or stripping intentional user-facing output.
 - Treat security issues, performance regressions, breaking changes, and insufficient error handling as risks.
 
 Rules:
 - Anchor every finding to a specific file and one-indexed line number in the changed code when possible.
 - Use severity "error" for problems that should absolutely not get merged, "warning" for things that are worth addressing but can be done in a follow up, and "info" for things that are nice to have.
-- Be concise and actionable. No generic advice like "add more tests" or "improve docs".
+- Be concise and actionable. No generic advice like "add more tests".
 - Only comment on things that genuinely matter.
 - Do NOT report styling, formatting, linting, compilation, or type-checking issues.
 - If the change is clean, return an empty findings array.

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1642,8 +1642,21 @@ func TestDocumentStep_MalformedOutput(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if outcome.NeedsApproval {
-		t.Error("document step should never require approval")
+	if !outcome.NeedsApproval {
+		t.Fatal("expected malformed output to require approval")
+	}
+	if !outcome.AutoFixable {
+		t.Fatal("expected malformed output finding to remain auto-fixable")
+	}
+	var findings Findings
+	if err := json.Unmarshal([]byte(outcome.Findings), &findings); err != nil {
+		t.Fatalf("unmarshal findings: %v", err)
+	}
+	if len(findings.Items) != 1 {
+		t.Fatalf("expected 1 finding, got %+v", findings.Items)
+	}
+	if findings.Items[0].Description != "I updated the docs" {
+		t.Fatalf("finding description = %q, want %q", findings.Items[0].Description, "I updated the docs")
 	}
 }
 
@@ -1669,6 +1682,41 @@ func TestDocumentStep_PromptIncludesIgnorePatterns(t *testing.T) {
 	}
 	if !strings.Contains(ag.calls[0].Prompt, "*.generated.go, vendor/**") {
 		t.Error("expected prompt to include ignore patterns")
+	}
+}
+
+func TestDocumentStep_IgnorePatternsFilterAllFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	os.WriteFile(filepath.Join(dir, "base.txt"), []byte("base"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "base")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "schema.generated.go"), []byte("package gen\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "add generated")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Config.IgnorePatterns = []string{"*.generated.go"}
+
+	step := &DocumentStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Error("expected no approval when all changes are ignored")
+	}
+	if len(ag.calls) != 0 {
+		t.Errorf("expected no agent calls when diff is empty after filtering, got %d", len(ag.calls))
 	}
 }
 
@@ -1927,6 +1975,24 @@ func TestIsDocumentationPath_DoesNotTreatArbitraryTxtAsDocs(t *testing.T) {
 	}
 	if !isDocumentationPath("docs/output.txt") {
 		t.Fatal("expected docs/ .txt file to be treated as documentation")
+	}
+}
+
+func TestParsePorcelainPath_UnquotesQuotedPaths(t *testing.T) {
+	path, untracked := parsePorcelainPath("?? \"docs/with space.md\"")
+	if path != "docs/with space.md" {
+		t.Fatalf("path = %q, want %q", path, "docs/with space.md")
+	}
+	if !untracked {
+		t.Fatal("expected quoted ?? path to be marked untracked")
+	}
+
+	renamedPath, renamedUntracked := parsePorcelainPath("R  \"old name.md\" -> \"new name.md\"")
+	if renamedPath != "new name.md" {
+		t.Fatalf("renamed path = %q, want %q", renamedPath, "new name.md")
+	}
+	if renamedUntracked {
+		t.Fatal("expected rename entry not to be marked untracked")
 	}
 }
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1750,6 +1750,78 @@ func TestDocumentStep_FixMode_NonDocumentationEditNeedsApproval(t *testing.T) {
 	}
 }
 
+func TestDocumentStep_FixMode_UntrackedNonDocumentationEditNeedsApproval(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			os.WriteFile(filepath.Join(dir, "feature.go"), []byte("package main\n\nfunc feature() {}\n"), 0o644)
+			return &agent.Result{Output: json.RawMessage(`{"verdict":"updated","summary":"updated docs"}`)}, nil
+		},
+	}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Fixing = true
+	sctx.PreviousFindings = `{"findings":[{"severity":"warning","description":"updated docs"}],"summary":"updated docs"}`
+
+	step := &DocumentStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected approval when agent creates non-documentation files")
+	}
+	if got := lastCommitMessage(t, dir); got != "add feature" {
+		t.Fatalf("expected no new commit, but last commit message = %q", got)
+	}
+	var findings Findings
+	if err := json.Unmarshal([]byte(outcome.Findings), &findings); err != nil {
+		t.Fatalf("unmarshal findings: %v", err)
+	}
+	if len(findings.Items) != 1 {
+		t.Fatalf("expected 1 finding, got %+v", findings.Items)
+	}
+	if findings.Items[0].File != "feature.go" {
+		t.Fatalf("finding file = %q, want %q", findings.Items[0].File, "feature.go")
+	}
+}
+
+func TestDocumentStep_FixMode_MalformedOutputWithEditsNeedsApproval(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Updated docs\n"), 0o644)
+			return &agent.Result{
+				Output: json.RawMessage(`{not valid json`),
+				Text:   "I updated the docs",
+			}, nil
+		},
+	}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Fixing = true
+	sctx.PreviousFindings = `{"findings":[{"severity":"warning","description":"updated docs"}],"summary":"updated docs"}`
+
+	step := &DocumentStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected malformed fix output with edits to require approval")
+	}
+	if got := lastCommitMessage(t, dir); got != "add feature" {
+		t.Fatalf("expected no new commit, but last commit message = %q", got)
+	}
+	if status := gitStatusPorcelain(t, dir); status == "" {
+		t.Fatal("expected documentation edit to remain for review")
+	}
+}
+
 func TestDocumentStep_FixMode_AllowsDocCommentOnlyEdits(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 	gitCmd(t, dir, "checkout", "--detach", headSHA)
@@ -1779,6 +1851,15 @@ func TestDocumentStep_FixMode_AllowsDocCommentOnlyEdits(t *testing.T) {
 	}
 	if got := lastCommitMessage(t, dir); got != "no-mistakes(document): add doc comment" {
 		t.Fatalf("last commit message = %q", got)
+	}
+}
+
+func TestIsDocumentationPath_DoesNotTreatArbitraryTxtAsDocs(t *testing.T) {
+	if isDocumentationPath("testdata/golden/output.txt") {
+		t.Fatal("expected arbitrary .txt file to be out of scope")
+	}
+	if !isDocumentationPath("docs/output.txt") {
+		t.Fatal("expected docs/ .txt file to be treated as documentation")
 	}
 }
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1659,6 +1659,40 @@ func TestDocumentStep_MalformedOutput(t *testing.T) {
 	}
 }
 
+func TestDocumentStep_NoStructuredOutputRequiresApproval(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			return &agent.Result{Text: "docs status unavailable"}, nil
+		},
+	}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+
+	step := &DocumentStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected missing structured output to require approval")
+	}
+	if !outcome.AutoFixable {
+		t.Fatal("expected missing structured output finding to remain auto-fixable")
+	}
+	var findings Findings
+	if err := json.Unmarshal([]byte(outcome.Findings), &findings); err != nil {
+		t.Fatalf("unmarshal findings: %v", err)
+	}
+	if len(findings.Items) != 1 {
+		t.Fatalf("expected 1 finding, got %+v", findings.Items)
+	}
+	if findings.Items[0].Description != "docs status unavailable" {
+		t.Fatalf("finding description = %q, want %q", findings.Items[0].Description, "docs status unavailable")
+	}
+}
+
 func TestDocumentStep_PromptIncludesIgnorePatterns(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
@@ -1840,6 +1874,37 @@ func TestDocumentStep_FixMode_NoChangesStillReassesses(t *testing.T) {
 	}
 	if outcome.NeedsApproval {
 		t.Error("expected no approval after clean re-assessment")
+	}
+}
+
+func TestDocumentStep_FixMode_RejectsNonDocumentEdits(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature code\nmore code\n"), 0o644)
+			return &agent.Result{Output: json.RawMessage(`{"summary":"update docs"}`)}, nil
+		},
+	}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Fixing = true
+	sctx.PreviousFindings = `{"findings":[{"severity":"warning","description":"docs outdated"}],"summary":"docs outdated"}`
+
+	step := &DocumentStep{}
+	_, err := step.Execute(sctx)
+	if err == nil {
+		t.Fatal("expected error for non-document edits")
+	}
+	if !strings.Contains(err.Error(), "non-document") {
+		t.Fatalf("error = %v, want to mention non-document edits", err)
+	}
+	if got := lastCommitMessage(t, dir); got != "add feature" {
+		t.Fatalf("expected no new commit, got %q", got)
+	}
+	if status := gitStatusPorcelain(t, dir); !strings.Contains(status, "feature.txt") {
+		t.Fatalf("expected non-document change to remain uncommitted, got %q", status)
 	}
 }
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1822,6 +1822,73 @@ func TestDocumentStep_FixMode_MalformedOutputWithEditsNeedsApproval(t *testing.T
 	}
 }
 
+func TestDocumentStep_FixMode_SkippedVerdictWithEditsNeedsApproval(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Updated docs\n"), 0o644)
+			return &agent.Result{Output: json.RawMessage(`{"verdict":"skipped","summary":"nothing to do"}`)}, nil
+		},
+	}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Fixing = true
+	sctx.PreviousFindings = `{"findings":[{"severity":"warning","description":"updated docs"}],"summary":"updated docs"}`
+
+	step := &DocumentStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected skipped verdict with edits to require approval")
+	}
+	if got := lastCommitMessage(t, dir); got != "add feature" {
+		t.Fatalf("expected no new commit, but last commit message = %q", got)
+	}
+	if status := gitStatusPorcelain(t, dir); status == "" {
+		t.Fatal("expected documentation edit to remain for review")
+	}
+}
+
+func TestDocumentStep_FixMode_IgnoresPreexistingDirtyFiles(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("existing dirty change\n"), 0o644)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Updated docs\n"), 0o644)
+			return &agent.Result{Output: json.RawMessage(`{"verdict":"updated","summary":"update docs"}`)}, nil
+		},
+	}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Fixing = true
+	sctx.PreviousFindings = `{"findings":[{"severity":"warning","description":"update docs"}],"summary":"update docs"}`
+
+	step := &DocumentStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Fatal("expected preexisting dirty files to be ignored")
+	}
+	if got := lastCommitMessage(t, dir); got != "no-mistakes(document): update docs" {
+		t.Fatalf("last commit message = %q", got)
+	}
+	status := gitStatusPorcelain(t, dir)
+	if !strings.Contains(status, "feature.txt") {
+		t.Fatalf("expected unrelated dirty file to remain uncommitted, got %q", status)
+	}
+	if strings.Contains(status, "README.md") {
+		t.Fatalf("expected README.md to be committed, got %q", status)
+	}
+}
+
 func TestDocumentStep_FixMode_AllowsDocCommentOnlyEdits(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 	gitCmd(t, dir, "checkout", "--detach", headSHA)

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1644,8 +1644,8 @@ func TestDocumentStep_MalformedOutput(t *testing.T) {
 	if !outcome.NeedsApproval {
 		t.Fatal("expected malformed output to require approval")
 	}
-	if !outcome.AutoFixable {
-		t.Fatal("expected malformed output finding to remain auto-fixable")
+	if outcome.AutoFixable {
+		t.Fatal("expected malformed output finding to require manual review")
 	}
 	var findings Findings
 	if err := json.Unmarshal([]byte(outcome.Findings), &findings); err != nil {
@@ -1653,6 +1653,9 @@ func TestDocumentStep_MalformedOutput(t *testing.T) {
 	}
 	if len(findings.Items) != 1 {
 		t.Fatalf("expected 1 finding, got %+v", findings.Items)
+	}
+	if !findings.Items[0].RequiresHumanReview {
+		t.Fatal("expected malformed output finding to require human review")
 	}
 	if findings.Items[0].Description != "I updated the docs" {
 		t.Fatalf("finding description = %q, want %q", findings.Items[0].Description, "I updated the docs")
@@ -1678,8 +1681,8 @@ func TestDocumentStep_NoStructuredOutputRequiresApproval(t *testing.T) {
 	if !outcome.NeedsApproval {
 		t.Fatal("expected missing structured output to require approval")
 	}
-	if !outcome.AutoFixable {
-		t.Fatal("expected missing structured output finding to remain auto-fixable")
+	if outcome.AutoFixable {
+		t.Fatal("expected missing structured output finding to require manual review")
 	}
 	var findings Findings
 	if err := json.Unmarshal([]byte(outcome.Findings), &findings); err != nil {
@@ -1687,6 +1690,9 @@ func TestDocumentStep_NoStructuredOutputRequiresApproval(t *testing.T) {
 	}
 	if len(findings.Items) != 1 {
 		t.Fatalf("expected 1 finding, got %+v", findings.Items)
+	}
+	if !findings.Items[0].RequiresHumanReview {
+		t.Fatal("expected missing structured output finding to require human review")
 	}
 	if findings.Items[0].Description != "docs status unavailable" {
 		t.Fatalf("finding description = %q, want %q", findings.Items[0].Description, "docs status unavailable")

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1527,13 +1527,10 @@ func TestDocumentStep_EmptyDiff(t *testing.T) {
 
 func TestDocumentStep_Updated(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
-	gitCmd(t, dir, "checkout", "--detach", headSHA)
 
 	ag := &mockAgent{
 		name: "test",
 		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
-			// Simulate agent updating a doc file
-			os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Updated docs\n"), 0o644)
 			return &agent.Result{Output: json.RawMessage(`{"verdict":"updated","summary":"updated README"}`)}, nil
 		},
 	}
@@ -1544,8 +1541,11 @@ func TestDocumentStep_Updated(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if outcome.NeedsApproval {
-		t.Error("document step should never require approval")
+	if !outcome.NeedsApproval {
+		t.Fatal("document step should require approval before applying edits")
+	}
+	if !outcome.AutoFixable {
+		t.Fatal("document step should be auto-fixable when docs need updates")
 	}
 	if len(ag.calls) != 1 {
 		t.Errorf("expected 1 agent call, got %d", len(ag.calls))
@@ -1559,12 +1559,21 @@ func TestDocumentStep_Updated(t *testing.T) {
 	if !strings.Contains(ag.calls[0].Prompt, "refs/heads/feature") {
 		t.Error("expected prompt to contain branch name")
 	}
-	// Verify changes were committed
-	if status := gitStatusPorcelain(t, dir); status != "" {
-		t.Fatalf("expected clean worktree after doc commit, got %q", status)
+	var findings Findings
+	if err := json.Unmarshal([]byte(outcome.Findings), &findings); err != nil {
+		t.Fatalf("unmarshal findings: %v", err)
 	}
-	if got := lastCommitMessage(t, dir); got != "no-mistakes(document): updated README" {
-		t.Fatalf("last commit message = %q", got)
+	if len(findings.Items) != 1 || findings.Items[0].Severity != "warning" {
+		t.Fatalf("unexpected findings: %+v", findings.Items)
+	}
+	if findings.Items[0].Description != "updated README" {
+		t.Fatalf("finding description = %q, want %q", findings.Items[0].Description, "updated README")
+	}
+	if status := gitStatusPorcelain(t, dir); status != "" {
+		t.Fatalf("expected clean worktree while awaiting approval, got %q", status)
+	}
+	if got := lastCommitMessage(t, dir); got != "add feature" {
+		t.Fatalf("expected no new commit, but last commit message = %q", got)
 	}
 }
 
@@ -1675,6 +1684,8 @@ func TestDocumentStep_UpdatesHeadSHA(t *testing.T) {
 		},
 	}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Fixing = true
+	sctx.PreviousFindings = `{"findings":[{"severity":"warning","description":"add README"}],"summary":"add README"}`
 
 	step := &DocumentStep{}
 	_, err := step.Execute(sctx)
@@ -1688,6 +1699,86 @@ func TestDocumentStep_UpdatesHeadSHA(t *testing.T) {
 	// Branch ref should also be updated
 	if branchSHA := gitCmd(t, dir, "rev-parse", "refs/heads/feature"); branchSHA != sctx.Run.HeadSHA {
 		t.Fatalf("branch SHA = %s, want %s", branchSHA, sctx.Run.HeadSHA)
+	}
+}
+
+func TestDocumentStep_FixMode_NonDocumentationEditNeedsApproval(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
+	os.WriteFile(filepath.Join(dir, "feature.go"), []byte("package main\n\nfunc feature() {}\n"), 0o644)
+	gitCmd(t, dir, "add", "feature.go")
+	gitCmd(t, dir, "commit", "-m", "add code file")
+	headSHA = gitCmd(t, dir, "rev-parse", "HEAD")
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			os.WriteFile(filepath.Join(dir, "feature.go"), []byte("package main\n\nfunc feature() { println(\"unsafe\") }\n"), 0o644)
+			return &agent.Result{Output: json.RawMessage(`{"verdict":"updated","summary":"updated docs"}`)}, nil
+		},
+	}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Fixing = true
+	sctx.PreviousFindings = `{"findings":[{"severity":"warning","description":"updated docs"}],"summary":"updated docs"}`
+
+	step := &DocumentStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected approval when agent edits non-documentation files")
+	}
+	if outcome.AutoFixable {
+		t.Fatal("expected out-of-scope document edits to require manual review")
+	}
+	if got := lastCommitMessage(t, dir); got != "add code file" {
+		t.Fatalf("expected no new commit, but last commit message = %q", got)
+	}
+	if status := gitStatusPorcelain(t, dir); status == "" {
+		t.Fatal("expected non-documentation edit to remain uncommitted for review")
+	}
+	var findings Findings
+	if err := json.Unmarshal([]byte(outcome.Findings), &findings); err != nil {
+		t.Fatalf("unmarshal findings: %v", err)
+	}
+	if len(findings.Items) != 1 {
+		t.Fatalf("expected 1 finding, got %+v", findings.Items)
+	}
+	if findings.Items[0].File != "feature.go" {
+		t.Fatalf("finding file = %q, want %q", findings.Items[0].File, "feature.go")
+	}
+}
+
+func TestDocumentStep_FixMode_AllowsDocCommentOnlyEdits(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
+	os.WriteFile(filepath.Join(dir, "feature.go"), []byte("package main\n\nfunc feature() {}\n"), 0o644)
+	gitCmd(t, dir, "add", "feature.go")
+	gitCmd(t, dir, "commit", "-m", "add go file")
+	headSHA = gitCmd(t, dir, "rev-parse", "HEAD")
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			os.WriteFile(filepath.Join(dir, "feature.go"), []byte("package main\n\n// feature documents the command behavior.\nfunc feature() {}\n"), 0o644)
+			return &agent.Result{Output: json.RawMessage(`{"verdict":"updated","summary":"add doc comment"}`)}, nil
+		},
+	}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Fixing = true
+	sctx.PreviousFindings = `{"findings":[{"severity":"warning","description":"add doc comment"}],"summary":"add doc comment"}`
+
+	step := &DocumentStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Fatal("expected doc comment edit to commit cleanly")
+	}
+	if got := lastCommitMessage(t, dir); got != "no-mistakes(document): add doc comment" {
+		t.Fatalf("last commit message = %q", got)
 	}
 }
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1699,6 +1699,52 @@ func TestDocumentStep_NoStructuredOutputRequiresApproval(t *testing.T) {
 	}
 }
 
+func TestDocumentStep_InvalidStructuredVerdictRequiresApproval(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			return &agent.Result{Output: json.RawMessage(`{"summary":"docs status unavailable"}`)}, nil
+		},
+	}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+
+	step := &DocumentStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected invalid structured output to require approval")
+	}
+	if outcome.AutoFixable {
+		t.Fatal("expected invalid structured output finding to require manual review")
+	}
+	var findings Findings
+	if err := json.Unmarshal([]byte(outcome.Findings), &findings); err != nil {
+		t.Fatalf("unmarshal findings: %v", err)
+	}
+	if len(findings.Items) != 1 {
+		t.Fatalf("expected 1 finding, got %+v", findings.Items)
+	}
+	if !findings.Items[0].RequiresHumanReview {
+		t.Fatal("expected invalid structured output finding to require human review")
+	}
+	if findings.Items[0].Description != "docs status unavailable" {
+		t.Fatalf("finding description = %q, want %q", findings.Items[0].Description, "docs status unavailable")
+	}
+	if findings.Summary != "docs status unavailable" {
+		t.Fatalf("findings summary = %q, want %q", findings.Summary, "docs status unavailable")
+	}
+	if strings.TrimSpace(outcome.Findings) == "" {
+		t.Fatal("expected findings to be recorded")
+	}
+	if len(ag.calls) != 1 {
+		t.Fatalf("expected 1 agent call, got %d", len(ag.calls))
+	}
+}
+
 func TestDocumentStep_PromptIncludesIgnorePatterns(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
@@ -1911,6 +1957,67 @@ func TestDocumentStep_FixMode_RejectsNonDocumentEdits(t *testing.T) {
 	}
 	if status := gitStatusPorcelain(t, dir); !strings.Contains(status, "feature.txt") {
 		t.Fatalf("expected non-document change to remain uncommitted, got %q", status)
+	}
+}
+
+func TestDocumentStep_FixMode_AllowsBlockCommentOnlyEdits(t *testing.T) {
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	baseContent := "package main\n\n/*\noriginal docs\n*/\nfunc main() {}\n"
+	if err := os.WriteFile(filepath.Join(dir, "feature.go"), []byte(baseContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "base commit")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	if err := os.WriteFile(filepath.Join(dir, "feature.go"), []byte("package main\n\n/*\nfeature docs\n*/\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "add feature docs")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
+
+	callCount := 0
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			callCount++
+			if callCount == 1 {
+				content := "package main\n\n/*\nupdated docs\n*/\nfunc main() {}\n"
+				if err := os.WriteFile(filepath.Join(dir, "feature.go"), []byte(content), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return &agent.Result{Output: json.RawMessage(`{"summary":"update comment"}`)}, nil
+			}
+			return &agent.Result{Output: json.RawMessage(`{"verdict":"skipped","summary":"docs are current"}`)}, nil
+		},
+	}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Fixing = true
+	sctx.PreviousFindings = `{"findings":[{"severity":"warning","description":"docs outdated"}],"summary":"docs outdated"}`
+
+	step := &DocumentStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Fatal("expected block comment only edit to pass document-only validation")
+	}
+	if callCount != 2 {
+		t.Fatalf("expected 2 agent calls, got %d", callCount)
+	}
+	if got := lastCommitMessage(t, dir); got != "no-mistakes(document): update comment" {
+		t.Fatalf("last commit message = %q", got)
+	}
+	if status := gitStatusPorcelain(t, dir); status != "" {
+		t.Fatalf("expected clean worktree after commit, got %q", status)
 	}
 }
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -370,10 +370,10 @@ func TestRunShellCommand(t *testing.T) {
 
 func TestAllSteps(t *testing.T) {
 	steps := AllSteps()
-	if len(steps) != 7 {
-		t.Fatalf("AllSteps() returned %d steps, want 7", len(steps))
+	if len(steps) != 8 {
+		t.Fatalf("AllSteps() returned %d steps, want 8", len(steps))
 	}
-	expected := []types.StepName{types.StepRebase, types.StepReview, types.StepTest, types.StepLint, types.StepPush, types.StepPR, types.StepCI}
+	expected := []types.StepName{types.StepRebase, types.StepReview, types.StepTest, types.StepDocument, types.StepLint, types.StepPush, types.StepPR, types.StepCI}
 	for i, s := range steps {
 		if s.Name() != expected[i] {
 			t.Errorf("step %d name = %s, want %s", i, s.Name(), expected[i])
@@ -1493,6 +1493,201 @@ func TestLintStep_NoCommand(t *testing.T) {
 	}
 	if !strings.Contains(ag.calls[0].Prompt, "branch: refs/heads/feature") {
 		t.Error("expected lint prompt to include branch metadata")
+	}
+}
+
+// --- Document step tests ---
+
+func TestDocumentStep_EmptyDiff(t *testing.T) {
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	os.WriteFile(filepath.Join(dir, "f.txt"), []byte("content"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	sha := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, sha, sha, config.Commands{})
+
+	step := &DocumentStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Error("expected no approval needed for empty diff")
+	}
+	if len(ag.calls) != 0 {
+		t.Error("expected no agent calls for empty diff")
+	}
+}
+
+func TestDocumentStep_Updated(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			// Simulate agent updating a doc file
+			os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Updated docs\n"), 0o644)
+			return &agent.Result{Output: json.RawMessage(`{"verdict":"updated","summary":"updated README"}`)}, nil
+		},
+	}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+
+	step := &DocumentStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Error("document step should never require approval")
+	}
+	if len(ag.calls) != 1 {
+		t.Errorf("expected 1 agent call, got %d", len(ag.calls))
+	}
+	if !strings.Contains(ag.calls[0].Prompt, baseSHA) {
+		t.Error("expected prompt to contain base SHA")
+	}
+	if !strings.Contains(ag.calls[0].Prompt, headSHA) {
+		t.Error("expected prompt to contain head SHA")
+	}
+	if !strings.Contains(ag.calls[0].Prompt, "refs/heads/feature") {
+		t.Error("expected prompt to contain branch name")
+	}
+	// Verify changes were committed
+	if status := gitStatusPorcelain(t, dir); status != "" {
+		t.Fatalf("expected clean worktree after doc commit, got %q", status)
+	}
+	if got := lastCommitMessage(t, dir); got != "no-mistakes(document): updated README" {
+		t.Fatalf("last commit message = %q", got)
+	}
+}
+
+func TestDocumentStep_Skipped(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			return &agent.Result{Output: json.RawMessage(`{"verdict":"skipped","summary":"internal refactoring only"}`)}, nil
+		},
+	}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+
+	step := &DocumentStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Error("document step should never require approval")
+	}
+	// No commit should happen since verdict is "skipped"
+	if got := lastCommitMessage(t, dir); got != "add feature" {
+		t.Fatalf("expected no new commit, but last commit message = %q", got)
+	}
+}
+
+func TestDocumentStep_AgentError(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			return nil, errors.New("agent crashed")
+		},
+	}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+
+	step := &DocumentStep{}
+	_, err := step.Execute(sctx)
+	if err == nil {
+		t.Fatal("expected error from agent failure")
+	}
+	if !strings.Contains(err.Error(), "agent document") {
+		t.Errorf("error = %v, want to contain 'agent document'", err)
+	}
+}
+
+func TestDocumentStep_MalformedOutput(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			return &agent.Result{
+				Output: json.RawMessage(`{not valid json`),
+				Text:   "I updated the docs",
+			}, nil
+		},
+	}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+
+	step := &DocumentStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Error("document step should never require approval")
+	}
+}
+
+func TestDocumentStep_PromptIncludesIgnorePatterns(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			return &agent.Result{Output: json.RawMessage(`{"verdict":"skipped","summary":"nothing to update"}`)}, nil
+		},
+	}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Config.IgnorePatterns = []string{"*.generated.go", "vendor/**"}
+
+	step := &DocumentStep{}
+	_, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ag.calls) != 1 {
+		t.Fatalf("expected 1 agent call, got %d", len(ag.calls))
+	}
+	if !strings.Contains(ag.calls[0].Prompt, "*.generated.go, vendor/**") {
+		t.Error("expected prompt to include ignore patterns")
+	}
+}
+
+func TestDocumentStep_UpdatesHeadSHA(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Docs\n"), 0o644)
+			return &agent.Result{Output: json.RawMessage(`{"verdict":"updated","summary":"add README"}`)}, nil
+		},
+	}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+
+	step := &DocumentStep{}
+	_, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// HeadSHA should have been updated to reflect the new commit
+	if sctx.Run.HeadSHA == headSHA {
+		t.Error("expected HeadSHA to be updated after doc commit")
+	}
+	// Branch ref should also be updated
+	if branchSHA := gitCmd(t, dir, "rev-parse", "refs/heads/feature"); branchSHA != sctx.Run.HeadSHA {
+		t.Fatalf("branch SHA = %s, want %s", branchSHA, sctx.Run.HeadSHA)
 	}
 }
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1594,9 +1594,8 @@ func TestDocumentStep_Skipped(t *testing.T) {
 		t.Fatal(err)
 	}
 	if outcome.NeedsApproval {
-		t.Error("document step should never require approval")
+		t.Error("document step should not require approval when skipped")
 	}
-	// No commit should happen since verdict is "skipped"
 	if got := lastCommitMessage(t, dir); got != "add feature" {
 		t.Fatalf("expected no new commit, but last commit message = %q", got)
 	}
@@ -1720,15 +1719,22 @@ func TestDocumentStep_IgnorePatternsFilterAllFiles(t *testing.T) {
 	}
 }
 
-func TestDocumentStep_UpdatesHeadSHA(t *testing.T) {
+func TestDocumentStep_FixMode_CommitsAndReassesses(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 	gitCmd(t, dir, "checkout", "--detach", headSHA)
 
+	callCount := 0
 	ag := &mockAgent{
 		name: "test",
 		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
-			os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Docs\n"), 0o644)
-			return &agent.Result{Output: json.RawMessage(`{"verdict":"updated","summary":"add README"}`)}, nil
+			callCount++
+			if callCount == 1 {
+				// Fix call: agent writes a file and returns summary
+				os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Docs\n"), 0o644)
+				return &agent.Result{Output: json.RawMessage(`{"summary":"add README"}`)}, nil
+			}
+			// Re-assessment call: docs are now up to date
+			return &agent.Result{Output: json.RawMessage(`{"verdict":"skipped","summary":"docs are current"}`)}, nil
 		},
 	}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
@@ -1736,38 +1742,49 @@ func TestDocumentStep_UpdatesHeadSHA(t *testing.T) {
 	sctx.PreviousFindings = `{"findings":[{"severity":"warning","description":"add README"}],"summary":"add README"}`
 
 	step := &DocumentStep{}
-	_, err := step.Execute(sctx)
+	outcome, err := step.Execute(sctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// HeadSHA should have been updated to reflect the new commit
+	if callCount != 2 {
+		t.Fatalf("expected 2 agent calls (fix + reassess), got %d", callCount)
+	}
+	if outcome.NeedsApproval {
+		t.Error("expected no approval after successful fix")
+	}
 	if sctx.Run.HeadSHA == headSHA {
 		t.Error("expected HeadSHA to be updated after doc commit")
 	}
-	// Branch ref should also be updated
-	if branchSHA := gitCmd(t, dir, "rev-parse", "refs/heads/feature"); branchSHA != sctx.Run.HeadSHA {
+	branchSHA := gitCmd(t, dir, "rev-parse", "refs/heads/feature")
+	if branchSHA != sctx.Run.HeadSHA {
 		t.Fatalf("branch SHA = %s, want %s", branchSHA, sctx.Run.HeadSHA)
 	}
+	if got := lastCommitMessage(t, dir); got != "no-mistakes(document): add README" {
+		t.Fatalf("last commit message = %q", got)
+	}
 }
 
-func TestDocumentStep_FixMode_NonDocumentationEditNeedsApproval(t *testing.T) {
+func TestDocumentStep_FixMode_StillNeedsWorkAfterFix(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 	gitCmd(t, dir, "checkout", "--detach", headSHA)
-	os.WriteFile(filepath.Join(dir, "feature.go"), []byte("package main\n\nfunc feature() {}\n"), 0o644)
-	gitCmd(t, dir, "add", "feature.go")
-	gitCmd(t, dir, "commit", "-m", "add code file")
-	headSHA = gitCmd(t, dir, "rev-parse", "HEAD")
 
+	callCount := 0
 	ag := &mockAgent{
 		name: "test",
 		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
-			os.WriteFile(filepath.Join(dir, "feature.go"), []byte("package main\n\nfunc feature() { println(\"unsafe\") }\n"), 0o644)
-			return &agent.Result{Output: json.RawMessage(`{"verdict":"updated","summary":"updated docs"}`)}, nil
+			callCount++
+			if callCount == 1 {
+				// Fix call: agent writes partial docs
+				os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Partial\n"), 0o644)
+				return &agent.Result{Output: json.RawMessage(`{"summary":"partial update"}`)}, nil
+			}
+			// Re-assessment: still needs more work
+			return &agent.Result{Output: json.RawMessage(`{"verdict":"updated","summary":"config section still missing"}`)}, nil
 		},
 	}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Fixing = true
-	sctx.PreviousFindings = `{"findings":[{"severity":"warning","description":"updated docs"}],"summary":"updated docs"}`
+	sctx.PreviousFindings = `{"findings":[{"severity":"warning","description":"docs outdated"}],"summary":"docs outdated"}`
 
 	step := &DocumentStep{}
 	outcome, err := step.Execute(sctx)
@@ -1775,16 +1792,10 @@ func TestDocumentStep_FixMode_NonDocumentationEditNeedsApproval(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !outcome.NeedsApproval {
-		t.Fatal("expected approval when agent edits non-documentation files")
+		t.Fatal("expected approval needed when re-assessment finds remaining issues")
 	}
-	if outcome.AutoFixable {
-		t.Fatal("expected out-of-scope document edits to require manual review")
-	}
-	if got := lastCommitMessage(t, dir); got != "add code file" {
-		t.Fatalf("expected no new commit, but last commit message = %q", got)
-	}
-	if status := gitStatusPorcelain(t, dir); status == "" {
-		t.Fatal("expected non-documentation edit to remain uncommitted for review")
+	if !outcome.AutoFixable {
+		t.Fatal("expected remaining issues to be auto-fixable for another round")
 	}
 	var findings Findings
 	if err := json.Unmarshal([]byte(outcome.Findings), &findings); err != nil {
@@ -1793,206 +1804,59 @@ func TestDocumentStep_FixMode_NonDocumentationEditNeedsApproval(t *testing.T) {
 	if len(findings.Items) != 1 {
 		t.Fatalf("expected 1 finding, got %+v", findings.Items)
 	}
-	if findings.Items[0].File != "feature.go" {
-		t.Fatalf("finding file = %q, want %q", findings.Items[0].File, "feature.go")
+	if findings.Items[0].Description != "config section still missing" {
+		t.Fatalf("finding description = %q", findings.Items[0].Description)
 	}
 }
 
-func TestDocumentStep_FixMode_UntrackedNonDocumentationEditNeedsApproval(t *testing.T) {
+func TestDocumentStep_FixMode_NoChangesStillReassesses(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 	gitCmd(t, dir, "checkout", "--detach", headSHA)
 
+	callCount := 0
 	ag := &mockAgent{
 		name: "test",
 		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
-			os.WriteFile(filepath.Join(dir, "feature.go"), []byte("package main\n\nfunc feature() {}\n"), 0o644)
-			return &agent.Result{Output: json.RawMessage(`{"verdict":"updated","summary":"updated docs"}`)}, nil
+			callCount++
+			if callCount == 1 {
+				// Fix call: agent decides no changes needed
+				return &agent.Result{Output: json.RawMessage(`{"summary":"no changes needed"}`)}, nil
+			}
+			// Re-assessment
+			return &agent.Result{Output: json.RawMessage(`{"verdict":"skipped","summary":"docs are fine"}`)}, nil
 		},
 	}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Fixing = true
-	sctx.PreviousFindings = `{"findings":[{"severity":"warning","description":"updated docs"}],"summary":"updated docs"}`
+	sctx.PreviousFindings = `{"findings":[{"severity":"warning","description":"check docs"}],"summary":"check docs"}`
 
 	step := &DocumentStep{}
 	outcome, err := step.Execute(sctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !outcome.NeedsApproval {
-		t.Fatal("expected approval when agent creates non-documentation files")
-	}
-	if got := lastCommitMessage(t, dir); got != "add feature" {
-		t.Fatalf("expected no new commit, but last commit message = %q", got)
-	}
-	var findings Findings
-	if err := json.Unmarshal([]byte(outcome.Findings), &findings); err != nil {
-		t.Fatalf("unmarshal findings: %v", err)
-	}
-	if len(findings.Items) != 1 {
-		t.Fatalf("expected 1 finding, got %+v", findings.Items)
-	}
-	if findings.Items[0].File != "feature.go" {
-		t.Fatalf("finding file = %q, want %q", findings.Items[0].File, "feature.go")
-	}
-}
-
-func TestDocumentStep_FixMode_MalformedOutputWithEditsNeedsApproval(t *testing.T) {
-	dir, baseSHA, headSHA := setupGitRepo(t)
-	gitCmd(t, dir, "checkout", "--detach", headSHA)
-
-	ag := &mockAgent{
-		name: "test",
-		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
-			os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Updated docs\n"), 0o644)
-			return &agent.Result{
-				Output: json.RawMessage(`{not valid json`),
-				Text:   "I updated the docs",
-			}, nil
-		},
-	}
-	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
-	sctx.Fixing = true
-	sctx.PreviousFindings = `{"findings":[{"severity":"warning","description":"updated docs"}],"summary":"updated docs"}`
-
-	step := &DocumentStep{}
-	outcome, err := step.Execute(sctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !outcome.NeedsApproval {
-		t.Fatal("expected malformed fix output with edits to require approval")
-	}
-	if got := lastCommitMessage(t, dir); got != "add feature" {
-		t.Fatalf("expected no new commit, but last commit message = %q", got)
-	}
-	if status := gitStatusPorcelain(t, dir); status == "" {
-		t.Fatal("expected documentation edit to remain for review")
-	}
-}
-
-func TestDocumentStep_FixMode_SkippedVerdictWithEditsNeedsApproval(t *testing.T) {
-	dir, baseSHA, headSHA := setupGitRepo(t)
-	gitCmd(t, dir, "checkout", "--detach", headSHA)
-
-	ag := &mockAgent{
-		name: "test",
-		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
-			os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Updated docs\n"), 0o644)
-			return &agent.Result{Output: json.RawMessage(`{"verdict":"skipped","summary":"nothing to do"}`)}, nil
-		},
-	}
-	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
-	sctx.Fixing = true
-	sctx.PreviousFindings = `{"findings":[{"severity":"warning","description":"updated docs"}],"summary":"updated docs"}`
-
-	step := &DocumentStep{}
-	outcome, err := step.Execute(sctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !outcome.NeedsApproval {
-		t.Fatal("expected skipped verdict with edits to require approval")
-	}
-	if got := lastCommitMessage(t, dir); got != "add feature" {
-		t.Fatalf("expected no new commit, but last commit message = %q", got)
-	}
-	if status := gitStatusPorcelain(t, dir); status == "" {
-		t.Fatal("expected documentation edit to remain for review")
-	}
-}
-
-func TestDocumentStep_FixMode_IgnoresPreexistingDirtyFiles(t *testing.T) {
-	dir, baseSHA, headSHA := setupGitRepo(t)
-	gitCmd(t, dir, "checkout", "--detach", headSHA)
-	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("existing dirty change\n"), 0o644)
-
-	ag := &mockAgent{
-		name: "test",
-		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
-			os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Updated docs\n"), 0o644)
-			return &agent.Result{Output: json.RawMessage(`{"verdict":"updated","summary":"update docs"}`)}, nil
-		},
-	}
-	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
-	sctx.Fixing = true
-	sctx.PreviousFindings = `{"findings":[{"severity":"warning","description":"update docs"}],"summary":"update docs"}`
-
-	step := &DocumentStep{}
-	outcome, err := step.Execute(sctx)
-	if err != nil {
-		t.Fatal(err)
+	if callCount != 2 {
+		t.Fatalf("expected 2 agent calls even with no changes, got %d", callCount)
 	}
 	if outcome.NeedsApproval {
-		t.Fatal("expected preexisting dirty files to be ignored")
-	}
-	if got := lastCommitMessage(t, dir); got != "no-mistakes(document): update docs" {
-		t.Fatalf("last commit message = %q", got)
-	}
-	status := gitStatusPorcelain(t, dir)
-	if !strings.Contains(status, "feature.txt") {
-		t.Fatalf("expected unrelated dirty file to remain uncommitted, got %q", status)
-	}
-	if strings.Contains(status, "README.md") {
-		t.Fatalf("expected README.md to be committed, got %q", status)
+		t.Error("expected no approval after clean re-assessment")
 	}
 }
 
-func TestDocumentStep_FixMode_AllowsDocCommentOnlyEdits(t *testing.T) {
+func TestDocumentStep_FixMode_RequiresPreviousFindings(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
-	gitCmd(t, dir, "checkout", "--detach", headSHA)
-	os.WriteFile(filepath.Join(dir, "feature.go"), []byte("package main\n\nfunc feature() {}\n"), 0o644)
-	gitCmd(t, dir, "add", "feature.go")
-	gitCmd(t, dir, "commit", "-m", "add go file")
-	headSHA = gitCmd(t, dir, "rev-parse", "HEAD")
 
-	ag := &mockAgent{
-		name: "test",
-		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
-			os.WriteFile(filepath.Join(dir, "feature.go"), []byte("package main\n\n// feature documents the command behavior.\nfunc feature() {}\n"), 0o644)
-			return &agent.Result{Output: json.RawMessage(`{"verdict":"updated","summary":"add doc comment"}`)}, nil
-		},
-	}
+	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Fixing = true
-	sctx.PreviousFindings = `{"findings":[{"severity":"warning","description":"add doc comment"}],"summary":"add doc comment"}`
 
 	step := &DocumentStep{}
-	outcome, err := step.Execute(sctx)
-	if err != nil {
-		t.Fatal(err)
+	_, err := step.Execute(sctx)
+	if err == nil {
+		t.Fatal("expected error when fixing without previous findings")
 	}
-	if outcome.NeedsApproval {
-		t.Fatal("expected doc comment edit to commit cleanly")
-	}
-	if got := lastCommitMessage(t, dir); got != "no-mistakes(document): add doc comment" {
-		t.Fatalf("last commit message = %q", got)
-	}
-}
-
-func TestIsDocumentationPath_DoesNotTreatArbitraryTxtAsDocs(t *testing.T) {
-	if isDocumentationPath("testdata/golden/output.txt") {
-		t.Fatal("expected arbitrary .txt file to be out of scope")
-	}
-	if !isDocumentationPath("docs/output.txt") {
-		t.Fatal("expected docs/ .txt file to be treated as documentation")
-	}
-}
-
-func TestParsePorcelainPath_UnquotesQuotedPaths(t *testing.T) {
-	path, untracked := parsePorcelainPath("?? \"docs/with space.md\"")
-	if path != "docs/with space.md" {
-		t.Fatalf("path = %q, want %q", path, "docs/with space.md")
-	}
-	if !untracked {
-		t.Fatal("expected quoted ?? path to be marked untracked")
-	}
-
-	renamedPath, renamedUntracked := parsePorcelainPath("R  \"old name.md\" -> \"new name.md\"")
-	if renamedPath != "new name.md" {
-		t.Fatalf("renamed path = %q, want %q", renamedPath, "new name.md")
-	}
-	if renamedUntracked {
-		t.Fatal("expected rename entry not to be marked untracked")
+	if !strings.Contains(err.Error(), "previous findings") {
+		t.Errorf("error = %v, want to contain 'previous findings'", err)
 	}
 }
 

--- a/internal/tui/pipeline.go
+++ b/internal/tui/pipeline.go
@@ -89,6 +89,8 @@ func stepLabel(name types.StepName) string {
 		return "Test"
 	case types.StepLint:
 		return "Lint"
+	case types.StepDocument:
+		return "Document"
 	case types.StepPush:
 		return "Push"
 	case types.StepPR:

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -71,6 +71,7 @@ func TestStepLabel(t *testing.T) {
 		{types.StepReview, "Review"},
 		{types.StepTest, "Test"},
 		{types.StepLint, "Lint"},
+		{types.StepDocument, "Document"},
 		{types.StepPush, "Push"},
 		{types.StepPR, "PR"},
 		{types.StepCI, "CI"},

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -26,13 +26,14 @@ const (
 type StepName string
 
 const (
-	StepRebase StepName = "rebase"
-	StepReview StepName = "review"
-	StepTest   StepName = "test"
-	StepLint   StepName = "lint"
-	StepPush   StepName = "push"
-	StepPR     StepName = "pr"
-	StepCI     StepName = "ci"
+	StepRebase   StepName = "rebase"
+	StepReview   StepName = "review"
+	StepTest     StepName = "test"
+	StepDocument StepName = "document"
+	StepLint     StepName = "lint"
+	StepPush     StepName = "push"
+	StepPR       StepName = "pr"
+	StepCI       StepName = "ci"
 )
 
 func normalizeStepName(s StepName) StepName {
@@ -80,14 +81,16 @@ func (s StepName) Order() int {
 		return 2
 	case StepTest:
 		return 3
-	case StepLint:
+	case StepDocument:
 		return 4
-	case StepPush:
+	case StepLint:
 		return 5
-	case StepPR:
+	case StepPush:
 		return 6
-	case StepCI:
+	case StepPR:
 		return 7
+	case StepCI:
+		return 8
 	default:
 		return 0
 	}
@@ -95,7 +98,7 @@ func (s StepName) Order() int {
 
 // AllSteps returns all pipeline steps in execution order.
 func AllSteps() []StepName {
-	return []StepName{StepRebase, StepReview, StepTest, StepLint, StepPush, StepPR, StepCI}
+	return []StepName{StepRebase, StepReview, StepTest, StepDocument, StepLint, StepPush, StepPR, StepCI}
 }
 
 // StepStatus represents the lifecycle state of a pipeline step.

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -7,11 +7,11 @@ import (
 
 func TestAllStepsOrder(t *testing.T) {
 	steps := AllSteps()
-	if len(steps) != 7 {
-		t.Fatalf("expected 7 steps, got %d", len(steps))
+	if len(steps) != 8 {
+		t.Fatalf("expected 8 steps, got %d", len(steps))
 	}
 
-	expected := []StepName{StepRebase, StepReview, StepTest, StepLint, StepPush, StepPR, StepCI}
+	expected := []StepName{StepRebase, StepReview, StepTest, StepDocument, StepLint, StepPush, StepPR, StepCI}
 	for i, s := range steps {
 		if s != expected[i] {
 			t.Errorf("step[%d] = %q, want %q", i, s, expected[i])
@@ -27,10 +27,11 @@ func TestStepNameOrder(t *testing.T) {
 		{StepRebase, 1},
 		{StepReview, 2},
 		{StepTest, 3},
-		{StepLint, 4},
-		{StepPush, 5},
-		{StepPR, 6},
-		{StepCI, 7},
+		{StepDocument, 4},
+		{StepLint, 5},
+		{StepPush, 6},
+		{StepPR, 7},
+		{StepCI, 8},
 		{StepName("unknown"), 0},
 	}
 


### PR DESCRIPTION
## Summary
- Add a new `document` pipeline step with config, TUI, type wiring, and broad test coverage so documentation checks and auto-fix can run as part of the branch pipeline.
- Harden document auto-fix and review handling by isolating worktrees, tightening document-only scope validation, and requiring manual review when agent output cannot be parsed cleanly.
- Update `README.md` and config examples to document the new step and its `auto_fix.document` configuration surface.

⚠️ medium: The change is localized, but the new document step can both miss later code changes and incorrectly permit some code edits during doc-only autofix, so it is not cleanly safe to merge as-is.

## Pipeline

Updates from `git push no-mistakes`

✅ **Rebase** - passed
⚠️ **Review** - 2 warnings
✅ **Test** - passed
✅ **Lint** - passed

<details>
<summary>Review details</summary>

**Round 1** - found 3 issues (1 error, 2 warnings)
- 🚨 `internal/pipeline/steps/document.go:95` - The fix path commits whatever the agent changed, but this step never verifies that the edits were limited to docs/doc comments. If the agent touches code or tests here, those changes are committed after the test step and will ship without being re-tested; reject or filter non-document edits before calling `commitAgentFixes`.
- ⚠️ `internal/pipeline/steps/document.go:169` - When the agent returns no structured payload (`result.Output == nil`), `verdict` stays empty and the step falls through as a clean pass. That turns a schema/agent failure into a false 'docs are up to date' result instead of failing closed or requiring approval.
- ⚠️ `internal/config/config.go:105` - The default `auto_fix.rebase` value changed from `0` to `3`, so fresh installs will now let the agent auto-resolve rebase conflicts and rewrite branch history without explicit approval. That is a material safety-model change and should stay opt-in unless you intend this behavior.

**Round 2** (auto-fix) - found 2 warnings
- ⚠️ `internal/config/config.go:251` - `autoFixDefaults()` now enables `rebase` auto-fix by default (`3` instead of `0`). That changes the safety model for every existing install that has not explicitly set `auto_fix.rebase`: merge-conflict rebases will now be handed to the agent automatically, which can rewrite branch history before a human ever approves it. Keep the old default or gate this behind an explicit opt-in/migration.
- ⚠️ `internal/pipeline/steps/document.go:175` - Unstructured or malformed agent output is coerced to `verdict:"updated"`, and the step remains auto-fixable. With `auto_fix.document` also defaulting to `3`, a transient schema/parsing failure can immediately trigger documentation edits and commits even when the branch does not actually need doc changes. Treat parse failures as non-fixable/manual-review states instead of actionable documentation debt.

**Round 3** (auto-fix) - found 3 issues (1 error, 2 warnings)
- 🚨 `internal/config/config.go:251` - `autoFixDefaults` now enables `rebase` auto-fix by default, which changes existing runs from manual approval on merge conflicts to agent-driven conflict resolution in every repo that does not opt out. That is a risky global behavior change unrelated to the document step and can silently rewrite conflicted code.
- ⚠️ `internal/pipeline/steps/document.go:189` - The document step only checks `verdict == "updated"` after unmarshalling, so a syntactically valid but schema-invalid response such as `{"summary":"..."}` leaves `verdict` empty and the step incorrectly passes with no approval required. Treat unknown or empty verdicts as manual-review failures instead of `skipped`.
- ⚠️ `internal/pipeline/steps/document.go:319` - `diffContainsOnlyCommentChanges` rejects legitimate block-comment edits where interior lines do not start with `/*`, `*`, or `*/` (for example `/*\ntext\n*/`). That makes the document auto-fix path fail on valid doc-comment-only changes and forces unnecessary manual intervention.

**Round 4** (auto-fix) - found 2 warnings
- ⚠️ `internal/pipeline/steps/common.go:360` - `DocumentStep` now runs before `LintStep`, but lint fix mode can still rewrite and commit code later in the pipeline. That leaves no chance to re-check docs after those edits, so approved/generated documentation can be stale by the time the branch is pushed.
- ⚠️ `internal/pipeline/steps/document.go:355` - `matchBlockCommentLine` treats any line containing `/*` as documentation-only and, once inside a block, accepts every changed line until `*/` appears. A document autofix can therefore modify executable code on inline/block-comment lines and still pass `ensureDocumentOnlyFixes`, bypassing the step's non-code-edit guard.

</details>
