### PR TITLE
feat(pipeline): add testing details to PR summaries

### DIFF
--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -53,6 +53,7 @@ Runs your test suite.
 **Behavior:**
 - If `commands.test` is set in repo config: runs it via the platform shell (`sh -c` on POSIX, `cmd.exe /c` on Windows) and captures output. Non-zero exit produces `error` findings.
 - If `commands.test` is empty: the agent detects and runs relevant tests, returning structured findings with severity, description, and `action` (`no-op`, `auto-fix`, `ask-user`).
+- The step also records the exact tests it exercised in a `tested` array and may include a short natural-language `testing_summary`; these are persisted even when tests pass so later steps can reuse them.
 - If the agent creates new test files (detected via `git status --porcelain`), approval is required even if tests pass.
 
 **Approval:** failing test findings with `action: ask-user` always require human approval. `action: auto-fix` findings stay eligible for the fix loop. `action: no-op` findings are informational only.
@@ -119,6 +120,7 @@ Creates or updates a pull request.
 - Uses the provider CLI for GitHub/GitLab and the Bitbucket API for Bitbucket Cloud
 - PR title: agent-generated in conventional commit format (`type(scope): description` or `type: description`); when a scope is used, it should be the primary affected real module/package from the changed paths and kept broad rather than file-level
 - PR body includes: an agent-authored `## Summary` plus regenerated `## Risk Assessment`, `## Testing`, and `## Pipeline` sections from recorded step results and rounds
+- The regenerated `## Testing` section prefers the recorded `testing_summary`, lists deduplicated `tested` commands or selectors, and ends with the overall outcome including run count and total duration when available
 
 Stores the PR URL in the database and streams it to the TUI.
 

--- a/internal/pipeline/findings.go
+++ b/internal/pipeline/findings.go
@@ -121,7 +121,7 @@ func mergeFindingsJSON(existingRaw, additionalRaw string) string {
 	seen := make(map[types.Finding]bool, len(existing.Items)+len(additional.Items))
 	existingCounts := countFindingFingerprints(existing.Items)
 	additionalCounts := countFindingFingerprints(additional.Items)
-	merged := types.Findings{}
+	merged := types.Findings{Summary: existing.Summary, Tested: existing.Tested, TestingSummary: existing.TestingSummary, RiskLevel: existing.RiskLevel, RiskRationale: existing.RiskRationale}
 	for _, item := range existing.Items {
 		merged.Items = append(merged.Items, item)
 		seen[findingKey(item)] = true
@@ -165,7 +165,7 @@ func removeMatchingFindingsJSON(existingRaw, removeRaw string) string {
 	for _, item := range remove.Items {
 		toRemove[findingKey(item)] = true
 	}
-	filtered := types.Findings{Summary: existing.Summary, RiskLevel: existing.RiskLevel, RiskRationale: existing.RiskRationale}
+	filtered := types.Findings{Summary: existing.Summary, Tested: existing.Tested, TestingSummary: existing.TestingSummary, RiskLevel: existing.RiskLevel, RiskRationale: existing.RiskRationale}
 	for _, item := range existing.Items {
 		if hasFindingMatch(item, toRemove, existingCounts, removeCounts) {
 			continue
@@ -200,7 +200,7 @@ func retainMatchingFindingsJSON(existingRaw, keepRaw string) string {
 	for _, item := range keep.Items {
 		allowed[findingKey(item)] = true
 	}
-	filtered := types.Findings{Summary: existing.Summary, RiskLevel: existing.RiskLevel, RiskRationale: existing.RiskRationale}
+	filtered := types.Findings{Summary: existing.Summary, Tested: existing.Tested, TestingSummary: existing.TestingSummary, RiskLevel: existing.RiskLevel, RiskRationale: existing.RiskRationale}
 	for _, item := range existing.Items {
 		if !hasFindingMatch(item, allowed, existingCounts, keepCounts) {
 			continue

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -32,7 +32,14 @@ var findingsSchema = json.RawMessage(`{
 				"required": ["severity", "description", "action"]
 			}
 		},
-		"summary": {"type": "string"}
+		"summary": {"type": "string"},
+		"tested": {
+			"type": "array",
+			"items": {"type": "string"}
+		},
+		"testing_summary": {
+			"type": "string"
+		}
 	},
 	"required": ["findings", "summary"]
 }`)

--- a/internal/pipeline/steps/common_test.go
+++ b/internal/pipeline/steps/common_test.go
@@ -816,6 +816,41 @@ func TestFindingsSchema_Action(t *testing.T) {
 	}
 }
 
+func TestFindingsSchema_IncludesTestedArray(t *testing.T) {
+	t.Parallel()
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(findingsSchema, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	props := parsed["properties"].(map[string]interface{})
+	tested, ok := props["tested"].(map[string]interface{})
+	if !ok {
+		t.Fatal("findingsSchema missing tested property")
+	}
+	if tested["type"] != "array" {
+		t.Fatalf("expected tested to be an array, got %#v", tested["type"])
+	}
+	if tested["items"].(map[string]interface{})["type"] != "string" {
+		t.Fatalf("expected tested items to be strings, got %#v", tested["items"])
+	}
+}
+
+func TestFindingsSchema_IncludesTestingSummary(t *testing.T) {
+	t.Parallel()
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(findingsSchema, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	props := parsed["properties"].(map[string]interface{})
+	field, ok := props["testing_summary"].(map[string]interface{})
+	if !ok {
+		t.Fatal("findingsSchema missing testing_summary property")
+	}
+	if field["type"] != "string" {
+		t.Fatalf("expected testing_summary to be a string, got %#v", field["type"])
+	}
+}
+
 func TestReviewFindingsSchema_ActionAtItemLevel(t *testing.T) {
 	t.Parallel()
 	var parsed map[string]interface{}

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -70,7 +70,7 @@ func BuildTestingSummary(steps []*db.StepResult, rounds map[string][]*db.StepRou
 		if testingSummary != "" {
 			rendered := renderTestingSummary(testingSummary)
 			if rendered != "" {
-			b.WriteString("- Summary: ")
+				b.WriteString("- Summary: ")
 				b.WriteString(rendered)
 				b.WriteString("\n")
 			}

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -73,8 +73,12 @@ func BuildTestingSummary(steps []*db.StepResult, rounds map[string][]*db.StepRou
 			b.WriteString("\n")
 		}
 		for _, detail := range tested {
+			rendered := renderTestedDetail(detail)
+			if rendered == "" {
+				continue
+			}
 			b.WriteString("- ")
-			b.WriteString(detail)
+			b.WriteString(rendered)
 			b.WriteString("\n")
 		}
 		if outcome := buildTestingOutcomeLine(line, stepRounds); outcome != "" {
@@ -138,6 +142,22 @@ func appendTestingDetails(details []string, seen map[string]bool, raw *string) [
 		details = append(details, clean)
 	}
 	return details
+}
+
+func renderTestedDetail(detail string) string {
+	clean := sanitizePromptMultilineText(detail)
+	if clean == "" {
+		return ""
+	}
+	if strings.HasPrefix(clean, "`") && strings.HasSuffix(clean, "`") && strings.Count(clean, "`") == 2 && !strings.Contains(clean[1:len(clean)-1], "\n") {
+		return clean
+	}
+	if !strings.Contains(clean, "`") && !strings.Contains(clean, "\n") {
+		return fmt.Sprintf("`%s`", clean)
+	}
+	escaped := html.EscapeString(clean)
+	escaped = strings.ReplaceAll(escaped, "\n", "&#10;")
+	return fmt.Sprintf("<code>%s</code>", escaped)
 }
 
 func buildTestingOutcomeLine(summaryLine string, rounds []*db.StepRound) string {
@@ -457,11 +477,11 @@ func buildStepDetails(summaryLine string, sr *db.StepResult, rounds []*db.StepRo
 			b.WriteString(fmt.Sprintf("**Round %d**%s - passed ✅\n", r.Round, triggerLabel))
 			if sr.StepName == types.StepTest {
 				for _, detail := range findings.Tested {
-					clean := strings.TrimSpace(detail)
-					if clean == "" {
+					rendered := renderTestedDetail(detail)
+					if rendered == "" {
 						continue
 					}
-					b.WriteString(fmt.Sprintf("- %s\n", html.EscapeString(clean)))
+					b.WriteString(fmt.Sprintf("- %s\n", rendered))
 				}
 			}
 			b.WriteString("\n")
@@ -482,6 +502,15 @@ func buildStepDetails(summaryLine string, sr *db.StepResult, rounds []*db.StepRo
 				loc += "` - "
 			}
 			b.WriteString(fmt.Sprintf("- %s %s%s\n", emoji, loc, html.EscapeString(f.Description)))
+		}
+		if sr.StepName == types.StepTest {
+			for _, detail := range findings.Tested {
+				rendered := renderTestedDetail(detail)
+				if rendered == "" {
+					continue
+				}
+				b.WriteString(fmt.Sprintf("- %s\n", rendered))
+			}
 		}
 		b.WriteString("\n")
 	}

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"html"
 	"strings"
+	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/types"
@@ -52,15 +53,128 @@ func BuildTestingSummary(steps []*db.StepResult, rounds map[string][]*db.StepRou
 			continue
 		}
 
-		line, _ := buildStepEntry(sr, rounds[sr.ID])
+		stepRounds := rounds[sr.ID]
+		line, _ := buildStepEntry(sr, stepRounds)
 		if line == "" {
 			return ""
 		}
 
-		return "## Testing\n\n- " + line
+		testingSummary := collectTestingSummary(sr, stepRounds)
+		tested := collectTestingDetails(sr, stepRounds)
+		if testingSummary == "" && len(tested) == 0 {
+			return "## Testing\n\n- " + line
+		}
+
+		var b strings.Builder
+		b.WriteString("## Testing\n\n")
+		if testingSummary != "" {
+			b.WriteString("- Summary: ")
+			b.WriteString(testingSummary)
+			b.WriteString("\n")
+		}
+		for _, detail := range tested {
+			b.WriteString("- ")
+			b.WriteString(detail)
+			b.WriteString("\n")
+		}
+		if outcome := buildTestingOutcomeLine(line, stepRounds); outcome != "" {
+			b.WriteString("- ")
+			b.WriteString(outcome)
+			b.WriteString("\n")
+		}
+
+		return strings.TrimSpace(b.String())
 	}
 
 	return ""
+}
+
+func collectTestingSummary(sr *db.StepResult, rounds []*db.StepRound) string {
+	if summary := testingSummaryFromFindings(sr.FindingsJSON); summary != "" {
+		return summary
+	}
+	for i := len(rounds) - 1; i >= 0; i-- {
+		if summary := testingSummaryFromFindings(rounds[i].FindingsJSON); summary != "" {
+			return summary
+		}
+	}
+	return ""
+}
+
+func testingSummaryFromFindings(raw *string) string {
+	if raw == nil || strings.TrimSpace(*raw) == "" {
+		return ""
+	}
+	findings, err := types.ParseFindingsJSON(*raw)
+	if err != nil {
+		return ""
+	}
+	return sanitizePromptMultilineText(findings.TestingSummary)
+}
+
+func collectTestingDetails(sr *db.StepResult, rounds []*db.StepRound) []string {
+	seen := map[string]bool{}
+	details := appendTestingDetails(nil, seen, sr.FindingsJSON)
+	for _, r := range rounds {
+		details = appendTestingDetails(details, seen, r.FindingsJSON)
+	}
+	return details
+}
+
+func appendTestingDetails(details []string, seen map[string]bool, raw *string) []string {
+	if raw == nil || strings.TrimSpace(*raw) == "" {
+		return details
+	}
+	findings, err := types.ParseFindingsJSON(*raw)
+	if err != nil {
+		return details
+	}
+	for _, detail := range findings.Tested {
+		clean := sanitizePromptText(detail)
+		if clean == "" || seen[clean] {
+			continue
+		}
+		seen[clean] = true
+		details = append(details, clean)
+	}
+	return details
+}
+
+func buildTestingOutcomeLine(summaryLine string, rounds []*db.StepRound) string {
+	outcome := strings.TrimSpace(strings.Replace(summaryLine, "**Test** - ", "", 1))
+	if outcome == "" {
+		return ""
+	}
+	if len(rounds) == 0 {
+		return "Outcome: " + outcome
+	}
+	runLabel := "1 run"
+	if len(rounds) != 1 {
+		runLabel = fmt.Sprintf("%d runs", len(rounds))
+	}
+	totalDuration := int64(0)
+	for _, r := range rounds {
+		totalDuration += r.DurationMS
+	}
+	if totalDuration > 0 {
+		return fmt.Sprintf("Outcome: %s across %s (%s)", outcome, runLabel, formatTestingDuration(totalDuration))
+	}
+	return fmt.Sprintf("Outcome: %s across %s", outcome, runLabel)
+}
+
+func formatTestingDuration(ms int64) string {
+	if ms < 1000 {
+		return fmt.Sprintf("%dms", ms)
+	}
+	d := time.Duration(ms) * time.Millisecond
+	if d < time.Minute {
+		seconds := float64(ms) / 1000
+		if ms%1000 == 0 {
+			return fmt.Sprintf("%ds", ms/1000)
+		}
+		return fmt.Sprintf("%.1fs", seconds)
+	}
+	return d.Round(time.Second).String()
 }
 
 func buildStepEntry(sr *db.StepResult, rounds []*db.StepRound) (statusLine, detailBlock string) {
@@ -337,6 +451,20 @@ func buildStepDetails(summaryLine string, sr *db.StepResult, rounds []*db.StepRo
 		findings, err := types.ParseFindingsJSON(*r.FindingsJSON)
 		if err != nil {
 			b.WriteString(fmt.Sprintf("**Round %d**%s - failed to parse findings\n\n", r.Round, triggerLabel))
+			continue
+		}
+		if len(findings.Items) == 0 {
+			b.WriteString(fmt.Sprintf("**Round %d**%s - passed ✅\n", r.Round, triggerLabel))
+			if sr.StepName == types.StepTest {
+				for _, detail := range findings.Tested {
+					clean := strings.TrimSpace(detail)
+					if clean == "" {
+						continue
+					}
+					b.WriteString(fmt.Sprintf("- %s\n", html.EscapeString(clean)))
+				}
+			}
+			b.WriteString("\n")
 			continue
 		}
 

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -68,9 +68,12 @@ func BuildTestingSummary(steps []*db.StepResult, rounds map[string][]*db.StepRou
 		var b strings.Builder
 		b.WriteString("## Testing\n\n")
 		if testingSummary != "" {
+			rendered := renderTestingSummary(testingSummary)
+			if rendered != "" {
 			b.WriteString("- Summary: ")
-			b.WriteString(testingSummary)
-			b.WriteString("\n")
+				b.WriteString(rendered)
+				b.WriteString("\n")
+			}
 		}
 		for _, detail := range tested {
 			rendered := renderTestedDetail(detail)
@@ -158,6 +161,17 @@ func renderTestedDetail(detail string) string {
 	escaped := html.EscapeString(clean)
 	escaped = strings.ReplaceAll(escaped, "\n", "&#10;")
 	return fmt.Sprintf("<code>%s</code>", escaped)
+}
+
+func renderTestingSummary(summary string) string {
+	clean := sanitizePromptMultilineText(summary)
+	if clean == "" {
+		return ""
+	}
+	if strings.ContainsAny(clean, "`\n<>") {
+		return renderTestedDetail(clean)
+	}
+	return clean
 }
 
 func buildTestingOutcomeLine(summaryLine string, rounds []*db.StepRound) string {

--- a/internal/pipeline/steps/prsummary_rounds_test.go
+++ b/internal/pipeline/steps/prsummary_rounds_test.go
@@ -146,3 +146,22 @@ func TestBuildPipelineSummary_UsesFinalFindingsWithoutInitialRoundData(t *testin
 		t.Errorf("expected missing round findings data to be called out explicitly, got:\n%s", md)
 	}
 }
+
+func TestBuildPipelineSummary_FailedTestRoundIncludesTestedDetails(t *testing.T) {
+	t.Parallel()
+	findings := `{"findings":[{"id":"test-1","severity":"error","description":"expected 429 got 200"}],"tested":["go test ./internal/cli -run '^TestDoctorBasic$' -count=1"],"summary":"1 failure"}`
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepTest, Status: types.StepStatusCompleted, FindingsJSON: &findings},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {
+			{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 300},
+		},
+	}
+
+	md, _ := BuildPipelineSummary(steps, rounds)
+
+	if !strings.Contains(md, "- `go test ./internal/cli -run '^TestDoctorBasic$' -count=1`") {
+		t.Fatalf("expected failed test round to include tested command details, got:\n%s", md)
+	}
+}

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -185,3 +185,29 @@ func TestBuildTestingSummary_DoesNotClaimPassedWithoutRounds(t *testing.T) {
 		t.Errorf("expected unavailable status without recorded rounds, got:\n%s", md)
 	}
 }
+
+func TestBuildTestingSummary_IncludesRecordedTestDetails(t *testing.T) {
+	t.Parallel()
+	findings := "{\"findings\":[],\"summary\":\"\",\"testing_summary\":\"Validated the CLI doctor path and config loading; both passed.\",\"tested\":[\"`go test ./internal/cli -run '^TestDoctorBasic$' -count=1`\"]}"
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepTest, Status: types.StepStatusCompleted, FindingsJSON: &findings},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 300}},
+	}
+
+	md := BuildTestingSummary(steps, rounds)
+
+	if !strings.Contains(md, "- Summary: Validated the CLI doctor path and config loading; both passed.") {
+		t.Fatalf("expected natural-language testing summary, got:\n%s", md)
+	}
+	if !strings.Contains(md, "- `go test ./internal/cli -run '^TestDoctorBasic$' -count=1`") {
+		t.Fatalf("expected recorded test command in testing summary, got:\n%s", md)
+	}
+	if !strings.Contains(md, "- Outcome: ✅ passed across 1 run (300ms)") {
+		t.Fatalf("expected outcome line with run count and duration, got:\n%s", md)
+	}
+	if strings.Index(md, "Summary:") > strings.Index(md, "`go test ./internal/cli -run '^TestDoctorBasic$' -count=1`") {
+		t.Fatalf("expected testing summary before raw test details, got:\n%s", md)
+	}
+}

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -211,3 +211,20 @@ func TestBuildTestingSummary_IncludesRecordedTestDetails(t *testing.T) {
 		t.Fatalf("expected testing summary before raw test details, got:\n%s", md)
 	}
 }
+
+func TestBuildTestingSummary_EscapesMarkdownInTestingSummary(t *testing.T) {
+	t.Parallel()
+	findings := "{\"findings\":[],\"summary\":\"\",\"testing_summary\":\"Validated `go test ./...`\\nand noted <details> output\",\"tested\":[]}"
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepTest, Status: types.StepStatusCompleted, FindingsJSON: &findings},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 300}},
+	}
+
+	md := BuildTestingSummary(steps, rounds)
+
+	if !strings.Contains(md, "- Summary: <code>Validated `go test ./...`&#10;and noted &lt;details&gt; output</code>") {
+		t.Fatalf("expected escaped testing summary, got:\n%s", md)
+	}
+}

--- a/internal/pipeline/steps/test.go
+++ b/internal/pipeline/steps/test.go
@@ -152,7 +152,7 @@ Rules:
 	if err != nil {
 		return nil, fmt.Errorf("run test command: %w", err)
 	}
-	tested := []string{fmt.Sprintf("`%s`", testCmd)}
+	tested := []string{testCmd}
 
 	sctx.Log(output)
 

--- a/internal/pipeline/steps/test.go
+++ b/internal/pipeline/steps/test.go
@@ -85,12 +85,16 @@ Task:
 - Understand the change before testing it.
 - Run existing tests that are relevant to the change.
 - Writing and running new tests if coverage is insufficient.
+- Include a concise "testing_summary" sentence describing what you exercised and the overall result.
+- Record the exact tests you ran in a "tested" array. Prefer concrete commands or test selectors wrapped in backticks.
 - If tests fail, determine whether the problem is a real product/code failure, a setup/environment problem you can fix, or a flaky/infrastructure issue.
 - If the issue is setup-related and fixable, fix it and retry the tests.
 
 Rules:
 - Do NOT run linters, formatters, or static analysis tools.
 - Focus on testing and test-related fixes only.
+- Keep "testing_summary" high-signal and natural language. Avoid raw logs and noisy counts.
+- Always return a non-empty "tested" array describing what you exercised, even when all tests pass.
 - Only report actionable findings: test failures, unfixable setup issues, or flaky tests you identified.
 - Do NOT report passing tests (whether existing or new), test counts, coverage summaries, or other non-actionable information.
 - If all tests pass and there are no issues, return an empty findings array.
@@ -148,6 +152,7 @@ Rules:
 	if err != nil {
 		return nil, fmt.Errorf("run test command: %w", err)
 	}
+	tested := []string{fmt.Sprintf("`%s`", testCmd)}
 
 	sctx.Log(output)
 
@@ -158,6 +163,7 @@ Rules:
 				Description: fmt.Sprintf("tests failed with exit code %d", exitCode),
 			}},
 			Summary: output,
+			Tested:  tested,
 		}
 		findingsJSON, _ := json.Marshal(findings)
 		return &pipeline.StepOutcome{
@@ -173,6 +179,7 @@ Rules:
 	if sctx.Fixing && len(newTestsFromFix) > 0 {
 		findings := Findings{
 			Summary: "tests passed, but agent wrote new test files",
+			Tested:  tested,
 		}
 		for _, f := range newTestsFromFix {
 			findings.Items = append(findings.Items, Finding{
@@ -190,5 +197,6 @@ Rules:
 	}
 
 	sctx.Log("all tests passed")
-	return &pipeline.StepOutcome{FixSummary: fixSummary}, nil
+	findingsJSON, _ := json.Marshal(Findings{Tested: tested})
+	return &pipeline.StepOutcome{Findings: string(findingsJSON), FixSummary: fixSummary}, nil
 }

--- a/internal/pipeline/steps/test_test.go
+++ b/internal/pipeline/steps/test_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
 	"github.com/kunchenguid/no-mistakes/internal/config"
+	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
 func TestTestStep_PassingCommand(t *testing.T) {
@@ -28,6 +29,13 @@ func TestTestStep_PassingCommand(t *testing.T) {
 	}
 	if len(ag.calls) != 0 {
 		t.Error("expected no agent calls when test command passes")
+	}
+	findings, err := types.ParseFindingsJSON(outcome.Findings)
+	if err != nil {
+		t.Fatalf("ParseFindingsJSON() error = %v", err)
+	}
+	if len(findings.Tested) != 1 || findings.Tested[0] != "`true`" {
+		t.Fatalf("expected passing command to record executed test command, got %+v", findings.Tested)
 	}
 }
 
@@ -94,7 +102,7 @@ func TestTestStep_NoCommand_AgentDetects(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 
-	findings := Findings{Items: nil, Summary: "all tests passed"}
+	findings := Findings{Items: nil, Summary: "all tests passed", TestingSummary: "Validated the CLI doctor path and config loading; both passed.", Tested: []string{"`go test ./internal/cli -run '^TestDoctorBasic$' -count=1`"}}
 	findingsJSON, _ := json.Marshal(findings)
 
 	ag := &mockAgent{
@@ -118,6 +126,16 @@ func TestTestStep_NoCommand_AgentDetects(t *testing.T) {
 	}
 	if !strings.Contains(ag.calls[0].Prompt, "branch: refs/heads/feature") {
 		t.Error("expected prompt to include branch metadata")
+	}
+	parsed, err := types.ParseFindingsJSON(outcome.Findings)
+	if err != nil {
+		t.Fatalf("ParseFindingsJSON() error = %v", err)
+	}
+	if len(parsed.Tested) != 1 || parsed.Tested[0] != findings.Tested[0] {
+		t.Fatalf("expected agent-reported test details to be preserved, got %+v", parsed.Tested)
+	}
+	if parsed.TestingSummary != findings.TestingSummary {
+		t.Fatalf("expected agent-reported testing summary to be preserved, got %q", parsed.TestingSummary)
 	}
 }
 
@@ -404,7 +422,7 @@ func TestTestStep_FixMode_AgentWritesNewTests_NeedsApproval(t *testing.T) {
 func TestTestStep_PromptIncludesAction(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	findings := Findings{Items: nil, Summary: "all tests passed"}
+	findings := Findings{Items: nil, Summary: "all tests passed", Tested: []string{"`go test ./...`"}}
 	findingsJSON, _ := json.Marshal(findings)
 	ag := &mockAgent{
 		name: "test",
@@ -422,5 +440,11 @@ func TestTestStep_PromptIncludesAction(t *testing.T) {
 	}
 	if !strings.Contains(ag.calls[0].Prompt, "action") {
 		t.Error("expected test prompt to instruct agent about action")
+	}
+	if !strings.Contains(ag.calls[0].Prompt, "tested") {
+		t.Error("expected test prompt to request recorded test details")
+	}
+	if !strings.Contains(ag.calls[0].Prompt, "testing_summary") {
+		t.Error("expected test prompt to request a natural-language testing summary")
 	}
 }

--- a/internal/pipeline/steps/test_test.go
+++ b/internal/pipeline/steps/test_test.go
@@ -34,7 +34,7 @@ func TestTestStep_PassingCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseFindingsJSON() error = %v", err)
 	}
-	if len(findings.Tested) != 1 || findings.Tested[0] != "`true`" {
+	if len(findings.Tested) != 1 || findings.Tested[0] != "true" {
 		t.Fatalf("expected passing command to record executed test command, got %+v", findings.Tested)
 	}
 }
@@ -95,6 +95,9 @@ func TestTestStep_FailingCommand(t *testing.T) {
 	}
 	if findings.Items[0].Severity != "error" {
 		t.Errorf("severity = %s, want error", findings.Items[0].Severity)
+	}
+	if len(findings.Tested) != 1 || findings.Tested[0] != "exit 1" {
+		t.Fatalf("expected failing command to record raw executed test command, got %+v", findings.Tested)
 	}
 }
 

--- a/internal/types/findings.go
+++ b/internal/types/findings.go
@@ -34,18 +34,22 @@ type findingWire struct {
 
 // Findings is the structured findings payload exchanged across pipeline, IPC, and TUI.
 type Findings struct {
-	Items         []Finding `json:"findings"`
-	Summary       string    `json:"summary"`
-	RiskLevel     string    `json:"risk_level"`
-	RiskRationale string    `json:"risk_rationale"`
+	Items          []Finding `json:"findings"`
+	Summary        string    `json:"summary"`
+	Tested         []string  `json:"tested,omitempty"`
+	TestingSummary string    `json:"testing_summary,omitempty"`
+	RiskLevel      string    `json:"risk_level"`
+	RiskRationale  string    `json:"risk_rationale"`
 }
 
 type findingsWire struct {
-	Items         []Finding `json:"findings"`
-	Legacy        []Finding `json:"items"`
-	Summary       string    `json:"summary"`
-	RiskLevel     string    `json:"risk_level"`
-	RiskRationale string    `json:"risk_rationale"`
+	Items          []Finding `json:"findings"`
+	Legacy         []Finding `json:"items"`
+	Summary        string    `json:"summary"`
+	Tested         []string  `json:"tested"`
+	TestingSummary string    `json:"testing_summary"`
+	RiskLevel      string    `json:"risk_level"`
+	RiskRationale  string    `json:"risk_rationale"`
 }
 
 // ParseFindingsJSON decodes findings JSON, accepting current and legacy item
@@ -59,7 +63,7 @@ func ParseFindingsJSON(raw string) (Findings, error) {
 	if len(items) == 0 && len(wire.Legacy) > 0 {
 		items = wire.Legacy
 	}
-	return Findings{Items: items, Summary: wire.Summary, RiskLevel: wire.RiskLevel, RiskRationale: wire.RiskRationale}, nil
+	return Findings{Items: items, Summary: wire.Summary, Tested: wire.Tested, TestingSummary: wire.TestingSummary, RiskLevel: wire.RiskLevel, RiskRationale: wire.RiskRationale}, nil
 }
 
 // NormalizeFindings assigns deterministic IDs to findings that do not have one yet.
@@ -82,7 +86,7 @@ func FilterFindings(findings Findings, ids []string) Findings {
 	for _, id := range ids {
 		selected[id] = true
 	}
-	filtered := Findings{Summary: findings.Summary, RiskLevel: findings.RiskLevel, RiskRationale: findings.RiskRationale}
+	filtered := Findings{Summary: findings.Summary, Tested: findings.Tested, TestingSummary: findings.TestingSummary, RiskLevel: findings.RiskLevel, RiskRationale: findings.RiskRationale}
 	for _, item := range findings.Items {
 		if selected[item.ID] {
 			filtered.Items = append(filtered.Items, item)
@@ -103,7 +107,7 @@ func ExcludeFindings(findings Findings, ids []string) Findings {
 	for _, id := range ids {
 		excluded[id] = true
 	}
-	result := Findings{Summary: findings.Summary, RiskLevel: findings.RiskLevel, RiskRationale: findings.RiskRationale}
+	result := Findings{Summary: findings.Summary, Tested: findings.Tested, TestingSummary: findings.TestingSummary, RiskLevel: findings.RiskLevel, RiskRationale: findings.RiskRationale}
 	for _, item := range findings.Items {
 		if !excluded[item.ID] {
 			result.Items = append(result.Items, item)
@@ -116,7 +120,7 @@ func ExcludeFindings(findings Findings, ids []string) Findings {
 // Action is "auto-fix". These are safe for automatic fixing without
 // user involvement.
 func AutoFixableFindings(findings Findings) Findings {
-	result := Findings{Summary: findings.Summary, RiskLevel: findings.RiskLevel, RiskRationale: findings.RiskRationale}
+	result := Findings{Summary: findings.Summary, Tested: findings.Tested, TestingSummary: findings.TestingSummary, RiskLevel: findings.RiskLevel, RiskRationale: findings.RiskRationale}
 	for _, item := range findings.Items {
 		if item.actionOrDefault() == ActionAutoFix {
 			result.Items = append(result.Items, item)

--- a/internal/types/findings_test.go
+++ b/internal/types/findings_test.go
@@ -41,6 +41,31 @@ func TestParseFindingsJSON_NoRiskFields(t *testing.T) {
 	}
 }
 
+func TestParseFindingsJSON_TestedDetails(t *testing.T) {
+	raw := `{"findings":[],"summary":"ok","tested":["` + "`go test ./...`" + `"]}`
+	f, err := ParseFindingsJSON(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Tested) != 1 {
+		t.Fatalf("Tested count = %d, want 1", len(f.Tested))
+	}
+	if f.Tested[0] != "`go test ./...`" {
+		t.Fatalf("Tested[0] = %q, want %q", f.Tested[0], "`go test ./...`")
+	}
+}
+
+func TestParseFindingsJSON_TestingSummary(t *testing.T) {
+	raw := `{"findings":[],"summary":"ok","testing_summary":"Validated CLI and config flows; all passed."}`
+	f, err := ParseFindingsJSON(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.TestingSummary != "Validated CLI and config flows; all passed." {
+		t.Fatalf("TestingSummary = %q", f.TestingSummary)
+	}
+}
+
 func TestFilterFindings_PreservesRiskFields(t *testing.T) {
 	f := Findings{
 		Items: []Finding{
@@ -263,6 +288,28 @@ func TestMarshalFindingsJSON_AlwaysIncludesRiskFields(t *testing.T) {
 	}
 	if !strings.Contains(raw, `"risk_rationale"`) {
 		t.Errorf("expected risk_rationale to be present even when empty, got %s", raw)
+	}
+}
+
+func TestMarshalFindingsJSON_IncludesTestedDetails(t *testing.T) {
+	f := Findings{Tested: []string{"`go test ./internal/cli`"}}
+	raw, err := MarshalFindingsJSON(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(raw, `"tested":["\u0060go test ./internal/cli\u0060"]`) && !strings.Contains(raw, `"tested":["`+"`go test ./internal/cli`"+`"]`) {
+		t.Fatalf("expected tested details to be encoded, got %s", raw)
+	}
+}
+
+func TestMarshalFindingsJSON_IncludesTestingSummary(t *testing.T) {
+	f := Findings{TestingSummary: "Validated CLI and config flows; all passed."}
+	raw, err := MarshalFindingsJSON(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(raw, `"testing_summary":"Validated CLI and config flows; all passed."`) {
+		t.Fatalf("expected testing summary to be encoded, got %s", raw)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Persist test execution details in pipeline findings by recording tested commands and a natural-language testing summary, and carry those fields safely through findings sanitization and filtering.
- Expand PR summary rendering to include escaped testing summaries, deduplicated commands, and per-round test details so failed and passing runs both show the debugging context that was actually executed.
- Update pipeline step docs and tests to cover the richer testing metadata and PR `## Testing` output.

## Risk Assessment

⚠️ Medium: The change is otherwise well-bounded, but it introduces a new path where agent-generated testing metadata can be replayed unsanitized into later fix prompts.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

**Round 1** - found 2 warnings
- ⚠️ `internal/pipeline/steps/test.go:155` - The configured test command is stored as a pre-backticked markdown fragment (`fmt.Sprintf(&#34;`%s`&#34;, testCmd)`). If the command itself contains backticks or embedded newlines, the generated Testing section becomes malformed markdown and can corrupt the deterministic PR body. Store the raw command and escape it when rendering instead of baking markdown into persisted data.
- ⚠️ `internal/pipeline/steps/prsummary.go:456` - Per-round test details are only rendered in the `len(findings.Items) == 0` branch, so failed test rounds still drop `findings.Tested`. That means the pipeline `&lt;details&gt;` block omits the exact failing command on the rounds where the debugging context is most useful.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `internal/pipeline/steps/prsummary.go:72` - `testing_summary` is written straight into a markdown list item after only whitespace normalization. If the agent returns embedded newlines or markdown control characters, the generated `## Testing` section can become malformed and destabilize the deterministic PR body. Escape or render this field the same way `tested` entries are rendered before appending it.

**Round 3** (auto-fix) - found 1 warning
- ⚠️ `internal/types/findings.go:39` - The new free-form `tested` and `testing_summary` fields are now preserved across auto-fix/filter flows, but follow-up fix prompts still sanitize only `Items`, `Summary`, and risk fields before re-embedding previous findings. That lets prior agent output in these new fields flow verbatim into later prompts, which reintroduces prompt-injection / malformed-prompt risk on multi-round test fixing. Sanitize or strip these fields in `sanitizedPreviousFindingsForPrompt` before marshaling previous findings back into a prompt.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed</summary>

**Round 1** - found 2 warnings
- ⚠️ `docs/src/content/docs/reference/pipeline-steps.md:53` - The Test step reference is stale relative to the new findings schema and step behavior. It still describes only findings severity/action, but the code now also records `tested` commands for both configured and agent-detected runs and asks the agent for a natural-language `testing_summary`. This page should document those new fields and that passing test runs now persist execution details for downstream consumers.
- ⚠️ `docs/src/content/docs/reference/pipeline-steps.md:121` - The PR step docs no longer match the generated `## Testing` section. PR summaries now include the agent-provided testing summary, the deduplicated list of exact tests run, and an outcome line with run count and duration, not just a generic regenerated Testing section. The reference should describe that richer Testing output so users know what will appear in PR bodies.

**Round 2** (auto-fix) - found 0 issues

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 error
- 🚨 `internal/pipeline/steps/prsummary.go:73` - `gofmt -l` reports this file as unformatted. The indentation on the `b.WriteString(&#34;- Summary: &#34;)` line does not match Go formatting.

**Round 2** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
