### PR TITLE
fix(prsummary): link the pipeline summary tagline

### DIFF
--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -45,7 +45,7 @@ func BuildPipelineSummary(steps []*db.StepResult, rounds map[string][]*db.StepRo
 	}
 
 	var b strings.Builder
-	b.WriteString("## Pipeline\n\nUpdates from `git push no-mistakes`\n\n")
+	b.WriteString("## Pipeline\n\nUpdates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)\n\n")
 	for _, line := range statusLines {
 		b.WriteString(line)
 		b.WriteString("\n")

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -24,11 +24,8 @@ func TestBuildPipelineSummary_AllClean(t *testing.T) {
 	if !strings.Contains(md, "## Pipeline") {
 		t.Error("missing Pipeline heading")
 	}
-	if !strings.Contains(md, "Updates from `git push no-mistakes`") {
-		t.Error("missing pipeline tagline")
-	}
-	if strings.Contains(md, "https://github.com/kunchenguid/no-mistakes") {
-		t.Error("did not expect hardcoded repository link in pipeline tagline")
+	if !strings.Contains(md, "[git push no-mistakes](https://github.com/kunchenguid/no-mistakes)") {
+		t.Errorf("expected linked tagline, got:\n%s", md)
 	}
 	// Clean steps should show checkmark
 	if !strings.Contains(md, "✅") {


### PR DESCRIPTION
## Summary
- Update the PR summary pipeline tagline to render as a link to the `no-mistakes` repository in generated PR bodies.
- Simplify `prsummary` test expectations to match the linked tagline output.

## Risk Assessment

🚨 High: This is a small diff, but it introduces a clear user-facing regression in generated PR content for every repository except this one.

## Pipeline

Updates from `git push no-mistakes`

✅ **Rebase** - passed
⚠️ **Review** - 1 error
✅ **Test** - passed
✅ **Lint** - passed

<details>
<summary>Review details</summary>

**Round 1** - found 1 error
- 🚨 `internal/pipeline/steps/prsummary.go:48` - The pipeline tagline now hardcodes `https://github.com/kunchenguid/no-mistakes`, so every generated PR body in every customer repository will point readers to this tool's repo instead of the repo being reviewed. That is misleading user-facing output and breaks multi-repo use of the CLI.

</details>
