### PR TITLE
fix(pipeline): preserve inline code in PR summaries

### DIFF
--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -335,7 +335,9 @@ func renderTestingSummary(summary string) string {
 	if clean == "" {
 		return ""
 	}
-	if strings.ContainsAny(clean, "`\n<>") {
+	// Inline backtick code spans are valid markdown prose and render fine on
+	// their own; only newlines or angle brackets need the escaped <code> wrapper.
+	if strings.ContainsAny(clean, "\n<>") {
 		return renderTestedDetail(clean)
 	}
 	return clean

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -331,6 +331,27 @@ func TestBuildTestingSummary_EscapesMarkdownInTestingSummary(t *testing.T) {
 	}
 }
 
+func TestBuildTestingSummaryForPR_KeepsInlineCodeProseAsPlainText(t *testing.T) {
+	t.Parallel()
+	summary := "The shutdown-focused tests passed, including explicit `/shutdown`, idle timeout, and `stop` command logic."
+	findings := fmt.Sprintf("{\"findings\":[],\"summary\":\"\",\"testing_summary\":%q,\"tested\":[]}", summary)
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepTest, Status: types.StepStatusCompleted, FindingsJSON: &findings},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 300}},
+	}
+
+	md := BuildTestingSummaryForPR(steps, rounds, "git@github.com:example/widgets.git", "abc123", t.TempDir())
+
+	if strings.Contains(md, "<code>") {
+		t.Fatalf("prose summary with inline code spans should not be wrapped in <code>, got:\n%s", md)
+	}
+	if !strings.Contains(md, summary) {
+		t.Fatalf("expected prose summary rendered verbatim, got:\n%s", md)
+	}
+}
+
 func TestBuildTestingSummary_RendersEvidenceArtifacts(t *testing.T) {
 	t.Parallel()
 	findings := `{"findings":[],"summary":"","testing_summary":"Checkout success was verified visually.","tested":["manual checkout flow"],"artifacts":[{"kind":"screenshot","label":"Checkout success screenshot","path":"artifacts/checkout-success.png"},{"kind":"log","label":"Checkout server log","content":"POST /checkout 200\nreceipt=ok"}]}`


### PR DESCRIPTION
## Intent

The developer wanted to find why generated PR descriptions rendered the Testing section prose with a light gray code-style background on GitHub. They identified that the PR summary generator was wrapping an entire testing paragraph in an HTML code tag whenever the text contained inline backticks, even though inline code spans should remain normal Markdown prose. They asked the agent to track down and fix the PR-description pipeline so future PR bodies keep testing prose as plain text while still safely escaping cases that genuinely need protection, such as newlines or literal angle brackets. They expected the change to be test-driven, with a regression test reproducing the inline-code prose case and standard Go verification run afterward.

## What Changed

- Updated PR summary formatting so prose containing inline Markdown code spans stays as normal Markdown instead of being wrapped in an HTML code block.
- Kept escaping behavior for summary text that still needs protection, such as literal angle brackets or multiline content.
- Added a regression test covering inline-code prose in generated PR testing summaries.

## Risk Assessment

✅ Low: The change is narrowly scoped to PR testing-summary rendering and adds a targeted regression test, with no material risks identified in the changed code.

## Testing

<code>No prior baseline commands were provided; I ran focused PR-summary regression tests, generated a reviewer-visible PR Testing markdown transcript, removed the temporary evidence test, and completed `go test -race ./...` successfully.</code>

<details>
<summary>Evidence: Rendered PR Testing markdown evidence</summary>

Source: local file <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSNGYVQBDKJ5QN80F4BZWR09/pr-testing-markdown-inline-code.txt</code>

```text
## Testing

The shutdown-focused tests passed, including explicit `/shutdown`, idle timeout, and `stop` command logic.

## Testing

`Verified that literal <angle> text is escaped for GitHub safety.`
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Review** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `go test ./internal/pipeline/steps -run 'TestBuildTestingSummary.*InlineCode|TestBuildTestingSummary_EscapesMarkdownInTestingSummary|TestBuildTestingSummaryForPR_OmitsRecordedTestDetails' -count=1 -v`
- <code>Temporary in-package evidence check: `go test ./internal/pipeline/steps -run &#39;^TestEvidence_PRTestingMarkdownInlineCode$&#39; -count=1 -v &gt; /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSNGYVQBDKJ5QN80F4BZWR09/pr-testing-markdown-inline-code.txt`</code>
- `go test -race ./...`

</details>

<details>
<summary>✅ **Document** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
