### PR TITLE
fix(tui): show findings navigation hint for multiple findings

### DIFF
--- a/docs/src/content/docs/guides/tui.md
+++ b/docs/src/content/docs/guides/tui.md
@@ -66,7 +66,7 @@ When a step pauses for approval, the findings panel shows structured results:
 - Severity icons: `E` (error, red), `W` (warning, yellow), `I` (info, blue)
 - Checkboxes: `[x]` (selected, green), `[ ]` (deselected, dim)
 - Blue `>` marks the focused finding
-- Scroll hint at the bottom when content overflows: `↑ N above / ↓ N more below (j/k)`
+- Bottom hint shows `↑ N above / ↓ N more below (j/k)` when scrolling, or `(j/k)` whenever there are multiple findings
 
 ### Diff panel
 

--- a/internal/tui/review.go
+++ b/internal/tui/review.go
@@ -333,6 +333,8 @@ func renderFindingsRange(f *findings, width int, cursor int, selected map[string
 		scrollFooter = fmt.Sprintf("↓ %d more below (j/k)", remaining)
 	} else if start > 0 {
 		scrollFooter = fmt.Sprintf("↑ %d above (j/k)", start)
+	} else if len(f.Items) > 1 {
+		scrollFooter = "(j/k)"
 	}
 
 	// Selection count by severity when not all findings are selected.

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -3742,6 +3742,20 @@ func TestRenderFindings_BothIndicatorsIncludeKeyHints(t *testing.T) {
 	}
 }
 
+func TestRenderFindings_NoScrollStillShowsJKHint(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.ANSI)
+	// 2 findings that all fit on screen - no scrolling needed.
+	raw := makeManyFindings(2)
+	selected := map[string]bool{"f1": true, "f2": true}
+
+	// Large maxVisible so everything fits without scrolling.
+	_, scrollFooter := renderFindingsWithSelection(raw, 80, 0, selected, 10)
+
+	if !strings.Contains(scrollFooter, "j/k") {
+		t.Errorf("expected j/k hint even when all findings fit, got: %q", scrollFooter)
+	}
+}
+
 func TestFindingsBox_ScrollDownInBottomBorder(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.ANSI)
 	run := testRun()


### PR DESCRIPTION
## Summary
- Show the findings panel `j/k` navigation hint whenever there are multiple findings, even if they all fit on screen, so keyboard navigation is discoverable.
- Add TUI coverage for the new hint behavior to prevent regressions.
- Update the TUI guide to match the revised findings hint behavior.

## Risk Assessment

✅ Low: The change is a small, well-tested TUI hint update with no evident correctness, safety, or maintainability issues in the modified code.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 info
- ℹ️ `docs/src/content/docs/guides/tui.md:69` - The TUI guide says the bottom `j/k` hint only appears when findings content overflows, but this change now shows `(j/k)` whenever there are multiple findings even if they all fit on screen. Update the findings panel docs to describe the new always-visible navigation hint behavior.

**Round 2** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
