### PR TITLE
feat(prsummary): improve generated PR description output

### DIFF
--- a/docs/src/content/docs/guides/auto-fix.md
+++ b/docs/src/content/docs/guides/auto-fix.md
@@ -76,7 +76,7 @@ The push step commits any remaining uncommitted changes with `no-mistakes: apply
 
 ## Step rounds
 
-Each execution of a step (initial run, auto-fix, user-fix) is recorded as a "round" in the database. The PR body's deterministic testing section and pipeline section are built from these rounds, giving reviewers visibility into test results, what was fixed, and how many attempts it took.
+Each execution of a step (initial run, auto-fix, user-fix) is recorded as a "round" in the database. The PR body's deterministic risk assessment, testing, and pipeline sections are built from these rounds, giving reviewers visibility into test results, review risk, what was fixed, and how many attempts it took.
 
 Round trigger types:
 - `initial` - first execution

--- a/docs/src/content/docs/guides/auto-fix.md
+++ b/docs/src/content/docs/guides/auto-fix.md
@@ -76,7 +76,7 @@ The push step commits any remaining uncommitted changes with `no-mistakes: apply
 
 ## Step rounds
 
-Each execution of a step (initial run, auto-fix, user-fix) is recorded as a "round" in the database. The PR body's pipeline section is built from these rounds, giving reviewers visibility into what was fixed and how many attempts it took.
+Each execution of a step (initial run, auto-fix, user-fix) is recorded as a "round" in the database. The PR body's deterministic testing section and pipeline section are built from these rounds, giving reviewers visibility into test results, what was fixed, and how many attempts it took.
 
 Round trigger types:
 - `initial` - first execution

--- a/docs/src/content/docs/guides/pipeline-steps.md
+++ b/docs/src/content/docs/guides/pipeline-steps.md
@@ -116,7 +116,7 @@ Creates or updates a pull request.
 - Checks for an existing PR on the branch
 - If one exists, updates it. If not, creates a new one.
 - PR title: agent-generated in conventional commit format (`type(scope): description`)
-- PR body includes: a summary section, risk assessment from the review step, and a pipeline section showing each step's execution rounds
+- PR body includes: a summary section, risk assessment from the review step, a deterministic testing section, and a pipeline section with per-step round details
 
 Stores the PR URL in the database and streams it to the TUI.
 

--- a/docs/src/content/docs/guides/pipeline-steps.md
+++ b/docs/src/content/docs/guides/pipeline-steps.md
@@ -116,7 +116,7 @@ Creates or updates a pull request.
 - Checks for an existing PR on the branch
 - If one exists, updates it. If not, creates a new one.
 - PR title: agent-generated in conventional commit format (`type(scope): description`)
-- PR body includes: a summary section, risk assessment from the review step, a deterministic testing section, and a pipeline section with per-step round details
+- PR body includes: an agent-authored `## Summary` plus regenerated `## Risk Assessment`, `## Testing`, and `## Pipeline` sections from recorded step results and rounds
 
 Stores the PR URL in the database and streams it to the TUI.
 

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -269,7 +269,7 @@ Diff stat:
 }
 
 // buildPipelineSection queries step results and rounds from the DB and
-// produces the deterministic pipeline markdown section.
+// produces the deterministic pipeline, risk, and testing sections.
 func (s *PRStep) buildPipelineSection(sctx *pipeline.StepContext) (string, string, string) {
 	steps, err := sctx.DB.GetStepsByRun(sctx.Run.ID)
 	if err != nil {

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -205,8 +205,8 @@ func (s *PRStep) buildPRContent(sctx *pipeline.StepContext, branch, baseSHA stri
 	commitLog, _ := git.Log(ctx, sctx.WorkDir, baseSHA, sctx.Run.HeadSHA)
 	diffStat, _ := git.Run(ctx, sctx.WorkDir, "diff", "--stat", baseSHA+".."+sctx.Run.HeadSHA)
 
-	// Build the deterministic pipeline section from step rounds.
-	pipelineMD, riskLine := s.buildPipelineSection(sctx)
+	// Build the deterministic sections from step rounds.
+	pipelineMD, riskLine, testingMD := s.buildPipelineSection(sctx)
 
 	// Build pipeline context for the agent prompt so it can reference findings in the summary.
 	pipelineContext := ""
@@ -227,7 +227,7 @@ Context:
 Rules:
 - Cover the full branch delta, not just the latest commit.
 - Title must use conventional commit format: "type(scope): description" or "type: description". Valid types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert. Scope is optional. Do not capitalize the type. Do not use the raw branch name.
-- Body: a "## Summary" section in GitHub-flavored markdown. 1-3 concise bullet points describing what changed and why. Do not include a Testing section - pipeline results are appended separately. The body value must be plain markdown text, never a JSON object or serialized JSON string.
+- Body: a "## Summary" section in GitHub-flavored markdown. 1-3 concise bullet points describing what changed and why. Do not include Risk Assessment, Testing, or Pipeline sections - those are appended separately. The body value must be plain markdown text, never a JSON object or serialized JSON string.
 - Do not invent tests or behavior.
 
 Commit history:
@@ -244,7 +244,7 @@ Diff stat:
 	})
 	if err != nil {
 		slog.Warn("agent failed for PR content, using fallback", "error", err)
-		return fallbackPRContent(branch, commitLog, pipelineMD, riskLine), nil
+		return fallbackPRContent(branch, commitLog, riskLine, testingMD, pipelineMD), nil
 	}
 
 	var content prContent
@@ -258,25 +258,22 @@ Diff stat:
 					slog.Warn("agent PR title is not conventional commit format, prepending chore:", "title", content.Title)
 					content.Title = "chore: " + content.Title
 				}
-				if riskLine != "" {
-					content.Body += "\n\n## Risk Assessment\n\n" + riskLine
-				}
-				content.Body = appendPipelineSection(content.Body, pipelineMD)
+				content.Body = appendGeneratedSections(content.Body, riskLine, testingMD, pipelineMD)
 				return content, nil
 			}
 		}
 	}
 
-	return fallbackPRContent(branch, commitLog, pipelineMD, riskLine), nil
+	return fallbackPRContent(branch, commitLog, riskLine, testingMD, pipelineMD), nil
 }
 
 // buildPipelineSection queries step results and rounds from the DB and
 // produces the deterministic pipeline markdown section.
-func (s *PRStep) buildPipelineSection(sctx *pipeline.StepContext) (string, string) {
+func (s *PRStep) buildPipelineSection(sctx *pipeline.StepContext) (string, string, string) {
 	steps, err := sctx.DB.GetStepsByRun(sctx.Run.ID)
 	if err != nil {
 		slog.Warn("failed to query step results for pipeline summary", "error", err)
-		return "", ""
+		return "", "", ""
 	}
 
 	rounds := make(map[string][]*db.StepRound, len(steps))
@@ -289,7 +286,9 @@ func (s *PRStep) buildPipelineSection(sctx *pipeline.StepContext) (string, strin
 		rounds[sr.ID] = r
 	}
 
-	return BuildPipelineSummary(steps, rounds)
+	pipelineMD, riskLine := BuildPipelineSummary(steps, rounds)
+	testingMD := BuildTestingSummary(steps, rounds)
+	return pipelineMD, riskLine, testingMD
 }
 
 // unwrapNestedPRBody detects when the agent returned the body as a
@@ -309,15 +308,21 @@ func unwrapNestedPRBody(body string) string {
 	return body
 }
 
-// appendPipelineSection appends the pipeline markdown after the agent's body.
-func appendPipelineSection(body, pipelineMD string) string {
-	if pipelineMD == "" {
-		return body
+// appendGeneratedSections appends deterministic sections after the agent's body.
+func appendGeneratedSections(body, riskLine, testingMD, pipelineMD string) string {
+	if riskLine != "" {
+		body += "\n\n## Risk Assessment\n\n" + riskLine
 	}
-	return body + "\n\n" + pipelineMD
+	if testingMD != "" {
+		body += "\n\n" + testingMD
+	}
+	if pipelineMD != "" {
+		body += "\n\n" + pipelineMD
+	}
+	return body
 }
 
-func fallbackPRContent(branch, commitLog, pipelineMD, riskLine string) prContent {
+func fallbackPRContent(branch, commitLog, riskLine, testingMD, pipelineMD string) prContent {
 	title := ""
 	for _, line := range strings.Split(commitLog, "\n") {
 		line = strings.TrimSpace(line)
@@ -341,10 +346,7 @@ func fallbackPRContent(branch, commitLog, pipelineMD, riskLine string) prContent
 	if body == "## Summary\n\n" {
 		body = fmt.Sprintf("## Summary\n\n- %s", title)
 	}
-	if riskLine != "" {
-		body += "\n\n## Risk Assessment\n\n" + riskLine
-	}
-	body = appendPipelineSection(body, pipelineMD)
+	body = appendGeneratedSections(body, riskLine, testingMD, pipelineMD)
 	return prContent{
 		Title: title,
 		Body:  body,

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -359,8 +359,16 @@ func stripGeneratedSections(body string) string {
 }
 
 func isGeneratedSectionHeading(line string) bool {
-	switch strings.TrimSpace(line) {
-	case "## Risk Assessment", "## Testing", "## Pipeline":
+	if !strings.HasPrefix(strings.TrimSpace(line), "##") {
+		return false
+	}
+
+	heading := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "##"))
+	heading = strings.TrimRight(heading, ":.!? ")
+	heading = strings.ToLower(heading)
+
+	switch heading {
+	case "risk assessment", "testing", "tests", "pipeline":
 		return true
 	default:
 		return false

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -253,6 +253,7 @@ Diff stat:
 			content.Title = strings.TrimSpace(content.Title)
 			content.Body = strings.TrimSpace(content.Body)
 			content.Body = unwrapNestedPRBody(content.Body)
+			content.Body = stripGeneratedSections(content.Body)
 			if content.Title != "" && content.Body != "" {
 				if !isConventionalTitle(content.Title) {
 					slog.Warn("agent PR title is not conventional commit format, prepending chore:", "title", content.Title)
@@ -310,6 +311,7 @@ func unwrapNestedPRBody(body string) string {
 
 // appendGeneratedSections appends deterministic sections after the agent's body.
 func appendGeneratedSections(body, riskLine, testingMD, pipelineMD string) string {
+	body = stripGeneratedSections(body)
 	if riskLine != "" {
 		body += "\n\n## Risk Assessment\n\n" + riskLine
 	}
@@ -320,6 +322,49 @@ func appendGeneratedSections(body, riskLine, testingMD, pipelineMD string) strin
 		body += "\n\n" + pipelineMD
 	}
 	return body
+}
+
+func stripGeneratedSections(body string) string {
+	if body == "" {
+		return ""
+	}
+
+	lines := strings.Split(body, "\n")
+	out := make([]string, 0, len(lines))
+	skipping := false
+
+	for _, raw := range lines {
+		line := strings.TrimSpace(raw)
+
+		if skipping {
+			if strings.HasPrefix(line, "## ") {
+				if isGeneratedSectionHeading(line) {
+					continue
+				}
+				skipping = false
+			} else {
+				continue
+			}
+		}
+
+		if isGeneratedSectionHeading(line) {
+			skipping = true
+			continue
+		}
+
+		out = append(out, raw)
+	}
+
+	return strings.TrimSpace(strings.Join(out, "\n"))
+}
+
+func isGeneratedSectionHeading(line string) bool {
+	switch strings.TrimSpace(line) {
+	case "## Risk Assessment", "## Testing", "## Pipeline":
+		return true
+	default:
+		return false
+	}
 }
 
 func fallbackPRContent(branch, commitLog, riskLine, testingMD, pipelineMD string) prContent {

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -2,6 +2,7 @@ package steps
 
 import (
 	"fmt"
+	"html"
 	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/db"
@@ -17,6 +18,9 @@ func BuildPipelineSummary(steps []*db.StepResult, rounds map[string][]*db.StepRo
 	var detailBlocks []string
 
 	for _, sr := range steps {
+		if shouldOmitPipelineStep(sr) {
+			continue
+		}
 		stepRounds := rounds[sr.ID]
 		line, detail := buildStepEntry(sr, stepRounds)
 		if line != "" && detail != "" {
@@ -343,13 +347,13 @@ func buildStepDetails(summaryLine string, sr *db.StepResult, rounds []*db.StepRo
 			emoji := severityEmoji(f.Severity)
 			loc := ""
 			if f.File != "" {
-				loc = fmt.Sprintf("`%s", f.File)
+				loc = fmt.Sprintf("`%s", html.EscapeString(f.File))
 				if f.Line > 0 {
 					loc += fmt.Sprintf(":%d", f.Line)
 				}
 				loc += "` - "
 			}
-			b.WriteString(fmt.Sprintf("- %s %s%s\n", emoji, loc, f.Description))
+			b.WriteString(fmt.Sprintf("- %s %s%s\n", emoji, loc, html.EscapeString(f.Description)))
 		}
 		b.WriteString("\n")
 	}
@@ -374,7 +378,7 @@ func writeStepStatusDetail(b *strings.Builder, sr *db.StepResult) {
 		b.WriteString("Step was skipped.\n\n")
 	case types.StepStatusFailed:
 		if sr.Error != nil && strings.TrimSpace(*sr.Error) != "" {
-			b.WriteString(strings.TrimSpace(*sr.Error))
+			b.WriteString(html.EscapeString(strings.TrimSpace(*sr.Error)))
 			b.WriteString("\n\n")
 			return
 		}
@@ -383,6 +387,23 @@ func writeStepStatusDetail(b *strings.Builder, sr *db.StepResult) {
 		b.WriteString("No round details recorded.\n\n")
 	default:
 		b.WriteString("Status unavailable.\n\n")
+	}
+}
+
+func shouldOmitPipelineStep(sr *db.StepResult) bool {
+	if sr == nil {
+		return false
+	}
+
+	if sr.StepName != types.StepPR && sr.StepName != types.StepCI {
+		return false
+	}
+
+	switch sr.Status {
+	case types.StepStatusPending, types.StepStatusRunning, types.StepStatusAwaitingApproval, types.StepStatusFixing, types.StepStatusFixReview:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -8,51 +8,32 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
-// summarySteps are the steps we include in the pipeline summary.
-// Push, PR, and CI are operational - not interesting for the PR reader.
-var summarySteps = map[types.StepName]bool{
-	types.StepRebase: true,
-	types.StepReview: true,
-	types.StepTest:   true,
-	types.StepLint:   true,
-}
-
 // BuildPipelineSummary produces a deterministic markdown section from step results and rounds.
 func BuildPipelineSummary(steps []*db.StepResult, rounds map[string][]*db.StepRound) (string, string) {
 	if len(steps) == 0 {
 		return "", ""
 	}
 
-	var statusLines []string
 	var detailBlocks []string
 
 	for _, sr := range steps {
-		if !summarySteps[sr.StepName] {
-			continue
-		}
 		stepRounds := rounds[sr.ID]
 		line, detail := buildStepEntry(sr, stepRounds)
-		if line != "" {
-			statusLines = append(statusLines, line)
-		}
-		if detail != "" {
+		if line != "" && detail != "" {
 			detailBlocks = append(detailBlocks, detail)
 		}
 	}
 
-	if len(statusLines) == 0 {
+	if len(detailBlocks) == 0 {
 		return "", ""
 	}
 
 	var b strings.Builder
 	b.WriteString("## Pipeline\n\nUpdates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)\n\n")
-	for _, line := range statusLines {
-		b.WriteString(line)
-		b.WriteString("\n")
-	}
-
-	for _, detail := range detailBlocks {
-		b.WriteString("\n")
+	for i, detail := range detailBlocks {
+		if i > 0 {
+			b.WriteString("\n")
+		}
 		b.WriteString(detail)
 	}
 
@@ -60,11 +41,47 @@ func BuildPipelineSummary(steps []*db.StepResult, rounds map[string][]*db.StepRo
 	return b.String(), riskLine
 }
 
+// BuildTestingSummary extracts a deterministic Testing section from the test step.
+func BuildTestingSummary(steps []*db.StepResult, rounds map[string][]*db.StepRound) string {
+	for _, sr := range steps {
+		if sr.StepName != types.StepTest {
+			continue
+		}
+
+		line, _ := buildStepEntry(sr, rounds[sr.ID])
+		if line == "" {
+			return ""
+		}
+
+		return "## Testing\n\n- " + line
+	}
+
+	return ""
+}
+
 func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, detailBlock string) {
 	name := stepDisplayName(sr.StepName)
+	buildDetail := func(line string) (string, string) {
+		return line, buildStepDetails(line, sr, rounds)
+	}
+
+	switch sr.Status {
+	case types.StepStatusPending:
+		return buildDetail(fmt.Sprintf("⏳ **%s** - pending", name))
+	case types.StepStatusRunning:
+		return buildDetail(fmt.Sprintf("⏳ **%s** - running", name))
+	case types.StepStatusAwaitingApproval:
+		return buildDetail(fmt.Sprintf("⏸️ **%s** - awaiting approval", name))
+	case types.StepStatusFixing:
+		return buildDetail(fmt.Sprintf("🔄 **%s** - auto-fixing", name))
+	case types.StepStatusFixReview:
+		return buildDetail(fmt.Sprintf("⏸️ **%s** - review fix", name))
+	case types.StepStatusFailed:
+		return buildDetail(fmt.Sprintf("❌ **%s** - failed", name))
+	}
 
 	if sr.Status == types.StepStatusSkipped {
-		return fmt.Sprintf("⏭️ **%s** - skipped", name), ""
+		return buildDetail(fmt.Sprintf("⏭️ **%s** - skipped", name))
 	}
 
 	// Parse the final findings on the step result (last state).
@@ -100,7 +117,6 @@ func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, deta
 	hasFinalFindings := finalFindings != nil && len(finalFindings.Items) > 0
 	hasAnyRoundFindings := roundsHaveFindings(rounds)
 	hasRoundParseFailure := roundsHaveParseFailure(rounds)
-	hasRoundDetails := roundsNeedDetail(rounds)
 	hadAnyFindings := hadFindings || hasFinalFindings || hasAnyRoundFindings
 	hasUnreadableFinalFindings := sr.FindingsJSON != nil && !finalFindingsParsed
 	wasFixed := hadFindings && len(rounds) > 1 && !hasUnreadableFinalFindings && !hasFinalFindings
@@ -117,42 +133,25 @@ func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, deta
 
 	// Unreadable final findings - can't make claims about the outcome.
 	if hasUnreadableFinalFindings {
-		detail := ""
-		if hasRoundDetails {
-			detail = buildRoundsDetail(name, rounds)
-		}
-		return fmt.Sprintf("⚠️ **%s** - findings unavailable", name), detail
+		return buildDetail(fmt.Sprintf("⚠️ **%s** - findings unavailable", name))
 	}
 
 	if sr.StepName == types.StepReview && (riskLevel == "medium" || riskLevel == "high") && !hadAnyFindings {
-		detail := ""
-		if hasRoundDetails {
-			detail = buildRoundsDetail(name, rounds)
-		}
-		return fmt.Sprintf("%s **%s** - %s risk", riskEmoji(riskLevel), name, riskLevel), detail
+		return buildDetail(fmt.Sprintf("%s **%s** - %s risk", riskEmoji(riskLevel), name, riskLevel))
 	}
 
 	if !hadAnyFindings && !hasRoundParseFailure {
-		detail := ""
-		if hasRoundDetails {
-			detail = buildRoundsDetail(name, rounds)
-		}
-		return fmt.Sprintf("✅ **%s** - passed", name), detail
+		return buildDetail(fmt.Sprintf("✅ **%s** - passed", name))
 	}
 
 	if hasRoundParseFailure && !hadAnyFindings {
-		detail := ""
-		if hasRoundDetails {
-			detail = buildRoundsDetail(name, rounds)
-		}
-		return fmt.Sprintf("⚠️ **%s** - findings unavailable", name), detail
+		return buildDetail(fmt.Sprintf("⚠️ **%s** - findings unavailable", name))
 	}
 
 	if wasFixed {
 		result := buildFixResultText(rounds)
 		line := fmt.Sprintf("🔧 **%s** - %s", name, result)
-		detail := buildRoundsDetail(name, rounds)
-		return line, detail
+		return buildDetail(line)
 	}
 
 	currentFindings := initialFindings
@@ -163,11 +162,7 @@ func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, deta
 	// Had findings and the final state still contains them - approved as-is.
 	count := countFindingsBySeverity(currentFindings)
 	line := fmt.Sprintf("⚠️ **%s** - %s", name, count)
-	detail := ""
-	if hasRoundDetails {
-		detail = buildRoundsDetail(name, rounds)
-	}
-	return line, detail
+	return buildDetail(line)
 }
 
 func extractRiskLine(steps []*db.StepResult, rounds map[string][]*db.StepRound) string {
@@ -263,26 +258,6 @@ func roundsHaveParseFailure(rounds []*db.StepRound) bool {
 	return false
 }
 
-func roundsNeedDetail(rounds []*db.StepRound) bool {
-	for _, r := range rounds {
-		if r.FindingsJSON == nil {
-			continue
-		}
-		if _, err := types.ParseFindingsJSON(*r.FindingsJSON); err != nil {
-			return true
-		}
-		f, err := types.ParseFindingsJSON(*r.FindingsJSON)
-		if err != nil {
-			return true
-		}
-		if len(f.Items) > 0 {
-			return true
-		}
-	}
-
-	return false
-}
-
 func buildFixResultText(rounds []*db.StepRound) string {
 	// Count findings in round 1.
 	var initialCount int
@@ -322,13 +297,18 @@ func buildFixResultText(rounds []*db.StepRound) string {
 	return strings.Join(parts, " → ")
 }
 
-func buildRoundsDetail(name string, rounds []*db.StepRound) string {
+func buildStepDetails(summaryLine string, sr *db.StepResult, rounds []*db.StepRound) string {
+	var b strings.Builder
+	b.WriteString("<details>\n")
+	b.WriteString(fmt.Sprintf("<summary>%s</summary>\n\n", summaryLine))
+
 	if len(rounds) == 0 {
-		return ""
+		writeStepStatusDetail(&b, sr)
+		b.WriteString("</details>\n")
+		return b.String()
 	}
 
-	var b strings.Builder
-	b.WriteString(fmt.Sprintf("<details>\n<summary>%s details</summary>\n\n", name))
+	missingRoundFindingsData := sr.FindingsJSON != nil && !roundsHaveFindings(rounds) && !roundsHaveParseFailure(rounds)
 
 	for _, r := range rounds {
 		triggerLabel := ""
@@ -342,6 +322,10 @@ func buildRoundsDetail(name string, rounds []*db.StepRound) string {
 		}
 
 		if r.FindingsJSON == nil {
+			if missingRoundFindingsData {
+				b.WriteString(fmt.Sprintf("**Round %d**%s - findings not recorded\n\n", r.Round, triggerLabel))
+				continue
+			}
 			b.WriteString(fmt.Sprintf("**Round %d**%s - passed ✅\n\n", r.Round, triggerLabel))
 			continue
 		}
@@ -372,6 +356,34 @@ func buildRoundsDetail(name string, rounds []*db.StepRound) string {
 
 	b.WriteString("</details>\n")
 	return b.String()
+}
+
+func writeStepStatusDetail(b *strings.Builder, sr *db.StepResult) {
+	switch sr.Status {
+	case types.StepStatusPending:
+		b.WriteString("Step has not started yet.\n\n")
+	case types.StepStatusRunning:
+		b.WriteString("Step is currently running.\n\n")
+	case types.StepStatusAwaitingApproval:
+		b.WriteString("Waiting for user approval.\n\n")
+	case types.StepStatusFixing:
+		b.WriteString("Agent is currently applying fixes.\n\n")
+	case types.StepStatusFixReview:
+		b.WriteString("Waiting to review the latest fix.\n\n")
+	case types.StepStatusSkipped:
+		b.WriteString("Step was skipped.\n\n")
+	case types.StepStatusFailed:
+		if sr.Error != nil && strings.TrimSpace(*sr.Error) != "" {
+			b.WriteString(strings.TrimSpace(*sr.Error))
+			b.WriteString("\n\n")
+			return
+		}
+		b.WriteString("Step failed.\n\n")
+	case types.StepStatusCompleted:
+		b.WriteString("No round details recorded.\n\n")
+	default:
+		b.WriteString("Status unavailable.\n\n")
+	}
 }
 
 func countFindingsBySeverity(findings *types.Findings) string {
@@ -436,8 +448,16 @@ func stepDisplayName(name types.StepName) string {
 		return "Review"
 	case types.StepTest:
 		return "Test"
+	case types.StepDocument:
+		return "Document"
 	case types.StepLint:
 		return "Lint"
+	case types.StepPush:
+		return "Push"
+	case types.StepPR:
+		return "PR"
+	case types.StepCI:
+		return "CI"
 	default:
 		return string(name)
 	}

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -145,6 +145,9 @@ func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, deta
 	}
 
 	if !hadAnyFindings && !hasRoundParseFailure {
+		if len(rounds) == 0 {
+			return buildDetail(fmt.Sprintf("⚠️ **%s** - findings unavailable", name))
+		}
 		return buildDetail(fmt.Sprintf("✅ **%s** - passed", name))
 	}
 

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -395,16 +395,7 @@ func shouldOmitPipelineStep(sr *db.StepResult) bool {
 		return false
 	}
 
-	if sr.StepName != types.StepPR && sr.StepName != types.StepCI {
-		return false
-	}
-
-	switch sr.Status {
-	case types.StepStatusPending, types.StepStatusRunning, types.StepStatusAwaitingApproval, types.StepStatusFixing, types.StepStatusFixReview:
-		return true
-	default:
-		return false
-	}
+	return sr.StepName == types.StepPR || sr.StepName == types.StepCI
 }
 
 func countFindingsBySeverity(findings *types.Findings) string {

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -27,16 +27,62 @@ func TestBuildPipelineSummary_AllClean(t *testing.T) {
 	if !strings.Contains(md, "[git push no-mistakes](https://github.com/kunchenguid/no-mistakes)") {
 		t.Errorf("expected linked tagline, got:\n%s", md)
 	}
-	// Clean steps should show checkmark
-	if !strings.Contains(md, "✅") {
-		t.Error("expected checkmark for clean steps")
+	if strings.Count(md, "<details>") != len(steps) {
+		t.Fatalf("expected one collapsible per step, got:\n%s", md)
 	}
-	// Clean run should have no <details> blocks
-	if strings.Contains(md, "<details>") {
-		t.Error("clean run should not have details blocks")
+	for _, want := range []string{
+		"<summary>✅ **Review** - passed</summary>",
+		"<summary>✅ **Test** - passed</summary>",
+		"<summary>✅ **Lint** - passed</summary>",
+		"**Round 1** - passed ✅",
+	} {
+		if !strings.Contains(md, want) {
+			t.Errorf("expected %q in pipeline summary, got:\n%s", want, md)
+		}
 	}
 	if risk != "" {
 		t.Errorf("expected empty risk for clean run, got: %q", risk)
+	}
+}
+
+func TestBuildPipelineSummary_IncludesAllPipelineSteps(t *testing.T) {
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepRebase, Status: types.StepStatusCompleted},
+		{ID: "s2", StepName: types.StepReview, Status: types.StepStatusCompleted},
+		{ID: "s3", StepName: types.StepTest, Status: types.StepStatusCompleted},
+		{ID: "s4", StepName: types.StepDocument, Status: types.StepStatusCompleted},
+		{ID: "s5", StepName: types.StepLint, Status: types.StepStatusCompleted},
+		{ID: "s6", StepName: types.StepPush, Status: types.StepStatusCompleted},
+		{ID: "s7", StepName: types.StepPR, Status: types.StepStatusRunning},
+		{ID: "s8", StepName: types.StepCI, Status: types.StepStatusPending},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {{Round: 1, Trigger: "initial", DurationMS: 200}},
+		"s2": {{Round: 1, Trigger: "initial", DurationMS: 300}},
+		"s3": {{Round: 1, Trigger: "initial", DurationMS: 400}},
+		"s4": {{Round: 1, Trigger: "initial", DurationMS: 500}},
+		"s5": {{Round: 1, Trigger: "initial", DurationMS: 600}},
+		"s6": {{Round: 1, Trigger: "initial", DurationMS: 700}},
+	}
+
+	md, _ := BuildPipelineSummary(steps, rounds)
+
+	for _, want := range []string{
+		"<summary>✅ **Rebase** - passed</summary>",
+		"<summary>✅ **Review** - passed</summary>",
+		"<summary>✅ **Test** - passed</summary>",
+		"<summary>✅ **Document** - passed</summary>",
+		"<summary>✅ **Lint** - passed</summary>",
+		"<summary>✅ **Push** - passed</summary>",
+		"<summary>⏳ **PR** - running</summary>",
+		"<summary>⏳ **CI** - pending</summary>",
+	} {
+		if !strings.Contains(md, want) {
+			t.Errorf("expected %q in pipeline summary, got:\n%s", want, md)
+		}
+	}
+	if strings.Count(md, "<details>") != len(steps) {
+		t.Fatalf("expected one collapsible per pipeline step, got:\n%s", md)
 	}
 }
 
@@ -167,11 +213,11 @@ func TestBuildPipelineSummary_UsesFinalFindingsWithoutInitialRoundData(t *testin
 	if !strings.Contains(md, "⚠️ **Test** - 1 error") {
 		t.Errorf("expected final findings count in status line, got:\n%s", md)
 	}
-	if strings.Contains(md, "<details>") {
-		t.Errorf("did not expect details block without round findings data, got:\n%s", md)
+	if !strings.Contains(md, "<summary>⚠️ **Test** - 1 error</summary>") {
+		t.Errorf("expected unresolved test step to render as a collapsible summary, got:\n%s", md)
 	}
-	if strings.Contains(md, "Round 1") {
-		t.Errorf("did not expect round details without round findings data, got:\n%s", md)
+	if !strings.Contains(md, "**Round 1** - findings not recorded") {
+		t.Errorf("expected missing round findings data to be called out explicitly, got:\n%s", md)
 	}
 }
 
@@ -194,7 +240,7 @@ func TestBuildPipelineSummary_SkippedStep(t *testing.T) {
 	}
 }
 
-func TestBuildPipelineSummary_ExcludesPushPRCI(t *testing.T) {
+func TestBuildPipelineSummary_IncludesPushPRCI(t *testing.T) {
 	steps := []*db.StepResult{
 		{ID: "s1", StepName: types.StepReview, Status: types.StepStatusCompleted},
 		{ID: "s2", StepName: types.StepPush, Status: types.StepStatusCompleted},
@@ -209,9 +255,10 @@ func TestBuildPipelineSummary_ExcludesPushPRCI(t *testing.T) {
 	}
 	md, _ := BuildPipelineSummary(steps, rounds)
 
-	// Push, PR, and CI should not appear in the summary
-	if strings.Contains(md, "**Push**") || strings.Contains(md, "**PR**") || strings.Contains(md, "**CI**") {
-		t.Errorf("should not include push/pr/ci steps, got:\n%s", md)
+	for _, want := range []string{"**Push**", "**PR**", "**CI**"} {
+		if !strings.Contains(md, want) {
+			t.Errorf("expected %s in pipeline summary, got:\n%s", want, md)
+		}
 	}
 }
 

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -247,12 +247,14 @@ func TestBuildPipelineSummary_IncludesPushPRCI(t *testing.T) {
 	steps := []*db.StepResult{
 		{ID: "s1", StepName: types.StepReview, Status: types.StepStatusCompleted},
 		{ID: "s2", StepName: types.StepPush, Status: types.StepStatusCompleted},
-		{ID: "s3", StepName: types.StepPR, Status: types.StepStatusRunning},
-		{ID: "s4", StepName: types.StepCI, Status: types.StepStatusPending},
+		{ID: "s3", StepName: types.StepPR, Status: types.StepStatusCompleted},
+		{ID: "s4", StepName: types.StepCI, Status: types.StepStatusCompleted},
 	}
 	rounds := map[string][]*db.StepRound{
 		"s1": {{Round: 1, Trigger: "initial", DurationMS: 500}},
 		"s2": {{Round: 1, Trigger: "initial", DurationMS: 100}},
+		"s3": {{Round: 1, Trigger: "initial", DurationMS: 200}},
+		"s4": {{Round: 1, Trigger: "initial", DurationMS: 300}},
 	}
 	md, _ := BuildPipelineSummary(steps, rounds)
 

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -483,6 +483,24 @@ func TestBuildPipelineSummary_EmptySteps(t *testing.T) {
 	}
 }
 
+func TestBuildTestingSummary_DoesNotClaimPassedWithoutRounds(t *testing.T) {
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepTest, Status: types.StepStatusCompleted},
+	}
+
+	md := BuildTestingSummary(steps, map[string][]*db.StepRound{})
+
+	if md == "" {
+		t.Fatal("expected testing summary for completed test step")
+	}
+	if strings.Contains(md, "passed") {
+		t.Errorf("did not expect passed status without recorded rounds, got:\n%s", md)
+	}
+	if !strings.Contains(md, "findings unavailable") {
+		t.Errorf("expected unavailable status without recorded rounds, got:\n%s", md)
+	}
+}
+
 func TestBuildPipelineSummary_RebaseWithConflicts(t *testing.T) {
 	findings := `{"findings":[{"id":"rebase-1","severity":"warning","file":"pkg/foo.go","description":"merge conflict resolved by agent"}],"summary":"1 conflict resolved"}`
 	steps := []*db.StepResult{

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -74,14 +74,17 @@ func TestBuildPipelineSummary_IncludesAllPipelineSteps(t *testing.T) {
 		"<summary>✅ **Document** - passed</summary>",
 		"<summary>✅ **Lint** - passed</summary>",
 		"<summary>✅ **Push** - passed</summary>",
-		"<summary>⏳ **PR** - running</summary>",
-		"<summary>⏳ **CI** - pending</summary>",
 	} {
 		if !strings.Contains(md, want) {
 			t.Errorf("expected %q in pipeline summary, got:\n%s", want, md)
 		}
 	}
-	if strings.Count(md, "<details>") != len(steps) {
+	for _, unwanted := range []string{"<summary>⏳ **PR** - running</summary>", "<summary>⏳ **CI** - pending</summary>"} {
+		if strings.Contains(md, unwanted) {
+			t.Errorf("did not expect %q in pipeline summary, got:\n%s", unwanted, md)
+		}
+	}
+	if strings.Count(md, "<details>") != len(steps)-2 {
 		t.Fatalf("expected one collapsible per pipeline step, got:\n%s", md)
 	}
 }
@@ -244,21 +247,41 @@ func TestBuildPipelineSummary_IncludesPushPRCI(t *testing.T) {
 	steps := []*db.StepResult{
 		{ID: "s1", StepName: types.StepReview, Status: types.StepStatusCompleted},
 		{ID: "s2", StepName: types.StepPush, Status: types.StepStatusCompleted},
-		{ID: "s3", StepName: types.StepPR, Status: types.StepStatusCompleted},
-		{ID: "s4", StepName: types.StepCI, Status: types.StepStatusCompleted},
+		{ID: "s3", StepName: types.StepPR, Status: types.StepStatusRunning},
+		{ID: "s4", StepName: types.StepCI, Status: types.StepStatusPending},
 	}
 	rounds := map[string][]*db.StepRound{
 		"s1": {{Round: 1, Trigger: "initial", DurationMS: 500}},
 		"s2": {{Round: 1, Trigger: "initial", DurationMS: 100}},
-		"s3": {{Round: 1, Trigger: "initial", DurationMS: 200}},
-		"s4": {{Round: 1, Trigger: "initial", DurationMS: 300}},
 	}
 	md, _ := BuildPipelineSummary(steps, rounds)
 
-	for _, want := range []string{"**Push**", "**PR**", "**CI**"} {
+	for _, want := range []string{"**Push**"} {
 		if !strings.Contains(md, want) {
 			t.Errorf("expected %s in pipeline summary, got:\n%s", want, md)
 		}
+	}
+	for _, unwanted := range []string{"**PR**", "**CI**"} {
+		if strings.Contains(md, unwanted) {
+			t.Errorf("did not expect %s in pipeline summary, got:\n%s", unwanted, md)
+		}
+	}
+}
+
+func TestBuildPipelineSummary_EscapesFindingDescriptionsInDetails(t *testing.T) {
+	findings := `{"findings":[{"id":"review-1","severity":"warning","file":"cmd/main.go","line":10,"description":"break </details><summary>oops</summary> after"}],"summary":"1 warning","risk_level":"low","risk_rationale":"safe"}`
+	steps := []*db.StepResult{{ID: "s1", StepName: types.StepReview, Status: types.StepStatusCompleted, FindingsJSON: &findings}}
+	rounds := map[string][]*db.StepRound{
+		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 1000}},
+	}
+
+	md, _ := BuildPipelineSummary(steps, rounds)
+
+	if !strings.Contains(md, "break &lt;/details&gt;&lt;summary&gt;oops&lt;/summary&gt; after") {
+		t.Errorf("expected finding description to be HTML-escaped, got:\n%s", md)
+	}
+	if strings.Contains(md, "- ⚠️ `cmd/main.go:10` - break </details><summary>oops</summary> after") {
+		t.Errorf("did not expect raw HTML in finding description, got:\n%s", md)
 	}
 }
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -3658,6 +3658,30 @@ func TestAppendGeneratedSections_StripsAgentGeneratedSections(t *testing.T) {
 	}
 }
 
+func TestAppendGeneratedSections_StripsCommonHeadingVariants(t *testing.T) {
+	body := "## Summary\n\n- improve PR descriptions\n\n## tests:\n\n- model-added testing\n\n## risk assessment\n\nold risk\n\n## Pipeline:\n\nold pipeline"
+
+	got := appendGeneratedSections(
+		body,
+		"real risk",
+		"## Testing\n\n- deterministic testing",
+		"## Pipeline\n\n- deterministic pipeline",
+	)
+
+	if strings.Contains(got, "model-added testing") || strings.Contains(got, "old risk") || strings.Contains(got, "old pipeline") {
+		t.Fatalf("expected generated heading variants to be replaced, got:\n%s", got)
+	}
+	if strings.Count(got, "## Testing") != 1 {
+		t.Fatalf("expected one normalized Testing section, got:\n%s", got)
+	}
+	if strings.Count(got, "## Risk Assessment") != 1 {
+		t.Fatalf("expected one normalized Risk Assessment section, got:\n%s", got)
+	}
+	if strings.Count(got, "## Pipeline") != 1 {
+		t.Fatalf("expected one normalized Pipeline section, got:\n%s", got)
+	}
+}
+
 func fakeGlab(t *testing.T, mrViewJSON string) (binDir string, logFile string) {
 	t.Helper()
 	binDir = fakeCLIBinDir(t)

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -3512,6 +3512,69 @@ func TestPRStep_UsesAgentGeneratedTitleAndBody(t *testing.T) {
 	}
 }
 
+func TestPRStep_AppendsTestingSectionFromTestStep(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	binDir, logFile := fakeGH(t, "")
+	prependPATH(t, binDir)
+
+	reviewFindings := `{"findings":[],"summary":"clean","risk_level":"medium","risk_rationale":"touches critical error handling"}`
+	testRound1 := `{"findings":[{"id":"test-1","severity":"error","file":"pkg/handler_test.go","line":42,"description":"expected 429 got 200"}],"summary":"1 failure"}`
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			payload := json.RawMessage(`{"title":"fix: improve pipeline header UX","body":"## Summary\n\n- keep branch status readable\n- fix footer truncation"}`)
+			return &agent.Result{Output: payload}, nil
+		},
+	}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+
+	reviewStep, err := sctx.DB.InsertStepResult(sctx.Run.ID, types.StepReview)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sctx.DB.UpdateStepStatus(reviewStep.ID, types.StepStatusCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if err := sctx.DB.SetStepFindings(reviewStep.ID, reviewFindings); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sctx.DB.InsertStepRound(reviewStep.ID, 1, "initial", &reviewFindings, 500); err != nil {
+		t.Fatal(err)
+	}
+
+	testStep, err := sctx.DB.InsertStepResult(sctx.Run.ID, types.StepTest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sctx.DB.UpdateStepStatus(testStep.ID, types.StepStatusCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sctx.DB.InsertStepRound(testStep.ID, 1, "initial", &testRound1, 800); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sctx.DB.InsertStepRound(testStep.ID, 2, "auto_fix", nil, 600); err != nil {
+		t.Fatal(err)
+	}
+
+	step := &PRStep{}
+	if _, err := step.Execute(sctx); err != nil {
+		t.Fatal(err)
+	}
+
+	logData, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ghLog := string(logData)
+
+	wantOrder := "## Risk Assessment\n\n⚠️ Medium: touches critical error handling\n\n## Testing\n\n- 🔧 **Test** - 1 issue found → auto-fixed\n\n## Pipeline"
+	if !strings.Contains(ghLog, wantOrder) {
+		t.Fatalf("expected testing section between risk assessment and pipeline, got:\n%s", ghLog)
+	}
+}
+
 func TestPRStep_UnwrapsNestedJSONBody(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -3634,6 +3634,30 @@ func TestUnwrapNestedPRBody(t *testing.T) {
 	}
 }
 
+func TestAppendGeneratedSections_StripsAgentGeneratedSections(t *testing.T) {
+	body := "## Summary\n\n- improve PR descriptions\n\n## Testing\n\n- model-added testing\n\n## Risk Assessment\n\nold risk\n\n## Pipeline\n\nold pipeline"
+
+	got := appendGeneratedSections(
+		body,
+		"real risk",
+		"## Testing\n\n- deterministic testing",
+		"## Pipeline\n\n- deterministic pipeline",
+	)
+
+	if strings.Count(got, "## Testing") != 1 {
+		t.Fatalf("expected one Testing section, got:\n%s", got)
+	}
+	if strings.Count(got, "## Risk Assessment") != 1 {
+		t.Fatalf("expected one Risk Assessment section, got:\n%s", got)
+	}
+	if strings.Count(got, "## Pipeline") != 1 {
+		t.Fatalf("expected one Pipeline section, got:\n%s", got)
+	}
+	if strings.Contains(got, "model-added testing") || strings.Contains(got, "old risk") || strings.Contains(got, "old pipeline") {
+		t.Fatalf("expected generated sections to replace agent-provided ones, got:\n%s", got)
+	}
+}
+
 func fakeGlab(t *testing.T, mrViewJSON string) (binDir string, logFile string) {
 	t.Helper()
 	binDir = fakeCLIBinDir(t)


### PR DESCRIPTION
## Summary
- Improve generated PR descriptions by refining PR summary assembly, fixing rendering issues, and deduplicating repeated sections so the final output is cleaner and more reliable.
- Exclude PR and CI pipeline steps from the generated summary and avoid reporting passed review summaries when no test rounds ran, so the description stays focused on meaningful branch changes.
- Add coverage for the new PR summary behavior and update the auto-fix and pipeline step docs to match the revised generated sections and risk guidance.

## Risk Assessment

✅ Low: The change is well-bounded to PR description generation and summary rendering, with focused test coverage around the new section-stripping and pipeline/testing formatting behavior.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

✅ **Rebase** - passed
✅ **Review** - passed
✅ **Test** - passed
✅ **Lint** - passed
