### PR TITLE
fix(pipeline): compact PR testing evidence

### DIFF
--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -68,7 +68,7 @@ Runs baseline tests and gathers evidence for the intended behavior.
 **Behavior:**
 - If `commands.test` is set in repo config: runs it first as a baseline via the platform shell (`sh -c` on POSIX, `cmd.exe /c` on Windows) and captures output. Non-zero exit produces `error` findings.
 - If `commands.test` is empty, or inferred user intent is available after the baseline command passes: the agent validates the change with evidence-oriented tests or manual checks, returning structured findings with severity, description, and `action` (`no-op`, `auto-fix`, `ask-user`).
-- The step records the exact tests and checks it exercised in a `tested` array, may include a short natural-language `testing_summary`, and includes an `artifacts` array for reviewer-visible evidence such as screenshots, videos, logs, CLI transcripts, rendered output, or API responses.
+- The step records the exact tests and checks it exercised in a `tested` array, may include a short natural-language `testing_summary`, and includes an `artifacts` array for reviewer-visible evidence; `path` artifacts must already exist in the repository and be available from the pushed commit, `url` artifacts must be externally visible, and `content` artifacts should be short logs or command output shown directly in the PR.
 - Missing evidence for inferred user intent can be reported as a warning with `action: ask-user`.
 - If the agent creates new test files (detected via `git status --porcelain`), approval is required even if tests pass.
 
@@ -142,7 +142,7 @@ Creates or updates a pull request.
 - PR title: agent-generated with inferred user intent when available, in conventional commit format (`type(scope): description` or `type: description`); user-facing product impact should use `feat` or `fix` so release automation can pick it up; when a scope is used, it should be the primary affected real module/package from the changed paths and kept broad rather than file-level
 - PR body includes: a `## Intent` section from extracted user intent when available, an agent-authored `## What Changed`, and regenerated `## Risk Assessment`, `## Testing`, and `## Pipeline` sections from recorded step results and rounds
 - The regenerated `## Testing` section prefers the recorded `testing_summary`, uses a compact recorded-check count when no summary is available, includes produced evidence artifacts from `path`, `url`, or `content` fields when available, and ends with the overall outcome including run count and total duration when available
-- Evidence artifacts render compactly in GitHub PR bodies: `path` and `url` artifacts become `Evidence` links, repository-relative paths use blob URLs, and `content` artifacts appear in collapsible details blocks
+- Evidence artifacts render compactly in PR bodies: `path` and `url` artifacts become `Evidence` links, `content` artifacts appear in collapsible details blocks, and GitHub PRs convert repository-relative paths to blob URLs
 
 Stores the PR URL in the database and streams it to the TUI.
 

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -141,8 +141,8 @@ Creates or updates a pull request.
 - Uses the provider CLI for GitHub/GitLab and the Bitbucket API for Bitbucket Cloud
 - PR title: agent-generated with inferred user intent when available, in conventional commit format (`type(scope): description` or `type: description`); user-facing product impact should use `feat` or `fix` so release automation can pick it up; when a scope is used, it should be the primary affected real module/package from the changed paths and kept broad rather than file-level
 - PR body includes: a `## Intent` section from extracted user intent when available, an agent-authored `## What Changed`, and regenerated `## Risk Assessment`, `## Testing`, and `## Pipeline` sections from recorded step results and rounds
-- The regenerated `## Testing` section prefers the recorded `testing_summary`, lists deduplicated `tested` commands or selectors, includes produced evidence artifacts from `path`, `url`, or `content` fields when available, and ends with the overall outcome including run count and total duration when available
-- Evidence artifacts render in the PR body: image artifacts appear inline, video artifacts use an HTML video element, log/file artifacts become links or inline text blocks, and GitHub PRs convert repository-relative paths to blob or raw URLs
+- The regenerated `## Testing` section prefers the recorded `testing_summary`, uses a compact recorded-check count when no summary is available, includes produced evidence artifacts from `path`, `url`, or `content` fields when available, and ends with the overall outcome including run count and total duration when available
+- Evidence artifacts render compactly in GitHub PR bodies: `path` and `url` artifacts become `Evidence` links, repository-relative paths use blob URLs, and `content` artifacts appear in collapsible details blocks
 
 Stores the PR URL in the database and streams it to the TUI.
 

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -13,8 +13,10 @@ import (
 )
 
 type testingSummaryOptions struct {
-	githubBlobBase string
-	githubRawBase  string
+	githubBlobBase       string
+	githubRawBase        string
+	includeTestedDetails bool
+	compactArtifacts     bool
 }
 
 // BuildPipelineSummary produces a deterministic markdown section from step results and rounds.
@@ -55,11 +57,13 @@ func BuildPipelineSummary(steps []*db.StepResult, rounds map[string][]*db.StepRo
 
 // BuildTestingSummary extracts a deterministic Testing section from the test step.
 func BuildTestingSummary(steps []*db.StepResult, rounds map[string][]*db.StepRound) string {
-	return buildTestingSummary(steps, rounds, testingSummaryOptions{})
+	return buildTestingSummary(steps, rounds, testingSummaryOptions{includeTestedDetails: true})
 }
 
 func BuildTestingSummaryForPR(steps []*db.StepResult, rounds map[string][]*db.StepRound, upstreamURL, ref string) string {
-	return buildTestingSummary(steps, rounds, testingSummaryOptionsForGitHub(upstreamURL, ref))
+	opts := testingSummaryOptionsForGitHub(upstreamURL, ref)
+	opts.compactArtifacts = true
+	return buildTestingSummary(steps, rounds, opts)
 }
 
 func buildTestingSummary(steps []*db.StepResult, rounds map[string][]*db.StepRound, opts testingSummaryOptions) string {
@@ -91,14 +95,16 @@ func buildTestingSummary(steps []*db.StepResult, rounds map[string][]*db.StepRou
 				b.WriteString("\n")
 			}
 		}
-		for _, detail := range tested {
-			rendered := renderTestedDetail(detail)
-			if rendered == "" {
-				continue
+		if opts.includeTestedDetails {
+			for _, detail := range tested {
+				rendered := renderTestedDetail(detail)
+				if rendered == "" {
+					continue
+				}
+				b.WriteString("- ")
+				b.WriteString(rendered)
+				b.WriteString("\n")
 			}
-			b.WriteString("- ")
-			b.WriteString(rendered)
-			b.WriteString("\n")
 		}
 		for _, artifact := range artifacts {
 			rendered := renderTestingArtifact(artifact, opts)
@@ -129,8 +135,9 @@ func testingSummaryOptionsForGitHub(upstreamURL, ref string) testingSummaryOptio
 		return testingSummaryOptions{}
 	}
 	return testingSummaryOptions{
-		githubBlobBase: "https://github.com/" + repoPath + "/blob/" + url.PathEscape(ref) + "/",
-		githubRawBase:  "https://raw.githubusercontent.com/" + repoPath + "/" + url.PathEscape(ref) + "/",
+		githubBlobBase:       "https://github.com/" + repoPath + "/blob/" + url.PathEscape(ref) + "/",
+		githubRawBase:        "https://raw.githubusercontent.com/" + repoPath + "/" + url.PathEscape(ref) + "/",
+		includeTestedDetails: false,
 	}
 }
 
@@ -304,6 +311,9 @@ func renderTestingArtifact(artifact types.TestArtifact, opts testingSummaryOptio
 	if label == "" {
 		return ""
 	}
+	if opts.compactArtifacts {
+		return renderCompactTestingArtifact(artifact, opts, label)
+	}
 	target := artifact.URL
 	if target == "" {
 		target = artifactTargetForPath(artifact, opts)
@@ -328,6 +338,30 @@ func renderTestingArtifact(artifact types.TestArtifact, opts testingSummaryOptio
 	return strings.TrimRight(b.String(), "\n") + "\n"
 }
 
+func renderCompactTestingArtifact(artifact types.TestArtifact, opts testingSummaryOptions, label string) string {
+	target := artifact.URL
+	if target == "" {
+		target = artifactLinkTargetForPath(artifact, opts)
+	}
+	if target == "" && artifact.Content == "" {
+		return ""
+	}
+
+	if artifact.Content == "" {
+		return fmt.Sprintf("- Evidence: [%s](%s)\n", html.EscapeString(label), target)
+	}
+
+	var b strings.Builder
+	b.WriteString("<details>\n")
+	b.WriteString(fmt.Sprintf("<summary>Evidence: %s</summary>\n\n", html.EscapeString(label)))
+	if target != "" {
+		b.WriteString(fmt.Sprintf("Source: [%s](%s)\n\n", html.EscapeString(label), target))
+	}
+	b.WriteString(fmt.Sprintf("```text\n%s\n```\n", escapeMarkdownFence(artifact.Content)))
+	b.WriteString("</details>\n")
+	return b.String()
+}
+
 func artifactTargetForPath(artifact types.TestArtifact, opts testingSummaryOptions) string {
 	if artifact.Path == "" {
 		return ""
@@ -337,6 +371,16 @@ func artifactTargetForPath(artifact types.TestArtifact, opts testingSummaryOptio
 	}
 	if isImageArtifact(artifact.Kind, artifact.Path) || isVideoArtifact(artifact.Kind, artifact.Path) {
 		return opts.githubRawBase + artifact.Path
+	}
+	return opts.githubBlobBase + artifact.Path
+}
+
+func artifactLinkTargetForPath(artifact types.TestArtifact, opts testingSummaryOptions) string {
+	if artifact.Path == "" {
+		return ""
+	}
+	if opts.githubBlobBase == "" {
+		return artifact.Path
 	}
 	return opts.githubBlobBase + artifact.Path
 }

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -94,6 +94,10 @@ func buildTestingSummary(steps []*db.StepResult, rounds map[string][]*db.StepRou
 				b.WriteString(rendered)
 				b.WriteString("\n")
 			}
+		} else if !opts.includeTestedDetails && len(tested) > 0 {
+			b.WriteString("- Summary: ")
+			b.WriteString(compactTestedSummary(len(tested)))
+			b.WriteString("\n")
 		}
 		if opts.includeTestedDetails {
 			for _, detail := range tested {
@@ -126,6 +130,13 @@ func buildTestingSummary(steps []*db.StepResult, rounds map[string][]*db.StepRou
 	}
 
 	return ""
+}
+
+func compactTestedSummary(count int) string {
+	if count == 1 {
+		return "Completed 1 recorded test check."
+	}
+	return fmt.Sprintf("Completed %d recorded test checks.", count)
 }
 
 func testingSummaryOptionsForGitHub(upstreamURL, ref string) testingSummaryOptions {

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -212,6 +212,31 @@ func TestBuildTestingSummary_IncludesRecordedTestDetails(t *testing.T) {
 	}
 }
 
+func TestBuildTestingSummaryForPR_OmitsRecordedTestDetails(t *testing.T) {
+	t.Parallel()
+	findings := "{\"findings\":[],\"summary\":\"\",\"testing_summary\":\"Validated the CLI doctor path and config loading; both passed.\",\"tested\":[\"`go test ./internal/cli -run '^TestDoctorBasic$' -count=1`\",\"`make e2e`\"]}"
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepTest, Status: types.StepStatusCompleted, FindingsJSON: &findings},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 300}},
+	}
+
+	md := BuildTestingSummaryForPR(steps, rounds, "git@github.com:example/widgets.git", "abc123")
+
+	if !strings.Contains(md, "- Summary: Validated the CLI doctor path and config loading; both passed.") {
+		t.Fatalf("expected natural-language testing summary, got:\n%s", md)
+	}
+	for _, command := range []string{"go test ./internal/cli", "make e2e"} {
+		if strings.Contains(md, command) {
+			t.Fatalf("did not expect raw recorded command %q in PR testing summary, got:\n%s", command, md)
+		}
+	}
+	if !strings.Contains(md, "- Outcome: ✅ passed across 1 run (300ms)") {
+		t.Fatalf("expected outcome line with run count and duration, got:\n%s", md)
+	}
+}
+
 func TestBuildTestingSummary_EscapesMarkdownInTestingSummary(t *testing.T) {
 	t.Parallel()
 	findings := "{\"findings\":[],\"summary\":\"\",\"testing_summary\":\"Validated `go test ./...`\\nand noted <details> output\",\"tested\":[]}"
@@ -301,9 +326,9 @@ func TestBuildTestingSummary_RejectsUnsafeArtifactTargets(t *testing.T) {
 	}
 }
 
-func TestBuildTestingSummary_ConvertsArtifactPathsToGitHubURLs(t *testing.T) {
+func TestBuildTestingSummaryForPR_RendersEvidenceArtifactsCompactly(t *testing.T) {
 	t.Parallel()
-	findings := `{"findings":[],"summary":"","testing_summary":"Evidence was collected.","artifacts":[{"kind":"screenshot","label":"Checkout screenshot","path":"artifacts/checkout.png"},{"kind":"log","label":"Server log","path":"artifacts/server.log"}]}`
+	findings := `{"findings":[],"summary":"","testing_summary":"Evidence was collected.","artifacts":[{"kind":"screenshot","label":"Checkout screenshot","path":"artifacts/checkout.png"},{"kind":"log","label":"Server log","path":"artifacts/server.log"},{"kind":"log","label":"Placement rectangle evidence","content":"{\"button\":{\"top\":169,\"left\":248,\"right\":272,\"bottom\":193}}"}]}`
 	steps := []*db.StepResult{
 		{ID: "s1", StepName: types.StepTest, Status: types.StepStatusCompleted, FindingsJSON: &findings},
 	}
@@ -314,15 +339,18 @@ func TestBuildTestingSummary_ConvertsArtifactPathsToGitHubURLs(t *testing.T) {
 	md := BuildTestingSummaryForPR(steps, rounds, "git@github.com:example/widgets.git", "abc123")
 	t.Logf("rendered PR testing markdown:\n%s", md)
 
-	if !strings.Contains(md, "![Checkout screenshot](https://raw.githubusercontent.com/example/widgets/abc123/artifacts/checkout.png)") {
-		t.Fatalf("expected screenshot path to render as raw GitHub URL, got:\n%s", md)
+	if !strings.Contains(md, "- Evidence: [Checkout screenshot](https://github.com/example/widgets/blob/abc123/artifacts/checkout.png)") {
+		t.Fatalf("expected screenshot path to render as compact GitHub blob link, got:\n%s", md)
 	}
 	if !strings.Contains(md, "[Server log](https://github.com/example/widgets/blob/abc123/artifacts/server.log)") {
 		t.Fatalf("expected log path to render as GitHub blob URL, got:\n%s", md)
 	}
-	for _, broken := range []string{"](artifacts/checkout.png)", "](artifacts/server.log)"} {
+	if !strings.Contains(md, "<details>\n<summary>Evidence: Placement rectangle evidence</summary>") || !strings.Contains(md, "```text\n{\"button\":{\"top\":169,\"left\":248,\"right\":272,\"bottom\":193}}\n```") {
+		t.Fatalf("expected content artifact to render in collapsible details, got:\n%s", md)
+	}
+	for _, broken := range []string{"![Checkout screenshot]", "raw.githubusercontent.com", "](artifacts/checkout.png)", "](artifacts/server.log)"} {
 		if strings.Contains(md, broken) {
-			t.Fatalf("did not expect raw repository-relative artifact path %q, got:\n%s", broken, md)
+			t.Fatalf("did not expect broken or noisy artifact rendering %q, got:\n%s", broken, md)
 		}
 	}
 }

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -237,6 +237,29 @@ func TestBuildTestingSummaryForPR_OmitsRecordedTestDetails(t *testing.T) {
 	}
 }
 
+func TestBuildTestingSummaryForPR_SummarizesBaselineOnlyTests(t *testing.T) {
+	t.Parallel()
+	findings := "{\"findings\":[],\"summary\":\"\",\"tested\":[\"`go test ./...`\"]}"
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepTest, Status: types.StepStatusCompleted, FindingsJSON: &findings},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 300}},
+	}
+
+	md := BuildTestingSummaryForPR(steps, rounds, "git@github.com:example/widgets.git", "abc123")
+
+	if !strings.Contains(md, "- Summary: Completed 1 recorded test check.") {
+		t.Fatalf("expected compact baseline test summary, got:\n%s", md)
+	}
+	if strings.Contains(md, "go test ./...") {
+		t.Fatalf("did not expect raw recorded command in PR testing summary, got:\n%s", md)
+	}
+	if !strings.Contains(md, "- Outcome: ✅ passed across 1 run (300ms)") {
+		t.Fatalf("expected outcome line with run count and duration, got:\n%s", md)
+	}
+}
+
 func TestBuildTestingSummary_EscapesMarkdownInTestingSummary(t *testing.T) {
 	t.Parallel()
 	findings := "{\"findings\":[],\"summary\":\"\",\"testing_summary\":\"Validated `go test ./...`\\nand noted <details> output\",\"tested\":[]}"

--- a/internal/pipeline/steps/test.go
+++ b/internal/pipeline/steps/test.go
@@ -132,8 +132,9 @@ Task:
 - If automated testing cannot produce the needed evidence, execute manual verification steps and record the evidence-producing steps you performed.
 - If sufficient evidence is not possible, report a warning finding explaining what evidence is missing and why the user needs to decide what to do.
 - Include a concise "testing_summary" sentence describing what you exercised and the overall result.
+- The "testing_summary" must account for the complete test step: baseline commands that already ran, automated tests, manual or evidence-producing checks, artifacts gathered, and the overall result.
 - Record the exact tests, manual checks, and evidence-producing steps you ran in a "tested" array. Prefer concrete commands or test selectors wrapped in backticks.
-- Always include an "artifacts" array. Leave it empty when you produced no reviewer-visible evidence artifacts. Use "path" for repository-relative files, "url" for externally visible artifacts, and "content" for short logs or command output that should be shown directly in the PR.
+- Always include an "artifacts" array. Leave it empty when you produced no reviewer-visible evidence artifacts. Use artifact path only for files that already exist in the repository and will be available from the pushed commit, artifact url for externally visible artifacts, and artifact content for short logs or command output that should be shown directly in the PR.
 - If tests fail, determine whether the problem is a real product/code failure, a setup/environment problem you can fix, or a flaky/infrastructure issue.
 - If the issue is setup-related and fixable, fix it and retry the tests.
 

--- a/internal/pipeline/steps/test_test.go
+++ b/internal/pipeline/steps/test_test.go
@@ -189,10 +189,12 @@ func TestTestStep_UserIntentRunsConfiguredCommandThenEvidenceAgent(t *testing.T)
 		"Only use command output as an artifact when that output directly demonstrates the end-user experience or requested behavior",
 		"Configured test command already ran successfully as baseline",
 		testCmd,
+		"The \"testing_summary\" must account for the complete test step: baseline commands that already ran, automated tests, manual or evidence-producing checks, artifacts gathered, and the overall result",
 		"screenshots, GIFs, videos, rendered UI, CLI transcripts",
 		"If no existing test produces sufficient evidence, write or improve a test",
 		"If automated testing cannot produce the needed evidence, execute manual verification steps",
 		"Always include an \"artifacts\" array",
+		"Use artifact path only for files that already exist in the repository and will be available from the pushed commit",
 		"If sufficient evidence is not possible, report a warning finding",
 	} {
 		if !strings.Contains(prompt, want) {


### PR DESCRIPTION
## Intent

The developer wanted the PR description's Testing section to stop listing raw test commands and instead show useful, concise evidence from the full test step. They specifically questioned whether the summary accounted for baseline checks, automated tests, manual/evidence-gathering work, artifacts, and final results. After seeing poorly rendered evidence artifacts, they explored ways to make screenshots visible in GitHub PR descriptions, including GitHub attachment behavior, official API or gh support, external storage, committing artifacts, and a dedicated artifact branch. They were interested in the dedicated GitHub artifact branch approach but wanted to understand its downsides, current implementation state, and whether suppressing inline images would leave empty or sparse Testing sections.

## What Changed

- Updated PR testing summaries to prefer concise `testing_summary` text, suppress raw recorded test details in PR bodies, and fall back to a compact recorded-check count when needed.
- Changed PR evidence artifact rendering so paths and URLs appear as compact `Evidence` links, content artifacts render in collapsible blocks, and GitHub repository paths resolve to blob links.
- Documented the new test artifact semantics and compact PR evidence behavior in the pipeline step reference.

## Risk Assessment

✅ Low: The change is narrowly scoped to rendering PR testing evidence and prompt wording, with the previously identified baseline-only evidence gap now covered by a compact generated summary.

## Testing

- Summary: Exercised the PR Testing renderer with baseline-only tests, evidence artifacts, compact GitHub artifact links, and the user-intent evidence agent flow, then ran the affected package suite; the generated PR markdown demonstrated concise evidence without raw test commands and all checks passed.
<details>
<summary>Evidence: Generated PR Testing markdown evidence</summary>

```text
## Testing

- Summary: Evidence was collected.
- Evidence: [Checkout screenshot](https://github.com/example/widgets/blob/abc123/artifacts/checkout.png)
- Evidence: [Server log](https://github.com/example/widgets/blob/abc123/artifacts/server.log)
<details>
<summary>Evidence: Placement rectangle evidence</summary>

`` `text
{"button":{"top":169,"left":248,"right":272,"bottom":193}}
`` `
</details>
- Outcome: ✅ passed across 1 run (300ms)
```
</details>
<details>
<summary>Evidence: Test-step recorded baseline plus evidence metadata</summary>

```text
evidence findings JSON: {"findings":[],"summary":"evidence demonstrates intent","tested":["go env GOOS \u003e baseline.log","manual screenshot review"],"testing_summary":"captured screenshot evidence","risk_level":"","risk_rationale":""}
```
</details>
- Outcome: ✅ passed across 1 run (1m5s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/pipeline/steps/prsummary.go:98` - PR rendering now suppresses every recorded `tested` detail, but the baseline-only test path still records only `Tested` and no `testing_summary`; those PRs will lose the only evidence of what was run and show just the generic outcome line. Add a concise generated summary for that path before hiding raw details, or preserve a compact non-raw description of the recorded check.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test -v ./internal/pipeline/steps -run '^TestBuildTestingSummaryForPR_(OmitsRecordedTestDetails|SummarizesBaselineOnlyTests|RendersEvidenceArtifactsCompactly)$'`
- `go test -v ./internal/pipeline/steps -run '^TestTestStep_UserIntentRunsConfiguredCommandThenEvidenceAgent$'`
- `go test ./internal/pipeline/steps`

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed (2)</summary>

**Round 1** - found 2 warnings
- ⚠️ `docs/src/content/docs/reference/pipeline-steps.md:144` - The PR step documentation still says the regenerated `## Testing` section lists deduplicated `tested` commands or selectors, but `BuildTestingSummaryForPR` now suppresses raw `tested` details in PR bodies and only emits a compact recorded-check count when no `testing_summary` is available. Update this bullet to describe the new compact PR behavior.
- ⚠️ `docs/src/content/docs/reference/pipeline-steps.md:145` - The evidence artifact documentation still says PR bodies render image artifacts inline, video artifacts with an HTML video element, and GitHub repository-relative paths as raw/blob URLs. PR rendering is now compact: path/url artifacts are emitted as `Evidence` links, repository paths use GitHub blob links, and content artifacts render inside collapsible `&lt;details&gt;` blocks. Update this documentation so it no longer promises inline images/videos or raw GitHub artifact URLs in PR Testing sections.

**Round 2** (auto-fix) - found 2 warnings
- ⚠️ `docs/src/content/docs/reference/pipeline-steps.md:71` - The Test step documentation still describes `artifacts` only as reviewer-visible evidence and lists examples, but the test prompt now constrains `path` artifacts to files that already exist in the repository and will be available from the pushed commit. Update this Test behavior bullet to document the `path`/`url`/`content` semantics so users and prompt authors do not expect temporary or uncommitted screenshot/log paths to work in PR evidence links.
- ⚠️ `docs/src/content/docs/reference/pipeline-steps.md:145` - The PR artifact documentation says compact evidence rendering applies in GitHub PR bodies, but `BuildTestingSummaryForPR` enables compact artifact rendering for every PR provider. Only repository-relative path rewriting to blob URLs is GitHub-specific; non-GitHub providers still get compact `Evidence` links using the recorded path/URL and collapsible content artifacts. Update this line to distinguish provider-wide compact rendering from GitHub-only blob URL conversion.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
