### PR TITLE
fix(intent): improve transcript session matching

### DIFF
--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -143,12 +143,13 @@ It matches sessions against the changed files, summarizes the likely author inte
 
 Transcript readers collect user and assistant text messages but exclude tool call output.
 They read Claude Code transcripts from `~/.claude/projects`, Codex metadata from `~/.codex/state_*.sqlite` plus referenced rollout files, OpenCode messages from `$XDG_DATA_HOME/opencode/opencode.db` or `~/.local/share/opencode/opencode.db`, and Rovo Dev sessions from `~/.rovodev/sessions`.
+Sessions are eligible when they come from the same working directory or an equivalent Git checkout with the same common Git directory or normalized remote URL.
 Pi and ACP transcripts are not currently read for intent extraction.
 The selected transcript text is sent to the configured pipeline agent for summarization during the `intent` step, which may incur an additional agent or API invocation.
 Before summarization, no-mistakes excludes tool output, redacts likely secrets, strips common prompt-control markers, and clamps long transcripts while preserving the beginning and end.
 no-mistakes stores derived intent summaries and matching metadata in `~/.no-mistakes/state.sqlite`, including the source, session ID, and match score on each run plus cached summaries for matching transcript sessions.
 It does not store raw transcript text in its database.
-When a transcript matches, the step logs the matched source, score, and sanitized inferred intent.
+The step logs candidate match diagnostics, then logs the matched source, score, and sanitized inferred intent when a transcript matches.
 
 Use `intent.disabled_readers` to disable specific transcript sources, or set `intent.enabled: false` to opt out entirely.
 

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -220,14 +220,17 @@ When enabled, no-mistakes can read recent local agent transcripts, match the ses
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `intent.enabled` | `bool` | `true` | Enable transcript-based intent extraction |
-| `intent.threshold` | `float` | `0.2` | Minimum match score for selecting a transcript session |
+| `intent.threshold` | `float` | `0.2` | Minimum raw match score for selecting a transcript session |
 | `intent.slack_days` | `int` | `3` | Extra days to look back before the change window |
 | `intent.disabled_readers` | `string[]` | Empty | Transcript readers to disable |
 
 Valid `disabled_readers` values are `claude`, `codex`, `opencode`, and `rovodev`.
 
 The match score is the share of changed files mentioned in a transcript session.
-Mentioning extra files does not reduce the score, and ties go to the most recent matching session.
+Mentioning extra files does not reduce the score.
+For multi-file diffs, no-mistakes still requires at least two overlapping files and an effective minimum score of `0.5`.
+Partial matches older than 24 hours are rejected unless their raw score is at least `0.8`.
+Accepted candidates are ranked by confidence, which combines the raw score with a small recency boost, with ties going to the most recent matching session.
 
 ## Environment variables
 

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -20,7 +20,8 @@ This is best-effort context, and when available it is included in rebase fixes, 
 - Runs only when `intent.enabled` is true
 - Matches local agent transcripts against the changed files and summarizes the likely author intent with the configured pipeline agent
 - Stores the derived summary, source, session ID, and match score on the run
-- Logs the matched source, score, and sanitized inferred intent
+- Logs candidate diagnostics, including source, session, CWD, score, confidence, overlap, decision, and rejection reason
+- Logs the matched source, score, and sanitized inferred intent when a transcript matches
 - Skips instead of failing when disabled, no matching transcript is found, the diff is empty, extraction errors, or persistence fails
 
 This step never blocks the pipeline. Missing transcripts, slow summarization, or other extraction failures are reported as skipped outcomes.

--- a/internal/intent/intent.go
+++ b/internal/intent/intent.go
@@ -42,6 +42,8 @@ type ExtractParams struct {
 	Cache Cache
 	// Summarizer turns the chosen session's text into a short summary.
 	Summarizer Summarizer
+	// Logf receives best-effort candidate diagnostics. Nil disables logging.
+	Logf func(format string, args ...any)
 }
 
 // ErrNoMatch indicates no agent transcript matched the change. Callers
@@ -116,7 +118,11 @@ func Extract(ctx context.Context, p ExtractParams) (*Result, error) {
 		loaded = append(loaded, s)
 	}
 
-	match := pickMatch(loaded, p.DiffFiles, p.Threshold)
+	match := pickMatchWithOptions(loaded, p.DiffFiles, matchOptions{
+		Threshold: p.Threshold,
+		HeadTime:  p.HeadTime,
+		Logf:      p.Logf,
+	})
 	if match == nil {
 		return nil, ErrNoMatch
 	}

--- a/internal/intent/intent.go
+++ b/internal/intent/intent.go
@@ -33,7 +33,8 @@ type ExtractParams struct {
 	HeadTime time.Time
 	// SlackDays extends WindowStart backwards. The plan called for 3 days.
 	SlackDays int
-	// Threshold is the minimum file-overlap score required to accept a match.
+	// Threshold is the minimum raw file-overlap score required before applying
+	// stricter multi-file and stale-partial acceptance rules.
 	Threshold float64
 	// Readers are the per-agent transcript readers to consult. Order is
 	// insignificant; matching picks the best score across all of them.
@@ -51,8 +52,8 @@ type ExtractParams struct {
 var ErrNoMatch = errors.New("intent: no matching transcript")
 
 // Extract runs the discover -> match -> cache -> summarize pipeline and
-// returns the final intent. It returns ErrNoMatch when nothing scored
-// above the threshold.
+// returns the final intent. It returns ErrNoMatch when no session satisfies
+// the matcher's threshold, overlap, and freshness acceptance rules.
 func Extract(ctx context.Context, p ExtractParams) (*Result, error) {
 	if p.OriginCWD == "" {
 		return nil, fmt.Errorf("intent: OriginCWD is required")

--- a/internal/intent/intent_test.go
+++ b/internal/intent/intent_test.go
@@ -3,6 +3,8 @@ package intent
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -164,6 +166,40 @@ func TestExtract_NoReaders(t *testing.T) {
 	})
 	if !errors.Is(err, ErrNoMatch) {
 		t.Errorf("expected ErrNoMatch with no readers, got %v", err)
+	}
+}
+
+func TestExtract_LogsCandidateDecisions(t *testing.T) {
+	r := &staticReader{
+		name: "opencode",
+		sessions: []*Session{{
+			SessionID:    "weak",
+			CWD:          "/tmp/repo",
+			LastActivity: time.Now(),
+			Messages:     []Message{{FilePaths: []string{"a.go"}}},
+		}},
+	}
+	var logs []string
+	_, err := Extract(context.Background(), ExtractParams{
+		OriginCWD:  "/tmp/repo",
+		DiffFiles:  []string{"a.go", "b.go", "c.go"},
+		HeadTime:   time.Now(),
+		BaseTime:   time.Now().Add(-time.Hour),
+		Threshold:  0.2,
+		Readers:    []Reader{r},
+		Summarizer: &fixedSummarizer{summary: "x"},
+		Logf: func(format string, args ...any) {
+			logs = append(logs, fmt.Sprintf(format, args...))
+		},
+	})
+	if !errors.Is(err, ErrNoMatch) {
+		t.Fatalf("expected ErrNoMatch, got %v", err)
+	}
+	joined := strings.Join(logs, "\n")
+	for _, want := range []string{"candidate", "opencode", "weak", "score 0.33", "rejected"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("logs missing %q:\n%s", want, joined)
+		}
 	}
 }
 

--- a/internal/intent/matcher.go
+++ b/internal/intent/matcher.go
@@ -3,15 +3,25 @@ package intent
 import (
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // Match is the chosen session along with its overlap score.
 type Match struct {
 	Session *Session
 	Score   float64
+	// Confidence is the score used to rank accepted candidates after applying
+	// recency. Score remains the raw file-overlap score surfaced to callers.
+	Confidence float64
 	// Overlap lists diff files that appeared in this session. Used purely
 	// for diagnostics/telemetry.
 	Overlap []string
+}
+
+type matchOptions struct {
+	Threshold float64
+	HeadTime  time.Time
+	Logf      func(format string, args ...any)
 }
 
 // score computes the share of diff files that appear anywhere in the
@@ -23,25 +33,19 @@ func score(s *Session, diffFiles []string) (float64, []string) {
 		return 0, nil
 	}
 
-	mentioned := make(map[string]bool)
+	var mentioned []string
 	for _, m := range s.Messages {
 		for _, p := range m.FilePaths {
-			for _, n := range normalizedPathVariants(p) {
-				mentioned[n] = true
-			}
+			mentioned = append(mentioned, p)
 		}
 		// Best-effort scan of assistant text for raw filenames.
-		for _, p := range scanFilePathsInText(m.Text) {
-			for _, n := range normalizedPathVariants(p) {
-				mentioned[n] = true
-			}
-		}
+		mentioned = append(mentioned, scanFilePathsInText(m.Text)...)
 	}
 
 	var overlap []string
 	for _, f := range diffFiles {
-		for _, n := range normalizedPathVariants(f) {
-			if mentioned[n] {
+		for _, p := range mentioned {
+			if pathMentionMatchesDiff(p, f) {
 				overlap = append(overlap, f)
 				break
 			}
@@ -50,21 +54,88 @@ func score(s *Session, diffFiles []string) (float64, []string) {
 	return float64(len(overlap)) / float64(len(diffFiles)), overlap
 }
 
+func pathMentionMatchesDiff(mention, diffFile string) bool {
+	mention = filepath.ToSlash(filepath.Clean(strings.TrimSpace(mention)))
+	mention = strings.TrimPrefix(mention, "./")
+	diffFile = filepath.ToSlash(filepath.Clean(strings.TrimSpace(diffFile)))
+	diffFile = strings.TrimPrefix(diffFile, "./")
+	if mention == "" || diffFile == "" || mention == "." || diffFile == "." {
+		return false
+	}
+	if mention == diffFile || strings.HasSuffix(mention, "/"+diffFile) {
+		return true
+	}
+	// Basename-only mentions are useful, but pathful mentions should not match
+	// unrelated files that happen to share names like update.go.
+	return !strings.Contains(mention, "/") && filepath.Base(diffFile) == mention
+}
+
 // pickMatch returns the highest-scoring session at or above the threshold.
 // Ties are broken by most recent LastActivity.
 func pickMatch(sessions []*Session, diffFiles []string, threshold float64) *Match {
+	return pickMatchWithOptions(sessions, diffFiles, matchOptions{Threshold: threshold})
+}
+
+func pickMatchWithOptions(sessions []*Session, diffFiles []string, opts matchOptions) *Match {
 	var best *Match
 	for _, s := range sessions {
 		sc, overlap := score(s, diffFiles)
-		if sc < threshold {
+		accepted, reason, confidence := acceptMatchCandidate(sc, len(overlap), len(diffFiles), s.LastActivity, opts)
+		if opts.Logf != nil {
+			decision := "accepted"
+			if !accepted {
+				decision = "rejected"
+			}
+			opts.Logf("candidate agent=%s session=%s cwd=%q score %.2f confidence %.2f overlap=%d/%d decision=%s reason=%s",
+				s.AgentName, s.SessionID, s.CWD, sc, confidence, len(overlap), len(diffFiles), decision, reason)
+		}
+		if !accepted {
 			continue
 		}
-		if best == nil || sc > best.Score ||
-			(sc == best.Score && s.LastActivity.After(best.Session.LastActivity)) {
-			best = &Match{Session: s, Score: sc, Overlap: overlap}
+		if best == nil || confidence > best.Confidence ||
+			(confidence == best.Confidence && s.LastActivity.After(best.Session.LastActivity)) {
+			best = &Match{Session: s, Score: sc, Confidence: confidence, Overlap: overlap}
 		}
 	}
 	return best
+}
+
+func acceptMatchCandidate(score float64, overlapCount, diffCount int, lastActivity time.Time, opts matchOptions) (bool, string, float64) {
+	if diffCount == 0 || overlapCount == 0 {
+		return false, "no_overlap", score
+	}
+	threshold := opts.Threshold
+	if diffCount > 1 && threshold < 0.5 {
+		threshold = 0.5
+	}
+	if diffCount > 1 && overlapCount < 2 {
+		return false, "single_overlap_multi_file_diff", score
+	}
+	if score < threshold {
+		return false, "below_threshold", score
+	}
+	confidence := score + recencyBoost(opts.HeadTime, lastActivity)
+	if !opts.HeadTime.IsZero() && lastActivity.Before(opts.HeadTime.Add(-24*time.Hour)) && score < 0.8 {
+		return false, "stale_partial", confidence
+	}
+	return true, "matched", confidence
+}
+
+func recencyBoost(headTime, lastActivity time.Time) float64 {
+	if headTime.IsZero() || lastActivity.IsZero() {
+		return 0
+	}
+	age := headTime.Sub(lastActivity)
+	if age < 0 {
+		age = -age
+	}
+	if age <= 2*time.Hour {
+		return 0.15
+	}
+	if age <= 24*time.Hour {
+		return 0.05
+	}
+	return 0
 }
 
 // normalizedPathVariants returns a small set of normalized forms for a

--- a/internal/intent/matcher.go
+++ b/internal/intent/matcher.go
@@ -70,8 +70,9 @@ func pathMentionMatchesDiff(mention, diffFile string) bool {
 	return !strings.Contains(mention, "/") && filepath.Base(diffFile) == mention
 }
 
-// pickMatch returns the highest-scoring session at or above the threshold.
-// Ties are broken by most recent LastActivity.
+// pickMatch returns the accepted session with the highest confidence score.
+// Acceptance applies the raw threshold, multi-file overlap, and stale-partial
+// rules; confidence applies a recency boost, with ties broken by LastActivity.
 func pickMatch(sessions []*Session, diffFiles []string, threshold float64) *Match {
 	return pickMatchWithOptions(sessions, diffFiles, matchOptions{Threshold: threshold})
 }

--- a/internal/intent/matcher_test.go
+++ b/internal/intent/matcher_test.go
@@ -90,6 +90,61 @@ func TestPickMatch_HigherScoreWins(t *testing.T) {
 	}
 }
 
+func TestPickMatch_RejectsSingleOverlapInMultiFileDiff(t *testing.T) {
+	s := &Session{
+		LastActivity: time.Now(),
+		Messages:     []Message{{FilePaths: []string{"internal/cli/update_test.go"}}},
+	}
+	diff := []string{
+		"internal/cli/update.go",
+		"internal/cli/update_test.go",
+		"internal/update/daemon.go",
+		"internal/update/update.go",
+		"internal/update/update_test.go",
+	}
+
+	got := pickMatch([]*Session{s}, diff, 0.2)
+	if got != nil {
+		t.Fatalf("expected no match for 1/5 overlap, got %+v", got)
+	}
+}
+
+func TestPickMatch_AllowsSingleOverlapForSingleFileDiff(t *testing.T) {
+	s := &Session{
+		LastActivity: time.Now(),
+		Messages:     []Message{{FilePaths: []string{"internal/update/update.go"}}},
+	}
+
+	got := pickMatch([]*Session{s}, []string{"internal/update/update.go"}, 0.2)
+	if got == nil {
+		t.Fatal("expected single-file match")
+	}
+}
+
+func TestPickMatch_RejectsOldPartialMatch(t *testing.T) {
+	headTime := time.Date(2026, 5, 15, 18, 53, 52, 0, time.UTC)
+	old := &Session{
+		LastActivity: headTime.Add(-48 * time.Hour),
+		Messages: []Message{{FilePaths: []string{
+			"internal/cli/update.go",
+			"internal/cli/update_test.go",
+			"internal/update/daemon.go",
+		}}},
+	}
+	diff := []string{
+		"internal/cli/update.go",
+		"internal/cli/update_test.go",
+		"internal/update/daemon.go",
+		"internal/update/update.go",
+		"internal/update/update_test.go",
+	}
+
+	got := pickMatchWithOptions([]*Session{old}, diff, matchOptions{Threshold: 0.2, HeadTime: headTime})
+	if got != nil {
+		t.Fatalf("expected old partial match to be rejected, got %+v", got)
+	}
+}
+
 func TestNormalizedPathVariants(t *testing.T) {
 	got := normalizedPathVariants("./internal/foo.go")
 	want := map[string]bool{"internal/foo.go": true, "foo.go": true}

--- a/internal/intent/paths.go
+++ b/internal/intent/paths.go
@@ -1,8 +1,12 @@
 package intent
 
 import (
+	"context"
+	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 )
 
 // resolveHome returns the home directory to use, preferring an explicit
@@ -35,4 +39,120 @@ func canonicalPath(p string) string {
 // pathsEqual compares two paths after canonicalization.
 func pathsEqual(a, b string) bool {
 	return canonicalPath(a) == canonicalPath(b)
+}
+
+type repoMatcher struct {
+	origin string
+	ids    map[string]repoIdentity
+}
+
+type repoIdentity struct {
+	canonical string
+	commonDir string
+	remote    string
+}
+
+func newRepoMatcher(ctx context.Context, originCWD string) *repoMatcher {
+	m := &repoMatcher{
+		origin: canonicalPath(originCWD),
+		ids:    make(map[string]repoIdentity),
+	}
+	if m.origin != "" {
+		m.ids[m.origin] = gitRepoIdentity(ctx, originCWD)
+	}
+	return m
+}
+
+func (m *repoMatcher) matches(ctx context.Context, cwd string) bool {
+	if m == nil || m.origin == "" {
+		return true
+	}
+	candidate := canonicalPath(cwd)
+	if candidate == "" {
+		return false
+	}
+	if candidate == m.origin {
+		return true
+	}
+	origin := m.ids[m.origin]
+	candidateID, ok := m.ids[candidate]
+	if !ok {
+		candidateID = gitRepoIdentity(ctx, cwd)
+		m.ids[candidate] = candidateID
+	}
+	if origin.commonDir != "" && candidateID.commonDir != "" && origin.commonDir == candidateID.commonDir {
+		return true
+	}
+	return origin.remote != "" && candidateID.remote != "" && origin.remote == candidateID.remote
+}
+
+func gitRepoIdentity(ctx context.Context, dir string) repoIdentity {
+	id := repoIdentity{canonical: canonicalPath(dir)}
+	if id.canonical == "" {
+		return id
+	}
+	if commonDir := gitOutput(ctx, dir, "rev-parse", "--git-common-dir"); commonDir != "" {
+		if !filepath.IsAbs(commonDir) {
+			commonDir = filepath.Join(dir, commonDir)
+		}
+		id.commonDir = canonicalPath(commonDir)
+	}
+	remote := gitOutput(ctx, dir, "remote", "get-url", "origin")
+	if remote == "" {
+		if first := firstLine(gitOutput(ctx, dir, "remote")); first != "" {
+			remote = gitOutput(ctx, dir, "remote", "get-url", first)
+		}
+	}
+	id.remote = normalizeGitRemote(remote)
+	return id
+}
+
+func gitOutput(ctx context.Context, dir string, args ...string) string {
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func normalizeGitRemote(remote string) string {
+	remote = strings.TrimSpace(remote)
+	if remote == "" {
+		return ""
+	}
+	if u, err := url.Parse(remote); err == nil && u.Host != "" {
+		return cleanRemoteParts(u.Host, u.Path)
+	}
+	if at := strings.Index(remote, "@"); at >= 0 {
+		rest := remote[at+1:]
+		if colon := strings.Index(rest, ":"); colon >= 0 {
+			return cleanRemoteParts(rest[:colon], rest[colon+1:])
+		}
+	}
+	if filepath.IsAbs(remote) {
+		return canonicalPath(remote)
+	}
+	return cleanRemoteParts("", remote)
+}
+
+func cleanRemoteParts(host, path string) string {
+	host = strings.ToLower(strings.TrimSpace(host))
+	path = strings.Trim(strings.TrimSpace(path), "/")
+	path = strings.TrimSuffix(path, ".git")
+	path = strings.ToLower(path)
+	if host == "" {
+		return path
+	}
+	if path == "" {
+		return host
+	}
+	return host + "/" + path
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return strings.TrimSpace(s)
 }

--- a/internal/intent/reader_claude.go
+++ b/internal/intent/reader_claude.go
@@ -43,7 +43,7 @@ func (r *claudeReader) Discover(ctx context.Context, opts DiscoverOpts) ([]*Sess
 		return nil, fmt.Errorf("read claude projects: %w", err)
 	}
 
-	wantCWD := canonicalPath(opts.OriginCWD)
+	matcher := newRepoMatcher(ctx, opts.OriginCWD)
 	var out []*Session
 
 	for _, dir := range entries {
@@ -80,7 +80,7 @@ func (r *claudeReader) Discover(ctx context.Context, opts DiscoverOpts) ([]*Sess
 			if err != nil || meta == nil {
 				continue
 			}
-			if wantCWD != "" && canonicalPath(meta.CWD) != wantCWD {
+			if !matcher.matches(ctx, meta.CWD) {
 				continue
 			}
 			session := &Session{

--- a/internal/intent/reader_codex.go
+++ b/internal/intent/reader_codex.go
@@ -53,7 +53,7 @@ func (r *codexReader) Discover(ctx context.Context, opts DiscoverOpts) ([]*Sessi
 	}
 	defer db.Close()
 
-	wantCWD := canonicalPath(opts.OriginCWD)
+	matcher := newRepoMatcher(ctx, opts.OriginCWD)
 	winStart := opts.WindowStart.Unix()
 	winEnd := opts.WindowEnd.Add(time.Hour).Unix()
 
@@ -79,7 +79,7 @@ func (r *codexReader) Discover(ctx context.Context, opts DiscoverOpts) ([]*Sessi
 		if err := rows.Scan(&id, &cwd, &createdAt, &updatedAt, &rolloutPath); err != nil {
 			continue
 		}
-		if wantCWD != "" && canonicalPath(cwd) != wantCWD {
+		if !matcher.matches(ctx, cwd) {
 			continue
 		}
 		// Resolve relative rollout paths against ~/.codex.

--- a/internal/intent/reader_opencode.go
+++ b/internal/intent/reader_opencode.go
@@ -49,7 +49,7 @@ func (r *opencodeReader) Discover(ctx context.Context, opts DiscoverOpts) ([]*Se
 	}
 	defer db.Close()
 
-	wantCWD := canonicalPath(opts.OriginCWD)
+	matcher := newRepoMatcher(ctx, opts.OriginCWD)
 	// OpenCode timestamps are unix milliseconds.
 	winStart := opts.WindowStart.UnixMilli()
 	winEnd := opts.WindowEnd.Add(time.Hour).UnixMilli()
@@ -73,7 +73,7 @@ func (r *opencodeReader) Discover(ctx context.Context, opts DiscoverOpts) ([]*Se
 		if err := rows.Scan(&id, &directory, &timeCreated, &timeUpdated); err != nil {
 			continue
 		}
-		if wantCWD != "" && canonicalPath(directory) != wantCWD {
+		if !matcher.matches(ctx, directory) {
 			continue
 		}
 		out = append(out, &Session{

--- a/internal/intent/reader_opencode_test.go
+++ b/internal/intent/reader_opencode_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -144,6 +145,30 @@ func TestOpenCodeReader_DiscoverAndLoad(t *testing.T) {
 	}
 }
 
+func TestOpenCodeReader_DiscoverAcceptsSameRemoteDifferentCheckout(t *testing.T) {
+	originCWD := initGitRepoWithRemote(t, filepath.Join(t.TempDir(), "origin"), "git@github.com:kunchenguid/no-mistakes.git")
+	sessionCWD := initGitRepoWithRemote(t, filepath.Join(t.TempDir(), "treehouse"), "https://github.com/kunchenguid/no-mistakes.git")
+	home := buildOpenCodeDB(t, sessionCWD)
+	t.Setenv("XDG_DATA_HOME", "")
+
+	r := NewOpenCodeReader()
+	sessions, err := r.Discover(context.Background(), DiscoverOpts{
+		HomeDir:     home,
+		OriginCWD:   originCWD,
+		WindowStart: time.Now().Add(-time.Hour),
+		WindowEnd:   time.Now().Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(sessions))
+	}
+	if sessions[0].CWD != sessionCWD {
+		t.Fatalf("session cwd = %q, want %q", sessions[0].CWD, sessionCWD)
+	}
+}
+
 func TestOpenCodeReader_NoDB(t *testing.T) {
 	r := NewOpenCodeReader()
 	sessions, err := r.Discover(context.Background(), DiscoverOpts{HomeDir: t.TempDir()})
@@ -153,4 +178,21 @@ func TestOpenCodeReader_NoDB(t *testing.T) {
 	if len(sessions) != 0 {
 		t.Errorf("expected 0 sessions, got %d", len(sessions))
 	}
+}
+
+func initGitRepoWithRemote(t *testing.T, dir, remote string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"init"},
+		{"remote", "add", "origin", remote},
+	} {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	return dir
 }

--- a/internal/intent/reader_rovodev.go
+++ b/internal/intent/reader_rovodev.go
@@ -24,7 +24,7 @@ func NewRovoDevReader() Reader { return &rovodevReader{} }
 
 func (r *rovodevReader) Name() string { return RovoDevReaderName }
 
-func (r *rovodevReader) Discover(_ context.Context, opts DiscoverOpts) ([]*Session, error) {
+func (r *rovodevReader) Discover(ctx context.Context, opts DiscoverOpts) ([]*Session, error) {
 	home, err := resolveHome(opts.HomeDir)
 	if err != nil {
 		return nil, err
@@ -38,7 +38,7 @@ func (r *rovodevReader) Discover(_ context.Context, opts DiscoverOpts) ([]*Sessi
 		return nil, fmt.Errorf("rovodev sessions: %w", err)
 	}
 
-	wantCWD := canonicalPath(opts.OriginCWD)
+	matcher := newRepoMatcher(ctx, opts.OriginCWD)
 	var out []*Session
 
 	for _, dir := range entries {
@@ -62,7 +62,7 @@ func (r *rovodevReader) Discover(_ context.Context, opts DiscoverOpts) ([]*Sessi
 		if err != nil || meta == nil {
 			continue
 		}
-		if wantCWD != "" && canonicalPath(meta.workspace) != wantCWD {
+		if !matcher.matches(ctx, meta.workspace) {
 			continue
 		}
 		out = append(out, &Session{

--- a/internal/pipeline/steps/intent.go
+++ b/internal/pipeline/steps/intent.go
@@ -201,6 +201,9 @@ func defaultRunIntent(ctx context.Context, sctx *pipeline.StepContext) (*intent.
 		Readers:    intent.AllReaders(cfg.Intent.DisabledReaders),
 		Cache:      intent.NewDBCache(sctx.DB),
 		Summarizer: intent.NewAgentSummarizer(sctx.Agent, sctx.WorkDir),
+		Logf: func(format string, args ...any) {
+			sctx.Log(fmt.Sprintf("intent "+format, args...))
+		},
 	})
 }
 


### PR DESCRIPTION
## Intent

The developer wanted to investigate why intent matching attached an unrelated older transcript to a run despite a newer better-matching transcript existing. They identified that exact working-directory filtering excluded equivalent Treehouse checkouts, then asked for a robust general fix. They specifically requested implementing repo-identity based eligibility, recency-aware scoring, stricter acceptance thresholds, and diagnostic logging, while leaving out the broader file-reference weighting changes.

## What Changed

- Match intent transcripts across equivalent Git checkouts by comparing repository identity through shared git common dirs or normalized remote URLs instead of requiring an exact working directory match.
- Tighten candidate selection with confidence-based ranking, recency-aware scoring, multi-file overlap requirements, stale partial-match rejection, and per-candidate diagnostic logging.
- Update intent reader coverage and documentation so agent guides, pipeline-step logs, config reference, and internal comments reflect the new matching behavior.

## Risk Assessment

✅ Low: The branch makes a bounded change to intent candidate eligibility and scoring with targeted coverage, and I did not find material correctness or safety issues in the changed paths.

## Testing

- Summary: After confirming the checked-out target change, I ran focused matcher/reader/diagnostic tests, the full intent package, the intent step integration checks, and the real e2e intent journey; all passed and the e2e path demonstrated transcript discovery, persistence, and review-prompt injection through the product flow.
<details>
<summary>Evidence: Focused intent behavior evidence</summary>

```text
=== RUN TestExtract_LogsCandidateDecisions
--- PASS: TestExtract_LogsCandidateDecisions (0.00s)
=== RUN TestPickMatch_RejectsOldPartialMatch
--- PASS: TestPickMatch_RejectsOldPartialMatch (0.00s)
=== RUN TestOpenCodeReader_DiscoverAcceptsSameRemoteDifferentCheckout
--- PASS: TestOpenCodeReader_DiscoverAcceptsSameRemoteDifferentCheckout (0.09s)
PASS
ok github.com/kunchenguid/no-mistakes/internal/intent 0.546s
```
</details>
<details>
<summary>Evidence: Product-level intent journey evidence</summary>

```text
=== RUN TestIntentJourney
--- PASS: TestIntentJourney (3.41s)
PASS
ok github.com/kunchenguid/no-mistakes/internal/e2e 3.784s
```
</details>
<details>
<summary>Evidence: Intent step persistence evidence</summary>

```text
=== RUN TestIntentStep_Integration_AttachesSummaryToRun
2026/05/15 19:44:59 INFO intent: attached run_id=01KRQAREP87NFRAEN04TX8XQVK agent=claude score=1
--- PASS: TestIntentStep_Integration_AttachesSummaryToRun (0.15s)
=== RUN TestIntentStep_Integration_UsesPipelineWorkDirForGitState
2026/05/15 19:44:59 INFO intent: attached run_id=01KRQARETHF5VE8XVAZ0K3E70D agent=claude score=1
--- PASS: TestIntentStep_Integration_UsesPipelineWorkDirForGitState (0.14s)
=== RUN TestIntentStep_SuccessPersistsAndAttaches
2026/05/15 19:44:59 INFO intent: attached run_id=01KRQAREW50E1JE5KTSCRMJFCJ agent=claude score=0.9
--- PASS: TestIntentStep_SuccessPersistsAndAttaches (0.00s)
PASS
ok github.com/kunchenguid/no-mistakes/internal/pipeline/steps 0.620s
```
</details>
- Outcome: ✅ passed across 1 run (1m38s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `git status --short --branch`
- `git diff --stat f7ba4a602bf47b6c9cc8ea3fcfcf3d83114dd811..99bba4ceac3d1c189f3969c0c6720877e815bb69`
- `go test -v ./internal/intent -run 'Test(OpenCodeReader_DiscoverAcceptsSameRemoteDifferentCheckout|PickMatch_RejectsOldPartialMatch|Extract_LogsCandidateDecisions)$'`
- `go test -v ./internal/intent`
- `go test -tags e2e -v ./internal/e2e -run '^TestIntentJourney$'`
- `go test -v ./internal/pipeline/steps -run 'TestIntentStep_(Integration_AttachesSummaryToRun|Integration_UsesPipelineWorkDirForGitState|SuccessPersistsAndAttaches)$'`

</details>

<details>
<summary>🔧 **Document** - 3 issues found → auto-fixed (2)</summary>

**Round 1** - found 3 issues (1 warning, 2 infos)
- ⚠️ `docs/src/content/docs/reference/global-config.md:223` - The `intent.threshold` and match-score documentation is stale. The code no longer accepts every candidate whose raw overlap score exceeds the configured threshold: multi-file diffs require at least two overlapping files and an effective minimum threshold of 0.5, stale partial matches older than 24 hours are rejected unless their raw score is at least 0.8, and accepted candidates are ranked by confidence with a recency boost rather than only raw score plus most-recent tie-breaks. Update this section so users understand what `intent.threshold` can and cannot control.
- ℹ️ `docs/src/content/docs/guides/agents.md:141` - The intent extraction guide does not document the new transcript eligibility behavior. Readers now accept sessions from equivalent Git checkouts when they share the same git common dir or normalized remote URL, not just the exact current working directory. This affects which local transcripts may be considered and should be described in the intent extraction section.
- ℹ️ `docs/src/content/docs/reference/pipeline-steps.md:23` - The intent step logging docs are incomplete after the change. The step now logs per-candidate diagnostics including agent, session, cwd, raw score, confidence, overlap, decision, and rejection reason, in addition to the final matched source and inferred intent. Update the behavior bullets so run-log expectations match the new diagnostic output.

**Round 2** (auto-fix) - found 3 infos
- ℹ️ `internal/intent/intent.go:36` - The `ExtractParams.Threshold` doc comment is now incomplete. Threshold is no longer the sole minimum file-overlap score required to accept a match: multi-file diffs use an effective minimum of 0.5, require at least two overlapping files, and stale partial matches can still be rejected. Update the comment so internal callers do not assume setting a lower threshold can accept those candidates.
- ℹ️ `internal/intent/intent.go:53` - The `Extract` doc comment is stale because it says `ErrNoMatch` is returned only when nothing scored above the threshold. The matcher now also returns `ErrNoMatch` when candidates are rejected by the multi-file overlap requirement or stale-partial rule despite being above the configured threshold. Update this comment to describe the broader acceptance criteria.
- ℹ️ `internal/intent/matcher.go:73` - The `pickMatch` doc comment is stale. It no longer returns the highest raw score above the threshold with recency only as a tie-breaker; accepted candidates are ranked by confidence, which adds a recency boost, and acceptance includes multi-file and stale-partial rules. Update the comment to match the new ranking and acceptance behavior.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
