### PR TITLE
fix(skill): escalate ask-user findings to users

### DIFF
--- a/.agents/skills/no-mistakes/SKILL.md
+++ b/.agents/skills/no-mistakes/SKILL.md
@@ -44,8 +44,16 @@ Run the pipeline and decide on its findings as they come up:
    no-mistakes axi run --intent "<what the user set out to accomplish>"
    ```
 2. If the output contains a `gate:` object, the pipeline is waiting on you.
-   Read its `findings` table (each has an `id`, `severity`, `file`, `action`,
-   and `description`) and choose one response:
+   Read its `findings` table. Each finding has an `id`, `severity`,
+   `file`, `description`, and an `action` that tells you how the
+   pipeline classified it:
+   - `auto-fix` - a mechanical, low-risk fix you can safely make yourself.
+   - `no-op` - informational only; nothing to do.
+   - `ask-user` - the finding challenges the user's deliberate intent or
+     touches product behavior. This is a call only the user can make - see
+     [Escalate `ask-user` findings](#escalate-ask-user-findings) below.
+
+   Choose one response:
    ```sh
    # accept the step as-is and continue
    no-mistakes axi respond --action approve
@@ -71,10 +79,32 @@ The CI step deliberately watches the PR until it is merged or closed, so
 `axi run` returns `checks-passed` the moment checks are green rather than
 blocking on the human merge. Never poll or re-run waiting for the merge yourself.
 
+## Escalate `ask-user` findings
+
+A gate whose findings are all `auto-fix` or `no-op` is safe to drive on your
+own judgment: fix or approve as appropriate. But a finding marked
+`ask-user` is a decision that belongs to the user, not you - the pipeline
+flagged it because it challenges their deliberate intent or changes product
+behavior. Do not approve, fix, or skip it on your own. Instead, stop and bring
+it to the user before you respond:
+
+- Relay each `ask-user` finding to them as the pipeline wrote it - its
+  `id`, `file`, and full `description` verbatim. Do not paraphrase,
+  summarize away the detail, or pre-judge the answer.
+- Ask how they want to proceed, then translate their decision into the matching
+  `respond` call: `--action fix` (pass their guidance through
+  `--instructions`), `--action approve`, or `--action skip`.
+
+The one exception is `--yes` (below): it is the user's standing consent to
+drive every gate unattended, so under `--yes` you resolve `ask-user`
+findings automatically instead of stopping to ask.
+
 If you have clear consent to drive the run automatically, pass `--yes` to `axi run`
-or `axi respond`. It treats actionable findings as consent to fix them,
-selects every current finding for one fix round, accepts the resulting fix review,
-and approves gates with only `no-op` findings.
+or `axi respond`. It treats every actionable finding - `auto-fix` and
+`ask-user` alike - as consent to fix it, selects every current finding for one
+fix round, accepts the resulting fix review, and approves gates with only
+`no-op` findings. Only use it when the user has asked you to drive the whole
+run without checking back.
 
 ## Inspecting state
 

--- a/.no-mistakes/evidence/skill-escalate-ask-user/ask-user-skill-excerpt.md
+++ b/.no-mistakes/evidence/skill-escalate-ask-user/ask-user-skill-excerpt.md
@@ -1,0 +1,23 @@
+# Ask-user Skill Escalation Evidence
+
+Source surface: `skills/no-mistakes/SKILL.md`.
+
+This excerpt is the generated agent skill text an end user-facing driving agent reads when a gate contains `ask-user` findings.
+
+```markdown
+## Escalate `ask-user` findings
+
+A gate whose findings are all `auto-fix` or `no-op` is safe to drive on your
+own judgment: fix or approve as appropriate. But a finding marked
+`ask-user` is a decision that belongs to the user, not you - the pipeline
+flagged it because it challenges their deliberate intent or changes product
+behavior. Do not approve, fix, or skip it on your own. Instead, stop and bring
+it to the user before you respond:
+
+- Relay each `ask-user` finding to them as the pipeline wrote it - its
+  `id`, `file`, and full `description` verbatim. Do not paraphrase,
+  summarize away the detail, or pre-judge the answer.
+- Ask how they want to proceed, then translate their decision into the matching
+  `respond` call: `--action fix` (pass their guidance through
+  `--instructions`), `--action approve`, or `--action skip`.
+```

--- a/docs/src/content/docs/concepts/auto-fix.md
+++ b/docs/src/content/docs/concepts/auto-fix.md
@@ -64,11 +64,11 @@ Repo config overlays global config - you can set `auto_fix.lint: 5` in a repo's 
 Agent-driven findings now use an `action` field instead of `requires_human_review`:
 
 - `auto-fix` - objective issues that can be fixed automatically
-- `ask-user` - intent-sensitive or ambiguous issues that pause for approval and are never auto-fixed
+- `ask-user` - intent-sensitive or ambiguous issues that pause for approval instead of entering the normal auto-fix loop
 - `no-op` - informational notes that do not need a fix
 
-`ask-user` is meant for findings that need human judgment - for example, questioning an intentional product or design choice, arguing that an intentional addition, removal, or guard should be undone, or reporting that the test step could not produce enough evidence for the available intent. Routine correctness, reliability, or security fixes still stay `auto-fix` even if the smallest fix reintroduces a small amount of previously deleted logic.
-In the TUI, yolo mode is an explicit override that auto-resolves paused steps by treating actionable findings, including `ask-user` findings, as consent to run one fix round.
+`ask-user` is meant for findings that need human judgment - for example, questioning an intentional product or design choice, arguing that an intentional addition, removal, or guard should be undone, or reporting that the test step could not produce enough evidence for the available intent. Routine correctness, reliability, or security fixes still stay `auto-fix` even if the smallest fix reintroduces a small amount of previously deleted logic. Agents driving the AXI skill should relay `ask-user` findings to the user unless they have explicit `--yes` consent to resolve gates unattended.
+In the TUI, yolo mode is an explicit override that auto-resolves paused steps by treating `auto-fix` and `ask-user` findings as consent to run one fix round.
 Steps with only `no-op` findings are approved as-is.
 
 The `review`, `test`, and configured-command `lint` steps use this shared model directly. The `document` step also uses the same `action` field, but unresolved documentation findings pause for approval because the initial document pass already attempted the documentation updates it could make safely.

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -103,6 +103,8 @@ no-mistakes axi abort
 When an agent starts a new run, `--intent` is required and should describe what the user wanted to accomplish, not what files changed.
 If the repo is on the default branch or has uncommitted changes, `axi run` returns a structured error with the command the agent should run instead of silently creating a branch or commit.
 Approval gates are exposed as `gate:` objects with finding IDs, severities, files, actions, descriptions, and help commands for `no-mistakes axi respond`.
+An agent should resolve `action: auto-fix` findings on its own judgment, ignore `action: no-op` findings when approving, and stop on `action: ask-user` findings unless it is running with explicit `--yes` consent.
+When it stops for `ask-user`, it should relay each finding's ID, file, and full description to the user before choosing `approve`, `fix`, or `skip`.
 Successful outputs can be `outcome: passed` for a completed run or `outcome: checks-passed` when CI has passed and the daemon is still monitoring the unmerged PR for humans.
 
 ## Binary resolution

--- a/docs/src/content/docs/guides/tui.md
+++ b/docs/src/content/docs/guides/tui.md
@@ -198,7 +198,7 @@ The `f fix (3/5)` label shows how many findings are selected out of the total.
 Press `e` to add or edit extra guidance for the current finding. Press `+` to add your own finding to the list. User-authored findings start selected by default and can be removed with `D`.
 
 Press `y` to toggle yolo mode when you want paused approval gates to resolve automatically.
-Yolo fixes gates with actionable findings by selecting every finding, then approves the resulting fix-review gate.
+Yolo fixes gates with `auto-fix` and `ask-user` findings by selecting every finding, then approves the resulting fix-review gate.
 It approves gates with no findings or only `action: no-op` findings as-is, and fixes each step at most once so unresolved findings do not loop forever.
 
 ## Outcome banner

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -68,8 +68,9 @@ no-mistakes axi run --intent "the user's goal" --yes
 It is the user's goal or request, and no-mistakes uses it verbatim instead of transcript inference.
 When starting a new run, `axi run` refuses the default branch and uncommitted working trees with actionable errors instead of auto-branching or auto-committing.
 Reattaching to an in-flight run does not require `--intent`.
-With `--yes`, `axi run` fixes gates that have actionable findings by selecting every finding, then accepts the resulting fix review.
+With `--yes`, `axi run` treats both `action: auto-fix` and `action: ask-user` findings as standing consent to fix them by selecting every finding, then accepts the resulting fix review.
 Gates with no findings or only `action: no-op` findings are approved as-is, and each step is fixed at most once so unresolved findings do not loop forever.
+Without `--yes`, an agent driving `axi run` should stop when a gate contains `action: ask-user` findings and relay each finding's ID, file, and full description to the user before responding.
 When the CI step is still monitoring an open PR and checks are green, `axi run` exits successfully with `outcome: checks-passed` instead of waiting for a human merge.
 Treat that as the agent stopping point: ask the user to review and merge the PR from the `help` line.
 
@@ -93,7 +94,7 @@ no-mistakes axi respond --action skip
 | `--add-finding` | `string` | (none) | JSON finding object to add and fix |
 | `-y`, `--yes` | `bool` | `false` | Auto-resolve every subsequent gate until a decision point or outcome |
 
-After the explicit response, `--yes` uses the same auto-resolution behavior as `axi run --yes`: fix actionable findings once, approve the fix review, approve gates that only contain non-actionable `no-op` findings, and stop at `outcome: checks-passed` when CI is green but the PR still needs a human merge.
+After the explicit response, `--yes` uses the same auto-resolution behavior as `axi run --yes`: fix `auto-fix` and `ask-user` findings once, approve the fix review, approve gates that only contain non-actionable `no-op` findings, and stop at `outcome: checks-passed` when CI is green but the PR still needs a human merge.
 
 ## no-mistakes axi status
 

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -10,7 +10,7 @@ intent → rebase → review → test → document → lint → push → pr → 
 ```
 
 Each step can produce findings, request approval, trigger auto-fix, or apply safe fixes during its own pass. Steps that encounter fatal errors stop the pipeline. Steps can also be pre-skipped when starting a run, skipped by the user, or skipped automatically by the pipeline.
-In the TUI, yolo mode is an explicit override that auto-resolves paused steps: actionable findings are fixed once with every finding selected, fix-review gates are approved, and gates with only `no-op` findings are approved as-is.
+In the TUI, yolo mode is an explicit override that auto-resolves paused steps: `auto-fix` and `ask-user` findings are fixed once with every finding selected, fix-review gates are approved, and gates with only `no-op` findings are approved as-is.
 Every pipeline agent invocation is prompt-steered to keep intentional writes inside the run worktree and avoid mutating system state outside it.
 This is a soft boundary, not OS-level sandbox enforcement.
 The steering still allows requested test evidence under the managed temporary `no-mistakes-evidence` directory or the configured in-repo evidence directory, plus incidental temp or cache writes from normal development tools.
@@ -62,7 +62,7 @@ AI code review of your diff.
 - Agent returns findings with severity (`error`, `warning`, `info`), file location, description, and an `action` (`no-op`, `auto-fix`, `ask-user`)
 - Also returns a `risk_level` (`low`, `medium`, `high`) and `risk_rationale`
 
-**Approval:** required if any finding has severity `error` or `warning`. Findings with `action: ask-user` pause for approval and are never auto-fixed. This is for findings that challenge the author's intent, not routine correctness, reliability, or security fixes that may need to re-add a small amount of deleted logic. Findings with `action: auto-fix` remain eligible for the fix loop. Findings with `action: no-op` are informational only.
+**Approval:** required if any finding has severity `error` or `warning`. Findings with `action: ask-user` pause for approval instead of entering the normal auto-fix loop. This is for findings that challenge the author's intent, not routine correctness, reliability, or security fixes that may need to re-add a small amount of deleted logic. Findings with `action: auto-fix` remain eligible for the fix loop. Findings with `action: no-op` are informational only.
 
 **Auto-fix:** the agent receives the selected previous findings plus any per-finding user notes, any selected user-authored findings from the TUI or AXI interface, and a sanitized history of prior rounds for that step, including earlier fix summaries and which findings the user left unselected. Follow-up review passes use that history to avoid re-reporting user-ignored findings unless the code now has a materially different problem. Fix commits use `no-mistakes(review): <summary>`.
 

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -75,8 +75,16 @@ Run the pipeline and decide on its findings as they come up:
    no-mistakes axi run --intent "<what the user set out to accomplish>"
    ` + "```" + `
 2. If the output contains a ` + "`gate:`" + ` object, the pipeline is waiting on you.
-   Read its ` + "`findings`" + ` table (each has an ` + "`id`" + `, ` + "`severity`" + `, ` + "`file`" + `, ` + "`action`" + `,
-   and ` + "`description`" + `) and choose one response:
+   Read its ` + "`findings`" + ` table. Each finding has an ` + "`id`" + `, ` + "`severity`" + `,
+   ` + "`file`" + `, ` + "`description`" + `, and an ` + "`action`" + ` that tells you how the
+   pipeline classified it:
+   - ` + "`auto-fix`" + ` - a mechanical, low-risk fix you can safely make yourself.
+   - ` + "`no-op`" + ` - informational only; nothing to do.
+   - ` + "`ask-user`" + ` - the finding challenges the user's deliberate intent or
+     touches product behavior. This is a call only the user can make - see
+     [Escalate ` + "`ask-user`" + ` findings](#escalate-ask-user-findings) below.
+
+   Choose one response:
    ` + "```sh" + `
    # accept the step as-is and continue
    no-mistakes axi respond --action approve
@@ -102,10 +110,32 @@ The CI step deliberately watches the PR until it is merged or closed, so
 ` + "`axi run`" + ` returns ` + "`checks-passed`" + ` the moment checks are green rather than
 blocking on the human merge. Never poll or re-run waiting for the merge yourself.
 
+## Escalate ` + "`ask-user`" + ` findings
+
+A gate whose findings are all ` + "`auto-fix`" + ` or ` + "`no-op`" + ` is safe to drive on your
+own judgment: fix or approve as appropriate. But a finding marked
+` + "`ask-user`" + ` is a decision that belongs to the user, not you - the pipeline
+flagged it because it challenges their deliberate intent or changes product
+behavior. Do not approve, fix, or skip it on your own. Instead, stop and bring
+it to the user before you respond:
+
+- Relay each ` + "`ask-user`" + ` finding to them as the pipeline wrote it - its
+  ` + "`id`" + `, ` + "`file`" + `, and full ` + "`description`" + ` verbatim. Do not paraphrase,
+  summarize away the detail, or pre-judge the answer.
+- Ask how they want to proceed, then translate their decision into the matching
+  ` + "`respond`" + ` call: ` + "`--action fix`" + ` (pass their guidance through
+  ` + "`--instructions`" + `), ` + "`--action approve`" + `, or ` + "`--action skip`" + `.
+
+The one exception is ` + "`--yes`" + ` (below): it is the user's standing consent to
+drive every gate unattended, so under ` + "`--yes`" + ` you resolve ` + "`ask-user`" + `
+findings automatically instead of stopping to ask.
+
 If you have clear consent to drive the run automatically, pass ` + "`--yes`" + ` to ` + "`axi run`" + `
-or ` + "`axi respond`" + `. It treats actionable findings as consent to fix them,
-selects every current finding for one fix round, accepts the resulting fix review,
-and approves gates with only ` + "`no-op`" + ` findings.
+or ` + "`axi respond`" + `. It treats every actionable finding - ` + "`auto-fix`" + ` and
+` + "`ask-user`" + ` alike - as consent to fix it, selects every current finding for one
+fix round, accepts the resulting fix review, and approves gates with only
+` + "`no-op`" + ` findings. Only use it when the user has asked you to drive the whole
+run without checking back.
 
 ## Inspecting state
 

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -44,8 +44,16 @@ Run the pipeline and decide on its findings as they come up:
    no-mistakes axi run --intent "<what the user set out to accomplish>"
    ```
 2. If the output contains a `gate:` object, the pipeline is waiting on you.
-   Read its `findings` table (each has an `id`, `severity`, `file`, `action`,
-   and `description`) and choose one response:
+   Read its `findings` table. Each finding has an `id`, `severity`,
+   `file`, `description`, and an `action` that tells you how the
+   pipeline classified it:
+   - `auto-fix` - a mechanical, low-risk fix you can safely make yourself.
+   - `no-op` - informational only; nothing to do.
+   - `ask-user` - the finding challenges the user's deliberate intent or
+     touches product behavior. This is a call only the user can make - see
+     [Escalate `ask-user` findings](#escalate-ask-user-findings) below.
+
+   Choose one response:
    ```sh
    # accept the step as-is and continue
    no-mistakes axi respond --action approve
@@ -71,10 +79,32 @@ The CI step deliberately watches the PR until it is merged or closed, so
 `axi run` returns `checks-passed` the moment checks are green rather than
 blocking on the human merge. Never poll or re-run waiting for the merge yourself.
 
+## Escalate `ask-user` findings
+
+A gate whose findings are all `auto-fix` or `no-op` is safe to drive on your
+own judgment: fix or approve as appropriate. But a finding marked
+`ask-user` is a decision that belongs to the user, not you - the pipeline
+flagged it because it challenges their deliberate intent or changes product
+behavior. Do not approve, fix, or skip it on your own. Instead, stop and bring
+it to the user before you respond:
+
+- Relay each `ask-user` finding to them as the pipeline wrote it - its
+  `id`, `file`, and full `description` verbatim. Do not paraphrase,
+  summarize away the detail, or pre-judge the answer.
+- Ask how they want to proceed, then translate their decision into the matching
+  `respond` call: `--action fix` (pass their guidance through
+  `--instructions`), `--action approve`, or `--action skip`.
+
+The one exception is `--yes` (below): it is the user's standing consent to
+drive every gate unattended, so under `--yes` you resolve `ask-user`
+findings automatically instead of stopping to ask.
+
 If you have clear consent to drive the run automatically, pass `--yes` to `axi run`
-or `axi respond`. It treats actionable findings as consent to fix them,
-selects every current finding for one fix round, accepts the resulting fix review,
-and approves gates with only `no-op` findings.
+or `axi respond`. It treats every actionable finding - `auto-fix` and
+`ask-user` alike - as consent to fix it, selects every current finding for one
+fix round, accepts the resulting fix review, and approves gates with only
+`no-op` findings. Only use it when the user has asked you to drive the whole
+run without checking back.
 
 ## Inspecting state
 


### PR DESCRIPTION
## Intent

Let the agent skill escalate ambiguous decisions to the user: when a no-mistakes gate has an ask-user finding, the driving agent should stop and relay it to the user verbatim instead of deciding itself, and relay each ask-user finding's id/file/description verbatim.

## What Changed

- Updated the no-mistakes agent skill and generated skill source so agents stop on `ask-user` gate findings, relay each finding's `id`, `file`, and full `description` verbatim, and only proceed after user direction.
- Clarified that `--yes` is the explicit unattended override that treats both `auto-fix` and `ask-user` findings as consent to run one fix round.
- Synced the docs for AXI, TUI yolo mode, auto-fix behavior, and pipeline step references with the new `ask-user` escalation guidance.

## Risk Assessment

✅ Low: The change is limited to generated skill documentation and clearly matches the intended ask-user escalation behavior without altering runtime code.

## Testing

I inspected the skill generator and generated skill diff, verified the committed skill is fresh, ran targeted unit tests for skill generation/installation guidance, ran the e2e init path that installs the skill into user-facing agent directories, and captured a reviewer-visible excerpt showing the ask-user id/file/description verbatim escalation guidance; all checks passed and only the intentional evidence file remains.

<details>
<summary>Evidence: Ask-user skill escalation excerpt</summary>

Source: [Ask-user skill escalation excerpt](https://github.com/kunchenguid/no-mistakes/blob/9b0d012aa64285705fdc905b15a6bd46fe0b2bcc/.no-mistakes/evidence/skill-escalate-ask-user/ask-user-skill-excerpt.md)

```text
Generated skill excerpt demonstrates that ask-user findings must be stopped on, relayed with id/file/full description verbatim, and resolved only after the user decides.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff 220229c6757a864b08149bba77eb486a4003d2cf...2d357c48804053577f34db2eaf849032c0147865 -- internal/skill/skill.go`
- `git diff 220229c6757a864b08149bba77eb486a4003d2cf...2d357c48804053577f34db2eaf849032c0147865 -- skills/no-mistakes/SKILL.md`
- `go run ./cmd/genskill --check`
- `go test ./internal/skill ./internal/cli -run 'TestMarkdownFrontmatter|TestInstallWritesBothPaths|TestInstallIsIdempotent|TestSkillExitCodeGuidanceDistinguishesDecisionGates'`
- `go test -tags=e2e -count=1 -timeout 300s ./internal/e2e -run '^TestInitIsIdempotent$'`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
