### PR TITLE
fix(tui): show completed fix progress counts

### DIFF
--- a/docs/src/content/docs/guides/tui.md
+++ b/docs/src/content/docs/guides/tui.md
@@ -76,7 +76,10 @@ Step status icons:
 | `–` | Skipped |
 | `✗` | Failed |
 
-Completed steps show their duration. Steps with fixed findings show a right-aligned count such as `2/3 fixed`. Connectors (`│`) between steps are hidden when the terminal height is under 30 lines.
+Completed steps show their duration.
+Steps with fixed findings, and steps currently fixing reported findings, show a right-aligned count such as `2/3 fixed` or `0/3 fixed`.
+The first number counts completed fixes, not findings selected for an in-progress fix.
+Connectors (`│`) between steps are hidden when the terminal height is under 30 lines.
 
 ### Findings panel
 

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -326,7 +326,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 						}
 					}
 				}
-				e.emitStepEventWithFindingsDiffErrorAndFixProgress(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFixing), "", "", "", nil, findingsCount(fixableFindings))
+				e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFixing), "", "", "", nil)
 				phaseStart = time.Now()
 				sctx.Fixing = true
 				sctx.PreviousFindings = fixableFindings
@@ -444,7 +444,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 					}
 				}
 			}
-			e.emitStepEventWithFindingsDiffErrorAndFixProgress(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFixing), "", "", "", nil, inFlightFixedFindingCount(outcome.Findings, response.findingIDs, response.addedFindings))
+			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFixing), "", "", "", nil)
 			slog.Info("step fix requested, re-executing", "step", stepName)
 			continue // loop back to step.Execute
 		}
@@ -550,10 +550,6 @@ func (e *Executor) emitStepEventWithFindingsAndDiff(eventType ipc.EventType, run
 }
 
 func (e *Executor) emitStepEventWithFindingsDiffAndError(eventType ipc.EventType, run *db.Run, repo *db.Repo, stepName types.StepName, status string, findings string, diff string, errMsg string, durationMS *int64) {
-	e.emitStepEventWithFindingsDiffErrorAndFixProgress(eventType, run, repo, stepName, status, findings, diff, errMsg, durationMS, 0)
-}
-
-func (e *Executor) emitStepEventWithFindingsDiffErrorAndFixProgress(eventType ipc.EventType, run *db.Run, repo *db.Repo, stepName types.StepName, status string, findings string, diff string, errMsg string, durationMS *int64, inFlightFixedFindings int) {
 	event := ipc.Event{
 		Type:       eventType,
 		RunID:      run.ID,
@@ -563,12 +559,6 @@ func (e *Executor) emitStepEventWithFindingsDiffErrorAndFixProgress(eventType ip
 		DurationMS: durationMS,
 	}
 	stats := e.findingStatsForStep(run.ID, stepName)
-	if inFlightFixedFindings > 0 && stats.ReportedFindings > 0 {
-		stats.FixedFindings += inFlightFixedFindings
-		if stats.FixedFindings > stats.ReportedFindings {
-			stats.FixedFindings = stats.ReportedFindings
-		}
-	}
 	if stats.ReportedFindings > 0 || stats.FixedFindings > 0 {
 		reported := stats.ReportedFindings
 		fixed := stats.FixedFindings
@@ -604,30 +594,6 @@ func (e *Executor) emitStepEventWithFindingsDiffErrorAndFixProgress(eventType ip
 		fields["findings_count"] = findingsCount(findings)
 	}
 	telemetry.Track("step", fields)
-}
-
-func inFlightFixedFindingCount(raw string, ids []string, addedFindings []types.Finding) int {
-	count := len(addedFindings)
-	if raw == "" || len(ids) == 0 {
-		return count
-	}
-	findings, err := types.ParseFindingsJSON(raw)
-	if err != nil {
-		return count
-	}
-	selected := make(map[string]bool, len(ids))
-	for _, id := range ids {
-		if id != "" {
-			selected[id] = true
-		}
-	}
-	for _, item := range findings.Items {
-		if selected[item.ID] {
-			count++
-			delete(selected, item.ID)
-		}
-	}
-	return count
 }
 
 func (e *Executor) findingStatsForStep(runID string, stepName types.StepName) db.StepStats {

--- a/internal/pipeline/executor_fix_test.go
+++ b/internal/pipeline/executor_fix_test.go
@@ -173,10 +173,10 @@ func TestExecutor_FixingEventIncludesFindingStats(t *testing.T) {
 		t.Fatal(err)
 	}
 	fixingEvent := waitForEvent(t, events, ipc.EventStepCompleted, string(types.StepStatusFixing))
-	if fixingEvent.FixedFindings == nil || *fixingEvent.FixedFindings != 1 {
+	if fixingEvent.FixedFindings == nil || *fixingEvent.FixedFindings != 0 {
 		close(releaseFix)
 		<-done
-		t.Fatalf("fixed findings = %v, want 1", fixingEvent.FixedFindings)
+		t.Fatalf("fixed findings = %v, want 0", fixingEvent.FixedFindings)
 	}
 	if fixingEvent.ReportedFindings == nil || *fixingEvent.ReportedFindings != 2 {
 		close(releaseFix)
@@ -192,31 +192,6 @@ func TestExecutor_FixingEventIncludesFindingStats(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("executor timed out")
-	}
-}
-
-func TestInFlightFixedFindingCount_EmptySelectionCountsNoExistingFindings(t *testing.T) {
-	raw := `{"findings":[{"id":"r1","severity":"warning","description":"one","action":"auto-fix"},{"id":"r2","severity":"warning","description":"two","action":"auto-fix"}],"summary":"two"}`
-
-	if got := inFlightFixedFindingCount(raw, nil, nil); got != 0 {
-		t.Fatalf("in-flight fixed findings = %d, want 0", got)
-	}
-}
-
-func TestInFlightFixedFindingCount_CountsOnlyUniqueMatchingSelection(t *testing.T) {
-	raw := `{"findings":[{"id":"r1","severity":"warning","description":"one","action":"auto-fix"},{"id":"r2","severity":"warning","description":"two","action":"auto-fix"}],"summary":"two"}`
-
-	if got := inFlightFixedFindingCount(raw, []string{"r1", "missing", "r1"}, nil); got != 1 {
-		t.Fatalf("in-flight fixed findings = %d, want 1", got)
-	}
-}
-
-func TestInFlightFixedFindingCount_CountsAddedFindings(t *testing.T) {
-	raw := `{"findings":[{"id":"r1","severity":"warning","description":"one","action":"auto-fix"},{"id":"r2","severity":"warning","description":"two","action":"auto-fix"}],"summary":"two"}`
-	added := []types.Finding{{ID: "u1", Severity: "warning", Description: "user one", Action: types.ActionAutoFix, Source: types.FindingSourceUser}}
-
-	if got := inFlightFixedFindingCount(raw, []string{"r1"}, added); got != 2 {
-		t.Fatalf("in-flight fixed findings = %d, want 2", got)
 	}
 }
 

--- a/internal/tui/pipeline.go
+++ b/internal/tui/pipeline.go
@@ -174,7 +174,7 @@ func renderPipelineView(run *ipc.RunInfo, steps []ipc.StepResultInfo, width int,
 				line += " " + dimStyle.Render(errText)
 			}
 		}
-		if step.FixedFindings > 0 && step.ReportedFindings > 0 {
+		if step.ReportedFindings > 0 && (step.FixedFindings > 0 || step.Status == types.StepStatusFixing) {
 			fixedLabel := dimStyle.Render(fmt.Sprintf("%d/%d fixed", step.FixedFindings, step.ReportedFindings))
 			line = appendRightLabel(line, fixedLabel, contentWidth)
 		}

--- a/internal/tui/pipeline_test.go
+++ b/internal/tui/pipeline_test.go
@@ -218,6 +218,24 @@ func TestRenderPipelineView_ShowsFixedFindingsAtRightEdge(t *testing.T) {
 	}
 }
 
+func TestRenderPipelineView_ShowsZeroFixedFindingsWhileFixing(t *testing.T) {
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusFixing
+	run.Steps[0].FixedFindings = 0
+	run.Steps[0].ReportedFindings = 3
+
+	out := stripANSI(renderPipelineView(run, run.Steps, 80, 0, 40))
+	var reviewLine string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "Review") {
+			reviewLine = line
+		}
+	}
+	if !strings.Contains(reviewLine, "0/3 fixed") {
+		t.Fatalf("expected fixing Review row to show completed fixed count, got %q", reviewLine)
+	}
+}
+
 func TestRenderPipelineView_FixingStatusOmitsAgentFixingLabel(t *testing.T) {
 	run := testRun()
 	run.Steps[1].Status = types.StepStatusFixing


### PR DESCRIPTION
## Intent

The developer wanted the TUI pipeline steps panel to distinguish completed fixes from fixes merely sent to an agent and still in progress. They specifically required the display to show a count like "0/3 fixed" when three findings have been identified but none have completed fixing yet, rather than hiding the label or showing "3/3 fixed". They clarified that the numerator must represent only completed fixes, not selected or in-flight findings.

## What Changed
- Updated the TUI pipeline row rendering so fixing steps show completed-fix progress such as `0/N fixed` instead of counting selected or in-flight fixes as complete.
- Removed pipeline-side adjustment logic that inflated fixed counts while agent fixes were still running.
- Clarified the TUI guide to explain that fixed counts represent completed fixes and can appear as `0/N fixed` during fixing.

## Risk Assessment

✅ Low: The change is narrowly scoped to removing in-flight fix counts from step events and showing zero-progress labels only while a step is fixing, with focused tests covering the intended behavior.

## Testing

- Summary: Exercised the TUI fixed-count rendering and pipeline executor fixing-event stats paths; all relevant targeted and package tests passed.
- `go test ./internal/tui -run 'TestRenderPipelineView_(ShowsFixedFindingsAtRightEdge|ShowsZeroFixedFindingsWhileFixing|FixingStatusOmitsAgentFixingLabel)' -count=1`
- `go test ./internal/pipeline -run '^TestExecutor_FixingEventIncludesFindingStats$' -count=1`
- `go test ./internal/tui -count=1`
- `go test ./internal/pipeline -count=1`
- Outcome: ✅ passed across 1 run (1m26s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/tui -run 'TestRenderPipelineView_(ShowsFixedFindingsAtRightEdge|ShowsZeroFixedFindingsWhileFixing|FixingStatusOmitsAgentFixingLabel)' -count=1`
- `go test ./internal/pipeline -run '^TestExecutor_FixingEventIncludesFindingStats$' -count=1`
- `go test ./internal/tui -count=1`
- `go test ./internal/pipeline -count=1`

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 info
- ℹ️ `docs/src/content/docs/guides/tui.md:79` - The TUI pipeline box documentation says fixed-finding counts are shown only for steps with fixed findings, but the changed behavior now also shows a right-aligned `0/N fixed` count while a step is in `fixing` status. Update this section to clarify that the numerator counts only completed fixes, not selected or in-flight findings, and that fixing rows can display `0/N fixed`.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
