### PR TITLE
fix(tui): preserve review timer across auto-fixes

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1063,8 +1063,12 @@ func (m *Model) applyEvent(event ipc.Event) {
 		if event.StepName != nil && event.Status != nil && types.StepStatus(*event.Status) == types.StepStatusFixing {
 			var accumulated time.Duration
 			for _, s := range m.steps {
-				if s.StepName == *event.StepName && s.DurationMS != nil {
-					accumulated = time.Duration(*s.DurationMS) * time.Millisecond
+				if s.StepName == *event.StepName {
+					if s.DurationMS != nil {
+						accumulated = time.Duration(*s.DurationMS) * time.Millisecond
+					} else if startTime, ok := m.stepStartTimes[*event.StepName]; ok {
+						accumulated = time.Since(startTime)
+					}
 					break
 				}
 			}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -5603,6 +5603,40 @@ func TestModel_FixingEventDoesNotFreezeDuration(t *testing.T) {
 	t.Fatal("Review step not found")
 }
 
+// Test: When a running step auto-fixes (no approval in between), the live timer
+// must continue accumulating from the original start time, not reset to 0.
+func TestModel_AutoFixPreservesAccumulatedElapsed(t *testing.T) {
+	configureTUIColors()
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusRunning
+
+	m := NewModel("", nil, run)
+	m.stepStartTimes[types.StepReview] = time.Now().Add(-5 * time.Second)
+
+	fixingStatus := string(types.StepStatusFixing)
+	stepName := types.StepReview
+	m.applyEvent(ipc.Event{
+		Type:     ipc.EventStepCompleted,
+		StepName: &stepName,
+		Status:   &fixingStatus,
+	})
+
+	// stepsWithRunningElapsed should report ~5s of accumulated time, not 0.
+	elapsed := m.stepsWithRunningElapsed()
+	for _, s := range elapsed {
+		if s.StepName == types.StepReview {
+			if s.DurationMS == nil {
+				t.Fatal("expected stepsWithRunningElapsed to compute live elapsed for Fixing step")
+			}
+			if *s.DurationMS < 4500 {
+				t.Errorf("expected accumulated elapsed >= 4500ms, got %dms (timer reset to 0)", *s.DurationMS)
+			}
+			return
+		}
+	}
+	t.Fatal("Review step not found")
+}
+
 // Test: When a step already has DurationMS persisted (e.g. from AwaitingApproval)
 // and then transitions to Fixing, the stale DurationMS must be cleared and the
 // live timer must accumulate from the previous execution time.


### PR DESCRIPTION
## Summary
- Keep the TUI review timer's accumulated elapsed time when a step auto-fixes itself so the timer no longer resets between attempts.
- Add regression coverage for the auto-fix flow to lock in the preserved-timer behavior and prevent the reset bug from returning.

## Risk Assessment

✅ Low: The change is narrowly scoped to TUI timer carry-over during fixing, matches the executor's event lifecycle, and is covered by focused regression tests without introducing broader behavioral surface area.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
