### PR TITLE
fix(agent): retry when Claude returns no structured output

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -429,8 +430,39 @@ func TestClaudeAgent_FinalizeResult_WithSchemaRequiresStructuredOutput(t *testin
 	if err == nil {
 		t.Fatal("expected error when structured output is missing")
 	}
-	if !strings.Contains(err.Error(), "no structured output") {
-		t.Fatalf("expected no structured output error, got: %v", err)
+	if !errors.Is(err, errNoStructuredOutput) {
+		t.Fatalf("expected errNoStructuredOutput, got: %v", err)
+	}
+}
+
+func TestClaudeAgent_FinalizeResult_ErrorSubtypeNotRetryable(t *testing.T) {
+	_, err := finalizeClaudeResult(&claudeResult{Subtype: "error", IsError: true}, json.RawMessage(`{"type":"object"}`), TokenUsage{})
+	if err == nil {
+		t.Fatal("expected error for error subtype")
+	}
+	if errors.Is(err, errNoStructuredOutput) {
+		t.Fatal("error subtype should not be retryable")
+	}
+}
+
+func TestParseClaudeEvents_ResultCapturesRawEvent(t *testing.T) {
+	events := `{"type":"result","subtype":"success","is_error":false,"structured_output":null}` + "\n"
+
+	var usage TokenUsage
+	var result *claudeResult
+
+	err := parseClaudeEvents(context.Background(), strings.NewReader(events), nil, &usage, &result)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected result event")
+	}
+	if result.rawEvent == nil {
+		t.Fatal("expected rawEvent to be captured")
+	}
+	if !strings.Contains(string(result.rawEvent), `"subtype":"success"`) {
+		t.Errorf("rawEvent should contain original JSON, got: %s", string(result.rawEvent))
 	}
 }
 

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -4,11 +4,17 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
 	"sync"
 )
+
+const claudeMaxRetries = 3
+
+// errNoStructuredOutput is returned when Claude succeeds but omits structured output.
+var errNoStructuredOutput = errors.New("claude returned no structured output")
 
 const claudeScannerMaxTokenSize = 256 * 1024 * 1024
 
@@ -20,6 +26,27 @@ type claudeAgent struct {
 func (a *claudeAgent) Name() string { return "claude" }
 
 func (a *claudeAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
+	var lastErr error
+	for attempt := 1; attempt <= claudeMaxRetries; attempt++ {
+		if attempt > 1 {
+			if opts.OnChunk != nil {
+				opts.OnChunk(fmt.Sprintf("retrying (attempt %d/%d) - previous attempt returned no structured output", attempt, claudeMaxRetries))
+			}
+		}
+
+		result, err := a.runOnce(ctx, opts)
+		if err == nil {
+			return result, nil
+		}
+		if !errors.Is(err, errNoStructuredOutput) {
+			return nil, err
+		}
+		lastErr = err
+	}
+	return nil, lastErr
+}
+
+func (a *claudeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 	args := a.buildArgs(opts.Prompt, opts.JSONSchema)
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD
@@ -64,7 +91,13 @@ func (a *claudeAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
 		return nil, fmt.Errorf("claude returned no result event")
 	}
 
-	return finalizeClaudeResult(result, opts.JSONSchema, usage)
+	res, err := finalizeClaudeResult(result, opts.JSONSchema, usage)
+	if errors.Is(err, errNoStructuredOutput) && opts.OnChunk != nil {
+		opts.OnChunk(fmt.Sprintf("structured output missing: subtype=%s, text_len=%d, input_tokens=%d, output_tokens=%d",
+			result.Subtype, len(result.text), usage.InputTokens, usage.OutputTokens))
+		opts.OnChunk(fmt.Sprintf("raw result event: %s", string(result.rawEvent)))
+	}
+	return res, err
 }
 
 func (a *claudeAgent) Close() error { return nil }
@@ -74,7 +107,7 @@ func finalizeClaudeResult(result *claudeResult, schema json.RawMessage, usage To
 		return nil, fmt.Errorf("claude error: subtype=%s", result.Subtype)
 	}
 	if len(schema) > 0 && result.StructuredOutput == nil {
-		return nil, fmt.Errorf("claude returned no structured output")
+		return nil, errNoStructuredOutput
 	}
 
 	return &Result{
@@ -116,6 +149,7 @@ type claudeResult struct {
 	IsError          bool
 	StructuredOutput json.RawMessage
 	text             string // accumulated text from assistant events
+	rawEvent         json.RawMessage
 }
 
 type claudeUsage struct {
@@ -182,11 +216,14 @@ func parseClaudeEvents(ctx context.Context, r io.Reader, onChunk func(string), u
 
 		case "result":
 			if result != nil {
+				raw := make(json.RawMessage, len(line))
+				copy(raw, line)
 				*result = &claudeResult{
 					Subtype:          event.Subtype,
 					IsError:          event.IsError,
 					StructuredOutput: event.StructuredOutput,
 					text:             textBuf,
+					rawEvent:         raw,
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

- Claude CLI occasionally returns a successful result but omits the expected structured output, causing the pipeline step to fail. This adds a retry loop (up to 3 attempts) for that specific failure mode, leaving all other errors untouched.
- Captures the raw result event JSON for diagnostic logging when structured output is missing, making it easier to debug why Claude dropped it.
- Pipeline passes cleanly - one informational note that retries re-consume input tokens, which is an acceptable tradeoff vs getting no result at all.

## Risk Assessment

✅ Low: Well-scoped retry mechanism with proper error discrimination, context cancellation passthrough, correct buffer handling, and good test coverage - straightforward resilience improvement.

## Pipeline

Updates from `git push no-mistakes`

✅ **Rebase** - passed
⚠️ **Review** - 1 info
✅ **Test** - passed
✅ **Lint** - passed

<details>
<summary>Review details</summary>

**Round 1** - found 1 info
- ℹ️ `internal/agent/claude.go:30` - The retry loop in Run() (line 30) spawns a fresh Claude CLI subprocess per attempt, re-consuming all input tokens each time. With claudeMaxRetries=3, worst case triples token cost for a single call. This is likely acceptable given the alternative (no result at all), but worth being aware of for cost monitoring.

</details>
