### PR TITLE
fix(agent): extend managed server health timeout

### DIFF
--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -40,13 +40,20 @@ func currentManagedServerOutput() io.Writer {
 	return managedServerOutput
 }
 
+// defaultHealthTimeout bounds how long startServerWithPort waits for a freshly
+// spawned server to answer its health endpoint before giving up. It is generous
+// enough to absorb cold starts under host load: opencode has been observed
+// taking 15s+ just to emit its first log line when the machine is busy.
+const defaultHealthTimeout = 60 * time.Second
+
 // managedServer manages a persistent HTTP server process (used by rovodev and opencode agents).
 type managedServer struct {
-	cmd     *exec.Cmd
-	port    int
-	pidFile string        // path to the on-disk PID record; empty if tracking disabled
-	exited  chan struct{} // closed exactly once when cmd.Wait returns
-	waitErr error         // result of cmd.Wait; only read after exited is closed
+	cmd           *exec.Cmd
+	port          int
+	pidFile       string        // path to the on-disk PID record; empty if tracking disabled
+	exited        chan struct{} // closed exactly once when cmd.Wait returns
+	waitErr       error         // result of cmd.Wait; only read after exited is closed
+	healthTimeout time.Duration // health-check deadline; defaults to defaultHealthTimeout when zero
 }
 
 // getAvailablePort finds an ephemeral port by binding to :0 and releasing.
@@ -88,7 +95,7 @@ func startServerWithPort(ctx context.Context, agentName, bin string, args []stri
 		StartedAt:      time.Now().UTC(),
 	})
 
-	srv := &managedServer{cmd: cmd, port: port, pidFile: pidFile, exited: make(chan struct{})}
+	srv := &managedServer{cmd: cmd, port: port, pidFile: pidFile, exited: make(chan struct{}), healthTimeout: defaultHealthTimeout}
 	go func() {
 		srv.waitErr = cmd.Wait()
 		close(srv.exited)
@@ -108,13 +115,26 @@ func (s *managedServer) baseURL() string {
 	return fmt.Sprintf("http://127.0.0.1:%d", s.port)
 }
 
+// formatHealthTimeout renders a health-check deadline for error messages,
+// preferring a plain seconds form (e.g. "60s") over Duration's "1m0s".
+func formatHealthTimeout(d time.Duration) string {
+	if d%time.Second == 0 {
+		return fmt.Sprintf("%ds", int(d/time.Second))
+	}
+	return d.String()
+}
+
 // waitForHealth polls the health endpoint until it returns 200 or timeout.
 // If the server process exits before becoming healthy, it returns immediately
 // with an exit error instead of waiting out the 30s deadline.
 func (s *managedServer) waitForHealth(ctx context.Context, path string) error {
 	url := s.baseURL() + path
 	client := &http.Client{Timeout: 2 * time.Second}
-	deadline := time.After(30 * time.Second)
+	timeout := s.healthTimeout
+	if timeout <= 0 {
+		timeout = defaultHealthTimeout
+	}
+	deadline := time.After(timeout)
 
 	for {
 		select {
@@ -123,7 +143,7 @@ func (s *managedServer) waitForHealth(ctx context.Context, path string) error {
 		case <-s.exited:
 			return fmt.Errorf("server exited before becoming healthy: %w", s.waitErr)
 		case <-deadline:
-			return fmt.Errorf("server health check timed out after 30s")
+			return fmt.Errorf("server health check timed out after %s", formatHealthTimeout(timeout))
 		default:
 		}
 

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -126,7 +126,7 @@ func formatHealthTimeout(d time.Duration) string {
 
 // waitForHealth polls the health endpoint until it returns 200 or timeout.
 // If the server process exits before becoming healthy, it returns immediately
-// with an exit error instead of waiting out the 30s deadline.
+// with an exit error instead of waiting out the health-check deadline.
 func (s *managedServer) waitForHealth(ctx context.Context, path string) error {
 	url := s.baseURL() + path
 	client := &http.Client{Timeout: 2 * time.Second}

--- a/internal/agent/server_test.go
+++ b/internal/agent/server_test.go
@@ -13,7 +13,7 @@ import (
 // TestStartServerWithPort_DetectsEarlyExit verifies that when the spawned
 // server exits before becoming healthy (e.g. `acli` not installed, bad
 // flags, or port bind failure), startup fails fast instead of waiting the
-// full 30s health-check deadline.
+// full health-check deadline.
 func TestStartServerWithPort_DetectsEarlyExit(t *testing.T) {
 	bin, err := exec.LookPath("true")
 	if err != nil {
@@ -33,6 +33,56 @@ func TestStartServerWithPort_DetectsEarlyExit(t *testing.T) {
 	}
 	if elapsed > 5*time.Second {
 		t.Errorf("should fail fast on early exit, waited %v", elapsed)
+	}
+}
+
+// TestDefaultHealthTimeout pins the cold-start budget for a freshly spawned
+// managed server. Bumped to 60s to absorb opencode boots of 15s+ when the
+// host is under load.
+func TestDefaultHealthTimeout(t *testing.T) {
+	if defaultHealthTimeout != 60*time.Second {
+		t.Errorf("defaultHealthTimeout = %v, want 60s", defaultHealthTimeout)
+	}
+}
+
+// TestWaitForHealth_TimesOut verifies that when the process stays alive but
+// never answers its health endpoint, waitForHealth gives up after the
+// configured healthTimeout and reports the duration it waited.
+func TestWaitForHealth_TimesOut(t *testing.T) {
+	bin, err := exec.LookPath("sleep")
+	if err != nil {
+		t.Skip("sleep binary not available")
+	}
+
+	cmd := exec.Command(bin, "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	defer func() { _ = cmd.Process.Kill() }()
+
+	// Port 1 has nothing listening, so health probes fail with connection
+	// refused but the process never exits — exercising the deadline path.
+	srv := &managedServer{cmd: cmd, port: 1, exited: make(chan struct{}), healthTimeout: 100 * time.Millisecond}
+	go func() {
+		srv.waitErr = cmd.Wait()
+		close(srv.exited)
+	}()
+
+	start := time.Now()
+	err = srv.waitForHealth(context.Background(), "/healthcheck")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "health check timed out") {
+		t.Errorf("error should mention health-check timeout, got: %v", err)
+	}
+	if elapsed < 100*time.Millisecond {
+		t.Errorf("returned before deadline, waited only %v", elapsed)
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("waited far past short deadline: %v", elapsed)
 	}
 }
 


### PR DESCRIPTION
## Intent

The developer wanted to understand why intent disambiguation was failing due to an opencode server health check and asked for an investigation into the actual cause. After learning that all agent-backed steps use the configured opencode agent and that host resource contention likely made opencode startup exceed the 30-second health deadline, they requested a concrete fix: make the default timeout 60 seconds. They expected the change to be implemented with test-driven development, consistent with the repository's workflow. The requirement was specifically to change the default managed-server health-check timeout from 30 seconds to 60 seconds, affecting the shared server path used by opencode and rovodev.

## What Changed

- Increased the default managed-server health-check timeout from 30s to 60s for agent server startup.
- Made the health timeout configurable on `managedServer` and updated timeout errors/comments to report the configured deadline.
- Added agent server tests covering the 60s default and the configured timeout path.

## Risk Assessment

✅ Low: The change is narrowly scoped to increasing the managed-server health-check timeout and adding focused coverage, with no material regressions identified in the changed code.

## Testing

I inspected the shared managed-server change, ran the targeted automated tests for the default timeout, timeout error path, and early-exit behavior, then captured a product-level managed-server startup transcript showing a fake opencode server becoming healthy after 31 seconds under the 60-second default; all exercised checks passed.

<details>
<summary>Evidence: Managed server 31-second cold-start evidence</summary>

Source: local file <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSNB3WKXWTYEPM27K374W2WN/managed-server-31s-cold-start.txt</code>

```text
=== RUN TestEvidenceStartServerWithPort_DefaultTimeoutAllowsThirtyOneSecondColdStart
server_timeout_evidence_test.go:35: managed server became healthy after 31s using default health timeout 60s
--- PASS: TestEvidenceStartServerWithPort_DefaultTimeoutAllowsThirtyOneSecondColdStart (31.13s)
PASS
ok github.com/kunchenguid/no-mistakes/internal/agent 31.531s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test -v ./internal/agent -run 'TestDefaultHealthTimeout|TestWaitForHealth_TimesOut|TestStartServerWithPort_DetectsEarlyExit'`
- `go test ./internal/agent -run 'TestDefaultHealthTimeout|TestWaitForHealth_TimesOut|TestStartServerWithPort_DetectsEarlyExit' -count=1`
- <code>Temporary evidence-only check: `go test -v ./internal/agent -run &#39;^TestEvidenceStartServerWithPort_DefaultTimeoutAllowsThirtyOneSecondColdStart$&#39; -count=1 &gt; /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSNB3WKXWTYEPM27K374W2WN/managed-server-31s-cold-start.txt 2&gt;&amp;1`</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `internal/agent/server.go:129` - The waitForHealth doc comment still says early process exits return without waiting out the 30s deadline, but this change raises the default managed-server health-check deadline to 60s. Update the comment to reference the configured health-check deadline or the new 60s default so the inline documentation matches the implementation.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
