### PR TITLE
fix(conventional): infer release types for non-conventional titles

### DIFF
--- a/docs/src/content/docs/guides/setup-wizard.md
+++ b/docs/src/content/docs/guides/setup-wizard.md
@@ -97,7 +97,7 @@ effects, so exiting should not be too easy once those side effects exist.
 When you leave branch name or commit subject blank, the wizard invokes the configured agent (global or per-repo `agent` setting) to produce a suggestion. The agent sees the local diff and returns:
 
 - A kebab-case branch name prefixed with a type (`feat/`, `fix/`, `chore/`, etc.)
-- A conventional-commit subject line
+- A conventional-commit subject line, using `feat` or `fix` for user-facing product impact so release automation can pick it up
 
 The managed agent server (Rovo Dev or OpenCode) writes its output to `~/.no-mistakes/logs/wizard-agent.log` during these runs.
 

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -134,7 +134,7 @@ Creates or updates a pull request.
 - Checks for an existing PR on the branch
 - If one exists, updates it. If not, creates a new one.
 - Uses the provider CLI for GitHub/GitLab and the Bitbucket API for Bitbucket Cloud
-- PR title: agent-generated with inferred user intent when available, in conventional commit format (`type(scope): description` or `type: description`); when a scope is used, it should be the primary affected real module/package from the changed paths and kept broad rather than file-level
+- PR title: agent-generated with inferred user intent when available, in conventional commit format (`type(scope): description` or `type: description`); user-facing product impact should use `feat` or `fix` so release automation can pick it up; when a scope is used, it should be the primary affected real module/package from the changed paths and kept broad rather than file-level
 - PR body includes: a `## Intent` section from extracted user intent when available, an agent-authored `## What Changed`, and regenerated `## Risk Assessment`, `## Testing`, and `## Pipeline` sections from recorded step results and rounds
 - The regenerated `## Testing` section prefers the recorded `testing_summary`, lists deduplicated `tested` commands or selectors, and ends with the overall outcome including run count and total duration when available
 

--- a/internal/agent/suggest.go
+++ b/internal/agent/suggest.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/kunchenguid/no-mistakes/internal/conventional"
 )
 
 // branchNameRules and commitSubjectRules are shared between the single-purpose
@@ -17,6 +19,7 @@ const branchNameRules = `- Use kebab-case.
 
 const commitSubjectRules = `- One line only, under 72 characters.
 - Use conventional commit format: "type(scope): description" or "type: description". Valid types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert. Scope is optional. Do not capitalize the type.
+` + conventional.ReleaseTypeRule + `
 - When including a scope, it MUST be a real package/module name that exists in the codebase (for example, a directory under internal/, cmd/, or the equivalent top-level grouping for this project), identified by inspecting the changed paths. Pick the primary module affected by the change, not a secondary or incidental one.
 - Keep the scope at a coarse level, not too granular: a codebase typically has fewer than 10 distinct scopes in use across its history. Prefer a broad module name (e.g. "daemon", "pipeline", "cli") over a narrow file or sub-feature name. If you cannot confidently identify a real primary module, omit the scope and use "type: description".
 - Do not invent behavior.`
@@ -245,5 +248,5 @@ func sanitizeCommitSubject(raw string) string {
 	if i := strings.IndexByte(s, '\n'); i >= 0 {
 		s = strings.TrimSpace(s[:i])
 	}
-	return s
+	return conventional.TightenTitle(s)
 }

--- a/internal/agent/suggest_test.go
+++ b/internal/agent/suggest_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -167,6 +168,34 @@ func TestSuggestCommitMessageTrimsNewlines(t *testing.T) {
 	}
 	if got != "fix: thing" {
 		t.Fatalf("expected first line only, got %q", got)
+	}
+}
+
+func TestSuggestCommitMessageKeepsConventionalNonReleaseType(t *testing.T) {
+	ag := &stubAgent{result: &Result{
+		Output: json.RawMessage(`{"subject":"refactor: improve CLI output"}`),
+	}}
+	got, err := SuggestCommitMessage(context.Background(), ag, "/tmp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "refactor: improve CLI output" {
+		t.Fatalf("subject = %q, want conventional agent subject unchanged", got)
+	}
+}
+
+func TestSuggestCommitMessagePromptRequiresReleaseTypesForProductImpact(t *testing.T) {
+	ag := &stubAgent{result: &Result{
+		Output: json.RawMessage(`{"subject":"fix: improve CLI output"}`),
+	}}
+	if _, err := SuggestCommitMessage(context.Background(), ag, "/tmp"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(ag.gotPrompt, "user-facing product impact") {
+		t.Fatalf("prompt should mention user-facing product impact rule, got:\n%s", ag.gotPrompt)
+	}
+	if !strings.Contains(ag.gotPrompt, "must use feat or fix") {
+		t.Fatalf("prompt should require feat or fix for product impact, got:\n%s", ag.gotPrompt)
 	}
 }
 

--- a/internal/conventional/title.go
+++ b/internal/conventional/title.go
@@ -1,0 +1,97 @@
+package conventional
+
+import (
+	"regexp"
+	"strings"
+)
+
+var titleRe = regexp.MustCompile(`^([a-z]+)(\([^)]+\))?(!)?: (.+)$`)
+
+var validTypes = map[string]bool{
+	"feat":     true,
+	"fix":      true,
+	"docs":     true,
+	"style":    true,
+	"refactor": true,
+	"perf":     true,
+	"test":     true,
+	"build":    true,
+	"ci":       true,
+	"chore":    true,
+	"revert":   true,
+}
+
+const ReleaseTypeRule = `- If the change has any user-facing product impact, the type must use feat or fix so release automation can pick it up. Use feat for a new user-visible capability and fix for a user-visible correction or behavior improvement. Use docs, refactor, chore, test, build, or ci only when the change has no user-facing product behavior impact.`
+
+func IsTitle(title string) bool {
+	m := titleRe.FindStringSubmatch(strings.TrimSpace(title))
+	return len(m) > 0 && validTypes[m[1]]
+}
+
+func TightenTitle(title string) string {
+	title = strings.TrimSpace(title)
+	if title == "" {
+		return ""
+	}
+
+	m := titleRe.FindStringSubmatch(title)
+	if len(m) == 0 || !validTypes[m[1]] {
+		return inferType(title) + ": " + title
+	}
+	return title
+}
+
+func inferType(text string) string {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	switch {
+	case hasDocumentationLanguage(lower):
+		return "docs"
+	case hasProductImpactLanguage(lower) || isFeatureLanguage(lower):
+		return inferReleaseType(lower)
+	default:
+		return "chore"
+	}
+}
+
+func inferReleaseType(text string) string {
+	if isFeatureLanguage(text) {
+		return "feat"
+	}
+	return "fix"
+}
+
+func isFeatureLanguage(text string) bool {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	featurePrefixes := []string{
+		"add ", "adds ", "added ", "introduce ", "introduces ", "introduced ",
+		"create ", "creates ", "created ", "implement ", "implements ", "implemented ",
+		"support ", "supports ", "supported ", "enable ", "enables ", "enabled ",
+		"allow ", "allows ", "allowed ",
+	}
+	for _, prefix := range featurePrefixes {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	return strings.Contains(lower, " new ") || strings.HasPrefix(lower, "new ")
+}
+
+func hasProductImpactLanguage(text string) bool {
+	lower := strings.ToLower(text)
+	terms := []string{
+		"user-facing", "user visible", "user-visible", "user experience", " ux", "ux ",
+		" ui", "ui ", "cli", "command", "output", "behavior", "workflow",
+		"prompt", "flag", "error message",
+	}
+	for _, term := range terms {
+		if strings.Contains(lower, term) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasDocumentationLanguage(text string) bool {
+	lower := strings.ToLower(text)
+	return strings.Contains(lower, "readme") || strings.Contains(lower, "documentation") || strings.Contains(lower, "docs")
+}

--- a/internal/conventional/title.go
+++ b/internal/conventional/title.go
@@ -46,7 +46,7 @@ func inferType(text string) string {
 	switch {
 	case hasDocumentationLanguage(lower):
 		return "docs"
-	case hasProductImpactLanguage(lower) || isFeatureLanguage(lower):
+	case hasProductImpactLanguage(lower) || isFeatureLanguage(lower) || isFixLanguage(lower):
 		return inferReleaseType(lower)
 	default:
 		return "chore"
@@ -58,6 +58,20 @@ func inferReleaseType(text string) string {
 		return "feat"
 	}
 	return "fix"
+}
+
+func isFixLanguage(text string) bool {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	fixPrefixes := []string{
+		"fix ", "fixes ", "fixed ", "resolve ", "resolves ", "resolved ",
+		"correct ", "corrects ", "corrected ", "repair ", "repairs ", "repaired ",
+	}
+	for _, prefix := range fixPrefixes {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func isFeatureLanguage(text string) bool {

--- a/internal/conventional/title_test.go
+++ b/internal/conventional/title_test.go
@@ -69,6 +69,8 @@ func TestTightenTitlePrefixesNonConventionalTitles(t *testing.T) {
 		want  string
 	}{
 		{name: "new feature", title: "add export command", want: "feat: add export command"},
+		{name: "direct fix verb", title: "fix login redirect", want: "fix: fix login redirect"},
+		{name: "direct correction verb", title: "correct cache invalidation", want: "fix: correct cache invalidation"},
 		{name: "user-facing fix", title: "Improve pipeline header UX", want: "fix: Improve pipeline header UX"},
 		{name: "documentation", title: "update README", want: "docs: update README"},
 		{name: "generic internal", title: "tidy retry helper", want: "chore: tidy retry helper"},

--- a/internal/conventional/title_test.go
+++ b/internal/conventional/title_test.go
@@ -1,0 +1,108 @@
+package conventional
+
+import "testing"
+
+func TestTightenTitleKeepsReleaseTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{
+		"feat(cli): add onboarding wizard",
+		"fix: improve command output",
+		"fix(api)!: require auth token",
+	}
+
+	for _, tc := range tests {
+		t.Run(tc, func(t *testing.T) {
+			t.Parallel()
+			if got := TightenTitle(tc); got != tc {
+				t.Fatalf("TightenTitle(%q) = %q", tc, got)
+			}
+		})
+	}
+}
+
+func TestTightenTitleKeepsConventionalNonReleaseTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{
+		"refactor: improve CLI output",
+		"docs: add user-facing export command",
+		"chore(cli)!: improve UI behavior",
+	}
+
+	for _, tc := range tests {
+		t.Run(tc, func(t *testing.T) {
+			t.Parallel()
+			if got := TightenTitle(tc); got != tc {
+				t.Fatalf("TightenTitle(%q) = %q", tc, got)
+			}
+		})
+	}
+}
+
+func TestTightenTitleKeepsNonProductImpactTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{
+		"docs: update README",
+		"docs: update CLI command documentation",
+		"refactor: simplify internal retry loop",
+		"test: cover config parsing",
+	}
+
+	for _, tc := range tests {
+		t.Run(tc, func(t *testing.T) {
+			t.Parallel()
+			if got := TightenTitle(tc); got != tc {
+				t.Fatalf("TightenTitle(%q) = %q", tc, got)
+			}
+		})
+	}
+}
+
+func TestTightenTitlePrefixesNonConventionalTitles(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		title string
+		want  string
+	}{
+		{name: "new feature", title: "add export command", want: "feat: add export command"},
+		{name: "user-facing fix", title: "Improve pipeline header UX", want: "fix: Improve pipeline header UX"},
+		{name: "documentation", title: "update README", want: "docs: update README"},
+		{name: "generic internal", title: "tidy retry helper", want: "chore: tidy retry helper"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := TightenTitle(tc.title); got != tc.want {
+				t.Fatalf("TightenTitle(%q) = %q, want %q", tc.title, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsTitle(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		title string
+		want  bool
+	}{
+		{title: "feat: add export", want: true},
+		{title: "fix(cli)!: change output", want: true},
+		{title: "add export", want: false},
+		{title: "Feat: add export", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+			if got := IsTitle(tc.title); got != tc.want {
+				t.Fatalf("IsTitle(%q) = %v, want %v", tc.title, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -4,24 +4,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"regexp"
 	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
+	"github.com/kunchenguid/no-mistakes/internal/conventional"
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/scm"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
-
-var conventionalTitleRe = regexp.MustCompile(
-	`^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([^)]+\))?!?: .+`,
-)
-
-func isConventionalTitle(title string) bool {
-	return conventionalTitleRe.MatchString(title)
-}
 
 // PRStep creates or updates a pull request via the provider CLI or API.
 type PRStep struct{}
@@ -147,6 +139,7 @@ Context:
 Rules:
 - Cover the full branch delta, not just the latest commit.
 - Title must use conventional commit format: "type(scope): description" or "type: description". Valid types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert. Scope is optional. Do not capitalize the type. Do not use the raw branch name.
+%s
 - When including a scope, it MUST be a real package/module name that exists in the codebase (for example, a directory under internal/, cmd/, or the equivalent top-level grouping for this project), identified by inspecting the changed paths. Pick the primary module affected by the change, not a secondary or incidental one.
 - Keep the scope at a coarse level, not too granular: a codebase typically has fewer than 10 distinct scopes in use across its history. Prefer a broad module name (e.g. "daemon", "pipeline", "cli") over a narrow file or sub-feature name. If you cannot confidently identify a real primary module, omit the scope and use "type: description".
 - Body: a "## What Changed" section in GitHub-flavored markdown. 1-3 concise bullet points describing the concrete changes in this branch (what code/behavior shifted), not the user's motivation. Do not include Intent, Risk Assessment, Testing, or Pipeline sections - those are prepended/appended separately. The body value must be plain markdown text, never a JSON object or serialized JSON string.
@@ -156,7 +149,7 @@ Commit history:
 %s
 
 Diff stat:
-%s%s%s%s`, branch, baseSHA, sctx.Run.HeadSHA, sctx.Repo.DefaultBranch, commitLog, diffStat, pipelineContext, userIntentPromptSection(sctx), executionContextPromptSection())
+%s%s%s%s`, branch, baseSHA, sctx.Run.HeadSHA, sctx.Repo.DefaultBranch, conventional.ReleaseTypeRule, commitLog, diffStat, pipelineContext, userIntentPromptSection(sctx), executionContextPromptSection())
 
 	result, err := sctx.Agent.Run(ctx, agent.RunOpts{
 		Prompt:     prompt,
@@ -177,9 +170,10 @@ Diff stat:
 			content.Body = unwrapNestedPRBody(content.Body)
 			content.Body = stripGeneratedSections(content.Body)
 			if content.Title != "" && content.Body != "" {
-				if !isConventionalTitle(content.Title) {
-					slog.Warn("agent PR title is not conventional commit format, prepending chore:", "title", content.Title)
-					content.Title = "chore: " + content.Title
+				originalTitle := content.Title
+				content.Title = conventional.TightenTitle(content.Title)
+				if content.Title != originalTitle {
+					slog.Warn("tightened agent PR title type", "from", originalTitle, "to", content.Title)
 				}
 				content.Body = appendGeneratedSections(content.Body, riskLine, testingMD, pipelineMD)
 				content.Body = prependIntentSection(content.Body, sctx)
@@ -332,8 +326,8 @@ func fallbackPRContent(sctx *pipeline.StepContext, branch, commitLog, riskLine, 
 	}
 	if title == "" {
 		title = "chore: update pull request"
-	} else if !isConventionalTitle(title) {
-		title = "chore: " + title
+	} else {
+		title = conventional.TightenTitle(title)
 	}
 	body := fmt.Sprintf("## What Changed\n\n%s", strings.TrimSpace(commitLog))
 	if body == "## What Changed\n\n" {

--- a/internal/pipeline/steps/pr_test.go
+++ b/internal/pipeline/steps/pr_test.go
@@ -279,8 +279,8 @@ func TestPRStep_CreatesNewPR(t *testing.T) {
 	if strings.Contains(ghLog, "--title add feature --") {
 		t.Fatalf("expected fallback PR title to reject raw non-conventional commit summary, got:\n%s", ghLog)
 	}
-	if !strings.Contains(ghLog, "--title chore: add feature --body") {
-		t.Fatalf("expected fallback PR title to use conventional commit format, got:\n%s", ghLog)
+	if !strings.Contains(ghLog, "--title feat: add feature --body") {
+		t.Fatalf("expected fallback PR title to use release-triggering conventional commit format, got:\n%s", ghLog)
 	}
 	if !strings.Contains(ghLog, "add feature\n\n## Risk Assessment\n\n⚠️ Medium: touches critical error handling") {
 		t.Fatalf("expected fallback PR body to append risk note under Risk Assessment heading, got:\n%s", ghLog)
@@ -1042,12 +1042,12 @@ func TestPRStep_AgentNonConventionalTitleFallsBack(t *testing.T) {
 		t.Fatal(err)
 	}
 	ghLog := string(logData)
-	// The title should be prefixed with "chore: ", not the raw agent output
+	// The title should be prefixed with a release-triggering type, not the raw agent output.
 	if strings.Contains(ghLog, "--title Improve pipeline header UX --") {
 		t.Fatal("non-conventional agent title should have been rejected")
 	}
-	if !strings.Contains(ghLog, "chore: Improve pipeline header UX") {
-		t.Fatal("expected agent title to be prefixed with chore:, got: " + ghLog)
+	if !strings.Contains(ghLog, "fix: Improve pipeline header UX") {
+		t.Fatal("expected user-facing agent title to be prefixed with fix:, got: " + ghLog)
 	}
 	// The agent's body should be preserved, not replaced with fallback
 	if !strings.Contains(ghLog, "## Summary") {
@@ -1087,6 +1087,66 @@ func TestPRStep_AgentScopedBreakingTitlePassesThrough(t *testing.T) {
 	}
 	if strings.Contains(ghLog, "--title chore: "+title+" --body") {
 		t.Fatalf("expected scoped conventional breaking-change title to avoid fallback prefix, got:\n%s", ghLog)
+	}
+}
+
+func TestPRStep_AgentConventionalNonReleaseTitlePassesThrough(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	env, logFile := fakeGH(t, "")
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			payload := json.RawMessage(`{"title":"refactor(cli): improve CLI output","body":"## Summary\n\n- improve user-visible command output"}`)
+			return &agent.Result{Output: payload}, nil
+		},
+	}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+
+	step := &PRStep{}
+	if _, err := step.Execute(sctx); err != nil {
+		t.Fatal(err)
+	}
+
+	logData, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ghLog := string(logData)
+	if !strings.Contains(ghLog, "--title refactor(cli): improve CLI output --body") {
+		t.Fatalf("expected conventional agent PR title to pass through unchanged, got:\n%s", ghLog)
+	}
+}
+
+func TestPRStep_PromptRequiresReleaseTypesForProductImpact(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			payload := json.RawMessage(`{"title":"fix: improve CLI output","body":"## What Changed\n\n- improve output"}`)
+			return &agent.Result{Output: payload}, nil
+		},
+	}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+
+	step := &PRStep{}
+	if _, err := step.buildPRContent(sctx, "feature", baseSHA); err != nil {
+		t.Fatal(err)
+	}
+	if len(ag.calls) != 1 {
+		t.Fatalf("agent calls = %d, want 1", len(ag.calls))
+	}
+	prompt := ag.calls[0].Prompt
+	if !strings.Contains(prompt, "user-facing product impact") {
+		t.Fatalf("prompt should mention user-facing product impact rule, got:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "must use feat or fix") {
+		t.Fatalf("prompt should require feat or fix for product impact, got:\n%s", prompt)
 	}
 }
 


### PR DESCRIPTION
## Intent

The developer wanted commit message and PR title generation tightened so any user-facing product impact is classified as `feat` or `fix`, because other conventional types often do not trigger releases. They explicitly wanted this applied to both the setup wizard commit message suggestions and the PR step's PR title creation. After learning the implementation used keyword heuristics to rewrite already-conventional titles, they rejected that approach and required valid conventional messages to be trusted unchanged, even if they use `docs`, `refactor`, or `chore`. They accepted only parsing conventional titles, leaving existing `feat` and `fix` unchanged, and inferring a prefix for non-conventional titles while relying on the agent prompt to choose the correct release-triggering type for product-impacting changes.

## What Changed

- Added conventional title parsing and normalization so already-valid conventional titles pass through unchanged while non-conventional titles get an inferred `feat`, `fix`, or `chore` prefix.
- Updated agent commit suggestions and PR title generation to steer user-facing product-impact changes toward release-triggering `feat` or `fix` types.
- Documented the release-triggering title type rule in the setup wizard and pipeline step references.

## Risk Assessment

✅ Low: The change is small and well-bounded to prompt wording plus centralized conventional-title normalization, with tests covering the intended pass-through and inference behavior.

## Testing

- Summary: Exercised the new conventional title helper, setup wizard commit suggestion path, PR title generation/fallback behavior, and the full Go test suite; all tests passed.
- `go test ./internal/conventional`
- `go test ./internal/agent -run 'TestSuggestCommitMessage'`
- `go test ./internal/pipeline/steps -run 'TestPRStep_(CreatesNewPR|AgentNonConventionalTitleFallsBack|AgentScopedBreakingTitlePassesThrough|AgentConventionalNonReleaseTitlePassesThrough|PromptRequiresReleaseTypesForProductImpact)'`
- `go test ./...`
- Outcome: ✅ passed across 1 run (1m24s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/conventional/title.go:49` - Non-conventional titles with obvious bug-fix verbs but without one of the product-impact keywords still fall through to `chore`; for example, `fix login redirect` becomes `chore: fix login redirect`, so release automation would not trigger for a user-facing fix. Add fix/correction verbs such as `fix`, `fixes`, `resolve`, `correct`, or `repair` to the release-type inference path.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/conventional`
- `go test ./internal/agent -run 'TestSuggestCommitMessage'`
- `go test ./internal/pipeline/steps -run 'TestPRStep_(CreatesNewPR|AgentNonConventionalTitleFallsBack|AgentScopedBreakingTitlePassesThrough|AgentConventionalNonReleaseTitlePassesThrough|PromptRequiresReleaseTypesForProductImpact)'`
- `go test ./...`

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed</summary>

**Round 1** - found 2 warnings
- ⚠️ `docs/src/content/docs/guides/setup-wizard.md:100` - The setup wizard documentation says agent commit suggestions are conventional-commit subject lines, but the changed prompt now adds a user-facing product-impact rule requiring `feat` or `fix` so release automation can pick those changes up. This guide should document that type-selection rule for blank commit subject suggestions.
- ⚠️ `docs/src/content/docs/reference/pipeline-steps.md:137` - The PR step reference documents that generated PR titles use conventional commit format, but the changed PR prompt and title tightening now require product-impacting user-facing changes to use `feat` or `fix`, while already-valid conventional titles are trusted unchanged. The PR title behavior should document that release-triggering type rule.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
