### PR TITLE
fix(ipc): add daemon request logging without health noise

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -257,6 +257,7 @@ func registerHandlers(srv *ipc.Server, mgr *RunManager, d *db.DB, shutdown func(
 		if err := json.Unmarshal(params, &p); err != nil {
 			return nil, fmt.Errorf("invalid params: %w", err)
 		}
+		slog.Info("push received", "ref", p.Ref, "old", p.Old, "new", p.New, "gate", p.Gate)
 		runID, err := mgr.HandlePushReceived(ctx, &p)
 		if err != nil {
 			return nil, err

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -152,6 +152,7 @@ func (s *Server) handleConn(conn net.Conn) {
 		s.mu.RUnlock()
 
 		if isStream {
+			slog.Info("ipc stream request", "method", req.Method)
 			// Send initial OK response.
 			resp, _ := NewResponse(req.ID, map[string]bool{"ok": true})
 			if err := encoder.Encode(resp); err != nil {
@@ -185,8 +186,10 @@ func (s *Server) dispatch(ctx context.Context, req Request) *Response {
 		return NewErrorResponse(req.ID, ErrMethodNotFound, "method not found: "+req.Method)
 	}
 
+	slog.Info("ipc request", "method", req.Method)
 	result, err := handler(ctx, req.Params)
 	if err != nil {
+		slog.Info("ipc request failed", "method", req.Method, "error", err)
 		return NewErrorResponse(req.ID, ErrInternal, err.Error())
 	}
 

--- a/internal/ipc/server.go
+++ b/internal/ipc/server.go
@@ -186,7 +186,11 @@ func (s *Server) dispatch(ctx context.Context, req Request) *Response {
 		return NewErrorResponse(req.ID, ErrMethodNotFound, "method not found: "+req.Method)
 	}
 
-	slog.Info("ipc request", "method", req.Method)
+	if req.Method == MethodHealth {
+		slog.Debug("ipc request", "method", req.Method)
+	} else {
+		slog.Info("ipc request", "method", req.Method)
+	}
 	result, err := handler(ctx, req.Params)
 	if err != nil {
 		slog.Info("ipc request failed", "method", req.Method, "error", err)

--- a/internal/ipc/server_test.go
+++ b/internal/ipc/server_test.go
@@ -2,9 +2,11 @@ package ipc_test
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -242,6 +244,49 @@ func TestNilParams(t *testing.T) {
 	}
 	if result.Status != "ok" {
 		t.Errorf("got status=%q, want %q", result.Status, "ok")
+	}
+}
+
+func TestHealthRequestsDoNotLogAtInfo(t *testing.T) {
+	sock := socketPath(t)
+	srv := startServer(t, sock)
+
+	srv.Handle(ipc.MethodHealth, func(_ context.Context, _ json.RawMessage) (interface{}, error) {
+		return ipc.HealthResult{Status: "ok"}, nil
+	})
+	srv.Handle("fail", func(_ context.Context, _ json.RawMessage) (interface{}, error) {
+		return nil, fmt.Errorf("something broke")
+	})
+
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	prev := slog.Default()
+	slog.SetDefault(logger)
+	defer slog.SetDefault(prev)
+
+	c, err := ipc.Dial(sock)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+
+	var health ipc.HealthResult
+	if err := c.Call(ipc.MethodHealth, nil, &health); err != nil {
+		t.Fatalf("health call: %v", err)
+	}
+
+	var raw json.RawMessage
+	err = c.Call("fail", nil, &raw)
+	if err == nil {
+		t.Fatal("expected fail call error")
+	}
+
+	logOutput := logs.String()
+	if strings.Contains(logOutput, "method=health") {
+		t.Fatalf("health request should not log at info: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "msg=\"ipc request failed\" method=fail") {
+		t.Fatalf("failed request log missing: %s", logOutput)
 	}
 }
 

--- a/internal/ipc/server_test.go
+++ b/internal/ipc/server_test.go
@@ -411,6 +411,50 @@ func TestStreamHandler(t *testing.T) {
 	}
 }
 
+func TestStreamRequestsLogAtInfo(t *testing.T) {
+	sock := socketPath(t)
+	srv := startServer(t, sock)
+
+	type streamEvent struct {
+		Index int `json:"index"`
+	}
+
+	srv.HandleStream("stream_test", func(_ context.Context, _ json.RawMessage, send func(interface{}) error) error {
+		return send(streamEvent{Index: 0})
+	})
+
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	prev := slog.Default()
+	slog.SetDefault(logger)
+	defer slog.SetDefault(prev)
+
+	rawConn := rawDial(t, sock)
+	defer rawConn.Close()
+
+	encoder := json.NewEncoder(rawConn)
+	scanner := bufio.NewScanner(rawConn)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024)
+
+	req, _ := ipc.NewRequest("stream_test", nil)
+	if err := encoder.Encode(req); err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+
+	if !scanner.Scan() {
+		t.Fatal("no initial response")
+	}
+
+	if !scanner.Scan() {
+		t.Fatal("no stream event")
+	}
+
+	logOutput := logs.String()
+	if !strings.Contains(logOutput, "msg=\"ipc stream request\" method=stream_test") {
+		t.Fatalf("stream request log missing: %s", logOutput)
+	}
+}
+
 func TestStreamHandlerAndRegularCoexist(t *testing.T) {
 	sock := socketPath(t)
 	srv := startServer(t, sock)


### PR DESCRIPTION
## Summary
- Add daemon-side IPC logging for incoming requests and push notifications so background activity is easier to diagnose when issues occur.
- Exclude the frequently polled health check from high-volume request logging to avoid noisy daemon logs during normal startup and shutdown.
- Add coverage for IPC server logging behavior to lock in the new diagnostics without regressing log volume.

## Risk Assessment

✅ Low: The change is narrowly scoped to IPC/daemon logging behavior with a focused regression test, and I did not find any changed-code issues that materially affect correctness or merge safety.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

✅ **Rebase** - passed
🔧 **Review** - 2 issues found → auto-fixed
✅ **Test** - passed
✅ **Lint** - passed

<details>
<summary>Review details</summary>

**Round 1** - found 2 issues (1 warning, 1 info)
- ⚠️ `internal/ipc/server.go:189` - Logging every IPC call at `Info` will materially increase daemon log volume on normal startup and shutdown because `IsRunning` polls the `health` endpoint every 100ms; this can drown useful diagnostics and grows `daemon.log` even when nothing is wrong.
- ℹ️ `internal/daemon/daemon.go:260` - `push received` now logs `gate`, which is the bare repo path passed from `daemon notify-push`; if these logs are shared for debugging, they will expose local filesystem paths, so confirm that this extra detail is actually desired.

**Round 2** (auto-fix) - found 0 issues

</details>
