### PR TITLE
feat(telemetry): add CLI and pipeline telemetry tracking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,7 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           TAG: ${{ needs.release-please.outputs.tag_name }}
           VERSION: ${{ needs.release-please.outputs.version }}
+          UMAMI_WEBSITE_ID: ${{ vars.UMAMI_WEBSITE_ID }}
         run: |
           set -euo pipefail
           mkdir -p dist
@@ -117,7 +118,7 @@ jobs:
             OUT="dist/${BIN}"
           fi
           CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" \
-            go build -ldflags "-X github.com/kunchenguid/no-mistakes/internal/buildinfo.Version=${TAG} -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Commit=${COMMIT} -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Date=${DATE}" \
+            go build -ldflags "-X github.com/kunchenguid/no-mistakes/internal/buildinfo.Version=${TAG} -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Commit=${COMMIT} -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Date=${DATE} -X github.com/kunchenguid/no-mistakes/internal/buildinfo.TelemetryWebsiteID=${UMAMI_WEBSITE_ID}" \
             -o "$OUT" ./cmd/no-mistakes
           if [ "$GOOS" = "windows" ]; then
             ARCHIVE="dist/no-mistakes-${TAG}-${GOOS}-${GOARCH}.zip"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 DATE    ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
--include .env
-DOTENV_UMAMI_WEBSITE_ID := $(patsubst "%",%,$(patsubst '%',%,$(strip $(NO_MISTAKES_UMAMI_WEBSITE_ID))))
+DOTENV_UMAMI_WEBSITE_ID_RAW := $(shell [ -f .env ] && sed -nE 's/^[[:space:]]*(export[[:space:]]+)?NO_MISTAKES_UMAMI_WEBSITE_ID[[:space:]]*=[[:space:]]*//p' .env | tail -n 1)
+DOTENV_UMAMI_WEBSITE_ID := $(patsubst "%",%,$(patsubst '%',%,$(strip $(DOTENV_UMAMI_WEBSITE_ID_RAW))))
 override UMAMI_WEBSITE_ID := $(if $(DOTENV_UMAMI_WEBSITE_ID),$(DOTENV_UMAMI_WEBSITE_ID),$(UMAMI_WEBSITE_ID))
 LDFLAGS := -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Version=$(VERSION) \
            -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Commit=$(COMMIT) \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 DATE    ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
-DOTENV_UMAMI_WEBSITE_ID_RAW := $(shell [ -f .env ] && sed -nE 's/^[[:space:]]*(export[[:space:]]+)?NO_MISTAKES_UMAMI_WEBSITE_ID[[:space:]]*=[[:space:]]*//p' .env | tail -n 1 | sed -E 's/[[:space:]]+\#.*$$//; s/[[:space:]]+$$//')
-DOTENV_UMAMI_WEBSITE_ID := $(patsubst "%",%,$(patsubst '%',%,$(strip $(DOTENV_UMAMI_WEBSITE_ID_RAW))))
+DOTENV_UMAMI_WEBSITE_ID := $(shell [ -f .env ] && perl -ne 'next if /^\s*(?:\#|$$)/; s/^\s*export\s+//; next unless /^\s*NO_MISTAKES_UMAMI_WEBSITE_ID\s*=\s*(.*)$$/; $$v=$$1; $$v =~ s/^\s+|\s+$$//g; if ($$v =~ /^(["\x27])(.*)\1$$/) { $$v=$$2; } else { $$v =~ s/\s+\#.*$$//; $$v =~ s/\s+$$//; } $$out=$$v; END { print $$out if defined $$out }' .env)
 override UMAMI_WEBSITE_ID := $(if $(DOTENV_UMAMI_WEBSITE_ID),$(DOTENV_UMAMI_WEBSITE_ID),$(UMAMI_WEBSITE_ID))
 LDFLAGS := -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Version=$(VERSION) \
            -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Commit=$(COMMIT) \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 DATE    ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
-DOTENV_UMAMI_WEBSITE_ID_RAW := $(shell [ -f .env ] && sed -nE 's/^[[:space:]]*(export[[:space:]]+)?NO_MISTAKES_UMAMI_WEBSITE_ID[[:space:]]*=[[:space:]]*//p' .env | tail -n 1)
+DOTENV_UMAMI_WEBSITE_ID_RAW := $(shell [ -f .env ] && sed -nE 's/^[[:space:]]*(export[[:space:]]+)?NO_MISTAKES_UMAMI_WEBSITE_ID[[:space:]]*=[[:space:]]*//p' .env | tail -n 1 | sed -E 's/[[:space:]]+\#.*$$//; s/[[:space:]]+$$//')
 DOTENV_UMAMI_WEBSITE_ID := $(patsubst "%",%,$(patsubst '%',%,$(strip $(DOTENV_UMAMI_WEBSITE_ID_RAW))))
 override UMAMI_WEBSITE_ID := $(if $(DOTENV_UMAMI_WEBSITE_ID),$(DOTENV_UMAMI_WEBSITE_ID),$(UMAMI_WEBSITE_ID))
 LDFLAGS := -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Version=$(VERSION) \

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,13 @@
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 DATE    ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+-include .env
+DOTENV_UMAMI_WEBSITE_ID := $(patsubst "%",%,$(patsubst '%',%,$(strip $(NO_MISTAKES_UMAMI_WEBSITE_ID))))
+override UMAMI_WEBSITE_ID := $(if $(DOTENV_UMAMI_WEBSITE_ID),$(DOTENV_UMAMI_WEBSITE_ID),$(UMAMI_WEBSITE_ID))
 LDFLAGS := -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Version=$(VERSION) \
            -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Commit=$(COMMIT) \
-           -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Date=$(DATE)
+           -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Date=$(DATE) \
+           -X github.com/kunchenguid/no-mistakes/internal/buildinfo.TelemetryWebsiteID=$(UMAMI_WEBSITE_ID)
 
 .PHONY: build dist install test lint fmt clean docs docs-build docs-preview demo
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/i
 
 Windows, Go install, and build-from-source instructions are in the [installation guide](https://kunchenguid.github.io/no-mistakes/start-here/installation/).
 
+Release builds may send telemetry when a telemetry website ID is embedded at build time. Local builds can opt in by setting `UMAMI_WEBSITE_ID` or `NO_MISTAKES_UMAMI_WEBSITE_ID`; see the [installation guide](https://kunchenguid.github.io/no-mistakes/start-here/installation/) and [environment reference](https://kunchenguid.github.io/no-mistakes/reference/environment/).
+
 ## Quick Start
 
 ```sh

--- a/cmd/no-mistakes/main.go
+++ b/cmd/no-mistakes/main.go
@@ -1,15 +1,18 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/cli"
 	"github.com/kunchenguid/no-mistakes/internal/daemon"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/telemetry"
 	"github.com/kunchenguid/no-mistakes/internal/update"
 )
 
@@ -45,6 +48,11 @@ func main() {
 	// leak into user-facing output. The daemon process sets up its own
 	// file-based logger before reaching this point.
 	slog.SetDefault(slog.New(slog.NewTextHandler(cliLogWriter(), nil)))
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 750*time.Millisecond)
+		defer cancel()
+		_ = telemetry.Close(ctx)
+	}()
 
 	cli.Execute()
 }

--- a/cmd/no-mistakes/main.go
+++ b/cmd/no-mistakes/main.go
@@ -17,29 +17,33 @@ import (
 )
 
 func main() {
+	os.Exit(run())
+}
+
+func run() int {
 	if root, ok, err := daemonRunRootFromArgs(os.Args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		return 1
 	} else if ok {
 		if root != "" {
 			if err := os.Setenv("NM_HOME", root); err != nil {
 				fmt.Fprintln(os.Stderr, err)
-				os.Exit(1)
+				return 1
 			}
 		}
 		if err := daemon.Run(); err != nil {
 			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
+			return 1
 		}
-		return
+		return 0
 	}
 
 	if handled, err := update.MaybeHandleBackgroundCheck(os.Args[1:]); handled {
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
+			return 1
 		}
-		return
+		return 0
 	}
 
 	update.MaybeNotifyAndCheck(os.Args[1:], os.Stderr)
@@ -54,7 +58,7 @@ func main() {
 		_ = telemetry.Close(ctx)
 	}()
 
-	cli.Execute()
+	return cli.Execute()
 }
 
 func daemonRunRootFromArgs(args []string) (string, bool, error) {

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -117,6 +117,8 @@ no-mistakes update
 
 Downloads the latest release, verifies the SHA-256 checksum, atomically replaces the running binary, and resets the daemon when it is running or stale daemon artifacts exist so the new executable is picked up, preferring the managed service path and falling back to a detached daemon if service startup is unavailable or fails. If the daemon is running, update first requires it to already be using the same executable path as the binary running `no-mistakes update`; if that daemon executable path cannot be determined or it points to a different binary, the update aborts before replacement. If the daemon does not come back cleanly after a successful replacement, the command reports that failure. On macOS, removes the quarantine extended attribute.
 
+Because `update` installs the latest official release binary, the replacement binary may already have telemetry enabled if a telemetry website ID was embedded at build time.
+
 Background update checks run automatically on each CLI invocation (except `update` itself). If a newer version is available, a notification is printed to stderr. Suppressed for dev builds or when `NO_MISTAKES_NO_UPDATE_CHECK=1` is set.
 
 ## no-mistakes daemon start

--- a/docs/src/content/docs/reference/environment.md
+++ b/docs/src/content/docs/reference/environment.md
@@ -77,7 +77,7 @@ Override or enable the telemetry website ID.
 
 When set, telemetry uses this website ID at runtime. If it is unset in a dev build, `no-mistakes` also checks a repo-local `.env` file for `NO_MISTAKES_UMAMI_WEBSITE_ID`. If no runtime value is found, it falls back to any website ID embedded at build time.
 
-When telemetry is enabled, `no-mistakes` sends command, run, step, approval, and fix events plus app version, platform, and build-channel metadata.
+When telemetry is enabled, `no-mistakes` sends command, run, step, approval, and fix events plus app version, platform, and build-channel metadata to Umami Cloud at `https://cloud.umami.is/api/send`.
 
 ## Environment the daemon sees
 

--- a/docs/src/content/docs/reference/environment.md
+++ b/docs/src/content/docs/reference/environment.md
@@ -75,7 +75,7 @@ Override or enable the telemetry website ID.
 | Type | `string` |
 | Default | unset |
 
-When set, telemetry uses this website ID at runtime. In dev builds, if the variable is unset, `no-mistakes` also checks a repo-local `.env` file for `NO_MISTAKES_UMAMI_WEBSITE_ID`. Release builds instead use any website ID embedded at build time.
+When set, telemetry uses this website ID at runtime. If it is unset in a dev build, `no-mistakes` also checks a repo-local `.env` file for `NO_MISTAKES_UMAMI_WEBSITE_ID`. If no runtime value is found, it falls back to any website ID embedded at build time.
 
 ## Environment the daemon sees
 

--- a/docs/src/content/docs/reference/environment.md
+++ b/docs/src/content/docs/reference/environment.md
@@ -77,6 +77,8 @@ Override or enable the telemetry website ID.
 
 When set, telemetry uses this website ID at runtime. If it is unset in a dev build, `no-mistakes` also checks a repo-local `.env` file for `NO_MISTAKES_UMAMI_WEBSITE_ID`. If no runtime value is found, it falls back to any website ID embedded at build time.
 
+When telemetry is enabled, `no-mistakes` sends command, run, step, approval, and fix events plus app version, platform, and build-channel metadata.
+
 ## Environment the daemon sees
 
 When the daemon runs through a managed service (launchd, systemd user service, Task Scheduler), it reloads environment from your login shell on macOS and Linux before each run so `PATH` and `NO_MISTAKES_*` vars match what you'd see in an interactive shell. On Windows it reuses the current process environment.

--- a/docs/src/content/docs/reference/environment.md
+++ b/docs/src/content/docs/reference/environment.md
@@ -66,6 +66,17 @@ Disable background update checks.
 
 Update checks run on every CLI invocation except `update` itself, hit GitHub releases, cache the result in `$NM_HOME/update-check.json`, and print a one-line notification to stderr when a newer version is available. Dev builds (non-semver versions) suppress the check automatically.
 
+## `NO_MISTAKES_UMAMI_WEBSITE_ID`
+
+Override or enable the telemetry website ID.
+
+| | |
+|---|---|
+| Type | `string` |
+| Default | unset |
+
+When set, telemetry uses this website ID at runtime. In dev builds, if the variable is unset, `no-mistakes` also checks a repo-local `.env` file for `NO_MISTAKES_UMAMI_WEBSITE_ID`. Release builds instead use any website ID embedded at build time.
+
 ## Environment the daemon sees
 
 When the daemon runs through a managed service (launchd, systemd user service, Task Scheduler), it reloads environment from your login shell on macOS and Linux before each run so `PATH` and `NO_MISTAKES_*` vars match what you'd see in an interactive shell. On Windows it reuses the current process environment.

--- a/docs/src/content/docs/start-here/installation.md
+++ b/docs/src/content/docs/start-here/installation.md
@@ -36,6 +36,8 @@ make build
 make install
 ```
 
+`make build` embeds the telemetry website ID from `NO_MISTAKES_UMAMI_WEBSITE_ID` in a repo-local `.env` first, then `UMAMI_WEBSITE_ID` from the shell if no `.env` value is present. If neither is set, the binary is built without telemetry enabled.
+
 ## Prerequisites
 
 - **git** - required

--- a/docs/src/content/docs/start-here/installation.md
+++ b/docs/src/content/docs/start-here/installation.md
@@ -13,6 +13,8 @@ The installer keeps the real binary in `~/.no-mistakes/bin` and exposes `no-mist
 
 It also attempts to install and start the background daemon for you, preferring a managed service (launchd on macOS, systemd user service on Linux) and falling back to a detached daemon if that path is unavailable. If startup fails, run `no-mistakes daemon start` manually.
 
+Official release binaries installed this way may already have telemetry enabled if a telemetry website ID was embedded at build time.
+
 ## Windows (PowerShell)
 
 ```powershell
@@ -20,6 +22,8 @@ irm https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.
 ```
 
 Installs the binary and attempts to start the background daemon automatically, preferring a managed Task Scheduler task and falling back to a detached daemon if needed.
+
+Official release binaries installed this way may already have telemetry enabled if a telemetry website ID was embedded at build time.
 
 ## Go install
 

--- a/docs/src/content/docs/start-here/installation.md
+++ b/docs/src/content/docs/start-here/installation.md
@@ -31,6 +31,8 @@ Official release binaries installed this way may already have telemetry enabled 
 go install github.com/kunchenguid/no-mistakes/cmd/no-mistakes@latest
 ```
 
+`go install` builds the CLI without an embedded telemetry website ID, so telemetry stays off by default unless you later set `NO_MISTAKES_UMAMI_WEBSITE_ID` at runtime.
+
 ## From source
 
 ```sh
@@ -62,6 +64,8 @@ no-mistakes update
 ```
 
 This downloads the latest release from GitHub, verifies the SHA-256 checksum, atomically replaces the binary, and resets the daemon so it picks up the new executable. It prefers the managed service path and falls back to a detached daemon if service startup is unavailable or fails.
+
+Because `update` installs the latest official release binary, it may change telemetry behavior if that release has a telemetry website ID embedded at build time.
 
 It only proceeds if the running daemon is already using the same executable path. If the daemon executable path cannot be determined or it was started from a different binary, the update aborts before replacing the binary. If the daemon does not come back cleanly after a successful replacement, the new binary stays installed but the command reports the daemon reset failure.
 

--- a/docs/src/content/docs/start-here/quick-start.md
+++ b/docs/src/content/docs/start-here/quick-start.md
@@ -13,6 +13,8 @@ curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/i
 
 The installer drops the binary in `~/.no-mistakes/bin`, links it into `~/.local/bin` or `/usr/local/bin`, and starts the background daemon. If startup fails, run `no-mistakes daemon start` manually.
 
+Official release binaries installed this way may already have telemetry enabled if a telemetry website ID was embedded at build time.
+
 ## 2. Check prerequisites
 
 ```sh

--- a/internal/buildinfo/version.go
+++ b/internal/buildinfo/version.go
@@ -8,9 +8,10 @@ import "runtime/debug"
 //	          -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Commit=abc1234
 //	          -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Date=2024-01-01"
 var (
-	Version = "dev"
-	Commit  = "unknown"
-	Date    = "unknown"
+	Version            = "dev"
+	Commit             = "unknown"
+	Date               = "unknown"
+	TelemetryWebsiteID = ""
 )
 
 func CurrentVersion() string {

--- a/internal/buildinfo/version.go
+++ b/internal/buildinfo/version.go
@@ -6,7 +6,8 @@ import "runtime/debug"
 //
 //	-ldflags "-X github.com/kunchenguid/no-mistakes/internal/buildinfo.Version=v1.0.0
 //	          -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Commit=abc1234
-//	          -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Date=2024-01-01"
+//	          -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Date=2024-01-01
+//	          -X github.com/kunchenguid/no-mistakes/internal/buildinfo.TelemetryWebsiteID=abc123"
 var (
 	Version            = "dev"
 	Commit             = "unknown"

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -200,7 +200,9 @@ func newAttachCmd() *cobra.Command {
 If no run ID is specified, attaches to the active run for the current repo.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return attachRun(cmd.OutOrStdout(), runID, false)
+			return trackCommand("attach", func() error {
+				return attachRun(cmd.OutOrStdout(), runID, false)
+			})
 		},
 	}
 

--- a/internal/cli/daemon_cmd.go
+++ b/internal/cli/daemon_cmd.go
@@ -77,18 +77,20 @@ func newDaemonStartCmd() *cobra.Command {
 		Use:   "start",
 		Short: "Install or refresh the managed daemon service and start it",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			p, err := paths.New()
-			if err != nil {
-				return err
-			}
-			if err := p.EnsureDirs(); err != nil {
-				return err
-			}
-			if err := daemon.Start(p); err != nil {
-				return err
-			}
-			fmt.Fprintf(cmd.OutOrStdout(), "  %s daemon started\n", sGreen.Render("✓"))
-			return nil
+			return trackCommand("daemon.start", func() error {
+				p, err := paths.New()
+				if err != nil {
+					return err
+				}
+				if err := p.EnsureDirs(); err != nil {
+					return err
+				}
+				if err := daemon.Start(p); err != nil {
+					return err
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "  %s daemon started\n", sGreen.Render("✓"))
+				return nil
+			})
 		},
 	}
 }
@@ -98,15 +100,17 @@ func newDaemonStopCmd() *cobra.Command {
 		Use:   "stop",
 		Short: "Stop the running daemon",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			p, err := paths.New()
-			if err != nil {
-				return err
-			}
-			if err := daemon.Stop(p); err != nil {
-				return err
-			}
-			fmt.Fprintf(cmd.OutOrStdout(), "  %s daemon stopped\n", sGreen.Render("✓"))
-			return nil
+			return trackCommand("daemon.stop", func() error {
+				p, err := paths.New()
+				if err != nil {
+					return err
+				}
+				if err := daemon.Stop(p); err != nil {
+					return err
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "  %s daemon stopped\n", sGreen.Render("✓"))
+				return nil
+			})
 		},
 	}
 }
@@ -116,25 +120,27 @@ func newDaemonStatusCmd() *cobra.Command {
 		Use:   "status",
 		Short: "Check if the daemon is running",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			p, err := paths.New()
-			if err != nil {
-				return err
-			}
-			alive, err := daemon.IsRunning(p)
-			if err != nil {
-				return err
-			}
-			if alive {
-				pid, _ := daemon.ReadPID(p)
-				if pid > 0 {
-					fmt.Fprintf(cmd.OutOrStdout(), "  %s daemon running %s\n", sGreen.Render("●"), sDim.Render(fmt.Sprintf("(pid %d)", pid)))
-				} else {
-					fmt.Fprintf(cmd.OutOrStdout(), "  %s daemon running\n", sGreen.Render("●"))
+			return trackCommand("daemon.status", func() error {
+				p, err := paths.New()
+				if err != nil {
+					return err
 				}
-			} else {
-				fmt.Fprintf(cmd.OutOrStdout(), "  %s daemon not running\n", sDim.Render("○"))
-			}
-			return nil
+				alive, err := daemon.IsRunning(p)
+				if err != nil {
+					return err
+				}
+				if alive {
+					pid, _ := daemon.ReadPID(p)
+					if pid > 0 {
+						fmt.Fprintf(cmd.OutOrStdout(), "  %s daemon running %s\n", sGreen.Render("●"), sDim.Render(fmt.Sprintf("(pid %d)", pid)))
+					} else {
+						fmt.Fprintf(cmd.OutOrStdout(), "  %s daemon running\n", sGreen.Render("●"))
+					}
+				} else {
+					fmt.Fprintf(cmd.OutOrStdout(), "  %s daemon not running\n", sDim.Render("○"))
+				}
+				return nil
+			})
 		},
 	}
 }

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -18,107 +18,103 @@ func newDoctorCmd() *cobra.Command {
 		Short: "Check system health and dependencies",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			w := cmd.OutOrStdout()
-			allOK := true
+			return trackCommand("doctor", func() error {
+				w := cmd.OutOrStdout()
+				allOK := true
 
-			ok := func(label, detail string) {
-				fmt.Fprintf(w, "  %s %s  %s\n", sGreen.Render("✓"), sDim.Render(label), detail)
-			}
-			warn := func(label, detail string) {
-				fmt.Fprintf(w, "  %s %s  %s\n", sYellow.Render("–"), sDim.Render(label), detail)
-			}
-			fail := func(label, detail string) {
-				fmt.Fprintf(w, "  %s %s  %s\n", sRed.Render("✗"), sDim.Render(label), detail)
-			}
+				ok := func(label, detail string) {
+					fmt.Fprintf(w, "  %s %s  %s\n", sGreen.Render("✓"), sDim.Render(label), detail)
+				}
+				warn := func(label, detail string) {
+					fmt.Fprintf(w, "  %s %s  %s\n", sYellow.Render("–"), sDim.Render(label), detail)
+				}
+				fail := func(label, detail string) {
+					fmt.Fprintf(w, "  %s %s  %s\n", sRed.Render("✗"), sDim.Render(label), detail)
+				}
 
-			fmt.Fprintf(w, "  %s\n", sCyan.Render("System"))
+				fmt.Fprintf(w, "  %s\n", sCyan.Render("System"))
 
-			// 1. Check git.
-			if _, err := exec.LookPath("git"); err != nil {
-				fail("git           ", "not found")
-				allOK = false
-			} else {
-				out, err := exec.Command("git", "--version").Output()
-				if err != nil {
-					fail("git           ", fmt.Sprintf("error (%v)", err))
+				if _, err := exec.LookPath("git"); err != nil {
+					fail("git           ", "not found")
 					allOK = false
 				} else {
-					ok("git           ", strings.TrimSpace(string(out)))
-				}
-			}
-
-			// 2. Check gh CLI (optional but useful for PR/CI steps).
-			if _, err := exec.LookPath("gh"); err != nil {
-				warn("gh            ", "not found "+sDim.Render("(optional, needed for PR/CI)"))
-			} else {
-				ok("gh            ", "ok")
-			}
-
-			// 3. Check data directory.
-			p, err := paths.New()
-			if err != nil {
-				fail("data directory", fmt.Sprintf("error resolving paths (%v)", err))
-				allOK = false
-			} else if _, err := os.Stat(p.Root()); os.IsNotExist(err) {
-				fail("data directory", fmt.Sprintf("not found (%s)", p.Root()))
-				allOK = false
-			} else {
-				ok("data directory", p.Root())
-			}
-
-			// 4. Check database.
-			if p != nil {
-				if _, err := os.Stat(p.DB()); os.IsNotExist(err) {
-					warn("database      ", "not found "+sDim.Render("(will be created on first use)"))
-				} else {
-					d, err := db.Open(p.DB())
+					out, err := exec.Command("git", "--version").Output()
 					if err != nil {
-						fail("database      ", fmt.Sprintf("error (%v)", err))
+						fail("git           ", fmt.Sprintf("error (%v)", err))
 						allOK = false
 					} else {
-						d.Close()
-						ok("database      ", "ok")
+						ok("git           ", strings.TrimSpace(string(out)))
 					}
 				}
-			}
 
-			// 5. Check daemon status.
-			if p != nil {
-				alive, _ := daemon.IsRunning(p)
-				if alive {
-					ok("daemon        ", "running")
+				if _, err := exec.LookPath("gh"); err != nil {
+					warn("gh            ", "not found "+sDim.Render("(optional, needed for PR/CI)"))
 				} else {
-					warn("daemon        ", "stopped")
+					ok("gh            ", "ok")
 				}
-			}
 
-			// 6. Check agent binaries.
-			agents := []struct {
-				name   string
-				binary string
-			}{
-				{"claude", "claude"},
-				{"codex", "codex"},
-				{"rovodev", "acli"},
-				{"opencode", "opencode"},
-			}
-			fmt.Fprintln(w)
-			fmt.Fprintf(w, "  %s\n", sCyan.Render("Agents"))
-			for _, a := range agents {
-				label := fmt.Sprintf("%-14s", a.name)
-				if path, err := exec.LookPath(a.binary); err != nil {
-					warn(label, "not found")
+				p, err := paths.New()
+				if err != nil {
+					fail("data directory", fmt.Sprintf("error resolving paths (%v)", err))
+					allOK = false
+				} else if _, err := os.Stat(p.Root()); os.IsNotExist(err) {
+					fail("data directory", fmt.Sprintf("not found (%s)", p.Root()))
+					allOK = false
 				} else {
-					ok(label, path)
+					ok("data directory", p.Root())
 				}
-			}
 
-			if !allOK {
+				if p != nil {
+					if _, err := os.Stat(p.DB()); os.IsNotExist(err) {
+						warn("database      ", "not found "+sDim.Render("(will be created on first use)"))
+					} else {
+						d, err := db.Open(p.DB())
+						if err != nil {
+							fail("database      ", fmt.Sprintf("error (%v)", err))
+							allOK = false
+						} else {
+							d.Close()
+							ok("database      ", "ok")
+						}
+					}
+				}
+
+				if p != nil {
+					alive, _ := daemon.IsRunning(p)
+					if alive {
+						ok("daemon        ", "running")
+					} else {
+						warn("daemon        ", "stopped")
+					}
+				}
+
+				agents := []struct {
+					name   string
+					binary string
+				}{
+					{"claude", "claude"},
+					{"codex", "codex"},
+					{"rovodev", "acli"},
+					{"opencode", "opencode"},
+				}
 				fmt.Fprintln(w)
-				fmt.Fprintf(w, "  %s\n", sRed.Render("some checks failed"))
-			}
+				fmt.Fprintf(w, "  %s\n", sCyan.Render("Agents"))
+				for _, a := range agents {
+					label := fmt.Sprintf("%-14s", a.name)
+					if path, err := exec.LookPath(a.binary); err != nil {
+						warn(label, "not found")
+					} else {
+						ok(label, path)
+					}
+				}
 
-			return nil
+				if !allOK {
+					fmt.Fprintln(w)
+					fmt.Fprintf(w, "  %s\n", sRed.Render("some checks failed"))
+				}
+
+				return nil
+			})
 		},
 	}
 }

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -18,7 +18,7 @@ func newDoctorCmd() *cobra.Command {
 		Short: "Check system health and dependencies",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return trackCommand("doctor", func() error {
+			return trackCommandStatus("doctor", func() (string, error) {
 				w := cmd.OutOrStdout()
 				allOK := true
 
@@ -111,9 +111,10 @@ func newDoctorCmd() *cobra.Command {
 				if !allOK {
 					fmt.Fprintln(w)
 					fmt.Fprintf(w, "  %s\n", sRed.Render("some checks failed"))
+					return "error", nil
 				}
 
-				return nil
+				return "success", nil
 			})
 		},
 	}

--- a/internal/cli/eject.go
+++ b/internal/cli/eject.go
@@ -15,23 +15,25 @@ func newEjectCmd() *cobra.Command {
 and removes the repo record from the database.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			p, d, err := openResources()
-			if err != nil {
-				return err
-			}
-			defer d.Close()
+			return trackCommand("eject", func() error {
+				p, d, err := openResources()
+				if err != nil {
+					return err
+				}
+				defer d.Close()
 
-			repo, err := gate.Eject(cmd.Context(), d, p, ".")
-			if err != nil {
-				return fmt.Errorf("eject: %w", err)
-			}
+				repo, err := gate.Eject(cmd.Context(), d, p, ".")
+				if err != nil {
+					return fmt.Errorf("eject: %w", err)
+				}
 
-			w := cmd.OutOrStdout()
-			fmt.Fprintf(w, "  %s Gate removed\n", sGreen.Render("✓"))
-			fmt.Fprintln(w)
-			fmt.Fprintf(w, "  %s  %s\n", sDim.Render("  repo"), repo.WorkingPath)
-			fmt.Fprintf(w, "  %s  %s\n", sDim.Render("remote"), repo.UpstreamURL)
-			return nil
+				w := cmd.OutOrStdout()
+				fmt.Fprintf(w, "  %s Gate removed\n", sGreen.Render("✓"))
+				fmt.Fprintln(w)
+				fmt.Fprintf(w, "  %s  %s\n", sDim.Render("  repo"), repo.WorkingPath)
+				fmt.Fprintf(w, "  %s  %s\n", sDim.Render("remote"), repo.UpstreamURL)
+				return nil
+			})
 		},
 	}
 }

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -22,35 +22,37 @@ adds a "no-mistakes" git remote, and records the repo in the database.
 Run this from inside a git repository that has an "origin" remote.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			p, d, err := openResources()
-			if err != nil {
-				return err
-			}
-			defer d.Close()
-
-			repo, err := gate.Init(cmd.Context(), d, p, ".")
-			if err != nil {
-				return fmt.Errorf("init: %w", err)
-			}
-			if err := daemon.EnsureDaemon(p); err != nil {
-				if _, ejectErr := gate.Eject(cmd.Context(), d, p, "."); ejectErr != nil {
-					return fmt.Errorf("start daemon: %w, rollback init: %v", err, ejectErr)
+			return trackCommand("init", func() error {
+				p, d, err := openResources()
+				if err != nil {
+					return err
 				}
-				return fmt.Errorf("start daemon: %w", err)
-			}
+				defer d.Close()
 
-			w := cmd.OutOrStdout()
-			fmt.Fprintln(w, sCyan.Render(banner))
-			fmt.Fprintln(w)
-			fmt.Fprintf(w, "  %s Gate initialized\n", sGreen.Render("✓"))
-			fmt.Fprintln(w)
-			fmt.Fprintf(w, "  %s  %s\n", sDim.Render("  repo"), repo.WorkingPath)
-			fmt.Fprintf(w, "  %s  no-mistakes → %s\n", sDim.Render("  gate"), p.RepoDir(repo.ID))
-			fmt.Fprintf(w, "  %s  %s\n", sDim.Render("remote"), repo.UpstreamURL)
-			fmt.Fprintln(w)
-			fmt.Fprintf(w, "  %s\n", sDim.Render("Push through the gate with:"))
-			fmt.Fprintf(w, "  %s\n", sBold.Render("git push no-mistakes <branch>"))
-			return nil
+				repo, err := gate.Init(cmd.Context(), d, p, ".")
+				if err != nil {
+					return fmt.Errorf("init: %w", err)
+				}
+				if err := daemon.EnsureDaemon(p); err != nil {
+					if _, ejectErr := gate.Eject(cmd.Context(), d, p, "."); ejectErr != nil {
+						return fmt.Errorf("start daemon: %w, rollback init: %v", err, ejectErr)
+					}
+					return fmt.Errorf("start daemon: %w", err)
+				}
+
+				w := cmd.OutOrStdout()
+				fmt.Fprintln(w, sCyan.Render(banner))
+				fmt.Fprintln(w)
+				fmt.Fprintf(w, "  %s Gate initialized\n", sGreen.Render("✓"))
+				fmt.Fprintln(w)
+				fmt.Fprintf(w, "  %s  %s\n", sDim.Render("  repo"), repo.WorkingPath)
+				fmt.Fprintf(w, "  %s  no-mistakes → %s\n", sDim.Render("  gate"), p.RepoDir(repo.ID))
+				fmt.Fprintf(w, "  %s  %s\n", sDim.Render("remote"), repo.UpstreamURL)
+				fmt.Fprintln(w)
+				fmt.Fprintf(w, "  %s\n", sDim.Render("Push through the gate with:"))
+				fmt.Fprintf(w, "  %s\n", sBold.Render("git push no-mistakes <branch>"))
+				return nil
+			})
 		},
 	}
 }

--- a/internal/cli/rerun.go
+++ b/internal/cli/rerun.go
@@ -16,42 +16,44 @@ func newRerunCmd() *cobra.Command {
 		Short: "Rerun the pipeline for the current branch",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			p, d, err := openResources()
-			if err != nil {
-				return err
-			}
-			defer d.Close()
+			return trackCommand("rerun", func() error {
+				p, d, err := openResources()
+				if err != nil {
+					return err
+				}
+				defer d.Close()
 
-			repo, err := findRepo(d)
-			if err != nil {
-				return err
-			}
+				repo, err := findRepo(d)
+				if err != nil {
+					return err
+				}
 
-			branch, err := git.CurrentBranch(context.Background(), ".")
-			if err != nil {
-				return fmt.Errorf("get current branch: %w", err)
-			}
-			if branch == "HEAD" {
-				return fmt.Errorf("not on a branch")
-			}
+				branch, err := git.CurrentBranch(context.Background(), ".")
+				if err != nil {
+					return fmt.Errorf("get current branch: %w", err)
+				}
+				if branch == "HEAD" {
+					return fmt.Errorf("not on a branch")
+				}
 
-			if err := daemon.EnsureDaemon(p); err != nil {
-				return fmt.Errorf("start daemon: %w", err)
-			}
+				if err := daemon.EnsureDaemon(p); err != nil {
+					return fmt.Errorf("start daemon: %w", err)
+				}
 
-			client, err := ipc.Dial(p.Socket())
-			if err != nil {
-				return fmt.Errorf("connect to daemon: %w", err)
-			}
-			defer client.Close()
+				client, err := ipc.Dial(p.Socket())
+				if err != nil {
+					return fmt.Errorf("connect to daemon: %w", err)
+				}
+				defer client.Close()
 
-			var result ipc.RerunResult
-			if err := client.Call(ipc.MethodRerun, &ipc.RerunParams{RepoID: repo.ID, Branch: branch}, &result); err != nil {
-				return fmt.Errorf("rerun pipeline: %w", err)
-			}
+				var result ipc.RerunResult
+				if err := client.Call(ipc.MethodRerun, &ipc.RerunParams{RepoID: repo.ID, Branch: branch}, &result); err != nil {
+					return fmt.Errorf("rerun pipeline: %w", err)
+				}
 
-			fmt.Fprintf(cmd.OutOrStdout(), "  %s Rerun started for %s %s\n", sGreen.Render("✓"), branch, sDim.Render(result.RunID))
-			return nil
+				fmt.Fprintf(cmd.OutOrStdout(), "  %s Rerun started for %s %s\n", sGreen.Render("✓"), branch, sDim.Render(result.RunID))
+				return nil
+			})
 		},
 	}
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/kunchenguid/no-mistakes/internal/buildinfo"
@@ -15,11 +14,12 @@ import (
 )
 
 // Execute runs the root CLI command.
-func Execute() {
+func Execute() int {
 	if err := newRootCmd().Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		fmt.Fprintln(newRootCmd().ErrOrStderr(), err)
+		return 1
 	}
+	return 0
 }
 
 func newRootCmd() *cobra.Command {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -36,7 +36,9 @@ func newRootCmd() *cobra.Command {
 		// When run without a subcommand, attach to the current branch run or
 		// route interactive users into the setup wizard when no run is active.
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return attachRun(cmd.OutOrStdout(), "", true)
+			return trackCommand("root", func() error {
+				return attachRun(cmd.OutOrStdout(), "", true)
+			})
 		},
 	}
 

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -197,3 +197,13 @@ func TestRootErrorFromNonGitDir(t *testing.T) {
 		t.Errorf("error should mention git repository, got: %v", err)
 	}
 }
+
+func TestExecuteReturnsExitCodeOnCommandError(t *testing.T) {
+	nonGitDir := t.TempDir()
+	t.Setenv("NM_HOME", t.TempDir())
+	chdir(t, nonGitDir)
+
+	if code := Execute(); code != 1 {
+		t.Fatalf("Execute() = %d, want 1", code)
+	}
+}

--- a/internal/cli/runs.go
+++ b/internal/cli/runs.go
@@ -17,45 +17,47 @@ func newRunsCmd() *cobra.Command {
 		Short: "List pipeline runs for the current repository",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			_, d, err := openResources()
-			if err != nil {
-				return err
-			}
-			defer d.Close()
+			return trackCommand("runs", func() error {
+				_, d, err := openResources()
+				if err != nil {
+					return err
+				}
+				defer d.Close()
 
-			repo, err := findRepo(d)
-			if err != nil {
-				return err
-			}
+				repo, err := findRepo(d)
+				if err != nil {
+					return err
+				}
 
-			runs, err := d.GetRunsByRepo(repo.ID)
-			if err != nil {
-				return fmt.Errorf("list runs: %w", err)
-			}
+				runs, err := d.GetRunsByRepo(repo.ID)
+				if err != nil {
+					return fmt.Errorf("list runs: %w", err)
+				}
 
-			w := cmd.OutOrStdout()
+				w := cmd.OutOrStdout()
 
-			if len(runs) == 0 {
-				fmt.Fprintf(w, "  %s\n", sDim.Render("no runs yet. Push through the gate to start a pipeline:"))
-				fmt.Fprintf(w, "  %s\n", sBold.Render("git push no-mistakes <branch>"))
+				if len(runs) == 0 {
+					fmt.Fprintf(w, "  %s\n", sDim.Render("no runs yet. Push through the gate to start a pipeline:"))
+					fmt.Fprintf(w, "  %s\n", sBold.Render("git push no-mistakes <branch>"))
+					return nil
+				}
+
+				// Apply limit.
+				shown := runs
+				if limit > 0 && len(shown) > limit {
+					shown = shown[:limit]
+				}
+
+				for _, r := range shown {
+					printRunLine(w, r)
+				}
+
+				if len(runs) > len(shown) {
+					fmt.Fprintf(w, "\n  %s\n", sDim.Render(fmt.Sprintf("(%d more runs, use --limit to see more)", len(runs)-len(shown))))
+				}
+
 				return nil
-			}
-
-			// Apply limit.
-			shown := runs
-			if limit > 0 && len(shown) > limit {
-				shown = shown[:limit]
-			}
-
-			for _, r := range shown {
-				printRunLine(w, r)
-			}
-
-			if len(runs) > len(shown) {
-				fmt.Fprintf(w, "\n  %s\n", sDim.Render(fmt.Sprintf("(%d more runs, use --limit to see more)", len(runs)-len(shown))))
-			}
-
-			return nil
+			})
 		},
 	}
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -14,10 +14,10 @@ func newStatusCmd() *cobra.Command {
 		Short: "Show status of the current repository",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return trackCommand("status", func() error {
+			return trackCommandStatus("status", func() (string, error) {
 				p, d, err := openResources()
 				if err != nil {
-					return err
+					return "", err
 				}
 				defer d.Close()
 
@@ -27,7 +27,7 @@ func newStatusCmd() *cobra.Command {
 				repo, err := findRepo(d)
 				if err != nil {
 					fmt.Fprintln(w, err)
-					return nil
+					return "error", nil
 				}
 
 				fmt.Fprintf(w, "  %s  %s\n", sDim.Render("  repo:"), repo.WorkingPath)
@@ -45,7 +45,7 @@ func newStatusCmd() *cobra.Command {
 				// Check for active run.
 				activeRun, err := d.GetActiveRun(repo.ID, "")
 				if err != nil {
-					return fmt.Errorf("check active run: %w", err)
+					return "", fmt.Errorf("check active run: %w", err)
 				}
 				if activeRun != nil {
 					fmt.Fprintln(w)
@@ -61,7 +61,7 @@ func newStatusCmd() *cobra.Command {
 					fmt.Fprintf(w, "\n  %s\n", sDim.Render("no active run"))
 				}
 
-				return nil
+				return "success", nil
 			})
 		},
 	}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -14,53 +14,55 @@ func newStatusCmd() *cobra.Command {
 		Short: "Show status of the current repository",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			p, d, err := openResources()
-			if err != nil {
-				return err
-			}
-			defer d.Close()
+			return trackCommand("status", func() error {
+				p, d, err := openResources()
+				if err != nil {
+					return err
+				}
+				defer d.Close()
 
-			w := cmd.OutOrStdout()
+				w := cmd.OutOrStdout()
 
-			// Look up repo from current directory.
-			repo, err := findRepo(d)
-			if err != nil {
-				fmt.Fprintln(w, err)
+				// Look up repo from current directory.
+				repo, err := findRepo(d)
+				if err != nil {
+					fmt.Fprintln(w, err)
+					return nil
+				}
+
+				fmt.Fprintf(w, "  %s  %s\n", sDim.Render("  repo:"), repo.WorkingPath)
+				fmt.Fprintf(w, "  %s  %s\n", sDim.Render("remote:"), repo.UpstreamURL)
+				fmt.Fprintf(w, "  %s  %s\n", sDim.Render("  gate:"), p.RepoDir(repo.ID))
+
+				// Check daemon status.
+				alive, _ := daemon.IsRunning(p)
+				if alive {
+					fmt.Fprintf(w, "  %s  %s %s\n", sDim.Render("daemon:"), sGreen.Render("●"), "running")
+				} else {
+					fmt.Fprintf(w, "  %s  %s %s\n", sDim.Render("daemon:"), sDim.Render("○"), "stopped")
+				}
+
+				// Check for active run.
+				activeRun, err := d.GetActiveRun(repo.ID, "")
+				if err != nil {
+					return fmt.Errorf("check active run: %w", err)
+				}
+				if activeRun != nil {
+					fmt.Fprintln(w)
+					fmt.Fprintf(w, "  %s\n", sCyan.Render("Active run"))
+					sha := activeRun.HeadSHA[:minLen(len(activeRun.HeadSHA), 8)]
+					ts := time.Unix(activeRun.CreatedAt, 0).Format(time.DateTime)
+					fmt.Fprintf(w, "  %s  %s\n", sDim.Render("     id:"), activeRun.ID)
+					fmt.Fprintf(w, "  %s  %s\n", sDim.Render(" branch:"), activeRun.Branch)
+					fmt.Fprintf(w, "  %s  %s\n", sDim.Render(" status:"), runStatusStyle(activeRun.Status))
+					fmt.Fprintf(w, "  %s  %s\n", sDim.Render("   head:"), sDim.Render(sha))
+					fmt.Fprintf(w, "  %s  %s\n", sDim.Render("started:"), sDim.Render(ts))
+				} else {
+					fmt.Fprintf(w, "\n  %s\n", sDim.Render("no active run"))
+				}
+
 				return nil
-			}
-
-			fmt.Fprintf(w, "  %s  %s\n", sDim.Render("  repo:"), repo.WorkingPath)
-			fmt.Fprintf(w, "  %s  %s\n", sDim.Render("remote:"), repo.UpstreamURL)
-			fmt.Fprintf(w, "  %s  %s\n", sDim.Render("  gate:"), p.RepoDir(repo.ID))
-
-			// Check daemon status.
-			alive, _ := daemon.IsRunning(p)
-			if alive {
-				fmt.Fprintf(w, "  %s  %s %s\n", sDim.Render("daemon:"), sGreen.Render("●"), "running")
-			} else {
-				fmt.Fprintf(w, "  %s  %s %s\n", sDim.Render("daemon:"), sDim.Render("○"), "stopped")
-			}
-
-			// Check for active run.
-			activeRun, err := d.GetActiveRun(repo.ID, "")
-			if err != nil {
-				return fmt.Errorf("check active run: %w", err)
-			}
-			if activeRun != nil {
-				fmt.Fprintln(w)
-				fmt.Fprintf(w, "  %s\n", sCyan.Render("Active run"))
-				sha := activeRun.HeadSHA[:minLen(len(activeRun.HeadSHA), 8)]
-				ts := time.Unix(activeRun.CreatedAt, 0).Format(time.DateTime)
-				fmt.Fprintf(w, "  %s  %s\n", sDim.Render("     id:"), activeRun.ID)
-				fmt.Fprintf(w, "  %s  %s\n", sDim.Render(" branch:"), activeRun.Branch)
-				fmt.Fprintf(w, "  %s  %s\n", sDim.Render(" status:"), runStatusStyle(activeRun.Status))
-				fmt.Fprintf(w, "  %s  %s\n", sDim.Render("   head:"), sDim.Render(sha))
-				fmt.Fprintf(w, "  %s  %s\n", sDim.Render("started:"), sDim.Render(ts))
-			} else {
-				fmt.Fprintf(w, "\n  %s\n", sDim.Render("no active run"))
-			}
-
-			return nil
+			})
 		},
 	}
 }

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/telemetry"
+)
+
+func trackCommand(name string, fn func() error) (err error) {
+	start := time.Now()
+	err = fn()
+	telemetry.Track("command", telemetry.Fields{
+		"command":     name,
+		"status":      commandStatus(err),
+		"duration_ms": time.Since(start).Milliseconds(),
+	})
+	return err
+}
+
+func commandStatus(err error) string {
+	if err != nil {
+		return "error"
+	}
+	return "success"
+}

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -7,17 +7,29 @@ import (
 )
 
 func trackCommand(name string, fn func() error) (err error) {
+	return trackCommandStatus(name, func() (string, error) {
+		if err := fn(); err != nil {
+			return "", err
+		}
+		return "success", nil
+	})
+}
+
+func trackCommandStatus(name string, fn func() (string, error)) (err error) {
 	start := time.Now()
-	err = fn()
+	status, err := fn()
 	telemetry.Track("command", telemetry.Fields{
 		"command":     name,
-		"status":      commandStatus(err),
+		"status":      commandStatus(status, err),
 		"duration_ms": time.Since(start).Milliseconds(),
 	})
 	return err
 }
 
-func commandStatus(err error) string {
+func commandStatus(status string, err error) string {
+	if status != "" {
+		return status
+	}
 	if err != nil {
 		return "error"
 	}

--- a/internal/cli/telemetry_test.go
+++ b/internal/cli/telemetry_test.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/telemetry"
+)
+
+type recordedTelemetryEvent struct {
+	name   string
+	fields telemetry.Fields
+}
+
+type telemetryRecorder struct {
+	mu     sync.Mutex
+	events []recordedTelemetryEvent
+}
+
+func (r *telemetryRecorder) Track(name string, fields telemetry.Fields) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	clone := make(telemetry.Fields, len(fields))
+	for k, v := range fields {
+		clone[k] = v
+	}
+	r.events = append(r.events, recordedTelemetryEvent{name: name, fields: clone})
+}
+
+func (r *telemetryRecorder) Close(context.Context) error { return nil }
+
+func (r *telemetryRecorder) find(name, field string, want any) *recordedTelemetryEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for i := len(r.events) - 1; i >= 0; i-- {
+		e := r.events[i]
+		if e.name != name {
+			continue
+		}
+		if field == "" {
+			cp := e
+			return &cp
+		}
+		if fmt.Sprint(e.fields[field]) == fmt.Sprint(want) {
+			cp := e
+			return &cp
+		}
+	}
+	return nil
+}
+
+func TestInitTracksCommandTelemetry(t *testing.T) {
+	setupTestRepo(t)
+
+	recorder := &telemetryRecorder{}
+	restore := telemetry.SetDefaultForTesting(recorder)
+	defer restore()
+
+	if _, err := executeCmd("init"); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	event := recorder.find("command", "command", "init")
+	if event == nil {
+		t.Fatal("expected command telemetry for init")
+	}
+	if got := event.fields["status"]; got != "success" {
+		t.Fatalf("status = %v, want success", got)
+	}
+	if _, ok := event.fields["duration_ms"]; !ok {
+		t.Fatal("expected duration_ms in command telemetry")
+	}
+}

--- a/internal/cli/telemetry_test.go
+++ b/internal/cli/telemetry_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -73,5 +74,49 @@ func TestInitTracksCommandTelemetry(t *testing.T) {
 	}
 	if _, ok := event.fields["duration_ms"]; !ok {
 		t.Fatal("expected duration_ms in command telemetry")
+	}
+}
+
+func TestStatusTracksSoftFailureAsError(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("NM_HOME", t.TempDir())
+	chdir(t, tmpDir)
+
+	recorder := &telemetryRecorder{}
+	restore := telemetry.SetDefaultForTesting(recorder)
+	defer restore()
+
+	if _, err := executeCmd("status"); err != nil {
+		t.Fatalf("status failed: %v", err)
+	}
+
+	event := recorder.find("command", "command", "status")
+	if event == nil {
+		t.Fatal("expected command telemetry for status")
+	}
+	if got := event.fields["status"]; got != "error" {
+		t.Fatalf("status = %v, want error", got)
+	}
+}
+
+func TestDoctorTracksFailedChecksAsError(t *testing.T) {
+	nmHome := filepath.Join(t.TempDir(), "missing-nm-home")
+	t.Setenv("NM_HOME", nmHome)
+	t.Setenv("PATH", "/nonexistent")
+
+	recorder := &telemetryRecorder{}
+	restore := telemetry.SetDefaultForTesting(recorder)
+	defer restore()
+
+	if _, err := executeCmd("doctor"); err != nil {
+		t.Fatalf("doctor failed: %v", err)
+	}
+
+	event := recorder.find("command", "command", "doctor")
+	if event == nil {
+		t.Fatal("expected command telemetry for doctor")
+	}
+	if got := event.fields["status"]; got != "error" {
+		t.Fatalf("status = %v, want error", got)
 	}
 }

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -11,7 +11,9 @@ func newUpdateCmd() *cobra.Command {
 		Short: "Update no-mistakes and reset the daemon",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return update.Run(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr())
+			return trackCommand("update", func() error {
+				return update.Run(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr())
+			})
 		},
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -9,6 +9,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/config"
 	"github.com/kunchenguid/no-mistakes/internal/db"
@@ -16,6 +17,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
 	"github.com/kunchenguid/no-mistakes/internal/shellenv"
+	"github.com/kunchenguid/no-mistakes/internal/telemetry"
 )
 
 var applyShellEnvToProcess = shellenv.ApplyToProcess
@@ -92,6 +94,12 @@ func RunWithResources(p *paths.Paths, d *db.DB) error {
 // RunWithOptions starts the daemon with optional overrides.
 // stepFactory overrides the default pipeline steps (for testing).
 func RunWithOptions(p *paths.Paths, d *db.DB, stepFactory StepFactory) error {
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 750*time.Millisecond)
+		defer cancel()
+		_ = telemetry.Close(ctx)
+	}()
+
 	// Recover stale runs from a previous daemon crash.
 	recoverOnStartup(d, p)
 

--- a/internal/daemon/helpers_test.go
+++ b/internal/daemon/helpers_test.go
@@ -122,6 +122,15 @@ func (s *mockSlowStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcom
 	return nil, sctx.Ctx.Err()
 }
 
+type mockPanicStep struct {
+	name types.StepName
+}
+
+func (s *mockPanicStep) Name() types.StepName { return s.name }
+func (s *mockPanicStep) Execute(_ *pipeline.StepContext) (*pipeline.StepOutcome, error) {
+	panic("boom")
+}
+
 type mockVerifyDefaultBranchStep struct {
 	name types.StepName
 }

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/paths"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline/steps"
+	"github.com/kunchenguid/no-mistakes/internal/telemetry"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
@@ -162,7 +163,7 @@ func (m *RunManager) HandlePushReceived(ctx context.Context, params *ipc.PushRec
 	}
 
 	branch := branchFromRef(params.Ref)
-	return m.startRun(ctx, repo, branch, params.New, params.Old)
+	return m.startRun(ctx, repo, branch, params.New, params.Old, "push")
 }
 
 // HandleRerun creates a new run for the latest gate head on a branch.
@@ -209,12 +210,23 @@ func (m *RunManager) HandleRerun(ctx context.Context, repoID, branch string) (st
 		baseSHA = matchingHead.BaseSHA
 	}
 
-	return m.startRun(ctx, repo, branch, headSHA, baseSHA)
+	return m.startRun(ctx, repo, branch, headSHA, baseSHA, "rerun")
 }
 
 // startRun creates a run, sets up a worktree, and launches pipeline execution.
-func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSHA, baseSHA string) (string, error) {
+func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSHA, baseSHA, trigger string) (string, error) {
+	branchRole := telemetryBranchRole(branch, repo.DefaultBranch)
+	trackStartFailure := func(stage string) {
+		telemetry.Track("run", telemetry.Fields{
+			"action":      "start_failed",
+			"trigger":     trigger,
+			"branch_role": branchRole,
+			"stage":       stage,
+		})
+	}
+
 	if m.shuttingDown.Load() {
+		trackStartFailure("daemon_shutdown")
 		return "", fmt.Errorf("daemon is shutting down")
 	}
 
@@ -232,6 +244,7 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 	// Create run record.
 	run, err := m.db.InsertRun(repo.ID, branch, headSHA, baseSHA)
 	if err != nil {
+		trackStartFailure("create_run")
 		return "", fmt.Errorf("create run: %w", err)
 	}
 
@@ -240,6 +253,7 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 	wtDir := m.paths.WorktreeDir(repo.ID, run.ID)
 	if err := git.WorktreeAdd(ctx, gateDir, wtDir, headSHA); err != nil {
 		m.db.UpdateRunError(run.ID, fmt.Sprintf("create worktree: %s", err))
+		trackStartFailure("create_worktree")
 		return "", fmt.Errorf("create worktree: %w", err)
 	}
 	if repo.DefaultBranch != "" {
@@ -262,11 +276,13 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 	globalCfg, err := config.LoadGlobal(m.paths.ConfigFile())
 	if err != nil {
 		m.db.UpdateRunError(run.ID, fmt.Sprintf("load config: %s", err))
+		trackStartFailure("load_global_config")
 		return "", fmt.Errorf("load global config: %w", err)
 	}
 	repoCfg, err := config.LoadRepo(wtDir)
 	if err != nil {
 		m.db.UpdateRunError(run.ID, fmt.Sprintf("load config: %s", err))
+		trackStartFailure("load_repo_config")
 		return "", fmt.Errorf("load repo config: %w", err)
 	}
 	cfg := config.Merge(globalCfg, repoCfg)
@@ -278,19 +294,31 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 	} else {
 		if err := cfg.ResolveAgent(ctx, exec.LookPath); err != nil {
 			m.db.UpdateRunError(run.ID, err.Error())
+			trackStartFailure("resolve_agent")
 			return "", err
 		}
 		var agErr error
 		ag, agErr = agent.New(cfg.Agent, cfg.AgentPath())
 		if agErr != nil {
 			m.db.UpdateRunError(run.ID, fmt.Sprintf("create agent: %s", agErr))
+			trackStartFailure("create_agent")
 			return "", fmt.Errorf("create agent: %w", agErr)
 		}
 	}
 
+	execSteps := m.steps()
+	telemetry.Track("run", telemetry.Fields{
+		"action":      "started",
+		"trigger":     trigger,
+		"agent":       string(cfg.Agent),
+		"branch_role": branchRole,
+		"step_count":  len(execSteps),
+		"demo_mode":   steps.IsDemoMode(),
+	})
+
 	// Create executor with event broadcast.
 	runCtx, cancel := context.WithCancelCause(context.Background())
-	executor := pipeline.NewExecutor(m.db, m.paths, cfg, ag, m.steps(), m.broadcast)
+	executor := pipeline.NewExecutor(m.db, m.paths, cfg, ag, execSteps, m.broadcast)
 
 	// Track executor.
 	done := make(chan struct{})
@@ -306,6 +334,7 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 	// Launch pipeline in background.
 	m.wg.Add(1)
 	go func() {
+		startedAt := time.Now()
 		defer m.wg.Done()
 		defer close(done)
 		defer func() {
@@ -330,13 +359,60 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 		}()
 
 		if err := executor.Execute(runCtx, run, repo, wtDir); err != nil {
+			fields := telemetry.Fields{
+				"action":      "finished",
+				"trigger":     trigger,
+				"agent":       string(cfg.Agent),
+				"branch_role": branchRole,
+				"status":      string(run.Status),
+				"duration_ms": time.Since(startedAt).Milliseconds(),
+				"step_count":  len(execSteps),
+				"pr_created":  run.PRURL != nil && *run.PRURL != "",
+			}
+			if failedStep := telemetryFailedStepName(m.db, run.ID); failedStep != "" {
+				fields["failed_step"] = failedStep
+			}
+			telemetry.Track("run", fields)
 			slog.Error("pipeline failed", "run_id", run.ID, "error", err)
 		} else {
+			telemetry.Track("run", telemetry.Fields{
+				"action":      "finished",
+				"trigger":     trigger,
+				"agent":       string(cfg.Agent),
+				"branch_role": branchRole,
+				"status":      string(run.Status),
+				"duration_ms": time.Since(startedAt).Milliseconds(),
+				"step_count":  len(execSteps),
+				"pr_created":  run.PRURL != nil && *run.PRURL != "",
+			})
 			slog.Info("pipeline completed", "run_id", run.ID)
 		}
 	}()
 
 	return run.ID, nil
+}
+
+func telemetryBranchRole(branch, defaultBranch string) string {
+	if branch == "" {
+		return "unknown"
+	}
+	if defaultBranch != "" && branch == defaultBranch {
+		return "default"
+	}
+	return "feature"
+}
+
+func telemetryFailedStepName(database *db.DB, runID string) string {
+	steps, err := database.GetStepsByRun(runID)
+	if err != nil {
+		return ""
+	}
+	for _, step := range steps {
+		if step.Status == types.StepStatusFailed {
+			return string(step.StepName)
+		}
+	}
+	return ""
 }
 
 // HandleRespond routes a user approval action to the executor for the given run.

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -339,8 +339,27 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 		defer close(done)
 		defer func() {
 			if r := recover(); r != nil {
+				errMsg := fmt.Sprintf("internal panic: %v", r)
 				slog.Error("panic in pipeline goroutine", "run_id", run.ID, "panic", r)
-				m.db.UpdateRunError(run.ID, fmt.Sprintf("internal panic: %v", r))
+				if dbErr := m.db.UpdateRunErrorStatus(run.ID, errMsg, types.RunFailed); dbErr != nil {
+					slog.Error("failed to update run after panic", "run_id", run.ID, "error", dbErr)
+				}
+				run.Status = types.RunFailed
+				run.Error = &errMsg
+				fields := telemetry.Fields{
+					"action":      "finished",
+					"trigger":     trigger,
+					"agent":       string(cfg.Agent),
+					"branch_role": branchRole,
+					"status":      string(run.Status),
+					"duration_ms": time.Since(startedAt).Milliseconds(),
+					"step_count":  len(execSteps),
+					"pr_created":  run.PRURL != nil && *run.PRURL != "",
+				}
+				if failedStep := telemetryFailedStepName(m.db, run.ID); failedStep != "" {
+					fields["failed_step"] = failedStep
+				}
+				telemetry.Track("run", fields)
 			}
 			cancel(nil)
 			ag.Close()

--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -282,6 +282,59 @@ func TestPushReceivedTracksRunTelemetry(t *testing.T) {
 	}
 }
 
+func TestPushReceivedTracksRunTelemetryAfterPanic(t *testing.T) {
+	recorder := &telemetryRecorder{}
+	restore := telemetry.SetDefaultForTesting(recorder)
+	defer restore()
+
+	step := &mockPanicStep{name: types.StepReview}
+	p, d := startTestDaemonWithSteps(t, func() []pipeline.Step {
+		return []pipeline.Step{step}
+	})
+
+	_, headSHA := setupTestGitRepo(t, p, d, "telemetry-panic-repo")
+
+	client, err := ipc.Dial(p.Socket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	var result ipc.PushReceivedResult
+	err = client.Call(ipc.MethodPushReceived, &ipc.PushReceivedParams{
+		Gate: p.RepoDir("telemetry-panic-repo"),
+		Ref:  "refs/heads/main",
+		Old:  "0000000000000000000000000000000000000000",
+		New:  headSHA,
+	}, &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		run, err := d.GetRun(result.RunID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if run != nil && run.Error != nil && strings.Contains(*run.Error, "internal panic") {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	finished := recorder.find("run", "action", "finished")
+	if finished == nil {
+		t.Fatal("expected run finished telemetry event after panic")
+	}
+	if got := finished.fields["status"]; got != string(types.RunFailed) {
+		t.Fatalf("finished status = %v, want %q", got, types.RunFailed)
+	}
+	if _, ok := finished.fields["duration_ms"]; !ok {
+		t.Fatal("expected duration_ms in run finished telemetry after panic")
+	}
+}
+
 func TestPushReceivedDemoModeBypassesAgentResolution(t *testing.T) {
 	t.Setenv("NM_DEMO", "1")
 

--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/paths"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline/steps"
+	"github.com/kunchenguid/no-mistakes/internal/telemetry"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 
 	"github.com/kunchenguid/no-mistakes/internal/db"
@@ -218,6 +219,66 @@ func TestPushReceivedCreatesRun(t *testing.T) {
 	// Verify step was executed.
 	if step.execCnt.Load() == 0 {
 		t.Error("mock step was never executed")
+	}
+}
+
+func TestPushReceivedTracksRunTelemetry(t *testing.T) {
+	recorder := &telemetryRecorder{}
+	restore := telemetry.SetDefaultForTesting(recorder)
+	defer restore()
+
+	step := &mockPassStep{name: types.StepReview}
+	p, d := startTestDaemonWithSteps(t, func() []pipeline.Step {
+		return []pipeline.Step{step}
+	})
+
+	_, headSHA := setupTestGitRepo(t, p, d, "telemetry-run-repo")
+
+	client, err := ipc.Dial(p.Socket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	var result ipc.PushReceivedResult
+	err = client.Call(ipc.MethodPushReceived, &ipc.PushReceivedParams{
+		Gate: p.RepoDir("telemetry-run-repo"),
+		Ref:  "refs/heads/main",
+		Old:  "0000000000000000000000000000000000000000",
+		New:  headSHA,
+	}, &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := waitForRunTerminalState(t, d, result.RunID)
+	if run.Status != types.RunCompleted {
+		t.Fatalf("run status = %q, want %q", run.Status, types.RunCompleted)
+	}
+
+	started := recorder.find("run", "action", "started")
+	if started == nil {
+		t.Fatal("expected run started telemetry event")
+	}
+	if got := started.fields["trigger"]; got != "push" {
+		t.Fatalf("started trigger = %v, want push", got)
+	}
+	if got := started.fields["agent"]; got != string(types.AgentClaude) {
+		t.Fatalf("started agent = %v, want %q", got, types.AgentClaude)
+	}
+	if got := started.fields["branch_role"]; got != "default" {
+		t.Fatalf("started branch_role = %v, want default", got)
+	}
+
+	finished := recorder.find("run", "action", "finished")
+	if finished == nil {
+		t.Fatal("expected run finished telemetry event")
+	}
+	if got := finished.fields["status"]; got != string(types.RunCompleted) {
+		t.Fatalf("finished status = %v, want %q", got, types.RunCompleted)
+	}
+	if _, ok := finished.fields["duration_ms"]; !ok {
+		t.Fatal("expected duration_ms in run finished telemetry")
 	}
 }
 

--- a/internal/daemon/telemetry_test.go
+++ b/internal/daemon/telemetry_test.go
@@ -1,0 +1,49 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/kunchenguid/no-mistakes/internal/telemetry"
+)
+
+type recordedTelemetryEvent struct {
+	name   string
+	fields telemetry.Fields
+}
+
+type telemetryRecorder struct {
+	mu     sync.Mutex
+	events []recordedTelemetryEvent
+}
+
+func (r *telemetryRecorder) Track(name string, fields telemetry.Fields) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	clone := make(telemetry.Fields, len(fields))
+	for k, v := range fields {
+		clone[k] = v
+	}
+	r.events = append(r.events, recordedTelemetryEvent{name: name, fields: clone})
+}
+
+func (r *telemetryRecorder) Close(context.Context) error { return nil }
+
+func (r *telemetryRecorder) find(name, field string, want any) *recordedTelemetryEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for i := len(r.events) - 1; i >= 0; i-- {
+		e := r.events[i]
+		if e.name != name {
+			continue
+		}
+		if field == "" || fmt.Sprint(e.fields[field]) == fmt.Sprint(want) {
+			cp := e
+			return &cp
+		}
+	}
+	return nil
+}

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/telemetry"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
@@ -275,6 +276,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			fixableFindings := autoFixableFindingsJSON(outcome.Findings)
 			if fixableFindings != "" {
 				autoFixAttempts++
+				telemetry.Track("fix", e.fixTelemetryFields("auto", stepName, findingsCount(fixableFindings), autoFixAttempts))
 				slog.Info("auto-fixing step", "step", stepName, "attempt", autoFixAttempts, "max", autoFixLimit)
 				executionMS += time.Since(phaseStart).Milliseconds()
 				if dbErr := e.db.UpdateStepStatus(sr.ID, types.StepStatusFixing); dbErr != nil {
@@ -346,6 +348,19 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			return false, fmt.Errorf("step %s: waiting for approval: %w", stepName, err)
 		}
 
+		approvalFields := telemetry.Fields{
+			"step":       string(stepName),
+			"action":     string(response.action),
+			"fix_review": sctx.Fixing,
+		}
+		if agentName := e.telemetryAgentName(); agentName != "" {
+			approvalFields["agent"] = agentName
+		}
+		if selectedCount := selectedFindingCount(outcome.Findings, response.findingIDs); selectedCount > 0 {
+			approvalFields["selected_findings_count"] = selectedCount
+		}
+		telemetry.Track("approval", approvalFields)
+
 		switch response.action {
 		case types.ActionApprove:
 			// Approved - execution already frozen in executionMS, reset phaseStart
@@ -372,6 +387,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			return false, fmt.Errorf("step %s: aborted by user", stepName)
 
 		case types.ActionFix:
+			telemetry.Track("fix", e.fixTelemetryFields("user", stepName, selectedFindingCount(outcome.Findings, response.findingIDs), 0))
 			// Fix - mark step as fixing, resume execution timer, re-execute.
 			phaseStart = time.Now()
 			if dbErr := e.db.UpdateStepStatus(sr.ID, types.StepStatusFixing); dbErr != nil {
@@ -508,6 +524,22 @@ func (e *Executor) emitStepEventWithFindingsDiffAndError(eventType ipc.EventType
 		event.Diff = &diff
 	}
 	e.onEvent(event)
+
+	fields := telemetry.Fields{
+		"event":  string(eventType),
+		"step":   string(stepName),
+		"status": status,
+	}
+	if agentName := e.telemetryAgentName(); agentName != "" {
+		fields["agent"] = agentName
+	}
+	if durationMS != nil {
+		fields["duration_ms"] = *durationMS
+	}
+	if findings != "" {
+		fields["findings_count"] = findingsCount(findings)
+	}
+	telemetry.Track("step", fields)
 }
 
 func (e *Executor) emitLogChunk(run *db.Run, repo *db.Repo, stepName types.StepName, content string) {
@@ -518,4 +550,41 @@ func (e *Executor) emitLogChunk(run *db.Run, repo *db.Repo, stepName types.StepN
 		StepName: &stepName,
 		Content:  &content,
 	})
+}
+
+func (e *Executor) telemetryAgentName() string {
+	if e.config == nil || e.config.Agent == "" {
+		return ""
+	}
+	return string(e.config.Agent)
+}
+
+func (e *Executor) fixTelemetryFields(source string, stepName types.StepName, selectedCount int, attempt int) telemetry.Fields {
+	fields := telemetry.Fields{
+		"source":                  source,
+		"step":                    string(stepName),
+		"selected_findings_count": selectedCount,
+	}
+	if agentName := e.telemetryAgentName(); agentName != "" {
+		fields["agent"] = agentName
+	}
+	if attempt > 0 {
+		fields["attempt"] = attempt
+	}
+	return fields
+}
+
+func findingsCount(raw string) int {
+	findings, err := types.ParseFindingsJSON(raw)
+	if err != nil {
+		return 0
+	}
+	return len(findings.Items)
+}
+
+func selectedFindingCount(raw string, ids []string) int {
+	if len(ids) > 0 {
+		return len(ids)
+	}
+	return findingsCount(raw)
 }

--- a/internal/pipeline/executor_approval_test.go
+++ b/internal/pipeline/executor_approval_test.go
@@ -2,11 +2,14 @@ package pipeline
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/kunchenguid/no-mistakes/internal/config"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
+	"github.com/kunchenguid/no-mistakes/internal/telemetry"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
@@ -323,6 +326,124 @@ func TestExecutor_ApprovalFix(t *testing.T) {
 	// Step should have been called twice (initial + after fix)
 	if callCount != 2 {
 		t.Errorf("expected step to be called 2 times, got %d", callCount)
+	}
+}
+
+func TestExecutor_TracksApprovalAndUserFixTelemetry(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	recorder := &telemetryRecorder{}
+	restore := telemetry.SetDefaultForTesting(recorder)
+	defer restore()
+
+	callCount := 0
+	step := &adaptiveCallStep{
+		name: types.StepReview,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			callCount++
+			if callCount == 1 {
+				return &StepOutcome{NeedsApproval: true, Findings: `{"findings":[{"severity":"error","description":"bug one","action":"auto-fix"},{"severity":"warn","description":"bug two","action":"ask-user"}],"summary":"2 issues"}`}, nil
+			}
+			return &StepOutcome{ExitCode: 0}, nil
+		},
+	}
+
+	exec := NewExecutor(database, p, &config.Config{Agent: types.AgentClaude}, nil, []Step{step}, nil)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- exec.Execute(context.Background(), run, repo, workDir)
+	}()
+
+	waitForStepStatus(t, database, run.ID, types.StepReview, types.StepStatusAwaitingApproval)
+
+	if err := exec.Respond(types.StepReview, types.ActionFix, nil); err != nil {
+		t.Fatalf("respond error: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("executor timed out")
+	}
+
+	approvalEvent := recorder.find("approval", "action", "fix")
+	if approvalEvent == nil {
+		t.Fatal("expected approval telemetry event")
+	}
+	if got := approvalEvent.fields["step"]; got != string(types.StepReview) {
+		t.Fatalf("approval step = %v, want %q", got, types.StepReview)
+	}
+	if got := approvalEvent.fields["selected_findings_count"]; fmt.Sprint(got) != "2" {
+		t.Fatalf("approval selected_findings_count = %v, want 2", got)
+	}
+
+	fixEvent := recorder.find("fix", "source", "user")
+	if fixEvent == nil {
+		t.Fatal("expected user fix telemetry event")
+	}
+	if got := fixEvent.fields["selected_findings_count"]; fmt.Sprint(got) != "2" {
+		t.Fatalf("fix selected_findings_count = %v, want 2", got)
+	}
+
+	stepEvent := recorder.find("step", "status", string(types.StepStatusAwaitingApproval))
+	if stepEvent == nil {
+		t.Fatal("expected awaiting approval step telemetry event")
+	}
+	if got := stepEvent.fields["findings_count"]; fmt.Sprint(got) != "2" {
+		t.Fatalf("step findings_count = %v, want 2", got)
+	}
+	if got := stepEvent.fields["agent"]; got != string(types.AgentClaude) {
+		t.Fatalf("step agent = %v, want %q", got, types.AgentClaude)
+	}
+}
+
+func TestExecutor_TracksAutoFixTelemetry(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	recorder := &telemetryRecorder{}
+	restore := telemetry.SetDefaultForTesting(recorder)
+	defer restore()
+
+	callCount := 0
+	step := &adaptiveCallStep{
+		name: types.StepReview,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			callCount++
+			if callCount == 1 {
+				return &StepOutcome{
+					AutoFixable: true,
+					Findings:    `{"findings":[{"severity":"error","description":"fix me","action":"auto-fix"}],"summary":"1 issue"}`,
+				}, nil
+			}
+			return &StepOutcome{ExitCode: 0}, nil
+		},
+	}
+
+	cfg := &config.Config{Agent: types.AgentClaude, AutoFix: config.AutoFix{Review: 1}}
+	exec := NewExecutor(database, p, cfg, nil, []Step{step}, nil)
+
+	if err := exec.Execute(context.Background(), run, repo, workDir); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	fixEvent := recorder.find("fix", "source", "auto")
+	if fixEvent == nil {
+		t.Fatal("expected auto-fix telemetry event")
+	}
+	if got := fixEvent.fields["step"]; got != string(types.StepReview) {
+		t.Fatalf("fix step = %v, want %q", got, types.StepReview)
+	}
+	if got := fixEvent.fields["selected_findings_count"]; fmt.Sprint(got) != "1" {
+		t.Fatalf("fix selected_findings_count = %v, want 1", got)
+	}
+	if got := fixEvent.fields["attempt"]; fmt.Sprint(got) != "1" {
+		t.Fatalf("fix attempt = %v, want 1", got)
 	}
 }
 

--- a/internal/pipeline/telemetry_test.go
+++ b/internal/pipeline/telemetry_test.go
@@ -1,0 +1,49 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/kunchenguid/no-mistakes/internal/telemetry"
+)
+
+type recordedTelemetryEvent struct {
+	name   string
+	fields telemetry.Fields
+}
+
+type telemetryRecorder struct {
+	mu     sync.Mutex
+	events []recordedTelemetryEvent
+}
+
+func (r *telemetryRecorder) Track(name string, fields telemetry.Fields) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	clone := make(telemetry.Fields, len(fields))
+	for k, v := range fields {
+		clone[k] = v
+	}
+	r.events = append(r.events, recordedTelemetryEvent{name: name, fields: clone})
+}
+
+func (r *telemetryRecorder) Close(context.Context) error { return nil }
+
+func (r *telemetryRecorder) find(name, field string, want any) *recordedTelemetryEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for i := len(r.events) - 1; i >= 0; i-- {
+		e := r.events[i]
+		if e.name != name {
+			continue
+		}
+		if field == "" || fmt.Sprint(e.fields[field]) == fmt.Sprint(want) {
+			cp := e
+			return &cp
+		}
+	}
+	return nil
+}

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -1,0 +1,112 @@
+package telemetry
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestClientTrackSendsUmamiEventPayload(t *testing.T) {
+	t.Parallel()
+
+	type requestBody struct {
+		Type    string `json:"type"`
+		Payload struct {
+			Website string         `json:"website"`
+			Name    string         `json:"name"`
+			URL     string         `json:"url"`
+			Title   string         `json:"title"`
+			Data    map[string]any `json:"data"`
+		} `json:"payload"`
+	}
+
+	reqCh := make(chan requestBody, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/send" {
+			t.Fatalf("path = %s, want /api/send", r.URL.Path)
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		defer r.Body.Close()
+
+		var got requestBody
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Fatalf("unmarshal body: %v\nbody=%s", err, string(body))
+		}
+		reqCh <- got
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"disabled":false}`)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{
+		Host:       server.URL,
+		WebsiteID:  "website-123",
+		App:        "no-mistakes",
+		Version:    "v1.2.3",
+		GOOS:       "darwin",
+		GOARCH:     "arm64",
+		HTTPClient: server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	client.Track("command", Fields{
+		"command": "init",
+		"status":  "success",
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := client.Close(ctx); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	select {
+	case got := <-reqCh:
+		if got.Type != "event" {
+			t.Fatalf("type = %q, want %q", got.Type, "event")
+		}
+		if got.Payload.Website != "website-123" {
+			t.Fatalf("website = %q, want %q", got.Payload.Website, "website-123")
+		}
+		if got.Payload.Name != "command" {
+			t.Fatalf("name = %q, want %q", got.Payload.Name, "command")
+		}
+		if got.Payload.URL != "app://no-mistakes/command" {
+			t.Fatalf("url = %q, want %q", got.Payload.URL, "app://no-mistakes/command")
+		}
+		if got.Payload.Title != "no-mistakes CLI" {
+			t.Fatalf("title = %q, want %q", got.Payload.Title, "no-mistakes CLI")
+		}
+		if got.Payload.Data["command"] != "init" {
+			t.Fatalf("data.command = %v, want %q", got.Payload.Data["command"], "init")
+		}
+		if got.Payload.Data["status"] != "success" {
+			t.Fatalf("data.status = %v, want %q", got.Payload.Data["status"], "success")
+		}
+		if got.Payload.Data["app_version"] != "v1.2.3" {
+			t.Fatalf("data.app_version = %v, want %q", got.Payload.Data["app_version"], "v1.2.3")
+		}
+		if got.Payload.Data["goos"] != "darwin" {
+			t.Fatalf("data.goos = %v, want %q", got.Payload.Data["goos"], "darwin")
+		}
+		if got.Payload.Data["goarch"] != "arm64" {
+			t.Fatalf("data.goarch = %v, want %q", got.Payload.Data["goarch"], "arm64")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for telemetry request")
+	}
+}

--- a/internal/telemetry/config_test.go
+++ b/internal/telemetry/config_test.go
@@ -1,0 +1,94 @@
+package telemetry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/buildinfo"
+)
+
+func TestDefaultUsesDotEnvInDevBuildWhenEnvMissing(t *testing.T) {
+	prevSink := defaultSink
+	defaultSink = nil
+	defer func() { defaultSink = prevSink }()
+
+	prevWebsiteID := buildinfo.TelemetryWebsiteID
+	defer func() {
+		buildinfo.TelemetryWebsiteID = prevWebsiteID
+	}()
+	buildinfo.TelemetryWebsiteID = ""
+
+	t.Setenv(umamiWebsiteIDEnv, "")
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	content := "NO_MISTAKES_UMAMI_WEBSITE_ID=website-from-dotenv\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd(): %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir(): %v", err)
+	}
+	defer os.Chdir(prevWD)
+
+	sink := Default()
+	client, ok := sink.(*Client)
+	if !ok {
+		t.Fatalf("Default() type = %T, want *Client", sink)
+	}
+	if client.endpoint != umamiCloudURL+"/api/send" {
+		t.Fatalf("endpoint = %q, want %q", client.endpoint, umamiCloudURL+"/api/send")
+	}
+	if client.websiteID != "website-from-dotenv" {
+		t.Fatalf("websiteID = %q, want %q", client.websiteID, "website-from-dotenv")
+	}
+}
+
+func TestDefaultPrefersEnvVarWebsiteIDAndIgnoresHostOverride(t *testing.T) {
+	prevSink := defaultSink
+	defaultSink = nil
+	defer func() { defaultSink = prevSink }()
+
+	prevWebsiteID := buildinfo.TelemetryWebsiteID
+	defer func() {
+		buildinfo.TelemetryWebsiteID = prevWebsiteID
+	}()
+	buildinfo.TelemetryWebsiteID = "embedded-website"
+
+	t.Setenv(umamiHostEnv, "https://env.example")
+	t.Setenv(umamiWebsiteIDEnv, "website-from-env")
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	content := "NO_MISTAKES_UMAMI_HOST=https://dotenv.example\nNO_MISTAKES_UMAMI_WEBSITE_ID=website-from-dotenv\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write .env: %v", err)
+	}
+
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd(): %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Chdir(): %v", err)
+	}
+	defer os.Chdir(prevWD)
+
+	sink := Default()
+	client, ok := sink.(*Client)
+	if !ok {
+		t.Fatalf("Default() type = %T, want *Client", sink)
+	}
+	if client.endpoint != umamiCloudURL+"/api/send" {
+		t.Fatalf("endpoint = %q, want %q", client.endpoint, umamiCloudURL+"/api/send")
+	}
+	if client.websiteID != "website-from-env" {
+		t.Fatalf("websiteID = %q, want %q", client.websiteID, "website-from-env")
+	}
+}

--- a/internal/telemetry/config_test.go
+++ b/internal/telemetry/config_test.go
@@ -92,3 +92,47 @@ func TestDefaultPrefersEnvVarWebsiteIDAndIgnoresHostOverride(t *testing.T) {
 		t.Fatalf("websiteID = %q, want %q", client.websiteID, "website-from-env")
 	}
 }
+
+func TestDefaultIgnoresDotEnvOutsideRepo(t *testing.T) {
+	prevSink := defaultSink
+	defaultSink = nil
+	defer func() { defaultSink = prevSink }()
+
+	prevWebsiteID := buildinfo.TelemetryWebsiteID
+	defer func() {
+		buildinfo.TelemetryWebsiteID = prevWebsiteID
+	}()
+	buildinfo.TelemetryWebsiteID = ""
+
+	t.Setenv(umamiWebsiteIDEnv, "")
+
+	parentDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(parentDir, ".env"), []byte("NO_MISTAKES_UMAMI_WEBSITE_ID=outside-repo\n"), 0o644); err != nil {
+		t.Fatalf("write parent .env: %v", err)
+	}
+
+	repoDir := filepath.Join(parentDir, "repo")
+	if err := os.Mkdir(repoDir, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	subDir := filepath.Join(repoDir, "nested")
+	if err := os.Mkdir(subDir, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(repoDir, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd(): %v", err)
+	}
+	if err := os.Chdir(subDir); err != nil {
+		t.Fatalf("Chdir(): %v", err)
+	}
+	defer os.Chdir(prevWD)
+
+	if _, ok := Default().(*Client); ok {
+		t.Fatal("Default() should ignore dotenv outside repo")
+	}
+}

--- a/internal/telemetry/config_test.go
+++ b/internal/telemetry/config_test.go
@@ -144,3 +144,11 @@ func TestParseDotEnvStripsInlineCommentsFromUnquotedValues(t *testing.T) {
 		t.Fatalf("website ID = %q, want %q", got, "abc123")
 	}
 }
+
+func TestParseDotEnvPreservesHashesInQuotedValues(t *testing.T) {
+	values := parseDotEnv([]byte("NO_MISTAKES_UMAMI_WEBSITE_ID=\"abc # dev\"\n"))
+
+	if got := values[umamiWebsiteIDEnv]; got != "abc # dev" {
+		t.Fatalf("website ID = %q, want %q", got, "abc # dev")
+	}
+}

--- a/internal/telemetry/config_test.go
+++ b/internal/telemetry/config_test.go
@@ -136,3 +136,11 @@ func TestDefaultIgnoresDotEnvOutsideRepo(t *testing.T) {
 		t.Fatal("Default() should ignore dotenv outside repo")
 	}
 }
+
+func TestParseDotEnvStripsInlineCommentsFromUnquotedValues(t *testing.T) {
+	values := parseDotEnv([]byte("NO_MISTAKES_UMAMI_WEBSITE_ID=abc123 # dev\n"))
+
+	if got := values[umamiWebsiteIDEnv]; got != "abc123" {
+		t.Fatalf("website ID = %q, want %q", got, "abc123")
+	}
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -395,9 +395,21 @@ func parseDotEnv(data []byte) map[string]string {
 		if key == "" {
 			continue
 		}
-		values[key] = dotenvValue(strings.TrimSpace(value))
+		values[key] = dotenvValue(trimDotEnvInlineComment(strings.TrimSpace(value)))
 	}
 	return values
+}
+
+func trimDotEnvInlineComment(value string) string {
+	for i := 0; i < len(value); i++ {
+		if value[i] != '#' {
+			continue
+		}
+		if i == 0 || value[i-1] == ' ' || value[i-1] == '\t' {
+			return strings.TrimSpace(value[:i])
+		}
+	}
+	return value
 }
 
 func dotenvValue(value string) string {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,0 +1,390 @@
+package telemetry
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/buildinfo"
+)
+
+const (
+	defaultHostname = "cli"
+	defaultTitle    = "no-mistakes CLI"
+	defaultPath     = "/api/send"
+	umamiCloudURL   = "https://cloud.umami.is"
+
+	umamiHostEnv      = "NO_MISTAKES_UMAMI_HOST"
+	umamiWebsiteIDEnv = "NO_MISTAKES_UMAMI_WEBSITE_ID"
+)
+
+type Fields map[string]any
+
+type Sink interface {
+	Track(name string, fields Fields)
+	Close(ctx context.Context) error
+}
+
+type Config struct {
+	Host       string
+	WebsiteID  string
+	App        string
+	Version    string
+	GOOS       string
+	GOARCH     string
+	HTTPClient *http.Client
+}
+
+type Client struct {
+	endpoint   string
+	websiteID  string
+	app        string
+	version    string
+	goos       string
+	goarch     string
+	httpClient *http.Client
+
+	mu     sync.Mutex
+	closed bool
+	wg     sync.WaitGroup
+}
+
+type noopSink struct{}
+
+type collectRequest struct {
+	Type    string         `json:"type"`
+	Payload collectPayload `json:"payload"`
+}
+
+type collectPayload struct {
+	Website   string         `json:"website"`
+	Hostname  string         `json:"hostname"`
+	Title     string         `json:"title"`
+	URL       string         `json:"url"`
+	Name      string         `json:"name"`
+	Data      map[string]any `json:"data,omitempty"`
+	Timestamp int64          `json:"timestamp,omitempty"`
+}
+
+var (
+	defaultMu   sync.Mutex
+	defaultSink Sink
+)
+
+func NewClient(cfg Config) (*Client, error) {
+	endpoint, err := normalizeEndpoint(cfg.Host)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.WebsiteID == "" {
+		return nil, fmt.Errorf("website ID is required")
+	}
+	if cfg.App == "" {
+		cfg.App = "no-mistakes"
+	}
+	if cfg.Version == "" {
+		cfg.Version = buildinfo.CurrentVersion()
+	}
+	if cfg.GOOS == "" {
+		cfg.GOOS = runtime.GOOS
+	}
+	if cfg.GOARCH == "" {
+		cfg.GOARCH = runtime.GOARCH
+	}
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = &http.Client{Timeout: time.Second}
+	}
+
+	return &Client{
+		endpoint:   endpoint,
+		websiteID:  cfg.WebsiteID,
+		app:        cfg.App,
+		version:    cfg.Version,
+		goos:       cfg.GOOS,
+		goarch:     cfg.GOARCH,
+		httpClient: cfg.HTTPClient,
+	}, nil
+}
+
+func Default() Sink {
+	defaultMu.Lock()
+	defer defaultMu.Unlock()
+
+	if defaultSink != nil {
+		return defaultSink
+	}
+
+	websiteID := defaultWebsiteID()
+	if websiteID == "" {
+		defaultSink = noopSink{}
+		return defaultSink
+	}
+
+	client, err := NewClient(Config{
+		Host:      umamiCloudURL,
+		WebsiteID: websiteID,
+		App:       "no-mistakes",
+		Version:   buildinfo.CurrentVersion(),
+		GOOS:      runtime.GOOS,
+		GOARCH:    runtime.GOARCH,
+	})
+	if err != nil {
+		defaultSink = noopSink{}
+		return defaultSink
+	}
+
+	defaultSink = client
+	return defaultSink
+}
+
+func SetDefaultForTesting(sink Sink) func() {
+	defaultMu.Lock()
+	prev := defaultSink
+	if sink == nil {
+		sink = noopSink{}
+	}
+	defaultSink = sink
+	defaultMu.Unlock()
+
+	return func() {
+		defaultMu.Lock()
+		defaultSink = prev
+		defaultMu.Unlock()
+	}
+}
+
+func Track(name string, fields Fields) {
+	Default().Track(name, fields)
+}
+
+func Close(ctx context.Context) error {
+	return Default().Close(ctx)
+}
+
+func (c *Client) Track(name string, fields Fields) {
+	if c == nil || strings.TrimSpace(name) == "" {
+		return
+	}
+
+	body, err := c.newRequest(name, fields)
+	if err != nil {
+		return
+	}
+
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
+	c.wg.Add(1)
+	c.mu.Unlock()
+
+	go func(payload []byte) {
+		defer c.wg.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		c.send(ctx, payload)
+	}(body)
+}
+
+func (c *Client) Close(ctx context.Context) error {
+	if c == nil {
+		return nil
+	}
+
+	c.mu.Lock()
+	c.closed = true
+	c.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.wg.Wait()
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (noopSink) Track(string, Fields) {}
+
+func (noopSink) Close(context.Context) error { return nil }
+
+func (c *Client) newRequest(name string, fields Fields) ([]byte, error) {
+	data := make(map[string]any, len(fields)+4)
+	for k, v := range fields {
+		data[k] = v
+	}
+	data["app_version"] = c.version
+	data["goos"] = c.goos
+	data["goarch"] = c.goarch
+	data["build_channel"] = buildChannel(c.version)
+
+	return json.Marshal(collectRequest{
+		Type: "event",
+		Payload: collectPayload{
+			Website:   c.websiteID,
+			Hostname:  defaultHostname,
+			Title:     defaultTitle,
+			URL:       eventURL(c.app, name),
+			Name:      name,
+			Data:      data,
+			Timestamp: time.Now().Unix(),
+		},
+	})
+}
+
+func (c *Client) send(ctx context.Context, payload []byte) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", fmt.Sprintf("no-mistakes/%s telemetry", c.version))
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+}
+
+func normalizeEndpoint(host string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(host))
+	if err != nil {
+		return "", fmt.Errorf("parse host: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("invalid host %q", host)
+	}
+	if strings.HasSuffix(u.Path, defaultPath) {
+		return strings.TrimRight(u.String(), "/"), nil
+	}
+	base := strings.TrimRight(u.Path, "/")
+	if base == "" {
+		u.Path = defaultPath
+	} else {
+		u.Path = base + defaultPath
+	}
+	return u.String(), nil
+}
+
+func eventURL(app, name string) string {
+	if app == "" {
+		app = "no-mistakes"
+	}
+	if name == "" {
+		return "app://" + app
+	}
+	return "app://" + app + "/" + strings.ReplaceAll(name, ".", "/")
+}
+
+func buildChannel(version string) string {
+	if version == "" || version == "dev" {
+		return "dev"
+	}
+	return "release"
+}
+
+func defaultWebsiteID() string {
+	websiteID := strings.TrimSpace(os.Getenv(umamiWebsiteIDEnv))
+
+	if buildChannel(buildinfo.CurrentVersion()) == "dev" && websiteID == "" {
+		values := loadDotEnvValues()
+		websiteID = strings.TrimSpace(values[umamiWebsiteIDEnv])
+	}
+
+	if websiteID == "" {
+		websiteID = strings.TrimSpace(buildinfo.TelemetryWebsiteID)
+	}
+
+	return websiteID
+}
+
+func loadDotEnvValues() map[string]string {
+	wd, err := os.Getwd()
+	if err != nil {
+		return nil
+	}
+
+	path, ok := findDotEnv(wd)
+	if !ok {
+		return nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+
+	return parseDotEnv(data)
+}
+
+func findDotEnv(dir string) (string, bool) {
+	for {
+		path := filepath.Join(dir, ".env")
+		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+			return path, true
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false
+		}
+		dir = parent
+	}
+}
+
+func parseDotEnv(data []byte) map[string]string {
+	values := map[string]string{}
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "export ") {
+			line = strings.TrimSpace(strings.TrimPrefix(line, "export "))
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		values[key] = dotenvValue(strings.TrimSpace(value))
+	}
+	return values
+}
+
+func dotenvValue(value string) string {
+	if len(value) >= 2 {
+		quote := value[0]
+		if (quote == '"' || quote == '\'') && value[len(value)-1] == quote {
+			if unquoted, err := strconv.Unquote(value); err == nil {
+				return unquoted
+			}
+			return value[1 : len(value)-1]
+		}
+	}
+	return value
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -338,10 +338,34 @@ func loadDotEnvValues() map[string]string {
 }
 
 func findDotEnv(dir string) (string, bool) {
+	repoRoot, ok := findRepoRoot(dir)
+	if !ok {
+		path := filepath.Join(dir, ".env")
+		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+			return path, true
+		}
+		return "", false
+	}
+
 	for {
 		path := filepath.Join(dir, ".env")
 		if info, err := os.Stat(path); err == nil && !info.IsDir() {
 			return path, true
+		}
+		if dir == repoRoot {
+			return "", false
+		}
+
+		parent := filepath.Dir(dir)
+		dir = parent
+	}
+}
+
+func findRepoRoot(dir string) (string, bool) {
+	for {
+		path := filepath.Join(dir, ".git")
+		if _, err := os.Stat(path); err == nil {
+			return dir, true
 		}
 
 		parent := filepath.Dir(dir)

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -395,9 +395,21 @@ func parseDotEnv(data []byte) map[string]string {
 		if key == "" {
 			continue
 		}
-		values[key] = dotenvValue(trimDotEnvInlineComment(strings.TrimSpace(value)))
+		trimmedValue := strings.TrimSpace(value)
+		if !isQuotedDotEnvValue(trimmedValue) {
+			trimmedValue = trimDotEnvInlineComment(trimmedValue)
+		}
+		values[key] = dotenvValue(trimmedValue)
 	}
 	return values
+}
+
+func isQuotedDotEnvValue(value string) bool {
+	if len(value) < 2 {
+		return false
+	}
+	quote := value[0]
+	return (quote == '"' || quote == '\'') && value[len(value)-1] == quote
 }
 
 func trimDotEnvInlineComment(value string) string {

--- a/makefile_test.go
+++ b/makefile_test.go
@@ -54,6 +54,29 @@ func TestMakeBuildUsesEnvUmamiWebsiteIDWhenDotEnvMissing(t *testing.T) {
 	}
 }
 
+func TestMakeBuildIgnoresUnrelatedDotEnvEntries(t *testing.T) {
+	skipMakeBuildTestsOnWindows(t)
+
+	makePath, err := exec.LookPath("make")
+	if err != nil {
+		t.Skip("make not available")
+	}
+
+	workDir := writeTestMakeWorkspace(t)
+	if err := os.WriteFile(filepath.Join(workDir, ".env"), []byte("VERSION=from-dotenv\nNO_MISTAKES_UMAMI_WEBSITE_ID=website-from-dotenv\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	output := runMakeDryBuild(t, makePath, workDir, nil)
+
+	if !strings.Contains(output, "TelemetryWebsiteID=website-from-dotenv") {
+		t.Fatalf("make build output should still embed dotenv website id, got:\n%s", output)
+	}
+	if strings.Contains(output, "/internal/buildinfo.Version=from-dotenv") {
+		t.Fatalf("make build should ignore unrelated dotenv entries, got:\n%s", output)
+	}
+}
+
 func skipMakeBuildTestsOnWindows(t *testing.T) {
 	t.Helper()
 	if runtime.GOOS == "windows" {

--- a/makefile_test.go
+++ b/makefile_test.go
@@ -77,6 +77,29 @@ func TestMakeBuildIgnoresUnrelatedDotEnvEntries(t *testing.T) {
 	}
 }
 
+func TestMakeBuildStripsInlineCommentsFromDotEnvUmamiWebsiteID(t *testing.T) {
+	skipMakeBuildTestsOnWindows(t)
+
+	makePath, err := exec.LookPath("make")
+	if err != nil {
+		t.Skip("make not available")
+	}
+
+	workDir := writeTestMakeWorkspace(t)
+	if err := os.WriteFile(filepath.Join(workDir, ".env"), []byte("NO_MISTAKES_UMAMI_WEBSITE_ID=website-from-dotenv # dev\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	output := runMakeDryBuild(t, makePath, workDir, nil)
+
+	if !strings.Contains(output, "TelemetryWebsiteID=website-from-dotenv") {
+		t.Fatalf("make build output should strip inline comments from dotenv website id, got:\n%s", output)
+	}
+	if strings.Contains(output, "TelemetryWebsiteID=website-from-dotenv # dev") {
+		t.Fatalf("make build output should not embed inline comments in website id, got:\n%s", output)
+	}
+}
+
 func skipMakeBuildTestsOnWindows(t *testing.T) {
 	t.Helper()
 	if runtime.GOOS == "windows" {

--- a/makefile_test.go
+++ b/makefile_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMakeBuildPrioritizesDotEnvUmamiWebsiteID(t *testing.T) {
+	skipMakeBuildTestsOnWindows(t)
+
+	makePath, err := exec.LookPath("make")
+	if err != nil {
+		t.Skip("make not available")
+	}
+
+	workDir := writeTestMakeWorkspace(t)
+	if err := os.WriteFile(filepath.Join(workDir, ".env"), []byte("NO_MISTAKES_UMAMI_WEBSITE_ID=website-from-dotenv\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	output := runMakeDryBuild(t, makePath, workDir, map[string]string{
+		"UMAMI_WEBSITE_ID": "website-from-env",
+	})
+
+	if !strings.Contains(output, "TelemetryWebsiteID=website-from-dotenv") {
+		t.Fatalf("make build output should embed .env website id, got:\n%s", output)
+	}
+	if strings.Contains(output, "TelemetryWebsiteID=website-from-env") {
+		t.Fatalf("make build output should not prefer env website id when .env exists, got:\n%s", output)
+	}
+}
+
+func TestMakeBuildUsesEnvUmamiWebsiteIDWhenDotEnvMissing(t *testing.T) {
+	skipMakeBuildTestsOnWindows(t)
+
+	makePath, err := exec.LookPath("make")
+	if err != nil {
+		t.Skip("make not available")
+	}
+
+	workDir := writeTestMakeWorkspace(t)
+	output := runMakeDryBuild(t, makePath, workDir, map[string]string{
+		"UMAMI_WEBSITE_ID": "website-from-env",
+	})
+
+	if !strings.Contains(output, "TelemetryWebsiteID=website-from-env") {
+		t.Fatalf("make build output should embed env website id when .env is absent, got:\n%s", output)
+	}
+}
+
+func skipMakeBuildTestsOnWindows(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("make build tests are POSIX-oriented")
+	}
+}
+
+func writeTestMakeWorkspace(t *testing.T) string {
+	t.Helper()
+
+	data, err := os.ReadFile("Makefile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workDir, "Makefile"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return workDir
+}
+
+func runMakeDryBuild(t *testing.T, makePath, workDir string, extraEnv map[string]string) string {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, makePath, "-n", "build")
+	cmd.Dir = workDir
+	cmd.Env = filteredEnv(os.Environ(), "UMAMI_WEBSITE_ID", "NO_MISTAKES_UMAMI_WEBSITE_ID")
+	for key, value := range extraEnv {
+		cmd.Env = append(cmd.Env, key+"="+value)
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("make -n build failed: %v\n%s", err, out)
+	}
+	return string(out)
+}

--- a/makefile_test.go
+++ b/makefile_test.go
@@ -100,6 +100,29 @@ func TestMakeBuildStripsInlineCommentsFromDotEnvUmamiWebsiteID(t *testing.T) {
 	}
 }
 
+func TestMakeBuildPreservesQuotedHashInDotEnvUmamiWebsiteID(t *testing.T) {
+	skipMakeBuildTestsOnWindows(t)
+
+	makePath, err := exec.LookPath("make")
+	if err != nil {
+		t.Skip("make not available")
+	}
+
+	workDir := writeTestMakeWorkspace(t)
+	if err := os.WriteFile(filepath.Join(workDir, ".env"), []byte("NO_MISTAKES_UMAMI_WEBSITE_ID=\"website # dev\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	output := runMakeDryBuild(t, makePath, workDir, nil)
+
+	if !strings.Contains(output, "TelemetryWebsiteID=website # dev") {
+		t.Fatalf("make build output should preserve quoted hashes in dotenv website id, got:\n%s", output)
+	}
+	if strings.Contains(output, "TelemetryWebsiteID=\"website") {
+		t.Fatalf("make build output should not truncate quoted dotenv website id, got:\n%s", output)
+	}
+}
+
 func skipMakeBuildTestsOnWindows(t *testing.T) {
 	t.Helper()
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
## Summary
- Add a new `internal/telemetry` client and wire telemetry into CLI commands, daemon run lifecycle, pipeline execution, and approval/fix flows so installs with a configured website ID can report usage events.
- Tighten telemetry enablement and event reporting by fixing command status handling, panic/exit paths, and `.env` parsing in both runtime config and build/release metadata injection.
- Document telemetry configuration, destination, and installer/update behavior across the README and docs so users understand when telemetry is enabled and what release binaries change.

## Risk Assessment

⚠️ Medium: The telemetry change is otherwise well-bounded, but the new build-time embedding path can produce broken local and release binaries for supported dotenv values, so it should be fixed before relying on this rollout.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

**Round 1** - found 3 warnings
- ⚠️ `internal/telemetry/telemetry.go:340` - `findDotEnv` walks parent directories all the way to filesystem root, so a dev build started from a subdirectory can pick up an unrelated ancestor `.env` such as `~/.env` and silently enable telemetry for the wrong workspace. Stop discovery at the repo boundary or only read the local working tree&#39;s dotenv file.
- ⚠️ `Makefile:4` - `-include .env` makes `make` parse the entire dotenv file as make syntax. Unrelated `.env` entries can change evaluation or break `make build`, even though this change only needs one telemetry variable. Extract `NO_MISTAKES_UMAMI_WEBSITE_ID` explicitly instead of including the whole file.
- ⚠️ `internal/cli/telemetry.go:9` - `trackCommand` derives success solely from the returned error, but some wrapped commands intentionally return `nil` after surfacing a problem to the user, such as `status` when `findRepo` fails and `doctor` when checks fail. The new telemetry will therefore overreport successful command executions.

**Round 2** (auto-fix) - found 3 warnings
- ⚠️ `internal/pipeline/executor.go:359` - `selectedFindingCount` falls back to the total findings count when `findingIDs` is empty, so approve/skip/abort actions now report `selected_findings_count` as if the user explicitly selected every finding. That makes the new approval telemetry materially misleading; only populate this field when IDs were actually provided, or rename it to reflect its real meaning.
- ⚠️ `internal/daemon/manager.go:340` - The new run telemetry never emits a terminal `run` event from the panic-recovery path. If a pipeline goroutine panics, analytics will record `action=started` without any matching `action=finished`, which hides the failure mode and skews started-vs-finished counts.
- ⚠️ `internal/telemetry/telemetry.go:390` - The dotenv parser now treats inline comments as part of the value, so a common entry like `NO_MISTAKES_UMAMI_WEBSITE_ID=abc123 # dev` produces a malformed website ID and silently disables telemetry in dev builds. Strip trailing comments for unquoted values before storing the parsed result.

**Round 3** (auto-fix) - found 2 warnings
- ⚠️ `cmd/no-mistakes/main.go:51` - The new telemetry flush is deferred in `main`, but `cli.Execute()` still calls `os.Exit(1)` on command errors, which skips defers entirely. That means failing CLI commands drop their async telemetry events before `telemetry.Close` can drain them, so error-path command tracking will be systematically missing unless exit handling is moved out of `cli.Execute` or flushed before exit.
- ⚠️ `Makefile:4` - The new `.env` extraction still captures trailing inline comments and similar suffixes, so a common entry like `NO_MISTAKES_UMAMI_WEBSITE_ID=abc123 # dev` gets embedded literally into `TelemetryWebsiteID` and disables telemetry in built binaries. Reuse the same comment-stripping behavior as the runtime dotenv parser before assigning `UMAMI_WEBSITE_ID`.

**Round 4** (auto-fix) - found 2 warnings
- ⚠️ `internal/telemetry/telemetry.go:306` - Release binaries with an embedded `TelemetryWebsiteID` will always emit command/run metadata, but `defaultWebsiteID` has no runtime opt-out or disable flag - only build-time omission stops collection. Because this sends behavioral data from user machines after install, confirm that always-on telemetry without a user-controlled kill switch is intentional before merging.
- ⚠️ `internal/telemetry/telemetry.go:398` - `parseDotEnv` strips inline comments before unquoting, so a valid quoted entry like `NO_MISTAKES_UMAMI_WEBSITE_ID=&#34;abc # dev&#34;` is truncated to `&#34;abc` and silently disables telemetry. Strip comments only for unquoted values, or unquote first and then trim comments only when the value was not quoted.

**Round 5** (auto-fix) - found 1 warning
- ⚠️ `Makefile:4` - The new `.env` extraction still strips `#...` before unquoting, so a valid quoted entry like `NO_MISTAKES_UMAMI_WEBSITE_ID=&#34;abc # dev&#34;` is truncated during `make build`/`make dist` and embeds a broken telemetry website ID. Apply the same quoted-vs-unquoted handling as `parseDotEnv` before removing inline comments.

**Round 6** (auto-fix) - found 1 warning
- ⚠️ `Makefile:9` - The new dotenv parsing and tests now allow quoted `NO_MISTAKES_UMAMI_WEBSITE_ID` values containing spaces or `#`, but `TelemetryWebsiteID` is injected into `-ldflags` without escaping. `go build` splits that linker arg on spaces, so values like `&#34;website # dev&#34;` will break `make build/dist` or embed only a prefix; escape or quote the value before passing it to `-X` (the release workflow has the same issue).

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>🔧 **Document** - 3 issues found → auto-fixed (5)</summary>

**Round 1** - found 3 warnings
- ⚠️ `docs/src/content/docs/reference/environment.md:58` - The environment-variable reference is missing `NO_MISTAKES_UMAMI_WEBSITE_ID`, which the new telemetry client now reads at runtime to override or enable telemetry. Document what it does, when it takes effect, and that dev builds also fall back to a repo-local `.env` value for this key.
- ⚠️ `docs/src/content/docs/start-here/installation.md:30` - The source-build instructions do not mention the new build-time telemetry configuration. `make build` now embeds `TelemetryWebsiteID` from `.env` (`NO_MISTAKES_UMAMI_WEBSITE_ID`) or `UMAMI_WEBSITE_ID`, so the installation/build docs should explain that behavior for maintainers and anyone producing custom binaries.
- ⚠️ `README.md:40` - The main README install/development guidance is now stale relative to the telemetry change. It still tells users to install or build the CLI without disclosing that release builds send telemetry when a website ID is embedded, or that local builds can opt in via `.env` / `UMAMI_WEBSITE_ID`. Add a short note or link so the top-level docs match the new runtime behavior.

**Round 2** (auto-fix) - found 2 warnings
- ⚠️ `docs/src/content/docs/reference/environment.md:78` - The `NO_MISTAKES_UMAMI_WEBSITE_ID` entry still describes release builds as using only the embedded website ID, but the new lookup order checks `NO_MISTAKES_UMAMI_WEBSITE_ID` first and only falls back to the embedded build-time ID when the env var is unset. Update this section to document the actual precedence so the runtime override behavior is accurate.
- ⚠️ `docs/src/content/docs/start-here/installation.md:12` - The installation guide now explains telemetry for `make build`, but it still does not tell users that the official macOS/Linux and Windows installer paths fetch release binaries that may already have telemetry enabled via an embedded website ID. Add a short note near the release install sections so the install guide matches the new runtime behavior, not just source builds.

**Round 3** (auto-fix) - found 3 warnings
- ⚠️ `docs/src/content/docs/reference/environment.md:78` - The new telemetry docs explain how `NO_MISTAKES_UMAMI_WEBSITE_ID` enables telemetry, but they still do not describe what telemetry is sent. The code now emits command, run, step, approval, and fix events plus app/version/platform metadata, so this reference should summarize the tracked event categories to make the new runtime behavior clear.
- ⚠️ `docs/src/content/docs/start-here/quick-start.md:14` - The quick-start install path uses the official release installer, but this page does not mention the new telemetry behavior. Add the same short note used in the installation guide so users following the quick start are told that installer-fetched release binaries may already have telemetry enabled via an embedded website ID.
- ⚠️ `internal/buildinfo/version.go:5` - The build-time ldflags doc comment is now stale. It documents `Version`, `Commit`, and `Date`, but omits the newly added `TelemetryWebsiteID` ldflag that release builds and `make build` now inject. Update the comment so the code-level build metadata docs match the new build contract.

**Round 4** (auto-fix) - found 1 warning
- ⚠️ `docs/src/content/docs/reference/environment.md:80` - The telemetry reference explains how telemetry is enabled and which event categories are emitted, but it still does not disclose where those events are sent. The new client posts telemetry to Umami Cloud at `https://cloud.umami.is/api/send`, so this section should name that fixed destination to make the runtime network behavior clear.

**Round 5** (auto-fix) - found 3 warnings
- ⚠️ `docs/src/content/docs/start-here/installation.md:28` - The `Go install` section does not explain telemetry behavior for that install path. `go install github.com/kunchenguid/no-mistakes/cmd/no-mistakes@latest` does not embed `TelemetryWebsiteID` the way release builds and `make build` can, so the install guide should say that this path is telemetry-off by default unless telemetry is enabled later at runtime via `NO_MISTAKES_UMAMI_WEBSITE_ID`.
- ⚠️ `docs/src/content/docs/start-here/installation.md:58` - The `Update` section is stale relative to the telemetry change. `no-mistakes update` replaces the current binary with the latest official release, and those release binaries may already have telemetry enabled through an embedded website ID, so this section should disclose that the update path can change telemetry behavior just like the installer path does.
- ⚠️ `docs/src/content/docs/reference/cli.md:110` - The `no-mistakes update` command reference omits the new telemetry implication of the update flow. Because `update` downloads an official release binary, the command docs should note that the replacement binary may already have telemetry enabled via an embedded website ID so the command reference matches the runtime behavior now introduced by release builds.

**Round 6** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
