### PR TITLE
feat: auto-resolve actionable findings in yolo mode

### DIFF
--- a/.no-mistakes/evidence/feat/yolo-auto-resolve/cli-gate-resolution-transcript.txt
+++ b/.no-mistakes/evidence/feat/yolo-auto-resolve/cli-gate-resolution-transcript.txt
@@ -1,0 +1,22 @@
+=== RUN   TestGateResolution
+=== RUN   TestGateResolution/actionable_findings_are_fixed_with_every_finding_selected
+    axi_drive_test.go:78: auto-resolution action=fix finding_ids=[review-1 review-2]
+=== RUN   TestGateResolution/only_non-actionable_findings_are_approved
+    axi_drive_test.go:78: auto-resolution action=approve finding_ids=[]
+=== RUN   TestGateResolution/no_findings_are_approved
+    axi_drive_test.go:78: auto-resolution action=approve finding_ids=[]
+=== RUN   TestGateResolution/already_fixed_step_is_approved_(no_fix_loop)
+    axi_drive_test.go:78: auto-resolution action=approve finding_ids=[]
+=== RUN   TestGateResolution/reattached_fix_review_is_approved_without_in-memory_fix_state
+    axi_drive_test.go:78: auto-resolution action=approve finding_ids=[]
+=== RUN   TestGateResolution/actionable_findings_without_ids_are_approved_rather_than_fixing_nothing
+    axi_drive_test.go:78: auto-resolution action=approve finding_ids=[]
+--- PASS: TestGateResolution (0.00s)
+    --- PASS: TestGateResolution/actionable_findings_are_fixed_with_every_finding_selected (0.00s)
+    --- PASS: TestGateResolution/only_non-actionable_findings_are_approved (0.00s)
+    --- PASS: TestGateResolution/no_findings_are_approved (0.00s)
+    --- PASS: TestGateResolution/already_fixed_step_is_approved_(no_fix_loop) (0.00s)
+    --- PASS: TestGateResolution/reattached_fix_review_is_approved_without_in-memory_fix_state (0.00s)
+    --- PASS: TestGateResolution/actionable_findings_without_ids_are_approved_rather_than_fixing_nothing (0.00s)
+PASS
+ok  	github.com/kunchenguid/no-mistakes/internal/cli	0.372s

--- a/.no-mistakes/evidence/feat/yolo-auto-resolve/tui-yolo-transcript.txt
+++ b/.no-mistakes/evidence/feat/yolo-auto-resolve/tui-yolo-transcript.txt
@@ -1,0 +1,23 @@
+=== RUN   TestModel_Yolo_FixesActionableFindings
+2026/06/07 15:22:50 INFO ipc request method=respond
+    yolo_test.go:142: yolo response action=fix finding_ids=[review-1]
+--- PASS: TestModel_Yolo_FixesActionableFindings (0.01s)
+=== RUN   TestModel_Yolo_FixesAllActionableFindingsDespiteManualDeselection
+2026/06/07 15:22:50 INFO ipc request method=respond
+    yolo_test.go:174: yolo response action=fix finding_ids=[review-1 review-2]
+--- PASS: TestModel_Yolo_FixesAllActionableFindingsDespiteManualDeselection (0.01s)
+=== RUN   TestModel_Yolo_ApprovesNonActionableFindings
+2026/06/07 15:22:50 INFO ipc request method=respond
+    yolo_test.go:205: yolo response action=approve finding_ids=[]
+--- PASS: TestModel_Yolo_ApprovesNonActionableFindings (0.01s)
+=== RUN   TestModel_Yolo_ApprovesFixReviewAfterFixingOnce
+2026/06/07 15:22:50 INFO ipc request method=respond
+2026/06/07 15:22:50 INFO ipc request method=respond
+    yolo_test.go:241: yolo responses first_action=fix first_finding_ids=[review-1] second_action=approve second_finding_ids=[]
+--- PASS: TestModel_Yolo_ApprovesFixReviewAfterFixingOnce (0.01s)
+=== RUN   TestModel_Yolo_ApprovesExistingFixReviewWithoutPriorFix
+2026/06/07 15:22:50 INFO ipc request method=respond
+    yolo_test.go:272: yolo response action=approve finding_ids=[]
+--- PASS: TestModel_Yolo_ApprovesExistingFixReviewWithoutPriorFix (0.01s)
+PASS
+ok  	github.com/kunchenguid/no-mistakes/internal/tui	0.604s

--- a/docs/src/content/docs/concepts/auto-fix.md
+++ b/docs/src/content/docs/concepts/auto-fix.md
@@ -68,7 +68,8 @@ Agent-driven findings now use an `action` field instead of `requires_human_revie
 - `no-op` - informational notes that do not need a fix
 
 `ask-user` is meant for findings that need human judgment - for example, questioning an intentional product or design choice, arguing that an intentional addition, removal, or guard should be undone, or reporting that the test step could not produce enough evidence for the available intent. Routine correctness, reliability, or security fixes still stay `auto-fix` even if the smallest fix reintroduces a small amount of previously deleted logic.
-In the TUI, yolo mode is an explicit override that auto-approves paused steps, including steps paused for `ask-user` findings.
+In the TUI, yolo mode is an explicit override that auto-resolves paused steps by treating actionable findings, including `ask-user` findings, as consent to run one fix round.
+Steps with only `no-op` findings are approved as-is.
 
 The `review`, `test`, and configured-command `lint` steps use this shared model directly. The `document` step also uses the same `action` field, but unresolved documentation findings pause for approval because the initial document pass already attempted the documentation updates it could make safely.
 When `commands.lint` is empty, lint findings describe issues left after the agent already attempted safe fixes, so they pause for approval instead of remaining eligible for another automatic fix loop.
@@ -89,6 +90,7 @@ That history includes which finding IDs were selected for a prior fix attempt, w
 On follow-up review passes, that history tells the agent not to re-report user-ignored findings unless the code now presents a materially different issue.
 
 After a user-triggered fix, the step re-runs and pauses again to show you the results (`fix_review` status). You can then approve, fix again, skip, or abort.
+Yolo and AXI `--yes` approve that fix review automatically after their one fix round, so a finding that remains after the fix does not trigger an unbounded fix loop.
 
 ## Fix commits
 

--- a/docs/src/content/docs/guides/tui.md
+++ b/docs/src/content/docs/guides/tui.md
@@ -177,7 +177,7 @@ When the instruction editor is open, press `Ctrl+s` or `Ctrl+enter` to save, or 
 | `d` | Toggle diff view (after fix cycle) |
 | `esc` | Exit diff view back to findings |
 | `?` | Toggle help overlay |
-| `y` | Toggle yolo mode, which auto-approves paused steps |
+| `y` | Toggle yolo mode, which auto-resolves paused steps |
 | `r` | Start a rerun after a failed or cancelled run |
 | `q` | Detach from TUI (or quit if run is done) |
 
@@ -197,7 +197,9 @@ The `f fix (3/5)` label shows how many findings are selected out of the total.
 
 Press `e` to add or edit extra guidance for the current finding. Press `+` to add your own finding to the list. User-authored findings start selected by default and can be removed with `D`.
 
-Press `y` to toggle yolo mode when you want paused approval and fix-review steps to approve automatically.
+Press `y` to toggle yolo mode when you want paused approval gates to resolve automatically.
+Yolo fixes gates with actionable findings by selecting every finding, then approves the resulting fix-review gate.
+It approves gates with no findings or only `action: no-op` findings as-is, and fixes each step at most once so unresolved findings do not loop forever.
 
 ## Outcome banner
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -61,13 +61,15 @@ no-mistakes axi run --intent "the user's goal" --yes
 | Flag | Type | Default | Description |
 |---|---|---|---|
 | `--intent` | `string` | (none) | What the user set out to accomplish; required to start a new run |
-| `-y`, `--yes` | `bool` | `false` | Auto-approve every gate and run to completion |
+| `-y`, `--yes` | `bool` | `false` | Auto-resolve every gate and run to completion |
 | `--skip` | `string` | (none) | Comma-separated pipeline steps to skip |
 
 `--intent` is not a description of the diff.
 It is the user's goal or request, and no-mistakes uses it verbatim instead of transcript inference.
 When starting a new run, `axi run` refuses the default branch and uncommitted working trees with actionable errors instead of auto-branching or auto-committing.
 Reattaching to an in-flight run does not require `--intent`.
+With `--yes`, `axi run` fixes gates that have actionable findings by selecting every finding, then accepts the resulting fix review.
+Gates with no findings or only `action: no-op` findings are approved as-is, and each step is fixed at most once so unresolved findings do not loop forever.
 
 ## no-mistakes axi respond
 
@@ -87,7 +89,9 @@ no-mistakes axi respond --action skip
 | `--findings` | `string` | (none) | Comma-separated finding IDs for `--action fix` |
 | `--instructions` | `string` | (none) | Guidance applied to selected findings |
 | `--add-finding` | `string` | (none) | JSON finding object to add and fix |
-| `-y`, `--yes` | `bool` | `false` | Auto-approve every subsequent gate to completion |
+| `-y`, `--yes` | `bool` | `false` | Auto-resolve every subsequent gate to completion |
+
+After the explicit response, `--yes` uses the same auto-resolution behavior as `axi run --yes`: fix actionable findings once, approve the fix review, and approve gates that only contain non-actionable `no-op` findings.
 
 ## no-mistakes axi status
 

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -10,7 +10,7 @@ intent → rebase → review → test → document → lint → push → pr → 
 ```
 
 Each step can produce findings, request approval, trigger auto-fix, or apply safe fixes during its own pass. Steps that encounter fatal errors stop the pipeline. Steps can also be pre-skipped when starting a run, skipped by the user, or skipped automatically by the pipeline.
-In the TUI, yolo mode is an explicit override that auto-approves steps paused for approval or fix review.
+In the TUI, yolo mode is an explicit override that auto-resolves paused steps: actionable findings are fixed once with every finding selected, fix-review gates are approved, and gates with only `no-op` findings are approved as-is.
 Every pipeline agent invocation is prompt-steered to keep intentional writes inside the run worktree and avoid mutating system state outside it.
 This is a soft boundary, not OS-level sandbox enforcement.
 The steering still allows requested test evidence under the managed temporary `no-mistakes-evidence` directory or the configured in-repo evidence directory, plus incidental temp or cache writes from normal development tools.

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -463,7 +463,7 @@ func newAxiRespondCmd() *cobra.Command {
 	cmd.Flags().StringVar(&findings, "findings", "", "comma-separated finding IDs to fix (with --action fix)")
 	cmd.Flags().StringVar(&instructions, "instructions", "", "guidance applied to the selected findings (with --action fix)")
 	cmd.Flags().StringVar(&addFinding, "add-finding", "", "JSON finding object to add and fix (with --action fix)")
-	cmd.Flags().BoolVarP(&autoYes, "yes", "y", false, "auto-approve every subsequent gate to completion")
+	cmd.Flags().BoolVarP(&autoYes, "yes", "y", false, "auto-resolve every subsequent gate to completion")
 	return cmd
 }
 

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -59,7 +59,8 @@ func newAxiRunCmd() *cobra.Command {
 		Short: "Validate your code changes, blocking until a decision point or the outcome",
 		Long: "Triggers a pipeline run for the current branch and drives it. Without\n" +
 			"--yes it blocks until the first approval gate (or the final outcome) and\n" +
-			"prints it. With --yes it auto-approves every gate and runs to completion.\n\n" +
+			"prints it. With --yes it auto-resolves every gate (fixing actionable\n" +
+			"findings, then accepting the result) and runs to completion.\n\n" +
 			"--intent is required when starting a new run: pass what the user set out\n" +
 			"to accomplish (the goal behind the change, not a description of the diff)\n" +
 			"so no-mistakes uses it directly instead of inferring it from transcripts.",
@@ -77,7 +78,7 @@ func newAxiRunCmd() *cobra.Command {
 			})
 		},
 	}
-	cmd.Flags().BoolVarP(&autoYes, "yes", "y", false, "auto-approve every gate and run to completion")
+	cmd.Flags().BoolVarP(&autoYes, "yes", "y", false, "auto-resolve every gate (fix findings, then accept) and run to completion")
 	cmd.Flags().StringVar(&skipValue, "skip", "", "comma-separated pipeline steps to skip")
 	cmd.Flags().StringVar(&intent, "intent", "", "what the user set out to accomplish (not a description of the diff); used instead of inferring from transcripts (required to start a run)")
 	return cmd
@@ -258,10 +259,17 @@ func rerunParams(repoID, branch string, skipSteps []types.StepName, intent strin
 
 // driveRun polls a run until it reaches an approval gate or a terminal state,
 // streaming step transitions to progress (stderr). When autoApprove is set it
-// approves each gate and continues; otherwise it returns at the first gate so
+// resolves each gate and continues; otherwise it returns at the first gate so
 // the caller can surface it for a human/agent decision.
+//
+// Auto-resolution means "agree to fix every finding": a gate with actionable
+// findings is fixed (every finding selected), and the resulting fix_review is
+// accepted; gates with only non-actionable findings are approved. Each step is
+// fixed at most once so a finding the fix cannot clear converges to an approval
+// instead of looping forever.
 func driveRun(ctx context.Context, progress io.Writer, client *ipc.Client, runID string, autoApprove bool) (*ipc.RunInfo, error) {
 	pp := &progressPrinter{w: progress, seen: map[string]string{}}
+	fixedSteps := map[string]bool{}
 	for {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -283,8 +291,12 @@ func driveRun(ctx context.Context, progress io.Writer, client *ipc.Client, runID
 			if !autoApprove {
 				return run, nil
 			}
-			if err := sendRespond(client, runID, types.StepName(gate.Name), types.ActionApprove, nil, nil, nil); err != nil {
-				return nil, fmt.Errorf("auto-approve %s: %w", gate.Name, err)
+			action, findingIDs := gateResolution(gate, fixedSteps[gate.Name])
+			if action == types.ActionFix {
+				fixedSteps[gate.Name] = true
+			}
+			if err := sendRespond(client, runID, types.StepName(gate.Name), action, findingIDs, nil, nil); err != nil {
+				return nil, fmt.Errorf("auto-resolve %s: %w", gate.Name, err)
 			}
 			if err := waitStepLeavesGate(ctx, client, runID, gate.Name, gate.Status); err != nil {
 				return nil, err
@@ -295,6 +307,33 @@ func driveRun(ctx context.Context, progress io.Writer, client *ipc.Client, runID
 			return nil, err
 		}
 	}
+}
+
+// gateResolution decides how --yes answers an approval gate. A gate with
+// actionable findings (anything other than purely informational "no-op") is
+// fixed with every finding selected, unless this step was already fixed once -
+// in which case the gate is approved so the run converges instead of looping on
+// a finding the fix cannot clear. Gates with only non-actionable findings, no
+// findings, or actionable findings that carry no IDs (which a fix would resolve
+// to zero selections) are approved.
+func gateResolution(gate stepView, alreadyFixed bool) (types.ApprovalAction, []string) {
+	if alreadyFixed {
+		return types.ActionApprove, nil
+	}
+	parsed, err := types.ParseFindingsJSON(gate.FindingsJSON)
+	if err != nil || !types.HasActionableFindings(parsed) {
+		return types.ActionApprove, nil
+	}
+	ids := make([]string, 0, len(parsed.Items))
+	for _, f := range parsed.Items {
+		if f.ID != "" {
+			ids = append(ids, f.ID)
+		}
+	}
+	if len(ids) == 0 {
+		return types.ActionApprove, nil
+	}
+	return types.ActionFix, ids
 }
 
 // waitStepLeavesGate blocks until the named step's status changes away from the

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -317,7 +317,7 @@ func driveRun(ctx context.Context, progress io.Writer, client *ipc.Client, runID
 // findings, or actionable findings that carry no IDs (which a fix would resolve
 // to zero selections) are approved.
 func gateResolution(gate stepView, alreadyFixed bool) (types.ApprovalAction, []string) {
-	if alreadyFixed {
+	if alreadyFixed || gate.Status == string(types.StepStatusFixReview) {
 		return types.ActionApprove, nil
 	}
 	parsed, err := types.ParseFindingsJSON(gate.FindingsJSON)

--- a/internal/cli/axi_drive_test.go
+++ b/internal/cli/axi_drive_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+func TestGateResolution(t *testing.T) {
+	tests := []struct {
+		name         string
+		gate         stepView
+		alreadyFixed bool
+		wantAction   types.ApprovalAction
+		wantIDs      []string
+	}{
+		{
+			name: "actionable findings are fixed with every finding selected",
+			gate: stepView{
+				Name:         "review",
+				Status:       string(types.StepStatusAwaitingApproval),
+				FindingsJSON: `{"findings":[{"id":"review-1","severity":"warning","description":"design choice","action":"ask-user"},{"id":"review-2","severity":"info","description":"fyi","action":"no-op"}],"summary":"2"}`,
+			},
+			wantAction: types.ActionFix,
+			wantIDs:    []string{"review-1", "review-2"},
+		},
+		{
+			name: "only non-actionable findings are approved",
+			gate: stepView{
+				Name:         "test",
+				Status:       string(types.StepStatusAwaitingApproval),
+				FindingsJSON: `{"findings":[{"id":"test-1","severity":"info","description":"fyi","action":"no-op"}],"summary":"1"}`,
+			},
+			wantAction: types.ActionApprove,
+		},
+		{
+			name: "no findings are approved",
+			gate: stepView{
+				Name:         "push",
+				Status:       string(types.StepStatusAwaitingApproval),
+				FindingsJSON: ``,
+			},
+			wantAction: types.ActionApprove,
+		},
+		{
+			name: "already fixed step is approved (no fix loop)",
+			gate: stepView{
+				Name:         "review",
+				Status:       string(types.StepStatusFixReview),
+				FindingsJSON: `{"findings":[{"id":"review-1","severity":"warning","description":"still here","action":"ask-user"}],"summary":"1"}`,
+			},
+			alreadyFixed: true,
+			wantAction:   types.ActionApprove,
+		},
+		{
+			name: "actionable findings without ids are approved rather than fixing nothing",
+			gate: stepView{
+				Name:         "review",
+				Status:       string(types.StepStatusAwaitingApproval),
+				FindingsJSON: `{"findings":[{"severity":"warning","description":"no id","action":"ask-user"}],"summary":"1"}`,
+			},
+			wantAction: types.ActionApprove,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			action, ids := gateResolution(tt.gate, tt.alreadyFixed)
+			if action != tt.wantAction {
+				t.Fatalf("action = %s, want %s", action, tt.wantAction)
+			}
+			if len(ids) != len(tt.wantIDs) {
+				t.Fatalf("ids = %v, want %v", ids, tt.wantIDs)
+			}
+			for i := range ids {
+				if ids[i] != tt.wantIDs[i] {
+					t.Fatalf("ids = %v, want %v", ids, tt.wantIDs)
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/axi_drive_test.go
+++ b/internal/cli/axi_drive_test.go
@@ -72,12 +72,13 @@ func TestGateResolution(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			action, ids := gateResolution(tt.gate, tt.alreadyFixed)
-			if action != tt.wantAction {
-				t.Fatalf("action = %s, want %s", action, tt.wantAction)
-			}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				action, ids := gateResolution(tt.gate, tt.alreadyFixed)
+				t.Logf("auto-resolution action=%s finding_ids=%v", action, ids)
+				if action != tt.wantAction {
+					t.Fatalf("action = %s, want %s", action, tt.wantAction)
+				}
 			if len(ids) != len(tt.wantIDs) {
 				t.Fatalf("ids = %v, want %v", ids, tt.wantIDs)
 			}

--- a/internal/cli/axi_drive_test.go
+++ b/internal/cli/axi_drive_test.go
@@ -72,13 +72,13 @@ func TestGateResolution(t *testing.T) {
 		},
 	}
 
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				action, ids := gateResolution(tt.gate, tt.alreadyFixed)
-				t.Logf("auto-resolution action=%s finding_ids=%v", action, ids)
-				if action != tt.wantAction {
-					t.Fatalf("action = %s, want %s", action, tt.wantAction)
-				}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			action, ids := gateResolution(tt.gate, tt.alreadyFixed)
+			t.Logf("auto-resolution action=%s finding_ids=%v", action, ids)
+			if action != tt.wantAction {
+				t.Fatalf("action = %s, want %s", action, tt.wantAction)
+			}
 			if len(ids) != len(tt.wantIDs) {
 				t.Fatalf("ids = %v, want %v", ids, tt.wantIDs)
 			}

--- a/internal/cli/axi_drive_test.go
+++ b/internal/cli/axi_drive_test.go
@@ -53,6 +53,15 @@ func TestGateResolution(t *testing.T) {
 			wantAction:   types.ActionApprove,
 		},
 		{
+			name: "reattached fix review is approved without in-memory fix state",
+			gate: stepView{
+				Name:         "review",
+				Status:       string(types.StepStatusFixReview),
+				FindingsJSON: `{"findings":[{"id":"review-1","severity":"warning","description":"still here","action":"ask-user"}],"summary":"1"}`,
+			},
+			wantAction: types.ActionApprove,
+		},
+		{
 			name: "actionable findings without ids are approved rather than fixing nothing",
 			gate: stepView{
 				Name:         "review",

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -92,6 +92,11 @@ Run the pipeline and decide on its findings as they come up:
    ` + "`outcome:`" + ` of ` + "`passed`" + ` means the changes cleared the gate; ` + "`failed`" + ` or
    ` + "`cancelled`" + ` means they did not - read the output and address it.
 
+If you have clear consent to drive the run automatically, pass ` + "`--yes`" + ` to ` + "`axi run`" + `
+or ` + "`axi respond`" + `. It treats actionable findings as consent to fix them,
+selects every current finding for one fix round, accepts the resulting fix review,
+and approves gates with only ` + "`no-op`" + ` findings.
+
 ## Inspecting state
 
 ` + "```sh" + `

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -50,8 +50,9 @@ type Model struct {
 	spinnerFrame     int
 	spinnerScheduled bool
 	syntheticSteps   bool
-	yoloMode         bool                    // auto-approve every step awaiting human action
-	yoloApproved     map[types.StepName]bool // steps already auto-approved this run
+	yoloMode         bool                    // auto-resolve every step awaiting human action
+	yoloApproved     map[types.StepName]bool // steps already finalized (approved) this run
+	yoloFixed        map[types.StepName]bool // steps yolo has already requested a fix for
 }
 
 // NewModel creates a TUI model for the given run.
@@ -77,6 +78,7 @@ func NewModel(socketPath string, client *ipc.Client, run *ipc.RunInfo) Model {
 		stepStartTimes:      make(map[types.StepName]time.Time),
 		syntheticSteps:      syntheticSteps,
 		yoloApproved:        make(map[types.StepName]bool),
+		yoloFixed:           make(map[types.StepName]bool),
 	}
 	// Populate findings and start times from initial step data (for re-attach scenarios).
 	for _, s := range steps {

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -91,6 +91,7 @@ func (m Model) maybeAutoApproveCmd() tea.Cmd {
 	}
 	if !m.yoloFixed[step.StepName] && m.stepHasActionableFindings(step.StepName) {
 		m.yoloFixed[step.StepName] = true
+		m.resetFindingSelection(step.StepName)
 		return m.respondCmd(types.ActionFix)
 	}
 	m.yoloApproved[step.StepName] = true

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -89,7 +89,7 @@ func (m Model) maybeAutoApproveCmd() tea.Cmd {
 	if step == nil || m.yoloApproved[step.StepName] {
 		return nil
 	}
-	if !m.yoloFixed[step.StepName] && m.stepHasActionableFindings(step.StepName) {
+	if step.Status != types.StepStatusFixReview && !m.yoloFixed[step.StepName] && m.stepHasActionableFindings(step.StepName) {
 		m.yoloFixed[step.StepName] = true
 		m.resetFindingSelection(step.StepName)
 		return m.respondCmd(types.ActionFix)

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -73,9 +73,14 @@ func (m Model) rerunCmd(requestID uint64) tea.Cmd {
 	}
 }
 
-// maybeAutoApproveCmd auto-approves the current awaiting step when yolo mode is
-// on, returning nil otherwise. Each step is approved at most once so duplicate
-// events while waiting for the approval round-trip don't resend the action.
+// maybeAutoApproveCmd auto-resolves the current awaiting step when yolo mode is
+// on, returning nil otherwise. Yolo means "agree to fix every finding": a gate
+// whose findings are actionable gets a fix request (all findings selected),
+// while a gate with only non-actionable (no-op) findings - or none at all - is
+// approved as-is. A step is fixed at most once; the fix re-runs the step and
+// re-enters the gate as a fix_review, which yolo then approves so the pipeline
+// runs to completion without looping. Each terminal action fires once so
+// duplicate events while waiting for the round-trip don't resend it.
 func (m Model) maybeAutoApproveCmd() tea.Cmd {
 	if !m.yoloMode {
 		return nil
@@ -83,6 +88,10 @@ func (m Model) maybeAutoApproveCmd() tea.Cmd {
 	step := awaitingStep(m.steps)
 	if step == nil || m.yoloApproved[step.StepName] {
 		return nil
+	}
+	if !m.yoloFixed[step.StepName] && m.stepHasActionableFindings(step.StepName) {
+		m.yoloFixed[step.StepName] = true
+		return m.respondCmd(types.ActionFix)
 	}
 	m.yoloApproved[step.StepName] = true
 	return m.respondCmd(types.ActionApprove)

--- a/internal/tui/findings.go
+++ b/internal/tui/findings.go
@@ -4,6 +4,14 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
+// stepHasActionableFindings reports whether the step's findings (agent-produced
+// plus any user-added) include at least one finding a fix agent could act on,
+// i.e. anything other than a purely informational "no-op". Yolo uses this to
+// decide between fixing a gate's findings and approving it as-is.
+func (m Model) stepHasActionableFindings(step types.StepName) bool {
+	return types.HasActionableFindings(types.Findings{Items: m.findingItems(step)})
+}
+
 func (m Model) awaitingActionState() (showSelectionActions bool, allowFix bool, selectedCount int, totalCount int) {
 	step := awaitingStep(m.steps)
 	if step == nil {

--- a/internal/tui/pipeline.go
+++ b/internal/tui/pipeline.go
@@ -418,9 +418,9 @@ func renderHelpOverlay(width int, run *ipc.RunInfo, hasAwaitingStep bool, showDi
 		footerEntries = append(footerEntries, helpEntry{"x x", "abort pipeline"})
 	}
 	footerEntries = append(footerEntries, helpEntry{"?", "close help"})
-	yoloDesc := "auto-accept every step"
+	yoloDesc := "auto-resolve every finding"
 	if yolo {
-		yoloDesc = "end yolo (auto-accept)"
+		yoloDesc = "end yolo (auto-resolve)"
 	}
 	footerEntries = append(footerEntries, helpEntry{"y", yoloDesc})
 	if canRerun(run) {

--- a/internal/tui/yolo_test.go
+++ b/internal/tui/yolo_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -143,6 +144,37 @@ func TestModel_Yolo_FixesActionableFindings(t *testing.T) {
 	}
 	if len(calls[0].FindingIDs) != 1 || calls[0].FindingIDs[0] != "review-1" {
 		t.Fatalf("FindingIDs = %v, want [review-1]", calls[0].FindingIDs)
+	}
+}
+
+func TestModel_Yolo_FixesAllActionableFindingsDespiteManualDeselection(t *testing.T) {
+	sock, client, snapshot := captureRespond(t)
+
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusAwaitingApproval
+	fj := `{"findings":[{"id":"review-1","severity":"warning","description":"first","action":"ask-user"},{"id":"review-2","severity":"warning","description":"second","action":"ask-user"}],"summary":"2 issues"}`
+	run.Steps[0].FindingsJSON = &fj
+	m := NewModel(sock, client, run)
+	m.yoloMode = true
+	m.findingSelections[types.StepReview] = map[string]bool{"review-1": true}
+
+	cmd := m.maybeAutoApproveCmd()
+	if cmd == nil {
+		t.Fatal("expected a yolo command for an awaiting step with actionable findings")
+	}
+	if msg := cmd(); msg != nil {
+		t.Fatalf("expected nil msg, got %#v", msg)
+	}
+
+	calls := snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 respond call, got %d", len(calls))
+	}
+	if calls[0].Action != types.ActionFix {
+		t.Fatalf("action = %s, want %s", calls[0].Action, types.ActionFix)
+	}
+	if got, want := calls[0].FindingIDs, []string{"review-1", "review-2"}; !slices.Equal(got, want) {
+		t.Fatalf("FindingIDs = %v, want %v", got, want)
 	}
 }
 

--- a/internal/tui/yolo_test.go
+++ b/internal/tui/yolo_test.go
@@ -139,6 +139,7 @@ func TestModel_Yolo_FixesActionableFindings(t *testing.T) {
 	if len(calls) != 1 {
 		t.Fatalf("expected 1 respond call, got %d", len(calls))
 	}
+	t.Logf("yolo response action=%s finding_ids=%v", calls[0].Action, calls[0].FindingIDs)
 	if calls[0].Action != types.ActionFix {
 		t.Fatalf("action = %s, want %s", calls[0].Action, types.ActionFix)
 	}
@@ -170,6 +171,7 @@ func TestModel_Yolo_FixesAllActionableFindingsDespiteManualDeselection(t *testin
 	if len(calls) != 1 {
 		t.Fatalf("expected 1 respond call, got %d", len(calls))
 	}
+	t.Logf("yolo response action=%s finding_ids=%v", calls[0].Action, calls[0].FindingIDs)
 	if calls[0].Action != types.ActionFix {
 		t.Fatalf("action = %s, want %s", calls[0].Action, types.ActionFix)
 	}
@@ -200,6 +202,7 @@ func TestModel_Yolo_ApprovesNonActionableFindings(t *testing.T) {
 	if len(calls) != 1 {
 		t.Fatalf("expected 1 respond call, got %d", len(calls))
 	}
+	t.Logf("yolo response action=%s finding_ids=%v", calls[0].Action, calls[0].FindingIDs)
 	if calls[0].Action != types.ActionApprove {
 		t.Fatalf("action = %s, want %s (non-actionable findings should be approved)", calls[0].Action, types.ActionApprove)
 	}
@@ -235,6 +238,7 @@ func TestModel_Yolo_ApprovesFixReviewAfterFixingOnce(t *testing.T) {
 	if len(calls) != 2 {
 		t.Fatalf("expected 2 respond calls, got %d", len(calls))
 	}
+	t.Logf("yolo responses first_action=%s first_finding_ids=%v second_action=%s second_finding_ids=%v", calls[0].Action, calls[0].FindingIDs, calls[1].Action, calls[1].FindingIDs)
 	if calls[0].Action != types.ActionFix {
 		t.Fatalf("first action = %s, want %s", calls[0].Action, types.ActionFix)
 	}
@@ -265,6 +269,7 @@ func TestModel_Yolo_ApprovesExistingFixReviewWithoutPriorFix(t *testing.T) {
 	if len(calls) != 1 {
 		t.Fatalf("expected 1 respond call, got %d", len(calls))
 	}
+	t.Logf("yolo response action=%s finding_ids=%v", calls[0].Action, calls[0].FindingIDs)
 	if calls[0].Action != types.ActionApprove {
 		t.Fatalf("action = %s, want %s", calls[0].Action, types.ActionApprove)
 	}

--- a/internal/tui/yolo_test.go
+++ b/internal/tui/yolo_test.go
@@ -243,6 +243,33 @@ func TestModel_Yolo_ApprovesFixReviewAfterFixingOnce(t *testing.T) {
 	}
 }
 
+func TestModel_Yolo_ApprovesExistingFixReviewWithoutPriorFix(t *testing.T) {
+	sock, client, snapshot := captureRespond(t)
+
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusFixReview
+	fj := `{"findings":[{"id":"review-1","severity":"warning","description":"still here","action":"ask-user"}],"summary":"1 issue"}`
+	run.Steps[0].FindingsJSON = &fj
+	m := NewModel(sock, client, run)
+	m.yoloMode = true
+
+	cmd := m.maybeAutoApproveCmd()
+	if cmd == nil {
+		t.Fatal("expected yolo to approve an existing fix_review gate")
+	}
+	if msg := cmd(); msg != nil {
+		t.Fatalf("expected nil msg, got %#v", msg)
+	}
+
+	calls := snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 respond call, got %d", len(calls))
+	}
+	if calls[0].Action != types.ActionApprove {
+		t.Fatalf("action = %s, want %s", calls[0].Action, types.ActionApprove)
+	}
+}
+
 func TestModel_Yolo_DoesNotAutoApproveTwiceForSameStep(t *testing.T) {
 	run := testRun()
 	run.Steps[0].Status = types.StepStatusAwaitingApproval

--- a/internal/tui/yolo_test.go
+++ b/internal/tui/yolo_test.go
@@ -83,6 +83,134 @@ func TestModel_Yolo_AutoApprovesAwaitingStep(t *testing.T) {
 	}
 }
 
+// captureRespond wires a model-facing IPC server that records every Respond
+// call, returning the connected client plus accessors for the captured params.
+func captureRespond(t *testing.T) (string, *ipc.Client, func() []ipc.RespondParams) {
+	t.Helper()
+	sock := testSocketPath(t)
+	srv := startTestIPCServer(t, sock)
+
+	var mu sync.Mutex
+	var calls []ipc.RespondParams
+	srv.Handle(ipc.MethodRespond, func(_ context.Context, raw json.RawMessage) (interface{}, error) {
+		var params ipc.RespondParams
+		if err := json.Unmarshal(raw, &params); err != nil {
+			return nil, err
+		}
+		mu.Lock()
+		calls = append(calls, params)
+		mu.Unlock()
+		return &ipc.RespondResult{}, nil
+	})
+
+	client, err := ipc.Dial(sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { client.Close() })
+
+	return sock, client, func() []ipc.RespondParams {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]ipc.RespondParams(nil), calls...)
+	}
+}
+
+func TestModel_Yolo_FixesActionableFindings(t *testing.T) {
+	sock, client, snapshot := captureRespond(t)
+
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusAwaitingApproval
+	fj := `{"findings":[{"id":"review-1","severity":"warning","description":"design choice","action":"ask-user"}],"summary":"1 issue"}`
+	run.Steps[0].FindingsJSON = &fj
+	m := NewModel(sock, client, run)
+	m.yoloMode = true
+
+	cmd := m.maybeAutoApproveCmd()
+	if cmd == nil {
+		t.Fatal("expected a yolo command for an awaiting step with actionable findings")
+	}
+	if msg := cmd(); msg != nil {
+		t.Fatalf("expected nil msg, got %#v", msg)
+	}
+
+	calls := snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 respond call, got %d", len(calls))
+	}
+	if calls[0].Action != types.ActionFix {
+		t.Fatalf("action = %s, want %s", calls[0].Action, types.ActionFix)
+	}
+	if len(calls[0].FindingIDs) != 1 || calls[0].FindingIDs[0] != "review-1" {
+		t.Fatalf("FindingIDs = %v, want [review-1]", calls[0].FindingIDs)
+	}
+}
+
+func TestModel_Yolo_ApprovesNonActionableFindings(t *testing.T) {
+	sock, client, snapshot := captureRespond(t)
+
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusAwaitingApproval
+	fj := `{"findings":[{"id":"review-1","severity":"info","description":"fyi","action":"no-op"}],"summary":"1 note"}`
+	run.Steps[0].FindingsJSON = &fj
+	m := NewModel(sock, client, run)
+	m.yoloMode = true
+
+	cmd := m.maybeAutoApproveCmd()
+	if cmd == nil {
+		t.Fatal("expected a yolo command for an awaiting step")
+	}
+	if msg := cmd(); msg != nil {
+		t.Fatalf("expected nil msg, got %#v", msg)
+	}
+
+	calls := snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 respond call, got %d", len(calls))
+	}
+	if calls[0].Action != types.ActionApprove {
+		t.Fatalf("action = %s, want %s (non-actionable findings should be approved)", calls[0].Action, types.ActionApprove)
+	}
+}
+
+func TestModel_Yolo_ApprovesFixReviewAfterFixingOnce(t *testing.T) {
+	sock, client, snapshot := captureRespond(t)
+
+	run := testRun()
+	run.Steps[0].Status = types.StepStatusAwaitingApproval
+	fj := `{"findings":[{"id":"review-1","severity":"warning","description":"design choice","action":"ask-user"}],"summary":"1 issue"}`
+	run.Steps[0].FindingsJSON = &fj
+	m := NewModel(sock, client, run)
+	m.yoloMode = true
+
+	// First gate: actionable findings -> fix.
+	if cmd := m.maybeAutoApproveCmd(); cmd != nil {
+		cmd()
+	} else {
+		t.Fatal("expected fix command on first gate")
+	}
+
+	// The fix re-runs the step, which re-enters the gate as a fix_review. Yolo
+	// must not fix again (that risks an unbounded loop); it accepts the result.
+	m.steps[0].Status = types.StepStatusFixReview
+	if cmd := m.maybeAutoApproveCmd(); cmd != nil {
+		cmd()
+	} else {
+		t.Fatal("expected approve command on fix_review gate")
+	}
+
+	calls := snapshot()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 respond calls, got %d", len(calls))
+	}
+	if calls[0].Action != types.ActionFix {
+		t.Fatalf("first action = %s, want %s", calls[0].Action, types.ActionFix)
+	}
+	if calls[1].Action != types.ActionApprove {
+		t.Fatalf("second action = %s, want %s", calls[1].Action, types.ActionApprove)
+	}
+}
+
 func TestModel_Yolo_DoesNotAutoApproveTwiceForSameStep(t *testing.T) {
 	run := testRun()
 	run.Steps[0].Status = types.StepStatusAwaitingApproval

--- a/internal/types/findings.go
+++ b/internal/types/findings.go
@@ -214,7 +214,7 @@ func HasAskUserFindings(findings Findings) bool {
 // any finding whose effective action is not "no-op". Findings that are purely
 // informational ("no-op") are not actionable and need no fix, so a step whose
 // findings are all no-op (or that has no findings) returns false. This is what
-// yolo / auto-approve uses to decide whether to fix a gate's findings or just
+// yolo / auto-resolve uses to decide whether to fix a gate's findings or just
 // accept the step as-is.
 func HasActionableFindings(findings Findings) bool {
 	for _, item := range findings.Items {

--- a/internal/types/findings.go
+++ b/internal/types/findings.go
@@ -210,6 +210,21 @@ func HasAskUserFindings(findings Findings) bool {
 	return false
 }
 
+// HasActionableFindings reports whether any finding warrants a fix - that is,
+// any finding whose effective action is not "no-op". Findings that are purely
+// informational ("no-op") are not actionable and need no fix, so a step whose
+// findings are all no-op (or that has no findings) returns false. This is what
+// yolo / auto-approve uses to decide whether to fix a gate's findings or just
+// accept the step as-is.
+func HasActionableFindings(findings Findings) bool {
+	for _, item := range findings.Items {
+		if item.actionOrDefault() != ActionNoOp {
+			return true
+		}
+	}
+	return false
+}
+
 func summarizeSelectedFindings(count int) string {
 	switch count {
 	case 0:

--- a/internal/types/findings_test.go
+++ b/internal/types/findings_test.go
@@ -274,6 +274,30 @@ func TestHasAskUserFindings(t *testing.T) {
 	}
 }
 
+func TestHasActionableFindings(t *testing.T) {
+	tests := []struct {
+		name   string
+		items  []Finding
+		expect bool
+	}{
+		{"has ask-user", []Finding{{Action: ActionAskUser}}, true},
+		{"has auto-fix", []Finding{{Action: ActionAutoFix}}, true},
+		{"empty action defaults to auto-fix", []Finding{{Action: ""}}, true},
+		{"only no-op", []Finding{{Action: ActionNoOp}}, false},
+		{"all no-op", []Finding{{Action: ActionNoOp}, {Action: ActionNoOp}}, false},
+		{"mixed no-op and ask-user", []Finding{{Action: ActionNoOp}, {Action: ActionAskUser}}, true},
+		{"empty", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := Findings{Items: tt.items}
+			if got := HasActionableFindings(f); got != tt.expect {
+				t.Errorf("HasActionableFindings() = %v, want %v", got, tt.expect)
+			}
+		})
+	}
+}
+
 func TestMarshalFindingsJSON_AlwaysIncludesRiskFields(t *testing.T) {
 	f := Findings{
 		Items:   []Finding{{Severity: "info", Description: "note"}},

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -61,6 +61,11 @@ Run the pipeline and decide on its findings as they come up:
    `outcome:` of `passed` means the changes cleared the gate; `failed` or
    `cancelled` means they did not - read the output and address it.
 
+If you have clear consent to drive the run automatically, pass `--yes` to `axi run`
+or `axi respond`. It treats actionable findings as consent to fix them,
+selects every current finding for one fix round, accepts the resulting fix review,
+and approves gates with only `no-op` findings.
+
 ## Inspecting state
 
 ```sh


### PR DESCRIPTION
## Intent

The developer wanted yolo mode and the --yes CLI path to treat every actionable finding as consent to fix it, not as approval to skip past it unchanged. They expected yolo to select all current findings for a fix automatically, matching the manual fix flow, while avoiding pointless fixes for non-actionable findings such as no-op/test-step findings. They also needed the behavior to be bounded so yolo would not loop forever if a fix review still had findings, and they wanted tests and verification around the changed TUI and CLI behavior.

## What Changed

- Updates `--yes` CLI gate handling and TUI yolo mode so actionable findings trigger fixes instead of being approved unchanged.
- Bounds auto-resolution around fix-review gates, including reattached runs, so existing fix-review findings are approved instead of repeatedly re-fixed.
- Adds finding actionability helpers, targeted CLI/TUI/type coverage, and refreshes the docs and skill text for the new auto-fix behavior.

## Risk Assessment

✅ Low: The change is narrowly scoped to yolo/--yes gate resolution, includes targeted helper coverage, and the previous auto-resolution issues appear addressed without introducing a substantiated merge-blocking risk.

## Testing

Focused tests, evidence-producing verbose transcripts, and the full changed-package test pass all succeeded; the evidence shows actionable findings are sent as fix requests with selected IDs, no-op findings are approved, and fix_review is approved to avoid an auto-fix loop.

<details>
<summary>Evidence: CLI --yes gate resolution transcript</summary>

Source: [CLI --yes gate resolution transcript](https://github.com/kunchenguid/no-mistakes/blob/d3bf1c3b7da4c595b3ae5910dce0498cf18e4075/.no-mistakes/evidence/feat/yolo-auto-resolve/cli-gate-resolution-transcript.txt)

```text
Shows action=fix with finding_ids=[review-1 review-2] for actionable findings, action=approve for no-op/no findings, and action=approve for fix_review/no-loop cases.
```
</details>
<details>
<summary>Evidence: TUI yolo response transcript</summary>

Source: [TUI yolo response transcript](https://github.com/kunchenguid/no-mistakes/blob/d3bf1c3b7da4c595b3ae5910dce0498cf18e4075/.no-mistakes/evidence/feat/yolo-auto-resolve/tui-yolo-transcript.txt)

```text
Shows yolo sends fix responses with selected finding IDs, resets manual deselection to fix all current findings, approves non-actionable findings, and approves fix_review after one fix.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ `internal/tui/commands.go:94` - Yolo fix reuses the current manual finding selection instead of selecting all current findings. If a user has deselected one actionable finding before enabling yolo, the TUI sends only the remaining selected IDs; if the user cleared all selections, `respondCmd(ActionFix)` returns nil after `yoloFixed` is set, so the next auto-resolution can approve the gate without ever fixing the actionable finding. Reset/select all findings before issuing the yolo fix so the TUI matches the new `--yes` behavior.

🔧 Fix: Fix yolo finding selection reset
2 warnings still open:
- ⚠️ `internal/cli/axi_drive.go:294` - `--yes` only remembers fixes issued during this `driveRun` process. If an agent starts or re-runs `no-mistakes axi run --yes` while the active run is already at `fix_review`, `fixedSteps` is empty, so actionable findings trigger another `fix` instead of accepting the fix review; repeated invocations can keep re-fixing the same review result rather than converging. Treat `fix_review` gates as already fixed for auto-resolution, or initialize the decision from the gate status rather than only the in-memory map.
- ⚠️ `internal/tui/commands.go:92` - Yolo mode has the same reattach/start-at-fix-review problem in the TUI. `yoloFixed` is only set when the current model previously sent a fix, so enabling yolo on a model that loads an existing `fix_review` gate with actionable findings sends another fix instead of approving the review result, defeating the intended one-fix bound. Check the awaiting step status and approve `fix_review` gates unless yolo has just produced a new fix cycle that legitimately needs handling.

🔧 Fix: Approve reattached fix review gates
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/cli -run '^TestGateResolution$' -count=1`
- `go test ./internal/tui -run '^TestModel_Yolo' -count=1`
- `go test ./internal/types -run '^Test(HasActionableFindings|ParseFindingsJSON)' -count=1`
- `go test -v ./internal/cli -run '^TestGateResolution$' -count=1 > .no-mistakes/evidence/feat/yolo-auto-resolve/cli-gate-resolution-transcript.txt`
- `go test -v ./internal/tui -run '^TestModel_Yolo_(FixesActionableFindings|FixesAllActionableFindingsDespiteManualDeselection|ApprovesNonActionableFindings|ApprovesFixReviewAfterFixingOnce|ApprovesExistingFixReviewWithoutPriorFix)$' -count=1 > .no-mistakes/evidence/feat/yolo-auto-resolve/tui-yolo-transcript.txt`
- `go test ./internal/cli ./internal/tui ./internal/types -count=1`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
