### PR TITLE
fix(daemon): preserve panic status after telemetry updates

### DIFF
--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -341,9 +341,6 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 			if r := recover(); r != nil {
 				errMsg := fmt.Sprintf("internal panic: %v", r)
 				slog.Error("panic in pipeline goroutine", "run_id", run.ID, "panic", r)
-				if dbErr := m.db.UpdateRunErrorStatus(run.ID, errMsg, types.RunFailed); dbErr != nil {
-					slog.Error("failed to update run after panic", "run_id", run.ID, "error", dbErr)
-				}
 				run.Status = types.RunFailed
 				run.Error = &errMsg
 				fields := telemetry.Fields{
@@ -360,6 +357,9 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 					fields["failed_step"] = failedStep
 				}
 				telemetry.Track("run", fields)
+				if dbErr := m.db.UpdateRunErrorStatus(run.ID, errMsg, types.RunFailed); dbErr != nil {
+					slog.Error("failed to update run after panic", "run_id", run.ID, "error", dbErr)
+				}
 			}
 			cancel(nil)
 			ag.Close()


### PR DESCRIPTION
## Summary
- Update `internal/daemon` run status ordering so panic handling is not overwritten by telemetry updates.
- Keep panic outcomes recorded correctly when processing push events, matching the daemon's final run state.
- This branch is limited to the daemon manager change and was validated with the targeted panic telemetry test coverage in the pipeline.

## Risk Assessment

✅ Low: The change is narrowly scoped to panic-path ordering in one deferred block, and the new sequence still preserves in-memory status updates, telemetry emission, and the subsequent database write without introducing a substantiated regression in the reviewed code.

## Testing

- Summary: I exercised the daemon telemetry success path and repeatedly stress-ran the panic recovery telemetry path; the targeted regression coverage passed cleanly with no reproducible failures.
- `go test ./internal/daemon -run 'TestPushReceivedTracksRunTelemetry|TestPushReceivedTracksRunTelemetryAfterPanic' -count=20`
- `go test ./internal/daemon -run '^TestPushReceivedTracksRunTelemetryAfterPanic$' -count=100`
- Outcome: ✅ passed across 1 run (2m37s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/daemon -run 'TestPushReceivedTracksRunTelemetry|TestPushReceivedTracksRunTelemetryAfterPanic' -count=20`
- `go test ./internal/daemon -run '^TestPushReceivedTracksRunTelemetryAfterPanic$' -count=100`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
