### PR TITLE
fix(git): move core.bare into worktree config

### DIFF
--- a/internal/daemon/helpers_test.go
+++ b/internal/daemon/helpers_test.go
@@ -29,6 +29,15 @@ func TestMain(m *testing.M) {
 		time.Sleep(30 * time.Second)
 		os.Exit(0)
 	}
+	// The post-receive hook embeds os.Executable() as NM_BIN. In tests that
+	// path is the test binary itself, so every `git push` to a bare gate
+	// would re-enter TestMain and run the whole daemon test suite inside
+	// the hook. Short-circuit: when we're being invoked as the hook's
+	// notifier, exit 0 immediately. Tests that care about the daemon seeing
+	// the push call push_received via IPC directly.
+	if os.Getenv("NM_HOOK_HELPER") == "1" {
+		os.Exit(0)
+	}
 	os.Exit(m.Run())
 }
 

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -256,6 +256,11 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 		trackStartFailure("create_worktree")
 		return "", fmt.Errorf("create worktree: %w", err)
 	}
+	if err := git.CopyLocalUserIdentity(ctx, repo.WorkingPath, wtDir); err != nil {
+		m.db.UpdateRunError(run.ID, fmt.Sprintf("configure worktree git identity: %s", err))
+		trackStartFailure("configure_worktree_identity")
+		return "", fmt.Errorf("configure worktree git identity: %w", err)
+	}
 	if repo.DefaultBranch != "" {
 		if err := git.FetchRemoteBranch(ctx, wtDir, "origin", repo.DefaultBranch); err != nil {
 			slog.Warn("failed to fetch default branch into worktree", "run_id", run.ID, "branch", repo.DefaultBranch, "error", err)

--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/kunchenguid/no-mistakes/internal/gate"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
@@ -982,5 +984,129 @@ func TestRespondNoActiveExecutor(t *testing.T) {
 	}, &result)
 	if err == nil {
 		t.Error("expected error when no active executor for run")
+	}
+}
+
+// TestGateInitPushPipelineRunsInLinkedWorktree is the full e2e regression
+// guard for the class of bugs where changes to gate setup silently break the
+// pipeline's ability to operate inside a linked worktree the daemon creates
+// from the gate. It covers the complete journey the user goes through:
+//
+//  1. gate.Init sets up the bare gate (including IsolateHooksPath).
+//  2. A working repo pushes a feature branch to the gate via real `git push`,
+//     which actually fires the installed post-receive hook.
+//  3. The daemon is notified of the push via the same IPC the hook would call.
+//  4. The daemon creates a linked worktree from the gate and runs the first
+//     pipeline step (rebase) inside it.
+//  5. Rebase actually runs against a diverged origin/main and must succeed.
+//
+// The rebase step is chosen because it's the first work-tree-requiring step
+// the pipeline runs - it's where the original production regression surfaced
+// with "fatal: this operation must be run in a work tree". Any future change
+// to gate config that leaks core.bare (or any other shared-config poison)
+// into linked worktrees will break this test.
+func TestGateInitPushPipelineRunsInLinkedWorktree(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("post-receive hook + git worktree flow is /bin/sh-only")
+	}
+
+	p, d := startTestDaemonWithSteps(t, func() []pipeline.Step {
+		return []pipeline.Step{&steps.RebaseStep{}}
+	})
+
+	ctx := context.Background()
+	base := t.TempDir()
+
+	// Upstream bare (the "real" remote `origin` the working repo pushes to).
+	upstreamDir := filepath.Join(base, "upstream.git")
+	gitCmd(t, "", "init", "--bare", "--initial-branch=main", upstreamDir)
+
+	// Working repo with one commit on main, wired to upstream as origin.
+	workDir := filepath.Join(base, "work")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, workDir, "init", "--initial-branch=main")
+	gitCmd(t, workDir, "config", "user.email", "test@test.com")
+	gitCmd(t, workDir, "config", "user.name", "Test")
+	gitCmd(t, workDir, "remote", "add", "origin", upstreamDir)
+	if err := os.WriteFile(filepath.Join(workDir, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, workDir, "add", "README.md")
+	gitCmd(t, workDir, "commit", "-m", "initial")
+	baseSHA := gitOutput(t, workDir, "rev-parse", "HEAD")
+	gitCmd(t, workDir, "push", "origin", "main")
+
+	// Run real gate.Init: creates bare gate, installs hook, calls
+	// IsolateHooksPath, adds no-mistakes remote, registers repo in DB.
+	repo, err := gate.Init(ctx, d, p, workDir)
+	if err != nil {
+		t.Fatalf("gate.Init: %v", err)
+	}
+	if repo == nil || repo.DefaultBranch != "main" {
+		t.Fatalf("gate.Init returned unexpected repo: %+v", repo)
+	}
+
+	// Advance origin/main with a second commit so the rebase step has
+	// something to actually rebase onto (otherwise shouldSkipRebase short-
+	// circuits as "already ahead" and git rebase never runs).
+	if err := os.WriteFile(filepath.Join(workDir, "README.md"), []byte("base\nadvanced\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, workDir, "add", "README.md")
+	gitCmd(t, workDir, "commit", "-m", "advance main")
+	gitCmd(t, workDir, "push", "origin", "main")
+
+	// Branch diverges from baseSHA (the original main, before "advance main"),
+	// so HEAD and origin/main both have commits the other doesn't - forcing
+	// a real `git rebase` inside the worktree.
+	gitCmd(t, workDir, "checkout", "-b", "feature/e2e", baseSHA)
+	if err := os.WriteFile(filepath.Join(workDir, "feature.txt"), []byte("feature\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, workDir, "add", "feature.txt")
+	gitCmd(t, workDir, "commit", "-m", "feature change")
+	featureSHA := gitOutput(t, workDir, "rev-parse", "HEAD")
+
+	// Push feature to the gate via the real no-mistakes remote. The hook
+	// fires here; it'll fail to notify (no no-mistakes binary on PATH) but
+	// post-receive exit code is ignored by git, so the ref still lands.
+	gitCmd(t, workDir, "push", gate.RemoteName, "feature/e2e")
+
+	// Notify the daemon directly (same IPC the hook would invoke). This is
+	// what takes us from "ref on gate" to "pipeline running".
+	client, err := ipc.Dial(p.Socket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	var pushResult ipc.PushReceivedResult
+	if err := client.Call(ipc.MethodPushReceived, &ipc.PushReceivedParams{
+		Gate: p.RepoDir(repo.ID),
+		Ref:  "refs/heads/feature/e2e",
+		Old:  "0000000000000000000000000000000000000000",
+		New:  featureSHA,
+	}, &pushResult); err != nil {
+		t.Fatalf("push_received: %v", err)
+	}
+	if pushResult.RunID == "" {
+		t.Fatal("expected non-empty run ID")
+	}
+
+	run := waitForRunTerminalState(t, d, pushResult.RunID)
+	if run.Status != types.RunCompleted {
+		var runErr string
+		if run.Error != nil {
+			runErr = *run.Error
+		}
+		// Surface the step log so a regression like the original
+		// "fatal: this operation must be run in a work tree" is
+		// diagnosable from CI output alone.
+		logPath := filepath.Join(p.LogsDir(), run.ID, "rebase.log")
+		logBytes, _ := os.ReadFile(logPath)
+		t.Fatalf("run status = %v, want completed. err=%s\nrebase.log:\n%s",
+			run.Status, runErr, string(logBytes))
 	}
 }

--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -1010,6 +1010,13 @@ func TestGateInitPushPipelineRunsInLinkedWorktree(t *testing.T) {
 		t.Skip("post-receive hook + git worktree flow is /bin/sh-only")
 	}
 
+	// Make the regression deterministic: the daemon-created worktree must not
+	// depend on any user-global git identity being present on the machine.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
+	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(home, "gitconfig"))
+
 	p, d := startTestDaemonWithSteps(t, func() []pipeline.Step {
 		return []pipeline.Step{&steps.RebaseStep{}}
 	})

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -253,6 +253,24 @@ func CommitAll(ctx context.Context, dir, message string) error {
 	return err
 }
 
+// CopyLocalUserIdentity copies local user.name and user.email from srcDir into
+// dstDir. Missing values in srcDir are ignored.
+func CopyLocalUserIdentity(ctx context.Context, srcDir, dstDir string) error {
+	for _, key := range []string{"user.name", "user.email"} {
+		value, err := Run(ctx, srcDir, "config", "--local", "--get", "--default", "", key)
+		if err != nil {
+			return err
+		}
+		if value == "" {
+			continue
+		}
+		if _, err := Run(ctx, dstDir, "config", "--local", key, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // WorktreeAdd creates a detached worktree at wtPath checked out to the given SHA.
 func WorktreeAdd(ctx context.Context, repoDir, wtPath, sha string) error {
 	_, err := Run(ctx, repoDir, "worktree", "add", "--detach", wtPath, sha)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -116,6 +116,26 @@ func TestRemoveRemote(t *testing.T) {
 	}
 }
 
+func TestCopyLocalUserIdentity(t *testing.T) {
+	ctx := context.Background()
+	src := initTestRepo(t)
+	dst := initTestRepo(t)
+
+	run(t, dst, "git", "config", "--local", "--unset", "user.name")
+	run(t, dst, "git", "config", "--local", "--unset", "user.email")
+
+	if err := CopyLocalUserIdentity(ctx, src, dst); err != nil {
+		t.Fatalf("CopyLocalUserIdentity failed: %v", err)
+	}
+
+	if got := run(t, dst, "git", "config", "--local", "--get", "user.name"); got != "Test" {
+		t.Fatalf("user.name = %q, want %q", got, "Test")
+	}
+	if got := run(t, dst, "git", "config", "--local", "--get", "user.email"); got != "test@test.com" {
+		t.Fatalf("user.email = %q, want %q", got, "test@test.com")
+	}
+}
+
 func TestGetRemoteURLNotFound(t *testing.T) {
 	dir := initTestRepo(t)
 	ctx := context.Background()

--- a/internal/git/hook.go
+++ b/internal/git/hook.go
@@ -103,6 +103,13 @@ func InstallPostReceiveHook(bareDir string) error {
 // hooks to its own absolute hooks dir, regardless of what tools write
 // to the shared config.
 //
+// Enabling extensions.worktreeConfig also forces us to relocate
+// core.bare: once the extension is on, Git requires core.bare and
+// core.worktree to live in per-worktree scope only. If we leave
+// core.bare=true in shared config, it leaks into linked worktrees and
+// causes commands like `git rebase` to fail with "this operation must
+// be run in a work tree".
+//
 // Best-effort only: if the installed Git does not support
 // `git config --worktree`, this returns nil without changing config.
 //
@@ -127,7 +134,34 @@ func IsolateHooksPath(ctx context.Context, bareDir string) error {
 		}
 		return fmt.Errorf("pin core.hookspath per-worktree: %w", err)
 	}
+	return relocateCoreBareToWorktreeScope(ctx, bareDir)
+}
+
+// relocateCoreBareToWorktreeScope moves core.bare out of shared local config
+// into the bare's per-worktree config. Required after enabling
+// extensions.worktreeConfig: Git otherwise leaks core.bare=true from shared
+// scope into linked worktrees, breaking rebase/merge/etc.
+func relocateCoreBareToWorktreeScope(ctx context.Context, bareDir string) error {
+	if _, err := runGit(ctx, bareDir, "config", "--worktree", "core.bare", "true"); err != nil {
+		if isWorktreeConfigUnsupported(err) {
+			return nil
+		}
+		return fmt.Errorf("pin core.bare per-worktree: %w", err)
+	}
+	if _, err := runGit(ctx, bareDir, "config", "--local", "--unset", "core.bare"); err != nil {
+		if isConfigKeyMissing(err) {
+			return nil
+		}
+		return fmt.Errorf("unset shared core.bare: %w", err)
+	}
 	return nil
+}
+
+// isConfigKeyMissing reports whether a `git config --unset` failure is the
+// benign "key not set" case (exit 5), which makes the unset idempotent.
+func isConfigKeyMissing(err error) bool {
+	var exitErr *exec.ExitError
+	return errors.As(err, &exitErr) && exitErr.ExitCode() == 5
 }
 
 func isWorktreeConfigUnsupported(err error) bool {

--- a/internal/git/hook_test.go
+++ b/internal/git/hook_test.go
@@ -257,6 +257,181 @@ func TestIsolateHooksPath_OverridesPoisonedSharedConfig(t *testing.T) {
 	}
 }
 
+// TestIsolateHooksPath_LinkedWorktreeCanRebase covers the regression where
+// enabling extensions.worktreeConfig on a bare repo while leaving
+// core.bare=true in shared config caused `git rebase` to fail inside linked
+// worktrees with "fatal: this operation must be run in a work tree". Git
+// requires core.bare to live in per-worktree scope once worktreeConfig is on.
+func TestIsolateHooksPath_LinkedWorktreeCanRebase(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree + shell pipeline is /bin/sh-only")
+	}
+	ctx := context.Background()
+	base := t.TempDir()
+	bare := filepath.Join(base, "gate.git")
+	if err := InitBare(ctx, bare); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed the bare with one commit on main so worktree add has a ref to check out.
+	seedGate(t, base, bare)
+
+	if err := IsolateHooksPath(ctx, bare); err != nil {
+		t.Fatalf("IsolateHooksPath: %v", err)
+	}
+
+	// The bare repo itself must still look bare to git, otherwise other
+	// operations (ls-remote, receive-pack) regress.
+	if got := strings.TrimSpace(runGitOrFatal(t, bare, "rev-parse", "--is-bare-repository")); got != "true" {
+		t.Fatalf("bare repo should still report is-bare-repository=true, got %q", got)
+	}
+
+	// Hook resolution must still point at the bare's hooks dir (the whole
+	// point of IsolateHooksPath).
+	wantHooks, err := filepath.Abs(filepath.Join(bare, "hooks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(runGitOrFatal(t, bare, "config", "--get", "core.hookspath")); got != wantHooks {
+		t.Fatalf("core.hookspath = %q, want %q", got, wantHooks)
+	}
+
+	// Create a linked worktree and confirm it actually behaves as a work tree.
+	wt := filepath.Join(base, "wt")
+	runGitOrFatal(t, bare, "worktree", "add", "--detach", wt, "refs/heads/main")
+
+	if got := strings.TrimSpace(runGitOrFatal(t, wt, "rev-parse", "--is-inside-work-tree")); got != "true" {
+		t.Fatalf("linked worktree should report is-inside-work-tree=true, got %q", got)
+	}
+
+	// Rebase onto the bare's main. Before the fix this errored with
+	// "fatal: this operation must be run in a work tree" because core.bare=true
+	// leaked from shared config into the linked worktree.
+	runGitOrFatal(t, wt, "fetch", bare, "main")
+	if out, err := exec.Command("git", "-C", wt, "rebase", "FETCH_HEAD").CombinedOutput(); err != nil {
+		t.Fatalf("rebase in linked worktree should succeed, got err=%v output:\n%s", err, out)
+	}
+}
+
+// TestIsolateHooksPath_PushToGateStillWorks guards the other critical path:
+// after IsolateHooksPath moves core.bare to per-worktree scope, a normal
+// `git push` from a working repo to the gate must still land, and the
+// post-receive hook (resolved via the pinned core.hookspath) must still fire.
+func TestIsolateHooksPath_PushToGateStillWorks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("post-receive hook is /bin/sh-only")
+	}
+	ctx := context.Background()
+	base := t.TempDir()
+	bare := filepath.Join(base, "gate.git")
+	if err := InitBare(ctx, bare); err != nil {
+		t.Fatal(err)
+	}
+	work := seedGate(t, base, bare)
+
+	// Install a trivial post-receive hook that writes a marker file so we can
+	// confirm hookspath resolution still finds the bare's hooks dir.
+	hooksDir := filepath.Join(bare, "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(base, "hook-ran")
+	hookScript := "#!/bin/sh\necho ran > " + marker + "\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(hooksDir, "post-receive"), []byte(hookScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := IsolateHooksPath(ctx, bare); err != nil {
+		t.Fatalf("IsolateHooksPath: %v", err)
+	}
+
+	// Make a second commit and push it. Push must succeed and the ref on the
+	// bare must advance to the new HEAD.
+	runGitOrFatal(t, work, "commit", "--allow-empty", "-m", "second")
+	newSHA := strings.TrimSpace(runGitOrFatal(t, work, "rev-parse", "HEAD"))
+	if out, err := exec.Command("git", "-C", work, "push", "gate", "HEAD:refs/heads/main").CombinedOutput(); err != nil {
+		t.Fatalf("push to gate should succeed, got err=%v output:\n%s", err, out)
+	}
+	if got := strings.TrimSpace(runGitOrFatal(t, bare, "rev-parse", "refs/heads/main")); got != newSHA {
+		t.Fatalf("bare refs/heads/main = %q, want %q (push did not advance ref)", got, newSHA)
+	}
+
+	// Hook fired via the per-worktree hookspath.
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("post-receive hook should have run, marker missing: %v", err)
+	}
+}
+
+// seedGate creates a working repo under base/work, wires it to the bare as a
+// remote, makes an initial commit, and pushes it as refs/heads/main. Returns
+// the working repo path.
+func seedGate(t *testing.T, base, bare string) string {
+	t.Helper()
+	work := filepath.Join(base, "work")
+	if out, err := exec.Command("git", "init", work).CombinedOutput(); err != nil {
+		t.Fatalf("init work: %v: %s", err, out)
+	}
+	runGitOrFatal(t, work, "config", "user.email", "t@t.com")
+	runGitOrFatal(t, work, "config", "user.name", "T")
+	runGitOrFatal(t, work, "remote", "add", "gate", bare)
+	runGitOrFatal(t, work, "commit", "--allow-empty", "-m", "init")
+	runGitOrFatal(t, work, "push", "gate", "HEAD:refs/heads/main")
+	return work
+}
+
+func runGitOrFatal(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s (in %s): %v: %s", strings.Join(args, " "), dir, err, out)
+	}
+	return string(out)
+}
+
+// TestIsolateHooksPath_MigratesFromPreFixState covers the upgrade path for
+// bare repos created by the previous version of IsolateHooksPath, which left
+// core.bare=true in shared config. Running the new IsolateHooksPath on that
+// state must relocate core.bare to per-worktree scope so linked worktrees
+// stop inheriting core.bare=true.
+func TestIsolateHooksPath_MigratesFromPreFixState(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("worktree + shell pipeline is /bin/sh-only")
+	}
+	ctx := context.Background()
+	base := t.TempDir()
+	bare := filepath.Join(base, "gate.git")
+	if err := InitBare(ctx, bare); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate the pre-fix state: extensions.worktreeConfig on, hookspath
+	// pinned per-worktree, but core.bare still in shared config.
+	hooksDir, err := filepath.Abs(filepath.Join(bare, "hooks"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	runGitOrFatal(t, bare, "config", "extensions.worktreeConfig", "true")
+	runGitOrFatal(t, bare, "config", "--worktree", "core.hookspath", hooksDir)
+
+	if err := IsolateHooksPath(ctx, bare); err != nil {
+		t.Fatalf("IsolateHooksPath: %v", err)
+	}
+
+	// core.bare must no longer be in shared config.
+	if out, err := exec.Command("git", "-C", bare, "config", "--local", "--get", "core.bare").CombinedOutput(); err == nil {
+		t.Fatalf("core.bare should have been removed from shared config, still set to %q", strings.TrimSpace(string(out)))
+	}
+	// core.bare must now be in per-worktree config with value true.
+	if got := strings.TrimSpace(runGitOrFatal(t, bare, "config", "--worktree", "--get", "core.bare")); got != "true" {
+		t.Fatalf("core.bare in config.worktree = %q, want %q", got, "true")
+	}
+	// Bare still reports as bare.
+	if got := strings.TrimSpace(runGitOrFatal(t, bare, "rev-parse", "--is-bare-repository")); got != "true" {
+		t.Fatalf("bare repo should still report is-bare-repository=true, got %q", got)
+	}
+}
+
 func TestIsolateHooksPath_Idempotent(t *testing.T) {
 	ctx := context.Background()
 	bare := filepath.Join(t.TempDir(), "test.git")


### PR DESCRIPTION
## Summary
- Move `core.bare` handling into each worktree's local git config so linked worktrees do not inherit a shared bare setting that breaks git operations.
- Isolate hook-path setup around that migration in `internal/git`, including coverage for the worktree-specific config behavior.
- Add daemon regression tests to verify push pipeline initialization still works correctly from linked worktrees after the config change.

## Risk Assessment

⚠️ Medium: The change is narrowly scoped and well tested, but it introduces a silent migration no-op for repositories with duplicated `core.bare` config entries, which can leave the original worktree breakage in place.

## Testing

- Summary: <code>Exercised the new `IsolateHooksPath` regression suite plus the daemon&#39;s linked-worktree rebase flow, and both passed with no actionable failures.</code>
- `go test ./internal/git -run 'TestIsolateHooksPath_' -count=1`
- `go test ./internal/daemon -run '^TestGateInitPushPipelineRunsInLinkedWorktree$' -count=1`
- Outcome: ✅ passed across 1 run (43.7s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/git/hook.go:152` - `git config --local --unset core.bare` returns exit code 5 both when the key is missing and when it has multiple values. `isConfigKeyMissing` treats all exit-5 cases as benign, so a repo with duplicated `core.bare` entries will silently keep the shared value(s) and still poison linked worktrees after this migration.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/git -run 'TestIsolateHooksPath_' -count=1`
- `go test ./internal/daemon -run '^TestGateInitPushPipelineRunsInLinkedWorktree$' -count=1`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
