### PR TITLE
ci: force release-please tag creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,6 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          release-type: go
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
       "release-type": "go",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
-      "draft": true
+      "draft": true,
+      "force-tag-creation": true
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"

--- a/workflow_release_test.go
+++ b/workflow_release_test.go
@@ -127,6 +127,44 @@ func TestReleasePleaseConfigCreatesDrafts(t *testing.T) {
 	}
 }
 
+func TestReleasePleaseConfigForcesTagCreation(t *testing.T) {
+	data, err := os.ReadFile("release-please-config.json")
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var cfg struct {
+		Packages map[string]struct {
+			ForceTagCreation bool `json:"force-tag-creation"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	pkg, ok := cfg.Packages["."]
+	if !ok {
+		t.Fatalf("release-please config missing '.' package")
+	}
+	if !pkg.ForceTagCreation {
+		t.Fatalf("release-please config must force tag creation so an existing GitHub release cannot silently prevent the tag from being recreated")
+	}
+}
+
+func TestReleaseWorkflowDoesNotOverrideReleaseType(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/release.yml")
+	if err != nil {
+		t.Fatalf("read workflow: %v", err)
+	}
+	content := string(data)
+
+	block := extractJobBlock(t, content, "release-please")
+	if strings.Contains(block, "release-type:") {
+		t.Fatalf("release workflow must not override release-type; release-please should read it from release-please-config.json")
+	}
+	if !strings.Contains(block, "config-file: release-please-config.json") {
+		t.Fatalf("release workflow must point release-please at release-please-config.json")
+	}
+}
+
 func TestReleaseWorkflowPromotesDraftOnlyAfterAssetsComplete(t *testing.T) {
 	data, err := os.ReadFile(".github/workflows/release.yml")
 	if err != nil {


### PR DESCRIPTION
## Summary
- Enable `force-tag-creation` in `release-please-config.json` so an existing GitHub release cannot silently prevent the tag from being recreated.
- Keep release settings sourced from `release-please-config.json` by removing the workflow-level `release-type` override.
- Add regression coverage for the release workflow and release-please config so tag creation and config-driven behavior stay enforced.

## Risk Assessment

✅ Low: The change is narrowly scoped to release-please configuration, matches the upstream v4 manifest setup, and does not introduce any obvious correctness or safety regressions in the reviewed diff.

## Testing

- Summary: <code>Exercised the release workflow and release-please config coverage, including new regressions for forced tag creation and removing the workflow-level `release-type` override, and all targeted tests passed.</code>
- `go test ./... -run 'TestReleaseWorkflow|TestReleasePleaseConfig'`
- `go test . -run 'TestReleasePleaseConfigForcesTagCreation|TestReleaseWorkflowDoesNotOverrideReleaseType'`
- Outcome: ✅ passed across 1 run (1m10s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./... -run 'TestReleaseWorkflow|TestReleasePleaseConfig'`
- `go test . -run 'TestReleasePleaseConfigForcesTagCreation|TestReleaseWorkflowDoesNotOverrideReleaseType'`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
