### PR TITLE
feat(agent): add Pi agent support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ Safest local verification sequence after non-trivial changes:
 - `internal/cli`: cobra commands and CLI wiring
 - `internal/daemon`: background daemon and run management
 - `internal/pipeline` and `internal/pipeline/steps`: orchestration plus review/test/lint/push/PR/CI steps
-- `internal/agent`: Claude, Codex, Rovo Dev, and OpenCode integrations
+- `internal/agent`: Claude, Codex, Rovo Dev, OpenCode, and Pi integrations
 - `internal/git`, `internal/ipc`, `internal/config`, `internal/db`, `internal/paths`, `internal/types`: shared infrastructure
 - `internal/tui`: terminal UI
 

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ test:
 
 # End-to-end suite: drives the real no-mistakes binary against a fake
 # agent through the full push -> pipeline -> push journey for each
-# supported agent backend. Excluded from `make test` because it is
+# e2e-covered agent backend. Excluded from `make test` because it is
 # behind the `e2e` build tag and rebuilds binaries on each run.
 e2e:
 	go test -tags=e2e -count=1 -timeout 300s ./internal/e2e/...

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 `no-mistakes` puts a local git proxy in front of your real remote. Push to `no-mistakes` instead of `origin`, and it spins up a disposable worktree, runs an AI-driven validation pipeline, forwards upstream only after every check passes, and opens a clean PR automatically.
 
 - **Non-blocking** - the pipeline runs in an isolated worktree without disrupting your work.
-- **Agent-agnostic** - `claude`, `codex`, `rovodev`, or `opencode`.
+- **Agent-agnostic** - `claude`, `codex`, `rovodev`, `opencode`, or `pi`.
 - **Human stays in charge** - auto-fix or review findings, your call.
 - **Clean PRs by default** - push, open PR, watch CI, and auto-fix failures in one shot.
 

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -29,6 +29,7 @@ commands are still the strongest way to make the gate predictable.
 | Codex | `codex` | Subprocess per invocation, JSONL events |
 | Rovo Dev | `acli` | Persistent HTTP server, SSE streaming |
 | OpenCode | `opencode` | Persistent HTTP server, SSE streaming |
+| Pi | `pi` | Subprocess per invocation, JSONL events |
 
 ## Setting the agent
 
@@ -67,6 +68,7 @@ By default, `no-mistakes` resolves `agent: auto` by checking for supported agent
 2. `codex`
 3. `opencode`
 4. `acli` with `rovodev` support
+5. `pi`
 
 The default binary names are:
 
@@ -76,6 +78,7 @@ The default binary names are:
 | `codex` | `codex` |
 | `rovodev` | `acli` |
 | `opencode` | `opencode` |
+| `pi` | `pi` |
 
 When the daemon is running through a managed service, that `PATH` comes from your login shell environment on macOS and Linux plus common user, Homebrew, and system binary directories. On Windows it reuses the current process environment instead of reloading a login shell. If agent discovery still does not resolve the binary you expect, use an explicit `agent_path_override`.
 
@@ -87,6 +90,7 @@ agent_path_override:
   codex: /opt/homebrew/bin/codex
   rovodev: /usr/local/bin/acli
   opencode: /usr/local/bin/opencode
+  pi: /usr/local/bin/pi
 ```
 
 You can also set extra agent-specific CLI flags in global config with
@@ -127,6 +131,13 @@ Starts a persistent HTTP server (`acli rovodev serve`) on first use and reuses i
 
 Starts a persistent HTTP server (`opencode serve`) on first use and reuses it across invocations. If a reused server refuses a connection, no-mistakes discards it and retries with a fresh server. Any `agent_args_override.opencode` flags are inserted before no-mistakes' managed serve flags. Similar session lifecycle to Rovo Dev: create session, send message, stream SSE events until idle, delete session. Supports `json_schema` format in the message request for structured output. When native structured output is absent, it falls back to parsing the final text with the same JSON fence and bare-object fallback, validating that fallback result against the requested schema while allowing `null` for optional fields.
 
+## Pi
+
+Spawns a `pi` subprocess for each invocation with `--mode json --no-session`.
+Any `agent_args_override.pi` flags are inserted before no-mistakes' managed flags.
+Reads JSONL events from stdout and streams incremental text deltas to the TUI.
+When structured output is requested, no-mistakes injects the JSON schema into the prompt and validates the final text response.
+
 ## Checking agent availability
 
 Run `no-mistakes doctor` to see which agent binaries are installed and available:
@@ -142,6 +153,7 @@ $ no-mistakes doctor
   – codex (not found)
   – acli (not found)
   – opencode (not found)
+  – pi (not found)
 ```
 
 `✓` = available, `–` = not found (optional), `✗` = problem detected.

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -48,7 +48,7 @@ Everything else can usually wait.
 
 # Default agent for all repos and setup-wizard suggestions.
 # "auto" picks the first available agent on PATH.
-agent: auto  # auto | claude | codex | rovodev | opencode
+agent: auto  # auto | claude | codex | rovodev | opencode | pi
 
 # Optional binary path overrides.
 agent_path_override:
@@ -56,6 +56,7 @@ agent_path_override:
   codex: /opt/homebrew/bin/codex
   rovodev: /usr/local/bin/acli
   opencode: /usr/local/bin/opencode
+  pi: /usr/local/bin/pi
 
 # Optional extra CLI flags per agent.
 # This is global-only.
@@ -121,7 +122,7 @@ See [Repo Config Reference](/no-mistakes/reference/repo-config/) for the full fi
 ## Precedence
 
 - Repo `agent` overrides global `agent`.
-- Global `agent: auto` resolves by checking `claude`, `codex`, `opencode`, then `acli` for `rovodev` on `PATH`.
+- Global `agent: auto` resolves by checking `claude`, `codex`, `opencode`, `acli` for `rovodev`, then `pi` on `PATH`.
 - `agent_path_override` and `agent_args_override` are global-only fields.
 - `auto_fix` from the repo config overlays global auto_fix. Fields not set in the repo config fall through to the global default.
 - `commands` and `ignore_patterns` are repo-only fields.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -105,7 +105,7 @@ Checks:
 - Data directory (`~/.no-mistakes/`)
 - SQLite database
 - Daemon status
-- Agent binaries: `claude`, `codex`, `acli`, `opencode`
+- Agent binaries: `claude`, `codex`, `acli`, `opencode`, `pi`
 
 Uses indicators: `✓` (available), `–` (not found, optional), `✗` (problem detected).
 

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -15,6 +15,7 @@ agent_path_override:
   codex: /opt/homebrew/bin/codex
   rovodev: /usr/local/bin/acli
   opencode: /usr/local/bin/opencode
+  pi: /usr/local/bin/pi
 
 agent_args_override:
   codex:
@@ -44,10 +45,10 @@ Default agent for all repos and setup-wizard suggestions. Can be overridden per-
 | | |
 |---|---|
 | Type | `string` |
-| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode` |
+| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi` |
 | Default | `auto` |
 
-`auto` resolves to the first supported agent found on `PATH` in this order: `claude`, `codex`, `opencode`, then `acli` with `rovodev` support.
+`auto` resolves to the first supported agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, then `pi`.
 
 ### agent_path_override
 
@@ -66,6 +67,7 @@ Default binary names when no override is set:
 | `codex` | `codex` |
 | `rovodev` | `acli` |
 | `opencode` | `opencode` |
+| `pi` | `pi` |
 
 ### agent_args_override
 
@@ -74,7 +76,7 @@ Extra CLI flags to pass to each agent. Use this to set model selection, reasonin
 | | |
 |---|---|
 | Type | `map[string][]string` |
-| Keys | `claude`, `codex`, `rovodev`, `opencode` |
+| Keys | `claude`, `codex`, `rovodev`, `opencode`, `pi` |
 | Default | Empty (no extra flags) |
 
 User-supplied flags are inserted ahead of no-mistakes' managed flags, so your choices usually take precedence. A few flags are reserved because no-mistakes depends on them to communicate with the agent - setting any of these returns a config error on load:
@@ -85,6 +87,7 @@ User-supplied flags are inserted ahead of no-mistakes' managed flags, so your ch
 | `codex` | `exec`, `--json`, `--color` |
 | `rovodev` | `rovodev`, `serve`, `--disable-session-token` |
 | `opencode` | `serve`, `--hostname`, `--port`, `--print-logs` |
+| `pi` | `--mode`, `--no-session` |
 
 For structured `codex` runs, no-mistakes also appends its own `--output-schema <tempfile>` after your overrides. Treat that flag as managed even though config validation does not currently reject it.
 
@@ -112,6 +115,9 @@ agent_args_override:
   opencode:
     - --model
     - gpt-5
+  pi:
+    - --provider
+    - google
 ```
 
 ### ci_timeout

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -37,10 +37,10 @@ Override the default agent for this repo and its setup-wizard suggestions.
 | | |
 |---|---|
 | Type | `string` |
-| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode` |
+| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi` |
 | Default | Inherits from global config |
 
-`auto` resolves to the first supported agent found on `PATH` in this order: `claude`, `codex`, `opencode`, then `acli` with `rovodev` support.
+`auto` resolves to the first supported agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, then `pi`.
 
 ### commands.test
 

--- a/docs/src/content/docs/start-here/installation.md
+++ b/docs/src/content/docs/start-here/installation.md
@@ -47,7 +47,7 @@ make install
 ## Prerequisites
 
 - **git** - required
-- **One supported agent binary** - `claude`, `codex`, `acli` (Rovo Dev), or `opencode`
+- **One supported agent binary** - `claude`, `codex`, `acli` (Rovo Dev), `opencode`, or `pi`
 - **Optional, for PRs and CI:**
   - `gh` CLI (GitHub)
   - `glab` CLI (GitLab)

--- a/docs/src/content/docs/start-here/introduction.md
+++ b/docs/src/content/docs/start-here/introduction.md
@@ -68,7 +68,7 @@ When a branch passes the gate, it means:
 ## What you get
 
 - A fixed, opinionated pipeline: `rebase → review → test → document → lint → push → pr → ci`. Order is not configurable; what each step runs is.
-- Choice of agent: `claude`, `codex`, `rovodev`, or `opencode`, with per-repo override.
+- Choice of agent: `claude`, `codex`, `rovodev`, `opencode`, or `pi`, with per-repo override.
 - A TUI to watch, approve, fix, skip, or abort any step.
 - A setup wizard when you run bare `no-mistakes` with no active run on the current branch - it walks you through creating a branch, committing, and pushing through the gate, then attaches if the daemon registers the new run.
 

--- a/docs/src/content/docs/start-here/quick-start.md
+++ b/docs/src/content/docs/start-here/quick-start.md
@@ -24,7 +24,7 @@ no-mistakes doctor
 You need:
 
 - `git`
-- One supported agent binary (`claude`, `codex`, `acli` for Rovo Dev, or `opencode`)
+- One supported agent binary (`claude`, `codex`, `acli` for Rovo Dev, `opencode`, or `pi`)
 - For PRs and CI: `gh` (GitHub), `glab` (GitLab), or Bitbucket Cloud credentials
 
 See [Provider Integration](/no-mistakes/guides/provider-integration/) for PR/CI setup.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -569,8 +569,10 @@ func New(name types.AgentName, bin string, extraArgs []string) (Agent, error) {
 		return &rovodevAgent{bin: bin, extraArgs: extraArgs}, nil
 	case types.AgentOpenCode:
 		return &opencodeAgent{bin: bin, extraArgs: extraArgs}, nil
+	case types.AgentPi:
+		return &piAgent{bin: bin, extraArgs: extraArgs}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode (set 'agent' in ~/.no-mistakes/config.yaml)", name)
+		return nil, fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi (set 'agent' in ~/.no-mistakes/config.yaml)", name)
 	}
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -19,6 +19,7 @@ func TestNew_KnownAgents(t *testing.T) {
 		{name: "codex", agent: types.AgentCodex, bin: "codex", wantName: "codex"},
 		{name: "rovodev", agent: types.AgentRovoDev, bin: "acli", wantName: "rovodev"},
 		{name: "opencode", agent: types.AgentOpenCode, bin: "opencode", wantName: "opencode"},
+		{name: "pi", agent: types.AgentPi, bin: "pi", wantName: "pi"},
 	}
 
 	for _, tt := range tests {

--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -126,6 +126,7 @@ type piParser struct {
 	completeText   map[int]string
 	finalAssistant map[string]any
 	usage          TokenUsage
+	seenUsage      map[string]struct{}
 	assistantError string
 }
 
@@ -135,6 +136,7 @@ func (p *piParser) parse(ctx context.Context, r io.Reader) error {
 
 	p.streamText = make(map[int]string)
 	p.completeText = make(map[int]string)
+	p.seenUsage = make(map[string]struct{})
 
 	for scanner.Scan() {
 		select {
@@ -166,22 +168,9 @@ func (p *piParser) handleEvent(event map[string]any) {
 		p.handleAssistantEvent(event["assistantMessageEvent"])
 	case "message_end", "turn_end":
 		p.rememberAssistant(event["message"])
+		p.recordAssistantUsage(event["message"])
 	case "agent_end":
-		// Fallback: pull the final assistant message from the conversation
-		// when no streaming message_end carried it.
-		if p.finalAssistant != nil {
-			return
-		}
-		messages, ok := event["messages"].([]any)
-		if !ok {
-			return
-		}
-		for i := len(messages) - 1; i >= 0; i-- {
-			if msg, ok := messages[i].(map[string]any); ok && msg["role"] == "assistant" {
-				p.rememberAssistant(msg)
-				return
-			}
-		}
+		p.rememberAgentEnd(event["messages"])
 	}
 }
 
@@ -200,11 +189,89 @@ func (p *piParser) rememberAssistant(raw any) {
 		if p.assistantError == "" {
 			p.assistantError = fmt.Sprintf("stopReason=%s", reason)
 		}
+	} else {
+		p.assistantError = ""
+	}
+}
+
+func (p *piParser) rememberAgentEnd(raw any) {
+	messages, ok := raw.([]any)
+	if !ok {
+		return
 	}
 
-	if usage, ok := msg["usage"].(map[string]any); ok {
-		p.usage = piUsageFrom(usage)
+	total := TokenUsage{}
+	seen := make(map[string]struct{})
+	hasUsage := false
+	for i, rawMsg := range messages {
+		msg, ok := rawMsg.(map[string]any)
+		if !ok || msg["role"] != "assistant" {
+			continue
+		}
+		usageMap, ok := msg["usage"].(map[string]any)
+		if !ok {
+			continue
+		}
+		usage := piUsageFrom(usageMap)
+		if piUsageIsZero(usage) {
+			continue
+		}
+		key := piUsageKey(msg)
+		if key == "" {
+			key = fmt.Sprintf("agent_end:%d", i)
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		total = piUsageAdd(total, usage)
+		hasUsage = true
 	}
+	if hasUsage {
+		p.usage = total
+		p.seenUsage = make(map[string]struct{}, len(seen))
+		for key := range seen {
+			p.seenUsage[key] = struct{}{}
+		}
+	}
+
+	for i := len(messages) - 1; i >= 0; i-- {
+		if msg, ok := messages[i].(map[string]any); ok && msg["role"] == "assistant" {
+			p.rememberAssistant(msg)
+			return
+		}
+	}
+}
+
+func (p *piParser) recordAssistantUsage(raw any) {
+	msg, ok := raw.(map[string]any)
+	if !ok || msg["role"] != "assistant" {
+		return
+	}
+	usageMap, ok := msg["usage"].(map[string]any)
+	if !ok {
+		return
+	}
+	usage := piUsageFrom(usageMap)
+	if piUsageIsZero(usage) {
+		return
+	}
+	key := piUsageKey(msg)
+	if key == "" {
+		encoded, err := json.Marshal([]any{msg["role"], msg["stopReason"], msg["content"], msg["usage"]})
+		if err != nil {
+			return
+		}
+		key = string(encoded)
+	}
+	if p.seenUsage == nil {
+		p.seenUsage = make(map[string]struct{})
+	}
+	if _, ok := p.seenUsage[key]; ok {
+		return
+	}
+	p.seenUsage[key] = struct{}{}
+	p.usage = piUsageAdd(p.usage, usage)
 }
 
 func (p *piParser) handleAssistantEvent(raw any) {
@@ -332,4 +399,27 @@ func piUsageFrom(usage map[string]any) TokenUsage {
 		CacheReadTokens:     piIntField(usage, "cacheRead"),
 		CacheCreationTokens: piIntField(usage, "cacheWrite"),
 	}
+}
+
+func piUsageAdd(a, b TokenUsage) TokenUsage {
+	return TokenUsage{
+		InputTokens:         a.InputTokens + b.InputTokens,
+		OutputTokens:        a.OutputTokens + b.OutputTokens,
+		CacheReadTokens:     a.CacheReadTokens + b.CacheReadTokens,
+		CacheCreationTokens: a.CacheCreationTokens + b.CacheCreationTokens,
+	}
+}
+
+func piUsageIsZero(usage TokenUsage) bool {
+	return usage.InputTokens == 0 && usage.OutputTokens == 0 &&
+		usage.CacheReadTokens == 0 && usage.CacheCreationTokens == 0
+}
+
+func piUsageKey(msg map[string]any) string {
+	for _, name := range []string{"responseId", "id"} {
+		if value, ok := msg[name].(string); ok && value != "" {
+			return name + ":" + value
+		}
+	}
+	return ""
 }

--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -1,0 +1,335 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+// piAgent spawns the pi CLI for each invocation. Pi reads its prompt from
+// stdin and emits JSONL on stdout when --mode json is set. The lifecycle is
+// codex-shaped: one process per Run, no managed server.
+type piAgent struct {
+	bin       string
+	extraArgs []string
+}
+
+func (a *piAgent) Name() string { return "pi" }
+
+func (a *piAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
+	return runWithRetry(ctx, "pi", opts, claudeMaxRetries, classifyTransient, nil, func() (*Result, error) {
+		return a.runOnce(ctx, opts)
+	})
+}
+
+func (a *piAgent) Close() error { return nil }
+
+func (a *piAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
+	args := a.buildArgs()
+	cmd := exec.CommandContext(ctx, a.bin, args...)
+	cmd.Dir = opts.CWD
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("pi stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("pi stdout pipe: %w", err)
+	}
+	stderrR, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("pi stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("pi start: %w", err)
+	}
+
+	prompt := buildPiPrompt(opts.Prompt, opts.JSONSchema)
+	go func() {
+		defer stdin.Close()
+		_, _ = io.WriteString(stdin, prompt)
+	}()
+
+	var stderrBuf []byte
+	var stderrWG sync.WaitGroup
+	stderrWG.Add(1)
+	go func() {
+		defer stderrWG.Done()
+		stderrBuf, _ = io.ReadAll(stderrR)
+	}()
+
+	pp := &piParser{onChunk: opts.OnChunk}
+	if err := pp.parse(ctx, stdout); err != nil {
+		stderrWG.Wait()
+		_ = cmd.Wait()
+		return nil, fmt.Errorf("pi parse events: %w", err)
+	}
+
+	stderrWG.Wait()
+	if err := cmd.Wait(); err != nil {
+		stderr := strings.TrimSpace(string(stderrBuf))
+		if stderr != "" {
+			return nil, fmt.Errorf("pi exited: %w: %s", err, stderr)
+		}
+		return nil, fmt.Errorf("pi exited: %w", err)
+	}
+
+	if pp.assistantError != "" {
+		return nil, fmt.Errorf("pi reported error: %s", pp.assistantError)
+	}
+
+	text := pp.finalText()
+	return finalizeTextResult("pi", text, opts.JSONSchema, pp.usage)
+}
+
+// buildArgs returns the Pi argv for one invocation. User extras come first
+// (so user --provider/--model take effect), then the managed flags that
+// no-mistakes requires for JSONL parsing.
+func (a *piAgent) buildArgs() []string {
+	args := make([]string, 0, len(a.extraArgs)+3)
+	args = append(args, a.extraArgs...)
+	args = append(args, "--mode", "json", "--no-session")
+	return args
+}
+
+// buildPiPrompt appends a JSON-output contract to the user prompt when a
+// schema is provided. Pi has no equivalent of codex's --output-schema flag,
+// so we inline the schema in the prompt the same way gnhf does.
+func buildPiPrompt(prompt string, schema json.RawMessage) string {
+	if len(schema) == 0 {
+		return prompt
+	}
+	pretty, err := json.MarshalIndent(json.RawMessage(schema), "", "  ")
+	if err != nil {
+		pretty = []byte(schema)
+	}
+	return prompt + "\n\n## no-mistakes final output contract\n\n" +
+		"When the iteration is complete, your final assistant response must be only valid JSON matching this JSON Schema. " +
+		"Do not wrap it in Markdown fences. Do not include prose before or after the JSON object.\n\n" +
+		string(pretty)
+}
+
+// piParser tracks the streaming state of one Pi run. It accumulates text
+// deltas, captures the final assistant text and usage, and surfaces any
+// reported assistant error.
+type piParser struct {
+	onChunk func(string)
+
+	streamText     map[int]string
+	completeText   map[int]string
+	finalAssistant map[string]any
+	usage          TokenUsage
+	assistantError string
+}
+
+func (p *piParser) parse(ctx context.Context, r io.Reader) error {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 256*1024*1024)
+
+	p.streamText = make(map[int]string)
+	p.completeText = make(map[int]string)
+
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var event map[string]any
+		if err := json.Unmarshal(line, &event); err != nil {
+			continue
+		}
+		p.handleEvent(event)
+	}
+
+	return scanner.Err()
+}
+
+func (p *piParser) handleEvent(event map[string]any) {
+	typ, _ := event["type"].(string)
+	switch typ {
+	case "message_update":
+		p.rememberAssistant(event["message"])
+		p.handleAssistantEvent(event["assistantMessageEvent"])
+	case "message_end", "turn_end":
+		p.rememberAssistant(event["message"])
+	case "agent_end":
+		// Fallback: pull the final assistant message from the conversation
+		// when no streaming message_end carried it.
+		if p.finalAssistant != nil {
+			return
+		}
+		messages, ok := event["messages"].([]any)
+		if !ok {
+			return
+		}
+		for i := len(messages) - 1; i >= 0; i-- {
+			if msg, ok := messages[i].(map[string]any); ok && msg["role"] == "assistant" {
+				p.rememberAssistant(msg)
+				return
+			}
+		}
+	}
+}
+
+func (p *piParser) rememberAssistant(raw any) {
+	msg, ok := raw.(map[string]any)
+	if !ok {
+		return
+	}
+	if role, _ := msg["role"].(string); role != "assistant" {
+		return
+	}
+	p.finalAssistant = msg
+
+	if reason, _ := msg["stopReason"].(string); reason == "error" || reason == "aborted" {
+		p.assistantError = piFirstString(msg, "errorMessage", "error", "message")
+		if p.assistantError == "" {
+			p.assistantError = fmt.Sprintf("stopReason=%s", reason)
+		}
+	}
+
+	if usage, ok := msg["usage"].(map[string]any); ok {
+		p.usage = piUsageFrom(usage)
+	}
+}
+
+func (p *piParser) handleAssistantEvent(raw any) {
+	evt, ok := raw.(map[string]any)
+	if !ok {
+		return
+	}
+	idx := piIntField(evt, "contentIndex", "content_index")
+	switch evt["type"] {
+	case "text_delta":
+		// Emit just the incremental delta. no-mistakes' OnChunk consumers
+		// (TUI log line buffer, file logger) expect appended text, not
+		// cumulative state.
+		delta := piFirstString(evt, "delta", "text", "content")
+		if delta == "" {
+			return
+		}
+		p.streamText[idx] += delta
+		if p.onChunk != nil {
+			p.onChunk(delta)
+		}
+	case "text_end":
+		// Capture the complete text for final-result resolution. Don't
+		// re-emit to OnChunk: the deltas already covered it. If the event
+		// carries the full text (Pi's normal shape), prefer that over the
+		// delta accumulator since it's authoritative.
+		text := piFirstString(evt, "text", "content")
+		if text == "" {
+			text = p.streamText[idx]
+		}
+		p.completeText[idx] = text
+	}
+}
+
+// finalText returns the final assistant text, preferring (in order) the
+// content of the last assistant message, the text_end-completed deltas, and
+// finally the in-flight stream buffer.
+func (p *piParser) finalText() string {
+	if text := strings.TrimSpace(textFromAssistantMessage(p.finalAssistant)); text != "" {
+		return text
+	}
+	if text := strings.TrimSpace(joinByIndex(p.completeText)); text != "" {
+		return text
+	}
+	return strings.TrimSpace(joinByIndex(p.streamText))
+}
+
+func textFromAssistantMessage(msg map[string]any) string {
+	if msg == nil {
+		return ""
+	}
+	switch v := msg["content"].(type) {
+	case string:
+		return v
+	case []any:
+		var b strings.Builder
+		for _, block := range v {
+			switch t := block.(type) {
+			case string:
+				b.WriteString(t)
+			case map[string]any:
+				if s, ok := t["text"].(string); ok {
+					b.WriteString(s)
+					continue
+				}
+				if s, ok := t["content"].(string); ok {
+					b.WriteString(s)
+				}
+			}
+		}
+		return b.String()
+	}
+	if s, ok := msg["text"].(string); ok {
+		return s
+	}
+	return ""
+}
+
+func joinByIndex(parts map[int]string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	max := -1
+	for k := range parts {
+		if k > max {
+			max = k
+		}
+	}
+	var b strings.Builder
+	for i := 0; i <= max; i++ {
+		b.WriteString(parts[i])
+	}
+	return b.String()
+}
+
+func piFirstString(m map[string]any, names ...string) string {
+	for _, n := range names {
+		if v, ok := m[n].(string); ok {
+			return v
+		}
+	}
+	return ""
+}
+
+func piIntField(m map[string]any, names ...string) int {
+	for _, n := range names {
+		switch v := m[n].(type) {
+		case float64:
+			return int(v)
+		case int:
+			return v
+		case json.Number:
+			if i, err := v.Int64(); err == nil {
+				return int(i)
+			}
+		}
+	}
+	return 0
+}
+
+func piUsageFrom(usage map[string]any) TokenUsage {
+	return TokenUsage{
+		InputTokens:         piIntField(usage, "input"),
+		OutputTokens:        piIntField(usage, "output"),
+		CacheReadTokens:     piIntField(usage, "cacheRead"),
+		CacheCreationTokens: piIntField(usage, "cacheWrite"),
+	}
+}

--- a/internal/agent/pi_test.go
+++ b/internal/agent/pi_test.go
@@ -163,6 +163,44 @@ printf '%s\n' '{"type":"agent_end","messages":[{"role":"user","content":"prompt"
 	}
 }
 
+func TestPiParser_ClearsPriorAssistantErrorAfterSuccessfulRetry(t *testing.T) {
+	stream := strings.Join([]string{
+		`{"type":"message_end","message":{"role":"assistant","responseId":"r1","stopReason":"error","errorMessage":"transient failure"}}`,
+		`{"type":"message_end","message":{"role":"assistant","responseId":"r2","stopReason":"stop","content":[{"type":"text","text":"success"}]}}`,
+		`{"type":"agent_end","messages":[{"role":"assistant","responseId":"r1","stopReason":"error","errorMessage":"transient failure"},{"role":"assistant","responseId":"r2","stopReason":"stop","content":[{"type":"text","text":"success"}]}]}`,
+	}, "\n")
+
+	pp := &piParser{}
+	if err := pp.parse(context.Background(), strings.NewReader(stream)); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if pp.assistantError != "" {
+		t.Fatalf("expected successful retry to clear assistant error, got %q", pp.assistantError)
+	}
+	if got := pp.finalText(); got != "success" {
+		t.Fatalf("expected final retry text, got %q", got)
+	}
+}
+
+func TestPiParser_SumsUniqueAssistantUsageAcrossTurns(t *testing.T) {
+	stream := strings.Join([]string{
+		`{"type":"message_end","message":{"role":"assistant","responseId":"r1","stopReason":"toolUse","content":[{"type":"toolCall","name":"bash"}],"usage":{"input":10,"output":2,"cacheRead":3,"cacheWrite":4}}}`,
+		`{"type":"turn_end","message":{"role":"assistant","responseId":"r1","stopReason":"toolUse","content":[{"type":"toolCall","name":"bash"}],"usage":{"input":10,"output":2,"cacheRead":3,"cacheWrite":4}}}`,
+		`{"type":"message_end","message":{"role":"assistant","responseId":"r2","stopReason":"stop","content":[{"type":"text","text":"done"}],"usage":{"input":1,"output":5,"cacheRead":6,"cacheWrite":7}}}`,
+		`{"type":"turn_end","message":{"role":"assistant","responseId":"r2","stopReason":"stop","content":[{"type":"text","text":"done"}],"usage":{"input":1,"output":5,"cacheRead":6,"cacheWrite":7}}}`,
+		`{"type":"agent_end","messages":[{"role":"assistant","responseId":"r1","stopReason":"toolUse","content":[{"type":"toolCall","name":"bash"}],"usage":{"input":10,"output":2,"cacheRead":3,"cacheWrite":4}},{"role":"toolResult","content":[{"type":"text","text":"ok"}]},{"role":"assistant","responseId":"r2","stopReason":"stop","content":[{"type":"text","text":"done"}],"usage":{"input":1,"output":5,"cacheRead":6,"cacheWrite":7}}]}`,
+	}, "\n")
+
+	pp := &piParser{}
+	if err := pp.parse(context.Background(), strings.NewReader(stream)); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	want := TokenUsage{InputTokens: 11, OutputTokens: 7, CacheReadTokens: 9, CacheCreationTokens: 11}
+	if pp.usage != want {
+		t.Fatalf("usage = %+v, want %+v", pp.usage, want)
+	}
+}
+
 func TestPiAgent_RunRejectsAssistantError(t *testing.T) {
 	dir := t.TempDir()
 	bin := writeFakePi(t, dir, `#!/bin/sh

--- a/internal/agent/pi_test.go
+++ b/internal/agent/pi_test.go
@@ -1,0 +1,265 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestPiAgent_BuildArgs(t *testing.T) {
+	pa := &piAgent{bin: "pi"}
+	args := pa.buildArgs()
+
+	expected := []string{"--mode", "json", "--no-session"}
+
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("arg[%d]: expected %q, got %q", i, want, args[i])
+		}
+	}
+}
+
+func TestPiAgent_BuildArgs_PrependsExtraArgs(t *testing.T) {
+	pa := &piAgent{bin: "pi", extraArgs: []string{"--provider", "google"}}
+	args := pa.buildArgs()
+
+	expected := []string{"--provider", "google", "--mode", "json", "--no-session"}
+
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("arg[%d]: expected %q, got %q", i, want, args[i])
+		}
+	}
+}
+
+func TestPiAgent_BuildPromptIncludesSchema(t *testing.T) {
+	schema := json.RawMessage(`{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"]}`)
+	prompt := buildPiPrompt("do a thing", schema)
+	if !strings.Contains(prompt, "do a thing") {
+		t.Errorf("prompt missing user prompt: %s", prompt)
+	}
+	if !strings.Contains(prompt, "no-mistakes final output contract") {
+		t.Errorf("prompt missing contract header: %s", prompt)
+	}
+	if !strings.Contains(prompt, "summary") {
+		t.Errorf("prompt missing schema property: %s", prompt)
+	}
+}
+
+func TestPiAgent_BuildPromptOmitsContractWhenSchemaEmpty(t *testing.T) {
+	prompt := buildPiPrompt("do a thing", nil)
+	if prompt != "do a thing" {
+		t.Errorf("expected raw prompt when no schema, got: %q", prompt)
+	}
+}
+
+func writeFakePi(t *testing.T, dir, posixScript, windowsScript string) string {
+	t.Helper()
+
+	name := "pi"
+	script := posixScript
+	if runtime.GOOS == "windows" {
+		name = "pi.cmd"
+		script = windowsScript
+	}
+
+	bin := filepath.Join(dir, name)
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake pi: %v", err)
+	}
+	return bin
+}
+
+func TestPiAgent_RunParsesAssistantContentAndUsage(t *testing.T) {
+	dir := t.TempDir()
+	// Fake pi that emits a streaming text_delta plus a final message_end with
+	// content blocks and a usage record. Mirrors the live JSONL shape.
+	bin := writeFakePi(t, dir, `#!/bin/sh
+cat > /dev/null
+printf '%s\n' '{"type":"message_update","message":{"role":"assistant","responseId":"r1"},"assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"{\"ok"}}'
+printf '%s\n' '{"type":"message_update","message":{"role":"assistant","responseId":"r1"},"assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"\":true}"}}'
+printf '%s\n' '{"type":"message_end","message":{"role":"assistant","responseId":"r1","content":[{"type":"text","text":"{\"ok\":true}"}],"usage":{"input":11,"output":7,"cacheRead":3,"cacheWrite":1}}}'
+printf '%s\n' '{"type":"agent_end","messages":[]}'
+`, strings.Join([]string{
+		"@echo off",
+		"more > nul",
+		"echo {\"type\":\"message_update\",\"message\":{\"role\":\"assistant\",\"responseId\":\"r1\"},\"assistantMessageEvent\":{\"type\":\"text_delta\",\"contentIndex\":0,\"delta\":\"{\\\"ok\"}}",
+		"echo {\"type\":\"message_update\",\"message\":{\"role\":\"assistant\",\"responseId\":\"r1\"},\"assistantMessageEvent\":{\"type\":\"text_delta\",\"contentIndex\":0,\"delta\":\"\\\":true}\"}}",
+		"echo {\"type\":\"message_end\",\"message\":{\"role\":\"assistant\",\"responseId\":\"r1\",\"content\":[{\"type\":\"text\",\"text\":\"{\\\"ok\\\":true}\"}],\"usage\":{\"input\":11,\"output\":7,\"cacheRead\":3,\"cacheWrite\":1}}}",
+		"echo {\"type\":\"agent_end\",\"messages\":[]}",
+	}, "\r\n"))
+
+	schema := json.RawMessage(`{"type":"object","properties":{"ok":{"type":"boolean"}},"required":["ok"]}`)
+	pa := &piAgent{bin: bin}
+
+	var chunks []string
+	result, err := pa.Run(context.Background(), RunOpts{
+		Prompt:     "review",
+		CWD:        t.TempDir(),
+		JSONSchema: schema,
+		OnChunk:    func(s string) { chunks = append(chunks, s) },
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result.Output) != `{"ok":true}` {
+		t.Fatalf("unexpected output: %s", string(result.Output))
+	}
+	if result.Usage.InputTokens != 11 || result.Usage.OutputTokens != 7 ||
+		result.Usage.CacheReadTokens != 3 || result.Usage.CacheCreationTokens != 1 {
+		t.Fatalf("unexpected usage: %+v", result.Usage)
+	}
+	if len(chunks) == 0 {
+		t.Fatal("expected onChunk to receive streaming text")
+	}
+	// OnChunk must receive the incremental deltas, not cumulative state.
+	// Otherwise the TUI log buffer (which appends each chunk) duplicates
+	// the running prefix.
+	wantChunks := []string{`{"ok`, `":true}`}
+	if len(chunks) != len(wantChunks) {
+		t.Fatalf("expected %d delta chunks, got %d: %v", len(wantChunks), len(chunks), chunks)
+	}
+	for i, want := range wantChunks {
+		if chunks[i] != want {
+			t.Errorf("chunk[%d] = %q, want %q", i, chunks[i], want)
+		}
+	}
+}
+
+func TestPiAgent_RunFallsBackToAgentEndMessages(t *testing.T) {
+	dir := t.TempDir()
+	bin := writeFakePi(t, dir, `#!/bin/sh
+cat > /dev/null
+printf '%s\n' '{"type":"agent_end","messages":[{"role":"user","content":"prompt"},{"role":"assistant","content":"{\"ok\":true}"}]}'
+`, strings.Join([]string{
+		"@echo off",
+		"more > nul",
+		"echo {\"type\":\"agent_end\",\"messages\":[{\"role\":\"user\",\"content\":\"prompt\"},{\"role\":\"assistant\",\"content\":\"{\\\"ok\\\":true}\"}]}",
+	}, "\r\n"))
+
+	schema := json.RawMessage(`{"type":"object","properties":{"ok":{"type":"boolean"}},"required":["ok"]}`)
+	pa := &piAgent{bin: bin}
+	result, err := pa.Run(context.Background(), RunOpts{
+		Prompt:     "review",
+		CWD:        t.TempDir(),
+		JSONSchema: schema,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result.Output) != `{"ok":true}` {
+		t.Fatalf("unexpected output: %s", string(result.Output))
+	}
+}
+
+func TestPiAgent_RunRejectsAssistantError(t *testing.T) {
+	dir := t.TempDir()
+	bin := writeFakePi(t, dir, `#!/bin/sh
+cat > /dev/null
+printf '%s\n' '{"type":"message_end","message":{"role":"assistant","stopReason":"error","errorMessage":"auth failed","content":[{"type":"text","text":"{\"ok\":true}"}]}}'
+`, strings.Join([]string{
+		"@echo off",
+		"more > nul",
+		"echo {\"type\":\"message_end\",\"message\":{\"role\":\"assistant\",\"stopReason\":\"error\",\"errorMessage\":\"auth failed\",\"content\":[{\"type\":\"text\",\"text\":\"{\\\"ok\\\":true}\"}]}}",
+	}, "\r\n"))
+
+	pa := &piAgent{bin: bin}
+	_, err := pa.Run(context.Background(), RunOpts{
+		Prompt:     "review",
+		CWD:        t.TempDir(),
+		JSONSchema: json.RawMessage(`{"type":"object"}`),
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "auth failed") {
+		t.Errorf("expected error to mention 'auth failed', got: %v", err)
+	}
+}
+
+func TestPiAgent_RunRejectsEmptyOutput(t *testing.T) {
+	dir := t.TempDir()
+	bin := writeFakePi(t, dir, `#!/bin/sh
+cat > /dev/null
+printf '%s\n' '{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"   "}]}}'
+`, strings.Join([]string{
+		"@echo off",
+		"more > nul",
+		"echo {\"type\":\"message_end\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"   \"}]}}",
+	}, "\r\n"))
+
+	pa := &piAgent{bin: bin}
+	_, err := pa.Run(context.Background(), RunOpts{
+		Prompt: "review",
+		CWD:    t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "no text output") {
+		t.Errorf("expected 'no text output', got: %v", err)
+	}
+}
+
+func TestPiAgent_RunSurfacesNonZeroExit(t *testing.T) {
+	dir := t.TempDir()
+	bin := writeFakePi(t, dir, `#!/bin/sh
+cat > /dev/null
+echo "boom" >&2
+exit 2
+`, strings.Join([]string{
+		"@echo off",
+		"more > nul",
+		"echo boom 1>&2",
+		"exit /b 2",
+	}, "\r\n"))
+
+	pa := &piAgent{bin: bin}
+	_, err := pa.Run(context.Background(), RunOpts{
+		Prompt: "review",
+		CWD:    t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("expected non-zero exit error")
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("expected stderr in error message, got: %v", err)
+	}
+}
+
+func TestPiAgent_RunCancelledByContext(t *testing.T) {
+	dir := t.TempDir()
+	bin := writeFakePi(t, dir, `#!/bin/sh
+cat > /dev/null
+sleep 30
+`, strings.Join([]string{
+		"@echo off",
+		"more > nul",
+		"timeout /t 30 /nobreak > nul",
+	}, "\r\n"))
+
+	pa := &piAgent{bin: bin}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := pa.Run(ctx, RunOpts{
+		Prompt: "review",
+		CWD:    t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), "context canceled") {
+		t.Logf("got error: %v", err)
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -96,6 +96,7 @@ func newDoctorCmd() *cobra.Command {
 					{"codex", "codex"},
 					{"rovodev", "acli"},
 					{"opencode", "opencode"},
+					{"pi", "pi"},
 				}
 				fmt.Fprintln(w)
 				fmt.Fprintf(w, "  %s\n", sCyan.Render("Agents"))

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -85,7 +85,7 @@ func TestDoctorAgentsSectionReportsFoundAndMissingBinaries(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, label := range []string{"Agents", "claude", "codex", "rovodev", "opencode"} {
+	for _, label := range []string{"Agents", "claude", "codex", "rovodev", "opencode", "pi"} {
 		if !strings.Contains(out, label) {
 			t.Fatalf("doctor output should include %q in agents section, got: %s", label, out)
 		}
@@ -93,7 +93,7 @@ func TestDoctorAgentsSectionReportsFoundAndMissingBinaries(t *testing.T) {
 	if !strings.Contains(out, claudePath) {
 		t.Fatalf("doctor output should report discovered claude path %q, got: %s", claudePath, out)
 	}
-	if got := strings.Count(out, "not found"); got < 3 {
+	if got := strings.Count(out, "not found"); got < 4 {
 		t.Fatalf("doctor output should report missing agent binaries, got %d not found markers in: %s", got, out)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,7 +91,7 @@ type Config struct {
 const defaultConfigYAML = `# no-mistakes global configuration
 
 # Agent to use for code generation
-# Options: auto, claude, codex, rovodev, opencode
+# Options: auto, claude, codex, rovodev, opencode, pi
 # "auto" detects the first available agent on your system
 agent: auto
 
@@ -129,6 +129,7 @@ var defaultBinary = map[types.AgentName]string{
 	types.AgentCodex:    "codex",
 	types.AgentRovoDev:  "acli",
 	types.AgentOpenCode: "opencode",
+	types.AgentPi:       "pi",
 }
 
 // agentProbeOrder is the priority order for auto-detecting agents.
@@ -137,6 +138,7 @@ var agentProbeOrder = []types.AgentName{
 	types.AgentCodex,
 	types.AgentOpenCode,
 	types.AgentRovoDev,
+	types.AgentPi,
 }
 
 var probeRovoDevSupport = func(ctx context.Context, bin string) (bool, error) {
@@ -237,6 +239,7 @@ var agentArgsOverrideAgents = map[string]bool{
 	string(types.AgentCodex):    true,
 	string(types.AgentRovoDev):  true,
 	string(types.AgentOpenCode): true,
+	string(types.AgentPi):       true,
 }
 
 // reservedAgentArgs lists flags that no-mistakes manages internally and that
@@ -266,6 +269,10 @@ var reservedAgentArgs = map[string]map[string]bool{
 		"--port":       true,
 		"--print-logs": true,
 	},
+	string(types.AgentPi): {
+		"--mode":       true,
+		"--no-session": true,
+	},
 }
 
 // validateAgentArgsOverride ensures each agent key is a known agent name and
@@ -274,7 +281,7 @@ var reservedAgentArgs = map[string]map[string]bool{
 func validateAgentArgsOverride(override map[string][]string) error {
 	for name, args := range override {
 		if !agentArgsOverrideAgents[name] {
-			return fmt.Errorf("invalid agent name in agent_args_override: %q (valid: claude, codex, rovodev, opencode)", name)
+			return fmt.Errorf("invalid agent name in agent_args_override: %q (valid: claude, codex, rovodev, opencode, pi)", name)
 		}
 		reserved := reservedAgentArgs[name]
 		for i, arg := range args {

--- a/internal/config/config_agent_test.go
+++ b/internal/config/config_agent_test.go
@@ -34,6 +34,7 @@ func TestAgentPath_DefaultBinaries(t *testing.T) {
 		{types.AgentCodex, "codex"},
 		{types.AgentRovoDev, "acli"},
 		{types.AgentOpenCode, "opencode"},
+		{types.AgentPi, "pi"},
 	}
 	for _, tt := range tests {
 		cfg := &Config{Agent: tt.agent}
@@ -172,7 +173,7 @@ func TestResolveAgent_AutoSkipsRovoDevWithoutSubcommand(t *testing.T) {
 
 	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
 		switch bin {
-		case "claude", "codex", "opencode":
+		case "claude", "codex", "opencode", "pi":
 			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
 		case "acli":
 			return "/usr/bin/acli", nil
@@ -204,7 +205,7 @@ func TestResolveAgent_AutoReturnsRovoDevProbeExitError(t *testing.T) {
 
 	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
 		switch bin {
-		case "claude", "codex", "opencode":
+		case "claude", "codex", "opencode", "pi":
 			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
 		case "acli":
 			return script, nil
@@ -305,7 +306,7 @@ func TestResolveAgent_AutoPassesContextToRovoDevProbe(t *testing.T) {
 
 	err := cfg.ResolveAgent(ctx, func(bin string) (string, error) {
 		switch bin {
-		case "claude", "codex", "opencode":
+		case "claude", "codex", "opencode", "pi":
 			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
 		case "acli":
 			return "/usr/bin/acli", nil

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -134,4 +134,5 @@ const (
 	AgentCodex    AgentName = "codex"
 	AgentRovoDev  AgentName = "rovodev"
 	AgentOpenCode AgentName = "opencode"
+	AgentPi       AgentName = "pi"
 )


### PR DESCRIPTION
## Summary

- Add Pi as a supported agent backend, including configuration, detection, doctor checks, and agent type wiring.
- Implement Pi JSONL subprocess handling with retry-safe error handling and accumulated usage totals.
- Update README, docs, and project guidance to document Pi support and current e2e coverage.

## Risk Assessment

⚠️ Medium: The change is a new external-agent integration with custom JSONL parsing, but the implementation is well-bounded and no material issues were found in the changed code.

## Testing

- Summary: Exercised the Pi agent wiring, related config and doctor changes, the full Go test suite, and e2e journeys; after clearing an inherited NM_DAEMON setup variable, all relevant tests passed.
- `go test ./internal/agent ./internal/config ./internal/cli ./internal/types`
- `go test ./...`
- `make e2e`
- `env -u NM_DAEMON make e2e`
- Outcome: ✅ passed across 1 run (10m20s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed</summary>

**Round 1** - found 2 warnings
- ⚠️ `internal/agent/pi.go:198` - assistantError is set on any error or aborted assistant message and is never cleared when Pi later succeeds after its built-in auto-retry, so a run can return an error even though the final assistant response succeeded.
- ⚠️ `internal/agent/pi.go:206` - Usage is overwritten for each assistant message, so multi-turn Pi runs only report the final turn&#39;s token usage instead of the total invocation usage.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/agent ./internal/config ./internal/cli ./internal/types`
- `go test ./...`
- `make e2e`
- `env -u NM_DAEMON make e2e`

</details>

<details>
<summary>🔧 **Document** - 9 issues found → auto-fixed (3)</summary>

**Round 1** - found 9 warnings
- ⚠️ `README.md:34` - The README&#39;s agent-agnostic feature list still names only claude, codex, rovodev, and opencode. Update it to include the new pi agent support.
- ⚠️ `docs/src/content/docs/start-here/introduction.md:71` - The introduction&#39;s supported agent list omits pi even though the code now accepts agent: pi and auto-detects the pi binary.
- ⚠️ `docs/src/content/docs/start-here/installation.md:50` - The installation prerequisites omit pi from the supported agent binaries. Add pi to the prerequisite list.
- ⚠️ `docs/src/content/docs/start-here/quick-start.md:27` - The quick start prerequisite list omits pi from the supported agent binaries. Add pi so first-run setup reflects the new agent.
- ⚠️ `docs/src/content/docs/guides/agents.md:28` - The agent guide is stale for Pi support: the supported agents table, auto-detection order, default binary table, path override example, per-agent implementation sections, and doctor output example all omit pi. Update these sections to document pi, its pi binary, its auto-detect order after rovodev, and its JSONL subprocess behavior.
- ⚠️ `docs/src/content/docs/guides/configuration.md:51` - The configuration guide&#39;s global config example and precedence notes omit pi from valid agent values, agent_path_override examples, and the auto-detection order. Update them to match the new config behavior.
- ⚠️ `docs/src/content/docs/reference/global-config.md:47` - The global config reference omits pi from agent values, auto-detection order, default binary names, accepted agent_args_override keys, reserved flags, and examples. Add pi and document its reserved --mode and --no-session flags.
- ⚠️ `docs/src/content/docs/reference/repo-config.md:40` - The repo config reference omits pi from valid repo-level agent values and the documented auto-detection order. Update both to include pi.
- ⚠️ `docs/src/content/docs/reference/cli.md:108` - The doctor command reference lists the checked agent binaries without pi, but doctor now checks the pi binary too. Update the list.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `AGENTS.md:55` - AGENTS.md&#39;s project layout still says internal/agent contains only Claude, Codex, Rovo Dev, and OpenCode integrations. Update it to include the new Pi integration; CLAUDE.md points to this same content.

**Round 3** (auto-fix) - found 1 warning
- ⚠️ `Makefile:55` - The e2e target comment says the suite runs for each supported agent backend, but the code now supports pi while the e2e suite still only covers claude, codex, and opencode. Update the comment to avoid overclaiming full supported-agent coverage, or document Pi&#39;s exclusion.

**Round 4** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
