### PR TITLE
fix(ci): improve auto-fix no-change handling and reporting

### DIFF
--- a/docs/src/content/docs/guides/pipeline-steps.md
+++ b/docs/src/content/docs/guides/pipeline-steps.md
@@ -128,8 +128,9 @@ Polls CI checks on the PR and auto-fixes failures.
 **Behavior:**
 - Polls `gh pr checks` at increasing intervals: every 30s for the first 5 minutes, every 60s for 5-15 minutes, every 120s after that
 - Waits a 60s grace period before trusting empty results (CI checks may not have registered yet)
-- On CI failure: fetches the failed run log (last 32KiB via `gh run view --log-failed`), sends to agent for fixing, commits and force-pushes
-- Deduplicates fix attempts by tracking which checks failed in the last attempt
+- On CI failure: fetches the failed run log (last 32KiB via `gh run view --log-failed`), sends it to the agent for fixing, and commits and force-pushes only if the agent produces changes
+- If a fix attempt produces no changes: automatic mode leaves the failure undeduplicated so it can retry until the auto-fix limit, while manual fix mode returns immediately for manual intervention
+- Deduplicates fix attempts only after a fix is actually committed and pushed
 - Exits cleanly when the PR is merged or closed, or when the timeout is reached (default 4h)
 - If CI failures persist after the auto-fix limit: pauses for user approval with findings listing each failing check
 

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -227,10 +227,14 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 			if sctx.Fixing && !manualFixAttempted {
 				manualFixAttempted = true
 				sctx.Log(fmt.Sprintf("CI failures detected: %s - manual fix requested...", strings.Join(failing, ", ")))
-				if err := s.autoFixCI(sctx, prNumber, failing); err != nil {
+				pushed, err := s.autoFixCI(sctx, prNumber, failing)
+				if err != nil {
 					sctx.Log(fmt.Sprintf("warning: CI manual fix failed: %v", err))
-				} else {
+				} else if pushed {
 					s.lastFixedChecks = fixKey
+				} else {
+					sctx.Log("CI fix produced no changes, returning for manual intervention...")
+					return ciFailureOutcome(failing, "CI fix produced no changes - failures require manual intervention"), nil
 				}
 			} else if sctx.Fixing && fixKey == s.lastFixedChecks {
 				sctx.Log("fix already attempted for these failures, waiting for CI re-run...")
@@ -245,10 +249,15 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 			} else {
 				s.ciFixAttempts++
 				sctx.Log(fmt.Sprintf("CI failures detected: %s - auto-fixing (attempt %d/%d)...", strings.Join(failing, ", "), s.ciFixAttempts, ciFixLimit))
-				if err := s.autoFixCI(sctx, prNumber, failing); err != nil {
+				pushed, err := s.autoFixCI(sctx, prNumber, failing)
+				if err != nil {
 					sctx.Log(fmt.Sprintf("warning: CI auto-fix failed: %v", err))
-				} else {
+				} else if pushed {
 					s.lastFixedChecks = fixKey
+				} else {
+					// No changes produced - don't set lastFixedChecks so next
+					// poll treats this as a new failure and retries if attempts remain.
+					sctx.Log("CI fix produced no changes, will retry if attempts remain...")
 				}
 			}
 		} else {
@@ -329,7 +338,9 @@ func (s *CIStep) getCIChecks(ctx context.Context, workDir, prNumber string) ([]c
 }
 
 // autoFixCI runs the agent to fix CI failures, then commits and pushes.
-func (s *CIStep) autoFixCI(sctx *pipeline.StepContext, prNumber string, failingNames []string) error {
+// Returns (true, nil) when changes were committed and pushed, (false, nil)
+// when the agent produced no changes, or (false, err) on failure.
+func (s *CIStep) autoFixCI(sctx *pipeline.StepContext, prNumber string, failingNames []string) (bool, error) {
 	ctx := sctx.Ctx
 	baseSHA := resolveBranchBaseSHA(ctx, sctx.WorkDir, sctx.Run.BaseSHA, sctx.Repo.DefaultBranch)
 
@@ -378,6 +389,9 @@ Context:
 - failing checks: %s
 
 		Rules:
+		- You MUST produce file changes that fix the failing checks. Do not conclude that nothing needs to change.
+		- If a test fails only on a specific OS (e.g. Windows CRLF, path separators), fix the test to be cross-platform.
+		- If a test is flaky, make it deterministic.
 		- Make the minimal change needed.
 		- Do not refactor beyond what is needed.
 		- Verify the fix by running the most relevant commands locally before finishing.`,
@@ -401,14 +415,16 @@ CI logs:
 		OnChunk: sctx.Log,
 	})
 	if err != nil {
-		return fmt.Errorf("agent CI fix: %w", err)
+		return false, fmt.Errorf("agent CI fix: %w", err)
 	}
 
 	return s.commitAndPush(sctx)
 }
 
 // commitAndPush commits any uncommitted changes and force-pushes to upstream.
-func (s *CIStep) commitAndPush(sctx *pipeline.StepContext) error {
+// Returns (true, nil) when changes were pushed, (false, nil) when there was
+// nothing to commit, or (false, err) on failure.
+func (s *CIStep) commitAndPush(sctx *pipeline.StepContext) (bool, error) {
 	ctx := sctx.Ctx
 	newHeadSHA := ""
 
@@ -419,21 +435,21 @@ func (s *CIStep) commitAndPush(sctx *pipeline.StepContext) error {
 		if err == nil && headSHA != sctx.Run.HeadSHA {
 			sctx.Run.HeadSHA = headSHA
 			if err := sctx.DB.UpdateRunHeadSHA(sctx.Run.ID, headSHA); err != nil {
-				return err
+				return false, err
 			}
 		}
-		return nil
+		return false, nil
 	}
 
 	if _, err := git.Run(ctx, sctx.WorkDir, "add", "-A"); err != nil {
-		return fmt.Errorf("stage CI changes: %w", err)
+		return false, fmt.Errorf("stage CI changes: %w", err)
 	}
 	if _, err := git.Run(ctx, sctx.WorkDir, "commit", "-m", "no-mistakes: apply CI fixes"); err != nil {
-		return fmt.Errorf("commit: %w", err)
+		return false, fmt.Errorf("commit: %w", err)
 	}
 	headSHA, err := git.HeadSHA(ctx, sctx.WorkDir)
 	if err != nil {
-		return fmt.Errorf("resolve head after commit: %w", err)
+		return false, fmt.Errorf("resolve head after commit: %w", err)
 	}
 	newHeadSHA = headSHA
 
@@ -445,19 +461,19 @@ func (s *CIStep) commitAndPush(sctx *pipeline.StepContext) error {
 	}
 	if err := git.Push(ctx, sctx.WorkDir, sctx.Repo.UpstreamURL, ref, upstreamSHA, upstreamSHA != ""); err != nil {
 		if lsErr != nil {
-			return fmt.Errorf("push (ls-remote failed: %v): %w", lsErr, err)
+			return false, fmt.Errorf("push (ls-remote failed: %v): %w", lsErr, err)
 		}
-		return fmt.Errorf("push: %w", err)
+		return false, fmt.Errorf("push: %w", err)
 	}
 
 	if _, err := git.Run(ctx, sctx.WorkDir, "update-ref", ref, newHeadSHA); err != nil {
-		return fmt.Errorf("update local branch ref: %w", err)
+		return false, fmt.Errorf("update local branch ref: %w", err)
 	}
 	sctx.Run.HeadSHA = newHeadSHA
 	if err := sctx.DB.UpdateRunHeadSHA(sctx.Run.ID, newHeadSHA); err != nil {
-		return err
+		return false, err
 	}
 
 	sctx.Log("committed and pushed fixes")
-	return nil
+	return true, nil
 }

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -428,7 +428,10 @@ func (s *CIStep) commitAndPush(sctx *pipeline.StepContext) (bool, error) {
 	ctx := sctx.Ctx
 	newHeadSHA := ""
 
-	status, _ := git.Run(ctx, sctx.WorkDir, "status", "--porcelain")
+	status, err := git.Run(ctx, sctx.WorkDir, "status", "--porcelain")
+	if err != nil {
+		return false, fmt.Errorf("check CI changes: %w", err)
+	}
 	if strings.TrimSpace(status) == "" {
 		sctx.Log("no changes to commit")
 		headSHA, err := git.HeadSHA(ctx, sctx.WorkDir)

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -3442,6 +3442,43 @@ func TestCIStep_CommitAndPush_NoChanges(t *testing.T) {
 	}
 }
 
+func TestCIStep_CommitAndPush_StatusError(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := fakeCLIBinDir(t)
+	gitPath := filepath.Join(binDir, "git")
+	script := fmt.Sprintf("#!/bin/sh\nif [ \"$1\" = \"status\" ] && [ \"$2\" = \"--porcelain\" ]; then\n  printf 'status failed\\n' >&2\n  exit 1\nfi\nexec %q \"$@\"\n", realGit)
+	if err := os.WriteFile(gitPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	prependPATH(t, binDir)
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Repo.UpstreamURL = "dummy"
+	sctx.Run.Branch = "refs/heads/feature"
+
+	step := &CIStep{}
+	pushed, err := step.commitAndPush(sctx)
+	if err == nil {
+		t.Fatal("expected status error")
+	}
+	if pushed {
+		t.Error("expected commitAndPush to report no push on status error")
+	}
+	if !strings.Contains(err.Error(), "git status --porcelain") {
+		t.Fatalf("expected status command in error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "status failed") {
+		t.Fatalf("expected status stderr in error, got %v", err)
+	}
+}
+
 func TestCIStep_CommitAndPush_NoChanges_ReconcilesStaleDatabaseHeadSHA(t *testing.T) {
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -3409,9 +3409,12 @@ func TestCIStep_CommitAndPush(t *testing.T) {
 	sctx.Run.Branch = "refs/heads/feature"
 
 	step := &CIStep{}
-	err := step.commitAndPush(sctx)
+	pushed, err := step.commitAndPush(sctx)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if !pushed {
+		t.Error("expected commitAndPush to report changes were pushed")
 	}
 
 	// Verify the commit and push happened
@@ -3430,11 +3433,13 @@ func TestCIStep_CommitAndPush_NoChanges(t *testing.T) {
 	sctx.Run.Branch = "refs/heads/feature"
 
 	step := &CIStep{}
-	err := step.commitAndPush(sctx)
+	pushed, err := step.commitAndPush(sctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// No error expected — just a no-op
+	if pushed {
+		t.Error("expected commitAndPush to report no changes pushed")
+	}
 }
 
 func TestCIStep_CommitAndPush_NoChanges_ReconcilesStaleDatabaseHeadSHA(t *testing.T) {
@@ -3468,9 +3473,12 @@ func TestCIStep_CommitAndPush_NoChanges_ReconcilesStaleDatabaseHeadSHA(t *testin
 	sctx.Run.Branch = "refs/heads/feature"
 
 	step := &CIStep{}
-	err := step.commitAndPush(sctx)
+	pushed, err := step.commitAndPush(sctx)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if pushed {
+		t.Error("expected commitAndPush to report no changes pushed for stale reconcile")
 	}
 
 	if sctx.Run.HeadSHA != actualHeadSHA {
@@ -3516,9 +3524,12 @@ func TestCIStep_CommitAndPush_UpdatesLocalBranchRefAfterDetachedPush(t *testing.
 	sctx.Run.Branch = "refs/heads/feature"
 
 	step := &CIStep{}
-	err := step.commitAndPush(sctx)
+	pushed, err := step.commitAndPush(sctx)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if !pushed {
+		t.Error("expected commitAndPush to report changes were pushed")
 	}
 	newHeadSHA := gitCmd(t, dir, "rev-parse", "HEAD")
 	branchSHA := gitCmd(t, dir, "rev-parse", "refs/heads/feature")
@@ -5191,5 +5202,263 @@ func TestCIStep_FixMode_ManualInterventionRunsCIFix(t *testing.T) {
 	}
 	if len(ag.calls) != 1 {
 		t.Fatalf("expected 1 agent call, got %d", len(ag.calls))
+	}
+}
+
+// TestCIStep_AutoFixNoChanges_CountsAsAttempt verifies that when the agent
+// produces no changes (nothing to commit), it still counts as a consumed fix
+// attempt rather than spinning forever with "fix already attempted".
+func TestCIStep_AutoFixNoChanges_CountsAsAttempt(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	checksJSON := `[{"name":"test","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`
+	binDir := fakeCIGH(t, "OPEN", checksJSON)
+	prependPATH(t, binDir)
+
+	fixCount := 0
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			fixCount++
+			// Agent "investigates" but produces NO changes
+			return &agent.Result{}, nil
+		},
+	}
+
+	prURL := "https://github.com/test/repo/pull/42"
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Run.PRURL = &prURL
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Config.CITimeout = 30 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{CI: 2}
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+
+	pollCount := 0
+	step := &CIStep{
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			pollCount++
+			return nil
+		},
+	}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatalf("expected approval outcome, got error: %v", err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected approval needed after exhausting fix attempts with no changes")
+	}
+
+	// Agent should be called for each attempt even though no changes were produced
+	if fixCount != 2 {
+		t.Fatalf("expected 2 fix attempts (limit=2), got %d", fixCount)
+	}
+
+	// Should eventually hit max attempts, not spin forever
+	foundExhausted := false
+	for _, l := range logs {
+		if strings.Contains(l, "max auto-fix attempts") {
+			foundExhausted = true
+			break
+		}
+	}
+	if !foundExhausted {
+		t.Errorf("expected 'max auto-fix attempts' in logs, got: %v", logs)
+	}
+
+	// Should never log "fix already attempted" indefinitely
+	waitCount := 0
+	for _, l := range logs {
+		if strings.Contains(l, "fix already attempted") {
+			waitCount++
+		}
+	}
+	if waitCount > 0 {
+		t.Errorf("expected no 'fix already attempted' loops when agent produces no changes, got %d", waitCount)
+	}
+}
+
+// TestCIStep_FixMode_NoChanges_CountsAsAttempt verifies the same no-changes
+// behavior for manual fix mode (sctx.Fixing = true).
+func TestCIStep_FixMode_NoChanges_CountsAsAttempt(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	checksJSON := `[{"name":"test","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`
+	binDir := fakeCIGH(t, "OPEN", checksJSON)
+	prependPATH(t, binDir)
+
+	fixCount := 0
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			fixCount++
+			// Agent produces NO changes
+			return &agent.Result{}, nil
+		},
+	}
+
+	findingsJSON, err := json.Marshal(Findings{
+		Summary: "CI failures require manual intervention",
+		Items: []Finding{{
+			Severity:    "warning",
+			Description: "CI check failing: test",
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prURL := "https://github.com/test/repo/pull/42"
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Run.PRURL = &prURL
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Config.CITimeout = 30 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{CI: 0}
+	sctx.Fixing = true
+	sctx.PreviousFindings = string(findingsJSON)
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+
+	pollCount := 0
+	step := &CIStep{
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			pollCount++
+			return nil
+		},
+	}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatalf("expected approval outcome, got error: %v", err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected approval needed after fix mode with no changes")
+	}
+
+	if fixCount != 1 {
+		t.Fatalf("expected 1 manual fix attempt, got %d", fixCount)
+	}
+
+	// Should return failure outcome, not spin forever
+	foundFailed := false
+	for _, l := range logs {
+		if strings.Contains(l, "CI fix produced no changes") {
+			foundFailed = true
+			break
+		}
+	}
+	if !foundFailed {
+		t.Errorf("expected 'CI fix produced no changes' in logs, got: %v", logs)
+	}
+}
+
+// TestCIStep_AutoFixPromptIncludesMustFixInstruction verifies the agent prompt
+// includes a strong instruction that the agent must produce changes.
+func TestCIStep_AutoFixPromptIncludesMustFixInstruction(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	checksJSON := `[{"name":"test","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`
+	binDir := fakeCIGH(t, "OPEN", checksJSON)
+	prependPATH(t, binDir)
+
+	var capturedPrompt string
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			capturedPrompt = opts.Prompt
+			os.WriteFile(filepath.Join(opts.CWD, "fix.txt"), []byte("fixed"), 0o644)
+			return &agent.Result{}, nil
+		},
+	}
+
+	prURL := "https://github.com/test/repo/pull/42"
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Run.PRURL = &prURL
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Config.CITimeout = 30 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{CI: 3}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+	sctx.Log = func(s string) {}
+
+	step := &CIStep{
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			cancel()
+			return ctx.Err()
+		},
+	}
+	step.Execute(sctx)
+
+	if capturedPrompt == "" {
+		t.Fatal("expected agent to be called with a prompt")
+	}
+	if !strings.Contains(capturedPrompt, "You MUST produce file changes") {
+		t.Errorf("prompt should instruct agent to produce changes, got:\n%s", capturedPrompt)
 	}
 }

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -48,6 +48,8 @@ func handleFakeCLI(mode string) {
 		fakeGHHandler(args)
 	case "glab":
 		fakeGlabHandler(args)
+	case "git-status-error":
+		fakeGitStatusErrorHandler(args)
 	case "ci-gh":
 		fakeCIGHHandler(args)
 	case "ci-gh-seq":
@@ -79,6 +81,33 @@ func fakeGHHandler(args []string) {
 		os.Exit(0)
 	}
 	os.Exit(1)
+}
+
+func fakeGitStatusErrorHandler(args []string) {
+	realGit := os.Getenv("FAKE_CLI_REAL_GIT")
+	if len(args) >= 2 && args[0] == "status" && args[1] == "--porcelain" {
+		fmt.Fprintln(os.Stderr, "status failed")
+		os.Exit(1)
+	}
+	if realGit == "" {
+		fmt.Fprintln(os.Stderr, "missing FAKE_CLI_REAL_GIT")
+		os.Exit(1)
+	}
+	cmd := exec.Command(realGit, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			if status := exitErr.ExitCode(); status >= 0 {
+				os.Exit(status)
+			}
+		}
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	os.Exit(0)
 }
 
 func fakeGlabHandler(args []string) {
@@ -3451,12 +3480,10 @@ func TestCIStep_CommitAndPush_StatusError(t *testing.T) {
 	}
 
 	binDir := fakeCLIBinDir(t)
-	gitPath := filepath.Join(binDir, "git")
-	script := fmt.Sprintf("#!/bin/sh\nif [ \"$1\" = \"status\" ] && [ \"$2\" = \"--porcelain\" ]; then\n  printf 'status failed\\n' >&2\n  exit 1\nfi\nexec %q \"$@\"\n", realGit)
-	if err := os.WriteFile(gitPath, []byte(script), 0o755); err != nil {
-		t.Fatal(err)
-	}
+	linkTestBinary(t, binDir, "git")
 	prependPATH(t, binDir)
+	t.Setenv("FAKE_CLI_MODE", "git-status-error")
+	t.Setenv("FAKE_CLI_REAL_GIT", realGit)
 
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})


### PR DESCRIPTION
## Summary
- Refine the CI auto-fix step so commit/push handling reports no-change outcomes more clearly and surfaces `git status` failures instead of treating them as a clean no-op.
- Add targeted coverage for CI step edge cases around auto-fix, commit, and reporting flows so the new behavior is locked in.
- Document the pipeline's CI no-change behavior so manual follow-up is clearer when the fixer does not produce a repository change.

## Risk Assessment

⚠️ Medium: The control-flow changes are well covered and targeted, but the stronger agent prompt can cause incorrect CI autofix commits in cases where the failure is not actually fixable by changing the repo.

## Pipeline

Updates from `git push no-mistakes`

✅ **Rebase** - passed
⚠️ **Review** - 1 warning
✅ **Test** - passed
✅ **Lint** - passed

<details>
<summary>Review details</summary>

**Round 1** - found 2 warnings
- ⚠️ `internal/pipeline/steps/ci.go:431` - `commitAndPush` still ignores errors from `git status --porcelain`, but this change now treats the empty result as a definitive 'no changes' signal. A transient git failure here will be misreported as an agent no-op, which can consume CI auto-fix attempts or prematurely fall back to manual intervention instead of surfacing the real repo error.
- ⚠️ `internal/pipeline/steps/ci.go:392` - The new prompt forbids the agent from concluding that no code change is needed. That pushes the fixer toward making speculative commits even when the failing check is infrastructure-related, permissions-related, or otherwise only needs a rerun/manual action.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `internal/pipeline/steps/ci.go:392` - The new prompt forbids the agent from concluding that no repository change is appropriate. That removes a valid outcome for infra-only, flaky, or already-fixed failures and increases the chance of the agent inventing a speculative code change just to satisfy the instruction.

</details>
