### PR TITLE
fix(telemetry): reduce event data volume

### DIFF
--- a/docs/src/content/docs/reference/environment.md
+++ b/docs/src/content/docs/reference/environment.md
@@ -78,7 +78,7 @@ Override or enable the telemetry website ID.
 
 When set, telemetry uses this website ID at runtime. If it is unset in a dev build, `no-mistakes` also checks a repo-local `.env` file for `NO_MISTAKES_UMAMI_WEBSITE_ID`. If no runtime value is found, it falls back to any website ID embedded at build time.
 
-When telemetry is enabled, `no-mistakes` sends command, run, approval, fix, and wizard events, selected completed step events, and pageviews for `/wizard` and `/tui` to Umami Cloud at `https://cloud.umami.is/api/send`.
+When telemetry is enabled, `no-mistakes` sends command, run, approval, fix, and wizard events, completed step events with `awaiting_approval`, `fix_review`, or `failed` status, and pageviews for `/wizard` and `/tui` to Umami Cloud at `https://cloud.umami.is/api/send`.
 
 ## `NO_MISTAKES_TELEMETRY`
 

--- a/docs/src/content/docs/reference/environment.md
+++ b/docs/src/content/docs/reference/environment.md
@@ -78,7 +78,18 @@ Override or enable the telemetry website ID.
 
 When set, telemetry uses this website ID at runtime. If it is unset in a dev build, `no-mistakes` also checks a repo-local `.env` file for `NO_MISTAKES_UMAMI_WEBSITE_ID`. If no runtime value is found, it falls back to any website ID embedded at build time.
 
-When telemetry is enabled, `no-mistakes` sends command, run, step, approval, fix, and wizard events plus pageviews for `/wizard` and `/tui`, along with app version, platform, and build-channel metadata, to Umami Cloud at `https://cloud.umami.is/api/send`.
+When telemetry is enabled, `no-mistakes` sends command, run, approval, fix, and wizard events, selected completed step events, and pageviews for `/wizard` and `/tui` to Umami Cloud at `https://cloud.umami.is/api/send`.
+
+## `NO_MISTAKES_TELEMETRY`
+
+Disable telemetry collection.
+
+| | |
+|---|---|
+| Type | `0`, `false`, or `off` to disable; anything else to leave enabled |
+| Default | unset |
+
+When set to a disabling value, telemetry stays off even if a runtime or embedded website ID is available.
 
 ## Environment the daemon sees
 

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -546,6 +546,9 @@ func (e *Executor) emitStepEventWithFindingsDiffAndError(eventType ipc.EventType
 		event.Diff = &diff
 	}
 	e.onEvent(event)
+	if !shouldTrackStepTelemetry(eventType, status) {
+		return
+	}
 
 	fields := telemetry.Fields{
 		"event":  string(eventType),
@@ -562,6 +565,18 @@ func (e *Executor) emitStepEventWithFindingsDiffAndError(eventType ipc.EventType
 		fields["findings_count"] = findingsCount(findings)
 	}
 	telemetry.Track("step", fields)
+}
+
+func shouldTrackStepTelemetry(eventType ipc.EventType, status string) bool {
+	if eventType != ipc.EventStepCompleted {
+		return false
+	}
+	switch types.StepStatus(status) {
+	case types.StepStatusAwaitingApproval, types.StepStatusFixReview, types.StepStatusFailed:
+		return true
+	default:
+		return false
+	}
 }
 
 func (e *Executor) emitLogChunk(run *db.Run, repo *db.Repo, stepName types.StepName, content string) {

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -209,6 +209,31 @@ func TestExecutor_StepError_FailsRun(t *testing.T) {
 	}
 }
 
+func TestExecutor_FailedStepEmitsTelemetry(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	recorder := &telemetryRecorder{}
+	restore := telemetry.SetDefaultForTesting(recorder)
+	defer restore()
+
+	exec := NewExecutor(database, p, nil, nil, []Step{
+		newFailStep(types.StepReview, fmt.Errorf("review crashed")),
+	}, nil)
+
+	if err := exec.Execute(context.Background(), run, repo, workDir); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	event := recorder.find("step", "status", string(types.StepStatusFailed))
+	if event == nil {
+		t.Fatal("expected failed step telemetry event")
+	}
+	if got := event.fields["step"]; got != string(types.StepReview) {
+		t.Fatalf("step telemetry step = %v, want %q", got, types.StepReview)
+	}
+}
+
 func TestExecutor_FailedStepRecordsDuration(t *testing.T) {
 	database, p, run, repo := setupTest(t)
 	workDir := t.TempDir()

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
+	"github.com/kunchenguid/no-mistakes/internal/telemetry"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
@@ -59,6 +60,54 @@ func TestExecutor_AllStepsPass(t *testing.T) {
 		if e := events.find(ipc.EventStepCompleted, name); e == nil {
 			t.Errorf("missing step_completed event for %s", name)
 		}
+	}
+}
+
+func TestExecutor_SuccessfulStepsDoNotEmitTelemetry(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	recorder := &telemetryRecorder{}
+	restore := telemetry.SetDefaultForTesting(recorder)
+	defer restore()
+
+	exec := NewExecutor(database, p, nil, nil, []Step{
+		newPassStep(types.StepReview),
+		newPassStep(types.StepTest),
+	}, nil)
+
+	if err := exec.Execute(context.Background(), run, repo, workDir); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if event := recorder.find("step", "", nil); event != nil {
+		t.Fatalf("successful steps should not emit step telemetry, got %v", event.fields)
+	}
+}
+
+func TestExecutor_SkippedStepsDoNotEmitTelemetry(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	recorder := &telemetryRecorder{}
+	restore := telemetry.SetDefaultForTesting(recorder)
+	defer restore()
+
+	skipStep := &mockStep{
+		name:    types.StepRebase,
+		outcome: &StepOutcome{ExitCode: 0, SkipRemaining: true},
+	}
+	exec := NewExecutor(database, p, nil, nil, []Step{
+		skipStep,
+		newPassStep(types.StepReview),
+	}, nil)
+
+	if err := exec.Execute(context.Background(), run, repo, workDir); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if event := recorder.find("step", "status", string(types.StepStatusSkipped)); event != nil {
+		t.Fatalf("skipped steps should not emit step telemetry, got %v", event.fields)
 	}
 }
 

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -97,14 +97,10 @@ func TestClientTrackSendsUmamiEventPayload(t *testing.T) {
 		if got.Payload.Data["status"] != "success" {
 			t.Fatalf("data.status = %v, want %q", got.Payload.Data["status"], "success")
 		}
-		if got.Payload.Data["app_version"] != "v1.2.3" {
-			t.Fatalf("data.app_version = %v, want %q", got.Payload.Data["app_version"], "v1.2.3")
-		}
-		if got.Payload.Data["goos"] != "darwin" {
-			t.Fatalf("data.goos = %v, want %q", got.Payload.Data["goos"], "darwin")
-		}
-		if got.Payload.Data["goarch"] != "arm64" {
-			t.Fatalf("data.goarch = %v, want %q", got.Payload.Data["goarch"], "arm64")
+		for _, key := range []string{"app_version", "goos", "goarch", "build_channel"} {
+			if _, ok := got.Payload.Data[key]; ok {
+				t.Fatalf("data.%s should be omitted to keep Umami event-data volume low", key)
+			}
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for telemetry request")

--- a/internal/telemetry/config_test.go
+++ b/internal/telemetry/config_test.go
@@ -93,6 +93,25 @@ func TestDefaultPrefersEnvVarWebsiteIDAndIgnoresHostOverride(t *testing.T) {
 	}
 }
 
+func TestDefaultDisablesTelemetryWhenEnvIsOff(t *testing.T) {
+	prevSink := defaultSink
+	defaultSink = nil
+	defer func() { defaultSink = prevSink }()
+
+	prevWebsiteID := buildinfo.TelemetryWebsiteID
+	defer func() {
+		buildinfo.TelemetryWebsiteID = prevWebsiteID
+	}()
+	buildinfo.TelemetryWebsiteID = "embedded-website"
+
+	t.Setenv("NO_MISTAKES_TELEMETRY", "off")
+	t.Setenv(umamiWebsiteIDEnv, "website-from-env")
+
+	if _, ok := Default().(*Client); ok {
+		t.Fatal("Default() should disable telemetry when NO_MISTAKES_TELEMETRY=off")
+	}
+}
+
 func TestDefaultIgnoresDotEnvOutsideRepo(t *testing.T) {
 	prevSink := defaultSink
 	defaultSink = nil

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -28,6 +28,7 @@ const (
 
 	umamiHostEnv      = "NO_MISTAKES_UMAMI_HOST"
 	umamiWebsiteIDEnv = "NO_MISTAKES_UMAMI_WEBSITE_ID"
+	telemetryEnv      = "NO_MISTAKES_TELEMETRY"
 )
 
 type Fields map[string]any
@@ -124,6 +125,10 @@ func Default() Sink {
 	defer defaultMu.Unlock()
 
 	if defaultSink != nil {
+		return defaultSink
+	}
+	if telemetryDisabled() {
+		defaultSink = noopSink{}
 		return defaultSink
 	}
 
@@ -260,14 +265,10 @@ func (noopSink) Pageview(string, Fields) {}
 func (noopSink) Close(context.Context) error { return nil }
 
 func (c *Client) newRequest(name, url string, fields Fields) ([]byte, error) {
-	data := make(map[string]any, len(fields)+4)
+	data := make(map[string]any, len(fields))
 	for k, v := range fields {
 		data[k] = v
 	}
-	data["app_version"] = c.version
-	data["goos"] = c.goos
-	data["goarch"] = c.goarch
-	data["build_channel"] = buildChannel(c.version)
 
 	return json.Marshal(collectRequest{
 		Type: "event",
@@ -360,6 +361,15 @@ func defaultWebsiteID() string {
 	}
 
 	return websiteID
+}
+
+func telemetryDisabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(telemetryEnv))) {
+	case "0", "false", "off":
+		return true
+	default:
+		return false
+	}
 }
 
 func loadDotEnvValues() map[string]string {


### PR DESCRIPTION
## Summary
- Trim Umami event payloads by omitting app/platform/build metadata from event data and limiting step telemetry to completed `awaiting_approval`, `fix_review`, and `failed` statuses.
- Add `NO_MISTAKES_TELEMETRY` as an explicit opt-out that disables telemetry even when runtime or embedded website IDs are configured.
- Update environment docs to describe the opt-out and the reduced telemetry behavior.

## Risk Assessment

✅ Low: The change is narrowly scoped to reducing telemetry payload fields and filtering step telemetry emission, with tests documenting the intended behavior and no material issues found in the changed code.

## Testing

- Summary: Exercised telemetry payload trimming, telemetry opt-out, and pipeline step telemetry filtering for successful, skipped, approval, autofix, and failed paths; all relevant tests passed.
- `go test ./internal/telemetry`
- `go test ./internal/pipeline -run 'TestExecutor_(SuccessfulStepsDoNotEmitTelemetry|SkippedStepsDoNotEmitTelemetry|TracksApprovalTelemetry|TracksAutoFixTelemetry|StepError_FailsRun)'`
- `go test ./internal/pipeline -run 'TestExecutor_(SuccessfulStepsDoNotEmitTelemetry|SkippedStepsDoNotEmitTelemetry|FailedStepEmitsTelemetry|TracksApprovalTelemetry|TracksAutoFixTelemetry|StepError_FailsRun)'`
- `go test ./internal/pipeline ./internal/telemetry`
- Outcome: ✅ passed across 1 run (58.8s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/telemetry`
- `go test ./internal/pipeline -run 'TestExecutor_(SuccessfulStepsDoNotEmitTelemetry|SkippedStepsDoNotEmitTelemetry|TracksApprovalTelemetry|TracksAutoFixTelemetry|StepError_FailsRun)'`
- `go test ./internal/pipeline -run 'TestExecutor_(SuccessfulStepsDoNotEmitTelemetry|SkippedStepsDoNotEmitTelemetry|FailedStepEmitsTelemetry|TracksApprovalTelemetry|TracksAutoFixTelemetry|StepError_FailsRun)'`
- `go test ./internal/pipeline ./internal/telemetry`

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed (2)</summary>

**Round 1** - found 2 warnings
- ⚠️ `docs/src/content/docs/reference/environment.md:70` - The change adds a public environment variable, `NO_MISTAKES_TELEMETRY`, that disables telemetry when set to `0`, `false`, or `off`, but the environment variable reference still does not document it. Add a section for this variable with accepted values, default behavior, and precedence over embedded or runtime website IDs.
- ⚠️ `docs/src/content/docs/reference/environment.md:81` - The telemetry payload description is stale. The code no longer adds `app_version`, `goos`, `goarch`, or `build_channel` to Umami event data, and step telemetry is now limited to completed steps with `awaiting_approval`, `fix_review`, or `failed` status instead of every step event. Update this sentence to match the trimmed telemetry behavior.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `docs/src/content/docs/reference/environment.md:81` - The telemetry reference says `no-mistakes` sends &#34;selected completed step events&#34; but does not document which completed step statuses are still sent. The code now only tracks completed step telemetry for `awaiting_approval`, `fix_review`, and `failed`, while omitting successful and skipped steps. Update this sentence to name those statuses so the public telemetry documentation precisely matches the trimmed behavior.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
