### PR TITLE
fix(rebase): harden force-push handling

### DIFF
--- a/docs/src/content/docs/guides/pipeline-steps.md
+++ b/docs/src/content/docs/guides/pipeline-steps.md
@@ -16,8 +16,10 @@ Each step can produce findings, request approval, or trigger auto-fix. Steps tha
 Fetches the latest upstream and rebases your branch onto it.
 
 **Behavior:**
-- Fetches `origin/<default_branch>` and `origin/<branch>` into the worktree
+- Fetches `origin/<default_branch>` into the worktree, and also fetches `origin/<branch>` for non-default branches unless the push rewrote branch history
 - If the branch is not the default branch, tries rebasing onto `origin/<branch>` first, then `origin/<default_branch>`
+- If the push rewrote branch history, skips the `origin/<branch>` rebase target so prior remote autofix commits do not get reintroduced
+- If the push rewrote the default branch and `origin/<default_branch>` advanced after that rewrite, pauses for manual approval before updating the branch
 - Skips targets that don't exist or are already ancestors
 - If a fast-forward is possible, does a hard-reset instead of a rebase
 - If the diff against the default branch is empty after rebase, completes rebase and skips all remaining pipeline steps

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -159,8 +159,10 @@ func DefaultBranch(ctx context.Context, dir, remote string) string {
 }
 
 // FetchRemoteBranch fetches a single branch into a remote-tracking ref.
+// Uses a force-update refspec (+) so non-fast-forward updates (e.g. after
+// a force push on the remote) are accepted instead of silently rejected.
 func FetchRemoteBranch(ctx context.Context, dir, remote, branch string) error {
-	refspec := fmt.Sprintf("refs/heads/%s:refs/remotes/%s/%s", branch, remote, branch)
+	refspec := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s/%s", branch, remote, branch)
 	_, err := Run(ctx, dir, "fetch", "--no-tags", remote, refspec)
 	return err
 }

--- a/internal/ipc/server_test.go
+++ b/internal/ipc/server_test.go
@@ -268,10 +268,18 @@ func TestServerClose(t *testing.T) {
 		t.Errorf("Serve returned unexpected error: %v", err)
 	}
 
-	// dial should fail after close
-	_, err = ipc.Dial(sock)
-	if err == nil {
-		t.Error("expected dial to fail after server close")
+	// dial should fail after close (on Windows named pipes may need a moment)
+	dialDeadline := time.Now().Add(2 * time.Second)
+	for {
+		_, dialErr := ipc.Dial(sock)
+		if dialErr != nil {
+			break
+		}
+		if time.Now().After(dialDeadline) {
+			t.Error("expected dial to fail after server close")
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
 	}
 }
 

--- a/internal/pipeline/steps/rebase.go
+++ b/internal/pipeline/steps/rebase.go
@@ -27,17 +27,27 @@ func (s *RebaseStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome,
 		defaultBranch = "main"
 	}
 
+	// Detect force push before fetching so we can skip origin/<branch> sync.
+	// A force push means the user explicitly rewrote the branch - the pushed
+	// commit is authoritative and must not be overwritten by prior pipeline
+	// state on the remote.
+	forcePush := isForcePush(ctx, sctx.WorkDir, sctx.Run.BaseSHA)
+
 	sctx.Log("fetching latest upstream state...")
 	if err := git.FetchRemoteBranch(ctx, sctx.WorkDir, "origin", defaultBranch); err != nil {
 		sctx.LogFile(fmt.Sprintf("warning: could not fetch origin/%s: %v", defaultBranch, err))
 	}
-	if branch != "" && branch != defaultBranch {
+	if !forcePush && branch != "" && branch != defaultBranch {
 		if err := git.FetchRemoteBranch(ctx, sctx.WorkDir, "origin", branch); err != nil {
 			sctx.LogFile(fmt.Sprintf("warning: could not fetch origin/%s: %v", branch, err))
 		}
 	}
 
 	targets := rebaseTargets(branch, defaultBranch)
+	if forcePush {
+		sctx.Log("force push detected, skipping origin/" + branch + " sync")
+		targets = forcePushRebaseTargets(defaultBranch)
+	}
 
 	if sctx.Fixing {
 		for _, target := range targets {
@@ -91,6 +101,24 @@ func rebaseTargets(branch, defaultBranch string) []string {
 		targets = append(targets, "origin/"+defaultBranch)
 	}
 	return targets
+}
+
+// forcePushRebaseTargets returns rebase targets for a force push - only the
+// default branch. The origin/<branch> target is skipped because it may contain
+// autofix commits from prior pipeline runs that the force push intended to discard.
+func forcePushRebaseTargets(defaultBranch string) []string {
+	return []string{"origin/" + defaultBranch}
+}
+
+// isForcePush returns true when the current push is non-fast-forward relative
+// to the previous push (baseSHA). This indicates the user explicitly rewrote
+// history and the pipeline should treat the new HEAD as authoritative.
+func isForcePush(ctx context.Context, workDir, baseSHA string) bool {
+	if git.IsZeroSHA(baseSHA) || baseSHA == "" {
+		return false
+	}
+	_, err := git.Run(ctx, workDir, "merge-base", "--is-ancestor", baseSHA, "HEAD")
+	return err != nil
 }
 
 // tryRebase attempts a rebase onto targetRef. Returns conflicted files when the

--- a/internal/pipeline/steps/rebase.go
+++ b/internal/pipeline/steps/rebase.go
@@ -48,7 +48,7 @@ func (s *RebaseStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome,
 	targets := rebaseTargets(branch, defaultBranch)
 	if forcePush {
 		sctx.Log("force push detected, skipping origin/" + branch + " sync")
-		targets = forcePushRebaseTargets(defaultBranch)
+		targets = forcePushRebaseTargets(branch, defaultBranch)
 	}
 
 	if sctx.Fixing {
@@ -105,10 +105,13 @@ func rebaseTargets(branch, defaultBranch string) []string {
 	return targets
 }
 
-// forcePushRebaseTargets returns rebase targets for a force push - only the
-// default branch. The origin/<branch> target is skipped because it may contain
-// autofix commits from prior pipeline runs that the force push intended to discard.
-func forcePushRebaseTargets(defaultBranch string) []string {
+// forcePushRebaseTargets returns rebase targets for a force push. The
+// origin/<branch> target is skipped because it may contain autofix commits
+// from prior pipeline runs that the force push intended to discard.
+func forcePushRebaseTargets(branch, defaultBranch string) []string {
+	if branch == defaultBranch {
+		return nil
+	}
 	return []string{"origin/" + defaultBranch}
 }
 
@@ -130,7 +133,11 @@ func isForcePush(ctx context.Context, workDir, branch, baseSHA string) bool {
 	if branch != "" {
 		remoteRef := "origin/" + branch
 		if _, err := git.Run(ctx, workDir, "rev-parse", "--verify", remoteRef); err == nil {
-			_, err := git.Run(ctx, workDir, "merge-base", "--is-ancestor", remoteRef, "HEAD")
+			return isRemoteBranchRewritten(ctx, workDir, remoteRef)
+		}
+		remoteSHA, err := git.LsRemote(ctx, workDir, "origin", "refs/heads/"+branch)
+		if err == nil && remoteSHA != "" {
+			_, err := git.Run(ctx, workDir, "merge-base", "--is-ancestor", remoteSHA, "HEAD")
 			if err == nil {
 				return false
 			}
@@ -139,6 +146,15 @@ func isForcePush(ctx context.Context, workDir, branch, baseSHA string) bool {
 		}
 	}
 	return true
+}
+
+func isRemoteBranchRewritten(ctx context.Context, workDir, remoteRef string) bool {
+	_, err := git.Run(ctx, workDir, "merge-base", "--is-ancestor", remoteRef, "HEAD")
+	if err == nil {
+		return false
+	}
+	var exitErr *exec.ExitError
+	return errors.As(err, &exitErr) && exitErr.ExitCode() == 1
 }
 
 // tryRebase attempts a rebase onto targetRef. Returns conflicted files when the

--- a/internal/pipeline/steps/rebase.go
+++ b/internal/pipeline/steps/rebase.go
@@ -44,6 +44,20 @@ func (s *RebaseStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome,
 			sctx.LogFile(fmt.Sprintf("warning: could not fetch origin/%s: %v", branch, err))
 		}
 	}
+	if forcePush && branch == defaultBranch && remoteDefaultBranchAdvanced(ctx, sctx.WorkDir, defaultBranch, sctx.Run.BaseSHA) {
+		findingsJSON, _ := json.Marshal(Findings{
+			Items: []Finding{{
+				Severity:    "warning",
+				File:        filepath.Join("internal", "pipeline", "steps", "rebase.go"),
+				Description: fmt.Sprintf("origin/%s advanced after the force push; manual review required before updating the default branch", defaultBranch),
+			}},
+			Summary: fmt.Sprintf("remote %s advanced during force push", defaultBranch),
+		})
+		return &pipeline.StepOutcome{
+			NeedsApproval: true,
+			Findings:      string(findingsJSON),
+		}, nil
+	}
 
 	targets := rebaseTargets(branch, defaultBranch)
 	if forcePush {
@@ -115,6 +129,17 @@ func forcePushRebaseTargets(branch, defaultBranch string) []string {
 	return []string{"origin/" + defaultBranch}
 }
 
+func remoteDefaultBranchAdvanced(ctx context.Context, workDir, defaultBranch, baseSHA string) bool {
+	if baseSHA == "" || git.IsZeroSHA(baseSHA) {
+		return false
+	}
+	remoteSHA, err := git.Run(ctx, workDir, "rev-parse", "--verify", "origin/"+defaultBranch)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(remoteSHA) != baseSHA
+}
+
 // isForcePush returns true when the current push is non-fast-forward relative
 // to the previous push (baseSHA). This indicates the user explicitly rewrote
 // history and the pipeline should treat the new HEAD as authoritative.
@@ -141,14 +166,13 @@ func isForcePush(ctx context.Context, workDir, branch, baseSHA string) bool {
 			if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
 				return true
 			}
-			return true
 		}
 		remoteRef := "origin/" + branch
 		if _, err := git.Run(ctx, workDir, "rev-parse", "--verify", remoteRef); err == nil {
 			return isRemoteBranchRewritten(ctx, workDir, remoteRef)
 		}
 	}
-	return true
+	return false
 }
 
 func isRemoteBranchRewritten(ctx context.Context, workDir, remoteRef string) bool {

--- a/internal/pipeline/steps/rebase.go
+++ b/internal/pipeline/steps/rebase.go
@@ -3,8 +3,10 @@ package steps
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -118,7 +120,11 @@ func isForcePush(ctx context.Context, workDir, baseSHA string) bool {
 		return false
 	}
 	_, err := git.Run(ctx, workDir, "merge-base", "--is-ancestor", baseSHA, "HEAD")
-	return err != nil
+	if err == nil {
+		return false
+	}
+	var exitErr *exec.ExitError
+	return errors.As(err, &exitErr) && exitErr.ExitCode() == 1
 }
 
 // tryRebase attempts a rebase onto targetRef. Returns conflicted files when the

--- a/internal/pipeline/steps/rebase.go
+++ b/internal/pipeline/steps/rebase.go
@@ -33,7 +33,7 @@ func (s *RebaseStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome,
 	// A force push means the user explicitly rewrote the branch - the pushed
 	// commit is authoritative and must not be overwritten by prior pipeline
 	// state on the remote.
-	forcePush := isForcePush(ctx, sctx.WorkDir, sctx.Run.BaseSHA)
+	forcePush := isForcePush(ctx, sctx.WorkDir, branch, sctx.Run.BaseSHA)
 
 	sctx.Log("fetching latest upstream state...")
 	if err := git.FetchRemoteBranch(ctx, sctx.WorkDir, "origin", defaultBranch); err != nil {
@@ -115,7 +115,7 @@ func forcePushRebaseTargets(defaultBranch string) []string {
 // isForcePush returns true when the current push is non-fast-forward relative
 // to the previous push (baseSHA). This indicates the user explicitly rewrote
 // history and the pipeline should treat the new HEAD as authoritative.
-func isForcePush(ctx context.Context, workDir, baseSHA string) bool {
+func isForcePush(ctx context.Context, workDir, branch, baseSHA string) bool {
 	if git.IsZeroSHA(baseSHA) || baseSHA == "" {
 		return false
 	}
@@ -124,7 +124,21 @@ func isForcePush(ctx context.Context, workDir, baseSHA string) bool {
 		return false
 	}
 	var exitErr *exec.ExitError
-	return errors.As(err, &exitErr) && exitErr.ExitCode() == 1
+	if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+		return false
+	}
+	if branch != "" {
+		remoteRef := "origin/" + branch
+		if _, err := git.Run(ctx, workDir, "rev-parse", "--verify", remoteRef); err == nil {
+			_, err := git.Run(ctx, workDir, "merge-base", "--is-ancestor", remoteRef, "HEAD")
+			if err == nil {
+				return false
+			}
+			var exitErr *exec.ExitError
+			return errors.As(err, &exitErr) && exitErr.ExitCode() == 1
+		}
+	}
+	return true
 }
 
 // tryRebase attempts a rebase onto targetRef. Returns conflicted files when the

--- a/internal/pipeline/steps/rebase.go
+++ b/internal/pipeline/steps/rebase.go
@@ -142,7 +142,10 @@ func isForcePush(ctx context.Context, workDir, branch, baseSHA string) bool {
 				return false
 			}
 			var exitErr *exec.ExitError
-			return errors.As(err, &exitErr) && exitErr.ExitCode() == 1
+			if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+				return true
+			}
+			return true
 		}
 	}
 	return true

--- a/internal/pipeline/steps/rebase.go
+++ b/internal/pipeline/steps/rebase.go
@@ -131,10 +131,6 @@ func isForcePush(ctx context.Context, workDir, branch, baseSHA string) bool {
 		return false
 	}
 	if branch != "" {
-		remoteRef := "origin/" + branch
-		if _, err := git.Run(ctx, workDir, "rev-parse", "--verify", remoteRef); err == nil {
-			return isRemoteBranchRewritten(ctx, workDir, remoteRef)
-		}
 		remoteSHA, err := git.LsRemote(ctx, workDir, "origin", "refs/heads/"+branch)
 		if err == nil && remoteSHA != "" {
 			_, err := git.Run(ctx, workDir, "merge-base", "--is-ancestor", remoteSHA, "HEAD")
@@ -146,6 +142,10 @@ func isForcePush(ctx context.Context, workDir, branch, baseSHA string) bool {
 				return true
 			}
 			return true
+		}
+		remoteRef := "origin/" + branch
+		if _, err := git.Run(ctx, workDir, "rev-parse", "--verify", remoteRef); err == nil {
+			return isRemoteBranchRewritten(ctx, workDir, remoteRef)
 		}
 	}
 	return true

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1272,6 +1272,47 @@ func TestIsForcePush_RerunWithoutLocalRemoteRefIsNotForcePush(t *testing.T) {
 	}
 }
 
+func TestIsForcePush_MissingRemoteObjectTreatsAsForcePush(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	originRepo := t.TempDir()
+	gitCmd(t, originRepo, "init")
+	gitCmd(t, originRepo, "config", "user.name", "test")
+	gitCmd(t, originRepo, "config", "user.email", "test@test.com")
+	gitCmd(t, originRepo, "checkout", "-b", "main")
+	gitCmd(t, originRepo, "remote", "add", "origin", upstream)
+
+	os.WriteFile(filepath.Join(originRepo, "app.txt"), []byte("base\n"), 0o644)
+	gitCmd(t, originRepo, "add", "-A")
+	gitCmd(t, originRepo, "commit", "-m", "base commit")
+	gitCmd(t, originRepo, "push", "origin", "main")
+
+	gitCmd(t, originRepo, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(originRepo, "feature.txt"), []byte("remote feature\n"), 0o644)
+	gitCmd(t, originRepo, "add", "-A")
+	gitCmd(t, originRepo, "commit", "-m", "feature commit")
+	gitCmd(t, originRepo, "push", "origin", "feature")
+
+	worktree := t.TempDir()
+	gitCmd(t, worktree, "init")
+	gitCmd(t, worktree, "config", "user.name", "test")
+	gitCmd(t, worktree, "config", "user.email", "test@test.com")
+	gitCmd(t, worktree, "remote", "add", "origin", upstream)
+	gitCmd(t, worktree, "fetch", "--no-tags", "origin", "+refs/heads/main:refs/remotes/origin/main")
+	gitCmd(t, worktree, "checkout", "--detach", "origin/main")
+
+	os.WriteFile(filepath.Join(worktree, "local.txt"), []byte("local only\n"), 0o644)
+	gitCmd(t, worktree, "add", "-A")
+	gitCmd(t, worktree, "commit", "-m", "local commit")
+	baseSHA := gitCmd(t, worktree, "rev-parse", "HEAD")
+	gitCmd(t, worktree, "checkout", "--detach", "origin/main")
+
+	if !isForcePush(context.Background(), worktree, "feature", baseSHA) {
+		t.Fatal("expected missing remote tip object to be treated as force push")
+	}
+}
+
 // --- Review step tests ---
 
 func TestReviewStep_EmptyDiff(t *testing.T) {

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1058,6 +1058,63 @@ func TestRebaseStep_ForcePushSkipsOriginBranch(t *testing.T) {
 	}
 }
 
+func TestRebaseStep_ForcePushOnDefaultBranchSkipsRemoteSync(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+
+	os.WriteFile(filepath.Join(dir, "app.txt"), []byte("base\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "base commit")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	os.WriteFile(filepath.Join(dir, "app.txt"), []byte("base\nuser-change\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "user commit")
+	userCommitSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	os.WriteFile(filepath.Join(dir, "app.txt"), []byte("base\nautofix\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "no-mistakes(review): autofix commit")
+	autofixSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "reset", "--hard", userCommitSHA)
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, autofixSHA, userCommitSHA, config.Commands{})
+	sctx.Run.Branch = "refs/heads/main"
+	sctx.Repo.UpstreamURL = upstream
+
+	step := &RebaseStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Fatal("expected no approval for clean default-branch force push")
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "app.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "base\nuser-change\n" {
+		t.Fatalf("app.txt = %q, want %q; default branch force push was not respected", string(content), "base\nuser-change\n")
+	}
+
+	if got := gitCmd(t, dir, "rev-parse", "HEAD"); got != userCommitSHA {
+		t.Fatalf("HEAD = %s, want %s", got, userCommitSHA)
+	}
+}
+
 func TestRebaseStep_NormalPushSyncsOriginBranch(t *testing.T) {
 	// Verify that a normal (non-force) push still syncs with origin/<branch>.
 	upstream := t.TempDir()
@@ -1164,6 +1221,54 @@ func TestIsForcePush_RerunAfterNormalRebaseIsNotForcePush(t *testing.T) {
 
 	if isForcePush(context.Background(), dir, "feature", baseSHA) {
 		t.Fatal("expected rerun after normal rebase to not be treated as force push")
+	}
+}
+
+func TestIsForcePush_RerunWithoutLocalRemoteRefIsNotForcePush(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	originRepo := t.TempDir()
+	gitCmd(t, originRepo, "init")
+	gitCmd(t, originRepo, "config", "user.name", "test")
+	gitCmd(t, originRepo, "config", "user.email", "test@test.com")
+	gitCmd(t, originRepo, "checkout", "-b", "main")
+	gitCmd(t, originRepo, "remote", "add", "origin", upstream)
+
+	os.WriteFile(filepath.Join(originRepo, "app.txt"), []byte("base\n"), 0o644)
+	gitCmd(t, originRepo, "add", "-A")
+	gitCmd(t, originRepo, "commit", "-m", "base commit")
+	gitCmd(t, originRepo, "push", "origin", "main")
+
+	gitCmd(t, originRepo, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(originRepo, "feature.txt"), []byte("v1\n"), 0o644)
+	gitCmd(t, originRepo, "add", "-A")
+	gitCmd(t, originRepo, "commit", "-m", "feature v1")
+	gitCmd(t, originRepo, "push", "origin", "feature")
+	baseSHA := gitCmd(t, originRepo, "rev-parse", "HEAD")
+
+	gitCmd(t, originRepo, "checkout", "main")
+	os.WriteFile(filepath.Join(originRepo, "app.txt"), []byte("base\nmain update\n"), 0o644)
+	gitCmd(t, originRepo, "add", "-A")
+	gitCmd(t, originRepo, "commit", "-m", "main update")
+	gitCmd(t, originRepo, "push", "origin", "main")
+
+	gitCmd(t, originRepo, "checkout", "feature")
+	gitCmd(t, originRepo, "rebase", "origin/main")
+	gitCmd(t, originRepo, "push", "origin", "feature", "--force-with-lease")
+
+	worktree := t.TempDir()
+	gitCmd(t, worktree, "init")
+	gitCmd(t, worktree, "config", "user.name", "test")
+	gitCmd(t, worktree, "config", "user.email", "test@test.com")
+	gitCmd(t, worktree, "remote", "add", "origin", upstream)
+	gitCmd(t, worktree, "fetch", "--no-tags", "origin", "+refs/heads/main:refs/remotes/origin/main")
+	gitCmd(t, worktree, "fetch", "--no-tags", "origin", "+refs/heads/feature:refs/tmp/feature")
+	gitCmd(t, worktree, "checkout", "--detach", "refs/tmp/feature")
+	gitCmd(t, worktree, "update-ref", "-d", "refs/tmp/feature")
+
+	if isForcePush(context.Background(), worktree, "feature", baseSHA) {
+		t.Fatal("expected rerun without local origin/feature ref to not be treated as force push")
 	}
 }
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1113,6 +1113,21 @@ func TestRebaseStep_NormalPushSyncsOriginBranch(t *testing.T) {
 	}
 }
 
+func TestIsForcePush_IgnoresMergeBaseLookupErrors(t *testing.T) {
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+
+	os.WriteFile(filepath.Join(dir, "app.txt"), []byte("base\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "base commit")
+
+	if isForcePush(context.Background(), dir, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef") {
+		t.Fatal("expected missing base SHA lookup error to not be treated as force push")
+	}
+}
+
 // --- Review step tests ---
 
 func TestReviewStep_EmptyDiff(t *testing.T) {

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1046,8 +1046,8 @@ func TestRebaseStep_ForcePushSkipsOriginBranch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(content) != "user-change\n" {
-		t.Fatalf("feature.txt = %q, want %q; force push was not respected", string(content), "user-change\n")
+	if got := strings.ReplaceAll(string(content), "\r\n", "\n"); got != "user-change\n" {
+		t.Fatalf("feature.txt = %q, want %q; force push was not respected", got, "user-change\n")
 	}
 
 	// Should be rebased onto origin/main
@@ -1106,8 +1106,8 @@ func TestRebaseStep_ForcePushOnDefaultBranchSkipsRemoteSync(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(content) != "base\nuser-change\n" {
-		t.Fatalf("app.txt = %q, want %q; default branch force push was not respected", string(content), "base\nuser-change\n")
+	if got := strings.ReplaceAll(string(content), "\r\n", "\n"); got != "base\nuser-change\n" {
+		t.Fatalf("app.txt = %q, want %q; default branch force push was not respected", got, "base\nuser-change\n")
 	}
 
 	if got := gitCmd(t, dir, "rev-parse", "HEAD"); got != userCommitSHA {

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -981,6 +981,138 @@ func TestRebaseStep_NonEmptyDiffAfterRebase_DoesNotSkip(t *testing.T) {
 	}
 }
 
+func TestRebaseStep_ForcePushSkipsOriginBranch(t *testing.T) {
+	// Simulate the scenario that caused the bug: user force-pushes a commit,
+	// but origin/<branch> on the upstream remote has autofix commits from a
+	// prior pipeline run. The rebase step should skip origin/<branch> entirely
+	// and only rebase onto origin/main.
+
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	os.WriteFile(filepath.Join(dir, "app.txt"), []byte("base\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "base commit")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	// Advance main with another commit
+	os.WriteFile(filepath.Join(dir, "app.txt"), []byte("base\nmain-update\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "main update")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	// Create feature branch with user's original commit
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("user-change\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "user commit")
+	userCommitSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	// Simulate a prior pipeline run that added autofix commits on top and pushed
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("autofix-overwrote-user\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "no-mistakes(review): autofix commit")
+	autofixSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	// User force-pushes back to their original commit
+	gitCmd(t, dir, "reset", "--hard", userCommitSHA)
+
+	// baseSHA = autofixSHA (what the gate had before force push)
+	// headSHA = userCommitSHA (what the user force-pushed)
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, autofixSHA, userCommitSHA, config.Commands{})
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Repo.UpstreamURL = upstream
+
+	step := &RebaseStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Fatal("expected no approval for clean rebase")
+	}
+
+	// After rebase, HEAD should contain the user's feature.txt content, not autofix
+	content, err := os.ReadFile(filepath.Join(dir, "feature.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "user-change\n" {
+		t.Fatalf("feature.txt = %q, want %q; force push was not respected", string(content), "user-change\n")
+	}
+
+	// Should be rebased onto origin/main
+	mergeBase := gitCmd(t, dir, "merge-base", "HEAD", "origin/main")
+	originMain := gitCmd(t, dir, "rev-parse", "origin/main")
+	if mergeBase != originMain {
+		t.Fatalf("merge-base = %s, want origin/main %s", mergeBase, originMain)
+	}
+}
+
+func TestRebaseStep_NormalPushSyncsOriginBranch(t *testing.T) {
+	// Verify that a normal (non-force) push still syncs with origin/<branch>.
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	os.WriteFile(filepath.Join(dir, "app.txt"), []byte("base\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "base commit")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	// Create feature branch with one commit
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("v1\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature v1")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	// Simulate another commit on origin/feature (e.g. from a prior pipeline run)
+	os.WriteFile(filepath.Join(dir, "extra.txt"), []byte("extra\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "extra commit on feature")
+	gitCmd(t, dir, "push", "origin", "feature")
+	originFeatureSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	// Go back to v1 - simulating a new push that's behind origin/feature
+	// but is NOT a force push (baseSHA is ancestor of headSHA)
+	gitCmd(t, dir, "reset", "--hard", "HEAD~1")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Repo.UpstreamURL = upstream
+
+	step := &RebaseStep{}
+	_, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should have incorporated origin/feature (fast-forward or rebase)
+	afterSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	// The extra.txt from origin/feature should be present
+	if _, err := os.Stat(filepath.Join(dir, "extra.txt")); os.IsNotExist(err) {
+		t.Fatalf("expected extra.txt from origin/feature to be present after normal push sync (HEAD=%s, origin/feature=%s)", afterSHA, originFeatureSHA)
+	}
+}
+
 // --- Review step tests ---
 
 func TestReviewStep_EmptyDiff(t *testing.T) {

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1272,6 +1272,55 @@ func TestIsForcePush_RerunWithoutLocalRemoteRefIsNotForcePush(t *testing.T) {
 	}
 }
 
+func TestIsForcePush_StaleLocalRemoteRefUsesAuthoritativeRemoteTip(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	originRepo := t.TempDir()
+	gitCmd(t, originRepo, "init")
+	gitCmd(t, originRepo, "config", "user.name", "test")
+	gitCmd(t, originRepo, "config", "user.email", "test@test.com")
+	gitCmd(t, originRepo, "checkout", "-b", "main")
+	gitCmd(t, originRepo, "remote", "add", "origin", upstream)
+
+	os.WriteFile(filepath.Join(originRepo, "app.txt"), []byte("base\n"), 0o644)
+	gitCmd(t, originRepo, "add", "-A")
+	gitCmd(t, originRepo, "commit", "-m", "base commit")
+	gitCmd(t, originRepo, "push", "origin", "main")
+
+	gitCmd(t, originRepo, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(originRepo, "feature.txt"), []byte("ancestor\n"), 0o644)
+	gitCmd(t, originRepo, "add", "-A")
+	gitCmd(t, originRepo, "commit", "-m", "feature ancestor")
+	ancestorSHA := gitCmd(t, originRepo, "rev-parse", "HEAD")
+	gitCmd(t, originRepo, "push", "origin", "feature")
+
+	worktree := t.TempDir()
+	gitCmd(t, worktree, "init")
+	gitCmd(t, worktree, "config", "user.name", "test")
+	gitCmd(t, worktree, "config", "user.email", "test@test.com")
+	gitCmd(t, worktree, "remote", "add", "origin", upstream)
+	gitCmd(t, worktree, "fetch", "--no-tags", "origin", "+refs/heads/main:refs/remotes/origin/main")
+	gitCmd(t, worktree, "fetch", "--no-tags", "origin", "+refs/heads/feature:refs/remotes/origin/feature")
+	gitCmd(t, worktree, "checkout", "--detach", ancestorSHA)
+
+	os.WriteFile(filepath.Join(originRepo, "feature.txt"), []byte("remote tip\n"), 0o644)
+	gitCmd(t, originRepo, "add", "-A")
+	gitCmd(t, originRepo, "commit", "-m", "remote tip")
+	baseSHA := gitCmd(t, originRepo, "rev-parse", "HEAD")
+	gitCmd(t, originRepo, "push", "origin", "feature")
+	gitCmd(t, worktree, "fetch", "--no-tags", "origin", "+refs/heads/feature:refs/tmp/base")
+	gitCmd(t, worktree, "update-ref", "-d", "refs/tmp/base")
+
+	os.WriteFile(filepath.Join(worktree, "feature.txt"), []byte("rewritten tip\n"), 0o644)
+	gitCmd(t, worktree, "add", "-A")
+	gitCmd(t, worktree, "commit", "-m", "rewritten tip")
+
+	if !isForcePush(context.Background(), worktree, "feature", baseSHA) {
+		t.Fatal("expected stale local origin/feature ref to defer to authoritative remote tip")
+	}
+}
+
 func TestIsForcePush_MissingRemoteObjectTreatsAsForcePush(t *testing.T) {
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1123,8 +1123,47 @@ func TestIsForcePush_IgnoresMergeBaseLookupErrors(t *testing.T) {
 	gitCmd(t, dir, "add", "-A")
 	gitCmd(t, dir, "commit", "-m", "base commit")
 
-	if isForcePush(context.Background(), dir, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef") {
+	if isForcePush(context.Background(), dir, "", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef") {
 		t.Fatal("expected missing base SHA lookup error to not be treated as force push")
+	}
+}
+
+func TestIsForcePush_RerunAfterNormalRebaseIsNotForcePush(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+
+	os.WriteFile(filepath.Join(dir, "app.txt"), []byte("base\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "base commit")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("v1\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature v1")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	os.WriteFile(filepath.Join(dir, "app.txt"), []byte("base\nmain update\n"), 0o644)
+	gitCmd(t, dir, "checkout", "main")
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "main update")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "feature")
+	gitCmd(t, dir, "rebase", "origin/main")
+	gitCmd(t, dir, "push", "origin", "feature", "--force-with-lease")
+
+	if isForcePush(context.Background(), dir, "feature", baseSHA) {
+		t.Fatal("expected rerun after normal rebase to not be treated as force push")
 	}
 }
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1115,6 +1115,67 @@ func TestRebaseStep_ForcePushOnDefaultBranchSkipsRemoteSync(t *testing.T) {
 	}
 }
 
+func TestRebaseStep_ForcePushOnDefaultBranchStopsWhenRemoteAdvanced(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+
+	os.WriteFile(filepath.Join(dir, "app.txt"), []byte("base\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "base commit")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	os.WriteFile(filepath.Join(dir, "user.txt"), []byte("user-change\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "user commit")
+	userCommitSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	os.WriteFile(filepath.Join(dir, "autofix.txt"), []byte("autofix\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "no-mistakes(review): autofix commit")
+	autofixSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "reset", "--hard", userCommitSHA)
+
+	other := t.TempDir()
+	gitCmd(t, other, "clone", upstream, ".")
+	gitCmd(t, other, "config", "user.name", "test")
+	gitCmd(t, other, "config", "user.email", "test@test.com")
+	gitCmd(t, other, "checkout", "main")
+	os.WriteFile(filepath.Join(other, "remote.txt"), []byte("remote update\n"), 0o644)
+	gitCmd(t, other, "add", "-A")
+	gitCmd(t, other, "commit", "-m", "remote update")
+	gitCmd(t, other, "push", "origin", "main")
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, autofixSHA, userCommitSHA, config.Commands{})
+	sctx.Run.Branch = "refs/heads/main"
+	sctx.Repo.UpstreamURL = upstream
+
+	step := &RebaseStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected approval when remote default branch advanced after force push")
+	}
+	if got := gitCmd(t, dir, "rev-parse", "HEAD"); got != userCommitSHA {
+		t.Fatalf("HEAD = %s, want %s", got, userCommitSHA)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "remote.txt")); !os.IsNotExist(err) {
+		t.Fatal("expected remote update to remain unapplied")
+	}
+}
+
 func TestRebaseStep_NormalPushSyncsOriginBranch(t *testing.T) {
 	// Verify that a normal (non-force) push still syncs with origin/<branch>.
 	upstream := t.TempDir()
@@ -1321,7 +1382,30 @@ func TestIsForcePush_StaleLocalRemoteRefUsesAuthoritativeRemoteTip(t *testing.T)
 	}
 }
 
-func TestIsForcePush_MissingRemoteObjectTreatsAsForcePush(t *testing.T) {
+func TestIsForcePush_LsRemoteFailureIsNotForcePush(t *testing.T) {
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	gitCmd(t, dir, "remote", "add", "origin", filepath.Join(t.TempDir(), "missing.git"))
+
+	os.WriteFile(filepath.Join(dir, "app.txt"), []byte("base\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "base commit")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	os.WriteFile(filepath.Join(dir, "app.txt"), []byte("rewritten\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "rewritten commit")
+	gitCmd(t, dir, "reset", "--hard", "HEAD~1")
+
+	if isForcePush(context.Background(), dir, "main", baseSHA) {
+		t.Fatal("expected ls-remote failure to not be treated as force push")
+	}
+}
+
+func TestIsForcePush_MissingRemoteObjectIsNotForcePush(t *testing.T) {
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -1357,8 +1441,8 @@ func TestIsForcePush_MissingRemoteObjectTreatsAsForcePush(t *testing.T) {
 	baseSHA := gitCmd(t, worktree, "rev-parse", "HEAD")
 	gitCmd(t, worktree, "checkout", "--detach", "origin/main")
 
-	if !isForcePush(context.Background(), worktree, "feature", baseSHA) {
-		t.Fatal("expected missing remote tip object to be treated as force push")
+	if isForcePush(context.Background(), worktree, "feature", baseSHA) {
+		t.Fatal("expected missing remote tip object to not be treated as force push")
 	}
 }
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1115,6 +1115,62 @@ func TestRebaseStep_ForcePushOnDefaultBranchSkipsRemoteSync(t *testing.T) {
 	}
 }
 
+func TestRebaseStep_ForcePushOnDefaultBranchAllowsRewrittenRemoteHead(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+
+	os.WriteFile(filepath.Join(dir, "app.txt"), []byte("base\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "base commit")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	os.WriteFile(filepath.Join(dir, "app.txt"), []byte("base\nuser-change\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "user commit")
+	userCommitSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	os.WriteFile(filepath.Join(dir, "app.txt"), []byte("base\nautofix\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "no-mistakes(review): autofix commit")
+	autofixSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "reset", "--hard", userCommitSHA)
+	gitCmd(t, dir, "push", "--force", "origin", "main")
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, autofixSHA, userCommitSHA, config.Commands{})
+	sctx.Run.Branch = "refs/heads/main"
+	sctx.Repo.UpstreamURL = upstream
+
+	step := &RebaseStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Fatal("expected no approval when origin/main matches forced HEAD")
+	}
+
+	if got := gitCmd(t, dir, "rev-parse", "origin/main"); got != userCommitSHA {
+		t.Fatalf("origin/main = %s, want %s", got, userCommitSHA)
+	}
+	if got := gitCmd(t, dir, "rev-parse", "HEAD"); got != userCommitSHA {
+		t.Fatalf("HEAD = %s, want %s", got, userCommitSHA)
+	}
+	if autofixSHA == userCommitSHA {
+		t.Fatal("expected distinct rewritten and previous tips")
+	}
+}
+
 func TestRebaseStep_ForcePushOnDefaultBranchStopsWhenRemoteAdvanced(t *testing.T) {
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")


### PR DESCRIPTION
## Summary
- Fix force-push detection in the rebase step so reruns, git/remote lookup failures, stale remote-tracking refs, and rewritten default-branch history are handled without skipping the wrong sync target or undoing the user's intent.
- Rebase against the authoritative remote tip when needed and preserve the latest `origin/main` integration path so rewritten branches and default-branch updates behave safely across fresh worktrees and repeated pipeline runs.
- Add regression coverage for the force-push/rebase edge cases and update the pipeline step guide to document the force-push exceptions reflected by the passing rebase, test, and lint pipeline runs.

## Risk Assessment

✅ Low: The change is tightly scoped to force-push handling, adds focused regression coverage for the new paths, and I did not find a concrete correctness or safety issue in the changed code.

## Pipeline

Updates from `git push no-mistakes`

✅ **Rebase** - passed
🔧 **Review** - 1 issue found → auto-fixed (3) + user-fixed (4)
✅ **Test** - passed
✅ **Lint** - passed

<details>
<summary>Review details</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/pipeline/steps/rebase.go:120` - `isForcePush` treats any `git merge-base --is-ancestor` error as a force push. That also includes missing-object and other git failures, so a normal push can be misclassified and skip the `origin/<branch>` sync whenever `baseSHA` is unavailable locally. Distinguish the real non-ancestor case from command errors before changing rebase targets.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `internal/pipeline/steps/rebase.go:118` - `isForcePush` treats any `BaseSHA` that is no longer an ancestor of `HEAD` as a force push, but reruns reuse the previous run's stored `BaseSHA` rather than the remote's old tip. After a normal run rebases or autofixes the branch, rerunning that same head will be misclassified as a force push and skip the `origin/<branch>` sync that reruns still need.

**Round 3** (auto-fix) - found 2 errors
- 🚨 `internal/pipeline/steps/rebase.go:111` - `forcePushRebaseTargets` always rebases onto `origin/<defaultBranch>`. If the user force-pushes the default branch itself, the rebase step will immediately replay the old remote default-branch history back on top of the rewritten branch, undoing the force-push intent instead of respecting it.
- 🚨 `internal/pipeline/steps/rebase.go:132` - The rerun safeguard only works when `origin/<branch>` already exists locally, but fresh worktrees are created detached and only `origin/<defaultBranch>` is fetched during setup. On reruns of a normally rebased branch, `rev-parse origin/<branch>` will usually fail here, so `isForcePush` still returns `true` and incorrectly skips the branch sync this change is meant to preserve.

**Round 4** (auto-fix) - found 1 warning
- ⚠️ `internal/pipeline/steps/rebase.go:140` - The `ls-remote` fallback only compares a raw remote SHA with `HEAD` using `merge-base --is-ancestor`. In a fresh worktree where that remote commit object has never been fetched, git exits 128, `isForcePush` falls back to `false`, and the step will rebase onto `origin/<branch>` even for a real force-push. Fetch the tip into a temporary local ref first, or treat the missing-object case as indeterminate and skip branch sync.

**Round 5** (user-fix) - found 1 warning
- ⚠️ `internal/pipeline/steps/rebase.go:135` - When `origin/<branch>` exists locally, force-push detection trusts that cached ref and skips checking the authoritative remote tip. In this pipeline, worktrees can inherit stale remote-tracking refs while pushes happen via URL, so a stale `origin/<branch>` that is still an ancestor of `HEAD` will return `false` here and the step will rebase onto `origin/<branch>`, reintroducing commits the user force-pushed away.

**Round 6** (user-fix) - found 2 issues (1 error, 1 warning)
- 🚨 `internal/pipeline/steps/rebase.go:112` - `forcePushRebaseTargets` returns no targets when the rewritten branch is the default branch, so the pipeline no longer integrates the latest `origin/main` before the later force-push. Because `PushStep` refreshes the lease SHA right before pushing, this can silently overwrite newer commits that landed on `main` after the user's rewrite instead of rebasing onto them or failing safely.
- ⚠️ `internal/pipeline/steps/rebase.go:144` - `isForcePush` treats `ls-remote`/remote-tip verification failures as `true`, which means a transient network/auth/object lookup issue flips normal pushes into the force-push path and skips `origin/<branch>` sync. On branches with remote-only commits, that can drop those commits from the rebase step and make the subsequent push overwrite them.

**Round 7** (user-fix) - found 1 error
- 🚨 `internal/pipeline/steps/rebase.go:140` - `remoteDefaultBranchAdvanced` treats any fetched `origin/main` SHA different from `baseSHA` as a concurrent advance. After a real force-push to the default branch, `origin/main` will already point at the rewritten HEAD, so this returns true and incorrectly forces manual approval even when nobody else updated the branch.

**Round 8** (user-fix) - found 0 issues

</details>
