### PR TITLE
fix(pipeline): restore findings compatibility and harden review intent

### DIFF
--- a/docs/src/content/docs/guides/auto-fix.md
+++ b/docs/src/content/docs/guides/auto-fix.md
@@ -34,15 +34,17 @@ Setting a step to `0` means the pipeline always pauses for human input when that
 
 Repo config overlays global config - you can set `auto_fix.lint: 5` in a repo's `.no-mistakes.yaml` to override just that step while inheriting the rest from global.
 
-## Review finding actions
+## Finding actions
 
-Review findings now use an `action` field instead of `requires_human_review`:
+Agent-driven findings now use an `action` field instead of `requires_human_review`:
 
 - `auto-fix` - objective issues that can be fixed automatically
 - `ask-user` - intent-sensitive or ambiguous issues that always require manual approval and are never auto-fixed
 - `no-op` - informational notes that do not need a fix
 
 `ask-user` is meant for findings that challenge the author's intent - for example, questioning an intentional product or design choice, or arguing that an intentional addition, removal, or guard should be undone. Routine correctness, reliability, or security fixes still stay `auto-fix` even if the smallest fix reintroduces a small amount of previously deleted logic.
+
+The `review`, `test`, and `lint` steps use this shared model directly. The `document` step also uses the same `action` field, but any documentation finding still pauses for approval because even objective doc gaps need an explicit documentation pass before the pipeline continues.
 
 Documentation findings use the same approval loop, but the `document` step treats any finding as a documentation gap that should pause for approval. When auto-fix is enabled, the agent can update docs or doc comments, then the step re-runs and proceeds only after reassessment returns no findings.
 

--- a/docs/src/content/docs/guides/auto-fix.md
+++ b/docs/src/content/docs/guides/auto-fix.md
@@ -34,11 +34,15 @@ Setting a step to `0` means the pipeline always pauses for human input when that
 
 Repo config overlays global config - you can set `auto_fix.lint: 5` in a repo's `.no-mistakes.yaml` to override just that step while inheriting the rest from global.
 
-## Human review findings
+## Review finding actions
 
-Some review findings are marked `requires_human_review: true` by the agent. These findings always require manual approval regardless of the auto-fix limit. They are never auto-fixed.
+Review findings now use an `action` field instead of `requires_human_review`:
 
-This is meant for findings that challenge the author's intent - for example, questioning an intentional product or design choice, or arguing that an intentional addition, removal, or guard should be undone. Routine correctness, reliability, or security fixes still stay auto-fixable even if the smallest fix reintroduces a small amount of previously deleted logic.
+- `auto-fix` - objective issues that can be fixed automatically
+- `ask-user` - intent-sensitive or ambiguous issues that always require manual approval and are never auto-fixed
+- `no-op` - informational notes that do not need a fix
+
+`ask-user` is meant for findings that challenge the author's intent - for example, questioning an intentional product or design choice, or arguing that an intentional addition, removal, or guard should be undone. Routine correctness, reliability, or security fixes still stay `auto-fix` even if the smallest fix reintroduces a small amount of previously deleted logic.
 
 Documentation findings use the same approval loop, but the `document` step treats any finding as a documentation gap that should pause for approval. When auto-fix is enabled, the agent can update docs or doc comments, then the step re-runs and proceeds only after reassessment returns no findings.
 

--- a/docs/src/content/docs/guides/pipeline-steps.md
+++ b/docs/src/content/docs/guides/pipeline-steps.md
@@ -51,10 +51,12 @@ Runs your test suite.
 
 **Behavior:**
 - If `commands.test` is set in repo config: runs it via `sh -c` and captures output. Non-zero exit produces `error` findings.
-- If `commands.test` is empty: the agent detects and runs relevant tests, returning structured findings.
+- If `commands.test` is empty: the agent detects and runs relevant tests, returning structured findings with severity, description, and `action` (`no-op`, `auto-fix`, `ask-user`).
 - If the agent creates new test files (detected via `git status --porcelain`), approval is required even if tests pass.
 
-**Auto-fix:** the agent receives previous failure output and fixes the code, then tests run again. Fix commits use `no-mistakes(test): <summary>`.
+**Approval:** failing test findings with `action: ask-user` always require human approval. `action: auto-fix` findings stay eligible for the fix loop. `action: no-op` findings are informational only.
+
+**Auto-fix:** the agent receives previous failure output and fixes the code for `action: auto-fix` findings, then tests run again. Fix commits use `no-mistakes(test): <summary>`.
 
 **Default auto-fix limit:** `3`.
 
@@ -64,7 +66,7 @@ Checks whether the code changes need matching documentation updates.
 
 **Behavior:**
 - Diffs the base commit against head and skips the step if there are no non-ignored changed files to document
-- Asks the agent to review the change and return documentation findings for any missing or stale docs
+- Asks the agent to review the change and return documentation findings for any missing or stale docs, using the same `action` field as other agent-driven steps
 - Requires approval whenever any documentation finding is returned, including `info` findings
 
 **Auto-fix:** the agent updates only documentation files or doc comments, then the step re-runs and expects an empty findings list before continuing. Fix commits use `no-mistakes(document): <summary>`.
@@ -77,9 +79,11 @@ Runs linters and static analysis.
 
 **Behavior:**
 - If `commands.lint` is set: runs it via `sh -c`. Non-zero exit produces `warning` findings.
-- If `commands.lint` is empty: the agent detects and runs appropriate linters/formatters.
+- If `commands.lint` is empty: the agent detects and runs appropriate linters/formatters, returning structured findings with severity, description, and `action` (`no-op`, `auto-fix`, `ask-user`).
 
-**Auto-fix:** same pattern as test - agent fixes issues, lint re-runs. Fix commits use `no-mistakes(lint): <summary>`.
+**Approval:** lint findings with `action: ask-user` always require human approval. `action: auto-fix` findings stay eligible for the fix loop. `action: no-op` findings are informational only.
+
+**Auto-fix:** same pattern as test - the agent fixes `action: auto-fix` issues, then lint re-runs. Fix commits use `no-mistakes(lint): <summary>`.
 
 **Default auto-fix limit:** `3`.
 

--- a/docs/src/content/docs/guides/pipeline-steps.md
+++ b/docs/src/content/docs/guides/pipeline-steps.md
@@ -34,11 +34,12 @@ AI code review of your diff.
 **Behavior:**
 - Diffs the base commit against head
 - Filters out files matching `ignore_patterns` from the repo config
+- Includes user-authored commit subjects between base and head as intent context for the agent
 - Sends the filtered diff to the agent with a structured output schema
-- Agent returns findings with severity (`error`, `warning`, `info`), file location, and description
+- Agent returns findings with severity (`error`, `warning`, `info`), file location, description, and an `action` (`no-op`, `auto-fix`, `ask-user`)
 - Also returns a `risk_level` (`low`, `medium`, `high`) and `risk_rationale`
 
-**Approval:** required if any finding has severity `error` or `warning`. Findings marked `requires_human_review` always require human approval and are never auto-fixed. This is for findings that challenge the author's intent, not routine correctness, reliability, or security fixes that may need to re-add a small amount of deleted logic.
+**Approval:** required if any finding has severity `error` or `warning`. Findings with `action: ask-user` always require human approval and are never auto-fixed. This is for findings that challenge the author's intent, not routine correctness, reliability, or security fixes that may need to re-add a small amount of deleted logic. Findings with `action: auto-fix` remain eligible for the fix loop. Findings with `action: no-op` are informational only.
 
 **Auto-fix:** the agent receives previous findings and applies fixes, then the review runs again. Fix commits use `no-mistakes(review): <summary>`.
 

--- a/docs/src/content/docs/how-it-works.md
+++ b/docs/src/content/docs/how-it-works.md
@@ -67,9 +67,9 @@ On startup, the daemon recovers from crashes by marking any stuck runs as failed
 The executor runs each step sequentially and manages the approval/fix loop. It can also end early after `rebase` if the branch has no diff against the default branch, marking the remaining steps as skipped.
 
 1. Execute the step
-2. If the step finds issues and auto-fix is enabled, loop back with the agent to fix them (up to the configured limit)
-3. If issues remain (or require human review), pause and wait for user action
-4. The user can approve, fix (with selected findings), skip, or abort
+2. If the step finds `action: auto-fix` findings and auto-fix is enabled, loop back with the agent to fix them (up to the configured limit)
+3. If blocking findings remain, or any finding has `action: ask-user`, pause and wait for user action
+4. `action: no-op` findings are informational only; the user can approve, fix selected findings, skip, or abort when the step pauses
 
 ### IPC
 

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -258,7 +258,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			}
 		}
 
-		if !outcome.NeedsApproval && !hasHumanReviewFindingsJSON(outcome.Findings) {
+		if !outcome.NeedsApproval && !hasAskUserFindingsJSON(outcome.Findings) {
 			// Step completed without needing approval.
 			// Any remaining info-only or human-review-only findings
 			// are acceptable and don't block the pipeline.

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -237,7 +237,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 		}
 
 		// Check if auto-fix should be attempted.
-		// Only auto-fix findings that don't require human review.
+		// Only auto-fix findings whose action is "auto-fix".
 		// This runs before the NeedsApproval check so that all severity
 		// levels (including "info") get a chance at automatic fixing.
 		if outcome.AutoFixable && autoFixLimit > 0 && autoFixAttempts < autoFixLimit {
@@ -260,7 +260,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 
 		if !outcome.NeedsApproval && !hasAskUserFindingsJSON(outcome.Findings) {
 			// Step completed without needing approval.
-			// Any remaining info-only or human-review-only findings
+			// Any remaining info-only or non-blocking findings
 			// are acceptable and don't block the pipeline.
 			skipRemaining = outcome.SkipRemaining
 			break

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -328,7 +328,7 @@ func TestExecutor_ApprovalApprove(t *testing.T) {
 	workDir := t.TempDir()
 
 	steps := []Step{
-		newApprovalStep(types.StepReview, `{"findings":[{"severity":"error","description":"bug found"}],"summary":"1 issue found"}`),
+		newApprovalStep(types.StepReview, `{"findings":[{"severity":"error","description":"bug found","action":"auto-fix"}],"summary":"1 issue found"}`),
 		newPassStep(types.StepTest),
 	}
 
@@ -395,7 +395,7 @@ func TestExecutor_ApprovalDurationExcludesWaitTime(t *testing.T) {
 	workDir := t.TempDir()
 
 	steps := []Step{
-		newApprovalStep(types.StepReview, `{"findings":[{"severity":"error","description":"bug"}],"summary":"1 issue"}`),
+		newApprovalStep(types.StepReview, `{"findings":[{"severity":"error","description":"bug","action":"auto-fix"}],"summary":"1 issue"}`),
 	}
 
 	exec := NewExecutor(database, p, nil, nil, steps, nil)
@@ -464,7 +464,7 @@ func TestExecutor_ApprovalApprovePreservesExitCode(t *testing.T) {
 			name: types.StepTest,
 			outcome: &StepOutcome{
 				NeedsApproval: true,
-				Findings:      `{"findings":[{"severity":"error","description":"tests failed"}],"summary":"failing test output"}`,
+				Findings:      `{"findings":[{"severity":"error","description":"tests failed","action":"auto-fix"}],"summary":"failing test output"}`,
 				ExitCode:      42,
 			},
 		},
@@ -818,7 +818,7 @@ func TestExecutor_FixSetsPreviousFindings(t *testing.T) {
 	database, p, run, repo := setupTest(t)
 	workDir := t.TempDir()
 
-	findings := `{"findings":[{"severity":"error","file":"main.go","line":42,"description":"nil pointer dereference"}],"summary":"1 error found"}`
+	findings := `{"findings":[{"severity":"error","file":"main.go","line":42,"description":"nil pointer dereference","action":"auto-fix"}],"summary":"1 error found"}`
 	var capturedFindings string
 
 	callCount := 0
@@ -873,7 +873,7 @@ func TestExecutor_AssignsFindingIDsBeforePersistingAndEmitting(t *testing.T) {
 		fn: func(sctx *StepContext) (*StepOutcome, error) {
 			return &StepOutcome{
 				NeedsApproval: true,
-				Findings:      `{"findings":[{"severity":"error","description":"first"},{"severity":"warning","description":"second"}],"summary":"2 findings"}`,
+				Findings:      `{"findings":[{"severity":"error","description":"first","action":"auto-fix"},{"severity":"warning","description":"second","action":"auto-fix"}],"summary":"2 findings"}`,
 			}, nil
 		},
 	}
@@ -935,7 +935,7 @@ func TestExecutor_FixUsesSelectedFindingIDsOnly(t *testing.T) {
 			if callCount == 1 {
 				return &StepOutcome{
 					NeedsApproval: true,
-					Findings:      `{"findings":[{"id":"review-1","severity":"error","description":"first"},{"id":"review-2","severity":"warning","description":"second"}],"summary":"2 findings"}`,
+					Findings:      `{"findings":[{"id":"review-1","severity":"error","description":"first","action":"auto-fix"},{"id":"review-2","severity":"warning","description":"second","action":"auto-fix"}],"summary":"2 findings"}`,
 				}, nil
 			}
 			capturedFindings = sctx.PreviousFindings
@@ -985,7 +985,7 @@ func TestExecutor_FixClearsStoredFindingsAfterSuccessfulReRun(t *testing.T) {
 			if callCount == 1 {
 				return &StepOutcome{
 					NeedsApproval: true,
-					Findings:      `{"findings":[{"severity":"error","description":"first pass issue"}],"summary":"1 issue"}`,
+					Findings:      `{"findings":[{"severity":"error","description":"first pass issue","action":"auto-fix"}],"summary":"1 issue"}`,
 				}, nil
 			}
 			return &StepOutcome{}, nil
@@ -1035,7 +1035,7 @@ func TestExecutor_FixSelectedFindingsRewritesSummary(t *testing.T) {
 			if callCount == 1 {
 				return &StepOutcome{
 					NeedsApproval: true,
-					Findings:      `{"findings":[{"id":"review-1","severity":"error","description":"first"},{"id":"review-2","severity":"warning","description":"second"}],"summary":"2 findings"}`,
+					Findings:      `{"findings":[{"id":"review-1","severity":"error","description":"first","action":"auto-fix"},{"id":"review-2","severity":"warning","description":"second","action":"auto-fix"}],"summary":"2 findings"}`,
 				}, nil
 			}
 			capturedFindings = sctx.PreviousFindings
@@ -1093,12 +1093,12 @@ func TestExecutor_FixDropsDismissedFindingsThatDisappearAcrossCycles(t *testing.
 			case 1:
 				return &StepOutcome{
 					NeedsApproval: true,
-					Findings:      `{"findings":[{"id":"review-1","severity":"error","description":"first"},{"id":"review-2","severity":"warning","description":"second"}],"summary":"2 findings"}`,
+					Findings:      `{"findings":[{"id":"review-1","severity":"error","description":"first","action":"auto-fix"},{"id":"review-2","severity":"warning","description":"second","action":"auto-fix"}],"summary":"2 findings"}`,
 				}, nil
 			case 2:
 				return &StepOutcome{
 					NeedsApproval: true,
-					Findings:      `{"findings":[{"id":"review-2","severity":"warning","description":"second"},{"id":"review-3","severity":"error","description":"third"}],"summary":"2 findings"}`,
+					Findings:      `{"findings":[{"id":"review-2","severity":"warning","description":"second","action":"auto-fix"},{"id":"review-3","severity":"error","description":"third","action":"auto-fix"}],"summary":"2 findings"}`,
 				}, nil
 			case 3:
 				capturedDismissed = sctx.DismissedFindings
@@ -1158,12 +1158,12 @@ func TestExecutor_FixRemovesReselectedDismissedFinding(t *testing.T) {
 			case 1:
 				return &StepOutcome{
 					NeedsApproval: true,
-					Findings:      `{"findings":[{"id":"review-1","severity":"error","description":"first"},{"id":"review-2","severity":"warning","description":"second"}],"summary":"2 findings"}`,
+					Findings:      `{"findings":[{"id":"review-1","severity":"error","description":"first","action":"auto-fix"},{"id":"review-2","severity":"warning","description":"second","action":"auto-fix"}],"summary":"2 findings"}`,
 				}, nil
 			case 2:
 				return &StepOutcome{
 					NeedsApproval: true,
-					Findings:      `{"findings":[{"id":"review-1","severity":"error","description":"first"},{"id":"review-3","severity":"warning","description":"third"}],"summary":"2 findings"}`,
+					Findings:      `{"findings":[{"id":"review-1","severity":"error","description":"first","action":"auto-fix"},{"id":"review-3","severity":"warning","description":"third","action":"auto-fix"}],"summary":"2 findings"}`,
 				}, nil
 			case 3:
 				capturedDismissed = sctx.DismissedFindings
@@ -1223,12 +1223,12 @@ func TestExecutor_FixDropsEarlierDismissedFindingWhenOrdinalReusedForDifferentIs
 			case 1:
 				return &StepOutcome{
 					NeedsApproval: true,
-					Findings:      `{"findings":[{"id":"review-1","severity":"error","description":"first"},{"id":"review-2","severity":"warning","description":"second"}],"summary":"2 findings"}`,
+					Findings:      `{"findings":[{"id":"review-1","severity":"error","description":"first","action":"auto-fix"},{"id":"review-2","severity":"warning","description":"second","action":"auto-fix"}],"summary":"2 findings"}`,
 				}, nil
 			case 2:
 				return &StepOutcome{
 					NeedsApproval: true,
-					Findings:      `{"findings":[{"id":"review-1","severity":"error","description":"replacement"},{"id":"review-3","severity":"warning","description":"third"}],"summary":"2 findings"}`,
+					Findings:      `{"findings":[{"id":"review-1","severity":"error","description":"replacement","action":"auto-fix"},{"id":"review-3","severity":"warning","description":"third","action":"auto-fix"}],"summary":"2 findings"}`,
 				}, nil
 			case 3:
 				capturedDismissed = sctx.DismissedFindings
@@ -1722,7 +1722,7 @@ func TestExecutor_AutoFixTriggersWithoutApproval(t *testing.T) {
 				return &StepOutcome{
 					NeedsApproval: true,
 					AutoFixable:   true,
-					Findings:      `{"findings":[{"severity":"error","description":"bug"}],"summary":"1 issue"}`,
+					Findings:      `{"findings":[{"severity":"error","description":"bug","action":"auto-fix"}],"summary":"1 issue"}`,
 				}, nil
 			}
 			// After auto-fix, verify Fixing is set
@@ -1769,7 +1769,7 @@ func TestExecutor_AutoFixRespectsMaxAttempts(t *testing.T) {
 			return &StepOutcome{
 				NeedsApproval: true,
 				AutoFixable:   true,
-				Findings:      `{"findings":[{"severity":"warning","description":"style issue"}],"summary":"lint issue"}`,
+				Findings:      `{"findings":[{"severity":"warning","description":"style issue","action":"auto-fix"}],"summary":"lint issue"}`,
 			}, nil
 		},
 	}
@@ -1817,7 +1817,7 @@ func TestExecutor_AutoFixDisabledWithZero(t *testing.T) {
 			callCount++
 			return &StepOutcome{
 				NeedsApproval: true,
-				Findings:      `{"findings":[{"severity":"error","description":"bug"}],"summary":"1 issue"}`,
+				Findings:      `{"findings":[{"severity":"error","description":"bug","action":"auto-fix"}],"summary":"1 issue"}`,
 			}, nil
 		},
 	}
@@ -1860,7 +1860,7 @@ func TestExecutor_AutoFixNilConfigUsesDefaults(t *testing.T) {
 			callCount++
 			return &StepOutcome{
 				NeedsApproval: true,
-				Findings:      `{"findings":[{"severity":"error","description":"bug"}],"summary":"1 issue"}`,
+				Findings:      `{"findings":[{"severity":"error","description":"bug","action":"auto-fix"}],"summary":"1 issue"}`,
 			}, nil
 		},
 	}
@@ -1898,7 +1898,7 @@ func TestExecutor_AutoFixEmitsEvents(t *testing.T) {
 				return &StepOutcome{
 					NeedsApproval: true,
 					AutoFixable:   true,
-					Findings:      `{"findings":[{"severity":"warning","description":"issue"}],"summary":"1 issue"}`,
+					Findings:      `{"findings":[{"severity":"warning","description":"issue","action":"auto-fix"}],"summary":"1 issue"}`,
 				}, nil
 			}
 			return &StepOutcome{}, nil
@@ -1933,7 +1933,7 @@ func TestExecutor_DoesNotAutoFixManualApprovalOutcome(t *testing.T) {
 			callCount++
 			return &StepOutcome{
 				NeedsApproval: true,
-				Findings:      `{"findings":[{"severity":"info","description":"new test file written by agent: agent_test.go"}],"summary":"tests passed, but agent wrote new test files"}`,
+				Findings:      `{"findings":[{"severity":"info","description":"new test file written by agent: agent_test.go","action":"no-op"}],"summary":"tests passed, but agent wrote new test files"}`,
 			}, nil
 		},
 	}
@@ -1981,7 +1981,7 @@ func TestExecutor_AutoFixInfoFindings(t *testing.T) {
 				return &StepOutcome{
 					NeedsApproval: false,
 					AutoFixable:   true,
-					Findings:      `{"findings":[{"severity":"info","description":"could simplify"}],"summary":"1 suggestion"}`,
+					Findings:      `{"findings":[{"severity":"info","description":"could simplify","action":"auto-fix"}],"summary":"1 suggestion"}`,
 				}, nil
 			}
 			// After auto-fix, step passes clean
@@ -2015,11 +2015,11 @@ func TestExecutor_AutoFixSkipsHumanReviewFindings(t *testing.T) {
 		name: types.StepReview,
 		fn: func(sctx *StepContext) (*StepOutcome, error) {
 			callCount++
-			// All findings require human review - auto-fix should not trigger
+			// All findings are ask-user - auto-fix should not trigger
 			return &StepOutcome{
 				NeedsApproval: true,
 				AutoFixable:   true,
-				Findings:      `{"findings":[{"severity":"warning","description":"design choice","requires_human_review":true}],"summary":"1 issue"}`,
+				Findings:      `{"findings":[{"severity":"warning","description":"design choice","action":"ask-user"}],"summary":"1 issue"}`,
 			}, nil
 		},
 	}
@@ -2035,7 +2035,7 @@ func TestExecutor_AutoFixSkipsHumanReviewFindings(t *testing.T) {
 	waitForStepStatus(t, database, run.ID, types.StepReview, types.StepStatusAwaitingApproval)
 
 	if callCount != 1 {
-		t.Fatalf("expected 1 call (no auto-fix for human-review findings), got %d", callCount)
+		t.Fatalf("expected 1 call (no auto-fix for ask-user findings), got %d", callCount)
 	}
 
 	exec.Respond(types.StepReview, types.ActionApprove, nil)
@@ -2060,7 +2060,7 @@ func TestExecutor_HumanReviewFindingsRequireApprovalWithoutNeedsApprovalFlag(t *
 			return &StepOutcome{
 				NeedsApproval: false,
 				AutoFixable:   true,
-				Findings:      `{"findings":[{"severity":"info","description":"design choice","requires_human_review":true}],"summary":"1 issue"}`,
+				Findings:      `{"findings":[{"severity":"info","description":"design choice","action":"ask-user"}],"summary":"1 issue"}`,
 			}, nil
 		},
 	}
@@ -2098,13 +2098,13 @@ func TestExecutor_AutoFixMixedFindings(t *testing.T) {
 		fn: func(sctx *StepContext) (*StepOutcome, error) {
 			callCount++
 			if callCount == 1 {
-				// Mix: one auto-fixable, one requires human review
+				// Mix: one auto-fixable, one ask-user
 				return &StepOutcome{
 					NeedsApproval: true,
 					AutoFixable:   true,
 					Findings: `{"findings":[
-						{"id":"review-1","severity":"error","description":"bug"},
-						{"id":"review-2","severity":"warning","description":"design choice","requires_human_review":true}
+						{"id":"review-1","severity":"error","description":"bug","action":"auto-fix"},
+						{"id":"review-2","severity":"warning","description":"design choice","action":"ask-user"}
 					],"summary":"2 issues","risk_level":"medium","risk_rationale":"mixed"}`,
 				}, nil
 			}
@@ -2119,11 +2119,11 @@ func TestExecutor_AutoFixMixedFindings(t *testing.T) {
 			if len(parsed.Items) > 0 && parsed.Items[0].Description != "bug" {
 				t.Errorf("expected fixable finding 'bug', got %q", parsed.Items[0].Description)
 			}
-			// Return only the human-review finding remaining
+			// Return only the ask-user finding remaining
 			return &StepOutcome{
 				NeedsApproval: true,
 				AutoFixable:   true,
-				Findings:      `{"findings":[{"id":"review-2","severity":"warning","description":"design choice","requires_human_review":true}],"summary":"1 issue"}`,
+				Findings:      `{"findings":[{"id":"review-2","severity":"warning","description":"design choice","action":"ask-user"}],"summary":"1 issue"}`,
 			}, nil
 		},
 	}
@@ -2135,7 +2135,7 @@ func TestExecutor_AutoFixMixedFindings(t *testing.T) {
 		done <- exec.Execute(context.Background(), run, repo, workDir)
 	}()
 
-	// After auto-fixing the bug, only human-review finding remains.
+	// After auto-fixing the bug, only ask-user finding remains.
 	// No more fixable findings, so falls through to user approval.
 	waitForStepStatus(t, database, run.ID, types.StepReview, types.StepStatusFixReview)
 

--- a/internal/pipeline/findings.go
+++ b/internal/pipeline/findings.go
@@ -4,7 +4,7 @@ import "github.com/kunchenguid/no-mistakes/internal/types"
 
 func findingKey(item types.Finding) types.Finding {
 	item.ID = ""
-	item.RequiresHumanReview = false
+	item.Action = ""
 	return item
 }
 
@@ -198,7 +198,7 @@ func autoFixableFindingsJSON(raw string) string {
 	return fixableRaw
 }
 
-func hasHumanReviewFindingsJSON(raw string) bool {
+func hasAskUserFindingsJSON(raw string) bool {
 	if raw == "" {
 		return false
 	}
@@ -206,7 +206,7 @@ func hasHumanReviewFindingsJSON(raw string) bool {
 	if err != nil {
 		return false
 	}
-	return types.HasHumanReviewFindings(findings)
+	return types.HasAskUserFindings(findings)
 }
 
 func filterFindingsJSON(raw string, ids []string) string {

--- a/internal/pipeline/findings_test.go
+++ b/internal/pipeline/findings_test.go
@@ -74,8 +74,8 @@ func TestRetainMatchingFindingsJSON_DoesNotKeepDistinctDuplicateLines(t *testing
 	}
 }
 
-func TestAutoFixableFindingsJSON_FiltersHumanReview(t *testing.T) {
-	raw := `{"findings":[{"id":"review-1","severity":"error","description":"bug"},{"id":"review-2","severity":"warning","description":"design choice","requires_human_review":true},{"id":"review-3","severity":"warning","description":"missing check"}],"risk_level":"medium","risk_rationale":"Mixed."}`
+func TestAutoFixableFindingsJSON_FiltersToAutoFix(t *testing.T) {
+	raw := `{"findings":[{"id":"review-1","severity":"error","description":"bug","action":"auto-fix"},{"id":"review-2","severity":"warning","description":"design choice","action":"ask-user"},{"id":"review-3","severity":"warning","description":"missing check","action":"auto-fix"},{"id":"review-4","severity":"info","description":"note","action":"no-op"}],"risk_level":"medium","risk_rationale":"Mixed."}`
 
 	fixableRaw := autoFixableFindingsJSON(raw)
 	fixable, err := types.ParseFindingsJSON(fixableRaw)
@@ -90,18 +90,27 @@ func TestAutoFixableFindingsJSON_FiltersHumanReview(t *testing.T) {
 	}
 }
 
-func TestAutoFixableFindingsJSON_AllHumanReview(t *testing.T) {
-	raw := `{"findings":[{"id":"review-1","severity":"warning","description":"choice","requires_human_review":true}],"risk_level":"high","risk_rationale":"Needs review."}`
+func TestAutoFixableFindingsJSON_AllAskUser(t *testing.T) {
+	raw := `{"findings":[{"id":"review-1","severity":"warning","description":"choice","action":"ask-user"}],"risk_level":"high","risk_rationale":"Needs review."}`
 
 	fixableRaw := autoFixableFindingsJSON(raw)
 	if fixableRaw != "" {
-		t.Fatalf("expected empty string for all-human-review findings, got %q", fixableRaw)
+		t.Fatalf("expected empty string for all-ask-user findings, got %q", fixableRaw)
 	}
 }
 
 func TestAutoFixableFindingsJSON_EmptyInput(t *testing.T) {
 	if got := autoFixableFindingsJSON(""); got != "" {
 		t.Fatalf("expected empty string for empty input, got %q", got)
+	}
+}
+
+func TestAutoFixableFindingsJSON_AllNoOp(t *testing.T) {
+	raw := `{"findings":[{"id":"review-1","severity":"info","description":"note","action":"no-op"}],"risk_level":"low","risk_rationale":"Clean."}`
+
+	fixableRaw := autoFixableFindingsJSON(raw)
+	if fixableRaw != "" {
+		t.Fatalf("expected empty string for all-no-op findings, got %q", fixableRaw)
 	}
 }
 

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -102,9 +102,9 @@ var findingsSchema = json.RawMessage(`{
 					"file": {"type": "string"},
 					"line": {"type": "integer"},
 					"description": {"type": "string"},
-					"requires_human_review": {"type": "boolean"}
+					"action": {"type": "string", "enum": ["no-op", "auto-fix", "ask-user"]}
 				},
-				"required": ["severity", "description", "requires_human_review"]
+				"required": ["severity", "description", "action"]
 			}
 		},
 		"summary": {"type": "string"}
@@ -199,9 +199,9 @@ var reviewFindingsSchema = json.RawMessage(`{
 					"file": {"type": "string"},
 					"line": {"type": "integer"},
 					"description": {"type": "string"},
-					"requires_human_review": {"type": "boolean"}
+					"action": {"type": "string", "enum": ["no-op", "auto-fix", "ask-user"]}
 				},
-				"required": ["severity", "description", "requires_human_review"]
+				"required": ["severity", "description", "action"]
 			}
 		},
 		"risk_level": {"type": "string", "enum": ["low", "medium", "high"]},

--- a/internal/pipeline/steps/document.go
+++ b/internal/pipeline/steps/document.go
@@ -358,33 +358,35 @@ func extractDocumentSummary(raw []byte, fallback string) string {
 }
 
 func unmarshalRequiredFindings(raw []byte, findings *Findings) error {
+	parsed, err := types.ParseFindingsJSON(string(raw))
+	if err != nil {
+		return err
+	}
 	var payload struct {
-		Summary string `json:"summary"`
-		Items   []struct {
-			Severity    string  `json:"severity"`
-			Description string  `json:"description"`
-			Action      *string `json:"action"`
-		} `json:"findings"`
+		Summary  *string            `json:"summary"`
+		Findings *[]json.RawMessage `json:"findings"`
+		Items    *[]json.RawMessage `json:"items"`
 	}
 	if err := json.Unmarshal(raw, &payload); err != nil {
 		return err
 	}
-	if payload.Items == nil {
+	if payload.Findings == nil && payload.Items == nil {
 		return fmt.Errorf("missing findings array")
 	}
-	if strings.TrimSpace(payload.Summary) == "" {
+	if payload.Summary == nil || strings.TrimSpace(*payload.Summary) == "" {
 		return fmt.Errorf("missing summary")
 	}
-	for i, item := range payload.Items {
+	for i, item := range parsed.Items {
 		if strings.TrimSpace(item.Severity) == "" {
 			return fmt.Errorf("finding %d missing severity", i)
 		}
 		if strings.TrimSpace(item.Description) == "" {
 			return fmt.Errorf("finding %d missing description", i)
 		}
-		if item.Action == nil {
+		if strings.TrimSpace(item.Action) == "" {
 			return fmt.Errorf("finding %d missing action", i)
 		}
 	}
-	return json.Unmarshal(raw, findings)
+	*findings = parsed
+	return nil
 }

--- a/internal/pipeline/steps/document.go
+++ b/internal/pipeline/steps/document.go
@@ -135,7 +135,7 @@ Task:
 Rules:
 - Do NOT make any file changes in this mode.
 - Only report gaps where documentation is missing or stale relative to the code change.
-- Set requires_human_review to false for all findings. Documentation gaps are objective.`,
+- Set action to "auto-fix" for all findings. Documentation gaps are objective.`,
 		sctx.Run.Branch,
 		baseSHA,
 		sctx.Run.HeadSHA,
@@ -159,9 +159,9 @@ Rules:
 		sctx.Log("missing structured output, requiring approval")
 		findings = Findings{
 			Items: []Finding{{
-				Severity:            "warning",
-				Description:         summary,
-				RequiresHumanReview: true,
+				Severity:    "warning",
+				Description: summary,
+				Action:      types.ActionAskUser,
 			}},
 			Summary: summary,
 		}
@@ -170,9 +170,9 @@ Rules:
 		sctx.Log("could not parse structured output, requiring approval")
 		findings = Findings{
 			Items: []Finding{{
-				Severity:            "warning",
-				Description:         summary,
-				RequiresHumanReview: true,
+				Severity:    "warning",
+				Description: summary,
+				Action:      types.ActionAskUser,
 			}},
 			Summary: summary,
 		}
@@ -361,9 +361,9 @@ func unmarshalRequiredFindings(raw []byte, findings *Findings) error {
 	var payload struct {
 		Summary string `json:"summary"`
 		Items   []struct {
-			Severity            string `json:"severity"`
-			Description         string `json:"description"`
-			RequiresHumanReview *bool  `json:"requires_human_review"`
+			Severity    string  `json:"severity"`
+			Description string  `json:"description"`
+			Action      *string `json:"action"`
 		} `json:"findings"`
 	}
 	if err := json.Unmarshal(raw, &payload); err != nil {
@@ -382,8 +382,8 @@ func unmarshalRequiredFindings(raw []byte, findings *Findings) error {
 		if strings.TrimSpace(item.Description) == "" {
 			return fmt.Errorf("finding %d missing description", i)
 		}
-		if item.RequiresHumanReview == nil {
-			return fmt.Errorf("finding %d missing requires_human_review", i)
+		if item.Action == nil {
+			return fmt.Errorf("finding %d missing action", i)
 		}
 	}
 	return json.Unmarshal(raw, findings)

--- a/internal/pipeline/steps/lint.go
+++ b/internal/pipeline/steps/lint.go
@@ -86,7 +86,7 @@ Task:
 Rules:
 - Do not run tests or broader behavioral validation.
 - Focus on lint, format, and static-analysis issues only.
-- Set requires_human_review to false for all findings. Lint findings are objective and do not question the author's intent.`,
+- Set action to "auto-fix" for all findings. Lint findings are objective and do not question the author's intent.`,
 				sctx.Run.Branch,
 				baseSHA,
 				sctx.Run.HeadSHA,

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -1,6 +1,7 @@
 package steps
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -10,6 +11,31 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
+
+// userCommitMessages returns commit messages for user-made commits (not pipeline
+// commits) between base and head. Pipeline commits have a "no-mistakes(" prefix.
+func userCommitMessages(ctx context.Context, workDir, base, head string) string {
+	// Use %s for subject-only, separated by newlines.
+	out, err := git.Run(ctx, workDir, "log", "--format=%s", base+".."+head)
+	if err != nil || strings.TrimSpace(out) == "" {
+		return ""
+	}
+	var userMessages []string
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "no-mistakes(") {
+			continue
+		}
+		userMessages = append(userMessages, "- "+line)
+	}
+	if len(userMessages) == 0 {
+		return ""
+	}
+	return strings.Join(userMessages, "\n")
+}
 
 // ReviewStep reviews the diff for bugs, security issues, and doc gaps.
 type ReviewStep struct{}
@@ -135,6 +161,16 @@ Previous review findings to address:
 
 	dismissedSection := dismissedFindingsPromptSection(sctx.DismissedFindings)
 
+	// Gather user commit messages to convey author intent.
+	userCommits := userCommitMessages(ctx, sctx.WorkDir, baseSHA, sctx.Run.HeadSHA)
+	userCommitsSection := ""
+	if userCommits != "" {
+		userCommitsSection = fmt.Sprintf(`
+
+User commit messages (these express the author's primary intent - treat them as ground truth for what the change is trying to do):
+%s`, userCommits)
+	}
+
 	prompt := fmt.Sprintf(
 		`Review the code changes and return structured findings with a risk assessment.
 
@@ -144,7 +180,7 @@ Context:
 - target commit: %s
 - review scope: %s
 - default branch: %s
-- ignore patterns: %s
+- ignore patterns: %s%s
 
 Task:
 - Read the relevant history and diff yourself.
@@ -160,7 +196,10 @@ Rules:
 - Only comment on things that genuinely matter.
 - Do NOT report styling, formatting, linting, compilation, or type-checking issues.
 - If the change is clean, return an empty findings array.
-- Set requires_human_review to true only when the finding challenges the author's intent - i.e. questions a deliberate design/product decision, or where the natural fix would undo something the author intentionally did (adding, removing, or changing code on purpose). Examples: "this feature seems unnecessary", "this deletion looks wrong", "this guard is redundant". A finding is not human-review-only just because the fix may reintroduce a small amount of previously deleted logic to restore correctness, reliability, or security. Set it to false for findings about objective correctness, error handling, security, performance, and mechanical code quality. When in doubt, default to false.
+- For each finding, set the action field to one of:
+  - "no-op": the finding is informational and does not require any action (e.g. noting a pattern, acknowledging a tradeoff).
+  - "auto-fix": the finding is an objective issue (correctness, error handling, security, performance, mechanical code quality) that can be safely fixed without changing the author's intent.
+  - "ask-user": the finding questions or challenges the author's deliberate intent, or the correct resolution is ambiguous. Examples: "this feature seems unnecessary", "this hardcoded value should be configurable", "this deletion looks wrong". When in doubt, default to "ask-user".
 
 Risk assessment (after listing all findings):
 - Set risk_level to "low" if the change is well-bounded, mostly cosmetic, or straightforward with little ambiguity.
@@ -173,6 +212,7 @@ Risk assessment (after listing all findings):
 		reviewScope,
 		sctx.Repo.DefaultBranch,
 		ignorePatterns,
+		userCommitsSection,
 		dismissedSection,
 	)
 

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -15,21 +15,26 @@ import (
 // userCommitMessages returns commit messages for user-made commits (not pipeline
 // commits) between base and head. Pipeline commits have a "no-mistakes(" prefix.
 func userCommitMessages(ctx context.Context, workDir, base, head string) string {
-	// Use %s for subject-only, separated by newlines.
-	out, err := git.Run(ctx, workDir, "log", "--format=%s", base+".."+head)
+	// Follow the branch's first-parent history and skip merge commits so this only
+	// reflects subjects authored on the branch itself.
+	out, err := git.Run(ctx, workDir, "log", "--first-parent", "--no-merges", "--format=%s", base+".."+head)
 	if err != nil || strings.TrimSpace(out) == "" {
 		return ""
 	}
 	var userMessages []string
 	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
-		line = strings.TrimSpace(line)
+		line = sanitizePromptText(line)
 		if line == "" {
 			continue
 		}
 		if strings.HasPrefix(line, "no-mistakes(") {
 			continue
 		}
-		userMessages = append(userMessages, "- "+line)
+		encoded, err := json.Marshal(line)
+		if err != nil {
+			continue
+		}
+		userMessages = append(userMessages, "- "+string(encoded))
 	}
 	if len(userMessages) == 0 {
 		return ""

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1273,11 +1273,11 @@ func TestReviewStep_FixMode(t *testing.T) {
 	if strings.Contains(ag.calls[1].Prompt, "<<<<<<< HEAD") {
 		t.Error("expected review prompt to exclude merge markers")
 	}
-	if !strings.Contains(ag.calls[1].Prompt, "challenges the author's intent") {
-		t.Error("expected review prompt requires_human_review to cover intent-challenging scenarios")
+	if !strings.Contains(ag.calls[1].Prompt, "challenges the author's deliberate intent") {
+		t.Error("expected review prompt action to cover intent-challenging scenarios")
 	}
-	if !strings.Contains(ag.calls[1].Prompt, "A finding is not human-review-only just because the fix may reintroduce a small amount of previously deleted logic") {
-		t.Error("expected review prompt to keep routine correctness fixes auto-fixable")
+	if !strings.Contains(ag.calls[1].Prompt, `"ask-user"`) {
+		t.Error("expected review prompt to include ask-user action for ambiguous findings")
 	}
 	if status := gitStatusPorcelain(t, dir); status != "" {
 		t.Fatalf("expected clean worktree after fix commit, got %q", status)
@@ -1663,7 +1663,7 @@ func TestDocumentStep_Updated(t *testing.T) {
 	ag := &mockAgent{
 		name: "test",
 		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
-			return &agent.Result{Output: json.RawMessage(`{"findings":[{"severity":"warning","description":"README missing new CLI flag","requires_human_review":false}],"summary":"README needs updating"}`)}, nil
+			return &agent.Result{Output: json.RawMessage(`{"findings":[{"severity":"warning","description":"README missing new CLI flag","action":"auto-fix"}],"summary":"README needs updating"}`)}, nil
 		},
 	}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
@@ -1739,7 +1739,7 @@ func TestDocumentStep_InfoFindingStillRequiresApproval(t *testing.T) {
 	ag := &mockAgent{
 		name: "test",
 		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
-			return &agent.Result{Output: json.RawMessage(`{"findings":[{"severity":"info","description":"README should mention the new flag","requires_human_review":false}],"summary":"README needs updating"}`)}, nil
+			return &agent.Result{Output: json.RawMessage(`{"findings":[{"severity":"info","description":"README should mention the new flag","action":"auto-fix"}],"summary":"README needs updating"}`)}, nil
 		},
 	}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
@@ -1810,7 +1810,7 @@ func TestDocumentStep_MalformedOutput(t *testing.T) {
 	if len(findings.Items) != 1 {
 		t.Fatalf("expected 1 finding, got %+v", findings.Items)
 	}
-	if !findings.Items[0].RequiresHumanReview {
+	if findings.Items[0].Action != types.ActionAskUser {
 		t.Fatal("expected malformed output finding to require human review")
 	}
 }
@@ -1844,7 +1844,7 @@ func TestDocumentStep_NoStructuredOutputRequiresApproval(t *testing.T) {
 	if len(findings.Items) != 1 {
 		t.Fatalf("expected 1 finding, got %+v", findings.Items)
 	}
-	if !findings.Items[0].RequiresHumanReview {
+	if findings.Items[0].Action != types.ActionAskUser {
 		t.Fatal("expected missing structured output finding to require human review")
 	}
 }
@@ -1879,7 +1879,7 @@ func TestDocumentStep_MissingFindingsFieldRequiresApproval(t *testing.T) {
 	if len(findings.Items) != 1 {
 		t.Fatalf("expected 1 finding, got %+v", findings.Items)
 	}
-	if !findings.Items[0].RequiresHumanReview {
+	if findings.Items[0].Action != types.ActionAskUser {
 		t.Fatal("expected missing findings field finding to require human review")
 	}
 	if findings.Summary != "docs status unavailable" {
@@ -1922,7 +1922,7 @@ func TestDocumentStep_MalformedFindingRequiresApproval(t *testing.T) {
 	if len(findings.Items) != 1 {
 		t.Fatalf("expected 1 finding, got %+v", findings.Items)
 	}
-	if !findings.Items[0].RequiresHumanReview {
+	if findings.Items[0].Action != types.ActionAskUser {
 		t.Fatal("expected malformed finding to require human review")
 	}
 	if findings.Summary != "README needs updating" {
@@ -1962,7 +1962,7 @@ func TestDocumentStep_MissingSummaryRequiresApproval(t *testing.T) {
 	if len(findings.Items) != 1 {
 		t.Fatalf("expected 1 finding, got %+v", findings.Items)
 	}
-	if !findings.Items[0].RequiresHumanReview {
+	if findings.Items[0].Action != types.ActionAskUser {
 		t.Fatal("expected missing summary finding to require human review")
 	}
 	if findings.Summary != "agent returned no structured output" {
@@ -2093,7 +2093,7 @@ func TestDocumentStep_FixMode_StillNeedsWorkAfterFix(t *testing.T) {
 				return &agent.Result{Output: json.RawMessage(`{"summary":"partial update"}`)}, nil
 			}
 			// Re-assessment: still needs more work
-			return &agent.Result{Output: json.RawMessage(`{"findings":[{"severity":"warning","description":"config section still missing","requires_human_review":false}],"summary":"config section still missing"}`)}, nil
+			return &agent.Result{Output: json.RawMessage(`{"findings":[{"severity":"warning","description":"config section still missing","action":"auto-fix"}],"summary":"config section still missing"}`)}, nil
 		},
 	}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
@@ -3934,7 +3934,7 @@ func TestReviewFindingsSchema_ValidJSON(t *testing.T) {
 	}
 }
 
-func TestFindingsSchema_RequiresHumanReview(t *testing.T) {
+func TestFindingsSchema_Action(t *testing.T) {
 	var parsed map[string]interface{}
 	if err := json.Unmarshal(findingsSchema, &parsed); err != nil {
 		t.Fatal(err)
@@ -3942,22 +3942,22 @@ func TestFindingsSchema_RequiresHumanReview(t *testing.T) {
 	props := parsed["properties"].(map[string]interface{})
 	items := props["findings"].(map[string]interface{})["items"].(map[string]interface{})
 	itemProps := items["properties"].(map[string]interface{})
-	if _, ok := itemProps["requires_human_review"]; !ok {
-		t.Error("findingsSchema missing requires_human_review property")
+	if _, ok := itemProps["action"]; !ok {
+		t.Error("findingsSchema missing action property")
 	}
 	required := items["required"].([]interface{})
 	found := false
 	for _, r := range required {
-		if r.(string) == "requires_human_review" {
+		if r.(string) == "action" {
 			found = true
 		}
 	}
 	if !found {
-		t.Error("findingsSchema does not require requires_human_review at item level")
+		t.Error("findingsSchema does not require action at item level")
 	}
 }
 
-func TestReviewFindingsSchema_RequiresHumanReviewAtItemLevel(t *testing.T) {
+func TestReviewFindingsSchema_ActionAtItemLevel(t *testing.T) {
 	var parsed map[string]interface{}
 	if err := json.Unmarshal(reviewFindingsSchema, &parsed); err != nil {
 		t.Fatal(err)
@@ -3967,16 +3967,16 @@ func TestReviewFindingsSchema_RequiresHumanReviewAtItemLevel(t *testing.T) {
 	required := items["required"].([]interface{})
 	found := false
 	for _, r := range required {
-		if r.(string) == "requires_human_review" {
+		if r.(string) == "action" {
 			found = true
 		}
 	}
 	if !found {
-		t.Error("reviewFindingsSchema does not require requires_human_review at item level")
+		t.Error("reviewFindingsSchema does not require action at item level")
 	}
 }
 
-func TestTestStep_PromptIncludesRequiresHumanReview(t *testing.T) {
+func TestTestStep_PromptIncludesAction(t *testing.T) {
 	dir := t.TempDir()
 	findings := Findings{Items: nil, Summary: "all tests passed"}
 	findingsJSON, _ := json.Marshal(findings)
@@ -3994,12 +3994,12 @@ func TestTestStep_PromptIncludesRequiresHumanReview(t *testing.T) {
 	if len(ag.calls) != 1 {
 		t.Fatalf("expected 1 agent call, got %d", len(ag.calls))
 	}
-	if !strings.Contains(ag.calls[0].Prompt, "requires_human_review") {
-		t.Error("expected test prompt to instruct agent about requires_human_review")
+	if !strings.Contains(ag.calls[0].Prompt, "action") {
+		t.Error("expected test prompt to instruct agent about action")
 	}
 }
 
-func TestLintStep_PromptIncludesRequiresHumanReview(t *testing.T) {
+func TestLintStep_PromptIncludesAction(t *testing.T) {
 	dir := t.TempDir()
 	findings := Findings{Items: nil, Summary: "all clean"}
 	findingsJSON, _ := json.Marshal(findings)
@@ -4017,8 +4017,8 @@ func TestLintStep_PromptIncludesRequiresHumanReview(t *testing.T) {
 	if len(ag.calls) != 1 {
 		t.Fatalf("expected 1 agent call, got %d", len(ag.calls))
 	}
-	if !strings.Contains(ag.calls[0].Prompt, "requires_human_review") {
-		t.Error("expected lint prompt to instruct agent about requires_human_review")
+	if !strings.Contains(ag.calls[0].Prompt, "action") {
+		t.Error("expected lint prompt to instruct agent about action")
 	}
 }
 
@@ -4226,15 +4226,80 @@ func TestReviewStep_DismissedFindingsSanitizesPromptContent(t *testing.T) {
 	}
 }
 
+func TestUserCommitMessages_FiltersPipelineCommits(t *testing.T) {
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+
+	os.WriteFile(filepath.Join(dir, "base.txt"), []byte("base"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "base")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+
+	// User commit
+	os.WriteFile(filepath.Join(dir, "a.txt"), []byte("a"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "fix(prsummary): link pipeline summary tagline")
+
+	// Pipeline commit - should be filtered out
+	os.WriteFile(filepath.Join(dir, "b.txt"), []byte("b"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "no-mistakes(review): remove hardcoded repo link")
+
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	result := userCommitMessages(context.Background(), dir, baseSHA, headSHA)
+	if !strings.Contains(result, "fix(prsummary): link pipeline summary tagline") {
+		t.Errorf("expected user commit message, got %q", result)
+	}
+	if strings.Contains(result, "no-mistakes(review)") {
+		t.Errorf("expected pipeline commit to be filtered out, got %q", result)
+	}
+}
+
+func TestReviewStep_PromptIncludesUserCommitMessages(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	findingsJSON, _ := json.Marshal(Findings{Summary: "clean"})
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			return &agent.Result{Output: findingsJSON}, nil
+		},
+	}
+
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+
+	step := &ReviewStep{}
+	_, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(ag.calls) != 1 {
+		t.Fatalf("expected 1 agent call, got %d", len(ag.calls))
+	}
+	// setupGitRepo creates a commit "add feature" - should appear in prompt
+	if !strings.Contains(ag.calls[0].Prompt, "add feature") {
+		t.Error("expected review prompt to include user commit message")
+	}
+	if !strings.Contains(ag.calls[0].Prompt, "author's primary intent") {
+		t.Error("expected review prompt to explain user commit messages as intent")
+	}
+}
+
 func TestSanitizedPreviousFindingsForPrompt_PreservesMultilineDescriptions(t *testing.T) {
 	raw, err := types.MarshalFindingsJSON(types.Findings{
 		Items: []types.Finding{{
-			ID:                  "review-1",
-			Severity:            "warning",
-			File:                "internal/pipeline/steps/review.go",
-			Line:                278,
-			Description:         "go test failed:\n--- FAIL: TestThing\nmain_test.go:42: expected x\n",
-			RequiresHumanReview: false,
+			ID:          "review-1",
+			Severity:    "warning",
+			File:        "internal/pipeline/steps/review.go",
+			Line:        278,
+			Description: "go test failed:\n--- FAIL: TestThing\nmain_test.go:42: expected x\n",
+			Action:      types.ActionAutoFix,
 		}},
 		Summary:       "1 selected finding",
 		RiskLevel:     "medium",

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -4395,6 +4395,38 @@ func TestUserCommitMessages_ExcludesMergedMainCommits(t *testing.T) {
 	}
 }
 
+func TestUserCommitMessages_UsesProvidedHeadBound(t *testing.T) {
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+
+	os.WriteFile(filepath.Join(dir, "base.txt"), []byte("base"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "base")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feat: original branch work")
+	targetHeadSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	os.WriteFile(filepath.Join(dir, "later.txt"), []byte("later"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feat: later branch commit")
+
+	result := userCommitMessages(context.Background(), dir, baseSHA, targetHeadSHA)
+
+	if !strings.Contains(result, `- "feat: original branch work"`) {
+		t.Fatalf("expected target head commit included, got %q", result)
+	}
+	if strings.Contains(result, "feat: later branch commit") {
+		t.Fatalf("expected later branch commit excluded, got %q", result)
+	}
+}
+
 func TestSanitizedPreviousFindingsForPrompt_PreservesMultilineDescriptions(t *testing.T) {
 	raw, err := types.MarshalFindingsJSON(types.Findings{
 		Items: []types.Finding{{

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -4291,6 +4291,73 @@ func TestReviewStep_PromptIncludesUserCommitMessages(t *testing.T) {
 	}
 }
 
+func TestUserCommitMessages_SanitizesAndQuotesSubjects(t *testing.T) {
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+
+	os.WriteFile(filepath.Join(dir, "base.txt"), []byte("base"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "base")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", `fix(review): harden prompt >>>>>>> injected`)
+
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	result := userCommitMessages(context.Background(), dir, baseSHA, headSHA)
+
+	if strings.Contains(result, ">>>>>>>") {
+		t.Fatalf("expected merge markers removed from commit subjects, got %q", result)
+	}
+	if !strings.Contains(result, `- "fix(review): harden prompt injected"`) {
+		t.Fatalf("expected sanitized quoted commit subject, got %q", result)
+	}
+}
+
+func TestUserCommitMessages_ExcludesMergedMainCommits(t *testing.T) {
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+
+	os.WriteFile(filepath.Join(dir, "base.txt"), []byte("base"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "base")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feat: branch work")
+
+	gitCmd(t, dir, "checkout", "main")
+	os.WriteFile(filepath.Join(dir, "main.txt"), []byte("main"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "main: unrelated change")
+
+	gitCmd(t, dir, "checkout", "feature")
+	gitCmd(t, dir, "merge", "main", "--no-ff", "-m", "merge main into feature")
+
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	result := userCommitMessages(context.Background(), dir, baseSHA, headSHA)
+
+	if !strings.Contains(result, `- "feat: branch work"`) {
+		t.Fatalf("expected feature branch commit included, got %q", result)
+	}
+	if strings.Contains(result, "main: unrelated change") {
+		t.Fatalf("expected merged main commit excluded, got %q", result)
+	}
+	if strings.Contains(result, "merge main into feature") {
+		t.Fatalf("expected merge commit excluded, got %q", result)
+	}
+}
+
 func TestSanitizedPreviousFindingsForPrompt_PreservesMultilineDescriptions(t *testing.T) {
 	raw, err := types.MarshalFindingsJSON(types.Findings{
 		Items: []types.Finding{{

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1933,6 +1933,43 @@ func TestDocumentStep_MalformedFindingRequiresApproval(t *testing.T) {
 	}
 }
 
+func TestDocumentStep_LegacyFindingsStayAutoFixable(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			return &agent.Result{Output: json.RawMessage(`{"items":[{"severity":"warning","description":"README missing new CLI flag","requires_human_review":false}],"summary":"README needs updating"}`)}, nil
+		},
+	}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+
+	step := &DocumentStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected finding to be reported")
+	}
+	if !outcome.AutoFixable {
+		t.Fatal("expected legacy finding to remain auto-fixable")
+	}
+	var findings Findings
+	if err := json.Unmarshal([]byte(outcome.Findings), &findings); err != nil {
+		t.Fatalf("unmarshal findings: %v", err)
+	}
+	if len(findings.Items) != 1 {
+		t.Fatalf("expected 1 finding, got %+v", findings.Items)
+	}
+	if findings.Items[0].Action != types.ActionAutoFix {
+		t.Fatalf("action = %q, want %q", findings.Items[0].Action, types.ActionAutoFix)
+	}
+	if findings.Summary != "README needs updating" {
+		t.Fatalf("summary = %q, want %q", findings.Summary, "README needs updating")
+	}
+}
+
 func TestDocumentStep_MissingSummaryRequiresApproval(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 

--- a/internal/pipeline/steps/test.go
+++ b/internal/pipeline/steps/test.go
@@ -94,7 +94,7 @@ Rules:
 - Only report actionable findings: test failures, unfixable setup issues, or flaky tests you identified.
 - Do NOT report passing tests (whether existing or new), test counts, coverage summaries, or other non-actionable information.
 - If all tests pass and there are no issues, return an empty findings array.
-- Set requires_human_review to true only when a test failure seems desired and you question the author's intent of having the test in the first place.`,
+- Set action to "ask-user" only when a test failure seems desired and you question the author's intent of having the test in the first place. Set action to "auto-fix" for objective test failures that can be safely fixed. Set action to "no-op" for informational notes.`,
 				sctx.Run.Branch,
 				baseSHA,
 				sctx.Run.HeadSHA,

--- a/internal/types/findings.go
+++ b/internal/types/findings.go
@@ -22,6 +22,16 @@ type Finding struct {
 	Action      string `json:"action"`
 }
 
+type findingWire struct {
+	ID                  string `json:"id,omitempty"`
+	Severity            string `json:"severity"`
+	File                string `json:"file,omitempty"`
+	Line                int    `json:"line,omitempty"`
+	Description         string `json:"description"`
+	Action              string `json:"action"`
+	RequiresHumanReview *bool  `json:"requires_human_review,omitempty"`
+}
+
 // Findings is the structured findings payload exchanged across pipeline, IPC, and TUI.
 type Findings struct {
 	Items         []Finding `json:"findings"`
@@ -107,7 +117,7 @@ func ExcludeFindings(findings Findings, ids []string) Findings {
 func AutoFixableFindings(findings Findings) Findings {
 	result := Findings{Summary: findings.Summary, RiskLevel: findings.RiskLevel, RiskRationale: findings.RiskRationale}
 	for _, item := range findings.Items {
-		if item.Action == ActionAutoFix {
+		if item.actionOrDefault() == ActionAutoFix {
 			result.Items = append(result.Items, item)
 		}
 	}
@@ -156,4 +166,32 @@ func itoa(v int) string {
 		v /= 10
 	}
 	return string(buf[i:])
+}
+
+func (f *Finding) UnmarshalJSON(data []byte) error {
+	var wire findingWire
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return err
+	}
+	f.ID = wire.ID
+	f.Severity = wire.Severity
+	f.File = wire.File
+	f.Line = wire.Line
+	f.Description = wire.Description
+	f.Action = wire.Action
+	if f.Action == "" && wire.RequiresHumanReview != nil {
+		if *wire.RequiresHumanReview {
+			f.Action = ActionAskUser
+		} else {
+			f.Action = ActionAutoFix
+		}
+	}
+	return nil
+}
+
+func (f Finding) actionOrDefault() string {
+	if f.Action == "" {
+		return ActionAutoFix
+	}
+	return f.Action
 }

--- a/internal/types/findings.go
+++ b/internal/types/findings.go
@@ -5,14 +5,21 @@ import (
 	"fmt"
 )
 
+// Finding action constants.
+const (
+	ActionNoOp    = "no-op"
+	ActionAutoFix = "auto-fix"
+	ActionAskUser = "ask-user"
+)
+
 // Finding represents a single review, test, lint, or PR comment finding.
 type Finding struct {
-	ID                  string `json:"id,omitempty"`
-	Severity            string `json:"severity"`
-	File                string `json:"file,omitempty"`
-	Line                int    `json:"line,omitempty"`
-	Description         string `json:"description"`
-	RequiresHumanReview bool   `json:"requires_human_review"`
+	ID          string `json:"id,omitempty"`
+	Severity    string `json:"severity"`
+	File        string `json:"file,omitempty"`
+	Line        int    `json:"line,omitempty"`
+	Description string `json:"description"`
+	Action      string `json:"action"`
 }
 
 // Findings is the structured findings payload exchanged across pipeline, IPC, and TUI.
@@ -95,21 +102,22 @@ func ExcludeFindings(findings Findings, ids []string) Findings {
 }
 
 // AutoFixableFindings returns a new Findings containing only items where
-// RequiresHumanReview is false. These are safe for automatic fixing without
+// Action is "auto-fix". These are safe for automatic fixing without
 // user involvement.
 func AutoFixableFindings(findings Findings) Findings {
 	result := Findings{Summary: findings.Summary, RiskLevel: findings.RiskLevel, RiskRationale: findings.RiskRationale}
 	for _, item := range findings.Items {
-		if !item.RequiresHumanReview {
+		if item.Action == ActionAutoFix {
 			result.Items = append(result.Items, item)
 		}
 	}
 	return result
 }
 
-func HasHumanReviewFindings(findings Findings) bool {
+// HasAskUserFindings returns true if any finding has Action "ask-user".
+func HasAskUserFindings(findings Findings) bool {
 	for _, item := range findings.Items {
-		if item.RequiresHumanReview {
+		if item.Action == ActionAskUser {
 			return true
 		}
 	}

--- a/internal/types/findings.go
+++ b/internal/types/findings.go
@@ -48,7 +48,8 @@ type findingsWire struct {
 	RiskRationale string    `json:"risk_rationale"`
 }
 
-// ParseFindingsJSON decodes findings JSON, accepting both current and legacy item keys.
+// ParseFindingsJSON decodes findings JSON, accepting current and legacy item
+// keys plus legacy requires_human_review fields.
 func ParseFindingsJSON(raw string) (Findings, error) {
 	var wire findingsWire
 	if err := json.Unmarshal([]byte(raw), &wire); err != nil {

--- a/internal/types/findings_test.go
+++ b/internal/types/findings_test.go
@@ -147,6 +147,23 @@ func TestParseFindingsJSON_Action(t *testing.T) {
 	}
 }
 
+func TestParseFindingsJSON_RequiresHumanReviewCompatibility(t *testing.T) {
+	raw := `{"findings":[{"severity":"warning","description":"design choice","requires_human_review":true},{"severity":"error","description":"bug","requires_human_review":false}]}`
+	f, err := ParseFindingsJSON(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Items) != 2 {
+		t.Fatalf("Items count = %d, want 2", len(f.Items))
+	}
+	if f.Items[0].Action != ActionAskUser {
+		t.Errorf("Items[0].Action = %q, want %q", f.Items[0].Action, ActionAskUser)
+	}
+	if f.Items[1].Action != ActionAutoFix {
+		t.Errorf("Items[1].Action = %q, want %q", f.Items[1].Action, ActionAutoFix)
+	}
+}
+
 func TestAutoFixableFindings_FiltersToAutoFix(t *testing.T) {
 	f := Findings{
 		Items: []Finding{
@@ -191,6 +208,22 @@ func TestAutoFixableFindings_NoOpExcluded(t *testing.T) {
 	fixable := AutoFixableFindings(f)
 	if len(fixable.Items) != 0 {
 		t.Errorf("Items count = %d, want 0", len(fixable.Items))
+	}
+}
+
+func TestAutoFixableFindings_EmptyActionDefaultsToAutoFix(t *testing.T) {
+	f := Findings{
+		Items: []Finding{
+			{ID: "f1", Severity: "error", Description: "bug"},
+			{ID: "f2", Severity: "warning", Description: "needs approval", Action: ActionAskUser},
+		},
+	}
+	fixable := AutoFixableFindings(f)
+	if len(fixable.Items) != 1 {
+		t.Fatalf("Items count = %d, want 1", len(fixable.Items))
+	}
+	if fixable.Items[0].ID != "f1" {
+		t.Errorf("Items[0].ID = %q, want %q", fixable.Items[0].ID, "f1")
 	}
 }
 

--- a/internal/types/findings_test.go
+++ b/internal/types/findings_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -129,8 +130,8 @@ func TestFilterFindings_EmptyIDs(t *testing.T) {
 	}
 }
 
-func TestParseFindingsJSON_RequiresHumanReview(t *testing.T) {
-	raw := `{"findings":[{"severity":"warning","description":"design choice","requires_human_review":true},{"severity":"error","description":"bug"}],"risk_level":"medium","risk_rationale":"Mixed."}`
+func TestParseFindingsJSON_Action(t *testing.T) {
+	raw := `{"findings":[{"severity":"warning","description":"design choice","action":"ask-user"},{"severity":"error","description":"bug","action":"auto-fix"}],"risk_level":"medium","risk_rationale":"Mixed."}`
 	f, err := ParseFindingsJSON(raw)
 	if err != nil {
 		t.Fatal(err)
@@ -138,20 +139,21 @@ func TestParseFindingsJSON_RequiresHumanReview(t *testing.T) {
 	if len(f.Items) != 2 {
 		t.Fatalf("Items count = %d, want 2", len(f.Items))
 	}
-	if !f.Items[0].RequiresHumanReview {
-		t.Error("Items[0].RequiresHumanReview = false, want true")
+	if f.Items[0].Action != ActionAskUser {
+		t.Errorf("Items[0].Action = %q, want %q", f.Items[0].Action, ActionAskUser)
 	}
-	if f.Items[1].RequiresHumanReview {
-		t.Error("Items[1].RequiresHumanReview = true, want false")
+	if f.Items[1].Action != ActionAutoFix {
+		t.Errorf("Items[1].Action = %q, want %q", f.Items[1].Action, ActionAutoFix)
 	}
 }
 
-func TestAutoFixableFindings_FiltersOutHumanReview(t *testing.T) {
+func TestAutoFixableFindings_FiltersToAutoFix(t *testing.T) {
 	f := Findings{
 		Items: []Finding{
-			{ID: "f1", Severity: "error", Description: "bug", RequiresHumanReview: false},
-			{ID: "f2", Severity: "warning", Description: "design choice", RequiresHumanReview: true},
-			{ID: "f3", Severity: "warning", Description: "missing check", RequiresHumanReview: false},
+			{ID: "f1", Severity: "error", Description: "bug", Action: ActionAutoFix},
+			{ID: "f2", Severity: "warning", Description: "design choice", Action: ActionAskUser},
+			{ID: "f3", Severity: "warning", Description: "missing check", Action: ActionAutoFix},
+			{ID: "f4", Severity: "info", Description: "note", Action: ActionNoOp},
 		},
 		RiskLevel: "medium",
 	}
@@ -167,10 +169,10 @@ func TestAutoFixableFindings_FiltersOutHumanReview(t *testing.T) {
 	}
 }
 
-func TestAutoFixableFindings_AllHumanReview(t *testing.T) {
+func TestAutoFixableFindings_AllAskUser(t *testing.T) {
 	f := Findings{
 		Items: []Finding{
-			{ID: "f1", Severity: "warning", Description: "choice", RequiresHumanReview: true},
+			{ID: "f1", Severity: "warning", Description: "choice", Action: ActionAskUser},
 		},
 	}
 	fixable := AutoFixableFindings(f)
@@ -179,16 +181,38 @@ func TestAutoFixableFindings_AllHumanReview(t *testing.T) {
 	}
 }
 
-func TestAutoFixableFindings_NoneHumanReview(t *testing.T) {
+func TestAutoFixableFindings_NoOpExcluded(t *testing.T) {
 	f := Findings{
 		Items: []Finding{
-			{ID: "f1", Severity: "error", Description: "bug"},
-			{ID: "f2", Severity: "warning", Description: "issue"},
+			{ID: "f1", Severity: "info", Description: "note", Action: ActionNoOp},
+			{ID: "f2", Severity: "info", Description: "fyi", Action: ActionNoOp},
 		},
 	}
 	fixable := AutoFixableFindings(f)
-	if len(fixable.Items) != 2 {
-		t.Errorf("Items count = %d, want 2", len(fixable.Items))
+	if len(fixable.Items) != 0 {
+		t.Errorf("Items count = %d, want 0", len(fixable.Items))
+	}
+}
+
+func TestHasAskUserFindings(t *testing.T) {
+	tests := []struct {
+		name   string
+		items  []Finding
+		expect bool
+	}{
+		{"has ask-user", []Finding{{Action: ActionAskUser}}, true},
+		{"only auto-fix", []Finding{{Action: ActionAutoFix}}, false},
+		{"only no-op", []Finding{{Action: ActionNoOp}}, false},
+		{"mixed", []Finding{{Action: ActionAutoFix}, {Action: ActionAskUser}}, true},
+		{"empty", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := Findings{Items: tt.items}
+			if got := HasAskUserFindings(f); got != tt.expect {
+				t.Errorf("HasAskUserFindings() = %v, want %v", got, tt.expect)
+			}
+		})
 	}
 }
 
@@ -209,14 +233,28 @@ func TestMarshalFindingsJSON_AlwaysIncludesRiskFields(t *testing.T) {
 	}
 }
 
-func TestFinding_RequiresHumanReview_SerializedWhenFalse(t *testing.T) {
-	f := Finding{Severity: "error", Description: "bug", RequiresHumanReview: false}
+func TestFinding_Action_SerializedWhenEmpty(t *testing.T) {
+	f := Finding{Severity: "error", Description: "bug", Action: ""}
 	raw, err := json.Marshal(f)
 	if err != nil {
 		t.Fatal(err)
 	}
 	s := string(raw)
-	if !strings.Contains(s, `"requires_human_review":false`) {
-		t.Errorf("expected requires_human_review to be present when false, got %s", s)
+	if !strings.Contains(s, `"action":`) {
+		t.Errorf("expected action to be present, got %s", s)
+	}
+}
+
+func TestFinding_Action_Values(t *testing.T) {
+	for _, action := range []string{ActionNoOp, ActionAutoFix, ActionAskUser} {
+		f := Finding{Severity: "error", Description: "test", Action: action}
+		raw, err := json.Marshal(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		s := string(raw)
+		if !strings.Contains(s, fmt.Sprintf(`"action":"%s"`, action)) {
+			t.Errorf("expected action %q in output, got %s", action, s)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Replace the old human-review approval path with shared finding actions and preserve compatibility with legacy findings payloads so existing autofix and ask-user flows keep working after upgrade.
- Harden review intent gathering by binding commit subjects to the target head, sanitizing prompt inputs, and adding regression coverage for review and document parsing edge cases surfaced during branch review.
- Update autofix and approval-flow docs to match the new pipeline behavior and make the review, lint, and test actions clearer for users.

## Risk Assessment

⚠️ Medium: The change is well-scoped and test-covered, but the new action-based findings format still accepts and emits invalid action values, which can lead to silently misclassified review outcomes.

## Pipeline

Updates from `git push no-mistakes`

✅ **Rebase** - passed
⚠️ **Review** - 2 warnings
✅ **Test** - passed
✅ **Lint** - passed

<details>
<summary>Review details</summary>

**Round 1** - found 2 warnings
- ⚠️ `internal/types/findings.go:110` - `AutoFixableFindings` now filters strictly on `action == "auto-fix"`, but several built-in findings are still emitted with an empty action (for example configured `test`/`lint` command failures). Those findings used to auto-fix and now silently fall back to manual approval, which regresses the pipeline's autofix behavior.
- ⚠️ `internal/types/findings.go:22` - Switching the wire format from `requires_human_review` to `action` was done without a compatibility path for older persisted findings payloads. Existing stored/in-flight findings will decode with an empty action, so prior human-review state is lost and resumed runs can take different approval/autofix paths after upgrade.

**Round 2** (auto-fix) - found 2 warnings
- ⚠️ `internal/pipeline/steps/review.go:32` - User commit subjects are injected into the review prompt without sanitization or quoting, so a crafted commit message can smuggle prompt-injection text and distort the agent's review/fix decisions.
- ⚠️ `internal/pipeline/steps/review.go:19` - `git log base..head` will pull in subjects from merged commits as well as the branch's own work, but the prompt labels them as the author's intent; on branches that merge `main`, this can feed unrelated intent into review.

**Round 3** (auto-fix) - found 1 warning
- ⚠️ `internal/pipeline/steps/document.go:360` - `unmarshalRequiredFindings` now hard-requires the new `findings[].action` shape and bypasses `types.ParseFindingsJSON`, so legacy agent output using `requires_human_review` or top-level `items` is treated as malformed and escalated to `ask-user` approval instead of preserving the intended autofix compatibility.

**Round 4** (auto-fix) - found 1 warning
- ⚠️ `internal/pipeline/steps/review.go:20` - `userCommitMessages` accepts a `head` argument but always reads `base..HEAD`, so if the branch advances while a run is in progress the review prompt can pick up unrelated later commit subjects and mis-state the author's intent for the target commit.

**Round 5** (user-fix) - found 2 warnings
- ⚠️ `internal/types/findings.go:181` - `Finding.UnmarshalJSON` accepts any non-empty `action` string, so malformed output like `"action":"manual"` survives parsing and then matches neither auto-fix nor ask-user handling. That can silently bypass both remediation and approval logic instead of failing closed.
- ⚠️ `internal/types/findings.go:149` - `MarshalFindingsJSON` re-serializes legacy findings with `"action":""` even though runtime logic treats an empty action as `auto-fix`. That leaks an invalid wire value to downstream consumers and makes action-based handling inconsistent across process boundaries.

</details>
