### PR TITLE
fix(update): guard daemon restarts by executable path

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ To update an existing install in place:
 no-mistakes update
 ```
 
-This replaces the binary and resets the background daemon so it picks up the new executable. If the daemon does not come back cleanly, the new binary stays installed but the command reports the daemon reset failure.
+This replaces the binary and resets the background daemon so it picks up the new executable, but only if the running daemon is already using the same executable path. If the daemon executable path cannot be determined or it was started from a different binary, the update aborts before replacing the binary. If the daemon does not come back cleanly after a successful replacement, the new binary stays installed but the command reports the daemon reset failure.
 
 ## How It Works
 

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -109,7 +109,7 @@ To update an existing install in place:
 no-mistakes update
 ```
 
-This downloads the latest release from GitHub, verifies the SHA-256 checksum, atomically replaces the binary, and resets the daemon so it starts using the new executable. If the daemon does not come back cleanly, the command reports that failure after the binary update.
+This downloads the latest release from GitHub, verifies the SHA-256 checksum, atomically replaces the binary, and resets the daemon so it starts using the new executable when the running daemon is already using the same executable path. If the daemon executable path cannot be determined or it was started from a different binary, the update aborts before replacing the binary. If the daemon does not come back cleanly after a successful replacement, the command reports that failure.
 
 ## Remove from a repo
 

--- a/docs/src/content/docs/guides/daemon.md
+++ b/docs/src/content/docs/guides/daemon.md
@@ -22,7 +22,7 @@ no-mistakes rerun
 no-mistakes update
 ```
 
-`no-mistakes update` stops and starts the daemon when it is running, or when stale daemon artifacts exist, so the new executable is used.
+`no-mistakes update` stops and starts the daemon when it is running, or when stale daemon artifacts exist, so the new executable is used. If the daemon is already running, update only proceeds when the daemon is using the same executable path as the binary running the update command; if that path cannot be determined or points to a different binary, the update aborts before replacing anything.
 
 The daemon writes its PID to `~/.no-mistakes/daemon.pid` and listens on a Unix socket at `~/.no-mistakes/socket`. On Windows, it uses a localhost TCP listener and a protected endpoint file at the same path.
 

--- a/docs/src/content/docs/how-it-works.md
+++ b/docs/src/content/docs/how-it-works.md
@@ -58,7 +58,7 @@ A long-running background process that manages pipeline runs. It:
 - Persists state to SQLite
 - Streams events to connected TUI clients via IPC
 
-The daemon auto-starts when needed (`init`, `attach`, `rerun`), and `update` resets it after replacing the binary when the daemon is running or stale daemon artifacts exist. You can also manage it explicitly with `no-mistakes daemon start|stop|status`.
+The daemon auto-starts when needed (`init`, `attach`, `rerun`), and `update` resets it after replacing the binary when the daemon is running or stale daemon artifacts exist. If the daemon is already running, `update` first checks that it was started from the same executable path and aborts if the daemon executable path cannot be determined or points to a different binary. You can also manage it explicitly with `no-mistakes daemon start|stop|status`.
 
 On startup, the daemon recovers from crashes by marking any stuck runs as failed and cleaning up orphaned worktrees.
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -113,7 +113,7 @@ Update the installed binary and reset the daemon.
 no-mistakes update
 ```
 
-Downloads the latest release, verifies the SHA-256 checksum, atomically replaces the running binary, and resets the daemon when it is running or stale daemon artifacts exist so the new executable is picked up. If the daemon does not come back cleanly, the command reports that failure after the binary update. On macOS, removes the quarantine extended attribute.
+Downloads the latest release, verifies the SHA-256 checksum, atomically replaces the running binary, and resets the daemon when it is running or stale daemon artifacts exist so the new executable is picked up. If the daemon is running, update first requires it to already be using the same executable path as the binary running `no-mistakes update`; if that daemon executable path cannot be determined or it points to a different binary, the update aborts before replacement. If the daemon does not come back cleanly after a successful replacement, the command reports that failure. On macOS, removes the quarantine extended attribute.
 
 Background update checks run automatically on each CLI invocation (except `update` itself). If a newer version is available, a notification is printed to stderr. Suppressed for dev builds or when `NO_MISTAKES_NO_UPDATE_CHECK=1` is set.
 

--- a/internal/update/process_path_nonwindows.go
+++ b/internal/update/process_path_nonwindows.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package update
+
+import "fmt"
+
+func defaultWindowsExecutablePathForPID(int) (string, error) {
+	return "", fmt.Errorf("windows process path lookup unavailable")
+}

--- a/internal/update/process_path_windows.go
+++ b/internal/update/process_path_windows.go
@@ -1,0 +1,38 @@
+//go:build windows
+
+package update
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+const processQueryLimitedInformation = 0x1000
+
+var queryFullProcessImageNameW = syscall.NewLazyDLL("kernel32.dll").NewProc("QueryFullProcessImageNameW")
+
+func defaultWindowsExecutablePathForPID(pid int) (string, error) {
+	handle, err := syscall.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
+	if err != nil {
+		return "", err
+	}
+	defer syscall.CloseHandle(handle)
+
+	size := uint32(32768)
+	buf := make([]uint16, size)
+	r1, _, callErr := queryFullProcessImageNameW.Call(
+		uintptr(handle),
+		0,
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(unsafe.Pointer(&size)),
+	)
+	if r1 == 0 {
+		if callErr != syscall.Errno(0) {
+			return "", callErr
+		}
+		return "", fmt.Errorf("query process image path: unknown error")
+	}
+
+	return syscall.UTF16ToString(buf[:size]), nil
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -41,10 +41,12 @@ const (
 
 var allowInsecureDownloads bool
 var githubAPIBaseURL = "https://api.github.com"
+var currentGOOS = runtime.GOOS
 var daemonIsRunning = daemon.IsRunning
 var daemonExecutablePath = runningDaemonExecutablePath
 var daemonStop = daemon.Stop
 var daemonStart = daemon.Start
+var windowsExecutablePathForPID = defaultWindowsExecutablePathForPID
 
 type daemonResetError struct {
 	err           error
@@ -540,8 +542,11 @@ func runningDaemonExecutablePath(p *paths.Paths) (string, error) {
 }
 
 func executablePathForPID(pid int) (string, error) {
-	if runtime.GOOS == "linux" {
+	if currentGOOS == "linux" {
 		return os.Readlink(filepath.Join("/proc", strconv.Itoa(pid), "exe"))
+	}
+	if currentGOOS == "windows" {
+		return windowsExecutablePathForPID(pid)
 	}
 	cmd := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "comm=")
 	out, err := cmd.Output()

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -480,7 +480,10 @@ func (u *updater) ensureDaemonUsesCurrentExecutable() error {
 	}
 	runningPath, err := daemonExecutablePath(u.paths)
 	if err != nil || runningPath == "" {
-		return nil
+		if err != nil {
+			return fmt.Errorf("cannot determine daemon executable path: %w", err)
+		}
+		return errors.New("cannot determine daemon executable path")
 	}
 	currentPath := resolveExecutablePath(u.executablePath)
 	runningPath = resolveExecutablePath(runningPath)
@@ -526,16 +529,26 @@ func runningDaemonExecutablePath(p *paths.Paths) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolve daemon executable: %w", err)
 	}
-	cmd := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "comm=")
-	out, err := cmd.Output()
+	path, err := executablePathForPID(pid)
 	if err != nil {
 		return "", fmt.Errorf("resolve daemon executable: %w", err)
 	}
-	line := strings.TrimSpace(string(out))
-	if line == "" {
+	if path == "" {
 		return "", fmt.Errorf("resolve daemon executable: empty process command")
 	}
-	return resolveExecutablePath(line), nil
+	return resolveExecutablePath(path), nil
+}
+
+func executablePathForPID(pid int) (string, error) {
+	if runtime.GOOS == "linux" {
+		return os.Readlink(filepath.Join("/proc", strconv.Itoa(pid), "exe"))
+	}
+	cmd := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "comm=")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
 }
 
 func resolveExecutablePath(path string) string {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -42,6 +42,7 @@ const (
 var allowInsecureDownloads bool
 var githubAPIBaseURL = "https://api.github.com"
 var daemonIsRunning = daemon.IsRunning
+var daemonExecutablePath = runningDaemonExecutablePath
 var daemonStop = daemon.Stop
 var daemonStart = daemon.Start
 
@@ -101,6 +102,7 @@ type updater struct {
 	now               func() time.Time
 	spawnBackground   func(currentVersion string) error
 	resetDaemon       func() error
+	paths             *paths.Paths
 	disableBackground bool
 	noColor           bool
 }
@@ -181,6 +183,7 @@ func defaultUpdater(stdout, stderr io.Writer) (*updater, error) {
 		stdout:          stdout,
 		stderr:          stderr,
 		now:             time.Now,
+		paths:           p,
 		spawnBackground: defaultSpawnBackground,
 		resetDaemon: func() error {
 			return defaultResetDaemon(p)
@@ -413,6 +416,9 @@ func (u *updater) run(ctx context.Context) error {
 		fmt.Fprintf(u.stdoutWriter(), "self-update unavailable for development builds (%s)\n", u.currentVersion)
 		return nil
 	}
+	if err := u.ensureDaemonUsesCurrentExecutable(); err != nil {
+		return err
+	}
 	plan, err := u.checkLatest(ctx)
 	if err != nil {
 		return err
@@ -464,6 +470,26 @@ func (u *updater) run(ctx context.Context) error {
 	return nil
 }
 
+func (u *updater) ensureDaemonUsesCurrentExecutable() error {
+	if u == nil || u.paths == nil || u.executablePath == "" {
+		return nil
+	}
+	alive, err := daemonIsRunning(u.paths)
+	if err != nil || !alive {
+		return nil
+	}
+	runningPath, err := daemonExecutablePath(u.paths)
+	if err != nil || runningPath == "" {
+		return nil
+	}
+	currentPath := resolveExecutablePath(u.executablePath)
+	runningPath = resolveExecutablePath(runningPath)
+	if currentPath == runningPath {
+		return nil
+	}
+	return fmt.Errorf("daemon is running from %s, but update is running from %s; run update using the same binary that started the daemon, or restart the daemon from this binary first", runningPath, currentPath)
+}
+
 func defaultResetDaemon(p *paths.Paths) error {
 	if p == nil {
 		return nil
@@ -490,6 +516,40 @@ func daemonArtifactsExist(p *paths.Paths) bool {
 		}
 	}
 	return false
+}
+
+func runningDaemonExecutablePath(p *paths.Paths) (string, error) {
+	if p == nil {
+		return "", fmt.Errorf("resolve daemon executable: nil paths")
+	}
+	pid, err := daemon.ReadPID(p)
+	if err != nil {
+		return "", fmt.Errorf("resolve daemon executable: %w", err)
+	}
+	cmd := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "command=")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("resolve daemon executable: %w", err)
+	}
+	line := strings.TrimSpace(string(out))
+	if line == "" {
+		return "", fmt.Errorf("resolve daemon executable: empty process command")
+	}
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return "", fmt.Errorf("resolve daemon executable: empty process command")
+	}
+	return resolveExecutablePath(fields[0]), nil
+}
+
+func resolveExecutablePath(path string) string {
+	if path == "" {
+		return ""
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	return path
 }
 
 func (u *updater) fetchLatestRelease(ctx context.Context) (*releaseResponse, error) {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -418,9 +418,6 @@ func (u *updater) run(ctx context.Context) error {
 		fmt.Fprintf(u.stdoutWriter(), "self-update unavailable for development builds (%s)\n", u.currentVersion)
 		return nil
 	}
-	if err := u.ensureDaemonUsesCurrentExecutable(); err != nil {
-		return err
-	}
 	plan, err := u.checkLatest(ctx)
 	if err != nil {
 		return err
@@ -431,6 +428,9 @@ func (u *updater) run(ctx context.Context) error {
 	if !plan.UpdateAvailable {
 		fmt.Fprintf(u.stdoutWriter(), "%s is already up to date (%s)\n", u.appName, u.currentVersion)
 		return nil
+	}
+	if err := u.ensureDaemonUsesCurrentExecutable(); err != nil {
+		return err
 	}
 
 	archiveData, err := u.downloadAsset(ctx, plan.Archive.BrowserDownloadURL, maxDownloadSize)

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -489,10 +489,19 @@ func (u *updater) ensureDaemonUsesCurrentExecutable() error {
 	}
 	currentPath := resolveExecutablePath(u.executablePath)
 	runningPath = resolveExecutablePath(runningPath)
-	if currentPath == runningPath {
+	if executablePathsMatch(currentPath, runningPath) {
 		return nil
 	}
 	return fmt.Errorf("daemon is running from %s, but update is running from %s; run update using the same binary that started the daemon, or restart the daemon from this binary first", runningPath, currentPath)
+}
+
+func executablePathsMatch(a, b string) bool {
+	if currentGOOS != "windows" {
+		return a == b
+	}
+	a = filepath.Clean(strings.ReplaceAll(a, `\`, "/"))
+	b = filepath.Clean(strings.ReplaceAll(b, `\`, "/"))
+	return strings.EqualFold(a, b)
 }
 
 func defaultResetDaemon(p *paths.Paths) error {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -526,7 +526,7 @@ func runningDaemonExecutablePath(p *paths.Paths) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolve daemon executable: %w", err)
 	}
-	cmd := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "command=")
+	cmd := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "comm=")
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("resolve daemon executable: %w", err)
@@ -535,11 +535,7 @@ func runningDaemonExecutablePath(p *paths.Paths) (string, error) {
 	if line == "" {
 		return "", fmt.Errorf("resolve daemon executable: empty process command")
 	}
-	fields := strings.Fields(line)
-	if len(fields) == 0 {
-		return "", fmt.Errorf("resolve daemon executable: empty process command")
-	}
-	return resolveExecutablePath(fields[0]), nil
+	return resolveExecutablePath(line), nil
 }
 
 func resolveExecutablePath(path string) string {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -900,7 +900,7 @@ func TestRunningDaemonExecutablePathHandlesExecutablePathsWithSpaces(t *testing.
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	copyPath := filepath.Join(dir, "no mistakes test binary")
+	copyPath := filepath.Join(dir, "no mistakes test binary"+filepath.Ext(originalPath))
 	if err := os.WriteFile(copyPath, binary, originalInfo.Mode().Perm()); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -729,6 +729,67 @@ func TestUpdaterRunFailsWhenDaemonExecutableCannotBeResolved(t *testing.T) {
 	}
 }
 
+func TestUpdaterRunSkipsDaemonExecutableCheckWhenAlreadyUpToDate(t *testing.T) {
+	allowInsecureDownloads = true
+	t.Cleanup(func() { allowInsecureDownloads = false })
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/kunchenguid/no-mistakes/releases/latest":
+			fmt.Fprint(w, `{"tag_name":"v1.2.2","assets":[]}`)
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	execPath := filepath.Join(t.TempDir(), "no-mistakes")
+	if err := os.WriteFile(execPath, []byte("current-binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origDaemonIsRunning := daemonIsRunning
+	origDaemonExecutablePath := daemonExecutablePath
+	t.Cleanup(func() {
+		daemonIsRunning = origDaemonIsRunning
+		daemonExecutablePath = origDaemonExecutablePath
+	})
+
+	checks := 0
+	daemonIsRunning = func(*paths.Paths) (bool, error) {
+		checks++
+		return true, nil
+	}
+	daemonExecutablePath = func(*paths.Paths) (string, error) {
+		return "", errors.New("pid lookup failed")
+	}
+
+	stdout := new(bytes.Buffer)
+	u := &updater{
+		appName:        "no-mistakes",
+		repo:           "kunchenguid/no-mistakes",
+		currentVersion: "v1.2.2",
+		platform:       platformSpec{GOOS: "darwin", GOARCH: "arm64"},
+		apiBaseURL:     server.URL,
+		httpClient:     server.Client(),
+		executablePath: execPath,
+		stdout:         stdout,
+		now:            func() time.Time { return time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC) },
+		paths:          paths.WithRoot(t.TempDir()),
+	}
+
+	if err := u.run(context.Background()); err != nil {
+		t.Fatalf("run error = %v", err)
+	}
+	if checks != 0 {
+		t.Fatalf("expected no daemon executable check when already up to date, got %d checks", checks)
+	}
+	if !strings.Contains(stdout.String(), "already up to date") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
 func TestDefaultResetDaemonReportsOfflineWhenRestartFails(t *testing.T) {
 	origIsRunning := daemonIsRunning
 	origStop := daemonStop

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -645,6 +645,34 @@ func TestUpdaterRunFailsWhenDaemonUsesDifferentExecutable(t *testing.T) {
 	}
 }
 
+func TestEnsureDaemonUsesCurrentExecutableAllowsWindowsCaseDifferences(t *testing.T) {
+	origGOOS := currentGOOS
+	origDaemonIsRunning := daemonIsRunning
+	origDaemonExecutablePath := daemonExecutablePath
+	t.Cleanup(func() {
+		currentGOOS = origGOOS
+		daemonIsRunning = origDaemonIsRunning
+		daemonExecutablePath = origDaemonExecutablePath
+	})
+
+	currentGOOS = "windows"
+	daemonIsRunning = func(*paths.Paths) (bool, error) {
+		return true, nil
+	}
+	daemonExecutablePath = func(*paths.Paths) (string, error) {
+		return `c:\program files\no-mistakes\NO-MISTAKES.exe`, nil
+	}
+
+	u := &updater{
+		executablePath: `C:\Program Files\No-Mistakes\no-mistakes.exe`,
+		paths:          paths.WithRoot(t.TempDir()),
+	}
+
+	if err := u.ensureDaemonUsesCurrentExecutable(); err != nil {
+		t.Fatalf("ensureDaemonUsesCurrentExecutable error = %v", err)
+	}
+}
+
 func TestUpdaterRunFailsWhenDaemonExecutableCannotBeResolved(t *testing.T) {
 	allowInsecureDownloads = true
 	t.Cleanup(func() { allowInsecureDownloads = false })

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -645,6 +645,90 @@ func TestUpdaterRunFailsWhenDaemonUsesDifferentExecutable(t *testing.T) {
 	}
 }
 
+func TestUpdaterRunFailsWhenDaemonExecutableCannotBeResolved(t *testing.T) {
+	allowInsecureDownloads = true
+	t.Cleanup(func() { allowInsecureDownloads = false })
+
+	archiveName := "no-mistakes-v1.2.3-darwin-arm64.tar.gz"
+	archive := makeTarGz(t, map[string][]byte{
+		"bin/no-mistakes": []byte("new-binary"),
+	})
+	sum := sha256.Sum256(archive)
+	checksums := fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), archiveName)
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/kunchenguid/no-mistakes/releases/latest":
+			fmt.Fprintf(w, `{"tag_name":"v1.2.3","assets":[{"name":%q,"browser_download_url":%q},{"name":"checksums.txt","browser_download_url":%q}]}`,
+				archiveName,
+				server.URL+"/archive",
+				server.URL+"/checksums",
+			)
+		case "/archive":
+			w.Write(archive)
+		case "/checksums":
+			fmt.Fprint(w, checksums)
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	execDir := t.TempDir()
+	execPath := filepath.Join(execDir, "no-mistakes")
+	if err := os.WriteFile(execPath, []byte("old-binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origDaemonIsRunning := daemonIsRunning
+	origDaemonExecutablePath := daemonExecutablePath
+	t.Cleanup(func() {
+		daemonIsRunning = origDaemonIsRunning
+		daemonExecutablePath = origDaemonExecutablePath
+	})
+
+	checks := 0
+	daemonIsRunning = func(*paths.Paths) (bool, error) {
+		checks++
+		return true, nil
+	}
+	daemonExecutablePath = func(*paths.Paths) (string, error) {
+		return "", errors.New("pid lookup failed")
+	}
+
+	resetCalled := false
+	u := &updater{
+		appName:        "no-mistakes",
+		repo:           "kunchenguid/no-mistakes",
+		currentVersion: "v1.2.2",
+		platform:       platformSpec{GOOS: "darwin", GOARCH: "arm64"},
+		apiBaseURL:     server.URL,
+		httpClient:     server.Client(),
+		executablePath: execPath,
+		now:            func() time.Time { return time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC) },
+		resetDaemon: func() error {
+			resetCalled = true
+			return nil
+		},
+		paths: paths.WithRoot(t.TempDir()),
+	}
+
+	err := u.run(context.Background())
+	if err == nil {
+		t.Fatal("run should fail when daemon executable cannot be resolved")
+	}
+	if !strings.Contains(err.Error(), "cannot determine daemon executable path") {
+		t.Fatalf("run error = %v", err)
+	}
+	if checks == 0 {
+		t.Fatal("expected daemon health check before update")
+	}
+	if resetCalled {
+		t.Fatal("reset daemon should not run when daemon executable cannot be resolved")
+	}
+}
+
 func TestDefaultResetDaemonReportsOfflineWhenRestartFails(t *testing.T) {
 	origIsRunning := daemonIsRunning
 	origStop := daemonStop

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -700,6 +701,58 @@ func TestRunningDaemonExecutablePathUsesPIDFile(t *testing.T) {
 	}
 	if got != resolveExecutablePath(want) {
 		t.Fatalf("runningDaemonExecutablePath = %q, want %q", got, resolveExecutablePath(want))
+	}
+}
+
+func TestRunningDaemonExecutablePathHandlesExecutablePathsWithSpaces(t *testing.T) {
+	if os.Getenv("NO_MISTAKES_TEST_CHILD") == "1" {
+		time.Sleep(10 * time.Second)
+		return
+	}
+
+	originalPath, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalInfo, err := os.Stat(originalPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	binary, err := os.ReadFile(originalPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := filepath.Join(t.TempDir(), "dir with spaces")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	copyPath := filepath.Join(dir, "no mistakes test binary")
+	if err := os.WriteFile(copyPath, binary, originalInfo.Mode().Perm()); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(copyPath, "-test.run=^TestRunningDaemonExecutablePathHandlesExecutablePathsWithSpaces$")
+	cmd.Env = append(os.Environ(), "NO_MISTAKES_TEST_CHILD=1")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	p := paths.WithRoot(t.TempDir())
+	if err := os.WriteFile(p.PIDFile(), []byte(fmt.Sprintf("%d", cmd.Process.Pid)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := runningDaemonExecutablePath(p)
+	if err != nil {
+		t.Fatalf("runningDaemonExecutablePath error = %v", err)
+	}
+	if got != resolveExecutablePath(copyPath) {
+		t.Fatalf("runningDaemonExecutablePath = %q, want %q", got, resolveExecutablePath(copyPath))
 	}
 }
 

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -840,6 +840,36 @@ func TestRunningDaemonExecutablePathHandlesExecutablePathsWithSpaces(t *testing.
 	}
 }
 
+func TestExecutablePathForPIDUsesWindowsResolver(t *testing.T) {
+	origGOOS := currentGOOS
+	origWindowsResolver := windowsExecutablePathForPID
+	t.Cleanup(func() {
+		currentGOOS = origGOOS
+		windowsExecutablePathForPID = origWindowsResolver
+	})
+
+	currentGOOS = "windows"
+	called := false
+	windowsExecutablePathForPID = func(pid int) (string, error) {
+		called = true
+		if pid != 4321 {
+			t.Fatalf("pid = %d, want %d", pid, 4321)
+		}
+		return `C:\Program Files\no-mistakes\no-mistakes.exe`, nil
+	}
+
+	got, err := executablePathForPID(4321)
+	if err != nil {
+		t.Fatalf("executablePathForPID error = %v", err)
+	}
+	if !called {
+		t.Fatal("expected windows resolver to be used")
+	}
+	if got != `C:\Program Files\no-mistakes\no-mistakes.exe` {
+		t.Fatalf("executablePathForPID = %q", got)
+	}
+}
+
 func TestDefaultResetDaemonRecoversWhenHealthCheckErrors(t *testing.T) {
 	origIsRunning := daemonIsRunning
 	origStop := daemonStop

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -549,6 +549,101 @@ func TestUpdaterRunFailsWhenDaemonResetLeavesDaemonOffline(t *testing.T) {
 	}
 }
 
+func TestUpdaterRunFailsWhenDaemonUsesDifferentExecutable(t *testing.T) {
+	allowInsecureDownloads = true
+	t.Cleanup(func() { allowInsecureDownloads = false })
+
+	archiveName := "no-mistakes-v1.2.3-darwin-arm64.tar.gz"
+	archive := makeTarGz(t, map[string][]byte{
+		"bin/no-mistakes": []byte("new-binary"),
+	})
+	sum := sha256.Sum256(archive)
+	checksums := fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), archiveName)
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/kunchenguid/no-mistakes/releases/latest":
+			fmt.Fprintf(w, `{"tag_name":"v1.2.3","assets":[{"name":%q,"browser_download_url":%q},{"name":"checksums.txt","browser_download_url":%q}]}`,
+				archiveName,
+				server.URL+"/archive",
+				server.URL+"/checksums",
+			)
+		case "/archive":
+			w.Write(archive)
+		case "/checksums":
+			fmt.Fprint(w, checksums)
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	execDir := t.TempDir()
+	execPath := filepath.Join(execDir, "no-mistakes")
+	if err := os.WriteFile(execPath, []byte("old-binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	otherExecPath := filepath.Join(execDir, "other-no-mistakes")
+	if err := os.WriteFile(otherExecPath, []byte("other-binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origDaemonIsRunning := daemonIsRunning
+	origDaemonExecutablePath := daemonExecutablePath
+	t.Cleanup(func() {
+		daemonIsRunning = origDaemonIsRunning
+		daemonExecutablePath = origDaemonExecutablePath
+	})
+
+	checks := 0
+	daemonIsRunning = func(*paths.Paths) (bool, error) {
+		checks++
+		return true, nil
+	}
+	daemonExecutablePath = func(*paths.Paths) (string, error) {
+		return otherExecPath, nil
+	}
+
+	resetCalled := false
+	u := &updater{
+		appName:        "no-mistakes",
+		repo:           "kunchenguid/no-mistakes",
+		currentVersion: "v1.2.2",
+		platform:       platformSpec{GOOS: "darwin", GOARCH: "arm64"},
+		apiBaseURL:     server.URL,
+		httpClient:     server.Client(),
+		executablePath: execPath,
+		now:            func() time.Time { return time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC) },
+		resetDaemon: func() error {
+			resetCalled = true
+			return nil
+		},
+		paths: paths.WithRoot(t.TempDir()),
+	}
+
+	err := u.run(context.Background())
+	if err == nil {
+		t.Fatal("run should fail when daemon uses a different executable")
+	}
+	if !strings.Contains(err.Error(), "daemon is running from") {
+		t.Fatalf("run error = %v", err)
+	}
+	if checks == 0 {
+		t.Fatal("expected daemon health check before update")
+	}
+	if resetCalled {
+		t.Fatal("reset daemon should not run when executables mismatch")
+	}
+	content, readErr := os.ReadFile(execPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(content) != "old-binary" {
+		t.Fatalf("executable content = %q", string(content))
+	}
+}
+
 func TestDefaultResetDaemonReportsOfflineWhenRestartFails(t *testing.T) {
 	origIsRunning := daemonIsRunning
 	origStop := daemonStop
@@ -586,6 +681,25 @@ func TestDefaultResetDaemonReportsOfflineWhenRestartFails(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "start daemon") {
 		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestRunningDaemonExecutablePathUsesPIDFile(t *testing.T) {
+	p := paths.WithRoot(t.TempDir())
+	if err := os.WriteFile(p.PIDFile(), []byte(fmt.Sprintf("%d", os.Getpid())), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := runningDaemonExecutablePath(p)
+	if err != nil {
+		t.Fatalf("runningDaemonExecutablePath error = %v", err)
+	}
+	want, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != resolveExecutablePath(want) {
+		t.Fatalf("runningDaemonExecutablePath = %q, want %q", got, resolveExecutablePath(want))
 	}
 }
 


### PR DESCRIPTION
## Summary
- Ensure `no-mistakes update` only replaces and restarts a running daemon when it can confirm the daemon was started from the current executable path, preventing updates from switching to the wrong binary.
- Harden daemon executable path detection across Windows and non-Windows platforms, including skipping the guard for no-op updates and handling path comparisons more reliably.
- Update the README and docs to explain the new daemon path guard and when `update` will refuse to reset a running daemon.

## Risk Assessment

✅ Low: The change is narrowly scoped to update-time daemon executable validation, includes targeted cross-platform tests, and I did not find a material correctness or regression risk in the changed code.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → user-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/update/update.go:529` - `runningDaemonExecutablePath` relies on `ps -o command=` plus `strings.Fields`, so executable detection becomes unreliable when the binary path contains spaces or when `ps` truncates long command lines; that can make `update` incorrectly fail with a daemon mismatch or skip the protection entirely.

**Round 2** (user-fix) - found 2 issues (1 error, 1 warning)
- 🚨 `internal/update/update.go:529` - `runningDaemonExecutablePath` shells out to `ps -o comm=` and treats the result as a filesystem path. On Linux/procps, `comm` commonly reports only the executable name, not its absolute path, so `ensureDaemonUsesCurrentExecutable` will compare `/path/to/no-mistakes` against `no-mistakes` and reject every update while the daemon is running. Read the executable path from a platform-specific source such as `/proc/&lt;pid&gt;/exe`, or persist the resolved path when the daemon starts.
- ⚠️ `internal/update/update.go:482` - If the daemon is alive but its executable path cannot be resolved, the new guard silently returns `nil` and proceeds with the update. That makes the fix best-effort only: on platforms without `ps` or when PID lookup fails, the daemon can still be restarted from the wrong binary. Return a user-facing error once the daemon is confirmed running but its executable path cannot be determined.

**Round 3** (user-fix) - found 1 error
- 🚨 `internal/update/update.go:542` - `executablePathForPID` now shells out to `ps` for every non-Linux platform. On Windows there is no `ps`, so `update` will start failing with &#34;cannot determine daemon executable path&#34; whenever the daemon is running, which is a user-visible regression in a supported target.

**Round 4** (user-fix) - found 1 warning
- ⚠️ `internal/update/update.go:421` - `run` now rejects the command before checking whether any update is actually needed. If the daemon was started from another install or its PID metadata cannot be resolved, even an otherwise harmless `no-mistakes update` status check now hard-fails instead of reporting &#34;already up to date&#34;. Consider moving the executable-consistency gate to just before replacing the binary, or only enforcing it when `plan.UpdateAvailable` is true.

**Round 5** (user-fix) - found 2 warnings
- ⚠️ `internal/update/update.go:484` - If the daemon is healthy but its PID file is missing, stale, or otherwise unreadable, `update` now fails before attempting the normal stop/restart path. That makes recovery depend on manual daemon intervention even though IPC shutdown may still work.
- ⚠️ `internal/update/update.go:492` - The daemon/current executable comparison uses exact string equality after symlink resolution. On Windows this can reject a valid self-update when the two APIs return the same path with different casing or spelling, because the filesystem is case-insensitive.

**Round 6** (user-fix) - found 0 issues

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>🔧 **Document** - 5 issues found → auto-fixed</summary>

**Round 1** - found 5 warnings
- ⚠️ `README.md:98` - The update docs now overstate behavior: `no-mistakes update` no longer always resets the daemon. It first verifies that the running daemon was started from the same executable path and fails if the daemon path cannot be resolved, so this section should document that precondition and failure mode.
- ⚠️ `docs/src/content/docs/getting-started.md:112` - The getting-started update section says the command resets the daemon after replacing the binary, but the new behavior aborts before replacement when the daemon is running from a different executable or its executable path cannot be determined. That constraint should be documented here.
- ⚠️ `docs/src/content/docs/reference/cli.md:110` - The CLI reference for `no-mistakes update` is stale. It should mention that daemon reset only proceeds when the daemon is already running from the same binary path, and that the command errors if it cannot determine the daemon executable path.
- ⚠️ `docs/src/content/docs/how-it-works.md:61` - The daemon lifecycle overview says `update` resets the daemon whenever it is running or stale artifacts exist, but the code now adds an executable-path consistency check before update/reset. This behavior change should be reflected in the architecture docs.
- ⚠️ `docs/src/content/docs/guides/daemon.md:25` - The daemon guide says `no-mistakes update` stops and starts the daemon whenever it is running or stale artifacts exist. That is now incomplete because update refuses to proceed if the daemon was started from a different executable path or its executable cannot be resolved.

**Round 2** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
