### PR TITLE
ci: publish releases only after assets finish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,3 +185,23 @@ jobs:
           GH_REPO: ${{ github.repository }}
           TAG: ${{ needs.release-please.outputs.tag_name }}
         run: gh release upload "$TAG" checksums.txt --clobber
+
+  finalize:
+    runs-on: ubuntu-latest
+    needs:
+      - release-please
+      - build-and-upload
+      - checksums
+    if: |
+      !cancelled() &&
+      needs.release-please.result == 'success' &&
+      needs.build-and-upload.result == 'success' &&
+      needs.checksums.result == 'success' &&
+      needs.release-please.outputs.release_created == 'true'
+    steps:
+      - name: Publish draft release as latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: gh release edit "$TAG" --draft=false --latest=true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,8 @@
     ".": {
       "release-type": "go",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "draft": true
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"

--- a/workflow_release_test.go
+++ b/workflow_release_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
@@ -91,33 +92,95 @@ func TestReleaseWorkflowRunsBuildAndChecksumsAfterSkippedValidation(t *testing.T
 	}
 
 	for _, j := range jobs {
-		header := "\n  " + j.name + ":\n"
-		start := strings.Index(content, header)
-		if start < 0 {
-			t.Fatalf("could not locate %s job in workflow", j.name)
-		}
-		rest := content[start+len(header):]
-		nextJob := strings.Index(rest, "\n  ")
-		for nextJob >= 0 {
-			line := rest[nextJob+1:]
-			if len(line) > 2 && line[2] != ' ' && line[2] != '#' && line[2] != '\n' {
-				break
-			}
-			next := strings.Index(rest[nextJob+1:], "\n  ")
-			if next < 0 {
-				nextJob = -1
-				break
-			}
-			nextJob = nextJob + 1 + next
-		}
-		block := rest
-		if nextJob > 0 {
-			block = rest[:nextJob]
-		}
+		block := extractJobBlock(t, content, j.name)
 		for _, req := range j.required {
 			if !strings.Contains(block, req) {
 				t.Fatalf("%s job must contain %q so it runs after skipped validation jobs", j.name, req)
 			}
 		}
+	}
+}
+
+// Partial-release protection: release-please must create drafts so that a
+// release is never marked "latest" until all binaries and checksums are
+// uploaded. A separate finalize job gates the promotion on every asset job
+// succeeding.
+func TestReleasePleaseConfigCreatesDrafts(t *testing.T) {
+	data, err := os.ReadFile("release-please-config.json")
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var cfg struct {
+		Packages map[string]struct {
+			Draft bool `json:"draft"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	pkg, ok := cfg.Packages["."]
+	if !ok {
+		t.Fatalf("release-please config missing '.' package")
+	}
+	if !pkg.Draft {
+		t.Fatalf("release-please must create releases as drafts; partial releases would otherwise be marked latest before binaries are uploaded")
+	}
+}
+
+func TestReleaseWorkflowPromotesDraftOnlyAfterAssetsComplete(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/release.yml")
+	if err != nil {
+		t.Fatalf("read workflow: %v", err)
+	}
+	content := string(data)
+
+	block := extractJobBlock(t, content, "finalize")
+
+	required := []string{
+		"!cancelled()",
+		"needs.release-please.result == 'success'",
+		"needs.build-and-upload.result == 'success'",
+		"needs.checksums.result == 'success'",
+		"needs.release-please.outputs.release_created == 'true'",
+		"gh release edit",
+		"--draft=false",
+		"--latest=true",
+	}
+	for _, req := range required {
+		if !strings.Contains(block, req) {
+			t.Fatalf("finalize job must contain %q so a draft is only promoted to latest after every asset job succeeds", req)
+		}
+	}
+
+	for _, dep := range []string{"release-please", "build-and-upload", "checksums"} {
+		if !strings.Contains(block, "- "+dep) {
+			t.Fatalf("finalize job must declare %q in needs so its gate sees all upstream results", dep)
+		}
+	}
+}
+
+func extractJobBlock(t *testing.T, content, name string) string {
+	t.Helper()
+	header := "\n  " + name + ":\n"
+	start := strings.Index(content, header)
+	if start < 0 {
+		t.Fatalf("could not locate %s job in workflow", name)
+	}
+	rest := content[start+len(header):]
+	idx := 0
+	for {
+		next := strings.Index(rest[idx:], "\n  ")
+		if next < 0 {
+			return rest
+		}
+		pos := idx + next + 1
+		if pos+2 >= len(rest) {
+			return rest
+		}
+		ch := rest[pos+2]
+		if ch != ' ' && ch != '#' && ch != '\n' {
+			return rest[:pos]
+		}
+		idx = pos + 1
 	}
 }


### PR DESCRIPTION
## Summary
- configure `release-please` to create GitHub releases as drafts instead of publishing them immediately
- add a `finalize` job to `.github/workflows/release.yml` so a draft is only promoted to the latest release after archive uploads and checksum generation succeed
- extend the release workflow regression tests to cover draft release creation and the new finalization gate

## Risk Assessment

🚨 High: This change alters release publication semantics in a way that can leave a release permanently stuck as an unpublished draft after a transient CI/upload failure, requiring manual recovery.

## Testing

- Summary: I exercised the release workflow and release-please config assertions in the root test package, then reran the full root package tests; everything passed with no actionable test issues.
- `go test -run 'TestRelease' .`
- `go test .`
- Outcome: ✅ passed across 1 run (47.4s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

**Round 1** - found 1 error
- 🚨 `.github/workflows/release.yml:200` - The new draft-release flow cannot recover from a transient asset failure on rerun. If any `build-and-upload` or `checksums` step fails after `release-please` creates the draft, a later workflow rerun will usually see `release_created == &#39;false&#39;`, so this `finalize` job is skipped and the existing draft never gets published automatically.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test -run 'TestRelease' .`
- `go test .`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
