### PR TITLE
Fix updater self-update and install.sh for user-owned paths on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build output
 bin/
+tmp/
 
 # Go
 *.exe

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ $ no-mistakes
 curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh
 ```
 
+The installer keeps the real binary in `~/.no-mistakes/bin` and exposes `no-mistakes` through a symlink in `~/.local/bin` or `/usr/local/bin`. That keeps future `no-mistakes update` runs in a user-owned location instead of rewriting a system binary in place.
+
 **Windows (PowerShell)**
 
 ```powershell

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -45,21 +45,31 @@ echo "Downloading no-mistakes ${VERSION} for ${OS}/${ARCH}..."
 curl -fsSL "$URL" -o "${TMPDIR}/${FILENAME}"
 tar xzf "${TMPDIR}/${FILENAME}" -C "$TMPDIR"
 
-mkdir -p "$INSTALL_DIR" 2>/dev/null || true
+if ! mkdir -p "$INSTALL_DIR" 2>/dev/null; then
+  echo "Could not create install directory: $INSTALL_DIR"
+  exit 1
+fi
 
 mv "${TMPDIR}/no-mistakes" "$BIN_PATH"
 chmod 755 "$BIN_PATH" 2>/dev/null || true
 
-mkdir -p "$LINK_DIR" 2>/dev/null || true
-
-if [ -w "$LINK_DIR" ]; then
-  rm -f "$LINK_PATH"
-  ln -s "$BIN_PATH" "$LINK_PATH"
+if [ "$BIN_PATH" = "$LINK_PATH" ]; then
+  echo "Install dir and link dir are the same; skipping symlink."
 else
-  echo "Linking ${LINK_PATH} to ${BIN_PATH} (requires sudo)..."
-  sudo mkdir -p "$LINK_DIR"
-  sudo rm -f "$LINK_PATH"
-  sudo ln -s "$BIN_PATH" "$LINK_PATH"
+  if ! mkdir -p "$LINK_DIR" 2>/dev/null; then
+    echo "Could not create link directory: $LINK_DIR"
+    exit 1
+  fi
+
+  if [ -w "$LINK_DIR" ]; then
+    rm -f "$LINK_PATH"
+    ln -s "$BIN_PATH" "$LINK_PATH"
+  else
+    echo "Linking ${LINK_PATH} to ${BIN_PATH} (requires sudo)..."
+    sudo mkdir -p "$LINK_DIR"
+    sudo rm -f "$LINK_PATH"
+    sudo ln -s "$BIN_PATH" "$LINK_PATH"
+  fi
 fi
 
 echo "no-mistakes ${VERSION} installed to ${BIN_PATH}"

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -63,7 +63,7 @@ REAL_LINK_DIR="$(resolve_path "$LINK_DIR" 2>/dev/null || echo "")"
 if [ -n "$REAL_INSTALL_DIR" ] && [ "$REAL_INSTALL_DIR" = "$REAL_LINK_DIR" ]; then
   echo "Install dir and link dir resolve to the same path; skipping symlink."
 else
-  if [ -w "$LINK_DIR" ] || mkdir -p "$LINK_DIR" 2>/dev/null; then
+  if [ -w "$LINK_DIR" ] || (mkdir -p "$LINK_DIR" 2>/dev/null && [ -w "$LINK_DIR" ]); then
     rm -f "$LINK_PATH"
     ln -s "$BIN_PATH" "$LINK_PATH"
   else

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -2,11 +2,18 @@
 set -e
 
 REPO="kunchenguid/no-mistakes"
+INSTALL_DIR="${NO_MISTAKES_INSTALL_DIR:-$HOME/.no-mistakes/bin}"
+LINK_DIR="${NO_MISTAKES_LINK_DIR:-}"
 
-case ":$PATH:" in
-  *":$HOME/.local/bin:"*) INSTALL_DIR="$HOME/.local/bin" ;;
-  *) INSTALL_DIR="/usr/local/bin" ;;
-esac
+if [ -z "$LINK_DIR" ]; then
+  case ":$PATH:" in
+    *":$HOME/.local/bin:"*) LINK_DIR="$HOME/.local/bin" ;;
+    *) LINK_DIR="/usr/local/bin" ;;
+  esac
+fi
+
+BIN_PATH="$INSTALL_DIR/no-mistakes"
+LINK_PATH="$LINK_DIR/no-mistakes"
 
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 ARCH="$(uname -m)"
@@ -40,13 +47,25 @@ tar xzf "${TMPDIR}/${FILENAME}" -C "$TMPDIR"
 
 mkdir -p "$INSTALL_DIR" 2>/dev/null || true
 
-if [ -w "$INSTALL_DIR" ]; then
-  mv "${TMPDIR}/no-mistakes" "${INSTALL_DIR}/no-mistakes"
+mv "${TMPDIR}/no-mistakes" "$BIN_PATH"
+chmod 755 "$BIN_PATH" 2>/dev/null || true
+
+mkdir -p "$LINK_DIR" 2>/dev/null || true
+
+if [ -w "$LINK_DIR" ]; then
+  rm -f "$LINK_PATH"
+  ln -s "$BIN_PATH" "$LINK_PATH"
 else
-  echo "Installing to ${INSTALL_DIR} (requires sudo)..."
-  sudo mkdir -p "$INSTALL_DIR"
-  sudo mv "${TMPDIR}/no-mistakes" "${INSTALL_DIR}/no-mistakes"
+  echo "Linking ${LINK_PATH} to ${BIN_PATH} (requires sudo)..."
+  sudo mkdir -p "$LINK_DIR"
+  sudo rm -f "$LINK_PATH"
+  sudo ln -s "$BIN_PATH" "$LINK_PATH"
 fi
 
-chmod 755 "${INSTALL_DIR}/no-mistakes" 2>/dev/null || true
-echo "no-mistakes ${VERSION} installed to ${INSTALL_DIR}/no-mistakes"
+echo "no-mistakes ${VERSION} installed to ${BIN_PATH}"
+echo "Command path: ${LINK_PATH} -> ${BIN_PATH}"
+
+case ":$PATH:" in
+  *":$LINK_DIR:"*) ;;
+  *) echo "Add ${LINK_DIR} to your PATH and restart your terminal." ;;
+esac

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -45,7 +45,7 @@ echo "Downloading no-mistakes ${VERSION} for ${OS}/${ARCH}..."
 curl -fsSL "$URL" -o "${TMPDIR}/${FILENAME}"
 tar xzf "${TMPDIR}/${FILENAME}" -C "$TMPDIR"
 
-if ! mkdir -p "$INSTALL_DIR" 2>/dev/null; then
+if ! mkdir -p "$INSTALL_DIR"; then
   echo "Could not create install directory: $INSTALL_DIR"
   exit 1
 fi
@@ -53,15 +53,17 @@ fi
 mv "${TMPDIR}/no-mistakes" "$BIN_PATH"
 chmod 755 "$BIN_PATH" 2>/dev/null || true
 
-if [ "$BIN_PATH" = "$LINK_PATH" ]; then
-  echo "Install dir and link dir are the same; skipping symlink."
-else
-  if ! mkdir -p "$LINK_DIR" 2>/dev/null; then
-    echo "Could not create link directory: $LINK_DIR"
-    exit 1
-  fi
+resolve_path() {
+  (cd "$1" 2>/dev/null && pwd -P)
+}
 
-  if [ -w "$LINK_DIR" ]; then
+REAL_INSTALL_DIR="$(resolve_path "$INSTALL_DIR")"
+REAL_LINK_DIR="$(resolve_path "$LINK_DIR" 2>/dev/null || echo "")"
+
+if [ -n "$REAL_INSTALL_DIR" ] && [ "$REAL_INSTALL_DIR" = "$REAL_LINK_DIR" ]; then
+  echo "Install dir and link dir resolve to the same path; skipping symlink."
+else
+  if [ -w "$LINK_DIR" ] || mkdir -p "$LINK_DIR" 2>/dev/null; then
     rm -f "$LINK_PATH"
     ln -s "$BIN_PATH" "$LINK_PATH"
   else

--- a/install_script_test.go
+++ b/install_script_test.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestInstallScriptInstallsUserOwnedBinaryAndPathSymlink(t *testing.T) {
+	home := t.TempDir()
+	archivePath := filepath.Join(t.TempDir(), "no-mistakes-v1.2.3-darwin-arm64.tar.gz")
+	makeInstallArchive(t, archivePath, "new-binary")
+	fakeBin := makeFakeInstallCommands(t)
+	localBin := filepath.Join(home, ".local", "bin")
+	if err := os.MkdirAll(localBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	runInstallScript(t, home, fakeBin, map[string]string{
+		"FAKE_RELEASE_ARCHIVE": archivePath,
+	})
+
+	realBin := filepath.Join(home, ".no-mistakes", "bin", "no-mistakes")
+	assertFileContent(t, realBin, "new-binary")
+	assertSymlinkTarget(t, filepath.Join(localBin, "no-mistakes"), realBin)
+}
+
+func TestInstallScriptReplacesExistingPathEntryWithSymlink(t *testing.T) {
+	home := t.TempDir()
+	archivePath := filepath.Join(t.TempDir(), "no-mistakes-v1.2.3-darwin-arm64.tar.gz")
+	makeInstallArchive(t, archivePath, "new-binary")
+	fakeBin := makeFakeInstallCommands(t)
+	linkDir := filepath.Join(t.TempDir(), "link-bin")
+	if err := os.MkdirAll(linkDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldPath := filepath.Join(linkDir, "no-mistakes")
+	if err := os.WriteFile(oldPath, []byte("old-binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	runInstallScript(t, home, fakeBin, map[string]string{
+		"FAKE_RELEASE_ARCHIVE": archivePath,
+		"NO_MISTAKES_LINK_DIR": linkDir,
+	})
+
+	realBin := filepath.Join(home, ".no-mistakes", "bin", "no-mistakes")
+	assertFileContent(t, realBin, "new-binary")
+	assertSymlinkTarget(t, oldPath, realBin)
+}
+
+func runInstallScript(t *testing.T, home, fakeBin string, extraEnv map[string]string) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "sh", "docs/install.sh")
+	pathValue := strings.Join([]string{fakeBin, filepath.Join(home, ".local", "bin"), os.Getenv("PATH")}, string(os.PathListSeparator))
+	cmd.Env = append(filteredEnv(os.Environ(), "HOME", "PATH"), []string{
+		"HOME=" + home,
+		"PATH=" + pathValue,
+	}...)
+	for key, value := range extraEnv {
+		cmd.Env = append(cmd.Env, key+"="+value)
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("install.sh failed: %v\n%s", err, output)
+	}
+}
+
+func filteredEnv(env []string, excluded ...string) []string {
+	blocked := make(map[string]struct{}, len(excluded))
+	for _, key := range excluded {
+		blocked[key] = struct{}{}
+	}
+	filtered := make([]string, 0, len(env))
+	for _, entry := range env {
+		key, _, found := strings.Cut(entry, "=")
+		if !found {
+			filtered = append(filtered, entry)
+			continue
+		}
+		if _, skip := blocked[key]; skip {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}
+
+func makeInstallArchive(t *testing.T, archivePath, binaryContent string) {
+	t.Helper()
+
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	gz := gzip.NewWriter(file)
+	tw := tar.NewWriter(gz)
+	data := []byte(binaryContent)
+	hdr := &tar.Header{Name: "no-mistakes", Mode: 0o755, Size: int64(len(data))}
+	if err := tw.WriteHeader(hdr); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func makeFakeInstallCommands(t *testing.T) string {
+	t.Helper()
+
+	binDir := t.TempDir()
+	writeExecutable(t, filepath.Join(binDir, "uname"), `#!/bin/sh
+case "$1" in
+  -s) printf 'Darwin\n' ;;
+  -m) printf 'arm64\n' ;;
+  *) command uname "$@" ;;
+esac
+`)
+	writeExecutable(t, filepath.Join(binDir, "curl"), `#!/bin/sh
+out=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    -*) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+if [ -n "$out" ]; then
+  cp "$FAKE_RELEASE_ARCHIVE" "$out"
+  exit 0
+fi
+	printf '{"tag_name":"v1.2.3"}'
+`)
+	writeExecutable(t, filepath.Join(binDir, "sudo"), "#!/bin/sh\nexec \"$@\"\n")
+	return binDir
+}
+
+func writeExecutable(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != want {
+		t.Fatalf("file %s = %q, want %q", path, string(data), want)
+	}
+}
+
+func assertSymlinkTarget(t *testing.T, path, wantTarget string) {
+	t.Helper()
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("%s is not a symlink", path)
+	}
+	target, err := os.Readlink(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != wantTarget {
+		t.Fatalf("symlink %s -> %s, want %s", path, target, wantTarget)
+	}
+}

--- a/install_script_test.go
+++ b/install_script_test.go
@@ -7,12 +7,15 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 )
 
 func TestInstallScriptInstallsUserOwnedBinaryAndPathSymlink(t *testing.T) {
+	skipInstallScriptTestsOnWindows(t)
+
 	home := t.TempDir()
 	archivePath := filepath.Join(t.TempDir(), "no-mistakes-v1.2.3-darwin-arm64.tar.gz")
 	makeInstallArchive(t, archivePath, "new-binary")
@@ -32,6 +35,8 @@ func TestInstallScriptInstallsUserOwnedBinaryAndPathSymlink(t *testing.T) {
 }
 
 func TestInstallScriptReplacesExistingPathEntryWithSymlink(t *testing.T) {
+	skipInstallScriptTestsOnWindows(t)
+
 	home := t.TempDir()
 	archivePath := filepath.Join(t.TempDir(), "no-mistakes-v1.2.3-darwin-arm64.tar.gz")
 	makeInstallArchive(t, archivePath, "new-binary")
@@ -53,6 +58,13 @@ func TestInstallScriptReplacesExistingPathEntryWithSymlink(t *testing.T) {
 	realBin := filepath.Join(home, ".no-mistakes", "bin", "no-mistakes")
 	assertFileContent(t, realBin, "new-binary")
 	assertSymlinkTarget(t, oldPath, realBin)
+}
+
+func skipInstallScriptTestsOnWindows(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("install.sh is a POSIX installer; Windows uses install.ps1")
+	}
 }
 
 func runInstallScript(t *testing.T, home, fakeBin string, extraEnv map[string]string) {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -490,30 +490,42 @@ func replaceExecutable(target string, binaryData []byte) error {
 		return fmt.Errorf("stat executable: %w", err)
 	}
 	perm := info.Mode().Perm()
-	dir := filepath.Dir(target)
-	tmp, err := os.CreateTemp(dir, filepath.Base(target)+"-new-*")
-	if err == nil {
-		tmpPath := tmp.Name()
-		if _, writeErr := tmp.Write(binaryData); writeErr == nil {
-			writeErr = tmp.Close()
-			if writeErr == nil {
-				writeErr = os.Chmod(tmpPath, perm)
-			}
-			if writeErr == nil {
-				writeErr = os.Rename(tmpPath, target)
-			}
-			if writeErr == nil {
-				removeQuarantine(target)
-				return nil
-			}
-		}
-		tmp.Close()
-		_ = os.Remove(tmp.Name())
+	if err := replaceExecutableAtomically(target, binaryData, perm); err == nil {
+		removeQuarantine(target)
+		return nil
+	} else if runtime.GOOS == "darwin" {
+		return fmt.Errorf("self-update requires an atomic replace on macOS; reinstall no-mistakes so the PATH entry points at a user-owned binary, then retry update: %w", err)
 	}
 	if err := overwriteExecutable(target, binaryData, perm); err != nil {
 		return err
 	}
 	removeQuarantine(target)
+	return nil
+}
+
+func replaceExecutableAtomically(target string, binaryData []byte, perm os.FileMode) error {
+	dir := filepath.Dir(target)
+	tmp, err := os.CreateTemp(dir, filepath.Base(target)+"-new-*")
+	if err != nil {
+		return fmt.Errorf("create temp executable: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+	}()
+	if _, err := tmp.Write(binaryData); err != nil {
+		return fmt.Errorf("write temp executable: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp executable: %w", err)
+	}
+	if err := os.Chmod(tmpPath, perm); err != nil {
+		return fmt.Errorf("chmod temp executable: %w", err)
+	}
+	if err := os.Rename(tmpPath, target); err != nil {
+		return fmt.Errorf("rename temp executable: %w", err)
+	}
 	return nil
 }
 

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -338,6 +339,42 @@ func TestUpdaterRunReplacesExecutable(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "updated no-mistakes") {
 		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestReplaceExecutableDarwinRequiresAtomicReplace(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-specific behavior")
+	}
+
+	dir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	execPath := filepath.Join(dir, "no-mistakes")
+	if err := os.WriteFile(execPath, []byte("old-binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(dir, 0o755)
+	})
+
+	err := replaceExecutable(execPath, []byte("new-binary"))
+	if err == nil {
+		t.Fatal("replaceExecutable should fail when atomic replacement is unavailable on darwin")
+	}
+	if !strings.Contains(err.Error(), "reinstall") {
+		t.Fatalf("replaceExecutable error = %v", err)
+	}
+	content, readErr := os.ReadFile(execPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(content) != "old-binary" {
+		t.Fatalf("executable content = %q", string(content))
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Updater**: Extract atomic-replace logic into its own function and fail explicitly on macOS when atomic rename isn't possible (e.g. system-owned `/usr/local/bin`), instead of silently falling back to in-place overwrite which macOS code-signing rejects. Error message tells the user to reinstall so the binary lives in a user-owned location.
- **install.sh**: Rewrite to install the real binary to `~/.no-mistakes/bin/` (user-owned) and create a symlink in `~/.local/bin` or `/usr/local/bin`. Adds `sudo` fallback only for the symlink dir when it isn't writable, resolves paths before comparing to avoid duplicate symlinks, and surfaces `mkdir` failures instead of swallowing them.
- **Tests**: Add `TestReplaceExecutableDarwinRequiresAtomicReplace` (read-only dir on darwin) and two install-script integration tests that exercise the symlink-based flow with fake `curl`/`uname` stubs.
- **Docs**: README now explains the install layout (binary in `~/.no-mistakes/bin`, symlink on PATH).

## Test plan

- [ ] `go test -race ./internal/update` - verify atomic-replace extraction and darwin-specific error
- [ ] `go test -race ./...` - verify install script integration tests pass (darwin)
- [ ] Run `docs/install.sh` on a clean macOS machine and confirm binary lands in `~/.no-mistakes/bin` with symlink in `~/.local/bin`
- [ ] Run `no-mistakes update` after installing via the new script and confirm atomic replace succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)