### PR TITLE
fix(banner): add missing banner line

### DIFF
--- a/internal/git/hook.go
+++ b/internal/git/hook.go
@@ -40,6 +40,7 @@ _  _ ____    _  _ _ ____ ___ ____ _  _ ____ ____
   * Pipeline started
 
   Run no-mistakes to review.
+
 BANNER
 exit 0
 `


### PR DESCRIPTION
## Summary
- add the missing banner line in `internal/git/hook.go` so the generated hook output includes the intended banner formatting.
- keep the hook banner output consistent and easier to scan without changing broader hook behavior.

## Risk Assessment

✅ Low: The change is a one-line banner output adjustment in a shell heredoc with no impact on the hook's execution path or daemon notification logic.

## Pipeline

Updates from `git push no-mistakes`

✅ **Rebase** - passed
✅ **Review** - passed
✅ **Test** - passed
✅ **Lint** - passed
