### PR TITLE
fix(agent): retry transient invocation failures

### DIFF
--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -109,6 +109,8 @@ Each invocation returns:
 - **Text** - raw text output
 - **Usage** - token counts (input, output, cache read, cache creation)
 
+Transient API and network failures are retried up to three times with exponential backoff. Retry messages are streamed through the same `OnChunk` path shown in the TUI.
+
 ## Claude
 
 Spawns a `claude` subprocess for each invocation with `--output-format stream-json`. By default it also adds `--dangerously-skip-permissions`, unless you already set your own Claude permission flag through `agent_args_override`. Reads JSONL events from stdout. Supports native structured output via `--json-schema`.
@@ -119,11 +121,11 @@ Spawns a `codex` subprocess for each invocation with `exec --json`. When structu
 
 ## Rovo Dev
 
-Starts a persistent HTTP server (`acli rovodev serve`) on first use and reuses it across invocations. Any `agent_args_override.rovodev` flags are inserted before no-mistakes' managed serve flags. Communicates via REST API and SSE streaming. Each invocation creates a session, sends the prompt, streams results, then deletes the session. Structured output is handled by injecting schema instructions into a system prompt, then parsing the final text with fallback parsing that accepts JSON fences, inline fence markers, or a final bare JSON object after prose, and validates the result against the requested schema while allowing `null` for optional fields.
+Starts a persistent HTTP server (`acli rovodev serve`) on first use and reuses it across invocations. If a reused server refuses a connection, no-mistakes discards it and retries with a fresh server. Any `agent_args_override.rovodev` flags are inserted before no-mistakes' managed serve flags. Communicates via REST API and SSE streaming. Each invocation creates a session, sends the prompt, streams results, then deletes the session. Structured output is handled by injecting schema instructions into a system prompt, then parsing the final text with fallback parsing that accepts JSON fences, inline fence markers, or a final bare JSON object after prose, and validates the result against the requested schema while allowing `null` for optional fields.
 
 ## OpenCode
 
-Starts a persistent HTTP server (`opencode serve`) on first use. Any `agent_args_override.opencode` flags are inserted before no-mistakes' managed serve flags. Similar session lifecycle to Rovo Dev: create session, send message, stream SSE events until idle, delete session. Supports `json_schema` format in the message request for structured output. When native structured output is absent, it falls back to parsing the final text with the same JSON fence and bare-object fallback, validating that fallback result against the requested schema while allowing `null` for optional fields.
+Starts a persistent HTTP server (`opencode serve`) on first use and reuses it across invocations. If a reused server refuses a connection, no-mistakes discards it and retries with a fresh server. Any `agent_args_override.opencode` flags are inserted before no-mistakes' managed serve flags. Similar session lifecycle to Rovo Dev: create session, send message, stream SSE events until idle, delete session. Supports `json_schema` format in the message request for structured output. When native structured output is absent, it falls back to parsing the final text with the same JSON fence and bare-object fallback, validating that fallback result against the requested schema while allowing `null` for optional fields.
 
 ## Checking agent availability
 

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -31,7 +31,7 @@ type claudeAgent struct {
 func (a *claudeAgent) Name() string { return "claude" }
 
 func (a *claudeAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
-	return runWithRetry(ctx, "claude", opts, claudeMaxRetries, claudeRetryClassifier, func() (*Result, error) {
+	return runWithRetry(ctx, "claude", opts, claudeMaxRetries, claudeRetryClassifier, nil, func() (*Result, error) {
 		return a.runOnce(ctx, opts)
 	})
 }

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -12,6 +12,9 @@ import (
 	"sync"
 )
 
+// claudeMaxRetries is the number of additional attempts past the initial
+// invocation. With 3 retries the agent makes up to 4 total attempts before
+// surfacing a transient API error to the pipeline.
 const claudeMaxRetries = 3
 
 // errNoStructuredOutput is returned when Claude succeeds but omits structured output.
@@ -28,24 +31,9 @@ type claudeAgent struct {
 func (a *claudeAgent) Name() string { return "claude" }
 
 func (a *claudeAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
-	var lastErr error
-	for attempt := 1; attempt <= claudeMaxRetries; attempt++ {
-		if attempt > 1 {
-			if opts.OnChunk != nil {
-				opts.OnChunk(fmt.Sprintf("retrying (attempt %d/%d) - previous attempt returned no structured output", attempt, claudeMaxRetries))
-			}
-		}
-
-		result, err := a.runOnce(ctx, opts)
-		if err == nil {
-			return result, nil
-		}
-		if !errors.Is(err, errNoStructuredOutput) {
-			return nil, err
-		}
-		lastErr = err
-	}
-	return nil, lastErr
+	return runWithRetry(ctx, "claude", opts, claudeMaxRetries, claudeRetryClassifier, func() (*Result, error) {
+		return a.runOnce(ctx, opts)
+	})
 }
 
 func (a *claudeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -22,6 +22,12 @@ type codexAgent struct {
 func (a *codexAgent) Name() string { return "codex" }
 
 func (a *codexAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
+	return runWithRetry(ctx, "codex", opts, claudeMaxRetries, classifyTransient, func() (*Result, error) {
+		return a.runOnce(ctx, opts)
+	})
+}
+
+func (a *codexAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 	schemaPath := ""
 	validationSchema := opts.JSONSchema
 	if len(opts.JSONSchema) > 0 {

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -22,7 +22,7 @@ type codexAgent struct {
 func (a *codexAgent) Name() string { return "codex" }
 
 func (a *codexAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
-	return runWithRetry(ctx, "codex", opts, claudeMaxRetries, classifyTransient, func() (*Result, error) {
+	return runWithRetry(ctx, "codex", opts, claudeMaxRetries, classifyTransient, nil, func() (*Result, error) {
 		return a.runOnce(ctx, opts)
 	})
 }

--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -19,9 +19,22 @@ type opencodeAgent struct {
 func (a *opencodeAgent) Name() string { return "opencode" }
 
 func (a *opencodeAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
-	return runWithRetry(ctx, "opencode", opts, claudeMaxRetries, classifyTransient, func() (*Result, error) {
+	return runWithRetry(ctx, "opencode", opts, claudeMaxRetries, classifyTransient, a.recoverTransientRetry, func() (*Result, error) {
 		return a.runOnce(ctx, opts)
 	})
+}
+
+func (a *opencodeAgent) recoverTransientRetry(label string) {
+	if label != "connection refused" {
+		return
+	}
+	a.mu.Lock()
+	srv := a.server
+	a.server = nil
+	a.mu.Unlock()
+	if srv != nil {
+		srv.shutdown()
+	}
 }
 
 func (a *opencodeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {

--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -19,6 +19,12 @@ type opencodeAgent struct {
 func (a *opencodeAgent) Name() string { return "opencode" }
 
 func (a *opencodeAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
+	return runWithRetry(ctx, "opencode", opts, claudeMaxRetries, classifyTransient, func() (*Result, error) {
+		return a.runOnce(ctx, opts)
+	})
+}
+
+func (a *opencodeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 	// Start server on first invocation (synchronized)
 	baseURL, err := a.ensureServer(ctx, opts.CWD)
 	if err != nil {

--- a/internal/agent/retry.go
+++ b/internal/agent/retry.go
@@ -60,6 +60,7 @@ func runWithRetry(
 	opts RunOpts,
 	maxRetries int,
 	classify retryClassifier,
+	recoverRetry func(label string),
 	runOnce func() (*Result, error),
 ) (*Result, error) {
 	var lastErr error
@@ -83,6 +84,9 @@ func runWithRetry(
 		label, retry := classify(err)
 		if !retry {
 			return nil, err
+		}
+		if recoverRetry != nil {
+			recoverRetry(label)
 		}
 		lastErr = err
 		lastLabel = label

--- a/internal/agent/retry.go
+++ b/internal/agent/retry.go
@@ -1,0 +1,145 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// retryClassifier inspects an error and reports whether it should be retried,
+// returning a short human-readable label for telemetry.
+type retryClassifier func(error) (label string, retry bool)
+
+// transientBackoff is the package-level sleep function used between retries.
+// It is overridden in tests to keep them fast while preserving cancellation
+// semantics.
+var transientBackoff = func(ctx context.Context, attempt int) error {
+	delay := transientBackoffBaseDuration(attempt, time.Second)
+	// Apply +/- 25% jitter.
+	if delay > 0 {
+		span := int64(delay) / 2
+		if span > 0 {
+			//nolint:gosec // non-cryptographic jitter is fine here.
+			delay += time.Duration(rand.Int63n(span+1)) - delay/4
+		}
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// transientBackoffBaseDuration returns the un-jittered delay for a given
+// 1-indexed retry attempt. Progression: base, 4*base, 16*base, ...
+func transientBackoffBaseDuration(attempt int, base time.Duration) time.Duration {
+	if attempt < 1 {
+		return 0
+	}
+	delay := base
+	for i := 1; i < attempt; i++ {
+		delay *= 4
+	}
+	return delay
+}
+
+// runWithRetry invokes runOnce up to maxRetries+1 times, retrying when the
+// classifier marks the error as retriable. Between retries it sleeps with
+// exponential backoff (via transientBackoff) and respects ctx cancellation.
+// The retry attempt and classification label are surfaced to opts.OnChunk.
+func runWithRetry(
+	ctx context.Context,
+	name string,
+	opts RunOpts,
+	maxRetries int,
+	classify retryClassifier,
+	runOnce func() (*Result, error),
+) (*Result, error) {
+	var lastErr error
+	var lastLabel string
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			if opts.OnChunk != nil {
+				opts.OnChunk(fmt.Sprintf(
+					"%s retrying after transient error %q (attempt %d/%d)",
+					name, lastLabel, attempt+1, maxRetries+1,
+				))
+			}
+			if err := transientBackoff(ctx, attempt); err != nil {
+				return nil, err
+			}
+		}
+		result, err := runOnce()
+		if err == nil {
+			return result, nil
+		}
+		label, retry := classify(err)
+		if !retry {
+			return nil, err
+		}
+		lastErr = err
+		lastLabel = label
+	}
+	return nil, lastErr
+}
+
+// claudeRetryClassifier retries both transient API errors and the
+// no-structured-output case that the existing loop already handled.
+func claudeRetryClassifier(err error) (string, bool) {
+	if errors.Is(err, errNoStructuredOutput) {
+		return "missing structured output", true
+	}
+	return classifyTransient(err)
+}
+
+var transientStatusRE = regexp.MustCompile(`\b(429|503|529)\b`)
+
+// transientNeedles matches case-insensitive substrings emitted by Anthropic
+// API errors, the various agent CLIs, or Go's net stack when the underlying
+// failure is recoverable (load shed, network blip, DNS hiccup, etc.).
+var transientNeedles = []struct {
+	needle string
+	label  string
+}{
+	{"overloaded_error", "overloaded_error"},
+	{`"type":"overloaded"`, "overloaded_error"},
+	{"rate_limit_error", "rate_limit_error"},
+	{"rate_limited", "rate_limited"},
+	{"service_unavailable", "service_unavailable"},
+	{"connection refused", "connection refused"},
+	{"connection reset", "connection reset"},
+	{"i/o timeout", "i/o timeout"},
+	{"no such host", "dns lookup failed"},
+	{"temporary failure in name resolution", "dns temporary failure"},
+	{"tls handshake", "tls handshake failure"},
+	{"unexpected eof", "unexpected eof"},
+}
+
+// classifyTransient reports whether an error message looks like a transient
+// API or network failure. It deliberately ignores ctx cancellation/deadline
+// errors so explicit cancellation is never silently retried.
+func classifyTransient(err error) (string, bool) {
+	if err == nil {
+		return "", false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return "", false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, sig := range transientNeedles {
+		if strings.Contains(msg, sig.needle) {
+			return sig.label, true
+		}
+	}
+	if m := transientStatusRE.FindString(msg); m != "" {
+		return "http " + m, true
+	}
+	return "", false
+}

--- a/internal/agent/retry_test.go
+++ b/internal/agent/retry_test.go
@@ -1,0 +1,292 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestClassifyTransient_Positive(t *testing.T) {
+	cases := []struct {
+		name    string
+		errMsg  string
+		wantSub string // substring of label
+	}{
+		{
+			name:    "claude overloaded_error stderr",
+			errMsg:  `claude exited: exit status 1: API Error: {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`,
+			wantSub: "overloaded",
+		},
+		{
+			name:    "rate_limit_error",
+			errMsg:  `claude exited: exit status 1: rate_limit_error: too many requests`,
+			wantSub: "rate_limit",
+		},
+		{
+			name:    "http 429 in body",
+			errMsg:  `POST https://api.anthropic.com/v1/messages failed with 429: rate limited`,
+			wantSub: "429",
+		},
+		{
+			name:    "http 503",
+			errMsg:  `GET /v3/stream_chat failed with 503: service unavailable`,
+			wantSub: "503",
+		},
+		{
+			name:    "http 529 anthropic overloaded",
+			errMsg:  `claude exited: exit status 1: HTTP 529 from api.anthropic.com`,
+			wantSub: "529",
+		},
+		{
+			name:    "connection refused",
+			errMsg:  `dial tcp 127.0.0.1:5555: connection refused`,
+			wantSub: "connection refused",
+		},
+		{
+			name:    "connection reset",
+			errMsg:  `read tcp 1.2.3.4:80: connection reset by peer`,
+			wantSub: "connection reset",
+		},
+		{
+			name:    "io timeout",
+			errMsg:  `Post "https://api.anthropic.com/v1/messages": context deadline exceeded (i/o timeout)`,
+			wantSub: "i/o timeout",
+		},
+		{
+			name:    "no such host",
+			errMsg:  `dial tcp: lookup api.anthropic.com: no such host`,
+			wantSub: "dns",
+		},
+		{
+			name:    "tls handshake",
+			errMsg:  `Post "https://api.anthropic.com": net/http: TLS handshake timeout`,
+			wantSub: "tls",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			label, ok := classifyTransient(errors.New(tc.errMsg))
+			if !ok {
+				t.Fatalf("expected transient classification for %q", tc.errMsg)
+			}
+			if !strings.Contains(strings.ToLower(label), strings.ToLower(tc.wantSub)) {
+				t.Errorf("label %q does not contain %q", label, tc.wantSub)
+			}
+		})
+	}
+}
+
+func TestClassifyTransient_Negative(t *testing.T) {
+	cases := []struct {
+		name   string
+		errMsg string
+	}{
+		{
+			name:   "auth failure",
+			errMsg: `claude exited: exit status 1: API Error: {"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}`,
+		},
+		{
+			name:   "invalid request",
+			errMsg: `claude exited: exit status 1: API Error: {"type":"error","error":{"type":"invalid_request_error","message":"Bad Request"}}`,
+		},
+		{
+			name:   "missing structured output",
+			errMsg: `claude returned no structured output`,
+		},
+		{
+			name:   "permission denied",
+			errMsg: `permission denied`,
+		},
+		{
+			name:   "schema validation",
+			errMsg: `JSON output missing required field "summary"`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if label, ok := classifyTransient(errors.New(tc.errMsg)); ok {
+				t.Errorf("expected non-transient for %q, got %q", tc.errMsg, label)
+			}
+		})
+	}
+}
+
+func TestClassifyTransient_NilAndContext(t *testing.T) {
+	if _, ok := classifyTransient(nil); ok {
+		t.Error("nil error should not be transient")
+	}
+	if _, ok := classifyTransient(context.Canceled); ok {
+		t.Error("context.Canceled should not be transient")
+	}
+	if _, ok := classifyTransient(context.DeadlineExceeded); ok {
+		t.Error("context.DeadlineExceeded should not be transient")
+	}
+}
+
+// withFastBackoff swaps transientBackoff with a near-instant version that
+// preserves ctx-cancel semantics. Returns a restore func.
+func withFastBackoff(t *testing.T) func() {
+	t.Helper()
+	prev := transientBackoff
+	transientBackoff = func(ctx context.Context, attempt int) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Millisecond):
+			return nil
+		}
+	}
+	return func() { transientBackoff = prev }
+}
+
+func TestRunWithRetry_RetriesTransientThenSucceeds(t *testing.T) {
+	defer withFastBackoff(t)()
+
+	calls := 0
+	transientErr := fmt.Errorf("API Error: overloaded_error: please retry")
+	var chunks []string
+	opts := RunOpts{OnChunk: func(s string) { chunks = append(chunks, s) }}
+
+	res, err := runWithRetry(context.Background(), "claude", opts, 3, classifyTransient, func() (*Result, error) {
+		calls++
+		if calls < 3 {
+			return nil, transientErr
+		}
+		return &Result{Text: "ok"}, nil
+	})
+	if err != nil {
+		t.Fatalf("expected success after retries, got %v", err)
+	}
+	if res == nil || res.Text != "ok" {
+		t.Fatalf("expected result text 'ok', got %+v", res)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls (2 retries + success), got %d", calls)
+	}
+	if len(chunks) < 2 {
+		t.Errorf("expected at least 2 retry notification chunks, got %d: %v", len(chunks), chunks)
+	}
+	for i, c := range chunks {
+		if !strings.Contains(strings.ToLower(c), "transient") || !strings.Contains(strings.ToLower(c), "overloaded") {
+			t.Errorf("chunk[%d]=%q should mention 'transient' and the classification label", i, c)
+		}
+	}
+}
+
+func TestRunWithRetry_PermanentErrorFailsImmediately(t *testing.T) {
+	defer withFastBackoff(t)()
+
+	calls := 0
+	permErr := errors.New("API Error: authentication_error: invalid x-api-key")
+
+	_, err := runWithRetry(context.Background(), "claude", RunOpts{}, 3, classifyTransient, func() (*Result, error) {
+		calls++
+		return nil, permErr
+	})
+	if err == nil {
+		t.Fatal("expected permanent error to propagate")
+	}
+	if calls != 1 {
+		t.Errorf("expected single call for permanent error, got %d", calls)
+	}
+}
+
+func TestRunWithRetry_ExhaustsRetries(t *testing.T) {
+	defer withFastBackoff(t)()
+
+	calls := 0
+	transientErr := errors.New("503 service unavailable")
+
+	_, err := runWithRetry(context.Background(), "claude", RunOpts{}, 3, classifyTransient, func() (*Result, error) {
+		calls++
+		return nil, transientErr
+	})
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if calls != 4 { // 1 initial + 3 retries
+		t.Errorf("expected 4 calls (1 + 3 retries), got %d", calls)
+	}
+}
+
+func TestRunWithRetry_RespectsContextCancellation(t *testing.T) {
+	// Use a real backoff that would normally take ~1s, but cancel ctx
+	// before the first sleep finishes to confirm short-circuit.
+	prev := transientBackoff
+	transientBackoff = func(ctx context.Context, attempt int) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(5 * time.Second):
+			return nil
+		}
+	}
+	defer func() { transientBackoff = prev }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	transientErr := errors.New("overloaded_error")
+	calls := 0
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := runWithRetry(ctx, "claude", RunOpts{}, 3, classifyTransient, func() (*Result, error) {
+		calls++
+		return nil, transientErr
+	})
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("expected fast cancel, took %v", elapsed)
+	}
+	if calls > 2 {
+		t.Errorf("expected at most 2 calls before cancel, got %d", calls)
+	}
+}
+
+func TestRunWithRetry_CombinedClassifierForClaude(t *testing.T) {
+	defer withFastBackoff(t)()
+
+	// claudeRetryClassifier should retry both transient API errors AND errNoStructuredOutput.
+	calls := 0
+	_, err := runWithRetry(context.Background(), "claude", RunOpts{}, 3, claudeRetryClassifier, func() (*Result, error) {
+		calls++
+		return nil, errNoStructuredOutput
+	})
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if calls != 4 {
+		t.Errorf("expected 4 calls for errNoStructuredOutput retries, got %d", calls)
+	}
+	if !errors.Is(err, errNoStructuredOutput) {
+		t.Errorf("expected errNoStructuredOutput to surface as final error, got %v", err)
+	}
+}
+
+func TestTransientBackoffDuration_Progression(t *testing.T) {
+	// Without jitter, progression should be base * 4^(attempt-1).
+	base := time.Second
+	for _, tc := range []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{1, base},
+		{2, 4 * base},
+		{3, 16 * base},
+	} {
+		got := transientBackoffBaseDuration(tc.attempt, base)
+		if got != tc.want {
+			t.Errorf("attempt %d: want %v, got %v", tc.attempt, tc.want, got)
+		}
+	}
+}

--- a/internal/agent/retry_test.go
+++ b/internal/agent/retry_test.go
@@ -152,7 +152,7 @@ func TestRunWithRetry_RetriesTransientThenSucceeds(t *testing.T) {
 	var chunks []string
 	opts := RunOpts{OnChunk: func(s string) { chunks = append(chunks, s) }}
 
-	res, err := runWithRetry(context.Background(), "claude", opts, 3, classifyTransient, func() (*Result, error) {
+	res, err := runWithRetry(context.Background(), "claude", opts, 3, classifyTransient, nil, func() (*Result, error) {
 		calls++
 		if calls < 3 {
 			return nil, transientErr
@@ -178,13 +178,40 @@ func TestRunWithRetry_RetriesTransientThenSucceeds(t *testing.T) {
 	}
 }
 
+func TestRunWithRetry_CallsRetryRecoveryBeforeRetry(t *testing.T) {
+	defer withFastBackoff(t)()
+
+	calls := 0
+	recovered := false
+	_, err := runWithRetry(context.Background(), "opencode", RunOpts{}, 1, classifyTransient, func(label string) {
+		if label == "connection refused" {
+			recovered = true
+		}
+	}, func() (*Result, error) {
+		calls++
+		if !recovered {
+			return nil, errors.New("dial tcp 127.0.0.1:5555: connection refused")
+		}
+		return &Result{Text: "ok"}, nil
+	})
+	if err != nil {
+		t.Fatalf("expected success after retry recovery, got %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected one retry after recovery, got %d calls", calls)
+	}
+	if !recovered {
+		t.Fatal("expected retry recovery to run")
+	}
+}
+
 func TestRunWithRetry_PermanentErrorFailsImmediately(t *testing.T) {
 	defer withFastBackoff(t)()
 
 	calls := 0
 	permErr := errors.New("API Error: authentication_error: invalid x-api-key")
 
-	_, err := runWithRetry(context.Background(), "claude", RunOpts{}, 3, classifyTransient, func() (*Result, error) {
+	_, err := runWithRetry(context.Background(), "claude", RunOpts{}, 3, classifyTransient, nil, func() (*Result, error) {
 		calls++
 		return nil, permErr
 	})
@@ -202,7 +229,7 @@ func TestRunWithRetry_ExhaustsRetries(t *testing.T) {
 	calls := 0
 	transientErr := errors.New("503 service unavailable")
 
-	_, err := runWithRetry(context.Background(), "claude", RunOpts{}, 3, classifyTransient, func() (*Result, error) {
+	_, err := runWithRetry(context.Background(), "claude", RunOpts{}, 3, classifyTransient, nil, func() (*Result, error) {
 		calls++
 		return nil, transientErr
 	})
@@ -238,7 +265,7 @@ func TestRunWithRetry_RespectsContextCancellation(t *testing.T) {
 	}()
 
 	start := time.Now()
-	_, err := runWithRetry(ctx, "claude", RunOpts{}, 3, classifyTransient, func() (*Result, error) {
+	_, err := runWithRetry(ctx, "claude", RunOpts{}, 3, classifyTransient, nil, func() (*Result, error) {
 		calls++
 		return nil, transientErr
 	})
@@ -258,7 +285,7 @@ func TestRunWithRetry_CombinedClassifierForClaude(t *testing.T) {
 
 	// claudeRetryClassifier should retry both transient API errors AND errNoStructuredOutput.
 	calls := 0
-	_, err := runWithRetry(context.Background(), "claude", RunOpts{}, 3, claudeRetryClassifier, func() (*Result, error) {
+	_, err := runWithRetry(context.Background(), "claude", RunOpts{}, 3, claudeRetryClassifier, nil, func() (*Result, error) {
 		calls++
 		return nil, errNoStructuredOutput
 	})

--- a/internal/agent/rovodev.go
+++ b/internal/agent/rovodev.go
@@ -24,6 +24,12 @@ type rovodevAgent struct {
 func (a *rovodevAgent) Name() string { return "rovodev" }
 
 func (a *rovodevAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
+	return runWithRetry(ctx, "rovodev", opts, claudeMaxRetries, classifyTransient, func() (*Result, error) {
+		return a.runOnce(ctx, opts)
+	})
+}
+
+func (a *rovodevAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 	// Start server on first invocation (synchronized)
 	baseURL, err := a.ensureServer(ctx, opts.CWD)
 	if err != nil {

--- a/internal/agent/rovodev.go
+++ b/internal/agent/rovodev.go
@@ -24,9 +24,22 @@ type rovodevAgent struct {
 func (a *rovodevAgent) Name() string { return "rovodev" }
 
 func (a *rovodevAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
-	return runWithRetry(ctx, "rovodev", opts, claudeMaxRetries, classifyTransient, func() (*Result, error) {
+	return runWithRetry(ctx, "rovodev", opts, claudeMaxRetries, classifyTransient, a.recoverTransientRetry, func() (*Result, error) {
 		return a.runOnce(ctx, opts)
 	})
+}
+
+func (a *rovodevAgent) recoverTransientRetry(label string) {
+	if label != "connection refused" {
+		return
+	}
+	a.mu.Lock()
+	srv := a.server
+	a.server = nil
+	a.mu.Unlock()
+	if srv != nil {
+		srv.shutdown()
+	}
 }
 
 func (a *rovodevAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {


### PR DESCRIPTION
## Summary
- Add shared transient retry handling for agent invocations so Claude, Codex, Rovo Dev, and OpenCode can recover from retryable API and network failures with backoff.
- Restart stale managed Rovo Dev and OpenCode servers on connection-refused retries instead of reusing dead cached server references.
- Document the new retry behavior and stale-server recovery expectations in the agent guide.

## Risk Assessment

⚠️ Medium: The retry logic is centralized and reasonably bounded, but it changes execution behavior for multiple external agents and persistent local servers, so regressions would likely appear only under transient failure conditions.

## Testing

- Summary: Exercised the new retry classifier/backoff behavior, agent package integrations, pipeline callers, and e2e agent flows; all selected tests passed.
- `go test ./internal/agent -run 'Test(ClassifyTransient|RunWithRetry|TransientBackoff)' -count=1`
- `go test ./internal/agent`
- `go test -race ./internal/agent`
- `go test ./internal/pipeline/...`
- `make e2e`
- Outcome: ✅ passed across 1 run (1m4s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/agent/retry.go:111` - Classifying `connection refused` as retriable does not recover opencode/rovodev server crashes because their `ensureServer` methods return the cached base URL whenever `a.server` is non-nil; retries will reuse the same dead local server and add the full backoff delay instead of restarting it or failing promptly.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/agent -run 'Test(ClassifyTransient|RunWithRetry|TransientBackoff)' -count=1`
- `go test ./internal/agent`
- `go test -race ./internal/agent`
- `go test ./internal/pipeline/...`
- `make e2e`

</details>

<details>
<summary>🔧 **Document** - 3 issues found → auto-fixed</summary>

**Round 1** - found 3 warnings
- ⚠️ `docs/src/content/docs/guides/agents.md:97` - The agent interface documentation omits the new cross-agent transient retry behavior. The change now retries Claude, Codex, Rovo Dev, and OpenCode invocations up to 3 additional times for retriable API/network failures such as 429, 503, 529, overloaded/rate-limit errors, connection resets/refusals, DNS failures, TLS handshake failures, and unexpected EOF, with exponential backoff and retry messages surfaced through OnChunk/TUI output. This affects user-visible latency, repeated agent attempts, and troubleshooting expectations, so the common agent behavior section should document it.
- ⚠️ `docs/src/content/docs/guides/agents.md:122` - The Rovo Dev section still says the persistent HTTP server is started once and reused across invocations, but the change now treats `connection refused` as recoverable by shutting down the cached server reference and starting a fresh server on retry. Update this section to mention automatic stale-server recovery on connection-refused retries.
- ⚠️ `docs/src/content/docs/guides/agents.md:126` - The OpenCode section documents the persistent server lifecycle but does not mention the new recovery path for stale managed servers. On `connection refused`, no-mistakes now clears and shuts down the cached OpenCode server before retrying so the next attempt can start a fresh server. Update this section to keep the documented lifecycle accurate.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
