### PR TITLE
fix(daemon): detach Windows daemon process

### DIFF
--- a/internal/daemon/proc_windows.go
+++ b/internal/daemon/proc_windows.go
@@ -4,6 +4,7 @@ package daemon
 
 import (
 	"os/exec"
+	"syscall"
 	"time"
 
 	"golang.org/x/sys/windows"
@@ -11,8 +12,17 @@ import (
 
 const windowsStillActive = 259
 
+// detachedDaemonCreationFlags detaches the spawned daemon from the parent's
+// console and process group so the parent CLI can exit cleanly even if the
+// caller (e.g. PowerShell `Start-Process -Wait`) is waiting on the whole
+// console-attached process tree. See issue #164.
+const detachedDaemonCreationFlags = windows.DETACHED_PROCESS | windows.CREATE_NEW_PROCESS_GROUP
+
 func setSysProcAttr(cmd *exec.Cmd) {
-	// No Setsid equivalent on Windows; daemon runs in same session.
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: detachedDaemonCreationFlags,
+		HideWindow:    true,
+	}
 }
 
 func processRunning(pid int) (bool, error) {

--- a/internal/daemon/proc_windows_test.go
+++ b/internal/daemon/proc_windows_test.go
@@ -2,7 +2,12 @@
 
 package daemon
 
-import "testing"
+import (
+	"os/exec"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
 
 func TestProcessRunningReturnsFalseForMissingPID(t *testing.T) {
 	running, err := processRunning(999999)
@@ -11,5 +16,27 @@ func TestProcessRunningReturnsFalseForMissingPID(t *testing.T) {
 	}
 	if running {
 		t.Fatal("expected missing pid to be reported as not running")
+	}
+}
+
+// TestSetSysProcAttrDetachesDaemonFromConsole guards the fix for issue #164:
+// without DETACHED_PROCESS and CREATE_NEW_PROCESS_GROUP the daemon child
+// inherits the installer's console, which causes PowerShell's
+// `Start-Process -Wait -NoNewWindow` to hang waiting on the (long-lived)
+// daemon instead of returning when the CLI exits.
+func TestSetSysProcAttrDetachesDaemonFromConsole(t *testing.T) {
+	cmd := exec.Command("does-not-need-to-exist.exe")
+	setSysProcAttr(cmd)
+
+	attr := cmd.SysProcAttr
+	if attr == nil {
+		t.Fatal("setSysProcAttr did not assign SysProcAttr")
+	}
+	wantFlags := uint32(windows.DETACHED_PROCESS | windows.CREATE_NEW_PROCESS_GROUP)
+	if attr.CreationFlags&wantFlags != wantFlags {
+		t.Fatalf("CreationFlags = %#x, want flags %#x set", attr.CreationFlags, wantFlags)
+	}
+	if !attr.HideWindow {
+		t.Fatal("HideWindow = false, want true")
 	}
 }


### PR DESCRIPTION
## Summary

- Detach spawned Windows daemon processes from the parent console and process group so parent CLI invocations can exit cleanly.
- Hide the daemon child window and document the issue #164 behavior around PowerShell `Start-Process -Wait -NoNewWindow` hangs.
- Add Windows daemon coverage for the process creation flags; pipeline testing passed for `go test ./internal/daemon` and the Windows test compile.

## Risk Assessment

✅ Low: The change is narrowly scoped to Windows daemon process creation flags with a focused regression test and no broader behavioral changes outside detached daemon startup.

## Testing

- Summary: <code>Exercised the daemon package tests on macOS and cross-compiled the Windows daemon tests that cover `setSysProcAttr`; all completed successfully.</code>
- `go test ./internal/daemon`
- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/no-mistakes-daemon-windows.test.exe ./internal/daemon`
- Outcome: ✅ passed across 1 run (50.7s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/daemon`
- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/no-mistakes-daemon-windows.test.exe ./internal/daemon`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
