### PR TITLE
test: cover CRLF parsing in release workflow tests

### DIFF
--- a/workflow_release_test.go
+++ b/workflow_release_test.go
@@ -159,8 +159,22 @@ func TestReleaseWorkflowPromotesDraftOnlyAfterAssetsComplete(t *testing.T) {
 	}
 }
 
+func TestExtractJobBlockHandlesCRLF(t *testing.T) {
+	lf := "jobs:\n  foo:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo foo\n  bar:\n    runs-on: ubuntu-latest\n"
+	crlf := strings.ReplaceAll(lf, "\n", "\r\n")
+
+	block := extractJobBlock(t, crlf, "foo")
+	if !strings.Contains(block, "echo foo") {
+		t.Fatalf("CRLF block missing foo body: %q", block)
+	}
+	if strings.Contains(block, "bar:") {
+		t.Fatalf("CRLF block must stop before next job: %q", block)
+	}
+}
+
 func extractJobBlock(t *testing.T, content, name string) string {
 	t.Helper()
+	content = strings.ReplaceAll(content, "\r\n", "\n")
 	header := "\n  " + name + ":\n"
 	start := strings.Index(content, header)
 	if start < 0 {


### PR DESCRIPTION
## Summary
- Add regression coverage for `extractJobBlock` when workflow content uses CRLF line endings.
- Keep the release workflow test suite resilient to Windows-style newlines so job-block assertions do not depend on LF-only formatting.

## Risk Assessment

✅ Low: The change is narrowly scoped to test-only CRLF handling in one helper and its coverage, with no material correctness or maintainability issues found in the reviewed diff.

## Testing

- Summary: Exercised the updated release workflow tests, including the new CRLF parsing regression coverage, and the root package test suite passed cleanly.
- `go test -run 'TestReleaseWorkflow|TestExtractJobBlockHandlesCRLF' .`
- `go test .`
- Outcome: ✅ passed across 1 run (44.3s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test -run 'TestReleaseWorkflow|TestExtractJobBlockHandlesCRLF' .`
- `go test .`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
