### PR TITLE
feat(config): add auto agent detection and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ auto_fix:
 
 - Repo `agent` overrides global `agent`.
 - `commands` and `ignore_patterns` are repo-only.
-- Missing global config defaults to `agent: claude`, `ci_timeout: 4h`, `log_level: info`.
+- Missing global config defaults to `agent: auto` (probing `claude`, `codex`, `opencode`, then `rovodev`), `ci_timeout: 4h`, `log_level: info`.
 - `ci_timeout` replaces `babysit_timeout`, and `auto_fix.ci` replaces `auto_fix.babysit`; legacy keys are still accepted for existing configs.
 - `auto_fix` can be set globally or per repo. All steps default to `3`.
 - `agent_path_override` changes which binary path is launched for a given agent.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ Config is optional and split across two files:
 # ~/.no-mistakes/config.yaml
 
 # Default agent for all repos.
-agent: claude # claude | codex | rovodev | opencode
+# "auto" picks the first available agent on PATH: claude, codex, opencode, then rovodev.
+agent: auto # auto | claude | codex | rovodev | opencode
 
 # Optional binary path overrides.
 agent_path_override:

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -3,7 +3,7 @@ title: Agents
 description: Supported AI agents and how they integrate.
 ---
 
-`no-mistakes` is agent-agnostic. It supports four agents and uses a common interface for all of them. The agent handles code review, test/lint detection (when no explicit command is configured), and auto-fixing.
+`no-mistakes` is agent-agnostic. It supports four agents and uses a common interface for all of them. The default `agent: auto` setting picks the first supported agent available on your system. The agent handles code review, test/lint detection (when no explicit command is configured), and auto-fixing.
 
 ## Supported agents
 
@@ -20,7 +20,7 @@ description: Supported AI agents and how they integrate.
 
 ```yaml
 # ~/.no-mistakes/config.yaml
-agent: claude
+agent: auto
 ```
 
 ### Per-repo override
@@ -34,7 +34,14 @@ Repo config takes precedence over global config.
 
 ## Binary resolution
 
-By default, `no-mistakes` looks for the agent binary on your `PATH`:
+By default, `no-mistakes` resolves `agent: auto` by checking for supported agents on your `PATH` in this order:
+
+1. `claude`
+2. `codex`
+3. `opencode`
+4. `acli` with `rovodev` support
+
+The default binary names are:
 
 | Agent | Default binary name |
 |---|---|

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -3,7 +3,7 @@ title: Configuration
 description: Global and per-repo configuration options.
 ---
 
-Configuration is optional. Without any config files, `no-mistakes` defaults to using Claude as the agent with sensible defaults for everything else.
+Configuration is optional. Without any config files, `no-mistakes` defaults to `agent: auto`, which picks the first supported agent available on your system, with sensible defaults for everything else.
 
 Config is split across two files:
 
@@ -20,7 +20,8 @@ Set `NM_HOME` to relocate the global config directory (the global file becomes `
 # ~/.no-mistakes/config.yaml
 
 # Default agent for all repos.
-agent: claude  # claude | codex | rovodev | opencode
+# "auto" picks the first available agent on PATH.
+agent: auto  # auto | claude | codex | rovodev | opencode
 
 # Optional binary path overrides.
 agent_path_override:
@@ -77,6 +78,7 @@ See [Repo Config Reference](/no-mistakes/reference/repo-config/) for the full fi
 ## Precedence
 
 - Repo `agent` overrides global `agent`.
+- Global `agent: auto` resolves by checking `claude`, `codex`, `opencode`, then `acli` for `rovodev` on `PATH`.
 - `auto_fix` from the repo config overlays global auto_fix. Fields not set in the repo config fall through to the global default.
 - `commands` and `ignore_patterns` are repo-only fields.
 - `ci_timeout` and `auto_fix.ci` are the canonical keys; `babysit_timeout` and `auto_fix.babysit` are still accepted as legacy aliases.

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -8,7 +8,7 @@ Global configuration lives at `~/.no-mistakes/config.yaml`. Set `NM_HOME` to rel
 ```yaml
 # ~/.no-mistakes/config.yaml
 
-agent: claude
+agent: auto
 
 agent_path_override:
   claude: /Users/you/bin/claude
@@ -38,8 +38,10 @@ Default agent for all repos. Can be overridden per-repo.
 | | |
 |---|---|
 | Type | `string` |
-| Values | `claude`, `codex`, `rovodev`, `opencode` |
-| Default | `claude` |
+| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode` |
+| Default | `auto` |
+
+`auto` resolves to the first supported agent found on `PATH` in this order: `claude`, `codex`, `opencode`, then `acli` with `rovodev` support.
 
 ### agent_path_override
 

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -40,6 +40,8 @@ Override the default agent for this repo.
 | Values | `auto`, `claude`, `codex`, `rovodev`, `opencode` |
 | Default | Inherits from global config |
 
+`auto` resolves to the first supported agent found on `PATH` in this order: `claude`, `codex`, `opencode`, then `acli` with `rovodev` support.
+
 ### commands.test
 
 Explicit test command. Run via `sh -c`.

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -37,7 +37,7 @@ Override the default agent for this repo.
 | | |
 |---|---|
 | Type | `string` |
-| Values | `claude`, `codex`, `rovodev`, `opencode` |
+| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode` |
 | Default | Inherits from global config |
 
 ### commands.test

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -79,6 +79,6 @@ func New(name types.AgentName, bin string) (Agent, error) {
 	case types.AgentOpenCode:
 		return &opencodeAgent{bin: bin}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent: %s", name)
+		return nil, fmt.Errorf("unknown agent %q; valid options: claude, codex, rovodev, opencode (set 'agent' in ~/.no-mistakes/config.yaml)", name)
 	}
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -79,6 +79,6 @@ func New(name types.AgentName, bin string) (Agent, error) {
 	case types.AgentOpenCode:
 		return &opencodeAgent{bin: bin}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent %q; valid options: claude, codex, rovodev, opencode (set 'agent' in ~/.no-mistakes/config.yaml)", name)
+		return nil, fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode (set 'agent' in ~/.no-mistakes/config.yaml)", name)
 	}
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -45,6 +45,9 @@ func TestNew_Unknown(t *testing.T) {
 	if !strings.Contains(err.Error(), "unknown agent") {
 		t.Errorf("expected 'unknown agent' in error, got: %v", err)
 	}
+	if !strings.Contains(err.Error(), "config.yaml") {
+		t.Errorf("expected config guidance in error, got: %v", err)
+	}
 }
 
 func TestTokenUsage_Total(t *testing.T) {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -45,6 +45,9 @@ func TestNew_Unknown(t *testing.T) {
 	if !strings.Contains(err.Error(), "unknown agent") {
 		t.Errorf("expected 'unknown agent' in error, got: %v", err)
 	}
+	if !strings.Contains(err.Error(), string(types.AgentAuto)) {
+		t.Errorf("expected auto agent option in error, got: %v", err)
+	}
 	if !strings.Contains(err.Error(), "config.yaml") {
 		t.Errorf("expected config guidance in error, got: %v", err)
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -107,6 +107,26 @@ func setupTestRepo(t *testing.T) string {
 	return repoDir
 }
 
+func writeMockClaude(t *testing.T, dir string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		path := filepath.Join(dir, "claude.bat")
+		script := "@echo off\r\necho {\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,\"structured_output\":{\"findings\":[],\"summary\":\"clean\"}}\r\n"
+		if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+	path := filepath.Join(dir, "claude")
+	script := `#!/bin/sh
+printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"structured_output":{"findings":[],"summary":"clean"}}'
+`
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
 func run(t *testing.T, dir string, name string, args ...string) {
 	t.Helper()
 	cmd := exec.Command(name, args...)
@@ -803,6 +823,11 @@ func TestRerunStartsPipelineForCurrentBranch(t *testing.T) {
 	if err := p.EnsureDirs(); err != nil {
 		t.Fatal(err)
 	}
+	mockClaude := writeMockClaude(t, t.TempDir())
+	configYAML := "agent: claude\nagent_path_override:\n  claude: " + mockClaude + "\n"
+	if err := os.WriteFile(p.ConfigFile(), []byte(configYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	d, err := db.Open(p.DB())
 	if err != nil {
@@ -869,6 +894,11 @@ func TestRerunFromWorktreeUsesCurrentWorktreeBranch(t *testing.T) {
 	t.Setenv("NM_HOME", nmHome)
 	p := paths.WithRoot(nmHome)
 	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	mockClaude := writeMockClaude(t, t.TempDir())
+	configYAML := "agent: claude\nagent_path_override:\n  claude: " + mockClaude + "\n"
+	if err := os.WriteFile(p.ConfigFile(), []byte(configYAML), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,13 +1,16 @@
 package config
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/types"
@@ -128,6 +131,30 @@ var agentProbeOrder = []types.AgentName{
 	types.AgentRovoDev,
 }
 
+var probeRovoDevSupport = func(bin string) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, bin, "rovodev", "--help")
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	err := cmd.Run()
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, exec.ErrNotFound) || errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return false, nil
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return false, fmt.Errorf("probe rovodev support via %q timed out", bin)
+	}
+	return false, fmt.Errorf("probe rovodev support via %q: %w", bin, err)
+}
+
 // ResolveAgent resolves AgentAuto to a concrete agent by probing which binaries
 // are available on the system. If agent is already set to a specific value, this
 // is a no-op. The lookPath function should behave like exec.LookPath.
@@ -135,6 +162,7 @@ func (c *Config) ResolveAgent(lookPath func(string) (string, error)) error {
 	if c.Agent != types.AgentAuto {
 		return nil
 	}
+	probed := make([]string, 0, len(agentProbeOrder))
 	for _, name := range agentProbeOrder {
 		bin := string(name)
 		if b, ok := defaultBinary[name]; ok {
@@ -145,14 +173,25 @@ func (c *Config) ResolveAgent(lookPath func(string) (string, error)) error {
 				bin = p
 			}
 		}
-		if _, err := lookPath(bin); err == nil {
+		probed = append(probed, bin)
+		resolvedBin, err := lookPath(bin)
+		if err == nil {
+			if name == types.AgentRovoDev {
+				ok, probeErr := probeRovoDevSupport(resolvedBin)
+				if probeErr != nil {
+					return probeErr
+				}
+				if !ok {
+					continue
+				}
+			}
 			c.Agent = name
 			return nil
 		} else if !errors.Is(err, exec.ErrNotFound) && !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("resolve %s agent from %q: %w", name, bin, err)
 		}
 	}
-	return fmt.Errorf("no supported agent found in PATH (looked for: claude, codex, opencode, acli); install one or set 'agent' in ~/.no-mistakes/config.yaml")
+	return fmt.Errorf("no supported agent found in PATH (looked for: %s); install one or set 'agent' in ~/.no-mistakes/config.yaml", strings.Join(probed, ", "))
 }
 
 // AgentPath returns the binary path for the configured agent,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"time"
 
@@ -147,6 +148,8 @@ func (c *Config) ResolveAgent(lookPath func(string) (string, error)) error {
 		if _, err := lookPath(bin); err == nil {
 			c.Agent = name
 			return nil
+		} else if !errors.Is(err, exec.ErrNotFound) {
+			return fmt.Errorf("resolve %s agent from %q: %w", name, bin, err)
 		}
 	}
 	return fmt.Errorf("no supported agent found in PATH (looked for: claude, codex, opencode, acli); install one or set 'agent' in ~/.no-mistakes/config.yaml")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -137,21 +137,17 @@ func (c *Config) ResolveAgent(lookPath func(string) (string, error)) error {
 	}
 	for _, name := range agentProbeOrder {
 		bin := string(name)
-		hasOverride := false
 		if b, ok := defaultBinary[name]; ok {
 			bin = b
 		}
 		if c.AgentPathOverride != nil {
 			if p, ok := c.AgentPathOverride[string(name)]; ok {
 				bin = p
-				hasOverride = true
 			}
 		}
 		if _, err := lookPath(bin); err == nil {
 			c.Agent = name
 			return nil
-		} else if hasOverride && (errors.Is(err, exec.ErrNotFound) || errors.Is(err, fs.ErrNotExist)) {
-			return fmt.Errorf("resolve %s agent from override %q: %w", name, bin, err)
 		} else if !errors.Is(err, exec.ErrNotFound) && !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("resolve %s agent from %q: %w", name, bin, err)
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -136,21 +135,26 @@ var probeRovoDevSupport = func(bin string) (bool, error) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, bin, "rovodev", "--help")
-	cmd.Stdout = io.Discard
-	cmd.Stderr = io.Discard
-	err := cmd.Run()
+	output, err := cmd.CombinedOutput()
 	if err == nil {
 		return true, nil
 	}
 	if errors.Is(err, exec.ErrNotFound) || errors.Is(err, fs.ErrNotExist) {
 		return false, nil
 	}
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) {
-		return false, nil
-	}
 	if errors.Is(err, context.DeadlineExceeded) {
 		return false, fmt.Errorf("probe rovodev support via %q timed out", bin)
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		text := strings.ToLower(string(output))
+		if strings.Contains(text, "unknown command") ||
+			strings.Contains(text, "unknown subcommand") ||
+			strings.Contains(text, "unrecognized command") ||
+			strings.Contains(text, "no help topic for") {
+			return false, nil
+		}
+		return false, fmt.Errorf("probe rovodev support via %q: %w", bin, err)
 	}
 	return false, fmt.Errorf("probe rovodev support via %q: %w", bin, err)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,8 +130,8 @@ var agentProbeOrder = []types.AgentName{
 	types.AgentRovoDev,
 }
 
-var probeRovoDevSupport = func(bin string) (bool, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+var probeRovoDevSupport = func(ctx context.Context, bin string) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, bin, "rovodev", "--help")
@@ -162,7 +162,7 @@ var probeRovoDevSupport = func(bin string) (bool, error) {
 // ResolveAgent resolves AgentAuto to a concrete agent by probing which binaries
 // are available on the system. If agent is already set to a specific value, this
 // is a no-op. The lookPath function should behave like exec.LookPath.
-func (c *Config) ResolveAgent(lookPath func(string) (string, error)) error {
+func (c *Config) ResolveAgent(ctx context.Context, lookPath func(string) (string, error)) error {
 	if c.Agent != types.AgentAuto {
 		return nil
 	}
@@ -181,7 +181,7 @@ func (c *Config) ResolveAgent(lookPath func(string) (string, error)) error {
 		resolvedBin, err := lookPath(bin)
 		if err == nil {
 			if name == types.AgentRovoDev {
-				ok, probeErr := probeRovoDevSupport(resolvedBin)
+				ok, probeErr := probeRovoDevSupport(ctx, resolvedBin)
 				if probeErr != nil {
 					return probeErr
 				}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,8 +85,9 @@ type Config struct {
 const defaultConfigYAML = `# no-mistakes global configuration
 
 # Agent to use for code generation
-# Options: claude, codex, rovodev, opencode
-agent: claude
+# Options: auto, claude, codex, rovodev, opencode
+# "auto" detects the first available agent on your system
+agent: auto
 
 # Maximum time to monitor CI before timing out
 ci_timeout: "4h"
@@ -116,6 +117,39 @@ var defaultBinary = map[types.AgentName]string{
 	types.AgentCodex:    "codex",
 	types.AgentRovoDev:  "acli",
 	types.AgentOpenCode: "opencode",
+}
+
+// agentProbeOrder is the priority order for auto-detecting agents.
+var agentProbeOrder = []types.AgentName{
+	types.AgentClaude,
+	types.AgentCodex,
+	types.AgentOpenCode,
+	types.AgentRovoDev,
+}
+
+// ResolveAgent resolves AgentAuto to a concrete agent by probing which binaries
+// are available on the system. If agent is already set to a specific value, this
+// is a no-op. The lookPath function should behave like exec.LookPath.
+func (c *Config) ResolveAgent(lookPath func(string) (string, error)) error {
+	if c.Agent != types.AgentAuto {
+		return nil
+	}
+	for _, name := range agentProbeOrder {
+		bin := string(name)
+		if b, ok := defaultBinary[name]; ok {
+			bin = b
+		}
+		if c.AgentPathOverride != nil {
+			if p, ok := c.AgentPathOverride[string(name)]; ok {
+				bin = p
+			}
+		}
+		if _, err := lookPath(bin); err == nil {
+			c.Agent = name
+			return nil
+		}
+	}
+	return fmt.Errorf("no supported agent found in PATH (looked for: claude, codex, opencode, acli); install one or set 'agent' in ~/.no-mistakes/config.yaml")
 }
 
 // AgentPath returns the binary path for the configured agent,
@@ -153,7 +187,7 @@ func EnsureDefaultGlobalConfig(path string) {
 // LoadGlobal reads global config from path. Returns defaults if file doesn't exist.
 func LoadGlobal(path string) (*GlobalConfig, error) {
 	cfg := &GlobalConfig{
-		Agent:     types.AgentClaude,
+		Agent:     types.AgentAuto,
 		CITimeout: 4 * time.Hour,
 		LogLevel:  "info",
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -148,7 +148,7 @@ func (c *Config) ResolveAgent(lookPath func(string) (string, error)) error {
 		if _, err := lookPath(bin); err == nil {
 			c.Agent = name
 			return nil
-		} else if !errors.Is(err, exec.ErrNotFound) {
+		} else if !errors.Is(err, exec.ErrNotFound) && !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("resolve %s agent from %q: %w", name, bin, err)
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -137,17 +137,21 @@ func (c *Config) ResolveAgent(lookPath func(string) (string, error)) error {
 	}
 	for _, name := range agentProbeOrder {
 		bin := string(name)
+		hasOverride := false
 		if b, ok := defaultBinary[name]; ok {
 			bin = b
 		}
 		if c.AgentPathOverride != nil {
 			if p, ok := c.AgentPathOverride[string(name)]; ok {
 				bin = p
+				hasOverride = true
 			}
 		}
 		if _, err := lookPath(bin); err == nil {
 			c.Agent = name
 			return nil
+		} else if hasOverride && (errors.Is(err, exec.ErrNotFound) || errors.Is(err, fs.ErrNotExist)) {
+			return fmt.Errorf("resolve %s agent from override %q: %w", name, bin, err)
 		} else if !errors.Is(err, exec.ErrNotFound) && !errors.Is(err, fs.ErrNotExist) {
 			return fmt.Errorf("resolve %s agent from %q: %w", name, bin, err)
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -806,6 +806,31 @@ func TestResolveAgent_AutoRespectsPathOverride(t *testing.T) {
 	}
 }
 
+func TestResolveAgent_AutoSkipsMissingOverridePath(t *testing.T) {
+	cfg := &Config{
+		Agent:             types.AgentAuto,
+		AgentPathOverride: map[string]string{"claude": "/custom/claude"},
+	}
+
+	err := cfg.ResolveAgent(func(bin string) (string, error) {
+		switch bin {
+		case "/custom/claude":
+			return "", &exec.Error{Name: bin, Err: fs.ErrNotExist}
+		case "codex":
+			return "/usr/bin/codex", nil
+		default:
+			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
+		}
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Agent != types.AgentCodex {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentCodex)
+	}
+}
+
 func TestResolveAgent_AutoReturnsOverrideProbeError(t *testing.T) {
 	cfg := &Config{
 		Agent:             types.AgentAuto,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -831,6 +831,39 @@ func TestResolveAgent_AutoSkipsMissingOverrideAndFallsBack(t *testing.T) {
 	}
 }
 
+func TestResolveAgent_AutoSkipsRovoDevWithoutSubcommand(t *testing.T) {
+	cfg := &Config{Agent: types.AgentAuto}
+	originalProbe := probeRovoDevSupport
+	probeRovoDevSupport = func(bin string) (bool, error) {
+		if bin != "/usr/bin/acli" {
+			t.Fatalf("unexpected rovodev probe for %q", bin)
+		}
+		return false, nil
+	}
+	t.Cleanup(func() {
+		probeRovoDevSupport = originalProbe
+	})
+
+	err := cfg.ResolveAgent(func(bin string) (string, error) {
+		switch bin {
+		case "claude", "codex", "opencode":
+			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
+		case "acli":
+			return "/usr/bin/acli", nil
+		default:
+			t.Fatalf("unexpected probe for %q", bin)
+			return "", nil
+		}
+	})
+
+	if err == nil {
+		t.Fatal("expected error when rovodev subcommand is unavailable")
+	}
+	if cfg.Agent != types.AgentAuto {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentAuto)
+	}
+}
+
 func TestResolveAgent_AutoReturnsOverrideProbeError(t *testing.T) {
 	cfg := &Config{
 		Agent:             types.AgentAuto,
@@ -866,5 +899,29 @@ func TestResolveAgent_AutoNoneAvailable(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "config") {
 		t.Errorf("expected config guidance in error, got: %v", err)
+	}
+}
+
+func TestResolveAgent_AutoNoneAvailableIncludesOverridePaths(t *testing.T) {
+	cfg := &Config{
+		Agent: types.AgentAuto,
+		AgentPathOverride: map[string]string{
+			"claude":   "/custom/claude",
+			"rovodev":  "/custom/acli",
+			"opencode": "/custom/opencode",
+		},
+	}
+
+	err := cfg.ResolveAgent(func(bin string) (string, error) {
+		return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
+	})
+
+	if err == nil {
+		t.Fatal("expected error when no agents found")
+	}
+	for _, want := range []string{"/custom/claude", "/custom/opencode", "/custom/acli"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("expected error to mention %q, got: %v", want, err)
+		}
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"errors"
+	"io/fs"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -801,6 +803,28 @@ func TestResolveAgent_AutoRespectsPathOverride(t *testing.T) {
 	}
 	if cfg.Agent != types.AgentOpenCode {
 		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentOpenCode)
+	}
+}
+
+func TestResolveAgent_AutoReturnsOverrideProbeError(t *testing.T) {
+	cfg := &Config{
+		Agent:             types.AgentAuto,
+		AgentPathOverride: map[string]string{"claude": "/custom/claude"},
+	}
+	wantErr := &exec.Error{Name: "/custom/claude", Err: fs.ErrPermission}
+
+	err := cfg.ResolveAgent(func(bin string) (string, error) {
+		if bin == "/custom/claude" {
+			return "", wantErr
+		}
+		return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
+	})
+
+	if !errors.Is(err, fs.ErrPermission) {
+		t.Fatalf("expected permission error, got %v", err)
+	}
+	if cfg.Agent != types.AgentAuto {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentAuto)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -18,8 +19,8 @@ func TestLoadGlobal_Defaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.Agent != types.AgentClaude {
-		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentClaude)
+	if cfg.Agent != types.AgentAuto {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentAuto)
 	}
 	if cfg.CITimeout != 4*time.Hour {
 		t.Errorf("ci_timeout = %v, want %v", cfg.CITimeout, 4*time.Hour)
@@ -44,7 +45,7 @@ func TestEnsureDefaultGlobalConfig_CreatesFile(t *testing.T) {
 	}
 	content := string(data)
 	for _, want := range []string{
-		"agent: claude",
+		"agent: auto",
 		"ci_timeout:",
 		"log_level: info",
 		"# agent_path_override:",
@@ -65,8 +66,8 @@ func TestEnsureDefaultGlobalConfig_CreatedConfigIsLoadable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error on reload: %v", err)
 	}
-	if cfg.Agent != types.AgentClaude {
-		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentClaude)
+	if cfg.Agent != types.AgentAuto {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentAuto)
 	}
 	if cfg.CITimeout != 4*time.Hour {
 		t.Errorf("ci_timeout = %v, want %v", cfg.CITimeout, 4*time.Hour)
@@ -470,8 +471,8 @@ func TestDefaultConfigYAML_MatchesGoDefaults(t *testing.T) {
 		t.Fatalf("defaultConfigYAML is not valid YAML: %v", err)
 	}
 
-	if raw.Agent != types.AgentClaude {
-		t.Errorf("YAML agent = %q, Go default = %q", raw.Agent, types.AgentClaude)
+	if raw.Agent != types.AgentAuto {
+		t.Errorf("YAML agent = %q, Go default = %q", raw.Agent, types.AgentAuto)
 	}
 	d, err := time.ParseDuration(raw.CITimeout)
 	if err != nil {
@@ -732,5 +733,89 @@ func TestParseLogLevel(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("ParseLogLevel(%q) = %v, want %v", tt.input, got, tt.want)
 		}
+	}
+}
+
+func TestResolveAgent_ExplicitAgent(t *testing.T) {
+	// When agent is explicitly set (not auto), ResolveAgent returns it as-is.
+	cfg := &Config{Agent: types.AgentCodex}
+	err := cfg.ResolveAgent(func(string) (string, error) {
+		t.Fatal("lookPath should not be called for explicit agent")
+		return "", nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Agent != types.AgentCodex {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentCodex)
+	}
+}
+
+func TestResolveAgent_AutoPicksFirstAvailable(t *testing.T) {
+	cfg := &Config{Agent: types.AgentAuto}
+	// Simulate: claude not found, codex found
+	err := cfg.ResolveAgent(func(bin string) (string, error) {
+		if bin == "codex" {
+			return "/usr/bin/codex", nil
+		}
+		return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Agent != types.AgentCodex {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentCodex)
+	}
+}
+
+func TestResolveAgent_AutoPicksClaude(t *testing.T) {
+	cfg := &Config{Agent: types.AgentAuto}
+	err := cfg.ResolveAgent(func(bin string) (string, error) {
+		if bin == "claude" {
+			return "/usr/bin/claude", nil
+		}
+		return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Agent != types.AgentClaude {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentClaude)
+	}
+}
+
+func TestResolveAgent_AutoRespectsPathOverride(t *testing.T) {
+	cfg := &Config{
+		Agent:             types.AgentAuto,
+		AgentPathOverride: map[string]string{"opencode": "/custom/opencode"},
+	}
+	// Only opencode override path exists
+	err := cfg.ResolveAgent(func(bin string) (string, error) {
+		if bin == "/custom/opencode" {
+			return "/custom/opencode", nil
+		}
+		return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Agent != types.AgentOpenCode {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentOpenCode)
+	}
+}
+
+func TestResolveAgent_AutoNoneAvailable(t *testing.T) {
+	cfg := &Config{Agent: types.AgentAuto}
+	err := cfg.ResolveAgent(func(bin string) (string, error) {
+		return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
+	})
+	if err == nil {
+		t.Fatal("expected error when no agents found")
+	}
+	if !strings.Contains(err.Error(), "no supported agent found") {
+		t.Errorf("expected 'no supported agent found' in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "config") {
+		t.Errorf("expected config guidance in error, got: %v", err)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -806,7 +806,7 @@ func TestResolveAgent_AutoRespectsPathOverride(t *testing.T) {
 	}
 }
 
-func TestResolveAgent_AutoSkipsMissingOverridePath(t *testing.T) {
+func TestResolveAgent_AutoReturnsMissingOverridePathError(t *testing.T) {
 	cfg := &Config{
 		Agent:             types.AgentAuto,
 		AgentPathOverride: map[string]string{"claude": "/custom/claude"},
@@ -816,18 +816,16 @@ func TestResolveAgent_AutoSkipsMissingOverridePath(t *testing.T) {
 		switch bin {
 		case "/custom/claude":
 			return "", &exec.Error{Name: bin, Err: fs.ErrNotExist}
-		case "codex":
-			return "/usr/bin/codex", nil
 		default:
 			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
 		}
 	})
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("expected missing override error, got %v", err)
 	}
-	if cfg.Agent != types.AgentCodex {
-		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentCodex)
+	if cfg.Agent != types.AgentAuto {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentAuto)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -864,6 +864,34 @@ func TestResolveAgent_AutoSkipsRovoDevWithoutSubcommand(t *testing.T) {
 	}
 }
 
+func TestResolveAgent_AutoReturnsRovoDevProbeExitError(t *testing.T) {
+	cfg := &Config{Agent: types.AgentAuto}
+	script := filepath.Join(t.TempDir(), "acli")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatalf("write probe script: %v", err)
+	}
+
+	err := cfg.ResolveAgent(func(bin string) (string, error) {
+		switch bin {
+		case "claude", "codex", "opencode":
+			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
+		case "acli":
+			return script, nil
+		default:
+			t.Fatalf("unexpected probe for %q", bin)
+			return "", nil
+		}
+	})
+
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected exit error, got %v", err)
+	}
+	if cfg.Agent != types.AgentAuto {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentAuto)
+	}
+}
+
 func TestResolveAgent_AutoReturnsOverrideProbeError(t *testing.T) {
 	cfg := &Config{
 		Agent:             types.AgentAuto,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"errors"
 	"io/fs"
 	"log/slog"
@@ -741,7 +742,7 @@ func TestParseLogLevel(t *testing.T) {
 func TestResolveAgent_ExplicitAgent(t *testing.T) {
 	// When agent is explicitly set (not auto), ResolveAgent returns it as-is.
 	cfg := &Config{Agent: types.AgentCodex}
-	err := cfg.ResolveAgent(func(string) (string, error) {
+	err := cfg.ResolveAgent(context.Background(), func(string) (string, error) {
 		t.Fatal("lookPath should not be called for explicit agent")
 		return "", nil
 	})
@@ -756,7 +757,7 @@ func TestResolveAgent_ExplicitAgent(t *testing.T) {
 func TestResolveAgent_AutoPicksFirstAvailable(t *testing.T) {
 	cfg := &Config{Agent: types.AgentAuto}
 	// Simulate: claude not found, codex found
-	err := cfg.ResolveAgent(func(bin string) (string, error) {
+	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
 		if bin == "codex" {
 			return "/usr/bin/codex", nil
 		}
@@ -772,7 +773,7 @@ func TestResolveAgent_AutoPicksFirstAvailable(t *testing.T) {
 
 func TestResolveAgent_AutoPicksClaude(t *testing.T) {
 	cfg := &Config{Agent: types.AgentAuto}
-	err := cfg.ResolveAgent(func(bin string) (string, error) {
+	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
 		if bin == "claude" {
 			return "/usr/bin/claude", nil
 		}
@@ -792,7 +793,7 @@ func TestResolveAgent_AutoRespectsPathOverride(t *testing.T) {
 		AgentPathOverride: map[string]string{"opencode": "/custom/opencode"},
 	}
 	// Only opencode override path exists
-	err := cfg.ResolveAgent(func(bin string) (string, error) {
+	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
 		if bin == "/custom/opencode" {
 			return "/custom/opencode", nil
 		}
@@ -812,7 +813,7 @@ func TestResolveAgent_AutoSkipsMissingOverrideAndFallsBack(t *testing.T) {
 		AgentPathOverride: map[string]string{"claude": "/custom/claude"},
 	}
 
-	err := cfg.ResolveAgent(func(bin string) (string, error) {
+	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
 		switch bin {
 		case "/custom/claude":
 			return "", &exec.Error{Name: bin, Err: fs.ErrNotExist}
@@ -834,7 +835,7 @@ func TestResolveAgent_AutoSkipsMissingOverrideAndFallsBack(t *testing.T) {
 func TestResolveAgent_AutoSkipsRovoDevWithoutSubcommand(t *testing.T) {
 	cfg := &Config{Agent: types.AgentAuto}
 	originalProbe := probeRovoDevSupport
-	probeRovoDevSupport = func(bin string) (bool, error) {
+	probeRovoDevSupport = func(_ context.Context, bin string) (bool, error) {
 		if bin != "/usr/bin/acli" {
 			t.Fatalf("unexpected rovodev probe for %q", bin)
 		}
@@ -844,7 +845,7 @@ func TestResolveAgent_AutoSkipsRovoDevWithoutSubcommand(t *testing.T) {
 		probeRovoDevSupport = originalProbe
 	})
 
-	err := cfg.ResolveAgent(func(bin string) (string, error) {
+	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
 		switch bin {
 		case "claude", "codex", "opencode":
 			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
@@ -871,7 +872,7 @@ func TestResolveAgent_AutoReturnsRovoDevProbeExitError(t *testing.T) {
 		t.Fatalf("write probe script: %v", err)
 	}
 
-	err := cfg.ResolveAgent(func(bin string) (string, error) {
+	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
 		switch bin {
 		case "claude", "codex", "opencode":
 			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
@@ -899,7 +900,7 @@ func TestResolveAgent_AutoReturnsOverrideProbeError(t *testing.T) {
 	}
 	wantErr := &exec.Error{Name: "/custom/claude", Err: fs.ErrPermission}
 
-	err := cfg.ResolveAgent(func(bin string) (string, error) {
+	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
 		if bin == "/custom/claude" {
 			return "", wantErr
 		}
@@ -916,7 +917,7 @@ func TestResolveAgent_AutoReturnsOverrideProbeError(t *testing.T) {
 
 func TestResolveAgent_AutoNoneAvailable(t *testing.T) {
 	cfg := &Config{Agent: types.AgentAuto}
-	err := cfg.ResolveAgent(func(bin string) (string, error) {
+	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
 		return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
 	})
 	if err == nil {
@@ -940,7 +941,7 @@ func TestResolveAgent_AutoNoneAvailableIncludesOverridePaths(t *testing.T) {
 		},
 	}
 
-	err := cfg.ResolveAgent(func(bin string) (string, error) {
+	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
 		return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
 	})
 
@@ -951,5 +952,43 @@ func TestResolveAgent_AutoNoneAvailableIncludesOverridePaths(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("expected error to mention %q, got: %v", want, err)
 		}
+	}
+}
+
+func TestResolveAgent_AutoPassesContextToRovoDevProbe(t *testing.T) {
+	cfg := &Config{Agent: types.AgentAuto}
+	originalProbe := probeRovoDevSupport
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	probeRovoDevSupport = func(ctx context.Context, bin string) (bool, error) {
+		if bin != "/usr/bin/acli" {
+			t.Fatalf("unexpected rovodev probe for %q", bin)
+		}
+		if !errors.Is(ctx.Err(), context.Canceled) {
+			t.Fatalf("probe context error = %v, want %v", ctx.Err(), context.Canceled)
+		}
+		return false, ctx.Err()
+	}
+	t.Cleanup(func() {
+		probeRovoDevSupport = originalProbe
+	})
+
+	err := cfg.ResolveAgent(ctx, func(bin string) (string, error) {
+		switch bin {
+		case "claude", "codex", "opencode":
+			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
+		case "acli":
+			return "/usr/bin/acli", nil
+		default:
+			t.Fatalf("unexpected probe for %q", bin)
+			return "", nil
+		}
+	})
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected canceled error, got %v", err)
+	}
+	if cfg.Agent != types.AgentAuto {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentAuto)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -806,7 +806,7 @@ func TestResolveAgent_AutoRespectsPathOverride(t *testing.T) {
 	}
 }
 
-func TestResolveAgent_AutoReturnsMissingOverridePathError(t *testing.T) {
+func TestResolveAgent_AutoSkipsMissingOverrideAndFallsBack(t *testing.T) {
 	cfg := &Config{
 		Agent:             types.AgentAuto,
 		AgentPathOverride: map[string]string{"claude": "/custom/claude"},
@@ -816,16 +816,18 @@ func TestResolveAgent_AutoReturnsMissingOverridePathError(t *testing.T) {
 		switch bin {
 		case "/custom/claude":
 			return "", &exec.Error{Name: bin, Err: fs.ErrNotExist}
+		case "codex":
+			return "/usr/bin/codex", nil
 		default:
 			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
 		}
 	})
 
-	if !errors.Is(err, fs.ErrNotExist) {
-		t.Fatalf("expected missing override error, got %v", err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.Agent != types.AgentAuto {
-		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentAuto)
+	if cfg.Agent != types.AgentCodex {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentCodex)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -868,7 +869,12 @@ func TestResolveAgent_AutoSkipsRovoDevWithoutSubcommand(t *testing.T) {
 func TestResolveAgent_AutoReturnsRovoDevProbeExitError(t *testing.T) {
 	cfg := &Config{Agent: types.AgentAuto}
 	script := filepath.Join(t.TempDir(), "acli")
-	if err := os.WriteFile(script, []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+	contents := []byte("#!/bin/sh\nexit 1\n")
+	if runtime.GOOS == "windows" {
+		script += ".cmd"
+		contents = []byte("@echo off\r\nexit /b 1\r\n")
+	}
+	if err := os.WriteFile(script, contents, 0o755); err != nil {
 		t.Fatalf("write probe script: %v", err)
 	}
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -458,6 +458,13 @@ func startTestDaemonWithSteps(t *testing.T, sf StepFactory) (*paths.Paths, *db.D
 		t.Fatal(err)
 	}
 
+	// Keep daemon tests hermetic now that the default config auto-detects agents.
+	mockClaude := writeMockClaude(t, t.TempDir())
+	configYAML := "agent: claude\nagent_path_override:\n  claude: " + mockClaude + "\n"
+	if err := os.WriteFile(p.ConfigFile(), []byte(configYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
 	d, err := db.Open(p.DB())
 	if err != nil {
 		t.Fatal(err)

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -269,6 +270,12 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 		return "", fmt.Errorf("load repo config: %w", err)
 	}
 	cfg := config.Merge(globalCfg, repoCfg)
+
+	// Resolve "auto" agent to whichever binary is available.
+	if err := cfg.ResolveAgent(exec.LookPath); err != nil {
+		m.db.UpdateRunError(run.ID, err.Error())
+		return "", err
+	}
 
 	// Create agent.
 	ag, err := agent.New(cfg.Agent, cfg.AgentPath())

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -272,7 +272,7 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 	cfg := config.Merge(globalCfg, repoCfg)
 
 	// Resolve "auto" agent to whichever binary is available.
-	if err := cfg.ResolveAgent(exec.LookPath); err != nil {
+	if err := cfg.ResolveAgent(ctx, exec.LookPath); err != nil {
 		m.db.UpdateRunError(run.ID, err.Error())
 		return "", err
 	}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -129,6 +129,7 @@ const (
 type AgentName string
 
 const (
+	AgentAuto     AgentName = "auto"
 	AgentClaude   AgentName = "claude"
 	AgentCodex    AgentName = "codex"
 	AgentRovoDev  AgentName = "rovodev"


### PR DESCRIPTION
## Summary
- add `auto` agent resolution in config so the CLI can pick an available backend by probing supported agents instead of requiring an explicit default
- harden auto-detection and startup behavior by surfacing broken Rovo Dev and override-path misconfigurations, propagating cancellation, and improving unknown-agent guidance
- update README and config/agent docs for the new default behavior, and hermeticize daemon tests so they do not depend on host-installed agent binaries

## Risk Assessment

✅ Low: The change is well-scoped, the new auto-detection path is covered by targeted tests, and I did not find a correctness or safety issue in the touched code.

## Pipeline

Updates from `git push no-mistakes`

✅ **Rebase** - passed
🔧 **Review** - 2 issues found → auto-fixed (3) + user-fixed (1)
🔧 **Test** - 1 issue found → auto-fixed
✅ **Lint** - passed

<details>
<summary>Review details</summary>

**Round 1** - found 2 issues (1 warning, 1 info)
- ⚠️ `internal/config/config.go:138` - `auto` mode considers `rovodev` available as soon as `acli` is on `PATH`, but the backend later depends on the `rovodev` subcommand (`acli rovodev serve`). A plain Atlassian CLI install can therefore be auto-selected and only fail after a run has already been created.
- ℹ️ `internal/config/config.go:155` - When auto-detection exhausts all candidates, the final error only reports the default binaries it looked for and omits any `agent_path_override` paths that were actually probed, which makes override misconfiguration harder to diagnose.

**Round 2** (auto-fix) - found 2 issues (1 warning, 1 info)
- ⚠️ `internal/config/config.go:149` - `probeRovoDevSupport` treats every non-zero exit from `acli rovodev --help` as "unsupported" and silently falls back. That masks broken `agent_path_override.rovodev` values or partially broken Rovo installs, so `agent: auto` can choose a different backend without surfacing the real misconfiguration.
- ℹ️ `internal/agent/agent.go:82` - The unknown-agent error message now lists only concrete backends even though `auto` is a supported config value. Any caller that reaches `agent.New("auto", ...)` will get misleading guidance while debugging resolution issues.

**Round 3** (auto-fix) - found 1 warning
- ⚠️ `internal/config/config.go:148` - Any non-zero exit from `acli rovodev --help` is treated as "unsupported" and skipped. If the `acli` binary is present but broken or crashes, auto-detection can silently fall through to a different agent (or report none found) instead of surfacing the real misconfiguration.

**Round 4** (auto-fix) - found 1 warning
- ⚠️ `internal/config/config.go:134` - `probeRovoDevSupport` launches `acli rovodev --help` with `context.Background()`, so a cancelled run startup or daemon shutdown cannot interrupt the probe and may still block for the full timeout before returning; pass the caller context through `ResolveAgent` instead.

**Round 5** (user-fix) - found 0 issues

</details>

<details>
<summary>Test details</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/daemon/daemon_test.go:447` - Daemon integration tests became environment-dependent after the default agent changed to `auto`. On a PATH without host agent binaries, `TestPushReceivedCreatesRun` fails with `no supported agent found in PATH...` because the shared test helper did not pin a mock agent config. I fixed this locally by writing a hermetic Claude override in the helper and re-ran the relevant tests successfully.

**Round 2** (auto-fix) - found 0 issues

</details>
