### PR TITLE
fix(skill): install skills through symlinked bases

### DIFF
--- a/.no-mistakes/evidence/fix/skill-install-symlinks/skill-install-symlink-installer-transcript.txt
+++ b/.no-mistakes/evidence/fix/skill-install-symlinks/skill-install-symlink-installer-transcript.txt
@@ -1,0 +1,29 @@
+Skill installer symlink verification
+$ NM_PROBE_WORKSPACE="$PWD" go run ./.nm-skill-e2e/probe.go
+## claude-skills-dangling
+written: .claude/skills/no-mistakes/SKILL.md, .agents/skills/no-mistakes/SKILL.md
+.claude/skills reachable: yes
+.claude/skills stale body present: false
+.claude/skills current content: true
+.agents/skills reachable: yes
+.agents/skills stale body present: false
+.agents/skills current content: true
+
+## agents-dir-reverse
+written: .claude/skills/no-mistakes/SKILL.md, .agents/skills/no-mistakes/SKILL.md
+.claude/skills reachable: yes
+.claude/skills stale body present: false
+.claude/skills current content: true
+.agents/skills reachable: yes
+.agents/skills stale body present: false
+.agents/skills current content: true
+
+## stale-upgrade
+written: .claude/skills/no-mistakes/SKILL.md, .agents/skills/no-mistakes/SKILL.md
+.claude/skills reachable: yes
+.claude/skills stale body present: false
+.claude/skills current content: true
+.agents/skills reachable: yes
+.agents/skills stale body present: false
+.agents/skills current content: true
+

--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -34,7 +34,7 @@ When you run `no-mistakes init` in a repo:
 3. It enables Git push options for the gate repo.
 4. It best-effort isolates the gate repo's hooks path from shared local Git config writes when Git supports `config --worktree`.
 5. It adds a `no-mistakes` remote to your working repo that points at the gate.
-6. It installs the `/no-mistakes` agent skill into `.claude/skills/no-mistakes/SKILL.md` and `.agents/skills/no-mistakes/SKILL.md` on a best-effort basis.
+6. It installs or refreshes the `/no-mistakes` agent skill into `.claude/skills/no-mistakes/SKILL.md` and `.agents/skills/no-mistakes/SKILL.md` on a best-effort basis, following existing symlinks between the `.claude` and `.agents` skill directories.
 7. It makes sure the daemon is running so incoming pushes can start runs.
 
 `init` is idempotent.

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -85,7 +85,8 @@ It does **not** change the pipeline order or the meaning of a passed gate.
 ## Driving no-mistakes as an agent
 
 `no-mistakes init` installs a `/no-mistakes` skill into `.claude/skills/no-mistakes/SKILL.md` and `.agents/skills/no-mistakes/SKILL.md`.
-Re-run `no-mistakes init` in an already-initialized repo to refresh or reinstall that skill after an upgrade.
+Repos that symlink `.claude` to `.agents`, `.claude/skills` to `.agents/skills`, or the reverse, keep that layout; `init` follows the symlink and makes the skill reachable from both logical paths.
+Re-run `no-mistakes init` in an already-initialized repo to refresh or reinstall that skill after an upgrade, including overwriting stale `SKILL.md` content from an older binary.
 The skill tells agents to use `no-mistakes axi`, a non-interactive command surface that prints TOON to stdout and progress to stderr.
 When CI is green but the PR is still open, `axi run` and `axi respond` return `outcome: checks-passed` with a help line pointing at the PR instead of waiting for a human merge.
 That is a successful agent stopping point: report that the PR is ready and ask the user to review and merge it.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -30,10 +30,11 @@ no-mistakes init
 ```
 
 Creates or refreshes a local bare repo, installs the post-receive hook, best-effort isolates the gate repo's hook path from shared git config changes when Git supports `config --worktree`, adds or repairs the `no-mistakes` git remote, detects the default branch, records or updates the repo in SQLite, installs the `/no-mistakes` agent skill into `.claude/skills/no-mistakes/SKILL.md` and `.agents/skills/no-mistakes/SKILL.md`, and ensures the daemon is running, installing the managed service when available and falling back to a detached daemon otherwise.
+If `.claude` links to `.agents`, `.claude/skills` links to `.agents/skills`, or the reverse, `init` follows that layout and still makes the skill readable from both logical paths.
 The gate advertises Git push-option support, so you can skip steps for one push with `git push -o no-mistakes.skip=test,lint no-mistakes <branch>`.
 
 Re-running `init` on an already-initialized repo succeeds and reports `Gate already initialized (refreshed)`.
-It refreshes managed gate wiring, origin/default-branch metadata, hook-path isolation, and the installed agent skill.
+It refreshes managed gate wiring, origin/default-branch metadata, hook-path isolation, and the installed agent skill, overwriting any stale `SKILL.md` content from an older binary.
 Fresh init rolls back gate setup when a required gate or daemon step fails; refresh does not eject a pre-existing gate if daemon startup fails.
 Skill installation is best-effort: if the skill write fails, init reports it and leaves the working gate in place.
 

--- a/docs/src/content/docs/start-here/quick-start.md
+++ b/docs/src/content/docs/start-here/quick-start.md
@@ -57,7 +57,7 @@ $ no-mistakes init
 `origin` is unchanged. If you need to bypass the gate for a specific push, use
 `git push origin <branch>`.
 
-You can safely re-run `no-mistakes init` later to refresh gate wiring or reinstall the agent skill.
+You can safely re-run `no-mistakes init` later to refresh gate wiring or update the installed agent skill after an upgrade.
 
 ## 4. Push through the gate
 

--- a/internal/skill/install.go
+++ b/internal/skill/install.go
@@ -3,6 +3,7 @@ package skill
 import (
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // InstallBases are the per-agent skill parent directories, relative to a repo
@@ -16,20 +17,67 @@ var InstallBases = []string{
 // Install writes SKILL.md into each agent skills directory under repoRoot,
 // creating directories as needed. It returns the repo-relative paths written so
 // the caller can report them. Writing is idempotent: re-running overwrites with
-// identical content.
+// identical content (refreshing a stale SKILL.md from an older version).
+//
+// Repos commonly consolidate the two bases with a symlink - `.claude/skills` ->
+// `.agents/skills`, the whole `.claude` dir -> `.agents`, or the reverse. Install
+// follows such links transparently, including when the symlinked target dir does
+// not exist yet (a plain os.MkdirAll would fail with "file exists" on a dangling
+// symlink). Both logical bases stay readable afterward via the link.
 func Install(repoRoot string) ([]string, error) {
 	content := []byte(Markdown())
 	written := make([]string, 0, len(InstallBases))
 	for _, base := range InstallBases {
 		rel := filepath.Join(base, Name, "SKILL.md")
 		path := filepath.Join(repoRoot, rel)
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		// Resolve any symlink components to a real directory before creating
+		// it, so a dangling symlink in the path does not collide with MkdirAll.
+		realDir, err := resolveThroughSymlinks(filepath.Dir(path))
+		if err != nil {
 			return written, err
 		}
-		if err := os.WriteFile(path, content, 0o644); err != nil {
+		if err := os.MkdirAll(realDir, 0o755); err != nil {
+			return written, err
+		}
+		if err := os.WriteFile(filepath.Join(realDir, "SKILL.md"), content, 0o644); err != nil {
 			return written, err
 		}
 		written = append(written, rel)
 	}
 	return written, nil
+}
+
+// resolveThroughSymlinks walks dir component by component and rewrites the path
+// through any symlink it encounters, even when the symlink's target does not
+// exist yet. The result contains no symlink components, so os.MkdirAll on it
+// will not trip over a dangling symlink. dir must be absolute.
+func resolveThroughSymlinks(dir string) (string, error) {
+	cur := string(filepath.Separator)
+	for _, part := range strings.Split(filepath.Clean(dir), string(filepath.Separator)) {
+		if part == "" {
+			continue
+		}
+		cur = filepath.Join(cur, part)
+		info, err := os.Lstat(cur)
+		if err != nil {
+			// This component does not exist yet; nothing left to resolve.
+			// Remaining parts are appended verbatim onto the resolved prefix.
+			continue
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			continue
+		}
+		target, err := os.Readlink(cur)
+		if err != nil {
+			return "", err
+		}
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(filepath.Dir(cur), target)
+		}
+		// The target may itself be or contain symlinks; resolve recursively.
+		if cur, err = resolveThroughSymlinks(target); err != nil {
+			return "", err
+		}
+	}
+	return cur, nil
 }

--- a/internal/skill/install.go
+++ b/internal/skill/install.go
@@ -57,8 +57,10 @@ func resolveThroughSymlinks(dir string) (string, error) {
 }
 
 func resolveThroughSymlinksSeen(dir string, seen map[string]struct{}) (string, error) {
-	cur := string(filepath.Separator)
-	for _, part := range strings.Split(filepath.Clean(dir), string(filepath.Separator)) {
+	clean := filepath.Clean(dir)
+	volume := filepath.VolumeName(clean)
+	cur := volume + string(filepath.Separator)
+	for _, part := range strings.Split(strings.TrimPrefix(clean, volume), string(filepath.Separator)) {
 		if part == "" {
 			continue
 		}

--- a/internal/skill/install.go
+++ b/internal/skill/install.go
@@ -1,6 +1,7 @@
 package skill
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -52,6 +53,10 @@ func Install(repoRoot string) ([]string, error) {
 // exist yet. The result contains no symlink components, so os.MkdirAll on it
 // will not trip over a dangling symlink. dir must be absolute.
 func resolveThroughSymlinks(dir string) (string, error) {
+	return resolveThroughSymlinksSeen(dir, make(map[string]struct{}))
+}
+
+func resolveThroughSymlinksSeen(dir string, seen map[string]struct{}) (string, error) {
 	cur := string(filepath.Separator)
 	for _, part := range strings.Split(filepath.Clean(dir), string(filepath.Separator)) {
 		if part == "" {
@@ -67,6 +72,11 @@ func resolveThroughSymlinks(dir string) (string, error) {
 		if info.Mode()&os.ModeSymlink == 0 {
 			continue
 		}
+		key := filepath.Clean(cur)
+		if _, ok := seen[key]; ok {
+			return "", fmt.Errorf("symlink cycle resolving %s", dir)
+		}
+		seen[key] = struct{}{}
 		target, err := os.Readlink(cur)
 		if err != nil {
 			return "", err
@@ -75,7 +85,7 @@ func resolveThroughSymlinks(dir string) (string, error) {
 			target = filepath.Join(filepath.Dir(cur), target)
 		}
 		// The target may itself be or contain symlinks; resolve recursively.
-		if cur, err = resolveThroughSymlinks(target); err != nil {
+		if cur, err = resolveThroughSymlinksSeen(target, seen); err != nil {
 			return "", err
 		}
 	}

--- a/internal/skill/install_windows_test.go
+++ b/internal/skill/install_windows_test.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package skill
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveThroughSymlinksPreservesWindowsVolume(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "missing", "skills", Name)
+	got, err := resolveThroughSymlinks(dir)
+	if err != nil {
+		t.Fatalf("resolveThroughSymlinks: %v", err)
+	}
+	if got != dir {
+		t.Fatalf("resolveThroughSymlinks(%q) = %q, want %q", dir, got, dir)
+	}
+}

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -181,6 +181,16 @@ func TestInstallOverwritesStaleContent(t *testing.T) {
 	}
 }
 
+func TestInstallRejectsSymlinkCycle(t *testing.T) {
+	root := t.TempDir()
+	symlink(t, ".agents", filepath.Join(root, ".claude"))
+	symlink(t, ".claude", filepath.Join(root, ".agents"))
+
+	if _, err := Install(root); err == nil {
+		t.Fatalf("Install succeeded with cyclic skill directory symlinks")
+	}
+}
+
 func mkdirAll(t *testing.T, dir string) {
 	t.Helper()
 	if err := os.MkdirAll(dir, 0o755); err != nil {

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -74,6 +74,127 @@ func TestInstallIsIdempotent(t *testing.T) {
 	}
 }
 
+// TestInstallSymlinkLayouts covers repos that consolidate the two skill bases
+// with a symlink. `.claude/skills` may link to `.agents/skills`, the whole
+// `.claude` dir may link to `.agents`, or the link may point the other way. In
+// every case Install must succeed and the skill must be reachable via both
+// logical bases - including when the symlink target dir does not exist yet.
+func TestInstallSymlinkLayouts(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, root string)
+	}{
+		{
+			name: "claude_skills_link_target_exists",
+			setup: func(t *testing.T, root string) {
+				mkdirAll(t, filepath.Join(root, ".agents", "skills"))
+				mkdirAll(t, filepath.Join(root, ".claude"))
+				symlink(t, filepath.Join("..", ".agents", "skills"), filepath.Join(root, ".claude", "skills"))
+			},
+		},
+		{
+			name: "claude_skills_link_target_missing",
+			setup: func(t *testing.T, root string) {
+				mkdirAll(t, filepath.Join(root, ".claude"))
+				symlink(t, filepath.Join("..", ".agents", "skills"), filepath.Join(root, ".claude", "skills"))
+			},
+		},
+		{
+			name: "claude_dir_link",
+			setup: func(t *testing.T, root string) {
+				mkdirAll(t, filepath.Join(root, ".agents"))
+				symlink(t, ".agents", filepath.Join(root, ".claude"))
+			},
+		},
+		{
+			name: "agents_skills_link_reverse",
+			setup: func(t *testing.T, root string) {
+				mkdirAll(t, filepath.Join(root, ".claude", "skills"))
+				mkdirAll(t, filepath.Join(root, ".agents"))
+				symlink(t, filepath.Join("..", ".claude", "skills"), filepath.Join(root, ".agents", "skills"))
+			},
+		},
+		{
+			name: "agents_dir_link_reverse",
+			setup: func(t *testing.T, root string) {
+				mkdirAll(t, filepath.Join(root, ".claude"))
+				symlink(t, ".claude", filepath.Join(root, ".agents"))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			tt.setup(t, root)
+
+			written, err := Install(root)
+			if err != nil {
+				t.Fatalf("Install: %v", err)
+			}
+
+			// Every reported path must be readable with current content.
+			for _, rel := range written {
+				data, err := os.ReadFile(filepath.Join(root, rel))
+				if err != nil {
+					t.Fatalf("read reported %s: %v", rel, err)
+				}
+				if string(data) != Markdown() {
+					t.Errorf("%s content does not match Markdown()", rel)
+				}
+			}
+
+			// The skill must be discoverable via both logical bases no matter
+			// which side carries the symlink.
+			for _, base := range InstallBases {
+				p := filepath.Join(root, base, Name, "SKILL.md")
+				data, err := os.ReadFile(p)
+				if err != nil {
+					t.Fatalf("skill not reachable via %s: %v", base, err)
+				}
+				if string(data) != Markdown() {
+					t.Errorf("%s content does not match Markdown()", base)
+				}
+			}
+		})
+	}
+}
+
+// TestInstallOverwritesStaleContent guards the upgrade path: an older SKILL.md
+// left by a previous binary version must be refreshed to current content when
+// Install runs again.
+func TestInstallOverwritesStaleContent(t *testing.T) {
+	root := t.TempDir()
+	stale := filepath.Join(root, ".claude", "skills", Name, "SKILL.md")
+	mkdirAll(t, filepath.Dir(stale))
+	if err := os.WriteFile(stale, []byte("---\nname: "+Name+"\n---\nstale body\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Install(root); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	data, err := os.ReadFile(stale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != Markdown() {
+		t.Errorf("stale SKILL.md was not refreshed to current content")
+	}
+}
+
+func mkdirAll(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func symlink(t *testing.T, target, link string) {
+	t.Helper()
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func min(a, b int) int {
 	if a < b {
 		return a


### PR DESCRIPTION
## Intent

Make skill installation work with repos that symlink .claude/skills to .agents/skills (or the reverse, or whole-dir symlinks), including dangling targets, and add test coverage for those cases plus stale-content overwrite on upgrade.

## What Changed

- Resolve skill install destinations through symlinked `.claude`/`.agents` bases and skill directories, including dangling targets, so installs land in the shared target instead of failing or writing beside the link.
- Detect symlink cycles during skill destination resolution and preserve Windows volume prefixes while resolving paths.
- Add skill installer coverage for symlink layouts, cyclic symlinks, Windows path handling, and stale-content overwrite behavior, with docs updated to reference the installed OpenCode skill path.

## Risk Assessment

✅ Low: The change is narrowly scoped to skill installation symlink resolution with focused coverage for the new layouts and previous review issues addressed.

## Testing

I ran the targeted symlink and stale-upgrade tests, attempted the real `no-mistakes init` CLI path but it was blocked by daemon Unix socket path length before skill installation, then captured reviewer-visible installer output showing the requested symlink and stale-overwrite behavior works through `skill.Install`; the full `internal/skill` package test suite passed and transient scratch data was removed.

<details>
<summary>Evidence: Skill install symlink installer transcript</summary>

Source: [Skill install symlink installer transcript](https://github.com/kunchenguid/no-mistakes/blob/5ccc77dbb912eddd5c6fa7c526540d9ee26b8095/.no-mistakes/evidence/fix/skill-install-symlinks/skill-install-symlink-installer-transcript.txt)

```text
Shows dangling forward symlink, reverse whole-dir symlink, and stale-upgrade layouts all writing `.claude/skills/no-mistakes/SKILL.md` and `.agents/skills/no-mistakes/SKILL.md`, with both paths reachable, no stale body remaining, and current content true.
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (5m36s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ `internal/skill/install.go:78` - `resolveThroughSymlinks` recursively follows symlink targets without tracking visited paths or a depth limit, so a symlink cycle in `.claude`/`.agents` (for example each base pointing at the other) can make `no-mistakes init` recurse until stack exhaustion instead of returning a best-effort skill-install error.

🔧 Fix: Handle cyclic skill symlinks
1 warning still open:
- ⚠️ `internal/skill/install.go:60` - `resolveThroughSymlinksSeen` builds paths by starting at `filepath.Separator` and splitting the cleaned path, which drops the volume from absolute Windows paths such as `C:\repo\...`; because `Install` now runs every skill install through this helper, supported Windows builds will resolve/write under the wrong root or skip skill installation even when no symlinks are present. Preserve the volume prefix with `filepath.VolumeName` or avoid manual component splitting.

🔧 Fix: Preserve Windows skill symlink paths
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ Full end-to-end `no-mistakes init` evidence could not be captured in this isolated worktree because the daemon failed before skill installation: its Unix socket path under the long worktree/NM_HOME path exceeded the platform socket path limit and `init` stopped with `daemon started but did not become responsive`. I captured direct installer evidence for the affected skill-install behavior instead.
- `go test ./internal/skill -run 'TestInstall(SymlinkLayouts|OverwritesStaleContent|RejectsSymlinkCycle)$' -count=1`
- <code>Attempted `no-mistakes init` in scratch git repos with `NM_HOME` under the evidence directory and then a shorter in-worktree scratch directory; both attempts failed before skill installation because the daemon Unix socket path was too long for this isolated worktree.</code>
- <code>`NM_PROBE_WORKSPACE=&#34;$PWD&#34; go run ./.nm-skill-e2e/probe.go` using a temporary in-module probe to call `internal/skill.Install` across dangling `.claude/skills -&gt; ../.agents/skills`, reverse `.agents -&gt; .claude`, and stale-content upgrade layouts; transcript saved as evidence, then probe and scratch repos removed.</code>
- `go test ./internal/skill -count=1`
- <code>Cleaned transient `.nm-skill-e2e` and failed CLI scratch directories; verified only the intended evidence transcript remains under `.no-mistakes/evidence/fix/skill-install-symlinks`.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
