### PR TITLE
ci: run publish jobs after skipped validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,10 @@ jobs:
   build-and-upload:
     runs-on: ubuntu-latest
     needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
+    if: |
+      !cancelled() &&
+      needs.release-please.result == 'success' &&
+      needs.release-please.outputs.release_created == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -157,7 +160,11 @@ jobs:
     needs:
       - release-please
       - build-and-upload
-    if: needs.release-please.outputs.release_created == 'true'
+    if: |
+      !cancelled() &&
+      needs.release-please.result == 'success' &&
+      needs.build-and-upload.result == 'success' &&
+      needs.release-please.outputs.release_created == 'true'
     steps:
       - uses: actions/download-artifact@v8
         with:

--- a/workflow_release_test.go
+++ b/workflow_release_test.go
@@ -53,3 +53,71 @@ func TestReleaseWorkflowAllowsReleasePleaseAfterSkippedValidation(t *testing.T) 
 		}
 	}
 }
+
+// Regression for the v1.8.1 incident: when check/test are skipped for release
+// PR merge commits, GitHub Actions implicitly wraps downstream job `if:`
+// expressions with success(), which returns false because upstream jobs did
+// not succeed. build-and-upload and checksums must include !cancelled() (or
+// success()/always()) so the implicit wrap is skipped, and must gate on
+// release-please succeeding plus release_created=='true'.
+func TestReleaseWorkflowRunsBuildAndChecksumsAfterSkippedValidation(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/release.yml")
+	if err != nil {
+		t.Fatalf("read workflow: %v", err)
+	}
+	content := string(data)
+
+	jobs := []struct {
+		name     string
+		required []string
+	}{
+		{
+			name: "build-and-upload",
+			required: []string{
+				"!cancelled()",
+				"needs.release-please.result == 'success'",
+				"needs.release-please.outputs.release_created == 'true'",
+			},
+		},
+		{
+			name: "checksums",
+			required: []string{
+				"!cancelled()",
+				"needs.release-please.result == 'success'",
+				"needs.build-and-upload.result == 'success'",
+				"needs.release-please.outputs.release_created == 'true'",
+			},
+		},
+	}
+
+	for _, j := range jobs {
+		header := "\n  " + j.name + ":\n"
+		start := strings.Index(content, header)
+		if start < 0 {
+			t.Fatalf("could not locate %s job in workflow", j.name)
+		}
+		rest := content[start+len(header):]
+		nextJob := strings.Index(rest, "\n  ")
+		for nextJob >= 0 {
+			line := rest[nextJob+1:]
+			if len(line) > 2 && line[2] != ' ' && line[2] != '#' && line[2] != '\n' {
+				break
+			}
+			next := strings.Index(rest[nextJob+1:], "\n  ")
+			if next < 0 {
+				nextJob = -1
+				break
+			}
+			nextJob = nextJob + 1 + next
+		}
+		block := rest
+		if nextJob > 0 {
+			block = rest[:nextJob]
+		}
+		for _, req := range j.required {
+			if !strings.Contains(block, req) {
+				t.Fatalf("%s job must contain %q so it runs after skipped validation jobs", j.name, req)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Update the release GitHub Actions workflow so publish jobs still run when validation jobs are skipped, fixing an incorrect workflow guard in release runs.
- Add release workflow regression coverage in `workflow_release_test.go` to lock in the skipped-validation behavior and protect the build/checksum path.

## Risk Assessment

✅ Low: The change is narrowly scoped to GitHub Actions job guards, preserves existing behavior outside the skipped-validation path, and adds targeted regression coverage for the specific incident being fixed.

## Testing

- Summary: I exercised the release workflow regression coverage, including the new skipped-validation guard test, and the relevant tests passed with no actionable failures.
- `go test -run '^TestReleaseWorkflow' ./...`
- `go test -run '^TestReleaseWorkflowRunsBuildAndChecksumsAfterSkippedValidation$' .`
- Outcome: ✅ passed across 1 run (36.2s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test -run '^TestReleaseWorkflow' ./...`
- `go test -run '^TestReleaseWorkflowRunsBuildAndChecksumsAfterSkippedValidation$' .`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
