### PR TITLE
fix(update): warn before updating with active runs

### DIFF
--- a/.no-mistakes/evidence/fix/update-active-run-warning/active-run-update-warning-transcript.txt
+++ b/.no-mistakes/evidence/fix/update-active-run-warning/active-run-update-warning-transcript.txt
@@ -1,0 +1,21 @@
+$ no-mistakes update
+stderr:
+warning: update will restart the daemon while 2 active pipeline runs are in progress
+active pipeline runs:
+  01KTG6BHNSBP6FSD2R7SGP6N55  running  feature-b  bbb22222
+  01KTG6BHNSBP6FSD2R7R2XYQGR  pending  feature-a  aaa11111
+continuing can cause these pipelines to fail
+Continue with update and restart the daemon? [y/N] exit error: update cancelled because 2 active pipeline runs are in progress
+
+$ no-mistakes update -y
+stdout:
+updated no-mistakes from v1.2.2 to v1.2.3
+stderr:
+warning: update will restart the daemon while 2 active pipeline runs are in progress
+active pipeline runs:
+  01KTG6BHP1M5HEA3HKDK7H5FT9  running  feature-b  bbb22222
+  01KTG6BHP05BVDC565E6TQW9V1  pending  feature-a  aaa11111
+continuing can cause these pipelines to fail
+continuing because -y was provided
+exit: 0
+

--- a/docs/src/content/docs/concepts/daemon.md
+++ b/docs/src/content/docs/concepts/daemon.md
@@ -51,7 +51,12 @@ no-mistakes rerun
 no-mistakes update
 ```
 
-`no-mistakes update` stops and starts the daemon when it is running, or when stale daemon artifacts exist, so the new executable is used. It prefers the managed service path and falls back to a detached daemon if service startup is unavailable or fails. If the daemon is already running from a different executable path, update prompts before replacing it; pass `-y` or `--yes` to confirm without prompting. If the daemon executable path cannot be determined, the update aborts before replacing anything.
+`no-mistakes update` stops and starts the daemon when it is running, or when stale daemon artifacts exist, so the new executable is used.
+It prefers the managed service path and falls back to a detached daemon if service startup is unavailable or fails.
+If pending or running pipeline runs exist, update warns that restarting the daemon can cause those runs to fail and prompts before continuing.
+If the daemon is already running from a different executable path, update prompts before replacing it.
+Pass `-y` or `--yes` to continue through update safety prompts while still printing warnings.
+If the daemon executable path cannot be determined, the update aborts before replacing anything.
 
 The daemon writes an identity record to `~/.no-mistakes/daemon.pid` and listens on a Unix socket at `~/.no-mistakes/socket`. On Windows, it uses a localhost TCP listener and a protected endpoint file at the same path.
 

--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -102,18 +102,15 @@ A long-running background process that manages pipeline runs. It:
 - Persists state to SQLite
 - Streams events to connected TUI clients via IPC
 
-The installer prefers setting up the daemon as a managed background service, and
-`no-mistakes`, `init`, `attach`, `rerun`, and `update` make sure the daemon is
-running when needed. Bare `no-mistakes` then attaches to the active run on the
-current branch when one exists, or routes to the setup wizard when it needs to
-create a new branch/run. If managed service install or startup is unavailable
-or fails, startup falls back to a detached daemon process. `update` resets the
-daemon after replacing the binary when the daemon is running or stale daemon
-artifacts exist. If the daemon is already running from a different executable
-path, `update` prompts before replacing it, and `-y` / `--yes` confirms without
-prompting. If the daemon executable path cannot be determined, `update` aborts
-before replacing anything. You can also manage it explicitly with `no-mistakes
-daemon start|stop|restart|status`.
+The installer prefers setting up the daemon as a managed background service, and `no-mistakes`, `init`, `attach`, `rerun`, and `update` make sure the daemon is running when needed.
+Bare `no-mistakes` then attaches to the active run on the current branch when one exists, or routes to the setup wizard when it needs to create a new branch/run.
+If managed service install or startup is unavailable or fails, startup falls back to a detached daemon process.
+`update` resets the daemon after replacing the binary when the daemon is running or stale daemon artifacts exist.
+If pending or running pipeline runs exist, `update` warns that restarting the daemon can cause those runs to fail and prompts before continuing.
+If the daemon is already running from a different executable path, `update` prompts before replacing it.
+The `-y` / `--yes` flag continues through update safety prompts while still printing warnings.
+If the daemon executable path cannot be determined, `update` aborts before replacing anything.
+You can also manage it explicitly with `no-mistakes daemon start|stop|restart|status`.
 
 On startup, the daemon recovers from crashes by marking any stuck runs as failed, reaping orphaned managed agent servers, cleaning up orphaned worktrees, refreshing legacy no-mistakes-managed `post-receive` hooks, enabling push options for older gate repos, and reapplying gate hook-path isolation when Git supports `config --worktree`.
 

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -66,9 +66,11 @@ If you have multiple installs with different `NM_HOME` roots, each gets its own 
 
 ## `no-mistakes update` prompts or aborts
 
-Symptom: `update` says the daemon is running from a different executable path, or aborts because the daemon executable path cannot be determined.
+Symptom: `update` warns about active pipeline runs, says the daemon is running from a different executable path, or aborts because the daemon executable path cannot be determined.
 
-When the running daemon uses a different binary, `update` prompts before replacing it. Pass `no-mistakes update -y` to confirm non-interactively.
+When pending or running pipeline runs exist, `update` warns that restarting the daemon can cause those runs to fail and prompts before continuing.
+When the running daemon uses a different binary, `update` prompts before replacing it.
+Pass `no-mistakes update -y` to confirm non-interactively while still printing warnings.
 
 If the daemon executable path can't be determined at all (stale PID, permissions), the update aborts before replacing anything.
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -138,7 +138,15 @@ no-mistakes update --beta
 no-mistakes update -y
 ```
 
-Downloads the latest release, verifies the SHA-256 checksum, atomically replaces the running binary, and resets the daemon when it is running or stale daemon artifacts exist so the new executable is picked up, preferring the managed service path and falling back to a detached daemon if service startup is unavailable or fails. By default this installs the latest stable release. Pass `--beta` to include prereleases and install the latest beta when one is newer than the current stable release. If the daemon is running from a different executable path, update prompts before replacing it; pass `-y` or `--yes` to replace that daemon without prompting. If the daemon executable path cannot be determined, the update aborts before replacement. If the daemon does not come back cleanly after a successful replacement, the command reports that failure. On macOS, removes the quarantine extended attribute.
+Downloads the latest release, verifies the SHA-256 checksum, atomically replaces the running binary, and resets the daemon when it is running or stale daemon artifacts exist so the new executable is picked up, preferring the managed service path and falling back to a detached daemon if service startup is unavailable or fails.
+By default this installs the latest stable release.
+Pass `--beta` to include prereleases and install the latest beta when one is newer than the current stable release.
+If pending or running pipeline runs exist, update warns that restarting the daemon can cause those runs to fail, prints each active run's ID, status, branch, and short head SHA, and prompts before continuing.
+If the daemon is running from a different executable path, update prompts before replacing it.
+Pass `-y` or `--yes` to continue through update safety prompts while still printing warnings.
+If the daemon executable path cannot be determined, the update aborts before replacement.
+If the daemon does not come back cleanly after a successful replacement, the command reports that failure.
+On macOS, removes the quarantine extended attribute.
 
 Because `update` installs the latest official release binary, the replacement binary includes the default self-hosted telemetry host and website ID. Disable telemetry with `NO_MISTAKES_TELEMETRY=0`, or override the host and website ID with `NO_MISTAKES_UMAMI_HOST` and `NO_MISTAKES_UMAMI_WEBSITE_ID`.
 

--- a/docs/src/content/docs/start-here/installation.md
+++ b/docs/src/content/docs/start-here/installation.md
@@ -68,11 +68,17 @@ no-mistakes update -y
 
 This downloads the latest release from GitHub, verifies the SHA-256 checksum, atomically replaces the binary, and resets the daemon so it picks up the new executable. It prefers the managed service path and falls back to a detached daemon if service startup is unavailable or fails.
 
-`no-mistakes update` installs the latest stable release. Use `no-mistakes update --beta` to opt into prereleases and install the latest beta when one is newer than the current stable release. Use `no-mistakes update -y` to replace a daemon started from a different binary without prompting.
+`no-mistakes update` installs the latest stable release.
+Use `no-mistakes update --beta` to opt into prereleases and install the latest beta when one is newer than the current stable release.
+Use `no-mistakes update -y` to answer yes to update safety prompts.
 
 Because `update` installs the latest official release binary, it installs a binary with the default self-hosted telemetry host and website ID. Disable telemetry with `NO_MISTAKES_TELEMETRY=0`, or override the host and website ID with `NO_MISTAKES_UMAMI_HOST` and `NO_MISTAKES_UMAMI_WEBSITE_ID`.
 
-If the running daemon was started from a different binary, the update prompts before replacing it. If the daemon executable path cannot be determined, the update aborts before replacing the binary. If the daemon does not come back cleanly after a successful replacement, the new binary stays installed but the command reports the daemon reset failure.
+If pending or running pipeline runs exist, the update warns that restarting the daemon can cause those runs to fail, prints each active run's ID, status, branch, and short head SHA, and prompts before continuing.
+If the running daemon was started from a different binary, the update prompts before replacing it.
+Pass `-y` or `--yes` to continue through these prompts while still printing warnings.
+If the daemon executable path cannot be determined, the update aborts before replacing the binary.
+If the daemon does not come back cleanly after a successful replacement, the new binary stays installed but the command reports the daemon reset failure.
 
 Background update checks run automatically on each CLI invocation (except `update` itself). Suppress with `NO_MISTAKES_NO_UPDATE_CHECK=1`.
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -19,6 +19,6 @@ func newUpdateCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&beta, "beta", false, "install the latest release including prereleases")
-	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "replace a daemon started by another no-mistakes binary without prompting")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "answer yes to update safety prompts")
 	return cmd
 }

--- a/internal/db/run.go
+++ b/internal/db/run.go
@@ -118,6 +118,28 @@ func (d *DB) GetActiveRun(repoID, branch string) (*Run, error) {
 	return r, nil
 }
 
+// GetActiveRuns returns all pending or running runs across all repos, newest first.
+func (d *DB) GetActiveRuns() ([]*Run, error) {
+	rows, err := d.sql.Query(
+		`SELECT `+runColumns+` FROM runs WHERE status IN (?, ?) ORDER BY created_at DESC, id DESC`,
+		types.RunPending, types.RunRunning,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get active runs: %w", err)
+	}
+	defer rows.Close()
+
+	var runs []*Run
+	for rows.Next() {
+		r := &Run{}
+		if err := scanRun(rows, r); err != nil {
+			return nil, fmt.Errorf("scan run: %w", err)
+		}
+		runs = append(runs, r)
+	}
+	return runs, rows.Err()
+}
+
 // UpdateRunStatus updates a run's status and updated_at timestamp.
 func (d *DB) UpdateRunStatus(id string, status types.RunStatus) error {
 	_, err := d.sql.Exec(`UPDATE runs SET status = ?, updated_at = ? WHERE id = ?`, status, now(), id)

--- a/internal/db/run_test.go
+++ b/internal/db/run_test.go
@@ -137,6 +137,58 @@ func TestActiveRunStrictBranchMatch(t *testing.T) {
 	}
 }
 
+func TestActiveRunsAcrossRepos(t *testing.T) {
+	d := openTestDB(t)
+	repoA, _ := d.InsertRepo("/home/user/project-a", "git@github.com:user/project-a.git", "main")
+	repoB, _ := d.InsertRepo("/home/user/project-b", "git@github.com:user/project-b.git", "main")
+
+	pendingRun, _ := d.InsertRun(repoA.ID, "feature-a", "aaa", "000")
+	runningRun, _ := d.InsertRun(repoB.ID, "feature-b", "bbb", "000")
+	if err := d.UpdateRunStatus(runningRun.ID, types.RunRunning); err != nil {
+		t.Fatalf("mark running: %v", err)
+	}
+	completedRun, _ := d.InsertRun(repoA.ID, "done", "ccc", "000")
+	if err := d.UpdateRunStatus(completedRun.ID, types.RunCompleted); err != nil {
+		t.Fatalf("mark completed: %v", err)
+	}
+	failedRun, _ := d.InsertRun(repoB.ID, "failed", "ddd", "000")
+	if err := d.UpdateRunStatus(failedRun.ID, types.RunFailed); err != nil {
+		t.Fatalf("mark failed: %v", err)
+	}
+	cancelledRun, _ := d.InsertRun(repoB.ID, "cancelled", "eee", "000")
+	if err := d.UpdateRunStatus(cancelledRun.ID, types.RunCancelled); err != nil {
+		t.Fatalf("mark cancelled: %v", err)
+	}
+
+	runs, err := d.GetActiveRuns()
+	if err != nil {
+		t.Fatalf("get active runs: %v", err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("got %d active runs, want 2", len(runs))
+	}
+
+	got := map[string]types.RunStatus{}
+	for _, run := range runs {
+		got[run.ID] = run.Status
+	}
+	if got[pendingRun.ID] != types.RunPending {
+		t.Fatalf("pending run missing from active runs: %#v", got)
+	}
+	if got[runningRun.ID] != types.RunRunning {
+		t.Fatalf("running run missing from active runs: %#v", got)
+	}
+	if _, ok := got[completedRun.ID]; ok {
+		t.Fatal("completed run should not be active")
+	}
+	if _, ok := got[failedRun.ID]; ok {
+		t.Fatal("failed run should not be active")
+	}
+	if _, ok := got[cancelledRun.ID]; ok {
+		t.Fatal("cancelled run should not be active")
+	}
+}
+
 func TestUpdateRunStatus(t *testing.T) {
 	d := openTestDB(t)
 	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")

--- a/internal/update/active_runs.go
+++ b/internal/update/active_runs.go
@@ -1,0 +1,86 @@
+package update
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/kunchenguid/no-mistakes/internal/db"
+)
+
+func (u *updater) confirmActiveRunsBeforeUpdate() error {
+	runs, err := u.activeRuns()
+	if err != nil {
+		return fmt.Errorf("check active pipeline runs: %w", err)
+	}
+	if len(runs) == 0 {
+		return nil
+	}
+
+	u.writeActiveRunWarning(runs)
+	if u.assumeYes {
+		fmt.Fprintln(u.stderrWriter(), "continuing because -y was provided")
+		return nil
+	}
+
+	fmt.Fprint(u.stderrWriter(), "Continue with update and restart the daemon? [y/N] ")
+	if readYes(u.stdin) {
+		return nil
+	}
+	return fmt.Errorf("update cancelled because %d active pipeline runs are in progress", len(runs))
+}
+
+func (u *updater) activeRuns() ([]*db.Run, error) {
+	if u == nil || u.paths == nil {
+		return nil, nil
+	}
+	dbPath := u.paths.DB()
+	if _, err := os.Stat(dbPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat database: %w", err)
+	}
+
+	database, err := db.Open(dbPath)
+	if err != nil {
+		return nil, err
+	}
+	defer database.Close()
+	return database.GetActiveRuns()
+}
+
+func (u *updater) writeActiveRunWarning(runs []*db.Run) {
+	runWord := "runs"
+	if len(runs) == 1 {
+		runWord = "run"
+	}
+	fmt.Fprintf(u.stderrWriter(), "warning: update will restart the daemon while %d active pipeline %s are in progress\n", len(runs), runWord)
+	fmt.Fprintln(u.stderrWriter(), "active pipeline runs:")
+	for _, run := range runs {
+		fmt.Fprintf(u.stderrWriter(), "  %s  %s  %s  %s\n", run.ID, run.Status, run.Branch, shortRunSHA(run.HeadSHA))
+	}
+	fmt.Fprintln(u.stderrWriter(), "continuing can cause these pipelines to fail")
+}
+
+func shortRunSHA(sha string) string {
+	if len(sha) <= 8 {
+		return sha
+	}
+	return sha[:8]
+}
+
+func readYes(input io.Reader) bool {
+	if input == nil {
+		input = os.Stdin
+	}
+	response, err := bufio.NewReader(input).ReadString('\n')
+	if err != nil && response == "" {
+		return false
+	}
+	answer := strings.ToLower(strings.TrimSpace(response))
+	return answer == "y" || answer == "yes"
+}

--- a/internal/update/daemon.go
+++ b/internal/update/daemon.go
@@ -1,7 +1,6 @@
 package update
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"os"
@@ -61,16 +60,7 @@ func (u *updater) confirmDaemonTakeover(runningPath, currentPath string) bool {
 
 	fmt.Fprintf(u.stderrWriter(), "daemon is running from %s, but update is running from %s\n", runningPath, currentPath)
 	fmt.Fprint(u.stderrWriter(), "Replace the running daemon with this binary? [y/N] ")
-	input := u.stdin
-	if input == nil {
-		input = os.Stdin
-	}
-	response, err := bufio.NewReader(input).ReadString('\n')
-	if err != nil && response == "" {
-		return false
-	}
-	answer := strings.ToLower(strings.TrimSpace(response))
-	return answer == "y" || answer == "yes"
+	return readYes(u.stdin)
 }
 
 func executablePathsMatch(a, b string) bool {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -201,6 +201,9 @@ func (u *updater) run(ctx context.Context) error {
 		fmt.Fprintf(u.stdoutWriter(), "%s is already up to date (%s)\n", u.appName, u.currentVersion)
 		return nil
 	}
+	if err := u.confirmActiveRunsBeforeUpdate(); err != nil {
+		return err
+	}
 	if err := u.ensureDaemonUsesCurrentExecutable(); err != nil {
 		return err
 	}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -15,7 +15,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
 func TestUpdaterCheckLatestAndRefreshCache(t *testing.T) {
@@ -210,6 +212,125 @@ func TestUpdaterRunResetsDaemonAfterUpdate(t *testing.T) {
 	}
 	if !resetCalled {
 		t.Fatal("expected daemon reset after successful update")
+	}
+}
+
+func TestUpdaterRunWarnsAndRequiresConfirmationForActiveRuns(t *testing.T) {
+	allowInsecureDownloads = true
+	t.Cleanup(func() { allowInsecureDownloads = false })
+
+	archiveName := "no-mistakes-v1.2.3-darwin-arm64.tar.gz"
+	archive := makeTarGz(t, map[string][]byte{
+		"bin/no-mistakes": []byte("new-binary"),
+	})
+	sum := sha256.Sum256(archive)
+	checksums := fmt.Sprintf("%s  %s\n", hex.EncodeToString(sum[:]), archiveName)
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/kunchenguid/no-mistakes/releases/latest":
+			fmt.Fprintf(w, `{"tag_name":"v1.2.3","assets":[{"name":%q,"browser_download_url":%q},{"name":"checksums.txt","browser_download_url":%q}]}`,
+				archiveName,
+				server.URL+"/archive",
+				server.URL+"/checksums",
+			)
+		case "/archive":
+			w.Write(archive)
+		case "/checksums":
+			fmt.Fprint(w, checksums)
+		default:
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatalf("ensure paths: %v", err)
+	}
+	database, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	repo, err := database.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")
+	if err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+	pendingRun, err := database.InsertRun(repo.ID, "feature-a", "aaa111", "000")
+	if err != nil {
+		t.Fatalf("insert pending run: %v", err)
+	}
+	runningRun, err := database.InsertRun(repo.ID, "feature-b", "bbb222", "000")
+	if err != nil {
+		t.Fatalf("insert running run: %v", err)
+	}
+	if err := database.UpdateRunStatus(runningRun.ID, types.RunRunning); err != nil {
+		t.Fatalf("mark running: %v", err)
+	}
+	if err := database.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	execPath := filepath.Join(t.TempDir(), "no-mistakes")
+	if err := os.WriteFile(execPath, []byte("old-binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+	resetCalled := false
+	u := &updater{
+		appName:        "no-mistakes",
+		repo:           "kunchenguid/no-mistakes",
+		currentVersion: "v1.2.2",
+		platform:       platformSpec{GOOS: "darwin", GOARCH: "arm64"},
+		apiBaseURL:     server.URL,
+		httpClient:     server.Client(),
+		executablePath: execPath,
+		stdout:         stdout,
+		stderr:         stderr,
+		stdin:          strings.NewReader("n\n"),
+		now:            func() time.Time { return time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC) },
+		resetDaemon: func() error {
+			resetCalled = true
+			return nil
+		},
+		paths: p,
+	}
+
+	err = u.run(context.Background())
+	if err == nil {
+		t.Fatal("run should fail when active run warning is rejected")
+	}
+	if !strings.Contains(err.Error(), "active pipeline runs") {
+		t.Fatalf("run error = %v", err)
+	}
+	transcript := stderr.String()
+	for _, want := range []string{
+		"2 active pipeline runs",
+		pendingRun.ID,
+		"feature-a",
+		runningRun.ID,
+		"feature-b",
+		"Continue with update and restart the daemon? [y/N]",
+	} {
+		if !strings.Contains(transcript, want) {
+			t.Fatalf("stderr should contain %q, got %q", want, transcript)
+		}
+	}
+	content, readErr := os.ReadFile(execPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(content) != "old-binary" {
+		t.Fatalf("executable content = %q", string(content))
+	}
+	if resetCalled {
+		t.Fatal("reset daemon should not run after rejecting active run warning")
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q", stdout.String())
 	}
 }
 


### PR DESCRIPTION
## Intent

The developer wanted `no-mistakes update` to detect active pipelines before performing an update, because replacing the binary or resetting the daemon can cause those pipelines to crash. They required the command to warn when pending or running pipelines exist, show enough information about the active runs to identify them, and ask for explicit confirmation before proceeding. They also expected the `-y` flag to bypass the safety prompt while still printing the warning, and the behavior needed to be implemented with test-driven development in the Go CLI codebase.

## What Changed

- Added active-run detection for `no-mistakes update`, warning when pending or running pipelines exist and requiring confirmation before proceeding.
- Kept `-y` as a bypass for the confirmation prompt while still surfacing the active-run warning details.
- Documented the update warning behavior across the daemon, gate model, troubleshooting, CLI reference, and installation docs.

## Risk Assessment

✅ Low: The change is narrowly scoped to adding an active-run warning and confirmation before updater replacement, with straightforward DB querying and no material correctness issues found.

## Testing

Targeted database, updater, and CLI package tests passed, and an evidence-producing updater run showed the active-run warning with pending/running run IDs, cancellation on declined confirmation, and successful `-y` continuation while preserving the warning.

<details>
<summary>Evidence: Active run update warning transcript</summary>

Source: [Active run update warning transcript](https://github.com/kunchenguid/no-mistakes/blob/1c5fe94436605ddff515853012ea51c978c007cd/.no-mistakes/evidence/fix/update-active-run-warning/active-run-update-warning-transcript.txt)

```text
$ no-mistakes update
stderr:
warning: update will restart the daemon while 2 active pipeline runs are in progress
active pipeline runs:
01KTG6BHNSBP6FSD2R7SGP6N55 running feature-b bbb22222
01KTG6BHNSBP6FSD2R7R2XYQGR pending feature-a aaa11111
continuing can cause these pipelines to fail
Continue with update and restart the daemon? [y/N] exit error: update cancelled because 2 active pipeline runs are in progress

$ no-mistakes update -y
stdout:
updated no-mistakes from v1.2.2 to v1.2.3
stderr:
warning: update will restart the daemon while 2 active pipeline runs are in progress
active pipeline runs:
01KTG6BHP1M5HEA3HKDK7H5FT9 running feature-b bbb22222
01KTG6BHP05BVDC565E6TQW9V1 pending feature-a aaa11111
continuing can cause these pipelines to fail
continuing because -y was provided
exit: 0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/db -run '^TestActiveRunsAcrossRepos$' -count=1`
- `go test ./internal/update -run '^TestUpdaterRunWarnsAndRequiresConfirmationForActiveRuns$' -count=1`
- <code>`go test ./internal/update -run &#39;^TestEvidenceActiveRunWarningTranscript$&#39; -count=1` using a temporary package-level evidence harness, then removed the harness</code>
- `go test ./internal/update ./internal/db -count=1`
- `go test ./internal/cli ./internal/update ./internal/db -count=1`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
