### PR TITLE
feat(cli): cache wizard commit subject from branch suggestions

### DIFF
--- a/internal/agent/suggest.go
+++ b/internal/agent/suggest.go
@@ -7,14 +7,26 @@ import (
 	"strings"
 )
 
+// branchNameRules and commitSubjectRules are shared between the single-purpose
+// prompts and the combined prompt so behavior stays in lock-step. The commit
+// rules mirror the PR title rules in internal/pipeline/steps/pr.go so a commit
+// made through the wizard and the PR title generated later feel consistent.
+const branchNameRules = `- Use kebab-case.
+- Prefer a conventional prefix: "feat/", "fix/", "chore/", "refactor/", "docs/", or "test/".
+- Keep it under 40 characters.`
+
+const commitSubjectRules = `- One line only, under 72 characters.
+- Use conventional commit format: "type(scope): description" or "type: description". Valid types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert. Scope is optional. Do not capitalize the type.
+- When including a scope, it MUST be a real package/module name that exists in the codebase (for example, a directory under internal/, cmd/, or the equivalent top-level grouping for this project), identified by inspecting the changed paths. Pick the primary module affected by the change, not a secondary or incidental one.
+- Keep the scope at a coarse level, not too granular: a codebase typically has fewer than 10 distinct scopes in use across its history. Prefer a broad module name (e.g. "daemon", "pipeline", "cli") over a narrow file or sub-feature name. If you cannot confidently identify a real primary module, omit the scope and use "type: description".
+- Do not invent behavior.`
+
 const branchNamePrompt = `Suggest a short, descriptive git branch name for the current working-tree changes in this repository.
 
 Inspect the state yourself (e.g. git status, git diff HEAD, git diff --staged) in the working directory.
 
 Rules:
-- Use kebab-case.
-- Prefer a conventional prefix: "feat/", "fix/", "chore/", "refactor/", "docs/", or "test/".
-- Keep it under 40 characters.
+` + branchNameRules + `
 - Return JSON: {"name":"..."}`
 
 const commitSubjectPrompt = `Suggest a conventional commit subject line summarizing the current working-tree changes.
@@ -22,10 +34,20 @@ const commitSubjectPrompt = `Suggest a conventional commit subject line summariz
 Inspect the state yourself (e.g. git status, git diff HEAD, git diff --staged) in the working directory.
 
 Rules:
-- One line only.
-- Use conventional commit style: "type(scope): description".
-- Keep it under 72 characters.
+` + commitSubjectRules + `
 - Return JSON: {"subject":"..."}`
+
+const branchAndCommitPrompt = `Suggest a git branch name and a conventional commit subject for the current working-tree changes in this repository.
+
+Inspect the state yourself (e.g. git status, git diff HEAD, git diff --staged) in the working directory.
+
+Branch name rules:
+` + branchNameRules + `
+
+Commit subject rules:
+` + commitSubjectRules + `
+
+Return JSON: {"branch":"...","subject":"..."}`
 
 var branchNameSchema = json.RawMessage(`{
 	"type": "object",
@@ -43,11 +65,25 @@ var commitSubjectSchema = json.RawMessage(`{
 	"required": ["subject"]
 }`)
 
+var branchAndCommitSchema = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"branch": {"type": "string"},
+		"subject": {"type": "string"}
+	},
+	"required": ["branch", "subject"]
+}`)
+
 type branchSuggestion struct {
 	Name string `json:"name"`
 }
 
 type commitSuggestion struct {
+	Subject string `json:"subject"`
+}
+
+type branchAndCommitSuggestion struct {
+	Branch  string `json:"branch"`
 	Subject string `json:"subject"`
 }
 
@@ -72,6 +108,36 @@ func SuggestBranchName(ctx context.Context, ag Agent, dir string) (string, error
 		return "", fmt.Errorf("agent returned empty or unusable branch name")
 	}
 	return name, nil
+}
+
+// SuggestBranchAndCommit asks the agent to propose both a git branch name and
+// a conventional commit subject for the current working-tree state in a
+// single call. Combining the two saves one full agent round-trip when the
+// wizard needs both (new branch + dirty tree).
+//
+// The branch name must be present and sanitizes to a valid git ref; otherwise
+// an error is returned. The commit subject is best-effort: if the agent
+// returns an empty subject, this function returns an empty string with no
+// error so the caller can fall back to SuggestCommitMessage.
+func SuggestBranchAndCommit(ctx context.Context, ag Agent, dir string) (branch, subject string, err error) {
+	result, err := ag.Run(ctx, RunOpts{
+		Prompt:     branchAndCommitPrompt,
+		CWD:        dir,
+		JSONSchema: branchAndCommitSchema,
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("suggest branch and commit: %w", err)
+	}
+	var parsed branchAndCommitSuggestion
+	if err := unmarshalSuggestion(result, &parsed); err != nil {
+		return "", "", fmt.Errorf("parse branch and commit suggestion: %w", err)
+	}
+	branch = sanitizeBranchName(parsed.Branch)
+	if branch == "" {
+		return "", "", fmt.Errorf("agent returned empty or unusable branch name")
+	}
+	subject = sanitizeCommitSubject(parsed.Subject)
+	return branch, subject, nil
 }
 
 // SuggestCommitMessage asks the agent to propose a single-line commit subject

--- a/internal/agent/suggest_test.go
+++ b/internal/agent/suggest_test.go
@@ -180,6 +180,81 @@ func TestSuggestCommitMessageEmpty(t *testing.T) {
 	}
 }
 
+func TestSuggestBranchAndCommit(t *testing.T) {
+	ag := &stubAgent{result: &Result{
+		Output: json.RawMessage(`{"branch":"feat/onboarding-wizard","subject":"feat(cli): add onboarding wizard"}`),
+	}}
+	branch, subject, err := SuggestBranchAndCommit(context.Background(), ag, "/tmp/repo")
+	if err != nil {
+		t.Fatalf("SuggestBranchAndCommit failed: %v", err)
+	}
+	if branch != "feat/onboarding-wizard" {
+		t.Fatalf("expected feat/onboarding-wizard, got %q", branch)
+	}
+	if subject != "feat(cli): add onboarding wizard" {
+		t.Fatalf("expected commit subject, got %q", subject)
+	}
+	if ag.gotCWD != "/tmp/repo" {
+		t.Fatalf("expected CWD to be forwarded, got %q", ag.gotCWD)
+	}
+	if len(ag.gotSchema) == 0 {
+		t.Fatal("expected JSONSchema to be set on RunOpts")
+	}
+	if ag.gotPrompt == "" {
+		t.Fatal("expected prompt to be non-empty")
+	}
+}
+
+func TestSuggestBranchAndCommitSanitizes(t *testing.T) {
+	ag := &stubAgent{result: &Result{
+		Output: json.RawMessage(`{"branch":"FEAT/New Thing","subject":"feat(cli): clean up thing\n\nbody paragraph"}`),
+	}}
+	branch, subject, err := SuggestBranchAndCommit(context.Background(), ag, "/tmp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if branch != "feat/new-thing" {
+		t.Fatalf("expected branch to be sanitized, got %q", branch)
+	}
+	if subject != "feat(cli): clean up thing" {
+		t.Fatalf("expected first-line commit subject, got %q", subject)
+	}
+}
+
+func TestSuggestBranchAndCommitEmptyBranchErrors(t *testing.T) {
+	ag := &stubAgent{result: &Result{
+		Output: json.RawMessage(`{"branch":"","subject":"feat: something"}`),
+	}}
+	if _, _, err := SuggestBranchAndCommit(context.Background(), ag, "/tmp"); err == nil {
+		t.Fatal("expected error when branch is empty")
+	}
+}
+
+func TestSuggestBranchAndCommitEmptySubjectReturnsBranch(t *testing.T) {
+	// An empty commit subject is tolerated: callers can fall back to a
+	// dedicated SuggestCommitMessage call rather than failing the wizard.
+	ag := &stubAgent{result: &Result{
+		Output: json.RawMessage(`{"branch":"fix/bug","subject":""}`),
+	}}
+	branch, subject, err := SuggestBranchAndCommit(context.Background(), ag, "/tmp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if branch != "fix/bug" {
+		t.Fatalf("expected fix/bug, got %q", branch)
+	}
+	if subject != "" {
+		t.Fatalf("expected empty subject, got %q", subject)
+	}
+}
+
+func TestSuggestBranchAndCommitAgentError(t *testing.T) {
+	ag := &stubAgent{err: errors.New("boom")}
+	if _, _, err := SuggestBranchAndCommit(context.Background(), ag, "/tmp"); err == nil {
+		t.Fatal("expected error from agent failure")
+	}
+}
+
 func jsonQuote(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -44,6 +44,12 @@ type wizardAgentSuggester struct {
 	once sync.Once
 	ag   agent.Agent
 	err  error
+
+	// cachedCommit holds a commit subject returned as a side-effect of the
+	// branch-name agent call, so the commit step can consume it without
+	// spending another full agent round-trip. Consumed on first read.
+	cacheMu      sync.Mutex
+	cachedCommit string
 }
 
 func newWizardAgentSuggester(cfg *config.Config, workDir string, resolve func(context.Context, *config.Config) error, new func(types.AgentName, string) (agent.Agent, error)) *wizardAgentSuggester {
@@ -76,10 +82,26 @@ func (s *wizardAgentSuggester) suggestBranch(ctx context.Context) (string, error
 	if err := s.ensure(ctx); err != nil {
 		return "", err
 	}
-	return agent.SuggestBranchName(ctx, s.ag, s.workDir)
+	branch, commit, err := agent.SuggestBranchAndCommit(ctx, s.ag, s.workDir)
+	if err != nil {
+		return "", err
+	}
+	if commit != "" {
+		s.cacheMu.Lock()
+		s.cachedCommit = commit
+		s.cacheMu.Unlock()
+	}
+	return branch, nil
 }
 
 func (s *wizardAgentSuggester) suggestCommit(ctx context.Context) (string, error) {
+	s.cacheMu.Lock()
+	cached := s.cachedCommit
+	s.cachedCommit = ""
+	s.cacheMu.Unlock()
+	if cached != "" {
+		return cached, nil
+	}
 	if err := s.ensure(ctx); err != nil {
 		return "", err
 	}

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -95,9 +95,14 @@ func (s *wizardAgentSuggester) suggestBranch(ctx context.Context) (string, error
 }
 
 func (s *wizardAgentSuggester) suggestCommit(ctx context.Context) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
 	s.cacheMu.Lock()
 	cached := s.cachedCommit
-	s.cachedCommit = ""
+	if cached != "" {
+		s.cachedCommit = ""
+	}
 	s.cacheMu.Unlock()
 	if cached != "" {
 		return cached, nil

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -82,15 +82,16 @@ func (s *wizardAgentSuggester) suggestBranch(ctx context.Context) (string, error
 	if err := s.ensure(ctx); err != nil {
 		return "", err
 	}
+	s.cacheMu.Lock()
+	s.cachedCommit = ""
+	s.cacheMu.Unlock()
 	branch, commit, err := agent.SuggestBranchAndCommit(ctx, s.ag, s.workDir)
 	if err != nil {
 		return "", err
 	}
-	if commit != "" {
-		s.cacheMu.Lock()
-		s.cachedCommit = commit
-		s.cacheMu.Unlock()
-	}
+	s.cacheMu.Lock()
+	s.cachedCommit = commit
+	s.cacheMu.Unlock()
 	return branch, nil
 }
 

--- a/internal/cli/wizard_test.go
+++ b/internal/cli/wizard_test.go
@@ -2,11 +2,15 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 
+	"github.com/kunchenguid/no-mistakes/internal/agent"
 	"github.com/kunchenguid/no-mistakes/internal/config"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
 	"github.com/kunchenguid/no-mistakes/internal/telemetry"
@@ -98,6 +102,114 @@ func TestWizardAgentSuggester_IsLazy(t *testing.T) {
 	}
 	if lookups != 1 {
 		t.Fatalf("expected one lazy resolution attempt, got %d", lookups)
+	}
+}
+
+type fakeSuggesterAgent struct {
+	mu    sync.Mutex
+	calls []agent.RunOpts
+}
+
+func (f *fakeSuggesterAgent) Name() string { return "fake" }
+func (f *fakeSuggesterAgent) Run(_ context.Context, opts agent.RunOpts) (*agent.Result, error) {
+	f.mu.Lock()
+	f.calls = append(f.calls, opts)
+	f.mu.Unlock()
+	if strings.Contains(opts.Prompt, "Branch name rules") {
+		return &agent.Result{
+			Output: json.RawMessage(`{"branch":"feat/auto","subject":"feat(cli): auto thing"}`),
+		}, nil
+	}
+	if strings.Contains(opts.Prompt, `{"subject":"..."}`) {
+		return &agent.Result{
+			Output: json.RawMessage(`{"subject":"feat(cli): standalone"}`),
+		}, nil
+	}
+	return &agent.Result{Output: json.RawMessage(`{}`)}, nil
+}
+func (f *fakeSuggesterAgent) Close() error { return nil }
+
+func (f *fakeSuggesterAgent) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+func newFakeSuggester(t *testing.T, ag *fakeSuggesterAgent) *wizardAgentSuggester {
+	t.Helper()
+	return newWizardAgentSuggester(
+		&config.Config{Agent: types.AgentClaude},
+		"/tmp/repo",
+		func(context.Context, *config.Config) error { return nil },
+		func(types.AgentName, string) (agent.Agent, error) { return ag, nil },
+	)
+}
+
+func TestWizardAgentSuggester_CachesCommitFromBranchCall(t *testing.T) {
+	ag := &fakeSuggesterAgent{}
+	s := newFakeSuggester(t, ag)
+	defer s.Close()
+
+	branch, err := s.suggestBranch(context.Background())
+	if err != nil {
+		t.Fatalf("suggestBranch failed: %v", err)
+	}
+	if branch != "feat/auto" {
+		t.Fatalf("unexpected branch: %q", branch)
+	}
+
+	commit, err := s.suggestCommit(context.Background())
+	if err != nil {
+		t.Fatalf("suggestCommit failed: %v", err)
+	}
+	if commit != "feat(cli): auto thing" {
+		t.Fatalf("expected cached commit, got %q", commit)
+	}
+
+	if got := ag.callCount(); got != 1 {
+		t.Fatalf("expected single combined agent call, got %d", got)
+	}
+}
+
+func TestWizardAgentSuggester_FallsBackToCommitCall(t *testing.T) {
+	// User typed the branch manually, so suggestBranch is never invoked and
+	// the cache stays empty — suggestCommit should fall back to its own call.
+	ag := &fakeSuggesterAgent{}
+	s := newFakeSuggester(t, ag)
+	defer s.Close()
+
+	commit, err := s.suggestCommit(context.Background())
+	if err != nil {
+		t.Fatalf("suggestCommit failed: %v", err)
+	}
+	if commit != "feat(cli): standalone" {
+		t.Fatalf("expected standalone commit, got %q", commit)
+	}
+
+	if got := ag.callCount(); got != 1 {
+		t.Fatalf("expected one standalone agent call, got %d", got)
+	}
+}
+
+func TestWizardAgentSuggester_CacheConsumedOnce(t *testing.T) {
+	// Consuming the cache should reset it so a subsequent commit call goes
+	// back through the agent (guards against stale state if the wizard ever
+	// calls suggestCommit twice).
+	ag := &fakeSuggesterAgent{}
+	s := newFakeSuggester(t, ag)
+	defer s.Close()
+
+	if _, err := s.suggestBranch(context.Background()); err != nil {
+		t.Fatalf("suggestBranch failed: %v", err)
+	}
+	if _, err := s.suggestCommit(context.Background()); err != nil {
+		t.Fatalf("first suggestCommit failed: %v", err)
+	}
+	if _, err := s.suggestCommit(context.Background()); err != nil {
+		t.Fatalf("second suggestCommit failed: %v", err)
+	}
+	if got := ag.callCount(); got != 2 {
+		t.Fatalf("expected combined+standalone agent calls (2), got %d", got)
 	}
 }
 

--- a/internal/cli/wizard_test.go
+++ b/internal/cli/wizard_test.go
@@ -213,6 +213,43 @@ func TestWizardAgentSuggester_CacheConsumedOnce(t *testing.T) {
 	}
 }
 
+func TestWizardAgentSuggester_CanceledContextSkipsCachedCommit(t *testing.T) {
+	ag := &fakeSuggesterAgent{}
+	s := newFakeSuggester(t, ag)
+	defer s.Close()
+
+	if _, err := s.suggestBranch(context.Background()); err != nil {
+		t.Fatalf("suggestBranch failed: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	commit, err := s.suggestCommit(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("suggestCommit error = %v, want %v", err, context.Canceled)
+	}
+	if commit != "" {
+		t.Fatalf("suggestCommit returned %q, want empty commit", commit)
+	}
+
+	if got := ag.callCount(); got != 1 {
+		t.Fatalf("expected no extra agent call, got %d calls", got)
+	}
+
+	commit, err = s.suggestCommit(context.Background())
+	if err != nil {
+		t.Fatalf("subsequent suggestCommit failed: %v", err)
+	}
+	if commit != "feat(cli): auto thing" {
+		t.Fatalf("expected cached commit after retry, got %q", commit)
+	}
+
+	if got := ag.callCount(); got != 1 {
+		t.Fatalf("expected combined agent call only after retry, got %d", got)
+	}
+}
+
 func TestRunWizardTracksPageview(t *testing.T) {
 	recorder := &telemetryRecorder{}
 	restoreTelemetry := telemetry.SetDefaultForTesting(recorder)

--- a/internal/cli/wizard_test.go
+++ b/internal/cli/wizard_test.go
@@ -110,6 +110,13 @@ type fakeSuggesterAgent struct {
 	calls []agent.RunOpts
 }
 
+type fakeSuggesterResponseAgent struct {
+	mu              sync.Mutex
+	combinedOutputs []string
+	commitOutput    string
+	calls           []agent.RunOpts
+}
+
 func (f *fakeSuggesterAgent) Name() string { return "fake" }
 func (f *fakeSuggesterAgent) Run(_ context.Context, opts agent.RunOpts) (*agent.Result, error) {
 	f.mu.Lock()
@@ -130,6 +137,34 @@ func (f *fakeSuggesterAgent) Run(_ context.Context, opts agent.RunOpts) (*agent.
 func (f *fakeSuggesterAgent) Close() error { return nil }
 
 func (f *fakeSuggesterAgent) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+func (f *fakeSuggesterResponseAgent) Name() string { return "fake" }
+
+func (f *fakeSuggesterResponseAgent) Run(_ context.Context, opts agent.RunOpts) (*agent.Result, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, opts)
+	if strings.Contains(opts.Prompt, "Branch name rules") {
+		if len(f.combinedOutputs) == 0 {
+			return &agent.Result{Output: json.RawMessage(`{"branch":"feat/default"}`)}, nil
+		}
+		output := f.combinedOutputs[0]
+		f.combinedOutputs = f.combinedOutputs[1:]
+		return &agent.Result{Output: json.RawMessage(output)}, nil
+	}
+	if strings.Contains(opts.Prompt, `{"subject":"..."}`) {
+		return &agent.Result{Output: json.RawMessage(f.commitOutput)}, nil
+	}
+	return &agent.Result{Output: json.RawMessage(`{}`)}, nil
+}
+
+func (f *fakeSuggesterResponseAgent) Close() error { return nil }
+
+func (f *fakeSuggesterResponseAgent) callCount() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return len(f.calls)
@@ -247,6 +282,42 @@ func TestWizardAgentSuggester_CanceledContextSkipsCachedCommit(t *testing.T) {
 
 	if got := ag.callCount(); got != 1 {
 		t.Fatalf("expected combined agent call only after retry, got %d", got)
+	}
+}
+
+func TestWizardAgentSuggester_EmptyRetryClearsCachedCommit(t *testing.T) {
+	ag := &fakeSuggesterResponseAgent{
+		combinedOutputs: []string{
+			`{"branch":"feat/first","subject":"feat(cli): first"}`,
+			`{"branch":"feat/second"}`,
+		},
+		commitOutput: `{"subject":"feat(cli): standalone"}`,
+	}
+	s := newWizardAgentSuggester(
+		&config.Config{Agent: types.AgentClaude},
+		"/tmp/repo",
+		func(context.Context, *config.Config) error { return nil },
+		func(types.AgentName, string) (agent.Agent, error) { return ag, nil },
+	)
+	defer s.Close()
+
+	if _, err := s.suggestBranch(context.Background()); err != nil {
+		t.Fatalf("first suggestBranch failed: %v", err)
+	}
+	if _, err := s.suggestBranch(context.Background()); err != nil {
+		t.Fatalf("second suggestBranch failed: %v", err)
+	}
+
+	commit, err := s.suggestCommit(context.Background())
+	if err != nil {
+		t.Fatalf("suggestCommit failed: %v", err)
+	}
+	if commit != "feat(cli): standalone" {
+		t.Fatalf("suggestCommit = %q, want standalone subject", commit)
+	}
+
+	if got := ag.callCount(); got != 3 {
+		t.Fatalf("expected two branch calls and one commit call, got %d", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- cache the commit subject returned by the combined branch suggestion flow so the wizard can reuse it when creating a commit, reducing duplicate prompting after branch selection
- make the wizard clear stale cached subjects and honor cancellation before using cached commit text, so retries and cancelled flows do not commit with outdated data
- update agent and wizard coverage for the combined branch-plus-commit suggestion path and its retry/cancellation edge cases

## Risk Assessment

✅ Low: The change is narrowly scoped to wizard suggestion plumbing and cache handling, and the newly added edge-case coverage leaves little remaining ambiguity in the changed code.

## Testing

- Summary: <code>Exercised the modified agent and wizard packages, including their new combined-suggestion and cache-path tests, and all relevant tests passed both normally and with `-race`.</code>
- `go test ./internal/agent`
- `go test ./internal/cli`
- `go test -race ./internal/agent ./internal/cli`
- Outcome: ✅ passed across 1 run (1m6s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2)</summary>

**Round 1** - found 2 warnings
- ⚠️ `internal/agent/suggest.go:74` - `SuggestBranchAndCommit` says the commit subject is best-effort, but the schema makes `subject` required. On schema-enforcing adapters like Claude, a branch suggestion can now fail outright if the model omits `subject`, including flows where the wizard only needs a branch and would have succeeded before.
- ⚠️ `internal/cli/wizard.go:97` - The cached commit path returns without checking `ctx.Err()`. If the caller cancels after the combined branch suggestion completes but before the commit step starts, the wizard can still commit and continue using the cached value instead of aborting on cancellation.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `internal/cli/wizard.go:89` - `cachedCommit` is only updated when the latest combined branch suggestion returns a non-empty subject, so a prior cached subject survives later branch retries that return an empty subject or fail. If the user retries branch suggestion and then continues with a manual branch name, the commit step can reuse a stale subject from an earlier attempt.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/agent`
- `go test ./internal/cli`
- `go test -race ./internal/agent ./internal/cli`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
