### PR TITLE
fix(review): harden autofix prompt guards and findings sanitization

### DIFF
--- a/docs/src/content/docs/guides/auto-fix.md
+++ b/docs/src/content/docs/guides/auto-fix.md
@@ -37,6 +37,8 @@ Repo config overlays global config - you can set `auto_fix.lint: 5` in a repo's 
 
 Some review findings are marked `requires_human_review: true` by the agent. These findings always require manual approval regardless of the auto-fix limit. They are never auto-fixed.
 
+This is meant for intentional product or design changes, or cases where the natural fix would remove, revert, or substantially reduce code the author added on purpose. Routine correctness, reliability, or security fixes can still stay auto-fixable even if the smallest fix reintroduces a small amount of previously deleted logic.
+
 ## User-triggered fixes
 
 When the pipeline pauses for approval, you can manually trigger a fix from the TUI:

--- a/docs/src/content/docs/guides/auto-fix.md
+++ b/docs/src/content/docs/guides/auto-fix.md
@@ -37,7 +37,7 @@ Repo config overlays global config - you can set `auto_fix.lint: 5` in a repo's 
 
 Some review findings are marked `requires_human_review: true` by the agent. These findings always require manual approval regardless of the auto-fix limit. They are never auto-fixed.
 
-This is meant for intentional product or design changes, or cases where the natural fix would remove, revert, or substantially reduce code the author added on purpose. Routine correctness, reliability, or security fixes can still stay auto-fixable even if the smallest fix reintroduces a small amount of previously deleted logic.
+This is meant for intentional product or design changes, or cases where the natural fix would remove, revert, or substantially reduce code the author added on purpose, or would undo an intentional deletion for non-correctness reasons. Routine correctness, reliability, or security fixes can still stay auto-fixable even if the smallest fix reintroduces a small amount of previously deleted logic.
 
 ## User-triggered fixes
 

--- a/docs/src/content/docs/guides/auto-fix.md
+++ b/docs/src/content/docs/guides/auto-fix.md
@@ -37,7 +37,7 @@ Repo config overlays global config - you can set `auto_fix.lint: 5` in a repo's 
 
 Some review findings are marked `requires_human_review: true` by the agent. These findings always require manual approval regardless of the auto-fix limit. They are never auto-fixed.
 
-This is meant for intentional product or design changes, or cases where the natural fix would remove, revert, or substantially reduce code the author added on purpose, or would undo an intentional deletion for non-correctness reasons. Routine correctness, reliability, or security fixes can still stay auto-fixable even if the smallest fix reintroduces a small amount of previously deleted logic.
+This is meant for findings that challenge the author's intent - for example, questioning an intentional product or design choice, or arguing that an intentional addition, removal, or guard should be undone. Routine correctness, reliability, or security fixes still stay auto-fixable even if the smallest fix reintroduces a small amount of previously deleted logic.
 
 ## User-triggered fixes
 

--- a/docs/src/content/docs/guides/pipeline-steps.md
+++ b/docs/src/content/docs/guides/pipeline-steps.md
@@ -37,7 +37,7 @@ AI code review of your diff.
 - Agent returns findings with severity (`error`, `warning`, `info`), file location, and description
 - Also returns a `risk_level` (`low`, `medium`, `high`) and `risk_rationale`
 
-**Approval:** required if any finding has severity `error` or `warning`. Findings marked `requires_human_review` always require human approval and are never auto-fixed. This is mainly for intentional product or design decisions, or fixes that would undo an intentional deletion for non-correctness reasons, not routine correctness, reliability, or security fixes that may need to re-add a small amount of deleted logic.
+**Approval:** required if any finding has severity `error` or `warning`. Findings marked `requires_human_review` always require human approval and are never auto-fixed. This is for findings that challenge the author's intent, not routine correctness, reliability, or security fixes that may need to re-add a small amount of deleted logic.
 
 **Auto-fix:** the agent receives previous findings and applies fixes, then the review runs again. Fix commits use `no-mistakes(review): <summary>`.
 

--- a/docs/src/content/docs/guides/pipeline-steps.md
+++ b/docs/src/content/docs/guides/pipeline-steps.md
@@ -37,7 +37,7 @@ AI code review of your diff.
 - Agent returns findings with severity (`error`, `warning`, `info`), file location, and description
 - Also returns a `risk_level` (`low`, `medium`, `high`) and `risk_rationale`
 
-**Approval:** required if any finding has severity `error` or `warning`. Findings marked `requires_human_review` always require human approval and are never auto-fixed. This is mainly for intentional product or design decisions, not routine correctness or reliability fixes that may need to re-add a small amount of deleted logic.
+**Approval:** required if any finding has severity `error` or `warning`. Findings marked `requires_human_review` always require human approval and are never auto-fixed. This is mainly for intentional product or design decisions, or fixes that would undo an intentional deletion for non-correctness reasons, not routine correctness, reliability, or security fixes that may need to re-add a small amount of deleted logic.
 
 **Auto-fix:** the agent receives previous findings and applies fixes, then the review runs again. Fix commits use `no-mistakes(review): <summary>`.
 

--- a/docs/src/content/docs/guides/pipeline-steps.md
+++ b/docs/src/content/docs/guides/pipeline-steps.md
@@ -37,7 +37,7 @@ AI code review of your diff.
 - Agent returns findings with severity (`error`, `warning`, `info`), file location, and description
 - Also returns a `risk_level` (`low`, `medium`, `high`) and `risk_rationale`
 
-**Approval:** required if any finding has severity `error` or `warning`. Findings marked `requires_human_review` always require human approval and are never auto-fixed.
+**Approval:** required if any finding has severity `error` or `warning`. Findings marked `requires_human_review` always require human approval and are never auto-fixed. This is mainly for intentional product or design decisions, not routine correctness or reliability fixes that may need to re-add a small amount of deleted logic.
 
 **Auto-fix:** the agent receives previous findings and applies fixes, then the review runs again. Fix commits use `no-mistakes(review): <summary>`.
 

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -101,9 +101,10 @@ var findingsSchema = json.RawMessage(`{
 					"severity": {"type": "string", "enum": ["error", "warning", "info"]},
 					"file": {"type": "string"},
 					"line": {"type": "integer"},
-					"description": {"type": "string"}
+					"description": {"type": "string"},
+					"requires_human_review": {"type": "boolean"}
 				},
-				"required": ["severity", "description"]
+				"required": ["severity", "description", "requires_human_review"]
 			}
 		},
 		"summary": {"type": "string"}
@@ -200,7 +201,7 @@ var reviewFindingsSchema = json.RawMessage(`{
 					"description": {"type": "string"},
 					"requires_human_review": {"type": "boolean"}
 				},
-				"required": ["severity", "description"]
+				"required": ["severity", "description", "requires_human_review"]
 			}
 		},
 		"risk_level": {"type": "string", "enum": ["low", "medium", "high"]},

--- a/internal/pipeline/steps/lint.go
+++ b/internal/pipeline/steps/lint.go
@@ -85,7 +85,8 @@ Task:
 
 Rules:
 - Do not run tests or broader behavioral validation.
-- Focus on lint, format, and static-analysis issues only.`,
+- Focus on lint, format, and static-analysis issues only.
+- Set requires_human_review to false for all findings. Lint findings are objective and do not question the author's intent.`,
 				sctx.Run.Branch,
 				baseSHA,
 				sctx.Run.HeadSHA,

--- a/internal/pipeline/steps/lint.go
+++ b/internal/pipeline/steps/lint.go
@@ -45,7 +45,7 @@ Rules:
 			fixPrompt += `
 
 Previous lint findings to address:
-` + sctx.PreviousFindings
+` + sanitizedPreviousFindingsForPrompt(sctx.PreviousFindings)
 		}
 		result, err := sctx.Agent.Run(ctx, agent.RunOpts{
 			Prompt:     fixPrompt,

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -36,6 +36,7 @@ func (s *ReviewStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome,
 			return nil, fmt.Errorf("review fix requires previous review findings")
 		}
 		sctx.Log("asking agent to fix identified issues...")
+		previousFindings := sanitizedPreviousFindingsForPrompt(sctx.PreviousFindings)
 		fixPrompt := fmt.Sprintf(
 			`Investigate previous review findings and address legitimate ones. 
 
@@ -66,7 +67,7 @@ Previous review findings to address:
 			reviewScope,
 			sctx.Repo.DefaultBranch,
 			ignorePatterns,
-			sctx.PreviousFindings,
+			previousFindings,
 		)
 		result, err := sctx.Agent.Run(ctx, agent.RunOpts{
 			Prompt:     fixPrompt,
@@ -240,7 +241,7 @@ The following findings from a previous review were explicitly dismissed by the u
 }
 
 func sanitizeDismissedFindingDescription(description string) string {
-	description = strings.Join(strings.Fields(description), " ")
+	description = sanitizePromptText(description)
 	if description == "" {
 		return ""
 	}
@@ -249,4 +250,26 @@ func sanitizeDismissedFindingDescription(description string) string {
 		return description
 	}
 	return strings.TrimSpace(description[:maxLen-3]) + "..."
+}
+
+func sanitizedPreviousFindingsForPrompt(raw string) string {
+	findings, err := types.ParseFindingsJSON(raw)
+	if err != nil {
+		return sanitizePromptText(raw)
+	}
+	for i := range findings.Items {
+		findings.Items[i].Description = sanitizePromptText(findings.Items[i].Description)
+	}
+	findings.Summary = sanitizePromptText(findings.Summary)
+	encoded, err := types.MarshalFindingsJSON(findings)
+	if err != nil {
+		return sanitizePromptText(raw)
+	}
+	return encoded
+}
+
+func sanitizePromptText(text string) string {
+	text = strings.NewReplacer("<<<<<<<", " ", "=======", " ", ">>>>>>>", " ").Replace(text)
+	text = strings.Join(strings.Fields(text), " ")
+	return text
 }

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -51,7 +51,6 @@ Context:
 
 Rules:
 - Always start with double checking whether the findings are legitimate.
-<<<<<<< HEAD
 - Avoid resolving a finding by removing or reverting the author's intentional code in their original 1st commit. If the original change introduced something on purpose, fix it forward (e.g. add validation, handle edge cases, tighten logic) rather than deleting it. Similarly, if the original change intentionally deleted or simplified code, do not restore or re-add the removed code unless the finding is a legitimate correctness, reliability, or security issue and the smallest reasonable fix happens to reintroduce a small amount of previously deleted logic. When in doubt about whether code is intentional, leave it and report the finding as unresolved.
 - Do not add code comments explaining your fixes.
 - Verify that the issues are resolved before finishing.
@@ -153,7 +152,6 @@ Rules:
 - Only comment on things that genuinely matter.
 - Do NOT report styling, formatting, linting, compilation, or type-checking issues.
 - If the change is clean, return an empty findings array.
-<<<<<<< HEAD
 - Set requires_human_review to true only when the finding challenges the author's intent - i.e. questions a deliberate design/product decision, or where the natural fix would undo something the author intentionally did (adding, removing, or changing code on purpose). Examples: "this feature seems unnecessary", "this deletion looks wrong", "this guard is redundant". A finding is not human-review-only just because the fix may reintroduce a small amount of previously deleted logic to restore correctness, reliability, or security. Set it to false for findings about objective correctness, error handling, security, performance, and mechanical code quality. When in doubt, default to false.
 
 Risk assessment (after listing all findings):

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -255,26 +255,35 @@ func sanitizeDismissedFindingDescription(description string) string {
 func sanitizedPreviousFindingsForPrompt(raw string) string {
 	findings, err := types.ParseFindingsJSON(raw)
 	if err != nil {
-		return sanitizePromptText(raw)
+		return sanitizePromptMultilineText(raw)
 	}
 	for i := range findings.Items {
 		findings.Items[i].ID = sanitizePromptText(findings.Items[i].ID)
 		findings.Items[i].Severity = sanitizePromptText(findings.Items[i].Severity)
 		findings.Items[i].File = sanitizePromptText(findings.Items[i].File)
-		findings.Items[i].Description = sanitizePromptText(findings.Items[i].Description)
+		findings.Items[i].Description = sanitizePromptMultilineText(findings.Items[i].Description)
 	}
-	findings.Summary = sanitizePromptText(findings.Summary)
+	findings.Summary = sanitizePromptMultilineText(findings.Summary)
 	findings.RiskLevel = sanitizePromptText(findings.RiskLevel)
-	findings.RiskRationale = sanitizePromptText(findings.RiskRationale)
+	findings.RiskRationale = sanitizePromptMultilineText(findings.RiskRationale)
 	encoded, err := types.MarshalFindingsJSON(findings)
 	if err != nil {
-		return sanitizePromptText(raw)
+		return sanitizePromptMultilineText(raw)
 	}
 	return encoded
 }
 
 func sanitizePromptText(text string) string {
+	return strings.Join(strings.Fields(sanitizePromptMultilineText(text)), " ")
+}
+
+func sanitizePromptMultilineText(text string) string {
 	text = strings.NewReplacer("<<<<<<<", " ", "=======", " ", ">>>>>>>", " ").Replace(text)
-	text = strings.Join(strings.Fields(text), " ")
-	return text
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	lines := strings.Split(text, "\n")
+	for i := range lines {
+		lines[i] = strings.Join(strings.Fields(lines[i]), " ")
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
 }

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -51,7 +51,7 @@ Context:
 
 Rules:
 - Always start with double checking whether the findings are legitimate.
-- Avoid resolving a finding by removing or reverting the author's intentional code in their original 1st commit. If the original change introduced something on purpose, fix it forward (e.g. add validation, handle edge cases, tighten logic) rather than deleting it. When in doubt about whether code is intentional, leave it and report the finding as unresolved.
+- Avoid resolving a finding by removing or reverting the author's intentional code in their original 1st commit. If the original change introduced something on purpose, fix it forward (e.g. add validation, handle edge cases, tighten logic) rather than deleting it. Similarly, if the original change intentionally deleted or simplified code, do not restore or re-add the removed code. When in doubt about whether code is intentional, leave it and report the finding as unresolved.
 - Do not add code comments explaining your fixes.
 - Verify that the issues are resolved before finishing.
 - Return JSON with a single "summary" field when you are done.
@@ -152,7 +152,7 @@ Rules:
 - Only comment on things that genuinely matter.
 - Do NOT report styling, formatting, linting, compilation, or type-checking issues.
 - If the change is clean, return an empty findings array.
-- Set requires_human_review to true when the finding questions an intentional design or product decision (e.g. "this feature/output/behavior seems unnecessary"), OR when the most natural fix would remove, revert, or substantially reduce existing intentional code or safety guards. If fixing the issue would likely undo something the author deliberately built, it requires human review. Most findings about correctness, error handling, security, performance, and mechanical code quality should be false. When in doubt, default to false.
+- Set requires_human_review to true when the finding questions an intentional design or product decision (e.g. "this feature/output/behavior seems unnecessary"), OR when the most natural fix would remove, revert, or substantially reduce existing intentional code or safety guards, OR when the most natural fix would restore, re-add, or undo a deletion that the author made intentionally. If fixing the issue would likely undo something the author deliberately did - whether they added it or removed it - it requires human review. Most findings about correctness, error handling, security, performance, and mechanical code quality should be false. When in doubt, default to false.
 
 Risk assessment (after listing all findings):
 - Set risk_level to "low" if the change is well-bounded, mostly cosmetic, or straightforward with little ambiguity.

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -51,7 +51,8 @@ Context:
 
 Rules:
 - Always start with double checking whether the findings are legitimate.
-- Avoid resolving a finding by removing or reverting the author's intentional code in their original 1st commit. If the original change introduced something on purpose, fix it forward (e.g. add validation, handle edge cases, tighten logic) rather than deleting it. Do not undo an intentional deletion unless the finding is a legitimate correctness, reliability, or security issue and the smallest reasonable fix happens to reintroduce a small amount of previously deleted logic. When in doubt about whether code is intentional, leave it and report the finding as unresolved.
+<<<<<<< HEAD
+- Avoid resolving a finding by removing or reverting the author's intentional code in their original 1st commit. If the original change introduced something on purpose, fix it forward (e.g. add validation, handle edge cases, tighten logic) rather than deleting it. Similarly, if the original change intentionally deleted or simplified code, do not restore or re-add the removed code unless the finding is a legitimate correctness, reliability, or security issue and the smallest reasonable fix happens to reintroduce a small amount of previously deleted logic. When in doubt about whether code is intentional, leave it and report the finding as unresolved.
 - Do not add code comments explaining your fixes.
 - Verify that the issues are resolved before finishing.
 - Return JSON with a single "summary" field when you are done.
@@ -152,7 +153,8 @@ Rules:
 - Only comment on things that genuinely matter.
 - Do NOT report styling, formatting, linting, compilation, or type-checking issues.
 - If the change is clean, return an empty findings array.
-- Set requires_human_review to true when the finding questions an intentional design or product decision (e.g. "this feature/output/behavior seems unnecessary"), OR when the most natural fix would remove, revert, or substantially reduce existing intentional code or safety guards, OR when fixing it would likely undo an intentional deletion for non-correctness reasons. A finding is not human-review-only just because the fix may reintroduce a small amount of previously deleted logic to restore correctness, reliability, or security. Most findings about correctness, error handling, security, performance, and mechanical code quality should be false. When in doubt, default to false.
+<<<<<<< HEAD
+- Set requires_human_review to true only when the finding challenges the author's intent - i.e. questions a deliberate design/product decision, or where the natural fix would undo something the author intentionally did (adding, removing, or changing code on purpose). Examples: "this feature seems unnecessary", "this deletion looks wrong", "this guard is redundant". A finding is not human-review-only just because the fix may reintroduce a small amount of previously deleted logic to restore correctness, reliability, or security. Set it to false for findings about objective correctness, error handling, security, performance, and mechanical code quality. When in doubt, default to false.
 
 Risk assessment (after listing all findings):
 - Set risk_level to "low" if the change is well-bounded, mostly cosmetic, or straightforward with little ambiguity.

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -51,7 +51,7 @@ Context:
 
 Rules:
 - Always start with double checking whether the findings are legitimate.
-- Avoid resolving a finding by removing or reverting the author's intentional code in their original 1st commit. If the original change introduced something on purpose, fix it forward (e.g. add validation, handle edge cases, tighten logic) rather than deleting it. Similarly, if the original change intentionally deleted or simplified code, do not restore or re-add the removed code. When in doubt about whether code is intentional, leave it and report the finding as unresolved.
+- Avoid resolving a finding by removing or reverting the author's intentional code in their original 1st commit. If the original change introduced something on purpose, fix it forward (e.g. add validation, handle edge cases, tighten logic) rather than deleting it. Do not undo an intentional deletion unless the finding is a legitimate correctness, reliability, or security issue and the smallest reasonable fix happens to reintroduce a small amount of previously deleted logic. When in doubt about whether code is intentional, leave it and report the finding as unresolved.
 - Do not add code comments explaining your fixes.
 - Verify that the issues are resolved before finishing.
 - Return JSON with a single "summary" field when you are done.
@@ -152,7 +152,7 @@ Rules:
 - Only comment on things that genuinely matter.
 - Do NOT report styling, formatting, linting, compilation, or type-checking issues.
 - If the change is clean, return an empty findings array.
-- Set requires_human_review to true when the finding questions an intentional design or product decision (e.g. "this feature/output/behavior seems unnecessary"), OR when the most natural fix would remove, revert, or substantially reduce existing intentional code or safety guards, OR when the most natural fix would restore, re-add, or undo a deletion that the author made intentionally. If fixing the issue would likely undo something the author deliberately did - whether they added it or removed it - it requires human review. Most findings about correctness, error handling, security, performance, and mechanical code quality should be false. When in doubt, default to false.
+- Set requires_human_review to true when the finding questions an intentional design or product decision (e.g. "this feature/output/behavior seems unnecessary"), OR when the most natural fix would remove, revert, or substantially reduce existing intentional code or safety guards, OR when fixing it would likely undo an intentional deletion for non-correctness reasons. A finding is not human-review-only just because the fix may reintroduce a small amount of previously deleted logic to restore correctness, reliability, or security. Most findings about correctness, error handling, security, performance, and mechanical code quality should be false. When in doubt, default to false.
 
 Risk assessment (after listing all findings):
 - Set risk_level to "low" if the change is well-bounded, mostly cosmetic, or straightforward with little ambiguity.

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -258,9 +258,14 @@ func sanitizedPreviousFindingsForPrompt(raw string) string {
 		return sanitizePromptText(raw)
 	}
 	for i := range findings.Items {
+		findings.Items[i].ID = sanitizePromptText(findings.Items[i].ID)
+		findings.Items[i].Severity = sanitizePromptText(findings.Items[i].Severity)
+		findings.Items[i].File = sanitizePromptText(findings.Items[i].File)
 		findings.Items[i].Description = sanitizePromptText(findings.Items[i].Description)
 	}
 	findings.Summary = sanitizePromptText(findings.Summary)
+	findings.RiskLevel = sanitizePromptText(findings.RiskLevel)
+	findings.RiskRationale = sanitizePromptText(findings.RiskRationale)
 	encoded, err := types.MarshalFindingsJSON(findings)
 	if err != nil {
 		return sanitizePromptText(raw)

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1137,7 +1137,7 @@ func TestReviewStep_FixMode(t *testing.T) {
 
 	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Fixing = true
-	sctx.PreviousFindings = `{"findings":[{"severity":"warning","description":"possible nil dereference"}],"summary":"1 issue"}`
+	sctx.PreviousFindings = `{"findings":[{"severity":"warning","description":"possible nil dereference <<<<<<< HEAD"}],"summary":"1 issue"}`
 
 	step := &ReviewStep{}
 	outcome, err := step.Execute(sctx)

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1336,7 +1336,7 @@ func TestLintStep_NoCommand_MalformedAgentOutput(t *testing.T) {
 func TestTestStep_FixMode(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 	gitCmd(t, dir, "checkout", "--detach", headSHA)
-	previousFindings := `{"items":[{"severity":"error","description":"tests failed with exit code 1"}],"summary":"FAIL: TestFoo expected 42 got 0"}`
+	previousFindings := `{"items":[{"id":"test-1 =======","severity":"error","file":"internal/pipeline/steps/test.go >>>>>>> prompt","description":"tests failed with exit code 1 <<<<<<< HEAD"}],"summary":"FAIL: TestFoo expected 42 got 0 ======="}`
 
 	callCount := 0
 	ag := &mockAgent{
@@ -1368,6 +1368,15 @@ func TestTestStep_FixMode(t *testing.T) {
 	if !strings.Contains(ag.calls[0].Prompt, "FAIL: TestFoo expected 42 got 0") {
 		t.Error("expected fix prompt to contain previous test failure summary")
 	}
+	if strings.Contains(ag.calls[0].Prompt, "test-1 =======") {
+		t.Error("expected test fix prompt to sanitize finding IDs")
+	}
+	if strings.Contains(ag.calls[0].Prompt, "test.go >>>>>>> prompt") {
+		t.Error("expected test fix prompt to sanitize finding file paths")
+	}
+	if strings.Contains(ag.calls[0].Prompt, "<<<<<<< HEAD") {
+		t.Error("expected test fix prompt to exclude merge markers")
+	}
 	if status := gitStatusPorcelain(t, dir); status != "" {
 		t.Fatalf("expected clean worktree after fix commit, got %q", status)
 	}
@@ -1379,7 +1388,7 @@ func TestTestStep_FixMode(t *testing.T) {
 func TestLintStep_FixMode_CommitsChanges(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 	gitCmd(t, dir, "checkout", "--detach", headSHA)
-	previousFindings := `{"items":[{"severity":"warning","description":"linter found issues (exit code 1)"}],"summary":"main.go:10: unused variable x"}`
+	previousFindings := `{"items":[{"id":"lint-1 =======","severity":"warning","file":"internal/pipeline/steps/lint.go >>>>>>> prompt","description":"linter found issues (exit code 1) <<<<<<< HEAD"}],"summary":"main.go:10: unused variable x ======="}`
 
 	callCount := 0
 	ag := &mockAgent{
@@ -1411,6 +1420,15 @@ func TestLintStep_FixMode_CommitsChanges(t *testing.T) {
 	}
 	if !strings.Contains(ag.calls[0].Prompt, "unused variable x") {
 		t.Error("expected fix prompt to contain previous lint summary")
+	}
+	if strings.Contains(ag.calls[0].Prompt, "lint-1 =======") {
+		t.Error("expected lint fix prompt to sanitize finding IDs")
+	}
+	if strings.Contains(ag.calls[0].Prompt, "lint.go >>>>>>> prompt") {
+		t.Error("expected lint fix prompt to sanitize finding file paths")
+	}
+	if strings.Contains(ag.calls[0].Prompt, "<<<<<<< HEAD") {
+		t.Error("expected lint fix prompt to exclude merge markers")
 	}
 	if status := gitStatusPorcelain(t, dir); status != "" {
 		t.Fatalf("expected clean worktree after fix commit, got %q", status)

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1162,6 +1162,12 @@ func TestReviewStep_FixMode(t *testing.T) {
 	if !strings.Contains(ag.calls[0].Prompt, "Avoid resolving a finding by removing or reverting") {
 		t.Error("expected fix prompt to include anti-revert guardrail")
 	}
+	if strings.Contains(ag.calls[0].Prompt, "do not restore or re-add the removed code") {
+		t.Error("expected fix prompt to allow re-adding small deleted logic for legitimate forward fixes")
+	}
+	if !strings.Contains(ag.calls[0].Prompt, "Do not undo an intentional deletion unless the finding is a legitimate correctness, reliability, or security issue") {
+		t.Error("expected fix prompt to distinguish intentional deletions from legitimate bug fixes")
+	}
 	if len(ag.calls[0].JSONSchema) == 0 {
 		t.Error("expected fix call to request structured JSON output")
 	}
@@ -1170,6 +1176,12 @@ func TestReviewStep_FixMode(t *testing.T) {
 	}
 	if !strings.Contains(ag.calls[1].Prompt, "remove, revert, or substantially reduce existing intentional code") {
 		t.Error("expected review prompt requires_human_review to cover revert scenarios")
+	}
+	if strings.Contains(ag.calls[1].Prompt, "restore, re-add, or undo a deletion that the author made intentionally") {
+		t.Error("expected review prompt not to classify all re-added deleted logic as human review")
+	}
+	if !strings.Contains(ag.calls[1].Prompt, "A finding is not human-review-only just because the fix may reintroduce a small amount of previously deleted logic") {
+		t.Error("expected review prompt to keep routine correctness fixes auto-fixable")
 	}
 	if status := gitStatusPorcelain(t, dir); status != "" {
 		t.Fatalf("expected clean worktree after fix commit, got %q", status)

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1174,8 +1174,8 @@ func TestReviewStep_FixMode(t *testing.T) {
 	if strings.Contains(ag.calls[1].Prompt, "feature code") {
 		t.Error("expected review prompt to avoid embedding diff contents in fix mode")
 	}
-	if !strings.Contains(ag.calls[1].Prompt, "remove, revert, or substantially reduce existing intentional code") {
-		t.Error("expected review prompt requires_human_review to cover revert scenarios")
+	if !strings.Contains(ag.calls[1].Prompt, "challenges the author's intent") {
+		t.Error("expected review prompt requires_human_review to cover intent-challenging scenarios")
 	}
 	if strings.Contains(ag.calls[1].Prompt, "restore, re-add, or undo a deletion that the author made intentionally") {
 		t.Error("expected review prompt not to classify all re-added deleted logic as human review")
@@ -3662,6 +3662,94 @@ func TestReviewFindingsSchema_ValidJSON(t *testing.T) {
 		if !found {
 			t.Errorf("missing required field %q in schema", field)
 		}
+	}
+}
+
+func TestFindingsSchema_RequiresHumanReview(t *testing.T) {
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(findingsSchema, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	props := parsed["properties"].(map[string]interface{})
+	items := props["findings"].(map[string]interface{})["items"].(map[string]interface{})
+	itemProps := items["properties"].(map[string]interface{})
+	if _, ok := itemProps["requires_human_review"]; !ok {
+		t.Error("findingsSchema missing requires_human_review property")
+	}
+	required := items["required"].([]interface{})
+	found := false
+	for _, r := range required {
+		if r.(string) == "requires_human_review" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("findingsSchema does not require requires_human_review at item level")
+	}
+}
+
+func TestReviewFindingsSchema_RequiresHumanReviewAtItemLevel(t *testing.T) {
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(reviewFindingsSchema, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	props := parsed["properties"].(map[string]interface{})
+	items := props["findings"].(map[string]interface{})["items"].(map[string]interface{})
+	required := items["required"].([]interface{})
+	found := false
+	for _, r := range required {
+		if r.(string) == "requires_human_review" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("reviewFindingsSchema does not require requires_human_review at item level")
+	}
+}
+
+func TestTestStep_PromptIncludesRequiresHumanReview(t *testing.T) {
+	dir := t.TempDir()
+	findings := Findings{Items: nil, Summary: "all tests passed"}
+	findingsJSON, _ := json.Marshal(findings)
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			return &agent.Result{Output: findingsJSON}, nil
+		},
+	}
+	sctx := newTestContext(t, ag, dir, "abc", "def", config.Commands{})
+	step := &TestStep{}
+	if _, err := step.Execute(sctx); err != nil {
+		t.Fatal(err)
+	}
+	if len(ag.calls) != 1 {
+		t.Fatalf("expected 1 agent call, got %d", len(ag.calls))
+	}
+	if !strings.Contains(ag.calls[0].Prompt, "requires_human_review") {
+		t.Error("expected test prompt to instruct agent about requires_human_review")
+	}
+}
+
+func TestLintStep_PromptIncludesRequiresHumanReview(t *testing.T) {
+	dir := t.TempDir()
+	findings := Findings{Items: nil, Summary: "all clean"}
+	findingsJSON, _ := json.Marshal(findings)
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			return &agent.Result{Output: findingsJSON}, nil
+		},
+	}
+	sctx := newTestContext(t, ag, dir, "abc", "def", config.Commands{})
+	step := &LintStep{}
+	if _, err := step.Execute(sctx); err != nil {
+		t.Fatal(err)
+	}
+	if len(ag.calls) != 1 {
+		t.Fatalf("expected 1 agent call, got %d", len(ag.calls))
+	}
+	if !strings.Contains(ag.calls[0].Prompt, "requires_human_review") {
+		t.Error("expected lint prompt to instruct agent about requires_human_review")
 	}
 }
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1162,10 +1162,10 @@ func TestReviewStep_FixMode(t *testing.T) {
 	if !strings.Contains(ag.calls[0].Prompt, "Avoid resolving a finding by removing or reverting") {
 		t.Error("expected fix prompt to include anti-revert guardrail")
 	}
-	if strings.Contains(ag.calls[0].Prompt, "do not restore or re-add the removed code") {
-		t.Error("expected fix prompt to allow re-adding small deleted logic for legitimate forward fixes")
+	if strings.Contains(ag.calls[0].Prompt, "<<<<<<< HEAD") {
+		t.Error("expected fix prompt to exclude merge markers")
 	}
-	if !strings.Contains(ag.calls[0].Prompt, "Do not undo an intentional deletion unless the finding is a legitimate correctness, reliability, or security issue") {
+	if !strings.Contains(ag.calls[0].Prompt, "do not restore or re-add the removed code unless the finding is a legitimate correctness, reliability, or security issue") {
 		t.Error("expected fix prompt to distinguish intentional deletions from legitimate bug fixes")
 	}
 	if len(ag.calls[0].JSONSchema) == 0 {
@@ -1174,11 +1174,11 @@ func TestReviewStep_FixMode(t *testing.T) {
 	if strings.Contains(ag.calls[1].Prompt, "feature code") {
 		t.Error("expected review prompt to avoid embedding diff contents in fix mode")
 	}
+	if strings.Contains(ag.calls[1].Prompt, "<<<<<<< HEAD") {
+		t.Error("expected review prompt to exclude merge markers")
+	}
 	if !strings.Contains(ag.calls[1].Prompt, "challenges the author's intent") {
 		t.Error("expected review prompt requires_human_review to cover intent-challenging scenarios")
-	}
-	if strings.Contains(ag.calls[1].Prompt, "restore, re-add, or undo a deletion that the author made intentionally") {
-		t.Error("expected review prompt not to classify all re-added deleted logic as human review")
 	}
 	if !strings.Contains(ag.calls[1].Prompt, "A finding is not human-review-only just because the fix may reintroduce a small amount of previously deleted logic") {
 		t.Error("expected review prompt to keep routine correctness fixes auto-fixable")

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1137,7 +1137,7 @@ func TestReviewStep_FixMode(t *testing.T) {
 
 	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Fixing = true
-	sctx.PreviousFindings = `{"findings":[{"severity":"warning","description":"possible nil dereference <<<<<<< HEAD"}],"summary":"1 issue"}`
+	sctx.PreviousFindings = `{"findings":[{"id":"review-1 =======","severity":"warning","file":"internal/pipeline/steps/review.go >>>>>>> prompt","description":"possible nil dereference <<<<<<< HEAD"}],"summary":"1 issue ======="}`
 
 	step := &ReviewStep{}
 	outcome, err := step.Execute(sctx)
@@ -1158,6 +1158,12 @@ func TestReviewStep_FixMode(t *testing.T) {
 	}
 	if !strings.Contains(ag.calls[0].Prompt, "possible nil dereference") {
 		t.Error("expected review fix prompt to include previous findings")
+	}
+	if strings.Contains(ag.calls[0].Prompt, "review-1 =======") {
+		t.Error("expected review fix prompt to sanitize finding IDs")
+	}
+	if strings.Contains(ag.calls[0].Prompt, "review.go >>>>>>> prompt") {
+		t.Error("expected review fix prompt to sanitize finding file paths")
 	}
 	if !strings.Contains(ag.calls[0].Prompt, "Avoid resolving a finding by removing or reverting") {
 		t.Error("expected fix prompt to include anti-revert guardrail")

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -3907,6 +3907,37 @@ func TestReviewStep_DismissedFindingsSanitizesPromptContent(t *testing.T) {
 	}
 }
 
+func TestSanitizedPreviousFindingsForPrompt_PreservesMultilineDescriptions(t *testing.T) {
+	raw, err := types.MarshalFindingsJSON(types.Findings{
+		Items: []types.Finding{{
+			ID:                  "review-1",
+			Severity:            "warning",
+			File:                "internal/pipeline/steps/review.go",
+			Line:                278,
+			Description:         "go test failed:\n--- FAIL: TestThing\nmain_test.go:42: expected x\n",
+			RequiresHumanReview: false,
+		}},
+		Summary:       "1 selected finding",
+		RiskLevel:     "medium",
+		RiskRationale: "compiler output:\nline 1\nline 2",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sanitized := sanitizedPreviousFindingsForPrompt(raw)
+	findings, err := types.ParseFindingsJSON(sanitized)
+	if err != nil {
+		t.Fatalf("ParseFindingsJSON() error = %v", err)
+	}
+	if !strings.Contains(findings.Items[0].Description, "\n--- FAIL: TestThing\n") {
+		t.Fatalf("expected multiline description to be preserved, got %q", findings.Items[0].Description)
+	}
+	if !strings.Contains(findings.RiskRationale, "\nline 1\nline 2") {
+		t.Fatalf("expected multiline risk rationale to be preserved, got %q", findings.RiskRationale)
+	}
+}
+
 // --- CI Execute tests ---
 
 // fakeCIGH creates a fake gh binary that responds to CI-related

--- a/internal/pipeline/steps/test.go
+++ b/internal/pipeline/steps/test.go
@@ -47,7 +47,7 @@ Rules:
 			fixPrompt += `
 
 Previous test findings to address:
-` + sctx.PreviousFindings
+` + sanitizedPreviousFindingsForPrompt(sctx.PreviousFindings)
 		}
 		result, err := sctx.Agent.Run(ctx, agent.RunOpts{
 			Prompt:     fixPrompt,

--- a/internal/pipeline/steps/test.go
+++ b/internal/pipeline/steps/test.go
@@ -93,7 +93,8 @@ Rules:
 - Focus on testing and test-related fixes only.
 - Only report actionable findings: test failures, unfixable setup issues, or flaky tests you identified.
 - Do NOT report passing tests (whether existing or new), test counts, coverage summaries, or other non-actionable information.
-- If all tests pass and there are no issues, return an empty findings array.`,
+- If all tests pass and there are no issues, return an empty findings array.
+- Set requires_human_review to true only when a test failure seems desired and you question the author's intent of having the test in the first place.`,
 				sctx.Run.Branch,
 				baseSHA,
 				sctx.Run.HeadSHA,

--- a/internal/types/findings.go
+++ b/internal/types/findings.go
@@ -12,7 +12,7 @@ type Finding struct {
 	File                string `json:"file,omitempty"`
 	Line                int    `json:"line,omitempty"`
 	Description         string `json:"description"`
-	RequiresHumanReview bool   `json:"requires_human_review,omitempty"`
+	RequiresHumanReview bool   `json:"requires_human_review"`
 }
 
 // Findings is the structured findings payload exchanged across pipeline, IPC, and TUI.

--- a/internal/types/findings_test.go
+++ b/internal/types/findings_test.go
@@ -1,6 +1,10 @@
 package types
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
 
 func TestParseFindingsJSON_RiskFields(t *testing.T) {
 	raw := `{"findings":[{"severity":"error","description":"bug"}],"risk_level":"high","risk_rationale":"Critical bug."}`
@@ -185,5 +189,17 @@ func TestAutoFixableFindings_NoneHumanReview(t *testing.T) {
 	fixable := AutoFixableFindings(f)
 	if len(fixable.Items) != 2 {
 		t.Errorf("Items count = %d, want 2", len(fixable.Items))
+	}
+}
+
+func TestFinding_RequiresHumanReview_SerializedWhenFalse(t *testing.T) {
+	f := Finding{Severity: "error", Description: "bug", RequiresHumanReview: false}
+	raw, err := json.Marshal(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(raw)
+	if !strings.Contains(s, `"requires_human_review":false`) {
+		t.Errorf("expected requires_human_review to be present when false, got %s", s)
 	}
 }


### PR DESCRIPTION
## Summary
- Sanitize prior and dismissed findings before embedding them in review, lint, and test autofix prompts so merge markers or other prompt-breaking text cannot leak into agent instructions.
- Preserve multiline finding text and tighten the deletion-guard wording so intentional deletions can still be auto-fixed for objective correctness, reliability, security, and performance issues.
- Add regression coverage for merge-marker and sanitization cases, and clarify the auto-fix human review guardrails in the docs.

## Risk Assessment

✅ Low: The change is narrowly scoped to prompt sanitization and findings schema updates, and the targeted tests for the touched pipeline/types packages pass without exposing functional regressions.

## Pipeline

Updates from `git push no-mistakes`

🔧 **Rebase** - 1 issue found → user-fixed
🔧 **Review** - 2 issues found → auto-fixed (3) + user-fixed (2)
✅ **Test** - passed
✅ **Lint** - passed

<details>
<summary>Rebase details</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/pipeline/steps/review.go` - merge conflict rebasing onto origin/fix/autofix-guard

**Round 2** (user-fix) - passed ✅

</details>

<details>
<summary>Review details</summary>

**Round 1** - found 2 errors
- 🚨 `internal/pipeline/steps/review.go:54` - An unresolved merge marker (`<<<<<<< HEAD`) is included in the review-fix prompt. This text will be sent directly to the agent during auto-fix runs, corrupting the instruction block and making review fixes less reliable.
- 🚨 `internal/pipeline/steps/review.go:156` - The main review prompt also contains an unresolved merge marker, so every review run on this branch sends malformed instructions to the agent. That can skew `requires_human_review` classification and the overall review output.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `internal/pipeline/steps/steps_test.go:1165` - The new merge-marker regression check is ineffective: this fixture's `PreviousFindings` only contains `possible nil dereference`, so the assertion can pass even though `ReviewStep` still interpolates raw findings text into the fix prompt. Seed the test with a finding containing `<<<<<<<` or sanitize `PreviousFindings` before embedding it.

**Round 3** (auto-fix) - found 1 warning
- ⚠️ `internal/pipeline/steps/review.go:261` - `sanitizedPreviousFindingsForPrompt` only scrubs `description` and `summary` before re-encoding prior findings. Untrusted `file` or `id` strings still reach the autofix prompt verbatim, so malformed prior findings can still inject merge-marker text or steering instructions. Sanitize every string field before calling `MarshalFindingsJSON`.

**Round 4** (auto-fix) - found 2 warnings
- ⚠️ `internal/pipeline/steps/review.go:39` - The new `sanitizedPreviousFindingsForPrompt` guard is only applied in `ReviewStep`; `LintStep` and `TestStep` still splice `sctx.PreviousFindings` into autofix prompts raw, so merge-marker or prompt-injection text from earlier findings can still steer those runs.
- ⚠️ `internal/pipeline/steps/review.go:221` - `dismissedFindingsPromptSection` now sanitizes the description, but it still serializes raw `id` and `file` values into the review prompt. Merge-marker tokens or other prompt-breaking text can still leak through dismissed metadata, which leaves this guardrail incomplete.

**Round 5** (user-fix) - found 2 warnings
- ⚠️ `internal/pipeline/steps/review.go:278` - `sanitizePromptText` collapses all whitespace with `strings.Fields`, so previous test/lint findings lose their line structure before being fed back into fix-mode prompts. That turns stack traces and multi-line compiler/test output into one long line, which materially reduces the agent's ability to diagnose and fix failures.
- ⚠️ `internal/pipeline/steps/review.go:55` - The new review fix guard only allows re-introducing deleted logic for correctness, reliability, or security issues, but the review prompt still treats performance regressions as objective risks. A real perf regression caused by an intentional deletion can therefore be marked auto-fixable yet blocked by the fixer instructions.

**Round 6** (user-fix) - found 0 issues

</details>
