### PR TITLE
feat(agent): support agent args override

### DIFF
--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -89,6 +89,11 @@ agent_path_override:
   opencode: /usr/local/bin/opencode
 ```
 
+You can also set extra agent-specific CLI flags in global config with
+`agent_args_override`. This is useful for things like model selection,
+reasoning level, or permission mode. Keep this in global config only, since it
+reflects your local agent setup rather than repo policy.
+
 ## Agent interface
 
 All agents implement the same interface. Each invocation receives:
@@ -106,19 +111,19 @@ Each invocation returns:
 
 ## Claude
 
-Spawns a `claude` subprocess for each invocation with `--output-format stream-json` and `--dangerously-skip-permissions`. Reads JSONL events from stdout. Supports native structured output via `--json-schema`.
+Spawns a `claude` subprocess for each invocation with `--output-format stream-json`. By default it also adds `--dangerously-skip-permissions`, unless you already set your own Claude permission flag through `agent_args_override`. Reads JSONL events from stdout. Supports native structured output via `--json-schema`.
 
 ## Codex
 
-Spawns a `codex` subprocess for each invocation with `exec --json --dangerously-bypass-approvals-and-sandbox`. Reads JSONL events. Structured output is extracted by parsing JSON from the agent's text output.
+Spawns a `codex` subprocess for each invocation with `exec --json`. By default it also adds `--dangerously-bypass-approvals-and-sandbox`, unless you already set your own Codex approval or sandbox flag through `agent_args_override`. Reads JSONL events. Structured output is extracted by parsing JSON from the agent's text output.
 
 ## Rovo Dev
 
-Starts a persistent HTTP server (`acli rovodev serve`) on first use and reuses it across invocations. Communicates via REST API and SSE streaming. Each invocation creates a session, sends the prompt, streams results, then deletes the session. Structured output is handled by injecting schema instructions into a system prompt.
+Starts a persistent HTTP server (`acli rovodev serve`) on first use and reuses it across invocations. Any `agent_args_override.rovodev` flags are inserted before no-mistakes' managed serve flags. Communicates via REST API and SSE streaming. Each invocation creates a session, sends the prompt, streams results, then deletes the session. Structured output is handled by injecting schema instructions into a system prompt.
 
 ## OpenCode
 
-Starts a persistent HTTP server (`opencode serve`) on first use. Similar session lifecycle to Rovo Dev: create session, send message, stream SSE events until idle, delete session. Supports `json_schema` format in the message request for structured output.
+Starts a persistent HTTP server (`opencode serve`) on first use. Any `agent_args_override.opencode` flags are inserted before no-mistakes' managed serve flags. Similar session lifecycle to Rovo Dev: create session, send message, stream SSE events until idle, delete session. Supports `json_schema` format in the message request for structured output.
 
 ## Checking agent availability
 

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -57,6 +57,14 @@ agent_path_override:
   rovodev: /usr/local/bin/acli
   opencode: /usr/local/bin/opencode
 
+# Optional extra CLI flags per agent.
+# This is global-only.
+agent_args_override:
+  codex:
+    - -m
+    - gpt-5.4
+    - --full-auto
+
 # How long the CI step waits for provider CI status, and GitHub/GitLab PR mergeability, before timing out.
 ci_timeout: "4h"  # any Go duration string
 
@@ -114,6 +122,7 @@ See [Repo Config Reference](/no-mistakes/reference/repo-config/) for the full fi
 
 - Repo `agent` overrides global `agent`.
 - Global `agent: auto` resolves by checking `claude`, `codex`, `opencode`, then `acli` for `rovodev` on `PATH`.
+- `agent_path_override` and `agent_args_override` are global-only fields.
 - `auto_fix` from the repo config overlays global auto_fix. Fields not set in the repo config fall through to the global default.
 - `commands` and `ignore_patterns` are repo-only fields.
 - `ci_timeout` and `auto_fix.ci` are the canonical keys; `babysit_timeout` and `auto_fix.babysit` are still accepted as legacy aliases.

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -16,6 +16,12 @@ agent_path_override:
   rovodev: /usr/local/bin/acli
   opencode: /usr/local/bin/opencode
 
+agent_args_override:
+  codex:
+    - -m
+    - gpt-5.4
+    - --full-auto
+
 ci_timeout: "4h"
 
 log_level: info
@@ -60,6 +66,51 @@ Default binary names when no override is set:
 | `codex` | `codex` |
 | `rovodev` | `acli` |
 | `opencode` | `opencode` |
+
+### agent_args_override
+
+Extra CLI flags to pass to each agent. Use this to set model selection, reasoning effort, permission mode, or any other flag the underlying agent supports.
+
+| | |
+|---|---|
+| Type | `map[string][]string` |
+| Keys | `claude`, `codex`, `rovodev`, `opencode` |
+| Default | Empty (no extra flags) |
+
+User-supplied flags are inserted ahead of no-mistakes' managed flags, so your choices take precedence. A few flags are reserved because no-mistakes depends on them to communicate with the agent - setting any of these returns a config error on load:
+
+| Agent | Reserved flags |
+|---|---|
+| `claude` | `-p`, `--print`, `--verbose`, `--output-format`, `--json-schema` |
+| `codex` | `exec`, `--json`, `--color` |
+| `rovodev` | `rovodev`, `serve`, `--disable-session-token` |
+| `opencode` | `serve`, `--hostname`, `--port`, `--print-logs` |
+
+Smart defaults:
+
+- For `claude`, supplying `--permission-mode` (or `--dangerously-skip-permissions`) suppresses the default `--dangerously-skip-permissions`.
+- For `codex`, supplying `--ask-for-approval`, `--sandbox`, or `--dangerously-bypass-approvals-and-sandbox` suppresses the default `--dangerously-bypass-approvals-and-sandbox`.
+
+Example:
+
+```yaml
+agent_args_override:
+  claude:
+    - --model
+    - sonnet
+    - --permission-mode
+    - acceptEdits
+  codex:
+    - -m
+    - gpt-5.4
+    - --full-auto
+  rovodev:
+    - --profile
+    - work
+  opencode:
+    - --model
+    - gpt-5
+```
 
 ### ci_timeout
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -67,17 +67,19 @@ func (u *TokenUsage) Add(other TokenUsage) {
 	u.CacheCreationTokens += other.CacheCreationTokens
 }
 
-// New creates an agent by name with the given binary path.
-func New(name types.AgentName, bin string) (Agent, error) {
+// New creates an agent by name with the given binary path. extraArgs are user
+// CLI flags (from agent_args_override in the global config) that the agent
+// injects into the underlying tool's argv ahead of no-mistakes' managed flags.
+func New(name types.AgentName, bin string, extraArgs []string) (Agent, error) {
 	switch name {
 	case types.AgentClaude:
-		return &claudeAgent{bin: bin}, nil
+		return &claudeAgent{bin: bin, extraArgs: extraArgs}, nil
 	case types.AgentCodex:
-		return &codexAgent{bin: bin}, nil
+		return &codexAgent{bin: bin, extraArgs: extraArgs}, nil
 	case types.AgentRovoDev:
-		return &rovodevAgent{bin: bin}, nil
+		return &rovodevAgent{bin: bin, extraArgs: extraArgs}, nil
 	case types.AgentOpenCode:
-		return &opencodeAgent{bin: bin}, nil
+		return &opencodeAgent{bin: bin, extraArgs: extraArgs}, nil
 	default:
 		return nil, fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode (set 'agent' in ~/.no-mistakes/config.yaml)", name)
 	}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -23,7 +23,7 @@ func TestNew_KnownAgents(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			a, err := New(tt.agent, tt.bin)
+			a, err := New(tt.agent, tt.bin, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -35,7 +35,7 @@ func TestNew_KnownAgents(t *testing.T) {
 }
 
 func TestNew_Unknown(t *testing.T) {
-	_, err := New("nonexistent", "foo")
+	_, err := New("nonexistent", "foo", nil)
 	if err == nil {
 		t.Fatal("expected error for unknown agent")
 	}

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"strings"
 	"sync"
 )
 
@@ -20,7 +21,8 @@ const claudeScannerMaxTokenSize = 256 * 1024 * 1024
 
 // claudeAgent spawns the claude CLI for each invocation.
 type claudeAgent struct {
-	bin string
+	bin       string
+	extraArgs []string
 }
 
 func (a *claudeAgent) Name() string { return "claude" }
@@ -117,18 +119,39 @@ func finalizeClaudeResult(result *claudeResult, schema json.RawMessage, usage To
 	}, nil
 }
 
-// buildArgs constructs the claude CLI arguments.
+// buildArgs constructs the claude CLI arguments. User-supplied extraArgs
+// (from agent_args_override in the global config) are inserted ahead of the
+// managed flags, so user choices win over no-mistakes' defaults. If the user
+// supplied their own permission mode, the default --dangerously-skip-permissions
+// is not added.
 func (a *claudeAgent) buildArgs(prompt string, schema json.RawMessage) []string {
-	args := []string{
+	args := make([]string, 0, len(a.extraArgs)+8)
+	args = append(args, a.extraArgs...)
+	args = append(args,
 		"-p", prompt,
 		"--verbose",
 		"--output-format", "stream-json",
-	}
+	)
 	if len(schema) > 0 {
 		args = append(args, "--json-schema", string(schema))
 	}
-	args = append(args, "--dangerously-skip-permissions")
+	if !claudeUserSetPermissionMode(a.extraArgs) {
+		args = append(args, "--dangerously-skip-permissions")
+	}
 	return args
+}
+
+// claudeUserSetPermissionMode reports whether extraArgs already declare a
+// permission flag, in which case buildArgs skips its default.
+func claudeUserSetPermissionMode(extraArgs []string) bool {
+	for _, arg := range extraArgs {
+		if arg == "--dangerously-skip-permissions" ||
+			arg == "--permission-mode" ||
+			strings.HasPrefix(arg, "--permission-mode=") {
+			return true
+		}
+	}
+	return false
 }
 
 // claudeEvent is the top-level JSONL event from claude CLI.

--- a/internal/agent/claude_test.go
+++ b/internal/agent/claude_test.go
@@ -48,6 +48,53 @@ func TestClaudeAgent_BuildArgs_NoSchema(t *testing.T) {
 	}
 }
 
+func TestClaudeAgent_BuildArgs_ExtraArgsPrepended(t *testing.T) {
+	ca := &claudeAgent{bin: "claude", extraArgs: []string{"--model", "sonnet"}}
+	args := ca.buildArgs("do it", nil)
+
+	expected := []string{
+		"--model", "sonnet",
+		"-p", "do it",
+		"--verbose",
+		"--output-format", "stream-json",
+		"--dangerously-skip-permissions",
+	}
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("arg[%d]: expected %q, got %q", i, want, args[i])
+		}
+	}
+}
+
+func TestClaudeAgent_BuildArgs_UserPermissionModeSuppressesDefault(t *testing.T) {
+	tests := [][]string{
+		{"--permission-mode", "acceptEdits"},
+		{"--permission-mode=plan"},
+		{"--dangerously-skip-permissions"},
+	}
+	for _, extra := range tests {
+		ca := &claudeAgent{bin: "claude", extraArgs: extra}
+		args := ca.buildArgs("p", nil)
+
+		dangerCount := 0
+		for _, a := range args {
+			if a == "--dangerously-skip-permissions" {
+				dangerCount++
+			}
+		}
+		if len(extra) == 1 && extra[0] == "--dangerously-skip-permissions" {
+			if dangerCount != 1 {
+				t.Errorf("extra=%v expected single --dangerously-skip-permissions, got %d: %v", extra, dangerCount, args)
+			}
+		} else if dangerCount != 0 {
+			t.Errorf("extra=%v expected no default --dangerously-skip-permissions, got: %v", extra, args)
+		}
+	}
+}
+
 func TestParseClaudeEvents_AssistantMessage(t *testing.T) {
 	events := `{"type":"assistant","message":{"usage":{"input_tokens":100,"output_tokens":50},"content":[{"type":"text","text":"hello world"}]}}
 `

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -7,12 +7,14 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"strings"
 	"sync"
 )
 
 // codexAgent spawns the codex CLI for each invocation.
 type codexAgent struct {
-	bin string
+	bin       string
+	extraArgs []string
 }
 
 func (a *codexAgent) Name() string { return "codex" }
@@ -63,14 +65,37 @@ func (a *codexAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
 
 func (a *codexAgent) Close() error { return nil }
 
-// buildArgs constructs the codex CLI arguments.
+// buildArgs constructs the codex CLI arguments. User-supplied extraArgs are
+// inserted between "exec" and the prompt so user flags (e.g. -m, --sandbox)
+// take effect. If the user declared their own execution-mode flag, the
+// default --dangerously-bypass-approvals-and-sandbox is not added.
 func (a *codexAgent) buildArgs(prompt string) []string {
-	return []string{
-		"exec", prompt,
-		"--json",
-		"--dangerously-bypass-approvals-and-sandbox",
-		"--color", "never",
+	args := make([]string, 0, len(a.extraArgs)+6)
+	args = append(args, "exec")
+	args = append(args, a.extraArgs...)
+	args = append(args, prompt, "--json")
+	if !codexUserSetExecutionMode(a.extraArgs) {
+		args = append(args, "--dangerously-bypass-approvals-and-sandbox")
 	}
+	args = append(args, "--color", "never")
+	return args
+}
+
+// codexUserSetExecutionMode reports whether extraArgs already declare an
+// execution/sandbox flag that conflicts with the default bypass.
+func codexUserSetExecutionMode(extraArgs []string) bool {
+	for _, arg := range extraArgs {
+		switch {
+		case arg == "--dangerously-bypass-approvals-and-sandbox",
+			arg == "--ask-for-approval",
+			arg == "--sandbox":
+			return true
+		case strings.HasPrefix(arg, "--ask-for-approval="),
+			strings.HasPrefix(arg, "--sandbox="):
+			return true
+		}
+	}
+	return false
 }
 
 // codexEvent is the top-level JSONL event from codex CLI.

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -27,6 +27,55 @@ func TestCodexAgent_BuildArgs(t *testing.T) {
 	}
 }
 
+func TestCodexAgent_BuildArgs_ExtraArgsAfterExec(t *testing.T) {
+	ca := &codexAgent{bin: "codex", extraArgs: []string{"-m", "gpt-5.4"}}
+	args := ca.buildArgs("fix it")
+
+	expected := []string{
+		"exec",
+		"-m", "gpt-5.4",
+		"fix it",
+		"--json",
+		"--dangerously-bypass-approvals-and-sandbox",
+		"--color", "never",
+	}
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("arg[%d]: expected %q, got %q", i, want, args[i])
+		}
+	}
+}
+
+func TestCodexAgent_BuildArgs_UserExecutionModeSuppressesBypass(t *testing.T) {
+	tests := [][]string{
+		{"--ask-for-approval", "untrusted"},
+		{"--sandbox", "read-only"},
+		{"--sandbox=workspace-write"},
+		{"--dangerously-bypass-approvals-and-sandbox"},
+	}
+	for _, extra := range tests {
+		ca := &codexAgent{bin: "codex", extraArgs: extra}
+		args := ca.buildArgs("p")
+
+		bypassCount := 0
+		for _, a := range args {
+			if a == "--dangerously-bypass-approvals-and-sandbox" {
+				bypassCount++
+			}
+		}
+		if len(extra) == 1 && extra[0] == "--dangerously-bypass-approvals-and-sandbox" {
+			if bypassCount != 1 {
+				t.Errorf("extra=%v expected single bypass, got %d: %v", extra, bypassCount, args)
+			}
+		} else if bypassCount != 0 {
+			t.Errorf("extra=%v expected no default bypass, got: %v", extra, args)
+		}
+	}
+}
+
 func TestParseCodexEvents_AgentMessage(t *testing.T) {
 	events := strings.Join([]string{
 		`{"type":"item.completed","item":{"type":"agent_message","text":"{\"success\":true,\"summary\":\"done\"}"}}`,

--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -10,9 +10,10 @@ import (
 // opencodeAgent starts a persistent HTTP server via `opencode serve`
 // and sends requests via REST with SSE streaming.
 type opencodeAgent struct {
-	bin    string
-	mu     sync.Mutex
-	server *managedServer
+	bin       string
+	extraArgs []string
+	mu        sync.Mutex
+	server    *managedServer
 }
 
 func (a *opencodeAgent) Name() string { return "opencode" }

--- a/internal/agent/opencode_http.go
+++ b/internal/agent/opencode_http.go
@@ -20,13 +20,23 @@ func (a *opencodeAgent) ensureServer(ctx context.Context, cwd string) (string, e
 	if err != nil {
 		return "", fmt.Errorf("opencode port: %w", err)
 	}
-	args := []string{"serve", "--hostname", "127.0.0.1", "--port", fmt.Sprintf("%d", port), "--print-logs"}
+	args := buildOpencodeServeArgs(a.extraArgs, port)
 	srv, err := startServerWithPort(ctx, "opencode", a.bin, args, cwd, "/global/health", port)
 	if err != nil {
 		return "", fmt.Errorf("opencode server: %w", err)
 	}
 	a.server = srv
 	return srv.baseURL(), nil
+}
+
+// buildOpencodeServeArgs builds `opencode serve`'s argv with user-supplied
+// extras inserted after the "serve" subcommand and before the managed flags.
+func buildOpencodeServeArgs(extraArgs []string, port int) []string {
+	args := make([]string, 0, len(extraArgs)+6)
+	args = append(args, "serve")
+	args = append(args, extraArgs...)
+	args = append(args, "--hostname", "127.0.0.1", "--port", fmt.Sprintf("%d", port), "--print-logs")
+	return args
 }
 
 func (a *opencodeAgent) createSession(ctx context.Context, baseURL, cwd string) (string, error) {

--- a/internal/agent/rovodev.go
+++ b/internal/agent/rovodev.go
@@ -15,9 +15,10 @@ import (
 // rovodevAgent starts a persistent HTTP server via `acli rovodev serve`
 // and sends requests via REST with SSE streaming.
 type rovodevAgent struct {
-	bin    string
-	mu     sync.Mutex
-	server *managedServer
+	bin       string
+	extraArgs []string
+	mu        sync.Mutex
+	server    *managedServer
 }
 
 func (a *rovodevAgent) Name() string { return "rovodev" }
@@ -71,13 +72,23 @@ func (a *rovodevAgent) ensureServer(ctx context.Context, cwd string) (string, er
 	if err != nil {
 		return "", fmt.Errorf("rovodev port: %w", err)
 	}
-	args := []string{"rovodev", "serve", "--disable-session-token", fmt.Sprintf("%d", port)}
+	args := buildRovodevServeArgs(a.extraArgs, port)
 	srv, err := startServerWithPort(ctx, "rovodev", a.bin, args, cwd, "/healthcheck", port)
 	if err != nil {
 		return "", fmt.Errorf("rovodev server: %w", err)
 	}
 	a.server = srv
 	return srv.baseURL(), nil
+}
+
+// buildRovodevServeArgs builds `acli`'s serve argv with user-supplied extras
+// inserted after the "rovodev serve" subcommands and before the managed flags.
+func buildRovodevServeArgs(extraArgs []string, port int) []string {
+	args := make([]string, 0, len(extraArgs)+4)
+	args = append(args, "rovodev", "serve")
+	args = append(args, extraArgs...)
+	args = append(args, "--disable-session-token", fmt.Sprintf("%d", port))
+	return args
 }
 
 func (a *rovodevAgent) Close() error {

--- a/internal/agent/servearg_test.go
+++ b/internal/agent/servearg_test.go
@@ -1,0 +1,53 @@
+package agent
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildRovodevServeArgs_Default(t *testing.T) {
+	got := buildRovodevServeArgs(nil, 51234)
+	want := []string{"rovodev", "serve", "--disable-session-token", "51234"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildRovodevServeArgs(nil) = %v, want %v", got, want)
+	}
+}
+
+func TestBuildRovodevServeArgs_ExtraArgsInserted(t *testing.T) {
+	got := buildRovodevServeArgs([]string{"--profile", "work"}, 51234)
+	want := []string{
+		"rovodev", "serve",
+		"--profile", "work",
+		"--disable-session-token", "51234",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildRovodevServeArgs = %v, want %v", got, want)
+	}
+}
+
+func TestBuildOpencodeServeArgs_Default(t *testing.T) {
+	got := buildOpencodeServeArgs(nil, 9999)
+	want := []string{
+		"serve",
+		"--hostname", "127.0.0.1",
+		"--port", "9999",
+		"--print-logs",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildOpencodeServeArgs(nil) = %v, want %v", got, want)
+	}
+}
+
+func TestBuildOpencodeServeArgs_ExtraArgsInserted(t *testing.T) {
+	got := buildOpencodeServeArgs([]string{"--model", "gpt-5"}, 9999)
+	want := []string{
+		"serve",
+		"--model", "gpt-5",
+		"--hostname", "127.0.0.1",
+		"--port", "9999",
+		"--print-logs",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildOpencodeServeArgs = %v, want %v", got, want)
+	}
+}

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -44,7 +44,7 @@ type wizardAgentSuggester struct {
 	cfg     *config.Config
 	workDir string
 	resolve func(context.Context, *config.Config) error
-	new     func(types.AgentName, string) (agent.Agent, error)
+	new     func(types.AgentName, string, []string) (agent.Agent, error)
 
 	once sync.Once
 	ag   agent.Agent
@@ -57,7 +57,7 @@ type wizardAgentSuggester struct {
 	cachedCommit string
 }
 
-func newWizardAgentSuggester(cfg *config.Config, workDir string, resolve func(context.Context, *config.Config) error, new func(types.AgentName, string) (agent.Agent, error)) *wizardAgentSuggester {
+func newWizardAgentSuggester(cfg *config.Config, workDir string, resolve func(context.Context, *config.Config) error, new func(types.AgentName, string, []string) (agent.Agent, error)) *wizardAgentSuggester {
 	if resolve == nil {
 		resolve = resolveWizardAgent
 	}
@@ -73,7 +73,7 @@ func (s *wizardAgentSuggester) ensure(ctx context.Context) error {
 			s.err = fmt.Errorf("resolve agent: %w", err)
 			return
 		}
-		ag, err := s.new(s.cfg.Agent, s.cfg.AgentPath())
+		ag, err := s.new(s.cfg.Agent, s.cfg.AgentPath(), s.cfg.AgentArgs())
 		if err != nil {
 			s.err = fmt.Errorf("create agent: %w", err)
 			return

--- a/internal/cli/wizard_test.go
+++ b/internal/cli/wizard_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -105,6 +106,46 @@ func TestWizardAgentSuggester_IsLazy(t *testing.T) {
 	}
 	if lookups != 1 {
 		t.Fatalf("expected one lazy resolution attempt, got %d", lookups)
+	}
+}
+
+func TestWizardAgentSuggester_ForwardsAgentArgsOverride(t *testing.T) {
+	t.Helper()
+
+	var (
+		gotName types.AgentName
+		gotBin  string
+		gotArgs []string
+	)
+	suggester := newWizardAgentSuggester(
+		&config.Config{
+			Agent: types.AgentClaude,
+			AgentArgsOverride: map[string][]string{
+				"claude": {"--permission-mode", "acceptEdits"},
+			},
+		},
+		"/tmp/repo",
+		func(context.Context, *config.Config) error { return nil },
+		func(name types.AgentName, bin string, args []string) (agent.Agent, error) {
+			gotName = name
+			gotBin = bin
+			gotArgs = append([]string(nil), args...)
+			return &fakeSuggesterAgent{}, nil
+		},
+	)
+	defer suggester.Close()
+
+	if err := suggester.ensure(context.Background()); err != nil {
+		t.Fatalf("ensure failed: %v", err)
+	}
+	if gotName != types.AgentClaude {
+		t.Fatalf("new agent name = %q, want %q", gotName, types.AgentClaude)
+	}
+	if gotBin != "claude" {
+		t.Fatalf("new agent bin = %q, want %q", gotBin, "claude")
+	}
+	if want := []string{"--permission-mode", "acceptEdits"}; !reflect.DeepEqual(gotArgs, want) {
+		t.Fatalf("new agent args = %v, want %v", gotArgs, want)
 	}
 }
 

--- a/internal/cli/wizard_test.go
+++ b/internal/cli/wizard_test.go
@@ -179,7 +179,7 @@ func newFakeSuggester(t *testing.T, ag *fakeSuggesterAgent) *wizardAgentSuggeste
 		&config.Config{Agent: types.AgentClaude},
 		"/tmp/repo",
 		func(context.Context, *config.Config) error { return nil },
-		func(types.AgentName, string) (agent.Agent, error) { return ag, nil },
+		func(types.AgentName, string, []string) (agent.Agent, error) { return ag, nil },
 	)
 }
 
@@ -300,7 +300,7 @@ func TestWizardAgentSuggester_EmptyRetryClearsCachedCommit(t *testing.T) {
 		&config.Config{Agent: types.AgentClaude},
 		"/tmp/repo",
 		func(context.Context, *config.Config) error { return nil },
-		func(types.AgentName, string) (agent.Agent, error) { return ag, nil },
+		func(types.AgentName, string, []string) (agent.Agent, error) { return ag, nil },
 	)
 	defer s.Close()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,21 +18,23 @@ import (
 
 // GlobalConfig represents ~/.no-mistakes/config.yaml.
 type GlobalConfig struct {
-	Agent             types.AgentName   `yaml:"agent"`
-	AgentPathOverride map[string]string `yaml:"agent_path_override"`
-	CITimeout         time.Duration     `yaml:"-"`
-	LogLevel          string            `yaml:"log_level"`
+	Agent             types.AgentName     `yaml:"agent"`
+	AgentPathOverride map[string]string   `yaml:"agent_path_override"`
+	AgentArgsOverride map[string][]string `yaml:"agent_args_override"`
+	CITimeout         time.Duration       `yaml:"-"`
+	LogLevel          string              `yaml:"log_level"`
 	AutoFix           AutoFixRaw
 }
 
 // globalConfigRaw is the on-disk YAML representation with duration as string.
 type globalConfigRaw struct {
-	Agent             types.AgentName   `yaml:"agent"`
-	AgentPathOverride map[string]string `yaml:"agent_path_override"`
-	CITimeout         string            `yaml:"ci_timeout"`
-	BabysitTimeout    string            `yaml:"babysit_timeout"`
-	LogLevel          string            `yaml:"log_level"`
-	AutoFix           AutoFixRaw        `yaml:"auto_fix"`
+	Agent             types.AgentName     `yaml:"agent"`
+	AgentPathOverride map[string]string   `yaml:"agent_path_override"`
+	AgentArgsOverride map[string][]string `yaml:"agent_args_override"`
+	CITimeout         string              `yaml:"ci_timeout"`
+	BabysitTimeout    string              `yaml:"babysit_timeout"`
+	LogLevel          string              `yaml:"log_level"`
+	AutoFix           AutoFixRaw          `yaml:"auto_fix"`
 }
 
 // RepoConfig represents .no-mistakes.yaml in a repo root.
@@ -77,6 +79,7 @@ type AutoFix struct {
 type Config struct {
 	Agent             types.AgentName
 	AgentPathOverride map[string]string
+	AgentArgsOverride map[string][]string
 	CITimeout         time.Duration
 	LogLevel          string
 	Commands          Commands
@@ -212,6 +215,78 @@ func (c *Config) AgentPath() string {
 	return string(c.Agent)
 }
 
+// AgentArgs returns extra CLI args for the configured agent, as declared in
+// agent_args_override. Returns nil when no override is set for this agent.
+func (c *Config) AgentArgs() []string {
+	if c.AgentArgsOverride == nil {
+		return nil
+	}
+	return c.AgentArgsOverride[string(c.Agent)]
+}
+
+// agentArgsOverrideAgents lists agent names accepted as keys in
+// agent_args_override.
+var agentArgsOverrideAgents = map[string]bool{
+	string(types.AgentClaude):   true,
+	string(types.AgentCodex):    true,
+	string(types.AgentRovoDev):  true,
+	string(types.AgentOpenCode): true,
+}
+
+// reservedAgentArgs lists flags that no-mistakes manages internally and that
+// users cannot override through agent_args_override. A flag is matched by its
+// bare form (e.g. "--color") as well as the "--color=value" form.
+var reservedAgentArgs = map[string]map[string]bool{
+	string(types.AgentClaude): {
+		"-p":              true,
+		"--print":         true,
+		"--verbose":       true,
+		"--output-format": true,
+		"--json-schema":   true,
+	},
+	string(types.AgentCodex): {
+		"exec":    true,
+		"--json":  true,
+		"--color": true,
+	},
+	string(types.AgentRovoDev): {
+		"rovodev":                 true,
+		"serve":                   true,
+		"--disable-session-token": true,
+	},
+	string(types.AgentOpenCode): {
+		"serve":        true,
+		"--hostname":   true,
+		"--port":       true,
+		"--print-logs": true,
+	},
+}
+
+// validateAgentArgsOverride ensures each agent key is a known agent name and
+// that no reserved flag appears. Empty args are rejected to catch trivially
+// broken YAML.
+func validateAgentArgsOverride(override map[string][]string) error {
+	for name, args := range override {
+		if !agentArgsOverrideAgents[name] {
+			return fmt.Errorf("invalid agent name in agent_args_override: %q (valid: claude, codex, rovodev, opencode)", name)
+		}
+		reserved := reservedAgentArgs[name]
+		for i, arg := range args {
+			if strings.TrimSpace(arg) == "" {
+				return fmt.Errorf("invalid agent_args_override.%s[%d]: empty arg", name, i)
+			}
+			base := arg
+			if idx := strings.Index(arg, "="); idx > 0 {
+				base = arg[:idx]
+			}
+			if reserved[base] {
+				return fmt.Errorf("invalid agent_args_override.%s[%d]: %q is managed by no-mistakes and cannot be overridden", name, i, arg)
+			}
+		}
+	}
+	return nil
+}
+
 // EnsureDefaultGlobalConfig writes the default config file at path if it does
 // not already exist. Failures are logged at debug level and silently ignored.
 func EnsureDefaultGlobalConfig(path string) {
@@ -256,6 +331,12 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 	}
 	if raw.AgentPathOverride != nil {
 		cfg.AgentPathOverride = raw.AgentPathOverride
+	}
+	if raw.AgentArgsOverride != nil {
+		if err := validateAgentArgsOverride(raw.AgentArgsOverride); err != nil {
+			return nil, err
+		}
+		cfg.AgentArgsOverride = raw.AgentArgsOverride
 	}
 	timeoutValue := raw.CITimeout
 	if timeoutValue == "" {
@@ -385,6 +466,7 @@ func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 	cfg := &Config{
 		Agent:             global.Agent,
 		AgentPathOverride: global.AgentPathOverride,
+		AgentArgsOverride: global.AgentArgsOverride,
 		CITimeout:         global.CITimeout,
 		LogLevel:          global.LogLevel,
 		Commands:          repo.Commands,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -107,6 +107,12 @@ log_level: info
 #   claude: /usr/local/bin/claude
 #   codex: /opt/codex
 
+# Extra agent CLI flags (optional, global only)
+# agent_args_override:
+#   codex:
+#     - -m
+#     - gpt-5.4
+#
 # Maximum auto-fix attempts per step (0 = disabled, requires manual approval)
 auto_fix:
   rebase: 3

--- a/internal/config/config_args_override_test.go
+++ b/internal/config/config_args_override_test.go
@@ -1,0 +1,171 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+func TestLoadGlobal_AgentArgsOverride(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	data := `agent: claude
+agent_args_override:
+  claude:
+    - --permission-mode
+    - acceptEdits
+  codex:
+    - -m
+    - gpt-5.4
+    - --full-auto
+  rovodev:
+    - --profile
+    - work
+  opencode:
+    - --model
+    - gpt-5
+`
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadGlobal(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cases := map[string][]string{
+		"claude":   {"--permission-mode", "acceptEdits"},
+		"codex":    {"-m", "gpt-5.4", "--full-auto"},
+		"rovodev":  {"--profile", "work"},
+		"opencode": {"--model", "gpt-5"},
+	}
+	for agent, want := range cases {
+		got := cfg.AgentArgsOverride[agent]
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("agent_args_override[%q] = %v, want %v", agent, got, want)
+		}
+	}
+}
+
+func TestLoadGlobal_AgentArgsOverride_UnknownAgentRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	data := `agent_args_override:
+  gpt5:
+    - --model
+    - foo
+`
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadGlobal(path)
+	if err == nil {
+		t.Fatal("expected error for unknown agent name in agent_args_override")
+	}
+	if !strings.Contains(err.Error(), "gpt5") {
+		t.Errorf("expected error to mention unknown agent %q, got: %v", "gpt5", err)
+	}
+}
+
+func TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected(t *testing.T) {
+	tests := []struct {
+		agent string
+		arg   string
+	}{
+		{"claude", "-p"},
+		{"claude", "--print"},
+		{"claude", "--verbose"},
+		{"claude", "--output-format"},
+		{"claude", "--output-format=stream-json"},
+		{"claude", "--json-schema"},
+		{"codex", "exec"},
+		{"codex", "--json"},
+		{"codex", "--color"},
+		{"codex", "--color=never"},
+		{"rovodev", "rovodev"},
+		{"rovodev", "serve"},
+		{"rovodev", "--disable-session-token"},
+		{"opencode", "serve"},
+		{"opencode", "--hostname"},
+		{"opencode", "--port"},
+		{"opencode", "--print-logs"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.agent+"_"+tt.arg, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.yaml")
+			data := "agent_args_override:\n  " + tt.agent + ":\n    - " + tt.arg + "\n"
+			if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := LoadGlobal(path)
+			if err == nil {
+				t.Fatalf("expected error for reserved arg %q on agent %q", tt.arg, tt.agent)
+			}
+			if !strings.Contains(err.Error(), "managed by no-mistakes") {
+				t.Errorf("error should mention 'managed by no-mistakes', got: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadGlobal_AgentArgsOverride_EmptyArgRejected(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	data := `agent_args_override:
+  claude:
+    - ""
+`
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadGlobal(path)
+	if err == nil {
+		t.Fatal("expected error for empty arg")
+	}
+}
+
+func TestAgentArgs_ReturnsEmptyWhenUnset(t *testing.T) {
+	cfg := &Config{Agent: types.AgentClaude}
+	if got := cfg.AgentArgs(); len(got) != 0 {
+		t.Errorf("AgentArgs() = %v, want empty", got)
+	}
+}
+
+func TestAgentArgs_ReturnsExtrasForConfiguredAgent(t *testing.T) {
+	cfg := &Config{
+		Agent: types.AgentClaude,
+		AgentArgsOverride: map[string][]string{
+			"claude":  {"--permission-mode", "acceptEdits"},
+			"codex":   {"-m", "gpt-5.4"},
+			"unused":  {"whatever"},
+			"rovodev": {"--profile", "work"},
+		},
+	}
+	want := []string{"--permission-mode", "acceptEdits"}
+	if got := cfg.AgentArgs(); !reflect.DeepEqual(got, want) {
+		t.Errorf("AgentArgs() = %v, want %v", got, want)
+	}
+}
+
+func TestMerge_PreservesAgentArgsOverride(t *testing.T) {
+	global := &GlobalConfig{
+		Agent: types.AgentClaude,
+		AgentArgsOverride: map[string][]string{
+			"claude": {"--permission-mode", "acceptEdits"},
+		},
+	}
+	repo := &RepoConfig{}
+	cfg := Merge(global, repo)
+	if got := cfg.AgentArgsOverride["claude"]; !reflect.DeepEqual(got, []string{"--permission-mode", "acceptEdits"}) {
+		t.Errorf("merged AgentArgsOverride[claude] = %v", got)
+	}
+}

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -303,7 +303,7 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 			return "", err
 		}
 		var agErr error
-		ag, agErr = agent.New(cfg.Agent, cfg.AgentPath())
+		ag, agErr = agent.New(cfg.Agent, cfg.AgentPath(), cfg.AgentArgs())
 		if agErr != nil {
 			m.db.UpdateRunError(run.ID, fmt.Sprintf("create agent: %s", agErr))
 			trackStartFailure("create_agent")


### PR DESCRIPTION
## Summary
- Add a global `agent_args_override` config setting so users can override or append agent CLI arguments without changing built-in agent integrations.
- Thread the override through agent command construction for Claude, Codex, Rovo Dev, and OpenCode, and update related config, daemon, and wizard behavior to use the new setting consistently.
- Document the new override in the generated config template and docs, including how it interacts with default flags and global configuration.

## Risk Assessment

✅ Low: The change is narrowly scoped, the new config surface is validated on load, and the agent wiring is consistently updated without obvious correctness or compatibility regressions in the reviewed diff.

## Testing

- Summary: I exercised config parsing/validation, agent argv construction for all supported agents, wizard forwarding of configured extra args, and the daemon package tests; all relevant tests passed after adding a focused wizard regression test.
- `go test ./internal/config`
- `go test ./internal/agent`
- `go test ./internal/cli`
- `go test ./internal/daemon`
- `go test ./internal/cli -run '^TestWizardAgentSuggester_ForwardsAgentArgsOverride$'`
- `go test ./internal/config ./internal/agent ./internal/cli ./internal/daemon`
- Outcome: ✅ passed across 1 run (2m25s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/config`
- `go test ./internal/agent`
- `go test ./internal/cli`
- `go test ./internal/daemon`
- `go test ./internal/cli -run '^TestWizardAgentSuggester_ForwardsAgentArgsOverride$'`
- `go test ./internal/config ./internal/agent ./internal/cli ./internal/daemon`

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed (2)</summary>

**Round 1** - found 2 warnings
- ⚠️ `docs/src/content/docs/guides/configuration.md:53` - The user-facing configuration guide still shows `agent_path_override` as the last agent-related global setting and never mentions the new `agent_args_override` feature. This change adds a new supported global config knob for per-agent CLI flags, so the guide&#39;s global config example and surrounding explanation should be updated to show when to use it and that it is global-only.
- ⚠️ `docs/src/content/docs/guides/agents.md:107` - The agent guide still describes Claude and Codex as always running with fixed default flags (`--dangerously-skip-permissions` and `--dangerously-bypass-approvals-and-sandbox`) and does not mention the new `agent_args_override` mechanism. After this change those defaults are conditional and users can inject extra agent-specific flags for Claude, Codex, Rovo Dev, and OpenCode, so the guide is now stale and should document the override behavior and reserved/internal flags at a high level.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `internal/config/config.go:105` - The generated default `~/.no-mistakes/config.yaml` template still documents `agent_path_override` and then jumps straight to `auto_fix`, so first-run users never see the new `agent_args_override` setting in the config example that no-mistakes writes for them. Update the template comment block to include this new global-only override and a minimal example or pointer.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
