### PR TITLE
fix(ci): handle merge conflicts in babysit and harden mergeability checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ agent_path_override:
   rovodev: /usr/local/bin/acli
   opencode: /usr/local/bin/opencode
 
-# How long the CI step monitors GitHub checks before timing out.
+# How long the babysit step waits for CI and PR mergeability before timing out.
 ci_timeout: "4h"
 
 # Optional auto-fix attempt limits per step (0 = require approval).
@@ -189,7 +189,7 @@ ci_timeout: "4h"
 #   test: 3
 #   review: 3
 #   document: 3
-#   ci: 3
+#   ci: 3        # shared by Babysit for CI failures and merge conflicts
 
 # debug | info | warn | error
 log_level: "info"

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -97,7 +97,7 @@ The pipeline runs these steps in order:
 5. **Lint** - run linters (configured command or agent-detected)
 6. **Push** - push to the real upstream remote
 7. **PR** - create or update a pull request
-8. **Babysit** - poll CI and auto-fix failures
+8. **Babysit** - poll CI, watch PR mergeability, and auto-fix failures or merge conflicts
 
 Steps that find issues pause for your approval. You can approve, fix, skip, or abort. See [Pipeline Steps](/no-mistakes/guides/pipeline-steps/) and [Auto-Fix](/no-mistakes/guides/auto-fix/) for details.
 

--- a/docs/src/content/docs/guides/auto-fix.md
+++ b/docs/src/content/docs/guides/auto-fix.md
@@ -27,10 +27,12 @@ auto_fix:
   test: 3
   document: 3
   lint: 3
-  ci: 3
+  ci: 3        # shared by Babysit for CI failures and merge conflicts
 ```
 
 Setting a step to `0` means the pipeline always pauses for human input when that step finds issues.
+
+`auto_fix.ci` applies to the Babysit step. The same limit covers both CI-failure fixes and merge-conflict fixes.
 
 Repo config overlays global config - you can set `auto_fix.lint: 5` in a repo's `.no-mistakes.yaml` to override just that step while inheriting the rest from global.
 

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -30,7 +30,7 @@ agent_path_override:
   rovodev: /usr/local/bin/acli
   opencode: /usr/local/bin/opencode
 
-# How long the babysit step polls CI before giving up.
+# How long the babysit step waits for CI and PR mergeability before timing out.
 ci_timeout: "4h"  # any Go duration string
 
 # Daemon log verbosity.

--- a/docs/src/content/docs/guides/pipeline-steps.md
+++ b/docs/src/content/docs/guides/pipeline-steps.md
@@ -128,14 +128,16 @@ Monitors PR health after creation and auto-fixes CI failures or merge conflicts.
 
 **Behavior:**
 - Polls `gh pr checks` at increasing intervals: every 30s for the first 5 minutes, every 60s for 5-15 minutes, every 120s after that
-- Polls `gh pr view --json mergeable` alongside CI checks and waits for GitHub to resolve mergeability before exiting cleanly
+- Polls `gh pr view --json mergeable` alongside CI checks and waits for GitHub to resolve mergeability before exiting
 - Waits a 60s grace period before trusting empty results (CI checks may not have registered yet)
 - On CI failure: fetches the failed run log (last 32KiB via `gh run view --log-failed`), sends it to the agent for fixing, and commits and force-pushes only if the agent produces changes
 - On merge conflict: asks the agent to rebase onto the latest default-branch tip and resolve the conflicts with minimal changes
 - If both CI failures and merge conflicts are present: fixes both in the same attempt
 - If a fix attempt produces no changes: automatic mode leaves the failure undeduplicated so it can retry until the auto-fix limit, while manual fix mode returns immediately for manual intervention
 - Deduplicates fix attempts only after a fix is actually committed and pushed
-- Exits cleanly when the PR is merged or closed, or when the timeout is reached (default 4h)
+- Exits cleanly when the PR is merged or closed, or when the timeout is reached with no known CI failures, merge conflicts, or unresolved mergeability state (default 4h)
+- If the timeout is reached while CI failures or a merge conflict are still known: pauses for user approval with findings for the remaining issues
+- If the timeout is reached while PR mergeability is still unresolved: pauses for user approval with a finding describing the unresolved mergeability state
 - If CI failures or merge conflicts persist after the auto-fix limit: pauses for user approval with findings listing each failing check and/or the merge conflict
 
 **Default auto-fix limit:** `3` total CI/Babysit auto-fix attempts.

--- a/docs/src/content/docs/guides/pipeline-steps.md
+++ b/docs/src/content/docs/guides/pipeline-steps.md
@@ -122,20 +122,23 @@ Stores the PR URL in the database and streams it to the TUI.
 
 ## Babysit
 
-Polls CI checks on the PR and auto-fixes failures.
+Monitors PR health after creation and auto-fixes CI failures or merge conflicts.
 
 **Only active for GitHub** (requires `gh` CLI, authenticated).
 
 **Behavior:**
 - Polls `gh pr checks` at increasing intervals: every 30s for the first 5 minutes, every 60s for 5-15 minutes, every 120s after that
+- Polls `gh pr view --json mergeable` alongside CI checks and waits for GitHub to resolve mergeability before exiting cleanly
 - Waits a 60s grace period before trusting empty results (CI checks may not have registered yet)
 - On CI failure: fetches the failed run log (last 32KiB via `gh run view --log-failed`), sends it to the agent for fixing, and commits and force-pushes only if the agent produces changes
+- On merge conflict: asks the agent to rebase onto the latest default-branch tip and resolve the conflicts with minimal changes
+- If both CI failures and merge conflicts are present: fixes both in the same attempt
 - If a fix attempt produces no changes: automatic mode leaves the failure undeduplicated so it can retry until the auto-fix limit, while manual fix mode returns immediately for manual intervention
 - Deduplicates fix attempts only after a fix is actually committed and pushed
 - Exits cleanly when the PR is merged or closed, or when the timeout is reached (default 4h)
-- If CI failures persist after the auto-fix limit: pauses for user approval with findings listing each failing check
+- If CI failures or merge conflicts persist after the auto-fix limit: pauses for user approval with findings listing each failing check and/or the merge conflict
 
-**Default auto-fix limit:** `3`.
+**Default auto-fix limit:** `3` total CI/Babysit auto-fix attempts.
 
 ## Step statuses
 

--- a/docs/src/content/docs/guides/pipeline-steps.md
+++ b/docs/src/content/docs/guides/pipeline-steps.md
@@ -130,6 +130,7 @@ Monitors PR health after creation and auto-fixes CI failures or merge conflicts.
 - Polls `gh pr checks` at increasing intervals: every 30s for the first 5 minutes, every 60s for 5-15 minutes, every 120s after that
 - Polls `gh pr view --json mergeable` alongside CI checks and waits for GitHub to resolve mergeability before exiting
 - Waits a 60s grace period before trusting empty results (CI checks may not have registered yet)
+- If CI failures or a merge conflict are already known while other checks are still pending: waits for all checks to finish before attempting an auto-fix
 - On CI failure: fetches the failed run log (last 32KiB via `gh run view --log-failed`), sends it to the agent for fixing, and commits and force-pushes only if the agent produces changes
 - On merge conflict: asks the agent to rebase onto the latest default-branch tip and resolve the conflicts with minimal changes
 - If both CI failures and merge conflicts are present: fixes both in the same attempt

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -30,7 +30,7 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
     pick what to fix, and decide when to ship.
   </Card>
   <Card title="CI babysitting" icon="sun">
-    After push, the pipeline watches CI checks and auto-fixes failures - so you
-    don't have to babysit your own PR.
+    After push, the pipeline watches CI and PR mergeability, and auto-fixes
+    failures or merge conflicts - so you don't have to babysit your own PR.
   </Card>
 </CardGrid>

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -63,7 +63,7 @@ Default binary names when no override is set:
 
 ### ci_timeout
 
-How long the babysit step polls CI before giving up.
+How long the babysit step waits for CI and PR mergeability before timing out.
 
 | | |
 |---|---|

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -99,7 +99,7 @@ Maximum auto-fix attempts per step. Set a step to `0` to disable auto-fix (findi
 | `auto_fix.test` | `int` | `3` | Test failure auto-fix attempts |
 | `auto_fix.document` | `int` | `3` | Documentation update auto-fix attempts |
 | `auto_fix.lint` | `int` | `3` | Lint issue auto-fix attempts |
-| `auto_fix.ci` | `int` | `3` | CI failure auto-fix attempts |
+| `auto_fix.ci` | `int` | `3` | CI/Babysit auto-fix attempts for CI failures and merge conflicts |
 
 Legacy alias: `auto_fix.babysit`.
 

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -109,4 +109,6 @@ Override auto-fix attempt limits for specific steps. Fields not set here inherit
 
 Set to `0` to disable auto-fix for a step (always requires manual approval).
 
+`auto_fix.ci` covers the Babysit step's CI failure and merge-conflict auto-fix attempts.
+
 Legacy alias: `auto_fix.babysit`.

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -221,11 +221,16 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 
 		// Check mergeable state
 		mergeConflict := false
+		mergeabilityKnown := false
 		mergeState, mergeErr := s.getMergeableState(sctx, prNumber)
 		if mergeErr != nil {
 			sctx.Log(fmt.Sprintf("warning: could not check mergeable state: %v", mergeErr))
-		} else if isMergeConflict(mergeState) {
-			mergeConflict = true
+		} else {
+			mergeConflict = isMergeConflict(mergeState)
+			mergeabilityKnown = isResolvedMergeableState(mergeState)
+			if !mergeabilityKnown {
+				sctx.Log(fmt.Sprintf("mergeable state still pending: %s", mergeState))
+			}
 		}
 
 		// Check CI status - wait for all checks to complete before fixing
@@ -295,7 +300,7 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 				}
 			} else {
 				s.lastFixedChecks = ""
-				if !pending {
+				if !pending && mergeabilityKnown {
 					if len(checks) == 0 && elapsed < s.gracePeriod() {
 						// CI checks may not be registered yet, keep polling
 						sctx.Log("no CI checks reported yet, waiting for checks to register...")
@@ -365,6 +370,10 @@ func (s *CIStep) getMergeableState(sctx *pipeline.StepContext, prNumber string) 
 // isMergeConflict returns true if the mergeable state indicates conflicts.
 func isMergeConflict(state string) bool {
 	return state == "CONFLICTING"
+}
+
+func isResolvedMergeableState(state string) bool {
+	return state == "MERGEABLE" || state == "CONFLICTING"
 }
 
 // getCIChecks fetches CI check results for a PR.

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -135,6 +135,22 @@ func ciFailureOutcome(failing []string, mergeConflict bool, summary string) *pip
 	}
 }
 
+func ciMergeabilityOutcome(summary, description string) *pipeline.StepOutcome {
+	findings := Findings{
+		Summary: summary,
+		Items: []Finding{{
+			Severity:    "warning",
+			Description: description,
+			Action:      types.ActionAskUser,
+		}},
+	}
+	findingsJSON, _ := json.Marshal(findings)
+	return &pipeline.StepOutcome{
+		NeedsApproval: true,
+		Findings:      string(findingsJSON),
+	}
+}
+
 func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, error) {
 	ctx := sctx.Ctx
 	if err := ctx.Err(); err != nil {
@@ -192,6 +208,7 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 	}
 	started := now()
 	manualFixAttempted := false
+	mergeabilityBlockedReason := ""
 
 	for {
 		checksReadyToExit := false
@@ -204,6 +221,9 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 		elapsed := now().Sub(started)
 		if elapsed >= timeout {
 			sctx.Log("CI timeout reached")
+			if mergeabilityBlockedReason != "" {
+				return ciMergeabilityOutcome("mergeability check timed out", mergeabilityBlockedReason), nil
+			}
 			return &pipeline.StepOutcome{}, nil
 		}
 
@@ -225,11 +245,15 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 		mergeState, mergeErr := s.getMergeableState(sctx, prNumber)
 		if mergeErr != nil {
 			sctx.Log(fmt.Sprintf("warning: could not check mergeable state: %v", mergeErr))
+			mergeabilityBlockedReason = fmt.Sprintf("PR mergeability could not be determined before timeout: %v", mergeErr)
 		} else {
 			mergeConflict = isMergeConflict(mergeState)
 			mergeabilityKnown = isResolvedMergeableState(mergeState)
 			if !mergeabilityKnown {
 				sctx.Log(fmt.Sprintf("mergeable state still pending: %s", mergeState))
+				mergeabilityBlockedReason = fmt.Sprintf("PR mergeability remained unresolved before timeout: %s", mergeState)
+			} else {
+				mergeabilityBlockedReason = ""
 			}
 		}
 
@@ -495,8 +519,6 @@ CI logs:
 // Returns (true, nil) when changes were pushed, (false, nil) when there was
 // nothing to commit, or (false, err) on failure.
 func (s *CIStep) commitAndPush(sctx *pipeline.StepContext) (bool, error) {
-	newHeadSHA := ""
-
 	status, err := stepGitRun(sctx, "status", "--porcelain")
 	if err != nil {
 		return false, fmt.Errorf("check CI changes: %w", err)
@@ -505,10 +527,7 @@ func (s *CIStep) commitAndPush(sctx *pipeline.StepContext) (bool, error) {
 		sctx.Log("no changes to commit")
 		headSHA, err := stepGitHeadSHA(sctx)
 		if err == nil && headSHA != sctx.Run.HeadSHA {
-			sctx.Run.HeadSHA = headSHA
-			if err := sctx.DB.UpdateRunHeadSHA(sctx.Run.ID, headSHA); err != nil {
-				return false, err
-			}
+			return s.pushUpdatedHeadSHA(sctx, headSHA)
 		}
 		return false, nil
 	}
@@ -523,13 +542,25 @@ func (s *CIStep) commitAndPush(sctx *pipeline.StepContext) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("resolve head after commit: %w", err)
 	}
-	newHeadSHA = headSHA
 
+	return s.pushUpdatedHeadSHA(sctx, headSHA)
+}
+
+func (s *CIStep) pushUpdatedHeadSHA(sctx *pipeline.StepContext, newHeadSHA string) (bool, error) {
 	ref := normalizedBranchRef(sctx.Run.Branch)
 
 	upstreamSHA, lsErr := stepGitLsRemote(sctx, sctx.Repo.UpstreamURL, ref)
 	if lsErr != nil {
 		slog.Warn("ls-remote failed, pushing without force-with-lease", "ref", ref, "error", lsErr)
+	} else if upstreamSHA == newHeadSHA {
+		if _, err := stepGitRun(sctx, "update-ref", ref, newHeadSHA); err != nil {
+			return false, fmt.Errorf("update local branch ref: %w", err)
+		}
+		sctx.Run.HeadSHA = newHeadSHA
+		if err := sctx.DB.UpdateRunHeadSHA(sctx.Run.ID, newHeadSHA); err != nil {
+			return false, err
+		}
+		return false, nil
 	}
 	if err := stepGitPush(sctx, sctx.Repo.UpstreamURL, ref, upstreamSHA, upstreamSHA != ""); err != nil {
 		if lsErr != nil {

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -469,13 +469,29 @@ func (s *CIStep) autoFixCI(sctx *pipeline.StepContext, prNumber string, failingN
 
 	// Build prompt based on what issues are present
 	var promptIntro string
+	var promptRules string
 	switch {
 	case len(failingNames) > 0 && mergeConflict:
 		promptIntro = "The following CI checks have failed and the PR has merge conflicts with the base branch. Diagnose and fix the CI issues, then rebase onto the base branch and resolve the merge conflicts."
+		promptRules = `- You MUST produce file changes that fix the failing checks. Do not conclude that nothing needs to change.
+		- If a test fails only on a specific OS (e.g. Windows CRLF, path separators), fix the test to be cross-platform.
+		- If a test is flaky, make it deterministic.
+		- Make the minimal change needed.
+		- Do not refactor beyond what is needed.
+		- Verify the fix by running the most relevant commands locally before finishing.`
 	case mergeConflict:
 		promptIntro = "The PR has merge conflicts with the base branch. Rebase onto the base branch and resolve the merge conflicts."
+		promptRules = `- Resolve the merge conflicts by applying the minimal necessary changes.
+		- Do not make unrelated file edits.
+		- Verify the rebase completes cleanly before finishing.`
 	default:
 		promptIntro = "The following CI checks have failed on this PR. Diagnose and fix the issues."
+		promptRules = `- You MUST produce file changes that fix the failing checks. Do not conclude that nothing needs to change.
+		- If a test fails only on a specific OS (e.g. Windows CRLF, path separators), fix the test to be cross-platform.
+		- If a test is flaky, make it deterministic.
+		- Make the minimal change needed.
+		- Do not refactor beyond what is needed.
+		- Verify the fix by running the most relevant commands locally before finishing.`
 	}
 
 	prompt := fmt.Sprintf(
@@ -490,12 +506,7 @@ Context:
 - merge conflict: %v
 
 		Rules:
-		- You MUST produce file changes that fix the failing checks. Do not conclude that nothing needs to change.
-		- If a test fails only on a specific OS (e.g. Windows CRLF, path separators), fix the test to be cross-platform.
-		- If a test is flaky, make it deterministic.
-		- Make the minimal change needed.
-		- Do not refactor beyond what is needed.
-		- Verify the fix by running the most relevant commands locally before finishing.`,
+		%s`,
 		promptIntro,
 		sctx.Run.Branch,
 		baseSHA,
@@ -503,6 +514,7 @@ Context:
 		prNumber,
 		strings.Join(failingNames, ", "),
 		mergeConflict,
+		promptRules,
 	)
 	if logOutput != "" {
 		prompt += fmt.Sprintf(`

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -246,11 +246,11 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 
 		// Check mergeable state
 		mergeConflict := false
-		mergeabilityKnown := false
+		mergeabilityKnown := true
 		mergeState, mergeErr := s.getMergeableState(sctx, prNumber)
 		if mergeErr != nil {
 			sctx.Log(fmt.Sprintf("warning: could not check mergeable state: %v", mergeErr))
-			mergeabilityBlockedReason = fmt.Sprintf("PR mergeability could not be determined before timeout: %v", mergeErr)
+			mergeabilityBlockedReason = ""
 		} else {
 			mergeConflict = isMergeConflict(mergeState)
 			mergeabilityKnown = isResolvedMergeableState(mergeState)
@@ -432,6 +432,11 @@ func (s *CIStep) getCIChecks(sctx *pipeline.StepContext, prNumber string) ([]ciC
 func (s *CIStep) autoFixCI(sctx *pipeline.StepContext, prNumber string, failingNames []string, mergeConflict bool) (bool, error) {
 	ctx := sctx.Ctx
 	baseSHA := resolveBranchBaseSHA(ctx, sctx.WorkDir, sctx.Run.BaseSHA, sctx.Repo.DefaultBranch)
+	rebaseBaseSHA := resolveDefaultBranchTipSHA(ctx, sctx.WorkDir, sctx.Run.BaseSHA, sctx.Repo.DefaultBranch)
+	promptBaseSHA := baseSHA
+	if mergeConflict {
+		promptBaseSHA = rebaseBaseSHA
+	}
 
 	// Find the most recent failing run for this branch so we fetch logs from the right run.
 	var runID string
@@ -509,13 +514,16 @@ Context:
 		%s`,
 		promptIntro,
 		sctx.Run.Branch,
-		baseSHA,
+		promptBaseSHA,
 		sctx.Run.HeadSHA,
 		prNumber,
 		strings.Join(failingNames, ", "),
 		mergeConflict,
 		promptRules,
 	)
+	if mergeConflict {
+		prompt += fmt.Sprintf("\n- rebase target commit: %s", rebaseBaseSHA)
+	}
 	if logOutput != "" {
 		prompt += fmt.Sprintf(`
 

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -432,7 +432,7 @@ func (s *CIStep) getCIChecks(sctx *pipeline.StepContext, prNumber string) ([]ciC
 func (s *CIStep) autoFixCI(sctx *pipeline.StepContext, prNumber string, failingNames []string, mergeConflict bool) (bool, error) {
 	ctx := sctx.Ctx
 	baseSHA := resolveBranchBaseSHA(ctx, sctx.WorkDir, sctx.Run.BaseSHA, sctx.Repo.DefaultBranch)
-	rebaseBaseSHA := resolveDefaultBranchTipSHA(ctx, sctx.WorkDir, sctx.Run.BaseSHA, sctx.Repo.DefaultBranch)
+	rebaseBaseSHA := resolveDefaultBranchTipSHA(ctx, sctx.WorkDir, sctx.Repo.UpstreamURL, sctx.Run.BaseSHA, sctx.Repo.DefaultBranch)
 	promptBaseSHA := baseSHA
 	if mergeConflict {
 		promptBaseSHA = rebaseBaseSHA

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -209,6 +209,8 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 	started := now()
 	manualFixAttempted := false
 	mergeabilityBlockedReason := ""
+	timeoutFailingChecks := []string{}
+	timeoutMergeConflict := false
 
 	for {
 		checksReadyToExit := false
@@ -221,6 +223,9 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 		elapsed := now().Sub(started)
 		if elapsed >= timeout {
 			sctx.Log("CI timeout reached")
+			if len(timeoutFailingChecks) > 0 || timeoutMergeConflict {
+				return ciFailureOutcome(timeoutFailingChecks, timeoutMergeConflict, "CI timed out with known failures still present"), nil
+			}
 			if mergeabilityBlockedReason != "" {
 				return ciMergeabilityOutcome("mergeability check timed out", mergeabilityBlockedReason), nil
 			}
@@ -268,6 +273,8 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 			sort.Strings(failing)
 			hasFailures := len(failing) > 0
 			hasIssues := hasFailures || mergeConflict
+			timeoutFailingChecks = append(timeoutFailingChecks[:0], failing...)
+			timeoutMergeConflict = mergeConflict
 
 			if hasIssues && pending {
 				// Some checks still running - wait for all to complete before fixing
@@ -289,10 +296,11 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 				if sctx.Fixing && !manualFixAttempted {
 					manualFixAttempted = true
 					sctx.Log(fmt.Sprintf("issues detected: %s - manual fix requested...", issueDesc))
+					previousHeadSHA := sctx.Run.HeadSHA
 					pushed, err := s.autoFixCI(sctx, prNumber, failing, mergeConflict)
 					if err != nil {
 						sctx.Log(fmt.Sprintf("warning: CI manual fix failed: %v", err))
-					} else if pushed {
+					} else if pushed || sctx.Run.HeadSHA != previousHeadSHA {
 						s.lastFixedChecks = fixKey
 					} else {
 						sctx.Log("CI fix produced no changes, returning for manual intervention...")
@@ -311,10 +319,11 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 				} else {
 					s.ciFixAttempts++
 					sctx.Log(fmt.Sprintf("issues detected: %s - auto-fixing (attempt %d/%d)...", issueDesc, s.ciFixAttempts, ciFixLimit))
+					previousHeadSHA := sctx.Run.HeadSHA
 					pushed, err := s.autoFixCI(sctx, prNumber, failing, mergeConflict)
 					if err != nil {
 						sctx.Log(fmt.Sprintf("warning: CI auto-fix failed: %v", err))
-					} else if pushed {
+					} else if pushed || sctx.Run.HeadSHA != previousHeadSHA {
 						s.lastFixedChecks = fixKey
 					} else {
 						// No changes produced - don't set lastFixedChecks so next

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -259,6 +259,7 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 				mergeabilityBlockedReason = fmt.Sprintf("PR mergeability remained unresolved before timeout: %s", mergeState)
 			} else {
 				mergeabilityBlockedReason = ""
+				timeoutMergeConflict = mergeConflict
 			}
 		}
 
@@ -274,7 +275,6 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 			hasFailures := len(failing) > 0
 			hasIssues := hasFailures || mergeConflict
 			timeoutFailingChecks = append(timeoutFailingChecks[:0], failing...)
-			timeoutMergeConflict = mergeConflict
 
 			if hasIssues && pending {
 				// Some checks still running - wait for all to complete before fixing

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -114,12 +114,18 @@ func failingCheckNames(checks []ciCheck) []string {
 	return names
 }
 
-func ciFailureOutcome(failing []string, summary string) *pipeline.StepOutcome {
+func ciFailureOutcome(failing []string, mergeConflict bool, summary string) *pipeline.StepOutcome {
 	findings := Findings{Summary: summary}
 	for _, name := range failing {
 		findings.Items = append(findings.Items, Finding{
 			Severity:    "warning",
 			Description: fmt.Sprintf("CI check failing: %s", name),
+		})
+	}
+	if mergeConflict {
+		findings.Items = append(findings.Items, Finding{
+			Severity:    "warning",
+			Description: "PR has merge conflicts with the base branch",
 		})
 	}
 	findingsJSON, _ := json.Marshal(findings)
@@ -213,63 +219,93 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 			return &pipeline.StepOutcome{}, nil
 		}
 
-		// Check CI status - auto-fix failures when configured
+		// Check mergeable state
+		mergeConflict := false
+		mergeState, mergeErr := s.getMergeableState(sctx, prNumber)
+		if mergeErr != nil {
+			sctx.Log(fmt.Sprintf("warning: could not check mergeable state: %v", mergeErr))
+		} else if isMergeConflict(mergeState) {
+			mergeConflict = true
+		}
+
+		// Check CI status - wait for all checks to complete before fixing
 		ciFixLimit := sctx.Config.AutoFix.CI
 		checks, err := s.getCIChecks(sctx, prNumber)
 		if err != nil {
 			sctx.Log(fmt.Sprintf("warning: could not check CI: %v", err))
-		} else if hasFailingChecks(checks) {
+		} else {
+			pending := hasPendingChecks(checks)
 			failing := failingCheckNames(checks)
 			sort.Strings(failing)
-			fixKey := strings.Join(failing, ",")
-			if sctx.Fixing && !manualFixAttempted {
-				manualFixAttempted = true
-				sctx.Log(fmt.Sprintf("CI failures detected: %s - manual fix requested...", strings.Join(failing, ", ")))
-				pushed, err := s.autoFixCI(sctx, prNumber, failing)
-				if err != nil {
-					sctx.Log(fmt.Sprintf("warning: CI manual fix failed: %v", err))
-				} else if pushed {
-					s.lastFixedChecks = fixKey
-				} else {
-					sctx.Log("CI fix produced no changes, returning for manual intervention...")
-					return ciFailureOutcome(failing, "CI fix produced no changes - failures require manual intervention"), nil
+			hasFailures := len(failing) > 0
+			hasIssues := hasFailures || mergeConflict
+
+			if hasIssues && pending {
+				// Some checks still running - wait for all to complete before fixing
+				sctx.Log("issues detected but checks still pending, waiting for all checks to complete...")
+			} else if hasIssues {
+				// All checks done, issues present - fix or report
+				fixKey := strings.Join(failing, ",")
+				if mergeConflict {
+					fixKey += "+conflict"
 				}
-			} else if sctx.Fixing && fixKey == s.lastFixedChecks {
-				sctx.Log("fix already attempted for these failures, waiting for CI re-run...")
-			} else if ciFixLimit <= 0 {
-				sctx.Log(fmt.Sprintf("CI failures detected: %s - auto-fix disabled, waiting for manual intervention...", strings.Join(failing, ", ")))
-				return ciFailureOutcome(failing, "CI failures require manual intervention"), nil
-			} else if s.ciFixAttempts >= ciFixLimit {
-				sctx.Log(fmt.Sprintf("CI failures detected: %s - max auto-fix attempts (%d) reached, waiting for manual intervention...", strings.Join(failing, ", "), ciFixLimit))
-				return ciFailureOutcome(failing, "CI failures still present after auto-fix attempts"), nil
-			} else if fixKey == s.lastFixedChecks {
-				sctx.Log("fix already attempted for these failures, waiting for CI re-run...")
-			} else {
-				s.ciFixAttempts++
-				sctx.Log(fmt.Sprintf("CI failures detected: %s - auto-fixing (attempt %d/%d)...", strings.Join(failing, ", "), s.ciFixAttempts, ciFixLimit))
-				pushed, err := s.autoFixCI(sctx, prNumber, failing)
-				if err != nil {
-					sctx.Log(fmt.Sprintf("warning: CI auto-fix failed: %v", err))
-				} else if pushed {
-					s.lastFixedChecks = fixKey
-				} else {
-					// No changes produced - don't set lastFixedChecks so next
-					// poll treats this as a new failure and retries if attempts remain.
-					sctx.Log("CI fix produced no changes, will retry if attempts remain...")
-				}
-			}
-		} else {
-			s.lastFixedChecks = ""
-			if !hasPendingChecks(checks) {
-				if len(checks) == 0 && elapsed < s.gracePeriod() {
-					// CI checks may not be registered yet, keep polling
-					sctx.Log("no CI checks reported yet, waiting for checks to register...")
-				} else {
-					checksReadyToExit = true
-					if len(checks) == 0 {
-						checksSummary = "no CI checks reported, CI monitoring complete"
+				issueDesc := strings.Join(failing, ", ")
+				if mergeConflict {
+					if issueDesc != "" {
+						issueDesc += " + merge conflict"
 					} else {
-						checksSummary = "all CI checks passed"
+						issueDesc = "merge conflict"
+					}
+				}
+				if sctx.Fixing && !manualFixAttempted {
+					manualFixAttempted = true
+					sctx.Log(fmt.Sprintf("issues detected: %s - manual fix requested...", issueDesc))
+					pushed, err := s.autoFixCI(sctx, prNumber, failing, mergeConflict)
+					if err != nil {
+						sctx.Log(fmt.Sprintf("warning: CI manual fix failed: %v", err))
+					} else if pushed {
+						s.lastFixedChecks = fixKey
+					} else {
+						sctx.Log("CI fix produced no changes, returning for manual intervention...")
+						return ciFailureOutcome(failing, mergeConflict, "CI fix produced no changes - failures require manual intervention"), nil
+					}
+				} else if sctx.Fixing && fixKey == s.lastFixedChecks {
+					sctx.Log("fix already attempted for these issues, waiting for CI re-run...")
+				} else if ciFixLimit <= 0 {
+					sctx.Log(fmt.Sprintf("issues detected: %s - auto-fix disabled, waiting for manual intervention...", issueDesc))
+					return ciFailureOutcome(failing, mergeConflict, "CI failures require manual intervention"), nil
+				} else if s.ciFixAttempts >= ciFixLimit {
+					sctx.Log(fmt.Sprintf("issues detected: %s - max auto-fix attempts (%d) reached, waiting for manual intervention...", issueDesc, ciFixLimit))
+					return ciFailureOutcome(failing, mergeConflict, "CI failures still present after auto-fix attempts"), nil
+				} else if fixKey == s.lastFixedChecks {
+					sctx.Log("fix already attempted for these issues, waiting for CI re-run...")
+				} else {
+					s.ciFixAttempts++
+					sctx.Log(fmt.Sprintf("issues detected: %s - auto-fixing (attempt %d/%d)...", issueDesc, s.ciFixAttempts, ciFixLimit))
+					pushed, err := s.autoFixCI(sctx, prNumber, failing, mergeConflict)
+					if err != nil {
+						sctx.Log(fmt.Sprintf("warning: CI auto-fix failed: %v", err))
+					} else if pushed {
+						s.lastFixedChecks = fixKey
+					} else {
+						// No changes produced - don't set lastFixedChecks so next
+						// poll treats this as a new failure and retries if attempts remain.
+						sctx.Log("CI fix produced no changes, will retry if attempts remain...")
+					}
+				}
+			} else {
+				s.lastFixedChecks = ""
+				if !pending {
+					if len(checks) == 0 && elapsed < s.gracePeriod() {
+						// CI checks may not be registered yet, keep polling
+						sctx.Log("no CI checks reported yet, waiting for checks to register...")
+					} else {
+						checksReadyToExit = true
+						if len(checks) == 0 {
+							checksSummary = "no CI checks reported, CI monitoring complete"
+						} else {
+							checksSummary = "all CI checks passed"
+						}
 					}
 				}
 			}
@@ -316,6 +352,21 @@ func (s *CIStep) getPRState(sctx *pipeline.StepContext, prNumber string) (string
 	return strings.TrimSpace(string(out)), nil
 }
 
+// getMergeableState returns the PR mergeable state (MERGEABLE, CONFLICTING, UNKNOWN).
+func (s *CIStep) getMergeableState(sctx *pipeline.StepContext, prNumber string) (string, error) {
+	cmd := stepCmd(sctx, "gh", "pr", "view", prNumber, "--json", "mergeable", "--jq", ".mergeable")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("gh pr view mergeable: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// isMergeConflict returns true if the mergeable state indicates conflicts.
+func isMergeConflict(state string) bool {
+	return state == "CONFLICTING"
+}
+
 // getCIChecks fetches CI check results for a PR.
 func (s *CIStep) getCIChecks(sctx *pipeline.StepContext, prNumber string) ([]ciCheck, error) {
 	cmd := stepCmd(sctx, "gh", "pr", "checks", prNumber, "--json", "name,state,bucket")
@@ -333,23 +384,25 @@ func (s *CIStep) getCIChecks(sctx *pipeline.StepContext, prNumber string) ([]ciC
 	return checks, nil
 }
 
-// autoFixCI runs the agent to fix CI failures, then commits and pushes.
+// autoFixCI runs the agent to fix CI failures and/or merge conflicts, then commits and pushes.
 // Returns (true, nil) when changes were committed and pushed, (false, nil)
 // when the agent produced no changes, or (false, err) on failure.
-func (s *CIStep) autoFixCI(sctx *pipeline.StepContext, prNumber string, failingNames []string) (bool, error) {
+func (s *CIStep) autoFixCI(sctx *pipeline.StepContext, prNumber string, failingNames []string, mergeConflict bool) (bool, error) {
 	ctx := sctx.Ctx
 	baseSHA := resolveBranchBaseSHA(ctx, sctx.WorkDir, sctx.Run.BaseSHA, sctx.Repo.DefaultBranch)
 
 	// Find the most recent failing run for this branch so we fetch logs from the right run.
 	var runID string
-	listCmd := stepCmd(sctx, "gh", "run", "list",
-		"--branch", sctx.Run.Branch,
-		"--status", "failure",
-		"--limit", "1",
-		"--json", "databaseId",
-		"--jq", ".[0].databaseId")
-	if listOut, err := listCmd.Output(); err == nil {
-		runID = strings.TrimSpace(string(listOut))
+	if len(failingNames) > 0 {
+		listCmd := stepCmd(sctx, "gh", "run", "list",
+			"--branch", sctx.Run.Branch,
+			"--status", "failure",
+			"--limit", "1",
+			"--json", "databaseId",
+			"--jq", ".[0].databaseId")
+		if listOut, err := listCmd.Output(); err == nil {
+			runID = strings.TrimSpace(string(listOut))
+		}
 	}
 
 	// Attempt to fetch CI failure logs for context
@@ -372,8 +425,19 @@ func (s *CIStep) autoFixCI(sctx *pipeline.StepContext, prNumber string, failingN
 		}
 	}
 
+	// Build prompt based on what issues are present
+	var promptIntro string
+	switch {
+	case len(failingNames) > 0 && mergeConflict:
+		promptIntro = "The following CI checks have failed and the PR has merge conflicts with the base branch. Diagnose and fix the CI issues, then rebase onto the base branch and resolve the merge conflicts."
+	case mergeConflict:
+		promptIntro = "The PR has merge conflicts with the base branch. Rebase onto the base branch and resolve the merge conflicts."
+	default:
+		promptIntro = "The following CI checks have failed on this PR. Diagnose and fix the issues."
+	}
+
 	prompt := fmt.Sprintf(
-		`The following CI checks have failed on this PR. Diagnose and fix the issues.
+		`%s
 
 Context:
 - branch: %s
@@ -381,6 +445,7 @@ Context:
 - target commit: %s
 - PR number: %s
 - failing checks: %s
+- merge conflict: %v
 
 		Rules:
 		- You MUST produce file changes that fix the failing checks. Do not conclude that nothing needs to change.
@@ -389,11 +454,13 @@ Context:
 		- Make the minimal change needed.
 		- Do not refactor beyond what is needed.
 		- Verify the fix by running the most relevant commands locally before finishing.`,
+		promptIntro,
 		sctx.Run.Branch,
 		baseSHA,
 		sctx.Run.HeadSHA,
 		prNumber,
 		strings.Join(failingNames, ", "),
+		mergeConflict,
 	)
 	if logOutput != "" {
 		prompt += fmt.Sprintf(`
@@ -402,7 +469,7 @@ CI logs:
 %s`, logOutput)
 	}
 
-	sctx.Log("running agent to fix CI failures...")
+	sctx.Log("running agent to fix CI issues...")
 	_, err := sctx.Agent.Run(ctx, agent.RunOpts{
 		Prompt:  prompt,
 		CWD:     sctx.WorkDir,

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -48,19 +48,20 @@ func resolveBranchBaseSHA(ctx context.Context, workDir, fallbackBaseSHA, default
 	return resolveBaseSHA(ctx, workDir, fallbackBaseSHA, defaultBranch)
 }
 
-func resolveDefaultBranchTipSHA(ctx context.Context, workDir, fallbackBaseSHA, defaultBranch string) string {
+func resolveDefaultBranchTipSHA(ctx context.Context, workDir, upstreamURL, fallbackBaseSHA, defaultBranch string) string {
 	if strings.TrimSpace(defaultBranch) != "" {
-		if err := git.FetchRemoteBranch(ctx, workDir, "origin", defaultBranch); err != nil {
+		remoteName := resolveUpstreamRemoteName(ctx, workDir, upstreamURL)
+		if err := git.FetchRemoteBranch(ctx, workDir, remoteName, defaultBranch); err != nil {
+			if !git.IsZeroSHA(fallbackBaseSHA) {
+				return fallbackBaseSHA
+			}
 			sha, localErr := git.Run(ctx, workDir, "rev-parse", "--verify", defaultBranch)
 			if localErr == nil && strings.TrimSpace(sha) != "" {
 				return strings.TrimSpace(sha)
 			}
-			if !git.IsZeroSHA(fallbackBaseSHA) {
-				return fallbackBaseSHA
-			}
 			return git.EmptyTreeSHA
 		}
-		for _, ref := range []string{"origin/" + defaultBranch, defaultBranch} {
+		for _, ref := range []string{remoteName + "/" + defaultBranch, defaultBranch} {
 			sha, err := git.Run(ctx, workDir, "rev-parse", "--verify", ref)
 			if err == nil && strings.TrimSpace(sha) != "" {
 				return strings.TrimSpace(sha)
@@ -68,6 +69,23 @@ func resolveDefaultBranchTipSHA(ctx context.Context, workDir, fallbackBaseSHA, d
 		}
 	}
 	return resolveBaseSHA(ctx, workDir, fallbackBaseSHA, defaultBranch)
+}
+
+func resolveUpstreamRemoteName(ctx context.Context, workDir, upstreamURL string) string {
+	if strings.TrimSpace(upstreamURL) == "" {
+		return "origin"
+	}
+	remotes, err := git.Run(ctx, workDir, "remote")
+	if err != nil {
+		return "origin"
+	}
+	for _, remote := range strings.Fields(remotes) {
+		url, urlErr := git.GetRemoteURL(ctx, workDir, remote)
+		if urlErr == nil && strings.TrimSpace(url) == strings.TrimSpace(upstreamURL) {
+			return remote
+		}
+	}
+	return "origin"
 }
 
 func mergeBaseWithDefaultBranch(ctx context.Context, workDir, defaultBranch string) string {

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -50,6 +50,7 @@ func resolveBranchBaseSHA(ctx context.Context, workDir, fallbackBaseSHA, default
 
 func resolveDefaultBranchTipSHA(ctx context.Context, workDir, fallbackBaseSHA, defaultBranch string) string {
 	if strings.TrimSpace(defaultBranch) != "" {
+		_ = git.FetchRemoteBranch(ctx, workDir, "origin", defaultBranch)
 		for _, ref := range []string{"origin/" + defaultBranch, defaultBranch} {
 			sha, err := git.Run(ctx, workDir, "rev-parse", "--verify", ref)
 			if err == nil && strings.TrimSpace(sha) != "" {

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -48,6 +48,18 @@ func resolveBranchBaseSHA(ctx context.Context, workDir, fallbackBaseSHA, default
 	return resolveBaseSHA(ctx, workDir, fallbackBaseSHA, defaultBranch)
 }
 
+func resolveDefaultBranchTipSHA(ctx context.Context, workDir, fallbackBaseSHA, defaultBranch string) string {
+	if strings.TrimSpace(defaultBranch) != "" {
+		for _, ref := range []string{"origin/" + defaultBranch, defaultBranch} {
+			sha, err := git.Run(ctx, workDir, "rev-parse", "--verify", ref)
+			if err == nil && strings.TrimSpace(sha) != "" {
+				return strings.TrimSpace(sha)
+			}
+		}
+	}
+	return resolveBaseSHA(ctx, workDir, fallbackBaseSHA, defaultBranch)
+}
+
 func mergeBaseWithDefaultBranch(ctx context.Context, workDir, defaultBranch string) string {
 	if strings.TrimSpace(defaultBranch) == "" {
 		return ""

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -50,7 +50,16 @@ func resolveBranchBaseSHA(ctx context.Context, workDir, fallbackBaseSHA, default
 
 func resolveDefaultBranchTipSHA(ctx context.Context, workDir, fallbackBaseSHA, defaultBranch string) string {
 	if strings.TrimSpace(defaultBranch) != "" {
-		_ = git.FetchRemoteBranch(ctx, workDir, "origin", defaultBranch)
+		if err := git.FetchRemoteBranch(ctx, workDir, "origin", defaultBranch); err != nil {
+			sha, localErr := git.Run(ctx, workDir, "rev-parse", "--verify", defaultBranch)
+			if localErr == nil && strings.TrimSpace(sha) != "" {
+				return strings.TrimSpace(sha)
+			}
+			if !git.IsZeroSHA(fallbackBaseSHA) {
+				return fallbackBaseSHA
+			}
+			return git.EmptyTreeSHA
+		}
 		for _, ref := range []string{"origin/" + defaultBranch, defaultBranch} {
 			sha, err := git.Run(ctx, workDir, "rev-parse", "--verify", ref)
 			if err == nil && strings.TrimSpace(sha) != "" {

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -149,12 +149,17 @@ func fakeCIGHHandler(args []string) {
 	state := os.Getenv("FAKE_CLI_STATE")
 	checksJSON := os.Getenv("FAKE_CLI_CHECKS")
 	mergeable := os.Getenv("FAKE_CLI_MERGEABLE")
+	mergeableErr := os.Getenv("FAKE_CLI_MERGEABLE_ERR")
 	joined := strings.Join(args, " ")
 
 	if len(args) >= 2 && args[0] == "auth" && args[1] == "status" {
 		os.Exit(0)
 	}
 	if strings.Contains(joined, "pr view") && strings.Contains(joined, "--json mergeable") {
+		if mergeableErr != "" {
+			fmt.Fprintln(os.Stderr, mergeableErr)
+			os.Exit(1)
+		}
 		if mergeable == "" {
 			mergeable = "MERGEABLE"
 		}
@@ -181,12 +186,17 @@ func fakeCIGHSequenceHandler(args []string) {
 	checksPath := os.Getenv("FAKE_CLI_CHECKS_PATH")
 	indexPath := os.Getenv("FAKE_CLI_CHECKS_INDEX_PATH")
 	mergeable := os.Getenv("FAKE_CLI_MERGEABLE")
+	mergeableErr := os.Getenv("FAKE_CLI_MERGEABLE_ERR")
 	joined := strings.Join(args, " ")
 
 	if len(args) >= 2 && args[0] == "auth" && args[1] == "status" {
 		os.Exit(0)
 	}
 	if strings.Contains(joined, "pr view") && strings.Contains(joined, "--json mergeable") {
+		if mergeableErr != "" {
+			fmt.Fprintln(os.Stderr, mergeableErr)
+			os.Exit(1)
+		}
 		if mergeable == "" {
 			mergeable = "MERGEABLE"
 		}
@@ -5599,6 +5609,18 @@ func fakeCIGHMergeable(t *testing.T, state, checksJSON, mergeable string) []stri
 	})
 }
 
+func fakeCIGHMergeableError(t *testing.T, state, checksJSON, mergeableErr string) []string {
+	t.Helper()
+	binDir := fakeCLIBinDir(t)
+	linkTestBinary(t, binDir, "gh")
+	return fakeCLIEnv(binDir, map[string]string{
+		"FAKE_CLI_MODE":          "ci-gh",
+		"FAKE_CLI_STATE":         state,
+		"FAKE_CLI_CHECKS":        checksJSON,
+		"FAKE_CLI_MERGEABLE_ERR": mergeableErr,
+	})
+}
+
 func fakeCIGHSequenceMergeable(t *testing.T, state string, checks []string, mergeable string) []string {
 	t.Helper()
 	binDir := fakeCLIBinDir(t)
@@ -6768,6 +6790,93 @@ func TestCIStep_MergeConflictDetected_ReturnsNeedsApproval(t *testing.T) {
 	}
 	if !foundConflict {
 		t.Fatalf("expected merge conflict finding, got: %+v", findings.Items)
+	}
+}
+
+func TestCIStep_UnknownMergeableStateDoesNotExitCleanly(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	checksJSON := `[{"name":"build","state":"SUCCESS","bucket":"pass"}]`
+	env := fakeCIGHMergeable(t, "OPEN", checksJSON, "UNKNOWN")
+
+	prURL := "https://github.com/test/repo/pull/42"
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+	sctx.Config.CITimeout = 10 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+
+	step := &CIStep{
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			cancel()
+			return ctx.Err()
+		},
+	}
+
+	_, err := step.Execute(sctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected polling to continue until canceled, got %v", err)
+	}
+
+	for _, l := range logs {
+		if strings.Contains(l, "all CI checks passed") {
+			t.Fatalf("expected UNKNOWN mergeability to block clean exit, got logs: %v", logs)
+		}
+	}
+}
+
+func TestCIStep_MergeableLookupErrorDoesNotExitCleanly(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	checksJSON := `[{"name":"build","state":"SUCCESS","bucket":"pass"}]`
+	env := fakeCIGHMergeableError(t, "OPEN", checksJSON, "gh mergeable failed")
+
+	prURL := "https://github.com/test/repo/pull/42"
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+	sctx.Config.CITimeout = 10 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+
+	step := &CIStep{
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			cancel()
+			return ctx.Err()
+		},
+	}
+
+	_, err := step.Execute(sctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected polling to continue until canceled, got %v", err)
+	}
+
+	foundWarning := false
+	for _, l := range logs {
+		if strings.Contains(l, "could not check mergeable state") {
+			foundWarning = true
+		}
+		if strings.Contains(l, "all CI checks passed") {
+			t.Fatalf("expected mergeable lookup error to block clean exit, got logs: %v", logs)
+		}
+	}
+	if !foundWarning {
+		t.Fatalf("expected mergeable lookup warning, got logs: %v", logs)
 	}
 }
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -148,9 +148,17 @@ func fakeGlabHandler(args []string) {
 func fakeCIGHHandler(args []string) {
 	state := os.Getenv("FAKE_CLI_STATE")
 	checksJSON := os.Getenv("FAKE_CLI_CHECKS")
+	mergeable := os.Getenv("FAKE_CLI_MERGEABLE")
 	joined := strings.Join(args, " ")
 
 	if len(args) >= 2 && args[0] == "auth" && args[1] == "status" {
+		os.Exit(0)
+	}
+	if strings.Contains(joined, "pr view") && strings.Contains(joined, "--json mergeable") {
+		if mergeable == "" {
+			mergeable = "MERGEABLE"
+		}
+		fmt.Println(mergeable)
 		os.Exit(0)
 	}
 	if strings.Contains(joined, "pr view") && strings.Contains(joined, "--json state") {
@@ -172,9 +180,17 @@ func fakeCIGHSequenceHandler(args []string) {
 	state := os.Getenv("FAKE_CLI_STATE")
 	checksPath := os.Getenv("FAKE_CLI_CHECKS_PATH")
 	indexPath := os.Getenv("FAKE_CLI_CHECKS_INDEX_PATH")
+	mergeable := os.Getenv("FAKE_CLI_MERGEABLE")
 	joined := strings.Join(args, " ")
 
 	if len(args) >= 2 && args[0] == "auth" && args[1] == "status" {
+		os.Exit(0)
+	}
+	if strings.Contains(joined, "pr view") && strings.Contains(joined, "--json mergeable") {
+		if mergeable == "" {
+			mergeable = "MERGEABLE"
+		}
+		fmt.Println(mergeable)
 		os.Exit(0)
 	}
 	if strings.Contains(joined, "pr view") && strings.Contains(joined, "--json state") {
@@ -5571,6 +5587,42 @@ func fakeCIGH(t *testing.T, state, checksJSON string) []string {
 	})
 }
 
+func fakeCIGHMergeable(t *testing.T, state, checksJSON, mergeable string) []string {
+	t.Helper()
+	binDir := fakeCLIBinDir(t)
+	linkTestBinary(t, binDir, "gh")
+	return fakeCLIEnv(binDir, map[string]string{
+		"FAKE_CLI_MODE":      "ci-gh",
+		"FAKE_CLI_STATE":     state,
+		"FAKE_CLI_CHECKS":    checksJSON,
+		"FAKE_CLI_MERGEABLE": mergeable,
+	})
+}
+
+func fakeCIGHSequenceMergeable(t *testing.T, state string, checks []string, mergeable string) []string {
+	t.Helper()
+	binDir := fakeCLIBinDir(t)
+	linkTestBinary(t, binDir, "gh")
+
+	checksPath := filepath.Join(t.TempDir(), "checks.txt")
+	indexPath := filepath.Join(t.TempDir(), "checks-index.txt")
+
+	if err := os.WriteFile(checksPath, []byte(strings.Join(checks, "\n")), 0o644); err != nil {
+		t.Fatalf("write checks sequence: %v", err)
+	}
+	if err := os.WriteFile(indexPath, []byte("0"), 0o644); err != nil {
+		t.Fatalf("write checks index: %v", err)
+	}
+
+	return fakeCLIEnv(binDir, map[string]string{
+		"FAKE_CLI_MODE":              "ci-gh-seq",
+		"FAKE_CLI_STATE":             state,
+		"FAKE_CLI_CHECKS_PATH":       checksPath,
+		"FAKE_CLI_CHECKS_INDEX_PATH": indexPath,
+		"FAKE_CLI_MERGEABLE":         mergeable,
+	})
+}
+
 func fakeCIGHSequence(t *testing.T, state string, checks []string) []string {
 	t.Helper()
 	binDir := fakeCLIBinDir(t)
@@ -5776,13 +5828,13 @@ func TestCIStep_CIFailureAutoFix(t *testing.T) {
 
 	foundAutoFix := false
 	for _, l := range logs {
-		if strings.Contains(l, "CI failures detected") {
+		if strings.Contains(l, "issues detected") && strings.Contains(l, "auto-fixing") {
 			foundAutoFix = true
 			break
 		}
 	}
 	if !foundAutoFix {
-		t.Errorf("expected CI failure detection in logs, got: %v", logs)
+		t.Errorf("expected issue detection in logs, got: %v", logs)
 	}
 }
 
@@ -5973,7 +6025,7 @@ func TestCIStep_NonEmptyPassingChecksExitImmediately(t *testing.T) {
 	if outcome.NeedsApproval {
 		t.Error("expected no approval needed")
 	}
-	if elapsed > 5*time.Second {
+	if elapsed > 10*time.Second {
 		t.Errorf("non-empty passing checks should exit quickly, took %v", elapsed)
 	}
 	found := false
@@ -6279,7 +6331,7 @@ func TestCIStep_CIAutoFixRetriesAfterChecksRerun(t *testing.T) {
 	sctx.Run.PRURL = &prURL
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "refs/heads/feature"
-	sctx.Config.CITimeout = 10 * time.Second
+	sctx.Config.CITimeout = 30 * time.Second
 	sctx.Config.AutoFix = config.AutoFix{CI: 2}
 
 	var logs []string
@@ -6665,5 +6717,297 @@ func TestCIStep_AutoFixPromptIncludesMustFixInstruction(t *testing.T) {
 	}
 	if !strings.Contains(capturedPrompt, "You MUST produce file changes") {
 		t.Errorf("prompt should instruct agent to produce changes, got:\n%s", capturedPrompt)
+	}
+}
+
+// --- merge conflict and wait-for-all-checks tests ---
+
+func TestCIStep_MergeConflictDetected_ReturnsNeedsApproval(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	// All CI checks pass, but PR has merge conflicts
+	checksJSON := `[{"name":"build","state":"SUCCESS","bucket":"pass"},{"name":"test","state":"SUCCESS","bucket":"pass"}]`
+	env := fakeCIGHMergeable(t, "OPEN", checksJSON, "CONFLICTING")
+
+	ag := &mockAgent{name: "test"}
+	prURL := "https://github.com/test/repo/pull/42"
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+	sctx.Config.CITimeout = 5 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{CI: 0} // disabled
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+
+	step := &CIStep{
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			return nil
+		},
+	}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatalf("expected outcome, got error: %v", err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected NeedsApproval when merge conflict detected")
+	}
+
+	var findings Findings
+	if err := json.Unmarshal([]byte(outcome.Findings), &findings); err != nil {
+		t.Fatalf("unmarshal findings: %v", err)
+	}
+
+	foundConflict := false
+	for _, f := range findings.Items {
+		if strings.Contains(f.Description, "merge conflict") {
+			foundConflict = true
+			break
+		}
+	}
+	if !foundConflict {
+		t.Fatalf("expected merge conflict finding, got: %+v", findings.Items)
+	}
+}
+
+func TestCIStep_WaitsForPendingChecksBeforeFixing(t *testing.T) {
+	t.Parallel()
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	// Poll 1: build failing, test still pending -> should NOT fix yet
+	// Poll 2: build failing, test also failing -> should fix now
+	checksSequence := []string{
+		`[{"name":"build","bucket":"fail"},{"name":"test","bucket":"pending"}]`,
+		`[{"name":"build","bucket":"fail"},{"name":"test","bucket":"fail"}]`,
+	}
+	env := fakeCIGHSequenceMergeable(t, "OPEN", checksSequence, "MERGEABLE")
+
+	agentCalled := false
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			agentCalled = true
+			os.WriteFile(filepath.Join(opts.CWD, "fix.txt"), []byte("fixed"), 0o644)
+			return &agent.Result{}, nil
+		},
+	}
+
+	prURL := "https://github.com/test/repo/pull/42"
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Config.CITimeout = 30 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{CI: 3}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+
+	pollCount := 0
+	step := &CIStep{
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			pollCount++
+			if pollCount >= 3 {
+				cancel()
+				return ctx.Err()
+			}
+			return nil
+		},
+	}
+	_, err := step.Execute(sctx)
+	if err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Agent should have been called on poll 2 (after pending resolved), not poll 1
+	if !agentCalled {
+		t.Fatal("expected agent to be called after all checks completed")
+	}
+
+	// Should have logged about waiting for pending checks
+	foundWaiting := false
+	for _, l := range logs {
+		if strings.Contains(l, "waiting for") && strings.Contains(l, "pending") {
+			foundWaiting = true
+			break
+		}
+	}
+	if !foundWaiting {
+		t.Fatalf("expected log about waiting for pending checks, got: %v", logs)
+	}
+}
+
+func TestCIStep_MergeConflictAndCIFailure_FixPromptIncludesBoth(t *testing.T) {
+	t.Parallel()
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	checksJSON := `[{"name":"test","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`
+	env := fakeCIGHMergeable(t, "OPEN", checksJSON, "CONFLICTING")
+
+	var capturedPrompt string
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			capturedPrompt = opts.Prompt
+			os.WriteFile(filepath.Join(opts.CWD, "fix.txt"), []byte("fixed"), 0o644)
+			return &agent.Result{}, nil
+		},
+	}
+
+	prURL := "https://github.com/test/repo/pull/42"
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Config.CITimeout = 30 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{CI: 3}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+	sctx.Log = func(s string) {}
+
+	step := &CIStep{
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			cancel()
+			return ctx.Err()
+		},
+	}
+	step.Execute(sctx)
+
+	if capturedPrompt == "" {
+		t.Fatal("expected agent to be called")
+	}
+	if !strings.Contains(capturedPrompt, "merge conflict") {
+		t.Errorf("expected prompt to mention merge conflict, got:\n%s", capturedPrompt)
+	}
+	if !strings.Contains(capturedPrompt, "test") {
+		t.Errorf("expected prompt to mention failing check name, got:\n%s", capturedPrompt)
+	}
+}
+
+func TestCIStep_MergeConflictOnly_AutoFix(t *testing.T) {
+	t.Parallel()
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	// All checks pass, but merge conflict
+	checksJSON := `[{"name":"build","state":"SUCCESS","bucket":"pass"},{"name":"test","state":"SUCCESS","bucket":"pass"}]`
+	env := fakeCIGHMergeable(t, "OPEN", checksJSON, "CONFLICTING")
+
+	agentCalled := false
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			agentCalled = true
+			os.WriteFile(filepath.Join(opts.CWD, "conflict-fix.txt"), []byte("resolved"), 0o644)
+			return &agent.Result{}, nil
+		},
+	}
+
+	prURL := "https://github.com/test/repo/pull/42"
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Config.CITimeout = 30 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{CI: 3}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+
+	step := &CIStep{
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			cancel()
+			return ctx.Err()
+		},
+	}
+	step.Execute(sctx)
+
+	if !agentCalled {
+		t.Fatal("expected agent to be called to resolve merge conflict")
+	}
+
+	// Should log about merge conflict
+	foundConflict := false
+	for _, l := range logs {
+		if strings.Contains(l, "merge conflict") {
+			foundConflict = true
+			break
+		}
+	}
+	if !foundConflict {
+		t.Fatalf("expected merge conflict log, got: %v", logs)
 	}
 }

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -7312,10 +7312,12 @@ func TestCIStep_MergeConflictOnly_AutoFix(t *testing.T) {
 	env := fakeCIGHMergeable(t, "OPEN", checksJSON, "CONFLICTING")
 
 	agentCalled := false
+	var capturedPrompt string
 	ag := &mockAgent{
 		name: "test",
 		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
 			agentCalled = true
+			capturedPrompt = opts.Prompt
 			os.WriteFile(filepath.Join(opts.CWD, "conflict-fix.txt"), []byte("resolved"), 0o644)
 			return &agent.Result{}, nil
 		},
@@ -7347,6 +7349,12 @@ func TestCIStep_MergeConflictOnly_AutoFix(t *testing.T) {
 
 	if !agentCalled {
 		t.Fatal("expected agent to be called to resolve merge conflict")
+	}
+	if strings.Contains(capturedPrompt, "You MUST produce file changes that fix the failing checks") {
+		t.Fatalf("merge-conflict-only prompt should not require file changes for failing checks, got:\n%s", capturedPrompt)
+	}
+	if !strings.Contains(capturedPrompt, "Rebase onto the base branch and resolve the merge conflicts") {
+		t.Fatalf("expected merge-conflict-only prompt to focus on rebase flow, got:\n%s", capturedPrompt)
 	}
 
 	// Should log about merge conflict

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -4811,6 +4811,65 @@ func TestCIStep_CommitAndPush_NoChanges_ReconcilesStaleDatabaseHeadSHA_UsesStepE
 	}
 }
 
+func TestCIStep_CommitAndPush_NoDirtyChangesButHeadAdvanced_PushesNewHead(t *testing.T) {
+	t.Parallel()
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	originalHeadSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	os.WriteFile(filepath.Join(dir, "resolved.txt"), []byte("resolved"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "resolve conflict")
+	advancedHeadSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, originalHeadSHA, config.Commands{})
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+
+	step := &CIStep{}
+	pushed, err := step.commitAndPush(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !pushed {
+		t.Fatal("expected commitAndPush to push advanced clean head")
+	}
+
+	upstreamSHA := gitCmd(t, upstream, "rev-parse", "refs/heads/feature")
+	if upstreamSHA != advancedHeadSHA {
+		t.Fatalf("upstream SHA = %s, want %s", upstreamSHA, advancedHeadSHA)
+	}
+	if sctx.Run.HeadSHA != advancedHeadSHA {
+		t.Fatalf("Run.HeadSHA = %s, want %s", sctx.Run.HeadSHA, advancedHeadSHA)
+	}
+	dbRun, err := sctx.DB.GetRun(sctx.Run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dbRun.HeadSHA != advancedHeadSHA {
+		t.Fatalf("DB HeadSHA = %s, want %s", dbRun.HeadSHA, advancedHeadSHA)
+	}
+}
+
 func TestCIStep_CommitAndPush_UpdatesLocalBranchRefAfterDetachedPush(t *testing.T) {
 	t.Parallel()
 	upstream := t.TempDir()
@@ -6877,6 +6936,57 @@ func TestCIStep_MergeableLookupErrorDoesNotExitCleanly(t *testing.T) {
 	}
 	if !foundWarning {
 		t.Fatalf("expected mergeable lookup warning, got logs: %v", logs)
+	}
+}
+
+func TestCIStep_TimeoutWithUnknownMergeableState_NeedsApproval(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	checksJSON := `[{"name":"build","state":"SUCCESS","bucket":"pass"}]`
+	env := fakeCIGHMergeable(t, "OPEN", checksJSON, "UNKNOWN")
+
+	prURL := "https://github.com/test/repo/pull/42"
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+	sctx.Config.CITimeout = 2 * time.Second
+
+	started := time.Unix(1700000000, 0)
+	now := started
+	step := &CIStep{
+		now: func() time.Time {
+			return now
+		},
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			now = now.Add(interval)
+			return nil
+		},
+	}
+
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected NeedsApproval when mergeability stays unknown until timeout")
+	}
+
+	var findings Findings
+	if err := json.Unmarshal([]byte(outcome.Findings), &findings); err != nil {
+		t.Fatalf("unmarshal findings: %v", err)
+	}
+
+	found := false
+	for _, item := range findings.Items {
+		if strings.Contains(strings.ToLower(item.Description), "mergeable") || strings.Contains(strings.ToLower(item.Description), "mergeability") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected unresolved mergeability finding, got %+v", findings.Items)
 	}
 }
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -538,6 +538,45 @@ func TestResolveDefaultBranchTipSHA_FetchesRemoteTip(t *testing.T) {
 	}
 }
 
+func TestResolveDefaultBranchTipSHA_FetchFailureAvoidsStaleOriginRef(t *testing.T) {
+	t.Parallel()
+
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	seed := t.TempDir()
+	gitCmd(t, seed, "init")
+	gitCmd(t, seed, "config", "user.name", "test")
+	gitCmd(t, seed, "config", "user.email", "test@test.com")
+	gitCmd(t, seed, "checkout", "-b", "main")
+	if err := os.WriteFile(filepath.Join(seed, "base.txt"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, seed, "add", "base.txt")
+	gitCmd(t, seed, "commit", "-m", "base")
+	gitCmd(t, seed, "remote", "add", "origin", upstream)
+	gitCmd(t, seed, "push", "origin", "main")
+
+	workDir := t.TempDir()
+	gitCmd(t, workDir, "init")
+	gitCmd(t, workDir, "config", "user.name", "test")
+	gitCmd(t, workDir, "config", "user.email", "test@test.com")
+	gitCmd(t, workDir, "remote", "add", "origin", upstream)
+	gitCmd(t, workDir, "fetch", "origin", "+refs/heads/main:refs/remotes/origin/main")
+	gitCmd(t, workDir, "checkout", "-b", "feature", "origin/main")
+	staleOriginTip := gitCmd(t, workDir, "rev-parse", "origin/main")
+	gitCmd(t, workDir, "remote", "set-url", "origin", filepath.Join(upstream, "missing"))
+
+	fallbackBaseSHA := "abc123"
+	got := resolveDefaultBranchTipSHA(context.Background(), workDir, fallbackBaseSHA, "main")
+	if got != fallbackBaseSHA {
+		t.Fatalf("resolveDefaultBranchTipSHA = %q, want fallback base %q when fetch fails", got, fallbackBaseSHA)
+	}
+	if got == staleOriginTip {
+		t.Fatalf("resolveDefaultBranchTipSHA reused stale origin/main %q after fetch failure", got)
+	}
+}
+
 func TestRunShellCommand(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -527,7 +527,7 @@ func TestResolveDefaultBranchTipSHA_FetchesRemoteTip(t *testing.T) {
 		t.Fatal("expected origin/main to be stale before resolveDefaultBranchTipSHA")
 	}
 
-	got := resolveDefaultBranchTipSHA(context.Background(), workDir, staleOriginTip, "main")
+	got := resolveDefaultBranchTipSHA(context.Background(), workDir, upstream, staleOriginTip, "main")
 	if got != remoteTip {
 		t.Fatalf("resolveDefaultBranchTipSHA = %q, want remote tip %q", got, remoteTip)
 	}
@@ -535,6 +535,59 @@ func TestResolveDefaultBranchTipSHA_FetchesRemoteTip(t *testing.T) {
 	fetchedOriginTip := gitCmd(t, workDir, "rev-parse", "origin/main")
 	if fetchedOriginTip != remoteTip {
 		t.Fatalf("origin/main after resolve = %q, want %q", fetchedOriginTip, remoteTip)
+	}
+}
+
+func TestResolveDefaultBranchTipSHA_UsesMatchingRemoteName(t *testing.T) {
+	t.Parallel()
+
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	seed := t.TempDir()
+	gitCmd(t, seed, "init")
+	gitCmd(t, seed, "config", "user.name", "test")
+	gitCmd(t, seed, "config", "user.email", "test@test.com")
+	gitCmd(t, seed, "checkout", "-b", "main")
+	if err := os.WriteFile(filepath.Join(seed, "base.txt"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, seed, "add", "base.txt")
+	gitCmd(t, seed, "commit", "-m", "base")
+	gitCmd(t, seed, "remote", "add", "upstream", upstream)
+	gitCmd(t, seed, "push", "upstream", "main")
+
+	workDir := t.TempDir()
+	gitCmd(t, workDir, "clone", upstream, ".")
+	gitCmd(t, workDir, "remote", "rename", "origin", "upstream")
+	gitCmd(t, workDir, "checkout", "-b", "feature", "upstream/main")
+
+	updater := t.TempDir()
+	gitCmd(t, updater, "clone", upstream, ".")
+	gitCmd(t, updater, "config", "user.name", "test")
+	gitCmd(t, updater, "config", "user.email", "test@test.com")
+	gitCmd(t, updater, "checkout", "main")
+	if err := os.WriteFile(filepath.Join(updater, "base.txt"), []byte("base updated\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, updater, "add", "base.txt")
+	gitCmd(t, updater, "commit", "-m", "main update")
+	remoteTip := gitCmd(t, updater, "rev-parse", "HEAD")
+	gitCmd(t, updater, "push", "origin", "main")
+
+	staleRemoteTip := gitCmd(t, workDir, "rev-parse", "upstream/main")
+	if staleRemoteTip == remoteTip {
+		t.Fatal("expected upstream/main to be stale before resolveDefaultBranchTipSHA")
+	}
+
+	got := resolveDefaultBranchTipSHA(context.Background(), workDir, upstream, staleRemoteTip, "main")
+	if got != remoteTip {
+		t.Fatalf("resolveDefaultBranchTipSHA = %q, want remote tip %q", got, remoteTip)
+	}
+
+	fetchedRemoteTip := gitCmd(t, workDir, "rev-parse", "upstream/main")
+	if fetchedRemoteTip != remoteTip {
+		t.Fatalf("upstream/main after resolve = %q, want %q", fetchedRemoteTip, remoteTip)
 	}
 }
 
@@ -568,12 +621,64 @@ func TestResolveDefaultBranchTipSHA_FetchFailureAvoidsStaleOriginRef(t *testing.
 	gitCmd(t, workDir, "remote", "set-url", "origin", filepath.Join(upstream, "missing"))
 
 	fallbackBaseSHA := "abc123"
-	got := resolveDefaultBranchTipSHA(context.Background(), workDir, fallbackBaseSHA, "main")
+	got := resolveDefaultBranchTipSHA(context.Background(), workDir, upstream, fallbackBaseSHA, "main")
 	if got != fallbackBaseSHA {
 		t.Fatalf("resolveDefaultBranchTipSHA = %q, want fallback base %q when fetch fails", got, fallbackBaseSHA)
 	}
 	if got == staleOriginTip {
 		t.Fatalf("resolveDefaultBranchTipSHA reused stale origin/main %q after fetch failure", got)
+	}
+}
+
+func TestResolveDefaultBranchTipSHA_FetchFailureAvoidsStaleLocalBranch(t *testing.T) {
+	t.Parallel()
+
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	seed := t.TempDir()
+	gitCmd(t, seed, "init")
+	gitCmd(t, seed, "config", "user.name", "test")
+	gitCmd(t, seed, "config", "user.email", "test@test.com")
+	gitCmd(t, seed, "checkout", "-b", "main")
+	if err := os.WriteFile(filepath.Join(seed, "base.txt"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, seed, "add", "base.txt")
+	gitCmd(t, seed, "commit", "-m", "base")
+	gitCmd(t, seed, "remote", "add", "origin", upstream)
+	gitCmd(t, seed, "push", "origin", "main")
+
+	workDir := t.TempDir()
+	gitCmd(t, workDir, "clone", upstream, ".")
+	gitCmd(t, workDir, "checkout", "main")
+
+	updater := t.TempDir()
+	gitCmd(t, updater, "clone", upstream, ".")
+	gitCmd(t, updater, "config", "user.name", "test")
+	gitCmd(t, updater, "config", "user.email", "test@test.com")
+	gitCmd(t, updater, "checkout", "main")
+	if err := os.WriteFile(filepath.Join(updater, "base.txt"), []byte("base updated\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, updater, "add", "base.txt")
+	gitCmd(t, updater, "commit", "-m", "main update")
+	remoteTip := gitCmd(t, updater, "rev-parse", "HEAD")
+	gitCmd(t, updater, "push", "origin", "main")
+
+	staleLocalTip := gitCmd(t, workDir, "rev-parse", "main")
+	if staleLocalTip == remoteTip {
+		t.Fatal("expected local main to be stale before resolveDefaultBranchTipSHA")
+	}
+	gitCmd(t, workDir, "remote", "set-url", "origin", filepath.Join(upstream, "missing"))
+
+	fallbackBaseSHA := "abc123"
+	got := resolveDefaultBranchTipSHA(context.Background(), workDir, upstream, fallbackBaseSHA, "main")
+	if got != fallbackBaseSHA {
+		t.Fatalf("resolveDefaultBranchTipSHA = %q, want fallback base %q when fetch fails", got, fallbackBaseSHA)
+	}
+	if got == staleLocalTip {
+		t.Fatalf("resolveDefaultBranchTipSHA reused stale local main %q after fetch failure", got)
 	}
 }
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -4870,6 +4870,81 @@ func TestCIStep_CommitAndPush_NoDirtyChangesButHeadAdvanced_PushesNewHead(t *tes
 	}
 }
 
+func TestCIStep_Execute_FixMode_RemoteAlreadyUpdatedDoesNotReturnManualIntervention(t *testing.T) {
+	t.Parallel()
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	originalHeadSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	os.WriteFile(filepath.Join(dir, "resolved.txt"), []byte("resolved"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "resolve conflict")
+	advancedHeadSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "--force-with-lease", "origin", "HEAD:refs/heads/feature")
+
+	checksJSON := `[{"name":"build","state":"FAILURE","bucket":"fail"}]`
+	env := fakeCIGHMergeable(t, "OPEN", checksJSON, "MERGEABLE")
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			return &agent.Result{}, nil
+		},
+	}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, originalHeadSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+	prURL := "https://github.com/test/repo/pull/42"
+	sctx.Run.PRURL = &prURL
+	sctx.Fixing = true
+	sctx.Config.CITimeout = 30 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
+	step := &CIStep{
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			cancel()
+			return ctx.Err()
+		},
+	}
+	_, err := step.Execute(sctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected polling to continue after head reconciliation, got %v", err)
+	}
+
+	if sctx.Run.HeadSHA != advancedHeadSHA {
+		t.Fatalf("Run.HeadSHA = %s, want %s", sctx.Run.HeadSHA, advancedHeadSHA)
+	}
+	dbRun, err := sctx.DB.GetRun(sctx.Run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dbRun.HeadSHA != advancedHeadSHA {
+		t.Fatalf("DB HeadSHA = %s, want %s", dbRun.HeadSHA, advancedHeadSHA)
+	}
+}
+
 func TestCIStep_CommitAndPush_UpdatesLocalBranchRefAfterDetachedPush(t *testing.T) {
 	t.Parallel()
 	upstream := t.TempDir()
@@ -6987,6 +7062,62 @@ func TestCIStep_TimeoutWithUnknownMergeableState_NeedsApproval(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected unresolved mergeability finding, got %+v", findings.Items)
+	}
+}
+
+func TestCIStep_TimeoutWithKnownFailureAndPendingCheck_NeedsApproval(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	checksJSON := `[{"name":"build","state":"FAILURE","bucket":"fail"},{"name":"test","state":"PENDING","bucket":"pending"}]`
+	env := fakeCIGHMergeable(t, "OPEN", checksJSON, "CONFLICTING")
+
+	prURL := "https://github.com/test/repo/pull/42"
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+	sctx.Config.CITimeout = 2 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{CI: 3}
+
+	started := time.Unix(1700000000, 0)
+	now := started
+	step := &CIStep{
+		now: func() time.Time {
+			return now
+		},
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			now = now.Add(interval)
+			return nil
+		},
+	}
+
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected NeedsApproval when known CI issues remain at timeout")
+	}
+
+	var findings Findings
+	if err := json.Unmarshal([]byte(outcome.Findings), &findings); err != nil {
+		t.Fatalf("unmarshal findings: %v", err)
+	}
+
+	foundFailure := false
+	foundConflict := false
+	for _, item := range findings.Items {
+		desc := strings.ToLower(item.Description)
+		if strings.Contains(desc, "build") {
+			foundFailure = true
+		}
+		if strings.Contains(desc, "merge conflict") {
+			foundConflict = true
+		}
+	}
+	if !foundFailure || !foundConflict {
+		t.Fatalf("expected failing check and merge conflict findings, got %+v", findings.Items)
 	}
 }
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -148,6 +148,7 @@ func fakeGlabHandler(args []string) {
 func fakeCIGHHandler(args []string) {
 	state := os.Getenv("FAKE_CLI_STATE")
 	checksJSON := os.Getenv("FAKE_CLI_CHECKS")
+	checksErr := os.Getenv("FAKE_CLI_CHECKS_ERR")
 	mergeable := os.Getenv("FAKE_CLI_MERGEABLE")
 	mergeableErr := os.Getenv("FAKE_CLI_MERGEABLE_ERR")
 	joined := strings.Join(args, " ")
@@ -171,6 +172,10 @@ func fakeCIGHHandler(args []string) {
 		os.Exit(0)
 	}
 	if strings.Contains(joined, "pr checks") {
+		if checksErr != "" {
+			fmt.Fprintln(os.Stderr, checksErr)
+			os.Exit(1)
+		}
 		fmt.Println(checksJSON)
 		os.Exit(0)
 	}
@@ -478,6 +483,58 @@ func TestResolveBaseSHA_ZeroNoDefaultBranch(t *testing.T) {
 	got := resolveBaseSHA(context.Background(), dir, zeroSHA, "main")
 	if got != git.EmptyTreeSHA {
 		t.Errorf("resolveBaseSHA zero no default = %q, want %q", got, git.EmptyTreeSHA)
+	}
+}
+
+func TestResolveDefaultBranchTipSHA_FetchesRemoteTip(t *testing.T) {
+	t.Parallel()
+
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	seed := t.TempDir()
+	gitCmd(t, seed, "init")
+	gitCmd(t, seed, "config", "user.name", "test")
+	gitCmd(t, seed, "config", "user.email", "test@test.com")
+	gitCmd(t, seed, "checkout", "-b", "main")
+	if err := os.WriteFile(filepath.Join(seed, "base.txt"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, seed, "add", "base.txt")
+	gitCmd(t, seed, "commit", "-m", "base")
+	gitCmd(t, seed, "remote", "add", "origin", upstream)
+	gitCmd(t, seed, "push", "origin", "main")
+
+	workDir := t.TempDir()
+	gitCmd(t, workDir, "clone", upstream, ".")
+	gitCmd(t, workDir, "checkout", "-b", "feature", "origin/main")
+
+	updater := t.TempDir()
+	gitCmd(t, updater, "clone", upstream, ".")
+	gitCmd(t, updater, "config", "user.name", "test")
+	gitCmd(t, updater, "config", "user.email", "test@test.com")
+	gitCmd(t, updater, "checkout", "main")
+	if err := os.WriteFile(filepath.Join(updater, "base.txt"), []byte("base updated\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, updater, "add", "base.txt")
+	gitCmd(t, updater, "commit", "-m", "main update")
+	remoteTip := gitCmd(t, updater, "rev-parse", "HEAD")
+	gitCmd(t, updater, "push", "origin", "main")
+
+	staleOriginTip := gitCmd(t, workDir, "rev-parse", "origin/main")
+	if staleOriginTip == remoteTip {
+		t.Fatal("expected origin/main to be stale before resolveDefaultBranchTipSHA")
+	}
+
+	got := resolveDefaultBranchTipSHA(context.Background(), workDir, staleOriginTip, "main")
+	if got != remoteTip {
+		t.Fatalf("resolveDefaultBranchTipSHA = %q, want remote tip %q", got, remoteTip)
+	}
+
+	fetchedOriginTip := gitCmd(t, workDir, "rev-parse", "origin/main")
+	if fetchedOriginTip != remoteTip {
+		t.Fatalf("origin/main after resolve = %q, want %q", fetchedOriginTip, remoteTip)
 	}
 }
 
@@ -5755,6 +5812,18 @@ func fakeCIGHMergeableError(t *testing.T, state, checksJSON, mergeableErr string
 	})
 }
 
+func fakeCIGHChecksError(t *testing.T, state, mergeable, checksErr string) []string {
+	t.Helper()
+	binDir := fakeCLIBinDir(t)
+	linkTestBinary(t, binDir, "gh")
+	return fakeCLIEnv(binDir, map[string]string{
+		"FAKE_CLI_MODE":       "ci-gh",
+		"FAKE_CLI_STATE":      state,
+		"FAKE_CLI_MERGEABLE":  mergeable,
+		"FAKE_CLI_CHECKS_ERR": checksErr,
+	})
+}
+
 func fakeCIGHSequenceMergeable(t *testing.T, state string, checks []string, mergeable string) []string {
 	t.Helper()
 	binDir := fakeCLIBinDir(t)
@@ -7116,6 +7185,56 @@ func TestCIStep_TimeoutWithKnownFailureAndPendingCheck_NeedsApproval(t *testing.
 	}
 	if !foundFailure || !foundConflict {
 		t.Fatalf("expected failing check and merge conflict findings, got %+v", findings.Items)
+	}
+}
+
+func TestCIStep_TimeoutWithMergeConflictAndCheckLookupError_NeedsApproval(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	env := fakeCIGHChecksError(t, "OPEN", "CONFLICTING", "gh checks failed")
+
+	prURL := "https://github.com/test/repo/pull/42"
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+	sctx.Config.CITimeout = 2 * time.Second
+
+	started := time.Unix(1700000000, 0)
+	now := started
+	step := &CIStep{
+		now: func() time.Time {
+			return now
+		},
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			now = now.Add(interval)
+			return nil
+		},
+	}
+
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected NeedsApproval when merge conflict remains known but checks lookup fails")
+	}
+
+	var findings Findings
+	if err := json.Unmarshal([]byte(outcome.Findings), &findings); err != nil {
+		t.Fatalf("unmarshal findings: %v", err)
+	}
+
+	foundConflict := false
+	for _, item := range findings.Items {
+		if strings.Contains(strings.ToLower(item.Description), "merge conflict") {
+			foundConflict = true
+			break
+		}
+	}
+	if !foundConflict {
+		t.Fatalf("expected merge conflict finding, got %+v", findings.Items)
 	}
 }
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -6967,7 +6967,7 @@ func TestCIStep_UnknownMergeableStateDoesNotExitCleanly(t *testing.T) {
 	}
 }
 
-func TestCIStep_MergeableLookupErrorDoesNotExitCleanly(t *testing.T) {
+func TestCIStep_MergeableLookupErrorStillExitsCleanlyWhenChecksPass(t *testing.T) {
 	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
@@ -6981,36 +6981,34 @@ func TestCIStep_MergeableLookupErrorDoesNotExitCleanly(t *testing.T) {
 	sctx.Run.PRURL = &prURL
 	sctx.Config.CITimeout = 10 * time.Second
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	sctx.Ctx = ctx
-
 	var logs []string
 	sctx.Log = func(s string) { logs = append(logs, s) }
 
-	step := &CIStep{
-		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
-			cancel()
-			return ctx.Err()
-		},
-	}
+	step := &CIStep{}
 
-	_, err := step.Execute(sctx)
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("expected polling to continue until canceled, got %v", err)
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatalf("expected clean exit, got %v", err)
+	}
+	if outcome.NeedsApproval {
+		t.Fatalf("expected clean outcome, got approval request: %+v", outcome)
 	}
 
 	foundWarning := false
+	foundPassed := false
 	for _, l := range logs {
 		if strings.Contains(l, "could not check mergeable state") {
 			foundWarning = true
 		}
 		if strings.Contains(l, "all CI checks passed") {
-			t.Fatalf("expected mergeable lookup error to block clean exit, got logs: %v", logs)
+			foundPassed = true
 		}
 	}
 	if !foundWarning {
 		t.Fatalf("expected mergeable lookup warning, got logs: %v", logs)
+	}
+	if !foundPassed {
+		t.Fatalf("expected clean-pass log after mergeable lookup warning, got logs: %v", logs)
 	}
 }
 
@@ -7367,5 +7365,84 @@ func TestCIStep_MergeConflictOnly_AutoFix(t *testing.T) {
 	}
 	if !foundConflict {
 		t.Fatalf("expected merge conflict log, got: %v", logs)
+	}
+}
+
+func TestCIStep_MergeConflictAutoFixPromptUsesBaseBranchTip(t *testing.T) {
+	t.Parallel()
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "shared.txt"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	if err := os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	featureHead := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	gitCmd(t, dir, "checkout", "main")
+	if err := os.WriteFile(filepath.Join(dir, "shared.txt"), []byte("base updated\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "shared.txt")
+	gitCmd(t, dir, "commit", "-m", "main update")
+	mainTip := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "main")
+	gitCmd(t, dir, "checkout", "feature")
+
+	checksJSON := `[{"name":"build","state":"SUCCESS","bucket":"pass"}]`
+	env := fakeCIGHMergeable(t, "OPEN", checksJSON, "CONFLICTING")
+
+	var capturedPrompt string
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			capturedPrompt = opts.Prompt
+			if err := os.WriteFile(filepath.Join(opts.CWD, "conflict-fix.txt"), []byte("resolved\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			return &agent.Result{}, nil
+		},
+	}
+
+	prURL := "https://github.com/test/repo/pull/42"
+	sctx := newTestContext(t, ag, dir, baseSHA, featureHead, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Repo.DefaultBranch = "main"
+	sctx.Config.CITimeout = 30 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{CI: 1}
+
+	step := &CIStep{}
+	_, err := step.autoFixCI(sctx, "42", nil, true)
+	if err != nil {
+		t.Fatalf("auto-fix CI: %v", err)
+	}
+	if capturedPrompt == "" {
+		t.Fatal("expected agent to receive a prompt")
+	}
+	if !strings.Contains(capturedPrompt, "base commit: "+mainTip) {
+		t.Fatalf("expected prompt to use base branch tip %s, got:\n%s", mainTip, capturedPrompt)
+	}
+	if strings.Contains(capturedPrompt, "base commit: "+baseSHA) {
+		t.Fatalf("expected prompt to avoid merge-base %s, got:\n%s", baseSHA, capturedPrompt)
 	}
 }


### PR DESCRIPTION
## Summary
- Update the Babysit CI step to watch PR mergeability alongside check status, wait for pending checks before acting, and auto-fix merge conflicts against the latest default-branch tip so conflicted branches are handled safely.
- Harden mergeability and base-tip resolution around GitHub/API and fetch failures to avoid stale targets or false clean outcomes while preserving conflict-related blocking behavior.
- Expand `internal/pipeline/steps` coverage and refresh the README and docs so Babysit, `ci_timeout`, and `auto_fix.ci` accurately describe merge-conflict monitoring and auto-fix behavior.

## Risk Assessment

⚠️ Medium: The change is well-scoped and heavily tested, but the new mergeability path can silently miss real merge conflicts when the lookup fails, so it is safer to merge only after that error-handling gap is addressed.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

**Round 1** - found 2 issues (1 error, 1 warning)
- 🚨 `internal/pipeline/steps/ci.go:366` - `isMergeConflict` only treats `CONFLICTING` as unresolved. GitHub reports `mergeable=UNKNOWN` while it is still computing mergeability, and `Execute` then falls through to the success path, so a PR with real merge conflicts can be marked clean if the first poll races that computation.
- ⚠️ `internal/pipeline/steps/ci.go:225` - When `gh pr view --json mergeable` fails, the code logs a warning and continues as if there is no merge issue. A transient GitHub CLI/API failure now bypasses the new merge-conflict gate and can incorrectly return `all CI checks passed`.

**Round 2** (auto-fix) - found 2 issues (1 error, 1 warning)
- 🚨 `internal/pipeline/steps/ci.go:268` - The new merge-conflict auto-fix path treats `autoFixCI(...)=false` as &#39;no changes&#39;, but `commitAndPush` returns false whenever the agent resolves conflicts by rebasing/cherry-picking to a clean `HEAD` with no dirty worktree. That means a successful conflict resolution can still fall through to manual intervention instead of being accepted and pushed.
- ⚠️ `internal/pipeline/steps/ci.go:303` - If `gh pr view --json mergeable` keeps returning `UNKNOWN` or errors, the step now waits until `CITimeout` and then exits with an empty outcome. This neither reports approval-needed nor surfaces an unresolved mergeability check, so the merge-conflict gate silently degrades under GitHub lag/API failures.

**Round 3** (auto-fix) - found 2 issues (1 error, 1 warning)
- 🚨 `internal/pipeline/steps/ci.go:222` - If at least one check is already failing or the PR is already in conflict while another check stays pending, the loop waits for &#34;all checks to complete&#34; and then returns a clean outcome on timeout because the timeout path only looks at `mergeabilityBlockedReason`. That can let a known-bad PR pass the CI step with no approval required.
- ⚠️ `internal/pipeline/steps/ci.go:555` - `pushUpdatedHeadSHA` reports `false` when the remote already points at `newHeadSHA`, but `Execute` treats any `false` from `autoFixCI` as &#34;CI fix produced no changes&#34;. In a concurrent or retried run where the same rewritten head was already pushed, this step can incorrectly fall back to manual intervention even though the fix is already on the branch.

**Round 4** (auto-fix) - found 2 warnings
- ⚠️ `internal/pipeline/steps/ci.go:279` - Merge conflicts are now gated behind `hasIssues &amp;&amp; pending`, so a PR that is already known to be unmergeable will sit waiting for unrelated in-flight checks to finish before rebasing. Those checks will be invalidated by the rebase anyway, so this can burn the full CI timeout and fall back to manual approval even though the conflict could have been fixed immediately.
- ⚠️ `internal/pipeline/steps/ci.go:493` - The auto-fix prompt still says the agent `MUST produce file changes that fix the failing checks` even in the merge-conflict-only path. That contradicts the new clean-head rebase flow and can push the agent toward unnecessary edits or a false &#39;no fix&#39; outcome when a rebase alone would resolve the issue.

**Round 5** (user-fix) - found 2 warnings
- ⚠️ `internal/pipeline/steps/ci.go:434` - `autoFixCI` now tells the agent to rebase onto the base branch for merge conflicts, but the only base context it passes is `resolveBranchBaseSHA(...)`, which returns the branch merge-base, not the current base branch tip. Rebasing onto that SHA is effectively a no-op, so merge-conflict auto-fix can be aimed at the wrong target.
- ⚠️ `internal/pipeline/steps/ci.go:395` - The new merge-conflict gating hard-requires `gh pr view --json mergeable`. If the local `gh` build does not expose that field, or GitHub returns a transient error, the step now blocks clean success and keeps polling until timeout even when all checks are passing.

**Round 6** (user-fix) - found 2 warnings
- ⚠️ `internal/pipeline/steps/common.go:51` - `resolveDefaultBranchTipSHA` reads `origin/&lt;default&gt;` from the local clone without fetching first, so a stale remote-tracking ref can tell the CI fixer to rebase onto the wrong base tip and leave the PR conflicted on GitHub.
- ⚠️ `internal/pipeline/steps/ci.go:267` - When `gh pr checks` fails, the loop logs and continues without recording the already-known merge-conflict state, so the timeout path can return a clean outcome even if `getMergeableState` kept reporting `CONFLICTING`. Treat CI lookup failures as blocking or persist mergeability state independently of the checks-success branch.

**Round 7** (user-fix) - found 2 warnings
- ⚠️ `internal/pipeline/steps/ci.go:251` - A `gh pr view --json mergeable` failure is treated like a known-good mergeability state: `mergeabilityKnown` stays `true` and `mergeConflict` stays `false`, so the success path can still return &#34;all CI checks passed&#34; when mergeability is actually unknown. Treat lookup errors as blocked/unknown so merge-conflict gating is not bypassed by transient GitHub CLI/API failures.
- ⚠️ `internal/pipeline/steps/common.go:53` - `resolveDefaultBranchTipSHA` silently ignores fetch failures and then reuses whatever local `origin/&lt;default&gt;` ref happens to exist. In the new merge-conflict auto-fix flow this can hand the agent a stale base commit, causing it to rebase onto the wrong tip and leave the PR conflicting. Surface the fetch failure or fall back in a way that cannot return a stale remote-tracking ref.

**Round 8** (user-fix) - found 2 warnings
- ⚠️ `internal/pipeline/steps/common.go:53` - `resolveDefaultBranchTipSHA` hard-codes the remote name `origin`, but this pipeline otherwise uses `Repo.UpstreamURL` directly; in repos whose upstream remote is not named `origin`, merge-conflict auto-fix will fall back to older local refs or the stored base SHA and hand the agent the wrong rebase target.
- ⚠️ `internal/pipeline/steps/common.go:54` - On fetch failure, the helper returns the local `main` tip before falling back to `fallbackBaseSHA`; if that local branch is stale, the new merge-conflict prompt still points the agent at an out-of-date base and can produce a conflict resolution that immediately diverges from the real default branch.

**Round 9** (user-fix) - found 1 warning
- ⚠️ `internal/pipeline/steps/ci.go:252` - If `gh pr view --json mergeable` fails, the step clears `mergeabilityBlockedReason` and continues as though mergeability were non-blocking. On a transient GitHub/API error, a PR with unresolved merge conflicts can therefore be reported as clean as soon as checks pass, which defeats the new merge-conflict gating.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>🔧 **Document** - 3 issues found → auto-fixed (3) + user-fixed (2)</summary>

**Round 1** - found 3 issues (1 warning, 2 infos)
- ⚠️ `docs/src/content/docs/guides/pipeline-steps.md:123` - The Babysit step docs are stale relative to the code change. The step now also polls PR mergeability, waits for unresolved mergeable state before exiting cleanly, and can auto-fix merge conflicts by rebasing/resolving against the latest default-branch tip, but the guide still describes only CI check polling and CI failure fixes.
- ℹ️ `docs/src/content/docs/reference/global-config.md:102` - `auto_fix.ci` is documented as covering only &#34;CI failure auto-fix attempts&#34;, but the CI/Babysit step now spends that budget on merge-conflict fixes too. The config reference should broaden this description so users understand the full scope of the setting.
- ℹ️ `docs/src/content/docs/reference/repo-config.md:108` - The repo config reference narrows `auto_fix.ci` to CI failures only, which is now stale. This setting also governs Babysit-step merge-conflict auto-fix attempts and should be documented that way here as well.

**Round 2** (auto-fix) - found 4 issues (2 warnings, 2 infos)
- ⚠️ `docs/src/content/docs/guides/pipeline-steps.md:138` - The Babysit guide still says the step exits cleanly when the timeout is reached, but the new code now returns approval findings on timeout when CI failures are still present or when PR mergeability never resolves. The timeout behavior needs to document these non-clean exit cases.
- ⚠️ `docs/src/content/docs/getting-started.md:100` - The high-level pipeline overview still describes Babysit as only polling CI and auto-fixing failures. This change also makes Babysit detect and auto-fix PR merge conflicts, so the step summary is now stale.
- ℹ️ `docs/src/content/docs/guides/configuration.md:33` - The configuration guide says `ci_timeout` only controls how long Babysit polls CI before giving up. After this change, the same timeout also covers waiting for PR mergeability and merge-conflict handling, so the field description should be broadened.
- ℹ️ `docs/src/content/docs/reference/global-config.md:66` - The `ci_timeout` reference still scopes the setting to polling CI only. Babysit now also waits on PR mergeability and can surface merge-conflict-related findings at timeout, so this field description is stale.

**Round 3** (auto-fix) - found 2 warnings
- ⚠️ `docs/src/content/docs/index.mdx:32` - The landing-page copy for &#34;CI babysitting&#34; still says the pipeline only watches CI checks and auto-fixes failures. This change also added PR mergeability monitoring and merge-conflict auto-fix, so the hero/tagline or feature card should be updated to describe Babysit as watching overall PR health, not just CI.
- ⚠️ `docs/src/content/docs/guides/auto-fix.md:30` - The Auto-Fix guide still lists `auto_fix.ci` without explaining that it now applies to the Babysit step&#39;s merge-conflict handling as well as CI failures. It should be updated so users configuring auto-fix limits understand that the same budget now covers mergeability/merge-conflict fixes too.

**Round 4** (auto-fix) - found 2 warnings
- ⚠️ `README.md:182` - The README config example still says `ci_timeout` controls only GitHub check monitoring. The code change extends the Babysit step to wait on both CI and PR mergeability, so this line should be updated to match the new behavior.
- ⚠️ `README.md:192` - The README&#39;s `auto_fix.ci` example is now incomplete. After this change, the CI/Babysit auto-fix budget is shared across CI-failure fixes and merge-conflict fixes, and the README should document that updated meaning.

**Round 5** (user-fix) - found 1 warning
- ⚠️ `docs/src/content/docs/guides/pipeline-steps.md:129` - The Babysit behavior docs were updated for mergeability and merge-conflict fixing, but they still do not mention the new wait-until-all-checks-finish behavior before auto-fixing known CI issues. The code now defers fix attempts while any checks remain pending, which is a user-visible behavior change worth documenting here.

**Round 6** (user-fix) - found 0 issues

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
