### PR TITLE
feat(pipeline): store test evidence in repos

### DIFF
--- a/docs/src/content/docs/concepts/pipeline.md
+++ b/docs/src/content/docs/concepts/pipeline.md
@@ -72,6 +72,7 @@ You can't reorder steps. You *can*:
 
 - Swap the agent (global or per-repo).
 - Set explicit `commands.test`, `commands.lint`, `commands.format`.
+- Store test evidence locally by default or opt into committed in-repo evidence with `test.evidence.store_in_repo`.
 - Control auto-fix limits per step.
 - Ignore paths during review and documentation checks.
 - Disable or tune transcript-based intent extraction.

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -14,7 +14,8 @@ when you leave prompts blank.
 
 Pipeline agent prompts also include a workspace-boundary preamble.
 It tells agents to keep intentional source, project, user-data, and system file writes inside the disposable worktree, avoid mutating system state such as Homebrew packages, `/Applications`, or global tool config, and treat that boundary as prompt steering rather than true enforcement.
-The only intentional out-of-worktree write it allows is test evidence under the managed temporary `no-mistakes-evidence` directory when a testing prompt asks for it; incidental temp or cache writes from normal development tools are still allowed.
+The only intentional out-of-worktree write it allows is test evidence under the managed temporary `no-mistakes-evidence` directory when a testing prompt asks for it; when in-repo evidence is enabled, test evidence stays inside the configured evidence directory instead.
+Incidental temp or cache writes from normal development tools are still allowed.
 Testing prompts also ask agents to remove transient working-tree artifacts they created, such as downloaded models, caches, build outputs, large binaries, or generated data directories, before reporting completion.
 
 ## How to choose quickly
@@ -27,6 +28,7 @@ That last point matters: the agent helps fill in gaps, but explicit repo
 commands are still the strongest way to make the baseline gate predictable.
 When user intent is available, the test step may still invoke the configured agent after `commands.test` succeeds to gather evidence that demonstrates the change.
 That testing invocation is expected to leave only intentional source or test-file changes in the worktree, while preserving requested evidence files under the dedicated evidence directory.
+By default that directory is temporary and local to the machine; repos can opt into committed evidence with `test.evidence.store_in_repo`.
 
 ## Supported agents
 

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -12,6 +12,7 @@ work. Config exists for the parts that genuinely vary by machine or repo:
 
 - which agent you prefer
 - which test or lint commands are the canonical ones for this repo
+- where test evidence artifacts should be stored
 - how aggressive the auto-fix loop should be
 - whether no-mistakes should infer intent from recent local agent transcripts
 
@@ -94,6 +95,12 @@ intent:
   threshold: 0.2
   slack_days: 3
   disabled_readers: []
+
+# Test evidence defaults to temporary local storage.
+test:
+  evidence:
+    store_in_repo: false
+    dir: .no-mistakes/evidence
 ```
 
 See [Global Config Reference](/no-mistakes/reference/global-config/) for the full field listing.
@@ -134,6 +141,12 @@ auto_fix:
 # Optional repo-level overrides for intent extraction.
 intent:
   enabled: true
+
+# Opt in when evidence artifacts should be committed and linked from the PR.
+test:
+  evidence:
+    store_in_repo: true
+    dir: .no-mistakes/evidence
 ```
 
 See [Repo Config Reference](/no-mistakes/reference/repo-config/) for the full field listing.
@@ -146,6 +159,7 @@ See [Repo Config Reference](/no-mistakes/reference/repo-config/) for the full fi
 - `agent_path_override`, `agent_args_override`, `acpx_path`, and `acp_registry_overrides` are global-only fields.
 - `auto_fix` from the repo config overlays global auto_fix. Fields not set in the repo config fall through to the global default.
 - `intent` from the repo config overlays global intent settings. Fields not set in the repo config fall through to the global default, except `intent.disabled_readers`, which adds to globally disabled readers.
+- `test.evidence` from the repo config overlays global test evidence settings. Fields not set in the repo config fall through to the global default.
 - `commands` and `ignore_patterns` are repo-only fields.
 - `ci_timeout` and `auto_fix.ci` are the canonical keys; `babysit_timeout` and `auto_fix.babysit` are still accepted as legacy aliases.
 - If `commands.test` is set, the test step runs it first as the baseline; when inferred user intent is available, the agent may still run afterward to gather evidence-oriented validation.
@@ -156,6 +170,7 @@ See [Repo Config Reference](/no-mistakes/reference/repo-config/) for the full fi
 The practical implication is simple: explicit commands give you deterministic
 baseline behavior, while leaving commands empty asks the agent to fill in the gap.
 For tests, inferred user intent can also trigger an evidence-oriented agent follow-up after the baseline command succeeds.
+By default, evidence stays in a temporary local directory; opt into `test.evidence.store_in_repo` when your team wants evidence artifacts committed, pushed, and linked directly from PRs.
 For lint, that gap includes safe formatter and linter fixes during the initial lint pass.
 
 ## Ignore pattern rules

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -115,7 +115,8 @@ Pipeline prompts steer agents to keep intentional writes inside the disposable w
 This reduces macOS App Management prompts from agent-invoked commands, but it is not an OS sandbox.
 
 If you still see prompts, check the step log for commands that intentionally write outside the worktree and move that setup into your normal development environment or an explicit repo-local command.
-Requested test evidence may still be written under the managed temporary `no-mistakes-evidence` directory, and normal tool temp or cache writes can still happen outside the worktree.
+Requested test evidence may still be written under the managed temporary `no-mistakes-evidence` directory, or under the configured in-repo evidence directory when `test.evidence.store_in_repo` is enabled.
+Normal tool temp or cache writes can still happen outside the worktree.
 Testing prompts ask agents to remove transient working-tree artifacts they created, such as downloaded models, caches, build outputs, large binaries, or generated data directories, before completion.
 
 ## A pipeline step failed

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -45,6 +45,11 @@ intent:
   threshold: 0.2
   slack_days: 3
   disabled_readers: []
+
+test:
+  evidence:
+    store_in_repo: false
+    dir: .no-mistakes/evidence
 ```
 
 ## Fields
@@ -237,6 +242,26 @@ For multi-file diffs, no-mistakes still requires at least two overlapping files 
 Partial matches older than 24 hours are rejected unless their raw score is at least `0.8`.
 If exactly one accepted candidate has a raw score of at least `0.85`, that decisive candidate wins before recency ranking.
 Otherwise, accepted candidates are ranked by confidence, which combines the raw score with a small recency boost, with ties going to the most recent matching session, and ambiguous accepted candidates may be disambiguated by the configured pipeline agent.
+
+### test.evidence
+
+Test-step evidence storage settings.
+By default, evidence artifacts stay in a temporary directory keyed by run ID and are referenced by local path.
+
+| | |
+|---|---|
+| Type | `object` |
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `test.evidence.store_in_repo` | `bool` | `false` | Commit and push test evidence artifacts from inside the repo worktree |
+| `test.evidence.dir` | `string` | `.no-mistakes/evidence` | Repo-relative parent directory used when `store_in_repo` is true |
+
+When `store_in_repo` is true, the test step writes evidence under `<dir>/<branch-slug>` and the push step stages files from that directory before committing agent changes.
+Branch slashes become nested directories, unsafe branch characters are replaced, and an empty branch slug falls back to the run ID.
+If `dir` is absolute, escapes the worktree, points into `.git`, crosses a symlink, or is ignored by Git, no-mistakes falls back to temporary evidence storage for that run.
+
+These are global defaults. Per-repo config can override either field.
 
 ## Environment variables
 

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -13,7 +13,7 @@ Each step can produce findings, request approval, trigger auto-fix, or apply saf
 In the TUI, yolo mode is an explicit override that auto-approves steps paused for approval or fix review.
 Every pipeline agent invocation is prompt-steered to keep intentional writes inside the run worktree and avoid mutating system state outside it.
 This is a soft boundary, not OS-level sandbox enforcement.
-The steering still allows requested test evidence under the managed temporary `no-mistakes-evidence` directory and incidental temp or cache writes from normal development tools.
+The steering still allows requested test evidence under the managed temporary `no-mistakes-evidence` directory or the configured in-repo evidence directory, plus incidental temp or cache writes from normal development tools.
 
 ## Intent
 
@@ -75,6 +75,7 @@ Runs baseline tests and gathers evidence for the intended behavior.
 - If `commands.test` is set in repo config: runs it first as a baseline via the platform shell (`sh -c` on POSIX, `cmd.exe /c` on Windows) and captures output. Non-zero exit produces `error` findings.
 - If `commands.test` is empty, or inferred user intent is available after the baseline command passes: the agent validates the change with evidence-oriented tests or manual checks, returning structured findings with severity, description, and `action` (`no-op`, `auto-fix`, `ask-user`). For UI, HTML, CSS, browser, visual layout, or copy-placement changes, the agent attempts reviewer-visible visual evidence and explains in `testing_summary` when screenshots, images, videos, GIFs, or rendered HTML artifacts are not captured.
 - The step records the exact tests and checks it exercised in a `tested` array, may include a short natural-language `testing_summary`, and includes an `artifacts` array for reviewer-visible evidence; `path` artifacts may be repository-relative paths or absolute paths under the temporary `no-mistakes-evidence/<runID>` directory, `url` artifacts must be externally visible, and `content` artifacts should be short logs or command output shown directly in the PR.
+- By default, evidence is stored under the temporary `no-mistakes-evidence/<runID>` directory. With `test.evidence.store_in_repo: true`, evidence is stored under `<test.evidence.dir>/<branch-slug>` inside the worktree, staged during push, and published with the branch. Unsafe, symlinked, or Git-ignored evidence directories fall back to temporary storage for that run.
 - Before finishing, test agents are instructed to remove transient working-tree artifacts they created, such as downloaded models, caches, build outputs, large binaries, or generated data directories, while preserving intentional source or test-file changes and evidence files under the dedicated evidence directory.
 - Missing evidence for inferred user intent can be reported as a warning with `action: ask-user`.
 - If the agent creates new test files (detected via `git status --porcelain`), approval is required even if tests pass.
@@ -124,6 +125,7 @@ Pushes the validated branch to the real upstream remote.
 
 **Behavior:**
 - If `commands.format` is set, runs it first
+- Stages in-repo test evidence artifacts when `test.evidence.store_in_repo` is enabled and the evidence directory is not ignored by Git
 - Commits any uncommitted agent changes with message `no-mistakes: apply agent fixes`
 - Queries upstream via `git ls-remote` to get the current SHA for the branch
 - Uses `--force-with-lease` when updating an existing branch (safe force-push that fails if the remote has diverged)

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -32,6 +32,11 @@ intent:
   threshold: 0.2
   slack_days: 3
   disabled_readers: []
+
+test:
+  evidence:
+    store_in_repo: true
+    dir: .no-mistakes/evidence
 ```
 
 ## Fields
@@ -141,3 +146,18 @@ Fields not set here inherit from global config and then the built-in defaults.
 | `intent.disabled_readers` | `string[]` | Adds to globally disabled readers |
 
 Valid `disabled_readers` values are `claude`, `codex`, `opencode`, `rovodev`, and `pi`.
+
+### test.evidence
+
+Override where evidence artifacts from the test step are stored.
+Fields not set here inherit from global config and then the built-in defaults.
+
+| Field | Type | Default |
+|---|---|---|
+| `test.evidence.store_in_repo` | `bool` | Inherits from global (default `false`) |
+| `test.evidence.dir` | `string` | Inherits from global (default `.no-mistakes/evidence`) |
+
+By default, test evidence stays in a temporary directory keyed by run ID and is referenced by local path.
+Set `store_in_repo: true` to write evidence under `<dir>/<branch-slug>` inside the worktree so push can commit and publish it with the branch.
+Branch slashes become nested directories, unsafe branch characters are replaced, and an empty branch slug falls back to the run ID.
+If `dir` is absolute, escapes the worktree, points into `.git`, crosses a symlink, or is ignored by Git, no-mistakes falls back to temporary evidence storage for that run.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,7 @@ type GlobalConfig struct {
 	LogLevel             string              `yaml:"log_level"`
 	AutoFix              AutoFixRaw
 	Intent               IntentRaw
+	Test                 TestRaw
 }
 
 // globalConfigRaw is the on-disk YAML representation with duration as string.
@@ -41,6 +42,7 @@ type globalConfigRaw struct {
 	LogLevel             string              `yaml:"log_level"`
 	AutoFix              AutoFixRaw          `yaml:"auto_fix"`
 	Intent               IntentRaw           `yaml:"intent"`
+	Test                 TestRaw             `yaml:"test"`
 }
 
 // RepoConfig represents .no-mistakes.yaml in a repo root.
@@ -50,6 +52,7 @@ type RepoConfig struct {
 	IgnorePatterns []string        `yaml:"ignore_patterns"`
 	AutoFix        AutoFixRaw      `yaml:"auto_fix"`
 	Intent         IntentRaw       `yaml:"intent"`
+	Test           TestRaw         `yaml:"test"`
 }
 
 // Commands holds optional per-repo command overrides.
@@ -95,6 +98,33 @@ type Config struct {
 	IgnorePatterns       []string
 	AutoFix              AutoFix
 	Intent               Intent
+	Test                 Test
+}
+
+// TestRaw is the YAML representation of test-step settings.
+type TestRaw struct {
+	Evidence EvidenceRaw `yaml:"evidence"`
+}
+
+// EvidenceRaw is the YAML representation of test-evidence settings.
+// Pointer fields distinguish "not set" (nil) from explicit zero/false values.
+type EvidenceRaw struct {
+	StoreInRepo *bool   `yaml:"store_in_repo"`
+	Dir         *string `yaml:"dir"`
+}
+
+// Test is the resolved test-step config.
+type Test struct {
+	Evidence Evidence
+}
+
+// Evidence is the resolved test-evidence config. When StoreInRepo is true, the
+// test step writes evidence artifacts into Dir (relative to the repo worktree)
+// so they are committed, pushed, and viewable directly on the PR. Otherwise
+// evidence stays in a temporary directory referenced only by local path.
+type Evidence struct {
+	StoreInRepo bool
+	Dir         string
 }
 
 // IntentRaw is the YAML representation of user-intent extraction settings.
@@ -168,6 +198,16 @@ intent:
   threshold: 0.2
   slack_days: 3
   # disabled_readers: [codex]
+
+# Test-step evidence artifacts (screenshots, recordings, logs the test step
+# gathers to demonstrate the change works). By default they are kept in a
+# temporary directory and referenced by local path. Opt in to store_in_repo to
+# commit them into the repo under a readable, branch-named directory so they are
+# pushed and render directly on the PR.
+# test:
+#   evidence:
+#     store_in_repo: true
+#     dir: .no-mistakes/evidence
 `
 
 // defaultBinary maps agent names to their default binary names.
@@ -439,6 +479,7 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 	}
 	cfg.AutoFix = raw.AutoFix
 	cfg.Intent = raw.Intent
+	cfg.Test = raw.Test
 
 	return cfg, nil
 }
@@ -517,6 +558,27 @@ func applyIntentOverrides(dst *Intent, src *IntentRaw) {
 	}
 }
 
+// testDefaults returns the default test-step settings. Evidence storage is
+// opt-in (off by default); when enabled it lands under .no-mistakes/evidence.
+func testDefaults() Test {
+	return Test{
+		Evidence: Evidence{
+			StoreInRepo: false,
+			Dir:         ".no-mistakes/evidence",
+		},
+	}
+}
+
+// applyTestOverrides applies non-nil raw values onto resolved defaults.
+func applyTestOverrides(dst *Test, src *TestRaw) {
+	if src.Evidence.StoreInRepo != nil {
+		dst.Evidence.StoreInRepo = *src.Evidence.StoreInRepo
+	}
+	if src.Evidence.Dir != nil && strings.TrimSpace(*src.Evidence.Dir) != "" {
+		dst.Evidence.Dir = strings.TrimSpace(*src.Evidence.Dir)
+	}
+}
+
 // autoFixDefaults returns the default auto-fix configuration.
 func autoFixDefaults() AutoFix {
 	return AutoFix{
@@ -583,6 +645,10 @@ func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 	applyIntentOverrides(&intent, &global.Intent)
 	applyIntentOverrides(&intent, &repo.Intent)
 
+	test := testDefaults()
+	applyTestOverrides(&test, &global.Test)
+	applyTestOverrides(&test, &repo.Test)
+
 	cfg := &Config{
 		Agent:                global.Agent,
 		ACPXPath:             global.ACPXPath,
@@ -595,6 +661,7 @@ func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 		IgnorePatterns:       repo.IgnorePatterns,
 		AutoFix:              af,
 		Intent:               intent,
+		Test:                 test,
 	}
 
 	if repo.Agent != "" {

--- a/internal/config/config_evidence_test.go
+++ b/internal/config/config_evidence_test.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTestEvidenceDefaults(t *testing.T) {
+	got := testDefaults()
+	if got.Evidence.StoreInRepo {
+		t.Error("default StoreInRepo should be false (opt-in)")
+	}
+	if got.Evidence.Dir != ".no-mistakes/evidence" {
+		t.Errorf("default Dir = %q, want .no-mistakes/evidence", got.Evidence.Dir)
+	}
+}
+
+func TestTestEvidenceMerge_GlobalEnable(t *testing.T) {
+	enabled := true
+	global := &GlobalConfig{Test: TestRaw{Evidence: EvidenceRaw{StoreInRepo: &enabled}}}
+	repo := &RepoConfig{}
+
+	cfg := Merge(global, repo)
+	if !cfg.Test.Evidence.StoreInRepo {
+		t.Error("global enable should propagate")
+	}
+	// Default dir preserved when not overridden.
+	if cfg.Test.Evidence.Dir != ".no-mistakes/evidence" {
+		t.Errorf("dir = %q, want default", cfg.Test.Evidence.Dir)
+	}
+}
+
+func TestTestEvidenceMerge_RepoOverridesGlobal(t *testing.T) {
+	enabled := true
+	disabled := false
+	dir := "docs/evidence"
+	global := &GlobalConfig{Test: TestRaw{Evidence: EvidenceRaw{StoreInRepo: &disabled}}}
+	repo := &RepoConfig{Test: TestRaw{Evidence: EvidenceRaw{StoreInRepo: &enabled, Dir: &dir}}}
+
+	cfg := Merge(global, repo)
+	if !cfg.Test.Evidence.StoreInRepo {
+		t.Error("repo enable should override global disable")
+	}
+	if cfg.Test.Evidence.Dir != "docs/evidence" {
+		t.Errorf("dir = %q, want docs/evidence", cfg.Test.Evidence.Dir)
+	}
+}
+
+func TestTestEvidenceMerge_BlankDirIgnored(t *testing.T) {
+	blank := "   "
+	repo := &RepoConfig{Test: TestRaw{Evidence: EvidenceRaw{Dir: &blank}}}
+
+	cfg := Merge(&GlobalConfig{}, repo)
+	if cfg.Test.Evidence.Dir != ".no-mistakes/evidence" {
+		t.Errorf("blank dir should fall back to default, got %q", cfg.Test.Evidence.Dir)
+	}
+}
+
+func TestLoadGlobalConfig_TestEvidenceParsed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	yaml := `
+agent: claude
+test:
+  evidence:
+    store_in_repo: true
+    dir: artifacts/evidence
+`
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cfg, err := LoadGlobal(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.Test.Evidence.StoreInRepo == nil || !*cfg.Test.Evidence.StoreInRepo {
+		t.Error("expected StoreInRepo=true")
+	}
+	if cfg.Test.Evidence.Dir == nil || *cfg.Test.Evidence.Dir != "artifacts/evidence" {
+		t.Error("expected Dir=artifacts/evidence")
+	}
+}
+
+func TestLoadRepoConfig_TestEvidenceParsed(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `
+test:
+  evidence:
+    store_in_repo: true
+`
+	if err := os.WriteFile(filepath.Join(dir, ".no-mistakes.yaml"), []byte(yaml), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cfg, err := LoadRepo(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.Test.Evidence.StoreInRepo == nil || !*cfg.Test.Evidence.StoreInRepo {
+		t.Error("expected repo StoreInRepo=true")
+	}
+}

--- a/internal/pipeline/steps/evidence.go
+++ b/internal/pipeline/steps/evidence.go
@@ -26,19 +26,29 @@ func testEvidenceDir(runID string) string {
 // and falls back to the temporary location so evidence can never be written
 // outside the worktree.
 func resolveTestEvidenceDir(workDir, branch, runID string, ev config.Evidence) string {
+	location := resolveTestEvidenceLocation(workDir, branch, runID, ev)
+	return location.Dir
+}
+
+type testEvidenceLocation struct {
+	Dir         string
+	StoreInRepo bool
+}
+
+func resolveTestEvidenceLocation(workDir, branch, runID string, ev config.Evidence) testEvidenceLocation {
 	if !ev.StoreInRepo {
-		return testEvidenceDir(runID)
+		return testEvidenceLocation{Dir: testEvidenceDir(runID)}
 	}
 	sub, ok := safeRepoSubdir(ev.Dir)
 	if !ok {
-		return testEvidenceDir(runID)
+		return testEvidenceLocation{Dir: testEvidenceDir(runID)}
 	}
 	segments := evidenceBranchSlug(branch)
 	if len(segments) == 0 {
 		segments = []string{runID}
 	}
 	parts := append([]string{workDir, sub}, segments...)
-	return filepath.Join(parts...)
+	return testEvidenceLocation{Dir: filepath.Join(parts...), StoreInRepo: true}
 }
 
 // safeRepoSubdir validates a configured evidence directory as a relative path

--- a/internal/pipeline/steps/evidence.go
+++ b/internal/pipeline/steps/evidence.go
@@ -63,6 +63,10 @@ func safeRepoSubdir(dir string) (string, bool) {
 	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
 		return "", false
 	}
+	first, _, _ := strings.Cut(clean, string(filepath.Separator))
+	if strings.EqualFold(first, ".git") {
+		return "", false
+	}
 	return clean, true
 }
 

--- a/internal/pipeline/steps/evidence.go
+++ b/internal/pipeline/steps/evidence.go
@@ -3,6 +3,9 @@ package steps
 import (
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/kunchenguid/no-mistakes/internal/config"
 )
 
 func testEvidenceRoot() string {
@@ -11,4 +14,80 @@ func testEvidenceRoot() string {
 
 func testEvidenceDir(runID string) string {
 	return filepath.Join(testEvidenceRoot(), runID)
+}
+
+// resolveTestEvidenceDir picks where the test step writes evidence artifacts.
+//
+// By default (opt-out), evidence lives in a temporary directory keyed by run ID
+// and is referenced only by local path. When the user opts in to storing
+// evidence in the repo, it instead lands under a readable, branch-named
+// directory inside the worktree so it is committed, pushed, and rendered
+// directly on the PR. An absolute or escaping configured directory is rejected
+// and falls back to the temporary location so evidence can never be written
+// outside the worktree.
+func resolveTestEvidenceDir(workDir, branch, runID string, ev config.Evidence) string {
+	if !ev.StoreInRepo {
+		return testEvidenceDir(runID)
+	}
+	sub, ok := safeRepoSubdir(ev.Dir)
+	if !ok {
+		return testEvidenceDir(runID)
+	}
+	segments := evidenceBranchSlug(branch)
+	if len(segments) == 0 {
+		segments = []string{runID}
+	}
+	parts := append([]string{workDir, sub}, segments...)
+	return filepath.Join(parts...)
+}
+
+// safeRepoSubdir validates a configured evidence directory as a relative path
+// that stays inside the repo worktree. It returns the cleaned, OS-native path
+// and false when the directory is empty, absolute, or escapes the worktree.
+func safeRepoSubdir(dir string) (string, bool) {
+	dir = strings.TrimSpace(dir)
+	if dir == "" || filepath.IsAbs(dir) {
+		return "", false
+	}
+	clean := filepath.Clean(filepath.FromSlash(dir))
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return clean, true
+}
+
+// evidenceBranchSlug turns a branch name into readable, filesystem-safe path
+// segments. Branch separators are preserved as nested directories; unsafe
+// characters are replaced with dashes and traversal segments are dropped.
+func evidenceBranchSlug(branch string) []string {
+	var segments []string
+	for _, raw := range strings.Split(branch, "/") {
+		seg := sanitizeEvidenceSegment(raw)
+		if seg == "" || seg == "." || seg == ".." {
+			continue
+		}
+		segments = append(segments, seg)
+	}
+	return segments
+}
+
+// sanitizeEvidenceSegment keeps alphanumerics, dash, underscore, and dot,
+// replacing every other rune with a dash, then collapses dash runs and trims
+// leading/trailing dashes.
+func sanitizeEvidenceSegment(s string) string {
+	s = strings.TrimSpace(s)
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_', r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	out := b.String()
+	for strings.Contains(out, "--") {
+		out = strings.ReplaceAll(out, "--", "-")
+	}
+	return strings.Trim(out, "-")
 }

--- a/internal/pipeline/steps/evidence.go
+++ b/internal/pipeline/steps/evidence.go
@@ -83,7 +83,7 @@ func repoPathHasSymlink(workDir, rel string) bool {
 // and false when the directory is empty, absolute, or escapes the worktree.
 func safeRepoSubdir(dir string) (string, bool) {
 	dir = strings.TrimSpace(dir)
-	if dir == "" || filepath.IsAbs(dir) {
+	if dir == "" || filepath.IsAbs(dir) || hasPathRootPrefix(dir) || hasWindowsDrivePrefix(dir) {
 		return "", false
 	}
 	clean := filepath.Clean(filepath.FromSlash(dir))
@@ -95,6 +95,18 @@ func safeRepoSubdir(dir string) (string, bool) {
 		return "", false
 	}
 	return clean, true
+}
+
+func hasPathRootPrefix(path string) bool {
+	return strings.HasPrefix(path, "/") || strings.HasPrefix(path, `\`)
+}
+
+func hasWindowsDrivePrefix(path string) bool {
+	if len(path) < 2 || path[1] != ':' {
+		return false
+	}
+	c := path[0]
+	return c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z'
 }
 
 // evidenceBranchSlug turns a branch name into readable, filesystem-safe path

--- a/internal/pipeline/steps/evidence.go
+++ b/internal/pipeline/steps/evidence.go
@@ -47,8 +47,35 @@ func resolveTestEvidenceLocation(workDir, branch, runID string, ev config.Eviden
 	if len(segments) == 0 {
 		segments = []string{runID}
 	}
-	parts := append([]string{workDir, sub}, segments...)
+	relParts := append([]string{sub}, segments...)
+	rel := filepath.Join(relParts...)
+	if repoPathHasSymlink(workDir, rel) {
+		return testEvidenceLocation{Dir: testEvidenceDir(runID)}
+	}
+	parts := append([]string{workDir}, relParts...)
 	return testEvidenceLocation{Dir: filepath.Join(parts...), StoreInRepo: true}
+}
+
+func repoPathHasSymlink(workDir, rel string) bool {
+	clean := filepath.Clean(rel)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) || filepath.IsAbs(clean) {
+		return true
+	}
+	current := workDir
+	for _, part := range strings.Split(clean, string(filepath.Separator)) {
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if os.IsNotExist(err) {
+			return false
+		}
+		if err != nil {
+			return true
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // safeRepoSubdir validates a configured evidence directory as a relative path

--- a/internal/pipeline/steps/evidence_test.go
+++ b/internal/pipeline/steps/evidence_test.go
@@ -54,6 +54,18 @@ func TestResolveTestEvidenceDir_UnsafeConfigDirFallsBackToTemp(t *testing.T) {
 	}
 }
 
+func TestSafeRepoSubdirRejectsWindowsDriveAbsolutePath(t *testing.T) {
+	if got, ok := safeRepoSubdir("C:/abs/evidence"); ok {
+		t.Fatalf("safeRepoSubdir accepted Windows absolute path as %q", got)
+	}
+}
+
+func TestSafeRepoSubdirRejectsWindowsRootedPath(t *testing.T) {
+	if got, ok := safeRepoSubdir(`\abs\evidence`); ok {
+		t.Fatalf("safeRepoSubdir accepted Windows rooted path as %q", got)
+	}
+}
+
 func TestResolveTestEvidenceDir_SymlinkConfigDirFallsBackToTemp(t *testing.T) {
 	workDir := t.TempDir()
 	externalDir := t.TempDir()

--- a/internal/pipeline/steps/evidence_test.go
+++ b/internal/pipeline/steps/evidence_test.go
@@ -45,7 +45,7 @@ func TestResolveTestEvidenceDir_EmptyBranchFallsBack(t *testing.T) {
 func TestResolveTestEvidenceDir_UnsafeConfigDirFallsBackToTemp(t *testing.T) {
 	// An absolute or escaping configured dir must not let evidence land outside
 	// the worktree; fall back to the temp directory instead.
-	for _, dir := range []string{"/abs/evidence", "../escape", "a/../../b"} {
+	for _, dir := range []string{"/abs/evidence", "../escape", "a/../../b", ".git", ".git/hooks"} {
 		got := resolveTestEvidenceDir("/work/tree", "feature/foo", "run-123", config.Evidence{StoreInRepo: true, Dir: dir})
 		want := filepath.Join(os.TempDir(), "no-mistakes-evidence", "run-123")
 		if got != want {

--- a/internal/pipeline/steps/evidence_test.go
+++ b/internal/pipeline/steps/evidence_test.go
@@ -53,3 +53,18 @@ func TestResolveTestEvidenceDir_UnsafeConfigDirFallsBackToTemp(t *testing.T) {
 		}
 	}
 }
+
+func TestResolveTestEvidenceDir_SymlinkConfigDirFallsBackToTemp(t *testing.T) {
+	workDir := t.TempDir()
+	externalDir := t.TempDir()
+	symlinkDir := filepath.Join(workDir, "evidence")
+	if err := os.Symlink(externalDir, symlinkDir); err != nil {
+		t.Skipf("create symlink: %v", err)
+	}
+
+	got := resolveTestEvidenceDir(workDir, "feature/foo", "run-123", config.Evidence{StoreInRepo: true, Dir: "evidence"})
+	want := filepath.Join(os.TempDir(), "no-mistakes-evidence", "run-123")
+	if got != want {
+		t.Errorf("symlink evidence dir = %q, want temp fallback %q", got, want)
+	}
+}

--- a/internal/pipeline/steps/evidence_test.go
+++ b/internal/pipeline/steps/evidence_test.go
@@ -1,0 +1,55 @@
+package steps
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/config"
+)
+
+func TestResolveTestEvidenceDir_DefaultUsesTempRunID(t *testing.T) {
+	got := resolveTestEvidenceDir("/work/tree", "feature/foo", "run-123", config.Evidence{StoreInRepo: false, Dir: ".no-mistakes/evidence"})
+	want := filepath.Join(os.TempDir(), "no-mistakes-evidence", "run-123")
+	if got != want {
+		t.Errorf("default dir = %q, want %q", got, want)
+	}
+}
+
+func TestResolveTestEvidenceDir_InRepoKeyedByBranch(t *testing.T) {
+	got := resolveTestEvidenceDir("/work/tree", "feature/add-login", "run-123", config.Evidence{StoreInRepo: true, Dir: ".no-mistakes/evidence"})
+	want := filepath.Join("/work/tree", ".no-mistakes", "evidence", "feature", "add-login")
+	if got != want {
+		t.Errorf("in-repo dir = %q, want %q", got, want)
+	}
+}
+
+func TestResolveTestEvidenceDir_SanitizesUnsafeBranch(t *testing.T) {
+	got := resolveTestEvidenceDir("/work/tree", "../../etc/pa ss~wd", "run-123", config.Evidence{StoreInRepo: true, Dir: "evidence"})
+	// Traversal segments dropped, spaces/unsafe chars replaced with dashes,
+	// result stays under <workdir>/evidence.
+	want := filepath.Join("/work/tree", "evidence", "etc", "pa-ss-wd")
+	if got != want {
+		t.Errorf("sanitized dir = %q, want %q", got, want)
+	}
+}
+
+func TestResolveTestEvidenceDir_EmptyBranchFallsBack(t *testing.T) {
+	got := resolveTestEvidenceDir("/work/tree", "///", "run-123", config.Evidence{StoreInRepo: true, Dir: "evidence"})
+	want := filepath.Join("/work/tree", "evidence", "run-123")
+	if got != want {
+		t.Errorf("empty-branch dir = %q, want %q", got, want)
+	}
+}
+
+func TestResolveTestEvidenceDir_UnsafeConfigDirFallsBackToTemp(t *testing.T) {
+	// An absolute or escaping configured dir must not let evidence land outside
+	// the worktree; fall back to the temp directory instead.
+	for _, dir := range []string{"/abs/evidence", "../escape", "a/../../b"} {
+		got := resolveTestEvidenceDir("/work/tree", "feature/foo", "run-123", config.Evidence{StoreInRepo: true, Dir: dir})
+		want := filepath.Join(os.TempDir(), "no-mistakes-evidence", "run-123")
+		if got != want {
+			t.Errorf("dir %q: got %q, want temp fallback %q", dir, got, want)
+		}
+	}
+}

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -2,6 +2,8 @@ package steps
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/git"
@@ -30,6 +32,9 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 	}
 
 	// Commit any uncommitted changes from agent fixes
+	if err := s.stageInRepoEvidence(sctx); err != nil {
+		return nil, err
+	}
 	status, _ := git.Run(ctx, sctx.WorkDir, "status", "--porcelain")
 	if strings.TrimSpace(status) != "" {
 		sctx.Log("committing agent changes...")
@@ -90,4 +95,37 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 
 	sctx.Log("pushed successfully")
 	return &pipeline.StepOutcome{}, nil
+}
+
+func (s *PushStep) stageInRepoEvidence(sctx *pipeline.StepContext) error {
+	ctx := sctx.Ctx
+	location := resolveTestEvidenceLocation(sctx.WorkDir, sctx.Run.Branch, sctx.Run.ID, sctx.Config.Test.Evidence)
+	if !location.StoreInRepo {
+		return nil
+	}
+	if !dirHasFiles(location.Dir) {
+		return nil
+	}
+	rel, err := filepath.Rel(sctx.WorkDir, location.Dir)
+	if err != nil || rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return nil
+	}
+	if _, err := git.Run(ctx, sctx.WorkDir, "add", "-f", "--", filepath.ToSlash(rel)); err != nil {
+		return fmt.Errorf("stage test evidence: %w", err)
+	}
+	return nil
+}
+
+func dirHasFiles(dir string) bool {
+	found := false
+	_ = filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || found {
+			return nil
+		}
+		if !d.IsDir() {
+			found = true
+		}
+		return nil
+	})
+	return found
 }

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -103,6 +103,9 @@ func (s *PushStep) stageInRepoEvidence(sctx *pipeline.StepContext) error {
 	if !location.StoreInRepo {
 		return nil
 	}
+	if gitIgnoresPath(ctx, sctx.WorkDir, location.Dir) {
+		return nil
+	}
 	if !dirHasFiles(location.Dir) {
 		return nil
 	}

--- a/internal/pipeline/steps/push_test.go
+++ b/internal/pipeline/steps/push_test.go
@@ -110,3 +110,34 @@ func TestPushStep_ForceAddsInRepoEvidenceArtifacts(t *testing.T) {
 		t.Fatalf("expected ignored evidence artifact to be pushed: %v", err)
 	}
 }
+
+func TestPushStep_DoesNotForceAddIgnoredEvidenceDirectory(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("evidence/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", ".gitignore")
+	gitCmd(t, dir, "commit", "-m", "ignore evidence")
+	headSHA = gitCmd(t, dir, "rev-parse", "HEAD")
+	evidenceDir := filepath.Join(dir, "evidence", "feature")
+	if err := os.MkdirAll(evidenceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(evidenceDir, "stale.png"), []byte("png"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Run.Branch = "feature"
+	sctx.Config.Test.Evidence = config.Evidence{StoreInRepo: true, Dir: "evidence"}
+
+	step := &PushStep{}
+	if err := step.stageInRepoEvidence(sctx); err != nil {
+		t.Fatal(err)
+	}
+	if status := gitStatusPorcelain(t, dir); status != "" {
+		t.Fatalf("ignored evidence directory was staged: %q", status)
+	}
+}

--- a/internal/pipeline/steps/push_test.go
+++ b/internal/pipeline/steps/push_test.go
@@ -60,3 +60,53 @@ func TestPushStep_ReconcilesStaleDatabaseHeadSHA(t *testing.T) {
 		t.Errorf("DB HeadSHA = %s, want %s", dbRun.HeadSHA, actualHeadSHA)
 	}
 }
+
+func TestPushStep_ForceAddsInRepoEvidenceArtifacts(t *testing.T) {
+	t.Parallel()
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("*.png\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	baseSHA := gitCmd(t, dir, "rev-parse", "main")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	evidenceDir := filepath.Join(dir, "evidence", "feature")
+	if err := os.MkdirAll(evidenceDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(evidenceDir, "checkout.png"), []byte("png"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "feature"
+	sctx.Config.Test.Evidence = config.Evidence{StoreInRepo: true, Dir: "evidence"}
+
+	step := &PushStep{}
+	if _, err := step.Execute(sctx); err != nil {
+		t.Fatal(err)
+	}
+
+	clone := t.TempDir()
+	gitCmd(t, clone, "clone", "--branch", "feature", upstream, ".")
+	if _, err := os.Stat(filepath.Join(clone, "evidence", "feature", "checkout.png")); err != nil {
+		t.Fatalf("expected ignored evidence artifact to be pushed: %v", err)
+	}
+}

--- a/internal/pipeline/steps/test.go
+++ b/internal/pipeline/steps/test.go
@@ -1,11 +1,15 @@
 package steps
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
+	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
@@ -14,6 +18,15 @@ import (
 type TestStep struct{}
 
 func (s *TestStep) Name() types.StepName { return types.StepTest }
+
+func gitIgnoresPath(ctx context.Context, workDir, target string) bool {
+	rel, err := filepath.Rel(workDir, target)
+	if err != nil || rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return false
+	}
+	_, err = git.Run(ctx, workDir, "check-ignore", "--quiet", "--", filepath.ToSlash(rel))
+	return err == nil
+}
 
 func (s *TestStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, error) {
 	ctx := sctx.Ctx
@@ -103,7 +116,12 @@ Previous test findings to address:
 
 	useEvidenceAgent := testCmd == "" || cleanedUserIntent(sctx) != ""
 	if useEvidenceAgent {
-		evidenceDir := resolveTestEvidenceDir(sctx.WorkDir, sctx.Run.Branch, sctx.Run.ID, sctx.Config.Test.Evidence)
+		evidenceLocation := resolveTestEvidenceLocation(sctx.WorkDir, sctx.Run.Branch, sctx.Run.ID, sctx.Config.Test.Evidence)
+		evidenceDir := evidenceLocation.Dir
+		if evidenceLocation.StoreInRepo && gitIgnoresPath(ctx, sctx.WorkDir, evidenceDir) {
+			evidenceLocation = testEvidenceLocation{Dir: testEvidenceDir(sctx.Run.ID)}
+			evidenceDir = evidenceLocation.Dir
+		}
 		if err := os.MkdirAll(evidenceDir, 0o755); err != nil {
 			return nil, fmt.Errorf("create test evidence dir: %w", err)
 		}
@@ -114,7 +132,7 @@ Previous test findings to address:
 		}
 		reassessHistory := executionContextPromptSection() + roundHistoryPromptSection(sctx) + userIntentPromptSection(sctx)
 		evidenceGuidance := fmt.Sprintf("- Write new evidence files into this temporary evidence directory: %s", evidenceDir)
-		if sctx.Config.Test.Evidence.StoreInRepo {
+		if evidenceLocation.StoreInRepo {
 			evidenceGuidance = fmt.Sprintf("- Write new evidence files into this in-repo evidence directory; it is committed and pushed automatically, so artifacts render directly on the PR: %s", evidenceDir)
 		}
 		configuredTestCommand := ""

--- a/internal/pipeline/steps/test.go
+++ b/internal/pipeline/steps/test.go
@@ -103,7 +103,7 @@ Previous test findings to address:
 
 	useEvidenceAgent := testCmd == "" || cleanedUserIntent(sctx) != ""
 	if useEvidenceAgent {
-		evidenceDir := testEvidenceDir(sctx.Run.ID)
+		evidenceDir := resolveTestEvidenceDir(sctx.WorkDir, sctx.Run.Branch, sctx.Run.ID, sctx.Config.Test.Evidence)
 		if err := os.MkdirAll(evidenceDir, 0o755); err != nil {
 			return nil, fmt.Errorf("create test evidence dir: %w", err)
 		}
@@ -113,6 +113,10 @@ Previous test findings to address:
 			sctx.Log("user intent available, asking agent to gather test evidence...")
 		}
 		reassessHistory := executionContextPromptSection() + roundHistoryPromptSection(sctx) + userIntentPromptSection(sctx)
+		evidenceGuidance := fmt.Sprintf("- Write new evidence files into this temporary evidence directory: %s", evidenceDir)
+		if sctx.Config.Test.Evidence.StoreInRepo {
+			evidenceGuidance = fmt.Sprintf("- Write new evidence files into this in-repo evidence directory; it is committed and pushed automatically, so artifacts render directly on the PR: %s", evidenceDir)
+		}
 		configuredTestCommand := ""
 		if testCmd != "" {
 			configuredTestCommand = fmt.Sprintf("\nConfigured test command already ran successfully as baseline: `%s`\n", testCmd)
@@ -136,7 +140,7 @@ Task:
 - Prefer screenshots, images, videos, GIFs, or rendered HTML artifacts that show the actual end-user surface.
 - DOM snapshots, selector assertions, and text-only render summaries are not substitutes for visual evidence when a rendered surface is available.
 - If a UI-facing change has no screenshot, image, video, GIF, or rendered HTML artifact, state why in testing_summary.
-- Write new evidence files into this temporary evidence directory: %s
+%s
 - Do not move, commit, or modify source files only to make evidence linkable. Record local evidence file paths exactly where you created them.
 - Only use command output as an artifact when that output directly demonstrates the end-user experience or requested behavior. Generic pass/fail, coverage, or clean-worktree output is not sufficient evidence.
 - Look for existing tests that would generate sufficient evidence. If they exist, run the smallest relevant set.
@@ -164,7 +168,7 @@ Rules:
 				baseSHA,
 				sctx.Run.HeadSHA,
 				configuredTestCommand,
-				evidenceDir,
+				evidenceGuidance,
 				reassessHistory,
 			),
 			CWD:        sctx.WorkDir,

--- a/internal/pipeline/steps/test_test.go
+++ b/internal/pipeline/steps/test_test.go
@@ -226,3 +226,64 @@ func TestTestStep_UserIntentRunsConfiguredCommandThenEvidenceAgent(t *testing.T)
 		t.Fatalf("expected baseline command and agent-tested evidence to be recorded, got %+v", findings.Tested)
 	}
 }
+
+func TestTestStep_InRepoEvidenceFallsBackWhenConfiguredDirEscapesWorktree(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			return &agent.Result{Output: json.RawMessage(`{"findings":[],"summary":"","tested":["manual evidence check"],"testing_summary":"checked evidence"}`)}, nil
+		},
+	}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.UserIntent = "Show users a success screen after checkout"
+	sctx.Config.Test.Evidence = config.Evidence{StoreInRepo: true, Dir: "../outside"}
+
+	step := &TestStep{}
+	if _, err := step.Execute(sctx); err != nil {
+		t.Fatal(err)
+	}
+
+	prompt := ag.calls[0].Prompt
+	wantDir := filepath.Join(os.TempDir(), "no-mistakes-evidence", sctx.Run.ID)
+	if !strings.Contains(prompt, "Write new evidence files into this temporary evidence directory: "+wantDir) {
+		t.Fatalf("expected temporary evidence guidance for unsafe in-repo dir, got:\n%s", prompt)
+	}
+	if strings.Contains(prompt, "in-repo evidence directory") || strings.Contains(prompt, "committed and pushed automatically") {
+		t.Fatalf("did not expect in-repo publishing promise for unsafe evidence dir, got:\n%s", prompt)
+	}
+}
+
+func TestTestStep_InRepoEvidenceFallsBackWhenEvidenceDirIsIgnored(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	if err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte("evidence/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			return &agent.Result{Output: json.RawMessage(`{"findings":[],"summary":"","tested":["manual evidence check"],"testing_summary":"checked evidence"}`)}, nil
+		},
+	}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.UserIntent = "Show users a success screen after checkout"
+	sctx.Config.Test.Evidence = config.Evidence{StoreInRepo: true, Dir: "evidence"}
+
+	step := &TestStep{}
+	if _, err := step.Execute(sctx); err != nil {
+		t.Fatal(err)
+	}
+
+	prompt := ag.calls[0].Prompt
+	wantDir := filepath.Join(os.TempDir(), "no-mistakes-evidence", sctx.Run.ID)
+	if !strings.Contains(prompt, "Write new evidence files into this temporary evidence directory: "+wantDir) {
+		t.Fatalf("expected temporary evidence guidance for ignored in-repo dir, got:\n%s", prompt)
+	}
+	if strings.Contains(prompt, "in-repo evidence directory") || strings.Contains(prompt, "committed and pushed automatically") {
+		t.Fatalf("did not expect in-repo publishing promise for ignored evidence dir, got:\n%s", prompt)
+	}
+}


### PR DESCRIPTION
## Intent

The developer wanted to investigate and then implement an opt-in configuration that stores test evidence artifacts inside the repository instead of only in local temp files, so they can be committed, pushed, and viewed directly from PRs. They accepted evidence accumulating for now and explicitly deferred cleanup/cap concerns. They wanted the in-repo evidence path keyed by a readable branch slug rather than only a run ID, while preserving the default behavior of temp-dir storage unless opted in. They also wanted the implementation to follow TDD and fit the existing config, test-step evidence, PR rendering, and push behavior.

## What Changed

- Added opt-in config for storing test evidence under a safe repository-relative directory, with branch-slug/run-based paths and fallback handling for non-publishable locations.
- Updated test and push pipeline steps to prompt agents for in-repo artifacts when enabled and force-stage publishable evidence so PR links resolve to committed files.
- Documented the new global and repo configuration options plus related pipeline, agent, and troubleshooting guidance.

## Risk Assessment

✅ Low: The change is well-scoped to opt-in test evidence storage and the latest fixes address the main publication, ignore-rule, and symlink escape risks without introducing a substantiated merge blocker.

## Testing

Inspected the target diff, ran focused evidence tests and the full affected config/steps package tests, captured a manual CLI transcript proving an ignored branch-slugged in-repo evidence artifact is committed, pushed, and visible in a cloned branch, and confirmed no transient worktree artifacts remained.

<details>
<summary>Evidence: In-repo evidence push transcript</summary>

<code>Shows `evidence/feat/in-repo-test-evidence/checkout.png` was ignored by `*.png`, force-added, committed, pushed, cloned from the feature branch, and verified as `artifact-present`.</code>

```text
Manual end-user evidence for opt-in in-repo test artifacts
Scenario: repository opts in with evidence dir evidence and branch feat/in-repo-test-evidence.

$ git init --bare upstream.git
Initialized empty Git repository in /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KTDMDVB1ASKFK3K5RF4K19V4/manual-in-repo-evidence/upstream.git/

$ git init repo && configure user
Initialized empty Git repository in /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KTDMDVB1ASKFK3K5RF4K19V4/manual-in-repo-evidence/repo/.git/
Switched to a new branch 'main'
[main (root-commit) d395862] initial
 2 files changed, 2 insertions(+)
 create mode 100644 .gitignore
 create mode 100644 init.txt
To /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KTDMDVB1ASKFK3K5RF4K19V4/manual-in-repo-evidence/upstream.git
 * [new branch]      main -> main

$ git checkout -b feat/in-repo-test-evidence
Switched to a new branch 'feat/in-repo-test-evidence'

$ git status --short --ignored evidence/feat/in-repo-test-evidence/checkout.png
!! evidence/feat/in-repo-test-evidence/checkout.png

$ git add -f -- evidence/feat/in-repo-test-evidence

$ git status --short
A  evidence/feat/in-repo-test-evidence/checkout.png
[feat/in-repo-test-evidence df9d388] no-mistakes: apply agent fixes
 1 file changed, 1 insertion(+)
 create mode 100644 evidence/feat/in-repo-test-evidence/checkout.png
To /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KTDMDVB1ASKFK3K5RF4K19V4/manual-in-repo-evidence/upstream.git
 * [new branch]      feat/in-repo-test-evidence -> feat/in-repo-test-evidence

$ git clone --branch feat/in-repo-test-evidence upstream.git clone
Cloning into '/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KTDMDVB1ASKFK3K5RF4K19V4/manual-in-repo-evidence/clone'...
done.

$ git ls-tree --name-only HEAD evidence/feat/in-repo-test-evidence
evidence/feat/in-repo-test-evidence

$ test -f evidence/feat/in-repo-test-evidence/checkout.png && printf artifact-present
artifact-present
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (3) ✅</summary>

- ⚠️ `internal/pipeline/steps/test.go:118` - The in-repo evidence prompt promises artifacts are committed and pushed, but the later push step stages with plain `git add -A`, which will skip artifacts under an ignored evidence directory. In that case PR rendering can still convert absolute in-repo artifact paths into GitHub links even though the files were never committed, producing broken evidence links. Check the resolved evidence directory with git ignore rules and either force-add that directory or fall back/report clearly before asking the agent to write artifacts there.
- ⚠️ `internal/pipeline/steps/test.go:117` - The guidance switches to &#34;in-repo evidence&#34; based only on `StoreInRepo`, even though `resolveTestEvidenceDir` can fall back to the temp directory when the configured dir is absolute or escapes the worktree. A bad config therefore tells the agent the artifacts will be committed and rendered on the PR while they are actually local temp artifacts. Base the message on whether the resolved directory is inside the worktree, or return that decision from the resolver.

🔧 Fix: Fix evidence directory publication fallback
2 warnings still open:
- ⚠️ `internal/pipeline/steps/test.go:121` - The ignored-path fallback only checks the evidence directory path before the agent writes artifacts, so common ignore rules that match files inside that directory, such as `*.png`, `*.gif`, or `*.log`, still let the prompt promise the artifacts are committed while `git add -A` later skips them. Force-add the dedicated evidence directory when in-repo evidence is enabled, or verify/stage the produced files with ignore handling after the agent returns.
- ⚠️ `internal/pipeline/steps/evidence.go:62` - `safeRepoSubdir` accepts reserved Git paths like `.git/hooks`, which can make the test agent write evidence into Git internals instead of tracked worktree files and can also create misleading PR artifact links that will never exist in the pushed commit. Reject `.git` as the configured evidence directory and any path below it before treating the location as publishable in-repo evidence.

🔧 Fix: Harden in-repo evidence publishing
2 warnings still open:
- ⚠️ `internal/pipeline/steps/push.go:102` - `stageInRepoEvidence` recomputes the configured in-repo location but does not repeat the test step&#39;s ignored-directory fallback. If the configured evidence directory is ignored, the test prompt correctly falls back to temp evidence, but the later push step will still `git add -f` any existing files under the ignored in-repo directory and commit/push them, which can publish stale or intentionally ignored artifacts. Gate staging with the same publishability check used by the test step, or persist the resolved evidence location decision from the test step.
- ⚠️ `internal/pipeline/steps/evidence.go:50` - The in-repo evidence path is only checked lexically before being joined to the worktree. If the configured directory, or any parent component below the worktree, is a symlink to an external location, `os.MkdirAll` in the test step can follow it and write evidence outside the repository while the prompt still promises in-repo committed artifacts. Resolve existing path components after directory creation or reject symlinked evidence roots before treating the location as publishable.

🔧 Fix: Harden in-repo evidence publication
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --name-only 4a570eb558f5d57f16275adebe8cec65765e5ddc..7e04f7dd2a4d0b649e0ef83a4f6a68ed0bd0dc07`
- `go test ./internal/config ./internal/pipeline/steps -run 'Test(TestEvidence|ResolveTestEvidenceDir|TestStep_.*Evidence|PushStep_.*Evidence)' -count=1 -v`
- <code>Manual git evidence simulation recorded to `/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KTDMDVB1ASKFK3K5RF4K19V4/in-repo-evidence-transcript.txt`</code>
- `go test ./internal/config ./internal/pipeline/steps -count=1`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
