### PR TITLE
feat(daemon): add managed daemon service startup with fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ $ no-mistakes
 curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh
 ```
 
-The installer keeps the real binary in `~/.no-mistakes/bin` and exposes `no-mistakes` through a symlink in `~/.local/bin` or `/usr/local/bin`. That keeps future `no-mistakes update` runs in a user-owned location instead of rewriting a system binary in place. It also installs and starts the background daemon for you so the command is ready immediately.
+The installer keeps the real binary in `~/.no-mistakes/bin` and exposes `no-mistakes` through a symlink in `~/.local/bin` or `/usr/local/bin`. That keeps future `no-mistakes update` runs in a user-owned location instead of rewriting a system binary in place. It also installs and starts the background daemon for you so the command is ready immediately, preferring a managed service and falling back to a detached daemon if that path is unavailable.
 
 **Windows (PowerShell)**
 
@@ -70,7 +70,7 @@ The installer keeps the real binary in `~/.no-mistakes/bin` and exposes `no-mist
 irm https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.ps1 | iex
 ```
 
-This installs the binary and starts the background daemon automatically.
+This installs the binary and starts the background daemon automatically, preferring a managed service and falling back to a detached daemon if needed.
 
 **Go install**
 
@@ -97,7 +97,7 @@ To update an existing install in place:
 no-mistakes update
 ```
 
-This replaces the binary and resets the background daemon service so it picks up the new executable, but only if the running daemon is already using the same executable path. If the daemon executable path cannot be determined or it was started from a different binary, the update aborts before replacing the binary. If the daemon does not come back cleanly after a successful replacement, the new binary stays installed but the command reports the daemon reset failure.
+This replaces the binary and resets the background daemon so it picks up the new executable, preferring the managed service path and falling back to a detached daemon if service startup is unavailable or fails. It only proceeds if the running daemon is already using the same executable path. If the daemon executable path cannot be determined or it was started from a different binary, the update aborts before replacing the binary. If the daemon does not come back cleanly after a successful replacement, the new binary stays installed but the command reports the daemon reset failure.
 
 ## How It Works
 
@@ -143,14 +143,14 @@ This replaces the binary and resets the background daemon service so it picks up
 | --------------------------- | ------------------------------------------------------ |
 | `no-mistakes`               | Attach to the active pipeline run for the current repo |
 | `no-mistakes init`          | Initialize the gate for the current repository         |
-| `no-mistakes update`        | Update the binary and reset the daemon service         |
+| `no-mistakes update`        | Update the binary and reset the daemon                 |
 | `no-mistakes eject`         | Remove the gate from the current repository            |
 | `no-mistakes attach`        | Attach to the active pipeline run                      |
 | `no-mistakes rerun`         | Rerun the pipeline for the current branch              |
 | `no-mistakes status`        | Show repo, daemon, and active run status               |
 | `no-mistakes runs`          | List recorded pipeline runs for the current repo       |
 | `no-mistakes doctor`        | Check system health and dependencies                   |
-| `no-mistakes daemon start`  | Install the daemon service and start it                |
+| `no-mistakes daemon start`  | Start the daemon, installing the service when possible |
 | `no-mistakes daemon stop`   | Stop the running daemon process                        |
 | `no-mistakes daemon status` | Check whether the daemon is running                    |
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ The installer keeps the real binary in `~/.no-mistakes/bin` and exposes `no-mist
 irm https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.ps1 | iex
 ```
 
+This installs the binary and starts the background daemon automatically.
+
 **Go install**
 
 ```sh
@@ -95,7 +97,7 @@ To update an existing install in place:
 no-mistakes update
 ```
 
-This replaces the binary and resets the background daemon so it picks up the new executable, but only if the running daemon is already using the same executable path. If the daemon executable path cannot be determined or it was started from a different binary, the update aborts before replacing the binary. If the daemon does not come back cleanly after a successful replacement, the new binary stays installed but the command reports the daemon reset failure.
+This replaces the binary and resets the background daemon service so it picks up the new executable, but only if the running daemon is already using the same executable path. If the daemon executable path cannot be determined or it was started from a different binary, the update aborts before replacing the binary. If the daemon does not come back cleanly after a successful replacement, the new binary stays installed but the command reports the daemon reset failure.
 
 ## How It Works
 
@@ -141,15 +143,15 @@ This replaces the binary and resets the background daemon so it picks up the new
 | --------------------------- | ------------------------------------------------------ |
 | `no-mistakes`               | Attach to the active pipeline run for the current repo |
 | `no-mistakes init`          | Initialize the gate for the current repository         |
-| `no-mistakes update`        | Update the binary and reset the daemon                 |
+| `no-mistakes update`        | Update the binary and reset the daemon service         |
 | `no-mistakes eject`         | Remove the gate from the current repository            |
 | `no-mistakes attach`        | Attach to the active pipeline run                      |
 | `no-mistakes rerun`         | Rerun the pipeline for the current branch              |
 | `no-mistakes status`        | Show repo, daemon, and active run status               |
 | `no-mistakes runs`          | List recorded pipeline runs for the current repo       |
 | `no-mistakes doctor`        | Check system health and dependencies                   |
-| `no-mistakes daemon start`  | Start the daemon in the background                     |
-| `no-mistakes daemon stop`   | Stop the running daemon                                |
+| `no-mistakes daemon start`  | Install the daemon service and start it                |
+| `no-mistakes daemon stop`   | Stop the running daemon process                        |
 | `no-mistakes daemon status` | Check whether the daemon is running                    |
 
 ### Flags

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ $ no-mistakes
 curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh
 ```
 
-The installer keeps the real binary in `~/.no-mistakes/bin` and exposes `no-mistakes` through a symlink in `~/.local/bin` or `/usr/local/bin`. That keeps future `no-mistakes update` runs in a user-owned location instead of rewriting a system binary in place.
+The installer keeps the real binary in `~/.no-mistakes/bin` and exposes `no-mistakes` through a symlink in `~/.local/bin` or `/usr/local/bin`. That keeps future `no-mistakes update` runs in a user-owned location instead of rewriting a system binary in place. It also installs and starts the background daemon for you so the command is ready immediately.
 
 **Windows (PowerShell)**
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ $ no-mistakes
 curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh
 ```
 
-The installer keeps the real binary in `~/.no-mistakes/bin` and exposes `no-mistakes` through a symlink in `~/.local/bin` or `/usr/local/bin`. That keeps future `no-mistakes update` runs in a user-owned location instead of rewriting a system binary in place. It also installs and starts the background daemon for you so the command is ready immediately, preferring a managed service and falling back to a detached daemon if that path is unavailable.
+The installer keeps the real binary in `~/.no-mistakes/bin` and exposes `no-mistakes` through a symlink in `~/.local/bin` or `/usr/local/bin`. That keeps future `no-mistakes update` runs in a user-owned location instead of rewriting a system binary in place. It also attempts to install and start the background daemon for you so the command is ready immediately, preferring a managed service and falling back to a detached daemon if that path is unavailable. If startup still fails, run `no-mistakes daemon start` manually.
 
 **Windows (PowerShell)**
 
@@ -70,7 +70,7 @@ The installer keeps the real binary in `~/.no-mistakes/bin` and exposes `no-mist
 irm https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.ps1 | iex
 ```
 
-This installs the binary and starts the background daemon automatically, preferring a managed service and falling back to a detached daemon if needed.
+This installs the binary and attempts to start the background daemon automatically, preferring a managed service and falling back to a detached daemon if needed. If startup still fails, run `no-mistakes daemon start` manually.
 
 **Go install**
 

--- a/cmd/no-mistakes/main.go
+++ b/cmd/no-mistakes/main.go
@@ -56,19 +56,26 @@ func daemonRunRootFromArgs(args []string) (string, bool, error) {
 	if len(args) < 2 || args[0] != "daemon" || args[1] != "run" {
 		return "", false, nil
 	}
-	for i := 2; i < len(args); i++ {
-		arg := args[i]
+	if len(args) == 2 {
+		return "", true, nil
+	}
+	if len(args) == 3 {
+		arg := args[2]
+		if arg == "--help" || arg == "-h" {
+			return "", false, nil
+		}
 		if arg == "--root" {
-			if i+1 >= len(args) {
-				return "", false, fmt.Errorf("missing value for --root")
-			}
-			return args[i+1], true, nil
+			return "", false, fmt.Errorf("missing value for --root")
 		}
 		if value, ok := strings.CutPrefix(arg, "--root="); ok {
 			return value, true, nil
 		}
+		return "", false, nil
 	}
-	return "", true, nil
+	if len(args) == 4 && args[2] == "--root" {
+		return args[3], true, nil
+	}
+	return "", false, nil
 }
 
 // cliLogWriter returns a writer for CLI logs. Falls back to io.Discard

--- a/cmd/no-mistakes/main.go
+++ b/cmd/no-mistakes/main.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/cli"
 	"github.com/kunchenguid/no-mistakes/internal/daemon"
@@ -13,7 +14,16 @@ import (
 )
 
 func main() {
-	if os.Getenv("NM_DAEMON") == "1" {
+	if root, ok, err := daemonRunRootFromArgs(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	} else if ok {
+		if root != "" {
+			if err := os.Setenv("NM_HOME", root); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+		}
 		if err := daemon.Run(); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
@@ -37,6 +47,28 @@ func main() {
 	slog.SetDefault(slog.New(slog.NewTextHandler(cliLogWriter(), nil)))
 
 	cli.Execute()
+}
+
+func daemonRunRootFromArgs(args []string) (string, bool, error) {
+	if os.Getenv("NM_DAEMON") == "1" {
+		return "", true, nil
+	}
+	if len(args) < 2 || args[0] != "daemon" || args[1] != "run" {
+		return "", false, nil
+	}
+	for i := 2; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--root" {
+			if i+1 >= len(args) {
+				return "", false, fmt.Errorf("missing value for --root")
+			}
+			return args[i+1], true, nil
+		}
+		if value, ok := strings.CutPrefix(arg, "--root="); ok {
+			return value, true, nil
+		}
+	}
+	return "", true, nil
 }
 
 // cliLogWriter returns a writer for CLI logs. Falls back to io.Discard

--- a/cmd/no-mistakes/main_test.go
+++ b/cmd/no-mistakes/main_test.go
@@ -52,3 +52,51 @@ func TestCLILogWriterAppendsToFileWhenLogsDirExists(t *testing.T) {
 		t.Fatalf("cli.log contents = %q, want %q", string(b), "hello\n")
 	}
 }
+
+func TestDaemonRunRootFromArgs(t *testing.T) {
+	t.Setenv("NM_DAEMON", "")
+
+	tests := []struct {
+		name     string
+		args     []string
+		wantRoot string
+		wantOK   bool
+		wantErr  string
+	}{
+		{name: "non-daemon command", args: []string{"daemon", "status"}},
+		{name: "daemon run no root", args: []string{"daemon", "run"}, wantOK: true},
+		{name: "daemon run root flag", args: []string{"daemon", "run", "--root", "/tmp/nm"}, wantRoot: "/tmp/nm", wantOK: true},
+		{name: "daemon run root equals", args: []string{"daemon", "run", "--root=/tmp/nm"}, wantRoot: "/tmp/nm", wantOK: true},
+		{name: "daemon run missing root value", args: []string{"daemon", "run", "--root"}, wantErr: "missing value for --root"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotRoot, gotOK, err := daemonRunRootFromArgs(tt.args)
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("err = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if gotRoot != tt.wantRoot || gotOK != tt.wantOK {
+				t.Fatalf("got (%q, %v), want (%q, %v)", gotRoot, gotOK, tt.wantRoot, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestDaemonRunRootFromArgs_EnvForcesDaemonMode(t *testing.T) {
+	t.Setenv("NM_DAEMON", "1")
+
+	gotRoot, gotOK, err := daemonRunRootFromArgs([]string{"status"})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if gotRoot != "" || !gotOK {
+		t.Fatalf("got (%q, %v), want (%q, %v)", gotRoot, gotOK, "", true)
+	}
+}

--- a/cmd/no-mistakes/main_test.go
+++ b/cmd/no-mistakes/main_test.go
@@ -68,6 +68,11 @@ func TestDaemonRunRootFromArgs(t *testing.T) {
 		{name: "daemon run root flag", args: []string{"daemon", "run", "--root", "/tmp/nm"}, wantRoot: "/tmp/nm", wantOK: true},
 		{name: "daemon run root equals", args: []string{"daemon", "run", "--root=/tmp/nm"}, wantRoot: "/tmp/nm", wantOK: true},
 		{name: "daemon run missing root value", args: []string{"daemon", "run", "--root"}, wantErr: "missing value for --root"},
+		{name: "daemon run help", args: []string{"daemon", "run", "--help"}},
+		{name: "daemon run short help", args: []string{"daemon", "run", "-h"}},
+		{name: "daemon run unknown flag", args: []string{"daemon", "run", "--bogus"}},
+		{name: "daemon run extra arg", args: []string{"daemon", "run", "extra"}},
+		{name: "daemon run root plus extra arg", args: []string{"daemon", "run", "--root", "/tmp/nm", "extra"}},
 	}
 
 	for _, tt := range tests {

--- a/docs/install.ps1
+++ b/docs/install.ps1
@@ -32,4 +32,6 @@ if ($userPath -notlike "*$installDir*") {
     Write-Host "Added $installDir to user PATH. Restart your terminal."
 }
 
+& "$installDir\no-mistakes.exe" daemon start | Out-Null
+
 Write-Host "no-mistakes $version installed to $installDir\no-mistakes.exe"

--- a/docs/install.ps1
+++ b/docs/install.ps1
@@ -32,6 +32,9 @@ if ($userPath -notlike "*$installDir*") {
     Write-Host "Added $installDir to user PATH. Restart your terminal."
 }
 
+$oldErrorActionPreference = $ErrorActionPreference
+$ErrorActionPreference = "Continue"
 & "$installDir\no-mistakes.exe" daemon start | Out-Null
+$ErrorActionPreference = $oldErrorActionPreference
 
 Write-Host "no-mistakes $version installed to $installDir\no-mistakes.exe"

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -77,7 +77,9 @@ fi
 echo "no-mistakes ${VERSION} installed to ${BIN_PATH}"
 echo "Command path: ${LINK_PATH} -> ${BIN_PATH}"
 
-"$BIN_PATH" daemon start >/dev/null
+if ! "$BIN_PATH" daemon start >/dev/null 2>&1; then
+  echo "Warning: failed to auto-start daemon; run 'no-mistakes daemon start' manually." >&2
+fi
 
 case ":$PATH:" in
   *":$LINK_DIR:"*) ;;

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -77,6 +77,8 @@ fi
 echo "no-mistakes ${VERSION} installed to ${BIN_PATH}"
 echo "Command path: ${LINK_PATH} -> ${BIN_PATH}"
 
+"$BIN_PATH" daemon start >/dev/null
+
 case ":$PATH:" in
   *":$LINK_DIR:"*) ;;
   *) echo "Add ${LINK_DIR} to your PATH and restart your terminal." ;;

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -11,11 +11,15 @@ description: Install no-mistakes and run your first gated push.
 curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh
 ```
 
+This installs the binary and starts the background daemon automatically.
+
 ### Windows (PowerShell)
 
 ```powershell
 irm https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.ps1 | iex
 ```
+
+This installs the binary and starts the background daemon automatically.
 
 ### Go install
 
@@ -54,7 +58,7 @@ This does the following:
 1. Creates a local bare git repo at `~/.no-mistakes/repos/<id>.git`
 2. Installs a `post-receive` hook in that bare repo
 3. Adds a git remote named `no-mistakes` to your working repo
-4. Starts the background daemon (if not already running)
+4. Ensures the background daemon service is installed and running
 5. Records the repo in the local SQLite database
 
 ```
@@ -109,7 +113,7 @@ To update an existing install in place:
 no-mistakes update
 ```
 
-This downloads the latest release from GitHub, verifies the SHA-256 checksum, atomically replaces the binary, and resets the daemon so it starts using the new executable when the running daemon is already using the same executable path. If the daemon executable path cannot be determined or it was started from a different binary, the update aborts before replacing the binary. If the daemon does not come back cleanly after a successful replacement, the command reports that failure.
+This downloads the latest release from GitHub, verifies the SHA-256 checksum, atomically replaces the binary, and resets the daemon service so it starts using the new executable when the running daemon is already using the same executable path. If the daemon executable path cannot be determined or it was started from a different binary, the update aborts before replacing the binary. If the daemon does not come back cleanly after a successful replacement, the command reports that failure.
 
 ## Remove from a repo
 

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -11,7 +11,7 @@ description: Install no-mistakes and run your first gated push.
 curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh
 ```
 
-This installs the binary and starts the background daemon automatically.
+This installs the binary and starts the background daemon automatically, preferring a managed service and falling back to a detached daemon if needed.
 
 ### Windows (PowerShell)
 
@@ -19,7 +19,7 @@ This installs the binary and starts the background daemon automatically.
 irm https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.ps1 | iex
 ```
 
-This installs the binary and starts the background daemon automatically.
+This installs the binary and starts the background daemon automatically, preferring a managed service and falling back to a detached daemon if needed.
 
 ### Go install
 
@@ -58,7 +58,7 @@ This does the following:
 1. Creates a local bare git repo at `~/.no-mistakes/repos/<id>.git`
 2. Installs a `post-receive` hook in that bare repo
 3. Adds a git remote named `no-mistakes` to your working repo
-4. Ensures the background daemon service is installed and running
+4. Ensures the background daemon is running, installing the managed service when available and falling back to a detached daemon otherwise
 5. Records the repo in the local SQLite database
 
 ```
@@ -113,7 +113,7 @@ To update an existing install in place:
 no-mistakes update
 ```
 
-This downloads the latest release from GitHub, verifies the SHA-256 checksum, atomically replaces the binary, and resets the daemon service so it starts using the new executable when the running daemon is already using the same executable path. If the daemon executable path cannot be determined or it was started from a different binary, the update aborts before replacing the binary. If the daemon does not come back cleanly after a successful replacement, the command reports that failure.
+This downloads the latest release from GitHub, verifies the SHA-256 checksum, atomically replaces the binary, and resets the daemon so it starts using the new executable when the running daemon is already using the same executable path, preferring the managed service path and falling back to a detached daemon if service startup is unavailable or fails. If the daemon executable path cannot be determined or it was started from a different binary, the update aborts before replacing the binary. If the daemon does not come back cleanly after a successful replacement, the command reports that failure.
 
 ## Remove from a repo
 

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -11,7 +11,7 @@ description: Install no-mistakes and run your first gated push.
 curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh
 ```
 
-This installs the binary and starts the background daemon automatically, preferring a managed service and falling back to a detached daemon if needed.
+This installs the binary and attempts to start the background daemon automatically, preferring a managed service and falling back to a detached daemon if needed. If startup still fails, run `no-mistakes daemon start` manually.
 
 ### Windows (PowerShell)
 
@@ -19,7 +19,7 @@ This installs the binary and starts the background daemon automatically, preferr
 irm https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.ps1 | iex
 ```
 
-This installs the binary and starts the background daemon automatically, preferring a managed service and falling back to a detached daemon if needed.
+This installs the binary and attempts to start the background daemon automatically, preferring a managed service and falling back to a detached daemon if needed. If startup still fails, run `no-mistakes daemon start` manually.
 
 ### Go install
 

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -50,6 +50,8 @@ The default binary names are:
 | `rovodev` | `acli` |
 | `opencode` | `opencode` |
 
+When the daemon is running through a managed service, that `PATH` comes from your login shell environment rather than the service manager's default environment. If agent discovery still does not resolve the binary you expect, use an explicit `agent_path_override`.
+
 Override paths in global config:
 
 ```yaml

--- a/docs/src/content/docs/guides/daemon.md
+++ b/docs/src/content/docs/guides/daemon.md
@@ -3,7 +3,7 @@ title: Daemon
 description: Background process management and recovery.
 ---
 
-The daemon is a long-running background process that manages pipeline runs. It auto-starts when needed and runs until explicitly stopped.
+The daemon is a long-running background process that manages pipeline runs. The installer sets it up as a managed background service, and `init`, `attach`, `rerun`, and `update` keep that service installed and running for you.
 
 ## Starting and stopping
 
@@ -13,7 +13,7 @@ no-mistakes daemon start
 no-mistakes daemon stop
 no-mistakes daemon status
 
-# Auto-starts on these commands if not running
+# Ensures the managed daemon service is installed and running
 no-mistakes init
 no-mistakes attach
 no-mistakes rerun
@@ -22,7 +22,7 @@ no-mistakes rerun
 no-mistakes update
 ```
 
-`no-mistakes update` stops and starts the daemon when it is running, or when stale daemon artifacts exist, so the new executable is used. If the daemon is already running, update only proceeds when the daemon is using the same executable path as the binary running the update command; if that path cannot be determined or points to a different binary, the update aborts before replacing anything.
+`no-mistakes update` stops and starts the daemon service when it is running, or when stale daemon artifacts exist, so the new executable is used. If the daemon is already running, update only proceeds when the daemon is using the same executable path as the binary running the update command; if that path cannot be determined or points to a different binary, the update aborts before replacing anything.
 
 The daemon writes its PID to `~/.no-mistakes/daemon.pid` and listens on a Unix socket at `~/.no-mistakes/socket`. On Windows, it uses a localhost TCP listener and a protected endpoint file at the same path.
 
@@ -64,7 +64,7 @@ log_level: debug  # debug | info | warn | error
 
 ## Shutdown
 
-`no-mistakes daemon stop` initiates a graceful shutdown:
+`no-mistakes daemon stop` stops the current daemon process without removing the managed service:
 
 1. Cancels all active runs
 2. Waits up to 30 seconds for goroutines to finish

--- a/docs/src/content/docs/guides/daemon.md
+++ b/docs/src/content/docs/guides/daemon.md
@@ -3,9 +3,9 @@ title: Daemon
 description: Background process management and recovery.
 ---
 
-The daemon is a long-running background process that manages pipeline runs. The installer sets it up as a managed background service, and `init`, `attach`, `rerun`, and `update` keep that service installed and running for you.
+The daemon is a long-running background process that manages pipeline runs. The installer prefers setting it up as a managed background service, and `init`, `attach`, `rerun`, and `update` keep that service installed and running for you when that path is available.
 
-On macOS this is a per-user `launchd` agent, on Linux a per-user `systemd` service, and on Windows a Task Scheduler task. Those service managers keep the daemon available across CLI invocations and restart it after `no-mistakes update` replaces the binary.
+On macOS this is a per-user `launchd` agent, on Linux a per-user `systemd` service, and on Windows a Task Scheduler task. Those service managers keep the daemon available across CLI invocations and restart it after `no-mistakes update` replaces the binary. If managed service install or startup is unavailable or fails, `no-mistakes` falls back to starting a detached daemon process instead.
 
 ## Starting and stopping
 
@@ -15,7 +15,7 @@ no-mistakes daemon start
 no-mistakes daemon stop
 no-mistakes daemon status
 
-# Ensures the managed daemon service is installed and running
+# Ensures the daemon is running, using the managed service when possible
 no-mistakes init
 no-mistakes attach
 no-mistakes rerun
@@ -24,7 +24,7 @@ no-mistakes rerun
 no-mistakes update
 ```
 
-`no-mistakes update` stops and starts the daemon service when it is running, or when stale daemon artifacts exist, so the new executable is used. If the daemon is already running, update only proceeds when the daemon is using the same executable path as the binary running the update command; if that path cannot be determined or points to a different binary, the update aborts before replacing anything.
+`no-mistakes update` stops and starts the daemon when it is running, or when stale daemon artifacts exist, so the new executable is used. It prefers the managed service path and falls back to a detached daemon if service startup is unavailable or fails. If the daemon is already running, update only proceeds when the daemon is using the same executable path as the binary running the update command; if that path cannot be determined or points to a different binary, the update aborts before replacing anything.
 
 The daemon writes its PID to `~/.no-mistakes/daemon.pid` and listens on a Unix socket at `~/.no-mistakes/socket`. On Windows, it uses a localhost TCP listener and a protected endpoint file at the same path.
 
@@ -66,7 +66,7 @@ log_level: debug  # debug | info | warn | error
 
 ## Shutdown
 
-`no-mistakes daemon stop` stops the current daemon process without removing the managed service. The next `no-mistakes daemon start`, `init`, `attach`, `rerun`, or `update` will start it again through the same service manager.
+`no-mistakes daemon stop` stops the current daemon process without removing the managed service. The next `no-mistakes daemon start`, `init`, `attach`, `rerun`, or `update` will start it again through the same service manager when available, or as a detached daemon otherwise.
 
 1. Cancels all active runs
 2. Waits up to 30 seconds for goroutines to finish

--- a/docs/src/content/docs/guides/daemon.md
+++ b/docs/src/content/docs/guides/daemon.md
@@ -5,6 +5,8 @@ description: Background process management and recovery.
 
 The daemon is a long-running background process that manages pipeline runs. The installer sets it up as a managed background service, and `init`, `attach`, `rerun`, and `update` keep that service installed and running for you.
 
+On macOS this is a per-user `launchd` agent, on Linux a per-user `systemd` service, and on Windows a Task Scheduler task. Those service managers keep the daemon available across CLI invocations and restart it after `no-mistakes update` replaces the binary.
+
 ## Starting and stopping
 
 ```sh
@@ -64,7 +66,7 @@ log_level: debug  # debug | info | warn | error
 
 ## Shutdown
 
-`no-mistakes daemon stop` stops the current daemon process without removing the managed service:
+`no-mistakes daemon stop` stops the current daemon process without removing the managed service. The next `no-mistakes daemon start`, `init`, `attach`, `rerun`, or `update` will start it again through the same service manager.
 
 1. Cancels all active runs
 2. Waits up to 30 seconds for goroutines to finish

--- a/docs/src/content/docs/guides/daemon.md
+++ b/docs/src/content/docs/guides/daemon.md
@@ -5,7 +5,7 @@ description: Background process management and recovery.
 
 The daemon is a long-running background process that manages pipeline runs. The installer prefers setting it up as a managed background service, and `init`, `attach`, `rerun`, and `update` keep that service installed and running for you when that path is available.
 
-On macOS this is a per-user `launchd` agent, on Linux a per-user `systemd` service, and on Windows a Task Scheduler task. Those service managers keep the daemon available across CLI invocations and restart it after `no-mistakes update` replaces the binary. If managed service install or startup is unavailable or fails, `no-mistakes` falls back to starting a detached daemon process instead.
+On macOS this is a per-user `launchd` agent, on Linux a per-user `systemd` service, and on Windows a Task Scheduler task. Those service managers keep the daemon available across CLI invocations and restart it after `no-mistakes update` replaces the binary. Before a managed daemon run starts, `no-mistakes` reloads the environment from your login shell so agent and tool discovery matches the shell you use interactively. If managed service install or startup is unavailable or fails, `no-mistakes` falls back to starting a detached daemon process instead.
 
 ## Starting and stopping
 

--- a/docs/src/content/docs/guides/daemon.md
+++ b/docs/src/content/docs/guides/daemon.md
@@ -5,7 +5,7 @@ description: Background process management and recovery.
 
 The daemon is a long-running background process that manages pipeline runs. The installer prefers setting it up as a managed background service, and `init`, `attach`, `rerun`, and `update` keep that service installed and running for you when that path is available.
 
-On macOS this is a per-user `launchd` agent, on Linux a per-user `systemd` service, and on Windows a Task Scheduler task. Those service managers keep the daemon available across CLI invocations and restart it after `no-mistakes update` replaces the binary. Before a managed daemon run starts, `no-mistakes` reloads the environment from your login shell so agent and tool discovery matches the shell you use interactively. If managed service install or startup is unavailable or fails, `no-mistakes` falls back to starting a detached daemon process instead.
+On macOS this is a per-user `launchd` agent, on Linux a per-user `systemd` service, and on Windows a Task Scheduler task. The installed artifacts are `~/Library/LaunchAgents/com.kunchenguid.no-mistakes.daemon.plist`, `~/.config/systemd/user/no-mistakes-daemon.service`, and the Windows task `no-mistakes-daemon`. Those service managers keep the daemon available across CLI invocations and restart it after `no-mistakes update` replaces the binary. Before a managed daemon run starts, `no-mistakes` reloads the environment from your login shell so agent and tool discovery matches the shell you use interactively. If managed service install or startup is unavailable or fails, `no-mistakes` falls back to starting a detached daemon process instead.
 
 ## Starting and stopping
 

--- a/docs/src/content/docs/how-it-works.md
+++ b/docs/src/content/docs/how-it-works.md
@@ -58,7 +58,7 @@ A long-running background process that manages pipeline runs. It:
 - Persists state to SQLite
 - Streams events to connected TUI clients via IPC
 
-The installer sets up the daemon as a managed background service, and `init`, `attach`, `rerun`, and `update` make sure that service is present and running when needed. `update` resets it after replacing the binary when the daemon is running or stale daemon artifacts exist. If the daemon is already running, `update` first checks that it was started from the same executable path and aborts if the daemon executable path cannot be determined or points to a different binary. You can also manage it explicitly with `no-mistakes daemon start|stop|status`.
+The installer prefers setting up the daemon as a managed background service, and `init`, `attach`, `rerun`, and `update` make sure the daemon is running when needed. If managed service install or startup is unavailable or fails, startup falls back to a detached daemon process. `update` resets the daemon after replacing the binary when the daemon is running or stale daemon artifacts exist. If the daemon is already running, `update` first checks that it was started from the same executable path and aborts if the daemon executable path cannot be determined or points to a different binary. You can also manage it explicitly with `no-mistakes daemon start|stop|status`.
 
 On startup, the daemon recovers from crashes by marking any stuck runs as failed and cleaning up orphaned worktrees.
 

--- a/docs/src/content/docs/how-it-works.md
+++ b/docs/src/content/docs/how-it-works.md
@@ -58,7 +58,7 @@ A long-running background process that manages pipeline runs. It:
 - Persists state to SQLite
 - Streams events to connected TUI clients via IPC
 
-The daemon auto-starts when needed (`init`, `attach`, `rerun`), and `update` resets it after replacing the binary when the daemon is running or stale daemon artifacts exist. If the daemon is already running, `update` first checks that it was started from the same executable path and aborts if the daemon executable path cannot be determined or points to a different binary. You can also manage it explicitly with `no-mistakes daemon start|stop|status`.
+The installer sets up the daemon as a managed background service, and `init`, `attach`, `rerun`, and `update` make sure that service is present and running when needed. `update` resets it after replacing the binary when the daemon is running or stale daemon artifacts exist. If the daemon is already running, `update` first checks that it was started from the same executable path and aborts if the daemon executable path cannot be determined or points to a different binary. You can also manage it explicitly with `no-mistakes daemon start|stop|status`.
 
 On startup, the daemon recovers from crashes by marking any stuck runs as failed and cleaning up orphaned worktrees.
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -135,6 +135,8 @@ Stop the running daemon process.
 no-mistakes daemon stop
 ```
 
+This does not remove the managed service. A later `no-mistakes daemon start`, `init`, `attach`, `rerun`, or `update` can start the daemon again through the same service manager when available, or as a detached daemon otherwise.
+
 ## no-mistakes daemon status
 
 Check whether the daemon is running.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -21,7 +21,7 @@ Initialize the gate for the current repository.
 no-mistakes init
 ```
 
-Creates a local bare repo, installs the post-receive hook, adds the `no-mistakes` git remote, detects the default branch, records the repo in SQLite, and ensures the managed daemon service is installed and running.
+Creates a local bare repo, installs the post-receive hook, adds the `no-mistakes` git remote, detects the default branch, records the repo in SQLite, and ensures the daemon is running, installing the managed service when available and falling back to a detached daemon otherwise.
 
 Rolls back all changes if any step fails.
 
@@ -107,23 +107,25 @@ Uses indicators: `✓` (available), `–` (not found, optional), `✗` (problem 
 
 ## no-mistakes update
 
-Update the installed binary and reset the daemon service.
+Update the installed binary and reset the daemon.
 
 ```sh
 no-mistakes update
 ```
 
-Downloads the latest release, verifies the SHA-256 checksum, atomically replaces the running binary, and resets the daemon service when it is running or stale daemon artifacts exist so the new executable is picked up. If the daemon is running, update first requires it to already be using the same executable path as the binary running `no-mistakes update`; if that daemon executable path cannot be determined or it points to a different binary, the update aborts before replacement. If the daemon does not come back cleanly after a successful replacement, the command reports that failure. On macOS, removes the quarantine extended attribute.
+Downloads the latest release, verifies the SHA-256 checksum, atomically replaces the running binary, and resets the daemon when it is running or stale daemon artifacts exist so the new executable is picked up, preferring the managed service path and falling back to a detached daemon if service startup is unavailable or fails. If the daemon is running, update first requires it to already be using the same executable path as the binary running `no-mistakes update`; if that daemon executable path cannot be determined or it points to a different binary, the update aborts before replacement. If the daemon does not come back cleanly after a successful replacement, the command reports that failure. On macOS, removes the quarantine extended attribute.
 
 Background update checks run automatically on each CLI invocation (except `update` itself). If a newer version is available, a notification is printed to stderr. Suppressed for dev builds or when `NO_MISTAKES_NO_UPDATE_CHECK=1` is set.
 
 ## no-mistakes daemon start
 
-Install or refresh the managed daemon service and start it.
+Start the daemon, installing or refreshing the managed service when possible.
 
 ```sh
 no-mistakes daemon start
 ```
+
+Prefers the managed service path and falls back to a detached daemon if service install or startup is unavailable or fails.
 
 ## no-mistakes daemon stop
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -21,7 +21,7 @@ Initialize the gate for the current repository.
 no-mistakes init
 ```
 
-Creates a local bare repo, installs the post-receive hook, adds the `no-mistakes` git remote, detects the default branch, records the repo in SQLite, and starts the daemon if needed.
+Creates a local bare repo, installs the post-receive hook, adds the `no-mistakes` git remote, detects the default branch, records the repo in SQLite, and ensures the managed daemon service is installed and running.
 
 Rolls back all changes if any step fails.
 
@@ -107,19 +107,19 @@ Uses indicators: `✓` (available), `–` (not found, optional), `✗` (problem 
 
 ## no-mistakes update
 
-Update the installed binary and reset the daemon.
+Update the installed binary and reset the daemon service.
 
 ```sh
 no-mistakes update
 ```
 
-Downloads the latest release, verifies the SHA-256 checksum, atomically replaces the running binary, and resets the daemon when it is running or stale daemon artifacts exist so the new executable is picked up. If the daemon is running, update first requires it to already be using the same executable path as the binary running `no-mistakes update`; if that daemon executable path cannot be determined or it points to a different binary, the update aborts before replacement. If the daemon does not come back cleanly after a successful replacement, the command reports that failure. On macOS, removes the quarantine extended attribute.
+Downloads the latest release, verifies the SHA-256 checksum, atomically replaces the running binary, and resets the daemon service when it is running or stale daemon artifacts exist so the new executable is picked up. If the daemon is running, update first requires it to already be using the same executable path as the binary running `no-mistakes update`; if that daemon executable path cannot be determined or it points to a different binary, the update aborts before replacement. If the daemon does not come back cleanly after a successful replacement, the command reports that failure. On macOS, removes the quarantine extended attribute.
 
 Background update checks run automatically on each CLI invocation (except `update` itself). If a newer version is available, a notification is printed to stderr. Suppressed for dev builds or when `NO_MISTAKES_NO_UPDATE_CHECK=1` is set.
 
 ## no-mistakes daemon start
 
-Start the daemon in the background.
+Install or refresh the managed daemon service and start it.
 
 ```sh
 no-mistakes daemon start
@@ -127,7 +127,7 @@ no-mistakes daemon start
 
 ## no-mistakes daemon stop
 
-Stop the running daemon.
+Stop the running daemon process.
 
 ```sh
 no-mistakes daemon stop

--- a/install_script_test.go
+++ b/install_script_test.go
@@ -18,7 +18,8 @@ func TestInstallScriptInstallsUserOwnedBinaryAndPathSymlink(t *testing.T) {
 
 	home := t.TempDir()
 	archivePath := filepath.Join(t.TempDir(), "no-mistakes-v1.2.3-darwin-arm64.tar.gz")
-	makeInstallArchive(t, archivePath, "new-binary")
+	binaryScript := "#!/bin/sh\nexit 0\n"
+	makeInstallArchive(t, archivePath, binaryScript)
 	fakeBin := makeFakeInstallCommands(t)
 	localBin := filepath.Join(home, ".local", "bin")
 	if err := os.MkdirAll(localBin, 0o755); err != nil {
@@ -30,7 +31,7 @@ func TestInstallScriptInstallsUserOwnedBinaryAndPathSymlink(t *testing.T) {
 	})
 
 	realBin := filepath.Join(home, ".no-mistakes", "bin", "no-mistakes")
-	assertFileContent(t, realBin, "new-binary")
+	assertFileContent(t, realBin, binaryScript)
 	assertSymlinkTarget(t, filepath.Join(localBin, "no-mistakes"), realBin)
 }
 
@@ -39,7 +40,8 @@ func TestInstallScriptReplacesExistingPathEntryWithSymlink(t *testing.T) {
 
 	home := t.TempDir()
 	archivePath := filepath.Join(t.TempDir(), "no-mistakes-v1.2.3-darwin-arm64.tar.gz")
-	makeInstallArchive(t, archivePath, "new-binary")
+	binaryScript := "#!/bin/sh\nexit 0\n"
+	makeInstallArchive(t, archivePath, binaryScript)
 	fakeBin := makeFakeInstallCommands(t)
 	linkDir := filepath.Join(t.TempDir(), "link-bin")
 	if err := os.MkdirAll(linkDir, 0o755); err != nil {
@@ -56,8 +58,35 @@ func TestInstallScriptReplacesExistingPathEntryWithSymlink(t *testing.T) {
 	})
 
 	realBin := filepath.Join(home, ".no-mistakes", "bin", "no-mistakes")
-	assertFileContent(t, realBin, "new-binary")
+	assertFileContent(t, realBin, binaryScript)
 	assertSymlinkTarget(t, oldPath, realBin)
+}
+
+func TestInstallScriptStartsDaemonAfterInstall(t *testing.T) {
+	skipInstallScriptTestsOnWindows(t)
+
+	home := t.TempDir()
+	archivePath := filepath.Join(t.TempDir(), "no-mistakes-v1.2.3-darwin-arm64.tar.gz")
+	callLog := filepath.Join(t.TempDir(), "calls.log")
+	makeInstallArchive(t, archivePath, "#!/bin/sh\nprintf '%s\n' \"$*\" >> \"$NO_MISTAKES_CALL_LOG\"\n")
+	fakeBin := makeFakeInstallCommands(t)
+	localBin := filepath.Join(home, ".local", "bin")
+	if err := os.MkdirAll(localBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	runInstallScript(t, home, fakeBin, map[string]string{
+		"FAKE_RELEASE_ARCHIVE": archivePath,
+		"NO_MISTAKES_CALL_LOG": callLog,
+	})
+
+	data, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "daemon start") {
+		t.Fatalf("install.sh should start the daemon after install, got calls %q", string(data))
+	}
 }
 
 func skipInstallScriptTestsOnWindows(t *testing.T) {

--- a/install_script_test.go
+++ b/install_script_test.go
@@ -89,6 +89,36 @@ func TestInstallScriptStartsDaemonAfterInstall(t *testing.T) {
 	}
 }
 
+func TestInstallScriptSucceedsWhenDaemonStartFails(t *testing.T) {
+	skipInstallScriptTestsOnWindows(t)
+
+	home := t.TempDir()
+	archivePath := filepath.Join(t.TempDir(), "no-mistakes-v1.2.3-darwin-arm64.tar.gz")
+	callLog := filepath.Join(t.TempDir(), "calls.log")
+	makeInstallArchive(t, archivePath, "#!/bin/sh\nprintf '%s\n' \"$*\" >> \"$NO_MISTAKES_CALL_LOG\"\nif [ \"$1\" = \"daemon\" ] && [ \"$2\" = \"start\" ]; then\n  exit 23\nfi\n")
+	fakeBin := makeFakeInstallCommands(t)
+	localBin := filepath.Join(home, ".local", "bin")
+	if err := os.MkdirAll(localBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	output, err := runInstallScriptCommand(t, home, fakeBin, map[string]string{
+		"FAKE_RELEASE_ARCHIVE": archivePath,
+		"NO_MISTAKES_CALL_LOG": callLog,
+	})
+	if err != nil {
+		t.Fatalf("install.sh should succeed even when daemon start fails: %v\n%s", err, output)
+	}
+
+	data, err := os.ReadFile(callLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "daemon start") {
+		t.Fatalf("install.sh should still attempt daemon start, got calls %q", string(data))
+	}
+}
+
 func skipInstallScriptTestsOnWindows(t *testing.T) {
 	t.Helper()
 	if runtime.GOOS == "windows" {
@@ -97,6 +127,14 @@ func skipInstallScriptTestsOnWindows(t *testing.T) {
 }
 
 func runInstallScript(t *testing.T, home, fakeBin string, extraEnv map[string]string) {
+	t.Helper()
+	output, err := runInstallScriptCommand(t, home, fakeBin, extraEnv)
+	if err != nil {
+		t.Fatalf("install.sh failed: %v\n%s", err, output)
+	}
+}
+
+func runInstallScriptCommand(t *testing.T, home, fakeBin string, extraEnv map[string]string) ([]byte, error) {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -110,10 +148,7 @@ func runInstallScript(t *testing.T, home, fakeBin string, extraEnv map[string]st
 	for key, value := range extraEnv {
 		cmd.Env = append(cmd.Env, key+"="+value)
 	}
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("install.sh failed: %v\n%s", err, output)
-	}
+	return cmd.CombinedOutput()
 }
 
 func filteredEnv(env []string, excluded ...string) []string {

--- a/install_script_test.go
+++ b/install_script_test.go
@@ -119,6 +119,26 @@ func TestInstallScriptSucceedsWhenDaemonStartFails(t *testing.T) {
 	}
 }
 
+func TestPowerShellInstallScriptAllowsDaemonStartFailure(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("docs", "install.ps1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "$oldErrorActionPreference = $ErrorActionPreference") {
+		t.Fatal("install.ps1 should preserve the current error preference before daemon start")
+	}
+	if !strings.Contains(text, "$ErrorActionPreference = \"Continue\"") {
+		t.Fatal("install.ps1 should relax error handling around daemon start")
+	}
+	if !strings.Contains(text, "& \"$installDir\\no-mistakes.exe\" daemon start | Out-Null") {
+		t.Fatal("install.ps1 should still attempt daemon start")
+	}
+	if !strings.Contains(text, "$ErrorActionPreference = $oldErrorActionPreference") {
+		t.Fatal("install.ps1 should restore the previous error preference")
+	}
+}
+
 func skipInstallScriptTestsOnWindows(t *testing.T) {
 	t.Helper()
 	if runtime.GOOS == "windows" {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -804,6 +804,29 @@ func TestDaemonStatusAndStopRunning(t *testing.T) {
 	}
 }
 
+func TestDaemonRunUsesProvidedRoot(t *testing.T) {
+	wantRoot := filepath.Join(t.TempDir(), "nm-home")
+	t.Setenv("NM_HOME", "")
+
+	oldRun := daemonRun
+	defer func() { daemonRun = oldRun }()
+
+	var gotRoot string
+	daemonRun = func() error {
+		gotRoot = os.Getenv("NM_HOME")
+		return nil
+	}
+
+	cmd := newDaemonCmd()
+	cmd.SetArgs([]string{"run", "--root", wantRoot})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if gotRoot != wantRoot {
+		t.Fatalf("daemon run should set NM_HOME to %q, got %q", wantRoot, gotRoot)
+	}
+}
+
 func TestRerunNotInitialized(t *testing.T) {
 	setupTestRepo(t)
 	nmHome, err := os.MkdirTemp("", "nmcli")

--- a/internal/cli/daemon_cmd.go
+++ b/internal/cli/daemon_cmd.go
@@ -2,12 +2,15 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/kunchenguid/no-mistakes/internal/daemon"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
 	"github.com/spf13/cobra"
 )
+
+var daemonRun = daemon.Run
 
 func newDaemonCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -18,6 +21,7 @@ func newDaemonCmd() *cobra.Command {
 	cmd.AddCommand(newDaemonStartCmd())
 	cmd.AddCommand(newDaemonStopCmd())
 	cmd.AddCommand(newDaemonStatusCmd())
+	cmd.AddCommand(newDaemonRunCmd())
 	cmd.AddCommand(newDaemonNotifyPushCmd())
 
 	return cmd
@@ -133,4 +137,26 @@ func newDaemonStatusCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func newDaemonRunCmd() *cobra.Command {
+	var root string
+
+	cmd := &cobra.Command{
+		Use:    "run",
+		Short:  "Run the daemon in the foreground",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if root != "" {
+				if err := os.Setenv("NM_HOME", root); err != nil {
+					return fmt.Errorf("set NM_HOME: %w", err)
+				}
+			}
+			return daemonRun()
+		},
+	}
+
+	cmd.Flags().StringVar(&root, "root", "", "override no-mistakes data directory")
+	return cmd
 }

--- a/internal/cli/daemon_cmd.go
+++ b/internal/cli/daemon_cmd.go
@@ -75,7 +75,7 @@ func newDaemonNotifyPushCmd() *cobra.Command {
 func newDaemonStartCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "start",
-		Short: "Start the daemon in the background",
+		Short: "Install or refresh the managed daemon service and start it",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			p, err := paths.New()
 			if err != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -21,7 +21,8 @@ import (
 var applyShellEnvToProcess = shellenv.ApplyToProcess
 
 // Run starts the daemon process. It blocks until a shutdown signal is received
-// or the shutdown IPC method is called. This is called when NM_DAEMON=1.
+// or the shutdown IPC method is called. This is called when NM_DAEMON=1 or via
+// the hidden `no-mistakes daemon run` entrypoint used by the managed service.
 func Run() error {
 	p, err := paths.New()
 	if err != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -15,7 +15,10 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/shellenv"
 )
+
+var applyShellEnvToProcess = shellenv.ApplyToProcess
 
 // Run starts the daemon process. It blocks until a shutdown signal is received
 // or the shutdown IPC method is called. This is called when NM_DAEMON=1.
@@ -26,6 +29,9 @@ func Run() error {
 	}
 	if err := p.EnsureDirs(); err != nil {
 		return fmt.Errorf("create directories: %w", err)
+	}
+	if err := prepareDaemonEnvironment(); err != nil {
+		return err
 	}
 
 	// Ensure default config exists, then load it.
@@ -43,6 +49,24 @@ func Run() error {
 	defer d.Close()
 
 	return RunWithResources(p, d)
+}
+
+func prepareDaemonEnvironment() error {
+	for _, key := range []string{
+		"CLAUDECODE",
+		"CLAUDE_CODE_ENTRYPOINT",
+		"CLAUDE_CODE_ENTRY_POINT",
+		"CLAUDE_CODE_SESSION_ID",
+		"CLAUDE_CODE_SESSION_ACCESS_TOKEN",
+	} {
+		if err := os.Unsetenv(key); err != nil {
+			return fmt.Errorf("unset %s: %w", key, err)
+		}
+	}
+	if err := applyShellEnvToProcess(); err != nil {
+		return fmt.Errorf("apply login shell environment: %w", err)
+	}
+	return nil
 }
 
 // initLogger sets up the global slog handler with the configured log level.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -52,6 +52,7 @@ func Run() error {
 }
 
 func prepareDaemonEnvironment() error {
+	nmHome := os.Getenv("NM_HOME")
 	for _, key := range []string{
 		"CLAUDECODE",
 		"CLAUDE_CODE_ENTRYPOINT",
@@ -65,6 +66,11 @@ func prepareDaemonEnvironment() error {
 	}
 	if err := applyShellEnvToProcess(); err != nil {
 		return fmt.Errorf("apply login shell environment: %w", err)
+	}
+	if nmHome != "" {
+		if err := os.Setenv("NM_HOME", nmHome); err != nil {
+			return fmt.Errorf("restore NM_HOME: %w", err)
+		}
 	}
 	return nil
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -20,6 +20,13 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
+func TestMain(m *testing.M) {
+	if os.Getenv("NM_DAEMON_HELPER_PROCESS") == "1" {
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
 // startTestDaemon starts RunWithResources in a goroutine with a temp root.
 // Returns paths, db, and a cleanup function that stops the daemon.
 func startTestDaemon(t *testing.T) (*paths.Paths, *db.DB) {

--- a/internal/daemon/env_test.go
+++ b/internal/daemon/env_test.go
@@ -46,3 +46,27 @@ func TestPrepareDaemonEnvironment_RemovesClaudeSessionVarsAndAppliesShellEnv(t *
 		t.Fatalf("expected applied PATH, got %q", got)
 	}
 }
+
+func TestPrepareDaemonEnvironment_PreservesExistingNMHome(t *testing.T) {
+	t.Setenv("NM_HOME", "/service/root")
+
+	oldApply := applyShellEnvToProcess
+	defer func() { applyShellEnvToProcess = oldApply }()
+
+	applyShellEnvToProcess = func() error {
+		if err := os.Setenv("NM_HOME", "/login/shell/root"); err != nil {
+			return err
+		}
+		return os.Setenv("PATH", "/resolved/bin")
+	}
+
+	if err := prepareDaemonEnvironment(); err != nil {
+		t.Fatal(err)
+	}
+	if got := os.Getenv("NM_HOME"); got != "/service/root" {
+		t.Fatalf("NM_HOME = %q, want %q", got, "/service/root")
+	}
+	if got := os.Getenv("PATH"); got != "/resolved/bin" {
+		t.Fatalf("PATH = %q, want %q", got, "/resolved/bin")
+	}
+}

--- a/internal/daemon/env_test.go
+++ b/internal/daemon/env_test.go
@@ -1,0 +1,48 @@
+package daemon
+
+import (
+	"os"
+	"testing"
+)
+
+func TestPrepareDaemonEnvironment_RemovesClaudeSessionVarsAndAppliesShellEnv(t *testing.T) {
+	for key, value := range map[string]string{
+		"CLAUDECODE":                       "1",
+		"CLAUDE_CODE_ENTRYPOINT":           "shell",
+		"CLAUDE_CODE_ENTRY_POINT":          "shell",
+		"CLAUDE_CODE_SESSION_ID":           "session",
+		"CLAUDE_CODE_SESSION_ACCESS_TOKEN": "token",
+	} {
+		t.Setenv(key, value)
+	}
+
+	oldApply := applyShellEnvToProcess
+	defer func() { applyShellEnvToProcess = oldApply }()
+
+	applied := false
+	applyShellEnvToProcess = func() error {
+		applied = true
+		return os.Setenv("PATH", "/resolved/bin")
+	}
+
+	if err := prepareDaemonEnvironment(); err != nil {
+		t.Fatal(err)
+	}
+	if !applied {
+		t.Fatal("expected shell env application")
+	}
+	for _, key := range []string{
+		"CLAUDECODE",
+		"CLAUDE_CODE_ENTRYPOINT",
+		"CLAUDE_CODE_ENTRY_POINT",
+		"CLAUDE_CODE_SESSION_ID",
+		"CLAUDE_CODE_SESSION_ACCESS_TOKEN",
+	} {
+		if got := os.Getenv(key); got != "" {
+			t.Fatalf("expected %s to be cleared, got %q", key, got)
+		}
+	}
+	if got := os.Getenv("PATH"); got != "/resolved/bin" {
+		t.Fatalf("expected applied PATH, got %q", got)
+	}
+}

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -145,7 +145,10 @@ func Stop(p *paths.Paths) error {
 			if alive, _ := daemonHealthCheck(p); !alive {
 				return nil
 			}
-			return err
+			if detachedErr := stopDetachedDaemon(p); detachedErr != nil {
+				return fmt.Errorf("%w; detached shutdown: %v", err, detachedErr)
+			}
+			return nil
 		}
 		return waitForDaemonStop(p)
 	}

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -34,9 +34,10 @@ func durationFromEnv(name string, fallback time.Duration) time.Duration {
 	return d
 }
 
-// Start forks a new daemon process by re-executing the current binary
-// with NM_DAEMON=1. It waits up to 5 seconds for the daemon to become
-// responsive on the IPC socket.
+// Start installs or refreshes the managed daemon service when supported and
+// starts it, falling back to a detached re-exec with NM_DAEMON=1 when managed
+// startup is unavailable or fails. It waits up to 5 seconds for the daemon to
+// become responsive on the IPC socket.
 func Start(p *paths.Paths) error {
 	if err := p.EnsureDirs(); err != nil {
 		return err

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -44,12 +44,13 @@ func Start(p *paths.Paths) error {
 	if alive, _ := daemonHealthCheck(p); alive {
 		return fmt.Errorf("daemon already running")
 	}
-	if managed, err := installManagedService(p); err != nil {
-		return err
-	} else if managed {
-		if err := startManagedDaemon(p); err != nil {
-			return err
+	if managed, err := installManagedService(p); err == nil {
+		if managed {
+			if err := startManagedDaemon(p); err == nil {
+				return nil
+			}
 		}
+	} else if alive, _ := daemonHealthCheck(p); alive {
 		return nil
 	}
 	return startDetachedDaemon(p)

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -12,6 +12,8 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/paths"
 )
 
+var daemonHealthCheck = daemonIsRunningViaIPC
+
 func daemonStartTimeout() time.Duration {
 	return durationFromEnv("NM_TEST_DAEMON_START_TIMEOUT", 5*time.Second)
 }
@@ -36,10 +38,24 @@ func durationFromEnv(name string, fallback time.Duration) time.Duration {
 // with NM_DAEMON=1. It waits up to 5 seconds for the daemon to become
 // responsive on the IPC socket.
 func Start(p *paths.Paths) error {
-	if alive, _ := IsRunning(p); alive {
+	if err := p.EnsureDirs(); err != nil {
+		return err
+	}
+	if alive, _ := daemonHealthCheck(p); alive {
 		return fmt.Errorf("daemon already running")
 	}
+	if managed, err := installManagedService(p); err != nil {
+		return err
+	} else if managed {
+		if err := startManagedDaemon(p); err != nil {
+			return err
+		}
+		return nil
+	}
+	return startDetachedDaemon(p)
+}
 
+func startDetachedDaemon(p *paths.Paths) error {
 	// Clean up stale socket/pid files
 	os.Remove(p.Socket())
 	os.Remove(p.PIDFile())
@@ -73,13 +89,26 @@ func Start(p *paths.Paths) error {
 	if err := cmd.Process.Release(); err != nil {
 		return fmt.Errorf("release daemon process: %w", err)
 	}
+	return waitForDaemonStart(p, pid)
+}
 
+func startManagedDaemon(p *paths.Paths) error {
+	if _, err := startManagedService(p); err != nil {
+		if alive, _ := daemonHealthCheck(p); alive {
+			return nil
+		}
+		return err
+	}
+	return waitForDaemonStart(p, 0)
+}
+
+func waitForDaemonStart(p *paths.Paths, pid int) error {
 	// Poll for the daemon to become responsive.
 	timeout := daemonStartTimeout()
 	pollInterval := daemonStartPollInterval()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		if alive, _ := IsRunning(p); alive {
+		if alive, _ := daemonHealthCheck(p); alive {
 			slog.Info("daemon is responsive", "pid", pid)
 			return nil
 		}
@@ -91,6 +120,10 @@ func Start(p *paths.Paths) error {
 
 // IsRunning checks if the daemon is alive by sending a health check via IPC.
 func IsRunning(p *paths.Paths) (bool, error) {
+	return daemonHealthCheck(p)
+}
+
+func daemonIsRunningViaIPC(p *paths.Paths) (bool, error) {
 	client, err := ipc.Dial(p.Socket())
 	if err != nil {
 		return false, nil
@@ -106,6 +139,19 @@ func IsRunning(p *paths.Paths) (bool, error) {
 
 // Stop sends a shutdown request to the running daemon and waits for it to exit.
 func Stop(p *paths.Paths) error {
+	if managed, err := stopManagedService(p); managed {
+		if err != nil {
+			if alive, _ := daemonHealthCheck(p); !alive {
+				return nil
+			}
+			return err
+		}
+		return waitForDaemonStop(p)
+	}
+	return stopDetachedDaemon(p)
+}
+
+func stopDetachedDaemon(p *paths.Paths) error {
 	client, err := ipc.Dial(p.Socket())
 	if err != nil {
 		return nil
@@ -116,11 +162,14 @@ func Stop(p *paths.Paths) error {
 	if err := client.Call(ipc.MethodShutdown, &ipc.ShutdownParams{}, &result); err != nil {
 		return fmt.Errorf("shutdown request: %w", err)
 	}
+	return waitForDaemonStop(p)
+}
 
+func waitForDaemonStop(p *paths.Paths) error {
 	// Wait for daemon to actually stop (socket becomes unavailable).
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
-		if alive, _ := IsRunning(p); !alive {
+		if alive, _ := daemonHealthCheck(p); !alive {
 			slog.Info("daemon stopped gracefully")
 			return nil
 		}
@@ -140,7 +189,7 @@ func Stop(p *paths.Paths) error {
 
 // EnsureDaemon starts the daemon if it's not already running.
 func EnsureDaemon(p *paths.Paths) error {
-	if alive, _ := IsRunning(p); alive {
+	if alive, _ := daemonHealthCheck(p); alive {
 		return nil
 	}
 	return Start(p)

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -48,12 +48,25 @@ func Start(p *paths.Paths) error {
 		if managed {
 			if err := startManagedDaemon(p); err == nil {
 				return nil
+			} else if err := stopManagedFallback(p); err != nil {
+				return err
 			}
 		}
 	} else if alive, _ := daemonHealthCheck(p); alive {
 		return nil
 	}
 	return startDetachedDaemon(p)
+}
+
+func stopManagedFallback(p *paths.Paths) error {
+	managed, err := stopManagedService(p)
+	if !managed || err == nil {
+		return nil
+	}
+	if alive, _ := daemonHealthCheck(p); alive {
+		return fmt.Errorf("managed daemon is still running: %w", err)
+	}
+	return fmt.Errorf("stop managed daemon before detached fallback: %w", err)
 }
 
 func startDetachedDaemon(p *paths.Paths) error {

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -1,0 +1,344 @@
+package daemon
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/kunchenguid/no-mistakes/internal/paths"
+)
+
+const (
+	launchdServiceLabel = "com.kunchenguid.no-mistakes.daemon"
+	systemdServiceName  = "no-mistakes-daemon.service"
+	windowsTaskName     = "no-mistakes-daemon"
+)
+
+var runtimeGOOS = runtime.GOOS
+var serviceUserHomeDir = os.UserHomeDir
+var serviceCurrentUser = user.Current
+var serviceExecutablePath = os.Executable
+var serviceCommandRunner = runServiceCommand
+var serviceManagerBypassed = func() bool {
+	return os.Getenv("NM_TEST_START_DAEMON") == "1"
+}
+
+func installManagedService(p *paths.Paths) (bool, error) {
+	if serviceManagerBypassed() {
+		return false, nil
+	}
+	exe, err := serviceExecutablePath()
+	if err != nil {
+		return false, fmt.Errorf("resolve executable: %w", err)
+	}
+	switch runtimeGOOS {
+	case "darwin":
+		return true, installLaunchAgent(p, exe)
+	case "linux":
+		return true, installSystemdUserService(p, exe)
+	case "windows":
+		return true, installWindowsTask(p, exe)
+	default:
+		return false, nil
+	}
+}
+
+func startManagedService(p *paths.Paths) (bool, error) {
+	if serviceManagerBypassed() {
+		return false, nil
+	}
+	switch runtimeGOOS {
+	case "darwin":
+		return true, startLaunchAgent(p)
+	case "linux":
+		return true, startSystemdUserService()
+	case "windows":
+		return true, startWindowsTask()
+	default:
+		return false, nil
+	}
+}
+
+func stopManagedService(p *paths.Paths) (bool, error) {
+	if serviceManagerBypassed() || !managedServiceInstalled(p) {
+		return false, nil
+	}
+	switch runtimeGOOS {
+	case "darwin":
+		return true, stopLaunchAgent(p)
+	case "linux":
+		return true, stopSystemdUserService()
+	case "windows":
+		return true, stopWindowsTask()
+	default:
+		return false, nil
+	}
+}
+
+func managedServiceInstalled(p *paths.Paths) bool {
+	if serviceManagerBypassed() {
+		return false
+	}
+	switch runtimeGOOS {
+	case "darwin":
+		_, err := os.Stat(launchAgentPath())
+		return err == nil
+	case "linux":
+		_, err := os.Stat(systemdUserServicePath())
+		return err == nil
+	case "windows":
+		return p != nil
+	default:
+		return false
+	}
+}
+
+func installLaunchAgent(p *paths.Paths, exe string) error {
+	path := launchAgentPath()
+	home, err := serviceUserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve user home: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create launch agents directory: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(renderLaunchAgent(exe, p, home)), 0o644); err != nil {
+		return fmt.Errorf("write launch agent: %w", err)
+	}
+	return nil
+}
+
+func startLaunchAgent(p *paths.Paths) error {
+	domain, err := launchdDomainTarget()
+	if err != nil {
+		return err
+	}
+	serviceTarget := domain + "/" + launchdServiceLabel
+	path := launchAgentPath()
+	_, _ = serviceCommandRunner("launchctl", "bootout", serviceTarget)
+	_, bootstrapErr := serviceCommandRunner("launchctl", "bootstrap", domain, path)
+	_, kickstartErr := serviceCommandRunner("launchctl", "kickstart", "-k", serviceTarget)
+	if kickstartErr != nil {
+		if bootstrapErr != nil {
+			return fmt.Errorf("launchctl bootstrap: %v; kickstart: %w", bootstrapErr, kickstartErr)
+		}
+		return fmt.Errorf("launchctl kickstart: %w", kickstartErr)
+	}
+	return nil
+}
+
+func stopLaunchAgent(_ *paths.Paths) error {
+	domain, err := launchdDomainTarget()
+	if err != nil {
+		return err
+	}
+	_, err = serviceCommandRunner("launchctl", "bootout", domain+"/"+launchdServiceLabel)
+	if err != nil {
+		return fmt.Errorf("launchctl bootout: %w", err)
+	}
+	return nil
+}
+
+func installSystemdUserService(p *paths.Paths, exe string) error {
+	path := systemdUserServicePath()
+	home, err := serviceUserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve user home: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create systemd user directory: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(renderSystemdUnit(exe, p, home)), 0o644); err != nil {
+		return fmt.Errorf("write systemd unit: %w", err)
+	}
+	if _, err := serviceCommandRunner("systemctl", "--user", "daemon-reload"); err != nil {
+		return fmt.Errorf("systemctl daemon-reload: %w", err)
+	}
+	if _, err := serviceCommandRunner("systemctl", "--user", "enable", systemdServiceName); err != nil {
+		return fmt.Errorf("systemctl enable: %w", err)
+	}
+	return nil
+}
+
+func startSystemdUserService() error {
+	_, err := serviceCommandRunner("systemctl", "--user", "start", systemdServiceName)
+	if err != nil {
+		return fmt.Errorf("systemctl start: %w", err)
+	}
+	return nil
+}
+
+func stopSystemdUserService() error {
+	_, err := serviceCommandRunner("systemctl", "--user", "stop", systemdServiceName)
+	if err != nil {
+		return fmt.Errorf("systemctl stop: %w", err)
+	}
+	return nil
+}
+
+func installWindowsTask(p *paths.Paths, exe string) error {
+	args := []string{
+		"/Create",
+		"/TN", windowsTaskName,
+		"/SC", "ONLOGON",
+		"/RL", "LIMITED",
+		"/F",
+		"/TR", buildWindowsTaskCommand(exe, p.Root()),
+	}
+	if _, err := serviceCommandRunner("schtasks", args...); err != nil {
+		return fmt.Errorf("schtasks create: %w", err)
+	}
+	return nil
+}
+
+func startWindowsTask() error {
+	_, err := serviceCommandRunner("schtasks", "/Run", "/TN", windowsTaskName)
+	if err != nil {
+		return fmt.Errorf("schtasks run: %w", err)
+	}
+	return nil
+}
+
+func stopWindowsTask() error {
+	_, err := serviceCommandRunner("schtasks", "/End", "/TN", windowsTaskName)
+	if err != nil {
+		return fmt.Errorf("schtasks end: %w", err)
+	}
+	return nil
+}
+
+func launchAgentPath() string {
+	home, err := serviceUserHomeDir()
+	if err != nil {
+		return filepath.Join("", "Library", "LaunchAgents", launchdServiceLabel+".plist")
+	}
+	return filepath.Join(home, "Library", "LaunchAgents", launchdServiceLabel+".plist")
+}
+
+func systemdUserServicePath() string {
+	home, err := serviceUserHomeDir()
+	if err != nil {
+		return filepath.Join("", ".config", "systemd", "user", systemdServiceName)
+	}
+	return filepath.Join(home, ".config", "systemd", "user", systemdServiceName)
+}
+
+func launchdDomainTarget() (string, error) {
+	u, err := serviceCurrentUser()
+	if err != nil {
+		return "", fmt.Errorf("resolve current user: %w", err)
+	}
+	if u == nil || u.Uid == "" {
+		return "", fmt.Errorf("resolve current user: empty uid")
+	}
+	return "gui/" + u.Uid, nil
+}
+
+func renderLaunchAgent(exe string, p *paths.Paths, home string) string {
+	values := []string{exe, "daemon", "run", "--root", p.Root()}
+	var args strings.Builder
+	for _, value := range values {
+		args.WriteString("    <string>")
+		args.WriteString(xmlEscaped(value))
+		args.WriteString("</string>\n")
+	}
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>%s</string>
+  <key>ProgramArguments</key>
+  <array>
+%s  </array>
+  <key>WorkingDirectory</key>
+  <string>%s</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>%s</string>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>%s</string>
+  <key>StandardErrorPath</key>
+  <string>%s</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+</dict>
+</plist>
+`, xmlEscaped(launchdServiceLabel), args.String(), xmlEscaped(p.Root()), xmlEscaped(home), xmlEscaped(p.DaemonLog()), xmlEscaped(p.DaemonLog()))
+}
+
+func renderSystemdUnit(exe string, p *paths.Paths, home string) string {
+	command := strings.Join([]string{
+		systemdEscapeArg(exe),
+		systemdEscapeArg("daemon"),
+		systemdEscapeArg("run"),
+		systemdEscapeArg("--root"),
+		systemdEscapeArg(p.Root()),
+	}, " ")
+	return fmt.Sprintf(`[Unit]
+Description=no-mistakes background daemon
+
+[Service]
+Type=simple
+ExecStart=%s
+WorkingDirectory=%s
+Environment=%s
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=default.target
+`, command, systemdEscapeArg(p.Root()), strconv.Quote("HOME="+home))
+}
+
+func buildWindowsTaskCommand(exe, root string) string {
+	args := []string{quoteWindowsTaskArg(exe), "daemon", "run", "--root", quoteWindowsTaskArg(root)}
+	return strings.Join(args, " ")
+}
+
+func systemdEscapeArg(arg string) string {
+	if arg == "" {
+		return `""`
+	}
+	if strings.ContainsAny(arg, " \t\n\r\"'\\") {
+		return strconv.Quote(arg)
+	}
+	return arg
+}
+
+func quoteWindowsTaskArg(arg string) string {
+	if !strings.ContainsAny(arg, " \t\"") {
+		return arg
+	}
+	return strconv.Quote(arg)
+}
+
+func xmlEscaped(value string) string {
+	var buf bytes.Buffer
+	_ = xml.EscapeText(&buf, []byte(value))
+	return buf.String()
+}
+
+func runServiceCommand(name string, args ...string) ([]byte, error) {
+	path, err := exec.LookPath(name)
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.Command(path, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return output, fmt.Errorf("%s %s: %w: %s", path, strings.Join(args, " "), err, strings.TrimSpace(string(output)))
+	}
+	return output, nil
+}

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -94,7 +94,11 @@ func managedServiceInstalled(p *paths.Paths) bool {
 		_, err := os.Stat(systemdUserServicePath())
 		return err == nil
 	case "windows":
-		return p != nil
+		if p == nil {
+			return false
+		}
+		_, err := serviceCommandRunner("schtasks", "/Query", "/TN", windowsTaskName)
+		return err == nil
 	default:
 		return false
 	}

--- a/internal/daemon/service_test.go
+++ b/internal/daemon/service_test.go
@@ -1,0 +1,197 @@
+package daemon
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/paths"
+)
+
+func TestStartInstallsLaunchAgentAndBootstrapsManagedDaemon(t *testing.T) {
+	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+
+	cleanup := stubServiceRuntime(t)
+	defer cleanup()
+	runtimeGOOS = "darwin"
+	serviceUserHomeDir = func() (string, error) { return home, nil }
+	serviceCurrentUser = func() (*user.User, error) { return &user.User{Uid: "501"}, nil }
+	serviceExecutablePath = func() (string, error) { return "/opt/no-mistakes/bin/no-mistakes", nil }
+
+	var commands []string
+	serviceCommandRunner = func(name string, args ...string) ([]byte, error) {
+		commands = append(commands, name+" "+strings.Join(args, " "))
+		return nil, nil
+	}
+	checks := 0
+	daemonHealthCheck = func(*paths.Paths) (bool, error) {
+		checks++
+		return checks >= 2, nil
+	}
+
+	if err := Start(p); err != nil {
+		t.Fatal(err)
+	}
+
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", launchdServiceLabel+".plist")
+	data, err := os.ReadFile(plistPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		"<string>/opt/no-mistakes/bin/no-mistakes</string>",
+		"<string>daemon</string>",
+		"<string>run</string>",
+		"<string>--root</string>",
+		"<string>" + p.Root() + "</string>",
+		"<key>EnvironmentVariables</key>",
+		"<key>HOME</key>",
+		"<string>" + home + "</string>",
+		"<key>RunAtLoad</key>",
+		"<key>KeepAlive</key>",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("launch agent should contain %q, got:\n%s", want, text)
+		}
+	}
+	if len(commands) != 3 {
+		t.Fatalf("expected bootout, bootstrap, and kickstart, got %v", commands)
+	}
+	if want := "launchctl bootout gui/501/" + launchdServiceLabel; commands[0] != want {
+		t.Fatalf("bootout command = %q, want %q", commands[0], want)
+	}
+	if want := "launchctl bootstrap gui/501 " + plistPath; commands[1] != want {
+		t.Fatalf("bootstrap command = %q, want %q", commands[1], want)
+	}
+	if want := "launchctl kickstart -k gui/501/" + launchdServiceLabel; commands[2] != want {
+		t.Fatalf("kickstart command = %q, want %q", commands[2], want)
+	}
+}
+
+func TestStartInstallsSystemdUnitAndStartsManagedDaemon(t *testing.T) {
+	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+
+	cleanup := stubServiceRuntime(t)
+	defer cleanup()
+	runtimeGOOS = "linux"
+	serviceUserHomeDir = func() (string, error) { return home, nil }
+	serviceExecutablePath = func() (string, error) { return "/usr/local/bin/no-mistakes", nil }
+
+	var commands []string
+	serviceCommandRunner = func(name string, args ...string) ([]byte, error) {
+		commands = append(commands, name+" "+strings.Join(args, " "))
+		return nil, nil
+	}
+	checks := 0
+	daemonHealthCheck = func(*paths.Paths) (bool, error) {
+		checks++
+		return checks >= 2, nil
+	}
+
+	if err := Start(p); err != nil {
+		t.Fatal(err)
+	}
+
+	unitPath := filepath.Join(home, ".config", "systemd", "user", systemdServiceName)
+	data, err := os.ReadFile(unitPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		"Description=no-mistakes background daemon",
+		"ExecStart=/usr/local/bin/no-mistakes daemon run --root " + p.Root(),
+		"WorkingDirectory=" + p.Root(),
+		"Environment=\"HOME=" + home + "\"",
+		"Restart=always",
+		"WantedBy=default.target",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("systemd unit should contain %q, got:\n%s", want, text)
+		}
+	}
+	want := []string{
+		"systemctl --user daemon-reload",
+		"systemctl --user enable " + systemdServiceName,
+		"systemctl --user start " + systemdServiceName,
+	}
+	if len(commands) != len(want) {
+		t.Fatalf("expected %d systemctl commands, got %v", len(want), commands)
+	}
+	for i, wantCmd := range want {
+		if commands[i] != wantCmd {
+			t.Fatalf("command[%d] = %q, want %q", i, commands[i], wantCmd)
+		}
+	}
+}
+
+func TestStopUsesManagedServiceWhenInstalled(t *testing.T) {
+	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+
+	cleanup := stubServiceRuntime(t)
+	defer cleanup()
+	runtimeGOOS = "linux"
+	serviceUserHomeDir = func() (string, error) { return home, nil }
+	daemonHealthCheck = func(*paths.Paths) (bool, error) { return false, nil }
+
+	unitPath := filepath.Join(home, ".config", "systemd", "user", systemdServiceName)
+	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unitPath, []byte("[Unit]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var commands []string
+	serviceCommandRunner = func(name string, args ...string) ([]byte, error) {
+		commands = append(commands, name+" "+strings.Join(args, " "))
+		return nil, nil
+	}
+
+	if err := Stop(p); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(commands) != 1 {
+		t.Fatalf("expected one stop command, got %v", commands)
+	}
+	if want := "systemctl --user stop " + systemdServiceName; commands[0] != want {
+		t.Fatalf("stop command = %q, want %q", commands[0], want)
+	}
+}
+
+func stubServiceRuntime(t *testing.T) func() {
+	t.Helper()
+	oldGOOS := runtimeGOOS
+	oldUserHomeDir := serviceUserHomeDir
+	oldCurrentUser := serviceCurrentUser
+	oldExecutablePath := serviceExecutablePath
+	oldCommandRunner := serviceCommandRunner
+	oldHealthCheck := daemonHealthCheck
+	oldServiceBypass := serviceManagerBypassed
+	serviceManagerBypassed = func() bool { return false }
+	return func() {
+		runtimeGOOS = oldGOOS
+		serviceUserHomeDir = oldUserHomeDir
+		serviceCurrentUser = oldCurrentUser
+		serviceExecutablePath = oldExecutablePath
+		serviceCommandRunner = oldCommandRunner
+		daemonHealthCheck = oldHealthCheck
+		serviceManagerBypassed = oldServiceBypass
+	}
+}

--- a/internal/daemon/service_test.go
+++ b/internal/daemon/service_test.go
@@ -240,6 +240,56 @@ func TestStopUsesManagedServiceWhenInstalled(t *testing.T) {
 	}
 }
 
+func TestStopFallsBackToDetachedDaemonWhenManagedStopFails(t *testing.T) {
+	p, _ := startTestDaemon(t)
+	home := t.TempDir()
+
+	cleanup := stubServiceRuntime(t)
+	defer cleanup()
+	runtimeGOOS = "linux"
+	serviceUserHomeDir = func() (string, error) { return home, nil }
+
+	unitPath := filepath.Join(home, ".config", "systemd", "user", systemdServiceName)
+	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unitPath, []byte("[Unit]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var commands []string
+	serviceCommandRunner = func(name string, args ...string) ([]byte, error) {
+		commands = append(commands, name+" "+strings.Join(args, " "))
+		return nil, fmt.Errorf("user manager unavailable")
+	}
+
+	if err := Stop(p); err != nil {
+		t.Fatalf("Stop should fall back to detached daemon shutdown: %v", err)
+	}
+
+	if len(commands) != 1 {
+		t.Fatalf("expected one managed stop command before fallback, got %v", commands)
+	}
+	if want := "systemctl --user stop " + systemdServiceName; commands[0] != want {
+		t.Fatalf("stop command = %q, want %q", commands[0], want)
+	}
+
+	alive, err := IsRunning(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if alive {
+		t.Fatal("daemon should be stopped")
+	}
+	if _, err := os.Stat(unitPath); err != nil {
+		t.Fatalf("managed unit should remain installed after fallback stop: %v", err)
+	}
+	_ = os.Remove(unitPath)
+	_ = os.Remove(filepath.Dir(unitPath))
+	_ = os.Remove(filepath.Dir(filepath.Dir(unitPath)))
+	_ = os.Remove(filepath.Dir(filepath.Dir(filepath.Dir(unitPath))))
+}
+
 func TestStopFallsBackToDetachedDaemonOnWindowsWithoutManagedService(t *testing.T) {
 	p, _ := startTestDaemon(t)
 

--- a/internal/daemon/service_test.go
+++ b/internal/daemon/service_test.go
@@ -152,9 +152,14 @@ func TestStartFallsBackToDetachedDaemonWhenManagedStartFails(t *testing.T) {
 	serviceExecutablePath = func() (string, error) { return "/usr/local/bin/no-mistakes", nil }
 
 	var commands []string
+	var managedStopped bool
 	serviceCommandRunner = func(name string, args ...string) ([]byte, error) {
 		command := name + " " + strings.Join(args, " ")
 		commands = append(commands, command)
+		if command == "systemctl --user stop "+systemdServiceName {
+			managedStopped = true
+			return nil, nil
+		}
 		if command == "systemctl --user start "+systemdServiceName {
 			return nil, fmt.Errorf("user manager unavailable")
 		}
@@ -170,19 +175,23 @@ func TestStartFallsBackToDetachedDaemonWhenManagedStartFails(t *testing.T) {
 		t.Fatalf("Start should fall back to detached mode: %v", err)
 	}
 
-	if len(commands) != 3 {
-		t.Fatalf("expected managed service install and start before fallback, got %v", commands)
+	if len(commands) != 4 {
+		t.Fatalf("expected managed start, stop, and detached fallback, got %v", commands)
 	}
 	if want := []string{
 		"systemctl --user daemon-reload",
 		"systemctl --user enable " + systemdServiceName,
 		"systemctl --user start " + systemdServiceName,
+		"systemctl --user stop " + systemdServiceName,
 	}; len(commands) == len(want) {
 		for i, wantCmd := range want {
 			if commands[i] != wantCmd {
 				t.Fatalf("command[%d] = %q, want %q", i, commands[i], wantCmd)
 			}
 		}
+	}
+	if !managedStopped {
+		t.Fatal("managed service should be stopped before detached fallback")
 	}
 	if _, err := os.Stat(p.DaemonLog()); err != nil {
 		t.Fatalf("detached fallback should open daemon log: %v", err)
@@ -195,6 +204,74 @@ func TestStartFallsBackToDetachedDaemonWhenManagedStartFails(t *testing.T) {
 	}
 	if checks < 3 {
 		t.Fatalf("expected health checks for preflight, managed failure, and detached wait, got %d", checks)
+	}
+	_ = os.Remove(p.DaemonLog())
+	_ = os.Remove(p.PIDFile())
+	_ = os.Remove(p.Socket())
+}
+
+func TestStartStopsManagedServiceBeforeDetachedFallbackAfterTimeout(t *testing.T) {
+	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+
+	cleanup := stubServiceRuntime(t)
+	defer cleanup()
+	t.Setenv("NM_DAEMON_HELPER_PROCESS", "1")
+	t.Setenv("NM_TEST_DAEMON_START_TIMEOUT", "20ms")
+	t.Setenv("NM_TEST_DAEMON_START_POLL_INTERVAL", "1ms")
+	runtimeGOOS = "linux"
+	serviceUserHomeDir = func() (string, error) { return home, nil }
+	serviceExecutablePath = func() (string, error) { return "/usr/local/bin/no-mistakes", nil }
+
+	var commands []string
+	var managedStopped bool
+	serviceCommandRunner = func(name string, args ...string) ([]byte, error) {
+		command := name + " " + strings.Join(args, " ")
+		commands = append(commands, command)
+		if command == "systemctl --user stop "+systemdServiceName {
+			managedStopped = true
+		}
+		return nil, nil
+	}
+	checks := 0
+	daemonHealthCheck = func(*paths.Paths) (bool, error) {
+		checks++
+		if !managedStopped {
+			return false, nil
+		}
+		return checks > 2, nil
+	}
+
+	if err := Start(p); err != nil {
+		t.Fatalf("Start should fall back to detached mode after managed timeout: %v", err)
+	}
+
+	if len(commands) != 4 {
+		t.Fatalf("expected managed start, stop, and detached fallback, got %v", commands)
+	}
+	if want := []string{
+		"systemctl --user daemon-reload",
+		"systemctl --user enable " + systemdServiceName,
+		"systemctl --user start " + systemdServiceName,
+		"systemctl --user stop " + systemdServiceName,
+	}; len(commands) == len(want) {
+		for i, wantCmd := range want {
+			if commands[i] != wantCmd {
+				t.Fatalf("command[%d] = %q, want %q", i, commands[i], wantCmd)
+			}
+		}
+	}
+	if !managedStopped {
+		t.Fatal("managed service should be stopped before detached fallback")
+	}
+	if _, err := os.Stat(p.DaemonLog()); err != nil {
+		t.Fatalf("detached fallback should open daemon log: %v", err)
+	}
+	if checks < 3 {
+		t.Fatalf("expected health checks during managed timeout and detached wait, got %d", checks)
 	}
 	_ = os.Remove(p.DaemonLog())
 	_ = os.Remove(p.PIDFile())

--- a/internal/daemon/service_test.go
+++ b/internal/daemon/service_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"fmt"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -136,6 +137,70 @@ func TestStartInstallsSystemdUnitAndStartsManagedDaemon(t *testing.T) {
 	}
 }
 
+func TestStartFallsBackToDetachedDaemonWhenManagedStartFails(t *testing.T) {
+	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+
+	cleanup := stubServiceRuntime(t)
+	defer cleanup()
+	t.Setenv("NM_DAEMON_HELPER_PROCESS", "1")
+	runtimeGOOS = "linux"
+	serviceUserHomeDir = func() (string, error) { return home, nil }
+	serviceExecutablePath = func() (string, error) { return "/usr/local/bin/no-mistakes", nil }
+
+	var commands []string
+	serviceCommandRunner = func(name string, args ...string) ([]byte, error) {
+		command := name + " " + strings.Join(args, " ")
+		commands = append(commands, command)
+		if command == "systemctl --user start "+systemdServiceName {
+			return nil, fmt.Errorf("user manager unavailable")
+		}
+		return nil, nil
+	}
+	checks := 0
+	daemonHealthCheck = func(*paths.Paths) (bool, error) {
+		checks++
+		return checks >= 3, nil
+	}
+
+	if err := Start(p); err != nil {
+		t.Fatalf("Start should fall back to detached mode: %v", err)
+	}
+
+	if len(commands) != 3 {
+		t.Fatalf("expected managed service install and start before fallback, got %v", commands)
+	}
+	if want := []string{
+		"systemctl --user daemon-reload",
+		"systemctl --user enable " + systemdServiceName,
+		"systemctl --user start " + systemdServiceName,
+	}; len(commands) == len(want) {
+		for i, wantCmd := range want {
+			if commands[i] != wantCmd {
+				t.Fatalf("command[%d] = %q, want %q", i, commands[i], wantCmd)
+			}
+		}
+	}
+	if _, err := os.Stat(p.DaemonLog()); err != nil {
+		t.Fatalf("detached fallback should open daemon log: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".config", "systemd", "user", systemdServiceName)); err != nil {
+		t.Fatalf("managed service install should still write unit file: %v", err)
+	}
+	if pidData, err := os.ReadFile(p.PIDFile()); err == nil && len(pidData) > 0 {
+		t.Fatalf("helper detached process should not leave a pid file, got %q", string(pidData))
+	}
+	if checks < 3 {
+		t.Fatalf("expected health checks for preflight, managed failure, and detached wait, got %d", checks)
+	}
+	_ = os.Remove(p.DaemonLog())
+	_ = os.Remove(p.PIDFile())
+	_ = os.Remove(p.Socket())
+}
+
 func TestStopUsesManagedServiceWhenInstalled(t *testing.T) {
 	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
 	if err := p.EnsureDirs(); err != nil {
@@ -172,6 +237,37 @@ func TestStopUsesManagedServiceWhenInstalled(t *testing.T) {
 	}
 	if want := "systemctl --user stop " + systemdServiceName; commands[0] != want {
 		t.Fatalf("stop command = %q, want %q", commands[0], want)
+	}
+}
+
+func TestStopFallsBackToDetachedDaemonOnWindowsWithoutManagedService(t *testing.T) {
+	p, _ := startTestDaemon(t)
+
+	cleanup := stubServiceRuntime(t)
+	defer cleanup()
+	runtimeGOOS = "windows"
+	var commands []string
+	serviceCommandRunner = func(name string, args ...string) ([]byte, error) {
+		commands = append(commands, name+" "+strings.Join(args, " "))
+		return nil, fmt.Errorf("task not found")
+	}
+
+	if err := Stop(p); err != nil {
+		t.Fatalf("Stop should fall back to detached daemon shutdown: %v", err)
+	}
+	if len(commands) != 1 {
+		t.Fatalf("expected one scheduled-task query, got %v", commands)
+	}
+	if want := "schtasks /Query /TN " + windowsTaskName; commands[0] != want {
+		t.Fatalf("query command = %q, want %q", commands[0], want)
+	}
+
+	alive, err := IsRunning(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if alive {
+		t.Fatal("daemon should be stopped")
 	}
 }
 

--- a/internal/pipeline/steps/shell_test.go
+++ b/internal/pipeline/steps/shell_test.go
@@ -1,0 +1,34 @@
+package steps
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunShellCommandWithEnv_UsesShAndIgnoresUserShell(t *testing.T) {
+	workDir := t.TempDir()
+	marker := filepath.Join(t.TempDir(), "user-shell-used")
+	shellPath := filepath.Join(t.TempDir(), "bash")
+	script := "#!/bin/sh\nprintf used > \"$USER_SHELL_MARKER\"\nexit 99\n"
+	if err := os.WriteFile(shellPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SHELL", shellPath)
+	t.Setenv("USER_SHELL_MARKER", marker)
+
+	output, exitCode, err := runShellCommandWithEnv(context.Background(), workDir, []string{"STEP_SPECIAL=from-step"}, "printf %s \"$STEP_SPECIAL\"")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exitCode != 0 {
+		t.Fatalf("exitCode = %d", exitCode)
+	}
+	if output != "from-step" {
+		t.Fatalf("output = %q", output)
+	}
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatal("expected custom user shell to be ignored")
+	}
+}

--- a/internal/shellenv/shellenv.go
+++ b/internal/shellenv/shellenv.go
@@ -1,0 +1,183 @@
+package shellenv
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+var runtimeGOOS = runtime.GOOS
+var lookupEnv = os.LookupEnv
+var currentUser = user.Current
+var shellCommandOutput = defaultShellCommandOutput
+
+var cacheMu sync.Mutex
+var cachedEnv []string
+
+func LoginShell() string {
+	if shell, ok := lookupEnv("SHELL"); ok && strings.TrimSpace(shell) != "" {
+		return shell
+	}
+	if runtimeGOOS == "darwin" {
+		if shell := shellFromDSCL(); shell != "" {
+			return shell
+		}
+	}
+	if runtimeGOOS == "linux" {
+		if shell := shellFromGetent(); shell != "" {
+			return shell
+		}
+	}
+	return "bash"
+}
+
+func SupportsInteractive(shell string) bool {
+	base := filepath.Base(shell)
+	return base == "bash" || base == "zsh"
+}
+
+func Resolve() ([]string, error) {
+	cacheMu.Lock()
+	if cachedEnv != nil {
+		defer cacheMu.Unlock()
+		return append([]string(nil), cachedEnv...), nil
+	}
+	cacheMu.Unlock()
+
+	resolved, err := resolveUncached()
+	if err != nil {
+		return nil, err
+	}
+
+	cacheMu.Lock()
+	if cachedEnv == nil {
+		cachedEnv = append([]string(nil), resolved...)
+	}
+	defer cacheMu.Unlock()
+	return append([]string(nil), cachedEnv...), nil
+}
+
+func ApplyToProcess() error {
+	env, err := Resolve()
+	if err != nil {
+		return err
+	}
+	for _, entry := range env {
+		key, value, found := strings.Cut(entry, "=")
+		if key == "" {
+			continue
+		}
+		if !found {
+			value = ""
+		}
+		if err := os.Setenv(key, value); err != nil {
+			return fmt.Errorf("set %s: %w", key, err)
+		}
+	}
+	return nil
+}
+
+func resolveUncached() ([]string, error) {
+	if runtimeGOOS == "windows" {
+		return append([]string(nil), os.Environ()...), nil
+	}
+
+	shell := LoginShell()
+	args := []string{"-l", "-c", "env -0"}
+	if SupportsInteractive(shell) {
+		args = []string{"-l", "-i", "-c", "env -0"}
+	}
+	out, err := shellCommandOutput(shell, args...)
+	if err != nil {
+		fallback := append([]string(nil), os.Environ()...)
+		return ensureShellEntry(fallback, shell), nil
+	}
+	resolved := parseEnvOutput(out)
+	if len(resolved) == 0 {
+		fallback := append([]string(nil), os.Environ()...)
+		return ensureShellEntry(fallback, shell), nil
+	}
+	return ensureShellEntry(resolved, shell), nil
+}
+
+func parseEnvOutput(out []byte) []string {
+	parts := strings.Split(string(out), "\x00")
+	env := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		env = append(env, part)
+	}
+	return env
+}
+
+func ensureShellEntry(env []string, shell string) []string {
+	for _, entry := range env {
+		if strings.HasPrefix(entry, "SHELL=") {
+			return env
+		}
+	}
+	return append(env, "SHELL="+shell)
+}
+
+func shellFromDSCL() string {
+	username := currentUsername()
+	if username == "" {
+		return ""
+	}
+	out, err := shellCommandOutput("dscl", ".", "-read", "/Users/"+username, "UserShell")
+	if err != nil {
+		return ""
+	}
+	line := strings.TrimSpace(string(out))
+	line = strings.TrimPrefix(line, "UserShell:")
+	return strings.TrimSpace(line)
+}
+
+func shellFromGetent() string {
+	username := currentUsername()
+	if username == "" {
+		return ""
+	}
+	out, err := shellCommandOutput("getent", "passwd", username)
+	if err != nil {
+		return ""
+	}
+	line := strings.TrimSpace(string(out))
+	if line == "" {
+		return ""
+	}
+	parts := strings.Split(line, ":")
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(parts[len(parts)-1])
+}
+
+func currentUsername() string {
+	if username, ok := lookupEnv("USER"); ok && strings.TrimSpace(username) != "" {
+		return username
+	}
+	u, err := currentUser()
+	if err != nil || u == nil {
+		return ""
+	}
+	return strings.TrimSpace(u.Username)
+}
+
+func defaultShellCommandOutput(name string, args ...string) ([]byte, error) {
+	cmd := exec.Command(name, args...)
+	return cmd.Output()
+}
+
+func resetForTests() {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+	cachedEnv = nil
+}

--- a/internal/shellenv/shellenv.go
+++ b/internal/shellenv/shellenv.go
@@ -1,6 +1,7 @@
 package shellenv
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -9,12 +10,14 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 )
 
 var runtimeGOOS = runtime.GOOS
 var lookupEnv = os.LookupEnv
 var currentUser = user.Current
 var shellCommandOutput = defaultShellCommandOutput
+var shellCommandTimeout = 2 * time.Second
 
 var cacheMu sync.Mutex
 var cachedEnv []string
@@ -214,7 +217,9 @@ func currentUsername() string {
 }
 
 func defaultShellCommandOutput(name string, args ...string) ([]byte, error) {
-	cmd := exec.Command(name, args...)
+	ctx, cancel := context.WithTimeout(context.Background(), shellCommandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, name, args...)
 	return cmd.Output()
 }
 

--- a/internal/shellenv/shellenv.go
+++ b/internal/shellenv/shellenv.go
@@ -109,12 +109,54 @@ func parseEnvOutput(out []byte) []string {
 	parts := strings.Split(string(out), "\x00")
 	env := make([]string, 0, len(parts))
 	for _, part := range parts {
-		if part == "" {
+		entry, ok := parseEnvEntry(part)
+		if !ok {
 			continue
 		}
-		env = append(env, part)
+		env = append(env, entry)
 	}
 	return env
+}
+
+func parseEnvEntry(part string) (string, bool) {
+	if part == "" {
+		return "", false
+	}
+	candidateStarts := []int{0}
+	for i := 0; i < len(part); i++ {
+		if part[i] == '\n' || part[i] == '\r' {
+			candidateStarts = append(candidateStarts, i+1)
+		}
+	}
+	for _, start := range candidateStarts {
+		candidate := strings.TrimLeft(part[start:], "\r\n")
+		if candidate == "" {
+			continue
+		}
+		key, _, found := strings.Cut(candidate, "=")
+		if found && validEnvKey(key) {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
+func validEnvKey(key string) bool {
+	if key == "" {
+		return false
+	}
+	for i, r := range key {
+		if i == 0 {
+			if !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || r == '_') {
+				return false
+			}
+			continue
+		}
+		if !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_') {
+			return false
+		}
+	}
+	return true
 }
 
 func ensureShellEntry(env []string, shell string) []string {

--- a/internal/shellenv/shellenv_test.go
+++ b/internal/shellenv/shellenv_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestResolve_UsesLoginShellAndCapturesEnv(t *testing.T) {
@@ -79,6 +80,23 @@ func TestParseEnvOutput_IgnoresShellNoiseBeforeEnv(t *testing.T) {
 	want := []string{"PATH=/resolved/bin", "HOME=/Users/test", "SPECIAL=1"}
 	if !reflect.DeepEqual(env, want) {
 		t.Fatalf("env = %v, want %v", env, want)
+	}
+}
+
+func TestDefaultShellCommandOutput_TimesOut(t *testing.T) {
+	oldTimeout := shellCommandTimeout
+	defer func() {
+		shellCommandTimeout = oldTimeout
+	}()
+
+	shellCommandTimeout = 20 * time.Millisecond
+	start := time.Now()
+	_, err := defaultShellCommandOutput("/bin/sh", "-c", "sleep 1")
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if elapsed := time.Since(start); elapsed >= 500*time.Millisecond {
+		t.Fatalf("command ran too long: %v", elapsed)
 	}
 }
 

--- a/internal/shellenv/shellenv_test.go
+++ b/internal/shellenv/shellenv_test.go
@@ -1,0 +1,83 @@
+package shellenv
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestResolve_UsesLoginShellAndCapturesEnv(t *testing.T) {
+	resetForTests()
+	t.Setenv("SHELL", "/bin/bash")
+
+	oldOutput := shellCommandOutput
+	defer func() {
+		shellCommandOutput = oldOutput
+		resetForTests()
+	}()
+
+	var gotShell string
+	var gotArgs []string
+	shellCommandOutput = func(shell string, args ...string) ([]byte, error) {
+		gotShell = shell
+		gotArgs = append([]string(nil), args...)
+		return []byte("PATH=/resolved/bin\x00HOME=/Users/test\x00SPECIAL=1\x00"), nil
+	}
+
+	env, err := Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotShell != "/bin/bash" {
+		t.Fatalf("shell = %q, want %q", gotShell, "/bin/bash")
+	}
+	if !reflect.DeepEqual(gotArgs, []string{"-l", "-i", "-c", "env -0"}) {
+		t.Fatalf("shell args = %v", gotArgs)
+	}
+	for _, want := range []string{"PATH=/resolved/bin", "HOME=/Users/test", "SPECIAL=1"} {
+		if !containsEnvEntry(env, want) {
+			t.Fatalf("expected resolved env to contain %q, got %v", want, env)
+		}
+	}
+}
+
+func TestApplyToProcess_SetsResolvedEnvEntries(t *testing.T) {
+	resetForTests()
+	t.Setenv("SHELL", "/bin/zsh")
+	t.Setenv("KEEP_ME", "1")
+
+	oldOutput := shellCommandOutput
+	defer func() {
+		shellCommandOutput = oldOutput
+		resetForTests()
+	}()
+
+	shellCommandOutput = func(shell string, args ...string) ([]byte, error) {
+		return []byte("PATH=/resolved/bin\x00HOME=/Users/test\x00SPECIAL=1\x00"), nil
+	}
+
+	if err := ApplyToProcess(); err != nil {
+		t.Fatal(err)
+	}
+	if got := os.Getenv("PATH"); got != "/resolved/bin" {
+		t.Fatalf("PATH = %q", got)
+	}
+	if got := os.Getenv("HOME"); got != "/Users/test" {
+		t.Fatalf("HOME = %q", got)
+	}
+	if got := os.Getenv("SPECIAL"); got != "1" {
+		t.Fatalf("SPECIAL = %q", got)
+	}
+	if got := os.Getenv("KEEP_ME"); got != "1" {
+		t.Fatalf("KEEP_ME = %q", got)
+	}
+}
+
+func containsEnvEntry(env []string, want string) bool {
+	for _, entry := range env {
+		if entry == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/shellenv/shellenv_test.go
+++ b/internal/shellenv/shellenv_test.go
@@ -73,6 +73,15 @@ func TestApplyToProcess_SetsResolvedEnvEntries(t *testing.T) {
 	}
 }
 
+func TestParseEnvOutput_IgnoresShellNoiseBeforeEnv(t *testing.T) {
+	env := parseEnvOutput([]byte("banner text\nPATH=/resolved/bin\x00HOME=/Users/test\x00SPECIAL=1\x00"))
+
+	want := []string{"PATH=/resolved/bin", "HOME=/Users/test", "SPECIAL=1"}
+	if !reflect.DeepEqual(env, want) {
+		t.Fatalf("env = %v, want %v", env, want)
+	}
+}
+
 func containsEnvEntry(env []string, want string) bool {
 	for _, entry := range env {
 		if entry == want {


### PR DESCRIPTION
## Summary
- add managed daemon service support across macOS, Linux, and Windows so `no-mistakes` can install and start the daemon through the OS service manager instead of only detached self-exec
- harden daemon startup and shutdown by falling back to detached mode when service-manager startup is unavailable or fails, and by bounding login-shell environment capture so daemon PATH discovery is more reliable
- update install flow, CLI text, README, and daemon/agent docs to explain managed-service behavior, fallback semantics, login-shell PATH handling, and where service artifacts are installed

## Risk Assessment

⚠️ Medium: The change is well-scoped and tested, but the managed-to-detached fallback path still has a startup/teardown race that can create duplicate daemon instances on some service managers.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

**Round 1** - found 3 issues (2 errors, 1 warning)
- 🚨 `internal/daemon/service.go:41` - `Start` now forces every macOS/Linux launch through `launchctl` or `systemctl --user` and returns that error directly, so environments without a GUI launchd session or without user systemd support can no longer start the daemon at all even though the old detached mode would have worked. Keep the managed-service path, but fall back to `startDetachedDaemon` when service installation/start fails.
- 🚨 `docs/install.sh:80` - The installer now runs `no-mistakes daemon start` under `set -e`, which means a service-manager startup failure aborts the install after the binary has already been copied and linked. That leaves users with a partial install and a non-zero installer exit on unsupported Linux/macOS setups.
- ⚠️ `internal/daemon/service.go:96` - `managedServiceInstalled` always returns true on Windows when `p != nil`, so `daemon stop` never falls back to the legacy IPC shutdown path. Detached or pre-existing daemons on Windows will now report a scheduled-task error instead of stopping cleanly.

**Round 2** (auto-fix) - found 3 issues (1 error, 2 warnings)
- 🚨 `internal/daemon/selfexec.go:143` - `Stop` assumes any existing launch agent/systemd unit means the running daemon is managed. If `Start` already fell back to detached mode after a service-manager failure, the unit/plist still exists, so `daemon stop` retries the broken service-manager path and returns that error instead of sending the IPC shutdown to the detached daemon. That leaves the fallback daemon impossible to stop cleanly in exactly the environments this change is meant to support.
- ⚠️ `internal/shellenv/shellenv.go:108` - `parseEnvOutput` accepts every stdout chunk from the interactive login shell as an environment entry. If a shell rc file prints banner text or other noise before `env -0`, the first real variable (often `PATH`) gets merged into a bogus key, so the daemon can start with a corrupted environment and fail to find required binaries.
- ⚠️ `docs/install.ps1:35` - The Windows installer now treats `no-mistakes.exe daemon start` as fatal because `$ErrorActionPreference = &#34;Stop&#34;` is still active. A transient scheduled-task startup failure will make the whole install report failure even though the binary was already installed, unlike the POSIX installer which degrades gracefully.

**Round 3** (auto-fix) - found 3 warnings
- ⚠️ `internal/daemon/daemon.go:66` - `prepareDaemonEnvironment` reapplies the full login-shell environment after `daemon run --root` sets `NM_HOME`, so any user shell config that exports a different `NM_HOME` will silently retarget the managed daemon away from the root baked into the service definition.
- ⚠️ `internal/daemon/service.go:19` - The managed service identifiers are global (`com.kunchenguid.no-mistakes.daemon` / `no-mistakes-daemon.service` / `no-mistakes-daemon`), so starting the daemon from a different `NM_HOME` rewrites the same service to point at a new root and breaks per-root isolation that the CLI otherwise supports.
- ⚠️ `internal/daemon/service.go:249` - The service templates start the daemon via `no-mistakes daemon run --root ...`, which still goes through normal CLI startup in `main()` before entering `daemon.Run()`. That means every service restart also runs update-check logic and background-check spawning, adding unrelated network/process side effects to daemon startup.

**Round 4** (auto-fix) - found 1 warning
- ⚠️ `internal/shellenv/shellenv.go:93` - Daemon startup now shells out with `-l -i -c &#39;env -0&#39;` and the subprocess has no timeout, so a valid `.bashrc`/`.zshrc` that prompts, blocks, or does slow startup work can hang `daemon start`, `init`, `attach`, installer auto-start, and update resets indefinitely. Run this env capture with a bounded context or avoid interactive mode on the startup path.

**Round 5** (auto-fix) - found 3 warnings
- ⚠️ `internal/daemon/selfexec.go:47` - When managed startup fails or just takes longer than the 5s health-check window, `Start` silently falls back to launching a detached daemon without first disabling/stopping the managed service. On systemd/launchd that can leave the managed unit retrying in the background while a second daemon is started manually, causing duplicate processes and socket churn.
- ⚠️ `cmd/no-mistakes/main.go:56` - The new `daemon run` short-circuit bypasses Cobra validation for any `daemon run ...` invocation. `no-mistakes daemon run --help` and unknown/extra flags now start the daemon instead of showing help or an error, because this parser treats every `daemon run` form as executable unless `--root` is missing its value.
- ⚠️ `internal/daemon/service.go:337` - Managed-service commands are executed with `exec.Command` and no timeout or context, so `daemon start`/`stop` can hang indefinitely if `launchctl`, `systemctl --user`, or `schtasks` blocks. This is a real operational risk on misconfigured or degraded machines.

**Round 6** (auto-fix) - found 1 warning
- ⚠️ `internal/daemon/selfexec.go:61` - When managed startup times out, `stopManagedFallback` treats a successful service-manager stop as immediate success and launches the detached fallback without waiting for the original daemon to exit. Backends like Task Scheduler can acknowledge the stop before teardown finishes, which can leave two daemons racing on the same root/socket.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>🔧 **Document** - 6 issues found → auto-fixed (5)</summary>

**Round 1** - found 6 issues (3 warnings, 3 infos)
- ⚠️ `README.md:67` - The README&#39;s Windows install section is now incomplete: `docs/install.ps1` starts the daemon after installing the binary, but this section does not mention the auto-started daemon service the way the macOS/Linux section and Getting Started guide do.
- ⚠️ `README.md:98` - The README still describes daemon management in pre-service terms. The update paragraph says `no-mistakes update` resets the background daemon, and the CLI reference rows below still say `update` resets the daemon and `daemon start` starts it in the background, but this branch changed those commands to manage a persistent OS service.
- ⚠️ `docs/src/content/docs/guides/daemon.md:6` - The daemon guide was updated to say a managed service exists, but it still does not document the new user-visible service behavior: which OS-level backend is installed (launchd, systemd user service, or Windows Task Scheduler) and that the daemon is now intended to persist/restart under that service manager. That troubleshooting detail became part of the feature surface in this branch.
- ℹ️ `internal/cli/daemon_cmd.go:78` - The Cobra help text for `no-mistakes daemon start` is stale. It still says `Start the daemon in the background`, but the command now installs or refreshes the managed daemon service before starting it.
- ℹ️ `internal/daemon/daemon.go:23` - The `Run` doc comment is stale. `daemon.Run()` is no longer invoked only when `NM_DAEMON=1`; `cmd/no-mistakes/main.go` now also routes the hidden `daemon run` subcommand through this entrypoint.
- ℹ️ `internal/daemon/selfexec.go:37` - The `Start` doc comment no longer matches the implementation. `Start` now prefers installing and starting a managed service, and only falls back to detached self-exec when service startup is unavailable or fails, so the comment should not describe detached `NM_DAEMON=1` re-exec as the only behavior.

**Round 2** (auto-fix) - found 5 warnings
- ⚠️ `README.md:153` - The README now describes `no-mistakes daemon start` as installing a daemon service, but the new startup code falls back to a detached daemon when managed-service setup or startup is unavailable or fails. The install and daemon sections should mention that fallback so users on systems without a working `launchd`/`systemd --user`/Task Scheduler path are not told the service path is the only behavior.
- ⚠️ `docs/src/content/docs/getting-started.md:61` - The getting-started flow says init &#39;ensures the background daemon service is installed and running&#39;, but `internal/daemon/selfexec.go` now falls back to a detached daemon if managed-service startup cannot be used. This guide should document that fallback in the install/init/update flow.
- ⚠️ `docs/src/content/docs/guides/daemon.md:6` - The daemon guide presents the new managed-service setup as the daemon model, but the implementation explicitly falls back to detached re-exec when service installation or startup fails. The guide should explain that the service manager is preferred, not mandatory, and note the fallback behavior.
- ⚠️ `docs/src/content/docs/how-it-works.md:61` - The architecture page says the installer and key commands keep a managed daemon service present and running, but it does not mention the new detached fallback path that is used when managed-service startup is unavailable or fails. That behavior change should be reflected here as well.
- ⚠️ `docs/src/content/docs/reference/cli.md:122` - The CLI reference documents `no-mistakes daemon start` only as managed-service installation/start, while the command now falls back to starting a detached daemon if the service manager path cannot be used. The `init`, `update`, and `daemon start` entries should call out that fallback so the reference matches the command&#39;s actual behavior.

**Round 3** (auto-fix) - found 2 warnings
- ⚠️ `docs/src/content/docs/guides/daemon.md:8` - The daemon guide documents managed-service installation and fallback, but it does not mention that managed-service launches now rebuild the daemon environment from the user&#39;s login shell before running. That new behavior is user-visible because it changes how PATH-based agent/binary discovery works under launchd, systemd, and Task Scheduler, and it explains why shell startup files now affect daemon-side tooling.
- ⚠️ `docs/src/content/docs/guides/agents.md:35` - The agent guide still says `agent: auto` resolves binaries from `PATH`, but it does not clarify that daemon-managed runs now source that PATH from the login shell environment. This should be documented alongside `agent_path_override` so users understand the new service-mode lookup behavior and when to use explicit binary overrides.

**Round 4** (auto-fix) - found 3 warnings
- ⚠️ `README.md:65` - The install section now says the installer starts the daemon automatically, but both `docs/install.sh` and `docs/install.ps1` treat `no-mistakes daemon start` as best-effort and can leave the daemon stopped if service setup or startup fails. Update the README install text to say startup is attempted and users may need to run `no-mistakes daemon start` manually.
- ⚠️ `docs/src/content/docs/getting-started.md:14` - The getting-started install text describes daemon startup as automatic, but the install scripts intentionally continue when `no-mistakes daemon start` fails. Update this guide to note that startup is best-effort and manual `no-mistakes daemon start` may still be required.
- ⚠️ `docs/src/content/docs/reference/cli.md:130` - The CLI reference for `no-mistakes daemon stop` only says it stops the running process. With the new managed-service behavior, the command leaves the launchd/systemd/Task Scheduler registration in place, so the docs should say the service is not removed and later `daemon start`/`init`/`attach`/`rerun`/`update` can start it again.

**Round 5** (auto-fix) - found 1 warning
- ⚠️ `docs/src/content/docs/guides/daemon.md:8` - The new managed-daemon feature explains that `launchd`, `systemd --user`, or Task Scheduler is used, but it never documents the actual service artifacts that get installed. Add the concrete locations/names introduced by the change so users can inspect or troubleshoot them: `~/Library/LaunchAgents/com.kunchenguid.no-mistakes.daemon.plist`, `~/.config/systemd/user/no-mistakes-daemon.service`, and the Windows task name `no-mistakes-daemon`.

**Round 6** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
