### PR TITLE
fix(wizard): wait for daemon run before attach handoff

### DIFF
--- a/docs/src/content/docs/guides/setup-wizard.md
+++ b/docs/src/content/docs/guides/setup-wizard.md
@@ -66,7 +66,7 @@ Always shown. Asks whether to push the current branch to the `no-mistakes` gate.
 - Press `y` to push.
 - Press `n` to stop.
 
-If the push succeeds, the wizard hands off to the main TUI and attaches to the new run.
+If the push succeeds, the interactive wizard stays visible in a brief `waiting for run…` state while the daemon registers the new run, then hands off to the main TUI and attaches.
 
 The goal is to keep the setup path short. If you already have a branch, it does
 not ask for one. If everything is already committed, it skips straight to push.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -5,7 +5,7 @@ description: Complete reference for all no-mistakes commands and flags.
 
 ## no-mistakes
 
-Attach to the active pipeline run for the current branch when one exists. If none exists, bare `no-mistakes` can start the setup wizard to create a branch, commit changes, push through the gate, and then attach once the new run appears. By default this wizard path is interactive and only runs in a TTY session. In non-interactive contexts, bare `no-mistakes` falls back to showing the last 5 runs inline unless you pass `-y` or `--yes` to run the wizard and accept defaults automatically. When a TTY is available, `-y` keeps the wizard visible and auto-advances the default path; without a TTY it falls back to the headless path.
+Attach to the active pipeline run for the current branch when one exists. If none exists, bare `no-mistakes` can start the setup wizard to create a branch, commit changes, push through the gate, wait for the daemon to register the new run, and then attach. By default this wizard path is interactive and only runs in a TTY session. In non-interactive contexts, bare `no-mistakes` falls back to showing the last 5 runs inline unless you pass `-y` or `--yes` to run the wizard and accept defaults automatically. When a TTY is available, `-y` keeps the wizard visible, shows a brief `waiting for run…` state after push, and auto-advances the default path; without a TTY it falls back to the headless path.
 
 ```sh
 no-mistakes

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -94,16 +94,29 @@ func attachRun(ctx context.Context, w io.Writer, runID string, rootDefault bool,
 		// existing headless path.
 		interactive := terminalInteractive()
 		if rootDefault && runID == "" && repo != nil && state != nil && (autoYes || interactive) {
+			// waitFn blocks inside the wizard's alt screen until the daemon
+			// has the run registered, so the handoff to runTUI below is
+			// seamless rather than flashing the pre-wizard terminal.
+			waitFn := func(ctx context.Context, branch string) error {
+				r, werr := waitForActiveRun(ctx, client, repo.ID, branch, 5*time.Second)
+				if werr != nil {
+					return werr
+				}
+				if r == nil {
+					return fmt.Errorf("no active run appeared after pushing %q", branch)
+				}
+				return nil
+			}
 			var res wizard.Result
 			var wErr error
 			if autoYes {
 				if interactive {
-					res, wErr = runWizardAutoVisible(ctx, p, state)
+					res, wErr = runWizardAutoVisible(ctx, p, state, waitFn)
 				} else {
-					res, wErr = runWizardAuto(ctx, p, state)
+					res, wErr = runWizardAuto(ctx, p, state, waitFn)
 				}
 			} else {
-				res, wErr = runWizard(ctx, p, state)
+				res, wErr = runWizard(ctx, p, state, waitFn)
 			}
 			if wErr != nil {
 				return wErr

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -98,12 +98,9 @@ func attachRun(ctx context.Context, w io.Writer, runID string, rootDefault bool,
 			// has the run registered, so the handoff to runTUI below is
 			// seamless rather than flashing the pre-wizard terminal.
 			waitFn := func(ctx context.Context, branch string) error {
-				r, werr := waitForActiveRun(ctx, client, repo.ID, branch, 5*time.Second)
+				_, werr := waitForActiveRun(ctx, client, repo.ID, branch, 5*time.Second)
 				if werr != nil {
 					return werr
-				}
-				if r == nil {
-					return fmt.Errorf("no active run appeared after pushing %q", branch)
 				}
 				return nil
 			}

--- a/internal/cli/attach_test.go
+++ b/internal/cli/attach_test.go
@@ -1,12 +1,16 @@
 package cli
 
 import (
+	"context"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/gate"
+	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/wizard"
 )
 
 func TestActiveRunBranchUsesRepoWideLookupForExplicitAttach(t *testing.T) {
@@ -127,5 +131,55 @@ func TestAttachNotGitRepoCommands(t *testing.T) {
 				t.Errorf("error should mention 'not in a git repository', got: %v", err)
 			}
 		})
+	}
+}
+
+func TestRootInteractiveWizardFallsBackWhenRunRegistrationIsSlow(t *testing.T) {
+	setupTestRepo(t)
+	nmHome := makeSocketSafeTempDir(t)
+	t.Setenv("NM_HOME", nmHome)
+	p := paths.WithRoot(nmHome)
+
+	d, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	if _, err := gate.Init(context.Background(), d, p, "."); err != nil {
+		t.Fatal(err)
+	}
+
+	startTestDaemon(t, p, d)
+
+	prevInteractive := terminalInteractive
+	terminalInteractive = func() bool { return true }
+	defer func() { terminalInteractive = prevInteractive }()
+
+	prevWizardRun := wizardRun
+	wizardRun = func(cfg wizard.Config) (wizard.Result, error) {
+		if cfg.WaitForRun == nil {
+			t.Fatal("expected wait function")
+		}
+		if err := cfg.WaitForRun(context.Background(), "feat/slow"); err != nil {
+			return wizard.Result{}, err
+		}
+		return wizard.Result{Success: true, Pushed: true, TargetBranch: "feat/slow"}, nil
+	}
+	defer func() { wizardRun = prevWizardRun }()
+
+	prevRunTUI := runTUI
+	runTUI = func(string, *ipc.Client, *ipc.RunInfo, string) error {
+		t.Fatal("should not attach when no run is visible yet")
+		return nil
+	}
+	defer func() { runTUI = prevRunTUI }()
+
+	out, err := executeCmd()
+	if err != nil {
+		t.Fatalf("executeCmd() error = %v", err)
+	}
+	if !strings.Contains(out, "No active run") {
+		t.Fatalf("expected existing fallback output, got %q", out)
 	}
 }

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -197,7 +197,7 @@ func TestRootYesRunsWizardNonInteractively(t *testing.T) {
 	}
 
 	prevAuto := runWizardAuto
-	runWizardAuto = func(ctx context.Context, p *paths.Paths, state *repoState) (wizard.Result, error) {
+	runWizardAuto = func(ctx context.Context, p *paths.Paths, state *repoState, _ waitForRunFunc) (wizard.Result, error) {
 		if state == nil {
 			t.Fatal("expected repo state")
 		}
@@ -257,7 +257,7 @@ func TestRootYesUsesVisibleWizardWhenInteractive(t *testing.T) {
 
 	prevVisible := runWizardAutoVisible
 	visible := false
-	runWizardAutoVisible = func(ctx context.Context, p *paths.Paths, state *repoState) (wizard.Result, error) {
+	runWizardAutoVisible = func(ctx context.Context, p *paths.Paths, state *repoState, _ waitForRunFunc) (wizard.Result, error) {
 		visible = true
 		if state == nil {
 			t.Fatal("expected repo state")
@@ -270,7 +270,7 @@ func TestRootYesUsesVisibleWizardWhenInteractive(t *testing.T) {
 	defer func() { runWizardAutoVisible = prevVisible }()
 
 	prevAuto := runWizardAuto
-	runWizardAuto = func(context.Context, *paths.Paths, *repoState) (wizard.Result, error) {
+	runWizardAuto = func(context.Context, *paths.Paths, *repoState, waitForRunFunc) (wizard.Result, error) {
 		t.Fatal("expected interactive -y path to show the wizard instead of using headless auto mode")
 		return wizard.Result{}, nil
 	}
@@ -314,7 +314,7 @@ func TestRootYesFailsWhenWizardPushProducesNoRun(t *testing.T) {
 	startTestDaemon(t, p, d)
 
 	prevAuto := runWizardAuto
-	runWizardAuto = func(ctx context.Context, p *paths.Paths, state *repoState) (wizard.Result, error) {
+	runWizardAuto = func(ctx context.Context, p *paths.Paths, state *repoState, _ waitForRunFunc) (wizard.Result, error) {
 		return wizard.Result{Success: true, Pushed: true, TargetBranch: "feat/missing"}, nil
 	}
 	defer func() { runWizardAuto = prevAuto }()
@@ -350,7 +350,7 @@ func TestRootYesPassesCommandContextToWizard(t *testing.T) {
 	cancel()
 
 	prevAuto := runWizardAuto
-	runWizardAuto = func(got context.Context, p *paths.Paths, state *repoState) (wizard.Result, error) {
+	runWizardAuto = func(got context.Context, p *paths.Paths, state *repoState, _ waitForRunFunc) (wizard.Result, error) {
 		if got == nil {
 			t.Fatal("expected command context")
 		}
@@ -389,7 +389,7 @@ func TestRootYesStopsWaitingForRunWhenContextCanceled(t *testing.T) {
 	defer cancel()
 
 	prevAuto := runWizardAuto
-	runWizardAuto = func(got context.Context, p *paths.Paths, state *repoState) (wizard.Result, error) {
+	runWizardAuto = func(got context.Context, p *paths.Paths, state *repoState, _ waitForRunFunc) (wizard.Result, error) {
 		cancel()
 		return wizard.Result{Success: true, Pushed: true, TargetBranch: "feat/missing"}, nil
 	}

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -25,14 +25,19 @@ var resolveWizardAgent = func(ctx context.Context, cfg *config.Config) error {
 	return cfg.ResolveAgent(ctx, exec.LookPath)
 }
 
+// waitForRunFunc blocks until the daemon-created run for branch is visible.
+// Wired by attach.go; passed into the wizard so the wait happens inside the
+// alt screen and the handoff to the attach TUI is seamless.
+type waitForRunFunc func(ctx context.Context, branch string) error
+
 var newWizardAgent = agent.New
 var wizardRun = wizard.Run
 var wizardRunAuto = wizard.RunAuto
-var runWizardAutoVisible = func(ctx context.Context, p *paths.Paths, state *repoState) (wizard.Result, error) {
-	return runWizardWithMode(ctx, p, state, true, true)
+var runWizardAutoVisible = func(ctx context.Context, p *paths.Paths, state *repoState, wait waitForRunFunc) (wizard.Result, error) {
+	return runWizardWithMode(ctx, p, state, true, true, wait)
 }
-var runWizardAuto = func(ctx context.Context, p *paths.Paths, state *repoState) (wizard.Result, error) {
-	return runWizardWithMode(ctx, p, state, true, false)
+var runWizardAuto = func(ctx context.Context, p *paths.Paths, state *repoState, wait waitForRunFunc) (wizard.Result, error) {
+	return runWizardWithMode(ctx, p, state, true, false, wait)
 }
 
 type wizardAgentSuggester struct {
@@ -182,11 +187,11 @@ func detectRepoState(ctx context.Context, repo *db.Repo) (*repoState, error) {
 
 // runWizard prepares optional suggestion hooks and runs the interactive
 // onboarding wizard against the supplied repo state.
-func runWizard(ctx context.Context, p *paths.Paths, state *repoState) (wizard.Result, error) {
-	return runWizardWithMode(ctx, p, state, false, true)
+func runWizard(ctx context.Context, p *paths.Paths, state *repoState, wait waitForRunFunc) (wizard.Result, error) {
+	return runWizardWithMode(ctx, p, state, false, true, wait)
 }
 
-func runWizardWithMode(ctx context.Context, p *paths.Paths, state *repoState, auto bool, visible bool) (wizard.Result, error) {
+func runWizardWithMode(ctx context.Context, p *paths.Paths, state *repoState, auto bool, visible bool, wait waitForRunFunc) (wizard.Result, error) {
 	workDir := state.workDir
 
 	globalCfg, err := config.LoadGlobal(p.ConfigFile())
@@ -235,6 +240,12 @@ func runWizardWithMode(ctx context.Context, p *paths.Paths, state *repoState, au
 		Track: func(action string, fields map[string]any) {
 			telemetry.Track("wizard", mergeTelemetryFields(fields, telemetry.Fields{"action": action}))
 		},
+	}
+
+	if wait != nil {
+		wizCfg.WaitForRun = func(ctx context.Context, branch string) error {
+			return wait(ctx, branch)
+		}
 	}
 
 	telemetry.Pageview("/wizard", telemetry.Fields{

--- a/internal/cli/wizard_test.go
+++ b/internal/cli/wizard_test.go
@@ -352,7 +352,7 @@ func TestRunWizardTracksPageview(t *testing.T) {
 		dirty:         true,
 	}
 
-	if _, err := runWizard(context.Background(), p, state); err != nil {
+	if _, err := runWizard(context.Background(), p, state, nil); err != nil {
 		t.Fatalf("runWizard() error = %v", err)
 	}
 
@@ -415,7 +415,7 @@ func TestRunWizardReturnsTerminalWizardError(t *testing.T) {
 		dirty:         true,
 	}
 
-	_, err := runWizard(context.Background(), p, state)
+	_, err := runWizard(context.Background(), p, state, nil)
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("runWizard() error = %v, want %v", err, wantErr)
 	}

--- a/internal/wizard/view.go
+++ b/internal/wizard/view.go
@@ -50,6 +50,12 @@ func (m Model) View() string {
 	out.WriteString(box)
 	out.WriteString("\n")
 
+	if m.waiting {
+		out.WriteString("\n")
+		out.WriteString(" " + blueStyle().Render(spinnerFrames[m.spinnerFrame%len(spinnerFrames)]) + " " + dimStyle().Render("waiting for run…"))
+		out.WriteString("\n")
+	}
+
 	if bar := m.renderActionBar(); bar != "" {
 		out.WriteString("\n")
 		out.WriteString(bar)

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -318,6 +318,15 @@ func (m Model) handleAutoAdvance() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.waiting {
+		switch msg.String() {
+		case "ctrl+c", "q":
+		default:
+			m.confirmQuit = false
+			return m, nil
+		}
+	}
+
 	s := m.activeStep()
 	if s == nil {
 		// Already finished; any key quits.

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -47,6 +47,11 @@ type Config struct {
 	SuggestBranch func(ctx context.Context) (string, error)
 	SuggestCommit func(ctx context.Context) (string, error)
 	Track         func(action string, fields map[string]any)
+	// WaitForRun, if set, runs after push succeeds and blocks while the
+	// daemon-created run is still catching up. Keeps the alt screen up so the
+	// handoff to the attach TUI has no visible gap. Only used by the
+	// interactive Run path; headless RunAuto ignores it.
+	WaitForRun func(ctx context.Context, branch string) error
 }
 
 // stepID identifies one of the three wizard steps.
@@ -110,6 +115,11 @@ type Model struct {
 	quitting bool
 	success  bool // all needed steps completed; pipeline pushed
 	aborted  bool // user explicitly aborted
+
+	// waiting is true while the WaitForRun hook is in flight. waitStarted
+	// latches so the hook only runs once even if setupActive is re-entered.
+	waiting     bool
+	waitStarted bool
 }
 
 // Result reports what the wizard did. Success means a push to the gate
@@ -187,6 +197,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case actionMsg:
 		return m.handleAction(msg)
 
+	case waitMsg:
+		return m.handleWait(msg)
+
 	case spinnerTickMsg:
 		m.spinnerAlive = false
 		if !m.anySpinnerActive() {
@@ -241,8 +254,13 @@ func (m *Model) activeStep() *step {
 func (m Model) setupActive() Model {
 	s := m.activeStep()
 	if s == nil {
+		if m.cfg.WaitForRun != nil && m.pushed && !m.waitStarted {
+			m.waiting = true
+			m.waitStarted = true
+			return m
+		}
 		m.success = m.pushed
-		if m.success {
+		if m.success && m.err == nil {
 			m.track("completed", map[string]any{
 				"branch_created": m.branchCreated,
 				"commit_made":    m.commitMade,
@@ -268,6 +286,9 @@ func (m Model) setupActive() Model {
 
 // afterEnterCmd returns the Cmd to kick off after transitioning to a new step.
 func (m Model) afterEnterCmd() tea.Cmd {
+	if m.waiting {
+		return tea.Batch(m.runWaitForRun(), m.scheduleSpinner())
+	}
 	if m.quitting {
 		return quitWithTitleReset()
 	}
@@ -463,6 +484,15 @@ func (m Model) handleAction(msg actionMsg) (tea.Model, tea.Cmd) {
 	return m, m.afterEnterCmd()
 }
 
+func (m Model) handleWait(msg waitMsg) (tea.Model, tea.Cmd) {
+	m.waiting = false
+	if msg.err != nil {
+		m.err = fmt.Errorf("wait for run: %w", msg.err)
+	}
+	m = m.setupActive()
+	return m, m.afterEnterCmd()
+}
+
 func (m Model) hasSideEffects() bool {
 	return m.branchCreated || m.commitMade
 }
@@ -490,6 +520,10 @@ func (m Model) terminalTitle() string {
 		if s.status == statFailed {
 			return "✗ Setup " + stepLabel(s.id) + suffix
 		}
+	}
+
+	if m.waiting {
+		return stepTitleIcon(statRunning, m.spinnerFrame) + " Setup attaching" + suffix
 	}
 
 	s := m.activeStep()
@@ -558,6 +592,9 @@ func (m Model) trackAbort(reason string) {
 }
 
 func (m Model) anySpinnerActive() bool {
+	if m.waiting {
+		return true
+	}
 	s := m.activeStep()
 	if s == nil {
 		return false
@@ -575,6 +612,10 @@ type suggestionMsg struct {
 
 type actionMsg struct {
 	id  stepID
+	err error
+}
+
+type waitMsg struct {
 	err error
 }
 
@@ -637,6 +678,15 @@ func (m Model) runPush() tea.Cmd {
 	return func() tea.Msg {
 		err := m.cfg.Push(m.ctx, branch)
 		return actionMsg{id: stepPush, err: err}
+	}
+}
+
+func (m Model) runWaitForRun() tea.Cmd {
+	branch := m.targetBranch
+	hook := m.cfg.WaitForRun
+	ctx := m.ctx
+	return func() tea.Msg {
+		return waitMsg{err: hook(ctx, branch)}
 	}
 }
 

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -767,6 +767,46 @@ func TestWaitForRun_CompletedTelemetrySkippedOnWaitError(t *testing.T) {
 	}
 }
 
+func TestWaitForRun_IgnoresStrayKeys(t *testing.T) {
+	cfg := baseConfig(&recorder{})
+	cfg.CurrentBranch = "feat/x"
+	cfg.NeedsBranch = false
+	cfg.IsDirty = false
+	cfg.WaitForRun = func(context.Context, string) error { return nil }
+
+	m := NewModel(cfg)
+	m = drain(m, m.Init())
+
+	next, _ := m.executeStep(m.activeStep(), "")
+	m = next.(Model)
+	next, _ = m.Update(actionMsg{id: stepPush})
+	m = next.(Model)
+
+	if !m.waiting {
+		t.Fatal("expected wizard to be in wait-for-run mode")
+	}
+	if m.quitting {
+		t.Fatal("wait-for-run mode should not already be quitting")
+	}
+
+	for _, key := range []tea.KeyMsg{
+		{Type: tea.KeyRunes, Runes: []rune("x")},
+		{Type: tea.KeyEnter},
+	} {
+		next, _ = m.Update(key)
+		m = next.(Model)
+		if !m.waiting {
+			t.Fatalf("expected wait-for-run mode to ignore %q", key.String())
+		}
+		if m.quitting {
+			t.Fatalf("expected wait-for-run mode to keep running after %q", key.String())
+		}
+		if err := m.ctx.Err(); err != nil {
+			t.Fatalf("expected wait-for-run context to stay active after %q, got %v", key.String(), err)
+		}
+	}
+}
+
 func TestPushStep_DeclineAborts(t *testing.T) {
 	cfg := baseConfig(&recorder{})
 	cfg.CurrentBranch = "feat/x"

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -643,6 +643,130 @@ func containsWizardEvent(events []wizardTelemetryEvent, action, field string, wa
 	return false
 }
 
+func TestWaitForRun_CalledAfterPushWithTargetBranch(t *testing.T) {
+	cfg := baseConfig(&recorder{})
+	cfg.CurrentBranch = "feat/x"
+	cfg.NeedsBranch = false
+	cfg.IsDirty = false
+
+	var gotBranch string
+	var called int
+	cfg.WaitForRun = func(_ context.Context, branch string) error {
+		called++
+		gotBranch = branch
+		return nil
+	}
+
+	m := NewModel(cfg)
+	m = drain(m, m.Init())
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+
+	if called != 1 {
+		t.Fatalf("WaitForRun called %d times, want 1", called)
+	}
+	if gotBranch != "feat/x" {
+		t.Fatalf("WaitForRun got branch %q, want feat/x", gotBranch)
+	}
+	if !m.success {
+		t.Fatal("expected success after wait completes")
+	}
+	if !m.quitting {
+		t.Fatal("expected wizard to quit after wait completes")
+	}
+	if m.err != nil {
+		t.Fatalf("unexpected err after successful wait: %v", m.err)
+	}
+}
+
+func TestWaitForRun_NotCalledWhenNil(t *testing.T) {
+	cfg := baseConfig(&recorder{})
+	cfg.CurrentBranch = "feat/x"
+	cfg.NeedsBranch = false
+	cfg.IsDirty = false
+	cfg.WaitForRun = nil
+
+	m := NewModel(cfg)
+	m = drain(m, m.Init())
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+
+	if !m.success || !m.quitting {
+		t.Fatal("nil WaitForRun should fall through to immediate quit")
+	}
+}
+
+func TestWaitForRun_NotCalledWhenUserDeclinesPush(t *testing.T) {
+	cfg := baseConfig(&recorder{})
+	cfg.CurrentBranch = "feat/x"
+	cfg.NeedsBranch = false
+	cfg.IsDirty = false
+	called := false
+	cfg.WaitForRun = func(context.Context, string) error {
+		called = true
+		return nil
+	}
+
+	m := NewModel(cfg)
+	m = drain(m, m.Init())
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+
+	if called {
+		t.Fatal("WaitForRun must not run when push is declined")
+	}
+	if !m.aborted {
+		t.Fatal("expected aborted on decline")
+	}
+}
+
+func TestWaitForRun_ErrorSurfacesInResult(t *testing.T) {
+	cfg := baseConfig(&recorder{})
+	cfg.CurrentBranch = "feat/x"
+	cfg.NeedsBranch = false
+	cfg.IsDirty = false
+	cfg.WaitForRun = func(context.Context, string) error {
+		return errors.New("run never appeared")
+	}
+
+	m := NewModel(cfg)
+	m = drain(m, m.Init())
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+
+	if !m.quitting {
+		t.Fatal("wizard should quit even when wait fails")
+	}
+	if m.err == nil || !strings.Contains(m.err.Error(), "run never appeared") {
+		t.Fatalf("expected wait error in m.err, got %v", m.err)
+	}
+	res := m.Result()
+	if !res.Pushed {
+		t.Fatal("Pushed should remain true even if wait errored")
+	}
+	if res.Err == nil {
+		t.Fatal("Result.Err should reflect the wait failure")
+	}
+}
+
+func TestWaitForRun_CompletedTelemetrySkippedOnWaitError(t *testing.T) {
+	r := &recorder{}
+	cfg := baseConfig(r)
+	cfg.CurrentBranch = "feat/x"
+	cfg.NeedsBranch = false
+	cfg.IsDirty = false
+	cfg.WaitForRun = func(context.Context, string) error {
+		return errors.New("timeout")
+	}
+
+	m := NewModel(cfg)
+	m = drain(m, m.Init())
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+
+	if containsWizardEvent(r.telemetry, "completed", "", nil) {
+		t.Fatal("completed telemetry should not fire when wait fails")
+	}
+	if !containsWizardEvent(r.telemetry, "pushed", "step", "push") {
+		t.Fatal("pushed telemetry should still fire")
+	}
+}
+
 func TestPushStep_DeclineAborts(t *testing.T) {
 	cfg := baseConfig(&recorder{})
 	cfg.CurrentBranch = "feat/x"


### PR DESCRIPTION
## Summary
- Keep the wizard in an explicit `waiting for run...` state after push so it waits for the daemon-created run to appear before handing off to attach, avoiding a premature exit when registration lags.
- Preserve the existing interactive attach fallback when no active run is visible yet, so slow run registration does not turn a successful push into a hard user-facing failure.
- Update `internal/cli` and `internal/wizard` coverage around the new wait flow, and refresh the wizard and CLI docs to describe the post-push waiting phase.

## Risk Assessment

✅ Low: The change is narrowly scoped, the earlier functional regressions appear addressed, and the remaining code paths are straightforward with no additional material risks evident in the reviewed diff.

## Testing

- Summary: Exercised the new wizard wait-for-run state machine and CLI attach handoff/fallback paths via the affected package test suites, and both passed cleanly.
- `go test ./internal/wizard`
- `go test ./internal/cli`
- Outcome: ✅ passed across 1 run (1m10s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed</summary>

**Round 1** - found 2 warnings
- ⚠️ `internal/wizard/wizard.go:257` - When `WaitForRun` starts, the model has no active step anymore, so `handleKey` falls into its &#34;already finished&#34; path; any stray keypress during the new `waiting for run…` phase immediately cancels the wait and exits the wizard instead of ignoring input or requiring an explicit abort.
- ⚠️ `internal/cli/attach.go:105` - The new `waitFn` turns &#34;run not visible after 5s&#34; into a hard wizard error for interactive users too. Before this change, the same slow-daemon case fell back to the existing `No active run` output and returned nil; now a successful push can surface as a command failure purely because registration was delayed.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/wizard`
- `go test ./internal/cli`

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed</summary>

**Round 1** - found 2 infos
- ℹ️ `docs/src/content/docs/reference/cli.md:8` - The `no-mistakes` command reference describes the wizard path as pushing and then attaching once the run appears, but it does not mention the new visible post-push wait state that keeps the wizard screen up while the daemon-created run is being registered before handoff to the TUI.
- ℹ️ `docs/src/content/docs/guides/setup-wizard.md:69` - The setup wizard guide still presents a successful push as an immediate handoff to the main TUI. The new behavior adds an explicit post-push waiting phase in the wizard (`waiting for run…`) while the daemon registers the run, so this step description should be updated.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
