### PR TITLE
feat(wizard): add branch-aware setup flow for run startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 </p>
 
 `no-mistakes` puts a local git proxy in front of your real remote.
-Push to `no-mistakes` instead of `origin`, and it spins up a disposable worktree, runs a validation pipeline with your AI agent of choice, forwards upstream only after the branch survives every check, and creates a clean PR automatically.
+Push to `no-mistakes` instead of `origin`, and it spins up a disposable worktree, runs a validation pipeline with your AI agent of choice, forwards upstream only after the branch survives every check, and creates a clean PR automatically. If you run bare `no-mistakes` with no active run on the current branch, it can also walk you through creating a branch, committing local changes, and pushing through the gate before opening the TUI.
 
 - **Non-blocking** - the whole pipeline runs in an isolated worktree without disrupting your workflow.
 - **Agent-agnostic** - runs your agent of choice. Currently supports `claude`, `codex`, `rovodev`, and `opencode`.
@@ -56,6 +56,11 @@ $ no-mistakes init
 $ git checkout my-branch
 
 # do some work in the branch...
+
+$ no-mistakes
+# if no active run exists on this branch, the setup wizard can
+# create a branch, commit local changes, push through the gate,
+# and then open the TUI for the new run
 
 $ git push no-mistakes
   * Pipeline started

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Config is optional and split across two files:
 ```yaml
 # ~/.no-mistakes/config.yaml
 
-# Default agent for all repos.
+# Default agent for all repos and setup-wizard suggestions.
 # "auto" picks the first available agent on PATH: claude, codex, opencode, then rovodev.
 agent: auto # auto | claude | codex | rovodev | opencode
 

--- a/README.md
+++ b/README.md
@@ -154,11 +154,11 @@ This replaces the binary and resets the background daemon so it picks up the new
 
 | Command                     | Description                                            |
 | --------------------------- | ------------------------------------------------------ |
-| `no-mistakes`               | Attach to the active pipeline run for the current repo |
+| `no-mistakes`               | Attach to the current branch run, or start the setup wizard |
 | `no-mistakes init`          | Initialize the gate for the current repository         |
 | `no-mistakes update`        | Update the binary and reset the daemon                 |
 | `no-mistakes eject`         | Remove the gate from the current repository            |
-| `no-mistakes attach`        | Attach to the active pipeline run                      |
+| `no-mistakes attach`        | Attach to the active pipeline run in the current repo  |
 | `no-mistakes rerun`         | Rerun the pipeline for the current branch              |
 | `no-mistakes status`        | Show status of the current repository                  |
 | `no-mistakes runs`          | List recorded pipeline runs for the current repo       |

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -88,6 +88,8 @@ Run `no-mistakes` (or `no-mistakes attach`) to open the TUI and watch the pipeli
 no-mistakes
 ```
 
+If the current branch already has an active run, `no-mistakes` attaches to it directly. If you're in an interactive terminal with no active run on the current branch, `no-mistakes` can instead walk you through creating a branch, committing local changes, and pushing to the `no-mistakes` remote before attaching to the new run. `no-mistakes attach` skips that branch-scoped wizard path and attaches to any active run in the repo.
+
 The TUI shows each step's progress, streams agent output, and pauses for your approval when findings need attention. See the [TUI guide](/no-mistakes/guides/tui/) for keybindings and layout.
 
 ## What happens next

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -3,7 +3,7 @@ title: Agents
 description: Supported AI agents and how they integrate.
 ---
 
-`no-mistakes` is agent-agnostic. It supports four agents and uses a common interface for all of them. The default `agent: auto` setting picks the first supported agent available on your system. The agent handles code review, test/lint detection (when no explicit command is configured), and auto-fixing.
+`no-mistakes` is agent-agnostic. It supports four agents and uses a common interface for all of them. The default `agent: auto` setting picks the first supported agent available on your system. The agent handles code review, test/lint detection (when no explicit command is configured), auto-fixing, and setup-wizard suggestions for branch names and commit subjects when you leave those prompts blank.
 
 ## Supported agents
 

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -19,7 +19,7 @@ Set `NM_HOME` to relocate the global config directory (the global file becomes `
 ```yaml
 # ~/.no-mistakes/config.yaml
 
-# Default agent for all repos.
+# Default agent for all repos and setup-wizard suggestions.
 # "auto" picks the first available agent on PATH.
 agent: auto  # auto | claude | codex | rovodev | opencode
 
@@ -61,7 +61,7 @@ Bitbucket Cloud PR creation and CI monitoring use environment variables instead 
 ```yaml
 # .no-mistakes.yaml (in repo root)
 
-# Override the agent for this repo only.
+# Override the agent for this repo and its setup-wizard suggestions.
 agent: codex
 
 # Explicit commands for test/lint/format steps.

--- a/docs/src/content/docs/guides/daemon.md
+++ b/docs/src/content/docs/guides/daemon.md
@@ -3,7 +3,7 @@ title: Daemon
 description: Background process management and recovery.
 ---
 
-The daemon is a long-running background process that manages pipeline runs. The installer prefers setting it up as a managed background service, and `init`, `attach`, `rerun`, and `update` keep that service installed and running for you when that path is available.
+The daemon is a long-running background process that manages pipeline runs. The installer prefers setting it up as a managed background service, and `no-mistakes`, `init`, `attach`, `rerun`, and `update` keep that service installed and running for you when that path is available.
 
 On macOS this is a per-user `launchd` agent, on Linux a per-user `systemd` service, and on Windows a Task Scheduler task. The installed artifact names are scoped by `NM_HOME` with a short stable suffix, so the paths and service identifiers look like `~/Library/LaunchAgents/com.kunchenguid.no-mistakes.daemon.<suffix>.plist`, `~/.config/systemd/user/no-mistakes-daemon-<suffix>.service`, and the Windows task `no-mistakes-daemon-<suffix>`. That keeps multiple `no-mistakes` installs from colliding when they use different `NM_HOME` roots. Those service managers keep the daemon available across CLI invocations and restart it after `no-mistakes update` replaces the binary. Before a managed daemon run starts, `no-mistakes` reloads the environment from your login shell on macOS and Linux so agent and tool discovery matches the shell you use interactively. On Windows it reuses the current process environment instead of shelling out to a login shell. If managed service install or startup is unavailable or fails, `no-mistakes` falls back to starting a detached daemon process instead.
 
@@ -16,6 +16,7 @@ no-mistakes daemon stop
 no-mistakes daemon status
 
 # Ensures the daemon is running, using the managed service when possible
+no-mistakes
 no-mistakes init
 no-mistakes attach
 no-mistakes rerun
@@ -56,7 +57,7 @@ On startup, the daemon checks for runs that were left in `pending` or `running` 
 
 ## Logging
 
-Daemon logs go to `~/.no-mistakes/logs/daemon.log`. Each pipeline step also writes to its own log at `~/.no-mistakes/logs/<runID>/<step>.log`.
+Daemon logs go to `~/.no-mistakes/logs/daemon.log`. The setup wizard captures managed agent-server output in `~/.no-mistakes/logs/wizard-agent.log`. Each pipeline step also writes to its own log at `~/.no-mistakes/logs/<runID>/<step>.log`.
 
 Set the log level in global config:
 
@@ -66,7 +67,7 @@ log_level: debug  # debug | info | warn | error
 
 ## Shutdown
 
-`no-mistakes daemon stop` stops the current daemon process without removing the managed service. The next `no-mistakes daemon start`, `init`, `attach`, `rerun`, or `update` will start it again through the same service manager when available, or as a detached daemon otherwise.
+`no-mistakes daemon stop` stops the current daemon process without removing the managed service. The next `no-mistakes daemon start`, `no-mistakes`, `init`, `attach`, `rerun`, or `update` will start it again through the same service manager when available, or as a detached daemon otherwise.
 
 1. Cancels all active runs
 2. Waits up to 30 seconds for goroutines to finish

--- a/docs/src/content/docs/guides/tui.md
+++ b/docs/src/content/docs/guides/tui.md
@@ -152,6 +152,6 @@ After a failed or cancelled run, press `r` to start a rerun. The TUI switches to
 
 ## Detaching
 
-Press `q` to detach from the TUI. The pipeline continues running in the background. Run `no-mistakes` again to reattach.
+Press `q` to detach from the TUI. The pipeline continues running in the background. Run `no-mistakes` again to reattach to the active run on your current branch, or `no-mistakes attach` to reattach to the repo's active run without branch scoping.
 
 If the run is already finished, `q` exits the TUI.

--- a/docs/src/content/docs/guides/tui.md
+++ b/docs/src/content/docs/guides/tui.md
@@ -5,6 +5,20 @@ description: Terminal UI layout, keybindings, and approval workflow.
 
 The TUI is how you interact with running pipelines. Launch it with `no-mistakes` or `no-mistakes attach`.
 
+Bare `no-mistakes` can also open a separate setup wizard first when there is no active run on the current branch and you need to create one.
+
+## Setup wizard
+
+The setup wizard is a full-screen flow that prepares a new run before the main pipeline TUI opens. It walks through up to three steps:
+
+- **Branch** - shown when you're on the default branch or detached `HEAD`
+- **Commit** - shown when you have uncommitted changes
+- **Push** - always shown before creating the new run
+
+Leave the branch name or commit message blank to ask the configured agent for a suggestion. During the push step, press `y` to push to the `no-mistakes` gate or `n` to stop. If a step fails, press `r` to retry.
+
+Press `q` to quit. After the wizard has created a branch or commit, quitting requires pressing `q` twice so you do not accidentally leave those side effects behind.
+
 ## Layout
 
 The layout adapts to terminal width:

--- a/docs/src/content/docs/how-it-works.md
+++ b/docs/src/content/docs/how-it-works.md
@@ -58,7 +58,7 @@ A long-running background process that manages pipeline runs. It:
 - Persists state to SQLite
 - Streams events to connected TUI clients via IPC
 
-The installer prefers setting up the daemon as a managed background service, and `init`, `attach`, `rerun`, and `update` make sure the daemon is running when needed. If managed service install or startup is unavailable or fails, startup falls back to a detached daemon process. `update` resets the daemon after replacing the binary when the daemon is running or stale daemon artifacts exist. If the daemon is already running, `update` first checks that it was started from the same executable path and aborts if the daemon executable path cannot be determined or points to a different binary. You can also manage it explicitly with `no-mistakes daemon start|stop|status`.
+The installer prefers setting up the daemon as a managed background service, and `no-mistakes`, `init`, `attach`, `rerun`, and `update` make sure the daemon is running when needed. Bare `no-mistakes` then attaches to the active run on the current branch when one exists, or routes to the setup wizard when it needs to create a new branch/run. If managed service install or startup is unavailable or fails, startup falls back to a detached daemon process. `update` resets the daemon after replacing the binary when the daemon is running or stale daemon artifacts exist. If the daemon is already running, `update` first checks that it was started from the same executable path and aborts if the daemon executable path cannot be determined or points to a different binary. You can also manage it explicitly with `no-mistakes daemon start|stop|status`.
 
 On startup, the daemon recovers from crashes by marking any stuck runs as failed and cleaning up orphaned worktrees.
 
@@ -94,5 +94,6 @@ Everything lives under `~/.no-mistakes/` by default. Set `NM_HOME` to relocate i
 | `worktrees/<repoID>/<runID>/` | Disposable worktrees (cleaned up after each run) |
 | `logs/<runID>/<step>.log` | Per-step log files |
 | `logs/daemon.log` | Daemon log |
+| `logs/wizard-agent.log` | Managed agent-server output captured during setup wizard runs |
 
 The repo ID is the first 6 bytes (12 hex chars) of `sha256(absolute_working_path)`.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -19,7 +19,8 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
 <CardGrid>
   <Card title="Push with intent" icon="rocket">
     `origin` stays untouched. `no-mistakes` becomes the explicit path for gated
-    pushes. You choose when code goes through the gate.
+    pushes. Or run bare `no-mistakes` to create a branch, commit local changes,
+    and send them through the gate before attaching to the new run.
   </Card>
   <Card title="Agent-agnostic" icon="puzzle">
     Use Claude, Codex, Rovo Dev, or OpenCode. Override the agent per-repo if

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -5,13 +5,13 @@ description: Complete reference for all no-mistakes commands and flags.
 
 ## no-mistakes
 
-Attach to the active pipeline run for the current repo. If no active run exists, shows the last 5 runs inline.
+Attach to the active pipeline run for the current repo. Bare `no-mistakes` first looks for an active run on the current branch. If none exists and you're in an interactive TTY session, it can start the setup wizard to create a branch, commit changes, push through the gate, and then attach once the new run appears. In non-interactive contexts, it falls back to showing the last 5 runs inline.
 
 ```sh
 no-mistakes
 ```
 
-Equivalent to `no-mistakes attach` when a run is active.
+Equivalent to `no-mistakes attach` when a run is active on the current branch.
 
 ## no-mistakes init
 
@@ -47,7 +47,7 @@ no-mistakes attach [--run <id>]
 |---|---|---|---|
 | `--run` | `string` | (none) | Attach to a specific run ID instead of the active run |
 
-Opens the TUI for the active run on the current branch. If `--run` is specified, attaches to that specific run regardless of branch.
+Opens the TUI for the active run anywhere in the current repo. If `--run` is specified, attaches to that specific run regardless of branch. Unlike bare `no-mistakes`, this does not stay branch-scoped before falling back.
 
 ## no-mistakes rerun
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -137,7 +137,7 @@ Stop the running daemon process.
 no-mistakes daemon stop
 ```
 
-This does not remove the managed service. A later `no-mistakes daemon start`, `init`, `attach`, `rerun`, or `update` can start the daemon again through the same service manager when available, or as a detached daemon otherwise.
+This does not remove the managed service. A later `no-mistakes`, `no-mistakes daemon start`, `init`, `attach`, `rerun`, or `update` can start the daemon again through the same service manager when available, or as a detached daemon otherwise.
 
 ## no-mistakes daemon status
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -11,7 +11,7 @@ Attach to the active pipeline run for the current repo. Bare `no-mistakes` first
 no-mistakes
 ```
 
-Equivalent to `no-mistakes attach` when a run is active on the current branch.
+Unlike `no-mistakes attach`, bare `no-mistakes` only auto-attaches to an active run on the current branch.
 
 ## no-mistakes init
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -5,7 +5,7 @@ description: Complete reference for all no-mistakes commands and flags.
 
 ## no-mistakes
 
-Attach to the active pipeline run for the current repo. Bare `no-mistakes` first looks for an active run on the current branch. If none exists and you're in an interactive TTY session, it can start the setup wizard to create a branch, commit changes, push through the gate, and then attach once the new run appears. In non-interactive contexts, it falls back to showing the last 5 runs inline.
+Attach to the active pipeline run for the current branch when one exists. If none exists and you're in an interactive TTY session, bare `no-mistakes` can start the setup wizard to create a branch, commit changes, push through the gate, and then attach once the new run appears. In non-interactive contexts, it falls back to showing the last 5 runs inline.
 
 ```sh
 no-mistakes

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -33,7 +33,7 @@ auto_fix:
 
 ### agent
 
-Default agent for all repos. Can be overridden per-repo.
+Default agent for all repos and setup-wizard suggestions. Can be overridden per-repo.
 
 | | |
 |---|---|

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -32,7 +32,7 @@ auto_fix:
 
 ### agent
 
-Override the default agent for this repo.
+Override the default agent for this repo and its setup-wizard suggestions.
 
 | | |
 |---|---|

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kunchenguid/no-mistakes
 go 1.25.0
 
 require (
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/bubbles v1.0.0 // indirect
 	github.com/charmbracelet/bubbletea v1.3.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -3,13 +3,42 @@ package agent
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
 	"os"
 	"os/exec"
+	"sync"
 	"time"
 )
+
+// managedServerOutput holds the writer used for managed-server stdout and
+// stderr. Defaults to os.Stderr so debug output is visible in normal CLI
+// sessions; callers rendering to a raw terminal (e.g. the setup wizard
+// alt-screen) should override it so log lines don't corrupt the display.
+var (
+	managedServerOutputMu sync.Mutex
+	managedServerOutput   io.Writer = os.Stderr
+)
+
+// SetManagedServerOutput routes future managed-server stdout/stderr to w.
+// Passing nil resets to the default (os.Stderr). Only affects servers
+// started after this call; already-running servers keep their original fds.
+func SetManagedServerOutput(w io.Writer) {
+	managedServerOutputMu.Lock()
+	defer managedServerOutputMu.Unlock()
+	if w == nil {
+		w = os.Stderr
+	}
+	managedServerOutput = w
+}
+
+func currentManagedServerOutput() io.Writer {
+	managedServerOutputMu.Lock()
+	defer managedServerOutputMu.Unlock()
+	return managedServerOutput
+}
 
 // managedServer manages a persistent HTTP server process (used by rovodev and opencode agents).
 type managedServer struct {
@@ -37,8 +66,9 @@ func startServerWithPort(ctx context.Context, bin string, args []string, cwd str
 	cmd := exec.Command(bin, args...)
 	cmd.Dir = cwd
 	cmd.Stdin = nil
-	cmd.Stdout = os.Stderr // server stdout goes to our stderr for debugging
-	cmd.Stderr = os.Stderr
+	out := currentManagedServerOutput()
+	cmd.Stdout = out // server stdout goes to the configured sink for debugging
+	cmd.Stderr = out
 	configureManagedServerCmd(cmd)
 
 	if err := cmd.Start(); err != nil {

--- a/internal/agent/server_test.go
+++ b/internal/agent/server_test.go
@@ -1,7 +1,9 @@
 package agent
 
 import (
+	"bytes"
 	"context"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -31,5 +33,42 @@ func TestStartServerWithPort_DetectsEarlyExit(t *testing.T) {
 	}
 	if elapsed > 5*time.Second {
 		t.Errorf("should fail fast on early exit, waited %v", elapsed)
+	}
+}
+
+func TestSetManagedServerOutput_RoutesSubprocessOutput(t *testing.T) {
+	// Use `sh -c` to emit known bytes to both stdout and stderr, then exit.
+	// This exercises the same fd-inheritance path startServerWithPort uses.
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("sh not available")
+	}
+
+	var buf bytes.Buffer
+	SetManagedServerOutput(&buf)
+	t.Cleanup(func() { SetManagedServerOutput(nil) })
+
+	// Reproduce the fd-wiring startServerWithPort does so we can assert the
+	// writer is honored without needing a real health endpoint.
+	cmd := exec.Command(sh, "-c", "echo hello-out; echo hello-err 1>&2")
+	cmd.Stdin = nil
+	out := currentManagedServerOutput()
+	cmd.Stdout = out
+	cmd.Stderr = out
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run subprocess: %v", err)
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, "hello-out") || !strings.Contains(got, "hello-err") {
+		t.Fatalf("managed-server writer did not capture subprocess output, got: %q", got)
+	}
+}
+
+func TestSetManagedServerOutput_NilResetsToDefault(t *testing.T) {
+	SetManagedServerOutput(&bytes.Buffer{})
+	SetManagedServerOutput(nil)
+	if currentManagedServerOutput() != os.Stderr {
+		t.Fatal("nil should reset to os.Stderr")
 	}
 }

--- a/internal/agent/suggest.go
+++ b/internal/agent/suggest.go
@@ -1,0 +1,147 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const branchNamePrompt = `Suggest a short, descriptive git branch name for the current working-tree changes in this repository.
+
+Inspect the state yourself (e.g. git status, git diff HEAD, git diff --staged) in the working directory.
+
+Rules:
+- Use kebab-case.
+- Prefer a conventional prefix: "feat/", "fix/", "chore/", "refactor/", "docs/", or "test/".
+- Keep it under 40 characters.
+- Return JSON: {"name":"..."}`
+
+const commitSubjectPrompt = `Suggest a conventional commit subject line summarizing the current working-tree changes.
+
+Inspect the state yourself (e.g. git status, git diff HEAD, git diff --staged) in the working directory.
+
+Rules:
+- One line only.
+- Use conventional commit style: "type(scope): description".
+- Keep it under 72 characters.
+- Return JSON: {"subject":"..."}`
+
+var branchNameSchema = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"name": {"type": "string"}
+	},
+	"required": ["name"]
+}`)
+
+var commitSubjectSchema = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"subject": {"type": "string"}
+	},
+	"required": ["subject"]
+}`)
+
+type branchSuggestion struct {
+	Name string `json:"name"`
+}
+
+type commitSuggestion struct {
+	Subject string `json:"subject"`
+}
+
+// SuggestBranchName asks the agent to propose a short git branch name for the
+// current working-tree state in dir. The suggestion is sanitized so it's safe
+// to pass to `git checkout -b`.
+func SuggestBranchName(ctx context.Context, ag Agent, dir string) (string, error) {
+	result, err := ag.Run(ctx, RunOpts{
+		Prompt:     branchNamePrompt,
+		CWD:        dir,
+		JSONSchema: branchNameSchema,
+	})
+	if err != nil {
+		return "", fmt.Errorf("suggest branch name: %w", err)
+	}
+	var parsed branchSuggestion
+	if err := unmarshalSuggestion(result, &parsed); err != nil {
+		return "", fmt.Errorf("parse branch name suggestion: %w", err)
+	}
+	name := sanitizeBranchName(parsed.Name)
+	if name == "" {
+		return "", fmt.Errorf("agent returned empty or unusable branch name")
+	}
+	return name, nil
+}
+
+// SuggestCommitMessage asks the agent to propose a single-line commit subject
+// summarizing the current working-tree state at dir.
+func SuggestCommitMessage(ctx context.Context, ag Agent, dir string) (string, error) {
+	result, err := ag.Run(ctx, RunOpts{
+		Prompt:     commitSubjectPrompt,
+		CWD:        dir,
+		JSONSchema: commitSubjectSchema,
+	})
+	if err != nil {
+		return "", fmt.Errorf("suggest commit message: %w", err)
+	}
+	var parsed commitSuggestion
+	if err := unmarshalSuggestion(result, &parsed); err != nil {
+		return "", fmt.Errorf("parse commit message suggestion: %w", err)
+	}
+	subject := sanitizeCommitSubject(parsed.Subject)
+	if subject == "" {
+		return "", fmt.Errorf("agent returned empty commit subject")
+	}
+	return subject, nil
+}
+
+func unmarshalSuggestion(result *Result, v any) error {
+	if result == nil {
+		return fmt.Errorf("agent returned no result")
+	}
+	if len(result.Output) > 0 {
+		return json.Unmarshal(result.Output, v)
+	}
+	if result.Text != "" {
+		return json.Unmarshal([]byte(result.Text), v)
+	}
+	return fmt.Errorf("agent returned no output")
+}
+
+// sanitizeBranchName normalizes an agent-suggested branch name: lowercase,
+// ASCII-only, alphanumerics plus - / . separators, length-capped.
+func sanitizeBranchName(raw string) string {
+	s := strings.TrimSpace(strings.Trim(raw, "\"'"))
+	s = strings.ToLower(s)
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '/', r == '.':
+			b.WriteRune(r)
+		case r == '-', r == '_', r == ' ':
+			b.WriteRune('-')
+		}
+	}
+	s = b.String()
+	for strings.Contains(s, "--") {
+		s = strings.ReplaceAll(s, "--", "-")
+	}
+	s = strings.Trim(s, "-/.")
+	if len(s) > 60 {
+		s = s[:60]
+		s = strings.Trim(s, "-/.")
+	}
+	return s
+}
+
+// sanitizeCommitSubject trims whitespace and keeps only the first line.
+func sanitizeCommitSubject(raw string) string {
+	s := strings.TrimSpace(raw)
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = strings.TrimSpace(s[:i])
+	}
+	return s
+}

--- a/internal/agent/suggest.go
+++ b/internal/agent/suggest.go
@@ -134,7 +134,43 @@ func sanitizeBranchName(raw string) string {
 		s = s[:60]
 		s = strings.Trim(s, "-/.")
 	}
+	if !isValidBranchName(s) {
+		return ""
+	}
 	return s
+}
+
+func isValidBranchName(name string) bool {
+	if name == "" || name == "@" {
+		return false
+	}
+	if strings.HasPrefix(name, "-") || strings.HasPrefix(name, "/") {
+		return false
+	}
+	if strings.HasSuffix(name, "/") || strings.HasSuffix(name, ".") {
+		return false
+	}
+	if strings.Contains(name, "..") || strings.Contains(name, "//") || strings.Contains(name, "@{") {
+		return false
+	}
+	for _, r := range name {
+		if r < ' ' || r == 0x7f {
+			return false
+		}
+		switch r {
+		case ' ', '~', '^', ':', '?', '*', '[', '\\':
+			return false
+		}
+	}
+	for _, part := range strings.Split(name, "/") {
+		if part == "" || part == "." || part == ".." {
+			return false
+		}
+		if strings.HasPrefix(part, ".") || strings.HasSuffix(part, ".lock") {
+			return false
+		}
+	}
+	return true
 }
 
 // sanitizeCommitSubject trims whitespace and keeps only the first line.

--- a/internal/agent/suggest_test.go
+++ b/internal/agent/suggest_test.go
@@ -79,6 +79,29 @@ func TestSuggestBranchNameSanitizes(t *testing.T) {
 	}
 }
 
+func TestSuggestBranchNameRejectsInvalidGitRefs(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "double dot", raw: "feat/bug..fix"},
+		{name: "double slash", raw: "feat//wizard"},
+		{name: "lock suffix", raw: "feat/wizard.lock"},
+		{name: "lock path component", raw: "feat/topic.lock/extra"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ag := &stubAgent{result: &Result{
+				Output: json.RawMessage(`{"name":` + jsonQuote(tc.raw) + `}`),
+			}}
+			if _, err := SuggestBranchName(context.Background(), ag, "/tmp"); err == nil {
+				t.Fatalf("expected invalid ref %q to be rejected", tc.raw)
+			}
+		})
+	}
+}
+
 func TestSuggestBranchNameLengthCapped(t *testing.T) {
 	long := "feat/really-long-branch-name-that-exceeds-the-limit-we-enforce-for-clarity"
 	ag := &stubAgent{result: &Result{

--- a/internal/agent/suggest_test.go
+++ b/internal/agent/suggest_test.go
@@ -1,0 +1,163 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+type stubAgent struct {
+	result *Result
+	err    error
+
+	gotPrompt string
+	gotCWD    string
+	gotSchema json.RawMessage
+}
+
+func (s *stubAgent) Name() string { return "stub" }
+func (s *stubAgent) Run(_ context.Context, opts RunOpts) (*Result, error) {
+	s.gotPrompt = opts.Prompt
+	s.gotCWD = opts.CWD
+	s.gotSchema = opts.JSONSchema
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.result, nil
+}
+func (s *stubAgent) Close() error { return nil }
+
+func TestSuggestBranchName(t *testing.T) {
+	ag := &stubAgent{result: &Result{
+		Output: json.RawMessage(`{"name":"feat/onboarding-wizard"}`),
+	}}
+	name, err := SuggestBranchName(context.Background(), ag, "/tmp/repo")
+	if err != nil {
+		t.Fatalf("SuggestBranchName failed: %v", err)
+	}
+	if name != "feat/onboarding-wizard" {
+		t.Fatalf("expected feat/onboarding-wizard, got %q", name)
+	}
+	if ag.gotCWD != "/tmp/repo" {
+		t.Fatalf("expected CWD to be forwarded, got %q", ag.gotCWD)
+	}
+	if len(ag.gotSchema) == 0 {
+		t.Fatal("expected JSONSchema to be set on RunOpts")
+	}
+	if ag.gotPrompt == "" {
+		t.Fatal("expected prompt to be non-empty")
+	}
+}
+
+func TestSuggestBranchNameSanitizes(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"spaces to hyphen", "feat new wizard", "feat-new-wizard"},
+		{"uppercase to lower", "FEAT/NewThing", "feat/newthing"},
+		{"strip quotes", "\"fix/bug\"", "fix/bug"},
+		{"collapse dashes", "fix--double---dash", "fix-double-dash"},
+		{"strip trailing slash", "feat/", "feat"},
+		{"strip bad chars", "fix: thing! @home", "fix-thing-home"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ag := &stubAgent{result: &Result{
+				Output: json.RawMessage(`{"name":` + jsonQuote(tc.raw) + `}`),
+			}}
+			got, err := SuggestBranchName(context.Background(), ag, "/tmp")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestSuggestBranchNameLengthCapped(t *testing.T) {
+	long := "feat/really-long-branch-name-that-exceeds-the-limit-we-enforce-for-clarity"
+	ag := &stubAgent{result: &Result{
+		Output: json.RawMessage(`{"name":` + jsonQuote(long) + `}`),
+	}}
+	got, err := SuggestBranchName(context.Background(), ag, "/tmp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) > 60 {
+		t.Fatalf("expected <= 60 chars, got %d: %q", len(got), got)
+	}
+}
+
+func TestSuggestBranchNameEmpty(t *testing.T) {
+	ag := &stubAgent{result: &Result{
+		Output: json.RawMessage(`{"name":""}`),
+	}}
+	_, err := SuggestBranchName(context.Background(), ag, "/tmp")
+	if err == nil {
+		t.Fatal("expected error for empty name")
+	}
+}
+
+func TestSuggestBranchNameOnlyInvalidChars(t *testing.T) {
+	ag := &stubAgent{result: &Result{
+		Output: json.RawMessage(`{"name":"!@#$%"}`),
+	}}
+	_, err := SuggestBranchName(context.Background(), ag, "/tmp")
+	if err == nil {
+		t.Fatal("expected error when all chars are stripped")
+	}
+}
+
+func TestSuggestBranchNameAgentError(t *testing.T) {
+	ag := &stubAgent{err: errors.New("boom")}
+	_, err := SuggestBranchName(context.Background(), ag, "/tmp")
+	if err == nil {
+		t.Fatal("expected error from agent failure")
+	}
+}
+
+func TestSuggestCommitMessage(t *testing.T) {
+	ag := &stubAgent{result: &Result{
+		Output: json.RawMessage(`{"subject":"feat(cli): add onboarding wizard"}`),
+	}}
+	got, err := SuggestCommitMessage(context.Background(), ag, "/tmp")
+	if err != nil {
+		t.Fatalf("SuggestCommitMessage failed: %v", err)
+	}
+	if got != "feat(cli): add onboarding wizard" {
+		t.Fatalf("unexpected subject: %q", got)
+	}
+}
+
+func TestSuggestCommitMessageTrimsNewlines(t *testing.T) {
+	ag := &stubAgent{result: &Result{
+		Output: json.RawMessage(`{"subject":"fix: thing\n\nbody"}`),
+	}}
+	got, err := SuggestCommitMessage(context.Background(), ag, "/tmp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "fix: thing" {
+		t.Fatalf("expected first line only, got %q", got)
+	}
+}
+
+func TestSuggestCommitMessageEmpty(t *testing.T) {
+	ag := &stubAgent{result: &Result{
+		Output: json.RawMessage(`{"subject":"   "}`),
+	}}
+	_, err := SuggestCommitMessage(context.Background(), ag, "/tmp")
+	if err == nil {
+		t.Fatal("expected error for empty subject")
+	}
+}
+
+func jsonQuote(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -18,7 +18,7 @@ import (
 
 // attachRun is the shared logic for attaching to a pipeline run. It's used by
 // both the root command (bare `no-mistakes`) and the `attach` subcommand.
-func attachRun(w io.Writer, runID string) error {
+func attachRun(w io.Writer, runID string, rootDefault bool) error {
 	p, d, err := openResources()
 	if err != nil {
 		return err
@@ -74,7 +74,7 @@ func attachRun(w io.Writer, runID string) error {
 		// match any existing run.
 		if !state.shouldRouteToWizard() {
 			var result ipc.GetActiveRunResult
-			if err := client.Call(ipc.MethodGetActiveRun, &ipc.GetActiveRunParams{RepoID: repo.ID, Branch: state.currentBranch}, &result); err != nil {
+			if err := client.Call(ipc.MethodGetActiveRun, &ipc.GetActiveRunParams{RepoID: repo.ID, Branch: activeRunBranch(state, rootDefault)}, &result); err != nil {
 				return fmt.Errorf("get active run: %w", err)
 			}
 			run = result.Run
@@ -86,7 +86,7 @@ func attachRun(w io.Writer, runID string) error {
 		// from a TTY, offer the interactive setup wizard instead of just
 		// dumping a hint. Skip the wizard in non-interactive contexts
 		// (tests, CI, piped output) and fall back to the old behavior.
-		if runID == "" && repo != nil && state != nil && isInteractive() {
+		if rootDefault && runID == "" && repo != nil && state != nil && isInteractive() {
 			res, wErr := runWizard(context.Background(), p, state)
 			if wErr != nil {
 				return wErr
@@ -110,6 +110,13 @@ func attachRun(w io.Writer, runID string) error {
 	}
 
 	return tui.Run(p.Socket(), client, run, update.CachedLatestVersion())
+}
+
+func activeRunBranch(state *repoState, rootDefault bool) string {
+	if rootDefault {
+		return state.currentBranch
+	}
+	return ""
 }
 
 // isInteractive reports whether stdin and stdout are both connected to a
@@ -193,7 +200,7 @@ func newAttachCmd() *cobra.Command {
 If no run ID is specified, attaches to the active run for the current repo.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return attachRun(cmd.OutOrStdout(), runID)
+			return attachRun(cmd.OutOrStdout(), runID, false)
 		},
 	}
 

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/daemon"
 	"github.com/kunchenguid/no-mistakes/internal/db"
-	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/tui"
 	"github.com/kunchenguid/no-mistakes/internal/update"
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 )
 
@@ -48,6 +49,7 @@ func attachRun(w io.Writer, runID string) error {
 
 	var run *ipc.RunInfo
 	var repoID string
+	var state *repoState
 
 	if runID != "" {
 		// Fetch specific run.
@@ -59,23 +61,62 @@ func attachRun(w io.Writer, runID string) error {
 	} else {
 		repoID = repo.ID
 
-		// Detect current branch to prefer runs on the same branch.
-		branch, _ := git.CurrentBranch(context.Background(), ".")
-
-		// Get active run for this repo, preferring the current branch.
-		var result ipc.GetActiveRunResult
-		if err := client.Call(ipc.MethodGetActiveRun, &ipc.GetActiveRunParams{RepoID: repo.ID, Branch: branch}, &result); err != nil {
-			return fmt.Errorf("get active run: %w", err)
+		// Detect current state so we can decide between attach and wizard
+		// consistently with what the wizard itself will see.
+		state, err = detectRepoState(context.Background(), repo)
+		if err != nil {
+			return err
 		}
-		run = result.Run
+
+		// Skip the active-run check entirely when the state clearly calls
+		// for the wizard (detached HEAD, or default branch with pending
+		// changes) — pipelines for the user's current situation don't
+		// match any existing run.
+		if !state.shouldRouteToWizard() {
+			var result ipc.GetActiveRunResult
+			if err := client.Call(ipc.MethodGetActiveRun, &ipc.GetActiveRunParams{RepoID: repo.ID, Branch: state.currentBranch}, &result); err != nil {
+				return fmt.Errorf("get active run: %w", err)
+			}
+			run = result.Run
+		}
 	}
 
 	if run == nil {
-		printNoActiveRun(w, d, repoID)
-		return nil
+		// No active run — if the user ran bare `no-mistakes` in their repo
+		// from a TTY, offer the interactive setup wizard instead of just
+		// dumping a hint. Skip the wizard in non-interactive contexts
+		// (tests, CI, piped output) and fall back to the old behavior.
+		if runID == "" && repo != nil && state != nil && isInteractive() {
+			res, wErr := runWizard(context.Background(), p, state)
+			if wErr != nil {
+				return wErr
+			}
+			if res.Success {
+				run, err = waitForActiveRun(client, repo.ID, res.TargetBranch, 5*time.Second)
+				if err != nil {
+					return fmt.Errorf("wait for active run: %w", err)
+				}
+			}
+			if run == nil {
+				if !res.Aborted {
+					printNoActiveRun(w, d, repoID)
+				}
+				return nil
+			}
+		} else {
+			printNoActiveRun(w, d, repoID)
+			return nil
+		}
 	}
 
 	return tui.Run(p.Socket(), client, run, update.CachedLatestVersion())
+}
+
+// isInteractive reports whether stdin and stdout are both connected to a
+// terminal. The wizard needs a real TTY to read keystrokes; in non-interactive
+// contexts we fall back to printing hints.
+func isInteractive() bool {
+	return isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd())
 }
 
 const recentRunsLimit = 5

--- a/internal/cli/attach_test.go
+++ b/internal/cli/attach_test.go
@@ -9,6 +9,26 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/paths"
 )
 
+func TestActiveRunBranchUsesRepoWideLookupForExplicitAttach(t *testing.T) {
+	tests := []struct {
+		name        string
+		rootDefault bool
+		want        string
+	}{
+		{name: "root command stays branch scoped", rootDefault: true, want: "feature/current"},
+		{name: "attach subcommand falls back across branches", rootDefault: false, want: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			state := &repoState{currentBranch: "feature/current"}
+			if got := activeRunBranch(state, tc.rootDefault); got != tc.want {
+				t.Fatalf("activeRunBranch() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestAttachRunIDWithUnknownRunReturnsHelpfulError(t *testing.T) {
 	nmHome, err := os.MkdirTemp("", "nmcli")
 	if err != nil {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -33,7 +33,8 @@ func newRootCmd() *cobra.Command {
 		// Silence cobra's default error/usage printing — we handle it ourselves.
 		SilenceErrors: true,
 		SilenceUsage:  true,
-		// When run without a subcommand, default to attach behavior.
+		// When run without a subcommand, attach to the current branch run or
+		// route interactive users into the setup wizard when no run is active.
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return attachRun(cmd.OutOrStdout(), "", true)
 		},

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -35,7 +35,7 @@ func newRootCmd() *cobra.Command {
 		SilenceUsage:  true,
 		// When run without a subcommand, default to attach behavior.
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return attachRun(cmd.OutOrStdout(), "")
+			return attachRun(cmd.OutOrStdout(), "", true)
 		},
 	}
 

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
@@ -15,8 +16,73 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/types"
 	"github.com/kunchenguid/no-mistakes/internal/wizard"
 )
+
+var resolveWizardAgent = func(ctx context.Context, cfg *config.Config) error {
+	return cfg.ResolveAgent(ctx, exec.LookPath)
+}
+
+var newWizardAgent = agent.New
+
+type wizardAgentSuggester struct {
+	cfg     *config.Config
+	workDir string
+	resolve func(context.Context, *config.Config) error
+	new     func(types.AgentName, string) (agent.Agent, error)
+
+	once sync.Once
+	ag   agent.Agent
+	err  error
+}
+
+func newWizardAgentSuggester(cfg *config.Config, workDir string, resolve func(context.Context, *config.Config) error, new func(types.AgentName, string) (agent.Agent, error)) *wizardAgentSuggester {
+	if resolve == nil {
+		resolve = resolveWizardAgent
+	}
+	if new == nil {
+		new = newWizardAgent
+	}
+	return &wizardAgentSuggester{cfg: cfg, workDir: workDir, resolve: resolve, new: new}
+}
+
+func (s *wizardAgentSuggester) ensure(ctx context.Context) error {
+	s.once.Do(func() {
+		if err := s.resolve(ctx, s.cfg); err != nil {
+			s.err = fmt.Errorf("resolve agent: %w", err)
+			return
+		}
+		ag, err := s.new(s.cfg.Agent, s.cfg.AgentPath())
+		if err != nil {
+			s.err = fmt.Errorf("create agent: %w", err)
+			return
+		}
+		s.ag = ag
+	})
+	return s.err
+}
+
+func (s *wizardAgentSuggester) suggestBranch(ctx context.Context) (string, error) {
+	if err := s.ensure(ctx); err != nil {
+		return "", err
+	}
+	return agent.SuggestBranchName(ctx, s.ag, s.workDir)
+}
+
+func (s *wizardAgentSuggester) suggestCommit(ctx context.Context) (string, error) {
+	if err := s.ensure(ctx); err != nil {
+		return "", err
+	}
+	return agent.SuggestCommitMessage(ctx, s.ag, s.workDir)
+}
+
+func (s *wizardAgentSuggester) Close() error {
+	if s.ag == nil {
+		return nil
+	}
+	return s.ag.Close()
+}
 
 // repoState captures the git state the wizard routing and the wizard itself
 // both need to know about.
@@ -77,7 +143,7 @@ func detectRepoState(ctx context.Context, repo *db.Repo) (*repoState, error) {
 	}, nil
 }
 
-// runWizard prepares an agent for suggestion calls and runs the interactive
+// runWizard prepares optional suggestion hooks and runs the interactive
 // onboarding wizard against the supplied repo state.
 func runWizard(ctx context.Context, p *paths.Paths, state *repoState) (wizard.Result, error) {
 	workDir := state.workDir
@@ -91,20 +157,14 @@ func runWizard(ctx context.Context, p *paths.Paths, state *repoState) (wizard.Re
 		return wizard.Result{}, fmt.Errorf("load repo config: %w", err)
 	}
 	cfg := config.Merge(globalCfg, repoCfg)
-	if err := cfg.ResolveAgent(ctx, exec.LookPath); err != nil {
-		return wizard.Result{}, fmt.Errorf("resolve agent: %w", err)
-	}
 	// Route agent-server stdout/stderr to a log file so lines don't corrupt
 	// the wizard's alt-screen display. Any opencode/rovodev server started
 	// during the wizard inherits this sink.
 	restoreOutput := captureAgentServerOutput(p)
 	defer restoreOutput()
 
-	ag, err := agent.New(cfg.Agent, cfg.AgentPath())
-	if err != nil {
-		return wizard.Result{}, fmt.Errorf("create agent: %w", err)
-	}
-	defer ag.Close()
+	suggester := newWizardAgentSuggester(cfg, workDir, nil, nil)
+	defer suggester.Close()
 
 	wizCfg := wizard.Config{
 		RepoDir:       workDir,
@@ -124,10 +184,10 @@ func runWizard(ctx context.Context, p *paths.Paths, state *repoState) (wizard.Re
 			return git.Push(ctx, workDir, gate.RemoteName, "refs/heads/"+branch, "", false)
 		},
 		SuggestBranch: func(ctx context.Context) (string, error) {
-			return agent.SuggestBranchName(ctx, ag, workDir)
+			return suggester.suggestBranch(ctx)
 		},
 		SuggestCommit: func(ctx context.Context) (string, error) {
-			return agent.SuggestCommitMessage(ctx, ag, workDir)
+			return suggester.suggestCommit(ctx)
 		},
 	}
 

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -1,0 +1,178 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/agent"
+	"github.com/kunchenguid/no-mistakes/internal/config"
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/gate"
+	"github.com/kunchenguid/no-mistakes/internal/git"
+	"github.com/kunchenguid/no-mistakes/internal/ipc"
+	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/wizard"
+)
+
+// repoState captures the git state the wizard routing and the wizard itself
+// both need to know about.
+type repoState struct {
+	workDir       string
+	currentBranch string
+	defaultBranch string
+	detached      bool
+	dirty         bool
+}
+
+// needsBranch reports whether the user has no feature branch to work on —
+// either they're on the default branch, or HEAD is detached.
+func (s *repoState) needsBranch() bool {
+	return s.detached || s.currentBranch == s.defaultBranch
+}
+
+// shouldRouteToWizard reports whether the active-run check should be
+// bypassed and the wizard invoked directly. Detached HEAD is the only such
+// case — pipelines need a real branch, and any "active run" matched here
+// couldn't be on our current ref anyway. On any real branch (default or
+// feature), we still fall through to strict branch-matched lookup and only
+// enter the wizard when no run exists for that branch.
+func (s *repoState) shouldRouteToWizard() bool {
+	return s.detached
+}
+
+// detectRepoState probes the git state for the working directory, falling
+// back to the repo's recorded default branch when the origin remote can't
+// answer.
+func detectRepoState(ctx context.Context, repo *db.Repo) (*repoState, error) {
+	workDir, err := git.FindGitRoot(".")
+	if err != nil {
+		workDir = repo.WorkingPath
+	}
+	currentBranch, err := git.CurrentBranch(ctx, workDir)
+	if err != nil {
+		return nil, fmt.Errorf("detect current branch: %w", err)
+	}
+	detached, err := git.IsDetachedHEAD(ctx, workDir)
+	if err != nil {
+		return nil, fmt.Errorf("detect detached HEAD: %w", err)
+	}
+	dirty, err := git.HasUncommittedChanges(ctx, workDir)
+	if err != nil {
+		return nil, fmt.Errorf("detect working-tree state: %w", err)
+	}
+	defaultBranch := repo.DefaultBranch
+	if defaultBranch == "" {
+		defaultBranch = git.DefaultBranch(ctx, workDir, "origin")
+	}
+	return &repoState{
+		workDir:       workDir,
+		currentBranch: currentBranch,
+		defaultBranch: defaultBranch,
+		detached:      detached,
+		dirty:         dirty,
+	}, nil
+}
+
+// runWizard prepares an agent for suggestion calls and runs the interactive
+// onboarding wizard against the supplied repo state.
+func runWizard(ctx context.Context, p *paths.Paths, state *repoState) (wizard.Result, error) {
+	workDir := state.workDir
+
+	globalCfg, err := config.LoadGlobal(p.ConfigFile())
+	if err != nil {
+		return wizard.Result{}, fmt.Errorf("load global config: %w", err)
+	}
+	repoCfg, err := config.LoadRepo(workDir)
+	if err != nil {
+		return wizard.Result{}, fmt.Errorf("load repo config: %w", err)
+	}
+	cfg := config.Merge(globalCfg, repoCfg)
+	if err := cfg.ResolveAgent(ctx, exec.LookPath); err != nil {
+		return wizard.Result{}, fmt.Errorf("resolve agent: %w", err)
+	}
+	// Route agent-server stdout/stderr to a log file so lines don't corrupt
+	// the wizard's alt-screen display. Any opencode/rovodev server started
+	// during the wizard inherits this sink.
+	restoreOutput := captureAgentServerOutput(p)
+	defer restoreOutput()
+
+	ag, err := agent.New(cfg.Agent, cfg.AgentPath())
+	if err != nil {
+		return wizard.Result{}, fmt.Errorf("create agent: %w", err)
+	}
+	defer ag.Close()
+
+	wizCfg := wizard.Config{
+		RepoDir:       workDir,
+		CurrentBranch: state.currentBranch,
+		DefaultBranch: state.defaultBranch,
+		NeedsBranch:   state.needsBranch(),
+		IsDirty:       state.dirty,
+		GateRemote:    gate.RemoteName,
+
+		CreateBranch: func(ctx context.Context, name string) error {
+			return git.CreateBranch(ctx, workDir, name)
+		},
+		CommitAll: func(ctx context.Context, msg string) error {
+			return git.CommitAll(ctx, workDir, msg)
+		},
+		Push: func(ctx context.Context, branch string) error {
+			return git.Push(ctx, workDir, gate.RemoteName, "refs/heads/"+branch, "", false)
+		},
+		SuggestBranch: func(ctx context.Context) (string, error) {
+			return agent.SuggestBranchName(ctx, ag, workDir)
+		},
+		SuggestCommit: func(ctx context.Context) (string, error) {
+			return agent.SuggestCommitMessage(ctx, ag, workDir)
+		},
+	}
+
+	return wizard.Run(wizCfg)
+}
+
+// captureAgentServerOutput routes managed-server logs to a file under
+// LogsDir for the duration of the wizard, restoring the previous writer on
+// cleanup. Failing to open the log file is not fatal — we fall back to
+// io.Discard to avoid corrupting the alt-screen.
+func captureAgentServerOutput(p *paths.Paths) func() {
+	_ = os.MkdirAll(p.LogsDir(), 0o755)
+	logPath := filepath.Join(p.LogsDir(), "wizard-agent.log")
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		agent.SetManagedServerOutput(discardWriter{})
+		return func() { agent.SetManagedServerOutput(nil) }
+	}
+	agent.SetManagedServerOutput(f)
+	return func() {
+		agent.SetManagedServerOutput(nil)
+		f.Close()
+	}
+}
+
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+// waitForActiveRun polls the daemon until an active run appears for the given
+// repo/branch, or the deadline elapses. The post-receive hook creates the run
+// asynchronously, so a short poll bridges the gap between push and attach.
+func waitForActiveRun(client *ipc.Client, repoID, branch string, timeout time.Duration) (*ipc.RunInfo, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		var result ipc.GetActiveRunResult
+		if err := client.Call(ipc.MethodGetActiveRun, &ipc.GetActiveRunParams{RepoID: repoID, Branch: branch}, &result); err != nil {
+			return nil, err
+		}
+		if result.Run != nil {
+			return result.Run, nil
+		}
+		if time.Now().After(deadline) {
+			return nil, nil
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+}

--- a/internal/cli/wizard_test.go
+++ b/internal/cli/wizard_test.go
@@ -1,0 +1,68 @@
+package cli
+
+import "testing"
+
+func TestShouldRouteToWizard(t *testing.T) {
+	tests := []struct {
+		name  string
+		state repoState
+		want  bool
+	}{
+		{
+			name:  "detached HEAD, clean",
+			state: repoState{currentBranch: "HEAD", defaultBranch: "main", detached: true, dirty: false},
+			want:  true,
+		},
+		{
+			name:  "detached HEAD, dirty",
+			state: repoState{currentBranch: "HEAD", defaultBranch: "main", detached: true, dirty: true},
+			want:  true,
+		},
+		{
+			name:  "default branch, dirty — defer to active-run check",
+			state: repoState{currentBranch: "main", defaultBranch: "main", dirty: true},
+			want:  false,
+		},
+		{
+			name:  "default branch, clean",
+			state: repoState{currentBranch: "main", defaultBranch: "main", dirty: false},
+			want:  false,
+		},
+		{
+			name:  "feature branch, dirty",
+			state: repoState{currentBranch: "feat/x", defaultBranch: "main", dirty: true},
+			want:  false,
+		},
+		{
+			name:  "feature branch, clean",
+			state: repoState{currentBranch: "feat/x", defaultBranch: "main", dirty: false},
+			want:  false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.state.shouldRouteToWizard(); got != tc.want {
+				t.Fatalf("shouldRouteToWizard() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNeedsBranch(t *testing.T) {
+	tests := []struct {
+		name  string
+		state repoState
+		want  bool
+	}{
+		{"default branch", repoState{currentBranch: "main", defaultBranch: "main"}, true},
+		{"feature branch", repoState{currentBranch: "feat/x", defaultBranch: "main"}, false},
+		{"detached HEAD", repoState{currentBranch: "HEAD", defaultBranch: "main", detached: true}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.state.needsBranch(); got != tc.want {
+				t.Fatalf("needsBranch() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/wizard_test.go
+++ b/internal/cli/wizard_test.go
@@ -1,6 +1,13 @@
 package cli
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/config"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
 
 func TestShouldRouteToWizard(t *testing.T) {
 	tests := []struct {
@@ -64,5 +71,27 @@ func TestNeedsBranch(t *testing.T) {
 				t.Fatalf("needsBranch() = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestWizardAgentSuggester_IsLazy(t *testing.T) {
+	t.Helper()
+
+	lookups := 0
+	suggester := newWizardAgentSuggester(&config.Config{Agent: types.AgentAuto}, "/tmp/repo", func(context.Context, *config.Config) error {
+		lookups++
+		return errors.New("no supported agent found")
+	}, nil)
+	defer suggester.Close()
+
+	if lookups != 0 {
+		t.Fatalf("expected no agent resolution during setup, got %d", lookups)
+	}
+
+	if _, err := suggester.suggestBranch(context.Background()); err == nil {
+		t.Fatal("expected suggestion to fail when no agent is available")
+	}
+	if lookups != 1 {
+		t.Fatalf("expected one lazy resolution attempt, got %d", lookups)
 	}
 }

--- a/internal/daemon/handlers_test.go
+++ b/internal/daemon/handlers_test.go
@@ -183,7 +183,7 @@ func TestGetActiveRunHandler(t *testing.T) {
 	}
 }
 
-func TestGetActiveRunHandlerPrefersRequestedBranch(t *testing.T) {
+func TestGetActiveRunHandlerStrictBranchMatch(t *testing.T) {
 	p, d := startTestDaemon(t)
 
 	repo, err := d.InsertRepoWithID("test-repo-branch", "/tmp/test-repo-branch", "https://github.com/test/repo-branch", "main")
@@ -195,8 +195,7 @@ func TestGetActiveRunHandlerPrefersRequestedBranch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	runB, err := d.InsertRun(repo.ID, "feature-b", "bbb", "000")
-	if err != nil {
+	if _, err := d.InsertRun(repo.ID, "feature-b", "bbb", "000"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -206,6 +205,7 @@ func TestGetActiveRunHandlerPrefersRequestedBranch(t *testing.T) {
 	}
 	defer client.Close()
 
+	// Specific branch returns only that branch's run.
 	var result ipc.GetActiveRunResult
 	if err := client.Call(ipc.MethodGetActiveRun, &ipc.GetActiveRunParams{RepoID: repo.ID, Branch: "feature-a"}, &result); err != nil {
 		t.Fatal(err)
@@ -217,21 +217,14 @@ func TestGetActiveRunHandlerPrefersRequestedBranch(t *testing.T) {
 		t.Fatalf("active run id = %q, want %q", result.Run.ID, runA.ID)
 	}
 
-	var fallback ipc.GetActiveRunResult
-	if err := client.Call(ipc.MethodGetActiveRun, &ipc.GetActiveRunParams{RepoID: repo.ID, Branch: "missing-branch"}, &fallback); err != nil {
+	// Unknown branch returns nil — no fallback. The setup wizard relies on
+	// this to detect that the current branch has no active run.
+	var missing ipc.GetActiveRunResult
+	if err := client.Call(ipc.MethodGetActiveRun, &ipc.GetActiveRunParams{RepoID: repo.ID, Branch: "missing-branch"}, &missing); err != nil {
 		t.Fatal(err)
 	}
-	if fallback.Run == nil {
-		t.Fatal("expected fallback active run")
-	}
-	if fallback.Run.ID != runB.ID {
-		t.Fatalf("fallback active run id = %q, want %q", fallback.Run.ID, runB.ID)
-	}
-	if fallback.Run.Branch != "feature-b" {
-		t.Fatalf("fallback active run branch = %q, want %q", fallback.Run.Branch, "feature-b")
-	}
-	if fallback.Run.ID == runA.ID {
-		t.Fatal("expected fallback to prefer newest run when branch is missing")
+	if missing.Run != nil {
+		t.Fatalf("expected nil run for unmatched branch, got %q on %q", missing.Run.ID, missing.Run.Branch)
 	}
 }
 

--- a/internal/db/run.go
+++ b/internal/db/run.go
@@ -79,14 +79,23 @@ func (d *DB) GetRunsByRepo(repoID string) ([]*Run, error) {
 	return runs, rows.Err()
 }
 
-// GetActiveRun returns the currently active run (pending or running) for a repo, if any.
-// When branch is non-empty, runs matching that branch are preferred; otherwise
-// falls back to the most recently created active run.
+// GetActiveRun returns the currently active run (pending or running) for a repo,
+// if any. When branch is non-empty, only a run on that exact branch is returned
+// — the setup wizard relies on this to decide whether a new run is needed for
+// the current branch. When branch is empty, returns the most recently created
+// active run across any branch.
 func (d *DB) GetActiveRun(repoID, branch string) (*Run, error) {
 	r := &Run{}
-	err := d.sql.QueryRow(
-		`SELECT id, repo_id, branch, head_sha, base_sha, status, pr_url, error, created_at, updated_at FROM runs WHERE repo_id = ? AND status IN ('pending', 'running') ORDER BY (branch = ?) DESC, created_at DESC, id DESC LIMIT 1`, repoID, branch,
-	).Scan(&r.ID, &r.RepoID, &r.Branch, &r.HeadSHA, &r.BaseSHA, &r.Status, &r.PRURL, &r.Error, &r.CreatedAt, &r.UpdatedAt)
+	var err error
+	if branch == "" {
+		err = d.sql.QueryRow(
+			`SELECT id, repo_id, branch, head_sha, base_sha, status, pr_url, error, created_at, updated_at FROM runs WHERE repo_id = ? AND status IN ('pending', 'running') ORDER BY created_at DESC, id DESC LIMIT 1`, repoID,
+		).Scan(&r.ID, &r.RepoID, &r.Branch, &r.HeadSHA, &r.BaseSHA, &r.Status, &r.PRURL, &r.Error, &r.CreatedAt, &r.UpdatedAt)
+	} else {
+		err = d.sql.QueryRow(
+			`SELECT id, repo_id, branch, head_sha, base_sha, status, pr_url, error, created_at, updated_at FROM runs WHERE repo_id = ? AND branch = ? AND status IN ('pending', 'running') ORDER BY created_at DESC, id DESC LIMIT 1`, repoID, branch,
+		).Scan(&r.ID, &r.RepoID, &r.Branch, &r.HeadSHA, &r.BaseSHA, &r.Status, &r.PRURL, &r.Error, &r.CreatedAt, &r.UpdatedAt)
+	}
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}

--- a/internal/db/run_test.go
+++ b/internal/db/run_test.go
@@ -90,7 +90,7 @@ func TestActiveRun(t *testing.T) {
 	}
 }
 
-func TestActiveRunPrefersBranch(t *testing.T) {
+func TestActiveRunStrictBranchMatch(t *testing.T) {
 	d := openTestDB(t)
 	repo, _ := d.InsertRepo("/home/user/branchpref", "git@github.com:user/branchpref.git", "main")
 
@@ -107,7 +107,7 @@ func TestActiveRunPrefersBranch(t *testing.T) {
 		t.Fatalf("expected newest run %q, got %v", runB.ID, active)
 	}
 
-	// With branch hint "feature-a", the older matching run wins.
+	// With branch hint "feature-a", the matching run is returned.
 	active, err = d.GetActiveRun(repo.ID, "feature-a")
 	if err != nil {
 		t.Fatalf("get active run with branch: %v", err)
@@ -125,13 +125,15 @@ func TestActiveRunPrefersBranch(t *testing.T) {
 		t.Fatalf("expected branch-matching run %q, got %q", runB.ID, active.ID)
 	}
 
-	// With branch hint for a non-existent branch, falls back to newest.
+	// With branch hint for a non-existent branch, return nil (strict match,
+	// no fallback). This is what lets the setup wizard know a fresh run is
+	// needed for the current branch.
 	active, err = d.GetActiveRun(repo.ID, "feature-c")
 	if err != nil {
 		t.Fatalf("get active run with unknown branch: %v", err)
 	}
-	if active == nil || active.ID != runB.ID {
-		t.Fatalf("expected fallback to newest run %q, got %q", runB.ID, active.ID)
+	if active != nil {
+		t.Fatalf("expected nil with no matching branch, got run %q on %q", active.ID, active.Branch)
 	}
 }
 

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -13,7 +13,8 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/paths"
 )
 
-const remoteName = "no-mistakes"
+// RemoteName is the name of the git remote that points to the local gate.
+const RemoteName = "no-mistakes"
 
 // repoID generates a deterministic 12-char hex ID from an absolute path.
 func repoID(absPath string) string {
@@ -72,7 +73,7 @@ func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Re
 	}
 
 	// Add remote to working repo.
-	if err := git.AddRemote(ctx, absRoot, remoteName, bareDir); err != nil {
+	if err := git.AddRemote(ctx, absRoot, RemoteName, bareDir); err != nil {
 		os.RemoveAll(bareDir)
 		return nil, fmt.Errorf("add remote: %w", err)
 	}
@@ -84,7 +85,7 @@ func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Re
 	repo, err := d.InsertRepoWithID(id, absRoot, upstreamURL, branch)
 	if err != nil {
 		// Rollback: remove remote and bare repo.
-		git.RemoveRemote(ctx, absRoot, remoteName)
+		git.RemoveRemote(ctx, absRoot, RemoteName)
 		os.RemoveAll(bareDir)
 		return nil, fmt.Errorf("insert repo: %w", err)
 	}
@@ -115,7 +116,7 @@ func Eject(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.R
 	}
 
 	// Remove remote from working repo (non-fatal).
-	_ = git.RemoveRemote(ctx, absRoot, remoteName)
+	_ = git.RemoveRemote(ctx, absRoot, RemoteName)
 
 	// Delete bare repo.
 	bareDir := p.RepoDir(repo.ID)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -137,6 +137,24 @@ func CurrentBranch(ctx context.Context, dir string) (string, error) {
 	return Run(ctx, dir, "rev-parse", "--abbrev-ref", "HEAD")
 }
 
+// IsDetachedHEAD reports whether the working tree is in a detached-HEAD state
+// (HEAD points at a commit rather than a branch ref). Uses `git symbolic-ref`
+// which fails cleanly when HEAD is not a symbolic ref.
+func IsDetachedHEAD(ctx context.Context, dir string) (bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "symbolic-ref", "-q", "HEAD")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			// Exit 1 means HEAD is not a symbolic ref — detached.
+			if ee.ExitCode() == 1 {
+				return true, nil
+			}
+		}
+		return false, fmt.Errorf("git symbolic-ref: %w", err)
+	}
+	return false, nil
+}
+
 // DefaultBranch queries a remote to determine its default branch name.
 // Uses git ls-remote --symref to read the remote's HEAD symref.
 // Falls back to "main" if detection fails (e.g. empty remote, unreachable).
@@ -198,6 +216,41 @@ func LsRemote(ctx context.Context, dir, remote, ref string) (string, error) {
 		return "", nil
 	}
 	return parts[0], nil
+}
+
+// HasUncommittedChanges reports whether the working tree or index differs from HEAD.
+// Returns true if any tracked file is modified, staged, or deleted, or if there are
+// untracked files. Equivalent to a non-empty `git status --porcelain`.
+func HasUncommittedChanges(ctx context.Context, dir string) (bool, error) {
+	out, err := Run(ctx, dir, "status", "--porcelain")
+	if err != nil {
+		return false, err
+	}
+	return out != "", nil
+}
+
+// CreateBranch creates a new branch with the given name and switches to it.
+// Fails if the branch already exists.
+func CreateBranch(ctx context.Context, dir, name string) error {
+	_, err := Run(ctx, dir, "checkout", "-b", name)
+	return err
+}
+
+// CommitAll stages every change in the working tree and creates a single commit
+// with the given message. Fails if there are no changes to commit.
+func CommitAll(ctx context.Context, dir, message string) error {
+	if _, err := Run(ctx, dir, "add", "-A"); err != nil {
+		return err
+	}
+	dirty, err := HasUncommittedChanges(ctx, dir)
+	if err != nil {
+		return err
+	}
+	if !dirty {
+		return fmt.Errorf("no changes to commit")
+	}
+	_, err = Run(ctx, dir, "commit", "-m", message)
+	return err
 }
 
 // WorktreeAdd creates a detached worktree at wtPath checked out to the given SHA.

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -162,3 +162,162 @@ func TestFindGitRootNotFound(t *testing.T) {
 		t.Fatal("expected error for non-git directory")
 	}
 }
+
+func TestHasUncommittedChangesClean(t *testing.T) {
+	dir := initTestRepo(t)
+	ctx := context.Background()
+
+	dirty, err := HasUncommittedChanges(ctx, dir)
+	if err != nil {
+		t.Fatalf("HasUncommittedChanges failed: %v", err)
+	}
+	if dirty {
+		t.Fatal("expected clean repo, got dirty")
+	}
+}
+
+func TestHasUncommittedChangesModifiedFile(t *testing.T) {
+	dir := initTestRepo(t)
+	ctx := context.Background()
+
+	writeFile(t, filepath.Join(dir, "README.md"), "# changed\n")
+
+	dirty, err := HasUncommittedChanges(ctx, dir)
+	if err != nil {
+		t.Fatalf("HasUncommittedChanges failed: %v", err)
+	}
+	if !dirty {
+		t.Fatal("expected dirty repo after modifying file")
+	}
+}
+
+func TestHasUncommittedChangesUntrackedFile(t *testing.T) {
+	dir := initTestRepo(t)
+	ctx := context.Background()
+
+	writeFile(t, filepath.Join(dir, "new.txt"), "new\n")
+
+	dirty, err := HasUncommittedChanges(ctx, dir)
+	if err != nil {
+		t.Fatalf("HasUncommittedChanges failed: %v", err)
+	}
+	if !dirty {
+		t.Fatal("expected dirty repo with untracked file")
+	}
+}
+
+func TestHasUncommittedChangesStagedOnly(t *testing.T) {
+	dir := initTestRepo(t)
+	ctx := context.Background()
+
+	writeFile(t, filepath.Join(dir, "staged.txt"), "staged\n")
+	run(t, dir, "git", "add", "staged.txt")
+
+	dirty, err := HasUncommittedChanges(ctx, dir)
+	if err != nil {
+		t.Fatalf("HasUncommittedChanges failed: %v", err)
+	}
+	if !dirty {
+		t.Fatal("expected dirty repo with staged-only change")
+	}
+}
+
+func TestCreateBranch(t *testing.T) {
+	dir := initTestRepo(t)
+	ctx := context.Background()
+
+	if err := CreateBranch(ctx, dir, "feature/new"); err != nil {
+		t.Fatalf("CreateBranch failed: %v", err)
+	}
+
+	branch, err := CurrentBranch(ctx, dir)
+	if err != nil {
+		t.Fatalf("CurrentBranch failed: %v", err)
+	}
+	if branch != "feature/new" {
+		t.Fatalf("expected 'feature/new', got %q", branch)
+	}
+}
+
+func TestCreateBranchDuplicate(t *testing.T) {
+	dir := initTestRepo(t)
+	ctx := context.Background()
+
+	if err := CreateBranch(ctx, dir, "dup"); err != nil {
+		t.Fatalf("first CreateBranch failed: %v", err)
+	}
+	// Switch away so we can try to create the same branch again.
+	run(t, dir, "git", "checkout", "-")
+
+	if err := CreateBranch(ctx, dir, "dup"); err == nil {
+		t.Fatal("expected error creating duplicate branch")
+	}
+}
+
+func TestCommitAll(t *testing.T) {
+	dir := initTestRepo(t)
+	ctx := context.Background()
+
+	writeFile(t, filepath.Join(dir, "a.txt"), "a\n")
+	writeFile(t, filepath.Join(dir, "b.txt"), "b\n")
+
+	if err := CommitAll(ctx, dir, "add a and b"); err != nil {
+		t.Fatalf("CommitAll failed: %v", err)
+	}
+
+	dirty, err := HasUncommittedChanges(ctx, dir)
+	if err != nil {
+		t.Fatalf("HasUncommittedChanges after commit failed: %v", err)
+	}
+	if dirty {
+		t.Fatal("expected clean repo after CommitAll")
+	}
+
+	msg := run(t, dir, "git", "log", "-1", "--pretty=%B")
+	if !strings.Contains(msg, "add a and b") {
+		t.Fatalf("commit message missing subject, got %q", msg)
+	}
+}
+
+func TestCommitAllNoChanges(t *testing.T) {
+	dir := initTestRepo(t)
+	ctx := context.Background()
+
+	if err := CommitAll(ctx, dir, "nothing"); err == nil {
+		t.Fatal("expected error committing with no changes")
+	}
+}
+
+func TestIsDetachedHEADOnBranch(t *testing.T) {
+	dir := initTestRepo(t)
+	ctx := context.Background()
+
+	detached, err := IsDetachedHEAD(ctx, dir)
+	if err != nil {
+		t.Fatalf("IsDetachedHEAD failed: %v", err)
+	}
+	if detached {
+		t.Fatal("fresh repo on a branch should not be detached")
+	}
+}
+
+func TestIsDetachedHEADWhenDetached(t *testing.T) {
+	dir := initTestRepo(t)
+	ctx := context.Background()
+
+	// Make a second commit so we have a specific SHA to detach onto.
+	writeFile(t, filepath.Join(dir, "two.txt"), "two\n")
+	run(t, dir, "git", "add", ".")
+	run(t, dir, "git", "commit", "-m", "second")
+	sha := run(t, dir, "git", "rev-parse", "HEAD~1")
+
+	run(t, dir, "git", "checkout", sha)
+
+	detached, err := IsDetachedHEAD(ctx, dir)
+	if err != nil {
+		t.Fatalf("IsDetachedHEAD failed: %v", err)
+	}
+	if !detached {
+		t.Fatal("expected detached HEAD after checking out a commit SHA")
+	}
+}

--- a/internal/wizard/view.go
+++ b/internal/wizard/view.go
@@ -1,0 +1,276 @@
+package wizard
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+)
+
+// ANSI-only palette, matching internal/tui/theme.go.
+const (
+	ansiRed         = "1"
+	ansiGreen       = "2"
+	ansiYellow      = "3"
+	ansiBlue        = "4"
+	ansiCyan        = "6"
+	ansiBrightBlack = "8"
+)
+
+func init() {
+	lipgloss.SetColorProfile(termenv.ANSI)
+}
+
+var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// View renders the wizard.
+func (m Model) View() string {
+	width := m.width
+	if width < 60 {
+		width = 60
+	}
+
+	var content strings.Builder
+
+	for i, s := range m.steps {
+		content.WriteString(m.renderStep(s))
+		content.WriteString("\n")
+		if i < len(m.steps)-1 {
+			content.WriteString(dimStyle().Render("│"))
+			content.WriteString("\n")
+		}
+	}
+
+	box := renderBox("Setup", strings.TrimRight(content.String(), "\n"), width)
+
+	var out strings.Builder
+	out.WriteString(box)
+	out.WriteString("\n")
+
+	if bar := m.renderActionBar(); bar != "" {
+		out.WriteString("\n")
+		out.WriteString(bar)
+		out.WriteString("\n")
+	}
+
+	out.WriteString("\n")
+	out.WriteString(m.renderFooter())
+	out.WriteString("\n")
+
+	if m.err != nil {
+		out.WriteString("\n")
+		out.WriteString(redStyle().Render("error: " + m.err.Error()))
+		out.WriteString("\n")
+	}
+
+	return out.String()
+}
+
+func (m Model) renderStep(s *step) string {
+	icon, style := stepIconAndStyle(s, m.spinnerFrame)
+	header := style.Render(icon) + " " + stepLabel(s.id)
+
+	switch s.status {
+	case statDone:
+		return header + "  " + dimStyle().Render(s.result)
+
+	case statSkipped:
+		if s.skipReason != "" {
+			return header + "  " + dimStyle().Render(s.skipReason)
+		}
+		return header
+
+	case statFailed:
+		lines := []string{header + "  " + redStyle().Render(s.errMsg)}
+		return strings.Join(lines, "\n")
+
+	case statInput:
+		lines := []string{header}
+		lines = append(lines, "    "+dimStyle().Render(inputLabel(s.id)))
+		lines = append(lines, "    "+m.input.View())
+		return strings.Join(lines, "\n")
+
+	case statAgent:
+		lines := []string{header}
+		lines = append(lines, "    "+dimStyle().Render(agentLabel(s.id)))
+		return strings.Join(lines, "\n")
+
+	case statRunning:
+		lines := []string{header}
+		lines = append(lines, "    "+dimStyle().Render(runningLabel(s.id, s.result)))
+		return strings.Join(lines, "\n")
+
+	case statConfirm:
+		lines := []string{header}
+		lines = append(lines, "    "+dimStyle().Render(confirmLabel(m.cfg.GateRemote, m.targetBranch)))
+		return strings.Join(lines, "\n")
+	}
+	return header
+}
+
+func (m Model) renderActionBar() string {
+	s := m.activeStep()
+	if s == nil {
+		return ""
+	}
+	switch s.status {
+	case statInput:
+		return " " + boldStyle().Render("⏎") + " submit"
+	case statConfirm:
+		return " " + boldStyle().Render("y") + " push  " + boldStyle().Render("n") + " skip"
+	case statFailed:
+		return " " + boldStyle().Render("r") + " retry"
+	}
+	return ""
+}
+
+func (m Model) renderFooter() string {
+	if m.confirmQuit {
+		msg := " " + boldStyle().Render("q") + " again to abort  " + dimStyle().Render(m.sideEffectsDescription()+" will stay")
+		return redStyle().Render(msg)
+	}
+	if m.hasSideEffects() {
+		return " " + boldStyle().Render("q") + " abort  " + dimStyle().Render(m.sideEffectsDescription()+" stays")
+	}
+	return " " + boldStyle().Render("q") + " quit"
+}
+
+func (m Model) sideEffectsDescription() string {
+	parts := []string{}
+	if m.branchCreated {
+		parts = append(parts, "branch "+m.targetBranch)
+	}
+	if m.commitMade {
+		parts = append(parts, "commit")
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, " + ")
+}
+
+func stepLabel(id stepID) string {
+	switch id {
+	case stepBranch:
+		return "Branch"
+	case stepCommit:
+		return "Commit"
+	case stepPush:
+		return "Push"
+	}
+	return "?"
+}
+
+func inputLabel(id stepID) string {
+	switch id {
+	case stepBranch:
+		return "branch name (blank to let the agent suggest):"
+	case stepCommit:
+		return "commit message (blank to let the agent suggest):"
+	}
+	return ""
+}
+
+func agentLabel(id stepID) string {
+	switch id {
+	case stepBranch:
+		return "asking agent for a branch name…"
+	case stepCommit:
+		return "asking agent for a commit message…"
+	}
+	return "asking agent…"
+}
+
+func runningLabel(id stepID, value string) string {
+	switch id {
+	case stepBranch:
+		return "creating branch " + value + "…"
+	case stepCommit:
+		return "committing \"" + value + "\"…"
+	case stepPush:
+		return "pushing to gate…"
+	}
+	return "working…"
+}
+
+func confirmLabel(remote, branch string) string {
+	if remote == "" {
+		remote = "no-mistakes"
+	}
+	return fmt.Sprintf("push %s to %s gate?", branch, remote)
+}
+
+func stepIconAndStyle(s *step, spinnerFrame int) (string, lipgloss.Style) {
+	switch s.status {
+	case statDone:
+		return "✓", greenStyle()
+	case statSkipped:
+		return "–", dimStyle()
+	case statFailed:
+		return "✗", redStyle()
+	case statAgent, statRunning:
+		if len(spinnerFrames) == 0 {
+			return "◉", blueStyle()
+		}
+		return spinnerFrames[spinnerFrame%len(spinnerFrames)], blueStyle()
+	case statInput:
+		return "⏸", yellowStyle()
+	case statConfirm:
+		return "⏸", yellowStyle()
+	}
+	return "○", dimStyle()
+}
+
+// Style helpers — kept as functions so tests can swap the color profile.
+
+func dimStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
+}
+func greenStyle() lipgloss.Style  { return lipgloss.NewStyle().Foreground(lipgloss.Color(ansiGreen)) }
+func redStyle() lipgloss.Style    { return lipgloss.NewStyle().Foreground(lipgloss.Color(ansiRed)) }
+func yellowStyle() lipgloss.Style { return lipgloss.NewStyle().Foreground(lipgloss.Color(ansiYellow)) }
+func blueStyle() lipgloss.Style   { return lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBlue)) }
+func cyanStyle() lipgloss.Style   { return lipgloss.NewStyle().Foreground(lipgloss.Color(ansiCyan)) }
+func boldStyle() lipgloss.Style   { return lipgloss.NewStyle().Bold(true) }
+
+// renderBox mirrors internal/tui/box.go: a rounded-border box with a cyan
+// bold title embedded in the top border.
+func renderBox(title, content string, width int) string {
+	if width < 6 {
+		width = 6
+	}
+	titleStyled := cyanStyle().Bold(true).Render(title)
+	borderColor := dimStyle()
+
+	titleWidth := lipgloss.Width(titleStyled)
+	fillWidth := width - 5 - titleWidth
+	if fillWidth < 1 {
+		fillWidth = 1
+	}
+	topBorder := borderColor.Render("╭─ ") + titleStyled + " " + borderColor.Render(strings.Repeat("─", fillWidth)+"╮")
+
+	contentWidth := width - 4
+	if contentWidth < 1 {
+		contentWidth = 1
+	}
+
+	var lines []string
+	for _, cl := range strings.Split(content, "\n") {
+		visWidth := lipgloss.Width(cl)
+		pad := contentWidth - visWidth
+		if pad < 0 {
+			pad = 0
+		}
+		line := borderColor.Render("│") + " " + cl + strings.Repeat(" ", pad) + " " + borderColor.Render("│")
+		lines = append(lines, line)
+	}
+
+	fill := width - 2
+	if fill < 1 {
+		fill = 1
+	}
+	bottom := borderColor.Render("╰" + strings.Repeat("─", fill) + "╯")
+
+	return topBorder + "\n" + strings.Join(lines, "\n") + "\n" + bottom
+}

--- a/internal/wizard/view_test.go
+++ b/internal/wizard/view_test.go
@@ -1,0 +1,77 @@
+package wizard
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestView_RendersSetupTitle(t *testing.T) {
+	m := NewModel(baseConfig(&recorder{}))
+	m.width = 80
+	out := m.View()
+	if !strings.Contains(out, "Setup") {
+		t.Fatalf("expected box title 'Setup', got:\n%s", out)
+	}
+}
+
+func TestView_RendersAllStepLabels(t *testing.T) {
+	m := NewModel(baseConfig(&recorder{}))
+	m.width = 80
+	out := m.View()
+	for _, label := range []string{"Branch", "Commit", "Push"} {
+		if !strings.Contains(out, label) {
+			t.Errorf("expected %q in view, got:\n%s", label, out)
+		}
+	}
+}
+
+func TestView_ShowsSkipReason(t *testing.T) {
+	cfg := baseConfig(&recorder{})
+	cfg.CurrentBranch = "feat/existing"
+	cfg.NeedsBranch = false
+	m := NewModel(cfg)
+	m.width = 80
+	out := m.View()
+	if !strings.Contains(out, "feat/existing") {
+		t.Fatalf("expected skip reason to mention branch, got:\n%s", out)
+	}
+}
+
+func TestView_FooterReflectsSideEffects(t *testing.T) {
+	r := &recorder{}
+	m := NewModel(baseConfig(r))
+	m.width = 80
+
+	// No side-effects yet: footer shows "q quit".
+	initial := m.View()
+	if !strings.Contains(initial, "quit") {
+		t.Fatalf("expected 'quit' in initial footer, got:\n%s", initial)
+	}
+
+	// After creating a branch, footer should mention side-effects stay.
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("feat/x")})
+	m = advance(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m.width = 80
+	after := m.View()
+	if !strings.Contains(after, "abort") {
+		t.Fatalf("expected 'abort' in footer after side-effects, got:\n%s", after)
+	}
+	if !strings.Contains(after, "feat/x") {
+		t.Fatalf("expected branch name in footer, got:\n%s", after)
+	}
+}
+
+func TestView_ActionBarForConfirm(t *testing.T) {
+	cfg := baseConfig(&recorder{})
+	cfg.CurrentBranch = "feat/x"
+	cfg.NeedsBranch = false
+	cfg.IsDirty = false
+	m := NewModel(cfg)
+	m.width = 80
+	out := m.View()
+	if !strings.Contains(out, "push") {
+		t.Fatalf("expected 'push' in action bar for confirm step, got:\n%s", out)
+	}
+}

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -67,7 +67,9 @@ type step struct {
 
 // Model is the bubbletea model for the wizard.
 type Model struct {
-	cfg Config
+	cfg    Config
+	ctx    context.Context
+	cancel context.CancelFunc
 
 	steps  []*step
 	active int // index of the currently active step, or len(steps) when finished
@@ -114,9 +116,12 @@ func NewModel(cfg Config) Model {
 	ti := textinput.New()
 	ti.Prompt = "› "
 	ti.CharLimit = 80
+	ctx, cancel := context.WithCancel(context.Background())
 
 	m := Model{
 		cfg:          cfg,
+		ctx:          ctx,
+		cancel:       cancel,
 		input:        ti,
 		targetBranch: cfg.CurrentBranch,
 	}
@@ -222,6 +227,7 @@ func (m Model) setupActive() Model {
 	if s == nil {
 		m.success = m.pushed
 		m.quitting = true
+		m.cancel()
 		return m
 	}
 	switch s.id {
@@ -254,6 +260,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if s == nil {
 		// Already finished; any key quits.
 		m.quitting = true
+		m.cancel()
 		return m, tea.Quit
 	}
 
@@ -261,6 +268,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "ctrl+c":
 		m.aborted = true
 		m.quitting = true
+		m.cancel()
 		return m, tea.Quit
 	case "q":
 		if m.hasSideEffects() && !m.confirmQuit {
@@ -269,6 +277,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		m.aborted = true
 		m.quitting = true
+		m.cancel()
 		return m, tea.Quit
 	}
 
@@ -311,6 +320,7 @@ func (m Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "n", "N":
 		m.aborted = true
 		m.quitting = true
+		m.cancel()
 		return m, tea.Quit
 	}
 	return m, nil
@@ -425,7 +435,7 @@ func (m *Model) scheduleSpinner() tea.Cmd {
 
 func (m Model) suggestCmd(id stepID) tea.Cmd {
 	return func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		ctx, cancel := context.WithTimeout(m.ctx, 60*time.Second)
 		defer cancel()
 		switch id {
 		case stepBranch:

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -1,0 +1,494 @@
+// Package wizard provides the pre-pipeline onboarding UI: it detects repo
+// state, optionally creates a branch, commits uncommitted changes, and pushes
+// to the no-mistakes gate, then hands off to the main TUI.
+package wizard
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Config describes the repo state and dependencies the wizard needs.
+// Callers pre-detect git state so the wizard can decide up-front which
+// steps to skip.
+type Config struct {
+	RepoDir       string
+	CurrentBranch string
+	DefaultBranch string
+	// NeedsBranch is true when the user has no usable feature branch yet —
+	// either they're on the default branch, or HEAD is detached. The branch
+	// step is only active when this is true.
+	NeedsBranch bool
+	IsDirty     bool
+	GateRemote  string
+
+	CreateBranch  func(ctx context.Context, name string) error
+	CommitAll     func(ctx context.Context, msg string) error
+	Push          func(ctx context.Context, branch string) error
+	SuggestBranch func(ctx context.Context) (string, error)
+	SuggestCommit func(ctx context.Context) (string, error)
+}
+
+// stepID identifies one of the three wizard steps.
+type stepID int
+
+const (
+	stepBranch stepID = iota
+	stepCommit
+	stepPush
+)
+
+// stepStatus is the visual + logical state of a single step.
+type stepStatus int
+
+const (
+	statPending stepStatus = iota
+	statInput              // awaiting text input from user (branch / commit)
+	statAgent              // agent generating a suggestion
+	statConfirm            // awaiting y/n (push)
+	statRunning            // git action in flight
+	statDone
+	statSkipped
+	statFailed
+)
+
+type step struct {
+	id         stepID
+	status     stepStatus
+	result     string // displayed when done
+	skipReason string // displayed when skipped
+	errMsg     string
+}
+
+// Model is the bubbletea model for the wizard.
+type Model struct {
+	cfg Config
+
+	steps  []*step
+	active int // index of the currently active step, or len(steps) when finished
+
+	input textinput.Model
+
+	targetBranch string // the branch we intend to end up on / push
+
+	// Tracks side-effects for abort-copy and for the final Result.
+	branchCreated bool
+	commitMade    bool
+	pushed        bool
+
+	width, height int
+
+	spinnerFrame int
+	spinnerAlive bool
+
+	confirmQuit bool // true after first q press while side-effects exist
+
+	err      error
+	quitting bool
+	success  bool // all needed steps completed; pipeline pushed
+	aborted  bool // user explicitly aborted
+}
+
+// Result reports what the wizard did. Success means a push to the gate
+// succeeded and the caller should re-attach to pick up the new run.
+type Result struct {
+	Success       bool
+	Aborted       bool
+	BranchCreated bool
+	CommitMade    bool
+	Pushed        bool
+	TargetBranch  string
+	Err           error
+}
+
+// NewModel constructs a wizard Model. Which steps end up active depends on
+// the supplied Config: if the current branch already differs from the default,
+// the branch step is skipped; if the working tree is clean, the commit step
+// is skipped; the push step always runs.
+func NewModel(cfg Config) Model {
+	ti := textinput.New()
+	ti.Prompt = "› "
+	ti.CharLimit = 80
+
+	m := Model{
+		cfg:          cfg,
+		input:        ti,
+		targetBranch: cfg.CurrentBranch,
+	}
+
+	branch := &step{id: stepBranch, status: statPending}
+	commit := &step{id: stepCommit, status: statPending}
+	push := &step{id: stepPush, status: statPending}
+
+	if !cfg.NeedsBranch {
+		branch.status = statSkipped
+		branch.skipReason = "already on " + cfg.CurrentBranch
+	}
+	if !cfg.IsDirty {
+		commit.status = statSkipped
+		commit.skipReason = "no uncommitted changes"
+	}
+	m.steps = []*step{branch, commit, push}
+	m.active = m.firstPending()
+	m = m.setupActive()
+	return m
+}
+
+// Init returns the initial Cmd for the active step. State was already
+// prepared in NewModel.
+func (m Model) Init() tea.Cmd {
+	if m.quitting {
+		return tea.Quit
+	}
+	s := m.activeStep()
+	if s != nil && s.status == statInput {
+		return textinput.Blink
+	}
+	return nil
+}
+
+// Update handles bubbletea events and drives the state machine.
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+
+	case suggestionMsg:
+		return m.handleSuggestion(msg)
+
+	case actionMsg:
+		return m.handleAction(msg)
+
+	case spinnerTickMsg:
+		m.spinnerAlive = false
+		if !m.anySpinnerActive() {
+			return m, nil
+		}
+		m.spinnerFrame = (m.spinnerFrame + 1) % len(spinnerFrames)
+		return m, m.scheduleSpinner()
+	}
+	return m, nil
+}
+
+// Result returns the terminal state of the wizard. Only meaningful once the
+// program has exited.
+func (m Model) Result() Result {
+	return Result{
+		Success:       m.success,
+		Aborted:       m.aborted,
+		BranchCreated: m.branchCreated,
+		CommitMade:    m.commitMade,
+		Pushed:        m.pushed,
+		TargetBranch:  m.targetBranch,
+		Err:           m.err,
+	}
+}
+
+// firstPending returns the index of the first step that still needs work.
+// Returns len(steps) if none are pending.
+func (m Model) firstPending() int {
+	for i, s := range m.steps {
+		if s.status == statPending {
+			return i
+		}
+	}
+	return len(m.steps)
+}
+
+// activeStep returns the step currently being worked on, or nil if the
+// wizard has finished.
+func (m *Model) activeStep() *step {
+	if m.active < 0 || m.active >= len(m.steps) {
+		return nil
+	}
+	return m.steps[m.active]
+}
+
+// setupActive transitions the active step into its initial interactive
+// state (input for branch/commit, confirm for push). When no step is
+// pending, it marks the wizard as finished.
+func (m Model) setupActive() Model {
+	s := m.activeStep()
+	if s == nil {
+		m.success = m.pushed
+		m.quitting = true
+		return m
+	}
+	switch s.id {
+	case stepBranch, stepCommit:
+		s.status = statInput
+		m.input.SetValue("")
+		m.input.Focus()
+		m.input.Placeholder = "blank = let agent suggest"
+	case stepPush:
+		s.status = statConfirm
+		m.input.Blur()
+	}
+	return m
+}
+
+// afterEnterCmd returns the Cmd to kick off after transitioning to a new step.
+func (m Model) afterEnterCmd() tea.Cmd {
+	if m.quitting {
+		return tea.Quit
+	}
+	s := m.activeStep()
+	if s != nil && s.status == statInput {
+		return textinput.Blink
+	}
+	return nil
+}
+
+func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	s := m.activeStep()
+	if s == nil {
+		// Already finished; any key quits.
+		m.quitting = true
+		return m, tea.Quit
+	}
+
+	switch msg.String() {
+	case "ctrl+c":
+		m.aborted = true
+		m.quitting = true
+		return m, tea.Quit
+	case "q":
+		if m.hasSideEffects() && !m.confirmQuit {
+			m.confirmQuit = true
+			return m, nil
+		}
+		m.aborted = true
+		m.quitting = true
+		return m, tea.Quit
+	}
+
+	// Any non-q key clears the abort confirmation.
+	m.confirmQuit = false
+
+	switch s.status {
+	case statInput:
+		return m.handleInputKey(msg)
+	case statConfirm:
+		return m.handleConfirmKey(msg)
+	case statFailed:
+		return m.handleFailedKey(msg)
+	}
+	return m, nil
+}
+
+func (m Model) handleInputKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	s := m.activeStep()
+	switch msg.String() {
+	case "enter":
+		value := strings.TrimSpace(m.input.Value())
+		if value == "" {
+			// Agent suggestion path.
+			s.status = statAgent
+			return m, tea.Batch(m.suggestCmd(s.id), m.scheduleSpinner())
+		}
+		return m.executeStep(s, value)
+	}
+	var cmd tea.Cmd
+	m.input, cmd = m.input.Update(msg)
+	return m, cmd
+}
+
+func (m Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	s := m.activeStep()
+	switch msg.String() {
+	case "y", "Y", "enter":
+		return m.executeStep(s, "")
+	case "n", "N":
+		m.aborted = true
+		m.quitting = true
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m Model) handleFailedKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "r":
+		s := m.activeStep()
+		s.status = statPending
+		s.errMsg = ""
+		m = m.setupActive()
+		return m, m.afterEnterCmd()
+	}
+	return m, nil
+}
+
+// executeStep runs the git action for the step. For branch/commit, value is
+// the user-supplied or agent-generated string. For push, value is ignored.
+func (m *Model) executeStep(s *step, value string) (tea.Model, tea.Cmd) {
+	s.status = statRunning
+	s.result = value
+	m.input.Blur()
+	switch s.id {
+	case stepBranch:
+		return *m, tea.Batch(m.runCreateBranch(value), m.scheduleSpinner())
+	case stepCommit:
+		return *m, tea.Batch(m.runCommit(value), m.scheduleSpinner())
+	case stepPush:
+		return *m, tea.Batch(m.runPush(), m.scheduleSpinner())
+	}
+	return *m, nil
+}
+
+func (m Model) handleSuggestion(msg suggestionMsg) (tea.Model, tea.Cmd) {
+	if m.active >= len(m.steps) || m.steps[m.active].id != msg.id {
+		return m, nil
+	}
+	s := m.steps[m.active]
+	if msg.err != nil {
+		// Fall back to asking the user to type.
+		s.status = statInput
+		m.input.SetValue("")
+		m.input.Placeholder = "agent unavailable: " + truncate(msg.err.Error(), 40)
+		m.input.Focus()
+		return m, textinput.Blink
+	}
+	return m.executeStep(s, msg.value)
+}
+
+func (m Model) handleAction(msg actionMsg) (tea.Model, tea.Cmd) {
+	if m.active >= len(m.steps) || m.steps[m.active].id != msg.id {
+		return m, nil
+	}
+	s := m.steps[m.active]
+	if msg.err != nil {
+		s.status = statFailed
+		s.errMsg = msg.err.Error()
+		return m, nil
+	}
+	switch s.id {
+	case stepBranch:
+		m.branchCreated = true
+		m.targetBranch = s.result
+	case stepCommit:
+		m.commitMade = true
+	case stepPush:
+		m.pushed = true
+	}
+	s.status = statDone
+	m.active = m.firstPending()
+	m = m.setupActive()
+	return m, m.afterEnterCmd()
+}
+
+func (m Model) hasSideEffects() bool {
+	return m.branchCreated || m.commitMade
+}
+
+func (m Model) anySpinnerActive() bool {
+	s := m.activeStep()
+	if s == nil {
+		return false
+	}
+	return s.status == statAgent || s.status == statRunning
+}
+
+// Commands.
+
+type suggestionMsg struct {
+	id    stepID
+	value string
+	err   error
+}
+
+type actionMsg struct {
+	id  stepID
+	err error
+}
+
+type spinnerTickMsg struct{}
+
+const spinnerInterval = 120 * time.Millisecond
+
+func (m *Model) scheduleSpinner() tea.Cmd {
+	if m.spinnerAlive {
+		return nil
+	}
+	m.spinnerAlive = true
+	return tea.Tick(spinnerInterval, func(time.Time) tea.Msg { return spinnerTickMsg{} })
+}
+
+func (m Model) suggestCmd(id stepID) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		switch id {
+		case stepBranch:
+			if m.cfg.SuggestBranch == nil {
+				return suggestionMsg{id: id, err: errors.New("no branch suggester configured")}
+			}
+			v, err := m.cfg.SuggestBranch(ctx)
+			return suggestionMsg{id: id, value: v, err: err}
+		case stepCommit:
+			if m.cfg.SuggestCommit == nil {
+				return suggestionMsg{id: id, err: errors.New("no commit suggester configured")}
+			}
+			v, err := m.cfg.SuggestCommit(ctx)
+			return suggestionMsg{id: id, value: v, err: err}
+		}
+		return suggestionMsg{id: id, err: errors.New("unknown step")}
+	}
+}
+
+func (m Model) runCreateBranch(name string) tea.Cmd {
+	return func() tea.Msg {
+		err := m.cfg.CreateBranch(context.Background(), name)
+		return actionMsg{id: stepBranch, err: err}
+	}
+}
+
+func (m Model) runCommit(msg string) tea.Cmd {
+	return func() tea.Msg {
+		err := m.cfg.CommitAll(context.Background(), msg)
+		return actionMsg{id: stepCommit, err: err}
+	}
+}
+
+func (m Model) runPush() tea.Cmd {
+	branch := m.targetBranch
+	return func() tea.Msg {
+		err := m.cfg.Push(context.Background(), branch)
+		return actionMsg{id: stepPush, err: err}
+	}
+}
+
+// Run invokes the wizard as an interactive bubbletea program. Returns the
+// terminal Result describing what happened.
+func Run(cfg Config) (Result, error) {
+	m := NewModel(cfg)
+	p := tea.NewProgram(m, tea.WithAltScreen())
+	final, err := p.Run()
+	if err != nil {
+		return Result{Err: err}, err
+	}
+	fm, ok := final.(Model)
+	if !ok {
+		return Result{}, errors.New("wizard: unexpected terminal model type")
+	}
+	return fm.Result(), nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n < 1 {
+		return ""
+	}
+	return s[:n-1] + "…"
+}

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -457,14 +457,14 @@ func (m Model) suggestCmd(id stepID) tea.Cmd {
 
 func (m Model) runCreateBranch(name string) tea.Cmd {
 	return func() tea.Msg {
-		err := m.cfg.CreateBranch(context.Background(), name)
+		err := m.cfg.CreateBranch(m.ctx, name)
 		return actionMsg{id: stepBranch, err: err}
 	}
 }
 
 func (m Model) runCommit(msg string) tea.Cmd {
 	return func() tea.Msg {
-		err := m.cfg.CommitAll(context.Background(), msg)
+		err := m.cfg.CommitAll(m.ctx, msg)
 		return actionMsg{id: stepCommit, err: err}
 	}
 }
@@ -472,7 +472,7 @@ func (m Model) runCommit(msg string) tea.Cmd {
 func (m Model) runPush() tea.Cmd {
 	branch := m.targetBranch
 	return func() tea.Msg {
-		err := m.cfg.Push(context.Background(), branch)
+		err := m.cfg.Push(m.ctx, branch)
 		return actionMsg{id: stepPush, err: err}
 	}
 }

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -1,0 +1,442 @@
+package wizard
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// recording stubs capture calls for assertions.
+type recorder struct {
+	createdBranch string
+	commitMsg     string
+	pushedBranch  string
+
+	createBranchErr error
+	commitErr       error
+	pushErr         error
+
+	suggestBranch    string
+	suggestCommit    string
+	suggestBranchErr error
+	suggestCommitErr error
+}
+
+func (r *recorder) deps() Config {
+	return Config{
+		CreateBranch: func(_ context.Context, name string) error {
+			r.createdBranch = name
+			return r.createBranchErr
+		},
+		CommitAll: func(_ context.Context, msg string) error {
+			r.commitMsg = msg
+			return r.commitErr
+		},
+		Push: func(_ context.Context, branch string) error {
+			r.pushedBranch = branch
+			return r.pushErr
+		},
+		SuggestBranch: func(_ context.Context) (string, error) {
+			return r.suggestBranch, r.suggestBranchErr
+		},
+		SuggestCommit: func(_ context.Context) (string, error) {
+			return r.suggestCommit, r.suggestCommitErr
+		},
+	}
+}
+
+func baseConfig(r *recorder) Config {
+	cfg := r.deps()
+	cfg.RepoDir = "/tmp/repo"
+	cfg.CurrentBranch = "main"
+	cfg.DefaultBranch = "main"
+	cfg.NeedsBranch = true
+	cfg.IsDirty = true
+	cfg.GateRemote = "no-mistakes"
+	return cfg
+}
+
+// step the model through a command synchronously by running the returned
+// Cmd and feeding the result back into Update.
+func drain(m Model, cmd tea.Cmd) Model {
+	for cmd != nil {
+		msg := cmd()
+		if msg == nil {
+			return m
+		}
+		// Skip timer ticks - they'd spin forever in tests.
+		if _, ok := msg.(spinnerTickMsg); ok {
+			return m
+		}
+		// Skip batched commands from bubbles/textinput (e.g. Blink).
+		if batch, ok := msg.(tea.BatchMsg); ok {
+			for _, c := range batch {
+				m = drain(m, c)
+			}
+			return m
+		}
+		next, nextCmd := m.Update(msg)
+		m = next.(Model)
+		cmd = nextCmd
+	}
+	return m
+}
+
+func advance(m Model, msg tea.Msg) Model {
+	next, cmd := m.Update(msg)
+	return drain(next.(Model), cmd)
+}
+
+func TestNewModel_AllStepsPending(t *testing.T) {
+	m := NewModel(baseConfig(&recorder{}))
+	if m.steps[0].status != statInput {
+		t.Errorf("active branch step should be in input mode, got %v", m.steps[0].status)
+	}
+	if m.steps[1].status != statPending {
+		t.Errorf("commit should be pending when dirty, got %v", m.steps[1].status)
+	}
+	if m.steps[2].status != statPending {
+		t.Errorf("push should be pending initially, got %v", m.steps[2].status)
+	}
+	if m.active != 0 {
+		t.Errorf("first active step should be branch (0), got %d", m.active)
+	}
+}
+
+func TestNewModel_SkipsBranchOnFeatureBranch(t *testing.T) {
+	cfg := baseConfig(&recorder{})
+	cfg.CurrentBranch = "feat/existing"
+	cfg.NeedsBranch = false
+	m := NewModel(cfg)
+	if m.steps[0].status != statSkipped {
+		t.Fatalf("expected branch skipped, got %v", m.steps[0].status)
+	}
+	if !strings.Contains(m.steps[0].skipReason, "feat/existing") {
+		t.Fatalf("skip reason should mention branch, got %q", m.steps[0].skipReason)
+	}
+	if m.active != 1 {
+		t.Fatalf("first active should be commit, got %d", m.active)
+	}
+}
+
+func TestNewModel_SkipsCommitWhenClean(t *testing.T) {
+	cfg := baseConfig(&recorder{})
+	cfg.IsDirty = false
+	m := NewModel(cfg)
+	if m.steps[1].status != statSkipped {
+		t.Fatalf("expected commit skipped, got %v", m.steps[1].status)
+	}
+}
+
+func TestNewModel_SkipsBothWhenOnFeatureAndClean(t *testing.T) {
+	cfg := baseConfig(&recorder{})
+	cfg.CurrentBranch = "feat/x"
+	cfg.NeedsBranch = false
+	cfg.IsDirty = false
+	m := NewModel(cfg)
+	if m.active != 2 {
+		t.Fatalf("expected push to be first active, got %d", m.active)
+	}
+}
+
+func TestNewModel_DetachedHEADForcesBranchStep(t *testing.T) {
+	// Simulates detached HEAD: CurrentBranch literally "HEAD" but caller
+	// set NeedsBranch=true to force the branch step to run.
+	cfg := baseConfig(&recorder{})
+	cfg.CurrentBranch = "HEAD"
+	cfg.DefaultBranch = "main"
+	cfg.NeedsBranch = true
+	cfg.IsDirty = false
+	m := NewModel(cfg)
+
+	if m.steps[0].status == statSkipped {
+		t.Fatal("branch step should NOT be skipped in detached HEAD")
+	}
+	if m.active != 0 {
+		t.Fatalf("expected branch to be first active, got %d", m.active)
+	}
+}
+
+func TestBranchStep_UserTyped(t *testing.T) {
+	r := &recorder{}
+	m := NewModel(baseConfig(r))
+	m = drain(m, m.Init())
+
+	// Type a name.
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("feat/wizard")})
+	m = advance(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	// After running the create-branch cmd, handleAction advances.
+	if r.createdBranch != "feat/wizard" {
+		t.Fatalf("expected CreateBranch called with feat/wizard, got %q", r.createdBranch)
+	}
+	if m.steps[0].status != statDone {
+		t.Fatalf("expected branch done, got %v", m.steps[0].status)
+	}
+	if !m.branchCreated {
+		t.Fatal("expected branchCreated = true")
+	}
+	if m.targetBranch != "feat/wizard" {
+		t.Fatalf("expected targetBranch feat/wizard, got %q", m.targetBranch)
+	}
+	if m.active != 1 {
+		t.Fatalf("expected active to be commit, got %d", m.active)
+	}
+}
+
+func TestBranchStep_BlankUsesAgent(t *testing.T) {
+	r := &recorder{suggestBranch: "fix/agent-name"}
+	m := NewModel(baseConfig(r))
+	m = drain(m, m.Init())
+
+	// Press enter with blank input.
+	m = advance(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if r.createdBranch != "fix/agent-name" {
+		t.Fatalf("expected agent suggestion used, got %q", r.createdBranch)
+	}
+	if m.targetBranch != "fix/agent-name" {
+		t.Fatalf("targetBranch should be agent suggestion, got %q", m.targetBranch)
+	}
+}
+
+func TestBranchStep_SuggestionFailureFallsBackToInput(t *testing.T) {
+	r := &recorder{suggestBranchErr: errors.New("agent down")}
+	m := NewModel(baseConfig(r))
+	m = drain(m, m.Init())
+
+	m = advance(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if m.steps[0].status != statInput {
+		t.Fatalf("expected fallback to input, got %v", m.steps[0].status)
+	}
+	if !strings.Contains(m.input.Placeholder, "agent unavailable") {
+		t.Fatalf("expected placeholder to mention agent failure, got %q", m.input.Placeholder)
+	}
+	if r.createdBranch != "" {
+		t.Fatalf("should not have called CreateBranch, got %q", r.createdBranch)
+	}
+}
+
+func TestCommitStep_UserTyped(t *testing.T) {
+	cfg := baseConfig(&recorder{})
+	cfg.CurrentBranch = "feat/x" // skip branch
+	cfg.NeedsBranch = false
+	r := &recorder{}
+	cfg2 := cfg
+	cfg2.CreateBranch = r.deps().CreateBranch
+	cfg2.CommitAll = r.deps().CommitAll
+	cfg2.Push = r.deps().Push
+	cfg2.SuggestBranch = r.deps().SuggestBranch
+	cfg2.SuggestCommit = r.deps().SuggestCommit
+	m := NewModel(cfg2)
+	m = drain(m, m.Init())
+
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("feat: add x")})
+	m = advance(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if r.commitMsg != "feat: add x" {
+		t.Fatalf("expected commit message, got %q", r.commitMsg)
+	}
+	if !m.commitMade {
+		t.Fatal("expected commitMade = true")
+	}
+	if m.steps[1].status != statDone {
+		t.Fatalf("expected commit done, got %v", m.steps[1].status)
+	}
+	if m.active != 2 {
+		t.Fatalf("expected push active, got %d", m.active)
+	}
+}
+
+func TestPushStep_Confirm(t *testing.T) {
+	cfg := baseConfig(&recorder{})
+	cfg.CurrentBranch = "feat/x" // skip branch
+	cfg.NeedsBranch = false
+	cfg.IsDirty = false // skip commit
+	r := &recorder{}
+	cfg.CreateBranch = r.deps().CreateBranch
+	cfg.CommitAll = r.deps().CommitAll
+	cfg.Push = r.deps().Push
+	cfg.SuggestBranch = r.deps().SuggestBranch
+	cfg.SuggestCommit = r.deps().SuggestCommit
+	m := NewModel(cfg)
+	m = drain(m, m.Init())
+
+	if m.active != 2 {
+		t.Fatalf("active should be push, got %d", m.active)
+	}
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+
+	if r.pushedBranch != "feat/x" {
+		t.Fatalf("expected Push for feat/x, got %q", r.pushedBranch)
+	}
+	if !m.pushed {
+		t.Fatal("expected pushed = true")
+	}
+	if !m.quitting {
+		t.Fatal("wizard should quit after final step")
+	}
+	if !m.success {
+		t.Fatal("wizard should report success")
+	}
+}
+
+func TestPushStep_DeclineAborts(t *testing.T) {
+	cfg := baseConfig(&recorder{})
+	cfg.CurrentBranch = "feat/x"
+	cfg.NeedsBranch = false
+	cfg.IsDirty = false
+	r := &recorder{}
+	cfg.CreateBranch = r.deps().CreateBranch
+	cfg.CommitAll = r.deps().CommitAll
+	cfg.Push = r.deps().Push
+	cfg.SuggestBranch = r.deps().SuggestBranch
+	cfg.SuggestCommit = r.deps().SuggestCommit
+	m := NewModel(cfg)
+	m = drain(m, m.Init())
+
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+
+	if r.pushedBranch != "" {
+		t.Fatalf("Push should not have run, got %q", r.pushedBranch)
+	}
+	if !m.aborted {
+		t.Fatal("expected aborted = true")
+	}
+	if m.success {
+		t.Fatal("declining push should not be success")
+	}
+}
+
+func TestActionFailure(t *testing.T) {
+	r := &recorder{createBranchErr: errors.New("branch exists")}
+	m := NewModel(baseConfig(r))
+	m = drain(m, m.Init())
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("dup")})
+	m = advance(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if m.steps[0].status != statFailed {
+		t.Fatalf("expected failed, got %v", m.steps[0].status)
+	}
+	if m.steps[0].errMsg == "" {
+		t.Fatal("expected error message")
+	}
+}
+
+func TestRetryAfterFailure(t *testing.T) {
+	r := &recorder{createBranchErr: errors.New("branch exists")}
+	m := NewModel(baseConfig(r))
+	m = drain(m, m.Init())
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("dup")})
+	m = advance(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.steps[0].status != statFailed {
+		t.Fatalf("precondition: expected failed, got %v", m.steps[0].status)
+	}
+
+	// Clear the error and press r to retry.
+	r.createBranchErr = nil
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("r")})
+	if m.steps[0].status != statInput {
+		t.Fatalf("expected retry to re-enter input, got %v", m.steps[0].status)
+	}
+
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("fresh")})
+	m = advance(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if m.steps[0].status != statDone {
+		t.Fatalf("expected retry to succeed, got %v", m.steps[0].status)
+	}
+}
+
+func TestQuit_NoSideEffects_SinglePress(t *testing.T) {
+	m := NewModel(baseConfig(&recorder{}))
+	m = drain(m, m.Init())
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	if !m.aborted || !m.quitting {
+		t.Fatal("single q with no side-effects should quit immediately")
+	}
+}
+
+func TestQuit_WithSideEffects_RequiresConfirm(t *testing.T) {
+	r := &recorder{}
+	m := NewModel(baseConfig(r))
+	m = drain(m, m.Init())
+	// Complete branch step (side-effect).
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("feat/x")})
+	m = advance(m, tea.KeyMsg{Type: tea.KeyEnter})
+	if !m.branchCreated {
+		t.Fatal("precondition: branch should be created")
+	}
+
+	// First q sets confirm, does not quit.
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	if m.quitting {
+		t.Fatal("first q should not quit when there are side-effects")
+	}
+	if !m.confirmQuit {
+		t.Fatal("first q should set confirmQuit")
+	}
+
+	// Second q actually quits.
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	if !m.aborted || !m.quitting {
+		t.Fatal("second q should abort")
+	}
+}
+
+func TestConfirmQuit_ResetsOnOtherKey(t *testing.T) {
+	r := &recorder{}
+	m := NewModel(baseConfig(r))
+	m = drain(m, m.Init())
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("feat/x")})
+	m = advance(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	if !m.confirmQuit {
+		t.Fatal("expected confirmQuit set")
+	}
+	// Any other key resets.
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
+	if m.confirmQuit {
+		t.Fatal("non-q key should clear confirmQuit")
+	}
+}
+
+func TestCtrlCAborts(t *testing.T) {
+	m := NewModel(baseConfig(&recorder{}))
+	m = drain(m, m.Init())
+	m = advance(m, tea.KeyMsg{Type: tea.KeyCtrlC})
+	if !m.aborted || !m.quitting {
+		t.Fatal("ctrl+c should abort regardless of side-effects")
+	}
+}
+
+func TestResult(t *testing.T) {
+	cfg := baseConfig(&recorder{})
+	cfg.CurrentBranch = "feat/x"
+	cfg.NeedsBranch = false
+	cfg.IsDirty = false
+	r := &recorder{}
+	cfg.CreateBranch = r.deps().CreateBranch
+	cfg.CommitAll = r.deps().CommitAll
+	cfg.Push = r.deps().Push
+	cfg.SuggestBranch = r.deps().SuggestBranch
+	cfg.SuggestCommit = r.deps().SuggestCommit
+	m := NewModel(cfg)
+	m = drain(m, m.Init())
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+
+	res := m.Result()
+	if !res.Success {
+		t.Fatal("expected Success")
+	}
+	if !res.Pushed {
+		t.Fatal("expected Pushed")
+	}
+	if res.TargetBranch != "feat/x" {
+		t.Fatalf("expected TargetBranch feat/x, got %q", res.TargetBranch)
+	}
+}

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -402,6 +403,55 @@ func TestConfirmQuit_ResetsOnOtherKey(t *testing.T) {
 	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("x")})
 	if m.confirmQuit {
 		t.Fatal("non-q key should clear confirmQuit")
+	}
+}
+
+func TestQuit_CancelsInFlightSuggestion(t *testing.T) {
+	ctxCh := make(chan context.Context, 1)
+	done := make(chan tea.Msg, 1)
+
+	cfg := baseConfig(&recorder{})
+	cfg.SuggestBranch = func(ctx context.Context) (string, error) {
+		ctxCh <- ctx
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+
+	m := NewModel(cfg)
+	cmd := m.suggestCmd(stepBranch)
+	go func() {
+		done <- cmd()
+	}()
+
+	var suggestCtx context.Context
+	select {
+	case suggestCtx = <-ctxCh:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for suggestion to start")
+	}
+
+	if err := suggestCtx.Err(); err != nil {
+		t.Fatalf("suggestion context should start active, got %v", err)
+	}
+
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	m = next.(Model)
+
+	if !m.aborted || !m.quitting {
+		t.Fatal("quit should abort the wizard")
+	}
+
+	select {
+	case msg := <-done:
+		suggestion, ok := msg.(suggestionMsg)
+		if !ok {
+			t.Fatalf("expected suggestionMsg, got %T", msg)
+		}
+		if !errors.Is(suggestion.err, context.Canceled) {
+			t.Fatalf("expected context canceled, got %v", suggestion.err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for suggestion cancellation")
 	}
 }
 

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -455,6 +455,85 @@ func TestQuit_CancelsInFlightSuggestion(t *testing.T) {
 	}
 }
 
+func TestQuit_CancelsInFlightGitActions(t *testing.T) {
+	tests := []struct {
+		name    string
+		run     func(Model, string) tea.Cmd
+		wantMsg stepID
+	}{
+		{name: "create branch", run: func(m Model, value string) tea.Cmd { return m.runCreateBranch(value) }, wantMsg: stepBranch},
+		{name: "commit", run: func(m Model, value string) tea.Cmd { return m.runCommit(value) }, wantMsg: stepCommit},
+		{name: "push", run: func(m Model, value string) tea.Cmd { return m.runPush() }, wantMsg: stepPush},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctxCh := make(chan context.Context, 1)
+			done := make(chan tea.Msg, 1)
+
+			cfg := baseConfig(&recorder{})
+			cfg.CurrentBranch = "feat/x"
+			cfg.NeedsBranch = false
+			cfg.IsDirty = false
+			cfg.CreateBranch = func(ctx context.Context, _ string) error {
+				ctxCh <- ctx
+				<-ctx.Done()
+				return ctx.Err()
+			}
+			cfg.CommitAll = func(ctx context.Context, _ string) error {
+				ctxCh <- ctx
+				<-ctx.Done()
+				return ctx.Err()
+			}
+			cfg.Push = func(ctx context.Context, _ string) error {
+				ctxCh <- ctx
+				<-ctx.Done()
+				return ctx.Err()
+			}
+
+			m := NewModel(cfg)
+			cmd := tc.run(m, "value")
+			go func() {
+				done <- cmd()
+			}()
+
+			var actionCtx context.Context
+			select {
+			case actionCtx = <-ctxCh:
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for action to start")
+			}
+
+			if err := actionCtx.Err(); err != nil {
+				t.Fatalf("action context should start active, got %v", err)
+			}
+
+			next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+			m = next.(Model)
+
+			if !m.aborted || !m.quitting {
+				t.Fatal("quit should abort the wizard")
+			}
+
+			select {
+			case msg := <-done:
+				action, ok := msg.(actionMsg)
+				if !ok {
+					t.Fatalf("expected actionMsg, got %T", msg)
+				}
+				if action.id != tc.wantMsg {
+					t.Fatalf("expected action id %v, got %v", tc.wantMsg, action.id)
+				}
+				if !errors.Is(action.err, context.Canceled) {
+					t.Fatalf("expected context canceled, got %v", action.err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for action cancellation")
+			}
+		})
+	}
+}
+
 func TestCtrlCAborts(t *testing.T) {
 	m := NewModel(baseConfig(&recorder{}))
 	m = drain(m, m.Init())


### PR DESCRIPTION
## Summary
- Add a new interactive setup wizard that bare `no-mistakes` can launch when the current branch has no active run, guiding branch creation, commit creation, and gated push before attaching.
- Use the configured agent for optional branch-name and commit-subject suggestions, and harden the flow with cancellation, error propagation, attach fallback, and git validation fixes discovered during review.
- Update CLI, TUI, daemon, configuration, and README/docs content so the new branch-scoped root-command behavior and wizard logging/suggestion semantics are documented.

## Risk Assessment

⚠️ Medium: The change is well-bounded, but the new default wizard path can accidentally commit unintended files and can hide failed git operations behind a successful process exit.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 2 warnings</summary>

**Round 1** - found 3 warnings
- ⚠️ `internal/cli/attach.go:77` - `attachRun` is shared by bare `no-mistakes` and the explicit `no-mistakes attach` subcommand, but the new branch-scoped `GetActiveRun` lookup means `no-mistakes attach` no longer attaches to an existing active run on another branch in the same repo. That changes the documented behavior of the explicit attach command, which used to fall back to any active run.
- ⚠️ `internal/wizard/wizard.go:450` - The branch/commit/push commands all run with `context.Background()`, so quitting the wizard does not cancel an in-flight git operation. A slow `git push` can still complete after the UI reports an abort, which makes the wizard&#39;s quit/abort semantics misleading.
- ⚠️ `internal/cli/wizard.go:85` - `runWizard` resolves config and constructs an agent before the UI starts, even for flows that never need a suggestion (for example a clean feature branch that only needs a push, or when the user types branch/commit text manually). A missing or broken agent configuration therefore blocks manual-only wizard flows unnecessarily.

**Round 2** (auto-fix) - found 2 warnings
- ⚠️ `internal/cli/attach.go:89` - This branch now launches the setup wizard for any interactive `no-mistakes` invocation with no active run, including a clean feature branch. In that case the wizard can collapse to a bare `git push`; if the branch is already at the gate tip, the push is a no-op, no post-receive hook fires, and the flow falls through to `No active run` instead of starting anything useful. Is that intended, or should clean/no-change branches stay on the old attach-or-hint path?
- ⚠️ `internal/wizard/wizard.go:428` - `suggestCmd` creates its own `context.Background()` timeout, so quitting the wizard does not cancel an in-flight branch or commit suggestion. On slower agents this can keep the request running for up to 60 seconds after the UI exits, leaving the managed server busy and still appending to the wizard log.

**Round 3** (auto-fix) - found 3 issues (1 error, 2 warnings)
- 🚨 `internal/cli/wizard.go:94` - `runWizard` now resolves and constructs an agent before launching the wizard, even when the current flow only needs the push confirmation step. On machines without a configured/supported agent, bare `no-mistakes` will fail outright instead of letting the user manually push or type their own inputs, which turns an optional suggestion feature into a hard startup dependency.
- ⚠️ `internal/wizard/wizard.go:460` - The branch, commit, and push commands all run with `context.Background()` instead of the wizard&#39;s cancellable context, so `q`/`ctrl+c` cannot interrupt a hung `git checkout`, `git commit`, or `git push`. This leaves the new interactive flow stuck until the subprocess exits on its own.
- ⚠️ `internal/agent/suggest.go:122` - `sanitizeBranchName` still permits ref forms that Git rejects, such as repeated slashes, `..`, or a `.lock` path component, so an agent-generated suggestion can pass sanitization and then fail at `git checkout -b`. Validate the final name with Git&#39;s ref-format rules before returning it.

**Round 4** (auto-fix) - found 2 warnings
- ⚠️ `internal/git/git.go:242` - `CommitAll` blindly runs `git add -A`, so the new wizard path will commit every untracked file in the repo, including accidentally-created secrets or local artifacts that were never reviewed. That is a security footgun for a default-path onboarding flow.
- ⚠️ `internal/wizard/wizard.go:379` - Step failures are only copied into `step.errMsg`; `Model.Result().Err` stays nil, so if the user quits after a failed branch/commit/push action the caller sees a clean nil result and the CLI exits 0. That makes operational failures easy to miss and breaks shell-level error handling.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>🔧 **Document** - 5 issues found → auto-fixed (8)</summary>

**Round 1** - found 5 issues (4 warnings, 1 info)
- ⚠️ `README.md:157` - The README CLI reference still describes bare `no-mistakes` as only attaching to the active run, but the root command now also launches the interactive setup wizard in TTY sessions when no attachable run exists. Add the new branch/commit/push onboarding behavior so the top-level command docs match the feature.
- ⚠️ `docs/src/content/docs/reference/cli.md:8` - The `no-mistakes` command reference is stale: it says the no-run fallback is just showing the last 5 runs inline, but the command now starts the setup wizard in interactive repo sessions with no active run and can attach after that push. Update this section to document the wizard path and when the old inline fallback still applies.
- ⚠️ `docs/src/content/docs/reference/cli.md:50` - The `no-mistakes attach` docs still say it opens the active run on the current branch, but the command now does a repo-wide active-run lookup unless `--run` is provided. Document that branch-agnostic behavior and contrast it with bare `no-mistakes`, which stays branch-scoped before invoking the wizard.
- ⚠️ `docs/src/content/docs/getting-started.md:85` - The getting-started guide says `no-mistakes` or `no-mistakes attach` simply opens the TUI, but after this change bare `no-mistakes` can instead walk the user through creating a branch, committing changes, and pushing through the gate when no run exists yet. Add that setup-wizard path so first-run behavior is documented.
- ℹ️ `docs/src/content/docs/guides/agents.md:6` - The agents guide still limits agent responsibilities to review, test/lint detection, and auto-fixing, but the new setup wizard also uses the configured agent to suggest branch names and commit subjects when those prompts are left blank. Update the guide so this new user-facing agent integration is discoverable.

**Round 2** (auto-fix) - found 5 warnings
- ⚠️ `docs/src/content/docs/guides/tui.md:155` - The TUI guide still tells users to run `no-mistakes` to reattach, but this commit makes bare `no-mistakes` branch-scoped and able to launch the setup wizard instead of reattaching. Update the guide to explain the new root-command behavior and point users to `no-mistakes attach` when they want a repo-wide reattach path.
- ⚠️ `docs/src/content/docs/guides/daemon.md:6` - The daemon guide&#39;s &#34;commands that keep the daemon running&#34; text and examples were not updated for the new root-command flow. Bare `no-mistakes` now goes through the attach/setup-wizard path and also ensures the daemon is running, so this command list is stale.
- ⚠️ `docs/src/content/docs/how-it-works.md:61` - The architecture guide still says only `init`, `attach`, `rerun`, and `update` ensure the daemon is running. After this change, bare `no-mistakes` also enters the attach/setup-wizard flow and should be included in that documentation.
- ⚠️ `docs/src/content/docs/how-it-works.md:95` - The local-state table only documents per-run step logs and `logs/daemon.log`, but the new setup wizard writes managed-agent output to `~/.no-mistakes/logs/wizard-agent.log`. Add that file to the documented state layout.
- ⚠️ `docs/src/content/docs/guides/daemon.md:59` - The logging section is now incomplete: the setup wizard captures managed agent-server output in `~/.no-mistakes/logs/wizard-agent.log`, but only daemon and per-step logs are documented here.

**Round 3** (auto-fix) - found 2 warnings
- ⚠️ `docs/src/content/docs/reference/cli.md:8` - The `no-mistakes` reference still opens with &#34;Attach to the active pipeline run for the current repo,&#34; but the new root-command behavior is branch-scoped first: bare `no-mistakes` only auto-attaches to an active run on the current branch, and otherwise falls back to the setup wizard or recent-runs output. That opening sentence should be updated so it does not imply repo-wide attach semantics.
- ⚠️ `docs/src/content/docs/guides/tui.md:6` - The new setup wizard launched by bare `no-mistakes` is not documented in the UI guides. Users now get a separate full-screen flow with Branch/Commit/Push steps, blank-input agent suggestions, `y`/`n` push confirmation, `r` retry on step failure, and `q` double-confirm once branch or commit side effects exist, but there is no guide section covering that behavior even though getting-started now routes users into it.

**Round 4** (auto-fix) - found 1 warning
- ⚠️ `internal/cli/root.go:36` - The inline doc comment is stale: bare `no-mistakes` no longer only defaults to attach behavior. It can now also launch the setup wizard when there is no active run for the current branch in an interactive TTY, so this comment should be updated to reflect the new routing behavior.

**Round 5** (auto-fix) - found 1 warning
- ⚠️ `docs/src/content/docs/reference/cli.md:140` - The `no-mistakes daemon stop` reference still says only `daemon start`, `init`, `attach`, `rerun`, or `update` will restart the daemon later. This change also makes bare `no-mistakes` ensure the daemon is running, so that restart list is now stale and should include `no-mistakes`.

**Round 6** (auto-fix) - found 1 warning
- ⚠️ `docs/src/content/docs/reference/cli.md:14` - The CLI reference still says bare `no-mistakes` is equivalent to `no-mistakes attach` when the current branch has an active run. That is no longer reliably true after this change: `no-mistakes` stays branch-scoped, while `no-mistakes attach` now falls back to the most recent active run anywhere in the repo. This line should be rewritten to describe the branch-scoped vs repo-scoped difference instead of claiming equivalence.

**Round 7** (auto-fix) - found 2 warnings
- ⚠️ `README.md:43` - The README quick-start still documents only the manual `git push no-mistakes` flow. This change adds a user-facing setup wizard on bare `no-mistakes` that can create a branch, commit local changes, and push through the gate when no current-branch run exists, so the top-level getting-started section should document that new workflow too.
- ⚠️ `docs/src/content/docs/index.mdx:20` - The docs landing page still presents `no-mistakes` only as an explicit gated-push tool. The new bare-`no-mistakes` setup wizard is a top-level workflow change, but the homepage does not mention or link to it, so users entering through the docs index will miss that the CLI can bootstrap a branch, commit, and push before opening the TUI.

**Round 8** (auto-fix) - found 5 warnings
- ⚠️ `docs/src/content/docs/reference/cli.md:8` - The `no-mistakes` command reference still opens with &#34;Attach to the active pipeline run for the current repo,&#34; but this change makes bare `no-mistakes` branch-scoped first and able to launch the setup wizard. Reword the lead sentence so it matches the new behavior instead of the old repo-wide attach semantics.
- ⚠️ `README.md:195` - The README config section still documents `agent` only as the default/override agent for repos. Since the setup wizard now uses the configured agent to suggest branch names and commit subjects, the config docs here should mention that `agent` also controls wizard suggestions.
- ⚠️ `docs/src/content/docs/guides/configuration.md:22` - The configuration guide&#39;s `agent` examples and comments do not mention that the selected agent now powers setup-wizard suggestions when branch or commit prompts are left blank. Update this guide so the meaning of `agent` matches the new wizard behavior.
- ⚠️ `docs/src/content/docs/reference/global-config.md:36` - The global config reference describes `agent` only as the default agent for repos. After this change, it also determines which agent the setup wizard uses for branch-name and commit-subject suggestions, so that should be documented in the field description.
- ⚠️ `docs/src/content/docs/reference/repo-config.md:35` - The repo config reference says `agent` only overrides the default agent for the repo, but repo-level `agent` now also affects setup-wizard suggestions in that repo. Update the field description to cover the wizard behavior.

**Round 9** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
