### PR TITLE
fix(pipeline): rename follow-up fix rounds to auto-fix

### DIFF
--- a/docs/src/content/docs/guides/auto-fix.md
+++ b/docs/src/content/docs/guides/auto-fix.md
@@ -78,9 +78,11 @@ The push step commits any remaining uncommitted changes with `no-mistakes: apply
 
 ## Step rounds
 
-Each execution of a step (initial run, auto-fix, user-fix) is recorded as a "round" in the database. The PR body's deterministic risk assessment, testing, and pipeline sections are built from these rounds, giving reviewers visibility into test results, review risk, what was fixed, and how many attempts it took.
+Each execution of a step (initial run or follow-up auto-fix run) is recorded as a "round" in the database. The PR body's deterministic risk assessment, testing, and pipeline sections are built from these rounds, giving reviewers visibility into test results, review risk, what was fixed, and how many attempts it took.
 
 Round trigger types:
 - `initial` - first execution
 - `auto_fix` - triggered by the automatic fix loop
-- `user_fix` - triggered by the user pressing `f` in the TUI
+- `auto_fix` - also used when you press `f` in the TUI to run a follow-up fix
+
+Legacy `user_fix` rounds are still rendered as `auto-fix` in PR summaries for backward compatibility.

--- a/docs/src/content/docs/how-it-works.md
+++ b/docs/src/content/docs/how-it-works.md
@@ -77,7 +77,7 @@ Communication between the CLI and daemon uses JSON-RPC 2.0 over the Unix socket.
 
 ### Database
 
-SQLite at `~/.no-mistakes/state.sqlite` tracks repos, runs, step results, and step rounds. Step rounds record each execution attempt (initial, auto-fix, user-fix) with its own findings and duration.
+SQLite at `~/.no-mistakes/state.sqlite` tracks repos, runs, step results, and step rounds. Step rounds record each execution attempt (initial, auto-fix) with its own findings and duration. Legacy `user_fix` rounds are still read as `auto-fix` for backward compatibility.
 
 ## Local state
 

--- a/internal/db/round.go
+++ b/internal/db/round.go
@@ -7,7 +7,7 @@ type StepRound struct {
 	ID           string
 	StepResultID string
 	Round        int
-	Trigger      string  // "initial", "auto_fix", "user_fix"
+	Trigger      string  // "initial", "auto_fix"; legacy "user_fix" is treated as "auto_fix"
 	FindingsJSON *string // nullable - findings produced by this round
 	DurationMS   int64
 	CreatedAt    int64

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -362,7 +362,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			sctx.Fixing = true
 			selectedFindings := filterFindingsJSON(outcome.Findings, response.findingIDs)
 			sctx.PreviousFindings = selectedFindings
-			nextTrigger = "user_fix"
+			nextTrigger = "auto_fix"
 			currentDismissed := excludeFindingsJSON(outcome.Findings, response.findingIDs)
 			previousDismissed := retainMatchingFindingsJSON(removeMatchingFindingsJSON(sctx.DismissedFindings, selectedFindings), outcome.Findings)
 			sctx.DismissedFindings = mergeFindingsJSON(previousDismissed, currentDismissed)

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -1022,6 +1022,69 @@ func TestExecutor_FixClearsStoredFindingsAfterSuccessfulReRun(t *testing.T) {
 	}
 }
 
+func TestExecutor_FixPersistsFollowUpRoundAsAutoFix(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	callCount := 0
+	step := &adaptiveCallStep{
+		name: types.StepReview,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			callCount++
+			if callCount == 1 {
+				return &StepOutcome{
+					NeedsApproval: true,
+					Findings:      `{"findings":[{"severity":"error","description":"first pass issue","action":"auto-fix"}],"summary":"1 issue"}`,
+				}, nil
+			}
+			return &StepOutcome{}, nil
+		},
+	}
+
+	exec := NewExecutor(database, p, nil, nil, []Step{step}, nil)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- exec.Execute(context.Background(), run, repo, workDir)
+	}()
+
+	waitForStepStatus(t, database, run.ID, types.StepReview, types.StepStatusAwaitingApproval)
+	if err := exec.Respond(types.StepReview, types.ActionFix, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("executor timed out")
+	}
+
+	dbSteps, err := database.GetStepsByRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dbSteps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(dbSteps))
+	}
+
+	rounds, err := database.GetRoundsByStep(dbSteps[0].ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rounds) != 2 {
+		t.Fatalf("expected 2 rounds, got %d", len(rounds))
+	}
+	if rounds[0].Trigger != "initial" {
+		t.Fatalf("round 1 trigger = %q, want %q", rounds[0].Trigger, "initial")
+	}
+	if rounds[1].Trigger != "auto_fix" {
+		t.Fatalf("round 2 trigger = %q, want %q", rounds[1].Trigger, "auto_fix")
+	}
+}
+
 func TestExecutor_FixSelectedFindingsRewritesSummary(t *testing.T) {
 	database, p, run, repo := setupTest(t)
 	workDir := t.TempDir()

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -274,15 +274,14 @@ func buildFixResultText(rounds []*db.StepRound) string {
 		}
 	}
 
-	// Categorize fix rounds.
+	// Categorize fix rounds. Legacy "user_fix" rounds are rendered as auto-fix.
 	autoFixRounds := 0
-	userFixRounds := 0
 	for _, r := range rounds[1:] {
 		switch r.Trigger {
 		case "auto_fix":
 			autoFixRounds++
 		case "user_fix":
-			userFixRounds++
+			autoFixRounds++
 		}
 	}
 
@@ -293,12 +292,10 @@ func buildFixResultText(rounds []*db.StepRound) string {
 
 	parts := []string{fmt.Sprintf("%d %s found", initialCount, noun)}
 
-	if autoFixRounds > 0 && userFixRounds > 0 {
-		parts = append(parts, fmt.Sprintf("auto-fixed (%d) + user-fixed (%d)", autoFixRounds, userFixRounds))
-	} else if autoFixRounds > 0 {
+	if autoFixRounds > 1 {
+		parts = append(parts, fmt.Sprintf("auto-fixed (%d)", autoFixRounds))
+	} else if autoFixRounds == 1 {
 		parts = append(parts, "auto-fixed")
-	} else if userFixRounds > 0 {
-		parts = append(parts, "user-fixed")
 	}
 
 	return strings.Join(parts, " → ")
@@ -325,7 +322,7 @@ func buildStepDetails(summaryLine string, sr *db.StepResult, rounds []*db.StepRo
 		case "auto_fix":
 			triggerLabel = " (auto-fix)"
 		case "user_fix":
-			triggerLabel = " (user-fix)"
+			triggerLabel = " (auto-fix)"
 		}
 
 		if r.FindingsJSON == nil {

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -180,6 +180,31 @@ func TestBuildPipelineSummary_MultiRoundWithFollowUpFix(t *testing.T) {
 	}
 }
 
+func TestBuildPipelineSummary_LegacyUserFixRoundsRenderAsAutoFix(t *testing.T) {
+	t.Parallel()
+	findings := `{"findings":[{"id":"review-1","severity":"warning","description":"legacy round"}],"summary":"1 warning"}`
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepReview, Status: types.StepStatusCompleted},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {
+			{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 1000},
+			{Round: 2, Trigger: "user_fix", DurationMS: 700},
+		},
+	}
+	md, _ := BuildPipelineSummary(steps, rounds)
+
+	if !strings.Contains(md, "auto-fixed") {
+		t.Errorf("expected legacy user_fix round to render as auto-fixed, got:\n%s", md)
+	}
+	if !strings.Contains(md, "Round 2** (auto-fix) - passed") {
+		t.Errorf("expected legacy user_fix round label to render as auto-fix, got:\n%s", md)
+	}
+	if strings.Contains(md, "user-fix") || strings.Contains(md, "user-fixed") {
+		t.Errorf("did not expect legacy user-fix wording in summary, got:\n%s", md)
+	}
+}
+
 func TestBuildPipelineSummary_MultiRoundStillFailing(t *testing.T) {
 	t.Parallel()
 	findings1 := `{"findings":[{"id":"lint-1","severity":"error","file":"pkg/foo.go","line":18,"description":"unused import"},{"id":"lint-2","severity":"warning","file":"pkg/bar.go","line":35,"description":"missing error check"}],"summary":"2 issues"}`

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -153,7 +153,7 @@ func TestBuildPipelineSummary_AutoFix(t *testing.T) {
 	}
 }
 
-func TestBuildPipelineSummary_MultiRoundWithUserFix(t *testing.T) {
+func TestBuildPipelineSummary_MultiRoundWithFollowUpFix(t *testing.T) {
 	t.Parallel()
 	findings1 := `{"findings":[{"id":"test-1","severity":"error","file":"pkg/handler_test.go","line":42,"description":"expected 429 got 200"},{"id":"test-2","severity":"error","file":"pkg/handler_test.go","line":78,"description":"context deadline exceeded"}],"summary":"2 failures"}`
 	findings2 := `{"findings":[{"id":"test-2","severity":"error","file":"pkg/handler_test.go","line":78,"description":"context deadline exceeded"}],"summary":"1 failure"}`
@@ -164,7 +164,7 @@ func TestBuildPipelineSummary_MultiRoundWithUserFix(t *testing.T) {
 		"s1": {
 			{Round: 1, Trigger: "initial", FindingsJSON: &findings1, DurationMS: 1000},
 			{Round: 2, Trigger: "auto_fix", FindingsJSON: &findings2, DurationMS: 900},
-			{Round: 3, Trigger: "user_fix", DurationMS: 700},
+			{Round: 3, Trigger: "auto_fix", DurationMS: 700},
 		},
 	}
 	md, _ := BuildPipelineSummary(steps, rounds)
@@ -172,8 +172,11 @@ func TestBuildPipelineSummary_MultiRoundWithUserFix(t *testing.T) {
 	if !strings.Contains(md, "Round 3") {
 		t.Errorf("expected 3 rounds in details, got:\n%s", md)
 	}
-	if !strings.Contains(md, "user-fix") || !strings.Contains(md, "auto-fix") {
-		t.Errorf("expected both fix types mentioned, got:\n%s", md)
+	if strings.Contains(md, "user-fix") || strings.Contains(md, "user-fixed") {
+		t.Errorf("did not expect user-fix wording, got:\n%s", md)
+	}
+	if !strings.Contains(md, "auto-fixed (2)") {
+		t.Errorf("expected consolidated auto-fix count, got:\n%s", md)
 	}
 }
 
@@ -305,7 +308,7 @@ func TestBuildPipelineSummary_ReviewUsesFinalCleanState(t *testing.T) {
 	rounds := map[string][]*db.StepRound{
 		"s1": {
 			{Round: 1, Trigger: "initial", FindingsJSON: &initialFindings, DurationMS: 1000},
-			{Round: 2, Trigger: "user_fix", FindingsJSON: &finalFindings, DurationMS: 700},
+			{Round: 2, Trigger: "auto_fix", FindingsJSON: &finalFindings, DurationMS: 700},
 		},
 	}
 	md, risk := BuildPipelineSummary(steps, rounds)
@@ -313,8 +316,11 @@ func TestBuildPipelineSummary_ReviewUsesFinalCleanState(t *testing.T) {
 	if !strings.Contains(md, "🔧 **Review**") {
 		t.Errorf("expected fixed review status, got:\n%s", md)
 	}
-	if !strings.Contains(md, "user-fixed") {
-		t.Errorf("expected user-fixed in review line, got:\n%s", md)
+	if !strings.Contains(md, "auto-fixed") {
+		t.Errorf("expected auto-fixed in review line, got:\n%s", md)
+	}
+	if strings.Contains(md, "user-fixed") {
+		t.Errorf("did not expect user-fixed in review line, got:\n%s", md)
 	}
 	if strings.Contains(risk, "initial risk rationale") {
 		t.Errorf("did not expect stale initial rationale in risk, got: %q", risk)
@@ -419,7 +425,7 @@ func TestBuildPipelineSummary_ReviewDoesNotReuseInitialRiskWhenFinalUnreadable(t
 	rounds := map[string][]*db.StepRound{
 		"s1": {
 			{Round: 1, Trigger: "initial", FindingsJSON: &initialFindings, DurationMS: 1000},
-			{Round: 2, Trigger: "user_fix", FindingsJSON: &invalidFinalFindings, DurationMS: 700},
+			{Round: 2, Trigger: "auto_fix", FindingsJSON: &invalidFinalFindings, DurationMS: 700},
 		},
 	}
 	md, risk := BuildPipelineSummary(steps, rounds)


### PR DESCRIPTION
## Summary
- Persist follow-up fix rounds under `auto_fix` in the pipeline executor and database path, replacing the previous `user_fix` naming.
- Update PR summary rendering to use the `auto-fix` label consistently, including compatibility handling around existing round data.
- Refresh the auto-fix and how-it-works docs, and add executor and PR summary test coverage so the renamed round flow is documented and verified.

## Risk Assessment

⚠️ Medium: The diff is small and localized, but it changes the semantics of recorded fix rounds and the user-facing summary in a way that may be intentional yet removes auditability if merged as-is.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 2 warnings</summary>

**Round 1** - found 2 warnings
- ⚠️ `internal/pipeline/executor.go:365` - `ActionFix` is still a user-approved follow-up fix path, but this now persists the next round as `auto_fix`; that removes the distinction between automatic retries and explicitly requested fixes, so existing DB history, metrics, and downstream summaries can no longer tell which changes were agent-initiated versus user-requested.
- ⚠️ `internal/pipeline/steps/prsummary.go:324` - The PR summary now renders legacy and new `user_fix` rounds as `auto-fix`, which retroactively changes the meaning of historical run data and can mislead reviewers about whether a fix was automatic or happened only after user approval.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed</summary>

**Round 1** - found 2 warnings
- ⚠️ `docs/src/content/docs/how-it-works.md:80` - The database overview still says step rounds are recorded as `initial`, `auto-fix`, and `user-fix`. After this change, new follow-up fix rounds are persisted as `auto_fix`, and legacy `user_fix` rounds are only treated as backward-compatible historical data. Update this description so the documented round types and labels match current behavior.
- ⚠️ `docs/src/content/docs/guides/auto-fix.md:81` - The auto-fix guide still documents `user-fix`/`user_fix` as a current step-round type and says it is triggered by pressing `f` in the TUI. The code now records that follow-up run as `auto_fix` and PR summaries render it as `auto-fix`, with `user_fix` only kept for legacy compatibility. Update the step-round section and trigger list to reflect the new canonical trigger name and legacy handling.

**Round 2** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
