### PR TITLE
fix(cli): stop axi drive after CI checks pass

### DIFF
--- a/.no-mistakes/evidence/fix/axi-ci-checks-passed/checks-passed-output.txt
+++ b/.no-mistakes/evidence/fix/axi-ci-checks-passed/checks-passed-output.txt
@@ -1,0 +1,17 @@
+Command: go test ./internal/cli -run '^TestEvidenceChecksPassedOutput$' -count=1 -v
+
+End-user output rendered by renderDriveResult when CI checks have passed but the run is still monitoring for a human merge:
+
+run:
+  id: run-1
+  branch: feature/x
+  status: running
+  head: abcdef12
+  pr: "https://github.com/user/repo/pull/42"
+  findings: none
+  steps[1]{step,status,findings,duration_ms}:
+    ci,running,0,0
+outcome: checks-passed
+help[1]: "CI checks passed - the PR is ready. Ask the user to review and merge it: https://github.com/user/repo/pull/42"
+
+Result: PASS

--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -54,7 +54,7 @@ That is a core design choice, not an implementation detail.
 6. If a step pauses, you can attach with the TUI or use `no-mistakes axi respond` to approve, fix, skip, or abort.
 7. After local checks pass, the push step forwards the branch upstream and the PR step creates or updates the pull request.
 8. The CI step keeps watching the open PR until it is merged or closed, and can auto-fix failures or merge conflicts when supported.
-   While it watches, the TUI and terminal title surface a `Checks passed` signal once checks are green and the PR is mergeable, so you know when to go merge it.
+   While it watches, the TUI and terminal title surface a `Checks passed` signal once checks are green and the PR is mergeable, and `no-mistakes axi` returns `outcome: checks-passed` so agents stop and ask you to review and merge it.
 
 **Key design decisions:**
 

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -87,6 +87,8 @@ It does **not** change the pipeline order or the meaning of a passed gate.
 `no-mistakes init` installs a `/no-mistakes` skill into `.claude/skills/no-mistakes/SKILL.md` and `.agents/skills/no-mistakes/SKILL.md`.
 Re-run `no-mistakes init` in an already-initialized repo to refresh or reinstall that skill after an upgrade.
 The skill tells agents to use `no-mistakes axi`, a non-interactive command surface that prints TOON to stdout and progress to stderr.
+When CI is green but the PR is still open, `axi run` and `axi respond` return `outcome: checks-passed` with a help line pointing at the PR instead of waiting for a human merge.
+That is a successful agent stopping point: report that the PR is ready and ask the user to review and merge it.
 
 Agents can also call `no-mistakes axi` directly:
 
@@ -101,6 +103,7 @@ no-mistakes axi abort
 When an agent starts a new run, `--intent` is required and should describe what the user wanted to accomplish, not what files changed.
 If the repo is on the default branch or has uncommitted changes, `axi run` returns a structured error with the command the agent should run instead of silently creating a branch or commit.
 Approval gates are exposed as `gate:` objects with finding IDs, severities, files, actions, descriptions, and help commands for `no-mistakes axi respond`.
+Successful outputs can be `outcome: passed` for a completed run or `outcome: checks-passed` when CI has passed and the daemon is still monitoring the unmerged PR for humans.
 
 ## Binary resolution
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -50,7 +50,7 @@ With no subcommand, shows the executable path, description, repo, daemon state, 
 
 ## no-mistakes axi run
 
-Start or reattach to validation for the current branch, blocking until the first approval gate or the final outcome.
+Start or reattach to validation for the current branch, blocking until the first approval gate, CI-ready decision point, or final outcome.
 
 ```sh
 no-mistakes axi run --intent "the user's goal"
@@ -61,7 +61,7 @@ no-mistakes axi run --intent "the user's goal" --yes
 | Flag | Type | Default | Description |
 |---|---|---|---|
 | `--intent` | `string` | (none) | What the user set out to accomplish; required to start a new run |
-| `-y`, `--yes` | `bool` | `false` | Auto-resolve every gate and run to completion |
+| `-y`, `--yes` | `bool` | `false` | Auto-resolve every gate until a decision point or outcome |
 | `--skip` | `string` | (none) | Comma-separated pipeline steps to skip |
 
 `--intent` is not a description of the diff.
@@ -70,10 +70,12 @@ When starting a new run, `axi run` refuses the default branch and uncommitted wo
 Reattaching to an in-flight run does not require `--intent`.
 With `--yes`, `axi run` fixes gates that have actionable findings by selecting every finding, then accepts the resulting fix review.
 Gates with no findings or only `action: no-op` findings are approved as-is, and each step is fixed at most once so unresolved findings do not loop forever.
+When the CI step is still monitoring an open PR and checks are green, `axi run` exits successfully with `outcome: checks-passed` instead of waiting for a human merge.
+Treat that as the agent stopping point: ask the user to review and merge the PR from the `help` line.
 
 ## no-mistakes axi respond
 
-Answer the current approval gate and continue until the next gate or final outcome.
+Answer the current approval gate and continue until the next gate, CI-ready decision point, or final outcome.
 
 ```sh
 no-mistakes axi respond --action approve
@@ -89,9 +91,9 @@ no-mistakes axi respond --action skip
 | `--findings` | `string` | (none) | Comma-separated finding IDs for `--action fix` |
 | `--instructions` | `string` | (none) | Guidance applied to selected findings |
 | `--add-finding` | `string` | (none) | JSON finding object to add and fix |
-| `-y`, `--yes` | `bool` | `false` | Auto-resolve every subsequent gate to completion |
+| `-y`, `--yes` | `bool` | `false` | Auto-resolve every subsequent gate until a decision point or outcome |
 
-After the explicit response, `--yes` uses the same auto-resolution behavior as `axi run --yes`: fix actionable findings once, approve the fix review, and approve gates that only contain non-actionable `no-op` findings.
+After the explicit response, `--yes` uses the same auto-resolution behavior as `axi run --yes`: fix actionable findings once, approve the fix review, approve gates that only contain non-actionable `no-op` findings, and stop at `outcome: checks-passed` when CI is green but the PR still needs a human merge.
 
 ## no-mistakes axi status
 

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -171,7 +171,8 @@ Monitors PR health after creation and auto-fixes CI failures. Mergeability polli
 - Polls provider CI status at increasing intervals: every 30s for the first 5 minutes, every 60s for 5-15 minutes, every 120s after that
 - Continues monitoring an open PR until it is merged, closed, declined, or times out, even after CI checks are currently healthy
 - On GitHub and GitLab, polls provider mergeability alongside CI checks while the PR remains open
-- While the PR stays open, the TUI and terminal title show `Checks passed` once checks are green and known mergeability is clear, and clear that signal if checks start running again, new failures appear, or provider state becomes uncertain
+- While the PR stays open, the TUI and terminal title show `Checks passed` once checks are green and known mergeability is clear, and `no-mistakes axi` returns `outcome: checks-passed` so agents can ask the user to review and merge instead of waiting
+- The ready signal clears if checks start running again, new failures appear, provider state becomes uncertain, or the PR is merged, closed, or declined
 - Waits a 60s grace period before trusting empty results (CI checks may not have registered yet)
 - If CI failures or, on GitHub or GitLab, a merge conflict are already known while other checks are still pending: waits for all checks to finish before attempting an auto-fix
 - On CI failure: fetches failed job logs (GitHub via `gh run view --log-failed`, GitLab via `glab ci trace`, Bitbucket Cloud via failed pipeline step logs), sends them to the agent with user intent when available, and commits and force-pushes only if the agent produces changes

--- a/internal/cimonitor/cimonitor.go
+++ b/internal/cimonitor/cimonitor.go
@@ -1,0 +1,94 @@
+// Package cimonitor is the single source of truth for the CI monitor's
+// human-facing log vocabulary and how to read monitoring state back out of it.
+//
+// The CI step (internal/pipeline/steps) emits these exact log lines while it
+// watches an open PR. Two very different consumers read them back: the TUI
+// renders a live CI panel, and the agent-facing `axi` commands decide when to
+// hand control back to the agent. Keeping the strings and the parser here means
+// both consumers interpret a run identically and cannot drift apart.
+package cimonitor
+
+import "strings"
+
+// Log messages the CI monitor emits. These are matched exactly (not by
+// substring) when deriving the "checks passed" state, so the producer and the
+// consumers must reference these constants rather than spelling out literals.
+const (
+	// ChecksPassedMsg is logged when every CI check has passed but the PR is
+	// not yet merged or closed, so the monitor keeps watching.
+	ChecksPassedMsg = "all CI checks passed - still monitoring until merged or closed"
+	// NoChecksPassedMsg is logged when the PR reports no CI checks at all and
+	// the monitor keeps watching for a merge or close.
+	NoChecksPassedMsg = "no CI checks reported - still monitoring until merged or closed"
+	// ChecksRunningMsg is logged when checks are (re-)running with no failures
+	// yet, which clears any previous passed-checks state.
+	ChecksRunningMsg = "CI checks running, waiting for results..."
+)
+
+// Activity summarizes what the CI step has been doing, derived from its logs.
+type Activity struct {
+	CIFixes    int    // number of auto-fix attempts observed
+	AutoFixing bool   // an auto-fix is currently in progress
+	Ready      bool   // checks have passed; the PR is ready for a human to merge
+	LastEvent  string // the most recent recognized log line
+}
+
+// ParseActivity extracts structured activity from CI log messages.
+//
+// Ready reflects the most recent monitoring state: it is true only when the
+// latest relevant log line announced passed checks (or no checks at all), and
+// any newer event clears it.
+func ParseActivity(logs []string) Activity {
+	var a Activity
+	for _, line := range logs {
+		switch {
+		case strings.Contains(line, "running agent to fix CI"):
+			// Emitted once per fix attempt by autoFixCI in real runs (and by
+			// demo mode), so it is the reliable signal for counting fixes.
+			a.CIFixes++
+			a.AutoFixing = true
+			a.Ready = false
+			a.LastEvent = line
+		case strings.Contains(line, "committed and pushed fixes"):
+			a.AutoFixing = false
+			a.Ready = false
+			a.LastEvent = line
+		case strings.Contains(line, "CI failures detected"):
+			a.AutoFixing = true
+			a.Ready = false
+			a.LastEvent = line
+		case line == ChecksPassedMsg || line == NoChecksPassedMsg:
+			a.AutoFixing = false
+			a.Ready = true
+			a.LastEvent = line
+		case strings.Contains(line, "issues detected"),
+			strings.Contains(line, "CI checks running"),
+			strings.Contains(line, "mergeable state still pending"),
+			strings.Contains(line, "warning: could not check CI"),
+			strings.Contains(line, "warning: could not check mergeable state"),
+			strings.Contains(line, "warning: could not check PR state"):
+			a.AutoFixing = false
+			a.Ready = false
+			a.LastEvent = line
+		case strings.Contains(line, "monitoring CI for PR"):
+			a.Ready = false
+			a.LastEvent = line
+		case strings.Contains(line, "PR has been merged"):
+			a.Ready = false
+			a.LastEvent = line
+		case strings.Contains(line, "PR has been closed"):
+			a.Ready = false
+			a.LastEvent = line
+		case strings.Contains(line, "CI timeout"):
+			a.Ready = false
+			a.LastEvent = line
+		}
+	}
+	return a
+}
+
+// ChecksPassed reports whether the CI monitor's latest state is "checks passed,
+// PR ready to merge". It is the agent-facing summary of ParseActivity(logs).Ready.
+func ChecksPassed(logs []string) bool {
+	return ParseActivity(logs).Ready
+}

--- a/internal/cimonitor/cimonitor_test.go
+++ b/internal/cimonitor/cimonitor_test.go
@@ -1,0 +1,106 @@
+package cimonitor
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseActivity_Empty(t *testing.T) {
+	a := ParseActivity(nil)
+	if a.CIFixes != 0 || a.AutoFixing || a.Ready || a.LastEvent != "" {
+		t.Errorf("expected zero activity for empty logs, got %+v", a)
+	}
+}
+
+func TestParseActivity_CountsFixes(t *testing.T) {
+	a := ParseActivity([]string{
+		"issues detected: test - auto-fixing (attempt 1/3)...",
+		"running agent to fix CI issues...",
+		"committed and pushed fixes",
+		"issues detected: lint - auto-fixing (attempt 2/3)...",
+		"running agent to fix CI issues...",
+	})
+	if a.CIFixes != 2 {
+		t.Errorf("expected 2 CI fixes, got %d", a.CIFixes)
+	}
+	if !a.AutoFixing {
+		t.Error("expected auto-fixing true while a fix is in progress")
+	}
+	if a.Ready {
+		t.Error("expected not ready while fixing")
+	}
+}
+
+func TestChecksPassed(t *testing.T) {
+	tests := []struct {
+		name string
+		logs []string
+		want bool
+	}{
+		{
+			name: "all checks passed",
+			logs: []string{
+				"monitoring CI for PR #42 (timeout: 4h)...",
+				ChecksPassedMsg,
+			},
+			want: true,
+		},
+		{
+			name: "no checks reported",
+			logs: []string{NoChecksPassedMsg},
+			want: true,
+		},
+		{
+			name: "still monitoring before checks pass",
+			logs: []string{"monitoring CI for PR #42 (timeout: 4h)..."},
+			want: false,
+		},
+		{
+			name: "cleared when checks re-run",
+			logs: []string{ChecksPassedMsg, ChecksRunningMsg},
+			want: false,
+		},
+		{
+			name: "cleared when a new failure appears",
+			logs: []string{ChecksPassedMsg, "issues detected: test - auto-fixing (attempt 1/3)..."},
+			want: false,
+		},
+		{
+			name: "cleared when mergeability pending",
+			logs: []string{ChecksPassedMsg, "mergeable state still pending: unknown"},
+			want: false,
+		},
+		{
+			name: "cleared when PR merged",
+			logs: []string{ChecksPassedMsg, "PR has been merged!"},
+			want: false,
+		},
+		{
+			name: "ignores unrelated agent output",
+			logs: []string{"CI failures detected: test failed", "agent says this is not ready to merge yet"},
+			want: false,
+		},
+		{
+			name: "empty",
+			logs: nil,
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ChecksPassed(tt.logs); got != tt.want {
+				t.Errorf("ChecksPassed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseActivity_LastEvent(t *testing.T) {
+	a := ParseActivity([]string{
+		"monitoring CI for PR #42 (timeout: 4h)...",
+		"PR has been merged!",
+	})
+	if !strings.Contains(a.LastEvent, "merged") {
+		t.Errorf("expected merged as last event, got %q", a.LastEvent)
+	}
+}

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -4,14 +4,18 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	toon "github.com/toon-format/toon-go"
 
+	"github.com/kunchenguid/no-mistakes/internal/cimonitor"
 	"github.com/kunchenguid/no-mistakes/internal/gate"
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
+	"github.com/kunchenguid/no-mistakes/internal/paths"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 	"github.com/spf13/cobra"
 )
@@ -130,11 +134,11 @@ func runAxiRun(cmd *cobra.Command, autoYes bool, skipSteps []types.StepName, int
 		}
 	}
 
-	run, err := driveRun(ctx, cmd.ErrOrStderr(), env.client, runID, autoYes)
+	run, ciReady, err := driveRun(ctx, cmd.ErrOrStderr(), env.client, runID, autoYes, ciLogReader(env.p))
 	if err != nil {
 		return emitError(cmd, 1, fmt.Sprintf("drive run: %v", err))
 	}
-	return renderDriveResult(cmd, run)
+	return renderDriveResult(cmd, run, ciReady)
 }
 
 // activeRunID returns the ID of a non-terminal run for branch and head, or "" if none.
@@ -257,55 +261,94 @@ func rerunParams(repoID, branch string, skipSteps []types.StepName, intent strin
 	return &ipc.RerunParams{RepoID: repoID, Branch: branch, SkipSteps: skipSteps, Intent: intent}
 }
 
-// driveRun polls a run until it reaches an approval gate or a terminal state,
-// streaming step transitions to progress (stderr). When autoApprove is set it
-// resolves each gate and continues; otherwise it returns at the first gate so
-// the caller can surface it for a human/agent decision.
+// driveRun polls a run until it reaches an approval gate, a terminal state, or
+// CI checks pass, streaming step transitions to progress (stderr). When
+// autoApprove is set it resolves each gate and continues; otherwise it returns
+// at the first gate so the caller can surface it for a human/agent decision.
 //
 // Auto-resolution means "agree to fix every finding": a gate with actionable
 // findings is fixed (every finding selected), and the resulting fix_review is
 // accepted; gates with only non-actionable findings are approved. Each step is
 // fixed at most once so a finding the fix cannot clear converges to an approval
 // instead of looping forever.
-func driveRun(ctx context.Context, progress io.Writer, client *ipc.Client, runID string, autoApprove bool) (*ipc.RunInfo, error) {
+//
+// The CI step monitors an open PR until a human merges or closes it (a live
+// status the TUI shows), so it never reaches a terminal state on its own. An
+// agent driving the run must not block on that human action, so once CI checks
+// pass driveRun returns with ciReady=true: the change is validated and the PR is
+// ready for a human to merge. The daemon keeps monitoring in the background.
+// readCILog reads the CI step's log lines for runID; it may be nil (no early
+// stop) and returns nil when no log exists yet.
+func driveRun(ctx context.Context, progress io.Writer, client *ipc.Client, runID string, autoApprove bool, readCILog func(string) []string) (run *ipc.RunInfo, ciReady bool, err error) {
 	pp := &progressPrinter{w: progress, seen: map[string]string{}}
 	fixedSteps := map[string]bool{}
 	for {
 		if err := ctx.Err(); err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		run, err := getRunInfo(client, runID)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		if run == nil {
-			return nil, fmt.Errorf("run %s not found", runID)
+			return nil, false, fmt.Errorf("run %s not found", runID)
 		}
 		pp.update(run)
 
 		rv := runViewFromIPC(run)
 		if terminalStatus(rv.Status) {
-			return run, nil
+			return run, false, nil
 		}
 		if gate, ok := rv.awaitingStep(); ok {
 			if !autoApprove {
-				return run, nil
+				return run, false, nil
 			}
 			action, findingIDs := gateResolution(gate, fixedSteps[gate.Name])
 			if action == types.ActionFix {
 				fixedSteps[gate.Name] = true
 			}
 			if err := sendRespond(client, runID, types.StepName(gate.Name), action, findingIDs, nil, nil); err != nil {
-				return nil, fmt.Errorf("auto-resolve %s: %w", gate.Name, err)
+				return nil, false, fmt.Errorf("auto-resolve %s: %w", gate.Name, err)
 			}
 			if err := waitStepLeavesGate(ctx, client, runID, gate.Name, gate.Status); err != nil {
-				return nil, err
+				return nil, false, err
 			}
 			continue
 		}
-		if err := sleepCtx(ctx, drivePollInterval); err != nil {
-			return nil, err
+		// CI is green but the PR is unmerged: hand control back rather than
+		// waiting on a human merge. This holds even under autoApprove, since
+		// the agent cannot approve away a human's merge.
+		if readCILog != nil && ciReadyToMerge(rv, readCILog(runID)) {
+			return run, true, nil
 		}
+		if err := sleepCtx(ctx, drivePollInterval); err != nil {
+			return nil, false, err
+		}
+	}
+}
+
+// ciReadyToMerge reports whether the CI step is actively monitoring and its logs
+// show all checks have passed, meaning the PR is ready for a human to merge. It
+// reads CI state through the same parser the TUI uses (see cimonitor) so the two
+// surfaces never disagree about when a run is "done" from the agent's view.
+func ciReadyToMerge(rv runView, ciLogs []string) bool {
+	for _, s := range rv.Steps {
+		if s.Name == string(types.StepCI) {
+			return s.Status == string(types.StepStatusRunning) && cimonitor.ChecksPassed(ciLogs)
+		}
+	}
+	return false
+}
+
+// ciLogReader returns a reader of the CI step's log lines for a run, sourced
+// from the same on-disk log the daemon writes and `axi logs` reads.
+func ciLogReader(p *paths.Paths) func(string) []string {
+	return func(runID string) []string {
+		data, err := os.ReadFile(filepath.Join(p.RunLogDir(runID), string(types.StepCI)+".log"))
+		if err != nil {
+			return nil
+		}
+		return splitLogLines(string(data))
 	}
 }
 
@@ -405,12 +448,27 @@ func sleepCtx(ctx context.Context, d time.Duration) error {
 	}
 }
 
-// renderDriveResult prints the run snapshot plus either the active gate (exit
-// 0, a normal decision point) or the terminal outcome (exit 0 when passed,
-// exit 1 when blocked, failed, or cancelled).
-func renderDriveResult(cmd *cobra.Command, run *ipc.RunInfo) error {
+// renderDriveResult prints the run snapshot plus one of: the active gate (exit
+// 0, a normal decision point), a checks-passed outcome (exit 0, CI is green and
+// the PR is ready for a human to merge), or the terminal outcome (exit 0 when
+// passed, exit 1 when blocked, failed, or cancelled).
+func renderDriveResult(cmd *cobra.Command, run *ipc.RunInfo, ciReady bool) error {
 	rv := runViewFromIPC(run)
 	fields := []toon.Field{runObjectField(rv)}
+
+	// CI passed but the run is intentionally still monitoring for a human
+	// merge. Report it as a distinct, successful outcome so the agent stops
+	// and asks the user to review and merge instead of waiting.
+	if ciReady {
+		fields = append(fields, toon.Field{Key: "outcome", Value: "checks-passed"})
+		merge := "CI checks passed - the PR is ready. Ask the user to review and merge it."
+		if rv.PRURL != "" {
+			merge = fmt.Sprintf("CI checks passed - the PR is ready. Ask the user to review and merge it: %s", rv.PRURL)
+		}
+		fields = append(fields, toon.Field{Key: "help", Value: []string{merge}})
+		emitDoc(cmd, fields...)
+		return nil
+	}
 
 	if gate, ok := rv.awaitingStep(); ok {
 		fields = append(fields, gateFields(gate)...)
@@ -561,11 +619,11 @@ func runAxiRespond(cmd *cobra.Command, ra respondArgs) error {
 		return emitError(cmd, 1, fmt.Sprintf("wait for %s: %v", stepName, err))
 	}
 
-	final, err := driveRun(ctx, cmd.ErrOrStderr(), env.client, runID, ra.autoYes)
+	final, ciReady, err := driveRun(ctx, cmd.ErrOrStderr(), env.client, runID, ra.autoYes, ciLogReader(env.p))
 	if err != nil {
 		return emitError(cmd, 1, fmt.Sprintf("drive run: %v", err))
 	}
-	return renderDriveResult(cmd, final)
+	return renderDriveResult(cmd, final, ciReady)
 }
 
 // gateStatusFor returns the current status of step in rv, defaulting to the

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -62,9 +62,9 @@ func newAxiRunCmd() *cobra.Command {
 		Use:   "run",
 		Short: "Validate your code changes, blocking until a decision point or the outcome",
 		Long: "Triggers a pipeline run for the current branch and drives it. Without\n" +
-			"--yes it blocks until the first approval gate (or the final outcome) and\n" +
+			"--yes it blocks until the first approval gate, CI-ready point, or final outcome and\n" +
 			"prints it. With --yes it auto-resolves every gate (fixing actionable\n" +
-			"findings, then accepting the result) and runs to completion.\n\n" +
+			"findings, then accepting the result) until a decision point or outcome.\n\n" +
 			"--intent is required when starting a new run: pass what the user set out\n" +
 			"to accomplish (the goal behind the change, not a description of the diff)\n" +
 			"so no-mistakes uses it directly instead of inferring it from transcripts.",
@@ -82,7 +82,7 @@ func newAxiRunCmd() *cobra.Command {
 			})
 		},
 	}
-	cmd.Flags().BoolVarP(&autoYes, "yes", "y", false, "auto-resolve every gate (fix findings, then accept) and run to completion")
+	cmd.Flags().BoolVarP(&autoYes, "yes", "y", false, "auto-resolve every gate (fix findings, then accept) until a decision point or outcome")
 	cmd.Flags().StringVar(&skipValue, "skip", "", "comma-separated pipeline steps to skip")
 	cmd.Flags().StringVar(&intent, "intent", "", "what the user set out to accomplish (not a description of the diff); used instead of inferring from transcripts (required to start a run)")
 	return cmd
@@ -499,7 +499,7 @@ func newAxiRespondCmd() *cobra.Command {
 		Use:   "respond",
 		Short: "Answer the current approval gate and continue the run",
 		Long: "Sends approve/fix/skip for the step currently awaiting approval, then\n" +
-			"blocks until the next gate or the final outcome.",
+			"blocks until the next gate, CI-ready decision point, or final outcome.",
 		Args:          cobra.NoArgs,
 		SilenceErrors: true,
 		SilenceUsage:  true,
@@ -521,7 +521,7 @@ func newAxiRespondCmd() *cobra.Command {
 	cmd.Flags().StringVar(&findings, "findings", "", "comma-separated finding IDs to fix (with --action fix)")
 	cmd.Flags().StringVar(&instructions, "instructions", "", "guidance applied to the selected findings (with --action fix)")
 	cmd.Flags().StringVar(&addFinding, "add-finding", "", "JSON finding object to add and fix (with --action fix)")
-	cmd.Flags().BoolVarP(&autoYes, "yes", "y", false, "auto-resolve every subsequent gate to completion")
+	cmd.Flags().BoolVarP(&autoYes, "yes", "y", false, "auto-resolve every subsequent gate until a decision point or outcome")
 	return cmd
 }
 

--- a/internal/cli/axi_drive_test.go
+++ b/internal/cli/axi_drive_test.go
@@ -1,10 +1,75 @@
 package cli
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
+
+	"github.com/kunchenguid/no-mistakes/internal/cimonitor"
+	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
+
+func ciRunView(ciStatus types.StepStatus) runView {
+	return runView{
+		ID:     "run-1",
+		Branch: "feature/x",
+		Status: string(types.RunRunning),
+		Steps: []stepView{
+			{Name: string(types.StepPR), Status: string(types.StepStatusCompleted)},
+			{Name: string(types.StepCI), Status: string(ciStatus)},
+		},
+	}
+}
+
+func TestCIReadyToMerge(t *testing.T) {
+	passedLogs := []string{
+		"monitoring CI for PR #42 (timeout: 4h)...",
+		cimonitor.ChecksPassedMsg,
+	}
+	runningLogs := []string{"monitoring CI for PR #42 (timeout: 4h)..."}
+
+	tests := []struct {
+		name     string
+		rv       runView
+		ciLogs   []string
+		wantStop bool
+	}{
+		{
+			name:     "ci running and checks passed",
+			rv:       ciRunView(types.StepStatusRunning),
+			ciLogs:   passedLogs,
+			wantStop: true,
+		},
+		{
+			name:     "ci running but checks not passed yet",
+			rv:       ciRunView(types.StepStatusRunning),
+			ciLogs:   runningLogs,
+			wantStop: false,
+		},
+		{
+			name:     "checks passed but ci step already completed",
+			rv:       ciRunView(types.StepStatusCompleted),
+			ciLogs:   passedLogs,
+			wantStop: false,
+		},
+		{
+			name:     "no ci step in run",
+			rv:       runView{Status: string(types.RunRunning), Steps: []stepView{{Name: string(types.StepPR), Status: string(types.StepStatusCompleted)}}},
+			ciLogs:   passedLogs,
+			wantStop: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ciReadyToMerge(tt.rv, tt.ciLogs); got != tt.wantStop {
+				t.Errorf("ciReadyToMerge() = %v, want %v", got, tt.wantStop)
+			}
+		})
+	}
+}
 
 func TestGateResolution(t *testing.T) {
 	tests := []struct {
@@ -88,5 +153,59 @@ func TestGateResolution(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestRenderDriveResult_ChecksPassed(t *testing.T) {
+	run := &ipc.RunInfo{
+		ID:      "run-1",
+		Branch:  "feature/x",
+		Status:  types.RunRunning, // not terminal: daemon keeps monitoring until merge
+		HeadSHA: "abcdef1234567890",
+		PRURL:   strptr("https://github.com/user/repo/pull/42"),
+		Steps: []ipc.StepResultInfo{
+			{StepName: types.StepCI, Status: types.StepStatusRunning},
+		},
+	}
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&out)
+
+	if err := renderDriveResult(cmd, run, true); err != nil {
+		t.Fatalf("checks-passed must exit 0, got error: %v", err)
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		"outcome: checks-passed",
+		"https://github.com/user/repo/pull/42",
+		"merge",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("checks-passed output missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "outcome: passed\n") {
+		t.Errorf("checks-passed must not report a terminal passed outcome:\n%s", got)
+	}
+}
+
+func TestRenderDriveResult_TerminalPassedUnaffected(t *testing.T) {
+	run := &ipc.RunInfo{
+		ID:     "run-1",
+		Branch: "feature/x",
+		Status: types.RunCompleted,
+		Steps:  []ipc.StepResultInfo{{StepName: types.StepCI, Status: types.StepStatusCompleted}},
+	}
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&out)
+
+	if err := renderDriveResult(cmd, run, false); err != nil {
+		t.Fatalf("terminal passed must exit 0, got error: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "outcome: passed") {
+		t.Errorf("expected terminal passed outcome, got:\n%s", got)
 	}
 }

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kunchenguid/no-mistakes/internal/cimonitor"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/scm"
 	"github.com/kunchenguid/no-mistakes/internal/types"
@@ -15,11 +16,13 @@ import (
 const defaultChecksGracePeriod = 60 * time.Second
 
 // CI monitoring status messages. These are surfaced to the user and parsed by
-// the TUI to distinguish passed checks from checks that are still running.
+// the TUI and the agent-facing axi commands to distinguish passed checks from
+// checks that are still running. The canonical strings live in cimonitor so all
+// producers and consumers agree on them.
 const (
-	ciChecksPassedMsg   = "all CI checks passed - still monitoring until merged or closed"
-	ciNoChecksPassedMsg = "no CI checks reported - still monitoring until merged or closed"
-	ciChecksRunningMsg  = "CI checks running, waiting for results..."
+	ciChecksPassedMsg   = cimonitor.ChecksPassedMsg
+	ciNoChecksPassedMsg = cimonitor.NoChecksPassedMsg
+	ciChecksRunningMsg  = cimonitor.ChecksRunningMsg
 )
 
 // CIStep monitors an open PR until it is merged or closed, auto-fixing CI failures.

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -87,7 +87,7 @@ Run the pipeline and decide on its findings as they come up:
    # skip this step
    no-mistakes axi respond --action skip
    ` + "```" + `
-   Each ` + "`respond`" + ` blocks until the next ` + "`gate:`" + ` or the final outcome.
+    Each ` + "`respond`" + ` blocks until the next ` + "`gate:`" + `, ` + "`checks-passed`" + ` decision point, or final outcome.
 3. Repeat step 2 until the output has an ` + "`outcome:`" + ` instead of a ` + "`gate:`" + `. The
    outcomes are:
    - ` + "`checks-passed`" + ` - the change is validated and CI is green, but the PR is

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -88,9 +88,19 @@ Run the pipeline and decide on its findings as they come up:
    no-mistakes axi respond --action skip
    ` + "```" + `
    Each ` + "`respond`" + ` blocks until the next ` + "`gate:`" + ` or the final outcome.
-3. Repeat step 2 until the output has an ` + "`outcome:`" + ` instead of a ` + "`gate:`" + `. An
-   ` + "`outcome:`" + ` of ` + "`passed`" + ` means the changes cleared the gate; ` + "`failed`" + ` or
-   ` + "`cancelled`" + ` means they did not - read the output and address it.
+3. Repeat step 2 until the output has an ` + "`outcome:`" + ` instead of a ` + "`gate:`" + `. The
+   outcomes are:
+   - ` + "`checks-passed`" + ` - the change is validated and CI is green, but the PR is
+     not merged yet. **You are done driving the pipeline.** Do not wait for the
+     merge: tell the user the PR is ready and ask them to review and merge it
+     (the PR link is in the ` + "`help`" + ` line). no-mistakes keeps monitoring the PR
+     in the background, so a human can watch it in the TUI.
+   - ` + "`passed`" + ` - the changes cleared the gate and the PR was merged or closed.
+   - ` + "`failed`" + ` or ` + "`cancelled`" + ` - they did not; read the output and address it.
+
+The CI step deliberately watches the PR until it is merged or closed, so
+` + "`axi run`" + ` returns ` + "`checks-passed`" + ` the moment checks are green rather than
+blocking on the human merge. Never poll or re-run waiting for the merge yourself.
 
 If you have clear consent to drive the run automatically, pass ` + "`--yes`" + ` to ` + "`axi run`" + `
 or ` + "`axi respond`" + `. It treats actionable findings as consent to fix them,

--- a/internal/tui/ci.go
+++ b/internal/tui/ci.go
@@ -5,13 +5,9 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/kunchenguid/no-mistakes/internal/cimonitor"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/types"
-)
-
-const (
-	ciChecksPassedLog   = "all CI checks passed - still monitoring until merged or closed"
-	ciNoChecksPassedLog = "no CI checks reported - still monitoring until merged or closed"
 )
 
 // isCIActive returns true if the CI step is currently running.
@@ -56,65 +52,15 @@ func extractPRFromLogs(logs []string) string {
 	return ""
 }
 
-// ciActivity summarizes what the CI step has been doing based on logs.
-type ciActivity struct {
-	CIFixes    int
-	AutoFixing bool
-	Ready      bool
-	LastEvent  string
-}
+// ciActivity summarizes what the CI step has been doing based on logs. It is an
+// alias of cimonitor.Activity so the TUI and the agent-facing axi commands read
+// CI state through the exact same parser.
+type ciActivity = cimonitor.Activity
 
-// parseCIActivity extracts structured activity from CI log messages.
-//
-// Ready reflects the most recent monitoring state: it is true only when the
-// latest relevant log line announced passed checks, and any newer event clears it.
+// parseCIActivity extracts structured activity from CI log messages. It defers
+// to cimonitor so the TUI never drifts from how axi interprets the same logs.
 func parseCIActivity(logs []string) ciActivity {
-	var a ciActivity
-	for _, line := range logs {
-		switch {
-		case strings.Contains(line, "running agent to fix CI"):
-			// Emitted once per fix attempt by autoFixCI in real runs (and by
-			// demo mode), so it is the reliable signal for counting fixes.
-			a.CIFixes++
-			a.AutoFixing = true
-			a.Ready = false
-			a.LastEvent = line
-		case strings.Contains(line, "committed and pushed fixes"):
-			a.AutoFixing = false
-			a.Ready = false
-			a.LastEvent = line
-		case strings.Contains(line, "CI failures detected"):
-			a.AutoFixing = true
-			a.Ready = false
-			a.LastEvent = line
-		case line == ciChecksPassedLog || line == ciNoChecksPassedLog:
-			a.AutoFixing = false
-			a.Ready = true
-			a.LastEvent = line
-		case strings.Contains(line, "issues detected"),
-			strings.Contains(line, "CI checks running"),
-			strings.Contains(line, "mergeable state still pending"),
-			strings.Contains(line, "warning: could not check CI"),
-			strings.Contains(line, "warning: could not check mergeable state"),
-			strings.Contains(line, "warning: could not check PR state"):
-			a.AutoFixing = false
-			a.Ready = false
-			a.LastEvent = line
-		case strings.Contains(line, "monitoring CI for PR"):
-			a.Ready = false
-			a.LastEvent = line
-		case strings.Contains(line, "PR has been merged"):
-			a.Ready = false
-			a.LastEvent = line
-		case strings.Contains(line, "PR has been closed"):
-			a.Ready = false
-			a.LastEvent = line
-		case strings.Contains(line, "CI timeout"):
-			a.Ready = false
-			a.LastEvent = line
-		}
-	}
-	return a
+	return cimonitor.ParseActivity(logs)
 }
 
 // renderCIView renders the CI-specific monitoring view.

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -57,9 +57,19 @@ Run the pipeline and decide on its findings as they come up:
    no-mistakes axi respond --action skip
    ```
    Each `respond` blocks until the next `gate:` or the final outcome.
-3. Repeat step 2 until the output has an `outcome:` instead of a `gate:`. An
-   `outcome:` of `passed` means the changes cleared the gate; `failed` or
-   `cancelled` means they did not - read the output and address it.
+3. Repeat step 2 until the output has an `outcome:` instead of a `gate:`. The
+   outcomes are:
+   - `checks-passed` - the change is validated and CI is green, but the PR is
+     not merged yet. **You are done driving the pipeline.** Do not wait for the
+     merge: tell the user the PR is ready and ask them to review and merge it
+     (the PR link is in the `help` line). no-mistakes keeps monitoring the PR
+     in the background, so a human can watch it in the TUI.
+   - `passed` - the changes cleared the gate and the PR was merged or closed.
+   - `failed` or `cancelled` - they did not; read the output and address it.
+
+The CI step deliberately watches the PR until it is merged or closed, so
+`axi run` returns `checks-passed` the moment checks are green rather than
+blocking on the human merge. Never poll or re-run waiting for the merge yourself.
 
 If you have clear consent to drive the run automatically, pass `--yes` to `axi run`
 or `axi respond`. It treats actionable findings as consent to fix them,

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -56,7 +56,7 @@ Run the pipeline and decide on its findings as they come up:
    # skip this step
    no-mistakes axi respond --action skip
    ```
-   Each `respond` blocks until the next `gate:` or the final outcome.
+    Each `respond` blocks until the next `gate:`, `checks-passed` decision point, or final outcome.
 3. Repeat step 2 until the output has an `outcome:` instead of a `gate:`. The
    outcomes are:
    - `checks-passed` - the change is validated and CI is green, but the PR is


### PR DESCRIPTION
## Intent

The developer wanted to fix a mismatch between the new CI behavior and the generated agent skill: the CI step now intentionally keeps monitoring until a PR is merged, but that causes agent-driven runs to wait forever after checks pass. They wanted a shared CI status signal used by both the TUI and axi commands, so the agent can stop once CI is green while the daemon continues monitoring for humans. The required behavior was for axi run to return a checks-passed outcome with guidance that the PR is ready and the agent should ask the user to review and merge, rather than polling until merge. They also wanted the agent skill updated to document this behavior, with tests and normal project verification kept green.

## What Changed

- Added shared CI monitoring status detection so checks-passed readiness can be surfaced consistently across AXI drive flows and the TUI.
- Updated `axi drive` to return a checks-passed outcome with ready-to-merge guidance instead of continuing to poll until PR merge.
- Documented the checks-passed AXI behavior in the docs and generated agent skill.

## Risk Assessment

✅ Low: The change is well-bounded: it centralizes existing CI log parsing, reuses the same log source as existing axi logs/TUI paths, and adds an agent-only early return without changing daemon CI monitoring behavior.

## Testing

Inspected the changed CI monitor, axi drive, TUI, and skill files; ran focused parser/render tests, captured the actual checks-passed TOON output as reviewer-visible evidence, then ran the full race-enabled Go suite and e2e suite successfully with no transient working-tree artifacts left beyond the requested evidence file.

<details>
<summary>Evidence: checks-passed axi output evidence</summary>

Source: [checks-passed axi output evidence](https://github.com/kunchenguid/no-mistakes/blob/bb52d4ae5ad33f51c75f1ed835bce408aef5c270/.no-mistakes/evidence/fix/axi-ci-checks-passed/checks-passed-output.txt)

```text
run:
id: run-1
branch: feature/x
status: running
head: abcdef12
pr: "https://github.com/user/repo/pull/42"
findings: none
steps[1]{step,status,findings,duration_ms}:
ci,running,0,0
outcome: checks-passed
help[1]: "CI checks passed - the PR is ready. Ask the user to review and merge it: https://github.com/user/repo/pull/42"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `internal/cli/axi_drive.go` - merge conflict rebasing onto origin/main
- ⚠️ `internal/cli/axi_drive_test.go` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --name-status 1c99c4ce97d591fc4e7300c699389973b78b1c4b..7ab81af1d8d50e8da2bd326bd49b994193c59eff`
- `go test ./internal/cimonitor -run 'TestParseActivity|TestChecksPassed' -count=1 -v`
- `go test ./internal/cli -run 'TestCIReadyToMerge|TestRenderDriveResult_ChecksPassed|TestRenderDriveResult_TerminalPassedUnaffected' -count=1 -v`
- <code>`go test ./internal/cli -run &#39;^TestEvidenceChecksPassedOutput$&#39; -count=1 -v` using a temporary test-only harness that was removed afterward</code>
- `go test -race ./...`
- `make e2e`
- <code>`git status --short` to confirm only the requested evidence directory remained changed</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
