### PR TITLE
fix(agent): strengthen JSON schema instruction in pi prompt for reliable structured output

### DIFF
--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -112,9 +112,18 @@ func buildPiPrompt(prompt string, schema json.RawMessage) string {
 		pretty = []byte(schema)
 	}
 	return prompt + "\n\n## no-mistakes final output contract\n\n" +
-		"When the iteration is complete, your final assistant response must be only valid JSON matching this JSON Schema. " +
-		"Do not wrap it in Markdown fences. Do not include prose before or after the JSON object.\n\n" +
-		string(pretty)
+		"Your final assistant response MUST be ONLY valid JSON matching the JSON Schema below. " +
+		"This is critical — your response will be programmatically parsed and validated against the schema. " +
+		"If the JSON does not match the schema (missing required fields, wrong types, or extra fields not in the schema), " +
+		"the entire pipeline step will fail and be retried, wasting time and tokens.\n\n" +
+		"Rules:\n" +
+		"- Output ONLY the JSON object. No prose before or after.\n" +
+		"- Do NOT wrap the JSON in Markdown fences (no ```json or ```).\n" +
+		"- Every finding in the \"findings\" array MUST include ALL required fields listed in the schema.\n" +
+		"- The \"action\" field in each finding MUST be one of the enum values specified in the schema.\n" +
+		"- Do not include fields that are not listed in the schema properties.\n" +
+		"- Double-check your output against the schema before finalizing.\n\n" +
+		"JSON Schema:\n" + string(pretty) + "\n"
 }
 
 // piParser tracks the streaming state of one Pi run. It accumulates text


### PR DESCRIPTION
## Problem

When no-mistakes invokes pi for pipeline steps that require structured JSON output (e.g., the test evidence step), pi sometimes omits required fields (like `"action"` in findings) from the output. This causes the pipeline step to fail with:

```
pi output parse: JSON output findings[0] missing required field "action"
```

## Root Cause

The `buildPiPrompt` function appends the JSON schema at the end of the prompt with minimal instruction: a single sentence saying the output must match the schema. For long prompts like the test evidence step (~80 lines of instructions), this instruction can be easy for the model to overlook or follow imprecisely.

Pi does not support native `--output-schema` or `--json-schema` flags like codex does, so the schema must be communicated entirely through the prompt.

## Fix

This change strengthens the output contract section appended by `buildPiPrompt`:

- **Explicitly states** the output will be programmatically parsed and validated
- **Lists concrete rules**: no prose, no fences, all required fields must be present
- **Calls out the `"action"` field specifically** since it is the most commonly omitted required field
- **Emphasizes consequences**: schema failures waste time and tokens by failing the step
- Uses bold/emphasis formatting to make key requirements visually prominent in the prompt

The structure remains the same (appended text, unchanged schema), so this is backward compatible for any agent that already followed the schema correctly.

## Testing

Ran `go vet ./internal/agent/` — passes. No formatting changes.
