### PR TITLE
fix(pipeline): honor step env for CI and PR commands

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -23,6 +23,7 @@ type StepContext struct {
 	Fixing            bool         // true when re-executing after a "fix" action
 	PreviousFindings  string       // JSON findings from the previous execution (set during fix loop)
 	DismissedFindings string       // JSON findings the user explicitly deselected (excluded from fix)
+	Env               []string     // extra environment variables for subprocesses (used in tests)
 }
 
 // StepOutcome is the result of executing a pipeline step.

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -143,11 +143,11 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 		sctx.Log(fmt.Sprintf("skipping CI: provider %s is not supported yet", provider))
 		return &pipeline.StepOutcome{}, nil
 	}
-	if !scm.CLIAvailable(provider) {
+	if !stepCLIAvailable(sctx, provider) {
 		sctx.Log("skipping CI: gh CLI is not installed")
 		return &pipeline.StepOutcome{}, nil
 	}
-	if !scm.AuthConfigured(ctx, provider, sctx.WorkDir) {
+	if !stepAuthConfigured(sctx, provider) {
 		sctx.Log("skipping CI: gh CLI is not authenticated")
 		return &pipeline.StepOutcome{}, nil
 	}

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -439,13 +439,13 @@ func (s *CIStep) commitAndPush(sctx *pipeline.StepContext) (bool, error) {
 		return false, nil
 	}
 
-	if _, err := git.Run(ctx, sctx.WorkDir, "add", "-A"); err != nil {
+	if _, err := stepGitRun(sctx, "add", "-A"); err != nil {
 		return false, fmt.Errorf("stage CI changes: %w", err)
 	}
-	if _, err := git.Run(ctx, sctx.WorkDir, "commit", "-m", "no-mistakes: apply CI fixes"); err != nil {
+	if _, err := stepGitRun(sctx, "commit", "-m", "no-mistakes: apply CI fixes"); err != nil {
 		return false, fmt.Errorf("commit: %w", err)
 	}
-	headSHA, err := git.HeadSHA(ctx, sctx.WorkDir)
+	headSHA, err := stepGitHeadSHA(sctx)
 	if err != nil {
 		return false, fmt.Errorf("resolve head after commit: %w", err)
 	}
@@ -453,18 +453,18 @@ func (s *CIStep) commitAndPush(sctx *pipeline.StepContext) (bool, error) {
 
 	ref := normalizedBranchRef(sctx.Run.Branch)
 
-	upstreamSHA, lsErr := git.LsRemote(ctx, sctx.WorkDir, sctx.Repo.UpstreamURL, ref)
+	upstreamSHA, lsErr := stepGitLsRemote(sctx, sctx.Repo.UpstreamURL, ref)
 	if lsErr != nil {
 		slog.Warn("ls-remote failed, pushing without force-with-lease", "ref", ref, "error", lsErr)
 	}
-	if err := git.Push(ctx, sctx.WorkDir, sctx.Repo.UpstreamURL, ref, upstreamSHA, upstreamSHA != ""); err != nil {
+	if err := stepGitPush(sctx, sctx.Repo.UpstreamURL, ref, upstreamSHA, upstreamSHA != ""); err != nil {
 		if lsErr != nil {
 			return false, fmt.Errorf("push (ls-remote failed: %v): %w", lsErr, err)
 		}
 		return false, fmt.Errorf("push: %w", err)
 	}
 
-	if _, err := git.Run(ctx, sctx.WorkDir, "update-ref", ref, newHeadSHA); err != nil {
+	if _, err := stepGitRun(sctx, "update-ref", ref, newHeadSHA); err != nil {
 		return false, fmt.Errorf("update local branch ref: %w", err)
 	}
 	sctx.Run.HeadSHA = newHeadSHA

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"os/exec"
 	"sort"
 	"strconv"
 	"strings"
@@ -204,7 +203,7 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 		}
 
 		// Check PR state (merged/closed -> exit)
-		state, err := s.getPRState(ctx, sctx.WorkDir, prNumber)
+		state, err := s.getPRState(sctx, prNumber)
 		if err != nil {
 			sctx.Log(fmt.Sprintf("warning: could not check PR state: %v", err))
 		} else if state == "MERGED" {
@@ -217,7 +216,7 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 
 		// Check CI status - auto-fix failures when configured
 		ciFixLimit := sctx.Config.AutoFix.CI
-		checks, err := s.getCIChecks(ctx, sctx.WorkDir, prNumber)
+		checks, err := s.getCIChecks(sctx, prNumber)
 		if err != nil {
 			sctx.Log(fmt.Sprintf("warning: could not check CI: %v", err))
 		} else if hasFailingChecks(checks) {
@@ -309,9 +308,8 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 }
 
 // getPRState returns the PR state (OPEN, MERGED, CLOSED).
-func (s *CIStep) getPRState(ctx context.Context, workDir, prNumber string) (string, error) {
-	cmd := exec.CommandContext(ctx, "gh", "pr", "view", prNumber, "--json", "state", "--jq", ".state")
-	cmd.Dir = workDir
+func (s *CIStep) getPRState(sctx *pipeline.StepContext, prNumber string) (string, error) {
+	cmd := stepCmd(sctx, "gh", "pr", "view", prNumber, "--json", "state", "--jq", ".state")
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("gh pr view: %w", err)
@@ -320,9 +318,8 @@ func (s *CIStep) getPRState(ctx context.Context, workDir, prNumber string) (stri
 }
 
 // getCIChecks fetches CI check results for a PR.
-func (s *CIStep) getCIChecks(ctx context.Context, workDir, prNumber string) ([]ciCheck, error) {
-	cmd := exec.CommandContext(ctx, "gh", "pr", "checks", prNumber, "--json", "name,state,bucket")
-	cmd.Dir = workDir
+func (s *CIStep) getCIChecks(sctx *pipeline.StepContext, prNumber string) ([]ciCheck, error) {
+	cmd := stepCmd(sctx, "gh", "pr", "checks", prNumber, "--json", "name,state,bucket")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		if strings.Contains(string(out), "no checks reported") {
@@ -346,13 +343,12 @@ func (s *CIStep) autoFixCI(sctx *pipeline.StepContext, prNumber string, failingN
 
 	// Find the most recent failing run for this branch so we fetch logs from the right run.
 	var runID string
-	listCmd := exec.CommandContext(ctx, "gh", "run", "list",
+	listCmd := stepCmd(sctx, "gh", "run", "list",
 		"--branch", sctx.Run.Branch,
 		"--status", "failure",
 		"--limit", "1",
 		"--json", "databaseId",
 		"--jq", ".[0].databaseId")
-	listCmd.Dir = sctx.WorkDir
 	if listOut, err := listCmd.Output(); err == nil {
 		runID = strings.TrimSpace(string(listOut))
 	}
@@ -361,8 +357,7 @@ func (s *CIStep) autoFixCI(sctx *pipeline.StepContext, prNumber string, failingN
 	const maxLogBytes = 32 * 1024
 	var logOutput string
 	if runID != "" {
-		cmd := exec.CommandContext(ctx, "gh", "run", "view", runID, "--log-failed")
-		cmd.Dir = sctx.WorkDir
+		cmd := stepCmd(sctx, "gh", "run", "view", runID, "--log-failed")
 		out, _ := cmd.Output()
 		if len(out) > 0 {
 			logOutput = strings.TrimSpace(string(out))
@@ -428,7 +423,7 @@ func (s *CIStep) commitAndPush(sctx *pipeline.StepContext) (bool, error) {
 	ctx := sctx.Ctx
 	newHeadSHA := ""
 
-	status, err := git.Run(ctx, sctx.WorkDir, "status", "--porcelain")
+	status, err := stepGitRun(sctx, "status", "--porcelain")
 	if err != nil {
 		return false, fmt.Errorf("check CI changes: %w", err)
 	}

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
-	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/scm"
 	"github.com/kunchenguid/no-mistakes/internal/types"
@@ -420,7 +419,6 @@ CI logs:
 // Returns (true, nil) when changes were pushed, (false, nil) when there was
 // nothing to commit, or (false, err) on failure.
 func (s *CIStep) commitAndPush(sctx *pipeline.StepContext) (bool, error) {
-	ctx := sctx.Ctx
 	newHeadSHA := ""
 
 	status, err := stepGitRun(sctx, "status", "--porcelain")
@@ -429,7 +427,7 @@ func (s *CIStep) commitAndPush(sctx *pipeline.StepContext) (bool, error) {
 	}
 	if strings.TrimSpace(status) == "" {
 		sctx.Log("no changes to commit")
-		headSHA, err := git.HeadSHA(ctx, sctx.WorkDir)
+		headSHA, err := stepGitHeadSHA(sctx)
 		if err == nil && headSHA != sctx.Run.HeadSHA {
 			sctx.Run.HeadSHA = headSHA
 			if err := sctx.DB.UpdateRunHeadSHA(sctx.Run.ID, headSHA); err != nil {

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -150,12 +150,22 @@ func findInCustomPath(env []string, name string) string {
 	for _, dir := range filepath.SplitList(customPath) {
 		for _, candidateName := range executableCandidates(name, env) {
 			candidate := filepath.Join(dir, candidateName)
-			if fi, err := os.Stat(candidate); err == nil && !fi.IsDir() && fi.Mode().Perm()&0o111 != 0 {
+			if fi, err := os.Stat(candidate); err == nil && pathCandidateUsable(runtime.GOOS, candidate, fi) {
 				return candidate
 			}
 		}
 	}
 	return ""
+}
+
+func pathCandidateUsable(goos, path string, fi os.FileInfo) bool {
+	if fi.IsDir() {
+		return false
+	}
+	if goos == "windows" {
+		return filepath.Ext(path) != ""
+	}
+	return fi.Mode().Perm()&0o111 != 0
 }
 
 func missingFromCustomPath(env []string, name string) string {

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -207,6 +207,39 @@ func stepGitRun(sctx *pipeline.StepContext, args ...string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+func stepGitHeadSHA(sctx *pipeline.StepContext) (string, error) {
+	return stepGitRun(sctx, "rev-parse", "HEAD")
+}
+
+func stepGitLsRemote(sctx *pipeline.StepContext, remote, ref string) (string, error) {
+	out, err := stepGitRun(sctx, "ls-remote", remote, ref)
+	if err != nil {
+		return "", err
+	}
+	if out == "" {
+		return "", nil
+	}
+	parts := strings.Fields(out)
+	if len(parts) < 1 {
+		return "", nil
+	}
+	return parts[0], nil
+}
+
+func stepGitPush(sctx *pipeline.StepContext, remote, ref, expectedSHA string, forceWithLease bool) error {
+	args := []string{"push", remote}
+	if forceWithLease {
+		if expectedSHA != "" {
+			args = append(args, fmt.Sprintf("--force-with-lease=%s:%s", ref, expectedSHA))
+		} else {
+			args = append(args, "--force-with-lease")
+		}
+	}
+	args = append(args, "HEAD:"+ref)
+	_, err := stepGitRun(sctx, args...)
+	return err
+}
+
 // stepCLIAvailable checks whether the provider CLI binary is available,
 // respecting any custom PATH in sctx.Env.
 func stepCLIAvailable(sctx *pipeline.StepContext, provider scm.Provider) bool {

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -12,6 +13,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/agent"
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
+	"github.com/kunchenguid/no-mistakes/internal/scm"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
@@ -66,6 +68,86 @@ func hasBlockingFindings(items []Finding) bool {
 		}
 	}
 	return false
+}
+
+// stepCmd creates an exec.Cmd that inherits the StepContext's extra Env, if any.
+// When sctx.Env overrides PATH, the binary is resolved from the overridden PATH
+// so that tests can inject fake binaries without modifying the process environment.
+func stepCmd(sctx *pipeline.StepContext, name string, args ...string) *exec.Cmd {
+	resolved := name
+	if len(sctx.Env) > 0 && !strings.Contains(name, string(filepath.Separator)) {
+		for _, e := range sctx.Env {
+			if strings.HasPrefix(e, "PATH=") {
+				customPath := strings.TrimPrefix(e, "PATH=")
+				for _, dir := range filepath.SplitList(customPath) {
+					candidate := filepath.Join(dir, name)
+					if fi, err := os.Stat(candidate); err == nil && !fi.IsDir() {
+						resolved = candidate
+						break
+					}
+				}
+				break
+			}
+		}
+	}
+	cmd := exec.CommandContext(sctx.Ctx, resolved, args...)
+	cmd.Dir = sctx.WorkDir
+	if len(sctx.Env) > 0 {
+		cmd.Env = append(os.Environ(), sctx.Env...)
+	}
+	return cmd
+}
+
+// stepGitRun runs a git command using the StepContext's environment.
+// It is like git.Run but respects sctx.Env so that tests can inject a fake git binary.
+func stepGitRun(sctx *pipeline.StepContext, args ...string) (string, error) {
+	cmd := stepCmd(sctx, "git", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		stderr := ""
+		if ee, ok := err.(*exec.ExitError); ok {
+			stderr = strings.TrimSpace(string(ee.Stderr))
+		}
+		return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, stderr)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// stepCLIAvailable checks whether the provider CLI binary is available,
+// respecting any custom PATH in sctx.Env.
+func stepCLIAvailable(sctx *pipeline.StepContext, provider scm.Provider) bool {
+	name := provider.CLIName()
+	if name == "" {
+		return false
+	}
+	if len(sctx.Env) == 0 {
+		return scm.CLIAvailable(provider)
+	}
+	// Search custom PATH from sctx.Env
+	for _, e := range sctx.Env {
+		if strings.HasPrefix(e, "PATH=") {
+			customPath := strings.TrimPrefix(e, "PATH=")
+			for _, dir := range filepath.SplitList(customPath) {
+				candidate := filepath.Join(dir, name)
+				if fi, err := os.Stat(candidate); err == nil && !fi.IsDir() {
+					return true
+				}
+			}
+			return false
+		}
+	}
+	return scm.CLIAvailable(provider)
+}
+
+// stepAuthConfigured checks whether the provider CLI is authenticated,
+// using sctx.Env to resolve the binary and pass environment variables.
+func stepAuthConfigured(sctx *pipeline.StepContext, provider scm.Provider) bool {
+	args := provider.AuthCheckCommand()
+	if len(args) == 0 {
+		return false
+	}
+	cmd := stepCmd(sctx, args[0], args[1:]...)
+	return cmd.Run() == nil
 }
 
 // runShellCommand executes a shell command and returns stdout+stderr, exit code, and error.

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -150,7 +150,7 @@ func findInCustomPath(env []string, name string) string {
 	for _, dir := range filepath.SplitList(customPath) {
 		for _, candidateName := range executableCandidates(name, env) {
 			candidate := filepath.Join(dir, candidateName)
-			if fi, err := os.Stat(candidate); err == nil && !fi.IsDir() {
+			if fi, err := os.Stat(candidate); err == nil && !fi.IsDir() && fi.Mode().Perm()&0o111 != 0 {
 				return candidate
 			}
 		}

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -128,12 +128,16 @@ func mergeEnv(extra []string) []string {
 }
 
 func executableCandidates(name string, env []string) []string {
+	return executableCandidatesForOS(runtime.GOOS, name, env)
+}
+
+func executableCandidatesForOS(goos, name string, env []string) []string {
 	candidates := []string{name}
-	if runtime.GOOS != "windows" || filepath.Ext(name) != "" {
+	if goos != "windows" || filepath.Ext(name) != "" {
 		return candidates
 	}
 	pathExt := ".COM;.EXE;.BAT;.CMD"
-	if customPathExt, ok := envValue(env, "PATHEXT"); ok && strings.TrimSpace(customPathExt) != "" {
+	if customPathExt, ok := envValueForOS(env, "PATHEXT", goos); ok {
 		pathExt = customPathExt
 	}
 	for _, ext := range strings.Split(pathExt, ";") {
@@ -146,12 +150,18 @@ func executableCandidates(name string, env []string) []string {
 	return candidates
 }
 
-func findInCustomPath(env []string, name string) string {
+func findInCustomPath(workDir string, env []string, name string) string {
 	customPath, ok := envValue(env, "PATH")
 	if !ok {
 		return ""
 	}
 	for _, dir := range filepath.SplitList(customPath) {
+		if dir == "" {
+			continue
+		}
+		if !filepath.IsAbs(dir) {
+			dir = filepath.Join(workDir, dir)
+		}
 		for _, candidateName := range executableCandidates(name, env) {
 			candidate := filepath.Join(dir, candidateName)
 			if fi, err := os.Stat(candidate); err == nil && pathCandidateUsable(runtime.GOOS, candidate, fi) {
@@ -249,7 +259,7 @@ func stepCmd(sctx *pipeline.StepContext, name string, args ...string) *exec.Cmd 
 	resolved := name
 	missingFromPath := false
 	if len(sctx.Env) > 0 && !strings.Contains(name, string(filepath.Separator)) {
-		if candidate := findInCustomPath(sctx.Env, name); candidate != "" {
+		if candidate := findInCustomPath(sctx.WorkDir, sctx.Env, name); candidate != "" {
 			resolved = candidate
 		} else if _, ok := envValue(sctx.Env, "PATH"); ok {
 			resolved = missingFromCustomPath(sctx.Env, name)
@@ -325,7 +335,7 @@ func stepCLIAvailable(sctx *pipeline.StepContext, provider scm.Provider) bool {
 	if len(sctx.Env) == 0 {
 		return scm.CLIAvailable(provider)
 	}
-	if candidate := findInCustomPath(sctx.Env, name); candidate != "" {
+	if candidate := findInCustomPath(sctx.WorkDir, sctx.Env, name); candidate != "" {
 		return true
 	}
 	_, ok := envValue(sctx.Env, "PATH")

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -84,6 +84,45 @@ func envValue(env []string, key string) (string, bool) {
 	return "", false
 }
 
+func envKey(entry string) string {
+	key, _, found := strings.Cut(entry, "=")
+	if !found {
+		key = entry
+	}
+	if runtime.GOOS == "windows" {
+		return strings.ToUpper(key)
+	}
+	return key
+}
+
+func mergeEnv(extra []string) []string {
+	if len(extra) == 0 {
+		return nil
+	}
+	merged := make([]string, 0, len(os.Environ())+len(extra))
+	overrides := make(map[string]string, len(extra))
+	for _, entry := range extra {
+		overrides[envKey(entry)] = entry
+	}
+	for _, entry := range os.Environ() {
+		key := envKey(entry)
+		if override, ok := overrides[key]; ok {
+			merged = append(merged, override)
+			delete(overrides, key)
+			continue
+		}
+		merged = append(merged, entry)
+	}
+	for _, entry := range extra {
+		key := envKey(entry)
+		if override, ok := overrides[key]; ok {
+			merged = append(merged, override)
+			delete(overrides, key)
+		}
+	}
+	return merged
+}
+
 func executableCandidates(name string, env []string) []string {
 	candidates := []string{name}
 	if runtime.GOOS != "windows" || filepath.Ext(name) != "" {
@@ -117,6 +156,20 @@ func findInCustomPath(env []string, name string) string {
 		}
 	}
 	return ""
+}
+
+func missingFromCustomPath(env []string, name string) string {
+	customPath, ok := envValue(env, "PATH")
+	if !ok {
+		return ""
+	}
+	for _, dir := range filepath.SplitList(customPath) {
+		if strings.TrimSpace(dir) == "" {
+			continue
+		}
+		return filepath.Join(dir, executableCandidates(name, env)[0])
+	}
+	return name
 }
 
 func copyDirContents(srcDir, dstDir string) error {
@@ -182,12 +235,14 @@ func stepCmd(sctx *pipeline.StepContext, name string, args ...string) *exec.Cmd 
 	if len(sctx.Env) > 0 && !strings.Contains(name, string(filepath.Separator)) {
 		if candidate := findInCustomPath(sctx.Env, name); candidate != "" {
 			resolved = candidate
+		} else if _, ok := envValue(sctx.Env, "PATH"); ok {
+			resolved = missingFromCustomPath(sctx.Env, name)
 		}
 	}
 	cmd := exec.CommandContext(sctx.Ctx, resolved, args...)
 	cmd.Dir = sctx.WorkDir
 	if len(sctx.Env) > 0 {
-		cmd.Env = append(os.Environ(), sctx.Env...)
+		cmd.Env = mergeEnv(sctx.Env)
 	}
 	return cmd
 }

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -72,12 +72,16 @@ func hasBlockingFindings(items []Finding) bool {
 }
 
 func envValue(env []string, key string) (string, bool) {
+	return envValueForOS(env, key, runtime.GOOS)
+}
+
+func envValueForOS(env []string, key, goos string) (string, bool) {
 	prefix := key + "="
 	for _, entry := range env {
 		if strings.HasPrefix(entry, prefix) {
 			return strings.TrimPrefix(entry, prefix), true
 		}
-		if runtime.GOOS == "windows" && len(entry) > len(prefix) && strings.EqualFold(entry[:len(prefix)], prefix) {
+		if goos == "windows" && len(entry) >= len(prefix) && strings.EqualFold(entry[:len(prefix)], prefix) {
 			return entry[len(prefix):], true
 		}
 	}

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -177,13 +177,14 @@ func missingFromCustomPath(env []string, name string) string {
 	if !ok {
 		return ""
 	}
+	missing := filepath.Join(".", executableCandidates(name, env)[0])
 	for _, dir := range filepath.SplitList(customPath) {
 		if strings.TrimSpace(dir) == "" {
 			continue
 		}
 		return filepath.Join(dir, executableCandidates(name, env)[0])
 	}
-	return name
+	return missing
 }
 
 func copyDirContents(srcDir, dstDir string) error {
@@ -246,17 +247,22 @@ func copyFile(srcPath, dstPath string, perm os.FileMode) error {
 // so that tests can inject fake binaries without modifying the process environment.
 func stepCmd(sctx *pipeline.StepContext, name string, args ...string) *exec.Cmd {
 	resolved := name
+	missingFromPath := false
 	if len(sctx.Env) > 0 && !strings.Contains(name, string(filepath.Separator)) {
 		if candidate := findInCustomPath(sctx.Env, name); candidate != "" {
 			resolved = candidate
 		} else if _, ok := envValue(sctx.Env, "PATH"); ok {
 			resolved = missingFromCustomPath(sctx.Env, name)
+			missingFromPath = true
 		}
 	}
 	cmd := exec.CommandContext(sctx.Ctx, resolved, args...)
 	cmd.Dir = sctx.WorkDir
 	if len(sctx.Env) > 0 {
 		cmd.Env = mergeEnv(sctx.Env)
+	}
+	if missingFromPath {
+		cmd.Err = &exec.Error{Name: name, Err: exec.ErrNotFound}
 	}
 	return cmd
 }

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -70,24 +71,117 @@ func hasBlockingFindings(items []Finding) bool {
 	return false
 }
 
+func envValue(env []string, key string) (string, bool) {
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			return strings.TrimPrefix(entry, prefix), true
+		}
+		if runtime.GOOS == "windows" && len(entry) > len(prefix) && strings.EqualFold(entry[:len(prefix)], prefix) {
+			return entry[len(prefix):], true
+		}
+	}
+	return "", false
+}
+
+func executableCandidates(name string, env []string) []string {
+	candidates := []string{name}
+	if runtime.GOOS != "windows" || filepath.Ext(name) != "" {
+		return candidates
+	}
+	pathExt := ".COM;.EXE;.BAT;.CMD"
+	if customPathExt, ok := envValue(env, "PATHEXT"); ok && strings.TrimSpace(customPathExt) != "" {
+		pathExt = customPathExt
+	}
+	for _, ext := range strings.Split(pathExt, ";") {
+		ext = strings.TrimSpace(ext)
+		if ext == "" {
+			continue
+		}
+		candidates = append(candidates, name+ext)
+	}
+	return candidates
+}
+
+func findInCustomPath(env []string, name string) string {
+	customPath, ok := envValue(env, "PATH")
+	if !ok {
+		return ""
+	}
+	for _, dir := range filepath.SplitList(customPath) {
+		for _, candidateName := range executableCandidates(name, env) {
+			candidate := filepath.Join(dir, candidateName)
+			if fi, err := os.Stat(candidate); err == nil && !fi.IsDir() {
+				return candidate
+			}
+		}
+	}
+	return ""
+}
+
+func copyDirContents(srcDir, dstDir string) error {
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		srcPath := filepath.Join(srcDir, entry.Name())
+		dstPath := filepath.Join(dstDir, entry.Name())
+		if err := copyPath(srcPath, dstPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func copyPath(srcPath, dstPath string) error {
+	info, err := os.Lstat(srcPath)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		target, err := os.Readlink(srcPath)
+		if err != nil {
+			return err
+		}
+		return os.Symlink(target, dstPath)
+	}
+	if info.IsDir() {
+		if err := os.MkdirAll(dstPath, info.Mode().Perm()); err != nil {
+			return err
+		}
+		return copyDirContents(srcPath, dstPath)
+	}
+	return copyFile(srcPath, dstPath, info.Mode().Perm())
+}
+
+func copyFile(srcPath, dstPath string, perm os.FileMode) error {
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	dst, err := os.OpenFile(dstPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, perm)
+	if err != nil {
+		return err
+	}
+	defer dst.Close()
+
+	if _, err := io.Copy(dst, src); err != nil {
+		return err
+	}
+	return nil
+}
+
 // stepCmd creates an exec.Cmd that inherits the StepContext's extra Env, if any.
 // When sctx.Env overrides PATH, the binary is resolved from the overridden PATH
 // so that tests can inject fake binaries without modifying the process environment.
 func stepCmd(sctx *pipeline.StepContext, name string, args ...string) *exec.Cmd {
 	resolved := name
 	if len(sctx.Env) > 0 && !strings.Contains(name, string(filepath.Separator)) {
-		for _, e := range sctx.Env {
-			if strings.HasPrefix(e, "PATH=") {
-				customPath := strings.TrimPrefix(e, "PATH=")
-				for _, dir := range filepath.SplitList(customPath) {
-					candidate := filepath.Join(dir, name)
-					if fi, err := os.Stat(candidate); err == nil && !fi.IsDir() {
-						resolved = candidate
-						break
-					}
-				}
-				break
-			}
+		if candidate := findInCustomPath(sctx.Env, name); candidate != "" {
+			resolved = candidate
 		}
 	}
 	cmd := exec.CommandContext(sctx.Ctx, resolved, args...)
@@ -123,18 +217,12 @@ func stepCLIAvailable(sctx *pipeline.StepContext, provider scm.Provider) bool {
 	if len(sctx.Env) == 0 {
 		return scm.CLIAvailable(provider)
 	}
-	// Search custom PATH from sctx.Env
-	for _, e := range sctx.Env {
-		if strings.HasPrefix(e, "PATH=") {
-			customPath := strings.TrimPrefix(e, "PATH=")
-			for _, dir := range filepath.SplitList(customPath) {
-				candidate := filepath.Join(dir, name)
-				if fi, err := os.Stat(candidate); err == nil && !fi.IsDir() {
-					return true
-				}
-			}
-			return false
-		}
+	if candidate := findInCustomPath(sctx.Env, name); candidate != "" {
+		return true
+	}
+	_, ok := envValue(sctx.Env, "PATH")
+	if ok {
+		return false
 	}
 	return scm.CLIAvailable(provider)
 }

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"os/exec"
 	"regexp"
 	"strings"
 
@@ -59,11 +58,11 @@ func (s *PRStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 		sctx.Log(fmt.Sprintf("skipping PR creation: provider %s is not supported yet", provider))
 		return &pipeline.StepOutcome{}, nil
 	}
-	if !scm.CLIAvailable(provider) {
+	if !stepCLIAvailable(sctx, provider) {
 		sctx.Log(fmt.Sprintf("skipping PR creation: %s CLI is not installed", provider.CLIName()))
 		return &pipeline.StepOutcome{}, nil
 	}
-	if !scm.AuthConfigured(ctx, provider, sctx.WorkDir) {
+	if !stepAuthConfigured(sctx, provider) {
 		sctx.Log(fmt.Sprintf("skipping PR creation: %s CLI is not authenticated", provider.CLIName()))
 		return &pipeline.StepOutcome{}, nil
 	}
@@ -86,20 +85,16 @@ func (s *PRStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 }
 
 func (s *PRStep) executeGitHubPR(sctx *pipeline.StepContext, branch string, content prContent) (*pipeline.StepOutcome, error) {
-	ctx := sctx.Ctx
-
 	// Check if PR already exists for this branch
 	sctx.Log(fmt.Sprintf("checking for existing PR on branch %s...", branch))
-	cmd := exec.CommandContext(ctx, "gh", "pr", "view", branch, "--json", "url", "--jq", ".url")
-	cmd.Dir = sctx.WorkDir
+	cmd := stepCmd(sctx, "gh", "pr", "view", branch, "--json", "url", "--jq", ".url")
 	out, err := cmd.Output()
 	if err == nil {
 		prURL := strings.TrimSpace(string(out))
 		if prURL != "" {
 			sctx.Log(fmt.Sprintf("PR already exists: %s, updating...", prURL))
 
-			editCmd := exec.CommandContext(ctx, "gh", "pr", "edit", branch, "--title", content.Title, "--body", content.Body)
-			editCmd.Dir = sctx.WorkDir
+			editCmd := stepCmd(sctx, "gh", "pr", "edit", branch, "--title", content.Title, "--body", content.Body)
 			if editOut, editErr := editCmd.CombinedOutput(); editErr != nil {
 				sctx.Log(fmt.Sprintf("warning: failed to update PR body: %s: %v", strings.TrimSpace(string(editOut)), editErr))
 			}
@@ -114,13 +109,12 @@ func (s *PRStep) executeGitHubPR(sctx *pipeline.StepContext, branch string, cont
 	// Create PR
 	sctx.Log("creating pull request...")
 
-	cmd = exec.CommandContext(ctx, "gh", "pr", "create",
+	cmd = stepCmd(sctx, "gh", "pr", "create",
 		"--head", branch,
 		"--base", sctx.Repo.DefaultBranch,
 		"--title", content.Title,
 		"--body", content.Body,
 	)
-	cmd.Dir = sctx.WorkDir
 	out, err = cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("gh pr create: %s: %w", strings.TrimSpace(string(out)), err)
@@ -136,17 +130,14 @@ func (s *PRStep) executeGitHubPR(sctx *pipeline.StepContext, branch string, cont
 }
 
 func (s *PRStep) executeGitLabMR(sctx *pipeline.StepContext, branch string, content prContent) (*pipeline.StepOutcome, error) {
-	ctx := sctx.Ctx
 	sctx.Log(fmt.Sprintf("checking for existing merge request on branch %s...", branch))
-	cmd := exec.CommandContext(ctx, "glab", "mr", "view", branch, "--output", "json")
-	cmd.Dir = sctx.WorkDir
+	cmd := stepCmd(sctx, "glab", "mr", "view", branch, "--output", "json")
 	out, err := cmd.CombinedOutput()
 	if err == nil {
 		mrURL := extractSCMURL(out)
 		if mrURL != "" {
 			sctx.Log(fmt.Sprintf("merge request already exists: %s, updating...", mrURL))
-			updateCmd := exec.CommandContext(ctx, "glab", "mr", "update", branch, "--title", content.Title, "--description", content.Body, "--yes")
-			updateCmd.Dir = sctx.WorkDir
+			updateCmd := stepCmd(sctx, "glab", "mr", "update", branch, "--title", content.Title, "--description", content.Body, "--yes")
 			if updateOut, updateErr := updateCmd.CombinedOutput(); updateErr != nil {
 				sctx.Log(fmt.Sprintf("warning: failed to update merge request: %s: %v", strings.TrimSpace(string(updateOut)), updateErr))
 			}
@@ -158,14 +149,13 @@ func (s *PRStep) executeGitLabMR(sctx *pipeline.StepContext, branch string, cont
 	}
 
 	sctx.Log("creating merge request...")
-	cmd = exec.CommandContext(ctx, "glab", "mr", "create",
+	cmd = stepCmd(sctx, "glab", "mr", "create",
 		"--source-branch", branch,
 		"--target-branch", sctx.Repo.DefaultBranch,
 		"--title", content.Title,
 		"--description", content.Body,
 		"--yes",
 	)
-	cmd.Dir = sctx.WorkDir
 	out, err = cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("glab mr create: %s: %w", strings.TrimSpace(string(out)), err)

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestBuildPipelineSummary_AllClean(t *testing.T) {
+	t.Parallel()
 	steps := []*db.StepResult{
 		{ID: "s1", StepName: types.StepReview, Status: types.StepStatusCompleted},
 		{ID: "s2", StepName: types.StepTest, Status: types.StepStatusCompleted},
@@ -90,6 +91,7 @@ func TestBuildPipelineSummary_IncludesAllPipelineSteps(t *testing.T) {
 }
 
 func TestBuildPipelineSummary_ReviewWithRisk(t *testing.T) {
+	t.Parallel()
 	findings := `{"findings":[{"id":"review-1","severity":"warning","file":"cmd/main.go","line":10,"description":"potential nil deref"}],"summary":"1 warning","risk_level":"low","risk_rationale":"straightforward refactor with no behavioral changes"}`
 	steps := []*db.StepResult{
 		{ID: "s1", StepName: types.StepReview, Status: types.StepStatusCompleted, FindingsJSON: &findings},
@@ -118,6 +120,7 @@ func TestBuildPipelineSummary_ReviewWithRisk(t *testing.T) {
 }
 
 func TestBuildPipelineSummary_AutoFix(t *testing.T) {
+	t.Parallel()
 	findings1 := `{"findings":[{"id":"lint-1","severity":"error","file":"pkg/foo.go","line":18,"description":"unused import"},{"id":"lint-2","severity":"warning","file":"pkg/bar.go","line":35,"description":"missing error check"}],"summary":"2 issues"}`
 	steps := []*db.StepResult{
 		{ID: "s1", StepName: types.StepLint, Status: types.StepStatusCompleted},
@@ -151,6 +154,7 @@ func TestBuildPipelineSummary_AutoFix(t *testing.T) {
 }
 
 func TestBuildPipelineSummary_MultiRoundWithUserFix(t *testing.T) {
+	t.Parallel()
 	findings1 := `{"findings":[{"id":"test-1","severity":"error","file":"pkg/handler_test.go","line":42,"description":"expected 429 got 200"},{"id":"test-2","severity":"error","file":"pkg/handler_test.go","line":78,"description":"context deadline exceeded"}],"summary":"2 failures"}`
 	findings2 := `{"findings":[{"id":"test-2","severity":"error","file":"pkg/handler_test.go","line":78,"description":"context deadline exceeded"}],"summary":"1 failure"}`
 	steps := []*db.StepResult{
@@ -174,6 +178,7 @@ func TestBuildPipelineSummary_MultiRoundWithUserFix(t *testing.T) {
 }
 
 func TestBuildPipelineSummary_MultiRoundStillFailing(t *testing.T) {
+	t.Parallel()
 	findings1 := `{"findings":[{"id":"lint-1","severity":"error","file":"pkg/foo.go","line":18,"description":"unused import"},{"id":"lint-2","severity":"warning","file":"pkg/bar.go","line":35,"description":"missing error check"}],"summary":"2 issues"}`
 	findings2 := `{"findings":[{"id":"lint-2","severity":"warning","file":"pkg/bar.go","line":35,"description":"missing error check"}],"summary":"1 issue"}`
 	steps := []*db.StepResult{
@@ -199,6 +204,7 @@ func TestBuildPipelineSummary_MultiRoundStillFailing(t *testing.T) {
 }
 
 func TestBuildPipelineSummary_UsesFinalFindingsWithoutInitialRoundData(t *testing.T) {
+	t.Parallel()
 	finalFindings := `{"findings":[{"id":"test-1","severity":"error","file":"pkg/handler_test.go","line":42,"description":"expected 429 got 200"}],"summary":"1 failure"}`
 	steps := []*db.StepResult{
 		{ID: "s1", StepName: types.StepTest, Status: types.StepStatusCompleted, FindingsJSON: &finalFindings},
@@ -225,6 +231,7 @@ func TestBuildPipelineSummary_UsesFinalFindingsWithoutInitialRoundData(t *testin
 }
 
 func TestBuildPipelineSummary_SkippedStep(t *testing.T) {
+	t.Parallel()
 	steps := []*db.StepResult{
 		{ID: "s1", StepName: types.StepReview, Status: types.StepStatusSkipped},
 		{ID: "s2", StepName: types.StepTest, Status: types.StepStatusCompleted},
@@ -243,7 +250,8 @@ func TestBuildPipelineSummary_SkippedStep(t *testing.T) {
 	}
 }
 
-func TestBuildPipelineSummary_IncludesPushPRCI(t *testing.T) {
+func TestBuildPipelineSummary_ExcludesPushPRCI(t *testing.T) {
+	t.Parallel()
 	steps := []*db.StepResult{
 		{ID: "s1", StepName: types.StepReview, Status: types.StepStatusCompleted},
 		{ID: "s2", StepName: types.StepPush, Status: types.StepStatusCompleted},
@@ -288,6 +296,7 @@ func TestBuildPipelineSummary_EscapesFindingDescriptionsInDetails(t *testing.T) 
 }
 
 func TestBuildPipelineSummary_ReviewUsesFinalCleanState(t *testing.T) {
+	t.Parallel()
 	initialFindings := `{"findings":[{"id":"review-1","severity":"warning","description":"risky change"}],"summary":"1 warning","risk_level":"medium","risk_rationale":"initial risk rationale"}`
 	finalFindings := `{"findings":[],"summary":"clean","risk_level":"low","risk_rationale":"follow-up fixes reduced risk"}`
 	steps := []*db.StepResult{
@@ -325,6 +334,7 @@ func TestBuildPipelineSummary_ReviewUsesFinalCleanState(t *testing.T) {
 }
 
 func TestBuildPipelineSummary_ReviewShowsWarningForUnresolvedRiskWithoutFindings(t *testing.T) {
+	t.Parallel()
 	findings := `{"findings":[],"summary":"clean","risk_level":"medium","risk_rationale":"touches critical error handling"}`
 	steps := []*db.StepResult{
 		{ID: "s1", StepName: types.StepReview, Status: types.StepStatusCompleted, FindingsJSON: &findings},
@@ -349,6 +359,7 @@ func TestBuildPipelineSummary_ReviewShowsWarningForUnresolvedRiskWithoutFindings
 }
 
 func TestBuildPipelineSummary_ShowsParseFailureForInvalidRoundFindings(t *testing.T) {
+	t.Parallel()
 	invalidFindings := `{"findings":[`
 	steps := []*db.StepResult{
 		{ID: "s1", StepName: types.StepTest, Status: types.StepStatusCompleted},
@@ -373,6 +384,7 @@ func TestBuildPipelineSummary_ShowsParseFailureForInvalidRoundFindings(t *testin
 }
 
 func TestBuildPipelineSummary_DoesNotClaimFixedWhenFinalFindingsUnreadable(t *testing.T) {
+	t.Parallel()
 	initialFindings := `{"findings":[{"id":"lint-1","severity":"warning","description":"still broken"}],"summary":"1 issue"}`
 	invalidFinalFindings := `{"findings":[`
 	steps := []*db.StepResult{
@@ -398,6 +410,7 @@ func TestBuildPipelineSummary_DoesNotClaimFixedWhenFinalFindingsUnreadable(t *te
 }
 
 func TestBuildPipelineSummary_ReviewDoesNotReuseInitialRiskWhenFinalUnreadable(t *testing.T) {
+	t.Parallel()
 	initialFindings := `{"findings":[{"id":"review-1","severity":"warning","description":"risky change"}],"summary":"1 warning","risk_level":"medium","risk_rationale":"initial risk rationale"}`
 	invalidFinalFindings := `{"findings":[`
 	steps := []*db.StepResult{
@@ -423,6 +436,7 @@ func TestBuildPipelineSummary_ReviewDoesNotReuseInitialRiskWhenFinalUnreadable(t
 }
 
 func TestBuildPipelineSummary_FindingSeverityEmoji(t *testing.T) {
+	t.Parallel()
 	findings := `{"findings":[{"id":"review-1","severity":"error","description":"critical bug"},{"id":"review-2","severity":"warning","description":"minor issue"},{"id":"review-3","severity":"info","description":"suggestion"}],"summary":"3 findings","risk_level":"high","risk_rationale":"critical bug found"}`
 	steps := []*db.StepResult{
 		{ID: "s1", StepName: types.StepReview, Status: types.StepStatusCompleted, FindingsJSON: &findings},
@@ -447,6 +461,7 @@ func TestBuildPipelineSummary_FindingSeverityEmoji(t *testing.T) {
 }
 
 func TestBuildPipelineSummary_ReviewUsesLatestRoundNotFirst(t *testing.T) {
+	t.Parallel()
 	// When sr.FindingsJSON is nil (cleared), the fallback should use the
 	// latest round's risk assessment, not the first round's stale one.
 	initialFindings := `{"findings":[{"id":"review-1","severity":"warning","description":"issue"}],"summary":"1 warning","risk_level":"medium","risk_rationale":"initial concern"}`
@@ -474,6 +489,7 @@ func TestBuildPipelineSummary_ReviewUsesLatestRoundNotFirst(t *testing.T) {
 }
 
 func TestBuildPipelineSummary_EmptySteps(t *testing.T) {
+	t.Parallel()
 	md, risk := BuildPipelineSummary(nil, nil)
 	if md != "" {
 		t.Errorf("expected empty string for nil steps, got: %q", md)
@@ -502,6 +518,7 @@ func TestBuildTestingSummary_DoesNotClaimPassedWithoutRounds(t *testing.T) {
 }
 
 func TestBuildPipelineSummary_RebaseWithConflicts(t *testing.T) {
+	t.Parallel()
 	findings := `{"findings":[{"id":"rebase-1","severity":"warning","file":"pkg/foo.go","description":"merge conflict resolved by agent"}],"summary":"1 conflict resolved"}`
 	steps := []*db.StepResult{
 		{ID: "s1", StepName: types.StepRebase, Status: types.StepStatusCompleted, FindingsJSON: &findings},

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -3594,7 +3594,20 @@ func TestExecutableCandidatesForOS_WindowsHonorsExplicitEmptyPATHEXT(t *testing.
 func TestStepCmd_ResolvesRelativeCustomPathFromWorkDir(t *testing.T) {
 	t.Parallel()
 
-	workDir := t.TempDir()
+	// Use os.MkdirTemp instead of t.TempDir so we can retry cleanup on
+	// Windows where the executed exe may briefly hold a file lock.
+	workDir, err := os.MkdirTemp("", "stepCmd-relpath")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		for i := 0; i < 10; i++ {
+			if err := os.RemoveAll(workDir); err == nil {
+				return
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
+	})
 	binDir := filepath.Join(workDir, "bin")
 	if err := os.MkdirAll(binDir, 0o755); err != nil {
 		t.Fatal(err)

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -50,6 +50,8 @@ func handleFakeCLI(mode string) {
 		fakeGHHandler(args)
 	case "glab":
 		fakeGlabHandler(args)
+	case "git-passthrough":
+		fakeGitPassthroughHandler(args)
 	case "git-status-error":
 		fakeGitStatusErrorHandler(args)
 	case "ci-gh":
@@ -91,6 +93,15 @@ func fakeGitStatusErrorHandler(args []string) {
 		fmt.Fprintln(os.Stderr, "status failed")
 		os.Exit(1)
 	}
+	fakeGitForward(args, realGit)
+}
+
+func fakeGitPassthroughHandler(args []string) {
+	realGit := os.Getenv("FAKE_CLI_REAL_GIT")
+	fakeGitForward(args, realGit)
+}
+
+func fakeGitForward(args []string, realGit string) {
 	if realGit == "" {
 		fmt.Fprintln(os.Stderr, "missing FAKE_CLI_REAL_GIT")
 		os.Exit(1)
@@ -4378,6 +4389,82 @@ func TestCIStep_CommitAndPush_StatusError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "status failed") {
 		t.Fatalf("expected status stderr in error, got %v", err)
+	}
+}
+
+func TestCIStep_CommitAndPush_UsesStepEnvForAllGitCommands(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+	os.WriteFile(filepath.Join(dir, "fix.txt"), []byte("ci fix"), 0o644)
+
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	binDir := fakeCLIBinDir(t)
+	linkTestBinary(t, binDir, "git")
+	env := fakeCLIEnv(binDir, map[string]string{
+		"FAKE_CLI_MODE":     "git-passthrough",
+		"FAKE_CLI_REAL_GIT": realGit,
+	})
+	t.Setenv("PATH", t.TempDir())
+	realGitCmd := func(dir string, args ...string) string {
+		t.Helper()
+		cmd := exec.Command(realGit, args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test",
+			"GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=test",
+			"GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+
+	step := &CIStep{}
+	pushed, err := step.commitAndPush(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !pushed {
+		t.Fatal("expected commitAndPush to report changes were pushed")
+	}
+
+	upstreamSHA := realGitCmd(upstream, "rev-parse", "refs/heads/feature")
+	if upstreamSHA == headSHA {
+		t.Fatal("expected upstream to receive CI fix commit")
+	}
+	if sctx.Run.HeadSHA != upstreamSHA {
+		t.Fatalf("Run.HeadSHA = %s, want %s", sctx.Run.HeadSHA, upstreamSHA)
 	}
 }
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -4048,6 +4048,40 @@ func TestCIStep_PendingChecksUseAdaptivePollIntervals(t *testing.T) {
 	}
 }
 
+func TestCIStep_UsesStepEnvForCLIStartupChecks(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	hiddenPath := t.TempDir()
+	t.Setenv("PATH", hiddenPath)
+
+	env := fakeCIGH(t, "MERGED", "[]")
+	prURL := "https://github.com/test/repo/pull/42"
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+
+	step := &CIStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Fatal("expected merged PR to exit cleanly")
+	}
+	for _, logLine := range logs {
+		if strings.Contains(logLine, "gh CLI is not installed") || strings.Contains(logLine, "gh CLI is not authenticated") {
+			t.Fatalf("expected startup checks to use StepContext env, got logs: %v", logs)
+		}
+	}
+	if len(logs) == 0 || !strings.Contains(logs[len(logs)-1], "PR has been merged") {
+		t.Fatalf("expected CI monitoring to reach PR state check, got logs: %v", logs)
+	}
+}
+
 func TestCIStep_NoPRURL(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -3559,6 +3559,26 @@ func TestPathCandidateUsable_WindowsAcceptsExeWithoutExecBits(t *testing.T) {
 	}
 }
 
+func TestEnvValueForOS_WindowsMatchesEmptyMixedCaseOverride(t *testing.T) {
+	t.Parallel()
+
+	value, ok := envValueForOS([]string{"Path=", "PathExt="}, "PATH", "windows")
+	if !ok {
+		t.Fatal("expected empty mixed-case PATH override to be present")
+	}
+	if value != "" {
+		t.Fatalf("expected empty PATH override, got %q", value)
+	}
+
+	value, ok = envValueForOS([]string{"Path=", "PathExt="}, "PATHEXT", "windows")
+	if !ok {
+		t.Fatal("expected empty mixed-case PATHEXT override to be present")
+	}
+	if value != "" {
+		t.Fatalf("expected empty PATHEXT override, got %q", value)
+	}
+}
+
 func TestStepCmd_DoesNotFallbackToHostPathWhenCustomPathOmitsBinary(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -3541,6 +3541,24 @@ func TestStepCLIAvailable_IgnoresNonExecutableFromCustomPath(t *testing.T) {
 	}
 }
 
+func TestPathCandidateUsable_WindowsAcceptsExeWithoutExecBits(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "gh.exe")
+	if err := os.WriteFile(path, []byte("stub"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !pathCandidateUsable("windows", path, info) {
+		t.Fatal("expected .exe without exec bits to be usable on windows")
+	}
+}
+
 func TestStepCmd_DoesNotFallbackToHostPathWhenCustomPathOmitsBinary(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -4520,6 +4520,69 @@ func TestCIStep_CommitAndPush_NoChanges_ReconcilesStaleDatabaseHeadSHA(t *testin
 	}
 }
 
+func TestCIStep_CommitAndPush_NoChanges_ReconcilesStaleDatabaseHeadSHA_UsesStepEnv(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	actualHeadSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	binDir := fakeCLIBinDir(t)
+	linkTestBinary(t, binDir, "git")
+	env := fakeCLIEnv(binDir, map[string]string{
+		"FAKE_CLI_MODE":     "git-passthrough",
+		"FAKE_CLI_REAL_GIT": realGit,
+	})
+	t.Setenv("PATH", t.TempDir())
+
+	staleHeadSHA := baseSHA
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, staleHeadSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+
+	step := &CIStep{}
+	pushed, err := step.commitAndPush(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pushed {
+		t.Error("expected commitAndPush to report no changes pushed for stale reconcile")
+	}
+
+	if sctx.Run.HeadSHA != actualHeadSHA {
+		t.Errorf("Run.HeadSHA = %s, want %s", sctx.Run.HeadSHA, actualHeadSHA)
+	}
+	dbRun, err := sctx.DB.GetRun(sctx.Run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dbRun.HeadSHA != actualHeadSHA {
+		t.Errorf("DB HeadSHA = %s, want %s", dbRun.HeadSHA, actualHeadSHA)
+	}
+}
+
 func TestCIStep_CommitAndPush_UpdatesLocalBranchRefAfterDetachedPush(t *testing.T) {
 	t.Parallel()
 	upstream := t.TempDir()

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -3513,6 +3513,34 @@ func TestStepCLIAvailable_ResolvesExecutableSuffixFromCustomPath(t *testing.T) {
 	}
 }
 
+func TestStepCLIAvailable_IgnoresNonExecutableFromCustomPath(t *testing.T) {
+	t.Parallel()
+
+	binDir := t.TempDir()
+	shimPath := filepath.Join(binDir, "gh")
+	if err := os.WriteFile(shimPath, []byte("#!/bin/sh\nexit 0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	sctx := &pipeline.StepContext{
+		Ctx:     context.Background(),
+		WorkDir: t.TempDir(),
+		Env:     []string{"PATH=" + binDir},
+	}
+
+	if stepCLIAvailable(sctx, scm.ProviderGitHub) {
+		t.Fatal("expected non-executable gh to be unavailable from custom PATH")
+	}
+
+	cmd := stepCmd(sctx, "gh", "auth", "status")
+	if cmd.Path != shimPath {
+		t.Fatalf("expected missing custom-path lookup to stay inside %q, got %q", binDir, cmd.Path)
+	}
+	if err := cmd.Run(); err == nil {
+		t.Fatal("expected non-executable gh to fail to run")
+	}
+}
+
 func TestStepCmd_DoesNotFallbackToHostPathWhenCustomPathOmitsBinary(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -267,31 +268,74 @@ func lastCommitMessage(t *testing.T, dir string) string {
 	return gitCmd(t, dir, "log", "-1", "--pretty=%s")
 }
 
+// gitRepoTemplate holds a cached template repo that setupGitRepo copies from
+// instead of running git init + config + commits each time.
+var gitRepoTemplate struct {
+	once    sync.Once
+	dir     string
+	baseSHA string
+	headSHA string
+}
+
+func ensureGitRepoTemplate(t *testing.T) {
+	t.Helper()
+	gitRepoTemplate.once.Do(func() {
+		dir, err := os.MkdirTemp("", "git-template-*")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		run := func(args ...string) string {
+			cmd := exec.Command("git", args...)
+			cmd.Dir = dir
+			cmd.Env = append(os.Environ(),
+				"GIT_AUTHOR_NAME=test",
+				"GIT_AUTHOR_EMAIL=test@test.com",
+				"GIT_COMMITTER_NAME=test",
+				"GIT_COMMITTER_EMAIL=test@test.com",
+			)
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				panic(fmt.Sprintf("git %v: %v: %s", args, err, out))
+			}
+			return strings.TrimSpace(string(out))
+		}
+
+		run("init")
+		run("config", "user.name", "test")
+		run("config", "user.email", "test@test.com")
+		run("checkout", "-b", "main")
+
+		os.WriteFile(filepath.Join(dir, "base.txt"), []byte("base content"), 0o644)
+		run("add", "-A")
+		run("commit", "-m", "base commit")
+		gitRepoTemplate.baseSHA = run("rev-parse", "HEAD")
+
+		run("checkout", "-b", "feature")
+		os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature code\n"), 0o644)
+		run("add", "-A")
+		run("commit", "-m", "add feature")
+		gitRepoTemplate.headSHA = run("rev-parse", "HEAD")
+
+		gitRepoTemplate.dir = dir
+	})
+}
+
 // setupGitRepo creates a git repo with a base commit on main and a head commit on feature.
 // Returns (repoDir, baseSHA, headSHA).
+// Uses a cached template repo and copies it via cp -a for speed.
 func setupGitRepo(t *testing.T) (string, string, string) {
 	t.Helper()
+	ensureGitRepoTemplate(t)
+
 	dir := t.TempDir()
+	// Copy template contents into the new dir
+	cmd := exec.Command("cp", "-a", gitRepoTemplate.dir+"/.", dir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("cp template repo: %v: %s", err, out)
+	}
 
-	gitCmd(t, dir, "init")
-	gitCmd(t, dir, "config", "user.name", "test")
-	gitCmd(t, dir, "config", "user.email", "test@test.com")
-	gitCmd(t, dir, "checkout", "-b", "main")
-
-	// Base commit
-	os.WriteFile(filepath.Join(dir, "base.txt"), []byte("base content"), 0o644)
-	gitCmd(t, dir, "add", "-A")
-	gitCmd(t, dir, "commit", "-m", "base commit")
-	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
-
-	// Feature branch with changes
-	gitCmd(t, dir, "checkout", "-b", "feature")
-	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature code\n"), 0o644)
-	gitCmd(t, dir, "add", "-A")
-	gitCmd(t, dir, "commit", "-m", "add feature")
-	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
-
-	return dir, baseSHA, headSHA
+	return dir, gitRepoTemplate.baseSHA, gitRepoTemplate.headSHA
 }
 
 // newTestContext creates a StepContext for testing with optional config overrides.
@@ -321,6 +365,7 @@ func newTestContext(t *testing.T, ag agent.Agent, workDir, baseSHA, headSHA stri
 // --- common tests ---
 
 func TestResolveBaseSHA_NonZero(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	got := resolveBaseSHA(context.Background(), dir, "abc123", "main")
 	if got != "abc123" {
@@ -329,6 +374,7 @@ func TestResolveBaseSHA_NonZero(t *testing.T) {
 }
 
 func TestResolveBaseSHA_ZeroWithMergeBase(t *testing.T) {
+	t.Parallel()
 	// Create a repo with main branch and feature branch diverging
 	dir := t.TempDir()
 	gitCmd(t, dir, "init")
@@ -353,6 +399,7 @@ func TestResolveBaseSHA_ZeroWithMergeBase(t *testing.T) {
 }
 
 func TestResolveBaseSHA_ZeroNoDefaultBranch(t *testing.T) {
+	t.Parallel()
 	// Repo with no "main" branch — should fall back to empty tree SHA
 	dir := t.TempDir()
 	gitCmd(t, dir, "init")
@@ -371,6 +418,7 @@ func TestResolveBaseSHA_ZeroNoDefaultBranch(t *testing.T) {
 }
 
 func TestRunShellCommand(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 
 	t.Run("success", func(t *testing.T) {
@@ -398,6 +446,7 @@ func TestRunShellCommand(t *testing.T) {
 }
 
 func TestAllSteps(t *testing.T) {
+	t.Parallel()
 	steps := AllSteps()
 	if len(steps) != 8 {
 		t.Fatalf("AllSteps() returned %d steps, want 8", len(steps))
@@ -411,6 +460,7 @@ func TestAllSteps(t *testing.T) {
 }
 
 func TestRebaseStep_RebasesOntoDefaultBranch(t *testing.T) {
+	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -470,6 +520,7 @@ func TestRebaseStep_RebasesOntoDefaultBranch(t *testing.T) {
 }
 
 func TestRebaseStep_ConflictReturnsFindings(t *testing.T) {
+	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -534,6 +585,7 @@ func TestRebaseStep_ConflictReturnsFindings(t *testing.T) {
 }
 
 func TestRebaseStep_ConflictTriesAllTargets(t *testing.T) {
+	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -611,6 +663,7 @@ func TestRebaseStep_ConflictTriesAllTargets(t *testing.T) {
 }
 
 func TestRebaseStep_ConflictFindingsIncludeFiles(t *testing.T) {
+	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -669,6 +722,7 @@ func TestRebaseStep_ConflictFindingsIncludeFiles(t *testing.T) {
 }
 
 func TestRebaseStep_FixModeCallsAgent(t *testing.T) {
+	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -760,6 +814,7 @@ func TestRebaseStep_FixModeCallsAgent(t *testing.T) {
 }
 
 func TestRebaseStep_FixModeNonConflictFailureReturnsError(t *testing.T) {
+	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -809,6 +864,7 @@ func TestRebaseStep_FixModeNonConflictFailureReturnsError(t *testing.T) {
 }
 
 func TestRebaseStep_NonConflictFailureWithRebaseMetadataReturnsError(t *testing.T) {
+	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -865,6 +921,7 @@ func TestRebaseStep_NonConflictFailureWithRebaseMetadataReturnsError(t *testing.
 }
 
 func TestRebaseStep_LogFileNotVisibleToUser(t *testing.T) {
+	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -921,6 +978,7 @@ func TestRebaseStep_LogFileNotVisibleToUser(t *testing.T) {
 }
 
 func TestRebaseStep_EmptyDiffAfterRebase_SkipsRemaining(t *testing.T) {
+	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -965,6 +1023,7 @@ func TestRebaseStep_EmptyDiffAfterRebase_SkipsRemaining(t *testing.T) {
 }
 
 func TestRebaseStep_NonEmptyDiffAfterRebase_DoesNotSkip(t *testing.T) {
+	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -1011,6 +1070,7 @@ func TestRebaseStep_NonEmptyDiffAfterRebase_DoesNotSkip(t *testing.T) {
 }
 
 func TestRebaseStep_ForcePushSkipsOriginBranch(t *testing.T) {
+	t.Parallel()
 	// Simulate the scenario that caused the bug: user force-pushes a commit,
 	// but origin/<branch> on the upstream remote has autofix commits from a
 	// prior pipeline run. The rebase step should skip origin/<branch> entirely
@@ -1088,6 +1148,7 @@ func TestRebaseStep_ForcePushSkipsOriginBranch(t *testing.T) {
 }
 
 func TestRebaseStep_ForcePushOnDefaultBranchSkipsRemoteSync(t *testing.T) {
+	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -1145,6 +1206,7 @@ func TestRebaseStep_ForcePushOnDefaultBranchSkipsRemoteSync(t *testing.T) {
 }
 
 func TestRebaseStep_ForcePushOnDefaultBranchAllowsRewrittenRemoteHead(t *testing.T) {
+	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -1201,6 +1263,7 @@ func TestRebaseStep_ForcePushOnDefaultBranchAllowsRewrittenRemoteHead(t *testing
 }
 
 func TestRebaseStep_ForcePushOnDefaultBranchStopsWhenRemoteAdvanced(t *testing.T) {
+	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -1262,6 +1325,7 @@ func TestRebaseStep_ForcePushOnDefaultBranchStopsWhenRemoteAdvanced(t *testing.T
 }
 
 func TestRebaseStep_NormalPushSyncsOriginBranch(t *testing.T) {
+	t.Parallel()
 	// Verify that a normal (non-force) push still syncs with origin/<branch>.
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
@@ -1317,6 +1381,7 @@ func TestRebaseStep_NormalPushSyncsOriginBranch(t *testing.T) {
 }
 
 func TestIsForcePush_IgnoresMergeBaseLookupErrors(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	gitCmd(t, dir, "init")
 	gitCmd(t, dir, "config", "user.name", "test")
@@ -1332,6 +1397,7 @@ func TestIsForcePush_IgnoresMergeBaseLookupErrors(t *testing.T) {
 }
 
 func TestIsForcePush_RerunAfterNormalRebaseIsNotForcePush(t *testing.T) {
+	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -1371,6 +1437,7 @@ func TestIsForcePush_RerunAfterNormalRebaseIsNotForcePush(t *testing.T) {
 }
 
 func TestIsForcePush_RerunWithoutLocalRemoteRefIsNotForcePush(t *testing.T) {
+	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -1419,6 +1486,7 @@ func TestIsForcePush_RerunWithoutLocalRemoteRefIsNotForcePush(t *testing.T) {
 }
 
 func TestIsForcePush_StaleLocalRemoteRefUsesAuthoritativeRemoteTip(t *testing.T) {
+	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -1468,6 +1536,7 @@ func TestIsForcePush_StaleLocalRemoteRefUsesAuthoritativeRemoteTip(t *testing.T)
 }
 
 func TestIsForcePush_LsRemoteFailureIsNotForcePush(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	gitCmd(t, dir, "init")
 	gitCmd(t, dir, "config", "user.name", "test")
@@ -1491,6 +1560,7 @@ func TestIsForcePush_LsRemoteFailureIsNotForcePush(t *testing.T) {
 }
 
 func TestIsForcePush_MissingRemoteObjectIsNotForcePush(t *testing.T) {
+	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -1534,6 +1604,7 @@ func TestIsForcePush_MissingRemoteObjectIsNotForcePush(t *testing.T) {
 // --- Review step tests ---
 
 func TestReviewStep_EmptyDiff(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	gitCmd(t, dir, "init")
 	gitCmd(t, dir, "config", "user.name", "test")
@@ -1562,6 +1633,7 @@ func TestReviewStep_EmptyDiff(t *testing.T) {
 }
 
 func TestReviewStep_WithWarnings(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	findings := Findings{
@@ -1610,6 +1682,7 @@ func TestReviewStep_WithWarnings(t *testing.T) {
 }
 
 func TestReviewStep_Clean(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	findings := Findings{
@@ -1637,6 +1710,7 @@ func TestReviewStep_Clean(t *testing.T) {
 }
 
 func TestReviewStep_AgentError(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	ag := &mockAgent{
@@ -1658,6 +1732,7 @@ func TestReviewStep_AgentError(t *testing.T) {
 }
 
 func TestReviewStep_ZeroBaseSHA(t *testing.T) {
+	t.Parallel()
 	// New branch scenario: baseSHA is all-zeros
 	dir := t.TempDir()
 	gitCmd(t, dir, "init")
@@ -1710,6 +1785,7 @@ func TestReviewStep_ZeroBaseSHA(t *testing.T) {
 }
 
 func TestReviewStep_ExistingBranchUsesMergeBaseScope(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	gitCmd(t, dir, "init")
 	gitCmd(t, dir, "config", "user.name", "test")
@@ -1756,6 +1832,7 @@ func TestReviewStep_ExistingBranchUsesMergeBaseScope(t *testing.T) {
 }
 
 func TestReviewStep_FixMode(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 	gitCmd(t, dir, "checkout", "--detach", headSHA)
 
@@ -1843,6 +1920,7 @@ func TestReviewStep_FixMode(t *testing.T) {
 // --- Test step tests ---
 
 func TestTestStep_PassingCommand(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, "abc", "def", config.Commands{Test: "true"})
@@ -1861,6 +1939,7 @@ func TestTestStep_PassingCommand(t *testing.T) {
 }
 
 func TestTestStep_FailingCommand(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, "abc", "def", config.Commands{Test: "exit 1"})
@@ -1888,6 +1967,7 @@ func TestTestStep_FailingCommand(t *testing.T) {
 }
 
 func TestTestStep_NoCommand_AgentDetects(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 
 	findings := Findings{Items: nil, Summary: "all tests passed"}
@@ -1918,6 +1998,7 @@ func TestTestStep_NoCommand_AgentDetects(t *testing.T) {
 }
 
 func TestTestStep_NoCommand_MalformedAgentOutput(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 
 	ag := &mockAgent{
@@ -1946,6 +2027,7 @@ func TestTestStep_NoCommand_MalformedAgentOutput(t *testing.T) {
 }
 
 func TestLintStep_NoCommand_MalformedAgentOutput(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 
 	ag := &mockAgent{
@@ -1974,6 +2056,7 @@ func TestLintStep_NoCommand_MalformedAgentOutput(t *testing.T) {
 }
 
 func TestTestStep_FixMode(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 	gitCmd(t, dir, "checkout", "--detach", headSHA)
 	previousFindings := `{"items":[{"id":"test-1 =======","severity":"error","file":"internal/pipeline/steps/test.go >>>>>>> prompt","description":"tests failed with exit code 1 <<<<<<< HEAD"}],"summary":"FAIL: TestFoo expected 42 got 0 ======="}`
@@ -2026,6 +2109,7 @@ func TestTestStep_FixMode(t *testing.T) {
 }
 
 func TestLintStep_FixMode_CommitsChanges(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 	gitCmd(t, dir, "checkout", "--detach", headSHA)
 	previousFindings := `{"items":[{"id":"lint-1 =======","severity":"warning","file":"internal/pipeline/steps/lint.go >>>>>>> prompt","description":"linter found issues (exit code 1) <<<<<<< HEAD"}],"summary":"main.go:10: unused variable x ======="}`
@@ -2079,6 +2163,7 @@ func TestLintStep_FixMode_CommitsChanges(t *testing.T) {
 }
 
 func TestLintStep_FixMode_UsesFallbackSummaryWhenStructuredSummaryMalformed(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 	gitCmd(t, dir, "checkout", "--detach", headSHA)
 
@@ -2106,6 +2191,7 @@ func TestLintStep_FixMode_UsesFallbackSummaryWhenStructuredSummaryMalformed(t *t
 // --- Lint step tests ---
 
 func TestLintStep_PassingCommand(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, "abc", "def", config.Commands{Lint: "true"})
@@ -2121,6 +2207,7 @@ func TestLintStep_PassingCommand(t *testing.T) {
 }
 
 func TestLintStep_FailingCommand(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	ag := &mockAgent{name: "test"}
 	lintCmd := "echo 'lint error'; exit 1"
@@ -2149,6 +2236,7 @@ func TestLintStep_FailingCommand(t *testing.T) {
 }
 
 func TestLintStep_NoCommand(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 
 	findings := Findings{Items: nil, Summary: "no lint issues"}
@@ -2181,6 +2269,7 @@ func TestLintStep_NoCommand(t *testing.T) {
 // --- Document step tests ---
 
 func TestDocumentStep_EmptyDiff(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	gitCmd(t, dir, "init")
 	gitCmd(t, dir, "config", "user.name", "test")
@@ -2208,6 +2297,7 @@ func TestDocumentStep_EmptyDiff(t *testing.T) {
 }
 
 func TestDocumentStep_Updated(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	ag := &mockAgent{
@@ -2260,6 +2350,7 @@ func TestDocumentStep_Updated(t *testing.T) {
 }
 
 func TestDocumentStep_Skipped(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	ag := &mockAgent{
@@ -2284,6 +2375,7 @@ func TestDocumentStep_Skipped(t *testing.T) {
 }
 
 func TestDocumentStep_InfoFindingStillRequiresApproval(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	ag := &mockAgent{
@@ -2308,6 +2400,7 @@ func TestDocumentStep_InfoFindingStillRequiresApproval(t *testing.T) {
 }
 
 func TestDocumentStep_AgentError(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	ag := &mockAgent{
@@ -2329,6 +2422,7 @@ func TestDocumentStep_AgentError(t *testing.T) {
 }
 
 func TestDocumentStep_MalformedOutput(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	ag := &mockAgent{
@@ -2366,6 +2460,7 @@ func TestDocumentStep_MalformedOutput(t *testing.T) {
 }
 
 func TestDocumentStep_NoStructuredOutputRequiresApproval(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	ag := &mockAgent{
@@ -2400,6 +2495,7 @@ func TestDocumentStep_NoStructuredOutputRequiresApproval(t *testing.T) {
 }
 
 func TestDocumentStep_MissingFindingsFieldRequiresApproval(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	ag := &mockAgent{
@@ -2444,6 +2540,7 @@ func TestDocumentStep_MissingFindingsFieldRequiresApproval(t *testing.T) {
 }
 
 func TestDocumentStep_MalformedFindingRequiresApproval(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	ag := &mockAgent{
@@ -2484,6 +2581,7 @@ func TestDocumentStep_MalformedFindingRequiresApproval(t *testing.T) {
 }
 
 func TestDocumentStep_LegacyFindingsStayAutoFixable(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	ag := &mockAgent{
@@ -2521,6 +2619,7 @@ func TestDocumentStep_LegacyFindingsStayAutoFixable(t *testing.T) {
 }
 
 func TestDocumentStep_MissingSummaryRequiresApproval(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	ag := &mockAgent{
@@ -2561,6 +2660,7 @@ func TestDocumentStep_MissingSummaryRequiresApproval(t *testing.T) {
 }
 
 func TestDocumentStep_PromptIncludesIgnorePatterns(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	ag := &mockAgent{
@@ -2586,6 +2686,7 @@ func TestDocumentStep_PromptIncludesIgnorePatterns(t *testing.T) {
 }
 
 func TestDocumentStep_IgnorePatternsFilterAllFiles(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 
 	gitCmd(t, dir, "init")
@@ -2621,6 +2722,7 @@ func TestDocumentStep_IgnorePatternsFilterAllFiles(t *testing.T) {
 }
 
 func TestDocumentStep_FixMode_CommitsAndReassesses(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 	gitCmd(t, dir, "checkout", "--detach", headSHA)
 
@@ -2666,6 +2768,7 @@ func TestDocumentStep_FixMode_CommitsAndReassesses(t *testing.T) {
 }
 
 func TestDocumentStep_FixMode_StillNeedsWorkAfterFix(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 	gitCmd(t, dir, "checkout", "--detach", headSHA)
 
@@ -2711,6 +2814,7 @@ func TestDocumentStep_FixMode_StillNeedsWorkAfterFix(t *testing.T) {
 }
 
 func TestDocumentStep_FixMode_NoChangesStillReassesses(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 	gitCmd(t, dir, "checkout", "--detach", headSHA)
 
@@ -2745,6 +2849,7 @@ func TestDocumentStep_FixMode_NoChangesStillReassesses(t *testing.T) {
 }
 
 func TestDocumentStep_FixMode_RequiresPreviousFindings(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	ag := &mockAgent{name: "test"}
@@ -2764,6 +2869,7 @@ func TestDocumentStep_FixMode_RequiresPreviousFindings(t *testing.T) {
 // --- Push step tests ---
 
 func TestPushStep_Success(t *testing.T) {
+	t.Parallel()
 	// Set up a bare repo as "upstream"
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
@@ -2809,6 +2915,7 @@ func TestPushStep_Success(t *testing.T) {
 }
 
 func TestPushStep_CommitsUncommittedChanges(t *testing.T) {
+	t.Parallel()
 	// Set up upstream
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
@@ -2858,6 +2965,7 @@ func TestPushStep_CommitsUncommittedChanges(t *testing.T) {
 }
 
 func TestPushStep_ShortBranch(t *testing.T) {
+	t.Parallel()
 	// Set up upstream
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
@@ -2899,6 +3007,7 @@ func TestPushStep_ShortBranch(t *testing.T) {
 }
 
 func TestPushStep_NewBranchSkipsForceWithLease(t *testing.T) {
+	t.Parallel()
 	// When the branch doesn't exist on upstream yet, push should use regular push
 	// (not force-with-lease, which isn't needed for new branches).
 	upstream := t.TempDir()
@@ -2945,6 +3054,7 @@ func TestPushStep_NewBranchSkipsForceWithLease(t *testing.T) {
 }
 
 func TestPushStep_ForceWithLeaseUsesExplicitSHA(t *testing.T) {
+	t.Parallel()
 	// When the branch already exists on upstream, push should use --force-with-lease
 	// with the explicit upstream SHA (queried via ls-remote), not the bare form.
 	upstream := t.TempDir()
@@ -2996,6 +3106,7 @@ func TestPushStep_ForceWithLeaseUsesExplicitSHA(t *testing.T) {
 }
 
 func TestPushStep_RunsFormatCommandBeforeCommit(t *testing.T) {
+	t.Parallel()
 	// When a format command is configured, the push step should run it
 	// before committing, so agent changes are formatted before push.
 	upstream := t.TempDir()
@@ -3053,6 +3164,7 @@ func TestPushStep_RunsFormatCommandBeforeCommit(t *testing.T) {
 }
 
 func TestPushStep_UpdatesLocalBranchRefAfterDetachedPush(t *testing.T) {
+	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -3099,6 +3211,7 @@ func TestPushStep_UpdatesLocalBranchRefAfterDetachedPush(t *testing.T) {
 }
 
 func TestPushStep_SkipsFormatWhenNotConfigured(t *testing.T) {
+	t.Parallel()
 	// When no format command is configured, push step should not fail.
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
@@ -3133,6 +3246,7 @@ func TestPushStep_SkipsFormatWhenNotConfigured(t *testing.T) {
 }
 
 func TestPushStep_FormatCommandFailureIsWarning(t *testing.T) {
+	t.Parallel()
 	// If the format command fails, push should still proceed (log warning, don't fail).
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
@@ -3181,6 +3295,7 @@ func TestPushStep_FormatCommandFailureIsWarning(t *testing.T) {
 }
 
 func TestPushStep_ReconcilesStaleDatabaseHeadSHA(t *testing.T) {
+	t.Parallel()
 	// When push retries after a prior UpdateRunHeadSHA failure, there are no
 	// uncommitted changes. The step must still reconcile the DB if HeadSHA is stale.
 	upstream := t.TempDir()
@@ -3235,6 +3350,7 @@ func TestPushStep_ReconcilesStaleDatabaseHeadSHA(t *testing.T) {
 // --- PR step tests ---
 
 func TestPRStep_GhNotAvailable(t *testing.T) {
+	t.Parallel()
 	// Verify the step skips gracefully when the required provider CLI is missing.
 	if _, err := exec.LookPath("gh"); err == nil {
 		// gh is available on this machine, so we can't force the missing-CLI path here.
@@ -3255,10 +3371,16 @@ func TestPRStep_GhNotAvailable(t *testing.T) {
 	}
 }
 
-// prependPATH prepends binDir to PATH using the platform-specific separator.
-func prependPATH(t *testing.T, binDir string) {
-	t.Helper()
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+// fakeCLIEnv builds environment variable entries for a fake CLI binary and PATH override.
+// Returns env entries that should be set on StepContext.Env for parallel-safe tests.
+func fakeCLIEnv(binDir string, vars map[string]string) []string {
+	env := []string{
+		"PATH=" + binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+	}
+	for k, v := range vars {
+		env = append(env, k+"="+v)
+	}
+	return env
 }
 
 // fakeCLIBinDir creates a temporary directory for fake CLI binaries.
@@ -3305,27 +3427,30 @@ func linkTestBinary(t *testing.T, binDir, name string) {
 	}
 }
 
-// fakeGH creates a mock gh binary in a temp dir and returns the dir (for PATH prepending).
+// fakeGH creates a mock gh binary in a temp dir and returns env entries for StepContext.Env.
 // The binary records all invocations to a log file and responds based on subcommand.
-func fakeGH(t *testing.T, prViewURL string) (binDir string, logFile string) {
+func fakeGH(t *testing.T, prViewURL string) (env []string, logFile string) {
 	t.Helper()
-	binDir = fakeCLIBinDir(t)
+	binDir := fakeCLIBinDir(t)
 	logFile = filepath.Join(t.TempDir(), "gh.log")
 	linkTestBinary(t, binDir, "gh")
-	t.Setenv("FAKE_CLI_MODE", "gh")
-	t.Setenv("FAKE_CLI_LOG", logFile)
-	t.Setenv("FAKE_CLI_PR_URL", prViewURL)
-	return binDir, logFile
+	env = fakeCLIEnv(binDir, map[string]string{
+		"FAKE_CLI_MODE":   "gh",
+		"FAKE_CLI_LOG":    logFile,
+		"FAKE_CLI_PR_URL": prViewURL,
+	})
+	return env, logFile
 }
 
 func TestPRStep_UpdatesExistingPR(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
-	binDir, logFile := fakeGH(t, "https://github.com/test/repo/pull/42")
-	prependPATH(t, binDir)
+	env, logFile := fakeGH(t, "https://github.com/test/repo/pull/42")
 
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 
 	step := &PRStep{}
 	outcome, err := step.Execute(sctx)
@@ -3360,6 +3485,7 @@ func TestPRStep_UpdatesExistingPR(t *testing.T) {
 }
 
 func TestPRStep_ZeroBaseSHA(t *testing.T) {
+	t.Parallel()
 	// New branch scenario: baseSHA is all-zeros, commit log should still work
 	dir := t.TempDir()
 	gitCmd(t, dir, "init")
@@ -3376,12 +3502,12 @@ func TestPRStep_ZeroBaseSHA(t *testing.T) {
 	gitCmd(t, dir, "commit", "-m", "add feature")
 	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
 
-	binDir, logFile := fakeGH(t, "")
-	prependPATH(t, binDir)
+	env, logFile := fakeGH(t, "")
 
 	ag := &mockAgent{name: "test"}
 	zeroSHA := "0000000000000000000000000000000000000000"
 	sctx := newTestContextWithDBRecords(t, ag, dir, zeroSHA, headSHA, config.Commands{})
+	sctx.Env = env
 
 	step := &PRStep{}
 	outcome, err := step.Execute(sctx)
@@ -3400,15 +3526,16 @@ func TestPRStep_ZeroBaseSHA(t *testing.T) {
 }
 
 func TestPRStep_CreatesNewPR(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	// No existing PR - pr view returns exit 1
-	binDir, logFile := fakeGH(t, "")
-	prependPATH(t, binDir)
+	env, logFile := fakeGH(t, "")
 
 	findings := `{"findings":[],"summary":"clean","risk_level":"medium","risk_rationale":"touches critical error handling"}`
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 	reviewStep, err := sctx.DB.InsertStepResult(sctx.Run.ID, types.StepReview)
 	if err != nil {
 		t.Fatal(err)
@@ -3459,10 +3586,10 @@ func TestPRStep_CreatesNewPR(t *testing.T) {
 }
 
 func TestPRStep_UsesAgentGeneratedTitleAndBody(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
-	binDir, logFile := fakeGH(t, "")
-	prependPATH(t, binDir)
+	env, logFile := fakeGH(t, "")
 
 	findings := `{"findings":[],"summary":"clean","risk_level":"medium","risk_rationale":"touches critical error handling"}`
 
@@ -3474,6 +3601,7 @@ func TestPRStep_UsesAgentGeneratedTitleAndBody(t *testing.T) {
 		},
 	}
 	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 	reviewStep, err := sctx.DB.InsertStepResult(sctx.Run.ID, types.StepReview)
 	if err != nil {
 		t.Fatal(err)
@@ -3513,10 +3641,10 @@ func TestPRStep_UsesAgentGeneratedTitleAndBody(t *testing.T) {
 }
 
 func TestPRStep_AppendsTestingSectionFromTestStep(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
-	binDir, logFile := fakeGH(t, "")
-	prependPATH(t, binDir)
+	env, logFile := fakeGH(t, "")
 
 	reviewFindings := `{"findings":[],"summary":"clean","risk_level":"medium","risk_rationale":"touches critical error handling"}`
 	testRound1 := `{"findings":[{"id":"test-1","severity":"error","file":"pkg/handler_test.go","line":42,"description":"expected 429 got 200"}],"summary":"1 failure"}`
@@ -3529,6 +3657,7 @@ func TestPRStep_AppendsTestingSectionFromTestStep(t *testing.T) {
 		},
 	}
 	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 
 	reviewStep, err := sctx.DB.InsertStepResult(sctx.Run.ID, types.StepReview)
 	if err != nil {
@@ -3576,10 +3705,10 @@ func TestPRStep_AppendsTestingSectionFromTestStep(t *testing.T) {
 }
 
 func TestPRStep_UnwrapsNestedJSONBody(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
-	binDir, logFile := fakeGH(t, "")
-	prependPATH(t, binDir)
+	env, logFile := fakeGH(t, "")
 
 	// Agent returns body as the serialized prContent JSON (the bug LLMs sometimes produce).
 	ag := &mockAgent{
@@ -3590,6 +3719,7 @@ func TestPRStep_UnwrapsNestedJSONBody(t *testing.T) {
 		},
 	}
 	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 
 	step := &PRStep{}
 	if _, err := step.Execute(sctx); err != nil {
@@ -3612,6 +3742,7 @@ func TestPRStep_UnwrapsNestedJSONBody(t *testing.T) {
 }
 
 func TestUnwrapNestedPRBody(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		body string
@@ -3682,22 +3813,24 @@ func TestAppendGeneratedSections_StripsCommonHeadingVariants(t *testing.T) {
 	}
 }
 
-func fakeGlab(t *testing.T, mrViewJSON string) (binDir string, logFile string) {
+func fakeGlab(t *testing.T, mrViewJSON string) (env []string, logFile string) {
 	t.Helper()
-	binDir = fakeCLIBinDir(t)
+	binDir := fakeCLIBinDir(t)
 	logFile = filepath.Join(t.TempDir(), "glab.log")
 	linkTestBinary(t, binDir, "glab")
-	t.Setenv("FAKE_CLI_MODE", "glab")
-	t.Setenv("FAKE_CLI_LOG", logFile)
-	t.Setenv("FAKE_CLI_MR_VIEW_JSON", mrViewJSON)
-	return binDir, logFile
+	env = fakeCLIEnv(binDir, map[string]string{
+		"FAKE_CLI_MODE":         "glab",
+		"FAKE_CLI_LOG":          logFile,
+		"FAKE_CLI_MR_VIEW_JSON": mrViewJSON,
+	})
+	return env, logFile
 }
 
 func TestPRStep_GitLabCreatesNewMR(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
-	binDir, logFile := fakeGlab(t, "")
-	prependPATH(t, binDir)
+	env, logFile := fakeGlab(t, "")
 
 	ag := &mockAgent{
 		name: "test",
@@ -3707,6 +3840,7 @@ func TestPRStep_GitLabCreatesNewMR(t *testing.T) {
 		},
 	}
 	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 	sctx.Repo.UpstreamURL = "https://gitlab.com/test/repo.git"
 
 	step := &PRStep{}
@@ -3727,6 +3861,7 @@ func TestPRStep_GitLabCreatesNewMR(t *testing.T) {
 }
 
 func TestPRStep_SkipsWhenProviderCLIUnavailable(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
@@ -3750,6 +3885,7 @@ func TestPRStep_SkipsWhenProviderCLIUnavailable(t *testing.T) {
 }
 
 func TestPRStep_ExistingBranchUsesMergeBaseCommitLog(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	gitCmd(t, dir, "init")
 	gitCmd(t, dir, "config", "user.name", "test")
@@ -3770,11 +3906,11 @@ func TestPRStep_ExistingBranchUsesMergeBaseCommitLog(t *testing.T) {
 	gitCmd(t, dir, "commit", "-m", "second feature commit")
 	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
 
-	binDir, logFile := fakeGH(t, "")
-	prependPATH(t, binDir)
+	env, logFile := fakeGH(t, "")
 
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContextWithDBRecords(t, ag, dir, oldRemoteSHA, headSHA, config.Commands{})
+	sctx.Env = env
 
 	step := &PRStep{}
 	if _, err := step.Execute(sctx); err != nil {
@@ -3815,6 +3951,7 @@ func newTestContextWithDBRecords(t *testing.T, ag agent.Agent, workDir, baseSHA,
 }
 
 func TestCommitAgentFixes_NoChanges(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 	gitCmd(t, dir, "checkout", "--detach", headSHA)
 
@@ -3832,6 +3969,7 @@ func TestCommitAgentFixes_NoChanges(t *testing.T) {
 }
 
 func TestCommitAgentFixes_UsesFallbackSummary(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 	gitCmd(t, dir, "checkout", "--detach", headSHA)
 
@@ -3851,6 +3989,7 @@ func TestCommitAgentFixes_UsesFallbackSummary(t *testing.T) {
 // --- CI step tests ---
 
 func TestCIStep_PendingChecksUseAdaptivePollIntervals(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	checksSequence := []string{
@@ -3859,12 +3998,12 @@ func TestCIStep_PendingChecksUseAdaptivePollIntervals(t *testing.T) {
 		`[{"name":"build","state":"PENDING","bucket":"pending"}]`,
 		`[{"name":"build","state":"SUCCESS","bucket":"pass"}]`,
 	}
-	binDir := fakeCIGHSequence(t, "OPEN", checksSequence)
-	prependPATH(t, binDir)
+	env := fakeCIGHSequence(t, "OPEN", checksSequence)
 
 	prURL := "https://github.com/test/repo/pull/42"
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 	sctx.Run.PRURL = &prURL
 	sctx.Config.CITimeout = 20 * time.Minute
 
@@ -3910,6 +4049,7 @@ func TestCIStep_PendingChecksUseAdaptivePollIntervals(t *testing.T) {
 }
 
 func TestCIStep_NoPRURL(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, "abc", "def", config.Commands{})
@@ -3926,14 +4066,15 @@ func TestCIStep_NoPRURL(t *testing.T) {
 }
 
 func TestCIStep_InvalidPRURLReturnsError(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
-	binDir := fakeCIGH(t, "OPEN", "[]")
-	prependPATH(t, binDir)
+	env := fakeCIGH(t, "OPEN", "[]")
 
 	prURL := "https://github.com/test/repo/pull/42/files"
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 	sctx.Run.PRURL = &prURL
 
 	step := &CIStep{}
@@ -3950,6 +4091,7 @@ func TestCIStep_InvalidPRURLReturnsError(t *testing.T) {
 }
 
 func TestCIStep_NonGitHubSkips(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 	prURL := "https://gitlab.com/test/repo/-/merge_requests/42"
 	ag := &mockAgent{name: "test"}
@@ -3974,6 +4116,7 @@ func TestCIStep_NonGitHubSkips(t *testing.T) {
 }
 
 func TestCIStep_ContextCancelled(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	ag := &mockAgent{name: "test"}
 	prURL := "https://github.com/test/repo/pull/1"
@@ -3996,14 +4139,15 @@ func TestCIStep_ContextCancelled(t *testing.T) {
 }
 
 func TestCIStep_TimeoutDoesNotSleepPastDeadline(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
-	binDir := fakeCIGH(t, "OPEN", "[]")
-	prependPATH(t, binDir)
+	env := fakeCIGH(t, "OPEN", "[]")
 
 	prURL := "https://github.com/test/repo/pull/42"
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 	sctx.Run.PRURL = &prURL
 	sctx.Config.CITimeout = 2 * time.Second
 
@@ -4037,6 +4181,7 @@ func TestCIStep_TimeoutDoesNotSleepPastDeadline(t *testing.T) {
 }
 
 func TestCIStep_CommitAndPush(t *testing.T) {
+	t.Parallel()
 	// Set up upstream bare repo
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
@@ -4086,6 +4231,7 @@ func TestCIStep_CommitAndPush(t *testing.T) {
 }
 
 func TestCIStep_CommitAndPush_NoChanges(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	ag := &mockAgent{name: "test"}
@@ -4104,6 +4250,7 @@ func TestCIStep_CommitAndPush_NoChanges(t *testing.T) {
 }
 
 func TestCIStep_CommitAndPush_StatusError(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	realGit, err := exec.LookPath("git")
@@ -4113,12 +4260,14 @@ func TestCIStep_CommitAndPush_StatusError(t *testing.T) {
 
 	binDir := fakeCLIBinDir(t)
 	linkTestBinary(t, binDir, "git")
-	prependPATH(t, binDir)
-	t.Setenv("FAKE_CLI_MODE", "git-status-error")
-	t.Setenv("FAKE_CLI_REAL_GIT", realGit)
+	env := fakeCLIEnv(binDir, map[string]string{
+		"FAKE_CLI_MODE":     "git-status-error",
+		"FAKE_CLI_REAL_GIT": realGit,
+	})
 
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 	sctx.Repo.UpstreamURL = "dummy"
 	sctx.Run.Branch = "refs/heads/feature"
 
@@ -4139,6 +4288,7 @@ func TestCIStep_CommitAndPush_StatusError(t *testing.T) {
 }
 
 func TestCIStep_CommitAndPush_NoChanges_ReconcilesStaleDatabaseHeadSHA(t *testing.T) {
+	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -4190,6 +4340,7 @@ func TestCIStep_CommitAndPush_NoChanges_ReconcilesStaleDatabaseHeadSHA(t *testin
 }
 
 func TestCIStep_CommitAndPush_UpdatesLocalBranchRefAfterDetachedPush(t *testing.T) {
+	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -4239,6 +4390,7 @@ func TestCIStep_CommitAndPush_UpdatesLocalBranchRefAfterDetachedPush(t *testing.
 }
 
 func TestTestStep_AgentWritesNewGoTests_NeedsApproval(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	findings := Findings{Items: nil, Summary: "all tests passed"}
@@ -4283,6 +4435,7 @@ func TestTestStep_AgentWritesNewGoTests_NeedsApproval(t *testing.T) {
 }
 
 func TestTestStep_AgentWritesNewTests_NeedsApproval(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	findings := Findings{Items: nil, Summary: "all tests passed"}
@@ -4322,6 +4475,7 @@ func TestTestStep_AgentWritesNewTests_NeedsApproval(t *testing.T) {
 }
 
 func TestTestStep_AgentStagesNewTests_NeedsApproval(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	findings := Findings{Items: nil, Summary: "all tests passed"}
@@ -4362,6 +4516,7 @@ func TestTestStep_AgentStagesNewTests_NeedsApproval(t *testing.T) {
 }
 
 func TestTestStep_FixMode_AgentWritesNewTests_NeedsApproval(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	callCount := 0
@@ -4406,6 +4561,7 @@ func TestTestStep_FixMode_AgentWritesNewTests_NeedsApproval(t *testing.T) {
 // --- ignore patterns tests ---
 
 func TestMatchIgnorePattern(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		path    string
 		pattern string
@@ -4443,6 +4599,7 @@ func TestMatchIgnorePattern(t *testing.T) {
 }
 
 func TestFilterDiff_Empty(t *testing.T) {
+	t.Parallel()
 	// No patterns → unchanged
 	diff := "diff --git a/foo.go b/foo.go\n--- a/foo.go\n+++ b/foo.go\n+line\n"
 	got := filterDiff(diff, nil)
@@ -4458,6 +4615,7 @@ func TestFilterDiff_Empty(t *testing.T) {
 }
 
 func TestFilterDiff_SingleFile(t *testing.T) {
+	t.Parallel()
 	diff := "diff --git a/foo.generated.go b/foo.generated.go\n--- a/foo.generated.go\n+++ b/foo.generated.go\n@@ -0,0 +1 @@\n+generated\n"
 	got := filterDiff(diff, []string{"*.generated.go"})
 	// All lines should be filtered
@@ -4467,6 +4625,7 @@ func TestFilterDiff_SingleFile(t *testing.T) {
 }
 
 func TestFilterDiff_MultipleFiles(t *testing.T) {
+	t.Parallel()
 	diff := strings.Join([]string{
 		"diff --git a/main.go b/main.go",
 		"--- a/main.go",
@@ -4502,6 +4661,7 @@ func TestFilterDiff_MultipleFiles(t *testing.T) {
 }
 
 func TestFilterDiff_MultiplePatterns(t *testing.T) {
+	t.Parallel()
 	diff := strings.Join([]string{
 		"diff --git a/main.go b/main.go",
 		"+++ b/main.go",
@@ -4528,6 +4688,7 @@ func TestFilterDiff_MultiplePatterns(t *testing.T) {
 }
 
 func TestFilterDiff_PathContainingBDividerSequence(t *testing.T) {
+	t.Parallel()
 	diff := strings.Join([]string{
 		"diff --git a/a b/c.go b/a b/c.go",
 		"--- a/a b/c.go",
@@ -4561,6 +4722,7 @@ func TestFilterDiff_PathContainingBDividerSequence(t *testing.T) {
 }
 
 func TestReviewFindingsSchema_ValidJSON(t *testing.T) {
+	t.Parallel()
 	if !json.Valid(reviewFindingsSchema) {
 		t.Errorf("reviewFindingsSchema is not valid JSON: %s", string(reviewFindingsSchema))
 	}
@@ -4585,6 +4747,7 @@ func TestReviewFindingsSchema_ValidJSON(t *testing.T) {
 }
 
 func TestFindingsSchema_Action(t *testing.T) {
+	t.Parallel()
 	var parsed map[string]interface{}
 	if err := json.Unmarshal(findingsSchema, &parsed); err != nil {
 		t.Fatal(err)
@@ -4608,6 +4771,7 @@ func TestFindingsSchema_Action(t *testing.T) {
 }
 
 func TestReviewFindingsSchema_ActionAtItemLevel(t *testing.T) {
+	t.Parallel()
 	var parsed map[string]interface{}
 	if err := json.Unmarshal(reviewFindingsSchema, &parsed); err != nil {
 		t.Fatal(err)
@@ -4627,6 +4791,7 @@ func TestReviewFindingsSchema_ActionAtItemLevel(t *testing.T) {
 }
 
 func TestTestStep_PromptIncludesAction(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	findings := Findings{Items: nil, Summary: "all tests passed"}
 	findingsJSON, _ := json.Marshal(findings)
@@ -4650,6 +4815,7 @@ func TestTestStep_PromptIncludesAction(t *testing.T) {
 }
 
 func TestLintStep_PromptIncludesAction(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	findings := Findings{Items: nil, Summary: "all clean"}
 	findingsJSON, _ := json.Marshal(findings)
@@ -4673,6 +4839,7 @@ func TestLintStep_PromptIncludesAction(t *testing.T) {
 }
 
 func TestReviewStep_IgnorePatterns(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	// Add a generated file to the feature branch
@@ -4706,6 +4873,7 @@ func TestReviewStep_IgnorePatterns(t *testing.T) {
 }
 
 func TestReviewStep_IgnorePatternsFilterAllFiles(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 
 	// Create a repo where the only change is a generated file
@@ -4745,6 +4913,7 @@ func TestReviewStep_IgnorePatternsFilterAllFiles(t *testing.T) {
 }
 
 func TestReviewStep_EmptyDiff_ReturnsLowRisk(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	gitCmd(t, dir, "init")
 	gitCmd(t, dir, "config", "user.name", "test")
@@ -4780,6 +4949,7 @@ func TestReviewStep_EmptyDiff_ReturnsLowRisk(t *testing.T) {
 }
 
 func TestReviewStep_IgnorePatternsFilterAllFiles_ReturnsLowRisk(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	gitCmd(t, dir, "init")
 	gitCmd(t, dir, "config", "user.name", "test")
@@ -4819,6 +4989,7 @@ func TestReviewStep_IgnorePatternsFilterAllFiles_ReturnsLowRisk(t *testing.T) {
 }
 
 func TestReviewStep_FixMode_RequiresPreviousFindings(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	ag := &mockAgent{
@@ -4844,6 +5015,7 @@ func TestReviewStep_FixMode_RequiresPreviousFindings(t *testing.T) {
 }
 
 func TestReviewStep_DismissedFindingsSanitizesPromptContent(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	findingsJSON, _ := json.Marshal(Findings{Summary: "clean"})
@@ -4877,6 +5049,7 @@ func TestReviewStep_DismissedFindingsSanitizesPromptContent(t *testing.T) {
 }
 
 func TestReviewStep_PromptOmitsUserCommitMessages(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	findingsJSON, _ := json.Marshal(Findings{Summary: "clean"})
@@ -4906,6 +5079,7 @@ func TestReviewStep_PromptOmitsUserCommitMessages(t *testing.T) {
 }
 
 func TestSanitizedPreviousFindingsForPrompt_PreservesMultilineDescriptions(t *testing.T) {
+	t.Parallel()
 	raw, err := types.MarshalFindingsJSON(types.Findings{
 		Items: []types.Finding{{
 			ID:          "review-1",
@@ -4940,17 +5114,18 @@ func TestSanitizedPreviousFindingsForPrompt_PreservesMultilineDescriptions(t *te
 
 // fakeCIGH creates a fake gh binary that responds to CI-related
 // commands (pr view --json state, pr checks --json, pr view --json comments).
-func fakeCIGH(t *testing.T, state, checksJSON string) string {
+func fakeCIGH(t *testing.T, state, checksJSON string) []string {
 	t.Helper()
 	binDir := fakeCLIBinDir(t)
 	linkTestBinary(t, binDir, "gh")
-	t.Setenv("FAKE_CLI_MODE", "ci-gh")
-	t.Setenv("FAKE_CLI_STATE", state)
-	t.Setenv("FAKE_CLI_CHECKS", checksJSON)
-	return binDir
+	return fakeCLIEnv(binDir, map[string]string{
+		"FAKE_CLI_MODE":   "ci-gh",
+		"FAKE_CLI_STATE":  state,
+		"FAKE_CLI_CHECKS": checksJSON,
+	})
 }
 
-func fakeCIGHSequence(t *testing.T, state string, checks []string) string {
+func fakeCIGHSequence(t *testing.T, state string, checks []string) []string {
 	t.Helper()
 	binDir := fakeCLIBinDir(t)
 	linkTestBinary(t, binDir, "gh")
@@ -4965,30 +5140,33 @@ func fakeCIGHSequence(t *testing.T, state string, checks []string) string {
 		t.Fatalf("write checks index: %v", err)
 	}
 
-	t.Setenv("FAKE_CLI_MODE", "ci-gh-seq")
-	t.Setenv("FAKE_CLI_STATE", state)
-	t.Setenv("FAKE_CLI_CHECKS_PATH", checksPath)
-	t.Setenv("FAKE_CLI_CHECKS_INDEX_PATH", indexPath)
-	return binDir
+	return fakeCLIEnv(binDir, map[string]string{
+		"FAKE_CLI_MODE":              "ci-gh-seq",
+		"FAKE_CLI_STATE":             state,
+		"FAKE_CLI_CHECKS_PATH":       checksPath,
+		"FAKE_CLI_CHECKS_INDEX_PATH": indexPath,
+	})
 }
 
-func fakeCIGHNoChecks(t *testing.T) string {
+func fakeCIGHNoChecks(t *testing.T) []string {
 	t.Helper()
 	binDir := fakeCLIBinDir(t)
 	linkTestBinary(t, binDir, "gh")
-	t.Setenv("FAKE_CLI_MODE", "ci-gh-nochecks")
-	return binDir
+	return fakeCLIEnv(binDir, map[string]string{
+		"FAKE_CLI_MODE": "ci-gh-nochecks",
+	})
 }
 
 func TestCIStep_PRMergedExitsEarly(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
-	binDir := fakeCIGH(t, "MERGED", "[]")
-	prependPATH(t, binDir)
+	env := fakeCIGH(t, "MERGED", "[]")
 
 	prURL := "https://github.com/test/repo/pull/42"
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 	sctx.Run.PRURL = &prURL
 	sctx.Config.CITimeout = 10 * time.Second
 
@@ -5017,14 +5195,15 @@ func TestCIStep_PRMergedExitsEarly(t *testing.T) {
 }
 
 func TestCIStep_PRClosedExitsEarly(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
-	binDir := fakeCIGH(t, "CLOSED", "[]")
-	prependPATH(t, binDir)
+	env := fakeCIGH(t, "CLOSED", "[]")
 
 	prURL := "https://github.com/test/repo/pull/42"
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 	sctx.Run.PRURL = &prURL
 	sctx.Config.CITimeout = 10 * time.Second
 
@@ -5053,11 +5232,16 @@ func TestCIStep_PRClosedExitsEarly(t *testing.T) {
 }
 
 func TestCIStep_GetCIChecksNoChecksReported(t *testing.T) {
-	binDir := fakeCIGHNoChecks(t)
-	prependPATH(t, binDir)
+	t.Parallel()
+	env := fakeCIGHNoChecks(t)
+
+	dir := t.TempDir()
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, "abc", "def", config.Commands{})
+	sctx.Env = env
 
 	step := &CIStep{}
-	checks, err := step.getCIChecks(context.Background(), t.TempDir(), "42")
+	checks, err := step.getCIChecks(sctx, "42")
 	if err != nil {
 		t.Fatalf("expected no error when gh reports no checks, got: %v", err)
 	}
@@ -5067,6 +5251,7 @@ func TestCIStep_GetCIChecksNoChecksReported(t *testing.T) {
 }
 
 func TestCIStep_CIFailureAutoFix(t *testing.T) {
+	t.Parallel()
 	// Set up upstream bare repo for push
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
@@ -5091,8 +5276,7 @@ func TestCIStep_CIFailureAutoFix(t *testing.T) {
 	gitCmd(t, dir, "push", "origin", "feature")
 
 	checksJSON := `[{"name":"build","status":"COMPLETED","conclusion":"success"},{"name":"test","status":"COMPLETED","conclusion":"failure"}]`
-	binDir := fakeCIGH(t, "OPEN", checksJSON)
-	prependPATH(t, binDir)
+	env := fakeCIGH(t, "OPEN", checksJSON)
 
 	agentCalled := false
 	ag := &mockAgent{
@@ -5107,6 +5291,7 @@ func TestCIStep_CIFailureAutoFix(t *testing.T) {
 
 	prURL := "https://github.com/test/repo/pull/42"
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 	sctx.Run.PRURL = &prURL
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "refs/heads/feature"
@@ -5156,18 +5341,19 @@ func TestCIStep_CIFailureAutoFix(t *testing.T) {
 }
 
 func TestCIStep_AllChecksPassingExitsCleanly(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	checksSequence := []string{
 		`[{"name":"build","state":"PENDING","bucket":"pending"}]`,
 		`[{"name":"build","state":"SUCCESS","bucket":"pass"},{"name":"test","state":"SUCCESS","bucket":"pass"}]`,
 	}
-	binDir := fakeCIGHSequence(t, "OPEN", checksSequence)
-	prependPATH(t, binDir)
+	env := fakeCIGHSequence(t, "OPEN", checksSequence)
 
 	prURL := "https://github.com/test/repo/pull/42"
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 	sctx.Run.PRURL = &prURL
 	sctx.Config.CITimeout = 10 * time.Second
 
@@ -5205,15 +5391,16 @@ func TestCIStep_AllChecksPassingExitsCleanly(t *testing.T) {
 }
 
 func TestCIStep_EmptyChecksWaitsDuringGracePeriod(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	// Fake gh returns OPEN state, empty checks, no comments
-	binDir := fakeCIGH(t, "OPEN", "[]")
-	prependPATH(t, binDir)
+	env := fakeCIGH(t, "OPEN", "[]")
 
 	prURL := "https://github.com/test/repo/pull/42"
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 	sctx.Run.PRURL = &prURL
 	sctx.Config.CITimeout = 5 * time.Second
 
@@ -5271,14 +5458,15 @@ func TestCIStep_EmptyChecksWaitsDuringGracePeriod(t *testing.T) {
 }
 
 func TestCIStep_LogsWaitingForChecksDuringGracePeriod(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
-	binDir := fakeCIGH(t, "OPEN", "[]")
-	prependPATH(t, binDir)
+	env := fakeCIGH(t, "OPEN", "[]")
 
 	prURL := "https://github.com/test/repo/pull/42"
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 	sctx.Run.PRURL = &prURL
 	sctx.Config.CITimeout = 5 * time.Second
 
@@ -5312,15 +5500,16 @@ func TestCIStep_LogsWaitingForChecksDuringGracePeriod(t *testing.T) {
 }
 
 func TestCIStep_NonEmptyPassingChecksExitImmediately(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	checksJSON := `[{"name":"build","state":"SUCCESS","bucket":"pass"}]`
-	binDir := fakeCIGH(t, "OPEN", checksJSON)
-	prependPATH(t, binDir)
+	env := fakeCIGH(t, "OPEN", checksJSON)
 
 	prURL := "https://github.com/test/repo/pull/42"
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 	sctx.Run.PRURL = &prURL
 	sctx.Config.CITimeout = 10 * time.Second
 
@@ -5354,10 +5543,10 @@ func TestCIStep_NonEmptyPassingChecksExitImmediately(t *testing.T) {
 }
 
 func TestPRStep_AgentNonConventionalTitleFallsBack(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
-	binDir, logFile := fakeGH(t, "")
-	prependPATH(t, binDir)
+	env, logFile := fakeGH(t, "")
 
 	ag := &mockAgent{
 		name: "test",
@@ -5367,6 +5556,7 @@ func TestPRStep_AgentNonConventionalTitleFallsBack(t *testing.T) {
 		},
 	}
 	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 
 	step := &PRStep{}
 	if _, err := step.Execute(sctx); err != nil {
@@ -5392,10 +5582,10 @@ func TestPRStep_AgentNonConventionalTitleFallsBack(t *testing.T) {
 }
 
 func TestPRStep_AgentScopedBreakingTitlePassesThrough(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
-	binDir, logFile := fakeGH(t, "")
-	prependPATH(t, binDir)
+	env, logFile := fakeGH(t, "")
 
 	const title = "feat(api)!: require auth token"
 	ag := &mockAgent{
@@ -5406,6 +5596,7 @@ func TestPRStep_AgentScopedBreakingTitlePassesThrough(t *testing.T) {
 		},
 	}
 	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 
 	step := &PRStep{}
 	if _, err := step.Execute(sctx); err != nil {
@@ -5426,6 +5617,7 @@ func TestPRStep_AgentScopedBreakingTitlePassesThrough(t *testing.T) {
 }
 
 func TestCIStep_CIAutoFixDisabledWithZero(t *testing.T) {
+	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
 	checksJSON := `[
@@ -5434,13 +5626,13 @@ func TestCIStep_CIAutoFixDisabledWithZero(t *testing.T) {
 		{"name":"lint","status":"COMPLETED","conclusion":"action_required"},
 		{"name":"deploy","status":"COMPLETED","conclusion":"neutral"}
 	]`
-	binDir := fakeCIGH(t, "OPEN", checksJSON)
-	prependPATH(t, binDir)
+	env := fakeCIGH(t, "OPEN", checksJSON)
 
 	ag := &mockAgent{name: "test"}
 
 	prURL := "https://github.com/test/repo/pull/42"
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 	sctx.Run.PRURL = &prURL
 	sctx.Config.CITimeout = 5 * time.Second
 	sctx.Config.AutoFix = config.AutoFix{CI: 0} // disabled
@@ -5503,6 +5695,7 @@ func TestCIStep_CIAutoFixDisabledWithZero(t *testing.T) {
 }
 
 func TestCIStep_CIAutoFixLimitExhausted(t *testing.T) {
+	t.Parallel()
 	// Set up upstream bare repo for push
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
@@ -5527,8 +5720,7 @@ func TestCIStep_CIAutoFixLimitExhausted(t *testing.T) {
 	gitCmd(t, dir, "push", "origin", "feature")
 
 	checksJSON := `[{"name":"test","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`
-	binDir := fakeCIGH(t, "OPEN", checksJSON)
-	prependPATH(t, binDir)
+	env := fakeCIGH(t, "OPEN", checksJSON)
 
 	fixCount := 0
 	ag := &mockAgent{
@@ -5543,6 +5735,7 @@ func TestCIStep_CIAutoFixLimitExhausted(t *testing.T) {
 
 	prURL := "https://github.com/test/repo/pull/42"
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 	sctx.Run.PRURL = &prURL
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "refs/heads/feature"
@@ -5592,6 +5785,7 @@ func TestCIStep_CIAutoFixLimitExhausted(t *testing.T) {
 }
 
 func TestCIStep_CIAutoFixRetriesAfterChecksRerun(t *testing.T) {
+	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -5621,8 +5815,7 @@ func TestCIStep_CIAutoFixRetriesAfterChecksRerun(t *testing.T) {
 		`[{"name":"test","status":"IN_PROGRESS","bucket":"pending"}]`,
 		`[{"name":"test","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`,
 	}
-	binDir := fakeCIGHSequence(t, "OPEN", checksSequence)
-	prependPATH(t, binDir)
+	env := fakeCIGHSequence(t, "OPEN", checksSequence)
 
 	fixCount := 0
 	ag := &mockAgent{
@@ -5636,6 +5829,7 @@ func TestCIStep_CIAutoFixRetriesAfterChecksRerun(t *testing.T) {
 
 	prURL := "https://github.com/test/repo/pull/42"
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 	sctx.Run.PRURL = &prURL
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "refs/heads/feature"
@@ -5682,6 +5876,7 @@ func TestCIStep_CIAutoFixRetriesAfterChecksRerun(t *testing.T) {
 }
 
 func TestCIStep_FixMode_ManualInterventionRunsCIFix(t *testing.T) {
+	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -5705,8 +5900,7 @@ func TestCIStep_FixMode_ManualInterventionRunsCIFix(t *testing.T) {
 	gitCmd(t, dir, "push", "origin", "feature")
 
 	checksJSON := `[{"name":"test","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`
-	binDir := fakeCIGH(t, "OPEN", checksJSON)
-	prependPATH(t, binDir)
+	env := fakeCIGH(t, "OPEN", checksJSON)
 
 	fixCount := 0
 	ag := &mockAgent{
@@ -5732,6 +5926,7 @@ func TestCIStep_FixMode_ManualInterventionRunsCIFix(t *testing.T) {
 
 	prURL := "https://github.com/test/repo/pull/42"
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 	sctx.Run.PRURL = &prURL
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "refs/heads/feature"
@@ -5770,6 +5965,7 @@ func TestCIStep_FixMode_ManualInterventionRunsCIFix(t *testing.T) {
 // produces no changes (nothing to commit), it still counts as a consumed fix
 // attempt rather than spinning forever with "fix already attempted".
 func TestCIStep_AutoFixNoChanges_CountsAsAttempt(t *testing.T) {
+	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -5793,8 +5989,7 @@ func TestCIStep_AutoFixNoChanges_CountsAsAttempt(t *testing.T) {
 	gitCmd(t, dir, "push", "origin", "feature")
 
 	checksJSON := `[{"name":"test","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`
-	binDir := fakeCIGH(t, "OPEN", checksJSON)
-	prependPATH(t, binDir)
+	env := fakeCIGH(t, "OPEN", checksJSON)
 
 	fixCount := 0
 	ag := &mockAgent{
@@ -5808,6 +6003,7 @@ func TestCIStep_AutoFixNoChanges_CountsAsAttempt(t *testing.T) {
 
 	prURL := "https://github.com/test/repo/pull/42"
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 	sctx.Run.PRURL = &prURL
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "refs/heads/feature"
@@ -5864,6 +6060,7 @@ func TestCIStep_AutoFixNoChanges_CountsAsAttempt(t *testing.T) {
 // TestCIStep_FixMode_NoChanges_CountsAsAttempt verifies the same no-changes
 // behavior for manual fix mode (sctx.Fixing = true).
 func TestCIStep_FixMode_NoChanges_CountsAsAttempt(t *testing.T) {
+	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -5887,8 +6084,7 @@ func TestCIStep_FixMode_NoChanges_CountsAsAttempt(t *testing.T) {
 	gitCmd(t, dir, "push", "origin", "feature")
 
 	checksJSON := `[{"name":"test","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`
-	binDir := fakeCIGH(t, "OPEN", checksJSON)
-	prependPATH(t, binDir)
+	env := fakeCIGH(t, "OPEN", checksJSON)
 
 	fixCount := 0
 	ag := &mockAgent{
@@ -5913,6 +6109,7 @@ func TestCIStep_FixMode_NoChanges_CountsAsAttempt(t *testing.T) {
 
 	prURL := "https://github.com/test/repo/pull/42"
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 	sctx.Run.PRURL = &prURL
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "refs/heads/feature"
@@ -5959,6 +6156,7 @@ func TestCIStep_FixMode_NoChanges_CountsAsAttempt(t *testing.T) {
 // TestCIStep_AutoFixPromptIncludesMustFixInstruction verifies the agent prompt
 // includes a strong instruction that the agent must produce changes.
 func TestCIStep_AutoFixPromptIncludesMustFixInstruction(t *testing.T) {
+	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -5982,8 +6180,7 @@ func TestCIStep_AutoFixPromptIncludesMustFixInstruction(t *testing.T) {
 	gitCmd(t, dir, "push", "origin", "feature")
 
 	checksJSON := `[{"name":"test","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`
-	binDir := fakeCIGH(t, "OPEN", checksJSON)
-	prependPATH(t, binDir)
+	env := fakeCIGH(t, "OPEN", checksJSON)
 
 	var capturedPrompt string
 	ag := &mockAgent{
@@ -5997,6 +6194,7 @@ func TestCIStep_AutoFixPromptIncludesMustFixInstruction(t *testing.T) {
 
 	prURL := "https://github.com/test/repo/pull/42"
 	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
 	sctx.Run.PRURL = &prURL
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "refs/heads/feature"

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -3579,6 +3579,58 @@ func TestEnvValueForOS_WindowsMatchesEmptyMixedCaseOverride(t *testing.T) {
 	}
 }
 
+func TestExecutableCandidatesForOS_WindowsHonorsExplicitEmptyPATHEXT(t *testing.T) {
+	t.Parallel()
+
+	candidates := executableCandidatesForOS("windows", "gh", []string{"PATHEXT="})
+	if len(candidates) != 1 {
+		t.Fatalf("expected only bare command name, got %v", candidates)
+	}
+	if candidates[0] != "gh" {
+		t.Fatalf("expected bare command candidate, got %q", candidates[0])
+	}
+}
+
+func TestStepCmd_ResolvesRelativeCustomPathFromWorkDir(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	binDir := filepath.Join(workDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	logFile := filepath.Join(t.TempDir(), "gh.log")
+	linkTestBinary(t, binDir, "gh")
+
+	sctx := &pipeline.StepContext{
+		Ctx:     context.Background(),
+		WorkDir: workDir,
+		Env: []string{
+			"PATH=bin",
+			"FAKE_CLI_MODE=gh",
+			"FAKE_CLI_LOG=" + logFile,
+		},
+	}
+
+	if !stepCLIAvailable(sctx, scm.ProviderGitHub) {
+		t.Fatal("expected gh to be available from workdir-relative custom PATH")
+	}
+
+	cmd := stepCmd(sctx, "gh", "auth", "status")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run fake gh from relative custom PATH: %v", err)
+	}
+
+	logData, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(logData), "auth status") {
+		t.Fatalf("expected fake gh invocation, got %q", string(logData))
+	}
+}
+
 func TestStepCmd_DoesNotFallbackToHostPathWhenCustomPathOmitsBinary(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -3599,6 +3599,24 @@ func TestStepCmd_DoesNotFallbackToHostPathWhenCustomPathOmitsBinary(t *testing.T
 	}
 }
 
+func TestStepCmd_DoesNotFallbackToHostPathWhenCustomPathIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	sctx := &pipeline.StepContext{
+		Ctx:     context.Background(),
+		WorkDir: t.TempDir(),
+		Env:     []string{"PATH="},
+	}
+
+	cmd := stepCmd(sctx, "git", "--version")
+	if !strings.Contains(cmd.Path, string(filepath.Separator)) {
+		t.Fatalf("expected explicit empty PATH to keep lookup out of host PATH, got %q", cmd.Path)
+	}
+	if err := cmd.Run(); err == nil {
+		t.Fatal("expected git lookup to fail when custom PATH is empty")
+	}
+}
+
 func TestStepCmd_OverridesPathWithoutDuplicateEntries(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -3513,6 +3513,58 @@ func TestStepCLIAvailable_ResolvesExecutableSuffixFromCustomPath(t *testing.T) {
 	}
 }
 
+func TestStepCmd_DoesNotFallbackToHostPathWhenCustomPathOmitsBinary(t *testing.T) {
+	t.Parallel()
+
+	customPath := t.TempDir()
+	sctx := &pipeline.StepContext{
+		Ctx:     context.Background(),
+		WorkDir: t.TempDir(),
+		Env:     []string{"PATH=" + customPath},
+	}
+
+	cmd := stepCmd(sctx, "git", "--version")
+	if cmd.Path != filepath.Join(customPath, "git") {
+		t.Fatalf("expected custom-path lookup to stay inside %q, got %q", customPath, cmd.Path)
+	}
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected git lookup to fail when custom PATH omits git")
+	}
+}
+
+func TestStepCmd_OverridesPathWithoutDuplicateEntries(t *testing.T) {
+	t.Parallel()
+
+	customPath := t.TempDir()
+	sctx := &pipeline.StepContext{
+		Ctx:     context.Background(),
+		WorkDir: t.TempDir(),
+		Env: []string{
+			"PATH=" + customPath,
+			"STEP_TEST_VAR=custom",
+		},
+	}
+
+	cmd := stepCmd(sctx, filepath.Join(string(filepath.Separator), "usr", "bin", "env"))
+
+	pathCount := 0
+	for _, entry := range cmd.Env {
+		switch {
+		case strings.HasPrefix(entry, "PATH="):
+			pathCount++
+			if entry != "PATH="+customPath {
+				t.Fatalf("expected overridden PATH, got %q", entry)
+			}
+		case entry == "STEP_TEST_VAR=custom":
+			continue
+		}
+	}
+	if pathCount != 1 {
+		t.Fatalf("expected exactly one PATH entry, got %d in %v", pathCount, cmd.Env)
+	}
+}
+
 func TestPRStep_UpdatesExistingPR(t *testing.T) {
 	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
+	"github.com/kunchenguid/no-mistakes/internal/scm"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
@@ -329,13 +330,38 @@ func setupGitRepo(t *testing.T) (string, string, string) {
 	ensureGitRepoTemplate(t)
 
 	dir := t.TempDir()
-	// Copy template contents into the new dir
-	cmd := exec.Command("cp", "-a", gitRepoTemplate.dir+"/.", dir)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("cp template repo: %v: %s", err, out)
+	if err := copyDirContents(gitRepoTemplate.dir, dir); err != nil {
+		t.Fatalf("copy template repo: %v", err)
 	}
 
 	return dir, gitRepoTemplate.baseSHA, gitRepoTemplate.headSHA
+}
+
+func TestCopyDirContents_PreservesGitRepo(t *testing.T) {
+	t.Parallel()
+	ensureGitRepoTemplate(t)
+
+	dir := t.TempDir()
+	if err := copyDirContents(gitRepoTemplate.dir, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	if headSHA != gitRepoTemplate.headSHA {
+		t.Fatalf("HEAD = %q, want %q", headSHA, gitRepoTemplate.headSHA)
+	}
+
+	status := gitCmd(t, dir, "status", "--short")
+	if status != "" {
+		t.Fatalf("expected clean copied repo, got %q", status)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, ".git")); err != nil {
+		t.Fatalf("stat .git: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "feature.txt")); err != nil {
+		t.Fatalf("stat feature.txt: %v", err)
+	}
 }
 
 // newTestContext creates a StepContext for testing with optional config overrides.
@@ -3440,6 +3466,40 @@ func fakeGH(t *testing.T, prViewURL string) (env []string, logFile string) {
 		"FAKE_CLI_PR_URL": prViewURL,
 	})
 	return env, logFile
+}
+
+func TestStepCLIAvailable_ResolvesExecutableSuffixFromCustomPath(t *testing.T) {
+	t.Parallel()
+
+	binDir := fakeCLIBinDir(t)
+	logFile := filepath.Join(t.TempDir(), "gh.log")
+	linkTestBinary(t, binDir, "gh")
+
+	sctx := &pipeline.StepContext{
+		Ctx:     context.Background(),
+		WorkDir: t.TempDir(),
+		Env: fakeCLIEnv(binDir, map[string]string{
+			"FAKE_CLI_MODE": "gh",
+			"FAKE_CLI_LOG":  logFile,
+		}),
+	}
+
+	if !stepCLIAvailable(sctx, scm.ProviderGitHub) {
+		t.Fatal("expected gh to be available from custom PATH")
+	}
+
+	cmd := stepCmd(sctx, "gh", "auth", "status")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run fake gh: %v", err)
+	}
+
+	logData, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(logData), "auth status") {
+		t.Fatalf("expected fake gh invocation, got %q", string(logData))
+	}
 }
 
 func TestPRStep_UpdatesExistingPR(t *testing.T) {


### PR DESCRIPTION
## Summary
- Route CI and PR step command resolution through `StepContext.Env` so custom `PATH` and related overrides are applied consistently, including strict empty overrides and Windows-specific lookup behavior.
- Fix edge cases in custom command lookup for executability, relative and empty `PATH` segments, and `PATHEXT` handling so env-isolated runs do not fall back to host binaries unexpectedly.
- Reduce pipeline step test latency by reworking the shared test setup while keeping coverage for the env-resolution and cross-platform command handling paths.

## Risk Assessment

⚠️ Medium: The change is well-scoped and tested, but it alters low-level command resolution semantics in CI/PR steps and has at least one user-visible edge case around custom PATH handling.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

✅ **Rebase** - passed
⚠️ **Review** - 1 warning
✅ **Test** - passed
✅ **Lint** - passed

<details>
<summary>Review details</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/pipeline/steps/ci.go:146` - `CIStep.Execute` still calls `scm.CLIAvailable` and `scm.AuthConfigured` directly, so the new `StepContext.Env` PATH/auth overrides are ignored for CI startup checks. In env-isolated runs this can incorrectly skip CI monitoring and auto-fix even though the later `stepCmd` calls would succeed.

**Round 2** (auto-fix) - found 2 errors
- 🚨 `internal/pipeline/steps/steps_test.go:333` - `setupGitRepo` now depends on the external command `cp -a` to clone the template repo. That command is not available on Windows, so this test-speedup change breaks the package test suite on Windows runners before any step logic is exercised.
- 🚨 `internal/pipeline/steps/common.go:82` - The new `StepContext.Env` PATH lookup only checks for an exact filename match like `gh`/`glab`. On Windows the injected binaries are `gh.exe`/`glab.exe`, so `stepCLIAvailable` reports the CLI missing and `stepCmd` fails to resolve the overridden PATH, causing PR/CI steps to skip or fail under Windows.

**Round 3** (auto-fix) - found 1 warning
- ⚠️ `internal/pipeline/steps/ci.go:442` - The new `StepContext.Env` plumbing only applies to `git status`; the subsequent `git add`, `git commit`, `git ls-remote`, `git push`, and `git update-ref` calls still use the parent process environment. In setups that rely on `sctx.Env` for PATH or auth, CI autofix can pass the startup checks and then fail during commit/push with a different environment.

**Round 4** (auto-fix) - found 1 warning
- ⚠️ `internal/pipeline/steps/ci.go:432` - `commitAndPush` still uses `git.HeadSHA` directly in the clean-worktree branch, so `StepContext.Env` is ignored exactly when the CI fixer produces no diff. That regresses the stale-HEAD reconciliation path under custom PATH/git wrappers; switch this call to the env-aware helper as well.

**Round 5** (user-fix) - found 2 warnings
- ⚠️ `internal/pipeline/steps/common.go:181` - `stepCmd` only resolves against `StepContext.Env` when it finds a matching binary there; otherwise it leaves `name` unchanged, which lets `exec` fall back to the host `PATH`. That means an overridden `PATH` that intentionally omits `git`/`gh` can still run the real system binary instead of honoring the step environment.
- ⚠️ `internal/pipeline/steps/common.go:189` - `cmd.Env = append(os.Environ(), sctx.Env...)` duplicates keys instead of overriding them. For variables like `PATH` this is not reliable on Unix - child processes and any grandchildren they spawn may still observe the original value - so the new env-respecting behavior can silently fail.

**Round 6** (user-fix) - found 1 warning
- ⚠️ `internal/pipeline/steps/common.go:153` - Custom PATH resolution treats any existing file as a valid executable. If `PATH` contains a non-executable `gh`/`git` shim, `stepCLIAvailable` will report the CLI as installed and `stepCmd` will try to run it, which turns an expected "not installed" path into runtime `permission denied` failures. Check executability, not just existence, when scanning overridden PATH entries.

**Round 7** (user-fix) - found 1 warning
- ⚠️ `internal/pipeline/steps/common.go:153` - `findInCustomPath` now requires Unix execute bits to treat a binary as runnable. On Windows, `.exe` files commonly report no execute bits, so `stepCLIAvailable`/`stepCmd` will miss valid `gh.exe`/`git.exe` shims in a custom `PATH` and then fail PR/CI step tests instead of using the injected binary.

**Round 8** (user-fix) - found 1 warning
- ⚠️ `internal/pipeline/steps/common.go:80` - On Windows, `envValue` does not treat a mixed-case variable set to an empty value like `Path=` or `PathExt=` as present because the case-insensitive branch requires `len(entry) > len(prefix)`. That makes an explicit empty override look absent, so `stepCmd` and `stepCLIAvailable` can incorrectly fall back to the host PATH/PATHEXT instead of honoring the step environment.

**Round 9** (user-fix) - found 1 warning
- ⚠️ `internal/pipeline/steps/common.go:186` - `missingFromCustomPath` falls back to the bare executable name when `PATH` is explicitly overridden to an empty value, so `stepCmd` will still resolve `git`/`gh` against the parent process PATH instead of honoring the step override. Return a path containing a separator (or skip `exec` lookup entirely) so an empty `PATH` reliably disables host binary fallback.

**Round 10** (user-fix) - found 2 warnings
- ⚠️ `internal/pipeline/steps/common.go:149` - `findInCustomPath` resolves `PATH` entries with `os.Stat` before `cmd.Dir` is applied, so relative entries like `PATH=bin:$PATH` are interpreted against the agent process cwd instead of `StepContext.WorkDir`. That makes step-local CLI overrides fail even though the command would be valid from the worktree.
- ⚠️ `internal/pipeline/steps/common.go:136` - `executableCandidates` still falls back to the default Windows `PATHEXT` when `PATHEXT` is explicitly set to the empty string. The new helper now detects empty mixed-case overrides, but command lookup does not honor that strict override, so `gh`/`git` can still resolve via `.EXE` unexpectedly.

**Round 11** (user-fix) - found 1 warning
- ⚠️ `internal/pipeline/steps/common.go:159` - `findInCustomPath` skips empty `PATH` segments, but in standard `PATH` semantics an empty element represents the current working directory. With a custom step env like `PATH=:/tmp/bin` or `PATH=bin:`, PR/CI subprocess resolution can now incorrectly miss binaries that are intentionally available from the step workdir.

</details>
