### PR TITLE
feat(cli): keep the setup wizard visible for interactive --yes runs

### DIFF
--- a/docs/src/content/docs/guides/setup-wizard.md
+++ b/docs/src/content/docs/guides/setup-wizard.md
@@ -20,7 +20,7 @@ The wizard kicks in when:
 
 In non-interactive contexts, bare `no-mistakes` without `-y` falls back to listing the last 5 runs instead.
 
-With `-y` / `--yes`, the wizard runs non-interactively and takes the default automated path for each step: use agent suggestions for branch and commit when needed, then push to the gate.
+With `-y` / `--yes`, the wizard takes the default automated path for each step: use agent suggestions for branch and commit when needed, then push to the gate. In a TTY, that path stays visible and auto-advances through the wizard. Without a TTY, it falls back to the headless path.
 
 If you want to attach to *any* active run in the repo (not just the current branch), use `no-mistakes attach` - that path skips the wizard entirely.
 
@@ -40,7 +40,7 @@ flowchart TD
 
 ## Steps
 
-The interactive wizard is a full-screen flow that runs only the steps your current repo state needs, up to three total. The `-y` / `--yes` path runs the same steps without the TUI and accepts the automated default at each one.
+The interactive wizard is a full-screen flow that runs only the steps your current repo state needs, up to three total. The `-y` / `--yes` path runs the same steps and accepts the automated default at each one. In a TTY, the TUI stays visible and auto-advances. Without a TTY, it runs headlessly.
 
 ### 1. Branch
 
@@ -73,7 +73,7 @@ not ask for one. If everything is already committed, it skips straight to push.
 
 If any step fails (git error, agent error, network error), the interactive wizard shows the error and lets you press `r` to retry the step without restarting the whole flow.
 
-With `-y` / `--yes`, the non-interactive path exits on the first error instead of prompting to retry.
+With `-y` / `--yes`, the wizard exits on the first error instead of prompting to retry, whether it is auto-advancing in a TTY or running headlessly.
 
 ## Quitting safely
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -5,7 +5,7 @@ description: Complete reference for all no-mistakes commands and flags.
 
 ## no-mistakes
 
-Attach to the active pipeline run for the current branch when one exists. If none exists, bare `no-mistakes` can start the setup wizard to create a branch, commit changes, push through the gate, and then attach once the new run appears. By default this wizard path is interactive and only runs in a TTY session. In non-interactive contexts, bare `no-mistakes` falls back to showing the last 5 runs inline unless you pass `-y` or `--yes` to run the wizard non-interactively and accept defaults.
+Attach to the active pipeline run for the current branch when one exists. If none exists, bare `no-mistakes` can start the setup wizard to create a branch, commit changes, push through the gate, and then attach once the new run appears. By default this wizard path is interactive and only runs in a TTY session. In non-interactive contexts, bare `no-mistakes` falls back to showing the last 5 runs inline unless you pass `-y` or `--yes` to run the wizard and accept defaults automatically. When a TTY is available, `-y` keeps the wizard visible and auto-advances the default path; without a TTY it falls back to the headless path.
 
 ```sh
 no-mistakes
@@ -13,7 +13,7 @@ no-mistakes
 
 | Flag | Type | Default | Description |
 |---|---|---|---|
-| `-y`, `--yes` | `bool` | `false` | Run setup wizard non-interactively, accepting defaults |
+| `-y`, `--yes` | `bool` | `false` | Run setup wizard and accept defaults automatically |
 
 Unlike `no-mistakes attach`, bare `no-mistakes` only auto-attaches to an active run on the current branch.
 

--- a/docs/src/content/docs/start-here/quick-start.md
+++ b/docs/src/content/docs/start-here/quick-start.md
@@ -72,7 +72,7 @@ The push lands in the local bare repo, the hook notifies the daemon, and the dae
 no-mistakes
 ```
 
-If the current branch has an active run, this attaches directly. If not, the setup wizard can walk you through creating a branch, committing, and pushing through the gate before attaching. By default that path is interactive in a TTY. In non-interactive contexts, use `no-mistakes -y` to run the same setup path and accept defaults automatically.
+If the current branch has an active run, this attaches directly. If not, the setup wizard can walk you through creating a branch, committing, and pushing through the gate before attaching. By default that path is interactive in a TTY. With `no-mistakes -y`, the wizard accepts defaults automatically, stays visible and auto-advances in a TTY, and falls back to the headless path without a TTY.
 
 The TUI shows each step's progress, streams agent output, and pauses for your approval when findings need attention. See [Using the TUI](/no-mistakes/guides/tui/) for keybindings and layout.
 

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -153,8 +153,8 @@ func activeRunBranch(state *repoState, rootDefault bool) string {
 }
 
 // isInteractive reports whether stdin and stdout are both connected to a
-// terminal. The interactive wizard needs a real TTY to read keystrokes; the
-// --yes path can still run the wizard non-interactively and accept defaults.
+// terminal. The visible wizard needs a real TTY to read keystrokes; without
+// one, the --yes path falls back to the headless auto-accept flow.
 func isInteractive() bool {
 	return isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd())
 }

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -19,6 +19,7 @@ import (
 )
 
 var runTUI = tui.Run
+var terminalInteractive = isInteractive
 
 // attachRun is the shared logic for attaching to a pipeline run. It's used by
 // both the root command (bare `no-mistakes`) and the `attach` subcommand.
@@ -88,13 +89,19 @@ func attachRun(ctx context.Context, w io.Writer, runID string, rootDefault bool,
 	if run == nil {
 		// No active run - if the user ran bare `no-mistakes` in their repo
 		// from a TTY, offer the interactive setup wizard instead of just
-		// dumping a hint. `-y` uses the same setup flow non-interactively,
-		// so it is allowed even when stdin/stdout are not TTYs.
-		if rootDefault && runID == "" && repo != nil && state != nil && (autoYes || isInteractive()) {
+		// dumping a hint. `-y` auto-accepts the wizard; when a TTY is
+		// available we keep the wizard visible, otherwise we fall back to the
+		// existing headless path.
+		interactive := terminalInteractive()
+		if rootDefault && runID == "" && repo != nil && state != nil && (autoYes || interactive) {
 			var res wizard.Result
 			var wErr error
 			if autoYes {
-				res, wErr = runWizardAuto(ctx, p, state)
+				if interactive {
+					res, wErr = runWizardAutoVisible(ctx, p, state)
+				} else {
+					res, wErr = runWizardAuto(ctx, p, state)
+				}
 			} else {
 				res, wErr = runWizard(ctx, p, state)
 			}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -37,7 +37,8 @@ func newRootCmd() *cobra.Command {
 		SilenceUsage:  true,
 		// When run without a subcommand, attach to the current branch run or
 		// route users into the setup wizard when no run is active. The default
-		// wizard flow is interactive, while --yes accepts defaults without a TTY.
+		// wizard flow is interactive, while --yes auto-accepts defaults and can
+		// still fall back to headless mode when no TTY is available.
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return trackCommand("root", func() error {
 				return attachRun(cmd.Context(), cmd.OutOrStdout(), "", true, autoYes)
@@ -45,7 +46,7 @@ func newRootCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVarP(&autoYes, "yes", "y", false, "run setup wizard non-interactively, accepting defaults")
+	cmd.Flags().BoolVarP(&autoYes, "yes", "y", false, "run setup wizard and accept defaults automatically")
 
 	cmd.AddCommand(newInitCmd())
 	cmd.AddCommand(newEjectCmd())

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -224,6 +224,77 @@ func TestRootYesRunsWizardNonInteractively(t *testing.T) {
 	}
 }
 
+func TestRootYesUsesVisibleWizardWhenInteractive(t *testing.T) {
+	setupTestRepo(t)
+	nmHome := makeSocketSafeTempDir(t)
+	t.Setenv("NM_HOME", nmHome)
+	p := paths.WithRoot(nmHome)
+
+	d, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	if _, err := gate.Init(context.Background(), d, p, "."); err != nil {
+		t.Fatal(err)
+	}
+
+	startTestDaemon(t, p, d)
+
+	gitRoot, err := git.FindGitRoot(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo, err := d.GetRepoByPath(gitRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prevInteractive := terminalInteractive
+	terminalInteractive = func() bool { return true }
+	defer func() { terminalInteractive = prevInteractive }()
+
+	prevVisible := runWizardAutoVisible
+	visible := false
+	runWizardAutoVisible = func(ctx context.Context, p *paths.Paths, state *repoState) (wizard.Result, error) {
+		visible = true
+		if state == nil {
+			t.Fatal("expected repo state")
+		}
+		if _, err := d.InsertRun(repo.ID, "feat/visible", "head1234", "base5678"); err != nil {
+			return wizard.Result{}, err
+		}
+		return wizard.Result{Success: true, Pushed: true, TargetBranch: "feat/visible"}, nil
+	}
+	defer func() { runWizardAutoVisible = prevVisible }()
+
+	prevAuto := runWizardAuto
+	runWizardAuto = func(context.Context, *paths.Paths, *repoState) (wizard.Result, error) {
+		t.Fatal("expected interactive -y path to show the wizard instead of using headless auto mode")
+		return wizard.Result{}, nil
+	}
+	defer func() { runWizardAuto = prevAuto }()
+
+	prevRunTUI := runTUI
+	attached := false
+	runTUI = func(string, *ipc.Client, *ipc.RunInfo, string) error {
+		attached = true
+		return nil
+	}
+	defer func() { runTUI = prevRunTUI }()
+
+	if _, err := executeCmd("-y"); err != nil {
+		t.Fatalf("executeCmd(-y) error = %v", err)
+	}
+	if !visible {
+		t.Fatal("expected -y run to launch the visible wizard path")
+	}
+	if !attached {
+		t.Fatal("expected -y run to attach to the created run")
+	}
+}
+
 func TestRootYesFailsWhenWizardPushProducesNoRun(t *testing.T) {
 	setupTestRepo(t)
 	nmHome := makeSocketSafeTempDir(t)

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -28,8 +28,11 @@ var resolveWizardAgent = func(ctx context.Context, cfg *config.Config) error {
 var newWizardAgent = agent.New
 var wizardRun = wizard.Run
 var wizardRunAuto = wizard.RunAuto
+var runWizardAutoVisible = func(ctx context.Context, p *paths.Paths, state *repoState) (wizard.Result, error) {
+	return runWizardWithMode(ctx, p, state, true, true)
+}
 var runWizardAuto = func(ctx context.Context, p *paths.Paths, state *repoState) (wizard.Result, error) {
-	return runWizardWithMode(ctx, p, state, true)
+	return runWizardWithMode(ctx, p, state, true, false)
 }
 
 type wizardAgentSuggester struct {
@@ -152,10 +155,10 @@ func detectRepoState(ctx context.Context, repo *db.Repo) (*repoState, error) {
 // runWizard prepares optional suggestion hooks and runs the interactive
 // onboarding wizard against the supplied repo state.
 func runWizard(ctx context.Context, p *paths.Paths, state *repoState) (wizard.Result, error) {
-	return runWizardWithMode(ctx, p, state, false)
+	return runWizardWithMode(ctx, p, state, false, true)
 }
 
-func runWizardWithMode(ctx context.Context, p *paths.Paths, state *repoState, auto bool) (wizard.Result, error) {
+func runWizardWithMode(ctx context.Context, p *paths.Paths, state *repoState, auto bool, visible bool) (wizard.Result, error) {
 	workDir := state.workDir
 
 	globalCfg, err := config.LoadGlobal(p.ConfigFile())
@@ -181,6 +184,7 @@ func runWizardWithMode(ctx context.Context, p *paths.Paths, state *repoState, au
 		RepoDir:       workDir,
 		CurrentBranch: state.currentBranch,
 		DefaultBranch: state.defaultBranch,
+		AutoAdvance:   auto && visible,
 		NeedsBranch:   state.needsBranch(),
 		IsDirty:       state.dirty,
 		GateRemote:    gate.RemoteName,
@@ -214,7 +218,7 @@ func runWizardWithMode(ctx context.Context, p *paths.Paths, state *repoState, au
 	})
 
 	run := wizardRun
-	if auto {
+	if auto && !visible {
 		run = wizardRunAuto
 	}
 

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -223,6 +223,9 @@ func runWizardWithMode(ctx context.Context, p *paths.Paths, state *repoState, au
 	}
 
 	res, err := run(wizCfg)
+	if err == nil && res.Err != nil {
+		err = res.Err
+	}
 	if err == nil {
 		telemetry.Track("wizard", telemetry.Fields{
 			"action":         "result",

--- a/internal/cli/wizard_test.go
+++ b/internal/cli/wizard_test.go
@@ -166,3 +166,37 @@ func TestRunWizardTracksPageview(t *testing.T) {
 		t.Fatalf("branch_created = %v, want true", got)
 	}
 }
+
+func TestRunWizardReturnsTerminalWizardError(t *testing.T) {
+	wantErr := errors.New("suggest branch: agent down")
+
+	prevRun := wizardRun
+	wizardRun = func(cfg wizard.Config) (wizard.Result, error) {
+		return wizard.Result{Err: wantErr}, nil
+	}
+	defer func() { wizardRun = prevRun }()
+
+	nmHome := makeSocketSafeTempDir(t)
+	t.Setenv("NM_HOME", nmHome)
+	p := paths.WithRoot(nmHome)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	repoDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repoDir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	state := &repoState{
+		workDir:       repoDir,
+		currentBranch: "main",
+		defaultBranch: "main",
+		dirty:         true,
+	}
+
+	_, err := runWizard(context.Background(), p, state)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("runWizard() error = %v, want %v", err, wantErr)
+	}
+}

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -23,6 +23,9 @@ type Config struct {
 	RepoDir       string
 	CurrentBranch string
 	DefaultBranch string
+	// AutoAdvance automatically presses Enter on each active wizard step,
+	// preserving the interactive TUI while accepting the default path.
+	AutoAdvance bool
 	// NeedsBranch is true when the user has no usable feature branch yet —
 	// either they're on the default branch, or HEAD is detached. The branch
 	// step is only active when this is true.
@@ -156,14 +159,7 @@ func NewModel(cfg Config) Model {
 // Init returns the initial Cmd for the active step. State was already
 // prepared in NewModel.
 func (m Model) Init() tea.Cmd {
-	if m.quitting {
-		return tea.Quit
-	}
-	s := m.activeStep()
-	if s != nil && s.status == statInput {
-		return textinput.Blink
-	}
-	return nil
+	return m.afterEnterCmd()
 }
 
 // Update handles bubbletea events and drives the state machine.
@@ -190,6 +186,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.spinnerFrame = (m.spinnerFrame + 1) % len(spinnerFrames)
 		return m, m.scheduleSpinner()
+
+	case autoAdvanceMsg:
+		return m.handleAutoAdvance()
 	}
 	return m, nil
 }
@@ -265,10 +264,24 @@ func (m Model) afterEnterCmd() tea.Cmd {
 		return tea.Quit
 	}
 	s := m.activeStep()
+	if s != nil && m.cfg.AutoAdvance && (s.status == statInput || s.status == statConfirm) {
+		return autoAdvanceCmd()
+	}
 	if s != nil && s.status == statInput {
 		return textinput.Blink
 	}
 	return nil
+}
+
+func (m Model) handleAutoAdvance() (tea.Model, tea.Cmd) {
+	s := m.activeStep()
+	if s == nil {
+		return m, nil
+	}
+	if s.status != statInput && s.status != statConfirm {
+		return m, nil
+	}
+	return m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
 }
 
 func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -467,7 +480,13 @@ type actionMsg struct {
 
 type spinnerTickMsg struct{}
 
+type autoAdvanceMsg struct{}
+
 const spinnerInterval = 120 * time.Millisecond
+
+func autoAdvanceCmd() tea.Cmd {
+	return func() tea.Msg { return autoAdvanceMsg{} }
+}
 
 func (m *Model) scheduleSpinner() tea.Cmd {
 	if m.spinnerAlive {

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -424,6 +424,12 @@ func (m Model) handleAction(msg actionMsg) (tea.Model, tea.Cmd) {
 	if msg.err != nil {
 		s.status = statFailed
 		s.errMsg = msg.err.Error()
+		if m.cfg.AutoAdvance {
+			m.err = msg.err
+			m.quitting = true
+			m.cancel()
+			return m, tea.Quit
+		}
 		return m, nil
 	}
 	switch s.id {

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -396,6 +396,15 @@ func (m Model) handleSuggestion(msg suggestionMsg) (tea.Model, tea.Cmd) {
 	}
 	s := m.steps[m.active]
 	if msg.err != nil {
+		wrappedErr := fmt.Errorf("suggest %s: %w", stepName(msg.id), msg.err)
+		if m.cfg.AutoAdvance {
+			s.status = statFailed
+			s.errMsg = wrappedErr.Error()
+			m.err = wrappedErr
+			m.quitting = true
+			m.cancel()
+			return m, tea.Quit
+		}
 		// Fall back to asking the user to type.
 		s.status = statInput
 		s.source = ""

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -281,6 +281,10 @@ func (m Model) handleAutoAdvance() (tea.Model, tea.Cmd) {
 	if s.status != statInput && s.status != statConfirm {
 		return m, nil
 	}
+	if s.status == statConfirm {
+		s.source = "auto"
+		return m.executeStep(s, "")
+	}
 	return m.handleKey(tea.KeyMsg{Type: tea.KeyEnter})
 }
 
@@ -422,10 +426,11 @@ func (m Model) handleAction(msg actionMsg) (tea.Model, tea.Cmd) {
 	}
 	s := m.steps[m.active]
 	if msg.err != nil {
+		wrappedErr := fmt.Errorf("%s: %w", stepActionLabel(msg.id), msg.err)
 		s.status = statFailed
-		s.errMsg = msg.err.Error()
+		s.errMsg = wrappedErr.Error()
 		if m.cfg.AutoAdvance {
-			m.err = msg.err
+			m.err = wrappedErr
 			m.quitting = true
 			m.cancel()
 			return m, tea.Quit
@@ -688,6 +693,19 @@ func stepName(id stepID) string {
 		return "push"
 	default:
 		return "unknown"
+	}
+}
+
+func stepActionLabel(id stepID) string {
+	switch id {
+	case stepBranch:
+		return "create branch"
+	case stepCommit:
+		return "commit changes"
+	case stepPush:
+		return "push branch"
+	default:
+		return stepName(id)
 	}
 }
 

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -423,6 +423,35 @@ func TestAutoAdvance_SuggestionErrorFailsFast(t *testing.T) {
 	}
 }
 
+func TestAutoAdvance_ActionErrorFailsFast(t *testing.T) {
+	r := &recorder{createBranchErr: errors.New("branch exists")}
+	cfg := baseConfig(r)
+	cfg.AutoAdvance = true
+
+	m := NewModel(cfg)
+	m = drain(m, m.Init())
+
+	if m.err == nil {
+		t.Fatal("expected auto-advance action failure to be recorded")
+	}
+	if !strings.Contains(m.err.Error(), "branch exists") {
+		t.Fatalf("error should mention branch failure, got %v", m.err)
+	}
+	if !m.quitting {
+		t.Fatal("expected auto-advance action failure to quit")
+	}
+	if m.steps[0].status != statFailed {
+		t.Fatalf("expected branch step to fail, got %v", m.steps[0].status)
+	}
+	if r.commitMsg != "" || r.pushedBranch != "" {
+		t.Fatalf("auto-advance should stop after branch failure, got commit=%q push=%q", r.commitMsg, r.pushedBranch)
+	}
+	res := m.Result()
+	if !errors.Is(res.Err, m.err) {
+		t.Fatalf("result error = %v, want %v", res.Err, m.err)
+	}
+}
+
 func TestRunAuto_SuggestionErrorReturnsFailure(t *testing.T) {
 	r := &recorder{suggestBranchErr: errors.New("agent down")}
 

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -356,6 +356,44 @@ func TestRunAuto_UsesAgentSuggestionsAndPushes(t *testing.T) {
 	}
 }
 
+func TestAutoAdvance_ActsLikePressingEnterThroughWizard(t *testing.T) {
+	r := &recorder{suggestBranch: "feat/auto", suggestCommit: "feat: auto commit"}
+	cfg := baseConfig(r)
+	cfg.AutoAdvance = true
+
+	m := NewModel(cfg)
+	m = drain(m, m.Init())
+
+	if r.createdBranch != "feat/auto" {
+		t.Fatalf("expected CreateBranch called with agent suggestion, got %q", r.createdBranch)
+	}
+	if r.commitMsg != "feat: auto commit" {
+		t.Fatalf("expected CommitAll called with agent suggestion, got %q", r.commitMsg)
+	}
+	if r.pushedBranch != "feat/auto" {
+		t.Fatalf("expected Push called with created branch, got %q", r.pushedBranch)
+	}
+	if !m.success || !m.quitting {
+		t.Fatalf("expected auto-advanced wizard to finish successfully, got success=%v quitting=%v", m.success, m.quitting)
+	}
+	out := m.View()
+	if !strings.Contains(out, "feat/auto") {
+		t.Fatalf("expected final view to show created branch, got:\n%s", out)
+	}
+	if !strings.Contains(out, "feat: auto commit") {
+		t.Fatalf("expected final view to show commit message, got:\n%s", out)
+	}
+	if !containsWizardEvent(r.telemetry, "branch_created", "source", "agent") {
+		t.Fatal("expected branch_created telemetry with agent source")
+	}
+	if !containsWizardEvent(r.telemetry, "committed", "source", "agent") {
+		t.Fatal("expected committed telemetry with agent source")
+	}
+	if !containsWizardEvent(r.telemetry, "pushed", "source", "user") {
+		t.Fatal("expected pushed telemetry with user source")
+	}
+}
+
 func TestRunAuto_SuggestionErrorReturnsFailure(t *testing.T) {
 	r := &recorder{suggestBranchErr: errors.New("agent down")}
 

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -389,8 +389,8 @@ func TestAutoAdvance_ActsLikePressingEnterThroughWizard(t *testing.T) {
 	if !containsWizardEvent(r.telemetry, "committed", "source", "agent") {
 		t.Fatal("expected committed telemetry with agent source")
 	}
-	if !containsWizardEvent(r.telemetry, "pushed", "source", "user") {
-		t.Fatal("expected pushed telemetry with user source")
+	if !containsWizardEvent(r.telemetry, "pushed", "source", "auto") {
+		t.Fatal("expected pushed telemetry with auto source")
 	}
 }
 
@@ -433,6 +433,9 @@ func TestAutoAdvance_ActionErrorFailsFast(t *testing.T) {
 
 	if m.err == nil {
 		t.Fatal("expected auto-advance action failure to be recorded")
+	}
+	if !strings.Contains(m.err.Error(), "create branch") {
+		t.Fatalf("error should mention branch action, got %v", m.err)
 	}
 	if !strings.Contains(m.err.Error(), "branch exists") {
 		t.Fatalf("error should mention branch failure, got %v", m.err)

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -394,6 +394,35 @@ func TestAutoAdvance_ActsLikePressingEnterThroughWizard(t *testing.T) {
 	}
 }
 
+func TestAutoAdvance_SuggestionErrorFailsFast(t *testing.T) {
+	r := &recorder{suggestBranchErr: errors.New("agent down")}
+	cfg := baseConfig(r)
+	cfg.AutoAdvance = true
+
+	m := NewModel(cfg)
+	m = drain(m, m.Init())
+
+	if m.err == nil {
+		t.Fatal("expected auto-advance suggestion failure to be recorded")
+	}
+	if !strings.Contains(m.err.Error(), "suggest branch") {
+		t.Fatalf("error should mention branch suggestion, got %v", m.err)
+	}
+	if !m.quitting {
+		t.Fatal("expected auto-advance suggestion failure to quit")
+	}
+	if m.steps[0].status != statFailed {
+		t.Fatalf("expected branch step to fail, got %v", m.steps[0].status)
+	}
+	if r.createdBranch != "" || r.commitMsg != "" || r.pushedBranch != "" {
+		t.Fatalf("auto-advance should stop before side effects, got branch=%q commit=%q push=%q", r.createdBranch, r.commitMsg, r.pushedBranch)
+	}
+	res := m.Result()
+	if !errors.Is(res.Err, m.err) {
+		t.Fatalf("result error = %v, want %v", res.Err, m.err)
+	}
+}
+
 func TestRunAuto_SuggestionErrorReturnsFailure(t *testing.T) {
 	r := &recorder{suggestBranchErr: errors.New("agent down")}
 


### PR DESCRIPTION
## Summary
- Show the setup wizard UI when `--yes` runs on an interactive TTY, while preserving the existing headless fallback when no TTY is available.
- Make visible auto-advance behave like the old headless path by failing fast on suggestion and git action errors, keeping step context in errors, and recording automated confirmations consistently.
- Update the wizard, CLI reference, and quick start docs to explain the visible `--yes` flow and its first-error exit behavior.

## Risk Assessment

✅ Low: The change is narrowly scoped to routing interactive `-y` runs through the visible wizard and the remaining behavior, error propagation, and telemetry updates appear internally consistent after the earlier fixes.

## Testing

- Summary: <code>Exercised the new interactive `-y` visible-wizard flow, the headless auto path, and the new fail-fast error propagation in the wizard model; all relevant existing tests passed.</code>
- `go test ./internal/wizard -run 'TestAutoAdvance_|TestRunAuto_|TestRun_' -count=1`
- `go test ./internal/cli -run 'TestRootYes|TestRunWizard' -count=1`
- `go test ./internal/cli -count=1`
- `go test ./internal/wizard -count=1`
- Outcome: ✅ passed across 1 run (1m5s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (3)</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/wizard/wizard.go:267` - `AutoAdvance` only injects Enter when a step is first entered. If the branch or commit suggestion fails, `handleSuggestion` falls back to manual input and the visible `-y` flow stops auto-progressing instead of returning an error like the old headless `RunAuto` path. On an interactive TTY this can leave `no-mistakes -y` waiting for manual input indefinitely when the agent is unavailable.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `internal/wizard/wizard.go:424` - Visible auto-advance still stops and waits for manual input when a git action fails. In `AutoAdvance` mode, `handleAction` marks the step failed but does not set `m.err` or quit, so `no-mistakes -y` on an interactive TTY can hang unattended on branch-create, commit, or push errors instead of returning the failure like the previous headless `RunAuto` path.

**Round 3** (auto-fix) - found 2 issues (1 warning, 1 info)
- ⚠️ `internal/wizard/wizard.go:428` - Auto-advance action failures return the raw git error (`msg.err`) without step context, so interactive `-y` failures are less actionable than the headless `RunAuto` path, which prefixes errors with `create branch`, `commit changes`, or `push branch`. Wrap the error here to keep diagnostics consistent across TTY and non-TTY `-y` runs.
- ℹ️ `internal/wizard/wizard.go:284` - `handleAutoAdvance` synthesizes an Enter key, which means the push step still records telemetry as `source=user` through `handleConfirmKey`. That makes `-y` analytics depend on TTY presence and splits the same automated flow across `user` and `auto` sources.

**Round 4** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/wizard -run 'TestAutoAdvance_|TestRunAuto_|TestRun_' -count=1`
- `go test ./internal/cli -run 'TestRootYes|TestRunWizard' -count=1`
- `go test ./internal/cli -count=1`
- `go test ./internal/wizard -count=1`

</details>

<details>
<summary>🔧 **Document** - 4 issues found → auto-fixed (2)</summary>

**Round 1** - found 4 issues (3 warnings, 1 info)
- ⚠️ `docs/src/content/docs/reference/cli.md:8` - The root command reference still says `-y`/`--yes` runs the setup wizard non-interactively. After this change, `--yes` keeps the wizard visible and auto-advances defaults when a TTY is available, and only falls back to the headless path without a TTY. Update both the command description and the flag table to match the new behavior.
- ⚠️ `docs/src/content/docs/guides/setup-wizard.md:23` - The setup wizard guide describes `-y`/`--yes` as a non-interactive, no-TUI path, but the new behavior is a visible auto-advancing wizard in interactive terminals and a headless fallback only when no TTY exists. The `-y` overview and the steps section should be updated so the guide reflects the split visible-vs-headless behavior.
- ⚠️ `docs/src/content/docs/guides/setup-wizard.md:76` - The failure-mode docs say the first-error exit behavior applies to the &#39;non-interactive path&#39;. With this change, `-y` also exits on first error in the visible auto-advance wizard shown in a TTY. Update this section to describe the `--yes` behavior rather than only the headless path.
- ℹ️ `internal/cli/attach.go:155` - The `isInteractive` doc comment still says the `--yes` path runs the wizard non-interactively. That is now stale because `--yes` can launch the visible auto-advancing wizard when stdin/stdout are TTYs, with headless mode only as a fallback.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `docs/src/content/docs/start-here/quick-start.md:75` - The quick-start guide still frames `no-mistakes -y` as the non-interactive way to run the setup path. After this change, `-y` also keeps the wizard visible and auto-advances defaults when stdin/stdout are TTYs, with headless execution only as the fallback without a TTY. Update this paragraph so the introductory docs match the new `--yes` behavior.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
