### PR TITLE
docs: clarify setup wizard usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ $ no-mistakes
 # opens the TUI for the active run
 ```
 
-You can also skip `git push` and run `no-mistakes` directly after making changes. The setup wizard walks you through creating a branch, committing, and pushing through the gate, then attaches if the daemon registers the new run.
+You can also skip `git push` and run `no-mistakes` directly after making changes (don't even need to commit it). You will then see a wizard TUI that walks you through creating a branch, committing, and pushing through the gate, then attaches if the daemon registers the new run.
+
+Run `no-mistakes -y` to let no-mistakes automatically create branch, commit changes and push through the gate for you.
 
 See the [quick start](https://kunchenguid.github.io/no-mistakes/start-here/quick-start/) for the full first-run walkthrough.
 


### PR DESCRIPTION
## Intent

The developer wanted to determine whether the extracted user intent is included in every agent execution throughout the pipeline, with special attention to autofix agent runs. They were specifically checking coverage across normal pipeline steps and autofix paths, and wanted to identify any agent executions where the intent is not passed through.

## What Changed

- Clarified that running `no-mistakes` directly after local changes opens the wizard TUI without requiring a prior commit.
- Documented `no-mistakes -y` as the automatic path for branch creation, committing changes, and pushing through the gate.

## Risk Assessment

✅ Low: The reviewed change is limited to README wording that matches the existing setup wizard and -y behavior, with no code or behavioral changes.

## Testing

- Summary: <code>Exercised the CLI setup wizard routing, `-y` auto-accept path, attach flow, and wizard package behavior relevant to the README setup clarification; all selected tests passed.</code>
- `go test ./internal/cli -run 'Test(RootYes|RootSkip|RootInteractiveWizard|ShouldRouteToWizard|NeedsBranch|RunWizard)' -count=1`
- `go test ./internal/wizard -count=1`
- `go test ./internal/cli -count=1`
- Outcome: ✅ passed across 1 run (1m52s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/cli -run 'Test(RootYes|RootSkip|RootInteractiveWizard|ShouldRouteToWizard|NeedsBranch|RunWizard)' -count=1`
- `go test ./internal/wizard -count=1`
- `go test ./internal/cli -count=1`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
