### PR TITLE
fix(pipeline): harden CI autofix rerun retry guards

### DIFF
--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -159,13 +159,9 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 			timeoutFailingChecks = append(timeoutFailingChecks[:0], failing...)
 
 			if hasIssues && pending {
-				// Some checks still running - wait for all to complete before fixing.
-				// A pending check means CI has started a new run (typically because
-				// the previous fix was pushed), so the earlier same-name failure set
-				// is no longer "old, stale data" - clear the guard so that if the
-				// new run finishes with the same failing names, we treat it as a
-				// fresh attempt rather than looping on "fix already attempted".
-				s.lastFixedChecks = ""
+				if pendingCheckMatchesLastFixed(checks, s.lastFixedChecks) {
+					s.lastFixedChecks = ""
+				}
 				sctx.Log("issues detected but checks still pending, waiting for all checks to complete...")
 			} else if hasIssues {
 				// All checks done, issues present - fix or report

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -165,10 +165,7 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 				sctx.Log("issues detected but checks still pending, waiting for all checks to complete...")
 			} else if hasIssues {
 				// All checks done, issues present - fix or report
-				fixKey := strings.Join(failing, ",")
-				if mergeConflict {
-					fixKey += "+conflict"
-				}
+				fixKey := encodeLastFixedChecks(failing, mergeConflict)
 				issueDesc := strings.Join(failing, ", ")
 				if mergeConflict {
 					if issueDesc != "" {

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -159,7 +159,13 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 			timeoutFailingChecks = append(timeoutFailingChecks[:0], failing...)
 
 			if hasIssues && pending {
-				// Some checks still running - wait for all to complete before fixing
+				// Some checks still running - wait for all to complete before fixing.
+				// A pending check means CI has started a new run (typically because
+				// the previous fix was pushed), so the earlier same-name failure set
+				// is no longer "old, stale data" - clear the guard so that if the
+				// new run finishes with the same failing names, we treat it as a
+				// fresh attempt rather than looping on "fix already attempted".
+				s.lastFixedChecks = ""
 				sctx.Log("issues detected but checks still pending, waiting for all checks to complete...")
 			} else if hasIssues {
 				// All checks done, issues present - fix or report

--- a/internal/pipeline/steps/ci_autofix_test.go
+++ b/internal/pipeline/steps/ci_autofix_test.go
@@ -364,6 +364,99 @@ func TestCIStep_CIAutoFixRetriesAfterChecksRerun(t *testing.T) {
 	}
 }
 
+// TestCIStep_CIAutoFixRetriesWhenSomeChecksStayFailing reproduces the real-world
+// scenario where multiple checks fail, the fix push causes only some of them to
+// re-run (and thus transit through pending) while at least one check keeps
+// reporting as failing throughout. The pipeline should still recognize the
+// post-rerun same-name failure as a new attempt and progress to attempt 2,
+// rather than logging "fix already attempted" indefinitely until CI timeout.
+func TestCIStep_CIAutoFixRetriesWhenSomeChecksStayFailing(t *testing.T) {
+	t.Parallel()
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	// At least one check stays failing throughout the push+rerun transition,
+	// so `failing` is never empty and the original "all pass" reset never fires.
+	checksSequence := []string{
+		`[{"name":"a","status":"COMPLETED","conclusion":"failure","bucket":"fail"},{"name":"b","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`,
+		`[{"name":"a","status":"IN_PROGRESS","bucket":"pending"},{"name":"b","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`,
+		`[{"name":"a","status":"COMPLETED","conclusion":"failure","bucket":"fail"},{"name":"b","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`,
+		`[{"name":"a","status":"IN_PROGRESS","bucket":"pending"},{"name":"b","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`,
+		`[{"name":"a","status":"COMPLETED","conclusion":"failure","bucket":"fail"},{"name":"b","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`,
+	}
+	env := fakeCIGHSequence(t, "OPEN", checksSequence)
+
+	fixCount := 0
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			fixCount++
+			os.WriteFile(filepath.Join(opts.CWD, fmt.Sprintf("fix-%d.txt", fixCount)), []byte("fixed"), 0o644)
+			return &agent.Result{}, nil
+		},
+	}
+
+	prURL := "https://github.com/test/repo/pull/42"
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Config.CITimeout = 30 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{CI: 2}
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+
+	pollCount := 0
+	step := &CIStep{
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			pollCount++
+			return nil
+		},
+	}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatalf("expected approval outcome after retries, got error: %v", err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected approval after exhausting rerun-backed retries")
+	}
+	if fixCount != 2 {
+		t.Fatalf("expected 2 auto-fix attempts when post-push rerun still fails with same check names, got %d (stuck in 'fix already attempted' loop?)", fixCount)
+	}
+
+	foundExhausted := false
+	for _, l := range logs {
+		if strings.Contains(l, "max auto-fix attempts (2) reached") {
+			foundExhausted = true
+			break
+		}
+	}
+	if !foundExhausted {
+		t.Fatalf("expected max-attempts log after rerun-backed retries, got: %v", logs)
+	}
+}
+
 func TestCIStep_FixMode_ManualInterventionRunsCIFix(t *testing.T) {
 	t.Parallel()
 	upstream := t.TempDir()

--- a/internal/pipeline/steps/ci_autofix_test.go
+++ b/internal/pipeline/steps/ci_autofix_test.go
@@ -546,6 +546,89 @@ func TestCIStep_DoesNotRetryOnUnrelatedPendingCheck(t *testing.T) {
 	}
 }
 
+func TestCIStep_RetriesMergeConflictAfterRerun(t *testing.T) {
+	t.Parallel()
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	checksSequence := []string{
+		`[{"name":"build","status":"COMPLETED","conclusion":"success","bucket":"pass"}]`,
+		`[{"name":"build","status":"IN_PROGRESS","bucket":"pending"}]`,
+		`[{"name":"build","status":"COMPLETED","conclusion":"success","bucket":"pass"}]`,
+		`[{"name":"build","status":"IN_PROGRESS","bucket":"pending"}]`,
+		`[{"name":"build","status":"COMPLETED","conclusion":"success","bucket":"pass"}]`,
+	}
+	env := fakeCIGHSequenceMergeable(t, "OPEN", checksSequence, "CONFLICTING")
+
+	fixCount := 0
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			fixCount++
+			os.WriteFile(filepath.Join(opts.CWD, fmt.Sprintf("conflict-fix-%d.txt", fixCount)), []byte("resolved"), 0o644)
+			return &agent.Result{}, nil
+		},
+	}
+
+	prURL := "https://github.com/test/repo/pull/42"
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Config.CITimeout = 30 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{CI: 2}
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+
+	step := &CIStep{
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			return nil
+		},
+	}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatalf("expected approval outcome after retries, got error: %v", err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected approval after exhausting conflict rerun-backed retries")
+	}
+	if fixCount != 2 {
+		t.Fatalf("expected 2 auto-fix attempts for persistent merge conflicts after reruns, got %d", fixCount)
+	}
+
+	foundExhausted := false
+	for _, l := range logs {
+		if strings.Contains(l, "max auto-fix attempts (2) reached") {
+			foundExhausted = true
+			break
+		}
+	}
+	if !foundExhausted {
+		t.Fatalf("expected max-attempts log after conflict rerun-backed retries, got: %v", logs)
+	}
+}
+
 func TestCIStep_FixMode_ManualInterventionRunsCIFix(t *testing.T) {
 	t.Parallel()
 	upstream := t.TempDir()

--- a/internal/pipeline/steps/ci_autofix_test.go
+++ b/internal/pipeline/steps/ci_autofix_test.go
@@ -457,6 +457,95 @@ func TestCIStep_CIAutoFixRetriesWhenSomeChecksStayFailing(t *testing.T) {
 	}
 }
 
+func TestCIStep_DoesNotRetryOnUnrelatedPendingCheck(t *testing.T) {
+	t.Parallel()
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	checksSequence := []string{
+		`[{"name":"test","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`,
+		`[{"name":"test","status":"COMPLETED","conclusion":"failure","bucket":"fail"},{"name":"docs","status":"IN_PROGRESS","bucket":"pending"}]`,
+		`[{"name":"test","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`,
+		`[{"name":"test","status":"COMPLETED","conclusion":"failure","bucket":"fail"}]`,
+	}
+	env := fakeCIGHSequence(t, "OPEN", checksSequence)
+
+	fixCount := 0
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			fixCount++
+			os.WriteFile(filepath.Join(opts.CWD, fmt.Sprintf("fix-%d.txt", fixCount)), []byte("fixed"), 0o644)
+			return &agent.Result{}, nil
+		},
+	}
+
+	prURL := "https://github.com/test/repo/pull/42"
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Config.CITimeout = 30 * time.Second
+	sctx.Config.AutoFix = config.AutoFix{CI: 2}
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
+	pollCount := 0
+	step := &CIStep{
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			pollCount++
+			if pollCount == 3 {
+				cancel()
+			}
+			return ctx.Err()
+		},
+	}
+
+	_, err := step.Execute(sctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation after observing repeated stale failure, got %v", err)
+	}
+	if fixCount != 1 {
+		t.Fatalf("expected unrelated pending checks not to trigger a second auto-fix attempt, got %d", fixCount)
+	}
+
+	foundWait := false
+	for _, l := range logs {
+		if strings.Contains(l, "fix already attempted for these issues") {
+			foundWait = true
+			break
+		}
+	}
+	if !foundWait {
+		t.Fatalf("expected stale failures to stay guarded while unrelated checks finish, got logs: %v", logs)
+	}
+}
+
 func TestCIStep_FixMode_ManualInterventionRunsCIFix(t *testing.T) {
 	t.Parallel()
 	upstream := t.TempDir()

--- a/internal/pipeline/steps/ci_checks.go
+++ b/internal/pipeline/steps/ci_checks.go
@@ -3,13 +3,17 @@ package steps
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/scm"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
+
+type lastFixedIssues struct {
+	Checks        []string `json:"checks,omitempty"`
+	MergeConflict bool     `json:"mergeConflict,omitempty"`
+}
 
 // pollInterval returns the polling interval based on elapsed time since CI monitoring started.
 // 30s for first 5min, 60s for 5-15min, 120s after.
@@ -56,20 +60,20 @@ func failingCheckNames(checks []scm.Check) []string {
 }
 
 func pendingCheckMatchesLastFixed(checks []scm.Check, lastFixedChecks string) bool {
-	if lastFixedChecks == "" {
+	issues, ok := decodeLastFixedChecks(lastFixedChecks)
+	if !ok {
 		return false
 	}
 
 	failedNames := map[string]struct{}{}
-	for _, name := range strings.Split(lastFixedChecks, ",") {
-		name = strings.TrimSuffix(name, "+conflict")
+	for _, name := range issues.Checks {
 		if name == "" {
 			continue
 		}
 		failedNames[name] = struct{}{}
 	}
 	if len(failedNames) == 0 {
-		return false
+		return issues.MergeConflict && hasPendingChecks(checks)
 	}
 
 	for _, c := range checks {
@@ -82,6 +86,31 @@ func pendingCheckMatchesLastFixed(checks []scm.Check, lastFixedChecks string) bo
 	}
 
 	return false
+}
+
+func encodeLastFixedChecks(failing []string, mergeConflict bool) string {
+	if len(failing) == 0 && !mergeConflict {
+		return ""
+	}
+	encoded, err := json.Marshal(lastFixedIssues{Checks: failing, MergeConflict: mergeConflict})
+	if err != nil {
+		return ""
+	}
+	return string(encoded)
+}
+
+func decodeLastFixedChecks(raw string) (lastFixedIssues, bool) {
+	if raw == "" {
+		return lastFixedIssues{}, false
+	}
+	var issues lastFixedIssues
+	if err := json.Unmarshal([]byte(raw), &issues); err != nil {
+		return lastFixedIssues{}, false
+	}
+	if len(issues.Checks) == 0 && !issues.MergeConflict {
+		return lastFixedIssues{}, false
+	}
+	return issues, true
 }
 
 func ciFailureOutcome(failing []string, mergeConflict bool, summary string) *pipeline.StepOutcome {

--- a/internal/pipeline/steps/ci_checks.go
+++ b/internal/pipeline/steps/ci_checks.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
@@ -52,6 +53,35 @@ func failingCheckNames(checks []scm.Check) []string {
 		}
 	}
 	return names
+}
+
+func pendingCheckMatchesLastFixed(checks []scm.Check, lastFixedChecks string) bool {
+	if lastFixedChecks == "" {
+		return false
+	}
+
+	failedNames := map[string]struct{}{}
+	for _, name := range strings.Split(lastFixedChecks, ",") {
+		name = strings.TrimSuffix(name, "+conflict")
+		if name == "" {
+			continue
+		}
+		failedNames[name] = struct{}{}
+	}
+	if len(failedNames) == 0 {
+		return false
+	}
+
+	for _, c := range checks {
+		if !c.Pending() {
+			continue
+		}
+		if _, ok := failedNames[c.Name]; ok {
+			return true
+		}
+	}
+
+	return false
 }
 
 func ciFailureOutcome(failing []string, mergeConflict bool, summary string) *pipeline.StepOutcome {

--- a/internal/pipeline/steps/ci_checks_test.go
+++ b/internal/pipeline/steps/ci_checks_test.go
@@ -1,0 +1,27 @@
+package steps
+
+import (
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/scm"
+)
+
+func TestPendingCheckMatchesLastFixed_SpecialCheckNames(t *testing.T) {
+	t.Parallel()
+
+	lastFixedChecks := encodeLastFixedChecks([]string{"lint,unit", "deploy+conflict"}, true)
+	checks := []scm.Check{
+		{Name: "lint,unit", Bucket: "pending"},
+	}
+
+	if !pendingCheckMatchesLastFixed(checks, lastFixedChecks) {
+		t.Fatalf("expected pending check with special characters to match encoded last fixed checks %q", lastFixedChecks)
+	}
+
+	checks = []scm.Check{
+		{Name: "lint", Bucket: "pending"},
+	}
+	if pendingCheckMatchesLastFixed(checks, lastFixedChecks) {
+		t.Fatalf("expected unrelated pending check not to match encoded last fixed checks %q", lastFixedChecks)
+	}
+}


### PR DESCRIPTION
## Summary
- Refine CI auto-fix retry gating so retries only unlock after the relevant failing checks actually rerun, avoiding extra attempts when unrelated checks are still pending.
- Cover edge cases around partial reruns, merge-conflict retries, and special check names so stale failures do not block or incorrectly re-trigger auto-fix.
- Add focused `internal/pipeline/steps` coverage for the rerun guard behavior to lock in the expected retry flow.

## Risk Assessment

⚠️ Medium: The patch is narrow and well-tested, but it still bakes in an ambiguous partial-rerun heuristic that can consume retry budget on stale failures.

## Testing

- Summary: <code>Exercised the CI rerun/retry paths and surrounding `internal/pipeline/steps` regressions, including race-enabled coverage of the new guard behavior; all relevant tests passed.</code>
- `go test ./internal/pipeline/steps -run 'TestPendingCheckMatchesLastFixed_SpecialCheckNames|TestCIStep_CIAutoFixRetriesAfterChecksRerun|TestCIStep_CIAutoFixRetriesWhenSomeChecksStayFailing|TestCIStep_DoesNotRetryOnUnrelatedPendingCheck|TestCIStep_RetriesMergeConflictAfterRerun' -count=1`
- `go test ./internal/pipeline/steps -run 'TestCIStep_CIFailureAutoFix|TestCIStep_CIAutoFixDisabledWithZero|TestCIStep_CIAutoFixLimitExhausted|TestCIStep_FixMode_ManualInterventionRunsCIFix|TestCIStep_AutoFixNoChanges_CountsAsAttempt' -count=1`
- `go test ./internal/pipeline/steps -count=1`
- `go test -race ./internal/pipeline/steps -run 'TestCIStep_CIAutoFixRetriesAfterChecksRerun|TestCIStep_CIAutoFixRetriesWhenSomeChecksStayFailing|TestCIStep_DoesNotRetryOnUnrelatedPendingCheck|TestCIStep_RetriesMergeConflictAfterRerun' -count=1`
- Outcome: ✅ passed across 1 run (1m23s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/pipeline/steps/ci.go:162` - Clearing `lastFixedChecks` on any mixed `failing+pending` state assumes a pending check means the failed checks have rerun, but `GetChecks` only exposes names and buckets, so an unrelated long-running/queued job can also make `pending` true. When that unrelated job finishes, the unchanged stale failure set is treated as fresh and the step can fire another auto-fix attempt or consume retry budget without evidence that the failing checks actually reran.

**Round 2** (auto-fix) - found 2 warnings
- ⚠️ `internal/pipeline/steps/ci.go:162` - The new rerun guard only clears `lastFixedChecks` when a pending check name matches a previously failing check name. For merge-conflict-only auto-fix attempts, `lastFixedChecks` is stored as `&#34;+conflict&#34;`, so this branch never clears it after the fix push. If the conflict remains after checks finish rerunning, the step stays stuck on `&#34;fix already attempted&#34;` until timeout instead of consuming the next retry.
- ⚠️ `internal/pipeline/steps/ci_checks.go:64` - `pendingCheckMatchesLastFixed` parses `lastFixedChecks` by splitting on `,` and stripping the `+conflict` suffix, but check names are free-form strings. A check name containing `,` or ending with `+conflict` will be misparsed, which can incorrectly clear or preserve the retry guard and change auto-fix behavior.

**Round 3** (auto-fix) - found 1 warning
- ⚠️ `internal/pipeline/steps/ci_checks.go:79` - `pendingCheckMatchesLastFixed` clears the retry guard as soon as any one previously failing check name becomes pending. After fixing `{a,b}`, if only `a` reruns while `b` is still the old stale failure, the next settled poll treats `b` as a fresh issue and can spend another auto-fix attempt without evidence that `b` ever reran. If that tradeoff is not intentional, the guard needs to track rerun coverage per failing check instead of using any-match.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/pipeline/steps -run 'TestPendingCheckMatchesLastFixed_SpecialCheckNames|TestCIStep_CIAutoFixRetriesAfterChecksRerun|TestCIStep_CIAutoFixRetriesWhenSomeChecksStayFailing|TestCIStep_DoesNotRetryOnUnrelatedPendingCheck|TestCIStep_RetriesMergeConflictAfterRerun' -count=1`
- `go test ./internal/pipeline/steps -run 'TestCIStep_CIFailureAutoFix|TestCIStep_CIAutoFixDisabledWithZero|TestCIStep_CIAutoFixLimitExhausted|TestCIStep_FixMode_ManualInterventionRunsCIFix|TestCIStep_AutoFixNoChanges_CountsAsAttempt' -count=1`
- `go test ./internal/pipeline/steps -count=1`
- `go test -race ./internal/pipeline/steps -run 'TestCIStep_CIAutoFixRetriesAfterChecksRerun|TestCIStep_CIAutoFixRetriesWhenSomeChecksStayFailing|TestCIStep_DoesNotRetryOnUnrelatedPendingCheck|TestCIStep_RetriesMergeConflictAfterRerun' -count=1`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
