### PR TITLE
feat(cli): add daemon restart command

### DIFF
--- a/docs/install.ps1
+++ b/docs/install.ps1
@@ -34,7 +34,7 @@ if ($userPath -notlike "*$installDir*") {
 
 $oldErrorActionPreference = $ErrorActionPreference
 $ErrorActionPreference = "Continue"
-& "$installDir\no-mistakes.exe" daemon start | Out-Null
+& "$installDir\no-mistakes.exe" daemon restart | Out-Null
 $ErrorActionPreference = $oldErrorActionPreference
 
 Write-Host "no-mistakes $version installed to $installDir\no-mistakes.exe"

--- a/docs/install.ps1
+++ b/docs/install.ps1
@@ -32,9 +32,12 @@ if ($userPath -notlike "*$installDir*") {
     Write-Host "Added $installDir to user PATH. Restart your terminal."
 }
 
-$oldErrorActionPreference = $ErrorActionPreference
-$ErrorActionPreference = "Continue"
-& "$installDir\no-mistakes.exe" daemon restart | Out-Null
-$ErrorActionPreference = $oldErrorActionPreference
+$restart = Start-Process -FilePath "$installDir\no-mistakes.exe" -ArgumentList @(
+    "daemon",
+    "restart"
+) -Wait -PassThru -NoNewWindow
+if ($restart.ExitCode -ne 0) {
+    throw "Failed to restart daemon (exit code $($restart.ExitCode))"
+}
 
 Write-Host "no-mistakes $version installed to $installDir\no-mistakes.exe"

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -77,9 +77,7 @@ fi
 echo "no-mistakes ${VERSION} installed to ${BIN_PATH}"
 echo "Command path: ${LINK_PATH} -> ${BIN_PATH}"
 
-if ! "$BIN_PATH" daemon restart >/dev/null 2>&1; then
-  echo "Warning: failed to auto-start daemon; run 'no-mistakes daemon restart' manually." >&2
-fi
+"$BIN_PATH" daemon restart >/dev/null
 
 case ":$PATH:" in
   *":$LINK_DIR:"*) ;;

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -77,8 +77,8 @@ fi
 echo "no-mistakes ${VERSION} installed to ${BIN_PATH}"
 echo "Command path: ${LINK_PATH} -> ${BIN_PATH}"
 
-if ! "$BIN_PATH" daemon start >/dev/null 2>&1; then
-  echo "Warning: failed to auto-start daemon; run 'no-mistakes daemon start' manually." >&2
+if ! "$BIN_PATH" daemon restart >/dev/null 2>&1; then
+  echo "Warning: failed to auto-start daemon; run 'no-mistakes daemon restart' manually." >&2
 fi
 
 case ":$PATH:" in

--- a/docs/src/content/docs/concepts/daemon.md
+++ b/docs/src/content/docs/concepts/daemon.md
@@ -38,6 +38,7 @@ already make sure it exists when needed.
 # Explicit management
 no-mistakes daemon start
 no-mistakes daemon stop
+no-mistakes daemon restart
 no-mistakes daemon status
 
 # Ensures the daemon is running, using the managed service when possible

--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -107,7 +107,7 @@ daemon after replacing the binary when the daemon is running or stale daemon
 artifacts exist. If the daemon is already running, `update` first checks that
 it was started from the same executable path and aborts if the daemon
 executable path cannot be determined or points to a different binary. You can
-also manage it explicitly with `no-mistakes daemon start|stop|status`.
+also manage it explicitly with `no-mistakes daemon start|stop|restart|status`.
 
 On startup, the daemon recovers from crashes by marking any stuck runs as failed and cleaning up orphaned worktrees.
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -141,6 +141,16 @@ no-mistakes daemon stop
 
 This does not remove the managed service. A later `no-mistakes`, `no-mistakes daemon start`, `init`, `attach`, `rerun`, or `update` can start the daemon again through the same service manager when available, or as a detached daemon otherwise.
 
+## no-mistakes daemon restart
+
+Restart the daemon.
+
+```sh
+no-mistakes daemon restart
+```
+
+Stops the current daemon and starts it again. This works whether the daemon is currently running or not.
+
 ## no-mistakes daemon status
 
 Check whether the daemon is running.

--- a/docs/src/content/docs/start-here/installation.md
+++ b/docs/src/content/docs/start-here/installation.md
@@ -11,7 +11,7 @@ curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/i
 
 The installer keeps the real binary in `~/.no-mistakes/bin` and exposes `no-mistakes` through a symlink in `~/.local/bin` or `/usr/local/bin`. That keeps future `no-mistakes update` runs in a user-owned location instead of rewriting a system binary in place.
 
-It also attempts to install and start the background daemon for you, preferring a managed service (launchd on macOS, systemd user service on Linux) and falling back to a detached daemon if that path is unavailable. If startup fails, run `no-mistakes daemon start` manually.
+It also installs or refreshes the background daemon for you by running `no-mistakes daemon restart`, preferring a managed service (launchd on macOS, systemd user service on Linux) and falling back to a detached daemon if that path is unavailable. If the restart fails, the install command fails.
 
 Official release binaries installed this way may already have telemetry enabled if a telemetry website ID was embedded at build time.
 
@@ -21,7 +21,7 @@ Official release binaries installed this way may already have telemetry enabled 
 irm https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.ps1 | iex
 ```
 
-Installs the binary and attempts to start the background daemon automatically, preferring a managed Task Scheduler task and falling back to a detached daemon if needed.
+Installs the binary and restarts the background daemon automatically with `no-mistakes.exe daemon restart`, preferring a managed Task Scheduler task and falling back to a detached daemon if needed. If the restart fails, the install command fails.
 
 Official release binaries installed this way may already have telemetry enabled if a telemetry website ID was embedded at build time.
 

--- a/docs/src/content/docs/start-here/quick-start.md
+++ b/docs/src/content/docs/start-here/quick-start.md
@@ -11,7 +11,7 @@ This walks you through your first gated push. For install options other than the
 curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh
 ```
 
-The installer drops the binary in `~/.no-mistakes/bin`, links it into `~/.local/bin` or `/usr/local/bin`, and starts the background daemon. If startup fails, run `no-mistakes daemon start` manually.
+The installer drops the binary in `~/.no-mistakes/bin`, links it into `~/.local/bin` or `/usr/local/bin`, and restarts the background daemon. If the restart fails, the install command fails.
 
 Official release binaries installed this way may already have telemetry enabled if a telemetry website ID was embedded at build time.
 

--- a/install_script_test.go
+++ b/install_script_test.go
@@ -89,7 +89,7 @@ func TestInstallScriptRestartsDaemonAfterInstall(t *testing.T) {
 	}
 }
 
-func TestInstallScriptSucceedsWhenDaemonRestartFails(t *testing.T) {
+func TestInstallScriptFailsWhenDaemonRestartFails(t *testing.T) {
 	skipInstallScriptTestsOnWindows(t)
 
 	home := t.TempDir()
@@ -106,8 +106,8 @@ func TestInstallScriptSucceedsWhenDaemonRestartFails(t *testing.T) {
 		"FAKE_RELEASE_ARCHIVE": archivePath,
 		"NO_MISTAKES_CALL_LOG": callLog,
 	})
-	if err != nil {
-		t.Fatalf("install.sh should succeed even when daemon restart fails: %v\n%s", err, output)
+	if err == nil {
+		t.Fatalf("install.sh should fail when daemon restart fails\n%s", output)
 	}
 
 	data, err := os.ReadFile(callLog)
@@ -119,23 +119,23 @@ func TestInstallScriptSucceedsWhenDaemonRestartFails(t *testing.T) {
 	}
 }
 
-func TestPowerShellInstallScriptAllowsDaemonRestartFailure(t *testing.T) {
+func TestPowerShellInstallScriptChecksDaemonRestartFailure(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join("docs", "install.ps1"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	text := string(data)
-	if !strings.Contains(text, "$oldErrorActionPreference = $ErrorActionPreference") {
-		t.Fatal("install.ps1 should preserve the current error preference before daemon restart")
+	if !strings.Contains(text, "$restart = Start-Process -FilePath \"$installDir\\no-mistakes.exe\" -ArgumentList @(") {
+		t.Fatal("install.ps1 should run daemon restart in a way that exposes the exit code")
 	}
-	if !strings.Contains(text, "$ErrorActionPreference = \"Continue\"") {
-		t.Fatal("install.ps1 should relax error handling around daemon restart")
+	if !strings.Contains(text, "-Wait -PassThru") {
+		t.Fatal("install.ps1 should wait for daemon restart to finish and inspect the process result")
 	}
-	if !strings.Contains(text, "& \"$installDir\\no-mistakes.exe\" daemon restart | Out-Null") {
-		t.Fatal("install.ps1 should still attempt daemon restart")
+	if !strings.Contains(text, "if ($restart.ExitCode -ne 0)") {
+		t.Fatal("install.ps1 should fail the install when daemon restart returns a non-zero exit code")
 	}
-	if !strings.Contains(text, "$ErrorActionPreference = $oldErrorActionPreference") {
-		t.Fatal("install.ps1 should restore the previous error preference")
+	if !strings.Contains(text, "throw \"Failed to restart daemon (exit code $($restart.ExitCode))\"") {
+		t.Fatal("install.ps1 should surface the daemon restart exit code")
 	}
 }
 

--- a/install_script_test.go
+++ b/install_script_test.go
@@ -62,7 +62,7 @@ func TestInstallScriptReplacesExistingPathEntryWithSymlink(t *testing.T) {
 	assertSymlinkTarget(t, oldPath, realBin)
 }
 
-func TestInstallScriptStartsDaemonAfterInstall(t *testing.T) {
+func TestInstallScriptRestartsDaemonAfterInstall(t *testing.T) {
 	skipInstallScriptTestsOnWindows(t)
 
 	home := t.TempDir()
@@ -84,18 +84,18 @@ func TestInstallScriptStartsDaemonAfterInstall(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(data), "daemon start") {
-		t.Fatalf("install.sh should start the daemon after install, got calls %q", string(data))
+	if !strings.Contains(string(data), "daemon restart") {
+		t.Fatalf("install.sh should restart the daemon after install, got calls %q", string(data))
 	}
 }
 
-func TestInstallScriptSucceedsWhenDaemonStartFails(t *testing.T) {
+func TestInstallScriptSucceedsWhenDaemonRestartFails(t *testing.T) {
 	skipInstallScriptTestsOnWindows(t)
 
 	home := t.TempDir()
 	archivePath := filepath.Join(t.TempDir(), "no-mistakes-v1.2.3-darwin-arm64.tar.gz")
 	callLog := filepath.Join(t.TempDir(), "calls.log")
-	makeInstallArchive(t, archivePath, "#!/bin/sh\nprintf '%s\n' \"$*\" >> \"$NO_MISTAKES_CALL_LOG\"\nif [ \"$1\" = \"daemon\" ] && [ \"$2\" = \"start\" ]; then\n  exit 23\nfi\n")
+	makeInstallArchive(t, archivePath, "#!/bin/sh\nprintf '%s\n' \"$*\" >> \"$NO_MISTAKES_CALL_LOG\"\nif [ \"$1\" = \"daemon\" ] && [ \"$2\" = \"restart\" ]; then\n  exit 23\nfi\n")
 	fakeBin := makeFakeInstallCommands(t)
 	localBin := filepath.Join(home, ".local", "bin")
 	if err := os.MkdirAll(localBin, 0o755); err != nil {
@@ -107,32 +107,32 @@ func TestInstallScriptSucceedsWhenDaemonStartFails(t *testing.T) {
 		"NO_MISTAKES_CALL_LOG": callLog,
 	})
 	if err != nil {
-		t.Fatalf("install.sh should succeed even when daemon start fails: %v\n%s", err, output)
+		t.Fatalf("install.sh should succeed even when daemon restart fails: %v\n%s", err, output)
 	}
 
 	data, err := os.ReadFile(callLog)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(data), "daemon start") {
-		t.Fatalf("install.sh should still attempt daemon start, got calls %q", string(data))
+	if !strings.Contains(string(data), "daemon restart") {
+		t.Fatalf("install.sh should still attempt daemon restart, got calls %q", string(data))
 	}
 }
 
-func TestPowerShellInstallScriptAllowsDaemonStartFailure(t *testing.T) {
+func TestPowerShellInstallScriptAllowsDaemonRestartFailure(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join("docs", "install.ps1"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	text := string(data)
 	if !strings.Contains(text, "$oldErrorActionPreference = $ErrorActionPreference") {
-		t.Fatal("install.ps1 should preserve the current error preference before daemon start")
+		t.Fatal("install.ps1 should preserve the current error preference before daemon restart")
 	}
 	if !strings.Contains(text, "$ErrorActionPreference = \"Continue\"") {
-		t.Fatal("install.ps1 should relax error handling around daemon start")
+		t.Fatal("install.ps1 should relax error handling around daemon restart")
 	}
-	if !strings.Contains(text, "& \"$installDir\\no-mistakes.exe\" daemon start | Out-Null") {
-		t.Fatal("install.ps1 should still attempt daemon start")
+	if !strings.Contains(text, "& \"$installDir\\no-mistakes.exe\" daemon restart | Out-Null") {
+		t.Fatal("install.ps1 should still attempt daemon restart")
 	}
 	if !strings.Contains(text, "$ErrorActionPreference = $oldErrorActionPreference") {
 		t.Fatal("install.ps1 should restore the previous error preference")

--- a/internal/cli/daemon_cmd.go
+++ b/internal/cli/daemon_cmd.go
@@ -134,8 +134,8 @@ func newDaemonRestartCmd() *cobra.Command {
 				if err := p.EnsureDirs(); err != nil {
 					return err
 				}
-				alive, _ := daemonIsRunningFn(p)
-				if alive {
+				alive, err := daemonIsRunningFn(p)
+				if err != nil || alive {
 					if err := daemonStopFn(p); err != nil {
 						return fmt.Errorf("stop daemon: %w", err)
 					}

--- a/internal/cli/daemon_cmd.go
+++ b/internal/cli/daemon_cmd.go
@@ -134,11 +134,8 @@ func newDaemonRestartCmd() *cobra.Command {
 				if err := p.EnsureDirs(); err != nil {
 					return err
 				}
-				alive, err := daemonIsRunningFn(p)
-				if err != nil || alive {
-					if err := daemonStopFn(p); err != nil {
-						return fmt.Errorf("stop daemon: %w", err)
-					}
+				if err := daemonStopFn(p); err != nil {
+					return fmt.Errorf("stop daemon: %w", err)
 				}
 				if err := daemonStartFn(p); err != nil {
 					return fmt.Errorf("start daemon: %w", err)

--- a/internal/cli/daemon_cmd.go
+++ b/internal/cli/daemon_cmd.go
@@ -10,7 +10,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var daemonRun = daemon.Run
+var (
+	daemonRun         = daemon.Run
+	daemonStartFn     = daemon.Start
+	daemonStopFn      = daemon.Stop
+	daemonIsRunningFn = daemon.IsRunning
+)
 
 func newDaemonCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -20,6 +25,7 @@ func newDaemonCmd() *cobra.Command {
 
 	cmd.AddCommand(newDaemonStartCmd())
 	cmd.AddCommand(newDaemonStopCmd())
+	cmd.AddCommand(newDaemonRestartCmd())
 	cmd.AddCommand(newDaemonStatusCmd())
 	cmd.AddCommand(newDaemonRunCmd())
 	cmd.AddCommand(newDaemonNotifyPushCmd())
@@ -85,7 +91,7 @@ func newDaemonStartCmd() *cobra.Command {
 				if err := p.EnsureDirs(); err != nil {
 					return err
 				}
-				if err := daemon.Start(p); err != nil {
+				if err := daemonStartFn(p); err != nil {
 					return err
 				}
 				fmt.Fprintf(cmd.OutOrStdout(), "  %s daemon started\n", sGreen.Render("✓"))
@@ -105,10 +111,39 @@ func newDaemonStopCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				if err := daemon.Stop(p); err != nil {
+				if err := daemonStopFn(p); err != nil {
 					return err
 				}
 				fmt.Fprintf(cmd.OutOrStdout(), "  %s daemon stopped\n", sGreen.Render("✓"))
+				return nil
+			})
+		},
+	}
+}
+
+func newDaemonRestartCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "restart",
+		Short: "Restart the daemon (stop if running, then start)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return trackCommand("daemon.restart", func() error {
+				p, err := paths.New()
+				if err != nil {
+					return err
+				}
+				if err := p.EnsureDirs(); err != nil {
+					return err
+				}
+				alive, _ := daemonIsRunningFn(p)
+				if alive {
+					if err := daemonStopFn(p); err != nil {
+						return fmt.Errorf("stop daemon: %w", err)
+					}
+				}
+				if err := daemonStartFn(p); err != nil {
+					return fmt.Errorf("start daemon: %w", err)
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "  %s daemon restarted\n", sGreen.Render("✓"))
 				return nil
 			})
 		},
@@ -125,7 +160,7 @@ func newDaemonStatusCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				alive, err := daemon.IsRunning(p)
+				alive, err := daemonIsRunningFn(p)
 				if err != nil {
 					return err
 				}

--- a/internal/cli/daemon_cmd_test.go
+++ b/internal/cli/daemon_cmd_test.go
@@ -117,7 +117,47 @@ func TestDaemonRestart(t *testing.T) {
 		}
 	})
 
-	t.Run("starts when daemon is not running", func(t *testing.T) {
+		t.Run("stops then starts when daemon is not running", func(t *testing.T) {
+			nmHome := makeSocketSafeTempDir(t)
+			t.Setenv("NM_HOME", nmHome)
+			p := paths.WithRoot(nmHome)
+		if err := p.EnsureDirs(); err != nil {
+			t.Fatal(err)
+		}
+
+		origStart := daemonStartFn
+		origStop := daemonStopFn
+		origAlive := daemonIsRunningFn
+		t.Cleanup(func() {
+			daemonStartFn = origStart
+			daemonStopFn = origStop
+			daemonIsRunningFn = origAlive
+		})
+
+			var calls []string
+			daemonIsRunningFn = func(*paths.Paths) (bool, error) { return false, nil }
+			daemonStopFn = func(*paths.Paths) error {
+				calls = append(calls, "stop")
+				return nil
+			}
+			daemonStartFn = func(*paths.Paths) error {
+				calls = append(calls, "start")
+				return nil
+			}
+
+			out, err := executeCmd("daemon", "restart")
+			if err != nil {
+				t.Fatalf("daemon restart failed: %v\noutput: %s", err, out)
+			}
+			if !strings.Contains(out, "daemon restarted") {
+				t.Errorf("expected 'daemon restarted', got: %s", out)
+			}
+			if len(calls) != 2 || calls[0] != "stop" || calls[1] != "start" {
+				t.Errorf("expected stop then start, got: %v", calls)
+			}
+		})
+
+	t.Run("stops then starts when health check reports not running", func(t *testing.T) {
 		nmHome := makeSocketSafeTempDir(t)
 		t.Setenv("NM_HOME", nmHome)
 		p := paths.WithRoot(nmHome)
@@ -134,15 +174,14 @@ func TestDaemonRestart(t *testing.T) {
 			daemonIsRunningFn = origAlive
 		})
 
-		stopCalled := false
-		startCalled := false
+		var calls []string
 		daemonIsRunningFn = func(*paths.Paths) (bool, error) { return false, nil }
 		daemonStopFn = func(*paths.Paths) error {
-			stopCalled = true
+			calls = append(calls, "stop")
 			return nil
 		}
 		daemonStartFn = func(*paths.Paths) error {
-			startCalled = true
+			calls = append(calls, "start")
 			return nil
 		}
 
@@ -150,14 +189,11 @@ func TestDaemonRestart(t *testing.T) {
 		if err != nil {
 			t.Fatalf("daemon restart failed: %v\noutput: %s", err, out)
 		}
-		if stopCalled {
-			t.Error("stop should not be called when daemon is not running")
-		}
-		if !startCalled {
-			t.Error("start should be called when daemon is not running")
-		}
 		if !strings.Contains(out, "daemon restarted") {
 			t.Errorf("expected 'daemon restarted', got: %s", out)
+		}
+		if len(calls) != 2 || calls[0] != "stop" || calls[1] != "start" {
+			t.Errorf("expected stop then start, got: %v", calls)
 		}
 	})
 

--- a/internal/cli/daemon_cmd_test.go
+++ b/internal/cli/daemon_cmd_test.go
@@ -238,6 +238,36 @@ func TestDaemonRestart(t *testing.T) {
 	})
 }
 
+func TestDaemonRestartStartsDaemonWhenNotRunning(t *testing.T) {
+	nmHome := makeSocketSafeTempDir(t)
+	t.Setenv("NM_HOME", nmHome)
+	t.Setenv("NM_TEST_START_DAEMON", "1")
+	p := paths.WithRoot(nmHome)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_ = daemon.Stop(p)
+	})
+
+	out, err := executeCmd("daemon", "restart")
+	if err != nil {
+		t.Fatalf("daemon restart failed: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(out, "daemon restarted") {
+		t.Fatalf("expected 'daemon restarted', got: %s", out)
+	}
+
+	alive, err := daemon.IsRunning(p)
+	if err != nil {
+		t.Fatalf("daemon health check failed after restart: %v", err)
+	}
+	if !alive {
+		t.Fatal("daemon should be running after restart")
+	}
+}
+
 func TestDaemonRunUsesProvidedRoot(t *testing.T) {
 	wantRoot := filepath.Join(t.TempDir(), "nm-home")
 	t.Setenv("NM_HOME", "")

--- a/internal/cli/daemon_cmd_test.go
+++ b/internal/cli/daemon_cmd_test.go
@@ -75,6 +75,92 @@ func TestDaemonStatusAndStopRunning(t *testing.T) {
 	}
 }
 
+func TestDaemonRestart(t *testing.T) {
+	t.Run("stops then starts when daemon is running", func(t *testing.T) {
+		nmHome := makeSocketSafeTempDir(t)
+		t.Setenv("NM_HOME", nmHome)
+		p := paths.WithRoot(nmHome)
+		if err := p.EnsureDirs(); err != nil {
+			t.Fatal(err)
+		}
+
+		origStart := daemonStartFn
+		origStop := daemonStopFn
+		origAlive := daemonIsRunningFn
+		t.Cleanup(func() {
+			daemonStartFn = origStart
+			daemonStopFn = origStop
+			daemonIsRunningFn = origAlive
+		})
+
+		var calls []string
+		daemonIsRunningFn = func(*paths.Paths) (bool, error) { return true, nil }
+		daemonStopFn = func(*paths.Paths) error {
+			calls = append(calls, "stop")
+			return nil
+		}
+		daemonStartFn = func(*paths.Paths) error {
+			calls = append(calls, "start")
+			return nil
+		}
+
+		out, err := executeCmd("daemon", "restart")
+		if err != nil {
+			t.Fatalf("daemon restart failed: %v\noutput: %s", err, out)
+		}
+		if !strings.Contains(out, "daemon restarted") {
+			t.Errorf("expected 'daemon restarted', got: %s", out)
+		}
+		if len(calls) != 2 || calls[0] != "stop" || calls[1] != "start" {
+			t.Errorf("expected stop then start, got: %v", calls)
+		}
+	})
+
+	t.Run("starts when daemon is not running", func(t *testing.T) {
+		nmHome := makeSocketSafeTempDir(t)
+		t.Setenv("NM_HOME", nmHome)
+		p := paths.WithRoot(nmHome)
+		if err := p.EnsureDirs(); err != nil {
+			t.Fatal(err)
+		}
+
+		origStart := daemonStartFn
+		origStop := daemonStopFn
+		origAlive := daemonIsRunningFn
+		t.Cleanup(func() {
+			daemonStartFn = origStart
+			daemonStopFn = origStop
+			daemonIsRunningFn = origAlive
+		})
+
+		stopCalled := false
+		startCalled := false
+		daemonIsRunningFn = func(*paths.Paths) (bool, error) { return false, nil }
+		daemonStopFn = func(*paths.Paths) error {
+			stopCalled = true
+			return nil
+		}
+		daemonStartFn = func(*paths.Paths) error {
+			startCalled = true
+			return nil
+		}
+
+		out, err := executeCmd("daemon", "restart")
+		if err != nil {
+			t.Fatalf("daemon restart failed: %v\noutput: %s", err, out)
+		}
+		if stopCalled {
+			t.Error("stop should not be called when daemon is not running")
+		}
+		if !startCalled {
+			t.Error("start should be called when daemon is not running")
+		}
+		if !strings.Contains(out, "daemon restarted") {
+			t.Errorf("expected 'daemon restarted', got: %s", out)
+		}
+	})
+}
+
 func TestDaemonRunUsesProvidedRoot(t *testing.T) {
 	wantRoot := filepath.Join(t.TempDir(), "nm-home")
 	t.Setenv("NM_HOME", "")

--- a/internal/cli/daemon_cmd_test.go
+++ b/internal/cli/daemon_cmd_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -157,6 +158,46 @@ func TestDaemonRestart(t *testing.T) {
 		}
 		if !strings.Contains(out, "daemon restarted") {
 			t.Errorf("expected 'daemon restarted', got: %s", out)
+		}
+	})
+
+	t.Run("stops then starts when daemon health check errors", func(t *testing.T) {
+		nmHome := makeSocketSafeTempDir(t)
+		t.Setenv("NM_HOME", nmHome)
+		p := paths.WithRoot(nmHome)
+		if err := p.EnsureDirs(); err != nil {
+			t.Fatal(err)
+		}
+
+		origStart := daemonStartFn
+		origStop := daemonStopFn
+		origAlive := daemonIsRunningFn
+		t.Cleanup(func() {
+			daemonStartFn = origStart
+			daemonStopFn = origStop
+			daemonIsRunningFn = origAlive
+		})
+
+		var calls []string
+		daemonIsRunningFn = func(*paths.Paths) (bool, error) { return false, errors.New("health check failed") }
+		daemonStopFn = func(*paths.Paths) error {
+			calls = append(calls, "stop")
+			return nil
+		}
+		daemonStartFn = func(*paths.Paths) error {
+			calls = append(calls, "start")
+			return nil
+		}
+
+		out, err := executeCmd("daemon", "restart")
+		if err != nil {
+			t.Fatalf("daemon restart failed: %v\noutput: %s", err, out)
+		}
+		if !strings.Contains(out, "daemon restarted") {
+			t.Errorf("expected 'daemon restarted', got: %s", out)
+		}
+		if len(calls) != 2 || calls[0] != "stop" || calls[1] != "start" {
+			t.Errorf("expected stop then start, got: %v", calls)
 		}
 	})
 }

--- a/internal/cli/daemon_cmd_test.go
+++ b/internal/cli/daemon_cmd_test.go
@@ -117,10 +117,10 @@ func TestDaemonRestart(t *testing.T) {
 		}
 	})
 
-		t.Run("stops then starts when daemon is not running", func(t *testing.T) {
-			nmHome := makeSocketSafeTempDir(t)
-			t.Setenv("NM_HOME", nmHome)
-			p := paths.WithRoot(nmHome)
+	t.Run("stops then starts when daemon is not running", func(t *testing.T) {
+		nmHome := makeSocketSafeTempDir(t)
+		t.Setenv("NM_HOME", nmHome)
+		p := paths.WithRoot(nmHome)
 		if err := p.EnsureDirs(); err != nil {
 			t.Fatal(err)
 		}
@@ -134,28 +134,28 @@ func TestDaemonRestart(t *testing.T) {
 			daemonIsRunningFn = origAlive
 		})
 
-			var calls []string
-			daemonIsRunningFn = func(*paths.Paths) (bool, error) { return false, nil }
-			daemonStopFn = func(*paths.Paths) error {
-				calls = append(calls, "stop")
-				return nil
-			}
-			daemonStartFn = func(*paths.Paths) error {
-				calls = append(calls, "start")
-				return nil
-			}
+		var calls []string
+		daemonIsRunningFn = func(*paths.Paths) (bool, error) { return false, nil }
+		daemonStopFn = func(*paths.Paths) error {
+			calls = append(calls, "stop")
+			return nil
+		}
+		daemonStartFn = func(*paths.Paths) error {
+			calls = append(calls, "start")
+			return nil
+		}
 
-			out, err := executeCmd("daemon", "restart")
-			if err != nil {
-				t.Fatalf("daemon restart failed: %v\noutput: %s", err, out)
-			}
-			if !strings.Contains(out, "daemon restarted") {
-				t.Errorf("expected 'daemon restarted', got: %s", out)
-			}
-			if len(calls) != 2 || calls[0] != "stop" || calls[1] != "start" {
-				t.Errorf("expected stop then start, got: %v", calls)
-			}
-		})
+		out, err := executeCmd("daemon", "restart")
+		if err != nil {
+			t.Fatalf("daemon restart failed: %v\noutput: %s", err, out)
+		}
+		if !strings.Contains(out, "daemon restarted") {
+			t.Errorf("expected 'daemon restarted', got: %s", out)
+		}
+		if len(calls) != 2 || calls[0] != "stop" || calls[1] != "start" {
+			t.Errorf("expected stop then start, got: %v", calls)
+		}
+	})
 
 	t.Run("stops then starts when health check reports not running", func(t *testing.T) {
 		nmHome := makeSocketSafeTempDir(t)


### PR DESCRIPTION
## Summary
- Add a `no-mistakes daemon restart` command so installs and upgrades can restart the daemon through a first-class CLI flow instead of separate stop/start handling.
- Harden restart behavior to stop existing processes more reliably and surface restart failures, preventing installs from reporting success when the daemon did not come back up.
- Update install scripts and docs to use and document `daemon restart`, and add CLI coverage for the new command and recovery paths.

## Risk Assessment

✅ Low: The remaining change set is small and well-bounded, and the earlier daemon restart recovery and installer exit-code issues appear to be addressed without introducing a substantiated new regression in the changed code.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (2)</summary>

**Round 1** - found 3 warnings
- ⚠️ `internal/cli/daemon_cmd.go:137` - `daemon restart` drops the error from `daemonIsRunningFn` and only stops when the health check returns `alive=true`. Because `daemon.Stop` is already idempotent and has stale-artifact/PID fallback, this makes restart unable to recover a wedged or partially responsive daemon and can turn a recoverable restart into a start failure.
- ⚠️ `docs/install.sh:80` - The installer now uses `daemon restart` but still treats failure as non-fatal. During an upgrade, a failed restart can stop a previously healthy daemon and then exit 0, leaving background automation disabled even though installation looked successful.
- ⚠️ `docs/install.ps1:37` - The PowerShell installer invokes `daemon restart` without checking the native command exit code, so a failed restart is silently ignored and the script still reports success. With the new restart behavior, that can leave an upgraded install with no running daemon and no warning.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `internal/cli/daemon_cmd.go:137` - `daemon restart` still relies on `daemon.IsRunning` to decide whether to call `daemon.Stop`, but `daemon.IsRunning` intentionally returns `(false, nil)` for any IPC dial failure. If the old daemon process is still alive but its socket is gone or unreachable, restart skips `Stop`, then `daemon.Start` also sees it as &#39;not running&#39; and can launch a second daemon instead of using `daemon.Stop`&#39;s PID-based recovery path.

**Round 3** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>🔧 **Document** - 6 issues found → auto-fixed</summary>

**Round 1** - found 6 warnings
- ⚠️ `docs/src/content/docs/reference/cli.md:124` - The CLI reference documents `no-mistakes daemon start`, `stop`, and `status`, but this change adds a new public `no-mistakes daemon restart` subcommand and there is no corresponding reference section or usage example for it.
- ⚠️ `docs/src/content/docs/start-here/installation.md:14` - The macOS/Linux install docs still say the installer &#39;attempts to install and start&#39; the daemon and tell users to run `no-mistakes daemon start` manually on failure. The installer now runs `no-mistakes daemon restart` and fails the install if that restart returns a non-zero exit code.
- ⚠️ `docs/src/content/docs/start-here/installation.md:24` - The Windows install section still describes daemon startup as a best-effort automatic step. `docs/install.ps1` now runs `no-mistakes.exe daemon restart`, waits for completion, and throws when restart fails, so this behavior needs to be documented.
- ⚠️ `docs/src/content/docs/start-here/quick-start.md:14` - Quick Start still says the installer starts the daemon and that users should run `no-mistakes daemon start` manually if startup fails. The installer now restarts the daemon and surfaces restart failure instead of treating it as a warning-only fallback.
- ⚠️ `docs/src/content/docs/concepts/gate-model.md:110` - The gate model page says explicit daemon management is `no-mistakes daemon start|stop|status`, but this branch adds `daemon restart` as another supported management command, so the command list is now stale.
- ⚠️ `docs/src/content/docs/concepts/daemon.md:37` - The daemon concept page&#39;s explicit management examples list only `daemon start`, `daemon stop`, and `daemon status`. It should be updated to include the new `daemon restart` command introduced by this change.

**Round 2** (auto-fix) - found 0 issues

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/cli/daemon_cmd_test.go:1` - `gofmt -l` reports this file is not formatted according to the repository&#39;s configured Go formatter.

**Round 2** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
