### PR TITLE
feat(tui): show checks-passed CI monitoring state

### DIFF
--- a/.no-mistakes/evidence/feat/ready-to-merge-ci-state/tui-ci-ready-surface.txt
+++ b/.no-mistakes/evidence/feat/ready-to-merge-ci-state/tui-ci-ready-surface.txt
@@ -1,0 +1,86 @@
+=== RUN   TestEvidence_CIReadyToMergeSurface
+    ci_evidence_test.go:23: terminal title when ready: ✓ Checks passed - feature/foo
+    ci_evidence_test.go:24: CI panel when ready:
+        ╭─ CI ─────────────────────────────────────────────────────────────────────────╮
+        │ PR #42                                                                       │
+        │                                                                              │
+        │ ✓ Checks passed                                                              │
+        │ still monitoring until merged or closed                                      │
+        │ Latest: all CI checks passed - still monitoring until merged or closed       │
+        │                                                                              │
+        │ monitoring CI for PR #42 (timeout: 4h)...                                    │
+        │ all CI checks passed - still monitoring until merged or closed               │
+        ╰──────────────────────────────────────────────────────────────────────────────╯
+    ci_evidence_test.go:30: CI panel after checks re-run:
+        ╭─ CI ─────────────────────────────────────────────────────────────────────────╮
+        │ PR #42                                                                       │
+        │                                                                              │
+        │ ◉ Monitoring CI checks...                                                    │
+        │ Latest: CI checks running, waiting for results...                            │
+        │                                                                              │
+        │ all CI checks passed - still monitoring until merged or closed               │
+        │ CI checks running, waiting for results...                                    │
+        ╰──────────────────────────────────────────────────────────────────────────────╯
+    ci_evidence_test.go:37: CI panel during real CI auto-fix attempt:
+        ╭─ CI ─────────────────────────────────────────────────────────────────────────╮
+        │ PR #42                                                                       │
+        │                                                                              │
+        │ ⚙ Auto-fixing CI failures...                                                 │
+        │ CI auto-fixes: 1                                                             │
+        │ Latest: running agent to fix CI issues...                                    │
+        │                                                                              │
+        │ monitoring CI for PR #42 (timeout: 4h)...                                    │
+        │ issues detected: test - auto-fixing (attempt 1/3)...                         │
+        │ running agent to fix CI issues...                                            │
+        ╰──────────────────────────────────────────────────────────────────────────────╯
+--- PASS: TestEvidence_CIReadyToMergeSurface (0.00s)
+=== RUN   TestParseCIActivity
+=== RUN   TestParseCIActivity/empty_logs
+=== RUN   TestParseCIActivity/polling
+=== RUN   TestParseCIActivity/ci_failure_detected
+=== RUN   TestParseCIActivity/ci_fix_completed
+=== RUN   TestParseCIActivity/multiple_ci_fixes
+=== RUN   TestParseCIActivity/pr_merged
+=== RUN   TestParseCIActivity/pr_closed
+=== RUN   TestParseCIActivity/timeout
+=== RUN   TestParseCIActivity/checks_passed_when_checks_pass
+=== RUN   TestParseCIActivity/checks_passed_when_no_checks_configured
+=== RUN   TestParseCIActivity/not_ready_from_agent_output
+=== RUN   TestParseCIActivity/ready_cleared_when_checks_re-run
+=== RUN   TestParseCIActivity/ready_cleared_when_new_failure_detected
+=== RUN   TestParseCIActivity/ready_cleared_when_mergeability_becomes_pending
+=== RUN   TestParseCIActivity/ready_cleared_when_polling_warning_appears
+=== RUN   TestParseCIActivity/ready_cleared_when_polling_warning_appears/warning:_could_not_check_CI:_rate_limited
+=== RUN   TestParseCIActivity/ready_cleared_when_polling_warning_appears/warning:_could_not_check_mergeable_state:_rate_limited
+=== RUN   TestParseCIActivity/ready_cleared_when_polling_warning_appears/warning:_could_not_check_PR_state:_rate_limited
+=== RUN   TestParseCIActivity/not_ready_while_monitoring
+--- PASS: TestParseCIActivity (0.00s)
+    --- PASS: TestParseCIActivity/empty_logs (0.00s)
+    --- PASS: TestParseCIActivity/polling (0.00s)
+    --- PASS: TestParseCIActivity/ci_failure_detected (0.00s)
+    --- PASS: TestParseCIActivity/ci_fix_completed (0.00s)
+    --- PASS: TestParseCIActivity/multiple_ci_fixes (0.00s)
+    --- PASS: TestParseCIActivity/pr_merged (0.00s)
+    --- PASS: TestParseCIActivity/pr_closed (0.00s)
+    --- PASS: TestParseCIActivity/timeout (0.00s)
+    --- PASS: TestParseCIActivity/checks_passed_when_checks_pass (0.00s)
+    --- PASS: TestParseCIActivity/checks_passed_when_no_checks_configured (0.00s)
+    --- PASS: TestParseCIActivity/not_ready_from_agent_output (0.00s)
+    --- PASS: TestParseCIActivity/ready_cleared_when_checks_re-run (0.00s)
+    --- PASS: TestParseCIActivity/ready_cleared_when_new_failure_detected (0.00s)
+    --- PASS: TestParseCIActivity/ready_cleared_when_mergeability_becomes_pending (0.00s)
+    --- PASS: TestParseCIActivity/ready_cleared_when_polling_warning_appears (0.00s)
+        --- PASS: TestParseCIActivity/ready_cleared_when_polling_warning_appears/warning:_could_not_check_CI:_rate_limited (0.00s)
+        --- PASS: TestParseCIActivity/ready_cleared_when_polling_warning_appears/warning:_could_not_check_mergeable_state:_rate_limited (0.00s)
+        --- PASS: TestParseCIActivity/ready_cleared_when_polling_warning_appears/warning:_could_not_check_PR_state:_rate_limited (0.00s)
+    --- PASS: TestParseCIActivity/not_ready_while_monitoring (0.00s)
+=== RUN   TestRenderCIView_ChecksPassed
+--- PASS: TestRenderCIView_ChecksPassed (0.00s)
+=== RUN   TestRenderCIView_ReadyClearedWhenChecksRerun
+--- PASS: TestRenderCIView_ReadyClearedWhenChecksRerun (0.00s)
+=== RUN   TestTerminalTitle_CIChecksPassed
+--- PASS: TestTerminalTitle_CIChecksPassed (0.00s)
+=== RUN   TestTerminalTitle_CIMonitoringNotReady
+--- PASS: TestTerminalTitle_CIMonitoringNotReady (0.00s)
+PASS
+ok  	github.com/kunchenguid/no-mistakes/internal/tui	0.396s

--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -54,6 +54,7 @@ That is a core design choice, not an implementation detail.
 6. If a step pauses, you can attach with the TUI or use `no-mistakes axi respond` to approve, fix, skip, or abort.
 7. After local checks pass, the push step forwards the branch upstream and the PR step creates or updates the pull request.
 8. The CI step keeps watching the open PR until it is merged or closed, and can auto-fix failures or merge conflicts when supported.
+   While it watches, the TUI and terminal title surface a `Ready to merge` signal once checks are green and the PR is mergeable, so you know when to go merge it.
 
 **Key design decisions:**
 

--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -54,7 +54,7 @@ That is a core design choice, not an implementation detail.
 6. If a step pauses, you can attach with the TUI or use `no-mistakes axi respond` to approve, fix, skip, or abort.
 7. After local checks pass, the push step forwards the branch upstream and the PR step creates or updates the pull request.
 8. The CI step keeps watching the open PR until it is merged or closed, and can auto-fix failures or merge conflicts when supported.
-   While it watches, the TUI and terminal title surface a `Ready to merge` signal once checks are green and the PR is mergeable, so you know when to go merge it.
+   While it watches, the TUI and terminal title surface a `Checks passed` signal once checks are green and the PR is mergeable, so you know when to go merge it.
 
 **Key design decisions:**
 

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -187,6 +187,8 @@ ci_timeout: "8h"
 ```
 
 The CI step keeps monitoring while the PR remains open, even after checks are currently healthy, because a later default-branch update can make the PR conflict or rerun CI.
+Once checks are green and the PR is mergeable, the CI panel shows `✓ Ready to merge` and the terminal title switches to `Ready to merge`, so you can tell when to go merge the PR.
+The signal clears automatically if checks start re-running or a new failure appears.
 If the PR is still open at the timeout, the step pauses for approval with findings for the open monitoring state or any known unresolved failures.
 You can approve (accept the risk), fix (run another auto-fix cycle), skip, or abort from the TUI or `no-mistakes axi respond`.
 

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -187,7 +187,7 @@ ci_timeout: "8h"
 ```
 
 The CI step keeps monitoring while the PR remains open, even after checks are currently healthy, because a later default-branch update can make the PR conflict or rerun CI.
-Once checks are green and the PR is mergeable, the CI panel shows `✓ Ready to merge` and the terminal title switches to `Ready to merge`, so you can tell when to go merge the PR.
+Once checks are green and the PR is mergeable, the CI panel shows `✓ Checks passed` and the terminal title switches to `Checks passed`, so you can tell when to go merge the PR.
 The signal clears automatically if checks start re-running or a new failure appears.
 If the PR is still open at the timeout, the step pauses for approval with findings for the open monitoring state or any known unresolved failures.
 You can approve (accept the risk), fix (run another auto-fix cycle), skip, or abort from the TUI or `no-mistakes axi respond`.

--- a/docs/src/content/docs/guides/tui.md
+++ b/docs/src/content/docs/guides/tui.md
@@ -123,6 +123,14 @@ During running steps, shows streaming agent output. Lines starting with `PASS` a
 
 On narrow terminals, the log panel expands to fill the remaining vertical space below the pipeline box instead of staying at the compact fixed height used in shorter layouts.
 
+### CI panel
+
+While the CI step is active, the TUI shows a dedicated CI panel instead of the generic findings view.
+It shows the PR label, the latest CI activity, and a log tail.
+When a real CI auto-fix attempt starts, the panel increments `CI auto-fixes: N`.
+Once checks are green and known mergeability is clear, the panel shows `✓ Checks passed` with `still monitoring until merged or closed`, and the terminal title switches to `Checks passed`.
+That ready signal clears if checks start running again, new failures appear, provider state becomes uncertain, or the PR is merged or closed.
+
 ### Footer
 
 The footer shows detach/help/yolo actions and, when `no-mistakes attach` has a cached newer release available, a right-aligned `<version> available` indicator. That update indicator stays visible after reruns in the same TUI session.

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -171,6 +171,7 @@ Monitors PR health after creation and auto-fixes CI failures. Mergeability polli
 - Polls provider CI status at increasing intervals: every 30s for the first 5 minutes, every 60s for 5-15 minutes, every 120s after that
 - Continues monitoring an open PR until it is merged, closed, declined, or times out, even after CI checks are currently healthy
 - On GitHub and GitLab, polls provider mergeability alongside CI checks while the PR remains open
+- While the PR stays open, the TUI and terminal title show `Checks passed` once checks are green and known mergeability is clear, and clear that signal if checks start running again, new failures appear, or provider state becomes uncertain
 - Waits a 60s grace period before trusting empty results (CI checks may not have registered yet)
 - If CI failures or, on GitHub or GitLab, a merge conflict are already known while other checks are still pending: waits for all checks to finish before attempting an auto-fix
 - On CI failure: fetches failed job logs (GitHub via `gh run view --log-failed`, GitLab via `glab ci trace`, Bitbucket Cloud via failed pipeline step logs), sends them to the agent with user intent when available, and commits and force-pushes only if the agent produces changes

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -121,9 +121,11 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 		}
 
 		// Check PR state (merged/closed -> exit)
+		prStateKnown := true
 		state, err := host.GetPRState(ctx, pr)
 		if err != nil {
 			sctx.Log(fmt.Sprintf("warning: could not check PR state: %v", err))
+			prStateKnown = false
 		} else if state == scm.PRStateMerged {
 			sctx.Log("PR has been merged!")
 			return &pipeline.StepOutcome{}, nil
@@ -140,6 +142,7 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 			if mergeErr != nil {
 				sctx.Log(fmt.Sprintf("warning: could not check mergeable state: %v", mergeErr))
 				mergeabilityBlockedReason = ""
+				mergeabilityKnown = false
 			} else {
 				mergeConflict = mergeState.Conflict()
 				mergeabilityKnown = mergeState.Resolved()
@@ -240,9 +243,7 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 				s.lastFixedChecks = ""
 				s.lastFixedCompletedAt = nil
 				switch {
-				case !mergeabilityKnown:
-					// Mergeability not yet resolved; the mergeable-state check
-					// above already logged the pending reason. Not ready to merge.
+				case !prStateKnown || !mergeabilityKnown:
 					lastMonitorLog = ""
 				case pending:
 					// Checks are (re-)running with no failures yet. Surface this

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -14,13 +14,12 @@ import (
 
 const defaultChecksGracePeriod = 60 * time.Second
 
-// CI monitoring status messages. These are surfaced to the user (and parsed by
-// the TUI) to distinguish a green, ready-to-merge PR from one whose checks are
-// still running. The "ready to merge" phrase is the signal the TUI keys on.
+// CI monitoring status messages. These are surfaced to the user and parsed by
+// the TUI to distinguish passed checks from checks that are still running.
 const (
-	ciReadyChecksPassedMsg = "all CI checks passed - PR is ready to merge (still monitoring until merged or closed)"
-	ciReadyNoChecksMsg     = "no CI checks reported - PR is ready to merge (still monitoring until merged or closed)"
-	ciChecksRunningMsg     = "CI checks running, waiting for results..."
+	ciChecksPassedMsg   = "all CI checks passed - still monitoring until merged or closed"
+	ciNoChecksPassedMsg = "no CI checks reported - still monitoring until merged or closed"
+	ciChecksRunningMsg  = "CI checks running, waiting for results..."
 )
 
 // CIStep monitors an open PR until it is merged or closed, auto-fixing CI failures.
@@ -160,6 +159,7 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 		ciFixLimit := sctx.Config.AutoFix.CI
 		checks, err := host.GetChecks(ctx, pr)
 		if err != nil {
+			lastMonitorLog = ""
 			sctx.Log(fmt.Sprintf("warning: could not check CI: %v", err))
 		} else {
 			pending := hasPendingChecks(checks)
@@ -247,17 +247,17 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 					lastMonitorLog = ""
 				case pending:
 					// Checks are (re-)running with no failures yet. Surface this
-					// so a PR that was green and starts re-running clears the
-					// ready-to-merge signal instead of looking stale.
+					// so a PR that passed checks and starts re-running clears the
+					// previous passed-checks signal instead of looking stale.
 					lastMonitorLog = logCIMonitorStatus(sctx, ciChecksRunningMsg, lastMonitorLog)
 				case len(checks) == 0 && elapsed < s.gracePeriod():
 					// CI checks may not be registered yet, keep polling.
 					lastMonitorLog = ""
 					sctx.Log("no CI checks reported yet, waiting for checks to register...")
 				case len(checks) == 0:
-					lastMonitorLog = logCIMonitorStatus(sctx, ciReadyNoChecksMsg, lastMonitorLog)
+					lastMonitorLog = logCIMonitorStatus(sctx, ciNoChecksPassedMsg, lastMonitorLog)
 				default:
-					lastMonitorLog = logCIMonitorStatus(sctx, ciReadyChecksPassedMsg, lastMonitorLog)
+					lastMonitorLog = logCIMonitorStatus(sctx, ciChecksPassedMsg, lastMonitorLog)
 				}
 			}
 		}

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -14,6 +14,15 @@ import (
 
 const defaultChecksGracePeriod = 60 * time.Second
 
+// CI monitoring status messages. These are surfaced to the user (and parsed by
+// the TUI) to distinguish a green, ready-to-merge PR from one whose checks are
+// still running. The "ready to merge" phrase is the signal the TUI keys on.
+const (
+	ciReadyChecksPassedMsg = "all CI checks passed - PR is ready to merge (still monitoring until merged or closed)"
+	ciReadyNoChecksMsg     = "no CI checks reported - PR is ready to merge (still monitoring until merged or closed)"
+	ciChecksRunningMsg     = "CI checks running, waiting for results..."
+)
+
 // CIStep monitors an open PR until it is merged or closed, auto-fixing CI failures.
 type CIStep struct {
 	lastFixedChecks      string               // sorted check names from last fix attempt, to avoid re-fixing
@@ -92,7 +101,7 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 	mergeabilityBlockedReason := ""
 	timeoutFailingChecks := []string{}
 	timeoutMergeConflict := false
-	lastHealthyLog := ""
+	lastMonitorLog := ""
 
 	for {
 		if err := ctx.Err(); err != nil {
@@ -168,14 +177,14 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 			}
 
 			if hasIssues && pending {
-				lastHealthyLog = ""
+				lastMonitorLog = ""
 				if pendingCheckMatchesLastFixed(checks, s.lastFixedChecks) {
 					s.lastFixedChecks = ""
 					s.lastFixedCompletedAt = nil
 				}
 				sctx.Log("issues detected but checks still pending, waiting for all checks to complete...")
 			} else if hasIssues {
-				lastHealthyLog = ""
+				lastMonitorLog = ""
 				// All checks done, issues present - fix or report
 				fixKey := encodeLastFixedChecks(failing, mergeConflict)
 				fixCompletedAt := failingCheckCompletionTimes(checks)
@@ -230,20 +239,24 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 			} else {
 				s.lastFixedChecks = ""
 				s.lastFixedCompletedAt = nil
-				if !pending && mergeabilityKnown {
-					if len(checks) == 0 && elapsed < s.gracePeriod() {
-						// CI checks may not be registered yet, keep polling
-						lastHealthyLog = ""
-						sctx.Log("no CI checks reported yet, waiting for checks to register...")
-					} else {
-						if len(checks) == 0 {
-							lastHealthyLog = logCIHealthyOpenPR(sctx, "no CI checks reported, continuing to monitor until PR is merged or closed", lastHealthyLog)
-						} else {
-							lastHealthyLog = logCIHealthyOpenPR(sctx, "all CI checks passed, continuing to monitor until PR is merged or closed", lastHealthyLog)
-						}
-					}
-				} else {
-					lastHealthyLog = ""
+				switch {
+				case !mergeabilityKnown:
+					// Mergeability not yet resolved; the mergeable-state check
+					// above already logged the pending reason. Not ready to merge.
+					lastMonitorLog = ""
+				case pending:
+					// Checks are (re-)running with no failures yet. Surface this
+					// so a PR that was green and starts re-running clears the
+					// ready-to-merge signal instead of looking stale.
+					lastMonitorLog = logCIMonitorStatus(sctx, ciChecksRunningMsg, lastMonitorLog)
+				case len(checks) == 0 && elapsed < s.gracePeriod():
+					// CI checks may not be registered yet, keep polling.
+					lastMonitorLog = ""
+					sctx.Log("no CI checks reported yet, waiting for checks to register...")
+				case len(checks) == 0:
+					lastMonitorLog = logCIMonitorStatus(sctx, ciReadyNoChecksMsg, lastMonitorLog)
+				default:
+					lastMonitorLog = logCIMonitorStatus(sctx, ciReadyChecksPassedMsg, lastMonitorLog)
 				}
 			}
 		}
@@ -274,7 +287,7 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 	}
 }
 
-func logCIHealthyOpenPR(sctx *pipeline.StepContext, message, previous string) string {
+func logCIMonitorStatus(sctx *pipeline.StepContext, message, previous string) string {
 	if message != previous {
 		sctx.Log(message)
 	}

--- a/internal/pipeline/steps/ci_bitbucket_test.go
+++ b/internal/pipeline/steps/ci_bitbucket_test.go
@@ -54,9 +54,11 @@ func TestCIStep_BitbucketPassesWhenStatusesPass(t *testing.T) {
 	}
 	foundPassed := false
 	for _, line := range logs {
-		if strings.Contains(line, "all CI checks passed - PR is ready to merge") {
+		if strings.Contains(line, "ready to merge") {
+			t.Fatalf("expected Bitbucket CI logs not to imply mergeability, got %v", logs)
+		}
+		if strings.Contains(line, "all CI checks passed - still monitoring until merged or closed") {
 			foundPassed = true
-			break
 		}
 	}
 	if !foundPassed {

--- a/internal/pipeline/steps/ci_bitbucket_test.go
+++ b/internal/pipeline/steps/ci_bitbucket_test.go
@@ -54,7 +54,7 @@ func TestCIStep_BitbucketPassesWhenStatusesPass(t *testing.T) {
 	}
 	foundPassed := false
 	for _, line := range logs {
-		if strings.Contains(line, "all CI checks passed, continuing to monitor") {
+		if strings.Contains(line, "all CI checks passed - PR is ready to merge") {
 			foundPassed = true
 			break
 		}

--- a/internal/pipeline/steps/ci_gitlab_test.go
+++ b/internal/pipeline/steps/ci_gitlab_test.go
@@ -48,7 +48,7 @@ func TestCIStep_GitLabPassesWhenJobsPass(t *testing.T) {
 	}
 	found := false
 	for _, line := range logs {
-		if strings.Contains(line, "all CI checks passed - PR is ready to merge") {
+		if strings.Contains(line, "all CI checks passed - still monitoring until merged or closed") {
 			found = true
 			break
 		}
@@ -283,7 +283,7 @@ func TestCIStep_GitLabPendingChecksKeepMonitoringWhenDone(t *testing.T) {
 	}
 	found := false
 	for _, line := range logs {
-		if strings.Contains(line, "all CI checks passed - PR is ready to merge") {
+		if strings.Contains(line, "all CI checks passed - still monitoring until merged or closed") {
 			found = true
 			break
 		}

--- a/internal/pipeline/steps/ci_gitlab_test.go
+++ b/internal/pipeline/steps/ci_gitlab_test.go
@@ -48,7 +48,7 @@ func TestCIStep_GitLabPassesWhenJobsPass(t *testing.T) {
 	}
 	found := false
 	for _, line := range logs {
-		if strings.Contains(line, "all CI checks passed, continuing to monitor") {
+		if strings.Contains(line, "all CI checks passed - PR is ready to merge") {
 			found = true
 			break
 		}
@@ -283,7 +283,7 @@ func TestCIStep_GitLabPendingChecksKeepMonitoringWhenDone(t *testing.T) {
 	}
 	found := false
 	for _, line := range logs {
-		if strings.Contains(line, "all CI checks passed, continuing to monitor") {
+		if strings.Contains(line, "all CI checks passed - PR is ready to merge") {
 			found = true
 			break
 		}

--- a/internal/pipeline/steps/ci_mergeable_test.go
+++ b/internal/pipeline/steps/ci_mergeable_test.go
@@ -141,7 +141,7 @@ func TestCIStep_MergeableLookupErrorDoesNotReportReadyWhenChecksPass(t *testing.
 		if strings.Contains(l, "could not check mergeable state") {
 			foundWarning = true
 		}
-		if strings.Contains(l, "all CI checks passed - PR is ready to merge") {
+		if strings.Contains(l, "all CI checks passed - still monitoring until merged or closed") {
 			t.Fatalf("expected mergeable lookup error to block ready log, got logs: %v", logs)
 		}
 	}
@@ -188,7 +188,7 @@ func TestCIStep_PRStateLookupErrorDoesNotReportReadyWhenChecksPass(t *testing.T)
 		if strings.Contains(l, "could not check PR state") {
 			foundWarning = true
 		}
-		if strings.Contains(l, "all CI checks passed - PR is ready to merge") {
+		if strings.Contains(l, "all CI checks passed - still monitoring until merged or closed") {
 			t.Fatalf("expected PR state lookup error to block ready log, got logs: %v", logs)
 		}
 	}

--- a/internal/pipeline/steps/ci_mergeable_test.go
+++ b/internal/pipeline/steps/ci_mergeable_test.go
@@ -142,7 +142,7 @@ func TestCIStep_MergeableLookupErrorStillKeepsMonitoringWhenChecksPass(t *testin
 		if strings.Contains(l, "could not check mergeable state") {
 			foundWarning = true
 		}
-		if strings.Contains(l, "all CI checks passed, continuing to monitor") {
+		if strings.Contains(l, "all CI checks passed - PR is ready to merge") {
 			foundPassed = true
 		}
 	}

--- a/internal/pipeline/steps/ci_mergeable_test.go
+++ b/internal/pipeline/steps/ci_mergeable_test.go
@@ -103,7 +103,7 @@ func TestCIStep_UnknownMergeableStateDoesNotExitCleanly(t *testing.T) {
 	}
 }
 
-func TestCIStep_MergeableLookupErrorStillKeepsMonitoringWhenChecksPass(t *testing.T) {
+func TestCIStep_MergeableLookupErrorDoesNotReportReadyWhenChecksPass(t *testing.T) {
 	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
@@ -137,20 +137,63 @@ func TestCIStep_MergeableLookupErrorStillKeepsMonitoringWhenChecksPass(t *testin
 	}
 
 	foundWarning := false
-	foundPassed := false
 	for _, l := range logs {
 		if strings.Contains(l, "could not check mergeable state") {
 			foundWarning = true
 		}
 		if strings.Contains(l, "all CI checks passed - PR is ready to merge") {
-			foundPassed = true
+			t.Fatalf("expected mergeable lookup error to block ready log, got logs: %v", logs)
 		}
 	}
 	if !foundWarning {
 		t.Fatalf("expected mergeable lookup warning, got logs: %v", logs)
 	}
-	if !foundPassed {
-		t.Fatalf("expected clean-pass log after mergeable lookup warning, got logs: %v", logs)
+}
+
+func TestCIStep_PRStateLookupErrorDoesNotReportReadyWhenChecksPass(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	checksJSON := `[{"name":"build","state":"SUCCESS","bucket":"pass"}]`
+	env := fakeCIGHStateError(t, "gh state failed", checksJSON)
+
+	prURL := "https://github.com/test/repo/pull/42"
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+	sctx.Config.CITimeout = 10 * time.Second
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
+	step := &CIStep{
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			cancel()
+			return ctx.Err()
+		},
+	}
+
+	_, err := step.Execute(sctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected polling to continue after passing checks, got %v", err)
+	}
+
+	foundWarning := false
+	for _, l := range logs {
+		if strings.Contains(l, "could not check PR state") {
+			foundWarning = true
+		}
+		if strings.Contains(l, "all CI checks passed - PR is ready to merge") {
+			t.Fatalf("expected PR state lookup error to block ready log, got logs: %v", logs)
+		}
+	}
+	if !foundWarning {
+		t.Fatalf("expected PR state lookup warning, got logs: %v", logs)
 	}
 }
 

--- a/internal/pipeline/steps/ci_test.go
+++ b/internal/pipeline/steps/ci_test.go
@@ -374,13 +374,65 @@ func TestCIStep_AllChecksPassingKeepsMonitoringOpenPR(t *testing.T) {
 
 	found := false
 	for _, l := range logs {
-		if strings.Contains(l, "all CI checks passed - PR is ready to merge") {
+		if strings.Contains(l, "all CI checks passed - still monitoring until merged or closed") {
 			found = true
 			break
 		}
 	}
 	if !found {
 		t.Fatalf("expected continued-monitoring CI log, got: %v", logs)
+	}
+}
+
+func TestCIStep_CIWarningAllowsChecksPassedToBeReannounced(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	checksSequence := []string{
+		`[{"name":"build","state":"SUCCESS","bucket":"pass"}]`,
+		`not-json`,
+		`[{"name":"build","state":"SUCCESS","bucket":"pass"}]`,
+	}
+	env := fakeCIGHSequence(t, "OPEN", checksSequence)
+
+	prURL := "https://github.com/test/repo/pull/42"
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+	sctx.Config.CITimeout = 10 * time.Second
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
+	waits := 0
+	step := &CIStep{
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			waits++
+			if waits == 3 {
+				cancel()
+				return ctx.Err()
+			}
+			return nil
+		},
+	}
+	_, err := step.Execute(sctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected open PR monitoring to continue, got %v", err)
+	}
+
+	passedLogs := 0
+	for _, l := range logs {
+		if strings.Contains(l, "all CI checks passed - still monitoring until merged or closed") {
+			passedLogs++
+		}
+	}
+	if passedLogs != 2 {
+		t.Fatalf("expected checks-passed status before and after CI warning, got %d logs: %v", passedLogs, logs)
 	}
 }
 
@@ -480,7 +532,7 @@ func TestCIStep_EmptyChecksWaitsDuringGracePeriod(t *testing.T) {
 	}
 	found := false
 	for _, l := range logs {
-		if strings.Contains(l, "no CI checks reported - PR is ready to merge") {
+		if strings.Contains(l, "no CI checks reported - still monitoring until merged or closed") {
 			found = true
 			break
 		}
@@ -575,7 +627,7 @@ func TestCIStep_NonEmptyPassingChecksSkipGracePeriodAndContinueMonitoring(t *tes
 	}
 	found := false
 	for _, l := range logs {
-		if strings.Contains(l, "all CI checks passed - PR is ready to merge") {
+		if strings.Contains(l, "all CI checks passed - still monitoring until merged or closed") {
 			found = true
 			break
 		}

--- a/internal/pipeline/steps/ci_test.go
+++ b/internal/pipeline/steps/ci_test.go
@@ -374,7 +374,7 @@ func TestCIStep_AllChecksPassingKeepsMonitoringOpenPR(t *testing.T) {
 
 	found := false
 	for _, l := range logs {
-		if strings.Contains(l, "all CI checks passed, continuing to monitor") {
+		if strings.Contains(l, "all CI checks passed - PR is ready to merge") {
 			found = true
 			break
 		}
@@ -480,7 +480,7 @@ func TestCIStep_EmptyChecksWaitsDuringGracePeriod(t *testing.T) {
 	}
 	found := false
 	for _, l := range logs {
-		if strings.Contains(l, "no CI checks reported, continuing to monitor") {
+		if strings.Contains(l, "no CI checks reported - PR is ready to merge") {
 			found = true
 			break
 		}
@@ -575,7 +575,7 @@ func TestCIStep_NonEmptyPassingChecksSkipGracePeriodAndContinueMonitoring(t *tes
 	}
 	found := false
 	for _, l := range logs {
-		if strings.Contains(l, "all CI checks passed, continuing to monitor") {
+		if strings.Contains(l, "all CI checks passed - PR is ready to merge") {
 			found = true
 			break
 		}

--- a/internal/pipeline/steps/demo.go
+++ b/internal/pipeline/steps/demo.go
@@ -269,7 +269,7 @@ func (s *demoCIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome,
 		return canceled()
 	}
 	sctx.Log("")
-	sctx.Log(ciReadyChecksPassedMsg)
+	sctx.Log(ciChecksPassedMsg)
 
 	return &pipeline.StepOutcome{
 		DurationOverrideMS: s.displayDur.Milliseconds(),

--- a/internal/pipeline/steps/demo.go
+++ b/internal/pipeline/steps/demo.go
@@ -269,7 +269,7 @@ func (s *demoCIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome,
 		return canceled()
 	}
 	sctx.Log("")
-	sctx.Log("All checks passed.")
+	sctx.Log(ciReadyChecksPassedMsg)
 
 	return &pipeline.StepOutcome{
 		DurationOverrideMS: s.displayDur.Milliseconds(),

--- a/internal/pipeline/steps/helpers_test.go
+++ b/internal/pipeline/steps/helpers_test.go
@@ -448,6 +448,17 @@ func fakeCIGHMergeableError(t *testing.T, state, checksJSON, mergeableErr string
 	})
 }
 
+func fakeCIGHStateError(t *testing.T, stateErr, checksJSON string) []string {
+	t.Helper()
+	binDir := fakeCLIBinDir(t)
+	linkTestBinary(t, binDir, "gh")
+	return fakeCLIEnv(binDir, map[string]string{
+		"FAKE_CLI_MODE":      "ci-gh",
+		"FAKE_CLI_STATE_ERR": stateErr,
+		"FAKE_CLI_CHECKS":    checksJSON,
+	})
+}
+
 func fakeCIGHChecksError(t *testing.T, state, mergeable, checksErr string) []string {
 	t.Helper()
 	binDir := fakeCLIBinDir(t)

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -186,6 +186,7 @@ func extractTrailingNumber(rawURL string) int {
 
 func fakeCIGHHandler(args []string) {
 	state := os.Getenv("FAKE_CLI_STATE")
+	stateErr := os.Getenv("FAKE_CLI_STATE_ERR")
 	checksJSON := os.Getenv("FAKE_CLI_CHECKS")
 	checksErr := os.Getenv("FAKE_CLI_CHECKS_ERR")
 	mergeable := os.Getenv("FAKE_CLI_MERGEABLE")
@@ -207,6 +208,10 @@ func fakeCIGHHandler(args []string) {
 		os.Exit(0)
 	}
 	if strings.Contains(joined, "pr view") && strings.Contains(joined, "--json state") {
+		if stateErr != "" {
+			fmt.Fprintln(os.Stderr, stateErr)
+			os.Exit(1)
+		}
 		fmt.Println(state)
 		os.Exit(0)
 	}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -269,6 +269,9 @@ func (m Model) terminalTitle() string {
 		icon := stepStatusIndicator(s.Status, m.spinnerFrame)
 		switch s.Status {
 		case types.StepStatusRunning, types.StepStatusFixing:
+			if s.StepName == types.StepCI && parseCIActivity(m.logs).Ready {
+				return "✓ Ready to merge" + suffix
+			}
 			return icon + " " + stepLabel(s.StepName) + suffix
 		case types.StepStatusAwaitingApproval, types.StepStatusFixReview:
 			return icon + " " + stepLabel(s.StepName) + suffix

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -270,7 +270,7 @@ func (m Model) terminalTitle() string {
 		switch s.Status {
 		case types.StepStatusRunning, types.StepStatusFixing:
 			if s.StepName == types.StepCI && parseCIActivity(m.logs).Ready {
-				return "✓ Ready to merge" + suffix
+				return "✓ Checks passed" + suffix
 			}
 			return icon + " " + stepLabel(s.StepName) + suffix
 		case types.StepStatusAwaitingApproval, types.StepStatusFixReview:

--- a/internal/tui/ci.go
+++ b/internal/tui/ci.go
@@ -55,31 +55,54 @@ func extractPRFromLogs(logs []string) string {
 type ciActivity struct {
 	CIFixes    int
 	AutoFixing bool
+	Ready      bool // CI is green and the PR is ready to merge
 	LastEvent  string
 }
 
 // parseCIActivity extracts structured activity from CI log messages.
+//
+// Ready reflects the most recent monitoring state: it is true only when the
+// latest relevant log line announced a ready-to-merge PR, and any newer event
+// (re-running checks, new failures, auto-fixing, merge/close) clears it.
 func parseCIActivity(logs []string) ciActivity {
 	var a ciActivity
 	for _, line := range logs {
 		switch {
-		case strings.Contains(line, "CI failures detected"):
+		case strings.Contains(line, "running agent to fix CI"):
+			// Emitted once per fix attempt by autoFixCI in real runs (and by
+			// demo mode), so it is the reliable signal for counting fixes.
 			a.CIFixes++
 			a.AutoFixing = true
+			a.Ready = false
 			a.LastEvent = line
 		case strings.Contains(line, "committed and pushed fixes"):
 			a.AutoFixing = false
+			a.Ready = false
 			a.LastEvent = line
-		case strings.Contains(line, "running agent to fix CI"):
+		case strings.Contains(line, "CI failures detected"):
 			a.AutoFixing = true
+			a.Ready = false
+			a.LastEvent = line
+		case strings.Contains(line, "ready to merge"):
+			a.AutoFixing = false
+			a.Ready = true
+			a.LastEvent = line
+		case strings.Contains(line, "issues detected"),
+			strings.Contains(line, "CI checks running"):
+			a.AutoFixing = false
+			a.Ready = false
 			a.LastEvent = line
 		case strings.Contains(line, "monitoring CI for PR"):
+			a.Ready = false
 			a.LastEvent = line
 		case strings.Contains(line, "PR has been merged"):
+			a.Ready = false
 			a.LastEvent = line
 		case strings.Contains(line, "PR has been closed"):
+			a.Ready = false
 			a.LastEvent = line
 		case strings.Contains(line, "CI timeout"):
+			a.Ready = false
 			a.LastEvent = line
 		}
 	}
@@ -121,6 +144,11 @@ func renderCIViewWithSelection(run *ipc.RunInfo, steps []ipc.StepResultInfo, fin
 		if activity.AutoFixing {
 			style := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBlue))
 			b.WriteString(style.Render("\u2699 Auto-fixing CI failures...") + "\n")
+		} else if activity.Ready {
+			style := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ansiGreen))
+			b.WriteString(style.Render("✓ Ready to merge") + "\n")
+			dim := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
+			b.WriteString(dim.Render("checks passed - merge when ready (still monitoring)") + "\n")
 		} else {
 			style := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiGreen))
 			b.WriteString(style.Render("◉ Monitoring CI checks...") + "\n")

--- a/internal/tui/ci.go
+++ b/internal/tui/ci.go
@@ -89,7 +89,10 @@ func parseCIActivity(logs []string) ciActivity {
 			a.LastEvent = line
 		case strings.Contains(line, "issues detected"),
 			strings.Contains(line, "CI checks running"),
-			strings.Contains(line, "mergeable state still pending"):
+			strings.Contains(line, "mergeable state still pending"),
+			strings.Contains(line, "warning: could not check CI"),
+			strings.Contains(line, "warning: could not check mergeable state"),
+			strings.Contains(line, "warning: could not check PR state"):
 			a.AutoFixing = false
 			a.Ready = false
 			a.LastEvent = line

--- a/internal/tui/ci.go
+++ b/internal/tui/ci.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	ciReadyChecksPassedLog = "all CI checks passed - PR is ready to merge (still monitoring until merged or closed)"
-	ciReadyNoChecksLog     = "no CI checks reported - PR is ready to merge (still monitoring until merged or closed)"
+	ciChecksPassedLog   = "all CI checks passed - still monitoring until merged or closed"
+	ciNoChecksPassedLog = "no CI checks reported - still monitoring until merged or closed"
 )
 
 // isCIActive returns true if the CI step is currently running.
@@ -60,15 +60,14 @@ func extractPRFromLogs(logs []string) string {
 type ciActivity struct {
 	CIFixes    int
 	AutoFixing bool
-	Ready      bool // CI is green and the PR is ready to merge
+	Ready      bool
 	LastEvent  string
 }
 
 // parseCIActivity extracts structured activity from CI log messages.
 //
 // Ready reflects the most recent monitoring state: it is true only when the
-// latest relevant log line announced a ready-to-merge PR, and any newer event
-// (re-running checks, new failures, auto-fixing, merge/close) clears it.
+// latest relevant log line announced passed checks, and any newer event clears it.
 func parseCIActivity(logs []string) ciActivity {
 	var a ciActivity
 	for _, line := range logs {
@@ -88,7 +87,7 @@ func parseCIActivity(logs []string) ciActivity {
 			a.AutoFixing = true
 			a.Ready = false
 			a.LastEvent = line
-		case line == ciReadyChecksPassedLog || line == ciReadyNoChecksLog:
+		case line == ciChecksPassedLog || line == ciNoChecksPassedLog:
 			a.AutoFixing = false
 			a.Ready = true
 			a.LastEvent = line
@@ -155,9 +154,9 @@ func renderCIViewWithSelection(run *ipc.RunInfo, steps []ipc.StepResultInfo, fin
 			b.WriteString(style.Render("\u2699 Auto-fixing CI failures...") + "\n")
 		} else if activity.Ready {
 			style := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ansiGreen))
-			b.WriteString(style.Render("✓ Ready to merge") + "\n")
+			b.WriteString(style.Render("✓ Checks passed") + "\n")
 			dim := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBrightBlack))
-			b.WriteString(dim.Render("checks passed - merge when ready (still monitoring)") + "\n")
+			b.WriteString(dim.Render("still monitoring until merged or closed") + "\n")
 		} else {
 			style := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiGreen))
 			b.WriteString(style.Render("◉ Monitoring CI checks...") + "\n")

--- a/internal/tui/ci.go
+++ b/internal/tui/ci.go
@@ -88,7 +88,8 @@ func parseCIActivity(logs []string) ciActivity {
 			a.Ready = true
 			a.LastEvent = line
 		case strings.Contains(line, "issues detected"),
-			strings.Contains(line, "CI checks running"):
+			strings.Contains(line, "CI checks running"),
+			strings.Contains(line, "mergeable state still pending"):
 			a.AutoFixing = false
 			a.Ready = false
 			a.LastEvent = line

--- a/internal/tui/ci.go
+++ b/internal/tui/ci.go
@@ -9,6 +9,11 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
+const (
+	ciReadyChecksPassedLog = "all CI checks passed - PR is ready to merge (still monitoring until merged or closed)"
+	ciReadyNoChecksLog     = "no CI checks reported - PR is ready to merge (still monitoring until merged or closed)"
+)
+
 // isCIActive returns true if the CI step is currently running.
 func isCIActive(steps []ipc.StepResultInfo) bool {
 	for _, s := range steps {
@@ -83,7 +88,7 @@ func parseCIActivity(logs []string) ciActivity {
 			a.AutoFixing = true
 			a.Ready = false
 			a.LastEvent = line
-		case strings.Contains(line, "ready to merge"):
+		case line == ciReadyChecksPassedLog || line == ciReadyNoChecksLog:
 			a.AutoFixing = false
 			a.Ready = true
 			a.LastEvent = line

--- a/internal/tui/ci_test.go
+++ b/internal/tui/ci_test.go
@@ -193,6 +193,16 @@ func TestParseCIActivity(t *testing.T) {
 		}
 	})
 
+	t.Run("not ready from agent output", func(t *testing.T) {
+		a := parseCIActivity([]string{
+			"CI failures detected: test failed",
+			"agent says this is not ready to merge yet",
+		})
+		if a.Ready {
+			t.Error("expected Ready to ignore non-monitor agent output")
+		}
+	})
+
 	t.Run("ready cleared when checks re-run", func(t *testing.T) {
 		a := parseCIActivity([]string{
 			"all CI checks passed - PR is ready to merge (still monitoring until merged or closed)",

--- a/internal/tui/ci_test.go
+++ b/internal/tui/ci_test.go
@@ -213,6 +213,16 @@ func TestParseCIActivity(t *testing.T) {
 		}
 	})
 
+	t.Run("ready cleared when mergeability becomes pending", func(t *testing.T) {
+		a := parseCIActivity([]string{
+			"all CI checks passed - PR is ready to merge (still monitoring until merged or closed)",
+			"mergeable state still pending: unknown",
+		})
+		if a.Ready {
+			t.Error("expected Ready to be cleared when mergeability is unresolved")
+		}
+	})
+
 	t.Run("not ready while monitoring", func(t *testing.T) {
 		a := parseCIActivity([]string{"monitoring CI for PR #42 (timeout: 4h)..."})
 		if a.Ready {

--- a/internal/tui/ci_test.go
+++ b/internal/tui/ci_test.go
@@ -108,9 +108,12 @@ func TestParseCIActivity(t *testing.T) {
 	})
 
 	t.Run("ci failure detected", func(t *testing.T) {
+		// Mirrors the real CI step log sequence for a failing check that triggers
+		// an auto-fix: the "issues detected" line followed by the agent run.
 		a := parseCIActivity([]string{
 			"monitoring CI for PR #42 (timeout: 4h)...",
-			"CI failures detected: test — auto-fixing...",
+			"issues detected: test - auto-fixing (attempt 1/3)...",
+			"running agent to fix CI issues...",
 		})
 		if a.CIFixes != 1 {
 			t.Errorf("expected 1 CI fix, got %d", a.CIFixes)
@@ -122,8 +125,8 @@ func TestParseCIActivity(t *testing.T) {
 
 	t.Run("ci fix completed", func(t *testing.T) {
 		a := parseCIActivity([]string{
-			"CI failures detected: test — auto-fixing...",
-			"running agent to fix CI failures...",
+			"issues detected: test - auto-fixing (attempt 1/3)...",
+			"running agent to fix CI issues...",
 			"committed and pushed fixes",
 		})
 		if a.CIFixes != 1 {
@@ -136,10 +139,11 @@ func TestParseCIActivity(t *testing.T) {
 
 	t.Run("multiple ci fixes", func(t *testing.T) {
 		a := parseCIActivity([]string{
-			"CI failures detected: test",
+			"issues detected: test - auto-fixing (attempt 1/3)...",
+			"running agent to fix CI issues...",
 			"committed and pushed fixes",
-			"CI failures detected: lint",
-			"running agent to fix CI failures...",
+			"issues detected: lint - auto-fixing (attempt 2/3)...",
+			"running agent to fix CI issues...",
 		})
 		if a.CIFixes != 2 {
 			t.Errorf("expected 2 CI fixes, got %d", a.CIFixes)
@@ -167,6 +171,52 @@ func TestParseCIActivity(t *testing.T) {
 		a := parseCIActivity([]string{"CI timeout reached"})
 		if !strings.Contains(a.LastEvent, "timeout") {
 			t.Error("expected timeout as last event")
+		}
+	})
+
+	t.Run("ready to merge when checks pass", func(t *testing.T) {
+		a := parseCIActivity([]string{
+			"monitoring CI for PR #42 (timeout: 4h)...",
+			"all CI checks passed - PR is ready to merge (still monitoring until merged or closed)",
+		})
+		if !a.Ready {
+			t.Error("expected Ready to be true after checks pass")
+		}
+	})
+
+	t.Run("ready to merge when no checks configured", func(t *testing.T) {
+		a := parseCIActivity([]string{
+			"no CI checks reported - PR is ready to merge (still monitoring until merged or closed)",
+		})
+		if !a.Ready {
+			t.Error("expected Ready to be true when no checks are configured")
+		}
+	})
+
+	t.Run("ready cleared when checks re-run", func(t *testing.T) {
+		a := parseCIActivity([]string{
+			"all CI checks passed - PR is ready to merge (still monitoring until merged or closed)",
+			"CI checks running, waiting for results...",
+		})
+		if a.Ready {
+			t.Error("expected Ready to be cleared once checks start re-running")
+		}
+	})
+
+	t.Run("ready cleared when new failure detected", func(t *testing.T) {
+		a := parseCIActivity([]string{
+			"all CI checks passed - PR is ready to merge (still monitoring until merged or closed)",
+			"issues detected: test - auto-fixing (attempt 1/3)...",
+		})
+		if a.Ready {
+			t.Error("expected Ready to be cleared when a new failure appears")
+		}
+	})
+
+	t.Run("not ready while monitoring", func(t *testing.T) {
+		a := parseCIActivity([]string{"monitoring CI for PR #42 (timeout: 4h)..."})
+		if a.Ready {
+			t.Error("expected Ready to be false before any checks pass")
 		}
 	})
 }
@@ -226,6 +276,42 @@ func TestRenderCIView_AutoFixing(t *testing.T) {
 	}
 	if !strings.Contains(out, "CI auto-fixes: 1") {
 		t.Error("expected CI fix count")
+	}
+}
+
+func TestRenderCIView_ReadyToMerge(t *testing.T) {
+	run := testRunWithCI()
+	run.Steps[5].Status = types.StepStatusRunning
+	logs := []string{
+		"monitoring CI for PR #42 (timeout: 4h)...",
+		"all CI checks passed - PR is ready to merge (still monitoring until merged or closed)",
+	}
+
+	out := stripANSI(renderCIView(run, run.Steps, "", logs, 80))
+
+	if !strings.Contains(out, "Ready to merge") {
+		t.Errorf("expected ready-to-merge indicator, got: %s", out)
+	}
+	if strings.Contains(out, "Monitoring CI checks...") {
+		t.Errorf("expected ready state to replace the monitoring indicator, got: %s", out)
+	}
+}
+
+func TestRenderCIView_ReadyClearedWhenChecksRerun(t *testing.T) {
+	run := testRunWithCI()
+	run.Steps[5].Status = types.StepStatusRunning
+	logs := []string{
+		"all CI checks passed - PR is ready to merge (still monitoring until merged or closed)",
+		"CI checks running, waiting for results...",
+	}
+
+	out := stripANSI(renderCIView(run, run.Steps, "", logs, 80))
+
+	if !strings.Contains(out, "Monitoring CI checks...") {
+		t.Errorf("expected monitoring indicator once checks re-run, got: %s", out)
+	}
+	if strings.Contains(out, "Ready to merge") {
+		t.Errorf("expected ready indicator cleared once checks re-run, got: %s", out)
 	}
 }
 

--- a/internal/tui/ci_test.go
+++ b/internal/tui/ci_test.go
@@ -174,19 +174,19 @@ func TestParseCIActivity(t *testing.T) {
 		}
 	})
 
-	t.Run("ready to merge when checks pass", func(t *testing.T) {
+	t.Run("checks passed when checks pass", func(t *testing.T) {
 		a := parseCIActivity([]string{
 			"monitoring CI for PR #42 (timeout: 4h)...",
-			"all CI checks passed - PR is ready to merge (still monitoring until merged or closed)",
+			"all CI checks passed - still monitoring until merged or closed",
 		})
 		if !a.Ready {
 			t.Error("expected Ready to be true after checks pass")
 		}
 	})
 
-	t.Run("ready to merge when no checks configured", func(t *testing.T) {
+	t.Run("checks passed when no checks configured", func(t *testing.T) {
 		a := parseCIActivity([]string{
-			"no CI checks reported - PR is ready to merge (still monitoring until merged or closed)",
+			"no CI checks reported - still monitoring until merged or closed",
 		})
 		if !a.Ready {
 			t.Error("expected Ready to be true when no checks are configured")
@@ -205,7 +205,7 @@ func TestParseCIActivity(t *testing.T) {
 
 	t.Run("ready cleared when checks re-run", func(t *testing.T) {
 		a := parseCIActivity([]string{
-			"all CI checks passed - PR is ready to merge (still monitoring until merged or closed)",
+			"all CI checks passed - still monitoring until merged or closed",
 			"CI checks running, waiting for results...",
 		})
 		if a.Ready {
@@ -215,7 +215,7 @@ func TestParseCIActivity(t *testing.T) {
 
 	t.Run("ready cleared when new failure detected", func(t *testing.T) {
 		a := parseCIActivity([]string{
-			"all CI checks passed - PR is ready to merge (still monitoring until merged or closed)",
+			"all CI checks passed - still monitoring until merged or closed",
 			"issues detected: test - auto-fixing (attempt 1/3)...",
 		})
 		if a.Ready {
@@ -225,7 +225,7 @@ func TestParseCIActivity(t *testing.T) {
 
 	t.Run("ready cleared when mergeability becomes pending", func(t *testing.T) {
 		a := parseCIActivity([]string{
-			"all CI checks passed - PR is ready to merge (still monitoring until merged or closed)",
+			"all CI checks passed - still monitoring until merged or closed",
 			"mergeable state still pending: unknown",
 		})
 		if a.Ready {
@@ -242,7 +242,7 @@ func TestParseCIActivity(t *testing.T) {
 		for _, warning := range tests {
 			t.Run(warning, func(t *testing.T) {
 				a := parseCIActivity([]string{
-					"all CI checks passed - PR is ready to merge (still monitoring until merged or closed)",
+					"all CI checks passed - still monitoring until merged or closed",
 					warning,
 				})
 				if a.Ready {
@@ -318,18 +318,18 @@ func TestRenderCIView_AutoFixing(t *testing.T) {
 	}
 }
 
-func TestRenderCIView_ReadyToMerge(t *testing.T) {
+func TestRenderCIView_ChecksPassed(t *testing.T) {
 	run := testRunWithCI()
 	run.Steps[5].Status = types.StepStatusRunning
 	logs := []string{
 		"monitoring CI for PR #42 (timeout: 4h)...",
-		"all CI checks passed - PR is ready to merge (still monitoring until merged or closed)",
+		"all CI checks passed - still monitoring until merged or closed",
 	}
 
 	out := stripANSI(renderCIView(run, run.Steps, "", logs, 80))
 
-	if !strings.Contains(out, "Ready to merge") {
-		t.Errorf("expected ready-to-merge indicator, got: %s", out)
+	if !strings.Contains(out, "Checks passed") {
+		t.Errorf("expected checks-passed indicator, got: %s", out)
 	}
 	if strings.Contains(out, "Monitoring CI checks...") {
 		t.Errorf("expected ready state to replace the monitoring indicator, got: %s", out)
@@ -340,7 +340,7 @@ func TestRenderCIView_ReadyClearedWhenChecksRerun(t *testing.T) {
 	run := testRunWithCI()
 	run.Steps[5].Status = types.StepStatusRunning
 	logs := []string{
-		"all CI checks passed - PR is ready to merge (still monitoring until merged or closed)",
+		"all CI checks passed - still monitoring until merged or closed",
 		"CI checks running, waiting for results...",
 	}
 
@@ -349,8 +349,8 @@ func TestRenderCIView_ReadyClearedWhenChecksRerun(t *testing.T) {
 	if !strings.Contains(out, "Monitoring CI checks...") {
 		t.Errorf("expected monitoring indicator once checks re-run, got: %s", out)
 	}
-	if strings.Contains(out, "Ready to merge") {
-		t.Errorf("expected ready indicator cleared once checks re-run, got: %s", out)
+	if strings.Contains(out, "Checks passed") {
+		t.Errorf("expected checks-passed indicator cleared once checks re-run, got: %s", out)
 	}
 }
 

--- a/internal/tui/ci_test.go
+++ b/internal/tui/ci_test.go
@@ -223,6 +223,25 @@ func TestParseCIActivity(t *testing.T) {
 		}
 	})
 
+	t.Run("ready cleared when polling warning appears", func(t *testing.T) {
+		tests := []string{
+			"warning: could not check CI: rate limited",
+			"warning: could not check mergeable state: rate limited",
+			"warning: could not check PR state: rate limited",
+		}
+		for _, warning := range tests {
+			t.Run(warning, func(t *testing.T) {
+				a := parseCIActivity([]string{
+					"all CI checks passed - PR is ready to merge (still monitoring until merged or closed)",
+					warning,
+				})
+				if a.Ready {
+					t.Error("expected Ready to be cleared when polling state is unknown")
+				}
+			})
+		}
+	})
+
 	t.Run("not ready while monitoring", func(t *testing.T) {
 		a := parseCIActivity([]string{"monitoring CI for PR #42 (timeout: 4h)..."})
 		if a.Ready {

--- a/internal/tui/terminal_title_test.go
+++ b/internal/tui/terminal_title_test.go
@@ -121,18 +121,18 @@ func TestTerminalTitle_RunningStep(t *testing.T) {
 	}
 }
 
-func TestTerminalTitle_CIReadyToMerge(t *testing.T) {
+func TestTerminalTitle_CIChecksPassed(t *testing.T) {
 	run := testRunWithCI()
 	run.Steps[5].Status = types.StepStatusRunning
 	m := NewModel("/tmp/sock", nil, run)
 	m.steps = run.Steps
 	m.logs = []string{
 		"monitoring CI for PR #42 (timeout: 4h)...",
-		"all CI checks passed - PR is ready to merge (still monitoring until merged or closed)",
+		"all CI checks passed - still monitoring until merged or closed",
 	}
 	title := m.terminalTitle()
-	if title != "✓ Ready to merge - feature/foo" {
-		t.Errorf("expected '✓ Ready to merge - feature/foo', got %q", title)
+	if title != "✓ Checks passed - feature/foo" {
+		t.Errorf("expected '✓ Checks passed - feature/foo', got %q", title)
 	}
 }
 
@@ -143,8 +143,8 @@ func TestTerminalTitle_CIMonitoringNotReady(t *testing.T) {
 	m.steps = run.Steps
 	m.logs = []string{"monitoring CI for PR #42 (timeout: 4h)..."}
 	title := m.terminalTitle()
-	if strings.Contains(title, "Ready to merge") {
-		t.Errorf("expected non-ready CI title while monitoring, got %q", title)
+	if strings.Contains(title, "Checks passed") {
+		t.Errorf("expected non-passed CI title while monitoring, got %q", title)
 	}
 }
 

--- a/internal/tui/terminal_title_test.go
+++ b/internal/tui/terminal_title_test.go
@@ -121,6 +121,33 @@ func TestTerminalTitle_RunningStep(t *testing.T) {
 	}
 }
 
+func TestTerminalTitle_CIReadyToMerge(t *testing.T) {
+	run := testRunWithCI()
+	run.Steps[5].Status = types.StepStatusRunning
+	m := NewModel("/tmp/sock", nil, run)
+	m.steps = run.Steps
+	m.logs = []string{
+		"monitoring CI for PR #42 (timeout: 4h)...",
+		"all CI checks passed - PR is ready to merge (still monitoring until merged or closed)",
+	}
+	title := m.terminalTitle()
+	if title != "✓ Ready to merge - feature/foo" {
+		t.Errorf("expected '✓ Ready to merge - feature/foo', got %q", title)
+	}
+}
+
+func TestTerminalTitle_CIMonitoringNotReady(t *testing.T) {
+	run := testRunWithCI()
+	run.Steps[5].Status = types.StepStatusRunning
+	m := NewModel("/tmp/sock", nil, run)
+	m.steps = run.Steps
+	m.logs = []string{"monitoring CI for PR #42 (timeout: 4h)..."}
+	title := m.terminalTitle()
+	if strings.Contains(title, "Ready to merge") {
+		t.Errorf("expected non-ready CI title while monitoring, got %q", title)
+	}
+}
+
 func TestTerminalTitle_RunningStepSpinnerAdvances(t *testing.T) {
 	run := testRun()
 	run.Steps[0].Status = types.StepStatusRunning


### PR DESCRIPTION
## Intent

The developer wanted a way to preserve the CI step's new behavior of monitoring until a PR is merged or closed while still exposing a clear signal that the PR is ready to merge once CI is green and mergeable. They specifically chose to surface that ready-to-merge state in the TUI CI panel and terminal title, and wanted the signal to clear if CI starts running again or new failures appear. After that change, they also asked to fix the TUI CI auto-fix counter so it increments during real CI fix attempts instead of only recognizing a demo-only failure string. They expected the work to follow TDD and include relevant tests, linting, race tests, and e2e verification where appropriate.

## What Changed

- Added a CI panel and terminal-title state that shows `Checks passed` once checks are green and PR state/mergeability are confirmed, while the CI step continues monitoring until the PR is merged or closed.
- Updated CI monitoring logs so the ready signal clears when checks rerun, failures appear, provider state becomes uncertain, or the PR is merged or closed.
- Fixed the TUI CI auto-fix counter to increment from real CI fix attempts and documented the new CI panel behavior.

## Risk Assessment

✅ Low: The change is narrowly scoped to CI monitoring status logs and TUI presentation, with tests updated around the new ready/clearing behavior and no additional material issues found in the reviewed diff.

## Testing

After inspecting the diff, I exercised the changed CI/TUI paths with targeted tests, captured a terminal-rendered CI panel artifact showing the ready state, cleared re-run state, and real auto-fix counter, ran race tests for the changed packages, and completed the e2e suite successfully after retrying with a longer command timeout.

<details>
<summary>Evidence: Rendered TUI CI ready-to-merge evidence</summary>

Source: [Rendered TUI CI ready-to-merge evidence](https://github.com/kunchenguid/no-mistakes/blob/7c83d0b3447582fe432b2dda6db656f34d11420a/.no-mistakes/evidence/feat/ready-to-merge-ci-state/tui-ci-ready-surface.txt)

```text
Shows terminal title `✓ Checks passed - feature/foo`, the CI panel displaying `✓ Checks passed` while still monitoring until merged or closed, readiness clearing back to `Monitoring CI checks...` when checks re-run, and `CI auto-fixes: 1` during a real CI auto-fix log sequence.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `internal/tui/ci.go:90` - `ciNoChecksPassedLog` is treated as `Ready`, so after the empty-check grace period the CI panel and terminal title render `✓ Checks passed` even when the host reported no checks at all; this can mislead users of repos without configured CI or with missing check discovery.
- ⚠️ `docs/src/content/docs/guides/troubleshooting.md:190` - The docs still say the CI panel and terminal title show `Ready to merge`, but the changed implementation and tests now show `Checks passed`; update this line and the matching gate-model docs text to avoid documenting the old UI state.

🔧 Fix: Update CI ready-state documentation
1 warning still open:
- ⚠️ `internal/tui/ci.go:90` - `ciNoChecksPassedLog` is parsed as `Ready`, so after the empty-check grace period the CI panel and terminal title render `✓ Checks passed` even when the host reported no checks at all; that can mislead users of repos without configured CI or with missing check discovery.

🔧 Fix: Confirm ignored CI no-checks finding
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected the target change with `git status --short` and `git diff --stat 0e1a08be7077117864faa854f9cdf08a1590c3e6..e77a6155fb2f5bc345f7783ae1a4ed0b09025fea`.</code>
- <code>Generated reviewer-visible TUI evidence with `go test ./internal/tui -run &#39;TestEvidence_CIReadyToMergeSurface|TestParseCIActivity|TestRenderCIView_ChecksPassed|TestRenderCIView_ReadyClearedWhenChecksRerun|TestTerminalTitle_CI&#39; -count=1 -v | tee &#39;.no-mistakes/evidence/feat/ready-to-merge-ci-state/tui-ci-ready-surface.txt&#39;`, then removed the temporary evidence-only test file.</code>
- <code>Ran targeted CI step behavior tests with `go test ./internal/pipeline/steps -run &#39;TestCIStep_(UnknownMergeableStateDoesNotExitCleanly|MergeableLookupErrorDoesNotReportReadyWhenChecksPass|PRStateLookupErrorDoesNotReportReadyWhenChecksPass|WaitsForPendingChecksBeforeFixing|PendingChecksUseAdaptivePollIntervals)&#39; -count=1 -v`.</code>
- <code>Ran changed-package race tests with `go test -race ./internal/tui ./internal/pipeline/steps`.</code>
- <code>Ran `make e2e`; the first invocation hit the 120s shell wrapper timeout, then `make e2e` passed when retried with a longer timeout.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
