### PR TITLE
fix(daemon): retry busy launchd bootstrap

### DIFF
--- a/internal/daemon/service_launchd.go
+++ b/internal/daemon/service_launchd.go
@@ -5,9 +5,23 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/paths"
 	"github.com/kunchenguid/no-mistakes/internal/shellenv"
+)
+
+// Retry parameters for `launchctl bootstrap` after a preceding bootout.
+// launchctl bootout is async: it SIGTERMs the existing service and gives
+// launchd up to ~5s to finalize cleanup. During that window, bootstrap
+// returns errno 37 EPROGRESS ("Operation already in progress") and there
+// is no synchronous API to wait for the previous instance to fully detach.
+// A stop+start sequence (which is exactly what `make install` does, and
+// what `daemon restart` does) collides with this window unless bootstrap
+// is retried. Exposed as package vars so tests can shrink the timings.
+var (
+	launchctlBootstrapRetryTimeout  = 10 * time.Second
+	launchctlBootstrapRetryInterval = 200 * time.Millisecond
 )
 
 func installLaunchAgent(p *paths.Paths, exe string) error {
@@ -52,7 +66,7 @@ func startLaunchAgent(p *paths.Paths) error {
 	serviceTarget := domain + "/" + launchdServiceLabel(p)
 	path := launchAgentPath(p)
 	_, _ = serviceCommandRunner("launchctl", "bootout", serviceTarget)
-	_, bootstrapErr := serviceCommandRunner("launchctl", "bootstrap", domain, path)
+	bootstrapErr := launchctlBootstrapWithRetry(domain, path)
 	_, kickstartErr := serviceCommandRunner("launchctl", "kickstart", "-k", serviceTarget)
 	if kickstartErr != nil {
 		if bootstrapErr != nil {
@@ -61,6 +75,43 @@ func startLaunchAgent(p *paths.Paths) error {
 		return fmt.Errorf("launchctl kickstart: %w", kickstartErr)
 	}
 	return nil
+}
+
+// launchctlBootstrapWithRetry runs `launchctl bootstrap` and retries on
+// errno 37 EPROGRESS until the bootout-cleanup window closes. Non-busy
+// failures (bad plist, bad permissions) return immediately so they can
+// surface through the normal managed-start fallback path.
+func launchctlBootstrapWithRetry(domain, path string) error {
+	deadline := time.Now().Add(launchctlBootstrapRetryTimeout)
+	var lastErr error
+	for {
+		_, err := serviceCommandRunner("launchctl", "bootstrap", domain, path)
+		if err == nil {
+			return nil
+		}
+		if !launchctlBootstrapBusy(err) {
+			return err
+		}
+		lastErr = err
+		if time.Now().After(deadline) {
+			return lastErr
+		}
+		time.Sleep(launchctlBootstrapRetryInterval)
+	}
+}
+
+// launchctlBootstrapBusy reports whether a bootstrap error is the
+// "previous instance still unloading" race. launchctl surfaces this as
+// exit 37 with stderr "Bootstrap failed: 37: Operation already in
+// progress". Match both exit status and message text so we remain robust
+// to launchctl output tweaks across macOS releases.
+func launchctlBootstrapBusy(err error) bool {
+	if err == nil {
+		return false
+	}
+	text := strings.ToLower(err.Error())
+	return strings.Contains(text, "operation already in progress") ||
+		strings.Contains(text, "exit status 37")
 }
 
 func stopLaunchAgent(p *paths.Paths) error {

--- a/internal/daemon/service_launchd_test.go
+++ b/internal/daemon/service_launchd_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/paths"
 )
@@ -134,6 +135,99 @@ func TestInstallLaunchAgentKeepsLegacyPlistOnScopedWriteFailure(t *testing.T) {
 	}
 	if _, statErr := os.Stat(legacyPath); statErr != nil {
 		t.Fatalf("legacy plist should remain after failed scoped install: %v", statErr)
+	}
+}
+
+// TestStartLaunchAgentRetriesBootstrapOnEPROGRESS locks in the fix for the
+// stop+start race observed during `make install`: launchctl bootout is
+// async and SIGTERMs the old service while keeping the label registered
+// for up to ~5s. A bootstrap in that window returns exit 37 "Operation
+// already in progress". Without retry, the caller sees a hard failure and
+// falls back to the detached-daemon path, dropping the plist on the floor -
+// which breaks auto-start on reboot and was the reason the #143 PATH fix
+// never actually reached the user's launchd daemon.
+func TestStartLaunchAgentRetriesBootstrapOnEPROGRESS(t *testing.T) {
+	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+
+	cleanup := stubServiceRuntime(t)
+	defer cleanup()
+	runtimeGOOS = "darwin"
+	serviceUserHomeDir = func() (string, error) { return home, nil }
+	serviceCurrentUser = func() (*user.User, error) { return &user.User{Uid: "501"}, nil }
+
+	oldInterval := launchctlBootstrapRetryInterval
+	oldTimeout := launchctlBootstrapRetryTimeout
+	launchctlBootstrapRetryInterval = time.Millisecond
+	launchctlBootstrapRetryTimeout = 200 * time.Millisecond
+	defer func() {
+		launchctlBootstrapRetryInterval = oldInterval
+		launchctlBootstrapRetryTimeout = oldTimeout
+	}()
+
+	var bootstrapAttempts int
+	serviceCommandRunner = func(name string, args ...string) ([]byte, error) {
+		if name == "launchctl" && len(args) > 0 && args[0] == "bootstrap" {
+			bootstrapAttempts++
+			if bootstrapAttempts < 3 {
+				return []byte("Bootstrap failed: 37: Operation already in progress"),
+					fmt.Errorf("/bin/launchctl bootstrap: exit status 37: Bootstrap failed: 37: Operation already in progress")
+			}
+		}
+		return nil, nil
+	}
+
+	if err := startLaunchAgent(p); err != nil {
+		t.Fatalf("startLaunchAgent should retry bootstrap on EPROGRESS, got %v", err)
+	}
+	if bootstrapAttempts < 3 {
+		t.Fatalf("expected bootstrap to retry until success, got %d attempts", bootstrapAttempts)
+	}
+}
+
+// TestStartLaunchAgentDoesNotRetryNonBusyBootstrapErrors ensures that
+// genuine failures (bad plist, missing binary, permissions) surface fast
+// rather than being silently retried for 10 seconds.
+func TestStartLaunchAgentDoesNotRetryNonBusyBootstrapErrors(t *testing.T) {
+	p := paths.WithRoot(filepath.Join(t.TempDir(), "nm-home"))
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	home := t.TempDir()
+
+	cleanup := stubServiceRuntime(t)
+	defer cleanup()
+	runtimeGOOS = "darwin"
+	serviceUserHomeDir = func() (string, error) { return home, nil }
+	serviceCurrentUser = func() (*user.User, error) { return &user.User{Uid: "501"}, nil }
+
+	oldInterval := launchctlBootstrapRetryInterval
+	oldTimeout := launchctlBootstrapRetryTimeout
+	launchctlBootstrapRetryInterval = time.Millisecond
+	launchctlBootstrapRetryTimeout = 200 * time.Millisecond
+	defer func() {
+		launchctlBootstrapRetryInterval = oldInterval
+		launchctlBootstrapRetryTimeout = oldTimeout
+	}()
+
+	var bootstrapAttempts int
+	serviceCommandRunner = func(name string, args ...string) ([]byte, error) {
+		if name == "launchctl" && len(args) > 0 && args[0] == "bootstrap" {
+			bootstrapAttempts++
+			return []byte("Bootstrap failed: Path had bad ownership/permissions"),
+				fmt.Errorf("launchctl bootstrap: exit status 78: permissions")
+		}
+		// kickstart fails when bootstrap never completed; that's fine for
+		// this test since we only care bootstrap didn't retry.
+		return nil, fmt.Errorf("no service")
+	}
+
+	_ = startLaunchAgent(p)
+	if bootstrapAttempts != 1 {
+		t.Fatalf("expected bootstrap to run once for non-busy errors, got %d attempts", bootstrapAttempts)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Retry launchd bootstrap when `launchctl` reports a busy/in-progress state, avoiding immediate failure during transient macOS service startup races.
- Keep non-busy bootstrap errors unchanged and cover the retry path with daemon package tests, with the pipeline passing targeted daemon tests and full `go test -race ./...`.

## Risk Assessment

✅ Low: The change is narrowly scoped to retrying a known transient launchd bootstrap failure and adds focused coverage for retry and non-retry behavior.

## Testing

- Summary: Exercised the launchd bootstrap retry/non-retry paths, daemon lifecycle package tests under race, and the full race test suite; after fixing the shell PATH to find Go, everything passed.
- `go test ./internal/daemon -run 'TestStartLaunchAgentRetriesBootstrapOnEPROGRESS|TestStartLaunchAgentDoesNotRetryNonBusyBootstrapErrors|TestStartInstallsLaunchAgentAndBootstrapsManagedDaemon|TestStartRemovesLaunchAgentBeforeDetachedFallbackAfterBootoutESRCH|TestStart_ReinstallsManagedServiceWhenPlistChanged' -count=1`
- `PATH=/opt/homebrew/bin:/usr/local/go/bin:$PATH go test ./internal/daemon -run 'TestStartLaunchAgentRetriesBootstrapOnEPROGRESS|TestStartLaunchAgentDoesNotRetryNonBusyBootstrapErrors|TestStartInstallsLaunchAgentAndBootstrapsManagedDaemon|TestStartRemovesLaunchAgentBeforeDetachedFallbackAfterBootoutESRCH|TestStart_ReinstallsManagedServiceWhenPlistChanged' -count=1`
- `PATH=/opt/homebrew/bin:/usr/local/go/bin:$PATH go test -race ./internal/daemon -count=1`
- `PATH=/opt/homebrew/bin:/usr/local/go/bin:$PATH go test -race ./...`
- Outcome: ✅ passed across 1 run (3m45s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/daemon -run 'TestStartLaunchAgentRetriesBootstrapOnEPROGRESS|TestStartLaunchAgentDoesNotRetryNonBusyBootstrapErrors|TestStartInstallsLaunchAgentAndBootstrapsManagedDaemon|TestStartRemovesLaunchAgentBeforeDetachedFallbackAfterBootoutESRCH|TestStart_ReinstallsManagedServiceWhenPlistChanged' -count=1`
- `PATH=/opt/homebrew/bin:/usr/local/go/bin:$PATH go test ./internal/daemon -run 'TestStartLaunchAgentRetriesBootstrapOnEPROGRESS|TestStartLaunchAgentDoesNotRetryNonBusyBootstrapErrors|TestStartInstallsLaunchAgentAndBootstrapsManagedDaemon|TestStartRemovesLaunchAgentBeforeDetachedFallbackAfterBootoutESRCH|TestStart_ReinstallsManagedServiceWhenPlistChanged' -count=1`
- `PATH=/opt/homebrew/bin:/usr/local/go/bin:$PATH go test -race ./internal/daemon -count=1`
- `PATH=/opt/homebrew/bin:/usr/local/go/bin:$PATH go test -race ./...`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
