### PR TITLE
fix(agent): disable interactive git prompts

### DIFF
--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -129,6 +129,7 @@ All agents implement the same interface. Each invocation receives:
 
 - **Prompt** - the task description (review this diff, fix these findings, etc.), prefixed during pipeline runs with the workspace-boundary steering described above
 - **CWD** - the worktree directory
+- **Environment** - the daemon environment plus non-interactive Git overrides (`GIT_EDITOR=true`, `GIT_SEQUENCE_EDITOR=true`, and `GIT_TERMINAL_PROMPT=0`) so agent-invoked Git commands do not hang on editors or credential prompts
 - **JSONSchema** - optional structured output schema for typed responses
 - **OnChunk** - callback for streaming text output to the TUI
 

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -45,7 +45,7 @@ Fetches the latest upstream and rebases your branch onto it.
 - If the diff against the default branch is empty after rebase, completes rebase and skips all remaining pipeline steps
 - On conflict: records conflicting files, aborts the rebase, and reports findings
 
-**Auto-fix:** when enabled, the agent resolves conflict markers, stages files, and runs `git rebase --continue`. The prompt includes inferred user intent when available. Manual fix rounds also include any per-conflict user notes, any selected user-authored findings from the TUI, and sanitized prior-round history in the prompt. Commits use the message format `no-mistakes(rebase): <summary>`.
+**Auto-fix:** when enabled, the agent resolves conflict markers, stages files, and runs `git rebase --continue` in a non-interactive Git environment so Git accepts the existing commit message instead of opening an editor. The prompt includes inferred user intent when available. Manual fix rounds also include any per-conflict user notes, any selected user-authored findings from the TUI, and sanitized prior-round history in the prompt. Commits use the message format `no-mistakes(rebase): <summary>`.
 
 **Default auto-fix limit:** `3`.
 

--- a/internal/agent/acpx.go
+++ b/internal/agent/acpx.go
@@ -32,6 +32,7 @@ func (a *acpxAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) 
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD
 	cmd.Stdin = nil
+	cmd.Env = gitSafeEnv(opts.CWD)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -41,6 +41,7 @@ func (a *claudeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD
 	cmd.Stdin = nil
+	cmd.Env = gitSafeEnv(opts.CWD)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -59,6 +59,7 @@ func (a *codexAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error)
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD
 	cmd.Stdin = nil
+	cmd.Env = gitSafeEnv(opts.CWD)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/internal/agent/env.go
+++ b/internal/agent/env.go
@@ -1,0 +1,15 @@
+package agent
+
+import "github.com/kunchenguid/no-mistakes/internal/git"
+
+// gitSafeEnv returns the environment for a spawned agent subprocess with git
+// forced into non-interactive mode. Agents shell out to git directly (for
+// example `git rebase --continue` during conflict resolution), which would
+// otherwise open $EDITOR and hang in the headless subprocess until the agent
+// times out.
+//
+// dir must be the value assigned to cmd.Dir so PWD stays coupled to the working
+// directory; see git.NonInteractiveEnv for why this matters.
+func gitSafeEnv(dir string) []string {
+	return git.NonInteractiveEnv(dir)
+}

--- a/internal/agent/env_test.go
+++ b/internal/agent/env_test.go
@@ -1,0 +1,47 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func resolveAgentEnv(env []string) map[string]string {
+	m := map[string]string{}
+	for _, kv := range env {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok {
+			continue
+		}
+		m[k] = v
+	}
+	return m
+}
+
+func TestGitSafeEnv_DisablesInteractiveGit(t *testing.T) {
+	t.Setenv("GIT_EDITOR", "vim")
+
+	resolved := resolveAgentEnv(gitSafeEnv("/work/dir"))
+
+	if resolved["GIT_EDITOR"] != "true" {
+		t.Errorf("GIT_EDITOR = %q, want \"true\"", resolved["GIT_EDITOR"])
+	}
+	if resolved["GIT_SEQUENCE_EDITOR"] != "true" {
+		t.Errorf("GIT_SEQUENCE_EDITOR = %q, want \"true\"", resolved["GIT_SEQUENCE_EDITOR"])
+	}
+	if resolved["GIT_TERMINAL_PROMPT"] != "0" {
+		t.Errorf("GIT_TERMINAL_PROMPT = %q, want \"0\"", resolved["GIT_TERMINAL_PROMPT"])
+	}
+}
+
+// TestGitSafeEnv_CouplesPWDToWorkdir guards the regression where assigning
+// cmd.Env dropped os/exec's automatic PWD=cmd.Dir, making os.Getwd in the agent
+// report a symlink-resolved path instead of the worktree path.
+func TestGitSafeEnv_CouplesPWDToWorkdir(t *testing.T) {
+	t.Setenv("PWD", "/somewhere/else")
+
+	resolved := resolveAgentEnv(gitSafeEnv("/work/dir"))
+
+	if resolved["PWD"] != "/work/dir" {
+		t.Errorf("PWD = %q, want \"/work/dir\"", resolved["PWD"])
+	}
+}

--- a/internal/agent/env_test.go
+++ b/internal/agent/env_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -40,6 +41,13 @@ func TestGitSafeEnv_CouplesPWDToWorkdir(t *testing.T) {
 	t.Setenv("PWD", "/somewhere/else")
 
 	resolved := resolveAgentEnv(gitSafeEnv("/work/dir"))
+
+	if runtime.GOOS == "windows" || runtime.GOOS == "plan9" {
+		if resolved["PWD"] != "/somewhere/else" {
+			t.Errorf("PWD = %q, want ambient PWD on %s", resolved["PWD"], runtime.GOOS)
+		}
+		return
+	}
 
 	if resolved["PWD"] != "/work/dir" {
 		t.Errorf("PWD = %q, want \"/work/dir\"", resolved["PWD"])

--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -33,6 +33,7 @@ func (a *piAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 	args := a.buildArgs()
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD
+	cmd.Env = gitSafeEnv(opts.CWD)
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -75,6 +75,7 @@ func startServerWithPort(ctx context.Context, agentName, bin string, args []stri
 	cmd := exec.Command(bin, args...)
 	cmd.Dir = cwd
 	cmd.Stdin = nil
+	cmd.Env = gitSafeEnv(cwd)
 	out := currentManagedServerOutput()
 	cmd.Stdout = out // server stdout goes to the configured sink for debugging
 	cmd.Stderr = out

--- a/internal/git/env.go
+++ b/internal/git/env.go
@@ -1,0 +1,39 @@
+package git
+
+import (
+	"os"
+	"runtime"
+)
+
+// NonInteractiveEnv returns the environment for a subprocess that may invoke
+// git, with git forced into a fully non-interactive mode. It is intended for
+// cmd.Env on any subprocess that may run git (our own git calls and the coding
+// agents we spawn).
+//
+// Without these overrides, git operations such as `git rebase --continue` or
+// `git commit` open $EDITOR to confirm a commit message, and remote operations
+// can block on a credential prompt. In a headless agent subprocess there is no
+// TTY, so the editor or prompt hangs until the agent times out. Pointing the
+// editors at `true` makes git accept the existing message immediately, and
+// GIT_TERMINAL_PROMPT=0 fails fast instead of blocking on credentials. The
+// overrides are appended last so they win over any ambient values (exec
+// resolves duplicate keys using the last occurrence).
+//
+// Pass the same directory assigned to cmd.Dir (or "" when it is unset). When
+// cmd.Env is left nil, os/exec injects PWD=cmd.Dir automatically; assigning
+// cmd.Env disables that, so callers must thread the working directory through
+// here to preserve symlinked working-directory paths (for example /tmp vs
+// /private/tmp on macOS, which os.Getwd reports differently depending on PWD).
+func NonInteractiveEnv(dir string) []string {
+	env := append(os.Environ(),
+		"GIT_EDITOR=true",
+		"GIT_SEQUENCE_EDITOR=true",
+		"GIT_TERMINAL_PROMPT=0",
+	)
+	// Mirror os/exec, which only injects PWD when Cmd.Env is nil and skips it
+	// on these platforms.
+	if dir != "" && runtime.GOOS != "windows" && runtime.GOOS != "plan9" {
+		env = append(env, "PWD="+dir)
+	}
+	return env
+}

--- a/internal/git/env_test.go
+++ b/internal/git/env_test.go
@@ -1,0 +1,87 @@
+package git
+
+import (
+	"strings"
+	"testing"
+)
+
+// resolveEnv collapses a KEY=VALUE slice into a map using last-wins semantics,
+// matching how exec resolves duplicate keys.
+func resolveEnv(env []string) map[string]string {
+	m := make(map[string]string, len(env))
+	for _, kv := range env {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok {
+			continue
+		}
+		m[k] = v
+	}
+	return m
+}
+
+func TestNonInteractiveEnv_SetsGitOverrides(t *testing.T) {
+	got := resolveEnv(NonInteractiveEnv(""))
+
+	want := map[string]string{
+		"GIT_EDITOR":          "true",
+		"GIT_SEQUENCE_EDITOR": "true",
+		"GIT_TERMINAL_PROMPT": "0",
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("env %s = %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestNonInteractiveEnv_OverridesAmbientEditor(t *testing.T) {
+	t.Setenv("GIT_EDITOR", "vim")
+	t.Setenv("GIT_SEQUENCE_EDITOR", "nano")
+	t.Setenv("GIT_TERMINAL_PROMPT", "1")
+
+	got := resolveEnv(NonInteractiveEnv(""))
+
+	if got["GIT_EDITOR"] != "true" {
+		t.Errorf("GIT_EDITOR = %q, want \"true\" (ambient vim must be overridden)", got["GIT_EDITOR"])
+	}
+	if got["GIT_SEQUENCE_EDITOR"] != "true" {
+		t.Errorf("GIT_SEQUENCE_EDITOR = %q, want \"true\"", got["GIT_SEQUENCE_EDITOR"])
+	}
+	if got["GIT_TERMINAL_PROMPT"] != "0" {
+		t.Errorf("GIT_TERMINAL_PROMPT = %q, want \"0\"", got["GIT_TERMINAL_PROMPT"])
+	}
+}
+
+func TestNonInteractiveEnv_PreservesAmbientEnv(t *testing.T) {
+	t.Setenv("NM_ENV_PROBE_XYZ", "kept")
+
+	got := resolveEnv(NonInteractiveEnv(""))
+
+	if got["NM_ENV_PROBE_XYZ"] != "kept" {
+		t.Errorf("ambient env not preserved: NM_ENV_PROBE_XYZ = %q, want \"kept\"", got["NM_ENV_PROBE_XYZ"])
+	}
+}
+
+// TestNonInteractiveEnv_SetsPWDToDir locks in the PWD coupling. Assigning
+// cmd.Env disables os/exec's automatic PWD=Cmd.Dir injection, so the helper
+// must restore it; otherwise os.Getwd in the child resolves symlinks (e.g.
+// /tmp -> /private/tmp on macOS) and reports a different working directory.
+func TestNonInteractiveEnv_SetsPWDToDir(t *testing.T) {
+	t.Setenv("PWD", "/somewhere/else")
+
+	got := resolveEnv(NonInteractiveEnv("/work/dir"))
+
+	if got["PWD"] != "/work/dir" {
+		t.Errorf("PWD = %q, want \"/work/dir\"", got["PWD"])
+	}
+}
+
+func TestNonInteractiveEnv_EmptyDirLeavesAmbientPWD(t *testing.T) {
+	t.Setenv("PWD", "/ambient/pwd")
+
+	got := resolveEnv(NonInteractiveEnv(""))
+
+	if got["PWD"] != "/ambient/pwd" {
+		t.Errorf("PWD = %q, want ambient \"/ambient/pwd\" when dir is empty", got["PWD"])
+	}
+}

--- a/internal/git/env_test.go
+++ b/internal/git/env_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -70,6 +71,13 @@ func TestNonInteractiveEnv_SetsPWDToDir(t *testing.T) {
 	t.Setenv("PWD", "/somewhere/else")
 
 	got := resolveEnv(NonInteractiveEnv("/work/dir"))
+
+	if runtime.GOOS == "windows" || runtime.GOOS == "plan9" {
+		if got["PWD"] != "/somewhere/else" {
+			t.Errorf("PWD = %q, want ambient PWD on %s", got["PWD"], runtime.GOOS)
+		}
+		return
+	}
 
 	if got["PWD"] != "/work/dir" {
 		t.Errorf("PWD = %q, want \"/work/dir\"", got["PWD"])

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -25,6 +25,7 @@ func IsZeroSHA(sha string) bool {
 func Run(ctx context.Context, dir string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
+	cmd.Env = NonInteractiveEnv(dir)
 	out, err := cmd.Output()
 	if err != nil {
 		stderr := ""


### PR DESCRIPTION
## Intent

The developer wanted to prevent the rebase conflict-resolution step from hanging when git opens an interactive editor during git rebase --continue in a non-interactive agent subprocess. They requested the minimal env var fix: set non-interactive git environment variables such as GIT_EDITOR=true, GIT_SEQUENCE_EDITOR=true, and GIT_TERMINAL_PROMPT=0 for both the repository's own git commands and spawned agent processes. They expected the work to follow the repo's TDD convention, include tests, and verify that the fix did not regress agent execution behavior.

## What Changed

- Added shared non-interactive Git environment helpers that set `GIT_EDITOR=true`, `GIT_SEQUENCE_EDITOR=true`, and `GIT_TERMINAL_PROMPT=0` for repository Git commands.
- Applied the same non-interactive Git environment to spawned agent processes across the agent integrations.
- Documented the non-interactive Git environment behavior in the agent and pipeline step docs.

## Risk Assessment

✅ Low: The change is small and focused on adding non-interactive git environment variables to repository git commands and spawned agent processes, with helper tests covering override and PWD behavior.

## Testing

Targeted tests and the full Go suite passed; the first e2e attempt was terminated by the harness timeout, the rerun completed successfully, and the captured rebase transcript shows the hang-prone conflict-resolution path completing without editor interaction.

<details>
<summary>Evidence: Non-interactive rebase continue transcript</summary>

<code>$ git rebase main&#10;rebase stopped for conflict as expected&#10;$ GIT_EDITOR=true GIT_SEQUENCE_EDITOR=true GIT_TERMINAL_PROMPT=0 git rebase --continue&#10;rebase --continue completed without editor interaction&#10;$ git status --short&#10;?? fail-editor.sh&#10;$ git log --oneline -2&#10;851270b topic-change&#10;bf1cd67 main-change&#10;no editor invocation log was created</code>

```text
$ mkdir rebase-editor-check && cd rebase-editor-check
$ git rebase main
rebase stopped for conflict as expected
$ GIT_EDITOR=true GIT_SEQUENCE_EDITOR=true GIT_TERMINAL_PROMPT=0 git rebase --continue
rebase --continue completed without editor interaction
$ git status --short
?? fail-editor.sh
$ git log --oneline -2
851270b topic-change
bf1cd67 main-change
no editor invocation log was created
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/git ./internal/agent`
- <code>Manual evidence check: created a throwaway conflicting rebase repo under `/var/folders/0k/bf8mwt2n5qddzk24r20gfk0c0000gn/T/no-mistakes-evidence/01KT8GW8D61TR72JYEZRGRCSRV/rebase-editor-check`, resolved the conflict, and ran `GIT_EDITOR=true GIT_SEQUENCE_EDITOR=true GIT_TERMINAL_PROMPT=0 git rebase --continue` while checking no editor log was created</code>
- `go test ./...`
- <code>`make e2e` initially with a 120s tool timeout, then reran `make e2e` with a 420s timeout</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
