### PR TITLE
feat(agent): add ACP target support via acpx

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ Safest local verification sequence after non-trivial changes:
 - `internal/cli`: cobra commands and CLI wiring
 - `internal/daemon`: background daemon and run management
 - `internal/pipeline` and `internal/pipeline/steps`: orchestration plus review/test/lint/push/PR/CI steps
-- `internal/agent`: Claude, Codex, Rovo Dev, OpenCode, and Pi integrations
+- `internal/agent`: Claude, Codex, Rovo Dev, OpenCode, Pi, and ACP/acpx integrations
 - `internal/git`, `internal/ipc`, `internal/config`, `internal/db`, `internal/paths`, `internal/types`: shared infrastructure
 - `internal/tui`: terminal UI
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 `no-mistakes` puts a local git proxy in front of your real remote. Push to `no-mistakes` instead of `origin`, and it spins up a disposable worktree, runs an AI-driven validation pipeline, forwards upstream only after every check passes, and opens a clean PR automatically.
 
 - **Non-blocking** - the pipeline runs in an isolated worktree without disrupting your work.
-- **Agent-agnostic** - `claude`, `codex`, `rovodev`, `opencode`, or `pi`.
+- **Agent-agnostic** - `claude`, `codex`, `rovodev`, `opencode`, `pi`, or `acp:<target>` via `acpx`.
 - **Human stays in charge** - auto-fix or review findings, your call.
 - **Clean PRs by default** - push, open PR, watch CI, and auto-fix failures in one shot.
 

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -30,6 +30,7 @@ commands are still the strongest way to make the gate predictable.
 | Rovo Dev | `acli` | Persistent HTTP server, SSE streaming |
 | OpenCode | `opencode` | Persistent HTTP server, SSE streaming |
 | Pi | `pi` | Subprocess per invocation, JSONL events |
+| ACP target | `acpx` | Optional user-installed ACP bridge |
 
 ## Setting the agent
 
@@ -48,6 +49,18 @@ agent: codex
 ```
 
 Repo config takes precedence over global config.
+
+### Optional ACP target
+
+If you install `acpx` separately, you can opt into any ACP target with the `acp:` prefix.
+
+```yaml
+# ~/.no-mistakes/config.yaml or .no-mistakes.yaml
+agent: acp:gemini
+```
+
+`agent: auto` only probes native agents.
+It does not auto-select ACP targets.
 
 ## Where agent choice matters most
 
@@ -79,6 +92,7 @@ The default binary names are:
 | `rovodev` | `acli` |
 | `opencode` | `opencode` |
 | `pi` | `pi` |
+| `acp:<target>` | `acpx` |
 
 When the daemon is running through a managed service, that `PATH` comes from your login shell environment on macOS and Linux plus common user, Homebrew, and system binary directories. On Windows it reuses the current process environment instead of reloading a login shell. If agent discovery still does not resolve the binary you expect, use an explicit `agent_path_override`.
 
@@ -91,6 +105,12 @@ agent_path_override:
   rovodev: /usr/local/bin/acli
   opencode: /usr/local/bin/opencode
   pi: /usr/local/bin/pi
+```
+
+For ACP targets, set `acpx_path` instead of `agent_path_override`:
+
+```yaml
+acpx_path: /Users/you/bin/acpx
 ```
 
 You can also set extra agent-specific CLI flags in global config with
@@ -137,6 +157,22 @@ Spawns a `pi` subprocess for each invocation with `--mode json --no-session`.
 Any `agent_args_override.pi` flags are inserted before no-mistakes' managed flags.
 Reads JSONL events from stdout and streams incremental text deltas to the TUI.
 When structured output is requested, no-mistakes injects the JSON schema into the prompt and validates the final text response.
+
+## ACP via acpx
+
+ACP support is optional and requires a separately installed `acpx` binary.
+Use `agent: acp:<target>` to run a target known to acpx, for example `agent: acp:gemini`.
+
+For custom ACP target commands, define a global override:
+
+```yaml
+agent: acp:local-gemini
+acp_registry_overrides:
+  local-gemini: node /opt/mock-acp-agent.mjs
+```
+
+no-mistakes invokes acpx with JSON output, approve-all permissions, denied non-interactive permission prompts, and the repo worktree as `--cwd`.
+Structured output is handled by appending the requested JSON schema to the prompt and validating the final assistant text.
 
 ## Checking agent availability
 

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -75,7 +75,7 @@ It does **not** change the pipeline order or the meaning of a passed gate.
 
 ## Binary resolution
 
-By default, `no-mistakes` resolves `agent: auto` by checking for supported agents on your `PATH` in this order:
+By default, `no-mistakes` resolves `agent: auto` by checking for supported native agents on your `PATH` in this order:
 
 1. `claude`
 2. `codex`
@@ -94,7 +94,7 @@ The default binary names are:
 | `pi` | `pi` |
 | `acp:<target>` | `acpx` |
 
-When the daemon is running through a managed service, that `PATH` comes from your login shell environment on macOS and Linux plus common user, Homebrew, and system binary directories. On Windows it reuses the current process environment instead of reloading a login shell. If agent discovery still does not resolve the binary you expect, use an explicit `agent_path_override`.
+When the daemon is running through a managed service, that `PATH` comes from your login shell environment on macOS and Linux plus common user, Homebrew, and system binary directories. On Windows it reuses the current process environment instead of reloading a login shell. If native agent discovery still does not resolve the binary you expect, use an explicit `agent_path_override`.
 
 Override paths in global config:
 

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -5,7 +5,7 @@ description: Supported AI agents, how to pick one, and how they integrate.
 
 `no-mistakes` is agent-agnostic by design. The gate should mean the same thing
 regardless of which agent you prefer. The default `agent: auto` setting picks
-the first supported agent available on your system.
+the first supported native agent available on your system.
 
 The agent is responsible for the parts of the gate that benefit from judgment:
 code review, test or lint detection when you have not configured explicit
@@ -113,7 +113,7 @@ For ACP targets, set `acpx_path` instead of `agent_path_override`:
 acpx_path: /Users/you/bin/acpx
 ```
 
-You can also set extra agent-specific CLI flags in global config with
+You can also set extra CLI flags for native agents in global config with
 `agent_args_override`. This is useful for things like model selection,
 reasoning level, or permission mode. Keep this in global config only, since it
 reflects your local agent setup rather than repo policy.

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -176,7 +176,7 @@ Structured output is handled by appending the requested JSON schema to the promp
 
 ## Checking agent availability
 
-Run `no-mistakes doctor` to see which agent binaries are installed and available:
+Run `no-mistakes doctor` to see which native agent binaries are installed and available:
 
 ```
 $ no-mistakes doctor
@@ -193,3 +193,6 @@ $ no-mistakes doctor
 ```
 
 `✓` = available, `–` = not found (optional), `✗` = problem detected.
+
+For `agent: acp:<target>`, make sure `acpx` is installed on `PATH` or set `acpx_path` in global config.
+`no-mistakes doctor` does not validate ACP targets.

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -48,9 +48,14 @@ Everything else can usually wait.
 
 # Default agent for all repos and setup-wizard suggestions.
 # "auto" picks the first available agent on PATH.
-agent: auto  # auto | claude | codex | rovodev | opencode | pi
+agent: auto  # auto | claude | codex | rovodev | opencode | pi | acp:<target>
 
-# Optional binary path overrides.
+# Optional acpx path and target command overrides for agent: acp:<target>.
+acpx_path: acpx
+acp_registry_overrides:
+  local-gemini: node /opt/mock-acp-agent.mjs
+
+# Optional native agent binary path overrides.
 agent_path_override:
   claude: /Users/you/bin/claude
   codex: /opt/homebrew/bin/codex
@@ -58,7 +63,7 @@ agent_path_override:
   opencode: /usr/local/bin/opencode
   pi: /usr/local/bin/pi
 
-# Optional extra CLI flags per agent.
+# Optional extra CLI flags per native agent.
 # This is global-only.
 agent_args_override:
   codex:
@@ -123,7 +128,8 @@ See [Repo Config Reference](/no-mistakes/reference/repo-config/) for the full fi
 
 - Repo `agent` overrides global `agent`.
 - Global `agent: auto` resolves by checking `claude`, `codex`, `opencode`, `acli` for `rovodev`, then `pi` on `PATH`.
-- `agent_path_override` and `agent_args_override` are global-only fields.
+- ACP agents are opt-in with `agent: acp:<target>` and are not considered by `agent: auto`.
+- `agent_path_override`, `agent_args_override`, `acpx_path`, and `acp_registry_overrides` are global-only fields.
 - `auto_fix` from the repo config overlays global auto_fix. Fields not set in the repo config fall through to the global default.
 - `commands` and `ignore_patterns` are repo-only fields.
 - `ci_timeout` and `auto_fix.ci` are the canonical keys; `babysit_timeout` and `auto_fix.babysit` are still accepted as legacy aliases.

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -4,7 +4,7 @@ description: Global and per-repo configuration options.
 ---
 
 Configuration is optional. Without any config files, `no-mistakes` defaults to
-`agent: auto`, which picks the first supported agent available on your system,
+`agent: auto`, which picks the first supported native agent available on your system,
 with sensible defaults for everything else.
 
 The goal is not to make you configure a mini CI system. The default path should
@@ -47,7 +47,7 @@ Everything else can usually wait.
 # ~/.no-mistakes/config.yaml
 
 # Default agent for all repos and setup-wizard suggestions.
-# "auto" picks the first available agent on PATH.
+# "auto" picks the first available native agent on PATH.
 agent: auto  # auto | claude | codex | rovodev | opencode | pi | acp:<target>
 
 # Optional acpx path and target command overrides for agent: acp:<target>.

--- a/docs/src/content/docs/guides/setup-wizard.md
+++ b/docs/src/content/docs/guides/setup-wizard.md
@@ -104,6 +104,9 @@ The wizard requires:
 
 - The gate to be initialized (`no-mistakes init` has run).
 - A clean enough state to commit and push.
-- A configured agent binary available on `PATH` (or via `agent_path_override`) only when the wizard needs to suggest a branch name or commit subject. If you already have a branch and clean working tree, or you enter those values yourself in the interactive flow, the wizard can continue without agent suggestions.
+- A configured native agent binary available on `PATH` (or via `agent_path_override`), or `acpx` available on `PATH` (or via `acpx_path`) for `agent: acp:<target>`, only when the wizard needs to suggest a branch name or commit subject.
+  If you already have a branch and clean working tree, or you enter those values yourself in the interactive flow, the wizard can continue without agent suggestions.
 
-If any of those are missing, the wizard reports the problem and exits. `no-mistakes doctor` is the fastest way to see what's available.
+If any of those are missing, the wizard reports the problem and exits.
+`no-mistakes doctor` is the fastest way to check native agent availability.
+For ACP targets, verify `acpx_path` yourself.

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -81,17 +81,23 @@ If the daemon executable path can't be determined at all (stale PID, permissions
 
 ## Agent binary not detected
 
-Symptom: `doctor` shows `–` for your agent, or the pipeline errors with "agent binary not found."
+Symptom: `doctor` shows `–` for your native agent, or the pipeline errors with "agent binary not found."
 
 ### Check PATH
 
 The daemon uses the same binary-discovery order described in [Choosing an Agent](/no-mistakes/guides/agents/). When it's running through a managed service, it reloads `PATH` from your login shell on macOS and Linux and appends common install locations such as `~/.local/bin`, `~/go/bin`, `~/.cargo/bin`, `~/bin`, `/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`, and `/bin`.
 
-If the agent is installed in a version-manager shim directory or another nonstandard location, set an explicit override in `~/.no-mistakes/config.yaml`:
+If a native agent is installed in a version-manager shim directory or another nonstandard location, set an explicit override in `~/.no-mistakes/config.yaml`:
 
 ```yaml
 agent_path_override:
   claude: /Users/you/.local/bin/claude
+```
+
+For `agent: acp:<target>`, set `acpx_path` instead:
+
+```yaml
+acpx_path: /Users/you/.local/bin/acpx
 ```
 
 The daemon logs its effective `PATH` at startup in `~/.no-mistakes/logs/daemon.log` with the message `daemon environment ready`.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -105,9 +105,11 @@ Checks:
 - Data directory (`~/.no-mistakes/`)
 - SQLite database
 - Daemon status
-- Agent binaries: `claude`, `codex`, `acli`, `opencode`, `pi`
+- Native agent binaries: `claude`, `codex`, `acli`, `opencode`, `pi`
 
 Uses indicators: `✓` (available), `–` (not found, optional), `✗` (problem detected).
+
+`doctor` does not validate `acpx` or ACP targets. For `agent: acp:<target>`, verify `acpx_path` yourself.
 
 `doctor` currently checks `gh` availability only. For GitLab PR and CI steps, install and authenticate `glab`. For Bitbucket Cloud PR and CI steps, set `NO_MISTAKES_BITBUCKET_EMAIL` and `NO_MISTAKES_BITBUCKET_API_TOKEN`.
 

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -86,14 +86,16 @@ acp_registry_overrides:
 
 ### agent_path_override
 
-Custom binary paths for each agent. When set, `no-mistakes` uses this path instead of looking up the binary on `PATH`.
+Custom binary paths for native agents.
+When set, `no-mistakes` uses this path instead of looking up the binary on `PATH`.
+ACP agents use `acpx_path` instead.
 
 | | |
 |---|---|
 | Type | `map[string]string` |
 | Default | Empty (uses default binary names) |
 
-Default binary names when no override is set:
+Default native binary names when no override is set:
 
 | Agent | Binary |
 |---|---|
@@ -105,7 +107,8 @@ Default binary names when no override is set:
 
 ### agent_args_override
 
-Extra CLI flags to pass to each agent. Use this to set model selection, reasoning effort, permission mode, or any other flag the underlying agent supports.
+Extra CLI flags to pass to each native agent.
+Use this to set model selection, reasoning effort, permission mode, or any other flag the underlying agent supports.
 
 | | |
 |---|---|

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -53,7 +53,7 @@ Default agent for all repos and setup-wizard suggestions. Can be overridden per-
 | Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `acp:<target>` |
 | Default | `auto` |
 
-`auto` resolves to the first supported agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, then `pi`.
+`auto` resolves to the first supported native agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, then `pi`.
 `acp:<target>` uses the user-installed `acpx` binary to run an ACP target, for example `acp:gemini`.
 ACP agents are opt-in and are not considered by `agent: auto`.
 

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -10,6 +10,11 @@ Global configuration lives at `~/.no-mistakes/config.yaml`. Set `NM_HOME` to rel
 
 agent: auto
 
+acpx_path: acpx
+
+acp_registry_overrides:
+  local-gemini: node /opt/mock-acp-agent.mjs
+
 agent_path_override:
   claude: /Users/you/bin/claude
   codex: /opt/homebrew/bin/codex
@@ -45,10 +50,39 @@ Default agent for all repos and setup-wizard suggestions. Can be overridden per-
 | | |
 |---|---|
 | Type | `string` |
-| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi` |
+| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `acp:<target>` |
 | Default | `auto` |
 
 `auto` resolves to the first supported agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, then `pi`.
+`acp:<target>` uses the user-installed `acpx` binary to run an ACP target, for example `acp:gemini`.
+ACP agents are opt-in and are not considered by `agent: auto`.
+
+### acpx_path
+
+Path to the user-installed `acpx` binary used for `agent: acp:<target>`.
+
+| | |
+|---|---|
+| Type | `string` |
+| Default | `acpx` |
+
+### acp_registry_overrides
+
+Map an ACP target name to a raw ACP agent command.
+When `agent: acp:<target>` matches an override key, no-mistakes runs `acpx --agent <command>` instead of `acpx <target>`.
+
+| | |
+|---|---|
+| Type | `map[string]string` |
+| Default | Empty |
+
+Example:
+
+```yaml
+agent: acp:local-gemini
+acp_registry_overrides:
+  local-gemini: node /opt/mock-acp-agent.mjs
+```
 
 ### agent_path_override
 

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -37,10 +37,12 @@ Override the default agent for this repo and its setup-wizard suggestions.
 | | |
 |---|---|
 | Type | `string` |
-| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi` |
+| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `acp:<target>` |
 | Default | Inherits from global config |
 
 `auto` resolves to the first supported agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, then `pi`.
+`acp:<target>` uses the user-installed `acpx` binary configured in global config.
+ACP agents are opt-in and are not considered by `agent: auto`.
 
 ### commands.test
 

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -40,7 +40,7 @@ Override the default agent for this repo and its setup-wizard suggestions.
 | Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `acp:<target>` |
 | Default | Inherits from global config |
 
-`auto` resolves to the first supported agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, then `pi`.
+`auto` resolves to the first supported native agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, then `pi`.
 `acp:<target>` uses the user-installed `acpx` binary configured in global config.
 ACP agents are opt-in and are not considered by `agent: auto`.
 

--- a/docs/src/content/docs/start-here/installation.md
+++ b/docs/src/content/docs/start-here/installation.md
@@ -53,7 +53,8 @@ make install
   - `glab` CLI (GitLab)
   - `NO_MISTAKES_BITBUCKET_EMAIL` and `NO_MISTAKES_BITBUCKET_API_TOKEN` (Bitbucket Cloud)
 
-Run `no-mistakes doctor` to check what's installed.
+Run `no-mistakes doctor` to check native agents and provider tools.
+For ACP agents, verify `acpx` or `acpx_path` separately because `doctor` does not validate ACP targets.
 
 See [Provider Integration](/no-mistakes/guides/provider-integration/) for PR and CI setup per host.
 

--- a/docs/src/content/docs/start-here/installation.md
+++ b/docs/src/content/docs/start-here/installation.md
@@ -47,7 +47,7 @@ make install
 ## Prerequisites
 
 - **git** - required
-- **One supported agent binary** - `claude`, `codex`, `acli` (Rovo Dev), `opencode`, or `pi`
+- **One supported agent binary** - `claude`, `codex`, `acli` (Rovo Dev), `opencode`, or `pi`, or a separately installed `acpx` binary for `agent: acp:<target>`
 - **Optional, for PRs and CI:**
   - `gh` CLI (GitHub)
   - `glab` CLI (GitLab)

--- a/docs/src/content/docs/start-here/introduction.md
+++ b/docs/src/content/docs/start-here/introduction.md
@@ -68,7 +68,7 @@ When a branch passes the gate, it means:
 ## What you get
 
 - A fixed, opinionated pipeline: `rebase → review → test → document → lint → push → pr → ci`. Order is not configurable; what each step runs is.
-- Choice of agent: `claude`, `codex`, `rovodev`, `opencode`, or `pi`, with per-repo override.
+- Choice of agent: `claude`, `codex`, `rovodev`, `opencode`, `pi`, or `acp:<target>` via `acpx`, with per-repo override.
 - A TUI to watch, approve, fix, skip, or abort any step.
 - A setup wizard when you run bare `no-mistakes` with no active run on the current branch - it walks you through creating a branch, committing, and pushing through the gate, then attaches if the daemon registers the new run.
 

--- a/docs/src/content/docs/start-here/quick-start.md
+++ b/docs/src/content/docs/start-here/quick-start.md
@@ -27,6 +27,8 @@ You need:
 - One supported agent binary (`claude`, `codex`, `acli` for Rovo Dev, `opencode`, or `pi`), or a separately installed `acpx` binary for `agent: acp:<target>`
 - For PRs and CI: `gh` (GitHub), `glab` (GitLab), or Bitbucket Cloud credentials
 
+For ACP agents, verify `acpx` or `acpx_path` separately because `no-mistakes doctor` does not validate ACP targets.
+
 See [Provider Integration](/no-mistakes/guides/provider-integration/) for PR/CI setup.
 
 ## 3. Initialize a repo

--- a/docs/src/content/docs/start-here/quick-start.md
+++ b/docs/src/content/docs/start-here/quick-start.md
@@ -24,7 +24,7 @@ no-mistakes doctor
 You need:
 
 - `git`
-- One supported agent binary (`claude`, `codex`, `acli` for Rovo Dev, `opencode`, or `pi`)
+- One supported agent binary (`claude`, `codex`, `acli` for Rovo Dev, `opencode`, or `pi`), or a separately installed `acpx` binary for `agent: acp:<target>`
 - For PRs and CI: `gh` (GitHub), `glab` (GitLab), or Bitbucket Cloud credentials
 
 See [Provider Integration](/no-mistakes/guides/provider-integration/) for PR/CI setup.

--- a/internal/agent/acpx.go
+++ b/internal/agent/acpx.go
@@ -1,0 +1,206 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+const acpxScannerMaxTokenSize = 256 * 1024 * 1024
+
+type acpxAgent struct {
+	bin        string
+	target     string
+	rawCommand string
+}
+
+func (a *acpxAgent) Name() string { return "acp:" + a.target }
+
+func (a *acpxAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
+	return runWithRetry(ctx, a.Name(), opts, claudeMaxRetries, classifyTransient, nil, func() (*Result, error) {
+		return a.runOnce(ctx, opts)
+	})
+}
+
+func (a *acpxAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
+	args := a.buildArgs(opts)
+	cmd := exec.CommandContext(ctx, a.bin, args...)
+	cmd.Dir = opts.CWD
+	cmd.Stdin = nil
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("acpx stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("acpx stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("acpx start: %w", err)
+	}
+
+	var stderrBuf []byte
+	var stderrWG sync.WaitGroup
+	stderrWG.Add(1)
+	go func() {
+		defer stderrWG.Done()
+		stderrBuf, _ = io.ReadAll(stderr)
+	}()
+
+	var usage TokenUsage
+	text, err := parseAcpxJSONEvents(ctx, stdout, opts.OnChunk, &usage)
+	stderrWG.Wait()
+	if err != nil {
+		_ = cmd.Wait()
+		return nil, fmt.Errorf("acpx parse events: %w", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		return nil, fmt.Errorf("acpx exited: %w: %s", err, strings.TrimSpace(string(stderrBuf)))
+	}
+	if usage.OutputTokens == 0 {
+		usage.OutputTokens = estimateAcpxTokens(len(text))
+	}
+	return finalizeTextResult(a.Name(), text, opts.JSONSchema, usage)
+}
+
+func (a *acpxAgent) Close() error { return nil }
+
+func (a *acpxAgent) buildArgs(opts RunOpts) []string {
+	prompt := opts.Prompt
+	if len(opts.JSONSchema) > 0 {
+		prompt = buildACPStructuredPrompt(prompt, opts.JSONSchema)
+	}
+
+	args := make([]string, 0, 12)
+	if a.rawCommand != "" {
+		args = append(args, "--agent", a.rawCommand)
+	}
+	if opts.CWD != "" {
+		args = append(args, "--cwd", opts.CWD)
+	}
+	args = append(args,
+		"--format", "json",
+		"--json-strict",
+		"--approve-all",
+		"--non-interactive-permissions", "deny",
+		"--suppress-reads",
+	)
+	if a.rawCommand == "" {
+		args = append(args, a.target)
+	}
+	args = append(args, prompt)
+	return args
+}
+
+func buildACPStructuredPrompt(prompt string, schema json.RawMessage) string {
+	return prompt + "\n\n## no-mistakes final output contract\n\n" +
+		"When the task is complete, your final assistant message must be a single JSON object that matches this JSON Schema. " +
+		"Return only the JSON object. Do not wrap it in Markdown fences. Do not include prose before or after the JSON.\n\n" +
+		string(schema)
+}
+
+type acpxJSONMessage struct {
+	Method string `json:"method"`
+	Params struct {
+		Update acpxSessionUpdate `json:"update"`
+	} `json:"params"`
+}
+
+type acpxSessionUpdate struct {
+	SessionUpdate string          `json:"sessionUpdate"`
+	Content       json.RawMessage `json:"content"`
+	Text          string          `json:"text"`
+	Used          int             `json:"used"`
+}
+
+func parseAcpxJSONEvents(ctx context.Context, r io.Reader, onChunk func(string), usage *TokenUsage) (string, error) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), acpxScannerMaxTokenSize)
+	var output strings.Builder
+
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		default:
+		}
+
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var msg acpxJSONMessage
+		if err := json.Unmarshal(line, &msg); err != nil {
+			continue
+		}
+		if msg.Method != "session/update" {
+			continue
+		}
+
+		update := msg.Params.Update
+		switch update.SessionUpdate {
+		case "usage_update":
+			if update.Used > usage.InputTokens {
+				usage.InputTokens = update.Used
+			}
+		case "agent_message_chunk":
+			text := acpxUpdateText(update)
+			if text == "" {
+				continue
+			}
+			output.WriteString(text)
+			if onChunk != nil {
+				onChunk(text)
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return output.String(), nil
+}
+
+func acpxUpdateText(update acpxSessionUpdate) string {
+	if update.Text != "" {
+		return update.Text
+	}
+	if len(update.Content) == 0 {
+		return ""
+	}
+	var content struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(update.Content, &content); err == nil && content.Text != "" {
+		return content.Text
+	}
+	var parts []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(update.Content, &parts); err != nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, part := range parts {
+		if part.Text != "" {
+			b.WriteString(part.Text)
+		}
+	}
+	return b.String()
+}
+
+func estimateAcpxTokens(charCount int) int {
+	if charCount <= 0 {
+		return 0
+	}
+	return (charCount + 3) / 4
+}

--- a/internal/agent/acpx.go
+++ b/internal/agent/acpx.go
@@ -155,8 +155,10 @@ type acpxUsageFields struct {
 	CacheCreationInputTokensCamel int `json:"cacheCreationInputTokens"`
 	CachedInputTokensCamel        int `json:"cachedInputTokens"`
 	CacheReadTokensCamel          int `json:"cacheReadTokens"`
+	CachedReadTokensCamel         int `json:"cachedReadTokens"`
 	CacheCreationTokensCamel      int `json:"cacheCreationTokens"`
 	CacheWriteTokensCamel         int `json:"cacheWriteTokens"`
+	CachedWriteTokensCamel        int `json:"cachedWriteTokens"`
 }
 
 func parseAcpxJSONEvents(ctx context.Context, r io.Reader, onChunk func(string), usage *TokenUsage) (string, string, error) {
@@ -236,6 +238,7 @@ func acpxUsageFieldsToTokenUsage(fields acpxUsageFields) TokenUsage {
 			fields.CacheReadInputTokensCamel,
 			fields.CachedInputTokensCamel,
 			fields.CacheReadTokensCamel,
+			fields.CachedReadTokensCamel,
 		),
 		CacheCreationTokens: acpxFirstPositive(
 			fields.CacheCreationInputTokens,
@@ -244,6 +247,7 @@ func acpxUsageFieldsToTokenUsage(fields acpxUsageFields) TokenUsage {
 			fields.CacheCreationInputTokensCamel,
 			fields.CacheCreationTokensCamel,
 			fields.CacheWriteTokensCamel,
+			fields.CachedWriteTokensCamel,
 		),
 	}
 }

--- a/internal/agent/acpx.go
+++ b/internal/agent/acpx.go
@@ -120,6 +120,9 @@ func buildACPStructuredPrompt(prompt string, schema json.RawMessage) string {
 type acpxJSONMessage struct {
 	Method string         `json:"method"`
 	Error  *acpxJSONError `json:"error"`
+	Result struct {
+		Usage acpxUsageFields `json:"usage"`
+	} `json:"result"`
 	Params struct {
 		Update acpxSessionUpdate `json:"update"`
 	} `json:"params"`
@@ -186,6 +189,7 @@ func parseAcpxJSONEvents(ctx context.Context, r io.Reader, onChunk func(string),
 		if msg.Error != nil && msg.Error.Message != "" && stdoutErr == "" {
 			stdoutErr = msg.Error.Message
 		}
+		*usage = acpxMaxUsage(*usage, acpxUsageFieldsToTokenUsage(msg.Result.Usage))
 		if msg.Method != "session/update" {
 			continue
 		}

--- a/internal/agent/acpx.go
+++ b/internal/agent/acpx.go
@@ -55,14 +55,14 @@ func (a *acpxAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) 
 	}()
 
 	var usage TokenUsage
-	text, err := parseAcpxJSONEvents(ctx, stdout, opts.OnChunk, &usage)
+	text, stdoutErr, err := parseAcpxJSONEvents(ctx, stdout, opts.OnChunk, &usage)
 	stderrWG.Wait()
 	if err != nil {
 		_ = cmd.Wait()
 		return nil, fmt.Errorf("acpx parse events: %w", err)
 	}
 	if err := cmd.Wait(); err != nil {
-		return nil, fmt.Errorf("acpx exited: %w: %s", err, strings.TrimSpace(string(stderrBuf)))
+		return nil, fmt.Errorf("acpx exited: %w: %s", err, acpxProcessErrorOutput(stderrBuf, stdoutErr))
 	}
 	if usage.OutputTokens == 0 {
 		usage.OutputTokens = estimateAcpxTokens(len(text))
@@ -95,8 +95,19 @@ func (a *acpxAgent) buildArgs(opts RunOpts) []string {
 	if a.rawCommand == "" {
 		args = append(args, a.target)
 	}
-	args = append(args, prompt)
+	args = append(args, "exec", prompt)
 	return args
+}
+
+func acpxProcessErrorOutput(stderr []byte, stdoutErr string) string {
+	parts := make([]string, 0, 2)
+	if stderrText := strings.TrimSpace(string(stderr)); stderrText != "" {
+		parts = append(parts, stderrText)
+	}
+	if stdoutErr != "" {
+		parts = append(parts, stdoutErr)
+	}
+	return strings.Join(parts, "\n")
 }
 
 func buildACPStructuredPrompt(prompt string, schema json.RawMessage) string {
@@ -107,10 +118,15 @@ func buildACPStructuredPrompt(prompt string, schema json.RawMessage) string {
 }
 
 type acpxJSONMessage struct {
-	Method string `json:"method"`
+	Method string         `json:"method"`
+	Error  *acpxJSONError `json:"error"`
 	Params struct {
 		Update acpxSessionUpdate `json:"update"`
 	} `json:"params"`
+}
+
+type acpxJSONError struct {
+	Message string `json:"message"`
 }
 
 type acpxSessionUpdate struct {
@@ -120,15 +136,16 @@ type acpxSessionUpdate struct {
 	Used          int             `json:"used"`
 }
 
-func parseAcpxJSONEvents(ctx context.Context, r io.Reader, onChunk func(string), usage *TokenUsage) (string, error) {
+func parseAcpxJSONEvents(ctx context.Context, r io.Reader, onChunk func(string), usage *TokenUsage) (string, string, error) {
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 64*1024), acpxScannerMaxTokenSize)
 	var output strings.Builder
+	var stdoutErr string
 
 	for scanner.Scan() {
 		select {
 		case <-ctx.Done():
-			return "", ctx.Err()
+			return "", stdoutErr, ctx.Err()
 		default:
 		}
 
@@ -140,6 +157,9 @@ func parseAcpxJSONEvents(ctx context.Context, r io.Reader, onChunk func(string),
 		var msg acpxJSONMessage
 		if err := json.Unmarshal(line, &msg); err != nil {
 			continue
+		}
+		if msg.Error != nil && msg.Error.Message != "" && stdoutErr == "" {
+			stdoutErr = msg.Error.Message
 		}
 		if msg.Method != "session/update" {
 			continue
@@ -163,9 +183,9 @@ func parseAcpxJSONEvents(ctx context.Context, r io.Reader, onChunk func(string),
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return "", err
+		return "", stdoutErr, err
 	}
-	return output.String(), nil
+	return output.String(), stdoutErr, nil
 }
 
 func acpxUpdateText(update acpxSessionUpdate) string {

--- a/internal/agent/acpx.go
+++ b/internal/agent/acpx.go
@@ -134,6 +134,29 @@ type acpxSessionUpdate struct {
 	Content       json.RawMessage `json:"content"`
 	Text          string          `json:"text"`
 	Used          int             `json:"used"`
+	acpxUsageFields
+	Meta struct {
+		Usage acpxUsageFields `json:"usage"`
+	} `json:"_meta"`
+}
+
+type acpxUsageFields struct {
+	InputTokens                   int `json:"input_tokens"`
+	OutputTokens                  int `json:"output_tokens"`
+	CacheReadInputTokens          int `json:"cache_read_input_tokens"`
+	CacheReadTokens               int `json:"cache_read_tokens"`
+	CacheCreationInputTokens      int `json:"cache_creation_input_tokens"`
+	CacheWriteInputTokens         int `json:"cache_write_input_tokens"`
+	CacheWriteTokens              int `json:"cache_write_tokens"`
+	CachedInputTokens             int `json:"cached_input_tokens"`
+	InputTokensCamel              int `json:"inputTokens"`
+	OutputTokensCamel             int `json:"outputTokens"`
+	CacheReadInputTokensCamel     int `json:"cacheReadInputTokens"`
+	CacheCreationInputTokensCamel int `json:"cacheCreationInputTokens"`
+	CachedInputTokensCamel        int `json:"cachedInputTokens"`
+	CacheReadTokensCamel          int `json:"cacheReadTokens"`
+	CacheCreationTokensCamel      int `json:"cacheCreationTokens"`
+	CacheWriteTokensCamel         int `json:"cacheWriteTokens"`
 }
 
 func parseAcpxJSONEvents(ctx context.Context, r io.Reader, onChunk func(string), usage *TokenUsage) (string, string, error) {
@@ -168,9 +191,7 @@ func parseAcpxJSONEvents(ctx context.Context, r io.Reader, onChunk func(string),
 		update := msg.Params.Update
 		switch update.SessionUpdate {
 		case "usage_update":
-			if update.Used > usage.InputTokens {
-				usage.InputTokens = update.Used
-			}
+			*usage = acpxMaxUsage(*usage, acpxUpdateUsage(update))
 		case "agent_message_chunk":
 			text := acpxUpdateText(update)
 			if text == "" {
@@ -186,6 +207,63 @@ func parseAcpxJSONEvents(ctx context.Context, r io.Reader, onChunk func(string),
 		return "", stdoutErr, err
 	}
 	return output.String(), stdoutErr, nil
+}
+
+func acpxUpdateUsage(update acpxSessionUpdate) TokenUsage {
+	usage := acpxUsageFieldsToTokenUsage(update.acpxUsageFields)
+	metaUsage := acpxUsageFieldsToTokenUsage(update.Meta.Usage)
+	usage = acpxMaxUsage(usage, metaUsage)
+	if update.Used > usage.InputTokens {
+		usage.InputTokens = update.Used
+	}
+	return usage
+}
+
+func acpxUsageFieldsToTokenUsage(fields acpxUsageFields) TokenUsage {
+	return TokenUsage{
+		InputTokens: acpxFirstPositive(
+			fields.InputTokens,
+			fields.InputTokensCamel,
+		),
+		OutputTokens: acpxFirstPositive(
+			fields.OutputTokens,
+			fields.OutputTokensCamel,
+		),
+		CacheReadTokens: acpxFirstPositive(
+			fields.CacheReadInputTokens,
+			fields.CacheReadTokens,
+			fields.CachedInputTokens,
+			fields.CacheReadInputTokensCamel,
+			fields.CachedInputTokensCamel,
+			fields.CacheReadTokensCamel,
+		),
+		CacheCreationTokens: acpxFirstPositive(
+			fields.CacheCreationInputTokens,
+			fields.CacheWriteInputTokens,
+			fields.CacheWriteTokens,
+			fields.CacheCreationInputTokensCamel,
+			fields.CacheCreationTokensCamel,
+			fields.CacheWriteTokensCamel,
+		),
+	}
+}
+
+func acpxMaxUsage(a, b TokenUsage) TokenUsage {
+	return TokenUsage{
+		InputTokens:         max(a.InputTokens, b.InputTokens),
+		OutputTokens:        max(a.OutputTokens, b.OutputTokens),
+		CacheReadTokens:     max(a.CacheReadTokens, b.CacheReadTokens),
+		CacheCreationTokens: max(a.CacheCreationTokens, b.CacheCreationTokens),
+	}
+}
+
+func acpxFirstPositive(values ...int) int {
+	for _, value := range values {
+		if value > 0 {
+			return value
+		}
+	}
+	return 0
 }
 
 func acpxUpdateText(update acpxSessionUpdate) string {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -48,6 +48,7 @@ type TokenUsage struct {
 }
 
 // Options configures backend-specific agent construction behavior.
+// ACPRegistryOverrides maps acpx target names to raw ACP agent commands.
 type Options struct {
 	ACPRegistryOverrides map[string]string
 }
@@ -561,9 +562,10 @@ func (u *TokenUsage) Add(other TokenUsage) {
 	u.CacheCreationTokens += other.CacheCreationTokens
 }
 
-// New creates an agent by name with the given binary path. extraArgs are user
-// CLI flags (from agent_args_override in the global config) that the agent
-// injects into the underlying tool's argv ahead of no-mistakes' managed flags.
+// New creates an agent by name with the given binary path.
+// For native agents, extraArgs are user CLI flags from agent_args_override that
+// are injected into the underlying tool's argv ahead of no-mistakes' managed flags.
+// ACP agents ignore extraArgs; use NewWithOptions to provide registry overrides.
 func New(name types.AgentName, bin string, extraArgs []string) (Agent, error) {
 	return NewWithOptions(name, bin, extraArgs, Options{})
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -47,6 +47,11 @@ type TokenUsage struct {
 	CacheCreationTokens int
 }
 
+// Options configures backend-specific agent construction behavior.
+type Options struct {
+	ACPRegistryOverrides map[string]string
+}
+
 func finalizeTextResult(agentName, text string, schema json.RawMessage, usage TokenUsage) (*Result, error) {
 	if text == "" {
 		return nil, fmt.Errorf("%s returned no text output", agentName)
@@ -560,6 +565,18 @@ func (u *TokenUsage) Add(other TokenUsage) {
 // CLI flags (from agent_args_override in the global config) that the agent
 // injects into the underlying tool's argv ahead of no-mistakes' managed flags.
 func New(name types.AgentName, bin string, extraArgs []string) (Agent, error) {
+	return NewWithOptions(name, bin, extraArgs, Options{})
+}
+
+// NewWithOptions creates an agent by name with additional backend-specific options.
+func NewWithOptions(name types.AgentName, bin string, extraArgs []string, opts Options) (Agent, error) {
+	if target, ok := acpTarget(name); ok {
+		rawCommand := ""
+		if opts.ACPRegistryOverrides != nil {
+			rawCommand = opts.ACPRegistryOverrides[target]
+		}
+		return &acpxAgent{bin: bin, target: target, rawCommand: rawCommand}, nil
+	}
 	switch name {
 	case types.AgentClaude:
 		return &claudeAgent{bin: bin, extraArgs: extraArgs}, nil
@@ -572,8 +589,20 @@ func New(name types.AgentName, bin string, extraArgs []string) (Agent, error) {
 	case types.AgentPi:
 		return &piAgent{bin: bin, extraArgs: extraArgs}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi (set 'agent' in ~/.no-mistakes/config.yaml)", name)
+		return nil, fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
 	}
+}
+
+func acpTarget(name types.AgentName) (string, bool) {
+	value := string(name)
+	if !strings.HasPrefix(value, "acp:") {
+		return "", false
+	}
+	target := strings.TrimPrefix(value, "acp:")
+	if target == "" || strings.ContainsAny(target, " \t\r\n") {
+		return "", false
+	}
+	return target, true
 }
 
 // NewNoop returns an agent that does nothing. Used for demo mode where

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1,7 +1,11 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -32,6 +36,93 @@ func TestNew_KnownAgents(t *testing.T) {
 				t.Errorf("expected name %q, got %q", tt.wantName, a.Name())
 			}
 		})
+	}
+}
+
+func TestNew_ACPAgent(t *testing.T) {
+	a, err := New("acp:gemini", "acpx", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a.Name() != "acp:gemini" {
+		t.Errorf("name = %q, want acp:gemini", a.Name())
+	}
+}
+
+func TestNewWithOptions_ACPRegistryOverride(t *testing.T) {
+	a, err := NewWithOptions("acp:local-gemini", "acpx", nil, Options{
+		ACPRegistryOverrides: map[string]string{"local-gemini": "node /tmp/mock-acp.mjs"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	acpx, ok := a.(*acpxAgent)
+	if !ok {
+		t.Fatalf("agent type = %T, want *acpxAgent", a)
+	}
+	args := acpx.buildArgs(RunOpts{Prompt: "do work", CWD: "/repo"})
+	joined := strings.Join(args, "\x00")
+	if !strings.Contains(joined, "--agent\x00node /tmp/mock-acp.mjs") {
+		t.Fatalf("args = %q, want raw --agent override", args)
+	}
+	if strings.Contains(joined, "\x00local-gemini\x00") {
+		t.Fatalf("args = %q, should not include target subcommand when override is used", args)
+	}
+}
+
+func TestACPAgentRunParsesAcpxJSONOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-only")
+	}
+	dir := t.TempDir()
+	script := filepath.Join(dir, "acpx")
+	argLog := filepath.Join(dir, "args.txt")
+	t.Setenv("ARG_LOG", argLog)
+	contents := `#!/bin/sh
+printf '%s\n' "$@" > "$ARG_LOG"
+printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"usage_update","used":123,"size":1000}}}'
+printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"{\"done\":true}"}}}}'
+`
+	if err := os.WriteFile(script, []byte(contents), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	a, err := New("acp:gemini", script, nil)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	var chunks []string
+	result, err := a.Run(context.Background(), RunOpts{
+		Prompt:     "do work",
+		CWD:        dir,
+		JSONSchema: json.RawMessage(`{"type":"object"}`),
+		OnChunk:    func(text string) { chunks = append(chunks, text) },
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	var output map[string]bool
+	if err := json.Unmarshal(result.Output, &output); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if !output["done"] {
+		t.Fatalf("output = %s, want done true", string(result.Output))
+	}
+	if result.Usage.InputTokens != 123 {
+		t.Errorf("input tokens = %d, want 123", result.Usage.InputTokens)
+	}
+	if len(chunks) != 1 || chunks[0] != `{"done":true}` {
+		t.Errorf("chunks = %q", chunks)
+	}
+	argsData, err := os.ReadFile(argLog)
+	if err != nil {
+		t.Fatalf("read args: %v", err)
+	}
+	argsText := string(argsData)
+	for _, want := range []string{"--cwd\n" + dir, "--format\njson", "--json-strict", "gemini", "do work"} {
+		if !strings.Contains(argsText, want) {
+			t.Errorf("args missing %q in:\n%s", want, argsText)
+		}
 	}
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -143,6 +143,20 @@ func TestParseAcpxJSONEventsParsesCacheWriteUsageFields(t *testing.T) {
 	}
 }
 
+func TestParseAcpxJSONEventsParsesNormalizedCachedUsageFields(t *testing.T) {
+	events := `{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"usage_update","inputTokens":5,"outputTokens":3,"cachedReadTokens":11,"cachedWriteTokens":13}}}` + "\n"
+	var usage TokenUsage
+
+	_, _, err := parseAcpxJSONEvents(context.Background(), strings.NewReader(events), nil, &usage)
+	if err != nil {
+		t.Fatalf("parseAcpxJSONEvents() error = %v", err)
+	}
+	want := TokenUsage{InputTokens: 5, OutputTokens: 3, CacheReadTokens: 11, CacheCreationTokens: 13}
+	if usage != want {
+		t.Fatalf("usage = %+v, want %+v", usage, want)
+	}
+}
+
 func TestACPAgentRunParsesAcpxJSONOutput(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell fixture is Unix-only")

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -106,6 +106,43 @@ exit 1
 	}
 }
 
+func TestParseAcpxJSONEventsParsesUsageFields(t *testing.T) {
+	events := strings.Join([]string{
+		`{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"usage_update","input_tokens":100,"output_tokens":50,"cache_read_input_tokens":30,"cache_creation_input_tokens":10}}}`,
+		`{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"usage_update","_meta":{"usage":{"inputTokens":120,"outputTokens":60,"cacheReadInputTokens":40,"cacheCreationInputTokens":15}}}}}`,
+		`{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"done"}}}}`,
+	}, "\n") + "\n"
+	var usage TokenUsage
+
+	text, stdoutErr, err := parseAcpxJSONEvents(context.Background(), strings.NewReader(events), nil, &usage)
+	if err != nil {
+		t.Fatalf("parseAcpxJSONEvents() error = %v", err)
+	}
+	if stdoutErr != "" {
+		t.Fatalf("stdout error = %q, want empty", stdoutErr)
+	}
+	if text != "done" {
+		t.Fatalf("text = %q, want done", text)
+	}
+	want := TokenUsage{InputTokens: 120, OutputTokens: 60, CacheReadTokens: 40, CacheCreationTokens: 15}
+	if usage != want {
+		t.Fatalf("usage = %+v, want %+v", usage, want)
+	}
+}
+
+func TestParseAcpxJSONEventsParsesCacheWriteUsageFields(t *testing.T) {
+	events := `{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"usage_update","input_tokens":5,"output_tokens":3,"cache_write_tokens":7}}}` + "\n"
+	var usage TokenUsage
+
+	_, _, err := parseAcpxJSONEvents(context.Background(), strings.NewReader(events), nil, &usage)
+	if err != nil {
+		t.Fatalf("parseAcpxJSONEvents() error = %v", err)
+	}
+	if usage.CacheCreationTokens != 7 {
+		t.Fatalf("cache creation tokens = %d, want 7", usage.CacheCreationTokens)
+	}
+}
+
 func TestACPAgentRunParsesAcpxJSONOutput(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell fixture is Unix-only")

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -70,6 +70,42 @@ func TestNewWithOptions_ACPRegistryOverride(t *testing.T) {
 	}
 }
 
+func TestACPAgentBuildArgsUsesExecMode(t *testing.T) {
+	a := &acpxAgent{target: "gemini"}
+	args := a.buildArgs(RunOpts{Prompt: "do work"})
+
+	if got, want := args[len(args)-3:], []string{"gemini", "exec", "do work"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("trailing args = %q, want %q", got, want)
+	}
+}
+
+func TestACPAgentRunReportsJSONRPCErrorMessage(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-only")
+	}
+	dir := t.TempDir()
+	script := filepath.Join(dir, "acpx")
+	contents := `#!/bin/sh
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"not authenticated"}}'
+exit 1
+`
+	if err := os.WriteFile(script, []byte(contents), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	a, err := New("acp:gemini", script, nil)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	_, err = a.Run(context.Background(), RunOpts{Prompt: "do work", CWD: dir})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "not authenticated") {
+		t.Fatalf("error = %v, want JSON-RPC error message", err)
+	}
+}
+
 func TestACPAgentRunParsesAcpxJSONOutput(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell fixture is Unix-only")

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -157,6 +157,20 @@ func TestParseAcpxJSONEventsParsesNormalizedCachedUsageFields(t *testing.T) {
 	}
 }
 
+func TestParseAcpxJSONEventsParsesResultUsage(t *testing.T) {
+	events := `{"jsonrpc":"2.0","id":1,"result":{"usage":{"input_tokens":21,"output_tokens":8,"cachedReadTokens":5,"cachedWriteTokens":2}}}` + "\n"
+	var usage TokenUsage
+
+	_, _, err := parseAcpxJSONEvents(context.Background(), strings.NewReader(events), nil, &usage)
+	if err != nil {
+		t.Fatalf("parseAcpxJSONEvents() error = %v", err)
+	}
+	want := TokenUsage{InputTokens: 21, OutputTokens: 8, CacheReadTokens: 5, CacheCreationTokens: 2}
+	if usage != want {
+		t.Fatalf("usage = %+v, want %+v", usage, want)
+	}
+}
+
 func TestACPAgentRunParsesAcpxJSONOutput(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell fixture is Unix-only")

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -30,7 +30,7 @@ var resolveWizardAgent = func(ctx context.Context, cfg *config.Config) error {
 // alt screen and the handoff to the attach TUI is seamless.
 type waitForRunFunc func(ctx context.Context, branch string) error
 
-var newWizardAgent = agent.New
+var newWizardAgent = agent.NewWithOptions
 var wizardRun = wizard.Run
 var wizardRunAuto = wizard.RunAuto
 var runWizardAutoVisible = func(ctx context.Context, p *paths.Paths, state *repoState, wait waitForRunFunc) (wizard.Result, error) {
@@ -44,7 +44,7 @@ type wizardAgentSuggester struct {
 	cfg     *config.Config
 	workDir string
 	resolve func(context.Context, *config.Config) error
-	new     func(types.AgentName, string, []string) (agent.Agent, error)
+	new     func(types.AgentName, string, []string, agent.Options) (agent.Agent, error)
 
 	once sync.Once
 	ag   agent.Agent
@@ -57,7 +57,7 @@ type wizardAgentSuggester struct {
 	cachedCommit string
 }
 
-func newWizardAgentSuggester(cfg *config.Config, workDir string, resolve func(context.Context, *config.Config) error, new func(types.AgentName, string, []string) (agent.Agent, error)) *wizardAgentSuggester {
+func newWizardAgentSuggester(cfg *config.Config, workDir string, resolve func(context.Context, *config.Config) error, new func(types.AgentName, string, []string, agent.Options) (agent.Agent, error)) *wizardAgentSuggester {
 	if resolve == nil {
 		resolve = resolveWizardAgent
 	}
@@ -73,7 +73,9 @@ func (s *wizardAgentSuggester) ensure(ctx context.Context) error {
 			s.err = fmt.Errorf("resolve agent: %w", err)
 			return
 		}
-		ag, err := s.new(s.cfg.Agent, s.cfg.AgentPath(), s.cfg.AgentArgs())
+		ag, err := s.new(s.cfg.Agent, s.cfg.AgentPath(), s.cfg.AgentArgs(), agent.Options{
+			ACPRegistryOverrides: s.cfg.ACPRegistryOverrides,
+		})
 		if err != nil {
 			s.err = fmt.Errorf("create agent: %w", err)
 			return

--- a/internal/cli/wizard_test.go
+++ b/internal/cli/wizard_test.go
@@ -116,6 +116,7 @@ func TestWizardAgentSuggester_ForwardsAgentArgsOverride(t *testing.T) {
 		gotName types.AgentName
 		gotBin  string
 		gotArgs []string
+		gotOpts agent.Options
 	)
 	suggester := newWizardAgentSuggester(
 		&config.Config{
@@ -126,10 +127,11 @@ func TestWizardAgentSuggester_ForwardsAgentArgsOverride(t *testing.T) {
 		},
 		"/tmp/repo",
 		func(context.Context, *config.Config) error { return nil },
-		func(name types.AgentName, bin string, args []string) (agent.Agent, error) {
+		func(name types.AgentName, bin string, args []string, opts agent.Options) (agent.Agent, error) {
 			gotName = name
 			gotBin = bin
 			gotArgs = append([]string(nil), args...)
+			gotOpts = opts
 			return &fakeSuggesterAgent{}, nil
 		},
 	)
@@ -146,6 +148,33 @@ func TestWizardAgentSuggester_ForwardsAgentArgsOverride(t *testing.T) {
 	}
 	if want := []string{"--permission-mode", "acceptEdits"}; !reflect.DeepEqual(gotArgs, want) {
 		t.Fatalf("new agent args = %v, want %v", gotArgs, want)
+	}
+	if gotOpts.ACPRegistryOverrides != nil {
+		t.Fatalf("new agent options = %+v, want zero options", gotOpts)
+	}
+}
+
+func TestWizardAgentSuggester_ForwardsACPRegistryOverrides(t *testing.T) {
+	var gotOpts agent.Options
+	suggester := newWizardAgentSuggester(
+		&config.Config{
+			Agent:                "acp:local-gemini",
+			ACPRegistryOverrides: map[string]string{"local-gemini": "node /tmp/mock-acp.mjs"},
+		},
+		"/tmp/repo",
+		func(context.Context, *config.Config) error { return nil },
+		func(_ types.AgentName, _ string, _ []string, opts agent.Options) (agent.Agent, error) {
+			gotOpts = opts
+			return &fakeSuggesterAgent{}, nil
+		},
+	)
+	defer suggester.Close()
+
+	if err := suggester.ensure(context.Background()); err != nil {
+		t.Fatalf("ensure failed: %v", err)
+	}
+	if got := gotOpts.ACPRegistryOverrides["local-gemini"]; got != "node /tmp/mock-acp.mjs" {
+		t.Fatalf("ACPRegistryOverrides[local-gemini] = %q", got)
 	}
 }
 
@@ -220,7 +249,7 @@ func newFakeSuggester(t *testing.T, ag *fakeSuggesterAgent) *wizardAgentSuggeste
 		&config.Config{Agent: types.AgentClaude},
 		"/tmp/repo",
 		func(context.Context, *config.Config) error { return nil },
-		func(types.AgentName, string, []string) (agent.Agent, error) { return ag, nil },
+		func(types.AgentName, string, []string, agent.Options) (agent.Agent, error) { return ag, nil },
 	)
 }
 
@@ -341,7 +370,7 @@ func TestWizardAgentSuggester_EmptyRetryClearsCachedCommit(t *testing.T) {
 		&config.Config{Agent: types.AgentClaude},
 		"/tmp/repo",
 		func(context.Context, *config.Config) error { return nil },
-		func(types.AgentName, string, []string) (agent.Agent, error) { return ag, nil },
+		func(types.AgentName, string, []string, agent.Options) (agent.Agent, error) { return ag, nil },
 	)
 	defer s.Close()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,23 +18,27 @@ import (
 
 // GlobalConfig represents ~/.no-mistakes/config.yaml.
 type GlobalConfig struct {
-	Agent             types.AgentName     `yaml:"agent"`
-	AgentPathOverride map[string]string   `yaml:"agent_path_override"`
-	AgentArgsOverride map[string][]string `yaml:"agent_args_override"`
-	CITimeout         time.Duration       `yaml:"-"`
-	LogLevel          string              `yaml:"log_level"`
-	AutoFix           AutoFixRaw
+	Agent                types.AgentName     `yaml:"agent"`
+	ACPXPath             string              `yaml:"acpx_path"`
+	ACPRegistryOverrides map[string]string   `yaml:"acp_registry_overrides"`
+	AgentPathOverride    map[string]string   `yaml:"agent_path_override"`
+	AgentArgsOverride    map[string][]string `yaml:"agent_args_override"`
+	CITimeout            time.Duration       `yaml:"-"`
+	LogLevel             string              `yaml:"log_level"`
+	AutoFix              AutoFixRaw
 }
 
 // globalConfigRaw is the on-disk YAML representation with duration as string.
 type globalConfigRaw struct {
-	Agent             types.AgentName     `yaml:"agent"`
-	AgentPathOverride map[string]string   `yaml:"agent_path_override"`
-	AgentArgsOverride map[string][]string `yaml:"agent_args_override"`
-	CITimeout         string              `yaml:"ci_timeout"`
-	BabysitTimeout    string              `yaml:"babysit_timeout"`
-	LogLevel          string              `yaml:"log_level"`
-	AutoFix           AutoFixRaw          `yaml:"auto_fix"`
+	Agent                types.AgentName     `yaml:"agent"`
+	ACPXPath             string              `yaml:"acpx_path"`
+	ACPRegistryOverrides map[string]string   `yaml:"acp_registry_overrides"`
+	AgentPathOverride    map[string]string   `yaml:"agent_path_override"`
+	AgentArgsOverride    map[string][]string `yaml:"agent_args_override"`
+	CITimeout            string              `yaml:"ci_timeout"`
+	BabysitTimeout       string              `yaml:"babysit_timeout"`
+	LogLevel             string              `yaml:"log_level"`
+	AutoFix              AutoFixRaw          `yaml:"auto_fix"`
 }
 
 // RepoConfig represents .no-mistakes.yaml in a repo root.
@@ -77,23 +81,33 @@ type AutoFix struct {
 
 // Config is the merged result of global + per-repo configuration.
 type Config struct {
-	Agent             types.AgentName
-	AgentPathOverride map[string]string
-	AgentArgsOverride map[string][]string
-	CITimeout         time.Duration
-	LogLevel          string
-	Commands          Commands
-	IgnorePatterns    []string
-	AutoFix           AutoFix
+	Agent                types.AgentName
+	ACPXPath             string
+	ACPRegistryOverrides map[string]string
+	AgentPathOverride    map[string]string
+	AgentArgsOverride    map[string][]string
+	CITimeout            time.Duration
+	LogLevel             string
+	Commands             Commands
+	IgnorePatterns       []string
+	AutoFix              AutoFix
 }
 
 // defaultConfigYAML is the template written when no global config file exists.
 const defaultConfigYAML = `# no-mistakes global configuration
 
 # Agent to use for code generation
-# Options: auto, claude, codex, rovodev, opencode, pi
+# Options: auto, claude, codex, rovodev, opencode, pi, acp:<target>
 # "auto" detects the first available agent on your system
+# Use acp:<target> to run an optional user-installed acpx target, for example acp:gemini
 agent: auto
+
+# Optional path to the user-installed acpx binary for acp:<target> agents
+# acpx_path: acpx
+
+# Optional ACP target command overrides for acp:<target> agents
+# acp_registry_overrides:
+#   local-gemini: node /opt/mock-acp-agent.mjs
 
 # Maximum time to monitor CI before timing out
 ci_timeout: "4h"
@@ -139,6 +153,15 @@ var agentProbeOrder = []types.AgentName{
 	types.AgentOpenCode,
 	types.AgentRovoDev,
 	types.AgentPi,
+}
+
+func isACPAgent(name types.AgentName) bool {
+	value := string(name)
+	if !strings.HasPrefix(value, "acp:") {
+		return false
+	}
+	target := strings.TrimPrefix(value, "acp:")
+	return target != "" && !strings.ContainsAny(target, " \t\r\n")
 }
 
 var probeRovoDevSupport = func(ctx context.Context, bin string) (bool, error) {
@@ -212,6 +235,12 @@ func (c *Config) ResolveAgent(ctx context.Context, lookPath func(string) (string
 // AgentPath returns the binary path for the configured agent,
 // using agent_path_override if set, otherwise the default binary name.
 func (c *Config) AgentPath() string {
+	if isACPAgent(c.Agent) {
+		if c.ACPXPath != "" {
+			return c.ACPXPath
+		}
+		return "acpx"
+	}
 	if c.AgentPathOverride != nil {
 		if p, ok := c.AgentPathOverride[string(c.Agent)]; ok {
 			return p
@@ -341,6 +370,12 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 
 	if raw.Agent != "" {
 		cfg.Agent = raw.Agent
+	}
+	if raw.ACPXPath != "" {
+		cfg.ACPXPath = raw.ACPXPath
+	}
+	if raw.ACPRegistryOverrides != nil {
+		cfg.ACPRegistryOverrides = raw.ACPRegistryOverrides
 	}
 	if raw.AgentPathOverride != nil {
 		cfg.AgentPathOverride = raw.AgentPathOverride
@@ -477,14 +512,16 @@ func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 	applyAutoFixOverrides(&af, &repo.AutoFix)
 
 	cfg := &Config{
-		Agent:             global.Agent,
-		AgentPathOverride: global.AgentPathOverride,
-		AgentArgsOverride: global.AgentArgsOverride,
-		CITimeout:         global.CITimeout,
-		LogLevel:          global.LogLevel,
-		Commands:          repo.Commands,
-		IgnorePatterns:    repo.IgnorePatterns,
-		AutoFix:           af,
+		Agent:                global.Agent,
+		ACPXPath:             global.ACPXPath,
+		ACPRegistryOverrides: global.ACPRegistryOverrides,
+		AgentPathOverride:    global.AgentPathOverride,
+		AgentArgsOverride:    global.AgentArgsOverride,
+		CITimeout:            global.CITimeout,
+		LogLevel:             global.LogLevel,
+		Commands:             repo.Commands,
+		IgnorePatterns:       repo.IgnorePatterns,
+		AutoFix:              af,
 	}
 
 	if repo.Agent != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -253,7 +253,7 @@ func (c *Config) AgentPath() string {
 	return string(c.Agent)
 }
 
-// AgentArgs returns extra CLI args for the configured agent, as declared in
+// AgentArgs returns extra CLI args for the configured native agent, as declared in
 // agent_args_override. Returns nil when no override is set for this agent.
 func (c *Config) AgentArgs() []string {
 	if c.AgentArgsOverride == nil {
@@ -262,7 +262,7 @@ func (c *Config) AgentArgs() []string {
 	return c.AgentArgsOverride[string(c.Agent)]
 }
 
-// agentArgsOverrideAgents lists agent names accepted as keys in
+// agentArgsOverrideAgents lists native agent names accepted as keys in
 // agent_args_override.
 var agentArgsOverrideAgents = map[string]bool{
 	string(types.AgentClaude):   true,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -232,8 +232,9 @@ func (c *Config) ResolveAgent(ctx context.Context, lookPath func(string) (string
 	return fmt.Errorf("no supported agent found in PATH (looked for: %s); install one or set 'agent' in ~/.no-mistakes/config.yaml", strings.Join(probed, ", "))
 }
 
-// AgentPath returns the binary path for the configured agent,
-// using agent_path_override if set, otherwise the default binary name.
+// AgentPath returns the binary path for the configured agent.
+// ACP agents use acpx_path if set, otherwise acpx.
+// Native agents use agent_path_override if set, otherwise the default binary name.
 func (c *Config) AgentPath() string {
 	if isACPAgent(c.Agent) {
 		if c.ACPXPath != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,7 +98,7 @@ const defaultConfigYAML = `# no-mistakes global configuration
 
 # Agent to use for code generation
 # Options: auto, claude, codex, rovodev, opencode, pi, acp:<target>
-# "auto" detects the first available agent on your system
+# "auto" detects the first available native agent on your system
 # Use acp:<target> to run an optional user-installed acpx target, for example acp:gemini
 agent: auto
 
@@ -116,12 +116,12 @@ ci_timeout: "4h"
 # Options: debug, info, warn, error
 log_level: info
 
-# Override agent binary paths (optional)
+# Override native agent binary paths (optional)
 # agent_path_override:
 #   claude: /usr/local/bin/claude
 #   codex: /opt/codex
 
-# Extra agent CLI flags (optional, global only)
+# Extra native agent CLI flags (optional, global only)
 # agent_args_override:
 #   codex:
 #     - -m

--- a/internal/config/config_agent_test.go
+++ b/internal/config/config_agent_test.go
@@ -44,6 +44,24 @@ func TestAgentPath_DefaultBinaries(t *testing.T) {
 	}
 }
 
+func TestAgentPath_ACPUsesAcpxPath(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+		want string
+	}{
+		{name: "default", cfg: &Config{Agent: "acp:gemini"}, want: "acpx"},
+		{name: "override", cfg: &Config{Agent: "acp:gemini", ACPXPath: "/opt/bin/acpx"}, want: "/opt/bin/acpx"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.AgentPath(); got != tt.want {
+				t.Errorf("AgentPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseLogLevel(t *testing.T) {
 	tests := []struct {
 		input string
@@ -77,6 +95,46 @@ func TestResolveAgent_ExplicitAgent(t *testing.T) {
 	}
 	if cfg.Agent != types.AgentCodex {
 		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentCodex)
+	}
+}
+
+func TestResolveAgent_ExplicitACPAgent(t *testing.T) {
+	cfg := &Config{Agent: "acp:gemini"}
+	err := cfg.ResolveAgent(context.Background(), func(string) (string, error) {
+		t.Fatal("lookPath should not be called for explicit acp agent")
+		return "", nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Agent != "acp:gemini" {
+		t.Errorf("agent = %q, want %q", cfg.Agent, "acp:gemini")
+	}
+}
+
+func TestLoadGlobal_ACPConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	data := []byte(`agent: acp:gemini
+acpx_path: /opt/bin/acpx
+acp_registry_overrides:
+  local-gemini: node /tmp/mock-acp.mjs
+`)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadGlobal(path)
+	if err != nil {
+		t.Fatalf("LoadGlobal() error = %v", err)
+	}
+	if cfg.Agent != "acp:gemini" {
+		t.Errorf("agent = %q, want acp:gemini", cfg.Agent)
+	}
+	if cfg.ACPXPath != "/opt/bin/acpx" {
+		t.Errorf("ACPXPath = %q, want /opt/bin/acpx", cfg.ACPXPath)
+	}
+	if got := cfg.ACPRegistryOverrides["local-gemini"]; got != "node /tmp/mock-acp.mjs" {
+		t.Errorf("ACPRegistryOverrides[local-gemini] = %q", got)
 	}
 }
 

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -303,7 +303,9 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 			return "", err
 		}
 		var agErr error
-		ag, agErr = agent.New(cfg.Agent, cfg.AgentPath(), cfg.AgentArgs())
+		ag, agErr = agent.NewWithOptions(cfg.Agent, cfg.AgentPath(), cfg.AgentArgs(), agent.Options{
+			ACPRegistryOverrides: cfg.ACPRegistryOverrides,
+		})
 		if agErr != nil {
 			m.db.UpdateRunError(run.ID, fmt.Sprintf("create agent: %s", agErr))
 			trackStartFailure("create_agent")

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -126,6 +126,7 @@ const (
 )
 
 // AgentName identifies a supported agent backend.
+// ACP agent names use dynamic acp:<target> values instead of constants.
 type AgentName string
 
 const (


### PR DESCRIPTION
## Summary

- Add ACP target support through `acpx`, including secure target validation, stateless exec invocation, JSON error handling, and token usage parsing.
- Extend agent/config plumbing for `agent: acp:<target>`, `acpx_path`, and global ACP registry overrides.
- Update setup, configuration, troubleshooting, and reference docs to explain ACP usage and native-agent discovery caveats.

## Risk Assessment

🚨 High: The change introduces a branch-controlled command execution path through permissive ACP target handling, so it should not merge without an explicit security decision.

## Testing

- Summary: Validated ACPX/ACP agent support across agent construction, JSON event parsing, config loading, wizard and daemon integration, the full Go test suite, and e2e suite; all passed.
- `go test ./internal/agent ./internal/config ./internal/cli ./internal/daemon`
- `go test ./...`
- `make e2e`
- `go test -count=1 ./internal/agent ./internal/config ./internal/cli ./internal/daemon`
- `go test -count=1 ./...`
- Outcome: ✅ passed across 1 run (4m7s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

**Round 1** - found 2 issues (1 error, 1 warning)
- 🚨 `internal/agent/acpx.go:98` - The acpx invocation appends the prompt directly after the target, which uses acpx&#39;s persistent-session prompt path. no-mistakes does not create or select an acpx session, so a fresh ACP setup will fail with no session found, and an existing setup may reuse stale session state. Insert the `exec` subcommand before the prompt to use acpx&#39;s stateless one-shot mode.
- ⚠️ `internal/agent/acpx.go:144` - The JSON parser drops all non-`session/update` messages, including top-level JSON-RPC error responses that acpx emits on stdout in `--json-strict` mode. If acpx exits nonzero with stderr suppressed, users get an empty `acpx exited` error instead of the real auth/session/startup failure. Capture `error.message` from stdout and include it when returning the process error.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `internal/agent/acpx.go:170` - ACP usage updates are parsed from a non-standard `used` field, but acpx emits token usage as `input_tokens`/`output_tokens` or camelCase equivalents, sometimes under `_meta.usage`. ACP runs will report zero input tokens and estimated output tokens instead of real usage. Parse the actual usage fields into `TokenUsage`, including cache read/write fields when present.

**Round 3** (auto-fix) - found 1 warning
- ⚠️ `internal/agent/acpx.go:143` - The acpx usage parser still misses the cache field names acpx itself normalizes, `cachedReadTokens` and `cachedWriteTokens`. Agents that emit those variants will report zero cache read/write usage even though the data is present. Add those JSON fields and include them in the cache read/write selection.

**Round 4** (auto-fix) - found 1 warning
- ⚠️ `internal/agent/acpx.go:189` - The JSON parser skips every non-session/update message, but ACP prompt responses can carry standard token usage in result.usage. Agents that only report usage there will show zero input and estimated output tokens even though acpx emitted exact values. Capture result.usage before continuing.

**Round 5** (auto-fix) - found 1 error
- 🚨 `internal/agent/agent.go:602` - ACP target validation only rejects whitespace, but acpx treats unknown positional targets as raw commands and dash-prefixed tokens as options. Since repo config can set `agent`, a branch can use values like `acp:./pwn` or `acp:--agent=./pwn` to execute a repo-controlled binary. Restrict positional ACP targets to known safe target names or require custom commands to come from global `acp_registry_overrides`.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/agent ./internal/config ./internal/cli ./internal/daemon`
- `go test ./...`
- `make e2e`
- `go test -count=1 ./internal/agent ./internal/config ./internal/cli ./internal/daemon`
- `go test -count=1 ./...`

</details>

<details>
<summary>🔧 **Document** - 8 issues found → auto-fixed (5)</summary>

**Round 1** - found 8 issues (7 warnings, 1 info)
- ⚠️ `README.md:34` - The high-level Agent-agnostic bullet still lists only claude, codex, rovodev, opencode, and pi. It should mention the new optional `acp:&lt;target&gt;` / `acpx` support.
- ⚠️ `docs/src/content/docs/start-here/introduction.md:71` - The introduction&#39;s agent choice list is stale and omits the new `acp:&lt;target&gt;` option backed by `acpx`.
- ⚠️ `docs/src/content/docs/guides/configuration.md:51` - The configuration guide sample still documents agent values as only `auto | claude | codex | rovodev | opencode | pi` and does not show the new `acp:&lt;target&gt;`, `acpx_path`, or `acp_registry_overrides` global config fields. The precedence section also only calls out `agent_path_override` and `agent_args_override` as global-only fields, omitting the new ACP global-only fields.
- ⚠️ `docs/src/content/docs/reference/global-config.md:89` - The `agent_path_override` description says it provides custom binary paths for each agent, but ACP agents ignore this map and use `acpx_path` instead. The reference should qualify this as native agents or explicitly point ACP users to `acpx_path`.
- ⚠️ `docs/src/content/docs/guides/agents.md:179` - The agent availability section says `no-mistakes doctor` shows which agent binaries are installed, but the displayed check only covers native agents and omits `acpx`. With ACP support added, this section should explain how to verify `acpx` or clarify that doctor does not validate ACP targets.
- ⚠️ `docs/src/content/docs/guides/setup-wizard.md:107` - The setup wizard environment sanity check only mentions `PATH` and `agent_path_override` for configured agent binaries. ACP-configured suggestions use `acpx_path`, so this requirement is incomplete for `agent: acp:&lt;target&gt;`.
- ⚠️ `docs/src/content/docs/guides/troubleshooting.md:90` - The agent binary troubleshooting guidance only tells users to set `agent_path_override`. For ACP agents, the code uses `acpx_path`, so this section should include the ACP-specific fix path.
- ℹ️ `internal/config/config.go:235` - The `AgentPath` doc comment says it uses `agent_path_override` or the default binary name. It should document the new ACP special case: `agent: acp:&lt;target&gt;` uses `acpx_path` or falls back to `acpx`.

**Round 2** (auto-fix) - found 3 issues (2 warnings, 1 info)
- ⚠️ `docs/src/content/docs/reference/cli.md:108` - The `no-mistakes doctor` CLI reference still says it checks agent binaries and lists only `claude`, `codex`, `acli`, `opencode`, and `pi`. With ACP support added, this should clarify these are native agent checks and note that `doctor` does not validate `acpx` or ACP targets.
- ⚠️ `internal/config/config.go:101` - The generated default config comments still say `agent: auto` detects the first available agent and describe `agent_path_override` / `agent_args_override` generically. Since ACP agents are opt-in, use `acpx_path`, and do not use those native-agent override maps, the template should qualify these comments as native-agent behavior.
- ℹ️ `internal/agent/agent.go:564` - The `New` doc comment says `extraArgs` are injected into the underlying tool argv, but ACP agents created through this path ignore `extraArgs` and use `Options.ACPRegistryOverrides` instead. The comment should qualify this as native-agent behavior or mention the ACP exception.

**Round 3** (auto-fix) - found 6 issues (5 warnings, 1 info)
- ⚠️ `docs/src/content/docs/guides/agents.md:7` - The guide still says default `agent: auto` picks the first supported agent available. Since ACP targets are now documented as supported but `agent: auto` only probes native agents, this should say first supported native agent or explicitly mention that ACP targets must be selected with `agent: acp:&lt;target&gt;`.
- ⚠️ `docs/src/content/docs/guides/agents.md:116` - The `agent_args_override` guidance still says extra flags can be set for agent-specific CLI flags generically. ACP agents ignore `agent_args_override`, so this should be qualified as native-agent-only.
- ⚠️ `docs/src/content/docs/guides/configuration.md:7` - The configuration guide still says `agent: auto` picks the first supported agent, and the sample comment says it picks the first available agent on PATH. With ACP support added, `auto` only probes native agents, so these comments should be qualified as native-agent behavior.
- ⚠️ `docs/src/content/docs/start-here/installation.md:56` - The installation prerequisites now list `acpx` for `agent: acp:&lt;target&gt;`, but the follow-up says `no-mistakes doctor` checks what is installed. `doctor` does not validate `acpx` or ACP targets, so this page should add the ACP-specific caveat.
- ⚠️ `docs/src/content/docs/start-here/quick-start.md:21` - Quick Start tells users to run `no-mistakes doctor` before listing `acpx` as a valid ACP prerequisite, but `doctor` does not validate `acpx` or ACP targets. Add a note that ACP users must verify `acpx_path` or `acpx` separately.
- ℹ️ `internal/types/types.go:128` - The `AgentName` doc comment says it identifies a supported agent backend, but the constants only enumerate the fixed native agents. With dynamic `acp:&lt;target&gt;` values now accepted, the comment should mention that ACP agent names are dynamic strings rather than constants.

**Round 4** (auto-fix) - found 1 warning
- ⚠️ `docs/src/content/docs/guides/agents.md:78` - The Binary resolution section still says `agent: auto` checks for supported agents and later directs unresolved agent discovery to `agent_path_override`. With `acp:&lt;target&gt;` now documented as supported but not auto-probed, and ACP paths using `acpx_path`, this section should qualify this as native-agent discovery and path overrides.

**Round 5** (auto-fix) - found 2 warnings
- ⚠️ `AGENTS.md:55` - The project layout still says `internal/agent` contains Claude, Codex, Rovo Dev, OpenCode, and Pi integrations. This change adds the ACP/acpx integration under `internal/agent/acpx.go`, so the list should include ACP/acpx.
- ⚠️ `CLAUDE.md:55` - The project layout still says `internal/agent` contains Claude, Codex, Rovo Dev, OpenCode, and Pi integrations. This change adds the ACP/acpx integration under `internal/agent/acpx.go`, so the list should include ACP/acpx.

**Round 6** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
