### PR TITLE
fix(pipeline): keep monitoring open PRs after CI passes

### DIFF
--- a/.no-mistakes/evidence/fix/pipeline-ci-open-pr-monitoring/ci-open-pr-monitoring-targeted-tests.txt
+++ b/.no-mistakes/evidence/fix/pipeline-ci-open-pr-monitoring/ci-open-pr-monitoring-targeted-tests.txt
@@ -1,0 +1,34 @@
+=== RUN   TestCIStep_BitbucketPassesWhenStatusesPass
+=== PAUSE TestCIStep_BitbucketPassesWhenStatusesPass
+=== RUN   TestCIStep_GitLabPassesWhenJobsPass
+=== PAUSE TestCIStep_GitLabPassesWhenJobsPass
+=== RUN   TestCIStep_TimeoutWithOpenPRNeedsApprovalAndDoesNotSleepPastDeadline
+=== PAUSE TestCIStep_TimeoutWithOpenPRNeedsApprovalAndDoesNotSleepPastDeadline
+=== RUN   TestCIStep_TimeoutWithUnknownMergeableState_NeedsApproval
+=== PAUSE TestCIStep_TimeoutWithUnknownMergeableState_NeedsApproval
+=== RUN   TestCIStep_TimeoutWithKnownFailureAndPendingCheck_NeedsApproval
+=== PAUSE TestCIStep_TimeoutWithKnownFailureAndPendingCheck_NeedsApproval
+=== RUN   TestCIStep_TimeoutWithMergeConflictAndCheckLookupError_NeedsApproval
+=== PAUSE TestCIStep_TimeoutWithMergeConflictAndCheckLookupError_NeedsApproval
+=== RUN   TestCIStep_AllChecksPassingKeepsMonitoringOpenPR
+=== PAUSE TestCIStep_AllChecksPassingKeepsMonitoringOpenPR
+=== RUN   TestCIStep_OpenPRKeepsMonitoringAfterChecksPass
+=== PAUSE TestCIStep_OpenPRKeepsMonitoringAfterChecksPass
+=== CONT  TestCIStep_BitbucketPassesWhenStatusesPass
+=== CONT  TestCIStep_AllChecksPassingKeepsMonitoringOpenPR
+=== CONT  TestCIStep_TimeoutWithOpenPRNeedsApprovalAndDoesNotSleepPastDeadline
+=== CONT  TestCIStep_TimeoutWithKnownFailureAndPendingCheck_NeedsApproval
+=== CONT  TestCIStep_GitLabPassesWhenJobsPass
+=== CONT  TestCIStep_OpenPRKeepsMonitoringAfterChecksPass
+=== CONT  TestCIStep_TimeoutWithUnknownMergeableState_NeedsApproval
+=== CONT  TestCIStep_TimeoutWithMergeConflictAndCheckLookupError_NeedsApproval
+--- PASS: TestCIStep_BitbucketPassesWhenStatusesPass (0.14s)
+--- PASS: TestCIStep_OpenPRKeepsMonitoringAfterChecksPass (0.29s)
+--- PASS: TestCIStep_TimeoutWithOpenPRNeedsApprovalAndDoesNotSleepPastDeadline (0.29s)
+--- PASS: TestCIStep_TimeoutWithKnownFailureAndPendingCheck_NeedsApproval (0.31s)
+--- PASS: TestCIStep_AllChecksPassingKeepsMonitoringOpenPR (0.31s)
+--- PASS: TestCIStep_TimeoutWithUnknownMergeableState_NeedsApproval (0.33s)
+--- PASS: TestCIStep_TimeoutWithMergeConflictAndCheckLookupError_NeedsApproval (0.35s)
+--- PASS: TestCIStep_GitLabPassesWhenJobsPass (0.36s)
+PASS
+ok  	github.com/kunchenguid/no-mistakes/internal/pipeline/steps	0.725s

--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -47,7 +47,7 @@ That is a core design choice, not an implementation detail.
 5. The pipeline runs in order: `intent -> rebase -> review -> test -> document -> lint -> push -> pr -> ci`.
 6. If a step pauses, you can attach with the TUI and approve, fix, skip, or abort.
 7. After local checks pass, the push step forwards the branch upstream and the PR step creates or updates the pull request.
-8. The CI step keeps watching after the PR exists and can auto-fix failures or merge conflicts when supported.
+8. The CI step keeps watching the open PR until it is merged or closed, and can auto-fix failures or merge conflicts when supported.
 
 **Key design decisions:**
 

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -73,7 +73,7 @@ agent_args_override:
     - gpt-5.4
     - --full-auto
 
-# How long the CI step waits for provider CI status, and GitHub/GitLab PR mergeability, before timing out.
+# How long the CI step monitors an open PR, including provider CI status and GitHub/GitLab PR mergeability, before timing out.
 ci_timeout: "4h"  # any Go duration string
 
 # Daemon log verbosity.

--- a/docs/src/content/docs/guides/provider-integration.md
+++ b/docs/src/content/docs/guides/provider-integration.md
@@ -20,7 +20,7 @@ Without any provider setup, `no-mistakes` still gives you the local gate:
 - lint
 - push through normal Git transport
 
-What you do not get is PR automation and CI babysitting.
+What you do not get is PR automation and CI monitoring.
 
 ## What each step needs
 
@@ -37,7 +37,7 @@ Once the host is wired up, `no-mistakes` can keep owning the branch after the
 upstream push:
 
 - create or update the PR automatically
-- poll hosted CI without you refreshing a browser tab
+- keep polling hosted CI until the PR is merged, closed, declined, or times out
 - fetch failing job logs for the CI auto-fix loop
 - on GitHub and GitLab, watch mergeability and fix merge conflicts when possible
 
@@ -66,7 +66,7 @@ gh auth status
 **What you get:**
 
 - PR creation and update on pushes
-- CI check polling with exponential backoff (30s → 60s → 120s)
+- CI check polling with exponential backoff (30s → 60s → 120s) until the PR is merged, closed, or times out
 - Failed job log fetching (`gh run view --log-failed`) for the CI auto-fix step
 - PR mergeability polling, and agent-driven merge-conflict resolution when the branch falls behind
 
@@ -87,7 +87,7 @@ glab auth login
 **What you get:**
 
 - PR (merge request) creation and update
-- CI pipeline status polling
+- CI pipeline status polling until the merge request is merged, closed, or times out
 - Failed job trace fetching (`glab ci trace`) for the CI auto-fix step
 - Merge-conflict polling and auto-fix, same as GitHub
 
@@ -108,7 +108,7 @@ Get an API token from [Bitbucket account settings](https://bitbucket.org/account
 **What you get:**
 
 - PR creation and update
-- CI pipeline status polling
+- CI pipeline status polling until the PR is merged, declined, or times out
 - Failed pipeline step log fetching for the CI auto-fix step
 
 **What you don't get (yet):**

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -183,7 +183,9 @@ Symptom: CI step runs for 4 hours and pauses for approval.
 ci_timeout: "8h"
 ```
 
-If CI is genuinely hanging on the provider side, the step times out and pauses with findings for the unresolved state. You can approve (accept the risk), fix (run another auto-fix cycle), skip, or abort from the TUI.
+The CI step keeps monitoring while the PR remains open, even after checks are currently healthy, because a later default-branch update can make the PR conflict or rerun CI.
+If the PR is still open at the timeout, the step pauses for approval with findings for the open monitoring state or any known unresolved failures.
+You can approve (accept the risk), fix (run another auto-fix cycle), skip, or abort from the TUI.
 
 ## Worktree won't clean up
 

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -173,7 +173,7 @@ agent_args_override:
 
 ### ci_timeout
 
-How long the CI step waits for provider CI status, and on GitHub or GitLab for PR mergeability, before timing out.
+How long the CI step monitors an open PR, including provider CI status and on GitHub or GitLab PR mergeability, before timing out.
 
 | | |
 |---|---|

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -168,7 +168,8 @@ Monitors PR health after creation and auto-fixes CI failures. Mergeability polli
 
 **Behavior:**
 - Polls provider CI status at increasing intervals: every 30s for the first 5 minutes, every 60s for 5-15 minutes, every 120s after that
-- On GitHub and GitLab, polls provider mergeability alongside CI checks and waits for that state to resolve before exiting
+- Continues monitoring an open PR until it is merged, closed, declined, or times out, even after CI checks are currently healthy
+- On GitHub and GitLab, polls provider mergeability alongside CI checks while the PR remains open
 - Waits a 60s grace period before trusting empty results (CI checks may not have registered yet)
 - If CI failures or, on GitHub or GitLab, a merge conflict are already known while other checks are still pending: waits for all checks to finish before attempting an auto-fix
 - On CI failure: fetches failed job logs (GitHub via `gh run view --log-failed`, GitLab via `glab ci trace`, Bitbucket Cloud via failed pipeline step logs), sends them to the agent with inferred user intent when available, and commits and force-pushes only if the agent produces changes
@@ -176,7 +177,8 @@ Monitors PR health after creation and auto-fixes CI failures. Mergeability polli
 - If both CI failures and a GitHub or GitLab merge conflict are present: fixes both in the same attempt
 - If a fix attempt produces no changes: automatic mode leaves the failure undeduplicated so it can retry until the auto-fix limit, while manual fix mode returns immediately for manual intervention
 - Deduplicates fix attempts only after a fix is actually committed and pushed
-- Exits cleanly when the PR is merged, closed, or declined, or when the timeout is reached with no known CI failures, merge conflicts, or unresolved mergeability state (default 4h)
+- Exits cleanly when the PR is merged, closed, or declined
+- If the timeout is reached while the PR is still open: pauses for user approval, even when CI checks are currently healthy
 - If the timeout is reached while CI failures or, on GitHub or GitLab, a merge conflict are still known: pauses for user approval with findings for the remaining issues
 - If the timeout is reached while GitHub or GitLab PR mergeability is still unresolved: pauses for user approval with a finding describing the unresolved mergeability state
 - If CI failures or a GitHub or GitLab merge conflict persist after the auto-fix limit: pauses for user approval with findings listing each failing check and/or the merge conflict

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -14,7 +14,7 @@ import (
 
 const defaultChecksGracePeriod = 60 * time.Second
 
-// CIStep monitors CI checks after PR creation, auto-fixing failures.
+// CIStep monitors an open PR until it is merged or closed, auto-fixing CI failures.
 type CIStep struct {
 	lastFixedChecks      string               // sorted check names from last fix attempt, to avoid re-fixing
 	lastFixedCompletedAt map[string]time.Time // failing check completion times seen before the last fix attempt

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -92,11 +92,9 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 	mergeabilityBlockedReason := ""
 	timeoutFailingChecks := []string{}
 	timeoutMergeConflict := false
+	lastHealthyLog := ""
 
 	for {
-		checksReadyToExit := false
-		checksSummary := ""
-
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
@@ -110,7 +108,7 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 			if mergeabilityBlockedReason != "" {
 				return ciMergeabilityOutcome("mergeability check timed out", mergeabilityBlockedReason), nil
 			}
-			return &pipeline.StepOutcome{}, nil
+			return ciMonitoringTimeoutOutcome(), nil
 		}
 
 		// Check PR state (merged/closed -> exit)
@@ -170,12 +168,14 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 			}
 
 			if hasIssues && pending {
+				lastHealthyLog = ""
 				if pendingCheckMatchesLastFixed(checks, s.lastFixedChecks) {
 					s.lastFixedChecks = ""
 					s.lastFixedCompletedAt = nil
 				}
 				sctx.Log("issues detected but checks still pending, waiting for all checks to complete...")
 			} else if hasIssues {
+				lastHealthyLog = ""
 				// All checks done, issues present - fix or report
 				fixKey := encodeLastFixedChecks(failing, mergeConflict)
 				fixCompletedAt := failingCheckCompletionTimes(checks)
@@ -233,22 +233,19 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 				if !pending && mergeabilityKnown {
 					if len(checks) == 0 && elapsed < s.gracePeriod() {
 						// CI checks may not be registered yet, keep polling
+						lastHealthyLog = ""
 						sctx.Log("no CI checks reported yet, waiting for checks to register...")
 					} else {
-						checksReadyToExit = true
 						if len(checks) == 0 {
-							checksSummary = "no CI checks reported, CI monitoring complete"
+							lastHealthyLog = logCIHealthyOpenPR(sctx, "no CI checks reported, continuing to monitor until PR is merged or closed", lastHealthyLog)
 						} else {
-							checksSummary = "all CI checks passed"
+							lastHealthyLog = logCIHealthyOpenPR(sctx, "all CI checks passed, continuing to monitor until PR is merged or closed", lastHealthyLog)
 						}
 					}
+				} else {
+					lastHealthyLog = ""
 				}
 			}
-		}
-
-		if checksReadyToExit {
-			sctx.Log(checksSummary)
-			return &pipeline.StepOutcome{}, nil
 		}
 
 		// Sleep for poll interval
@@ -275,4 +272,11 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 			return nil, err
 		}
 	}
+}
+
+func logCIHealthyOpenPR(sctx *pipeline.StepContext, message, previous string) string {
+	if message != previous {
+		sctx.Log(message)
+	}
+	return message
 }

--- a/internal/pipeline/steps/ci_bitbucket_test.go
+++ b/internal/pipeline/steps/ci_bitbucket_test.go
@@ -32,13 +32,19 @@ func TestCIStep_BitbucketPassesWhenStatusesPass(t *testing.T) {
 	var logs []string
 	sctx.Log = func(s string) { logs = append(logs, s) }
 
-	step := &CIStep{}
-	outcome, err := step.Execute(sctx)
-	if err != nil {
-		t.Fatal(err)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
+	step := &CIStep{
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			cancel()
+			return ctx.Err()
+		},
 	}
-	if outcome.NeedsApproval {
-		t.Fatal("expected Bitbucket CI pass to complete without approval")
+	_, err := step.Execute(sctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected Bitbucket CI pass to keep monitoring while PR is open, got %v", err)
 	}
 	if api.prStateCalls == 0 {
 		t.Fatal("expected Bitbucket PR state endpoint to be called")
@@ -48,7 +54,7 @@ func TestCIStep_BitbucketPassesWhenStatusesPass(t *testing.T) {
 	}
 	foundPassed := false
 	for _, line := range logs {
-		if strings.Contains(line, "all CI checks passed") {
+		if strings.Contains(line, "all CI checks passed, continuing to monitor") {
 			foundPassed = true
 			break
 		}
@@ -72,13 +78,19 @@ func TestCIStep_BitbucketUsesProcessEnvWhenStepEnvIsNil(t *testing.T) {
 	sctx.Repo.UpstreamURL = "https://bitbucket.org/test/repo.git"
 	sctx.Config.CITimeout = 30 * time.Second
 
-	step := &CIStep{}
-	outcome, err := step.Execute(sctx)
-	if err != nil {
-		t.Fatal(err)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
+	step := &CIStep{
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			cancel()
+			return ctx.Err()
+		},
 	}
-	if outcome.NeedsApproval {
-		t.Fatal("expected Bitbucket CI pass to complete without approval")
+	_, err := step.Execute(sctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected Bitbucket CI pass to keep monitoring while PR is open, got %v", err)
 	}
 	if api.prStateCalls == 0 || api.statusesCalls == 0 {
 		t.Fatalf("expected Bitbucket CI endpoints to be called, got state=%d statuses=%d", api.prStateCalls, api.statusesCalls)
@@ -133,13 +145,19 @@ func TestCIStep_BitbucketStoppedDoesNotNeedApproval(t *testing.T) {
 	sctx.Repo.UpstreamURL = "https://bitbucket.org/test/repo.git"
 	sctx.Config.CITimeout = 30 * time.Second
 
-	step := &CIStep{}
-	outcome, err := step.Execute(sctx)
-	if err != nil {
-		t.Fatal(err)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
+	step := &CIStep{
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			cancel()
+			return ctx.Err()
+		},
 	}
-	if outcome.NeedsApproval {
-		t.Fatal("expected stopped Bitbucket CI to avoid failure handling")
+	_, err := step.Execute(sctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected stopped Bitbucket CI to keep monitoring without failure handling, got %v", err)
 	}
 }
 

--- a/internal/pipeline/steps/ci_checks.go
+++ b/internal/pipeline/steps/ci_checks.go
@@ -185,3 +185,19 @@ func ciMergeabilityOutcome(summary, description string) *pipeline.StepOutcome {
 		Findings:      string(findingsJSON),
 	}
 }
+
+func ciMonitoringTimeoutOutcome() *pipeline.StepOutcome {
+	findings := Findings{
+		Summary: "CI monitoring timed out before PR was merged or closed",
+		Items: []Finding{{
+			Severity:    "warning",
+			Description: "PR was still open when CI monitoring timed out",
+			Action:      types.ActionAskUser,
+		}},
+	}
+	findingsJSON, _ := json.Marshal(findings)
+	return &pipeline.StepOutcome{
+		NeedsApproval: true,
+		Findings:      string(findingsJSON),
+	}
+}

--- a/internal/pipeline/steps/ci_gitlab_test.go
+++ b/internal/pipeline/steps/ci_gitlab_test.go
@@ -32,17 +32,23 @@ func TestCIStep_GitLabPassesWhenJobsPass(t *testing.T) {
 	var logs []string
 	sctx.Log = func(s string) { logs = append(logs, s) }
 
-	step := &CIStep{}
-	outcome, err := step.Execute(sctx)
-	if err != nil {
-		t.Fatal(err)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
+	step := &CIStep{
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			cancel()
+			return ctx.Err()
+		},
 	}
-	if outcome.NeedsApproval {
-		t.Fatal("expected passing GitLab CI to complete without approval")
+	_, err := step.Execute(sctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected passing GitLab CI to keep monitoring while MR is open, got %v", err)
 	}
 	found := false
 	for _, line := range logs {
-		if strings.Contains(line, "all CI checks passed") {
+		if strings.Contains(line, "all CI checks passed, continuing to monitor") {
 			found = true
 			break
 		}
@@ -232,7 +238,7 @@ func TestCIStep_GitLabAutoFixIncludesJobTrace(t *testing.T) {
 	}
 }
 
-func TestCIStep_GitLabPendingChecksExitCleanlyWhenDone(t *testing.T) {
+func TestCIStep_GitLabPendingChecksKeepMonitoringWhenDone(t *testing.T) {
 	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
@@ -253,31 +259,36 @@ func TestCIStep_GitLabPendingChecksExitCleanlyWhenDone(t *testing.T) {
 	var logs []string
 	sctx.Log = func(s string) { logs = append(logs, s) }
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
 	pollCount := 0
 	step := &CIStep{
 		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
 			pollCount++
-			return nil
+			if pollCount == 1 {
+				return nil
+			}
+			cancel()
+			return ctx.Err()
 		},
 	}
-	outcome, err := step.Execute(sctx)
-	if err != nil {
-		t.Fatal(err)
+	_, err := step.Execute(sctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected passing GitLab CI to keep monitoring while MR is open, got %v", err)
 	}
-	if outcome.NeedsApproval {
-		t.Fatal("expected passing GitLab CI to exit cleanly")
-	}
-	if pollCount != 1 {
-		t.Fatalf("expected one poll wait while jobs were pending, got %d", pollCount)
+	if pollCount != 2 {
+		t.Fatalf("expected one pending wait plus one healthy monitoring wait, got %d", pollCount)
 	}
 	found := false
 	for _, line := range logs {
-		if strings.Contains(line, "all CI checks passed") {
+		if strings.Contains(line, "all CI checks passed, continuing to monitor") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Fatalf("expected 'all CI checks passed' log, got: %v", logs)
+		t.Fatalf("expected continued-monitoring pass log, got: %v", logs)
 	}
 }

--- a/internal/pipeline/steps/ci_mergeable_test.go
+++ b/internal/pipeline/steps/ci_mergeable_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/config"
 )
 
-func TestCIStep_TimeoutDoesNotSleepPastDeadline(t *testing.T) {
+func TestCIStep_TimeoutWithOpenPRNeedsApprovalAndDoesNotSleepPastDeadline(t *testing.T) {
 	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
@@ -45,8 +45,15 @@ func TestCIStep_TimeoutDoesNotSleepPastDeadline(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if outcome.NeedsApproval {
-		t.Error("expected no approval when timeout expires")
+	if !outcome.NeedsApproval {
+		t.Fatal("expected approval when CI monitoring times out before PR is merged or closed")
+	}
+	var findings Findings
+	if err := json.Unmarshal([]byte(outcome.Findings), &findings); err != nil {
+		t.Fatalf("unmarshal findings: %v", err)
+	}
+	if !strings.Contains(findings.Summary, "timed out") {
+		t.Fatalf("expected timeout finding summary, got %+v", findings)
 	}
 	if len(intervals) != 1 {
 		t.Fatalf("expected exactly one poll wait before timeout, got %d", len(intervals))
@@ -96,7 +103,7 @@ func TestCIStep_UnknownMergeableStateDoesNotExitCleanly(t *testing.T) {
 	}
 }
 
-func TestCIStep_MergeableLookupErrorStillExitsCleanlyWhenChecksPass(t *testing.T) {
+func TestCIStep_MergeableLookupErrorStillKeepsMonitoringWhenChecksPass(t *testing.T) {
 	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
@@ -113,14 +120,20 @@ func TestCIStep_MergeableLookupErrorStillExitsCleanlyWhenChecksPass(t *testing.T
 	var logs []string
 	sctx.Log = func(s string) { logs = append(logs, s) }
 
-	step := &CIStep{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
 
-	outcome, err := step.Execute(sctx)
-	if err != nil {
-		t.Fatalf("expected clean exit, got %v", err)
+	step := &CIStep{
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			cancel()
+			return ctx.Err()
+		},
 	}
-	if outcome.NeedsApproval {
-		t.Fatalf("expected clean outcome, got approval request: %+v", outcome)
+
+	_, err := step.Execute(sctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected polling to continue after passing checks, got %v", err)
 	}
 
 	foundWarning := false
@@ -129,7 +142,7 @@ func TestCIStep_MergeableLookupErrorStillExitsCleanlyWhenChecksPass(t *testing.T
 		if strings.Contains(l, "could not check mergeable state") {
 			foundWarning = true
 		}
-		if strings.Contains(l, "all CI checks passed") {
+		if strings.Contains(l, "all CI checks passed, continuing to monitor") {
 			foundPassed = true
 		}
 	}

--- a/internal/pipeline/steps/ci_test.go
+++ b/internal/pipeline/steps/ci_test.go
@@ -37,6 +37,10 @@ func TestCIStep_PendingChecksUseAdaptivePollIntervals(t *testing.T) {
 	current := started
 	var waits []time.Duration
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
 	step := &CIStep{
 		now: func() time.Time { return current },
 		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
@@ -47,7 +51,8 @@ func TestCIStep_PendingChecksUseAdaptivePollIntervals(t *testing.T) {
 			case 2:
 				current = started.Add(15 * time.Minute)
 			case 3:
-				current = current.Add(interval)
+				cancel()
+				return ctx.Err()
 			default:
 				t.Fatalf("unexpected extra poll wait: %v", interval)
 			}
@@ -55,12 +60,9 @@ func TestCIStep_PendingChecksUseAdaptivePollIntervals(t *testing.T) {
 		},
 	}
 
-	outcome, err := step.Execute(sctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if outcome.NeedsApproval {
-		t.Fatal("expected pending checks to exit cleanly once checks pass")
+	_, err := step.Execute(sctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected cancellation after observing adaptive waits, got %v", err)
 	}
 
 	want := []time.Duration{30 * time.Second, 60 * time.Second, 120 * time.Second}
@@ -327,7 +329,7 @@ func TestCIStep_GetCIChecksNoChecksReported(t *testing.T) {
 	}
 }
 
-func TestCIStep_AllChecksPassingExitsCleanly(t *testing.T) {
+func TestCIStep_AllChecksPassingKeepsMonitoringOpenPR(t *testing.T) {
 	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
@@ -347,33 +349,73 @@ func TestCIStep_AllChecksPassingExitsCleanly(t *testing.T) {
 	var logs []string
 	sctx.Log = func(s string) { logs = append(logs, s) }
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
 	pollCount := 0
 	step := &CIStep{
 		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
 			pollCount++
-			return nil
+			if pollCount == 1 {
+				return nil
+			}
+			cancel()
+			return ctx.Err()
 		},
 	}
-	outcome, err := step.Execute(sctx)
-	if err != nil {
-		t.Fatal(err)
+	_, err := step.Execute(sctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected open PR monitoring to continue after passing checks, got %v", err)
 	}
-	if outcome.NeedsApproval {
-		t.Error("expected no approval when CI checks are already passing")
-	}
-	if pollCount != 1 {
-		t.Fatalf("expected one poll wait while CI checks were pending, got %d", pollCount)
+	if pollCount != 2 {
+		t.Fatalf("expected one pending wait plus one healthy monitoring wait, got %d", pollCount)
 	}
 
 	found := false
 	for _, l := range logs {
-		if strings.Contains(l, "all CI checks passed") {
+		if strings.Contains(l, "all CI checks passed, continuing to monitor") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Fatalf("expected clean-exit CI log, got: %v", logs)
+		t.Fatalf("expected continued-monitoring CI log, got: %v", logs)
+	}
+}
+
+func TestCIStep_OpenPRKeepsMonitoringAfterChecksPass(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	checksJSON := `[{"name":"build","state":"SUCCESS","bucket":"pass"}]`
+	env := fakeCIGH(t, "OPEN", checksJSON)
+
+	prURL := "https://github.com/test/repo/pull/42"
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+	sctx.Config.CITimeout = 10 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
+	pollCount := 0
+	step := &CIStep{
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			pollCount++
+			cancel()
+			return ctx.Err()
+		},
+	}
+	_, err := step.Execute(sctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected open PR monitoring to continue after passing checks, got %v", err)
+	}
+	if pollCount != 1 {
+		t.Fatalf("poll count = %d, want 1", pollCount)
 	}
 }
 
@@ -398,49 +440,53 @@ func TestCIStep_EmptyChecksWaitsDuringGracePeriod(t *testing.T) {
 	current := started
 	var waits []time.Duration
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
 	step := &CIStep{
 		checksGracePeriod:    200 * time.Millisecond,
 		pollIntervalOverride: 75 * time.Millisecond,
 		now:                  func() time.Time { return current },
 		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
 			waits = append(waits, interval)
+			if current.Sub(started) >= 200*time.Millisecond {
+				cancel()
+				return ctx.Err()
+			}
 			current = current.Add(interval)
 			return nil
 		},
 	}
-	outcome, err := step.Execute(sctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if outcome.NeedsApproval {
-		t.Error("expected no approval needed")
+	_, err := step.Execute(sctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected cancellation after grace-period monitoring continued, got %v", err)
 	}
 	if elapsed := current.Sub(started); elapsed < 200*time.Millisecond {
 		t.Errorf("CI exited in %v, expected to wait at least 200ms grace period", elapsed)
 	}
-	if len(waits) != 3 {
-		t.Fatalf("expected 3 grace-period waits, got %v", waits)
+	if len(waits) != 4 {
+		t.Fatalf("expected 3 grace-period waits plus one continued-monitoring wait, got %v", waits)
 	}
-	for _, interval := range waits {
+	for _, interval := range waits[:3] {
 		if interval != 75*time.Millisecond {
 			t.Fatalf("expected 75ms waits during grace period, got %v", waits)
 		}
 	}
-	// Should exit via grace period expiry, not CI timeout
 	for _, l := range logs {
 		if strings.Contains(l, "CI timeout reached") {
-			t.Fatal("expected exit via grace period expiry, not CI timeout")
+			t.Fatal("expected cancellation before CI timeout")
 		}
 	}
 	found := false
 	for _, l := range logs {
-		if strings.Contains(l, "CI monitoring complete") {
+		if strings.Contains(l, "no CI checks reported, continuing to monitor") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Fatalf("expected 'CI monitoring complete' log, got: %v", logs)
+		t.Fatalf("expected continued-monitoring log after grace period, got: %v", logs)
 	}
 }
 
@@ -460,18 +506,22 @@ func TestCIStep_LogsWaitingForChecksDuringGracePeriod(t *testing.T) {
 	var logs []string
 	sctx.Log = func(s string) { logs = append(logs, s) }
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
 	current := time.Date(2026, time.January, 1, 12, 0, 0, 0, time.UTC)
 	step := &CIStep{
 		checksGracePeriod:    50 * time.Millisecond,
 		pollIntervalOverride: 10 * time.Millisecond,
 		now:                  func() time.Time { return current },
 		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
-			current = current.Add(interval)
-			return nil
+			cancel()
+			return ctx.Err()
 		},
 	}
-	if _, err := step.Execute(sctx); err != nil {
-		t.Fatal(err)
+	if _, err := step.Execute(sctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected cancellation after first grace-period wait, got %v", err)
 	}
 
 	found := false
@@ -486,7 +536,7 @@ func TestCIStep_LogsWaitingForChecksDuringGracePeriod(t *testing.T) {
 	}
 }
 
-func TestCIStep_NonEmptyPassingChecksExitImmediately(t *testing.T) {
+func TestCIStep_NonEmptyPassingChecksSkipGracePeriodAndContinueMonitoring(t *testing.T) {
 	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
@@ -503,28 +553,34 @@ func TestCIStep_NonEmptyPassingChecksExitImmediately(t *testing.T) {
 	var logs []string
 	sctx.Log = func(s string) { logs = append(logs, s) }
 
-	// Even with a long grace period, non-empty passing checks should exit immediately
-	step := &CIStep{checksGracePeriod: 10 * time.Second}
-	started := time.Now()
-	outcome, err := step.Execute(sctx)
-	elapsed := time.Since(started)
-	if err != nil {
-		t.Fatal(err)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
+	pollCount := 0
+	step := &CIStep{
+		checksGracePeriod: 10 * time.Second,
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			pollCount++
+			cancel()
+			return ctx.Err()
+		},
 	}
-	if outcome.NeedsApproval {
-		t.Error("expected no approval needed")
+	_, err := step.Execute(sctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected open PR monitoring to continue after passing checks, got %v", err)
 	}
-	if elapsed > 10*time.Second {
-		t.Errorf("non-empty passing checks should exit quickly, took %v", elapsed)
+	if pollCount != 1 {
+		t.Fatalf("expected one healthy monitoring wait, got %d", pollCount)
 	}
 	found := false
 	for _, l := range logs {
-		if strings.Contains(l, "all CI checks passed") {
+		if strings.Contains(l, "all CI checks passed, continuing to monitor") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Fatalf("expected 'all CI checks passed' log, got: %v", logs)
+		t.Fatalf("expected continued-monitoring pass log, got: %v", logs)
 	}
 }


### PR DESCRIPTION
## Intent

The developer wanted the CI pipeline step changed so it does not stop monitoring as soon as checks pass. Their requirement was that an open PR should continue being polled until it is closed or merged, because another PR merging into main can later create conflicts even after CI was green. They also expected this behavior to be covered with tests, including provider-specific CI monitoring paths, and to treat timeouts on still-open PRs as needing attention rather than silently succeeding.

## What Changed

- Updated the CI pipeline step to keep polling an open PR after checks are healthy, exiting only when the PR is merged, closed, or declined.
- Changed CI monitoring timeouts on still-open PRs to require user approval instead of completing silently, while preserving failure and mergeability findings.
- Updated CI step tests across GitHub, GitLab, and Bitbucket paths, plus docs describing the new monitoring behavior.

## Risk Assessment

✅ Low: The change is localized to CI monitoring timeout/polling behavior, aligns with the stated requirement, and includes provider-specific test coverage without obvious correctness regressions.

## Testing

Exercised the targeted CI step tests for GitHub open-PR green-check polling, GitLab and Bitbucket provider-specific open-PR monitoring, and still-open PR timeout approval behavior, saved the behavior-specific test transcript as evidence, then ran the full `internal/pipeline/steps` package successfully.

<details>
<summary>Evidence: Targeted CI open-PR monitoring test transcript</summary>

Source: [Targeted CI open-PR monitoring test transcript](https://github.com/kunchenguid/no-mistakes/blob/640357578489f0b89caa9f4ddaddc04216048b5b/.no-mistakes/evidence/fix/pipeline-ci-open-pr-monitoring/ci-open-pr-monitoring-targeted-tests.txt)

```text
Shows passing behavior-specific tests for open PRs continuing to be monitored after checks pass, provider-specific GitLab and Bitbucket paths, and timeout cases requiring approval.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/pipeline/steps -run 'TestCIStep_(AllChecksPassingKeepsMonitoringOpenPR|OpenPRKeepsMonitoringAfterChecksPass|GitLabPassesWhenJobsPass|BitbucketPassesWhenStatusesPass|TimeoutWithOpenPRNeedsApprovalAndDoesNotSleepPastDeadline|TimeoutWithUnknownMergeableState_NeedsApproval|TimeoutWithKnownFailureAndPendingCheck_NeedsApproval|TimeoutWithMergeConflictAndCheckLookupError_NeedsApproval)$' -v 2>&1 | tee ".no-mistakes/evidence/fix/pipeline-ci-open-pr-monitoring/ci-open-pr-monitoring-targeted-tests.txt"`
- `go test ./internal/pipeline/steps`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
