### PR TITLE
feat(skill): support task-first no-mistakes invocation

### DIFF
--- a/.agents/skills/no-mistakes/SKILL.md
+++ b/.agents/skills/no-mistakes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: no-mistakes
-description: Validate your code changes through the no-mistakes pipeline - automated code review, tests, lint, docs, push, PR, and CI - before they reach upstream. Use when the user asks to run no-mistakes, gate or ship or validate their changes, push safely, or invokes /no-mistakes.
+description: Validate your code changes through the no-mistakes pipeline - automated code review, tests, lint, docs, push, PR, and CI - before they reach upstream. Use when the user asks to run no-mistakes, gate or ship or validate their changes, push safely, asks you to do a task and then validate it, or invokes /no-mistakes.
 user-invocable: true
 ---
 
@@ -11,10 +11,37 @@ user-invocable: true
 upstream. You drive it through the `no-mistakes axi` command family, which prints
 machine-readable [TOON](https://toonformat.dev) to stdout and progress to stderr.
 
-When the user invokes `/no-mistakes`, validate the changes and report the outcome.
-If the user asks for something specific, translate that request into the matching
-`axi run` flags yourself - for example, "skip the lint step" becomes `--skip=lint`.
-Run `no-mistakes axi run --help` to see the available flags.
+When the user invokes `/no-mistakes`, report the outcome at the end. If the user
+asks for something specific, translate that request into the matching `axi run`
+flags yourself - for example, "skip the lint step" becomes `--skip=lint`. Run
+`no-mistakes axi run --help` to see the available flags.
+
+## Two ways to invoke
+
+`/no-mistakes` works in two modes, depending on whether the user hands you a
+task along with the command:
+
+- **Validate-only** - bare `/no-mistakes` (optionally with flag-style requests
+  like "skip the lint step"). The user's code changes are already committed;
+  validate them and report the outcome.
+- **Task-first** - `/no-mistakes <task>`, e.g.
+  `/no-mistakes add a --json flag to the status command`. First carry out the
+  task yourself, then validate the result through the pipeline:
+  1. **Check scope.** Inspect `git status` before you change or commit anything.
+     Preserve unrelated pre-existing uncommitted changes, and when you commit,
+     commit only the changes that belong to the user's task.
+  2. **Do the work.** Make the changes the task describes, then **commit them on
+     a feature branch**. If the user is on the repository's default branch,
+     create a feature branch first - the gate validates committed history on a
+     non-default branch, so the work must land there before you run.
+  3. **Then validate**, passing the user's task as your `--intent`. The task
+     text is exactly what the user set out to accomplish, in their own words, so
+     it *is* the intent - pass it through, enriched with the decisions and
+     tradeoffs you made while doing the work (see
+     [Intent is required](#intent-is-required)).
+
+Everything below - preconditions, intent, the validate-and-decide loop - applies
+the same way once the work is committed on a feature branch.
 
 ## Before you start
 

--- a/.no-mistakes/evidence/feat/skill-task-first-invocation/skill-task-first-evidence.md
+++ b/.no-mistakes/evidence/feat/skill-task-first-invocation/skill-task-first-evidence.md
@@ -1,0 +1,44 @@
+# Task-First `/no-mistakes` Skill Evidence
+
+This evidence captures the end-user skill prompt surface generated from `internal/skill/skill.go` into `skills/no-mistakes/SKILL.md`.
+
+## Generator Check
+
+Command: `go run ./cmd/genskill --check`
+
+Output:
+
+```text
+genskill: skills/no-mistakes/SKILL.md is up to date
+```
+
+## Generated Skill Excerpt
+
+Source: `skills/no-mistakes/SKILL.md`
+
+```markdown
+description: Validate your code changes through the no-mistakes pipeline - automated code review, tests, lint, docs, push, PR, and CI - before they reach upstream. Use when the user asks to run no-mistakes, gate or ship or validate their changes, push safely, asks you to do a task and then validate it, or invokes /no-mistakes.
+
+## Two ways to invoke
+
+`/no-mistakes` works in two modes, depending on whether the user hands you a
+task along with the command:
+
+- **Validate-only** - bare `/no-mistakes` (optionally with flag-style requests
+  like "skip the lint step"). The user's code changes are already committed;
+  validate them and report the outcome.
+- **Task-first** - `/no-mistakes <task>`, e.g.
+  `/no-mistakes add a --json flag to the status command`. First carry out the
+  task yourself, then validate the result through the pipeline:
+  1. **Check scope.** Inspect `git status` before you change or commit anything.
+     Preserve unrelated pre-existing uncommitted changes, and when you commit,
+     commit only the changes that belong to the user's task.
+  2. **Do the work.** Make the changes the task describes, then **commit them on
+     a feature branch**. If the user is on the repository's default branch,
+     create a feature branch first - the gate validates committed history on a
+     non-default branch, so the work must land there before you run.
+  3. **Then validate**, passing the user's task as your `--intent`. The task
+     text is exactly what the user set out to accomplish, in their own words, so
+     it *is* the intent - pass it through, enriched with the decisions and
+     tradeoffs you made while doing the work.
+```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 - **Non-blocking** - the pipeline runs in an isolated worktree without disrupting your work.
 - **Agent-agnostic** - `claude`, `codex`, `rovodev`, `opencode`, `pi`, or `acp:<target>` via `acpx`.
-- **Agent-native** - `/no-mistakes` lets the coding agent that wrote the change also gate it: it runs the pipeline, applies the safe fixes, and escalates the rest to you.
+- **Agent-native** - `/no-mistakes` lets your coding agent do a task and gate it, or gate existing committed work: it runs the pipeline, applies the safe fixes, and escalates the rest to you.
 - **Human stays in charge** - auto-fix or review findings, your call.
 - **Clean PRs by default** - push, open PR, watch CI, and auto-fix failures in one shot.
 
@@ -79,7 +79,7 @@ Every change runs through the same pipeline. Pick the entry point that fits how 
 
 - **`git push no-mistakes`** - the explicit Git path. Push a committed branch to the gate remote instead of `origin`.
 - **`no-mistakes`** - the TUI. Run it after making changes (no commit needed) and a wizard walks you through creating a branch, committing, and pushing through the gate, then attaches to the run. `no-mistakes -y` does all of that automatically.
-- **`/no-mistakes`** - the agent skill. Tell the coding agent that wrote the change to gate it. It runs the pipeline, applies the safe fixes itself, and stops to ask you about anything that needs a human call.
+- **`/no-mistakes`** - the agent skill. Tell the coding agent to do a task and gate it with `/no-mistakes <task>`, or use bare `/no-mistakes` to gate existing committed work. It runs the pipeline, applies the safe fixes itself, and stops to ask you about anything that needs a human call.
 
 `no-mistakes init` installs the `/no-mistakes` skill for Claude Code and other agents. Under the hood the skill drives `no-mistakes axi`, a non-interactive TOON interface to the same approval flow.
 

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -85,7 +85,10 @@ It does **not** change the pipeline order or the meaning of a passed gate.
 ## Driving no-mistakes as an agent
 
 The primary way to put a change through the gate from inside a coding agent is the `/no-mistakes` skill.
-When the agent that wrote the change is a skill-aware tool like Claude Code, you invoke `/no-mistakes` and it runs the whole pipeline for you: it starts the run with the intent it already has from the conversation, resolves the low-risk findings on its own, and stops to relay anything that needs your decision.
+A skill-aware tool like Claude Code supports two invocation modes.
+Use bare `/no-mistakes` to validate existing committed work.
+Use `/no-mistakes <task>` to have the agent first do the task, commit only that task's changes on a feature branch, then run the pipeline with the task text as `--intent`.
+In both modes, it resolves low-risk findings on its own and stops to relay anything that needs your decision.
 
 `no-mistakes init` installs that skill into `.claude/skills/no-mistakes/SKILL.md` and `.agents/skills/no-mistakes/SKILL.md`, so it is available to every supported agent in the repo.
 Repos that symlink `.claude` to `.agents`, `.claude/skills` to `.agents/skills`, or the reverse, keep that layout; `init` follows the symlink and makes the skill reachable from both logical paths.
@@ -93,6 +96,9 @@ Re-run `no-mistakes init` in an already-initialized repo to refresh or reinstall
 The skill drives `no-mistakes axi`, a non-interactive command surface that prints TOON to stdout and progress to stderr.
 When CI is green but the PR is still open, `axi run` and `axi respond` return `outcome: checks-passed` with a help line pointing at the PR instead of waiting for a human merge.
 That is a successful agent stopping point: report that the PR is ready and ask the user to review and merge it.
+
+In task-first mode, if the repo is on the default branch, the skill tells the agent to create a feature branch before committing because the gate validates committed history on a non-default branch.
+The agent should inspect `git status` before changing or committing anything, preserve unrelated pre-existing uncommitted changes, and commit only the changes that belong to the user's task.
 
 Agents can also call `no-mistakes axi` directly:
 
@@ -106,7 +112,7 @@ no-mistakes axi abort
 
 When an agent starts a new run, `--intent` is required and should describe what the user wanted to accomplish, not what files changed.
 Agents should prefer a few complete sentences over a terse summary, capturing user decisions, tradeoffs, constraints, ruled-out approaches, and explicit requests that would not be obvious from the diff alone.
-If the repo is on the default branch or has uncommitted changes, `axi run` returns a structured error with the command the agent should run instead of silently creating a branch or commit.
+If the repo is on the default branch or has uncommitted changes, direct `axi run` returns a structured error with the command the agent should run instead of silently creating a branch or commit.
 Approval gates are exposed as `gate:` objects with finding IDs, severities, files, actions, descriptions, and help commands for `no-mistakes axi respond`.
 An agent should resolve `action: auto-fix` findings on its own judgment, ignore `action: no-op` findings when approving, and stop on `action: ask-user` findings unless it is running with explicit `--yes` consent.
 When it stops for `ask-user`, it should relay each finding's ID, file, and full description to the user before choosing `approve`, `fix`, or `skip`.

--- a/docs/src/content/docs/start-here/introduction.md
+++ b/docs/src/content/docs/start-here/introduction.md
@@ -70,7 +70,7 @@ When a branch passes the gate, it means:
 - A fixed, opinionated pipeline: `intent → rebase → review → test → document → lint → push → pr → ci`. Order is not configurable; what each step runs is.
 - Choice of agent: `claude`, `codex`, `rovodev`, `opencode`, `pi`, or `acp:<target>` via `acpx`, with per-repo override.
 - A TUI to watch, approve, fix, skip, or abort any step.
-- A `/no-mistakes` agent skill so the coding agent that wrote the change can also gate it, backed by a non-interactive `no-mistakes axi` interface.
+- A `/no-mistakes` agent skill so a coding agent can do a task and gate it, or gate existing committed work, backed by a non-interactive `no-mistakes axi` interface.
 - A setup wizard when you run bare `no-mistakes` with no active run on the current branch - it walks you through creating a branch, committing, and pushing through the gate, then attaches if the daemon registers the new run.
 
 ## Three ways to trigger the gate
@@ -79,7 +79,7 @@ The pipeline is the same no matter how you start it. There are three first-class
 
 - **`git push no-mistakes`** - the explicit Git path. You push a committed branch to the gate remote instead of `origin`, and the daemon takes it from there. See [Quick Start](/no-mistakes/start-here/quick-start/).
 - **`no-mistakes`** - the terminal UI. Run it after making changes and a [setup wizard](/no-mistakes/guides/setup-wizard/) walks you through branch, commit, and push, then attaches to the live run so you can watch, approve, fix, skip, or abort each step.
-- **`/no-mistakes`** - the agent skill. When a coding agent like Claude Code wrote the change, you tell it `/no-mistakes` and it runs the gate for you: it starts the pipeline with the intent it already knows from your conversation, resolves the safe findings on its own, and stops to relay anything that needs your decision. See [Driving no-mistakes as an agent](/no-mistakes/guides/agents/#driving-no-mistakes-as-an-agent).
+- **`/no-mistakes`** - the agent skill. Tell a coding agent `/no-mistakes <task>` to have it do the task, commit it on a feature branch, and then gate it with that task as intent; use bare `/no-mistakes` to gate existing committed work. It resolves safe findings on its own and stops to relay anything that needs your decision. See [Driving no-mistakes as an agent](/no-mistakes/guides/agents/#driving-no-mistakes-as-an-agent).
 
 `no-mistakes init` installs the `/no-mistakes` skill into your repo for every supported agent. The skill drives `no-mistakes axi`, a non-interactive command surface that prints [TOON](https://toonformat.dev) to stdout, so an agent reaches the same gate and the same approval points you get in the TUI.
 

--- a/docs/src/content/docs/start-here/quick-start.md
+++ b/docs/src/content/docs/start-here/quick-start.md
@@ -83,13 +83,23 @@ The TUI shows each step's progress, streams agent output, and pauses for your ap
 
 ## Or let your agent run the gate
 
-If a coding agent like Claude Code made the change, you don't have to switch to the terminal at all. `no-mistakes init` installed a `/no-mistakes` skill into the repo, so you can just tell the agent:
+If you are already working inside a coding agent like Claude Code, you don't have to switch to the terminal at all.
+`no-mistakes init` installed a `/no-mistakes` skill into the repo, so you can ask the agent to do a task and gate it:
+
+```
+/no-mistakes add a --json flag to the status command
+```
+
+Or, if the work is already committed on a feature branch, use bare `/no-mistakes` to validate it:
 
 ```
 /no-mistakes
 ```
 
-The agent commits if needed, starts the pipeline with the intent it already has from your conversation, applies the low-risk fixes itself, and stops to relay any finding that needs your judgment. It drives the same gate as the TUI through `no-mistakes axi`, a non-interactive command surface that uses flags only, prints TOON on stdout, and exposes the same approval gates through `no-mistakes axi respond`.
+In task-first mode, the agent inspects scope, preserves unrelated work, commits only the task changes on a feature branch, and passes your task text as `--intent`.
+In validate-only mode, it validates the existing committed work.
+Either way, it applies low-risk fixes itself and stops to relay any finding that needs your judgment.
+It drives the same gate as the TUI through `no-mistakes axi`, a non-interactive command surface that uses flags only, prints TOON on stdout, and exposes the same approval gates through `no-mistakes axi respond`.
 
 See [Driving no-mistakes as an agent](/no-mistakes/guides/agents/#driving-no-mistakes-as-an-agent) for the full agent workflow.
 

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -58,11 +58,14 @@ task along with the command:
 - **Task-first** - ` + "`/no-mistakes <task>`" + `, e.g.
   ` + "`/no-mistakes add a --json flag to the status command`" + `. First carry out the
   task yourself, then validate the result through the pipeline:
-  1. **Do the work.** Make the changes the task describes, then **commit them on
+  1. **Check scope.** Inspect ` + "`git status`" + ` before you change or commit anything.
+     Preserve unrelated pre-existing uncommitted changes, and when you commit,
+     commit only the changes that belong to the user's task.
+  2. **Do the work.** Make the changes the task describes, then **commit them on
      a feature branch**. If the user is on the repository's default branch,
      create a feature branch first - the gate validates committed history on a
      non-default branch, so the work must land there before you run.
-  2. **Then validate**, passing the user's task as your ` + "`--intent`" + `. The task
+  3. **Then validate**, passing the user's task as your ` + "`--intent`" + `. The task
      text is exactly what the user set out to accomplish, in their own words, so
      it *is* the intent - pass it through, enriched with the decisions and
      tradeoffs you made while doing the work (see

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -16,7 +16,7 @@ const Name = "no-mistakes"
 // Description is the trigger-shaped frontmatter description: what the skill
 // does and when to use it. It is the single most important field for the
 // agent's decision to load the skill, so it leads with outcomes and keywords.
-const Description = "Validate your code changes through the no-mistakes pipeline - automated code review, tests, lint, docs, push, PR, and CI - before they reach upstream. Use when the user asks to run no-mistakes, gate or ship or validate their changes, push safely, or invokes /no-mistakes."
+const Description = "Validate your code changes through the no-mistakes pipeline - automated code review, tests, lint, docs, push, PR, and CI - before they reach upstream. Use when the user asks to run no-mistakes, gate or ship or validate their changes, push safely, asks you to do a task and then validate it, or invokes /no-mistakes."
 
 // Markdown returns the complete SKILL.md document (YAML frontmatter plus body).
 // The output is deterministic so it can be regenerated and diff-checked.
@@ -42,10 +42,34 @@ const body = `
 upstream. You drive it through the ` + "`no-mistakes axi`" + ` command family, which prints
 machine-readable [TOON](https://toonformat.dev) to stdout and progress to stderr.
 
-When the user invokes ` + "`/no-mistakes`" + `, validate the changes and report the outcome.
-If the user asks for something specific, translate that request into the matching
-` + "`axi run`" + ` flags yourself - for example, "skip the lint step" becomes ` + "`--skip=lint`" + `.
-Run ` + "`no-mistakes axi run --help`" + ` to see the available flags.
+When the user invokes ` + "`/no-mistakes`" + `, report the outcome at the end. If the user
+asks for something specific, translate that request into the matching ` + "`axi run`" + `
+flags yourself - for example, "skip the lint step" becomes ` + "`--skip=lint`" + `. Run
+` + "`no-mistakes axi run --help`" + ` to see the available flags.
+
+## Two ways to invoke
+
+` + "`/no-mistakes`" + ` works in two modes, depending on whether the user hands you a
+task along with the command:
+
+- **Validate-only** - bare ` + "`/no-mistakes`" + ` (optionally with flag-style requests
+  like "skip the lint step"). The user's code changes are already committed;
+  validate them and report the outcome.
+- **Task-first** - ` + "`/no-mistakes <task>`" + `, e.g.
+  ` + "`/no-mistakes add a --json flag to the status command`" + `. First carry out the
+  task yourself, then validate the result through the pipeline:
+  1. **Do the work.** Make the changes the task describes, then **commit them on
+     a feature branch**. If the user is on the repository's default branch,
+     create a feature branch first - the gate validates committed history on a
+     non-default branch, so the work must land there before you run.
+  2. **Then validate**, passing the user's task as your ` + "`--intent`" + `. The task
+     text is exactly what the user set out to accomplish, in their own words, so
+     it *is* the intent - pass it through, enriched with the decisions and
+     tradeoffs you made while doing the work (see
+     [Intent is required](#intent-is-required)).
+
+Everything below - preconditions, intent, the validate-and-decide loop - applies
+the same way once the work is committed on a feature branch.
 
 ## Before you start
 

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -35,6 +35,8 @@ func TestBodyDocumentsTaskFirstFlow(t *testing.T) {
 	for _, want := range []string{
 		"## Two ways to invoke",
 		"feature branch",
+		"Inspect `git status` before you change or commit anything",
+		"commit only the changes that belong to the user's task",
 		"passing the user's task as your `--intent`",
 	} {
 		if !strings.Contains(md, want) {

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -30,6 +30,19 @@ func TestMarkdownFrontmatter(t *testing.T) {
 	}
 }
 
+func TestBodyDocumentsTaskFirstFlow(t *testing.T) {
+	md := Markdown()
+	for _, want := range []string{
+		"## Two ways to invoke",
+		"feature branch",
+		"passing the user's task as your `--intent`",
+	} {
+		if !strings.Contains(md, want) {
+			t.Errorf("body should document the task-first flow: missing %q", want)
+		}
+	}
+}
+
 func TestInstallWritesBothPaths(t *testing.T) {
 	root := t.TempDir()
 	written, err := Install(root)

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -27,11 +27,14 @@ task along with the command:
 - **Task-first** - `/no-mistakes <task>`, e.g.
   `/no-mistakes add a --json flag to the status command`. First carry out the
   task yourself, then validate the result through the pipeline:
-  1. **Do the work.** Make the changes the task describes, then **commit them on
+  1. **Check scope.** Inspect `git status` before you change or commit anything.
+     Preserve unrelated pre-existing uncommitted changes, and when you commit,
+     commit only the changes that belong to the user's task.
+  2. **Do the work.** Make the changes the task describes, then **commit them on
      a feature branch**. If the user is on the repository's default branch,
      create a feature branch first - the gate validates committed history on a
      non-default branch, so the work must land there before you run.
-  2. **Then validate**, passing the user's task as your `--intent`. The task
+  3. **Then validate**, passing the user's task as your `--intent`. The task
      text is exactly what the user set out to accomplish, in their own words, so
      it *is* the intent - pass it through, enriched with the decisions and
      tradeoffs you made while doing the work (see

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: no-mistakes
-description: Validate your code changes through the no-mistakes pipeline - automated code review, tests, lint, docs, push, PR, and CI - before they reach upstream. Use when the user asks to run no-mistakes, gate or ship or validate their changes, push safely, or invokes /no-mistakes.
+description: Validate your code changes through the no-mistakes pipeline - automated code review, tests, lint, docs, push, PR, and CI - before they reach upstream. Use when the user asks to run no-mistakes, gate or ship or validate their changes, push safely, asks you to do a task and then validate it, or invokes /no-mistakes.
 user-invocable: true
 ---
 
@@ -11,10 +11,34 @@ user-invocable: true
 upstream. You drive it through the `no-mistakes axi` command family, which prints
 machine-readable [TOON](https://toonformat.dev) to stdout and progress to stderr.
 
-When the user invokes `/no-mistakes`, validate the changes and report the outcome.
-If the user asks for something specific, translate that request into the matching
-`axi run` flags yourself - for example, "skip the lint step" becomes `--skip=lint`.
-Run `no-mistakes axi run --help` to see the available flags.
+When the user invokes `/no-mistakes`, report the outcome at the end. If the user
+asks for something specific, translate that request into the matching `axi run`
+flags yourself - for example, "skip the lint step" becomes `--skip=lint`. Run
+`no-mistakes axi run --help` to see the available flags.
+
+## Two ways to invoke
+
+`/no-mistakes` works in two modes, depending on whether the user hands you a
+task along with the command:
+
+- **Validate-only** - bare `/no-mistakes` (optionally with flag-style requests
+  like "skip the lint step"). The user's code changes are already committed;
+  validate them and report the outcome.
+- **Task-first** - `/no-mistakes <task>`, e.g.
+  `/no-mistakes add a --json flag to the status command`. First carry out the
+  task yourself, then validate the result through the pipeline:
+  1. **Do the work.** Make the changes the task describes, then **commit them on
+     a feature branch**. If the user is on the repository's default branch,
+     create a feature branch first - the gate validates committed history on a
+     non-default branch, so the work must land there before you run.
+  2. **Then validate**, passing the user's task as your `--intent`. The task
+     text is exactly what the user set out to accomplish, in their own words, so
+     it *is* the intent - pass it through, enriched with the decisions and
+     tradeoffs you made while doing the work (see
+     [Intent is required](#intent-is-required)).
+
+Everything below - preconditions, intent, the validate-and-decide loop - applies
+the same way once the work is committed on a feature branch.
 
 ## Before you start
 


### PR DESCRIPTION
## Intent

Add a task-first invocation mode to the no-mistakes agent skill, so users can type '/no-mistakes <task>' and the agent will first carry out the task (committing it on a feature branch, creating one if needed) and then validate it through the pipeline, using the user's task text as the --intent. Bare '/no-mistakes' must keep its existing validate-only behavior unchanged. This is deliberately a skill-content-only change: the source of truth is the body/Description constants in internal/skill/skill.go, regenerated into skills/no-mistakes/SKILL.md via 'make skill'; the no-mistakes binary, CLI flags, pipeline, daemon, and git logic are intentionally untouched because the chaining lives entirely in how the agent reads the static skill prompt. I added a new 'Two ways to invoke' section, updated the intro, and extended the trigger Description to advertise the new mode. I followed TDD: added TestBodyDocumentsTaskFirstFlow first (red), then implemented. A deliberate decision: when the user is on the default branch in task-first mode, the agent auto-creates a feature branch rather than stopping to ask, matching the existing precondition guidance. Note gofmt reflowed the body prose, which is expected for the generated skill text.

## What Changed

- Adds task-first `/no-mistakes <task>` guidance to the no-mistakes skill so agents complete and commit the requested task before running validation with the task text as `--intent`.
- Preserves bare `/no-mistakes` as validate-only behavior and documents the branch/status checks that protect unrelated worktree changes.
- Regenerates the committed skill, updates user docs for the new invocation mode, and adds skill test coverage plus evidence for the generated output.

## Risk Assessment

✅ Low: The change is limited to static skill prompt content, generated skill output, and a focused documentation assertion, with no runtime CLI or pipeline behavior changes.

## Testing

Exercised the canonical skill source, generated skill file, generator drift check, CLI-related skill tests, and the full Go test suite; captured reviewer-visible evidence showing the rendered prompt now supports task-first invocation while bare `/no-mistakes` remains validate-only.

<details>
<summary>Evidence: Task-first skill prompt evidence</summary>

Source: [Task-first skill prompt evidence](https://github.com/kunchenguid/no-mistakes/blob/91c33851b28fa52c3e5710dd2ea042036a2fe9e3/.no-mistakes/evidence/feat/skill-task-first-invocation/skill-task-first-evidence.md)

```text
Contains `go run ./cmd/genskill --check` output and the generated `skills/no-mistakes/SKILL.md` excerpt for the `Two ways to invoke` section.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `internal/skill/skill.go:61` - Task-first mode tells agents to make changes and commit them, but it never tells them to inspect the pre-existing working tree or keep unrelated uncommitted user changes out of the commit. That can cause `/no-mistakes &lt;task&gt;` to accidentally commit unrelated local edits before the gate runs; add an explicit status/scope check before the work/commit step.

🔧 Fix: Protect task-first commit scope
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `internal/skill/skill.go`, `internal/skill/skill_test.go`, and `skills/no-mistakes/SKILL.md` for the task-first invocation contract.</code>
- `go test ./internal/skill`
- `go test ./cmd/genskill ./internal/cli`
- `go run ./cmd/genskill --check`
- `go test ./...`
- <code>Created and verified `.no-mistakes/evidence/feat/skill-task-first-invocation/skill-task-first-evidence.md` with the generated skill excerpt and generator-check output.</code>
- <code>`git status --short` to confirm only the requested evidence directory was left as a new working-tree artifact.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
