### PR TITLE
fix(git): isolate gate hooks from shared hookspath changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ no-mistakes
 # opens the TUI for the active run
 ```
 
-You can also skip `git push` and run `no-mistakes` directly after making changes. The setup wizard walks you through creating a branch, committing, pushing through the gate, and attaching to the new run.
+You can also skip `git push` and run `no-mistakes` directly after making changes. The setup wizard walks you through creating a branch, committing, and pushing through the gate, then attaches if the daemon registers the new run.
 
 See the [quick start](https://kunchenguid.github.io/no-mistakes/start-here/quick-start/) for the full first-run walkthrough.
 

--- a/docs/src/content/docs/concepts/daemon.md
+++ b/docs/src/content/docs/concepts/daemon.md
@@ -84,7 +84,7 @@ On startup, the daemon checks for runs that were left in `pending` or `running` 
 - Marks those runs as `failed` with the message "daemon crashed during execution"
 - Reaps orphaned managed agent servers left behind by a crashed daemon or setup wizard
 - Removes any orphaned worktree directories via `git worktree remove --force`
-- Reapplies per-worktree gate hook-path isolation to existing bare repos so shared `core.hookspath` writes cannot disable `post-receive`
+- Reapplies per-worktree gate hook-path isolation to existing bare repos when Git supports `config --worktree`, so shared `core.hookspath` writes cannot disable `post-receive`
 
 ## Logging
 

--- a/docs/src/content/docs/concepts/daemon.md
+++ b/docs/src/content/docs/concepts/daemon.md
@@ -84,6 +84,7 @@ On startup, the daemon checks for runs that were left in `pending` or `running` 
 - Marks those runs as `failed` with the message "daemon crashed during execution"
 - Reaps orphaned managed agent servers left behind by a crashed daemon or setup wizard
 - Removes any orphaned worktree directories via `git worktree remove --force`
+- Reapplies per-worktree gate hook-path isolation to existing bare repos so shared `core.hookspath` writes cannot disable `post-receive`
 
 ## Logging
 

--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -30,8 +30,9 @@ When you run `no-mistakes init` in a repo:
 
 1. It creates a local bare gate repo under `~/.no-mistakes/repos/<id>.git`.
 2. It installs a `post-receive` hook in that gate repo.
-3. It adds a `no-mistakes` remote to your working repo that points at the gate.
-4. It makes sure the daemon is running so incoming pushes can start runs.
+3. It isolates the gate repo's hooks path from shared local Git config writes.
+4. It adds a `no-mistakes` remote to your working repo that points at the gate.
+5. It makes sure the daemon is running so incoming pushes can start runs.
 
 After init, your original `origin` still points at the real upstream remote.
 That is a core design choice, not an implementation detail.

--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -30,7 +30,7 @@ When you run `no-mistakes init` in a repo:
 
 1. It creates a local bare gate repo under `~/.no-mistakes/repos/<id>.git`.
 2. It installs a `post-receive` hook in that gate repo.
-3. It isolates the gate repo's hooks path from shared local Git config writes.
+3. It best-effort isolates the gate repo's hooks path from shared local Git config writes when Git supports `config --worktree`.
 4. It adds a `no-mistakes` remote to your working repo that points at the gate.
 5. It makes sure the daemon is running so incoming pushes can start runs.
 
@@ -112,7 +112,7 @@ it was started from the same executable path and aborts if the daemon
 executable path cannot be determined or points to a different binary. You can
 also manage it explicitly with `no-mistakes daemon start|stop|restart|status`.
 
-On startup, the daemon recovers from crashes by marking any stuck runs as failed, reaping orphaned managed agent servers, cleaning up orphaned worktrees, and reapplying gate hook-path isolation for older bare repos.
+On startup, the daemon recovers from crashes by marking any stuck runs as failed, reaping orphaned managed agent servers, cleaning up orphaned worktrees, and reapplying gate hook-path isolation for older bare repos when Git supports `config --worktree`.
 
 ### Pipeline executor
 

--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -83,8 +83,10 @@ agent edit files, and commit fixes. Your day-to-day working tree stays clean.
 
 When `git push no-mistakes <branch>` lands, the bare repo's `post-receive` hook
 fires. It calls `no-mistakes daemon notify-push` with the gate path, ref name,
-and old/new SHAs. The hook never blocks the push - it runs the notification in
-the background and always exits 0.
+and old/new SHAs. The hook never blocks the push - Git ignores `post-receive`
+exit status, so pushes still succeed - but notification failures are surfaced
+to the pushing client on stderr and appended to `notify-push.log` in the bare
+repo for later inspection.
 
 ### Daemon
 
@@ -109,7 +111,7 @@ it was started from the same executable path and aborts if the daemon
 executable path cannot be determined or points to a different binary. You can
 also manage it explicitly with `no-mistakes daemon start|stop|restart|status`.
 
-On startup, the daemon recovers from crashes by marking any stuck runs as failed, reaping orphaned managed agent servers, and cleaning up orphaned worktrees.
+On startup, the daemon recovers from crashes by marking any stuck runs as failed, reaping orphaned managed agent servers, cleaning up orphaned worktrees, and reapplying gate hook-path isolation for older bare repos.
 
 ### Pipeline executor
 
@@ -148,6 +150,7 @@ Everything lives under `~/.no-mistakes/` by default. Set `NM_HOME` to relocate i
 | `update-check.json` | Cached update check result |
 | `servers/` | PID-tracking records for managed agent servers |
 | `repos/<id>.git` | Bare gate repos |
+| `repos/<id>.git/notify-push.log` | Persistent hook notification failure log |
 | `worktrees/<repoID>/<runID>/` | Disposable worktrees (cleaned up after each run) |
 | `logs/<runID>/<step>.log` | Per-step log files |
 | `logs/daemon.log` | Daemon log |

--- a/docs/src/content/docs/guides/setup-wizard.md
+++ b/docs/src/content/docs/guides/setup-wizard.md
@@ -5,8 +5,8 @@ description: What bare `no-mistakes` does when there's no active run on the curr
 
 When you run `no-mistakes` with no arguments and there is no active run on the
 current branch, `no-mistakes` can walk you through creating a branch,
-committing local changes, and pushing through the gate before attaching to the
-new run. This is the setup wizard.
+committing local changes, and pushing through the gate, then attach if the
+daemon registers the new run. This is the setup wizard.
 
 The point of the wizard is to make bare `no-mistakes` a useful starting
 command, not just an attach command. If you have local work but no run yet, the

--- a/docs/src/content/docs/guides/setup-wizard.md
+++ b/docs/src/content/docs/guides/setup-wizard.md
@@ -66,7 +66,7 @@ Always shown. Asks whether to push the current branch to the `no-mistakes` gate.
 - Press `y` to push.
 - Press `n` to stop.
 
-If the push succeeds, the interactive wizard stays visible in a brief `waiting for run…` state while the daemon registers the new run, then hands off to the main TUI and attaches.
+If the push succeeds, the interactive wizard stays visible in a brief `waiting for run…` state while the daemon registers the new run, then hands off to the main TUI and attaches. If no run appears in time, the wizard exits with an error instead of silently falling through, and points you at the gate's `notify-push.log` for hook diagnostics.
 
 The goal is to keep the setup path short. If you already have a branch, it does
 not ask for one. If everything is already committed, it skips straight to push.

--- a/docs/src/content/docs/guides/setup-wizard.md
+++ b/docs/src/content/docs/guides/setup-wizard.md
@@ -10,7 +10,8 @@ daemon registers the new run. This is the setup wizard.
 
 The point of the wizard is to make bare `no-mistakes` a useful starting
 command, not just an attach command. If you have local work but no run yet, the
-wizard helps turn that state into branch -> commit -> push -> attach.
+wizard helps turn that state into branch -> commit -> push -> attach when the
+daemon registers the new run.
 
 The wizard kicks in when:
 
@@ -35,7 +36,9 @@ flowchart TD
   interactive -- "yes" --> branch["Branch step if needed"]
   branch --> commit["Commit step if needed"]
   commit --> push["Push step"]
-  push --> tui["Attach to new run"]
+  push --> registered{"Run registered?"}
+  registered -- "yes" --> tui["Attach to new run"]
+  registered -- "no" --> error["Show notify-push error"]
 ```
 
 ## Steps

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -132,7 +132,7 @@ Also check `<gate-path>/notify-push.log`. The hook now appends daemon notificati
 
 The hook talks to the daemon over `~/.no-mistakes/socket`. If the daemon isn't running, the push still succeeds (the hook never blocks), but no pipeline starts. Start the daemon and push again.
 
-If the gate is older, restarting the daemon also reapplies hook-path isolation for existing bare repos. That protects the gate hook if a tool such as Husky wrote `core.hookspath` into shared git config from inside a linked worktree.
+If the gate is older, restarting the daemon also reapplies hook-path isolation for existing bare repos when Git supports `config --worktree`. That protects the gate hook if a tool such as Husky wrote `core.hookspath` into shared git config from inside a linked worktree.
 
 ## PR step is skipped
 

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -126,9 +126,13 @@ ls -la <gate-path>/hooks/post-receive
 
 The hook should be executable. If it's missing or non-executable, `no-mistakes init` will reinstall it.
 
+Also check `<gate-path>/notify-push.log`. The hook now appends daemon notification failures there and prints the same error back to the pushing client.
+
 ### Check the daemon socket
 
 The hook talks to the daemon over `~/.no-mistakes/socket`. If the daemon isn't running, the push still succeeds (the hook never blocks), but no pipeline starts. Start the daemon and push again.
+
+If the gate is older, restarting the daemon also reapplies hook-path isolation for existing bare repos. That protects the gate hook if a tool such as Husky wrote `core.hookspath` into shared git config from inside a linked worktree.
 
 ## PR step is skipped
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -25,7 +25,7 @@ Initialize the gate for the current repository.
 no-mistakes init
 ```
 
-Creates a local bare repo, installs the post-receive hook, isolates the gate repo's hook path from shared git config changes, adds the `no-mistakes` git remote, detects the default branch, records the repo in SQLite, and ensures the daemon is running, installing the managed service when available and falling back to a detached daemon otherwise.
+Creates a local bare repo, installs the post-receive hook, best-effort isolates the gate repo's hook path from shared git config changes when Git supports `config --worktree`, adds the `no-mistakes` git remote, detects the default branch, records the repo in SQLite, and ensures the daemon is running, installing the managed service when available and falling back to a detached daemon otherwise.
 
 Rolls back all changes if any step fails.
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -5,7 +5,7 @@ description: Complete reference for all no-mistakes commands and flags.
 
 ## no-mistakes
 
-Attach to the active pipeline run for the current branch when one exists. If none exists, bare `no-mistakes` can start the setup wizard to create a branch, commit changes, push through the gate, wait for the daemon to register the new run, and then attach. By default this wizard path is interactive and only runs in a TTY session. In non-interactive contexts, bare `no-mistakes` falls back to showing the last 5 runs inline unless you pass `-y` or `--yes` to run the wizard and accept defaults automatically. When a TTY is available, `-y` keeps the wizard visible, shows a brief `waiting for run…` state after push, and auto-advances the default path; without a TTY it falls back to the headless path.
+Attach to the active pipeline run for the current branch when one exists. If none exists, bare `no-mistakes` can start the setup wizard to create a branch, commit changes, push through the gate, wait for the daemon to register the new run, and then attach. If the push succeeds but no run is registered, that wizard path now exits with an explicit error instead of silently falling through. By default this wizard path is interactive and only runs in a TTY session. In non-interactive contexts, bare `no-mistakes` falls back to showing the last 5 runs inline unless you pass `-y` or `--yes` to run the wizard and accept defaults automatically. When a TTY is available, `-y` keeps the wizard visible, shows a brief `waiting for run…` state after push, and auto-advances the default path; without a TTY it falls back to the headless path.
 
 ```sh
 no-mistakes
@@ -25,7 +25,7 @@ Initialize the gate for the current repository.
 no-mistakes init
 ```
 
-Creates a local bare repo, installs the post-receive hook, adds the `no-mistakes` git remote, detects the default branch, records the repo in SQLite, and ensures the daemon is running, installing the managed service when available and falling back to a detached daemon otherwise.
+Creates a local bare repo, installs the post-receive hook, isolates the gate repo's hook path from shared git config changes, adds the `no-mistakes` git remote, detects the default branch, records the repo in SQLite, and ensures the daemon is running, installing the managed service when available and falling back to a detached daemon otherwise.
 
 Rolls back all changes if any step fails.
 

--- a/docs/src/content/docs/start-here/introduction.md
+++ b/docs/src/content/docs/start-here/introduction.md
@@ -70,7 +70,7 @@ When a branch passes the gate, it means:
 - A fixed, opinionated pipeline: `rebase → review → test → document → lint → push → pr → ci`. Order is not configurable; what each step runs is.
 - Choice of agent: `claude`, `codex`, `rovodev`, or `opencode`, with per-repo override.
 - A TUI to watch, approve, fix, skip, or abort any step.
-- A setup wizard when you run bare `no-mistakes` with no active run on the current branch - it walks you through creating a branch, committing, and pushing through the gate before attaching to the new run.
+- A setup wizard when you run bare `no-mistakes` with no active run on the current branch - it walks you through creating a branch, committing, and pushing through the gate, then attaches if the daemon registers the new run.
 
 ## Next
 

--- a/docs/src/content/docs/start-here/quick-start.md
+++ b/docs/src/content/docs/start-here/quick-start.md
@@ -37,7 +37,7 @@ Navigate to any git repo with an `origin` remote:
 no-mistakes init
 ```
 
-This creates a local bare repo at `~/.no-mistakes/repos/<id>.git`, installs a post-receive hook, isolates the gate's hooks path from shared local Git config writes, adds a `no-mistakes` git remote to your working repo, and ensures the daemon is running.
+This creates a local bare repo at `~/.no-mistakes/repos/<id>.git`, installs a post-receive hook, best-effort isolates the gate's hooks path from shared local Git config writes when Git supports `config --worktree`, adds a `no-mistakes` git remote to your working repo, and ensures the daemon is running.
 
 ```
 $ no-mistakes init

--- a/docs/src/content/docs/start-here/quick-start.md
+++ b/docs/src/content/docs/start-here/quick-start.md
@@ -72,7 +72,7 @@ The push lands in the local bare repo, the hook notifies the daemon, and the dae
 no-mistakes
 ```
 
-If the current branch has an active run, this attaches directly. If not, the setup wizard can walk you through creating a branch, committing, and pushing through the gate before attaching. By default that path is interactive in a TTY. With `no-mistakes -y`, the wizard accepts defaults automatically, stays visible and auto-advances in a TTY, and falls back to the headless path without a TTY.
+If the current branch has an active run, this attaches directly. If not, the setup wizard can walk you through creating a branch, committing, and pushing through the gate, then attach if the daemon registers the new run. By default that path is interactive in a TTY. With `no-mistakes -y`, the wizard accepts defaults automatically, stays visible and auto-advances in a TTY, and falls back to the headless path without a TTY.
 
 The TUI shows each step's progress, streams agent output, and pauses for your approval when findings need attention. See [Using the TUI](/no-mistakes/guides/tui/) for keybindings and layout.
 

--- a/docs/src/content/docs/start-here/quick-start.md
+++ b/docs/src/content/docs/start-here/quick-start.md
@@ -37,7 +37,7 @@ Navigate to any git repo with an `origin` remote:
 no-mistakes init
 ```
 
-This creates a local bare repo at `~/.no-mistakes/repos/<id>.git`, installs a post-receive hook, adds a `no-mistakes` git remote to your working repo, and ensures the daemon is running.
+This creates a local bare repo at `~/.no-mistakes/repos/<id>.git`, installs a post-receive hook, isolates the gate's hooks path from shared local Git config writes, adds a `no-mistakes` git remote to your working repo, and ensures the daemon is running.
 
 ```
 $ no-mistakes init

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -98,11 +98,7 @@ func attachRun(ctx context.Context, w io.Writer, runID string, rootDefault bool,
 			// has the run registered, so the handoff to runTUI below is
 			// seamless rather than flashing the pre-wizard terminal.
 			waitFn := func(ctx context.Context, branch string) error {
-				_, werr := waitForActiveRun(ctx, client, repo.ID, branch, 5*time.Second)
-				if werr != nil {
-					return werr
-				}
-				return nil
+				return awaitDaemonRunRegistration(ctx, client, repo.ID, branch, 5*time.Second)
 			}
 			var res wizard.Result
 			var wErr error

--- a/internal/cli/attach_test.go
+++ b/internal/cli/attach_test.go
@@ -134,7 +134,13 @@ func TestAttachNotGitRepoCommands(t *testing.T) {
 	}
 }
 
-func TestRootInteractiveWizardFallsBackWhenRunRegistrationIsSlow(t *testing.T) {
+// TestRootInteractiveWizardFailsLoudlyWhenRunRegistrationIsSlow covers
+// issue #122 defect 3. Prior behavior: if the daemon didn't register a
+// run after push (e.g. gate hook disabled by husky), the wizard's wait
+// silently returned nil, the wizard declared success, and the command
+// printed "No active run" with exit code 0. That masked the real failure.
+// After the fix, an error surfaces all the way to the CLI.
+func TestRootInteractiveWizardFailsLoudlyWhenRunRegistrationIsSlow(t *testing.T) {
 	setupTestRepo(t)
 	nmHome := makeSocketSafeTempDir(t)
 	t.Setenv("NM_HOME", nmHome)
@@ -175,11 +181,11 @@ func TestRootInteractiveWizardFallsBackWhenRunRegistrationIsSlow(t *testing.T) {
 	}
 	defer func() { runTUI = prevRunTUI }()
 
-	out, err := executeCmd()
-	if err != nil {
-		t.Fatalf("executeCmd() error = %v", err)
+	_, err = executeCmd()
+	if err == nil {
+		t.Fatal("executeCmd() should return an error when the daemon doesn't register a run")
 	}
-	if !strings.Contains(out, "No active run") {
-		t.Fatalf("expected existing fallback output, got %q", out)
+	if !strings.Contains(err.Error(), "feat/slow") {
+		t.Errorf("error should name the branch we were waiting for, got: %v", err)
 	}
 }

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -16,11 +16,10 @@ func newInitCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "init",
 		Short: "Initialize no-mistakes gate for the current repository",
-		Long: `Sets up a local bare repo as a gate, installs a post-receive hook,
-best-effort isolates the gate hook path from shared local git config writes when Git supports `config --worktree`,
-adds a "no-mistakes" git remote, and records the repo in the database.
-
-Run this from inside a git repository that has an "origin" remote.`,
+		Long: "Sets up a local bare repo as a gate, installs a post-receive hook,\n" +
+			"best-effort isolates the gate hook path from shared local git config writes when Git supports `config --worktree`,\n" +
+			"adds a \"no-mistakes\" git remote, and records the repo in the database.\n\n" +
+			"Run this from inside a git repository that has an \"origin\" remote.",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return trackCommand("init", func() error {

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -17,7 +17,8 @@ func newInitCmd() *cobra.Command {
 		Use:   "init",
 		Short: "Initialize no-mistakes gate for the current repository",
 		Long: `Sets up a local bare repo as a gate, installs a post-receive hook,
-adds a "no-mistakes" git remote, and records the repo in the database.
+isolates the gate hook path from shared local git config writes, adds a
+"no-mistakes" git remote, and records the repo in the database.
 
 Run this from inside a git repository that has an "origin" remote.`,
 		Args: cobra.NoArgs,

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -17,7 +17,7 @@ func newInitCmd() *cobra.Command {
 		Use:   "init",
 		Short: "Initialize no-mistakes gate for the current repository",
 		Long: `Sets up a local bare repo as a gate, installs a post-receive hook,
-best-effort isolates the gate hook path from shared local git config writes,
+best-effort isolates the gate hook path from shared local git config writes when Git supports `config --worktree`,
 adds a "no-mistakes" git remote, and records the repo in the database.
 
 Run this from inside a git repository that has an "origin" remote.`,

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -17,8 +17,8 @@ func newInitCmd() *cobra.Command {
 		Use:   "init",
 		Short: "Initialize no-mistakes gate for the current repository",
 		Long: `Sets up a local bare repo as a gate, installs a post-receive hook,
-isolates the gate hook path from shared local git config writes, adds a
-"no-mistakes" git remote, and records the repo in the database.
+best-effort isolates the gate hook path from shared local git config writes,
+adds a "no-mistakes" git remote, and records the repo in the database.
 
 Run this from inside a git repository that has an "origin" remote.`,
 		Args: cobra.NoArgs,

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -316,7 +316,11 @@ func awaitDaemonRunRegistration(ctx context.Context, client *ipc.Client, repoID,
 		return err
 	}
 	if run == nil {
-		return fmt.Errorf("daemon did not register a pipeline run for %q within %s - the gate hook may not have fired (check ~/.no-mistakes/repos/<id>.git/notify-push.log and that the daemon is running)", branch, timeout)
+		logPath := filepath.Join("~/.no-mistakes", "repos", repoID+".git", "notify-push.log")
+		if p, pathErr := paths.New(); pathErr == nil {
+			logPath = filepath.Join(p.RepoDir(repoID), "notify-push.log")
+		}
+		return fmt.Errorf("daemon did not register a pipeline run for %q within %s - the gate hook may not have fired (check %s and that the daemon is running)", branch, timeout, logPath)
 	}
 	return nil
 }

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -304,6 +304,23 @@ type discardWriter struct{}
 
 func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
 
+// awaitDaemonRunRegistration waits for the daemon to register a run for
+// the given branch. A missing run within the timeout is treated as a
+// failure: if the push completed but no run exists, the gate hook
+// probably didn't fire (e.g. core.hookspath poisoning from husky, see
+// issue #122) or the daemon isn't receiving events. Surfacing this as an
+// error prevents the wizard from silently declaring success.
+func awaitDaemonRunRegistration(ctx context.Context, client *ipc.Client, repoID, branch string, timeout time.Duration) error {
+	run, err := waitForActiveRun(ctx, client, repoID, branch, timeout)
+	if err != nil {
+		return err
+	}
+	if run == nil {
+		return fmt.Errorf("daemon did not register a pipeline run for %q within %s - the gate hook may not have fired (check ~/.no-mistakes/repos/<id>.git/notify-push.log and that the daemon is running)", branch, timeout)
+	}
+	return nil
+}
+
 // waitForActiveRun polls the daemon until an active run appears for the given
 // repo/branch, or the deadline elapses. The post-receive hook creates the run
 // asynchronously, so a short poll bridges the gap between push and attach.

--- a/internal/cli/wizard_test.go
+++ b/internal/cli/wizard_test.go
@@ -520,3 +520,40 @@ func TestAwaitDaemonRunRegistration_ErrorsWhenNoRunAppears(t *testing.T) {
 		t.Errorf("error should name the branch we were waiting for, got: %v", err)
 	}
 }
+
+func TestAwaitDaemonRunRegistration_UsesNMHomeInTimeoutError(t *testing.T) {
+	nmHome := makeSocketSafeTempDir(t)
+	t.Setenv("NM_HOME", nmHome)
+
+	p := paths.WithRoot(nmHome)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	startTestDaemon(t, p, d)
+
+	client, err := ipc.Dial(p.Socket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	err = awaitDaemonRunRegistration(context.Background(), client, "repo123", "feat/missing", 200*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+
+	wantLogPath := filepath.Join(nmHome, "repos", "repo123.git", "notify-push.log")
+	if !strings.Contains(err.Error(), wantLogPath) {
+		t.Fatalf("timeout error = %q, want log path %q", err.Error(), wantLogPath)
+	}
+	if strings.Contains(err.Error(), "<id>") {
+		t.Fatalf("timeout error should not contain placeholder repo id: %q", err.Error())
+	}
+}

--- a/internal/cli/wizard_test.go
+++ b/internal/cli/wizard_test.go
@@ -9,9 +9,12 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
 	"github.com/kunchenguid/no-mistakes/internal/config"
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
 	"github.com/kunchenguid/no-mistakes/internal/telemetry"
 	"github.com/kunchenguid/no-mistakes/internal/types"
@@ -476,5 +479,44 @@ func TestRunWizard_ConfiguresServerPIDsDir(t *testing.T) {
 	}
 	if got := agent.CurrentServerPIDOwner(); got != "" {
 		t.Fatalf("after wizard, CurrentServerPIDOwner = %q, want empty", got)
+	}
+}
+
+// TestAwaitDaemonRunRegistration_ErrorsWhenNoRunAppears covers issue #122
+// defect 3. When a push succeeds but the daemon never registers a run
+// (e.g. the gate hook was disabled by husky), the wait must surface an
+// error the caller can propagate. The previous implementation returned nil
+// on timeout, which let the wizard declare success and silently fall
+// through to "No active run".
+func TestAwaitDaemonRunRegistration_ErrorsWhenNoRunAppears(t *testing.T) {
+	nmHome := makeSocketSafeTempDir(t)
+	t.Setenv("NM_HOME", nmHome)
+	p := paths.WithRoot(nmHome)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	startTestDaemon(t, p, d)
+
+	client, err := ipc.Dial(p.Socket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	// Use a short timeout - no run will ever register because nothing
+	// triggers one.
+	err = awaitDaemonRunRegistration(context.Background(), client, "no-such-repo", "feat/missing", 200*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error when no run registers within the timeout")
+	}
+	if !strings.Contains(err.Error(), "feat/missing") {
+		t.Errorf("error should name the branch we were waiting for, got: %v", err)
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -227,8 +227,9 @@ func writeDaemonPIDFile(path string, record daemonPIDFile) error {
 // recoverOnStartup cleans up after a previous daemon crash by marking stale
 // runs/steps as failed, killing orphaned managed-server subprocesses
 // (opencode, rovodev), and removing orphaned worktree directories. It also
-// migrates gate bare repos in place so older installs pick up the
-// per-worktree hookspath isolation introduced for issue #122.
+// best-effort migrates gate bare repos in place so older installs pick up
+// the per-worktree hookspath isolation introduced for issue #122 when Git
+// supports config --worktree.
 func recoverOnStartup(d *db.DB, p *paths.Paths) {
 	reapOrphanedServers(p)
 	migrateGateConfigs(context.Background(), p)
@@ -281,9 +282,10 @@ func recoverOnStartup(d *db.DB, p *paths.Paths) {
 // migrateGateConfigs walks every bare repo under p.ReposDir() and applies
 // git.IsolateHooksPath. The operation is idempotent: bare repos already
 // configured by gate.Init are left effectively unchanged. Older bare repos
-// (from before issue #122 was fixed) get their per-worktree hookspath
-// pinned so subsequent husky-style writes to shared local config can no
-// longer disable the post-receive hook.
+// (from before issue #122 was fixed) best-effort get their per-worktree
+// hookspath pinned when Git supports config --worktree, so subsequent
+// husky-style writes to shared local config can no longer disable the
+// post-receive hook.
 func migrateGateConfigs(ctx context.Context, p *paths.Paths) {
 	entries, err := os.ReadDir(p.ReposDir())
 	if err != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -226,9 +226,12 @@ func writeDaemonPIDFile(path string, record daemonPIDFile) error {
 
 // recoverOnStartup cleans up after a previous daemon crash by marking stale
 // runs/steps as failed, killing orphaned managed-server subprocesses
-// (opencode, rovodev), and removing orphaned worktree directories.
+// (opencode, rovodev), and removing orphaned worktree directories. It also
+// migrates gate bare repos in place so older installs pick up the
+// per-worktree hookspath isolation introduced for issue #122.
 func recoverOnStartup(d *db.DB, p *paths.Paths) {
 	reapOrphanedServers(p)
+	migrateGateConfigs(context.Background(), p)
 
 	count, err := d.RecoverStaleRuns("daemon crashed during execution")
 	if err != nil {
@@ -272,6 +275,29 @@ func recoverOnStartup(d *db.DB, p *paths.Paths) {
 		}
 		// Remove empty repo dir.
 		os.Remove(repoPath)
+	}
+}
+
+// migrateGateConfigs walks every bare repo under p.ReposDir() and applies
+// git.IsolateHooksPath. The operation is idempotent: bare repos already
+// configured by gate.Init are left effectively unchanged. Older bare repos
+// (from before issue #122 was fixed) get their per-worktree hookspath
+// pinned so subsequent husky-style writes to shared local config can no
+// longer disable the post-receive hook.
+func migrateGateConfigs(ctx context.Context, p *paths.Paths) {
+	entries, err := os.ReadDir(p.ReposDir())
+	if err != nil {
+		// Repos dir may not exist yet on a fresh install.
+		return
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		bareDir := filepath.Join(p.ReposDir(), entry.Name())
+		if err := git.IsolateHooksPath(ctx, bareDir); err != nil {
+			slog.Warn("isolate gate hooks path failed", "bare", bareDir, "error", err)
+		}
 	}
 }
 

--- a/internal/daemon/subscribe_recover_test.go
+++ b/internal/daemon/subscribe_recover_test.go
@@ -1,12 +1,16 @@
 package daemon
 
 import (
+	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/db"
+	gitpkg "github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
@@ -390,5 +394,44 @@ func TestRecoverCleansUpOrphanedWorktrees(t *testing.T) {
 	// Orphaned worktree directory should be removed.
 	if _, err := os.Stat(orphanDir); !os.IsNotExist(err) {
 		t.Errorf("orphaned worktree dir still exists: %s", orphanDir)
+	}
+}
+
+// TestRecoverIsolatesGateRepoHooksPath covers issue #122 for existing
+// installs: bare repos created before the fix have no per-worktree
+// core.hookspath, so a husky pollution still disables their hook.
+// Daemon startup must migrate them in place.
+func TestRecoverIsolatesGateRepoHooksPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	p := paths.WithRoot(tmpDir)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate an existing install: a bare repo created the old way
+	// (without IsolateHooksPath) whose shared local config has been
+	// poisoned by husky during a prior pipeline run.
+	bareDir := p.RepoDir("legacy-repo")
+	ctx := context.Background()
+	if err := gitpkg.InitBare(ctx, bareDir); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command("git", "-C", bareDir, "config", "core.hookspath", ".husky/_").CombinedOutput(); err != nil {
+		t.Fatalf("seed poisoned config: %v: %s", err, out)
+	}
+
+	migrateGateConfigs(ctx, p)
+
+	// Effective core.hookspath should now resolve to the bare's hooks dir.
+	out, err := exec.Command("git", "-C", bareDir, "config", "--get", "core.hookspath").Output()
+	if err != nil {
+		t.Fatalf("get core.hookspath: %v", err)
+	}
+	want, err := filepath.Abs(filepath.Join(bareDir, "hooks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(out)); got != want {
+		t.Errorf("after migration, core.hookspath = %q, want %q", got, want)
 	}
 }

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -65,6 +65,14 @@ func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Re
 		return nil, fmt.Errorf("install hook: %w", err)
 	}
 
+	// Pin core.hookspath in the bare's per-worktree config so subprocess
+	// writes to shared local config (e.g. husky during pnpm install) can't
+	// disable the gate hook. See git.IsolateHooksPath for details.
+	if err := git.IsolateHooksPath(ctx, bareDir); err != nil {
+		os.RemoveAll(bareDir)
+		return nil, fmt.Errorf("isolate hooks path: %w", err)
+	}
+
 	// Record upstream as origin on the gate repo so gh can resolve repository context
 	// from detached worktrees created from the gate.
 	if err := git.AddRemote(ctx, bareDir, "origin", upstreamURL); err != nil {

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -23,7 +23,8 @@ func repoID(absPath string) string {
 }
 
 // Init sets up a no-mistakes gate for the git repo at workDir.
-// It creates a bare repo, installs the post-receive hook, adds the
+// It creates a bare repo, installs the post-receive hook, isolates the
+// bare repo's hooks path from shared local config writes, adds the
 // no-mistakes remote, and records the repo in the database.
 func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Repo, error) {
 	// Normalize worktrees back to the main repo root so one repo record works

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -23,9 +23,10 @@ func repoID(absPath string) string {
 }
 
 // Init sets up a no-mistakes gate for the git repo at workDir.
-// It creates a bare repo, installs the post-receive hook, isolates the
-// bare repo's hooks path from shared local config writes, adds the
-// no-mistakes remote, and records the repo in the database.
+// It creates a bare repo, installs the post-receive hook, best-effort
+// isolates the bare repo's hooks path from shared local config writes when
+// Git supports config --worktree, adds the no-mistakes remote, and records
+// the repo in the database.
 func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Repo, error) {
 	// Normalize worktrees back to the main repo root so one repo record works
 	// from either the main checkout or any attached worktree.

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -360,3 +360,55 @@ func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
 }
+
+// TestInit_PostReceiveSurvivesHooksPathPoisoning reproduces issue #122.
+// Husky and similar tools run `git config core.hookspath .husky/_` from
+// inside a worktree of the gate bare repo. That write lands in the bare's
+// shared local config and silently disables the post-receive hook, so
+// subsequent pushes complete but never trigger a pipeline.
+//
+// The gate repo must isolate its own core.hookspath so external writes to
+// the shared config can't reach it.
+func TestInit_PostReceiveSurvivesHooksPathPoisoning(t *testing.T) {
+	workDir := setupTestRepo(t)
+	nmRoot := t.TempDir()
+	p := paths.WithRoot(nmRoot)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	d := openTestDB(t, p)
+	ctx := context.Background()
+
+	repo, err := Init(ctx, d, p, workDir)
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	bareDir := p.RepoDir(repo.ID)
+
+	// Replace the installed hook with one that touches a marker file so we
+	// can detect whether receive-pack actually invokes hooks/post-receive.
+	markerDir := resolveSymlinks(t, t.TempDir())
+	marker := filepath.Join(markerDir, "fired")
+	hookPath := filepath.Join(bareDir, "hooks", "post-receive")
+	hook := "#!/bin/sh\ntouch '" + marker + "'\nexit 0\n"
+	if err := os.WriteFile(hookPath, []byte(hook), 0o755); err != nil {
+		t.Fatalf("write marker hook: %v", err)
+	}
+
+	// Simulate husky: pnpm install in a pipeline worktree runs
+	// `git config core.hookspath .husky/_`. Because worktrees share local
+	// config with the bare main repo, that write lands in bareDir/config.
+	if out, err := exec.Command("git", "-C", bareDir, "config", "core.hookspath", ".husky/_").CombinedOutput(); err != nil {
+		t.Fatalf("simulate husky poisoning: %v: %s", err, out)
+	}
+
+	// Push to the gate. The bare repo's own core.hookspath must still
+	// resolve to its hooks dir so post-receive fires.
+	if out, err := exec.Command("git", "-C", workDir, "push", "no-mistakes", "HEAD:refs/heads/test-branch").CombinedOutput(); err != nil {
+		t.Fatalf("push: %v: %s", err, out)
+	}
+
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("post-receive did not fire after husky poisoned core.hookspath: %v", err)
+	}
+}

--- a/internal/git/hook.go
+++ b/internal/git/hook.go
@@ -2,11 +2,15 @@ package git
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
+
+var runGit = Run
 
 // PostReceiveHookScript returns the shell script for the post-receive hook.
 // The hook notifies the daemon via the CLI so it works across platforms.
@@ -101,15 +105,26 @@ func InstallPostReceiveHook(bareDir string) error {
 // Idempotent: safe to call on an already-configured bare repo to
 // migrate older installs.
 func IsolateHooksPath(ctx context.Context, bareDir string) error {
-	if _, err := Run(ctx, bareDir, "config", "extensions.worktreeConfig", "true"); err != nil {
+	if _, err := runGit(ctx, bareDir, "config", "extensions.worktreeConfig", "true"); err != nil {
 		return fmt.Errorf("enable worktree config: %w", err)
 	}
 	hooksDir, err := filepath.Abs(filepath.Join(bareDir, "hooks"))
 	if err != nil {
 		return fmt.Errorf("resolve hooks dir: %w", err)
 	}
-	if _, err := Run(ctx, bareDir, "config", "--worktree", "core.hookspath", hooksDir); err != nil {
+	if _, err := runGit(ctx, bareDir, "config", "--worktree", "core.hookspath", hooksDir); err != nil {
+		if isWorktreeConfigUnsupported(err) {
+			return nil
+		}
 		return fmt.Errorf("pin core.hookspath per-worktree: %w", err)
 	}
 	return nil
+}
+
+func isWorktreeConfigUnsupported(err error) bool {
+	if errors.Is(err, exec.ErrNotFound) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "unknown option") && strings.Contains(msg, "worktree")
 }

--- a/internal/git/hook.go
+++ b/internal/git/hook.go
@@ -14,7 +14,8 @@ var runGit = Run
 
 // PostReceiveHookScript returns the shell script for the post-receive hook.
 // The hook notifies the daemon via the CLI so it works across platforms.
-// It never blocks the push - notification failures are silently ignored.
+// It never blocks the push - notification failures are surfaced to stderr and
+// appended to notify-push.log inside the bare repo.
 func PostReceiveHookScript() string {
 	exe, err := os.Executable()
 	if err != nil {

--- a/internal/git/hook.go
+++ b/internal/git/hook.go
@@ -105,6 +105,11 @@ func InstallPostReceiveHook(bareDir string) error {
 // Idempotent: safe to call on an already-configured bare repo to
 // migrate older installs.
 func IsolateHooksPath(ctx context.Context, bareDir string) error {
+	if _, err := runGit(ctx, bareDir, "config", "--worktree", "--get", "core.hookspath"); err != nil {
+		if isWorktreeConfigUnsupported(err) {
+			return nil
+		}
+	}
 	if _, err := runGit(ctx, bareDir, "config", "extensions.worktreeConfig", "true"); err != nil {
 		return fmt.Errorf("enable worktree config: %w", err)
 	}

--- a/internal/git/hook.go
+++ b/internal/git/hook.go
@@ -103,8 +103,11 @@ func InstallPostReceiveHook(bareDir string) error {
 // hooks to its own absolute hooks dir, regardless of what tools write
 // to the shared config.
 //
+// Best-effort only: if the installed Git does not support
+// `git config --worktree`, this returns nil without changing config.
+//
 // Idempotent: safe to call on an already-configured bare repo to
-// migrate older installs.
+// migrate older installs when per-worktree config is available.
 func IsolateHooksPath(ctx context.Context, bareDir string) error {
 	if _, err := runGit(ctx, bareDir, "config", "--worktree", "--get", "core.hookspath"); err != nil {
 		if isWorktreeConfigUnsupported(err) {

--- a/internal/git/hook.go
+++ b/internal/git/hook.go
@@ -1,6 +1,8 @@
 package git
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,19 +22,40 @@ func PostReceiveHookScript() string {
 func postReceiveHookScript(command string) string {
 	return `#!/bin/sh
 # no-mistakes post-receive hook
-# Notify daemon of push. Non-blocking - push always succeeds.
+# Notifies the daemon of the push. Non-blocking: post-receive exit code is
+# ignored by git, so we never reject the push here. Instead, failures are
+# surfaced on stderr (so the pushing client sees them) and appended to
+# notify-push.log inside the bare repo for later inspection.
 NM_BIN=` + shellSingleQuote(command) + `
 if [ ! -f "$NM_BIN" ]; then
   NM_BIN="$(command -v no-mistakes 2>/dev/null || echo no-mistakes)"
 fi
+LOG="$(pwd)/notify-push.log"
+nm_ts() { date '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || echo unknown; }
+notify_failed=0
 while read oldrev newrev refname; do
-  NM_HOOK_HELPER=1 "$NM_BIN" daemon notify-push \
+  out=$(NM_HOOK_HELPER=1 "$NM_BIN" daemon notify-push \
     --gate "$(pwd)" \
     --ref "$refname" \
     --old "$oldrev" \
-    --new "$newrev" >/dev/null 2>&1 || true
+    --new "$newrev" 2>&1)
+  status=$?
+  if [ $status -ne 0 ]; then
+    notify_failed=1
+    {
+      printf '[%s] notify-push failed for %s (exit %d)\n' "$(nm_ts)" "$refname" "$status"
+      printf '%s\n\n' "$out"
+    } >> "$LOG"
+    {
+      printf 'no-mistakes: notify-push failed for %s (exit %d):\n' "$refname" "$status"
+      printf '%s\n' "$out"
+      printf 'See %s for full history.\n' "$LOG"
+    } >&2
+  fi
 done
-cat >&2 <<'BANNER'
+
+if [ "$notify_failed" -eq 0 ]; then
+  cat >&2 <<'BANNER'
 _  _ ____    _  _ _ ____ ___ ____ _  _ ____ ____
 |\ | |  |    |\/| | [__   |  |__| |_/  |___ [__
 | \| |__|    |  | | ___]  |  |  | | \_ |___ ___]
@@ -42,6 +65,7 @@ _  _ ____    _  _ _ ____ ___ ____ _  _ ____ ____
   Run no-mistakes to review.
 
 BANNER
+fi
 exit 0
 `
 }
@@ -59,4 +83,33 @@ func InstallPostReceiveHook(bareDir string) error {
 	}
 	hookPath := filepath.Join(hooksDir, "post-receive")
 	return os.WriteFile(hookPath, []byte(PostReceiveHookScript()), 0o755)
+}
+
+// IsolateHooksPath protects the gate's post-receive hook from being
+// disabled when a pipeline subprocess (e.g. husky during `pnpm install`)
+// runs `git config core.hookspath` from inside a linked worktree.
+//
+// Linked worktrees share the bare's local config, so an unscoped
+// `git config` write lands in <bareDir>/config and silently overrides
+// the gate's hooks lookup. To defend against this, we enable
+// extensions.worktreeConfig on the bare and pin core.hookspath in the
+// bare's per-worktree config (<bareDir>/config.worktree). Per-worktree
+// scope wins over local, so the bare's main worktree always resolves
+// hooks to its own absolute hooks dir, regardless of what tools write
+// to the shared config.
+//
+// Idempotent: safe to call on an already-configured bare repo to
+// migrate older installs.
+func IsolateHooksPath(ctx context.Context, bareDir string) error {
+	if _, err := Run(ctx, bareDir, "config", "extensions.worktreeConfig", "true"); err != nil {
+		return fmt.Errorf("enable worktree config: %w", err)
+	}
+	hooksDir, err := filepath.Abs(filepath.Join(bareDir, "hooks"))
+	if err != nil {
+		return fmt.Errorf("resolve hooks dir: %w", err)
+	}
+	if _, err := Run(ctx, bareDir, "config", "--worktree", "core.hookspath", hooksDir); err != nil {
+		return fmt.Errorf("pin core.hookspath per-worktree: %w", err)
+	}
+	return nil
 }

--- a/internal/git/hook_test.go
+++ b/internal/git/hook_test.go
@@ -3,6 +3,7 @@ package git
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -41,8 +42,11 @@ func TestPostReceiveHookScript(t *testing.T) {
 	if !strings.Contains(script, "command -v no-mistakes") {
 		t.Fatal("hook should fall back to PATH when baked-in path doesn't exist")
 	}
-	if !strings.Contains(script, ">/dev/null 2>&1 || true") {
-		t.Fatal("hook should suppress notifier output so pushes stay clean")
+	if strings.Contains(script, ">/dev/null 2>&1 || true") {
+		t.Fatal("hook should not silently swallow notify-push errors (issue #122)")
+	}
+	if !strings.Contains(script, "notify-push.log") {
+		t.Fatal("hook should log notify-push output to a file under the bare repo")
 	}
 
 	// should print plain ASCII banner to stderr
@@ -135,6 +139,135 @@ func TestInstallPostReceiveHook(t *testing.T) {
 	}
 	if string(content) != postReceiveHookScript(exe) {
 		t.Fatal("hook content doesn't match template")
+	}
+}
+
+// TestPostReceiveHook_SurfacesNotifyFailures covers issue #122 defect 2:
+// when notify-push fails (daemon down, missing-hook state, etc.), the user
+// must see the failure on stderr instead of getting a clean-looking push.
+// We also persist failures to <bareDir>/notify-push.log so they survive past
+// the terminal scrollback.
+//
+// Note: post-receive's exit code is ignored by git, so we can't make
+// `git push` exit non-zero. The wizard's push-confirmation step (defect 3)
+// is responsible for surfacing the failure to the user as an error.
+func TestPostReceiveHook_SurfacesNotifyFailures(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("post-receive hook is /bin/sh-only")
+	}
+	ctx := context.Background()
+
+	base := t.TempDir()
+	bare := filepath.Join(base, "test.git")
+	if err := InitBare(ctx, bare); err != nil {
+		t.Fatal(err)
+	}
+	work := filepath.Join(base, "work")
+	if out, err := exec.Command("git", "init", work).CombinedOutput(); err != nil {
+		t.Fatalf("init work: %v: %s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", work, "config", "user.email", "t@t.com").CombinedOutput(); err != nil {
+		t.Fatalf("config email: %v: %s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", work, "config", "user.name", "T").CombinedOutput(); err != nil {
+		t.Fatalf("config name: %v: %s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", work, "remote", "add", "gate", bare).CombinedOutput(); err != nil {
+		t.Fatalf("add remote: %v: %s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", work, "commit", "--allow-empty", "-m", "init").CombinedOutput(); err != nil {
+		t.Fatalf("commit: %v: %s", err, out)
+	}
+
+	// Fake no-mistakes binary that always fails notify-push with a
+	// distinctive marker on stderr.
+	fakeBin := filepath.Join(base, "fake-no-mistakes")
+	fakeScript := "#!/bin/sh\necho 'TESTMARKER notify failed' >&2\nexit 7\n"
+	if err := os.WriteFile(fakeBin, []byte(fakeScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Install the real hook generated against the fake binary.
+	hooksDir := filepath.Join(bare, "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hookPath := filepath.Join(hooksDir, "post-receive")
+	if err := os.WriteFile(hookPath, []byte(postReceiveHookScript(fakeBin)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Push. We don't care whether `git push` exits zero (post-receive
+	// exit code is ignored by git); we care that the failure surfaced.
+	pushOut, _ := exec.Command("git", "-C", work, "push", "gate", "HEAD:refs/heads/main").CombinedOutput()
+
+	if !strings.Contains(string(pushOut), "TESTMARKER notify failed") {
+		t.Errorf("push output should surface notify-push stderr to the client, got:\n%s", pushOut)
+	}
+
+	logPath := filepath.Join(bare, "notify-push.log")
+	logContent, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("notify-push.log should exist at %s: %v", logPath, err)
+	}
+	if !strings.Contains(string(logContent), "TESTMARKER notify failed") {
+		t.Errorf("notify-push.log should contain notify-push stderr, got:\n%s", logContent)
+	}
+}
+
+func TestIsolateHooksPath_OverridesPoisonedSharedConfig(t *testing.T) {
+	ctx := context.Background()
+	bare := filepath.Join(t.TempDir(), "test.git")
+	if err := InitBare(ctx, bare); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate husky writing core.hookspath into the bare's shared local
+	// config (this is what `git config core.hookspath .husky/_` does when
+	// invoked from a linked worktree).
+	if out, err := exec.Command("git", "-C", bare, "config", "core.hookspath", ".husky/_").CombinedOutput(); err != nil {
+		t.Fatalf("seed shared core.hookspath: %v: %s", err, out)
+	}
+
+	if err := IsolateHooksPath(ctx, bare); err != nil {
+		t.Fatalf("IsolateHooksPath: %v", err)
+	}
+
+	out, err := exec.Command("git", "-C", bare, "config", "--get", "core.hookspath").Output()
+	if err != nil {
+		t.Fatalf("get core.hookspath: %v", err)
+	}
+	want, err := filepath.Abs(filepath.Join(bare, "hooks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(out)); got != want {
+		t.Errorf("effective core.hookspath = %q, want %q (per-worktree should win over poisoned shared)", got, want)
+	}
+
+	// Verify the shared poisoning is still observable in the local scope -
+	// we don't try to clean it up because husky will just re-add it on the
+	// next pipeline run. Per-worktree is what protects us.
+	out, err = exec.Command("git", "-C", bare, "config", "--local", "--get", "core.hookspath").Output()
+	if err != nil {
+		t.Fatalf("get local core.hookspath: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != ".husky/_" {
+		t.Errorf("local core.hookspath = %q, want %q", got, ".husky/_")
+	}
+}
+
+func TestIsolateHooksPath_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	bare := filepath.Join(t.TempDir(), "test.git")
+	if err := InitBare(ctx, bare); err != nil {
+		t.Fatal(err)
+	}
+	if err := IsolateHooksPath(ctx, bare); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if err := IsolateHooksPath(ctx, bare); err != nil {
+		t.Fatalf("second call should be a no-op: %v", err)
 	}
 }
 

--- a/internal/git/hook_test.go
+++ b/internal/git/hook_test.go
@@ -299,6 +299,11 @@ func TestIsolateHooksPath_SkipsIsolationWhenWorktreeConfigUnsupported(t *testing
 	if err == nil && strings.TrimSpace(string(out)) != "" {
 		t.Fatalf("local core.hookspath should remain unset without worktree support, got %q", strings.TrimSpace(string(out)))
 	}
+
+	out, err = exec.Command("git", "-C", bare, "config", "--local", "--get", "extensions.worktreeConfig").CombinedOutput()
+	if err == nil && strings.TrimSpace(string(out)) != "" {
+		t.Fatalf("extensions.worktreeConfig should remain unset without worktree support, got %q", strings.TrimSpace(string(out)))
+	}
 }
 
 func TestInstallPostReceiveHookCreatesDir(t *testing.T) {

--- a/internal/git/hook_test.go
+++ b/internal/git/hook_test.go
@@ -271,6 +271,36 @@ func TestIsolateHooksPath_Idempotent(t *testing.T) {
 	}
 }
 
+func TestIsolateHooksPath_SkipsIsolationWhenWorktreeConfigUnsupported(t *testing.T) {
+	ctx := context.Background()
+	bare := filepath.Join(t.TempDir(), "test.git")
+	if err := InitBare(ctx, bare); err != nil {
+		t.Fatal(err)
+	}
+
+	originalRunGit := runGit
+	runGit = func(_ context.Context, dir string, args ...string) (string, error) {
+		t.Helper()
+		if dir != bare {
+			t.Fatalf("run dir = %q, want %q", dir, bare)
+		}
+		if len(args) >= 3 && args[0] == "config" && args[1] == "--worktree" {
+			return "", exec.ErrNotFound
+		}
+		return originalRunGit(ctx, dir, args...)
+	}
+	defer func() { runGit = originalRunGit }()
+
+	if err := IsolateHooksPath(ctx, bare); err != nil {
+		t.Fatalf("IsolateHooksPath should tolerate missing --worktree support: %v", err)
+	}
+
+	out, err := exec.Command("git", "-C", bare, "config", "--local", "--get", "core.hookspath").CombinedOutput()
+	if err == nil && strings.TrimSpace(string(out)) != "" {
+		t.Fatalf("local core.hookspath should remain unset without worktree support, got %q", strings.TrimSpace(string(out)))
+	}
+}
+
 func TestInstallPostReceiveHookCreatesDir(t *testing.T) {
 	// hooks dir might not exist in some bare repos; installer should create it
 	dir := t.TempDir()

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -122,8 +122,10 @@ type Model struct {
 	waitStarted bool
 }
 
-// Result reports what the wizard did. Success means a push to the gate
-// succeeded and the caller should re-attach to pick up the new run.
+// Result reports what the wizard did. Success means the wizard completed all
+// required steps: the push to the gate succeeded, and when WaitForRun is set,
+// the daemon handoff completed so the caller can re-attach to pick up the new
+// run.
 type Result struct {
 	Success       bool
 	Aborted       bool

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -259,8 +259,12 @@ func (m Model) setupActive() Model {
 			m.waitStarted = true
 			return m
 		}
-		m.success = m.pushed
-		if m.success && m.err == nil {
+		// Success requires both the push and the daemon-confirmation wait
+		// to have completed without error. Treating a wait failure as a
+		// success silently masks broken-gate cases like husky disabling
+		// the post-receive hook (issue #122).
+		m.success = m.pushed && m.err == nil
+		if m.success {
 			m.track("completed", map[string]any{
 				"branch_created": m.branchCreated,
 				"commit_made":    m.commitMade,

--- a/internal/wizard/wizard_test.go
+++ b/internal/wizard/wizard_test.go
@@ -743,6 +743,9 @@ func TestWaitForRun_ErrorSurfacesInResult(t *testing.T) {
 	if res.Err == nil {
 		t.Fatal("Result.Err should reflect the wait failure")
 	}
+	if res.Success {
+		t.Fatal("Result.Success must be false when wait fails (issue #122)")
+	}
 }
 
 func TestWaitForRun_CompletedTelemetrySkippedOnWaitError(t *testing.T) {


### PR DESCRIPTION
## Summary
- Isolate gate repositories' `core.hooksPath` with per-worktree config when supported, preserve the `post-receive` hook, and avoid leaving bare repos in a broken state on older Git versions.
- Tighten the push-to-attach flow by surfacing when a push succeeds but no run is registered, and point users to the correct `notify-push.log` path for diagnosis.
- Update CLI help, code comments, and docs to explain the conditional hook-path isolation behavior, startup migration for existing gates, and the new troubleshooting guidance.

## Risk Assessment

✅ Low: The change is narrowly scoped around hook-path isolation and wizard error surfacing, and the remaining code paths look internally consistent after the follow-up fixes.

## Testing

- Summary: Exercised the changed hook, gate, daemon, CLI, and wizard paths with focused package tests, and everything relevant to this change passed cleanly.
- `go test ./internal/git`
- `go test ./internal/gate`
- `go test ./internal/cli`
- `go test ./internal/daemon`
- `go test ./internal/wizard`
- Outcome: ✅ passed across 1 run (1m8s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2)</summary>

**Round 1** - found 2 warnings
- ⚠️ `internal/git/hook.go:104` - The new isolation path unconditionally depends on `extensions.worktreeConfig` and `git config --worktree`. If a user is on an older Git that lacks that feature, `no-mistakes init` now fails outright and startup migration cannot repair existing repos, but this change does not gate or document that compatibility requirement.
- ⚠️ `internal/cli/wizard.go:319` - The new timeout error tells users to inspect `~/.no-mistakes/repos/&lt;id&gt;.git/notify-push.log`, but the real path is under the current `NM_HOME` and the placeholder `&lt;id&gt;` is never replaced. In custom `NM_HOME` setups this sends debugging to the wrong location.

**Round 2** (auto-fix) - found 1 error
- 🚨 `internal/git/hook.go:108` - `IsolateHooksPath` sets `extensions.worktreeConfig=true` before proving that this Git actually supports per-worktree config. On older Git versions, the later `git config --worktree ...` call falls into the &#34;unsupported&#34; fallback, but the repo has already been marked with the `worktreeConfig` extension, which can make subsequent Git commands fail for that bare repo. Because `gate.Init` and `migrateGateConfigs` both call this path, the regression can break both new and existing installs.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/git`
- `go test ./internal/gate`
- `go test ./internal/cli`
- `go test ./internal/daemon`
- `go test ./internal/wizard`

</details>

<details>
<summary>🔧 **Document** - 5 issues found → auto-fixed (8)</summary>

**Round 1** - found 5 warnings
- ⚠️ `docs/src/content/docs/concepts/gate-model.md:84` - The post-receive hook section is now stale: it says the hook &#39;runs the notification in the background and always exits 0&#39;, but the new hook behavior runs `daemon notify-push` inline, surfaces failures on stderr, and writes them to `notify-push.log` while still letting the push succeed. That section should describe the new failure-reporting behavior.
- ⚠️ `docs/src/content/docs/concepts/gate-model.md:150` - The local-state table no longer documents `repos/&lt;id&gt;.git/notify-push.log`, which this change introduces as the persistent log for gate hook notification failures and which the wizard error message now points users to.
- ⚠️ `docs/src/content/docs/guides/setup-wizard.md:69` - The setup-wizard guide says a successful push waits briefly and then attaches, but the new behavior treats &#39;push succeeded but no run was registered&#39; as an error and tells the user to inspect the gate&#39;s `notify-push.log`. The wizard handoff section should document that failure mode instead of implying attach is guaranteed after push.
- ⚠️ `docs/src/content/docs/reference/cli.md:8` - The `no-mistakes` command reference still describes the wizard path as &#39;push, wait for the daemon to register the new run, and then attach&#39; without mentioning the new timeout/error path when no run appears. The CLI reference should mention that this now fails explicitly rather than silently falling through.
- ⚠️ `docs/src/content/docs/guides/troubleshooting.md:116` - The troubleshooting guide for &#39;git push no-mistakes doesn&#39;t start a pipeline&#39; only tells users to check that `hooks/post-receive` exists and that the daemon socket is up. After this change it should also direct users to inspect `&lt;gate-path&gt;/notify-push.log` and verify `core.hookspath` was not overridden, since hook notification failures are now logged/surfaced and hook-path poisoning is the bug being fixed here.

**Round 2** (auto-fix) - found 4 warnings
- ⚠️ `docs/src/content/docs/concepts/daemon.md:82` - The crash-recovery section is now incomplete. Daemon startup also migrates older gate bare repos by reapplying per-worktree hook-path isolation, which is part of the fix for `core.hookspath` poisoning and should be documented alongside stale-run/server/worktree recovery.
- ⚠️ `README.md:74` - The README still says the setup wizard walks the user through pushing and attaching to the new run, but this change makes the wizard fail explicitly when the push succeeds and no run is registered. That quick-start sentence should mention the possible error path instead of implying attach is guaranteed.
- ⚠️ `docs/src/content/docs/start-here/quick-start.md:75` - The quick-start guide still describes bare `no-mistakes` as walking through the wizard &#39;before attaching&#39; when no active run exists. After this change, the wizard can also exit with an explicit error if the daemon never registers the run, so this high-level flow should no longer imply attach is guaranteed.
- ⚠️ `internal/git/hook.go:15` - The `PostReceiveHookScript` doc comment is stale. It still says notification failures are &#39;silently ignored&#39;, but the hook now surfaces notify failures on stderr and appends them to `notify-push.log` while still allowing the push to succeed.

**Round 3** (auto-fix) - found 2 warnings
- ⚠️ `internal/gate/gate.go:25` - The `Init` doc comment is now incomplete. `gate.Init` no longer just creates the bare repo, installs the hook, adds the remote, and records the repo - it also isolates the bare repo&#39;s hook path via per-worktree config so shared `core.hookspath` writes cannot disable the gate hook.
- ⚠️ `internal/cli/init.go:19` - The `no-mistakes init` command help text is stale. It still describes init as installing the hook, adding the remote, and recording the repo, but this change also makes init isolate the gate repo&#39;s hook path from shared git config writes. `--help` should document that behavior to match the current command semantics.

**Round 4** (auto-fix) - found 2 warnings
- ⚠️ `docs/src/content/docs/concepts/gate-model.md:31` - The `What no-mistakes init does` list is now incomplete. `gate.Init` also isolates the bare gate repo&#39;s hook path via per-worktree config so shared `core.hookspath` writes from linked worktrees cannot disable `post-receive`, and that step should be documented alongside hook installation and remote setup.
- ⚠️ `docs/src/content/docs/start-here/quick-start.md:40` - The quick-start description of `no-mistakes init` is stale. It still says init creates the bare repo, installs the hook, adds the remote, and starts the daemon, but this change also makes init isolate the gate repo&#39;s hook path from shared git config writes. That one-line walkthrough should be updated to match current behavior.

**Round 5** (auto-fix) - found 6 warnings
- ⚠️ `internal/cli/init.go:19` - The `no-mistakes init` help text now overstates the new behavior. `gate.Init` only isolates the gate hook path when the installed Git supports `git config --worktree`; otherwise `git.IsolateHooksPath` intentionally no-ops. `--help` should mention that this protection is best-effort or note the Git version requirement instead of implying it always applies.
- ⚠️ `docs/src/content/docs/reference/cli.md:28` - The CLI reference says init &#39;isolates the gate repo&#39;s hook path from shared git config changes&#39; unconditionally, but `git.IsolateHooksPath` skips that setup when `git config --worktree` is unsupported. This page should add the same caveat or minimum-Git requirement so the documented behavior matches the implementation.
- ⚠️ `docs/src/content/docs/start-here/quick-start.md:40` - The quick-start walkthrough says `no-mistakes init` isolates the gate&#39;s hooks path as a guaranteed step. In code that isolation is conditional on Git supporting per-worktree config, so this first-run guide should mention the requirement or describe the isolation as best-effort.
- ⚠️ `docs/src/content/docs/concepts/gate-model.md:33` - The gate model doc now describes hook-path isolation as unconditional during init and startup recovery, but `git.IsolateHooksPath` is intentionally a no-op on Git builds that lack `config --worktree`. That limitation should be documented here because this page explains the mechanism in detail.
- ⚠️ `docs/src/content/docs/concepts/daemon.md:87` - The crash-recovery section says daemon startup reapplies gate hook-path isolation for existing bare repos, but the migration path silently skips repos when the local Git does not support per-worktree config. This should be qualified so readers do not assume a restart always remediates old gates.
- ⚠️ `docs/src/content/docs/guides/troubleshooting.md:135` - The troubleshooting guide says restarting the daemon reapplies hook-path isolation for older gates, but that remediation is conditional on Git supporting `config --worktree`. The guide should tell users to verify Git supports per-worktree config or note that restart alone is insufficient on older Git versions.

**Round 6** (auto-fix) - found 3 warnings
- ⚠️ `internal/cli/init.go:19` - The `no-mistakes init` help text is still incomplete. It says init &#39;best-effort isolates the gate hook path from shared local git config writes&#39;, but the implementation only does that when the installed Git supports `git config --worktree`. `--help` should mention that requirement so the documented behavior matches the code.
- ⚠️ `internal/gate/gate.go:25` - The `gate.Init` doc comment overstates hook-path isolation as an unconditional step. In code, `git.IsolateHooksPath` intentionally no-ops when Git lacks `config --worktree` support, so this comment should mention that the isolation is best-effort or gated on Git support.
- ⚠️ `internal/daemon/daemon.go:227` - The `recoverOnStartup`/`migrateGateConfigs` comments describe startup migration as if older gates always &#39;pick up&#39; per-worktree hook-path isolation, but that migration is skipped when the local Git does not support `config --worktree`. Those comments should be qualified so they do not promise remediation that may not happen on older Git builds.

**Round 7** (auto-fix) - found 1 warning
- ⚠️ `internal/wizard/wizard.go:125` - The `wizard.Result` doc comment is now stale. It still says `Success` means the push succeeded and the caller should re-attach, but after this change `Success` is false when the post-push daemon-registration wait fails even though `Pushed` remains true. The comment should document that `Success` requires both a successful push and a successful wait/registration handoff when `WaitForRun` is enabled.

**Round 8** (auto-fix) - found 2 warnings
- ⚠️ `docs/src/content/docs/guides/setup-wizard.md:13` - The setup-wizard guide still has unconditional attach wording after the new daemon-registration failure path. The prose shortcut (`branch -&gt; commit -&gt; push -&gt; attach`) and Mermaid node `Attach to new run` no longer match the implementation, which now exits with an explicit error when the push succeeds but no run is registered. This guide should show that attach is conditional and that the flow can end in a hook/daemon diagnostic error.
- ⚠️ `internal/git/hook.go:93` - The `IsolateHooksPath` doc comment overstates the behavior as if hook-path isolation is always applied. In code, the function intentionally returns nil without changing config when `git config --worktree` is unsupported, so the comment should document that this protection is best-effort and gated on Git support.

**Round 9** (auto-fix) - passed ✅

</details>

<details>
<summary>🔧 **Lint** - 5 issues found → auto-fixed</summary>

**Round 1** - found 5 errors
- 🚨 `internal/cli/init.go:20` - `gofmt` and `go vet` both fail to parse this file: missing `,` in composite literal.
- 🚨 `internal/cli/init.go:26` - `gofmt` and `go vet` both fail to parse this file: missing `,` in composite literal.
- 🚨 `internal/cli/init.go:56` - `gofmt` and `go vet` both fail to parse this file: missing `,` before newline in composite literal.
- 🚨 `internal/cli/init.go:58` - `gofmt` and `go vet` both fail to parse this file: expected operand, found `}`.
- 🚨 `internal/cli/init.go:59` - `gofmt` and `go vet` both fail to parse this file: expected `;`, found `EOF`.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
