### PR TITLE
fix(pipeline): commit no-config lint agent fixes

### DIFF
--- a/docs/src/content/docs/concepts/auto-fix.md
+++ b/docs/src/content/docs/concepts/auto-fix.md
@@ -30,6 +30,9 @@ flowchart TD
    - If issues remain, the step pauses for user approval
    - If everything passes, the step completes and the pipeline moves on
 
+The lint step has one exception: when `commands.lint` is empty, the agent detects relevant linters and formatters, applies safe fixes, verifies them, and commits any changes during the initial lint pass.
+Any unresolved lint findings from that pass pause for approval instead of entering another automatic fix loop.
+
 ## Configuration
 
 Set limits in global or repo config:
@@ -44,7 +47,8 @@ auto_fix:
   ci: 3        # shared by CI for failures, and on GitHub/GitLab for merge conflicts
 ```
 
-Setting a step to `0` means the pipeline always pauses for human input when that step finds issues.
+Setting a step to `0` disables the follow-up auto-fix loop, so the pipeline pauses for human input when that step finds issues.
+For empty `commands.lint`, the initial lint pass can still apply safe fixes before reporting unresolved issues.
 
 `auto_fix.review` defaults to `0`, so review findings require manual approval unless you opt in.
 
@@ -62,7 +66,8 @@ Agent-driven findings now use an `action` field instead of `requires_human_revie
 
 `ask-user` is meant for findings that challenge the author's intent - for example, questioning an intentional product or design choice, or arguing that an intentional addition, removal, or guard should be undone. Routine correctness, reliability, or security fixes still stay `auto-fix` even if the smallest fix reintroduces a small amount of previously deleted logic.
 
-The `review`, `test`, and `lint` steps use this shared model directly. The `document` step also uses the same `action` field, but any documentation finding still pauses for approval because even objective doc gaps need an explicit documentation pass before the pipeline continues.
+The `review`, `test`, and configured-command `lint` steps use this shared model directly. The `document` step also uses the same `action` field, but any documentation finding still pauses for approval because even objective doc gaps need an explicit documentation pass before the pipeline continues.
+When `commands.lint` is empty, lint findings describe issues left after the agent already attempted safe fixes, so they pause for approval instead of remaining eligible for another automatic fix loop.
 
 Documentation findings use the same approval loop, but the `document` step treats any finding as a documentation gap that should pause for approval. When auto-fix is enabled, the agent can update docs or doc comments, then the step re-runs and proceeds only after reassessment returns no findings.
 

--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -123,7 +123,7 @@ can also end early after `rebase` if the branch has no diff against the default
 branch, marking the remaining steps as skipped.
 
 1. Execute the step
-2. If the step finds `action: auto-fix` findings and auto-fix is enabled, loop back with the agent to fix them (up to the configured limit)
+2. If the step finds `action: auto-fix` findings, the step result is auto-fixable, and auto-fix is enabled, loop back with the agent to fix them (up to the configured limit)
 3. If blocking findings remain, or any finding has `action: ask-user`, pause and wait for user action
 4. `action: no-op` findings are informational only; the user can approve, fix selected findings, skip, or abort when the step pauses
 

--- a/docs/src/content/docs/concepts/pipeline.md
+++ b/docs/src/content/docs/concepts/pipeline.md
@@ -59,7 +59,7 @@ Every step can:
 
 - **Complete** cleanly and advance the pipeline.
 - **Return findings** with severity (`error`, `warning`, `info`) and an action (`auto-fix`, `ask-user`, `no-op`).
-- **Trigger auto-fix** if the step's `auto_fix` limit is above 0 and any finding is `auto-fix`-eligible.
+- **Trigger auto-fix** if the step's `auto_fix` limit is above 0, the step result is auto-fixable, and any finding is `auto-fix`-eligible.
 - **Pause for approval** if blocking findings remain after auto-fix, or if any finding is `ask-user`.
 - **Skip** when there's nothing to do (e.g., no diff, unsupported host).
 - **Fail** on fatal errors and stop the pipeline.

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -146,11 +146,13 @@ See [Repo Config Reference](/no-mistakes/reference/repo-config/) for the full fi
 - `intent` from the repo config overlays global intent settings. Fields not set in the repo config fall through to the global default, except `intent.disabled_readers`, which adds to globally disabled readers.
 - `commands` and `ignore_patterns` are repo-only fields.
 - `ci_timeout` and `auto_fix.ci` are the canonical keys; `babysit_timeout` and `auto_fix.babysit` are still accepted as legacy aliases.
-- If `commands.test` or `commands.lint` is empty, the agent detects and runs relevant commands itself.
+- If `commands.test` is empty, the agent detects and runs relevant tests itself.
+- If `commands.lint` is empty, the agent detects relevant linters and formatters, applies safe fixes, verifies them, commits any agent changes, and reports only unresolved issues.
 - If `commands.format` is empty, no formatter is run automatically.
 
 The practical implication is simple: explicit commands give you deterministic
 repo behavior, while leaving commands empty asks the agent to fill in the gap.
+For lint, that gap includes safe formatter and linter fixes during the initial lint pass.
 
 ## Ignore pattern rules
 

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -148,7 +148,7 @@ See [Repo Config Reference](/no-mistakes/reference/repo-config/) for the full fi
 - `ci_timeout` and `auto_fix.ci` are the canonical keys; `babysit_timeout` and `auto_fix.babysit` are still accepted as legacy aliases.
 - If `commands.test` is empty, the agent detects and runs relevant tests itself.
 - If `commands.lint` is empty, the agent detects relevant linters and formatters, applies safe fixes, verifies them, commits any agent changes, and reports only unresolved issues.
-- If `commands.format` is empty, no formatter is run automatically.
+- If `commands.format` is empty, no separate push-step formatter is run automatically.
 
 The practical implication is simple: explicit commands give you deterministic
 repo behavior, while leaving commands empty asks the agent to fill in the gap.

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -78,7 +78,7 @@ ci_timeout: "4h"  # any Go duration string
 # Daemon log verbosity.
 log_level: info  # debug | info | warn | error
 
-# Max auto-fix attempts per step. 0 = disabled (requires manual approval).
+# Max follow-up auto-fix attempts per step. 0 = disabled after the initial step pass.
 auto_fix:
   rebase: 3
   document: 3

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -188,7 +188,8 @@ Daemon log verbosity.
 
 ### auto_fix
 
-Maximum auto-fix attempts per step. Set a step to `0` to disable auto-fix (findings always require manual approval).
+Maximum follow-up auto-fix attempts per step. Set a step to `0` to disable the follow-up auto-fix loop, so findings require manual approval.
+For empty `commands.lint`, the agent still attempts safe fixes during the initial lint pass; unresolved lint findings then pause for approval instead of starting another automatic fix loop.
 
 | | |
 |---|---|

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -97,11 +97,15 @@ Runs linters and static analysis.
 
 **Behavior:**
 - If `commands.lint` is set: runs it via the platform shell (`sh -c` on POSIX, `cmd.exe /c` on Windows). Non-zero exit produces `warning` findings.
-- If `commands.lint` is empty: the agent detects and runs appropriate linters/formatters with inferred user intent when available, returning structured findings with severity, description, and `action` (`no-op`, `auto-fix`, `ask-user`).
+- If `commands.lint` is empty: the agent detects appropriate linters/formatters, applies safe fixes, reruns the relevant checks, commits any agent changes, and returns structured findings only for unresolved issues.
 
-**Approval:** lint findings with `action: ask-user` always require human approval. `action: auto-fix` findings stay eligible for the fix loop. `action: no-op` findings are informational only.
+**Approval:** lint findings with `action: ask-user` always require human approval.
+`action: auto-fix` findings stay eligible for the fix loop when `commands.lint` is configured.
+`action: no-op` findings are informational only.
 
-**Auto-fix:** same pattern as test - the agent fixes `action: auto-fix` issues using the previous findings plus any per-finding user notes, any selected user-authored findings from the TUI, and a sanitized history of prior rounds for that step, including earlier fix summaries and any findings the user left unselected in prior approval cycles, then lint re-runs. Fix commits use `no-mistakes(lint): <summary>`.
+**Auto-fix:** when `commands.lint` is configured, the lint step follows the same pattern as test - the agent fixes `action: auto-fix` issues using the previous findings plus any per-finding user notes, any selected user-authored findings from the TUI, and a sanitized history of prior rounds for that step, including earlier fix summaries and any findings the user left unselected in prior approval cycles, then lint re-runs.
+Fix commits use `no-mistakes(lint): <summary>`.
+When `commands.lint` is empty, unresolved findings pause for approval instead of starting another automatic lint/fix loop, because the agent already attempted a fix during the lint pass.
 
 **Default auto-fix limit:** `3`.
 

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -80,7 +80,9 @@ Formatter command run before the push step commits agent fixes.
 | | |
 |---|---|
 | Type | `string` |
-| Default | Empty (no formatter) |
+| Default | Empty (no separate push-step formatter) |
+
+This does not prevent empty `commands.lint` from detecting and running formatters during the lint step.
 
 ### ignore_patterns
 

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -70,7 +70,8 @@ Explicit lint command. Run via the platform shell - `sh -c` on POSIX, `cmd.exe /
 | Type | `string` |
 | Default | Empty (agent auto-detects) |
 
-Same behavior as `commands.test` - explicit command uses exit code, empty means agent-detected.
+When set, the lint step runs this exact command and checks the exit code.
+When empty, the agent detects relevant linters and formatters, applies safe fixes, reruns the relevant checks, commits any agent changes, and reports only unresolved issues.
 
 ### commands.format
 
@@ -115,7 +116,8 @@ Override auto-fix attempt limits for specific steps. Fields not set here inherit
 | `auto_fix.lint` | `int` | Inherits from global (default `3`) |
 | `auto_fix.ci` | `int` | Inherits from global (default `3`) |
 
-Set to `0` to disable auto-fix for a step (always requires manual approval).
+Set to `0` to disable the follow-up auto-fix loop for a step (findings require manual approval).
+For empty `commands.lint`, the agent still attempts safe fixes during the initial lint pass; unresolved lint findings then pause for approval instead of starting another automatic fix loop.
 
 `auto_fix.ci` covers the CI step's CI failure and merge-conflict auto-fix attempts.
 

--- a/internal/e2e/journey_test.go
+++ b/internal/e2e/journey_test.go
@@ -184,7 +184,7 @@ func runHappyPath(t *testing.T, agentName string) {
 	assertDocumentPrompt(t, h, run, invs)
 	assertDocumentStepNoGaps(t, run.Steps)
 	assertNoCommandTestStep(t, run.Steps, invs)
-	if !sawPromptContainingAll(invs, "Detect the linting and formatting tools", "branch: feature/e2e", "Set action to") {
+	if !sawPromptContainingAll(invs, "Detect the linting and formatting tools", "branch: feature/e2e", "only unresolved") {
 		t.Errorf("expected a lint prompt with branch metadata and action guidance in invocations, got %d:\n%s", len(invs), summarisePrompts(invs))
 	}
 	assertPromptsAbsent(t, invs,
@@ -369,7 +369,7 @@ func cleanReviewScenario(t *testing.T) string {
   - match: "You are validating a code change by testing it. Examine the repository and run the appropriate tests yourself.\n\nContext:\n- branch: test-malformed-structured-output"
     text: "tests found some issues"
     structured_raw: '{"summary":123}'
-  - match: "Detect the linting and formatting tools for this project and run the relevant checks yourself.\n\nContext:\n- branch: lint-malformed-structured-output"
+  - match: "Detect the linting and formatting tools for this project, run the relevant checks yourself, apply safe fixes, and verify the result.\n\nContext:\n- branch: lint-malformed-structured-output"
     text: "lint found some issues"
     structured_raw: '{"summary":123}'
   - match: "You are validating a code change by testing it. Examine the repository and run the appropriate tests yourself.\n\nContext:\n- branch: test-agent-staged-new-test-file"

--- a/internal/pipeline/steps/lint.go
+++ b/internal/pipeline/steps/lint.go
@@ -17,6 +17,78 @@ func (s *LintStep) Name() types.StepName { return types.StepLint }
 func (s *LintStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, error) {
 	ctx := sctx.Ctx
 	baseSHA := resolveBranchBaseSHA(ctx, sctx.WorkDir, sctx.Run.BaseSHA, sctx.Repo.DefaultBranch)
+	lintCmd := sctx.Config.Commands.Lint
+
+	if lintCmd == "" {
+		sctx.Log("no lint command configured, asking agent to lint and fix...")
+		reassessHistory := executionContextPromptSection() + roundHistoryPromptSection(sctx) + userIntentPromptSection(sctx)
+		prompt := fmt.Sprintf(
+			`Detect the linting and formatting tools for this project, run the relevant checks yourself, apply safe fixes, and verify the result.
+
+Context:
+- branch: %s
+- base commit: %s
+- target commit: %s
+
+Task:
+- Discover the configured linters and formatters for this repository.
+- Only lint or format the relevant changed files when possible.
+- Apply safe formatter, linter, and static-analysis fixes yourself.
+- Re-run the relevant checks after fixing.
+- Report only unresolved lint, format, or static-analysis issues as structured findings.
+- If everything is clean or fixed, return an empty findings array.
+
+Rules:
+- Do not run tests or broader behavioral validation.
+- Focus on lint, format, and static-analysis issues only.
+- Do not report issues you already fixed.
+- The summary must be one concise sentence fragment suitable for a git commit subject.
+- Keep the summary under 10 words.%s`,
+			sctx.Run.Branch,
+			baseSHA,
+			sctx.Run.HeadSHA,
+			reassessHistory,
+		)
+		if sctx.PreviousFindings != "" {
+			prompt += `
+
+Previous lint findings to address:
+` + sanitizedPreviousFindingsForPrompt(sctx.PreviousFindings)
+		}
+		result, err := sctx.Agent.Run(ctx, agent.RunOpts{
+			Prompt:     prompt,
+			CWD:        sctx.WorkDir,
+			JSONSchema: findingsSchema,
+			OnChunk:    sctx.LogChunk,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("agent lint: %w", err)
+		}
+
+		var findings Findings
+		if result.Output != nil {
+			if err := json.Unmarshal(result.Output, &findings); err != nil {
+				sctx.Log("could not parse structured output, using text response")
+				findings = Findings{Summary: result.Text}
+			}
+		}
+		summary, err := extractCommitSummary(result)
+		if err != nil {
+			sctx.Log(fmt.Sprintf("warning: could not parse lint summary: %v", err))
+		}
+		if err := commitAgentFixes(sctx, s.Name(), summary, "fix lint issues"); err != nil {
+			return nil, err
+		}
+
+		needsApproval := hasBlockingFindings(findings.Items)
+		findingsJSON, _ := json.Marshal(findings)
+		return &pipeline.StepOutcome{
+			NeedsApproval: needsApproval,
+			AutoFixable:   false,
+			Findings:      string(findingsJSON),
+			FixSummary:    summary,
+		}, nil
+	}
 
 	// In fix mode, ask agent to fix lint issues first
 	var fixSummary string
@@ -59,60 +131,6 @@ Previous lint findings to address:
 			return nil, err
 		}
 		fixSummary = summary
-	}
-
-	lintCmd := sctx.Config.Commands.Lint
-	if lintCmd == "" {
-		// No lint command configured — ask agent to detect and run linter
-		sctx.Log("no lint command configured, asking agent to lint...")
-		reassessHistory := executionContextPromptSection() + roundHistoryPromptSection(sctx) + userIntentPromptSection(sctx)
-		result, err := sctx.Agent.Run(ctx, agent.RunOpts{
-			Prompt: fmt.Sprintf(
-				`Detect the linting and formatting tools for this project and run the relevant checks yourself.
-
-Context:
-- branch: %s
-- base commit: %s
-- target commit: %s
-
-Task:
-- Discover the configured linters and formatters for this repository.
-- Only lint or format the relevant changed files when possible.
-- Report any issues found as structured findings.
-
-Rules:
-- Do not run tests or broader behavioral validation.
-- Focus on lint, format, and static-analysis issues only.
-- Set action to "auto-fix" for all findings. Lint findings are objective and do not question the author's intent.%s`,
-				sctx.Run.Branch,
-				baseSHA,
-				sctx.Run.HeadSHA,
-				reassessHistory,
-			),
-			CWD:        sctx.WorkDir,
-			JSONSchema: findingsSchema,
-			OnChunk:    sctx.LogChunk,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("agent lint: %w", err)
-		}
-
-		var findings Findings
-		if result.Output != nil {
-			if err := json.Unmarshal(result.Output, &findings); err != nil {
-				sctx.Log("could not parse structured output, using text response")
-				findings = Findings{Summary: result.Text}
-			}
-		}
-
-		needsApproval := hasBlockingFindings(findings.Items)
-		findingsJSON, _ := json.Marshal(findings)
-		return &pipeline.StepOutcome{
-			NeedsApproval: needsApproval,
-			AutoFixable:   needsApproval,
-			Findings:      string(findingsJSON),
-			FixSummary:    fixSummary,
-		}, nil
 	}
 
 	// Run configured lint command

--- a/internal/pipeline/steps/lint_test.go
+++ b/internal/pipeline/steps/lint_test.go
@@ -97,3 +97,71 @@ func TestLintStep_FixMode_UsesFallbackSummaryWhenStructuredSummaryMalformed(t *t
 		t.Fatalf("last commit message = %q", got)
 	}
 }
+
+func TestLintStep_NoConfiguredLint_CommitsAgentFixesWithoutApproval(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
+
+	callCount := 0
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			callCount++
+			os.WriteFile(filepath.Join(dir, "lint-fix.txt"), []byte("fixed"), 0o644)
+			return &agent.Result{Output: json.RawMessage(`{"findings":[],"summary":"format code"}`)}, nil
+		},
+	}
+
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+
+	step := &LintStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.NeedsApproval {
+		t.Error("expected no approval when agent fixed no-config lint issues")
+	}
+	if outcome.AutoFixable {
+		t.Error("expected no auto-fix loop when no unresolved lint issues remain")
+	}
+	if callCount != 1 {
+		t.Errorf("expected 1 agent call, got %d", callCount)
+	}
+	if status := gitStatusPorcelain(t, dir); status != "" {
+		t.Fatalf("expected clean worktree after lint fix commit, got %q", status)
+	}
+	if got := lastCommitMessage(t, dir); got != "no-mistakes(lint): format code" {
+		t.Fatalf("last commit message = %q", got)
+	}
+}
+
+func TestLintStep_NoConfiguredLint_UnresolvedFindingsNeedApprovalWithoutAutoFixLoop(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			return &agent.Result{Output: json.RawMessage(`{"findings":[{"severity":"warning","description":"prettier still fails","action":"auto-fix"}],"summary":"lint still fails"}`)}, nil
+		},
+	}
+
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+
+	step := &LintStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.NeedsApproval {
+		t.Error("expected approval for unresolved no-config lint findings")
+	}
+	if outcome.AutoFixable {
+		t.Error("expected unresolved no-config lint findings not to auto-fix again")
+	}
+	if !strings.Contains(ag.calls[0].Prompt, "only unresolved") {
+		t.Error("expected no-config lint prompt to report only unresolved issues")
+	}
+}


### PR DESCRIPTION
## Intent

The developer wanted to add automatic user-intent extraction to no-mistakes so pipeline agents understand the original goal behind a change. They wanted the system to find recent agent transcripts for the same repo and changed files, include all user and assistant text messages but no tool calls, summarize the developer's intent, and inject that context into downstream review/test/lint/document/PR prompts. They specified support for Claude, Codex, OpenCode, and Rovo Dev, no Aider support, default enabled with opt-out, a 3-day slack window for transcript matching, and graceful behavior when no session matches. They also required real e2e smoke coverage, fixing worktree/CWD issues for stateful agents like OpenCode, preserving both the beginning and end of long transcripts by trimming from the middle, hardening prompt injection handling, and fixing Codex state DB numeric version selection.

## What Changed
- Updated the lint step so repositories without `commands.lint` ask the agent to detect linting/formatting tools, apply safe fixes, verify them, and commit resulting changes during the initial lint pass.
- Changed unresolved no-config lint findings to require approval without triggering a second auto-fix loop, while preserving the existing fix-mode flow for configured lint commands.
- Added lint regression coverage and refreshed docs to describe the new no-config lint behavior and formatter interaction.

## Risk Assessment

✅ Low: The change is narrowly scoped to the no-config lint path, preserves the configured-lint behavior, and includes targeted coverage for the new commit-and-approval behavior.

## Testing

- Summary: Exercised the touched lint-step unit tests plus the relevant e2e user journey; after updating stale e2e prompt fixtures, all selected tests passed.
- `go test ./internal/pipeline/steps`
- `go test -tags=e2e -count=1 -timeout 300s ./internal/e2e -run '^TestUserJourney/claude$'`
- `go test -race ./internal/pipeline/steps`
- `go test -tags=e2e -count=1 -timeout 300s ./internal/e2e -run '^TestUserJourney$'`
- Outcome: ✅ passed across 1 run (7m36s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/pipeline/steps`
- `go test -tags=e2e -count=1 -timeout 300s ./internal/e2e -run '^TestUserJourney/claude$'`
- `go test -race ./internal/pipeline/steps`
- `go test -tags=e2e -count=1 -timeout 300s ./internal/e2e -run '^TestUserJourney$'`

</details>

<details>
<summary>🔧 **Document** - 5 issues found → auto-fixed (3)</summary>

**Round 1** - found 5 warnings
- ⚠️ `docs/src/content/docs/reference/repo-config.md:73` - `commands.lint` is documented as having the same empty-command behavior as `commands.test`, but the change makes the empty lint path materially different: the agent now detects linters/formatters, applies safe fixes, reruns checks, commits any changes, reports only unresolved findings, and disables the subsequent auto-fix loop. Update this reference to distinguish empty `commands.lint` from empty `commands.test`.
- ⚠️ `docs/src/content/docs/reference/global-config.md:191` - The global `auto_fix` reference says setting a step to `0` disables auto-fix and findings always require manual approval. For lint with no configured `commands.lint`, the new code applies and commits safe fixes during the initial lint pass regardless of the auto-fix retry loop, then pauses only for unresolved findings. Document this lint exception or clarify that `auto_fix.lint` controls only the follow-up lint fix loop when a lint command is configured.
- ⚠️ `docs/src/content/docs/reference/repo-config.md:118` - The repo-level `auto_fix` docs say setting a step to `0` disables auto-fix and always requires manual approval. That is stale for the no-`commands.lint` path introduced here, where lint fixes can be applied and committed during the initial lint pass and unresolved findings are not auto-fixable afterward. Clarify the lint-specific exception in the repo config reference.
- ⚠️ `docs/src/content/docs/guides/configuration.md:149` - The configuration guide says empty `commands.test` or `commands.lint` means the agent detects and runs relevant commands itself. This now underspecifies lint behavior: empty `commands.lint` also asks the agent to apply safe fixes, verify them, commit changes, and avoid a second auto-fix loop for unresolved findings. Update the guide so users understand the operational difference between leaving test and lint commands empty.
- ⚠️ `docs/src/content/docs/concepts/auto-fix.md:24` - The auto-fix concept page describes a generic flow where a step first returns findings, then the executor reruns the step with `fixing=true` when eligible. The new no-config lint path performs fix-and-verify work inside the initial lint execution and returns `AutoFixable: false` for unresolved findings, so the conceptual flow needs a lint-specific exception. The statement at line 65 that `review`, `test`, and `lint` use the shared model directly should also be narrowed.

**Round 2** (auto-fix) - found 3 warnings
- ⚠️ `docs/src/content/docs/guides/configuration.md:81` - The global config example still says `0 = disabled (requires manual approval)`. After this change, `auto_fix.lint: 0` only disables the follow-up lint auto-fix loop; when `commands.lint` is empty, the initial lint pass can still apply and commit safe fixes before reporting unresolved issues. Update the example comment to match the clarified lint exception documented later on the page.
- ⚠️ `docs/src/content/docs/concepts/gate-model.md:126` - The executor overview says any step with `action: auto-fix` findings and auto-fix enabled loops back with the agent. The changed no-config lint path can return unresolved findings with `action: auto-fix` while setting the step outcome as not auto-fixable, so it pauses instead of looping. Update this flow to mention step-level auto-fix eligibility or the no-`commands.lint` exception.
- ⚠️ `docs/src/content/docs/concepts/pipeline.md:62` - The pipeline concept page states that a step triggers auto-fix whenever the step&#39;s `auto_fix` limit is above 0 and any finding is `auto-fix`-eligible. With empty `commands.lint`, the lint step now applies safe fixes during the initial pass and marks unresolved findings as not eligible for another automatic fix loop even if their action is `auto-fix`. Add the lint exception or clarify that auto-fix also depends on the step outcome being auto-fixable.

**Round 3** (auto-fix) - found 2 warnings
- ⚠️ `docs/src/content/docs/guides/configuration.md:151` - The guide still says that if `commands.format` is empty, no formatter is run automatically. That is now stale when `commands.lint` is empty: the lint step can detect formatters, apply safe formatting fixes, verify them, and commit those changes during the initial lint pass. Clarify that `commands.format` only controls the formatter run before push/agent-fix commits, and that no-config lint may still run formatters.
- ⚠️ `docs/src/content/docs/reference/repo-config.md:83` - The `commands.format` default is documented as `Empty (no formatter)`, but the new empty-`commands.lint` behavior can still run detected formatters as part of linting and commit those safe fixes. Update this reference to distinguish an unset push-step formatter from formatter use inside the no-config lint pass.

**Round 4** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
