### PR TITLE
feat(pipeline): skip remaining steps on empty diff

### DIFF
--- a/docs/src/content/docs/guides/pipeline-steps.md
+++ b/docs/src/content/docs/guides/pipeline-steps.md
@@ -20,6 +20,7 @@ Fetches the latest upstream and rebases your branch onto it.
 - If the branch is not the default branch, tries rebasing onto `origin/<branch>` first, then `origin/<default_branch>`
 - Skips targets that don't exist or are already ancestors
 - If a fast-forward is possible, does a hard-reset instead of a rebase
+- If the diff against the default branch is empty after rebase, completes rebase and skips all remaining pipeline steps
 - On conflict: records conflicting files, aborts the rebase, and reports findings
 
 **Auto-fix:** when enabled, the agent resolves conflict markers, stages files, and runs `git rebase --continue`. Commits use the message format `no-mistakes(rebase): <summary>`.
@@ -141,5 +142,5 @@ Each step progresses through these statuses:
 | `awaiting_approval` | Paused, waiting for user action |
 | `fix_review` | Paused after a fix cycle, showing results for review |
 | `completed` | Finished successfully |
-| `skipped` | User chose to skip |
+| `skipped` | User chose to skip, or the pipeline skipped it automatically |
 | `failed` | Step failed |

--- a/docs/src/content/docs/guides/pipeline-steps.md
+++ b/docs/src/content/docs/guides/pipeline-steps.md
@@ -9,7 +9,7 @@ The pipeline runs a fixed sequence of steps. The order is not configurable - thi
 rebase → review → test → document → lint → push → pr → babysit
 ```
 
-Each step can produce findings, request approval, or trigger auto-fix. Steps that encounter fatal errors stop the pipeline. Steps can also be skipped by the user.
+Each step can produce findings, request approval, or trigger auto-fix. Steps that encounter fatal errors stop the pipeline. Steps can also be skipped by the user or automatically by the pipeline.
 
 ## Rebase
 

--- a/docs/src/content/docs/guides/tui.md
+++ b/docs/src/content/docs/guides/tui.md
@@ -137,7 +137,7 @@ The `f fix (3/5)` label shows how many findings are selected out of the total.
 
 When a run finishes, a one-line banner appears:
 
-- `✓ Pipeline passed  4.2s` (green) - all steps completed
+- `✓ Pipeline passed  4.2s` (green) - the run finished successfully, even if later steps were auto-skipped
 - `✗ Review failed  1.8s` (red) - names the failing step
 - `✗ Pipeline cancelled` (red) - user aborted
 

--- a/docs/src/content/docs/how-it-works.md
+++ b/docs/src/content/docs/how-it-works.md
@@ -64,7 +64,7 @@ On startup, the daemon recovers from crashes by marking any stuck runs as failed
 
 ### Pipeline executor
 
-The executor runs each step sequentially and manages the approval/fix loop:
+The executor runs each step sequentially and manages the approval/fix loop. It can also end early after `rebase` if the branch has no diff against the default branch, marking the remaining steps as skipped.
 
 1. Execute the step
 2. If the step finds issues and auto-fix is enabled, loop back with the agent to fix them (up to the configured limit)

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -107,14 +107,26 @@ func (e *Executor) Execute(ctx context.Context, run *db.Run, repo *db.Repo, work
 	}
 
 	// Execute steps sequentially
-	for _, step := range e.steps {
+	for i, step := range e.steps {
 		if ctx.Err() != nil {
 			return e.failRun(run, repo, context.Cause(ctx))
 		}
 
 		sr := stepRecords[step.Name()]
-		if err := e.executeStep(ctx, step, sr, run, repo, workDir, logDir); err != nil {
+		skipRemaining, err := e.executeStep(ctx, step, sr, run, repo, workDir, logDir)
+		if err != nil {
 			return e.failRun(run, repo, err, ctx)
+		}
+		if skipRemaining {
+			// Mark all subsequent steps as skipped
+			for _, remaining := range e.steps[i+1:] {
+				rsr := stepRecords[remaining.Name()]
+				if dbErr := e.db.UpdateStepStatus(rsr.ID, types.StepStatusSkipped); dbErr != nil {
+					slog.Warn("failed to mark step as skipped", "step", remaining.Name(), "error", dbErr)
+				}
+				e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, remaining.Name(), string(types.StepStatusSkipped), "", "", "", nil)
+			}
+			break
 		}
 	}
 
@@ -128,14 +140,15 @@ func (e *Executor) Execute(ctx context.Context, run *db.Run, repo *db.Repo, work
 }
 
 // executeStep runs a single step with approval coordination.
-func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult, run *db.Run, repo *db.Repo, workDir, logDir string) error {
+// Returns (skipRemaining, error).
+func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult, run *db.Run, repo *db.Repo, workDir, logDir string) (bool, error) {
 	stepName := step.Name()
 	logPath := filepath.Join(logDir, string(stepName)+".log")
 	finalExitCode := 0
 
 	// Mark step as running
 	if err := e.db.StartStep(sr.ID); err != nil {
-		return fmt.Errorf("start step %s: %w", stepName, err)
+		return false, fmt.Errorf("start step %s: %w", stepName, err)
 	}
 	e.emitStepEvent(ipc.EventStepStarted, run, repo, stepName, string(types.StepStatusRunning))
 
@@ -146,7 +159,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 	// Open log file for persistent step logging
 	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 	if err != nil {
-		return fmt.Errorf("create step log file %s: %w", stepName, err)
+		return false, fmt.Errorf("create step log file %s: %w", stepName, err)
 	}
 	defer logFile.Close()
 
@@ -176,6 +189,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 	autoFixAttempts := 0
 	roundNum := 0
 	nextTrigger := "initial"
+	skipRemaining := false
 
 	// Execute with possible fix loop
 	for {
@@ -188,7 +202,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 				slog.Warn("failed to mark step as failed in db", "step", stepName, "error", dbErr)
 			}
 			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFailed), "", "", err.Error(), &durationMS)
-			return fmt.Errorf("step %s failed: %w", stepName, err)
+			return false, fmt.Errorf("step %s failed: %w", stepName, err)
 		}
 
 		outcome.Findings = normalizeFindingsJSON(outcome.Findings, string(stepName))
@@ -245,6 +259,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			// Step completed without needing approval.
 			// Any remaining info-only or human-review-only findings
 			// are acceptable and don't block the pipeline.
+			skipRemaining = outcome.SkipRemaining
 			break
 		}
 
@@ -287,7 +302,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 				slog.Warn("failed to mark step as failed in db", "step", stepName, "error", dbErr)
 			}
 			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFailed), "", "", err.Error(), &executionMS)
-			return fmt.Errorf("step %s: waiting for approval: %w", stepName, err)
+			return false, fmt.Errorf("step %s: waiting for approval: %w", stepName, err)
 		}
 
 		switch response.action {
@@ -300,20 +315,20 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 		case types.ActionSkip:
 			// Skip - mark step skipped and return (not an error)
 			if err := e.db.CompleteStep(sr.ID, finalExitCode, executionMS, logPath); err != nil {
-				return fmt.Errorf("complete step %s (skip): %w", stepName, err)
+				return false, fmt.Errorf("complete step %s (skip): %w", stepName, err)
 			}
 			if dbErr := e.db.UpdateStepStatus(sr.ID, types.StepStatusSkipped); dbErr != nil {
 				slog.Warn("failed to update step status in db", "step", stepName, "status", "skipped", "error", dbErr)
 			}
 			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusSkipped), "", "", "", &executionMS)
-			return nil
+			return false, nil
 
 		case types.ActionAbort:
 			if dbErr := e.db.FailStep(sr.ID, "aborted by user", executionMS); dbErr != nil {
 				slog.Warn("failed to mark step as failed in db", "step", stepName, "error", dbErr)
 			}
 			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFailed), "", "", "aborted by user", &executionMS)
-			return fmt.Errorf("step %s: aborted by user", stepName)
+			return false, fmt.Errorf("step %s: aborted by user", stepName)
 
 		case types.ActionFix:
 			// Fix - mark step as fixing, resume execution timer, re-execute.
@@ -338,10 +353,10 @@ done:
 	// Mark step completed with execution-only timing.
 	durationMS := executionMS + time.Since(phaseStart).Milliseconds()
 	if err := e.db.CompleteStep(sr.ID, finalExitCode, durationMS, logPath); err != nil {
-		return fmt.Errorf("complete step %s: %w", stepName, err)
+		return false, fmt.Errorf("complete step %s: %w", stepName, err)
 	}
 	e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusCompleted), "", "", "", &durationMS)
-	return nil
+	return skipRemaining, nil
 }
 
 // waitForApproval blocks until a user action arrives or context is cancelled.

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -121,6 +121,9 @@ func (e *Executor) Execute(ctx context.Context, run *db.Run, repo *db.Repo, work
 			// Mark all subsequent steps as skipped
 			for _, remaining := range e.steps[i+1:] {
 				rsr := stepRecords[remaining.Name()]
+				if dbErr := e.db.CompleteStep(rsr.ID, 0, 0, ""); dbErr != nil {
+					slog.Warn("failed to finalize skipped step", "step", remaining.Name(), "error", dbErr)
+				}
 				if dbErr := e.db.UpdateStepStatus(rsr.ID, types.StepStatusSkipped); dbErr != nil {
 					slog.Warn("failed to mark step as skipped", "step", remaining.Name(), "error", dbErr)
 				}

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -2267,6 +2267,64 @@ func writeTestFile(t *testing.T, dir, name, content string) {
 	}
 }
 
+func TestExecutor_SkipRemaining_SkipsSubsequentSteps(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	skipStep := &mockStep{
+		name:    types.StepRebase,
+		outcome: &StepOutcome{ExitCode: 0, SkipRemaining: true},
+	}
+	reviewStep := newPassStep(types.StepReview)
+	testStep := newPassStep(types.StepTest)
+
+	steps := []Step{skipStep, reviewStep, testStep}
+	exec := NewExecutor(database, p, nil, nil, steps, nil)
+	events := collectEvents(exec)
+
+	err := exec.Execute(context.Background(), run, repo, workDir)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// Run should be completed
+	updated, _ := database.GetRun(run.ID)
+	if updated.Status != types.RunCompleted {
+		t.Errorf("expected run status %q, got %q", types.RunCompleted, updated.Status)
+	}
+
+	// The rebase step should be completed
+	dbSteps, _ := database.GetStepsByRun(run.ID)
+	if len(dbSteps) != 3 {
+		t.Fatalf("expected 3 steps, got %d", len(dbSteps))
+	}
+	if dbSteps[0].Status != types.StepStatusCompleted {
+		t.Errorf("rebase step: expected status %q, got %q", types.StepStatusCompleted, dbSteps[0].Status)
+	}
+
+	// Subsequent steps should be skipped
+	for _, s := range dbSteps[1:] {
+		if s.Status != types.StepStatusSkipped {
+			t.Errorf("step %s: expected status %q, got %q", s.StepName, types.StepStatusSkipped, s.Status)
+		}
+	}
+
+	// Subsequent steps should NOT have been executed
+	if reviewStep.callCount() != 0 {
+		t.Errorf("review step was called %d times, expected 0", reviewStep.callCount())
+	}
+	if testStep.callCount() != 0 {
+		t.Errorf("test step was called %d times, expected 0", testStep.callCount())
+	}
+
+	// Should have completed events for all steps
+	for _, name := range []types.StepName{types.StepRebase, types.StepReview, types.StepTest} {
+		if e := events.find(ipc.EventStepCompleted, name); e == nil {
+			t.Errorf("missing step_completed event for %s", name)
+		}
+	}
+}
+
 func TestExecutor_StepOutcomePRURL_EmitsRunUpdated(t *testing.T) {
 	database, p, run, repo := setupTest(t)
 	workDir := t.TempDir()

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -2307,6 +2307,9 @@ func TestExecutor_SkipRemaining_SkipsSubsequentSteps(t *testing.T) {
 		if s.Status != types.StepStatusSkipped {
 			t.Errorf("step %s: expected status %q, got %q", s.StepName, types.StepStatusSkipped, s.Status)
 		}
+		if s.CompletedAt == nil {
+			t.Errorf("step %s: completed_at should be set for skipped steps", s.StepName)
+		}
 	}
 
 	// Subsequent steps should NOT have been executed

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -32,6 +32,7 @@ type StepOutcome struct {
 	Findings      string // JSON findings for TUI display (optional)
 	ExitCode      int    // process exit code (0 = success)
 	PRURL         string // PR/MR URL if this step created or found one
+	SkipRemaining bool   // skip all subsequent steps (e.g. empty diff after rebase)
 }
 
 // Step is the interface that each pipeline step implements.

--- a/internal/pipeline/steps/rebase.go
+++ b/internal/pipeline/steps/rebase.go
@@ -264,7 +264,8 @@ func dedupeRebaseFindings(findings []Finding) []Finding {
 	return filtered
 }
 
-// updateHeadSHA syncs the run's head SHA after rebase.
+// updateHeadSHA syncs the run's head SHA after rebase and checks for an empty diff.
+// When the branch diff against the default branch is empty, SkipRemaining is set.
 func updateHeadSHA(ctx context.Context, sctx *pipeline.StepContext) (*pipeline.StepOutcome, error) {
 	headSHA, err := git.HeadSHA(ctx, sctx.WorkDir)
 	if err != nil {
@@ -277,6 +278,20 @@ func updateHeadSHA(ctx context.Context, sctx *pipeline.StepContext) (*pipeline.S
 		}
 		sctx.Log(fmt.Sprintf("updated head SHA to %s", shortSHA(headSHA)))
 	}
+
+	// Check if the branch has any diff against the default branch.
+	// If the diff is empty (e.g. branch was already merged), skip remaining steps.
+	defaultBranch := strings.TrimSpace(sctx.Repo.DefaultBranch)
+	if defaultBranch == "" {
+		defaultBranch = "main"
+	}
+	baseSHA := resolveBranchBaseSHA(ctx, sctx.WorkDir, sctx.Run.BaseSHA, defaultBranch)
+	diff, err := git.Diff(ctx, sctx.WorkDir, baseSHA, "HEAD")
+	if err == nil && strings.TrimSpace(diff) == "" {
+		sctx.Log("empty diff after rebase, skipping remaining steps")
+		return &pipeline.StepOutcome{SkipRemaining: true}, nil
+	}
+
 	return &pipeline.StepOutcome{}, nil
 }
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -891,6 +891,96 @@ func TestRebaseStep_LogFileNotVisibleToUser(t *testing.T) {
 	}
 }
 
+func TestRebaseStep_EmptyDiffAfterRebase_SkipsRemaining(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	os.WriteFile(filepath.Join(dir, "app.txt"), []byte("base\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "base commit")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	// Feature branch with a change
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature commit")
+	featureHeadSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	// Merge feature into main upstream so after rebase, diff is empty
+	gitCmd(t, dir, "checkout", "main")
+	gitCmd(t, dir, "merge", "feature")
+	gitCmd(t, dir, "push", "origin", "main")
+	gitCmd(t, dir, "checkout", "feature")
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, featureHeadSHA, config.Commands{})
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Repo.UpstreamURL = upstream
+
+	step := &RebaseStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.SkipRemaining {
+		t.Error("expected SkipRemaining=true when diff is empty after rebase")
+	}
+}
+
+func TestRebaseStep_NonEmptyDiffAfterRebase_DoesNotSkip(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	os.WriteFile(filepath.Join(dir, "app.txt"), []byte("base\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "base commit")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	// Feature branch with a unique change
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature commit")
+	featureHeadSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	// Main has separate changes (not merging feature), so diff should be non-empty
+	gitCmd(t, dir, "checkout", "main")
+	os.WriteFile(filepath.Join(dir, "app.txt"), []byte("base\nmain update\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "main update")
+	gitCmd(t, dir, "push", "origin", "main")
+	gitCmd(t, dir, "checkout", "feature")
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, featureHeadSHA, config.Commands{})
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Repo.UpstreamURL = upstream
+
+	step := &RebaseStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.SkipRemaining {
+		t.Error("expected SkipRemaining=false when diff is non-empty after rebase")
+	}
+}
+
 // --- Review step tests ---
 
 func TestReviewStep_EmptyDiff(t *testing.T) {


### PR DESCRIPTION
## Summary
- Stop the pipeline early when a step produces an empty diff, so later steps are skipped instead of running against no-op changes.
- Finalize skipped steps correctly in pipeline state and cover the empty-diff and rebase-skip paths with tests to make the behavior explicit.
- Update pipeline and TUI docs so the auto-skip behavior is documented for users.

## Risk Assessment

✅ Low: The change is narrowly scoped, covered by focused tests for both the rebase empty-diff case and executor skip propagation, and I did not find a concrete correctness or regression issue in the modified paths.

## Pipeline

Updates from `git push no-mistakes`

✅ **Rebase** - passed
✅ **Review** - passed
✅ **Test** - passed
✅ **Lint** - passed
