### PR TITLE
fix(update): reset daemon after self-update and document failure handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ To update an existing install in place:
 no-mistakes update
 ```
 
-This replaces the binary and resets the background daemon so it picks up the new executable. If the daemon does not come back cleanly, the update still succeeds but reports the daemon reset failure.
+This replaces the binary and resets the background daemon so it picks up the new executable. If the daemon does not come back cleanly, the new binary stays installed but the command reports the daemon reset failure.
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ To update an existing install in place:
 no-mistakes update
 ```
 
+This replaces the binary and resets the background daemon so it picks up the new executable. If the daemon does not come back cleanly, the update still succeeds but reports the daemon reset failure.
+
 ## How It Works
 
 ```text
@@ -139,7 +141,7 @@ no-mistakes update
 | --------------------------- | ------------------------------------------------------ |
 | `no-mistakes`               | Attach to the active pipeline run for the current repo |
 | `no-mistakes init`          | Initialize the gate for the current repository         |
-| `no-mistakes update`        | Update the installed binary from GitHub Releases       |
+| `no-mistakes update`        | Update the binary and reset the daemon                 |
 | `no-mistakes eject`         | Remove the gate from the current repository            |
 | `no-mistakes attach`        | Attach to the active pipeline run                      |
 | `no-mistakes rerun`         | Rerun the pipeline for the current branch              |

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -109,7 +109,7 @@ To update an existing install in place:
 no-mistakes update
 ```
 
-This downloads the latest release from GitHub, verifies the SHA-256 checksum, and atomically replaces the binary.
+This downloads the latest release from GitHub, verifies the SHA-256 checksum, atomically replaces the binary, and resets the daemon so it starts using the new executable. If the daemon does not come back cleanly, the command reports that failure after the binary update.
 
 ## Remove from a repo
 

--- a/docs/src/content/docs/guides/daemon.md
+++ b/docs/src/content/docs/guides/daemon.md
@@ -17,7 +17,12 @@ no-mistakes daemon status
 no-mistakes init
 no-mistakes attach
 no-mistakes rerun
+
+# Resets the daemon after replacing the binary
+no-mistakes update
 ```
+
+`no-mistakes update` stops and starts the daemon when it is running, or when stale daemon artifacts exist, so the new executable is used.
 
 The daemon writes its PID to `~/.no-mistakes/daemon.pid` and listens on a Unix socket at `~/.no-mistakes/socket`. On Windows, it uses a localhost TCP listener and a protected endpoint file at the same path.
 

--- a/docs/src/content/docs/how-it-works.md
+++ b/docs/src/content/docs/how-it-works.md
@@ -58,7 +58,7 @@ A long-running background process that manages pipeline runs. It:
 - Persists state to SQLite
 - Streams events to connected TUI clients via IPC
 
-The daemon auto-starts when needed (`init`, `attach`, `rerun`) and can be managed explicitly with `no-mistakes daemon start|stop|status`.
+The daemon auto-starts when needed (`init`, `attach`, `rerun`), and `update` resets it after replacing the binary when the daemon is running or stale daemon artifacts exist. You can also manage it explicitly with `no-mistakes daemon start|stop|status`.
 
 On startup, the daemon recovers from crashes by marking any stuck runs as failed and cleaning up orphaned worktrees.
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -107,7 +107,7 @@ Uses indicators: `✓` (available), `–` (not found, optional), `✗` (problem 
 
 ## no-mistakes update
 
-Update the installed binary from GitHub Releases.
+Update the installed binary and reset the daemon.
 
 ```sh
 no-mistakes update

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -113,7 +113,7 @@ Update the installed binary from GitHub Releases.
 no-mistakes update
 ```
 
-Downloads the latest release, verifies the SHA-256 checksum, and atomically replaces the running binary. On macOS, removes the quarantine extended attribute.
+Downloads the latest release, verifies the SHA-256 checksum, atomically replaces the running binary, and resets the daemon when it is running or stale daemon artifacts exist so the new executable is picked up. If the daemon does not come back cleanly, the command reports that failure after the binary update. On macOS, removes the quarantine extended attribute.
 
 Background update checks run automatically on each CLI invocation (except `update` itself). If a newer version is available, a notification is printed to stderr. Suppressed for dev builds or when `NO_MISTAKES_NO_UPDATE_CHECK=1` is set.
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -8,7 +8,7 @@ import (
 func newUpdateCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "update",
-		Short: "Update no-mistakes from GitHub Releases",
+		Short: "Update no-mistakes and reset the daemon",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return update.Run(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr())

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -9,6 +9,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -40,6 +41,22 @@ const (
 
 var allowInsecureDownloads bool
 var githubAPIBaseURL = "https://api.github.com"
+var daemonIsRunning = daemon.IsRunning
+var daemonStop = daemon.Stop
+var daemonStart = daemon.Start
+
+type daemonResetError struct {
+	err           error
+	daemonOffline bool
+}
+
+func (e *daemonResetError) Error() string {
+	return e.err.Error()
+}
+
+func (e *daemonResetError) Unwrap() error {
+	return e.err
+}
 
 type platformSpec struct {
 	GOOS   string
@@ -413,6 +430,10 @@ func (u *updater) run(ctx context.Context) error {
 	}
 	if u.resetDaemon != nil {
 		if err := u.resetDaemon(); err != nil {
+			var resetErr *daemonResetError
+			if errors.As(err, &resetErr) && resetErr.daemonOffline {
+				return fmt.Errorf("updated %s to %s, but daemon is offline: %w", u.appName, plan.LatestVersion, err)
+			}
 			fmt.Fprintf(u.stderrWriter(), "updated %s to %s, but failed to reset daemon: %v\n", u.appName, plan.LatestVersion, err)
 		}
 	}
@@ -424,18 +445,18 @@ func defaultResetDaemon(p *paths.Paths) error {
 	if p == nil {
 		return nil
 	}
-	alive, err := daemon.IsRunning(p)
+	alive, err := daemonIsRunning(p)
 	if err != nil {
 		return fmt.Errorf("check daemon: %w", err)
 	}
 	if !alive {
 		return nil
 	}
-	if err := daemon.Stop(p); err != nil {
+	if err := daemonStop(p); err != nil {
 		return fmt.Errorf("stop daemon: %w", err)
 	}
-	if err := daemon.Start(p); err != nil {
-		return fmt.Errorf("start daemon: %w", err)
+	if err := daemonStart(p); err != nil {
+		return &daemonResetError{err: fmt.Errorf("start daemon: %w", err), daemonOffline: true}
 	}
 	return nil
 }

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -434,7 +434,7 @@ func (u *updater) run(ctx context.Context) error {
 			if errors.As(err, &resetErr) && resetErr.daemonOffline {
 				return fmt.Errorf("updated %s to %s, but daemon is offline: %w", u.appName, plan.LatestVersion, err)
 			}
-			fmt.Fprintf(u.stderrWriter(), "updated %s to %s, but failed to reset daemon: %v\n", u.appName, plan.LatestVersion, err)
+			return fmt.Errorf("updated %s to %s, but failed to reset daemon: %w", u.appName, plan.LatestVersion, err)
 		}
 	}
 	fmt.Fprintf(u.stdoutWriter(), "updated %s from %s to %s\n", u.appName, u.currentVersion, plan.LatestVersion)

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/buildinfo"
+	"github.com/kunchenguid/no-mistakes/internal/daemon"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
 )
 
@@ -82,6 +83,7 @@ type updater struct {
 	stderr            io.Writer
 	now               func() time.Time
 	spawnBackground   func(currentVersion string) error
+	resetDaemon       func() error
 	disableBackground bool
 	noColor           bool
 }
@@ -155,6 +157,9 @@ func defaultUpdater(stdout, stderr io.Writer) (*updater, error) {
 		stderr:          stderr,
 		now:             time.Now,
 		spawnBackground: defaultSpawnBackground,
+		resetDaemon: func() error {
+			return defaultResetDaemon(p)
+		},
 	}, nil
 }
 
@@ -406,7 +411,32 @@ func (u *updater) run(ctx context.Context) error {
 	if err := replaceExecutable(u.executablePath, binaryData); err != nil {
 		return err
 	}
+	if u.resetDaemon != nil {
+		if err := u.resetDaemon(); err != nil {
+			return fmt.Errorf("reset daemon: %w", err)
+		}
+	}
 	fmt.Fprintf(u.stdoutWriter(), "updated %s from %s to %s\n", u.appName, u.currentVersion, plan.LatestVersion)
+	return nil
+}
+
+func defaultResetDaemon(p *paths.Paths) error {
+	if p == nil {
+		return nil
+	}
+	alive, err := daemon.IsRunning(p)
+	if err != nil {
+		return fmt.Errorf("check daemon: %w", err)
+	}
+	if !alive {
+		return nil
+	}
+	if err := daemon.Stop(p); err != nil {
+		return fmt.Errorf("stop daemon: %w", err)
+	}
+	if err := daemon.Start(p); err != nil {
+		return fmt.Errorf("start daemon: %w", err)
+	}
 	return nil
 }
 

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -446,7 +446,7 @@ func defaultResetDaemon(p *paths.Paths) error {
 		return nil
 	}
 	alive, err := daemonIsRunning(p)
-	if err == nil && !alive {
+	if err == nil && !alive && !daemonArtifactsExist(p) {
 		return nil
 	}
 	if err := daemonStop(p); err != nil {
@@ -458,6 +458,15 @@ func defaultResetDaemon(p *paths.Paths) error {
 		return &daemonResetError{err: fmt.Errorf("start daemon: %w", err), daemonOffline: offline}
 	}
 	return nil
+}
+
+func daemonArtifactsExist(p *paths.Paths) bool {
+	for _, path := range []string{p.Socket(), p.PIDFile()} {
+		if _, err := os.Stat(path); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 func (u *updater) fetchLatestRelease(ctx context.Context) (*releaseResponse, error) {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -413,7 +413,7 @@ func (u *updater) run(ctx context.Context) error {
 	}
 	if u.resetDaemon != nil {
 		if err := u.resetDaemon(); err != nil {
-			return fmt.Errorf("reset daemon: %w", err)
+			fmt.Fprintf(u.stderrWriter(), "updated %s to %s, but failed to reset daemon: %v\n", u.appName, plan.LatestVersion, err)
 		}
 	}
 	fmt.Fprintf(u.stdoutWriter(), "updated %s from %s to %s\n", u.appName, u.currentVersion, plan.LatestVersion)

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -446,17 +446,16 @@ func defaultResetDaemon(p *paths.Paths) error {
 		return nil
 	}
 	alive, err := daemonIsRunning(p)
-	if err != nil {
-		return fmt.Errorf("check daemon: %w", err)
-	}
-	if !alive {
+	if err == nil && !alive {
 		return nil
 	}
 	if err := daemonStop(p); err != nil {
 		return fmt.Errorf("stop daemon: %w", err)
 	}
 	if err := daemonStart(p); err != nil {
-		return &daemonResetError{err: fmt.Errorf("start daemon: %w", err), daemonOffline: true}
+		running, checkErr := daemonIsRunning(p)
+		offline := checkErr == nil && !running
+		return &daemonResetError{err: fmt.Errorf("start daemon: %w", err), daemonOffline: offline}
 	}
 	return nil
 }

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +18,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/paths"
 )
 
 func TestCompareVersions(t *testing.T) {
@@ -469,6 +472,106 @@ func TestUpdaterRunKeepsSuccessfulUpdateWhenDaemonResetFails(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "reset daemon") {
 		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestUpdaterRunFailsWhenDaemonResetLeavesDaemonOffline(t *testing.T) {
+	allowInsecureDownloads = true
+	t.Cleanup(func() { allowInsecureDownloads = false })
+
+	archiveName := "no-mistakes-v1.2.3-darwin-arm64.tar.gz"
+	archive := makeTarGz(t, map[string][]byte{
+		"bin/no-mistakes": []byte("new-binary"),
+	})
+	sum := sha256.Sum256(archive)
+	checksums := fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), archiveName)
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/kunchenguid/no-mistakes/releases/latest":
+			fmt.Fprintf(w, `{"tag_name":"v1.2.3","assets":[{"name":%q,"browser_download_url":%q},{"name":"checksums.txt","browser_download_url":%q}]}`,
+				archiveName,
+				server.URL+"/archive",
+				server.URL+"/checksums",
+			)
+		case "/archive":
+			w.Write(archive)
+		case "/checksums":
+			fmt.Fprint(w, checksums)
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	execPath := filepath.Join(t.TempDir(), "no-mistakes")
+	if err := os.WriteFile(execPath, []byte("old-binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout := new(bytes.Buffer)
+	u := &updater{
+		appName:        "no-mistakes",
+		repo:           "kunchenguid/no-mistakes",
+		currentVersion: "v1.2.2",
+		platform:       platformSpec{GOOS: "darwin", GOARCH: "arm64"},
+		apiBaseURL:     server.URL,
+		httpClient:     server.Client(),
+		executablePath: execPath,
+		stdout:         stdout,
+		now:            func() time.Time { return time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC) },
+		resetDaemon: func() error {
+			return &daemonResetError{err: errors.New("start daemon: boom"), daemonOffline: true}
+		},
+	}
+
+	err := u.run(context.Background())
+	if err == nil {
+		t.Fatal("run should fail when daemon reset leaves daemon offline")
+	}
+	if !strings.Contains(err.Error(), "daemon is offline") {
+		t.Fatalf("run error = %v", err)
+	}
+	content, readErr := os.ReadFile(execPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(content) != "new-binary" {
+		t.Fatalf("executable content = %q", string(content))
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestDefaultResetDaemonReportsOfflineWhenRestartFails(t *testing.T) {
+	origIsRunning := daemonIsRunning
+	origStop := daemonStop
+	origStart := daemonStart
+	t.Cleanup(func() {
+		daemonIsRunning = origIsRunning
+		daemonStop = origStop
+		daemonStart = origStart
+	})
+
+	daemonIsRunning = func(*paths.Paths) (bool, error) { return true, nil }
+	daemonStop = func(*paths.Paths) error { return nil }
+	daemonStart = func(*paths.Paths) error { return errors.New("boom") }
+
+	err := defaultResetDaemon(&paths.Paths{})
+	if err == nil {
+		t.Fatal("defaultResetDaemon should fail when restart fails")
+	}
+	var resetErr *daemonResetError
+	if !errors.As(err, &resetErr) {
+		t.Fatalf("expected daemonResetError, got %T", err)
+	}
+	if !resetErr.daemonOffline {
+		t.Fatal("expected daemon to be marked offline")
+	}
+	if !strings.Contains(err.Error(), "start daemon") {
+		t.Fatalf("error = %v", err)
 	}
 }
 

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -622,6 +622,40 @@ func TestDefaultResetDaemonRecoversWhenHealthCheckErrors(t *testing.T) {
 	}
 }
 
+func TestDefaultResetDaemonNoopWhenDaemonOfflineAndNoArtifacts(t *testing.T) {
+	origIsRunning := daemonIsRunning
+	origStop := daemonStop
+	origStart := daemonStart
+	t.Cleanup(func() {
+		daemonIsRunning = origIsRunning
+		daemonStop = origStop
+		daemonStart = origStart
+	})
+
+	p := paths.WithRoot(t.TempDir())
+	stopCalled := false
+	startCalled := false
+	daemonIsRunning = func(*paths.Paths) (bool, error) { return false, nil }
+	daemonStop = func(*paths.Paths) error {
+		stopCalled = true
+		return nil
+	}
+	daemonStart = func(*paths.Paths) error {
+		startCalled = true
+		return nil
+	}
+
+	if err := defaultResetDaemon(p); err != nil {
+		t.Fatalf("defaultResetDaemon error = %v", err)
+	}
+	if stopCalled {
+		t.Fatal("expected stop to be skipped when daemon is offline without artifacts")
+	}
+	if startCalled {
+		t.Fatal("expected start to be skipped when daemon is offline without artifacts")
+	}
+}
+
 func TestDefaultResetDaemonRecoversWhenDaemonArtifactsRemain(t *testing.T) {
 	origIsRunning := daemonIsRunning
 	origStop := daemonStop

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -342,6 +342,65 @@ func TestUpdaterRunReplacesExecutable(t *testing.T) {
 	}
 }
 
+func TestUpdaterRunResetsDaemonAfterUpdate(t *testing.T) {
+	allowInsecureDownloads = true
+	t.Cleanup(func() { allowInsecureDownloads = false })
+
+	archiveName := "no-mistakes-v1.2.3-darwin-arm64.tar.gz"
+	archive := makeTarGz(t, map[string][]byte{
+		"bin/no-mistakes": []byte("new-binary"),
+	})
+	sum := sha256.Sum256(archive)
+	checksums := fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), archiveName)
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/kunchenguid/no-mistakes/releases/latest":
+			fmt.Fprintf(w, `{"tag_name":"v1.2.3","assets":[{"name":%q,"browser_download_url":%q},{"name":"checksums.txt","browser_download_url":%q}]}`,
+				archiveName,
+				server.URL+"/archive",
+				server.URL+"/checksums",
+			)
+		case "/archive":
+			w.Write(archive)
+		case "/checksums":
+			fmt.Fprint(w, checksums)
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	execPath := filepath.Join(t.TempDir(), "no-mistakes")
+	if err := os.WriteFile(execPath, []byte("old-binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	resetCalled := false
+	u := &updater{
+		appName:        "no-mistakes",
+		repo:           "kunchenguid/no-mistakes",
+		currentVersion: "v1.2.2",
+		platform:       platformSpec{GOOS: "darwin", GOARCH: "arm64"},
+		apiBaseURL:     server.URL,
+		httpClient:     server.Client(),
+		executablePath: execPath,
+		now:            func() time.Time { return time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC) },
+		resetDaemon: func() error {
+			resetCalled = true
+			return nil
+		},
+	}
+
+	if err := u.run(context.Background()); err != nil {
+		t.Fatalf("run error = %v", err)
+	}
+	if !resetCalled {
+		t.Fatal("expected daemon reset after successful update")
+	}
+}
+
 func TestReplaceExecutableDarwinRequiresAtomicReplace(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("darwin-specific behavior")

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -559,7 +559,14 @@ func TestDefaultResetDaemonReportsOfflineWhenRestartFails(t *testing.T) {
 		daemonStart = origStart
 	})
 
-	daemonIsRunning = func(*paths.Paths) (bool, error) { return true, nil }
+	checks := 0
+	daemonIsRunning = func(*paths.Paths) (bool, error) {
+		checks++
+		if checks == 1 {
+			return true, nil
+		}
+		return false, nil
+	}
 	daemonStop = func(*paths.Paths) error { return nil }
 	daemonStart = func(*paths.Paths) error { return errors.New("boom") }
 
@@ -574,8 +581,81 @@ func TestDefaultResetDaemonReportsOfflineWhenRestartFails(t *testing.T) {
 	if !resetErr.daemonOffline {
 		t.Fatal("expected daemon to be marked offline")
 	}
+	if checks < 2 {
+		t.Fatalf("expected follow-up daemon check, got %d checks", checks)
+	}
 	if !strings.Contains(err.Error(), "start daemon") {
 		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestDefaultResetDaemonRecoversWhenHealthCheckErrors(t *testing.T) {
+	origIsRunning := daemonIsRunning
+	origStop := daemonStop
+	origStart := daemonStart
+	t.Cleanup(func() {
+		daemonIsRunning = origIsRunning
+		daemonStop = origStop
+		daemonStart = origStart
+	})
+
+	stopCalled := false
+	startCalled := false
+	daemonIsRunning = func(*paths.Paths) (bool, error) { return false, errors.New("health check failed") }
+	daemonStop = func(*paths.Paths) error {
+		stopCalled = true
+		return nil
+	}
+	daemonStart = func(*paths.Paths) error {
+		startCalled = true
+		return nil
+	}
+
+	if err := defaultResetDaemon(&paths.Paths{}); err != nil {
+		t.Fatalf("defaultResetDaemon error = %v", err)
+	}
+	if !stopCalled {
+		t.Fatal("expected stop to be attempted after health-check error")
+	}
+	if !startCalled {
+		t.Fatal("expected start to be attempted after health-check error")
+	}
+}
+
+func TestDefaultResetDaemonDoesNotReportOfflineWhenRestartLeavesDaemonRunning(t *testing.T) {
+	origIsRunning := daemonIsRunning
+	origStop := daemonStop
+	origStart := daemonStart
+	t.Cleanup(func() {
+		daemonIsRunning = origIsRunning
+		daemonStop = origStop
+		daemonStart = origStart
+	})
+
+	checks := 0
+	daemonIsRunning = func(*paths.Paths) (bool, error) {
+		checks++
+		if checks == 1 {
+			return true, nil
+		}
+		return true, nil
+	}
+	daemonStop = func(*paths.Paths) error { return nil }
+	daemonStart = func(*paths.Paths) error { return errors.New("daemon already running") }
+
+	err := defaultResetDaemon(&paths.Paths{})
+	if err == nil {
+		t.Fatal("defaultResetDaemon should fail when restart fails")
+	}
+	var resetErr *daemonResetError
+	if !errors.As(err, &resetErr) {
+		t.Fatalf("expected daemonResetError, got %T", err)
+	}
+	if resetErr.daemonOffline {
+		t.Fatal("expected daemon to stay online")
+	}
+	if checks < 2 {
+		t.Fatalf("expected follow-up daemon check, got %d checks", checks)
 	}
 }
 

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -401,6 +401,77 @@ func TestUpdaterRunResetsDaemonAfterUpdate(t *testing.T) {
 	}
 }
 
+func TestUpdaterRunKeepsSuccessfulUpdateWhenDaemonResetFails(t *testing.T) {
+	allowInsecureDownloads = true
+	t.Cleanup(func() { allowInsecureDownloads = false })
+
+	archiveName := "no-mistakes-v1.2.3-darwin-arm64.tar.gz"
+	archive := makeTarGz(t, map[string][]byte{
+		"bin/no-mistakes": []byte("new-binary"),
+	})
+	sum := sha256.Sum256(archive)
+	checksums := fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), archiveName)
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/kunchenguid/no-mistakes/releases/latest":
+			fmt.Fprintf(w, `{"tag_name":"v1.2.3","assets":[{"name":%q,"browser_download_url":%q},{"name":"checksums.txt","browser_download_url":%q}]}`,
+				archiveName,
+				server.URL+"/archive",
+				server.URL+"/checksums",
+			)
+		case "/archive":
+			w.Write(archive)
+		case "/checksums":
+			fmt.Fprint(w, checksums)
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	execPath := filepath.Join(t.TempDir(), "no-mistakes")
+	if err := os.WriteFile(execPath, []byte("old-binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	u := &updater{
+		appName:        "no-mistakes",
+		repo:           "kunchenguid/no-mistakes",
+		currentVersion: "v1.2.2",
+		platform:       platformSpec{GOOS: "darwin", GOARCH: "arm64"},
+		apiBaseURL:     server.URL,
+		httpClient:     server.Client(),
+		executablePath: execPath,
+		stdout:         stdout,
+		stderr:         stderr,
+		now:            func() time.Time { return time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC) },
+		resetDaemon: func() error {
+			return fmt.Errorf("boom")
+		},
+	}
+
+	if err := u.run(context.Background()); err != nil {
+		t.Fatalf("run error = %v", err)
+	}
+	content, err := os.ReadFile(execPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "new-binary" {
+		t.Fatalf("executable content = %q", string(content))
+	}
+	if !strings.Contains(stdout.String(), "updated no-mistakes") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "reset daemon") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
 func TestReplaceExecutableDarwinRequiresAtomicReplace(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("darwin-specific behavior")

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -622,6 +622,44 @@ func TestDefaultResetDaemonRecoversWhenHealthCheckErrors(t *testing.T) {
 	}
 }
 
+func TestDefaultResetDaemonRecoversWhenDaemonArtifactsRemain(t *testing.T) {
+	origIsRunning := daemonIsRunning
+	origStop := daemonStop
+	origStart := daemonStart
+	t.Cleanup(func() {
+		daemonIsRunning = origIsRunning
+		daemonStop = origStop
+		daemonStart = origStart
+	})
+
+	p := paths.WithRoot(t.TempDir())
+	if err := os.WriteFile(p.Socket(), []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stopCalled := false
+	startCalled := false
+	daemonIsRunning = func(*paths.Paths) (bool, error) { return false, nil }
+	daemonStop = func(*paths.Paths) error {
+		stopCalled = true
+		return nil
+	}
+	daemonStart = func(*paths.Paths) error {
+		startCalled = true
+		return nil
+	}
+
+	if err := defaultResetDaemon(p); err != nil {
+		t.Fatalf("defaultResetDaemon error = %v", err)
+	}
+	if !stopCalled {
+		t.Fatal("expected stop to be attempted when daemon artifacts remain")
+	}
+	if !startCalled {
+		t.Fatal("expected start to be attempted when daemon artifacts remain")
+	}
+}
+
 func TestDefaultResetDaemonDoesNotReportOfflineWhenRestartLeavesDaemonRunning(t *testing.T) {
 	origIsRunning := daemonIsRunning
 	origStop := daemonStop

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -404,7 +404,7 @@ func TestUpdaterRunResetsDaemonAfterUpdate(t *testing.T) {
 	}
 }
 
-func TestUpdaterRunKeepsSuccessfulUpdateWhenDaemonResetFails(t *testing.T) {
+func TestUpdaterRunFailsWhenDaemonResetFails(t *testing.T) {
 	allowInsecureDownloads = true
 	t.Cleanup(func() { allowInsecureDownloads = false })
 
@@ -457,7 +457,11 @@ func TestUpdaterRunKeepsSuccessfulUpdateWhenDaemonResetFails(t *testing.T) {
 		},
 	}
 
-	if err := u.run(context.Background()); err != nil {
+	err := u.run(context.Background())
+	if err == nil {
+		t.Fatal("run should fail when daemon reset fails")
+	}
+	if !strings.Contains(err.Error(), "failed to reset daemon") {
 		t.Fatalf("run error = %v", err)
 	}
 	content, err := os.ReadFile(execPath)
@@ -467,10 +471,10 @@ func TestUpdaterRunKeepsSuccessfulUpdateWhenDaemonResetFails(t *testing.T) {
 	if string(content) != "new-binary" {
 		t.Fatalf("executable content = %q", string(content))
 	}
-	if !strings.Contains(stdout.String(), "updated no-mistakes") {
+	if stdout.Len() != 0 {
 		t.Fatalf("stdout = %q", stdout.String())
 	}
-	if !strings.Contains(stderr.String(), "reset daemon") {
+	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q", stderr.String())
 	}
 }


### PR DESCRIPTION
## Summary
- Reset the daemon after `no-mistakes update` so running services pick up the newly installed binary, and fail the command when reset or restart recovery leaves the daemon unavailable.
- Harden daemon reset handling around stale artifacts, health-check failures, and restart races so update reporting matches the actual post-update daemon state.
- Update the README, CLI help, and docs to explain that `update` now resets the daemon and may report a post-install daemon recovery failure.

## Risk Assessment

✅ Low: The change is narrowly scoped to post-update daemon reset handling, and the added tests cover the main success and failure paths without exposing a concrete merge-blocking issue in the modified code.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (3) + user-fixed (2)</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/update/update.go:415` - If `resetDaemon` fails after `replaceExecutable` succeeds, `update` returns an error even though the on-disk binary is already upgraded. That leaves the system in a partially updated state: the daemon may be stopped or still running the old binary, while a retry from the new binary will report &#34;already up to date&#34; and won&#39;t re-run the reset path.

**Round 2** (user-fix) - found 2 issues (1 error, 1 warning)
- 🚨 `internal/update/update.go:434` - Stopping the daemon here will cancel any in-flight pipeline runs via `RunManager.Shutdown()`, so `no-mistakes update` now aborts active work without checking or warning first. If that disruption is intentional it needs explicit product sign-off; otherwise gate the restart on daemon idleness or require user confirmation.
- ⚠️ `internal/update/update.go:437` - If `daemon.Start` fails after a successful stop, the update still reports success and leaves the daemon offline. That turns a CLI self-update into a service outage; consider preserving the old daemon until restart is confirmed, or surface the partial failure more prominently than a stderr warning.

**Round 3** (auto-fix) - found 1 warning
- ⚠️ `internal/update/update.go:432` - The update path only fails when `resetDaemon` marks the daemon as offline; plain `check daemon` or `stop daemon` errors are downgraded to a warning and the command still reports success. That can leave a previously running daemon on the old binary, creating CLI/daemon version skew after an update.

**Round 4** (user-fix) - found 2 warnings
- ⚠️ `internal/update/update.go:449` - `defaultResetDaemon` aborts immediately when `daemonIsRunning` returns a health-check error, so an update can replace the binary and then fail without ever attempting the intended stop/start recovery for a wedged but still reachable daemon.
- ⚠️ `internal/update/update.go:459` - All `daemonStart` failures are tagged as `daemonOffline`, but some start errors do not imply the daemon is offline (for example, `daemon already running`), so the update command can report a false offline state and send operators toward the wrong remediation.

**Round 5** (auto-fix) - found 2 warnings
- ⚠️ `internal/update/update.go:449` - `defaultResetDaemon` returns immediately when `daemon.IsRunning` reports `alive=false,nil`, but that helper also returns `false,nil` on IPC dial failures. On a stale or temporarily unreachable socket, the update will report success without ever attempting the stop/start recovery, leaving the old or wedged daemon running after the binary has been replaced.
- ⚠️ `internal/update/update.go:458` - When `daemonStart` returns an error but the follow-up health check shows the daemon is actually running, this still returns an error and `update` exits non-zero. That creates false failures for callers on benign races such as `Start` timing out just before the daemon becomes responsive, or reporting `daemon already running` after the restart succeeded.

**Round 6** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>🔧 **Document** - 3 issues found → auto-fixed (3) + user-fixed (1)</summary>

**Round 1** - found 3 warnings
- ⚠️ `docs/src/content/docs/reference/cli.md:110` - The `no-mistakes update` reference still describes the command as only downloading and replacing the binary. This change now also stops and restarts the background daemon when it is running or stale daemon artifacts exist, and can return an update-completed error if the daemon fails to come back. The command reference should document that post-update daemon reset behavior and its failure mode.
- ⚠️ `docs/src/content/docs/getting-started.md:112` - The getting-started update section is now stale: it says `no-mistakes update` only downloads, verifies, and replaces the binary. After this change, update also resets the daemon so it picks up the new executable, and users may need to manually restart the daemon if that reset fails. That operational behavior should be mentioned here as well.
- ⚠️ `README.md:92` - The README&#39;s install/update section still shows `no-mistakes update` without noting the new daemon-reset side effect. Since self-update now restarts the daemon to load the new binary and may surface a daemon restart failure after the binary swap, the README should add a short note so the top-level usage docs stay aligned with the command behavior.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `README.md:98` - The README says `no-mistakes update` &#34;still succeeds&#34; when the daemon reset fails, but `internal/update/update.go` now returns an error after replacing the binary if the daemon reset fails or leaves the daemon offline. Update this text to reflect that the binary update is applied before the command reports failure, rather than implying a successful command outcome.

**Round 3** (auto-fix) - found 4 warnings
- ⚠️ `docs/src/content/docs/reference/cli.md:110` - The one-line summary for `no-mistakes update` still says it only updates from GitHub Releases. The body now documents the daemon reset behavior, so this summary should also mention that `update` resets or restarts the daemon to pick up the new executable and can report a daemon reset failure after the binary update.
- ⚠️ `docs/src/content/docs/guides/daemon.md:16` - The daemon guide still lists only `init`, `attach`, and `rerun` as commands that affect daemon startup. This change makes `no-mistakes update` part of daemon lifecycle management by stopping and starting the daemon when it is running or stale daemon artifacts exist, so the guide is now missing that behavior.
- ⚠️ `internal/cli/update.go:11` - The Cobra short help for `no-mistakes update` is now stale relative to the new behavior. It still describes the command as only updating from GitHub Releases, but the command also resets the daemon so users invoking `--help` see incomplete documentation.
- ⚠️ `docs/src/content/docs/how-it-works.md:61` - The architecture guide says the daemon auto-starts when needed for `init`, `attach`, and `rerun`, but it does not mention that `no-mistakes update` now resets the daemon to switch it to the newly installed binary. That leaves the daemon lifecycle description stale after this change.

**Round 4** (auto-fix) - found 1 warning
- ⚠️ `internal/cli/update.go:11` - The user-facing `no-mistakes update` command help text is now stale. The change makes `update` reset the daemon after replacing the binary, but the `Short` description still says only &#34;Update no-mistakes from GitHub Releases&#34;, so CLI help should mention the daemon reset behavior too.

**Round 5** (user-fix) - found 0 issues

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
