### PR TITLE
fix(pr): unwrap nested PR body JSON and improve summary handling

### DIFF
--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -35,8 +35,8 @@ type prContent struct {
 var prContentSchema = json.RawMessage(`{
 	"type": "object",
 	"properties": {
-		"title": {"type": "string"},
-		"body": {"type": "string"}
+		"title": {"type": "string", "description": "Conventional commit PR title, e.g. fix(scope): short description"},
+		"body": {"type": "string", "description": "GitHub-flavored markdown body starting with ## Summary. Plain text, NOT JSON."}
 	},
 	"required": ["title", "body"]
 }`)
@@ -227,7 +227,7 @@ Context:
 Rules:
 - Cover the full branch delta, not just the latest commit.
 - Title must use conventional commit format: "type(scope): description" or "type: description". Valid types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert. Scope is optional. Do not capitalize the type. Do not use the raw branch name.
-- Body: a "## Summary" section in GitHub-flavored markdown. 1-3 concise bullet points describing what changed and why. Do not include a Testing section - pipeline results are appended separately.
+- Body: a "## Summary" section in GitHub-flavored markdown. 1-3 concise bullet points describing what changed and why. Do not include a Testing section - pipeline results are appended separately. The body value must be plain markdown text, never a JSON object or serialized JSON string.
 - Do not invent tests or behavior.
 
 Commit history:
@@ -252,6 +252,7 @@ Diff stat:
 		if err := json.Unmarshal(result.Output, &content); err == nil {
 			content.Title = strings.TrimSpace(content.Title)
 			content.Body = strings.TrimSpace(content.Body)
+			content.Body = unwrapNestedPRBody(content.Body)
 			if content.Title != "" && content.Body != "" {
 				if !isConventionalTitle(content.Title) {
 					slog.Warn("agent PR title is not conventional commit format, prepending chore:", "title", content.Title)
@@ -289,6 +290,23 @@ func (s *PRStep) buildPipelineSection(sctx *pipeline.StepContext) (string, strin
 	}
 
 	return BuildPipelineSummary(steps, rounds)
+}
+
+// unwrapNestedPRBody detects when the agent returned the body as a
+// serialized prContent JSON string and extracts the real markdown body.
+func unwrapNestedPRBody(body string) string {
+	if len(body) == 0 || body[0] != '{' {
+		return body
+	}
+	var nested prContent
+	if err := json.Unmarshal([]byte(body), &nested); err != nil {
+		return body
+	}
+	if strings.TrimSpace(nested.Body) != "" {
+		slog.Warn("agent returned nested JSON in PR body, unwrapping")
+		return strings.TrimSpace(nested.Body)
+	}
+	return body
 }
 
 // appendPipelineSection appends the pipeline markdown after the agent's body.

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -2929,6 +2929,42 @@ func TestPRStep_UsesAgentGeneratedTitleAndBody(t *testing.T) {
 	}
 }
 
+func TestPRStep_UnwrapsNestedJSONBody(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	binDir, logFile := fakeGH(t, "")
+	prependPATH(t, binDir)
+
+	// Agent returns body as the serialized prContent JSON (the bug LLMs sometimes produce).
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			payload := json.RawMessage(`{"title":"fix: improve pipeline header UX","body":"{\"title\":\"fix: improve pipeline header UX\",\"body\":\"## Summary\\n\\n- keep branch status readable\\n- fix footer truncation\"}"}`)
+			return &agent.Result{Output: payload}, nil
+		},
+	}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+
+	step := &PRStep{}
+	if _, err := step.Execute(sctx); err != nil {
+		t.Fatal(err)
+	}
+
+	logData, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ghLog := string(logData)
+
+	// The guard should unwrap the nested body and use the real markdown.
+	if !strings.Contains(ghLog, "keep branch status readable") {
+		t.Fatalf("expected unwrapped PR body in gh call, got:\n%s", ghLog)
+	}
+	if strings.Contains(ghLog, `"title"`) {
+		t.Fatalf("expected JSON wrapper to be stripped from PR body, got:\n%s", ghLog)
+	}
+}
+
 func fakeGlab(t *testing.T, mrViewJSON string) (binDir string, logFile string) {
 	t.Helper()
 	binDir = fakeCLIBinDir(t)

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -2965,6 +2965,29 @@ func TestPRStep_UnwrapsNestedJSONBody(t *testing.T) {
 	}
 }
 
+func TestUnwrapNestedPRBody(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "empty string", body: "", want: ""},
+		{name: "plain markdown", body: "## Summary\n\n- bullet one", want: "## Summary\n\n- bullet one"},
+		{name: "invalid JSON starting with brace", body: "{not valid json", want: "{not valid json"},
+		{name: "valid JSON but empty nested body", body: `{"title":"fix: stuff","body":""}`, want: `{"title":"fix: stuff","body":""}`},
+		{name: "nested JSON body is unwrapped", body: `{"title":"fix: stuff","body":"## Summary\n\n- real body"}`, want: "## Summary\n\n- real body"},
+		{name: "nested JSON body with whitespace", body: `{"title":"fix: stuff","body":"  ## Summary  "}`, want: "## Summary"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := unwrapNestedPRBody(tt.body)
+			if got != tt.want {
+				t.Errorf("unwrapNestedPRBody(%q) = %q, want %q", tt.body, got, tt.want)
+			}
+		})
+	}
+}
+
 func fakeGlab(t *testing.T, mrViewJSON string) (binDir string, logFile string) {
 	t.Helper()
 	binDir = fakeCLIBinDir(t)


### PR DESCRIPTION
## Summary

- Fix a bug where the agent sometimes returns the PR body as a nested JSON string instead of plain markdown, causing raw JSON to appear in the PR description. Added `unwrapNestedPRBody` to detect and extract the real markdown body.
- Improved the structured output schema descriptions to explicitly tell the agent the body must be plain markdown, not JSON.
- Added unit and integration tests covering the unwrap logic and the end-to-end nested body scenario. All pipeline checks pass.

## Risk Assessment

✅ Low: Defensive fix for a known LLM output bug, with a clean unwrap function that falls back safely, good test coverage, and no behavioral change for well-formed inputs.

## Pipeline

Updates from `git push no-mistakes`

✅ **Rebase** - passed
✅ **Review** - passed
✅ **Test** - passed
✅ **Lint** - passed
