### PR TITLE
feat(bitbucket): add Bitbucket Cloud PR and CI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ agent_path_override:
   rovodev: /usr/local/bin/acli
   opencode: /usr/local/bin/opencode
 
-# How long the CI step waits for checks and PR mergeability before timing out.
+# How long the CI step waits for provider CI status, and GitHub PR mergeability, before timing out.
 ci_timeout: "4h"
 
 # debug | info | warn | error

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ make build
 make install
 ```
 
-You will also need `git` and one supported agent binary. For PR creation, install `gh` (GitHub) or `glab` (GitLab), or set `NO_MISTAKES_BITBUCKET_EMAIL` and `NO_MISTAKES_BITBUCKET_API_TOKEN` for Bitbucket. CI monitoring supports GitHub via `gh` and Bitbucket via those Bitbucket API credentials.
+You will also need `git` and one supported agent binary. For PR creation, install `gh` (GitHub) or `glab` (GitLab), or set `NO_MISTAKES_BITBUCKET_EMAIL` and `NO_MISTAKES_BITBUCKET_API_TOKEN` for Bitbucket Cloud. CI monitoring supports GitHub via `gh` and Bitbucket Cloud via those Bitbucket API credentials.
 
 Full documentation is published at <https://kunchenguid.github.io/no-mistakes/>.
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ make build
 make install
 ```
 
-You will also need `git` and one supported agent binary. For PR creation, install `gh` (GitHub) or `glab` (GitLab). CI monitoring currently only supports Github.
+You will also need `git` and one supported agent binary. For PR creation, install `gh` (GitHub) or `glab` (GitLab), or set `NO_MISTAKES_BITBUCKET_EMAIL` and `NO_MISTAKES_BITBUCKET_API_TOKEN` for Bitbucket. CI monitoring supports GitHub via `gh` and Bitbucket via those Bitbucket API credentials.
 
 Full documentation is published at <https://kunchenguid.github.io/no-mistakes/>.
 

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -40,8 +40,9 @@ make install
 
 - **git** - required
 - **One supported agent binary** - `claude`, `codex`, `acli` (Rovo Dev), or `opencode`
-- **gh** (GitHub CLI) or **glab** (GitLab CLI) - optional, needed for PR/MR creation
-- **gh** (GitHub CLI) - optional, needed for CI monitoring
+- **gh** (GitHub CLI) or **glab** (GitLab CLI) - optional, needed for GitHub/GitLab PR creation
+- **Bitbucket API credentials** - optional, needed for Bitbucket PR creation and CI monitoring: `NO_MISTAKES_BITBUCKET_EMAIL` and `NO_MISTAKES_BITBUCKET_API_TOKEN`
+- **gh** (GitHub CLI) - optional, needed for GitHub CI monitoring
 
 Run `no-mistakes doctor` to check what's installed and ready.
 

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -102,7 +102,7 @@ The pipeline runs these steps in order:
 5. **Lint** - run linters (configured command or agent-detected)
 6. **Push** - push to the real upstream remote
 7. **PR** - create or update a pull request
-8. **CI** - poll CI, watch PR mergeability, and auto-fix failures or merge conflicts
+8. **CI** - poll CI, and on GitHub also watch PR mergeability, then auto-fix CI failures or merge conflicts when supported
 
 Steps that find issues pause for your approval. You can approve, fix, skip, or abort. See [Pipeline Steps](/no-mistakes/guides/pipeline-steps/) and [Auto-Fix](/no-mistakes/guides/auto-fix/) for details.
 

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -41,7 +41,7 @@ make install
 - **git** - required
 - **One supported agent binary** - `claude`, `codex`, `acli` (Rovo Dev), or `opencode`
 - **gh** (GitHub CLI) or **glab** (GitLab CLI) - optional, needed for GitHub/GitLab PR creation
-- **Bitbucket API credentials** - optional, needed for Bitbucket PR creation and CI monitoring: `NO_MISTAKES_BITBUCKET_EMAIL` and `NO_MISTAKES_BITBUCKET_API_TOKEN`
+- **Bitbucket API credentials** - optional, needed for Bitbucket Cloud PR creation and CI monitoring: `NO_MISTAKES_BITBUCKET_EMAIL` and `NO_MISTAKES_BITBUCKET_API_TOKEN`
 - **gh** (GitHub CLI) - optional, needed for GitHub CI monitoring
 
 Run `no-mistakes doctor` to check what's installed and ready.

--- a/docs/src/content/docs/guides/auto-fix.md
+++ b/docs/src/content/docs/guides/auto-fix.md
@@ -27,14 +27,14 @@ auto_fix:
   test: 3
   document: 3
   lint: 3
-  ci: 3        # shared by CI for failures and merge conflicts
+  ci: 3        # shared by CI for failures, and on GitHub for merge conflicts
 ```
 
 Setting a step to `0` means the pipeline always pauses for human input when that step finds issues.
 
 `auto_fix.review` defaults to `0`, so review findings require manual approval unless you opt in.
 
-`auto_fix.ci` applies to the CI step. The same limit covers both CI-failure fixes and merge-conflict fixes.
+`auto_fix.ci` applies to the CI step. The same limit covers CI-failure fixes for supported providers, plus merge-conflict fixes on GitHub.
 
 Repo config overlays global config - you can set `auto_fix.lint: 5` in a repo's `.no-mistakes.yaml` to override just that step while inheriting the rest from global.
 

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -30,7 +30,7 @@ agent_path_override:
   rovodev: /usr/local/bin/acli
   opencode: /usr/local/bin/opencode
 
-# How long the CI step waits for checks and PR mergeability before timing out.
+# How long the CI step waits for provider CI status, and GitHub PR mergeability, before timing out.
 ci_timeout: "4h"  # any Go duration string
 
 # Daemon log verbosity.
@@ -47,6 +47,14 @@ auto_fix:
 ```
 
 See [Global Config Reference](/no-mistakes/reference/global-config/) for the full field listing.
+
+## Environment variables
+
+Bitbucket Cloud PR creation and CI monitoring use environment variables instead of a provider CLI:
+
+- `NO_MISTAKES_BITBUCKET_EMAIL`
+- `NO_MISTAKES_BITBUCKET_API_TOKEN`
+- `NO_MISTAKES_BITBUCKET_API_BASE_URL` - optional API base URL override
 
 ## Repo config
 

--- a/docs/src/content/docs/guides/pipeline-steps.md
+++ b/docs/src/content/docs/guides/pipeline-steps.md
@@ -108,15 +108,15 @@ Creates or updates a pull request.
 
 **Skipped when:**
 - The branch is the default branch
-- The upstream host is not GitHub, GitLab, or Bitbucket
+- The upstream host is not GitHub, GitLab, or Bitbucket Cloud (`bitbucket.org`)
 - The provider CLI (`gh` or `glab`) is not installed for GitHub or GitLab
 - The provider CLI is not authenticated for GitHub or GitLab
-- Bitbucket credentials are missing (`NO_MISTAKES_BITBUCKET_EMAIL` or `NO_MISTAKES_BITBUCKET_API_TOKEN`)
+- Bitbucket Cloud credentials are missing (`NO_MISTAKES_BITBUCKET_EMAIL` or `NO_MISTAKES_BITBUCKET_API_TOKEN`)
 
 **Behavior:**
 - Checks for an existing PR on the branch
 - If one exists, updates it. If not, creates a new one.
-- Uses the provider CLI for GitHub/GitLab and the Bitbucket API for Bitbucket
+- Uses the provider CLI for GitHub/GitLab and the Bitbucket API for Bitbucket Cloud
 - PR title: agent-generated in conventional commit format (`type(scope): description`)
 - PR body includes: an agent-authored `## Summary` plus regenerated `## Risk Assessment`, `## Testing`, and `## Pipeline` sections from recorded step results and rounds
 
@@ -126,17 +126,17 @@ Stores the PR URL in the database and streams it to the TUI.
 
 Monitors PR health after creation and auto-fixes CI failures or merge conflicts.
 
-**Active for GitHub and Bitbucket**.
+**Active for GitHub and Bitbucket Cloud (`bitbucket.org`)**.
 
 - GitHub requires `gh` CLI, installed and authenticated.
-- Bitbucket requires `NO_MISTAKES_BITBUCKET_EMAIL` and `NO_MISTAKES_BITBUCKET_API_TOKEN`.
+- Bitbucket Cloud requires `NO_MISTAKES_BITBUCKET_EMAIL` and `NO_MISTAKES_BITBUCKET_API_TOKEN`.
 
 **Behavior:**
 - Polls provider CI status at increasing intervals: every 30s for the first 5 minutes, every 60s for 5-15 minutes, every 120s after that
 - On GitHub, polls `gh pr view --json mergeable` alongside CI checks and waits for GitHub to resolve mergeability before exiting
 - Waits a 60s grace period before trusting empty results (CI checks may not have registered yet)
 - If CI failures or a merge conflict are already known while other checks are still pending: waits for all checks to finish before attempting an auto-fix
-- On CI failure: fetches failed job logs (GitHub via `gh run view --log-failed`, Bitbucket via failed pipeline step logs), sends them to the agent for fixing, and commits and force-pushes only if the agent produces changes
+- On CI failure: fetches failed job logs (GitHub via `gh run view --log-failed`, Bitbucket Cloud via failed pipeline step logs), sends them to the agent for fixing, and commits and force-pushes only if the agent produces changes
 - On merge conflict: asks the agent to rebase onto the latest default-branch tip and resolve the conflicts with minimal changes
 - If both CI failures and merge conflicts are present: fixes both in the same attempt
 - If a fix attempt produces no changes: automatic mode leaves the failure undeduplicated so it can retry until the auto-fix limit, while manual fix mode returns immediately for manual intervention

--- a/docs/src/content/docs/guides/pipeline-steps.md
+++ b/docs/src/content/docs/guides/pipeline-steps.md
@@ -108,13 +108,15 @@ Creates or updates a pull request.
 
 **Skipped when:**
 - The branch is the default branch
-- The upstream host is not GitHub or GitLab
-- The SCM CLI (`gh` or `glab`) is not installed
-- The CLI is not authenticated
+- The upstream host is not GitHub, GitLab, or Bitbucket
+- The provider CLI (`gh` or `glab`) is not installed for GitHub or GitLab
+- The provider CLI is not authenticated for GitHub or GitLab
+- Bitbucket credentials are missing (`NO_MISTAKES_BITBUCKET_EMAIL` or `NO_MISTAKES_BITBUCKET_API_TOKEN`)
 
 **Behavior:**
 - Checks for an existing PR on the branch
 - If one exists, updates it. If not, creates a new one.
+- Uses the provider CLI for GitHub/GitLab and the Bitbucket API for Bitbucket
 - PR title: agent-generated in conventional commit format (`type(scope): description`)
 - PR body includes: an agent-authored `## Summary` plus regenerated `## Risk Assessment`, `## Testing`, and `## Pipeline` sections from recorded step results and rounds
 
@@ -124,19 +126,22 @@ Stores the PR URL in the database and streams it to the TUI.
 
 Monitors PR health after creation and auto-fixes CI failures or merge conflicts.
 
-**Only active for GitHub** (requires `gh` CLI, authenticated).
+**Active for GitHub and Bitbucket**.
+
+- GitHub requires `gh` CLI, installed and authenticated.
+- Bitbucket requires `NO_MISTAKES_BITBUCKET_EMAIL` and `NO_MISTAKES_BITBUCKET_API_TOKEN`.
 
 **Behavior:**
-- Polls `gh pr checks` at increasing intervals: every 30s for the first 5 minutes, every 60s for 5-15 minutes, every 120s after that
-- Polls `gh pr view --json mergeable` alongside CI checks and waits for GitHub to resolve mergeability before exiting
+- Polls provider CI status at increasing intervals: every 30s for the first 5 minutes, every 60s for 5-15 minutes, every 120s after that
+- On GitHub, polls `gh pr view --json mergeable` alongside CI checks and waits for GitHub to resolve mergeability before exiting
 - Waits a 60s grace period before trusting empty results (CI checks may not have registered yet)
 - If CI failures or a merge conflict are already known while other checks are still pending: waits for all checks to finish before attempting an auto-fix
-- On CI failure: fetches the failed run log (last 32KiB via `gh run view --log-failed`), sends it to the agent for fixing, and commits and force-pushes only if the agent produces changes
+- On CI failure: fetches failed job logs (GitHub via `gh run view --log-failed`, Bitbucket via failed pipeline step logs), sends them to the agent for fixing, and commits and force-pushes only if the agent produces changes
 - On merge conflict: asks the agent to rebase onto the latest default-branch tip and resolve the conflicts with minimal changes
 - If both CI failures and merge conflicts are present: fixes both in the same attempt
 - If a fix attempt produces no changes: automatic mode leaves the failure undeduplicated so it can retry until the auto-fix limit, while manual fix mode returns immediately for manual intervention
 - Deduplicates fix attempts only after a fix is actually committed and pushed
-- Exits cleanly when the PR is merged or closed, or when the timeout is reached with no known CI failures, merge conflicts, or unresolved mergeability state (default 4h)
+- Exits cleanly when the PR is merged, closed, or declined, or when the timeout is reached with no known CI failures, merge conflicts, or unresolved mergeability state (default 4h)
 - If the timeout is reached while CI failures or a merge conflict are still known: pauses for user approval with findings for the remaining issues
 - If the timeout is reached while PR mergeability is still unresolved: pauses for user approval with a finding describing the unresolved mergeability state
 - If CI failures or merge conflicts persist after the auto-fix limit: pauses for user approval with findings listing each failing check and/or the merge conflict

--- a/docs/src/content/docs/guides/pipeline-steps.md
+++ b/docs/src/content/docs/guides/pipeline-steps.md
@@ -124,7 +124,7 @@ Stores the PR URL in the database and streams it to the TUI.
 
 ## CI
 
-Monitors PR health after creation and auto-fixes CI failures or merge conflicts.
+Monitors PR health after creation and auto-fixes CI failures. Mergeability polling and merge-conflict handling currently remain GitHub-only.
 
 **Active for GitHub and Bitbucket Cloud (`bitbucket.org`)**.
 
@@ -135,16 +135,16 @@ Monitors PR health after creation and auto-fixes CI failures or merge conflicts.
 - Polls provider CI status at increasing intervals: every 30s for the first 5 minutes, every 60s for 5-15 minutes, every 120s after that
 - On GitHub, polls `gh pr view --json mergeable` alongside CI checks and waits for GitHub to resolve mergeability before exiting
 - Waits a 60s grace period before trusting empty results (CI checks may not have registered yet)
-- If CI failures or a merge conflict are already known while other checks are still pending: waits for all checks to finish before attempting an auto-fix
+- If CI failures or, on GitHub, a merge conflict are already known while other checks are still pending: waits for all checks to finish before attempting an auto-fix
 - On CI failure: fetches failed job logs (GitHub via `gh run view --log-failed`, Bitbucket Cloud via failed pipeline step logs), sends them to the agent for fixing, and commits and force-pushes only if the agent produces changes
-- On merge conflict: asks the agent to rebase onto the latest default-branch tip and resolve the conflicts with minimal changes
-- If both CI failures and merge conflicts are present: fixes both in the same attempt
+- On GitHub merge conflict: asks the agent to rebase onto the latest default-branch tip and resolve the conflicts with minimal changes
+- If both CI failures and a GitHub merge conflict are present: fixes both in the same attempt
 - If a fix attempt produces no changes: automatic mode leaves the failure undeduplicated so it can retry until the auto-fix limit, while manual fix mode returns immediately for manual intervention
 - Deduplicates fix attempts only after a fix is actually committed and pushed
 - Exits cleanly when the PR is merged, closed, or declined, or when the timeout is reached with no known CI failures, merge conflicts, or unresolved mergeability state (default 4h)
-- If the timeout is reached while CI failures or a merge conflict are still known: pauses for user approval with findings for the remaining issues
-- If the timeout is reached while PR mergeability is still unresolved: pauses for user approval with a finding describing the unresolved mergeability state
-- If CI failures or merge conflicts persist after the auto-fix limit: pauses for user approval with findings listing each failing check and/or the merge conflict
+- If the timeout is reached while CI failures or, on GitHub, a merge conflict are still known: pauses for user approval with findings for the remaining issues
+- If the timeout is reached while GitHub PR mergeability is still unresolved: pauses for user approval with a finding describing the unresolved mergeability state
+- If CI failures or a GitHub merge conflict persist after the auto-fix limit: pauses for user approval with findings listing each failing check and/or the merge conflict
 
 **Default auto-fix limit:** `3` total CI auto-fix attempts.
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -30,7 +30,7 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
     pick what to fix, and decide when to ship.
   </Card>
   <Card title="CI monitoring" icon="sun">
-    After push, the pipeline watches CI and PR mergeability, and auto-fixes
-    failures or merge conflicts before the branch is considered done.
+    After push, the pipeline watches CI and auto-fixes failures. On GitHub it
+    also watches PR mergeability and can fix merge conflicts.
   </Card>
 </CardGrid>

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -105,7 +105,7 @@ Checks:
 
 Uses indicators: `✓` (available), `–` (not found, optional), `✗` (problem detected).
 
-For GitLab PR steps, install `glab`. For Bitbucket PR and CI steps, set `NO_MISTAKES_BITBUCKET_EMAIL` and `NO_MISTAKES_BITBUCKET_API_TOKEN`.
+For GitLab PR steps, install `glab`. For Bitbucket Cloud PR and CI steps, set `NO_MISTAKES_BITBUCKET_EMAIL` and `NO_MISTAKES_BITBUCKET_API_TOKEN`.
 
 ## no-mistakes update
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -97,13 +97,15 @@ no-mistakes doctor
 
 Checks:
 - `git` binary
-- `gh` CLI (optional, needed for PR and CI steps)
+- `gh` CLI (optional, needed for GitHub PR and CI steps)
 - Data directory (`~/.no-mistakes/`)
 - SQLite database
 - Daemon status
 - Agent binaries: `claude`, `codex`, `acli`, `opencode`
 
 Uses indicators: `✓` (available), `–` (not found, optional), `✗` (problem detected).
+
+For GitLab PR steps, install `glab`. For Bitbucket PR and CI steps, set `NO_MISTAKES_BITBUCKET_EMAIL` and `NO_MISTAKES_BITBUCKET_API_TOKEN`.
 
 ## no-mistakes update
 

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -110,7 +110,7 @@ These are global defaults. Per-repo config can override individual steps.
 | Variable | Description |
 |---|---|
 | `NM_HOME` | Override the data directory (default `~/.no-mistakes/`) |
-| `NO_MISTAKES_BITBUCKET_EMAIL` | Bitbucket email used for Bitbucket PR creation and CI monitoring |
-| `NO_MISTAKES_BITBUCKET_API_TOKEN` | Bitbucket API token used for Bitbucket PR creation and CI monitoring |
-| `NO_MISTAKES_BITBUCKET_API_BASE_URL` | Override the Bitbucket API base URL (optional) |
+| `NO_MISTAKES_BITBUCKET_EMAIL` | Bitbucket Cloud email used for Bitbucket Cloud PR creation and CI monitoring |
+| `NO_MISTAKES_BITBUCKET_API_TOKEN` | Bitbucket Cloud API token used for Bitbucket Cloud PR creation and CI monitoring |
+| `NO_MISTAKES_BITBUCKET_API_BASE_URL` | Override the Bitbucket Cloud API base URL (optional) |
 | `NO_MISTAKES_NO_UPDATE_CHECK` | Set to `1` to suppress background update checks |

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -110,4 +110,7 @@ These are global defaults. Per-repo config can override individual steps.
 | Variable | Description |
 |---|---|
 | `NM_HOME` | Override the data directory (default `~/.no-mistakes/`) |
+| `NO_MISTAKES_BITBUCKET_EMAIL` | Bitbucket email used for Bitbucket PR creation and CI monitoring |
+| `NO_MISTAKES_BITBUCKET_API_TOKEN` | Bitbucket API token used for Bitbucket PR creation and CI monitoring |
+| `NO_MISTAKES_BITBUCKET_API_BASE_URL` | Override the Bitbucket API base URL (optional) |
 | `NO_MISTAKES_NO_UPDATE_CHECK` | Set to `1` to suppress background update checks |

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -63,7 +63,7 @@ Default binary names when no override is set:
 
 ### ci_timeout
 
-How long the CI step waits for checks and PR mergeability before timing out.
+How long the CI step waits for provider CI status, and on GitHub for PR mergeability, before timing out.
 
 | | |
 |---|---|
@@ -99,7 +99,7 @@ Maximum auto-fix attempts per step. Set a step to `0` to disable auto-fix (findi
 | `auto_fix.test` | `int` | `3` | Test failure auto-fix attempts |
 | `auto_fix.document` | `int` | `3` | Documentation update auto-fix attempts |
 | `auto_fix.lint` | `int` | `3` | Lint issue auto-fix attempts |
-| `auto_fix.ci` | `int` | `3` | CI auto-fix attempts for CI failures and merge conflicts |
+| `auto_fix.ci` | `int` | `3` | CI auto-fix attempts for CI failures, plus GitHub merge conflicts |
 
 Legacy alias: `auto_fix.babysit`.
 

--- a/internal/bitbucket/client.go
+++ b/internal/bitbucket/client.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 )
@@ -344,5 +343,5 @@ func lookupEnv(env []string, key string) string {
 			return strings.TrimPrefix(entry, prefix)
 		}
 	}
-	return os.Getenv(key)
+	return ""
 }

--- a/internal/bitbucket/client.go
+++ b/internal/bitbucket/client.go
@@ -112,9 +112,14 @@ func parseRepoPath(path string) (RepoRef, error) {
 	return RepoRef{Workspace: parts[0], RepoSlug: parts[1]}, nil
 }
 
-func (c *Client) FindOpenPRBySourceBranch(ctx context.Context, repo RepoRef, branch string) (*PullRequest, error) {
+func (c *Client) FindOpenPRBySourceBranch(ctx context.Context, repo RepoRef, branch, destBranch string) (*PullRequest, error) {
 	query := url.Values{}
-	query.Set("q", fmt.Sprintf(`source.branch.name=%q AND state=%q`, branch, "OPEN"))
+	clauses := []string{fmt.Sprintf(`source.branch.name=%q`, branch)}
+	if strings.TrimSpace(destBranch) != "" {
+		clauses = append(clauses, fmt.Sprintf(`destination.branch.name=%q`, destBranch))
+	}
+	clauses = append(clauses, fmt.Sprintf(`state=%q`, "OPEN"))
+	query.Set("q", strings.Join(clauses, " AND "))
 
 	var response struct {
 		Values []bitbucketPullRequest `json:"values"`

--- a/internal/bitbucket/client.go
+++ b/internal/bitbucket/client.go
@@ -96,7 +96,8 @@ func ParseRepoRef(raw string) (RepoRef, error) {
 	if err != nil {
 		return RepoRef{}, fmt.Errorf("parse bitbucket repo URL: %w", err)
 	}
-	if !strings.Contains(strings.ToLower(parsed.Host), "bitbucket.org") {
+	host := strings.ToLower(parsed.Hostname())
+	if host != "bitbucket.org" && !strings.HasSuffix(host, ".bitbucket.org") {
 		return RepoRef{}, fmt.Errorf("unsupported Bitbucket host %q", parsed.Host)
 	}
 	return parseRepoPath(strings.TrimPrefix(parsed.Path, "/"))

--- a/internal/bitbucket/client.go
+++ b/internal/bitbucket/client.go
@@ -164,13 +164,20 @@ func (c *Client) GetPR(ctx context.Context, repo RepoRef, prID int) (*PullReques
 }
 
 func (c *Client) ListPRStatuses(ctx context.Context, repo RepoRef, prID int) ([]CommitStatus, error) {
-	var response struct {
-		Values []CommitStatus `json:"values"`
+	next := fmt.Sprintf("%s/%d/statuses", repoPRPath(repo), prID)
+	statuses := make([]CommitStatus, 0)
+	for next != "" {
+		var response struct {
+			Values []CommitStatus `json:"values"`
+			Next   string         `json:"next"`
+		}
+		if err := c.doJSONPathOrURL(ctx, http.MethodGet, next, nil, &response); err != nil {
+			return nil, err
+		}
+		statuses = append(statuses, response.Values...)
+		next = response.Next
 	}
-	if err := c.doJSON(ctx, http.MethodGet, fmt.Sprintf("%s/%d/statuses", repoPRPath(repo), prID), nil, nil, &response); err != nil {
-		return nil, err
-	}
-	return response.Values, nil
+	return statuses, nil
 }
 
 func (c *Client) ListPipelinesByCommit(ctx context.Context, repo RepoRef, commitSHA string) ([]Pipeline, error) {
@@ -237,6 +244,14 @@ func (pr bitbucketPullRequest) toPullRequest() *PullRequest {
 }
 
 func (c *Client) doJSON(ctx context.Context, method, path string, query url.Values, requestBody any, responseBody any) error {
+	endpoint := c.baseURL + path
+	if len(query) > 0 {
+		endpoint += "?" + query.Encode()
+	}
+	return c.doJSONPathOrURL(ctx, method, endpoint, requestBody, responseBody)
+}
+
+func (c *Client) doJSONPathOrURL(ctx context.Context, method, pathOrURL string, requestBody any, responseBody any) error {
 	var bodyReader io.Reader = http.NoBody
 	if requestBody != nil {
 		payload, err := json.Marshal(requestBody)
@@ -246,9 +261,10 @@ func (c *Client) doJSON(ctx context.Context, method, path string, query url.Valu
 		bodyReader = bytes.NewReader(payload)
 	}
 
-	endpoint := c.baseURL + path
-	if len(query) > 0 {
-		endpoint += "?" + query.Encode()
+	endpoint := pathOrURL
+	requestLabel := pathOrURL
+	if !strings.HasPrefix(pathOrURL, "http://") && !strings.HasPrefix(pathOrURL, "https://") {
+		endpoint = c.baseURL + pathOrURL
 	}
 	req, err := http.NewRequestWithContext(ctx, method, endpoint, bodyReader)
 	if err != nil {
@@ -262,13 +278,13 @@ func (c *Client) doJSON(ctx context.Context, method, path string, query url.Valu
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("Bitbucket %s %s: %w", method, path, err)
+		return fmt.Errorf("Bitbucket %s %s: %w", method, requestLabel, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		data, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("Bitbucket %s %s: status %d: %s", method, path, resp.StatusCode, strings.TrimSpace(string(data)))
+		return fmt.Errorf("Bitbucket %s %s: status %d: %s", method, requestLabel, resp.StatusCode, strings.TrimSpace(string(data)))
 	}
 	if responseBody == nil {
 		return nil

--- a/internal/bitbucket/client.go
+++ b/internal/bitbucket/client.go
@@ -26,9 +26,10 @@ type RepoRef struct {
 }
 
 type PullRequest struct {
-	ID    int
-	URL   string
-	State string
+	ID               int
+	URL              string
+	State            string
+	SourceCommitHash string
 }
 
 type CommitStatus struct {
@@ -175,6 +176,14 @@ func (c *Client) ListPRStatuses(ctx context.Context, repo RepoRef, prID int) ([]
 			return nil, err
 		}
 		statuses = append(statuses, response.Values...)
+		if response.Next != "" {
+			validatedNext, err := c.validatePaginationURL(response.Next)
+			if err != nil {
+				return nil, err
+			}
+			next = validatedNext
+			continue
+		}
 		next = response.Next
 	}
 	return statuses, nil
@@ -230,8 +239,13 @@ func (c *Client) GetStepLog(ctx context.Context, repo RepoRef, pipelineUUID, ste
 }
 
 type bitbucketPullRequest struct {
-	ID    int    `json:"id"`
-	State string `json:"state"`
+	ID     int    `json:"id"`
+	State  string `json:"state"`
+	Source struct {
+		Commit struct {
+			Hash string `json:"hash"`
+		} `json:"commit"`
+	} `json:"source"`
 	Links struct {
 		HTML struct {
 			Href string `json:"href"`
@@ -240,7 +254,30 @@ type bitbucketPullRequest struct {
 }
 
 func (pr bitbucketPullRequest) toPullRequest() *PullRequest {
-	return &PullRequest{ID: pr.ID, URL: strings.TrimSpace(pr.Links.HTML.Href), State: strings.TrimSpace(pr.State)}
+	return &PullRequest{
+		ID:               pr.ID,
+		URL:              strings.TrimSpace(pr.Links.HTML.Href),
+		State:            strings.TrimSpace(pr.State),
+		SourceCommitHash: strings.TrimSpace(pr.Source.Commit.Hash),
+	}
+}
+
+func (c *Client) validatePaginationURL(rawURL string) (string, error) {
+	base, err := url.Parse(c.baseURL)
+	if err != nil {
+		return "", fmt.Errorf("parse Bitbucket base URL: %w", err)
+	}
+	nextURL, err := url.Parse(rawURL)
+	if err != nil {
+		return "", fmt.Errorf("parse Bitbucket pagination URL: %w", err)
+	}
+	if !nextURL.IsAbs() {
+		return rawURL, nil
+	}
+	if !strings.EqualFold(nextURL.Scheme, base.Scheme) || !strings.EqualFold(nextURL.Host, base.Host) {
+		return "", fmt.Errorf("reject cross-origin Bitbucket pagination URL %q", rawURL)
+	}
+	return rawURL, nil
 }
 
 func (c *Client) doJSON(ctx context.Context, method, path string, query url.Values, requestBody any, responseBody any) error {

--- a/internal/bitbucket/client.go
+++ b/internal/bitbucket/client.go
@@ -114,7 +114,10 @@ func parseRepoPath(path string) (RepoRef, error) {
 
 func (c *Client) FindOpenPRBySourceBranch(ctx context.Context, repo RepoRef, branch, destBranch string) (*PullRequest, error) {
 	query := url.Values{}
-	clauses := []string{fmt.Sprintf(`source.branch.name=%q`, branch)}
+	clauses := []string{
+		fmt.Sprintf(`source.branch.name=%q`, branch),
+		fmt.Sprintf(`source.repository.full_name=%q`, repo.Workspace+"/"+repo.RepoSlug),
+	}
 	if strings.TrimSpace(destBranch) != "" {
 		clauses = append(clauses, fmt.Sprintf(`destination.branch.name=%q`, destBranch))
 	}

--- a/internal/bitbucket/client.go
+++ b/internal/bitbucket/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 )
@@ -415,6 +416,9 @@ func lookupEnv(env []string, key string) string {
 		if strings.HasPrefix(entry, prefix) {
 			return strings.TrimPrefix(entry, prefix)
 		}
+	}
+	if value, ok := os.LookupEnv(key); ok {
+		return value
 	}
 	return ""
 }

--- a/internal/bitbucket/client.go
+++ b/internal/bitbucket/client.go
@@ -1,0 +1,294 @@
+package bitbucket
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	defaultAPIBaseURL = "https://api.bitbucket.org"
+	envEmail          = "NO_MISTAKES_BITBUCKET_EMAIL"
+	envToken          = "NO_MISTAKES_BITBUCKET_API_TOKEN"
+	envAPIBaseURL     = "NO_MISTAKES_BITBUCKET_API_BASE_URL"
+)
+
+type RepoRef struct {
+	Workspace string
+	RepoSlug  string
+}
+
+type PullRequest struct {
+	ID    int
+	URL   string
+	State string
+}
+
+type CommitStatus struct {
+	Name        string `json:"name"`
+	State       string `json:"state"`
+	Description string `json:"description"`
+	URL         string `json:"url"`
+}
+
+type Pipeline struct {
+	UUID string `json:"uuid"`
+}
+
+type PipelineStep struct {
+	UUID  string `json:"uuid"`
+	State struct {
+		Name   string `json:"name"`
+		Result struct {
+			Name string `json:"name"`
+		} `json:"result"`
+	} `json:"state"`
+}
+
+type Client struct {
+	baseURL    string
+	email      string
+	token      string
+	httpClient *http.Client
+}
+
+func NewClientFromEnv(env []string) (*Client, error) {
+	email := lookupEnv(env, envEmail)
+	if strings.TrimSpace(email) == "" {
+		return nil, fmt.Errorf("missing %s", envEmail)
+	}
+	token := lookupEnv(env, envToken)
+	if strings.TrimSpace(token) == "" {
+		return nil, fmt.Errorf("missing %s", envToken)
+	}
+	baseURL := lookupEnv(env, envAPIBaseURL)
+	if strings.TrimSpace(baseURL) == "" {
+		baseURL = defaultAPIBaseURL
+	}
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		email:   email,
+		token:   token,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}, nil
+}
+
+func ParseRepoRef(raw string) (RepoRef, error) {
+	trimmed := strings.TrimSpace(raw)
+	trimmed = strings.TrimSuffix(trimmed, ".git")
+
+	if strings.HasPrefix(trimmed, "git@bitbucket.org:") {
+		path := strings.TrimPrefix(trimmed, "git@bitbucket.org:")
+		return parseRepoPath(path)
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return RepoRef{}, fmt.Errorf("parse bitbucket repo URL: %w", err)
+	}
+	if !strings.Contains(strings.ToLower(parsed.Host), "bitbucket.org") {
+		return RepoRef{}, fmt.Errorf("unsupported Bitbucket host %q", parsed.Host)
+	}
+	return parseRepoPath(strings.TrimPrefix(parsed.Path, "/"))
+}
+
+func parseRepoPath(path string) (RepoRef, error) {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) < 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return RepoRef{}, fmt.Errorf("invalid Bitbucket repository path %q", path)
+	}
+	return RepoRef{Workspace: parts[0], RepoSlug: parts[1]}, nil
+}
+
+func (c *Client) FindOpenPRBySourceBranch(ctx context.Context, repo RepoRef, branch string) (*PullRequest, error) {
+	query := url.Values{}
+	query.Set("q", fmt.Sprintf(`source.branch.name=%q AND state=%q`, branch, "OPEN"))
+
+	var response struct {
+		Values []bitbucketPullRequest `json:"values"`
+	}
+	if err := c.doJSON(ctx, http.MethodGet, repoPRPath(repo), query, nil, &response); err != nil {
+		return nil, err
+	}
+	if len(response.Values) == 0 {
+		return nil, nil
+	}
+	return response.Values[0].toPullRequest(), nil
+}
+
+func (c *Client) CreatePR(ctx context.Context, repo RepoRef, sourceBranch, destBranch, title, body string) (*PullRequest, error) {
+	requestBody := map[string]any{
+		"title":       title,
+		"description": body,
+		"source": map[string]any{
+			"branch": map[string]string{"name": sourceBranch},
+		},
+		"destination": map[string]any{
+			"branch": map[string]string{"name": destBranch},
+		},
+	}
+	var response bitbucketPullRequest
+	if err := c.doJSON(ctx, http.MethodPost, repoPRPath(repo), nil, requestBody, &response); err != nil {
+		return nil, err
+	}
+	return response.toPullRequest(), nil
+}
+
+func (c *Client) UpdatePR(ctx context.Context, repo RepoRef, prID int, title, body string) (*PullRequest, error) {
+	requestBody := map[string]any{
+		"title":       title,
+		"description": body,
+	}
+	var response bitbucketPullRequest
+	if err := c.doJSON(ctx, http.MethodPut, fmt.Sprintf("%s/%d", repoPRPath(repo), prID), nil, requestBody, &response); err != nil {
+		return nil, err
+	}
+	return response.toPullRequest(), nil
+}
+
+func (c *Client) GetPR(ctx context.Context, repo RepoRef, prID int) (*PullRequest, error) {
+	var response bitbucketPullRequest
+	if err := c.doJSON(ctx, http.MethodGet, fmt.Sprintf("%s/%d", repoPRPath(repo), prID), nil, nil, &response); err != nil {
+		return nil, err
+	}
+	return response.toPullRequest(), nil
+}
+
+func (c *Client) ListPRStatuses(ctx context.Context, repo RepoRef, prID int) ([]CommitStatus, error) {
+	var response struct {
+		Values []CommitStatus `json:"values"`
+	}
+	if err := c.doJSON(ctx, http.MethodGet, fmt.Sprintf("%s/%d/statuses", repoPRPath(repo), prID), nil, nil, &response); err != nil {
+		return nil, err
+	}
+	return response.Values, nil
+}
+
+func (c *Client) ListPipelinesByCommit(ctx context.Context, repo RepoRef, commitSHA string) ([]Pipeline, error) {
+	query := url.Values{}
+	query.Set("target.commit.hash", commitSHA)
+	query.Set("sort", "-created_on")
+
+	var response struct {
+		Values []Pipeline `json:"values"`
+	}
+	if err := c.doJSON(ctx, http.MethodGet, fmt.Sprintf("/2.0/repositories/%s/%s/pipelines", repo.Workspace, repo.RepoSlug), query, nil, &response); err != nil {
+		return nil, err
+	}
+	return response.Values, nil
+}
+
+func (c *Client) ListPipelineSteps(ctx context.Context, repo RepoRef, pipelineUUID string) ([]PipelineStep, error) {
+	var response struct {
+		Values []PipelineStep `json:"values"`
+	}
+	path := fmt.Sprintf("/2.0/repositories/%s/%s/pipelines/%s/steps", repo.Workspace, repo.RepoSlug, pipelineUUID)
+	if err := c.doJSON(ctx, http.MethodGet, path, nil, nil, &response); err != nil {
+		return nil, err
+	}
+	return response.Values, nil
+}
+
+func (c *Client) GetStepLog(ctx context.Context, repo RepoRef, pipelineUUID, stepUUID string) (string, error) {
+	path := fmt.Sprintf("/2.0/repositories/%s/%s/pipelines/%s/steps/%s/log", repo.Workspace, repo.RepoSlug, pipelineUUID, stepUUID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return "", fmt.Errorf("build Bitbucket request: %w", err)
+	}
+	req.SetBasicAuth(c.email, c.token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("Bitbucket GET %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		data, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("Bitbucket GET %s: status %d: %s", path, resp.StatusCode, strings.TrimSpace(string(data)))
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read Bitbucket step log: %w", err)
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+type bitbucketPullRequest struct {
+	ID    int    `json:"id"`
+	State string `json:"state"`
+	Links struct {
+		HTML struct {
+			Href string `json:"href"`
+		} `json:"html"`
+	} `json:"links"`
+}
+
+func (pr bitbucketPullRequest) toPullRequest() *PullRequest {
+	return &PullRequest{ID: pr.ID, URL: strings.TrimSpace(pr.Links.HTML.Href), State: strings.TrimSpace(pr.State)}
+}
+
+func (c *Client) doJSON(ctx context.Context, method, path string, query url.Values, requestBody any, responseBody any) error {
+	var bodyReader io.Reader = http.NoBody
+	if requestBody != nil {
+		payload, err := json.Marshal(requestBody)
+		if err != nil {
+			return fmt.Errorf("marshal Bitbucket request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(payload)
+	}
+
+	endpoint := c.baseURL + path
+	if len(query) > 0 {
+		endpoint += "?" + query.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, bodyReader)
+	if err != nil {
+		return fmt.Errorf("build Bitbucket request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.SetBasicAuth(c.email, c.token)
+	if requestBody != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("Bitbucket %s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		data, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("Bitbucket %s %s: status %d: %s", method, path, resp.StatusCode, strings.TrimSpace(string(data)))
+	}
+	if responseBody == nil {
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(responseBody); err != nil {
+		return fmt.Errorf("decode Bitbucket response: %w", err)
+	}
+	return nil
+}
+
+func repoPRPath(repo RepoRef) string {
+	return fmt.Sprintf("/2.0/repositories/%s/%s/pullrequests", repo.Workspace, repo.RepoSlug)
+}
+
+func lookupEnv(env []string, key string) string {
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			return strings.TrimPrefix(entry, prefix)
+		}
+	}
+	return os.Getenv(key)
+}

--- a/internal/bitbucket/client.go
+++ b/internal/bitbucket/client.go
@@ -17,6 +17,7 @@ const (
 	envEmail          = "NO_MISTAKES_BITBUCKET_EMAIL"
 	envToken          = "NO_MISTAKES_BITBUCKET_API_TOKEN"
 	envAPIBaseURL     = "NO_MISTAKES_BITBUCKET_API_BASE_URL"
+	maxStepLogBytes   = 32 * 1024
 )
 
 type RepoRef struct {
@@ -195,24 +196,53 @@ func (c *Client) ListPipelinesByCommit(ctx context.Context, repo RepoRef, commit
 	query.Set("target.commit.hash", commitSHA)
 	query.Set("sort", "-created_on")
 
-	var response struct {
-		Values []Pipeline `json:"values"`
+	next := fmt.Sprintf("%s/2.0/repositories/%s/%s/pipelines?%s", c.baseURL, repo.Workspace, repo.RepoSlug, query.Encode())
+	pipelines := make([]Pipeline, 0)
+	for next != "" {
+		var response struct {
+			Values []Pipeline `json:"values"`
+			Next   string     `json:"next"`
+		}
+		if err := c.doJSONPathOrURL(ctx, http.MethodGet, next, nil, &response); err != nil {
+			return nil, err
+		}
+		pipelines = append(pipelines, response.Values...)
+		if response.Next == "" {
+			next = ""
+			continue
+		}
+		validatedNext, err := c.validatePaginationURL(response.Next)
+		if err != nil {
+			return nil, err
+		}
+		next = validatedNext
 	}
-	if err := c.doJSON(ctx, http.MethodGet, fmt.Sprintf("/2.0/repositories/%s/%s/pipelines", repo.Workspace, repo.RepoSlug), query, nil, &response); err != nil {
-		return nil, err
-	}
-	return response.Values, nil
+	return pipelines, nil
 }
 
 func (c *Client) ListPipelineSteps(ctx context.Context, repo RepoRef, pipelineUUID string) ([]PipelineStep, error) {
-	var response struct {
-		Values []PipelineStep `json:"values"`
+	next := fmt.Sprintf("%s/2.0/repositories/%s/%s/pipelines/%s/steps", c.baseURL, repo.Workspace, repo.RepoSlug, pipelineUUID)
+	steps := make([]PipelineStep, 0)
+	for next != "" {
+		var response struct {
+			Values []PipelineStep `json:"values"`
+			Next   string         `json:"next"`
+		}
+		if err := c.doJSONPathOrURL(ctx, http.MethodGet, next, nil, &response); err != nil {
+			return nil, err
+		}
+		steps = append(steps, response.Values...)
+		if response.Next == "" {
+			next = ""
+			continue
+		}
+		validatedNext, err := c.validatePaginationURL(response.Next)
+		if err != nil {
+			return nil, err
+		}
+		next = validatedNext
 	}
-	path := fmt.Sprintf("/2.0/repositories/%s/%s/pipelines/%s/steps", repo.Workspace, repo.RepoSlug, pipelineUUID)
-	if err := c.doJSON(ctx, http.MethodGet, path, nil, nil, &response); err != nil {
-		return nil, err
-	}
-	return response.Values, nil
+	return steps, nil
 }
 
 func (c *Client) GetStepLog(ctx context.Context, repo RepoRef, pipelineUUID, stepUUID string) (string, error) {
@@ -232,11 +262,42 @@ func (c *Client) GetStepLog(ctx context.Context, repo RepoRef, pipelineUUID, ste
 		data, _ := io.ReadAll(resp.Body)
 		return "", fmt.Errorf("Bitbucket GET %s: status %d: %s", path, resp.StatusCode, strings.TrimSpace(string(data)))
 	}
-	data, err := io.ReadAll(resp.Body)
+	data, err := readTail(resp.Body, maxStepLogBytes)
 	if err != nil {
 		return "", fmt.Errorf("read Bitbucket step log: %w", err)
 	}
 	return strings.TrimSpace(string(data)), nil
+}
+
+func readTail(r io.Reader, maxBytes int) ([]byte, error) {
+	if maxBytes <= 0 {
+		return nil, nil
+	}
+	buf := make([]byte, 0, maxBytes)
+	tmp := make([]byte, 4096)
+	for {
+		n, err := r.Read(tmp)
+		if n > 0 {
+			chunk := tmp[:n]
+			if len(chunk) >= maxBytes {
+				buf = append(buf[:0], chunk[len(chunk)-maxBytes:]...)
+			} else {
+				overflow := len(buf) + len(chunk) - maxBytes
+				if overflow > 0 {
+					buf = append(buf[overflow:], chunk...)
+				} else {
+					buf = append(buf, chunk...)
+				}
+			}
+		}
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+	}
+	return append([]byte(nil), buf...), nil
 }
 
 type bitbucketPullRequest struct {

--- a/internal/bitbucket/client.go
+++ b/internal/bitbucket/client.go
@@ -167,7 +167,10 @@ func (c *Client) GetPR(ctx context.Context, repo RepoRef, prID int) (*PullReques
 }
 
 func (c *Client) ListPRStatuses(ctx context.Context, repo RepoRef, prID int) ([]CommitStatus, error) {
-	next := fmt.Sprintf("%s/%d/statuses", repoPRPath(repo), prID)
+	query := url.Values{}
+	query.Set("sort", "-created_on")
+
+	next := fmt.Sprintf("%s/%d/statuses?%s", repoPRPath(repo), prID, query.Encode())
 	statuses := make([]CommitStatus, 0)
 	for next != "" {
 		var response struct {

--- a/internal/bitbucket/client.go
+++ b/internal/bitbucket/client.go
@@ -33,6 +33,7 @@ type PullRequest struct {
 
 type CommitStatus struct {
 	Name        string `json:"name"`
+	Key         string `json:"key"`
 	State       string `json:"state"`
 	Description string `json:"description"`
 	URL         string `json:"url"`

--- a/internal/bitbucket/client_env_test.go
+++ b/internal/bitbucket/client_env_test.go
@@ -1,0 +1,20 @@
+package bitbucket
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewClientFromEnvDoesNotReadAmbientEnvironment(t *testing.T) {
+	t.Setenv(envEmail, "ambient@example.com")
+	t.Setenv(envToken, "ambient-token")
+	t.Setenv(envAPIBaseURL, "https://ambient.example")
+
+	_, err := NewClientFromEnv(nil)
+	if err == nil {
+		t.Fatal("expected missing credentials error")
+	}
+	if !strings.Contains(err.Error(), envEmail) {
+		t.Fatalf("error = %q, want missing %s", err, envEmail)
+	}
+}

--- a/internal/bitbucket/client_env_test.go
+++ b/internal/bitbucket/client_env_test.go
@@ -1,20 +1,47 @@
 package bitbucket
 
-import (
-	"strings"
-	"testing"
-)
+import "testing"
 
-func TestNewClientFromEnvDoesNotReadAmbientEnvironment(t *testing.T) {
+func TestNewClientFromEnvReadsAmbientEnvironment(t *testing.T) {
 	t.Setenv(envEmail, "ambient@example.com")
 	t.Setenv(envToken, "ambient-token")
 	t.Setenv(envAPIBaseURL, "https://ambient.example")
 
-	_, err := NewClientFromEnv(nil)
-	if err == nil {
-		t.Fatal("expected missing credentials error")
+	client, err := NewClientFromEnv(nil)
+	if err != nil {
+		t.Fatalf("NewClientFromEnv(nil) error = %v", err)
 	}
-	if !strings.Contains(err.Error(), envEmail) {
-		t.Fatalf("error = %q, want missing %s", err, envEmail)
+	if client.email != "ambient@example.com" {
+		t.Fatalf("email = %q, want ambient@example.com", client.email)
+	}
+	if client.token != "ambient-token" {
+		t.Fatalf("token = %q, want ambient-token", client.token)
+	}
+	if client.baseURL != "https://ambient.example" {
+		t.Fatalf("baseURL = %q, want https://ambient.example", client.baseURL)
+	}
+}
+
+func TestNewClientFromEnvPrefersExplicitEnvironment(t *testing.T) {
+	t.Setenv(envEmail, "ambient@example.com")
+	t.Setenv(envToken, "ambient-token")
+	t.Setenv(envAPIBaseURL, "https://ambient.example")
+
+	client, err := NewClientFromEnv([]string{
+		envEmail + "=explicit@example.com",
+		envToken + "=explicit-token",
+		envAPIBaseURL + "=https://explicit.example",
+	})
+	if err != nil {
+		t.Fatalf("NewClientFromEnv(explicit env) error = %v", err)
+	}
+	if client.email != "explicit@example.com" {
+		t.Fatalf("email = %q, want explicit@example.com", client.email)
+	}
+	if client.token != "explicit-token" {
+		t.Fatalf("token = %q, want explicit-token", client.token)
+	}
+	if client.baseURL != "https://explicit.example" {
+		t.Fatalf("baseURL = %q, want https://explicit.example", client.baseURL)
 	}
 }

--- a/internal/bitbucket/client_test.go
+++ b/internal/bitbucket/client_test.go
@@ -1,0 +1,55 @@
+package bitbucket
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestListPRStatusesFollowsPagination(t *testing.T) {
+	repo := RepoRef{Workspace: "test", RepoSlug: "repo"}
+	var pageCalls int
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/2.0/repositories/test/repo/pullrequests/42/statuses" {
+			t.Fatalf("path = %q, want %q", r.URL.Path, "/2.0/repositories/test/repo/pullrequests/42/statuses")
+		}
+		pageCalls++
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "", "1":
+			_, _ = w.Write([]byte(`{"values":[{"name":"build","state":"SUCCESSFUL"}],"next":"` + server.URL + `/2.0/repositories/test/repo/pullrequests/42/statuses?page=2"}`))
+		case "2":
+			_, _ = w.Write([]byte(`{"values":[{"name":"tests","state":"FAILED"}]}`))
+		default:
+			t.Fatalf("unexpected page query %q", r.URL.RawQuery)
+		}
+	}))
+	defer server.Close()
+
+	client := &Client{
+		baseURL: server.URL,
+		email:   "test@example.com",
+		token:   "token",
+		httpClient: &http.Client{
+			Timeout: time.Second,
+		},
+	}
+
+	statuses, err := client.ListPRStatuses(context.Background(), repo, 42)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(statuses) != 2 {
+		t.Fatalf("len(statuses) = %d, want 2", len(statuses))
+	}
+	if statuses[0].Name != "build" || statuses[1].Name != "tests" {
+		t.Fatalf("statuses = %#v, want build then tests", statuses)
+	}
+	if pageCalls != 2 {
+		t.Fatalf("pageCalls = %d, want 2", pageCalls)
+	}
+}

--- a/internal/bitbucket/client_test.go
+++ b/internal/bitbucket/client_test.go
@@ -63,11 +63,14 @@ func TestListPRStatusesFollowsPagination(t *testing.T) {
 		if r.URL.Path != "/2.0/repositories/test/repo/pullrequests/42/statuses" {
 			t.Fatalf("path = %q, want %q", r.URL.Path, "/2.0/repositories/test/repo/pullrequests/42/statuses")
 		}
+		if got := r.URL.Query().Get("sort"); got != "-created_on" {
+			t.Fatalf("sort = %q, want -created_on", got)
+		}
 		pageCalls++
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Query().Get("page") {
 		case "", "1":
-			_, _ = w.Write([]byte(`{"values":[{"name":"build","state":"SUCCESSFUL"}],"next":"` + server.URL + `/2.0/repositories/test/repo/pullrequests/42/statuses?page=2"}`))
+			_, _ = w.Write([]byte(`{"values":[{"name":"build","state":"SUCCESSFUL"}],"next":"` + server.URL + `/2.0/repositories/test/repo/pullrequests/42/statuses?sort=-created_on&page=2"}`))
 		case "2":
 			_, _ = w.Write([]byte(`{"values":[{"name":"tests","state":"FAILED"}]}`))
 		default:

--- a/internal/bitbucket/client_test.go
+++ b/internal/bitbucket/client_test.go
@@ -130,6 +130,41 @@ func TestListPRStatusesRejectsCrossOriginPagination(t *testing.T) {
 	}
 }
 
+func TestFindOpenPRBySourceAndDestinationBranchFiltersDestination(t *testing.T) {
+	repo := RepoRef{Workspace: "test", RepoSlug: "repo"}
+	var gotQ string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/2.0/repositories/test/repo/pullrequests" {
+			t.Fatalf("path = %q, want %q", r.URL.Path, "/2.0/repositories/test/repo/pullrequests")
+		}
+		gotQ = r.URL.Query().Get("q")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"values":[{"id":42,"links":{"html":{"href":"https://bitbucket.org/test/repo/pull-requests/42"}}}]}`))
+	}))
+	defer server.Close()
+
+	client := &Client{
+		baseURL: server.URL,
+		email:   "test@example.com",
+		token:   "token",
+		httpClient: &http.Client{
+			Timeout: time.Second,
+		},
+	}
+
+	pr, err := client.FindOpenPRBySourceBranch(context.Background(), repo, "feature", "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pr == nil || pr.ID != 42 {
+		t.Fatalf("pr = %#v, want id 42", pr)
+	}
+	if gotQ != `source.branch.name="feature" AND destination.branch.name="main" AND state="OPEN"` {
+		t.Fatalf("q = %q, want destination branch filter", gotQ)
+	}
+}
+
 func TestListPipelinesByCommitFollowsPagination(t *testing.T) {
 	repo := RepoRef{Workspace: "test", RepoSlug: "repo"}
 	var pageCalls int

--- a/internal/bitbucket/client_test.go
+++ b/internal/bitbucket/client_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -123,5 +124,139 @@ func TestListPRStatusesRejectsCrossOriginPagination(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "cross-origin") {
 		t.Fatalf("error = %q, want cross-origin validation failure", err)
+	}
+}
+
+func TestListPipelinesByCommitFollowsPagination(t *testing.T) {
+	repo := RepoRef{Workspace: "test", RepoSlug: "repo"}
+	var pageCalls int
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/2.0/repositories/test/repo/pipelines" {
+			t.Fatalf("path = %q, want %q", r.URL.Path, "/2.0/repositories/test/repo/pipelines")
+		}
+		if got := r.URL.Query().Get("target.commit.hash"); got != "abc123" {
+			t.Fatalf("target.commit.hash = %q, want abc123", got)
+		}
+		if got := r.URL.Query().Get("sort"); got != "-created_on" {
+			t.Fatalf("sort = %q, want -created_on", got)
+		}
+		pageCalls++
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "", "1":
+			_, _ = w.Write([]byte(`{"values":[{"uuid":"{first}"}],"next":"` + server.URL + `/2.0/repositories/test/repo/pipelines?target.commit.hash=abc123&sort=-created_on&page=2"}`))
+		case "2":
+			_, _ = w.Write([]byte(`{"values":[{"uuid":"{second}"}]}`))
+		default:
+			t.Fatalf("unexpected page query %q", r.URL.RawQuery)
+		}
+	}))
+	defer server.Close()
+
+	client := &Client{
+		baseURL: server.URL,
+		email:   "test@example.com",
+		token:   "token",
+		httpClient: &http.Client{
+			Timeout: time.Second,
+		},
+	}
+
+	pipelines, err := client.ListPipelinesByCommit(context.Background(), repo, "abc123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pipelines) != 2 {
+		t.Fatalf("len(pipelines) = %d, want 2", len(pipelines))
+	}
+	if pipelines[0].UUID != "{first}" || pipelines[1].UUID != "{second}" {
+		t.Fatalf("pipelines = %#v, want first then second", pipelines)
+	}
+	if pageCalls != 2 {
+		t.Fatalf("pageCalls = %d, want 2", pageCalls)
+	}
+}
+
+func TestListPipelineStepsFollowsPagination(t *testing.T) {
+	repo := RepoRef{Workspace: "test", RepoSlug: "repo"}
+	var pageCalls int
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/2.0/repositories/test/repo/pipelines/{pipe}/steps" {
+			t.Fatalf("path = %q, want %q", r.URL.Path, "/2.0/repositories/test/repo/pipelines/{pipe}/steps")
+		}
+		pageCalls++
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "", "1":
+			_, _ = w.Write([]byte(`{"values":[{"uuid":"{step-1}"}],"next":"` + server.URL + `/2.0/repositories/test/repo/pipelines/%7Bpipe%7D/steps?page=2"}`))
+		case "2":
+			_, _ = w.Write([]byte(`{"values":[{"uuid":"{step-2}","state":{"result":{"name":"FAILED"}}}]}`))
+		default:
+			t.Fatalf("unexpected page query %q", r.URL.RawQuery)
+		}
+	}))
+	defer server.Close()
+
+	client := &Client{
+		baseURL: server.URL,
+		email:   "test@example.com",
+		token:   "token",
+		httpClient: &http.Client{
+			Timeout: time.Second,
+		},
+	}
+
+	steps, err := client.ListPipelineSteps(context.Background(), repo, "{pipe}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(steps) != 2 {
+		t.Fatalf("len(steps) = %d, want 2", len(steps))
+	}
+	if steps[0].UUID != "{step-1}" || steps[1].UUID != "{step-2}" {
+		t.Fatalf("steps = %#v, want step-1 then step-2", steps)
+	}
+	if pageCalls != 2 {
+		t.Fatalf("pageCalls = %d, want 2", pageCalls)
+	}
+}
+
+func TestGetStepLogCapsResponseToTail(t *testing.T) {
+	repo := RepoRef{Workspace: "test", RepoSlug: "repo"}
+	const maxLogBytes = 32 * 1024
+	prefix := strings.Repeat("a", 4096)
+	tail := strings.Repeat("z", maxLogBytes)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/2.0/repositories/test/repo/pipelines/{pipe}/steps/{step}/log" {
+			t.Fatalf("path = %q, want %q", r.URL.Path, "/2.0/repositories/test/repo/pipelines/{pipe}/steps/{step}/log")
+		}
+		w.Header().Set("Content-Length", strconv.Itoa(len(prefix)+len(tail)))
+		_, _ = w.Write([]byte(prefix + tail))
+	}))
+	defer server.Close()
+
+	client := &Client{
+		baseURL: server.URL,
+		email:   "test@example.com",
+		token:   "token",
+		httpClient: &http.Client{
+			Timeout: time.Second,
+		},
+	}
+
+	logOutput, err := client.GetStepLog(context.Background(), repo, "{pipe}", "{step}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(logOutput) != maxLogBytes {
+		t.Fatalf("len(logOutput) = %d, want %d", len(logOutput), maxLogBytes)
+	}
+	if logOutput != tail {
+		t.Fatalf("logOutput did not keep the expected tail")
 	}
 }

--- a/internal/bitbucket/client_test.go
+++ b/internal/bitbucket/client_test.go
@@ -10,6 +10,49 @@ import (
 	"time"
 )
 
+func TestParseRepoRefRejectsLookalikeHosts(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr string
+	}{
+		{
+			name:    "rejects lookalike host",
+			raw:     "https://bitbucket.org.evil.example/workspace/repo.git",
+			wantErr: `unsupported Bitbucket host "bitbucket.org.evil.example"`,
+		},
+		{
+			name: "accepts exact host",
+			raw:  "https://bitbucket.org/workspace/repo.git",
+		},
+		{
+			name: "accepts subdomain host",
+			raw:  "https://foo.bitbucket.org/workspace/repo.git",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo, err := ParseRepoRef(tt.raw)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				if err.Error() != tt.wantErr {
+					t.Fatalf("error = %q, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseRepoRef returned error: %v", err)
+			}
+			if repo != (RepoRef{Workspace: "workspace", RepoSlug: "repo"}) {
+				t.Fatalf("repo = %#v, want workspace/repo", repo)
+			}
+		})
+	}
+}
+
 func TestListPRStatusesFollowsPagination(t *testing.T) {
 	repo := RepoRef{Workspace: "test", RepoSlug: "repo"}
 	var pageCalls int

--- a/internal/bitbucket/client_test.go
+++ b/internal/bitbucket/client_test.go
@@ -130,7 +130,7 @@ func TestListPRStatusesRejectsCrossOriginPagination(t *testing.T) {
 	}
 }
 
-func TestFindOpenPRBySourceAndDestinationBranchFiltersDestination(t *testing.T) {
+func TestFindOpenPRBySourceAndDestinationBranchFiltersSourceRepo(t *testing.T) {
 	repo := RepoRef{Workspace: "test", RepoSlug: "repo"}
 	var gotQ string
 
@@ -160,8 +160,8 @@ func TestFindOpenPRBySourceAndDestinationBranchFiltersDestination(t *testing.T) 
 	if pr == nil || pr.ID != 42 {
 		t.Fatalf("pr = %#v, want id 42", pr)
 	}
-	if gotQ != `source.branch.name="feature" AND destination.branch.name="main" AND state="OPEN"` {
-		t.Fatalf("q = %q, want destination branch filter", gotQ)
+	if gotQ != `source.branch.name="feature" AND source.repository.full_name="test/repo" AND destination.branch.name="main" AND state="OPEN"` {
+		t.Fatalf("q = %q, want source repo and destination branch filters", gotQ)
 	}
 }
 

--- a/internal/bitbucket/client_test.go
+++ b/internal/bitbucket/client_test.go
@@ -2,8 +2,10 @@ package bitbucket
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -51,5 +53,32 @@ func TestListPRStatusesFollowsPagination(t *testing.T) {
 	}
 	if pageCalls != 2 {
 		t.Fatalf("pageCalls = %d, want 2", pageCalls)
+	}
+}
+
+func TestListPRStatusesRejectsCrossOriginPagination(t *testing.T) {
+	repo := RepoRef{Workspace: "test", RepoSlug: "repo"}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"values":[{"name":"build","state":"SUCCESSFUL"}],"next":"https://evil.example/2.0/repositories/test/repo/pullrequests/42/statuses?page=2"}`)
+	}))
+	defer server.Close()
+
+	client := &Client{
+		baseURL: server.URL,
+		email:   "test@example.com",
+		token:   "token",
+		httpClient: &http.Client{
+			Timeout: time.Second,
+		},
+	}
+
+	_, err := client.ListPRStatuses(context.Background(), repo, 42)
+	if err == nil {
+		t.Fatal("expected cross-origin pagination to fail")
+	}
+	if !strings.Contains(err.Error(), "cross-origin") {
+		t.Fatalf("error = %q, want cross-origin validation failure", err)
 	}
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -492,6 +492,16 @@ func TestStopDetachedDaemonFallsBackToPIDWhenSocketIsBroken(t *testing.T) {
 	defer func() {
 		daemonProcessRunning = originalProcessRunning
 	}()
+	originalProcessStartTime := daemonProcessStartTime
+	daemonProcessStartTime = func(checkPID int) (time.Time, error) {
+		if checkPID != pid {
+			t.Fatalf("processStartTime pid = %d, want %d", checkPID, pid)
+		}
+		return time.Now(), nil
+	}
+	defer func() {
+		daemonProcessStartTime = originalProcessStartTime
+	}()
 	originalKillPID := daemonKillPID
 	killedPID := 0
 	daemonKillPID = func(killPID int) error {
@@ -516,6 +526,66 @@ func TestStopDetachedDaemonFallsBackToPIDWhenSocketIsBroken(t *testing.T) {
 	}
 	if _, statErr := os.Stat(p.Socket()); !os.IsNotExist(statErr) {
 		t.Fatalf("expected socket file to be removed after PID fallback, got err=%v", statErr)
+	}
+}
+
+func TestStopDetachedDaemonRejectsStalePIDFallback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix socket setup is platform-specific")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "dtest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	p := paths.WithRoot(tmpDir)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.PIDFile(), []byte(fmt.Sprintf("%d", os.Getpid())), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-24 * time.Hour)
+	if err := os.Chtimes(p.PIDFile(), oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+	ln, err := net.Listen("unix", p.Socket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	originalDial := daemonDial
+	daemonDial = func(string) (*ipc.Client, error) {
+		return nil, fmt.Errorf("transient ipc failure")
+	}
+	defer func() {
+		daemonDial = originalDial
+	}()
+	originalKillPID := daemonKillPID
+	killCalled := false
+	daemonKillPID = func(int) error {
+		killCalled = true
+		return nil
+	}
+	defer func() {
+		daemonKillPID = originalKillPID
+	}()
+
+	err = stopDetachedDaemon(p)
+	if err == nil {
+		t.Fatal("expected stale pid fallback to fail")
+	}
+	if killCalled {
+		t.Fatal("expected stale pid fallback to avoid killing the process")
+	}
+	if _, statErr := os.Stat(p.PIDFile()); statErr != nil {
+		t.Fatalf("expected pid file to remain after rejected pid fallback, got err=%v", statErr)
+	}
+	if _, statErr := os.Stat(p.Socket()); statErr != nil {
+		t.Fatalf("expected socket file to remain after rejected pid fallback, got err=%v", statErr)
 	}
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -663,6 +663,39 @@ func TestStaleDaemonArtifactsKeepsPIDForLiveProcessWithoutSocket(t *testing.T) {
 	}
 }
 
+func TestStaleDaemonArtifactsKeepsRegularEndpointFileForLiveProcess(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dtest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	p := paths.WithRoot(tmpDir)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.PIDFile(), []byte(fmt.Sprintf("%d", os.Getpid())), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.Socket(), []byte("127.0.0.1:1234\ntoken\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	original := daemonEndpointUsesRegularFile
+	daemonEndpointUsesRegularFile = func() bool { return true }
+	defer func() {
+		daemonEndpointUsesRegularFile = original
+	}()
+
+	stale, err := staleDaemonArtifacts(p)
+	if err != nil {
+		t.Fatalf("staleDaemonArtifacts returned error: %v", err)
+	}
+	if stale {
+		t.Fatal("expected live pid with regular endpoint file to be treated as non-stale")
+	}
+}
+
 func TestReadPIDNoFile(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "dtest")
 	if err != nil {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -3,6 +3,8 @@ package daemon
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -441,6 +443,50 @@ func TestWaitForDaemonStopKeepsArtifactsWhenKillFails(t *testing.T) {
 	}
 	if _, err := os.Stat(p.Socket()); err != nil {
 		t.Fatalf("expected socket file to remain after failed kill, got err=%v", err)
+	}
+}
+
+func TestStopDetachedDaemonKeepsArtifactsOnDialFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix socket setup is platform-specific")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "dtest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	p := paths.WithRoot(tmpDir)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.PIDFile(), []byte("12345"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ln, err := net.Listen("unix", p.Socket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	originalDial := daemonDial
+	daemonDial = func(string) (*ipc.Client, error) {
+		return nil, fmt.Errorf("transient ipc failure")
+	}
+	defer func() {
+		daemonDial = originalDial
+	}()
+
+	err = stopDetachedDaemon(p)
+	if err == nil {
+		t.Fatal("expected stopDetachedDaemon to fail when IPC dial fails")
+	}
+	if _, statErr := os.Stat(p.PIDFile()); statErr != nil {
+		t.Fatalf("expected pid file to remain after dial failure, got err=%v", statErr)
+	}
+	if _, statErr := os.Stat(p.Socket()); statErr != nil {
+		t.Fatalf("expected socket file to remain after dial failure, got err=%v", statErr)
 	}
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -762,6 +762,46 @@ func TestStaleDaemonArtifactsKeepsRegularEndpointFileForLiveProcess(t *testing.T
 	}
 }
 
+func TestStopDetachedDaemonKeepsArtifactsWhenPIDMissingButDaemonLooksLive(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix socket setup is platform-specific")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "dtest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	p := paths.WithRoot(tmpDir)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	ln, err := net.Listen("unix", p.Socket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	originalDial := daemonDial
+	daemonDial = func(string) (*ipc.Client, error) {
+		return nil, fmt.Errorf("transient ipc failure")
+	}
+	defer func() {
+		daemonDial = originalDial
+	}()
+	err = stopDetachedDaemon(p)
+	if err == nil {
+		t.Fatal("expected stopDetachedDaemon to fail without a pid file")
+	}
+	if _, statErr := os.Stat(p.Socket()); statErr != nil {
+		t.Fatalf("expected socket file to remain when daemon looks live, got err=%v", statErr)
+	}
+	if _, statErr := os.Stat(p.PIDFile()); !os.IsNotExist(statErr) {
+		t.Fatalf("expected pid file to remain missing, got err=%v", statErr)
+	}
+}
+
 func TestStaleDaemonArtifactsRejectsNonPositivePID(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -22,6 +22,9 @@ import (
 
 func TestMain(m *testing.M) {
 	if os.Getenv("NM_DAEMON_HELPER_PROCESS") == "1" {
+		if capturePath := os.Getenv("NM_CAPTURE_NM_HOME_FILE"); capturePath != "" {
+			_ = os.WriteFile(capturePath, []byte(os.Getenv("NM_HOME")), 0o644)
+		}
 		os.Exit(0)
 	}
 	os.Exit(m.Run())
@@ -366,6 +369,35 @@ func TestStopNotRunningIsNoop(t *testing.T) {
 
 	if err := Stop(p); err != nil {
 		t.Fatalf("stop should succeed when daemon is not running: %v", err)
+	}
+}
+
+func TestStopNotRunningRemovesStaleArtifacts(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dtest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	p := paths.WithRoot(tmpDir)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.PIDFile(), []byte("12345"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.Socket(), []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Stop(p); err != nil {
+		t.Fatalf("stop should succeed when daemon is not running: %v", err)
+	}
+	if _, err := os.Stat(p.PIDFile()); !os.IsNotExist(err) {
+		t.Fatalf("expected stale pid file to be removed, got err=%v", err)
+	}
+	if _, err := os.Stat(p.Socket()); !os.IsNotExist(err) {
+		t.Fatalf("expected stale socket file to be removed, got err=%v", err)
 	}
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -541,6 +541,30 @@ func TestStopDetachedDaemonRemovesArtifactsForDeadPID(t *testing.T) {
 	}
 }
 
+func TestStaleDaemonArtifactsKeepsPIDForLiveProcessWithoutSocket(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dtest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	p := paths.WithRoot(tmpDir)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.PIDFile(), []byte(fmt.Sprintf("%d", os.Getpid())), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	stale, err := staleDaemonArtifacts(p)
+	if err != nil {
+		t.Fatalf("staleDaemonArtifacts returned error: %v", err)
+	}
+	if stale {
+		t.Fatal("expected live pid without socket to be treated as non-stale")
+	}
+}
+
 func TestReadPIDNoFile(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "dtest")
 	if err != nil {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -25,7 +25,8 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	if os.Getenv("NM_DAEMON_HELPER_PROCESS") == "1" {
+	switch os.Getenv("NM_DAEMON_HELPER_PROCESS") {
+	case "1":
 		if capturePath := os.Getenv("NM_CAPTURE_NM_HOME_FILE"); capturePath != "" {
 			_ = os.WriteFile(capturePath, []byte(os.Getenv("NM_HOME")), 0o644)
 		}
@@ -447,7 +448,7 @@ func TestWaitForDaemonStopKeepsArtifactsWhenKillFails(t *testing.T) {
 	}
 }
 
-func TestStopDetachedDaemonKeepsArtifactsOnDialFailure(t *testing.T) {
+func TestStopDetachedDaemonFallsBackToPIDWhenSocketIsBroken(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("unix socket setup is platform-specific")
 	}
@@ -462,7 +463,8 @@ func TestStopDetachedDaemonKeepsArtifactsOnDialFailure(t *testing.T) {
 	if err := p.EnsureDirs(); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(p.PIDFile(), []byte(fmt.Sprintf("%d", os.Getpid())), 0o644); err != nil {
+	const pid = 424242
+	if err := os.WriteFile(p.PIDFile(), []byte(fmt.Sprintf("%d", pid)), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	ln, err := net.Listen("unix", p.Socket())
@@ -478,16 +480,42 @@ func TestStopDetachedDaemonKeepsArtifactsOnDialFailure(t *testing.T) {
 	defer func() {
 		daemonDial = originalDial
 	}()
+	originalProcessRunning := daemonProcessRunning
+	runningChecks := 0
+	daemonProcessRunning = func(checkPID int) (bool, error) {
+		if checkPID != pid {
+			t.Fatalf("processRunning pid = %d, want %d", checkPID, pid)
+		}
+		runningChecks++
+		return runningChecks == 1, nil
+	}
+	defer func() {
+		daemonProcessRunning = originalProcessRunning
+	}()
+	originalKillPID := daemonKillPID
+	killedPID := 0
+	daemonKillPID = func(killPID int) error {
+		killedPID = killPID
+		return nil
+	}
+	defer func() {
+		daemonKillPID = originalKillPID
+	}()
 
-	err = stopDetachedDaemon(p)
-	if err == nil {
-		t.Fatal("expected stopDetachedDaemon to fail when IPC dial fails")
+	if err := stopDetachedDaemon(p); err != nil {
+		t.Fatalf("expected stopDetachedDaemon to stop live pid when IPC dial fails, got %v", err)
 	}
-	if _, statErr := os.Stat(p.PIDFile()); statErr != nil {
-		t.Fatalf("expected pid file to remain after dial failure, got err=%v", statErr)
+	if killedPID != pid {
+		t.Fatalf("expected pid fallback to kill pid %d, got %d", pid, killedPID)
 	}
-	if _, statErr := os.Stat(p.Socket()); statErr != nil {
-		t.Fatalf("expected socket file to remain after dial failure, got err=%v", statErr)
+	if runningChecks == 0 {
+		t.Fatal("expected pid fallback to check process state")
+	}
+	if _, statErr := os.Stat(p.PIDFile()); !os.IsNotExist(statErr) {
+		t.Fatalf("expected pid file to be removed after PID fallback, got err=%v", statErr)
+	}
+	if _, statErr := os.Stat(p.Socket()); !os.IsNotExist(statErr) {
+		t.Fatalf("expected socket file to be removed after PID fallback, got err=%v", statErr)
 	}
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -386,7 +387,7 @@ func TestStopNotRunningRemovesStaleArtifacts(t *testing.T) {
 	if err := p.EnsureDirs(); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(p.PIDFile(), []byte("12345"), 0o644); err != nil {
+	if err := os.WriteFile(p.PIDFile(), []byte(fmt.Sprintf("%d", os.Getpid())), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(p.Socket(), []byte("stale"), 0o644); err != nil {
@@ -461,7 +462,7 @@ func TestStopDetachedDaemonKeepsArtifactsOnDialFailure(t *testing.T) {
 	if err := p.EnsureDirs(); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(p.PIDFile(), []byte("12345"), 0o644); err != nil {
+	if err := os.WriteFile(p.PIDFile(), []byte(fmt.Sprintf("%d", os.Getpid())), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	ln, err := net.Listen("unix", p.Socket())
@@ -487,6 +488,56 @@ func TestStopDetachedDaemonKeepsArtifactsOnDialFailure(t *testing.T) {
 	}
 	if _, statErr := os.Stat(p.Socket()); statErr != nil {
 		t.Fatalf("expected socket file to remain after dial failure, got err=%v", statErr)
+	}
+}
+
+func TestStopDetachedDaemonRemovesArtifactsForDeadPID(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix socket setup is platform-specific")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "dtest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	p := paths.WithRoot(tmpDir)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.PIDFile(), []byte("999999"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fd, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := &syscall.SockaddrUnix{Name: p.Socket()}
+	if err := syscall.Bind(fd, addr); err != nil {
+		_ = syscall.Close(fd)
+		t.Fatal(err)
+	}
+	if err := syscall.Close(fd); err != nil {
+		t.Fatal(err)
+	}
+
+	originalDial := daemonDial
+	daemonDial = func(string) (*ipc.Client, error) {
+		return nil, fmt.Errorf("transient ipc failure")
+	}
+	defer func() {
+		daemonDial = originalDial
+	}()
+
+	if err := stopDetachedDaemon(p); err != nil {
+		t.Fatalf("expected stopDetachedDaemon to clean stale artifacts, got %v", err)
+	}
+	if _, statErr := os.Stat(p.PIDFile()); !os.IsNotExist(statErr) {
+		t.Fatalf("expected stale pid file to be removed, got err=%v", statErr)
+	}
+	if _, statErr := os.Stat(p.Socket()); !os.IsNotExist(statErr) {
+		t.Fatalf("expected stale socket file to be removed, got err=%v", statErr)
 	}
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -401,6 +401,48 @@ func TestStopNotRunningRemovesStaleArtifacts(t *testing.T) {
 	}
 }
 
+func TestWaitForDaemonStopKeepsArtifactsWhenKillFails(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dtest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	p := paths.WithRoot(tmpDir)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.PIDFile(), []byte("999999"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.Socket(), []byte("still-there"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	originalHealthCheck := daemonHealthCheck
+	daemonHealthCheck = func(*paths.Paths) (bool, error) {
+		return true, nil
+	}
+	defer func() {
+		daemonHealthCheck = originalHealthCheck
+	}()
+
+	started := time.Now()
+	err = waitForDaemonStop(p)
+	if err == nil {
+		t.Fatal("expected waitForDaemonStop to fail when kill fails")
+	}
+	if time.Since(started) < 5*time.Second {
+		t.Fatalf("waitForDaemonStop returned too early after %v", time.Since(started))
+	}
+	if _, err := os.Stat(p.PIDFile()); err != nil {
+		t.Fatalf("expected pid file to remain after failed kill, got err=%v", err)
+	}
+	if _, err := os.Stat(p.Socket()); err != nil {
+		t.Fatalf("expected socket file to remain after failed kill, got err=%v", err)
+	}
+}
+
 func TestReadPIDNoFile(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "dtest")
 	if err != nil {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -454,6 +455,48 @@ func TestReadPIDNoFile(t *testing.T) {
 	_, err = ReadPID(p)
 	if err == nil {
 		t.Error("expected error when no PID file")
+	}
+}
+
+func TestWaitForDaemonStopDoesNotTreatHealthCheckErrorsAsStopped(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dtest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	p := paths.WithRoot(tmpDir)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.PIDFile(), []byte("999999"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.Socket(), []byte("still-there"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	originalHealthCheck := daemonHealthCheck
+	daemonHealthCheck = func(*paths.Paths) (bool, error) {
+		return false, errors.New("transient ipc failure")
+	}
+	defer func() {
+		daemonHealthCheck = originalHealthCheck
+	}()
+
+	started := time.Now()
+	err = waitForDaemonStop(p)
+	if err == nil {
+		t.Fatal("expected waitForDaemonStop to fail when health checks only error")
+	}
+	if time.Since(started) < 5*time.Second {
+		t.Fatalf("waitForDaemonStop returned too early after %v", time.Since(started))
+	}
+	if _, err := os.Stat(p.PIDFile()); err != nil {
+		t.Fatalf("expected pid file to remain after health-check errors, got err=%v", err)
+	}
+	if _, err := os.Stat(p.Socket()); err != nil {
+		t.Fatalf("expected socket file to remain after health-check errors, got err=%v", err)
 	}
 }
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -589,6 +589,72 @@ func TestStopDetachedDaemonRejectsStalePIDFallback(t *testing.T) {
 	}
 }
 
+func TestStopDetachedDaemonRejectsUnrelatedLiveProcessPIDFallback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix socket setup is platform-specific")
+	}
+
+	tmpDir, err := os.MkdirTemp("", "dtest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	p := paths.WithRoot(tmpDir)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.PIDFile(), []byte(fmt.Sprintf("%d", os.Getpid())), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ln, err := net.Listen("unix", p.Socket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	originalDial := daemonDial
+	daemonDial = func(string) (*ipc.Client, error) {
+		return nil, fmt.Errorf("transient ipc failure")
+	}
+	defer func() {
+		daemonDial = originalDial
+	}()
+	originalProcessStartTime := daemonProcessStartTime
+	daemonProcessStartTime = func(checkPID int) (time.Time, error) {
+		if checkPID != os.Getpid() {
+			t.Fatalf("processStartTime pid = %d, want %d", checkPID, os.Getpid())
+		}
+		return time.Now().Add(-time.Hour), nil
+	}
+	defer func() {
+		daemonProcessStartTime = originalProcessStartTime
+	}()
+	originalKillPID := daemonKillPID
+	killCalled := false
+	daemonKillPID = func(int) error {
+		killCalled = true
+		return nil
+	}
+	defer func() {
+		daemonKillPID = originalKillPID
+	}()
+
+	err = stopDetachedDaemon(p)
+	if err == nil {
+		t.Fatal("expected unrelated live process pid fallback to fail")
+	}
+	if killCalled {
+		t.Fatal("expected unrelated live process pid fallback to avoid killing the process")
+	}
+	if _, statErr := os.Stat(p.PIDFile()); statErr != nil {
+		t.Fatalf("expected pid file to remain after rejected pid fallback, got err=%v", statErr)
+	}
+	if _, statErr := os.Stat(p.Socket()); statErr != nil {
+		t.Fatalf("expected socket file to remain after rejected pid fallback, got err=%v", statErr)
+	}
+}
+
 func TestStopDetachedDaemonRemovesArtifactsForDeadPID(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("unix socket setup is platform-specific")

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -719,6 +719,74 @@ func TestWaitForDaemonStopDoesNotTreatHealthCheckErrorsAsStopped(t *testing.T) {
 	}
 }
 
+func TestWaitForDaemonStopRejectsStalePIDBeforeKill(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dtest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	p := paths.WithRoot(tmpDir)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.PIDFile(), []byte(fmt.Sprintf("%d", os.Getpid())), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-24 * time.Hour)
+	if err := os.Chtimes(p.PIDFile(), oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.Socket(), []byte("still-there"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	originalHealthCheck := daemonHealthCheck
+	daemonHealthCheck = func(*paths.Paths) (bool, error) {
+		return true, nil
+	}
+	defer func() {
+		daemonHealthCheck = originalHealthCheck
+	}()
+	originalProcessStartTime := daemonProcessStartTime
+	daemonProcessStartTime = func(checkPID int) (time.Time, error) {
+		if checkPID != os.Getpid() {
+			t.Fatalf("processStartTime pid = %d, want %d", checkPID, os.Getpid())
+		}
+		return time.Now(), nil
+	}
+	defer func() {
+		daemonProcessStartTime = originalProcessStartTime
+	}()
+	originalKillPID := daemonKillPID
+	killCalled := false
+	daemonKillPID = func(int) error {
+		killCalled = true
+		return nil
+	}
+	defer func() {
+		daemonKillPID = originalKillPID
+	}()
+
+	started := time.Now()
+	err = waitForDaemonStop(p)
+	if err == nil {
+		t.Fatal("expected waitForDaemonStop to fail for stale pid")
+	}
+	if time.Since(started) < 5*time.Second {
+		t.Fatalf("waitForDaemonStop returned too early after %v", time.Since(started))
+	}
+	if killCalled {
+		t.Fatal("expected stale pid to avoid killing the process")
+	}
+	if _, err := os.Stat(p.PIDFile()); err != nil {
+		t.Fatalf("expected pid file to remain after rejected kill, got err=%v", err)
+	}
+	if _, err := os.Stat(p.Socket()); err != nil {
+		t.Fatalf("expected socket file to remain after rejected kill, got err=%v", err)
+	}
+}
+
 func TestReadPIDInvalid(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "dtest")
 	if err != nil {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -696,6 +696,55 @@ func TestStaleDaemonArtifactsKeepsRegularEndpointFileForLiveProcess(t *testing.T
 	}
 }
 
+func TestStaleDaemonArtifactsRejectsNonPositivePID(t *testing.T) {
+	tests := []struct {
+		name string
+		pid  string
+	}{
+		{name: "zero", pid: "0"},
+		{name: "negative", pid: "-1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "dtest")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(tmpDir)
+
+			p := paths.WithRoot(tmpDir)
+			if err := p.EnsureDirs(); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(p.PIDFile(), []byte(tt.pid), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			called := false
+			original := daemonProcessRunning
+			daemonProcessRunning = func(int) (bool, error) {
+				called = true
+				return false, nil
+			}
+			defer func() {
+				daemonProcessRunning = original
+			}()
+
+			_, err = staleDaemonArtifacts(p)
+			if err == nil {
+				t.Fatal("expected invalid pid error")
+			}
+			if !strings.Contains(err.Error(), "invalid") {
+				t.Fatalf("error = %q, want invalid pid error", err)
+			}
+			if called {
+				t.Fatal("expected invalid pid to avoid process probe")
+			}
+		})
+	}
+}
+
 func TestReadPIDNoFile(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "dtest")
 	if err != nil {
@@ -832,6 +881,39 @@ func TestReadPIDInvalid(t *testing.T) {
 	_, err = ReadPID(p)
 	if err == nil {
 		t.Error("expected error for invalid PID content")
+	}
+}
+
+func TestReadPIDRejectsNonPositiveValues(t *testing.T) {
+	tests := []struct {
+		name string
+		pid  string
+	}{
+		{name: "zero", pid: "0"},
+		{name: "negative", pid: "-1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "dtest")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(tmpDir)
+
+			p := paths.WithRoot(tmpDir)
+			if err := os.WriteFile(filepath.Join(tmpDir, "daemon.pid"), []byte(tt.pid), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err = ReadPID(p)
+			if err == nil {
+				t.Fatal("expected invalid pid error")
+			}
+			if !strings.Contains(err.Error(), "invalid") {
+				t.Fatalf("error = %q, want invalid pid error", err)
+			}
+		})
 	}
 }
 

--- a/internal/daemon/proc_unix.go
+++ b/internal/daemon/proc_unix.go
@@ -52,7 +52,8 @@ func processStartTime(pid int) (time.Time, error) {
 
 func processStartTimeCommand(pid int) *exec.Cmd {
 	cmd := exec.Command("ps", "-p", fmt.Sprintf("%d", pid), "-o", "lstart=")
-	cmd.Env = append(os.Environ(), "LC_ALL=C", "LANG=C")
+	env := upsertEnv(os.Environ(), "LC_ALL", "C")
+	cmd.Env = upsertEnv(env, "LANG", "C")
 	return cmd
 }
 

--- a/internal/daemon/proc_unix.go
+++ b/internal/daemon/proc_unix.go
@@ -42,9 +42,16 @@ func processStartTime(pid int) (time.Time, error) {
 	if startedAt == "" {
 		return time.Time{}, fmt.Errorf("missing process start time")
 	}
-	parsed, err := time.Parse("Mon Jan 2 15:04:05 2006", startedAt)
+	parsed, err := parseProcessStartTime(startedAt, time.Local)
 	if err != nil {
 		return time.Time{}, err
 	}
 	return parsed, nil
+}
+
+func parseProcessStartTime(value string, loc *time.Location) (time.Time, error) {
+	if loc == nil {
+		loc = time.Local
+	}
+	return time.ParseInLocation("Mon Jan 2 15:04:05 2006", value, loc)
 }

--- a/internal/daemon/proc_unix.go
+++ b/internal/daemon/proc_unix.go
@@ -5,6 +5,7 @@ package daemon
 import (
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"syscall"
@@ -33,7 +34,7 @@ func processStartTime(pid int) (time.Time, error) {
 	if pid <= 0 {
 		return time.Time{}, fmt.Errorf("invalid pid %d", pid)
 	}
-	cmd := exec.Command("ps", "-p", fmt.Sprintf("%d", pid), "-o", "lstart=")
+	cmd := processStartTimeCommand(pid)
 	out, err := cmd.Output()
 	if err != nil {
 		return time.Time{}, err
@@ -47,6 +48,12 @@ func processStartTime(pid int) (time.Time, error) {
 		return time.Time{}, err
 	}
 	return parsed, nil
+}
+
+func processStartTimeCommand(pid int) *exec.Cmd {
+	cmd := exec.Command("ps", "-p", fmt.Sprintf("%d", pid), "-o", "lstart=")
+	cmd.Env = append(os.Environ(), "LC_ALL=C", "LANG=C")
+	return cmd
 }
 
 func parseProcessStartTime(value string, loc *time.Location) (time.Time, error) {

--- a/internal/daemon/proc_unix.go
+++ b/internal/daemon/proc_unix.go
@@ -38,14 +38,19 @@ func processRunning(pid int) (bool, error) {
 }
 
 func processState(pid int) (string, error) {
-	cmd := exec.Command("/bin/ps", "-p", fmt.Sprintf("%d", pid), "-o", "stat=")
-	env := upsertEnv(os.Environ(), "LC_ALL", "C")
-	cmd.Env = upsertEnv(env, "LANG", "C")
+	cmd := processStateCommand(pid)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+func processStateCommand(pid int) *exec.Cmd {
+	cmd := exec.Command(psExecutable(), "-p", fmt.Sprintf("%d", pid), "-o", "stat=")
+	env := upsertEnv(os.Environ(), "LC_ALL", "C")
+	cmd.Env = upsertEnv(env, "LANG", "C")
+	return cmd
 }
 
 func processStartTime(pid int) (time.Time, error) {
@@ -69,10 +74,20 @@ func processStartTime(pid int) (time.Time, error) {
 }
 
 func processStartTimeCommand(pid int) *exec.Cmd {
-	cmd := exec.Command("ps", "-p", fmt.Sprintf("%d", pid), "-o", "lstart=")
+	cmd := exec.Command(psExecutable(), "-p", fmt.Sprintf("%d", pid), "-o", "lstart=")
 	env := upsertEnv(os.Environ(), "LC_ALL", "C")
 	cmd.Env = upsertEnv(env, "LANG", "C")
 	return cmd
+}
+
+func psExecutable() string {
+	if path, err := exec.LookPath("ps"); err == nil {
+		return path
+	}
+	if _, err := os.Stat("/bin/ps"); err == nil {
+		return "/bin/ps"
+	}
+	return "ps"
 }
 
 func parseProcessStartTime(value string, loc *time.Location) (time.Time, error) {

--- a/internal/daemon/proc_unix.go
+++ b/internal/daemon/proc_unix.go
@@ -4,8 +4,11 @@ package daemon
 
 import (
 	"errors"
+	"fmt"
 	"os/exec"
+	"strings"
 	"syscall"
+	"time"
 )
 
 func setSysProcAttr(cmd *exec.Cmd) {
@@ -24,4 +27,24 @@ func processRunning(pid int) (bool, error) {
 		return true, nil
 	}
 	return false, err
+}
+
+func processStartTime(pid int) (time.Time, error) {
+	if pid <= 0 {
+		return time.Time{}, fmt.Errorf("invalid pid %d", pid)
+	}
+	cmd := exec.Command("ps", "-p", fmt.Sprintf("%d", pid), "-o", "lstart=")
+	out, err := cmd.Output()
+	if err != nil {
+		return time.Time{}, err
+	}
+	startedAt := strings.TrimSpace(string(out))
+	if startedAt == "" {
+		return time.Time{}, fmt.Errorf("missing process start time")
+	}
+	parsed, err := time.Parse("Mon Jan 2 15:04:05 2006", startedAt)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return parsed, nil
 }

--- a/internal/daemon/proc_unix.go
+++ b/internal/daemon/proc_unix.go
@@ -3,10 +3,25 @@
 package daemon
 
 import (
+	"errors"
 	"os/exec"
 	"syscall"
 )
 
 func setSysProcAttr(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}
+
+func processRunning(pid int) (bool, error) {
+	err := syscall.Kill(pid, 0)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, syscall.ESRCH) {
+		return false, nil
+	}
+	if errors.Is(err, syscall.EPERM) {
+		return true, nil
+	}
+	return false, err
 }

--- a/internal/daemon/proc_unix.go
+++ b/internal/daemon/proc_unix.go
@@ -19,6 +19,13 @@ func setSysProcAttr(cmd *exec.Cmd) {
 func processRunning(pid int) (bool, error) {
 	err := syscall.Kill(pid, 0)
 	if err == nil {
+		state, err := processState(pid)
+		if err != nil {
+			return false, err
+		}
+		if strings.HasPrefix(state, "Z") {
+			return false, nil
+		}
 		return true, nil
 	}
 	if errors.Is(err, syscall.ESRCH) {
@@ -28,6 +35,17 @@ func processRunning(pid int) (bool, error) {
 		return true, nil
 	}
 	return false, err
+}
+
+func processState(pid int) (string, error) {
+	cmd := exec.Command("/bin/ps", "-p", fmt.Sprintf("%d", pid), "-o", "stat=")
+	env := upsertEnv(os.Environ(), "LC_ALL", "C")
+	cmd.Env = upsertEnv(env, "LANG", "C")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
 }
 
 func processStartTime(pid int) (time.Time, error) {

--- a/internal/daemon/proc_unix_test.go
+++ b/internal/daemon/proc_unix_test.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseProcessStartTimeUsesProvidedLocation(t *testing.T) {
+	loc := time.FixedZone("UTC+9", 9*60*60)
+
+	startedAt, err := parseProcessStartTime("Mon Jan 2 15:04:05 2006", loc)
+	if err != nil {
+		t.Fatalf("parseProcessStartTime returned error: %v", err)
+	}
+
+	if startedAt.Location() != loc {
+		t.Fatalf("location = %v, want %v", startedAt.Location(), loc)
+	}
+	if startedAt.UTC() != time.Date(2006, time.January, 2, 6, 4, 5, 0, time.UTC) {
+		t.Fatalf("utc time = %v, want %v", startedAt.UTC(), time.Date(2006, time.January, 2, 6, 4, 5, 0, time.UTC))
+	}
+}

--- a/internal/daemon/proc_unix_test.go
+++ b/internal/daemon/proc_unix_test.go
@@ -3,6 +3,7 @@
 package daemon
 
 import (
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -45,6 +46,30 @@ func TestProcessStartTimeCommandForcesCLocale(t *testing.T) {
 	if countEnvEntries(cmd.Env, "LANG") != 1 {
 		t.Fatalf("expected one LANG entry, got %v", cmd.Env)
 	}
+}
+
+func TestProcessRunningTreatsZombieAsNotRunning(t *testing.T) {
+	cmd := exec.Command("/bin/sh", "-c", "exit 0")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start child: %v", err)
+	}
+	defer func() {
+		_ = cmd.Wait()
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		running, err := processRunning(cmd.Process.Pid)
+		if err != nil {
+			t.Fatalf("processRunning returned error: %v", err)
+		}
+		if !running {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("expected zombie pid %d to be treated as not running", cmd.Process.Pid)
 }
 
 func containsEnvEntry(env []string, want string) bool {

--- a/internal/daemon/proc_unix_test.go
+++ b/internal/daemon/proc_unix_test.go
@@ -4,6 +4,7 @@ package daemon
 
 import (
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -31,8 +32,37 @@ func TestProcessStartTimeCommandForcesCLocale(t *testing.T) {
 
 	cmd := processStartTimeCommand(123)
 
-	if got := strings.Join(cmd.Args, " "); got != "ps -p 123 -o lstart=" {
-		t.Fatalf("args = %q, want %q", got, "ps -p 123 -o lstart=")
+	if got := strings.Join(cmd.Args[1:], " "); got != "-p 123 -o lstart=" {
+		t.Fatalf("args = %q, want %q", got, "-p 123 -o lstart=")
+	}
+	if filepath.Base(cmd.Path) != "ps" {
+		t.Fatalf("path = %q, want ps executable", cmd.Path)
+	}
+	if !containsEnvEntry(cmd.Env, "LC_ALL=C") {
+		t.Fatalf("expected LC_ALL=C in env, got %v", cmd.Env)
+	}
+	if !containsEnvEntry(cmd.Env, "LANG=C") {
+		t.Fatalf("expected LANG=C in env, got %v", cmd.Env)
+	}
+	if countEnvEntries(cmd.Env, "LC_ALL") != 1 {
+		t.Fatalf("expected one LC_ALL entry, got %v", cmd.Env)
+	}
+	if countEnvEntries(cmd.Env, "LANG") != 1 {
+		t.Fatalf("expected one LANG entry, got %v", cmd.Env)
+	}
+}
+
+func TestProcessStateCommandForcesCLocale(t *testing.T) {
+	t.Setenv("LC_ALL", "fr_FR.UTF-8")
+	t.Setenv("LANG", "fr_FR.UTF-8")
+
+	cmd := processStateCommand(123)
+
+	if got := strings.Join(cmd.Args[1:], " "); got != "-p 123 -o stat=" {
+		t.Fatalf("args = %q, want %q", got, "-p 123 -o stat=")
+	}
+	if filepath.Base(cmd.Path) != "ps" {
+		t.Fatalf("path = %q, want ps executable", cmd.Path)
 	}
 	if !containsEnvEntry(cmd.Env, "LC_ALL=C") {
 		t.Fatalf("expected LC_ALL=C in env, got %v", cmd.Env)

--- a/internal/daemon/proc_unix_test.go
+++ b/internal/daemon/proc_unix_test.go
@@ -25,6 +25,9 @@ func TestParseProcessStartTimeUsesProvidedLocation(t *testing.T) {
 }
 
 func TestProcessStartTimeCommandForcesCLocale(t *testing.T) {
+	t.Setenv("LC_ALL", "fr_FR.UTF-8")
+	t.Setenv("LANG", "fr_FR.UTF-8")
+
 	cmd := processStartTimeCommand(123)
 
 	if got := strings.Join(cmd.Args, " "); got != "ps -p 123 -o lstart=" {
@@ -36,6 +39,12 @@ func TestProcessStartTimeCommandForcesCLocale(t *testing.T) {
 	if !containsEnvEntry(cmd.Env, "LANG=C") {
 		t.Fatalf("expected LANG=C in env, got %v", cmd.Env)
 	}
+	if countEnvEntries(cmd.Env, "LC_ALL") != 1 {
+		t.Fatalf("expected one LC_ALL entry, got %v", cmd.Env)
+	}
+	if countEnvEntries(cmd.Env, "LANG") != 1 {
+		t.Fatalf("expected one LANG entry, got %v", cmd.Env)
+	}
 }
 
 func containsEnvEntry(env []string, want string) bool {
@@ -45,4 +54,15 @@ func containsEnvEntry(env []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func countEnvEntries(env []string, key string) int {
+	prefix := key + "="
+	count := 0
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			count++
+		}
+	}
+	return count
 }

--- a/internal/daemon/proc_unix_test.go
+++ b/internal/daemon/proc_unix_test.go
@@ -3,6 +3,7 @@
 package daemon
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -21,4 +22,27 @@ func TestParseProcessStartTimeUsesProvidedLocation(t *testing.T) {
 	if startedAt.UTC() != time.Date(2006, time.January, 2, 6, 4, 5, 0, time.UTC) {
 		t.Fatalf("utc time = %v, want %v", startedAt.UTC(), time.Date(2006, time.January, 2, 6, 4, 5, 0, time.UTC))
 	}
+}
+
+func TestProcessStartTimeCommandForcesCLocale(t *testing.T) {
+	cmd := processStartTimeCommand(123)
+
+	if got := strings.Join(cmd.Args, " "); got != "ps -p 123 -o lstart=" {
+		t.Fatalf("args = %q, want %q", got, "ps -p 123 -o lstart=")
+	}
+	if !containsEnvEntry(cmd.Env, "LC_ALL=C") {
+		t.Fatalf("expected LC_ALL=C in env, got %v", cmd.Env)
+	}
+	if !containsEnvEntry(cmd.Env, "LANG=C") {
+		t.Fatalf("expected LANG=C in env, got %v", cmd.Env)
+	}
+}
+
+func containsEnvEntry(env []string, want string) bool {
+	for _, entry := range env {
+		if entry == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/daemon/proc_windows.go
+++ b/internal/daemon/proc_windows.go
@@ -4,6 +4,7 @@ package daemon
 
 import (
 	"os/exec"
+	"time"
 
 	"golang.org/x/sys/windows"
 )
@@ -32,4 +33,24 @@ func processRunning(pid int) (bool, error) {
 		return false, err
 	}
 	return exitCode == windowsStillActive, nil
+}
+
+func processStartTime(pid int) (time.Time, error) {
+	if pid <= 0 {
+		return time.Time{}, windows.ERROR_INVALID_PARAMETER
+	}
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return time.Time{}, err
+	}
+	defer windows.CloseHandle(handle)
+
+	var created windows.Filetime
+	var exited windows.Filetime
+	var kernel windows.Filetime
+	var user windows.Filetime
+	if err := windows.GetProcessTimes(handle, &created, &exited, &kernel, &user); err != nil {
+		return time.Time{}, err
+	}
+	return time.Unix(0, created.Nanoseconds()), nil
 }

--- a/internal/daemon/proc_windows.go
+++ b/internal/daemon/proc_windows.go
@@ -2,7 +2,13 @@
 
 package daemon
 
-import "os/exec"
+import (
+	"os/exec"
+
+	"golang.org/x/sys/windows"
+)
+
+const windowsStillActive = 259
 
 func setSysProcAttr(cmd *exec.Cmd) {
 	// No Setsid equivalent on Windows; daemon runs in same session.
@@ -12,5 +18,18 @@ func processRunning(pid int) (bool, error) {
 	if pid <= 0 {
 		return false, nil
 	}
-	return true, nil
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		if err == windows.ERROR_INVALID_PARAMETER {
+			return false, nil
+		}
+		return false, err
+	}
+	defer windows.CloseHandle(handle)
+
+	var exitCode uint32
+	if err := windows.GetExitCodeProcess(handle, &exitCode); err != nil {
+		return false, err
+	}
+	return exitCode == windowsStillActive, nil
 }

--- a/internal/daemon/proc_windows.go
+++ b/internal/daemon/proc_windows.go
@@ -7,3 +7,10 @@ import "os/exec"
 func setSysProcAttr(cmd *exec.Cmd) {
 	// No Setsid equivalent on Windows; daemon runs in same session.
 }
+
+func processRunning(pid int) (bool, error) {
+	if pid <= 0 {
+		return false, nil
+	}
+	return true, nil
+}

--- a/internal/daemon/proc_windows_test.go
+++ b/internal/daemon/proc_windows_test.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package daemon
+
+import "testing"
+
+func TestProcessRunningReturnsFalseForMissingPID(t *testing.T) {
+	running, err := processRunning(999999)
+	if err != nil {
+		t.Fatalf("processRunning returned error: %v", err)
+	}
+	if running {
+		t.Fatal("expected missing pid to be reported as not running")
+	}
+}

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -200,12 +200,24 @@ func waitForDaemonStop(p *paths.Paths) error {
 	if pid, err := ReadPID(p); err == nil {
 		if proc, err := os.FindProcess(pid); err == nil {
 			slog.Warn("daemon did not stop gracefully, killing", "pid", pid)
-			proc.Kill()
+			if err := proc.Kill(); err != nil {
+				return fmt.Errorf("kill daemon pid %d: %w", pid, err)
+			}
+
+			killDeadline := time.Now().Add(2 * time.Second)
+			for time.Now().Before(killDeadline) {
+				if alive, _ := daemonHealthCheck(p); !alive {
+					cleanupDaemonArtifacts(p)
+					slog.Warn("daemon killed after shutdown timeout", "pid", pid)
+					return nil
+				}
+				time.Sleep(100 * time.Millisecond)
+			}
+			return fmt.Errorf("daemon pid %d still running after kill", pid)
 		}
 	}
-	cleanupDaemonArtifacts(p)
 
-	return nil
+	return fmt.Errorf("daemon did not stop within timeout")
 }
 
 func cleanupDaemonArtifacts(p *paths.Paths) {

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -203,13 +203,18 @@ func staleDaemonArtifacts(p *paths.Paths) (bool, error) {
 	if info.Mode()&os.ModeSocket == 0 {
 		return true, nil
 	}
-	if _, err := ReadPID(p); err != nil {
+	pid, err := ReadPID(p)
+	if err != nil {
 		if os.IsNotExist(err) {
 			return true, nil
 		}
 		return false, err
 	}
-	return false, nil
+	running, err := processRunning(pid)
+	if err != nil {
+		return false, err
+	}
+	return !running, nil
 }
 
 func waitForDaemonStop(p *paths.Paths) error {

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -14,6 +14,7 @@ import (
 )
 
 var daemonHealthCheck = daemonIsRunningViaIPC
+var daemonDial = ipc.Dial
 
 func daemonStartTimeout() time.Duration {
 	return durationFromEnv("NM_TEST_DAEMON_START_TIMEOUT", 5*time.Second)
@@ -170,10 +171,17 @@ func Stop(p *paths.Paths) error {
 }
 
 func stopDetachedDaemon(p *paths.Paths) error {
-	client, err := ipc.Dial(p.Socket())
+	client, err := daemonDial(p.Socket())
 	if err != nil {
-		cleanupDaemonArtifacts(p)
-		return nil
+		stale, staleErr := staleDaemonArtifacts(p)
+		if staleErr != nil {
+			return staleErr
+		}
+		if stale {
+			cleanupDaemonArtifacts(p)
+			return nil
+		}
+		return fmt.Errorf("dial daemon: %w", err)
 	}
 	defer client.Close()
 
@@ -182,6 +190,26 @@ func stopDetachedDaemon(p *paths.Paths) error {
 		return fmt.Errorf("shutdown request: %w", err)
 	}
 	return waitForDaemonStop(p)
+}
+
+func staleDaemonArtifacts(p *paths.Paths) (bool, error) {
+	info, err := os.Stat(p.Socket())
+	if os.IsNotExist(err) {
+		return true, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("stat daemon socket: %w", err)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return true, nil
+	}
+	if _, err := ReadPID(p); err != nil {
+		if os.IsNotExist(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	return false, nil
 }
 
 func waitForDaemonStop(p *paths.Paths) error {

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -293,24 +293,28 @@ func waitForDaemonStop(p *paths.Paths) error {
 
 	// Try to kill by PID as last resort.
 	if pid, err := ReadPID(p); err == nil {
-		if proc, err := os.FindProcess(pid); err == nil {
-			slog.Warn("daemon did not stop gracefully, killing", "pid", pid)
-			if err := proc.Kill(); err != nil {
-				return fmt.Errorf("kill daemon pid %d: %w", pid, err)
-			}
-
-			killDeadline := time.Now().Add(2 * time.Second)
-			for time.Now().Before(killDeadline) {
-				alive, err := daemonHealthCheck(p)
-				if err == nil && !alive {
-					cleanupDaemonArtifacts(p)
-					slog.Warn("daemon killed after shutdown timeout", "pid", pid)
-					return nil
-				}
-				time.Sleep(100 * time.Millisecond)
-			}
-			return fmt.Errorf("daemon pid %d still running after kill", pid)
+		if err := validateDaemonPIDFallback(p, pid); err != nil {
+			return err
 		}
+		slog.Warn("daemon did not stop gracefully, killing", "pid", pid)
+		if err := daemonKillPID(pid); err != nil {
+			return fmt.Errorf("kill daemon pid %d: %w", pid, err)
+		}
+
+		killDeadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(killDeadline) {
+			running, err := daemonProcessRunning(pid)
+			if err != nil {
+				return err
+			}
+			if !running {
+				cleanupDaemonArtifacts(p)
+				slog.Warn("daemon killed after shutdown timeout", "pid", pid)
+				return nil
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		return fmt.Errorf("daemon pid %d still running after kill", pid)
 	}
 
 	return fmt.Errorf("daemon did not stop within timeout")

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"os/exec"
 	"runtime"
@@ -266,7 +267,17 @@ func staleDaemonArtifacts(p *paths.Paths) (bool, error) {
 	pid, err := ReadPID(p)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return true, nil
+			if missingSocket {
+				return true, nil
+			}
+			if daemonEndpointUsesRegularFile() {
+				return false, nil
+			}
+			alive, err := daemonSocketAcceptingConnections(p.Socket())
+			if err != nil {
+				return false, err
+			}
+			return !alive, nil
 		}
 		return false, err
 	}
@@ -278,6 +289,15 @@ func staleDaemonArtifacts(p *paths.Paths) (bool, error) {
 		return false, nil
 	}
 	return !running, nil
+}
+
+func daemonSocketAcceptingConnections(path string) (bool, error) {
+	conn, err := net.DialTimeout("unix", path, 200*time.Millisecond)
+	if err != nil {
+		return false, nil
+	}
+	defer conn.Close()
+	return true, nil
 }
 
 func waitForDaemonStop(p *paths.Paths) error {

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -240,7 +240,7 @@ func validateDaemonPIDFallback(p *paths.Paths, pid int) error {
 	if err != nil {
 		return fmt.Errorf("inspect daemon pid %d: %w", pid, err)
 	}
-	if info.ModTime().Before(startTime.Add(-time.Second)) {
+	if startTime.Sub(info.ModTime()) > time.Second || info.ModTime().Sub(startTime) > time.Second {
 		return fmt.Errorf("daemon pid %d does not match pid file instance", pid)
 	}
 	return nil

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -16,6 +16,7 @@ import (
 var daemonHealthCheck = daemonIsRunningViaIPC
 var daemonDial = ipc.Dial
 var daemonProcessRunning = processRunning
+var daemonProcessStartTime = processStartTime
 var daemonKillPID = killPID
 
 func daemonStartTimeout() time.Duration {
@@ -202,6 +203,9 @@ func stopDetachedDaemonByPID(p *paths.Paths) error {
 	if err != nil {
 		return err
 	}
+	if err := validateDaemonPIDFallback(p, pid); err != nil {
+		return err
+	}
 	if err := daemonKillPID(pid); err != nil {
 		return fmt.Errorf("kill daemon pid %d: %w", pid, err)
 	}
@@ -220,6 +224,24 @@ func stopDetachedDaemonByPID(p *paths.Paths) error {
 	}
 
 	return fmt.Errorf("daemon pid %d still running after kill", pid)
+}
+
+func validateDaemonPIDFallback(p *paths.Paths, pid int) error {
+	if pid <= 0 {
+		return fmt.Errorf("invalid daemon pid %d", pid)
+	}
+	info, err := os.Stat(p.PIDFile())
+	if err != nil {
+		return fmt.Errorf("stat pid file: %w", err)
+	}
+	startTime, err := daemonProcessStartTime(pid)
+	if err != nil {
+		return fmt.Errorf("inspect daemon pid %d: %w", pid, err)
+	}
+	if info.ModTime().Before(startTime.Add(-time.Second)) {
+		return fmt.Errorf("daemon pid %d does not match pid file instance", pid)
+	}
+	return nil
 }
 
 func killPID(pid int) error {

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -365,5 +365,8 @@ func ReadPID(p *paths.Paths) (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("invalid pid file: %w", err)
 	}
+	if pid <= 0 {
+		return 0, fmt.Errorf("invalid pid file: pid must be positive")
+	}
 	return pid, nil
 }

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
@@ -71,9 +72,7 @@ func stopManagedFallback(p *paths.Paths) error {
 }
 
 func startDetachedDaemon(p *paths.Paths) error {
-	// Clean up stale socket/pid files
-	os.Remove(p.Socket())
-	os.Remove(p.PIDFile())
+	cleanupDaemonArtifacts(p)
 
 	exe, err := os.Executable()
 	if err != nil {
@@ -87,7 +86,8 @@ func startDetachedDaemon(p *paths.Paths) error {
 	defer logFile.Close()
 
 	cmd := exec.Command(exe)
-	cmd.Env = append(os.Environ(), "NM_DAEMON=1")
+	cmd.Env = upsertEnv(os.Environ(), "NM_HOME", p.Root())
+	cmd.Env = upsertEnv(cmd.Env, "NM_DAEMON", "1")
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 	// Detach from parent process group so daemon survives CLI exit.
@@ -172,6 +172,7 @@ func Stop(p *paths.Paths) error {
 func stopDetachedDaemon(p *paths.Paths) error {
 	client, err := ipc.Dial(p.Socket())
 	if err != nil {
+		cleanupDaemonArtifacts(p)
 		return nil
 	}
 	defer client.Close()
@@ -188,6 +189,7 @@ func waitForDaemonStop(p *paths.Paths) error {
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		if alive, _ := daemonHealthCheck(p); !alive {
+			cleanupDaemonArtifacts(p)
 			slog.Info("daemon stopped gracefully")
 			return nil
 		}
@@ -201,8 +203,34 @@ func waitForDaemonStop(p *paths.Paths) error {
 			proc.Kill()
 		}
 	}
+	cleanupDaemonArtifacts(p)
 
 	return nil
+}
+
+func cleanupDaemonArtifacts(p *paths.Paths) {
+	_ = os.Remove(p.Socket())
+	_ = os.Remove(p.PIDFile())
+}
+
+func upsertEnv(env []string, key, value string) []string {
+	prefix := key + "="
+	updated := false
+	result := make([]string, 0, len(env)+1)
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			if !updated {
+				result = append(result, prefix+value)
+				updated = true
+			}
+			continue
+		}
+		result = append(result, entry)
+	}
+	if !updated {
+		result = append(result, prefix+value)
+	}
+	return result
 }
 
 // EnsureDaemon starts the daemon if it's not already running.

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -194,13 +194,11 @@ func stopDetachedDaemon(p *paths.Paths) error {
 
 func staleDaemonArtifacts(p *paths.Paths) (bool, error) {
 	info, err := os.Stat(p.Socket())
-	if os.IsNotExist(err) {
-		return true, nil
-	}
-	if err != nil {
+	missingSocket := os.IsNotExist(err)
+	if err != nil && !missingSocket {
 		return false, fmt.Errorf("stat daemon socket: %w", err)
 	}
-	if info.Mode()&os.ModeSocket == 0 {
+	if err == nil && info.Mode()&os.ModeSocket == 0 {
 		return true, nil
 	}
 	pid, err := ReadPID(p)
@@ -213,6 +211,9 @@ func staleDaemonArtifacts(p *paths.Paths) (bool, error) {
 	running, err := processRunning(pid)
 	if err != nil {
 		return false, err
+	}
+	if missingSocket && running {
+		return false, nil
 	}
 	return !running, nil
 }

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -15,6 +15,8 @@ import (
 
 var daemonHealthCheck = daemonIsRunningViaIPC
 var daemonDial = ipc.Dial
+var daemonProcessRunning = processRunning
+var daemonKillPID = killPID
 
 func daemonStartTimeout() time.Duration {
 	return durationFromEnv("NM_TEST_DAEMON_START_TIMEOUT", 5*time.Second)
@@ -181,7 +183,10 @@ func stopDetachedDaemon(p *paths.Paths) error {
 			cleanupDaemonArtifacts(p)
 			return nil
 		}
-		return fmt.Errorf("dial daemon: %w", err)
+		if killErr := stopDetachedDaemonByPID(p); killErr != nil {
+			return fmt.Errorf("dial daemon: %w; pid fallback: %v", err, killErr)
+		}
+		return nil
 	}
 	defer client.Close()
 
@@ -190,6 +195,39 @@ func stopDetachedDaemon(p *paths.Paths) error {
 		return fmt.Errorf("shutdown request: %w", err)
 	}
 	return waitForDaemonStop(p)
+}
+
+func stopDetachedDaemonByPID(p *paths.Paths) error {
+	pid, err := ReadPID(p)
+	if err != nil {
+		return err
+	}
+	if err := daemonKillPID(pid); err != nil {
+		return fmt.Errorf("kill daemon pid %d: %w", pid, err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		running, err := daemonProcessRunning(pid)
+		if err != nil {
+			return err
+		}
+		if !running {
+			cleanupDaemonArtifacts(p)
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	return fmt.Errorf("daemon pid %d still running after kill", pid)
+}
+
+func killPID(pid int) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("find process: %w", err)
+	}
+	return proc.Kill()
 }
 
 func staleDaemonArtifacts(p *paths.Paths) (bool, error) {
@@ -208,7 +246,7 @@ func staleDaemonArtifacts(p *paths.Paths) (bool, error) {
 		}
 		return false, err
 	}
-	running, err := processRunning(pid)
+	running, err := daemonProcessRunning(pid)
 	if err != nil {
 		return false, err
 	}

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -188,7 +188,8 @@ func waitForDaemonStop(p *paths.Paths) error {
 	// Wait for daemon to actually stop (socket becomes unavailable).
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
-		if alive, _ := daemonHealthCheck(p); !alive {
+		alive, err := daemonHealthCheck(p)
+		if err == nil && !alive {
 			cleanupDaemonArtifacts(p)
 			slog.Info("daemon stopped gracefully")
 			return nil
@@ -206,7 +207,8 @@ func waitForDaemonStop(p *paths.Paths) error {
 
 			killDeadline := time.Now().Add(2 * time.Second)
 			for time.Now().Before(killDeadline) {
-				if alive, _ := daemonHealthCheck(p); !alive {
+				alive, err := daemonHealthCheck(p)
+				if err == nil && !alive {
 					cleanupDaemonArtifacts(p)
 					slog.Warn("daemon killed after shutdown timeout", "pid", pid)
 					return nil

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -18,6 +19,7 @@ var daemonDial = ipc.Dial
 var daemonProcessRunning = processRunning
 var daemonProcessStartTime = processStartTime
 var daemonKillPID = killPID
+var daemonEndpointUsesRegularFile = func() bool { return runtime.GOOS == "windows" }
 
 func daemonStartTimeout() time.Duration {
 	return durationFromEnv("NM_TEST_DAEMON_START_TIMEOUT", 5*time.Second)
@@ -258,7 +260,7 @@ func staleDaemonArtifacts(p *paths.Paths) (bool, error) {
 	if err != nil && !missingSocket {
 		return false, fmt.Errorf("stat daemon socket: %w", err)
 	}
-	if err == nil && info.Mode()&os.ModeSocket == 0 {
+	if err == nil && info.Mode()&os.ModeSocket == 0 && !daemonEndpointUsesRegularFile() {
 		return true, nil
 	}
 	pid, err := ReadPID(p)

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -217,7 +217,7 @@ func installLaunchAgent(p *paths.Paths, exe string) error {
 	if err := os.WriteFile(path, []byte(renderLaunchAgent(exe, p, home)), 0o644); err != nil {
 		return fmt.Errorf("write launch agent: %w", err)
 	}
-	cleanupLegacyLaunchAgent()
+	cleanupLegacyLaunchAgent(p)
 	return nil
 }
 
@@ -227,9 +227,10 @@ func installLaunchAgent(p *paths.Paths, exe string) error {
 // before deleting so an already-loaded legacy daemon is released from
 // launchd (it will exit on SIGTERM). Any error is best-effort: if there's
 // no legacy plist or launchctl refuses, we proceed with the scoped install.
-func cleanupLegacyLaunchAgent() {
+func cleanupLegacyLaunchAgent(p *paths.Paths) {
 	path := legacyLaunchAgentPath()
-	if _, err := os.Stat(path); err != nil {
+	data, err := os.ReadFile(path)
+	if err != nil || !serviceDefinitionMatchesRoot(data, p) {
 		return
 	}
 	if domain, err := launchdDomainTarget(); err == nil {
@@ -287,13 +288,14 @@ func installSystemdUserService(p *paths.Paths, exe string) error {
 	if _, err := serviceCommandRunner("systemctl", "--user", "enable", systemdServiceName(p)); err != nil {
 		return fmt.Errorf("systemctl enable: %w", err)
 	}
-	cleanupLegacySystemdUnit()
+	cleanupLegacySystemdUnit(p)
 	return nil
 }
 
-func cleanupLegacySystemdUnit() {
+func cleanupLegacySystemdUnit(p *paths.Paths) {
 	path := legacySystemdUserServicePath()
-	if _, err := os.Stat(path); err != nil {
+	data, err := os.ReadFile(path)
+	if err != nil || !serviceDefinitionMatchesRoot(data, p) {
 		return
 	}
 	_, _ = serviceCommandRunner("systemctl", "--user", "stop", legacySystemdServiceName)
@@ -329,15 +331,13 @@ func installWindowsTask(p *paths.Paths, exe string) error {
 	if _, err := serviceCommandRunner("schtasks", args...); err != nil {
 		return fmt.Errorf("schtasks create: %w", err)
 	}
-	cleanupLegacyWindowsTask()
+	cleanupLegacyWindowsTask(p)
 	return nil
 }
 
-func cleanupLegacyWindowsTask() {
-	// schtasks /Query returns a non-zero exit when the task doesn't exist,
-	// so we only issue the destructive Delete when the legacy task is
-	// actually present.
-	if _, err := serviceCommandRunner("schtasks", "/Query", "/TN", legacyWindowsTaskName); err != nil {
+func cleanupLegacyWindowsTask(p *paths.Paths) {
+	data, err := serviceCommandRunner("schtasks", "/Query", "/TN", legacyWindowsTaskName, "/XML")
+	if err != nil || !serviceDefinitionMatchesRoot(data, p) {
 		return
 	}
 	_, _ = serviceCommandRunner("schtasks", "/End", "/TN", legacyWindowsTaskName)

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -195,6 +195,16 @@ func managedServiceInstalled(p *paths.Paths) bool {
 	}
 }
 
+func serviceDefinitionMatchesRoot(data []byte, p *paths.Paths) bool {
+	if len(data) == 0 {
+		return false
+	}
+	if p == nil {
+		return true
+	}
+	return strings.Contains(string(data), p.Root())
+}
+
 func installLaunchAgent(p *paths.Paths, exe string) error {
 	path := launchAgentPath(p)
 	home, err := serviceUserHomeDir()

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -202,7 +202,26 @@ func serviceDefinitionMatchesRoot(data []byte, p *paths.Paths) bool {
 	if p == nil {
 		return true
 	}
-	return strings.Contains(string(data), p.Root())
+	root := p.Root()
+	text := string(data)
+	if strings.Contains(text, "<string>"+xmlEscaped(root)+"</string>") {
+		return true
+	}
+	for _, line := range strings.Split(text, "\n") {
+		if strings.TrimSpace(line) == "WorkingDirectory="+systemdEscapeArg(root) {
+			return true
+		}
+	}
+	windowsRoot := quoteWindowsTaskArg(root)
+	for _, suffix := range []string{
+		"--root " + windowsRoot + "</Arguments>",
+		"--root " + xmlEscaped(windowsRoot) + "</Arguments>",
+	} {
+		if strings.Contains(text, suffix) {
+			return true
+		}
+	}
+	return false
 }
 
 func installLaunchAgent(p *paths.Paths, exe string) error {

--- a/internal/daemon/service_test.go
+++ b/internal/daemon/service_test.go
@@ -160,7 +160,7 @@ func TestStartInstallsWindowsTaskAndStartsManagedDaemon_EnableWindowsCI(t *testi
 		// Simulate fresh-install: the legacy unsuffixed task is absent, so
 		// the pre-install cleanup query fails and cleanupLegacyWindowsTask
 		// returns without issuing End/Delete.
-		if name == "schtasks" && len(args) >= 3 && args[0] == "/Query" && args[2] == legacyWindowsTaskName {
+		if name == "schtasks" && len(args) >= 4 && args[0] == "/Query" && args[2] == legacyWindowsTaskName && args[3] == "/XML" {
 			return nil, fmt.Errorf("task not found")
 		}
 		return nil, nil
@@ -176,7 +176,7 @@ func TestStartInstallsWindowsTaskAndStartsManagedDaemon_EnableWindowsCI(t *testi
 	}
 
 	wantTaskCommand := strconv.Quote(exe) + " daemon run --root " + strconv.Quote(p.Root())
-	wantQueryLegacy := "schtasks /Query /TN " + legacyWindowsTaskName
+	wantQueryLegacy := "schtasks /Query /TN " + legacyWindowsTaskName + " /XML"
 	wantCreate := "schtasks /Create /TN " + windowsTaskName(p) +
 		" /SC ONLOGON /RL LIMITED /F /TR " + wantTaskCommand
 	wantRun := "schtasks /Run /TN " + windowsTaskName(p)
@@ -223,6 +223,116 @@ func TestInstallLaunchAgentKeepsLegacyPlistOnScopedWriteFailure(t *testing.T) {
 	}
 	if _, statErr := os.Stat(legacyPath); statErr != nil {
 		t.Fatalf("legacy plist should remain after failed scoped install: %v", statErr)
+	}
+}
+
+func TestInstallLaunchAgentDoesNotRemoveLegacyPlistForDifferentRoot(t *testing.T) {
+	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+
+	cleanup := stubServiceRuntime(t)
+	defer cleanup()
+	runtimeGOOS = "darwin"
+	serviceUserHomeDir = func() (string, error) { return home, nil }
+	serviceCurrentUser = func() (*user.User, error) { return &user.User{Uid: "501"}, nil }
+
+	legacyPath := filepath.Join(home, "Library", "LaunchAgents", legacyLaunchdServiceLabel+".plist")
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	otherRoot := filepath.Join(t.TempDir(), "other-nm-home")
+	legacyPlist := renderLaunchAgent("/opt/no-mistakes/bin/no-mistakes", paths.WithRoot(otherRoot), home)
+	if err := os.WriteFile(legacyPath, []byte(legacyPlist), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var commands []string
+	serviceCommandRunner = func(name string, args ...string) ([]byte, error) {
+		commands = append(commands, name+" "+strings.Join(args, " "))
+		return nil, nil
+	}
+
+	if err := installLaunchAgent(p, "/opt/no-mistakes/bin/no-mistakes"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(legacyPath); err != nil {
+		t.Fatalf("legacy plist for different root should remain: %v", err)
+	}
+	if len(commands) != 0 {
+		t.Fatalf("install should not boot out unrelated legacy daemon, got commands %v", commands)
+	}
+}
+
+func TestInstallSystemdUserServiceDoesNotRemoveLegacyUnitForDifferentRoot(t *testing.T) {
+	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+
+	cleanup := stubServiceRuntime(t)
+	defer cleanup()
+	runtimeGOOS = "linux"
+	serviceUserHomeDir = func() (string, error) { return home, nil }
+
+	legacyPath := filepath.Join(home, ".config", "systemd", "user", legacySystemdServiceName)
+	if err := os.MkdirAll(filepath.Dir(legacyPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	otherRoot := filepath.Join(t.TempDir(), "other-nm-home")
+	legacyUnit := renderSystemdUnit("/usr/local/bin/no-mistakes", paths.WithRoot(otherRoot), home)
+	if err := os.WriteFile(legacyPath, []byte(legacyUnit), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var commands []string
+	serviceCommandRunner = func(name string, args ...string) ([]byte, error) {
+		commands = append(commands, name+" "+strings.Join(args, " "))
+		return nil, nil
+	}
+
+	if err := installSystemdUserService(p, "/usr/local/bin/no-mistakes"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(legacyPath); err != nil {
+		t.Fatalf("legacy unit for different root should remain: %v", err)
+	}
+	if len(commands) != 2 {
+		t.Fatalf("install should not stop unrelated legacy service, got commands %v", commands)
+	}
+}
+
+func TestInstallWindowsTaskDoesNotRemoveLegacyTaskForDifferentRoot_EnableWindowsCI(t *testing.T) {
+	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	cleanup := stubServiceRuntime(t)
+	defer cleanup()
+	runtimeGOOS = "windows"
+
+	var commands []string
+	serviceCommandRunner = func(name string, args ...string) ([]byte, error) {
+		commands = append(commands, name+" "+strings.Join(args, " "))
+		if name == "schtasks" && len(args) >= 4 && args[0] == "/Query" && args[2] == legacyWindowsTaskName && args[3] == "/XML" {
+			otherRoot := filepath.Join(t.TempDir(), "other-nm-home")
+			return []byte(`<Task><Exec><Command>C:\nm.exe</Command><Arguments>daemon run --root ` + otherRoot + `</Arguments></Exec></Task>`), nil
+		}
+		return nil, nil
+	}
+
+	if err := installWindowsTask(p, `C:\Program Files\no-mistakes\no-mistakes.exe`); err != nil {
+		t.Fatal(err)
+	}
+	if len(commands) != 2 {
+		t.Fatalf("install should not end or delete unrelated legacy task, got commands %v", commands)
+	}
+	if commands[1] != "schtasks /Query /TN "+legacyWindowsTaskName+" /XML" {
+		t.Fatalf("legacy query command = %q", commands[1])
 	}
 }
 

--- a/internal/daemon/service_test.go
+++ b/internal/daemon/service_test.go
@@ -336,6 +336,36 @@ func TestInstallWindowsTaskDoesNotRemoveLegacyTaskForDifferentRoot_EnableWindows
 	}
 }
 
+func TestServiceDefinitionMatchesRootRejectsPrefixOnlyMatch(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), "nm")
+	otherRoot := root + "-prod"
+	home := t.TempDir()
+	p := paths.WithRoot(root)
+	other := paths.WithRoot(otherRoot)
+
+	if serviceDefinitionMatchesRoot([]byte(renderLaunchAgent("/opt/no-mistakes/bin/no-mistakes", other, home)), p) {
+		t.Fatal("expected launch agent root prefix collision to be rejected")
+	}
+	if serviceDefinitionMatchesRoot([]byte(renderSystemdUnit("/usr/local/bin/no-mistakes", other, home)), p) {
+		t.Fatal("expected systemd root prefix collision to be rejected")
+	}
+	if serviceDefinitionMatchesRoot([]byte(`<Task><Exec><Command>C:\nm.exe</Command><Arguments>`+buildWindowsTaskCommand(`C:\nm.exe`, otherRoot)+`</Arguments></Exec></Task>`), p) {
+		t.Fatal("expected windows task root prefix collision to be rejected")
+	}
+
+	if !serviceDefinitionMatchesRoot([]byte(renderLaunchAgent("/opt/no-mistakes/bin/no-mistakes", p, home)), p) {
+		t.Fatal("expected exact launch agent root match")
+	}
+	if !serviceDefinitionMatchesRoot([]byte(renderSystemdUnit("/usr/local/bin/no-mistakes", p, home)), p) {
+		t.Fatal("expected exact systemd root match")
+	}
+	if !serviceDefinitionMatchesRoot([]byte(`<Task><Exec><Command>C:\nm.exe</Command><Arguments>`+buildWindowsTaskCommand(`C:\nm.exe`, root)+`</Arguments></Exec></Task>`), p) {
+		t.Fatal("expected exact windows task root match")
+	}
+}
+
 func TestInstallSystemdUserServiceKeepsLegacyUnitOnEnableFailure(t *testing.T) {
 	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
 	if err := p.EnsureDirs(); err != nil {

--- a/internal/daemon/service_test.go
+++ b/internal/daemon/service_test.go
@@ -374,6 +374,38 @@ func TestStartFallsBackToDetachedDaemonWhenManagedStartFails(t *testing.T) {
 	_ = os.Remove(p.Socket())
 }
 
+func TestStartDetachedDaemonUsesProvidedRootViaNMHome(t *testing.T) {
+	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	capturePath := filepath.Join(t.TempDir(), "nm-home.txt")
+
+	t.Setenv("NM_DAEMON_HELPER_PROCESS", "1")
+	t.Setenv("NM_CAPTURE_NM_HOME_FILE", capturePath)
+	t.Setenv("NM_HOME", "")
+
+	cleanup := stubServiceRuntime(t)
+	defer cleanup()
+	checks := 0
+	daemonHealthCheck = func(*paths.Paths) (bool, error) {
+		checks++
+		return checks >= 2, nil
+	}
+
+	if err := startDetachedDaemon(p); err != nil {
+		t.Fatalf("startDetachedDaemon should succeed: %v", err)
+	}
+
+	data, err := os.ReadFile(capturePath)
+	if err != nil {
+		t.Fatalf("read captured NM_HOME: %v", err)
+	}
+	if got := string(data); got != p.Root() {
+		t.Fatalf("child NM_HOME = %q, want %q", got, p.Root())
+	}
+}
+
 func TestStartStopsManagedServiceBeforeDetachedFallbackAfterTimeout(t *testing.T) {
 	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
 	if err := p.EnsureDirs(); err != nil {
@@ -459,7 +491,7 @@ func TestStopUsesManagedServiceWhenInstalled(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(unitPath, []byte("[Unit]\n"), 0o644); err != nil {
+	if err := os.WriteFile(unitPath, []byte("WorkingDirectory="+p.Root()+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -481,6 +513,32 @@ func TestStopUsesManagedServiceWhenInstalled(t *testing.T) {
 	}
 }
 
+func TestManagedServiceInstalledRequiresMatchingRoot(t *testing.T) {
+	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
+	home := t.TempDir()
+
+	cleanup := stubServiceRuntime(t)
+	defer cleanup()
+	runtimeGOOS = "darwin"
+	serviceUserHomeDir = func() (string, error) { return home, nil }
+
+	otherRoot := filepath.Join(t.TempDir(), "other-root")
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", launchdServiceLabel(paths.WithRoot(otherRoot))+".plist")
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(plistPath, []byte(renderLaunchAgent("/opt/no-mistakes/bin/no-mistakes", paths.WithRoot(otherRoot), home)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if managedServiceInstalled(p) {
+		t.Fatal("expected mismatched launch agent root to be ignored")
+	}
+	if !managedServiceInstalled(paths.WithRoot(otherRoot)) {
+		t.Fatal("expected matching launch agent root to be detected")
+	}
+}
+
 func TestStopFallsBackToDetachedDaemonWhenManagedStopFails(t *testing.T) {
 	p, _ := startTestDaemon(t)
 	home := t.TempDir()
@@ -494,7 +552,7 @@ func TestStopFallsBackToDetachedDaemonWhenManagedStopFails(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(unitPath, []byte("[Unit]\n"), 0o644); err != nil {
+	if err := os.WriteFile(unitPath, []byte("WorkingDirectory="+p.Root()+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -481,7 +481,10 @@ func latestBitbucketStatuses(statuses []bitbucket.CommitStatus) []bitbucket.Comm
 	latest := make([]bitbucket.CommitStatus, 0, len(statuses))
 	seen := make(map[string]struct{}, len(statuses))
 	for _, status := range statuses {
-		id := bitbucketStatusName(status)
+		id := strings.TrimSpace(status.Key)
+		if id == "" {
+			id = bitbucketStatusName(status)
+		}
 		if id == "" {
 			latest = append(latest, status)
 			continue

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -480,8 +480,10 @@ func bitbucketStatusBucket(state string) string {
 	switch strings.ToUpper(strings.TrimSpace(state)) {
 	case "SUCCESSFUL", "SUCCESS":
 		return "pass"
-	case "FAILED", "FAILURE", "ERROR", "STOPPED":
+	case "FAILED", "FAILURE", "ERROR":
 		return "fail"
+	case "STOPPED":
+		return "cancel"
 	case "INPROGRESS", "IN_PROGRESS", "PENDING":
 		return "pending"
 	default:

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -451,6 +451,7 @@ func (s *CIStep) getCIChecks(sctx *pipeline.StepContext, provider scm.Provider, 
 		if err != nil {
 			return nil, err
 		}
+		statuses = latestBitbucketStatuses(statuses)
 		checks := make([]ciCheck, 0, len(statuses))
 		for _, status := range statuses {
 			checks = append(checks, ciCheck{
@@ -474,6 +475,27 @@ func (s *CIStep) getCIChecks(sctx *pipeline.StepContext, provider scm.Provider, 
 		return nil, fmt.Errorf("parse CI checks: %w", err)
 	}
 	return checks, nil
+}
+
+func latestBitbucketStatuses(statuses []bitbucket.CommitStatus) []bitbucket.CommitStatus {
+	latest := make([]bitbucket.CommitStatus, 0, len(statuses))
+	seen := make(map[string]struct{}, len(statuses))
+	for _, status := range statuses {
+		id := strings.TrimSpace(status.Key)
+		if id == "" {
+			id = strings.TrimSpace(status.Name)
+		}
+		if id == "" {
+			latest = append(latest, status)
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		latest = append(latest, status)
+	}
+	return latest
 }
 
 func bitbucketStatusBucket(state string) string {

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
+	"github.com/kunchenguid/no-mistakes/internal/bitbucket"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/scm"
 	"github.com/kunchenguid/no-mistakes/internal/types"
@@ -160,17 +161,32 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 	if provider == scm.ProviderUnknown && sctx.Run.PRURL != nil {
 		provider = scm.DetectProvider(*sctx.Run.PRURL)
 	}
-	if provider != scm.ProviderGitHub {
+	if provider != scm.ProviderGitHub && provider != scm.ProviderBitbucket {
 		sctx.Log(fmt.Sprintf("skipping CI: provider %s is not supported yet", provider))
 		return &pipeline.StepOutcome{}, nil
 	}
-	if !stepCLIAvailable(sctx, provider) {
-		sctx.Log("skipping CI: gh CLI is not installed")
-		return &pipeline.StepOutcome{}, nil
-	}
-	if !stepAuthConfigured(sctx, provider) {
-		sctx.Log("skipping CI: gh CLI is not authenticated")
-		return &pipeline.StepOutcome{}, nil
+	var bitbucketClient *bitbucket.Client
+	var bitbucketRepo bitbucket.RepoRef
+	if provider == scm.ProviderGitHub {
+		if !stepCLIAvailable(sctx, provider) {
+			sctx.Log("skipping CI: gh CLI is not installed")
+			return &pipeline.StepOutcome{}, nil
+		}
+		if !stepAuthConfigured(sctx, provider) {
+			sctx.Log("skipping CI: gh CLI is not authenticated")
+			return &pipeline.StepOutcome{}, nil
+		}
+	} else {
+		var err error
+		bitbucketClient, err = bitbucket.NewClientFromEnv(sctx.Env)
+		if err != nil {
+			sctx.Log(fmt.Sprintf("skipping CI: %v", err))
+			return &pipeline.StepOutcome{}, nil
+		}
+		bitbucketRepo, err = resolveBitbucketRepoRef(sctx.Repo.UpstreamURL, sctx.Run.PRURL)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Get PR URL from run record
@@ -233,13 +249,13 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 		}
 
 		// Check PR state (merged/closed -> exit)
-		state, err := s.getPRState(sctx, prNumber)
+		state, err := s.getPRState(sctx, provider, bitbucketClient, bitbucketRepo, prNumber)
 		if err != nil {
 			sctx.Log(fmt.Sprintf("warning: could not check PR state: %v", err))
 		} else if state == "MERGED" {
 			sctx.Log("PR has been merged!")
 			return &pipeline.StepOutcome{}, nil
-		} else if state == "CLOSED" {
+		} else if state == "CLOSED" || state == "DECLINED" {
 			sctx.Log("PR has been closed")
 			return &pipeline.StepOutcome{}, nil
 		}
@@ -247,25 +263,27 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 		// Check mergeable state
 		mergeConflict := false
 		mergeabilityKnown := true
-		mergeState, mergeErr := s.getMergeableState(sctx, prNumber)
-		if mergeErr != nil {
-			sctx.Log(fmt.Sprintf("warning: could not check mergeable state: %v", mergeErr))
-			mergeabilityBlockedReason = ""
-		} else {
-			mergeConflict = isMergeConflict(mergeState)
-			mergeabilityKnown = isResolvedMergeableState(mergeState)
-			if !mergeabilityKnown {
-				sctx.Log(fmt.Sprintf("mergeable state still pending: %s", mergeState))
-				mergeabilityBlockedReason = fmt.Sprintf("PR mergeability remained unresolved before timeout: %s", mergeState)
-			} else {
+		if provider == scm.ProviderGitHub {
+			mergeState, mergeErr := s.getMergeableState(sctx, prNumber)
+			if mergeErr != nil {
+				sctx.Log(fmt.Sprintf("warning: could not check mergeable state: %v", mergeErr))
 				mergeabilityBlockedReason = ""
-				timeoutMergeConflict = mergeConflict
+			} else {
+				mergeConflict = isMergeConflict(mergeState)
+				mergeabilityKnown = isResolvedMergeableState(mergeState)
+				if !mergeabilityKnown {
+					sctx.Log(fmt.Sprintf("mergeable state still pending: %s", mergeState))
+					mergeabilityBlockedReason = fmt.Sprintf("PR mergeability remained unresolved before timeout: %s", mergeState)
+				} else {
+					mergeabilityBlockedReason = ""
+					timeoutMergeConflict = mergeConflict
+				}
 			}
 		}
 
 		// Check CI status - wait for all checks to complete before fixing
 		ciFixLimit := sctx.Config.AutoFix.CI
-		checks, err := s.getCIChecks(sctx, prNumber)
+		checks, err := s.getCIChecks(sctx, provider, bitbucketClient, bitbucketRepo, prNumber)
 		if err != nil {
 			sctx.Log(fmt.Sprintf("warning: could not check CI: %v", err))
 		} else {
@@ -381,7 +399,19 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 }
 
 // getPRState returns the PR state (OPEN, MERGED, CLOSED).
-func (s *CIStep) getPRState(sctx *pipeline.StepContext, prNumber string) (string, error) {
+
+func (s *CIStep) getPRState(sctx *pipeline.StepContext, provider scm.Provider, bitbucketClient *bitbucket.Client, bitbucketRepo bitbucket.RepoRef, prNumber string) (string, error) {
+	if provider == scm.ProviderBitbucket {
+		prID, err := strconv.Atoi(prNumber)
+		if err != nil {
+			return "", err
+		}
+		pr, err := bitbucketClient.GetPR(sctx.Ctx, bitbucketRepo, prID)
+		if err != nil {
+			return "", err
+		}
+		return pr.State, nil
+	}
 	cmd := stepCmd(sctx, "gh", "pr", "view", prNumber, "--json", "state", "--jq", ".state")
 	out, err := cmd.Output()
 	if err != nil {
@@ -410,7 +440,27 @@ func isResolvedMergeableState(state string) bool {
 }
 
 // getCIChecks fetches CI check results for a PR.
-func (s *CIStep) getCIChecks(sctx *pipeline.StepContext, prNumber string) ([]ciCheck, error) {
+
+func (s *CIStep) getCIChecks(sctx *pipeline.StepContext, provider scm.Provider, bitbucketClient *bitbucket.Client, bitbucketRepo bitbucket.RepoRef, prNumber string) ([]ciCheck, error) {
+	if provider == scm.ProviderBitbucket {
+		prID, err := strconv.Atoi(prNumber)
+		if err != nil {
+			return nil, err
+		}
+		statuses, err := bitbucketClient.ListPRStatuses(sctx.Ctx, bitbucketRepo, prID)
+		if err != nil {
+			return nil, err
+		}
+		checks := make([]ciCheck, 0, len(statuses))
+		for _, status := range statuses {
+			checks = append(checks, ciCheck{
+				Name:   status.Name,
+				State:  status.State,
+				Bucket: bitbucketStatusBucket(status.State),
+			})
+		}
+		return checks, nil
+	}
 	cmd := stepCmd(sctx, "gh", "pr", "checks", prNumber, "--json", "name,state,bucket")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -426,6 +476,68 @@ func (s *CIStep) getCIChecks(sctx *pipeline.StepContext, prNumber string) ([]ciC
 	return checks, nil
 }
 
+func bitbucketStatusBucket(state string) string {
+	switch strings.ToUpper(strings.TrimSpace(state)) {
+	case "SUCCESSFUL", "SUCCESS":
+		return "pass"
+	case "FAILED", "FAILURE", "ERROR", "STOPPED":
+		return "fail"
+	case "INPROGRESS", "IN_PROGRESS", "PENDING":
+		return "pending"
+	default:
+		return ""
+	}
+}
+
+func resolveBitbucketRepoRef(upstreamURL string, prURL *string) (bitbucket.RepoRef, error) {
+	if repo, err := bitbucket.ParseRepoRef(upstreamURL); err == nil {
+		return repo, nil
+	}
+	if prURL != nil && strings.TrimSpace(*prURL) != "" {
+		return bitbucket.ParseRepoRef(*prURL)
+	}
+	return bitbucket.RepoRef{}, fmt.Errorf("resolve Bitbucket repository from upstream %q", upstreamURL)
+}
+
+func trimLogOutput(logOutput string, maxBytes int) string {
+	if len(logOutput) <= maxBytes {
+		return logOutput
+	}
+	logOutput = logOutput[len(logOutput)-maxBytes:]
+	for i := 0; i < len(logOutput) && i < 4; i++ {
+		if logOutput[i]&0xC0 != 0x80 {
+			return logOutput[i:]
+		}
+	}
+	return logOutput
+}
+
+func (s *CIStep) fetchBitbucketFailedStepLogs(sctx *pipeline.StepContext, client *bitbucket.Client, repo bitbucket.RepoRef, commitSHA string) string {
+	if client == nil || strings.TrimSpace(commitSHA) == "" {
+		return ""
+	}
+	pipelines, err := client.ListPipelinesByCommit(sctx.Ctx, repo, commitSHA)
+	if err != nil {
+		return ""
+	}
+	for _, pipelineRun := range pipelines {
+		steps, err := client.ListPipelineSteps(sctx.Ctx, repo, pipelineRun.UUID)
+		if err != nil {
+			continue
+		}
+		for _, step := range steps {
+			if strings.EqualFold(step.State.Result.Name, "FAILED") {
+				logOutput, err := client.GetStepLog(sctx.Ctx, repo, pipelineRun.UUID, step.UUID)
+				if err != nil || strings.TrimSpace(logOutput) == "" {
+					continue
+				}
+				return trimLogOutput(strings.TrimSpace(logOutput), 32*1024)
+			}
+		}
+	}
+	return ""
+}
+
 // autoFixCI runs the agent to fix CI failures and/or merge conflicts, then commits and pushes.
 // Returns (true, nil) when changes were committed and pushed, (false, nil)
 // when the agent produced no changes, or (false, err) on failure.
@@ -439,8 +551,23 @@ func (s *CIStep) autoFixCI(sctx *pipeline.StepContext, prNumber string, failingN
 	}
 
 	// Find the most recent failing run for this branch so we fetch logs from the right run.
+	provider := scm.DetectProvider(sctx.Repo.UpstreamURL)
+	if provider == scm.ProviderUnknown && sctx.Run.PRURL != nil {
+		provider = scm.DetectProvider(*sctx.Run.PRURL)
+	}
+
 	var runID string
-	if len(failingNames) > 0 {
+	const maxLogBytes = 32 * 1024
+	var logOutput string
+	if provider == scm.ProviderBitbucket {
+		client, err := bitbucket.NewClientFromEnv(sctx.Env)
+		if err == nil {
+			repo, repoErr := resolveBitbucketRepoRef(sctx.Repo.UpstreamURL, sctx.Run.PRURL)
+			if repoErr == nil {
+				logOutput = s.fetchBitbucketFailedStepLogs(sctx, client, repo, sctx.Run.HeadSHA)
+			}
+		}
+	} else if len(failingNames) > 0 {
 		listCmd := stepCmd(sctx, "gh", "run", "list",
 			"--branch", sctx.Run.Branch,
 			"--status", "failure",
@@ -453,22 +580,12 @@ func (s *CIStep) autoFixCI(sctx *pipeline.StepContext, prNumber string, failingN
 	}
 
 	// Attempt to fetch CI failure logs for context
-	const maxLogBytes = 32 * 1024
-	var logOutput string
 	if runID != "" {
 		cmd := stepCmd(sctx, "gh", "run", "view", runID, "--log-failed")
 		out, _ := cmd.Output()
 		if len(out) > 0 {
 			logOutput = strings.TrimSpace(string(out))
-			if len(logOutput) > maxLogBytes {
-				logOutput = logOutput[len(logOutput)-maxLogBytes:]
-				for i := 0; i < len(logOutput) && i < 4; i++ {
-					if logOutput[i]&0xC0 != 0x80 {
-						logOutput = logOutput[i:]
-						break
-					}
-				}
-			}
+			logOutput = trimLogOutput(logOutput, maxLogBytes)
 		}
 	}
 

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -455,7 +455,7 @@ func (s *CIStep) getCIChecks(sctx *pipeline.StepContext, provider scm.Provider, 
 		checks := make([]ciCheck, 0, len(statuses))
 		for _, status := range statuses {
 			checks = append(checks, ciCheck{
-				Name:   status.Name,
+				Name:   bitbucketStatusName(status),
 				State:  status.State,
 				Bucket: bitbucketStatusBucket(status.State),
 			})
@@ -481,10 +481,7 @@ func latestBitbucketStatuses(statuses []bitbucket.CommitStatus) []bitbucket.Comm
 	latest := make([]bitbucket.CommitStatus, 0, len(statuses))
 	seen := make(map[string]struct{}, len(statuses))
 	for _, status := range statuses {
-		id := strings.TrimSpace(status.Key)
-		if id == "" {
-			id = strings.TrimSpace(status.Name)
-		}
+		id := bitbucketStatusName(status)
 		if id == "" {
 			latest = append(latest, status)
 			continue
@@ -496,6 +493,14 @@ func latestBitbucketStatuses(statuses []bitbucket.CommitStatus) []bitbucket.Comm
 		latest = append(latest, status)
 	}
 	return latest
+}
+
+func bitbucketStatusName(status bitbucket.CommitStatus) string {
+	name := strings.TrimSpace(status.Name)
+	if name != "" {
+		return name
+	}
+	return strings.TrimSpace(status.Key)
 }
 
 func bitbucketStatusBucket(state string) string {

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -564,7 +564,14 @@ func (s *CIStep) autoFixCI(sctx *pipeline.StepContext, prNumber string, failingN
 		if err == nil {
 			repo, repoErr := resolveBitbucketRepoRef(sctx.Repo.UpstreamURL, sctx.Run.PRURL)
 			if repoErr == nil {
-				logOutput = s.fetchBitbucketFailedStepLogs(sctx, client, repo, sctx.Run.HeadSHA)
+				prID, convErr := strconv.Atoi(prNumber)
+				if convErr == nil {
+					commitSHA := strings.TrimSpace(sctx.Run.HeadSHA)
+					if pr, prErr := client.GetPR(sctx.Ctx, repo, prID); prErr == nil && pr != nil && strings.TrimSpace(pr.SourceCommitHash) != "" {
+						commitSHA = strings.TrimSpace(pr.SourceCommitHash)
+					}
+					logOutput = s.fetchBitbucketFailedStepLogs(sctx, client, repo, commitSHA)
+				}
 			}
 		}
 	} else if len(failingNames) > 0 {

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -544,7 +545,65 @@ func trimLogOutput(logOutput string, maxBytes int) string {
 	return logOutput
 }
 
-func (s *CIStep) fetchBitbucketFailedStepLogs(sctx *pipeline.StepContext, client *bitbucket.Client, repo bitbucket.RepoRef, commitSHA string) string {
+func normalizeBitbucketPipelineUUID(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	trimmed = strings.Trim(trimmed, "{}")
+	if trimmed == "" {
+		return ""
+	}
+	return strings.ToLower(trimmed)
+}
+
+func bitbucketPipelineUUIDFromStatusURL(raw string) string {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return ""
+	}
+	fragments := []string{parsed.Fragment, parsed.Path}
+	for _, fragment := range fragments {
+		idx := strings.LastIndex(fragment, "/results/")
+		if idx < 0 {
+			continue
+		}
+		uuid := fragment[idx+len("/results/"):]
+		uuid = strings.TrimSpace(strings.SplitN(uuid, "?", 2)[0])
+		uuid = strings.TrimSpace(strings.SplitN(uuid, "/", 2)[0])
+		return normalizeBitbucketPipelineUUID(uuid)
+	}
+	return ""
+}
+
+func bitbucketFailedPipelineUUIDs(statuses []bitbucket.CommitStatus, failingNames []string) map[string]struct{} {
+	if len(failingNames) == 0 {
+		return nil
+	}
+	failing := make(map[string]struct{}, len(failingNames))
+	for _, name := range failingNames {
+		trimmed := strings.TrimSpace(name)
+		if trimmed != "" {
+			failing[trimmed] = struct{}{}
+		}
+	}
+	if len(failing) == 0 {
+		return nil
+	}
+	targets := map[string]struct{}{}
+	for _, status := range latestBitbucketStatuses(statuses) {
+		if _, ok := failing[bitbucketStatusName(status)]; !ok {
+			continue
+		}
+		uuid := bitbucketPipelineUUIDFromStatusURL(status.URL)
+		if uuid != "" {
+			targets[uuid] = struct{}{}
+		}
+	}
+	if len(targets) == 0 {
+		return nil
+	}
+	return targets
+}
+
+func (s *CIStep) fetchBitbucketFailedStepLogs(sctx *pipeline.StepContext, client *bitbucket.Client, repo bitbucket.RepoRef, commitSHA string, targetPipelines map[string]struct{}) string {
 	if client == nil || strings.TrimSpace(commitSHA) == "" {
 		return ""
 	}
@@ -553,6 +612,11 @@ func (s *CIStep) fetchBitbucketFailedStepLogs(sctx *pipeline.StepContext, client
 		return ""
 	}
 	for _, pipelineRun := range pipelines {
+		if len(targetPipelines) > 0 {
+			if _, ok := targetPipelines[normalizeBitbucketPipelineUUID(pipelineRun.UUID)]; !ok {
+				continue
+			}
+		}
 		steps, err := client.ListPipelineSteps(sctx.Ctx, repo, pipelineRun.UUID)
 		if err != nil {
 			continue
@@ -599,10 +663,14 @@ func (s *CIStep) autoFixCI(sctx *pipeline.StepContext, prNumber string, failingN
 				prID, convErr := strconv.Atoi(prNumber)
 				if convErr == nil {
 					commitSHA := strings.TrimSpace(sctx.Run.HeadSHA)
+					var targetPipelines map[string]struct{}
 					if pr, prErr := client.GetPR(sctx.Ctx, repo, prID); prErr == nil && pr != nil && strings.TrimSpace(pr.SourceCommitHash) != "" {
 						commitSHA = strings.TrimSpace(pr.SourceCommitHash)
 					}
-					logOutput = s.fetchBitbucketFailedStepLogs(sctx, client, repo, commitSHA)
+					if statuses, statusErr := client.ListPRStatuses(sctx.Ctx, repo, prID); statusErr == nil {
+						targetPipelines = bitbucketFailedPipelineUUIDs(statuses, failingNames)
+					}
+					logOutput = s.fetchBitbucketFailedStepLogs(sctx, client, repo, commitSHA, targetPipelines)
 				}
 			}
 		}

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
+	"github.com/kunchenguid/no-mistakes/internal/bitbucket"
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
@@ -54,16 +55,8 @@ func (s *PRStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 		return &pipeline.StepOutcome{}, nil
 	}
 	provider := scm.DetectProvider(sctx.Repo.UpstreamURL)
-	if provider == scm.ProviderUnknown || provider == scm.ProviderBitbucket {
+	if provider == scm.ProviderUnknown {
 		sctx.Log(fmt.Sprintf("skipping PR creation: provider %s is not supported yet", provider))
-		return &pipeline.StepOutcome{}, nil
-	}
-	if !stepCLIAvailable(sctx, provider) {
-		sctx.Log(fmt.Sprintf("skipping PR creation: %s CLI is not installed", provider.CLIName()))
-		return &pipeline.StepOutcome{}, nil
-	}
-	if !stepAuthConfigured(sctx, provider) {
-		sctx.Log(fmt.Sprintf("skipping PR creation: %s CLI is not authenticated", provider.CLIName()))
 		return &pipeline.StepOutcome{}, nil
 	}
 
@@ -73,6 +66,19 @@ func (s *PRStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 	if err != nil {
 		return nil, err
 	}
+	if provider == scm.ProviderBitbucket {
+		return s.executeBitbucketPR(sctx, branch, content)
+	}
+
+	if !stepCLIAvailable(sctx, provider) {
+		sctx.Log(fmt.Sprintf("skipping PR creation: %s CLI is not installed", provider.CLIName()))
+		return &pipeline.StepOutcome{}, nil
+	}
+	if !stepAuthConfigured(sctx, provider) {
+		sctx.Log(fmt.Sprintf("skipping PR creation: %s CLI is not authenticated", provider.CLIName()))
+		return &pipeline.StepOutcome{}, nil
+	}
+
 	switch provider {
 	case scm.ProviderGitHub:
 		return s.executeGitHubPR(sctx, branch, content)
@@ -127,6 +133,52 @@ func (s *PRStep) executeGitHubPR(sctx *pipeline.StepContext, branch string, cont
 	}
 
 	return &pipeline.StepOutcome{PRURL: prURL}, nil
+}
+
+func (s *PRStep) executeBitbucketPR(sctx *pipeline.StepContext, branch string, content prContent) (*pipeline.StepOutcome, error) {
+	client, err := bitbucket.NewClientFromEnv(sctx.Env)
+	if err != nil {
+		sctx.Log(fmt.Sprintf("skipping PR creation: %v", err))
+		return &pipeline.StepOutcome{}, nil
+	}
+	repo, err := bitbucket.ParseRepoRef(sctx.Repo.UpstreamURL)
+	if err != nil {
+		return nil, err
+	}
+
+	sctx.Log(fmt.Sprintf("checking for existing pull request on branch %s...", branch))
+	existingPR, err := client.FindOpenPRBySourceBranch(sctx.Ctx, repo, branch)
+	if err != nil {
+		return nil, err
+	}
+	if existingPR != nil && existingPR.URL != "" {
+		sctx.Log(fmt.Sprintf("pull request already exists: %s, updating...", existingPR.URL))
+		updatedPR, err := client.UpdatePR(sctx.Ctx, repo, existingPR.ID, content.Title, content.Body)
+		if err != nil {
+			return nil, err
+		}
+		if updatedPR != nil && updatedPR.URL != "" {
+			if err := sctx.DB.UpdateRunPRURL(sctx.Run.ID, updatedPR.URL); err != nil {
+				slog.Warn("failed to persist PR URL", "run", sctx.Run.ID, "url", updatedPR.URL, "err", err)
+			}
+			return &pipeline.StepOutcome{PRURL: updatedPR.URL}, nil
+		}
+		return &pipeline.StepOutcome{}, nil
+	}
+
+	sctx.Log("creating pull request...")
+	createdPR, err := client.CreatePR(sctx.Ctx, repo, branch, sctx.Repo.DefaultBranch, content.Title, content.Body)
+	if err != nil {
+		return nil, err
+	}
+	if createdPR != nil && createdPR.URL != "" {
+		sctx.Log(fmt.Sprintf("created pull request: %s", createdPR.URL))
+		if err := sctx.DB.UpdateRunPRURL(sctx.Run.ID, createdPR.URL); err != nil {
+			slog.Warn("failed to persist PR URL", "run", sctx.Run.ID, "url", createdPR.URL, "err", err)
+		}
+		return &pipeline.StepOutcome{PRURL: createdPR.URL}, nil
+	}
+	return &pipeline.StepOutcome{}, nil
 }
 
 func (s *PRStep) executeGitLabMR(sctx *pipeline.StepContext, branch string, content prContent) (*pipeline.StepOutcome, error) {

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -68,6 +68,11 @@ func (s *PRStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 			sctx.Log(fmt.Sprintf("skipping PR creation: %s CLI is not authenticated", provider.CLIName()))
 			return &pipeline.StepOutcome{}, nil
 		}
+	} else {
+		if _, err := bitbucket.NewClientFromEnv(sctx.Env); err != nil {
+			sctx.Log(fmt.Sprintf("skipping PR creation: %v", err))
+			return &pipeline.StepOutcome{}, nil
+		}
 	}
 
 	// Resolve the branch base so PR summaries cover the full branch delta.

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -157,8 +157,12 @@ func (s *PRStep) executeBitbucketPR(sctx *pipeline.StepContext, branch string, c
 	if err != nil {
 		return nil, err
 	}
-	if existingPR != nil && existingPR.URL != "" {
-		sctx.Log(fmt.Sprintf("pull request already exists: %s, updating...", existingPR.URL))
+	if existingPR != nil {
+		if existingPR.URL != "" {
+			sctx.Log(fmt.Sprintf("pull request already exists: %s, updating...", existingPR.URL))
+		} else {
+			sctx.Log(fmt.Sprintf("pull request already exists: #%d, updating...", existingPR.ID))
+		}
 		updatedPR, err := client.UpdatePR(sctx.Ctx, repo, existingPR.ID, content.Title, content.Body)
 		if err != nil {
 			return nil, err

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -158,8 +158,9 @@ func (s *PRStep) executeBitbucketPR(sctx *pipeline.StepContext, branch string, c
 		return nil, err
 	}
 	if existingPR != nil {
-		if existingPR.URL != "" {
-			sctx.Log(fmt.Sprintf("pull request already exists: %s, updating...", existingPR.URL))
+		existingPRURL := bitbucketPRURL(repo, existingPR.ID, existingPR.URL)
+		if existingPRURL != "" {
+			sctx.Log(fmt.Sprintf("pull request already exists: %s, updating...", existingPRURL))
 		} else {
 			sctx.Log(fmt.Sprintf("pull request already exists: #%d, updating...", existingPR.ID))
 		}
@@ -167,9 +168,9 @@ func (s *PRStep) executeBitbucketPR(sctx *pipeline.StepContext, branch string, c
 		if err != nil {
 			return nil, err
 		}
-		prURL := existingPR.URL
-		if updatedPR != nil && updatedPR.URL != "" {
-			prURL = updatedPR.URL
+		prURL := existingPRURL
+		if updatedPR != nil {
+			prURL = bitbucketPRURL(repo, updatedPR.ID, updatedPR.URL)
 		}
 		if prURL != "" {
 			if err := sctx.DB.UpdateRunPRURL(sctx.Run.ID, prURL); err != nil {
@@ -185,14 +186,28 @@ func (s *PRStep) executeBitbucketPR(sctx *pipeline.StepContext, branch string, c
 	if err != nil {
 		return nil, err
 	}
-	if createdPR != nil && createdPR.URL != "" {
-		sctx.Log(fmt.Sprintf("created pull request: %s", createdPR.URL))
-		if err := sctx.DB.UpdateRunPRURL(sctx.Run.ID, createdPR.URL); err != nil {
-			slog.Warn("failed to persist PR URL", "run", sctx.Run.ID, "url", createdPR.URL, "err", err)
+	createdPRURL := ""
+	if createdPR != nil {
+		createdPRURL = bitbucketPRURL(repo, createdPR.ID, createdPR.URL)
+	}
+	if createdPRURL != "" {
+		sctx.Log(fmt.Sprintf("created pull request: %s", createdPRURL))
+		if err := sctx.DB.UpdateRunPRURL(sctx.Run.ID, createdPRURL); err != nil {
+			slog.Warn("failed to persist PR URL", "run", sctx.Run.ID, "url", createdPRURL, "err", err)
 		}
-		return &pipeline.StepOutcome{PRURL: createdPR.URL}, nil
+		return &pipeline.StepOutcome{PRURL: createdPRURL}, nil
 	}
 	return &pipeline.StepOutcome{}, nil
+}
+
+func bitbucketPRURL(repo bitbucket.RepoRef, prID int, rawURL string) string {
+	if url := strings.TrimSpace(rawURL); url != "" {
+		return url
+	}
+	if prID <= 0 || strings.TrimSpace(repo.Workspace) == "" || strings.TrimSpace(repo.RepoSlug) == "" {
+		return ""
+	}
+	return fmt.Sprintf("https://bitbucket.org/%s/%s/pull-requests/%d", repo.Workspace, repo.RepoSlug, prID)
 }
 
 func (s *PRStep) executeGitLabMR(sctx *pipeline.StepContext, branch string, content prContent) (*pipeline.StepOutcome, error) {

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -153,7 +153,7 @@ func (s *PRStep) executeBitbucketPR(sctx *pipeline.StepContext, branch string, c
 	}
 
 	sctx.Log(fmt.Sprintf("checking for existing pull request on branch %s...", branch))
-	existingPR, err := client.FindOpenPRBySourceBranch(sctx.Ctx, repo, branch)
+	existingPR, err := client.FindOpenPRBySourceBranch(sctx.Ctx, repo, branch, sctx.Repo.DefaultBranch)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -24,7 +24,7 @@ func isConventionalTitle(title string) bool {
 	return conventionalTitleRe.MatchString(title)
 }
 
-// PRStep creates or updates a pull request via gh CLI.
+// PRStep creates or updates a pull request via the provider CLI or API.
 type PRStep struct{}
 
 type prContent struct {

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -167,11 +167,15 @@ func (s *PRStep) executeBitbucketPR(sctx *pipeline.StepContext, branch string, c
 		if err != nil {
 			return nil, err
 		}
+		prURL := existingPR.URL
 		if updatedPR != nil && updatedPR.URL != "" {
-			if err := sctx.DB.UpdateRunPRURL(sctx.Run.ID, updatedPR.URL); err != nil {
-				slog.Warn("failed to persist PR URL", "run", sctx.Run.ID, "url", updatedPR.URL, "err", err)
+			prURL = updatedPR.URL
+		}
+		if prURL != "" {
+			if err := sctx.DB.UpdateRunPRURL(sctx.Run.ID, prURL); err != nil {
+				slog.Warn("failed to persist PR URL", "run", sctx.Run.ID, "url", prURL, "err", err)
 			}
-			return &pipeline.StepOutcome{PRURL: updatedPR.URL}, nil
+			return &pipeline.StepOutcome{PRURL: prURL}, nil
 		}
 		return &pipeline.StepOutcome{}, nil
 	}

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -59,6 +59,16 @@ func (s *PRStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 		sctx.Log(fmt.Sprintf("skipping PR creation: provider %s is not supported yet", provider))
 		return &pipeline.StepOutcome{}, nil
 	}
+	if provider != scm.ProviderBitbucket {
+		if !stepCLIAvailable(sctx, provider) {
+			sctx.Log(fmt.Sprintf("skipping PR creation: %s CLI is not installed", provider.CLIName()))
+			return &pipeline.StepOutcome{}, nil
+		}
+		if !stepAuthConfigured(sctx, provider) {
+			sctx.Log(fmt.Sprintf("skipping PR creation: %s CLI is not authenticated", provider.CLIName()))
+			return &pipeline.StepOutcome{}, nil
+		}
+	}
 
 	// Resolve the branch base so PR summaries cover the full branch delta.
 	baseSHA := resolveBranchBaseSHA(ctx, sctx.WorkDir, sctx.Run.BaseSHA, sctx.Repo.DefaultBranch)
@@ -68,15 +78,6 @@ func (s *PRStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 	}
 	if provider == scm.ProviderBitbucket {
 		return s.executeBitbucketPR(sctx, branch, content)
-	}
-
-	if !stepCLIAvailable(sctx, provider) {
-		sctx.Log(fmt.Sprintf("skipping PR creation: %s CLI is not installed", provider.CLIName()))
-		return &pipeline.StepOutcome{}, nil
-	}
-	if !stepAuthConfigured(sctx, provider) {
-		sctx.Log(fmt.Sprintf("skipping PR creation: %s CLI is not authenticated", provider.CLIName()))
-		return &pipeline.StepOutcome{}, nil
 	}
 
 	switch provider {

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -6953,6 +6953,28 @@ func TestLatestBitbucketStatusesKeepsNewestStatusPerCheck(t *testing.T) {
 	}
 }
 
+func TestLatestBitbucketStatusesDeduplicatesByKeyBeforeName(t *testing.T) {
+	t.Parallel()
+
+	statuses := []bitbucket.CommitStatus{
+		{Name: "build v2", Key: "build", State: "SUCCESSFUL"},
+		{Name: "build", Key: "build", State: "FAILED"},
+		{Name: "tests", State: "SUCCESSFUL"},
+		{Name: "tests", State: "FAILED"},
+	}
+
+	got := latestBitbucketStatuses(statuses)
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2", len(got))
+	}
+	if got[0].Key != "build" || got[0].Name != "build v2" || got[0].State != "SUCCESSFUL" {
+		t.Fatalf("got[0] = %#v, want newest keyed build status", got[0])
+	}
+	if got[1].Key != "" || got[1].Name != "tests" || got[1].State != "SUCCESSFUL" {
+		t.Fatalf("got[1] = %#v, want newest unnamed tests status", got[1])
+	}
+}
+
 func TestCIStep_GetCIChecksBitbucketFallsBackToKeyWhenNameMissing(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -16,6 +19,7 @@ import (
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
+	"github.com/kunchenguid/no-mistakes/internal/bitbucket"
 	"github.com/kunchenguid/no-mistakes/internal/config"
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/git"
@@ -3911,6 +3915,141 @@ func fakeGH(t *testing.T, prViewURL string) (env []string, logFile string) {
 	return env, logFile
 }
 
+type fakeBitbucketPRAPI struct {
+	server         *httptest.Server
+	listCalls      int
+	createCalls    int
+	updateCalls    int
+	lastAuthHeader string
+	lastCreateBody string
+	lastUpdateBody string
+	existingPRID   int
+	existingPRURL  string
+	createdPRURL   string
+}
+
+func newFakeBitbucketPRAPI(t *testing.T, existingPRID int, existingPRURL string) *fakeBitbucketPRAPI {
+	t.Helper()
+
+	api := &fakeBitbucketPRAPI{
+		existingPRID:  existingPRID,
+		existingPRURL: existingPRURL,
+		createdPRURL:  "https://bitbucket.org/test/repo/pull-requests/99",
+	}
+
+	api.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		api.lastAuthHeader = r.Header.Get("Authorization")
+
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/2.0/repositories/test/repo/pullrequests":
+			api.listCalls++
+			w.Header().Set("Content-Type", "application/json")
+			if api.existingPRID == 0 {
+				fmt.Fprint(w, `{"values":[]}`)
+				return
+			}
+			fmt.Fprintf(w, `{"values":[{"id":%d,"links":{"html":{"href":%q}}}]}`,
+				api.existingPRID,
+				api.existingPRURL,
+			)
+		case r.Method == http.MethodPost && r.URL.Path == "/2.0/repositories/test/repo/pullrequests":
+			api.createCalls++
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read create body: %v", err)
+			}
+			api.lastCreateBody = string(body)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprintf(w, `{"id":99,"links":{"html":{"href":%q}}}`,
+				api.createdPRURL,
+			)
+		case r.Method == http.MethodPut && r.URL.Path == fmt.Sprintf("/2.0/repositories/test/repo/pullrequests/%d", api.existingPRID):
+			api.updateCalls++
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read update body: %v", err)
+			}
+			api.lastUpdateBody = string(body)
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"id":%d,"links":{"html":{"href":%q}}}`,
+				api.existingPRID,
+				api.existingPRURL,
+			)
+		default:
+			t.Fatalf("unexpected Bitbucket PR API request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	t.Cleanup(api.server.Close)
+
+	return api
+}
+
+func fakeBitbucketEnv(apiBaseURL string) []string {
+	return []string{
+		"NO_MISTAKES_BITBUCKET_EMAIL=test@example.com",
+		"NO_MISTAKES_BITBUCKET_API_TOKEN=test-token",
+		"NO_MISTAKES_BITBUCKET_API_BASE_URL=" + apiBaseURL,
+	}
+}
+
+type fakeBitbucketCIAPI struct {
+	server         *httptest.Server
+	prState        string
+	statusesJSON   string
+	pipelinesJSON  string
+	stepsJSON      string
+	stepLog        string
+	prStateCalls   int
+	statusesCalls  int
+	pipelinesCalls int
+	stepsCalls     int
+	stepLogCalls   int
+	lastAuthHeader string
+	lastStatusesQ  string
+}
+
+func newFakeBitbucketCIAPI(t *testing.T, prState, statusesJSON string) *fakeBitbucketCIAPI {
+	t.Helper()
+
+	api := &fakeBitbucketCIAPI{
+		prState:      prState,
+		statusesJSON: statusesJSON,
+	}
+
+	api.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		api.lastAuthHeader = r.Header.Get("Authorization")
+
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/2.0/repositories/test/repo/pullrequests/42":
+			api.prStateCalls++
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"id":42,"state":%q}`, api.prState)
+		case r.Method == http.MethodGet && r.URL.Path == "/2.0/repositories/test/repo/pullrequests/42/statuses":
+			api.statusesCalls++
+			api.lastStatusesQ = r.URL.Query().Get("q")
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, api.statusesJSON)
+		case r.Method == http.MethodGet && r.URL.Path == "/2.0/repositories/test/repo/pipelines" && api.pipelinesJSON != "":
+			api.pipelinesCalls++
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, api.pipelinesJSON)
+		case r.Method == http.MethodGet && r.URL.Path == "/2.0/repositories/test/repo/pipelines/{pipeline-1}/steps" && api.stepsJSON != "":
+			api.stepsCalls++
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, api.stepsJSON)
+		case r.Method == http.MethodGet && r.URL.Path == "/2.0/repositories/test/repo/pipelines/{pipeline-1}/steps/{step-1}/log" && api.stepLog != "":
+			api.stepLogCalls++
+			fmt.Fprint(w, api.stepLog)
+		default:
+			t.Fatalf("unexpected Bitbucket CI API request: %s %s", r.Method, r.URL.String())
+		}
+	}))
+	t.Cleanup(api.server.Close)
+
+	return api
+}
+
 func TestStepCLIAvailable_ResolvesExecutableSuffixFromCustomPath_EnableWindowsCI(t *testing.T) {
 	t.Parallel()
 
@@ -4188,6 +4327,49 @@ func TestPRStep_UpdatesExistingPR(t *testing.T) {
 	}
 }
 
+func TestPRStep_BitbucketUpdatesExistingPR(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	api := newFakeBitbucketPRAPI(t, 42, "https://bitbucket.org/test/repo/pull-requests/42")
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = fakeBitbucketEnv(api.server.URL)
+	sctx.Repo.UpstreamURL = "https://bitbucket.org/test/repo.git"
+
+	step := &PRStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Fatal("bitbucket PR step should never need approval")
+	}
+	if api.listCalls != 1 {
+		t.Fatalf("list calls = %d, want 1", api.listCalls)
+	}
+	if api.updateCalls != 1 {
+		t.Fatalf("update calls = %d, want 1", api.updateCalls)
+	}
+	if api.createCalls != 0 {
+		t.Fatalf("create calls = %d, want 0", api.createCalls)
+	}
+	if api.lastAuthHeader == "" {
+		t.Fatal("expected Authorization header for Bitbucket API")
+	}
+	if !strings.Contains(api.lastUpdateBody, "title") || !strings.Contains(api.lastUpdateBody, "description") {
+		t.Fatalf("expected Bitbucket PR update payload to include title and description, got %q", api.lastUpdateBody)
+	}
+
+	run, err := sctx.DB.GetRun(sctx.Run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.PRURL == nil || *run.PRURL != "https://bitbucket.org/test/repo/pull-requests/42" {
+		t.Fatalf("PR URL = %v, want Bitbucket PR URL", run.PRURL)
+	}
+}
+
 func TestPRStep_ZeroBaseSHA(t *testing.T) {
 	t.Parallel()
 	// New branch scenario: baseSHA is all-zeros, commit log should still work
@@ -4286,6 +4468,57 @@ func TestPRStep_CreatesNewPR(t *testing.T) {
 	}
 	if run.PRURL == nil || *run.PRURL != "https://github.com/test/repo/pull/99" {
 		t.Errorf("PR URL = %v, want https://github.com/test/repo/pull/99", run.PRURL)
+	}
+}
+
+func TestPRStep_BitbucketCreatesNewPR(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	api := newFakeBitbucketPRAPI(t, 0, "")
+
+	findings := `{"findings":[],"summary":"clean","risk_level":"medium","risk_rationale":"touches critical error handling"}`
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = fakeBitbucketEnv(api.server.URL)
+	sctx.Repo.UpstreamURL = "https://bitbucket.org/test/repo.git"
+	reviewStep, err := sctx.DB.InsertStepResult(sctx.Run.ID, types.StepReview)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sctx.DB.UpdateStepStatus(reviewStep.ID, types.StepStatusCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if err := sctx.DB.SetStepFindings(reviewStep.ID, findings); err != nil {
+		t.Fatal(err)
+	}
+
+	step := &PRStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Fatal("bitbucket PR step should never need approval")
+	}
+	if api.listCalls != 1 {
+		t.Fatalf("list calls = %d, want 1", api.listCalls)
+	}
+	if api.createCalls != 1 {
+		t.Fatalf("create calls = %d, want 1", api.createCalls)
+	}
+	if api.updateCalls != 0 {
+		t.Fatalf("update calls = %d, want 0", api.updateCalls)
+	}
+	if !strings.Contains(api.lastCreateBody, `"source"`) || !strings.Contains(api.lastCreateBody, `"destination"`) {
+		t.Fatalf("expected Bitbucket PR create payload to include source and destination, got %q", api.lastCreateBody)
+	}
+
+	run, err := sctx.DB.GetRun(sctx.Run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.PRURL == nil || *run.PRURL != api.createdPRURL {
+		t.Fatalf("PR URL = %v, want %q", run.PRURL, api.createdPRURL)
 	}
 }
 
@@ -4749,6 +4982,156 @@ func TestCIStep_PendingChecksUseAdaptivePollIntervals(t *testing.T) {
 		if waits[i] != want[i] {
 			t.Fatalf("wait %d = %v, want %v (all waits: %v)", i, waits[i], want[i], waits)
 		}
+	}
+}
+
+func TestCIStep_BitbucketPassesWhenStatusesPass(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	api := newFakeBitbucketCIAPI(t, "OPEN", `{"values":[{"name":"build","state":"SUCCESSFUL"}]}`)
+
+	prURL := "https://bitbucket.org/test/repo/pull-requests/42"
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = fakeBitbucketEnv(api.server.URL)
+	sctx.Run.PRURL = &prURL
+	sctx.Repo.UpstreamURL = "https://bitbucket.org/test/repo.git"
+	sctx.Config.CITimeout = 30 * time.Second
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+
+	step := &CIStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Fatal("expected Bitbucket CI pass to complete without approval")
+	}
+	if api.prStateCalls == 0 {
+		t.Fatal("expected Bitbucket PR state endpoint to be called")
+	}
+	if api.statusesCalls == 0 {
+		t.Fatal("expected Bitbucket statuses endpoint to be called")
+	}
+	foundPassed := false
+	for _, line := range logs {
+		if strings.Contains(line, "all CI checks passed") {
+			foundPassed = true
+			break
+		}
+	}
+	if !foundPassed {
+		t.Fatalf("expected successful Bitbucket CI logs, got %v", logs)
+	}
+}
+
+func TestCIStep_BitbucketFailureNeedsApproval(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	api := newFakeBitbucketCIAPI(t, "OPEN", `{"values":[{"name":"build","state":"FAILED"}]}`)
+
+	prURL := "https://bitbucket.org/test/repo/pull-requests/42"
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = fakeBitbucketEnv(api.server.URL)
+	sctx.Run.PRURL = &prURL
+	sctx.Repo.UpstreamURL = "https://bitbucket.org/test/repo.git"
+	sctx.Config.CITimeout = 30 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{CI: 0}
+
+	step := &CIStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected Bitbucket CI failures to require approval when auto-fix is disabled")
+	}
+	if api.prStateCalls == 0 || api.statusesCalls == 0 {
+		t.Fatalf("expected Bitbucket CI endpoints to be called, got state=%d statuses=%d", api.prStateCalls, api.statusesCalls)
+	}
+
+	var findings Findings
+	if err := json.Unmarshal([]byte(outcome.Findings), &findings); err != nil {
+		t.Fatalf("unmarshal findings: %v", err)
+	}
+	if len(findings.Items) == 0 || !strings.Contains(findings.Items[0].Description, "build") {
+		t.Fatalf("expected failing Bitbucket check finding, got %+v", findings.Items)
+	}
+}
+
+func TestCIStep_BitbucketAutoFixIncludesPipelineLogs(t *testing.T) {
+	t.Parallel()
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	api := newFakeBitbucketCIAPI(t, "OPEN", `{"values":[{"name":"test","state":"FAILED"}]}`)
+	api.pipelinesJSON = `{"values":[{"uuid":"{pipeline-1}"}]}`
+	api.stepsJSON = `{"values":[{"uuid":"{step-1}","state":{"name":"COMPLETED","result":{"name":"FAILED"}}}]}`
+	api.stepLog = "error log output"
+
+	var capturedPrompt string
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			capturedPrompt = opts.Prompt
+			os.WriteFile(filepath.Join(opts.CWD, "ci-fix.txt"), []byte("fixed"), 0o644)
+			return &agent.Result{}, nil
+		},
+	}
+
+	prURL := "https://bitbucket.org/test/repo/pull-requests/42"
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = fakeBitbucketEnv(api.server.URL)
+	sctx.Run.PRURL = &prURL
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Config.CITimeout = 30 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{CI: 1}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
+	step := &CIStep{
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			cancel()
+			return ctx.Err()
+		},
+	}
+	_, err := step.Execute(sctx)
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation after auto-fix poll, got %v", err)
+	}
+	if capturedPrompt == "" {
+		t.Fatal("expected Bitbucket auto-fix to call the agent")
+	}
+	if !strings.Contains(capturedPrompt, "CI logs:") || !strings.Contains(capturedPrompt, "error log output") {
+		t.Fatalf("expected Bitbucket auto-fix prompt to include pipeline logs, got:\n%s", capturedPrompt)
+	}
+	if api.pipelinesCalls == 0 || api.stepsCalls == 0 || api.stepLogCalls == 0 {
+		t.Fatalf("expected Bitbucket pipeline log endpoints to be called, got pipelines=%d steps=%d log=%d", api.pipelinesCalls, api.stepsCalls, api.stepLogCalls)
 	}
 }
 
@@ -6312,7 +6695,7 @@ func TestCIStep_GetCIChecksNoChecksReported(t *testing.T) {
 	sctx.Env = env
 
 	step := &CIStep{}
-	checks, err := step.getCIChecks(sctx, "42")
+	checks, err := step.getCIChecks(sctx, scm.ProviderGitHub, nil, bitbucket.RepoRef{}, "42")
 	if err != nil {
 		t.Fatalf("expected no error when gh reports no checks, got: %v", err)
 	}

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -6953,6 +6953,35 @@ func TestLatestBitbucketStatusesKeepsNewestStatusPerCheck(t *testing.T) {
 	}
 }
 
+func TestCIStep_GetCIChecksBitbucketFallsBackToKeyWhenNameMissing(t *testing.T) {
+	t.Parallel()
+
+	api := newFakeBitbucketCIAPI(t, "OPEN", `{"values":[{"key":"build","state":"FAILED"}]}`)
+	client, err := bitbucket.NewClientFromEnv(fakeBitbucketEnv(api.server.URL))
+	if err != nil {
+		t.Fatalf("new bitbucket client: %v", err)
+	}
+
+	dir := t.TempDir()
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, "abc", "def", config.Commands{})
+	step := &CIStep{}
+
+	checks, err := step.getCIChecks(sctx, scm.ProviderBitbucket, client, bitbucket.RepoRef{Workspace: "test", RepoSlug: "repo"}, "42")
+	if err != nil {
+		t.Fatalf("getCIChecks returned error: %v", err)
+	}
+	if len(checks) != 1 {
+		t.Fatalf("len(checks) = %d, want 1", len(checks))
+	}
+	if checks[0].Name != "build" {
+		t.Fatalf("checks[0].Name = %q, want build", checks[0].Name)
+	}
+	if checks[0].Bucket != "fail" {
+		t.Fatalf("checks[0].Bucket = %q, want fail", checks[0].Bucket)
+	}
+}
+
 func TestCIStep_CIFailureAutoFix(t *testing.T) {
 	t.Parallel()
 	// Set up upstream bare repo for push

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -4373,6 +4373,35 @@ func TestPRStep_BitbucketUpdatesExistingPR(t *testing.T) {
 	}
 }
 
+func TestPRStep_BitbucketUpdatesExistingPRWithoutHTMLLink(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	api := newFakeBitbucketPRAPI(t, 42, "")
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = fakeBitbucketEnv(api.server.URL)
+	sctx.Repo.UpstreamURL = "https://bitbucket.org/test/repo.git"
+
+	step := &PRStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Fatal("bitbucket PR step should never need approval")
+	}
+	if api.listCalls != 1 {
+		t.Fatalf("list calls = %d, want 1", api.listCalls)
+	}
+	if api.updateCalls != 1 {
+		t.Fatalf("update calls = %d, want 1", api.updateCalls)
+	}
+	if api.createCalls != 0 {
+		t.Fatalf("create calls = %d, want 0", api.createCalls)
+	}
+}
+
 func TestPRStep_ZeroBaseSHA(t *testing.T) {
 	t.Parallel()
 	// New branch scenario: baseSHA is all-zeros, commit log should still work

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -6927,6 +6927,32 @@ func TestCIStep_GetCIChecksNoChecksReported(t *testing.T) {
 	}
 }
 
+func TestLatestBitbucketStatusesKeepsNewestStatusPerCheck(t *testing.T) {
+	t.Parallel()
+
+	statuses := []bitbucket.CommitStatus{
+		{Name: "build", State: "SUCCESSFUL", Key: "build"},
+		{Name: "tests", State: "FAILED", Key: "tests"},
+		{Name: "build", State: "FAILED", Key: "build"},
+		{Name: "tests", State: "SUCCESSFUL", Key: "tests"},
+		{Name: "lint", State: "INPROGRESS"},
+	}
+
+	got := latestBitbucketStatuses(statuses)
+	if len(got) != 3 {
+		t.Fatalf("len(got) = %d, want 3", len(got))
+	}
+	if got[0].Name != "build" || got[0].State != "SUCCESSFUL" {
+		t.Fatalf("got[0] = %#v, want latest successful build", got[0])
+	}
+	if got[1].Name != "tests" || got[1].State != "FAILED" {
+		t.Fatalf("got[1] = %#v, want latest failed tests", got[1])
+	}
+	if got[2].Name != "lint" || got[2].State != "INPROGRESS" {
+		t.Fatalf("got[2] = %#v, want pending lint", got[2])
+	}
+}
+
 func TestCIStep_CIFailureAutoFix(t *testing.T) {
 	t.Parallel()
 	// Set up upstream bare repo for push

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -4602,6 +4602,71 @@ func TestPRStep_BitbucketCreatesNewPR(t *testing.T) {
 	}
 }
 
+func TestPRStep_BitbucketCreatesNewPRWithoutHTMLLink(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	api := newFakeBitbucketPRAPI(t, 0, "")
+	api.createdPRURL = ""
+
+	findings := `{"findings":[],"summary":"clean","risk_level":"medium","risk_rationale":"touches critical error handling"}`
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = fakeBitbucketEnv(api.server.URL)
+	sctx.Repo.UpstreamURL = "https://bitbucket.org/test/repo.git"
+	reviewStep, err := sctx.DB.InsertStepResult(sctx.Run.ID, types.StepReview)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sctx.DB.UpdateStepStatus(reviewStep.ID, types.StepStatusCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if err := sctx.DB.SetStepFindings(reviewStep.ID, findings); err != nil {
+		t.Fatal(err)
+	}
+	api.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		api.lastAuthHeader = r.Header.Get("Authorization")
+
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/2.0/repositories/test/repo/pullrequests":
+			api.listCalls++
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"values":[]}`)
+		case r.Method == http.MethodPost && r.URL.Path == "/2.0/repositories/test/repo/pullrequests":
+			api.createCalls++
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read create body: %v", err)
+			}
+			api.lastCreateBody = string(body)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprint(w, `{"id":99}`)
+		default:
+			t.Fatalf("unexpected Bitbucket PR API request: %s %s", r.Method, r.URL.String())
+		}
+	})
+
+	step := &PRStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Fatal("bitbucket PR step should never need approval")
+	}
+	if outcome.PRURL != "https://bitbucket.org/test/repo/pull-requests/99" {
+		t.Fatalf("PR URL = %q, want derived Bitbucket PR URL", outcome.PRURL)
+	}
+
+	run, err := sctx.DB.GetRun(sctx.Run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.PRURL == nil || *run.PRURL != "https://bitbucket.org/test/repo/pull-requests/99" {
+		t.Fatalf("PR URL = %v, want derived Bitbucket PR URL", run.PRURL)
+	}
+}
+
 func TestPRStep_BitbucketMissingEnvSkipsBeforeBuildingContent(t *testing.T) {
 	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -4000,6 +4000,8 @@ type fakeBitbucketCIAPI struct {
 	pipelinesJSON  string
 	stepsJSON      string
 	stepLog        string
+	stepsByPath    map[string]string
+	stepLogsByPath map[string]string
 	prSourceSHA    string
 	prStateCalls   int
 	statusesCalls  int
@@ -4037,6 +4039,13 @@ func newFakeBitbucketCIAPI(t *testing.T, prState, statusesJSON string) *fakeBitb
 			api.lastPipelineQ = r.URL.Query().Get("target.commit.hash")
 			w.Header().Set("Content-Type", "application/json")
 			fmt.Fprint(w, api.pipelinesJSON)
+		case r.Method == http.MethodGet && api.stepsByPath[r.URL.Path] != "":
+			api.stepsCalls++
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, api.stepsByPath[r.URL.Path])
+		case r.Method == http.MethodGet && api.stepLogsByPath[r.URL.Path] != "":
+			api.stepLogCalls++
+			fmt.Fprint(w, api.stepLogsByPath[r.URL.Path])
 		case r.Method == http.MethodGet && r.URL.Path == "/2.0/repositories/test/repo/pipelines/{pipeline-1}/steps" && api.stepsJSON != "":
 			api.stepsCalls++
 			w.Header().Set("Content-Type", "application/json")
@@ -5355,6 +5364,95 @@ func TestCIStep_BitbucketAutoFixUsesLivePRHeadSHAForLogs(t *testing.T) {
 	}
 	if api.lastPipelineQ == staleHeadSHA {
 		t.Fatalf("pipeline lookup used stale run head SHA %q", staleHeadSHA)
+	}
+}
+
+func TestCIStep_BitbucketAutoFixUsesMatchingPipelineLogs(t *testing.T) {
+	t.Parallel()
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	if err := os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	api := newFakeBitbucketCIAPI(t, "OPEN", `{"values":[{"name":"test","state":"FAILED","url":"https://bitbucket.org/test/repo/addon/pipelines/home#!/results/pipeline-2"}]}`)
+	api.pipelinesJSON = `{"values":[{"uuid":"{pipeline-1}"},{"uuid":"{pipeline-2}"}]}`
+	api.stepsByPath = map[string]string{
+		"/2.0/repositories/test/repo/pipelines/{pipeline-1}/steps": `{"values":[{"uuid":"{step-1}","state":{"name":"COMPLETED","result":{"name":"FAILED"}}}]}`,
+		"/2.0/repositories/test/repo/pipelines/{pipeline-2}/steps": `{"values":[{"uuid":"{step-2}","state":{"name":"COMPLETED","result":{"name":"FAILED"}}}]}`,
+	}
+	api.stepLogsByPath = map[string]string{
+		"/2.0/repositories/test/repo/pipelines/{pipeline-1}/steps/{step-1}/log": "wrong pipeline log",
+		"/2.0/repositories/test/repo/pipelines/{pipeline-2}/steps/{step-2}/log": "matching pipeline log",
+	}
+	api.prSourceSHA = headSHA
+
+	var capturedPrompt string
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			capturedPrompt = opts.Prompt
+			if err := os.WriteFile(filepath.Join(opts.CWD, "ci-fix.txt"), []byte("fixed"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			return &agent.Result{}, nil
+		},
+	}
+
+	prURL := "https://bitbucket.org/test/repo/pull-requests/42"
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = fakeBitbucketEnv(api.server.URL)
+	sctx.Run.PRURL = &prURL
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Config.CITimeout = 30 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{CI: 1}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
+	step := &CIStep{
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			cancel()
+			return ctx.Err()
+		},
+	}
+	_, err := step.Execute(sctx)
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation after auto-fix poll, got %v", err)
+	}
+	if capturedPrompt == "" {
+		t.Fatal("expected Bitbucket auto-fix to call the agent")
+	}
+	if !strings.Contains(capturedPrompt, "matching pipeline log") {
+		t.Fatalf("expected prompt to include matching pipeline log, got:\n%s", capturedPrompt)
+	}
+	if strings.Contains(capturedPrompt, "wrong pipeline log") {
+		t.Fatalf("expected prompt to exclude unrelated pipeline log, got:\n%s", capturedPrompt)
+	}
+	if api.stepLogCalls != 1 {
+		t.Fatalf("expected exactly one Bitbucket step log fetch, got %d", api.stepLogCalls)
 	}
 }
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -4376,12 +4376,40 @@ func TestPRStep_BitbucketUpdatesExistingPR(t *testing.T) {
 func TestPRStep_BitbucketUpdatesExistingPRWithoutHTMLLink(t *testing.T) {
 	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
-	api := newFakeBitbucketPRAPI(t, 42, "")
+	api := newFakeBitbucketPRAPI(t, 42, "https://bitbucket.org/test/repo/pull-requests/42")
+	api.existingPRURL = "https://bitbucket.org/test/repo/pull-requests/42"
+	api.createdPRURL = ""
 
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Env = fakeBitbucketEnv(api.server.URL)
 	sctx.Repo.UpstreamURL = "https://bitbucket.org/test/repo.git"
+	api.server.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		api.lastAuthHeader = r.Header.Get("Authorization")
+
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/2.0/repositories/test/repo/pullrequests":
+			api.listCalls++
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"values":[{"id":%d,"links":{"html":{"href":%q}}}]}`,
+				api.existingPRID,
+				api.existingPRURL,
+			)
+		case r.Method == http.MethodPut && r.URL.Path == fmt.Sprintf("/2.0/repositories/test/repo/pullrequests/%d", api.existingPRID):
+			api.updateCalls++
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read update body: %v", err)
+			}
+			api.lastUpdateBody = string(body)
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"id":%d}`,
+				api.existingPRID,
+			)
+		default:
+			t.Fatalf("unexpected Bitbucket PR API request: %s %s", r.Method, r.URL.String())
+		}
+	})
 
 	step := &PRStep{}
 	outcome, err := step.Execute(sctx)
@@ -4399,6 +4427,17 @@ func TestPRStep_BitbucketUpdatesExistingPRWithoutHTMLLink(t *testing.T) {
 	}
 	if api.createCalls != 0 {
 		t.Fatalf("create calls = %d, want 0", api.createCalls)
+	}
+	if outcome.PRURL != api.existingPRURL {
+		t.Fatalf("outcome PR URL = %q, want %q", outcome.PRURL, api.existingPRURL)
+	}
+
+	run, err := sctx.DB.GetRun(sctx.Run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.PRURL == nil || *run.PRURL != api.existingPRURL {
+		t.Fatalf("PR URL = %v, want %q", run.PRURL, api.existingPRURL)
 	}
 }
 
@@ -5139,6 +5178,29 @@ func TestCIStep_BitbucketFailureNeedsApproval(t *testing.T) {
 	}
 	if len(findings.Items) == 0 || !strings.Contains(findings.Items[0].Description, "build") {
 		t.Fatalf("expected failing Bitbucket check finding, got %+v", findings.Items)
+	}
+}
+
+func TestCIStep_BitbucketStoppedDoesNotNeedApproval(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	api := newFakeBitbucketCIAPI(t, "OPEN", `{"values":[{"name":"build","state":"STOPPED"}]}`)
+
+	prURL := "https://bitbucket.org/test/repo/pull-requests/42"
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = fakeBitbucketEnv(api.server.URL)
+	sctx.Run.PRURL = &prURL
+	sctx.Repo.UpstreamURL = "https://bitbucket.org/test/repo.git"
+	sctx.Config.CITimeout = 30 * time.Second
+
+	step := &CIStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Fatal("expected stopped Bitbucket CI to avoid failure handling")
 	}
 }
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -4000,6 +4000,7 @@ type fakeBitbucketCIAPI struct {
 	pipelinesJSON  string
 	stepsJSON      string
 	stepLog        string
+	prSourceSHA    string
 	prStateCalls   int
 	statusesCalls  int
 	pipelinesCalls int
@@ -4007,6 +4008,7 @@ type fakeBitbucketCIAPI struct {
 	stepLogCalls   int
 	lastAuthHeader string
 	lastStatusesQ  string
+	lastPipelineQ  string
 }
 
 func newFakeBitbucketCIAPI(t *testing.T, prState, statusesJSON string) *fakeBitbucketCIAPI {
@@ -4024,7 +4026,7 @@ func newFakeBitbucketCIAPI(t *testing.T, prState, statusesJSON string) *fakeBitb
 		case r.Method == http.MethodGet && r.URL.Path == "/2.0/repositories/test/repo/pullrequests/42":
 			api.prStateCalls++
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{"id":42,"state":%q}`, api.prState)
+			fmt.Fprintf(w, `{"id":42,"state":%q,"source":{"commit":{"hash":%q}}}`, api.prState, api.prSourceSHA)
 		case r.Method == http.MethodGet && r.URL.Path == "/2.0/repositories/test/repo/pullrequests/42/statuses":
 			api.statusesCalls++
 			api.lastStatusesQ = r.URL.Query().Get("q")
@@ -4032,6 +4034,7 @@ func newFakeBitbucketCIAPI(t *testing.T, prState, statusesJSON string) *fakeBitb
 			fmt.Fprint(w, api.statusesJSON)
 		case r.Method == http.MethodGet && r.URL.Path == "/2.0/repositories/test/repo/pipelines" && api.pipelinesJSON != "":
 			api.pipelinesCalls++
+			api.lastPipelineQ = r.URL.Query().Get("target.commit.hash")
 			w.Header().Set("Content-Type", "application/json")
 			fmt.Fprint(w, api.pipelinesJSON)
 		case r.Method == http.MethodGet && r.URL.Path == "/2.0/repositories/test/repo/pipelines/{pipeline-1}/steps" && api.stepsJSON != "":
@@ -4519,6 +4522,27 @@ func TestPRStep_BitbucketCreatesNewPR(t *testing.T) {
 	}
 	if run.PRURL == nil || *run.PRURL != api.createdPRURL {
 		t.Fatalf("PR URL = %v, want %q", run.PRURL, api.createdPRURL)
+	}
+}
+
+func TestPRStep_BitbucketMissingEnvSkipsBeforeBuildingContent(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Repo.UpstreamURL = "https://bitbucket.org/test/repo.git"
+
+	step := &PRStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Fatal("bitbucket PR step should never need approval")
+	}
+	if len(ag.calls) != 0 {
+		t.Fatalf("expected Bitbucket PR step to skip before building content, got %d agent calls", len(ag.calls))
 	}
 }
 
@@ -5159,6 +5183,87 @@ func TestCIStep_BitbucketAutoFixIncludesPipelineLogs(t *testing.T) {
 	}
 	if api.pipelinesCalls == 0 || api.stepsCalls == 0 || api.stepLogCalls == 0 {
 		t.Fatalf("expected Bitbucket pipeline log endpoints to be called, got pipelines=%d steps=%d log=%d", api.pipelinesCalls, api.stepsCalls, api.stepLogCalls)
+	}
+}
+
+func TestCIStep_BitbucketAutoFixUsesLivePRHeadSHAForLogs(t *testing.T) {
+	t.Parallel()
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	if err := os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	api := newFakeBitbucketCIAPI(t, "OPEN", `{"values":[{"name":"test","state":"FAILED"}]}`)
+	api.pipelinesJSON = `{"values":[{"uuid":"{pipeline-1}"}]}`
+	api.stepsJSON = `{"values":[{"uuid":"{step-1}","state":{"name":"COMPLETED","result":{"name":"FAILED"}}}]}`
+	api.stepLog = "error log output"
+	api.prSourceSHA = headSHA
+
+	staleHeadSHA := strings.Repeat("a", 40)
+	var capturedPrompt string
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			capturedPrompt = opts.Prompt
+			if err := os.WriteFile(filepath.Join(opts.CWD, "ci-fix.txt"), []byte("fixed"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			return &agent.Result{}, nil
+		},
+	}
+
+	prURL := "https://bitbucket.org/test/repo/pull-requests/42"
+	sctx := newTestContext(t, ag, dir, baseSHA, staleHeadSHA, config.Commands{})
+	sctx.Env = fakeBitbucketEnv(api.server.URL)
+	sctx.Run.PRURL = &prURL
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Config.CITimeout = 30 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{CI: 1}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
+	step := &CIStep{
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			cancel()
+			return ctx.Err()
+		},
+	}
+	_, err := step.Execute(sctx)
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation after auto-fix poll, got %v", err)
+	}
+	if capturedPrompt == "" {
+		t.Fatal("expected Bitbucket auto-fix to call the agent")
+	}
+	if api.lastPipelineQ != headSHA {
+		t.Fatalf("pipeline commit SHA = %q, want live PR source commit %q", api.lastPipelineQ, headSHA)
+	}
+	if api.lastPipelineQ == staleHeadSHA {
+		t.Fatalf("pipeline lookup used stale run head SHA %q", staleHeadSHA)
 	}
 }
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -4623,6 +4623,39 @@ func TestPRStep_BitbucketMissingEnvSkipsBeforeBuildingContent(t *testing.T) {
 	}
 }
 
+func TestPRStep_BitbucketUsesProcessEnvWhenStepEnvIsNil(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	api := newFakeBitbucketPRAPI(t, 0, "")
+	t.Setenv("NO_MISTAKES_BITBUCKET_EMAIL", "test@example.com")
+	t.Setenv("NO_MISTAKES_BITBUCKET_API_TOKEN", "test-token")
+	t.Setenv("NO_MISTAKES_BITBUCKET_API_BASE_URL", api.server.URL)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			payload := json.RawMessage(`{"title":"fix: process env bitbucket pr","body":"## Summary\n\n- create PR via process env"}`)
+			return &agent.Result{Output: payload}, nil
+		},
+	}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Repo.UpstreamURL = "https://bitbucket.org/test/repo.git"
+
+	step := &PRStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Fatal("bitbucket PR step should never need approval")
+	}
+	if outcome.PRURL != api.createdPRURL {
+		t.Fatalf("PR URL = %q, want %q", outcome.PRURL, api.createdPRURL)
+	}
+	if api.createCalls != 1 {
+		t.Fatalf("expected Bitbucket PR create API to be called once, got %d", api.createCalls)
+	}
+}
+
 func TestPRStep_UsesAgentGeneratedTitleAndBody(t *testing.T) {
 	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
@@ -5152,6 +5185,33 @@ func TestCIStep_BitbucketPassesWhenStatusesPass(t *testing.T) {
 	}
 	if !foundPassed {
 		t.Fatalf("expected successful Bitbucket CI logs, got %v", logs)
+	}
+}
+
+func TestCIStep_BitbucketUsesProcessEnvWhenStepEnvIsNil(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	api := newFakeBitbucketCIAPI(t, "OPEN", `{"values":[{"name":"build","state":"SUCCESSFUL"}]}`)
+	t.Setenv("NO_MISTAKES_BITBUCKET_EMAIL", "test@example.com")
+	t.Setenv("NO_MISTAKES_BITBUCKET_API_TOKEN", "test-token")
+	t.Setenv("NO_MISTAKES_BITBUCKET_API_BASE_URL", api.server.URL)
+
+	prURL := "https://bitbucket.org/test/repo/pull-requests/42"
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Run.PRURL = &prURL
+	sctx.Repo.UpstreamURL = "https://bitbucket.org/test/repo.git"
+	sctx.Config.CITimeout = 30 * time.Second
+
+	step := &CIStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Fatal("expected Bitbucket CI pass to complete without approval")
+	}
+	if api.prStateCalls == 0 || api.statusesCalls == 0 {
+		t.Fatalf("expected Bitbucket CI endpoints to be called, got state=%d statuses=%d", api.prStateCalls, api.statusesCalls)
 	}
 }
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -4821,6 +4821,33 @@ func TestPRStep_SkipsWhenProviderCLIUnavailable(t *testing.T) {
 	}
 }
 
+func TestPRStep_SkipsBeforeBuildingContentWhenProviderCLIUnavailable(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			t.Fatal("expected PR content generation to be skipped when CLI is unavailable")
+			return nil, nil
+		},
+	}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Repo.UpstreamURL = "https://gitlab.com/test/repo.git"
+	sctx.Env = []string{"PATH=" + t.TempDir()}
+
+	step := &PRStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatalf("expected skip instead of failure, got: %v", err)
+	}
+	if outcome.NeedsApproval {
+		t.Fatal("expected no approval when PR step skips")
+	}
+	if len(ag.calls) != 0 {
+		t.Fatalf("expected no agent calls when provider CLI unavailable, got %d", len(ag.calls))
+	}
+}
+
 func TestPRStep_ExistingBranchUsesMergeBaseCommitLog(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -676,8 +676,8 @@ func browserCommandSpec(goos, url string) (string, []string) {
 
 // shortPRLabel extracts a compact label like "PR #42" from a PR URL.
 func shortPRLabel(url string) string {
-	// GitHub: .../pull/42, GitLab: .../merge_requests/42
-	for _, prefix := range []string{"/pull/", "/merge_requests/"} {
+	// GitHub: .../pull/42, GitLab: .../merge_requests/42, Bitbucket: .../pull-requests/42
+	for _, prefix := range []string{"/pull/", "/merge_requests/", "/pull-requests/"} {
 		if idx := strings.LastIndex(url, prefix); idx >= 0 {
 			num := url[idx+len(prefix):]
 			if num != "" {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -2233,6 +2233,18 @@ func TestRenderCIView_ShowsPRContextFromURL(t *testing.T) {
 	}
 }
 
+func TestRenderCIView_ShowsBitbucketPRContextFromURL(t *testing.T) {
+	run := testRunWithCI()
+	run.PRURL = ptr("https://bitbucket.org/user/repo/pull-requests/77")
+	run.Steps[5].Status = types.StepStatusRunning
+
+	out := stripANSI(renderCIView(run, run.Steps, "", nil, 80))
+
+	if !strings.Contains(out, "PR #77") {
+		t.Fatalf("expected CI panel to show Bitbucket PR context, got: %s", out)
+	}
+}
+
 func TestRenderCIView_AutoFixing(t *testing.T) {
 	run := testRunWithCI()
 	run.Steps[5].Status = types.StepStatusRunning


### PR DESCRIPTION
## Summary
- Add Bitbucket Cloud integration for PR creation/reuse, commit status polling, and failed pipeline log collection so the pipeline can operate on Bitbucket repos instead of only GitHub/GitLab flows.
- Harden detached daemon shutdown, stale-artifact cleanup, and PID validation across Unix and Windows to make the new provider flow safer and more reliable.
- Update README and docs to clarify Bitbucket Cloud-only support, required authentication variables, and provider-specific PR/CI behavior.

## Risk Assessment

⚠️ Medium: The branch adds substantial new Bitbucket and daemon-stop logic, and while most paths are covered, there are still a few correctness edges around URL generation and process-liveness fallback handling.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 3 warnings</summary>

**Round 1** - found 3 issues (2 errors, 1 warning)
- 🚨 `internal/daemon/selfexec.go:206` - `waitForDaemonStop` now deletes the socket and PID file immediately after issuing `proc.Kill()` without checking whether the kill succeeded or waiting for the daemon to exit. A surviving process will be hidden from future `IsRunning`/`Start` calls, which can leave an orphaned daemon and allow a second daemon to start against the same NM_HOME.
- 🚨 `internal/bitbucket/client.go:166` - `ListPRStatuses` only reads the first page of Bitbucket&#39;s paginated `.../pullrequests/{id}/statuses` response. Repos with more statuses than the default page size can silently miss failing checks on later pages, causing the CI step to report success and skip autofix/manual intervention.
- ⚠️ `internal/pipeline/steps/ci.go:266` - Bitbucket PRs skip mergeability handling entirely: `mergeabilityKnown` starts as true and the conflict check only runs for GitHub, so a Bitbucket PR with merge conflicts is treated as clean as soon as statuses pass. That is a behavioral gap from the existing CI step, which is supposed to surface or fix merge conflicts before continuing.

**Round 2** (auto-fix) - found 2 warnings
- ⚠️ `internal/daemon/selfexec.go:191` - `waitForDaemonStop` treats any failed IPC health check as proof the daemon exited and immediately deletes the socket/PID files. If the daemon is still running but the health RPC is transiently failing or the socket disappeared early, `Stop` returns success while leaving a live orphaned process with no local artifacts left to target.
- ⚠️ `internal/pipeline/steps/pr.go:63` - `Execute` now builds PR content before checking whether the provider can actually create a PR. On machines missing `gh`/`glab` auth or Bitbucket credentials, this still runs the expensive summary generation path and then logs a skip, which is a avoidable latency/token-cost regression.

**Round 3** (auto-fix) - found 3 issues (2 warnings, 1 info)
- ⚠️ `internal/bitbucket/client.go:174` - `ListPRStatuses` follows the API-supplied `next` URL verbatim, and `doJSONPathOrURL` will attach Basic Auth to any absolute URL. A cross-origin pagination link would leak the Bitbucket API token; only follow relative links or verify the host matches `baseURL` before sending credentials.
- ⚠️ `internal/pipeline/steps/ci.go:567` - Bitbucket auto-fix fetches pipeline logs by `sctx.Run.HeadSHA`, while the failing status list is read from the live PR. If the branch head changed after this run record was created, the agent will see logs for the wrong commit or no logs at all.
- ℹ️ `internal/pipeline/steps/pr.go:75` - For Bitbucket repos the step builds PR content before checking whether Bitbucket credentials are present, so a misconfigured run still pays the agent/diff cost and then immediately skips in `executeBitbucketPR`. Moving the env validation earlier would avoid wasted work.

**Round 4** (auto-fix) - found 3 warnings
- ⚠️ `internal/bitbucket/client.go:99` - `ParseRepoRef` accepts any host containing `bitbucket.org`, so URLs like `bitbucket.org.evil.example` are treated as Bitbucket remotes. Tighten this to an exact host or subdomain check before using the path to drive PR/CI API calls.
- ⚠️ `internal/bitbucket/client.go:115` - `FindOpenPRBySourceBranch` only filters on source branch and open state. If Bitbucket has multiple open PRs from the same branch to different destinations, `executeBitbucketPR` can update the wrong PR instead of the one targeting the default branch.
- ⚠️ `internal/daemon/selfexec.go:173` - `stopDetachedDaemon` now deletes the socket and PID files whenever `ipc.Dial` fails and then returns success. A transient or partial IPC failure would leave a still-running daemon orphaned and unmanaged because the fallback PID-based stop path has already been removed.

**Round 5** (auto-fix) - found 2 warnings
- ⚠️ `internal/pipeline/steps/ci.go:266` - The Bitbucket CI path never checks PR mergeability, so a Bitbucket PR with passing statuses but unresolved merge conflicts now exits as &#34;all CI checks passed&#34; and skips the existing conflict-handling flow.
- ⚠️ `internal/daemon/selfexec.go:206` - `staleDaemonArtifacts` treats any existing PID file as proof that the daemon is still live. After a crash, the stale socket and PID file can both remain, causing `daemon stop` to fail with a dial error instead of cleaning up the dead daemon&#39;s artifacts.

**Round 6** (auto-fix) - found 2 warnings
- ⚠️ `internal/daemon/selfexec.go:197` - `staleDaemonArtifacts` treats a missing socket file as automatically stale and returns before checking the PID, so `Stop` can report success and delete the pid file even if the daemon process is still alive but its socket was removed or never recreated.
- ⚠️ `internal/daemon/proc_windows.go:11` - The Windows `processRunning` stub returns `true` for every positive PID, so the new stale-artifact cleanup path cannot distinguish a dead daemon from a live one on Windows and will leave behind broken endpoint state after crashes or PID reuse.

**Round 7** (auto-fix) - found 3 warnings
- ⚠️ `internal/pipeline/steps/ci.go:266` - The Bitbucket CI path never checks PR mergeability, so a conflicting Bitbucket PR can be reported as clean once statuses pass and the CI auto-fix flow will never attempt to resolve the conflict. Decide whether Bitbucket support is intentionally status-only or should preserve the existing merge-conflict gating behavior.
- ⚠️ `internal/bitbucket/client.go:116` - `FindOpenPRBySourceBranch` filters only on source branch and OPEN state. If the same branch has multiple open Bitbucket PRs against different destination branches, the PR step can update the wrong PR instead of the one targeting the default branch.
- ⚠️ `internal/daemon/selfexec.go:174` - When IPC dialing fails but the PID still belongs to a live detached daemon, `stopDetachedDaemon` returns an error immediately and never falls back to stopping the process by PID. A running daemon with a broken or missing socket becomes impossible to stop from the CLI.

**Round 8** (auto-fix) - found 2 issues (1 error, 1 warning)
- 🚨 `internal/daemon/selfexec.go:205` - The new PID fallback kills whatever process ID is stored in `daemon.pid` without first validating that the PID is positive and still belongs to this daemon instance. If the pidfile is stale or the PID has been reused, `Stop()` can terminate an unrelated process.
- ⚠️ `internal/pipeline/steps/pr.go:160` - An existing Bitbucket PR is only reused when `existingPR.URL` is non-empty. If Bitbucket returns a valid open PR object without `links.html.href`, this path skips the update and creates a second PR instead of updating the one it already found by ID.

**Round 9** (auto-fix) - found 3 issues (1 error, 2 warnings)
- 🚨 `internal/bitbucket/client.go:116` - Existing Bitbucket PR reuse matches only `source.branch.name` plus `OPEN`. If two open PRs share the same branch name - for example a forked branch or the same branch targeting a different base branch - `executeBitbucketPR` will update whichever PR Bitbucket returns first and overwrite the wrong title/body.
- ⚠️ `internal/daemon/proc_unix.go:45` - `ps -o lstart` returns local time, but `time.Parse` without a zone interprets it as UTC. On hosts east of UTC this can make a live daemon look older than its PID file, so the PID fallback rejects the correct process as stale and `daemon stop` fails when IPC is broken.
- ⚠️ `internal/bitbucket/client.go:347` - `NewClientFromEnv` takes an explicit env slice, but `lookupEnv` falls back to `os.Getenv` when a key is missing. That breaks step-level env isolation: CI/PR steps can silently use ambient Bitbucket credentials or API base URL from the host process instead of the `StepContext` env they were given.

**Round 10** (auto-fix) - found 3 warnings
- ⚠️ `internal/pipeline/steps/pr.go:170` - When a Bitbucket PR update succeeds but the response omits `links.html.href`, this path returns an empty outcome instead of reusing `existingPR.URL`. That drops already-known PR context, so later CI/TUI steps can behave as if no PR exists even though the update succeeded.
- ⚠️ `internal/pipeline/steps/ci.go:483` - `bitbucketStatusBucket` classifies `STOPPED` as a failure. Bitbucket uses that state for manually stopped or canceled pipelines, so canceled runs will now trigger CI failure handling and auto-fix attempts instead of being treated like GitHub&#39;s non-failing cancel bucket.
- ⚠️ `internal/daemon/proc_unix.go:36` - The PID fallback reads `ps -o lstart` and parses it with a fixed English layout. Because `ps` output is locale-sensitive, non-English `LANG`/`LC_TIME` settings can make `processStartTime` fail, which in turn breaks detached-daemon shutdown on localized Unix systems.

**Round 11** (auto-fix) - found 2 issues (1 error, 1 warning)
- 🚨 `internal/daemon/selfexec.go:295` - `waitForDaemonStop` still does a raw `os.FindProcess(pid).Kill()` on the PID file without validating that the PID belongs to the same daemon instance. If the daemon exits, the socket stays unhealthy for 5s, and the OS reuses that PID, this path can kill an unrelated process.
- ⚠️ `internal/daemon/proc_unix.go:54` - `processStartTimeCommand` appends `LC_ALL=C` and `LANG=C` to `os.Environ()` instead of replacing existing locale variables. Duplicate env keys are unspecified on Unix, so localized `ps` output can still slip through and make `parseProcessStartTime` fail on non-English systems.

**Round 12** (auto-fix) - found 3 warnings
- ⚠️ `internal/bitbucket/client.go:115` - `FindOpenPRBySourceBranch` only filters by source branch and `OPEN` state. Bitbucket allows multiple open PRs from the same branch to different destination branches, so the PR step can update the wrong PR instead of the one targeting the repo default branch.
- ⚠️ `internal/daemon/proc_unix.go:64` - `ps -o lstart=` emits a space-padded day-of-month (for example `Apr  6`), but the parser uses `Jan 2` instead of `Jan _2`. On days 1-9 this can make PID validation fail and break daemon stop fallback on Unix.
- ⚠️ `internal/pipeline/steps/ci.go:485` - Mapping Bitbucket `STOPPED` statuses to `cancel` means cancelled CI is neither pending nor failing, so the CI step exits successfully once no other checks remain. If a pipeline is cancelled manually or by infra, the branch can look green without any successful CI run.

**Round 13** (auto-fix) - found 3 issues (1 error, 2 warnings)
- ⚠️ `internal/bitbucket/client.go:125` - `CreatePR` only sends `source.branch.name`, but Bitbucket&#39;s API requires `source.repository` when the branch lives in a fork. Any fork-based workflow will fail to create the PR because the destination repo URL is also used as the source repo by default.
- ⚠️ `internal/pipeline/steps/ci.go:450` - `getCIChecks` maps every object returned by `/pullrequests/{id}/statuses` into a live CI check, but Bitbucket documents that endpoint as returning all statuses for the PR. Without collapsing by key/name to the latest result, an old failed status can keep the step in failure/manual-intervention mode even after a rerun passes.
- 🚨 `internal/daemon/selfexec.go:261` - `staleDaemonArtifacts` treats any non-socket endpoint as stale, but the Windows IPC transport intentionally uses a regular endpoint file rather than a Unix socket. On Windows, any transient `daemonDial` failure will therefore delete the endpoint and PID files and return success without attempting PID fallback, leaving the daemon process running but unmanaged.

**Round 14** (auto-fix) - found 3 warnings
- ⚠️ `internal/bitbucket/client.go:193` - The Bitbucket log-collection path only reads the first page from both `ListPipelinesByCommit` and `ListPipelineSteps`. Once a repo has enough pipelines or a pipeline has enough steps to paginate, `fetchBitbucketFailedStepLogs` can miss the failing run entirely and auto-fix will lose the main CI context.
- ⚠️ `internal/bitbucket/client.go:235` - `GetStepLog` buffers the entire step log with `io.ReadAll` and only trims it afterward. Large Bitbucket logs can therefore consume unbounded memory and add avoidable latency even though the caller keeps only 32 KB; cap the response while reading or use HTTP range requests.
- ⚠️ `internal/daemon/selfexec.go:273` - `staleDaemonArtifacts` trusts any PID returned by `ReadPID`. On Unix, a corrupted PID file containing `0` or `-1` makes `processRunning` probe the current process/group, so stale daemon artifacts can be misclassified as live and never cleaned up. Validate PIDs are positive before calling `daemonProcessRunning`.

**Round 15** (auto-fix) - found 2 warnings
- ⚠️ `internal/bitbucket/client.go:117` - `FindOpenPRBySourceBranch` only filters on `source.branch.name` and `state`, so a branch with multiple open PRs can cause `PRStep` to update the wrong Bitbucket PR instead of the one targeting the repo&#39;s default branch. Include `destination.branch.name` in the query or verify the destination before updating.
- ⚠️ `internal/pipeline/steps/ci.go:480` - `latestBitbucketStatuses` keeps the first status seen for each key/name, but the client never requests a stable sort order from Bitbucket. If the API returns older statuses first or splits duplicates across pages, a stale failure can override a newer success and keep CI stuck in failure handling after checks are actually green.

**Round 16** (auto-fix) - found 1 error
- 🚨 `internal/daemon/selfexec.go:243` - `validateDaemonPIDFallback` only rejects PIDs whose start time is newer than the pid-file mtime. A stale pid file that happens to contain the PID of any long-running unrelated process will pass this check, and both `stopDetachedDaemonByPID` and `waitForDaemonStop` can then kill that unrelated process.

**Round 17** (auto-fix) - found 3 issues (1 error, 2 warnings)
- 🚨 `internal/daemon/selfexec.go:269` - If the PID file is missing, `staleDaemonArtifacts` treats the daemon as stale and `stopDetachedDaemon` deletes the socket/PID artifacts without any other liveness check. A live daemon that lost its PID file would keep running but become orphaned and unreachable.
- ⚠️ `internal/daemon/proc_unix.go:20` - Using `kill(pid, 0)` as the post-kill liveness check misclassifies zombie processes as still running on Unix. After `proc.Kill()`, both stop paths can time out with `still running after kill` even though the daemon has already exited, leaving stale artifacts behind.
- ⚠️ `internal/pipeline/steps/ci.go:458` - Bitbucket status deduplication falls back to `status.Key` when `status.Name` is empty, but the later `ciCheck` conversion drops that fallback and stores an empty name. For statuses that only provide a key, CI findings and autofix prompts will lose the identity of the failing check.

**Round 18** (auto-fix) - found 3 warnings
- ⚠️ `internal/pipeline/steps/ci.go:484` - `latestBitbucketStatuses` deduplicates statuses by the display name returned from `bitbucketStatusName`, not by Bitbucket&#39;s stable `key`. If the same status key is re-emitted with a renamed `name`, an older failed entry can survive alongside the newer passing one and keep CI stuck in a false-failing state. Deduplicate by `Key` first and only fall back to `Name` when the key is empty.
- ⚠️ `internal/bitbucket/client.go:117` - Open-PR lookup matches only `source.branch.name`, and `executeBitbucketPR` updates the first result it gets back. Bitbucket can have multiple open PRs from the same source branch to different destination branches, so this can overwrite the wrong PR instead of creating/updating the one targeting the repo&#39;s default branch.
- ⚠️ `internal/pipeline/steps/ci.go:512` - `STOPPED` Bitbucket statuses are mapped to `cancel`, but canceled checks are treated as neither pending nor failing. That means a canceled Bitbucket pipeline can let the CI step complete successfully once no other checks are pending, even though no successful run replaced it.

**Round 19** (auto-fix) - found 2 warnings
- ⚠️ `internal/bitbucket/client.go:117` - `FindOpenPRBySourceBranch` filters only on source branch name and destination branch, so a fork PR with the same branch name can be mistaken for this branch and get updated instead of creating/updating the correct PR. Include the source repository in the Bitbucket query before reusing an open PR.
- ⚠️ `internal/daemon/proc_unix.go:41` - `processState` shells out to a hard-coded `/bin/ps`, which will fail on Linux setups where `ps` is only available via `PATH` (for example Nix-style installs). That turns the new daemon liveness checks into false errors on otherwise supported systems.

**Round 20** (auto-fix) - found 2 warnings
- ⚠️ `internal/pipeline/steps/ci.go:266` - Bitbucket PRs never go through any mergeability check, so a conflicted Bitbucket PR is treated as clean once statuses pass and this step can exit with &#34;all CI checks passed&#34; even though the branch is not mergeable.
- ⚠️ `internal/pipeline/steps/ci.go:551` - Auto-fix pulls logs from the first failed pipeline for the commit without matching it back to the failing PR status/check, so a manual or unrelated pipeline on the same commit can inject the wrong failure context into the agent prompt.

**Round 21** (auto-fix) - found 2 errors
- 🚨 `internal/pipeline/steps/pr.go:72` - This Bitbucket path reads credentials only from `sctx.Env`, but the production executor never populates `StepContext.Env`; outside tests, PR creation will always be skipped with missing Bitbucket credential errors even when the variables are present in the real process environment.
- 🚨 `internal/pipeline/steps/ci.go:182` - CI monitoring/autofix has the same environment lookup bug: `bitbucket.NewClientFromEnv(sctx.Env)` only sees the test-only step env, so real Bitbucket runs will skip CI monitoring and later log fetching because `StepContext.Env` is nil in production.

**Round 22** (auto-fix) - found 3 issues (1 error, 2 warnings)
- 🚨 `internal/daemon/service.go:230` - The legacy-service cleanup now unconditionally bootouts/stops/deletes the global pre-scoping daemon artifact during install, so starting a new scoped install can tear down another live daemon owned by a different `NM_HOME`. The new `serviceDefinitionMatchesRoot` helper is never used to guard this.
- ⚠️ `internal/pipeline/steps/ci.go:267` - Bitbucket PRs skip mergeability checks entirely, but `mergeabilityKnown` stays `true`, so a conflicted Bitbucket PR can still exit as `all CI checks passed` once statuses are green. That regresses the safety check the GitHub path still enforces.
- ⚠️ `internal/bitbucket/client.go:420` - `lookupEnv` falls back to ambient `os.LookupEnv` whenever a key is missing from the step&#39;s explicit env slice, so a supposedly isolated run can silently reuse the caller&#39;s Bitbucket credentials or API base URL and operate on the wrong account/host. If that fallback is intentional, it should at least be limited to a nil env instead of overriding partial per-step envs.

**Round 23** (auto-fix) - found 2 warnings
- ⚠️ `internal/daemon/service.go:205` - `serviceDefinitionMatchesRoot` uses a raw substring match on the serialized plist/unit/task definition, so roots like `/nm` will also match unrelated installs rooted at `/nm-prod` and the new legacy-cleanup path can stop/delete the wrong managed daemon.
- ⚠️ `internal/pipeline/steps/pr.go:188` - Bitbucket PR creation is treated as a success only when `links.html.href` is present; if the API returns a created PR without that field, the step returns an empty outcome and never persists a PR URL, which causes later CI/TUI flows to behave as if no PR exists.

**Round 24** (auto-fix) - found 3 warnings
- ⚠️ `internal/pipeline/steps/pr.go:210` - `bitbucketPRURL` hardcodes `https://bitbucket.org` when the API response omits `links.html.href`, so PR URLs are persisted/opened against the wrong host for any non-default Bitbucket deployment or custom API base URL.
- ⚠️ `internal/daemon/proc_unix.go:22` - `processRunning` treats any `ps` failure as fatal after `kill(pid, 0)` succeeds; if the process exits between those two probes, stop/cleanup paths fail even though the daemon is already gone.
- ⚠️ `internal/daemon/selfexec.go:244` - The PID fallback only accepts a 1-second match between the pidfile mtime and process start time, which is brittle on coarse-timestamp filesystems or delayed writes and can reject the real daemon during stop/cleanup.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>🔧 **Document** - 6 issues found → auto-fixed (3)</summary>

**Round 1** - found 6 warnings
- ⚠️ `README.md:102` - The install/prerequisites section is stale after this change: PR creation is no longer limited to `gh`/`glab`, and CI monitoring is no longer GitHub-only. Update it to mention Bitbucket support and the Bitbucket authentication requirements added by this branch.
- ⚠️ `docs/src/content/docs/getting-started.md:43` - The prerequisites list still says PR/MR creation needs only `gh` or `glab`, and CI monitoring needs `gh`. That is now outdated because Bitbucket PR creation and CI monitoring are supported via Bitbucket API credentials instead of a CLI.
- ⚠️ `docs/src/content/docs/guides/pipeline-steps.md:109` - The PR step documentation still says the step is skipped unless the upstream host is GitHub or GitLab and a provider CLI is installed/authenticated. The implementation now supports Bitbucket PR creation and updates via API credentials, so the skip conditions and behavior section need to include Bitbucket.
- ⚠️ `docs/src/content/docs/guides/pipeline-steps.md:123` - The CI step documentation is stale: it says the step is only active for GitHub and describes only `gh`-based checks/log retrieval. The code now also monitors Bitbucket PRs, reads Bitbucket commit statuses, treats `DECLINED` as closed, and pulls failed Bitbucket pipeline step logs for auto-fix prompts.
- ⚠️ `docs/src/content/docs/reference/global-config.md:108` - The environment variables reference does not document the new Bitbucket authentication settings required by this feature. Add `NO_MISTAKES_BITBUCKET_EMAIL`, `NO_MISTAKES_BITBUCKET_API_TOKEN`, and the optional `NO_MISTAKES_BITBUCKET_API_BASE_URL`.
- ⚠️ `docs/src/content/docs/reference/cli.md:100` - The `no-mistakes doctor` reference says `gh` is needed for the PR and CI steps, which is no longer true for Bitbucket repositories. Update this note so it reflects provider-specific requirements instead of implying GitHub CLI is universally required.

**Round 2** (auto-fix) - found 4 warnings
- ⚠️ `README.md:102` - The new SCM support is documented as generic &#34;Bitbucket&#34; support, but the implementation only accepts `bitbucket.org` and `*.bitbucket.org` repository hosts. Update this note to say Bitbucket Cloud explicitly so self-hosted Bitbucket Server/Data Center users are not misled.
- ⚠️ `docs/src/content/docs/getting-started.md:44` - The prerequisites section says Bitbucket credentials enable &#34;Bitbucket PR creation and CI monitoring&#34; without noting that the new support is limited to Bitbucket Cloud-style hosts. Add that scope here to match the actual host parsing behavior.
- ⚠️ `docs/src/content/docs/guides/pipeline-steps.md:111` - The PR and CI step docs now list Bitbucket as a supported provider, but they do not mention that only Bitbucket Cloud hosts are accepted by the new implementation. Clarify that the provider support here is for `bitbucket.org`/Bitbucket Cloud, not self-hosted Bitbucket variants.
- ⚠️ `docs/src/content/docs/reference/cli.md:108` - The CLI reference tells users to set Bitbucket credentials for PR and CI steps, but it does not document that this integration only works with Bitbucket Cloud hosts. Add that limitation so the command reference matches the new provider behavior.

**Round 3** (auto-fix) - found 8 issues (7 warnings, 1 info)
- ⚠️ `docs/src/content/docs/guides/pipeline-steps.md:127` - The CI step docs now say the step generally auto-fixes merge conflicts and tracks unresolved mergeability, but the new Bitbucket Cloud implementation only polls commit statuses and failed pipeline-step logs; mergeability polling and merge-conflict detection remain GitHub-only. This page needs provider-specific wording so Bitbucket support is not overstated.
- ⚠️ `docs/src/content/docs/getting-started.md:105` - The pipeline overview still describes the CI step as always watching PR mergeability and auto-fixing merge conflicts. After this change that is no longer true for Bitbucket Cloud, so the getting-started guide needs to qualify that behavior as GitHub-only or describe the provider differences.
- ⚠️ `docs/src/content/docs/index.mdx:33` - The homepage CI monitoring card still says the pipeline watches PR mergeability and fixes merge conflicts before the branch is done. With Bitbucket Cloud support added, that copy is stale because Bitbucket CI monitoring does not implement mergeability/merge-conflict handling.
- ⚠️ `docs/src/content/docs/guides/auto-fix.md:30` - This guide says `auto_fix.ci` is shared for CI failures and merge conflicts without any provider qualifier. After the Bitbucket change, merge-conflict auto-fix is only available on the GitHub path, so the CI auto-fix docs should call out that limitation.
- ⚠️ `docs/src/content/docs/guides/configuration.md:33` - The configuration guide still defines `ci_timeout` in terms of waiting for checks and PR mergeability, which is now only accurate for GitHub. It should describe the provider-specific behavior or avoid implying Bitbucket Cloud also has mergeability polling.
- ⚠️ `docs/src/content/docs/reference/global-config.md:66` - The `ci_timeout` and `auto_fix.ci` reference text still frames CI around PR mergeability and merge conflicts as if that applied to every provider. Since the new Bitbucket Cloud path only supports CI status polling and failed-log collection, this reference needs provider-specific wording.
- ⚠️ `README.md:201` - The sample config comment still says the CI step waits for checks and PR mergeability before timing out. That overstates the new Bitbucket Cloud support, where mergeability is not polled, so the README should be updated to avoid implying identical CI behavior across providers.
- ℹ️ `docs/src/content/docs/guides/configuration.md:17` - This change adds Bitbucket-specific environment configuration (`NO_MISTAKES_BITBUCKET_EMAIL`, `NO_MISTAKES_BITBUCKET_API_TOKEN`, and optional `NO_MISTAKES_BITBUCKET_API_BASE_URL`), but the main configuration guide still only walks through YAML config files. Add a short environment-variables section or link so Bitbucket setup is documented in the primary configuration guide, not only in the reference table.

**Round 4** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
