### PR TITLE
fix(prompts): keep document prompts in sync

### DIFF
--- a/internal/pipeline/steps/document.go
+++ b/internal/pipeline/steps/document.go
@@ -114,8 +114,9 @@ Task:
      - Removed functionality - remove or update stale references
 
 3. Return findings
-   - Return a finding for each specific documentation gap (file, description of what needs updating).
-   - If no documentation updates are needed (e.g., internal refactoring, test-only changes, or documentation is already up to date), return an empty findings array.
+    - Return a finding for each specific documentation gap (file, description of what needs updating).
+    - If no documentation updates are needed (e.g., internal refactoring, test-only changes, or documentation is already up to date), return an empty findings array.
+    - Do a full documentation pass before returning. Do not stop after the first documentation gap. Continue checking the rest of the affected docs until you have enumerated all specific gaps you can substantiate.
 
 Rules:
 - Do NOT make any file changes in this mode.

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -142,6 +142,7 @@ Task:
 - Analyze for bugs, risks, and code simplification opportunities.
 - "Simplification" means reducing code complexity through non-functional refactoring (e.g. deduplication, clearer control flow). It does NOT mean removing features, changing product behavior, or stripping intentional user-facing output.
 - Treat security issues, performance regressions, breaking changes, and insufficient error handling as risks.
+- Do a full review pass before returning. Do not stop after the first valid finding. Continue inspecting the rest of the changed code until you have enumerated all material issues you can substantiate.
 
 Rules:
 - Anchor every finding to a specific file and one-indexed line number in the changed code when possible.

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1958,6 +1958,12 @@ func TestReviewStep_WithWarnings(t *testing.T) {
 	if strings.Contains(ag.calls[0].Prompt, "feature code") {
 		t.Error("expected prompt to avoid embedding diff contents")
 	}
+	if !strings.Contains(ag.calls[0].Prompt, "Do a full review pass before returning.") {
+		t.Error("expected review prompt to require a full pass before returning")
+	}
+	if !strings.Contains(ag.calls[0].Prompt, "Do not stop after the first valid finding.") {
+		t.Error("expected review prompt to discourage stopping at the first finding")
+	}
 }
 
 func TestReviewStep_Clean(t *testing.T) {
@@ -2734,6 +2740,12 @@ func TestDocumentStep_Updated(t *testing.T) {
 	}
 	if !strings.Contains(ag.calls[0].Prompt, "refs/heads/feature") {
 		t.Error("expected prompt to contain branch name")
+	}
+	if !strings.Contains(ag.calls[0].Prompt, "Do a full documentation pass before returning.") {
+		t.Error("expected document prompt to require a full pass before returning")
+	}
+	if !strings.Contains(ag.calls[0].Prompt, "Do not stop after the first documentation gap.") {
+		t.Error("expected document prompt to discourage stopping at the first gap")
 	}
 	var findings Findings
 	if err := json.Unmarshal([]byte(outcome.Findings), &findings); err != nil {


### PR DESCRIPTION
## Summary
- Update the document step prompts so documentation guidance stays aligned with the pipeline's expected prompt set.
- Add coverage for prompt assembly across pipeline steps to catch prompt drift and prevent regressions.

## Risk Assessment

✅ Low: The change is narrowly scoped to prompt text and matching tests, with no functional control-flow or data-handling changes in the reviewed code paths.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
