### PR TITLE
feat(cli): emit AXI pageview telemetry

### DIFF
--- a/.no-mistakes/evidence/feat/axi-pageview-telemetry/axi-telemetry-events.json
+++ b/.no-mistakes/evidence/feat/axi-pageview-telemetry/axi-telemetry-events.json
@@ -1,0 +1,243 @@
+{
+  "purpose": "Capture real no-mistakes axi CLI telemetry sent to a mock Umami endpoint, demonstrating /axi/* pageviews are emitted alongside existing command events.",
+  "generated_at": "2026-06-08T04:04:48Z",
+  "invocations": [
+    {
+      "args": [
+        "axi"
+      ],
+      "exit_code": 1,
+      "stdout": "error: repo not initialized (run 'no-mistakes init' first)\nhelp[1]: Run `no-mistakes init` to set up the gate in this repository",
+      "stderr": "exit status 1",
+      "events": [
+        {
+          "type": "event",
+          "payload": {
+            "website": "evidence-website",
+            "hostname": "cli",
+            "title": "no-mistakes CLI",
+            "url": "/axi"
+          }
+        },
+        {
+          "type": "event",
+          "payload": {
+            "website": "evidence-website",
+            "hostname": "cli",
+            "title": "no-mistakes CLI",
+            "url": "app://no-mistakes/command",
+            "name": "command",
+            "data": {
+              "command": "axi-home",
+              "duration_ms": 27,
+              "status": "error"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "args": [
+        "axi",
+        "run",
+        "--intent",
+        "ship the thing",
+        "--yes",
+        "--skip",
+        "lint"
+      ],
+      "exit_code": 1,
+      "stdout": "error: repo not initialized (run 'no-mistakes init' first)\nhelp[1]: Run `no-mistakes init` to set up the gate in this repository",
+      "stderr": "exit status 1",
+      "events": [
+        {
+          "type": "event",
+          "payload": {
+            "website": "evidence-website",
+            "hostname": "cli",
+            "title": "no-mistakes CLI",
+            "url": "/axi/run",
+            "data": {
+              "auto_yes": true,
+              "has_intent": true,
+              "has_skip": true
+            }
+          }
+        },
+        {
+          "type": "event",
+          "payload": {
+            "website": "evidence-website",
+            "hostname": "cli",
+            "title": "no-mistakes CLI",
+            "url": "app://no-mistakes/command",
+            "name": "command",
+            "data": {
+              "command": "axi-run",
+              "duration_ms": 23,
+              "status": "error"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "args": [
+        "axi",
+        "respond",
+        "--action",
+        "approve"
+      ],
+      "exit_code": 1,
+      "stdout": "error: repo not initialized (run 'no-mistakes init' first)\nhelp[1]: Run `no-mistakes init` to set up the gate in this repository",
+      "stderr": "exit status 1",
+      "events": [
+        {
+          "type": "event",
+          "payload": {
+            "website": "evidence-website",
+            "hostname": "cli",
+            "title": "no-mistakes CLI",
+            "url": "/axi/respond",
+            "data": {
+              "action": "approve",
+              "auto_yes": false
+            }
+          }
+        },
+        {
+          "type": "event",
+          "payload": {
+            "website": "evidence-website",
+            "hostname": "cli",
+            "title": "no-mistakes CLI",
+            "url": "app://no-mistakes/command",
+            "name": "command",
+            "data": {
+              "command": "axi-respond",
+              "duration_ms": 9,
+              "status": "error"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "args": [
+        "axi",
+        "status"
+      ],
+      "exit_code": 1,
+      "stdout": "error: repo not initialized (run 'no-mistakes init' first)\nhelp[1]: Run `no-mistakes init` to set up the gate in this repository",
+      "stderr": "exit status 1",
+      "events": [
+        {
+          "type": "event",
+          "payload": {
+            "website": "evidence-website",
+            "hostname": "cli",
+            "title": "no-mistakes CLI",
+            "url": "/axi/status",
+            "data": {
+              "explicit_run_id": false
+            }
+          }
+        },
+        {
+          "type": "event",
+          "payload": {
+            "website": "evidence-website",
+            "hostname": "cli",
+            "title": "no-mistakes CLI",
+            "url": "app://no-mistakes/command",
+            "name": "command",
+            "data": {
+              "command": "axi-status",
+              "duration_ms": 10,
+              "status": "error"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "args": [
+        "axi",
+        "logs",
+        "--step",
+        "test",
+        "--run",
+        "run-123"
+      ],
+      "exit_code": 1,
+      "stdout": "error: repo not initialized (run 'no-mistakes init' first)\nhelp[1]: Run `no-mistakes init` to set up the gate in this repository",
+      "stderr": "exit status 1",
+      "events": [
+        {
+          "type": "event",
+          "payload": {
+            "website": "evidence-website",
+            "hostname": "cli",
+            "title": "no-mistakes CLI",
+            "url": "/axi/logs",
+            "data": {
+              "explicit_run_id": true,
+              "full": false,
+              "step": "test"
+            }
+          }
+        },
+        {
+          "type": "event",
+          "payload": {
+            "website": "evidence-website",
+            "hostname": "cli",
+            "title": "no-mistakes CLI",
+            "url": "app://no-mistakes/command",
+            "name": "command",
+            "data": {
+              "command": "axi-logs",
+              "duration_ms": 9,
+              "status": "error"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "args": [
+        "axi",
+        "abort"
+      ],
+      "exit_code": 1,
+      "stdout": "error: repo not initialized (run 'no-mistakes init' first)\nhelp[1]: Run `no-mistakes init` to set up the gate in this repository",
+      "stderr": "exit status 1",
+      "events": [
+        {
+          "type": "event",
+          "payload": {
+            "website": "evidence-website",
+            "hostname": "cli",
+            "title": "no-mistakes CLI",
+            "url": "/axi/abort"
+          }
+        },
+        {
+          "type": "event",
+          "payload": {
+            "website": "evidence-website",
+            "hostname": "cli",
+            "title": "no-mistakes CLI",
+            "url": "app://no-mistakes/command",
+            "name": "command",
+            "data": {
+              "command": "axi-abort",
+              "duration_ms": 10,
+              "status": "error"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/docs/src/content/docs/reference/environment.md
+++ b/docs/src/content/docs/reference/environment.md
@@ -102,6 +102,8 @@ Override or enable the telemetry website ID.
 When set, telemetry uses this website ID at runtime. If it is unset in a dev build, `no-mistakes` also checks a repo-local `.env` file for `NO_MISTAKES_UMAMI_WEBSITE_ID`. If no runtime value is found, it falls back to any website ID embedded at build time.
 
 When telemetry is enabled, `no-mistakes` sends command, run, approval, fix, and wizard events, completed step events with `awaiting_approval`, `fix_review`, or `failed` status, and pageviews for the human surfaces `/wizard` and `/tui` and the agent surfaces `/axi`, `/axi/run`, `/axi/respond`, `/axi/status`, `/axi/logs`, and `/axi/abort` to Umami.
+AXI pageviews are sent alongside command events, so command status and duration remain available.
+They include only flag-derived context: `/axi/run` records whether `--yes`, `--intent`, or `--skip` was present; `/axi/respond` records the sanitized action and whether `--yes` was present; `/axi/status` records whether `--run` was present; and `/axi/logs` records the sanitized step, whether `--full` was present, and whether `--run` was present.
 
 ## `NO_MISTAKES_TELEMETRY`
 

--- a/docs/src/content/docs/reference/environment.md
+++ b/docs/src/content/docs/reference/environment.md
@@ -101,7 +101,7 @@ Override or enable the telemetry website ID.
 
 When set, telemetry uses this website ID at runtime. If it is unset in a dev build, `no-mistakes` also checks a repo-local `.env` file for `NO_MISTAKES_UMAMI_WEBSITE_ID`. If no runtime value is found, it falls back to any website ID embedded at build time.
 
-When telemetry is enabled, `no-mistakes` sends command, run, approval, fix, and wizard events, completed step events with `awaiting_approval`, `fix_review`, or `failed` status, and pageviews for `/wizard` and `/tui` to Umami.
+When telemetry is enabled, `no-mistakes` sends command, run, approval, fix, and wizard events, completed step events with `awaiting_approval`, `fix_review`, or `failed` status, and pageviews for the human surfaces `/wizard` and `/tui` and the agent surfaces `/axi`, `/axi/run`, `/axi/respond`, `/axi/status`, `/axi/logs`, and `/axi/abort` to Umami.
 
 ## `NO_MISTAKES_TELEMETRY`
 

--- a/internal/cli/axi.go
+++ b/internal/cli/axi.go
@@ -35,7 +35,7 @@ func newAxiCmd() *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return trackCommand("axi-home", func() error {
+			return trackAxiSurface("axi-home", "/axi", nil, func() error {
 				return runAxiHome(cmd)
 			})
 		},

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -510,7 +510,7 @@ func newAxiRespondCmd() *cobra.Command {
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return trackAxiSurface("axi-respond", "/axi/respond", telemetry.Fields{
-				"action":   strings.TrimSpace(action),
+				"action":   sanitizeAxiTelemetryAction(action),
 				"auto_yes": autoYes,
 			}, func() error {
 				return runAxiRespond(cmd, respondArgs{

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/telemetry"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 	"github.com/spf13/cobra"
 )
@@ -72,7 +73,11 @@ func newAxiRunCmd() *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return trackCommand("axi-run", func() error {
+			return trackAxiSurface("axi-run", "/axi/run", telemetry.Fields{
+				"auto_yes":   autoYes,
+				"has_intent": strings.TrimSpace(intent) != "",
+				"has_skip":   strings.TrimSpace(skipValue) != "",
+			}, func() error {
 				skipSteps, err := parseSkipSteps(skipValue)
 				if err != nil {
 					return emitError(cmd, 2, err.Error(),
@@ -504,7 +509,10 @@ func newAxiRespondCmd() *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return trackCommand("axi-respond", func() error {
+			return trackAxiSurface("axi-respond", "/axi/respond", telemetry.Fields{
+				"action":   strings.TrimSpace(action),
+				"auto_yes": autoYes,
+			}, func() error {
 				return runAxiRespond(cmd, respondArgs{
 					action:       action,
 					step:         step,
@@ -646,7 +654,7 @@ func newAxiAbortCmd() *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return trackCommand("axi-abort", func() error {
+			return trackAxiSurface("axi-abort", "/axi/abort", nil, func() error {
 				return runAxiAbort(cmd)
 			})
 		},

--- a/internal/cli/axi_query.go
+++ b/internal/cli/axi_query.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
+	"github.com/kunchenguid/no-mistakes/internal/telemetry"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 	"github.com/spf13/cobra"
 )
@@ -30,7 +31,9 @@ func newAxiStatusCmd() *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return trackCommand("axi-status", func() error {
+			return trackAxiSurface("axi-status", "/axi/status", telemetry.Fields{
+				"explicit_run_id": strings.TrimSpace(runID) != "",
+			}, func() error {
 				return runAxiStatus(cmd, runID)
 			})
 		},
@@ -98,7 +101,11 @@ func newAxiLogsCmd() *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return trackCommand("axi-logs", func() error {
+			return trackAxiSurface("axi-logs", "/axi/logs", telemetry.Fields{
+				"step":            strings.TrimSpace(step),
+				"full":            full,
+				"explicit_run_id": strings.TrimSpace(runID) != "",
+			}, func() error {
 				return runAxiLogs(cmd, step, runID, full)
 			})
 		},

--- a/internal/cli/axi_query.go
+++ b/internal/cli/axi_query.go
@@ -102,7 +102,7 @@ func newAxiLogsCmd() *cobra.Command {
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return trackAxiSurface("axi-logs", "/axi/logs", telemetry.Fields{
-				"step":            strings.TrimSpace(step),
+				"step":            sanitizeAxiTelemetryStep(step),
 				"full":            full,
 				"explicit_run_id": strings.TrimSpace(runID) != "",
 			}, func() error {

--- a/internal/cli/axi_telemetry_test.go
+++ b/internal/cli/axi_telemetry_test.go
@@ -104,3 +104,43 @@ func TestAxiLogsPageviewCarriesStep(t *testing.T) {
 		t.Fatalf("explicit_run_id = %v, want true", got)
 	}
 }
+
+func TestAxiLogsPageviewSanitizesInvalidStep(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("NM_HOME", t.TempDir())
+	chdir(t, tmpDir)
+
+	recorder := &telemetryRecorder{}
+	restore := telemetry.SetDefaultForTesting(recorder)
+	defer restore()
+
+	_, _ = executeCmd("axi", "logs", "--step", "secret user text")
+
+	event := recorder.find("pageview", "path", "/axi/logs")
+	if event == nil {
+		t.Fatal("expected /axi/logs pageview")
+	}
+	if got := event.fields["step"]; got != "invalid" {
+		t.Fatalf("step = %v, want invalid", got)
+	}
+}
+
+func TestAxiRespondPageviewSanitizesInvalidAction(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("NM_HOME", t.TempDir())
+	chdir(t, tmpDir)
+
+	recorder := &telemetryRecorder{}
+	restore := telemetry.SetDefaultForTesting(recorder)
+	defer restore()
+
+	_, _ = executeCmd("axi", "respond", "--action", "secret user text")
+
+	event := recorder.find("pageview", "path", "/axi/respond")
+	if event == nil {
+		t.Fatal("expected /axi/respond pageview")
+	}
+	if got := event.fields["action"]; got != "invalid" {
+		t.Fatalf("action = %v, want invalid", got)
+	}
+}

--- a/internal/cli/axi_telemetry_test.go
+++ b/internal/cli/axi_telemetry_test.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/telemetry"
+)
+
+// TestAxiCommandsEmitPageviews verifies that every agent-facing axi command
+// records a pageview, giving agent usage parity with the human surfaces (the
+// TUI emits /tui and the wizard /wizard). The commands fail fast here because
+// the repo is uninitialized, but the pageview fires at command entry before any
+// of that, so it is still recorded.
+func TestAxiCommandsEmitPageviews(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		path    string
+		command string
+	}{
+		{"home", []string{"axi"}, "/axi", "axi-home"},
+		{"run", []string{"axi", "run", "--intent", "ship the thing"}, "/axi/run", "axi-run"},
+		{"respond", []string{"axi", "respond", "--action", "approve"}, "/axi/respond", "axi-respond"},
+		{"status", []string{"axi", "status"}, "/axi/status", "axi-status"},
+		{"logs", []string{"axi", "logs", "--step", "review"}, "/axi/logs", "axi-logs"},
+		{"abort", []string{"axi", "abort"}, "/axi/abort", "axi-abort"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			t.Setenv("NM_HOME", t.TempDir())
+			chdir(t, tmpDir)
+
+			recorder := &telemetryRecorder{}
+			restore := telemetry.SetDefaultForTesting(recorder)
+			defer restore()
+
+			// The command may fail (uninitialized repo); we only assert telemetry.
+			_, _ = executeCmd(tc.args...)
+
+			if event := recorder.find("pageview", "path", tc.path); event == nil {
+				t.Fatalf("expected %s pageview for %v", tc.path, tc.args)
+			}
+			// The pageview is added alongside the existing command event, not in
+			// place of it, so per-command status/duration is still recorded.
+			if event := recorder.find("command", "command", tc.command); event == nil {
+				t.Fatalf("expected %s command event alongside the pageview", tc.command)
+			}
+		})
+	}
+}
+
+// TestAxiRunPageviewCarriesFlags verifies the run pageview includes the
+// flag-derived context an analytics surface can segment on, mirroring how the
+// TUI pageview carries entrypoint/run_status.
+func TestAxiRunPageviewCarriesFlags(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("NM_HOME", t.TempDir())
+	chdir(t, tmpDir)
+
+	recorder := &telemetryRecorder{}
+	restore := telemetry.SetDefaultForTesting(recorder)
+	defer restore()
+
+	_, _ = executeCmd("axi", "run", "--intent", "ship it", "--yes", "--skip", "lint")
+
+	event := recorder.find("pageview", "path", "/axi/run")
+	if event == nil {
+		t.Fatal("expected /axi/run pageview")
+	}
+	if got := event.fields["auto_yes"]; got != true {
+		t.Fatalf("auto_yes = %v, want true", got)
+	}
+	if got := event.fields["has_intent"]; got != true {
+		t.Fatalf("has_intent = %v, want true", got)
+	}
+	if got := event.fields["has_skip"]; got != true {
+		t.Fatalf("has_skip = %v, want true", got)
+	}
+}
+
+// TestAxiLogsPageviewCarriesStep verifies the logs pageview records which step
+// and whether a specific run was requested.
+func TestAxiLogsPageviewCarriesStep(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("NM_HOME", t.TempDir())
+	chdir(t, tmpDir)
+
+	recorder := &telemetryRecorder{}
+	restore := telemetry.SetDefaultForTesting(recorder)
+	defer restore()
+
+	_, _ = executeCmd("axi", "logs", "--step", "test", "--run", "run-123")
+
+	event := recorder.find("pageview", "path", "/axi/logs")
+	if event == nil {
+		t.Fatal("expected /axi/logs pageview")
+	}
+	if got := event.fields["step"]; got != "test" {
+		t.Fatalf("step = %v, want test", got)
+	}
+	if got := event.fields["explicit_run_id"]; got != true {
+		t.Fatalf("explicit_run_id = %v, want true", got)
+	}
+}

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -1,9 +1,11 @@
 package cli
 
 import (
+	"strings"
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/telemetry"
+	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
 // trackAxiSurface records an agent-driven axi command both as a pageview and as
@@ -16,6 +18,24 @@ import (
 func trackAxiSurface(command, path string, fields telemetry.Fields, fn func() error) error {
 	telemetry.Pageview(path, fields)
 	return trackCommand(command, fn)
+}
+
+func sanitizeAxiTelemetryStep(step string) string {
+	step = strings.TrimSpace(step)
+	if validStep(types.StepName(step)) {
+		return step
+	}
+	return "invalid"
+}
+
+func sanitizeAxiTelemetryAction(action string) string {
+	action = strings.TrimSpace(action)
+	switch types.ApprovalAction(action) {
+	case types.ActionApprove, types.ActionFix, types.ActionSkip:
+		return action
+	default:
+		return "invalid"
+	}
 }
 
 func trackCommand(name string, fn func() error) (err error) {

--- a/internal/cli/telemetry.go
+++ b/internal/cli/telemetry.go
@@ -6,6 +6,18 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/telemetry"
 )
 
+// trackAxiSurface records an agent-driven axi command both as a pageview and as
+// a command event. The pageview gives agent usage parity with the human
+// surfaces (the TUI emits /tui, the wizard /wizard) so agent and human activity
+// show up the same way in analytics; the command event, added alongside rather
+// than replacing the pageview, keeps the per-command status and duration. It
+// fires at command entry so the surface is recorded even when the command later
+// fails. fields may be nil.
+func trackAxiSurface(command, path string, fields telemetry.Fields, fn func() error) error {
+	telemetry.Pageview(path, fields)
+	return trackCommand(command, fn)
+}
+
 func trackCommand(name string, fn func() error) (err error) {
 	return trackCommandStatus(name, func() (string, error) {
 		if err := fn(); err != nil {


### PR DESCRIPTION
## Intent

The user wanted agent usage of no-mistakes through the axi command family to be logged the same way human TUI usage is logged. Previously the human surfaces (TUI, wizard) emitted Umami pageviews (/tui, /wizard) but agent axi commands only emitted 'command' events with app:// URLs, so agent activity was invisible in Umami's Pages view. The user explicitly chose two design decisions: (1) ADD pageviews alongside the existing 'command' events rather than replacing them, so per-command status/duration_ms is preserved; (2) use a per-command /axi/* path scheme (/axi for home, /axi/run, /axi/respond, /axi/status, /axi/logs, /axi/abort) rather than a single /axi or mirroring human surfaces. Implementation adds a trackAxiSurface helper that fires telemetry.Pageview at command entry (so the surface is recorded even if the command later fails, mirroring how /tui is a visited surface) then wraps the existing trackCommand. Pageviews carry flag-derived context fields only (no DB lookups), so unlike /tui they intentionally do not carry run_status; this was a deliberate tradeoff for cheap, reliable entry-point emission. Docs reference enumerating tracked telemetry was updated. Added TDD tests in axi_telemetry_test.go.

## What Changed

- Added AXI command pageview tracking alongside existing command telemetry for `axi`, `axi run`, `axi respond`, `axi status`, `axi logs`, and `axi abort`.
- Included flag-derived pageview context for AXI surfaces while sanitizing invalid `logs --step` and `respond --action` values into fixed telemetry buckets.
- Added AXI telemetry tests, captured telemetry evidence, and updated environment reference docs for the newly tracked pageviews.

## Risk Assessment

✅ Low: The change is well-bounded to adding AXI pageview telemetry at command entry, preserves existing command events, and the prior raw enum telemetry issues are now sanitized.

## Testing

Exercised the new AXI telemetry behavior with targeted unit tests, an affected-package race test, focused telemetry serialization tests, and a mock-Umami end-to-end CLI capture showing each `/axi/*` pageview emitted alongside its existing `command` event; all checks passed and only the requested JSON evidence artifact remains.

<details>
<summary>Evidence: Captured AXI telemetry payloads</summary>

Source: [Captured AXI telemetry payloads](https://github.com/kunchenguid/no-mistakes/blob/8a373b829558d72336992f2139ae6b8b4abc138d/.no-mistakes/evidence/feat/axi-pageview-telemetry/axi-telemetry-events.json)

```text
Shows real CLI telemetry for `/axi`, `/axi/run`, `/axi/respond`, `/axi/status`, `/axi/logs`, and `/axi/abort`, each paired with the existing `app://no-mistakes/command` event.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `internal/cli/axi_query.go:105` - The `/axi/logs` pageview records the raw `--step` value before `runAxiLogs` validates it, so an invalid invocation can send arbitrary user-supplied text to the telemetry endpoint instead of the intended fixed step enum. Sanitize this field to a known step value or an `invalid` bucket before emitting the pageview.
- ⚠️ `internal/cli/axi_drive.go:513` - The `/axi/respond` pageview records the raw `--action` value before validation, so malformed invocations can send arbitrary user-supplied text to telemetry instead of the intended `approve|fix|skip` enum. Normalize it to a valid action or an `invalid` bucket before emitting the pageview.

🔧 Fix: Sanitize invalid axi telemetry enums
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/cli -run '^TestAxi.*Telemetry|^TestAxiCommandsEmitPageviews|^TestAxiRunPageviewCarriesFlags|^TestAxiLogsPageviewCarriesStep|^TestAxiLogsPageviewSanitizesInvalidStep|^TestAxiRespondPageviewSanitizesInvalidAction$' -count=1 -v`
- <code>`go run ./.no-mistakes/evidence/feat/axi-pageview-telemetry/capture_axi_telemetry.go` against a local mock Umami endpoint to capture real `no-mistakes axi` telemetry payloads for `axi`, `axi run`, `axi respond`, `axi status`, `axi logs`, and `axi abort`</code>
- `go test -race ./internal/cli -count=1`
- `go test ./internal/telemetry ./internal/cli -run 'TestClientPageviewSendsUmamiPageviewPayload|TestAxi' -count=1`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
