### PR TITLE
fix(agent): harden structured JSON fallback parsing

### DIFF
--- a/cmd/fakeagent/codex.go
+++ b/cmd/fakeagent/codex.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 )
 
 func runCodex(args []string, scenario *Scenario) int {
@@ -14,6 +15,20 @@ func runCodex(args []string, scenario *Scenario) int {
 	action := scenario.Match(prompt)
 	if err := applyEdits(action.Edits); err != nil {
 		return 1
+	}
+
+	// Real codex constrains output to --output-schema, so the fake
+	// mirrors that by trimming the scenario's catch-all structured map
+	// to only fields declared in the schema. Otherwise no-mistakes'
+	// schema validation rejects the extra fields the defaultScenario
+	// carries to satisfy other steps (e.g. pr's title/body).
+	if schemaPath := extractCodexOutputSchema(args); schemaPath != "" && action.Structured != nil {
+		filtered, err := filterStructuredToSchema(action.Structured, schemaPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "fakeagent: codex schema filter: %v\n", err)
+			return 1
+		}
+		action.Structured = filtered
 	}
 
 	// Replay recorded codex output if a fixture is available. no-mistakes
@@ -110,6 +125,51 @@ func patchCodexFixture(raw []byte, action Action) ([]byte, error) {
 		out.WriteByte('\n')
 	}
 	return out.Bytes(), nil
+}
+
+// extractCodexOutputSchema returns the --output-schema value from the
+// argv, supporting both `--output-schema path` and `--output-schema=path`.
+// Returns "" when the flag is absent.
+func extractCodexOutputSchema(args []string) string {
+	for i, a := range args {
+		switch {
+		case a == "--output-schema" && i+1 < len(args):
+			return args[i+1]
+		case strings.HasPrefix(a, "--output-schema="):
+			return strings.TrimPrefix(a, "--output-schema=")
+		}
+	}
+	return ""
+}
+
+// filterStructuredToSchema drops fields from structured that are not
+// declared as properties on the top-level object schema at schemaPath.
+// Real codex would not emit undeclared fields under --output-schema, so
+// mirroring that behaviour keeps the fake consistent with no-mistakes'
+// additionalProperties:false validation. schemaPath == "" is a no-op.
+func filterStructuredToSchema(structured map[string]any, schemaPath string) (map[string]any, error) {
+	if schemaPath == "" {
+		return structured, nil
+	}
+	data, err := os.ReadFile(schemaPath)
+	if err != nil {
+		return nil, fmt.Errorf("read schema %s: %w", schemaPath, err)
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(data, &schema); err != nil {
+		return nil, fmt.Errorf("parse schema %s: %w", schemaPath, err)
+	}
+	properties, _ := schema["properties"].(map[string]any)
+	if properties == nil {
+		return structured, nil
+	}
+	filtered := make(map[string]any, len(properties))
+	for key, value := range structured {
+		if _, ok := properties[key]; ok {
+			filtered[key] = value
+		}
+	}
+	return filtered, nil
 }
 
 // extractCodexPrompt finds the prompt positional. Real codex argv is

--- a/cmd/fakeagent/codex_test.go
+++ b/cmd/fakeagent/codex_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -68,6 +71,88 @@ func TestPatchCodexFixturePlainRunRewritesAgentMessageText(t *testing.T) {
 	}
 	if item.Item.Text != "scenario text" {
 		t.Fatalf("agent_message text = %q, want scenario text", item.Item.Text)
+	}
+}
+
+func TestFilterStructuredToSchemaKeepsOnlyDeclaredProperties(t *testing.T) {
+	schemaPath := filepath.Join(t.TempDir(), "schema.json")
+	schema := []byte(`{
+		"type": "object",
+		"properties": {
+			"findings": {"type": "array"},
+			"risk_level": {"type": "string"},
+			"risk_rationale": {"type": "string"}
+		},
+		"required": ["findings", "risk_level", "risk_rationale"]
+	}`)
+	if err := os.WriteFile(schemaPath, schema, 0o644); err != nil {
+		t.Fatalf("write schema: %v", err)
+	}
+
+	structured := map[string]any{
+		"findings":        []any{},
+		"risk_level":      "low",
+		"risk_rationale":  "no risks",
+		"summary":         "no issues found",
+		"tested":          []any{"x"},
+		"testing_summary": "simulated tests passed",
+		"title":           "feat: extra",
+		"body":            "extra body",
+	}
+
+	got, err := filterStructuredToSchema(structured, schemaPath)
+	if err != nil {
+		t.Fatalf("filter: %v", err)
+	}
+	want := map[string]any{
+		"findings":       []any{},
+		"risk_level":     "low",
+		"risk_rationale": "no risks",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("filtered = %#v\nwant = %#v", got, want)
+	}
+}
+
+func TestFilterStructuredToSchemaNilWhenNoSchema(t *testing.T) {
+	structured := map[string]any{"summary": "ok"}
+	got, err := filterStructuredToSchema(structured, "")
+	if err != nil {
+		t.Fatalf("filter: %v", err)
+	}
+	if !reflect.DeepEqual(got, structured) {
+		t.Fatalf("got %#v, want passthrough %#v", got, structured)
+	}
+}
+
+func TestExtractCodexOutputSchemaPath(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "separate flag",
+			args: []string{"exec", "--output-schema", "/tmp/s.json", "prompt", "--json"},
+			want: "/tmp/s.json",
+		},
+		{
+			name: "equals form",
+			args: []string{"exec", "--output-schema=/tmp/s.json", "prompt", "--json"},
+			want: "/tmp/s.json",
+		},
+		{
+			name: "absent",
+			args: []string{"exec", "prompt", "--json"},
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractCodexOutputSchema(tc.args); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -115,7 +115,7 @@ Spawns a `claude` subprocess for each invocation with `--output-format stream-js
 
 ## Codex
 
-Spawns a `codex` subprocess for each invocation with `exec --json`. When structured output is requested, no-mistakes also writes a normalized schema file and passes it with `--output-schema`. By default it also adds `--dangerously-bypass-approvals-and-sandbox`, unless you already set your own Codex approval or sandbox flag through `agent_args_override`. Reads JSONL events. Structured output is returned from the final `agent_message` text, with fenced JSON accepted as a fallback.
+Spawns a `codex` subprocess for each invocation with `exec --json`. When structured output is requested, no-mistakes also writes a normalized schema file and passes it with `--output-schema`. By default it also adds `--dangerously-bypass-approvals-and-sandbox`, unless you already set your own Codex approval or sandbox flag through `agent_args_override`. Reads JSONL events. Structured output is returned from the final `agent_message` text, with fallback parsing that accepts JSON fences, inline fence markers, or a final bare JSON object after prose.
 
 ## Rovo Dev
 

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -105,7 +105,7 @@ All agents implement the same interface. Each invocation receives:
 
 Each invocation returns:
 
-- **Output** - structured JSON output (when schema was provided)
+- **Output** - structured JSON output validated against the normalized schema; optional fields may be `null`
 - **Text** - raw text output
 - **Usage** - token counts (input, output, cache read, cache creation)
 
@@ -115,15 +115,15 @@ Spawns a `claude` subprocess for each invocation with `--output-format stream-js
 
 ## Codex
 
-Spawns a `codex` subprocess for each invocation with `exec --json`. When structured output is requested, no-mistakes also writes a normalized schema file and passes it with `--output-schema`. By default it also adds `--dangerously-bypass-approvals-and-sandbox`, unless you already set your own Codex approval or sandbox flag through `agent_args_override`. Reads JSONL events. Structured output is returned from the final `agent_message` text, with fallback parsing that accepts JSON fences, inline fence markers, or a final bare JSON object after prose.
+Spawns a `codex` subprocess for each invocation with `exec --json`. When structured output is requested, no-mistakes also writes a normalized schema file and passes it with `--output-schema`. By default it also adds `--dangerously-bypass-approvals-and-sandbox`, unless you already set your own Codex approval or sandbox flag through `agent_args_override`. Reads JSONL events. Structured output is returned from the final `agent_message` text, with fallback parsing that accepts JSON fences, inline fence markers, or a final bare JSON object after prose, then validates the result against the normalized schema.
 
 ## Rovo Dev
 
-Starts a persistent HTTP server (`acli rovodev serve`) on first use and reuses it across invocations. Any `agent_args_override.rovodev` flags are inserted before no-mistakes' managed serve flags. Communicates via REST API and SSE streaming. Each invocation creates a session, sends the prompt, streams results, then deletes the session. Structured output is handled by injecting schema instructions into a system prompt, then parsing the final text with fallback parsing that accepts JSON fences, inline fence markers, or a final bare JSON object after prose.
+Starts a persistent HTTP server (`acli rovodev serve`) on first use and reuses it across invocations. Any `agent_args_override.rovodev` flags are inserted before no-mistakes' managed serve flags. Communicates via REST API and SSE streaming. Each invocation creates a session, sends the prompt, streams results, then deletes the session. Structured output is handled by injecting schema instructions into a system prompt, then parsing the final text with fallback parsing that accepts JSON fences, inline fence markers, or a final bare JSON object after prose, and validates the result against the normalized schema.
 
 ## OpenCode
 
-Starts a persistent HTTP server (`opencode serve`) on first use. Any `agent_args_override.opencode` flags are inserted before no-mistakes' managed serve flags. Similar session lifecycle to Rovo Dev: create session, send message, stream SSE events until idle, delete session. Supports `json_schema` format in the message request for structured output, and falls back to parsing the final text with the same JSON fence and bare-object fallback when native structured output is absent.
+Starts a persistent HTTP server (`opencode serve`) on first use. Any `agent_args_override.opencode` flags are inserted before no-mistakes' managed serve flags. Similar session lifecycle to Rovo Dev: create session, send message, stream SSE events until idle, delete session. Supports `json_schema` format in the message request for structured output, and falls back to parsing the final text with the same JSON fence and bare-object fallback when native structured output is absent, validating the result against the normalized schema.
 
 ## Checking agent availability
 

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -105,7 +105,7 @@ All agents implement the same interface. Each invocation receives:
 
 Each invocation returns:
 
-- **Output** - structured JSON output validated against the normalized schema; optional fields may be `null`
+- **Output** - structured JSON output; native structured responses are returned as-is, while text-parsed fallbacks are validated before return and may use `null` for optional fields
 - **Text** - raw text output
 - **Usage** - token counts (input, output, cache read, cache creation)
 
@@ -119,11 +119,11 @@ Spawns a `codex` subprocess for each invocation with `exec --json`. When structu
 
 ## Rovo Dev
 
-Starts a persistent HTTP server (`acli rovodev serve`) on first use and reuses it across invocations. Any `agent_args_override.rovodev` flags are inserted before no-mistakes' managed serve flags. Communicates via REST API and SSE streaming. Each invocation creates a session, sends the prompt, streams results, then deletes the session. Structured output is handled by injecting schema instructions into a system prompt, then parsing the final text with fallback parsing that accepts JSON fences, inline fence markers, or a final bare JSON object after prose, and validates the result against the normalized schema.
+Starts a persistent HTTP server (`acli rovodev serve`) on first use and reuses it across invocations. Any `agent_args_override.rovodev` flags are inserted before no-mistakes' managed serve flags. Communicates via REST API and SSE streaming. Each invocation creates a session, sends the prompt, streams results, then deletes the session. Structured output is handled by injecting schema instructions into a system prompt, then parsing the final text with fallback parsing that accepts JSON fences, inline fence markers, or a final bare JSON object after prose, and validates the result against the requested schema while allowing `null` for optional fields.
 
 ## OpenCode
 
-Starts a persistent HTTP server (`opencode serve`) on first use. Any `agent_args_override.opencode` flags are inserted before no-mistakes' managed serve flags. Similar session lifecycle to Rovo Dev: create session, send message, stream SSE events until idle, delete session. Supports `json_schema` format in the message request for structured output, and falls back to parsing the final text with the same JSON fence and bare-object fallback when native structured output is absent, validating the result against the normalized schema.
+Starts a persistent HTTP server (`opencode serve`) on first use. Any `agent_args_override.opencode` flags are inserted before no-mistakes' managed serve flags. Similar session lifecycle to Rovo Dev: create session, send message, stream SSE events until idle, delete session. Supports `json_schema` format in the message request for structured output. When native structured output is absent, it falls back to parsing the final text with the same JSON fence and bare-object fallback, validating that fallback result against the requested schema while allowing `null` for optional fields.
 
 ## Checking agent availability
 

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -119,11 +119,11 @@ Spawns a `codex` subprocess for each invocation with `exec --json`. When structu
 
 ## Rovo Dev
 
-Starts a persistent HTTP server (`acli rovodev serve`) on first use and reuses it across invocations. Any `agent_args_override.rovodev` flags are inserted before no-mistakes' managed serve flags. Communicates via REST API and SSE streaming. Each invocation creates a session, sends the prompt, streams results, then deletes the session. Structured output is handled by injecting schema instructions into a system prompt.
+Starts a persistent HTTP server (`acli rovodev serve`) on first use and reuses it across invocations. Any `agent_args_override.rovodev` flags are inserted before no-mistakes' managed serve flags. Communicates via REST API and SSE streaming. Each invocation creates a session, sends the prompt, streams results, then deletes the session. Structured output is handled by injecting schema instructions into a system prompt, then parsing the final text with fallback parsing that accepts JSON fences, inline fence markers, or a final bare JSON object after prose.
 
 ## OpenCode
 
-Starts a persistent HTTP server (`opencode serve`) on first use. Any `agent_args_override.opencode` flags are inserted before no-mistakes' managed serve flags. Similar session lifecycle to Rovo Dev: create session, send message, stream SSE events until idle, delete session. Supports `json_schema` format in the message request for structured output.
+Starts a persistent HTTP server (`opencode serve`) on first use. Any `agent_args_override.opencode` flags are inserted before no-mistakes' managed serve flags. Similar session lifecycle to Rovo Dev: create session, send message, stream SSE events until idle, delete session. Supports `json_schema` format in the message request for structured output, and falls back to parsing the final text with the same JSON fence and bare-object fallback when native structured output is absent.
 
 ## Checking agent availability
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -47,7 +47,7 @@ func finalizeTextResult(agentName, text string, schema json.RawMessage, usage To
 		return &Result{Text: text, Usage: usage}, nil
 	}
 
-	output, err := parseStructuredTextOutput(text)
+	output, err := parseStructuredTextOutput(text, schema)
 	if err != nil {
 		return nil, fmt.Errorf("%s output parse: %w", agentName, err)
 	}
@@ -55,35 +55,43 @@ func finalizeTextResult(agentName, text string, schema json.RawMessage, usage To
 	return &Result{Output: output, Text: text, Usage: usage}, nil
 }
 
-func parseStructuredTextOutput(text string) (json.RawMessage, error) {
-	var output json.RawMessage
-	if err := json.Unmarshal([]byte(text), &output); err == nil {
+func parseStructuredTextOutput(text string, schema json.RawMessage) (json.RawMessage, error) {
+	output, rawErr := parseStructuredCandidate([]byte(text), schema)
+	if rawErr == nil {
 		return output, nil
-	} else {
-		rawErr := err
-
-		candidates := fencedJSONCandidates(text)
-		var parsed []json.RawMessage
-		for _, candidate := range candidates {
-			var fenced json.RawMessage
-			if err := json.Unmarshal([]byte(candidate), &fenced); err == nil {
-				parsed = append(parsed, fenced)
-			}
-		}
-		switch len(parsed) {
-		case 0:
-			// fall through to bare-object scan
-		case 1:
-			return parsed[0], nil
-		default:
-			return nil, fmt.Errorf("multiple JSON code fences found in output")
-		}
-
-		if bare := lastBareJSONObject(text); bare != nil {
-			return bare, nil
-		}
-		return nil, rawErr
 	}
+
+	candidates := fencedJSONCandidates(text)
+	var parsed []json.RawMessage
+	var candidateErr error
+	for _, candidate := range candidates {
+		fenced, err := parseStructuredCandidate([]byte(candidate), schema)
+		if err == nil {
+			parsed = append(parsed, fenced)
+			continue
+		}
+		if candidateErr == nil {
+			candidateErr = err
+		}
+	}
+	switch len(parsed) {
+	case 0:
+	case 1:
+		return parsed[0], nil
+	default:
+		return nil, fmt.Errorf("multiple JSON code fences found in output")
+	}
+
+	if bare, err := lastBareJSONObject(text, schema); err == nil {
+		return bare, nil
+	} else if candidateErr == nil && err != nil {
+		candidateErr = err
+	}
+
+	if candidateErr != nil {
+		return nil, candidateErr
+	}
+	return nil, rawErr
 }
 
 // fencedJSONCandidates extracts JSON bodies from ```json ... ``` fences.
@@ -99,7 +107,7 @@ func fencedJSONCandidates(text string) []string {
 			return candidates
 		}
 		body := rest[start:]
-		end := strings.Index(body, "```")
+		end := indexJSONFenceClose(body)
 		if end < 0 {
 			return candidates
 		}
@@ -138,11 +146,27 @@ func indexJSONFenceOpen(text string) int {
 	}
 }
 
+func indexJSONFenceClose(text string) int {
+	lineStart := true
+	for i := 0; i < len(text); i++ {
+		if lineStart && strings.HasPrefix(text[i:], "```") {
+			return i
+		}
+		lineStart = text[i] == '\n'
+	}
+	trimmed := strings.TrimRight(text, " \t\r\n")
+	if strings.HasSuffix(trimmed, "```") {
+		return len(trimmed) - 3
+	}
+	return -1
+}
+
 // lastBareJSONObject scans text for balanced {...} substrings that parse
 // as JSON and returns the last one found. This handles models that emit
 // reasoning prose followed by a raw JSON answer, with no code fence.
-func lastBareJSONObject(text string) json.RawMessage {
+func lastBareJSONObject(text string, schema json.RawMessage) (json.RawMessage, error) {
 	var last json.RawMessage
+	var lastErr error
 	for i := 0; i < len(text); i++ {
 		if text[i] != '{' {
 			continue
@@ -152,13 +176,19 @@ func lastBareJSONObject(text string) json.RawMessage {
 			continue
 		}
 		candidate := text[i:end]
-		var obj json.RawMessage
-		if err := json.Unmarshal([]byte(candidate), &obj); err == nil {
+		obj, err := parseStructuredCandidate([]byte(candidate), schema)
+		if err == nil {
 			last = obj
-			i = end - 1
+			lastErr = nil
+		} else if lastErr == nil {
+			lastErr = err
 		}
+		i = end - 1
 	}
-	return last
+	if last != nil {
+		return last, nil
+	}
+	return nil, lastErr
 }
 
 // scanBalancedObject returns the exclusive end index of a brace-balanced
@@ -197,6 +227,48 @@ func scanBalancedObject(text string, start int) (int, bool) {
 		}
 	}
 	return 0, false
+}
+
+func parseStructuredCandidate(candidate, schema []byte) (json.RawMessage, error) {
+	var output json.RawMessage
+	if err := json.Unmarshal(candidate, &output); err != nil {
+		return nil, err
+	}
+	if err := validateStructuredOutput(output, schema); err != nil {
+		return nil, err
+	}
+	return output, nil
+}
+
+func validateStructuredOutput(output, schema json.RawMessage) error {
+	required, err := schemaRequiredFields(schema)
+	if err != nil || len(required) == 0 {
+		return err
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(output, &object); err != nil {
+		return fmt.Errorf("JSON output must be an object")
+	}
+	var missing []string
+	for _, key := range required {
+		if _, ok := object[key]; !ok {
+			missing = append(missing, key)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("JSON output missing required fields: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+func schemaRequiredFields(schema json.RawMessage) ([]string, error) {
+	var raw struct {
+		Required []string `json:"required"`
+	}
+	if err := json.Unmarshal(schema, &raw); err != nil {
+		return nil, err
+	}
+	return raw.Required, nil
 }
 
 // Total returns input + output tokens (the billing-relevant total).

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -29,9 +29,14 @@ type RunOpts struct {
 
 // Result holds the output of an agent invocation.
 type Result struct {
-	Output json.RawMessage // structured output matching the normalized JSONSchema; optional fields may be nullable
-	Text   string          // raw text output
-	Usage  TokenUsage
+	// Output is structured JSON returned by the agent. Text-parsed fallback
+	// results are validated before return, and optional fields may be
+	// nullable there.
+	Output json.RawMessage
+	// Text is the raw text output.
+	Text string
+	// Usage tracks token consumption for the invocation.
+	Usage TokenUsage
 }
 
 // TokenUsage tracks token consumption for an agent invocation.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -29,7 +29,7 @@ type RunOpts struct {
 
 // Result holds the output of an agent invocation.
 type Result struct {
-	Output json.RawMessage // structured output matching JSONSchema
+	Output json.RawMessage // structured output matching the normalized JSONSchema; optional fields may be nullable
 	Text   string          // raw text output
 	Usage  TokenUsage
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -59,7 +59,12 @@ func finalizeTextResult(agentName, text string, schema json.RawMessage, usage To
 }
 
 func parseStructuredTextOutput(text string, schema json.RawMessage) (json.RawMessage, error) {
-	output, rawErr := parseStructuredCandidate([]byte(text), schema)
+	validationSchema, err := textValidationSchema(schema)
+	if err != nil {
+		return nil, err
+	}
+
+	output, rawErr := parseStructuredCandidate([]byte(text), validationSchema)
 	if rawErr == nil {
 		return output, nil
 	}
@@ -68,7 +73,7 @@ func parseStructuredTextOutput(text string, schema json.RawMessage) (json.RawMes
 	var parsed []json.RawMessage
 	var candidateErr error
 	for _, candidate := range candidates {
-		fenced, err := parseStructuredCandidate([]byte(candidate), schema)
+		fenced, err := parseStructuredCandidate([]byte(candidate), validationSchema)
 		if err == nil {
 			parsed = append(parsed, fenced)
 			continue
@@ -85,7 +90,7 @@ func parseStructuredTextOutput(text string, schema json.RawMessage) (json.RawMes
 		return nil, fmt.Errorf("multiple JSON code fences found in output")
 	}
 
-	if bare, err := lastBareJSONObject(text, schema); err == nil && bare != nil {
+	if bare, err := lastBareJSONObject(text, validationSchema); err == nil && bare != nil {
 		return bare, nil
 	} else if candidateErr == nil && err != nil {
 		candidateErr = err
@@ -95,6 +100,19 @@ func parseStructuredTextOutput(text string, schema json.RawMessage) (json.RawMes
 		return nil, candidateErr
 	}
 	return nil, rawErr
+}
+
+func textValidationSchema(schema json.RawMessage) (json.RawMessage, error) {
+	if len(schema) == 0 {
+		return nil, nil
+	}
+
+	var value any
+	if err := json.Unmarshal(schema, &value); err != nil {
+		return nil, err
+	}
+	allowOptionalSchemaNulls(value)
+	return json.Marshal(value)
 }
 
 // fencedJSONCandidates extracts JSON bodies from ```json ... ``` fences.
@@ -313,6 +331,26 @@ func validateStructuredOutput(output, schema json.RawMessage) error {
 		return fmt.Errorf("JSON output %w", err)
 	}
 	return nil
+}
+
+func allowOptionalSchemaNulls(value any) {
+	schema, ok := value.(map[string]any)
+	if !ok {
+		return
+	}
+
+	required := requiredSet(schema)
+	if properties, ok := schema["properties"].(map[string]any); ok {
+		for name, property := range properties {
+			allowOptionalSchemaNulls(property)
+			if !required[name] {
+				allowSchemaNull(property)
+			}
+		}
+	}
+	if items, ok := schema["items"]; ok {
+		allowOptionalSchemaNulls(items)
+	}
 }
 
 func decodeJSONValue(raw []byte) (any, error) {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -85,7 +85,7 @@ func parseStructuredTextOutput(text string, schema json.RawMessage) (json.RawMes
 		return nil, fmt.Errorf("multiple JSON code fences found in output")
 	}
 
-	if bare, err := lastBareJSONObject(text, schema); err == nil {
+	if bare, err := lastBareJSONObject(text, schema); err == nil && bare != nil {
 		return bare, nil
 	} else if candidateErr == nil && err != nil {
 		candidateErr = err
@@ -123,30 +123,61 @@ func fencedJSONCandidates(text string) []string {
 // following an opening ```json fence (the char after the info line's
 // newline), or -1 if no opener exists.
 func indexJSONFenceOpen(text string) int {
-	search := text
-	offset := 0
-	for {
-		i := strings.Index(search, "```")
+	for searchStart := 0; searchStart < len(text); {
+		i := strings.Index(text[searchStart:], "```")
 		if i < 0 {
 			return -1
 		}
-		after := search[i+3:]
-		lineEnd := strings.IndexByte(after, '\n')
-		var info string
-		if lineEnd < 0 {
-			info = after
-		} else {
-			info = after[:lineEnd]
-		}
+		i += searchStart
+		contentStart, info := fenceContentStart(text, i)
 		if strings.EqualFold(strings.TrimSpace(info), "json") {
-			if lineEnd < 0 {
-				return offset + i + 3 + len(after)
-			}
-			return offset + i + 3 + lineEnd + 1
+			return contentStart
 		}
-		offset += i + 3
-		search = after
+		next := skipFenceBlock(text[contentStart:])
+		if next < 0 {
+			return -1
+		}
+		searchStart = contentStart + next
 	}
+	return -1
+}
+
+func fenceContentStart(text string, fenceStart int) (int, string) {
+	after := text[fenceStart+3:]
+	lineEnd := strings.IndexByte(after, '\n')
+	if lineEnd < 0 {
+		return fenceStart + 3 + len(after), after
+	}
+	return fenceStart + 3 + lineEnd + 1, after[:lineEnd]
+}
+
+func skipFenceBlock(text string) int {
+	depth := 1
+	for lineStart := 0; lineStart < len(text); {
+		lineEnd := strings.IndexByte(text[lineStart:], '\n')
+		if lineEnd < 0 {
+			lineEnd = len(text)
+		} else {
+			lineEnd += lineStart
+		}
+		line := text[lineStart:lineEnd]
+		trimmed := strings.TrimLeft(line, " \t")
+		if strings.HasPrefix(trimmed, "```") {
+			if strings.TrimSpace(trimmed[3:]) == "" {
+				depth--
+				if depth == 0 {
+					return lineStart + (len(line) - len(trimmed)) + 3
+				}
+			} else {
+				depth++
+			}
+		}
+		if lineEnd == len(text) {
+			break
+		}
+		lineStart = lineEnd + 1
+	}
+	return -1
 }
 
 func indexJSONFenceClose(text string) (int, int) {
@@ -182,6 +213,15 @@ func lastBareJSONObject(text string, schema json.RawMessage) (json.RawMessage, e
 	var last json.RawMessage
 	var lastErr error
 	for i := 0; i < len(text); i++ {
+		if strings.HasPrefix(text[i:], "```") {
+			contentStart, _ := fenceContentStart(text, i)
+			next := skipFenceBlock(text[contentStart:])
+			if next < 0 {
+				break
+			}
+			i = contentStart + next - 1
+			continue
+		}
 		if text[i] != '{' {
 			continue
 		}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1,9 +1,12 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/types"
@@ -107,12 +110,12 @@ func fencedJSONCandidates(text string) []string {
 			return candidates
 		}
 		body := rest[start:]
-		end := indexJSONFenceClose(body)
+		end, next := indexJSONFenceClose(body)
 		if end < 0 {
 			return candidates
 		}
 		candidates = append(candidates, body[:end])
-		rest = body[end+3:]
+		rest = body[next:]
 	}
 }
 
@@ -146,19 +149,30 @@ func indexJSONFenceOpen(text string) int {
 	}
 }
 
-func indexJSONFenceClose(text string) int {
-	lineStart := true
-	for i := 0; i < len(text); i++ {
-		if lineStart && strings.HasPrefix(text[i:], "```") {
-			return i
+func indexJSONFenceClose(text string) (int, int) {
+	for lineStart := 0; lineStart < len(text); {
+		lineEnd := strings.IndexByte(text[lineStart:], '\n')
+		if lineEnd < 0 {
+			lineEnd = len(text)
+		} else {
+			lineEnd += lineStart
 		}
-		lineStart = text[i] == '\n'
+		line := text[lineStart:lineEnd]
+		trimmed := strings.TrimLeft(line, " \t")
+		if strings.HasPrefix(trimmed, "```") {
+			indent := len(line) - len(trimmed)
+			return lineStart, lineStart + indent + 3
+		}
+		if lineEnd == len(text) {
+			break
+		}
+		lineStart = lineEnd + 1
 	}
 	trimmed := strings.TrimRight(text, " \t\r\n")
 	if strings.HasSuffix(trimmed, "```") {
-		return len(trimmed) - 3
+		return len(trimmed) - 3, len(trimmed)
 	}
-	return -1
+	return -1, -1
 }
 
 // lastBareJSONObject scans text for balanced {...} substrings that parse
@@ -241,34 +255,209 @@ func parseStructuredCandidate(candidate, schema []byte) (json.RawMessage, error)
 }
 
 func validateStructuredOutput(output, schema json.RawMessage) error {
-	required, err := schemaRequiredFields(schema)
-	if err != nil || len(required) == 0 {
+	if len(schema) == 0 {
+		return nil
+	}
+
+	var parsedSchema any
+	if err := json.Unmarshal(schema, &parsedSchema); err != nil {
 		return err
 	}
-	var object map[string]json.RawMessage
-	if err := json.Unmarshal(output, &object); err != nil {
-		return fmt.Errorf("JSON output must be an object")
+
+	value, err := decodeJSONValue(output)
+	if err != nil {
+		return err
 	}
-	var missing []string
-	for _, key := range required {
-		if _, ok := object[key]; !ok {
-			missing = append(missing, key)
-		}
-	}
-	if len(missing) > 0 {
-		return fmt.Errorf("JSON output missing required fields: %s", strings.Join(missing, ", "))
+
+	if err := validateJSONValue(value, parsedSchema, ""); err != nil {
+		return fmt.Errorf("JSON output %w", err)
 	}
 	return nil
 }
 
-func schemaRequiredFields(schema json.RawMessage) ([]string, error) {
-	var raw struct {
-		Required []string `json:"required"`
-	}
-	if err := json.Unmarshal(schema, &raw); err != nil {
+func decodeJSONValue(raw []byte) (any, error) {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var value any
+	if err := dec.Decode(&value); err != nil {
 		return nil, err
 	}
-	return raw.Required, nil
+	if err := dec.Decode(&struct{}{}); err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+	return value, nil
+}
+
+func validateJSONValue(value, schema any, path string) error {
+	schemaMap, ok := schema.(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	if enum, ok := schemaMap["enum"].([]any); ok && !matchesEnum(value, enum) {
+		return fmt.Errorf("%smust match one of the allowed values", formatJSONPath(path))
+	}
+
+	if types, ok := schemaTypes(schemaMap); ok && !matchesAnyType(value, types) {
+		return fmt.Errorf("%smust be %s", formatJSONPath(path), strings.Join(types, " or "))
+	}
+
+	if object, ok := value.(map[string]any); ok {
+		if err := validateJSONObject(object, schemaMap, path); err != nil {
+			return err
+		}
+	}
+	if array, ok := value.([]any); ok {
+		if err := validateJSONArray(array, schemaMap, path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateJSONObject(object map[string]any, schema map[string]any, path string) error {
+	required := stringSlice(schema["required"])
+	for _, key := range required {
+		if _, ok := object[key]; !ok {
+			return fmt.Errorf("%smissing required field %q", formatJSONPath(path), key)
+		}
+	}
+
+	properties, _ := schema["properties"].(map[string]any)
+	if additional, ok := schema["additionalProperties"].(bool); ok && !additional {
+		for key := range object {
+			if _, ok := properties[key]; !ok {
+				return fmt.Errorf("%scontains unknown field %q", formatJSONPath(path), key)
+			}
+		}
+	}
+
+	for key, propSchema := range properties {
+		child, ok := object[key]
+		if !ok {
+			continue
+		}
+		if err := validateJSONValue(child, propSchema, joinJSONPath(path, key)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateJSONArray(array []any, schema map[string]any, path string) error {
+	itemsSchema, ok := schema["items"]
+	if !ok {
+		return nil
+	}
+	for i, item := range array {
+		if err := validateJSONValue(item, itemsSchema, fmt.Sprintf("%s[%d]", path, i)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func schemaTypes(schema map[string]any) ([]string, bool) {
+	switch raw := schema["type"].(type) {
+	case string:
+		return []string{raw}, true
+	case []any:
+		types := stringSlice(raw)
+		return types, len(types) > 0
+	default:
+		return nil, false
+	}
+}
+
+func stringSlice(raw any) []string {
+	items, ok := raw.([]any)
+	if !ok {
+		if single, ok := raw.([]string); ok {
+			return single
+		}
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		str, ok := item.(string)
+		if !ok {
+			continue
+		}
+		out = append(out, str)
+	}
+	return out
+}
+
+func matchesAnyType(value any, types []string) bool {
+	for _, typ := range types {
+		if matchesType(value, typ) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesType(value any, typ string) bool {
+	switch typ {
+	case "object":
+		_, ok := value.(map[string]any)
+		return ok
+	case "array":
+		_, ok := value.([]any)
+		return ok
+	case "string":
+		_, ok := value.(string)
+		return ok
+	case "integer":
+		number, ok := value.(json.Number)
+		return ok && isJSONInteger(number)
+	case "number":
+		_, ok := value.(json.Number)
+		return ok
+	case "boolean":
+		_, ok := value.(bool)
+		return ok
+	case "null":
+		return value == nil
+	default:
+		return true
+	}
+}
+
+func isJSONInteger(number json.Number) bool {
+	_, err := number.Int64()
+	return err == nil
+}
+
+func matchesEnum(value any, allowed []any) bool {
+	valueJSON, err := json.Marshal(value)
+	if err != nil {
+		return false
+	}
+	for _, candidate := range allowed {
+		candidateJSON, err := json.Marshal(candidate)
+		if err != nil {
+			continue
+		}
+		if bytes.Equal(valueJSON, candidateJSON) {
+			return true
+		}
+	}
+	return false
+}
+
+func joinJSONPath(path, key string) string {
+	if path == "" {
+		return key
+	}
+	return path + "." + key
+}
+
+func formatJSONPath(path string) string {
+	if path == "" {
+		return ""
+	}
+	return path + " "
 }
 
 // Total returns input + output tokens (the billing-relevant total).

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -61,6 +61,7 @@ func parseStructuredTextOutput(text string) (json.RawMessage, error) {
 		return output, nil
 	} else {
 		rawErr := err
+
 		candidates := fencedJSONCandidates(text)
 		var parsed []json.RawMessage
 		for _, candidate := range candidates {
@@ -71,46 +72,131 @@ func parseStructuredTextOutput(text string) (json.RawMessage, error) {
 		}
 		switch len(parsed) {
 		case 0:
-			return nil, rawErr
+			// fall through to bare-object scan
 		case 1:
 			return parsed[0], nil
 		default:
 			return nil, fmt.Errorf("multiple JSON code fences found in output")
 		}
+
+		if bare := lastBareJSONObject(text); bare != nil {
+			return bare, nil
+		}
+		return nil, rawErr
 	}
 }
 
+// fencedJSONCandidates extracts JSON bodies from ```json ... ``` fences.
+// Fence markers may appear anywhere in the text, including glued to the end
+// of a preceding line (e.g. "...behavior.```json"), which is a shape real
+// codex/GPT-5 output regularly produces.
 func fencedJSONCandidates(text string) []string {
 	var candidates []string
-	var b strings.Builder
-	inJSONFence := false
-
-	for _, line := range strings.Split(text, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if !inJSONFence {
-			if !strings.HasPrefix(trimmed, "```") {
-				continue
-			}
-			info := strings.TrimSpace(strings.TrimPrefix(trimmed, "```"))
-			fields := strings.Fields(info)
-			if len(fields) == 0 || !strings.EqualFold(fields[0], "json") {
-				continue
-			}
-			inJSONFence = true
-			b.Reset()
-			continue
+	rest := text
+	for {
+		start := indexJSONFenceOpen(rest)
+		if start < 0 {
+			return candidates
 		}
-
-		if strings.HasPrefix(trimmed, "```") {
-			candidates = append(candidates, b.String())
-			inJSONFence = false
-			continue
+		body := rest[start:]
+		end := strings.Index(body, "```")
+		if end < 0 {
+			return candidates
 		}
-		b.WriteString(line)
-		b.WriteByte('\n')
+		candidates = append(candidates, body[:end])
+		rest = body[end+3:]
 	}
+}
 
-	return candidates
+// indexJSONFenceOpen returns the byte offset of the content immediately
+// following an opening ```json fence (the char after the info line's
+// newline), or -1 if no opener exists.
+func indexJSONFenceOpen(text string) int {
+	search := text
+	offset := 0
+	for {
+		i := strings.Index(search, "```")
+		if i < 0 {
+			return -1
+		}
+		after := search[i+3:]
+		lineEnd := strings.IndexByte(after, '\n')
+		var info string
+		if lineEnd < 0 {
+			info = after
+		} else {
+			info = after[:lineEnd]
+		}
+		if strings.EqualFold(strings.TrimSpace(info), "json") {
+			if lineEnd < 0 {
+				return offset + i + 3 + len(after)
+			}
+			return offset + i + 3 + lineEnd + 1
+		}
+		offset += i + 3
+		search = after
+	}
+}
+
+// lastBareJSONObject scans text for balanced {...} substrings that parse
+// as JSON and returns the last one found. This handles models that emit
+// reasoning prose followed by a raw JSON answer, with no code fence.
+func lastBareJSONObject(text string) json.RawMessage {
+	var last json.RawMessage
+	for i := 0; i < len(text); i++ {
+		if text[i] != '{' {
+			continue
+		}
+		end, ok := scanBalancedObject(text, i)
+		if !ok {
+			continue
+		}
+		candidate := text[i:end]
+		var obj json.RawMessage
+		if err := json.Unmarshal([]byte(candidate), &obj); err == nil {
+			last = obj
+			i = end - 1
+		}
+	}
+	return last
+}
+
+// scanBalancedObject returns the exclusive end index of a brace-balanced
+// substring starting at text[start] == '{', or (0, false) if no balanced
+// closing brace exists. It respects JSON string literals so braces inside
+// strings do not affect the depth count.
+func scanBalancedObject(text string, start int) (int, bool) {
+	depth := 0
+	inString := false
+	escape := false
+	for i := start; i < len(text); i++ {
+		c := text[i]
+		if inString {
+			if escape {
+				escape = false
+				continue
+			}
+			switch c {
+			case '\\':
+				escape = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inString = true
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i + 1, true
+			}
+		}
+	}
+	return 0, false
 }
 
 // Total returns input + output tokens (the billing-relevant total).

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -237,6 +237,39 @@ func TestFinalizeTextResult_WithSchemaRejectsNestedEnumViolations(t *testing.T) 
 	}
 }
 
+func TestFinalizeTextResult_WithSchemaAllowsNullOptionalFieldsInTextFallback(t *testing.T) {
+	text := `{"findings":[{"severity":"warning","file":null,"line":null,"description":"x","action":"auto-fix"}],"summary":"1 issue"}`
+	schema := json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"findings":{
+				"type":"array",
+				"items":{
+					"type":"object",
+					"properties":{
+						"severity":{"type":"string","enum":["error","warning","info"]},
+						"file":{"type":"string"},
+						"line":{"type":"integer"},
+						"description":{"type":"string"},
+						"action":{"type":"string","enum":["no-op","auto-fix","ask-user"]}
+					},
+					"required":["severity","description","action"]
+				}
+			},
+			"summary":{"type":"string"}
+		},
+		"required":["findings","summary"]
+	}`)
+
+	result, err := finalizeTextResult("opencode", text, schema, TokenUsage{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result.Output) != text {
+		t.Fatalf("unexpected output: %s", string(result.Output))
+	}
+}
+
 func TestFinalizeTextResult_WithSchemaParsesCodexRealWorldOutput(t *testing.T) {
 	// Regression: real codex output from pipeline 01KPYD4SD644SR9JCNX6Y.
 	// Reasoning sentences were concatenated with no newlines, and the

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -311,3 +311,25 @@ func TestFencedJSONCandidates_AllowIndentedClosingFence(t *testing.T) {
 		t.Fatalf("candidate = %q, want %q", got[0], want)
 	}
 }
+
+func TestFinalizeTextResult_WithSchemaIgnoresJSONInsideNonJSONFence(t *testing.T) {
+	text := strings.Join([]string{
+		"Reasoning follows.",
+		"```markdown",
+		"Example output:",
+		"```json",
+		`{"done":true}`,
+		"```",
+		"```",
+		"Final answer: not valid JSON",
+	}, "\n")
+
+	if got := fencedJSONCandidates(text); len(got) != 0 {
+		t.Fatalf("expected no fenced JSON candidates, got %q", got)
+	}
+
+	_, err := finalizeTextResult("codex", text, json.RawMessage(`{"type":"object"}`), TokenUsage{})
+	if err == nil {
+		t.Fatal("expected parse failure")
+	}
+}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -192,6 +192,23 @@ func TestFinalizeTextResult_WithSchemaPrefersLastBareJSON(t *testing.T) {
 	}
 }
 
+func TestFinalizeTextResult_WithSchemaRejectsBareJSONMissingRequiredKeys(t *testing.T) {
+	text := `I inspected the diff and found no issues. {"foo":"bar"}`
+	schema := json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"findings":{"type":"array"},
+			"summary":{"type":"string"}
+		},
+		"required":["findings","summary"]
+	}`)
+
+	_, err := finalizeTextResult("codex", text, schema, TokenUsage{})
+	if err == nil {
+		t.Fatal("expected bare JSON missing required keys to fail")
+	}
+}
+
 func TestFinalizeTextResult_WithSchemaParsesCodexRealWorldOutput(t *testing.T) {
 	// Regression: real codex output from pipeline 01KPYD4SD644SR9JCNX6Y.
 	// Reasoning sentences were concatenated with no newlines, and the
@@ -238,5 +255,18 @@ func TestFinalizeTextResult_WithSchemaRejectsAmbiguousFencedJSON(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "multiple JSON code fences") {
 		t.Fatalf("expected multiple JSON code fences error, got %v", err)
+	}
+}
+
+func TestFencedJSONCandidates_IgnoreBackticksInsideJSONString(t *testing.T) {
+	text := "review complete\n```json\n{\"summary\":\"quoted ```snippet``` in markdown\",\"findings\":[]}\n```\npostlude"
+
+	got := fencedJSONCandidates(text)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 candidate, got %d", len(got))
+	}
+	want := "{\"summary\":\"quoted ```snippet``` in markdown\",\"findings\":[]}\n"
+	if got[0] != want {
+		t.Fatalf("candidate = %q, want %q", got[0], want)
 	}
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -125,6 +125,104 @@ func TestFinalizeTextResult_WithSchemaParsesFencedJSON(t *testing.T) {
 	}
 }
 
+func TestFinalizeTextResult_WithSchemaParsesInlineOpenFence(t *testing.T) {
+	// Codex/GPT-5 sometimes glues the opening ```json fence to the end of
+	// the prior reasoning line, with no newline between text and backticks.
+	text := "thinking about edge cases now.```json\n{\"done\":true}\n```"
+	result, err := finalizeTextResult("codex", text, json.RawMessage(`{"type":"object"}`), TokenUsage{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var output map[string]any
+	if err := json.Unmarshal(result.Output, &output); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+	if output["done"] != true {
+		t.Errorf("expected done=true, got %v", output["done"])
+	}
+}
+
+func TestFinalizeTextResult_WithSchemaParsesInlineCloseFence(t *testing.T) {
+	// Symmetric case: closing fence immediately follows the JSON with no
+	// newline before the backticks.
+	text := "prelude\n```json\n{\"done\":true}```"
+	result, err := finalizeTextResult("codex", text, json.RawMessage(`{"type":"object"}`), TokenUsage{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var output map[string]any
+	if err := json.Unmarshal(result.Output, &output); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+	if output["done"] != true {
+		t.Errorf("expected done=true, got %v", output["done"])
+	}
+}
+
+func TestFinalizeTextResult_WithSchemaParsesBareJSONAfterText(t *testing.T) {
+	// No fence at all: reasoning prose followed by a raw JSON object.
+	text := "Here's the review:\n{\"done\":true}"
+	result, err := finalizeTextResult("codex", text, json.RawMessage(`{"type":"object"}`), TokenUsage{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var output map[string]any
+	if err := json.Unmarshal(result.Output, &output); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+	if output["done"] != true {
+		t.Errorf("expected done=true, got %v", output["done"])
+	}
+}
+
+func TestFinalizeTextResult_WithSchemaPrefersLastBareJSON(t *testing.T) {
+	// If reasoning text embeds a decorative JSON object and the final
+	// answer is a separate object at the end, the final one should win.
+	text := `I considered {"foo":"bar"} as one option. Final: {"done":true}`
+	result, err := finalizeTextResult("codex", text, json.RawMessage(`{"type":"object"}`), TokenUsage{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var output map[string]any
+	if err := json.Unmarshal(result.Output, &output); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+	if output["done"] != true {
+		t.Errorf("expected done=true, got %v", output["done"])
+	}
+}
+
+func TestFinalizeTextResult_WithSchemaParsesCodexRealWorldOutput(t *testing.T) {
+	// Regression: real codex output from pipeline 01KPYD4SD644SR9JCNX6Y.
+	// Reasoning sentences were concatenated with no newlines, and the
+	// opening ```json fence was glued to the end of the last sentence.
+	text := "Reviewing the diff between `ba90e3c` and `6fdb361` first.I'm reading the patch now.I'm down to edge cases: timer semantics after multiple `result` events.```json\n" +
+		"{\n" +
+		"  \"findings\": [],\n" +
+		"  \"risk_assessment\": {\n" +
+		"    \"risk_level\": \"low\",\n" +
+		"    \"risk_rationale\": \"clean\"\n" +
+		"  }\n" +
+		"}\n" +
+		"```"
+	result, err := finalizeTextResult("codex", text, json.RawMessage(`{"type":"object"}`), TokenUsage{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var output struct {
+		Findings       []any `json:"findings"`
+		RiskAssessment struct {
+			RiskLevel string `json:"risk_level"`
+		} `json:"risk_assessment"`
+	}
+	if err := json.Unmarshal(result.Output, &output); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+	if output.RiskAssessment.RiskLevel != "low" {
+		t.Errorf("expected risk_level=low, got %q", output.RiskAssessment.RiskLevel)
+	}
+}
+
 func TestFinalizeTextResult_WithSchemaRejectsAmbiguousFencedJSON(t *testing.T) {
 	text := strings.Join([]string{
 		"```json",

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -209,6 +209,34 @@ func TestFinalizeTextResult_WithSchemaRejectsBareJSONMissingRequiredKeys(t *test
 	}
 }
 
+func TestFinalizeTextResult_WithSchemaRejectsNestedEnumViolations(t *testing.T) {
+	text := `review complete {"findings":[{"severity":"fatal","description":"x","action":"fix-it"}],"summary":"1 issue"}`
+	schema := json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"findings":{
+				"type":"array",
+				"items":{
+					"type":"object",
+					"properties":{
+						"severity":{"type":"string","enum":["error","warning","info"]},
+						"description":{"type":"string"},
+						"action":{"type":"string","enum":["auto-fix","ask-user","no-op"]}
+					},
+					"required":["severity","description","action"]
+				}
+			},
+			"summary":{"type":"string"}
+		},
+		"required":["findings","summary"]
+	}`)
+
+	_, err := finalizeTextResult("codex", text, schema, TokenUsage{})
+	if err == nil {
+		t.Fatal("expected nested enum violation to fail")
+	}
+}
+
 func TestFinalizeTextResult_WithSchemaParsesCodexRealWorldOutput(t *testing.T) {
 	// Regression: real codex output from pipeline 01KPYD4SD644SR9JCNX6Y.
 	// Reasoning sentences were concatenated with no newlines, and the
@@ -266,6 +294,19 @@ func TestFencedJSONCandidates_IgnoreBackticksInsideJSONString(t *testing.T) {
 		t.Fatalf("expected 1 candidate, got %d", len(got))
 	}
 	want := "{\"summary\":\"quoted ```snippet``` in markdown\",\"findings\":[]}\n"
+	if got[0] != want {
+		t.Fatalf("candidate = %q, want %q", got[0], want)
+	}
+}
+
+func TestFencedJSONCandidates_AllowIndentedClosingFence(t *testing.T) {
+	text := "review complete\n```json\n{\"summary\":\"ok\",\"findings\":[]}\n   ```\nnext paragraph"
+
+	got := fencedJSONCandidates(text)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 candidate, got %d", len(got))
+	}
+	want := "{\"summary\":\"ok\",\"findings\":[]}\n"
 	if got[0] != want {
 		t.Fatalf("candidate = %q, want %q", got[0], want)
 	}

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -23,6 +23,7 @@ func (a *codexAgent) Name() string { return "codex" }
 
 func (a *codexAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
 	schemaPath := ""
+	validationSchema := opts.JSONSchema
 	if len(opts.JSONSchema) > 0 {
 		f, err := os.CreateTemp("", "no-mistakes-codex-schema-*.json")
 		if err != nil {
@@ -35,6 +36,7 @@ func (a *codexAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
 			_ = os.Remove(schemaPath)
 			return nil, fmt.Errorf("codex schema normalize: %w", err)
 		}
+		validationSchema = schema
 		if _, err := f.Write(schema); err != nil {
 			_ = f.Close()
 			_ = os.Remove(schemaPath)
@@ -95,7 +97,7 @@ func (a *codexAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
 		return nil, fmt.Errorf("codex exited: %w: %s", err, detail)
 	}
 
-	return finalizeTextResult("codex", lastMessage, opts.JSONSchema, usage)
+	return finalizeTextResult("codex", lastMessage, validationSchema, usage)
 }
 
 func (a *codexAgent) Close() error { return nil }

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -242,6 +242,53 @@ exit 1
 	}
 }
 
+func TestCodexAgent_RunAcceptsNormalizedNullableFields(t *testing.T) {
+	dir := t.TempDir()
+	bin := writeFakeCodex(t, dir, `#!/bin/sh
+printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"{\"findings\":[{\"severity\":\"warning\",\"file\":null,\"line\":null,\"description\":\"x\",\"action\":\"auto-fix\"}],\"summary\":\"1 issue\"}"}}'
+printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":2}}'
+`, strings.Join([]string{
+		"@echo off",
+		"echo {\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"{\\\"findings\\\":[{\\\"severity\\\":\\\"warning\\\",\\\"file\\\":null,\\\"line\\\":null,\\\"description\\\":\\\"x\\\",\\\"action\\\":\\\"auto-fix\\\"}],\\\"summary\\\":\\\"1 issue\\\"}\"}}",
+		"echo {\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":1,\"output_tokens\":2}}",
+	}, "\r\n"))
+
+	schema := json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"findings":{
+				"type":"array",
+				"items":{
+					"type":"object",
+					"properties":{
+						"severity":{"type":"string","enum":["error","warning","info"]},
+						"file":{"type":"string"},
+						"line":{"type":"integer"},
+						"description":{"type":"string"},
+						"action":{"type":"string","enum":["no-op","auto-fix","ask-user"]}
+					},
+					"required":["severity","description","action"]
+				}
+			},
+			"summary":{"type":"string"}
+		},
+		"required":["findings","summary"]
+	}`)
+
+	ca := &codexAgent{bin: bin}
+	result, err := ca.Run(context.Background(), RunOpts{
+		Prompt:     "review",
+		CWD:        t.TempDir(),
+		JSONSchema: schema,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result.Output) != `{"findings":[{"severity":"warning","file":null,"line":null,"description":"x","action":"auto-fix"}],"summary":"1 issue"}` {
+		t.Fatalf("unexpected output: %s", string(result.Output))
+	}
+}
+
 func TestCodexOutputSchemaAddsAdditionalPropertiesFalse(t *testing.T) {
 	schema := json.RawMessage(`{
 		"type":"object",

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -64,6 +64,13 @@ var reviewFindingsSchema = json.RawMessage(`{
 				"required": ["severity", "description", "action"]
 			}
 		},
+		"tested": {
+			"type": "array",
+			"items": {"type": "string"}
+		},
+		"testing_summary": {
+			"type": "string"
+		},
 		"risk_level": {"type": "string", "enum": ["low", "medium", "high"]},
 		"risk_rationale": {"type": "string"}
 	},

--- a/internal/pipeline/steps/common_test.go
+++ b/internal/pipeline/steps/common_test.go
@@ -871,6 +871,34 @@ func TestReviewFindingsSchema_ActionAtItemLevel(t *testing.T) {
 	}
 }
 
+func TestReviewFindingsSchema_AllowsTestingMetadata(t *testing.T) {
+	t.Parallel()
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(reviewFindingsSchema, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	props := parsed["properties"].(map[string]interface{})
+
+	tested, ok := props["tested"].(map[string]interface{})
+	if !ok {
+		t.Fatal("reviewFindingsSchema missing tested property")
+	}
+	if tested["type"] != "array" {
+		t.Fatalf("expected tested to be an array, got %#v", tested["type"])
+	}
+	if tested["items"].(map[string]interface{})["type"] != "string" {
+		t.Fatalf("expected tested items to be strings, got %#v", tested["items"])
+	}
+
+	testingSummary, ok := props["testing_summary"].(map[string]interface{})
+	if !ok {
+		t.Fatal("reviewFindingsSchema missing testing_summary property")
+	}
+	if testingSummary["type"] != "string" {
+		t.Fatalf("expected testing_summary to be a string, got %#v", testingSummary["type"])
+	}
+}
+
 func TestSanitizedPreviousFindingsForPrompt_PreservesMultilineDescriptions(t *testing.T) {
 	t.Parallel()
 	raw, err := types.MarshalFindingsJSON(types.Findings{


### PR DESCRIPTION
## Summary
- Harden structured text fallback parsing in `internal/agent` so agent replies can be recovered from inline ```json fences or a trailing bare JSON object, while avoiding unrelated fenced examples and rejecting schema-invalid payloads.
- Validate parsed fallback output against the effective schema, including nullable optional fields, and align Codex fallback validation with the normalized schema it already sends via `--output-schema`.
- Add regression coverage for shared agent parsing and Codex structured output, and update the agent guide to document the actual fallback and validation behavior for Codex, Rovo Dev, and OpenCode.

## Risk Assessment

⚠️ Medium: The change is focused and mostly hardens parsing, but the fence-skipping logic still has a realistic regression that can make otherwise valid agent replies fail to parse.

## Testing

- Summary: <code>Exercised the updated `internal/agent` JSON parsing paths, including inline and bare-object fallback handling plus Codex nullable-field schema validation, and the targeted package tests passed in both normal and race runs.</code>
- `/opt/homebrew/bin/go test ./internal/agent`
- `/opt/homebrew/bin/go test -race ./internal/agent`
- Outcome: ✅ passed across 1 run (1m39s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

**Round 1** - found 2 issues (1 error, 1 warning)
- 🚨 `internal/agent/agent.go:82` - The new bare-object fallback accepts the last syntactically valid `{...}` anywhere in the transcript without checking that it matches the requested schema. In the review and lint paths, an unrelated object like `{&#34;foo&#34;:&#34;bar&#34;}` will still unmarshal into an empty `Findings` struct, which turns a malformed agent reply into a silent &#39;no findings&#39; result instead of a parse failure. Reject ambiguous bare JSON, or validate the extracted object against the expected required keys before returning it.
- ⚠️ `internal/agent/agent.go:102` - `fencedJSONCandidates` now treats the first raw ``` sequence inside the fenced body as the closing fence. That truncates otherwise valid JSON when a string field contains triple backticks, which is realistic for review summaries/descriptions that quote markdown or shell snippets. Use a real fence-line scan for the terminator instead of `strings.Index(body, &#34;```&#34;)`.

**Round 2** (auto-fix) - found 2 warnings
- ⚠️ `internal/agent/agent.go:243` - `validateStructuredOutput` only enforces the schema&#39;s top-level `required` list, so fallback parsing still accepts structurally invalid payloads as long as those keys exist. For example, a review reply like `{&#34;findings&#34;:[{&#34;severity&#34;:&#34;fatal&#34;,&#34;description&#34;:&#34;x&#34;,&#34;action&#34;:&#34;fix-it&#34;}],&#34;summary&#34;:&#34;1 issue&#34;}` now parses successfully even though it violates the nested enums, and downstream code will treat the unknown action/severity as real data instead of failing fast and retrying.
- ⚠️ `internal/agent/agent.go:149` - `indexJSONFenceClose` no longer recognizes indented closing fences except at absolute end-of-text. A valid model reply inside a list or quoted block, such as `  ```json ...\n  ```\nnext paragraph`, was handled by the previous `TrimSpace`-based parser but now returns no fenced candidate and falls back to a parse error.

**Round 3** (auto-fix) - found 2 issues (1 error, 1 warning)
- 🚨 `internal/agent/agent.go:257` - `validateStructuredOutput` checks fallback text against the original schema, not the Codex-normalized schema we actually send via `codexOutputSchema`. That means a valid Codex reply with nullable optional fields like `&#34;file&#34;: null` or `&#34;line&#34;: null` will now be rejected during text parsing even though it satisfied the requested output contract. Normalize before validating, or validate against the same schema bytes passed to Codex.
- ⚠️ `internal/agent/agent.go:181` - `lastBareJSONObject` still accepts the last schema-valid object anywhere in the transcript. If the model echoes an example payload that matches the schema and then emits a malformed final answer, this path will silently return the example object instead of failing the parse. Constrain the bare-JSON fallback to a trailing standalone object or another unambiguous boundary.

**Round 4** (auto-fix) - found 2 warnings
- ⚠️ `internal/agent/agent.go:129` - `indexJSONFenceOpen` searches for the next ```json opener without tracking whether it is already inside a different fenced block. A reply that contains a non-JSON fenced example with an inner ```json snippet can now be misparsed as the real answer, so an example payload in reasoning can silently override a malformed final response. Skip over non-JSON fences or make opener detection fence-state aware.
- ⚠️ `internal/agent/agent.go:251` - The new schema validation runs before downstream legacy normalization, so text outputs like `{&#34;items&#34;:[...],&#34;summary&#34;:&#34;...&#34;}` now fail at parse time even though the pipeline still has explicit support for legacy `items` findings payloads. If live-agent backward compatibility still matters, normalize legacy keys before validating or limit strict validation to agents/schemas that are intended to be strict.

**Round 5** (auto-fix) - found 2 warnings
- ⚠️ `internal/agent/agent.go:291` - Text fallback validation now uses the literal schema for every agent except Codex, so `rovodev` and `opencode` can reject otherwise-usable payloads like `{&#34;file&#34;:null,&#34;line&#34;:null}` against `findingsSchema`. The rest of the pipeline already tolerates those optional-null fields, and Codex explicitly normalizes them to nullable, so this creates an agent-specific parse regression instead of a real schema violation.
- ⚠️ `internal/agent/agent.go:125` - Fence opener detection still treats any raw ``` sequence in prose as a real fence. If the model says something like `Use ```json for output.` before the actual answer, the parser treats that mention as an opener, fails to find a matching close, and gives up before it can reach a later valid fenced or bare JSON result.

**Round 6** (auto-fix) - found 1 warning
- ⚠️ `internal/agent/agent.go:172` - `skipFenceBlock` only recognizes closing fences when the backticks start a new line. If the model emits a non-JSON fenced example with an inline close, such as ` ```markdown\nexample```\n```json ...`, `indexJSONFenceOpen` treats that first block as unterminated and stops scanning, so the later valid JSON answer is never parsed. Handle inline closes here too, or recover from an unterminated non-JSON block instead of aborting the scan.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `/opt/homebrew/bin/go test ./internal/agent`
- `/opt/homebrew/bin/go test -race ./internal/agent`

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed (4)</summary>

**Round 1** - found 2 warnings
- ⚠️ `docs/src/content/docs/guides/agents.md:118` - The Codex integration guide is now stale: it still says structured output falls back to fenced JSON only, but this change also accepts inline fence markers and a final bare JSON object after prose. Update the Codex section so the documented fallback behavior matches the parser in `parseStructuredTextOutput`/`lastBareJSONObject`.
- ⚠️ `internal/agent/agent.go:32` - The `Result.Output` doc comment no longer matches behavior. `parseStructuredTextOutput` now validates against a normalized schema that allows `null` for optional fields, so callers can receive output that matches the effective normalized schema rather than the original `JSONSchema` literally. Update the comment to mention that optional properties may be nullable after normalization.

**Round 2** (auto-fix) - found 2 warnings
- ⚠️ `docs/src/content/docs/guides/agents.md:122` - The Rovo Dev guide is now stale. `rovodevAgent.Run` still resolves structured output through `finalizeTextResult`, so after this change it also accepts inline ```json fences and a final bare JSON object after prose, validated against the normalized schema. Update this section so Rovo Dev&#39;s structured-output behavior matches the shared parser described in code.
- ⚠️ `docs/src/content/docs/guides/agents.md:126` - The OpenCode guide is incomplete after this change. When `Info.Structured` is absent, `opencodeAgent.Run` falls back to `finalizeTextResult`, which now accepts inline JSON fences and a final bare JSON object after prose and validates against the normalized schema. Document that fallback path here so the structured-output behavior is accurate.

**Round 3** (auto-fix) - found 1 warning
- ⚠️ `docs/src/content/docs/guides/agents.md:108` - The agent guide is still missing the new structured-output contract from `validateStructuredOutput`/`textValidationSchema`. Codex, Rovo Dev, and OpenCode text fallbacks now only succeed when the parsed JSON matches the normalized schema, and optional fields may come back as `null`. Update the `Output` description and the per-agent fallback sections so they document schema validation, not just fence and bare-object extraction.

**Round 4** (auto-fix) - found 2 warnings
- ⚠️ `docs/src/content/docs/guides/agents.md:108` - The shared `Output` description now overstates the new behavior. `Result.Output` is not universally post-validated against a normalized schema: Claude returns native `structured_output`, and OpenCode does the same when `Info.Structured` is present. Only the text-fallback paths run the new parsing/validation logic, and Codex uses a stricter normalized schema than Rovo Dev/OpenCode. Update the guide so it distinguishes native structured-output paths from text-fallback validation instead of promising normalized output for every invocation.
- ⚠️ `internal/agent/agent.go:32` - The `Result.Output` doc comment is still too broad after this change. It says all structured output matches the normalized JSON schema and may include nullable optional fields, but that is only true for text-parsed fallback results; `finalizeClaudeResult` and OpenCode&#39;s native structured-response path return agent-native JSON without this post-validation step. Narrow the comment so it matches the actual contract.

**Round 5** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
