### PR TITLE
feat(wizard): show setup progress in terminal title

### DIFF
--- a/docs/src/content/docs/guides/setup-wizard.md
+++ b/docs/src/content/docs/guides/setup-wizard.md
@@ -42,6 +42,8 @@ flowchart TD
 
 The interactive wizard is a full-screen flow that runs only the steps your current repo state needs, up to three total. The `-y` / `--yes` path runs the same steps and accepts the automated default at each one. In a TTY, the TUI stays visible and auto-advances. Without a TTY, it runs headlessly.
 
+While the wizard is running, it also updates your terminal window title with the current setup step and branch. On exit or cancel, it clears that temporary title.
+
 ### 1. Branch
 
 Shown when you're on the default branch or a detached `HEAD`. Prompts for a branch name.

--- a/internal/wizard/view.go
+++ b/internal/wizard/view.go
@@ -46,6 +46,7 @@ func (m Model) View() string {
 	box := renderBox("Setup", strings.TrimRight(content.String(), "\n"), width)
 
 	var out strings.Builder
+	out.WriteString(setTerminalTitle(m.terminalTitle()))
 	out.WriteString(box)
 	out.WriteString("\n")
 

--- a/internal/wizard/view_test.go
+++ b/internal/wizard/view_test.go
@@ -137,6 +137,93 @@ func TestView_InlineInputFitsInsideBoxAtMinimumWidth(t *testing.T) {
 	}
 }
 
+func TestView_EmitsTerminalTitleEscapeSequence(t *testing.T) {
+	m := NewModel(baseConfig(&recorder{}))
+	m.width = 80
+	out := m.View()
+	if !strings.HasPrefix(out, "\x1b]2;") {
+		t.Fatalf("expected View output to start with OSC 2 terminal title sequence, got: %q", out[:min(40, len(out))])
+	}
+	// Title must end with BEL before the rest of the rendered UI.
+	end := strings.Index(out, "\x07")
+	if end < 0 {
+		t.Fatalf("expected BEL terminator in terminal title sequence, got: %q", out)
+	}
+}
+
+func TestTerminalTitle_BranchInputIncludesCurrentBranch(t *testing.T) {
+	m := NewModel(baseConfig(&recorder{}))
+	got := m.terminalTitle()
+	if !strings.Contains(got, "Branch") {
+		t.Fatalf("expected title to mention Branch step, got: %q", got)
+	}
+	if !strings.Contains(got, "main") {
+		t.Fatalf("expected title to mention current branch %q, got: %q", "main", got)
+	}
+	if !strings.Contains(got, "Setup") {
+		t.Fatalf("expected title to include Setup prefix, got: %q", got)
+	}
+}
+
+func TestTerminalTitle_PushConfirmUsesTargetBranch(t *testing.T) {
+	cfg := baseConfig(&recorder{})
+	cfg.CurrentBranch = "feat/x"
+	cfg.NeedsBranch = false
+	cfg.IsDirty = false
+	m := NewModel(cfg)
+	got := m.terminalTitle()
+	if !strings.Contains(got, "Push") {
+		t.Fatalf("expected title to mention Push step, got: %q", got)
+	}
+	if !strings.Contains(got, "feat/x") {
+		t.Fatalf("expected title to include target branch, got: %q", got)
+	}
+}
+
+func TestTerminalTitle_SuccessShowsComplete(t *testing.T) {
+	m := NewModel(baseConfig(&recorder{}))
+	m.success = true
+	m.pushed = true
+	m.targetBranch = "feat/done"
+	got := m.terminalTitle()
+	if !strings.Contains(got, "complete") {
+		t.Fatalf("expected title to indicate completion, got: %q", got)
+	}
+	if !strings.Contains(got, "feat/done") {
+		t.Fatalf("expected title to include target branch on success, got: %q", got)
+	}
+}
+
+func TestTerminalTitle_AbortedShowsAborted(t *testing.T) {
+	m := NewModel(baseConfig(&recorder{}))
+	m.aborted = true
+	got := m.terminalTitle()
+	if !strings.Contains(got, "aborted") {
+		t.Fatalf("expected title to indicate aborted, got: %q", got)
+	}
+}
+
+func TestTerminalTitle_FailedShowsStepName(t *testing.T) {
+	m := NewModel(baseConfig(&recorder{}))
+	m.steps[0].status = statFailed
+	m.steps[0].errMsg = "boom"
+	got := m.terminalTitle()
+	if !strings.Contains(got, "Branch") {
+		t.Fatalf("expected failed title to mention failing step, got: %q", got)
+	}
+	if !strings.Contains(got, "✗") {
+		t.Fatalf("expected failed title to include ✗ icon, got: %q", got)
+	}
+}
+
+func TestSetTerminalTitle_FormatsOSCSequence(t *testing.T) {
+	got := setTerminalTitle("hello")
+	want := "\x1b]2;hello\x07"
+	if got != want {
+		t.Fatalf("setTerminalTitle: got %q, want %q", got, want)
+	}
+}
+
 func TestView_RendersTransientStatusInlineWithStep(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -25,13 +27,15 @@ type Config struct {
 	DefaultBranch string
 	// AutoAdvance automatically presses Enter on each active wizard step,
 	// preserving the interactive TUI while accepting the default path.
-	AutoAdvance bool
-	// NeedsBranch is true when the user has no usable feature branch yet —
+	AutoAdvance  bool
+	DisableInput bool
+	// NeedsBranch is true when the user has no usable feature branch yet -
 	// either they're on the default branch, or HEAD is detached. The branch
 	// step is only active when this is true.
 	NeedsBranch bool
 	IsDirty     bool
 	GateRemote  string
+	Output      io.Writer
 
 	CreateBranch  func(ctx context.Context, name string) error
 	CommitAll     func(ctx context.Context, msg string) error
@@ -524,6 +528,13 @@ func quitWithTitleReset() tea.Cmd {
 	return tea.Sequence(tea.SetWindowTitle(""), tea.Quit)
 }
 
+func resetTerminalTitle(output io.Writer) {
+	if output == nil {
+		output = os.Stdout
+	}
+	_, _ = io.WriteString(output, setTerminalTitle(""))
+}
+
 func (m Model) track(action string, fields map[string]any) {
 	if m.cfg.Track == nil {
 		return
@@ -636,7 +647,15 @@ func Run(cfg Config) (Result, error) {
 		return Result{Err: err}, err
 	}
 	m := NewModel(cfg)
-	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithContext(baseCtx))
+	options := []tea.ProgramOption{tea.WithAltScreen(), tea.WithContext(baseCtx)}
+	if cfg.DisableInput {
+		options = append(options, tea.WithInput(nil))
+	}
+	if cfg.Output != nil {
+		options = append(options, tea.WithOutput(cfg.Output))
+	}
+	defer resetTerminalTitle(cfg.Output)
+	p := tea.NewProgram(m, options...)
 	final, err := p.Run()
 	if err != nil {
 		return Result{Err: err}, err

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -261,7 +261,7 @@ func (m Model) setupActive() Model {
 // afterEnterCmd returns the Cmd to kick off after transitioning to a new step.
 func (m Model) afterEnterCmd() tea.Cmd {
 	if m.quitting {
-		return tea.Quit
+		return quitWithTitleReset()
 	}
 	s := m.activeStep()
 	if s != nil && m.cfg.AutoAdvance && (s.status == statInput || s.status == statConfirm) {
@@ -294,7 +294,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Already finished; any key quits.
 		m.quitting = true
 		m.cancel()
-		return m, tea.Quit
+		return m, quitWithTitleReset()
 	}
 
 	switch msg.String() {
@@ -303,7 +303,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.aborted = true
 		m.quitting = true
 		m.cancel()
-		return m, tea.Quit
+		return m, quitWithTitleReset()
 	case "q":
 		if m.hasSideEffects() && !m.confirmQuit {
 			m.confirmQuit = true
@@ -313,7 +313,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.aborted = true
 		m.quitting = true
 		m.cancel()
-		return m, tea.Quit
+		return m, quitWithTitleReset()
 	}
 
 	// Any non-q key clears the abort confirmation.
@@ -360,7 +360,7 @@ func (m Model) handleConfirmKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.aborted = true
 		m.quitting = true
 		m.cancel()
-		return m, tea.Quit
+		return m, quitWithTitleReset()
 	}
 	return m, nil
 }
@@ -407,7 +407,7 @@ func (m Model) handleSuggestion(msg suggestionMsg) (tea.Model, tea.Cmd) {
 			m.err = wrappedErr
 			m.quitting = true
 			m.cancel()
-			return m, tea.Quit
+			return m, quitWithTitleReset()
 		}
 		// Fall back to asking the user to type.
 		s.status = statInput
@@ -433,7 +433,7 @@ func (m Model) handleAction(msg actionMsg) (tea.Model, tea.Cmd) {
 			m.err = wrappedErr
 			m.quitting = true
 			m.cancel()
-			return m, tea.Quit
+			return m, quitWithTitleReset()
 		}
 		return m, nil
 	}
@@ -457,6 +457,71 @@ func (m Model) handleAction(msg actionMsg) (tea.Model, tea.Cmd) {
 
 func (m Model) hasSideEffects() bool {
 	return m.branchCreated || m.commitMade
+}
+
+// terminalTitle returns the terminal title string reflecting wizard state.
+// Format mirrors internal/tui: "<icon> Setup <step> - <branch>".
+func (m Model) terminalTitle() string {
+	branch := m.targetBranch
+	if branch == "" {
+		branch = m.cfg.CurrentBranch
+	}
+	suffix := ""
+	if branch != "" {
+		suffix = " - " + branch
+	}
+
+	switch {
+	case m.success:
+		return "✓ Setup complete" + suffix
+	case m.aborted:
+		return "✗ Setup aborted" + suffix
+	}
+
+	for _, s := range m.steps {
+		if s.status == statFailed {
+			return "✗ Setup " + stepLabel(s.id) + suffix
+		}
+	}
+
+	s := m.activeStep()
+	if s == nil {
+		return "○ Setup" + suffix
+	}
+	icon := stepTitleIcon(s.status, m.spinnerFrame)
+	return icon + " Setup " + stepLabel(s.id) + suffix
+}
+
+// stepTitleIcon returns a plain-text icon suitable for use in the terminal
+// title bar. It mirrors the visual icons in stepIconAndStyle but without
+// lipgloss styling, since terminal titles can't render ANSI.
+func stepTitleIcon(status stepStatus, spinnerFrame int) string {
+	switch status {
+	case statDone:
+		return "✓"
+	case statSkipped:
+		return "–"
+	case statFailed:
+		return "✗"
+	case statAgent, statRunning:
+		if len(spinnerFrames) == 0 {
+			return "◉"
+		}
+		return spinnerFrames[spinnerFrame%len(spinnerFrames)]
+	case statInput, statConfirm:
+		return "⏸"
+	}
+	return "○"
+}
+
+// setTerminalTitle returns the OSC escape sequence to set the terminal title.
+func setTerminalTitle(title string) string {
+	return "\x1b]2;" + title + "\x07"
+}
+
+// quitWithTitleReset clears the terminal title via bubbletea, then quits.
+func quitWithTitleReset() tea.Cmd {
+	return tea.Sequence(tea.SetWindowTitle(""), tea.Quit)
 }
 
 func (m Model) track(action string, fields map[string]any) {

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -27,7 +27,7 @@ type Config struct {
 	DefaultBranch string
 	// AutoAdvance automatically presses Enter on each active wizard step,
 	// preserving the interactive TUI while accepting the default path.
-	AutoAdvance  bool
+	AutoAdvance bool
 	// DisableInput disables Bubble Tea input, which is useful for headless runs
 	// and tests that drive cancellation through the caller context.
 	DisableInput bool
@@ -39,7 +39,7 @@ type Config struct {
 	GateRemote  string
 	// Output overrides the Bubble Tea output writer and is also used for the
 	// terminal-title reset sequence emitted when the wizard shuts down.
-	Output      io.Writer
+	Output io.Writer
 
 	CreateBranch  func(ctx context.Context, name string) error
 	CommitAll     func(ctx context.Context, msg string) error

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -28,6 +28,8 @@ type Config struct {
 	// AutoAdvance automatically presses Enter on each active wizard step,
 	// preserving the interactive TUI while accepting the default path.
 	AutoAdvance  bool
+	// DisableInput disables Bubble Tea input, which is useful for headless runs
+	// and tests that drive cancellation through the caller context.
 	DisableInput bool
 	// NeedsBranch is true when the user has no usable feature branch yet -
 	// either they're on the default branch, or HEAD is detached. The branch
@@ -35,6 +37,8 @@ type Config struct {
 	NeedsBranch bool
 	IsDirty     bool
 	GateRemote  string
+	// Output overrides the Bubble Tea output writer and is also used for the
+	// terminal-title reset sequence emitted when the wizard shuts down.
 	Output      io.Writer
 
 	CreateBranch  func(ctx context.Context, name string) error

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -1,6 +1,7 @@
 package wizard
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"strings"
@@ -534,6 +535,43 @@ func TestRun_UsesCallerContext(t *testing.T) {
 	}
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Run() error = %v, want wrapped context.Canceled", err)
+	}
+}
+
+func TestRun_ContextCancelResetsTerminalTitle(t *testing.T) {
+	var out bytes.Buffer
+	cfg := baseConfig(&recorder{})
+	cfg.CurrentBranch = "feat/existing"
+	cfg.NeedsBranch = false
+	cfg.IsDirty = false
+	cfg.DisableInput = true
+	cfg.Output = &out
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cfg.Context = ctx
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := Run(cfg)
+	if err == nil {
+		t.Fatal("expected Run to fail when caller context is canceled")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run() error = %v, want wrapped context.Canceled", err)
+	}
+
+	initialTitle := setTerminalTitle("⏸ Setup Push - feat/existing")
+	resetTitle := setTerminalTitle("")
+	if !strings.Contains(out.String(), initialTitle) {
+		t.Fatalf("expected wizard output to include initial title sequence, got %q", out.String())
+	}
+	if !strings.Contains(out.String(), resetTitle) {
+		t.Fatalf("expected wizard output to include title reset sequence on context cancel, got %q", out.String())
+	}
+	if strings.LastIndex(out.String(), resetTitle) < strings.Index(out.String(), initialTitle) {
+		t.Fatalf("expected title reset to be emitted after initial title, got %q", out.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Update the setup wizard to write the current step and branch to the terminal title so progress stays visible outside the TUI.
- Reset the terminal title when the wizard exits or is canceled, avoiding stale titles after interrupted runs.
- Document the terminal-title behavior and add wizard coverage for title emission and cleanup paths.

## Risk Assessment

✅ Low: The change is narrowly scoped to wizard terminal-title updates and reset handling, and the implementation aligns with the existing TUI title pattern without exposing a clear correctness or safety issue in the changed code.

## Testing

- Summary: Exercised the wizard terminal-title rendering and reset behavior, including context-cancel and quit flows, and all relevant wizard tests passed.
- `go test ./internal/wizard -run 'Test(View_EmitsTerminalTitleEscapeSequence|TerminalTitle_|SetTerminalTitle_|Run_ContextCancelResetsTerminalTitle)$' -count=1`
- `go test ./internal/wizard -count=1`
- `go test ./internal/wizard -run 'TestQuit_|TestConfirmQuit_|TestHandleKey_CtrlCAborts$' -count=1`
- Outcome: ✅ passed across 1 run (1m5s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/wizard -run 'Test(View_EmitsTerminalTitleEscapeSequence|TerminalTitle_|SetTerminalTitle_|Run_ContextCancelResetsTerminalTitle)$' -count=1`
- `go test ./internal/wizard -count=1`
- `go test ./internal/wizard -run 'TestQuit_|TestConfirmQuit_|TestHandleKey_CtrlCAborts$' -count=1`

</details>

<details>
<summary>🔧 **Document** - 3 issues found → auto-fixed</summary>

**Round 1** - found 3 infos
- ℹ️ `docs/src/content/docs/guides/setup-wizard.md:41` - The setup-wizard guide documents the interactive flow but does not mention the new terminal-title behavior. This change now updates the terminal/window title with the current setup step and branch, and clears it again on exit or cancellation, so the wizard guide should note that new user-visible behavior.
- ℹ️ `internal/wizard/wizard.go:31` - The new exported `Config.DisableInput` field was added without a field comment, while the surrounding `Config` fields are documented. Add a doc comment explaining that it disables Bubble Tea input for headless or test-driven runs.
- ℹ️ `internal/wizard/wizard.go:38` - The new exported `Config.Output` field was added without a field comment. Document that it overrides the Bubble Tea output writer and is also where the wizard writes the terminal-title reset sequence on shutdown.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>🔧 **Lint** - 2 issues found → auto-fixed</summary>

**Round 1** - found 2 warnings
- ⚠️ `internal/wizard/wizard.go:27` - `gofmt` reports misaligned struct field spacing in `WizardOptions`; the file is not formatted according to the repository&#39;s configured Go formatter.
- ⚠️ `internal/wizard/wizard.go:39` - `gofmt` reports additional misaligned struct field spacing near the `Output` field; the file is not formatted according to the repository&#39;s configured Go formatter.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
