### PR TITLE
fix(tui): correct timer handling for fixing status

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1057,8 +1057,20 @@ func (m *Model) applyEvent(event ipc.Event) {
 		}
 		// Persist duration so the step continues to display its elapsed time.
 		// Prefer the event's execution-only duration; fall back to local timing.
-		// Skip for "fixing" status so stepsWithRunningElapsed keeps the timer ticking.
-		if event.StepName != nil && (event.Status == nil || types.StepStatus(*event.Status) != types.StepStatusFixing) {
+		// For "fixing" status, clear the persisted duration and back-date the
+		// start time by the accumulated execution so the live timer continues
+		// from where it left off rather than resetting to zero.
+		if event.StepName != nil && event.Status != nil && types.StepStatus(*event.Status) == types.StepStatusFixing {
+			var accumulated time.Duration
+			for _, s := range m.steps {
+				if s.StepName == *event.StepName && s.DurationMS != nil {
+					accumulated = time.Duration(*s.DurationMS) * time.Millisecond
+					break
+				}
+			}
+			m.setStepDuration(*event.StepName, nil)
+			m.stepStartTimes[*event.StepName] = time.Now().Add(-accumulated)
+		} else if event.StepName != nil {
 			if event.DurationMS != nil {
 				m.setStepDuration(*event.StepName, event.DurationMS)
 			} else if startTime, ok := m.stepStartTimes[*event.StepName]; ok {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -5603,6 +5603,70 @@ func TestModel_FixingEventDoesNotFreezeDuration(t *testing.T) {
 	t.Fatal("Review step not found")
 }
 
+// Test: When a step already has DurationMS persisted (e.g. from AwaitingApproval)
+// and then transitions to Fixing, the stale DurationMS must be cleared and the
+// live timer must accumulate from the previous execution time.
+func TestModel_FixingEventClearsStaleDuration(t *testing.T) {
+	configureTUIColors()
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusRunning
+
+	m := NewModel("", nil, run)
+	m.stepStartTimes[types.StepReview] = time.Now().Add(-10 * time.Second)
+
+	// Simulate step entering AwaitingApproval with 10s of persisted execution time.
+	awaitingStatus := string(types.StepStatusAwaitingApproval)
+	stepName := types.StepReview
+	dur := int64(10000)
+	m.applyEvent(ipc.Event{
+		Type:       ipc.EventStepCompleted,
+		StepName:   &stepName,
+		Status:     &awaitingStatus,
+		DurationMS: &dur,
+	})
+
+	// Verify duration was persisted.
+	for _, s := range m.steps {
+		if s.StepName == types.StepReview && s.DurationMS == nil {
+			t.Fatal("expected DurationMS to be set after AwaitingApproval event")
+		}
+	}
+
+	// Now simulate user pressing fix - step transitions to Fixing.
+	fixingStatus := string(types.StepStatusFixing)
+	m.applyEvent(ipc.Event{
+		Type:     ipc.EventStepCompleted,
+		StepName: &stepName,
+		Status:   &fixingStatus,
+	})
+
+	// DurationMS must be nil so stepsWithRunningElapsed computes live elapsed.
+	for _, s := range m.steps {
+		if s.StepName == types.StepReview {
+			if s.DurationMS != nil {
+				t.Errorf("expected DurationMS to be cleared when entering Fixing, got %d", *s.DurationMS)
+			}
+			break
+		}
+	}
+
+	// stepsWithRunningElapsed should accumulate: the 10s of prior execution
+	// plus a small amount of wall time since the Fixing event.
+	elapsed := m.stepsWithRunningElapsed()
+	for _, s := range elapsed {
+		if s.StepName == types.StepReview {
+			if s.DurationMS == nil {
+				t.Fatal("expected stepsWithRunningElapsed to compute live elapsed for Fixing step")
+			}
+			if *s.DurationMS < 9500 || *s.DurationMS > 11000 {
+				t.Errorf("expected accumulated elapsed ~10000ms, got %dms", *s.DurationMS)
+			}
+			return
+		}
+	}
+	t.Fatal("Review step not found")
+}
+
 func TestRenderDiff_BlankLineBetweenFiles(t *testing.T) {
 	// Multi-file diff should have a blank line before the second file header.
 	raw := `diff --git a/foo.go b/foo.go


### PR DESCRIPTION
## Summary

- When a step transitions to "fixing" status, the TUI now clears any stale persisted `DurationMS` and back-dates the start time by the accumulated execution so the live timer continues from where it left off instead of resetting to zero.
- Previously the code skipped persisting duration for fixing steps, but a stale `DurationMS` from a prior status (e.g. AwaitingApproval) would still freeze the displayed time. The new logic explicitly clears it and restores the running timer.
- Adds a regression test (`TestModel_FixingEventClearsStaleDuration`) covering the AwaitingApproval-to-Fixing transition. All pipeline checks (rebase, review, test, lint) pass.

## Risk Assessment

✅ Low: Small, well-tested TUI-only fix that corrects timer display during fixing status transitions; no behavioral, API, or data changes.

## Pipeline

Updates from `git push no-mistakes`

✅ **Rebase** - passed
✅ **Review** - passed
✅ **Test** - passed
✅ **Lint** - passed
