### PR TITLE
fix(config): enable rebase auto-fix by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ ci_timeout: "4h"
 
 # Optional auto-fix attempt limits per step (0 = require approval).
 # auto_fix:
-#   rebase: 0
+#   rebase: 3
 #   lint: 3
 #   test: 3
 #   review: 3
@@ -195,7 +195,7 @@ log_level: "info"
 
 # Maximum auto-fix attempts per step (0 = disabled, requires manual approval)
 auto_fix:
-  rebase: 0
+  rebase: 3
   lint: 3
   test: 3
   review: 3

--- a/docs/src/content/docs/guides/auto-fix.md
+++ b/docs/src/content/docs/guides/auto-fix.md
@@ -22,7 +22,7 @@ Set limits in global or repo config:
 
 ```yaml
 auto_fix:
-  rebase: 0    # 0 = disabled, always requires manual approval
+  rebase: 3
   review: 3    # up to 3 auto-fix attempts
   test: 3
   document: 3
@@ -30,7 +30,7 @@ auto_fix:
   ci: 3
 ```
 
-Setting a step to `0` means the pipeline always pauses for human input when that step finds issues. This is the default for `rebase` since conflict resolution is high-risk.
+Setting a step to `0` means the pipeline always pauses for human input when that step finds issues.
 
 Repo config overlays global config - you can set `auto_fix.lint: 5` in a repo's `.no-mistakes.yaml` to override just that step while inheriting the rest from global.
 

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -37,7 +37,7 @@ log_level: info  # debug | info | warn | error
 
 # Max auto-fix attempts per step. 0 = disabled (requires manual approval).
 auto_fix:
-  rebase: 0
+  rebase: 3
   document: 3
   lint: 3
   test: 3

--- a/docs/src/content/docs/guides/pipeline-steps.md
+++ b/docs/src/content/docs/guides/pipeline-steps.md
@@ -24,7 +24,7 @@ Fetches the latest upstream and rebases your branch onto it.
 
 **Auto-fix:** when enabled, the agent resolves conflict markers, stages files, and runs `git rebase --continue`. Commits use the message format `no-mistakes(rebase): <summary>`.
 
-**Default auto-fix limit:** `0` (disabled - conflicts always require manual approval).
+**Default auto-fix limit:** `3`.
 
 ## Review
 

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -21,7 +21,7 @@ ci_timeout: "4h"
 log_level: info
 
 auto_fix:
-  rebase: 0
+  rebase: 3
   review: 3
   test: 3
   document: 3
@@ -92,7 +92,7 @@ Maximum auto-fix attempts per step. Set a step to `0` to disable auto-fix (findi
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `auto_fix.rebase` | `int` | `0` | Disabled by default - conflicts always require approval |
+| `auto_fix.rebase` | `int` | `3` | Rebase conflict auto-fix attempts |
 | `auto_fix.review` | `int` | `3` | Review finding auto-fix attempts |
 | `auto_fix.test` | `int` | `3` | Test failure auto-fix attempts |
 | `auto_fix.document` | `int` | `3` | Documentation update auto-fix attempts |

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -20,7 +20,7 @@ ignore_patterns:
   - "vendor/**"
 
 auto_fix:
-  rebase: 0
+  rebase: 3
   review: 3
   test: 3
   document: 3
@@ -98,7 +98,7 @@ Override auto-fix attempt limits for specific steps. Fields not set here inherit
 
 | Field | Type | Default |
 |---|---|---|
-| `auto_fix.rebase` | `int` | Inherits from global (default `0`) |
+| `auto_fix.rebase` | `int` | Inherits from global (default `3`) |
 | `auto_fix.review` | `int` | Inherits from global (default `3`) |
 | `auto_fix.test` | `int` | Inherits from global (default `3`) |
 | `auto_fix.document` | `int` | Inherits from global (default `3`) |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -102,7 +102,7 @@ log_level: info
 
 # Maximum auto-fix attempts per step (0 = disabled, requires manual approval)
 auto_fix:
-  rebase: 0
+  rebase: 3
   lint: 3
   test: 3
   review: 3
@@ -248,7 +248,7 @@ func autoFixDefaults() AutoFix {
 		Review:   3,
 		Document: 3,
 		CI:       3,
-		Rebase:   0,
+		Rebase:   3,
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -632,8 +632,8 @@ func TestMerge_AutoFixDefaults(t *testing.T) {
 	if cfg.AutoFix.CI != 3 {
 		t.Errorf("ci = %d, want 3", cfg.AutoFix.CI)
 	}
-	if cfg.AutoFix.Rebase != 0 {
-		t.Errorf("rebase = %d, want 0", cfg.AutoFix.Rebase)
+	if cfg.AutoFix.Rebase != 3 {
+		t.Errorf("rebase = %d, want 3", cfg.AutoFix.Rebase)
 	}
 }
 
@@ -658,8 +658,8 @@ func TestMerge_AutoFixGlobalOverridesDefaults(t *testing.T) {
 	if cfg.AutoFix.CI != 0 {
 		t.Errorf("ci =%d, want 0 (global override)", cfg.AutoFix.CI)
 	}
-	if cfg.AutoFix.Rebase != 0 {
-		t.Errorf("rebase = %d, want 0 (default, no override)", cfg.AutoFix.Rebase)
+	if cfg.AutoFix.Rebase != 3 {
+		t.Errorf("rebase = %d, want 3 (default, no override)", cfg.AutoFix.Rebase)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Change the runtime default for `auto_fix.rebase` from `0` to `3`, so repos that do not set this value now opt into agent-driven rebase conflict autofix by default.
- Update the README and config/reference guides to document the new default and keep user-facing setup guidance consistent with the shipped behavior.

## Risk Assessment

🚨 High: This patch is mechanically small, but it flips a previously manual, history-rewriting rebase flow to automatic for all configs that do not already pin `auto_fix.rebase`, which is a broad behavioral change with non-trivial rollout risk.

## Pipeline

Updates from `git push no-mistakes`

✅ **Rebase** - passed
⚠️ **Review** - 1 warning
✅ **Test** - passed
✅ **Lint** - passed

<details>
<summary>Review details</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/config/config.go:251` - Changing the runtime default `AutoFix.Rebase` from `0` to `3` silently opts every existing install whose config omits `auto_fix.rebase` into agent-driven rebase conflict resolution. Unlike lint/test autofixes, this path rewrites git history and can auto-author conflict resolutions, so it is a breaking behavior change unless you explicitly want old configs to inherit the new default.

</details>
