### PR TITLE
fix(pipeline): report live fix progress accurately

### DIFF
--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -326,7 +326,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 						}
 					}
 				}
-				e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFixing), "", "", "", nil)
+				e.emitStepEventWithFindingsDiffErrorAndFixProgress(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFixing), "", "", "", nil, findingsCount(fixableFindings))
 				phaseStart = time.Now()
 				sctx.Fixing = true
 				sctx.PreviousFindings = fixableFindings
@@ -444,7 +444,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 					}
 				}
 			}
-			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFixing), "", "", "", nil)
+			e.emitStepEventWithFindingsDiffErrorAndFixProgress(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFixing), "", "", "", nil, inFlightFixedFindingCount(outcome.Findings, response.findingIDs, response.addedFindings))
 			slog.Info("step fix requested, re-executing", "step", stepName)
 			continue // loop back to step.Execute
 		}
@@ -550,6 +550,10 @@ func (e *Executor) emitStepEventWithFindingsAndDiff(eventType ipc.EventType, run
 }
 
 func (e *Executor) emitStepEventWithFindingsDiffAndError(eventType ipc.EventType, run *db.Run, repo *db.Repo, stepName types.StepName, status string, findings string, diff string, errMsg string, durationMS *int64) {
+	e.emitStepEventWithFindingsDiffErrorAndFixProgress(eventType, run, repo, stepName, status, findings, diff, errMsg, durationMS, 0)
+}
+
+func (e *Executor) emitStepEventWithFindingsDiffErrorAndFixProgress(eventType ipc.EventType, run *db.Run, repo *db.Repo, stepName types.StepName, status string, findings string, diff string, errMsg string, durationMS *int64, inFlightFixedFindings int) {
 	event := ipc.Event{
 		Type:       eventType,
 		RunID:      run.ID,
@@ -559,6 +563,12 @@ func (e *Executor) emitStepEventWithFindingsDiffAndError(eventType ipc.EventType
 		DurationMS: durationMS,
 	}
 	stats := e.findingStatsForStep(run.ID, stepName)
+	if inFlightFixedFindings > 0 && stats.ReportedFindings > 0 {
+		stats.FixedFindings += inFlightFixedFindings
+		if stats.FixedFindings > stats.ReportedFindings {
+			stats.FixedFindings = stats.ReportedFindings
+		}
+	}
 	if stats.ReportedFindings > 0 || stats.FixedFindings > 0 {
 		reported := stats.ReportedFindings
 		fixed := stats.FixedFindings
@@ -594,6 +604,16 @@ func (e *Executor) emitStepEventWithFindingsDiffAndError(eventType ipc.EventType
 		fields["findings_count"] = findingsCount(findings)
 	}
 	telemetry.Track("step", fields)
+}
+
+func inFlightFixedFindingCount(raw string, ids []string, addedFindings []types.Finding) int {
+	if len(ids) > 0 {
+		return len(ids)
+	}
+	if len(addedFindings) > 0 {
+		return 0
+	}
+	return selectedFindingCount(raw, ids)
 }
 
 func (e *Executor) findingStatsForStep(runID string, stepName types.StepName) db.StepStats {

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -607,12 +607,13 @@ func (e *Executor) emitStepEventWithFindingsDiffErrorAndFixProgress(eventType ip
 }
 
 func inFlightFixedFindingCount(raw string, ids []string, addedFindings []types.Finding) int {
+	count := len(addedFindings)
 	if raw == "" || len(ids) == 0 {
-		return 0
+		return count
 	}
 	findings, err := types.ParseFindingsJSON(raw)
 	if err != nil {
-		return 0
+		return count
 	}
 	selected := make(map[string]bool, len(ids))
 	for _, id := range ids {
@@ -620,7 +621,6 @@ func inFlightFixedFindingCount(raw string, ids []string, addedFindings []types.F
 			selected[id] = true
 		}
 	}
-	count := 0
 	for _, item := range findings.Items {
 		if selected[item.ID] {
 			count++

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -610,10 +610,7 @@ func inFlightFixedFindingCount(raw string, ids []string, addedFindings []types.F
 	if len(ids) > 0 {
 		return len(ids)
 	}
-	if len(addedFindings) > 0 {
-		return 0
-	}
-	return selectedFindingCount(raw, ids)
+	return 0
 }
 
 func (e *Executor) findingStatsForStep(runID string, stepName types.StepName) db.StepStats {

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -607,10 +607,27 @@ func (e *Executor) emitStepEventWithFindingsDiffErrorAndFixProgress(eventType ip
 }
 
 func inFlightFixedFindingCount(raw string, ids []string, addedFindings []types.Finding) int {
-	if len(ids) > 0 {
-		return len(ids)
+	if raw == "" || len(ids) == 0 {
+		return 0
 	}
-	return 0
+	findings, err := types.ParseFindingsJSON(raw)
+	if err != nil {
+		return 0
+	}
+	selected := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		if id != "" {
+			selected[id] = true
+		}
+	}
+	count := 0
+	for _, item := range findings.Items {
+		if selected[item.ID] {
+			count++
+			delete(selected, item.ID)
+		}
+	}
+	return count
 }
 
 func (e *Executor) findingStatsForStep(runID string, stepName types.StepName) db.StepStats {

--- a/internal/pipeline/executor_fix_test.go
+++ b/internal/pipeline/executor_fix_test.go
@@ -203,6 +203,14 @@ func TestInFlightFixedFindingCount_EmptySelectionCountsNoExistingFindings(t *tes
 	}
 }
 
+func TestInFlightFixedFindingCount_CountsOnlyUniqueMatchingSelection(t *testing.T) {
+	raw := `{"findings":[{"id":"r1","severity":"warning","description":"one","action":"auto-fix"},{"id":"r2","severity":"warning","description":"two","action":"auto-fix"}],"summary":"two"}`
+
+	if got := inFlightFixedFindingCount(raw, []string{"r1", "missing", "r1"}, nil); got != 1 {
+		t.Fatalf("in-flight fixed findings = %d, want 1", got)
+	}
+}
+
 func TestExecutor_FixReviewNoChanges(t *testing.T) {
 	database, p, run, repo := setupTest(t)
 

--- a/internal/pipeline/executor_fix_test.go
+++ b/internal/pipeline/executor_fix_test.go
@@ -173,10 +173,10 @@ func TestExecutor_FixingEventIncludesFindingStats(t *testing.T) {
 		t.Fatal(err)
 	}
 	fixingEvent := waitForEvent(t, events, ipc.EventStepCompleted, string(types.StepStatusFixing))
-	if fixingEvent.FixedFindings == nil || *fixingEvent.FixedFindings != 0 {
+	if fixingEvent.FixedFindings == nil || *fixingEvent.FixedFindings != 1 {
 		close(releaseFix)
 		<-done
-		t.Fatalf("fixed findings = %v, want 0", fixingEvent.FixedFindings)
+		t.Fatalf("fixed findings = %v, want 1", fixingEvent.FixedFindings)
 	}
 	if fixingEvent.ReportedFindings == nil || *fixingEvent.ReportedFindings != 2 {
 		close(releaseFix)

--- a/internal/pipeline/executor_fix_test.go
+++ b/internal/pipeline/executor_fix_test.go
@@ -211,6 +211,15 @@ func TestInFlightFixedFindingCount_CountsOnlyUniqueMatchingSelection(t *testing.
 	}
 }
 
+func TestInFlightFixedFindingCount_CountsAddedFindings(t *testing.T) {
+	raw := `{"findings":[{"id":"r1","severity":"warning","description":"one","action":"auto-fix"},{"id":"r2","severity":"warning","description":"two","action":"auto-fix"}],"summary":"two"}`
+	added := []types.Finding{{ID: "u1", Severity: "warning", Description: "user one", Action: types.ActionAutoFix, Source: types.FindingSourceUser}}
+
+	if got := inFlightFixedFindingCount(raw, []string{"r1"}, added); got != 2 {
+		t.Fatalf("in-flight fixed findings = %d, want 2", got)
+	}
+}
+
 func TestExecutor_FixReviewNoChanges(t *testing.T) {
 	database, p, run, repo := setupTest(t)
 

--- a/internal/pipeline/executor_fix_test.go
+++ b/internal/pipeline/executor_fix_test.go
@@ -195,6 +195,14 @@ func TestExecutor_FixingEventIncludesFindingStats(t *testing.T) {
 	}
 }
 
+func TestInFlightFixedFindingCount_EmptySelectionCountsNoExistingFindings(t *testing.T) {
+	raw := `{"findings":[{"id":"r1","severity":"warning","description":"one","action":"auto-fix"},{"id":"r2","severity":"warning","description":"two","action":"auto-fix"}],"summary":"two"}`
+
+	if got := inFlightFixedFindingCount(raw, nil, nil); got != 0 {
+		t.Fatalf("in-flight fixed findings = %d, want 0", got)
+	}
+}
+
 func TestExecutor_FixReviewNoChanges(t *testing.T) {
 	database, p, run, repo := setupTest(t)
 


### PR DESCRIPTION
## Intent

The developer wanted to diagnose why a recently implemented TUI label showing step-level fix progress, like "N/M fixed", did not appear during the first live fix phase of a pipeline run despite findings being selected and fixed. They clarified that the label appeared after the second round, so the specific requirement was to make the fix count visible in real time rather than only after DB-backed round stats were updated. The intended behavior was for live fixing events to carry optimistic in-flight progress based on findings already fixed plus findings currently dispatched to the fix agent, capped by the reported total, while later recheck events could still replace that with verified persisted counts.

## What Changed

- Updated pipeline fixing events to include optimistic in-flight fixed finding counts so live progress can show selected findings being dispatched before persisted round stats update.
- Corrected progress counting for empty selections, duplicate or unknown selected finding IDs, and user-added findings so reported counts match the findings actually sent to the fix agent.
- Added pipeline tests covering in-flight fix progress, selected finding counting, empty selections, and added findings.

## Risk Assessment

✅ Low: The change is narrowly scoped to optimistic progress metadata on step events, with targeted coverage for selection counting and no material correctness risks found.

## Testing

- Summary: Exercised the pipeline fix-progress event path, helper counting logic, DB-backed pipeline package behavior, and TUI consumption/rendering of fixed-finding labels; all selected tests passed.
- `go test ./internal/pipeline -run 'TestExecutor_FixingEventIncludesFindingStats|TestInFlightFixedFindingCount|TestExecutor_FixEmitsFixingStatusImmediately' -count=1`
- `go test ./internal/pipeline -count=1`
- `go test ./internal/tui -run 'TestModel_ApplyEvent_StepCompleted_StoresFixedFindings|TestRenderPipelineView_ShowsFixedFindingsAtRightEdge' -count=1`
- `go test -race ./internal/pipeline -count=1`
- `go test ./internal/tui -count=1`
- Outcome: ✅ passed across 1 run (2m0s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (3)</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/pipeline/executor.go:616` - Empty user-selected finding IDs are counted as all current findings for the optimistic fixing event, but the fix path sends an empty findings payload in that same case via filterFindingsJSON. Any IPC/API caller that submits ActionFix without explicit IDs will show all findings as in-flight fixed even though none were dispatched to the fix agent.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `internal/pipeline/executor.go:610` - The optimistic in-flight fixed count trusts the raw length of `ids`, so duplicate or unknown finding IDs from an IPC/API caller can make the fixing event report progress for findings that were not actually dispatched after `filterFindingsJSON` filters the payload. Count the unique IDs that match parsed findings instead of `len(ids)` so the live `N/M fixed` label reflects real selected findings.

**Round 3** (auto-fix) - found 1 warning
- ⚠️ `internal/pipeline/executor.go:609` - `inFlightFixedFindingCount` accepts `addedFindings` but never counts them, even though `mergeUserOverridesJSON` dispatches those user-authored findings to the fix agent and `combineSelectedFindingIDs` persists them as selected. A fix request that contains only user-added findings, or selected existing findings plus added findings, will under-report the optimistic fixing progress and can still omit the live `N/M fixed` label for an in-flight fix.

**Round 4** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/pipeline -run 'TestExecutor_FixingEventIncludesFindingStats|TestInFlightFixedFindingCount|TestExecutor_FixEmitsFixingStatusImmediately' -count=1`
- `go test ./internal/pipeline -count=1`
- `go test ./internal/tui -run 'TestModel_ApplyEvent_StepCompleted_StoresFixedFindings|TestRenderPipelineView_ShowsFixedFindingsAtRightEdge' -count=1`
- `go test -race ./internal/pipeline -count=1`
- `go test ./internal/tui -count=1`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
