### PR TITLE
feat(cli): add usage stats command

### DIFF
--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -96,6 +96,16 @@ no-mistakes runs [--limit <n>]
 
 Shows runs newest-first with branch, status (styled), short SHA, timestamp, and PR URL if set.
 
+## no-mistakes stats
+
+Show historical usage stats across all repos.
+
+```sh
+no-mistakes stats
+```
+
+Displays total changes, rescued changes, rescue rate, reported and fixed mistakes, fixes by pipeline step, and the top repos by rescue activity.
+
 ## no-mistakes doctor
 
 Check system health and dependencies.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -62,6 +62,7 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(newRerunCmd())
 	cmd.AddCommand(newStatusCmd())
 	cmd.AddCommand(newRunsCmd())
+	cmd.AddCommand(newStatsCmd())
 	cmd.AddCommand(newDoctorCmd())
 
 	return cmd

--- a/internal/cli/stats.go
+++ b/internal/cli/stats.go
@@ -1,0 +1,232 @@
+package cli
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+	"github.com/spf13/cobra"
+)
+
+const (
+	statsBoxWidth     = 61
+	statsContentWidth = statsBoxWidth - 4
+	statsBarWidth     = 30
+	statsRepoBarWidth = 10
+)
+
+func newStatsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "stats",
+		Short: "Show historical no-mistakes usage stats",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return trackCommand("stats", func() error {
+				_, database, err := openResources()
+				if err != nil {
+					return err
+				}
+				defer database.Close()
+
+				stats, err := database.GetStats()
+				if err != nil {
+					return fmt.Errorf("get stats: %w", err)
+				}
+
+				fmt.Fprintln(cmd.OutOrStdout(), renderStatsDashboard(stats))
+				return nil
+			})
+		},
+	}
+}
+
+func renderStatsDashboard(stats *db.Stats) string {
+	var lines []string
+	lines = append(lines, "")
+	lines = append(lines, centeredStatsBlock(strings.Split(banner, "\n"))...)
+	lines = append(lines, "", "")
+
+	rescueRate := ratio(stats.RescueRuns, stats.TotalRuns)
+	fixRate := ratio(stats.FixedFindings, stats.ReportedFindings)
+	repoDetail := "across all repos"
+	if stats.TotalRepos > 0 {
+		repoDetail = fmt.Sprintf("across %d repos", stats.TotalRepos)
+	}
+	lines = append(lines,
+		metricStatsLine("Total changes", fmt.Sprintf("%d", stats.TotalRuns), repoDetail),
+		metricStatsLine("Rescued changes", fmt.Sprintf("%d", stats.RescueRuns), "mistake caught + fixed"),
+		metricStatsLine("Rescue rate", percent(rescueRate), progressBar(rescueRate, statsBarWidth)),
+		"",
+		"  Mistakes",
+		metricStatsLine("Reported", fmt.Sprintf("%d", stats.ReportedFindings), progressBar(1, statsBarWidth)),
+		metricStatsLine("Fixed", percent(fixRate), progressBar(fixRate, statsBarWidth)),
+		"",
+		"  Fixes by step",
+	)
+
+	maxStepFixes := maxStepFixedFindings(stats.StepStats)
+	for _, step := range pipelineOrderedStepStats(stats.StepStats) {
+		if step.FixedFindings == 0 {
+			continue
+		}
+		lines = append(lines, metricStatsLine(string(step.StepName), fmt.Sprintf("%d", step.FixedFindings), progressBar(ratio(step.FixedFindings, maxStepFixes), statsBarWidth)))
+	}
+
+	lines = append(lines, "", "  Top repos")
+	maxRepoFixes := maxRepoFixedFindings(stats.RepoStats)
+	repoCount := 0
+	for _, repo := range stats.RepoStats {
+		if repo.Runs == 0 {
+			continue
+		}
+		lines = append(lines, repoStatsLine(repo, maxRepoFixes))
+		repoCount++
+		if repoCount == 3 {
+			break
+		}
+	}
+	if repoCount == 0 {
+		lines = append(lines, "  no runs yet")
+	}
+	lines = append(lines, "")
+
+	return renderStatsBox(lines)
+}
+
+func renderStatsBox(lines []string) string {
+	var b strings.Builder
+	b.WriteString("╭" + strings.Repeat("─", statsBoxWidth-2) + "╮\n")
+	for _, line := range lines {
+		b.WriteString(renderStatsBoxLine(line))
+		b.WriteByte('\n')
+	}
+	b.WriteString("╰" + strings.Repeat("─", statsBoxWidth-2) + "╯")
+	return b.String()
+}
+
+func renderStatsBoxLine(line string) string {
+	width := lipgloss.Width(line)
+	if width > statsContentWidth {
+		line = truncateStatsLine(line, statsContentWidth)
+		width = lipgloss.Width(line)
+	}
+	return "│ " + line + strings.Repeat(" ", statsContentWidth-width) + " │"
+}
+
+func centerStatsLine(line string) string {
+	width := lipgloss.Width(line)
+	if width >= statsContentWidth {
+		return line
+	}
+	return strings.Repeat(" ", (statsContentWidth-width)/2) + line
+}
+
+func centeredStatsBlock(lines []string) []string {
+	maxWidth := 0
+	for _, line := range lines {
+		if width := lipgloss.Width(line); width > maxWidth {
+			maxWidth = width
+		}
+	}
+	if maxWidth >= statsContentWidth {
+		return lines
+	}
+	indent := strings.Repeat(" ", (statsContentWidth-maxWidth)/2)
+	centered := make([]string, 0, len(lines))
+	for _, line := range lines {
+		centered = append(centered, indent+sCyan.Render(line))
+	}
+	return centered
+}
+
+func metricStatsLine(label, value, detail string) string {
+	return fmt.Sprintf("  %-16s %5s   %s", label, value, detail)
+}
+
+func repoStatsLine(repo db.RepoStats, maxFixes int) string {
+	name := truncateStatsLine(repo.DisplayName(), 16)
+	return fmt.Sprintf("  %-16s %5d rescue %5d fixes   %s", name, repo.RescueRuns, repo.FixedFindings, progressBar(ratio(repo.FixedFindings, maxFixes), statsRepoBarWidth))
+}
+
+func progressBar(value float64, width int) string {
+	if value < 0 {
+		value = 0
+	}
+	if value > 1 {
+		value = 1
+	}
+	filled := int(math.Round(value * float64(width)))
+	if filled > width {
+		filled = width
+	}
+	return sGreen.Render(strings.Repeat("█", filled)) + sDim.Render(strings.Repeat("░", width-filled))
+}
+
+func percent(value float64) string {
+	return fmt.Sprintf("%d%%", int(math.Round(value*100)))
+}
+
+func ratio(value, total int) float64 {
+	if total <= 0 {
+		return 0
+	}
+	return float64(value) / float64(total)
+}
+
+func maxStepFixedFindings(stats []db.StepStats) int {
+	maxValue := 0
+	for _, stat := range stats {
+		if stat.FixedFindings > maxValue {
+			maxValue = stat.FixedFindings
+		}
+	}
+	return maxValue
+}
+
+func pipelineOrderedStepStats(stats []db.StepStats) []db.StepStats {
+	byStep := make(map[types.StepName]db.StepStats, len(stats))
+	for _, stat := range stats {
+		byStep[stat.StepName] = stat
+	}
+	ordered := make([]db.StepStats, 0, len(stats))
+	seen := make(map[types.StepName]bool, len(stats))
+	for _, step := range types.AllSteps() {
+		stat, ok := byStep[step]
+		if !ok {
+			continue
+		}
+		ordered = append(ordered, stat)
+		seen[step] = true
+	}
+	for _, stat := range stats {
+		if seen[stat.StepName] {
+			continue
+		}
+		ordered = append(ordered, stat)
+	}
+	return ordered
+}
+
+func maxRepoFixedFindings(stats []db.RepoStats) int {
+	maxValue := 0
+	for _, stat := range stats {
+		if stat.FixedFindings > maxValue {
+			maxValue = stat.FixedFindings
+		}
+	}
+	return maxValue
+}
+
+func truncateStatsLine(value string, width int) string {
+	if lipgloss.Width(value) <= width {
+		return value
+	}
+	runes := []rune(value)
+	for len(runes) > 0 && lipgloss.Width(string(runes)) > width {
+		runes = runes[:len(runes)-1]
+	}
+	return string(runes)
+}

--- a/internal/cli/stats.go
+++ b/internal/cli/stats.go
@@ -61,7 +61,7 @@ func renderStatsDashboard(stats *db.Stats) string {
 		metricStatsLine("Rescue rate", percent(rescueRate), progressBar(rescueRate, statsBarWidth)),
 		"",
 		"  Mistakes",
-		metricStatsLine("Reported", fmt.Sprintf("%d", stats.ReportedFindings), progressBar(1, statsBarWidth)),
+		metricStatsLine("Reported", fmt.Sprintf("%d", stats.ReportedFindings), progressBar(ratio(stats.ReportedFindings, stats.ReportedFindings), statsBarWidth)),
 		metricStatsLine("Fixed", percent(fixRate), progressBar(fixRate, statsBarWidth)),
 		"",
 		"  Fixes by step",

--- a/internal/cli/stats_test.go
+++ b/internal/cli/stats_test.go
@@ -180,6 +180,14 @@ func TestStatsDashboardFixedPercentMovesIntoValueColumnAndBarsReachRightEdge(t *
 	}
 }
 
+func TestStatsDashboardReportedBarIsEmptyWhenNoFindingsReported(t *testing.T) {
+	out := renderStatsDashboard(&db.Stats{})
+	line := findLineContaining(t, strings.Split(out, "\n"), "Reported")
+	if strings.Contains(line, "█") {
+		t.Fatalf("reported row should not show filled progress for zero findings:\n%s", out)
+	}
+}
+
 func insertRound(t *testing.T, database *db.DB, stepID string, round int, trigger string, findings *string) {
 	t.Helper()
 	if _, err := database.InsertStepRound(stepID, round, trigger, findings, nil, 100); err != nil {

--- a/internal/cli/stats_test.go
+++ b/internal/cli/stats_test.go
@@ -1,0 +1,218 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+	"github.com/muesli/termenv"
+)
+
+func TestStatsCommandRendersAllRepoDashboard(t *testing.T) {
+	nmHome := makeSocketSafeTempDir(t)
+	t.Setenv("NM_HOME", nmHome)
+	p := paths.WithRoot(nmHome)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	database, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+
+	repoA, _ := database.InsertRepo("/work/alpha", "git@example.com:alpha.git", "main")
+	repoB, _ := database.InsertRepo("/work/beta", "git@example.com:beta.git", "main")
+
+	runA, _ := database.InsertRun(repoA.ID, "feature-a", "head-a", "base-a")
+	reviewA, _ := database.InsertStepResult(runA.ID, types.StepReview)
+	reviewAInitial := `{"findings":[{"id":"r1","severity":"warning","description":"one","action":"auto-fix"},{"id":"r2","severity":"warning","description":"two","action":"auto-fix"},{"id":"r3","severity":"warning","description":"three","action":"auto-fix"}],"summary":"three","risk_level":"medium","risk_rationale":"test"}`
+	reviewAFinal := `{"findings":[{"id":"r3","severity":"warning","description":"three","action":"ask-user"}],"summary":"one left","risk_level":"medium","risk_rationale":"test"}`
+	insertRound(t, database, reviewA.ID, 1, "initial", &reviewAInitial)
+	insertRound(t, database, reviewA.ID, 2, "auto_fix", &reviewAFinal)
+
+	lintA, _ := database.InsertStepResult(runA.ID, types.StepLint)
+	lintAInitial := `{"findings":[{"id":"l1","severity":"error","description":"lint","action":"auto-fix"}],"summary":"one","risk_level":"low","risk_rationale":"test"}`
+	insertRound(t, database, lintA.ID, 1, "initial", &lintAInitial)
+	insertRound(t, database, lintA.ID, 2, "auto_fix", nil)
+
+	runB, _ := database.InsertRun(repoB.ID, "feature-b", "head-b", "base-b")
+	testB, _ := database.InsertStepResult(runB.ID, types.StepTest)
+	testBInitial := `{"findings":[{"id":"t1","severity":"error","description":"test","action":"ask-user"}],"summary":"one","risk_level":"low","risk_rationale":"test"}`
+	insertRound(t, database, testB.ID, 1, "initial", &testBInitial)
+
+	out, err := executeCmd("stats")
+	if err != nil {
+		t.Fatalf("stats command: %v\n%s", err, out)
+	}
+
+	for _, want := range []string{
+		"╭────────────────",
+		"_  _ ____    _  _ _ ____ ___ ____ _  _ ____ ____",
+		"Total changes",
+		"Rescued changes",
+		"Rescue rate",
+		"50%",
+		"Mistakes",
+		"Reported",
+		"Fixed",
+		"Fixes by step",
+		"review",
+		"lint",
+		"Top repos",
+		"alpha",
+		"3 fixes",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stats output missing %q:\n%s", want, out)
+		}
+	}
+	assertOrder(t, out, "Total changes", "Rescued changes", "Rescue rate", "Mistakes", "Reported", "Fixed")
+	for _, notWant := range []string{"Saved", "Rescue runs", "Mistakes fixed", "auto-fix", "caught in review", "╭─ no-mistakes"} {
+		if strings.Contains(out, notWant) {
+			t.Fatalf("stats output should not contain %q:\n%s", notWant, out)
+		}
+	}
+}
+
+func TestStatsDashboardCapsTopReposAndUsesPipelineStepOrder(t *testing.T) {
+	stats := &db.Stats{
+		TotalRuns:        4,
+		RescueRuns:       4,
+		ReportedFindings: 12,
+		FixedFindings:    12,
+		StepStats: []db.StepStats{
+			{StepName: types.StepLint, FixedFindings: 3},
+			{StepName: types.StepReview, FixedFindings: 1},
+			{StepName: types.StepDocument, FixedFindings: 4},
+			{StepName: types.StepTest, FixedFindings: 2},
+		},
+		RepoStats: []db.RepoStats{
+			{WorkingPath: "/repos/one", Runs: 1, RescueRuns: 1, FixedFindings: 4},
+			{WorkingPath: "/repos/two", Runs: 1, RescueRuns: 1, FixedFindings: 3},
+			{WorkingPath: "/repos/three", Runs: 1, RescueRuns: 1, FixedFindings: 2},
+			{WorkingPath: "/repos/four", Runs: 1, RescueRuns: 1, FixedFindings: 1},
+		},
+	}
+	out := renderStatsDashboard(stats)
+
+	assertOrder(t, out, "review", "test", "document", "lint")
+	for _, want := range []string{"one", "two", "three"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stats output missing top repo %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "four") {
+		t.Fatalf("stats output should cap top repos at 3:\n%s", out)
+	}
+}
+
+func TestStatsDashboardCentersBannerAsBlock(t *testing.T) {
+	out := renderStatsDashboard(&db.Stats{})
+	lines := strings.Split(out, "\n")
+	var bannerLines []string
+	for _, line := range lines {
+		if strings.Contains(line, "_  _ ____") || strings.Contains(line, `|\ | |  |`) || strings.Contains(line, `| \| |__|`) {
+			bannerLines = append(bannerLines, strings.TrimSuffix(strings.TrimPrefix(line, "│ "), " │"))
+		}
+	}
+	if len(bannerLines) != 3 {
+		t.Fatalf("found %d banner lines, want 3:\n%s", len(bannerLines), out)
+	}
+
+	indent := leadingSpaces(bannerLines[0])
+	for _, line := range bannerLines[1:] {
+		if got := leadingSpaces(line); got != indent {
+			t.Fatalf("banner line indent = %d, want %d:\n%s", got, indent, out)
+		}
+	}
+}
+
+func TestStatsDashboardStylesBannerAndProgressBars(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.ANSI)
+	out := renderStatsDashboard(&db.Stats{TotalRuns: 1, RescueRuns: 1, ReportedFindings: 2, FixedFindings: 1})
+	if !strings.Contains(out, sCyan.Render("_  _ ____    _  _ _ ____ ___ ____ _  _ ____ ____")) {
+		t.Fatalf("stats banner should be cyan:\n%s", out)
+	}
+	if !strings.Contains(out, "\x1b[32m") {
+		t.Fatalf("stats progress bars should use green filled segments:\n%s", out)
+	}
+	if !strings.Contains(out, "\x1b[90m") {
+		t.Fatalf("stats progress bars should use dim empty segments:\n%s", out)
+	}
+}
+
+func TestStatsDashboardAddsMarginAboveBottomBorder(t *testing.T) {
+	out := renderStatsDashboard(&db.Stats{})
+	lines := strings.Split(out, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("stats output too short:\n%s", out)
+	}
+	if got := lines[len(lines)-2]; strings.TrimSpace(strings.Trim(got, "│")) != "" {
+		t.Fatalf("line above bottom border should be blank, got %q:\n%s", got, out)
+	}
+}
+
+func TestStatsDashboardFixedPercentMovesIntoValueColumnAndBarsReachRightEdge(t *testing.T) {
+	stats := &db.Stats{
+		TotalRuns:        1,
+		RescueRuns:       1,
+		ReportedFindings: 5,
+		FixedFindings:    4,
+		RepoStats: []db.RepoStats{
+			{WorkingPath: "/repos/one", Runs: 1, RescueRuns: 1, FixedFindings: 4},
+		},
+	}
+	out := renderStatsDashboard(stats)
+	lines := strings.Split(out, "\n")
+	fixedLine := findLineContaining(t, lines, "Fixed")
+	if !strings.Contains(fixedLine, "Fixed              80%") {
+		t.Fatalf("fixed row should show percent in the value column:\n%s", out)
+	}
+	if strings.Count(fixedLine, "80%") != 1 {
+		t.Fatalf("fixed row should not repeat percent after the bar:\n%s", out)
+	}
+	if barEnd := lipgloss.Width(fixedLine) - 3; barEnd != statsContentWidth+1 {
+		t.Fatalf("fixed bar should reach right edge, got end %d want %d:\n%s", barEnd, statsContentWidth+1, out)
+	}
+}
+
+func insertRound(t *testing.T, database *db.DB, stepID string, round int, trigger string, findings *string) {
+	t.Helper()
+	if _, err := database.InsertStepRound(stepID, round, trigger, findings, nil, 100); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func findLineContaining(t *testing.T, lines []string, needle string) string {
+	t.Helper()
+	for _, line := range lines {
+		if strings.Contains(line, needle) {
+			return line
+		}
+	}
+	t.Fatalf("missing line containing %q", needle)
+	return ""
+}
+
+func leadingSpaces(value string) int {
+	return len(value) - len(strings.TrimLeft(value, " "))
+}
+
+func assertOrder(t *testing.T, value string, ordered ...string) {
+	t.Helper()
+	last := -1
+	for _, item := range ordered {
+		idx := strings.Index(value, item)
+		if idx == -1 {
+			t.Fatalf("missing %q in:\n%s", item, value)
+		}
+		if idx <= last {
+			t.Fatalf("%q appeared out of order in:\n%s", item, value)
+		}
+		last = idx
+	}
+}

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -1,0 +1,203 @@
+package db
+
+import (
+	"fmt"
+	"path/filepath"
+	"slices"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// Stats summarizes historical no-mistakes usage across all repositories.
+type Stats struct {
+	TotalRepos       int
+	TotalRuns        int
+	PullRequests     int
+	RescueRuns       int
+	ReportedFindings int
+	FixedFindings    int
+	StepStats        []StepStats
+	RepoStats        []RepoStats
+}
+
+// StepStats summarizes reported and fixed findings for one pipeline step.
+type StepStats struct {
+	StepName         types.StepName
+	ReportedFindings int
+	FixedFindings    int
+}
+
+// RepoStats summarizes historical usage for one repository.
+type RepoStats struct {
+	RepoID           string
+	WorkingPath      string
+	Runs             int
+	RescueRuns       int
+	ReportedFindings int
+	FixedFindings    int
+}
+
+// DisplayName returns a compact repository name for terminal reports.
+func (r RepoStats) DisplayName() string {
+	name := filepath.Base(r.WorkingPath)
+	if name == "." || name == string(filepath.Separator) || name == "" {
+		return r.WorkingPath
+	}
+	return name
+}
+
+// GetStats aggregates historical usage across all repositories.
+func (d *DB) GetStats() (*Stats, error) {
+	repos, err := d.getRepos()
+	if err != nil {
+		return nil, err
+	}
+
+	stats := &Stats{TotalRepos: len(repos)}
+	stepStats := map[types.StepName]*StepStats{}
+
+	for _, repo := range repos {
+		repoStats := RepoStats{RepoID: repo.ID, WorkingPath: repo.WorkingPath}
+		runs, err := d.GetRunsByRepo(repo.ID)
+		if err != nil {
+			return nil, err
+		}
+		repoStats.Runs = len(runs)
+		stats.TotalRuns += len(runs)
+
+		for _, run := range runs {
+			if run.PRURL != nil && *run.PRURL != "" {
+				stats.PullRequests++
+			}
+
+			runReported, runFixed, err := d.aggregateRunStats(run.ID, stepStats)
+			if err != nil {
+				return nil, err
+			}
+			stats.ReportedFindings += runReported
+			stats.FixedFindings += runFixed
+			repoStats.ReportedFindings += runReported
+			repoStats.FixedFindings += runFixed
+			if runReported > 0 && runFixed > 0 {
+				stats.RescueRuns++
+				repoStats.RescueRuns++
+			}
+		}
+
+		stats.RepoStats = append(stats.RepoStats, repoStats)
+	}
+
+	for _, step := range stepStats {
+		if step.ReportedFindings == 0 && step.FixedFindings == 0 {
+			continue
+		}
+		stats.StepStats = append(stats.StepStats, *step)
+	}
+	sortStepStats(stats.StepStats)
+	sortRepoStats(stats.RepoStats)
+
+	return stats, nil
+}
+
+func (d *DB) aggregateRunStats(runID string, stepStats map[types.StepName]*StepStats) (int, int, error) {
+	steps, err := d.GetStepsByRun(runID)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	runReported := 0
+	runFixed := 0
+	for _, step := range steps {
+		rounds, err := d.GetRoundsByStep(step.ID)
+		if err != nil {
+			return 0, 0, err
+		}
+		reported, final := stepFindingCounts(step, rounds)
+		fixed := reported - final
+		if fixed < 0 {
+			fixed = 0
+		}
+
+		runReported += reported
+		runFixed += fixed
+		stat := stepStats[step.StepName]
+		if stat == nil {
+			stat = &StepStats{StepName: step.StepName}
+			stepStats[step.StepName] = stat
+		}
+		stat.ReportedFindings += reported
+		stat.FixedFindings += fixed
+	}
+
+	return runReported, runFixed, nil
+}
+
+func stepFindingCounts(step *StepResult, rounds []*StepRound) (reported int, final int) {
+	if len(rounds) == 0 {
+		count := findingsCount(step.FindingsJSON)
+		return count, count
+	}
+	return findingsCount(rounds[0].FindingsJSON), findingsCount(rounds[len(rounds)-1].FindingsJSON)
+}
+
+func findingsCount(raw *string) int {
+	if raw == nil || *raw == "" {
+		return 0
+	}
+	findings, err := types.ParseFindingsJSON(*raw)
+	if err != nil {
+		return 0
+	}
+	return len(findings.Items)
+}
+
+func sortStepStats(stats []StepStats) {
+	slices.SortFunc(stats, func(a, b StepStats) int {
+		if a.FixedFindings != b.FixedFindings {
+			return b.FixedFindings - a.FixedFindings
+		}
+		if a.ReportedFindings != b.ReportedFindings {
+			return b.ReportedFindings - a.ReportedFindings
+		}
+		return a.StepName.Order() - b.StepName.Order()
+	})
+}
+
+func sortRepoStats(stats []RepoStats) {
+	slices.SortFunc(stats, func(a, b RepoStats) int {
+		if a.RescueRuns != b.RescueRuns {
+			return b.RescueRuns - a.RescueRuns
+		}
+		if a.FixedFindings != b.FixedFindings {
+			return b.FixedFindings - a.FixedFindings
+		}
+		if a.Runs != b.Runs {
+			return b.Runs - a.Runs
+		}
+		if a.WorkingPath < b.WorkingPath {
+			return -1
+		}
+		if a.WorkingPath > b.WorkingPath {
+			return 1
+		}
+		return 0
+	})
+}
+
+func (d *DB) getRepos() ([]*Repo, error) {
+	rows, err := d.sql.Query(`SELECT id, working_path, upstream_url, default_branch, created_at FROM repos ORDER BY working_path`)
+	if err != nil {
+		return nil, fmt.Errorf("get repos: %w", err)
+	}
+	defer rows.Close()
+
+	var repos []*Repo
+	for rows.Next() {
+		repo := &Repo{}
+		if err := rows.Scan(&repo.ID, &repo.WorkingPath, &repo.UpstreamURL, &repo.DefaultBranch, &repo.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan repo: %w", err)
+		}
+		repos = append(repos, repo)
+	}
+	return repos, rows.Err()
+}

--- a/internal/db/stats_test.go
+++ b/internal/db/stats_test.go
@@ -1,0 +1,112 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+func TestGetStatsAggregatesReportedFixesAndRescueRuns(t *testing.T) {
+	d := openTestDB(t)
+	repoA, _ := d.InsertRepo("/repo/a", "git@example.com:a.git", "main")
+	repoB, _ := d.InsertRepo("/repo/b", "git@example.com:b.git", "main")
+
+	runA, _ := d.InsertRun(repoA.ID, "feature-a", "head-a", "base-a")
+	reviewA, _ := d.InsertStepResult(runA.ID, types.StepReview)
+	reviewAInitial := `{"findings":[{"id":"r1","severity":"warning","description":"one","action":"auto-fix"},{"id":"r2","severity":"warning","description":"two","action":"auto-fix"},{"id":"r3","severity":"warning","description":"three","action":"auto-fix"}],"summary":"three","risk_level":"medium","risk_rationale":"test"}`
+	reviewAFinal := `{"findings":[{"id":"r3","severity":"warning","description":"three","action":"ask-user"}],"summary":"one left","risk_level":"medium","risk_rationale":"test"}`
+	if _, err := d.InsertStepRound(reviewA.ID, 1, "initial", &reviewAInitial, nil, 100); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.InsertStepRound(reviewA.ID, 2, "auto_fix", &reviewAFinal, nil, 100); err != nil {
+		t.Fatal(err)
+	}
+
+	lintA, _ := d.InsertStepResult(runA.ID, types.StepLint)
+	lintAInitial := `{"findings":[{"id":"l1","severity":"error","description":"lint","action":"auto-fix"}],"summary":"one","risk_level":"low","risk_rationale":"test"}`
+	if _, err := d.InsertStepRound(lintA.ID, 1, "initial", &lintAInitial, nil, 100); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.InsertStepRound(lintA.ID, 2, "auto_fix", nil, nil, 100); err != nil {
+		t.Fatal(err)
+	}
+
+	runB, _ := d.InsertRun(repoB.ID, "feature-b", "head-b", "base-b")
+	testB, _ := d.InsertStepResult(runB.ID, types.StepTest)
+	testBInitial := `{"findings":[{"id":"t1","severity":"error","description":"test","action":"ask-user"}],"summary":"one","risk_level":"low","risk_rationale":"test"}`
+	if _, err := d.InsertStepRound(testB.ID, 1, "initial", &testBInitial, nil, 100); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := d.GetStats()
+	if err != nil {
+		t.Fatalf("get stats: %v", err)
+	}
+
+	if stats.TotalRuns != 2 {
+		t.Fatalf("TotalRuns = %d, want 2", stats.TotalRuns)
+	}
+	if stats.RescueRuns != 1 {
+		t.Fatalf("RescueRuns = %d, want 1", stats.RescueRuns)
+	}
+	if stats.ReportedFindings != 5 {
+		t.Fatalf("ReportedFindings = %d, want 5", stats.ReportedFindings)
+	}
+	if stats.FixedFindings != 3 {
+		t.Fatalf("FixedFindings = %d, want 3", stats.FixedFindings)
+	}
+
+	assertStepStat(t, stats.StepStats, types.StepReview, 3, 2)
+	assertStepStat(t, stats.StepStats, types.StepLint, 1, 1)
+	assertStepStat(t, stats.StepStats, types.StepTest, 1, 0)
+
+	if len(stats.RepoStats) != 2 {
+		t.Fatalf("len(RepoStats) = %d, want 2", len(stats.RepoStats))
+	}
+	if stats.RepoStats[0].WorkingPath != "/repo/a" {
+		t.Fatalf("top repo = %q, want /repo/a", stats.RepoStats[0].WorkingPath)
+	}
+	if stats.RepoStats[0].RescueRuns != 1 || stats.RepoStats[0].FixedFindings != 3 {
+		t.Fatalf("top repo stats = %#v, want rescue 1 fixes 3", stats.RepoStats[0])
+	}
+}
+
+func TestGetStatsFallsBackToStepFindingsWhenRoundsAreMissing(t *testing.T) {
+	d := openTestDB(t)
+	repo, _ := d.InsertRepo("/repo/legacy", "git@example.com:legacy.git", "main")
+	run, _ := d.InsertRun(repo.ID, "legacy", "head", "base")
+	step, _ := d.InsertStepResult(run.ID, types.StepReview)
+	findings := `{"findings":[{"id":"legacy-1","severity":"warning","description":"legacy","action":"ask-user"}],"summary":"one","risk_level":"low","risk_rationale":"test"}`
+	if err := d.SetStepFindings(step.ID, findings); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := d.GetStats()
+	if err != nil {
+		t.Fatalf("get stats: %v", err)
+	}
+
+	if stats.ReportedFindings != 1 {
+		t.Fatalf("ReportedFindings = %d, want 1", stats.ReportedFindings)
+	}
+	if stats.FixedFindings != 0 {
+		t.Fatalf("FixedFindings = %d, want 0", stats.FixedFindings)
+	}
+	if stats.RescueRuns != 0 {
+		t.Fatalf("RescueRuns = %d, want 0", stats.RescueRuns)
+	}
+}
+
+func assertStepStat(t *testing.T, stats []StepStats, step types.StepName, reported int, fixes int) {
+	t.Helper()
+	for _, got := range stats {
+		if got.StepName != step {
+			continue
+		}
+		if got.ReportedFindings != reported || got.FixedFindings != fixes {
+			t.Fatalf("step %s = reported %d fixes %d, want reported %d fixes %d", step, got.ReportedFindings, got.FixedFindings, reported, fixes)
+		}
+		return
+	}
+	t.Fatalf("missing stats for step %s", step)
+}

--- a/internal/e2e/journey_test.go
+++ b/internal/e2e/journey_test.go
@@ -456,7 +456,7 @@ func assertRootHelp(t *testing.T, h *Harness) {
 	if err != nil {
 		t.Fatalf("nm --help: %v\n%s", err, out)
 	}
-	for _, want := range []string{"init", "eject", "attach", "rerun", "status", "runs", "doctor", "daemon", "update"} {
+	for _, want := range []string{"init", "eject", "attach", "rerun", "status", "runs", "stats", "doctor", "daemon", "update"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("help output should list %q command, got:\n%s", want, out)
 		}


### PR DESCRIPTION
## Intent

The developer wanted to add and refine a new `no-mistakes stats` command that reports historical usage across all repositories, especially total changes/runs, rescued changes/runs, rescue rate, mistakes reported, mistakes fixed, fixes by pipeline step, and top repos. They wanted the UI to be screenshot-worthy with the existing gate-push ASCII art centered, colored consistently with the app palette, progress bars aligned and extended cleanly, top repos capped at 3, and step breakdown ordered by pipeline order. They explicitly decided to use “runs/changes” terminology rather than “pushes” because historical data cannot distinguish push-triggered runs from reruns. They also required several display details: sentence-case labels, a “Mistakes” section heading, “Reported” and “Fixed” capitalization, no auto-fix row, no redundant top-border label, one blank row below the banner and above the bottom border, and top repo wording using “fixes”.

## What Changed

- Added `no-mistakes stats` as a top-level CLI command with a terminal dashboard for historical runs, rescued changes, rescue rate, reported/fixed mistakes, fixes by step, and top repositories.
- Added database aggregation helpers for usage statistics across repositories, including mistake counts and pipeline-step fix breakdowns.
- Documented the new stats command in the CLI reference and added CLI/database test coverage for the new behavior.

## Risk Assessment

⚠️ Medium: The change is localized to a new stats command, but stats can overstate fixes/rescues when persisted findings JSON is malformed.

## Testing

- Summary: Exercised the stats aggregation and CLI dashboard tests plus the e2e command-help journey; all relevant tests passed after retrying e2e with an appropriate timeout.
- `go test ./internal/db ./internal/cli`
- `go test -count=1 ./internal/db ./internal/cli`
- `make e2e`
- Outcome: ✅ passed across 1 run (5m25s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/cli/stats.go:64` - The Reported row always renders a full progress bar, even when ReportedFindings is 0, so a fresh or empty database displays a green full bar next to &#34;Reported 0&#34;. Gate the full bar on ReportedFindings &gt; 0 or render an empty/omitted bar for the zero case.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `internal/db/stats.go:148` - Unreadable findings JSON is silently counted as zero findings, so a run whose final round cannot be parsed is reported as fully fixed/rescued instead of unavailable. Return a parse error or otherwise exclude that step from fixed/rescue counts when parsing fails.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/db ./internal/cli`
- `go test -count=1 ./internal/db ./internal/cli`
- `make e2e`

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `docs/src/content/docs/reference/cli.md:99` - The branch adds a new public top-level `no-mistakes stats` command (`internal/cli/stats.go`) that reports historical usage across all repositories, including total/rescued changes, rescue rate, reported/fixed mistakes, fixes by step, and top repos. The CLI reference describes itself as the complete command reference but jumps from `no-mistakes runs` to `no-mistakes doctor`, so it omits this new command, its usage, and what the dashboard summarizes.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
