### PR TITLE
feat(update): add beta release channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,9 +198,9 @@ jobs:
       needs.checksums.result == 'success' &&
       needs.release-please.outputs.release_created == 'true'
     steps:
-      - name: Publish draft release as latest
+      - name: Publish draft release as prerelease
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           TAG: ${{ needs.release-please.outputs.tag_name }}
-        run: gh release edit "$TAG" --draft=false --latest=true
+        run: gh release edit "$TAG" --draft=false --prerelease=true

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -117,9 +117,10 @@ Update the installed binary and reset the daemon.
 
 ```sh
 no-mistakes update
+no-mistakes update --beta
 ```
 
-Downloads the latest release, verifies the SHA-256 checksum, atomically replaces the running binary, and resets the daemon when it is running or stale daemon artifacts exist so the new executable is picked up, preferring the managed service path and falling back to a detached daemon if service startup is unavailable or fails. If the daemon is running, update first requires it to already be using the same executable path as the binary running `no-mistakes update`; if that daemon executable path cannot be determined or it points to a different binary, the update aborts before replacement. If the daemon does not come back cleanly after a successful replacement, the command reports that failure. On macOS, removes the quarantine extended attribute.
+Downloads the latest release, verifies the SHA-256 checksum, atomically replaces the running binary, and resets the daemon when it is running or stale daemon artifacts exist so the new executable is picked up, preferring the managed service path and falling back to a detached daemon if service startup is unavailable or fails. By default this installs the latest stable release. Pass `--beta` to include prereleases and install the latest beta when one is newer than the current stable release. If the daemon is running, update first requires it to already be using the same executable path as the binary running `no-mistakes update`; if that daemon executable path cannot be determined or it points to a different binary, the update aborts before replacement. If the daemon does not come back cleanly after a successful replacement, the command reports that failure. On macOS, removes the quarantine extended attribute.
 
 Because `update` installs the latest official release binary, the replacement binary may already have telemetry enabled if a telemetry website ID was embedded at build time.
 

--- a/docs/src/content/docs/start-here/installation.md
+++ b/docs/src/content/docs/start-here/installation.md
@@ -61,9 +61,12 @@ See [Provider Integration](/no-mistakes/guides/provider-integration/) for PR and
 
 ```sh
 no-mistakes update
+no-mistakes update --beta
 ```
 
 This downloads the latest release from GitHub, verifies the SHA-256 checksum, atomically replaces the binary, and resets the daemon so it picks up the new executable. It prefers the managed service path and falls back to a detached daemon if service startup is unavailable or fails.
+
+`no-mistakes update` installs the latest stable release. Use `no-mistakes update --beta` to opt into prereleases and install the latest beta when one is newer than the current stable release.
 
 Because `update` installs the latest official release binary, it may change telemetry behavior if that release has a telemetry website ID embedded at build time.
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -6,14 +6,17 @@ import (
 )
 
 func newUpdateCmd() *cobra.Command {
-	return &cobra.Command{
+	var beta bool
+	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update no-mistakes and reset the daemon",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return trackCommand("update", func() error {
-				return update.Run(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr())
+				return update.Run(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), update.RunOptions{Beta: beta})
 			})
 		},
 	}
+	cmd.Flags().BoolVar(&beta, "beta", false, "install the latest release including prereleases")
+	return cmd
 }

--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -14,3 +14,13 @@ func TestUpdateCommandDevBuild(t *testing.T) {
 		t.Fatalf("unexpected update output: %s", out)
 	}
 }
+
+func TestUpdateCommandBetaFlag(t *testing.T) {
+	out, err := executeCmd("update", "--beta")
+	if err != nil {
+		t.Fatalf("update --beta failed: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(out, "self-update unavailable for development builds") {
+		t.Fatalf("unexpected update output: %s", out)
+	}
+}

--- a/internal/update/release.go
+++ b/internal/update/release.go
@@ -19,8 +19,10 @@ type releaseAsset struct {
 }
 
 type releaseResponse struct {
-	TagName string         `json:"tag_name"`
-	Assets  []releaseAsset `json:"assets"`
+	TagName    string         `json:"tag_name"`
+	Draft      bool           `json:"draft"`
+	Prerelease bool           `json:"prerelease"`
+	Assets     []releaseAsset `json:"assets"`
 }
 
 type releasePlan struct {
@@ -84,6 +86,9 @@ func (u *updater) fetchLatestRelease(ctx context.Context) (*releaseResponse, err
 	if u.httpClient == nil {
 		u.httpClient = &http.Client{Timeout: 30 * time.Second}
 	}
+	if u.includePrereleases {
+		return u.fetchLatestReleaseIncludingPrereleases(ctx)
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(u.apiBaseURL, "/")+"/repos/"+u.repo+"/releases/latest", nil)
 	if err != nil {
 		return nil, fmt.Errorf("build release request: %w", err)
@@ -111,6 +116,52 @@ func (u *updater) fetchLatestRelease(ctx context.Context) (*releaseResponse, err
 		return nil, fmt.Errorf("latest release missing tag_name")
 	}
 	return &release, nil
+}
+
+func (u *updater) fetchLatestReleaseIncludingPrereleases(ctx context.Context) (*releaseResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(u.apiBaseURL, "/")+"/repos/"+u.repo+"/releases", nil)
+	if err != nil {
+		return nil, fmt.Errorf("build release request: %w", err)
+	}
+	resp, err := u.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch releases: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch releases: unexpected status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxAPIResponseSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("read releases: %w", err)
+	}
+	if len(body) > maxAPIResponseSize {
+		return nil, fmt.Errorf("releases response exceeds %d bytes", maxAPIResponseSize)
+	}
+	var releases []releaseResponse
+	if err := json.Unmarshal(body, &releases); err != nil {
+		return nil, fmt.Errorf("parse releases: %w", err)
+	}
+	var best *releaseResponse
+	var bestVer semVersion
+	for i := range releases {
+		r := &releases[i]
+		if r.Draft || r.TagName == "" {
+			continue
+		}
+		v, err := parseVersion(r.TagName)
+		if err != nil {
+			continue
+		}
+		if best == nil || v.compare(bestVer) > 0 {
+			best = r
+			bestVer = v
+		}
+	}
+	if best == nil {
+		return nil, fmt.Errorf("no releases found")
+	}
+	return best, nil
 }
 
 func (u *updater) downloadAsset(ctx context.Context, assetURL string, limit int64) ([]byte, error) {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -42,29 +42,35 @@ type platformSpec struct {
 }
 
 type updater struct {
-	appName           string
-	repo              string
-	currentVersion    string
-	platform          platformSpec
-	apiBaseURL        string
-	httpClient        *http.Client
-	cachePath         string
-	executablePath    string
-	stdout            io.Writer
-	stderr            io.Writer
-	now               func() time.Time
-	spawnBackground   func(currentVersion string) error
-	resetDaemon       func() error
-	paths             *paths.Paths
-	disableBackground bool
-	noColor           bool
+	appName            string
+	repo               string
+	currentVersion     string
+	platform           platformSpec
+	apiBaseURL         string
+	httpClient         *http.Client
+	cachePath          string
+	executablePath     string
+	stdout             io.Writer
+	stderr             io.Writer
+	now                func() time.Time
+	spawnBackground    func(currentVersion string) error
+	resetDaemon        func() error
+	paths              *paths.Paths
+	disableBackground  bool
+	noColor            bool
+	includePrereleases bool
 }
 
-func Run(ctx context.Context, stdout, stderr io.Writer) error {
+type RunOptions struct {
+	Beta bool
+}
+
+func Run(ctx context.Context, stdout, stderr io.Writer, opts RunOptions) error {
 	u, err := defaultUpdater(stdout, stderr)
 	if err != nil {
 		return err
 	}
+	u.includePrereleases = opts.Beta
 	return u.run(ctx)
 }
 

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -644,6 +644,88 @@ func TestUpdaterMaybeNotifyAndCheck(t *testing.T) {
 	}
 }
 
+func TestUpdaterCheckLatestBetaUsesReleasesList(t *testing.T) {
+	allowInsecureDownloads = true
+	t.Cleanup(func() { allowInsecureDownloads = false })
+
+	archiveName := "no-mistakes-v1.3.0-beta.1-darwin-arm64.tar.gz"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/kunchenguid/no-mistakes/releases" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		fmt.Fprintf(w, `[
+			{"tag_name":"v1.3.0-beta.1","draft":false,"prerelease":true,"assets":[{"name":%q,"browser_download_url":"http://example.com/archive"},{"name":"checksums.txt","browser_download_url":"http://example.com/checksums"}]},
+			{"tag_name":"v1.2.3","draft":false,"prerelease":false,"assets":[]},
+			{"tag_name":"v1.4.0-draft","draft":true,"prerelease":true,"assets":[]}
+		]`, archiveName)
+	}))
+	defer server.Close()
+
+	u := &updater{
+		appName:            "no-mistakes",
+		repo:               "kunchenguid/no-mistakes",
+		currentVersion:     "v1.2.3",
+		platform:           platformSpec{GOOS: "darwin", GOARCH: "arm64"},
+		apiBaseURL:         server.URL,
+		httpClient:         server.Client(),
+		cachePath:          filepath.Join(t.TempDir(), "update-check.json"),
+		now:                func() time.Time { return time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC) },
+		includePrereleases: true,
+	}
+
+	plan, err := u.checkLatest(context.Background())
+	if err != nil {
+		t.Fatalf("checkLatest error = %v", err)
+	}
+	if !plan.UpdateAvailable {
+		t.Fatal("expected update to be available")
+	}
+	if plan.LatestVersion != "v1.3.0-beta.1" {
+		t.Fatalf("LatestVersion = %q", plan.LatestVersion)
+	}
+	if plan.ArchiveName != archiveName {
+		t.Fatalf("ArchiveName = %q", plan.ArchiveName)
+	}
+}
+
+func TestUpdaterCheckLatestBetaPicksHighestSemver(t *testing.T) {
+	allowInsecureDownloads = true
+	t.Cleanup(func() { allowInsecureDownloads = false })
+
+	archiveName := "no-mistakes-v1.3.0-beta.2-darwin-arm64.tar.gz"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/kunchenguid/no-mistakes/releases" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		fmt.Fprintf(w, `[
+			{"tag_name":"v1.3.0-beta.1","draft":false,"prerelease":true,"assets":[]},
+			{"tag_name":"v1.3.0-beta.2","draft":false,"prerelease":true,"assets":[{"name":%q,"browser_download_url":"http://example.com/archive"},{"name":"checksums.txt","browser_download_url":"http://example.com/checksums"}]},
+			{"tag_name":"v1.2.3","draft":false,"prerelease":false,"assets":[]}
+		]`, archiveName)
+	}))
+	defer server.Close()
+
+	u := &updater{
+		appName:            "no-mistakes",
+		repo:               "kunchenguid/no-mistakes",
+		currentVersion:     "v1.2.3",
+		platform:           platformSpec{GOOS: "darwin", GOARCH: "arm64"},
+		apiBaseURL:         server.URL,
+		httpClient:         server.Client(),
+		cachePath:          filepath.Join(t.TempDir(), "update-check.json"),
+		now:                func() time.Time { return time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC) },
+		includePrereleases: true,
+	}
+
+	plan, err := u.checkLatest(context.Background())
+	if err != nil {
+		t.Fatalf("checkLatest error = %v", err)
+	}
+	if plan.LatestVersion != "v1.3.0-beta.2" {
+		t.Fatalf("LatestVersion = %q", plan.LatestVersion)
+	}
+}
+
 func TestUpdaterCachedLatestVersion(t *testing.T) {
 	cachePath := filepath.Join(t.TempDir(), "update-check.json")
 	if err := writeCache(cachePath, &checkCache{

--- a/workflow_release_test.go
+++ b/workflow_release_test.go
@@ -165,7 +165,7 @@ func TestReleaseWorkflowDoesNotOverrideReleaseType(t *testing.T) {
 	}
 }
 
-func TestReleaseWorkflowPromotesDraftOnlyAfterAssetsComplete(t *testing.T) {
+func TestReleaseWorkflowPublishesPrereleaseOnlyAfterAssetsComplete(t *testing.T) {
 	data, err := os.ReadFile(".github/workflows/release.yml")
 	if err != nil {
 		t.Fatalf("read workflow: %v", err)
@@ -182,12 +182,15 @@ func TestReleaseWorkflowPromotesDraftOnlyAfterAssetsComplete(t *testing.T) {
 		"needs.release-please.outputs.release_created == 'true'",
 		"gh release edit",
 		"--draft=false",
-		"--latest=true",
+		"--prerelease=true",
 	}
 	for _, req := range required {
 		if !strings.Contains(block, req) {
-			t.Fatalf("finalize job must contain %q so a draft is only promoted to latest after every asset job succeeds", req)
+			t.Fatalf("finalize job must contain %q so a draft is only published as prerelease after every asset job succeeds", req)
 		}
+	}
+	if strings.Contains(block, "--latest=true") {
+		t.Fatalf("finalize job must not auto-promote to latest; latest is set manually")
 	}
 
 	for _, dep := range []string{"release-please", "build-and-upload", "checksums"} {


### PR DESCRIPTION
## Summary
- add beta-aware release discovery in `internal/update` and expose it via `no-mistakes update --beta`, with tests covering prerelease selection and CLI behavior
- update the release workflow to publish beta builds as GitHub prereleases so the beta channel can consume them
- refresh the CLI reference and installation docs to explain opting into beta updates and how that differs from the default stable path

## Risk Assessment

🚨 High: This change alters release publication semantics and update-channel selection in ways that can hide future releases from stable users and leave beta users off the intended channel after installation.

## Testing

- Summary: <code>Exercised the updater prerelease-selection path, the `update --beta` CLI wiring, and the release workflow prerelease publish guardrails; all targeted tests passed.</code>
- `go test ./internal/update`
- `go test ./internal/cli`
- `go test . -run 'TestReleaseWorkflow|TestReleasePleaseConfig|TestExtractJobBlock'`
- Outcome: ✅ passed across 1 run (1m14s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 2 issues (1 error, 1 warning)</summary>

**Round 1** - found 2 issues (1 error, 1 warning)
- 🚨 `.github/workflows/release.yml:206` - The finalize step now marks every published release as `prerelease`. The default self-update path still queries GitHub&#39;s `/releases/latest`, which excludes prereleases, so ordinary users will stop seeing new releases unless someone manually clears the prerelease flag afterward.
- ⚠️ `internal/update/update.go:73` - The new beta channel is only applied to the foreground `update --beta` command. Background refreshes, cached version checks, and upgrade notifications still use the stable-only path, so a user who installs a beta build will not automatically discover later beta builds.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/update`
- `go test ./internal/cli`
- `go test . -run 'TestReleaseWorkflow|TestReleasePleaseConfig|TestExtractJobBlock'`

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed</summary>

**Round 1** - found 2 warnings
- ⚠️ `docs/src/content/docs/reference/cli.md:118` - The CLI reference for `no-mistakes update` is now stale: the command gained a public `--beta` flag in `internal/cli/update.go`, but this section still documents only `no-mistakes update` with no flag table or explanation that `--beta` switches release discovery to include prereleases.
- ⚠️ `docs/src/content/docs/start-here/installation.md:60` - The installation guide&#39;s Update section only describes downloading the latest stable release. This change adds a beta update channel (`no-mistakes update --beta`) and the release workflow now publishes releases as prereleases, so the guide should document how users opt into prerelease installs and how that differs from the default update path.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
