### PR TITLE
fix(agent): steer pipeline agents away from system writes

### DIFF
--- a/docs/src/content/docs/concepts/daemon.md
+++ b/docs/src/content/docs/concepts/daemon.md
@@ -64,6 +64,9 @@ When a push arrives via the post-receive hook:
 3. Streams events to any connected TUI clients
 4. Cleans up the worktree when the run finishes (success or failure)
 
+Pipeline agents are prompted to keep intentional writes inside that detached worktree and avoid changing system state outside it, such as Homebrew packages, apps under `/Applications`, or global tool configuration.
+That reduces surprising machine-level side effects and macOS App Management prompts, but it is prompt steering rather than a true sandbox.
+
 ## Concurrent push handling
 
 If you push to the same branch while a run is already active, the daemon:

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -12,6 +12,10 @@ code review, evidence-oriented test validation, test or lint detection when you
 have not configured explicit commands, auto-fixing, and setup-wizard suggestions
 when you leave prompts blank.
 
+Pipeline agent prompts also include a workspace-boundary preamble.
+It tells agents to keep intentional source, project, user-data, and system file writes inside the disposable worktree, avoid mutating system state such as Homebrew packages, `/Applications`, or global tool config, and treat that boundary as prompt steering rather than true enforcement.
+The only intentional out-of-worktree write it allows is test evidence under the managed temporary `no-mistakes-evidence` directory when a testing prompt asks for it; incidental temp or cache writes from normal development tools are still allowed.
+
 ## How to choose quickly
 
 - Leave `agent: auto` if one good agent is already installed and you do not need repo-specific behavior.
@@ -123,7 +127,7 @@ reflects your local agent setup rather than repo policy.
 
 All agents implement the same interface. Each invocation receives:
 
-- **Prompt** - the task description (review this diff, fix these findings, etc.)
+- **Prompt** - the task description (review this diff, fix these findings, etc.), prefixed during pipeline runs with the workspace-boundary steering described above
 - **CWD** - the worktree directory
 - **JSONSchema** - optional structured output schema for typed responses
 - **OnChunk** - callback for streaming text output to the TUI

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -109,6 +109,14 @@ no-mistakes daemon stop
 no-mistakes daemon start
 ```
 
+## macOS App Management prompts during agent runs
+
+Pipeline prompts steer agents to keep intentional writes inside the disposable worktree and avoid mutating system locations such as `/Applications`, Homebrew-managed packages, or global tool configuration.
+This reduces macOS App Management prompts from agent-invoked commands, but it is not an OS sandbox.
+
+If you still see prompts, check the step log for commands that intentionally write outside the worktree and move that setup into your normal development environment or an explicit repo-local command.
+Requested test evidence may still be written under the managed temporary `no-mistakes-evidence` directory, and normal tool temp or cache writes can still happen outside the worktree.
+
 ## `git push no-mistakes` doesn't start a pipeline
 
 Symptom: push succeeds but `no-mistakes` shows no active run.

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -139,6 +139,9 @@ Smart defaults:
 - For `claude`, supplying `--permission-mode` (or `--dangerously-skip-permissions`) suppresses the default `--dangerously-skip-permissions`.
 - For `codex`, supplying `--ask-for-approval`, `--sandbox`, or `--dangerously-bypass-approvals-and-sandbox` suppresses the default `--dangerously-bypass-approvals-and-sandbox`.
 
+Permission and sandbox flags affect the underlying agent, but they do not disable no-mistakes' pipeline prompt steering.
+Pipeline agents are still told to keep intentional writes inside the worktree and avoid mutating system state outside it.
+
 Example:
 
 ```yaml

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -11,6 +11,9 @@ intent → rebase → review → test → document → lint → push → pr → 
 
 Each step can produce findings, request approval, trigger auto-fix, or apply safe fixes during its own pass. Steps that encounter fatal errors stop the pipeline. Steps can also be pre-skipped when starting a run, skipped by the user, or skipped automatically by the pipeline.
 In the TUI, yolo mode is an explicit override that auto-approves steps paused for approval or fix review.
+Every pipeline agent invocation is prompt-steered to keep intentional writes inside the run worktree and avoid mutating system state outside it.
+This is a soft boundary, not OS-level sandbox enforcement.
+The steering still allows requested test evidence under the managed temporary `no-mistakes-evidence` directory and incidental temp or cache writes from normal development tools.
 
 ## Intent
 

--- a/internal/agent/steering.go
+++ b/internal/agent/steering.go
@@ -1,6 +1,11 @@
 package agent
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+)
 
 // WorktreeSteering is prepended to every pipeline agent prompt. It keeps the
 // agent's writes inside the git worktree and steers it away from mutating
@@ -8,12 +13,13 @@ import "context"
 // modifying apps in /Applications, changing global config). Those out-of-tree
 // writes are what trigger macOS "App Management" / Privacy notifications and
 // risk surprising side effects on the user's machine.
-const WorktreeSteering = `Workspace boundary (important):
+var WorktreeSteering = fmt.Sprintf(`Workspace boundary (important):
 - Confine all file changes to the current working directory, which is a git worktree. Do not create, modify, move, or delete files anywhere outside it.
 - Do not modify system state outside the worktree. In particular, do not install or upgrade system packages (for example brew install/upgrade, or other system package managers), do not modify applications under /Applications, and do not change global or user-level tool configuration.
-- You may read files outside the worktree and run read-only commands, but every write must stay inside the worktree.
+- The only allowed out-of-worktree writes are test evidence files under %s when a testing prompt explicitly asks for them.
+- You may read files outside the worktree and run read-only commands, but every other write must stay inside the worktree.
 
-`
+`, filepath.Join(os.TempDir(), "no-mistakes-evidence"))
 
 // steeredAgent wraps an Agent and prepends WorktreeSteering to each prompt.
 type steeredAgent struct {

--- a/internal/agent/steering.go
+++ b/internal/agent/steering.go
@@ -1,0 +1,41 @@
+package agent
+
+import "context"
+
+// WorktreeSteering is prepended to every pipeline agent prompt. It keeps the
+// agent's writes inside the git worktree and steers it away from mutating
+// system state outside the workspace (installing/upgrading system packages,
+// modifying apps in /Applications, changing global config). Those out-of-tree
+// writes are what trigger macOS "App Management" / Privacy notifications and
+// risk surprising side effects on the user's machine.
+const WorktreeSteering = `Workspace boundary (important):
+- Confine all file changes to the current working directory, which is a git worktree. Do not create, modify, move, or delete files anywhere outside it.
+- Do not modify system state outside the worktree. In particular, do not install or upgrade system packages (for example brew install/upgrade, or other system package managers), do not modify applications under /Applications, and do not change global or user-level tool configuration.
+- You may read files outside the worktree and run read-only commands, but every write must stay inside the worktree.
+
+`
+
+// steeredAgent wraps an Agent and prepends WorktreeSteering to each prompt.
+type steeredAgent struct {
+	Agent
+}
+
+// Run prepends the worktree steering preamble before delegating to the
+// wrapped agent. All other RunOpts fields pass through unchanged.
+func (s steeredAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
+	opts.Prompt = WorktreeSteering + opts.Prompt
+	return s.Agent.Run(ctx, opts)
+}
+
+// WithSteering wraps an agent so every invocation is steered to keep writes
+// inside the worktree. Wrapping is idempotent: an already-steered agent is
+// returned unchanged so the preamble is never added twice.
+func WithSteering(a Agent) Agent {
+	if a == nil {
+		return nil
+	}
+	if _, ok := a.(steeredAgent); ok {
+		return a
+	}
+	return steeredAgent{a}
+}

--- a/internal/agent/steering.go
+++ b/internal/agent/steering.go
@@ -14,10 +14,11 @@ import (
 // writes are what trigger macOS "App Management" / Privacy notifications and
 // risk surprising side effects on the user's machine.
 var WorktreeSteering = fmt.Sprintf(`Workspace boundary (important):
-- Confine all file changes to the current working directory, which is a git worktree. Do not create, modify, move, or delete files anywhere outside it.
+- Confine source, project, user-data, and system file changes to the current working directory, which is a git worktree. Do not intentionally create, modify, move, or delete those files anywhere outside it.
 - Do not modify system state outside the worktree. In particular, do not install or upgrade system packages (for example brew install/upgrade, or other system package managers), do not modify applications under /Applications, and do not change global or user-level tool configuration.
 - The only allowed out-of-worktree writes are test evidence files under %s when a testing prompt explicitly asks for them.
-- You may read files outside the worktree and run read-only commands, but every other write must stay inside the worktree.
+- Ephemeral temp/cache writes that are incidental side effects of running the project development toolchain are allowed outside the worktree for tests, linters, formatters, builds, and manual verification commands.
+- You may read files outside the worktree and run read-only commands, but every other intentional write must stay inside the worktree.
 
 `, filepath.Join(os.TempDir(), "no-mistakes-evidence"))
 

--- a/internal/agent/steering.go
+++ b/internal/agent/steering.go
@@ -16,6 +16,7 @@ import (
 var WorktreeSteering = fmt.Sprintf(`Workspace boundary (important):
 - Confine source, project, user-data, and system file changes to the current working directory, which is a git worktree. Do not intentionally create, modify, move, or delete those files anywhere outside it.
 - Do not modify system state outside the worktree. In particular, do not install or upgrade system packages (for example brew install/upgrade, or other system package managers), do not modify applications under /Applications, and do not change global or user-level tool configuration.
+- This is prompt steering, not true enforcement: treat the worktree boundary as a soft boundary you must follow.
 - The only allowed out-of-worktree writes are test evidence files under %s when a testing prompt explicitly asks for them.
 - Ephemeral temp/cache writes that are incidental side effects of running the project development toolchain are allowed outside the worktree for tests, linters, formatters, builds, and manual verification commands.
 - You may read files outside the worktree and run read-only commands, but every other intentional write must stay inside the worktree.

--- a/internal/agent/steering_test.go
+++ b/internal/agent/steering_test.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -75,5 +77,13 @@ func TestWithSteering_DoesNotDoubleWrap(t *testing.T) {
 
 	if got := strings.Count(inner.gotOpts.Prompt, WorktreeSteering); got != 1 {
 		t.Errorf("steering preamble appeared %d times, want 1:\n%q", got, inner.gotOpts.Prompt)
+	}
+}
+
+func TestWorktreeSteering_AllowsManagedTestEvidenceDirectory(t *testing.T) {
+	want := filepath.Join(os.TempDir(), "no-mistakes-evidence")
+
+	if !strings.Contains(WorktreeSteering, want) {
+		t.Fatalf("steering preamble does not allow managed evidence directory %q:\n%s", want, WorktreeSteering)
 	}
 }

--- a/internal/agent/steering_test.go
+++ b/internal/agent/steering_test.go
@@ -87,3 +87,12 @@ func TestWorktreeSteering_AllowsManagedTestEvidenceDirectory(t *testing.T) {
 		t.Fatalf("steering preamble does not allow managed evidence directory %q:\n%s", want, WorktreeSteering)
 	}
 }
+
+func TestWorktreeSteering_AllowsEphemeralToolchainWrites(t *testing.T) {
+	prompt := strings.ToLower(WorktreeSteering)
+	for _, want := range []string{"ephemeral", "toolchain", "temp", "cache"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("steering preamble does not mention %q writes:\n%s", want, WorktreeSteering)
+		}
+	}
+}

--- a/internal/agent/steering_test.go
+++ b/internal/agent/steering_test.go
@@ -1,0 +1,79 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// recordingAgent captures the RunOpts it was invoked with.
+type recordingAgent struct {
+	name     string
+	gotOpts  RunOpts
+	runCalls int
+	closed   bool
+}
+
+func (r *recordingAgent) Name() string { return r.name }
+
+func (r *recordingAgent) Run(_ context.Context, opts RunOpts) (*Result, error) {
+	r.runCalls++
+	r.gotOpts = opts
+	return &Result{Text: "ok"}, nil
+}
+
+func (r *recordingAgent) Close() error {
+	r.closed = true
+	return nil
+}
+
+func TestWithSteering_PrependsPreamble(t *testing.T) {
+	inner := &recordingAgent{name: "claude"}
+	steered := WithSteering(inner)
+
+	const userPrompt = "Fix the failing test in foo_test.go"
+	if _, err := steered.Run(context.Background(), RunOpts{Prompt: userPrompt, CWD: "/tmp/wt"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if !strings.HasPrefix(inner.gotOpts.Prompt, WorktreeSteering) {
+		t.Errorf("prompt did not start with steering preamble:\n%q", inner.gotOpts.Prompt)
+	}
+	if !strings.HasSuffix(inner.gotOpts.Prompt, userPrompt) {
+		t.Errorf("original prompt not preserved at end:\n%q", inner.gotOpts.Prompt)
+	}
+	// Other opts must pass through untouched.
+	if inner.gotOpts.CWD != "/tmp/wt" {
+		t.Errorf("CWD = %q, want /tmp/wt", inner.gotOpts.CWD)
+	}
+}
+
+func TestWithSteering_PassesThroughNameAndClose(t *testing.T) {
+	inner := &recordingAgent{name: "codex"}
+	steered := WithSteering(inner)
+
+	if steered.Name() != "codex" {
+		t.Errorf("Name() = %q, want codex", steered.Name())
+	}
+	if err := steered.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !inner.closed {
+		t.Error("Close() did not propagate to inner agent")
+	}
+}
+
+func TestWithSteering_DoesNotDoubleWrap(t *testing.T) {
+	inner := &recordingAgent{name: "pi"}
+	once := WithSteering(inner)
+	twice := WithSteering(once)
+
+	const userPrompt = "do the thing"
+	if _, err := twice.Run(context.Background(), RunOpts{Prompt: userPrompt}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if got := strings.Count(inner.gotOpts.Prompt, WorktreeSteering); got != 1 {
+		t.Errorf("steering preamble appeared %d times, want 1:\n%q", got, inner.gotOpts.Prompt)
+	}
+}

--- a/internal/agent/steering_test.go
+++ b/internal/agent/steering_test.go
@@ -96,3 +96,12 @@ func TestWorktreeSteering_AllowsEphemeralToolchainWrites(t *testing.T) {
 		}
 	}
 }
+
+func TestWorktreeSteering_DescribesSoftBoundary(t *testing.T) {
+	prompt := strings.ToLower(WorktreeSteering)
+	for _, want := range []string{"soft boundary", "prompt steering", "not true enforcement"} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("steering preamble does not mention %q:\n%s", want, WorktreeSteering)
+		}
+	}
+}

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -311,6 +311,10 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 			trackStartFailure("create_agent")
 			return "", fmt.Errorf("create agent: %w", agErr)
 		}
+		// Steer every pipeline agent to keep writes inside the worktree and
+		// avoid mutating system state (e.g. brew/Homebrew touching
+		// /Applications), which triggers macOS App Management prompts.
+		ag = agent.WithSteering(ag)
 	}
 
 	execSteps := m.steps()


### PR DESCRIPTION
## Intent

The developer wanted to prevent no-mistakes pipeline agents from triggering macOS App Management permission prompts when they run commands that mutate system locations such as /Applications. They first asked whether users could grant those permissions upfront during installation, but then chose the simpler fix of always steering agents to keep writes inside the worktree instead of adding OS-level permission or sandbox handling. They wanted the change applied broadly to pipeline agent runs through a shared chokepoint, with the explicit caveat that prompt steering is a soft boundary rather than true enforcement.

## What Changed

- Added shared agent prompt steering that tells pipeline agents to keep source and system mutations inside the run worktree, with explicit allowances for managed evidence files and ephemeral tool/test cache writes.
- Wired the daemon pipeline agent launch path through the steering chokepoint so worktree guidance is applied broadly to pipeline runs.
- Documented the worktree-steering behavior and its soft-boundary caveat across agent, daemon, troubleshooting, config, and pipeline-step docs.

## Risk Assessment

✅ Low: The change is limited to prepending a shared prompt steering preamble and the current wording accounts for managed evidence and incidental toolchain temp/cache writes, leaving little implementation surface for regressions.

## Testing

Targeted steering unit tests passed, and a daemon `push_received` path with a prompt-capturing fake Claude agent produced reviewer-visible prompt evidence showing the worktree-only guidance, /Applications/system-state restriction, allowed evidence directory, ephemeral toolchain allowance, and explicit soft-boundary caveat before the original agent prompt.

<details>
<summary>Evidence: Captured daemon-launched agent prompt</summary>

<code>Workspace boundary (important):&#10;- Confine source, project, user-data, and system file changes to the current working directory, which is a git worktree. Do not intentionally create, modify, move, or delete those files anywhere outside it.&#10;- Do not modify system state outside the worktree. In particular, do not install or upgrade system packages (for example brew install/upgrade, or other system package managers), do not modify applications under /Applications, and do not change global or user-level tool configuration.&#10;- This is prompt steering, not true enforcement: treat the worktree boundary as a soft boundary you must follow.&#10;...&#10;Attempt to validate without touching /Applications.</code>

```text
Workspace boundary (important):
- Confine source, project, user-data, and system file changes to the current working directory, which is a git worktree. Do not intentionally create, modify, move, or delete those files anywhere outside it.
- Do not modify system state outside the worktree. In particular, do not install or upgrade system packages (for example brew install/upgrade, or other system package managers), do not modify applications under /Applications, and do not change global or user-level tool configuration.
- This is prompt steering, not true enforcement: treat the worktree boundary as a soft boundary you must follow.
- The only allowed out-of-worktree writes are test evidence files under /var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence when a testing prompt explicitly asks for them.
- Ephemeral temp/cache writes that are incidental side effects of running the project development toolchain are allowed outside the worktree for tests, linters, formatters, builds, and manual verification commands.
- You may read files outside the worktree and run read-only commands, but every other intentional write must stay inside the worktree.

Attempt to validate without touching /Applications.
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (7m32s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `internal/agent/steering.go:12` - The new global steering forbids every write outside the worktree, but the test step tells agents to write evidence artifacts to `os.TempDir()/no-mistakes-evidence/&lt;runID&gt;`, which is outside `sctx.WorkDir`. This prompt conflict can cause pipeline agents to skip or refuse evidence generation during the test step; either move evidence storage under the worktree or explicitly exempt no-mistakes-managed evidence paths.

🔧 Fix: Exempt managed test evidence directory
1 error still open:
- 🚨 `internal/agent/steering.go:19` - The steering prompt now says the only allowed out-of-worktree writes are evidence files, but pipeline prompts still ask agents to run tests, linters, formatters, and manual verification commands that commonly create temp files or tool caches outside the worktree (for example Go test temp dirs/build cache or npm/browser caches). This can make agents refuse or avoid required validation/fix commands; narrow the rule to source/user/system mutations or explicitly allow ephemeral tool/test temp and cache writes.

🔧 Fix: Allow toolchain temp/cache writes
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `internal/agent/steering.go:16` - The daemon-push evidence path showed the steering preamble is delivered to the pipeline agent and includes the /Applications/system-state restrictions, but it does not state that this is prompt steering only and not true enforcement. That misses the explicit user-intent caveat that the worktree boundary is a soft boundary rather than OS-level permission or sandbox enforcement.
- <code>`git diff 0be2387bcf6d910e2c20e6f494cc3239eba31b93...8a21b9916c314e7b59d34cbd11d1deb02902c951` to understand the changed steering and daemon chokepoint</code>
- `go test ./internal/agent -run 'TestWithSteering|TestWorktreeSteering' -count=1`
- `go test ./internal/daemon -run 'TestPushReceivedTracksRunTelemetry|TestPushReceivedSkipStepsConfiguresExecutor|TestPushReceivedDemoModeBypassesAgentResolution' -count=1`
- <code>Temporary evidence test `NM_STEERING_EVIDENCE_DIR=&#34;/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01KSS1665PTKKYJRE921GVBT4P&#34; go test ./internal/daemon -run &#39;^TestEvidencePushRunSteersAgentPrompt$&#39; -count=1` drove a daemon IPC push run and captured the mock Claude `-p` prompt; it failed because the captured prompt lacked the soft-boundary caveat.</code>
- <code>`go test ./internal/agent ./internal/daemon -run &#39;TestWithSteering|TestWorktreeSteering|TestPushReceivedTracksRunTelemetry|TestPushReceivedSkipStepsConfiguresExecutor|TestPushReceivedDemoModeBypassesAgentResolution&#39; -count=1` after removing the temporary evidence test</code>

🔧 Fix: Add soft-boundary steering caveat
✅ Re-checked - no issues remain.
- `go test ./internal/agent -run 'TestWithSteering|TestWorktreeSteering' -count=1`
- <code>Temporary evidence-only daemon test via `NM_STEERING_EVIDENCE_PATH=&#34;/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01KSS1665PTKKYJRE921GVBT4P/daemon-agent-prompt.txt&#34; go test ./internal/daemon -run &#39;^TestEvidencePushReceivedSteersPipelineAgentPrompt$&#39; -count=1`</code>
- <code>Inspected `/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01KSS1665PTKKYJRE921GVBT4P/daemon-agent-prompt.txt` to confirm the actual daemon-launched agent prompt starts with the steering preamble and preserves the user prompt.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
