### PR TITLE
feat(tui): add finding overrides for manual fix rounds

### DIFF
--- a/docs/src/content/docs/concepts/auto-fix.md
+++ b/docs/src/content/docs/concepts/auto-fix.md
@@ -72,9 +72,10 @@ When the pipeline pauses for approval, you can manually trigger a fix from the T
 
 1. The findings panel shows all findings with checkboxes
 2. Toggle individual findings with `space`, or use `A` (all) / `N` (none)
-3. Press `f` to fix the selected findings
+3. Optionally press `e` to attach a note to the current finding, or `+` to add your own finding to the fix request
+4. Press `f` to fix the selected findings
 
-The agent receives the selected findings plus a sanitized history of previous rounds for that step, including which finding IDs were selected for a prior fix attempt, which findings were left unselected by the user, and any one-line summaries from earlier fix commits. On follow-up review passes, that history tells the agent not to re-report user-ignored findings unless the code now presents a materially different issue.
+The agent receives the merged fix payload for that round: the selected agent findings, any per-finding user notes, any selected user-authored findings added from the TUI, and a sanitized history of previous rounds for that step. That history includes which finding IDs were selected for a prior fix attempt, which findings were left unselected by the user, and any one-line summaries from earlier fix commits. On follow-up review passes, that history tells the agent not to re-report user-ignored findings unless the code now presents a materially different issue.
 
 After a user-triggered fix, the step re-runs and pauses again to show you the results (`fix_review` status). You can then approve, fix again, skip, or abort.
 
@@ -94,7 +95,7 @@ The push step commits any remaining uncommitted changes with `no-mistakes: apply
 
 ## Step rounds
 
-Each execution of a step (initial run or follow-up auto-fix run) is recorded as a "round" in the database. A round stores its findings, duration, any selected finding IDs and whether that selection came from the user or auto-fix filtering, plus the one-line fix summary for fix rounds. The PR body's deterministic risk assessment, testing, and pipeline sections are built from these rounds, giving reviewers visibility into test results, review risk, what was fixed, and how many attempts it took.
+Each execution of a step (initial run or follow-up auto-fix run) is recorded as a "round" in the database. A round stores its findings, duration, any selected finding IDs and whether that selection came from the user or auto-fix filtering, the merged finding payload actually sent to the fix agent for that round, and the one-line fix summary for fix rounds. That merged payload can include per-finding user notes and user-authored findings added from the TUI. The PR body's deterministic risk assessment, testing, and pipeline sections are built from these rounds, giving reviewers visibility into test results, review risk, what was fixed, and how many attempts it took.
 
 Round trigger types:
 - `initial` - first execution

--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -134,9 +134,11 @@ Communication between the CLI and daemon uses JSON-RPC 2.0 over the Unix socket.
 SQLite at `~/.no-mistakes/state.sqlite` tracks repos, runs, step results, and
 step rounds. Step rounds record each execution attempt (initial, auto-fix) with
 its own findings and duration, plus selected finding IDs, whether the
-selection came from the user or auto-fix filtering, and the one-line fix
-summary for fix rounds. Legacy `user_fix` rounds are still read as `auto-fix`
-for backward compatibility.
+selection came from the user or auto-fix filtering, the merged finding payload
+actually sent to the fix agent for that round, and the one-line fix summary
+for fix rounds. That merged payload can include per-finding user notes and
+user-authored findings from the TUI. Legacy `user_fix` rounds are still read
+as `auto-fix` for backward compatibility.
 
 ## Local state
 

--- a/docs/src/content/docs/guides/tui.md
+++ b/docs/src/content/docs/guides/tui.md
@@ -154,7 +154,7 @@ The footer shows detach/help actions and, when `no-mistakes attach` has a cached
 | `+` | Add a user-authored finding |
 | `D` | Delete the current user-authored finding |
 
-When the instruction editor is open, press `Ctrl+s` to save or `esc` to cancel. In the add-finding editor, use `tab` / `shift+tab` to move between fields, `Ctrl+s` to save, and `esc` to cancel.
+When the instruction editor is open, press `Ctrl+s` or `Ctrl+enter` to save, or `esc` to cancel. In the add-finding editor, use `tab` / `shift+tab` to move between fields, `Ctrl+s` to save, and `esc` to cancel.
 
 ### View
 

--- a/docs/src/content/docs/guides/tui.md
+++ b/docs/src/content/docs/guides/tui.md
@@ -85,16 +85,22 @@ When a step pauses for approval, the findings panel shows structured results:
   Potential null pointer in error path
 
   > [x] E  src/handler.go:42
-         Missing nil check before dereferencing resp.Body
+          Missing nil check before dereferencing resp.Body
+         > keep the existing retry behavior
+    [x] I  [user]
+          Also update the CLI help text for this new flag
+         > mention the env var in the docs too
     [x] W  src/handler.go:78
-         Error string should not be capitalized
+          Error string should not be capitalized
     [ ] I  src/handler.go:95
-         Consider extracting this into a helper function
+          Consider extracting this into a helper function
 ```
 
 - Severity icons: `E` (error, red), `W` (warning, yellow), `I` (info, blue)
 - Checkboxes: `[x]` (selected, green), `[ ]` (deselected, dim)
 - Blue `>` marks the focused finding
+- User-added findings are marked with `[user]`
+- Per-finding notes render inline as `> ...` and are sent with the next fix request
 - Bottom hint shows `↑ N above / ↓ N more below (j/k)` when scrolling, or `(j/k)` whenever there are multiple findings
 
 ### Diff panel
@@ -144,6 +150,9 @@ The footer shows detach/help actions and, when `no-mistakes attach` has a cached
 | `space` | Toggle current finding |
 | `A` | Select all findings |
 | `N` | Deselect all findings |
+| `e` | Edit fix note for the current finding |
+| `+` | Add a user-authored finding |
+| `D` | Delete the current user-authored finding |
 
 ### View
 
@@ -164,10 +173,12 @@ The action bar appears below the pipeline box when a step is awaiting approval:
 ```
 Review awaiting action:
  a approve  f fix (3/5)  s skip  x abort  d diff
- [space] toggle  A all  N none
+ [space] toggle  A all  N none  e edit note  + add  D delete user
 ```
 
 The `f fix (3/5)` label shows how many findings are selected out of the total.
+
+Press `e` to add or edit extra guidance for the current finding. Press `+` to add your own finding to the list. User-authored findings start selected by default and can be removed with `D`.
 
 ## Outcome banner
 

--- a/docs/src/content/docs/guides/tui.md
+++ b/docs/src/content/docs/guides/tui.md
@@ -154,6 +154,8 @@ The footer shows detach/help actions and, when `no-mistakes attach` has a cached
 | `+` | Add a user-authored finding |
 | `D` | Delete the current user-authored finding |
 
+When the instruction editor is open, press `Ctrl+s` to save or `esc` to cancel. In the add-finding editor, use `tab` / `shift+tab` to move between fields, `Ctrl+s` to save, and `esc` to cancel.
+
 ### View
 
 | Key | Action |
@@ -173,7 +175,7 @@ The action bar appears below the pipeline box when a step is awaiting approval:
 ```
 Review awaiting action:
  a approve  f fix (3/5)  s skip  x abort  d diff
- [space] toggle  A all  N none  e edit note  + add  D delete user
+ [space] toggle  e edit  + add  A all  N none
 ```
 
 The `f fix (3/5)` label shows how many findings are selected out of the total.

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -58,7 +58,7 @@ Runs your test suite.
 
 **Approval:** failing test findings with `action: ask-user` always require human approval. `action: auto-fix` findings stay eligible for the fix loop. `action: no-op` findings are informational only.
 
-**Auto-fix:** the agent receives previous failure output plus a sanitized history of prior rounds for that step, including earlier fix summaries and any findings the user left unselected in prior approval cycles, then tests run again. Fix commits use `no-mistakes(test): <summary>`.
+**Auto-fix:** the agent receives the previous test findings plus any per-finding user notes, any selected user-authored findings from the TUI, and a sanitized history of prior rounds for that step, including earlier fix summaries and any findings the user left unselected in prior approval cycles, then tests run again. Fix commits use `no-mistakes(test): <summary>`.
 
 **Default auto-fix limit:** `3`.
 

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -25,7 +25,7 @@ Fetches the latest upstream and rebases your branch onto it.
 - If the diff against the default branch is empty after rebase, completes rebase and skips all remaining pipeline steps
 - On conflict: records conflicting files, aborts the rebase, and reports findings
 
-**Auto-fix:** when enabled, the agent resolves conflict markers, stages files, and runs `git rebase --continue`. Commits use the message format `no-mistakes(rebase): <summary>`.
+**Auto-fix:** when enabled, the agent resolves conflict markers, stages files, and runs `git rebase --continue`. Manual fix rounds also include any per-conflict user notes, any selected user-authored findings from the TUI, and sanitized prior-round history in the prompt. Commits use the message format `no-mistakes(rebase): <summary>`.
 
 **Default auto-fix limit:** `3`.
 

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -42,7 +42,7 @@ AI code review of your diff.
 
 **Approval:** required if any finding has severity `error` or `warning`. Findings with `action: ask-user` always require human approval and are never auto-fixed. This is for findings that challenge the author's intent, not routine correctness, reliability, or security fixes that may need to re-add a small amount of deleted logic. Findings with `action: auto-fix` remain eligible for the fix loop. Findings with `action: no-op` are informational only.
 
-**Auto-fix:** the agent receives the selected previous findings plus a sanitized history of prior rounds for that step, including earlier fix summaries and which findings the user left unselected. Follow-up review passes use that history to avoid re-reporting user-ignored findings unless the code now has a materially different problem. Fix commits use `no-mistakes(review): <summary>`.
+**Auto-fix:** the agent receives the selected previous findings plus any per-finding user notes, any selected user-authored findings from the TUI, and a sanitized history of prior rounds for that step, including earlier fix summaries and which findings the user left unselected. Follow-up review passes use that history to avoid re-reporting user-ignored findings unless the code now has a materially different problem. Fix commits use `no-mistakes(review): <summary>`.
 
 **Default auto-fix limit:** `0`.
 
@@ -71,7 +71,7 @@ Checks whether the code changes need matching documentation updates.
 - Asks the agent to review the change and return documentation findings for any missing or stale docs, using the same `action` field as other agent-driven steps
 - Requires approval whenever any documentation finding is returned, including `info` findings
 
-**Auto-fix:** the agent updates only documentation files or doc comments, using the previous documentation findings plus a sanitized history of prior rounds for that step, including earlier fix summaries and any findings the user left unselected in prior approval cycles. The step then re-runs and expects an empty findings list before continuing. Fix commits use `no-mistakes(document): <summary>`.
+**Auto-fix:** the agent updates only documentation files or doc comments, using the previous documentation findings plus any per-finding user notes, any selected user-authored findings from the TUI, and a sanitized history of prior rounds for that step, including earlier fix summaries and any findings the user left unselected in prior approval cycles. The step then re-runs and expects an empty findings list before continuing. Fix commits use `no-mistakes(document): <summary>`.
 
 **Default auto-fix limit:** `3`.
 
@@ -85,7 +85,7 @@ Runs linters and static analysis.
 
 **Approval:** lint findings with `action: ask-user` always require human approval. `action: auto-fix` findings stay eligible for the fix loop. `action: no-op` findings are informational only.
 
-**Auto-fix:** same pattern as test - the agent fixes `action: auto-fix` issues using the previous findings plus a sanitized history of prior rounds for that step, including earlier fix summaries and any findings the user left unselected in prior approval cycles, then lint re-runs. Fix commits use `no-mistakes(lint): <summary>`.
+**Auto-fix:** same pattern as test - the agent fixes `action: auto-fix` issues using the previous findings plus any per-finding user notes, any selected user-authored findings from the TUI, and a sanitized history of prior rounds for that step, including earlier fix summaries and any findings the user left unselected in prior approval cycles, then lint re-runs. Fix commits use `no-mistakes(lint): <summary>`.
 
 **Default auto-fix limit:** `3`.
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -401,7 +401,7 @@ func registerHandlers(srv *ipc.Server, mgr *RunManager, d *db.DB, shutdown func(
 		if err := json.Unmarshal(params, &p); err != nil {
 			return nil, fmt.Errorf("invalid params: %w", err)
 		}
-		if err := mgr.HandleRespond(p.RunID, p.Step, p.Action, p.FindingIDs); err != nil {
+		if err := mgr.HandleRespondWithOverrides(p.RunID, p.Step, p.Action, p.FindingIDs, p.Instructions, p.AddedFindings); err != nil {
 			return nil, err
 		}
 		return &ipc.RespondResult{OK: true}, nil

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -441,6 +441,12 @@ func telemetryFailedStepName(database *db.DB, runID string) string {
 
 // HandleRespond routes a user approval action to the executor for the given run.
 func (m *RunManager) HandleRespond(runID string, step types.StepName, action types.ApprovalAction, findingIDs []string) error {
+	return m.HandleRespondWithOverrides(runID, step, action, findingIDs, nil, nil)
+}
+
+// HandleRespondWithOverrides is like HandleRespond but also forwards user
+// instructions and user-authored findings to the executor.
+func (m *RunManager) HandleRespondWithOverrides(runID string, step types.StepName, action types.ApprovalAction, findingIDs []string, instructions map[string]string, addedFindings []types.Finding) error {
 	m.mu.Lock()
 	exec, ok := m.executors[runID]
 	m.mu.Unlock()
@@ -449,7 +455,7 @@ func (m *RunManager) HandleRespond(runID string, step types.StepName, action typ
 		return fmt.Errorf("no active executor for run %s", runID)
 	}
 
-	return exec.Respond(step, action, findingIDs)
+	return exec.RespondWithOverrides(step, action, findingIDs, instructions, addedFindings)
 }
 
 // Shutdown cancels all active runs. Called during daemon shutdown to prevent

--- a/internal/db/round.go
+++ b/internal/db/round.go
@@ -14,6 +14,12 @@ type StepRound struct {
 	Round        int
 	Trigger      string  // "initial", "auto_fix"; legacy "user_fix" is treated as "auto_fix"
 	FindingsJSON *string // nullable - findings produced by this round
+	// UserFindingsJSON, when non-nil, is the merged finding list that was
+	// dispatched to the fix agent after the user edited per-finding
+	// instructions or added their own findings. It includes both the
+	// selected agent-produced findings (with any attached user
+	// instructions) and the user-authored findings.
+	UserFindingsJSON *string
 	// SelectedFindingIDs, when non-nil, is a JSON array of finding IDs that
 	// were chosen (by the user or auto-fix filter) to be fixed AFTER this
 	// round. It is populated on the round whose findings triggered the next
@@ -43,8 +49,8 @@ func (d *DB) InsertStepRound(stepResultID string, round int, trigger string, fin
 		CreatedAt:    now(),
 	}
 	_, err := d.sql.Exec(
-		`INSERT INTO step_rounds (id, step_result_id, round, trigger_type, findings_json, selected_finding_ids, selection_source, fix_summary, duration_ms, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		r.ID, r.StepResultID, r.Round, r.Trigger, r.FindingsJSON, r.SelectedFindingIDs, r.SelectionSource, r.FixSummary, r.DurationMS, r.CreatedAt,
+		`INSERT INTO step_rounds (id, step_result_id, round, trigger_type, findings_json, user_findings_json, selected_finding_ids, selection_source, fix_summary, duration_ms, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		r.ID, r.StepResultID, r.Round, r.Trigger, r.FindingsJSON, r.UserFindingsJSON, r.SelectedFindingIDs, r.SelectionSource, r.FixSummary, r.DurationMS, r.CreatedAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("insert step round: %w", err)
@@ -76,10 +82,23 @@ func (d *DB) SetStepRoundSelectedFindingIDs(id string, selectedFindingIDs *strin
 	return d.SetStepRoundSelection(id, selectedFindingIDs, RoundSelectionSourceUser)
 }
 
+// SetStepRoundUserFindings records the merged finding list (with user
+// instructions attached and user-added findings appended) that was
+// dispatched to the fix agent for the round. Passing nil clears the column.
+func (d *DB) SetStepRoundUserFindings(id string, userFindingsJSON *string) error {
+	if _, err := d.sql.Exec(
+		`UPDATE step_rounds SET user_findings_json = ? WHERE id = ?`,
+		userFindingsJSON, id,
+	); err != nil {
+		return fmt.Errorf("set step round user findings: %w", err)
+	}
+	return nil
+}
+
 // GetRoundsByStep returns all rounds for a step result, ordered by round number.
 func (d *DB) GetRoundsByStep(stepResultID string) ([]*StepRound, error) {
 	rows, err := d.sql.Query(
-		`SELECT id, step_result_id, round, trigger_type, findings_json, selected_finding_ids, selection_source, fix_summary, duration_ms, created_at FROM step_rounds WHERE step_result_id = ? ORDER BY round`,
+		`SELECT id, step_result_id, round, trigger_type, findings_json, user_findings_json, selected_finding_ids, selection_source, fix_summary, duration_ms, created_at FROM step_rounds WHERE step_result_id = ? ORDER BY round`,
 		stepResultID,
 	)
 	if err != nil {
@@ -89,7 +108,7 @@ func (d *DB) GetRoundsByStep(stepResultID string) ([]*StepRound, error) {
 	var rounds []*StepRound
 	for rows.Next() {
 		r := &StepRound{}
-		if err := rows.Scan(&r.ID, &r.StepResultID, &r.Round, &r.Trigger, &r.FindingsJSON, &r.SelectedFindingIDs, &r.SelectionSource, &r.FixSummary, &r.DurationMS, &r.CreatedAt); err != nil {
+		if err := rows.Scan(&r.ID, &r.StepResultID, &r.Round, &r.Trigger, &r.FindingsJSON, &r.UserFindingsJSON, &r.SelectedFindingIDs, &r.SelectionSource, &r.FixSummary, &r.DurationMS, &r.CreatedAt); err != nil {
 			return nil, fmt.Errorf("scan step round: %w", err)
 		}
 		rounds = append(rounds, r)

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -43,6 +43,7 @@ CREATE TABLE IF NOT EXISTS step_rounds (
     round                INTEGER NOT NULL,
     trigger_type         TEXT NOT NULL,
     findings_json        TEXT,
+    user_findings_json   TEXT,
     selected_finding_ids TEXT,
     selection_source     TEXT,
     fix_summary          TEXT,
@@ -58,4 +59,5 @@ var migrationStatements = []string{
 	`ALTER TABLE step_rounds ADD COLUMN selected_finding_ids TEXT`,
 	`ALTER TABLE step_rounds ADD COLUMN selection_source TEXT`,
 	`ALTER TABLE step_rounds ADD COLUMN fix_summary TEXT`,
+	`ALTER TABLE step_rounds ADD COLUMN user_findings_json TEXT`,
 }

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -93,11 +93,19 @@ type SubscribeParams struct {
 }
 
 // RespondParams sends a user action for a step awaiting approval.
+//
+// Instructions carries optional per-finding notes keyed by finding ID, which
+// the daemon attaches to the corresponding finding before dispatching a fix.
+// AddedFindings carries user-authored findings that are merged into the round
+// alongside agent-produced ones. Both fields only apply when Action triggers
+// a fix round.
 type RespondParams struct {
-	RunID      string               `json:"run_id"`
-	Step       types.StepName       `json:"step"`
-	Action     types.ApprovalAction `json:"action"`
-	FindingIDs []string             `json:"finding_ids,omitempty"`
+	RunID         string               `json:"run_id"`
+	Step          types.StepName       `json:"step"`
+	Action        types.ApprovalAction `json:"action"`
+	FindingIDs    []string             `json:"finding_ids,omitempty"`
+	Instructions  map[string]string    `json:"instructions,omitempty"`
+	AddedFindings []types.Finding      `json:"added_findings,omitempty"`
 }
 
 // CancelRunParams cancels an active pipeline run.

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -24,8 +24,10 @@ import (
 type EventFunc func(ipc.Event)
 
 type approvalResponse struct {
-	action     types.ApprovalAction
-	findingIDs []string
+	action        types.ApprovalAction
+	findingIDs    []string
+	instructions  map[string]string
+	addedFindings []types.Finding
 }
 
 // Executor runs pipeline steps sequentially and coordinates approval interactions.
@@ -64,6 +66,13 @@ func NewExecutor(database *db.DB, p *paths.Paths, cfg *config.Config, ag agent.A
 // The step parameter must match the step currently awaiting approval.
 // Returns an error if no step is awaiting approval or if the step name doesn't match.
 func (e *Executor) Respond(step types.StepName, action types.ApprovalAction, findingIDs []string) error {
+	return e.RespondWithOverrides(step, action, findingIDs, nil, nil)
+}
+
+// RespondWithOverrides is like Respond but also carries per-finding user
+// instructions and user-authored findings. Both are merged into the round's
+// findings on a fix action before the fix agent runs.
+func (e *Executor) RespondWithOverrides(step types.StepName, action types.ApprovalAction, findingIDs []string, instructions map[string]string, addedFindings []types.Finding) error {
 	e.mu.Lock()
 	if !e.waiting {
 		e.mu.Unlock()
@@ -76,7 +85,12 @@ func (e *Executor) Respond(step types.StepName, action types.ApprovalAction, fin
 	e.waiting = false
 	e.mu.Unlock()
 
-	e.approvalCh <- approvalResponse{action: action, findingIDs: findingIDs}
+	e.approvalCh <- approvalResponse{
+		action:        action,
+		findingIDs:    findingIDs,
+		instructions:  instructions,
+		addedFindings: addedFindings,
+	}
 	return nil
 }
 
@@ -396,12 +410,20 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFixing), "", "", "", nil)
 			sctx.Fixing = true
 			selectedFindings := filterFindingsJSON(outcome.Findings, response.findingIDs)
-			sctx.PreviousFindings = selectedFindings
+			mergedFindings := mergeUserOverridesJSON(selectedFindings, response.instructions, response.addedFindings)
+			sctx.PreviousFindings = mergedFindings
 			nextTrigger = "auto_fix"
 			if currentRoundID != "" {
-				if idsJSON := marshalFindingIDs(response.findingIDs); idsJSON != "" {
+				allSelectedIDs := combineSelectedFindingIDs(response.findingIDs, mergedFindings)
+				if idsJSON := marshalFindingIDs(allSelectedIDs); idsJSON != "" {
 					if dbErr := e.db.SetStepRoundSelection(currentRoundID, &idsJSON, db.RoundSelectionSourceUser); dbErr != nil {
 						slog.Warn("failed to record selected finding ids", "step", stepName, "round", roundNum, "error", dbErr)
+					}
+				}
+				if mergedFindings != "" && mergedFindings != selectedFindings {
+					merged := mergedFindings
+					if dbErr := e.db.SetStepRoundUserFindings(currentRoundID, &merged); dbErr != nil {
+						slog.Warn("failed to record user findings", "step", stepName, "round", roundNum, "error", dbErr)
 					}
 				}
 			}

--- a/internal/pipeline/executor_fix_test.go
+++ b/internal/pipeline/executor_fix_test.go
@@ -229,12 +229,15 @@ func TestExecutor_FixSetsPreviousFindings(t *testing.T) {
 		t.Fatal("executor timed out")
 	}
 
-	items := mustParseFindingItems(t, capturedFindings)
-	if len(items) != 1 {
-		t.Fatalf("expected 1 finding, got %d", len(items))
+	payload, err := types.ParseFindingsJSON(capturedFindings)
+	if err != nil {
+		t.Fatalf("parse PreviousFindings: %v", err)
 	}
-	if items[0].ID != "review-1" || items[0].Description != "nil pointer dereference" {
-		t.Errorf("unexpected PreviousFindings: %#v", items)
+	if len(payload.Items) != 0 {
+		t.Fatalf("expected 0 findings, got %d", len(payload.Items))
+	}
+	if payload.Summary != "0 selected findings" {
+		t.Fatalf("summary = %q, want %q", payload.Summary, "0 selected findings")
 	}
 }
 

--- a/internal/pipeline/executor_fix_test.go
+++ b/internal/pipeline/executor_fix_test.go
@@ -296,6 +296,101 @@ func TestExecutor_AssignsFindingIDsBeforePersistingAndEmitting(t *testing.T) {
 	<-done
 }
 
+func TestExecutor_FixAppliesUserInstructionsAndAddedFindings(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	var capturedFindings string
+	callCount := 0
+	step := &adaptiveCallStep{
+		name: types.StepReview,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			callCount++
+			if callCount == 1 {
+				return &StepOutcome{
+					NeedsApproval: true,
+					Findings:      `{"findings":[{"id":"review-1","severity":"error","description":"first","action":"auto-fix"},{"id":"review-2","severity":"warning","description":"second","action":"auto-fix"}],"summary":"2 findings"}`,
+				}, nil
+			}
+			capturedFindings = sctx.PreviousFindings
+			return &StepOutcome{}, nil
+		},
+	}
+
+	exec := NewExecutor(database, p, nil, nil, []Step{step}, nil)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- exec.Execute(context.Background(), run, repo, workDir)
+	}()
+
+	waitForStepStatus(t, database, run.ID, types.StepReview, types.StepStatusAwaitingApproval)
+	instructions := map[string]string{"review-1": "only touch parser.go, skip helpers"}
+	added := []types.Finding{{Severity: "warning", Description: "also audit logger init", Action: types.ActionAutoFix}}
+	if err := exec.RespondWithOverrides(types.StepReview, types.ActionFix, []string{"review-1"}, instructions, added); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("executor timed out")
+	}
+
+	items := mustParseFindingItems(t, capturedFindings)
+	if len(items) != 2 {
+		t.Fatalf("expected 2 findings (selected + user-added), got %d: %s", len(items), capturedFindings)
+	}
+	if items[0].ID != "review-1" {
+		t.Errorf("expected selected agent finding first, got %q", items[0].ID)
+	}
+	if items[0].UserInstructions != "only touch parser.go, skip helpers" {
+		t.Errorf("expected instruction attached to review-1, got %q", items[0].UserInstructions)
+	}
+	if items[1].ID != "user-1" {
+		t.Errorf("expected user-added finding to get ID user-1, got %q", items[1].ID)
+	}
+	if items[1].Source != types.FindingSourceUser {
+		t.Errorf("expected user-added finding to be tagged source=user, got %q", items[1].Source)
+	}
+
+	rounds, err := database.GetRoundsByStep(firstStepID(t, database, run.ID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rounds) == 0 {
+		t.Fatal("expected at least one round")
+	}
+	round := rounds[0]
+	if round.UserFindingsJSON == nil {
+		t.Fatal("expected user_findings_json to be persisted on the selection round")
+	}
+	if !strings.Contains(*round.UserFindingsJSON, "audit logger init") {
+		t.Errorf("expected user findings payload to include user-added description, got %s", *round.UserFindingsJSON)
+	}
+	if round.SelectedFindingIDs == nil {
+		t.Fatal("expected selected_finding_ids to be set")
+	}
+	if !strings.Contains(*round.SelectedFindingIDs, "user-1") {
+		t.Errorf("expected user-added finding id in selected list, got %s", *round.SelectedFindingIDs)
+	}
+}
+
+func firstStepID(t *testing.T, database *db.DB, runID string) string {
+	t.Helper()
+	steps, err := database.GetStepsByRun(runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(steps) == 0 {
+		t.Fatal("no steps persisted")
+	}
+	return steps[0].ID
+}
+
 func TestExecutor_FixUsesSelectedFindingIDsOnly(t *testing.T) {
 	database, p, run, repo := setupTest(t)
 	workDir := t.TempDir()

--- a/internal/pipeline/findings.go
+++ b/internal/pipeline/findings.go
@@ -298,7 +298,7 @@ func mergeUserOverridesJSON(raw string, instructions map[string]string, added []
 }
 
 func filterFindingsJSON(raw string, ids []string) string {
-	if raw == "" || len(ids) == 0 {
+	if raw == "" {
 		return raw
 	}
 	findings, err := types.ParseFindingsJSON(raw)
@@ -306,6 +306,15 @@ func filterFindingsJSON(raw string, ids []string) string {
 		return raw
 	}
 	filtered := types.FilterFindings(findings, ids)
+	if len(ids) == 0 {
+		filtered = types.Findings{
+			Summary:        "0 selected findings",
+			Tested:         findings.Tested,
+			TestingSummary: findings.TestingSummary,
+			RiskLevel:      findings.RiskLevel,
+			RiskRationale:  findings.RiskRationale,
+		}
+	}
 	filteredRaw, err := types.MarshalFindingsJSON(filtered)
 	if err != nil {
 		return raw

--- a/internal/pipeline/findings.go
+++ b/internal/pipeline/findings.go
@@ -43,6 +43,8 @@ func marshalFindingIDs(ids []string) string {
 func findingKey(item types.Finding) types.Finding {
 	item.ID = ""
 	item.Action = ""
+	item.Source = ""
+	item.UserInstructions = ""
 	return item
 }
 
@@ -245,6 +247,54 @@ func hasAskUserFindingsJSON(raw string) bool {
 		return false
 	}
 	return types.HasAskUserFindings(findings)
+}
+
+// combineSelectedFindingIDs returns the ordered list of finding IDs that
+// were dispatched to the fix agent: the user's selected agent-produced
+// IDs plus any user-authored finding IDs (which only appear in the merged
+// list).
+func combineSelectedFindingIDs(selected []string, mergedFindings string) []string {
+	if mergedFindings == "" {
+		return selected
+	}
+	merged, err := types.ParseFindingsJSON(mergedFindings)
+	if err != nil {
+		return selected
+	}
+	seen := make(map[string]bool, len(selected))
+	for _, id := range selected {
+		if id != "" {
+			seen[id] = true
+		}
+	}
+	result := append([]string(nil), selected...)
+	for _, item := range merged.Items {
+		if item.ID == "" || seen[item.ID] {
+			continue
+		}
+		result = append(result, item.ID)
+		seen[item.ID] = true
+	}
+	return result
+}
+
+// mergeUserOverridesJSON takes a findings JSON payload and applies
+// per-finding user instructions and user-authored findings. When no
+// overrides are present the input is returned unchanged.
+func mergeUserOverridesJSON(raw string, instructions map[string]string, added []types.Finding) string {
+	if len(instructions) == 0 && len(added) == 0 {
+		return raw
+	}
+	base, err := types.ParseFindingsJSON(raw)
+	if err != nil {
+		base = types.Findings{}
+	}
+	merged := types.MergeUserOverrides(base, instructions, added)
+	encoded, err := types.MarshalFindingsJSON(merged)
+	if err != nil {
+		return raw
+	}
+	return encoded
 }
 
 func filterFindingsJSON(raw string, ids []string) string {

--- a/internal/pipeline/findings_test.go
+++ b/internal/pipeline/findings_test.go
@@ -130,3 +130,19 @@ func TestMergeFindingsJSON_DeduplicatesShiftedUniqueDismissedFinding(t *testing.
 		t.Fatalf("unexpected merged findings: %#v", merged.Items)
 	}
 }
+
+func TestFilterFindingsJSON_EmptySelectionReturnsEmptyFindings(t *testing.T) {
+	raw := `{"findings":[{"id":"review-1","severity":"error","description":"first"}],"summary":"1 finding"}`
+
+	filteredRaw := filterFindingsJSON(raw, nil)
+	filtered, err := types.ParseFindingsJSON(filteredRaw)
+	if err != nil {
+		t.Fatalf("parse filtered findings: %v", err)
+	}
+	if len(filtered.Items) != 0 {
+		t.Fatalf("expected 0 findings, got %d", len(filtered.Items))
+	}
+	if filtered.Summary != "0 selected findings" {
+		t.Fatalf("summary = %q, want %q", filtered.Summary, "0 selected findings")
+	}
+}

--- a/internal/pipeline/helpers_test.go
+++ b/internal/pipeline/helpers_test.go
@@ -215,9 +215,11 @@ func dirExists(path string) bool {
 }
 
 type findingJSON struct {
-	ID          string `json:"id"`
-	Severity    string `json:"severity"`
-	Description string `json:"description"`
+	ID               string `json:"id"`
+	Severity         string `json:"severity"`
+	Description      string `json:"description"`
+	Source           string `json:"source"`
+	UserInstructions string `json:"user_instructions"`
 }
 
 func mustParseFindingItems(t *testing.T, raw string) []findingJSON {

--- a/internal/pipeline/steps/common_test.go
+++ b/internal/pipeline/steps/common_test.go
@@ -902,3 +902,40 @@ func TestSanitizedPreviousFindingsForPrompt_PreservesMultilineDescriptions(t *te
 		t.Fatalf("expected multiline risk rationale to be preserved, got %q", findings.RiskRationale)
 	}
 }
+
+func TestSanitizedPreviousFindingsForPrompt_PreservesSourceAndInstructions(t *testing.T) {
+	t.Parallel()
+	raw, err := types.MarshalFindingsJSON(types.Findings{
+		Items: []types.Finding{
+			{
+				ID:               "review-1",
+				Severity:         "error",
+				File:             "internal/pipeline/steps/review.go",
+				Description:      "missing nil check",
+				Action:           types.ActionAutoFix,
+				UserInstructions: "only touch parser.go",
+			},
+			{
+				ID:          "user-1",
+				Severity:    "warning",
+				Description: "also audit logger init",
+				Action:      types.ActionAutoFix,
+				Source:      types.FindingSourceUser,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sanitized := sanitizedPreviousFindingsForPrompt(raw)
+	findings, err := types.ParseFindingsJSON(sanitized)
+	if err != nil {
+		t.Fatalf("ParseFindingsJSON() error = %v", err)
+	}
+	if findings.Items[0].UserInstructions != "only touch parser.go" {
+		t.Errorf("expected UserInstructions preserved, got %q", findings.Items[0].UserInstructions)
+	}
+	if findings.Items[1].Source != types.FindingSourceUser {
+		t.Errorf("expected Source %q, got %q", types.FindingSourceUser, findings.Items[1].Source)
+	}
+}

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -217,6 +217,8 @@ func sanitizedPreviousFindingsForPrompt(raw string) string {
 		findings.Items[i].Severity = sanitizePromptText(findings.Items[i].Severity)
 		findings.Items[i].File = sanitizePromptText(findings.Items[i].File)
 		findings.Items[i].Description = sanitizePromptMultilineText(findings.Items[i].Description)
+		findings.Items[i].Source = sanitizePromptText(findings.Items[i].Source)
+		findings.Items[i].UserInstructions = sanitizePromptMultilineText(findings.Items[i].UserInstructions)
 	}
 	findings.Summary = sanitizePromptMultilineText(findings.Summary)
 	findings.RiskLevel = sanitizePromptText(findings.RiskLevel)

--- a/internal/pipeline/steps/round_history.go
+++ b/internal/pipeline/steps/round_history.go
@@ -123,19 +123,23 @@ func parseRoundFindingLines(raw string) []roundFindingLine {
 	lines := make([]roundFindingLine, 0, len(findings.Items))
 	for _, item := range findings.Items {
 		payload := struct {
-			ID          string `json:"id,omitempty"`
-			Severity    string `json:"severity,omitempty"`
-			File        string `json:"file,omitempty"`
-			Line        int    `json:"line,omitempty"`
-			Description string `json:"description,omitempty"`
-			Action      string `json:"action,omitempty"`
+			ID               string `json:"id,omitempty"`
+			Severity         string `json:"severity,omitempty"`
+			File             string `json:"file,omitempty"`
+			Line             int    `json:"line,omitempty"`
+			Description      string `json:"description,omitempty"`
+			Action           string `json:"action,omitempty"`
+			Source           string `json:"source,omitempty"`
+			UserInstructions string `json:"user_instructions,omitempty"`
 		}{
-			ID:          sanitizePromptText(item.ID),
-			Severity:    sanitizePromptText(item.Severity),
-			File:        sanitizePromptText(item.File),
-			Line:        item.Line,
-			Description: sanitizePromptMultilineText(item.Description),
-			Action:      sanitizePromptText(item.Action),
+			ID:               sanitizePromptText(item.ID),
+			Severity:         sanitizePromptText(item.Severity),
+			File:             sanitizePromptText(item.File),
+			Line:             item.Line,
+			Description:      sanitizePromptMultilineText(item.Description),
+			Action:           sanitizePromptText(item.Action),
+			Source:           sanitizePromptText(item.Source),
+			UserInstructions: sanitizePromptMultilineText(item.UserInstructions),
 		}
 		encoded, err := json.Marshal(payload)
 		if err != nil {

--- a/internal/pipeline/steps/round_history.go
+++ b/internal/pipeline/steps/round_history.go
@@ -60,7 +60,7 @@ func renderRoundHistoryEntry(r *db.StepRound) string {
 		}
 	}
 
-	selected, unselected := partitionRoundFindings(r.FindingsJSON, r.SelectedFindingIDs)
+	selected, unselected := partitionRoundFindings(r.FindingsJSON, r.UserFindingsJSON, r.SelectedFindingIDs)
 
 	if r.FindingsJSON != nil && strings.TrimSpace(*r.FindingsJSON) != "" {
 		if items := renderRoundFindingLines(*r.FindingsJSON); len(items) > 0 {
@@ -155,11 +155,15 @@ func parseRoundFindingLines(raw string) []roundFindingLine {
 // was chosen. A nil return for either side indicates the information is
 // unavailable, so the caller can omit the line entirely rather than emit a
 // misleading empty set.
-func partitionRoundFindings(findingsJSON *string, selectedJSON *string) (selected []string, unselected []string) {
+func partitionRoundFindings(findingsJSON *string, userFindingsJSON *string, selectedJSON *string) (selected []string, unselected []string) {
 	if findingsJSON == nil || strings.TrimSpace(*findingsJSON) == "" {
 		return nil, nil
 	}
 	allFindings := parseRoundFindingLines(*findingsJSON)
+	selectedFindings := allFindings
+	if userFindingsJSON != nil && strings.TrimSpace(*userFindingsJSON) != "" {
+		selectedFindings = parseRoundFindingLines(*userFindingsJSON)
+	}
 
 	if selectedJSON == nil {
 		return nil, nil
@@ -179,13 +183,17 @@ func partitionRoundFindings(findingsJSON *string, selectedJSON *string) (selecte
 	selected = make([]string, 0, len(selectedSet))
 	unselected = make([]string, 0, len(allFindings))
 	selectedSeen := make(map[string]bool, len(selectedSet))
-	for _, item := range allFindings {
+	for _, item := range selectedFindings {
 		if item.ID != "" && selectedSet[item.ID] {
 			selected = append(selected, item.Line)
 			selectedSeen[item.ID] = true
-		} else {
-			unselected = append(unselected, item.Line)
 		}
+	}
+	for _, item := range allFindings {
+		if item.ID != "" && selectedSet[item.ID] {
+			continue
+		}
+		unselected = append(unselected, item.Line)
 	}
 	for id := range selectedSet {
 		if !selectedSeen[id] {

--- a/internal/pipeline/steps/round_history_test.go
+++ b/internal/pipeline/steps/round_history_test.go
@@ -125,8 +125,17 @@ func TestRoundHistoryPromptSection_DoesNotTreatAutoFixFilteringAsUserIgnore(t *t
 
 func TestRoundHistoryPromptSection_IncludesSourceAndUserInstructions(t *testing.T) {
 	sctx, stepID := newRoundHistoryContext(t)
-	round1 := `{"findings":[{"id":"review-1","severity":"error","description":"panic risk","action":"auto-fix","user_instructions":"only in parser.go"},{"id":"user-1","severity":"warning","description":"audit logger","action":"auto-fix","source":"user"}],"summary":"2"}`
-	if _, err := sctx.DB.InsertStepRound(stepID, 1, "initial", &round1, nil, 100); err != nil {
+	round1 := `{"findings":[{"id":"review-1","severity":"error","description":"panic risk","action":"auto-fix"},{"id":"review-2","severity":"warning","description":"secondary","action":"auto-fix"}],"summary":"2"}`
+	r1, err := sctx.DB.InsertStepRound(stepID, 1, "initial", &round1, nil, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	selected := `["review-1","user-1"]`
+	if err := sctx.DB.SetStepRoundSelection(r1.ID, &selected, db.RoundSelectionSourceUser); err != nil {
+		t.Fatal(err)
+	}
+	userFindings := `{"findings":[{"id":"review-1","severity":"error","description":"panic risk","action":"auto-fix","user_instructions":"only in parser.go"},{"id":"user-1","severity":"info","description":"audit logger","action":"auto-fix","source":"user"}],"summary":"2"}`
+	if err := sctx.DB.SetStepRoundUserFindings(r1.ID, &userFindings); err != nil {
 		t.Fatal(err)
 	}
 	got := roundHistoryPromptSection(sctx)
@@ -135,6 +144,9 @@ func TestRoundHistoryPromptSection_IncludesSourceAndUserInstructions(t *testing.
 	}
 	if !strings.Contains(got, `"source":"user"`) {
 		t.Errorf("expected source in round history, got:\n%s", got)
+	}
+	if !strings.Contains(got, `user_chose_to_ignore:`) || !strings.Contains(got, `"id":"review-2"`) {
+		t.Errorf("expected unselected agent findings to remain visible, got:\n%s", got)
 	}
 }
 

--- a/internal/pipeline/steps/round_history_test.go
+++ b/internal/pipeline/steps/round_history_test.go
@@ -123,6 +123,21 @@ func TestRoundHistoryPromptSection_DoesNotTreatAutoFixFilteringAsUserIgnore(t *t
 	}
 }
 
+func TestRoundHistoryPromptSection_IncludesSourceAndUserInstructions(t *testing.T) {
+	sctx, stepID := newRoundHistoryContext(t)
+	round1 := `{"findings":[{"id":"review-1","severity":"error","description":"panic risk","action":"auto-fix","user_instructions":"only in parser.go"},{"id":"user-1","severity":"warning","description":"audit logger","action":"auto-fix","source":"user"}],"summary":"2"}`
+	if _, err := sctx.DB.InsertStepRound(stepID, 1, "initial", &round1, nil, 100); err != nil {
+		t.Fatal(err)
+	}
+	got := roundHistoryPromptSection(sctx)
+	if !strings.Contains(got, `"user_instructions":"only in parser.go"`) {
+		t.Errorf("expected user_instructions in round history, got:\n%s", got)
+	}
+	if !strings.Contains(got, `"source":"user"`) {
+		t.Errorf("expected source in round history, got:\n%s", got)
+	}
+}
+
 func TestRoundHistoryPromptSection_SanitizesInjectionAttempts(t *testing.T) {
 	sctx, stepID := newRoundHistoryContext(t)
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -19,14 +19,17 @@ type Model struct {
 	subscriptionID uint64
 
 	// State.
-	run               *ipc.RunInfo
-	steps             []ipc.StepResultInfo
-	stepFindings      map[types.StepName]string          // step name → raw findings JSON
-	stepDiffs         map[types.StepName]string          // step name → raw unified diff
-	findingSelections map[types.StepName]map[string]bool // step name → finding ID → selected
-	findingCursor     map[types.StepName]int             // step name → current finding cursor
-	logs              []string
-	logPartial        string // buffered partial line (no trailing newline yet)
+	run                 *ipc.RunInfo
+	steps               []ipc.StepResultInfo
+	stepFindings        map[types.StepName]string            // step name → raw findings JSON
+	stepDiffs           map[types.StepName]string            // step name → raw unified diff
+	findingSelections   map[types.StepName]map[string]bool   // step name → finding ID → selected
+	findingCursor       map[types.StepName]int               // step name → current finding cursor
+	findingInstructions map[types.StepName]map[string]string // step name → finding ID → user note
+	addedFindings       map[types.StepName][]types.Finding   // user-authored findings per step
+	editor              *editorState                         // active modal editor (nil when none)
+	logs                []string
+	logPartial          string // buffered partial line (no trailing newline yet)
 
 	// Timing.
 	stepStartTimes map[types.StepName]time.Time // when each step started running
@@ -56,19 +59,21 @@ func NewModel(socketPath string, client *ipc.Client, run *ipc.RunInfo) Model {
 	steps := normalizePipelineSteps(run.ID, run.Status, run.Steps)
 	run.Steps = steps
 	m := Model{
-		socketPath:        socketPath,
-		client:            client,
-		runID:             run.ID,
-		subscriptionID:    1,
-		run:               run,
-		done:              run.Status == types.RunCompleted || run.Status == types.RunFailed || run.Status == types.RunCancelled,
-		steps:             steps,
-		stepFindings:      make(map[types.StepName]string),
-		stepDiffs:         make(map[types.StepName]string),
-		findingSelections: make(map[types.StepName]map[string]bool),
-		findingCursor:     make(map[types.StepName]int),
-		stepStartTimes:    make(map[types.StepName]time.Time),
-		syntheticSteps:    syntheticSteps,
+		socketPath:          socketPath,
+		client:              client,
+		runID:               run.ID,
+		subscriptionID:      1,
+		run:                 run,
+		done:                run.Status == types.RunCompleted || run.Status == types.RunFailed || run.Status == types.RunCancelled,
+		steps:               steps,
+		stepFindings:        make(map[types.StepName]string),
+		stepDiffs:           make(map[types.StepName]string),
+		findingSelections:   make(map[types.StepName]map[string]bool),
+		findingCursor:       make(map[types.StepName]int),
+		findingInstructions: make(map[types.StepName]map[string]string),
+		addedFindings:       make(map[types.StepName][]types.Finding),
+		stepStartTimes:      make(map[types.StepName]time.Time),
+		syntheticSteps:      syntheticSteps,
 	}
 	// Populate findings and start times from initial step data (for re-attach scenarios).
 	for _, s := range steps {

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -80,7 +80,8 @@ func (m Model) respondCmd(action types.ApprovalAction) tea.Cmd {
 	}
 	if action == types.ActionFix {
 		ids := m.selectedFindingIDs(step.StepName)
-		if len(ids) == 0 && len(m.findingItems(step.StepName)) > 0 {
+		userAdded := m.selectedUserAddedFindings(step.StepName)
+		if len(ids) == 0 && len(userAdded) == 0 && len(m.findingItems(step.StepName)) > 0 {
 			return nil
 		}
 	}
@@ -94,6 +95,20 @@ func (m Model) respondCmd(action types.ApprovalAction) tea.Cmd {
 			ids := m.selectedFindingIDs(step.StepName)
 			if len(ids) > 0 {
 				params.FindingIDs = ids
+				if byStep := m.findingInstructions[step.StepName]; len(byStep) > 0 {
+					filtered := make(map[string]string, len(byStep))
+					for _, id := range ids {
+						if note, ok := byStep[id]; ok && note != "" {
+							filtered[id] = note
+						}
+					}
+					if len(filtered) > 0 {
+						params.Instructions = filtered
+					}
+				}
+			}
+			if added := m.selectedUserAddedFindings(step.StepName); len(added) > 0 {
+				params.AddedFindings = append([]types.Finding(nil), added...)
 			}
 		}
 		var result ipc.RespondResult

--- a/internal/tui/editors.go
+++ b/internal/tui/editors.go
@@ -2,11 +2,9 @@ package tui
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textarea"
-	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/kunchenguid/no-mistakes/internal/types"
@@ -25,15 +23,10 @@ const (
 type addFindingField int
 
 const (
-	addFieldSeverity addFindingField = iota
-	addFieldFile
-	addFieldLine
-	addFieldDescription
+	addFieldDescription addFindingField = iota
 	addFieldInstruction
 	addFieldCount
 )
-
-var addFindingSeverities = []string{"error", "warning", "info"}
 
 // editorState holds in-progress state for the currently open modal editor.
 // Only one editor is active at a time; m.editor is nil when none is open.
@@ -47,12 +40,9 @@ type editorState struct {
 	instruction textarea.Model
 
 	// add-finding editor fields
-	addSeverityIdx int
-	addFile        textinput.Model
-	addLine        textinput.Model
-	addDesc        textarea.Model
-	addInstr       textarea.Model
-	addFocus       addFindingField
+	addDesc  textarea.Model
+	addInstr textarea.Model
+	addFocus addFindingField
 }
 
 func newInstructionEditor(step types.StepName, findingID, existing string) *editorState {
@@ -73,31 +63,13 @@ func newInstructionEditor(step types.StepName, findingID, existing string) *edit
 }
 
 func newAddFindingEditor(step types.StepName) *editorState {
-	file := textinput.New()
-	file.Placeholder = "file (optional, e.g. internal/foo/bar.go)"
-	file.CharLimit = 500
-	file.Width = 70
-
-	line := textinput.New()
-	line.Placeholder = "line (optional)"
-	line.CharLimit = 10
-	line.Width = 12
-	line.Validate = func(s string) error {
-		if s == "" {
-			return nil
-		}
-		if _, err := strconv.Atoi(s); err != nil {
-			return fmt.Errorf("must be a number")
-		}
-		return nil
-	}
-
 	desc := textarea.New()
 	desc.Placeholder = "what's the issue (required)..."
 	desc.ShowLineNumbers = false
 	desc.CharLimit = 4000
 	desc.SetHeight(3)
 	desc.SetWidth(72)
+	desc.Focus()
 
 	instr := textarea.New()
 	instr.Placeholder = "extra guidance for the fix agent (optional)..."
@@ -109,11 +81,9 @@ func newAddFindingEditor(step types.StepName) *editorState {
 	e := &editorState{
 		kind:     editorAddFinding,
 		step:     step,
-		addFile:  file,
-		addLine:  line,
 		addDesc:  desc,
 		addInstr: instr,
-		addFocus: addFieldSeverity,
+		addFocus: addFieldDescription,
 	}
 	return e
 }
@@ -161,6 +131,10 @@ func (m *Model) saveInstruction() {
 	step := m.editor.step
 	id := m.editor.findingID
 	text := strings.TrimSpace(m.editor.instruction.Value())
+	if m.updateUserFindingInstruction(step, id, text) {
+		m.editor = nil
+		return
+	}
 	if m.findingInstructions == nil {
 		m.findingInstructions = make(map[types.StepName]map[string]string)
 	}
@@ -200,28 +174,8 @@ func (m Model) updateAddFindingEditor(msg tea.KeyMsg) (Model, tea.Cmd) {
 		return m, nil
 	}
 
-	if m.editor.addFocus == addFieldSeverity {
-		switch key {
-		case "left", "h":
-			if m.editor.addSeverityIdx > 0 {
-				m.editor.addSeverityIdx--
-			}
-			return m, nil
-		case "right", "l":
-			if m.editor.addSeverityIdx < len(addFindingSeverities)-1 {
-				m.editor.addSeverityIdx++
-			}
-			return m, nil
-		}
-		return m, nil
-	}
-
 	var cmd tea.Cmd
 	switch m.editor.addFocus {
-	case addFieldFile:
-		m.editor.addFile, cmd = m.editor.addFile.Update(msg)
-	case addFieldLine:
-		m.editor.addLine, cmd = m.editor.addLine.Update(msg)
 	case addFieldDescription:
 		m.editor.addDesc, cmd = m.editor.addDesc.Update(msg)
 	case addFieldInstruction:
@@ -231,15 +185,9 @@ func (m Model) updateAddFindingEditor(msg tea.KeyMsg) (Model, tea.Cmd) {
 }
 
 func (m *Model) applyAddFindingFocus() {
-	m.editor.addFile.Blur()
-	m.editor.addLine.Blur()
 	m.editor.addDesc.Blur()
 	m.editor.addInstr.Blur()
 	switch m.editor.addFocus {
-	case addFieldFile:
-		m.editor.addFile.Focus()
-	case addFieldLine:
-		m.editor.addLine.Focus()
 	case addFieldDescription:
 		m.editor.addDesc.Focus()
 	case addFieldInstruction:
@@ -255,18 +203,8 @@ func (m *Model) saveAddFinding() error {
 	if desc == "" {
 		return fmt.Errorf("description is required")
 	}
-	line := 0
-	if raw := strings.TrimSpace(m.editor.addLine.Value()); raw != "" {
-		n, err := strconv.Atoi(raw)
-		if err != nil {
-			return fmt.Errorf("line must be a number")
-		}
-		line = n
-	}
 	f := types.Finding{
-		Severity:         addFindingSeverities[m.editor.addSeverityIdx],
-		File:             strings.TrimSpace(m.editor.addFile.Value()),
-		Line:             line,
+		Severity:         "info",
 		Description:      desc,
 		Action:           types.ActionAutoFix,
 		Source:           types.FindingSourceUser,
@@ -327,6 +265,19 @@ func (m *Model) removeUserFinding(step types.StepName, id string) bool {
 			}
 			return true
 		}
+	}
+	return false
+}
+
+func (m *Model) updateUserFindingInstruction(step types.StepName, id, text string) bool {
+	items := m.addedFindings[step]
+	for i := range items {
+		if items[i].ID != id {
+			continue
+		}
+		items[i].UserInstructions = text
+		m.addedFindings[step] = items
+		return true
 	}
 	return false
 }
@@ -396,7 +347,6 @@ func (m Model) renderAddFindingEditor(width int) string {
 	if contentWidth < 20 {
 		contentWidth = 20
 	}
-	m.editor.addFile.Width = contentWidth - 2
 	m.editor.addDesc.SetWidth(contentWidth)
 	m.editor.addInstr.SetWidth(contentWidth)
 
@@ -412,33 +362,7 @@ func (m Model) renderAddFindingEditor(width int) string {
 		return labelStyle.Render("  " + text)
 	}
 
-	// Severity row
-	sevRow := ""
-	for i, name := range addFindingSeverities {
-		marker := "  "
-		style := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
-		if i == m.editor.addSeverityIdx {
-			marker = "● "
-			style = severityStyle(name).Bold(true)
-		} else {
-			marker = "○ "
-		}
-		sevRow += style.Render(marker+name) + "  "
-	}
-
 	var body strings.Builder
-	body.WriteString(label(addFieldSeverity, "Severity"))
-	body.WriteString("\n  ")
-	body.WriteString(sevRow)
-	body.WriteString("\n\n")
-	body.WriteString(label(addFieldFile, "File"))
-	body.WriteString("\n")
-	body.WriteString("  " + m.editor.addFile.View())
-	body.WriteString("\n\n")
-	body.WriteString(label(addFieldLine, "Line"))
-	body.WriteString("\n")
-	body.WriteString("  " + m.editor.addLine.View())
-	body.WriteString("\n\n")
 	body.WriteString(label(addFieldDescription, "Description"))
 	body.WriteString("\n")
 	body.WriteString(m.editor.addDesc.View())

--- a/internal/tui/editors.go
+++ b/internal/tui/editors.go
@@ -1,0 +1,459 @@
+package tui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textarea"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// editorKind identifies which modal editor is currently active.
+type editorKind int
+
+const (
+	editorNone editorKind = iota
+	editorInstruction
+	editorAddFinding
+)
+
+// addFindingField identifies the currently focused input in the add-finding modal.
+type addFindingField int
+
+const (
+	addFieldSeverity addFindingField = iota
+	addFieldFile
+	addFieldLine
+	addFieldDescription
+	addFieldInstruction
+	addFieldCount
+)
+
+var addFindingSeverities = []string{"error", "warning", "info"}
+
+// editorState holds in-progress state for the currently open modal editor.
+// Only one editor is active at a time; m.editor is nil when none is open.
+type editorState struct {
+	kind     editorKind
+	step     types.StepName
+	errorMsg string
+
+	// instruction editor fields
+	findingID   string
+	instruction textarea.Model
+
+	// add-finding editor fields
+	addSeverityIdx int
+	addFile        textinput.Model
+	addLine        textinput.Model
+	addDesc        textarea.Model
+	addInstr       textarea.Model
+	addFocus       addFindingField
+}
+
+func newInstructionEditor(step types.StepName, findingID, existing string) *editorState {
+	ta := textarea.New()
+	ta.Placeholder = "extra guidance for the fix agent (optional)..."
+	ta.SetValue(existing)
+	ta.ShowLineNumbers = false
+	ta.CharLimit = 2000
+	ta.SetHeight(5)
+	ta.SetWidth(72)
+	ta.Focus()
+	return &editorState{
+		kind:        editorInstruction,
+		step:        step,
+		findingID:   findingID,
+		instruction: ta,
+	}
+}
+
+func newAddFindingEditor(step types.StepName) *editorState {
+	file := textinput.New()
+	file.Placeholder = "file (optional, e.g. internal/foo/bar.go)"
+	file.CharLimit = 500
+	file.Width = 70
+
+	line := textinput.New()
+	line.Placeholder = "line (optional)"
+	line.CharLimit = 10
+	line.Width = 12
+	line.Validate = func(s string) error {
+		if s == "" {
+			return nil
+		}
+		if _, err := strconv.Atoi(s); err != nil {
+			return fmt.Errorf("must be a number")
+		}
+		return nil
+	}
+
+	desc := textarea.New()
+	desc.Placeholder = "what's the issue (required)..."
+	desc.ShowLineNumbers = false
+	desc.CharLimit = 4000
+	desc.SetHeight(3)
+	desc.SetWidth(72)
+
+	instr := textarea.New()
+	instr.Placeholder = "extra guidance for the fix agent (optional)..."
+	instr.ShowLineNumbers = false
+	instr.CharLimit = 2000
+	instr.SetHeight(3)
+	instr.SetWidth(72)
+
+	e := &editorState{
+		kind:     editorAddFinding,
+		step:     step,
+		addFile:  file,
+		addLine:  line,
+		addDesc:  desc,
+		addInstr: instr,
+		addFocus: addFieldSeverity,
+	}
+	return e
+}
+
+// isActive reports whether an editor modal is currently open.
+func (m Model) editorActive() bool { return m.editor != nil && m.editor.kind != editorNone }
+
+// updateEditor routes a key event to the active editor. It returns the
+// possibly-updated model plus any tea.Cmd produced by the underlying
+// bubble components. When the editor consumes the key (anything that is
+// not an escape/save shortcut) the caller should not fall through to the
+// app-level key handling.
+func (m Model) updateEditor(msg tea.KeyMsg) (Model, tea.Cmd) {
+	if m.editor == nil {
+		return m, nil
+	}
+	switch m.editor.kind {
+	case editorInstruction:
+		return m.updateInstructionEditor(msg)
+	case editorAddFinding:
+		return m.updateAddFindingEditor(msg)
+	}
+	return m, nil
+}
+
+func (m Model) updateInstructionEditor(msg tea.KeyMsg) (Model, tea.Cmd) {
+	key := msg.String()
+	switch key {
+	case "esc":
+		m.editor = nil
+		return m, nil
+	case "ctrl+s", "ctrl+enter":
+		m.saveInstruction()
+		return m, nil
+	}
+	var cmd tea.Cmd
+	m.editor.instruction, cmd = m.editor.instruction.Update(msg)
+	return m, cmd
+}
+
+func (m *Model) saveInstruction() {
+	if m.editor == nil || m.editor.kind != editorInstruction {
+		return
+	}
+	step := m.editor.step
+	id := m.editor.findingID
+	text := strings.TrimSpace(m.editor.instruction.Value())
+	if m.findingInstructions == nil {
+		m.findingInstructions = make(map[types.StepName]map[string]string)
+	}
+	if m.findingInstructions[step] == nil {
+		m.findingInstructions[step] = make(map[string]string)
+	}
+	if text == "" {
+		delete(m.findingInstructions[step], id)
+		if len(m.findingInstructions[step]) == 0 {
+			delete(m.findingInstructions, step)
+		}
+	} else {
+		m.findingInstructions[step][id] = text
+	}
+	m.editor = nil
+}
+
+func (m Model) updateAddFindingEditor(msg tea.KeyMsg) (Model, tea.Cmd) {
+	key := msg.String()
+	switch key {
+	case "esc":
+		m.editor = nil
+		return m, nil
+	case "ctrl+s":
+		if err := m.saveAddFinding(); err != nil {
+			m.editor.errorMsg = err.Error()
+			return m, nil
+		}
+		return m, nil
+	case "tab":
+		m.editor.addFocus = (m.editor.addFocus + 1) % addFieldCount
+		m.applyAddFindingFocus()
+		return m, nil
+	case "shift+tab":
+		m.editor.addFocus = (m.editor.addFocus + addFieldCount - 1) % addFieldCount
+		m.applyAddFindingFocus()
+		return m, nil
+	}
+
+	if m.editor.addFocus == addFieldSeverity {
+		switch key {
+		case "left", "h":
+			if m.editor.addSeverityIdx > 0 {
+				m.editor.addSeverityIdx--
+			}
+			return m, nil
+		case "right", "l":
+			if m.editor.addSeverityIdx < len(addFindingSeverities)-1 {
+				m.editor.addSeverityIdx++
+			}
+			return m, nil
+		}
+		return m, nil
+	}
+
+	var cmd tea.Cmd
+	switch m.editor.addFocus {
+	case addFieldFile:
+		m.editor.addFile, cmd = m.editor.addFile.Update(msg)
+	case addFieldLine:
+		m.editor.addLine, cmd = m.editor.addLine.Update(msg)
+	case addFieldDescription:
+		m.editor.addDesc, cmd = m.editor.addDesc.Update(msg)
+	case addFieldInstruction:
+		m.editor.addInstr, cmd = m.editor.addInstr.Update(msg)
+	}
+	return m, cmd
+}
+
+func (m *Model) applyAddFindingFocus() {
+	m.editor.addFile.Blur()
+	m.editor.addLine.Blur()
+	m.editor.addDesc.Blur()
+	m.editor.addInstr.Blur()
+	switch m.editor.addFocus {
+	case addFieldFile:
+		m.editor.addFile.Focus()
+	case addFieldLine:
+		m.editor.addLine.Focus()
+	case addFieldDescription:
+		m.editor.addDesc.Focus()
+	case addFieldInstruction:
+		m.editor.addInstr.Focus()
+	}
+}
+
+func (m *Model) saveAddFinding() error {
+	if m.editor == nil || m.editor.kind != editorAddFinding {
+		return nil
+	}
+	desc := strings.TrimSpace(m.editor.addDesc.Value())
+	if desc == "" {
+		return fmt.Errorf("description is required")
+	}
+	line := 0
+	if raw := strings.TrimSpace(m.editor.addLine.Value()); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			return fmt.Errorf("line must be a number")
+		}
+		line = n
+	}
+	f := types.Finding{
+		Severity:         addFindingSeverities[m.editor.addSeverityIdx],
+		File:             strings.TrimSpace(m.editor.addFile.Value()),
+		Line:             line,
+		Description:      desc,
+		Action:           types.ActionAutoFix,
+		Source:           types.FindingSourceUser,
+		UserInstructions: strings.TrimSpace(m.editor.addInstr.Value()),
+	}
+	step := m.editor.step
+	if m.addedFindings == nil {
+		m.addedFindings = make(map[types.StepName][]types.Finding)
+	}
+	assignedID := m.nextUserFindingID(step)
+	f.ID = assignedID
+	m.addedFindings[step] = append(m.addedFindings[step], f)
+	if m.findingSelections == nil {
+		m.findingSelections = make(map[types.StepName]map[string]bool)
+	}
+	if m.findingSelections[step] == nil {
+		m.findingSelections[step] = make(map[string]bool)
+	}
+	m.findingSelections[step][assignedID] = true
+	m.editor = nil
+	return nil
+}
+
+// nextUserFindingID returns a unique "user-N" ID that does not collide
+// with any agent-produced finding or prior user-added finding for this step.
+func (m Model) nextUserFindingID(step types.StepName) string {
+	used := make(map[string]bool)
+	for _, item := range m.findingItems(step) {
+		if item.ID != "" {
+			used[item.ID] = true
+		}
+	}
+	for _, item := range m.addedFindings[step] {
+		if item.ID != "" {
+			used[item.ID] = true
+		}
+	}
+	for i := 1; ; i++ {
+		candidate := fmt.Sprintf("user-%d", i)
+		if !used[candidate] {
+			return candidate
+		}
+	}
+}
+
+// removeUserFinding removes a user-added finding by ID from the given step
+// if present. Returns true when a removal occurred.
+func (m *Model) removeUserFinding(step types.StepName, id string) bool {
+	items := m.addedFindings[step]
+	for i, item := range items {
+		if item.ID == id {
+			m.addedFindings[step] = append(items[:i], items[i+1:]...)
+			if len(m.addedFindings[step]) == 0 {
+				delete(m.addedFindings, step)
+			}
+			if sel := m.findingSelections[step]; sel != nil {
+				delete(sel, id)
+			}
+			return true
+		}
+	}
+	return false
+}
+
+// findingAtCursor returns the finding currently highlighted in the findings
+// list for the given step, combining agent-produced and user-added items.
+// Returns false when the cursor is out of range.
+func (m Model) findingAtCursor(step types.StepName) (types.Finding, bool) {
+	all := m.combinedFindingItems(step)
+	if len(all) == 0 {
+		return types.Finding{}, false
+	}
+	cur := m.findingCursor[step]
+	if cur < 0 || cur >= len(all) {
+		return types.Finding{}, false
+	}
+	return all[cur], true
+}
+
+// combinedFindingItems returns the full list of findings for a step as
+// rendered: agent-produced items first, user-added items appended.
+func (m Model) combinedFindingItems(step types.StepName) []types.Finding {
+	items := m.findingItems(step)
+	result := make([]types.Finding, 0, len(items)+len(m.addedFindings[step]))
+	result = append(result, items...)
+	result = append(result, m.addedFindings[step]...)
+	return result
+}
+
+// renderInstructionEditor renders the instruction editor overlay.
+func (m Model) renderInstructionEditor(width int) string {
+	if m.editor == nil || m.editor.kind != editorInstruction {
+		return ""
+	}
+	boxWidth := width
+	if boxWidth < 40 {
+		boxWidth = 40
+	}
+	contentWidth := boxWidth - 4
+	if contentWidth < 20 {
+		contentWidth = 20
+	}
+	m.editor.instruction.SetWidth(contentWidth)
+
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ansiCyan))
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
+	title := titleStyle.Render(fmt.Sprintf("Instruction for %s", m.editor.findingID))
+
+	var body strings.Builder
+	body.WriteString(m.editor.instruction.View())
+	body.WriteString("\n")
+	body.WriteString(dimStyle.Render("ctrl+s save  ·  esc cancel"))
+
+	return renderBoxWithStyledTitle(title, body.String(), boxWidth, "")
+}
+
+// renderAddFindingEditor renders the add-finding editor overlay.
+func (m Model) renderAddFindingEditor(width int) string {
+	if m.editor == nil || m.editor.kind != editorAddFinding {
+		return ""
+	}
+	boxWidth := width
+	if boxWidth < 40 {
+		boxWidth = 40
+	}
+	contentWidth := boxWidth - 4
+	if contentWidth < 20 {
+		contentWidth = 20
+	}
+	m.editor.addFile.Width = contentWidth - 2
+	m.editor.addDesc.SetWidth(contentWidth)
+	m.editor.addInstr.SetWidth(contentWidth)
+
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ansiCyan))
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
+	focusStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ansiCyan))
+	labelStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
+
+	label := func(field addFindingField, text string) string {
+		if m.editor.addFocus == field {
+			return focusStyle.Render("> " + text)
+		}
+		return labelStyle.Render("  " + text)
+	}
+
+	// Severity row
+	sevRow := ""
+	for i, name := range addFindingSeverities {
+		marker := "  "
+		style := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
+		if i == m.editor.addSeverityIdx {
+			marker = "● "
+			style = severityStyle(name).Bold(true)
+		} else {
+			marker = "○ "
+		}
+		sevRow += style.Render(marker+name) + "  "
+	}
+
+	var body strings.Builder
+	body.WriteString(label(addFieldSeverity, "Severity"))
+	body.WriteString("\n  ")
+	body.WriteString(sevRow)
+	body.WriteString("\n\n")
+	body.WriteString(label(addFieldFile, "File"))
+	body.WriteString("\n")
+	body.WriteString("  " + m.editor.addFile.View())
+	body.WriteString("\n\n")
+	body.WriteString(label(addFieldLine, "Line"))
+	body.WriteString("\n")
+	body.WriteString("  " + m.editor.addLine.View())
+	body.WriteString("\n\n")
+	body.WriteString(label(addFieldDescription, "Description"))
+	body.WriteString("\n")
+	body.WriteString(m.editor.addDesc.View())
+	body.WriteString("\n\n")
+	body.WriteString(label(addFieldInstruction, "Fix instruction (optional)"))
+	body.WriteString("\n")
+	body.WriteString(m.editor.addInstr.View())
+	body.WriteString("\n\n")
+	if m.editor.errorMsg != "" {
+		errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiRed))
+		body.WriteString(errStyle.Render("! " + m.editor.errorMsg))
+		body.WriteString("\n")
+	}
+	body.WriteString(dimStyle.Render("tab next field  ·  ctrl+s save  ·  esc cancel"))
+
+	title := titleStyle.Render("Add finding")
+	return renderBoxWithStyledTitle(title, body.String(), boxWidth, "")
+}

--- a/internal/tui/editors_test.go
+++ b/internal/tui/editors_test.go
@@ -1,0 +1,309 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+	"github.com/muesli/termenv"
+)
+
+func keyMsg(s string) tea.KeyMsg {
+	switch s {
+	case "esc":
+		return tea.KeyMsg{Type: tea.KeyEsc}
+	case "ctrl+s":
+		return tea.KeyMsg{Type: tea.KeyCtrlS}
+	case "tab":
+		return tea.KeyMsg{Type: tea.KeyTab}
+	case "shift+tab":
+		return tea.KeyMsg{Type: tea.KeyShiftTab}
+	case "left":
+		return tea.KeyMsg{Type: tea.KeyLeft}
+	case "right":
+		return tea.KeyMsg{Type: tea.KeyRight}
+	case "down":
+		return tea.KeyMsg{Type: tea.KeyDown}
+	case "up":
+		return tea.KeyMsg{Type: tea.KeyUp}
+	case "space":
+		return tea.KeyMsg{Type: tea.KeySpace, Runes: []rune{' '}}
+	}
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+}
+
+func newAwaitingModel(t *testing.T, findings string) Model {
+	t.Helper()
+	lipgloss.SetColorProfile(termenv.Ascii)
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusAwaitingApproval
+	m := NewModel("", nil, run)
+	m.width = 120
+	m.height = 40
+	if findings != "" {
+		m.stepFindings[types.StepReview] = findings
+		m.resetFindingSelection(types.StepReview)
+	}
+	return m
+}
+
+func TestEditInstruction_OpensEditorWithExistingNote(t *testing.T) {
+	findings := `{"findings":[{"id":"review-1","severity":"error","file":"a.go","line":1,"description":"bug","action":"auto-fix"}],"summary":"1 issue"}`
+	m := newAwaitingModel(t, findings)
+	m.findingInstructions = map[types.StepName]map[string]string{
+		types.StepReview: {"review-1": "focus on parser.go"},
+	}
+
+	next, _ := m.handleKey(keyMsg("e"))
+	updated := next.(Model)
+	if !updated.editorActive() {
+		t.Fatal("expected editor to be active after pressing 'e'")
+	}
+	if updated.editor.kind != editorInstruction {
+		t.Errorf("expected instruction editor, got %d", updated.editor.kind)
+	}
+	if updated.editor.findingID != "review-1" {
+		t.Errorf("expected editor to target review-1, got %q", updated.editor.findingID)
+	}
+	if updated.editor.instruction.Value() != "focus on parser.go" {
+		t.Errorf("expected existing instruction to be pre-filled, got %q", updated.editor.instruction.Value())
+	}
+}
+
+func TestEditInstruction_EscCancelsWithoutSaving(t *testing.T) {
+	findings := `{"findings":[{"id":"review-1","severity":"error","description":"bug","action":"auto-fix"}],"summary":"1"}`
+	m := newAwaitingModel(t, findings)
+	next, _ := m.handleKey(keyMsg("e"))
+	m = next.(Model)
+	m.editor.instruction.SetValue("draft note")
+	next, _ = m.handleKey(keyMsg("esc"))
+	m = next.(Model)
+	if m.editorActive() {
+		t.Fatal("expected editor to close on esc")
+	}
+	if got := m.findingInstructions[types.StepReview]["review-1"]; got != "" {
+		t.Errorf("expected no saved instruction after cancel, got %q", got)
+	}
+}
+
+func TestEditInstruction_CtrlSSavesInstruction(t *testing.T) {
+	findings := `{"findings":[{"id":"review-1","severity":"error","description":"bug","action":"auto-fix"}],"summary":"1"}`
+	m := newAwaitingModel(t, findings)
+	next, _ := m.handleKey(keyMsg("e"))
+	m = next.(Model)
+	m.editor.instruction.SetValue("only touch handler.go")
+	next, _ = m.handleKey(keyMsg("ctrl+s"))
+	m = next.(Model)
+	if m.editorActive() {
+		t.Fatal("expected editor to close on save")
+	}
+	got := m.findingInstructions[types.StepReview]["review-1"]
+	if got != "only touch handler.go" {
+		t.Errorf("expected instruction saved, got %q", got)
+	}
+}
+
+func TestEditInstruction_ClearingRemovesEntry(t *testing.T) {
+	findings := `{"findings":[{"id":"review-1","severity":"error","description":"bug","action":"auto-fix"}],"summary":"1"}`
+	m := newAwaitingModel(t, findings)
+	m.findingInstructions = map[types.StepName]map[string]string{
+		types.StepReview: {"review-1": "old note"},
+	}
+	next, _ := m.handleKey(keyMsg("e"))
+	m = next.(Model)
+	m.editor.instruction.SetValue("   ")
+	next, _ = m.handleKey(keyMsg("ctrl+s"))
+	m = next.(Model)
+	if _, ok := m.findingInstructions[types.StepReview]; ok {
+		t.Error("expected findingInstructions entry to be cleared")
+	}
+}
+
+func TestAddFinding_OpensEditorEmpty(t *testing.T) {
+	m := newAwaitingModel(t, `{"findings":[{"id":"review-1","severity":"error","description":"bug","action":"auto-fix"}],"summary":"1"}`)
+	next, _ := m.handleKey(keyMsg("+"))
+	m = next.(Model)
+	if !m.editorActive() || m.editor.kind != editorAddFinding {
+		t.Fatal("expected add-finding editor to be active")
+	}
+	if m.editor.addFocus != addFieldSeverity {
+		t.Error("expected initial focus on severity field")
+	}
+}
+
+func TestAddFinding_SaveAppendsUserFinding(t *testing.T) {
+	m := newAwaitingModel(t, `{"findings":[{"id":"review-1","severity":"error","description":"bug","action":"auto-fix"}],"summary":"1"}`)
+	next, _ := m.handleKey(keyMsg("+"))
+	m = next.(Model)
+	// Change severity to info (index 2).
+	m.editor.addSeverityIdx = 2
+	m.editor.addDesc.SetValue("also audit logger init path")
+	m.editor.addInstr.SetValue("prefer slog")
+	next, _ = m.handleKey(keyMsg("ctrl+s"))
+	m = next.(Model)
+
+	if m.editorActive() {
+		t.Fatal("expected editor to close after save")
+	}
+	added := m.addedFindings[types.StepReview]
+	if len(added) != 1 {
+		t.Fatalf("expected 1 user-added finding, got %d", len(added))
+	}
+	if added[0].Severity != "info" {
+		t.Errorf("expected severity=info, got %q", added[0].Severity)
+	}
+	if added[0].Description != "also audit logger init path" {
+		t.Errorf("expected description saved, got %q", added[0].Description)
+	}
+	if added[0].UserInstructions != "prefer slog" {
+		t.Errorf("expected instruction saved, got %q", added[0].UserInstructions)
+	}
+	if added[0].Source != types.FindingSourceUser {
+		t.Errorf("expected source=user, got %q", added[0].Source)
+	}
+	if added[0].ID == "" || !strings.HasPrefix(added[0].ID, "user-") {
+		t.Errorf("expected user-N ID, got %q", added[0].ID)
+	}
+	// User-added finding should be auto-selected so 'f' includes it.
+	if !m.findingSelections[types.StepReview][added[0].ID] {
+		t.Error("expected user-added finding to be auto-selected")
+	}
+}
+
+func TestAddFinding_RequiresDescription(t *testing.T) {
+	m := newAwaitingModel(t, `{"findings":[],"summary":"0"}`)
+	next, _ := m.handleKey(keyMsg("+"))
+	m = next.(Model)
+	next, _ = m.handleKey(keyMsg("ctrl+s"))
+	m = next.(Model)
+	if !m.editorActive() {
+		t.Fatal("expected editor to stay open without description")
+	}
+	if m.editor.errorMsg == "" {
+		t.Error("expected validation error message")
+	}
+	if len(m.addedFindings[types.StepReview]) != 0 {
+		t.Error("expected no finding appended when validation fails")
+	}
+}
+
+func TestAddFinding_TabCyclesFocus(t *testing.T) {
+	m := newAwaitingModel(t, `{"findings":[],"summary":"0"}`)
+	next, _ := m.handleKey(keyMsg("+"))
+	m = next.(Model)
+	next, _ = m.handleKey(keyMsg("tab"))
+	m = next.(Model)
+	if m.editor.addFocus != addFieldFile {
+		t.Errorf("expected focus on File after tab, got %d", m.editor.addFocus)
+	}
+	for i := 0; i < int(addFieldCount); i++ {
+		next, _ = m.handleKey(keyMsg("tab"))
+		m = next.(Model)
+	}
+	if m.editor.addFocus != addFieldFile {
+		t.Errorf("expected focus to wrap around to File, got %d", m.editor.addFocus)
+	}
+}
+
+func TestDeleteUserFinding_RemovesOnlyUserAuthored(t *testing.T) {
+	findings := `{"findings":[{"id":"review-1","severity":"error","description":"agent bug","action":"auto-fix"}],"summary":"1"}`
+	m := newAwaitingModel(t, findings)
+	// Manually add a user finding.
+	m.addedFindings[types.StepReview] = []types.Finding{
+		{ID: "user-1", Severity: "info", Description: "user idea", Source: types.FindingSourceUser, Action: types.ActionAutoFix},
+	}
+	m.findingSelections[types.StepReview]["user-1"] = true
+	m.findingCursor[types.StepReview] = 1 // cursor on user-added
+
+	next, _ := m.handleKey(keyMsg("D"))
+	m = next.(Model)
+
+	if len(m.addedFindings[types.StepReview]) != 0 {
+		t.Errorf("expected user finding removed, still have %d", len(m.addedFindings[types.StepReview]))
+	}
+
+	// Now try deleting the agent finding - D should be a no-op.
+	m.findingCursor[types.StepReview] = 0
+	next, _ = m.handleKey(keyMsg("D"))
+	m = next.(Model)
+	if len(m.findingItems(types.StepReview)) != 1 {
+		t.Error("expected agent finding to be preserved when D pressed on it")
+	}
+}
+
+func TestAddFinding_RendersEvenOnSmallTerminal(t *testing.T) {
+	// Regression: the editor used to compete with findings/logs for the
+	// content budget and get dropped on smaller terminals, making the UI
+	// feel frozen. It must always render when active.
+	m := newAwaitingModel(t, `{"findings":[{"id":"review-1","severity":"error","description":"bug","action":"auto-fix"}],"summary":"1"}`)
+	m.height = 24
+	next, _ := m.handleKey(keyMsg("+"))
+	m = next.(Model)
+	plain := stripANSI(m.View())
+	if !strings.Contains(plain, "Add finding") {
+		t.Errorf("expected Add finding editor to render, got:\n%s", plain)
+	}
+	if !strings.Contains(plain, "Severity") {
+		t.Errorf("expected Severity label to render, got:\n%s", plain)
+	}
+}
+
+func TestEditInstruction_RendersEvenOnSmallTerminal(t *testing.T) {
+	m := newAwaitingModel(t, `{"findings":[{"id":"review-1","severity":"error","description":"bug","action":"auto-fix"}],"summary":"1"}`)
+	m.height = 24
+	next, _ := m.handleKey(keyMsg("e"))
+	m = next.(Model)
+	plain := stripANSI(m.View())
+	if !strings.Contains(plain, "Instruction for review-1") {
+		t.Errorf("expected Instruction editor to render, got:\n%s", plain)
+	}
+}
+
+func TestActionBar_SelectionOrder_EditAddBeforeAllNone(t *testing.T) {
+	findings := `{"findings":[{"id":"review-1","severity":"error","description":"bug","action":"auto-fix"}],"summary":"1"}`
+	m := newAwaitingModel(t, findings)
+	plain := stripANSI(m.View())
+	eIdx := strings.Index(plain, "e edit")
+	plusIdx := strings.Index(plain, "+ add")
+	aIdx := strings.Index(plain, "A all")
+	nIdx := strings.Index(plain, "N none")
+	if eIdx < 0 || plusIdx < 0 || aIdx < 0 || nIdx < 0 {
+		t.Fatalf("expected all selection actions visible, got:\n%s", plain)
+	}
+	if !(eIdx < aIdx && plusIdx < aIdx) {
+		t.Errorf("expected 'e edit' and '+ add' to appear before 'A all'; got e@%d + @%d A@%d", eIdx, plusIdx, aIdx)
+	}
+	if !(plusIdx < nIdx) {
+		t.Errorf("expected '+ add' before 'N none'; got + @%d N@%d", plusIdx, nIdx)
+	}
+}
+
+func TestRespondCmd_IncludesInstructionsAndAddedFindings(t *testing.T) {
+	findings := `{"findings":[{"id":"review-1","severity":"error","description":"bug","action":"auto-fix"}],"summary":"1"}`
+	m := newAwaitingModel(t, findings)
+	m.findingInstructions = map[types.StepName]map[string]string{
+		types.StepReview: {"review-1": "only touch parser.go"},
+	}
+	m.addedFindings[types.StepReview] = []types.Finding{
+		{ID: "user-1", Severity: "warning", Description: "also logger", Source: types.FindingSourceUser, Action: types.ActionAutoFix},
+	}
+	m.findingSelections[types.StepReview] = map[string]bool{
+		"review-1": true,
+		"user-1":   true,
+	}
+
+	ids := m.selectedFindingIDs(types.StepReview)
+	if len(ids) != 1 || ids[0] != "review-1" {
+		t.Fatalf("expected only agent ID in selectedFindingIDs, got %v", ids)
+	}
+	added := m.selectedUserAddedFindings(types.StepReview)
+	if len(added) != 1 || added[0].ID != "user-1" {
+		t.Fatalf("expected one user-added finding, got %v", added)
+	}
+	// Instructions that don't match a selected ID should be dropped.
+	if _, ok := m.findingInstructions[types.StepReview]["review-99"]; ok {
+		t.Fatal("test setup bug")
+	}
+}

--- a/internal/tui/editors_test.go
+++ b/internal/tui/editors_test.go
@@ -128,8 +128,8 @@ func TestAddFinding_OpensEditorEmpty(t *testing.T) {
 	if !m.editorActive() || m.editor.kind != editorAddFinding {
 		t.Fatal("expected add-finding editor to be active")
 	}
-	if m.editor.addFocus != addFieldSeverity {
-		t.Error("expected initial focus on severity field")
+	if m.editor.addFocus != addFieldDescription {
+		t.Error("expected initial focus on description field")
 	}
 }
 
@@ -137,8 +137,6 @@ func TestAddFinding_SaveAppendsUserFinding(t *testing.T) {
 	m := newAwaitingModel(t, `{"findings":[{"id":"review-1","severity":"error","description":"bug","action":"auto-fix"}],"summary":"1"}`)
 	next, _ := m.handleKey(keyMsg("+"))
 	m = next.(Model)
-	// Change severity to info (index 2).
-	m.editor.addSeverityIdx = 2
 	m.editor.addDesc.SetValue("also audit logger init path")
 	m.editor.addInstr.SetValue("prefer slog")
 	next, _ = m.handleKey(keyMsg("ctrl+s"))
@@ -153,6 +151,12 @@ func TestAddFinding_SaveAppendsUserFinding(t *testing.T) {
 	}
 	if added[0].Severity != "info" {
 		t.Errorf("expected severity=info, got %q", added[0].Severity)
+	}
+	if added[0].File != "" {
+		t.Errorf("expected file to stay empty for global finding, got %q", added[0].File)
+	}
+	if added[0].Line != 0 {
+		t.Errorf("expected line to stay zero for global finding, got %d", added[0].Line)
 	}
 	if added[0].Description != "also audit logger init path" {
 		t.Errorf("expected description saved, got %q", added[0].Description)
@@ -195,15 +199,31 @@ func TestAddFinding_TabCyclesFocus(t *testing.T) {
 	m = next.(Model)
 	next, _ = m.handleKey(keyMsg("tab"))
 	m = next.(Model)
-	if m.editor.addFocus != addFieldFile {
-		t.Errorf("expected focus on File after tab, got %d", m.editor.addFocus)
+	if m.editor.addFocus != addFieldInstruction {
+		t.Errorf("expected focus on instruction after tab, got %d", m.editor.addFocus)
 	}
 	for i := 0; i < int(addFieldCount); i++ {
 		next, _ = m.handleKey(keyMsg("tab"))
 		m = next.(Model)
 	}
-	if m.editor.addFocus != addFieldFile {
-		t.Errorf("expected focus to wrap around to File, got %d", m.editor.addFocus)
+	if m.editor.addFocus != addFieldInstruction {
+		t.Errorf("expected focus to wrap around to instruction, got %d", m.editor.addFocus)
+	}
+}
+
+func TestEditInstruction_UserFindingUpdatesAddedFinding(t *testing.T) {
+	m := newAwaitingModel(t, `{"findings":[],"summary":"0"}`)
+	m.addedFindings[types.StepReview] = []types.Finding{{ID: "user-1", Severity: "info", Description: "user idea", Source: types.FindingSourceUser, Action: types.ActionAutoFix, UserInstructions: "old note"}}
+	m.findingSelections[types.StepReview] = map[string]bool{"user-1": true}
+
+	next, _ := m.handleKey(keyMsg("e"))
+	m = next.(Model)
+	m.editor.instruction.SetValue("new note")
+	next, _ = m.handleKey(keyMsg("ctrl+s"))
+	m = next.(Model)
+
+	if got := m.addedFindings[types.StepReview][0].UserInstructions; got != "new note" {
+		t.Fatalf("expected edited user finding note to persist into addedFindings, got %q", got)
 	}
 }
 
@@ -245,8 +265,11 @@ func TestAddFinding_RendersEvenOnSmallTerminal(t *testing.T) {
 	if !strings.Contains(plain, "Add finding") {
 		t.Errorf("expected Add finding editor to render, got:\n%s", plain)
 	}
-	if !strings.Contains(plain, "Severity") {
-		t.Errorf("expected Severity label to render, got:\n%s", plain)
+	if !strings.Contains(plain, "Description") {
+		t.Errorf("expected Description label to render, got:\n%s", plain)
+	}
+	if strings.Contains(plain, "Severity") || strings.Contains(plain, "File") || strings.Contains(plain, "Line") {
+		t.Errorf("expected add-finding editor to omit local fields, got:\n%s", plain)
 	}
 }
 

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -89,6 +89,8 @@ func (m *Model) applyEvent(event ipc.Event) {
 			m.showDiff = false
 			m.diffOffset = 0
 			if event.Status != nil && (types.StepStatus(*event.Status) == types.StepStatusAwaitingApproval || types.StepStatus(*event.Status) == types.StepStatusFixReview) {
+				delete(m.findingInstructions, *event.StepName)
+				delete(m.addedFindings, *event.StepName)
 				m.resetFindingSelection(*event.StepName)
 			}
 		}

--- a/internal/tui/findings.go
+++ b/internal/tui/findings.go
@@ -1,6 +1,8 @@
 package tui
 
-import "github.com/kunchenguid/no-mistakes/internal/types"
+import (
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
 
 func (m Model) awaitingActionState() (showSelectionActions bool, allowFix bool, selectedCount int, totalCount int) {
 	step := awaitingStep(m.steps)
@@ -20,13 +22,53 @@ func (m Model) awaitingActionState() (showSelectionActions bool, allowFix bool, 
 	return true, selectedCount > 0, selectedCount, totalCount
 }
 
+// findingItems returns the complete list of findings rendered for the step,
+// agent-produced items first followed by any user-added findings. Cursor
+// positions and selection state are tracked against this combined list.
 func (m *Model) findingItems(step types.StepName) []finding {
+	raw := m.stepFindings[step]
+	var items []finding
+	if f, err := parseFindings(raw); err == nil && f != nil {
+		items = append(items, f.Items...)
+	}
+	if added, ok := m.addedFindings[step]; ok {
+		items = append(items, added...)
+	}
+	return items
+}
+
+// agentFindingItems returns only the agent-produced findings for the step,
+// used when the caller must distinguish user-authored findings from the
+// rest (e.g. when building RespondParams).
+func (m *Model) agentFindingItems(step types.StepName) []finding {
 	raw := m.stepFindings[step]
 	f, err := parseFindings(raw)
 	if err != nil || f == nil {
 		return nil
 	}
 	return f.Items
+}
+
+// combinedFindingsJSON returns the findings JSON for the step merged with
+// any user overrides (per-finding instructions) and user-added findings.
+// If no overrides exist, the original JSON is returned unchanged.
+func (m *Model) combinedFindingsJSON(step types.StepName) string {
+	raw := m.stepFindings[step]
+	instructions := m.findingInstructions[step]
+	added := m.addedFindings[step]
+	if len(instructions) == 0 && len(added) == 0 {
+		return raw
+	}
+	base, err := parseFindings(raw)
+	if err != nil || base == nil {
+		base = &findings{}
+	}
+	merged := types.MergeUserOverrides(*base, instructions, added)
+	encoded, err := types.MarshalFindingsJSON(merged)
+	if err != nil {
+		return raw
+	}
+	return encoded
 }
 
 func (m *Model) ensureFindingSelection(step types.StepName) {
@@ -59,18 +101,38 @@ func (m *Model) resetFindingSelection(step types.StepName) {
 	m.findingCursor[step] = 0
 }
 
+// selectedFindingIDs returns the IDs of selected agent-produced findings.
+// User-authored findings are conveyed via addedFindings separately because
+// the daemon only recognizes agent IDs in the FindingIDs list.
 func (m *Model) selectedFindingIDs(step types.StepName) []string {
 	selected := m.findingSelections[step]
 	if len(selected) == 0 {
 		return nil
 	}
 	var ids []string
-	for _, item := range m.findingItems(step) {
+	for _, item := range m.agentFindingItems(step) {
 		if selected[item.ID] {
 			ids = append(ids, item.ID)
 		}
 	}
 	return ids
+}
+
+// selectedUserAddedFindings returns the user-added findings that are
+// currently selected (and therefore should be sent to the fix agent).
+func (m *Model) selectedUserAddedFindings(step types.StepName) []finding {
+	added := m.addedFindings[step]
+	if len(added) == 0 {
+		return nil
+	}
+	selected := m.findingSelections[step]
+	var result []finding
+	for _, item := range added {
+		if selected == nil || selected[item.ID] {
+			result = append(result, item)
+		}
+	}
+	return result
 }
 
 // diffOffsetForCurrentFinding returns the diff scroll offset that corresponds

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -8,6 +8,12 @@ import (
 func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
+	// Route to modal editor first, if one is open. ctrl+c always quits.
+	if m.editorActive() && key != "ctrl+c" {
+		updated, cmd := m.updateEditor(msg)
+		return updated, cmd
+	}
+
 	// Reset abort confirmation on any key except 'x'.
 	if key != "x" {
 		m.confirmAbort = false
@@ -162,6 +168,40 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if !m.showDiff {
 			if step := awaitingStep(m.steps); step != nil {
 				m.clearAllFindings(step.StepName)
+			}
+		}
+		return m, nil
+
+	case "e":
+		if !m.showDiff {
+			if step := awaitingStep(m.steps); step != nil {
+				if item, ok := m.findingAtCursor(step.StepName); ok && item.ID != "" {
+					existing := ""
+					if byStep := m.findingInstructions[step.StepName]; byStep != nil {
+						existing = byStep[item.ID]
+					}
+					if item.Source == types.FindingSourceUser {
+						existing = item.UserInstructions
+					}
+					m.editor = newInstructionEditor(step.StepName, item.ID, existing)
+				}
+			}
+		}
+		return m, nil
+	case "+":
+		if !m.showDiff {
+			if step := awaitingStep(m.steps); step != nil {
+				m.editor = newAddFindingEditor(step.StepName)
+			}
+		}
+		return m, nil
+	case "D":
+		if !m.showDiff {
+			if step := awaitingStep(m.steps); step != nil {
+				if item, ok := m.findingAtCursor(step.StepName); ok && item.Source == types.FindingSourceUser {
+					m.removeUserFinding(step.StepName, item.ID)
+					m.moveFindingCursor(step.StepName, 0)
+				}
 			}
 		}
 		return m, nil

--- a/internal/tui/pipeline.go
+++ b/internal/tui/pipeline.go
@@ -250,7 +250,7 @@ func renderApprovalActions(showSelectionActions bool, allowFix bool, showDiff bo
 
 	if showSelectionActions {
 		dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
-		selection := []string{renderAction("\u2423", "toggle"), renderAction("A", "all"), renderAction("N", "none")}
+		selection := []string{renderAction("\u2423", "toggle"), renderAction("e", "edit"), renderAction("+", "add"), renderAction("A", "all"), renderAction("N", "none")}
 		result += " " + dimStyle.Render("│") + " " + strings.Join(selection, "  ")
 	} else if showDiff {
 		dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
@@ -383,6 +383,7 @@ func renderHelpOverlay(width int, run *ipc.RunInfo, hasAwaitingStep bool, showDi
 				{"\u2423", "toggle current"},
 				{"A", "select all"},
 				{"N", "select none"},
+				{"e", "edit instruction / + add finding / D delete"},
 			}))
 		}
 	}

--- a/internal/tui/review.go
+++ b/internal/tui/review.go
@@ -295,6 +295,12 @@ func renderFindingsRange(f *findings, width int, cursor int, selected map[string
 		}
 		line := pointer + " " + checkbox + " " + iconStyled
 
+		// Tag user-authored findings right after the icon so they remain
+		// visible when unfocused and do not shift alignment of the ref.
+		if item.Source == nmtypes.FindingSourceUser {
+			line += " " + blueStyle.Render("[user]")
+		}
+
 		// File:line reference, truncated to fit within content width.
 		if item.File != "" {
 			ref := item.File
@@ -322,6 +328,11 @@ func renderFindingsRange(f *findings, width int, cursor int, selected map[string
 			desc = dimStyle.Render(desc)
 		}
 		b.WriteString(desc + "\n")
+
+		if item.UserInstructions != "" {
+			instr := wrapIndentedText("> "+item.UserInstructions, width, 8)
+			b.WriteString(blueStyle.Render(instr) + "\n")
+		}
 	}
 
 	// Scroll footer for the box border - combines up and down indicators.

--- a/internal/tui/stale_error_test.go
+++ b/internal/tui/stale_error_test.go
@@ -111,6 +111,31 @@ func TestStaleShowDiff_DiffResetAlsoResetsOffset(t *testing.T) {
 	}
 }
 
+func TestApplyEvent_NewApprovalPayloadClearsPreviousOverrides(t *testing.T) {
+	run := testRun()
+	m := NewModel("", nil, run)
+	m.stepFindings[types.StepReview] = `{"findings":[{"id":"review-1","severity":"error","description":"old","action":"auto-fix"}],"summary":"1"}`
+	m.findingInstructions[types.StepReview] = map[string]string{"review-1": "old note"}
+	m.addedFindings[types.StepReview] = []types.Finding{{ID: "user-1", Severity: "info", Description: "old added", Source: types.FindingSourceUser, Action: types.ActionAutoFix}}
+	m.findingSelections[types.StepReview] = map[string]bool{"review-1": true, "user-1": true}
+
+	findingsJSON := `{"findings":[{"id":"review-2","severity":"warning","description":"new","action":"auto-fix"}],"summary":"1"}`
+	status := string(types.StepStatusAwaitingApproval)
+	stepName := types.StepReview
+	m.applyEvent(ipc.Event{Type: ipc.EventStepCompleted, StepName: &stepName, Status: &status, Findings: &findingsJSON})
+
+	if _, ok := m.findingInstructions[types.StepReview]; ok {
+		t.Fatal("expected stale finding instructions to be cleared")
+	}
+	if len(m.addedFindings[types.StepReview]) != 0 {
+		t.Fatalf("expected stale user-added findings to be cleared, got %d", len(m.addedFindings[types.StepReview]))
+	}
+	selected := m.findingSelections[types.StepReview]
+	if len(selected) != 1 || !selected["review-2"] {
+		t.Fatalf("expected selection reset to only new finding, got %#v", selected)
+	}
+}
+
 func TestActionBar_ShowsDiffWhenDiffDataExists(t *testing.T) {
 	// The action bar SHOULD show 'd diff' when diff data exists for the current step.
 	configureTUIColors()

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -95,8 +95,34 @@ func (m Model) View() string {
 		appendExtraSection(renderErrorBox(m.err, rightWidth))
 	}
 
+	// Modal editor takes priority over findings/logs so it always renders
+	// when active. Bypass the content budget so it never gets dropped on
+	// cramped terminals; the editor is user-driven and must stay visible.
+	if m.editorActive() {
+		boxWidth := rightWidth
+		if boxWidth < 40 {
+			boxWidth = 80
+		}
+		var section string
+		switch m.editor.kind {
+		case editorInstruction:
+			section = m.renderInstructionEditor(boxWidth)
+		case editorAddFinding:
+			section = m.renderAddFindingEditor(boxWidth)
+		}
+		if section != "" {
+			extraSections = append(extraSections, section)
+			if contentBudget > 0 {
+				contentBudget -= lipgloss.Height(section)
+				if contentBudget < 0 {
+					contentBudget = 0
+				}
+			}
+		}
+	}
+
 	// CI-specific view when CI step is active.
-	if !m.showHelp && hasCI {
+	if !m.showHelp && !m.editorActive() && hasCI {
 		findings := ""
 		cursor := 0
 		var selected map[string]bool
@@ -113,7 +139,7 @@ func (m Model) View() string {
 			ciHeight = contentBudget
 		}
 		appendExtraSection(renderCIViewWithSelection(m.run, m.steps, findings, m.logs, rightWidth, ciHeight, cursor, selected))
-	} else if !m.showHelp {
+	} else if !m.showHelp && !m.editorActive() {
 		if step := awaitingStep(m.steps); step != nil {
 			// Generic findings or diff for non-CI steps awaiting approval.
 			label := stepLabel(step.StepName)
@@ -144,12 +170,13 @@ func (m Model) View() string {
 						appendExtraSection(renderDiff(raw, rightWidth, viewHeight, m.diffOffset, label, findingCtx))
 					}
 				}
-			} else if raw, ok := m.stepFindings[step.StepName]; ok {
+			} else if _, ok := m.stepFindings[step.StepName]; ok || len(m.addedFindings[step.StepName]) > 0 {
 				cursor := m.findingCursor[step.StepName]
 				boxHeight := m.height
 				if contentBudget >= 0 {
 					boxHeight = contentBudget
 				}
+				raw := m.combinedFindingsJSON(step.StepName)
 				appendExtraSection(renderFindingsBoxForHeight(raw, rightWidth, cursor, m.findingSelections[step.StepName], boxHeight))
 			}
 		}
@@ -162,6 +189,9 @@ func (m Model) View() string {
 	// budget so the log box can consume the available terminal height.
 	// Also hidden when CI is active (log context integrated into CI box).
 	logLines := 5
+	if m.editorActive() {
+		logLines = 0
+	}
 	if !m.showHelp && contentBudget > 0 {
 		if useResponsiveLayout {
 			if len(extraSections) == 0 {

--- a/internal/types/findings.go
+++ b/internal/types/findings.go
@@ -12,14 +12,22 @@ const (
 	ActionAskUser = "ask-user"
 )
 
+// Finding source constants. An empty Source is treated as agent-produced.
+const (
+	FindingSourceAgent = "agent"
+	FindingSourceUser  = "user"
+)
+
 // Finding represents a single review, test, lint, or PR comment finding.
 type Finding struct {
-	ID          string `json:"id,omitempty"`
-	Severity    string `json:"severity"`
-	File        string `json:"file,omitempty"`
-	Line        int    `json:"line,omitempty"`
-	Description string `json:"description"`
-	Action      string `json:"action"`
+	ID               string `json:"id,omitempty"`
+	Severity         string `json:"severity"`
+	File             string `json:"file,omitempty"`
+	Line             int    `json:"line,omitempty"`
+	Description      string `json:"description"`
+	Action           string `json:"action"`
+	Source           string `json:"source,omitempty"`
+	UserInstructions string `json:"user_instructions,omitempty"`
 }
 
 type findingWire struct {
@@ -29,6 +37,8 @@ type findingWire struct {
 	Line                int    `json:"line,omitempty"`
 	Description         string `json:"description"`
 	Action              string `json:"action"`
+	Source              string `json:"source,omitempty"`
+	UserInstructions    string `json:"user_instructions,omitempty"`
 	RequiresHumanReview *bool  `json:"requires_human_review,omitempty"`
 }
 
@@ -129,6 +139,57 @@ func AutoFixableFindings(findings Findings) Findings {
 	return result
 }
 
+// MergeUserOverrides applies per-finding user instructions to existing agent
+// findings and appends user-added findings at the end. Added findings have
+// Source stamped to FindingSourceUser and receive deterministic "user-N" IDs
+// if they do not carry an ID. The original Findings is not mutated.
+func MergeUserOverrides(findings Findings, instructions map[string]string, added []Finding) Findings {
+	result := Findings{
+		Summary:        findings.Summary,
+		Tested:         findings.Tested,
+		TestingSummary: findings.TestingSummary,
+		RiskLevel:      findings.RiskLevel,
+		RiskRationale:  findings.RiskRationale,
+	}
+	if len(findings.Items) > 0 {
+		result.Items = make([]Finding, len(findings.Items))
+		copy(result.Items, findings.Items)
+	}
+	for i := range result.Items {
+		if note, ok := instructions[result.Items[i].ID]; ok {
+			result.Items[i].UserInstructions = note
+		}
+	}
+	used := make(map[string]bool, len(result.Items)+len(added))
+	for _, item := range result.Items {
+		if item.ID != "" {
+			used[item.ID] = true
+		}
+	}
+	counter := 0
+	for _, item := range added {
+		item.Source = FindingSourceUser
+		if item.Action == "" {
+			item.Action = ActionAutoFix
+		}
+		if item.ID == "" {
+			for {
+				counter++
+				candidate := "user-" + itoa(counter)
+				if !used[candidate] {
+					item.ID = candidate
+					used[candidate] = true
+					break
+				}
+			}
+		} else {
+			used[item.ID] = true
+		}
+		result.Items = append(result.Items, item)
+	}
+	return result
+}
+
 // HasAskUserFindings returns true if any finding has Action "ask-user".
 func HasAskUserFindings(findings Findings) bool {
 	for _, item := range findings.Items {
@@ -184,6 +245,8 @@ func (f *Finding) UnmarshalJSON(data []byte) error {
 	f.Line = wire.Line
 	f.Description = wire.Description
 	f.Action = wire.Action
+	f.Source = wire.Source
+	f.UserInstructions = wire.UserInstructions
 	if f.Action == "" && wire.RequiresHumanReview != nil {
 		if *wire.RequiresHumanReview {
 			f.Action = ActionAskUser

--- a/internal/types/findings.go
+++ b/internal/types/findings.go
@@ -3,6 +3,7 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // Finding action constants.
@@ -167,25 +168,22 @@ func MergeUserOverrides(findings Findings, instructions map[string]string, added
 		}
 	}
 	counter := 0
+	appended := false
 	for _, item := range added {
 		item.Source = FindingSourceUser
 		if item.Action == "" {
 			item.Action = ActionAutoFix
 		}
-		if item.ID == "" {
-			for {
-				counter++
-				candidate := "user-" + itoa(counter)
-				if !used[candidate] {
-					item.ID = candidate
-					used[candidate] = true
-					break
-				}
-			}
+		if item.ID == "" || used[item.ID] {
+			item.ID, counter = nextUserFindingID(used, counter)
 		} else {
 			used[item.ID] = true
 		}
 		result.Items = append(result.Items, item)
+		appended = true
+	}
+	if appended && isSelectedFindingsSummary(result.Summary) {
+		result.Summary = summarizeSelectedFindings(len(result.Items))
 	}
 	return result
 }
@@ -209,6 +207,37 @@ func summarizeSelectedFindings(count int) string {
 	default:
 		return fmt.Sprintf("%d selected findings", count)
 	}
+}
+
+func nextUserFindingID(used map[string]bool, counter int) (string, int) {
+	for {
+		counter++
+		candidate := "user-" + itoa(counter)
+		if used[candidate] {
+			continue
+		}
+		used[candidate] = true
+		return candidate, counter
+	}
+}
+
+func isSelectedFindingsSummary(summary string) bool {
+	if summary == "0 selected findings" || summary == "1 selected finding" {
+		return true
+	}
+	if !strings.HasSuffix(summary, " selected findings") {
+		return false
+	}
+	count := strings.TrimSuffix(summary, " selected findings")
+	if count == "" {
+		return false
+	}
+	for _, r := range count {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // MarshalFindingsJSON encodes findings using the current wire shape.

--- a/internal/types/findings_test.go
+++ b/internal/types/findings_test.go
@@ -325,6 +325,108 @@ func TestFinding_Action_SerializedWhenEmpty(t *testing.T) {
 	}
 }
 
+func TestParseFindingsJSON_SourceAndUserInstructions(t *testing.T) {
+	raw := `{"findings":[{"severity":"error","description":"bug","source":"user","user_instructions":"focus on handler.go"}]}`
+	f, err := ParseFindingsJSON(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.Items) != 1 {
+		t.Fatalf("Items count = %d, want 1", len(f.Items))
+	}
+	if f.Items[0].Source != FindingSourceUser {
+		t.Errorf("Source = %q, want %q", f.Items[0].Source, FindingSourceUser)
+	}
+	if f.Items[0].UserInstructions != "focus on handler.go" {
+		t.Errorf("UserInstructions = %q", f.Items[0].UserInstructions)
+	}
+}
+
+func TestMarshalFindingsJSON_OmitsEmptySourceAndInstructions(t *testing.T) {
+	f := Findings{Items: []Finding{{Severity: "error", Description: "bug"}}}
+	raw, err := MarshalFindingsJSON(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(raw, `"source"`) {
+		t.Errorf("expected source to be omitted, got %s", raw)
+	}
+	if strings.Contains(raw, `"user_instructions"`) {
+		t.Errorf("expected user_instructions to be omitted, got %s", raw)
+	}
+}
+
+func TestMergeUserOverrides_AttachesInstructions(t *testing.T) {
+	f := Findings{Items: []Finding{
+		{ID: "review-1", Severity: "error", Description: "bug"},
+		{ID: "review-2", Severity: "warning", Description: "style"},
+	}}
+	merged := MergeUserOverrides(f, map[string]string{"review-1": "only touch parser.go"}, nil)
+	if merged.Items[0].UserInstructions != "only touch parser.go" {
+		t.Errorf("expected instruction attached to review-1, got %q", merged.Items[0].UserInstructions)
+	}
+	if merged.Items[1].UserInstructions != "" {
+		t.Errorf("unexpected instruction on review-2: %q", merged.Items[1].UserInstructions)
+	}
+	if f.Items[0].UserInstructions != "" {
+		t.Errorf("original findings mutated: %q", f.Items[0].UserInstructions)
+	}
+}
+
+func TestMergeUserOverrides_AppendsUserFindings(t *testing.T) {
+	f := Findings{Items: []Finding{{ID: "review-1", Severity: "error", Description: "bug"}}}
+	added := []Finding{
+		{Severity: "warning", Description: "also inspect logger usage"},
+		{ID: "custom-xyz", Severity: "info", Description: "low priority"},
+	}
+	merged := MergeUserOverrides(f, nil, added)
+	if len(merged.Items) != 3 {
+		t.Fatalf("Items count = %d, want 3", len(merged.Items))
+	}
+	if merged.Items[1].ID != "user-1" {
+		t.Errorf("Items[1].ID = %q, want user-1", merged.Items[1].ID)
+	}
+	if merged.Items[1].Source != FindingSourceUser {
+		t.Errorf("Items[1].Source = %q, want %q", merged.Items[1].Source, FindingSourceUser)
+	}
+	if merged.Items[1].Action != ActionAutoFix {
+		t.Errorf("Items[1].Action = %q, want %q", merged.Items[1].Action, ActionAutoFix)
+	}
+	if merged.Items[2].ID != "custom-xyz" {
+		t.Errorf("Items[2].ID = %q, want custom-xyz", merged.Items[2].ID)
+	}
+	if merged.Items[2].Source != FindingSourceUser {
+		t.Errorf("Items[2].Source = %q, want %q", merged.Items[2].Source, FindingSourceUser)
+	}
+}
+
+func TestMergeUserOverrides_AvoidsIDCollision(t *testing.T) {
+	f := Findings{Items: []Finding{
+		{ID: "user-1", Severity: "error", Description: "existing"},
+	}}
+	added := []Finding{
+		{Severity: "warning", Description: "new one"},
+	}
+	merged := MergeUserOverrides(f, nil, added)
+	if merged.Items[1].ID == "user-1" {
+		t.Fatal("user-added finding collided with existing user-1")
+	}
+	if merged.Items[1].ID != "user-2" {
+		t.Errorf("Items[1].ID = %q, want user-2", merged.Items[1].ID)
+	}
+}
+
+func TestMergeUserOverrides_NoChanges(t *testing.T) {
+	f := Findings{Items: []Finding{{ID: "review-1", Severity: "error", Description: "bug"}}}
+	merged := MergeUserOverrides(f, nil, nil)
+	if len(merged.Items) != 1 {
+		t.Fatalf("Items count = %d, want 1", len(merged.Items))
+	}
+	if merged.Items[0].UserInstructions != "" {
+		t.Errorf("unexpected UserInstructions: %q", merged.Items[0].UserInstructions)
+	}
+}
+
 func TestFinding_Action_Values(t *testing.T) {
 	for _, action := range []string{ActionNoOp, ActionAutoFix, ActionAskUser} {
 		f := Finding{Severity: "error", Description: "test", Action: action}

--- a/internal/types/findings_test.go
+++ b/internal/types/findings_test.go
@@ -400,6 +400,14 @@ func TestMergeUserOverrides_AppendsUserFindings(t *testing.T) {
 	}
 }
 
+func TestMergeUserOverrides_UpdatesSummaryForAddedFindings(t *testing.T) {
+	f := Findings{Summary: "0 selected findings"}
+	merged := MergeUserOverrides(f, nil, []Finding{{Severity: "warning", Description: "new user finding"}})
+	if merged.Summary != "1 selected finding" {
+		t.Errorf("Summary = %q, want %q", merged.Summary, "1 selected finding")
+	}
+}
+
 func TestMergeUserOverrides_AvoidsIDCollision(t *testing.T) {
 	f := Findings{Items: []Finding{
 		{ID: "user-1", Severity: "error", Description: "existing"},
@@ -413,6 +421,20 @@ func TestMergeUserOverrides_AvoidsIDCollision(t *testing.T) {
 	}
 	if merged.Items[1].ID != "user-2" {
 		t.Errorf("Items[1].ID = %q, want user-2", merged.Items[1].ID)
+	}
+}
+
+func TestMergeUserOverrides_ReassignsCollidingExplicitUserID(t *testing.T) {
+	f := Findings{Items: []Finding{{ID: "review-1", Severity: "error", Description: "existing"}}}
+	merged := MergeUserOverrides(f, nil, []Finding{{ID: "review-1", Severity: "warning", Description: "new user finding"}})
+	if len(merged.Items) != 2 {
+		t.Fatalf("Items count = %d, want 2", len(merged.Items))
+	}
+	if merged.Items[1].ID == "review-1" {
+		t.Fatal("user-added finding reused existing review-1 ID")
+	}
+	if merged.Items[1].ID != "user-1" {
+		t.Errorf("Items[1].ID = %q, want user-1", merged.Items[1].ID)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add TUI support for manual fix-round finding overrides, including per-finding instruction editing, user-authored findings, updated keybindings, and approval-flow handling so reviewers can shape the fix input before dispatch.
- Carry those overrides through the fix pipeline by merging and validating selected findings, persisting the actual user-adjusted payload in IPC/DB/round history, and fixing empty-selection, summary, and ID-collision edge cases.
- Update the docs to describe the new TUI controls and the expanded manual fix-round data flow across auto-fix, gate-model, and pipeline-step references.

## Risk Assessment

✅ Low: The override flow looks bounded and the earlier correctness regressions appear addressed; the only remaining issue I found is a small internal duplication in the TUI helper path.

## Testing

- Summary: Exercised the edited-findings flow across TUI, executor, persistence, IPC, daemon, and round-history tests, and all relevant suites passed on this branch.
- `go test ./internal/types -count=1`
- `go test ./internal/tui -count=1`
- `go test ./internal/pipeline -count=1`
- `go test ./internal/pipeline/steps -count=1`
- `go test ./internal/daemon ./internal/db ./internal/ipc -count=1`
- `go test ./internal/tui`
- `go test ./internal/pipeline/steps`
- `go test ./internal/pipeline`
- `go test ./internal/pipeline -run 'TestExecutor_FixSetsPreviousFindings|TestExecutor_FixUsesSelectedFindingIDsOnly|TestExecutor_FixSelectedFindingsRewritesSummary|TestExecutor_FixAppliesUserInstructionsAndAddedFindings' -count=1`
- Outcome: 🔧 1 issue found → auto-fixed across 2 runs (3m57s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

**Round 1** - found 3 issues (1 error, 2 warnings)
- 🚨 `internal/tui/events.go:85` - When a new approval payload arrives for the same step, the model replaces `stepFindings` and resets selection but never clears `findingInstructions` or `addedFindings`. A second fix round will therefore reapply stale user notes and user-added findings to the new findings set, sending the fix agent context the user did not select for this round.
- ⚠️ `internal/tui/commands.go:98` - Edited instructions are only serialized for selected agent finding IDs. The UI also allows `e` on `[user]` findings, but those edits never propagate into `AddedFindings`, so the fix agent still receives the original user-authored finding text and note.
- ⚠️ `internal/pipeline/steps/round_history.go:63` - The new `user_findings_json` column is persisted but never consumed here: round history still partitions and renders only `FindingsJSON`. On later fix/review rounds, user-added findings and attached instructions from earlier rounds are dropped from the historical context, which makes repeated work and missed constraints more likely.

**Round 2** (auto-fix) - found 1 error
- 🚨 `internal/pipeline/findings.go:300` - `filterFindingsJSON` treats an empty `findingIDs` slice as &#34;keep everything&#34;. After `respondCmd` started allowing fix requests with only selected user-added findings, that path now sends all original agent findings back into `sctx.PreviousFindings` instead of fixing just the user-added items the reviewer selected.

**Round 3** (auto-fix) - found 2 warnings
- ⚠️ `internal/types/findings.go:147` - `MergeUserOverrides` preserves the original summary even after appending user-added findings. In the new fix flow this yields payloads like `&#34;0 selected findings&#34;` while still sending user-authored items to the fix agent, which gives contradictory context in follow-up rounds and history.
- ⚠️ `internal/types/findings.go:175` - User-added findings only get a fresh ID when `item.ID` is empty. If an IPC client supplies an `added_findings` entry whose ID collides with an existing finding, the merged payload can contain duplicate IDs, and later selection/history code uses IDs as the source of truth.

**Round 4** (auto-fix) - found 1 info
- ℹ️ `internal/tui/editors.go:302` - `combinedFindingItems` appends `m.addedFindings[step]` even though `findingItems(step)` already includes those entries. `findingAtCursor` happens to work today because cursors are bounded by `findingItems`, but this helper now returns a duplicated list and is an unnecessary source of future cursor/edit bugs.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 error
- 🚨 `internal/pipeline/executor_fix_test.go:221` - `go test ./internal/pipeline` fails in `TestExecutor_FixSetsPreviousFindings`: the test still expects `Respond(..., ActionFix, nil)` to resend the original finding set, but this branch&#39;s empty-selection filtering now passes `0 selected findings` into `PreviousFindings`, producing `expected 1 finding, got 0`.
- `go test ./internal/tui`
- `go test ./internal/pipeline/steps`
- `go test ./internal/pipeline`
- `go test ./internal/pipeline -run 'TestExecutor_FixSetsPreviousFindings|TestExecutor_FixUsesSelectedFindingIDsOnly|TestExecutor_FixSelectedFindingsRewritesSummary|TestExecutor_FixAppliesUserInstructionsAndAddedFindings' -count=1`

**Round 2** (auto-fix) - passed ✅
- `go test ./internal/types -count=1`
- `go test ./internal/tui -count=1`
- `go test ./internal/pipeline -count=1`
- `go test ./internal/pipeline/steps -count=1`
- `go test ./internal/daemon ./internal/db ./internal/ipc -count=1`

</details>

<details>
<summary>🔧 **Document** - 5 issues found → auto-fixed (3)</summary>

**Round 1** - found 5 warnings
- ⚠️ `docs/src/content/docs/guides/tui.md:81` - The TUI guide is stale for the new approval workflow. It still documents only selection/fix actions, but the code now supports editing per-finding fix instructions (`e`), adding user-authored findings (`+`), deleting user-authored findings (`D`), rendering `[user]` markers and inline instructions in the findings list, and showing those actions in the action bar/help overlay.
- ⚠️ `docs/src/content/docs/concepts/auto-fix.md:69` - The auto-fix concept doc still describes manual fixes as sending only the selected findings. The implementation now also lets the user attach per-finding instructions and add ad-hoc findings from the TUI, and those merged findings are what get sent to the fix agent.
- ⚠️ `docs/src/content/docs/concepts/auto-fix.md:95` - The step-round documentation is stale. Rounds no longer store only the original findings, selected IDs, selection source, and fix summary; they also persist the merged finding payload that was actually dispatched to the fix agent, including user instructions and user-authored findings.
- ⚠️ `docs/src/content/docs/reference/pipeline-steps.md:45` - The per-step auto-fix reference for agent-driven steps is incomplete. Review/test/document/lint fix rounds now receive more than the selected prior findings and sanitized history: they can also include per-finding user notes and user-authored findings supplied from the TUI, so the reference should describe those additional fix inputs.
- ⚠️ `docs/src/content/docs/concepts/gate-model.md:134` - The gate model&#39;s database section is stale relative to the schema change. `step_rounds` now includes `user_findings_json` for the merged findings sent to a fix round, but the docs still describe round records as only tracking findings, selected IDs, selection source, and fix summary.

**Round 2** (auto-fix) - found 3 issues (2 warnings, 1 info)
- ⚠️ `docs/src/content/docs/reference/pipeline-steps.md:61` - The Test step reference is still stale for manual fix rounds. `Executor.RespondWithOverrides` now merges per-finding user notes and selected user-authored findings into `PreviousFindings` for every fix round, and `internal/pipeline/steps/test.go` consumes that merged payload, but the Test section still says fix mode only receives previous failure output plus round history.
- ⚠️ `docs/src/content/docs/guides/tui.md:153` - The TUI guide documents `e`, `+`, and `D`, but it does not document how the new modal editors are operated. The instruction editor requires `ctrl+s` to save and `esc` to cancel, and the add-finding editor also uses `tab`/`shift+tab` to move between fields, so the keybindings or workflow text should cover those controls.
- ℹ️ `docs/src/content/docs/guides/tui.md:176` - The action-bar example is stale relative to the actual UI. `internal/tui/pipeline.go` renders the selection actions as `[space] toggle  e edit  + add  A all  N none`, but the guide still shows `A all  N none` before `e` and `+`.

**Round 3** (auto-fix) - found 2 issues (1 warning, 1 info)
- ⚠️ `docs/src/content/docs/reference/pipeline-steps.md:28` - The Rebase step reference is still stale for manual fix rounds. `Executor.RespondWithOverrides` now forwards per-finding notes and user-authored findings into every fix round, and `internal/pipeline/steps/rebase.go` appends `PreviousFindings` to the rebase-conflict prompt, but the Rebase section still documents only generic automatic conflict resolution and does not mention that TUI-authored override context is included when you trigger a fix from approval.
- ℹ️ `docs/src/content/docs/guides/tui.md:157` - The TUI guide&#39;s editor shortcut docs are still incomplete. `internal/tui/editors.go` accepts both `Ctrl+s` and `Ctrl+enter` to save the instruction editor, but the guide documents only `Ctrl+s`.

**Round 4** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
