### PR TITLE
fix(daemon): refresh managed hooks during recovery

### DIFF
--- a/docs/src/content/docs/concepts/daemon.md
+++ b/docs/src/content/docs/concepts/daemon.md
@@ -84,6 +84,7 @@ On startup, the daemon checks for runs that were left in `pending` or `running` 
 - Marks those runs as `failed` with the message "daemon crashed during execution"
 - Reaps orphaned managed agent servers left behind by a crashed daemon or setup wizard
 - Removes any orphaned worktree directories via `git worktree remove --force`
+- Refreshes legacy no-mistakes-managed `post-receive` hooks, installs missing managed hooks, and leaves custom hooks untouched
 - Reapplies per-worktree gate hook-path isolation to existing bare repos when Git supports `config --worktree`, so shared `core.hookspath` writes cannot disable `post-receive`
 - Enables Git push-option support on existing gate repos so per-push options like `no-mistakes.skip=...` keep working after upgrades
 

--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -114,7 +114,7 @@ it was started from the same executable path and aborts if the daemon
 executable path cannot be determined or points to a different binary. You can
 also manage it explicitly with `no-mistakes daemon start|stop|restart|status`.
 
-On startup, the daemon recovers from crashes by marking any stuck runs as failed, reaping orphaned managed agent servers, cleaning up orphaned worktrees, enabling push options for older gate repos, and reapplying gate hook-path isolation when Git supports `config --worktree`.
+On startup, the daemon recovers from crashes by marking any stuck runs as failed, reaping orphaned managed agent servers, cleaning up orphaned worktrees, refreshing legacy no-mistakes-managed `post-receive` hooks, enabling push options for older gate repos, and reapplying gate hook-path isolation when Git supports `config --worktree`.
 
 ### Pipeline executor
 

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -133,6 +133,7 @@ ls -la <gate-path>/hooks/post-receive
 ```
 
 The hook should be executable. If it's missing or non-executable, `no-mistakes init` will reinstall it.
+For existing gate repos, `no-mistakes daemon restart` also installs missing no-mistakes-managed hooks and refreshes legacy managed hooks without overwriting custom hooks.
 
 Also check `<gate-path>/notify-push.log`. The hook now appends daemon notification failures there and prints the same error back to the pushing client.
 
@@ -140,7 +141,8 @@ Also check `<gate-path>/notify-push.log`. The hook now appends daemon notificati
 
 The hook talks to the daemon over `~/.no-mistakes/socket`. If the daemon isn't running, the push still succeeds (the hook never blocks), but no pipeline starts. Start the daemon and push again.
 
-If the gate is older, restarting the daemon also reapplies hook-path isolation for existing bare repos when Git supports `config --worktree`. That protects the gate hook if a tool such as Husky wrote `core.hookspath` into shared git config from inside a linked worktree.
+If the gate is older, restarting the daemon also reapplies hook-path isolation for existing bare repos when Git supports `config --worktree`.
+That protects the gate hook if a tool such as Husky wrote `core.hookspath` into shared git config from inside a linked worktree.
 
 ## PR step is skipped
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -297,13 +297,14 @@ func recoverOnStartup(d *db.DB, p *paths.Paths) {
 	}
 }
 
-// migrateGateConfigs walks every bare repo under p.ReposDir() and applies
+// migrateGateConfigs walks every bare repo under p.ReposDir() and refreshes
+// no-mistakes-managed post-receive hooks, enables push options, and applies
 // git.IsolateHooksPath. The operation is idempotent: bare repos already
-// configured by gate.Init are left effectively unchanged. Older bare repos
-// (from before issue #122 was fixed) best-effort get their per-worktree
-// hookspath pinned when Git supports config --worktree, so subsequent
-// husky-style writes to shared local config can no longer disable the
-// post-receive hook.
+// configured by gate.Init are left effectively unchanged, and custom hooks are
+// preserved. Older bare repos (from before issue #122 was fixed) best-effort
+// get their managed hook updated and per-worktree hookspath pinned when Git
+// supports config --worktree, so subsequent husky-style writes to shared local
+// config can no longer disable the post-receive hook.
 func migrateGateConfigs(ctx context.Context, p *paths.Paths) {
 	entries, err := os.ReadDir(p.ReposDir())
 	if err != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -315,6 +315,9 @@ func migrateGateConfigs(ctx context.Context, p *paths.Paths) {
 			continue
 		}
 		bareDir := filepath.Join(p.ReposDir(), entry.Name())
+		if _, err := git.RefreshManagedPostReceiveHook(bareDir); err != nil {
+			slog.Warn("refresh gate post-receive hook failed", "bare", bareDir, "error", err)
+		}
 		if _, err := git.Run(ctx, bareDir, "config", "receive.advertisePushOptions", "true"); err != nil {
 			slog.Warn("enable gate push options failed", "bare", bareDir, "error", err)
 		}

--- a/internal/daemon/subscribe_recover_test.go
+++ b/internal/daemon/subscribe_recover_test.go
@@ -442,3 +442,51 @@ func TestRecoverIsolatesGateRepoHooksPath(t *testing.T) {
 		t.Fatalf("receive.advertisePushOptions = %q, want true", got)
 	}
 }
+
+func TestRecoverRefreshesLegacyManagedGateHook(t *testing.T) {
+	tmpDir := t.TempDir()
+	p := paths.WithRoot(tmpDir)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+
+	bareDir := p.RepoDir("legacy-repo")
+	ctx := context.Background()
+	if err := gitpkg.InitBare(ctx, bareDir); err != nil {
+		t.Fatal(err)
+	}
+	hookPath := filepath.Join(bareDir, "hooks", "post-receive")
+	legacyHook := `#!/bin/sh
+# no-mistakes post-receive hook
+# Notify daemon of push. Non-blocking - push always succeeds.
+NM_BIN='/usr/local/bin/no-mistakes'
+while read oldrev newrev refname; do
+  NM_HOOK_HELPER=1 "$NM_BIN" daemon notify-push \
+    --gate "$(pwd)" \
+    --ref "$refname" \
+    --old "$oldrev" \
+    --new "$newrev" >/dev/null 2>&1 || true
+done
+exit 0
+`
+	if err := os.WriteFile(hookPath, []byte(legacyHook), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	migrateGateConfigs(ctx, p)
+
+	data, err := os.ReadFile(hookPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "GIT_PUSH_OPTION_COUNT") {
+		t.Fatalf("migrated hook should forward git push options, got:\n%s", content)
+	}
+	if !strings.Contains(content, "--push-option") {
+		t.Fatalf("migrated hook should pass push options to notify-push, got:\n%s", content)
+	}
+	if strings.Contains(content, ">/dev/null 2>&1 || true") {
+		t.Fatalf("migrated hook should not silently swallow notify-push errors, got:\n%s", content)
+	}
+}

--- a/internal/git/hook.go
+++ b/internal/git/hook.go
@@ -85,6 +85,11 @@ func shellSingleQuote(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }
 
+func isManagedPostReceiveHook(content []byte) bool {
+	text := string(content)
+	return strings.Contains(text, "# no-mistakes post-receive hook") && strings.Contains(text, "daemon notify-push")
+}
+
 // InstallPostReceiveHook writes the post-receive hook script into
 // the hooks directory of a bare repo at bareDir.
 func InstallPostReceiveHook(bareDir string) error {
@@ -93,7 +98,55 @@ func InstallPostReceiveHook(bareDir string) error {
 		return err
 	}
 	hookPath := filepath.Join(hooksDir, "post-receive")
-	return os.WriteFile(hookPath, []byte(PostReceiveHookScript()), 0o755)
+	return writeHookFileAtomic(hookPath, []byte(PostReceiveHookScript()))
+}
+
+// RefreshManagedPostReceiveHook updates an existing no-mistakes-owned hook.
+// Custom hooks are left untouched; missing hooks are installed for gate repos.
+func RefreshManagedPostReceiveHook(bareDir string) (bool, error) {
+	hooksDir := filepath.Join(bareDir, "hooks")
+	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
+		return false, err
+	}
+	hookPath := filepath.Join(hooksDir, "post-receive")
+	desired := []byte(PostReceiveHookScript())
+	existing, err := os.ReadFile(hookPath)
+	if err == nil {
+		if string(existing) == string(desired) {
+			return false, nil
+		}
+		if !isManagedPostReceiveHook(existing) {
+			return false, nil
+		}
+	} else if !os.IsNotExist(err) {
+		return false, err
+	}
+	if err := writeHookFileAtomic(hookPath, desired); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func writeHookFileAtomic(path string, content []byte) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".post-receive-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0o755); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
 }
 
 // IsolateHooksPath protects the gate's post-receive hook from being

--- a/internal/git/hook_test.go
+++ b/internal/git/hook_test.go
@@ -198,6 +198,57 @@ func TestInstallPostReceiveHook(t *testing.T) {
 	}
 }
 
+func TestRefreshManagedPostReceiveHookPreservesCustomHook(t *testing.T) {
+	ctx := context.Background()
+	bare := filepath.Join(t.TempDir(), "test.git")
+	if err := InitBare(ctx, bare); err != nil {
+		t.Fatal(err)
+	}
+	hookPath := filepath.Join(bare, "hooks", "post-receive")
+	custom := "#!/bin/sh\necho custom hook\n"
+	if err := os.WriteFile(hookPath, []byte(custom), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := RefreshManagedPostReceiveHook(bare)
+	if err != nil {
+		t.Fatalf("RefreshManagedPostReceiveHook: %v", err)
+	}
+	if changed {
+		t.Fatal("custom hook should not be overwritten")
+	}
+	data, err := os.ReadFile(hookPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != custom {
+		t.Fatalf("custom hook changed to:\n%s", data)
+	}
+}
+
+func TestRefreshManagedPostReceiveHookInstallsMissingHook(t *testing.T) {
+	ctx := context.Background()
+	bare := filepath.Join(t.TempDir(), "test.git")
+	if err := InitBare(ctx, bare); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := RefreshManagedPostReceiveHook(bare)
+	if err != nil {
+		t.Fatalf("RefreshManagedPostReceiveHook: %v", err)
+	}
+	if !changed {
+		t.Fatal("missing managed hook should be installed")
+	}
+	info, err := os.Stat(filepath.Join(bare, "hooks", "post-receive"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.GOOS != "windows" && info.Mode()&0o111 == 0 {
+		t.Fatalf("hook should be executable, got mode %v", info.Mode())
+	}
+}
+
 // TestPostReceiveHook_SurfacesNotifyFailures covers issue #122 defect 2:
 // when notify-push fails (daemon down, missing-hook state, etc.), the user
 // must see the failure on stderr instead of getting a clean-looking push.


### PR DESCRIPTION
## Summary
- Refresh or reinstall no-mistakes-managed gate `post-receive` hooks during daemon recovery so existing repos get updated push option and notify-push behavior.
- Preserve custom hooks while isolating gate repo hook paths and covering legacy or missing managed hook cases with daemon and git tests.
- Update daemon, gate model, and troubleshooting docs to describe startup repair for managed hooks.

## Risk Assessment

✅ Low: The change is narrowly scoped to refreshing no-mistakes-managed post-receive hooks during daemon recovery and uses ownership detection to avoid overwriting custom hooks.

## Testing

- Summary: Exercised the new managed post-receive hook refresh behavior, daemon recovery migration path, and surrounding affected package tests with race detection; all selected tests passed.
- `go test ./internal/git -run 'Test(RefreshManagedPostReceiveHook|InstallPostReceiveHook|PostReceiveHook)' -count=1`
- `go test ./internal/daemon -run 'TestRecover(RefreshesLegacyManagedGateHook|IsolatesGateRepoHooksPath)' -count=1`
- `go test ./internal/git -count=1`
- `go test ./internal/daemon -count=1`
- `go test -race ./internal/git ./internal/daemon -count=1`
- Outcome: ✅ passed across 1 run (1m22s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/git -run 'Test(RefreshManagedPostReceiveHook|InstallPostReceiveHook|PostReceiveHook)' -count=1`
- `go test ./internal/daemon -run 'TestRecover(RefreshesLegacyManagedGateHook|IsolatesGateRepoHooksPath)' -count=1`
- `go test ./internal/git -count=1`
- `go test ./internal/daemon -count=1`
- `go test -race ./internal/git ./internal/daemon -count=1`

</details>

<details>
<summary>🔧 **Document** - 4 issues found → auto-fixed</summary>

**Round 1** - found 4 warnings
- ⚠️ `internal/daemon/daemon.go:300` - The `migrateGateConfigs` doc comment still says daemon startup migration only applies hook-path isolation, but the implementation now also refreshes no-mistakes-managed post-receive hooks and installs missing managed hooks for existing gate repos. Update the comment so internal docs match the new migration behavior.
- ⚠️ `docs/src/content/docs/concepts/daemon.md:80` - The Crash recovery section lists startup recovery tasks but omits the new behavior that existing gate repos have their no-mistakes-managed post-receive hook refreshed or reinstalled. This should mention that legacy managed hooks are upgraded so push options and notify-push error reporting work after daemon restart, while custom hooks are left untouched.
- ⚠️ `docs/src/content/docs/concepts/gate-model.md:117` - The daemon startup recovery summary is stale: it mentions enabling push options and reapplying hook-path isolation for older gate repos, but not refreshing legacy no-mistakes-managed post-receive hooks. Update it to include the new managed hook refresh/reinstall behavior.
- ⚠️ `docs/src/content/docs/guides/troubleshooting.md:135` - The troubleshooting guide says a missing or non-executable gate hook is fixed by running `no-mistakes init`, but the change adds daemon-startup repair for missing no-mistakes-managed hooks and refreshes legacy managed hooks. Update this section so users know `no-mistakes daemon restart` can repair or refresh managed gate hooks and that custom hooks are preserved.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
