### PR TITLE
fix(pipeline): preserve local test evidence in PR summaries

### DIFF
--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -69,8 +69,8 @@ Runs baseline tests and gathers evidence for the intended behavior.
 
 **Behavior:**
 - If `commands.test` is set in repo config: runs it first as a baseline via the platform shell (`sh -c` on POSIX, `cmd.exe /c` on Windows) and captures output. Non-zero exit produces `error` findings.
-- If `commands.test` is empty, or inferred user intent is available after the baseline command passes: the agent validates the change with evidence-oriented tests or manual checks, returning structured findings with severity, description, and `action` (`no-op`, `auto-fix`, `ask-user`).
-- The step records the exact tests and checks it exercised in a `tested` array, may include a short natural-language `testing_summary`, and includes an `artifacts` array for reviewer-visible evidence; `path` artifacts must already exist in the repository and be available from the pushed commit, `url` artifacts must be externally visible, and `content` artifacts should be short logs or command output shown directly in the PR.
+- If `commands.test` is empty, or inferred user intent is available after the baseline command passes: the agent validates the change with evidence-oriented tests or manual checks, returning structured findings with severity, description, and `action` (`no-op`, `auto-fix`, `ask-user`). For UI, HTML, CSS, browser, visual layout, or copy-placement changes, the agent attempts reviewer-visible visual evidence and explains in `testing_summary` when screenshots, images, videos, GIFs, or rendered HTML artifacts are not captured.
+- The step records the exact tests and checks it exercised in a `tested` array, may include a short natural-language `testing_summary`, and includes an `artifacts` array for reviewer-visible evidence; `path` artifacts may be repository-relative paths or absolute paths under the temporary `no-mistakes-evidence/<runID>` directory, `url` artifacts must be externally visible, and `content` artifacts should be short logs or command output shown directly in the PR.
 - Missing evidence for inferred user intent can be reported as a warning with `action: ask-user`.
 - If the agent creates new test files (detected via `git status --porcelain`), approval is required even if tests pass.
 
@@ -144,7 +144,7 @@ Creates or updates a pull request.
 - PR title: agent-generated with inferred user intent when available, in conventional commit format (`type(scope): description` or `type: description`); user-facing product impact should use `feat` or `fix` so release automation can pick it up; when a scope is used, it should be the primary affected real module/package from the changed paths and kept broad rather than file-level
 - PR body includes: a `## Intent` section from extracted user intent when available, an agent-authored `## What Changed`, and regenerated `## Risk Assessment`, `## Testing`, and `## Pipeline` sections from recorded step results and rounds
 - The regenerated `## Testing` section prefers the recorded `testing_summary` as prose, uses a compact recorded-check count when no summary is available, includes produced evidence artifacts from `path`, `url`, or `content` fields when available, and only adds an outcome with run count and total duration when it is failed or needed as a fallback
-- Evidence artifacts render compactly in PR bodies: `path` and `url` artifacts become `Evidence` links, `content` artifacts appear in collapsible details blocks, and GitHub PRs convert repository-relative paths to blob URLs
+- Evidence artifacts render compactly in PR bodies: repository-relative `path` artifacts and `url` artifacts become `Evidence` links, `content` artifacts appear in collapsible details blocks, GitHub PRs convert repository-relative paths to blob URLs, and local temporary evidence paths render as non-link local file references
 
 Stores the PR URL in the database and streams it to the TUI.
 

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -77,7 +77,7 @@ var testFindingsSchema = json.RawMessage(`{
 				"properties": {
 					"kind": {"type": "string", "description": "artifact type such as screenshot, gif, image, video, log, command-output, or other"},
 					"label": {"type": "string"},
-					"path": {"type": "string", "description": "repository-relative artifact path when available"},
+					"path": {"type": "string", "description": "artifact file path, including absolute paths for temporary local evidence files when available"},
 					"url": {"type": "string", "description": "artifact URL when available"},
 					"content": {"type": "string", "description": "short log, command output, or textual artifact content to show inline"}
 				},

--- a/internal/pipeline/steps/evidence.go
+++ b/internal/pipeline/steps/evidence.go
@@ -1,0 +1,14 @@
+package steps
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func testEvidenceRoot() string {
+	return filepath.Join(os.TempDir(), "no-mistakes-evidence")
+}
+
+func testEvidenceDir(runID string) string {
+	return filepath.Join(testEvidenceRoot(), runID)
+}

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -205,7 +205,7 @@ func (s *PRStep) buildPipelineSection(sctx *pipeline.StepContext) (string, strin
 	}
 
 	pipelineMD, riskLine := BuildPipelineSummary(steps, rounds)
-	testingMD := BuildTestingSummaryForPR(steps, rounds, sctx.Repo.UpstreamURL, sctx.Run.HeadSHA)
+	testingMD := BuildTestingSummaryForPR(steps, rounds, sctx.Repo.UpstreamURL, sctx.Run.HeadSHA, sctx.WorkDir)
 	return pipelineMD, riskLine, testingMD
 }
 

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -387,10 +387,10 @@ func renderCompactTestingArtifact(artifact types.TestArtifact, opts testingSumma
 	}
 
 	if artifact.Content == "" {
-		if localPath != "" {
-			return renderLocalArtifactLine(label, localPath)
+		if target != "" {
+			return fmt.Sprintf("- Evidence: [%s](%s)\n", html.EscapeString(label), target)
 		}
-		return fmt.Sprintf("- Evidence: [%s](%s)\n", html.EscapeString(label), target)
+		return renderLocalArtifactLine(label, localPath)
 	}
 
 	var b strings.Builder
@@ -502,6 +502,8 @@ func artifactPathRelativeToRoot(target, root string) (string, bool) {
 	}
 	rootAbs = filepath.Clean(rootAbs)
 	targetAbs = filepath.Clean(targetAbs)
+	rootAbs = resolveArtifactPathSymlinks(rootAbs)
+	targetAbs = resolveArtifactPathSymlinks(targetAbs)
 	if !sameVolume(rootAbs, targetAbs) {
 		return "", false
 	}
@@ -510,6 +512,26 @@ func artifactPathRelativeToRoot(target, root string) (string, bool) {
 		return "", false
 	}
 	return rel, true
+}
+
+func resolveArtifactPathSymlinks(target string) string {
+	if resolved, err := filepath.EvalSymlinks(target); err == nil {
+		return filepath.Clean(resolved)
+	}
+	for candidate := target; ; candidate = filepath.Dir(candidate) {
+		resolved, err := filepath.EvalSymlinks(candidate)
+		if err == nil {
+			rel, err := filepath.Rel(candidate, target)
+			if err != nil || rel == "." {
+				return filepath.Clean(resolved)
+			}
+			return filepath.Clean(filepath.Join(resolved, rel))
+		}
+		parent := filepath.Dir(candidate)
+		if parent == candidate {
+			return target
+		}
+	}
 }
 
 func sameVolume(a, b string) bool {

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -5,6 +5,7 @@ import (
 	"html"
 	"net/url"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -19,6 +20,7 @@ type testingSummaryOptions struct {
 	compactArtifacts     bool
 	summaryParagraph     bool
 	omitOutcome          bool
+	repoRoot             string
 }
 
 // BuildPipelineSummary produces a deterministic markdown section from step results and rounds.
@@ -62,11 +64,12 @@ func BuildTestingSummary(steps []*db.StepResult, rounds map[string][]*db.StepRou
 	return buildTestingSummary(steps, rounds, testingSummaryOptions{includeTestedDetails: true})
 }
 
-func BuildTestingSummaryForPR(steps []*db.StepResult, rounds map[string][]*db.StepRound, upstreamURL, ref string) string {
+func BuildTestingSummaryForPR(steps []*db.StepResult, rounds map[string][]*db.StepRound, upstreamURL, ref, repoRoot string) string {
 	opts := testingSummaryOptionsForGitHub(upstreamURL, ref)
 	opts.compactArtifacts = true
 	opts.summaryParagraph = true
 	opts.omitOutcome = true
+	opts.repoRoot = repoRoot
 	return buildTestingSummary(steps, rounds, opts)
 }
 
@@ -84,7 +87,7 @@ func buildTestingSummary(steps []*db.StepResult, rounds map[string][]*db.StepRou
 
 		testingSummary := collectTestingSummary(sr, stepRounds)
 		tested := collectTestingDetails(sr, stepRounds)
-		artifacts := collectTestingArtifacts(sr, stepRounds)
+		artifacts := collectTestingArtifacts(sr, stepRounds, opts)
 		if testingSummary == "" && len(tested) == 0 && len(artifacts) == 0 {
 			return "## Testing\n\n- " + line
 		}
@@ -233,11 +236,11 @@ func collectTestingDetails(sr *db.StepResult, rounds []*db.StepRound) []string {
 	return details
 }
 
-func collectTestingArtifacts(sr *db.StepResult, rounds []*db.StepRound) []types.TestArtifact {
+func collectTestingArtifacts(sr *db.StepResult, rounds []*db.StepRound, opts testingSummaryOptions) []types.TestArtifact {
 	seen := map[string]bool{}
 	var artifacts []types.TestArtifact
 	for _, raw := range testingEvidenceFindingsJSON(sr, rounds) {
-		artifacts = appendTestingArtifacts(artifacts, seen, raw)
+		artifacts = appendTestingArtifacts(artifacts, seen, raw, opts)
 	}
 	return artifacts
 }
@@ -265,7 +268,7 @@ func hasTestingEvidenceMetadata(raw *string) bool {
 	return strings.TrimSpace(findings.TestingSummary) != "" || len(findings.Tested) > 0 || len(findings.Artifacts) > 0
 }
 
-func appendTestingArtifacts(artifacts []types.TestArtifact, seen map[string]bool, raw *string) []types.TestArtifact {
+func appendTestingArtifacts(artifacts []types.TestArtifact, seen map[string]bool, raw *string, opts testingSummaryOptions) []types.TestArtifact {
 	if raw == nil || strings.TrimSpace(*raw) == "" {
 		return artifacts
 	}
@@ -276,7 +279,7 @@ func appendTestingArtifacts(artifacts []types.TestArtifact, seen map[string]bool
 	for _, artifact := range findings.Artifacts {
 		artifact.Label = sanitizePromptText(artifact.Label)
 		artifact.Kind = strings.ToLower(sanitizePromptText(artifact.Kind))
-		artifact.Path = sanitizeArtifactPath(artifact.Path)
+		artifact.Path = sanitizeArtifactPath(artifact.Path, opts)
 		artifact.URL = sanitizeArtifactURL(artifact.URL)
 		artifact.Content = sanitizePromptMultilineText(artifact.Content)
 		key := artifact.Kind + "\x00" + artifact.Label + "\x00" + artifact.Path + "\x00" + artifact.URL + "\x00" + artifact.Content
@@ -350,6 +353,7 @@ func renderTestingArtifact(artifact types.TestArtifact, opts testingSummaryOptio
 	if target == "" {
 		target = artifactTargetForPath(artifact, opts)
 	}
+	localPath := localArtifactPath(artifact.Path, opts)
 
 	var b strings.Builder
 	if target != "" {
@@ -360,6 +364,8 @@ func renderTestingArtifact(artifact types.TestArtifact, opts testingSummaryOptio
 		} else {
 			b.WriteString(fmt.Sprintf("- Evidence: [%s](%s)\n", html.EscapeString(label), target))
 		}
+	} else if localPath != "" {
+		b.WriteString(renderLocalArtifactLine(label, localPath))
 	}
 	if artifact.Content != "" {
 		if b.Len() > 0 && !strings.HasSuffix(b.String(), "\n\n") {
@@ -375,11 +381,15 @@ func renderCompactTestingArtifact(artifact types.TestArtifact, opts testingSumma
 	if target == "" {
 		target = artifactLinkTargetForPath(artifact, opts)
 	}
-	if target == "" && artifact.Content == "" {
+	localPath := localArtifactPath(artifact.Path, opts)
+	if target == "" && localPath == "" && artifact.Content == "" {
 		return ""
 	}
 
 	if artifact.Content == "" {
+		if localPath != "" {
+			return renderLocalArtifactLine(label, localPath)
+		}
 		return fmt.Sprintf("- Evidence: [%s](%s)\n", html.EscapeString(label), target)
 	}
 
@@ -388,6 +398,8 @@ func renderCompactTestingArtifact(artifact types.TestArtifact, opts testingSumma
 	b.WriteString(fmt.Sprintf("<summary>Evidence: %s</summary>\n\n", html.EscapeString(label)))
 	if target != "" {
 		b.WriteString(fmt.Sprintf("Source: [%s](%s)\n\n", html.EscapeString(label), target))
+	} else if localPath != "" {
+		b.WriteString(fmt.Sprintf("Source: local file <code>%s</code>\n\n", html.EscapeString(localPath)))
 	}
 	b.WriteString(fmt.Sprintf("```text\n%s\n```\n", escapeMarkdownFence(artifact.Content)))
 	b.WriteString("</details>\n")
@@ -395,34 +407,39 @@ func renderCompactTestingArtifact(artifact types.TestArtifact, opts testingSumma
 }
 
 func artifactTargetForPath(artifact types.TestArtifact, opts testingSummaryOptions) string {
-	if artifact.Path == "" {
+	repoPath := repoRelativeArtifactPath(artifact.Path, opts)
+	if repoPath == "" {
 		return ""
 	}
 	if opts.githubBlobBase == "" || opts.githubRawBase == "" {
-		return artifact.Path
+		return repoPath
 	}
-	if isImageArtifact(artifact.Kind, artifact.Path) || isVideoArtifact(artifact.Kind, artifact.Path) {
-		return opts.githubRawBase + artifact.Path
+	if isImageArtifact(artifact.Kind, repoPath) || isVideoArtifact(artifact.Kind, repoPath) {
+		return opts.githubRawBase + repoPath
 	}
-	return opts.githubBlobBase + artifact.Path
+	return opts.githubBlobBase + repoPath
 }
 
 func artifactLinkTargetForPath(artifact types.TestArtifact, opts testingSummaryOptions) string {
-	if artifact.Path == "" {
+	repoPath := repoRelativeArtifactPath(artifact.Path, opts)
+	if repoPath == "" {
 		return ""
 	}
 	if opts.githubBlobBase == "" {
-		return artifact.Path
+		return repoPath
 	}
-	return opts.githubBlobBase + artifact.Path
+	return opts.githubBlobBase + repoPath
 }
 
-func sanitizeArtifactPath(target string) string {
+func sanitizeArtifactPath(target string, opts testingSummaryOptions) string {
 	clean := strings.TrimSpace(target)
-	if clean == "" || clean != sanitizePromptText(target) || strings.ContainsAny(clean, "\n\r<>[]()\\") {
+	if clean == "" || clean != sanitizePromptText(target) || strings.ContainsAny(clean, "\n\r<>[]()`") {
 		return ""
 	}
-	if strings.HasPrefix(clean, "/") || strings.HasPrefix(clean, "~") || strings.Contains(clean, ":") {
+	if filepath.IsAbs(clean) {
+		return sanitizeAbsoluteArtifactPath(clean, opts)
+	}
+	if strings.HasPrefix(clean, "~") || strings.Contains(clean, ":") || strings.Contains(clean, "\\") {
 		return ""
 	}
 	cleanedPath := path.Clean(clean)
@@ -430,6 +447,77 @@ func sanitizeArtifactPath(target string) string {
 		return ""
 	}
 	return clean
+}
+
+func sanitizeAbsoluteArtifactPath(clean string, opts testingSummaryOptions) string {
+	cleanedPath := filepath.Clean(clean)
+	if cleanedPath != clean {
+		return ""
+	}
+	if _, ok := artifactPathRelativeToRoot(cleanedPath, opts.repoRoot); ok {
+		return cleanedPath
+	}
+	if _, ok := artifactPathRelativeToRoot(cleanedPath, testEvidenceRoot()); ok {
+		return cleanedPath
+	}
+	return ""
+}
+
+func repoRelativeArtifactPath(target string, opts testingSummaryOptions) string {
+	if target == "" {
+		return ""
+	}
+	if !filepath.IsAbs(target) {
+		return target
+	}
+	rel, ok := artifactPathRelativeToRoot(target, opts.repoRoot)
+	if !ok {
+		return ""
+	}
+	return filepath.ToSlash(rel)
+}
+
+func localArtifactPath(target string, opts testingSummaryOptions) string {
+	if target == "" || !filepath.IsAbs(target) {
+		return ""
+	}
+	if _, ok := artifactPathRelativeToRoot(target, opts.repoRoot); ok {
+		return ""
+	}
+	return target
+}
+
+func artifactPathRelativeToRoot(target, root string) (string, bool) {
+	root = strings.TrimSpace(root)
+	if target == "" || root == "" {
+		return "", false
+	}
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return "", false
+	}
+	targetAbs, err := filepath.Abs(target)
+	if err != nil {
+		return "", false
+	}
+	rootAbs = filepath.Clean(rootAbs)
+	targetAbs = filepath.Clean(targetAbs)
+	if !sameVolume(rootAbs, targetAbs) {
+		return "", false
+	}
+	rel, err := filepath.Rel(rootAbs, targetAbs)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return rel, true
+}
+
+func sameVolume(a, b string) bool {
+	return strings.EqualFold(filepath.VolumeName(a), filepath.VolumeName(b)) || filepath.VolumeName(a) == "" || filepath.VolumeName(b) == ""
+}
+
+func renderLocalArtifactLine(label, localPath string) string {
+	return fmt.Sprintf("- Evidence: %s (local file: <code>%s</code>)\n", html.EscapeString(label), html.EscapeString(localPath))
 }
 
 func sanitizeArtifactURL(target string) string {

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -439,7 +439,7 @@ func sanitizeArtifactPath(target string, opts testingSummaryOptions) string {
 	if filepath.IsAbs(clean) {
 		return sanitizeAbsoluteArtifactPath(clean, opts)
 	}
-	if strings.HasPrefix(clean, "~") || strings.Contains(clean, ":") || strings.Contains(clean, "\\") {
+	if strings.HasPrefix(clean, "/") || strings.HasPrefix(clean, "~") || strings.Contains(clean, ":") || strings.Contains(clean, "\\") {
 		return ""
 	}
 	cleanedPath := path.Clean(clean)

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -1,6 +1,10 @@
 package steps
 
 import (
+	"fmt"
+	"html"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -222,7 +226,7 @@ func TestBuildTestingSummaryForPR_OmitsRecordedTestDetails(t *testing.T) {
 		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 300}},
 	}
 
-	md := BuildTestingSummaryForPR(steps, rounds, "git@github.com:example/widgets.git", "abc123")
+	md := BuildTestingSummaryForPR(steps, rounds, "git@github.com:example/widgets.git", "abc123", t.TempDir())
 	t.Logf("rendered PR testing markdown:\n%s", md)
 
 	if !strings.Contains(md, "## Testing\n\nValidated the CLI doctor path and config loading; both passed.") {
@@ -251,7 +255,7 @@ func TestBuildTestingSummaryForPR_SummarizesBaselineOnlyTests(t *testing.T) {
 		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 300}},
 	}
 
-	md := BuildTestingSummaryForPR(steps, rounds, "git@github.com:example/widgets.git", "abc123")
+	md := BuildTestingSummaryForPR(steps, rounds, "git@github.com:example/widgets.git", "abc123", t.TempDir())
 	t.Logf("rendered PR testing markdown:\n%s", md)
 
 	if !strings.Contains(md, "## Testing\n\nCompleted 1 recorded test check.") {
@@ -278,7 +282,7 @@ func TestBuildTestingSummaryForPR_KeepsFailedOutcomeForCompactTestedSummary(t *t
 		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 300}},
 	}
 
-	md := BuildTestingSummaryForPR(steps, rounds, "git@github.com:example/widgets.git", "abc123")
+	md := BuildTestingSummaryForPR(steps, rounds, "git@github.com:example/widgets.git", "abc123", t.TempDir())
 	t.Logf("rendered PR testing markdown:\n%s", md)
 
 	if !strings.Contains(md, "Completed 1 recorded test check.") {
@@ -299,7 +303,7 @@ func TestBuildTestingSummaryForPR_KeepsOutcomeForArtifactOnlyEvidence(t *testing
 		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 300}},
 	}
 
-	md := BuildTestingSummaryForPR(steps, rounds, "git@github.com:example/widgets.git", "abc123")
+	md := BuildTestingSummaryForPR(steps, rounds, "git@github.com:example/widgets.git", "abc123", t.TempDir())
 	t.Logf("rendered PR testing markdown:\n%s", md)
 
 	if !strings.Contains(md, "Outcome:") {
@@ -409,7 +413,7 @@ func TestBuildTestingSummaryForPR_RendersEvidenceArtifactsCompactly(t *testing.T
 		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 300}},
 	}
 
-	md := BuildTestingSummaryForPR(steps, rounds, "git@github.com:example/widgets.git", "abc123")
+	md := BuildTestingSummaryForPR(steps, rounds, "git@github.com:example/widgets.git", "abc123", t.TempDir())
 	t.Logf("rendered PR testing markdown:\n%s", md)
 
 	if !strings.Contains(md, "- Evidence: [Checkout screenshot](https://github.com/example/widgets/blob/abc123/artifacts/checkout.png)") {
@@ -424,6 +428,32 @@ func TestBuildTestingSummaryForPR_RendersEvidenceArtifactsCompactly(t *testing.T
 	for _, broken := range []string{"![Checkout screenshot]", "raw.githubusercontent.com", "](artifacts/checkout.png)", "](artifacts/server.log)"} {
 		if strings.Contains(md, broken) {
 			t.Fatalf("did not expect broken or noisy artifact rendering %q, got:\n%s", broken, md)
+		}
+	}
+}
+
+func TestBuildTestingSummaryForPR_RendersLocalTempVisualArtifactPath(t *testing.T) {
+	t.Parallel()
+	repoRoot := t.TempDir()
+	localPath := filepath.Join(os.TempDir(), "no-mistakes-evidence", "run-123", "checkout.png")
+	findings := fmt.Sprintf(`{"findings":[],"summary":"","testing_summary":"Evidence was collected.","artifacts":[{"kind":"screenshot","label":"Checkout screenshot","path":%q}]}`, localPath)
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepTest, Status: types.StepStatusCompleted, FindingsJSON: &findings},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 300}},
+	}
+
+	md := BuildTestingSummaryForPR(steps, rounds, "git@github.com:example/widgets.git", "abc123", repoRoot)
+	t.Logf("rendered PR testing markdown:\n%s", md)
+
+	want := "- Evidence: Checkout screenshot (local file: <code>" + html.EscapeString(localPath) + "</code>)"
+	if !strings.Contains(md, want) {
+		t.Fatalf("expected local temp screenshot path to render as local evidence, got:\n%s", md)
+	}
+	for _, broken := range []string{"![Checkout screenshot]", "github.com/example/widgets/blob/abc123/"} {
+		if strings.Contains(md, broken) {
+			t.Fatalf("did not expect local temp artifact to be rendered as a visual or GitHub link %q, got:\n%s", broken, md)
 		}
 	}
 }

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -457,3 +457,54 @@ func TestBuildTestingSummaryForPR_RendersLocalTempVisualArtifactPath(t *testing.
 		}
 	}
 }
+
+func TestBuildTestingSummaryForPR_PrefersArtifactURLOverLocalPath(t *testing.T) {
+	t.Parallel()
+	repoRoot := t.TempDir()
+	localPath := filepath.Join(os.TempDir(), "no-mistakes-evidence", "run-123", "checkout.png")
+	findings := fmt.Sprintf(`{"findings":[],"summary":"","testing_summary":"Evidence was collected.","artifacts":[{"kind":"screenshot","label":"Checkout screenshot","url":"https://example.com/checkout.png","path":%q}]}`, localPath)
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepTest, Status: types.StepStatusCompleted, FindingsJSON: &findings},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 300}},
+	}
+
+	md := BuildTestingSummaryForPR(steps, rounds, "git@github.com:example/widgets.git", "abc123", repoRoot)
+
+	if !strings.Contains(md, "- Evidence: [Checkout screenshot](https://example.com/checkout.png)") {
+		t.Fatalf("expected artifact URL to take precedence, got:\n%s", md)
+	}
+	if strings.Contains(md, "local file:") || strings.Contains(md, localPath) {
+		t.Fatalf("did not expect local path to replace URL, got:\n%s", md)
+	}
+}
+
+func TestArtifactPathRelativeToRoot_AllowsSymlinkEquivalentPaths(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	root := filepath.Join(tempDir, "evidence")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkedRoot := filepath.Join(tempDir, "linked-evidence")
+	if err := os.Symlink(root, linkedRoot); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	target := filepath.Join(linkedRoot, "run-123", "checkout.png")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("png"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rel, ok := artifactPathRelativeToRoot(target, root)
+
+	if !ok {
+		t.Fatalf("expected symlink-equivalent target to be within root")
+	}
+	if rel != filepath.Join("run-123", "checkout.png") {
+		t.Fatalf("expected normalized relative path, got %q", rel)
+	}
+}

--- a/internal/pipeline/steps/test.go
+++ b/internal/pipeline/steps/test.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
@@ -101,6 +102,10 @@ Previous test findings to address:
 
 	useEvidenceAgent := testCmd == "" || cleanedUserIntent(sctx) != ""
 	if useEvidenceAgent {
+		evidenceDir := testEvidenceDir(sctx.Run.ID)
+		if err := os.MkdirAll(evidenceDir, 0o755); err != nil {
+			return nil, fmt.Errorf("create test evidence dir: %w", err)
+		}
 		if testCmd == "" {
 			sctx.Log("no test command configured, asking agent to run tests...")
 		} else {
@@ -126,6 +131,12 @@ Task:
 - Decide what evidence or artifacts would clearly demonstrate the user intent is satisfied. Unit tests passing is not sufficient evidence by itself.
 - Demonstrate the user intent working end-to-end in a way consistent with how an end user would actually experience it.
 - Prefer product-level artifacts: screenshots, GIFs, videos, rendered UI, CLI transcripts, API responses, persisted database state, generated PR markdown, logs, or other outputs that directly show the intended behavior working.
+- For UI, HTML, CSS, Electron renderer, browser, visual layout, or copy-placement changes, attempt to capture reviewer-visible visual evidence.
+- Prefer screenshots, images, videos, GIFs, or rendered HTML artifacts that show the actual end-user surface.
+- DOM snapshots, selector assertions, and text-only render summaries are not substitutes for visual evidence when a rendered surface is available.
+- If a UI-facing change has no screenshot, image, video, GIF, or rendered HTML artifact, state why in testing_summary.
+- Write new evidence files into this temporary evidence directory: %s
+- Do not move, commit, or modify source files only to make evidence linkable. Record local evidence file paths exactly where you created them.
 - Only use command output as an artifact when that output directly demonstrates the end-user experience or requested behavior. Generic pass/fail, coverage, or clean-worktree output is not sufficient evidence.
 - Look for existing tests that would generate sufficient evidence. If they exist, run the smallest relevant set.
 - If no existing test produces sufficient evidence, write or improve a test so that it does.
@@ -134,7 +145,7 @@ Task:
 - Include a concise "testing_summary" sentence describing what you exercised and the overall result.
 - The "testing_summary" must account for the complete test step: baseline commands that already ran, automated tests, manual or evidence-producing checks, artifacts gathered, and the overall result.
 - Record the exact tests, manual checks, and evidence-producing steps you ran in a "tested" array. Prefer concrete commands or test selectors wrapped in backticks.
-- Always include an "artifacts" array. Leave it empty when you produced no reviewer-visible evidence artifacts. Use artifact path only for files that already exist in the repository and will be available from the pushed commit, artifact url for externally visible artifacts, and artifact content for short logs or command output that should be shown directly in the PR.
+- Always include an "artifacts" array. Leave it empty when you produced no reviewer-visible evidence artifacts. Use artifact path for file artifacts, artifact url for externally visible artifacts, and artifact content for short logs or command output that should be shown directly in the PR.
 - If tests fail, determine whether the problem is a real product/code failure, a setup/environment problem you can fix, or a flaky/infrastructure issue.
 - If the issue is setup-related and fixable, fix it and retry the tests.
 
@@ -151,6 +162,7 @@ Rules:
 				baseSHA,
 				sctx.Run.HeadSHA,
 				configuredTestCommand,
+				evidenceDir,
 				reassessHistory,
 			),
 			CWD:        sctx.WorkDir,

--- a/internal/pipeline/steps/test_test.go
+++ b/internal/pipeline/steps/test_test.go
@@ -191,15 +191,26 @@ func TestTestStep_UserIntentRunsConfiguredCommandThenEvidenceAgent(t *testing.T)
 		testCmd,
 		"The \"testing_summary\" must account for the complete test step: baseline commands that already ran, automated tests, manual or evidence-producing checks, artifacts gathered, and the overall result",
 		"screenshots, GIFs, videos, rendered UI, CLI transcripts",
+		"For UI, HTML, CSS, Electron renderer, browser, visual layout, or copy-placement changes, attempt to capture reviewer-visible visual evidence",
+		"DOM snapshots, selector assertions, and text-only render summaries are not substitutes for visual evidence when a rendered surface is available",
+		"If a UI-facing change has no screenshot, image, video, GIF, or rendered HTML artifact, state why in testing_summary",
+		"Write new evidence files into this temporary evidence directory:",
+		filepath.Join(os.TempDir(), "no-mistakes-evidence", sctx.Run.ID),
+		"Do not move, commit, or modify source files only to make evidence linkable",
 		"If no existing test produces sufficient evidence, write or improve a test",
 		"If automated testing cannot produce the needed evidence, execute manual verification steps",
 		"Always include an \"artifacts\" array",
-		"Use artifact path only for files that already exist in the repository and will be available from the pushed commit",
 		"If sufficient evidence is not possible, report a warning finding",
 	} {
 		if !strings.Contains(prompt, want) {
 			t.Fatalf("expected prompt to contain %q, got:\n%s", want, prompt)
 		}
+	}
+	if strings.Contains(prompt, "will be available from the pushed commit") || strings.Contains(prompt, "files that already exist in the repository") {
+		t.Fatalf("expected prompt not to make the testing agent worry about committed evidence files, got:\n%s", prompt)
+	}
+	if _, err := os.Stat(filepath.Join(os.TempDir(), "no-mistakes-evidence", sctx.Run.ID)); err != nil {
+		t.Fatalf("expected temporary evidence directory to exist: %v", err)
 	}
 
 	var findings Findings


### PR DESCRIPTION
## Intent

The developer wanted to improve the pipeline testing step so UI-facing changes are more likely to produce reviewer-visible visual evidence. They asked to add stronger prompt requirements for screenshots or visual artifacts, treat DOM/text output as insufficient when visual evidence is feasible, and require an explanation when no visual artifact is captured. They also wanted evidence files written to a temporary directory rather than requiring the testing agent to worry about committing them or ensuring repo-relative paths. For PR descriptions, they wanted local temp evidence outside the repo to be detected and shown as local file paths rather than dropped or rendered as broken GitHub links.

## What Changed

- Directs test evidence artifacts to a temporary no-mistakes evidence directory and strengthens test-step guidance for reviewer-visible visual evidence when UI changes are involved.
- Updates PR summary rendering to preserve valid artifact URLs while showing accepted local evidence paths instead of dropping them or converting them into broken repository links.
- Documents the revised test evidence contract and distinguishes repo-relative PR links from temporary local file references.

## Risk Assessment

✅ Low: The change is limited to test-evidence prompting and PR summary rendering, and the follow-up commit addresses the previously identified URL-precedence and symlink-normalization risks.

## Testing

Inspected the evidence-related diff, ran targeted evidence tests that exercise the generated test-step evidence requirements and rendered PR markdown for repo, URL, and local temp artifacts, captured the rendered markdown output as reviewer-visible evidence, then ran the full affected package test suite; all exercised behavior passed.

<details>
<summary>Evidence: Targeted evidence behavior transcript</summary>

```text
Rendered PR markdown for temp local evidence:
## Testing

Evidence was collected.

- Evidence: Checkout screenshot (local file: <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/run-123/checkout.png</code>)

Rendered PR markdown for repo evidence:
## Testing

Evidence was collected.

- Evidence: [Checkout screenshot](https://github.com/example/widgets/blob/abc123/artifacts/checkout.png)
- Evidence: [Server log](https://github.com/example/widgets/blob/abc123/artifacts/server.log)
<details>
<summary>Evidence: Placement rectangle evidence</summary>

`` `text
{"button":{"top":169,"left":248,"right":272,"bottom":193}}
`` `
</details>

Evidence findings JSON from test step:
{"findings":[],"summary":"evidence demonstrates intent","tested":["go env GOOS \u003e baseline.log","manual screenshot review"],"testing_summary":"captured screenshot evidence","risk_level":"","risk_rationale":""}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed</summary>

**Round 1** - found 2 warnings
- ⚠️ `internal/pipeline/steps/prsummary.go:503` - Absolute evidence paths are compared with `filepath.Clean`/`filepath.Rel` only, so symlink-equivalent temp paths such as `/var/...` versus `/private/var/...` on macOS are treated as outside `testEvidenceRoot()` and get dropped from PR testing evidence even when they point at the prompted evidence directory. Resolve root and target symlinks before the containment check, or otherwise normalize this known temp-dir alias.
- ⚠️ `internal/pipeline/steps/prsummary.go:389` - Compact PR artifact rendering now prefers any local absolute path over a valid `artifact.URL` when `content` is empty. If an agent returns both an externally viewable URL and the local file it came from, the PR loses the clickable URL and shows a machine-local path instead. Keep URL precedence and only fall back to `localPath` when no URL/link target exists.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `git diff --stat bf0e88697c2c0072e92584949a73540e8d4946e3...5abe147482f6f8d81d14aea68033733fca2eb43e`
- `git diff bf0e88697c2c0072e92584949a73540e8d4946e3...5abe147482f6f8d81d14aea68033733fca2eb43e -- internal/pipeline/steps/test.go internal/pipeline/steps/evidence.go internal/pipeline/steps/common.go`
- `git diff bf0e88697c2c0072e92584949a73540e8d4946e3...5abe147482f6f8d81d14aea68033733fca2eb43e -- internal/pipeline/steps/prsummary.go internal/pipeline/steps/prsummary_test.go internal/pipeline/steps/test_test.go`
- `go test ./internal/pipeline/steps -run 'TestTestStep_UserIntentRunsConfiguredCommandThenEvidenceAgent|TestBuildTestingSummaryForPR_RendersLocalTempVisualArtifactPath|TestBuildTestingSummaryForPR_PrefersArtifactURLOverLocalPath|TestBuildTestingSummaryForPR_RendersEvidenceArtifactsCompactly' -v -count=1`
- `go test ./internal/pipeline/steps -count=1`

</details>

<details>
<summary>🔧 **Document** - 3 issues found → auto-fixed</summary>

**Round 1** - found 3 warnings
- ⚠️ `docs/src/content/docs/reference/pipeline-steps.md:73` - The Test step reference still says `path` artifacts must already exist in the repository and be available from the pushed commit, but the change now instructs agents to write evidence files into a temporary `no-mistakes-evidence/&lt;runID&gt;` directory and accepts absolute temp artifact paths. Update this artifact contract so it no longer tells users/agents that file evidence must be repo-relative or committed.
- ⚠️ `docs/src/content/docs/reference/pipeline-steps.md:147` - The PR step reference says `path` artifacts become Evidence links and GitHub PRs convert repository-relative paths to blob URLs, but local temporary evidence paths now render as non-link local file references while repo-relative paths still become blob links. Update the PR evidence rendering docs to distinguish repo-relative artifact links from temporary local file paths.
- ⚠️ `docs/src/content/docs/reference/pipeline-steps.md:72` - The Test step behavior now has stronger UI-facing evidence requirements: for UI/HTML/CSS/browser/visual layout/copy-placement changes it attempts reviewer-visible visual evidence, treats DOM snapshots and text-only summaries as insufficient when rendered evidence is feasible, and requires `testing_summary` to explain missing visual artifacts. The reference only says evidence-oriented tests or manual checks, so it should document these visual-evidence expectations.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
