### PR TITLE
feat(telemetry): track wizard and tui pageviews

### DIFF
--- a/docs/src/content/docs/reference/environment.md
+++ b/docs/src/content/docs/reference/environment.md
@@ -77,7 +77,7 @@ Override or enable the telemetry website ID.
 
 When set, telemetry uses this website ID at runtime. If it is unset in a dev build, `no-mistakes` also checks a repo-local `.env` file for `NO_MISTAKES_UMAMI_WEBSITE_ID`. If no runtime value is found, it falls back to any website ID embedded at build time.
 
-When telemetry is enabled, `no-mistakes` sends command, run, step, approval, and fix events plus app version, platform, and build-channel metadata to Umami Cloud at `https://cloud.umami.is/api/send`.
+When telemetry is enabled, `no-mistakes` sends command, run, step, approval, fix, and wizard events plus pageviews for `/wizard` and `/tui`, along with app version, platform, and build-channel metadata, to Umami Cloud at `https://cloud.umami.is/api/send`.
 
 ## Environment the daemon sees
 

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -10,11 +10,14 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/daemon"
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
+	"github.com/kunchenguid/no-mistakes/internal/telemetry"
 	"github.com/kunchenguid/no-mistakes/internal/tui"
 	"github.com/kunchenguid/no-mistakes/internal/update"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 )
+
+var runTUI = tui.Run
 
 // attachRun is the shared logic for attaching to a pipeline run. It's used by
 // both the root command (bare `no-mistakes`) and the `attach` subcommand.
@@ -109,7 +112,20 @@ func attachRun(w io.Writer, runID string, rootDefault bool) error {
 		}
 	}
 
-	return tui.Run(p.Socket(), client, run, update.CachedLatestVersion())
+	telemetry.Pageview("/tui", telemetry.Fields{
+		"entrypoint":      attachEntrypoint(rootDefault, runID),
+		"run_status":      run.Status,
+		"explicit_run_id": runID != "",
+	})
+
+	return runTUI(p.Socket(), client, run, update.CachedLatestVersion())
+}
+
+func attachEntrypoint(rootDefault bool, runID string) string {
+	if rootDefault && runID == "" {
+		return "root"
+	}
+	return "attach"
 }
 
 func activeRunBranch(state *repoState, rootDefault bool) string {

--- a/internal/cli/telemetry_test.go
+++ b/internal/cli/telemetry_test.go
@@ -3,10 +3,14 @@ package cli
 import (
 	"context"
 	"fmt"
+	"io"
 	"path/filepath"
 	"sync"
 	"testing"
 
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/ipc"
+	"github.com/kunchenguid/no-mistakes/internal/paths"
 	"github.com/kunchenguid/no-mistakes/internal/telemetry"
 )
 
@@ -21,6 +25,19 @@ type telemetryRecorder struct {
 }
 
 func (r *telemetryRecorder) Track(name string, fields telemetry.Fields) {
+	r.record(name, fields)
+}
+
+func (r *telemetryRecorder) Pageview(path string, fields telemetry.Fields) {
+	clone := make(telemetry.Fields, len(fields)+1)
+	for k, v := range fields {
+		clone[k] = v
+	}
+	clone["path"] = path
+	r.record("pageview", clone)
+}
+
+func (r *telemetryRecorder) record(name string, fields telemetry.Fields) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -118,5 +135,52 @@ func TestDoctorTracksFailedChecksAsError(t *testing.T) {
 	}
 	if got := event.fields["status"]; got != "error" {
 		t.Fatalf("status = %v, want error", got)
+	}
+}
+
+func TestAttachTracksTUIPageview(t *testing.T) {
+	nmHome := makeSocketSafeTempDir(t)
+	t.Setenv("NM_HOME", nmHome)
+	p := paths.WithRoot(nmHome)
+
+	d, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	repo, err := d.InsertRepoWithID("repo-1", "/tmp/repo", "https://github.com/test/repo", "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	startTestDaemon(t, p, d)
+
+	run, err := d.InsertRun(repo.ID, "feature/test", "abc123", "def456")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	recorder := &telemetryRecorder{}
+	restore := telemetry.SetDefaultForTesting(recorder)
+	defer restore()
+
+	prevRunTUI := runTUI
+	runTUI = func(string, *ipc.Client, *ipc.RunInfo, string) error { return nil }
+	defer func() { runTUI = prevRunTUI }()
+
+	if err := attachRun(io.Discard, run.ID, false); err != nil {
+		t.Fatalf("attachRun() error = %v", err)
+	}
+
+	event := recorder.find("pageview", "path", "/tui")
+	if event == nil {
+		t.Fatal("expected TUI pageview telemetry")
+	}
+	if got := event.fields["entrypoint"]; got != "attach" {
+		t.Fatalf("entrypoint = %v, want attach", got)
+	}
+	if got := fmt.Sprint(event.fields["run_status"]); got != "pending" {
+		t.Fatalf("run_status = %v, want pending", got)
 	}
 }

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/telemetry"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 	"github.com/kunchenguid/no-mistakes/internal/wizard"
 )
@@ -25,6 +26,7 @@ var resolveWizardAgent = func(ctx context.Context, cfg *config.Config) error {
 }
 
 var newWizardAgent = agent.New
+var wizardRun = wizard.Run
 
 type wizardAgentSuggester struct {
 	cfg     *config.Config
@@ -189,9 +191,30 @@ func runWizard(ctx context.Context, p *paths.Paths, state *repoState) (wizard.Re
 		SuggestCommit: func(ctx context.Context) (string, error) {
 			return suggester.suggestCommit(ctx)
 		},
+		Track: func(action string, fields map[string]any) {
+			telemetry.Track("wizard", mergeTelemetryFields(fields, telemetry.Fields{"action": action}))
+		},
 	}
 
-	return wizard.Run(wizCfg)
+	telemetry.Pageview("/wizard", telemetry.Fields{
+		"entrypoint":          "wizard",
+		"needs_branch":        state.needsBranch(),
+		"is_dirty":            state.dirty,
+		"detached":            state.detached,
+		"current_branch_role": wizardBranchRole(state.currentBranch, state.defaultBranch, state.detached),
+	})
+
+	res, err := wizardRun(wizCfg)
+	if err == nil {
+		telemetry.Track("wizard", telemetry.Fields{
+			"action":         "result",
+			"status":         wizardResultStatus(res),
+			"branch_created": res.BranchCreated,
+			"commit_made":    res.CommitMade,
+			"pushed":         res.Pushed,
+		})
+	}
+	return res, err
 }
 
 // captureAgentServerOutput routes managed-server logs to a file under
@@ -235,4 +258,35 @@ func waitForActiveRun(client *ipc.Client, repoID, branch string, timeout time.Du
 		}
 		time.Sleep(150 * time.Millisecond)
 	}
+}
+
+func wizardBranchRole(currentBranch, defaultBranch string, detached bool) string {
+	if detached {
+		return "detached"
+	}
+	if currentBranch != "" && currentBranch == defaultBranch {
+		return "default"
+	}
+	return "feature"
+}
+
+func wizardResultStatus(res wizard.Result) string {
+	if res.Success {
+		return "completed"
+	}
+	if res.Aborted {
+		return "aborted"
+	}
+	return "closed"
+}
+
+func mergeTelemetryFields(fields map[string]any, extra telemetry.Fields) telemetry.Fields {
+	merged := make(telemetry.Fields, len(fields)+len(extra))
+	for k, v := range fields {
+		merged[k] = v
+	}
+	for k, v := range extra {
+		merged[k] = v
+	}
+	return merged
 }

--- a/internal/cli/wizard_test.go
+++ b/internal/cli/wizard_test.go
@@ -3,10 +3,15 @@ package cli
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/kunchenguid/no-mistakes/internal/config"
+	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/telemetry"
 	"github.com/kunchenguid/no-mistakes/internal/types"
+	"github.com/kunchenguid/no-mistakes/internal/wizard"
 )
 
 func TestShouldRouteToWizard(t *testing.T) {
@@ -93,5 +98,71 @@ func TestWizardAgentSuggester_IsLazy(t *testing.T) {
 	}
 	if lookups != 1 {
 		t.Fatalf("expected one lazy resolution attempt, got %d", lookups)
+	}
+}
+
+func TestRunWizardTracksPageview(t *testing.T) {
+	recorder := &telemetryRecorder{}
+	restoreTelemetry := telemetry.SetDefaultForTesting(recorder)
+	defer restoreTelemetry()
+
+	prevRun := wizardRun
+	wizardRun = func(cfg wizard.Config) (wizard.Result, error) {
+		return wizard.Result{Success: true, BranchCreated: true, CommitMade: true, Pushed: true}, nil
+	}
+	defer func() { wizardRun = prevRun }()
+
+	nmHome := makeSocketSafeTempDir(t)
+	t.Setenv("NM_HOME", nmHome)
+	p := paths.WithRoot(nmHome)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	repoDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repoDir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	state := &repoState{
+		workDir:       repoDir,
+		currentBranch: "main",
+		defaultBranch: "main",
+		detached:      false,
+		dirty:         true,
+	}
+
+	if _, err := runWizard(context.Background(), p, state); err != nil {
+		t.Fatalf("runWizard() error = %v", err)
+	}
+
+	event := recorder.find("pageview", "path", "/wizard")
+	if event == nil {
+		t.Fatal("expected wizard pageview telemetry")
+	}
+	if got := event.fields["needs_branch"]; got != true {
+		t.Fatalf("needs_branch = %v, want true", got)
+	}
+	if got := event.fields["is_dirty"]; got != true {
+		t.Fatalf("is_dirty = %v, want true", got)
+	}
+	if got := event.fields["detached"]; got != false {
+		t.Fatalf("detached = %v, want false", got)
+	}
+	if got := event.fields["entrypoint"]; got != "wizard" {
+		t.Fatalf("entrypoint = %v, want wizard", got)
+	}
+	if got := event.fields["current_branch_role"]; got != "default" {
+		t.Fatalf("current_branch_role = %v, want default", got)
+	}
+	resultEvent := recorder.find("wizard", "action", "result")
+	if resultEvent == nil {
+		t.Fatal("expected wizard result telemetry")
+	}
+	if got := resultEvent.fields["status"]; got != "completed" {
+		t.Fatalf("status = %v, want completed", got)
+	}
+	if got := resultEvent.fields["branch_created"]; got != true {
+		t.Fatalf("branch_created = %v, want true", got)
 	}
 }

--- a/internal/daemon/telemetry_test.go
+++ b/internal/daemon/telemetry_test.go
@@ -29,6 +29,10 @@ func (r *telemetryRecorder) Track(name string, fields telemetry.Fields) {
 	r.events = append(r.events, recordedTelemetryEvent{name: name, fields: clone})
 }
 
+func (r *telemetryRecorder) Pageview(path string, fields telemetry.Fields) {
+	r.Track("pageview", fields)
+}
+
 func (r *telemetryRecorder) Close(context.Context) error { return nil }
 
 func (r *telemetryRecorder) find(name, field string, want any) *recordedTelemetryEvent {

--- a/internal/pipeline/telemetry_test.go
+++ b/internal/pipeline/telemetry_test.go
@@ -29,6 +29,10 @@ func (r *telemetryRecorder) Track(name string, fields telemetry.Fields) {
 	r.events = append(r.events, recordedTelemetryEvent{name: name, fields: clone})
 }
 
+func (r *telemetryRecorder) Pageview(path string, fields telemetry.Fields) {
+	r.Track("pageview", fields)
+}
+
 func (r *telemetryRecorder) Close(context.Context) error { return nil }
 
 func (r *telemetryRecorder) find(name, field string, want any) *recordedTelemetryEvent {

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -110,3 +110,82 @@ func TestClientTrackSendsUmamiEventPayload(t *testing.T) {
 		t.Fatal("timed out waiting for telemetry request")
 	}
 }
+
+func TestClientPageviewSendsUmamiPageviewPayload(t *testing.T) {
+	t.Parallel()
+
+	type requestBody struct {
+		Type    string `json:"type"`
+		Payload struct {
+			Website string         `json:"website"`
+			Name    *string        `json:"name,omitempty"`
+			URL     string         `json:"url"`
+			Title   string         `json:"title"`
+			Data    map[string]any `json:"data"`
+		} `json:"payload"`
+	}
+
+	reqCh := make(chan requestBody, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		defer r.Body.Close()
+
+		var got requestBody
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Fatalf("unmarshal body: %v\nbody=%s", err, string(body))
+		}
+		reqCh <- got
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"disabled":false}`)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(Config{
+		Host:       server.URL,
+		WebsiteID:  "website-123",
+		App:        "no-mistakes",
+		Version:    "v1.2.3",
+		GOOS:       "darwin",
+		GOARCH:     "arm64",
+		HTTPClient: server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	client.Pageview("/tui", Fields{"entrypoint": "attach"})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := client.Close(ctx); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	select {
+	case got := <-reqCh:
+		if got.Type != "event" {
+			t.Fatalf("type = %q, want %q", got.Type, "event")
+		}
+		if got.Payload.Website != "website-123" {
+			t.Fatalf("website = %q, want %q", got.Payload.Website, "website-123")
+		}
+		if got.Payload.Name != nil {
+			t.Fatalf("name = %v, want omitted for pageview", *got.Payload.Name)
+		}
+		if got.Payload.URL != "/tui" {
+			t.Fatalf("url = %q, want %q", got.Payload.URL, "/tui")
+		}
+		if got.Payload.Title != "no-mistakes CLI" {
+			t.Fatalf("title = %q, want %q", got.Payload.Title, "no-mistakes CLI")
+		}
+		if got.Payload.Data["entrypoint"] != "attach" {
+			t.Fatalf("data.entrypoint = %v, want %q", got.Payload.Data["entrypoint"], "attach")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for telemetry request")
+	}
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -34,6 +34,7 @@ type Fields map[string]any
 
 type Sink interface {
 	Track(name string, fields Fields)
+	Pageview(path string, fields Fields)
 	Close(ctx context.Context) error
 }
 
@@ -73,7 +74,7 @@ type collectPayload struct {
 	Hostname  string         `json:"hostname"`
 	Title     string         `json:"title"`
 	URL       string         `json:"url"`
-	Name      string         `json:"name"`
+	Name      string         `json:"name,omitempty"`
 	Data      map[string]any `json:"data,omitempty"`
 	Timestamp int64          `json:"timestamp,omitempty"`
 }
@@ -169,6 +170,10 @@ func Track(name string, fields Fields) {
 	Default().Track(name, fields)
 }
 
+func Pageview(path string, fields Fields) {
+	Default().Pageview(path, fields)
+}
+
 func Close(ctx context.Context) error {
 	return Default().Close(ctx)
 }
@@ -178,7 +183,33 @@ func (c *Client) Track(name string, fields Fields) {
 		return
 	}
 
-	body, err := c.newRequest(name, fields)
+	body, err := c.newRequest(name, eventURL(c.app, name), fields)
+	if err != nil {
+		return
+	}
+
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
+	c.wg.Add(1)
+	c.mu.Unlock()
+
+	go func(payload []byte) {
+		defer c.wg.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		c.send(ctx, payload)
+	}(body)
+}
+
+func (c *Client) Pageview(path string, fields Fields) {
+	if c == nil {
+		return
+	}
+
+	body, err := c.newRequest("", normalizePagePath(path), fields)
 	if err != nil {
 		return
 	}
@@ -224,9 +255,11 @@ func (c *Client) Close(ctx context.Context) error {
 
 func (noopSink) Track(string, Fields) {}
 
+func (noopSink) Pageview(string, Fields) {}
+
 func (noopSink) Close(context.Context) error { return nil }
 
-func (c *Client) newRequest(name string, fields Fields) ([]byte, error) {
+func (c *Client) newRequest(name, url string, fields Fields) ([]byte, error) {
 	data := make(map[string]any, len(fields)+4)
 	for k, v := range fields {
 		data[k] = v
@@ -242,7 +275,7 @@ func (c *Client) newRequest(name string, fields Fields) ([]byte, error) {
 			Website:   c.websiteID,
 			Hostname:  defaultHostname,
 			Title:     defaultTitle,
-			URL:       eventURL(c.app, name),
+			URL:       url,
 			Name:      name,
 			Data:      data,
 			Timestamp: time.Now().Unix(),
@@ -301,6 +334,17 @@ func buildChannel(version string) string {
 		return "dev"
 	}
 	return "release"
+}
+
+func normalizePagePath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "/"
+	}
+	if strings.HasPrefix(path, "/") {
+		return path
+	}
+	return "/" + path
 }
 
 func defaultWebsiteID() string {

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -32,6 +32,7 @@ type Config struct {
 	Push          func(ctx context.Context, branch string) error
 	SuggestBranch func(ctx context.Context) (string, error)
 	SuggestCommit func(ctx context.Context) (string, error)
+	Track         func(action string, fields map[string]any)
 }
 
 // stepID identifies one of the three wizard steps.
@@ -63,6 +64,7 @@ type step struct {
 	result     string // displayed when done
 	skipReason string // displayed when skipped
 	errMsg     string
+	source     string
 }
 
 // Model is the bubbletea model for the wizard.
@@ -226,6 +228,13 @@ func (m Model) setupActive() Model {
 	s := m.activeStep()
 	if s == nil {
 		m.success = m.pushed
+		if m.success {
+			m.track("completed", map[string]any{
+				"branch_created": m.branchCreated,
+				"commit_made":    m.commitMade,
+				"pushed":         m.pushed,
+			})
+		}
 		m.quitting = true
 		m.cancel()
 		return m
@@ -266,6 +275,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	switch msg.String() {
 	case "ctrl+c":
+		m.trackAbort("interrupt")
 		m.aborted = true
 		m.quitting = true
 		m.cancel()
@@ -275,6 +285,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.confirmQuit = true
 			return m, nil
 		}
+		m.trackAbort("quit")
 		m.aborted = true
 		m.quitting = true
 		m.cancel()
@@ -303,8 +314,10 @@ func (m Model) handleInputKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if value == "" {
 			// Agent suggestion path.
 			s.status = statAgent
+			s.source = "agent"
 			return m, tea.Batch(m.suggestCmd(s.id), m.scheduleSpinner())
 		}
+		s.source = "user"
 		return m.executeStep(s, value)
 	}
 	var cmd tea.Cmd
@@ -316,8 +329,10 @@ func (m Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	s := m.activeStep()
 	switch msg.String() {
 	case "y", "Y", "enter":
+		s.source = "user"
 		return m.executeStep(s, "")
 	case "n", "N":
+		m.trackAbort("decline_push")
 		m.aborted = true
 		m.quitting = true
 		m.cancel()
@@ -363,6 +378,7 @@ func (m Model) handleSuggestion(msg suggestionMsg) (tea.Model, tea.Cmd) {
 	if msg.err != nil {
 		// Fall back to asking the user to type.
 		s.status = statInput
+		s.source = ""
 		m.input.SetValue("")
 		m.input.Placeholder = "agent unavailable: " + truncate(msg.err.Error(), 40)
 		m.input.Focus()
@@ -385,10 +401,13 @@ func (m Model) handleAction(msg actionMsg) (tea.Model, tea.Cmd) {
 	case stepBranch:
 		m.branchCreated = true
 		m.targetBranch = s.result
+		m.track("branch_created", map[string]any{"step": stepName(s.id), "source": stepSource(s.source)})
 	case stepCommit:
 		m.commitMade = true
+		m.track("committed", map[string]any{"step": stepName(s.id), "source": stepSource(s.source)})
 	case stepPush:
 		m.pushed = true
+		m.track("pushed", map[string]any{"step": stepName(s.id), "source": stepSource(s.source)})
 	}
 	s.status = statDone
 	m.active = m.firstPending()
@@ -398,6 +417,24 @@ func (m Model) handleAction(msg actionMsg) (tea.Model, tea.Cmd) {
 
 func (m Model) hasSideEffects() bool {
 	return m.branchCreated || m.commitMade
+}
+
+func (m Model) track(action string, fields map[string]any) {
+	if m.cfg.Track == nil {
+		return
+	}
+	if fields == nil {
+		fields = map[string]any{}
+	}
+	m.cfg.Track(action, fields)
+}
+
+func (m Model) trackAbort(reason string) {
+	fields := map[string]any{"reason": reason}
+	if s := m.activeStep(); s != nil {
+		fields["step"] = stepName(s.id)
+	}
+	m.track("aborted", fields)
 }
 
 func (m Model) anySpinnerActive() bool {
@@ -491,6 +528,26 @@ func Run(cfg Config) (Result, error) {
 		return Result{}, errors.New("wizard: unexpected terminal model type")
 	}
 	return fm.Result(), nil
+}
+
+func stepName(id stepID) string {
+	switch id {
+	case stepBranch:
+		return "branch"
+	case stepCommit:
+		return "commit"
+	case stepPush:
+		return "push"
+	default:
+		return "unknown"
+	}
+}
+
+func stepSource(source string) string {
+	if source == "" {
+		return "user"
+	}
+	return source
 }
 
 func truncate(s string, n int) string {

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -15,6 +15,7 @@ type recorder struct {
 	createdBranch string
 	commitMsg     string
 	pushedBranch  string
+	telemetry     []wizardTelemetryEvent
 
 	createBranchErr error
 	commitErr       error
@@ -24,6 +25,11 @@ type recorder struct {
 	suggestCommit    string
 	suggestBranchErr error
 	suggestCommitErr error
+}
+
+type wizardTelemetryEvent struct {
+	action string
+	fields map[string]any
 }
 
 func (r *recorder) deps() Config {
@@ -45,6 +51,13 @@ func (r *recorder) deps() Config {
 		},
 		SuggestCommit: func(_ context.Context) (string, error) {
 			return r.suggestCommit, r.suggestCommitErr
+		},
+		Track: func(action string, fields map[string]any) {
+			clone := make(map[string]any, len(fields))
+			for k, v := range fields {
+				clone[k] = v
+			}
+			r.telemetry = append(r.telemetry, wizardTelemetryEvent{action: action, fields: clone})
 		},
 	}
 }
@@ -284,6 +297,74 @@ func TestPushStep_Confirm(t *testing.T) {
 	if !m.success {
 		t.Fatal("wizard should report success")
 	}
+}
+
+func TestWizardTracksCompletedKeyActions(t *testing.T) {
+	r := &recorder{}
+	m := NewModel(baseConfig(r))
+	m = drain(m, m.Init())
+
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("feat/wizard")})
+	m = advance(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("feat: add wizard telemetry")})
+	m = advance(m, tea.KeyMsg{Type: tea.KeyEnter})
+	m = advance(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if !containsWizardEvent(r.telemetry, "branch_created", "source", "user") {
+		t.Fatal("expected branch_created telemetry with user source")
+	}
+	if !containsWizardEvent(r.telemetry, "committed", "source", "user") {
+		t.Fatal("expected committed telemetry with user source")
+	}
+	if !containsWizardEvent(r.telemetry, "pushed", "step", "push") {
+		t.Fatal("expected pushed telemetry")
+	}
+	if !containsWizardEvent(r.telemetry, "completed", "pushed", true) {
+		t.Fatal("expected completed telemetry")
+	}
+}
+
+func TestWizardTracksAbortOnPushDecline(t *testing.T) {
+	r := &recorder{}
+	cfg := baseConfig(r)
+	cfg.CurrentBranch = "feat/x"
+	cfg.NeedsBranch = false
+	cfg.IsDirty = false
+	m := NewModel(cfg)
+	m = drain(m, m.Init())
+
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+
+	if !containsWizardEvent(r.telemetry, "aborted", "reason", "decline_push") {
+		t.Fatal("expected aborted telemetry with decline_push reason")
+	}
+}
+
+func TestWizardTracksAgentSourcedBranchAction(t *testing.T) {
+	r := &recorder{suggestBranch: "feat/agent"}
+	m := NewModel(baseConfig(r))
+	m = drain(m, m.Init())
+
+	m = advance(m, tea.KeyMsg{Type: tea.KeyEnter})
+
+	if !containsWizardEvent(r.telemetry, "branch_created", "source", "agent") {
+		t.Fatal("expected branch_created telemetry with agent source")
+	}
+}
+
+func containsWizardEvent(events []wizardTelemetryEvent, action, field string, want any) bool {
+	for _, event := range events {
+		if event.action != action {
+			continue
+		}
+		if field == "" {
+			return true
+		}
+		if got, ok := event.fields[field]; ok && got == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestPushStep_DeclineAborts(t *testing.T) {


### PR DESCRIPTION
## Summary
- add telemetry support for Umami pageview payloads covering `/wizard` and `/tui`, so interactive flows are captured alongside existing command and run events
- emit wizard-specific telemetry action and result events from the CLI and wizard flow, with test coverage across CLI, daemon, pipeline, telemetry, and wizard packages
- update the telemetry environment reference to document the new pageview and wizard event payloads

## Risk Assessment

✅ Low: The change is narrowly scoped to telemetry/pageview plumbing and wizard instrumentation, and I did not find any material correctness, security, or behavioral regressions in the modified code.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `docs/src/content/docs/reference/environment.md:80` - The telemetry reference is now stale: this change adds Umami pageview payloads for `/wizard` and `/tui`, plus new `wizard` action/result events, but the docs still say telemetry only sends command, run, step, approval, and fix events.

**Round 2** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
