### PR TITLE
fix(pipeline): improve risk handling in PR summary and review

### DIFF
--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -85,6 +85,17 @@ func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, deta
 		}
 	}
 
+	// Parse latest round findings for risk fallback when final state is cleared.
+	var latestRoundFindings *types.Findings
+	if len(rounds) > 0 {
+		last := rounds[len(rounds)-1]
+		if last.FindingsJSON != nil {
+			if f, err := types.ParseFindingsJSON(*last.FindingsJSON); err == nil {
+				latestRoundFindings = &f
+			}
+		}
+	}
+
 	hadFindings := initialFindings != nil && len(initialFindings.Items) > 0
 	hasFinalFindings := finalFindings != nil && len(finalFindings.Items) > 0
 	hasAnyRoundFindings := roundsHaveFindings(rounds)
@@ -97,7 +108,7 @@ func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, deta
 	if sr.StepName == types.StepReview {
 		src := finalFindings
 		if src == nil && !hasUnreadableFinalFindings {
-			src = initialFindings
+			src = latestRoundFindings
 		}
 		if src != nil {
 			riskLevel = src.RiskLevel
@@ -178,9 +189,12 @@ func extractRiskLine(steps []*db.StepResult, rounds map[string][]*db.StepRound) 
 		src := finalFindings
 		if src == nil && !hasUnreadableFinal {
 			stepRounds := rounds[sr.ID]
-			if len(stepRounds) > 0 && stepRounds[0].FindingsJSON != nil {
-				if f, err := types.ParseFindingsJSON(*stepRounds[0].FindingsJSON); err == nil {
-					src = &f
+			if len(stepRounds) > 0 {
+				last := stepRounds[len(stepRounds)-1]
+				if last.FindingsJSON != nil {
+					if f, err := types.ParseFindingsJSON(*last.FindingsJSON); err == nil {
+						src = &f
+					}
 				}
 			}
 		}

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -377,6 +377,33 @@ func TestBuildPipelineSummary_FindingSeverityEmoji(t *testing.T) {
 	}
 }
 
+func TestBuildPipelineSummary_ReviewUsesLatestRoundNotFirst(t *testing.T) {
+	// When sr.FindingsJSON is nil (cleared), the fallback should use the
+	// latest round's risk assessment, not the first round's stale one.
+	initialFindings := `{"findings":[{"id":"review-1","severity":"warning","description":"issue"}],"summary":"1 warning","risk_level":"medium","risk_rationale":"initial concern"}`
+	latestFindings := `{"findings":[],"summary":"clean","risk_level":"low","risk_rationale":"issues resolved"}`
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepReview, Status: types.StepStatusCompleted, FindingsJSON: nil},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {
+			{Round: 1, Trigger: "initial", FindingsJSON: &initialFindings, DurationMS: 1000},
+			{Round: 2, Trigger: "auto_fix", FindingsJSON: &latestFindings, DurationMS: 700},
+		},
+	}
+	_, risk := BuildPipelineSummary(steps, rounds)
+
+	if strings.Contains(risk, "initial concern") {
+		t.Errorf("expected latest round risk, not stale first round, got: %q", risk)
+	}
+	if !strings.Contains(risk, "issues resolved") {
+		t.Errorf("expected latest round rationale, got: %q", risk)
+	}
+	if !strings.Contains(risk, "Low") {
+		t.Errorf("expected Low risk from latest round, got: %q", risk)
+	}
+}
+
 func TestBuildPipelineSummary_EmptySteps(t *testing.T) {
 	md, risk := BuildPipelineSummary(nil, nil)
 	if md != "" {

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -120,7 +120,14 @@ Previous review findings to address:
 
 	if !hasReviewableChanges {
 		sctx.Log("no changes to review")
-		return &pipeline.StepOutcome{}, nil
+		noChangeFindings := Findings{
+			RiskLevel:     "low",
+			RiskRationale: "no reviewable changes",
+		}
+		findingsJSON, _ := json.Marshal(noChangeFindings)
+		return &pipeline.StepOutcome{
+			Findings: string(findingsJSON),
+		}, nil
 	}
 
 	// Ask agent to review

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -3945,6 +3945,80 @@ func TestReviewStep_IgnorePatternsFilterAllFiles(t *testing.T) {
 	}
 }
 
+func TestReviewStep_EmptyDiff_ReturnsLowRisk(t *testing.T) {
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	os.WriteFile(filepath.Join(dir, "f.txt"), []byte("content"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	sha := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, sha, sha, config.Commands{})
+
+	step := &ReviewStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.Findings == "" {
+		t.Fatal("expected findings JSON with risk assessment for empty diff")
+	}
+
+	f, err := types.ParseFindingsJSON(outcome.Findings)
+	if err != nil {
+		t.Fatalf("failed to parse findings: %v", err)
+	}
+	if f.RiskLevel != "low" {
+		t.Errorf("RiskLevel = %q, want %q", f.RiskLevel, "low")
+	}
+	if f.RiskRationale == "" {
+		t.Error("expected non-empty RiskRationale for empty diff")
+	}
+}
+
+func TestReviewStep_IgnorePatternsFilterAllFiles_ReturnsLowRisk(t *testing.T) {
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	os.WriteFile(filepath.Join(dir, "base.txt"), []byte("base"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "base")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "schema.generated.go"), []byte("package gen\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "add generated")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Config.IgnorePatterns = []string{"*.generated.go"}
+
+	step := &ReviewStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.Findings == "" {
+		t.Fatal("expected findings JSON with risk assessment when all files ignored")
+	}
+
+	f, err := types.ParseFindingsJSON(outcome.Findings)
+	if err != nil {
+		t.Fatalf("failed to parse findings: %v", err)
+	}
+	if f.RiskLevel != "low" {
+		t.Errorf("RiskLevel = %q, want %q", f.RiskLevel, "low")
+	}
+}
+
 func TestReviewStep_FixMode_RequiresPreviousFindings(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 

--- a/internal/types/findings.go
+++ b/internal/types/findings.go
@@ -19,8 +19,8 @@ type Finding struct {
 type Findings struct {
 	Items         []Finding `json:"findings"`
 	Summary       string    `json:"summary"`
-	RiskLevel     string    `json:"risk_level,omitempty"`
-	RiskRationale string    `json:"risk_rationale,omitempty"`
+	RiskLevel     string    `json:"risk_level"`
+	RiskRationale string    `json:"risk_rationale"`
 }
 
 type findingsWire struct {

--- a/internal/types/findings_test.go
+++ b/internal/types/findings_test.go
@@ -192,6 +192,23 @@ func TestAutoFixableFindings_NoneHumanReview(t *testing.T) {
 	}
 }
 
+func TestMarshalFindingsJSON_AlwaysIncludesRiskFields(t *testing.T) {
+	f := Findings{
+		Items:   []Finding{{Severity: "info", Description: "note"}},
+		Summary: "ok",
+	}
+	raw, err := MarshalFindingsJSON(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(raw, `"risk_level"`) {
+		t.Errorf("expected risk_level to be present even when empty, got %s", raw)
+	}
+	if !strings.Contains(raw, `"risk_rationale"`) {
+		t.Errorf("expected risk_rationale to be present even when empty, got %s", raw)
+	}
+}
+
 func TestFinding_RequiresHumanReview_SerializedWhenFalse(t *testing.T) {
 	f := Finding{Severity: "error", Description: "bug", RequiresHumanReview: false}
 	raw, err := json.Marshal(f)


### PR DESCRIPTION
## Summary

- Fix PR summary risk fallback to use the latest review round instead of the first, so auto-fix rounds that clear issues correctly show the updated risk level
- Return a low-risk findings payload from the review step when there are no reviewable changes (empty diff or all files ignored), instead of returning an empty outcome that left risk assessment missing
- Remove `omitempty` from `risk_level` and `risk_rationale` JSON tags so these fields are always serialized, preventing silent drops during marshaling

## Risk Assessment

✅ Low: Straightforward bug fix that changes risk fallback from first round to latest round, adds explicit low-risk findings for empty diffs, and removes omitempty on risk fields - all well-tested and consistent with existing patterns.

## Pipeline

Updates from `git push no-mistakes`

✅ **Rebase** - passed
🔧 **Review** - 1 issue found → auto-fixed
✅ **Test** - passed
✅ **Lint** - passed

<details>
<summary>Review details</summary>

**Round 1** - found 1 info
- ℹ️ `internal/pipeline/steps/review.go:127` - json.Marshal error is discarded with `_` at line 127. This is safe in practice since the struct contains only string fields that can't fail marshaling, but a brief comment or wrapping with a nil-check would make the intent explicit.

**Round 2** (auto-fix) - found 0 issues

</details>
