### PR TITLE
feat(tui): add rerun action for completed pipeline runs

### DIFF
--- a/docs/src/content/docs/guides/tui.md
+++ b/docs/src/content/docs/guides/tui.md
@@ -119,6 +119,7 @@ On narrow terminals, the log panel expands to fill the remaining vertical space 
 | `d` | Toggle diff view (after fix cycle) |
 | `esc` | Exit diff view back to findings |
 | `?` | Toggle help overlay |
+| `r` | Start a rerun after a failed or cancelled run |
 | `q` | Detach from TUI (or quit if run is done) |
 
 In diff view, `n`/`p` jumps the viewport to the file and line of the next/previous finding.
@@ -142,6 +143,8 @@ When a run finishes, a one-line banner appears:
 - `✓ Pipeline passed  4.2s` (green) - the run finished successfully, even if later steps were auto-skipped
 - `✗ Review failed  1.8s` (red) - names the failing step
 - `✗ Pipeline cancelled` (red) - user aborted
+
+After a failed or cancelled run, press `r` to start a rerun. The TUI switches to the new run automatically.
 
 ## Detaching
 

--- a/internal/tui/DESIGN.md
+++ b/internal/tui/DESIGN.md
@@ -114,10 +114,12 @@ Dim content inside a subtle frame:
 Minimal dim hint at the very bottom, outside all boxes:
 
 ```
-  q quit
+  q quit  ? help
 ```
 
-Or when the pipeline is still running: `q detach`
+While the pipeline is still running, the footer shows `q detach` instead of `q quit`.
+
+After a failed or cancelled run, it also shows `r rerun`.
 
 ## Spacing Rules
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -14,10 +14,18 @@ import (
 )
 
 // eventMsg wraps an IPC event received from the daemon.
-type eventMsg ipc.Event
+type eventMsg struct {
+	event          ipc.Event
+	subscriptionID uint64
+}
 
 // errMsg wraps an error from async operations.
 type errMsg struct{ err error }
+
+type subscriptionErrMsg struct {
+	err            error
+	subscriptionID uint64
+}
 
 // rerunStartedMsg switches the TUI onto a newly created rerun.
 type rerunStartedMsg struct{ run *ipc.RunInfo }
@@ -48,18 +56,20 @@ func (e errMsg) Error() string { return e.err.Error() }
 
 // connectedMsg signals that the event subscription is ready.
 type connectedMsg struct {
-	events    <-chan ipc.Event
-	cancelSub func()
+	events         <-chan ipc.Event
+	cancelSub      func()
+	subscriptionID uint64
 }
 
 // Model is the root bubbletea model for the TUI.
 type Model struct {
 	// Connection.
-	socketPath string
-	client     *ipc.Client
-	events     <-chan ipc.Event
-	cancelSub  func()
-	runID      string
+	socketPath     string
+	client         *ipc.Client
+	events         <-chan ipc.Event
+	cancelSub      func()
+	runID          string
+	subscriptionID uint64
 
 	// State.
 	run               *ipc.RunInfo
@@ -95,6 +105,7 @@ func NewModel(socketPath string, client *ipc.Client, run *ipc.RunInfo) Model {
 		socketPath:        socketPath,
 		client:            client,
 		runID:             run.ID,
+		subscriptionID:    1,
 		run:               run,
 		done:              run.Status == types.RunCompleted || run.Status == types.RunFailed || run.Status == types.RunCancelled,
 		steps:             run.Steps,
@@ -135,6 +146,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case connectedMsg:
+		if msg.subscriptionID != m.subscriptionID {
+			if msg.cancelSub != nil {
+				msg.cancelSub()
+			}
+			return m, nil
+		}
 		m.events = msg.events
 		m.cancelSub = msg.cancelSub
 		return m, tea.Batch(m.waitForEvent(), m.startSpinnerIfNeeded())
@@ -150,11 +167,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(m.subscribeCmd(), m.startSpinnerIfNeeded())
 
 	case eventMsg:
-		m.applyEvent(ipc.Event(msg))
+		if msg.subscriptionID != m.subscriptionID {
+			return m, nil
+		}
+		m.applyEvent(msg.event)
 		if m.done {
 			return m, nil
 		}
 		return m, tea.Batch(m.waitForEvent(), m.startSpinnerIfNeeded())
+
+	case subscriptionErrMsg:
+		if msg.subscriptionID != m.subscriptionID {
+			return m, nil
+		}
+		m.err = msg.err
+		return m, nil
 
 	case spinnerTickMsg:
 		m.spinnerScheduled = false
@@ -1003,9 +1030,11 @@ func (m Model) rerunCmd() tea.Cmd {
 
 func (m *Model) resetForRun(run *ipc.RunInfo) {
 	width, height := m.width, m.height
+	nextSubscriptionID := m.subscriptionID + 1
 	fresh := NewModel(m.socketPath, m.client, run)
 	fresh.width = width
 	fresh.height = height
+	fresh.subscriptionID = nextSubscriptionID
 	*m = fresh
 }
 
@@ -1064,7 +1093,7 @@ func (m Model) subscribeCmd() tea.Cmd {
 		if err != nil {
 			return errMsg{fmt.Errorf("subscribe: %w", err)}
 		}
-		return connectedMsg{events: events, cancelSub: cancel}
+		return connectedMsg{events: events, cancelSub: cancel, subscriptionID: m.subscriptionID}
 	}
 }
 
@@ -1076,9 +1105,9 @@ func (m Model) waitForEvent() tea.Cmd {
 	return func() tea.Msg {
 		event, ok := <-events
 		if !ok {
-			return errMsg{fmt.Errorf("event stream closed")}
+			return subscriptionErrMsg{err: fmt.Errorf("event stream closed"), subscriptionID: m.subscriptionID}
 		}
-		return eventMsg(event)
+		return eventMsg{event: event, subscriptionID: m.subscriptionID}
 	}
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -28,7 +28,15 @@ type subscriptionErrMsg struct {
 }
 
 // rerunStartedMsg switches the TUI onto a newly created rerun.
-type rerunStartedMsg struct{ run *ipc.RunInfo }
+type rerunStartedMsg struct {
+	run       *ipc.RunInfo
+	requestID uint64
+}
+
+type rerunErrMsg struct {
+	err       error
+	requestID uint64
+}
 
 type spinnerTickMsg struct{}
 
@@ -90,6 +98,7 @@ type Model struct {
 	err              error
 	quitting         bool
 	done             bool // run completed or failed
+	rerunRequestID   uint64
 	showDiff         bool // toggle diff viewer
 	showHelp         bool // toggle help overlay
 	confirmAbort     bool // true after first x press, next x actually aborts
@@ -157,6 +166,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(m.waitForEvent(), m.startSpinnerIfNeeded())
 
 	case rerunStartedMsg:
+		if msg.requestID != m.rerunRequestID {
+			return m, nil
+		}
 		if m.cancelSub != nil {
 			m.cancelSub()
 		}
@@ -165,6 +177,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		return m, tea.Batch(m.subscribeCmd(), m.startSpinnerIfNeeded())
+
+	case rerunErrMsg:
+		if msg.requestID != m.rerunRequestID {
+			return m, nil
+		}
+		m.err = msg.err
+		return m, nil
 
 	case eventMsg:
 		if msg.subscriptionID != m.subscriptionID {
@@ -979,7 +998,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case "r":
-		return m, m.rerunCmd()
+		m.rerunRequestID++
+		return m, m.rerunCmd(m.rerunRequestID)
 	case "x":
 		if m.done || m.run == nil {
 			return m, nil
@@ -1006,7 +1026,7 @@ func canRerun(run *ipc.RunInfo) bool {
 	}
 }
 
-func (m Model) rerunCmd() tea.Cmd {
+func (m Model) rerunCmd(requestID uint64) tea.Cmd {
 	if !canRerun(m.run) || m.client == nil || m.run == nil {
 		return nil
 	}
@@ -1015,16 +1035,16 @@ func (m Model) rerunCmd() tea.Cmd {
 	return func() tea.Msg {
 		var rerun ipc.RerunResult
 		if err := m.client.Call(ipc.MethodRerun, &ipc.RerunParams{RepoID: repoID, Branch: branch}, &rerun); err != nil {
-			return errMsg{err}
+			return rerunErrMsg{err: err, requestID: requestID}
 		}
 		var result ipc.GetRunResult
 		if err := m.client.Call(ipc.MethodGetRun, &ipc.GetRunParams{RunID: rerun.RunID}, &result); err != nil {
-			return errMsg{fmt.Errorf("load rerun: %w", err)}
+			return rerunErrMsg{err: fmt.Errorf("load rerun: %w", err), requestID: requestID}
 		}
 		if result.Run == nil {
-			return errMsg{fmt.Errorf("load rerun: run %s not found", rerun.RunID)}
+			return rerunErrMsg{err: fmt.Errorf("load rerun: run %s not found", rerun.RunID), requestID: requestID}
 		}
-		return rerunStartedMsg{run: result.Run}
+		return rerunStartedMsg{run: result.Run, requestID: requestID}
 	}
 }
 
@@ -1035,6 +1055,7 @@ func (m *Model) resetForRun(run *ipc.RunInfo) {
 	fresh.width = width
 	fresh.height = height
 	fresh.subscriptionID = nextSubscriptionID
+	fresh.rerunRequestID = m.rerunRequestID
 	*m = fresh
 }
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -98,6 +98,7 @@ type Model struct {
 	err              error
 	quitting         bool
 	done             bool // run completed or failed
+	rerunPending     bool
 	rerunRequestID   uint64
 	showDiff         bool // toggle diff viewer
 	showHelp         bool // toggle help overlay
@@ -169,6 +170,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.requestID != m.rerunRequestID {
 			return m, nil
 		}
+		m.rerunPending = false
 		if m.cancelSub != nil {
 			m.cancelSub()
 		}
@@ -182,6 +184,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.requestID != m.rerunRequestID {
 			return m, nil
 		}
+		m.rerunPending = false
 		m.err = msg.err
 		return m, nil
 
@@ -998,6 +1001,10 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 	case "r":
+		if m.rerunPending || !canRerun(m.run) {
+			return m, nil
+		}
+		m.rerunPending = true
 		m.rerunRequestID++
 		return m, m.rerunCmd(m.rerunRequestID)
 	case "x":
@@ -1112,7 +1119,7 @@ func (m Model) subscribeCmd() tea.Cmd {
 			RunID: m.runID,
 		})
 		if err != nil {
-			return errMsg{fmt.Errorf("subscribe: %w", err)}
+			return subscriptionErrMsg{err: fmt.Errorf("subscribe: %w", err), subscriptionID: m.subscriptionID}
 		}
 		return connectedMsg{events: events, cancelSub: cancel, subscriptionID: m.subscriptionID}
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -144,6 +144,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.cancelSub()
 		}
 		m.resetForRun(msg.run)
+		if m.done {
+			return m, nil
+		}
 		return m, tea.Batch(m.subscribeCmd(), m.startSpinnerIfNeeded())
 
 	case eventMsg:

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -19,6 +19,9 @@ type eventMsg ipc.Event
 // errMsg wraps an error from async operations.
 type errMsg struct{ err error }
 
+// rerunStartedMsg switches the TUI onto a newly created rerun.
+type rerunStartedMsg struct{ run *ipc.RunInfo }
+
 type spinnerTickMsg struct{}
 
 const spinnerTickInterval = 120 * time.Millisecond
@@ -136,6 +139,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.cancelSub = msg.cancelSub
 		return m, tea.Batch(m.waitForEvent(), m.startSpinnerIfNeeded())
 
+	case rerunStartedMsg:
+		if m.cancelSub != nil {
+			m.cancelSub()
+		}
+		m.resetForRun(msg.run)
+		return m, tea.Batch(m.subscribeCmd(), m.startSpinnerIfNeeded())
+
 	case eventMsg:
 		m.applyEvent(ipc.Event(msg))
 		if m.done {
@@ -249,11 +259,7 @@ func (m Model) View() string {
 	}
 	actionBar := renderActionBar(m.steps, showSelectionActions, allowFix, m.showDiff, selectedCount, totalCount, m.confirmAbort, hasDiff)
 
-	var prURL *string
-	if m.run != nil {
-		prURL = m.run.PRURL
-	}
-	footer := renderFooter(m.done, m.showHelp, m.confirmAbort, prURL, m.width)
+	footer := renderFooter(m.done, m.showHelp, m.confirmAbort, m.run, m.width)
 	contentBudget := -1
 	if m.height > 0 {
 		baseSections := []string{}
@@ -522,7 +528,7 @@ func renderErrorBox(err error, width int) string {
 	return renderBox("Error", errContent.String(), boxWidth)
 }
 
-func renderFooter(done bool, showHelp bool, confirmAbort bool, prURL *string, width int) string {
+func renderFooter(done bool, showHelp bool, confirmAbort bool, run *ipc.RunInfo, width int) string {
 	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
 	boldKey := lipgloss.NewStyle().Bold(true)
 	qLabel := "detach"
@@ -542,6 +548,14 @@ func renderFooter(done bool, showHelp bool, confirmAbort bool, prURL *string, wi
 		left += "  " + boldKey.Render("x") + " " + dimStyle.Render(xLabel)
 	}
 	left += "  " + boldKey.Render("?") + " " + dimStyle.Render(helpLabel)
+	if canRerun(run) {
+		left += "  " + boldKey.Render("r") + " " + dimStyle.Render("rerun")
+	}
+
+	var prURL *string
+	if run != nil {
+		prURL = run.PRURL
+	}
 	if prURL == nil || *prURL == "" {
 		return left
 	}
@@ -934,6 +948,8 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, openBrowserCmd(*m.run.PRURL)
 		}
 		return m, nil
+	case "r":
+		return m, m.rerunCmd()
 	case "x":
 		if m.done || m.run == nil {
 			return m, nil
@@ -946,6 +962,48 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	return m, nil
+}
+
+func canRerun(run *ipc.RunInfo) bool {
+	if run == nil {
+		return false
+	}
+	switch run.Status {
+	case types.RunFailed, types.RunCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+func (m Model) rerunCmd() tea.Cmd {
+	if !canRerun(m.run) || m.client == nil || m.run == nil {
+		return nil
+	}
+	repoID := m.run.RepoID
+	branch := m.run.Branch
+	return func() tea.Msg {
+		var rerun ipc.RerunResult
+		if err := m.client.Call(ipc.MethodRerun, &ipc.RerunParams{RepoID: repoID, Branch: branch}, &rerun); err != nil {
+			return errMsg{err}
+		}
+		var result ipc.GetRunResult
+		if err := m.client.Call(ipc.MethodGetRun, &ipc.GetRunParams{RunID: rerun.RunID}, &result); err != nil {
+			return errMsg{fmt.Errorf("load rerun: %w", err)}
+		}
+		if result.Run == nil {
+			return errMsg{fmt.Errorf("load rerun: run %s not found", rerun.RunID)}
+		}
+		return rerunStartedMsg{run: result.Run}
+	}
+}
+
+func (m *Model) resetForRun(run *ipc.RunInfo) {
+	width, height := m.width, m.height
+	fresh := NewModel(m.socketPath, m.client, run)
+	fresh.width = width
+	fresh.height = height
+	*m = fresh
 }
 
 func (m Model) respondCmd(action types.ApprovalAction) tea.Cmd {

--- a/internal/tui/pipeline.go
+++ b/internal/tui/pipeline.go
@@ -407,6 +407,9 @@ func renderHelpOverlay(width int, run *ipc.RunInfo, hasAwaitingStep bool, showDi
 		footerEntries = append(footerEntries, helpEntry{"x x", "abort pipeline"})
 	}
 	footerEntries = append(footerEntries, helpEntry{"?", "close help"})
+	if canRerun(run) {
+		footerEntries = append(footerEntries, helpEntry{"r", "rerun pipeline"})
+	}
 	if run != nil && run.PRURL != nil && *run.PRURL != "" {
 		footerEntries = append(footerEntries, helpEntry{"o", "open PR in browser"})
 	}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1,8 +1,12 @@
 package tui
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"runtime"
@@ -24,6 +28,39 @@ func stripANSI(s string) string {
 }
 
 func ptr[T any](v T) *T { return &v }
+
+func testSocketPath(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "tui-ipc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, "s.sock")
+}
+
+func startTestIPCServer(t *testing.T, sock string) *ipc.Server {
+	t.Helper()
+	srv := ipc.NewServer()
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Serve(sock) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		c, err := ipc.Dial(sock)
+		if err == nil {
+			_ = c.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Cleanup(func() {
+		srv.Close()
+		<-errCh
+	})
+	return srv
+}
 
 func testRun() *ipc.RunInfo {
 	return &ipc.RunInfo{
@@ -440,7 +477,10 @@ func TestModel_ApplyEvent_RunCompleted_PRURL(t *testing.T) {
 func TestRenderFooter_WithPRURL_ShowsOpenAction(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.Ascii)
 	prURL := "https://github.com/test/repo/pull/42"
-	footer := renderFooter(true, false, false, &prURL, 80)
+	run := testRun()
+	run.Status = types.RunCompleted
+	run.PRURL = &prURL
+	footer := renderFooter(true, false, false, run, 80)
 	stripped := stripANSI(footer)
 
 	if !strings.Contains(stripped, "o") || !strings.Contains(stripped, "open PR") {
@@ -461,11 +501,26 @@ func TestRenderFooter_WithoutPRURL(t *testing.T) {
 	}
 }
 
+func TestRenderFooter_FailedRun_ShowsRerun(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.Ascii)
+	run := testRun()
+	run.Status = types.RunFailed
+	footer := renderFooter(true, false, false, run, 80)
+	stripped := stripANSI(footer)
+
+	if !strings.Contains(stripped, "rerun") {
+		t.Fatalf("expected footer to contain rerun action, got: %s", stripped)
+	}
+}
+
 func TestRenderFooter_PRURL_ActionShownAtNarrowWidth(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.Ascii)
 	prURL := "https://github.com/test/repo/pull/42"
 	// Even at narrow width, "open PR" action should appear
-	footer := renderFooter(true, false, false, &prURL, 40)
+	run := testRun()
+	run.Status = types.RunCompleted
+	run.PRURL = &prURL
+	footer := renderFooter(true, false, false, run, 40)
 	stripped := stripANSI(footer)
 
 	if !strings.Contains(stripped, "open PR") {
@@ -576,6 +631,95 @@ func TestModel_Update_OpenPRKeyRunsBrowserCommand(t *testing.T) {
 	}
 	if !reflect.DeepEqual(gotArgs, wantArgs) {
 		t.Fatalf("unexpected command args: got %v want %v", gotArgs, wantArgs)
+	}
+}
+
+func TestModel_Update_RerunKeyStartsNewRunAndSwitchesModel(t *testing.T) {
+	sock := testSocketPath(t)
+	srv := startTestIPCServer(t, sock)
+
+	newRun := testRun()
+	newRun.ID = "run-002"
+	newRun.Status = types.RunRunning
+	newRun.Error = nil
+
+	srv.Handle(ipc.MethodRerun, func(_ context.Context, raw json.RawMessage) (interface{}, error) {
+		var params ipc.RerunParams
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return nil, err
+		}
+		if params.RepoID != "repo-001" || params.Branch != "feature/foo" {
+			return nil, fmt.Errorf("unexpected rerun params: %#v", params)
+		}
+		return &ipc.RerunResult{RunID: newRun.ID}, nil
+	})
+	srv.Handle(ipc.MethodGetRun, func(_ context.Context, raw json.RawMessage) (interface{}, error) {
+		var params ipc.GetRunParams
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return nil, err
+		}
+		if params.RunID != newRun.ID {
+			return nil, fmt.Errorf("unexpected get_run id: %s", params.RunID)
+		}
+		return &ipc.GetRunResult{Run: newRun}, nil
+	})
+	srv.HandleStream(ipc.MethodSubscribe, func(_ context.Context, raw json.RawMessage, send func(interface{}) error) error {
+		var params ipc.SubscribeParams
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return err
+		}
+		if params.RunID != newRun.ID {
+			return fmt.Errorf("unexpected subscribe id: %s", params.RunID)
+		}
+		return nil
+	})
+
+	client, err := ipc.Dial(sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	run := testRun()
+	run.Status = types.RunFailed
+	run.Error = ptr("push failed")
+	m := NewModel(sock, client, run)
+	m.width = 80
+	m.height = 24
+	m.err = errors.New("old error")
+	m.logs = []string{"old log"}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	if cmd == nil {
+		t.Fatal("expected rerun command")
+	}
+	msg := cmd()
+	if _, ok := msg.(rerunStartedMsg); !ok {
+		t.Fatalf("expected rerunStartedMsg, got %T", msg)
+	}
+
+	updated, nextCmd := updated.(Model).Update(msg)
+	model := updated.(Model)
+	if model.runID != newRun.ID {
+		t.Fatalf("runID = %s, want %s", model.runID, newRun.ID)
+	}
+	if model.run == nil || model.run.ID != newRun.ID {
+		t.Fatalf("run = %#v, want new run %#v", model.run, newRun)
+	}
+	if model.run.Status != types.RunRunning {
+		t.Fatalf("run status = %s, want %s", model.run.Status, types.RunRunning)
+	}
+	if model.done {
+		t.Fatal("expected rerun model to no longer be done")
+	}
+	if model.err != nil {
+		t.Fatalf("expected rerun to clear error, got %v", model.err)
+	}
+	if len(model.logs) != 0 {
+		t.Fatalf("expected rerun to clear logs, got %v", model.logs)
+	}
+	if nextCmd == nil {
+		t.Fatal("expected subscribe command after rerun")
 	}
 }
 

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -746,6 +746,32 @@ func TestModel_Update_RerunStartedSkipsSubscribeForTerminalRun(t *testing.T) {
 	}
 }
 
+func TestModel_SubscribeCmdReturnsScopedError(t *testing.T) {
+	run := testRun()
+	m := NewModel(filepath.Join(t.TempDir(), "missing.sock"), nil, run)
+	m.subscriptionID = 7
+
+	cmd := m.subscribeCmd()
+	if cmd == nil {
+		t.Fatal("expected subscribe command")
+	}
+
+	msg := cmd()
+	subErr, ok := msg.(subscriptionErrMsg)
+	if !ok {
+		t.Fatalf("expected subscriptionErrMsg, got %T", msg)
+	}
+	if subErr.subscriptionID != m.subscriptionID {
+		t.Fatalf("subscriptionID = %d, want %d", subErr.subscriptionID, m.subscriptionID)
+	}
+	if subErr.err == nil || !strings.Contains(subErr.err.Error(), "subscribe:") {
+		t.Fatalf("expected wrapped subscribe error, got %v", subErr.err)
+	}
+	if _, ok := msg.(errMsg); ok {
+		t.Fatal("expected subscribe failure to avoid errMsg")
+	}
+}
+
 func TestModel_Update_IgnoresStaleSubscriptionMessagesAfterRerun(t *testing.T) {
 	run := testRun()
 	m := NewModel("/tmp/sock", nil, run)
@@ -802,6 +828,46 @@ func TestModel_Update_IgnoresStaleSubscriptionMessagesAfterRerun(t *testing.T) {
 	if model.run.Status != types.RunRunning {
 		t.Fatalf("run status = %s, want %s", model.run.Status, types.RunRunning)
 	}
+}
+
+func TestModel_Update_IgnoresRepeatedRerunKeyWhilePending(t *testing.T) {
+	sock := testSocketPath(t)
+	srv := startTestIPCServer(t, sock)
+
+	client, err := ipc.Dial(sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	run := testRun()
+	run.Status = types.RunFailed
+	m := NewModel(sock, client, run)
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	model := updated.(Model)
+	if cmd == nil {
+		t.Fatal("expected first rerun key to start rerun")
+	}
+	if !model.rerunPending {
+		t.Fatal("expected rerun to become pending")
+	}
+	if model.rerunRequestID != 1 {
+		t.Fatalf("rerunRequestID = %d, want 1", model.rerunRequestID)
+	}
+
+	updated, secondCmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	model = updated.(Model)
+	if secondCmd != nil {
+		t.Fatal("expected repeated rerun key to be ignored while pending")
+	}
+	if !model.rerunPending {
+		t.Fatal("expected rerun to remain pending")
+	}
+	if model.rerunRequestID != 1 {
+		t.Fatalf("rerunRequestID = %d, want 1", model.rerunRequestID)
+	}
+	_ = srv
 }
 
 func TestModel_Update_IgnoresStaleRerunStartedMessage(t *testing.T) {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -723,6 +723,29 @@ func TestModel_Update_RerunKeyStartsNewRunAndSwitchesModel(t *testing.T) {
 	}
 }
 
+func TestModel_Update_RerunStartedSkipsSubscribeForTerminalRun(t *testing.T) {
+	run := testRun()
+	m := NewModel("/tmp/sock", nil, run)
+
+	terminalRun := testRun()
+	terminalRun.ID = "run-002"
+	terminalRun.Status = types.RunFailed
+	terminalRun.Error = ptr("fast failure")
+
+	updated, cmd := m.Update(rerunStartedMsg{run: terminalRun})
+	model := updated.(Model)
+
+	if model.runID != terminalRun.ID {
+		t.Fatalf("runID = %s, want %s", model.runID, terminalRun.ID)
+	}
+	if !model.done {
+		t.Fatal("expected terminal rerun to mark model done")
+	}
+	if cmd != nil {
+		t.Fatal("expected no subscribe command for terminal rerun")
+	}
+}
+
 func TestModel_ApplyEvent_LogChunk(t *testing.T) {
 	run := testRun()
 	m := NewModel("/tmp/sock", nil, run)
@@ -4425,7 +4448,7 @@ func TestModel_View_StackedLogBoxFillsRemainingHeight(t *testing.T) {
 	}
 
 	pipelineView := renderPipelineView(run, m.stepsWithRunningElapsed(), m.width, 0, m.height)
-	footer := renderFooter(false, false, false, run.PRURL, m.width)
+	footer := renderFooter(false, false, false, run, m.width)
 	expectedLogLines := m.height - sectionsHeight([]string{pipelineView}, 2) - 2 - lipgloss.Height(footer) - 2
 	if expectedLogLines <= 5 {
 		t.Fatalf("expected stacked layout to leave room for more than 5 log lines, got %d", expectedLogLines)

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -746,6 +746,64 @@ func TestModel_Update_RerunStartedSkipsSubscribeForTerminalRun(t *testing.T) {
 	}
 }
 
+func TestModel_Update_IgnoresStaleSubscriptionMessagesAfterRerun(t *testing.T) {
+	run := testRun()
+	m := NewModel("/tmp/sock", nil, run)
+
+	oldEvents := make(chan ipc.Event)
+	oldCancelled := false
+	updated, _ := m.Update(connectedMsg{events: oldEvents, cancelSub: func() { oldCancelled = true }, subscriptionID: m.subscriptionID})
+	model := updated.(Model)
+
+	newRun := testRun()
+	newRun.ID = "run-002"
+	newRun.Status = types.RunRunning
+
+	updated, cmd := model.Update(rerunStartedMsg{run: newRun})
+	model = updated.(Model)
+
+	if !oldCancelled {
+		t.Fatal("expected rerun to cancel the previous subscription")
+	}
+	if cmd == nil {
+		t.Fatal("expected rerun to subscribe to the new run")
+	}
+
+	newEvents := make(chan ipc.Event)
+	updated, _ = model.Update(connectedMsg{events: newEvents, cancelSub: func() {}, subscriptionID: model.subscriptionID})
+	model = updated.(Model)
+
+	staleCancelled := false
+	updated, _ = model.Update(connectedMsg{events: make(chan ipc.Event), cancelSub: func() { staleCancelled = true }, subscriptionID: model.subscriptionID - 1})
+	model = updated.(Model)
+	if !staleCancelled {
+		t.Fatal("expected stale connected message to be cancelled")
+	}
+	if model.events != newEvents {
+		t.Fatal("expected stale connected message to be ignored")
+	}
+
+	updated, _ = model.Update(subscriptionErrMsg{err: errors.New("event stream closed"), subscriptionID: model.subscriptionID - 1})
+	model = updated.(Model)
+	if model.err != nil {
+		t.Fatalf("expected stale subscription error to be ignored, got %v", model.err)
+	}
+
+	staleStatus := string(types.RunFailed)
+	staleError := "stale completion"
+	updated, _ = model.Update(eventMsg{event: ipc.Event{Type: ipc.EventRunCompleted, Status: &staleStatus, Error: &staleError}, subscriptionID: model.subscriptionID - 1})
+	model = updated.(Model)
+	if model.done {
+		t.Fatal("expected stale event to be ignored")
+	}
+	if model.run == nil || model.run.ID != newRun.ID {
+		t.Fatalf("run = %#v, want rerun %#v", model.run, newRun)
+	}
+	if model.run.Status != types.RunRunning {
+		t.Fatalf("run status = %s, want %s", model.run.Status, types.RunRunning)
+	}
+}
+
 func TestModel_ApplyEvent_LogChunk(t *testing.T) {
 	run := testRun()
 	m := NewModel("/tmp/sock", nil, run)
@@ -882,11 +940,11 @@ func TestModel_Update_StepStartedBeginsSpinnerLoop(t *testing.T) {
 	run := testRun()
 	m := NewModel("/tmp/sock", nil, run)
 
-	updated, cmd := m.Update(eventMsg(ipc.Event{
+	updated, cmd := m.Update(eventMsg{event: ipc.Event{
 		Type:     ipc.EventStepStarted,
 		RunID:    run.ID,
 		StepName: ptr(types.StepReview),
-	}))
+	}, subscriptionID: m.subscriptionID})
 	model := updated.(Model)
 
 	if model.steps[0].Status != types.StepStatusRunning {
@@ -976,7 +1034,7 @@ func TestModel_ConnectedMsg(t *testing.T) {
 	ch := make(chan ipc.Event, 1)
 	cancel := func() {}
 
-	updated, _ := m.Update(connectedMsg{events: ch, cancelSub: cancel})
+	updated, _ := m.Update(connectedMsg{events: ch, cancelSub: cancel, subscriptionID: m.subscriptionID})
 	model := updated.(Model)
 	if model.events == nil {
 		t.Error("expected events channel to be set")
@@ -5466,10 +5524,10 @@ func TestModel_Update_StepStartedRecordsStartTime(t *testing.T) {
 
 	before := time.Now()
 	stepName := types.StepReview
-	m.Update(eventMsg(ipc.Event{
+	m.Update(eventMsg{event: ipc.Event{
 		Type:     ipc.EventStepStarted,
 		StepName: &stepName,
-	}))
+	}, subscriptionID: m.subscriptionID})
 	after := time.Now()
 
 	startTime, ok := m.stepStartTimes[types.StepReview]

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -804,6 +804,46 @@ func TestModel_Update_IgnoresStaleSubscriptionMessagesAfterRerun(t *testing.T) {
 	}
 }
 
+func TestModel_Update_IgnoresStaleRerunStartedMessage(t *testing.T) {
+	run := testRun()
+	m := NewModel("/tmp/sock", nil, run)
+	m.rerunRequestID = 2
+
+	staleRun := testRun()
+	staleRun.ID = "run-002"
+	staleRun.Status = types.RunRunning
+
+	updated, cmd := m.Update(rerunStartedMsg{run: staleRun, requestID: 1})
+	model := updated.(Model)
+
+	if model.runID != run.ID {
+		t.Fatalf("runID = %s, want %s", model.runID, run.ID)
+	}
+	if model.run == nil || model.run.ID != run.ID {
+		t.Fatalf("run = %#v, want original run %#v", model.run, run)
+	}
+	if cmd != nil {
+		t.Fatal("expected stale rerun message to be ignored")
+	}
+
+	currentRun := testRun()
+	currentRun.ID = "run-003"
+	currentRun.Status = types.RunRunning
+
+	updated, cmd = model.Update(rerunStartedMsg{run: currentRun, requestID: 2})
+	model = updated.(Model)
+
+	if model.runID != currentRun.ID {
+		t.Fatalf("runID = %s, want %s", model.runID, currentRun.ID)
+	}
+	if model.run == nil || model.run.ID != currentRun.ID {
+		t.Fatalf("run = %#v, want current run %#v", model.run, currentRun)
+	}
+	if cmd == nil {
+		t.Fatal("expected current rerun message to subscribe")
+	}
+}
+
 func TestModel_ApplyEvent_LogChunk(t *testing.T) {
 	run := testRun()
 	m := NewModel("/tmp/sock", nil, run)


### PR DESCRIPTION
## Summary
- Add an `r` rerun action in the TUI for failed or cancelled runs so users can start a new pipeline run and immediately follow it without leaving the terminal.
- Harden rerun state management by scoping subscriptions, ignoring stale async messages/results, and blocking duplicate rerun requests so the TUI stays attached to the correct run.
- Update the TUI guide and design docs to document the new rerun keybinding and footer behavior.

## Risk Assessment

✅ Low: The change is confined to the TUI rerun/subscription state machine and is covered by focused tests for stale-message and duplicate-rerun paths, so I did not find any merge-blocking risks in the changed code.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (3) + user-fixed (1)</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/tui/app.go:147` - `rerunStartedMsg` always resubscribes to the new run, even if `GetRun` already returned a terminal run. In that case `Subscribe` immediately closes, `waitForEvent` turns that into `event stream closed`, and the rerun UI can show a spurious error after a fast failure/completion. Skip the resubscribe when `m.done` is already true after `resetForRun`.

**Round 2** (auto-fix) - found 1 error
- 🚨 `internal/tui/app.go:143` - Switching to the new run cancels the old subscription, but the old `waitForEvent`/`connectedMsg` commands are still live and unscoped. After `cancelSub()`, the old waiter can emit `errMsg(&#34;event stream closed&#34;)`, and delayed messages from the old subscription can overwrite the new run attachment, making reruns show spurious errors or stop following the new run.

**Round 3** (auto-fix) - found 1 warning
- ⚠️ `internal/tui/app.go:159` - `rerunStartedMsg` is applied unconditionally, so two quick `r` presses can race: a slower, older rerun RPC response can replace the UI state for a newer rerun and reattach the TUI to the wrong run. Tag rerun requests with a generation/request ID and ignore stale completions.

**Round 4** (auto-fix) - found 2 warnings
- ⚠️ `internal/tui/app.go:1115` - `subscribeCmd` still returns an unscoped `errMsg` on subscribe failure, so a slow failed subscription from the pre-rerun run can surface on the new run even though stale `connectedMsg`/`eventMsg`/`subscriptionErrMsg` are filtered. Return a subscription-scoped error message here too.
- ⚠️ `internal/tui/app.go:1000` - Pressing `r` repeatedly before the first rerun RPC finishes will enqueue multiple reruns. Only the newest result is shown, but the earlier RPCs still create runs server-side and can cancel each other via `startRun`&#39;s active-run cancellation. If duplicate reruns are not intentional, gate or debounce the key until the request resolves.

**Round 5** (user-fix) - found 0 issues

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `docs/src/content/docs/guides/tui.md:97` - The TUI guide is stale after this change. Failed or cancelled runs now expose an `r` action that starts a new pipeline run and switches the attached TUI to that rerun, but the keybindings and post-run workflow documentation still only cover approval actions, quitting, and opening the PR.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `internal/tui/DESIGN.md:112` - The Footer section is now stale relative to the TUI behavior. The code adds a conditional `r rerun` footer action for failed or cancelled runs, but this design doc still describes the footer as only showing `q quit` or `q detach`.

**Round 3** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
