### PR TITLE
ci: simplify release workflow and restore macOS coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,59 +14,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  check:
-    if: "!startsWith(github.event.head_commit.message, 'chore(main): release')"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: Format check
-        run: |
-          output=$(gofmt -l .)
-          if [ -n "$output" ]; then
-            echo "Files not formatted:"
-            echo "$output"
-            exit 1
-          fi
-
-      - name: Vet
-        run: go vet ./...
-
-  test:
-    if: "!startsWith(github.event.head_commit.message, 'chore(main): release')"
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: Test on Unix
-        if: runner.os != 'Windows'
-        run: go test -race ./...
-
-      - name: Test on Windows
-        if: runner.os == 'Windows'
-        run: go test ./...
-
-      - name: Build
-        run: go build ./cmd/no-mistakes
-
   release-please:
-    needs: [check, test]
-    if: |
-      !cancelled() &&
-      (needs.check.result == 'success' || needs.check.result == 'skipped') &&
-      (needs.test.result == 'success' || needs.test.result == 'skipped')
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -82,10 +30,7 @@ jobs:
   build-and-upload:
     runs-on: ubuntu-latest
     needs: release-please
-    if: |
-      !cancelled() &&
-      needs.release-please.result == 'success' &&
-      needs.release-please.outputs.release_created == 'true'
+    if: needs.release-please.outputs.release_created == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/workflow_ci_test.go
+++ b/workflow_ci_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestCIWorkflowRunsTestsOnAllSupportedDesktopPlatforms(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/ci.yml")
+	if err != nil {
+		t.Fatalf("read workflow: %v", err)
+	}
+
+	content := string(data)
+	for _, osName := range []string{"ubuntu-latest", "macos-latest", "windows-latest"} {
+		if !strings.Contains(content, osName) {
+			t.Fatalf("CI workflow must test %q", osName)
+		}
+	}
+}
+
+func TestCIWorkflowUsesRaceTestsOnUnixRunners(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/ci.yml")
+	if err != nil {
+		t.Fatalf("read workflow: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "if: runner.os != 'Windows'") {
+		t.Fatalf("CI workflow must keep the Unix test branch so macOS runs the Unix suite")
+	}
+	if !strings.Contains(content, "run: go test -race ./...") {
+		t.Fatalf("CI workflow must run the race-enabled suite on Unix runners")
+	}
+}

--- a/workflow_release_test.go
+++ b/workflow_release_test.go
@@ -22,81 +22,49 @@ func TestReleaseWorkflowUsesScopedConcurrencyGroup(t *testing.T) {
 	}
 }
 
-func TestReleaseWorkflowSkipsValidationJobsForReleaseCommits(t *testing.T) {
+func TestReleaseWorkflowDoesNotDefineValidationJobs(t *testing.T) {
 	data, err := os.ReadFile(".github/workflows/release.yml")
 	if err != nil {
 		t.Fatalf("read workflow: %v", err)
 	}
 
 	content := string(data)
-	guard := "if: \"!startsWith(github.event.head_commit.message, 'chore(main): release')\""
-	if strings.Count(content, guard) != 2 {
-		t.Fatalf("release workflow must skip both validation jobs for release commits")
-	}
-}
-
-func TestReleaseWorkflowAllowsReleasePleaseAfterSkippedValidation(t *testing.T) {
-	data, err := os.ReadFile(".github/workflows/release.yml")
-	if err != nil {
-		t.Fatalf("read workflow: %v", err)
-	}
-
-	content := string(data)
-	checks := []string{
-		"if: |",
-		"!cancelled() &&",
-		"(needs.check.result == 'success' || needs.check.result == 'skipped') &&",
-		"(needs.test.result == 'success' || needs.test.result == 'skipped')",
-	}
-	for _, check := range checks {
-		if !strings.Contains(content, check) {
-			t.Fatalf("release workflow must allow release-please to proceed when validation jobs are skipped: missing %q", check)
+	for _, job := range []string{"check", "test"} {
+		if strings.Contains(content, "\n  "+job+":\n") {
+			t.Fatalf("release workflow must not define %q; CI owns validation now", job)
 		}
 	}
 }
 
-// Regression for the v1.8.1 incident: when check/test are skipped for release
-// PR merge commits, GitHub Actions implicitly wraps downstream job `if:`
-// expressions with success(), which returns false because upstream jobs did
-// not succeed. build-and-upload and checksums must include !cancelled() (or
-// success()/always()) so the implicit wrap is skipped, and must gate on
-// release-please succeeding plus release_created=='true'.
-func TestReleaseWorkflowRunsBuildAndChecksumsAfterSkippedValidation(t *testing.T) {
+func TestReleaseWorkflowRunsReleasePleaseWithoutValidationGuards(t *testing.T) {
 	data, err := os.ReadFile(".github/workflows/release.yml")
 	if err != nil {
 		t.Fatalf("read workflow: %v", err)
 	}
-	content := string(data)
 
-	jobs := []struct {
-		name     string
-		required []string
-	}{
-		{
-			name: "build-and-upload",
-			required: []string{
-				"!cancelled()",
-				"needs.release-please.result == 'success'",
-				"needs.release-please.outputs.release_created == 'true'",
-			},
-		},
-		{
-			name: "checksums",
-			required: []string{
-				"!cancelled()",
-				"needs.release-please.result == 'success'",
-				"needs.build-and-upload.result == 'success'",
-				"needs.release-please.outputs.release_created == 'true'",
-			},
-		},
+	block := extractJobBlock(t, string(data), "release-please")
+	if strings.Contains(block, "needs:") {
+		t.Fatalf("release-please must not depend on in-workflow validation jobs")
+	}
+	guard := "!startsWith(github.event.head_commit.message, 'chore(main): release')"
+	if strings.Contains(block, guard) {
+		t.Fatalf("release-please must not carry the old release-commit skip guard")
+	}
+}
+
+func TestReleaseWorkflowBuildStartsOnlyWhenReleaseIsCreated(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/release.yml")
+	if err != nil {
+		t.Fatalf("read workflow: %v", err)
 	}
 
-	for _, j := range jobs {
-		block := extractJobBlock(t, content, j.name)
-		for _, req := range j.required {
-			if !strings.Contains(block, req) {
-				t.Fatalf("%s job must contain %q so it runs after skipped validation jobs", j.name, req)
-			}
+	block := extractJobBlock(t, string(data), "build-and-upload")
+	if !strings.Contains(block, "if: needs.release-please.outputs.release_created == 'true'") {
+		t.Fatalf("build-and-upload must run only when release-please created a release")
+	}
+	for _, unexpected := range []string{"!cancelled()", "needs.release-please.result == 'success'"} {
+		if strings.Contains(block, unexpected) {
+			t.Fatalf("build-and-upload must not keep the old skipped-validation guard %q", unexpected)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- simplify `.github/workflows/release.yml` into a release-only pipeline by removing the in-workflow `check` and `test` jobs that duplicated normal CI responsibilities
- restore macOS coverage in `.github/workflows/ci.yml` so darwin builds and tests still run before publishing release artifacts
- refresh the workflow test suite to match the new release flow and assert the three-platform CI matrix

## Risk Assessment

✅ Low: The diff is narrowly scoped to GitHub Actions workflow wiring, and the changed conditions look consistent after restoring macOS coverage in PR CI.

## Testing

- Summary: <code>I first reproduced the stale workflow-test failures, then updated the release-workflow assertions and added CI coverage for the restored macOS matrix entry, and finally re-ran the targeted workflow tests plus the full macOS `go test -race ./...` and `go build`; all of them passed.</code>
- `/opt/homebrew/bin/go test ./... -run 'TestReleaseWorkflow|TestReleasePleaseConfig|TestExtractJobBlock'`
- `/opt/homebrew/bin/go test ./... -run 'Test(CIWorkflow|ReleaseWorkflow|ReleasePleaseConfig|ExtractJobBlock)'`
- `/opt/homebrew/bin/go test -race ./...`
- `/opt/homebrew/bin/go build ./cmd/no-mistakes`
- Outcome: ⚠️ 3 issues (1 warning, 2 infos) across 1 run (4m44s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `.github/workflows/release.yml:38` - The workflow still publishes `darwin` artifacts here, but dropping the earlier `test` job removes the only GitHub Actions macOS coverage in the repo. `ci.yml` now runs only on Ubuntu and Windows, so darwin-only behavior and tests can regress without any macOS runner exercising them before a release is published.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>⚠️ **Test** - 3 issues (1 warning, 2 infos)</summary>

**Round 1** - found 3 issues (1 warning, 2 infos)
- ⚠️ `workflow_release_test.go:25` - Release workflow tests were stale: they still expected in-workflow `check`/`test` jobs and skipped-validation guards that this branch intentionally removed from `.github/workflows/release.yml`. I updated the assertions to validate the new release-only workflow shape.
- ℹ️ `workflow_ci_test.go:9` - The restored `macos-latest` CI lane had no automated workflow coverage. I added CI workflow tests that assert the three-platform matrix and the Unix race-test branch used by macOS runners.
- ℹ️ `workflow_ci_test.go` - new test file written by agent: workflow_ci_test.go
- `/opt/homebrew/bin/go test ./... -run 'TestReleaseWorkflow|TestReleasePleaseConfig|TestExtractJobBlock'`
- `/opt/homebrew/bin/go test ./... -run 'Test(CIWorkflow|ReleaseWorkflow|ReleasePleaseConfig|ExtractJobBlock)'`
- `/opt/homebrew/bin/go test -race ./...`
- `/opt/homebrew/bin/go build ./cmd/no-mistakes`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
