### PR TITLE
fix(pipeline): tighten PR title scope selection

### DIFF
--- a/docs/src/content/docs/guides/pipeline-steps.md
+++ b/docs/src/content/docs/guides/pipeline-steps.md
@@ -117,7 +117,7 @@ Creates or updates a pull request.
 - Checks for an existing PR on the branch
 - If one exists, updates it. If not, creates a new one.
 - Uses the provider CLI for GitHub/GitLab and the Bitbucket API for Bitbucket Cloud
-- PR title: agent-generated in conventional commit format (`type(scope): description`)
+- PR title: agent-generated in conventional commit format (`type(scope): description` or `type: description`); when a scope is used, it should be the primary affected real module/package from the changed paths and kept broad rather than file-level
 - PR body includes: an agent-authored `## Summary` plus regenerated `## Risk Assessment`, `## Testing`, and `## Pipeline` sections from recorded step results and rounds
 
 Stores the PR URL in the database and streams it to the TUI.

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -298,6 +298,8 @@ Context:
 Rules:
 - Cover the full branch delta, not just the latest commit.
 - Title must use conventional commit format: "type(scope): description" or "type: description". Valid types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert. Scope is optional. Do not capitalize the type. Do not use the raw branch name.
+- When including a scope, it MUST be a real package/module name that exists in the codebase (for example, a directory under internal/, cmd/, or the equivalent top-level grouping for this project), identified by inspecting the changed paths. Pick the primary module affected by the change, not a secondary or incidental one.
+- Keep the scope at a coarse level, not too granular: a codebase typically has fewer than 10 distinct scopes in use across its history. Prefer a broad module name (e.g. "daemon", "pipeline", "cli") over a narrow file or sub-feature name. If you cannot confidently identify a real primary module, omit the scope and use "type: description".
 - Body: a "## Summary" section in GitHub-flavored markdown. 1-3 concise bullet points describing what changed and why. Do not include Risk Assessment, Testing, or Pipeline sections - those are appended separately. The body value must be plain markdown text, never a JSON object or serialized JSON string.
 - Do not invent tests or behavior.
 

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -7593,6 +7593,46 @@ func TestPRStep_AgentScopedBreakingTitlePassesThrough(t *testing.T) {
 	}
 }
 
+// TestPRStep_PromptGuidesScopeToRealModule verifies the PR prompt instructs
+// the agent to pick a scope that is a real, primary, not-too-granular
+// module/package name in the codebase.
+func TestPRStep_PromptGuidesScopeToRealModule(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	env, _ := fakeGH(t, "")
+
+	var capturedPrompt string
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			capturedPrompt = opts.Prompt
+			payload := json.RawMessage(`{"title":"fix(daemon): tidy logs","body":"## Summary\n\n- tidy"}`)
+			return &agent.Result{Output: payload}, nil
+		},
+	}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+
+	step := &PRStep{}
+	if _, err := step.Execute(sctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(capturedPrompt, "real package/module name that exists in the codebase") {
+		t.Errorf("expected PR prompt to require scope be a real package/module name in the codebase, got:\n%s", capturedPrompt)
+	}
+	if !strings.Contains(capturedPrompt, "primary module affected") {
+		t.Errorf("expected PR prompt to require scope be the primary module affected, got:\n%s", capturedPrompt)
+	}
+	if !strings.Contains(capturedPrompt, "not too granular") {
+		t.Errorf("expected PR prompt to warn scope should not be too granular, got:\n%s", capturedPrompt)
+	}
+	if !strings.Contains(capturedPrompt, "fewer than 10 distinct") {
+		t.Errorf("expected PR prompt to convey typical module count heuristic, got:\n%s", capturedPrompt)
+	}
+}
+
 func TestCIStep_CIAutoFixDisabledWithZero(t *testing.T) {
 	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)


### PR DESCRIPTION
## Summary
- Update the PR pipeline prompt to prefer real package or module scopes from the changed paths so generated titles use a clearer primary scope when one exists.
- Add regression coverage for the PR prompt so scope-selection guidance stays in place as the pipeline evolves.
- Document the PR title scope rule in the pipeline steps guide, including when to keep scopes coarse or omit them entirely.

## Risk Assessment

⚠️ Medium: This is a narrow prompt-only change, but it changes user-visible PR title generation and bakes in repo-specific assumptions that do not match the current history, so it is safe only if that policy shift is explicitly intended.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 3 issues (2 warnings, 1 info)</summary>

**Round 1** - found 3 issues (2 warnings, 1 info)
- ⚠️ `internal/pipeline/steps/pr.go:301` - The new prompt now treats scopes as package/module names only, but this repo&#39;s own title history already uses many non-directory scopes such as `prsummary`, `pr-url`, `windows`, and `main`. Unless that naming-policy change is intentional, PR titles generated after this change will drift away from the repo&#39;s established conventions.
- ⚠️ `internal/pipeline/steps/pr.go:302` - The prompt says a codebase &#39;typically has fewer than 10 distinct scopes&#39;, but this repository already has 31 distinct scoped titles in git history. That false heuristic will bias the model toward dropping valid scopes or collapsing them into overly broad ones, which undercuts the stated goal of choosing the real primary scope.
- ℹ️ `internal/pipeline/steps/steps_test.go:7631` - The new regression test hard-codes the &#39;fewer than 10 distinct&#39; wording instead of validating the actual behavior we care about. That makes future prompt corrections fail the test even if they improve scope selection, so the assertion is more brittle than necessary.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `docs/src/content/docs/guides/pipeline-steps.md:120` - The PR step guide still only says titles use conventional commit format. This change adds behavior that, when a scope is used, it should be a real package/module from the changed paths, biased toward the primary affected module and kept coarse rather than file-level. The guide should document that scope-selection rule, including that scope may be omitted when no clear primary module exists.

**Round 2** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
