### PR TITLE
fix(tui): use available height for stacked log tail

### DIFF
--- a/docs/src/content/docs/guides/tui.md
+++ b/docs/src/content/docs/guides/tui.md
@@ -81,6 +81,8 @@ After a fix cycle, press `d` to toggle the diff view:
 
 During running steps, shows streaming agent output. Lines starting with `PASS` are green, `FAIL` are red, everything else is dim.
 
+On narrow terminals, the log panel expands to fill the remaining vertical space below the pipeline box instead of staying at the compact fixed height used in shorter layouts.
+
 ## Keybindings
 
 ### Navigation

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -363,13 +363,20 @@ func (m Model) View() string {
 	// Log tail in a box - adaptive line count based on terminal height.
 	// In responsive layout with no other right-column content, expand to
 	// fill the remaining vertical budget so the log panel matches the
-	// pipeline panel height. Otherwise use compact defaults.
+	// pipeline panel height. In stacked layout, use the remaining content
+	// budget so the log box can consume the available terminal height.
 	// Also hidden when CI is active (log context integrated into CI box).
 	logLines := 5
-	if useResponsiveLayout && !m.showHelp && contentBudget > 0 && len(extraSections) == 0 {
-		logLines = contentBudget - 2 // subtract box borders
-		if actionBar != "" {
-			logLines -= sectionGapHeight
+	if !m.showHelp && contentBudget > 0 {
+		if useResponsiveLayout {
+			if len(extraSections) == 0 {
+				logLines = contentBudget - 2 // subtract box borders
+				if actionBar != "" {
+					logLines -= sectionGapHeight
+				}
+			}
+		} else {
+			logLines = contentBudget - 2 // subtract box borders
 		}
 	} else if m.height > 0 && m.height < 30 {
 		logLines = 3

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -4208,18 +4208,26 @@ func TestOutcomeBanner_NoDurationWhenNoStepTimes(t *testing.T) {
 }
 
 func TestModel_View_LogTailCompact(t *testing.T) {
-	// In small terminals (height 20-29), log tail should show only 3 lines instead of 5.
+	// In stacked layout, compact terminals should still use the remaining height budget.
+	prev := lipgloss.ColorProfile()
+	defer lipgloss.SetColorProfile(prev)
+
+	lipgloss.SetColorProfile(termenv.Ascii)
 	run := testRun()
 	m := NewModel("/tmp/sock", nil, run)
 	m.width = 80
-	m.height = 25 // compact range
-	for i := 1; i <= 10; i++ {
+	m.height = 25
+	for i := 1; i <= 20; i++ {
 		m.logs = append(m.logs, fmt.Sprintf("log line %d", i))
 	}
-	view := m.View()
+
+	view := stripANSI(m.View())
 	count := strings.Count(view, "log line")
-	if count != 3 {
-		t.Errorf("expected 3 log lines in compact mode (height=25), got %d", count)
+	if count <= 3 {
+		t.Fatalf("expected compact stacked layout to expand beyond the old 3-line cap, got %d\n%s", count, view)
+	}
+	if got := lipgloss.Height(view); got != m.height {
+		t.Fatalf("expected compact stacked layout to use full terminal height %d, got %d\n%s", m.height, got, view)
 	}
 }
 
@@ -4259,19 +4267,33 @@ func TestModel_View_ShortTerminalDoesNotOverflowHeight(t *testing.T) {
 	}
 }
 
-func TestModel_View_LogTailNormalShowsFive(t *testing.T) {
-	// In normal terminals (height >= 30), log tail should show 5 lines.
+func TestModel_View_StackedLogBoxFillsRemainingHeight(t *testing.T) {
+	prev := lipgloss.ColorProfile()
+	defer lipgloss.SetColorProfile(prev)
+
+	lipgloss.SetColorProfile(termenv.Ascii)
 	run := testRun()
 	m := NewModel("/tmp/sock", nil, run)
 	m.width = 80
-	m.height = 40 // normal terminal
-	for i := 1; i <= 10; i++ {
+	m.height = 40
+	for i := 1; i <= 40; i++ {
 		m.logs = append(m.logs, fmt.Sprintf("log line %d", i))
 	}
-	view := m.View()
+
+	pipelineView := renderPipelineView(run, m.stepsWithRunningElapsed(), m.width, 0, m.height)
+	footer := renderFooter(false, false, false, run.PRURL, m.width)
+	expectedLogLines := m.height - sectionsHeight([]string{pipelineView}, 2) - 2 - lipgloss.Height(footer) - 2
+	if expectedLogLines <= 5 {
+		t.Fatalf("expected stacked layout to leave room for more than 5 log lines, got %d", expectedLogLines)
+	}
+
+	view := stripANSI(m.View())
 	count := strings.Count(view, "log line")
-	if count != 5 {
-		t.Errorf("expected 5 log lines in normal mode (height=40), got %d", count)
+	if count != expectedLogLines {
+		t.Fatalf("expected stacked log box to fill remaining height with %d log lines, got %d\n%s", expectedLogLines, count, view)
+	}
+	if got := lipgloss.Height(view); got > m.height {
+		t.Fatalf("expected rendered view height <= terminal height (%d), got %d\n%s", m.height, got, view)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Update the TUI log box layout so stacked views on narrow terminals use the remaining vertical space instead of staying at the old fixed height.
- Extend TUI coverage to lock in the new vertical sizing behavior and avoid regressions in constrained layouts.
- Document the stacked log tail behavior in the TUI guide so the docs match the current interface.

## Risk Assessment

✅ Low: The change is narrowly scoped to stacked TUI log-box sizing and targeted tests, and the updated logic appears internally consistent without introducing obvious correctness or safety regressions in the reviewed diff.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `docs/src/content/docs/guides/tui.md:80` - The TUI guide&#39;s `Log tail` section does not document the new stacked-layout behavior introduced in this change: on narrow terminals, the log panel now expands to use the remaining vertical space instead of staying at the old fixed 3/5-line height. Add a short note so the layout guide matches the current UI behavior.

**Round 2** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
