### PR TITLE
fix(pipeline): ignore deleted files for intent matching

### DIFF
--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -139,13 +139,13 @@ Transient API and network failures are retried up to three times with exponentia
 ## Intent extraction
 
 When `intent.enabled` is true, no-mistakes reads recent local transcripts from Claude Code, Codex, OpenCode, Rovo Dev, and Pi during the `intent` pipeline step.
-It matches sessions against the changed files, summarizes the likely author intent with the configured pipeline agent, includes that summary as untrusted context in rebase fixes, review checks and fixes, test detection, evidence validation, and fixes, lint detection and fixes, documentation checks and fixes, CI auto-fixes, and PR prompts, and renders it in generated PR descriptions.
+It matches sessions against non-deleted changed files when present, falls back to all changed files for all-deletion diffs, summarizes the likely author intent with the configured pipeline agent, includes that summary as untrusted context in rebase fixes, review checks and fixes, test detection, evidence validation, and fixes, lint detection and fixes, documentation checks and fixes, CI auto-fixes, and PR prompts, and renders it in generated PR descriptions.
 
 Transcript readers collect user and assistant text messages but exclude tool call output.
 They read Claude Code transcripts from `~/.claude/projects`, Codex metadata from `~/.codex/state_*.sqlite` plus referenced rollout files, OpenCode messages from `$XDG_DATA_HOME/opencode/opencode.db` or `~/.local/share/opencode/opencode.db`, Rovo Dev sessions from `~/.rovodev/sessions`, and Pi transcripts from `~/.pi/agent/sessions`.
 Sessions are eligible when they come from the same working directory or an equivalent Git checkout with the same common Git directory or normalized remote URL.
 ACP transcripts are not currently read for intent extraction.
-When deterministic matching leaves multiple plausible sessions, no-mistakes may ask the configured pipeline agent to choose among them using the changed file paths and sanitized transcript packet files.
+When deterministic matching leaves multiple plausible sessions, no-mistakes may ask the configured pipeline agent to choose among them using the matching file paths and sanitized transcript packet files.
 The selected transcript text is then sent to the configured pipeline agent for summarization during the `intent` step, so intent extraction may incur additional agent or API invocations.
 Before disambiguation or summarization, no-mistakes excludes tool output, redacts likely secrets, strips common prompt-control markers, and clamps long transcripts while preserving the beginning and end.
 no-mistakes stores derived intent summaries and matching metadata in `~/.no-mistakes/state.sqlite`, including the source, session ID, and match score on each run plus cached summaries for matching transcript sessions.

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -226,7 +226,8 @@ When enabled, no-mistakes can read recent local agent transcripts, match the ses
 
 Valid `disabled_readers` values are `claude`, `codex`, `opencode`, `rovodev`, and `pi`.
 
-The match score is the share of changed files mentioned in a transcript session.
+The match score is the share of matching files mentioned in a transcript session; deleted files are ignored when the diff also contains non-deleted changes.
+All-deletion diffs still match against the deleted changed files.
 Mentioning extra files does not reduce the score.
 For multi-file diffs, no-mistakes still requires at least two overlapping files and an effective minimum score of `0.5`.
 Partial matches older than 24 hours are rejected unless their raw score is at least `0.8`.

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -18,7 +18,7 @@ This is best-effort context, and when available it is included in rebase fixes, 
 
 **Behavior:**
 - Runs only when `intent.enabled` is true
-- Matches local agent transcripts against the changed files, may use the configured pipeline agent to disambiguate plausible matches, and summarizes the likely author intent with that agent
+- Matches local agent transcripts against non-deleted changed files when present, falling back to all changed files for all-deletion diffs, may use the configured pipeline agent to disambiguate plausible matches, and summarizes the likely author intent with that agent
 - Stores the derived summary, source, session ID, and match score on the run
 - Logs accepted candidate diagnostics, including source, session, CWD, score, confidence, overlap, decision, and acceptance reason
 - Logs the matched source, score, and sanitized inferred intent when a transcript matches

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -24,7 +24,7 @@ This is best-effort context, and when available it is included in rebase fixes, 
 - Logs the matched source, score, and sanitized inferred intent when a transcript matches
 - Skips instead of failing when disabled, no matching transcript is found, the diff is empty, extraction errors, or persistence fails
 
-This step does not block the pipeline for missing transcripts, slow summarization, or other extraction failures, which are reported as skipped outcomes.
+This step does not block the pipeline for missing transcripts, summarization that exceeds the five-minute extraction cap, or other extraction failures, which are reported as skipped outcomes.
 It can fail the run only if cleanup fails after the disambiguation agent leaves worktree side effects.
 
 ## Rebase

--- a/internal/intent/intent.go
+++ b/internal/intent/intent.go
@@ -25,7 +25,7 @@ type ExtractParams struct {
 	// OriginCWD is the user's actual repo directory. The caller is responsible
 	// for passing the original working path, NOT the no-mistakes worktree.
 	OriginCWD string
-	// DiffFiles is the set of files changed between base and head, repo-relative.
+	// DiffFiles is the repo-relative file set used for matching and scoring.
 	DiffFiles []string
 	// BaseTime is the committer time of the base SHA.
 	BaseTime time.Time

--- a/internal/pipeline/steps/intent.go
+++ b/internal/pipeline/steps/intent.go
@@ -18,7 +18,7 @@ import (
 )
 
 // intentExtractTimeout caps total wall-clock time spent on intent extraction.
-const intentExtractTimeout = 90 * time.Second
+const intentExtractTimeout = 300 * time.Second
 
 // IntentStep is a best-effort pipeline step that infers the user's intent
 // from local agent transcripts and attaches it to the run so downstream
@@ -169,7 +169,7 @@ func defaultRunIntent(ctx context.Context, sctx *pipeline.StepContext) (*intent.
 	}
 
 	resolvedBaseSHA := resolveIntentBaseSHA(ctx, gitWorkDir, run.BaseSHA, repo.DefaultBranch)
-	diffFiles, err := git.DiffNameOnly(ctx, gitWorkDir, resolvedBaseSHA, run.HeadSHA)
+	diffFiles, err := diffFilesForIntentMatching(ctx, gitWorkDir, resolvedBaseSHA, run.HeadSHA)
 	if err != nil {
 		return nil, err
 	}
@@ -212,6 +212,33 @@ func defaultRunIntent(ctx context.Context, sctx *pipeline.StepContext) (*intent.
 			sctx.Log(fmt.Sprintf("intent "+format, args...))
 		},
 	})
+}
+
+func diffFilesForIntentMatching(ctx context.Context, dir, base, head string) ([]string, error) {
+	diffFiles, err := git.DiffNameOnly(ctx, dir, base, head)
+	if err != nil || len(diffFiles) == 0 {
+		return diffFiles, err
+	}
+
+	nonDeletedOut, err := git.Run(ctx, dir, "diff", "--name-only", "--diff-filter=d", base+".."+head)
+	if err != nil {
+		return nil, err
+	}
+	nonDeletedFiles := splitDiffNameOnly(nonDeletedOut)
+	if len(nonDeletedFiles) == 0 {
+		return diffFiles, nil
+	}
+	return nonDeletedFiles, nil
+}
+
+func splitDiffNameOnly(out string) []string {
+	var files []string
+	for _, line := range strings.Split(out, "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			files = append(files, trimmed)
+		}
+	}
+	return files
 }
 
 // resolveIntentBaseSHA returns a usable base SHA for diff'ing against head.

--- a/internal/pipeline/steps/intent_integration_test.go
+++ b/internal/pipeline/steps/intent_integration_test.go
@@ -253,6 +253,13 @@ func TestIntentStep_Integration_DeletedFilesDoNotDiluteIntentMatch(t *testing.T)
 	if got.Intent == nil {
 		t.Fatal("intent not attached")
 	}
+	if got.IntentSource == nil || *got.IntentSource != "claude" {
+		t.Fatalf("intent source = %v, want claude", got.IntentSource)
+	}
+	if got.IntentScore == nil || *got.IntentScore < 1 {
+		t.Fatalf("intent score = %v, want full active.go match", got.IntentScore)
+	}
+	t.Logf("deleted 40 files and changed active.go; attached intent from claude session with score %.2f: %s", *got.IntentScore, *got.Intent)
 }
 
 func TestIntentStep_Integration_ZeroBaseSHA_NewBranchPush(t *testing.T) {

--- a/internal/pipeline/steps/intent_integration_test.go
+++ b/internal/pipeline/steps/intent_integration_test.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -190,6 +191,67 @@ func TestIntentStep_Integration_NoTranscriptIsNoOp(t *testing.T) {
 	got, _ := sctx.DB.GetRun(sctx.Run.ID)
 	if got.Intent != nil {
 		t.Errorf("expected nil Intent, got %v", *got.Intent)
+	}
+}
+
+func TestIntentStep_Integration_DeletedFilesDoNotDiluteIntentMatch(t *testing.T) {
+	repoDir := t.TempDir()
+	gitCmd(t, repoDir, "init")
+	gitCmd(t, repoDir, "config", "user.email", "test@example.com")
+	gitCmd(t, repoDir, "config", "user.name", "Tester")
+	if err := os.WriteFile(filepath.Join(repoDir, "active.go"), []byte("package active\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 40; i++ {
+		name := filepath.Join(repoDir, fmt.Sprintf("obsolete_%02d.go", i))
+		if err := os.WriteFile(name, []byte("package obsolete\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	gitCmd(t, repoDir, "add", ".")
+	gitCmd(t, repoDir, "commit", "-m", "base")
+	base := gitCmd(t, repoDir, "rev-parse", "HEAD")
+
+	for i := 0; i < 40; i++ {
+		if err := os.Remove(filepath.Join(repoDir, fmt.Sprintf("obsolete_%02d.go", i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "active.go"), []byte("package active\nfunc Run() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, repoDir, "add", ".")
+	gitCmd(t, repoDir, "commit", "-m", "replace obsolete code")
+	head := gitCmd(t, repoDir, "rev-parse", "HEAD")
+
+	fakeHome := t.TempDir()
+	encoded := testClaudeProjectDirName(repoDir)
+	claudeDir := filepath.Join(fakeHome, ".claude", "projects", encoded)
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	transcript := `{"type":"user","cwd":` + testJSONString(t, repoDir) + `,"timestamp":"2026-04-18T02:15:37.407Z","uuid":"u1","sessionId":"s1","message":{"role":"user","content":"please add Run() to active.go"}}
+{"type":"assistant","cwd":` + testJSONString(t, repoDir) + `,"timestamp":"2026-04-18T02:15:38.000Z","uuid":"u2","sessionId":"s1","message":{"role":"assistant","content":[{"type":"tool_use","name":"Edit","input":{"file_path":` + testJSONString(t, filepath.Join(repoDir, "active.go")) + `}}]}}
+`
+	if err := os.WriteFile(filepath.Join(claudeDir, "session.jsonl"), []byte(transcript), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	withFakeHome(t, fakeHome)
+
+	cfg := &config.Config{Intent: config.Intent{Enabled: true, Threshold: 0.2, SlackDays: 3}}
+	sctx := newIntentIntegrationContext(t, repoDir, base, head, cfg)
+
+	outcome, err := (&IntentStep{}).Execute(sctx)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if outcome == nil || outcome.Skipped {
+		t.Fatalf("expected deleted files to be ignored for intent matching, got %+v", outcome)
+	}
+
+	got, _ := sctx.DB.GetRun(sctx.Run.ID)
+	if got.Intent == nil {
+		t.Fatal("intent not attached")
 	}
 }
 

--- a/internal/pipeline/steps/intent_test.go
+++ b/internal/pipeline/steps/intent_test.go
@@ -187,7 +187,7 @@ func TestIntentStep_ExtractErrorReturnsSkippedNotError(t *testing.T) {
 	}
 }
 
-func TestIntentStep_UsesNinetySecondExtractionTimeout(t *testing.T) {
+func TestIntentStep_UsesFiveMinuteExtractionTimeout(t *testing.T) {
 	sctx := newIntentStepContext(t)
 	var remaining time.Duration
 	var hasDeadline bool
@@ -207,8 +207,8 @@ func TestIntentStep_UsesNinetySecondExtractionTimeout(t *testing.T) {
 	if !hasDeadline {
 		t.Fatalf("intent extraction context had no deadline")
 	}
-	if remaining < 85*time.Second || remaining > 95*time.Second {
-		t.Fatalf("intent extraction timeout = %s, want about 90s", remaining)
+	if remaining < 295*time.Second || remaining > 305*time.Second {
+		t.Fatalf("intent extraction timeout = %s, want about 300s", remaining)
 	}
 }
 


### PR DESCRIPTION
## What Changed

- Updated the intent pipeline step to score transcripts against non-deleted changed files when available, preventing deleted paths from diluting intent matches while preserving all-deletion diffs as matchable input.
- Added regression coverage for mixed delete/modify diffs and the five-minute intent extraction timeout behavior.
- Documented the filtered intent matching file set and the five-minute best-effort extraction cap in the agent guide and pipeline/config references.

## Risk Assessment

⚠️ Medium: The deleted-file matching change is small, but the unrelated default-on timeout increase can materially delay pipelines when intent extraction is slow or stuck.

## Testing

After inspecting the target diff, I strengthened the deleted-file integration test to emit reviewer-visible DB evidence, then ran the evidence-producing test plus all intent step tests; the deleted-file scenario attached a Claude intent with score 1.00 despite 40 deleted files, and the five-minute timeout path also passed.

<details>
<summary>Evidence: Deleted-file intent evidence</summary>

```text
=== RUN TestIntentStep_Integration_DeletedFilesDoNotDiluteIntentMatch
2026/05/21 10:51:29 INFO intent: attached run_id=01KS5TKTQZA8AB8QFMGNG332MB agent=claude score=1
intent_integration_test.go:262: deleted 40 files and changed active.go; attached intent from claude session with score 1.00: user wanted to add Bar() to internal/foo.go
--- PASS: TestIntentStep_Integration_DeletedFilesDoNotDiluteIntentMatch
```
</details>
<details>
<summary>Evidence: Evidence-producing test assertion</summary>

Source: [Evidence-producing test assertion](https://github.com/kunchenguid/no-mistakes/blob/8b1be884f0c53a91fc2f1abdc451435509e43dd9/internal/pipeline/steps/intent_integration_test.go)

```text
The integration test now asserts the persisted intent source is `claude`, the score is a full active-file match, and logs the attached DB intent after constructing a repo that deletes 40 obsolete files while changing `active.go`.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/pipeline/steps/intent.go:21` - Intent extraction is best-effort and enabled by default, but this raises the worst-case stall from 90 seconds to 5 minutes before every downstream pipeline step can start if transcript discovery, summarization, or disambiguation hangs until context cancellation. Consider keeping the cap closer to the old budget or making the longer timeout explicitly configurable.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `git diff ea67db5411be0480d87767a0cd63399f5148158b..ec4adc229dcc8b19417310b496e798c8432cc4cf -- internal/pipeline/steps/intent.go internal/pipeline/steps/intent_test.go internal/pipeline/steps/intent_integration_test.go`
- `go test ./internal/pipeline/steps -run '^TestIntentStep_Integration_DeletedFilesDoNotDiluteIntentMatch$' -count=1 -v`
- `go test ./internal/pipeline/steps -run '^(TestIntentStep_Integration_DeletedFilesDoNotDiluteIntentMatch|TestIntentStep_UsesFiveMinuteExtractionTimeout|TestIntentStep_SlowExtractionPastOldTimeoutStillAttachesIntent)$' -count=1 -v`
- `go test ./internal/pipeline/steps -run '^TestIntent' -count=1`

</details>

<details>
<summary>🔧 **Document** - 3 issues found → auto-fixed (2)</summary>

**Round 1** - found 3 warnings
- ⚠️ `docs/src/content/docs/reference/global-config.md:229` - The intent scoring reference still says the match score is the share of changed files mentioned in a transcript. The code now filters deleted files out of intent matching when the diff contains any non-deleted files, so this should document that the denominator is the non-deleted changed-file set in mixed diffs, with all-deletion diffs still falling back to the full diff.
- ⚠️ `docs/src/content/docs/reference/pipeline-steps.md:21` - The Intent step behavior says transcripts are matched against the changed files. This is stale for mixed add/modify/delete diffs because deleted files are now ignored for intent matching to avoid diluting the score. Update the behavior description to describe matching against non-deleted changed files when present, with all-deletion diffs still treated as changed files.
- ⚠️ `docs/src/content/docs/guides/agents.md:142` - The agent guide says intent extraction matches sessions against the changed files and later says disambiguation uses the changed file paths. This guide should be updated to clarify that deleted paths are excluded from the matching/disambiguation file set when the diff also contains non-deleted files, matching the new pipeline behavior.

**Round 2** (auto-fix) - found 2 warnings
- ⚠️ `docs/src/content/docs/reference/pipeline-steps.md:29` - The implementation changed the intent extraction cap from 90 seconds to 300 seconds, but the Intent step reference still only says slow summarization is skipped without documenting that this best-effort step can now wait up to five minutes before timing out. Update the behavior description to include the five-minute cap so users understand the possible pipeline delay.
- ⚠️ `internal/intent/intent.go:28` - The ExtractParams.DiffFiles doc comment still defines the field as the complete set of files changed between base and head. The production caller now passes a filtered matching file set that excludes deleted files when non-deleted changes exist, so the comment should describe this as the repo-relative file set used for matching/scoring rather than always the full changed-file set.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
