### PR TITLE
fix(wizard): show inline branch input and status in the setup flow

### DIFF
--- a/internal/wizard/view.go
+++ b/internal/wizard/view.go
@@ -30,6 +30,7 @@ func (m Model) View() string {
 	if width < 60 {
 		width = 60
 	}
+	m.width = width
 
 	var content strings.Builder
 
@@ -86,27 +87,32 @@ func (m Model) renderStep(s *step) string {
 		return strings.Join(lines, "\n")
 
 	case statInput:
-		lines := []string{header}
-		lines = append(lines, "    "+dimStyle().Render(inputLabel(s.id)))
-		lines = append(lines, "    "+m.input.View())
-		return strings.Join(lines, "\n")
+		return header + "  " + m.inlineInputView(header)
 
 	case statAgent:
-		lines := []string{header}
-		lines = append(lines, "    "+dimStyle().Render(agentLabel(s.id)))
-		return strings.Join(lines, "\n")
+		return header + "  " + dimStyle().Render(agentLabel(s.id))
 
 	case statRunning:
-		lines := []string{header}
-		lines = append(lines, "    "+dimStyle().Render(runningLabel(s.id, s.result)))
-		return strings.Join(lines, "\n")
+		return header + "  " + dimStyle().Render(runningLabel(s.id, s.result))
 
 	case statConfirm:
-		lines := []string{header}
-		lines = append(lines, "    "+dimStyle().Render(confirmLabel(m.cfg.GateRemote, m.targetBranch)))
-		return strings.Join(lines, "\n")
+		return header + "  " + dimStyle().Render(confirmLabel(m.cfg.GateRemote, m.targetBranch))
 	}
 	return header
+}
+
+func (m Model) inlineInputView(header string) string {
+	input := m.input
+	contentWidth := m.width - 4
+	availableWidth := contentWidth - lipgloss.Width(header) - 2
+	promptWidth := lipgloss.Width(input.Prompt)
+	fieldWidth := availableWidth - promptWidth - 1
+	if fieldWidth < 1 {
+		fieldWidth = 1
+	}
+	input.Width = fieldWidth
+	input.SetCursor(input.Position())
+	return input.View()
 }
 
 func (m Model) renderActionBar() string {

--- a/internal/wizard/view_test.go
+++ b/internal/wizard/view_test.go
@@ -1,11 +1,44 @@
 package wizard
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
+
+var ansiRegexp = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func stripANSI(s string) string {
+	return ansiRegexp.ReplaceAllString(s, "")
+}
+
+func hasLineContainingAll(view string, needles ...string) bool {
+	for _, line := range strings.Split(stripANSI(view), "\n") {
+		match := true
+		for _, needle := range needles {
+			if !strings.Contains(line, needle) {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+func lineContaining(view string, needle string) string {
+	for _, line := range strings.Split(stripANSI(view), "\n") {
+		if strings.Contains(line, needle) {
+			return line
+		}
+	}
+	return ""
+}
 
 func TestView_RendersSetupTitle(t *testing.T) {
 	m := NewModel(baseConfig(&recorder{}))
@@ -73,5 +106,60 @@ func TestView_ActionBarForConfirm(t *testing.T) {
 	out := m.View()
 	if !strings.Contains(out, "push") {
 		t.Fatalf("expected 'push' in action bar for confirm step, got:\n%s", out)
+	}
+}
+
+func TestView_RendersInputInlineWithPlaceholder(t *testing.T) {
+	m := NewModel(baseConfig(&recorder{}))
+	m.width = 80
+
+	out := m.View()
+	if !hasLineContainingAll(out, "Branch", "›", "blank = let agent suggest") {
+		t.Fatalf("expected inline input placeholder on Branch line, got:\n%s", stripANSI(out))
+	}
+	if strings.Contains(stripANSI(out), "branch name (blank to let the agent suggest):") {
+		t.Fatalf("expected stacked branch input label to be removed, got:\n%s", stripANSI(out))
+	}
+}
+
+func TestView_InlineInputFitsInsideBoxAtMinimumWidth(t *testing.T) {
+	m := NewModel(baseConfig(&recorder{}))
+	m.width = 60
+	m.input.SetValue(strings.Repeat("x", 80))
+
+	out := m.View()
+	branchLine := lineContaining(out, "Branch")
+	if branchLine == "" {
+		t.Fatalf("expected branch line in view, got:\n%s", stripANSI(out))
+	}
+	if got := lipgloss.Width(branchLine); got > 60 {
+		t.Fatalf("expected inline input line width <= 60, got %d:\n%s", got, stripANSI(out))
+	}
+}
+
+func TestView_RendersTransientStatusInlineWithStep(t *testing.T) {
+	tests := []struct {
+		name   string
+		status stepStatus
+		result string
+		want   string
+	}{
+		{name: "agent", status: statAgent, want: "asking agent for a branch name"},
+		{name: "running", status: statRunning, result: "feat/wizard", want: "creating branch feat/wizard"},
+		{name: "confirm", status: statConfirm, want: "push main to no-mistakes gate?"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewModel(baseConfig(&recorder{}))
+			m.width = 120
+			m.steps[0].status = tt.status
+			m.steps[0].result = tt.result
+
+			out := m.View()
+			if !hasLineContainingAll(out, "Branch", tt.want) {
+				t.Fatalf("expected Branch and %q on the same line, got:\n%s", tt.want, stripANSI(out))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Render the branch step input inline with its status row so the wizard keeps the active prompt in context instead of splitting it across separate lines.
- Update inline status rendering for branch-related states to keep setup progress compact and easier to follow while creating or confirming the branch.
- Add `internal/wizard` view coverage for the inline input and status cases to lock in the updated wizard layout.

## Risk Assessment

✅ Low: The change is narrowly scoped to wizard view rendering and accompanying tests, and I did not find any material correctness, safety, or maintainability issues in the modified code.

## Testing

- Summary: Exercised the wizard view package with race-enabled tests covering the new inline input and status rendering paths, and everything passed.
- `go test -race ./internal/wizard`
- Outcome: ✅ passed across 1 run (55.8s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test -race ./internal/wizard`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
