### PR TITLE
feat(cli): add per-run pipeline step skipping

### DIFF
--- a/docs/src/content/docs/concepts/daemon.md
+++ b/docs/src/content/docs/concepts/daemon.md
@@ -85,6 +85,7 @@ On startup, the daemon checks for runs that were left in `pending` or `running` 
 - Reaps orphaned managed agent servers left behind by a crashed daemon or setup wizard
 - Removes any orphaned worktree directories via `git worktree remove --force`
 - Reapplies per-worktree gate hook-path isolation to existing bare repos when Git supports `config --worktree`, so shared `core.hookspath` writes cannot disable `post-receive`
+- Enables Git push-option support on existing gate repos so per-push options like `no-mistakes.skip=...` keep working after upgrades
 
 ## Logging
 

--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -30,9 +30,10 @@ When you run `no-mistakes init` in a repo:
 
 1. It creates a local bare gate repo under `~/.no-mistakes/repos/<id>.git`.
 2. It installs a `post-receive` hook in that gate repo.
-3. It best-effort isolates the gate repo's hooks path from shared local Git config writes when Git supports `config --worktree`.
-4. It adds a `no-mistakes` remote to your working repo that points at the gate.
-5. It makes sure the daemon is running so incoming pushes can start runs.
+3. It enables Git push options for the gate repo.
+4. It best-effort isolates the gate repo's hooks path from shared local Git config writes when Git supports `config --worktree`.
+5. It adds a `no-mistakes` remote to your working repo that points at the gate.
+6. It makes sure the daemon is running so incoming pushes can start runs.
 
 After init, your original `origin` still points at the real upstream remote.
 That is a core design choice, not an implementation detail.
@@ -84,10 +85,11 @@ agent edit files, and commit fixes. Your day-to-day working tree stays clean.
 
 When `git push no-mistakes <branch>` lands, the bare repo's `post-receive` hook
 fires. It calls `no-mistakes daemon notify-push` with the gate path, ref name,
-and old/new SHAs. The hook never blocks the push - Git ignores `post-receive`
-exit status, so pushes still succeed - but notification failures are surfaced
-to the pushing client on stderr and appended to `notify-push.log` in the bare
-repo for later inspection.
+old/new SHAs, and any Git push options such as `no-mistakes.skip=test,lint`.
+The hook never blocks the push - Git ignores `post-receive` exit status, so
+pushes still succeed - but notification failures are surfaced to the pushing
+client on stderr and appended to `notify-push.log` in the bare repo for later
+inspection.
 
 ### Daemon
 
@@ -112,7 +114,7 @@ it was started from the same executable path and aborts if the daemon
 executable path cannot be determined or points to a different binary. You can
 also manage it explicitly with `no-mistakes daemon start|stop|restart|status`.
 
-On startup, the daemon recovers from crashes by marking any stuck runs as failed, reaping orphaned managed agent servers, cleaning up orphaned worktrees, and reapplying gate hook-path isolation for older bare repos when Git supports `config --worktree`.
+On startup, the daemon recovers from crashes by marking any stuck runs as failed, reaping orphaned managed agent servers, cleaning up orphaned worktrees, enabling push options for older gate repos, and reapplying gate hook-path isolation when Git supports `config --worktree`.
 
 ### Pipeline executor
 

--- a/docs/src/content/docs/concepts/pipeline.md
+++ b/docs/src/content/docs/concepts/pipeline.md
@@ -72,13 +72,14 @@ You can't reorder steps. You *can*:
 - Set explicit `commands.test`, `commands.lint`, `commands.format`.
 - Control auto-fix limits per step.
 - Ignore paths during review and documentation checks.
+- Skip steps for one run with `no-mistakes --skip <steps>`, `git push -o no-mistakes.skip=<steps>`, or from the TUI.
 
 See [Configuration](/no-mistakes/guides/configuration/).
 
 ## What you can't configure
 
 - The step order.
-- Skipping specific steps permanently - you can skip them per-run from the TUI, but the pipeline itself always has all eight.
+- Skipping specific steps permanently - per-run skips are allowed, but the pipeline itself always has all eight.
 - Adding new steps.
 
 This is intentional. The pipeline is opinionated so that "passed the gate" means the same thing across repos.

--- a/docs/src/content/docs/guides/setup-wizard.md
+++ b/docs/src/content/docs/guides/setup-wizard.md
@@ -23,6 +23,9 @@ In non-interactive contexts, bare `no-mistakes` without `-y` falls back to listi
 
 With `-y` / `--yes`, the wizard takes the default automated path for each step: use agent suggestions for branch and commit when needed, then push to the gate. In a TTY, that path stays visible and auto-advances through the wizard. Without a TTY, it falls back to the headless path.
 
+Pass `--skip` to skip comma-separated pipeline steps for the new run created by the wizard, for example `no-mistakes --skip test,lint`.
+It only applies when the wizard starts a new pipeline run; if bare `no-mistakes` attaches to an active run or lists recent runs, `--skip` exits with an error.
+
 If you want to attach to *any* active run in the repo (not just the current branch), use `no-mistakes attach` - that path skips the wizard entirely.
 
 ## Wizard flow

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -9,13 +9,17 @@ Attach to the active pipeline run for the current branch when one exists. If non
 
 ```sh
 no-mistakes
+no-mistakes --skip test,lint
 ```
 
 | Flag | Type | Default | Description |
 |---|---|---|---|
 | `-y`, `--yes` | `bool` | `false` | Run setup wizard and accept defaults automatically |
+| `--skip` | `string` | (none) | Comma-separated pipeline steps to skip for a new run |
 
 Unlike `no-mistakes attach`, bare `no-mistakes` only auto-attaches to an active run on the current branch.
+`--skip` only applies when bare `no-mistakes` starts a new pipeline run through the wizard; it does not skip a step on an already-active run.
+Valid step names are `rebase`, `review`, `test`, `document`, `lint`, `push`, `pr`, and `ci`.
 
 ## no-mistakes init
 
@@ -26,6 +30,7 @@ no-mistakes init
 ```
 
 Creates a local bare repo, installs the post-receive hook, best-effort isolates the gate repo's hook path from shared git config changes when Git supports `config --worktree`, adds the `no-mistakes` git remote, detects the default branch, records the repo in SQLite, and ensures the daemon is running, installing the managed service when available and falling back to a detached daemon otherwise.
+The gate advertises Git push-option support, so you can skip steps for one push with `git push -o no-mistakes.skip=test,lint no-mistakes <branch>`.
 
 Rolls back all changes if any step fails.
 

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -9,7 +9,7 @@ This is the per-step reference. For the overview and rationale, see [Pipeline](/
 rebase → review → test → document → lint → push → pr → ci
 ```
 
-Each step can produce findings, request approval, or trigger auto-fix. Steps that encounter fatal errors stop the pipeline. Steps can also be skipped by the user or automatically by the pipeline.
+Each step can produce findings, request approval, or trigger auto-fix. Steps that encounter fatal errors stop the pipeline. Steps can also be pre-skipped when starting a run, skipped by the user, or skipped automatically by the pipeline.
 
 ## Rebase
 
@@ -163,5 +163,5 @@ Each step progresses through these statuses:
 | `awaiting_approval` | Paused, waiting for user action |
 | `fix_review` | Paused after a fix cycle, showing results for review |
 | `completed` | Finished successfully |
-| `skipped` | User chose to skip, or the pipeline skipped it automatically |
+| `skipped` | Pre-skipped for the run, skipped by the user, or skipped automatically by the pipeline |
 | `failed` | Step failed |

--- a/internal/cli/attach.go
+++ b/internal/cli/attach.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/telemetry"
 	"github.com/kunchenguid/no-mistakes/internal/tui"
+	"github.com/kunchenguid/no-mistakes/internal/types"
 	"github.com/kunchenguid/no-mistakes/internal/update"
 	"github.com/kunchenguid/no-mistakes/internal/wizard"
 	"github.com/mattn/go-isatty"
@@ -23,7 +24,7 @@ var terminalInteractive = isInteractive
 
 // attachRun is the shared logic for attaching to a pipeline run. It's used by
 // both the root command (bare `no-mistakes`) and the `attach` subcommand.
-func attachRun(ctx context.Context, w io.Writer, runID string, rootDefault bool, autoYes bool) error {
+func attachRun(ctx context.Context, w io.Writer, runID string, rootDefault bool, autoYes bool, skipSteps []types.StepName) error {
 	p, d, err := openResources()
 	if err != nil {
 		return err
@@ -55,6 +56,7 @@ func attachRun(ctx context.Context, w io.Writer, runID string, rootDefault bool,
 	var run *ipc.RunInfo
 	var repoID string
 	var state *repoState
+	startedViaWizard := false
 
 	if runID != "" {
 		// Fetch specific run.
@@ -94,6 +96,7 @@ func attachRun(ctx context.Context, w io.Writer, runID string, rootDefault bool,
 		// existing headless path.
 		interactive := terminalInteractive()
 		if rootDefault && runID == "" && repo != nil && state != nil && (autoYes || interactive) {
+			startedViaWizard = true
 			// waitFn blocks inside the wizard's alt screen until the daemon
 			// has the run registered, so the handoff to runTUI below is
 			// seamless rather than flashing the pre-wizard terminal.
@@ -104,12 +107,12 @@ func attachRun(ctx context.Context, w io.Writer, runID string, rootDefault bool,
 			var wErr error
 			if autoYes {
 				if interactive {
-					res, wErr = runWizardAutoVisible(ctx, p, state, waitFn)
+					res, wErr = runWizardAutoVisible(ctx, p, state, skipSteps, waitFn)
 				} else {
-					res, wErr = runWizardAuto(ctx, p, state, waitFn)
+					res, wErr = runWizardAuto(ctx, p, state, skipSteps, waitFn)
 				}
 			} else {
-				res, wErr = runWizard(ctx, p, state, waitFn)
+				res, wErr = runWizardWithSkip(ctx, p, state, skipSteps, waitFn)
 			}
 			if wErr != nil {
 				return wErr
@@ -133,6 +136,9 @@ func attachRun(ctx context.Context, w io.Writer, runID string, rootDefault bool,
 			printNoActiveRun(w, d, repoID)
 			return nil
 		}
+	}
+	if len(skipSteps) > 0 && !startedViaWizard {
+		return fmt.Errorf("--skip only applies when starting a new pipeline run")
 	}
 
 	telemetry.Pageview("/tui", telemetry.Fields{
@@ -240,7 +246,7 @@ If no run ID is specified, attaches to the active run for the current repo.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return trackCommand("attach", func() error {
-				return attachRun(cmd.Context(), cmd.OutOrStdout(), runID, false, false)
+				return attachRun(cmd.Context(), cmd.OutOrStdout(), runID, false, false, nil)
 			})
 		},
 	}

--- a/internal/cli/daemon_cmd.go
+++ b/internal/cli/daemon_cmd.go
@@ -3,10 +3,12 @@ package cli
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/daemon"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/types"
 	"github.com/spf13/cobra"
 )
 
@@ -38,6 +40,7 @@ func newDaemonNotifyPushCmd() *cobra.Command {
 	var ref string
 	var oldSHA string
 	var newSHA string
+	var pushOptions []string
 
 	cmd := &cobra.Command{
 		Use:    "notify-push",
@@ -45,6 +48,11 @@ func newDaemonNotifyPushCmd() *cobra.Command {
 		Hidden: true,
 		Args:   cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			skipSteps, err := parseSkipPushOptions(pushOptions)
+			if err != nil {
+				return err
+			}
+
 			p, err := paths.New()
 			if err != nil {
 				return err
@@ -58,10 +66,11 @@ func newDaemonNotifyPushCmd() *cobra.Command {
 
 			var result ipc.PushReceivedResult
 			return client.Call(ipc.MethodPushReceived, &ipc.PushReceivedParams{
-				Gate: gate,
-				Ref:  ref,
-				Old:  oldSHA,
-				New:  newSHA,
+				Gate:      gate,
+				Ref:       ref,
+				Old:       oldSHA,
+				New:       newSHA,
+				SkipSteps: skipSteps,
 			}, &result)
 		},
 	}
@@ -70,12 +79,77 @@ func newDaemonNotifyPushCmd() *cobra.Command {
 	cmd.Flags().StringVar(&ref, "ref", "", "git ref name")
 	cmd.Flags().StringVar(&oldSHA, "old", "", "previous commit SHA")
 	cmd.Flags().StringVar(&newSHA, "new", "", "new commit SHA")
+	cmd.Flags().StringArrayVar(&pushOptions, "push-option", nil, "git push option")
 	_ = cmd.MarkFlagRequired("gate")
 	_ = cmd.MarkFlagRequired("ref")
 	_ = cmd.MarkFlagRequired("old")
 	_ = cmd.MarkFlagRequired("new")
 
 	return cmd
+}
+
+func parseSkipPushOptions(options []string) ([]types.StepName, error) {
+	var steps []types.StepName
+	for _, option := range options {
+		value, ok := strings.CutPrefix(option, "no-mistakes.skip=")
+		if !ok {
+			continue
+		}
+		parsed, err := parseSkipSteps(value)
+		if err != nil {
+			return nil, err
+		}
+		steps = append(steps, parsed...)
+	}
+	return dedupeSteps(steps), nil
+}
+
+func parseSkipSteps(value string) ([]types.StepName, error) {
+	if strings.TrimSpace(value) == "" {
+		return nil, nil
+	}
+	var steps []types.StepName
+	for _, part := range strings.Split(value, ",") {
+		step := types.StepName(strings.TrimSpace(part))
+		if !validStep(step) {
+			return nil, fmt.Errorf("unknown step %q", step)
+		}
+		steps = append(steps, step)
+	}
+	return dedupeSteps(steps), nil
+}
+
+func formatSkipPushOptions(steps []types.StepName) []string {
+	if len(steps) == 0 {
+		return nil
+	}
+	parts := make([]string, 0, len(steps))
+	for _, step := range dedupeSteps(steps) {
+		parts = append(parts, string(step))
+	}
+	return []string{"no-mistakes.skip=" + strings.Join(parts, ",")}
+}
+
+func validStep(step types.StepName) bool {
+	for _, known := range types.AllSteps() {
+		if step == known {
+			return true
+		}
+	}
+	return false
+}
+
+func dedupeSteps(steps []types.StepName) []types.StepName {
+	seen := make(map[types.StepName]bool, len(steps))
+	out := make([]types.StepName, 0, len(steps))
+	for _, step := range steps {
+		if seen[step] {
+			continue
+		}
+		seen[step] = true
+		out = append(out, step)
+	}
+	return out
 }
 
 func newDaemonStartCmd() *cobra.Command {

--- a/internal/cli/daemon_cmd_test.go
+++ b/internal/cli/daemon_cmd_test.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+func TestParseSkipPushOptions(t *testing.T) {
+	got, err := parseSkipPushOptions([]string{
+		"ci.skip",
+		"no-mistakes.skip=test,lint",
+	})
+	if err != nil {
+		t.Fatalf("parseSkipPushOptions() error = %v", err)
+	}
+	want := []types.StepName{types.StepTest, types.StepLint}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseSkipPushOptions() = %v, want %v", got, want)
+	}
+}
+
+func TestParseSkipPushOptionsRejectsUnknownStep(t *testing.T) {
+	_, err := parseSkipPushOptions([]string{"no-mistakes.skip=test,deploy"})
+	if err == nil {
+		t.Fatal("expected unknown step to fail")
+	}
+}
+
+func TestFormatSkipPushOptions(t *testing.T) {
+	got := formatSkipPushOptions([]types.StepName{types.StepTest, types.StepLint})
+	want := []string{"no-mistakes.skip=test,lint"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("formatSkipPushOptions() = %v, want %v", got, want)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -24,6 +24,7 @@ func Execute() int {
 
 func newRootCmd() *cobra.Command {
 	var autoYes bool
+	var skipValue string
 
 	cmd := &cobra.Command{
 		Use:     "no-mistakes",
@@ -41,12 +42,17 @@ func newRootCmd() *cobra.Command {
 		// still fall back to headless mode when no TTY is available.
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return trackCommand("root", func() error {
-				return attachRun(cmd.Context(), cmd.OutOrStdout(), "", true, autoYes)
+				skipSteps, err := parseSkipSteps(skipValue)
+				if err != nil {
+					return err
+				}
+				return attachRun(cmd.Context(), cmd.OutOrStdout(), "", true, autoYes, skipSteps)
 			})
 		},
 	}
 
 	cmd.Flags().BoolVarP(&autoYes, "yes", "y", false, "run setup wizard and accept defaults automatically")
+	cmd.Flags().StringVar(&skipValue, "skip", "", "comma-separated pipeline steps to skip for a new run")
 
 	cmd.AddCommand(newInitCmd())
 	cmd.AddCommand(newEjectCmd())

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/types"
 	"github.com/kunchenguid/no-mistakes/internal/wizard"
 )
 
@@ -43,7 +45,7 @@ func TestRootYesRunsWizardNonInteractively(t *testing.T) {
 	}
 
 	prevAuto := runWizardAuto
-	runWizardAuto = func(ctx context.Context, p *paths.Paths, state *repoState, _ waitForRunFunc) (wizard.Result, error) {
+	runWizardAuto = func(ctx context.Context, p *paths.Paths, state *repoState, _ []types.StepName, _ waitForRunFunc) (wizard.Result, error) {
 		if state == nil {
 			t.Fatal("expected repo state")
 		}
@@ -67,6 +69,57 @@ func TestRootYesRunsWizardNonInteractively(t *testing.T) {
 	}
 	if !attached {
 		t.Fatal("expected -y run to attach to the created run")
+	}
+}
+
+func TestRootSkipPassesStepsToWizard(t *testing.T) {
+	setupTestRepo(t)
+	nmHome := makeSocketSafeTempDir(t)
+	t.Setenv("NM_HOME", nmHome)
+	p := paths.WithRoot(nmHome)
+
+	d, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	if _, err := gate.Init(context.Background(), d, p, "."); err != nil {
+		t.Fatal(err)
+	}
+
+	startTestDaemon(t, p, d)
+
+	gitRoot, err := git.FindGitRoot(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo, err := d.GetRepoByPath(gitRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prevAuto := runWizardAuto
+	var gotSkip []types.StepName
+	runWizardAuto = func(ctx context.Context, p *paths.Paths, state *repoState, skipSteps []types.StepName, _ waitForRunFunc) (wizard.Result, error) {
+		gotSkip = append([]types.StepName(nil), skipSteps...)
+		if _, err := d.InsertRun(repo.ID, "feat/auto", "head1234", "base5678"); err != nil {
+			return wizard.Result{}, err
+		}
+		return wizard.Result{Success: true, Pushed: true, TargetBranch: "feat/auto"}, nil
+	}
+	defer func() { runWizardAuto = prevAuto }()
+
+	prevRunTUI := runTUI
+	runTUI = func(string, *ipc.Client, *ipc.RunInfo, string) error { return nil }
+	defer func() { runTUI = prevRunTUI }()
+
+	if _, err := executeCmd("--skip", "test,lint", "-y"); err != nil {
+		t.Fatalf("executeCmd(--skip test,lint -y) error = %v", err)
+	}
+	want := []types.StepName{types.StepTest, types.StepLint}
+	if !reflect.DeepEqual(gotSkip, want) {
+		t.Fatalf("skip steps = %v, want %v", gotSkip, want)
 	}
 }
 
@@ -103,7 +156,7 @@ func TestRootYesUsesVisibleWizardWhenInteractive(t *testing.T) {
 
 	prevVisible := runWizardAutoVisible
 	visible := false
-	runWizardAutoVisible = func(ctx context.Context, p *paths.Paths, state *repoState, _ waitForRunFunc) (wizard.Result, error) {
+	runWizardAutoVisible = func(ctx context.Context, p *paths.Paths, state *repoState, _ []types.StepName, _ waitForRunFunc) (wizard.Result, error) {
 		visible = true
 		if state == nil {
 			t.Fatal("expected repo state")
@@ -116,7 +169,7 @@ func TestRootYesUsesVisibleWizardWhenInteractive(t *testing.T) {
 	defer func() { runWizardAutoVisible = prevVisible }()
 
 	prevAuto := runWizardAuto
-	runWizardAuto = func(context.Context, *paths.Paths, *repoState, waitForRunFunc) (wizard.Result, error) {
+	runWizardAuto = func(context.Context, *paths.Paths, *repoState, []types.StepName, waitForRunFunc) (wizard.Result, error) {
 		t.Fatal("expected interactive -y path to show the wizard instead of using headless auto mode")
 		return wizard.Result{}, nil
 	}
@@ -160,7 +213,7 @@ func TestRootYesFailsWhenWizardPushProducesNoRun(t *testing.T) {
 	startTestDaemon(t, p, d)
 
 	prevAuto := runWizardAuto
-	runWizardAuto = func(ctx context.Context, p *paths.Paths, state *repoState, _ waitForRunFunc) (wizard.Result, error) {
+	runWizardAuto = func(ctx context.Context, p *paths.Paths, state *repoState, _ []types.StepName, _ waitForRunFunc) (wizard.Result, error) {
 		return wizard.Result{Success: true, Pushed: true, TargetBranch: "feat/missing"}, nil
 	}
 	defer func() { runWizardAuto = prevAuto }()
@@ -196,7 +249,7 @@ func TestRootYesPassesCommandContextToWizard(t *testing.T) {
 	cancel()
 
 	prevAuto := runWizardAuto
-	runWizardAuto = func(got context.Context, p *paths.Paths, state *repoState, _ waitForRunFunc) (wizard.Result, error) {
+	runWizardAuto = func(got context.Context, p *paths.Paths, state *repoState, _ []types.StepName, _ waitForRunFunc) (wizard.Result, error) {
 		if got == nil {
 			t.Fatal("expected command context")
 		}
@@ -235,7 +288,7 @@ func TestRootYesStopsWaitingForRunWhenContextCanceled(t *testing.T) {
 	defer cancel()
 
 	prevAuto := runWizardAuto
-	runWizardAuto = func(got context.Context, p *paths.Paths, state *repoState, _ waitForRunFunc) (wizard.Result, error) {
+	runWizardAuto = func(got context.Context, p *paths.Paths, state *repoState, _ []types.StepName, _ waitForRunFunc) (wizard.Result, error) {
 		cancel()
 		return wizard.Result{Success: true, Pushed: true, TargetBranch: "feat/missing"}, nil
 	}

--- a/internal/cli/telemetry_test.go
+++ b/internal/cli/telemetry_test.go
@@ -169,7 +169,7 @@ func TestAttachTracksTUIPageview(t *testing.T) {
 	runTUI = func(string, *ipc.Client, *ipc.RunInfo, string) error { return nil }
 	defer func() { runTUI = prevRunTUI }()
 
-	if err := attachRun(context.Background(), io.Discard, run.ID, false, false); err != nil {
+	if err := attachRun(context.Background(), io.Discard, run.ID, false, false, nil); err != nil {
 		t.Fatalf("attachRun() error = %v", err)
 	}
 

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -33,11 +33,11 @@ type waitForRunFunc func(ctx context.Context, branch string) error
 var newWizardAgent = agent.NewWithOptions
 var wizardRun = wizard.Run
 var wizardRunAuto = wizard.RunAuto
-var runWizardAutoVisible = func(ctx context.Context, p *paths.Paths, state *repoState, wait waitForRunFunc) (wizard.Result, error) {
-	return runWizardWithMode(ctx, p, state, true, true, wait)
+var runWizardAutoVisible = func(ctx context.Context, p *paths.Paths, state *repoState, skipSteps []types.StepName, wait waitForRunFunc) (wizard.Result, error) {
+	return runWizardWithMode(ctx, p, state, skipSteps, true, true, wait)
 }
-var runWizardAuto = func(ctx context.Context, p *paths.Paths, state *repoState, wait waitForRunFunc) (wizard.Result, error) {
-	return runWizardWithMode(ctx, p, state, true, false, wait)
+var runWizardAuto = func(ctx context.Context, p *paths.Paths, state *repoState, skipSteps []types.StepName, wait waitForRunFunc) (wizard.Result, error) {
+	return runWizardWithMode(ctx, p, state, skipSteps, true, false, wait)
 }
 
 type wizardAgentSuggester struct {
@@ -190,10 +190,14 @@ func detectRepoState(ctx context.Context, repo *db.Repo) (*repoState, error) {
 // runWizard prepares optional suggestion hooks and runs the interactive
 // onboarding wizard against the supplied repo state.
 func runWizard(ctx context.Context, p *paths.Paths, state *repoState, wait waitForRunFunc) (wizard.Result, error) {
-	return runWizardWithMode(ctx, p, state, false, true, wait)
+	return runWizardWithSkip(ctx, p, state, nil, wait)
 }
 
-func runWizardWithMode(ctx context.Context, p *paths.Paths, state *repoState, auto bool, visible bool, wait waitForRunFunc) (wizard.Result, error) {
+func runWizardWithSkip(ctx context.Context, p *paths.Paths, state *repoState, skipSteps []types.StepName, wait waitForRunFunc) (wizard.Result, error) {
+	return runWizardWithMode(ctx, p, state, skipSteps, false, true, wait)
+}
+
+func runWizardWithMode(ctx context.Context, p *paths.Paths, state *repoState, skipSteps []types.StepName, auto bool, visible bool, wait waitForRunFunc) (wizard.Result, error) {
 	workDir := state.workDir
 
 	globalCfg, err := config.LoadGlobal(p.ConfigFile())
@@ -235,7 +239,7 @@ func runWizardWithMode(ctx context.Context, p *paths.Paths, state *repoState, au
 			return git.CommitAll(ctx, workDir, msg)
 		},
 		Push: func(ctx context.Context, branch string) error {
-			return git.Push(ctx, workDir, gate.RemoteName, "refs/heads/"+branch, "", false)
+			return git.PushWithOptions(ctx, workDir, gate.RemoteName, "refs/heads/"+branch, "", false, formatSkipPushOptions(skipSteps))
 		},
 		SuggestBranch: func(ctx context.Context) (string, error) {
 			return suggester.suggestBranch(ctx)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -315,6 +315,9 @@ func migrateGateConfigs(ctx context.Context, p *paths.Paths) {
 			continue
 		}
 		bareDir := filepath.Join(p.ReposDir(), entry.Name())
+		if _, err := git.Run(ctx, bareDir, "config", "receive.advertisePushOptions", "true"); err != nil {
+			slog.Warn("enable gate push options failed", "bare", bareDir, "error", err)
+		}
 		if err := git.IsolateHooksPath(ctx, bareDir); err != nil {
 			slog.Warn("isolate gate hooks path failed", "bare", bareDir, "error", err)
 		}

--- a/internal/daemon/lifecycle_test.go
+++ b/internal/daemon/lifecycle_test.go
@@ -74,6 +74,17 @@ func TestWaitForDaemonStopKeepsArtifactsWhenKillFails(t *testing.T) {
 	}
 }
 
+func TestDaemonStartTimeoutDefaultsToLongerWindowOnWindows(t *testing.T) {
+	t.Setenv("NM_TEST_DAEMON_START_TIMEOUT", "")
+	oldGOOS := runtimeGOOS
+	runtimeGOOS = "windows"
+	t.Cleanup(func() { runtimeGOOS = oldGOOS })
+
+	if got := daemonStartTimeout(); got != 15*time.Second {
+		t.Fatalf("daemonStartTimeout() = %v, want 15s", got)
+	}
+}
+
 func TestStopDetachedDaemonFallsBackToPIDWhenSocketIsBroken(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("unix socket setup is platform-specific")

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -163,7 +163,7 @@ func (m *RunManager) HandlePushReceived(ctx context.Context, params *ipc.PushRec
 	}
 
 	branch := branchFromRef(params.Ref)
-	return m.startRun(ctx, repo, branch, params.New, params.Old, "push")
+	return m.startRun(ctx, repo, branch, params.New, params.Old, "push", params.SkipSteps)
 }
 
 // HandleRerun creates a new run for the latest gate head on a branch.
@@ -210,11 +210,11 @@ func (m *RunManager) HandleRerun(ctx context.Context, repoID, branch string) (st
 		baseSHA = matchingHead.BaseSHA
 	}
 
-	return m.startRun(ctx, repo, branch, headSHA, baseSHA, "rerun")
+	return m.startRun(ctx, repo, branch, headSHA, baseSHA, "rerun", nil)
 }
 
 // startRun creates a run, sets up a worktree, and launches pipeline execution.
-func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSHA, baseSHA, trigger string) (string, error) {
+func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSHA, baseSHA, trigger string, skipSteps []types.StepName) (string, error) {
 	branchRole := telemetryBranchRole(branch, repo.DefaultBranch)
 	trackStartFailure := func(stage string) {
 		telemetry.Track("run", telemetry.Fields{
@@ -326,6 +326,7 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 	// Create executor with event broadcast.
 	runCtx, cancel := context.WithCancelCause(context.Background())
 	executor := pipeline.NewExecutor(m.db, m.paths, cfg, ag, execSteps, m.broadcast)
+	executor.SetSkippedSteps(skipSteps)
 
 	// Track executor.
 	done := make(chan struct{})

--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -74,6 +74,54 @@ func TestPushReceivedTracksRunTelemetry(t *testing.T) {
 	}
 }
 
+func TestPushReceivedSkipStepsConfiguresExecutor(t *testing.T) {
+	review := &mockPassStep{name: types.StepReview}
+	testStep := &mockPassStep{name: types.StepTest}
+	p, d := startTestDaemonWithSteps(t, func() []pipeline.Step {
+		return []pipeline.Step{review, testStep}
+	})
+
+	_, headSHA := setupTestGitRepo(t, p, d, "skip-run-repo")
+
+	client, err := ipc.Dial(p.Socket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	var result ipc.PushReceivedResult
+	err = client.Call(ipc.MethodPushReceived, &ipc.PushReceivedParams{
+		Gate:      p.RepoDir("skip-run-repo"),
+		Ref:       "refs/heads/main",
+		Old:       "0000000000000000000000000000000000000000",
+		New:       headSHA,
+		SkipSteps: []types.StepName{types.StepReview},
+	}, &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := waitForRunTerminalState(t, d, result.RunID)
+	if run.Status != types.RunCompleted {
+		t.Fatalf("run status = %q, want %q", run.Status, types.RunCompleted)
+	}
+	if got := review.execCnt.Load(); got != 0 {
+		t.Fatalf("review executed %d times, want 0", got)
+	}
+	if got := testStep.execCnt.Load(); got != 1 {
+		t.Fatalf("test executed %d times, want 1", got)
+	}
+	steps, err := d.GetStepsByRun(result.RunID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, step := range steps {
+		if step.StepName == types.StepReview && step.Status != types.StepStatusSkipped {
+			t.Fatalf("review status = %s, want %s", step.Status, types.StepStatusSkipped)
+		}
+	}
+}
+
 func TestPushReceivedTracksRunTelemetryAfterPanic(t *testing.T) {
 	recorder := &telemetryRecorder{}
 	restore := telemetry.SetDefaultForTesting(recorder)

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -22,7 +22,11 @@ var daemonKillPID = killPID
 var daemonEndpointUsesRegularFile = func() bool { return runtime.GOOS == "windows" }
 
 func daemonStartTimeout() time.Duration {
-	return durationFromEnv("NM_TEST_DAEMON_START_TIMEOUT", 5*time.Second)
+	fallback := 5 * time.Second
+	if runtimeGOOS == "windows" {
+		fallback = 15 * time.Second
+	}
+	return durationFromEnv("NM_TEST_DAEMON_START_TIMEOUT", fallback)
 }
 
 func daemonStartPollInterval() time.Duration {

--- a/internal/daemon/subscribe_recover_test.go
+++ b/internal/daemon/subscribe_recover_test.go
@@ -434,4 +434,11 @@ func TestRecoverIsolatesGateRepoHooksPath(t *testing.T) {
 	if got := strings.TrimSpace(string(out)); got != want {
 		t.Errorf("after migration, core.hookspath = %q, want %q", got, want)
 	}
+	out, err = exec.Command("git", "-C", bareDir, "config", "--get", "receive.advertisePushOptions").Output()
+	if err != nil {
+		t.Fatalf("get receive.advertisePushOptions: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != "true" {
+		t.Fatalf("receive.advertisePushOptions = %q, want true", got)
+	}
 }

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -59,6 +59,10 @@ func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Re
 	if err := git.InitBare(ctx, bareDir); err != nil {
 		return nil, fmt.Errorf("create bare repo: %w", err)
 	}
+	if _, err := git.Run(ctx, bareDir, "config", "receive.advertisePushOptions", "true"); err != nil {
+		os.RemoveAll(bareDir)
+		return nil, fmt.Errorf("enable push options: %w", err)
+	}
 
 	// Install post-receive hook.
 	if err := git.InstallPostReceiveHook(bareDir); err != nil {

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -105,6 +105,11 @@ func TestInit(t *testing.T) {
 	if !fileExists(hookPath) {
 		t.Error("post-receive hook not installed")
 	}
+	if out, err := exec.Command("git", "-C", bareDir, "config", "--get", "receive.advertisePushOptions").Output(); err != nil {
+		t.Fatalf("get receive.advertisePushOptions: %v", err)
+	} else if got := string(out); got != "true\n" {
+		t.Fatalf("receive.advertisePushOptions = %q, want true", got)
+	}
 
 	// Verify no-mistakes remote was added to working repo.
 	url, err := gitpkg.GetRemoteURL(ctx, workDir, "no-mistakes")

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -188,7 +188,16 @@ func FetchRemoteBranch(ctx context.Context, dir, remote, branch string) error {
 // Push pushes a ref to a remote. If forceWithLease is true, uses
 // --force-with-lease with the expectedSHA for safe force-push.
 func Push(ctx context.Context, dir, remote, ref, expectedSHA string, forceWithLease bool) error {
-	args := []string{"push", remote}
+	return PushWithOptions(ctx, dir, remote, ref, expectedSHA, forceWithLease, nil)
+}
+
+// PushWithOptions pushes a ref to a remote with per-push options.
+func PushWithOptions(ctx context.Context, dir, remote, ref, expectedSHA string, forceWithLease bool, pushOptions []string) error {
+	args := []string{"push"}
+	for _, option := range pushOptions {
+		args = append(args, "-o", option)
+	}
+	args = append(args, remote)
 	if forceWithLease {
 		if expectedSHA != "" {
 			args = append(args, fmt.Sprintf("--force-with-lease=%s:%s", ref, expectedSHA))

--- a/internal/git/git_branch_worktree_test.go
+++ b/internal/git/git_branch_worktree_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -122,6 +123,35 @@ func TestPush(t *testing.T) {
 	expected := run(t, src, "git", "rev-parse", "HEAD")
 	if out != expected {
 		t.Fatalf("expected %q, got %q", expected, out)
+	}
+}
+
+func TestPushWithOptionsForwardsPushOptions(t *testing.T) {
+	ctx := context.Background()
+	src := initTestRepo(t)
+	bare := filepath.Join(t.TempDir(), "dest.git")
+	if err := InitBare(ctx, bare); err != nil {
+		t.Fatal(err)
+	}
+	run(t, bare, "git", "config", "receive.advertisePushOptions", "true")
+	run(t, src, "git", "remote", "add", "dest", bare)
+
+	marker := filepath.Join(t.TempDir(), "push-options.txt")
+	hook := "#!/bin/sh\nprintf '%s:%s\n' \"$GIT_PUSH_OPTION_COUNT\" \"$GIT_PUSH_OPTION_0\" > " + shellSingleQuote(marker) + "\n"
+	if err := os.WriteFile(filepath.Join(bare, "hooks", "post-receive"), []byte(hook), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := PushWithOptions(ctx, src, "dest", "refs/heads/main", "", false, []string{"no-mistakes.skip=test,lint"}); err != nil {
+		t.Fatalf("PushWithOptions failed: %v", err)
+	}
+
+	data, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := strings.TrimSpace(string(data)), "1:no-mistakes.skip=test,lint"; got != want {
+		t.Fatalf("push options marker = %q, want %q", got, want)
 	}
 }
 

--- a/internal/git/hook.go
+++ b/internal/git/hook.go
@@ -45,7 +45,7 @@ while read oldrev newrev refname; do
 	    --new "$newrev"
 	  i=0
 	  while [ "$i" -lt "${GIT_PUSH_OPTION_COUNT:-0}" ]; do
-	    eval "opt=\${GIT_PUSH_OPTION_$i}"
+	    opt=$(printenv "GIT_PUSH_OPTION_$i" 2>/dev/null || :)
 	    set -- "$@" --push-option "$opt"
 	    i=$((i + 1))
 	  done

--- a/internal/git/hook.go
+++ b/internal/git/hook.go
@@ -39,11 +39,17 @@ LOG="$(pwd)/notify-push.log"
 nm_ts() { date '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || echo unknown; }
 notify_failed=0
 while read oldrev newrev refname; do
-  out=$(NM_HOOK_HELPER=1 "$NM_BIN" daemon notify-push \
-    --gate "$(pwd)" \
-    --ref "$refname" \
-    --old "$oldrev" \
-    --new "$newrev" 2>&1)
+	  set -- --gate "$(pwd)" \
+	    --ref "$refname" \
+	    --old "$oldrev" \
+	    --new "$newrev"
+	  i=0
+	  while [ "$i" -lt "${GIT_PUSH_OPTION_COUNT:-0}" ]; do
+	    eval "opt=\${GIT_PUSH_OPTION_$i}"
+	    set -- "$@" --push-option "$opt"
+	    i=$((i + 1))
+	  done
+	  out=$(NM_HOOK_HELPER=1 "$NM_BIN" daemon notify-push "$@" 2>&1)
   status=$?
   if [ $status -ne 0 ]; then
     notify_failed=1

--- a/internal/git/hook_test.go
+++ b/internal/git/hook_test.go
@@ -33,6 +33,12 @@ func TestPostReceiveHookScript(t *testing.T) {
 	if !strings.Contains(script, "daemon notify-push") {
 		t.Fatal("hook should invoke the CLI notify subcommand")
 	}
+	if !strings.Contains(script, "GIT_PUSH_OPTION_COUNT") {
+		t.Fatal("hook should forward git push options to notify-push")
+	}
+	if !strings.Contains(script, "--push-option") {
+		t.Fatal("hook should pass each git push option as a notify-push flag")
+	}
 	if strings.Contains(script, "nc -U") {
 		t.Fatal("hook should not depend on netcat")
 	}

--- a/internal/git/hook_test.go
+++ b/internal/git/hook_test.go
@@ -42,6 +42,9 @@ func TestPostReceiveHookScript(t *testing.T) {
 	if strings.Contains(script, "nc -U") {
 		t.Fatal("hook should not depend on netcat")
 	}
+	if strings.Contains(script, "eval") {
+		t.Fatal("hook should not use eval to read push options")
+	}
 	if !strings.Contains(script, "\"$NM_BIN\" daemon notify-push") {
 		t.Fatal("hook should execute the embedded binary path")
 	}
@@ -107,6 +110,53 @@ func TestPostReceiveHookScriptWithQuotedPath(t *testing.T) {
 	script := postReceiveHookScript("/opt/it's here/no-mistakes")
 	if !strings.Contains(script, "NM_BIN='/opt/it'\"'\"'s here/no-mistakes'") {
 		t.Fatal("hook should correctly escape single quotes in the executable path")
+	}
+}
+
+func TestPostReceiveHookScriptDoesNotEvaluatePushOptions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("post-receive hook is /bin/sh-only")
+	}
+
+	base := t.TempDir()
+	bare := filepath.Join(base, "test.git")
+	if err := os.MkdirAll(bare, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	argsPath := filepath.Join(base, "args.txt")
+	fakeBin := filepath.Join(base, "fake-no-mistakes")
+	fakeScript := "#!/bin/sh\nprintf '%s\n' \"$@\" > " + shellSingleQuote(argsPath) + "\nexit 0\n"
+	if err := os.WriteFile(fakeBin, []byte(fakeScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	hookPath := filepath.Join(base, "post-receive")
+	if err := os.WriteFile(hookPath, []byte(postReceiveHookScript(fakeBin)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	markerPath := filepath.Join(base, "pwned")
+	cmd := exec.Command("/bin/sh", hookPath)
+	cmd.Dir = bare
+	cmd.Stdin = strings.NewReader("oldrev newrev refs/heads/main\n")
+	cmd.Env = append(os.Environ(),
+		"GIT_PUSH_OPTION_COUNT=1",
+		"GIT_PUSH_OPTION_0=ok; touch "+markerPath,
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run hook: %v: %s", err, out)
+	}
+
+	if _, err := os.Stat(markerPath); !os.IsNotExist(err) {
+		t.Fatalf("hook should not evaluate push option shell syntax, stat err: %v", err)
+	}
+	args, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(args), "ok; touch "+markerPath) {
+		t.Fatalf("hook should forward push option literally, got:\n%s", args)
 	}
 }
 

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -58,10 +58,11 @@ func (e *RPCError) Error() string { return e.Message }
 
 // PushReceivedParams are sent by the post-receive hook when a push arrives.
 type PushReceivedParams struct {
-	Gate string `json:"gate"`
-	Ref  string `json:"ref"`
-	Old  string `json:"old"`
-	New  string `json:"new"`
+	Gate      string           `json:"gate"`
+	Ref       string           `json:"ref"`
+	Old       string           `json:"old"`
+	New       string           `json:"new"`
+	SkipSteps []types.StepName `json:"skip_steps,omitempty"`
 }
 
 // GetRunParams requests a single run by ID.

--- a/internal/ipc/protocol_test.go
+++ b/internal/ipc/protocol_test.go
@@ -2,6 +2,7 @@ package ipc
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/kunchenguid/no-mistakes/internal/types"
@@ -124,10 +125,11 @@ func TestResponseError(t *testing.T) {
 
 func TestPushReceivedParams(t *testing.T) {
 	params := PushReceivedParams{
-		Gate: "/path/to/gate.git",
-		Ref:  "refs/heads/main",
-		Old:  "aaa",
-		New:  "bbb",
+		Gate:      "/path/to/gate.git",
+		Ref:       "refs/heads/main",
+		Old:       "aaa",
+		New:       "bbb",
+		SkipSteps: []types.StepName{types.StepTest, types.StepLint},
 	}
 	data, _ := json.Marshal(params)
 	var got PushReceivedParams
@@ -136,6 +138,9 @@ func TestPushReceivedParams(t *testing.T) {
 	}
 	if got.Gate != params.Gate || got.Ref != params.Ref || got.Old != params.Old || got.New != params.New {
 		t.Errorf("round-trip mismatch: got %+v, want %+v", got, params)
+	}
+	if !reflect.DeepEqual(got.SkipSteps, params.SkipSteps) {
+		t.Errorf("skip_steps = %+v, want %+v", got.SkipSteps, params.SkipSteps)
 	}
 }
 

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -37,6 +37,7 @@ type Executor struct {
 	config *config.Config
 	agent  agent.Agent
 	steps  []Step
+	skips  map[types.StepName]bool
 
 	onEvent EventFunc
 
@@ -44,6 +45,18 @@ type Executor struct {
 	approvalCh  chan approvalResponse // buffered channel for approval responses
 	waiting     bool                  // true when blocked on approval
 	waitingStep types.StepName        // which step is currently awaiting approval
+}
+
+// SetSkippedSteps configures steps that should be marked skipped without running.
+func (e *Executor) SetSkippedSteps(steps []types.StepName) {
+	if len(steps) == 0 {
+		e.skips = nil
+		return
+	}
+	e.skips = make(map[types.StepName]bool, len(steps))
+	for _, step := range steps {
+		e.skips[step] = true
+	}
 }
 
 // NewExecutor creates a pipeline executor.
@@ -129,6 +142,13 @@ func (e *Executor) Execute(ctx context.Context, run *db.Run, repo *db.Repo, work
 		}
 
 		sr := stepRecords[step.Name()]
+		if e.skips[step.Name()] {
+			if err := e.db.CompleteStepWithStatus(sr.ID, types.StepStatusSkipped, 0, 0, ""); err != nil {
+				return e.failRun(run, repo, fmt.Errorf("skip step %s: %w", step.Name(), err), ctx)
+			}
+			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, step.Name(), string(types.StepStatusSkipped), "", "", "", nil)
+			continue
+		}
 		skipRemaining, err := e.executeStep(ctx, step, sr, run, repo, workDir, logDir)
 		if err != nil {
 			return e.failRun(run, repo, err, ctx)

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -349,3 +349,41 @@ func TestExecutor_SkippedOutcome_EmitsSkippedEvent(t *testing.T) {
 		t.Fatalf("expected skipped event status, got %q", got)
 	}
 }
+
+func TestExecutor_ConfiguredSkippedStepDoesNotExecuteAndContinues(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	review := newPassStep(types.StepReview)
+	testStep := newPassStep(types.StepTest)
+	exec := NewExecutor(database, p, nil, nil, []Step{review, testStep}, nil)
+	exec.SetSkippedSteps([]types.StepName{types.StepReview})
+	events := collectEvents(exec)
+
+	if err := exec.Execute(context.Background(), run, repo, workDir); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got := review.callCount(); got != 0 {
+		t.Fatalf("skipped step executed %d times, want 0", got)
+	}
+	if got := testStep.callCount(); got != 1 {
+		t.Fatalf("next step executed %d times, want 1", got)
+	}
+	if event := events.find(ipc.EventStepStarted, types.StepReview); event != nil {
+		t.Fatal("configured skipped step should not emit step_started")
+	}
+	event := events.find(ipc.EventStepCompleted, types.StepReview)
+	if event == nil || event.Status == nil || *event.Status != string(types.StepStatusSkipped) {
+		t.Fatalf("expected skipped completion event, got %+v", event)
+	}
+
+	steps, err := database.GetStepsByRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, step := range steps {
+		if step.StepName == types.StepReview && step.Status != types.StepStatusSkipped {
+			t.Fatalf("review status = %s, want %s", step.Status, types.StepStatusSkipped)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add `--skip` support for starting new runs from the CLI and setup wizard so selected pipeline steps can be pre-skipped per run.
- Forward `no-mistakes.skip` Git push options through gate hooks, daemon IPC, and pipeline execution, including push-option enablement for existing gate repos.
- Update CLI, pipeline, gate, daemon, and step reference docs to describe the new skip mechanisms and push-option migration.

## Risk Assessment

✅ Low: The change is well-bounded to skip-step propagation through CLI, push options, daemon IPC, and executor handling, with the previously reported hook eval risk addressed and no additional material issues found.

## Testing

- Summary: Exercised the skip-step changes across CLI parsing, git push options, hook forwarding, IPC, daemon run startup, pipeline execution, and full e2e flows; all tests passed.
- `go test -race -count=1 ./internal/cli ./internal/daemon ./internal/gate ./internal/git ./internal/ipc ./internal/pipeline`
- `make e2e`
- `go test -race -count=1 ./...`
- Outcome: ✅ passed across 1 run (4m17s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/git/hook.go:48` - The hook uses eval to read GIT_PUSH_OPTION_N, so a push option containing shell metacharacters or command substitution can be executed by the post-receive hook before notify-push runs; read the indexed environment variable without eval, or at least quote the evaluated assignment safely.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test -race -count=1 ./internal/cli ./internal/daemon ./internal/gate ./internal/git ./internal/ipc ./internal/pipeline`
- `make e2e`
- `go test -race -count=1 ./...`

</details>

<details>
<summary>🔧 **Document** - 4 issues found → auto-fixed (2)</summary>

**Round 1** - found 4 warnings
- ⚠️ `docs/src/content/docs/guides/setup-wizard.md:18` - The setup wizard guide only documents `-y` / `--yes` as a flag that changes bare `no-mistakes` wizard behavior. The change adds `no-mistakes --skip &lt;steps&gt;` for wizard-started runs, including the constraint that it only applies when the wizard creates a new run and is invalid when attaching/listing existing runs, so this guide needs to document that new wizard option and its limits.
- ⚠️ `docs/src/content/docs/concepts/pipeline.md:81` - The pipeline concept page says specific steps can only be skipped per-run from the TUI. That is now stale because steps can also be pre-skipped when starting a run with bare `no-mistakes --skip` or with the Git push option `no-mistakes.skip=...`. Update the configurability section to include these per-run start mechanisms while preserving that permanent step skipping is not configurable.
- ⚠️ `docs/src/content/docs/reference/pipeline-steps.md:12` - The step reference describes skips as user-initiated or automatic, and the status table later repeats that meaning. The new executor path marks steps as `skipped` before execution when requested through CLI or Git push options, so this reference should add that explicit skip source to avoid stale semantics for the `skipped` status.
- ⚠️ `docs/src/content/docs/concepts/gate-model.md:85` - The gate model&#39;s post-receive hook description says the hook calls `no-mistakes daemon notify-push` with only the gate path, ref name, and old/new SHAs. The hook now also forwards Git push options so `no-mistakes.skip=...` can reach the daemon, and `init`/daemon migration enable `receive.advertisePushOptions` on gate repos. Update this architecture section to document push-option forwarding and gate push-option support.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `docs/src/content/docs/concepts/daemon.md:87` - The daemon crash recovery section says startup only reapplies gate hook-path isolation for existing bare repos. The change also makes daemon startup enable `receive.advertisePushOptions` for older gate repos so `git push -o no-mistakes.skip=...` works after upgrade, so this recovery list is now incomplete and should document the push-options migration.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
