### PR TITLE
fix(tui): keep fix review row within width

### DIFF
--- a/internal/tui/pipeline.go
+++ b/internal/tui/pipeline.go
@@ -162,8 +162,6 @@ func renderPipelineView(run *ipc.RunInfo, steps []ipc.StepResultInfo, width int,
 		switch step.Status {
 		case types.StepStatusAwaitingApproval:
 			line += " " + dimStyle.Render("- awaiting approval")
-		case types.StepStatusFixReview:
-			line += " " + dimStyle.Render("- review fix")
 		case types.StepStatusFailed:
 			if step.Error != nil {
 				errText := "- " + *step.Error

--- a/internal/tui/pipeline_test.go
+++ b/internal/tui/pipeline_test.go
@@ -236,6 +236,32 @@ func TestRenderPipelineView_ShowsZeroFixedFindingsWhileFixing(t *testing.T) {
 	}
 }
 
+func TestRenderPipelineView_FixReviewRowFitsWithFixedCount(t *testing.T) {
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusFixReview
+	run.Steps[0].DurationMS = ptr(int64(6604700))
+	run.Steps[0].FixedFindings = 65
+	run.Steps[0].ReportedFindings = 66
+
+	boxWidth := 40
+	out := stripANSI(renderPipelineView(run, run.Steps, boxWidth, 0, 40))
+	var reviewLine string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "Review") {
+			reviewLine = line
+		}
+	}
+	if !strings.Contains(reviewLine, "65/66 fixed") {
+		t.Fatalf("expected fixed count on FixReview row, got %q", reviewLine)
+	}
+	if strings.Contains(reviewLine, "review fix") {
+		t.Fatalf("expected no 'review fix' suffix on FixReview row so it fits, got %q", reviewLine)
+	}
+	if w := lipgloss.Width(reviewLine); w > boxWidth {
+		t.Fatalf("expected FixReview row to fit within box width %d, got %d: %q", boxWidth, w, reviewLine)
+	}
+}
+
 func TestRenderPipelineView_FixingStatusOmitsAgentFixingLabel(t *testing.T) {
 	run := testRun()
 	run.Steps[1].Status = types.StepStatusFixing


### PR DESCRIPTION
## Intent

The developer wanted to fix a TUI line-wrapping overflow where a pipeline row containing the "review fix" label exceeded the left pipeline box width. They specifically asked to remove the "review fix" label so the line would not overflow, while preserving the relevant progress/status information elsewhere.

## What Changed

- Removed the extra `review fix` suffix from TUI pipeline rows in the fix review state so the row no longer overflows narrow pipeline boxes.
- Kept the fixed findings progress label visible on fix review rows and aligned within the row width.
- Added coverage for fix review row rendering with fixed counts in constrained widths.

## Risk Assessment

✅ Low: The branch only removes a TUI row suffix and adds a targeted regression test, with the fix-review status still surfaced in the action bar and no material risks found.

## Testing

Inspected the TUI diff, ran targeted pipeline-row tests, generated a terminal rendering artifact showing the 40-column FixReview row fits without the `review fix` suffix while fixed-progress and action-bar context remain visible, then ran the full TUI package and full Go test suite successfully.

<details>
<summary>Evidence: FixReview row terminal rendering</summary>

<code>Pipeline width: 40 columns&#10;Review row width: 40 columns&#10;&#10;╭─ Pipeline ───────────────────────────╮&#10;│ feature/foo running │&#10;│ │&#10;│ ⏸ Review 6604.7s 65/66 fixed │&#10;│ │ │&#10;│ ○ Test │&#10;│ │ │&#10;│ ○ Lint │&#10;│ │ │&#10;│ ○ Push │&#10;│ │ │&#10;│ ○ PR │&#10;╰──────────────────────────────────────╯&#10;Review - review fix:&#10;a approve f fix (65/66) s skip x abort d diff │ ␣ toggle e edit + add A all N none</code>

```text
Pipeline width: 40 columns
Review row width: 40 columns

╭─ Pipeline ───────────────────────────╮
│ feature/foo                  running │
│                                      │
│ ⏸ Review  6604.7s        65/66 fixed │
│ │                                    │
│ ○ Test                               │
│ │                                    │
│ ○ Lint                               │
│ │                                    │
│ ○ Push                               │
│ │                                    │
│ ○ PR                                 │
╰──────────────────────────────────────╯
Review - review fix:
 a approve  f fix (65/66)  s skip  x abort  d diff │ ␣ toggle  e edit  + add  A all  N none
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --unified=80 7b73238f5ce2fcd7810e8014e4da5fdde8a92105..fcbcb854fc2ea7150859c9c5da325e070368c97d -- internal/tui/pipeline.go internal/tui/pipeline_test.go`
- `go test ./internal/tui -run 'TestRenderPipelineView_FixReviewRowFitsWithFixedCount|TestRenderPipelineView_ShowsFixedFindingsAtRightEdge|TestRenderPipelineView_ShowsZeroFixedFindingsWhileFixing|TestRenderPipelineView_FixingStatusOmitsAgentFixingLabel|TestRenderPipelineView_HidesFixActionWhenDisabled' -count=1`
- <code>`NM_EVIDENCE_DIR=&#34;/var/folders/5x/4nqprlbx0518e3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSPCT1VC2FT28P7PPZ2JKK73&#34; go test ./internal/tui -run &#39;^TestEvidenceFixReviewRowRendering$&#39; -count=1 -v` (temporary evidence-only test rendered the actual pipeline and action bar, then was removed)</code>
- `go test ./internal/tui -count=1`
- `go test ./...`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
