### PR TITLE
feat(tui): show fixed finding progress in pipeline rows

### DIFF
--- a/docs/src/content/docs/guides/tui.md
+++ b/docs/src/content/docs/guides/tui.md
@@ -50,7 +50,7 @@ Shows the branch name and run status in the header, followed by each step:
   │
   ✓ Rebase            320ms
   │
-  ⏸ Review     - awaiting approval
+  ⏸ Review     - awaiting approval       2/3 fixed
   │
   ○ Test
   │
@@ -76,7 +76,7 @@ Step status icons:
 | `–` | Skipped |
 | `✗` | Failed |
 
-Completed steps show their duration. Connectors (`│`) between steps are hidden when the terminal height is under 30 lines.
+Completed steps show their duration. Steps with fixed findings show a right-aligned count such as `2/3 fixed`. Connectors (`│`) between steps are hidden when the terminal height is under 30 lines.
 
 ### Findings panel
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -354,7 +354,7 @@ func registerHandlers(srv *ipc.Server, mgr *RunManager, d *db.DB, shutdown func(
 		if err != nil {
 			return nil, fmt.Errorf("get steps: %w", err)
 		}
-		return &ipc.GetRunResult{Run: runToInfo(run, steps)}, nil
+		return &ipc.GetRunResult{Run: runToInfo(d, run, steps)}, nil
 	})
 
 	srv.Handle(ipc.MethodGetRuns, func(_ context.Context, params json.RawMessage) (interface{}, error) {
@@ -372,7 +372,7 @@ func registerHandlers(srv *ipc.Server, mgr *RunManager, d *db.DB, shutdown func(
 			if err != nil {
 				return nil, fmt.Errorf("get steps for run %s: %w", r.ID, err)
 			}
-			infos = append(infos, *runToInfo(r, steps))
+			infos = append(infos, *runToInfo(d, r, steps))
 		}
 		return &ipc.GetRunsResult{Runs: infos}, nil
 	})
@@ -393,7 +393,7 @@ func registerHandlers(srv *ipc.Server, mgr *RunManager, d *db.DB, shutdown func(
 		if err != nil {
 			return nil, fmt.Errorf("get steps: %w", err)
 		}
-		return &ipc.GetActiveRunResult{Run: runToInfo(run, steps)}, nil
+		return &ipc.GetActiveRunResult{Run: runToInfo(d, run, steps)}, nil
 	})
 
 	srv.Handle(ipc.MethodRerun, func(ctx context.Context, params json.RawMessage) (interface{}, error) {
@@ -468,7 +468,7 @@ func registerHandlers(srv *ipc.Server, mgr *RunManager, d *db.DB, shutdown func(
 	})
 }
 
-func runToInfo(r *db.Run, steps []*db.StepResult) *ipc.RunInfo {
+func runToInfo(d *db.DB, r *db.Run, steps []*db.StepResult) *ipc.RunInfo {
 	info := &ipc.RunInfo{
 		ID:        r.ID,
 		RepoID:    r.RepoID,
@@ -484,14 +484,14 @@ func runToInfo(r *db.Run, steps []*db.StepResult) *ipc.RunInfo {
 	if len(steps) > 0 {
 		info.Steps = make([]ipc.StepResultInfo, 0, len(steps))
 		for _, s := range steps {
-			info.Steps = append(info.Steps, stepToInfo(s))
+			info.Steps = append(info.Steps, stepToInfo(d, s))
 		}
 	}
 	return info
 }
 
-func stepToInfo(s *db.StepResult) ipc.StepResultInfo {
-	return ipc.StepResultInfo{
+func stepToInfo(d *db.DB, s *db.StepResult) ipc.StepResultInfo {
+	info := ipc.StepResultInfo{
 		ID:           s.ID,
 		RunID:        s.RunID,
 		StepName:     s.StepName,
@@ -504,4 +504,8 @@ func stepToInfo(s *db.StepResult) ipc.StepResultInfo {
 		StartedAt:    s.StartedAt,
 		CompletedAt:  s.CompletedAt,
 	}
+	if fixed, err := d.FixedFindingsByStep(s); err == nil {
+		info.FixedFindings = fixed
+	}
+	return info
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -504,8 +504,9 @@ func stepToInfo(d *db.DB, s *db.StepResult) ipc.StepResultInfo {
 		StartedAt:    s.StartedAt,
 		CompletedAt:  s.CompletedAt,
 	}
-	if fixed, err := d.FixedFindingsByStep(s); err == nil {
-		info.FixedFindings = fixed
+	if stats, err := d.StepFindingStats(s); err == nil {
+		info.ReportedFindings = stats.ReportedFindings
+		info.FixedFindings = stats.FixedFindings
 	}
 	return info
 }

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -140,6 +140,20 @@ func stepFindingCounts(step *StepResult, rounds []*StepRound) (reported int, fin
 	return findingsCount(rounds[0].FindingsJSON), findingsCount(rounds[len(rounds)-1].FindingsJSON)
 }
 
+// FixedFindingsByStep returns how many findings were resolved for a single step.
+func (d *DB) FixedFindingsByStep(step *StepResult) (int, error) {
+	rounds, err := d.GetRoundsByStep(step.ID)
+	if err != nil {
+		return 0, err
+	}
+	reported, final := stepFindingCounts(step, rounds)
+	fixed := reported - final
+	if fixed < 0 {
+		fixed = 0
+	}
+	return fixed, nil
+}
+
 func findingsCount(raw *string) int {
 	if raw == nil || *raw == "" {
 		return 0

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"slices"
@@ -112,11 +113,8 @@ func (d *DB) aggregateRunStats(runID string, stepStats map[types.StepName]*StepS
 		if err != nil {
 			return 0, 0, err
 		}
-		reported, final := stepFindingCounts(step, rounds)
-		fixed := reported - final
-		if fixed < 0 {
-			fixed = 0
-		}
+		findingStats := stepFindingStats(step, rounds)
+		reported, fixed := findingStats.ReportedFindings, findingStats.FixedFindings
 
 		runReported += reported
 		runFixed += fixed
@@ -133,25 +131,59 @@ func (d *DB) aggregateRunStats(runID string, stepStats map[types.StepName]*StepS
 }
 
 func stepFindingCounts(step *StepResult, rounds []*StepRound) (reported int, final int) {
+	stats := stepFindingStats(step, rounds)
+	return stats.ReportedFindings, stats.ReportedFindings - stats.FixedFindings
+}
+
+func stepFindingStats(step *StepResult, rounds []*StepRound) StepStats {
+	stats := StepStats{StepName: step.StepName}
 	if len(rounds) == 0 {
 		count := findingsCount(step.FindingsJSON)
-		return count, count
+		stats.ReportedFindings = count
+		return stats
 	}
-	return findingsCount(rounds[0].FindingsJSON), findingsCount(rounds[len(rounds)-1].FindingsJSON)
+
+	reported := make(map[types.Finding]bool)
+	var current []types.Finding
+	for _, round := range rounds {
+		items := findingItems(round.FindingsJSON)
+		for _, item := range items {
+			reported[findingStatsKey(item)] = true
+		}
+		current = items
+	}
+
+	stats.ReportedFindings = len(reported)
+	currentCount := len(current)
+	stats.FixedFindings = stats.ReportedFindings - currentCount
+	if stats.FixedFindings < 0 {
+		stats.FixedFindings = 0
+	}
+	if selected := selectedCurrentFindingCount(rounds[len(rounds)-1].SelectedFindingIDs, current); selected > 0 {
+		stats.FixedFindings += selected
+	}
+	if stats.FixedFindings > stats.ReportedFindings {
+		stats.FixedFindings = stats.ReportedFindings
+	}
+	return stats
 }
 
 // FixedFindingsByStep returns how many findings were resolved for a single step.
 func (d *DB) FixedFindingsByStep(step *StepResult) (int, error) {
-	rounds, err := d.GetRoundsByStep(step.ID)
+	stats, err := d.StepFindingStats(step)
 	if err != nil {
 		return 0, err
 	}
-	reported, final := stepFindingCounts(step, rounds)
-	fixed := reported - final
-	if fixed < 0 {
-		fixed = 0
+	return stats.FixedFindings, nil
+}
+
+// StepFindingStats returns reported and fixed finding counts for a single step.
+func (d *DB) StepFindingStats(step *StepResult) (StepStats, error) {
+	rounds, err := d.GetRoundsByStep(step.ID)
+	if err != nil {
+		return StepStats{}, err
 	}
-	return fixed, nil
+	return stepFindingStats(step, rounds), nil
 }
 
 func findingsCount(raw *string) int {
@@ -163,6 +195,46 @@ func findingsCount(raw *string) int {
 		return 0
 	}
 	return len(findings.Items)
+}
+
+func findingItems(raw *string) []types.Finding {
+	if raw == nil || *raw == "" {
+		return nil
+	}
+	findings, err := types.ParseFindingsJSON(*raw)
+	if err != nil {
+		return nil
+	}
+	return findings.Items
+}
+
+func findingStatsKey(item types.Finding) types.Finding {
+	item.ID = ""
+	item.Action = ""
+	item.Source = ""
+	item.UserInstructions = ""
+	return item
+}
+
+func selectedCurrentFindingCount(raw *string, current []types.Finding) int {
+	if raw == nil || *raw == "" || len(current) == 0 {
+		return 0
+	}
+	var ids []string
+	if err := json.Unmarshal([]byte(*raw), &ids); err != nil {
+		return 0
+	}
+	selected := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		selected[id] = true
+	}
+	count := 0
+	for _, item := range current {
+		if selected[item.ID] {
+			count++
+		}
+	}
+	return count
 }
 
 func sortStepStats(stats []StepStats) {

--- a/internal/db/stats.go
+++ b/internal/db/stats.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"slices"
@@ -159,9 +158,6 @@ func stepFindingStats(step *StepResult, rounds []*StepRound) StepStats {
 	if stats.FixedFindings < 0 {
 		stats.FixedFindings = 0
 	}
-	if selected := selectedCurrentFindingCount(rounds[len(rounds)-1].SelectedFindingIDs, current); selected > 0 {
-		stats.FixedFindings += selected
-	}
 	if stats.FixedFindings > stats.ReportedFindings {
 		stats.FixedFindings = stats.ReportedFindings
 	}
@@ -214,27 +210,6 @@ func findingStatsKey(item types.Finding) types.Finding {
 	item.Source = ""
 	item.UserInstructions = ""
 	return item
-}
-
-func selectedCurrentFindingCount(raw *string, current []types.Finding) int {
-	if raw == nil || *raw == "" || len(current) == 0 {
-		return 0
-	}
-	var ids []string
-	if err := json.Unmarshal([]byte(*raw), &ids); err != nil {
-		return 0
-	}
-	selected := make(map[string]bool, len(ids))
-	for _, id := range ids {
-		selected[id] = true
-	}
-	count := 0
-	for _, item := range current {
-		if selected[item.ID] {
-			count++
-		}
-	}
-	return count
 }
 
 func sortStepStats(stats []StepStats) {

--- a/internal/db/stats_test.go
+++ b/internal/db/stats_test.go
@@ -120,6 +120,53 @@ func TestFixedFindingsByStepCountsResolvedRoundFindings(t *testing.T) {
 	}
 }
 
+func TestStepFindingStatsCountsSelectedFindingsDuringFix(t *testing.T) {
+	d := openTestDB(t)
+	repo, _ := d.InsertRepo("/repo/fixing", "git@example.com:fixing.git", "main")
+	run, _ := d.InsertRun(repo.ID, "fixing", "head", "base")
+	step, _ := d.InsertStepResult(run.ID, types.StepReview)
+	initial := `{"findings":[{"id":"r1","severity":"warning","description":"one"},{"id":"r2","severity":"warning","description":"two"},{"id":"r3","severity":"warning","description":"three"}],"summary":"three"}`
+	round, err := d.InsertStepRound(step.ID, 1, "initial", &initial, nil, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	selected := `["r1","r2"]`
+	if err := d.SetStepRoundSelection(round.ID, &selected, RoundSelectionSourceUser); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := d.StepFindingStats(step)
+	if err != nil {
+		t.Fatalf("step finding stats: %v", err)
+	}
+	if stats.ReportedFindings != 3 || stats.FixedFindings != 2 {
+		t.Fatalf("stats = reported %d fixed %d, want reported 3 fixed 2", stats.ReportedFindings, stats.FixedFindings)
+	}
+}
+
+func TestStepFindingStatsAddsNewFindingsToTotal(t *testing.T) {
+	d := openTestDB(t)
+	repo, _ := d.InsertRepo("/repo/new-findings", "git@example.com:new.git", "main")
+	run, _ := d.InsertRun(repo.ID, "new", "head", "base")
+	step, _ := d.InsertStepResult(run.ID, types.StepReview)
+	initial := `{"findings":[{"id":"r1","severity":"warning","description":"one"},{"id":"r2","severity":"warning","description":"two"},{"id":"r3","severity":"warning","description":"three"}],"summary":"three"}`
+	final := `{"findings":[{"id":"r3","severity":"warning","description":"three"},{"id":"r4","severity":"warning","description":"four"}],"summary":"two left"}`
+	if _, err := d.InsertStepRound(step.ID, 1, "initial", &initial, nil, 100); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.InsertStepRound(step.ID, 2, "auto_fix", &final, nil, 100); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := d.StepFindingStats(step)
+	if err != nil {
+		t.Fatalf("step finding stats: %v", err)
+	}
+	if stats.ReportedFindings != 4 || stats.FixedFindings != 2 {
+		t.Fatalf("stats = reported %d fixed %d, want reported 4 fixed 2", stats.ReportedFindings, stats.FixedFindings)
+	}
+}
+
 func assertStepStat(t *testing.T, stats []StepStats, step types.StepName, reported int, fixes int) {
 	t.Helper()
 	for _, got := range stats {

--- a/internal/db/stats_test.go
+++ b/internal/db/stats_test.go
@@ -120,7 +120,7 @@ func TestFixedFindingsByStepCountsResolvedRoundFindings(t *testing.T) {
 	}
 }
 
-func TestStepFindingStatsCountsSelectedFindingsDuringFix(t *testing.T) {
+func TestStepFindingStatsDoesNotCountSelectedFindingsAsFixed(t *testing.T) {
 	d := openTestDB(t)
 	repo, _ := d.InsertRepo("/repo/fixing", "git@example.com:fixing.git", "main")
 	run, _ := d.InsertRun(repo.ID, "fixing", "head", "base")
@@ -139,8 +139,8 @@ func TestStepFindingStatsCountsSelectedFindingsDuringFix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("step finding stats: %v", err)
 	}
-	if stats.ReportedFindings != 3 || stats.FixedFindings != 2 {
-		t.Fatalf("stats = reported %d fixed %d, want reported 3 fixed 2", stats.ReportedFindings, stats.FixedFindings)
+	if stats.ReportedFindings != 3 || stats.FixedFindings != 0 {
+		t.Fatalf("stats = reported %d fixed %d, want reported 3 fixed 0", stats.ReportedFindings, stats.FixedFindings)
 	}
 }
 

--- a/internal/db/stats_test.go
+++ b/internal/db/stats_test.go
@@ -97,6 +97,29 @@ func TestGetStatsFallsBackToStepFindingsWhenRoundsAreMissing(t *testing.T) {
 	}
 }
 
+func TestFixedFindingsByStepCountsResolvedRoundFindings(t *testing.T) {
+	d := openTestDB(t)
+	repo, _ := d.InsertRepo("/repo/fixes", "git@example.com:fixes.git", "main")
+	run, _ := d.InsertRun(repo.ID, "fixes", "head", "base")
+	step, _ := d.InsertStepResult(run.ID, types.StepReview)
+	initial := `{"findings":[{"id":"r1","severity":"warning","description":"one"},{"id":"r2","severity":"warning","description":"two"},{"id":"r3","severity":"warning","description":"three"}],"summary":"three"}`
+	final := `{"findings":[{"id":"r3","severity":"warning","description":"three"}],"summary":"one left"}`
+	if _, err := d.InsertStepRound(step.ID, 1, "initial", &initial, nil, 100); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.InsertStepRound(step.ID, 2, "auto_fix", &final, nil, 100); err != nil {
+		t.Fatal(err)
+	}
+
+	fixed, err := d.FixedFindingsByStep(step)
+	if err != nil {
+		t.Fatalf("fixed findings by step: %v", err)
+	}
+	if fixed != 2 {
+		t.Fatalf("fixed = %d, want 2", fixed)
+	}
+}
+
 func assertStepStat(t *testing.T, stats []StepStats, step types.StepName, reported int, fixes int) {
 	t.Helper()
 	for _, got := range stats {

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -186,17 +186,18 @@ type RunInfo struct {
 
 // StepResultInfo is the IPC representation of a step result.
 type StepResultInfo struct {
-	ID           string           `json:"id"`
-	RunID        string           `json:"run_id"`
-	StepName     types.StepName   `json:"step_name"`
-	StepOrder    int              `json:"step_order"`
-	Status       types.StepStatus `json:"status"`
-	ExitCode     *int             `json:"exit_code,omitempty"`
-	DurationMS   *int64           `json:"duration_ms,omitempty"`
-	FindingsJSON *string          `json:"findings_json,omitempty"`
-	Error        *string          `json:"error,omitempty"`
-	StartedAt    *int64           `json:"started_at,omitempty"`
-	CompletedAt  *int64           `json:"completed_at,omitempty"`
+	ID            string           `json:"id"`
+	RunID         string           `json:"run_id"`
+	StepName      types.StepName   `json:"step_name"`
+	StepOrder     int              `json:"step_order"`
+	Status        types.StepStatus `json:"status"`
+	ExitCode      *int             `json:"exit_code,omitempty"`
+	DurationMS    *int64           `json:"duration_ms,omitempty"`
+	FindingsJSON  *string          `json:"findings_json,omitempty"`
+	FixedFindings int              `json:"fixed_findings,omitempty"`
+	Error         *string          `json:"error,omitempty"`
+	StartedAt     *int64           `json:"started_at,omitempty"`
+	CompletedAt   *int64           `json:"completed_at,omitempty"`
 }
 
 // --- Events (for subscribe stream) ---
@@ -215,19 +216,20 @@ const (
 
 // Event is a real-time update sent to subscribers.
 type Event struct {
-	Type       EventType       `json:"type"`
-	RunID      string          `json:"run_id"`
-	RepoID     string          `json:"repo_id"`
-	StepName   *types.StepName `json:"step_name,omitempty"`
-	Status     *string         `json:"status,omitempty"`
-	Error      *string         `json:"error,omitempty"`
-	Stream     *string         `json:"stream,omitempty"`
-	Content    *string         `json:"content,omitempty"`
-	Branch     *string         `json:"branch,omitempty"`
-	Findings   *string         `json:"findings,omitempty"`    // JSON-encoded findings for step_completed events
-	Diff       *string         `json:"diff,omitempty"`        // unified diff for fix_review events
-	DurationMS *int64          `json:"duration_ms,omitempty"` // execution-only duration for step events
-	PRURL      *string         `json:"pr_url,omitempty"`      // PR URL for run_updated/run_completed events
+	Type          EventType       `json:"type"`
+	RunID         string          `json:"run_id"`
+	RepoID        string          `json:"repo_id"`
+	StepName      *types.StepName `json:"step_name,omitempty"`
+	Status        *string         `json:"status,omitempty"`
+	Error         *string         `json:"error,omitempty"`
+	Stream        *string         `json:"stream,omitempty"`
+	Content       *string         `json:"content,omitempty"`
+	Branch        *string         `json:"branch,omitempty"`
+	Findings      *string         `json:"findings,omitempty"` // JSON-encoded findings for step_completed events
+	Diff          *string         `json:"diff,omitempty"`     // unified diff for fix_review events
+	FixedFindings *int            `json:"fixed_findings,omitempty"`
+	DurationMS    *int64          `json:"duration_ms,omitempty"` // execution-only duration for step events
+	PRURL         *string         `json:"pr_url,omitempty"`      // PR URL for run_updated/run_completed events
 }
 
 // --- Helpers ---

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -186,18 +186,19 @@ type RunInfo struct {
 
 // StepResultInfo is the IPC representation of a step result.
 type StepResultInfo struct {
-	ID            string           `json:"id"`
-	RunID         string           `json:"run_id"`
-	StepName      types.StepName   `json:"step_name"`
-	StepOrder     int              `json:"step_order"`
-	Status        types.StepStatus `json:"status"`
-	ExitCode      *int             `json:"exit_code,omitempty"`
-	DurationMS    *int64           `json:"duration_ms,omitempty"`
-	FindingsJSON  *string          `json:"findings_json,omitempty"`
-	FixedFindings int              `json:"fixed_findings,omitempty"`
-	Error         *string          `json:"error,omitempty"`
-	StartedAt     *int64           `json:"started_at,omitempty"`
-	CompletedAt   *int64           `json:"completed_at,omitempty"`
+	ID               string           `json:"id"`
+	RunID            string           `json:"run_id"`
+	StepName         types.StepName   `json:"step_name"`
+	StepOrder        int              `json:"step_order"`
+	Status           types.StepStatus `json:"status"`
+	ExitCode         *int             `json:"exit_code,omitempty"`
+	DurationMS       *int64           `json:"duration_ms,omitempty"`
+	FindingsJSON     *string          `json:"findings_json,omitempty"`
+	ReportedFindings int              `json:"reported_findings,omitempty"`
+	FixedFindings    int              `json:"fixed_findings,omitempty"`
+	Error            *string          `json:"error,omitempty"`
+	StartedAt        *int64           `json:"started_at,omitempty"`
+	CompletedAt      *int64           `json:"completed_at,omitempty"`
 }
 
 // --- Events (for subscribe stream) ---
@@ -216,20 +217,21 @@ const (
 
 // Event is a real-time update sent to subscribers.
 type Event struct {
-	Type          EventType       `json:"type"`
-	RunID         string          `json:"run_id"`
-	RepoID        string          `json:"repo_id"`
-	StepName      *types.StepName `json:"step_name,omitempty"`
-	Status        *string         `json:"status,omitempty"`
-	Error         *string         `json:"error,omitempty"`
-	Stream        *string         `json:"stream,omitempty"`
-	Content       *string         `json:"content,omitempty"`
-	Branch        *string         `json:"branch,omitempty"`
-	Findings      *string         `json:"findings,omitempty"` // JSON-encoded findings for step_completed events
-	Diff          *string         `json:"diff,omitempty"`     // unified diff for fix_review events
-	FixedFindings *int            `json:"fixed_findings,omitempty"`
-	DurationMS    *int64          `json:"duration_ms,omitempty"` // execution-only duration for step events
-	PRURL         *string         `json:"pr_url,omitempty"`      // PR URL for run_updated/run_completed events
+	Type             EventType       `json:"type"`
+	RunID            string          `json:"run_id"`
+	RepoID           string          `json:"repo_id"`
+	StepName         *types.StepName `json:"step_name,omitempty"`
+	Status           *string         `json:"status,omitempty"`
+	Error            *string         `json:"error,omitempty"`
+	Stream           *string         `json:"stream,omitempty"`
+	Content          *string         `json:"content,omitempty"`
+	Branch           *string         `json:"branch,omitempty"`
+	Findings         *string         `json:"findings,omitempty"` // JSON-encoded findings for step_completed events
+	Diff             *string         `json:"diff,omitempty"`     // unified diff for fix_review events
+	ReportedFindings *int            `json:"reported_findings,omitempty"`
+	FixedFindings    *int            `json:"fixed_findings,omitempty"`
+	DurationMS       *int64          `json:"duration_ms,omitempty"` // execution-only duration for step events
+	PRURL            *string         `json:"pr_url,omitempty"`      // PR URL for run_updated/run_completed events
 }
 
 // --- Helpers ---

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -319,7 +319,6 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 				if dbErr := e.db.UpdateStepStatus(sr.ID, types.StepStatusFixing); dbErr != nil {
 					slog.Warn("failed to update step status in db", "step", stepName, "status", "fixing", "error", dbErr)
 				}
-				e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFixing), "", "", "", nil)
 				if currentRoundID != "" {
 					if idsJSON := findingIDsJSON(fixableFindings); idsJSON != "" {
 						if dbErr := e.db.SetStepRoundSelection(currentRoundID, &idsJSON, db.RoundSelectionSourceAutoFix); dbErr != nil {
@@ -327,6 +326,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 						}
 					}
 				}
+				e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFixing), "", "", "", nil)
 				phaseStart = time.Now()
 				sctx.Fixing = true
 				sctx.PreviousFindings = fixableFindings
@@ -425,7 +425,6 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			if dbErr := e.db.UpdateStepStatus(sr.ID, types.StepStatusFixing); dbErr != nil {
 				slog.Warn("failed to update step status in db", "step", stepName, "status", "fixing", "error", dbErr)
 			}
-			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFixing), "", "", "", nil)
 			sctx.Fixing = true
 			selectedFindings := filterFindingsJSON(outcome.Findings, response.findingIDs)
 			mergedFindings := mergeUserOverridesJSON(selectedFindings, response.instructions, response.addedFindings)
@@ -445,6 +444,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 					}
 				}
 			}
+			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFixing), "", "", "", nil)
 			slog.Info("step fix requested, re-executing", "step", stepName)
 			continue // loop back to step.Execute
 		}
@@ -558,7 +558,11 @@ func (e *Executor) emitStepEventWithFindingsDiffAndError(eventType ipc.EventType
 		Status:     &status,
 		DurationMS: durationMS,
 	}
-	if fixed := e.fixedFindingsForStep(run.ID, stepName); fixed > 0 {
+	stats := e.findingStatsForStep(run.ID, stepName)
+	if stats.ReportedFindings > 0 || stats.FixedFindings > 0 {
+		reported := stats.ReportedFindings
+		fixed := stats.FixedFindings
+		event.ReportedFindings = &reported
 		event.FixedFindings = &fixed
 	}
 	if errMsg != "" {
@@ -592,22 +596,22 @@ func (e *Executor) emitStepEventWithFindingsDiffAndError(eventType ipc.EventType
 	telemetry.Track("step", fields)
 }
 
-func (e *Executor) fixedFindingsForStep(runID string, stepName types.StepName) int {
+func (e *Executor) findingStatsForStep(runID string, stepName types.StepName) db.StepStats {
 	steps, err := e.db.GetStepsByRun(runID)
 	if err != nil {
-		return 0
+		return db.StepStats{StepName: stepName}
 	}
 	for _, step := range steps {
 		if step.StepName != stepName {
 			continue
 		}
-		fixed, err := e.db.FixedFindingsByStep(step)
+		stats, err := e.db.StepFindingStats(step)
 		if err != nil {
-			return 0
+			return db.StepStats{StepName: stepName}
 		}
-		return fixed
+		return stats
 	}
-	return 0
+	return db.StepStats{StepName: stepName}
 }
 
 func shouldTrackStepTelemetry(eventType ipc.EventType, status string) bool {

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -558,6 +558,9 @@ func (e *Executor) emitStepEventWithFindingsDiffAndError(eventType ipc.EventType
 		Status:     &status,
 		DurationMS: durationMS,
 	}
+	if fixed := e.fixedFindingsForStep(run.ID, stepName); fixed > 0 {
+		event.FixedFindings = &fixed
+	}
 	if errMsg != "" {
 		event.Error = &errMsg
 	}
@@ -587,6 +590,24 @@ func (e *Executor) emitStepEventWithFindingsDiffAndError(eventType ipc.EventType
 		fields["findings_count"] = findingsCount(findings)
 	}
 	telemetry.Track("step", fields)
+}
+
+func (e *Executor) fixedFindingsForStep(runID string, stepName types.StepName) int {
+	steps, err := e.db.GetStepsByRun(runID)
+	if err != nil {
+		return 0
+	}
+	for _, step := range steps {
+		if step.StepName != stepName {
+			continue
+		}
+		fixed, err := e.db.FixedFindingsByStep(step)
+		if err != nil {
+			return 0
+		}
+		return fixed
+	}
+	return 0
 }
 
 func shouldTrackStepTelemetry(eventType ipc.EventType, status string) bool {

--- a/internal/pipeline/executor_fix_test.go
+++ b/internal/pipeline/executor_fix_test.go
@@ -173,10 +173,10 @@ func TestExecutor_FixingEventIncludesFindingStats(t *testing.T) {
 		t.Fatal(err)
 	}
 	fixingEvent := waitForEvent(t, events, ipc.EventStepCompleted, string(types.StepStatusFixing))
-	if fixingEvent.FixedFindings == nil || *fixingEvent.FixedFindings != 1 {
+	if fixingEvent.FixedFindings == nil || *fixingEvent.FixedFindings != 0 {
 		close(releaseFix)
 		<-done
-		t.Fatalf("fixed findings = %v, want 1", fixingEvent.FixedFindings)
+		t.Fatalf("fixed findings = %v, want 0", fixingEvent.FixedFindings)
 	}
 	if fixingEvent.ReportedFindings == nil || *fixingEvent.ReportedFindings != 2 {
 		close(releaseFix)

--- a/internal/pipeline/executor_fix_test.go
+++ b/internal/pipeline/executor_fix_test.go
@@ -143,6 +143,58 @@ func TestExecutor_FixEmitsFixingStatusImmediately(t *testing.T) {
 	}
 }
 
+func TestExecutor_FixingEventIncludesFindingStats(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+	releaseFix := make(chan struct{})
+	callCount := 0
+	findings := `{"findings":[{"id":"r1","severity":"warning","description":"one","action":"auto-fix"},{"id":"r2","severity":"warning","description":"two","action":"auto-fix"}],"summary":"two"}`
+	step := &adaptiveCallStep{
+		name: types.StepReview,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			callCount++
+			if callCount == 1 {
+				return &StepOutcome{NeedsApproval: true, Findings: findings}, nil
+			}
+			<-releaseFix
+			return &StepOutcome{}, nil
+		},
+	}
+
+	exec := NewExecutor(database, p, nil, nil, []Step{step}, nil)
+	events := collectEvents(exec)
+	done := make(chan error, 1)
+	go func() {
+		done <- exec.Execute(context.Background(), run, repo, workDir)
+	}()
+
+	waitForStepStatus(t, database, run.ID, types.StepReview, types.StepStatusAwaitingApproval)
+	if err := exec.Respond(types.StepReview, types.ActionFix, []string{"r1"}); err != nil {
+		t.Fatal(err)
+	}
+	fixingEvent := waitForEvent(t, events, ipc.EventStepCompleted, string(types.StepStatusFixing))
+	if fixingEvent.FixedFindings == nil || *fixingEvent.FixedFindings != 1 {
+		close(releaseFix)
+		<-done
+		t.Fatalf("fixed findings = %v, want 1", fixingEvent.FixedFindings)
+	}
+	if fixingEvent.ReportedFindings == nil || *fixingEvent.ReportedFindings != 2 {
+		close(releaseFix)
+		<-done
+		t.Fatalf("reported findings = %v, want 2", fixingEvent.ReportedFindings)
+	}
+
+	close(releaseFix)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("executor timed out")
+	}
+}
+
 func TestExecutor_FixReviewNoChanges(t *testing.T) {
 	database, p, run, repo := setupTest(t)
 

--- a/internal/tui/DESIGN.md
+++ b/internal/tui/DESIGN.md
@@ -43,7 +43,7 @@ Every distinct content region gets a rounded-border box:
 Steps connected by a vertical line to convey flow:
 
 ```
-  ✓ Review  1.2s
+  ✓ Review  1.2s                  2/3 fixed
   │
   ⏸ Test - awaiting approval
   │
@@ -52,7 +52,7 @@ Steps connected by a vertical line to convey flow:
   ○ Push
 ```
 
-Connector `│` in bright black. The active/awaiting step visually breaks the flow.
+Connector `│` in bright black. The active/awaiting step visually breaks the flow. Fixed-finding counts are right-aligned meta text on the step row.
 
 ## Action Bar
 

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -55,6 +55,9 @@ func (m *Model) applyEvent(event ipc.Event) {
 		if event.StepName != nil && event.Error != nil {
 			m.setStepError(*event.StepName, event.Error)
 		}
+		if event.StepName != nil && event.FixedFindings != nil {
+			m.setStepFixedFindings(*event.StepName, *event.FixedFindings)
+		}
 		// Persist duration so the step continues to display its elapsed time.
 		// Prefer the event's execution-only duration; fall back to local timing.
 		// For "fixing" status, clear the persisted duration and back-date the
@@ -171,6 +174,15 @@ func (m *Model) setStepError(name types.StepName, errMsg *string) {
 	for i := range m.steps {
 		if m.steps[i].StepName == name {
 			m.steps[i].Error = errMsg
+			return
+		}
+	}
+}
+
+func (m *Model) setStepFixedFindings(name types.StepName, fixedFindings int) {
+	for i := range m.steps {
+		if m.steps[i].StepName == name {
+			m.steps[i].FixedFindings = fixedFindings
 			return
 		}
 	}

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -58,6 +58,9 @@ func (m *Model) applyEvent(event ipc.Event) {
 		if event.StepName != nil && event.FixedFindings != nil {
 			m.setStepFixedFindings(*event.StepName, *event.FixedFindings)
 		}
+		if event.StepName != nil && event.ReportedFindings != nil {
+			m.setStepReportedFindings(*event.StepName, *event.ReportedFindings)
+		}
 		// Persist duration so the step continues to display its elapsed time.
 		// Prefer the event's execution-only duration; fall back to local timing.
 		// For "fixing" status, clear the persisted duration and back-date the
@@ -183,6 +186,15 @@ func (m *Model) setStepFixedFindings(name types.StepName, fixedFindings int) {
 	for i := range m.steps {
 		if m.steps[i].StepName == name {
 			m.steps[i].FixedFindings = fixedFindings
+			return
+		}
+	}
+}
+
+func (m *Model) setStepReportedFindings(name types.StepName, reportedFindings int) {
+	for i := range m.steps {
+		if m.steps[i].StepName == name {
+			m.steps[i].ReportedFindings = reportedFindings
 			return
 		}
 	}

--- a/internal/tui/pipeline.go
+++ b/internal/tui/pipeline.go
@@ -162,8 +162,6 @@ func renderPipelineView(run *ipc.RunInfo, steps []ipc.StepResultInfo, width int,
 		switch step.Status {
 		case types.StepStatusAwaitingApproval:
 			line += " " + dimStyle.Render("- awaiting approval")
-		case types.StepStatusFixing:
-			line += " " + dimStyle.Render("- agent fixing...")
 		case types.StepStatusFixReview:
 			line += " " + dimStyle.Render("- review fix")
 		case types.StepStatusFailed:
@@ -175,6 +173,10 @@ func renderPipelineView(run *ipc.RunInfo, steps []ipc.StepResultInfo, width int,
 				}
 				line += " " + dimStyle.Render(errText)
 			}
+		}
+		if step.FixedFindings > 0 {
+			fixedLabel := dimStyle.Render(fmt.Sprintf("%d fixed", step.FixedFindings))
+			line = appendRightLabel(line, fixedLabel, contentWidth)
 		}
 
 		b.WriteString(line)
@@ -194,6 +196,14 @@ func renderPipelineView(run *ipc.RunInfo, steps []ipc.StepResultInfo, width int,
 		b.WriteString("\n" + errStyle.Render(errText) + "\n")
 	}
 	return renderBox("Pipeline", b.String(), boxWidth)
+}
+
+func appendRightLabel(line, label string, width int) string {
+	gap := width - lipgloss.Width(line) - lipgloss.Width(label)
+	if gap < 1 {
+		gap = 1
+	}
+	return line + strings.Repeat(" ", gap) + label
 }
 
 // renderActionBar renders the approval prompt and action keys as a standalone element.

--- a/internal/tui/pipeline.go
+++ b/internal/tui/pipeline.go
@@ -174,8 +174,8 @@ func renderPipelineView(run *ipc.RunInfo, steps []ipc.StepResultInfo, width int,
 				line += " " + dimStyle.Render(errText)
 			}
 		}
-		if step.FixedFindings > 0 {
-			fixedLabel := dimStyle.Render(fmt.Sprintf("%d fixed", step.FixedFindings))
+		if step.FixedFindings > 0 && step.ReportedFindings > 0 {
+			fixedLabel := dimStyle.Render(fmt.Sprintf("%d/%d fixed", step.FixedFindings, step.ReportedFindings))
 			line = appendRightLabel(line, fixedLabel, contentWidth)
 		}
 

--- a/internal/tui/pipeline_test.go
+++ b/internal/tui/pipeline_test.go
@@ -192,7 +192,9 @@ func TestRenderPipelineView_ShowsFixedFindingsAtRightEdge(t *testing.T) {
 	run := testRun()
 	run.Steps[0].Status = types.StepStatusCompleted
 	run.Steps[0].FixedFindings = 2
+	run.Steps[0].ReportedFindings = 3
 	run.Steps[1].Status = types.StepStatusCompleted
+	run.Steps[1].ReportedFindings = 4
 
 	out := stripANSI(renderPipelineView(run, run.Steps, 80, 0, 40))
 	var reviewLine string
@@ -205,10 +207,10 @@ func TestRenderPipelineView_ShowsFixedFindingsAtRightEdge(t *testing.T) {
 			testLine = line
 		}
 	}
-	if !strings.Contains(reviewLine, "2 fixed") {
+	if !strings.Contains(reviewLine, "2/3 fixed") {
 		t.Fatalf("expected Review row to include fixed count, got %q", reviewLine)
 	}
-	if !strings.HasSuffix(strings.TrimSpace(strings.TrimSuffix(reviewLine, "│")), "2 fixed") {
+	if !strings.HasSuffix(strings.TrimSpace(strings.TrimSuffix(reviewLine, "│")), "2/3 fixed") {
 		t.Fatalf("expected fixed count at right edge, got %q", reviewLine)
 	}
 	if strings.Contains(testLine, "fixed") {
@@ -344,15 +346,19 @@ func TestModel_ApplyEvent_StepCompleted_StoresFixedFindings(t *testing.T) {
 	m := NewModel("/tmp/sock", nil, run)
 
 	m.applyEvent(ipc.Event{
-		Type:          ipc.EventStepCompleted,
-		RunID:         run.ID,
-		StepName:      ptr(types.StepReview),
-		Status:        ptr(string(types.StepStatusFixReview)),
-		FixedFindings: ptr(3),
+		Type:             ipc.EventStepCompleted,
+		RunID:            run.ID,
+		StepName:         ptr(types.StepReview),
+		Status:           ptr(string(types.StepStatusFixReview)),
+		FixedFindings:    ptr(3),
+		ReportedFindings: ptr(5),
 	})
 
 	if m.steps[0].FixedFindings != 3 {
 		t.Fatalf("expected fixed findings to be stored, got %d", m.steps[0].FixedFindings)
+	}
+	if m.steps[0].ReportedFindings != 5 {
+		t.Fatalf("expected reported findings to be stored, got %d", m.steps[0].ReportedFindings)
 	}
 }
 

--- a/internal/tui/pipeline_test.go
+++ b/internal/tui/pipeline_test.go
@@ -188,6 +188,45 @@ func TestRenderPipelineView_StepError(t *testing.T) {
 	}
 }
 
+func TestRenderPipelineView_ShowsFixedFindingsAtRightEdge(t *testing.T) {
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusCompleted
+	run.Steps[0].FixedFindings = 2
+	run.Steps[1].Status = types.StepStatusCompleted
+
+	out := stripANSI(renderPipelineView(run, run.Steps, 80, 0, 40))
+	var reviewLine string
+	var testLine string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "Review") {
+			reviewLine = line
+		}
+		if strings.Contains(line, "Test") {
+			testLine = line
+		}
+	}
+	if !strings.Contains(reviewLine, "2 fixed") {
+		t.Fatalf("expected Review row to include fixed count, got %q", reviewLine)
+	}
+	if !strings.HasSuffix(strings.TrimSpace(strings.TrimSuffix(reviewLine, "│")), "2 fixed") {
+		t.Fatalf("expected fixed count at right edge, got %q", reviewLine)
+	}
+	if strings.Contains(testLine, "fixed") {
+		t.Fatalf("expected no fixed count when none were fixed, got %q", testLine)
+	}
+}
+
+func TestRenderPipelineView_FixingStatusOmitsAgentFixingLabel(t *testing.T) {
+	run := testRun()
+	run.Steps[1].Status = types.StepStatusFixing
+	run.Steps[1].DurationMS = ptr(int64(146000))
+
+	out := stripANSI(renderPipelineView(run, run.Steps, 80, 0, 40))
+	if strings.Contains(out, "agent fixing") {
+		t.Fatalf("expected fixing status label to be hidden, got:\n%s", out)
+	}
+}
+
 func TestRenderApprovalActions_FormatWithSeparator(t *testing.T) {
 	out := stripANSI(renderApprovalActions(true, true, false, 5, 5, false, true))
 	// Keys should not be bracket-wrapped - design uses "a approve" not "[a] approve".
@@ -297,6 +336,23 @@ func TestModel_ApplyEvent_StepCompleted(t *testing.T) {
 
 	if m.steps[0].Status != types.StepStatusCompleted {
 		t.Errorf("expected completed, got %s", m.steps[0].Status)
+	}
+}
+
+func TestModel_ApplyEvent_StepCompleted_StoresFixedFindings(t *testing.T) {
+	run := testRun()
+	m := NewModel("/tmp/sock", nil, run)
+
+	m.applyEvent(ipc.Event{
+		Type:          ipc.EventStepCompleted,
+		RunID:         run.ID,
+		StepName:      ptr(types.StepReview),
+		Status:        ptr(string(types.StepStatusFixReview)),
+		FixedFindings: ptr(3),
+	})
+
+	if m.steps[0].FixedFindings != 3 {
+		t.Fatalf("expected fixed findings to be stored, got %d", m.steps[0].FixedFindings)
 	}
 }
 


### PR DESCRIPTION
## What Changed

- Added fixed-finding totals to pipeline stats, IPC events, daemon updates, and executor result handling so the TUI can track fixed findings against the reported total.
- Updated pipeline rows to show right-aligned fixed counts like `2/3 fixed` when findings are resolved, including coverage for counter behavior in db, pipeline, and TUI tests.
- Documented the fixed-findings counter in the TUI guide and internal TUI design notes.

## Risk Assessment

✅ Low: The change is narrowly scoped to finding count aggregation, IPC propagation, and TUI display, with targeted tests covering the main counter semantics and no material regressions found.

## Testing

- Summary: Exercised the changed fixed-finding aggregation, pipeline event emission, daemon IPC run info, TUI rendering/event handling, and the full Go test suite; all tests passed.
- `go test ./internal/db`
- `go test ./internal/pipeline`
- `go test ./internal/tui`
- `go test ./internal/daemon`
- `go test ./...`
- Outcome: ✅ passed across 1 run (1m51s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/db`
- `go test ./internal/pipeline`
- `go test ./internal/tui`
- `go test ./internal/daemon`
- `go test ./...`

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed</summary>

**Round 1** - found 2 issues (1 warning, 1 info)
- ⚠️ `docs/src/content/docs/guides/tui.md:42` - The TUI guide&#39;s Pipeline box section describes status icons and durations but does not document the new right-aligned fixed-findings counter (for example, `2/3 fixed`) shown when a step has fixed findings. Update this section and/or the sample pipeline box so users understand the new count and when it appears.
- ℹ️ `internal/tui/DESIGN.md:41` - The TUI design system&#39;s Pipeline Connector section defines the step row layout but omits the new right-aligned fixed-findings count added to pipeline rows. Update the design documentation so future TUI changes preserve the intended placement and meta styling for fixed-findings counts.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
