### PR TITLE
feat(intent): support Pi transcript reading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6
 
@@ -46,7 +47,7 @@ jobs:
 
       - name: Test on Windows
         if: runner.os == 'Windows'
-        run: go test ./...
+        run: go test -v -timeout=15m ./...
 
       - name: Build
         run: go build ./cmd/no-mistakes

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -138,13 +138,13 @@ Transient API and network failures are retried up to three times with exponentia
 
 ## Intent extraction
 
-When `intent.enabled` is true, no-mistakes reads recent local transcripts from Claude Code, Codex, OpenCode, and Rovo Dev during the `intent` pipeline step.
+When `intent.enabled` is true, no-mistakes reads recent local transcripts from Claude Code, Codex, OpenCode, Rovo Dev, and Pi during the `intent` pipeline step.
 It matches sessions against the changed files, summarizes the likely author intent with the configured pipeline agent, includes that summary as untrusted context in rebase fixes, review checks and fixes, test detection, evidence validation, and fixes, lint detection and fixes, documentation checks and fixes, CI auto-fixes, and PR prompts, and renders it in generated PR descriptions.
 
 Transcript readers collect user and assistant text messages but exclude tool call output.
-They read Claude Code transcripts from `~/.claude/projects`, Codex metadata from `~/.codex/state_*.sqlite` plus referenced rollout files, OpenCode messages from `$XDG_DATA_HOME/opencode/opencode.db` or `~/.local/share/opencode/opencode.db`, and Rovo Dev sessions from `~/.rovodev/sessions`.
+They read Claude Code transcripts from `~/.claude/projects`, Codex metadata from `~/.codex/state_*.sqlite` plus referenced rollout files, OpenCode messages from `$XDG_DATA_HOME/opencode/opencode.db` or `~/.local/share/opencode/opencode.db`, Rovo Dev sessions from `~/.rovodev/sessions`, and Pi transcripts from `~/.pi/agent/sessions`.
 Sessions are eligible when they come from the same working directory or an equivalent Git checkout with the same common Git directory or normalized remote URL.
-Pi and ACP transcripts are not currently read for intent extraction.
+ACP transcripts are not currently read for intent extraction.
 When deterministic matching leaves multiple plausible sessions, no-mistakes may ask the configured pipeline agent to choose among them using the changed file paths and sanitized transcript packet files.
 The selected transcript text is then sent to the configured pipeline agent for summarization during the `intent` step, so intent extraction may incur additional agent or API invocations.
 Before disambiguation or summarization, no-mistakes excludes tool output, redacts likely secrets, strips common prompt-control markers, and clamps long transcripts while preserving the beginning and end.

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -224,7 +224,7 @@ When enabled, no-mistakes can read recent local agent transcripts, match the ses
 | `intent.slack_days` | `int` | `3` | Extra days to look back before the change window |
 | `intent.disabled_readers` | `string[]` | Empty | Transcript readers to disable |
 
-Valid `disabled_readers` values are `claude`, `codex`, `opencode`, and `rovodev`.
+Valid `disabled_readers` values are `claude`, `codex`, `opencode`, `rovodev`, and `pi`.
 
 The match score is the share of changed files mentioned in a transcript session.
 Mentioning extra files does not reduce the score.

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -13,7 +13,7 @@ Each step can produce findings, request approval, or trigger auto-fix. Steps tha
 
 ## Intent
 
-Infers the author's intent from recent local Claude Code, Codex, OpenCode, or Rovo Dev transcripts.
+Infers the author's intent from recent local Claude Code, Codex, OpenCode, Rovo Dev, or Pi transcripts.
 This is best-effort context, and when available it is included in rebase fixes, review checks and fixes, test detection, evidence validation, and fixes, documentation checks and fixes, lint detection and fixes, CI auto-fixes, and PR drafting.
 
 **Behavior:**

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -139,4 +139,4 @@ Fields not set here inherit from global config and then the built-in defaults.
 | `intent.slack_days` | `int` | Inherits from global (default `3`) |
 | `intent.disabled_readers` | `string[]` | Adds to globally disabled readers |
 
-Valid `disabled_readers` values are `claude`, `codex`, `opencode`, and `rovodev`.
+Valid `disabled_readers` values are `claude`, `codex`, `opencode`, `rovodev`, and `pi`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -158,7 +158,7 @@ auto_fix:
   ci: 3
 
 # User-intent extraction. When you push a branch, no-mistakes can read recent
-# transcripts from your local agent (Claude Code, Codex, OpenCode, Rovo Dev),
+# transcripts from your local agent (Claude Code, Codex, OpenCode, Rovo Dev, Pi),
 # pick the session that produced the change, summarize the user intent, and
 # feed it to review, test, document, lint, and PR agents so they understand
 # what you were trying to do - not just the diff.

--- a/internal/intent/extract_e2e_test.go
+++ b/internal/intent/extract_e2e_test.go
@@ -3,6 +3,7 @@ package intent
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -36,5 +37,43 @@ func TestExtract_EndToEndWithClaudeFixture(t *testing.T) {
 	}
 	if got.Summary != "user wanted Bar() helper in internal/foo.go" {
 		t.Errorf("summary = %q", got.Summary)
+	}
+}
+
+func TestExtract_EndToEndWithPiFixture(t *testing.T) {
+	repoCWD := t.TempDir()
+	home := writePiFixture(t, repoCWD)
+
+	fa := &fakeAgent{output: `{"summary": "user wanted foo helper changes in internal/foo.go"}`}
+
+	got, err := Extract(context.Background(), ExtractParams{
+		HomeDir:    home,
+		OriginCWD:  repoCWD,
+		DiffFiles:  []string{"internal/foo.go"},
+		BaseTime:   time.Now().Add(-time.Hour),
+		HeadTime:   time.Now(),
+		SlackDays:  3,
+		Threshold:  0.2,
+		Readers:    AllReaders(nil),
+		Cache:      NewMemCache(),
+		Summarizer: NewAgentSummarizer(fa, ""),
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if got.AgentName != "pi" {
+		t.Errorf("AgentName = %q", got.AgentName)
+	}
+	if got.SessionID != "session-1" {
+		t.Errorf("SessionID = %q", got.SessionID)
+	}
+	if got.Summary != "user wanted foo helper changes in internal/foo.go" {
+		t.Errorf("summary = %q", got.Summary)
+	}
+	if !strings.Contains(fa.lastPrompt, "please add a foo helper to internal/foo.go") {
+		t.Errorf("prompt should include Pi user text, got %q", fa.lastPrompt)
+	}
+	if strings.Contains(fa.lastPrompt, "private chain of thought") || strings.Contains(fa.lastPrompt, "tool output should not become transcript text") {
+		t.Errorf("prompt leaked non-user-intent Pi content: %q", fa.lastPrompt)
 	}
 }

--- a/internal/intent/reader_pi.go
+++ b/internal/intent/reader_pi.go
@@ -260,6 +260,7 @@ func parsePiParsedMessage(raw json.RawMessage, timestamp string) (piParsedMessag
 
 	var msg struct {
 		Role       string          `json:"role"`
+		ID         string          `json:"id"`
 		ResponseID string          `json:"responseId"`
 		Content    json.RawMessage `json:"content"`
 	}
@@ -294,7 +295,9 @@ func parsePiParsedMessage(raw json.RawMessage, timestamp string) (piParsedMessag
 	}
 	identity := ""
 	if msg.ResponseID != "" {
-		identity = string(role) + "\x00" + msg.ResponseID
+		identity = string(role) + "\x00responseId:" + msg.ResponseID
+	} else if msg.ID != "" {
+		identity = string(role) + "\x00id:" + msg.ID
 	}
 	return piParsedMessage{Message: out, identity: identity}, true
 }

--- a/internal/intent/reader_pi.go
+++ b/internal/intent/reader_pi.go
@@ -16,6 +16,8 @@ import (
 // PiReaderName is the agent name used in cache keys and DB rows.
 const PiReaderName = "pi"
 
+const piScannerMaxTokenSize = 256 * 1024 * 1024
+
 // piReader reads Pi coding-agent transcripts from ~/.pi/agent/sessions/.
 type piReader struct{}
 
@@ -106,7 +108,7 @@ func (r *piReader) Load(_ context.Context, s *Session) error {
 	defer f.Close()
 
 	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
+	scanner.Buffer(make([]byte, 0, 64*1024), piScannerMaxTokenSize)
 	var lastID string
 	seen := make(map[string]struct{})
 	for scanner.Scan() {
@@ -157,7 +159,7 @@ func piPeekMetadata(path string) (*piMetadata, error) {
 	defer f.Close()
 
 	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
+	scanner.Buffer(make([]byte, 0, 64*1024), piScannerMaxTokenSize)
 	for scanner.Scan() {
 		var raw struct {
 			Type      string `json:"type"`

--- a/internal/intent/reader_pi.go
+++ b/internal/intent/reader_pi.go
@@ -111,6 +111,7 @@ func (r *piReader) Load(_ context.Context, s *Session) error {
 	scanner.Buffer(make([]byte, 0, 64*1024), piScannerMaxTokenSize)
 	var lastID string
 	seen := make(map[string]struct{})
+	seenLive := make(map[string]struct{})
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		if len(line) == 0 {
@@ -131,14 +132,20 @@ func (r *piReader) Load(_ context.Context, s *Session) error {
 			}
 		}
 		for _, msg := range msgs {
-			key := piMessageKey(msg)
+			if !aggregate && msg.identity != "" {
+				if _, ok := seenLive[msg.identity]; ok {
+					continue
+				}
+				seenLive[msg.identity] = struct{}{}
+			}
+			key := piMessageKey(msg.Message)
 			if aggregate {
 				if _, ok := priorSeen[key]; ok {
 					continue
 				}
 			}
 			seen[key] = struct{}{}
-			s.Messages = append(s.Messages, msg)
+			s.Messages = append(s.Messages, msg.Message)
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -152,6 +159,11 @@ func (r *piReader) Load(_ context.Context, s *Session) error {
 
 func piMessageKey(msg Message) string {
 	return string(msg.Role) + "\x00" + msg.Text + "\x00" + strings.Join(msg.FilePaths, "\x00")
+}
+
+type piParsedMessage struct {
+	Message
+	identity string
 }
 
 type piMetadata struct {
@@ -191,7 +203,7 @@ func piPeekMetadata(path string) (*piMetadata, error) {
 	return nil, nil
 }
 
-func parsePiRecord(line []byte) ([]Message, string, bool, bool) {
+func parsePiRecord(line []byte) ([]piParsedMessage, string, bool, bool) {
 	var raw struct {
 		Type      string          `json:"type"`
 		ID        string          `json:"id"`
@@ -204,11 +216,11 @@ func parsePiRecord(line []byte) ([]Message, string, bool, bool) {
 	}
 	switch raw.Type {
 	case "message", "message_end", "turn_end":
-		msg, ok := parsePiMessage(raw.Message, raw.Timestamp)
+		msg, ok := parsePiParsedMessage(raw.Message, raw.Timestamp)
 		if !ok {
 			return nil, raw.ID, false, true
 		}
-		return []Message{msg}, raw.ID, false, true
+		return []piParsedMessage{msg}, raw.ID, false, true
 	case "message_update":
 		return nil, raw.ID, false, true
 	case "agent_end":
@@ -218,7 +230,7 @@ func parsePiRecord(line []byte) ([]Message, string, bool, bool) {
 	}
 }
 
-func parsePiMessages(raw json.RawMessage, timestamp string) []Message {
+func parsePiMessages(raw json.RawMessage, timestamp string) []piParsedMessage {
 	if len(raw) == 0 {
 		return nil
 	}
@@ -226,9 +238,9 @@ func parsePiMessages(raw json.RawMessage, timestamp string) []Message {
 	if err := json.Unmarshal(raw, &items); err != nil {
 		return nil
 	}
-	msgs := make([]Message, 0, len(items))
+	msgs := make([]piParsedMessage, 0, len(items))
 	for _, item := range items {
-		msg, ok := parsePiMessage(item, timestamp)
+		msg, ok := parsePiParsedMessage(item, timestamp)
 		if ok {
 			msgs = append(msgs, msg)
 		}
@@ -237,16 +249,22 @@ func parsePiMessages(raw json.RawMessage, timestamp string) []Message {
 }
 
 func parsePiMessage(raw json.RawMessage, timestamp string) (Message, bool) {
+	msg, ok := parsePiParsedMessage(raw, timestamp)
+	return msg.Message, ok
+}
+
+func parsePiParsedMessage(raw json.RawMessage, timestamp string) (piParsedMessage, bool) {
 	if len(raw) == 0 {
-		return Message{}, false
+		return piParsedMessage{}, false
 	}
 
 	var msg struct {
-		Role    string          `json:"role"`
-		Content json.RawMessage `json:"content"`
+		Role       string          `json:"role"`
+		ResponseID string          `json:"responseId"`
+		Content    json.RawMessage `json:"content"`
 	}
 	if err := json.Unmarshal(raw, &msg); err != nil {
-		return Message{}, false
+		return piParsedMessage{}, false
 	}
 
 	role := RoleAssistant
@@ -256,7 +274,7 @@ func parsePiMessage(raw json.RawMessage, timestamp string) (Message, bool) {
 	case strings.EqualFold(msg.Role, "assistant"):
 		role = RoleAssistant
 	default:
-		return Message{}, false
+		return piParsedMessage{}, false
 	}
 
 	text, paths := parsePiContent(msg.Content)
@@ -265,15 +283,20 @@ func parsePiMessage(raw json.RawMessage, timestamp string) (Message, bool) {
 		paths = append(paths, scanFilePathsInText(text)...)
 	}
 	if text == "" && len(paths) == 0 {
-		return Message{}, false
+		return piParsedMessage{}, false
 	}
 	ts, _ := parsePiTimestamp(timestamp)
-	return Message{
+	out := Message{
 		Role:      role,
 		Text:      text,
 		FilePaths: paths,
 		Timestamp: ts,
-	}, true
+	}
+	identity := ""
+	if msg.ResponseID != "" {
+		identity = string(role) + "\x00" + msg.ResponseID
+	}
+	return piParsedMessage{Message: out, identity: identity}, true
 }
 
 func parsePiContent(raw json.RawMessage) (string, []string) {

--- a/internal/intent/reader_pi.go
+++ b/internal/intent/reader_pi.go
@@ -1,0 +1,308 @@
+package intent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// PiReaderName is the agent name used in cache keys and DB rows.
+const PiReaderName = "pi"
+
+// piReader reads Pi coding-agent transcripts from ~/.pi/agent/sessions/.
+type piReader struct{}
+
+// NewPiReader returns a Reader for Pi coding-agent transcripts.
+func NewPiReader() Reader { return &piReader{} }
+
+func (r *piReader) Name() string { return PiReaderName }
+
+func (r *piReader) Discover(ctx context.Context, opts DiscoverOpts) ([]*Session, error) {
+	home, err := resolveHome(opts.HomeDir)
+	if err != nil {
+		return nil, err
+	}
+	root := filepath.Join(home, ".pi", "agent", "sessions")
+	repoDirs, err := os.ReadDir(root)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("pi sessions: %w", err)
+	}
+
+	matcher := newRepoMatcher(ctx, opts.OriginCWD)
+	var out []*Session
+	for _, repoDir := range repoDirs {
+		if ctx.Err() != nil {
+			return out, ctx.Err()
+		}
+		if !repoDir.IsDir() {
+			continue
+		}
+		dirPath := filepath.Join(root, repoDir.Name())
+		files, err := os.ReadDir(dirPath)
+		if err != nil {
+			continue
+		}
+		for _, f := range files {
+			if f.IsDir() || !strings.HasSuffix(f.Name(), ".jsonl") {
+				continue
+			}
+			info, err := f.Info()
+			if err != nil {
+				continue
+			}
+			modTime := info.ModTime()
+			if !opts.WindowStart.IsZero() && modTime.Before(opts.WindowStart) {
+				continue
+			}
+			if !opts.WindowEnd.IsZero() && modTime.After(opts.WindowEnd.Add(time.Hour)) {
+				continue
+			}
+			path := filepath.Join(dirPath, f.Name())
+			meta, err := piPeekMetadata(path)
+			if err != nil || meta == nil {
+				continue
+			}
+			if !matcher.matches(ctx, meta.cwd) {
+				continue
+			}
+			sessionID := meta.id
+			if sessionID == "" {
+				sessionID = strings.TrimSuffix(f.Name(), ".jsonl")
+			}
+			session := &Session{
+				AgentName:     PiReaderName,
+				SessionID:     sessionID,
+				CWD:           meta.cwd,
+				StartedAt:     meta.startedAt,
+				LastActivity:  modTime,
+				LastMsgKey:    modTime.UTC().Format(time.RFC3339Nano),
+				startedAtPath: path,
+			}
+			session.LastMsgKey = path + "|" + session.LastMsgKey
+			out = append(out, session)
+		}
+	}
+	return out, nil
+}
+
+func (r *piReader) Load(_ context.Context, s *Session) error {
+	if s.startedAtPath == "" {
+		return fmt.Errorf("pi: session has no path")
+	}
+	f, err := os.Open(s.startedAtPath)
+	if err != nil {
+		return fmt.Errorf("pi open: %w", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
+	var lastID string
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		msg, id, ok := parsePiRecord(line)
+		if !ok {
+			continue
+		}
+		if id != "" {
+			lastID = id
+		}
+		if msg == nil {
+			continue
+		}
+		s.Messages = append(s.Messages, *msg)
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("pi scan: %w", err)
+	}
+	if lastID != "" {
+		s.LastMsgKey = lastID
+	}
+	return nil
+}
+
+type piMetadata struct {
+	id        string
+	cwd       string
+	startedAt time.Time
+}
+
+func piPeekMetadata(path string) (*piMetadata, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
+	for scanner.Scan() {
+		var raw struct {
+			Type      string `json:"type"`
+			ID        string `json:"id"`
+			Timestamp string `json:"timestamp"`
+			CWD       string `json:"cwd"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &raw); err != nil {
+			continue
+		}
+		if raw.Type != "session" || raw.CWD == "" {
+			continue
+		}
+		startedAt, _ := parsePiTimestamp(raw.Timestamp)
+		return &piMetadata{id: raw.ID, cwd: raw.CWD, startedAt: startedAt}, nil
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func parsePiRecord(line []byte) (*Message, string, bool) {
+	var raw struct {
+		Type      string          `json:"type"`
+		ID        string          `json:"id"`
+		Timestamp string          `json:"timestamp"`
+		Message   json.RawMessage `json:"message"`
+	}
+	if err := json.Unmarshal(line, &raw); err != nil {
+		return nil, "", false
+	}
+	if raw.Type != "message" || len(raw.Message) == 0 {
+		return nil, raw.ID, true
+	}
+
+	var msg struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(raw.Message, &msg); err != nil {
+		return nil, raw.ID, true
+	}
+
+	role := RoleAssistant
+	switch {
+	case strings.EqualFold(msg.Role, "user"):
+		role = RoleUser
+	case strings.EqualFold(msg.Role, "assistant"):
+		role = RoleAssistant
+	default:
+		return nil, raw.ID, true
+	}
+
+	text, paths := parsePiContent(msg.Content)
+	text = strings.TrimSpace(text)
+	if role == RoleUser {
+		paths = append(paths, scanFilePathsInText(text)...)
+	}
+	if text == "" && len(paths) == 0 {
+		return nil, raw.ID, true
+	}
+	ts, _ := parsePiTimestamp(raw.Timestamp)
+	return &Message{
+		Role:      role,
+		Text:      text,
+		FilePaths: paths,
+		Timestamp: ts,
+	}, raw.ID, true
+}
+
+func parsePiContent(raw json.RawMessage) (string, []string) {
+	if len(raw) == 0 {
+		return "", nil
+	}
+	if raw[0] == '"' {
+		var s string
+		if err := json.Unmarshal(raw, &s); err == nil {
+			return s, nil
+		}
+		return "", nil
+	}
+
+	var items []map[string]any
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return "", nil
+	}
+	var sb strings.Builder
+	var paths []string
+	for _, item := range items {
+		t, _ := item["type"].(string)
+		switch t {
+		case "text", "input_text", "output_text":
+			if s, ok := item["text"].(string); ok {
+				sb.WriteString(s)
+				sb.WriteString("\n")
+			} else if s, ok := item["content"].(string); ok {
+				sb.WriteString(s)
+				sb.WriteString("\n")
+			}
+		case "toolCall", "tool_call", "tool_use":
+			paths = append(paths, piToolCallPaths(item)...)
+		}
+	}
+	return sb.String(), paths
+}
+
+func piToolCallPaths(item map[string]any) []string {
+	var out []string
+	for _, key := range []string{"arguments", "input"} {
+		args, ok := item[key]
+		if !ok {
+			continue
+		}
+		switch v := args.(type) {
+		case map[string]any:
+			out = append(out, extractToolPaths(v)...)
+			out = append(out, piCommandPaths(v["command"])...)
+		case string:
+			var m map[string]any
+			if err := json.Unmarshal([]byte(v), &m); err == nil {
+				out = append(out, extractToolPaths(m)...)
+				out = append(out, piCommandPaths(m["command"])...)
+			} else {
+				out = append(out, scanFilePathsInText(v)...)
+			}
+		}
+	}
+	return out
+}
+
+func piCommandPaths(raw any) []string {
+	switch v := raw.(type) {
+	case string:
+		return scanFilePathsInText(v)
+	case []any:
+		var out []string
+		for _, part := range v {
+			if s, ok := part.(string); ok {
+				out = append(out, scanFilePathsInText(s)...)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func parsePiTimestamp(raw string) (time.Time, error) {
+	if raw == "" {
+		return time.Time{}, nil
+	}
+	if t, err := time.Parse(time.RFC3339Nano, raw); err == nil {
+		return t, nil
+	}
+	return time.Parse(time.RFC3339, raw)
+}

--- a/internal/intent/reader_pi.go
+++ b/internal/intent/reader_pi.go
@@ -203,12 +203,14 @@ func parsePiRecord(line []byte) ([]Message, string, bool, bool) {
 		return nil, "", false, false
 	}
 	switch raw.Type {
-	case "message", "message_update", "message_end", "turn_end":
+	case "message", "message_end", "turn_end":
 		msg, ok := parsePiMessage(raw.Message, raw.Timestamp)
 		if !ok {
 			return nil, raw.ID, false, true
 		}
 		return []Message{msg}, raw.ID, false, true
+	case "message_update":
+		return nil, raw.ID, false, true
 	case "agent_end":
 		return parsePiMessages(raw.Messages, raw.Timestamp), raw.ID, true, true
 	default:

--- a/internal/intent/reader_pi.go
+++ b/internal/intent/reader_pi.go
@@ -108,6 +108,7 @@ func (r *piReader) Load(_ context.Context, s *Session) error {
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
 	var lastID string
+	seen := make(map[string]struct{})
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		if len(line) == 0 {
@@ -120,7 +121,14 @@ func (r *piReader) Load(_ context.Context, s *Session) error {
 		if id != "" {
 			lastID = id
 		}
-		s.Messages = append(s.Messages, msgs...)
+		for _, msg := range msgs {
+			key := piMessageKey(msg)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			s.Messages = append(s.Messages, msg)
+		}
 	}
 	if err := scanner.Err(); err != nil {
 		return fmt.Errorf("pi scan: %w", err)
@@ -129,6 +137,10 @@ func (r *piReader) Load(_ context.Context, s *Session) error {
 		s.LastMsgKey = lastID
 	}
 	return nil
+}
+
+func piMessageKey(msg Message) string {
+	return string(msg.Role) + "\x00" + msg.Text + "\x00" + strings.Join(msg.FilePaths, "\x00")
 }
 
 type piMetadata struct {

--- a/internal/intent/reader_pi.go
+++ b/internal/intent/reader_pi.go
@@ -116,17 +116,26 @@ func (r *piReader) Load(_ context.Context, s *Session) error {
 		if len(line) == 0 {
 			continue
 		}
-		msgs, id, ok := parsePiRecord(line)
+		msgs, id, aggregate, ok := parsePiRecord(line)
 		if !ok {
 			continue
 		}
 		if id != "" {
 			lastID = id
 		}
+		priorSeen := seen
+		if aggregate {
+			priorSeen = make(map[string]struct{}, len(seen))
+			for key := range seen {
+				priorSeen[key] = struct{}{}
+			}
+		}
 		for _, msg := range msgs {
 			key := piMessageKey(msg)
-			if _, ok := seen[key]; ok {
-				continue
+			if aggregate {
+				if _, ok := priorSeen[key]; ok {
+					continue
+				}
 			}
 			seen[key] = struct{}{}
 			s.Messages = append(s.Messages, msg)
@@ -182,7 +191,7 @@ func piPeekMetadata(path string) (*piMetadata, error) {
 	return nil, nil
 }
 
-func parsePiRecord(line []byte) ([]Message, string, bool) {
+func parsePiRecord(line []byte) ([]Message, string, bool, bool) {
 	var raw struct {
 		Type      string          `json:"type"`
 		ID        string          `json:"id"`
@@ -191,19 +200,19 @@ func parsePiRecord(line []byte) ([]Message, string, bool) {
 		Messages  json.RawMessage `json:"messages"`
 	}
 	if err := json.Unmarshal(line, &raw); err != nil {
-		return nil, "", false
+		return nil, "", false, false
 	}
 	switch raw.Type {
 	case "message", "message_update", "message_end", "turn_end":
 		msg, ok := parsePiMessage(raw.Message, raw.Timestamp)
 		if !ok {
-			return nil, raw.ID, true
+			return nil, raw.ID, false, true
 		}
-		return []Message{msg}, raw.ID, true
+		return []Message{msg}, raw.ID, false, true
 	case "agent_end":
-		return parsePiMessages(raw.Messages, raw.Timestamp), raw.ID, true
+		return parsePiMessages(raw.Messages, raw.Timestamp), raw.ID, true, true
 	default:
-		return nil, raw.ID, true
+		return nil, raw.ID, false, true
 	}
 }
 

--- a/internal/intent/reader_pi.go
+++ b/internal/intent/reader_pi.go
@@ -113,17 +113,14 @@ func (r *piReader) Load(_ context.Context, s *Session) error {
 		if len(line) == 0 {
 			continue
 		}
-		msg, id, ok := parsePiRecord(line)
+		msgs, id, ok := parsePiRecord(line)
 		if !ok {
 			continue
 		}
 		if id != "" {
 			lastID = id
 		}
-		if msg == nil {
-			continue
-		}
-		s.Messages = append(s.Messages, *msg)
+		s.Messages = append(s.Messages, msgs...)
 	}
 	if err := scanner.Err(); err != nil {
 		return fmt.Errorf("pi scan: %w", err)
@@ -171,26 +168,60 @@ func piPeekMetadata(path string) (*piMetadata, error) {
 	return nil, nil
 }
 
-func parsePiRecord(line []byte) (*Message, string, bool) {
+func parsePiRecord(line []byte) ([]Message, string, bool) {
 	var raw struct {
 		Type      string          `json:"type"`
 		ID        string          `json:"id"`
 		Timestamp string          `json:"timestamp"`
 		Message   json.RawMessage `json:"message"`
+		Messages  json.RawMessage `json:"messages"`
 	}
 	if err := json.Unmarshal(line, &raw); err != nil {
 		return nil, "", false
 	}
-	if raw.Type != "message" || len(raw.Message) == 0 {
+	switch raw.Type {
+	case "message", "message_update", "message_end", "turn_end":
+		msg, ok := parsePiMessage(raw.Message, raw.Timestamp)
+		if !ok {
+			return nil, raw.ID, true
+		}
+		return []Message{msg}, raw.ID, true
+	case "agent_end":
+		return parsePiMessages(raw.Messages, raw.Timestamp), raw.ID, true
+	default:
 		return nil, raw.ID, true
+	}
+}
+
+func parsePiMessages(raw json.RawMessage, timestamp string) []Message {
+	if len(raw) == 0 {
+		return nil
+	}
+	var items []json.RawMessage
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return nil
+	}
+	msgs := make([]Message, 0, len(items))
+	for _, item := range items {
+		msg, ok := parsePiMessage(item, timestamp)
+		if ok {
+			msgs = append(msgs, msg)
+		}
+	}
+	return msgs
+}
+
+func parsePiMessage(raw json.RawMessage, timestamp string) (Message, bool) {
+	if len(raw) == 0 {
+		return Message{}, false
 	}
 
 	var msg struct {
 		Role    string          `json:"role"`
 		Content json.RawMessage `json:"content"`
 	}
-	if err := json.Unmarshal(raw.Message, &msg); err != nil {
-		return nil, raw.ID, true
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		return Message{}, false
 	}
 
 	role := RoleAssistant
@@ -200,7 +231,7 @@ func parsePiRecord(line []byte) (*Message, string, bool) {
 	case strings.EqualFold(msg.Role, "assistant"):
 		role = RoleAssistant
 	default:
-		return nil, raw.ID, true
+		return Message{}, false
 	}
 
 	text, paths := parsePiContent(msg.Content)
@@ -209,15 +240,15 @@ func parsePiRecord(line []byte) (*Message, string, bool) {
 		paths = append(paths, scanFilePathsInText(text)...)
 	}
 	if text == "" && len(paths) == 0 {
-		return nil, raw.ID, true
+		return Message{}, false
 	}
-	ts, _ := parsePiTimestamp(raw.Timestamp)
-	return &Message{
+	ts, _ := parsePiTimestamp(timestamp)
+	return Message{
 		Role:      role,
 		Text:      text,
 		FilePaths: paths,
 		Timestamp: ts,
-	}, raw.ID, true
+	}, true
 }
 
 func parsePiContent(raw json.RawMessage) (string, []string) {

--- a/internal/intent/reader_pi_real_test.go
+++ b/internal/intent/reader_pi_real_test.go
@@ -1,0 +1,39 @@
+package intent
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+func TestPiReader_RealLocalSessions(t *testing.T) {
+	if os.Getenv("NM_TEST_REAL_PI") != "1" {
+		t.Skip("set NM_TEST_REAL_PI=1 to validate against local ~/.pi/agent/sessions")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("home: %v", err)
+	}
+	sessions, err := NewPiReader().Discover(context.Background(), DiscoverOpts{HomeDir: home})
+	if err != nil {
+		t.Fatalf("discover real Pi sessions: %v", err)
+	}
+	if len(sessions) == 0 {
+		t.Fatal("no real Pi sessions discovered")
+	}
+	loaded := 0
+	messages := 0
+	for _, s := range sessions {
+		if err := NewPiReader().Load(context.Background(), s); err != nil {
+			t.Fatalf("load real Pi session %q: %v", s.SessionID, err)
+		}
+		if len(s.Messages) > 0 {
+			loaded++
+			messages += len(s.Messages)
+		}
+	}
+	if loaded == 0 {
+		t.Fatal("real Pi sessions loaded but produced no user/assistant messages")
+	}
+	t.Logf("loaded %d/%d real Pi sessions with %d extracted user/assistant messages", loaded, len(sessions), messages)
+}

--- a/internal/intent/reader_pi_test.go
+++ b/internal/intent/reader_pi_test.go
@@ -369,6 +369,10 @@ func TestPiReader_PreservesRepeatedLiveMessages(t *testing.T) {
 }
 
 func TestPiReader_LoadsOversizedAgentEndRecord(t *testing.T) {
+	// Keep this well above bufio.Scanner's default 64 KiB token limit without
+	// making Windows CI spend excessive time writing and parsing the fixture.
+	const oversizedPayloadSize = 1024 * 1024
+
 	repoCWD := t.TempDir()
 	home := t.TempDir()
 	dir := filepath.Join(home, ".pi", "agent", "sessions", "repo")
@@ -379,7 +383,7 @@ func TestPiReader_LoadsOversizedAgentEndRecord(t *testing.T) {
 	lines := []string{
 		`{"type":"session","version":3,"id":"session-large","timestamp":"2026-04-18T02:15:37.407Z","cwd":` + jsonString(t, repoCWD) + `}`,
 		`{"type":"message_end","id":"u1","timestamp":"2026-04-18T02:15:39.000Z","message":{"role":"user","content":"fix internal/pi.go"}}`,
-		`{"type":"agent_end","id":"u2","timestamp":"2026-04-18T02:15:41.000Z","messages":[{"role":"toolResult","content":"` + strings.Repeat("x", 16*1024*1024) + `"}]}`,
+		`{"type":"agent_end","id":"u2","timestamp":"2026-04-18T02:15:41.000Z","messages":[{"role":"toolResult","content":"` + strings.Repeat("x", oversizedPayloadSize) + `"}]}`,
 	}
 	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
 		t.Fatal(err)

--- a/internal/intent/reader_pi_test.go
+++ b/internal/intent/reader_pi_test.go
@@ -184,6 +184,47 @@ func TestPiReader_DeduplicatesAgentEndMessages(t *testing.T) {
 	}
 }
 
+func TestPiReader_LoadsOversizedAgentEndRecord(t *testing.T) {
+	repoCWD := t.TempDir()
+	home := t.TempDir()
+	dir := filepath.Join(home, ".pi", "agent", "sessions", "repo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "2026-04-18T02-15-37-407Z_session-large.jsonl")
+	lines := []string{
+		`{"type":"session","version":3,"id":"session-large","timestamp":"2026-04-18T02:15:37.407Z","cwd":` + jsonString(t, repoCWD) + `}`,
+		`{"type":"message_end","id":"u1","timestamp":"2026-04-18T02:15:39.000Z","message":{"role":"user","content":"fix internal/pi.go"}}`,
+		`{"type":"agent_end","id":"u2","timestamp":"2026-04-18T02:15:41.000Z","messages":[{"role":"toolResult","content":"` + strings.Repeat("x", 16*1024*1024) + `"}]}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewPiReader()
+	sessions, err := r.Discover(context.Background(), DiscoverOpts{HomeDir: home, OriginCWD: repoCWD})
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(sessions))
+	}
+	if err := r.Load(context.Background(), sessions[0]); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	msgs := sessions[0].Messages
+	if len(msgs) != 1 {
+		t.Fatalf("got %d messages, want 1: %+v", len(msgs), msgs)
+	}
+	if msgs[0].Role != RoleUser || msgs[0].Text != "fix internal/pi.go" {
+		t.Errorf("message wrong: %+v", msgs[0])
+	}
+	if sessions[0].LastMsgKey != "u2" {
+		t.Errorf("LastMsgKey = %q, want u2", sessions[0].LastMsgKey)
+	}
+}
+
 func readerByName(t *testing.T, readers []Reader, name string) Reader {
 	t.Helper()
 	for _, r := range readers {

--- a/internal/intent/reader_pi_test.go
+++ b/internal/intent/reader_pi_test.go
@@ -184,6 +184,56 @@ func TestPiReader_DeduplicatesAgentEndMessages(t *testing.T) {
 	}
 }
 
+func TestPiReader_PreservesRepeatedLiveMessages(t *testing.T) {
+	repoCWD := t.TempDir()
+	home := t.TempDir()
+	dir := filepath.Join(home, ".pi", "agent", "sessions", "repo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "2026-04-18T02-15-37-407Z_session-repeat.jsonl")
+	lines := []string{
+		`{"type":"session","version":3,"id":"session-repeat","timestamp":"2026-04-18T02:15:37.407Z","cwd":` + jsonString(t, repoCWD) + `}`,
+		`{"type":"message_end","id":"u1","timestamp":"2026-04-18T02:15:39.000Z","message":{"role":"user","content":"yes"}}`,
+		`{"type":"message_end","id":"u2","timestamp":"2026-04-18T02:15:40.000Z","message":{"role":"user","content":"yes"}}`,
+		`{"type":"turn_end","id":"u3","timestamp":"2026-04-18T02:15:41.000Z","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}`,
+		`{"type":"turn_end","id":"u4","timestamp":"2026-04-18T02:15:42.000Z","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewPiReader()
+	sessions, err := r.Discover(context.Background(), DiscoverOpts{HomeDir: home, OriginCWD: repoCWD})
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(sessions))
+	}
+	if err := r.Load(context.Background(), sessions[0]); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	msgs := sessions[0].Messages
+	if len(msgs) != 4 {
+		t.Fatalf("got %d messages, want 4: %+v", len(msgs), msgs)
+	}
+	for i, want := range []struct {
+		role Role
+		text string
+	}{
+		{RoleUser, "yes"},
+		{RoleUser, "yes"},
+		{RoleAssistant, "done"},
+		{RoleAssistant, "done"},
+	} {
+		if msgs[i].Role != want.role || msgs[i].Text != want.text {
+			t.Errorf("message %d = %+v, want role %s text %q", i, msgs[i], want.role, want.text)
+		}
+	}
+}
+
 func TestPiReader_LoadsOversizedAgentEndRecord(t *testing.T) {
 	repoCWD := t.TempDir()
 	home := t.TempDir()

--- a/internal/intent/reader_pi_test.go
+++ b/internal/intent/reader_pi_test.go
@@ -230,6 +230,52 @@ func TestPiReader_DeduplicatesCompletedEventsByResponseID(t *testing.T) {
 	}
 }
 
+func TestPiReader_DeduplicatesCompletedEventsByMessageID(t *testing.T) {
+	repoCWD := t.TempDir()
+	home := t.TempDir()
+	dir := filepath.Join(home, ".pi", "agent", "sessions", "repo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "2026-04-18T02-15-37-407Z_session-completed-message-id-dedupe.jsonl")
+	lines := []string{
+		`{"type":"session","version":3,"id":"session-completed-message-id-dedupe","timestamp":"2026-04-18T02:15:37.407Z","cwd":` + jsonString(t, repoCWD) + `}`,
+		`{"type":"message_end","id":"u1","timestamp":"2026-04-18T02:15:39.000Z","message":{"role":"assistant","id":"m1","content":[{"type":"toolCall","name":"edit","arguments":{"file_path":"internal/intent/reader_pi.go"}}]}}`,
+		`{"type":"turn_end","id":"u2","timestamp":"2026-04-18T02:15:40.000Z","message":{"role":"assistant","id":"m1","content":[{"type":"toolCall","name":"edit","arguments":{"file_path":"internal/intent/reader_pi.go"}}]}}`,
+		`{"type":"message_end","id":"u3","timestamp":"2026-04-18T02:15:41.000Z","message":{"role":"assistant","id":"m2","content":[{"type":"text","text":"done"}]}}`,
+		`{"type":"turn_end","id":"u4","timestamp":"2026-04-18T02:15:42.000Z","message":{"role":"assistant","id":"m2","content":[{"type":"text","text":"done"}]}}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewPiReader()
+	sessions, err := r.Discover(context.Background(), DiscoverOpts{HomeDir: home, OriginCWD: repoCWD})
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(sessions))
+	}
+	if err := r.Load(context.Background(), sessions[0]); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	msgs := sessions[0].Messages
+	if len(msgs) != 2 {
+		t.Fatalf("got %d messages, want 2: %+v", len(msgs), msgs)
+	}
+	if len(msgs[0].FilePaths) != 1 || msgs[0].FilePaths[0] != "internal/intent/reader_pi.go" {
+		t.Errorf("first message paths = %v, want [internal/intent/reader_pi.go]", msgs[0].FilePaths)
+	}
+	if msgs[1].Role != RoleAssistant || msgs[1].Text != "done" {
+		t.Errorf("second message wrong: %+v", msgs[1])
+	}
+	if sessions[0].LastMsgKey != "u4" {
+		t.Errorf("LastMsgKey = %q, want u4", sessions[0].LastMsgKey)
+	}
+}
+
 func TestPiReader_DeduplicatesAgentEndMessages(t *testing.T) {
 	repoCWD := t.TempDir()
 	home := t.TempDir()

--- a/internal/intent/reader_pi_test.go
+++ b/internal/intent/reader_pi_test.go
@@ -87,6 +87,61 @@ func TestPiReader_DiscoverAndLoad(t *testing.T) {
 	}
 }
 
+func TestPiReader_LoadsPiEventStreamRecords(t *testing.T) {
+	repoCWD := t.TempDir()
+	home := t.TempDir()
+	dir := filepath.Join(home, ".pi", "agent", "sessions", "repo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "2026-04-18T02-15-37-407Z_session-events.jsonl")
+	lines := []string{
+		`{"type":"session","version":3,"id":"session-events","timestamp":"2026-04-18T02:15:37.407Z","cwd":` + jsonString(t, repoCWD) + `}`,
+		`{"type":"message_update","id":"u1","timestamp":"2026-04-18T02:15:38.000Z","message":{"role":"assistant","responseId":"r1"},"assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"partial"}}`,
+		`{"type":"message_end","id":"u2","timestamp":"2026-04-18T02:15:39.000Z","message":{"role":"user","content":"fix internal/pi.go"}}`,
+		`{"type":"turn_end","id":"u3","timestamp":"2026-04-18T02:15:40.000Z","message":{"role":"assistant","content":[{"type":"text","text":"updated it"},{"type":"toolCall","name":"edit","arguments":{"file_path":"internal/pi.go"}}]}}`,
+		`{"type":"agent_end","id":"u4","timestamp":"2026-04-18T02:15:41.000Z","messages":[{"role":"user","content":"also update docs/pi.md"},{"role":"assistant","content":[{"type":"text","text":"updated docs"}]}]}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewPiReader()
+	sessions, err := r.Discover(context.Background(), DiscoverOpts{HomeDir: home, OriginCWD: repoCWD})
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(sessions))
+	}
+	if err := r.Load(context.Background(), sessions[0]); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	msgs := sessions[0].Messages
+	if len(msgs) != 4 {
+		t.Fatalf("got %d messages, want 4: %+v", len(msgs), msgs)
+	}
+	if msgs[0].Role != RoleUser || !strings.Contains(msgs[0].Text, "internal/pi.go") {
+		t.Errorf("message_end user message wrong: %+v", msgs[0])
+	}
+	if msgs[1].Role != RoleAssistant || !strings.Contains(msgs[1].Text, "updated it") {
+		t.Errorf("turn_end assistant message wrong: %+v", msgs[1])
+	}
+	if len(msgs[1].FilePaths) != 1 || msgs[1].FilePaths[0] != "internal/pi.go" {
+		t.Errorf("turn_end tool paths = %v, want [internal/pi.go]", msgs[1].FilePaths)
+	}
+	if msgs[2].Role != RoleUser || !strings.Contains(msgs[2].Text, "docs/pi.md") {
+		t.Errorf("agent_end user message wrong: %+v", msgs[2])
+	}
+	if msgs[3].Role != RoleAssistant || !strings.Contains(msgs[3].Text, "updated docs") {
+		t.Errorf("agent_end assistant message wrong: %+v", msgs[3])
+	}
+	if sessions[0].LastMsgKey != "u4" {
+		t.Errorf("LastMsgKey = %q, want u4", sessions[0].LastMsgKey)
+	}
+}
+
 func readerByName(t *testing.T, readers []Reader, name string) Reader {
 	t.Helper()
 	for _, r := range readers {

--- a/internal/intent/reader_pi_test.go
+++ b/internal/intent/reader_pi_test.go
@@ -184,6 +184,52 @@ func TestPiReader_IgnoresStreamingMessageUpdates(t *testing.T) {
 	}
 }
 
+func TestPiReader_DeduplicatesCompletedEventsByResponseID(t *testing.T) {
+	repoCWD := t.TempDir()
+	home := t.TempDir()
+	dir := filepath.Join(home, ".pi", "agent", "sessions", "repo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "2026-04-18T02-15-37-407Z_session-completed-dedupe.jsonl")
+	lines := []string{
+		`{"type":"session","version":3,"id":"session-completed-dedupe","timestamp":"2026-04-18T02:15:37.407Z","cwd":` + jsonString(t, repoCWD) + `}`,
+		`{"type":"message_end","id":"u1","timestamp":"2026-04-18T02:15:39.000Z","message":{"role":"assistant","responseId":"r1","content":[{"type":"toolCall","name":"edit","arguments":{"file_path":"internal/intent/reader_pi.go"}}]}}`,
+		`{"type":"turn_end","id":"u2","timestamp":"2026-04-18T02:15:40.000Z","message":{"role":"assistant","responseId":"r1","content":[{"type":"toolCall","name":"edit","arguments":{"file_path":"internal/intent/reader_pi.go"}}]}}`,
+		`{"type":"message_end","id":"u3","timestamp":"2026-04-18T02:15:41.000Z","message":{"role":"assistant","responseId":"r2","content":[{"type":"text","text":"done"}]}}`,
+		`{"type":"turn_end","id":"u4","timestamp":"2026-04-18T02:15:42.000Z","message":{"role":"assistant","responseId":"r2","content":[{"type":"text","text":"done"}]}}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewPiReader()
+	sessions, err := r.Discover(context.Background(), DiscoverOpts{HomeDir: home, OriginCWD: repoCWD})
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(sessions))
+	}
+	if err := r.Load(context.Background(), sessions[0]); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	msgs := sessions[0].Messages
+	if len(msgs) != 2 {
+		t.Fatalf("got %d messages, want 2: %+v", len(msgs), msgs)
+	}
+	if len(msgs[0].FilePaths) != 1 || msgs[0].FilePaths[0] != "internal/intent/reader_pi.go" {
+		t.Errorf("first message paths = %v, want [internal/intent/reader_pi.go]", msgs[0].FilePaths)
+	}
+	if msgs[1].Role != RoleAssistant || msgs[1].Text != "done" {
+		t.Errorf("second message wrong: %+v", msgs[1])
+	}
+	if sessions[0].LastMsgKey != "u4" {
+		t.Errorf("LastMsgKey = %q, want u4", sessions[0].LastMsgKey)
+	}
+}
+
 func TestPiReader_DeduplicatesAgentEndMessages(t *testing.T) {
 	repoCWD := t.TempDir()
 	home := t.TempDir()

--- a/internal/intent/reader_pi_test.go
+++ b/internal/intent/reader_pi_test.go
@@ -1,0 +1,123 @@
+package intent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPiReader_DiscoverAndLoad(t *testing.T) {
+	repoCWD := t.TempDir()
+	home := writePiFixture(t, repoCWD)
+
+	r := readerByName(t, AllReaders(nil), "pi")
+	sessions, err := r.Discover(context.Background(), DiscoverOpts{
+		HomeDir:     home,
+		OriginCWD:   repoCWD,
+		WindowStart: time.Now().Add(-time.Hour),
+		WindowEnd:   time.Now().Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(sessions))
+	}
+	s := sessions[0]
+	if s.AgentName != "pi" {
+		t.Errorf("AgentName = %q, want pi", s.AgentName)
+	}
+	if s.SessionID != "session-1" {
+		t.Errorf("SessionID = %q, want session-1", s.SessionID)
+	}
+	if canonicalPath(s.CWD) != canonicalPath(repoCWD) {
+		t.Errorf("CWD = %q, want %q", s.CWD, repoCWD)
+	}
+
+	if err := r.Load(context.Background(), s); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(s.Messages) != 4 {
+		t.Fatalf("got %d messages, want 4: %+v", len(s.Messages), s.Messages)
+	}
+	if s.Messages[0].Role != RoleUser || !strings.Contains(s.Messages[0].Text, "foo helper") {
+		t.Errorf("first message wrong: %+v", s.Messages[0])
+	}
+	if s.Messages[1].Role != RoleAssistant || !strings.Contains(s.Messages[1].Text, "I'll edit") {
+		t.Errorf("second message wrong: %+v", s.Messages[1])
+	}
+	if strings.Contains(s.Messages[1].Text, "private chain of thought") {
+		t.Errorf("assistant thinking leaked into text: %q", s.Messages[1].Text)
+	}
+	foundToolPath := false
+	for _, p := range s.Messages[1].FilePaths {
+		if p == "internal/foo.go" {
+			foundToolPath = true
+		}
+	}
+	if !foundToolPath {
+		t.Errorf("expected tool-call path in assistant FilePaths, got %v", s.Messages[1].FilePaths)
+	}
+	if s.Messages[2].Role != RoleAssistant || s.Messages[2].Text != "" {
+		t.Errorf("third message should be a path-only assistant tool call, got %+v", s.Messages[2])
+	}
+	foundCamelPath := false
+	for _, p := range s.Messages[2].FilePaths {
+		if p == "internal/bar.go" {
+			foundCamelPath = true
+		}
+	}
+	if !foundCamelPath {
+		t.Errorf("expected camelCase filePath in path-only tool call, got %v", s.Messages[2].FilePaths)
+	}
+	foundCommandPath := false
+	for _, p := range s.Messages[3].FilePaths {
+		if p == "internal/baz.go" {
+			foundCommandPath = true
+		}
+	}
+	if !foundCommandPath {
+		t.Errorf("expected shell command path in path-only tool call, got %v", s.Messages[3].FilePaths)
+	}
+	if s.LastMsgKey != "m6" {
+		t.Errorf("LastMsgKey = %q, want m6", s.LastMsgKey)
+	}
+}
+
+func readerByName(t *testing.T, readers []Reader, name string) Reader {
+	t.Helper()
+	for _, r := range readers {
+		if r.Name() == name {
+			return r
+		}
+	}
+	t.Fatalf("reader %q not found", name)
+	return nil
+}
+
+func writePiFixture(t *testing.T, repoCWD string) string {
+	t.Helper()
+	home := t.TempDir()
+	dir := filepath.Join(home, ".pi", "agent", "sessions", "repo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "2026-04-18T02-15-37-407Z_session-1.jsonl")
+	lines := []string{
+		`{"type":"session","version":3,"id":"session-1","timestamp":"2026-04-18T02:15:37.407Z","cwd":` + jsonString(t, repoCWD) + `}`,
+		`{"type":"model_change","id":"meta-1","timestamp":"2026-04-18T02:15:37.500Z","modelId":"gpt-5.5"}`,
+		`{"type":"message","id":"m1","timestamp":"2026-04-18T02:15:38.000Z","message":{"role":"user","content":[{"type":"text","text":"please add a foo helper to internal/foo.go"}]}}`,
+		`{"type":"message","id":"m2","timestamp":"2026-04-18T02:15:39.000Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"private chain of thought"},{"type":"text","text":"I'll edit internal/foo.go"},{"type":"toolCall","name":"edit","arguments":{"file_path":"internal/foo.go"}}]}}`,
+		`{"type":"message","id":"m3","timestamp":"2026-04-18T02:15:40.000Z","message":{"role":"toolResult","toolName":"edit","content":[{"type":"text","text":"tool output should not become transcript text"}]}}`,
+		`{"type":"message","id":"m4","timestamp":"2026-04-18T02:15:41.000Z","message":{"role":"assistant","content":[{"type":"toolCall","name":"read","arguments":{"filePath":"internal/bar.go"}}]}}`,
+		`{"type":"message","id":"m5","timestamp":"2026-04-18T02:15:42.000Z","message":{"role":"assistant","content":[{"type":"toolCall","name":"bash","arguments":{"command":"gofmt -w internal/baz.go"}}]}}`,
+		`{"type":"message","id":"m6","timestamp":"2026-04-18T02:15:43.000Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"only thinking should be skipped"}]}}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}

--- a/internal/intent/reader_pi_test.go
+++ b/internal/intent/reader_pi_test.go
@@ -142,6 +142,48 @@ func TestPiReader_LoadsPiEventStreamRecords(t *testing.T) {
 	}
 }
 
+func TestPiReader_IgnoresStreamingMessageUpdates(t *testing.T) {
+	repoCWD := t.TempDir()
+	home := t.TempDir()
+	dir := filepath.Join(home, ".pi", "agent", "sessions", "repo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "2026-04-18T02-15-37-407Z_session-updates.jsonl")
+	lines := []string{
+		`{"type":"session","version":3,"id":"session-updates","timestamp":"2026-04-18T02:15:37.407Z","cwd":` + jsonString(t, repoCWD) + `}`,
+		`{"type":"message_update","id":"u1","timestamp":"2026-04-18T02:15:38.000Z","message":{"role":"assistant","content":[{"type":"text","text":"updated"}]}}`,
+		`{"type":"message_update","id":"u2","timestamp":"2026-04-18T02:15:39.000Z","message":{"role":"assistant","content":[{"type":"text","text":"updated internal"}]}}`,
+		`{"type":"turn_end","id":"u3","timestamp":"2026-04-18T02:15:40.000Z","message":{"role":"assistant","content":[{"type":"text","text":"updated internal/pi.go"}]}}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewPiReader()
+	sessions, err := r.Discover(context.Background(), DiscoverOpts{HomeDir: home, OriginCWD: repoCWD})
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(sessions))
+	}
+	if err := r.Load(context.Background(), sessions[0]); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	msgs := sessions[0].Messages
+	if len(msgs) != 1 {
+		t.Fatalf("got %d messages, want 1: %+v", len(msgs), msgs)
+	}
+	if msgs[0].Role != RoleAssistant || msgs[0].Text != "updated internal/pi.go" {
+		t.Errorf("message wrong: %+v", msgs[0])
+	}
+	if sessions[0].LastMsgKey != "u3" {
+		t.Errorf("LastMsgKey = %q, want u3", sessions[0].LastMsgKey)
+	}
+}
+
 func TestPiReader_DeduplicatesAgentEndMessages(t *testing.T) {
 	repoCWD := t.TempDir()
 	home := t.TempDir()

--- a/internal/intent/reader_pi_test.go
+++ b/internal/intent/reader_pi_test.go
@@ -142,6 +142,48 @@ func TestPiReader_LoadsPiEventStreamRecords(t *testing.T) {
 	}
 }
 
+func TestPiReader_DeduplicatesAgentEndMessages(t *testing.T) {
+	repoCWD := t.TempDir()
+	home := t.TempDir()
+	dir := filepath.Join(home, ".pi", "agent", "sessions", "repo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "2026-04-18T02-15-37-407Z_session-dedupe.jsonl")
+	lines := []string{
+		`{"type":"session","version":3,"id":"session-dedupe","timestamp":"2026-04-18T02:15:37.407Z","cwd":` + jsonString(t, repoCWD) + `}`,
+		`{"type":"message_end","id":"u1","timestamp":"2026-04-18T02:15:39.000Z","message":{"role":"user","content":"fix internal/pi.go"}}`,
+		`{"type":"turn_end","id":"u2","timestamp":"2026-04-18T02:15:40.000Z","message":{"role":"assistant","content":[{"type":"text","text":"updated it"}]}}`,
+		`{"type":"agent_end","id":"u3","timestamp":"2026-04-18T02:15:41.000Z","messages":[{"role":"user","content":"fix internal/pi.go"},{"role":"assistant","content":[{"type":"text","text":"updated it"}]}]}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewPiReader()
+	sessions, err := r.Discover(context.Background(), DiscoverOpts{HomeDir: home, OriginCWD: repoCWD})
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(sessions))
+	}
+	if err := r.Load(context.Background(), sessions[0]); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	msgs := sessions[0].Messages
+	if len(msgs) != 2 {
+		t.Fatalf("got %d messages, want 2: %+v", len(msgs), msgs)
+	}
+	if msgs[0].Role != RoleUser || msgs[0].Text != "fix internal/pi.go" {
+		t.Errorf("first message wrong: %+v", msgs[0])
+	}
+	if msgs[1].Role != RoleAssistant || msgs[1].Text != "updated it" {
+		t.Errorf("second message wrong: %+v", msgs[1])
+	}
+}
+
 func readerByName(t *testing.T, readers []Reader, name string) Reader {
 	t.Helper()
 	for _, r := range readers {

--- a/internal/intent/readers.go
+++ b/internal/intent/readers.go
@@ -9,6 +9,7 @@ func AllReaders(disabled map[string]bool) []Reader {
 		NewCodexReader(),
 		NewOpenCodeReader(),
 		NewRovoDevReader(),
+		NewPiReader(),
 	}
 	if len(disabled) == 0 {
 		return all

--- a/internal/intent/readers_test.go
+++ b/internal/intent/readers_test.go
@@ -4,15 +4,15 @@ import "testing"
 
 func TestAllReaders_NoDisabled(t *testing.T) {
 	got := AllReaders(nil)
-	if len(got) != 4 {
-		t.Errorf("expected 4 readers, got %d", len(got))
+	if len(got) != 5 {
+		t.Errorf("expected 5 readers, got %d", len(got))
 	}
 }
 
 func TestAllReaders_Disabled(t *testing.T) {
 	got := AllReaders(map[string]bool{"codex": true, "rovodev": true})
-	if len(got) != 2 {
-		t.Errorf("expected 2 readers, got %d", len(got))
+	if len(got) != 3 {
+		t.Errorf("expected 3 readers, got %d", len(got))
 	}
 	for _, r := range got {
 		if r.Name() == "codex" || r.Name() == "rovodev" {


### PR DESCRIPTION
## Intent

The developer wanted intent extraction to support transcripts produced by Pi coding agents, in addition to existing agent transcript readers. They expected the implementation to discover and parse Pi sessions from the real local Pi session directory, register Pi in the default reader list, and handle Pi JSONL content including session metadata, user/assistant messages, tool calls, and path hints while ignoring non-user-intent content like thinking and tool results. After implementation, they explicitly required validation against their actual ~/.pi/agent/sessions data rather than only synthetic tests.

## What Changed

- Added a Pi intent reader that discovers Pi session transcripts, parses supported JSONL message and event-stream records, and registers it with the default intent reader set.
- Handled Pi transcript edge cases including aggregate `agent_end` replay data, streaming updates, duplicate completed events, stable message IDs, larger transcript records, repeated live messages, tool calls, and path hints.
- Updated agent/config/pipeline documentation and added Pi-focused synthetic, end-to-end, and real local session tests for intent extraction.

## Risk Assessment

⚠️ Medium: The change is contained to adding a Pi intent transcript reader and related documentation, but it parses a new, variable JSONL format by default, so the main residual risk is transcript-shape coverage rather than core pipeline correctness.

## Testing

<code>Focused Pi reader and registration tests passed, a new end-to-end Pi intent extraction test passed, the opt-in real local Pi session check loaded 17 of 17 discovered sessions with extracted user/assistant messages, and the full `internal/intent` package test run passed.</code>

<details>
<summary>Evidence: Real local Pi session smoke test</summary>

```text
=== RUN TestPiReader_RealLocalSessions
reader_pi_real_test.go:38: loaded 17/17 real Pi sessions with 1987 extracted user/assistant messages
--- PASS: TestPiReader_RealLocalSessions (0.36s)
PASS
```
</details>
<details>
<summary>Evidence: End-to-end Pi extraction coverage</summary>

```text
`TestExtract_EndToEndWithPiFixture` exercises `Extract` with `AllReaders(nil)`, selects `AgentName=pi` and `SessionID=session-1`, sends Pi user text to the summarizer prompt, and asserts thinking/tool-result content does not leak into the summarization prompt.
```
</details>
- Outcome: ⚠️ 1 info across 1 run (3m22s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (7)</summary>

**Round 1** - found 1 error
- 🚨 `internal/intent/reader_pi.go:184` - The Pi reader only loads records whose top-level type is &#34;message&#34;, but the existing Pi integration documents and parses live Pi JSONL as &#34;message_update&#34;, &#34;message_end&#34;, &#34;turn_end&#34;, and &#34;agent_end&#34; events. If persisted Pi session files use that same event stream, Discover can find a session but Load will drop every user/assistant turn and the matcher will never select it. Extend parsing to handle the Pi event shapes already supported by internal/agent/pi.go, especially final message_end/turn_end messages and agent_end message arrays.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `internal/intent/reader_pi.go:190` - Pi event streams can contain both per-turn `message_end`/`turn_end` records and a final `agent_end.messages` array with the same assistant turns; this appends the aggregate messages after the already parsed per-turn records, so real transcripts like the existing Pi parser fixtures will duplicate turns in the intent packet and can skew or bloat the summary. Prefer one source for completed messages or dedupe by stable fields such as response id/content before appending `agent_end` messages.

**Round 3** (auto-fix) - found 1 warning
- ⚠️ `internal/intent/reader_pi.go:109` - Pi `agent_end` records can contain the full transcript on a single JSONL line, including tool results that this reader later ignores, but the scanner caps tokens at 16 MiB. Long real Pi sessions can therefore hit `bufio.Scanner: token too long`, causing `Load` to fail and the intent extractor to discard the whole session even if earlier per-turn records were usable. Raise the Pi reader limit to match the existing Pi stream parser or avoid failing the whole load on an oversized aggregate record.

**Round 4** (auto-fix) - found 1 warning
- ⚠️ `internal/intent/reader_pi.go:127` - The duplicate filter applies to every parsed Pi message using only role, text, and file paths, so two legitimate repeated turns in the same session, such as a user repeating the same confirmation or an assistant retrying the same file operation, are collapsed before matching and summarization. Limit deduplication to aggregate `agent_end` replay records or include a stable per-record identity so repeated live turns are preserved.

**Round 5** (auto-fix) - found 1 warning
- ⚠️ `internal/intent/reader_pi.go:206` - `message_update` is a streaming event, but the reader appends it as a completed transcript message whenever the event&#39;s `message` snapshot has parseable content. In Pi streams that also end with `message_end`, `turn_end`, or `agent_end`, this can leave partial assistant snapshots in the intent transcript because the aggregate dedupe only applies to `agent_end` and the partial text will not match the final message. Treat `message_update` as delta state to buffer, or ignore it when completed records are available.

**Round 6** (auto-fix) - found 1 warning
- ⚠️ `internal/intent/reader_pi.go:206` - Pi streams can emit both `message_end` and `turn_end` for the same assistant response, as shown by the existing Pi parser fixtures, but this reader appends both as separate completed transcript messages. That leaves duplicate assistant/tool-path turns before `agent_end` dedupe runs and can bloat or skew intent matching and summaries; dedupe these paired live events by stable identity such as `responseId`, or choose one completed event type as authoritative.

**Round 7** (auto-fix) - found 1 warning
- ⚠️ `internal/intent/reader_pi.go:263` - Completed-event deduplication only uses `responseId`, but the existing Pi stream parser treats either `responseId` or message-level `id` as the stable assistant identity. If Pi emits paired `message_end`/`turn_end` records with `message.id` instead of `responseId`, this reader will still append both turns and reintroduce duplicate assistant/tool-path messages in the intent transcript. Include `id` as a fallback identity when `responseId` is absent.

**Round 8** (auto-fix) - passed ✅

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

**Round 1** - found 1 info
- ℹ️ `internal/intent/reader_pi_real_test.go` - new test file written by agent: internal/intent/reader_pi_real_test.go
- `go test ./internal/intent -run 'TestPiReader|TestAllReaders' -count=1`
- `go test ./internal/intent -run 'TestPiReader|TestAllReaders|TestExtract_EndToEndWithPiFixture' -count=1`
- `NM_TEST_REAL_PI=1 go test ./internal/intent -run '^TestPiReader_RealLocalSessions$' -count=1 -v`
- `go test ./internal/intent -count=1`

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `docs/src/content/docs/reference/pipeline-steps.md:16` - The Intent step reference still says intent is inferred from Claude Code, Codex, OpenCode, or Rovo Dev transcripts only. This change registers a Pi transcript reader in the default reader list, so the per-step reference should include Pi as a supported transcript source.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
