### PR TITLE
feat(cli): add non-interactive setup wizard with --yes

### DIFF
--- a/docs/src/content/docs/guides/setup-wizard.md
+++ b/docs/src/content/docs/guides/setup-wizard.md
@@ -71,7 +71,9 @@ not ask for one. If everything is already committed, it skips straight to push.
 
 ## Retry on failure
 
-If any step fails (git error, agent error, network error), the wizard shows the error and lets you press `r` to retry the step without restarting the whole flow.
+If any step fails (git error, agent error, network error), the interactive wizard shows the error and lets you press `r` to retry the step without restarting the whole flow.
+
+With `-y` / `--yes`, the non-interactive path exits on the first error instead of prompting to retry.
 
 ## Quitting safely
 

--- a/docs/src/content/docs/guides/setup-wizard.md
+++ b/docs/src/content/docs/guides/setup-wizard.md
@@ -12,13 +12,15 @@ The point of the wizard is to make bare `no-mistakes` a useful starting
 command, not just an attach command. If you have local work but no run yet, the
 wizard helps turn that state into branch -> commit -> push -> attach.
 
-The wizard only kicks in when:
+The wizard kicks in when:
 
-- You're in an interactive terminal.
+- You're in an interactive terminal, or you passed `no-mistakes -y` / `no-mistakes --yes`.
 - The gate is initialized for the current repo (`no-mistakes init` has been run).
 - There's no active run on the current branch.
 
-In non-interactive contexts, bare `no-mistakes` falls back to listing the last 5 runs instead.
+In non-interactive contexts, bare `no-mistakes` without `-y` falls back to listing the last 5 runs instead.
+
+With `-y` / `--yes`, the wizard runs non-interactively and takes the default automated path for each step: use agent suggestions for branch and commit when needed, then push to the gate.
 
 If you want to attach to *any* active run in the repo (not just the current branch), use `no-mistakes attach` - that path skips the wizard entirely.
 
@@ -28,7 +30,7 @@ If you want to attach to *any* active run in the repo (not just the current bran
 flowchart TD
   start["Run no-mistakes"] --> active{"Active run on current branch?"}
   active -- "yes" --> attach["Attach to run"]
-  active -- "no" --> interactive{"Interactive terminal and gate initialized?"}
+  active -- "no" --> interactive{"Interactive terminal, or -y/--yes, and gate initialized?"}
   interactive -- "no" --> recent["Show recent runs"]
   interactive -- "yes" --> branch["Branch step if needed"]
   branch --> commit["Commit step if needed"]
@@ -38,8 +40,7 @@ flowchart TD
 
 ## Steps
 
-The wizard is a full-screen flow that runs only the steps your current repo
-state needs, up to three total:
+The interactive wizard is a full-screen flow that runs only the steps your current repo state needs, up to three total. The `-y` / `--yes` path runs the same steps without the TUI and accepts the automated default at each one.
 
 ### 1. Branch
 

--- a/docs/src/content/docs/guides/setup-wizard.md
+++ b/docs/src/content/docs/guides/setup-wizard.md
@@ -98,7 +98,7 @@ The managed agent server (Rovo Dev or OpenCode) writes its output to `~/.no-mist
 The wizard requires:
 
 - The gate to be initialized (`no-mistakes init` has run).
-- A configured agent binary available on `PATH` (or via `agent_path_override`).
 - A clean enough state to commit and push.
+- A configured agent binary available on `PATH` (or via `agent_path_override`) only when the wizard needs to suggest a branch name or commit subject. If you already have a branch and clean working tree, or you enter those values yourself in the interactive flow, the wizard can continue without agent suggestions.
 
 If any of those are missing, the wizard reports the problem and exits. `no-mistakes doctor` is the fastest way to see what's available.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -5,11 +5,15 @@ description: Complete reference for all no-mistakes commands and flags.
 
 ## no-mistakes
 
-Attach to the active pipeline run for the current branch when one exists. If none exists and you're in an interactive TTY session, bare `no-mistakes` can start the setup wizard to create a branch, commit changes, push through the gate, and then attach once the new run appears. In non-interactive contexts, it falls back to showing the last 5 runs inline.
+Attach to the active pipeline run for the current branch when one exists. If none exists, bare `no-mistakes` can start the setup wizard to create a branch, commit changes, push through the gate, and then attach once the new run appears. By default this wizard path is interactive and only runs in a TTY session. In non-interactive contexts, bare `no-mistakes` falls back to showing the last 5 runs inline unless you pass `-y` or `--yes` to run the wizard non-interactively and accept defaults.
 
 ```sh
 no-mistakes
 ```
+
+| Flag | Type | Default | Description |
+|---|---|---|---|
+| `-y`, `--yes` | `bool` | `false` | Run setup wizard non-interactively, accepting defaults |
 
 Unlike `no-mistakes attach`, bare `no-mistakes` only auto-attaches to an active run on the current branch.
 

--- a/docs/src/content/docs/start-here/quick-start.md
+++ b/docs/src/content/docs/start-here/quick-start.md
@@ -72,7 +72,7 @@ The push lands in the local bare repo, the hook notifies the daemon, and the dae
 no-mistakes
 ```
 
-If the current branch has an active run, this attaches directly. If not, and you're in an interactive terminal, the setup wizard walks you through creating a branch, committing, and pushing through the gate before attaching.
+If the current branch has an active run, this attaches directly. If not, the setup wizard can walk you through creating a branch, committing, and pushing through the gate before attaching. By default that path is interactive in a TTY. In non-interactive contexts, use `no-mistakes -y` to run the same setup path and accept defaults automatically.
 
 The TUI shows each step's progress, streams agent output, and pauses for your approval when findings need attention. See [Using the TUI](/no-mistakes/guides/tui/) for keybindings and layout.
 

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -146,8 +146,8 @@ func activeRunBranch(state *repoState, rootDefault bool) string {
 }
 
 // isInteractive reports whether stdin and stdout are both connected to a
-// terminal. The wizard needs a real TTY to read keystrokes; in non-interactive
-// contexts we fall back to printing hints.
+// terminal. The interactive wizard needs a real TTY to read keystrokes; the
+// --yes path can still run the wizard non-interactively and accept defaults.
 func isInteractive() bool {
 	return isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd())
 }

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -22,7 +22,7 @@ var runTUI = tui.Run
 
 // attachRun is the shared logic for attaching to a pipeline run. It's used by
 // both the root command (bare `no-mistakes`) and the `attach` subcommand.
-func attachRun(w io.Writer, runID string, rootDefault bool, autoYes bool) error {
+func attachRun(ctx context.Context, w io.Writer, runID string, rootDefault bool, autoYes bool) error {
 	p, d, err := openResources()
 	if err != nil {
 		return err
@@ -67,7 +67,7 @@ func attachRun(w io.Writer, runID string, rootDefault bool, autoYes bool) error 
 
 		// Detect current state so we can decide between attach and wizard
 		// consistently with what the wizard itself will see.
-		state, err = detectRepoState(context.Background(), repo)
+		state, err = detectRepoState(ctx, repo)
 		if err != nil {
 			return err
 		}
@@ -94,9 +94,9 @@ func attachRun(w io.Writer, runID string, rootDefault bool, autoYes bool) error 
 			var res wizard.Result
 			var wErr error
 			if autoYes {
-				res, wErr = runWizardAuto(context.Background(), p, state)
+				res, wErr = runWizardAuto(ctx, p, state)
 			} else {
-				res, wErr = runWizard(context.Background(), p, state)
+				res, wErr = runWizard(ctx, p, state)
 			}
 			if wErr != nil {
 				return wErr
@@ -227,7 +227,7 @@ If no run ID is specified, attaches to the active run for the current repo.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return trackCommand("attach", func() error {
-				return attachRun(cmd.OutOrStdout(), runID, false, false)
+				return attachRun(cmd.Context(), cmd.OutOrStdout(), runID, false, false)
 			})
 		},
 	}

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -106,6 +106,9 @@ func attachRun(w io.Writer, runID string, rootDefault bool, autoYes bool) error 
 				if err != nil {
 					return fmt.Errorf("wait for active run: %w", err)
 				}
+				if autoYes && run == nil {
+					return fmt.Errorf("no active run appeared after pushing %q", res.TargetBranch)
+				}
 			}
 			if run == nil {
 				if !res.Aborted {

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -102,7 +102,7 @@ func attachRun(ctx context.Context, w io.Writer, runID string, rootDefault bool,
 				return wErr
 			}
 			if res.Success {
-				run, err = waitForActiveRun(client, repo.ID, res.TargetBranch, 5*time.Second)
+				run, err = waitForActiveRun(ctx, client, repo.ID, res.TargetBranch, 5*time.Second)
 				if err != nil {
 					return fmt.Errorf("wait for active run: %w", err)
 				}

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/telemetry"
 	"github.com/kunchenguid/no-mistakes/internal/tui"
 	"github.com/kunchenguid/no-mistakes/internal/update"
+	"github.com/kunchenguid/no-mistakes/internal/wizard"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 )
@@ -21,7 +22,7 @@ var runTUI = tui.Run
 
 // attachRun is the shared logic for attaching to a pipeline run. It's used by
 // both the root command (bare `no-mistakes`) and the `attach` subcommand.
-func attachRun(w io.Writer, runID string, rootDefault bool) error {
+func attachRun(w io.Writer, runID string, rootDefault bool, autoYes bool) error {
 	p, d, err := openResources()
 	if err != nil {
 		return err
@@ -85,12 +86,18 @@ func attachRun(w io.Writer, runID string, rootDefault bool) error {
 	}
 
 	if run == nil {
-		// No active run — if the user ran bare `no-mistakes` in their repo
+		// No active run - if the user ran bare `no-mistakes` in their repo
 		// from a TTY, offer the interactive setup wizard instead of just
-		// dumping a hint. Skip the wizard in non-interactive contexts
-		// (tests, CI, piped output) and fall back to the old behavior.
-		if rootDefault && runID == "" && repo != nil && state != nil && isInteractive() {
-			res, wErr := runWizard(context.Background(), p, state)
+		// dumping a hint. `-y` uses the same setup flow non-interactively,
+		// so it is allowed even when stdin/stdout are not TTYs.
+		if rootDefault && runID == "" && repo != nil && state != nil && (autoYes || isInteractive()) {
+			var res wizard.Result
+			var wErr error
+			if autoYes {
+				res, wErr = runWizardAuto(context.Background(), p, state)
+			} else {
+				res, wErr = runWizard(context.Background(), p, state)
+			}
 			if wErr != nil {
 				return wErr
 			}
@@ -217,7 +224,7 @@ If no run ID is specified, attaches to the active run for the current repo.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return trackCommand("attach", func() error {
-				return attachRun(cmd.OutOrStdout(), runID, false)
+				return attachRun(cmd.OutOrStdout(), runID, false, false)
 			})
 		},
 	}

--- a/internal/cli/helpers_test.go
+++ b/internal/cli/helpers_test.go
@@ -171,6 +171,17 @@ func executeCmd(args ...string) (string, error) {
 	return buf.String(), err
 }
 
+func executeCmdWithContext(ctx context.Context, args ...string) (string, error) {
+	cmd := newRootCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs(args)
+	cmd.SetContext(ctx)
+	err := cmd.Execute()
+	return buf.String(), err
+}
+
 func linkTestBinary(t *testing.T, binDir, name string) string {
 	t.Helper()
 	if runtime.GOOS == "windows" {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -39,7 +39,7 @@ func newRootCmd() *cobra.Command {
 		// route interactive users into the setup wizard when no run is active.
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return trackCommand("root", func() error {
-				return attachRun(cmd.OutOrStdout(), "", true, autoYes)
+				return attachRun(cmd.Context(), cmd.OutOrStdout(), "", true, autoYes)
 			})
 		},
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -23,6 +23,8 @@ func Execute() int {
 }
 
 func newRootCmd() *cobra.Command {
+	var autoYes bool
+
 	cmd := &cobra.Command{
 		Use:     "no-mistakes",
 		Short:   "Local Git proxy that validates code before pushing upstream",
@@ -37,10 +39,12 @@ func newRootCmd() *cobra.Command {
 		// route interactive users into the setup wizard when no run is active.
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return trackCommand("root", func() error {
-				return attachRun(cmd.OutOrStdout(), "", true)
+				return attachRun(cmd.OutOrStdout(), "", true, autoYes)
 			})
 		},
 	}
+
+	cmd.Flags().BoolVarP(&autoYes, "yes", "y", false, "run setup wizard non-interactively, accepting defaults")
 
 	cmd.AddCommand(newInitCmd())
 	cmd.AddCommand(newEjectCmd())

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -36,7 +36,8 @@ func newRootCmd() *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		// When run without a subcommand, attach to the current branch run or
-		// route interactive users into the setup wizard when no run is active.
+		// route users into the setup wizard when no run is active. The default
+		// wizard flow is interactive, while --yes accepts defaults without a TTY.
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return trackCommand("root", func() error {
 				return attachRun(cmd.Context(), cmd.OutOrStdout(), "", true, autoYes)

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -253,6 +254,45 @@ func TestRootYesFailsWhenWizardPushProducesNoRun(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no active run") {
 		t.Fatalf("error should mention missing active run, got %v", err)
+	}
+}
+
+func TestRootYesPassesCommandContextToWizard(t *testing.T) {
+	setupTestRepo(t)
+	nmHome := makeSocketSafeTempDir(t)
+	t.Setenv("NM_HOME", nmHome)
+	p := paths.WithRoot(nmHome)
+
+	d, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	if _, err := gate.Init(context.Background(), d, p, "."); err != nil {
+		t.Fatal(err)
+	}
+
+	startTestDaemon(t, p, d)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	prevAuto := runWizardAuto
+	runWizardAuto = func(got context.Context, p *paths.Paths, state *repoState) (wizard.Result, error) {
+		if got == nil {
+			t.Fatal("expected command context")
+		}
+		if err := got.Err(); err != context.Canceled {
+			t.Fatalf("wizard context err = %v, want %v", err, context.Canceled)
+		}
+		return wizard.Result{}, got.Err()
+	}
+	defer func() { runWizardAuto = prevAuto }()
+
+	_, err = executeCmdWithContext(ctx, "-y")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("executeCmdWithContext(-y) error = %v, want %v", err, context.Canceled)
 	}
 }
 

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -223,6 +223,39 @@ func TestRootYesRunsWizardNonInteractively(t *testing.T) {
 	}
 }
 
+func TestRootYesFailsWhenWizardPushProducesNoRun(t *testing.T) {
+	setupTestRepo(t)
+	nmHome := makeSocketSafeTempDir(t)
+	t.Setenv("NM_HOME", nmHome)
+	p := paths.WithRoot(nmHome)
+
+	d, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	if _, err := gate.Init(context.Background(), d, p, "."); err != nil {
+		t.Fatal(err)
+	}
+
+	startTestDaemon(t, p, d)
+
+	prevAuto := runWizardAuto
+	runWizardAuto = func(ctx context.Context, p *paths.Paths, state *repoState) (wizard.Result, error) {
+		return wizard.Result{Success: true, Pushed: true, TargetBranch: "feat/missing"}, nil
+	}
+	defer func() { runWizardAuto = prevAuto }()
+
+	_, err = executeCmd("-y")
+	if err == nil {
+		t.Fatal("expected -y to fail when no active run appears after push")
+	}
+	if !strings.Contains(err.Error(), "no active run") {
+		t.Fatalf("error should mention missing active run, got %v", err)
+	}
+}
+
 func setRunCreatedAt(t *testing.T, dbPath, runID string, ts int64) {
 	t.Helper()
 

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -14,7 +14,9 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/gate"
 	"github.com/kunchenguid/no-mistakes/internal/git"
+	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/wizard"
 	"github.com/muesli/termenv"
 )
 
@@ -163,6 +165,61 @@ func TestRootDefaultsToAttachWithAndWithoutHistory(t *testing.T) {
 	// Should still show push instructions.
 	if !strings.Contains(out, "git push no-mistakes") {
 		t.Errorf("expected push instructions, got: %s", out)
+	}
+}
+
+func TestRootYesRunsWizardNonInteractively(t *testing.T) {
+	setupTestRepo(t)
+	nmHome := makeSocketSafeTempDir(t)
+	t.Setenv("NM_HOME", nmHome)
+	p := paths.WithRoot(nmHome)
+
+	d, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	if _, err := gate.Init(context.Background(), d, p, "."); err != nil {
+		t.Fatal(err)
+	}
+
+	startTestDaemon(t, p, d)
+
+	gitRoot, err := git.FindGitRoot(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo, err := d.GetRepoByPath(gitRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prevAuto := runWizardAuto
+	runWizardAuto = func(ctx context.Context, p *paths.Paths, state *repoState) (wizard.Result, error) {
+		if state == nil {
+			t.Fatal("expected repo state")
+		}
+		if _, err := d.InsertRun(repo.ID, "feat/auto", "head1234", "base5678"); err != nil {
+			return wizard.Result{}, err
+		}
+		return wizard.Result{Success: true, Pushed: true, TargetBranch: "feat/auto"}, nil
+	}
+	defer func() { runWizardAuto = prevAuto }()
+
+	prevRunTUI := runTUI
+	attached := false
+	runTUI = func(string, *ipc.Client, *ipc.RunInfo, string) error {
+		attached = true
+		return nil
+	}
+	defer func() { runTUI = prevRunTUI }()
+
+	if _, err := executeCmd("-y"); err != nil {
+		t.Fatalf("executeCmd(-y) error = %v", err)
+	}
+	if !attached {
+		t.Fatal("expected -y run to attach to the created run")
 	}
 }
 

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -296,6 +296,44 @@ func TestRootYesPassesCommandContextToWizard(t *testing.T) {
 	}
 }
 
+func TestRootYesStopsWaitingForRunWhenContextCanceled(t *testing.T) {
+	setupTestRepo(t)
+	nmHome := makeSocketSafeTempDir(t)
+	t.Setenv("NM_HOME", nmHome)
+	p := paths.WithRoot(nmHome)
+
+	d, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	if _, err := gate.Init(context.Background(), d, p, "."); err != nil {
+		t.Fatal(err)
+	}
+
+	startTestDaemon(t, p, d)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	prevAuto := runWizardAuto
+	runWizardAuto = func(got context.Context, p *paths.Paths, state *repoState) (wizard.Result, error) {
+		cancel()
+		return wizard.Result{Success: true, Pushed: true, TargetBranch: "feat/missing"}, nil
+	}
+	defer func() { runWizardAuto = prevAuto }()
+
+	start := time.Now()
+	_, err = executeCmdWithContext(ctx, "-y")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("executeCmdWithContext(-y) error = %v, want %v", err, context.Canceled)
+	}
+	if elapsed := time.Since(start); elapsed >= time.Second {
+		t.Fatalf("executeCmdWithContext(-y) took %v after cancellation, want under %v", elapsed, time.Second)
+	}
+}
+
 func setRunCreatedAt(t *testing.T, dbPath, runID string, ts int64) {
 	t.Helper()
 

--- a/internal/cli/telemetry_test.go
+++ b/internal/cli/telemetry_test.go
@@ -169,7 +169,7 @@ func TestAttachTracksTUIPageview(t *testing.T) {
 	runTUI = func(string, *ipc.Client, *ipc.RunInfo, string) error { return nil }
 	defer func() { runTUI = prevRunTUI }()
 
-	if err := attachRun(io.Discard, run.ID, false, false); err != nil {
+	if err := attachRun(context.Background(), io.Discard, run.ID, false, false); err != nil {
 		t.Fatalf("attachRun() error = %v", err)
 	}
 

--- a/internal/cli/telemetry_test.go
+++ b/internal/cli/telemetry_test.go
@@ -169,7 +169,7 @@ func TestAttachTracksTUIPageview(t *testing.T) {
 	runTUI = func(string, *ipc.Client, *ipc.RunInfo, string) error { return nil }
 	defer func() { runTUI = prevRunTUI }()
 
-	if err := attachRun(io.Discard, run.ID, false); err != nil {
+	if err := attachRun(io.Discard, run.ID, false, false); err != nil {
 		t.Fatalf("attachRun() error = %v", err)
 	}
 

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -257,9 +257,17 @@ func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
 // waitForActiveRun polls the daemon until an active run appears for the given
 // repo/branch, or the deadline elapses. The post-receive hook creates the run
 // asynchronously, so a short poll bridges the gap between push and attach.
-func waitForActiveRun(client *ipc.Client, repoID, branch string, timeout time.Duration) (*ipc.RunInfo, error) {
-	deadline := time.Now().Add(timeout)
+func waitForActiveRun(ctx context.Context, client *ipc.Client, repoID, branch string, timeout time.Duration) (*ipc.RunInfo, error) {
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+
+	poll := time.NewTicker(150 * time.Millisecond)
+	defer poll.Stop()
+
 	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		var result ipc.GetActiveRunResult
 		if err := client.Call(ipc.MethodGetActiveRun, &ipc.GetActiveRunParams{RepoID: repoID, Branch: branch}, &result); err != nil {
 			return nil, err
@@ -267,10 +275,13 @@ func waitForActiveRun(client *ipc.Client, repoID, branch string, timeout time.Du
 		if result.Run != nil {
 			return result.Run, nil
 		}
-		if time.Now().After(deadline) {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-deadline.C:
 			return nil, nil
+		case <-poll.C:
 		}
-		time.Sleep(150 * time.Millisecond)
 	}
 }
 

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -177,6 +177,7 @@ func runWizardWithMode(ctx context.Context, p *paths.Paths, state *repoState, au
 	defer suggester.Close()
 
 	wizCfg := wizard.Config{
+		Context:       ctx,
 		RepoDir:       workDir,
 		CurrentBranch: state.currentBranch,
 		DefaultBranch: state.defaultBranch,

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -27,6 +27,10 @@ var resolveWizardAgent = func(ctx context.Context, cfg *config.Config) error {
 
 var newWizardAgent = agent.New
 var wizardRun = wizard.Run
+var wizardRunAuto = wizard.RunAuto
+var runWizardAuto = func(ctx context.Context, p *paths.Paths, state *repoState) (wizard.Result, error) {
+	return runWizardWithMode(ctx, p, state, true)
+}
 
 type wizardAgentSuggester struct {
 	cfg     *config.Config
@@ -148,6 +152,10 @@ func detectRepoState(ctx context.Context, repo *db.Repo) (*repoState, error) {
 // runWizard prepares optional suggestion hooks and runs the interactive
 // onboarding wizard against the supplied repo state.
 func runWizard(ctx context.Context, p *paths.Paths, state *repoState) (wizard.Result, error) {
+	return runWizardWithMode(ctx, p, state, false)
+}
+
+func runWizardWithMode(ctx context.Context, p *paths.Paths, state *repoState, auto bool) (wizard.Result, error) {
 	workDir := state.workDir
 
 	globalCfg, err := config.LoadGlobal(p.ConfigFile())
@@ -197,14 +205,19 @@ func runWizard(ctx context.Context, p *paths.Paths, state *repoState) (wizard.Re
 	}
 
 	telemetry.Pageview("/wizard", telemetry.Fields{
-		"entrypoint":          "wizard",
+		"entrypoint":          wizardEntrypoint(auto),
 		"needs_branch":        state.needsBranch(),
 		"is_dirty":            state.dirty,
 		"detached":            state.detached,
 		"current_branch_role": wizardBranchRole(state.currentBranch, state.defaultBranch, state.detached),
 	})
 
-	res, err := wizardRun(wizCfg)
+	run := wizardRun
+	if auto {
+		run = wizardRunAuto
+	}
+
+	res, err := run(wizCfg)
 	if err == nil {
 		telemetry.Track("wizard", telemetry.Fields{
 			"action":         "result",
@@ -278,6 +291,13 @@ func wizardResultStatus(res wizard.Result) string {
 		return "aborted"
 	}
 	return "closed"
+}
+
+func wizardEntrypoint(auto bool) string {
+	if auto {
+		return "wizard_auto"
+	}
+	return "wizard"
 }
 
 func mergeTelemetryFields(fields map[string]any, extra telemetry.Fields) telemetry.Fields {

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -17,6 +17,7 @@ import (
 // Callers pre-detect git state so the wizard can decide up-front which
 // steps to skip.
 type Config struct {
+	Context       context.Context
 	RepoDir       string
 	CurrentBranch string
 	DefaultBranch string
@@ -535,7 +536,11 @@ func Run(cfg Config) (Result, error) {
 // then push to the gate. Suggestion failures are returned immediately.
 func RunAuto(cfg Config) (Result, error) {
 	res := Result{TargetBranch: cfg.CurrentBranch}
-	ctx, cancel := context.WithCancel(context.Background())
+	baseCtx := cfg.Context
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+	ctx, cancel := context.WithCancel(baseCtx)
 	defer cancel()
 
 	track := func(action string, fields map[string]any) {

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -119,7 +119,11 @@ func NewModel(cfg Config) Model {
 	ti := textinput.New()
 	ti.Prompt = "› "
 	ti.CharLimit = 80
-	ctx, cancel := context.WithCancel(context.Background())
+	baseCtx := cfg.Context
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+	ctx, cancel := context.WithCancel(baseCtx)
 
 	m := Model{
 		cfg:          cfg,

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -6,6 +6,7 @@ package wizard
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -522,8 +523,15 @@ func (m Model) runPush() tea.Cmd {
 // Run invokes the wizard as an interactive bubbletea program. Returns the
 // terminal Result describing what happened.
 func Run(cfg Config) (Result, error) {
+	baseCtx := cfg.Context
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+	if err := baseCtx.Err(); err != nil {
+		return Result{Err: err}, err
+	}
 	m := NewModel(cfg)
-	p := tea.NewProgram(m, tea.WithAltScreen())
+	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithContext(baseCtx))
 	final, err := p.Run()
 	if err != nil {
 		return Result{Err: err}, err
@@ -567,7 +575,7 @@ func RunAuto(cfg Config) (Result, error) {
 		branch, err := cfg.SuggestBranch(suggestCtx)
 		suggestCancel()
 		if err != nil {
-			err = errors.New("suggest branch: " + err.Error())
+			err = fmt.Errorf("suggest branch: %w", err)
 			res.Err = err
 			return res, err
 		}
@@ -577,7 +585,7 @@ func RunAuto(cfg Config) (Result, error) {
 			return res, err
 		}
 		if err := cfg.CreateBranch(ctx, branch); err != nil {
-			err = errors.New("create branch: " + err.Error())
+			err = fmt.Errorf("create branch: %w", err)
 			res.Err = err
 			return res, err
 		}
@@ -596,7 +604,7 @@ func RunAuto(cfg Config) (Result, error) {
 		commitMsg, err := cfg.SuggestCommit(suggestCtx)
 		suggestCancel()
 		if err != nil {
-			err = errors.New("suggest commit: " + err.Error())
+			err = fmt.Errorf("suggest commit: %w", err)
 			res.Err = err
 			return res, err
 		}
@@ -606,7 +614,7 @@ func RunAuto(cfg Config) (Result, error) {
 			return res, err
 		}
 		if err := cfg.CommitAll(ctx, commitMsg); err != nil {
-			err = errors.New("commit changes: " + err.Error())
+			err = fmt.Errorf("commit changes: %w", err)
 			res.Err = err
 			return res, err
 		}
@@ -620,7 +628,7 @@ func RunAuto(cfg Config) (Result, error) {
 		return res, err
 	}
 	if err := cfg.Push(ctx, res.TargetBranch); err != nil {
-		err = errors.New("push branch: " + err.Error())
+		err = fmt.Errorf("push branch: %w", err)
 		res.Err = err
 		return res, err
 	}

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -530,6 +530,102 @@ func Run(cfg Config) (Result, error) {
 	return fm.Result(), nil
 }
 
+// RunAuto executes the wizard steps non-interactively. It accepts the default
+// automated path for each step: use agent suggestions for branch and commit,
+// then push to the gate. Suggestion failures are returned immediately.
+func RunAuto(cfg Config) (Result, error) {
+	res := Result{TargetBranch: cfg.CurrentBranch}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	track := func(action string, fields map[string]any) {
+		if cfg.Track == nil {
+			return
+		}
+		if fields == nil {
+			fields = map[string]any{}
+		}
+		cfg.Track(action, fields)
+	}
+
+	if cfg.NeedsBranch {
+		if cfg.SuggestBranch == nil {
+			err := errors.New("no branch suggester configured")
+			res.Err = err
+			return res, err
+		}
+		suggestCtx, suggestCancel := context.WithTimeout(ctx, 60*time.Second)
+		branch, err := cfg.SuggestBranch(suggestCtx)
+		suggestCancel()
+		if err != nil {
+			err = errors.New("suggest branch: " + err.Error())
+			res.Err = err
+			return res, err
+		}
+		if cfg.CreateBranch == nil {
+			err = errors.New("no branch creator configured")
+			res.Err = err
+			return res, err
+		}
+		if err := cfg.CreateBranch(ctx, branch); err != nil {
+			err = errors.New("create branch: " + err.Error())
+			res.Err = err
+			return res, err
+		}
+		res.BranchCreated = true
+		res.TargetBranch = branch
+		track("branch_created", map[string]any{"step": stepName(stepBranch), "source": "agent"})
+	}
+
+	if cfg.IsDirty {
+		if cfg.SuggestCommit == nil {
+			err := errors.New("no commit suggester configured")
+			res.Err = err
+			return res, err
+		}
+		suggestCtx, suggestCancel := context.WithTimeout(ctx, 60*time.Second)
+		commitMsg, err := cfg.SuggestCommit(suggestCtx)
+		suggestCancel()
+		if err != nil {
+			err = errors.New("suggest commit: " + err.Error())
+			res.Err = err
+			return res, err
+		}
+		if cfg.CommitAll == nil {
+			err = errors.New("no commit action configured")
+			res.Err = err
+			return res, err
+		}
+		if err := cfg.CommitAll(ctx, commitMsg); err != nil {
+			err = errors.New("commit changes: " + err.Error())
+			res.Err = err
+			return res, err
+		}
+		res.CommitMade = true
+		track("committed", map[string]any{"step": stepName(stepCommit), "source": "agent"})
+	}
+
+	if cfg.Push == nil {
+		err := errors.New("no push action configured")
+		res.Err = err
+		return res, err
+	}
+	if err := cfg.Push(ctx, res.TargetBranch); err != nil {
+		err = errors.New("push branch: " + err.Error())
+		res.Err = err
+		return res, err
+	}
+	res.Pushed = true
+	res.Success = true
+	track("pushed", map[string]any{"step": stepName(stepPush), "source": "auto"})
+	track("completed", map[string]any{
+		"branch_created": res.BranchCreated,
+		"commit_made":    res.CommitMade,
+		"pushed":         res.Pushed,
+	})
+	return res, nil
+}
+
 func stepName(id stepID) string {
 	switch id {
 	case stepBranch:

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -1,6 +1,7 @@
-// Package wizard provides the pre-pipeline onboarding UI: it detects repo
+// Package wizard provides the pre-pipeline onboarding flow: it detects repo
 // state, optionally creates a branch, commits uncommitted changes, and pushes
-// to the no-mistakes gate, then hands off to the main TUI.
+// to the no-mistakes gate, then hands off to the main TUI. It supports both
+// the interactive wizard UI and the non-interactive auto-accept path.
 package wizard
 
 import (

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -174,6 +174,23 @@ func TestNewModel_DetachedHEADForcesBranchStep(t *testing.T) {
 	}
 }
 
+func TestNewModel_UsesConfigContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cfg := baseConfig(&recorder{})
+	cfg.Context = ctx
+
+	m := NewModel(cfg)
+	defer m.cancel()
+
+	cancel()
+
+	select {
+	case <-m.ctx.Done():
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected model context to be cancelled with config context")
+	}
+}
+
 func TestBranchStep_UserTyped(t *testing.T) {
 	r := &recorder{}
 	m := NewModel(baseConfig(r))

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -400,6 +400,44 @@ func TestRunAuto_UsesCallerContext(t *testing.T) {
 	}
 }
 
+func TestRunAuto_WrapsUnderlyingContextError(t *testing.T) {
+	r := &recorder{}
+	cfg := baseConfig(r)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cfg.Context = ctx
+	cfg.SuggestBranch = func(ctx context.Context) (string, error) {
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+
+	_, err := RunAuto(cfg)
+	if err == nil {
+		t.Fatal("expected RunAuto to fail when caller context is canceled")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("errors.Is(err, context.Canceled) = false, err = %v", err)
+	}
+}
+
+func TestRun_UsesCallerContext(t *testing.T) {
+	cfg := baseConfig(&recorder{})
+	cfg.CurrentBranch = "feat/existing"
+	cfg.NeedsBranch = false
+	cfg.IsDirty = false
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cfg.Context = ctx
+
+	_, err := Run(cfg)
+	if err == nil {
+		t.Fatal("expected Run to fail when caller context is canceled")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run() error = %v, want wrapped context.Canceled", err)
+	}
+}
+
 func TestWizardTracksCompletedKeyActions(t *testing.T) {
 	r := &recorder{}
 	m := NewModel(baseConfig(r))

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -357,6 +357,32 @@ func TestRunAuto_SuggestionErrorReturnsFailure(t *testing.T) {
 	}
 }
 
+func TestRunAuto_UsesCallerContext(t *testing.T) {
+	r := &recorder{}
+	cfg := baseConfig(r)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cfg.Context = ctx
+	cfg.SuggestBranch = func(ctx context.Context) (string, error) {
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+
+	res, err := RunAuto(cfg)
+	if err == nil {
+		t.Fatal("expected RunAuto to fail when caller context is canceled")
+	}
+	if !strings.Contains(err.Error(), context.Canceled.Error()) {
+		t.Fatalf("error should mention canceled context, got %v", err)
+	}
+	if res.Success {
+		t.Fatal("RunAuto should not report success when caller context is canceled")
+	}
+	if r.createdBranch != "" || r.commitMsg != "" || r.pushedBranch != "" {
+		t.Fatalf("RunAuto should stop before side effects, got branch=%q commit=%q push=%q", r.createdBranch, r.commitMsg, r.pushedBranch)
+	}
+}
+
 func TestWizardTracksCompletedKeyActions(t *testing.T) {
 	r := &recorder{}
 	m := NewModel(baseConfig(r))

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -299,6 +299,64 @@ func TestPushStep_Confirm(t *testing.T) {
 	}
 }
 
+func TestRunAuto_UsesAgentSuggestionsAndPushes(t *testing.T) {
+	r := &recorder{suggestBranch: "feat/auto", suggestCommit: "feat: auto commit"}
+
+	res, err := RunAuto(baseConfig(r))
+	if err != nil {
+		t.Fatalf("RunAuto() error = %v", err)
+	}
+
+	if r.createdBranch != "feat/auto" {
+		t.Fatalf("expected CreateBranch called with agent suggestion, got %q", r.createdBranch)
+	}
+	if r.commitMsg != "feat: auto commit" {
+		t.Fatalf("expected CommitAll called with agent suggestion, got %q", r.commitMsg)
+	}
+	if r.pushedBranch != "feat/auto" {
+		t.Fatalf("expected Push called with created branch, got %q", r.pushedBranch)
+	}
+	if !res.Success {
+		t.Fatal("expected success result")
+	}
+	if !res.BranchCreated || !res.CommitMade || !res.Pushed {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	if res.TargetBranch != "feat/auto" {
+		t.Fatalf("TargetBranch = %q, want %q", res.TargetBranch, "feat/auto")
+	}
+	if !containsWizardEvent(r.telemetry, "branch_created", "source", "agent") {
+		t.Fatal("expected branch_created telemetry with agent source")
+	}
+	if !containsWizardEvent(r.telemetry, "committed", "source", "agent") {
+		t.Fatal("expected committed telemetry with agent source")
+	}
+	if !containsWizardEvent(r.telemetry, "pushed", "source", "auto") {
+		t.Fatal("expected pushed telemetry with auto source")
+	}
+	if !containsWizardEvent(r.telemetry, "completed", "pushed", true) {
+		t.Fatal("expected completed telemetry")
+	}
+}
+
+func TestRunAuto_SuggestionErrorReturnsFailure(t *testing.T) {
+	r := &recorder{suggestBranchErr: errors.New("agent down")}
+
+	res, err := RunAuto(baseConfig(r))
+	if err == nil {
+		t.Fatal("expected RunAuto to fail when branch suggestion fails")
+	}
+	if !strings.Contains(err.Error(), "suggest branch") {
+		t.Fatalf("error should mention branch suggestion, got %v", err)
+	}
+	if res.Success {
+		t.Fatal("RunAuto should not report success on suggestion error")
+	}
+	if r.createdBranch != "" || r.commitMsg != "" || r.pushedBranch != "" {
+		t.Fatalf("RunAuto should stop before side effects, got branch=%q commit=%q push=%q", r.createdBranch, r.commitMsg, r.pushedBranch)
+	}
+}
+
 func TestWizardTracksCompletedKeyActions(t *testing.T) {
 	r := &recorder{}
 	m := NewModel(baseConfig(r))


### PR DESCRIPTION
## Summary
- Add a non-interactive `no-mistakes -y` / `--yes` flow that runs the setup wizard with default choices so automation can bootstrap a branch, commit, and push without a TTY.
- Preserve wizard cancellation and failure semantics by threading command context through interactive and auto modes, honoring cancellation while polling for an active run, and surfacing auto-attach failures instead of silently succeeding.
- Update CLI and setup wizard docs to explain the new `--yes` behavior, its failure mode differences from the interactive wizard, and when agent suggestions are actually required.

## Risk Assessment

✅ Low: The change is narrowly scoped around the new `-y` wizard path and cancellation plumbing, and the updated control flow is consistent with the intended behavior with no additional material defects evident in the reviewed diff.

## Testing

- ✅ **Test** - passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (5)</summary>

**Round 1** - found 2 warnings
- ⚠️ `internal/cli/attach.go:110` - In `-y` mode, a successful wizard push still exits 0 when no active run appears within the 5 second poll window. That makes automation treat a missing or delayed pipeline as success instead of surfacing a failure condition.
- ⚠️ `internal/wizard/wizard.go:538` - `RunAuto` starts from `context.Background()` instead of a caller-controlled context, so agent suggestions and git operations in the new non-interactive flow cannot be cancelled or timed out by the CLI layer if they hang.

**Round 2** (auto-fix) - found 2 warnings
- ⚠️ `internal/cli/attach.go:97` - The new `-y` flow still starts repo detection and wizard execution from `context.Background()`, so cancellation from the Cobra command context never reaches agent suggestions or git operations. If automation or a user interrupts the command, the non-interactive wizard can keep running until its own timeouts or subprocess exits.
- ⚠️ `internal/cli/attach.go:93` - `autoYes` is only consulted in the `run == nil` branch. When `no-mistakes -y` is invoked on a branch that already has an active run, it still falls through to `runTUI(...)` and opens the interactive TUI, which breaks the new non-interactive contract for automation callers.

**Round 3** (auto-fix) - found 1 warning
- ⚠️ `internal/cli/wizard.go:180` - `wizard.Config.Context` is now threaded into both wizard modes here, but the interactive `wizard.Run` path still creates its model from `context.Background()` instead of `cfg.Context`. That means Cobra cancellation and caller timeouts still do not stop agent suggestions or git subprocesses when the interactive wizard is open.

**Round 4** (auto-fix) - found 2 warnings
- ⚠️ `internal/wizard/wizard.go:570` - `RunAuto` rebuilds underlying errors with `errors.New(&#34;...&#34; + err.Error())` instead of wrapping them, so callers can no longer detect `context.Canceled`, deadline expiry, or typed git errors with `errors.Is`/`errors.As`. That undermines the new context propagation in the non-interactive path.
- ⚠️ `internal/wizard/wizard.go:122` - The new `Config.Context` only feeds the model’s internal child operations. If the interactive wizard is sitting on a text input or push confirmation, canceling the caller context does not stop `Run()` itself, so the command can remain open indefinitely until the user presses a key. Wire the Bubble Tea program lifecycle to the same context as well.

**Round 5** (auto-fix) - found 1 warning
- ⚠️ `internal/cli/attach.go:105` - After a successful wizard push, the new attach polling path still ignores the command context because `waitForActiveRun` has no `context.Context` parameter. `no-mistakes -y` will therefore keep sleeping and polling for up to 5 seconds after cancellation or timeout instead of stopping promptly, which partially defeats the context-propagation fixes in this series.

**Round 6** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>🔧 **Document** - 3 issues found → auto-fixed (4)</summary>

**Round 1** - found 3 warnings
- ⚠️ `docs/src/content/docs/reference/cli.md:8` - The root command reference is stale after adding `--yes`/`-y` in `internal/cli/root.go`. It still says bare `no-mistakes` only starts the setup wizard in an interactive TTY and always falls back to recent runs in non-interactive contexts, and it does not document the new flag or its non-interactive default-accepting behavior.
- ⚠️ `docs/src/content/docs/guides/setup-wizard.md:15` - The setup wizard guide now has incorrect behavior docs. It says the wizard only kicks in when you&#39;re in an interactive terminal and that non-interactive runs always fall back to recent runs, but the new bare-command `--yes` path runs the wizard non-interactively and accepts defaults automatically.
- ⚠️ `docs/src/content/docs/start-here/quick-start.md:75` - The quick start walkthrough is missing the new non-interactive bootstrap path for bare `no-mistakes`. This section still describes the setup wizard as interactive-only, so it should mention that `no-mistakes -y` can create the branch/commit/push flow without a TTY.

**Round 2** (auto-fix) - found 2 infos
- ℹ️ `internal/cli/root.go:38` - The inline command comment is stale after adding `--yes`/`-y`. It still says bare `no-mistakes` routes only interactive users into the setup wizard, but the root command now also supports a non-interactive wizard path when `-y` is passed.
- ℹ️ `internal/cli/attach.go:148` - The `isInteractive` comment still documents the old behavior that non-interactive contexts always fall back to printing hints. After this change, bare `no-mistakes -y` can run the wizard without a TTY, so the comment should be updated to explain that the TTY requirement only applies to the interactive wizard path.

**Round 3** (auto-fix) - found 1 warning
- ⚠️ `docs/src/content/docs/guides/setup-wizard.md:74` - The failure-handling section is stale for the new `-y` / `--yes` mode. It currently says &#34;the wizard&#34; shows the error and lets you press `r` to retry, but `internal/wizard.RunAuto` exits immediately on branch/commit/push errors and provides no retry prompt. This guide should clarify that retry-on-`r` only applies to the interactive TUI wizard, while the non-interactive `--yes` path fails fast.

**Round 4** (auto-fix) - found 2 issues (1 warning, 1 info)
- ⚠️ `docs/src/content/docs/guides/setup-wizard.md:101` - The setup wizard guide still states that the wizard requires a configured agent binary on PATH. That is now stale relative to the new `-y` / `--yes` flow: the auto path only needs agent suggestions when the branch or commit steps are actually required, and the interactive path can still proceed with manually entered branch and commit text. This section should distinguish when an agent is required instead of documenting it as an unconditional prerequisite.
- ℹ️ `internal/wizard/wizard.go:1` - The package comment is stale after adding `RunAuto`. It still documents `internal/wizard` as only the pre-pipeline onboarding UI, but the package now also exposes a non-interactive wizard runner used by `no-mistakes -y` / `--yes`. The comment should be updated so it no longer implies the package is UI-only.

**Round 5** (auto-fix) - found 0 issues

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - found 0 issues

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
