### PR TITLE
fix(review): clarify review prompt to avoid running tests

### DIFF
--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -139,6 +139,7 @@ Context:
 Task:
 - Read the relevant history and diff yourself.
 - focus only on changed code.
+- Do NOT run tests during review. The pipeline has a dedicated test step after review.
 - Analyze for bugs, risks, and code simplification opportunities.
 - "Simplification" means reducing code complexity through non-functional refactoring (e.g. deduplication, clearer control flow). It does NOT mean removing features, changing product behavior, or stripping intentional user-facing output.
 - Treat security issues, performance regressions, breaking changes, and insufficient error handling as risks.

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1964,6 +1964,9 @@ func TestReviewStep_WithWarnings(t *testing.T) {
 	if !strings.Contains(ag.calls[0].Prompt, "Do not stop after the first valid finding.") {
 		t.Error("expected review prompt to discourage stopping at the first finding")
 	}
+	if !strings.Contains(ag.calls[0].Prompt, "Do NOT run tests during review.") {
+		t.Error("expected review prompt to avoid running tests during review")
+	}
 }
 
 func TestReviewStep_Clean(t *testing.T) {


### PR DESCRIPTION
## Summary
- Update the review step prompt to explicitly tell the reviewer not to run tests, keeping review focused on code analysis instead of duplicate execution.
- Add coverage in `internal/pipeline/steps/steps_test.go` to lock in the new review prompt wording and prevent regressions.

## Risk Assessment

✅ Low: The change is a single prompt constraint plus a matching test assertion, and it stays aligned with the pipeline's default review-then-test flow without altering execution logic.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
