### PR TITLE
fix(document): validate findings payloads and document auto-fix flow

### DIFF
--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -93,10 +93,11 @@ The pipeline runs these steps in order:
 1. **Rebase** - rebase onto the latest upstream
 2. **Review** - AI code review of your diff
 3. **Test** - run tests (configured command or agent-detected)
-4. **Lint** - run linters (configured command or agent-detected)
-5. **Push** - push to the real upstream remote
-6. **PR** - create or update a pull request
-7. **Babysit** - poll CI and auto-fix failures
+4. **Document** - check for required documentation updates
+5. **Lint** - run linters (configured command or agent-detected)
+6. **Push** - push to the real upstream remote
+7. **PR** - create or update a pull request
+8. **Babysit** - poll CI and auto-fix failures
 
 Steps that find issues pause for your approval. You can approve, fix, skip, or abort. See [Pipeline Steps](/no-mistakes/guides/pipeline-steps/) and [Auto-Fix](/no-mistakes/guides/auto-fix/) for details.
 

--- a/docs/src/content/docs/guides/auto-fix.md
+++ b/docs/src/content/docs/guides/auto-fix.md
@@ -25,6 +25,7 @@ auto_fix:
   rebase: 0    # 0 = disabled, always requires manual approval
   review: 3    # up to 3 auto-fix attempts
   test: 3
+  document: 3
   lint: 3
   ci: 3
 ```
@@ -38,6 +39,8 @@ Repo config overlays global config - you can set `auto_fix.lint: 5` in a repo's 
 Some review findings are marked `requires_human_review: true` by the agent. These findings always require manual approval regardless of the auto-fix limit. They are never auto-fixed.
 
 This is meant for findings that challenge the author's intent - for example, questioning an intentional product or design choice, or arguing that an intentional addition, removal, or guard should be undone. Routine correctness, reliability, or security fixes still stay auto-fixable even if the smallest fix reintroduces a small amount of previously deleted logic.
+
+Documentation findings use the same approval loop, but the `document` step treats any finding as a documentation gap that should pause for approval. When auto-fix is enabled, the agent can update docs or doc comments, then the step re-runs and proceeds only after reassessment returns no findings.
 
 ## User-triggered fixes
 
@@ -60,6 +63,7 @@ Each auto-fix cycle commits its changes with a descriptive message:
 | Rebase | `no-mistakes(rebase): <summary>` |
 | Review | `no-mistakes(review): <summary>` |
 | Test | `no-mistakes(test): <summary>` |
+| Document | `no-mistakes(document): <summary>` |
 | Lint | `no-mistakes(lint): <summary>` |
 
 The push step commits any remaining uncommitted changes with `no-mistakes: apply agent fixes`.

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -38,6 +38,7 @@ log_level: info  # debug | info | warn | error
 # Max auto-fix attempts per step. 0 = disabled (requires manual approval).
 auto_fix:
   rebase: 0
+  document: 3
   lint: 3
   test: 3
   review: 3
@@ -67,6 +68,7 @@ ignore_patterns:
 
 # Override auto-fix limits for this repo.
 auto_fix:
+  document: 3
   lint: 5
 ```
 

--- a/docs/src/content/docs/guides/pipeline-steps.md
+++ b/docs/src/content/docs/guides/pipeline-steps.md
@@ -6,7 +6,7 @@ description: What each step in the validation pipeline does.
 The pipeline runs a fixed sequence of steps. The order is not configurable - this is a deliberate design choice.
 
 ```
-rebase → review → test → lint → push → pr → babysit
+rebase → review → test → document → lint → push → pr → babysit
 ```
 
 Each step can produce findings, request approval, or trigger auto-fix. Steps that encounter fatal errors stop the pipeline. Steps can also be skipped by the user.
@@ -53,6 +53,19 @@ Runs your test suite.
 - If the agent creates new test files (detected via `git status --porcelain`), approval is required even if tests pass.
 
 **Auto-fix:** the agent receives previous failure output and fixes the code, then tests run again. Fix commits use `no-mistakes(test): <summary>`.
+
+**Default auto-fix limit:** `3`.
+
+## Document
+
+Checks whether the code changes need matching documentation updates.
+
+**Behavior:**
+- Diffs the base commit against head and skips the step if there are no non-ignored changed files to document
+- Asks the agent to review the change and return documentation findings for any missing or stale docs
+- Requires approval whenever any documentation finding is returned, including `info` findings
+
+**Auto-fix:** the agent updates only documentation files or doc comments, then the step re-runs and expects an empty findings list before continuing. Fix commits use `no-mistakes(document): <summary>`.
 
 **Default auto-fix limit:** `3`.
 

--- a/docs/src/content/docs/how-it-works.md
+++ b/docs/src/content/docs/how-it-works.md
@@ -25,9 +25,10 @@ description: Architecture and data flow of no-mistakes.
        │                                                          ▼
        │                                               ┌─────────────────────┐
        │                                               │ Pipeline            │
-       │                                               │ rebase → review     │
-       │                                               │ test → lint         │
-       │                                               │ push → pr → babysit│
+        │                                               │ rebase → review     │
+        │                                               │ test → document     │
+        │                                               │ lint → push → pr    │
+        │                                               │ → babysit           │
        │                                               └──────────┬──────────┘
        │                                                          │
        └────────────────────────────────────────────────────────► │ upstream
@@ -38,7 +39,7 @@ description: Architecture and data flow of no-mistakes.
 
 - **Named remote** - `origin` is never hijacked. You push to `no-mistakes` on purpose, so regular `git push` still works normally.
 - **Disposable worktrees** - each run happens in its own detached worktree under `~/.no-mistakes/worktrees/`. The daemon can safely modify files, run tests, and commit fixes without touching your working directory.
-- **Fixed pipeline** - the step order is opinionated and not configurable: `rebase → review → test → lint → push → pr → babysit`. What you _can_ configure is the commands each step runs and how many auto-fix attempts are allowed.
+- **Fixed pipeline** - the step order is opinionated and not configurable: `rebase → review → test → document → lint → push → pr → babysit`. What you _can_ configure is the commands each step runs and how many auto-fix attempts are allowed.
 
 ## Component overview
 

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -24,6 +24,7 @@ auto_fix:
   rebase: 0
   review: 3
   test: 3
+  document: 3
   lint: 3
   ci: 3
 ```

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -94,6 +94,7 @@ Maximum auto-fix attempts per step. Set a step to `0` to disable auto-fix (findi
 | `auto_fix.rebase` | `int` | `0` | Disabled by default - conflicts always require approval |
 | `auto_fix.review` | `int` | `3` | Review finding auto-fix attempts |
 | `auto_fix.test` | `int` | `3` | Test failure auto-fix attempts |
+| `auto_fix.document` | `int` | `3` | Documentation update auto-fix attempts |
 | `auto_fix.lint` | `int` | `3` | Lint issue auto-fix attempts |
 | `auto_fix.ci` | `int` | `3` | CI failure auto-fix attempts |
 

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -23,6 +23,7 @@ auto_fix:
   rebase: 0
   review: 3
   test: 3
+  document: 3
   lint: 5
   ci: 3
 ```

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -100,6 +100,7 @@ Override auto-fix attempt limits for specific steps. Fields not set here inherit
 | `auto_fix.rebase` | `int` | Inherits from global (default `0`) |
 | `auto_fix.review` | `int` | Inherits from global (default `3`) |
 | `auto_fix.test` | `int` | Inherits from global (default `3`) |
+| `auto_fix.document` | `int` | Inherits from global (default `3`) |
 | `auto_fix.lint` | `int` | Inherits from global (default `3`) |
 | `auto_fix.ci` | `int` | Inherits from global (default `3`) |
 

--- a/internal/pipeline/steps/document.go
+++ b/internal/pipeline/steps/document.go
@@ -18,23 +18,6 @@ type DocumentStep struct{}
 
 func (s *DocumentStep) Name() types.StepName { return types.StepDocument }
 
-// documentVerdictSchema is the JSON schema for the document step's structured output.
-var documentVerdictSchema = json.RawMessage(`{
-	"type": "object",
-	"properties": {
-		"verdict": {"type": "string", "enum": ["updated", "skipped"]},
-		"summary": {"type": "string"},
-		"details": {"type": "string"}
-	},
-	"required": ["verdict", "summary"]
-}`)
-
-type documentVerdict struct {
-	Verdict string `json:"verdict"`
-	Summary string `json:"summary"`
-	Details string `json:"details,omitempty"`
-}
-
 func (s *DocumentStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, error) {
 	ctx := sctx.Ctx
 	baseSHA := resolveBranchBaseSHA(ctx, sctx.WorkDir, sctx.Run.BaseSHA, sctx.Repo.DefaultBranch)
@@ -122,7 +105,7 @@ Previous documentation findings to address:
 	sctx.Log("checking documentation...")
 
 	prompt := fmt.Sprintf(
-		`Review the code changes and determine whether project documentation needs to be updated.
+		`Review the code changes and identify any documentation gaps.
 
 Context:
 - branch: %s
@@ -137,7 +120,7 @@ Task:
    - Read the diff and changed files to understand what was added, modified, or removed.
    - Identify the intent and scope of the change (new feature, API change, config change, behavioral change, etc.).
 
-2. Identify documentation that needs updating
+2. Identify documentation gaps
    - Look for existing documentation files in the project: README.md, docs/, doc comments, config examples, etc.
    - Determine which docs are affected by the change. Common cases:
      - New or changed public APIs - update API docs, doc comments, or usage examples
@@ -145,13 +128,14 @@ Task:
      - Changed configuration - update config docs or examples
      - Removed functionality - remove or update stale references
 
-3. Decide whether documentation updates are needed
-	- If the change requires doc updates, return verdict "updated" with a concise summary of what should change.
-	- If no documentation updates are needed (e.g., internal refactoring, test-only changes), return verdict "skipped".
+3. Return findings
+   - Return a finding for each specific documentation gap (file, description of what needs updating).
+   - If no documentation updates are needed (e.g., internal refactoring, test-only changes, or documentation is already up to date), return an empty findings array.
 
 Rules:
 - Do NOT make any file changes in this mode.
-- Return JSON with "verdict" ("updated" or "skipped"), "summary" (brief description of what was updated and why), and optional "details".`,
+- Only report gaps where documentation is missing or stale relative to the code change.
+- Set requires_human_review to false for all findings. Documentation gaps are objective.`,
 		sctx.Run.Branch,
 		baseSHA,
 		sctx.Run.HeadSHA,
@@ -162,50 +146,41 @@ Rules:
 	result, err := sctx.Agent.Run(ctx, agent.RunOpts{
 		Prompt:     prompt,
 		CWD:        sctx.WorkDir,
-		JSONSchema: documentVerdictSchema,
+		JSONSchema: findingsSchema,
 		OnChunk:    sctx.Log,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("agent document: %w", err)
 	}
 
-	// Parse verdict
-	var (
-		verdict             documentVerdict
-		requiresHumanReview bool
-	)
+	var findings Findings
 	if result.Output == nil {
 		sctx.Log("missing structured output, requiring approval")
-		verdict = documentVerdict{Verdict: "updated", Summary: fallbackDocumentSummary(result.Text)}
-		requiresHumanReview = true
-	} else {
-		if err := json.Unmarshal(result.Output, &verdict); err != nil {
-			sctx.Log("could not parse structured output, requiring approval")
-			verdict = documentVerdict{Verdict: "updated", Summary: fallbackDocumentSummary(result.Text)}
-			requiresHumanReview = true
-		} else if verdict.Verdict != "updated" && verdict.Verdict != "skipped" {
-			sctx.Log("invalid structured output verdict, requiring approval")
-			verdict = documentVerdict{Verdict: "updated", Summary: fallbackDocumentSummary(verdict.Summary)}
-			requiresHumanReview = true
-		}
-	}
-
-	needsApproval := verdict.Verdict == "updated"
-	findings := Findings{}
-	if needsApproval {
 		findings = Findings{
 			Items: []Finding{{
 				Severity:            "warning",
-				Description:         verdict.Summary,
-				RequiresHumanReview: requiresHumanReview,
+				Description:         fallbackDocumentSummary(result.Text),
+				RequiresHumanReview: true,
 			}},
-			Summary: verdict.Summary,
+			Summary: fallbackDocumentSummary(result.Text),
+		}
+	} else if err := json.Unmarshal(result.Output, &findings); err != nil {
+		sctx.Log("could not parse structured output, requiring approval")
+		findings = Findings{
+			Items: []Finding{{
+				Severity:            "warning",
+				Description:         fallbackDocumentSummary(result.Text),
+				RequiresHumanReview: true,
+			}},
+			Summary: fallbackDocumentSummary(result.Text),
 		}
 	}
 
+	needsApproval := hasBlockingFindings(findings.Items)
 	findingsJSON, _ := json.Marshal(findings)
-	sctx.Log(fmt.Sprintf("document verdict: %s - %s", verdict.Verdict, verdict.Summary))
 	autoFixable := len(types.AutoFixableFindings(findings).Items) > 0
+
+	sctx.Log(fmt.Sprintf("document findings: %d items", len(findings.Items)))
 
 	return &pipeline.StepOutcome{
 		NeedsApproval: needsApproval,

--- a/internal/pipeline/steps/document.go
+++ b/internal/pipeline/steps/document.go
@@ -164,7 +164,7 @@ Rules:
 			}},
 			Summary: fallbackDocumentSummary(result.Text),
 		}
-	} else if err := json.Unmarshal(result.Output, &findings); err != nil {
+	} else if err := unmarshalRequiredFindings(result.Output, &findings); err != nil {
 		sctx.Log("could not parse structured output, requiring approval")
 		findings = Findings{
 			Items: []Finding{{
@@ -343,4 +343,17 @@ func fallbackDocumentSummary(text string) string {
 		return "agent returned no structured output"
 	}
 	return cleaned
+}
+
+func unmarshalRequiredFindings(raw []byte, findings *Findings) error {
+	var payload struct {
+		Items []Finding `json:"findings"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return err
+	}
+	if payload.Items == nil {
+		return fmt.Errorf("missing findings array")
+	}
+	return json.Unmarshal(raw, findings)
 }

--- a/internal/pipeline/steps/document.go
+++ b/internal/pipeline/steps/document.go
@@ -155,28 +155,30 @@ Rules:
 
 	var findings Findings
 	if result.Output == nil {
+		summary := fallbackDocumentSummary(result.Text)
 		sctx.Log("missing structured output, requiring approval")
 		findings = Findings{
 			Items: []Finding{{
 				Severity:            "warning",
-				Description:         fallbackDocumentSummary(result.Text),
+				Description:         summary,
 				RequiresHumanReview: true,
 			}},
-			Summary: fallbackDocumentSummary(result.Text),
+			Summary: summary,
 		}
 	} else if err := unmarshalRequiredFindings(result.Output, &findings); err != nil {
+		summary := fallbackDocumentSummary(extractDocumentSummary(result.Output, result.Text))
 		sctx.Log("could not parse structured output, requiring approval")
 		findings = Findings{
 			Items: []Finding{{
 				Severity:            "warning",
-				Description:         fallbackDocumentSummary(result.Text),
+				Description:         summary,
 				RequiresHumanReview: true,
 			}},
-			Summary: fallbackDocumentSummary(result.Text),
+			Summary: summary,
 		}
 	}
 
-	needsApproval := hasBlockingFindings(findings.Items)
+	needsApproval := len(findings.Items) > 0
 	findingsJSON, _ := json.Marshal(findings)
 	autoFixable := len(types.AutoFixableFindings(findings).Items) > 0
 
@@ -343,6 +345,16 @@ func fallbackDocumentSummary(text string) string {
 		return "agent returned no structured output"
 	}
 	return cleaned
+}
+
+func extractDocumentSummary(raw []byte, fallback string) string {
+	var payload struct {
+		Summary string `json:"summary"`
+	}
+	if err := json.Unmarshal(raw, &payload); err == nil && strings.TrimSpace(payload.Summary) != "" {
+		return payload.Summary
+	}
+	return fallback
 }
 
 func unmarshalRequiredFindings(raw []byte, findings *Findings) error {

--- a/internal/pipeline/steps/document.go
+++ b/internal/pipeline/steps/document.go
@@ -359,13 +359,28 @@ func extractDocumentSummary(raw []byte, fallback string) string {
 
 func unmarshalRequiredFindings(raw []byte, findings *Findings) error {
 	var payload struct {
-		Items []Finding `json:"findings"`
+		Items []struct {
+			Severity            string `json:"severity"`
+			Description         string `json:"description"`
+			RequiresHumanReview *bool  `json:"requires_human_review"`
+		} `json:"findings"`
 	}
 	if err := json.Unmarshal(raw, &payload); err != nil {
 		return err
 	}
 	if payload.Items == nil {
 		return fmt.Errorf("missing findings array")
+	}
+	for i, item := range payload.Items {
+		if strings.TrimSpace(item.Severity) == "" {
+			return fmt.Errorf("finding %d missing severity", i)
+		}
+		if strings.TrimSpace(item.Description) == "" {
+			return fmt.Errorf("finding %d missing description", i)
+		}
+		if item.RequiresHumanReview == nil {
+			return fmt.Errorf("finding %d missing requires_human_review", i)
+		}
 	}
 	return json.Unmarshal(raw, findings)
 }

--- a/internal/pipeline/steps/document.go
+++ b/internal/pipeline/steps/document.go
@@ -359,7 +359,8 @@ func extractDocumentSummary(raw []byte, fallback string) string {
 
 func unmarshalRequiredFindings(raw []byte, findings *Findings) error {
 	var payload struct {
-		Items []struct {
+		Summary string `json:"summary"`
+		Items   []struct {
 			Severity            string `json:"severity"`
 			Description         string `json:"description"`
 			RequiresHumanReview *bool  `json:"requires_human_review"`
@@ -370,6 +371,9 @@ func unmarshalRequiredFindings(raw []byte, findings *Findings) error {
 	}
 	if payload.Items == nil {
 		return fmt.Errorf("missing findings array")
+	}
+	if strings.TrimSpace(payload.Summary) == "" {
+		return fmt.Errorf("missing summary")
 	}
 	for i, item := range payload.Items {
 		if strings.TrimSpace(item.Severity) == "" {

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1843,6 +1843,46 @@ func TestDocumentStep_MalformedFindingRequiresApproval(t *testing.T) {
 	}
 }
 
+func TestDocumentStep_MissingSummaryRequiresApproval(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			return &agent.Result{Output: json.RawMessage(`{"findings":[]}`)}, nil
+		},
+	}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+
+	step := &DocumentStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected missing summary to require approval")
+	}
+	if outcome.AutoFixable {
+		t.Fatal("expected missing summary finding to require manual review")
+	}
+	var findings Findings
+	if err := json.Unmarshal([]byte(outcome.Findings), &findings); err != nil {
+		t.Fatalf("unmarshal findings: %v", err)
+	}
+	if len(findings.Items) != 1 {
+		t.Fatalf("expected 1 finding, got %+v", findings.Items)
+	}
+	if !findings.Items[0].RequiresHumanReview {
+		t.Fatal("expected missing summary finding to require human review")
+	}
+	if findings.Summary != "agent returned no structured output" {
+		t.Fatalf("summary = %q, want %q", findings.Summary, "agent returned no structured output")
+	}
+	if findings.Items[0].Description != "agent returned no structured output" {
+		t.Fatalf("description = %q, want %q", findings.Items[0].Description, "agent returned no structured output")
+	}
+}
+
 func TestDocumentStep_PromptIncludesIgnorePatterns(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1752,10 +1752,21 @@ func TestDocumentStep_MissingFindingsFieldRequiresApproval(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Missing findings field means the output parsed but findings is nil/empty.
-	// This is equivalent to "no gaps found" - should not need approval.
-	if outcome.NeedsApproval {
-		t.Error("expected no approval when findings array is empty/missing")
+	if !outcome.NeedsApproval {
+		t.Fatal("expected missing findings field to require approval")
+	}
+	if outcome.AutoFixable {
+		t.Fatal("expected missing findings field finding to require manual review")
+	}
+	var findings Findings
+	if err := json.Unmarshal([]byte(outcome.Findings), &findings); err != nil {
+		t.Fatalf("unmarshal findings: %v", err)
+	}
+	if len(findings.Items) != 1 {
+		t.Fatalf("expected 1 finding, got %+v", findings.Items)
+	}
+	if !findings.Items[0].RequiresHumanReview {
+		t.Fatal("expected missing findings field finding to require human review")
 	}
 	if len(ag.calls) != 1 {
 		t.Fatalf("expected 1 agent call, got %d", len(ag.calls))

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1573,7 +1573,7 @@ func TestDocumentStep_Updated(t *testing.T) {
 	ag := &mockAgent{
 		name: "test",
 		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
-			return &agent.Result{Output: json.RawMessage(`{"verdict":"updated","summary":"updated README"}`)}, nil
+			return &agent.Result{Output: json.RawMessage(`{"findings":[{"severity":"warning","description":"README missing new CLI flag","requires_human_review":false}],"summary":"README needs updating"}`)}, nil
 		},
 	}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
@@ -1608,8 +1608,8 @@ func TestDocumentStep_Updated(t *testing.T) {
 	if len(findings.Items) != 1 || findings.Items[0].Severity != "warning" {
 		t.Fatalf("unexpected findings: %+v", findings.Items)
 	}
-	if findings.Items[0].Description != "updated README" {
-		t.Fatalf("finding description = %q, want %q", findings.Items[0].Description, "updated README")
+	if findings.Items[0].Description != "README missing new CLI flag" {
+		t.Fatalf("finding description = %q, want %q", findings.Items[0].Description, "README missing new CLI flag")
 	}
 	if status := gitStatusPorcelain(t, dir); status != "" {
 		t.Fatalf("expected clean worktree while awaiting approval, got %q", status)
@@ -1625,7 +1625,7 @@ func TestDocumentStep_Skipped(t *testing.T) {
 	ag := &mockAgent{
 		name: "test",
 		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
-			return &agent.Result{Output: json.RawMessage(`{"verdict":"skipped","summary":"internal refactoring only"}`)}, nil
+			return &agent.Result{Output: json.RawMessage(`{"findings":[],"summary":"internal refactoring only"}`)}, nil
 		},
 	}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
@@ -1636,7 +1636,7 @@ func TestDocumentStep_Skipped(t *testing.T) {
 		t.Fatal(err)
 	}
 	if outcome.NeedsApproval {
-		t.Error("document step should not require approval when skipped")
+		t.Error("document step should not require approval when no gaps found")
 	}
 	if got := lastCommitMessage(t, dir); got != "add feature" {
 		t.Fatalf("expected no new commit, but last commit message = %q", got)
@@ -1699,9 +1699,6 @@ func TestDocumentStep_MalformedOutput(t *testing.T) {
 	if !findings.Items[0].RequiresHumanReview {
 		t.Fatal("expected malformed output finding to require human review")
 	}
-	if findings.Items[0].Description != "I updated the docs" {
-		t.Fatalf("finding description = %q, want %q", findings.Items[0].Description, "I updated the docs")
-	}
 }
 
 func TestDocumentStep_NoStructuredOutputRequiresApproval(t *testing.T) {
@@ -1736,17 +1733,15 @@ func TestDocumentStep_NoStructuredOutputRequiresApproval(t *testing.T) {
 	if !findings.Items[0].RequiresHumanReview {
 		t.Fatal("expected missing structured output finding to require human review")
 	}
-	if findings.Items[0].Description != "docs status unavailable" {
-		t.Fatalf("finding description = %q, want %q", findings.Items[0].Description, "docs status unavailable")
-	}
 }
 
-func TestDocumentStep_InvalidStructuredVerdictRequiresApproval(t *testing.T) {
+func TestDocumentStep_MissingFindingsFieldRequiresApproval(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	ag := &mockAgent{
 		name: "test",
 		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			// Agent returns structured output but without the findings array
 			return &agent.Result{Output: json.RawMessage(`{"summary":"docs status unavailable"}`)}, nil
 		},
 	}
@@ -1757,30 +1752,10 @@ func TestDocumentStep_InvalidStructuredVerdictRequiresApproval(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !outcome.NeedsApproval {
-		t.Fatal("expected invalid structured output to require approval")
-	}
-	if outcome.AutoFixable {
-		t.Fatal("expected invalid structured output finding to require manual review")
-	}
-	var findings Findings
-	if err := json.Unmarshal([]byte(outcome.Findings), &findings); err != nil {
-		t.Fatalf("unmarshal findings: %v", err)
-	}
-	if len(findings.Items) != 1 {
-		t.Fatalf("expected 1 finding, got %+v", findings.Items)
-	}
-	if !findings.Items[0].RequiresHumanReview {
-		t.Fatal("expected invalid structured output finding to require human review")
-	}
-	if findings.Items[0].Description != "docs status unavailable" {
-		t.Fatalf("finding description = %q, want %q", findings.Items[0].Description, "docs status unavailable")
-	}
-	if findings.Summary != "docs status unavailable" {
-		t.Fatalf("findings summary = %q, want %q", findings.Summary, "docs status unavailable")
-	}
-	if strings.TrimSpace(outcome.Findings) == "" {
-		t.Fatal("expected findings to be recorded")
+	// Missing findings field means the output parsed but findings is nil/empty.
+	// This is equivalent to "no gaps found" - should not need approval.
+	if outcome.NeedsApproval {
+		t.Error("expected no approval when findings array is empty/missing")
 	}
 	if len(ag.calls) != 1 {
 		t.Fatalf("expected 1 agent call, got %d", len(ag.calls))
@@ -1793,7 +1768,7 @@ func TestDocumentStep_PromptIncludesIgnorePatterns(t *testing.T) {
 	ag := &mockAgent{
 		name: "test",
 		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
-			return &agent.Result{Output: json.RawMessage(`{"verdict":"skipped","summary":"nothing to update"}`)}, nil
+			return &agent.Result{Output: json.RawMessage(`{"findings":[],"summary":"nothing to update"}`)}, nil
 		},
 	}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
@@ -1861,8 +1836,8 @@ func TestDocumentStep_FixMode_CommitsAndReassesses(t *testing.T) {
 				os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Docs\n"), 0o644)
 				return &agent.Result{Output: json.RawMessage(`{"summary":"add README"}`)}, nil
 			}
-			// Re-assessment call: docs are now up to date
-			return &agent.Result{Output: json.RawMessage(`{"verdict":"skipped","summary":"docs are current"}`)}, nil
+			// Re-assessment call: docs are now up to date, empty findings
+			return &agent.Result{Output: json.RawMessage(`{"findings":[],"summary":"docs are current"}`)}, nil
 		},
 	}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
@@ -1907,7 +1882,7 @@ func TestDocumentStep_FixMode_StillNeedsWorkAfterFix(t *testing.T) {
 				return &agent.Result{Output: json.RawMessage(`{"summary":"partial update"}`)}, nil
 			}
 			// Re-assessment: still needs more work
-			return &agent.Result{Output: json.RawMessage(`{"verdict":"updated","summary":"config section still missing"}`)}, nil
+			return &agent.Result{Output: json.RawMessage(`{"findings":[{"severity":"warning","description":"config section still missing","requires_human_review":false}],"summary":"config section still missing"}`)}, nil
 		},
 	}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
@@ -1951,7 +1926,7 @@ func TestDocumentStep_FixMode_NoChangesStillReassesses(t *testing.T) {
 				return &agent.Result{Output: json.RawMessage(`{"summary":"no changes needed"}`)}, nil
 			}
 			// Re-assessment
-			return &agent.Result{Output: json.RawMessage(`{"verdict":"skipped","summary":"docs are fine"}`)}, nil
+			return &agent.Result{Output: json.RawMessage(`{"findings":[],"summary":"docs are fine"}`)}, nil
 		},
 	}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
@@ -2039,7 +2014,7 @@ func TestDocumentStep_FixMode_AllowsBlockCommentOnlyEdits(t *testing.T) {
 				}
 				return &agent.Result{Output: json.RawMessage(`{"summary":"update comment"}`)}, nil
 			}
-			return &agent.Result{Output: json.RawMessage(`{"verdict":"skipped","summary":"docs are current"}`)}, nil
+			return &agent.Result{Output: json.RawMessage(`{"findings":[],"summary":"docs are current"}`)}, nil
 		},
 	}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1803,6 +1803,46 @@ func TestDocumentStep_MissingFindingsFieldRequiresApproval(t *testing.T) {
 	}
 }
 
+func TestDocumentStep_MalformedFindingRequiresApproval(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			return &agent.Result{Output: json.RawMessage(`{"findings":[{"severity":"warning","description":"README missing new CLI flag"}],"summary":"README needs updating"}`)}, nil
+		},
+	}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+
+	step := &DocumentStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected malformed finding to require approval")
+	}
+	if outcome.AutoFixable {
+		t.Fatal("expected malformed finding to require manual review")
+	}
+	var findings Findings
+	if err := json.Unmarshal([]byte(outcome.Findings), &findings); err != nil {
+		t.Fatalf("unmarshal findings: %v", err)
+	}
+	if len(findings.Items) != 1 {
+		t.Fatalf("expected 1 finding, got %+v", findings.Items)
+	}
+	if !findings.Items[0].RequiresHumanReview {
+		t.Fatal("expected malformed finding to require human review")
+	}
+	if findings.Summary != "README needs updating" {
+		t.Fatalf("summary = %q, want %q", findings.Summary, "README needs updating")
+	}
+	if findings.Items[0].Description != "README needs updating" {
+		t.Fatalf("description = %q, want %q", findings.Items[0].Description, "README needs updating")
+	}
+}
+
 func TestDocumentStep_PromptIncludesIgnorePatterns(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1643,6 +1643,30 @@ func TestDocumentStep_Skipped(t *testing.T) {
 	}
 }
 
+func TestDocumentStep_InfoFindingStillRequiresApproval(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			return &agent.Result{Output: json.RawMessage(`{"findings":[{"severity":"info","description":"README should mention the new flag","requires_human_review":false}],"summary":"README needs updating"}`)}, nil
+		},
+	}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+
+	step := &DocumentStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected any documentation finding to require approval")
+	}
+	if !outcome.AutoFixable {
+		t.Fatal("expected info-level documentation finding to remain auto-fixable")
+	}
+}
+
 func TestDocumentStep_AgentError(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
@@ -1767,6 +1791,12 @@ func TestDocumentStep_MissingFindingsFieldRequiresApproval(t *testing.T) {
 	}
 	if !findings.Items[0].RequiresHumanReview {
 		t.Fatal("expected missing findings field finding to require human review")
+	}
+	if findings.Summary != "docs status unavailable" {
+		t.Fatalf("summary = %q, want %q", findings.Summary, "docs status unavailable")
+	}
+	if findings.Items[0].Description != "docs status unavailable" {
+		t.Fatalf("description = %q, want %q", findings.Items[0].Description, "docs status unavailable")
 	}
 	if len(ag.calls) != 1 {
 		t.Fatalf("expected 1 agent call, got %d", len(ag.calls))


### PR DESCRIPTION
{"title":"fix(document): validate findings payloads and document auto-fix flow","body":"## Summary\n- Tighten the document pipeline step to enforce the findings schema, including required summary and finding fields, so malformed agent output falls back safely instead of being treated as a clean pass or auto-fixable result.\n- Restore the expected document review behavior by treating documentation gaps consistently for approval and fallback handling, including cases where structured output is incomplete or severity is omitted.\n- Update the docs and config examples to explain the document step and its auto-fix flow so the documented behavior matches the branch fixes."}

## Risk Assessment

✅ Low: The change is narrowly scoped to the document step's findings schema migration and fallback validation, and the updated behavior is covered by focused tests without exposing a clear correctness or safety regression.

## Pipeline

Updates from `git push no-mistakes`

✅ **Rebase** - passed
🔧 **Review** - 1 issue found → auto-fixed (3) + user-fixed (1)
✅ **Test** - passed
✅ **Lint** - passed

<details>
<summary>Review details</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/pipeline/steps/document.go:167` - After switching to `findingsSchema`, the code no longer validates that the parsed payload actually contains a `findings` array. A response like `{"summary":"docs status unavailable"}` unmarshals successfully into an empty `Findings`, so the step reports no documentation gaps and skips approval instead of treating the agent output as invalid.

**Round 2** (auto-fix) - found 2 issues (1 warning, 1 info)
- ⚠️ `internal/pipeline/steps/document.go:179` - Documentation gaps no longer trigger approval unless the agent labels them as `warning` or `error`, but the new prompt never requires a severity. If the agent emits an `info` finding for a real doc gap, the step will silently pass instead of requesting a documentation fix.
- ℹ️ `internal/pipeline/steps/document.go:167` - When structured output is present but malformed or missing `findings`, the fallback ignores any valid `summary` already returned in JSON and uses `result.Text` instead. Structured-only responses commonly leave `Text` empty, so operators can get the generic `agent returned no structured output` message instead of the agent's actual explanation.

**Round 3** (auto-fix) - found 1 warning
- ⚠️ `internal/pipeline/steps/document.go:360` - `unmarshalRequiredFindings` only verifies that the top-level `findings` array exists. If the agent returns finding objects missing required fields such as `requires_human_review`, `json.Unmarshal` fills zero values and the step will treat those malformed findings as auto-fixable instead of falling back to manual review. Validate each finding's required fields before accepting the payload.

**Round 4** (auto-fix) - found 2 warnings
- ⚠️ `internal/pipeline/steps/document.go:360` - `unmarshalRequiredFindings` no longer validates the top-level `summary`, so payloads like `{"findings":[]}` are accepted as a clean pass even though they violate the schema and bypass the fallback/manual-review path added for malformed agent output. Reject missing or blank summaries here as malformed too.
- ⚠️ `internal/pipeline/steps/document.go:381` - The new field validation only checks that `requires_human_review` is present, not that it is `false` as required by the document-step contract. If the model returns `true`, documentation gaps become non-autofixable and can block the normal doc-fix loop despite being objective issues.

**Round 5** (user-fix) - found 0 issues

</details>
