### PR TITLE
fix(skill): improve intent guidance completeness

### DIFF
--- a/.agents/skills/no-mistakes/SKILL.md
+++ b/.agents/skills/no-mistakes/SKILL.md
@@ -33,7 +33,16 @@ accomplish** - the goal or request behind this work, in their terms. This is not
 a description of the diff or the files you changed; it is the objective the
 change is meant to achieve. You know it from the conversation, so pass it
 directly - no-mistakes uses it verbatim instead of inferring it from local agent
-transcripts (slower and flakier). One or two sentences.
+transcripts (slower and flakier).
+
+Err on the side of completeness, not brevity. The review step uses `--intent`
+to tell a deliberate decision apart from a mistake, so a thin one-line summary
+makes it flag things the user already chose. Capture the nuance: the user's
+goal, the specific decisions and tradeoffs they made along the way, any
+constraints or approaches they ruled in or out, and anything they explicitly
+asked for that might otherwise look surprising in the diff. A few sentences to a
+short paragraph is normal - write down what you learned from the conversation
+that a reviewer reading only the diff would not know.
 
 ## Validate and decide
 

--- a/.no-mistakes/evidence/skill-intent-completeness/skill-intent-guidance.md
+++ b/.no-mistakes/evidence/skill-intent-completeness/skill-intent-guidance.md
@@ -1,0 +1,41 @@
+# Skill Intent Guidance Evidence
+
+This artifact captures the reviewer-visible guidance now present in the generated `no-mistakes` skill.
+
+Source of truth checked: `internal/skill/skill.go`.
+Generated skill checked: `skills/no-mistakes/SKILL.md`.
+Dogfooded install copy checked: `.agents/skills/no-mistakes/SKILL.md`.
+
+## Rendered Skill Excerpt
+
+```md
+## Intent is required
+
+When you start a run you must pass `--intent`: **what the user set out to
+accomplish** - the goal or request behind this work, in their terms. This is not
+a description of the diff or the files you changed; it is the objective the
+change is meant to achieve. You know it from the conversation, so pass it
+directly - no-mistakes uses it verbatim instead of inferring it from local agent
+transcripts (slower and flakier).
+
+Err on the side of completeness, not brevity. The review step uses `--intent`
+to tell a deliberate decision apart from a mistake, so a thin one-line summary
+makes it flag things the user already chose. Capture the nuance: the user's
+goal, the specific decisions and tradeoffs they made along the way, any
+constraints or approaches they ruled in or out, and anything they explicitly
+asked for that might otherwise look surprising in the diff. A few sentences to a
+short paragraph is normal - write down what you learned from the conversation
+that a reviewer reading only the diff would not know.
+```
+
+## Verification Commands
+
+```sh
+go test ./internal/skill -run 'TestMarkdownFrontmatter|TestInstallWritesBothPaths|TestInstallIsIdempotent' -v
+go run ./cmd/genskill --check
+```
+
+## Verification Result
+
+The targeted skill tests passed, including installation of the generated `SKILL.md` into both supported agent skill paths.
+The generator check reported `skills/no-mistakes/SKILL.md` is up to date, demonstrating that the committed generated skill matches `internal/skill/skill.go`.

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -101,6 +101,7 @@ no-mistakes axi abort
 ```
 
 When an agent starts a new run, `--intent` is required and should describe what the user wanted to accomplish, not what files changed.
+Agents should prefer a few complete sentences over a terse summary, capturing user decisions, tradeoffs, constraints, ruled-out approaches, and explicit requests that would not be obvious from the diff alone.
 If the repo is on the default branch or has uncommitted changes, `axi run` returns a structured error with the command the agent should run instead of silently creating a branch or commit.
 Approval gates are exposed as `gate:` objects with finding IDs, severities, files, actions, descriptions, and help commands for `no-mistakes axi respond`.
 An agent should resolve `action: auto-fix` findings on its own judgment, ignore `action: no-op` findings when approving, and stop on `action: ask-user` findings unless it is running with explicit `--yes` consent.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -66,6 +66,7 @@ no-mistakes axi run --intent "the user's goal" --yes
 
 `--intent` is not a description of the diff.
 It is the user's goal or request, and no-mistakes uses it verbatim instead of transcript inference.
+Err on the side of completeness: include the goal, important decisions and tradeoffs, constraints or approaches ruled in or out, and explicit requests that might otherwise look surprising in the diff.
 When starting a new run, `axi run` refuses the default branch and uncommitted working trees with actionable errors instead of auto-branching or auto-committing.
 Reattaching to an in-flight run does not require `--intent`.
 With `--yes`, `axi run` treats both `action: auto-fix` and `action: ask-user` findings as standing consent to fix them by selecting every finding, then accepts the resulting fix review.

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -64,7 +64,16 @@ accomplish** - the goal or request behind this work, in their terms. This is not
 a description of the diff or the files you changed; it is the objective the
 change is meant to achieve. You know it from the conversation, so pass it
 directly - no-mistakes uses it verbatim instead of inferring it from local agent
-transcripts (slower and flakier). One or two sentences.
+transcripts (slower and flakier).
+
+Err on the side of completeness, not brevity. The review step uses ` + "`--intent`" + `
+to tell a deliberate decision apart from a mistake, so a thin one-line summary
+makes it flag things the user already chose. Capture the nuance: the user's
+goal, the specific decisions and tradeoffs they made along the way, any
+constraints or approaches they ruled in or out, and anything they explicitly
+asked for that might otherwise look surprising in the diff. A few sentences to a
+short paragraph is normal - write down what you learned from the conversation
+that a reviewer reading only the diff would not know.
 
 ## Validate and decide
 

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -33,7 +33,16 @@ accomplish** - the goal or request behind this work, in their terms. This is not
 a description of the diff or the files you changed; it is the objective the
 change is meant to achieve. You know it from the conversation, so pass it
 directly - no-mistakes uses it verbatim instead of inferring it from local agent
-transcripts (slower and flakier). One or two sentences.
+transcripts (slower and flakier).
+
+Err on the side of completeness, not brevity. The review step uses `--intent`
+to tell a deliberate decision apart from a mistake, so a thin one-line summary
+makes it flag things the user already chose. Capture the nuance: the user's
+goal, the specific decisions and tradeoffs they made along the way, any
+constraints or approaches they ruled in or out, and anything they explicitly
+asked for that might otherwise look surprising in the diff. A few sentences to a
+short paragraph is normal - write down what you learned from the conversation
+that a reviewer reading only the diff would not know.
 
 ## Validate and decide
 


### PR DESCRIPTION
## Intent

Make the no-mistakes skill's guidance on the --intent flag favor completeness over brevity. The user's observation: the review step uses --intent to tell a deliberate user decision apart from a mistake, and the prior wording ('one or two sentences', 'a bit more comprehensive... concise summary') produced thin summaries that made the gate flag choices the user had already deliberately made.

Decision made: rewrite the 'Intent is required' section to explicitly ask the agent to err on the side of completeness, not brevity, and to capture nuance - the user's goal, the specific decisions and tradeoffs made along the way, constraints or approaches ruled in or out, and anything explicitly requested that would look surprising in the diff. Target length changed from 'one or two sentences' to 'a few sentences to a short paragraph'.

Key constraint discovered during the work: internal/skill/skill.go is the single source of truth (a Go string), NOT the markdown files. The committed skills/no-mistakes/SKILL.md is generated from it via 'make skill' (cmd/genskill), so my first edit to the markdown was overwritten by the generator and I had to move the change into skill.go instead. The .agents/skills/no-mistakes/SKILL.md copy is the dogfooded install of the skill in this repo; it is git-tracked, not regenerated by 'make skill', and was identical to the canonical copy before my change, so I synced it by hand to keep the three files consistent. Verified with 'make lint' (genskill --check passes, go vet clean) and 'go test ./internal/skill/'. This is a docs/guidance-only change with no behavioral code change.

## What Changed

- Updated the no-mistakes skill's `--intent` guidance to favor complete, nuanced summaries over terse one- or two-sentence descriptions.
- Added documentation explaining how intent helps the review gate distinguish deliberate choices from mistakes.
- Kept the canonical skill source, generated skill markdown, and dogfooded installed skill copy in sync.

## Risk Assessment

✅ Low: The branch only updates generated and dogfooded skill guidance text plus the canonical Go string, with no runtime behavior changes or material code risks found.

## Testing

I inspected the target diff, ran the targeted skill package tests that exercise generated markdown and installation into both agent skill paths, verified the committed generated skill matches `internal/skill/skill.go`, confirmed the dogfooded `.agents` copy is identical to the canonical generated skill, and recorded reviewer-visible markdown evidence showing the new completeness-focused --intent guidance.

- Evidence: [Rendered skill intent guidance evidence](https://github.com/kunchenguid/no-mistakes/blob/f1a29f273ba06674a218bf1a5b25dd5829ec5113/.no-mistakes/evidence/skill-intent-completeness/skill-intent-guidance.md)
<details>
<summary>Evidence: Generator freshness check</summary>

```text
genskill: skills/no-mistakes/SKILL.md is up to date
```
</details>
<details>
<summary>Evidence: Targeted skill tests</summary>

```text
=== RUN TestMarkdownFrontmatter
--- PASS: TestMarkdownFrontmatter (0.00s)
=== RUN TestInstallWritesBothPaths
--- PASS: TestInstallWritesBothPaths (0.00s)
=== RUN TestInstallIsIdempotent
--- PASS: TestInstallIsIdempotent (0.00s)
PASS
ok github.com/kunchenguid/no-mistakes/internal/skill 0.478s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --unified=80 c015392d7d0e4c59ca6f887c9547186105684da3..a2a2e3fedf5cec4db055ab2ecf408c81a1de8441`
- `go test ./internal/skill -run 'TestMarkdownFrontmatter|TestInstallWritesBothPaths|TestInstallIsIdempotent' -v`
- `go run ./cmd/genskill --check`
- `cmp -s "skills/no-mistakes/SKILL.md" ".agents/skills/no-mistakes/SKILL.md"`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
