### PR TITLE
fix(pipeline): handle discrete log chunks across pipeline output

### DIFF
--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -166,7 +167,10 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 	}
 	defer logFile.Close()
 
-	// Build step context with log callback that emits events and writes to file
+	// Build step context with log callback that emits events and writes to file.
+	// lastChunkNewline tracks whether the most recent chunk ended with \n,
+	// so Log knows whether it needs a leading \n to flush a streaming partial.
+	lastChunkNewline := true
 	sctx := &StepContext{
 		Ctx:     ctx,
 		Run:     run,
@@ -176,8 +180,23 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 		Config:  e.config,
 		DB:      e.db,
 		Log: func(text string) {
+			if text != "" {
+				prefix := ""
+				if !lastChunkNewline {
+					prefix = "\n"
+				}
+				text = prefix + strings.TrimRight(text, "\n") + "\n\n"
+				lastChunkNewline = true
+			}
 			e.emitLogChunk(run, repo, stepName, text)
-			fmt.Fprintln(logFile, text)
+			fmt.Fprint(logFile, text)
+		},
+		LogChunk: func(text string) {
+			if text != "" {
+				lastChunkNewline = strings.HasSuffix(text, "\n")
+			}
+			e.emitLogChunk(run, repo, stepName, text)
+			fmt.Fprint(logFile, text)
 		},
 		LogFile: func(text string) {
 			fmt.Fprintln(logFile, text)

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -1569,13 +1569,65 @@ func TestExecutor_LogCallback(t *testing.T) {
 	defer mu.Unlock()
 	found := false
 	for _, msg := range logMessages {
-		if msg == "hello from review" {
+		if strings.TrimSpace(msg) == "hello from review" {
 			found = true
 			break
 		}
 	}
 	if !found {
 		t.Errorf("expected log message 'hello from review' in events, got: %v", logMessages)
+	}
+}
+
+func TestExecutor_LogVsLogChunk(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	var chunks []string
+	var mu sync.Mutex
+
+	step := &adaptiveCallStep{
+		name: types.StepReview,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			// Streaming chunk without trailing newline (simulates agent SSE delta).
+			sctx.LogChunk("streaming partial")
+			// Discrete message after unterminated stream - should get leading \n.
+			sctx.Log("after stream")
+			// Consecutive discrete message - no leading \n needed.
+			sctx.Log("second discrete")
+			// Raw streaming chunk should pass through unchanged.
+			sctx.LogChunk("raw chunk")
+			return &StepOutcome{ExitCode: 0}, nil
+		},
+	}
+
+	onEvent := func(e ipc.Event) {
+		if e.Type == ipc.EventLogChunk && e.Content != nil {
+			mu.Lock()
+			chunks = append(chunks, *e.Content)
+			mu.Unlock()
+		}
+	}
+
+	exec := NewExecutor(database, p, nil, nil, []Step{step}, onEvent)
+	exec.Execute(context.Background(), run, repo, workDir)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	want := []string{
+		"streaming partial",   // raw chunk, no newline
+		"\nafter stream\n\n",  // leading \n flushes partial, trailing \n\n separates
+		"second discrete\n\n", // no leading \n (previous Log ended with \n)
+		"raw chunk",           // raw chunk, unchanged
+	}
+	if len(chunks) != len(want) {
+		t.Fatalf("expected %d chunks, got %d: %q", len(want), len(chunks), chunks)
+	}
+	for i, w := range want {
+		if chunks[i] != w {
+			t.Errorf("chunks[%d] = %q, want %q", i, chunks[i], w)
+		}
 	}
 }
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -18,7 +18,8 @@ type StepContext struct {
 	Agent             agent.Agent
 	Config            *config.Config
 	DB                *db.DB
-	Log               func(string) // streaming log callback (user-visible + file)
+	Log               func(string) // discrete log line (newline-terminated, user-visible + file)
+	LogChunk          func(string) // raw streaming chunk (user-visible + file)
 	LogFile           func(string) // file-only log callback (not shown to user)
 	Fixing            bool         // true when re-executing after a "fix" action
 	PreviousFindings  string       // JSON findings from the previous execution (set during fix loop)

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -406,7 +406,7 @@ CI logs:
 	_, err := sctx.Agent.Run(ctx, agent.RunOpts{
 		Prompt:  prompt,
 		CWD:     sctx.WorkDir,
-		OnChunk: sctx.Log,
+		OnChunk: sctx.LogChunk,
 	})
 	if err != nil {
 		return false, fmt.Errorf("agent CI fix: %w", err)

--- a/internal/pipeline/steps/document.go
+++ b/internal/pipeline/steps/document.go
@@ -66,7 +66,7 @@ Previous documentation findings to address:
 			Prompt:     fixPrompt,
 			CWD:        sctx.WorkDir,
 			JSONSchema: commitSummarySchema,
-			OnChunk:    sctx.Log,
+			OnChunk:    sctx.LogChunk,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("agent document fix: %w", err)
@@ -142,7 +142,7 @@ Rules:
 		Prompt:     prompt,
 		CWD:        sctx.WorkDir,
 		JSONSchema: findingsSchema,
-		OnChunk:    sctx.Log,
+		OnChunk:    sctx.LogChunk,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("agent document: %w", err)

--- a/internal/pipeline/steps/lint.go
+++ b/internal/pipeline/steps/lint.go
@@ -51,7 +51,7 @@ Previous lint findings to address:
 			Prompt:     fixPrompt,
 			CWD:        sctx.WorkDir,
 			JSONSchema: commitSummarySchema,
-			OnChunk:    sctx.Log,
+			OnChunk:    sctx.LogChunk,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("agent fix lint: %w", err)
@@ -93,7 +93,7 @@ Rules:
 			),
 			CWD:        sctx.WorkDir,
 			JSONSchema: findingsSchema,
-			OnChunk:    sctx.Log,
+			OnChunk:    sctx.LogChunk,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("agent lint: %w", err)

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -230,7 +230,7 @@ Diff stat:
 		Prompt:     prompt,
 		CWD:        sctx.WorkDir,
 		JSONSchema: prContentSchema,
-		OnChunk:    sctx.Log,
+		OnChunk:    sctx.LogChunk,
 	})
 	if err != nil {
 		slog.Warn("agent failed for PR content, using fallback", "error", err)

--- a/internal/pipeline/steps/rebase.go
+++ b/internal/pipeline/steps/rebase.go
@@ -256,7 +256,7 @@ Instructions:
 		Prompt:     prompt,
 		CWD:        sctx.WorkDir,
 		JSONSchema: commitSummarySchema,
-		OnChunk:    sctx.Log,
+		OnChunk:    sctx.LogChunk,
 	})
 	if err != nil {
 		_, _ = git.Run(ctx, sctx.WorkDir, "rebase", "--abort")

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -73,7 +73,7 @@ Previous review findings to address:
 			Prompt:     fixPrompt,
 			CWD:        sctx.WorkDir,
 			JSONSchema: commitSummarySchema,
-			OnChunk:    sctx.Log,
+			OnChunk:    sctx.LogChunk,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("agent fix: %w", err)
@@ -183,7 +183,7 @@ Risk assessment (after listing all findings):
 		Prompt:     prompt,
 		CWD:        sctx.WorkDir,
 		JSONSchema: reviewFindingsSchema,
-		OnChunk:    sctx.Log,
+		OnChunk:    sctx.LogChunk,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("agent review: %w", err)

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -387,15 +387,16 @@ func newTestContext(t *testing.T, ag agent.Agent, workDir, baseSHA, headSHA stri
 	t.Cleanup(func() { database.Close() })
 
 	return &pipeline.StepContext{
-		Ctx:     context.Background(),
-		Run:     &db.Run{ID: "run-1", RepoID: "repo-1", Branch: "refs/heads/feature", HeadSHA: headSHA, BaseSHA: baseSHA},
-		Repo:    &db.Repo{ID: "repo-1", WorkingPath: workDir, UpstreamURL: "https://github.com/test/repo", DefaultBranch: "main"},
-		WorkDir: workDir,
-		Agent:   ag,
-		Config:  &config.Config{Agent: types.AgentClaude, Commands: cmds},
-		DB:      database,
-		Log:     func(s string) {},
-		LogFile: func(s string) {},
+		Ctx:      context.Background(),
+		Run:      &db.Run{ID: "run-1", RepoID: "repo-1", Branch: "refs/heads/feature", HeadSHA: headSHA, BaseSHA: baseSHA},
+		Repo:     &db.Repo{ID: "repo-1", WorkingPath: workDir, UpstreamURL: "https://github.com/test/repo", DefaultBranch: "main"},
+		WorkDir:  workDir,
+		Agent:    ag,
+		Config:   &config.Config{Agent: types.AgentClaude, Commands: cmds},
+		DB:       database,
+		Log:      func(s string) {},
+		LogChunk: func(s string) {},
+		LogFile:  func(s string) {},
 	}
 }
 

--- a/internal/pipeline/steps/test.go
+++ b/internal/pipeline/steps/test.go
@@ -53,7 +53,7 @@ Previous test findings to address:
 			Prompt:     fixPrompt,
 			CWD:        sctx.WorkDir,
 			JSONSchema: commitSummarySchema,
-			OnChunk:    sctx.Log,
+			OnChunk:    sctx.LogChunk,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("agent fix tests: %w", err)
@@ -101,7 +101,7 @@ Rules:
 			),
 			CWD:        sctx.WorkDir,
 			JSONSchema: findingsSchema,
-			OnChunk:    sctx.Log,
+			OnChunk:    sctx.LogChunk,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("agent run tests: %w", err)

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1115,7 +1115,7 @@ func (m *Model) applyEvent(event ipc.Event) {
 			}
 
 			if text != "" {
-				lines := strings.Split(strings.TrimRight(text, "\n"), "\n")
+				lines := strings.Split(strings.TrimSuffix(text, "\n"), "\n")
 				m.logs = append(m.logs, lines...)
 			}
 			if m.logPartial != "" {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -7669,6 +7669,43 @@ func TestModel_ApplyEvent_LogChunk_FlushesPartialOnRunCompleted(t *testing.T) {
 	}
 }
 
+func TestModel_ApplyEvent_LogChunk_BlankLineSeparators(t *testing.T) {
+	// The executor's Log callback formats discrete messages as "text\n\n",
+	// with a leading \n only when flushing an unterminated streaming partial.
+	run := testRun()
+	m := NewModel("/tmp/sock", nil, run)
+
+	// Streaming agent text without trailing newline (partial).
+	m.applyEvent(ipc.Event{
+		Type:    ipc.EventLogChunk,
+		RunID:   run.ID,
+		Content: ptr("streaming text"),
+	})
+	// Discrete message after unterminated stream: leading \n flushes partial.
+	m.applyEvent(ipc.Event{
+		Type:    ipc.EventLogChunk,
+		RunID:   run.ID,
+		Content: ptr("\ncommitted agent fixes\n\n"),
+	})
+	// Consecutive discrete message: no leading \n (previous ended with \n\n).
+	m.applyEvent(ipc.Event{
+		Type:    ipc.EventLogChunk,
+		RunID:   run.ID,
+		Content: ptr("reviewing changes...\n\n"),
+	})
+
+	// Exactly one blank line between each entry.
+	want := []string{"streaming text", "committed agent fixes", "", "reviewing changes...", ""}
+	if len(m.logs) != len(want) {
+		t.Fatalf("expected %d log entries, got %d: %v", len(want), len(m.logs), m.logs)
+	}
+	for i, w := range want {
+		if m.logs[i] != w {
+			t.Errorf("logs[%d] = %q, want %q", i, m.logs[i], w)
+		}
+	}
+}
+
 func TestPipelineConnectors_NotSuppressedDuringCI(t *testing.T) {
 	// When CI is active in responsive layout (wide terminal), the pipeline
 	// height should not be capped, so connector lines between steps are preserved.


### PR DESCRIPTION
## Summary
- Update pipeline log handling to preserve discrete output chunks instead of flattening them together, so step logs render correctly through the executor and TUI.
- Align pipeline steps with the new logging flow by switching call sites to the chunk-aware interface, keeping pipeline output behavior consistent across review, test, lint, document, CI, PR, and rebase steps.
- Add executor, step, and TUI coverage for the new log-chunk behavior to prevent regressions in how streamed pipeline output is displayed.

## Risk Assessment

✅ Low: The change is narrowly scoped to log chunk formatting and TUI consumption, and the updated behavior is covered by focused tests without exposing an obvious correctness or regression risk in the changed paths.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
