### PR TITLE
fix(document,review): correct spelling errors (unparseable -> unparsable, funcitonal -> functional)

### DIFF
--- a/internal/pipeline/steps/document.go
+++ b/internal/pipeline/steps/document.go
@@ -135,7 +135,7 @@ Previous documentation findings to address:
 }
 
 // documentApprovalOutcome builds a single ask-user finding for cases where the
-// agent's structured output is missing or unparseable, so a human can confirm
+// agent's structured output is missing or unparsable, so a human can confirm
 // the documentation state instead of silently trusting an opaque response.
 func documentApprovalOutcome(summary string) *pipeline.StepOutcome {
 	findings := Findings{

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -162,7 +162,7 @@ Rules:
 - If the change is clean, return an empty findings array.
 - For each finding, set the action field to one of:
   - "ask-user": the finding is about functional requirements or product behavior, or otherwise challenges the author's deliberate intent. Even if it seems obviously wrong, we should ask the user for review. Examples: "this feature seems unnecessary", "this hardcoded value should be configurable", "this deletion looks wrong". When in doubt, default to "ask-user".
-  - "auto-fix": the finding is a non-funcitonal, non user-visible issue (correctness, error handling, security, performance, mechanical code quality) that can be safely fixed without any discussion about the author's intent.
+  - "auto-fix": the finding is a non-functional, non user-visible issue (correctness, error handling, security, performance, mechanical code quality) that can be safely fixed without any discussion about the author's intent.
   - "no-op": the finding is informational and does not require any action (e.g. noting a pattern, acknowledging a tradeoff).
 
 Risk assessment (after listing all findings):


### PR DESCRIPTION
Closes #261

## Changes
- `internal/pipeline/steps/document.go`: `unparseable` → `unparsable`
- `internal/pipeline/steps/review.go`: `funcitonal` → `functional`