### PR TITLE
fix(pipeline): extend intent extraction timeout

### DIFF
--- a/internal/pipeline/steps/intent.go
+++ b/internal/pipeline/steps/intent.go
@@ -18,7 +18,7 @@ import (
 )
 
 // intentExtractTimeout caps total wall-clock time spent on intent extraction.
-const intentExtractTimeout = 30 * time.Second
+const intentExtractTimeout = 90 * time.Second
 
 // IntentStep is a best-effort pipeline step that infers the user's intent
 // from local agent transcripts and attaches it to the run so downstream

--- a/internal/pipeline/steps/intent_test.go
+++ b/internal/pipeline/steps/intent_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/config"
 	"github.com/kunchenguid/no-mistakes/internal/db"
@@ -183,6 +184,31 @@ func TestIntentStep_ExtractErrorReturnsSkippedNotError(t *testing.T) {
 	}
 	if sctx.Run.Intent != nil {
 		t.Errorf("run.Intent should remain nil on error, got %q", *sctx.Run.Intent)
+	}
+}
+
+func TestIntentStep_UsesNinetySecondExtractionTimeout(t *testing.T) {
+	sctx := newIntentStepContext(t)
+	var remaining time.Duration
+	var hasDeadline bool
+	step := &IntentStep{
+		runIntent: func(ctx context.Context, _ *pipeline.StepContext) (*intent.Result, error) {
+			deadline, ok := ctx.Deadline()
+			hasDeadline = ok
+			remaining = time.Until(deadline)
+			return nil, intent.ErrNoMatch
+		},
+	}
+
+	_, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !hasDeadline {
+		t.Fatalf("intent extraction context had no deadline")
+	}
+	if remaining < 85*time.Second || remaining > 95*time.Second {
+		t.Fatalf("intent extraction timeout = %s, want about 90s", remaining)
 	}
 }
 

--- a/internal/pipeline/steps/intent_test.go
+++ b/internal/pipeline/steps/intent_test.go
@@ -212,6 +212,41 @@ func TestIntentStep_UsesNinetySecondExtractionTimeout(t *testing.T) {
 	}
 }
 
+func TestIntentStep_SlowExtractionPastOldTimeoutStillAttachesIntent(t *testing.T) {
+	sctx := newIntentStepContext(t)
+	step := &IntentStep{
+		runIntent: func(ctx context.Context, _ *pipeline.StepContext) (*intent.Result, error) {
+			select {
+			case <-time.After(31 * time.Second):
+				return &intent.Result{
+					Summary:   "user wanted slow transcript summarization to finish",
+					AgentName: "claude",
+					SessionID: "slow-session",
+					Score:     0.92,
+				}, nil
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		},
+	}
+
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if outcome == nil || outcome.Skipped {
+		t.Fatalf("expected slow extraction to attach intent, got %+v", outcome)
+	}
+
+	persisted, err := sctx.DB.GetRun(sctx.Run.ID)
+	if err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if persisted.Intent == nil || *persisted.Intent != "user wanted slow transcript summarization to finish" {
+		t.Fatalf("persisted intent = %v, want slow summarization intent", persisted.Intent)
+	}
+}
+
 func TestIntentStep_DisambiguatorCleanupErrorReturnsError(t *testing.T) {
 	sctx := newIntentStepContext(t)
 	step := &IntentStep{


### PR DESCRIPTION
## Intent

The developer wanted to understand why a specific pipeline run appeared to fail at the Intent step, then determined that the step had actually been skipped because intent summarization timed out. They concluded the existing 30-second timeout for intent extraction/summarization was too short. They requested increasing that timeout to 90 seconds so optional Intent context has more time to complete instead of being skipped prematurely.

## What Changed

- Increased the intent extraction timeout from 30 seconds to 90 seconds so slower optional intent summarization can complete instead of being skipped prematurely.
- Added intent-step coverage for the 90-second timeout, slow extraction past the old timeout, and existing successful persistence/attachment behavior.

## Risk Assessment

✅ Low: The change is limited to increasing a single best-effort Intent extraction timeout constant with a focused regression test, and no material correctness or integration risks were found.

## Testing

- Summary: <code>I inspected the intent-timeout change, added an evidence-producing test that waits 31 seconds before returning an intent result, confirmed the targeted timeout and persistence behavior with verbose output, and then ran the full `internal/pipeline/steps` package tests successfully.</code>
<details>
<summary>Evidence: Targeted intent timeout behavior transcript</summary>

```text
=== RUN TestIntentStep_SuccessPersistsAndAttaches
2026/05/18 10:27:05 INFO intent: attached run_id=01KRY212CWS0GGKKQJN2SBZYHN agent=claude score=0.9
--- PASS: TestIntentStep_SuccessPersistsAndAttaches (0.01s)
=== RUN TestIntentStep_UsesNinetySecondExtractionTimeout
--- PASS: TestIntentStep_UsesNinetySecondExtractionTimeout (0.00s)
=== RUN TestIntentStep_SlowExtractionPastOldTimeoutStillAttachesIntent
2026/05/18 10:27:36 INFO intent: attached run_id=01KRY212D2JECNMCC81KZ47CRQ agent=claude score=0.92
--- PASS: TestIntentStep_SlowExtractionPastOldTimeoutStillAttachesIntent (31.01s)
PASS
ok github.com/kunchenguid/no-mistakes/internal/pipeline/steps 31.680s
```
</details>
- Outcome: ✅ passed across 1 run (2m56s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/pipeline/steps -run 'TestIntentStep_(UsesNinetySecondExtractionTimeout|SlowExtractionPastOldTimeoutStillAttachesIntent|SuccessPersistsAndAttaches)$' -v`
- `go test ./internal/pipeline/steps`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
