### PR TITLE
fix(daemon): tighten detached fallback around managed service stop failures

### DIFF
--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -86,8 +86,11 @@ func managedStopErrorAllowsDetachedFallback(err error) bool {
 	if err == nil {
 		return false
 	}
+	if runtimeGOOS != "darwin" {
+		return false
+	}
 	message := strings.ToLower(err.Error())
-	return strings.Contains(message, "no such process") || strings.Contains(message, "not loaded")
+	return strings.Contains(message, "no such process")
 }
 
 func startDetachedDaemon(p *paths.Paths) error {

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -75,14 +75,19 @@ func stopManagedFallback(p *paths.Paths) error {
 	if alive, _ := daemonHealthCheck(p); alive {
 		return fmt.Errorf("managed daemon is still running: %w", err)
 	}
-	// The managed stop is best-effort cleanup before the detached fallback.
-	// If the daemon isn't alive, the goal is already met and we should let
-	// Start continue into startDetachedDaemon. Erroring out here previously
-	// masked a healthy recovery path - notably when `launchctl bootout`
-	// returns ESRCH ("No such process") because bootstrap/kickstart never
-	// loaded the service in the first place.
-	slog.Debug("managed stop failed but daemon is not running; proceeding with detached fallback", "err", err)
-	return nil
+	if managedStopErrorAllowsDetachedFallback(err) {
+		slog.Debug("managed stop reported daemon already stopped; proceeding with detached fallback", "err", err)
+		return nil
+	}
+	return fmt.Errorf("stop managed daemon before detached fallback: %w", err)
+}
+
+func managedStopErrorAllowsDetachedFallback(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "no such process") || strings.Contains(message, "not loaded")
 }
 
 func startDetachedDaemon(p *paths.Paths) error {

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -75,7 +75,14 @@ func stopManagedFallback(p *paths.Paths) error {
 	if alive, _ := daemonHealthCheck(p); alive {
 		return fmt.Errorf("managed daemon is still running: %w", err)
 	}
-	return fmt.Errorf("stop managed daemon before detached fallback: %w", err)
+	// The managed stop is best-effort cleanup before the detached fallback.
+	// If the daemon isn't alive, the goal is already met and we should let
+	// Start continue into startDetachedDaemon. Erroring out here previously
+	// masked a healthy recovery path - notably when `launchctl bootout`
+	// returns ESRCH ("No such process") because bootstrap/kickstart never
+	// loaded the service in the first place.
+	slog.Debug("managed stop failed but daemon is not running; proceeding with detached fallback", "err", err)
+	return nil
 }
 
 func startDetachedDaemon(p *paths.Paths) error {

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -69,28 +69,21 @@ func Start(p *paths.Paths) error {
 
 func stopManagedFallback(p *paths.Paths) error {
 	managed, err := stopManagedService(p)
-	if !managed || err == nil {
+	if !managed {
+		return nil
+	}
+	if err == nil {
+		if runtimeGOOS == "darwin" {
+			if err := removeLaunchAgent(p); err != nil {
+				return fmt.Errorf("remove launch agent before detached fallback: %w", err)
+			}
+		}
 		return nil
 	}
 	if alive, _ := daemonHealthCheck(p); alive {
 		return fmt.Errorf("managed daemon is still running: %w", err)
 	}
-	if managedStopErrorAllowsDetachedFallback(err) {
-		slog.Debug("managed stop reported daemon already stopped; proceeding with detached fallback", "err", err)
-		return nil
-	}
 	return fmt.Errorf("stop managed daemon before detached fallback: %w", err)
-}
-
-func managedStopErrorAllowsDetachedFallback(err error) bool {
-	if err == nil {
-		return false
-	}
-	if runtimeGOOS != "darwin" {
-		return false
-	}
-	message := strings.ToLower(err.Error())
-	return strings.Contains(message, "no such process")
 }
 
 func startDetachedDaemon(p *paths.Paths) error {

--- a/internal/daemon/service_launchd.go
+++ b/internal/daemon/service_launchd.go
@@ -77,6 +77,14 @@ func stopLaunchAgent(p *paths.Paths) error {
 	return nil
 }
 
+func removeLaunchAgent(p *paths.Paths) error {
+	err := os.Remove(launchAgentPath(p))
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
 // launchctlBootoutServiceNotLoaded reports whether a launchctl bootout
 // failure is the ESRCH case ("No such process", exit 3) that launchctl
 // emits when the service label isn't currently loaded. That is semantically

--- a/internal/daemon/service_launchd.go
+++ b/internal/daemon/service_launchd.go
@@ -67,11 +67,26 @@ func stopLaunchAgent(p *paths.Paths) error {
 	if err != nil {
 		return err
 	}
-	_, err = serviceCommandRunner("launchctl", "bootout", domain+"/"+launchdServiceLabel(p))
+	output, err := serviceCommandRunner("launchctl", "bootout", domain+"/"+launchdServiceLabel(p))
 	if err != nil {
+		if launchctlBootoutServiceNotLoaded(err, output) {
+			return nil
+		}
 		return fmt.Errorf("launchctl bootout: %w", err)
 	}
 	return nil
+}
+
+// launchctlBootoutServiceNotLoaded reports whether a launchctl bootout
+// failure is the ESRCH case ("No such process", exit 3) that launchctl
+// emits when the service label isn't currently loaded. That is semantically
+// a successful stop - the service is already not running.
+func launchctlBootoutServiceNotLoaded(err error, output []byte) bool {
+	if err == nil {
+		return false
+	}
+	combined := strings.ToLower(string(output) + " " + err.Error())
+	return strings.Contains(combined, "no such process")
 }
 
 func launchAgentPath(p *paths.Paths) string {

--- a/internal/daemon/service_launchd_test.go
+++ b/internal/daemon/service_launchd_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"fmt"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -72,6 +73,35 @@ func TestStartInstallsLaunchAgentAndBootstrapsManagedDaemon(t *testing.T) {
 	}
 	if want := "launchctl kickstart -k gui/501/" + launchdServiceLabel(p); commands[2] != want {
 		t.Fatalf("kickstart command = %q, want %q", commands[2], want)
+	}
+}
+
+// TestStopLaunchAgentTreatsBootoutNotLoadedAsSuccess locks in that
+// `launchctl bootout` returning ESRCH ("No such process", exit 3) is
+// treated as a successful no-op. launchctl emits this when the service
+// label isn't currently loaded, which is semantically the same as "already
+// stopped" for stop purposes. Without this, a plain `daemon stop` after
+// the plist was unloaded out-of-band surfaces a scary error and the
+// detached-fallback path in Start() short-circuits on an install where
+// bootstrap/kickstart failed and the service was never loaded.
+func TestStopLaunchAgentTreatsBootoutNotLoadedAsSuccess(t *testing.T) {
+	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
+	home := t.TempDir()
+
+	cleanup := stubServiceRuntime(t)
+	defer cleanup()
+	runtimeGOOS = "darwin"
+	serviceUserHomeDir = func() (string, error) { return home, nil }
+	serviceCurrentUser = func() (*user.User, error) { return &user.User{Uid: "501"}, nil }
+
+	serviceCommandRunner = func(name string, args ...string) ([]byte, error) {
+		target := "gui/501/" + launchdServiceLabel(p)
+		return []byte("Boot-out failed: 3: No such process"),
+			fmt.Errorf("/bin/launchctl bootout %s: exit status 3: Boot-out failed: 3: No such process", target)
+	}
+
+	if err := stopLaunchAgent(p); err != nil {
+		t.Fatalf("stopLaunchAgent should treat ESRCH bootout as success, got: %v", err)
 	}
 }
 

--- a/internal/daemon/service_test.go
+++ b/internal/daemon/service_test.go
@@ -185,6 +185,60 @@ func TestStartStopsManagedServiceBeforeDetachedFallbackAfterTimeout(t *testing.T
 	_ = os.Remove(p.Socket())
 }
 
+// TestStartFallsBackToDetachedDaemonWhenManagedStopFailsButDaemonIsDead is
+// the regression test for the install.sh failure observed in v1.8.0 on
+// macOS: `daemon restart` on a fresh install runs `launchctl bootstrap` +
+// `kickstart`, one of them fails, Start falls into stopManagedFallback to
+// clean up, and `launchctl bootout` returns ESRCH ("No such process", exit
+// 3) because the service was never loaded. Before the fix, stopManagedFallback
+// treated that as fatal and short-circuited the detached fallback, leaving
+// the user with no daemon running. The fix: when the managed stop fails but
+// the daemon isn't alive, proceed with the detached fallback - the goal of
+// stop is already satisfied.
+func TestStartFallsBackToDetachedDaemonWhenManagedStopFailsButDaemonIsDead(t *testing.T) {
+	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+
+	cleanup := stubServiceRuntime(t)
+	defer cleanup()
+	t.Setenv("NM_DAEMON_HELPER_PROCESS", "1")
+	runtimeGOOS = "linux"
+	serviceUserHomeDir = func() (string, error) { return home, nil }
+	serviceExecutablePath = func() (string, error) { return "/usr/local/bin/no-mistakes", nil }
+
+	var commands []string
+	serviceCommandRunner = func(name string, args ...string) ([]byte, error) {
+		command := name + " " + strings.Join(args, " ")
+		commands = append(commands, command)
+		if command == "systemctl --user start "+systemdServiceName(p) {
+			return nil, fmt.Errorf("user manager unavailable")
+		}
+		if command == "systemctl --user stop "+systemdServiceName(p) {
+			return nil, fmt.Errorf("Unit not loaded")
+		}
+		return nil, nil
+	}
+	checks := 0
+	daemonHealthCheck = func(*paths.Paths) (bool, error) {
+		checks++
+		return checks >= 4, nil
+	}
+
+	if err := Start(p); err != nil {
+		t.Fatalf("Start should fall back to detached mode when managed stop fails but daemon is dead: %v", err)
+	}
+
+	if _, err := os.Stat(p.DaemonLog()); err != nil {
+		t.Fatalf("detached fallback should open daemon log: %v", err)
+	}
+	_ = os.Remove(p.DaemonLog())
+	_ = os.Remove(p.PIDFile())
+	_ = os.Remove(p.Socket())
+}
+
 func TestStopUsesManagedServiceWhenInstalled(t *testing.T) {
 	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
 	if err := p.EnsureDirs(); err != nil {

--- a/internal/daemon/service_test.go
+++ b/internal/daemon/service_test.go
@@ -185,17 +185,7 @@ func TestStartStopsManagedServiceBeforeDetachedFallbackAfterTimeout(t *testing.T
 	_ = os.Remove(p.Socket())
 }
 
-// TestStartFallsBackToDetachedDaemonWhenManagedStopFailsButDaemonIsDead is
-// the regression test for the install.sh failure observed in v1.8.0 on
-// macOS: `daemon restart` on a fresh install runs `launchctl bootstrap` +
-// `kickstart`, one of them fails, Start falls into stopManagedFallback to
-// clean up, and `launchctl bootout` returns ESRCH ("No such process", exit
-// 3) because the service was never loaded. Before the fix, stopManagedFallback
-// treated that as fatal and short-circuited the detached fallback, leaving
-// the user with no daemon running. The fix: when the managed stop fails but
-// the daemon isn't alive, proceed with the detached fallback - the goal of
-// stop is already satisfied.
-func TestStartFallsBackToDetachedDaemonWhenManagedStopFailsButDaemonIsDead(t *testing.T) {
+func TestStartReturnsManagedStopErrorWhenSystemdStopSaysNotLoaded(t *testing.T) {
 	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
 	if err := p.EnsureDirs(); err != nil {
 		t.Fatal(err)
@@ -224,19 +214,22 @@ func TestStartFallsBackToDetachedDaemonWhenManagedStopFailsButDaemonIsDead(t *te
 	checks := 0
 	daemonHealthCheck = func(*paths.Paths) (bool, error) {
 		checks++
-		return checks >= 4, nil
+		return false, nil
 	}
 
-	if err := Start(p); err != nil {
-		t.Fatalf("Start should fall back to detached mode when managed stop fails but daemon is dead: %v", err)
+	err := Start(p)
+	if err == nil {
+		t.Fatal("Start should return the managed stop error")
 	}
-
-	if _, err := os.Stat(p.DaemonLog()); err != nil {
-		t.Fatalf("detached fallback should open daemon log: %v", err)
+	if !strings.Contains(err.Error(), "stop managed daemon before detached fallback") {
+		t.Fatalf("Start error = %v, want managed stop failure", err)
 	}
-	_ = os.Remove(p.DaemonLog())
-	_ = os.Remove(p.PIDFile())
-	_ = os.Remove(p.Socket())
+	if !strings.Contains(err.Error(), "Unit not loaded") {
+		t.Fatalf("Start error = %v, want original stop error", err)
+	}
+	if checks < 2 {
+		t.Fatalf("expected health checks before and after managed stop failure, got %d", checks)
+	}
 }
 
 func TestStartReturnsManagedStopErrorWhenFallbackCleanupFails(t *testing.T) {

--- a/internal/daemon/service_test.go
+++ b/internal/daemon/service_test.go
@@ -277,6 +277,52 @@ func TestStartReturnsManagedStopErrorWhenFallbackCleanupFails(t *testing.T) {
 	}
 }
 
+func TestStartRemovesLaunchAgentBeforeDetachedFallbackAfterBootoutESRCH(t *testing.T) {
+	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+
+	cleanup := stubServiceRuntime(t)
+	defer cleanup()
+	t.Setenv("NM_DAEMON_HELPER_PROCESS", "1")
+	runtimeGOOS = "darwin"
+	serviceUserHomeDir = func() (string, error) { return home, nil }
+	serviceCurrentUser = func() (*user.User, error) { return &user.User{Uid: "501"}, nil }
+	serviceExecutablePath = func() (string, error) { return "/opt/no-mistakes/bin/no-mistakes", nil }
+
+	serviceCommandRunner = func(name string, args ...string) ([]byte, error) {
+		command := name + " " + strings.Join(args, " ")
+		switch command {
+		case "launchctl bootout gui/501/" + launchdServiceLabel(p):
+			return []byte("Boot-out failed: 3: No such process"), fmt.Errorf("exit status 3: Boot-out failed: 3: No such process")
+		case "launchctl bootstrap gui/501 " + launchAgentPath(p):
+			return nil, nil
+		case "launchctl kickstart -k gui/501/" + launchdServiceLabel(p):
+			return nil, fmt.Errorf("launchctl kickstart failed")
+		default:
+			return nil, nil
+		}
+	}
+	checks := 0
+	daemonHealthCheck = func(*paths.Paths) (bool, error) {
+		checks++
+		return checks >= 3, nil
+	}
+
+	if err := Start(p); err != nil {
+		t.Fatalf("Start should fall back to detached mode: %v", err)
+	}
+
+	if _, err := os.Stat(launchAgentPath(p)); !os.IsNotExist(err) {
+		t.Fatalf("launch agent plist should be removed before detached fallback, stat err = %v", err)
+	}
+	_ = os.Remove(p.DaemonLog())
+	_ = os.Remove(p.PIDFile())
+	_ = os.Remove(p.Socket())
+}
+
 func TestStopUsesManagedServiceWhenInstalled(t *testing.T) {
 	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
 	if err := p.EnsureDirs(); err != nil {

--- a/internal/daemon/service_test.go
+++ b/internal/daemon/service_test.go
@@ -239,6 +239,51 @@ func TestStartFallsBackToDetachedDaemonWhenManagedStopFailsButDaemonIsDead(t *te
 	_ = os.Remove(p.Socket())
 }
 
+func TestStartReturnsManagedStopErrorWhenFallbackCleanupFails(t *testing.T) {
+	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+
+	cleanup := stubServiceRuntime(t)
+	defer cleanup()
+	t.Setenv("NM_DAEMON_HELPER_PROCESS", "1")
+	runtimeGOOS = "linux"
+	serviceUserHomeDir = func() (string, error) { return home, nil }
+	serviceExecutablePath = func() (string, error) { return "/usr/local/bin/no-mistakes", nil }
+
+	serviceCommandRunner = func(name string, args ...string) ([]byte, error) {
+		command := name + " " + strings.Join(args, " ")
+		if command == "systemctl --user start "+systemdServiceName(p) {
+			return nil, fmt.Errorf("user manager unavailable")
+		}
+		if command == "systemctl --user stop "+systemdServiceName(p) {
+			return nil, fmt.Errorf("permission denied")
+		}
+		return nil, nil
+	}
+	checks := 0
+	daemonHealthCheck = func(*paths.Paths) (bool, error) {
+		checks++
+		return false, nil
+	}
+
+	err := Start(p)
+	if err == nil {
+		t.Fatal("Start should return the managed stop error")
+	}
+	if !strings.Contains(err.Error(), "stop managed daemon before detached fallback") {
+		t.Fatalf("Start error = %v, want managed stop failure", err)
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("Start error = %v, want original stop error", err)
+	}
+	if checks < 2 {
+		t.Fatalf("expected health checks before and after managed stop failure, got %d", checks)
+	}
+}
+
 func TestStopUsesManagedServiceWhenInstalled(t *testing.T) {
 	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
 	if err := p.EnsureDirs(); err != nil {


### PR DESCRIPTION
## Summary
- Treat managed-service stop failures more precisely during daemon startup fallback: ignore launchd `bootout` "No such process" cases that already mean the service is stopped, but keep surfacing real stop/cleanup errors instead of suppressing them.
- Restrict the detached fallback path on macOS to the launchd ESRCH case and remove the LaunchAgent plist before falling back, so the detached daemon does not leave stale managed-service registration behind.
- Add daemon tests covering launchd bootout ESRCH handling, launchd plist cleanup before detached fallback, and managed-stop error propagation during fallback startup.

## Risk Assessment

🚨 High: The patch is small, but on macOS it changes fallback behavior from a temporary recovery path into a persistent uninstall of the managed service, which is a user-visible lifecycle change that should not merge without explicit approval.

## Testing

- Summary: <code>Exercised the new managed-stop fallback paths with focused daemon tests and then reran the full `internal/daemon` package; everything passed on the target commit.</code>
- `go test ./internal/daemon -run 'TestStopLaunchAgentTreatsBootoutNotLoadedAsSuccess|TestStartReturnsManagedStopErrorWhenSystemdStopSaysNotLoaded|TestStartReturnsManagedStopErrorWhenFallbackCleanupFails|TestStartRemovesLaunchAgentBeforeDetachedFallbackAfterBootoutESRCH' -count=1`
- `go test ./internal/daemon -count=1`
- Outcome: ✅ passed across 1 run (1m7s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/daemon/selfexec.go:76` - `stopManagedFallback` now deletes the LaunchAgent plist before starting the detached daemon. Any transient managed-start failure or health-check timeout on macOS will therefore silently unregister login/reboot auto-start for this `NM_HOME`, and a subsequent detached-start failure leaves the install stopped with no managed service left to recover on the next session.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/daemon -run 'TestStopLaunchAgentTreatsBootoutNotLoadedAsSuccess|TestStartReturnsManagedStopErrorWhenSystemdStopSaysNotLoaded|TestStartReturnsManagedStopErrorWhenFallbackCleanupFails|TestStartRemovesLaunchAgentBeforeDetachedFallbackAfterBootoutESRCH' -count=1`
- `go test ./internal/daemon -count=1`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
