### PR TITLE
ci(release): gate releases on CI completion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
@@ -48,12 +45,8 @@ jobs:
         run: go test -race ./...
 
       - name: Test on Windows (PR)
-        if: runner.os == 'Windows' && github.event_name == 'pull_request'
+        if: runner.os == 'Windows'
         run: go test ./... -run '_EnableWindowsCI$'
-
-      - name: Test on Windows (Main)
-        if: runner.os == 'Windows' && github.event_name != 'pull_request'
-        run: go test ./...
 
       - name: Build
         run: go build ./cmd/no-mistakes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,53 @@ permissions:
   pull-requests: write
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Format check
+        run: |
+          output=$(gofmt -l .)
+          if [ -n "$output" ]; then
+            echo "Files not formatted:"
+            echo "$output"
+            exit 1
+          fi
+
+      - name: Vet
+        run: go vet ./...
+
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Test on Unix
+        if: runner.os != 'Windows'
+        run: go test -race ./...
+
+      - name: Test on Windows
+        if: runner.os == 'Windows'
+        run: go test ./...
+
+      - name: Build
+        run: go build ./cmd/no-mistakes
+
   release-please:
+    needs: [check, test]
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -46,6 +92,8 @@ jobs:
             goarch: arm64
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
 
       - uses: actions/setup-go@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
           set -euo pipefail
           mkdir -p dist
           DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          COMMIT="${GITHUB_SHA::7}"
+          COMMIT="$(git rev-parse --short=7 HEAD)"
           BIN="no-mistakes"
           OUT="dist/${BIN}"
           if [ "$GOOS" = "windows" ]; then

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -388,19 +388,37 @@ func TestStopNotRunningRemovesStaleArtifacts(t *testing.T) {
 	if err := p.EnsureDirs(); err != nil {
 		t.Fatal(err)
 	}
-	// Use a pid that is not running so Stop() recognizes the artifacts as
-	// stale on all platforms. os.Getpid() would be a live process that the
-	// Windows pid-fallback validator correctly rejects as "not the daemon",
-	// because the test runner's start time predates the pid file.
-	if err := os.WriteFile(p.PIDFile(), []byte("999999"), 0o644); err != nil {
+	const pid = 424242
+	if err := os.WriteFile(p.PIDFile(), []byte(fmt.Sprintf("%d", pid)), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(p.Socket(), []byte("stale"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
+	originalUsesRegularFile := daemonEndpointUsesRegularFile
+	daemonEndpointUsesRegularFile = func() bool { return true }
+	defer func() {
+		daemonEndpointUsesRegularFile = originalUsesRegularFile
+	}()
+	originalProcessRunning := daemonProcessRunning
+	processRunningChecks := 0
+	daemonProcessRunning = func(checkPID int) (bool, error) {
+		if checkPID != pid {
+			t.Fatalf("processRunning pid = %d, want %d", checkPID, pid)
+		}
+		processRunningChecks++
+		return false, nil
+	}
+	defer func() {
+		daemonProcessRunning = originalProcessRunning
+	}()
+
 	if err := Stop(p); err != nil {
 		t.Fatalf("stop should succeed when daemon is not running: %v", err)
+	}
+	if processRunningChecks == 0 {
+		t.Fatal("expected stale-artifact detection to check process state")
 	}
 	if _, err := os.Stat(p.PIDFile()); !os.IsNotExist(err) {
 		t.Fatalf("expected stale pid file to be removed, got err=%v", err)
@@ -674,7 +692,8 @@ func TestStopDetachedDaemonRemovesArtifactsForDeadPID(t *testing.T) {
 	if err := p.EnsureDirs(); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(p.PIDFile(), []byte("999999"), 0o644); err != nil {
+	const pid = 424242
+	if err := os.WriteFile(p.PIDFile(), []byte(fmt.Sprintf("%d", pid)), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	fd, err := syscall.Socket(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
@@ -697,9 +716,24 @@ func TestStopDetachedDaemonRemovesArtifactsForDeadPID(t *testing.T) {
 	defer func() {
 		daemonDial = originalDial
 	}()
+	originalProcessRunning := daemonProcessRunning
+	processRunningChecks := 0
+	daemonProcessRunning = func(checkPID int) (bool, error) {
+		if checkPID != pid {
+			t.Fatalf("processRunning pid = %d, want %d", checkPID, pid)
+		}
+		processRunningChecks++
+		return false, nil
+	}
+	defer func() {
+		daemonProcessRunning = originalProcessRunning
+	}()
 
 	if err := stopDetachedDaemon(p); err != nil {
 		t.Fatalf("expected stopDetachedDaemon to clean stale artifacts, got %v", err)
+	}
+	if processRunningChecks == 0 {
+		t.Fatal("expected stale-artifact detection to check process state")
 	}
 	if _, statErr := os.Stat(p.PIDFile()); !os.IsNotExist(statErr) {
 		t.Fatalf("expected stale pid file to be removed, got err=%v", statErr)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -388,7 +388,11 @@ func TestStopNotRunningRemovesStaleArtifacts(t *testing.T) {
 	if err := p.EnsureDirs(); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(p.PIDFile(), []byte(fmt.Sprintf("%d", os.Getpid())), 0o644); err != nil {
+	// Use a pid that is not running so Stop() recognizes the artifacts as
+	// stale on all platforms. os.Getpid() would be a live process that the
+	// Windows pid-fallback validator correctly rejects as "not the daemon",
+	// because the test runner's start time predates the pid file.
+	if err := os.WriteFile(p.PIDFile(), []byte("999999"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(p.Socket(), []byte("stale"), 0o644); err != nil {


### PR DESCRIPTION
## Summary
- Update the release workflow to run after CI completes and add release gating jobs so release automation depends on the branch's CI result instead of publishing independently.
- Fix release build metadata to use the checked-out ref's commit SHA so generated artifacts report the commit they were actually built from.
- Stabilize stale daemon artifact tests to make the release-related test path deterministic and reduce flaky failures in CI.

## Risk Assessment

⚠️ Medium: The daemon test changes are low-risk, but the workflow changes alter release automation behavior and introduce a meaningful chance of post-merge release blocking or stalled release bookkeeping.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 2 warnings</summary>

**Round 1** - found 2 warnings
- ⚠️ `.github/workflows/release.yml:51` - The new release gate is not actually using the same test surface as PR CI: `ci.yml` only runs `_EnableWindowsCI$` on Windows PRs, but the release workflow runs the full Windows suite on `main`. That means a PR can be green and still block release immediately after merge, which defeats the goal of gating release on CI completion unless this stricter post-merge behavior is explicitly intended.
- ⚠️ `internal/daemon/daemon_test.go:395` - This test now assumes PID `999999` is always unused. On hosts with a larger PID space or long-lived runners, that PID can legitimately exist, which makes the stale-artifact path nondeterministic and can fail the test for reasons unrelated to the code under test. Stub the process-check helpers instead of relying on a magic PID.

**Round 2** (auto-fix) - found 2 issues (1 warning, 1 info)
- ⚠️ `.github/workflows/release.yml:112` - The release artifacts are built from the checked-out tag, but the embedded `Commit` metadata still comes from `GITHUB_SHA`, which is the workflow event SHA rather than the checked-out ref. A rerun or any future non-push trigger can stamp binaries with the wrong commit hash.
- ℹ️ `.github/workflows/release.yml:13` - `check` and `test` now duplicate the CI workflow logic instead of reusing it, so the release gate can silently drift from `ci.yml` again the next time somebody changes one workflow but not the other. Extracting a reusable workflow would remove that maintenance risk.

**Round 3** (auto-fix) - found 2 warnings
- ⚠️ `.github/workflows/release.yml:59` - Gating `release-please` behind `check` and `test` blocks not just publishing, but also the action&#39;s normal release-PR creation/update path whenever `main` is red. That means a transient failure on `main` can stall the release automation entirely until someone fixes CI, even for later commits that would repair it.
- ⚠️ `.github/workflows/release.yml:51` - The new release gate runs the full Windows suite on `main`, while PR CI still runs only `_EnableWindowsCI$` tests. A change can now merge with a green PR and then fail only after merge in the release workflow, turning this into a post-merge release blocker rather than a pre-merge signal.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
