### PR TITLE
feat(tui): show cached update indicator in footer

### DIFF
--- a/docs/src/content/docs/guides/tui.md
+++ b/docs/src/content/docs/guides/tui.md
@@ -83,6 +83,10 @@ During running steps, shows streaming agent output. Lines starting with `PASS` a
 
 On narrow terminals, the log panel expands to fill the remaining vertical space below the pipeline box instead of staying at the compact fixed height used in shorter layouts.
 
+### Footer
+
+The footer shows detach/help actions and, when `no-mistakes attach` has a cached newer release available, a right-aligned `<version> available` indicator. That update indicator stays visible after reruns in the same TUI session.
+
 ## Keybindings
 
 ### Navigation

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/tui"
+	"github.com/kunchenguid/no-mistakes/internal/update"
 	"github.com/spf13/cobra"
 )
 
@@ -74,7 +75,7 @@ func attachRun(w io.Writer, runID string) error {
 		return nil
 	}
 
-	return tui.Run(p.Socket(), client, run)
+	return tui.Run(p.Socket(), client, run, update.CachedLatestVersion())
 }
 
 const recentRunsLimit = 5

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -233,7 +234,7 @@ func cleanupWorktree(t *testing.T, repoDir, wtDir string) {
 		var err error
 		for attempt := 0; attempt < 5; attempt++ {
 			err = git.WorktreeRemove(ctx, repoDir, wtDir)
-			if err == nil {
+			if err == nil || isMissingWorktreeError(err) {
 				return
 			}
 			if runtime.GOOS != "windows" {
@@ -243,6 +244,28 @@ func cleanupWorktree(t *testing.T, repoDir, wtDir string) {
 		}
 		t.Fatalf("remove worktree %q: %v", wtDir, err)
 	})
+}
+
+func isMissingWorktreeError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "is not a working tree")
+}
+
+func TestIsMissingWorktreeError(t *testing.T) {
+	t.Parallel()
+
+	if isMissingWorktreeError(nil) {
+		t.Fatal("nil should not be treated as a missing worktree error")
+	}
+
+	err := errors.New("git worktree remove --force C:\\temp\\worktree: exit status 128: fatal: 'C:\\temp\\worktree' is not a working tree")
+	if !isMissingWorktreeError(err) {
+		t.Fatal("expected missing worktree error to be ignored during cleanup")
+	}
+
+	err = errors.New("git worktree remove failed: permission denied")
+	if isMissingWorktreeError(err) {
+		t.Fatal("unexpected error should not be treated as a missing worktree error")
+	}
 }
 
 func makeSocketSafeTempDir(t *testing.T) string {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -95,6 +95,7 @@ type Model struct {
 	// UI.
 	width            int
 	height           int
+	latestVersion    string
 	err              error
 	quitting         bool
 	done             bool // run completed or failed
@@ -311,7 +312,7 @@ func (m Model) View() string {
 	}
 	actionBar := renderActionBar(m.steps, showSelectionActions, allowFix, m.showDiff, selectedCount, totalCount, m.confirmAbort, hasDiff)
 
-	footer := renderFooter(m.done, m.showHelp, m.confirmAbort, m.run, m.width)
+	footer := renderFooter(m.done, m.showHelp, m.confirmAbort, m.run, m.latestVersion, m.width)
 	contentBudget := -1
 	if m.height > 0 {
 		baseSections := []string{}
@@ -580,8 +581,9 @@ func renderErrorBox(err error, width int) string {
 	return renderBox("Error", errContent.String(), boxWidth)
 }
 
-func renderFooter(done bool, showHelp bool, confirmAbort bool, run *ipc.RunInfo, width int) string {
+func renderFooter(done bool, showHelp bool, confirmAbort bool, run *ipc.RunInfo, latestVersion string, width int) string {
 	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
+	warnStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiYellow))
 	boldKey := lipgloss.NewStyle().Bold(true)
 	qLabel := "detach"
 	if done {
@@ -608,23 +610,43 @@ func renderFooter(done bool, showHelp bool, confirmAbort bool, run *ipc.RunInfo,
 	if run != nil {
 		prURL = run.PRURL
 	}
+
+	rightParts := []string{}
+	if latestVersion != "" {
+		rightParts = append(rightParts, warnStyle.Render(latestVersion+" available"))
+	}
 	if prURL == nil || *prURL == "" {
-		return left
+		if len(rightParts) == 0 {
+			return left
+		}
+		right := strings.Join(rightParts, "  ")
+		gap := width - lipgloss.Width(left) - lipgloss.Width(right)
+		if gap < 2 {
+			return left
+		}
+		return left + strings.Repeat(" ", gap) + right
 	}
 
 	left += "  " + boldKey.Render("o") + " " + dimStyle.Render("open PR")
 	leftWidth := lipgloss.Width(left)
+	reservedRightWidth := 0
+	if len(rightParts) > 0 {
+		reservedRightWidth = lipgloss.Width(strings.Join(rightParts, "  ")) + 2
+	}
+	available := width - leftWidth - reservedRightWidth - 2
 	prText := *prURL
-	available := width - leftWidth - 4
-	if available < len(prText) {
+	if available < lipgloss.Width(prText) {
 		prText = shortPRLabel(*prURL)
 	}
-	if available < len(prText) {
+	if available >= lipgloss.Width(prText) {
+		rightParts = append([]string{dimStyle.Render(prText)}, rightParts...)
+	}
+	if len(rightParts) == 0 {
 		return left
 	}
-	right := dimStyle.Render(prText) + "  "
+	right := strings.Join(rightParts, "  ")
 	gap := width - leftWidth - lipgloss.Width(right)
-	if gap < 1 {
+	if gap < 2 {
 		return left
 	}
 	return left + strings.Repeat(" ", gap) + right
@@ -1426,8 +1448,10 @@ func (m *Model) clearAllFindings(step types.StepName) {
 }
 
 // Run starts the TUI program.
-func Run(socketPath string, client *ipc.Client, run *ipc.RunInfo) error {
+
+func Run(socketPath string, client *ipc.Client, run *ipc.RunInfo, latestVersion string) error {
 	model := NewModel(socketPath, client, run)
+	model.latestVersion = latestVersion
 	p := tea.NewProgram(model, tea.WithAltScreen())
 	_, err := p.Run()
 	return err

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -1080,11 +1080,13 @@ func (m Model) rerunCmd(requestID uint64) tea.Cmd {
 func (m *Model) resetForRun(run *ipc.RunInfo) {
 	width, height := m.width, m.height
 	nextSubscriptionID := m.subscriptionID + 1
+	latestVersion := m.latestVersion
 	fresh := NewModel(m.socketPath, m.client, run)
 	fresh.width = width
 	fresh.height = height
 	fresh.subscriptionID = nextSubscriptionID
 	fresh.rerunRequestID = m.rerunRequestID
+	fresh.latestVersion = latestVersion
 	*m = fresh
 }
 

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -760,6 +760,24 @@ func TestModel_Update_RerunStartedSkipsSubscribeForTerminalRun(t *testing.T) {
 	}
 }
 
+func TestModel_Update_RerunPreservesLatestVersion(t *testing.T) {
+	run := testRun()
+	run.Status = types.RunFailed
+	m := NewModel("/tmp/sock", nil, run)
+	m.latestVersion = "v1.2.3"
+
+	newRun := testRun()
+	newRun.ID = "run-002"
+	newRun.Status = types.RunRunning
+
+	updated, _ := m.Update(rerunStartedMsg{run: newRun})
+	model := updated.(Model)
+
+	if model.latestVersion != "v1.2.3" {
+		t.Fatalf("latestVersion = %q, want %q", model.latestVersion, "v1.2.3")
+	}
+}
+
 func TestModel_SubscribeCmdReturnsScopedError(t *testing.T) {
 	run := testRun()
 	m := NewModel(filepath.Join(t.TempDir(), "missing.sock"), nil, run)

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -480,7 +480,7 @@ func TestRenderFooter_WithPRURL_ShowsOpenAction(t *testing.T) {
 	run := testRun()
 	run.Status = types.RunCompleted
 	run.PRURL = &prURL
-	footer := renderFooter(true, false, false, run, 80)
+	footer := renderFooter(true, false, false, run, "", 80)
 	stripped := stripANSI(footer)
 
 	if !strings.Contains(stripped, "o") || !strings.Contains(stripped, "open PR") {
@@ -493,7 +493,7 @@ func TestRenderFooter_WithPRURL_ShowsOpenAction(t *testing.T) {
 
 func TestRenderFooter_WithoutPRURL(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.Ascii)
-	footer := renderFooter(false, false, false, nil, 80)
+	footer := renderFooter(false, false, false, nil, "", 80)
 	stripped := stripANSI(footer)
 
 	if strings.Contains(stripped, "open PR") {
@@ -505,7 +505,7 @@ func TestRenderFooter_FailedRun_ShowsRerun(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.Ascii)
 	run := testRun()
 	run.Status = types.RunFailed
-	footer := renderFooter(true, false, false, run, 80)
+	footer := renderFooter(true, false, false, run, "", 80)
 	stripped := stripANSI(footer)
 
 	if !strings.Contains(stripped, "rerun") {
@@ -520,11 +520,25 @@ func TestRenderFooter_PRURL_ActionShownAtNarrowWidth(t *testing.T) {
 	run := testRun()
 	run.Status = types.RunCompleted
 	run.PRURL = &prURL
-	footer := renderFooter(true, false, false, run, 40)
+	footer := renderFooter(true, false, false, run, "", 40)
 	stripped := stripANSI(footer)
 
 	if !strings.Contains(stripped, "open PR") {
 		t.Errorf("expected footer to contain 'open PR' action, got: %s", stripped)
+	}
+}
+
+func TestRenderFooter_WithAvailableUpdate_ShowsIndicator(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.Ascii)
+	footer := renderFooter(false, false, false, nil, "v1.2.3", 80)
+	stripped := stripANSI(footer)
+
+	if !strings.Contains(stripped, "v1.2.3 available") {
+		t.Fatalf("expected footer to contain update indicator, got: %s", stripped)
+	}
+
+	if !strings.HasSuffix(strings.TrimRight(stripped, " "), "v1.2.3 available") {
+		t.Fatalf("expected update indicator at right edge, got: %s", stripped)
 	}
 }
 
@@ -4612,7 +4626,7 @@ func TestModel_View_StackedLogBoxFillsRemainingHeight(t *testing.T) {
 	}
 
 	pipelineView := renderPipelineView(run, m.stepsWithRunningElapsed(), m.width, 0, m.height)
-	footer := renderFooter(false, false, false, run, m.width)
+	footer := renderFooter(false, false, false, run, "", m.width)
 	expectedLogLines := m.height - sectionsHeight([]string{pipelineView}, 2) - 2 - lipgloss.Height(footer) - 2
 	if expectedLogLines <= 5 {
 		t.Fatalf("expected stacked layout to leave room for more than 5 log lines, got %d", expectedLogLines)

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -152,6 +152,14 @@ func MaybeNotifyAndCheck(args []string, stderr io.Writer) {
 	u.maybeNotifyAndCheck(args)
 }
 
+func CachedLatestVersion() string {
+	u, err := defaultUpdater(io.Discard, io.Discard)
+	if err != nil {
+		return ""
+	}
+	return u.cachedLatestVersion()
+}
+
 func defaultUpdater(stdout, stderr io.Writer) (*updater, error) {
 	p, err := paths.New()
 	if err != nil {
@@ -383,6 +391,21 @@ func (u *updater) maybeNotifyAndCheck(args []string) {
 	if cacheStale(cache, u.currentVersion, u.now()) && u.spawnBackground != nil {
 		_ = u.spawnBackground(u.currentVersion)
 	}
+}
+
+func (u *updater) cachedLatestVersion() string {
+	if u == nil || u.disableBackground || isDevVersion(u.currentVersion) || os.Getenv(noUpdateCheckEnv) == "1" {
+		return ""
+	}
+	cache := readCache(u.cachePath)
+	if cache == nil {
+		return ""
+	}
+	cmp, err := compareVersions(u.currentVersion, cache.LatestVersion)
+	if err != nil || cmp >= 0 {
+		return ""
+	}
+	return cache.LatestVersion
 }
 
 func (u *updater) run(ctx context.Context) error {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -813,6 +813,30 @@ func TestUpdaterMaybeNotifyAndCheck(t *testing.T) {
 	}
 }
 
+func TestUpdaterCachedLatestVersion(t *testing.T) {
+	cachePath := filepath.Join(t.TempDir(), "update-check.json")
+	if err := writeCache(cachePath, &checkCache{
+		CheckedAt:     time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC),
+		LatestVersion: "v1.2.3",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	u := &updater{
+		currentVersion: "v1.2.2",
+		cachePath:      cachePath,
+	}
+
+	if got := u.cachedLatestVersion(); got != "v1.2.3" {
+		t.Fatalf("cachedLatestVersion() = %q, want %q", got, "v1.2.3")
+	}
+
+	u.currentVersion = "v1.2.3"
+	if got := u.cachedLatestVersion(); got != "" {
+		t.Fatalf("cachedLatestVersion() = %q, want empty when already current", got)
+	}
+}
+
 func stringsRepeat(s string, count int) string {
 	buf := bytes.NewBuffer(nil)
 	for i := 0; i < count; i++ {


### PR DESCRIPTION
## Summary
- surface a cached newer-version indicator in the attach TUI footer so users can see when an update is available without triggering a fresh check
- preserve the footer indicator across TUI reruns by carrying the cached update state into rebuilt models
- document the new footer behavior in the TUI guide so the update signal is discoverable

## Risk Assessment

✅ Low: The change is narrowly scoped to surfacing cached update state in the TUI and preserving it across reruns, and the added logic is covered by targeted tests without introducing obvious correctness or safety regressions.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → user-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/tui/app.go:1454` - `latestVersion` is only set on the initial model instance. When the user reruns a failed/cancelled pipeline, `resetForRun` rebuilds the model with `NewModel(...)` and does not carry this field forward, so the new footer silently loses the cached update indicator for the rest of the session.

**Round 2** (user-fix) - found 0 issues

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 info
- ℹ️ `docs/src/content/docs/guides/tui.md:8` - The TUI guide does not document the new footer behavior added in this change: when a cached newer release exists, the attach TUI now shows `&lt;version&gt; available` at the right side of the footer and preserves that indicator across reruns. Add a short note to the layout/footer documentation so the user-facing update signal is discoverable.

**Round 2** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
