### PR TITLE
test(daemon): extend push test timeout

### DIFF
--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -102,7 +102,7 @@ func TestPushReceivedWithRealStepsPushesToUpstream(t *testing.T) {
 		t.Fatal("expected non-empty run ID")
 	}
 
-	deadline := time.Now().Add(10 * time.Second)
+	deadline := time.Now().Add(30 * time.Second)
 	for time.Now().Before(deadline) {
 		run, err := d.GetRun(result.RunID)
 		if err != nil {


### PR DESCRIPTION
## Summary
- extend the timeout used by the daemon push test so `TestPushReceivedWithRealStepsPushesToUpstream` has more time to complete
- keep the branch focused on stabilizing the `internal/daemon` push test path without changing production behavior

## Risk Assessment

✅ Low: The review scope is a single test-only timeout increase in one integration test, with no production code changes and no material correctness or maintainability issues visible in the diff.

## Testing

- Summary: Exercised the widened-timeout daemon push integration path with repeated and race-enabled runs, plus related and package-level daemon tests, and everything passed without exposing a product or test-environment issue.
- `go test ./internal/daemon -run '^TestPushReceivedWithRealStepsPushesToUpstream$' -count=5`
- `go test ./internal/daemon -run '^(TestPushReceivedCreatesRun|TestPushReceivedTracksRunTelemetry)$' -count=1`
- `go test ./internal/daemon -count=1`
- `go test -race ./internal/daemon -run '^TestPushReceivedWithRealStepsPushesToUpstream$' -count=1`
- Outcome: ✅ passed across 1 run (1m24s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/daemon -run '^TestPushReceivedWithRealStepsPushesToUpstream$' -count=5`
- `go test ./internal/daemon -run '^(TestPushReceivedCreatesRun|TestPushReceivedTracksRunTelemetry)$' -count=1`
- `go test ./internal/daemon -count=1`
- `go test -race ./internal/daemon -run '^TestPushReceivedWithRealStepsPushesToUpstream$' -count=1`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
