### PR TITLE
fix(gate): make init idempotent

### DIFF
--- a/.no-mistakes/evidence/fix/idempotent-init/idempotent-init-cli-transcript.txt
+++ b/.no-mistakes/evidence/fix/idempotent-init/idempotent-init-cli-transcript.txt
@@ -1,0 +1,49 @@
+$ git init --bare upstream.git
+Initialized empty Git repository in /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/idempotent-init.ZfF6JE/upstream.git/
+
+$ git init work && create initial commit
+Initialized empty Git repository in /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/idempotent-init.ZfF6JE/work/.git/
+[main (root-commit) 9a23fed] init
+To /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/idempotent-init.ZfF6JE/upstream.git
+ * [new branch]      main -> main
+branch 'main' set up to track 'origin/main'.
+
+$ no-mistakes init # first run
+_  _ ____    _  _ _ ____ ___ ____ _  _ ____ ____
+|\ | |  |    |\/| | [__   |  |__| |_/  |___ [__ 
+| \| |__|    |  | | ___]  |  |  | | \_ |___ ___]
+
+  ✓ Gate initialized
+
+    repo  /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/idempotent-init.ZfF6JE/work
+    gate  no-mistakes → /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/idempotent-init.ZfF6JE/nm/repos/ccb98d74178d.git
+  remote  /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/idempotent-init.ZfF6JE/upstream.git
+   skill  /no-mistakes installed for agents
+
+  Push through the gate with:
+  git push no-mistakes <branch>
+
+$ remove installed skill to simulate an existing user adopting the new skill
+skill removed
+
+$ no-mistakes init # re-run on already initialized repo
+_  _ ____    _  _ _ ____ ___ ____ _  _ ____ ____
+|\ | |  |    |\/| | [__   |  |__| |_/  |___ [__ 
+| \| |__|    |  | | ___]  |  |  | | \_ |___ ___]
+
+  ✓ Gate already initialized (refreshed)
+
+    repo  /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/idempotent-init.ZfF6JE/work
+    gate  no-mistakes → /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/idempotent-init.ZfF6JE/nm/repos/ccb98d74178d.git
+  remote  /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/idempotent-init.ZfF6JE/upstream.git
+   skill  /no-mistakes installed for agents
+
+  Push through the gate with:
+  git push no-mistakes <branch>
+
+$ verify skill, remote, gate hook, and isolated hook path
+skill restored: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/idempotent-init.ZfF6JE/work/.claude/skills/no-mistakes/SKILL.md
+no-mistakes remote: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/idempotent-init.ZfF6JE/nm/repos/ccb98d74178d.git
+post-receive hook executable: yes
+gate core.hooksPath: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/idempotent-init.ZfF6JE/nm/repos/ccb98d74178d.git/hooks
+gate origin remote: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/idempotent-init.ZfF6JE/upstream.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ A GitHub Actions check (`Require no-mistakes`) runs on every PR and fails if the
 
 1. Fork the repo and clone your fork.
 2. Create a branch and make your changes.
-3. Initialize the gate in the repo once: `no-mistakes init`.
+3. Initialize or refresh the gate in the repo: `no-mistakes init`.
 4. Commit your changes.
 5. Push through the gate instead of pushing to `origin`:
 

--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -37,6 +37,10 @@ When you run `no-mistakes init` in a repo:
 6. It installs the `/no-mistakes` agent skill into `.claude/skills/no-mistakes/SKILL.md` and `.agents/skills/no-mistakes/SKILL.md` on a best-effort basis.
 7. It makes sure the daemon is running so incoming pushes can start runs.
 
+`init` is idempotent.
+If the repo is already initialized, it refreshes the existing gate instead of failing: managed hook installation, push-option support, hook-path isolation, gate and working remotes, origin/default-branch metadata, and the `/no-mistakes` agent skill are repaired or updated where needed.
+If daemon startup fails during a refresh, `init` reports the error but does not eject the pre-existing gate.
+
 After init, your original `origin` still points at the real upstream remote.
 That is a core design choice, not an implementation detail.
 

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -85,6 +85,7 @@ It does **not** change the pipeline order or the meaning of a passed gate.
 ## Driving no-mistakes as an agent
 
 `no-mistakes init` installs a `/no-mistakes` skill into `.claude/skills/no-mistakes/SKILL.md` and `.agents/skills/no-mistakes/SKILL.md`.
+Re-run `no-mistakes init` in an already-initialized repo to refresh or reinstall that skill after an upgrade.
 The skill tells agents to use `no-mistakes axi`, a non-interactive command surface that prints TOON to stdout and progress to stderr.
 
 Agents can also call `no-mistakes axi` directly:

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -139,6 +139,7 @@ git remote -v | grep no-mistakes
 ```
 
 If it's missing, run `no-mistakes init` again.
+Re-running init refreshes an existing gate and repairs the `no-mistakes` remote when it is missing.
 
 ### Check the hook
 
@@ -151,7 +152,7 @@ no-mistakes status
 ls -la <gate-path>/hooks/post-receive
 ```
 
-The hook should be executable. If it's missing or non-executable, `no-mistakes init` will reinstall it.
+The hook should be executable. If it's missing or non-executable, `no-mistakes init` will reinstall it for an existing no-mistakes-managed gate.
 For existing gate repos, `no-mistakes daemon restart` also installs missing no-mistakes-managed hooks and refreshes legacy managed hooks without overwriting custom hooks.
 
 Also check `<gate-path>/notify-push.log`. The hook now appends daemon notification failures there and prints the same error back to the pushing client.
@@ -160,7 +161,7 @@ Also check `<gate-path>/notify-push.log`. The hook now appends daemon notificati
 
 The hook talks to the daemon over `~/.no-mistakes/socket`. If the daemon isn't running, the push still succeeds (the hook never blocks), but no pipeline starts. Start the daemon and push again.
 
-If the gate is older, restarting the daemon also reapplies hook-path isolation for existing bare repos when Git supports `config --worktree`.
+If the gate is older, re-running `no-mistakes init` or restarting the daemon also reapplies hook-path isolation for existing bare repos when Git supports `config --worktree`.
 That protects the gate hook if a tool such as Husky wrote `core.hookspath` into shared git config from inside a linked worktree.
 
 ## PR step is skipped

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -23,16 +23,18 @@ Valid step names are `intent`, `rebase`, `review`, `test`, `document`, `lint`, `
 
 ## no-mistakes init
 
-Initialize the gate for the current repository.
+Initialize or refresh the gate for the current repository.
 
 ```sh
 no-mistakes init
 ```
 
-Creates a local bare repo, installs the post-receive hook, best-effort isolates the gate repo's hook path from shared git config changes when Git supports `config --worktree`, adds the `no-mistakes` git remote, detects the default branch, records the repo in SQLite, installs the `/no-mistakes` agent skill into `.claude/skills/no-mistakes/SKILL.md` and `.agents/skills/no-mistakes/SKILL.md`, and ensures the daemon is running, installing the managed service when available and falling back to a detached daemon otherwise.
+Creates or refreshes a local bare repo, installs the post-receive hook, best-effort isolates the gate repo's hook path from shared git config changes when Git supports `config --worktree`, adds or repairs the `no-mistakes` git remote, detects the default branch, records or updates the repo in SQLite, installs the `/no-mistakes` agent skill into `.claude/skills/no-mistakes/SKILL.md` and `.agents/skills/no-mistakes/SKILL.md`, and ensures the daemon is running, installing the managed service when available and falling back to a detached daemon otherwise.
 The gate advertises Git push-option support, so you can skip steps for one push with `git push -o no-mistakes.skip=test,lint no-mistakes <branch>`.
 
-Rolls back gate setup when a required gate or daemon step fails.
+Re-running `init` on an already-initialized repo succeeds and reports `Gate already initialized (refreshed)`.
+It refreshes managed gate wiring, origin/default-branch metadata, hook-path isolation, and the installed agent skill.
+Fresh init rolls back gate setup when a required gate or daemon step fails; refresh does not eject a pre-existing gate if daemon startup fails.
 Skill installation is best-effort: if the skill write fails, init reports it and leaves the working gate in place.
 
 ## no-mistakes axi

--- a/docs/src/content/docs/start-here/quick-start.md
+++ b/docs/src/content/docs/start-here/quick-start.md
@@ -39,7 +39,7 @@ Navigate to any git repo with an `origin` remote:
 no-mistakes init
 ```
 
-This creates a local bare repo at `~/.no-mistakes/repos/<id>.git`, installs a post-receive hook, best-effort isolates the gate's hooks path from shared local Git config writes when Git supports `config --worktree`, adds a `no-mistakes` git remote to your working repo, installs the `/no-mistakes` agent skill, and ensures the daemon is running.
+This creates or refreshes a local bare repo at `~/.no-mistakes/repos/<id>.git`, installs a post-receive hook, best-effort isolates the gate's hooks path from shared local Git config writes when Git supports `config --worktree`, adds or repairs a `no-mistakes` git remote in your working repo, installs the `/no-mistakes` agent skill, and ensures the daemon is running.
 
 ```
 $ no-mistakes init
@@ -56,6 +56,8 @@ $ no-mistakes init
 
 `origin` is unchanged. If you need to bypass the gate for a specific push, use
 `git push origin <branch>`.
+
+You can safely re-run `no-mistakes init` later to refresh gate wiring or reinstall the agent skill.
 
 ## 4. Push through the gate
 

--- a/internal/cli/attach_test.go
+++ b/internal/cli/attach_test.go
@@ -30,7 +30,7 @@ func TestRootInteractiveWizardFailsLoudlyWhenRunRegistrationIsSlow(t *testing.T)
 	}
 	defer d.Close()
 
-	if _, err := gate.Init(context.Background(), d, p, "."); err != nil {
+	if _, _, err := gate.Init(context.Background(), d, p, "."); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -30,13 +30,17 @@ func newInitCmd() *cobra.Command {
 				}
 				defer d.Close()
 
-				repo, err := gate.Init(cmd.Context(), d, p, ".")
+				repo, created, err := gate.Init(cmd.Context(), d, p, ".")
 				if err != nil {
 					return fmt.Errorf("init: %w", err)
 				}
 				if err := daemon.EnsureDaemon(p); err != nil {
-					if _, ejectErr := gate.Eject(cmd.Context(), d, p, "."); ejectErr != nil {
-						return fmt.Errorf("start daemon: %w, rollback init: %v", err, ejectErr)
+					// Only roll back a gate we created in this run; a re-init
+					// must never eject a user's pre-existing gate.
+					if created {
+						if _, ejectErr := gate.Eject(cmd.Context(), d, p, "."); ejectErr != nil {
+							return fmt.Errorf("start daemon: %w, rollback init: %v", err, ejectErr)
+						}
 					}
 					return fmt.Errorf("start daemon: %w", err)
 				}
@@ -49,7 +53,11 @@ func newInitCmd() *cobra.Command {
 				w := cmd.OutOrStdout()
 				fmt.Fprintln(w, sCyan.Render(banner))
 				fmt.Fprintln(w)
-				fmt.Fprintf(w, "  %s Gate initialized\n", sGreen.Render("✓"))
+				headline := "Gate initialized"
+				if !created {
+					headline = "Gate already initialized (refreshed)"
+				}
+				fmt.Fprintf(w, "  %s %s\n", sGreen.Render("✓"), headline)
 				fmt.Fprintln(w)
 				fmt.Fprintf(w, "  %s  %s\n", sDim.Render("  repo"), repo.WorkingPath)
 				fmt.Fprintf(w, "  %s  no-mistakes → %s\n", sDim.Render("  gate"), p.RepoDir(repo.ID))

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -17,9 +17,9 @@ func newInitCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "init",
 		Short: "Initialize no-mistakes gate for the current repository",
-		Long: "Sets up a local bare repo as a gate, installs a post-receive hook,\n" +
+		Long: "Sets up or refreshes a local bare repo as a gate, installs a post-receive hook,\n" +
 			"best-effort isolates the gate hook path from shared local git config writes when Git supports `config --worktree`,\n" +
-			"adds a \"no-mistakes\" git remote, and records the repo in the database.\n\n" +
+			"adds or repairs the \"no-mistakes\" git remote, and records the repo in the database.\n\n" +
 			"Run this from inside a git repository that has an \"origin\" remote.",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -29,7 +29,7 @@ func TestRootYesRunsWizardNonInteractively(t *testing.T) {
 	}
 	defer d.Close()
 
-	if _, err := gate.Init(context.Background(), d, p, "."); err != nil {
+	if _, _, err := gate.Init(context.Background(), d, p, "."); err != nil {
 		t.Fatal(err)
 	}
 
@@ -84,7 +84,7 @@ func TestRootSkipPassesStepsToWizard(t *testing.T) {
 	}
 	defer d.Close()
 
-	if _, err := gate.Init(context.Background(), d, p, "."); err != nil {
+	if _, _, err := gate.Init(context.Background(), d, p, "."); err != nil {
 		t.Fatal(err)
 	}
 
@@ -135,7 +135,7 @@ func TestRootYesUsesVisibleWizardWhenInteractive(t *testing.T) {
 	}
 	defer d.Close()
 
-	if _, err := gate.Init(context.Background(), d, p, "."); err != nil {
+	if _, _, err := gate.Init(context.Background(), d, p, "."); err != nil {
 		t.Fatal(err)
 	}
 
@@ -206,7 +206,7 @@ func TestRootYesFailsWhenWizardPushProducesNoRun(t *testing.T) {
 	}
 	defer d.Close()
 
-	if _, err := gate.Init(context.Background(), d, p, "."); err != nil {
+	if _, _, err := gate.Init(context.Background(), d, p, "."); err != nil {
 		t.Fatal(err)
 	}
 
@@ -239,7 +239,7 @@ func TestRootYesPassesCommandContextToWizard(t *testing.T) {
 	}
 	defer d.Close()
 
-	if _, err := gate.Init(context.Background(), d, p, "."); err != nil {
+	if _, _, err := gate.Init(context.Background(), d, p, "."); err != nil {
 		t.Fatal(err)
 	}
 
@@ -278,7 +278,7 @@ func TestRootYesStopsWaitingForRunWhenContextCanceled(t *testing.T) {
 	}
 	defer d.Close()
 
-	if _, err := gate.Init(context.Background(), d, p, "."); err != nil {
+	if _, _, err := gate.Init(context.Background(), d, p, "."); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/db/repo.go
+++ b/internal/db/repo.go
@@ -82,6 +82,17 @@ func (d *DB) GetRepoByPath(workingPath string) (*Repo, error) {
 	return r, nil
 }
 
+func (d *DB) UpdateRepoMetadata(id, upstreamURL, defaultBranch string) (*Repo, error) {
+	_, err := d.sql.Exec(
+		`UPDATE repos SET upstream_url = ?, default_branch = ? WHERE id = ?`,
+		upstreamURL, defaultBranch, id,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("update repo metadata: %w", err)
+	}
+	return d.GetRepo(id)
+}
+
 // DeleteRepo deletes a repo by ID (cascade deletes runs and steps).
 func (d *DB) DeleteRepo(id string) error {
 	_, err := d.sql.Exec(`DELETE FROM repos WHERE id = ?`, id)

--- a/internal/db/repo.go
+++ b/internal/db/repo.go
@@ -82,6 +82,8 @@ func (d *DB) GetRepoByPath(workingPath string) (*Repo, error) {
 	return r, nil
 }
 
+// UpdateRepoMetadata refreshes mutable repository metadata while preserving the
+// stable repo ID and created_at timestamp.
 func (d *DB) UpdateRepoMetadata(id, upstreamURL, defaultBranch string) (*Repo, error) {
 	_, err := d.sql.Exec(
 		`UPDATE repos SET upstream_url = ?, default_branch = ? WHERE id = ?`,

--- a/internal/e2e/init_test.go
+++ b/internal/e2e/init_test.go
@@ -16,6 +16,45 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/paths"
 )
 
+// TestInitIsIdempotent proves an existing user can re-run `init` to adopt new
+// capabilities (the agent skill) without hitting an "already initialized"
+// error, and that the second run reports the refresh and re-installs the skill.
+func TestInitIsIdempotent(t *testing.T) {
+	h := NewHarness(t, SetupOpts{Agent: "claude"})
+
+	first, err := h.RunInDir(h.WorkDir, "init")
+	if err != nil {
+		t.Fatalf("first init: %v\n%s", err, first)
+	}
+	if !strings.Contains(first, "Gate initialized") {
+		t.Errorf("first init should report a fresh gate, got:\n%s", first)
+	}
+	assertSkillInstalled(t, h)
+
+	// Remove the installed skill to prove the re-run reinstalls it.
+	skillPath := filepath.Join(h.WorkDir, ".claude", "skills", "no-mistakes", "SKILL.md")
+	if err := os.Remove(skillPath); err != nil {
+		t.Fatalf("remove skill: %v", err)
+	}
+
+	second, err := h.RunInDir(h.WorkDir, "init")
+	if err != nil {
+		t.Fatalf("re-init should succeed: %v\n%s", err, second)
+	}
+	if !strings.Contains(second, "already initialized") {
+		t.Errorf("re-init should report an existing gate, got:\n%s", second)
+	}
+	if strings.Contains(second, "already initialized for") {
+		t.Errorf("re-init must not fail with the old error, got:\n%s", second)
+	}
+	assertSkillInstalled(t, h)
+
+	// The no-mistakes remote must still be wired after the refresh.
+	if out, err := h.runGit(context.Background(), h.WorkDir, "remote", "get-url", "no-mistakes"); err != nil {
+		t.Fatalf("no-mistakes remote missing after re-init: %v\n%s", err, out)
+	}
+}
+
 func TestInitRollsBackWhenDaemonStartFails(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows IPC does not use Unix socket path limits")

--- a/internal/e2e/journey_test.go
+++ b/internal/e2e/journey_test.go
@@ -737,12 +737,14 @@ func assertInitOutput(t *testing.T, h *Harness, out string) {
 
 func assertInitAlreadyInitialized(t *testing.T, h *Harness) {
 	t.Helper()
+	// init is idempotent: re-running on an already-initialized repo must
+	// succeed and report a refresh rather than failing.
 	out, err := h.Run("init")
-	if err == nil {
-		t.Fatalf("second nm init should fail, got output:\n%s", out)
+	if err != nil {
+		t.Fatalf("second nm init should succeed (idempotent), got error: %v\n%s", err, out)
 	}
 	if !strings.Contains(out, "already initialized") {
-		t.Errorf("second init error output should mention 'already initialized', got:\n%s", out)
+		t.Errorf("second init should report 'already initialized', got:\n%s", out)
 	}
 }
 

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -70,13 +70,17 @@ func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Re
 		return nil, false, err
 	}
 
-	if existing != nil {
-		slog.Info("gate refreshed", "repo_id", existing.ID, "path", absRoot)
-		return existing, false, nil
-	}
-
 	// Detect default branch from upstream remote.
 	branch := git.DefaultBranch(ctx, absRoot, "origin")
+
+	if existing != nil {
+		repo, err := d.UpdateRepoMetadata(existing.ID, upstreamURL, branch)
+		if err != nil {
+			return nil, false, fmt.Errorf("update repo metadata: %w", err)
+		}
+		slog.Info("gate refreshed", "repo_id", repo.ID, "path", absRoot)
+		return repo, false, nil
+	}
 
 	// Insert repo record with deterministic ID.
 	repo, err := d.InsertRepoWithID(id, absRoot, upstreamURL, branch)

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -27,69 +27,52 @@ func repoID(absPath string) string {
 // isolates the bare repo's hooks path from shared local config writes when
 // Git supports config --worktree, adds the no-mistakes remote, and records
 // the repo in the database.
-func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Repo, error) {
+//
+// Init is idempotent: re-running it on an already-initialized repo repairs and
+// refreshes the gate (for example installing a newer hook, picking up hook-path
+// isolation, or restoring a missing remote) instead of failing. The returned
+// bool reports whether a new gate was created (true) or an existing one was
+// refreshed (false).
+func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Repo, bool, error) {
 	// Normalize worktrees back to the main repo root so one repo record works
 	// from either the main checkout or any attached worktree.
 	gitRoot, err := git.FindMainRepoRoot(workDir)
 	if err != nil {
-		return nil, fmt.Errorf("find git root: %w", err)
+		return nil, false, fmt.Errorf("find git root: %w", err)
 	}
 	absRoot := gitRoot
 
-	// Check if already initialized.
+	// Look up any existing gate so we know whether this is a fresh init or a
+	// refresh, and so we never tear down a working gate on a repair failure.
 	existing, err := d.GetRepoByPath(absRoot)
 	if err != nil {
-		return nil, fmt.Errorf("check existing: %w", err)
-	}
-	if existing != nil {
-		return nil, fmt.Errorf("already initialized for %s", absRoot)
+		return nil, false, fmt.Errorf("check existing: %w", err)
 	}
 
 	// Read origin URL.
 	upstreamURL, err := git.GetRemoteURL(ctx, absRoot, "origin")
 	if err != nil {
-		return nil, fmt.Errorf("get origin url: %w", err)
+		return nil, false, fmt.Errorf("get origin url: %w", err)
 	}
 
 	// Generate deterministic repo ID.
 	id := repoID(absRoot)
-
-	// Create bare repo.
 	bareDir := p.RepoDir(id)
-	if err := git.InitBare(ctx, bareDir); err != nil {
-		return nil, fmt.Errorf("create bare repo: %w", err)
-	}
-	if _, err := git.Run(ctx, bareDir, "config", "receive.advertisePushOptions", "true"); err != nil {
-		os.RemoveAll(bareDir)
-		return nil, fmt.Errorf("enable push options: %w", err)
+
+	// Provision (or repair) the on-disk gate. This is idempotent.
+	if err := provisionGate(ctx, bareDir, absRoot, upstreamURL); err != nil {
+		// Only tear down a gate we created in this call; never destroy an
+		// already-initialized gate when a repair pass fails.
+		if existing == nil {
+			git.RemoveRemote(ctx, absRoot, RemoteName)
+			os.RemoveAll(bareDir)
+		}
+		return nil, false, err
 	}
 
-	// Install post-receive hook.
-	if err := git.InstallPostReceiveHook(bareDir); err != nil {
-		// Rollback: remove bare repo.
-		os.RemoveAll(bareDir)
-		return nil, fmt.Errorf("install hook: %w", err)
-	}
-
-	// Pin core.hookspath in the bare's per-worktree config so subprocess
-	// writes to shared local config (e.g. husky during pnpm install) can't
-	// disable the gate hook. See git.IsolateHooksPath for details.
-	if err := git.IsolateHooksPath(ctx, bareDir); err != nil {
-		os.RemoveAll(bareDir)
-		return nil, fmt.Errorf("isolate hooks path: %w", err)
-	}
-
-	// Record upstream as origin on the gate repo so gh can resolve repository context
-	// from detached worktrees created from the gate.
-	if err := git.AddRemote(ctx, bareDir, "origin", upstreamURL); err != nil {
-		os.RemoveAll(bareDir)
-		return nil, fmt.Errorf("add gate origin remote: %w", err)
-	}
-
-	// Add remote to working repo.
-	if err := git.AddRemote(ctx, absRoot, RemoteName, bareDir); err != nil {
-		os.RemoveAll(bareDir)
-		return nil, fmt.Errorf("add remote: %w", err)
+	if existing != nil {
+		slog.Info("gate refreshed", "repo_id", existing.ID, "path", absRoot)
+		return existing, false, nil
 	}
 
 	// Detect default branch from upstream remote.
@@ -101,11 +84,50 @@ func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Re
 		// Rollback: remove remote and bare repo.
 		git.RemoveRemote(ctx, absRoot, RemoteName)
 		os.RemoveAll(bareDir)
-		return nil, fmt.Errorf("insert repo: %w", err)
+		return nil, false, fmt.Errorf("insert repo: %w", err)
 	}
 
 	slog.Info("gate initialized", "repo_id", id, "path", absRoot, "upstream", upstreamURL)
-	return repo, nil
+	return repo, true, nil
+}
+
+// provisionGate creates or repairs the on-disk gate for a repo: the bare repo,
+// its push/hook configuration, hook-path isolation, and the git remotes wiring
+// the working repo to the gate and the gate to its upstream. Every step is
+// idempotent so this doubles as the repair path for re-running init.
+func provisionGate(ctx context.Context, bareDir, absRoot, upstreamURL string) error {
+	// Create the bare repo. git init --bare is a no-op on an existing one.
+	if err := git.InitBare(ctx, bareDir); err != nil {
+		return fmt.Errorf("create bare repo: %w", err)
+	}
+	if _, err := git.Run(ctx, bareDir, "config", "receive.advertisePushOptions", "true"); err != nil {
+		return fmt.Errorf("enable push options: %w", err)
+	}
+
+	// Install post-receive hook.
+	if err := git.InstallPostReceiveHook(bareDir); err != nil {
+		return fmt.Errorf("install hook: %w", err)
+	}
+
+	// Pin core.hookspath in the bare's per-worktree config so subprocess
+	// writes to shared local config (e.g. husky during pnpm install) can't
+	// disable the gate hook. See git.IsolateHooksPath for details.
+	if err := git.IsolateHooksPath(ctx, bareDir); err != nil {
+		return fmt.Errorf("isolate hooks path: %w", err)
+	}
+
+	// Record upstream as origin on the gate repo so gh can resolve repository
+	// context from detached worktrees created from the gate.
+	if err := git.EnsureRemote(ctx, bareDir, "origin", upstreamURL); err != nil {
+		return fmt.Errorf("add gate origin remote: %w", err)
+	}
+
+	// Add remote to working repo.
+	if err := git.EnsureRemote(ctx, absRoot, RemoteName, bareDir); err != nil {
+		return fmt.Errorf("add remote: %w", err)
+	}
+
+	return nil
 }
 
 // Eject removes the no-mistakes gate from the repo at workDir.

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -55,8 +55,10 @@ func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Re
 		return nil, false, fmt.Errorf("get origin url: %w", err)
 	}
 
-	// Generate deterministic repo ID.
 	id := repoID(absRoot)
+	if existing != nil {
+		id = existing.ID
+	}
 	bareDir := p.RepoDir(id)
 
 	// Provision (or repair) the on-disk gate. This is idempotent.

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -60,11 +60,13 @@ func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Re
 	bareDir := p.RepoDir(id)
 
 	// Provision (or repair) the on-disk gate. This is idempotent.
-	if err := provisionGate(ctx, bareDir, absRoot, upstreamURL); err != nil {
+	if err := provisionGate(ctx, bareDir, absRoot, upstreamURL, existing != nil); err != nil {
 		// Only tear down a gate we created in this call; never destroy an
 		// already-initialized gate when a repair pass fails.
 		if existing == nil {
-			git.RemoveRemote(ctx, absRoot, RemoteName)
+			if remoteURL, remoteErr := git.GetRemoteURL(ctx, absRoot, RemoteName); remoteErr == nil && remoteURL == bareDir {
+				git.RemoveRemote(ctx, absRoot, RemoteName)
+			}
 			os.RemoveAll(bareDir)
 		}
 		return nil, false, err
@@ -99,7 +101,7 @@ func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Re
 // its push/hook configuration, hook-path isolation, and the git remotes wiring
 // the working repo to the gate and the gate to its upstream. Every step is
 // idempotent so this doubles as the repair path for re-running init.
-func provisionGate(ctx context.Context, bareDir, absRoot, upstreamURL string) error {
+func provisionGate(ctx context.Context, bareDir, absRoot, upstreamURL string, refresh bool) error {
 	// Create the bare repo. git init --bare is a no-op on an existing one.
 	if err := git.InitBare(ctx, bareDir); err != nil {
 		return fmt.Errorf("create bare repo: %w", err)
@@ -108,8 +110,7 @@ func provisionGate(ctx context.Context, bareDir, absRoot, upstreamURL string) er
 		return fmt.Errorf("enable push options: %w", err)
 	}
 
-	// Install post-receive hook.
-	if err := git.InstallPostReceiveHook(bareDir); err != nil {
+	if _, err := git.RefreshManagedPostReceiveHook(bareDir); err != nil {
 		return fmt.Errorf("install hook: %w", err)
 	}
 
@@ -126,12 +127,25 @@ func provisionGate(ctx context.Context, bareDir, absRoot, upstreamURL string) er
 		return fmt.Errorf("add gate origin remote: %w", err)
 	}
 
-	// Add remote to working repo.
-	if err := git.EnsureRemote(ctx, absRoot, RemoteName, bareDir); err != nil {
+	if err := ensureWorkingRemote(ctx, absRoot, bareDir, refresh); err != nil {
 		return fmt.Errorf("add remote: %w", err)
 	}
 
 	return nil
+}
+
+func ensureWorkingRemote(ctx context.Context, absRoot, bareDir string, refresh bool) error {
+	if refresh {
+		return git.EnsureRemote(ctx, absRoot, RemoteName, bareDir)
+	}
+	existingURL, err := git.GetRemoteURL(ctx, absRoot, RemoteName)
+	if err != nil {
+		return git.AddRemote(ctx, absRoot, RemoteName, bareDir)
+	}
+	if existingURL == bareDir {
+		return nil
+	}
+	return fmt.Errorf("remote %q already exists with url %q", RemoteName, existingURL)
 }
 
 // Eject removes the no-mistakes gate from the repo at workDir.

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -76,7 +76,7 @@ func TestInit(t *testing.T) {
 	d := openTestDB(t, p)
 	ctx := context.Background()
 
-	repo, err := Init(ctx, d, p, workDir)
+	repo, _, err := Init(ctx, d, p, workDir)
 	if err != nil {
 		t.Fatalf("init: %v", err)
 	}
@@ -160,7 +160,11 @@ func TestInitRepoID(t *testing.T) {
 	}
 }
 
-func TestInitAlreadyInitialized(t *testing.T) {
+// TestInitIsIdempotent verifies that re-running Init on an already-initialized
+// repo succeeds, reports that it was not newly created, and leaves a single
+// repo record and an intact gate. This is what lets existing users re-run init
+// to adopt new capabilities (e.g. the agent skill) without hitting an error.
+func TestInitIsIdempotent(t *testing.T) {
 	workDir := setupTestRepo(t)
 	nmRoot := t.TempDir()
 	p := paths.WithRoot(nmRoot)
@@ -170,14 +174,83 @@ func TestInitAlreadyInitialized(t *testing.T) {
 	d := openTestDB(t, p)
 	ctx := context.Background()
 
-	if _, err := Init(ctx, d, p, workDir); err != nil {
+	first, created, err := Init(ctx, d, p, workDir)
+	if err != nil {
 		t.Fatalf("first init: %v", err)
 	}
+	if !created {
+		t.Error("first init should report created=true")
+	}
 
-	// Second init should fail.
-	_, err := Init(ctx, d, p, workDir)
-	if err == nil {
-		t.Fatal("expected error on re-init")
+	second, created, err := Init(ctx, d, p, workDir)
+	if err != nil {
+		t.Fatalf("re-init should succeed, got: %v", err)
+	}
+	if created {
+		t.Error("re-init should report created=false")
+	}
+	if second.ID != first.ID {
+		t.Errorf("re-init repo ID = %q, want %q", second.ID, first.ID)
+	}
+
+	// The gate must remain healthy and the DB must not gain a duplicate record.
+	bareDir := p.RepoDir(first.ID)
+	if !fileExists(filepath.Join(bareDir, "hooks", "post-receive")) {
+		t.Error("post-receive hook missing after re-init")
+	}
+	if url, err := gitpkg.GetRemoteURL(ctx, workDir, RemoteName); err != nil {
+		t.Errorf("no-mistakes remote missing after re-init: %v", err)
+	} else if url != bareDir {
+		t.Errorf("remote url = %q, want %q", url, bareDir)
+	}
+	dbRepo, err := d.GetRepoByPath(workDir)
+	if err != nil {
+		t.Fatalf("get repo by path: %v", err)
+	}
+	if dbRepo == nil || dbRepo.ID != first.ID {
+		t.Errorf("expected single repo record %q, got %+v", first.ID, dbRepo)
+	}
+}
+
+// TestInitRepairsBrokenGate verifies that re-running Init restores gate wiring
+// that was torn down out from under it (e.g. a deleted hook or remote), so init
+// doubles as a repair command.
+func TestInitRepairsBrokenGate(t *testing.T) {
+	workDir := setupTestRepo(t)
+	nmRoot := t.TempDir()
+	p := paths.WithRoot(nmRoot)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	d := openTestDB(t, p)
+	ctx := context.Background()
+
+	repo, _, err := Init(ctx, d, p, workDir)
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	bareDir := p.RepoDir(repo.ID)
+
+	// Break the gate: drop the working repo's remote and delete the hook.
+	if err := gitpkg.RemoveRemote(ctx, workDir, RemoteName); err != nil {
+		t.Fatalf("remove remote: %v", err)
+	}
+	hookPath := filepath.Join(bareDir, "hooks", "post-receive")
+	if err := os.Remove(hookPath); err != nil {
+		t.Fatalf("remove hook: %v", err)
+	}
+
+	if _, _, err := Init(ctx, d, p, workDir); err != nil {
+		t.Fatalf("re-init (repair) should succeed: %v", err)
+	}
+
+	if !fileExists(hookPath) {
+		t.Error("post-receive hook not restored after repair re-init")
+	}
+	if url, err := gitpkg.GetRemoteURL(ctx, workDir, RemoteName); err != nil {
+		t.Errorf("no-mistakes remote not restored after repair re-init: %v", err)
+	} else if url != bareDir {
+		t.Errorf("restored remote url = %q, want %q", url, bareDir)
 	}
 }
 
@@ -195,7 +268,7 @@ func TestInitNoOrigin(t *testing.T) {
 	}
 	d := openTestDB(t, p)
 
-	_, err := Init(context.Background(), d, p, work)
+	_, _, err := Init(context.Background(), d, p, work)
 	if err == nil {
 		t.Fatal("expected error when no origin remote")
 	}
@@ -210,7 +283,7 @@ func TestInitNotGitRepo(t *testing.T) {
 	}
 	d := openTestDB(t, p)
 
-	_, err := Init(context.Background(), d, p, notGit)
+	_, _, err := Init(context.Background(), d, p, notGit)
 	if err == nil {
 		t.Fatal("expected error for non-git directory")
 	}
@@ -258,7 +331,7 @@ func TestInitDetectsDefaultBranchFromRemote(t *testing.T) {
 	}
 	d := openTestDB(t, p)
 
-	repo, err := Init(context.Background(), d, p, work)
+	repo, _, err := Init(context.Background(), d, p, work)
 	if err != nil {
 		t.Fatalf("init: %v", err)
 	}
@@ -279,7 +352,7 @@ func TestEject(t *testing.T) {
 	d := openTestDB(t, p)
 	ctx := context.Background()
 
-	repo, err := Init(ctx, d, p, workDir)
+	repo, _, err := Init(ctx, d, p, workDir)
 	if err != nil {
 		t.Fatalf("init: %v", err)
 	}
@@ -320,7 +393,7 @@ func TestEjectCleansUpWorktrees(t *testing.T) {
 	d := openTestDB(t, p)
 	ctx := context.Background()
 
-	repo, err := Init(ctx, d, p, workDir)
+	repo, _, err := Init(ctx, d, p, workDir)
 	if err != nil {
 		t.Fatalf("init: %v", err)
 	}
@@ -384,7 +457,7 @@ func TestInit_PostReceiveSurvivesHooksPathPoisoning(t *testing.T) {
 	d := openTestDB(t, p)
 	ctx := context.Background()
 
-	repo, err := Init(ctx, d, p, workDir)
+	repo, _, err := Init(ctx, d, p, workDir)
 	if err != nil {
 		t.Fatalf("init: %v", err)
 	}

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -284,6 +284,55 @@ func TestInitRefreshUpdatesRepoMetadata(t *testing.T) {
 	}
 }
 
+func TestInitRefreshUsesPersistedRepoID(t *testing.T) {
+	workDir := setupTestRepo(t)
+	nmRoot := t.TempDir()
+	p := paths.WithRoot(nmRoot)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	d := openTestDB(t, p)
+	ctx := context.Background()
+
+	legacyID := "legacy-repo"
+	originURL, err := gitpkg.GetRemoteURL(ctx, workDir, "origin")
+	if err != nil {
+		t.Fatalf("get origin url: %v", err)
+	}
+	if _, err := d.InsertRepoWithID(legacyID, workDir, originURL, "main"); err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+
+	repo, created, err := Init(ctx, d, p, workDir)
+	if err != nil {
+		t.Fatalf("refresh init: %v", err)
+	}
+	if created {
+		t.Fatal("refresh init should report created=false")
+	}
+	if repo.ID != legacyID {
+		t.Fatalf("repo ID = %q, want %q", repo.ID, legacyID)
+	}
+
+	legacyBareDir := p.RepoDir(legacyID)
+	url, err := gitpkg.GetRemoteURL(ctx, workDir, RemoteName)
+	if err != nil {
+		t.Fatalf("get no-mistakes remote: %v", err)
+	}
+	if url != legacyBareDir {
+		t.Errorf("no-mistakes remote = %q, want %q", url, legacyBareDir)
+	}
+	if out, err := exec.Command("git", "-C", legacyBareDir, "rev-parse", "--is-bare-repository").Output(); err != nil {
+		t.Errorf("legacy bare repo check failed: %v", err)
+	} else if got := string(out); got != "true\n" {
+		t.Errorf("legacy is-bare = %q, want true", got)
+	}
+	computedBareDir := p.RepoDir(repoID(workDir))
+	if computedBareDir != legacyBareDir && fileExists(computedBareDir) {
+		t.Errorf("unexpected computed bare repo exists at %q", computedBareDir)
+	}
+}
+
 // TestInitRepairsBrokenGate verifies that re-running Init restores gate wiring
 // that was torn down out from under it (e.g. a deleted hook or remote), so init
 // doubles as a repair command.

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -326,6 +326,71 @@ func TestInitRepairsBrokenGate(t *testing.T) {
 	}
 }
 
+func TestInitDoesNotOverwriteExistingNoMistakesRemoteOnFreshInit(t *testing.T) {
+	workDir := setupTestRepo(t)
+	nmRoot := t.TempDir()
+	p := paths.WithRoot(nmRoot)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	d := openTestDB(t, p)
+	ctx := context.Background()
+
+	customRemote := filepath.Join(resolveSymlinks(t, t.TempDir()), "custom.git")
+	if out, err := exec.Command("git", "init", "--bare", customRemote).CombinedOutput(); err != nil {
+		t.Fatalf("init custom remote: %v: %s", err, out)
+	}
+	if err := gitpkg.AddRemote(ctx, workDir, RemoteName, customRemote); err != nil {
+		t.Fatalf("add custom remote: %v", err)
+	}
+
+	_, _, err := Init(ctx, d, p, workDir)
+	if err == nil {
+		t.Fatal("expected init to fail when no-mistakes remote already exists")
+	}
+
+	url, err := gitpkg.GetRemoteURL(ctx, workDir, RemoteName)
+	if err != nil {
+		t.Fatalf("get custom remote: %v", err)
+	}
+	if url != customRemote {
+		t.Errorf("no-mistakes remote = %q, want %q", url, customRemote)
+	}
+}
+
+func TestInitRefreshPreservesCustomPostReceiveHook(t *testing.T) {
+	workDir := setupTestRepo(t)
+	nmRoot := t.TempDir()
+	p := paths.WithRoot(nmRoot)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	d := openTestDB(t, p)
+	ctx := context.Background()
+
+	repo, _, err := Init(ctx, d, p, workDir)
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	hookPath := filepath.Join(p.RepoDir(repo.ID), "hooks", "post-receive")
+	customHook := []byte("#!/bin/sh\necho custom hook\n")
+	if err := os.WriteFile(hookPath, customHook, 0o755); err != nil {
+		t.Fatalf("write custom hook: %v", err)
+	}
+
+	if _, _, err := Init(ctx, d, p, workDir); err != nil {
+		t.Fatalf("re-init: %v", err)
+	}
+
+	got, err := os.ReadFile(hookPath)
+	if err != nil {
+		t.Fatalf("read hook: %v", err)
+	}
+	if string(got) != string(customHook) {
+		t.Errorf("custom hook was overwritten")
+	}
+}
+
 func TestInitNoOrigin(t *testing.T) {
 	// Create a repo without origin.
 	work := filepath.Join(resolveSymlinks(t, t.TempDir()), "work")

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -212,6 +212,78 @@ func TestInitIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestInitRefreshUpdatesRepoMetadata(t *testing.T) {
+	workDir := setupTestRepo(t)
+	nmRoot := t.TempDir()
+	p := paths.WithRoot(nmRoot)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	d := openTestDB(t, p)
+	ctx := context.Background()
+
+	first, created, err := Init(ctx, d, p, workDir)
+	if err != nil {
+		t.Fatalf("first init: %v", err)
+	}
+	if !created {
+		t.Fatal("first init should report created=true")
+	}
+
+	newUpstream := filepath.Join(resolveSymlinks(t, t.TempDir()), "new-upstream.git")
+	if out, err := exec.Command("git", "init", "--bare", newUpstream).CombinedOutput(); err != nil {
+		t.Fatalf("init new upstream: %v: %s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", workDir, "push", newUpstream, "HEAD:refs/heads/trunk").CombinedOutput(); err != nil {
+		t.Fatalf("push trunk: %v: %s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", newUpstream, "symbolic-ref", "HEAD", "refs/heads/trunk").CombinedOutput(); err != nil {
+		t.Fatalf("set new upstream HEAD: %v: %s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", workDir, "remote", "set-url", "origin", newUpstream).CombinedOutput(); err != nil {
+		t.Fatalf("set origin url: %v: %s", err, out)
+	}
+
+	refreshed, created, err := Init(ctx, d, p, workDir)
+	if err != nil {
+		t.Fatalf("refresh init: %v", err)
+	}
+	if created {
+		t.Fatal("refresh init should report created=false")
+	}
+	if refreshed.ID != first.ID {
+		t.Fatalf("refreshed repo ID = %q, want %q", refreshed.ID, first.ID)
+	}
+	if refreshed.UpstreamURL != newUpstream {
+		t.Errorf("refreshed upstream URL = %q, want %q", refreshed.UpstreamURL, newUpstream)
+	}
+	if refreshed.DefaultBranch != "trunk" {
+		t.Errorf("refreshed default branch = %q, want trunk", refreshed.DefaultBranch)
+	}
+
+	dbRepo, err := d.GetRepoByPath(workDir)
+	if err != nil {
+		t.Fatalf("get repo by path: %v", err)
+	}
+	if dbRepo == nil {
+		t.Fatal("expected repo in DB")
+	}
+	if dbRepo.UpstreamURL != newUpstream {
+		t.Errorf("db upstream URL = %q, want %q", dbRepo.UpstreamURL, newUpstream)
+	}
+	if dbRepo.DefaultBranch != "trunk" {
+		t.Errorf("db default branch = %q, want trunk", dbRepo.DefaultBranch)
+	}
+
+	gateOrigin, err := gitpkg.GetRemoteURL(ctx, p.RepoDir(first.ID), "origin")
+	if err != nil {
+		t.Fatalf("get gate origin: %v", err)
+	}
+	if gateOrigin != newUpstream {
+		t.Errorf("gate origin = %q, want %q", gateOrigin, newUpstream)
+	}
+}
+
 // TestInitRepairsBrokenGate verifies that re-running Init restores gate wiring
 // that was torn down out from under it (e.g. a deleted hook or remote), so init
 // doubles as a repair command.

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -53,6 +53,17 @@ func AddRemote(ctx context.Context, dir, name, url string) error {
 	return err
 }
 
+// EnsureRemote sets the named remote to url, adding it when absent and
+// updating its URL when it already exists. Idempotent, so it is safe to call
+// when repairing or re-running an init.
+func EnsureRemote(ctx context.Context, dir, name, url string) error {
+	if _, err := GetRemoteURL(ctx, dir, name); err == nil {
+		_, err := Run(ctx, dir, "remote", "set-url", name, url)
+		return err
+	}
+	return AddRemote(ctx, dir, name, url)
+}
+
 // RemoveRemote removes a named remote from the repo at dir.
 func RemoveRemote(ctx context.Context, dir, name string) error {
 	_, err := Run(ctx, dir, "remote", "remove", name)


### PR DESCRIPTION
## Intent

The developer wanted no-mistakes init to become idempotent so existing users who had already initialized a repo could rerun it successfully to adopt the newly added agent skill. They required re-init to refresh or repair the existing gate rather than fail, including updating hooks, remotes, hook-path isolation, and skill installation. They also wanted to avoid destroying an existing working gate if daemon startup failed during a re-run. Verification needed to follow TDD with updated unit and e2e coverage for the new idempotent behavior.

## What Changed

- Reworked `no-mistakes init` to refresh existing repository gates instead of failing, repairing gate config, remotes, hook-path isolation, post-receive hooks, and agent skill installation.
- Preserved user-owned working remotes and custom gate hooks during refresh, while updating persisted repo metadata and using the stored repo ID for existing records.
- Added unit, e2e, documentation, and manual verification coverage for idempotent init and refresh behavior.

## Risk Assessment

⚠️ Medium: The remaining change is well covered and no material issues were found, but it modifies gate initialization, hook refresh, and git remote wiring, which are stateful user-repository operations.

## Testing

No separate baseline commands were provided; I ran targeted gate and e2e tests for the idempotent init change, captured an end-user CLI transcript showing first init and refreshed re-init restoring the skill and gate wiring, cleaned the temporary sandbox, and finished with `go test -race ./...`; all checks passed.

<details>
<summary>Evidence: Idempotent init CLI transcript</summary>

Source: [Idempotent init CLI transcript](https://github.com/kunchenguid/no-mistakes/blob/3c3d60480a5b27a2dd70b0577ae7f7125dbf3fc5/.no-mistakes/evidence/fix/idempotent-init/idempotent-init-cli-transcript.txt)

```text
Shows first `no-mistakes init` reporting `Gate initialized`, second init reporting `Gate already initialized (refreshed)`, and verification that the skill was restored, the `no-mistakes` remote points at the gate, the post-receive hook is executable, `core.hooksPath` is isolated, and the gate origin remote points to upstream.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (3) ✅</summary>

- ⚠️ `internal/gate/gate.go:73` - Refresh uses the current `origin` to repair the gate remote, but then returns the existing DB row without updating `upstream_url` or `default_branch`. After a repo&#39;s origin/default branch changes, `init` appears to refresh successfully while later pipeline steps still push/fetch/PR against stale DB values.
- ⚠️ `internal/gate/gate.go:108` - Re-init always calls `InstallPostReceiveHook`, which unconditionally overwrites any existing `hooks/post-receive` in the gate. This conflicts with the existing managed-hook refresh path that preserves custom hooks, and can silently delete a user&#39;s custom gate hook during an idempotent refresh.

🔧 Fix: Refresh repo metadata during init
2 warnings still open:
- ⚠️ `internal/gate/gate.go:130` - Fresh init now calls `EnsureRemote` for the working repo, so if a repo already has a user-created `no-mistakes` remote but no DB record, init silently rewrites that remote to the local gate. The previous `AddRemote` path failed without changing the user&#39;s remote, so this can unexpectedly retarget an existing remote during first-time init; keep overwrite behavior only for confirmed refreshes or when the existing URL already matches the gate.
- ⚠️ `internal/gate/gate.go:112` - Re-init still uses `InstallPostReceiveHook`, which unconditionally overwrites `hooks/post-receive` in the gate. That conflicts with the managed-hook refresh path in `daemon.migrateGateConfigs` that preserves custom hooks, and can delete a user&#39;s custom gate hook during an idempotent refresh.

🔧 Fix: Preserve user remotes and custom hooks
1 warning still open:
- ⚠️ `internal/gate/gate.go:60` - Refresh computes the gate path from `repoID(absRoot)` instead of using the persisted `existing.ID`. If an existing DB row ever has a non-matching ID, init repairs and rewires the working remote to one gate directory while returning a repo whose ID makes the daemon/status/output look at a different directory, leaving the refreshed gate unusable. Use `existing.ID` for the refresh gate path and reserve the computed ID for fresh inserts.

🔧 Fix: Use persisted repo ID on refresh
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/gate -run 'TestInit(IsIdempotent|RefreshUpdatesRepoMetadata|RefreshUsesPersistedRepoID|RepairsBrokenGate|RefreshPreservesCustomPostReceiveHook)$' -count=1`
- `go test -tags e2e ./internal/e2e -run '^TestInit(IsIdempotent|RollsBackWhenDaemonStartFails)$' -count=1`
- <code>Manual CLI verification: built `./cmd/no-mistakes`, initialized a real git repo with an origin, ran `no-mistakes init`, removed `.claude/skills/no-mistakes/SKILL.md`, reran `no-mistakes init`, then verified the refreshed output, restored skill, `no-mistakes` remote, executable post-receive hook, isolated `core.hooksPath`, and gate origin remote.</code>
- `go test -race ./...`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
