### PR TITLE
fix(agent): harden rovodev SSE parsing and server health checks

### DIFF
--- a/internal/agent/rovodev.go
+++ b/internal/agent/rovodev.go
@@ -180,67 +180,132 @@ func buildRovodevSystemPrompt(schema json.RawMessage) string {
 	}, "\n")
 }
 
-// rovodevSSEEvent is the JSON payload from a rovodev SSE data field.
+// rovodevSSEEvent captures every field we care about from a rovodev SSE
+// data payload. Real rovodev emits text content via part_start / part_delta
+// events (not a single "text" event) and puts request-usage fields at the
+// top level of the payload, not nested under "usage". Shape matches the
+// well-proven gnhf integration.
 type rovodevSSEEvent struct {
-	EventKind string           `json:"event_kind,omitempty"`
-	Content   string           `json:"content,omitempty"`
-	Usage     *rovodevSSEUsage `json:"usage,omitempty"`
+	EventKind string `json:"event_kind,omitempty"`
+	Content   string `json:"content,omitempty"`
+
+	// request-usage
+	InputTokens      int `json:"input_tokens,omitempty"`
+	OutputTokens     int `json:"output_tokens,omitempty"`
+	CacheReadTokens  int `json:"cache_read_tokens,omitempty"`
+	CacheWriteTokens int `json:"cache_write_tokens,omitempty"`
+
+	// part_start
+	Index int             `json:"index,omitempty"`
+	Part  *rovodevSSEPart `json:"part,omitempty"`
+
+	// part_delta
+	Delta *rovodevSSEDelta `json:"delta,omitempty"`
 }
 
-type rovodevSSEUsage struct {
-	InputTokens      int `json:"input_tokens"`
-	OutputTokens     int `json:"output_tokens"`
-	CacheReadTokens  int `json:"cache_read_tokens"`
-	CacheWriteTokens int `json:"cache_write_tokens"`
+type rovodevSSEPart struct {
+	Content  string `json:"content"`
+	PartKind string `json:"part_kind"`
+}
+
+type rovodevSSEDelta struct {
+	ContentDelta  string `json:"content_delta"`
+	PartDeltaKind string `json:"part_delta_kind"`
 }
 
 // parseRovodevSSE processes the SSE stream from rovodev, extracting text
-// chunks, token usage, and the latest text segment for structured output.
+// chunks, token usage, and the latest assembled text for structured output.
+//
+// Text arrives in three possible shapes:
+//   - "text" events carry the full current message in `content`.
+//   - "part_start" events start a new text part at an index.
+//   - "part_delta" events append to the part at the given index.
+//
+// Tool activity ("tool-return", "on_call_tools_start") resets the buffer so
+// only the final post-tool text segment is returned as the structured answer.
 func parseRovodevSSE(r io.Reader, onChunk func(string), usage *TokenUsage, latestText *string) error {
+	var parts []string
+	partIndex := map[int]int{}
 	var hasEmittedText, hadToolActivity bool
+
+	updateLatest := func() {
+		*latestText = strings.TrimSpace(strings.Join(parts, ""))
+	}
+	resetParts := func() {
+		parts = nil
+		partIndex = map[int]int{}
+		*latestText = ""
+	}
+	emitSeparator := func() {
+		if hasEmittedText && hadToolActivity && onChunk != nil {
+			onChunk("\n\n")
+		}
+		hadToolActivity = false
+	}
+	emitChunk := func(s string) {
+		if onChunk != nil {
+			onChunk(s)
+			hasEmittedText = true
+		}
+	}
+
 	return parseSSE(r, func(ev sseEvent) bool {
 		if ev.Data == "" {
 			return true
 		}
 
-		// Determine event kind from SSE event name or JSON payload
 		kind := ev.Name
-
 		var payload rovodevSSEEvent
-		if err := json.Unmarshal([]byte(ev.Data), &payload); err == nil {
-			if kind == "" && payload.EventKind != "" {
-				kind = payload.EventKind
+		if err := json.Unmarshal([]byte(ev.Data), &payload); err != nil {
+			return true
+		}
+		if kind == "" && payload.EventKind != "" {
+			kind = payload.EventKind
+		}
+
+		switch kind {
+		case "request-usage":
+			usage.Add(TokenUsage{
+				InputTokens:         payload.InputTokens,
+				OutputTokens:        payload.OutputTokens,
+				CacheReadTokens:     payload.CacheReadTokens,
+				CacheCreationTokens: payload.CacheWriteTokens,
+			})
+
+		case "text":
+			if payload.Content != "" {
+				emitSeparator()
+				parts = []string{payload.Content}
+				partIndex = map[int]int{0: 0}
+				updateLatest()
+				emitChunk(payload.Content)
 			}
 
-			switch kind {
-			case "request-usage":
-				if payload.Usage != nil {
-					usage.Add(TokenUsage{
-						InputTokens:         payload.Usage.InputTokens,
-						OutputTokens:        payload.Usage.OutputTokens,
-						CacheReadTokens:     payload.Usage.CacheReadTokens,
-						CacheCreationTokens: payload.Usage.CacheWriteTokens,
-					})
-				}
-
-			case "text":
-				if payload.Content != "" {
-					if hasEmittedText && hadToolActivity && onChunk != nil {
-						onChunk("\n\n")
-					}
-					hadToolActivity = false
-					*latestText = payload.Content
-					if onChunk != nil {
-						onChunk(payload.Content)
-						hasEmittedText = true
-					}
-				}
-
-			case "tool-return", "on_call_tools_start":
-				// Reset text buffer — agent is doing tool calls
-				*latestText = ""
-				hadToolActivity = true
+		case "part_start":
+			if payload.Part != nil && payload.Part.PartKind == "text" && payload.Part.Content != "" {
+				emitSeparator()
+				parts = append(parts, payload.Part.Content)
+				partIndex[payload.Index] = len(parts) - 1
+				updateLatest()
+				emitChunk(payload.Part.Content)
 			}
+
+		case "part_delta":
+			if payload.Delta != nil && payload.Delta.PartDeltaKind == "text" && payload.Delta.ContentDelta != "" {
+				if idx, ok := partIndex[payload.Index]; ok {
+					parts[idx] += payload.Delta.ContentDelta
+				} else {
+					emitSeparator()
+					parts = append(parts, payload.Delta.ContentDelta)
+					partIndex[payload.Index] = len(parts) - 1
+				}
+				updateLatest()
+				emitChunk(payload.Delta.ContentDelta)
+			}
+
+		case "tool-return", "on_call_tools_start":
+			resetParts()
+			hadToolActivity = true
 		}
 
 		return true

--- a/internal/agent/rovodev.go
+++ b/internal/agent/rovodev.go
@@ -229,7 +229,7 @@ func parseRovodevSSE(r io.Reader, onChunk func(string), usage *TokenUsage, lates
 	var hasEmittedText, hadToolActivity bool
 
 	updateLatest := func() {
-		*latestText = strings.TrimSpace(strings.Join(parts, ""))
+		*latestText = strings.Join(parts, "")
 	}
 	resetParts := func() {
 		parts = nil

--- a/internal/agent/rovodev_test.go
+++ b/internal/agent/rovodev_test.go
@@ -250,6 +250,26 @@ data: {"index":0,"delta":{"content_delta":"orphan","part_delta_kind":"text"},"ev
 	}
 }
 
+func TestParseRovodevSSE_PreservesWhitespaceInAssembledText(t *testing.T) {
+	input := `event: part_start
+data: {"index":0,"part":{"content":"  hello","part_kind":"text"},"event_kind":"part_start"}
+
+event: part_delta
+data: {"index":0,"delta":{"content_delta":" world\n","part_delta_kind":"text"},"event_kind":"part_delta"}
+
+`
+	var usage TokenUsage
+	var latestText string
+
+	err := parseRovodevSSE(strings.NewReader(input), nil, &usage, &latestText)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if latestText != "  hello world\n" {
+		t.Errorf("expected whitespace-preserved latest text, got %q", latestText)
+	}
+}
+
 func TestParseRovodevSSE_GnhfFixture(t *testing.T) {
 	// Full stream replay from gnhf's primary rovodev integration test, which
 	// exercises part_start + part_delta assembly and top-level request-usage.

--- a/internal/agent/rovodev_test.go
+++ b/internal/agent/rovodev_test.go
@@ -35,8 +35,10 @@ data: {"content":"hello world"}
 }
 
 func TestParseRovodevSSE_UsageEvent(t *testing.T) {
+	// Real rovodev emits usage fields at the top level of the data payload,
+	// matching the fixture format used by the gnhf integration.
 	input := `event: request-usage
-data: {"usage":{"input_tokens":100,"output_tokens":50,"cache_read_tokens":30,"cache_write_tokens":10}}
+data: {"input_tokens":100,"output_tokens":50,"cache_read_tokens":30,"cache_write_tokens":10}
 
 `
 	var usage TokenUsage
@@ -118,10 +120,10 @@ func TestParseRovodevSSE_EventKindFallback(t *testing.T) {
 
 func TestParseRovodevSSE_MultipleUsageAccumulates(t *testing.T) {
 	input := `event: request-usage
-data: {"usage":{"input_tokens":50,"output_tokens":20}}
+data: {"input_tokens":50,"output_tokens":20}
 
 event: request-usage
-data: {"usage":{"input_tokens":100,"output_tokens":30}}
+data: {"input_tokens":100,"output_tokens":30}
 
 `
 	var usage TokenUsage
@@ -136,6 +138,161 @@ data: {"usage":{"input_tokens":100,"output_tokens":30}}
 	}
 	if usage.OutputTokens != 50 {
 		t.Errorf("expected accumulated output tokens 50, got %d", usage.OutputTokens)
+	}
+}
+
+func TestParseRovodevSSE_PartStart(t *testing.T) {
+	input := `event: part_start
+data: {"index":0,"part":{"content":"hello","part_kind":"text"},"event_kind":"part_start"}
+
+`
+	var usage TokenUsage
+	var latestText string
+	var chunks []string
+
+	err := parseRovodevSSE(strings.NewReader(input), func(text string) {
+		chunks = append(chunks, text)
+	}, &usage, &latestText)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if latestText != "hello" {
+		t.Errorf("expected latest text 'hello', got %q", latestText)
+	}
+	if len(chunks) != 1 || chunks[0] != "hello" {
+		t.Errorf("expected 1 chunk 'hello', got %v", chunks)
+	}
+}
+
+func TestParseRovodevSSE_PartStartThenDelta(t *testing.T) {
+	// Matches the shape used by gnhf's "starts the server..." fixture: the
+	// final JSON answer arrives as a part_start (initial chunk) followed by
+	// one or more part_deltas carrying incremental content_delta strings.
+	input := `event: part_start
+data: {"index":0,"part":{"content":"{\"success\":true","part_kind":"text"},"event_kind":"part_start"}
+
+event: part_delta
+data: {"index":0,"delta":{"content_delta":",\"summary\":\"done\"}","part_delta_kind":"text"},"event_kind":"part_delta"}
+
+`
+	var usage TokenUsage
+	var latestText string
+	var chunks []string
+
+	err := parseRovodevSSE(strings.NewReader(input), func(text string) {
+		chunks = append(chunks, text)
+	}, &usage, &latestText)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantText := `{"success":true,"summary":"done"}`
+	if latestText != wantText {
+		t.Errorf("expected latest text %q, got %q", wantText, latestText)
+	}
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks (start, delta), got %d: %v", len(chunks), chunks)
+	}
+	if chunks[0] != `{"success":true` {
+		t.Errorf("first chunk wrong: %q", chunks[0])
+	}
+	if chunks[1] != `,"summary":"done"}` {
+		t.Errorf("second chunk wrong: %q", chunks[1])
+	}
+}
+
+func TestParseRovodevSSE_PartStartResetsAfterToolActivity(t *testing.T) {
+	// Mirrors gnhf's "treats text separated by tool activity as distinct
+	// message segments" fixture: prose text, then tool activity, then the
+	// real JSON answer. The text between tool events must be discarded.
+	input := `event: part_start
+data: {"index":0,"part":{"content":"I will inspect the file.","part_kind":"text"},"event_kind":"part_start"}
+
+event: on_call_tools_start
+data: {"parts":[{"tool_name":"open_files","part_kind":"tool-call"}]}
+
+event: tool-return
+data: {"tool_name":"open_files","content":"ok","part_kind":"tool-return"}
+
+event: part_start
+data: {"index":0,"part":{"content":"{\"success\":true}","part_kind":"text"},"event_kind":"part_start"}
+
+`
+	var usage TokenUsage
+	var latestText string
+
+	err := parseRovodevSSE(strings.NewReader(input), nil, &usage, &latestText)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if latestText != `{"success":true}` {
+		t.Errorf("expected final JSON text only, got %q", latestText)
+	}
+}
+
+func TestParseRovodevSSE_PartDeltaWithoutStart(t *testing.T) {
+	// Defensive: a part_delta that arrives before any part_start still
+	// accumulates into the buffer instead of being dropped.
+	input := `event: part_delta
+data: {"index":0,"delta":{"content_delta":"orphan","part_delta_kind":"text"},"event_kind":"part_delta"}
+
+`
+	var usage TokenUsage
+	var latestText string
+
+	err := parseRovodevSSE(strings.NewReader(input), nil, &usage, &latestText)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if latestText != "orphan" {
+		t.Errorf("expected 'orphan', got %q", latestText)
+	}
+}
+
+func TestParseRovodevSSE_GnhfFixture(t *testing.T) {
+	// Full stream replay from gnhf's primary rovodev integration test, which
+	// exercises part_start + part_delta assembly and top-level request-usage.
+	input := strings.Join([]string{
+		"event: user-prompt",
+		`data: {"content":"test","part_kind":"user-prompt"}`,
+		"",
+		"event: part_start",
+		`data: {"index":0,"part":{"content":"{\"success\":true","part_kind":"text"},"event_kind":"part_start"}`,
+		"",
+		"event: part_delta",
+		`data: {"index":0,"delta":{"content_delta":",\"summary\":\"done\",\"key_changes_made\":[\"a\"],\"key_learnings\":[\"b\"]}","part_delta_kind":"text"},"event_kind":"part_delta"}`,
+		"",
+		"event: request-usage",
+		`data: {"input_tokens":10,"cache_write_tokens":2,"cache_read_tokens":3,"output_tokens":4}`,
+		"",
+		"event: close",
+		"data: ",
+		"",
+	}, "\n")
+
+	var usage TokenUsage
+	var latestText string
+	err := parseRovodevSSE(strings.NewReader(input), nil, &usage, &latestText)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantText := `{"success":true,"summary":"done","key_changes_made":["a"],"key_learnings":["b"]}`
+	if latestText != wantText {
+		t.Errorf("latestText mismatch:\n  want %q\n  got  %q", wantText, latestText)
+	}
+	if usage.InputTokens != 10 {
+		t.Errorf("input tokens: want 10, got %d", usage.InputTokens)
+	}
+	if usage.OutputTokens != 4 {
+		t.Errorf("output tokens: want 4, got %d", usage.OutputTokens)
+	}
+	if usage.CacheReadTokens != 3 {
+		t.Errorf("cache read tokens: want 3, got %d", usage.CacheReadTokens)
+	}
+	if usage.CacheCreationTokens != 2 {
+		t.Errorf("cache creation tokens: want 2, got %d", usage.CacheCreationTokens)
 	}
 }
 
@@ -272,9 +429,11 @@ func TestRovodevAgent_FullFlow(t *testing.T) {
 			}
 			w.Header().Set("Content-Type", "text/event-stream")
 			w.WriteHeader(http.StatusOK)
-			// Send usage event then text event with JSON output
-			fmt.Fprint(w, "event: request-usage\ndata: {\"usage\":{\"input_tokens\":100,\"output_tokens\":50}}\n\n")
-			fmt.Fprint(w, "event: text\ndata: {\"content\":\"{\\\"success\\\":true,\\\"summary\\\":\\\"all good\\\"}\"}\n\n")
+			// Real rovodev emits top-level usage fields and streams text
+			// via part_start + part_delta events.
+			fmt.Fprint(w, "event: request-usage\ndata: {\"input_tokens\":100,\"output_tokens\":50}\n\n")
+			fmt.Fprint(w, "event: part_start\ndata: {\"index\":0,\"part\":{\"content\":\"{\\\"success\\\":true\",\"part_kind\":\"text\"},\"event_kind\":\"part_start\"}\n\n")
+			fmt.Fprint(w, "event: part_delta\ndata: {\"index\":0,\"delta\":{\"content_delta\":\",\\\"summary\\\":\\\"all good\\\"}\",\"part_delta_kind\":\"text\"},\"event_kind\":\"part_delta\"}\n\n")
 
 		case r.URL.Path == "/v3/sessions/test-session-123" && r.Method == http.MethodDelete:
 			step++
@@ -317,8 +476,9 @@ func TestRovodevAgent_FullFlow(t *testing.T) {
 	if result.Usage.OutputTokens != 50 {
 		t.Errorf("expected output tokens 50, got %d", result.Usage.OutputTokens)
 	}
-	if len(chunks) != 1 {
-		t.Errorf("expected 1 chunk, got %d", len(chunks))
+	// Streamed as part_start + part_delta, so onChunk fires twice.
+	if len(chunks) != 2 {
+		t.Errorf("expected 2 streamed chunks (part_start + part_delta), got %d: %v", len(chunks), chunks)
 	}
 
 	// Verify structured output parsed
@@ -348,7 +508,7 @@ func TestRovodevAgent_NoSchema(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		case r.URL.Path == "/v3/stream_chat":
 			w.Header().Set("Content-Type", "text/event-stream")
-			fmt.Fprint(w, "event: text\ndata: {\"content\":\"done\"}\n\n")
+			fmt.Fprint(w, "event: part_start\ndata: {\"index\":0,\"part\":{\"content\":\"done\",\"part_kind\":\"text\"},\"event_kind\":\"part_start\"}\n\n")
 		case r.URL.Path == "/v3/sessions/s1":
 			w.WriteHeader(http.StatusOK)
 		default:

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -13,8 +13,10 @@ import (
 
 // managedServer manages a persistent HTTP server process (used by rovodev and opencode agents).
 type managedServer struct {
-	cmd  *exec.Cmd
-	port int
+	cmd     *exec.Cmd
+	port    int
+	exited  chan struct{} // closed exactly once when cmd.Wait returns
+	waitErr error         // result of cmd.Wait; only read after exited is closed
 }
 
 // getAvailablePort finds an ephemeral port by binding to :0 and releasing.
@@ -43,7 +45,11 @@ func startServerWithPort(ctx context.Context, bin string, args []string, cwd str
 		return nil, fmt.Errorf("start server %s: %w", bin, err)
 	}
 
-	srv := &managedServer{cmd: cmd, port: port}
+	srv := &managedServer{cmd: cmd, port: port, exited: make(chan struct{})}
+	go func() {
+		srv.waitErr = cmd.Wait()
+		close(srv.exited)
+	}()
 
 	// Wait for health check to pass
 	if err := srv.waitForHealth(ctx, healthPath); err != nil {
@@ -60,6 +66,8 @@ func (s *managedServer) baseURL() string {
 }
 
 // waitForHealth polls the health endpoint until it returns 200 or timeout.
+// If the server process exits before becoming healthy, it returns immediately
+// with an exit error instead of waiting out the 30s deadline.
 func (s *managedServer) waitForHealth(ctx context.Context, path string) error {
 	url := s.baseURL() + path
 	client := &http.Client{Timeout: 2 * time.Second}
@@ -69,6 +77,8 @@ func (s *managedServer) waitForHealth(ctx context.Context, path string) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
+		case <-s.exited:
+			return fmt.Errorf("server exited before becoming healthy: %w", s.waitErr)
 		case <-deadline:
 			return fmt.Errorf("server health check timed out after 30s")
 		default:
@@ -82,37 +92,42 @@ func (s *managedServer) waitForHealth(ctx context.Context, path string) error {
 			}
 		}
 
-		time.Sleep(250 * time.Millisecond)
+		select {
+		case <-s.exited:
+			return fmt.Errorf("server exited before becoming healthy: %w", s.waitErr)
+		case <-time.After(250 * time.Millisecond):
+		}
 	}
 }
 
-// shutdown gracefully stops the server process.
+// shutdown gracefully stops the server process. The long-running goroutine
+// spawned in startServerWithPort owns cmd.Wait(); shutdown signals the
+// process and waits on s.exited to observe termination.
 func (s *managedServer) shutdown() {
 	if s.cmd == nil || s.cmd.Process == nil {
 		return
 	}
 
+	// Already exited (e.g. early-exit path)?
+	select {
+	case <-s.exited:
+		return
+	default:
+	}
+
 	_ = signalManagedProcess(s.cmd, false)
 
-	// Wait up to 3 seconds for graceful exit
-	done := make(chan struct{})
-	go func() {
-		_ = s.cmd.Wait()
-		close(done)
-	}()
-
 	select {
-	case <-done:
+	case <-s.exited:
 		return
 	case <-time.After(3 * time.Second):
 	}
 
-	// Force kill
 	slog.Warn("server did not exit gracefully, sending SIGKILL", "pid", s.cmd.Process.Pid)
 	_ = signalManagedProcess(s.cmd, true)
 
 	select {
-	case <-done:
+	case <-s.exited:
 	case <-time.After(5 * time.Second):
 		slog.Warn("server process did not exit after SIGKILL", "pid", s.cmd.Process.Pid)
 	}

--- a/internal/agent/server_test.go
+++ b/internal/agent/server_test.go
@@ -1,0 +1,32 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestStartServerWithPort_DetectsEarlyExit verifies that when the spawned
+// server exits before becoming healthy (e.g. `acli` not installed, bad
+// flags, or port bind failure), startup fails fast instead of waiting the
+// full 30s health-check deadline.
+func TestStartServerWithPort_DetectsEarlyExit(t *testing.T) {
+	// /usr/bin/true exits 0 immediately without opening a listener.
+	const bin = "/usr/bin/true"
+
+	start := time.Now()
+	srv, err := startServerWithPort(context.Background(), bin, nil, t.TempDir(), "/healthcheck", 1)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		srv.shutdown()
+		t.Fatal("expected error when server exits before becoming healthy")
+	}
+	if !strings.Contains(err.Error(), "exit") {
+		t.Errorf("error should mention early exit, got: %v", err)
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("should fail fast on early exit, waited %v", elapsed)
+	}
+}

--- a/internal/agent/server_test.go
+++ b/internal/agent/server_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -12,8 +13,10 @@ import (
 // flags, or port bind failure), startup fails fast instead of waiting the
 // full 30s health-check deadline.
 func TestStartServerWithPort_DetectsEarlyExit(t *testing.T) {
-	// /usr/bin/true exits 0 immediately without opening a listener.
-	const bin = "/usr/bin/true"
+	bin, err := exec.LookPath("true")
+	if err != nil {
+		t.Skip("true binary not available")
+	}
 
 	start := time.Now()
 	srv, err := startServerWithPort(context.Background(), bin, nil, t.TempDir(), "/healthcheck", 1)


### PR DESCRIPTION
## Summary
- Fix Rovodev SSE handling in `internal/agent` so streamed responses and usage metadata are reconstructed more reliably.
- Tighten the agent server health-check path to detect unavailable backing processes earlier and fail more predictably.
- Expand `internal/agent` test coverage around SSE parsing, server behavior, and cross-platform test portability.

## Risk Assessment

⚠️ Medium: The change is well-scoped, but it modifies protocol parsing in ways that can misassemble streamed text or silently lose usage metrics across Rovodev payload variants.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 2 warnings</summary>

**Round 1** - found 2 issues (1 error, 1 warning)
- 🚨 `internal/agent/server_test.go:16` - The new early-exit test hardcodes `/usr/bin/true`, which does not exist on Windows, so this package will fail in cross-platform CI even though the production code is unchanged. Use a portable helper binary lookup or skip the test on unsupported platforms.
- ⚠️ `internal/agent/rovodev.go:232` - `parseRovodevSSE` now applies `strings.TrimSpace` to every assembled part-based response, which changes the agent&#39;s actual output in no-schema mode by stripping leading/trailing newlines or spaces. Preserve the raw joined text and let callers decide whether whitespace should be normalized.

**Round 2** (auto-fix) - found 2 warnings
- ⚠️ `internal/agent/rovodev.go:287` - `part_start` ignores the event&#39;s `index` when placing new text parts and always appends by arrival order. If Rovodev emits text parts out of order or reuses an index, `latestText` can be reconstructed incorrectly and break structured JSON parsing.
- ⚠️ `internal/agent/rovodev.go:267` - `request-usage` parsing now only reads top-level token fields and dropped support for the previously handled nested `{&#34;usage&#34;:...}` shape. Older Rovodev/acli builds would still return answers, but usage accounting would silently become zero.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
