### PR TITLE
fix(pipeline): use step workdir for intent git state

### DIFF
--- a/internal/pipeline/steps/intent.go
+++ b/internal/pipeline/steps/intent.go
@@ -157,9 +157,13 @@ func defaultRunIntent(ctx context.Context, sctx *pipeline.StepContext) (*intent.
 	repo := sctx.Repo
 	run := sctx.Run
 	cfg := sctx.Config
+	gitWorkDir := strings.TrimSpace(sctx.WorkDir)
+	if gitWorkDir == "" {
+		gitWorkDir = repo.WorkingPath
+	}
 
-	resolvedBaseSHA := resolveIntentBaseSHA(ctx, repo.WorkingPath, run.BaseSHA, repo.DefaultBranch)
-	diffFiles, err := git.DiffNameOnly(ctx, repo.WorkingPath, resolvedBaseSHA, run.HeadSHA)
+	resolvedBaseSHA := resolveIntentBaseSHA(ctx, gitWorkDir, run.BaseSHA, repo.DefaultBranch)
+	diffFiles, err := git.DiffNameOnly(ctx, gitWorkDir, resolvedBaseSHA, run.HeadSHA)
 	if err != nil {
 		return nil, err
 	}
@@ -167,16 +171,16 @@ func defaultRunIntent(ctx context.Context, sctx *pipeline.StepContext) (*intent.
 		return nil, errIntentEmptyDiff
 	}
 
-	baseTime, err := git.CommitTime(ctx, repo.WorkingPath, resolvedBaseSHA)
+	baseTime, err := git.CommitTime(ctx, gitWorkDir, resolvedBaseSHA)
 	if err != nil || git.IsZeroSHA(run.BaseSHA) {
 		baseTime = time.Now().Add(-7 * 24 * time.Hour)
 	}
-	headTime, err := git.CommitTime(ctx, repo.WorkingPath, run.HeadSHA)
+	headTime, err := git.CommitTime(ctx, gitWorkDir, run.HeadSHA)
 	if err != nil {
 		headTime = time.Now()
 	}
 
-	if authorEmail, err := git.CommitAuthorEmail(ctx, repo.WorkingPath, run.HeadSHA); err == nil && authorEmail != "" {
+	if authorEmail, err := git.CommitAuthorEmail(ctx, gitWorkDir, run.HeadSHA); err == nil && authorEmail != "" {
 		if u, uerr := user.Current(); uerr == nil && u != nil {
 			localUser := strings.ToLower(u.Username)
 			emailUser := strings.ToLower(strings.SplitN(authorEmail, "@", 2)[0])

--- a/internal/pipeline/steps/intent_integration_test.go
+++ b/internal/pipeline/steps/intent_integration_test.go
@@ -226,6 +226,64 @@ func TestIntentStep_Integration_ZeroBaseSHA_NewBranchPush(t *testing.T) {
 	}
 }
 
+func TestIntentStep_Integration_UsesPipelineWorkDirForGitState(t *testing.T) {
+	originRepo := t.TempDir()
+	gitCmd(t, originRepo, "init")
+	gitCmd(t, originRepo, "config", "user.email", "test@example.com")
+	gitCmd(t, originRepo, "config", "user.name", "Tester")
+	if err := os.WriteFile(filepath.Join(originRepo, "internal_foo.go"), []byte("package foo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, originRepo, "add", ".")
+	gitCmd(t, originRepo, "commit", "-m", "base")
+	base := gitCmd(t, originRepo, "rev-parse", "HEAD")
+
+	fakeHome := t.TempDir()
+	encoded := testClaudeProjectDirName(originRepo)
+	claudeDir := filepath.Join(fakeHome, ".claude", "projects", encoded)
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	transcript := `{"type":"user","cwd":` + testJSONString(t, originRepo) + `,"timestamp":"2026-04-18T02:15:37.407Z","uuid":"u1","sessionId":"s1","message":{"role":"user","content":"please add Bar() to internal_foo.go"}}
+{"type":"assistant","cwd":` + testJSONString(t, originRepo) + `,"timestamp":"2026-04-18T02:15:38.000Z","uuid":"u2","sessionId":"s1","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":` + testJSONString(t, filepath.Join(originRepo, "internal_foo.go")) + `}}]}}
+`
+	if err := os.WriteFile(filepath.Join(claudeDir, "session.jsonl"), []byte(transcript), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	withFakeHome(t, fakeHome)
+
+	pipelineWorkDir := filepath.Join(t.TempDir(), "worktree")
+	gitCmd(t, t.TempDir(), "clone", originRepo, pipelineWorkDir)
+	gitCmd(t, pipelineWorkDir, "config", "user.email", "test@example.com")
+	gitCmd(t, pipelineWorkDir, "config", "user.name", "Tester")
+	if err := os.WriteFile(filepath.Join(pipelineWorkDir, "internal_foo.go"), []byte("package foo\nfunc Bar() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, pipelineWorkDir, "add", ".")
+	gitCmd(t, pipelineWorkDir, "commit", "-m", "head only in pipeline workdir")
+	head := gitCmd(t, pipelineWorkDir, "rev-parse", "HEAD")
+
+	cfg := &config.Config{Intent: config.Intent{Enabled: true, Threshold: 0.1, SlackDays: 3}}
+	sctx := newIntentIntegrationContext(t, originRepo, base, head, cfg)
+	sctx.WorkDir = pipelineWorkDir
+
+	outcome, err := (&IntentStep{}).Execute(sctx)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if outcome == nil || outcome.Skipped {
+		t.Fatalf("expected non-skipped outcome when head exists in pipeline workdir, got %+v", outcome)
+	}
+
+	got, _ := sctx.DB.GetRun(sctx.Run.ID)
+	if got.Intent == nil {
+		t.Fatal("intent not attached")
+	}
+	if !strings.Contains(*got.Intent, "Bar()") {
+		t.Errorf("Intent = %q", *got.Intent)
+	}
+}
+
 // After a force push, Run.BaseSHA is the prior remote tip of the branch, which
 // may be unreachable in the worktree (rewritten away or never fetched). The
 // step must fall back to merge-base against the default branch instead of


### PR DESCRIPTION
## Intent

The developer wanted to understand the existing intent extraction flow and refactor it from daemon-level special-cased logic into a normal pipeline step. They preferred avoiding a separate PreStep/Advisory abstraction, with the intent step handling its own failures as skips and persisting the extracted intent to the database so downstream steps can consume it. They explicitly asked for the implementation to start only after confirming integration points, and to use TDD. After the refactor, they wanted the intent step to print the inferred intent into the log, and asked what is currently logged when intent extraction fails.

## What Changed

- Updated intent extraction to resolve base SHAs, changed files, commit times, and author metadata from the pipeline step workdir when present.
- Kept transcript matching rooted at the original repository path while summarization continues to run from the pipeline workdir.
- Added integration coverage for intent extraction when the target head commit exists only in the pipeline workdir.

## Risk Assessment

✅ Low: The change is narrowly scoped to using the pipeline worktree for intent-step git queries, with targeted coverage and no material risks found in the changed code.

## Testing

- Summary: Exercised the intent step integration coverage, including the new pipeline workdir git-state case, and then ran the related pipeline packages; all selected tests passed.
- `go test ./internal/pipeline/steps -run 'TestIntentStep' -count=1`
- `go test ./internal/pipeline/... -count=1`
- Outcome: ✅ passed across 1 run (51.7s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/pipeline/steps -run 'TestIntentStep' -count=1`
- `go test ./internal/pipeline/... -count=1`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
