### PR TITLE
fix(intent): log accepted candidates only

### DIFF
--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -150,7 +150,7 @@ The selected transcript text is then sent to the configured pipeline agent for s
 Before disambiguation or summarization, no-mistakes excludes tool output, redacts likely secrets, strips common prompt-control markers, and clamps long transcripts while preserving the beginning and end.
 no-mistakes stores derived intent summaries and matching metadata in `~/.no-mistakes/state.sqlite`, including the source, session ID, and match score on each run plus cached summaries for matching transcript sessions.
 It does not store raw transcript text in its database.
-The step logs candidate match diagnostics, then logs the matched source, score, and sanitized inferred intent when a transcript matches.
+The step logs accepted candidate match diagnostics, then logs the matched source, score, and sanitized inferred intent when a transcript matches.
 
 Use `intent.disabled_readers` to disable specific transcript sources, or set `intent.enabled: false` to opt out entirely.
 

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -20,7 +20,7 @@ This is best-effort context, and when available it is included in rebase fixes, 
 - Runs only when `intent.enabled` is true
 - Matches local agent transcripts against the changed files, may use the configured pipeline agent to disambiguate plausible matches, and summarizes the likely author intent with that agent
 - Stores the derived summary, source, session ID, and match score on the run
-- Logs candidate diagnostics, including source, session, CWD, score, confidence, overlap, decision, and rejection reason
+- Logs accepted candidate diagnostics, including source, session, CWD, score, confidence, overlap, decision, and acceptance reason
 - Logs the matched source, score, and sanitized inferred intent when a transcript matches
 - Skips instead of failing when disabled, no matching transcript is found, the diff is empty, extraction errors, or persistence fails
 

--- a/internal/intent/intent.go
+++ b/internal/intent/intent.go
@@ -48,7 +48,7 @@ type ExtractParams struct {
 	// Disambiguator optionally chooses among multiple plausible sessions when
 	// file-overlap scoring is not decisive enough to pick one safely.
 	Disambiguator Disambiguator
-	// Logf receives best-effort candidate diagnostics. Nil disables logging.
+	// Logf receives best-effort accepted candidate diagnostics. Nil disables logging.
 	Logf func(format string, args ...any)
 }
 

--- a/internal/intent/intent_test.go
+++ b/internal/intent/intent_test.go
@@ -401,7 +401,7 @@ func TestExtract_NoReaders(t *testing.T) {
 	}
 }
 
-func TestExtract_LogsCandidateDecisions(t *testing.T) {
+func TestExtract_LogsAcceptedCandidatesOnly(t *testing.T) {
 	r := &staticReader{
 		name: "opencode",
 		sessions: []*Session{{
@@ -409,6 +409,11 @@ func TestExtract_LogsCandidateDecisions(t *testing.T) {
 			CWD:          "/tmp/repo",
 			LastActivity: time.Now(),
 			Messages:     []Message{{FilePaths: []string{"a.go"}}},
+		}, {
+			SessionID:    "strong",
+			CWD:          "/tmp/repo",
+			LastActivity: time.Now(),
+			Messages:     []Message{{FilePaths: []string{"b.go", "c.go"}}},
 		}},
 	}
 	var logs []string
@@ -424,13 +429,18 @@ func TestExtract_LogsCandidateDecisions(t *testing.T) {
 			logs = append(logs, fmt.Sprintf(format, args...))
 		},
 	})
-	if !errors.Is(err, ErrNoMatch) {
-		t.Fatalf("expected ErrNoMatch, got %v", err)
+	if err != nil {
+		t.Fatalf("extract: %v", err)
 	}
 	joined := strings.Join(logs, "\n")
-	for _, want := range []string{"candidate", "opencode", "weak", "score 0.33", "rejected"} {
+	for _, want := range []string{"candidate", "opencode", "strong", "accepted"} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("logs missing %q:\n%s", want, joined)
+		}
+	}
+	for _, unwanted := range []string{"weak", "rejected", "no_overlap", "single_overlap_multi_file_diff"} {
+		if strings.Contains(joined, unwanted) {
+			t.Fatalf("logs contain rejected candidate detail %q:\n%s", unwanted, joined)
 		}
 	}
 }

--- a/internal/intent/matcher.go
+++ b/internal/intent/matcher.go
@@ -94,16 +94,12 @@ func acceptedMatches(sessions []*Session, diffFiles []string, opts matchOptions)
 	for _, s := range sessions {
 		sc, overlap := score(s, diffFiles)
 		accepted, reason, confidence := acceptMatchCandidate(sc, len(overlap), len(diffFiles), s.LastActivity, opts)
-		if opts.Logf != nil {
-			decision := "accepted"
-			if !accepted {
-				decision = "rejected"
-			}
-			opts.Logf("candidate agent=%s session=%s cwd=%q score %.2f confidence %.2f overlap=%d/%d decision=%s reason=%s",
-				s.AgentName, s.SessionID, s.CWD, sc, confidence, len(overlap), len(diffFiles), decision, reason)
-		}
 		if !accepted {
 			continue
+		}
+		if opts.Logf != nil {
+			opts.Logf("candidate agent=%s session=%s cwd=%q score %.2f confidence %.2f overlap=%d/%d decision=accepted reason=%s",
+				s.AgentName, s.SessionID, s.CWD, sc, confidence, len(overlap), len(diffFiles), reason)
 		}
 		candidates = append(candidates, &Match{Session: s, Score: sc, Confidence: confidence, Overlap: overlap})
 	}


### PR DESCRIPTION
## Intent

The developer wanted to understand why a pipeline run’s Intent step appeared to fail, then adjust the system so intent extraction had enough time and its output was less noisy. They explicitly requested increasing the Intent step timeout from 30 seconds to 90 seconds because 30 seconds was too short for summarization. After seeing rejected transcript matches in the TUI, they asked whether all candidates were being ranked and wanted the current behavior investigated. They then required that only accepted intent candidates be shown in both the TUI and log file, suppressing rejected matches such as score-0 or no-overlap candidates.

## What Changed

- Changed intent candidate diagnostics to emit only accepted matches, suppressing rejected candidates from the step log and TUI output.
- Updated intent extraction tests to assert rejected candidates are not logged while accepted candidates remain visible.
- Refreshed intent logging documentation in the agent guide, pipeline step reference, and callback comment.

## Risk Assessment

✅ Low: The change is narrowly scoped to suppressing diagnostics for rejected intent candidates while preserving matching, ranking, and disambiguation behavior.

## Testing

- Summary: No baseline commands had already run; I exercised the accepted-only intent candidate log path, the 90-second intent extraction timeout, the slow-past-30-seconds persistence path, and the relevant intent package suites, and all checks passed.
<details>
<summary>Evidence: Accepted-only intent log test output</summary>

```text
=== RUN TestExtract_LogsAcceptedCandidatesOnly
--- PASS: TestExtract_LogsAcceptedCandidatesOnly (0.00s)
PASS
ok github.com/kunchenguid/no-mistakes/internal/intent 0.278s
```
</details>
<details>
<summary>Evidence: 90-second timeout and slow extraction test output</summary>

```text
=== RUN TestIntentStep_UsesNinetySecondExtractionTimeout
--- PASS: TestIntentStep_UsesNinetySecondExtractionTimeout (0.02s)
=== RUN TestIntentStep_SlowExtractionPastOldTimeoutStillAttachesIntent
2026/05/18 10:43:33 INFO intent: attached run_id=01KRY2Y84B15J19CT9WXV8V20V agent=claude score=0.92
--- PASS: TestIntentStep_SlowExtractionPastOldTimeoutStillAttachesIntent (31.01s)
PASS
ok github.com/kunchenguid/no-mistakes/internal/pipeline/steps 31.294s
```
</details>
<details>
<summary>Evidence: Evidence assertions for rejected candidates being suppressed</summary>

Source: [Evidence assertions for rejected candidates being suppressed](https://github.com/kunchenguid/no-mistakes/blob/796e3903e07ef96a071079366a59ebe46bab8756/internal/intent/intent_test.go)

```text
TestExtract_LogsAcceptedCandidatesOnly asserts the captured intent logs include the accepted `strong` candidate and do not contain `weak`, `rejected`, `no_overlap`, or `single_overlap_multi_file_diff`.
```
</details>
<details>
<summary>Evidence: Evidence assertions for timeout behavior</summary>

Source: [Evidence assertions for timeout behavior](https://github.com/kunchenguid/no-mistakes/blob/796e3903e07ef96a071079366a59ebe46bab8756/internal/pipeline/steps/intent_test.go)

```text
TestIntentStep_UsesNinetySecondExtractionTimeout asserts the extraction context deadline is about 90 seconds; TestIntentStep_SlowExtractionPastOldTimeoutStillAttachesIntent waits 31 seconds and then verifies the inferred intent is persisted.
```
</details>
- Outcome: ✅ passed across 1 run (2m29s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/intent -run '^TestExtract_LogsAcceptedCandidatesOnly$' -v -count=1`
- `go test ./internal/pipeline/steps -run '^TestIntentStep_(UsesNinetySecondExtractionTimeout|SlowExtractionPastOldTimeoutStillAttachesIntent)$' -v -count=1`
- `go test ./internal/intent ./internal/pipeline/steps -count=1`

</details>

<details>
<summary>🔧 **Document** - 3 issues found → auto-fixed</summary>

**Round 1** - found 3 issues (2 warnings, 1 info)
- ⚠️ `docs/src/content/docs/reference/pipeline-steps.md:23` - The Intent step reference still says candidate diagnostics include decisions and rejection reasons, but the matcher now logs only accepted candidates and never logs rejected candidates or rejection reasons. Update this bullet to describe accepted-candidate-only diagnostics.
- ⚠️ `docs/src/content/docs/guides/agents.md:153` - The agent guide says the step logs candidate match diagnostics without clarifying that only accepted candidates are logged. With rejected matches intentionally suppressed from the TUI and step log, this should be updated to avoid implying all considered candidates are visible.
- ℹ️ `internal/intent/intent.go:51` - The `ExtractParams.Logf` doc comment describes generic candidate diagnostics, but the callback now receives accepted-candidate diagnostics only. Update the comment so callers do not rely on rejected-candidate log entries.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
