### PR TITLE
fix(tui): backfill rerun pipeline steps without stale placeholders

### DIFF
--- a/docs/src/content/docs/guides/tui.md
+++ b/docs/src/content/docs/guides/tui.md
@@ -52,6 +52,8 @@ Shows the branch name and run status in the header, followed by each step:
   │
   ○ Test
   │
+  ○ Document
+  │
   ○ Lint
   │
   ○ Push

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -46,11 +46,13 @@ type Model struct {
 	diffOffset       int  // scroll position in diff view
 	spinnerFrame     int
 	spinnerScheduled bool
+	syntheticSteps   bool
 }
 
 // NewModel creates a TUI model for the given run.
 // The client should already be connected to the daemon.
 func NewModel(socketPath string, client *ipc.Client, run *ipc.RunInfo) Model {
+	syntheticSteps := len(run.Steps) == 0 && shouldBackfillPipelineSteps(run.Status, run.Steps, types.AllSteps())
 	steps := normalizePipelineSteps(run.ID, run.Status, run.Steps)
 	run.Steps = steps
 	m := Model{
@@ -66,6 +68,7 @@ func NewModel(socketPath string, client *ipc.Client, run *ipc.RunInfo) Model {
 		findingSelections: make(map[types.StepName]map[string]bool),
 		findingCursor:     make(map[types.StepName]int),
 		stepStartTimes:    make(map[types.StepName]time.Time),
+		syntheticSteps:    syntheticSteps,
 	}
 	// Populate findings and start times from initial step data (for re-attach scenarios).
 	for _, s := range steps {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -51,7 +51,7 @@ type Model struct {
 // NewModel creates a TUI model for the given run.
 // The client should already be connected to the daemon.
 func NewModel(socketPath string, client *ipc.Client, run *ipc.RunInfo) Model {
-	steps := normalizePipelineSteps(run.ID, run.Steps)
+	steps := normalizePipelineSteps(run.ID, run.Status, run.Steps)
 	run.Steps = steps
 	m := Model{
 		socketPath:        socketPath,
@@ -83,9 +83,9 @@ func NewModel(socketPath string, client *ipc.Client, run *ipc.RunInfo) Model {
 	return m
 }
 
-func normalizePipelineSteps(runID string, steps []ipc.StepResultInfo) []ipc.StepResultInfo {
+func normalizePipelineSteps(runID string, runStatus types.RunStatus, steps []ipc.StepResultInfo) []ipc.StepResultInfo {
 	knownSteps := types.AllSteps()
-	if !shouldBackfillPipelineSteps(steps, knownSteps) {
+	if !shouldBackfillPipelineSteps(runStatus, steps, knownSteps) {
 		return steps
 	}
 
@@ -127,9 +127,9 @@ func normalizePipelineSteps(runID string, steps []ipc.StepResultInfo) []ipc.Step
 	return normalized
 }
 
-func shouldBackfillPipelineSteps(steps []ipc.StepResultInfo, knownSteps []types.StepName) bool {
+func shouldBackfillPipelineSteps(runStatus types.RunStatus, steps []ipc.StepResultInfo, knownSteps []types.StepName) bool {
 	if len(steps) == 0 {
-		return true
+		return runStatus == types.RunPending || runStatus == types.RunRunning
 	}
 	if len(steps) >= len(knownSteps) {
 		return false

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -51,6 +51,8 @@ type Model struct {
 // NewModel creates a TUI model for the given run.
 // The client should already be connected to the daemon.
 func NewModel(socketPath string, client *ipc.Client, run *ipc.RunInfo) Model {
+	steps := normalizePipelineSteps(run.ID, run.Steps)
+	run.Steps = steps
 	m := Model{
 		socketPath:        socketPath,
 		client:            client,
@@ -58,7 +60,7 @@ func NewModel(socketPath string, client *ipc.Client, run *ipc.RunInfo) Model {
 		subscriptionID:    1,
 		run:               run,
 		done:              run.Status == types.RunCompleted || run.Status == types.RunFailed || run.Status == types.RunCancelled,
-		steps:             run.Steps,
+		steps:             steps,
 		stepFindings:      make(map[types.StepName]string),
 		stepDiffs:         make(map[types.StepName]string),
 		findingSelections: make(map[types.StepName]map[string]bool),
@@ -66,7 +68,7 @@ func NewModel(socketPath string, client *ipc.Client, run *ipc.RunInfo) Model {
 		stepStartTimes:    make(map[types.StepName]time.Time),
 	}
 	// Populate findings and start times from initial step data (for re-attach scenarios).
-	for _, s := range run.Steps {
+	for _, s := range steps {
 		if s.FindingsJSON != nil && *s.FindingsJSON != "" {
 			m.stepFindings[s.StepName] = *s.FindingsJSON
 			if s.Status == types.StepStatusAwaitingApproval || s.Status == types.StepStatusFixReview {
@@ -79,6 +81,65 @@ func NewModel(socketPath string, client *ipc.Client, run *ipc.RunInfo) Model {
 		}
 	}
 	return m
+}
+
+func normalizePipelineSteps(runID string, steps []ipc.StepResultInfo) []ipc.StepResultInfo {
+	knownSteps := types.AllSteps()
+	if !shouldBackfillPipelineSteps(steps, knownSteps) {
+		return steps
+	}
+
+	byName := make(map[types.StepName]ipc.StepResultInfo, len(steps))
+	for _, step := range steps {
+		byName[step.StepName] = step
+	}
+
+	normalized := make([]ipc.StepResultInfo, 0, len(knownSteps)+len(steps))
+	for _, stepName := range knownSteps {
+		step, ok := byName[stepName]
+		if !ok {
+			normalized = append(normalized, ipc.StepResultInfo{
+				RunID:     runID,
+				StepName:  stepName,
+				StepOrder: stepName.Order(),
+				Status:    types.StepStatusPending,
+			})
+			continue
+		}
+		if step.RunID == "" {
+			step.RunID = runID
+		}
+		if step.StepOrder == 0 {
+			step.StepOrder = stepName.Order()
+		}
+		normalized = append(normalized, step)
+		delete(byName, stepName)
+	}
+
+	for _, step := range steps {
+		if _, ok := byName[step.StepName]; !ok {
+			continue
+		}
+		normalized = append(normalized, step)
+		delete(byName, step.StepName)
+	}
+
+	return normalized
+}
+
+func shouldBackfillPipelineSteps(steps []ipc.StepResultInfo, knownSteps []types.StepName) bool {
+	if len(steps) == 0 {
+		return true
+	}
+	if len(steps) >= len(knownSteps) {
+		return false
+	}
+	for i, step := range steps {
+		if step.StepName != knownSteps[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func (m Model) Init() tea.Cmd {

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -306,6 +306,51 @@ func TestModel_Update_RerunStartedBackfillsMissingPipelineSteps(t *testing.T) {
 	}
 }
 
+func TestModel_Update_RerunStartedBackfillsEmptyRunningPipelineSteps(t *testing.T) {
+	run := testRun()
+	run.Status = types.RunFailed
+	m := NewModel("/tmp/sock", nil, run)
+
+	newRun := &ipc.RunInfo{
+		ID:      "run-002",
+		RepoID:  run.RepoID,
+		Branch:  run.Branch,
+		HeadSHA: run.HeadSHA,
+		BaseSHA: run.BaseSHA,
+		Status:  types.RunRunning,
+	}
+
+	updated, _ := m.Update(rerunStartedMsg{run: newRun})
+	model := updated.(Model)
+
+	if len(model.steps) != len(types.AllSteps()) {
+		t.Fatalf("step count = %d, want %d", len(model.steps), len(types.AllSteps()))
+	}
+	for i, stepName := range types.AllSteps() {
+		if model.steps[i].StepName != stepName {
+			t.Fatalf("step %d = %s, want %s", i, model.steps[i].StepName, stepName)
+		}
+		if model.steps[i].Status != types.StepStatusPending {
+			t.Fatalf("step %s status = %s, want %s", stepName, model.steps[i].Status, types.StepStatusPending)
+		}
+	}
+}
+
+func TestNewModel_DoesNotBackfillEmptyTerminalPipelineSteps(t *testing.T) {
+	run := testRun()
+	run.Status = types.RunFailed
+	run.Steps = nil
+
+	m := NewModel("/tmp/sock", nil, run)
+
+	if len(m.steps) != 0 {
+		t.Fatalf("step count = %d, want 0", len(m.steps))
+	}
+	if len(m.run.Steps) != 0 {
+		t.Fatalf("run step count = %d, want 0", len(m.run.Steps))
+	}
+}
+
 func TestModel_SubscribeCmdReturnsScopedError(t *testing.T) {
 	run := testRun()
 	m := NewModel(filepath.Join(t.TempDir(), "missing.sock"), nil, run)

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -253,6 +253,59 @@ func TestModel_Update_RerunPreservesLatestVersion(t *testing.T) {
 	}
 }
 
+func TestModel_Update_RerunStartedBackfillsMissingPipelineSteps(t *testing.T) {
+	run := testRun()
+	run.Status = types.RunFailed
+	m := NewModel("/tmp/sock", nil, run)
+
+	newRun := &ipc.RunInfo{
+		ID:      "run-002",
+		RepoID:  run.RepoID,
+		Branch:  run.Branch,
+		HeadSHA: run.HeadSHA,
+		BaseSHA: run.BaseSHA,
+		Status:  types.RunRunning,
+		Steps: []ipc.StepResultInfo{{
+			ID:        "s1",
+			RunID:     "run-002",
+			StepName:  types.StepRebase,
+			StepOrder: types.StepRebase.Order(),
+			Status:    types.StepStatusRunning,
+		}},
+	}
+
+	updated, _ := m.Update(rerunStartedMsg{run: newRun})
+	model := updated.(Model)
+
+	if len(model.steps) != len(types.AllSteps()) {
+		t.Fatalf("step count = %d, want %d", len(model.steps), len(types.AllSteps()))
+	}
+	for i, stepName := range types.AllSteps() {
+		if model.steps[i].StepName != stepName {
+			t.Fatalf("step %d = %s, want %s", i, model.steps[i].StepName, stepName)
+		}
+	}
+	if model.steps[0].Status != types.StepStatusRunning {
+		t.Fatalf("rebase status = %s, want %s", model.steps[0].Status, types.StepStatusRunning)
+	}
+	if model.steps[1].Status != types.StepStatusPending {
+		t.Fatalf("review status = %s, want %s", model.steps[1].Status, types.StepStatusPending)
+	}
+
+	plain := stripANSI(renderPipelineView(model.run, model.steps, 80, 0, 40))
+	for _, label := range []string{"Rebase", "Review", "Test", "Document", "Lint", "Push", "PR", "CI"} {
+		if !strings.Contains(plain, label) {
+			t.Fatalf("expected pipeline view to contain %q, got:\n%s", label, plain)
+		}
+	}
+
+	review := types.StepReview
+	model.applyEvent(ipc.Event{Type: ipc.EventStepStarted, StepName: &review})
+	if model.steps[1].Status != types.StepStatusRunning {
+		t.Fatalf("review status after event = %s, want %s", model.steps[1].Status, types.StepStatusRunning)
+	}
+}
+
 func TestModel_SubscribeCmdReturnsScopedError(t *testing.T) {
 	run := testRun()
 	m := NewModel(filepath.Join(t.TempDir(), "missing.sock"), nil, run)

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -30,11 +30,16 @@ func (m *Model) applyEvent(event ipc.Event) {
 		if event.PRURL != nil {
 			m.run.PRURL = event.PRURL
 		}
+		if m.syntheticSteps {
+			m.steps = nil
+			m.run.Steps = nil
+		}
 		m.flushPartialLog()
 		m.done = true
 
 	case ipc.EventStepStarted:
 		m.err = nil
+		m.syntheticSteps = false
 		if event.StepName != nil {
 			m.updateStepStatus(*event.StepName, types.StepStatusRunning)
 			m.stepStartTimes[*event.StepName] = time.Now()
@@ -42,6 +47,7 @@ func (m *Model) applyEvent(event ipc.Event) {
 
 	case ipc.EventStepCompleted:
 		m.err = nil
+		m.syntheticSteps = false
 		m.flushPartialLog()
 		if event.StepName != nil && event.Status != nil {
 			m.updateStepStatus(*event.StepName, types.StepStatus(*event.Status))

--- a/internal/tui/pipeline_test.go
+++ b/internal/tui/pipeline_test.go
@@ -370,6 +370,31 @@ func TestModel_ApplyEvent_RunCompleted_FailedStoresError(t *testing.T) {
 	}
 }
 
+func TestModel_ApplyEvent_RunCompleted_FailedClearsSyntheticBackfill(t *testing.T) {
+	run := testRun()
+	run.Steps = nil
+	m := NewModel("/tmp/sock", nil, run)
+	errMsg := "setup failed before any step started"
+
+	if len(m.steps) == 0 {
+		t.Fatal("expected active run to backfill pipeline steps")
+	}
+
+	m.applyEvent(ipc.Event{
+		Type:   ipc.EventRunCompleted,
+		RunID:  run.ID,
+		Status: ptr(string(types.RunFailed)),
+		Error:  &errMsg,
+	})
+
+	if len(m.steps) != 0 {
+		t.Fatalf("expected synthetic pending steps to be cleared, got %d", len(m.steps))
+	}
+	if m.run.Status != types.RunFailed {
+		t.Fatalf("expected failed status, got %s", m.run.Status)
+	}
+}
+
 func TestModel_ApplyEvent_RunUpdated_PRURL(t *testing.T) {
 	run := testRun()
 	m := NewModel("/tmp/sock", nil, run)


### PR DESCRIPTION
## Summary
- Backfill the canonical pipeline step list in `internal/tui` when reruns attach before step rows arrive, so running sessions show the expected pipeline progression instead of missing steps.
- Restrict empty-step backfill to active runs and clear synthetic placeholders when a rerun becomes terminal without real step updates, avoiding misleading pending steps after early failures.
- Add focused TUI coverage for rerun and terminal-state edge cases, and update the TUI guide example to match the full step list now shown in the pipeline box.

## Risk Assessment

✅ Low: The change is tightly scoped to TUI step backfilling and terminal-state cleanup, and the updated logic appears consistent with the event model without introducing material correctness or maintainability issues in the reviewed paths.

## Testing

- Summary: <code>Exercised the TUI rerun/backfill and terminal-completion paths in `internal/tui`, including the new synthetic-step regression cases, and all relevant tests passed including under `-race`.</code>
- `go test ./internal/tui`
- `go test ./internal/tui -run 'TestModel_Update_RerunStartedBackfillsMissingPipelineSteps|TestModel_Update_RerunStartedBackfillsEmptyRunningPipelineSteps|TestNewModel_DoesNotBackfillEmptyTerminalPipelineSteps|TestModel_ApplyEvent_RunCompleted_FailedClearsSyntheticBackfill' -count=1`
- `go test -race ./internal/tui`
- Outcome: ✅ passed across 1 run (37.3s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2)</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/tui/app.go:131` - Backfilling when `len(steps) == 0` also affects runs that failed before the executor created any step rows, such as setup failures in `startRun`; those runs will now render the full pipeline as pending instead of showing that no step ever started. Restrict the zero-step backfill to the rerun race you actually want to smooth over, or preserve the empty-step view for terminal failures.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `internal/tui/app.go:131` - Zero-step backfill still misrepresents reruns that fail before any real step row is created: a rerun loaded as `pending`/`running` gets synthetic pending steps here, and if the daemon later sends only `run_completed`, the TUI keeps showing the full pipeline as pending even though no step ever started. Either delay the empty-step backfill until the first step event arrives, or clear synthetic placeholders when a run becomes terminal without receiving any real step updates.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/tui`
- `go test ./internal/tui -run 'TestModel_Update_RerunStartedBackfillsMissingPipelineSteps|TestModel_Update_RerunStartedBackfillsEmptyRunningPipelineSteps|TestNewModel_DoesNotBackfillEmptyTerminalPipelineSteps|TestModel_ApplyEvent_RunCompleted_FailedClearsSyntheticBackfill' -count=1`
- `go test -race ./internal/tui`

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 info
- ℹ️ `docs/src/content/docs/guides/tui.md:46` - The pipeline box example is now stale relative to the TUI behavior. This change makes running and rerun-attached sessions consistently show the full canonical step list via backfilled pending steps, but the documented example still skips the `Document` step. Update the example so it shows all eight pipeline steps in order.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
