### PR TITLE
feat(tui): add yolo auto-approval mode

### DIFF
--- a/docs/src/content/docs/concepts/auto-fix.md
+++ b/docs/src/content/docs/concepts/auto-fix.md
@@ -64,10 +64,11 @@ Repo config overlays global config - you can set `auto_fix.lint: 5` in a repo's 
 Agent-driven findings now use an `action` field instead of `requires_human_review`:
 
 - `auto-fix` - objective issues that can be fixed automatically
-- `ask-user` - intent-sensitive or ambiguous issues that always require manual approval and are never auto-fixed
+- `ask-user` - intent-sensitive or ambiguous issues that pause for approval and are never auto-fixed
 - `no-op` - informational notes that do not need a fix
 
 `ask-user` is meant for findings that need human judgment - for example, questioning an intentional product or design choice, arguing that an intentional addition, removal, or guard should be undone, or reporting that the test step could not produce enough evidence for the inferred intent. Routine correctness, reliability, or security fixes still stay `auto-fix` even if the smallest fix reintroduces a small amount of previously deleted logic.
+In the TUI, yolo mode is an explicit override that auto-approves paused steps, including steps paused for `ask-user` findings.
 
 The `review`, `test`, and configured-command `lint` steps use this shared model directly. The `document` step also uses the same `action` field, but unresolved documentation findings pause for approval because the initial document pass already attempted the documentation updates it could make safely.
 When `commands.lint` is empty, lint findings describe issues left after the agent already attempted safe fixes, so they pause for approval instead of remaining eligible for another automatic fix loop.

--- a/docs/src/content/docs/guides/tui.md
+++ b/docs/src/content/docs/guides/tui.md
@@ -125,7 +125,8 @@ On narrow terminals, the log panel expands to fill the remaining vertical space 
 
 ### Footer
 
-The footer shows detach/help actions and, when `no-mistakes attach` has a cached newer release available, a right-aligned `<version> available` indicator. That update indicator stays visible after reruns in the same TUI session.
+The footer shows detach/help/yolo actions and, when `no-mistakes attach` has a cached newer release available, a right-aligned `<version> available` indicator. That update indicator stays visible after reruns in the same TUI session.
+When yolo mode is on, the footer changes from `y yolo` to `y end yolo`.
 
 ## Keybindings
 
@@ -168,6 +169,7 @@ When the instruction editor is open, press `Ctrl+s` or `Ctrl+enter` to save, or 
 | `d` | Toggle diff view (after fix cycle) |
 | `esc` | Exit diff view back to findings |
 | `?` | Toggle help overlay |
+| `y` | Toggle yolo mode, which auto-approves paused steps |
 | `r` | Start a rerun after a failed or cancelled run |
 | `q` | Detach from TUI (or quit if run is done) |
 
@@ -186,6 +188,8 @@ Review awaiting action:
 The `f fix (3/5)` label shows how many findings are selected out of the total.
 
 Press `e` to add or edit extra guidance for the current finding. Press `+` to add your own finding to the list. User-authored findings start selected by default and can be removed with `D`.
+
+Press `y` to toggle yolo mode when you want paused approval and fix-review steps to approve automatically.
 
 ## Outcome banner
 

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -10,6 +10,7 @@ intent → rebase → review → test → document → lint → push → pr → 
 ```
 
 Each step can produce findings, request approval, trigger auto-fix, or apply safe fixes during its own pass. Steps that encounter fatal errors stop the pipeline. Steps can also be pre-skipped when starting a run, skipped by the user, or skipped automatically by the pipeline.
+In the TUI, yolo mode is an explicit override that auto-approves steps paused for approval or fix review.
 
 ## Intent
 
@@ -57,7 +58,7 @@ AI code review of your diff.
 - Agent returns findings with severity (`error`, `warning`, `info`), file location, description, and an `action` (`no-op`, `auto-fix`, `ask-user`)
 - Also returns a `risk_level` (`low`, `medium`, `high`) and `risk_rationale`
 
-**Approval:** required if any finding has severity `error` or `warning`. Findings with `action: ask-user` always require human approval and are never auto-fixed. This is for findings that challenge the author's intent, not routine correctness, reliability, or security fixes that may need to re-add a small amount of deleted logic. Findings with `action: auto-fix` remain eligible for the fix loop. Findings with `action: no-op` are informational only.
+**Approval:** required if any finding has severity `error` or `warning`. Findings with `action: ask-user` pause for approval and are never auto-fixed. This is for findings that challenge the author's intent, not routine correctness, reliability, or security fixes that may need to re-add a small amount of deleted logic. Findings with `action: auto-fix` remain eligible for the fix loop. Findings with `action: no-op` are informational only.
 
 **Auto-fix:** the agent receives the selected previous findings plus any per-finding user notes, any selected user-authored findings from the TUI, and a sanitized history of prior rounds for that step, including earlier fix summaries and which findings the user left unselected. Follow-up review passes use that history to avoid re-reporting user-ignored findings unless the code now has a materially different problem. Fix commits use `no-mistakes(review): <summary>`.
 
@@ -74,7 +75,7 @@ Runs baseline tests and gathers evidence for the intended behavior.
 - Missing evidence for inferred user intent can be reported as a warning with `action: ask-user`.
 - If the agent creates new test files (detected via `git status --porcelain`), approval is required even if tests pass.
 
-**Approval:** test findings with `action: ask-user` always require human approval, including missing-evidence warnings for inferred intent. `action: auto-fix` findings stay eligible for the fix loop. `action: no-op` findings are informational only.
+**Approval:** test findings with `action: ask-user` pause for approval, including missing-evidence warnings for inferred intent. `action: auto-fix` findings stay eligible for the fix loop. `action: no-op` findings are informational only.
 
 **Auto-fix:** the agent receives the previous test findings plus any per-finding user notes, any selected user-authored findings from the TUI, and a sanitized history of prior rounds for that step, including earlier fix summaries and any findings the user left unselected in prior approval cycles, then tests run again. Fix commits use `no-mistakes(test): <summary>`.
 
@@ -103,7 +104,7 @@ Runs linters and static analysis.
 - If `commands.lint` is set: runs it via the platform shell (`sh -c` on POSIX, `cmd.exe /c` on Windows). Non-zero exit produces `warning` findings.
 - If `commands.lint` is empty: the agent detects appropriate linters/formatters, applies safe fixes, reruns the relevant checks, commits any agent changes, and returns structured findings only for unresolved issues.
 
-**Approval:** lint findings with `action: ask-user` always require human approval.
+**Approval:** lint findings with `action: ask-user` pause for approval.
 `action: auto-fix` findings stay eligible for the fix loop when `commands.lint` is configured.
 `action: no-op` findings are informational only.
 

--- a/internal/tui/DESIGN.md
+++ b/internal/tui/DESIGN.md
@@ -114,10 +114,11 @@ Dim content inside a subtle frame:
 Minimal dim hint at the very bottom, outside all boxes:
 
 ```
-  q quit  ? help
+  q quit  ? help  y yolo
 ```
 
 While the pipeline is still running, the footer shows `q detach` instead of `q quit`.
+When yolo mode is active, `y yolo` changes to warning-styled `y end yolo`.
 
 After a failed or cancelled run, it also shows `r rerun`.
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -50,6 +50,8 @@ type Model struct {
 	spinnerFrame     int
 	spinnerScheduled bool
 	syntheticSteps   bool
+	yoloMode         bool                    // auto-approve every step awaiting human action
+	yoloApproved     map[types.StepName]bool // steps already auto-approved this run
 }
 
 // NewModel creates a TUI model for the given run.
@@ -74,6 +76,7 @@ func NewModel(socketPath string, client *ipc.Client, run *ipc.RunInfo) Model {
 		addedFindings:       make(map[types.StepName][]types.Finding),
 		stepStartTimes:      make(map[types.StepName]time.Time),
 		syntheticSteps:      syntheticSteps,
+		yoloApproved:        make(map[types.StepName]bool),
 	}
 	// Populate findings and start times from initial step data (for re-attach scenarios).
 	for _, s := range steps {
@@ -205,7 +208,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.done {
 			return m, nil
 		}
-		return m, tea.Batch(m.waitForEvent(), m.startSpinnerIfNeeded())
+		return m, tea.Batch(m.waitForEvent(), m.startSpinnerIfNeeded(), m.maybeAutoApproveCmd())
 
 	case subscriptionErrMsg:
 		if msg.subscriptionID != m.subscriptionID {

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -73,6 +73,21 @@ func (m Model) rerunCmd(requestID uint64) tea.Cmd {
 	}
 }
 
+// maybeAutoApproveCmd auto-approves the current awaiting step when yolo mode is
+// on, returning nil otherwise. Each step is approved at most once so duplicate
+// events while waiting for the approval round-trip don't resend the action.
+func (m Model) maybeAutoApproveCmd() tea.Cmd {
+	if !m.yoloMode {
+		return nil
+	}
+	step := awaitingStep(m.steps)
+	if step == nil || m.yoloApproved[step.StepName] {
+		return nil
+	}
+	m.yoloApproved[step.StepName] = true
+	return m.respondCmd(types.ActionApprove)
+}
+
 func (m Model) respondCmd(action types.ApprovalAction) tea.Cmd {
 	step := awaitingStep(m.steps)
 	if step == nil {

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -206,6 +206,13 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case "y":
+		m.yoloMode = !m.yoloMode
+		if m.yoloMode {
+			return m, m.maybeAutoApproveCmd()
+		}
+		return m, nil
+
 	case "a":
 		return m, m.respondCmd(types.ActionApprove)
 	case "f":

--- a/internal/tui/layout_compact_test.go
+++ b/internal/tui/layout_compact_test.go
@@ -161,7 +161,7 @@ func TestModel_View_StackedLogBoxFillsRemainingHeight(t *testing.T) {
 	}
 
 	pipelineView := renderPipelineView(run, m.stepsWithRunningElapsed(), m.width, 0, m.height)
-	footer := renderFooter(false, false, false, run, "", m.width)
+	footer := renderFooter(false, false, false, false, run, "", m.width)
 	expectedLogLines := m.height - sectionsHeight([]string{pipelineView}, 2) - 2 - lipgloss.Height(footer) - 2
 	if expectedLogLines <= 5 {
 		t.Fatalf("expected stacked layout to leave room for more than 5 log lines, got %d", expectedLogLines)

--- a/internal/tui/layout_wide_test.go
+++ b/internal/tui/layout_wide_test.go
@@ -97,7 +97,7 @@ func TestModel_View_Width100UsesResponsiveLayout(t *testing.T) {
 
 func TestHelpOverlay_NavigationDescriptionsAligned(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.Ascii)
-	result := renderHelpOverlay(80, testRun(), true, true, true, false)
+	result := renderHelpOverlay(80, testRun(), true, true, true, false, false)
 	plain := stripANSI(result)
 	lines := strings.Split(plain, "\n")
 
@@ -127,7 +127,7 @@ func TestHelpOverlay_NavigationDescriptionsAligned(t *testing.T) {
 
 func TestHelpOverlay_ActionDescriptionsAligned(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.Ascii)
-	result := renderHelpOverlay(80, testRun(), true, false, true, false)
+	result := renderHelpOverlay(80, testRun(), true, false, true, false, false)
 	plain := stripANSI(result)
 	lines := strings.Split(plain, "\n")
 
@@ -158,7 +158,7 @@ func TestHelpOverlay_ActionDescriptionsAligned(t *testing.T) {
 func TestHelpOverlay_ShowsRunContext(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.Ascii)
 	run := testRun()
-	result := stripANSI(renderHelpOverlay(80, run, true, false, true, false))
+	result := stripANSI(renderHelpOverlay(80, run, true, false, true, false, false))
 	if !strings.Contains(result, run.Branch) {
 		t.Fatalf("expected help overlay to show branch name, got:\n%s", result)
 	}
@@ -176,7 +176,7 @@ func TestHelpOverlay_ShowsOpenPRActionWhenPRURLPresent(t *testing.T) {
 	prURL := "https://github.com/test/repo/pull/42"
 	run.PRURL = &prURL
 
-	result := stripANSI(renderHelpOverlay(80, run, true, false, true, false))
+	result := stripANSI(renderHelpOverlay(80, run, true, false, true, false, false))
 	if !strings.Contains(result, "open PR in browser") {
 		t.Fatalf("expected help overlay to include PR browser action, got:\n%s", result)
 	}
@@ -417,7 +417,7 @@ func TestModel_View_ConsistentFooterSpacing(t *testing.T) {
 func TestHelpOverlay_SelectionDescriptionsAligned(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.Ascii)
 	// showDiff=false so selection section is visible.
-	result := renderHelpOverlay(80, testRun(), true, false, true, false)
+	result := renderHelpOverlay(80, testRun(), true, false, true, false, false)
 	plain := stripANSI(result)
 	lines := strings.Split(plain, "\n")
 

--- a/internal/tui/pipeline.go
+++ b/internal/tui/pipeline.go
@@ -324,7 +324,7 @@ type helpEntry struct {
 }
 
 // renderHelpOverlay renders a help box showing keybindings relevant to the current state.
-func renderHelpOverlay(width int, run *ipc.RunInfo, hasAwaitingStep bool, showDiff bool, hasDiff bool, done bool) string {
+func renderHelpOverlay(width int, run *ipc.RunInfo, hasAwaitingStep bool, showDiff bool, hasDiff bool, done bool, yolo bool) string {
 	boldKey := lipgloss.NewStyle().Bold(true)
 	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
 	contentWidth := width - 4
@@ -418,6 +418,11 @@ func renderHelpOverlay(width int, run *ipc.RunInfo, hasAwaitingStep bool, showDi
 		footerEntries = append(footerEntries, helpEntry{"x x", "abort pipeline"})
 	}
 	footerEntries = append(footerEntries, helpEntry{"?", "close help"})
+	yoloDesc := "auto-accept every step"
+	if yolo {
+		yoloDesc = "end yolo (auto-accept)"
+	}
+	footerEntries = append(footerEntries, helpEntry{"y", yoloDesc})
 	if canRerun(run) {
 		footerEntries = append(footerEntries, helpEntry{"r", "rerun pipeline"})
 	}

--- a/internal/tui/pipeline_test.go
+++ b/internal/tui/pipeline_test.go
@@ -541,7 +541,7 @@ func TestRenderFooter_WithPRURL_ShowsOpenAction(t *testing.T) {
 	run := testRun()
 	run.Status = types.RunCompleted
 	run.PRURL = &prURL
-	footer := renderFooter(true, false, false, run, "", 80)
+	footer := renderFooter(true, false, false, false, run, "", 80)
 	stripped := stripANSI(footer)
 
 	if !strings.Contains(stripped, "o") || !strings.Contains(stripped, "open PR") {
@@ -554,7 +554,7 @@ func TestRenderFooter_WithPRURL_ShowsOpenAction(t *testing.T) {
 
 func TestRenderFooter_WithoutPRURL(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.Ascii)
-	footer := renderFooter(false, false, false, nil, "", 80)
+	footer := renderFooter(false, false, false, false, nil, "", 80)
 	stripped := stripANSI(footer)
 
 	if strings.Contains(stripped, "open PR") {
@@ -566,7 +566,7 @@ func TestRenderFooter_FailedRun_ShowsRerun(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.Ascii)
 	run := testRun()
 	run.Status = types.RunFailed
-	footer := renderFooter(true, false, false, run, "", 80)
+	footer := renderFooter(true, false, false, false, run, "", 80)
 	stripped := stripANSI(footer)
 
 	if !strings.Contains(stripped, "rerun") {
@@ -581,7 +581,7 @@ func TestRenderFooter_PRURL_ActionShownAtNarrowWidth(t *testing.T) {
 	run := testRun()
 	run.Status = types.RunCompleted
 	run.PRURL = &prURL
-	footer := renderFooter(true, false, false, run, "", 40)
+	footer := renderFooter(true, false, false, false, run, "", 40)
 	stripped := stripANSI(footer)
 
 	if !strings.Contains(stripped, "open PR") {
@@ -591,7 +591,7 @@ func TestRenderFooter_PRURL_ActionShownAtNarrowWidth(t *testing.T) {
 
 func TestRenderFooter_WithAvailableUpdate_ShowsIndicator(t *testing.T) {
 	lipgloss.SetColorProfile(termenv.Ascii)
-	footer := renderFooter(false, false, false, nil, "v1.2.3", 80)
+	footer := renderFooter(false, false, false, false, nil, "v1.2.3", 80)
 	stripped := stripANSI(footer)
 
 	if !strings.Contains(stripped, "v1.2.3 available") {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -48,7 +48,7 @@ func (m Model) View() string {
 	}
 	actionBar := renderActionBar(m.steps, showSelectionActions, allowFix, m.showDiff, selectedCount, totalCount, m.confirmAbort, hasDiff)
 
-	footer := renderFooter(m.done, m.showHelp, m.confirmAbort, m.run, m.latestVersion, m.width)
+	footer := renderFooter(m.done, m.showHelp, m.confirmAbort, m.yoloMode, m.run, m.latestVersion, m.width)
 	contentBudget := -1
 	if m.height > 0 {
 		baseSections := []string{}
@@ -218,7 +218,18 @@ func (m Model) View() string {
 		if boxWidth < 20 {
 			boxWidth = 80
 		}
-		appendExtraSection(renderHelpOverlay(boxWidth, m.run, awaitingStep(m.steps) != nil, m.showDiff, hasDiff, m.done))
+		// The help overlay is user-invoked, so render it even when the content
+		// budget is exhausted rather than silently dropping it.
+		overlay := renderHelpOverlay(boxWidth, m.run, awaitingStep(m.steps) != nil, m.showDiff, hasDiff, m.done, m.yoloMode)
+		if overlay != "" {
+			extraSections = append(extraSections, overlay)
+			if contentBudget > 0 {
+				contentBudget -= lipgloss.Height(overlay)
+				if contentBudget < 0 {
+					contentBudget = 0
+				}
+			}
+		}
 	}
 
 	if useResponsiveLayout {
@@ -347,7 +358,7 @@ func renderErrorBox(err error, width int) string {
 	return renderBox("Error", errContent.String(), boxWidth)
 }
 
-func renderFooter(done bool, showHelp bool, confirmAbort bool, run *ipc.RunInfo, latestVersion string, width int) string {
+func renderFooter(done bool, showHelp bool, confirmAbort bool, yolo bool, run *ipc.RunInfo, latestVersion string, width int) string {
 	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
 	warnStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiYellow))
 	boldKey := lipgloss.NewStyle().Bold(true)
@@ -368,6 +379,11 @@ func renderFooter(done bool, showHelp bool, confirmAbort bool, run *ipc.RunInfo,
 		left += "  " + boldKey.Render("x") + " " + dimStyle.Render(xLabel)
 	}
 	left += "  " + boldKey.Render("?") + " " + dimStyle.Render(helpLabel)
+	if yolo {
+		left += "  " + boldKey.Render("y") + " " + warnStyle.Render("end yolo")
+	} else {
+		left += "  " + boldKey.Render("y") + " " + dimStyle.Render("yolo")
+	}
 	if canRerun(run) {
 		left += "  " + boldKey.Render("r") + " " + dimStyle.Render("rerun")
 	}

--- a/internal/tui/yolo_test.go
+++ b/internal/tui/yolo_test.go
@@ -1,0 +1,143 @@
+package tui
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/kunchenguid/no-mistakes/internal/ipc"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+	"github.com/muesli/termenv"
+)
+
+func TestModel_Update_YoloKeyTogglesMode(t *testing.T) {
+	run := testRun()
+	m := NewModel("/tmp/sock", nil, run)
+	if m.yoloMode {
+		t.Fatal("expected yolo mode off by default")
+	}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	model := updated.(Model)
+	if !model.yoloMode {
+		t.Fatal("expected first y press to enable yolo mode")
+	}
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	model = updated.(Model)
+	if model.yoloMode {
+		t.Fatal("expected second y press to disable yolo mode")
+	}
+}
+
+func TestModel_Yolo_AutoApprovesAwaitingStep(t *testing.T) {
+	sock := testSocketPath(t)
+	srv := startTestIPCServer(t, sock)
+
+	var mu sync.Mutex
+	var calls []ipc.RespondParams
+	srv.Handle(ipc.MethodRespond, func(_ context.Context, raw json.RawMessage) (interface{}, error) {
+		var params ipc.RespondParams
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return nil, err
+		}
+		mu.Lock()
+		calls = append(calls, params)
+		mu.Unlock()
+		return &ipc.RespondResult{}, nil
+	})
+
+	client, err := ipc.Dial(sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusAwaitingApproval
+	m := NewModel(sock, client, run)
+	m.yoloMode = true
+
+	cmd := m.maybeAutoApproveCmd()
+	if cmd == nil {
+		t.Fatal("expected auto-approve command when yolo on and step awaiting")
+	}
+	if msg := cmd(); msg != nil {
+		t.Fatalf("expected nil msg from auto-approve, got %#v", msg)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly 1 respond call, got %d", len(calls))
+	}
+	if calls[0].Action != types.ActionApprove {
+		t.Fatalf("action = %s, want %s", calls[0].Action, types.ActionApprove)
+	}
+	if calls[0].Step != types.StepReview {
+		t.Fatalf("step = %s, want %s", calls[0].Step, types.StepReview)
+	}
+}
+
+func TestModel_Yolo_DoesNotAutoApproveTwiceForSameStep(t *testing.T) {
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusAwaitingApproval
+	m := NewModel("/tmp/sock", nil, run)
+	m.yoloMode = true
+
+	if cmd := m.maybeAutoApproveCmd(); cmd == nil {
+		t.Fatal("expected first auto-approve command")
+	}
+	if cmd := m.maybeAutoApproveCmd(); cmd != nil {
+		t.Fatal("expected no second auto-approve command for the same awaiting step")
+	}
+}
+
+func TestModel_Yolo_NoAutoApproveWhenOff(t *testing.T) {
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusAwaitingApproval
+	m := NewModel("/tmp/sock", nil, run)
+
+	if cmd := m.maybeAutoApproveCmd(); cmd != nil {
+		t.Fatal("expected no auto-approve command when yolo off")
+	}
+}
+
+func TestModel_View_FooterShowsYoloLabel(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.Ascii)
+	run := testRun()
+	m := NewModel("", nil, run)
+	m.width = 120
+	m.height = 40
+
+	plain := stripANSI(m.View())
+	if !footerContains(plain, "y", "yolo") {
+		t.Errorf("footer should show 'y yolo' when yolo off, got:\n%s", plain)
+	}
+
+	m.yoloMode = true
+	plain = stripANSI(m.View())
+	if !footerContains(plain, "y", "end yolo") {
+		t.Errorf("footer should show 'y end yolo' when yolo on, got:\n%s", plain)
+	}
+}
+
+func footerContains(plain string, needles ...string) bool {
+	for _, line := range strings.Split(plain, "\n") {
+		all := true
+		for _, n := range needles {
+			if !strings.Contains(line, n) {
+				all = false
+				break
+			}
+		}
+		if all {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Intent

The developer wanted to add a global "yolo" mode to the TUI, toggled with the `y` key alongside existing global keybinds like quit. The footer label should display "yolo" normally and change to "end yolo" while active. When yolo mode is enabled, any findings that would normally pause for human approval should be automatically approved instead.

## What Changed

- Added a global TUI `y` keybinding that toggles yolo mode, updates the footer/help labels between `yolo` and `end yolo`, and highlights the active state.
- When yolo mode is enabled, awaiting approval steps are automatically approved once per step instead of pausing for manual approval.
- Updated TUI docs, pipeline approval docs, design notes, and TUI tests to cover the new auto-approval behavior.

## Risk Assessment

✅ Low: The change is localized to TUI state, key handling, and rendering, with auto-approval routed through the existing approval command path and no material correctness risks found in the review pass.

## Testing

Inspected the target diff, ran the focused yolo TUI tests and the full TUI package tests, then generated reviewer-visible evidence showing the rendered footer before and after pressing `y` plus the auto-approval IPC payload; all exercised checks passed.

<details>
<summary>Evidence: TUI footer before and after yolo toggle</summary>

<code>Rendered terminal snapshot shows the footer changing from `q detach x abort ? help y yolo` to `q detach x abort ? help y end yolo` after pressing `y`.</code>

```text
<!doctype html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>TUI yolo evidence</title>
<style>
body{font-family:ui-sans-serif,system-ui,sans-serif;margin:32px;background:#101114;color:#f5f5f5}h1{font-size:22px}.grid{display:grid;grid-template-columns:1fr 1fr;gap:20px}.card{background:#181a20;border:1px solid #343844;border-radius:12px;padding:16px;min-width:0}.label{font-weight:700;margin-bottom:10px}.term{font:12px/1.25 ui-monospace,SFMono-Regular,Menlo,monospace;white-space:pre-wrap;overflow-wrap:anywhere;background:#050607;border-radius:8px;padding:12px}.note{color:#adb5c3;margin-bottom:20px}
</style>
</head>
<body>
<h1>TUI yolo mode footer evidence</h1>
<p class="note">After pressing <code>y</code>, the footer changes from <code>y yolo</code> to <code>y end yolo</code> while the same run is awaiting approval.</p>
<div class="grid">
<section class="card"><div class="label">Before pressing y</div><div class="term">]2;⏸ Review - feature/foo╭─ Pipeline ───────────────────────────╮  Review awaiting action:                                                       
│ feature/foo                  running │   a approve  s skip  x abort                                                   
│                                      │                                                                                
│ ⏸ Review - awaiting approval         │                                                                                
│ │                                    │                                                                                
│ ○ Test                               │                                                                                
│ │                                    │                                                                                
│ ○ Lint                               │                                                                                
│ │                                    │                                                                                
│ ○ Push                               │                                                                                
│ │                                    │                                                                                
│ ○ PR                                 │                                                                                
╰──────────────────────────────────────╯                                                                                

  q detach  x abort  ? help  y yolo</div></section>
<section class="card"><div class="label">After pressing y</div><div class="term">]2;⏸ Review - feature/foo╭─ Pipeline ───────────────────────────╮  Review awaiting action:                                                       
│ feature/foo                  running │   a approve  s skip  x abort                                                   
│                                      │                                                                                
│ ⏸ Review - awaiting approval         │                                                                                
│ │                                    │                                                                                
│ ○ Test                               │                                                                                
│ │                                    │                                                                                
│ ○ Lint                               │                                                                                
│ │                                    │                                                                                
│ ○ Push                               │                                                                                
│ │                                    │                                                                                
│ ○ PR                                 │                                                                                
╰──────────────────────────────────────╯                                                                                

  q detach  x abort  ? help  y end yolo</div></section>
</div>
</body>
</html>
```
</details>
<details>
<summary>Evidence: Auto-approval IPC payload</summary>

<code>{&#10;&#34;run_id&#34;: &#34;run-001&#34;,&#10;&#34;step&#34;: &#34;review&#34;,&#10;&#34;action&#34;: &#34;approve&#34;&#10;}</code>

```text
{
  "run_id": "run-001",
  "step": "review",
  "action": "approve"
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --stat 3270c0cfeba94c7f9d9a86c43a9d22583a3beea2..366c7b7b6d189b0c7cce7ccfe61b074fdff558e3`
- `go test ./internal/tui -run 'TestModel_(Update_YoloKeyTogglesMode|Yolo_AutoApprovesAwaitingStep|Yolo_DoesNotAutoApproveTwiceForSameStep|Yolo_NoAutoApproveWhenOff|View_FooterShowsYoloLabel)$' -count=1 -v`
- `YOLO_EVIDENCE_DIR="/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KSPNKBCPGFAJVSBE9S91N8PF" go test ./internal/tui -run '^TestYoloEvidence_EndUserSurfaceAndAutoApproval$' -count=1 -v`
- `go test ./internal/tui -count=1`

</details>

<details>
<summary>🔧 **Document** - 4 issues found → auto-fixed ✅</summary>

- ⚠️ `docs/src/content/docs/guides/tui.md:130` - The TUI guide documents layout, footer behavior, and keybindings but does not mention the new global `y` yolo toggle. The change adds a public keybinding whose footer label changes from `yolo` to `end yolo` and whose behavior auto-approves awaiting/fix-review steps, so this guide should add the keybinding and explain the approval workflow impact.
- ⚠️ `docs/src/content/docs/concepts/auto-fix.md:67` - The auto-fix concept page says `ask-user` findings always require manual approval. With TUI yolo mode enabled, any step that pauses for approval is automatically approved, including steps containing `ask-user` findings. This page should qualify the manual-approval language or mention the explicit yolo override.
- ⚠️ `docs/src/content/docs/reference/pipeline-steps.md:60` - The pipeline-step reference repeats per-step approval rules such as `ask-user` findings always requiring human approval, but the new TUI yolo mode auto-approves all awaiting approval/fix-review steps. The reference should document that yolo is an opt-in TUI override for paused approvals or qualify the affected approval statements for Review, Test, Document, Lint, and CI/rebase pauses.
- ℹ️ `internal/tui/DESIGN.md:112` - The internal TUI design document&#39;s footer section still shows only `q quit  ? help` plus rerun behavior. The implemented footer now always includes `y yolo`, switches to `y end yolo` while enabled, and uses warning styling for active yolo mode, so the design doc is stale.

🔧 Fix: Document TUI yolo mode
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
