### PR TITLE
fix(scm): make GitHub operations repo-aware

### DIFF
--- a/.no-mistakes/evidence/fix/ci-gh-repo-flag/repo_flag_probe.go
+++ b/.no-mistakes/evidence/fix/ci-gh-repo-flag/repo_flag_probe.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/kunchenguid/no-mistakes/internal/scm"
+	"github.com/kunchenguid/no-mistakes/internal/scm/github"
+)
+
+func main() {
+	if len(os.Args) > 1 && os.Args[1] == "__fake_gh__" {
+		fakeGH(os.Args[2:])
+		return
+	}
+
+	ctx := context.Background()
+	host := github.New(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		cmd := exec.CommandContext(ctx, os.Args[0], append([]string{"__fake_gh__", name}, args...)...)
+		cmd.Dir = "/"
+		return cmd
+	}, nil, github.RepoSlug("git@github.com:test/repo.git"))
+
+	checks, err := host.GetChecks(ctx, &scm.PR{Number: "123"})
+	if err != nil {
+		fmt.Printf("GetChecks failed: %v\n", err)
+		os.Exit(1)
+	}
+	state, err := host.GetPRState(ctx, &scm.PR{Number: "123"})
+	if err != nil {
+		fmt.Printf("GetPRState failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("non-repo cwd: /")
+	fmt.Println("resolved repo slug: test/repo")
+	fmt.Println("accepted command: gh pr checks 123 --repo test/repo --json name,state,bucket,completedAt")
+	fmt.Println("accepted command: gh pr view 123 --repo test/repo --json state --jq .state")
+	fmt.Printf("GetChecks returned %d check named %q\n", len(checks), checks[0].Name)
+	fmt.Printf("GetPRState returned %q\n", state)
+	fmt.Println("fake gh accepted both commands only because --repo test/repo was present")
+}
+
+func fakeGH(args []string) {
+	wd, _ := os.Getwd()
+	joined := strings.Join(args, " ")
+
+	if wd != "/" {
+		fmt.Fprintf(os.Stderr, "expected non-repo cwd /, got %s\n", wd)
+		os.Exit(1)
+	}
+	if !containsRepo(args, "test/repo") {
+		fmt.Fprintln(os.Stderr, "missing required --repo test/repo")
+		os.Exit(1)
+	}
+
+	switch joined {
+	case "gh pr checks 123 --repo test/repo --json name,state,bucket,completedAt":
+		fmt.Println(`[{"name":"build","state":"SUCCESS","bucket":"pass","completedAt":"2026-06-08T00:00:00Z"}]`)
+	case "gh pr view 123 --repo test/repo --json state --jq .state":
+		fmt.Println("MERGED")
+	default:
+		fmt.Fprintf(os.Stderr, "unexpected command: %s\n", joined)
+		os.Exit(1)
+	}
+}
+
+func containsRepo(args []string, want string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "--repo" && args[i+1] == want {
+			return true
+		}
+	}
+	return false
+}

--- a/.no-mistakes/evidence/fix/ci-gh-repo-flag/repo_flag_probe.txt
+++ b/.no-mistakes/evidence/fix/ci-gh-repo-flag/repo_flag_probe.txt
@@ -1,0 +1,7 @@
+non-repo cwd: /
+resolved repo slug: test/repo
+accepted command: gh pr checks 123 --repo test/repo --json name,state,bucket,completedAt
+accepted command: gh pr view 123 --repo test/repo --json state --jq .state
+GetChecks returned 1 check named "build"
+GetPRState returned "MERGED"
+fake gh accepted both commands only because --repo test/repo was present

--- a/docs/src/content/docs/guides/provider-integration.md
+++ b/docs/src/content/docs/guides/provider-integration.md
@@ -62,6 +62,7 @@ gh auth status
 ```
 
 `no-mistakes doctor` also checks for `gh` availability.
+For PR and workflow-run commands, no-mistakes passes the repository slug from the recorded upstream remote or PR URL to `gh`, so daemon-run commands do not depend on the daemon's current working directory.
 
 **What you get:**
 

--- a/internal/pipeline/steps/host.go
+++ b/internal/pipeline/steps/host.go
@@ -22,7 +22,14 @@ func buildHost(sctx *pipeline.StepContext, provider scm.Provider) (scm.Host, str
 	}
 	switch provider {
 	case scm.ProviderGitHub:
-		return github.New(cmdFactory, func() bool { return stepCLIAvailable(sctx, provider) }), ""
+		// Resolve the owner/name slug so gh commands carry --repo and work from
+		// the daemon's fixed (non-repo) working directory. Fall back to the PR
+		// URL when the upstream remote URL is unavailable.
+		repo := github.RepoSlug(sctx.Repo.UpstreamURL)
+		if repo == "" && sctx.Run.PRURL != nil {
+			repo = github.RepoSlug(*sctx.Run.PRURL)
+		}
+		return github.New(cmdFactory, func() bool { return stepCLIAvailable(sctx, provider) }, repo), ""
 	case scm.ProviderGitLab:
 		return gitlab.New(cmdFactory, func() bool { return stepCLIAvailable(sctx, provider) }), ""
 	case scm.ProviderBitbucket:

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -20,12 +20,62 @@ type CmdFactory func(ctx context.Context, name string, args ...string) *exec.Cmd
 type Host struct {
 	cmd          CmdFactory
 	cliAvailable func() bool
+	repo         string // "owner/name" slug for --repo; empty when unknown
 }
 
 // New builds a Host. cliAvailable reports whether the gh binary is
-// resolvable on the caller's PATH (possibly overridden by env).
-func New(cmd CmdFactory, cliAvailable func() bool) *Host {
-	return &Host{cmd: cmd, cliAvailable: cliAvailable}
+// resolvable on the caller's PATH (possibly overridden by env). repo is the
+// "owner/name" slug; when set it is passed via --repo to every PR/run command
+// so they resolve the right repository regardless of the process working
+// directory. The daemon runs from a fixed, non-repo working dir, so without
+// this gh cannot infer the repo (or branch) and fails on every poll.
+func New(cmd CmdFactory, cliAvailable func() bool, repo string) *Host {
+	return &Host{cmd: cmd, cliAvailable: cliAvailable, repo: strings.TrimSpace(repo)}
+}
+
+// RepoSlug extracts the "owner/name" identifier from a GitHub remote or PR URL.
+// It supports https URLs, scp-style ssh URLs (git@github.com:owner/name.git),
+// ssh:// URLs, and longer paths such as PR links (the leading two path segments
+// are used). It returns "" when the input has no owner/name pair.
+func RepoSlug(remoteURL string) string {
+	raw := strings.TrimSpace(remoteURL)
+	if raw == "" {
+		return ""
+	}
+	raw = strings.TrimSuffix(raw, ".git")
+
+	// Reduce raw to the path portion after the host.
+	switch {
+	case strings.Contains(raw, "://"):
+		rest := raw[strings.Index(raw, "://")+len("://"):]
+		slash := strings.IndexByte(rest, '/')
+		if slash < 0 {
+			return ""
+		}
+		raw = rest[slash+1:]
+	case strings.Contains(raw, ":"):
+		// scp-style ssh: [user@]host:owner/name
+		raw = raw[strings.IndexByte(raw, ':')+1:]
+	}
+
+	parts := strings.Split(strings.Trim(raw, "/"), "/")
+	if len(parts) < 2 {
+		return ""
+	}
+	owner, name := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+	if owner == "" || name == "" {
+		return ""
+	}
+	return owner + "/" + name
+}
+
+// repoArgs returns the --repo flag pair when the slug is known, so gh commands
+// resolve the right repository regardless of the process working directory.
+func (h *Host) repoArgs() []string {
+	if h.repo == "" {
+		return nil
+	}
+	return []string{"--repo", h.repo}
 }
 
 func (h *Host) Provider() scm.Provider { return scm.ProviderGitHub }
@@ -49,6 +99,7 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 	if strings.TrimSpace(base) != "" {
 		args = append(args, "--base", base)
 	}
+	args = append(args, h.repoArgs()...)
 	args = append(args, "--state", "open", "--json", "number,url")
 	cmd := h.cmd(ctx, "gh", args...)
 	out, err := cmd.CombinedOutput()
@@ -75,12 +126,12 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 }
 
 func (h *Host) CreatePR(ctx context.Context, branch, base string, content scm.PRContent) (*scm.PR, error) {
-	cmd := h.cmd(ctx, "gh", "pr", "create",
+	args := append([]string{"pr", "create",
 		"--head", branch,
 		"--base", base,
-		"--title", content.Title,
-		"--body", content.Body,
-	)
+	}, h.repoArgs()...)
+	args = append(args, "--title", content.Title, "--body", content.Body)
+	cmd := h.cmd(ctx, "gh", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("gh pr create: %s: %w", strings.TrimSpace(string(out)), err)
@@ -98,7 +149,9 @@ func (h *Host) UpdatePR(ctx context.Context, pr *scm.PR, content scm.PRContent) 
 	if id == "" {
 		id = pr.URL
 	}
-	cmd := h.cmd(ctx, "gh", "pr", "edit", id, "--title", content.Title, "--body", content.Body)
+	args := append([]string{"pr", "edit", id}, h.repoArgs()...)
+	args = append(args, "--title", content.Title, "--body", content.Body)
+	cmd := h.cmd(ctx, "gh", args...)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return nil, fmt.Errorf("gh pr edit: %s: %w", strings.TrimSpace(string(out)), err)
 	}
@@ -106,7 +159,9 @@ func (h *Host) UpdatePR(ctx context.Context, pr *scm.PR, content scm.PRContent) 
 }
 
 func (h *Host) GetPRState(ctx context.Context, pr *scm.PR) (scm.PRState, error) {
-	cmd := h.cmd(ctx, "gh", "pr", "view", pr.Number, "--json", "state", "--jq", ".state")
+	args := append([]string{"pr", "view", pr.Number}, h.repoArgs()...)
+	args = append(args, "--json", "state", "--jq", ".state")
+	cmd := h.cmd(ctx, "gh", args...)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("gh pr view: %w", err)
@@ -115,7 +170,9 @@ func (h *Host) GetPRState(ctx context.Context, pr *scm.PR) (scm.PRState, error) 
 }
 
 func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
-	cmd := h.cmd(ctx, "gh", "pr", "checks", pr.Number, "--json", "name,state,bucket,completedAt")
+	args := append([]string{"pr", "checks", pr.Number}, h.repoArgs()...)
+	args = append(args, "--json", "name,state,bucket,completedAt")
+	cmd := h.cmd(ctx, "gh", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		if strings.Contains(string(out), "no checks reported") {
@@ -146,7 +203,9 @@ func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
 }
 
 func (h *Host) GetMergeableState(ctx context.Context, pr *scm.PR) (scm.MergeableState, error) {
-	cmd := h.cmd(ctx, "gh", "pr", "view", pr.Number, "--json", "mergeable", "--jq", ".mergeable")
+	args := append([]string{"pr", "view", pr.Number}, h.repoArgs()...)
+	args = append(args, "--json", "mergeable", "--jq", ".mergeable")
+	cmd := h.cmd(ctx, "gh", args...)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("gh pr view mergeable: %w", err)
@@ -172,6 +231,7 @@ func (h *Host) FetchFailedCheckLogs(ctx context.Context, _ *scm.PR, branch, head
 	if strings.TrimSpace(headSHA) != "" {
 		args = append(args, "--commit", strings.TrimSpace(headSHA))
 	}
+	args = append(args, h.repoArgs()...)
 	args = append(args,
 		"--status", "failure",
 		"--limit", "20",
@@ -190,7 +250,9 @@ func (h *Host) FetchFailedCheckLogs(ctx context.Context, _ *scm.PR, branch, head
 		if !runMatchesTargets(ctx, h, run, targets) {
 			continue
 		}
-		viewCmd := h.cmd(ctx, "gh", "run", "view", fmt.Sprintf("%d", run.DatabaseID), "--log-failed")
+		viewArgs := append([]string{"run", "view", fmt.Sprintf("%d", run.DatabaseID)}, h.repoArgs()...)
+		viewArgs = append(viewArgs, "--log-failed")
+		viewCmd := h.cmd(ctx, "gh", viewArgs...)
 		out, err := viewCmd.Output()
 		if err != nil {
 			continue
@@ -230,7 +292,9 @@ func runMatchesTargets(ctx context.Context, h *Host, run githubRun, targets map[
 	if run.DatabaseID == 0 {
 		return false
 	}
-	viewCmd := h.cmd(ctx, "gh", "run", "view", fmt.Sprintf("%d", run.DatabaseID), "--json", "jobs")
+	viewArgs := append([]string{"run", "view", fmt.Sprintf("%d", run.DatabaseID)}, h.repoArgs()...)
+	viewArgs = append(viewArgs, "--json", "jobs")
+	viewCmd := h.cmd(ctx, "gh", viewArgs...)
 	out, err := viewCmd.Output()
 	if err != nil {
 		return false

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -12,6 +12,72 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/scm"
 )
 
+func TestRepoSlug(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"https", "https://github.com/test/repo", "test/repo"},
+		{"https with .git suffix", "https://github.com/test/repo.git", "test/repo"},
+		{"pr url", "https://github.com/test/repo/pull/42", "test/repo"},
+		{"ssh scp form", "git@github.com:test/repo.git", "test/repo"},
+		{"ssh scp form no suffix", "git@github.com:test/repo", "test/repo"},
+		{"ssh url form", "ssh://git@github.com/test/repo.git", "test/repo"},
+		{"https with port", "https://github.com:8443/test/repo", "test/repo"},
+		{"already a slug", "test/repo", "test/repo"},
+		{"trailing slash", "https://github.com/test/repo/", "test/repo"},
+		{"empty", "", ""},
+		{"host only", "https://github.com/", ""},
+		{"owner only", "https://github.com/onlyowner", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RepoSlug(tc.in); got != tc.want {
+				t.Fatalf("RepoSlug(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetChecksPassesRepoFlag(t *testing.T) {
+	t.Parallel()
+
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		"gh pr checks 123 --repo test/repo --json name,state,bucket,completedAt": {
+			stdout: `[{"name":"build","state":"SUCCESS","bucket":"pass"}]` + "\n",
+		},
+	}), nil, "test/repo")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
+	if err != nil {
+		t.Fatalf("GetChecks() error = %v", err)
+	}
+	if len(checks) != 1 || checks[0].Name != "build" {
+		t.Fatalf("checks = %+v, want single build check", checks)
+	}
+}
+
+func TestGetPRStatePassesRepoFlag(t *testing.T) {
+	t.Parallel()
+
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		"gh pr view 123 --repo test/repo --json state --jq .state": {
+			stdout: "MERGED\n",
+		},
+	}), nil, "test/repo")
+
+	state, err := host.GetPRState(context.Background(), &scm.PR{Number: "123"})
+	if err != nil {
+		t.Fatalf("GetPRState() error = %v", err)
+	}
+	if state != scm.PRStateMerged {
+		t.Fatalf("GetPRState() = %q, want %q", state, scm.PRStateMerged)
+	}
+}
+
 func TestGetChecksFallsBackToStateWhenBucketMissing(t *testing.T) {
 	t.Parallel()
 
@@ -19,7 +85,7 @@ func TestGetChecksFallsBackToStateWhenBucketMissing(t *testing.T) {
 		"gh pr checks 123 --json name,state,bucket,completedAt": {
 			stdout: `[{"name":"build","state":"FAILURE","bucket":""},{"name":"tests","state":"PENDING","bucket":""}]` + "\n",
 		},
-	}), nil)
+	}), nil, "")
 
 	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
 	if err != nil {
@@ -43,7 +109,7 @@ func TestGetChecksParsesCompletedAt(t *testing.T) {
 		"gh pr checks 123 --json name,state,bucket,completedAt": {
 			stdout: `[{"name":"build","state":"FAILURE","bucket":"fail","completedAt":"2026-04-24T04:15:00Z"},{"name":"tests","state":"SUCCESS","bucket":"pass","completedAt":"not-a-time"}]` + "\n",
 		},
-	}), nil)
+	}), nil, "")
 
 	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
 	if err != nil {
@@ -78,7 +144,7 @@ func TestFetchFailedCheckLogsSelectsMatchingRunForHeadSHA(t *testing.T) {
 		"gh run view 102 --log-failed": {
 			stdout: "lint failed\n",
 		},
-	}), nil)
+	}), nil, "")
 
 	logs, err := host.FetchFailedCheckLogs(context.Background(), &scm.PR{Number: "123"}, "feature", "abc123", []string{"lint"})
 	if err != nil {
@@ -96,7 +162,7 @@ func TestFindPRFiltersByBaseBranch(t *testing.T) {
 		"gh pr list --head feature/refactor --base release/1.0 --state open --json number,url": {
 			stdout: `[{"number":42,"url":"https://github.example.com/org/repo/pull/42"}]` + "\n",
 		},
-	}), nil)
+	}), nil, "")
 
 	pr, err := host.FindPR(context.Background(), "feature/refactor", "release/1.0")
 	if err != nil {
@@ -121,7 +187,7 @@ func TestFindPRReturnsCLIError(t *testing.T) {
 			stderr: "api unavailable\n",
 			code:   1,
 		},
-	}), nil)
+	}), nil, "")
 
 	pr, err := host.FindPR(context.Background(), "feature/refactor", "main")
 	if err == nil {


### PR DESCRIPTION
## Intent

Fix GitHub issue #255: the CI-watch step hangs until ci_timeout (default 4h) on every run, logging 'could not check CI: gh pr checks: exit status 1' on each poll even when checks are green. The bug reporter guessed gh pr checks was invoked bare with no PR arg, but investigation showed pr.Number is already passed - the actual root cause is that NONE of the gh PR/run commands pass --repo, and the daemon runs gh from a fixed, non-repo working directory (cmd.Dir = sctx.WorkDir = the no-mistakes root). From a non-repo cwd, gh cannot infer the repository from a local git remote, so it exits 1 independent of real CI state. The fix (issue's preferred option 1) makes every gh command cwd-independent by passing --repo <owner>/<name>, applied consistently across GetPRState, GetChecks, GetMergeableState, FindPR, CreatePR, UpdatePR, and the gh run log-fetch calls - not just gh pr checks - since they all share the same failure mode. github.New now takes a repo slug; added RepoSlug to parse https, scp-style ssh (git@host:owner/name.git), ssh://, and PR URLs, and a repoArgs helper spliced into all invocations (gh auth status is intentionally left alone since it is global and needs no repo). buildHost resolves the slug from sctx.Repo.UpstreamURL, falling back to the PR URL. Done via TDD: wrote TestRepoSlug (12 cases), TestGetChecksPassesRepoFlag, TestGetPRStatePassesRepoFlag first. The New signature gained a third arg, so existing github_test.go callers were updated to pass empty string (no --repo, keys unchanged); existing step tests use substring-matching fake gh binaries so they were unaffected by the added flags.

## What Changed

- Pass `--repo <owner>/<name>` through GitHub PR, checks, mergeability, and run log commands so `gh` works from the daemon's non-repo working directory.
- Resolve the repository slug from the upstream remote URL with PR URL fallback, including HTTPS, SSH, SCP-style SSH, and PR URL parsing.
- Document the repository-resolution requirement for GitHub provider integration and add coverage for repo slug parsing plus repo flag propagation.

## Risk Assessment

✅ Low: The change is narrowly scoped to adding gh --repo arguments and slug parsing, with targeted coverage for the primary CI polling commands and no material regressions found in the reviewed diff.

## Testing

Exercised the repo slug parsing and `--repo` command construction tests, ran the affected GitHub SCM and pipeline steps packages, and generated an evidence transcript from a fake `gh` invoked with `cmd.Dir="/"`; all final checks passed and the transcript shows cwd-independent PR checks/state behavior.

<details>
<summary>Evidence: Cwd-independent GitHub repo flag probe transcript</summary>

Source: [Cwd-independent GitHub repo flag probe transcript](https://github.com/kunchenguid/no-mistakes/blob/3d5f98b97be6aad0b09d0c84e2cc602192fed6cf/.no-mistakes/evidence/fix/ci-gh-repo-flag/repo_flag_probe.txt)

```text
non-repo cwd: /
resolved repo slug: test/repo
accepted command: gh pr checks 123 --repo test/repo --json name,state,bucket,completedAt
accepted command: gh pr view 123 --repo test/repo --json state --jq .state
GetChecks returned 1 check named "build"
GetPRState returned "MERGED"
fake gh accepted both commands only because --repo test/repo was present
```
</details>
- Evidence: [Evidence probe source](https://github.com/kunchenguid/no-mistakes/blob/3d5f98b97be6aad0b09d0c84e2cc602192fed6cf/.no-mistakes/evidence/fix/ci-gh-repo-flag/repo_flag_probe.go)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/scm/github -run 'TestRepoSlug|TestGetChecksPassesRepoFlag|TestGetPRStatePassesRepoFlag' -count=1`
- `go test ./internal/scm/github ./internal/pipeline/steps -count=1`
- `go run ./.no-mistakes/evidence/fix/ci-gh-repo-flag/repo_flag_probe.go > ./.no-mistakes/evidence/fix/ci-gh-repo-flag/repo_flag_probe.txt 2>&1`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
