### PR TITLE
fix(daemon): clean up timed-out daemon startups safely

### DIFF
--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -168,6 +168,9 @@ func TestInitRollsBackWhenDaemonStartFails(t *testing.T) {
 	if !strings.Contains(err.Error(), "start daemon") {
 		t.Fatalf("init error = %v, want daemon startup failure", err)
 	}
+	if strings.Contains(err.Error(), "rollback init:") {
+		t.Fatalf("rollback should succeed cleanly, got wrapped error: %v", err)
+	}
 	if elapsed >= time.Second {
 		t.Fatalf("init rollback should fail fast in tests, took %v", elapsed)
 	}

--- a/internal/daemon/helpers_test.go
+++ b/internal/daemon/helpers_test.go
@@ -25,6 +25,9 @@ func TestMain(m *testing.M) {
 			_ = os.WriteFile(capturePath, []byte(os.Getenv("NM_HOME")), 0o644)
 		}
 		os.Exit(0)
+	case "block":
+		time.Sleep(30 * time.Second)
+		os.Exit(0)
 	}
 	os.Exit(m.Run())
 }

--- a/internal/daemon/lifecycle_test.go
+++ b/internal/daemon/lifecycle_test.go
@@ -442,6 +442,34 @@ func TestValidateDaemonPIDFallback_RejectsLegacyPIDFileTouchedNearLivePID(t *tes
 	}
 }
 
+func TestWaitForProcessExitRetriesTransientInspectionErrors(t *testing.T) {
+	originalProcessRunning := daemonProcessRunning
+	checks := 0
+	daemonProcessRunning = func(pid int) (bool, error) {
+		if pid != 4242 {
+			t.Fatalf("daemonProcessRunning pid = %d, want 4242", pid)
+		}
+		checks++
+		switch checks {
+		case 1:
+			return false, fmt.Errorf("transient failure")
+		case 2:
+			return true, nil
+		default:
+			return false, nil
+		}
+	}
+	t.Cleanup(func() {
+		daemonProcessRunning = originalProcessRunning
+	})
+
+	waitForProcessExit(4242, 50*time.Millisecond)
+
+	if checks < 3 {
+		t.Fatalf("waitForProcessExit stopped after %d checks, want at least 3", checks)
+	}
+}
+
 func TestCurrentDaemonPIDRecord_UsesProcessStartTime(t *testing.T) {
 	want := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
 	now := want.Add(10 * time.Second)

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -114,15 +114,22 @@ func startDetachedDaemon(p *paths.Paths) error {
 	pid := cmd.Process.Pid
 	startedAt, err := daemonProcessStartTime(pid)
 	if err != nil {
+		if cleanupErr := cleanupStartedDaemonProcess(cmd.Process); cleanupErr != nil {
+			return fmt.Errorf("inspect daemon process %d: %w; cleanup daemon child: %v", pid, err, cleanupErr)
+		}
 		return fmt.Errorf("inspect daemon process %d: %w", pid, err)
 	}
 	slog.Info("daemon process started", "pid", pid, "log", p.DaemonLog())
+
+	if err := waitForDaemonStartWithProcess(p, cmd.Process, pid, startedAt); err != nil {
+		return err
+	}
 
 	// Release the child so it's not reaped when we exit.
 	if err := cmd.Process.Release(); err != nil {
 		return fmt.Errorf("release daemon process: %w", err)
 	}
-	return waitForDaemonStart(p, pid, startedAt)
+	return nil
 }
 
 func startManagedDaemon(p *paths.Paths) error {
@@ -136,6 +143,10 @@ func startManagedDaemon(p *paths.Paths) error {
 }
 
 func waitForDaemonStart(p *paths.Paths, pid int, startedAt time.Time) error {
+	return waitForDaemonStartWithProcess(p, nil, pid, startedAt)
+}
+
+func waitForDaemonStartWithProcess(p *paths.Paths, proc *os.Process, pid int, startedAt time.Time) error {
 	// Poll for the daemon to become responsive.
 	timeout := daemonStartTimeout()
 	pollInterval := daemonStartPollInterval()
@@ -151,14 +162,37 @@ func waitForDaemonStart(p *paths.Paths, pid int, startedAt time.Time) error {
 	// Kill the child so it can't race with rollback work (e.g. SQLite writes)
 	// after the caller gives up on it. Skip when pid is 0 (managed service).
 	if pid > 0 {
-		if err := killTimedOutDaemonPID(pid, startedAt); err != nil {
-			slog.Warn("kill unresponsive daemon child failed", "pid", pid, "error", err)
-		} else if !startedAt.IsZero() {
+		var cleanupErr error
+		if proc != nil {
+			cleanupErr = cleanupStartedDaemonProcess(proc)
+		} else {
+			cleanupErr = killTimedOutDaemonPID(pid, startedAt)
+		}
+		if cleanupErr != nil {
+			return fmt.Errorf("daemon started but did not become responsive within %v: cleanup daemon child %d: %w", timeout, pid, cleanupErr)
+		}
+		if proc == nil && !startedAt.IsZero() {
 			waitForProcessExit(pid, timeout)
 		}
 	}
 
 	return fmt.Errorf("daemon started but did not become responsive within %v", timeout)
+}
+
+func cleanupStartedDaemonProcess(proc *os.Process) error {
+	if proc == nil {
+		return nil
+	}
+	if err := proc.Kill(); err != nil {
+		if _, waitErr := proc.Wait(); waitErr == nil {
+			return nil
+		}
+		return fmt.Errorf("kill daemon child: %w", err)
+	}
+	if _, err := proc.Wait(); err != nil {
+		return fmt.Errorf("wait daemon child exit: %w", err)
+	}
+	return nil
 }
 
 func killTimedOutDaemonPID(pid int, startedAt time.Time) error {

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -112,13 +112,17 @@ func startDetachedDaemon(p *paths.Paths) error {
 	}
 
 	pid := cmd.Process.Pid
+	startedAt, err := daemonProcessStartTime(pid)
+	if err != nil {
+		return fmt.Errorf("inspect daemon process %d: %w", pid, err)
+	}
 	slog.Info("daemon process started", "pid", pid, "log", p.DaemonLog())
 
 	// Release the child so it's not reaped when we exit.
 	if err := cmd.Process.Release(); err != nil {
 		return fmt.Errorf("release daemon process: %w", err)
 	}
-	return waitForDaemonStart(p, pid)
+	return waitForDaemonStart(p, pid, startedAt)
 }
 
 func startManagedDaemon(p *paths.Paths) error {
@@ -128,10 +132,10 @@ func startManagedDaemon(p *paths.Paths) error {
 		}
 		return err
 	}
-	return waitForDaemonStart(p, 0)
+	return waitForDaemonStart(p, 0, time.Time{})
 }
 
-func waitForDaemonStart(p *paths.Paths, pid int) error {
+func waitForDaemonStart(p *paths.Paths, pid int, startedAt time.Time) error {
 	// Poll for the daemon to become responsive.
 	timeout := daemonStartTimeout()
 	pollInterval := daemonStartPollInterval()
@@ -147,9 +151,9 @@ func waitForDaemonStart(p *paths.Paths, pid int) error {
 	// Kill the child so it can't race with rollback work (e.g. SQLite writes)
 	// after the caller gives up on it. Skip when pid is 0 (managed service).
 	if pid > 0 {
-		if err := daemonKillPID(pid); err != nil {
+		if err := killTimedOutDaemonPID(pid, startedAt); err != nil {
 			slog.Warn("kill unresponsive daemon child failed", "pid", pid, "error", err)
-		} else {
+		} else if !startedAt.IsZero() {
 			waitForProcessExit(pid, timeout)
 		}
 	}
@@ -157,11 +161,25 @@ func waitForDaemonStart(p *paths.Paths, pid int) error {
 	return fmt.Errorf("daemon started but did not become responsive within %v", timeout)
 }
 
+func killTimedOutDaemonPID(pid int, startedAt time.Time) error {
+	if pid <= 0 || startedAt.IsZero() {
+		return nil
+	}
+	currentStartTime, err := daemonProcessStartTime(pid)
+	if err != nil {
+		return fmt.Errorf("inspect daemon pid %d before kill: %w", pid, err)
+	}
+	if !currentStartTime.Equal(startedAt) {
+		return fmt.Errorf("daemon pid %d no longer matches original process", pid)
+	}
+	return daemonKillPID(pid)
+}
+
 func waitForProcessExit(pid int, timeout time.Duration) {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		running, err := daemonProcessRunning(pid)
-		if err != nil || !running {
+		if err == nil && !running {
 			return
 		}
 		time.Sleep(10 * time.Millisecond)

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -144,7 +144,28 @@ func waitForDaemonStart(p *paths.Paths, pid int) error {
 		time.Sleep(pollInterval)
 	}
 
+	// Kill the child so it can't race with rollback work (e.g. SQLite writes)
+	// after the caller gives up on it. Skip when pid is 0 (managed service).
+	if pid > 0 {
+		if err := daemonKillPID(pid); err != nil {
+			slog.Warn("kill unresponsive daemon child failed", "pid", pid, "error", err)
+		} else {
+			waitForProcessExit(pid, timeout)
+		}
+	}
+
 	return fmt.Errorf("daemon started but did not become responsive within %v", timeout)
+}
+
+func waitForProcessExit(pid int, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		running, err := daemonProcessRunning(pid)
+		if err != nil || !running {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 // IsRunning checks if the daemon is alive by sending a health check via IPC.

--- a/internal/daemon/service_test.go
+++ b/internal/daemon/service_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/paths"
 )
@@ -771,12 +772,23 @@ func TestWaitForDaemonStartKillsChildOnTimeout(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	startedAt := time.Date(2026, 4, 21, 10, 0, 0, 0, time.UTC)
+
 	t.Setenv("NM_TEST_DAEMON_START_TIMEOUT", "20ms")
 	t.Setenv("NM_TEST_DAEMON_START_POLL_INTERVAL", "1ms")
 
 	oldHealthCheck := daemonHealthCheck
 	daemonHealthCheck = func(*paths.Paths) (bool, error) { return false, nil }
 	defer func() { daemonHealthCheck = oldHealthCheck }()
+
+	oldStartTime := daemonProcessStartTime
+	daemonProcessStartTime = func(pid int) (time.Time, error) {
+		if pid != 4242 {
+			t.Fatalf("daemonProcessStartTime pid = %d, want 4242", pid)
+		}
+		return startedAt, nil
+	}
+	defer func() { daemonProcessStartTime = oldStartTime }()
 
 	oldKill := daemonKillPID
 	killed := 0
@@ -786,12 +798,53 @@ func TestWaitForDaemonStartKillsChildOnTimeout(t *testing.T) {
 	}
 	defer func() { daemonKillPID = oldKill }()
 
-	err := waitForDaemonStart(p, 4242)
+	err := waitForDaemonStart(p, 4242, startedAt)
 	if err == nil {
 		t.Fatal("waitForDaemonStart should fail when daemon never becomes responsive")
 	}
 	if killed != 4242 {
 		t.Fatalf("waitForDaemonStart should kill pid 4242 on timeout, killed=%d", killed)
+	}
+}
+
+func TestWaitForDaemonStartSkipsKillForReusedPID(t *testing.T) {
+	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	startedAt := time.Date(2026, 4, 21, 10, 0, 0, 0, time.UTC)
+
+	t.Setenv("NM_TEST_DAEMON_START_TIMEOUT", "20ms")
+	t.Setenv("NM_TEST_DAEMON_START_POLL_INTERVAL", "1ms")
+
+	oldHealthCheck := daemonHealthCheck
+	daemonHealthCheck = func(*paths.Paths) (bool, error) { return false, nil }
+	defer func() { daemonHealthCheck = oldHealthCheck }()
+
+	oldStartTime := daemonProcessStartTime
+	daemonProcessStartTime = func(pid int) (time.Time, error) {
+		if pid != 4242 {
+			t.Fatalf("daemonProcessStartTime pid = %d, want 4242", pid)
+		}
+		return startedAt.Add(time.Second), nil
+	}
+	defer func() { daemonProcessStartTime = oldStartTime }()
+
+	oldKill := daemonKillPID
+	killCalled := false
+	daemonKillPID = func(int) error {
+		killCalled = true
+		return nil
+	}
+	defer func() { daemonKillPID = oldKill }()
+
+	err := waitForDaemonStart(p, 4242, startedAt)
+	if err == nil {
+		t.Fatal("waitForDaemonStart should fail when daemon never becomes responsive")
+	}
+	if killCalled {
+		t.Fatal("waitForDaemonStart should not kill when pid start time no longer matches")
 	}
 }
 
@@ -816,7 +869,7 @@ func TestWaitForDaemonStartDoesNotKillWhenPIDZero(t *testing.T) {
 	}
 	defer func() { daemonKillPID = oldKill }()
 
-	if err := waitForDaemonStart(p, 0); err == nil {
+	if err := waitForDaemonStart(p, 0, time.Time{}); err == nil {
 		t.Fatal("waitForDaemonStart should fail when daemon never becomes responsive")
 	}
 	if killCalled {

--- a/internal/daemon/service_test.go
+++ b/internal/daemon/service_test.go
@@ -118,6 +118,68 @@ func TestStartDetachedDaemonUsesProvidedRootViaNMHome(t *testing.T) {
 	}
 }
 
+func TestStartDetachedDaemonCleansUpChildWhenStartTimeProbeFails(t *testing.T) {
+	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("NM_DAEMON_HELPER_PROCESS", "block")
+
+	oldStartTime := daemonProcessStartTime
+	startedPID := 0
+	daemonProcessStartTime = func(pid int) (time.Time, error) {
+		startedPID = pid
+		return time.Time{}, fmt.Errorf("inspect failed")
+	}
+	t.Cleanup(func() {
+		daemonProcessStartTime = oldStartTime
+		if startedPID <= 0 {
+			return
+		}
+		running, err := daemonProcessRunning(startedPID)
+		if err == nil && running {
+			_ = daemonKillPID(startedPID)
+			deadline := time.Now().Add(2 * time.Second)
+			for time.Now().Before(deadline) {
+				running, err = daemonProcessRunning(startedPID)
+				if err == nil && !running {
+					return
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+		}
+	})
+
+	err := startDetachedDaemon(p)
+	if err == nil {
+		t.Fatal("startDetachedDaemon should fail when process inspection fails")
+	}
+	if !strings.Contains(err.Error(), "inspect daemon process") {
+		t.Fatalf("startDetachedDaemon error = %v, want process inspection failure", err)
+	}
+	if startedPID <= 0 {
+		t.Fatal("expected startDetachedDaemon to spawn a child process")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		running, runErr := daemonProcessRunning(startedPID)
+		if runErr == nil && !running {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	running, runErr := daemonProcessRunning(startedPID)
+	if runErr != nil {
+		t.Fatalf("daemonProcessRunning(%d) returned error after inspection failure: %v", startedPID, runErr)
+	}
+	if running {
+		t.Fatalf("child pid %d still running after inspection failure", startedPID)
+	}
+}
+
 func TestStartStopsManagedServiceBeforeDetachedFallbackAfterTimeout(t *testing.T) {
 	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
 	if err := p.EnsureDirs(); err != nil {
@@ -804,6 +866,48 @@ func TestWaitForDaemonStartKillsChildOnTimeout(t *testing.T) {
 	}
 	if killed != 4242 {
 		t.Fatalf("waitForDaemonStart should kill pid 4242 on timeout, killed=%d", killed)
+	}
+}
+
+func TestWaitForDaemonStartReturnsCleanupErrorOnTimeout(t *testing.T) {
+	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	startedAt := time.Date(2026, 4, 21, 10, 0, 0, 0, time.UTC)
+
+	t.Setenv("NM_TEST_DAEMON_START_TIMEOUT", "20ms")
+	t.Setenv("NM_TEST_DAEMON_START_POLL_INTERVAL", "1ms")
+
+	oldHealthCheck := daemonHealthCheck
+	daemonHealthCheck = func(*paths.Paths) (bool, error) { return false, nil }
+	defer func() { daemonHealthCheck = oldHealthCheck }()
+
+	oldStartTime := daemonProcessStartTime
+	daemonProcessStartTime = func(pid int) (time.Time, error) {
+		if pid != 4242 {
+			t.Fatalf("daemonProcessStartTime pid = %d, want 4242", pid)
+		}
+		return startedAt, nil
+	}
+	defer func() { daemonProcessStartTime = oldStartTime }()
+
+	oldKill := daemonKillPID
+	daemonKillPID = func(pid int) error {
+		if pid != 4242 {
+			t.Fatalf("daemonKillPID pid = %d, want 4242", pid)
+		}
+		return fmt.Errorf("kill failed")
+	}
+	defer func() { daemonKillPID = oldKill }()
+
+	err := waitForDaemonStart(p, 4242, startedAt)
+	if err == nil {
+		t.Fatal("waitForDaemonStart should fail when cleanup fails")
+	}
+	if !strings.Contains(err.Error(), "kill failed") {
+		t.Fatalf("waitForDaemonStart error = %v, want cleanup failure", err)
 	}
 }
 

--- a/internal/daemon/service_test.go
+++ b/internal/daemon/service_test.go
@@ -765,6 +765,65 @@ func TestStopDoesNotTouchManagedDaemonOwnedByDifferentNMHome(t *testing.T) {
 	}
 }
 
+func TestWaitForDaemonStartKillsChildOnTimeout(t *testing.T) {
+	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("NM_TEST_DAEMON_START_TIMEOUT", "20ms")
+	t.Setenv("NM_TEST_DAEMON_START_POLL_INTERVAL", "1ms")
+
+	oldHealthCheck := daemonHealthCheck
+	daemonHealthCheck = func(*paths.Paths) (bool, error) { return false, nil }
+	defer func() { daemonHealthCheck = oldHealthCheck }()
+
+	oldKill := daemonKillPID
+	killed := 0
+	daemonKillPID = func(pid int) error {
+		killed = pid
+		return nil
+	}
+	defer func() { daemonKillPID = oldKill }()
+
+	err := waitForDaemonStart(p, 4242)
+	if err == nil {
+		t.Fatal("waitForDaemonStart should fail when daemon never becomes responsive")
+	}
+	if killed != 4242 {
+		t.Fatalf("waitForDaemonStart should kill pid 4242 on timeout, killed=%d", killed)
+	}
+}
+
+func TestWaitForDaemonStartDoesNotKillWhenPIDZero(t *testing.T) {
+	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("NM_TEST_DAEMON_START_TIMEOUT", "20ms")
+	t.Setenv("NM_TEST_DAEMON_START_POLL_INTERVAL", "1ms")
+
+	oldHealthCheck := daemonHealthCheck
+	daemonHealthCheck = func(*paths.Paths) (bool, error) { return false, nil }
+	defer func() { daemonHealthCheck = oldHealthCheck }()
+
+	oldKill := daemonKillPID
+	killCalled := false
+	daemonKillPID = func(int) error {
+		killCalled = true
+		return nil
+	}
+	defer func() { daemonKillPID = oldKill }()
+
+	if err := waitForDaemonStart(p, 0); err == nil {
+		t.Fatal("waitForDaemonStart should fail when daemon never becomes responsive")
+	}
+	if killCalled {
+		t.Fatal("waitForDaemonStart should not kill when pid is 0 (managed daemon case)")
+	}
+}
+
 func stubServiceRuntime(t *testing.T) func() {
 	t.Helper()
 	oldGOOS := runtimeGOOS


### PR DESCRIPTION
## Summary
- Kill detached daemon children when startup times out or the post-start inspection fails, so init rollback does not race with a still-running daemon.
- Guard timeout cleanup against PID reuse and transient process-inspection failures before treating the child as gone, avoiding accidental kills and unsafe rollback.
- Add daemon and init regression coverage for timeout cleanup, cleanup failure propagation, reused PIDs, and rollback behavior.

## Risk Assessment

✅ Low: The change is tightly scoped to detached-daemon startup timeout cleanup, and the updated implementation now handles the previously flagged child-process cleanup races without introducing any new material issues in the reviewed diff.

## Testing

- Summary: Exercised the new daemon startup-timeout cleanup paths and the init rollback path they affect, and the relevant tests all passed.
- `go test ./internal/daemon -run '^(TestStartDetachedDaemonCleansUpChildWhenStartTimeProbeFails|TestWaitForDaemonStartKillsChildOnTimeout|TestWaitForDaemonStartReturnsCleanupErrorOnTimeout|TestWaitForDaemonStartSkipsKillForReusedPID|TestWaitForDaemonStartDoesNotKillWhenPIDZero|TestWaitForProcessExitRetriesTransientInspectionErrors)$' -count=1`
- `go test ./internal/cli -run '^TestInitRollsBackWhenDaemonStartFails$' -count=1`
- `go test ./internal/daemon`
- Outcome: ✅ passed across 1 run (51.1s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2)</summary>

**Round 1** - found 2 warnings
- ⚠️ `internal/daemon/selfexec.go:150` - The new timeout cleanup kills a bare PID after the child has already been `Release()`d, without checking that the PID still belongs to the process started here. If the daemon exits quickly and the OS recycles the PID before timeout, this path can kill an unrelated process. Defer `Release()` until startup succeeds, or capture and validate the child&#39;s start time before killing.
- ⚠️ `internal/daemon/selfexec.go:163` - `waitForProcessExit` treats any `daemonProcessRunning` error as equivalent to &#39;process is gone&#39; and returns immediately. A transient process-inspection failure (`ps`/Win32 query) would let rollback proceed while the timed-out child is still alive, which is the exact race this change is trying to avoid.

**Round 2** (auto-fix) - found 2 warnings
- ⚠️ `internal/daemon/selfexec.go:115` - `startDetachedDaemon` now aborts immediately if the post-`Start()` `daemonProcessStartTime` probe fails. That introduces a new path where the daemon process has already been spawned but we return before `Release()`/timeout cleanup, so callers can roll back while a live detached child is still touching the same `NM_HOME`. Kill or fully detach the child before surfacing this inspection error.
- ⚠️ `internal/daemon/selfexec.go:154` - Timeout cleanup failures are only logged and then collapsed into the generic startup-timeout error. If the start-time recheck or `daemonKillPID` call fails, rollback still proceeds even though the unresponsive daemon may still be alive, which reintroduces the rollback race this change is trying to prevent. Propagate the cleanup failure or otherwise block rollback until the child is confirmed gone.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/daemon -run '^(TestStartDetachedDaemonCleansUpChildWhenStartTimeProbeFails|TestWaitForDaemonStartKillsChildOnTimeout|TestWaitForDaemonStartReturnsCleanupErrorOnTimeout|TestWaitForDaemonStartSkipsKillForReusedPID|TestWaitForDaemonStartDoesNotKillWhenPIDZero|TestWaitForProcessExitRetriesTransientInspectionErrors)$' -count=1`
- `go test ./internal/cli -run '^TestInitRollsBackWhenDaemonStartFails$' -count=1`
- `go test ./internal/daemon`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
