### PR TITLE
fix(update): resolve beta releases from tags

### DIFF
--- a/internal/update/release.go
+++ b/internal/update/release.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 )
@@ -118,10 +119,92 @@ func (u *updater) fetchLatestRelease(ctx context.Context) (*releaseResponse, err
 	return &release, nil
 }
 
+// fetchLatestReleaseIncludingPrereleases finds the highest-semver release including
+// prereleases. The unauthenticated /releases listing endpoint can lag minutes behind
+// reality at GitHub's edge, so we cross-reference it with /tags (fresher in practice)
+// and fall through to fetching the specific tag's release directly when the listing
+// hasn't caught up yet.
 func (u *updater) fetchLatestReleaseIncludingPrereleases(ctx context.Context) (*releaseResponse, error) {
+	listed, listErr := u.fetchAllReleases(ctx)
+	tags, tagsErr := u.fetchTagNames(ctx)
+	if listErr != nil && tagsErr != nil {
+		return nil, listErr
+	}
+
+	byTag := make(map[string]*releaseResponse, len(listed))
+	for i := range listed {
+		r := &listed[i]
+		if r.Draft || r.TagName == "" {
+			continue
+		}
+		byTag[r.TagName] = r
+	}
+
+	type candidate struct {
+		name string
+		ver  semVersion
+	}
+	seen := make(map[string]struct{})
+	var candidates []candidate
+	add := func(name string) {
+		if name == "" {
+			return
+		}
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		v, err := parseVersion(name)
+		if err != nil {
+			return
+		}
+		candidates = append(candidates, candidate{name: name, ver: v})
+	}
+	for _, name := range tags {
+		add(name)
+	}
+	for i := range listed {
+		if listed[i].Draft {
+			continue
+		}
+		add(listed[i].TagName)
+	}
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("no releases found")
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].ver.compare(candidates[j].ver) > 0
+	})
+
+	const maxAttempts = 5
+	var lastErr error
+	for i, c := range candidates {
+		if i >= maxAttempts {
+			break
+		}
+		if r, ok := byTag[c.name]; ok {
+			return r, nil
+		}
+		r, err := u.fetchReleaseByTag(ctx, c.name)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if r.Draft {
+			continue
+		}
+		return r, nil
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, fmt.Errorf("no releases found")
+}
+
+func (u *updater) fetchAllReleases(ctx context.Context) ([]releaseResponse, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(u.apiBaseURL, "/")+"/repos/"+u.repo+"/releases", nil)
 	if err != nil {
-		return nil, fmt.Errorf("build release request: %w", err)
+		return nil, fmt.Errorf("build releases request: %w", err)
 	}
 	resp, err := u.httpClient.Do(req)
 	if err != nil {
@@ -142,26 +225,72 @@ func (u *updater) fetchLatestReleaseIncludingPrereleases(ctx context.Context) (*
 	if err := json.Unmarshal(body, &releases); err != nil {
 		return nil, fmt.Errorf("parse releases: %w", err)
 	}
-	var best *releaseResponse
-	var bestVer semVersion
-	for i := range releases {
-		r := &releases[i]
-		if r.Draft || r.TagName == "" {
-			continue
-		}
-		v, err := parseVersion(r.TagName)
-		if err != nil {
-			continue
-		}
-		if best == nil || v.compare(bestVer) > 0 {
-			best = r
-			bestVer = v
+	return releases, nil
+}
+
+func (u *updater) fetchTagNames(ctx context.Context) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(u.apiBaseURL, "/")+"/repos/"+u.repo+"/tags?per_page=100", nil)
+	if err != nil {
+		return nil, fmt.Errorf("build tags request: %w", err)
+	}
+	resp, err := u.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch tags: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch tags: unexpected status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxAPIResponseSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("read tags: %w", err)
+	}
+	if len(body) > maxAPIResponseSize {
+		return nil, fmt.Errorf("tags response exceeds %d bytes", maxAPIResponseSize)
+	}
+	var tags []struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(body, &tags); err != nil {
+		return nil, fmt.Errorf("parse tags: %w", err)
+	}
+	names := make([]string, 0, len(tags))
+	for _, t := range tags {
+		if t.Name != "" {
+			names = append(names, t.Name)
 		}
 	}
-	if best == nil {
-		return nil, fmt.Errorf("no releases found")
+	return names, nil
+}
+
+func (u *updater) fetchReleaseByTag(ctx context.Context, tag string) (*releaseResponse, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(u.apiBaseURL, "/")+"/repos/"+u.repo+"/releases/tags/"+tag, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build release-by-tag request: %w", err)
 	}
-	return best, nil
+	resp, err := u.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch release for tag %s: %w", tag, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("no release for tag %s", tag)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch release for tag %s: unexpected status %d", tag, resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxAPIResponseSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("read release for tag %s: %w", tag, err)
+	}
+	if len(body) > maxAPIResponseSize {
+		return nil, fmt.Errorf("release response for tag %s exceeds %d bytes", tag, maxAPIResponseSize)
+	}
+	var release releaseResponse
+	if err := json.Unmarshal(body, &release); err != nil {
+		return nil, fmt.Errorf("parse release for tag %s: %w", tag, err)
+	}
+	return &release, nil
 }
 
 func (u *updater) downloadAsset(ctx context.Context, assetURL string, limit int64) ([]byte, error) {

--- a/internal/update/release.go
+++ b/internal/update/release.go
@@ -178,13 +178,15 @@ func (u *updater) fetchLatestReleaseIncludingPrereleases(ctx context.Context) (*
 
 	const maxAttempts = 5
 	var lastErr error
-	for i, c := range candidates {
-		if i >= maxAttempts {
-			break
-		}
+	attempts := 0
+	for _, c := range candidates {
 		if r, ok := byTag[c.name]; ok {
 			return r, nil
 		}
+		if attempts >= maxAttempts {
+			continue
+		}
+		attempts++
 		r, err := u.fetchReleaseByTag(ctx, c.name)
 		if err != nil {
 			lastErr = err

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -783,6 +783,64 @@ func TestUpdaterCheckLatestBetaFallsBackToTagsWhenListingStale(t *testing.T) {
 	}
 }
 
+func TestUpdaterCheckLatestBetaChecksListedReleaseAfterMissingTags(t *testing.T) {
+	allowInsecureDownloads = true
+	t.Cleanup(func() { allowInsecureDownloads = false })
+
+	archiveName := "no-mistakes-v1.3.0-beta.1-darwin-arm64.tar.gz"
+	tagFetches := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/kunchenguid/no-mistakes/releases":
+			fmt.Fprintf(w, `[
+				{"tag_name":"v1.3.0-beta.1","draft":false,"prerelease":true,"assets":[{"name":%q,"browser_download_url":"http://example.com/archive"},{"name":"checksums.txt","browser_download_url":"http://example.com/checksums"}]},
+				{"tag_name":"v1.2.3","draft":false,"prerelease":false,"assets":[]}
+			]`, archiveName)
+		case "/repos/kunchenguid/no-mistakes/tags":
+			fmt.Fprint(w, `[
+				{"name":"v1.3.0-beta.6"},
+				{"name":"v1.3.0-beta.5"},
+				{"name":"v1.3.0-beta.4"},
+				{"name":"v1.3.0-beta.3"},
+				{"name":"v1.3.0-beta.2"},
+				{"name":"v1.3.0-beta.1"},
+				{"name":"v1.2.3"}
+			]`)
+		default:
+			if strings.HasPrefix(r.URL.Path, "/repos/kunchenguid/no-mistakes/releases/tags/") {
+				tagFetches++
+				http.NotFound(w, r)
+				return
+			}
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	u := &updater{
+		appName:            "no-mistakes",
+		repo:               "kunchenguid/no-mistakes",
+		currentVersion:     "v1.2.3",
+		platform:           platformSpec{GOOS: "darwin", GOARCH: "arm64"},
+		apiBaseURL:         server.URL,
+		httpClient:         server.Client(),
+		cachePath:          filepath.Join(t.TempDir(), "update-check.json"),
+		now:                func() time.Time { return time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC) },
+		includePrereleases: true,
+	}
+
+	plan, err := u.checkLatest(context.Background())
+	if err != nil {
+		t.Fatalf("checkLatest error = %v", err)
+	}
+	if plan.LatestVersion != "v1.3.0-beta.1" {
+		t.Fatalf("LatestVersion = %q", plan.LatestVersion)
+	}
+	if tagFetches != 5 {
+		t.Fatalf("tagFetches = %d, want 5", tagFetches)
+	}
+}
+
 func TestUpdaterCachedLatestVersion(t *testing.T) {
 	cachePath := filepath.Join(t.TempDir(), "update-check.json")
 	if err := writeCache(cachePath, &checkCache{

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -650,14 +650,18 @@ func TestUpdaterCheckLatestBetaUsesReleasesList(t *testing.T) {
 
 	archiveName := "no-mistakes-v1.3.0-beta.1-darwin-arm64.tar.gz"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/repos/kunchenguid/no-mistakes/releases" {
+		switch r.URL.Path {
+		case "/repos/kunchenguid/no-mistakes/releases":
+			fmt.Fprintf(w, `[
+				{"tag_name":"v1.3.0-beta.1","draft":false,"prerelease":true,"assets":[{"name":%q,"browser_download_url":"http://example.com/archive"},{"name":"checksums.txt","browser_download_url":"http://example.com/checksums"}]},
+				{"tag_name":"v1.2.3","draft":false,"prerelease":false,"assets":[]},
+				{"tag_name":"v1.4.0-draft","draft":true,"prerelease":true,"assets":[]}
+			]`, archiveName)
+		case "/repos/kunchenguid/no-mistakes/tags":
+			fmt.Fprint(w, `[{"name":"v1.3.0-beta.1"},{"name":"v1.2.3"}]`)
+		default:
 			t.Fatalf("unexpected path %q", r.URL.Path)
 		}
-		fmt.Fprintf(w, `[
-			{"tag_name":"v1.3.0-beta.1","draft":false,"prerelease":true,"assets":[{"name":%q,"browser_download_url":"http://example.com/archive"},{"name":"checksums.txt","browser_download_url":"http://example.com/checksums"}]},
-			{"tag_name":"v1.2.3","draft":false,"prerelease":false,"assets":[]},
-			{"tag_name":"v1.4.0-draft","draft":true,"prerelease":true,"assets":[]}
-		]`, archiveName)
 	}))
 	defer server.Close()
 
@@ -694,14 +698,18 @@ func TestUpdaterCheckLatestBetaPicksHighestSemver(t *testing.T) {
 
 	archiveName := "no-mistakes-v1.3.0-beta.2-darwin-arm64.tar.gz"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/repos/kunchenguid/no-mistakes/releases" {
+		switch r.URL.Path {
+		case "/repos/kunchenguid/no-mistakes/releases":
+			fmt.Fprintf(w, `[
+				{"tag_name":"v1.3.0-beta.1","draft":false,"prerelease":true,"assets":[]},
+				{"tag_name":"v1.3.0-beta.2","draft":false,"prerelease":true,"assets":[{"name":%q,"browser_download_url":"http://example.com/archive"},{"name":"checksums.txt","browser_download_url":"http://example.com/checksums"}]},
+				{"tag_name":"v1.2.3","draft":false,"prerelease":false,"assets":[]}
+			]`, archiveName)
+		case "/repos/kunchenguid/no-mistakes/tags":
+			fmt.Fprint(w, `[{"name":"v1.3.0-beta.2"},{"name":"v1.3.0-beta.1"},{"name":"v1.2.3"}]`)
+		default:
 			t.Fatalf("unexpected path %q", r.URL.Path)
 		}
-		fmt.Fprintf(w, `[
-			{"tag_name":"v1.3.0-beta.1","draft":false,"prerelease":true,"assets":[]},
-			{"tag_name":"v1.3.0-beta.2","draft":false,"prerelease":true,"assets":[{"name":%q,"browser_download_url":"http://example.com/archive"},{"name":"checksums.txt","browser_download_url":"http://example.com/checksums"}]},
-			{"tag_name":"v1.2.3","draft":false,"prerelease":false,"assets":[]}
-		]`, archiveName)
 	}))
 	defer server.Close()
 
@@ -723,6 +731,55 @@ func TestUpdaterCheckLatestBetaPicksHighestSemver(t *testing.T) {
 	}
 	if plan.LatestVersion != "v1.3.0-beta.2" {
 		t.Fatalf("LatestVersion = %q", plan.LatestVersion)
+	}
+}
+
+func TestUpdaterCheckLatestBetaFallsBackToTagsWhenListingStale(t *testing.T) {
+	allowInsecureDownloads = true
+	t.Cleanup(func() { allowInsecureDownloads = false })
+
+	archiveName := "no-mistakes-v1.3.0-beta.1-darwin-arm64.tar.gz"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/kunchenguid/no-mistakes/releases":
+			fmt.Fprint(w, `[
+				{"tag_name":"v1.2.3","draft":false,"prerelease":false,"assets":[]},
+				{"tag_name":"v1.2.2","draft":false,"prerelease":false,"assets":[]}
+			]`)
+		case "/repos/kunchenguid/no-mistakes/tags":
+			fmt.Fprint(w, `[{"name":"v1.3.0-beta.1"},{"name":"v1.2.3"},{"name":"v1.2.2"}]`)
+		case "/repos/kunchenguid/no-mistakes/releases/tags/v1.3.0-beta.1":
+			fmt.Fprintf(w, `{"tag_name":"v1.3.0-beta.1","draft":false,"prerelease":true,"assets":[{"name":%q,"browser_download_url":"http://example.com/archive"},{"name":"checksums.txt","browser_download_url":"http://example.com/checksums"}]}`, archiveName)
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	u := &updater{
+		appName:            "no-mistakes",
+		repo:               "kunchenguid/no-mistakes",
+		currentVersion:     "v1.2.3",
+		platform:           platformSpec{GOOS: "darwin", GOARCH: "arm64"},
+		apiBaseURL:         server.URL,
+		httpClient:         server.Client(),
+		cachePath:          filepath.Join(t.TempDir(), "update-check.json"),
+		now:                func() time.Time { return time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC) },
+		includePrereleases: true,
+	}
+
+	plan, err := u.checkLatest(context.Background())
+	if err != nil {
+		t.Fatalf("checkLatest error = %v", err)
+	}
+	if !plan.UpdateAvailable {
+		t.Fatal("expected update to be available")
+	}
+	if plan.LatestVersion != "v1.3.0-beta.1" {
+		t.Fatalf("LatestVersion = %q", plan.LatestVersion)
+	}
+	if plan.ArchiveName != archiveName {
+		t.Fatalf("ArchiveName = %q", plan.ArchiveName)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Updated beta release discovery to consider semver prerelease tags when GitHub releases are missing, so beta update checks can resolve tag-backed releases.
- Fixed fallback limiting so known releases are still considered even when newer beta tags require tag-by-tag lookup.
- Expanded `internal/update` tests for beta tag discovery, fallback behavior, and version parsing/comparison coverage.

## Risk Assessment

✅ Low: The change is narrowly scoped to prerelease release discovery, preserves the previous listed-release path, and the new tag fallback has bounded network behavior with coverage for the previously reported edge case.

## Testing

- Summary: Exercised the beta release/tag fallback update logic directly, the full update package, and the repository test suite; all completed successfully after fixing the local PATH to include the installed Go toolchain.
- `PATH=/opt/homebrew/bin:$PATH go test ./internal/update -run 'TestUpdaterCheckLatestBeta|TestCompareVersions|TestParseVersion' -count=1`
- `PATH=/opt/homebrew/bin:$PATH go test ./internal/update -count=1`
- `PATH=/opt/homebrew/bin:$PATH go test ./... -count=1`
- Outcome: ✅ passed across 1 run (1m42s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/update/release.go:179` - `maxAttempts` is applied to the combined sorted candidate list, including releases already returned by `/releases`. If the repo has five newer semver tags without GitHub releases, this loop exits before considering a known listed release below them and returns the last 404 instead of the latest valid release. Limit only the tag-by-tag fallback fetches, or always allow candidates present in `byTag` to be considered.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `PATH=/opt/homebrew/bin:$PATH go test ./internal/update -run 'TestUpdaterCheckLatestBeta|TestCompareVersions|TestParseVersion' -count=1`
- `PATH=/opt/homebrew/bin:$PATH go test ./internal/update -count=1`
- `PATH=/opt/homebrew/bin:$PATH go test ./... -count=1`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
