### PR TITLE
fix(telemetry): use self-hosted Umami defaults

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,8 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           TAG: ${{ needs.release-please.outputs.tag_name }}
-          UMAMI_WEBSITE_ID: ${{ vars.UMAMI_WEBSITE_ID }}
+          UMAMI_HOST: https://a.kunchenguid.com
+          UMAMI_WEBSITE_ID: f959e889-92f5-4121-8a1f-571b10861198
         run: |
           set -euo pipefail
           mkdir -p dist
@@ -74,7 +75,7 @@ jobs:
             OUT="dist/${BIN}"
           fi
           CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" \
-            go build -ldflags "-X github.com/kunchenguid/no-mistakes/internal/buildinfo.Version=${TAG} -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Commit=${COMMIT} -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Date=${DATE} -X github.com/kunchenguid/no-mistakes/internal/buildinfo.TelemetryWebsiteID=${UMAMI_WEBSITE_ID}" \
+            go build -ldflags "-X github.com/kunchenguid/no-mistakes/internal/buildinfo.Version=${TAG} -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Commit=${COMMIT} -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Date=${DATE} -X github.com/kunchenguid/no-mistakes/internal/buildinfo.TelemetryHost=${UMAMI_HOST} -X github.com/kunchenguid/no-mistakes/internal/buildinfo.TelemetryWebsiteID=${UMAMI_WEBSITE_ID}" \
             -o "$OUT" ./cmd/no-mistakes
           if [ "$GOOS" = "windows" ]; then
             ARCHIVE="dist/no-mistakes-${TAG}-${GOOS}-${GOARCH}.zip"

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,16 @@
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
 DATE    ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+DEFAULT_UMAMI_HOST := https://a.kunchenguid.com
+DEFAULT_UMAMI_WEBSITE_ID := f959e889-92f5-4121-8a1f-571b10861198
+DOTENV_UMAMI_HOST := $(shell [ -f .env ] && perl -ne 'next if /^\s*(?:\#|$$)/; s/^\s*export\s+//; next unless /^\s*NO_MISTAKES_UMAMI_HOST\s*=\s*(.*)$$/; $$v=$$1; $$v =~ s/^\s+|\s+$$//g; if ($$v =~ /^( ["\x27] )(.*)\1$$/x) { $$v=$$2; } else { $$v =~ s/\s+\#.*$$//; $$v =~ s/\s+$$//; } $$out=$$v; END { print $$out if defined $$out }' .env)
 DOTENV_UMAMI_WEBSITE_ID := $(shell [ -f .env ] && perl -ne 'next if /^\s*(?:\#|$$)/; s/^\s*export\s+//; next unless /^\s*NO_MISTAKES_UMAMI_WEBSITE_ID\s*=\s*(.*)$$/; $$v=$$1; $$v =~ s/^\s+|\s+$$//g; if ($$v =~ /^(["\x27])(.*)\1$$/) { $$v=$$2; } else { $$v =~ s/\s+\#.*$$//; $$v =~ s/\s+$$//; } $$out=$$v; END { print $$out if defined $$out }' .env)
-override UMAMI_WEBSITE_ID := $(if $(DOTENV_UMAMI_WEBSITE_ID),$(DOTENV_UMAMI_WEBSITE_ID),$(UMAMI_WEBSITE_ID))
+override UMAMI_HOST := $(if $(DOTENV_UMAMI_HOST),$(DOTENV_UMAMI_HOST),$(if $(UMAMI_HOST),$(UMAMI_HOST),$(DEFAULT_UMAMI_HOST)))
+override UMAMI_WEBSITE_ID := $(if $(DOTENV_UMAMI_WEBSITE_ID),$(DOTENV_UMAMI_WEBSITE_ID),$(if $(UMAMI_WEBSITE_ID),$(UMAMI_WEBSITE_ID),$(DEFAULT_UMAMI_WEBSITE_ID)))
 LDFLAGS := -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Version=$(VERSION) \
            -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Commit=$(COMMIT) \
            -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Date=$(DATE) \
+           -X github.com/kunchenguid/no-mistakes/internal/buildinfo.TelemetryHost=$(UMAMI_HOST) \
            -X github.com/kunchenguid/no-mistakes/internal/buildinfo.TelemetryWebsiteID=$(UMAMI_WEBSITE_ID)
 
 .PHONY: build dist install test e2e e2e-record lint fmt clean docs docs-build docs-preview demo

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -122,7 +122,7 @@ no-mistakes update --beta
 
 Downloads the latest release, verifies the SHA-256 checksum, atomically replaces the running binary, and resets the daemon when it is running or stale daemon artifacts exist so the new executable is picked up, preferring the managed service path and falling back to a detached daemon if service startup is unavailable or fails. By default this installs the latest stable release. Pass `--beta` to include prereleases and install the latest beta when one is newer than the current stable release. If the daemon is running, update first requires it to already be using the same executable path as the binary running `no-mistakes update`; if that daemon executable path cannot be determined or it points to a different binary, the update aborts before replacement. If the daemon does not come back cleanly after a successful replacement, the command reports that failure. On macOS, removes the quarantine extended attribute.
 
-Because `update` installs the latest official release binary, the replacement binary may already have telemetry enabled if a telemetry website ID was embedded at build time.
+Because `update` installs the latest official release binary, the replacement binary includes the default self-hosted telemetry host and website ID. Disable telemetry with `NO_MISTAKES_TELEMETRY=0`, or override the host and website ID with `NO_MISTAKES_UMAMI_HOST` and `NO_MISTAKES_UMAMI_WEBSITE_ID`.
 
 Background update checks run automatically on each CLI invocation (except `update` itself). If a newer version is available, a notification is printed to stderr. Suppressed for dev builds or when `NO_MISTAKES_NO_UPDATE_CHECK=1` is set.
 

--- a/docs/src/content/docs/reference/environment.md
+++ b/docs/src/content/docs/reference/environment.md
@@ -67,6 +67,17 @@ Disable background update checks.
 
 Update checks run on every CLI invocation except `update` itself, hit GitHub releases, cache the result in `$NM_HOME/update-check.json`, and print a one-line notification to stderr when a newer version is available. Dev builds (non-semver versions) suppress the check automatically.
 
+## `NO_MISTAKES_UMAMI_HOST`
+
+Override the telemetry collection host.
+
+| | |
+|---|---|
+| Type | `URL` |
+| Default | `https://a.kunchenguid.com` |
+
+When set, telemetry sends events to this host's `/api/send` endpoint. If it is unset in a dev build, `no-mistakes` also checks a repo-local `.env` file for `NO_MISTAKES_UMAMI_HOST`. If no runtime value is found, it falls back to any host embedded at build time and then the default self-hosted Umami instance.
+
 ## `NO_MISTAKES_UMAMI_WEBSITE_ID`
 
 Override or enable the telemetry website ID.
@@ -74,11 +85,11 @@ Override or enable the telemetry website ID.
 | | |
 |---|---|
 | Type | `string` |
-| Default | unset |
+| Default | embedded in release builds |
 
 When set, telemetry uses this website ID at runtime. If it is unset in a dev build, `no-mistakes` also checks a repo-local `.env` file for `NO_MISTAKES_UMAMI_WEBSITE_ID`. If no runtime value is found, it falls back to any website ID embedded at build time.
 
-When telemetry is enabled, `no-mistakes` sends command, run, approval, fix, and wizard events, completed step events with `awaiting_approval`, `fix_review`, or `failed` status, and pageviews for `/wizard` and `/tui` to Umami Cloud at `https://cloud.umami.is/api/send`.
+When telemetry is enabled, `no-mistakes` sends command, run, approval, fix, and wizard events, completed step events with `awaiting_approval`, `fix_review`, or `failed` status, and pageviews for `/wizard` and `/tui` to Umami.
 
 ## `NO_MISTAKES_TELEMETRY`
 

--- a/docs/src/content/docs/reference/environment.md
+++ b/docs/src/content/docs/reference/environment.md
@@ -85,7 +85,7 @@ Override or enable the telemetry website ID.
 | | |
 |---|---|
 | Type | `string` |
-| Default | embedded in release builds |
+| Default | embedded in Makefile and release builds; unset in unembedded dev builds |
 
 When set, telemetry uses this website ID at runtime. If it is unset in a dev build, `no-mistakes` also checks a repo-local `.env` file for `NO_MISTAKES_UMAMI_WEBSITE_ID`. If no runtime value is found, it falls back to any website ID embedded at build time.
 

--- a/docs/src/content/docs/start-here/installation.md
+++ b/docs/src/content/docs/start-here/installation.md
@@ -13,7 +13,7 @@ The installer keeps the real binary in `~/.no-mistakes/bin` and exposes `no-mist
 
 It also installs or refreshes the background daemon for you by running `no-mistakes daemon restart`, preferring a managed service (launchd on macOS, systemd user service on Linux) and falling back to a detached daemon if that path is unavailable. If the restart fails, the install command fails.
 
-Official release binaries installed this way may already have telemetry enabled if a telemetry website ID was embedded at build time.
+Official release binaries installed this way include the default self-hosted telemetry host and website ID. Disable telemetry with `NO_MISTAKES_TELEMETRY=0`, or override the host and website ID with `NO_MISTAKES_UMAMI_HOST` and `NO_MISTAKES_UMAMI_WEBSITE_ID`.
 
 ## Windows (PowerShell)
 
@@ -23,7 +23,7 @@ irm https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.
 
 Installs the binary and restarts the background daemon automatically with `no-mistakes.exe daemon restart`, preferring a managed Task Scheduler task and falling back to a detached daemon if needed. If the restart fails, the install command fails.
 
-Official release binaries installed this way may already have telemetry enabled if a telemetry website ID was embedded at build time.
+Official release binaries installed this way include the default self-hosted telemetry host and website ID. Disable telemetry with `NO_MISTAKES_TELEMETRY=0`, or override the host and website ID with `NO_MISTAKES_UMAMI_HOST` and `NO_MISTAKES_UMAMI_WEBSITE_ID`.
 
 ## Go install
 
@@ -42,7 +42,7 @@ make build
 make install
 ```
 
-`make build` embeds the telemetry website ID from `NO_MISTAKES_UMAMI_WEBSITE_ID` in a repo-local `.env` first, then `UMAMI_WEBSITE_ID` from the shell if no `.env` value is present. If neither is set, the binary is built without telemetry enabled.
+`make build` embeds the telemetry host from `NO_MISTAKES_UMAMI_HOST` in a repo-local `.env` first, then `UMAMI_HOST` from the shell, then the default self-hosted host. It embeds the telemetry website ID from `NO_MISTAKES_UMAMI_WEBSITE_ID` in `.env` first, then `UMAMI_WEBSITE_ID` from the shell, then the default website ID.
 
 ## Prerequisites
 
@@ -68,7 +68,7 @@ This downloads the latest release from GitHub, verifies the SHA-256 checksum, at
 
 `no-mistakes update` installs the latest stable release. Use `no-mistakes update --beta` to opt into prereleases and install the latest beta when one is newer than the current stable release.
 
-Because `update` installs the latest official release binary, it may change telemetry behavior if that release has a telemetry website ID embedded at build time.
+Because `update` installs the latest official release binary, it installs a binary with the default self-hosted telemetry host and website ID. Disable telemetry with `NO_MISTAKES_TELEMETRY=0`, or override the host and website ID with `NO_MISTAKES_UMAMI_HOST` and `NO_MISTAKES_UMAMI_WEBSITE_ID`.
 
 It only proceeds if the running daemon is already using the same executable path. If the daemon executable path cannot be determined or it was started from a different binary, the update aborts before replacing the binary. If the daemon does not come back cleanly after a successful replacement, the new binary stays installed but the command reports the daemon reset failure.
 

--- a/docs/src/content/docs/start-here/quick-start.md
+++ b/docs/src/content/docs/start-here/quick-start.md
@@ -13,7 +13,7 @@ curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/i
 
 The installer drops the binary in `~/.no-mistakes/bin`, links it into `~/.local/bin` or `/usr/local/bin`, and restarts the background daemon. If the restart fails, the install command fails.
 
-Official release binaries installed this way may already have telemetry enabled if a telemetry website ID was embedded at build time.
+Official release binaries installed this way include the default self-hosted telemetry host and website ID. Disable telemetry with `NO_MISTAKES_TELEMETRY=0`, or override the host and website ID with `NO_MISTAKES_UMAMI_HOST` and `NO_MISTAKES_UMAMI_WEBSITE_ID`.
 
 ## 2. Check prerequisites
 

--- a/internal/buildinfo/version.go
+++ b/internal/buildinfo/version.go
@@ -7,11 +7,13 @@ import "runtime/debug"
 //	-ldflags "-X github.com/kunchenguid/no-mistakes/internal/buildinfo.Version=v1.0.0
 //	          -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Commit=abc1234
 //	          -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Date=2024-01-01
+//	          -X github.com/kunchenguid/no-mistakes/internal/buildinfo.TelemetryHost=https://a.example.com
 //	          -X github.com/kunchenguid/no-mistakes/internal/buildinfo.TelemetryWebsiteID=abc123"
 var (
 	Version            = "dev"
 	Commit             = "unknown"
 	Date               = "unknown"
+	TelemetryHost      = ""
 	TelemetryWebsiteID = ""
 )
 

--- a/internal/telemetry/config_test.go
+++ b/internal/telemetry/config_test.go
@@ -13,17 +13,21 @@ func TestDefaultUsesDotEnvInDevBuildWhenEnvMissing(t *testing.T) {
 	defaultSink = nil
 	defer func() { defaultSink = prevSink }()
 
+	prevHost := buildinfo.TelemetryHost
 	prevWebsiteID := buildinfo.TelemetryWebsiteID
 	defer func() {
+		buildinfo.TelemetryHost = prevHost
 		buildinfo.TelemetryWebsiteID = prevWebsiteID
 	}()
+	buildinfo.TelemetryHost = ""
 	buildinfo.TelemetryWebsiteID = ""
 
+	t.Setenv(umamiHostEnv, "")
 	t.Setenv(umamiWebsiteIDEnv, "")
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".env")
-	content := "NO_MISTAKES_UMAMI_WEBSITE_ID=website-from-dotenv\n"
+	content := "NO_MISTAKES_UMAMI_HOST=https://dotenv.example\nNO_MISTAKES_UMAMI_WEBSITE_ID=website-from-dotenv\n"
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write .env: %v", err)
 	}
@@ -42,23 +46,29 @@ func TestDefaultUsesDotEnvInDevBuildWhenEnvMissing(t *testing.T) {
 	if !ok {
 		t.Fatalf("Default() type = %T, want *Client", sink)
 	}
-	if client.endpoint != umamiCloudURL+"/api/send" {
-		t.Fatalf("endpoint = %q, want %q", client.endpoint, umamiCloudURL+"/api/send")
+	if client.endpoint != "https://dotenv.example/api/send" {
+		t.Fatalf("endpoint = %q, want %q", client.endpoint, "https://dotenv.example/api/send")
 	}
 	if client.websiteID != "website-from-dotenv" {
 		t.Fatalf("websiteID = %q, want %q", client.websiteID, "website-from-dotenv")
 	}
 }
 
-func TestDefaultPrefersEnvVarWebsiteIDAndIgnoresHostOverride(t *testing.T) {
+func TestDefaultPrefersEnvVarsOverDotEnvAndEmbeddedConfig(t *testing.T) {
 	prevSink := defaultSink
 	defaultSink = nil
 	defer func() { defaultSink = prevSink }()
 
+	prevHost := buildinfo.TelemetryHost
+	prevVersion := buildinfo.Version
 	prevWebsiteID := buildinfo.TelemetryWebsiteID
 	defer func() {
+		buildinfo.TelemetryHost = prevHost
+		buildinfo.Version = prevVersion
 		buildinfo.TelemetryWebsiteID = prevWebsiteID
 	}()
+	buildinfo.TelemetryHost = "https://embedded.example"
+	buildinfo.Version = "v1.2.3"
 	buildinfo.TelemetryWebsiteID = "embedded-website"
 
 	t.Setenv(umamiHostEnv, "https://env.example")
@@ -85,11 +95,74 @@ func TestDefaultPrefersEnvVarWebsiteIDAndIgnoresHostOverride(t *testing.T) {
 	if !ok {
 		t.Fatalf("Default() type = %T, want *Client", sink)
 	}
-	if client.endpoint != umamiCloudURL+"/api/send" {
-		t.Fatalf("endpoint = %q, want %q", client.endpoint, umamiCloudURL+"/api/send")
+	if client.endpoint != "https://env.example/api/send" {
+		t.Fatalf("endpoint = %q, want %q", client.endpoint, "https://env.example/api/send")
 	}
 	if client.websiteID != "website-from-env" {
 		t.Fatalf("websiteID = %q, want %q", client.websiteID, "website-from-env")
+	}
+}
+
+func TestDefaultUsesEmbeddedTelemetryHostAndWebsiteID(t *testing.T) {
+	prevSink := defaultSink
+	defaultSink = nil
+	defer func() { defaultSink = prevSink }()
+
+	prevHost := buildinfo.TelemetryHost
+	prevVersion := buildinfo.Version
+	prevWebsiteID := buildinfo.TelemetryWebsiteID
+	defer func() {
+		buildinfo.TelemetryHost = prevHost
+		buildinfo.Version = prevVersion
+		buildinfo.TelemetryWebsiteID = prevWebsiteID
+	}()
+	buildinfo.TelemetryHost = "https://embedded.example"
+	buildinfo.Version = "v1.2.3"
+	buildinfo.TelemetryWebsiteID = "embedded-website"
+
+	t.Setenv(umamiHostEnv, "")
+	t.Setenv(umamiWebsiteIDEnv, "")
+
+	sink := Default()
+	client, ok := sink.(*Client)
+	if !ok {
+		t.Fatalf("Default() type = %T, want *Client", sink)
+	}
+	if client.endpoint != "https://embedded.example/api/send" {
+		t.Fatalf("endpoint = %q, want %q", client.endpoint, "https://embedded.example/api/send")
+	}
+	if client.websiteID != "embedded-website" {
+		t.Fatalf("websiteID = %q, want %q", client.websiteID, "embedded-website")
+	}
+}
+
+func TestDefaultUsesSelfHostedHostWhenHostConfigMissing(t *testing.T) {
+	prevSink := defaultSink
+	defaultSink = nil
+	defer func() { defaultSink = prevSink }()
+
+	prevHost := buildinfo.TelemetryHost
+	prevVersion := buildinfo.Version
+	prevWebsiteID := buildinfo.TelemetryWebsiteID
+	defer func() {
+		buildinfo.TelemetryHost = prevHost
+		buildinfo.Version = prevVersion
+		buildinfo.TelemetryWebsiteID = prevWebsiteID
+	}()
+	buildinfo.TelemetryHost = ""
+	buildinfo.Version = "v1.2.3"
+	buildinfo.TelemetryWebsiteID = "embedded-website"
+
+	t.Setenv(umamiHostEnv, "")
+	t.Setenv(umamiWebsiteIDEnv, "")
+
+	sink := Default()
+	client, ok := sink.(*Client)
+	if !ok {
+		t.Fatalf("Default() type = %T, want *Client", sink)
+	}
+	if client.endpoint != defaultHost+"/api/send" {
+		t.Fatalf("endpoint = %q, want %q", client.endpoint, defaultHost+"/api/send")
 	}
 }
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -24,7 +24,7 @@ const (
 	defaultHostname = "cli"
 	defaultTitle    = "no-mistakes CLI"
 	defaultPath     = "/api/send"
-	umamiCloudURL   = "https://cloud.umami.is"
+	defaultHost     = "https://a.kunchenguid.com"
 
 	umamiHostEnv      = "NO_MISTAKES_UMAMI_HOST"
 	umamiWebsiteIDEnv = "NO_MISTAKES_UMAMI_WEBSITE_ID"
@@ -138,8 +138,9 @@ func Default() Sink {
 		return defaultSink
 	}
 
+	host := defaultHostValue()
 	client, err := NewClient(Config{
-		Host:      umamiCloudURL,
+		Host:      host,
 		WebsiteID: websiteID,
 		App:       "no-mistakes",
 		Version:   buildinfo.CurrentVersion(),
@@ -361,6 +362,24 @@ func defaultWebsiteID() string {
 	}
 
 	return websiteID
+}
+
+func defaultHostValue() string {
+	host := strings.TrimSpace(os.Getenv(umamiHostEnv))
+
+	if buildChannel(buildinfo.CurrentVersion()) == "dev" && host == "" {
+		values := loadDotEnvValues()
+		host = strings.TrimSpace(values[umamiHostEnv])
+	}
+
+	if host == "" {
+		host = strings.TrimSpace(buildinfo.TelemetryHost)
+	}
+	if host == "" {
+		host = defaultHost
+	}
+
+	return host
 }
 
 func telemetryDisabled() bool {

--- a/makefile_test.go
+++ b/makefile_test.go
@@ -54,6 +54,50 @@ func TestMakeBuildUsesEnvUmamiWebsiteIDWhenDotEnvMissing(t *testing.T) {
 	}
 }
 
+func TestMakeBuildEmbedsDefaultSelfHostedTelemetryConfig(t *testing.T) {
+	skipMakeBuildTestsOnWindows(t)
+
+	makePath, err := exec.LookPath("make")
+	if err != nil {
+		t.Skip("make not available")
+	}
+
+	workDir := writeTestMakeWorkspace(t)
+	output := runMakeDryBuild(t, makePath, workDir, nil)
+
+	if !strings.Contains(output, "TelemetryHost=https://a.kunchenguid.com") {
+		t.Fatalf("make build output should embed default telemetry host, got:\n%s", output)
+	}
+	if !strings.Contains(output, "TelemetryWebsiteID=f959e889-92f5-4121-8a1f-571b10861198") {
+		t.Fatalf("make build output should embed default telemetry website id, got:\n%s", output)
+	}
+}
+
+func TestMakeBuildPrioritizesDotEnvUmamiHost(t *testing.T) {
+	skipMakeBuildTestsOnWindows(t)
+
+	makePath, err := exec.LookPath("make")
+	if err != nil {
+		t.Skip("make not available")
+	}
+
+	workDir := writeTestMakeWorkspace(t)
+	if err := os.WriteFile(filepath.Join(workDir, ".env"), []byte("NO_MISTAKES_UMAMI_HOST=https://dotenv.example\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	output := runMakeDryBuild(t, makePath, workDir, map[string]string{
+		"UMAMI_HOST": "https://env.example",
+	})
+
+	if !strings.Contains(output, "TelemetryHost=https://dotenv.example") {
+		t.Fatalf("make build output should embed .env telemetry host, got:\n%s", output)
+	}
+	if strings.Contains(output, "TelemetryHost=https://env.example") {
+		t.Fatalf("make build output should not prefer env telemetry host when .env exists, got:\n%s", output)
+	}
+}
+
 func TestMakeBuildIgnoresUnrelatedDotEnvEntries(t *testing.T) {
 	skipMakeBuildTestsOnWindows(t)
 
@@ -152,7 +196,7 @@ func runMakeDryBuild(t *testing.T, makePath, workDir string, extraEnv map[string
 
 	cmd := exec.CommandContext(ctx, makePath, "-n", "build")
 	cmd.Dir = workDir
-	cmd.Env = filteredEnv(os.Environ(), "UMAMI_WEBSITE_ID", "NO_MISTAKES_UMAMI_WEBSITE_ID")
+	cmd.Env = filteredEnv(os.Environ(), "UMAMI_HOST", "UMAMI_WEBSITE_ID", "NO_MISTAKES_UMAMI_HOST", "NO_MISTAKES_UMAMI_WEBSITE_ID")
 	for key, value := range extraEnv {
 		cmd.Env = append(cmd.Env, key+"="+value)
 	}

--- a/workflow_release_test.go
+++ b/workflow_release_test.go
@@ -69,6 +69,25 @@ func TestReleaseWorkflowBuildStartsOnlyWhenReleaseIsCreated(t *testing.T) {
 	}
 }
 
+func TestReleaseWorkflowEmbedsSelfHostedTelemetryConfig(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/release.yml")
+	if err != nil {
+		t.Fatalf("read workflow: %v", err)
+	}
+
+	block := extractJobBlock(t, string(data), "build-and-upload")
+	for _, want := range []string{
+		"UMAMI_HOST: https://a.kunchenguid.com",
+		"UMAMI_WEBSITE_ID: f959e889-92f5-4121-8a1f-571b10861198",
+		"TelemetryHost=${UMAMI_HOST}",
+		"TelemetryWebsiteID=${UMAMI_WEBSITE_ID}",
+	} {
+		if !strings.Contains(block, want) {
+			t.Fatalf("build-and-upload must contain %q", want)
+		}
+	}
+}
+
 // Partial-release protection: release-please must create drafts so that a
 // release is never marked "latest" until all binaries and checksums are
 // uploaded. A separate finalize job gates the promotion on every asset job


### PR DESCRIPTION
## Summary
- Embed the self-hosted Umami host and website ID through release and Makefile builds so telemetry defaults point at the project-owned endpoint.
- Add telemetry configuration coverage for build-time defaults, runtime overrides, and disabled/unconfigured behavior.
- Update CLI, installation, quick-start, and environment docs to describe the new default telemetry behavior and override controls.

## Risk Assessment

🚨 High: The code change is small, but it changes telemetry from opt-in to on-by-default for local Makefile builds, which is a product/privacy behavior that should not merge without explicit human approval.

## Testing

- Summary: Exercised telemetry host and website ID resolution, Makefile/release workflow embedding tests, and the full Go suite; all tests passed.
- `go test ./internal/telemetry`
- `go test .`
- `go test ./...`
- Outcome: ✅ passed across 1 run (1m5s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

**Round 1** - found 1 warning
- ⚠️ `Makefile:9` - This default embeds the production telemetry website ID into every `make build` and `make install` when no `.env` or env override exists, so source-built binaries that previously had telemetry disabled now send telemetry by default. Confirm whether the production default should apply to local/source builds or only to release artifacts.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/telemetry`
- `go test .`
- `go test ./...`

</details>

<details>
<summary>🔧 **Document** - 4 issues found → auto-fixed (2)</summary>

**Round 1** - found 4 issues (1 warning, 3 infos)
- ⚠️ `docs/src/content/docs/start-here/installation.md:45` - The from-source `make build` documentation is stale. The Makefile now embeds a default self-hosted telemetry host and website ID when no overrides are provided, and it also supports `NO_MISTAKES_UMAMI_HOST` from `.env` and `UMAMI_HOST` from the shell. This paragraph still says the binary is built without telemetry enabled when no website ID override is set and does not document the new host override precedence.
- ℹ️ `docs/src/content/docs/start-here/installation.md:16` - The install guide&#39;s official-release telemetry note is now underspecified. Release builds now embed the self-hosted telemetry host and website ID directly in the workflow, so the docs should state the default release telemetry behavior and the disable/override knobs instead of only saying releases may have a website ID embedded.
- ℹ️ `docs/src/content/docs/start-here/quick-start.md:16` - The quick-start install note is now underspecified for the release telemetry change. Official release binaries now embed the self-hosted telemetry host and website ID, so this note should be updated to describe the default telemetry behavior and point to the environment variables for disabling or overriding it.
- ℹ️ `docs/src/content/docs/reference/cli.md:125` - The `no-mistakes update` documentation is now underspecified. Updating installs an official release binary that now embeds the self-hosted telemetry host and website ID, so this note should describe that default behavior and reference the telemetry environment controls rather than only mentioning a possibly embedded website ID.

**Round 2** (auto-fix) - found 1 info
- ℹ️ `docs/src/content/docs/reference/environment.md:88` - The `NO_MISTAKES_UMAMI_WEBSITE_ID` default is still underspecified. The Makefile now embeds a default telemetry website ID for `make build` and `make dist` as well as official release builds, while this reference says the default is only embedded in release builds. Update the default text to cover build-time embedded defaults generally, and distinguish `go install` or unembedded dev builds where no website ID is present.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
