### PR TITLE
fix(daemon): harden orphaned agent server recovery

### DIFF
--- a/docs/src/content/docs/concepts/daemon.md
+++ b/docs/src/content/docs/concepts/daemon.md
@@ -53,7 +53,7 @@ no-mistakes update
 
 `no-mistakes update` stops and starts the daemon when it is running, or when stale daemon artifacts exist, so the new executable is used. It prefers the managed service path and falls back to a detached daemon if service startup is unavailable or fails. If the daemon is already running, update only proceeds when the daemon is using the same executable path as the binary running the update command; if that path cannot be determined or points to a different binary, the update aborts before replacing anything.
 
-The daemon writes its PID to `~/.no-mistakes/daemon.pid` and listens on a Unix socket at `~/.no-mistakes/socket`. On Windows, it uses a localhost TCP listener and a protected endpoint file at the same path.
+The daemon writes an identity record to `~/.no-mistakes/daemon.pid` and listens on a Unix socket at `~/.no-mistakes/socket`. On Windows, it uses a localhost TCP listener and a protected endpoint file at the same path.
 
 ## What it does
 
@@ -82,6 +82,7 @@ reason about in one long-lived process than inside independent hook invocations.
 On startup, the daemon checks for runs that were left in `pending` or `running` status (which means the daemon crashed while they were active):
 
 - Marks those runs as `failed` with the message "daemon crashed during execution"
+- Reaps orphaned managed agent servers left behind by a crashed daemon or setup wizard
 - Removes any orphaned worktree directories via `git worktree remove --force`
 
 ## Logging

--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -91,7 +91,7 @@ the background and always exits 0.
 A long-running background process that manages pipeline runs. It:
 
 - Listens on a Unix socket at `~/.no-mistakes/socket`
-- Writes its PID to `~/.no-mistakes/daemon.pid`
+- Writes its identity record to `~/.no-mistakes/daemon.pid`
 - Serializes concurrent pushes to the same branch (new push cancels the in-progress run)
 - Creates and cleans up worktrees
 - Persists state to SQLite
@@ -109,7 +109,7 @@ it was started from the same executable path and aborts if the daemon
 executable path cannot be determined or points to a different binary. You can
 also manage it explicitly with `no-mistakes daemon start|stop|restart|status`.
 
-On startup, the daemon recovers from crashes by marking any stuck runs as failed and cleaning up orphaned worktrees.
+On startup, the daemon recovers from crashes by marking any stuck runs as failed, reaping orphaned managed agent servers, and cleaning up orphaned worktrees.
 
 ### Pipeline executor
 
@@ -143,9 +143,10 @@ Everything lives under `~/.no-mistakes/` by default. Set `NM_HOME` to relocate i
 |---|---|
 | `state.sqlite` | SQLite database |
 | `socket` | Unix domain socket for IPC |
-| `daemon.pid` | Daemon process ID |
+| `daemon.pid` | Daemon identity record |
 | `config.yaml` | Global configuration |
 | `update-check.json` | Cached update check result |
+| `servers/` | PID-tracking records for managed agent servers |
 | `repos/<id>.git` | Bare gate repos |
 | `worktrees/<repoID>/<runID>/` | Disposable worktrees (cleaned up after each run) |
 | `logs/<runID>/<step>.log` | Per-step log files |

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -179,7 +179,7 @@ When state is genuinely wedged:
 
 ```sh
 no-mistakes daemon stop
-rm -rf ~/.no-mistakes/worktrees ~/.no-mistakes/socket ~/.no-mistakes/daemon.pid
+rm -rf ~/.no-mistakes/worktrees ~/.no-mistakes/servers ~/.no-mistakes/socket ~/.no-mistakes/daemon.pid
 no-mistakes daemon start
 ```
 

--- a/docs/src/content/docs/reference/environment.md
+++ b/docs/src/content/docs/reference/environment.md
@@ -20,6 +20,7 @@ When set, everything else moves under this root:
 - Logs: `$NM_HOME/logs/`
 - Database: `$NM_HOME/state.sqlite`
 - Socket / PID: `$NM_HOME/socket` and `$NM_HOME/daemon.pid`
+- Managed agent server PID records: `$NM_HOME/servers/`
 - Managed service names get a short stable suffix derived from `$NM_HOME` so multiple installs don't collide.
 
 ## `NO_MISTAKES_BITBUCKET_EMAIL`

--- a/internal/agent/opencode_http.go
+++ b/internal/agent/opencode_http.go
@@ -21,7 +21,7 @@ func (a *opencodeAgent) ensureServer(ctx context.Context, cwd string) (string, e
 		return "", fmt.Errorf("opencode port: %w", err)
 	}
 	args := []string{"serve", "--hostname", "127.0.0.1", "--port", fmt.Sprintf("%d", port), "--print-logs"}
-	srv, err := startServerWithPort(ctx, a.bin, args, cwd, "/global/health", port)
+	srv, err := startServerWithPort(ctx, "opencode", a.bin, args, cwd, "/global/health", port)
 	if err != nil {
 		return "", fmt.Errorf("opencode server: %w", err)
 	}

--- a/internal/agent/rovodev.go
+++ b/internal/agent/rovodev.go
@@ -72,7 +72,7 @@ func (a *rovodevAgent) ensureServer(ctx context.Context, cwd string) (string, er
 		return "", fmt.Errorf("rovodev port: %w", err)
 	}
 	args := []string{"rovodev", "serve", "--disable-session-token", fmt.Sprintf("%d", port)}
-	srv, err := startServerWithPort(ctx, a.bin, args, cwd, "/healthcheck", port)
+	srv, err := startServerWithPort(ctx, "rovodev", a.bin, args, cwd, "/healthcheck", port)
 	if err != nil {
 		return "", fmt.Errorf("rovodev server: %w", err)
 	}

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -44,6 +44,7 @@ func currentManagedServerOutput() io.Writer {
 type managedServer struct {
 	cmd     *exec.Cmd
 	port    int
+	pidFile string        // path to the on-disk PID record; empty if tracking disabled
 	exited  chan struct{} // closed exactly once when cmd.Wait returns
 	waitErr error         // result of cmd.Wait; only read after exited is closed
 }
@@ -62,7 +63,8 @@ func getAvailablePort() (int, error) {
 // startServerWithPort spawns the server process on a given port and waits for health.
 // The process is not tied to ctx - it outlives individual Run calls and is stopped via shutdown().
 // ctx is only used for the health check timeout.
-func startServerWithPort(ctx context.Context, bin string, args []string, cwd string, healthPath string, port int) (*managedServer, error) {
+// agentName tags the PID tracking file so crash-recovery can identify orphans.
+func startServerWithPort(ctx context.Context, agentName, bin string, args []string, cwd string, healthPath string, port int) (*managedServer, error) {
 	cmd := exec.Command(bin, args...)
 	cmd.Dir = cwd
 	cmd.Stdin = nil
@@ -75,7 +77,15 @@ func startServerWithPort(ctx context.Context, bin string, args []string, cwd str
 		return nil, fmt.Errorf("start server %s: %w", bin, err)
 	}
 
-	srv := &managedServer{cmd: cmd, port: port, exited: make(chan struct{})}
+	pidFile := writeServerPIDFile(currentServerPIDsDir(), ServerPIDInfo{
+		PID:       cmd.Process.Pid,
+		Agent:     agentName,
+		Bin:       bin,
+		Port:      port,
+		StartedAt: time.Now().UTC(),
+	})
+
+	srv := &managedServer{cmd: cmd, port: port, pidFile: pidFile, exited: make(chan struct{})}
 	go func() {
 		srv.waitErr = cmd.Wait()
 		close(srv.exited)
@@ -133,14 +143,19 @@ func (s *managedServer) waitForHealth(ctx context.Context, path string) error {
 // shutdown gracefully stops the server process. The long-running goroutine
 // spawned in startServerWithPort owns cmd.Wait(); shutdown signals the
 // process and waits on s.exited to observe termination.
+// The PID tracking file is removed only after the process is confirmed
+// exited - if SIGKILL fails to reap it, the file is left on disk so a
+// future daemon can finish the job.
 func (s *managedServer) shutdown() {
 	if s.cmd == nil || s.cmd.Process == nil {
+		removeServerPIDFile(s.pidFile)
 		return
 	}
 
 	// Already exited (e.g. early-exit path)?
 	select {
 	case <-s.exited:
+		removeServerPIDFile(s.pidFile)
 		return
 	default:
 	}
@@ -149,6 +164,7 @@ func (s *managedServer) shutdown() {
 
 	select {
 	case <-s.exited:
+		removeServerPIDFile(s.pidFile)
 		return
 	case <-time.After(3 * time.Second):
 	}
@@ -158,6 +174,7 @@ func (s *managedServer) shutdown() {
 
 	select {
 	case <-s.exited:
+		removeServerPIDFile(s.pidFile)
 	case <-time.After(5 * time.Second):
 		slog.Warn("server process did not exit after SIGKILL", "pid", s.cmd.Process.Pid)
 	}

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -80,6 +80,7 @@ func startServerWithPort(ctx context.Context, agentName, bin string, args []stri
 	pidFile := writeServerPIDFile(currentServerPIDsDir(), ServerPIDInfo{
 		PID:       cmd.Process.Pid,
 		Owner:     currentServerPIDOwner(),
+		OwnerPID:  os.Getpid(),
 		Agent:     agentName,
 		Bin:       bin,
 		Port:      port,

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -78,13 +78,14 @@ func startServerWithPort(ctx context.Context, agentName, bin string, args []stri
 	}
 
 	pidFile := writeServerPIDFile(currentServerPIDsDir(), ServerPIDInfo{
-		PID:       cmd.Process.Pid,
-		Owner:     currentServerPIDOwner(),
-		OwnerPID:  os.Getpid(),
-		Agent:     agentName,
-		Bin:       bin,
-		Port:      port,
-		StartedAt: time.Now().UTC(),
+		PID:            cmd.Process.Pid,
+		Owner:          currentServerPIDOwner(),
+		OwnerPID:       os.Getpid(),
+		OwnerStartedAt: CurrentProcessStartedAt(),
+		Agent:          agentName,
+		Bin:            bin,
+		Port:           port,
+		StartedAt:      time.Now().UTC(),
 	})
 
 	srv := &managedServer{cmd: cmd, port: port, pidFile: pidFile, exited: make(chan struct{})}

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -79,6 +79,7 @@ func startServerWithPort(ctx context.Context, agentName, bin string, args []stri
 
 	pidFile := writeServerPIDFile(currentServerPIDsDir(), ServerPIDInfo{
 		PID:       cmd.Process.Pid,
+		Owner:     currentServerPIDOwner(),
 		Agent:     agentName,
 		Bin:       bin,
 		Port:      port,

--- a/internal/agent/server_test.go
+++ b/internal/agent/server_test.go
@@ -21,7 +21,7 @@ func TestStartServerWithPort_DetectsEarlyExit(t *testing.T) {
 	}
 
 	start := time.Now()
-	srv, err := startServerWithPort(context.Background(), bin, nil, t.TempDir(), "/healthcheck", 1)
+	srv, err := startServerWithPort(context.Background(), "test", bin, nil, t.TempDir(), "/healthcheck", 1)
 	elapsed := time.Since(start)
 
 	if err == nil {
@@ -70,5 +70,80 @@ func TestSetManagedServerOutput_NilResetsToDefault(t *testing.T) {
 	SetManagedServerOutput(nil)
 	if currentManagedServerOutput() != os.Stderr {
 		t.Fatal("nil should reset to os.Stderr")
+	}
+}
+
+// TestStartServerWithPort_RemovesPIDFileOnEarlyExit proves that when a
+// server exits before passing its health check, shutdown() still cleans up
+// the tracking file so recovery won't later try to reap a non-existent PID.
+func TestStartServerWithPort_RemovesPIDFileOnEarlyExit(t *testing.T) {
+	bin, err := exec.LookPath("true")
+	if err != nil {
+		t.Skip("true binary not available")
+	}
+
+	pidsDir := t.TempDir()
+	SetServerPIDsDir(pidsDir)
+	t.Cleanup(func() { SetServerPIDsDir("") })
+
+	srv, err := startServerWithPort(context.Background(), "test", bin, nil, t.TempDir(), "/healthcheck", 1)
+	if err == nil {
+		srv.shutdown()
+		t.Fatal("expected error when server exits before becoming healthy")
+	}
+
+	entries, rdErr := os.ReadDir(pidsDir)
+	if rdErr != nil {
+		t.Fatalf("read pids dir: %v", rdErr)
+	}
+	if len(entries) != 0 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("expected no leftover pid files, got %v", names)
+	}
+}
+
+// TestManagedServerShutdown_RemovesPIDFile covers the graceful-shutdown
+// happy path: a running subprocess whose PID file gets cleaned once the
+// process exits.
+func TestManagedServerShutdown_RemovesPIDFile(t *testing.T) {
+	sh, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("sh not available")
+	}
+
+	pidsDir := t.TempDir()
+	SetServerPIDsDir(pidsDir)
+	t.Cleanup(func() { SetServerPIDsDir("") })
+
+	cmd := exec.Command(sh, "-c", "sleep 30")
+	configureManagedServerCmd(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sh: %v", err)
+	}
+
+	pidFile := writeServerPIDFile(pidsDir, ServerPIDInfo{
+		PID:       cmd.Process.Pid,
+		Agent:     "test",
+		Bin:       sh,
+		Port:      0,
+		StartedAt: time.Now().UTC(),
+	})
+	if pidFile == "" {
+		t.Fatal("expected pid file path")
+	}
+
+	srv := &managedServer{cmd: cmd, pidFile: pidFile, exited: make(chan struct{})}
+	go func() {
+		srv.waitErr = cmd.Wait()
+		close(srv.exited)
+	}()
+
+	srv.shutdown()
+
+	if _, err := os.Stat(pidFile); !os.IsNotExist(err) {
+		t.Errorf("pid file should be removed after shutdown, got err=%v", err)
 	}
 }

--- a/internal/agent/serverpid.go
+++ b/internal/agent/serverpid.go
@@ -16,15 +16,22 @@ import (
 // and deleted after it shuts down cleanly.
 type ServerPIDInfo struct {
 	PID       int       `json:"pid"`
+	Owner     string    `json:"owner,omitempty"`
 	Agent     string    `json:"agent"`
 	Bin       string    `json:"bin"`
 	Port      int       `json:"port"`
 	StartedAt time.Time `json:"started_at"`
 }
 
+const (
+	ServerPIDOwnerDaemon = "daemon"
+	ServerPIDOwnerWizard = "wizard"
+)
+
 var (
 	serverPIDsDirMu sync.RWMutex
 	serverPIDsDir   string
+	serverPIDOwner  string
 )
 
 // SetServerPIDsDir configures where managed-server PID files are written.
@@ -32,9 +39,18 @@ var (
 // paths.ServerPIDsDir(). Empty string disables PID tracking, which is the
 // default for processes that don't own a long-running daemon identity.
 func SetServerPIDsDir(dir string) {
+	owner := ""
+	if dir != "" {
+		owner = ServerPIDOwnerDaemon
+	}
+	SetServerPIDsDirForOwner(dir, owner)
+}
+
+func SetServerPIDsDirForOwner(dir, owner string) {
 	serverPIDsDirMu.Lock()
 	defer serverPIDsDirMu.Unlock()
 	serverPIDsDir = dir
+	serverPIDOwner = owner
 }
 
 func currentServerPIDsDir() string {
@@ -43,9 +59,17 @@ func currentServerPIDsDir() string {
 	return serverPIDsDir
 }
 
+func currentServerPIDOwner() string {
+	serverPIDsDirMu.RLock()
+	defer serverPIDsDirMu.RUnlock()
+	return serverPIDOwner
+}
+
 // CurrentServerPIDsDir returns the configured directory for PID tracking
 // files, or "" if tracking is disabled.
 func CurrentServerPIDsDir() string { return currentServerPIDsDir() }
+
+func CurrentServerPIDOwner() string { return currentServerPIDOwner() }
 
 // writeServerPIDFile serializes info into a uniquely named file under dir
 // and returns the file path. When dir is empty the call is a no-op and the

--- a/internal/agent/serverpid.go
+++ b/internal/agent/serverpid.go
@@ -1,0 +1,85 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// ServerPIDInfo records a managed server's identity on disk so that a
+// freshly started daemon can reap orphaned subprocesses left behind by a
+// crashed predecessor. The file is written after the subprocess starts
+// and deleted after it shuts down cleanly.
+type ServerPIDInfo struct {
+	PID       int       `json:"pid"`
+	Agent     string    `json:"agent"`
+	Bin       string    `json:"bin"`
+	Port      int       `json:"port"`
+	StartedAt time.Time `json:"started_at"`
+}
+
+var (
+	serverPIDsDirMu sync.RWMutex
+	serverPIDsDir   string
+)
+
+// SetServerPIDsDir configures where managed-server PID files are written.
+// Callers (typically the daemon at startup) should point this at
+// paths.ServerPIDsDir(). Empty string disables PID tracking, which is the
+// default for processes that don't own a long-running daemon identity.
+func SetServerPIDsDir(dir string) {
+	serverPIDsDirMu.Lock()
+	defer serverPIDsDirMu.Unlock()
+	serverPIDsDir = dir
+}
+
+func currentServerPIDsDir() string {
+	serverPIDsDirMu.RLock()
+	defer serverPIDsDirMu.RUnlock()
+	return serverPIDsDir
+}
+
+// CurrentServerPIDsDir returns the configured directory for PID tracking
+// files, or "" if tracking is disabled.
+func CurrentServerPIDsDir() string { return currentServerPIDsDir() }
+
+// writeServerPIDFile serializes info into a uniquely named file under dir
+// and returns the file path. When dir is empty the call is a no-op and the
+// empty string is returned so callers can treat "no tracking" uniformly.
+// Failures are logged but not surfaced because PID tracking is best-effort
+// and shouldn't block a server from starting.
+func writeServerPIDFile(dir string, info ServerPIDInfo) string {
+	if dir == "" {
+		return ""
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		slog.Warn("create server pid dir", "dir", dir, "error", err)
+		return ""
+	}
+	name := fmt.Sprintf("%s-%d.json", info.Agent, info.PID)
+	path := filepath.Join(dir, name)
+	data, err := json.Marshal(info)
+	if err != nil {
+		slog.Warn("marshal server pid", "error", err)
+		return ""
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		slog.Warn("write server pid file", "path", path, "error", err)
+		return ""
+	}
+	return path
+}
+
+// removeServerPIDFile deletes path, silently ignoring missing files.
+func removeServerPIDFile(path string) {
+	if path == "" {
+		return
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		slog.Warn("remove server pid file", "path", path, "error", err)
+	}
+}

--- a/internal/agent/serverpid.go
+++ b/internal/agent/serverpid.go
@@ -17,6 +17,7 @@ import (
 type ServerPIDInfo struct {
 	PID       int       `json:"pid"`
 	Owner     string    `json:"owner,omitempty"`
+	OwnerPID  int       `json:"owner_pid,omitempty"`
 	Agent     string    `json:"agent"`
 	Bin       string    `json:"bin"`
 	Port      int       `json:"port"`
@@ -91,10 +92,31 @@ func writeServerPIDFile(dir string, info ServerPIDInfo) string {
 		slog.Warn("marshal server pid", "error", err)
 		return ""
 	}
-	if err := os.WriteFile(path, data, 0o644); err != nil {
+	tmp, err := os.CreateTemp(dir, name+".tmp-*")
+	if err != nil {
+		slog.Warn("create server pid temp file", "dir", dir, "error", err)
+		return ""
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		if tmpPath != "" {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		slog.Warn("write server pid temp file", "path", tmpPath, "error", err)
+		return ""
+	}
+	if err := tmp.Close(); err != nil {
+		slog.Warn("close server pid temp file", "path", tmpPath, "error", err)
+		return ""
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
 		slog.Warn("write server pid file", "path", path, "error", err)
 		return ""
 	}
+	tmpPath = ""
 	return path
 }
 

--- a/internal/agent/serverpid.go
+++ b/internal/agent/serverpid.go
@@ -15,13 +15,14 @@ import (
 // crashed predecessor. The file is written after the subprocess starts
 // and deleted after it shuts down cleanly.
 type ServerPIDInfo struct {
-	PID       int       `json:"pid"`
-	Owner     string    `json:"owner,omitempty"`
-	OwnerPID  int       `json:"owner_pid,omitempty"`
-	Agent     string    `json:"agent"`
-	Bin       string    `json:"bin"`
-	Port      int       `json:"port"`
-	StartedAt time.Time `json:"started_at"`
+	PID            int       `json:"pid"`
+	Owner          string    `json:"owner,omitempty"`
+	OwnerPID       int       `json:"owner_pid,omitempty"`
+	OwnerStartedAt time.Time `json:"owner_started_at,omitempty"`
+	Agent          string    `json:"agent"`
+	Bin            string    `json:"bin"`
+	Port           int       `json:"port"`
+	StartedAt      time.Time `json:"started_at"`
 }
 
 const (
@@ -30,9 +31,10 @@ const (
 )
 
 var (
-	serverPIDsDirMu sync.RWMutex
-	serverPIDsDir   string
-	serverPIDOwner  string
+	serverPIDsDirMu  sync.RWMutex
+	serverPIDsDir    string
+	serverPIDOwner   string
+	processStartedAt = time.Now().UTC()
 )
 
 // SetServerPIDsDir configures where managed-server PID files are written.
@@ -71,6 +73,8 @@ func currentServerPIDOwner() string {
 func CurrentServerPIDsDir() string { return currentServerPIDsDir() }
 
 func CurrentServerPIDOwner() string { return currentServerPIDOwner() }
+
+func CurrentProcessStartedAt() time.Time { return processStartedAt }
 
 // writeServerPIDFile serializes info into a uniquely named file under dir
 // and returns the file path. When dir is empty the call is a no-op and the

--- a/internal/agent/serverpid_test.go
+++ b/internal/agent/serverpid_test.go
@@ -1,0 +1,94 @@
+package agent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWriteServerPIDFile_WritesJSONInDir(t *testing.T) {
+	dir := t.TempDir()
+	info := ServerPIDInfo{
+		PID:       12345,
+		Agent:     "opencode",
+		Bin:       "/usr/local/bin/opencode",
+		Port:      54321,
+		StartedAt: time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC),
+	}
+
+	path := writeServerPIDFile(dir, info)
+	if path == "" {
+		t.Fatal("expected non-empty path")
+	}
+	if filepath.Dir(path) != dir {
+		t.Errorf("path not under dir: %q", path)
+	}
+	if !strings.Contains(filepath.Base(path), "opencode") || !strings.Contains(filepath.Base(path), "12345") {
+		t.Errorf("filename should include agent and pid, got %q", filepath.Base(path))
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got ServerPIDInfo
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got != info {
+		t.Errorf("roundtrip mismatch: got %+v want %+v", got, info)
+	}
+}
+
+func TestWriteServerPIDFile_EmptyDirNoop(t *testing.T) {
+	path := writeServerPIDFile("", ServerPIDInfo{PID: 1, Agent: "x"})
+	if path != "" {
+		t.Errorf("expected empty path when dir disabled, got %q", path)
+	}
+}
+
+func TestWriteServerPIDFile_CreatesMissingDir(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "nested", "servers")
+
+	path := writeServerPIDFile(dir, ServerPIDInfo{PID: 2, Agent: "rovodev"})
+	if path == "" {
+		t.Fatal("expected path")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("file should exist: %v", err)
+	}
+}
+
+func TestRemoveServerPIDFile_DeletesAndIgnoresMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "foo.json")
+	if err := os.WriteFile(path, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	removeServerPIDFile(path)
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("file should be gone, got err=%v", err)
+	}
+	// Second call on missing file must not panic or error loudly.
+	removeServerPIDFile(path)
+	removeServerPIDFile("")
+}
+
+func TestSetServerPIDsDir_RoundTrip(t *testing.T) {
+	prev := currentServerPIDsDir()
+	t.Cleanup(func() { SetServerPIDsDir(prev) })
+
+	SetServerPIDsDir("/tmp/pids")
+	if got := currentServerPIDsDir(); got != "/tmp/pids" {
+		t.Errorf("got %q want /tmp/pids", got)
+	}
+	SetServerPIDsDir("")
+	if got := currentServerPIDsDir(); got != "" {
+		t.Errorf("empty reset, got %q", got)
+	}
+}

--- a/internal/agent/serverpid_test.go
+++ b/internal/agent/serverpid_test.go
@@ -2,9 +2,11 @@ package agent
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -104,5 +106,71 @@ func TestSetServerPIDsDir_RoundTrip(t *testing.T) {
 	}
 	if got := currentServerPIDOwner(); got != "" {
 		t.Errorf("empty reset owner, got %q", got)
+	}
+}
+
+func TestWriteServerPIDFile_ConcurrentReadersNeverSeePartialJSON(t *testing.T) {
+	dir := t.TempDir()
+	info := ServerPIDInfo{
+		PID:       12345,
+		Owner:     ServerPIDOwnerDaemon,
+		OwnerPID:  4321,
+		Agent:     "opencode",
+		Bin:       strings.Repeat("/usr/local/bin/opencode", 1<<15),
+		Port:      54321,
+		StartedAt: time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC),
+	}
+	path := writeServerPIDFile(dir, info)
+	if path == "" {
+		t.Fatal("expected non-empty path")
+	}
+
+	stop := make(chan struct{})
+	errCh := make(chan error, 1)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
+				select {
+				case errCh <- fmt.Errorf("read pid file: %w", err):
+				default:
+				}
+				return
+			}
+			var got ServerPIDInfo
+			if err := json.Unmarshal(data, &got); err != nil {
+				select {
+				case errCh <- fmt.Errorf("saw partial pid file: %w", err):
+				default:
+				}
+				return
+			}
+		}
+	}()
+
+	for i := 0; i < 200; i++ {
+		info.Port = 54321 + i
+		if got := writeServerPIDFile(dir, info); got != path {
+			t.Fatalf("writeServerPIDFile() path = %q, want %q", got, path)
+		}
+	}
+
+	close(stop)
+	wg.Wait()
+	select {
+	case err := <-errCh:
+		t.Fatal(err)
+	default:
 	}
 }

--- a/internal/agent/serverpid_test.go
+++ b/internal/agent/serverpid_test.go
@@ -81,14 +81,28 @@ func TestRemoveServerPIDFile_DeletesAndIgnoresMissing(t *testing.T) {
 
 func TestSetServerPIDsDir_RoundTrip(t *testing.T) {
 	prev := currentServerPIDsDir()
-	t.Cleanup(func() { SetServerPIDsDir(prev) })
+	prevOwner := currentServerPIDOwner()
+	t.Cleanup(func() { SetServerPIDsDirForOwner(prev, prevOwner) })
 
 	SetServerPIDsDir("/tmp/pids")
 	if got := currentServerPIDsDir(); got != "/tmp/pids" {
 		t.Errorf("got %q want /tmp/pids", got)
 	}
+	if got := currentServerPIDOwner(); got != ServerPIDOwnerDaemon {
+		t.Errorf("got owner %q want %q", got, ServerPIDOwnerDaemon)
+	}
+	SetServerPIDsDirForOwner("/tmp/wizard", ServerPIDOwnerWizard)
+	if got := currentServerPIDsDir(); got != "/tmp/wizard" {
+		t.Errorf("got %q want /tmp/wizard", got)
+	}
+	if got := currentServerPIDOwner(); got != ServerPIDOwnerWizard {
+		t.Errorf("got owner %q want %q", got, ServerPIDOwnerWizard)
+	}
 	SetServerPIDsDir("")
 	if got := currentServerPIDsDir(); got != "" {
 		t.Errorf("empty reset, got %q", got)
+	}
+	if got := currentServerPIDOwner(); got != "" {
+		t.Errorf("empty reset owner, got %q", got)
 	}
 }

--- a/internal/agent/serverpid_test.go
+++ b/internal/agent/serverpid_test.go
@@ -14,11 +14,12 @@ import (
 func TestWriteServerPIDFile_WritesJSONInDir(t *testing.T) {
 	dir := t.TempDir()
 	info := ServerPIDInfo{
-		PID:       12345,
-		Agent:     "opencode",
-		Bin:       "/usr/local/bin/opencode",
-		Port:      54321,
-		StartedAt: time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC),
+		PID:            12345,
+		OwnerStartedAt: time.Date(2026, 4, 20, 9, 59, 0, 0, time.UTC),
+		Agent:          "opencode",
+		Bin:            "/usr/local/bin/opencode",
+		Port:           54321,
+		StartedAt:      time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC),
 	}
 
 	path := writeServerPIDFile(dir, info)
@@ -112,13 +113,14 @@ func TestSetServerPIDsDir_RoundTrip(t *testing.T) {
 func TestWriteServerPIDFile_ConcurrentReadersNeverSeePartialJSON(t *testing.T) {
 	dir := t.TempDir()
 	info := ServerPIDInfo{
-		PID:       12345,
-		Owner:     ServerPIDOwnerDaemon,
-		OwnerPID:  4321,
-		Agent:     "opencode",
-		Bin:       strings.Repeat("/usr/local/bin/opencode", 1<<15),
-		Port:      54321,
-		StartedAt: time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC),
+		PID:            12345,
+		Owner:          ServerPIDOwnerDaemon,
+		OwnerPID:       4321,
+		OwnerStartedAt: time.Date(2026, 4, 20, 9, 59, 0, 0, time.UTC),
+		Agent:          "opencode",
+		Bin:            strings.Repeat("/usr/local/bin/opencode", 1<<15),
+		Port:           54321,
+		StartedAt:      time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC),
 	}
 	path := writeServerPIDFile(dir, info)
 	if path == "" {

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -210,8 +210,8 @@ func runWizardWithMode(ctx context.Context, p *paths.Paths, state *repoState, au
 	defer restoreOutput()
 	// Leave PID breadcrumbs so a daemon startup after a wizard crash can
 	// reap orphaned opencode/rovodev servers.
-	agent.SetServerPIDsDir(p.ServerPIDsDir())
-	defer agent.SetServerPIDsDir("")
+	agent.SetServerPIDsDirForOwner(p.ServerPIDsDir(), agent.ServerPIDOwnerWizard)
+	defer agent.SetServerPIDsDirForOwner("", "")
 
 	suggester := newWizardAgentSuggester(cfg, workDir, nil, nil)
 	defer suggester.Close()

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -208,6 +208,10 @@ func runWizardWithMode(ctx context.Context, p *paths.Paths, state *repoState, au
 	// during the wizard inherits this sink.
 	restoreOutput := captureAgentServerOutput(p)
 	defer restoreOutput()
+	// Leave PID breadcrumbs so a daemon startup after a wizard crash can
+	// reap orphaned opencode/rovodev servers.
+	agent.SetServerPIDsDir(p.ServerPIDsDir())
+	defer agent.SetServerPIDsDir("")
 
 	suggester := newWizardAgentSuggester(cfg, workDir, nil, nil)
 	defer suggester.Close()

--- a/internal/cli/wizard_test.go
+++ b/internal/cli/wizard_test.go
@@ -443,9 +443,11 @@ func TestRunWizard_ConfiguresServerPIDsDir(t *testing.T) {
 	if err := p.EnsureDirs(); err != nil {
 		t.Fatal(err)
 	}
+	prevDir := agent.CurrentServerPIDsDir()
+	prevOwner := agent.CurrentServerPIDOwner()
 	// Start from a known-empty setting so we can tell if the wizard set it.
-	agent.SetServerPIDsDir("")
-	t.Cleanup(func() { agent.SetServerPIDsDir("") })
+	agent.SetServerPIDsDirForOwner("", "")
+	t.Cleanup(func() { agent.SetServerPIDsDirForOwner(prevDir, prevOwner) })
 
 	repoDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(repoDir, ".git"), 0o755); err != nil {

--- a/internal/cli/wizard_test.go
+++ b/internal/cli/wizard_test.go
@@ -429,8 +429,10 @@ func TestRunWizardReturnsTerminalWizardError(t *testing.T) {
 func TestRunWizard_ConfiguresServerPIDsDir(t *testing.T) {
 	prevRun := wizardRun
 	var observedDir string
+	var observedOwner string
 	wizardRun = func(cfg wizard.Config) (wizard.Result, error) {
 		observedDir = agent.CurrentServerPIDsDir()
+		observedOwner = agent.CurrentServerPIDOwner()
 		return wizard.Result{Success: true}, nil
 	}
 	defer func() { wizardRun = prevRun }()
@@ -464,7 +466,13 @@ func TestRunWizard_ConfiguresServerPIDsDir(t *testing.T) {
 	if want := p.ServerPIDsDir(); observedDir != want {
 		t.Fatalf("during wizard, CurrentServerPIDsDir = %q, want %q", observedDir, want)
 	}
+	if observedOwner != agent.ServerPIDOwnerWizard {
+		t.Fatalf("during wizard, CurrentServerPIDOwner = %q, want %q", observedOwner, agent.ServerPIDOwnerWizard)
+	}
 	if got := agent.CurrentServerPIDsDir(); got != "" {
 		t.Fatalf("after wizard, CurrentServerPIDsDir = %q, want empty", got)
+	}
+	if got := agent.CurrentServerPIDOwner(); got != "" {
+		t.Fatalf("after wizard, CurrentServerPIDOwner = %q, want empty", got)
 	}
 }

--- a/internal/cli/wizard_test.go
+++ b/internal/cli/wizard_test.go
@@ -461,7 +461,7 @@ func TestRunWizard_ConfiguresServerPIDsDir(t *testing.T) {
 		dirty:         true,
 	}
 
-	if _, err := runWizard(context.Background(), p, state); err != nil {
+	if _, err := runWizard(context.Background(), p, state, nil); err != nil {
 		t.Fatalf("runWizard() error = %v", err)
 	}
 

--- a/internal/cli/wizard_test.go
+++ b/internal/cli/wizard_test.go
@@ -420,3 +420,51 @@ func TestRunWizardReturnsTerminalWizardError(t *testing.T) {
 		t.Fatalf("runWizard() error = %v, want %v", err, wantErr)
 	}
 }
+
+// TestRunWizard_ConfiguresServerPIDsDir ensures the wizard points the
+// agent package at its PID tracking dir while running, so orphaned
+// opencode/rovodev processes left behind by a wizard crash can be reaped
+// by the next daemon startup. It also verifies the setting is cleared
+// afterwards.
+func TestRunWizard_ConfiguresServerPIDsDir(t *testing.T) {
+	prevRun := wizardRun
+	var observedDir string
+	wizardRun = func(cfg wizard.Config) (wizard.Result, error) {
+		observedDir = agent.CurrentServerPIDsDir()
+		return wizard.Result{Success: true}, nil
+	}
+	defer func() { wizardRun = prevRun }()
+
+	nmHome := makeSocketSafeTempDir(t)
+	t.Setenv("NM_HOME", nmHome)
+	p := paths.WithRoot(nmHome)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	// Start from a known-empty setting so we can tell if the wizard set it.
+	agent.SetServerPIDsDir("")
+	t.Cleanup(func() { agent.SetServerPIDsDir("") })
+
+	repoDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repoDir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	state := &repoState{
+		workDir:       repoDir,
+		currentBranch: "main",
+		defaultBranch: "main",
+		dirty:         true,
+	}
+
+	if _, err := runWizard(context.Background(), p, state); err != nil {
+		t.Fatalf("runWizard() error = %v", err)
+	}
+
+	if want := p.ServerPIDsDir(); observedDir != want {
+		t.Fatalf("during wizard, CurrentServerPIDsDir = %q, want %q", observedDir, want)
+	}
+	if got := agent.CurrentServerPIDsDir(); got != "" {
+		t.Fatalf("after wizard, CurrentServerPIDsDir = %q, want empty", got)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -130,13 +130,19 @@ func RunWithOptions(p *paths.Paths, d *db.DB, stepFactory StepFactory) error {
 
 	// Write PID file
 	pidPath := p.PIDFile()
-	myPID := fmt.Sprintf("%d", os.Getpid())
-	if err := os.WriteFile(pidPath, []byte(myPID), 0o644); err != nil {
+	pidRecord := daemonPIDFile{PID: os.Getpid(), StartedAt: time.Now().UTC()}
+	pidData, err := json.Marshal(pidRecord)
+	if err != nil {
+		return fmt.Errorf("marshal pid file: %w", err)
+	}
+	if err := os.WriteFile(pidPath, pidData, 0o644); err != nil {
 		return fmt.Errorf("write pid file: %w", err)
 	}
 	defer func() {
-		if pidData, err := os.ReadFile(pidPath); err == nil && string(pidData) == myPID {
-			os.Remove(pidPath)
+		if pidData, err := os.ReadFile(pidPath); err == nil {
+			if current, readErr := readDaemonPIDFileData(pidData); readErr == nil && current.PID == pidRecord.PID && current.StartedAt.Equal(pidRecord.StartedAt) {
+				os.Remove(pidPath)
+			}
 		}
 	}()
 
@@ -162,8 +168,11 @@ func RunWithOptions(p *paths.Paths, d *db.DB, stepFactory StepFactory) error {
 
 	// Clean up socket file only if we still own the PID file.
 	// A new daemon may have already replaced the socket.
-	if pidData, err := os.ReadFile(pidPath); err == nil && string(pidData) == myPID {
-		os.Remove(socketPath)
+	if pidData, err := os.ReadFile(pidPath); err == nil {
+		if current, readErr := readDaemonPIDFileData(pidData); readErr == nil && current.PID == pidRecord.PID && current.StartedAt.Equal(pidRecord.StartedAt) {
+			os.Remove(pidPath)
+			os.Remove(socketPath)
+		}
 	}
 	slog.Info("daemon stopped")
 	return nil

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -130,7 +130,10 @@ func RunWithOptions(p *paths.Paths, d *db.DB, stepFactory StepFactory) error {
 
 	// Write PID file
 	pidPath := p.PIDFile()
-	pidRecord := daemonPIDFile{PID: os.Getpid(), StartedAt: time.Now().UTC()}
+	pidRecord, err := currentDaemonPIDRecord(processStartTime, func() time.Time { return time.Now().UTC() })
+	if err != nil {
+		return fmt.Errorf("build pid file: %w", err)
+	}
 	pidData, err := json.Marshal(pidRecord)
 	if err != nil {
 		return fmt.Errorf("marshal pid file: %w", err)
@@ -176,6 +179,18 @@ func RunWithOptions(p *paths.Paths, d *db.DB, stepFactory StepFactory) error {
 	}
 	slog.Info("daemon stopped")
 	return nil
+}
+
+func currentDaemonPIDRecord(startTime func(int) (time.Time, error), now func() time.Time) (daemonPIDFile, error) {
+	pid := os.Getpid()
+	startedAt, err := startTime(pid)
+	if err != nil {
+		startedAt = agent.CurrentProcessStartedAt()
+		if startedAt.IsZero() {
+			startedAt = now()
+		}
+	}
+	return daemonPIDFile{PID: pid, StartedAt: startedAt.UTC()}, nil
 }
 
 // recoverOnStartup cleans up after a previous daemon crash by marking stale

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -22,6 +22,8 @@ import (
 )
 
 var applyShellEnvToProcess = shellenv.ApplyToProcess
+var createDaemonPIDTempFile = os.CreateTemp
+var renameDaemonPIDFile = os.Rename
 
 // Run starts the daemon process. It blocks until a shutdown signal is received
 // or the shutdown IPC method is called. This is called when NM_DAEMON=1 or via
@@ -134,11 +136,7 @@ func RunWithOptions(p *paths.Paths, d *db.DB, stepFactory StepFactory) error {
 	if err != nil {
 		return fmt.Errorf("build pid file: %w", err)
 	}
-	pidData, err := json.Marshal(pidRecord)
-	if err != nil {
-		return fmt.Errorf("marshal pid file: %w", err)
-	}
-	if err := os.WriteFile(pidPath, pidData, 0o644); err != nil {
+	if err := writeDaemonPIDFile(pidPath, pidRecord); err != nil {
 		return fmt.Errorf("write pid file: %w", err)
 	}
 	defer func() {
@@ -191,6 +189,39 @@ func currentDaemonPIDRecord(startTime func(int) (time.Time, error), now func() t
 		}
 	}
 	return daemonPIDFile{PID: pid, StartedAt: startedAt.UTC()}, nil
+}
+
+func writeDaemonPIDFile(path string, record daemonPIDFile) error {
+	data, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("marshal pid file: %w", err)
+	}
+	tmp, err := createDaemonPIDTempFile(filepath.Dir(path), filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create pid temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		if tmpPath != "" {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := tmp.Chmod(0o644); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod pid temp file: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write pid temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close pid temp file: %w", err)
+	}
+	if err := renameDaemonPIDFile(tmpPath, path); err != nil {
+		return fmt.Errorf("rename pid file: %w", err)
+	}
+	tmpPath = ""
+	return nil
 }
 
 // recoverOnStartup cleans up after a previous daemon crash by marking stale

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kunchenguid/no-mistakes/internal/agent"
 	"github.com/kunchenguid/no-mistakes/internal/config"
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/git"
@@ -103,6 +104,11 @@ func RunWithOptions(p *paths.Paths, d *db.DB, stepFactory StepFactory) error {
 	// Recover stale runs from a previous daemon crash.
 	recoverOnStartup(d, p)
 
+	// Point the agent package at our PID tracking dir so any managed
+	// servers we spawn from here on leave crash-recovery breadcrumbs.
+	agent.SetServerPIDsDir(p.ServerPIDsDir())
+	defer agent.SetServerPIDsDir("")
+
 	srv := ipc.NewServer()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -164,8 +170,11 @@ func RunWithOptions(p *paths.Paths, d *db.DB, stepFactory StepFactory) error {
 }
 
 // recoverOnStartup cleans up after a previous daemon crash by marking stale
-// runs/steps as failed and removing orphaned worktree directories.
+// runs/steps as failed, killing orphaned managed-server subprocesses
+// (opencode, rovodev), and removing orphaned worktree directories.
 func recoverOnStartup(d *db.DB, p *paths.Paths) {
+	reapOrphanedServers(p)
+
 	count, err := d.RecoverStaleRuns("daemon crashed during execution")
 	if err != nil {
 		slog.Error("failed to recover stale runs", "error", err)

--- a/internal/daemon/lifecycle_test.go
+++ b/internal/daemon/lifecycle_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -15,6 +16,17 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
 )
+
+func writeDaemonPIDRecord(t *testing.T, path string, record daemonPIDFile) {
+	t.Helper()
+	data, err := json.Marshal(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
 
 func TestIsRunningFalseWhenNoSocket(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "dtest")
@@ -251,13 +263,7 @@ func TestStopDetachedDaemonRejectsStalePIDFallback(t *testing.T) {
 	if err := p.EnsureDirs(); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(p.PIDFile(), []byte(fmt.Sprintf("%d", os.Getpid())), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	oldTime := time.Now().Add(-24 * time.Hour)
-	if err := os.Chtimes(p.PIDFile(), oldTime, oldTime); err != nil {
-		t.Fatal(err)
-	}
+	writeDaemonPIDRecord(t, p.PIDFile(), daemonPIDFile{PID: os.Getpid(), StartedAt: time.Now().Add(-24 * time.Hour)})
 	ln, err := net.Listen("unix", p.Socket())
 	if err != nil {
 		t.Fatal(err)
@@ -311,9 +317,7 @@ func TestStopDetachedDaemonRejectsUnrelatedLiveProcessPIDFallback(t *testing.T) 
 	if err := p.EnsureDirs(); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(p.PIDFile(), []byte(fmt.Sprintf("%d", os.Getpid())), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeDaemonPIDRecord(t, p.PIDFile(), daemonPIDFile{PID: os.Getpid(), StartedAt: time.Now()})
 	ln, err := net.Listen("unix", p.Socket())
 	if err != nil {
 		t.Fatal(err)
@@ -625,13 +629,7 @@ func TestWaitForDaemonStopRejectsStalePIDBeforeKill(t *testing.T) {
 	if err := p.EnsureDirs(); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(p.PIDFile(), []byte(fmt.Sprintf("%d", os.Getpid())), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	oldTime := time.Now().Add(-24 * time.Hour)
-	if err := os.Chtimes(p.PIDFile(), oldTime, oldTime); err != nil {
-		t.Fatal(err)
-	}
+	writeDaemonPIDRecord(t, p.PIDFile(), daemonPIDFile{PID: os.Getpid(), StartedAt: time.Now().Add(-24 * time.Hour)})
 	if err := os.WriteFile(p.Socket(), []byte("still-there"), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/daemon/lifecycle_test.go
+++ b/internal/daemon/lifecycle_test.go
@@ -17,6 +17,10 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/paths"
 )
 
+type failingRenameError string
+
+func (e failingRenameError) Error() string { return string(e) }
+
 func writeDaemonPIDRecord(t *testing.T, path string, record daemonPIDFile) {
 	t.Helper()
 	data, err := json.Marshal(record)
@@ -418,6 +422,42 @@ func TestCurrentDaemonPIDRecord_UsesProcessStartTime(t *testing.T) {
 	}
 	if !record.StartedAt.Equal(want) {
 		t.Fatalf("record started_at = %v, want %v", record.StartedAt, want)
+	}
+}
+
+func TestWriteDaemonPIDFile_LeavesExistingFileUntouchedOnRenameFailure(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "daemon.pid")
+	original := []byte("old-data")
+	if err := os.WriteFile(path, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldRename := renameDaemonPIDFile
+	renameDaemonPIDFile = func(_, _ string) error {
+		return failingRenameError("rename failed")
+	}
+	t.Cleanup(func() {
+		renameDaemonPIDFile = oldRename
+	})
+
+	err := writeDaemonPIDFile(path, daemonPIDFile{PID: 12345, StartedAt: time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)})
+	if err == nil {
+		t.Fatal("expected writeDaemonPIDFile to fail when rename fails")
+	}
+	data, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("read pid file: %v", readErr)
+	}
+	if string(data) != string(original) {
+		t.Fatalf("pid file changed after failed atomic write: got %q want %q", string(data), string(original))
+	}
+	matches, globErr := filepath.Glob(filepath.Join(tmpDir, "daemon.pid.tmp-*"))
+	if globErr != nil {
+		t.Fatalf("glob temp files: %v", globErr)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected temp files to be cleaned up, got %v", matches)
 	}
 }
 

--- a/internal/daemon/lifecycle_test.go
+++ b/internal/daemon/lifecycle_test.go
@@ -366,6 +366,61 @@ func TestStopDetachedDaemonRejectsUnrelatedLiveProcessPIDFallback(t *testing.T) 
 	}
 }
 
+func TestValidateDaemonPIDFallback_RejectsLegacyPIDFileForReusedPID(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dtest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	p := paths.WithRoot(tmpDir)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.PIDFile(), []byte(fmt.Sprintf("%d", os.Getpid())), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	old := daemonProcessStartTime
+	daemonProcessStartTime = func(checkPID int) (time.Time, error) {
+		if checkPID != os.Getpid() {
+			t.Fatalf("processStartTime pid = %d, want %d", checkPID, os.Getpid())
+		}
+		return time.Now().Add(-time.Hour), nil
+	}
+	t.Cleanup(func() {
+		daemonProcessStartTime = old
+	})
+
+	err = validateDaemonPIDFallback(p, os.Getpid())
+	if err == nil {
+		t.Fatal("expected legacy pid fallback to reject reused pid")
+	}
+}
+
+func TestCurrentDaemonPIDRecord_UsesProcessStartTime(t *testing.T) {
+	want := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	now := want.Add(10 * time.Second)
+
+	record, err := currentDaemonPIDRecord(func(pid int) (time.Time, error) {
+		if pid != os.Getpid() {
+			t.Fatalf("processStartTime pid = %d, want %d", pid, os.Getpid())
+		}
+		return want, nil
+	}, func() time.Time {
+		return now
+	})
+	if err != nil {
+		t.Fatalf("currentDaemonPIDRecord returned error: %v", err)
+	}
+	if record.PID != os.Getpid() {
+		t.Fatalf("record pid = %d, want %d", record.PID, os.Getpid())
+	}
+	if !record.StartedAt.Equal(want) {
+		t.Fatalf("record started_at = %v, want %v", record.StartedAt, want)
+	}
+}
+
 func TestStopDetachedDaemonRemovesArtifactsForDeadPID(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("unix socket setup is platform-specific")

--- a/internal/daemon/lifecycle_test.go
+++ b/internal/daemon/lifecycle_test.go
@@ -187,9 +187,8 @@ func TestStopDetachedDaemonFallsBackToPIDWhenSocketIsBroken(t *testing.T) {
 		t.Fatal(err)
 	}
 	const pid = 424242
-	if err := os.WriteFile(p.PIDFile(), []byte(fmt.Sprintf("%d", pid)), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	startedAt := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	writeDaemonPIDRecord(t, p.PIDFile(), daemonPIDFile{PID: pid, StartedAt: startedAt})
 	ln, err := net.Listen("unix", p.Socket())
 	if err != nil {
 		t.Fatal(err)
@@ -220,7 +219,7 @@ func TestStopDetachedDaemonFallsBackToPIDWhenSocketIsBroken(t *testing.T) {
 		if checkPID != pid {
 			t.Fatalf("processStartTime pid = %d, want %d", checkPID, pid)
 		}
-		return time.Now(), nil
+		return startedAt, nil
 	}
 	defer func() {
 		daemonProcessStartTime = originalProcessStartTime
@@ -399,6 +398,47 @@ func TestValidateDaemonPIDFallback_RejectsLegacyPIDFileForReusedPID(t *testing.T
 	err = validateDaemonPIDFallback(p, os.Getpid())
 	if err == nil {
 		t.Fatal("expected legacy pid fallback to reject reused pid")
+	}
+}
+
+func TestValidateDaemonPIDFallback_RejectsLegacyPIDFileTouchedNearLivePID(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "dtest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	p := paths.WithRoot(tmpDir)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.PIDFile(), []byte(fmt.Sprintf("%d", os.Getpid())), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mtime := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(p.PIDFile(), mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+
+	oldStartTime := daemonProcessStartTime
+	oldHealth := daemonHealthCheck
+	daemonProcessStartTime = func(checkPID int) (time.Time, error) {
+		if checkPID != os.Getpid() {
+			t.Fatalf("processStartTime pid = %d, want %d", checkPID, os.Getpid())
+		}
+		return mtime.Add(time.Second), nil
+	}
+	daemonHealthCheck = func(*paths.Paths) (bool, error) {
+		return false, nil
+	}
+	t.Cleanup(func() {
+		daemonProcessStartTime = oldStartTime
+		daemonHealthCheck = oldHealth
+	})
+
+	err = validateDaemonPIDFallback(p, os.Getpid())
+	if err == nil {
+		t.Fatal("expected legacy pid fallback to reject timestamp-only matches")
 	}
 }
 

--- a/internal/daemon/recover_servers.go
+++ b/internal/daemon/recover_servers.go
@@ -19,6 +19,9 @@ import (
 // gap between cmd.Start() and the time.Now() we record.
 const orphanStartTimeTolerance = 2 * time.Second
 
+var processRunningFunc = processRunning
+var terminateOrphanProcessGroupFunc = terminateOrphanProcessGroup
+
 // reapOrphanedServers kills managed-server subprocesses (opencode,
 // rovodev) left behind by a crashed predecessor daemon and deletes their
 // stale PID files.
@@ -58,7 +61,7 @@ func reapOrphanedServers(p *paths.Paths) {
 			removeServerPIDFile(path)
 			continue
 		}
-		alive, err := processRunning(info.PID)
+		alive, err := processRunningFunc(info.PID)
 		if err != nil {
 			slog.Warn("check orphaned server", "pid", info.PID, "error", err)
 			continue
@@ -74,8 +77,9 @@ func reapOrphanedServers(p *paths.Paths) {
 			continue
 		}
 		slog.Info("reaping orphaned managed server", "pid", info.PID, "agent", info.Agent, "bin", info.Bin)
-		if err := terminateOrphanProcessGroup(info.PID); err != nil {
+		if err := terminateOrphanProcessGroupFunc(info.PID); err != nil {
 			slog.Warn("terminate orphan", "pid", info.PID, "error", err)
+			continue
 		}
 		removeServerPIDFile(path)
 	}
@@ -111,7 +115,11 @@ func otherDaemonAlive(p *paths.Paths) bool {
 	if err != nil || pid <= 0 || pid == os.Getpid() {
 		return false
 	}
-	alive, _ := processRunning(pid)
+	alive, err := processRunningFunc(pid)
+	if err != nil {
+		slog.Warn("check daemon pid", "pid", pid, "error", err)
+		return true
+	}
 	return alive
 }
 

--- a/internal/daemon/recover_servers.go
+++ b/internal/daemon/recover_servers.go
@@ -62,7 +62,7 @@ func reapOrphanedServers(p *paths.Paths) {
 			removeServerPIDFile(path)
 			continue
 		}
-		if info.Owner != "" && info.Owner != agent.ServerPIDOwnerDaemon {
+		if shouldSkipOrphanRecord(info) {
 			continue
 		}
 		alive, err := processRunningFunc(info.PID)
@@ -92,6 +92,24 @@ func reapOrphanedServers(p *paths.Paths) {
 		}
 		removeServerPIDFile(path)
 	}
+}
+
+func shouldSkipOrphanRecord(info agent.ServerPIDInfo) bool {
+	if info.Owner == "" || info.Owner == agent.ServerPIDOwnerDaemon {
+		return false
+	}
+	if info.Owner != agent.ServerPIDOwnerWizard {
+		return true
+	}
+	if info.OwnerPID <= 0 || info.OwnerPID == os.Getpid() {
+		return true
+	}
+	alive, err := processRunningFunc(info.OwnerPID)
+	if err != nil {
+		slog.Warn("check wizard owner pid", "pid", info.OwnerPID, "error", err)
+		return true
+	}
+	return alive
 }
 
 func readServerPIDRecord(path string) (agent.ServerPIDInfo, bool) {

--- a/internal/daemon/recover_servers.go
+++ b/internal/daemon/recover_servers.go
@@ -122,8 +122,16 @@ func otherDaemonAlive(p *paths.Paths) bool {
 		return false
 	}
 	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
-	if err != nil || pid <= 0 || pid == os.Getpid() {
+	if err != nil {
+		slog.Warn("parse daemon pid file", "path", p.PIDFile(), "error", err)
+		return true
+	}
+	if pid == os.Getpid() {
 		return false
+	}
+	if pid <= 0 {
+		slog.Warn("invalid daemon pid", "path", p.PIDFile(), "pid", pid)
+		return true
 	}
 	alive, err := processRunningFunc(pid)
 	if err != nil {

--- a/internal/daemon/recover_servers.go
+++ b/internal/daemon/recover_servers.go
@@ -183,7 +183,7 @@ func otherDaemonAlive(p *paths.Paths) bool {
 		slog.Warn("check daemon start time", "pid", record.PID, "error", err)
 		return true
 	}
-	matches, err := daemonPIDRecordMatchesProcess(p.PIDFile(), record, startedAt)
+	matches, err := daemonPIDRecordMatchesProcess(p, record, startedAt)
 	if err != nil {
 		slog.Warn("validate daemon pid", "path", p.PIDFile(), "pid", record.PID, "error", err)
 		return true
@@ -229,14 +229,21 @@ func orphanStartTimeMatches(info agent.ServerPIDInfo) (bool, error) {
 	return diff <= orphanStartTimeTolerance, nil
 }
 
-func daemonPIDRecordMatchesProcess(path string, record daemonPIDFile, actualStart time.Time) (bool, error) {
+func daemonPIDRecordMatchesProcess(p *paths.Paths, record daemonPIDFile, actualStart time.Time) (bool, error) {
 	expectedStart := record.StartedAt.UTC()
 	if expectedStart.IsZero() {
-		info, err := os.Stat(path)
+		alive, err := daemonHealthCheck(p)
 		if err != nil {
-			return false, fmt.Errorf("stat pid file: %w", err)
+			return false, fmt.Errorf("health check daemon: %w", err)
 		}
-		expectedStart = info.ModTime().UTC()
+		if !alive {
+			return false, nil
+		}
+		upgraded := daemonPIDFile{PID: record.PID, StartedAt: actualStart.UTC()}
+		if err := writeDaemonPIDFile(p.PIDFile(), upgraded); err != nil {
+			slog.Warn("upgrade legacy daemon pid file", "path", p.PIDFile(), "pid", record.PID, "error", err)
+		}
+		return true, nil
 	}
 	diff := actualStart.Sub(expectedStart)
 	if diff < 0 {

--- a/internal/daemon/recover_servers.go
+++ b/internal/daemon/recover_servers.go
@@ -109,7 +109,15 @@ func shouldSkipOrphanRecord(info agent.ServerPIDInfo) bool {
 		slog.Warn("check wizard owner pid", "pid", info.OwnerPID, "error", err)
 		return true
 	}
-	return alive
+	if !alive {
+		return false
+	}
+	startedAt, err := processStartTimeFunc(info.OwnerPID)
+	if err != nil {
+		slog.Warn("check wizard owner start time", "pid", info.OwnerPID, "error", err)
+		return true
+	}
+	return !startedAt.After(info.StartedAt.Add(orphanStartTimeTolerance))
 }
 
 func readServerPIDRecord(path string) (agent.ServerPIDInfo, bool) {
@@ -134,6 +142,14 @@ func removeServerPIDFile(path string) {
 // process that isn't us. The recovery path runs before the new daemon
 // writes its own PID file, so any live PID here belongs to a predecessor.
 func otherDaemonAlive(p *paths.Paths) bool {
+	info, statErr := os.Stat(p.PIDFile())
+	if statErr != nil {
+		if !os.IsNotExist(statErr) {
+			slog.Warn("stat daemon pid file", "path", p.PIDFile(), "error", statErr)
+			return true
+		}
+		return false
+	}
 	data, err := os.ReadFile(p.PIDFile())
 	if err != nil {
 		if !os.IsNotExist(err) {
@@ -159,7 +175,15 @@ func otherDaemonAlive(p *paths.Paths) bool {
 		slog.Warn("check daemon pid", "pid", pid, "error", err)
 		return true
 	}
-	return alive
+	if !alive {
+		return false
+	}
+	startedAt, err := processStartTimeFunc(pid)
+	if err != nil {
+		slog.Warn("check daemon start time", "pid", pid, "error", err)
+		return true
+	}
+	return !startedAt.After(info.ModTime().Add(orphanStartTimeTolerance))
 }
 
 func orphanStartTimeMatches(info agent.ServerPIDInfo) (bool, error) {

--- a/internal/daemon/recover_servers.go
+++ b/internal/daemon/recover_servers.go
@@ -20,6 +20,7 @@ import (
 const orphanStartTimeTolerance = 2 * time.Second
 
 var processRunningFunc = processRunning
+var processStartTimeFunc = processStartTime
 var terminateOrphanProcessGroupFunc = terminateOrphanProcessGroup
 
 // reapOrphanedServers kills managed-server subprocesses (opencode,
@@ -70,7 +71,12 @@ func reapOrphanedServers(p *paths.Paths) {
 			removeServerPIDFile(path)
 			continue
 		}
-		if !orphanStartTimeMatches(info) {
+		matches, err := orphanStartTimeMatches(info)
+		if err != nil {
+			slog.Warn("check orphan start time", "pid", info.PID, "error", err)
+			continue
+		}
+		if !matches {
 			slog.Info("orphan pid file stale; pid reused by unrelated process, not killing",
 				"pid", info.PID, "agent", info.Agent)
 			removeServerPIDFile(path)
@@ -109,6 +115,10 @@ func removeServerPIDFile(path string) {
 func otherDaemonAlive(p *paths.Paths) bool {
 	data, err := os.ReadFile(p.PIDFile())
 	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Warn("read daemon pid file", "path", p.PIDFile(), "error", err)
+			return true
+		}
 		return false
 	}
 	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
@@ -123,14 +133,14 @@ func otherDaemonAlive(p *paths.Paths) bool {
 	return alive
 }
 
-func orphanStartTimeMatches(info agent.ServerPIDInfo) bool {
-	actual, err := processStartTime(info.PID)
+func orphanStartTimeMatches(info agent.ServerPIDInfo) (bool, error) {
+	actual, err := processStartTimeFunc(info.PID)
 	if err != nil {
-		return false
+		return false, err
 	}
 	diff := actual.Sub(info.StartedAt)
 	if diff < 0 {
 		diff = -diff
 	}
-	return diff <= orphanStartTimeTolerance
+	return diff <= orphanStartTimeTolerance, nil
 }

--- a/internal/daemon/recover_servers.go
+++ b/internal/daemon/recover_servers.go
@@ -1,0 +1,128 @@
+package daemon
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/agent"
+	"github.com/kunchenguid/no-mistakes/internal/paths"
+)
+
+// orphanStartTimeTolerance bounds the acceptable difference between the
+// process start time recorded in a PID file and the one reported by the
+// kernel now. A small nonzero value absorbs clock quirks and the sub-second
+// gap between cmd.Start() and the time.Now() we record.
+const orphanStartTimeTolerance = 2 * time.Second
+
+// reapOrphanedServers kills managed-server subprocesses (opencode,
+// rovodev) left behind by a crashed predecessor daemon and deletes their
+// stale PID files.
+//
+// Safety rules:
+//   - If another no-mistakes daemon is still running, skip everything so
+//     we don't kill that daemon's live servers.
+//   - For each PID file, require the recorded StartedAt to match the
+//     process's actual start time within orphanStartTimeTolerance. If not,
+//     the PID has been reused by something unrelated; delete the file but
+//     do not signal the process.
+func reapOrphanedServers(p *paths.Paths) {
+	dir := p.ServerPIDsDir()
+	if otherDaemonAlive(p) {
+		slog.Info("another daemon appears to be running; skipping managed-server reap", "dir", dir)
+		return
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Warn("read server pids dir", "dir", dir, "error", err)
+		}
+		return
+	}
+	myPID := os.Getpid()
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		info, ok := readServerPIDRecord(path)
+		if !ok {
+			removeServerPIDFile(path)
+			continue
+		}
+		if info.PID <= 0 || info.PID == myPID {
+			removeServerPIDFile(path)
+			continue
+		}
+		alive, err := processRunning(info.PID)
+		if err != nil {
+			slog.Warn("check orphaned server", "pid", info.PID, "error", err)
+			continue
+		}
+		if !alive {
+			removeServerPIDFile(path)
+			continue
+		}
+		if !orphanStartTimeMatches(info) {
+			slog.Info("orphan pid file stale; pid reused by unrelated process, not killing",
+				"pid", info.PID, "agent", info.Agent)
+			removeServerPIDFile(path)
+			continue
+		}
+		slog.Info("reaping orphaned managed server", "pid", info.PID, "agent", info.Agent, "bin", info.Bin)
+		if err := terminateOrphanProcessGroup(info.PID); err != nil {
+			slog.Warn("terminate orphan", "pid", info.PID, "error", err)
+		}
+		removeServerPIDFile(path)
+	}
+}
+
+func readServerPIDRecord(path string) (agent.ServerPIDInfo, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return agent.ServerPIDInfo{}, false
+	}
+	var info agent.ServerPIDInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return agent.ServerPIDInfo{}, false
+	}
+	return info, true
+}
+
+func removeServerPIDFile(path string) {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		slog.Warn("remove server pid file", "path", path, "error", err)
+	}
+}
+
+// otherDaemonAlive returns true if the daemon PID file points at a running
+// process that isn't us. The recovery path runs before the new daemon
+// writes its own PID file, so any live PID here belongs to a predecessor.
+func otherDaemonAlive(p *paths.Paths) bool {
+	data, err := os.ReadFile(p.PIDFile())
+	if err != nil {
+		return false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 || pid == os.Getpid() {
+		return false
+	}
+	alive, _ := processRunning(pid)
+	return alive
+}
+
+func orphanStartTimeMatches(info agent.ServerPIDInfo) bool {
+	actual, err := processStartTime(info.PID)
+	if err != nil {
+		return false
+	}
+	diff := actual.Sub(info.StartedAt)
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff <= orphanStartTimeTolerance
+}

--- a/internal/daemon/recover_servers.go
+++ b/internal/daemon/recover_servers.go
@@ -62,6 +62,9 @@ func reapOrphanedServers(p *paths.Paths) {
 			removeServerPIDFile(path)
 			continue
 		}
+		if info.Owner != "" && info.Owner != agent.ServerPIDOwnerDaemon {
+			continue
+		}
 		alive, err := processRunningFunc(info.PID)
 		if err != nil {
 			slog.Warn("check orphaned server", "pid", info.PID, "error", err)

--- a/internal/daemon/recover_servers.go
+++ b/internal/daemon/recover_servers.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -22,6 +23,11 @@ const orphanStartTimeTolerance = 2 * time.Second
 var processRunningFunc = processRunning
 var processStartTimeFunc = processStartTime
 var terminateOrphanProcessGroupFunc = terminateOrphanProcessGroup
+
+type daemonPIDFile struct {
+	PID       int       `json:"pid"`
+	StartedAt time.Time `json:"started_at,omitempty"`
+}
 
 // reapOrphanedServers kills managed-server subprocesses (opencode,
 // rovodev) left behind by a crashed predecessor daemon and deletes their
@@ -117,7 +123,14 @@ func shouldSkipOrphanRecord(info agent.ServerPIDInfo) bool {
 		slog.Warn("check wizard owner start time", "pid", info.OwnerPID, "error", err)
 		return true
 	}
-	return !startedAt.After(info.StartedAt.Add(orphanStartTimeTolerance))
+	if info.OwnerStartedAt.IsZero() {
+		return true
+	}
+	diff := startedAt.Sub(info.OwnerStartedAt)
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff <= orphanStartTimeTolerance
 }
 
 func readServerPIDRecord(path string) (agent.ServerPIDInfo, bool) {
@@ -142,15 +155,7 @@ func removeServerPIDFile(path string) {
 // process that isn't us. The recovery path runs before the new daemon
 // writes its own PID file, so any live PID here belongs to a predecessor.
 func otherDaemonAlive(p *paths.Paths) bool {
-	info, statErr := os.Stat(p.PIDFile())
-	if statErr != nil {
-		if !os.IsNotExist(statErr) {
-			slog.Warn("stat daemon pid file", "path", p.PIDFile(), "error", statErr)
-			return true
-		}
-		return false
-	}
-	data, err := os.ReadFile(p.PIDFile())
+	record, err := readDaemonPIDFile(p.PIDFile())
 	if err != nil {
 		if !os.IsNotExist(err) {
 			slog.Warn("read daemon pid file", "path", p.PIDFile(), "error", err)
@@ -158,32 +163,60 @@ func otherDaemonAlive(p *paths.Paths) bool {
 		}
 		return false
 	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
-	if err != nil {
-		slog.Warn("parse daemon pid file", "path", p.PIDFile(), "error", err)
-		return true
-	}
-	if pid == os.Getpid() {
+	if record.PID == os.Getpid() {
 		return false
 	}
-	if pid <= 0 {
-		slog.Warn("invalid daemon pid", "path", p.PIDFile(), "pid", pid)
+	if record.PID <= 0 {
+		slog.Warn("invalid daemon pid", "path", p.PIDFile(), "pid", record.PID)
 		return true
 	}
-	alive, err := processRunningFunc(pid)
+	alive, err := processRunningFunc(record.PID)
 	if err != nil {
-		slog.Warn("check daemon pid", "pid", pid, "error", err)
+		slog.Warn("check daemon pid", "pid", record.PID, "error", err)
 		return true
 	}
 	if !alive {
 		return false
 	}
-	startedAt, err := processStartTimeFunc(pid)
-	if err != nil {
-		slog.Warn("check daemon start time", "pid", pid, "error", err)
+	if record.StartedAt.IsZero() {
 		return true
 	}
-	return !startedAt.After(info.ModTime().Add(orphanStartTimeTolerance))
+	startedAt, err := processStartTimeFunc(record.PID)
+	if err != nil {
+		slog.Warn("check daemon start time", "pid", record.PID, "error", err)
+		return true
+	}
+	diff := startedAt.Sub(record.StartedAt)
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff <= orphanStartTimeTolerance
+}
+
+func readDaemonPIDFile(path string) (daemonPIDFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return daemonPIDFile{}, err
+	}
+	return readDaemonPIDFileData(data)
+}
+
+func readDaemonPIDFileData(data []byte) (daemonPIDFile, error) {
+	var record daemonPIDFile
+	if err := json.Unmarshal(data, &record); err == nil {
+		if record.PID <= 0 {
+			return daemonPIDFile{}, fmt.Errorf("invalid pid file: pid must be positive")
+		}
+		return record, nil
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return daemonPIDFile{}, fmt.Errorf("invalid pid file: %w", err)
+	}
+	if pid <= 0 {
+		return daemonPIDFile{}, fmt.Errorf("invalid pid file: pid must be positive")
+	}
+	return daemonPIDFile{PID: pid}, nil
 }
 
 func orphanStartTimeMatches(info agent.ServerPIDInfo) (bool, error) {

--- a/internal/daemon/recover_servers.go
+++ b/internal/daemon/recover_servers.go
@@ -107,7 +107,7 @@ func shouldSkipOrphanRecord(info agent.ServerPIDInfo) bool {
 	if info.Owner != agent.ServerPIDOwnerWizard {
 		return true
 	}
-	if info.OwnerPID <= 0 || info.OwnerPID == os.Getpid() {
+	if info.OwnerPID <= 0 {
 		return true
 	}
 	alive, err := processRunningFunc(info.OwnerPID)

--- a/internal/daemon/recover_servers.go
+++ b/internal/daemon/recover_servers.go
@@ -178,19 +178,17 @@ func otherDaemonAlive(p *paths.Paths) bool {
 	if !alive {
 		return false
 	}
-	if record.StartedAt.IsZero() {
-		return true
-	}
 	startedAt, err := processStartTimeFunc(record.PID)
 	if err != nil {
 		slog.Warn("check daemon start time", "pid", record.PID, "error", err)
 		return true
 	}
-	diff := startedAt.Sub(record.StartedAt)
-	if diff < 0 {
-		diff = -diff
+	matches, err := daemonPIDRecordMatchesProcess(p.PIDFile(), record, startedAt)
+	if err != nil {
+		slog.Warn("validate daemon pid", "path", p.PIDFile(), "pid", record.PID, "error", err)
+		return true
 	}
-	return diff <= orphanStartTimeTolerance
+	return matches
 }
 
 func readDaemonPIDFile(path string) (daemonPIDFile, error) {
@@ -225,6 +223,22 @@ func orphanStartTimeMatches(info agent.ServerPIDInfo) (bool, error) {
 		return false, err
 	}
 	diff := actual.Sub(info.StartedAt)
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff <= orphanStartTimeTolerance, nil
+}
+
+func daemonPIDRecordMatchesProcess(path string, record daemonPIDFile, actualStart time.Time) (bool, error) {
+	expectedStart := record.StartedAt.UTC()
+	if expectedStart.IsZero() {
+		info, err := os.Stat(path)
+		if err != nil {
+			return false, fmt.Errorf("stat pid file: %w", err)
+		}
+		expectedStart = info.ModTime().UTC()
+	}
+	diff := actualStart.Sub(expectedStart)
 	if diff < 0 {
 		diff = -diff
 	}

--- a/internal/daemon/recover_servers_test.go
+++ b/internal/daemon/recover_servers_test.go
@@ -96,10 +96,11 @@ func TestReapOrphanedServers_SkipsWizardOwnedRecord(t *testing.T) {
 		t.Fatal(err)
 	}
 	startedAt := time.Now().UTC()
+	const ownerPID = 54321
 	path := writePIDRecord(t, p.ServerPIDsDir(), "opencode-wizard.json", agent.ServerPIDInfo{
 		PID:            12345,
 		Owner:          agent.ServerPIDOwnerWizard,
-		OwnerPID:       os.Getpid(),
+		OwnerPID:       ownerPID,
 		OwnerStartedAt: startedAt,
 		Agent:          "opencode",
 		StartedAt:      startedAt,
@@ -109,16 +110,16 @@ func TestReapOrphanedServers_SkipsWizardOwnedRecord(t *testing.T) {
 	oldStartTime := processStartTimeFunc
 	oldTerminate := terminateOrphanProcessGroupFunc
 	processRunningFunc = func(pid int) (bool, error) {
-		if pid != 12345 {
+		if pid != ownerPID {
 			t.Fatalf("unexpected pid %d", pid)
 		}
 		return true, nil
 	}
 	processStartTimeFunc = func(pid int) (time.Time, error) {
-		if pid != 12345 {
+		if pid != ownerPID {
 			t.Fatalf("unexpected pid %d", pid)
 		}
-		return startedAt.Add(-time.Second), nil
+		return startedAt.Add(time.Second), nil
 	}
 	terminateOrphanProcessGroupFunc = func(pid int) error {
 		t.Fatalf("wizard-owned pid %d should not be terminated", pid)
@@ -196,6 +197,37 @@ func TestReapOrphanedServers_ReapsWizardOwnedRecordWhenOwnerPIDReused(t *testing
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Fatalf("wizard-owned pid file should be removed after reap, got err=%v", err)
+	}
+}
+
+func TestShouldSkipOrphanRecord_FalseWhenWizardOwnerPIDMatchesCurrentDaemonButStartTimeDiffers(t *testing.T) {
+	startedAt := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+
+	oldRunning := processRunningFunc
+	oldStartTime := processStartTimeFunc
+	processRunningFunc = func(pid int) (bool, error) {
+		if pid != os.Getpid() {
+			t.Fatalf("unexpected pid %d", pid)
+		}
+		return true, nil
+	}
+	processStartTimeFunc = func(pid int) (time.Time, error) {
+		if pid != os.Getpid() {
+			t.Fatalf("unexpected pid %d", pid)
+		}
+		return startedAt.Add(10 * time.Minute), nil
+	}
+	t.Cleanup(func() {
+		processRunningFunc = oldRunning
+		processStartTimeFunc = oldStartTime
+	})
+
+	if shouldSkipOrphanRecord(agent.ServerPIDInfo{
+		Owner:          agent.ServerPIDOwnerWizard,
+		OwnerPID:       os.Getpid(),
+		OwnerStartedAt: startedAt,
+	}) {
+		t.Fatal("expected mismatched current-daemon pid reuse to be reaped")
 	}
 }
 

--- a/internal/daemon/recover_servers_test.go
+++ b/internal/daemon/recover_servers_test.go
@@ -145,3 +145,17 @@ func TestOtherDaemonAlive_TrueWhenLivenessCheckErrors(t *testing.T) {
 		t.Error("liveness-check errors should conservatively block orphan reaping")
 	}
 }
+
+func TestOtherDaemonAlive_TrueWhenPIDFileUnreadable(t *testing.T) {
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(p.PIDFile(), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if !otherDaemonAlive(p) {
+		t.Error("pid-file read errors should conservatively block orphan reaping")
+	}
+}

--- a/internal/daemon/recover_servers_test.go
+++ b/internal/daemon/recover_servers_test.go
@@ -159,3 +159,17 @@ func TestOtherDaemonAlive_TrueWhenPIDFileUnreadable(t *testing.T) {
 		t.Error("pid-file read errors should conservatively block orphan reaping")
 	}
 }
+
+func TestOtherDaemonAlive_TrueWhenPIDFileCorrupt(t *testing.T) {
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.PIDFile(), []byte("not-a-pid"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !otherDaemonAlive(p) {
+		t.Error("corrupt pid file should conservatively block orphan reaping")
+	}
+}

--- a/internal/daemon/recover_servers_test.go
+++ b/internal/daemon/recover_servers_test.go
@@ -393,6 +393,102 @@ func TestOtherDaemonAlive_FalseWhenLegacyPIDFileMatchesReusedPID(t *testing.T) {
 	}
 }
 
+func TestOtherDaemonAlive_FalseWhenLegacyPIDFileTouchedNearLivePID(t *testing.T) {
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.PIDFile(), []byte("12345"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mtime := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(p.PIDFile(), mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+
+	oldRunning := processRunningFunc
+	oldStartTime := processStartTimeFunc
+	oldHealth := daemonHealthCheck
+	processRunningFunc = func(pid int) (bool, error) {
+		if pid != 12345 {
+			t.Fatalf("unexpected pid %d", pid)
+		}
+		return true, nil
+	}
+	processStartTimeFunc = func(pid int) (time.Time, error) {
+		if pid != 12345 {
+			t.Fatalf("unexpected pid %d", pid)
+		}
+		return mtime.Add(time.Second), nil
+	}
+	daemonHealthCheck = func(*paths.Paths) (bool, error) {
+		return false, nil
+	}
+	t.Cleanup(func() {
+		processRunningFunc = oldRunning
+		processStartTimeFunc = oldStartTime
+		daemonHealthCheck = oldHealth
+	})
+
+	if otherDaemonAlive(p) {
+		t.Error("legacy pid file should not trust file timestamps as process identity")
+	}
+}
+
+func TestOtherDaemonAlive_TrueWhenLegacyPIDFileMatchesResponsiveDaemon(t *testing.T) {
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.PIDFile(), []byte("12345"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mtime := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(p.PIDFile(), mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+	startedAt := mtime.Add(time.Hour)
+
+	oldRunning := processRunningFunc
+	oldStartTime := processStartTimeFunc
+	oldHealth := daemonHealthCheck
+	processRunningFunc = func(pid int) (bool, error) {
+		if pid != 12345 {
+			t.Fatalf("unexpected pid %d", pid)
+		}
+		return true, nil
+	}
+	processStartTimeFunc = func(pid int) (time.Time, error) {
+		if pid != 12345 {
+			t.Fatalf("unexpected pid %d", pid)
+		}
+		return startedAt, nil
+	}
+	daemonHealthCheck = func(*paths.Paths) (bool, error) {
+		return true, nil
+	}
+	t.Cleanup(func() {
+		processRunningFunc = oldRunning
+		processStartTimeFunc = oldStartTime
+		daemonHealthCheck = oldHealth
+	})
+
+	if !otherDaemonAlive(p) {
+		t.Fatal("responsive legacy daemon should still block orphan reaping")
+	}
+
+	record, err := readDaemonPIDFile(p.PIDFile())
+	if err != nil {
+		t.Fatalf("read upgraded pid file: %v", err)
+	}
+	if record.PID != 12345 {
+		t.Fatalf("upgraded pid = %d, want 12345", record.PID)
+	}
+	if !record.StartedAt.Equal(startedAt.UTC()) {
+		t.Fatalf("upgraded started_at = %v, want %v", record.StartedAt, startedAt.UTC())
+	}
+}
+
 func TestOtherDaemonAlive_TrueWhenDaemonStartTimeMatchesRecord(t *testing.T) {
 	p := paths.WithRoot(t.TempDir())
 	if err := p.EnsureDirs(); err != nil {

--- a/internal/daemon/recover_servers_test.go
+++ b/internal/daemon/recover_servers_test.go
@@ -98,6 +98,7 @@ func TestReapOrphanedServers_SkipsWizardOwnedRecord(t *testing.T) {
 	path := writePIDRecord(t, p.ServerPIDsDir(), "opencode-wizard.json", agent.ServerPIDInfo{
 		PID:       12345,
 		Owner:     agent.ServerPIDOwnerWizard,
+		OwnerPID:  os.Getpid(),
 		Agent:     "opencode",
 		StartedAt: time.Now().UTC(),
 	})

--- a/internal/daemon/recover_servers_test.go
+++ b/internal/daemon/recover_servers_test.go
@@ -356,6 +356,43 @@ func TestOtherDaemonAlive_FalseWhenPIDReusedByNewerProcess(t *testing.T) {
 	}
 }
 
+func TestOtherDaemonAlive_FalseWhenLegacyPIDFileMatchesReusedPID(t *testing.T) {
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.PIDFile(), []byte("12345"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mtime := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(p.PIDFile(), mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+
+	oldRunning := processRunningFunc
+	oldStartTime := processStartTimeFunc
+	processRunningFunc = func(pid int) (bool, error) {
+		if pid != 12345 {
+			t.Fatalf("unexpected pid %d", pid)
+		}
+		return true, nil
+	}
+	processStartTimeFunc = func(pid int) (time.Time, error) {
+		if pid != 12345 {
+			t.Fatalf("unexpected pid %d", pid)
+		}
+		return mtime.Add(time.Hour), nil
+	}
+	t.Cleanup(func() {
+		processRunningFunc = oldRunning
+		processStartTimeFunc = oldStartTime
+	})
+
+	if otherDaemonAlive(p) {
+		t.Error("legacy pid file with reused pid should not block orphan reaping")
+	}
+}
+
 func TestOtherDaemonAlive_TrueWhenDaemonStartTimeMatchesRecord(t *testing.T) {
 	p := paths.WithRoot(t.TempDir())
 	if err := p.EnsureDirs(); err != nil {

--- a/internal/daemon/recover_servers_test.go
+++ b/internal/daemon/recover_servers_test.go
@@ -1,0 +1,124 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/agent"
+	"github.com/kunchenguid/no-mistakes/internal/paths"
+)
+
+func writePIDRecord(t *testing.T, dir, name string, info agent.ServerPIDInfo) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, name)
+	data, err := json.Marshal(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestReapOrphanedServers_NonexistentDirNoop(t *testing.T) {
+	p := paths.WithRoot(t.TempDir())
+	// Don't call EnsureDirs - ServerPIDsDir won't exist.
+	reapOrphanedServers(p) // must not panic
+}
+
+func TestReapOrphanedServers_EmptyDirNoop(t *testing.T) {
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	reapOrphanedServers(p)
+}
+
+func TestReapOrphanedServers_RemovesMalformedFile(t *testing.T) {
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	bad := filepath.Join(p.ServerPIDsDir(), "garbage.json")
+	if err := os.WriteFile(bad, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reapOrphanedServers(p)
+	if _, err := os.Stat(bad); !os.IsNotExist(err) {
+		t.Errorf("malformed file should be removed, got err=%v", err)
+	}
+}
+
+func TestReapOrphanedServers_RemovesStaleFileForDeadPID(t *testing.T) {
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	path := writePIDRecord(t, p.ServerPIDsDir(), "opencode-999999.json", agent.ServerPIDInfo{
+		PID:       999999, // conventional "almost certainly unused" PID
+		Agent:     "opencode",
+		Bin:       "/bin/fake",
+		StartedAt: time.Now().UTC(),
+	})
+	reapOrphanedServers(p)
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("stale file should be removed, got err=%v", err)
+	}
+}
+
+func TestReapOrphanedServers_SkipsAndRemovesOwnPID(t *testing.T) {
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	path := writePIDRecord(t, p.ServerPIDsDir(), "opencode-self.json", agent.ServerPIDInfo{
+		PID:       os.Getpid(),
+		Agent:     "opencode",
+		StartedAt: time.Now().UTC(),
+	})
+	reapOrphanedServers(p)
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("own-pid file should be cleared, got err=%v", err)
+	}
+}
+
+func TestOtherDaemonAlive_FalseForMissingFile(t *testing.T) {
+	p := paths.WithRoot(t.TempDir())
+	if otherDaemonAlive(p) {
+		t.Error("expected false when no daemon pid file")
+	}
+}
+
+func TestOtherDaemonAlive_FalseForOwnPID(t *testing.T) {
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.PIDFile(), []byte(fmt.Sprintf("%d", os.Getpid())), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if otherDaemonAlive(p) {
+		t.Error("own pid should not count as another daemon")
+	}
+}
+
+func TestOtherDaemonAlive_FalseForDeadPID(t *testing.T) {
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.PIDFile(), []byte("999999"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if otherDaemonAlive(p) {
+		t.Error("dead pid should not count as another daemon")
+	}
+}

--- a/internal/daemon/recover_servers_test.go
+++ b/internal/daemon/recover_servers_test.go
@@ -95,12 +95,13 @@ func TestReapOrphanedServers_SkipsWizardOwnedRecord(t *testing.T) {
 	if err := p.EnsureDirs(); err != nil {
 		t.Fatal(err)
 	}
+	startedAt := time.Now().UTC()
 	path := writePIDRecord(t, p.ServerPIDsDir(), "opencode-wizard.json", agent.ServerPIDInfo{
 		PID:       12345,
 		Owner:     agent.ServerPIDOwnerWizard,
 		OwnerPID:  os.Getpid(),
 		Agent:     "opencode",
-		StartedAt: time.Now().UTC(),
+		StartedAt: startedAt,
 	})
 
 	oldRunning := processRunningFunc
@@ -113,8 +114,10 @@ func TestReapOrphanedServers_SkipsWizardOwnedRecord(t *testing.T) {
 		return true, nil
 	}
 	processStartTimeFunc = func(pid int) (time.Time, error) {
-		t.Fatalf("start time should not be checked for wizard-owned pid %d", pid)
-		return time.Time{}, nil
+		if pid != 12345 {
+			t.Fatalf("unexpected pid %d", pid)
+		}
+		return startedAt.Add(-time.Second), nil
 	}
 	terminateOrphanProcessGroupFunc = func(pid int) error {
 		t.Fatalf("wizard-owned pid %d should not be terminated", pid)
@@ -130,6 +133,67 @@ func TestReapOrphanedServers_SkipsWizardOwnedRecord(t *testing.T) {
 
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("wizard-owned pid file should be kept, got err=%v", err)
+	}
+}
+
+func TestReapOrphanedServers_ReapsWizardOwnedRecordWhenOwnerPIDReused(t *testing.T) {
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	startedAt := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	path := writePIDRecord(t, p.ServerPIDsDir(), "opencode-wizard-reused.json", agent.ServerPIDInfo{
+		PID:       12345,
+		Owner:     agent.ServerPIDOwnerWizard,
+		OwnerPID:  54321,
+		Agent:     "opencode",
+		StartedAt: startedAt,
+	})
+
+	oldRunning := processRunningFunc
+	oldStartTime := processStartTimeFunc
+	oldTerminate := terminateOrphanProcessGroupFunc
+	processRunningFunc = func(pid int) (bool, error) {
+		switch pid {
+		case 54321, 12345:
+			return true, nil
+		default:
+			t.Fatalf("unexpected pid %d", pid)
+			return false, nil
+		}
+	}
+	processStartTimeFunc = func(pid int) (time.Time, error) {
+		switch pid {
+		case 54321:
+			return startedAt.Add(time.Hour), nil
+		case 12345:
+			return startedAt, nil
+		default:
+			t.Fatalf("unexpected pid %d", pid)
+			return time.Time{}, nil
+		}
+	}
+	terminated := 0
+	terminateOrphanProcessGroupFunc = func(pid int) error {
+		if pid != 12345 {
+			t.Fatalf("unexpected pid %d", pid)
+		}
+		terminated++
+		return nil
+	}
+	t.Cleanup(func() {
+		processRunningFunc = oldRunning
+		processStartTimeFunc = oldStartTime
+		terminateOrphanProcessGroupFunc = oldTerminate
+	})
+
+	reapOrphanedServers(p)
+
+	if terminated != 1 {
+		t.Fatalf("expected one terminate call, got %d", terminated)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("wizard-owned pid file should be removed after reap, got err=%v", err)
 	}
 }
 
@@ -214,5 +278,42 @@ func TestOtherDaemonAlive_TrueWhenPIDFileCorrupt(t *testing.T) {
 
 	if !otherDaemonAlive(p) {
 		t.Error("corrupt pid file should conservatively block orphan reaping")
+	}
+}
+
+func TestOtherDaemonAlive_FalseWhenPIDReusedByNewerProcess(t *testing.T) {
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.PIDFile(), []byte("12345"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pidFileTime := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(p.PIDFile(), pidFileTime, pidFileTime); err != nil {
+		t.Fatal(err)
+	}
+
+	oldRunning := processRunningFunc
+	oldStartTime := processStartTimeFunc
+	processRunningFunc = func(pid int) (bool, error) {
+		if pid != 12345 {
+			t.Fatalf("unexpected pid %d", pid)
+		}
+		return true, nil
+	}
+	processStartTimeFunc = func(pid int) (time.Time, error) {
+		if pid != 12345 {
+			t.Fatalf("unexpected pid %d", pid)
+		}
+		return pidFileTime.Add(time.Hour), nil
+	}
+	t.Cleanup(func() {
+		processRunningFunc = oldRunning
+		processStartTimeFunc = oldStartTime
+	})
+
+	if otherDaemonAlive(p) {
+		t.Error("reused pid from a newer process should not block orphan reaping")
 	}
 }

--- a/internal/daemon/recover_servers_test.go
+++ b/internal/daemon/recover_servers_test.go
@@ -90,6 +90,48 @@ func TestReapOrphanedServers_SkipsAndRemovesOwnPID(t *testing.T) {
 	}
 }
 
+func TestReapOrphanedServers_SkipsWizardOwnedRecord(t *testing.T) {
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	path := writePIDRecord(t, p.ServerPIDsDir(), "opencode-wizard.json", agent.ServerPIDInfo{
+		PID:       12345,
+		Owner:     agent.ServerPIDOwnerWizard,
+		Agent:     "opencode",
+		StartedAt: time.Now().UTC(),
+	})
+
+	oldRunning := processRunningFunc
+	oldStartTime := processStartTimeFunc
+	oldTerminate := terminateOrphanProcessGroupFunc
+	processRunningFunc = func(pid int) (bool, error) {
+		if pid != 12345 {
+			t.Fatalf("unexpected pid %d", pid)
+		}
+		return true, nil
+	}
+	processStartTimeFunc = func(pid int) (time.Time, error) {
+		t.Fatalf("start time should not be checked for wizard-owned pid %d", pid)
+		return time.Time{}, nil
+	}
+	terminateOrphanProcessGroupFunc = func(pid int) error {
+		t.Fatalf("wizard-owned pid %d should not be terminated", pid)
+		return nil
+	}
+	t.Cleanup(func() {
+		processRunningFunc = oldRunning
+		processStartTimeFunc = oldStartTime
+		terminateOrphanProcessGroupFunc = oldTerminate
+	})
+
+	reapOrphanedServers(p)
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("wizard-owned pid file should be kept, got err=%v", err)
+	}
+}
+
 func TestOtherDaemonAlive_FalseForMissingFile(t *testing.T) {
 	p := paths.WithRoot(t.TempDir())
 	if otherDaemonAlive(p) {

--- a/internal/daemon/recover_servers_test.go
+++ b/internal/daemon/recover_servers_test.go
@@ -97,11 +97,12 @@ func TestReapOrphanedServers_SkipsWizardOwnedRecord(t *testing.T) {
 	}
 	startedAt := time.Now().UTC()
 	path := writePIDRecord(t, p.ServerPIDsDir(), "opencode-wizard.json", agent.ServerPIDInfo{
-		PID:       12345,
-		Owner:     agent.ServerPIDOwnerWizard,
-		OwnerPID:  os.Getpid(),
-		Agent:     "opencode",
-		StartedAt: startedAt,
+		PID:            12345,
+		Owner:          agent.ServerPIDOwnerWizard,
+		OwnerPID:       os.Getpid(),
+		OwnerStartedAt: startedAt,
+		Agent:          "opencode",
+		StartedAt:      startedAt,
 	})
 
 	oldRunning := processRunningFunc
@@ -143,11 +144,12 @@ func TestReapOrphanedServers_ReapsWizardOwnedRecordWhenOwnerPIDReused(t *testing
 	}
 	startedAt := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
 	path := writePIDRecord(t, p.ServerPIDsDir(), "opencode-wizard-reused.json", agent.ServerPIDInfo{
-		PID:       12345,
-		Owner:     agent.ServerPIDOwnerWizard,
-		OwnerPID:  54321,
-		Agent:     "opencode",
-		StartedAt: startedAt,
+		PID:            12345,
+		Owner:          agent.ServerPIDOwnerWizard,
+		OwnerPID:       54321,
+		OwnerStartedAt: startedAt,
+		Agent:          "opencode",
+		StartedAt:      startedAt,
 	})
 
 	oldRunning := processRunningFunc
@@ -289,8 +291,12 @@ func TestOtherDaemonAlive_FalseWhenPIDReusedByNewerProcess(t *testing.T) {
 	if err := os.WriteFile(p.PIDFile(), []byte("12345"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	pidFileTime := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
-	if err := os.Chtimes(p.PIDFile(), pidFileTime, pidFileTime); err != nil {
+	recordedStart := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	pidData, err := json.Marshal(daemonPIDFile{PID: 12345, StartedAt: recordedStart})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.PIDFile(), pidData, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -306,7 +312,7 @@ func TestOtherDaemonAlive_FalseWhenPIDReusedByNewerProcess(t *testing.T) {
 		if pid != 12345 {
 			t.Fatalf("unexpected pid %d", pid)
 		}
-		return pidFileTime.Add(time.Hour), nil
+		return recordedStart.Add(time.Hour), nil
 	}
 	t.Cleanup(func() {
 		processRunningFunc = oldRunning
@@ -315,5 +321,43 @@ func TestOtherDaemonAlive_FalseWhenPIDReusedByNewerProcess(t *testing.T) {
 
 	if otherDaemonAlive(p) {
 		t.Error("reused pid from a newer process should not block orphan reaping")
+	}
+}
+
+func TestOtherDaemonAlive_TrueWhenDaemonStartTimeMatchesRecord(t *testing.T) {
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	recordedStart := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	pidData, err := json.Marshal(daemonPIDFile{PID: 12345, StartedAt: recordedStart})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.PIDFile(), pidData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldRunning := processRunningFunc
+	oldStartTime := processStartTimeFunc
+	processRunningFunc = func(pid int) (bool, error) {
+		if pid != 12345 {
+			t.Fatalf("unexpected pid %d", pid)
+		}
+		return true, nil
+	}
+	processStartTimeFunc = func(pid int) (time.Time, error) {
+		if pid != 12345 {
+			t.Fatalf("unexpected pid %d", pid)
+		}
+		return recordedStart.Add(time.Second), nil
+	}
+	t.Cleanup(func() {
+		processRunningFunc = oldRunning
+		processStartTimeFunc = oldStartTime
+	})
+
+	if !otherDaemonAlive(p) {
+		t.Error("matching daemon start time should block orphan reaping")
 	}
 }

--- a/internal/daemon/recover_servers_test.go
+++ b/internal/daemon/recover_servers_test.go
@@ -122,3 +122,26 @@ func TestOtherDaemonAlive_FalseForDeadPID(t *testing.T) {
 		t.Error("dead pid should not count as another daemon")
 	}
 }
+
+func TestOtherDaemonAlive_TrueWhenLivenessCheckErrors(t *testing.T) {
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.PIDFile(), []byte("12345"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	old := processRunningFunc
+	processRunningFunc = func(pid int) (bool, error) {
+		if pid != 12345 {
+			t.Fatalf("unexpected pid %d", pid)
+		}
+		return false, fmt.Errorf("transient failure")
+	}
+	t.Cleanup(func() { processRunningFunc = old })
+
+	if !otherDaemonAlive(p) {
+		t.Error("liveness-check errors should conservatively block orphan reaping")
+	}
+}

--- a/internal/daemon/recover_servers_unix.go
+++ b/internal/daemon/recover_servers_unix.go
@@ -1,0 +1,35 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+	"time"
+)
+
+// terminateOrphanProcessGroup sends SIGTERM then SIGKILL to the entire
+// process group led by pid. Managed servers are spawned with Setpgid so
+// their pgid equals their pid, and killing the group reaps any helper
+// children (language servers, sub-shells) the server may have spawned.
+func terminateOrphanProcessGroup(pid int) error {
+	pgid, err := syscall.Getpgid(pid)
+	if err != nil {
+		pgid = pid
+	}
+	if err := syscall.Kill(-pgid, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return fmt.Errorf("sigterm pgid %d: %w", pgid, err)
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if alive, _ := processRunning(pid); !alive {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return fmt.Errorf("sigkill pgid %d: %w", pgid, err)
+	}
+	return nil
+}

--- a/internal/daemon/recover_servers_unix_test.go
+++ b/internal/daemon/recover_servers_unix_test.go
@@ -186,3 +186,39 @@ func TestReapOrphanedServers_KeepsPIDFileWhenTerminateFails(t *testing.T) {
 		t.Error("process should remain alive when terminate hook fails")
 	}
 }
+
+func TestReapOrphanedServers_KeepsPIDFileWhenStartTimeCheckFails(t *testing.T) {
+	cmd, pid := spawnSleepProcess(t)
+	t.Cleanup(func() { killAndWait(cmd) })
+
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	path := writePIDRecord(t, p.ServerPIDsDir(), "opencode-live.json", agent.ServerPIDInfo{
+		PID:       pid,
+		Agent:     "opencode",
+		Bin:       "/bin/sleep",
+		StartedAt: time.Now().UTC(),
+	})
+
+	old := processStartTimeFunc
+	processStartTimeFunc = func(gotPID int) (time.Time, error) {
+		if gotPID != pid {
+			t.Fatalf("unexpected pid %d", gotPID)
+		}
+		return time.Time{}, errors.New("boom")
+	}
+	t.Cleanup(func() { processStartTimeFunc = old })
+
+	reapOrphanedServers(p)
+
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("pid file should be kept for retry after start time check failure, got err=%v", err)
+	}
+	if alive, err := processRunning(pid); err != nil {
+		t.Fatalf("processRunning: %v", err)
+	} else if !alive {
+		t.Error("process should remain alive when start time check fails")
+	}
+}

--- a/internal/daemon/recover_servers_unix_test.go
+++ b/internal/daemon/recover_servers_unix_test.go
@@ -3,6 +3,7 @@
 package daemon
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -145,5 +146,43 @@ func TestReapOrphanedServers_SkipsKillWhenStartTimeMismatched(t *testing.T) {
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Errorf("stale pid file should still be removed, got err=%v", err)
+	}
+}
+
+func TestReapOrphanedServers_KeepsPIDFileWhenTerminateFails(t *testing.T) {
+	cmd, pid := spawnSleepProcess(t)
+	t.Cleanup(func() { killAndWait(cmd) })
+
+	started, err := processStartTime(pid)
+	if err != nil {
+		t.Fatalf("read start time: %v", err)
+	}
+
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	path := writePIDRecord(t, p.ServerPIDsDir(), "opencode-live.json", agent.ServerPIDInfo{
+		PID:       pid,
+		Agent:     "opencode",
+		Bin:       "/bin/sleep",
+		StartedAt: started,
+	})
+
+	old := terminateOrphanProcessGroupFunc
+	terminateOrphanProcessGroupFunc = func(pid int) error {
+		return errors.New("boom")
+	}
+	t.Cleanup(func() { terminateOrphanProcessGroupFunc = old })
+
+	reapOrphanedServers(p)
+
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("pid file should be kept for retry after terminate failure, got err=%v", err)
+	}
+	if alive, err := processRunning(pid); err != nil {
+		t.Fatalf("processRunning: %v", err)
+	} else if !alive {
+		t.Error("process should remain alive when terminate hook fails")
 	}
 }

--- a/internal/daemon/recover_servers_unix_test.go
+++ b/internal/daemon/recover_servers_unix_test.go
@@ -1,0 +1,149 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/agent"
+	"github.com/kunchenguid/no-mistakes/internal/paths"
+)
+
+// spawnSleepProcess launches `sleep 30` in its own process group so that a
+// reap test that kills the pgroup can't take out the go test runner. The
+// returned *exec.Cmd lets the caller clean up with killAndWait.
+func spawnSleepProcess(t *testing.T) (*exec.Cmd, int) {
+	t.Helper()
+	bin, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Skip("sleep not available")
+	}
+	cmd := exec.Command(bin, "30")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	return cmd, cmd.Process.Pid
+}
+
+func killAndWait(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = cmd.Process.Kill()
+	_, _ = cmd.Process.Wait()
+}
+
+func waitForPIDExit(pid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		alive, _ := processRunning(pid)
+		if !alive {
+			return true
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return false
+}
+
+// TestReapOrphanedServers_KillsLiveMatchingProcess proves the full reap
+// flow: a PID file whose recorded StartedAt matches the subprocess's real
+// start time triggers a kill, and the PID file is removed.
+func TestReapOrphanedServers_KillsLiveMatchingProcess(t *testing.T) {
+	cmd, pid := spawnSleepProcess(t)
+	t.Cleanup(func() { killAndWait(cmd) })
+
+	started, err := processStartTime(pid)
+	if err != nil {
+		t.Fatalf("read start time: %v", err)
+	}
+
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	path := writePIDRecord(t, p.ServerPIDsDir(), "opencode-live.json", agent.ServerPIDInfo{
+		PID:       pid,
+		Agent:     "opencode",
+		Bin:       "/bin/sleep",
+		StartedAt: started,
+	})
+
+	reapOrphanedServers(p)
+
+	if !waitForPIDExit(pid, 5*time.Second) {
+		t.Errorf("expected pid %d to be terminated", pid)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("pid file should be removed after reap, got err=%v", err)
+	}
+}
+
+// TestReapOrphanedServers_SkipsWhenDaemonAlive verifies that if the daemon
+// PID file points at a running process, reaping is skipped entirely -
+// protects a concurrently-running old daemon's legitimate servers.
+func TestReapOrphanedServers_SkipsWhenDaemonAlive(t *testing.T) {
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	other, otherPID := spawnSleepProcess(t)
+	t.Cleanup(func() { killAndWait(other) })
+
+	if err := os.WriteFile(p.PIDFile(), []byte(fmt.Sprintf("%d", otherPID)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	path := writePIDRecord(t, p.ServerPIDsDir(), "opencode-999999.json", agent.ServerPIDInfo{
+		PID:       999999,
+		Agent:     "opencode",
+		StartedAt: time.Now().UTC(),
+	})
+
+	reapOrphanedServers(p)
+
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("pid file should be untouched when a daemon is alive, got err=%v", err)
+	}
+}
+
+// TestReapOrphanedServers_SkipsKillWhenStartTimeMismatched simulates PID
+// reuse: the PID file's StartedAt doesn't match the live process's actual
+// start time, so the reaper must NOT send signals - it just drops the
+// stale file.
+func TestReapOrphanedServers_SkipsKillWhenStartTimeMismatched(t *testing.T) {
+	cmd, pid := spawnSleepProcess(t)
+	t.Cleanup(func() { killAndWait(cmd) })
+
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	// Bogus StartedAt far in the past makes this look like a reused PID.
+	path := writePIDRecord(t, p.ServerPIDsDir(), "opencode-reused.json", agent.ServerPIDInfo{
+		PID:       pid,
+		Agent:     "opencode",
+		Bin:       "/bin/sleep",
+		StartedAt: time.Now().UTC().Add(-24 * time.Hour),
+	})
+
+	reapOrphanedServers(p)
+
+	// The process must still be alive - we didn't own it.
+	alive, err := processRunning(pid)
+	if err != nil {
+		t.Fatalf("processRunning: %v", err)
+	}
+	if !alive {
+		t.Error("reaper killed a process whose start time did not match the pid record")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("stale pid file should still be removed, got err=%v", err)
+	}
+}

--- a/internal/daemon/recover_servers_unix_test.go
+++ b/internal/daemon/recover_servers_unix_test.go
@@ -4,7 +4,6 @@ package daemon
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"os/exec"
 	"syscall"
@@ -96,10 +95,12 @@ func TestReapOrphanedServers_SkipsWhenDaemonAlive(t *testing.T) {
 
 	other, otherPID := spawnSleepProcess(t)
 	t.Cleanup(func() { killAndWait(other) })
-
-	if err := os.WriteFile(p.PIDFile(), []byte(fmt.Sprintf("%d", otherPID)), 0o644); err != nil {
-		t.Fatal(err)
+	startedAt, err := processStartTime(otherPID)
+	if err != nil {
+		t.Fatalf("processStartTime: %v", err)
 	}
+
+	writeDaemonPIDRecord(t, p.PIDFile(), daemonPIDFile{PID: otherPID, StartedAt: startedAt})
 
 	path := writePIDRecord(t, p.ServerPIDsDir(), "opencode-999999.json", agent.ServerPIDInfo{
 		PID:       999999,

--- a/internal/daemon/recover_servers_unix_test.go
+++ b/internal/daemon/recover_servers_unix_test.go
@@ -222,3 +222,35 @@ func TestReapOrphanedServers_KeepsPIDFileWhenStartTimeCheckFails(t *testing.T) {
 		t.Error("process should remain alive when start time check fails")
 	}
 }
+
+func TestReapOrphanedServers_ReapsWizardOwnedRecordWhenWizardGone(t *testing.T) {
+	cmd, pid := spawnSleepProcess(t)
+	t.Cleanup(func() { killAndWait(cmd) })
+
+	started, err := processStartTime(pid)
+	if err != nil {
+		t.Fatalf("read start time: %v", err)
+	}
+
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	path := writePIDRecord(t, p.ServerPIDsDir(), "opencode-wizard-live.json", agent.ServerPIDInfo{
+		PID:       pid,
+		Owner:     agent.ServerPIDOwnerWizard,
+		OwnerPID:  999999,
+		Agent:     "opencode",
+		Bin:       "/bin/sleep",
+		StartedAt: started,
+	})
+
+	reapOrphanedServers(p)
+
+	if !waitForPIDExit(pid, 5*time.Second) {
+		t.Errorf("expected pid %d to be terminated", pid)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("pid file should be removed after reap, got err=%v", err)
+	}
+}

--- a/internal/daemon/recover_servers_windows.go
+++ b/internal/daemon/recover_servers_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+)
+
+// terminateOrphanProcessGroup forcibly terminates the orphaned process.
+// Windows lacks a Unix-style process group concept, so this maps to
+// TerminateProcess on the top-level PID. Child processes that aren't
+// parented via a Job Object will not be cleaned up by this call, but the
+// managed server itself will be gone.
+func terminateOrphanProcessGroup(pid int) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("find process %d: %w", pid, err)
+	}
+	if err := proc.Kill(); err != nil {
+		return fmt.Errorf("kill process %d: %w", pid, err)
+	}
+	return nil
+}

--- a/internal/daemon/recover_servers_windows.go
+++ b/internal/daemon/recover_servers_windows.go
@@ -4,21 +4,21 @@ package daemon
 
 import (
 	"fmt"
-	"os"
+	"os/exec"
+	"strconv"
+	"strings"
 )
 
-// terminateOrphanProcessGroup forcibly terminates the orphaned process.
-// Windows lacks a Unix-style process group concept, so this maps to
-// TerminateProcess on the top-level PID. Child processes that aren't
-// parented via a Job Object will not be cleaned up by this call, but the
-// managed server itself will be gone.
+// terminateOrphanProcessGroup forcibly terminates the orphaned process tree.
 func terminateOrphanProcessGroup(pid int) error {
-	proc, err := os.FindProcess(pid)
+	cmd := exec.Command("taskkill", "/PID", strconv.Itoa(pid), "/T", "/F")
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("find process %d: %w", pid, err)
-	}
-	if err := proc.Kill(); err != nil {
-		return fmt.Errorf("kill process %d: %w", pid, err)
+		output := strings.TrimSpace(string(out))
+		if output != "" {
+			return fmt.Errorf("taskkill pid %d: %w: %s", pid, err, output)
+		}
+		return fmt.Errorf("taskkill pid %d: %w", pid, err)
 	}
 	return nil
 }

--- a/internal/daemon/recover_servers_windows.go
+++ b/internal/daemon/recover_servers_windows.go
@@ -9,11 +9,19 @@ import (
 	"strings"
 )
 
+var taskkillProcessTree = func(pid int) ([]byte, error) {
+	cmd := exec.Command("taskkill", "/PID", strconv.Itoa(pid), "/T", "/F")
+	return cmd.CombinedOutput()
+}
+
 // terminateOrphanProcessGroup forcibly terminates the orphaned process tree.
 func terminateOrphanProcessGroup(pid int) error {
-	cmd := exec.Command("taskkill", "/PID", strconv.Itoa(pid), "/T", "/F")
-	out, err := cmd.CombinedOutput()
+	out, err := taskkillProcessTree(pid)
 	if err != nil {
+		alive, runningErr := processRunningFunc(pid)
+		if runningErr == nil && !alive {
+			return nil
+		}
 		output := strings.TrimSpace(string(out))
 		if output != "" {
 			return fmt.Errorf("taskkill pid %d: %w: %s", pid, err, output)

--- a/internal/daemon/recover_servers_windows_test.go
+++ b/internal/daemon/recover_servers_windows_test.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package daemon
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestTerminateOrphanProcessGroup_IgnoresAlreadyExitedTaskkillRace(t *testing.T) {
+	oldTaskkill := taskkillProcessTree
+	oldRunning := processRunningFunc
+	taskkillProcessTree = func(pid int) ([]byte, error) {
+		if pid != 12345 {
+			t.Fatalf("unexpected pid %d", pid)
+		}
+		return []byte("ERROR: The process with PID 12345 could not be terminated."), errors.New("exit status 128")
+	}
+	processRunningFunc = func(pid int) (bool, error) {
+		if pid != 12345 {
+			t.Fatalf("unexpected pid %d", pid)
+		}
+		return false, nil
+	}
+	t.Cleanup(func() {
+		taskkillProcessTree = oldTaskkill
+		processRunningFunc = oldRunning
+	})
+
+	if err := terminateOrphanProcessGroup(12345); err != nil {
+		t.Fatalf("terminateOrphanProcessGroup returned error: %v", err)
+	}
+}

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -251,18 +251,11 @@ func validateDaemonPIDFallback(p *paths.Paths, pid int) error {
 	if err != nil {
 		return fmt.Errorf("inspect daemon pid %d: %w", pid, err)
 	}
-	if record.StartedAt.IsZero() {
-		info, err := os.Stat(p.PIDFile())
-		if err != nil {
-			return fmt.Errorf("stat pid file: %w", err)
-		}
-		mtime := info.ModTime().UTC()
-		if startTime.Sub(mtime) > time.Second || mtime.Sub(startTime) > time.Second {
-			return fmt.Errorf("daemon pid %d does not match pid file instance", pid)
-		}
-		return nil
+	matches, err := daemonPIDRecordMatchesProcess(p.PIDFile(), record, startTime)
+	if err != nil {
+		return fmt.Errorf("validate daemon pid %d: %w", pid, err)
 	}
-	if startTime.Sub(record.StartedAt) > time.Second || record.StartedAt.Sub(startTime) > time.Second {
+	if !matches {
 		return fmt.Errorf("daemon pid %d does not match pid file instance", pid)
 	}
 	return nil

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
@@ -241,15 +240,21 @@ func validateDaemonPIDFallback(p *paths.Paths, pid int) error {
 	if pid <= 0 {
 		return fmt.Errorf("invalid daemon pid %d", pid)
 	}
-	info, err := os.Stat(p.PIDFile())
+	record, err := readDaemonPIDFile(p.PIDFile())
 	if err != nil {
-		return fmt.Errorf("stat pid file: %w", err)
+		return fmt.Errorf("read pid file: %w", err)
+	}
+	if record.PID != pid {
+		return fmt.Errorf("daemon pid %d does not match pid file instance", pid)
 	}
 	startTime, err := daemonProcessStartTime(pid)
 	if err != nil {
 		return fmt.Errorf("inspect daemon pid %d: %w", pid, err)
 	}
-	if startTime.Sub(info.ModTime()) > time.Second || info.ModTime().Sub(startTime) > time.Second {
+	if record.StartedAt.IsZero() {
+		return nil
+	}
+	if startTime.Sub(record.StartedAt) > time.Second || record.StartedAt.Sub(startTime) > time.Second {
 		return fmt.Errorf("daemon pid %d does not match pid file instance", pid)
 	}
 	return nil
@@ -385,16 +390,9 @@ func EnsureDaemon(p *paths.Paths) error {
 
 // ReadPID reads the daemon PID from the PID file.
 func ReadPID(p *paths.Paths) (int, error) {
-	data, err := os.ReadFile(p.PIDFile())
+	record, err := readDaemonPIDFile(p.PIDFile())
 	if err != nil {
 		return 0, err
 	}
-	pid, err := strconv.Atoi(string(data))
-	if err != nil {
-		return 0, fmt.Errorf("invalid pid file: %w", err)
-	}
-	if pid <= 0 {
-		return 0, fmt.Errorf("invalid pid file: pid must be positive")
-	}
-	return pid, nil
+	return record.PID, nil
 }

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -252,6 +252,14 @@ func validateDaemonPIDFallback(p *paths.Paths, pid int) error {
 		return fmt.Errorf("inspect daemon pid %d: %w", pid, err)
 	}
 	if record.StartedAt.IsZero() {
+		info, err := os.Stat(p.PIDFile())
+		if err != nil {
+			return fmt.Errorf("stat pid file: %w", err)
+		}
+		mtime := info.ModTime().UTC()
+		if startTime.Sub(mtime) > time.Second || mtime.Sub(startTime) > time.Second {
+			return fmt.Errorf("daemon pid %d does not match pid file instance", pid)
+		}
 		return nil
 	}
 	if startTime.Sub(record.StartedAt) > time.Second || record.StartedAt.Sub(startTime) > time.Second {

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -251,7 +251,7 @@ func validateDaemonPIDFallback(p *paths.Paths, pid int) error {
 	if err != nil {
 		return fmt.Errorf("inspect daemon pid %d: %w", pid, err)
 	}
-	matches, err := daemonPIDRecordMatchesProcess(p.PIDFile(), record, startTime)
+	matches, err := daemonPIDRecordMatchesProcess(p, record, startTime)
 	if err != nil {
 		return fmt.Errorf("validate daemon pid %d: %w", pid, err)
 	}

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -55,6 +55,11 @@ func (p *Paths) RunLogDir(runID string) string {
 func (p *Paths) DaemonLog() string { return filepath.Join(p.root, "logs", "daemon.log") }
 func (p *Paths) CLILog() string    { return filepath.Join(p.root, "logs", "cli.log") }
 
+// ServerPIDsDir holds PID-tracking files for managed agent servers
+// (opencode, rovodev) so a freshly started daemon can reap orphans left
+// behind by a crashed predecessor.
+func (p *Paths) ServerPIDsDir() string { return filepath.Join(p.root, "servers") }
+
 // EnsureDirs creates all required directories under root.
 func (p *Paths) EnsureDirs() error {
 	dirs := []string{
@@ -62,6 +67,7 @@ func (p *Paths) EnsureDirs() error {
 		p.ReposDir(),
 		p.WorktreesDir(),
 		p.LogsDir(),
+		p.ServerPIDsDir(),
 	}
 	for _, d := range dirs {
 		if err := os.MkdirAll(d, 0o755); err != nil {

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -101,7 +101,7 @@ func TestEnsureDirs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, d := range []string{p.Root(), p.ReposDir(), p.WorktreesDir(), p.LogsDir()} {
+	for _, d := range []string{p.Root(), p.ReposDir(), p.WorktreesDir(), p.LogsDir(), p.ServerPIDsDir()} {
 		info, err := os.Stat(d)
 		if err != nil {
 			t.Errorf("expected dir %q to exist: %v", d, err)

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -1090,3 +1090,38 @@ func TestResult(t *testing.T) {
 		t.Fatalf("expected TargetBranch feat/x, got %q", res.TargetBranch)
 	}
 }
+
+func TestWaitForRun_CalledAfterPush(t *testing.T) {
+	cfg := baseConfig(&recorder{})
+	cfg.CurrentBranch = "feat/x"
+	cfg.NeedsBranch = false
+	cfg.IsDirty = false
+
+	called := 0
+	gotBranch := ""
+	cfg.WaitForRun = func(_ context.Context, branch string) error {
+		called++
+		gotBranch = branch
+		return nil
+	}
+
+	m := NewModel(cfg)
+	m = drain(m, m.Init())
+	m = advance(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+
+	if called != 1 {
+		t.Fatalf("WaitForRun called %d times, want 1", called)
+	}
+	if gotBranch != "feat/x" {
+		t.Fatalf("WaitForRun branch = %q, want %q", gotBranch, "feat/x")
+	}
+	if !m.success || !m.quitting {
+		t.Fatalf("expected successful quit after wait, got success=%v quitting=%v", m.success, m.quitting)
+	}
+	if m.err != nil {
+		t.Fatalf("unexpected wait error: %v", m.err)
+	}
+	if !m.Result().Pushed {
+		t.Fatal("expected pushed result to remain true")
+	}
+}


### PR DESCRIPTION
## Summary
- add startup recovery for orphaned managed agent servers by persisting server PID records and reaping daemon- or wizard-owned servers left behind after crashes
- harden recovery and shutdown identity checks with stable PID metadata, atomic record writes, and cross-platform safeguards so live processes are not misidentified during PID reuse or corrupt-state scenarios
- update daemon, gate-model, troubleshooting, and environment docs to describe the structured daemon PID record and new `$NM_HOME/servers/` recovery state

## Risk Assessment

⚠️ Medium: This is a substantial process-recovery change with good coverage, but the remaining legacy-PID fallback can still misidentify a live daemon and trigger unsafe orphan cleanup.

## Testing

- Summary: Exercised the daemon orphan-recovery, daemon PID-file validation, agent server PID tracking, wizard PID-dir wiring, and path creation paths through the relevant package test suites; all targeted tests passed.
- `go test ./internal/daemon`
- `go test ./internal/agent`
- `go test ./internal/cli`
- `go test ./internal/paths`
- Outcome: ✅ passed across 1 run (1m28s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

**Round 1** - found 3 warnings
- ⚠️ `internal/daemon/recover_servers.go:114` - `otherDaemonAlive` ignores errors from `processRunning` and treats them as &#34;daemon not alive&#34;. If the liveness check fails transiently, startup can proceed to reap agent servers that still belong to a running daemon, violating the safety rule documented above this function.
- ⚠️ `internal/daemon/recover_servers.go:77` - The PID breadcrumb is removed even when `terminateOrphanProcessGroup` returns an error. That discards the only retry signal for a server we failed to kill, so future daemon restarts will stop attempting cleanup and the orphan can persist indefinitely.
- ⚠️ `internal/daemon/recover_servers_windows.go:13` - The Windows reaper only calls `Kill` on the top-level server PID and explicitly leaves any child processes behind. If `opencode` or `rovodev` spawn helper processes, crashes will still leak those children on Windows even though this change advertises orphan recovery for managed servers.

**Round 2** (auto-fix) - found 2 warnings
- ⚠️ `internal/daemon/recover_servers.go:110` - `otherDaemonAlive` treats any PID-file read failure as &#34;no other daemon&#34;. If the daemon PID file exists but is temporarily unreadable or I/O fails, startup can still reap agent servers that may belong to a live daemon, which breaks the safety guard this function is supposed to enforce.
- ⚠️ `internal/daemon/recover_servers.go:127` - `orphanStartTimeMatches` collapses &#34;could not read process start time&#34; into a plain mismatch, and `reapOrphanedServers` then deletes the PID breadcrumb. A transient `ps`/`GetProcessTimes` failure will leave the orphaned server running but remove the only retry signal for future daemon restarts.

**Round 3** (auto-fix) - found 1 warning
- ⚠️ `internal/daemon/recover_servers.go:125` - `otherDaemonAlive` treats a non-numeric or otherwise corrupt `daemon.pid` as &#34;no daemon running&#34;. If that file is truncated or partially written while an older daemon is still alive, this startup path can still reap that daemon&#39;s live agent servers, which defeats the safety guard meant to avoid killing active processes.

**Round 4** (auto-fix) - found 1 warning
- ⚠️ `internal/cli/wizard.go:208` - The wizard now writes server PID breadcrumbs into the same `servers/` directory that daemon startup reaps unconditionally. If a daemon crashes and restarts while a wizard session is still running, `reapOrphanedServers` will treat the wizard&#39;s live opencode/rovodev server as an orphan and kill it, because the PID record carries no owner information to distinguish wizard-owned servers from daemon-owned ones.

**Round 5** (auto-fix) - found 2 warnings
- ⚠️ `internal/daemon/recover_servers.go:65` - Wizard-owned PID records are now skipped unconditionally, so a daemon restart will never reap agent servers left behind by a crashed wizard. That contradicts the new comments/tests around `runWizardWithMode` and means this branch still does not recover wizard-started orphan servers.
- ⚠️ `internal/agent/serverpid.go:94` - PID breadcrumbs are written directly to their final path with `os.WriteFile`, so a crash or partial write can leave malformed JSON behind. `reapOrphanedServers` treats malformed records as garbage and deletes them, which drops the only recovery signal and can leak the orphaned server indefinitely.

**Round 6** (auto-fix) - found 2 warnings
- ⚠️ `internal/daemon/recover_servers.go:107` - Wizard-owned records are gated only by `OwnerPID` liveness. If the wizard crashes and that PID gets reused by an unrelated process before the next daemon startup, `shouldSkipOrphanRecord` will treat the orphan as still owned by a live wizard and skip reaping indefinitely. Record and validate the wizard owner&#39;s start time or another stable identity before trusting `OwnerPID`.
- ⚠️ `internal/daemon/recover_servers.go:157` - `otherDaemonAlive` treats any live process in `daemon.pid` as an active no-mistakes daemon, but the PID file contains no start-time or process-identity check. After a crash, a reused PID from an unrelated process will block orphan-server recovery on every restart until that process exits.

**Round 7** (auto-fix) - found 2 warnings
- ⚠️ `internal/daemon/recover_servers.go:120` - Wizard-owned records still do not validate the wizard&#39;s own identity - they only check whether the current `OwnerPID` process started before `server.StartedAt + 2s`. If the crashed wizard&#39;s PID is reused by an unrelated process within that tolerance window, `shouldSkipOrphanRecord` will treat the orphaned server as still owned and skip reaping indefinitely. Persist the wizard owner&#39;s start time in the PID record and compare against that instead of the child server timestamp.
- ⚠️ `internal/daemon/recover_servers.go:186` - `otherDaemonAlive` uses `daemon.pid` file mtime as a stand-in for the daemon&#39;s start time. A stale daemon PID that gets reused quickly by an unrelated process can still look &#34;alive&#34; if that new process starts within the 2-second tolerance, which blocks orphan-server recovery until that unrelated process exits. Record the daemon&#39;s start time (or another stable identity) in the PID file rather than inferring it from filesystem metadata.

**Round 8** (auto-fix) - found 3 issues (1 error, 2 warnings)
- ⚠️ `internal/daemon/daemon.go:133` - The daemon now records `started_at` with `time.Now()` when the PID file is written, but that happens only after `recoverOnStartup` and other initialization work. If startup takes more than the 2-second tolerance, later identity checks in `otherDaemonAlive` and `validateDaemonPIDFallback` can misclassify the live daemon as a different process, leading to orphan reaping against an active daemon or rejecting a legitimate stop fallback. Record the process&#39;s actual start time instead.
- ⚠️ `internal/daemon/recover_servers.go:110` - `shouldSkipOrphanRecord` skips any wizard-owned record whose `OwnerPID` matches the current daemon PID before checking `OwnerStartedAt`. If the crashed wizard&#39;s PID gets reused by the new daemon, orphaned wizard servers will be treated as still owned and never reaped on that startup, defeating the PID-reuse protection added elsewhere in this branch.
- 🚨 `internal/daemon/selfexec.go:254` - Legacy plain-text `daemon.pid` files now bypass instance validation entirely: `validateDaemonPIDFallback` returns success whenever `StartedAt` is zero. After upgrading from an older daemon or encountering a stale text PID file, the PID fallback in `stopDetachedDaemonByPID`/`waitForDaemonStop` can kill an unrelated process that later reused that PID. Keep a safety check for legacy files instead of treating them as automatically valid.

**Round 9** (auto-fix) - found 2 warnings
- ⚠️ `internal/daemon/recover_servers.go:181` - Legacy plain-text `daemon.pid` files still bypass PID-reuse validation here: when `StartedAt` is zero, `otherDaemonAlive` treats any live process with that PID as an active daemon. After upgrading from an older build, a stale text PID file whose PID gets reused by an unrelated process will block orphan-server recovery until that process exits. Reuse the same fallback identity check as `validateDaemonPIDFallback` instead of returning `true` unconditionally.
- ⚠️ `internal/daemon/daemon.go:141` - The new JSON `daemon.pid` record is written directly to its final path with `os.WriteFile`. A crash or concurrent read can observe truncated JSON, and the new readers treat unreadable/corrupt PID files conservatively as &#34;daemon alive&#34; or invalid, which can skip orphan recovery or break PID-based shutdown. Write the PID file atomically via a temp file plus rename, like `writeServerPIDFile` does for server breadcrumbs.

**Round 10** (auto-fix) - found 2 warnings
- ⚠️ `internal/daemon/recover_servers_windows.go:14` - `taskkill` failures are treated as fatal even when the target exits between the earlier liveness check and the kill attempt. In that common race, `reapOrphanedServers` keeps the PID breadcrumb and retries forever, so stale server records can accumulate on Windows despite the process already being gone.
- ⚠️ `internal/daemon/recover_servers.go:234` - Legacy plain-text `daemon.pid` files are still identified by file mtime instead of a stable process identity. If that file is touched or a reused PID starts within the 2-second tolerance, `otherDaemonAlive` and the PID fallback shutdown path can misclassify an unrelated process as the daemon, which can block orphan recovery or target the wrong process during forced stop.

**Round 11** (auto-fix) - found 1 warning
- ⚠️ `internal/daemon/recover_servers.go:220` - `daemonPIDRecordMatchesProcess` treats a legacy plain-text `daemon.pid` as stale whenever `daemonHealthCheck` fails, even though `processRunning(record.PID)` already proved that PID is still alive. On upgrade from an older daemon, a live-but-unresponsive predecessor can therefore be misclassified as dead and `reapOrphanedServers` may kill that daemon&#39;s active agent servers.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/daemon`
- `go test ./internal/agent`
- `go test ./internal/cli`
- `go test ./internal/paths`

</details>

<details>
<summary>🔧 **Document** - 4 issues found → auto-fixed (2)</summary>

**Round 1** - found 4 issues (2 warnings, 2 infos)
- ⚠️ `docs/src/content/docs/concepts/daemon.md:80` - The crash-recovery section is stale relative to this change. Startup recovery now also reaps orphaned managed agent servers left behind by crashed daemon or wizard processes, but the doc still only mentions marking stale runs failed and removing orphaned worktrees.
- ⚠️ `docs/src/content/docs/reference/environment.md:15` - The `NM_HOME` layout list is missing the new `$NM_HOME/servers/` directory that stores PID-tracking records for managed agent servers. This change adds persistent runtime state under `NM_HOME`, so the environment reference is now incomplete.
- ℹ️ `docs/src/content/docs/concepts/daemon.md:56` - This line still describes `~/.no-mistakes/daemon.pid` as a plain PID file, but the daemon now writes a structured identity record (`pid` plus `started_at`) and only reads legacy plain-PID content for compatibility. The state-file description should be updated to avoid stale implementation details.
- ℹ️ `docs/src/content/docs/guides/troubleshooting.md:176` - The &#39;Reset everything&#39; cleanup command no longer clears all transient daemon state after this change. Managed-agent PID records now live under `~/.no-mistakes/servers/`, so that directory should be included or explicitly discussed alongside `worktrees`, `socket`, and `daemon.pid`.

**Round 2** (auto-fix) - found 3 issues (2 warnings, 1 info)
- ℹ️ `docs/src/content/docs/concepts/gate-model.md:94` - The daemon overview still says `daemon.pid` is just a PID file, but this change switched it to a structured identity record (`pid` plus `started_at`, with legacy plain-PID reads only for compatibility). That line should be updated to avoid stale implementation details.
- ⚠️ `docs/src/content/docs/concepts/gate-model.md:112` - The crash-recovery description is stale. Startup recovery now also reaps orphaned managed agent servers left behind by crashed daemon or wizard processes, not just stuck runs and orphaned worktrees.
- ⚠️ `docs/src/content/docs/concepts/gate-model.md:146` - The local-state table is incomplete after this change: it still documents `daemon.pid` as a plain process ID file and does not list the new `servers/` directory that stores managed agent server PID records under `NM_HOME`.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
