### PR TITLE
ci(windows): enable targeted Windows PR test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,17 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Test
-        run: go test ${{ runner.os != 'Windows' && '-race' || '' }} ./...
+      - name: Test on Unix
+        if: runner.os != 'Windows'
+        run: go test -race ./...
+
+      - name: Test on Windows (PR)
+        if: runner.os == 'Windows' && github.event_name == 'pull_request'
+        run: go test ./... -run '_EnableWindowsCI$'
+
+      - name: Test on Windows (Main)
+        if: runner.os == 'Windows' && github.event_name != 'pull_request'
+        run: go test ./...
 
       - name: Build
         run: go build ./cmd/no-mistakes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,8 @@ Safest local verification sequence after non-trivial changes:
 - Prefer creating real git repos in temp directories instead of relying on heavy mocking.
 - CLI tests often capture output and assert with `strings.Contains`.
 - Prefer targeted package tests while iterating, then finish with `go test -race ./...`.
+- Tests whose main value is keeping Windows pull request CI coverage should use the `_EnableWindowsCI` suffix.
+- Use `_EnableWindowsCI` only for tests that exercise Windows-specific behavior or Windows-only regression risk worth keeping in the reduced PR suite. Do not add the suffix to general cross-platform coverage.
 
 **When Making Changes**
 

--- a/internal/ipc/server_test.go
+++ b/internal/ipc/server_test.go
@@ -53,7 +53,7 @@ func startServer(t *testing.T, sock string) *ipc.Server {
 	return srv
 }
 
-func TestServerClientRoundTrip(t *testing.T) {
+func TestServerClientRoundTrip_EnableWindowsCI(t *testing.T) {
 	sock := socketPath(t)
 	srv := startServer(t, sock)
 
@@ -142,7 +142,7 @@ func TestHandlerError(t *testing.T) {
 	}
 }
 
-func TestMultipleClients(t *testing.T) {
+func TestMultipleClients_EnableWindowsCI(t *testing.T) {
 	sock := socketPath(t)
 	srv := startServer(t, sock)
 
@@ -290,7 +290,7 @@ func TestHealthRequestsDoNotLogAtInfo(t *testing.T) {
 	}
 }
 
-func TestServerClose(t *testing.T) {
+func TestServerClose_EnableWindowsCI(t *testing.T) {
 	sock := socketPath(t)
 	srv := ipc.NewServer()
 	errCh := make(chan error, 1)
@@ -328,14 +328,14 @@ func TestServerClose(t *testing.T) {
 	}
 }
 
-func TestDialNonexistentSocket(t *testing.T) {
+func TestDialNonexistentSocket_EnableWindowsCI(t *testing.T) {
 	_, err := ipc.Dial(filepath.Join(t.TempDir(), "nonexistent.sock"))
 	if err == nil {
 		t.Error("expected error dialing nonexistent socket")
 	}
 }
 
-func TestStreamHandler(t *testing.T) {
+func TestStreamHandler_EnableWindowsCI(t *testing.T) {
 	sock := socketPath(t)
 	srv := startServer(t, sock)
 
@@ -779,7 +779,7 @@ func TestServerEmptyLine(t *testing.T) {
 	}
 }
 
-func TestSubscribeClient(t *testing.T) {
+func TestSubscribeClient_EnableWindowsCI(t *testing.T) {
 	sock := socketPath(t)
 	srv := startServer(t, sock)
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -3908,7 +3908,7 @@ func fakeGH(t *testing.T, prViewURL string) (env []string, logFile string) {
 	return env, logFile
 }
 
-func TestStepCLIAvailable_ResolvesExecutableSuffixFromCustomPath(t *testing.T) {
+func TestStepCLIAvailable_ResolvesExecutableSuffixFromCustomPath_EnableWindowsCI(t *testing.T) {
 	t.Parallel()
 
 	binDir := fakeCLIBinDir(t)
@@ -3942,7 +3942,7 @@ func TestStepCLIAvailable_ResolvesExecutableSuffixFromCustomPath(t *testing.T) {
 	}
 }
 
-func TestStepCLIAvailable_IgnoresNonExecutableFromCustomPath(t *testing.T) {
+func TestStepCLIAvailable_IgnoresNonExecutableFromCustomPath_EnableWindowsCI(t *testing.T) {
 	t.Parallel()
 
 	binDir := t.TempDir()
@@ -3970,7 +3970,7 @@ func TestStepCLIAvailable_IgnoresNonExecutableFromCustomPath(t *testing.T) {
 	}
 }
 
-func TestPathCandidateUsable_WindowsAcceptsExeWithoutExecBits(t *testing.T) {
+func TestPathCandidateUsable_WindowsAcceptsExeWithoutExecBits_EnableWindowsCI(t *testing.T) {
 	t.Parallel()
 
 	path := filepath.Join(t.TempDir(), "gh.exe")
@@ -3988,7 +3988,7 @@ func TestPathCandidateUsable_WindowsAcceptsExeWithoutExecBits(t *testing.T) {
 	}
 }
 
-func TestEnvValueForOS_WindowsMatchesEmptyMixedCaseOverride(t *testing.T) {
+func TestEnvValueForOS_WindowsMatchesEmptyMixedCaseOverride_EnableWindowsCI(t *testing.T) {
 	t.Parallel()
 
 	value, ok := envValueForOS([]string{"Path=", "PathExt="}, "PATH", "windows")
@@ -4008,7 +4008,7 @@ func TestEnvValueForOS_WindowsMatchesEmptyMixedCaseOverride(t *testing.T) {
 	}
 }
 
-func TestExecutableCandidatesForOS_WindowsHonorsExplicitEmptyPATHEXT(t *testing.T) {
+func TestExecutableCandidatesForOS_WindowsHonorsExplicitEmptyPATHEXT_EnableWindowsCI(t *testing.T) {
 	t.Parallel()
 
 	candidates := executableCandidatesForOS("windows", "gh", []string{"PATHEXT="})
@@ -4020,7 +4020,7 @@ func TestExecutableCandidatesForOS_WindowsHonorsExplicitEmptyPATHEXT(t *testing.
 	}
 }
 
-func TestStepCmd_ResolvesRelativeCustomPathFromWorkDir(t *testing.T) {
+func TestStepCmd_ResolvesRelativeCustomPathFromWorkDir_EnableWindowsCI(t *testing.T) {
 	t.Parallel()
 
 	// Use os.MkdirTemp instead of t.TempDir so we can retry cleanup on
@@ -4073,7 +4073,7 @@ func TestStepCmd_ResolvesRelativeCustomPathFromWorkDir(t *testing.T) {
 	}
 }
 
-func TestStepCmd_DoesNotFallbackToHostPathWhenCustomPathOmitsBinary(t *testing.T) {
+func TestStepCmd_DoesNotFallbackToHostPathWhenCustomPathOmitsBinary_EnableWindowsCI(t *testing.T) {
 	t.Parallel()
 
 	customPath := t.TempDir()
@@ -4093,7 +4093,7 @@ func TestStepCmd_DoesNotFallbackToHostPathWhenCustomPathOmitsBinary(t *testing.T
 	}
 }
 
-func TestStepCmd_DoesNotFallbackToHostPathWhenCustomPathIsEmpty(t *testing.T) {
+func TestStepCmd_DoesNotFallbackToHostPathWhenCustomPathIsEmpty_EnableWindowsCI(t *testing.T) {
 	t.Parallel()
 
 	sctx := &pipeline.StepContext{
@@ -4111,7 +4111,7 @@ func TestStepCmd_DoesNotFallbackToHostPathWhenCustomPathIsEmpty(t *testing.T) {
 	}
 }
 
-func TestStepCmd_OverridesPathWithoutDuplicateEntries(t *testing.T) {
+func TestStepCmd_OverridesPathWithoutDuplicateEntries_EnableWindowsCI(t *testing.T) {
 	t.Parallel()
 
 	customPath := t.TempDir()

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -645,7 +645,7 @@ func TestUpdaterRunFailsWhenDaemonUsesDifferentExecutable(t *testing.T) {
 	}
 }
 
-func TestEnsureDaemonUsesCurrentExecutableAllowsWindowsCaseDifferences(t *testing.T) {
+func TestEnsureDaemonUsesCurrentExecutableAllowsWindowsCaseDifferences_EnableWindowsCI(t *testing.T) {
 	origGOOS := currentGOOS
 	origDaemonIsRunning := daemonIsRunning
 	origDaemonExecutablePath := daemonExecutablePath
@@ -877,7 +877,7 @@ func TestRunningDaemonExecutablePathUsesPIDFile(t *testing.T) {
 	}
 }
 
-func TestRunningDaemonExecutablePathHandlesExecutablePathsWithSpaces(t *testing.T) {
+func TestRunningDaemonExecutablePathHandlesExecutablePathsWithSpaces_EnableWindowsCI(t *testing.T) {
 	if os.Getenv("NO_MISTAKES_TEST_CHILD") == "1" {
 		time.Sleep(10 * time.Second)
 		return
@@ -929,7 +929,7 @@ func TestRunningDaemonExecutablePathHandlesExecutablePathsWithSpaces(t *testing.
 	}
 }
 
-func TestExecutablePathForPIDUsesWindowsResolver(t *testing.T) {
+func TestExecutablePathForPIDUsesWindowsResolver_EnableWindowsCI(t *testing.T) {
 	origGOOS := currentGOOS
 	origWindowsResolver := windowsExecutablePathForPID
 	t.Cleanup(func() {


### PR DESCRIPTION
## Summary
- Update the PR CI workflow to run a reduced Windows test suite on pull requests so Windows-specific regressions get earlier coverage without paying the full matrix cost on every PR.
- Rename the current Windows-sensitive tests with the `_EnableWindowsCI` suffix so they are included in that targeted PR job and keep existing Windows coverage aligned with the new workflow.
- Document the `_EnableWindowsCI` convention in `AGENTS.md` so future Windows-specific tests are explicitly opted into PR coverage.

## Risk Assessment

⚠️ Medium: The change is narrowly scoped and mechanically simple, but it intentionally reduces Windows PR coverage behind a manual naming convention that can easily drift and hide regressions until after merge.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

**Round 1** - found 1 warning
- ⚠️ `.github/workflows/ci.yml:52` - Windows pull requests now execute only tests whose names end with `_EnableWindowsCI`, so any future Windows-sensitive test that is added or renamed without that suffix will be silently excluded from PR coverage and regressions will only surface after merge or on `main`. Consider whether this reduced allowlist is an acceptable tradeoff, or add an explicit safeguard that fails when Windows-targeted tests are not opted in.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
