### PR TITLE
fix(pipeline): render PR testing summaries as prose

### DIFF
--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -143,7 +143,7 @@ Creates or updates a pull request.
 - Uses the provider CLI for GitHub/GitLab and the Bitbucket API for Bitbucket Cloud
 - PR title: agent-generated with inferred user intent when available, in conventional commit format (`type(scope): description` or `type: description`); user-facing product impact should use `feat` or `fix` so release automation can pick it up; when a scope is used, it should be the primary affected real module/package from the changed paths and kept broad rather than file-level
 - PR body includes: a `## Intent` section from extracted user intent when available, an agent-authored `## What Changed`, and regenerated `## Risk Assessment`, `## Testing`, and `## Pipeline` sections from recorded step results and rounds
-- The regenerated `## Testing` section prefers the recorded `testing_summary`, uses a compact recorded-check count when no summary is available, includes produced evidence artifacts from `path`, `url`, or `content` fields when available, and ends with the overall outcome including run count and total duration when available
+- The regenerated `## Testing` section prefers the recorded `testing_summary` as prose, uses a compact recorded-check count when no summary is available, includes produced evidence artifacts from `path`, `url`, or `content` fields when available, and only adds an outcome with run count and total duration when it is failed or needed as a fallback
 - Evidence artifacts render compactly in PR bodies: `path` and `url` artifacts become `Evidence` links, `content` artifacts appear in collapsible details blocks, and GitHub PRs convert repository-relative paths to blob URLs
 
 Stores the PR URL in the database and streams it to the TUI.

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -91,13 +91,16 @@ func buildTestingSummary(steps []*db.StepResult, rounds map[string][]*db.StepRou
 
 		var b strings.Builder
 		b.WriteString("## Testing\n\n")
+		wroteSummary := false
 		if testingSummary != "" {
 			rendered := renderTestingSummary(testingSummary)
 			if rendered != "" {
 				writeTestingSummary(&b, rendered, opts)
+				wroteSummary = true
 			}
 		} else if !opts.includeTestedDetails && len(tested) > 0 {
 			writeTestingSummary(&b, compactTestedSummary(len(tested)), opts)
+			wroteSummary = true
 		}
 		if opts.includeTestedDetails {
 			for _, detail := range tested {
@@ -120,7 +123,7 @@ func buildTestingSummary(steps []*db.StepResult, rounds map[string][]*db.StepRou
 				b.WriteString("\n")
 			}
 		}
-		if outcome := buildTestingOutcomeLine(line, stepRounds); !opts.omitOutcome && outcome != "" {
+		if outcome := buildTestingOutcomeLine(line, stepRounds); (!opts.omitOutcome || !wroteSummary) && outcome != "" {
 			b.WriteString("- ")
 			b.WriteString(outcome)
 			b.WriteString("\n")

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -123,7 +123,7 @@ func buildTestingSummary(steps []*db.StepResult, rounds map[string][]*db.StepRou
 				b.WriteString("\n")
 			}
 		}
-		if outcome := buildTestingOutcomeLine(line, stepRounds); (!opts.omitOutcome || !wroteSummary) && outcome != "" {
+		if outcome := buildTestingOutcomeLine(line, stepRounds); shouldRenderTestingOutcome(opts, wroteSummary, outcome) {
 			b.WriteString("- ")
 			b.WriteString(outcome)
 			b.WriteString("\n")
@@ -133,6 +133,13 @@ func buildTestingSummary(steps []*db.StepResult, rounds map[string][]*db.StepRou
 	}
 
 	return ""
+}
+
+func shouldRenderTestingOutcome(opts testingSummaryOptions, wroteSummary bool, outcome string) bool {
+	if outcome == "" {
+		return false
+	}
+	return !opts.omitOutcome || !wroteSummary || !strings.Contains(outcome, "✅ passed")
 }
 
 func compactTestedSummary(count int) string {

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -17,6 +17,8 @@ type testingSummaryOptions struct {
 	githubRawBase        string
 	includeTestedDetails bool
 	compactArtifacts     bool
+	summaryParagraph     bool
+	omitOutcome          bool
 }
 
 // BuildPipelineSummary produces a deterministic markdown section from step results and rounds.
@@ -63,6 +65,8 @@ func BuildTestingSummary(steps []*db.StepResult, rounds map[string][]*db.StepRou
 func BuildTestingSummaryForPR(steps []*db.StepResult, rounds map[string][]*db.StepRound, upstreamURL, ref string) string {
 	opts := testingSummaryOptionsForGitHub(upstreamURL, ref)
 	opts.compactArtifacts = true
+	opts.summaryParagraph = true
+	opts.omitOutcome = true
 	return buildTestingSummary(steps, rounds, opts)
 }
 
@@ -90,14 +94,10 @@ func buildTestingSummary(steps []*db.StepResult, rounds map[string][]*db.StepRou
 		if testingSummary != "" {
 			rendered := renderTestingSummary(testingSummary)
 			if rendered != "" {
-				b.WriteString("- Summary: ")
-				b.WriteString(rendered)
-				b.WriteString("\n")
+				writeTestingSummary(&b, rendered, opts)
 			}
 		} else if !opts.includeTestedDetails && len(tested) > 0 {
-			b.WriteString("- Summary: ")
-			b.WriteString(compactTestedSummary(len(tested)))
-			b.WriteString("\n")
+			writeTestingSummary(&b, compactTestedSummary(len(tested)), opts)
 		}
 		if opts.includeTestedDetails {
 			for _, detail := range tested {
@@ -120,7 +120,7 @@ func buildTestingSummary(steps []*db.StepResult, rounds map[string][]*db.StepRou
 				b.WriteString("\n")
 			}
 		}
-		if outcome := buildTestingOutcomeLine(line, stepRounds); outcome != "" {
+		if outcome := buildTestingOutcomeLine(line, stepRounds); !opts.omitOutcome && outcome != "" {
 			b.WriteString("- ")
 			b.WriteString(outcome)
 			b.WriteString("\n")
@@ -137,6 +137,17 @@ func compactTestedSummary(count int) string {
 		return "Completed 1 recorded test check."
 	}
 	return fmt.Sprintf("Completed %d recorded test checks.", count)
+}
+
+func writeTestingSummary(b *strings.Builder, rendered string, opts testingSummaryOptions) {
+	if opts.summaryParagraph {
+		b.WriteString(rendered)
+		b.WriteString("\n\n")
+		return
+	}
+	b.WriteString("- Summary: ")
+	b.WriteString(rendered)
+	b.WriteString("\n")
 }
 
 func testingSummaryOptionsForGitHub(upstreamURL, ref string) testingSummaryOptions {

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -266,6 +266,26 @@ func TestBuildTestingSummaryForPR_SummarizesBaselineOnlyTests(t *testing.T) {
 	}
 }
 
+func TestBuildTestingSummaryForPR_KeepsOutcomeForArtifactOnlyEvidence(t *testing.T) {
+	t.Parallel()
+	findings := `{"findings":[],"summary":"","artifacts":[{"kind":"log","label":"Rendered PR markdown","content":"## Testing\n\n- Evidence captured"}]}`
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepTest, Status: types.StepStatusCompleted, FindingsJSON: &findings},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 300}},
+	}
+
+	md := BuildTestingSummaryForPR(steps, rounds, "git@github.com:example/widgets.git", "abc123")
+
+	if !strings.Contains(md, "Outcome:") {
+		t.Fatalf("expected artifact-only evidence to keep outcome fallback, got:\n%s", md)
+	}
+	if !strings.Contains(md, "Evidence: Rendered PR markdown") {
+		t.Fatalf("expected artifact evidence to render, got:\n%s", md)
+	}
+}
+
 func TestBuildTestingSummary_EscapesMarkdownInTestingSummary(t *testing.T) {
 	t.Parallel()
 	findings := "{\"findings\":[],\"summary\":\"\",\"testing_summary\":\"Validated `go test ./...`\\nand noted <details> output\",\"tested\":[]}"

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -266,6 +266,26 @@ func TestBuildTestingSummaryForPR_SummarizesBaselineOnlyTests(t *testing.T) {
 	}
 }
 
+func TestBuildTestingSummaryForPR_KeepsFailedOutcomeForCompactTestedSummary(t *testing.T) {
+	t.Parallel()
+	findings := "{\"findings\":[],\"summary\":\"\",\"tested\":[\"`go test ./...`\"]}"
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepTest, Status: types.StepStatusFailed, FindingsJSON: &findings},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 300}},
+	}
+
+	md := BuildTestingSummaryForPR(steps, rounds, "git@github.com:example/widgets.git", "abc123")
+
+	if !strings.Contains(md, "Completed 1 recorded test check.") {
+		t.Fatalf("expected compact baseline test summary as a paragraph, got:\n%s", md)
+	}
+	if !strings.Contains(md, "Outcome: ❌ failed across 1 run (300ms)") {
+		t.Fatalf("expected failed outcome to remain visible, got:\n%s", md)
+	}
+}
+
 func TestBuildTestingSummaryForPR_KeepsOutcomeForArtifactOnlyEvidence(t *testing.T) {
 	t.Parallel()
 	findings := `{"findings":[],"summary":"","artifacts":[{"kind":"log","label":"Rendered PR markdown","content":"## Testing\n\n- Evidence captured"}]}`

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -224,16 +224,19 @@ func TestBuildTestingSummaryForPR_OmitsRecordedTestDetails(t *testing.T) {
 
 	md := BuildTestingSummaryForPR(steps, rounds, "git@github.com:example/widgets.git", "abc123")
 
-	if !strings.Contains(md, "- Summary: Validated the CLI doctor path and config loading; both passed.") {
-		t.Fatalf("expected natural-language testing summary, got:\n%s", md)
+	if !strings.Contains(md, "## Testing\n\nValidated the CLI doctor path and config loading; both passed.") {
+		t.Fatalf("expected natural-language testing summary as a paragraph, got:\n%s", md)
+	}
+	if strings.Contains(md, "- Summary:") {
+		t.Fatalf("did not expect PR testing summary to render as a Summary bullet, got:\n%s", md)
 	}
 	for _, command := range []string{"go test ./internal/cli", "make e2e"} {
 		if strings.Contains(md, command) {
 			t.Fatalf("did not expect raw recorded command %q in PR testing summary, got:\n%s", command, md)
 		}
 	}
-	if !strings.Contains(md, "- Outcome: ✅ passed across 1 run (300ms)") {
-		t.Fatalf("expected outcome line with run count and duration, got:\n%s", md)
+	if strings.Contains(md, "Outcome:") {
+		t.Fatalf("did not expect outcome row in PR testing summary, got:\n%s", md)
 	}
 }
 
@@ -249,14 +252,17 @@ func TestBuildTestingSummaryForPR_SummarizesBaselineOnlyTests(t *testing.T) {
 
 	md := BuildTestingSummaryForPR(steps, rounds, "git@github.com:example/widgets.git", "abc123")
 
-	if !strings.Contains(md, "- Summary: Completed 1 recorded test check.") {
-		t.Fatalf("expected compact baseline test summary, got:\n%s", md)
+	if !strings.Contains(md, "## Testing\n\nCompleted 1 recorded test check.") {
+		t.Fatalf("expected compact baseline test summary as a paragraph, got:\n%s", md)
+	}
+	if strings.Contains(md, "- Summary:") {
+		t.Fatalf("did not expect compact baseline summary to render as a Summary bullet, got:\n%s", md)
 	}
 	if strings.Contains(md, "go test ./...") {
 		t.Fatalf("did not expect raw recorded command in PR testing summary, got:\n%s", md)
 	}
-	if !strings.Contains(md, "- Outcome: ✅ passed across 1 run (300ms)") {
-		t.Fatalf("expected outcome line with run count and duration, got:\n%s", md)
+	if strings.Contains(md, "Outcome:") {
+		t.Fatalf("did not expect outcome row in PR testing summary, got:\n%s", md)
 	}
 }
 

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -223,6 +223,7 @@ func TestBuildTestingSummaryForPR_OmitsRecordedTestDetails(t *testing.T) {
 	}
 
 	md := BuildTestingSummaryForPR(steps, rounds, "git@github.com:example/widgets.git", "abc123")
+	t.Logf("rendered PR testing markdown:\n%s", md)
 
 	if !strings.Contains(md, "## Testing\n\nValidated the CLI doctor path and config loading; both passed.") {
 		t.Fatalf("expected natural-language testing summary as a paragraph, got:\n%s", md)
@@ -251,6 +252,7 @@ func TestBuildTestingSummaryForPR_SummarizesBaselineOnlyTests(t *testing.T) {
 	}
 
 	md := BuildTestingSummaryForPR(steps, rounds, "git@github.com:example/widgets.git", "abc123")
+	t.Logf("rendered PR testing markdown:\n%s", md)
 
 	if !strings.Contains(md, "## Testing\n\nCompleted 1 recorded test check.") {
 		t.Fatalf("expected compact baseline test summary as a paragraph, got:\n%s", md)
@@ -277,6 +279,7 @@ func TestBuildTestingSummaryForPR_KeepsFailedOutcomeForCompactTestedSummary(t *t
 	}
 
 	md := BuildTestingSummaryForPR(steps, rounds, "git@github.com:example/widgets.git", "abc123")
+	t.Logf("rendered PR testing markdown:\n%s", md)
 
 	if !strings.Contains(md, "Completed 1 recorded test check.") {
 		t.Fatalf("expected compact baseline test summary as a paragraph, got:\n%s", md)
@@ -297,6 +300,7 @@ func TestBuildTestingSummaryForPR_KeepsOutcomeForArtifactOnlyEvidence(t *testing
 	}
 
 	md := BuildTestingSummaryForPR(steps, rounds, "git@github.com:example/widgets.git", "abc123")
+	t.Logf("rendered PR testing markdown:\n%s", md)
 
 	if !strings.Contains(md, "Outcome:") {
 		t.Fatalf("expected artifact-only evidence to keep outcome fallback, got:\n%s", md)


### PR DESCRIPTION
## What Changed

- Changed PR `## Testing` generation to render testing summaries and compact recorded-check summaries as prose instead of `Summary` bullets.
- Omitted successful outcome rows when a PR testing summary already communicates the result, while preserving failed outcomes and artifact-only fallback outcomes.
- Updated pipeline step documentation and PR summary tests for the new PR-specific testing summary format.

## Risk Assessment

✅ Low: The change is narrowly scoped to PR testing-summary rendering and includes focused coverage for the previously reported artifact-only and failed-outcome cases.

## Testing

- Summary: <code>No external baseline commands were supplied; I ran the targeted PR testing-summary cases, added evidence logging to show the generated PR markdown, captured success, failure, and artifact-only rendered outputs, and then ran the full `internal/pipeline/steps` test package successfully.</code>
<details>
<summary>Evidence: Successful PR testing summary markdown</summary>

```text
## Testing

Validated the CLI doctor path and config loading; both passed.
```
</details>
<details>
<summary>Evidence: Failed PR testing summary markdown preserves outcome</summary>

```text
## Testing

Completed 1 recorded test check.

- Outcome: ❌ failed across 1 run (300ms)
```
</details>
<details>
<summary>Evidence: Artifact-only PR testing summary markdown preserves outcome</summary>

```text
## Testing

<details>
<summary>Evidence: Rendered PR markdown</summary>

`` `text
## Testing

- Evidence captured
`` `
</details>
- Outcome: ✅ passed across 1 run (300ms)
```
</details>
- Outcome: ✅ passed across 1 run (1m37s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2)</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/pipeline/steps/prsummary.go:123` - When PR testing evidence contains artifacts but no testing_summary or tested entries, this now suppresses the only outcome line, so the generated Testing section can contain evidence links without saying whether the test step passed, failed, or was unavailable. Consider keeping the outcome fallback when no paragraph summary was emitted.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `internal/pipeline/steps/prsummary.go:126` - PR testing summaries now suppress the outcome whenever a summary paragraph was written, including the fallback paragraph created from `tested` entries. If the test step records only commands and fails, the PR body can say only `Completed 1 recorded test check.` and omit the `failed` outcome. Keep the outcome for non-passing or compact fallback summaries so failures remain visible.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/pipeline/steps -run 'TestBuildTestingSummaryForPR_(OmitsRecordedTestDetails|SummarizesBaselineOnlyTests|KeepsFailedOutcomeForCompactTestedSummary|KeepsOutcomeForArtifactOnlyEvidence)$' -count=1 -v`
- `go test ./internal/pipeline/steps -run '^TestBuildTestingSummaryForPR_OmitsRecordedTestDetails$' -count=1 -v`
- `go test ./internal/pipeline/steps -run '^TestBuildTestingSummaryForPR_KeepsFailedOutcomeForCompactTestedSummary$' -count=1 -v`
- `go test ./internal/pipeline/steps -run '^TestBuildTestingSummaryForPR_KeepsOutcomeForArtifactOnlyEvidence$' -count=1 -v`
- `go test ./internal/pipeline/steps -count=1`

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `docs/src/content/docs/reference/pipeline-steps.md:146` - The PR step documentation still says the regenerated `## Testing` section ends with the overall outcome when available. The code now formats PR testing summaries as a paragraph and omits the successful `Outcome` row whenever a testing summary or compact recorded-check summary is present, while preserving failed outcomes and fallback outcomes. Update this bullet to describe the new PR-specific formatting and conditional outcome behavior.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
