### PR TITLE
feat(pipeline): prefer root-cause fix prompts

### DIFF
--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -138,7 +138,7 @@ Transient API and network failures are retried up to three times with exponentia
 ## Intent extraction
 
 When `intent.enabled` is true, no-mistakes reads recent local transcripts from Claude Code, Codex, OpenCode, and Rovo Dev during the `intent` pipeline step.
-It matches sessions against the changed files, summarizes the likely author intent with the configured pipeline agent, includes that summary as untrusted context in review checks and fixes, test detection and fixes, lint detection and fixes, documentation checks and fixes, and PR prompts, and renders it in generated PR descriptions.
+It matches sessions against the changed files, summarizes the likely author intent with the configured pipeline agent, includes that summary as untrusted context in rebase fixes, review checks and fixes, test detection and fixes, lint detection and fixes, documentation checks and fixes, CI auto-fixes, and PR prompts, and renders it in generated PR descriptions.
 
 Transcript readers collect user and assistant text messages but exclude tool call output.
 They read Claude Code transcripts from `~/.claude/projects`, Codex metadata from `~/.codex/state_*.sqlite` plus referenced rollout files, OpenCode messages from `$XDG_DATA_HOME/opencode/opencode.db` or `~/.local/share/opencode/opencode.db`, and Rovo Dev sessions from `~/.rovodev/sessions`.

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -210,7 +210,7 @@ These are global defaults. Per-repo config can override individual steps.
 ### intent
 
 User-intent extraction settings.
-When enabled, no-mistakes can read recent local agent transcripts, match the session that produced the change, summarize the author's intent, pass that summary to review, test, document, lint, and PR prompts, and include it in generated PR descriptions.
+When enabled, no-mistakes can read recent local agent transcripts, match the session that produced the change, summarize the author's intent, pass that summary to rebase, review, test, document, lint, CI auto-fix, and PR prompts, and include it in generated PR descriptions.
 
 | | |
 |---|---|

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -14,7 +14,7 @@ Each step can produce findings, request approval, or trigger auto-fix. Steps tha
 ## Intent
 
 Infers the author's intent from recent local Claude Code, Codex, OpenCode, or Rovo Dev transcripts.
-This is best-effort context, and when available it is included in review checks and fixes, test detection and fixes, documentation checks and fixes, lint detection and fixes, and PR drafting.
+This is best-effort context, and when available it is included in rebase fixes, review checks and fixes, test detection and fixes, documentation checks and fixes, lint detection and fixes, CI auto-fixes, and PR drafting.
 
 **Behavior:**
 - Runs only when `intent.enabled` is true
@@ -39,7 +39,7 @@ Fetches the latest upstream and rebases your branch onto it.
 - If the diff against the default branch is empty after rebase, completes rebase and skips all remaining pipeline steps
 - On conflict: records conflicting files, aborts the rebase, and reports findings
 
-**Auto-fix:** when enabled, the agent resolves conflict markers, stages files, and runs `git rebase --continue`. Manual fix rounds also include any per-conflict user notes, any selected user-authored findings from the TUI, and sanitized prior-round history in the prompt. Commits use the message format `no-mistakes(rebase): <summary>`.
+**Auto-fix:** when enabled, the agent resolves conflict markers, stages files, and runs `git rebase --continue`. The prompt includes inferred user intent when available. Manual fix rounds also include any per-conflict user notes, any selected user-authored findings from the TUI, and sanitized prior-round history in the prompt. Commits use the message format `no-mistakes(rebase): <summary>`.
 
 **Default auto-fix limit:** `3`.
 
@@ -155,8 +155,8 @@ Monitors PR health after creation and auto-fixes CI failures. Mergeability polli
 - On GitHub and GitLab, polls provider mergeability alongside CI checks and waits for that state to resolve before exiting
 - Waits a 60s grace period before trusting empty results (CI checks may not have registered yet)
 - If CI failures or, on GitHub or GitLab, a merge conflict are already known while other checks are still pending: waits for all checks to finish before attempting an auto-fix
-- On CI failure: fetches failed job logs (GitHub via `gh run view --log-failed`, GitLab via `glab ci trace`, Bitbucket Cloud via failed pipeline step logs), sends them to the agent for fixing, and commits and force-pushes only if the agent produces changes
-- On GitHub or GitLab merge conflict: asks the agent to rebase onto the latest default-branch tip and resolve the conflicts with minimal changes
+- On CI failure: fetches failed job logs (GitHub via `gh run view --log-failed`, GitLab via `glab ci trace`, Bitbucket Cloud via failed pipeline step logs), sends them to the agent with inferred user intent when available, and commits and force-pushes only if the agent produces changes
+- On GitHub or GitLab merge conflict: asks the agent to rebase onto the latest default-branch tip and make the smallest correct root-cause fix for the conflicts, using inferred user intent when available
 - If both CI failures and a GitHub or GitLab merge conflict are present: fixes both in the same attempt
 - If a fix attempt produces no changes: automatic mode leaves the failure undeduplicated so it can retry until the auto-fix limit, while manual fix mode returns immediately for manual intervention
 - Deduplicates fix attempts only after a fix is actually committed and pushed

--- a/internal/pipeline/steps/ci_autofix_test.go
+++ b/internal/pipeline/steps/ci_autofix_test.go
@@ -60,6 +60,7 @@ func TestCIStep_CIFailureAutoFix(t *testing.T) {
 	sctx.Run.PRURL = &prURL
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "refs/heads/feature"
+	sctx.UserIntent = "user wanted CI autofix to preserve the extracted intent"
 	sctx.Config.CITimeout = 30 * time.Second
 	sctx.Config.AutoFix = config.AutoFix{CI: 3}
 
@@ -1127,6 +1128,7 @@ func TestCIStep_AutoFixPromptIncludesMustFixInstruction(t *testing.T) {
 	sctx.Run.PRURL = &prURL
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "refs/heads/feature"
+	sctx.UserIntent = "user wanted CI autofix to preserve the extracted intent"
 	sctx.Config.CITimeout = 30 * time.Second
 	sctx.Config.AutoFix = config.AutoFix{CI: 3}
 
@@ -1154,5 +1156,8 @@ func TestCIStep_AutoFixPromptIncludesMustFixInstruction(t *testing.T) {
 	}
 	if strings.Contains(capturedPrompt, "Make the minimal change needed") {
 		t.Errorf("prompt should not prefer narrow minimal changes, got:\n%s", capturedPrompt)
+	}
+	if !strings.Contains(capturedPrompt, "user wanted CI autofix to preserve the extracted intent") {
+		t.Errorf("prompt should include extracted user intent, got:\n%s", capturedPrompt)
 	}
 }

--- a/internal/pipeline/steps/ci_autofix_test.go
+++ b/internal/pipeline/steps/ci_autofix_test.go
@@ -1149,4 +1149,10 @@ func TestCIStep_AutoFixPromptIncludesMustFixInstruction(t *testing.T) {
 	if !strings.Contains(capturedPrompt, "You MUST produce file changes") {
 		t.Errorf("prompt should instruct agent to produce changes, got:\n%s", capturedPrompt)
 	}
+	if !strings.Contains(capturedPrompt, "smallest correct root-cause fix") {
+		t.Errorf("prompt should prefer root-cause fixes over bandaids, got:\n%s", capturedPrompt)
+	}
+	if strings.Contains(capturedPrompt, "Make the minimal change needed") {
+		t.Errorf("prompt should not prefer narrow minimal changes, got:\n%s", capturedPrompt)
+	}
 }

--- a/internal/pipeline/steps/ci_fix.go
+++ b/internal/pipeline/steps/ci_fix.go
@@ -92,6 +92,7 @@ Context:
 CI logs:
 %s`, logOutput)
 	}
+	prompt += userIntentPromptSection(sctx)
 
 	sctx.Log("running agent to fix CI issues...")
 	_, err := sctx.Agent.Run(ctx, agent.RunOpts{

--- a/internal/pipeline/steps/ci_fix.go
+++ b/internal/pipeline/steps/ci_fix.go
@@ -43,8 +43,8 @@ func (s *CIStep) autoFixCI(sctx *pipeline.StepContext, host scm.Host, pr *scm.PR
 		promptRules = `- You MUST produce file changes that fix the failing checks. Do not conclude that nothing needs to change.
 		- If a test fails only on a specific OS (e.g. Windows CRLF, path separators), fix the test to be cross-platform.
 		- If a test is flaky, make it deterministic.
-		- Make the minimal change needed.
-		- Do not refactor beyond what is needed.
+		- Make the smallest correct root-cause fix.
+		- Do not refactor beyond what is needed for that root-cause fix.
 		- Verify the fix by running the most relevant commands locally before finishing.`
 	case mergeConflict:
 		promptIntro = "The PR has merge conflicts with the base branch. Rebase onto the base branch and resolve the merge conflicts."
@@ -56,8 +56,8 @@ func (s *CIStep) autoFixCI(sctx *pipeline.StepContext, host scm.Host, pr *scm.PR
 		promptRules = `- You MUST produce file changes that fix the failing checks. Do not conclude that nothing needs to change.
 		- If a test fails only on a specific OS (e.g. Windows CRLF, path separators), fix the test to be cross-platform.
 		- If a test is flaky, make it deterministic.
-		- Make the minimal change needed.
-		- Do not refactor beyond what is needed.
+		- Make the smallest correct root-cause fix.
+		- Do not refactor beyond what is needed for that root-cause fix.
 		- Verify the fix by running the most relevant commands locally before finishing.`
 	}
 

--- a/internal/pipeline/steps/lint.go
+++ b/internal/pipeline/steps/lint.go
@@ -31,8 +31,8 @@ Context:
 - target commit: %s
 
 Rules:
-- Make the minimal change needed.
-- Do not refactor beyond what is needed.
+- Make the smallest correct root-cause fix.
+- Do not refactor beyond what is needed for that root-cause fix.
 - Do not run tests or broader behavioral validation.
 - Re-run the relevant lint or format commands before finishing.
 - Return JSON with a single "summary" field when you are done.

--- a/internal/pipeline/steps/lint_test.go
+++ b/internal/pipeline/steps/lint_test.go
@@ -58,6 +58,12 @@ func TestLintStep_FixMode_CommitsChanges(t *testing.T) {
 	if strings.Contains(ag.calls[0].Prompt, "<<<<<<< HEAD") {
 		t.Error("expected lint fix prompt to exclude merge markers")
 	}
+	if !strings.Contains(ag.calls[0].Prompt, "smallest correct root-cause fix") {
+		t.Error("expected lint fix prompt to prefer root-cause fixes over bandaids")
+	}
+	if strings.Contains(ag.calls[0].Prompt, "Make the minimal change needed") {
+		t.Error("expected lint fix prompt not to prefer narrow minimal changes")
+	}
 	if status := gitStatusPorcelain(t, dir); status != "" {
 		t.Fatalf("expected clean worktree after fix commit, got %q", status)
 	}

--- a/internal/pipeline/steps/rebase.go
+++ b/internal/pipeline/steps/rebase.go
@@ -251,6 +251,7 @@ Instructions:
 	if sctx.PreviousFindings != "" {
 		prompt += "\n\nPrevious findings:\n" + sctx.PreviousFindings
 	}
+	prompt += userIntentPromptSection(sctx)
 
 	_, err = sctx.Agent.Run(ctx, agent.RunOpts{
 		Prompt:     prompt,

--- a/internal/pipeline/steps/rebase_test.go
+++ b/internal/pipeline/steps/rebase_test.go
@@ -158,6 +158,7 @@ func TestRebaseStep_FixModeCallsAgent(t *testing.T) {
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Fixing = true
 	sctx.PreviousFindings = `{"findings":[{"severity":"warning","file":"other.txt","description":"merge conflict rebasing onto origin/feature"}]}`
+	sctx.UserIntent = "user wanted conflict resolution to preserve the extracted intent"
 
 	step := &RebaseStep{}
 	outcome, err := step.Execute(sctx)
@@ -175,6 +176,9 @@ func TestRebaseStep_FixModeCallsAgent(t *testing.T) {
 	}
 	if strings.Contains(ag.calls[0].Prompt, "other.txt") && !strings.Contains(ag.calls[0].Prompt, "Current conflicted files") {
 		t.Fatalf("expected prompt to scope fixes using current conflicted files, got: %s", ag.calls[0].Prompt)
+	}
+	if !strings.Contains(ag.calls[0].Prompt, "user wanted conflict resolution to preserve the extracted intent") {
+		t.Fatalf("expected agent prompt to include extracted user intent, got: %s", ag.calls[0].Prompt)
 	}
 	// Verify rebase completed - feature is now ahead of origin/main
 	mergeBase := gitCmd(t, dir, "merge-base", "HEAD", "origin/main")

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -50,6 +50,8 @@ Context:
 
 Rules:
 - Always start with double checking whether the findings are legitimate.
+- Before changing code, identify whether each finding is a local defect or a symptom of a deeper design, abstraction, validation, ownership, or test-coverage flaw. Prefer the smallest correct root-cause fix within the changed area over patching only the reported line.
+- If a narrow fix would leave the same class of bug likely elsewhere, fix the deepest practical cause instead.
 - Avoid resolving a finding by removing or reverting the author's intentional code in their original 1st commit. If the original change introduced something on purpose, fix it forward (e.g. add validation, handle edge cases, tighten logic) rather than deleting it. Similarly, if the original change intentionally deleted or simplified code, do not restore or re-add the removed code unless the finding is a legitimate correctness, reliability, or security issue and the smallest reasonable fix happens to reintroduce a small amount of previously deleted logic. When in doubt about whether code is intentional, leave it and report the finding as unresolved.
 - Do not add code comments explaining your fixes.
 - Verify that the issues are resolved before finishing.
@@ -144,7 +146,7 @@ Context:
 
 Task:
 - Read the relevant history and diff yourself.
-- focus only on changed code.
+- Focus findings on risks introduced by changed code, but inspect surrounding code, call sites, shared helpers, tests, and invariants when needed to understand root cause.
 - Do NOT run tests during review. The pipeline has a dedicated test step after review.
 - Analyze for bugs, risks, and code simplification opportunities.
 - "Simplification" means reducing code complexity through non-functional refactoring (e.g. deduplication, clearer control flow). It does NOT mean removing features, changing product behavior, or stripping intentional user-facing output.

--- a/internal/pipeline/steps/review_test.go
+++ b/internal/pipeline/steps/review_test.go
@@ -74,6 +74,15 @@ func TestReviewStep_FixMode(t *testing.T) {
 	if !strings.Contains(ag.calls[0].Prompt, "do not restore or re-add the removed code unless the finding is a legitimate correctness, reliability, or security issue") {
 		t.Error("expected fix prompt to distinguish intentional deletions from legitimate bug fixes")
 	}
+	if !strings.Contains(ag.calls[0].Prompt, "smallest correct root-cause fix") {
+		t.Error("expected review fix prompt to prefer root-cause fixes over bandaids")
+	}
+	if !strings.Contains(ag.calls[0].Prompt, "deeper design, abstraction, validation, ownership, or test-coverage flaw") {
+		t.Error("expected review fix prompt to require root-cause diagnosis before editing")
+	}
+	if !strings.Contains(ag.calls[0].Prompt, "leave the same class of bug likely elsewhere") {
+		t.Error("expected review fix prompt to avoid narrow fixes that leave systemic bugs")
+	}
 	if len(ag.calls[0].JSONSchema) == 0 {
 		t.Error("expected fix call to request structured JSON output")
 	}
@@ -88,6 +97,9 @@ func TestReviewStep_FixMode(t *testing.T) {
 	}
 	if !strings.Contains(ag.calls[1].Prompt, `"ask-user"`) {
 		t.Error("expected review prompt to include ask-user action for ambiguous findings")
+	}
+	if !strings.Contains(ag.calls[1].Prompt, "inspect surrounding code, call sites, shared helpers, tests, and invariants") {
+		t.Error("expected review prompt to allow surrounding-code inspection for root cause")
 	}
 	if status := gitStatusPorcelain(t, dir); status != "" {
 		t.Fatalf("expected clean worktree after fix commit, got %q", status)

--- a/internal/pipeline/steps/test.go
+++ b/internal/pipeline/steps/test.go
@@ -32,8 +32,8 @@ Context:
 - target commit: %s
 
 Rules:
-- Make the minimal change needed.
-- Do not refactor beyond what is needed.
+- Make the smallest correct root-cause fix.
+- Do not refactor beyond what is needed for that root-cause fix.
 - If tests fail, determine whether the problem is a real product/code failure, a setup/environment problem you can fix, or a flaky/infrastructure issue.
 - Do NOT run linters, formatters, or static analysis tools.
 - Re-run the relevant tests before finishing.

--- a/internal/pipeline/steps/test_test.go
+++ b/internal/pipeline/steps/test_test.go
@@ -57,6 +57,12 @@ func TestTestStep_FixMode(t *testing.T) {
 	if strings.Contains(ag.calls[0].Prompt, "<<<<<<< HEAD") {
 		t.Error("expected test fix prompt to exclude merge markers")
 	}
+	if !strings.Contains(ag.calls[0].Prompt, "smallest correct root-cause fix") {
+		t.Error("expected test fix prompt to prefer root-cause fixes over bandaids")
+	}
+	if strings.Contains(ag.calls[0].Prompt, "Make the minimal change needed") {
+		t.Error("expected test fix prompt not to prefer narrow minimal changes")
+	}
 	if status := gitStatusPorcelain(t, dir); status != "" {
 		t.Fatalf("expected clean worktree after fix commit, got %q", status)
 	}


### PR DESCRIPTION
## Intent

The developer wanted to determine whether the extracted user intent is included in every agent execution throughout the pipeline, with special attention to autofix agent runs. They were specifically checking coverage across normal pipeline steps and autofix paths, and wanted to identify any agent executions where the intent is not passed through.

## What Changed
- Updated pipeline agent fix prompts to request the smallest correct root-cause fix rather than narrow minimal changes.
- Added extracted user intent to CI auto-fix and rebase conflict-resolution agent prompts, with regression coverage across CI, rebase, lint, review, and test fix-mode prompts.
- Updated agent and pipeline documentation to describe the expanded intent prompt coverage and root-cause fix guidance.

## Risk Assessment

✅ Low: The branch only adjusts agent prompt wording and assertions around those prompts, with no substantive control-flow or data-handling changes.

## Testing

- Summary: Exercised the affected pipeline prompt tests, all pipeline tests, and the full Go test suite; all completed successfully.
- `go test ./internal/pipeline/steps -run 'Test(CIStep_CIFailureAutoFix|CIStep_AutoFixPromptIncludesMustFixInstruction|LintStep_FixMode_CommitsChanges|RebaseStep_FixModeCallsAgent|ReviewStep_FixMode|TestStep_FixMode)$' -count=1`
- `go test ./internal/pipeline/steps -count=1`
- `go test ./internal/pipeline/... -count=1`
- `go test ./... -count=1`
- `go test ./internal/pipeline/steps -run 'Test(LintStep_FixMode_CommitsChanges|TestStep_FixMode|ReviewStep_FixMode|CIStep_AutoFixPromptIncludesMustFixInstruction)$'`
- `go test ./internal/pipeline/steps -run '^TestCIStep_AutoFixPromptIncludesMustFixInstruction$' -count=1`
- `go test ./internal/pipeline/steps -run 'Test(CIStep_CIFailureAutoFix|CIStep_AutoFixPromptIncludesMustFixInstruction|LintStep_FixMode_CommitsChanges|ReviewStep_FixMode|TestStep_FixMode)$'`
- `go test ./internal/pipeline/steps`
- `go test ./internal/pipeline`
- `go test ./internal/pipeline/steps -run '^TestRebaseStep_FixModeCallsAgent$'`
- Outcome: 🔧 1 issue found → auto-fixed (2) across 3 runs (7m59s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed (2)</summary>

**Round 1** - found 1 error
- 🚨 `internal/pipeline/steps/ci_fix.go:64` - CI autofix agent prompts do not include the extracted user intent. A new regression assertion setting StepContext.UserIntent fails because autoFixCI builds its prompt without appending userIntentPromptSection(sctx), unlike the lint, test, and review agent executions.
- `go test ./internal/pipeline/steps -run 'Test(LintStep_FixMode_CommitsChanges|TestStep_FixMode|ReviewStep_FixMode|CIStep_AutoFixPromptIncludesMustFixInstruction)$'`
- `go test ./internal/pipeline/steps -run '^TestCIStep_AutoFixPromptIncludesMustFixInstruction$' -count=1`
- `go test ./internal/pipeline/steps -count=1`

**Round 2** (auto-fix) - found 1 error
- 🚨 `internal/pipeline/steps/rebase.go:255` - The rebase conflict-resolution agent prompt does not include the extracted user intent. A regression assertion added to TestRebaseStep_FixModeCallsAgent fails because resolveRebaseWithAgent builds the prompt with conflict details and previous findings only, unlike the other pipeline agent prompts that append userIntentPromptSection(sctx).
- `go test ./internal/pipeline/steps -run 'Test(CIStep_CIFailureAutoFix|CIStep_AutoFixPromptIncludesMustFixInstruction|LintStep_FixMode_CommitsChanges|ReviewStep_FixMode|TestStep_FixMode)$'`
- `go test ./internal/pipeline/steps`
- `go test ./internal/pipeline`
- `go test ./internal/pipeline/steps -run '^TestRebaseStep_FixModeCallsAgent$'`

**Round 3** (auto-fix) - passed ✅
- `go test ./internal/pipeline/steps -run 'Test(CIStep_CIFailureAutoFix|CIStep_AutoFixPromptIncludesMustFixInstruction|LintStep_FixMode_CommitsChanges|RebaseStep_FixModeCallsAgent|ReviewStep_FixMode|TestStep_FixMode)$' -count=1`
- `go test ./internal/pipeline/steps -count=1`
- `go test ./internal/pipeline/... -count=1`
- `go test ./... -count=1`

</details>

<details>
<summary>🔧 **Document** - 4 issues found → auto-fixed</summary>

**Round 1** - found 4 warnings
- ⚠️ `docs/src/content/docs/reference/global-config.md:213` - The intent configuration reference still says extracted intent is passed only to review, test, document, lint, and PR prompts. This change adds inferred user intent to rebase conflict-fix prompts and CI auto-fix prompts, so the documented prompt coverage is stale and should include rebase and CI auto-fix paths.
- ⚠️ `docs/src/content/docs/guides/agents.md:141` - The agent guide&#39;s intent extraction section lists the prompts that receive extracted intent but omits the newly covered rebase conflict-fix and CI auto-fix prompts. Update this list so agent users understand where transcript-derived intent is now supplied.
- ⚠️ `docs/src/content/docs/reference/pipeline-steps.md:17` - The pipeline step reference describes extracted intent as being included in review, test, documentation, lint, and PR prompts only. The code now also appends user intent to rebase fix prompts and CI auto-fix prompts, so this overview and the affected Rebase/CI step descriptions should be updated.
- ⚠️ `docs/src/content/docs/reference/pipeline-steps.md:159` - The CI step documentation still says merge-conflict auto-fix asks the agent to resolve conflicts &#34;with minimal changes.&#34; The prompt guidance changed away from narrow minimal fixes to the &#34;smallest correct root-cause fix,&#34; so this wording is stale and should reflect the new root-cause-fix behavior.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
