### PR TITLE
test(daemon): cover stale artifact process-state detection

### DIFF
--- a/internal/daemon/lifecycle_test.go
+++ b/internal/daemon/lifecycle_test.go
@@ -73,15 +73,37 @@ func TestStopNotRunningRemovesStaleArtifacts(t *testing.T) {
 	if err := p.EnsureDirs(); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(p.PIDFile(), []byte(fmt.Sprintf("%d", os.Getpid())), 0o644); err != nil {
+	const pid = 424242
+	if err := os.WriteFile(p.PIDFile(), []byte(fmt.Sprintf("%d", pid)), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(p.Socket(), []byte("stale"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
+	originalUsesRegularFile := daemonEndpointUsesRegularFile
+	daemonEndpointUsesRegularFile = func() bool { return true }
+	defer func() {
+		daemonEndpointUsesRegularFile = originalUsesRegularFile
+	}()
+	originalProcessRunning := daemonProcessRunning
+	processRunningChecks := 0
+	daemonProcessRunning = func(checkPID int) (bool, error) {
+		if checkPID != pid {
+			t.Fatalf("processRunning pid = %d, want %d", checkPID, pid)
+		}
+		processRunningChecks++
+		return false, nil
+	}
+	defer func() {
+		daemonProcessRunning = originalProcessRunning
+	}()
+
 	if err := Stop(p); err != nil {
 		t.Fatalf("stop should succeed when daemon is not running: %v", err)
+	}
+	if processRunningChecks == 0 {
+		t.Fatal("expected stale-artifact detection to check process state")
 	}
 	if _, err := os.Stat(p.PIDFile()); !os.IsNotExist(err) {
 		t.Fatalf("expected stale pid file to be removed, got err=%v", err)


### PR DESCRIPTION
## Summary
- Add daemon lifecycle coverage for stale artifact detection when deciding whether a recorded process is still active.
- Verify the check consults real process state so stale artifacts are identified correctly instead of relying only on persisted metadata.

## Risk Assessment

✅ Low: The branch only adjusts one daemon lifecycle test to better assert stale-artifact behavior, and the change is narrowly scoped with no material correctness or maintainability issues in the modified code.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
