### PR TITLE
fix(gate): reattach init after repo directory rename

### DIFF
--- a/.no-mistakes/evidence/fix/init-reattach-renamed-repo/init-rename-reattach-transcript.txt
+++ b/.no-mistakes/evidence/fix/init-reattach-renamed-repo/init-rename-reattach-transcript.txt
@@ -1,0 +1,47 @@
+no-mistakes init rename reattach evidence
+workspace=/Users/kunchen/.no-mistakes/worktrees/4e1218e2705b/01KTQ46N047X1N30HNES9A3FKR
+tmp_root=.x.0Tme7c
+
+$ no-mistakes init (firstpass)
+_  _ ____    _  _ _ ____ ___ ____ _  _ ____ ____
+|\ | |  |    |\/| | [__   |  |__| |_/  |___ [__ 
+| \| |__|    |  | | ___]  |  |  | | \_ |___ ___]
+
+  ✓ Gate initialized
+
+    repo  /Users/kunchen/.no-mistakes/worktrees/4e1218e2705b/01KTQ46N047X1N30HNES9A3FKR/.x.0Tme7c/firstpass
+    gate  no-mistakes → /Users/kunchen/.no-mistakes/worktrees/4e1218e2705b/01KTQ46N047X1N30HNES9A3FKR/.x.0Tme7c/nm/repos/eda0babc26f2.git
+  remote  /Users/kunchen/.no-mistakes/worktrees/4e1218e2705b/01KTQ46N047X1N30HNES9A3FKR/.x.0Tme7c/origin.git
+   skill  /no-mistakes installed for agents
+
+  Push through the gate with:
+  git push no-mistakes <branch>
+first no-mistakes remote: /Users/kunchen/.no-mistakes/worktrees/4e1218e2705b/01KTQ46N047X1N30HNES9A3FKR/.x.0Tme7c/nm/repos/eda0babc26f2.git
+first gate id: eda0babc26f2
+
+$ mv firstpass m87
+$ no-mistakes init (m87)
+_  _ ____    _  _ _ ____ ___ ____ _  _ ____ ____
+|\ | |  |    |\/| | [__   |  |__| |_/  |___ [__ 
+| \| |__|    |  | | ___]  |  |  | | \_ |___ ___]
+
+  ✓ Gate already initialized (refreshed)
+
+    repo  /Users/kunchen/.no-mistakes/worktrees/4e1218e2705b/01KTQ46N047X1N30HNES9A3FKR/.x.0Tme7c/m87
+    gate  no-mistakes → /Users/kunchen/.no-mistakes/worktrees/4e1218e2705b/01KTQ46N047X1N30HNES9A3FKR/.x.0Tme7c/nm/repos/eda0babc26f2.git
+  remote  /Users/kunchen/.no-mistakes/worktrees/4e1218e2705b/01KTQ46N047X1N30HNES9A3FKR/.x.0Tme7c/origin.git
+   skill  /no-mistakes installed for agents
+
+  Push through the gate with:
+  git push no-mistakes <branch>
+second no-mistakes remote: /Users/kunchen/.no-mistakes/worktrees/4e1218e2705b/01KTQ46N047X1N30HNES9A3FKR/.x.0Tme7c/nm/repos/eda0babc26f2.git
+second gate id: eda0babc26f2
+RESULT: same gate remote preserved after rename
+
+$ no-mistakes status from renamed repo
+    repo:  /Users/kunchen/.no-mistakes/worktrees/4e1218e2705b/01KTQ46N047X1N30HNES9A3FKR/.x.0Tme7c/m87
+  remote:  /Users/kunchen/.no-mistakes/worktrees/4e1218e2705b/01KTQ46N047X1N30HNES9A3FKR/.x.0Tme7c/origin.git
+    gate:  /Users/kunchen/.no-mistakes/worktrees/4e1218e2705b/01KTQ46N047X1N30HNES9A3FKR/.x.0Tme7c/nm/repos/eda0babc26f2.git
+  daemon:  ● running
+
+  no active run

--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -39,6 +39,8 @@ When you run `no-mistakes init` in a repo:
 
 `init` is idempotent.
 If the repo is already initialized, it refreshes the existing gate instead of failing: managed hook installation, push-option support, hook-path isolation, gate and working remotes, origin/default-branch metadata, and the `/no-mistakes` agent skill are repaired or updated where needed.
+If the working repo was renamed or moved and the old path no longer exists, `init` reattaches the existing gate from the leftover `no-mistakes` remote, updates the stored working path, and preserves the repo ID plus run history.
+If the working repo was copied and the original path still exists, `init` treats the copy as a new repo and repoints the copied `no-mistakes` remote to a fresh gate.
 If daemon startup fails during a refresh, `init` reports the error but does not eject the pre-existing gate.
 
 After init, your original `origin` still points at the real upstream remote.
@@ -171,4 +173,5 @@ Everything lives under `~/.no-mistakes/` by default. Set `NM_HOME` to relocate i
 | `logs/daemon.log` | Daemon log |
 | `logs/wizard-agent.log` | Managed agent-server output captured during setup wizard runs |
 
-The repo ID is the first 6 bytes (12 hex chars) of `sha256(absolute_working_path)`.
+New repo IDs are the first 6 bytes (12 hex chars) of `sha256(absolute_working_path)`.
+When an initialized working repo is renamed or moved, `init` preserves the existing repo ID instead of deriving a new one from the new path.

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -140,6 +140,7 @@ git remote -v | grep no-mistakes
 
 If it's missing, run `no-mistakes init` again.
 Re-running init refreshes an existing gate and repairs the `no-mistakes` remote when it is missing.
+It also reattaches an existing gate after you rename or move the repo directory, as long as the old path no longer exists.
 
 ### Check the hook
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -35,6 +35,8 @@ The gate advertises Git push-option support, so you can skip steps for one push 
 
 Re-running `init` on an already-initialized repo succeeds and reports `Gate already initialized (refreshed)`.
 It refreshes managed gate wiring, origin/default-branch metadata, hook-path isolation, and the installed agent skill, overwriting any stale `SKILL.md` content from an older binary.
+If you rename or move an initialized working directory and the old path no longer exists, re-running `init` from the new path reattaches the existing gate, preserves the repo ID and run history, and updates the stored working path.
+If you copy an initialized working directory while the original still exists, the copy is treated as a separate repo and gets a fresh gate.
 Fresh init rolls back gate setup when a required gate or daemon step fails; refresh does not eject a pre-existing gate if daemon startup fails.
 Skill installation is best-effort: if the skill write fails, init reports it and leaves the working gate in place.
 

--- a/docs/src/content/docs/start-here/quick-start.md
+++ b/docs/src/content/docs/start-here/quick-start.md
@@ -58,6 +58,8 @@ $ no-mistakes init
 `git push origin <branch>`.
 
 You can safely re-run `no-mistakes init` later to refresh gate wiring or update the installed agent skill after an upgrade.
+If you rename or move the repo directory, re-run `no-mistakes init` from the new path to reattach the existing gate and keep its run history.
+Copied repos get their own fresh gate while the original path still exists.
 
 ## 4. Push through the gate
 

--- a/internal/db/repo.go
+++ b/internal/db/repo.go
@@ -95,6 +95,20 @@ func (d *DB) UpdateRepoMetadata(id, upstreamURL, defaultBranch string) (*Repo, e
 	return d.GetRepo(id)
 }
 
+// UpdateRepoWorkingPath moves a repo record to a new working path, preserving
+// the repo ID (and with it the gate and run history) when the working
+// directory is renamed or moved on disk.
+func (d *DB) UpdateRepoWorkingPath(id, workingPath string) (*Repo, error) {
+	_, err := d.sql.Exec(
+		`UPDATE repos SET working_path = ? WHERE id = ?`,
+		workingPath, id,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("update repo working path: %w", err)
+	}
+	return d.GetRepo(id)
+}
+
 // DeleteRepo deletes a repo by ID (cascade deletes runs and steps).
 func (d *DB) DeleteRepo(id string) error {
 	_, err := d.sql.Exec(`DELETE FROM repos WHERE id = ?`, id)

--- a/internal/e2e/init_test.go
+++ b/internal/e2e/init_test.go
@@ -55,6 +55,50 @@ func TestInitIsIdempotent(t *testing.T) {
 	}
 }
 
+// TestInitRepoRename proves that a user who renames or moves their repo
+// directory can re-run `init` from the new location and get their existing
+// gate back, instead of the historical failure:
+//
+//	init: add remote: remote "no-mistakes" already exists with url "..."
+//
+// The test name is deliberately short: it becomes part of t.TempDir(), which
+// hosts NM_HOME, and the daemon's Unix socket path under it must stay within
+// the OS socket path limit (104 bytes on macOS).
+func TestInitRepoRename(t *testing.T) {
+	h := NewHarness(t, SetupOpts{Agent: "claude"})
+	ctx := context.Background()
+
+	first, err := h.RunInDir(h.WorkDir, "init")
+	if err != nil {
+		t.Fatalf("first init: %v\n%s", err, first)
+	}
+	gateURLOut, err := h.runGit(ctx, h.WorkDir, "remote", "get-url", "no-mistakes")
+	if err != nil {
+		t.Fatalf("get gate url: %v\n%s", err, gateURLOut)
+	}
+	gateURL := strings.TrimSpace(string(gateURLOut))
+
+	renamed := filepath.Join(filepath.Dir(h.WorkDir), "work-renamed")
+	if err := os.Rename(h.WorkDir, renamed); err != nil {
+		t.Fatalf("rename work dir: %v", err)
+	}
+
+	second, err := h.RunInDir(renamed, "init")
+	if err != nil {
+		t.Fatalf("init after rename should succeed: %v\n%s", err, second)
+	}
+	if !strings.Contains(second, "already initialized") {
+		t.Errorf("init after rename should report an existing gate, got:\n%s", second)
+	}
+
+	// The repo must be reattached to the same gate, not a new one.
+	if out, err := h.runGit(ctx, renamed, "remote", "get-url", "no-mistakes"); err != nil {
+		t.Fatalf("no-mistakes remote missing after rename re-init: %v\n%s", err, out)
+	} else if url := strings.TrimSpace(string(out)); url != gateURL {
+		t.Errorf("gate url after rename = %q, want %q", url, gateURL)
+	}
+}
+
 func TestInitRollsBackWhenDaemonStartFails(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows IPC does not use Unix socket path limits")

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/git"
@@ -30,9 +31,11 @@ func repoID(absPath string) string {
 //
 // Init is idempotent: re-running it on an already-initialized repo repairs and
 // refreshes the gate (for example installing a newer hook, picking up hook-path
-// isolation, or restoring a missing remote) instead of failing. The returned
-// bool reports whether a new gate was created (true) or an existing one was
-// refreshed (false).
+// isolation, or restoring a missing remote) instead of failing. This includes
+// a working directory that was renamed or moved since the gate was created:
+// the gate identified by the leftover no-mistakes remote is reattached at the
+// new path, preserving its run history. The returned bool reports whether a
+// new gate was created (true) or an existing one was refreshed (false).
 func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Repo, bool, error) {
 	// Normalize worktrees back to the main repo root so one repo record works
 	// from either the main checkout or any attached worktree.
@@ -48,6 +51,15 @@ func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Re
 	if err != nil {
 		return nil, false, fmt.Errorf("check existing: %w", err)
 	}
+	if existing == nil {
+		// No record at this path, but the repo may have been moved or renamed
+		// after init; if so, reattach its existing gate instead of failing on
+		// the leftover remote.
+		existing, err = reattachRelocatedRepo(ctx, d, p, absRoot)
+		if err != nil {
+			return nil, false, err
+		}
+	}
 
 	// Read origin URL.
 	upstreamURL, err := git.GetRemoteURL(ctx, absRoot, "origin")
@@ -62,7 +74,7 @@ func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Re
 	bareDir := p.RepoDir(id)
 
 	// Provision (or repair) the on-disk gate. This is idempotent.
-	if err := provisionGate(ctx, bareDir, absRoot, upstreamURL, existing != nil); err != nil {
+	if err := provisionGate(ctx, bareDir, absRoot, upstreamURL, p.ReposDir(), existing != nil); err != nil {
 		// Only tear down a gate we created in this call; never destroy an
 		// already-initialized gate when a repair pass fails.
 		if existing == nil {
@@ -103,7 +115,7 @@ func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Re
 // its push/hook configuration, hook-path isolation, and the git remotes wiring
 // the working repo to the gate and the gate to its upstream. Every step is
 // idempotent so this doubles as the repair path for re-running init.
-func provisionGate(ctx context.Context, bareDir, absRoot, upstreamURL string, refresh bool) error {
+func provisionGate(ctx context.Context, bareDir, absRoot, upstreamURL, reposDir string, refresh bool) error {
 	// Create the bare repo. git init --bare is a no-op on an existing one.
 	if err := git.InitBare(ctx, bareDir); err != nil {
 		return fmt.Errorf("create bare repo: %w", err)
@@ -129,14 +141,14 @@ func provisionGate(ctx context.Context, bareDir, absRoot, upstreamURL string, re
 		return fmt.Errorf("add gate origin remote: %w", err)
 	}
 
-	if err := ensureWorkingRemote(ctx, absRoot, bareDir, refresh); err != nil {
+	if err := ensureWorkingRemote(ctx, absRoot, bareDir, reposDir, refresh); err != nil {
 		return fmt.Errorf("add remote: %w", err)
 	}
 
 	return nil
 }
 
-func ensureWorkingRemote(ctx context.Context, absRoot, bareDir string, refresh bool) error {
+func ensureWorkingRemote(ctx context.Context, absRoot, bareDir, reposDir string, refresh bool) error {
 	if refresh {
 		return git.EnsureRemote(ctx, absRoot, RemoteName, bareDir)
 	}
@@ -147,7 +159,50 @@ func ensureWorkingRemote(ctx context.Context, absRoot, bareDir string, refresh b
 	if existingURL == bareDir {
 		return nil
 	}
+	// A leftover remote pointing into our own repos dir is stale gate wiring
+	// (e.g. the working directory was copied, or its gate was half-ejected);
+	// repoint it. Anything else is a user-managed remote we must not touch.
+	if filepath.Dir(existingURL) == reposDir {
+		return git.EnsureRemote(ctx, absRoot, RemoteName, bareDir)
+	}
 	return fmt.Errorf("remote %q already exists with url %q", RemoteName, existingURL)
+}
+
+// reattachRelocatedRepo detects a working directory that was renamed or moved
+// after init: it carries a no-mistakes remote pointing at a gate in our repos
+// dir, but its repo record references the old path. When the old path no
+// longer exists, the record is migrated to the new path so the existing gate
+// and its run history are reattached. It returns nil when the repo should be
+// treated as a fresh init instead: no gate remote, an orphan gate with no
+// record, or a copy whose original still exists on disk.
+func reattachRelocatedRepo(ctx context.Context, d *db.DB, p *paths.Paths, absRoot string) (*db.Repo, error) {
+	remoteURL, err := git.GetRemoteURL(ctx, absRoot, RemoteName)
+	if err != nil {
+		return nil, nil
+	}
+	id := strings.TrimSuffix(filepath.Base(remoteURL), ".git")
+	if p.RepoDir(id) != remoteURL {
+		// Not one of our gate paths; fresh init decides what to do with it.
+		return nil, nil
+	}
+	repo, err := d.GetRepo(id)
+	if err != nil {
+		return nil, fmt.Errorf("look up relocated repo: %w", err)
+	}
+	if repo == nil {
+		return nil, nil
+	}
+	if _, err := os.Stat(repo.WorkingPath); err == nil {
+		// The recorded checkout still exists, so absRoot is a copy of it, not
+		// a move; the copy gets its own gate.
+		return nil, nil
+	}
+	migrated, err := d.UpdateRepoWorkingPath(id, absRoot)
+	if err != nil {
+		return nil, fmt.Errorf("migrate repo working path: %w", err)
+	}
+	slog.Info("gate reattached after working dir move", "repo_id", id, "old_path", repo.WorkingPath, "new_path", absRoot)
+	return migrated, nil
 }
 
 // Eject removes the no-mistakes gate from the repo at workDir.

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -375,6 +375,174 @@ func TestInitRepairsBrokenGate(t *testing.T) {
 	}
 }
 
+// TestInitReattachesGateAfterWorkingDirRename verifies that renaming or moving
+// a working directory does not break init idempotency: the leftover no-mistakes
+// remote identifies the existing gate, and re-running init from the new
+// location reattaches it (same repo ID, same bare repo, run history intact)
+// instead of failing with "remote already exists".
+func TestInitReattachesGateAfterWorkingDirRename(t *testing.T) {
+	workDir := setupTestRepo(t)
+	nmRoot := t.TempDir()
+	p := paths.WithRoot(nmRoot)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	d := openTestDB(t, p)
+	ctx := context.Background()
+
+	first, _, err := Init(ctx, d, p, workDir)
+	if err != nil {
+		t.Fatalf("first init: %v", err)
+	}
+	if _, err := d.InsertRun(first.ID, "feature", "headsha", "basesha"); err != nil {
+		t.Fatalf("insert run: %v", err)
+	}
+
+	renamed := filepath.Join(filepath.Dir(workDir), "renamed")
+	if err := os.Rename(workDir, renamed); err != nil {
+		t.Fatalf("rename working dir: %v", err)
+	}
+
+	second, created, err := Init(ctx, d, p, renamed)
+	if err != nil {
+		t.Fatalf("init after rename should reattach the gate, got: %v", err)
+	}
+	if created {
+		t.Error("init after rename should report created=false")
+	}
+	if second.ID != first.ID {
+		t.Errorf("repo ID after rename = %q, want %q", second.ID, first.ID)
+	}
+	if second.WorkingPath != renamed {
+		t.Errorf("working path = %q, want %q", second.WorkingPath, renamed)
+	}
+
+	// The remote must still point at the original gate.
+	bareDir := p.RepoDir(first.ID)
+	if url, err := gitpkg.GetRemoteURL(ctx, renamed, RemoteName); err != nil {
+		t.Errorf("no-mistakes remote missing after reattach: %v", err)
+	} else if url != bareDir {
+		t.Errorf("remote url = %q, want %q", url, bareDir)
+	}
+
+	// The DB record must have migrated to the new path without duplicates.
+	dbRepo, err := d.GetRepoByPath(renamed)
+	if err != nil {
+		t.Fatalf("get repo by new path: %v", err)
+	}
+	if dbRepo == nil || dbRepo.ID != first.ID {
+		t.Fatalf("expected repo %q at new path, got %+v", first.ID, dbRepo)
+	}
+	if stale, err := d.GetRepoByPath(workDir); err != nil {
+		t.Fatalf("get repo by old path: %v", err)
+	} else if stale != nil {
+		t.Errorf("stale repo record remains at old path: %+v", stale)
+	}
+
+	// Run history must survive the reattach.
+	runs, err := d.GetRunsByRepo(first.ID)
+	if err != nil {
+		t.Fatalf("get runs: %v", err)
+	}
+	if len(runs) != 1 {
+		t.Errorf("runs after reattach = %d, want 1", len(runs))
+	}
+}
+
+// TestInitCreatesFreshGateForCopiedWorkingDir verifies that when a working
+// directory is copied (the original still exists), init treats the copy as a
+// new repo: it gets its own gate and the copied no-mistakes remote is
+// repointed, while the original repo's gate is left untouched.
+func TestInitCreatesFreshGateForCopiedWorkingDir(t *testing.T) {
+	workDir := setupTestRepo(t)
+	nmRoot := t.TempDir()
+	p := paths.WithRoot(nmRoot)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	d := openTestDB(t, p)
+	ctx := context.Background()
+
+	first, _, err := Init(ctx, d, p, workDir)
+	if err != nil {
+		t.Fatalf("first init: %v", err)
+	}
+
+	copyDir := filepath.Join(filepath.Dir(workDir), "copy")
+	if out, err := exec.Command("cp", "-R", workDir, copyDir).CombinedOutput(); err != nil {
+		t.Fatalf("copy working dir: %v: %s", err, out)
+	}
+
+	second, created, err := Init(ctx, d, p, copyDir)
+	if err != nil {
+		t.Fatalf("init on copy should succeed, got: %v", err)
+	}
+	if !created {
+		t.Error("init on copy should report created=true")
+	}
+	if second.ID == first.ID {
+		t.Error("copy should get its own gate, not reuse the original's")
+	}
+
+	// The copy's remote must point at its own gate.
+	if url, err := gitpkg.GetRemoteURL(ctx, copyDir, RemoteName); err != nil {
+		t.Errorf("no-mistakes remote missing on copy: %v", err)
+	} else if url != p.RepoDir(second.ID) {
+		t.Errorf("copy remote url = %q, want %q", url, p.RepoDir(second.ID))
+	}
+
+	// The original must be untouched.
+	if url, err := gitpkg.GetRemoteURL(ctx, workDir, RemoteName); err != nil {
+		t.Errorf("original no-mistakes remote missing: %v", err)
+	} else if url != p.RepoDir(first.ID) {
+		t.Errorf("original remote url = %q, want %q", url, p.RepoDir(first.ID))
+	}
+	if dbRepo, err := d.GetRepoByPath(workDir); err != nil || dbRepo == nil || dbRepo.ID != first.ID {
+		t.Errorf("original repo record damaged: %+v, %v", dbRepo, err)
+	}
+}
+
+// TestInitRepointsOrphanGateRemoteOnFreshInit verifies that a leftover
+// no-mistakes remote pointing into our repos dir with no matching DB record
+// (a half-ejected gate) is repointed to the fresh gate instead of failing.
+func TestInitRepointsOrphanGateRemoteOnFreshInit(t *testing.T) {
+	workDir := setupTestRepo(t)
+	nmRoot := t.TempDir()
+	p := paths.WithRoot(nmRoot)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	d := openTestDB(t, p)
+	ctx := context.Background()
+
+	first, _, err := Init(ctx, d, p, workDir)
+	if err != nil {
+		t.Fatalf("first init: %v", err)
+	}
+	// Orphan the gate: drop the DB record, then move the working dir so the
+	// computed gate path no longer matches the leftover remote.
+	if err := d.DeleteRepo(first.ID); err != nil {
+		t.Fatalf("delete repo record: %v", err)
+	}
+	renamed := filepath.Join(filepath.Dir(workDir), "renamed")
+	if err := os.Rename(workDir, renamed); err != nil {
+		t.Fatalf("rename working dir: %v", err)
+	}
+
+	repo, created, err := Init(ctx, d, p, renamed)
+	if err != nil {
+		t.Fatalf("init with orphan remote should succeed, got: %v", err)
+	}
+	if !created {
+		t.Error("init with orphan remote should report created=true")
+	}
+	if url, err := gitpkg.GetRemoteURL(ctx, renamed, RemoteName); err != nil {
+		t.Errorf("no-mistakes remote missing: %v", err)
+	} else if url != p.RepoDir(repo.ID) {
+		t.Errorf("remote url = %q, want %q", url, p.RepoDir(repo.ID))
+	}
+}
+
 func TestInitDoesNotOverwriteExistingNoMistakesRemoteOnFreshInit(t *testing.T) {
 	workDir := setupTestRepo(t)
 	nmRoot := t.TempDir()


### PR DESCRIPTION
## Intent

Fix a reported idempotency bug in 'no-mistakes init': the user renamed a repo directory (firstpass -> m87) and re-running init at the new path failed with 'init: add remote: remote "no-mistakes" already exists with url .../repos/4063127faf49.git'. Root cause: the gate ID is a sha256 hash of the working dir's absolute path, so after a rename the leftover no-mistakes remote points at the old gate while the DB record still holds the old working_path; init treats the new path as a fresh init with a new ID and refuses to touch the existing remote. The user explicitly chose the 'reattach' design over 'always start fresh': when init finds a no-mistakes remote pointing at one of our own gate dirs and the recorded working path no longer exists on disk, it migrates the DB record to the new path (new db.UpdateRepoWorkingPath) and refreshes the existing gate, preserving the repo ID, bare repo, and run history. Deliberate decisions: (1) a copied working dir, where the recorded original path still exists, is treated as a new repo and gets its own fresh gate rather than stealing the original's; (2) a stale no-mistakes remote pointing into our own repos dir (e.g. after a copy or a half-ejected gate with no DB record) is repointed to the correct gate instead of erroring, since that namespace is ours; (3) a user-managed no-mistakes remote pointing anywhere else still fails with the same error as before, preserving the existing guard test. TDD was used: three new unit tests in internal/gate (rename reattach incl. run-history survival, copy gets fresh gate, orphan remote repoint) plus one new e2e test (TestInitRepoRename) that runs the real binary through init -> rename dir -> init. The e2e test name is deliberately short and its comment explains why: the test name becomes part of t.TempDir() which hosts NM_HOME, and the daemon's Unix socket path under it must stay within the ~104-byte macOS socket path limit - a longer name made the daemon fail to start. gofmt, make lint, go test -race ./..., and make e2e all pass.

## What Changed

- Updated `init` gate handling to reattach an existing no-mistakes remote when the recorded working path was renamed, preserving the gate repo ID, bare repository, and run history.
- Added database support and gate tests for renamed repos, copied working directories, orphan no-mistakes remotes, and existing user-managed remote protections.
- Documented the reattach behavior in the gate model, troubleshooting guide, CLI reference, and quick start docs.

## Risk Assessment

✅ Low: The change is narrowly scoped to init idempotency around renamed or copied working directories, preserves existing user-managed remote safeguards, and includes focused unit and e2e coverage in the diff.

## Testing

I inspected the target diff, ran the focused gate unit tests and the real e2e rename test, then manually exercised the CLI flow an end user would perform; the evidence transcript shows re-running `no-mistakes init` after renaming the repo refreshes the existing gate with the same gate ID and status now points at the renamed path. Transient temp directories/build outputs were removed, and only the requested evidence file remains untracked.

<details>
<summary>Evidence: CLI transcript: init after repo rename reattaches existing gate</summary>

Source: [CLI transcript: init after repo rename reattaches existing gate](https://github.com/kunchenguid/no-mistakes/blob/433c24cd4bba711ede550e5eb8345793da38027d/.no-mistakes/evidence/fix/init-reattach-renamed-repo/init-rename-reattach-transcript.txt)

```text
Shows first init creating gate `eda0babc26f2`, `mv firstpass m87`, second init reporting `Gate already initialized (refreshed)`, the same `no-mistakes` remote/gate ID after rename, and `no-mistakes status` reporting the renamed repo path.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --stat 2419b8c30a43c803d763cd67dde734403f78cb6a..d2cba33a08f5447ad9420f18ed76e7ee6bc1559b`
- `go test ./internal/gate -run 'TestInit(ReattachesGateAfterWorkingDirRename|CreatesFreshGateForCopiedWorkingDir|RepointsOrphanGateRemoteOnFreshInit|DoesNotOverwriteExistingNoMistakesRemoteOnFreshInit)$' -count=1`
- `go test -tags=e2e ./internal/e2e -run '^TestInitRepoRename$' -count=1`
- <code>Manual CLI evidence run: built `./cmd/no-mistakes` into a short in-worktree temp dir, initialized a real git repo, ran `no-mistakes init`, renamed `firstpass` to `m87`, reran `no-mistakes init`, compared the `no-mistakes` remote URL/gate ID, captured `no-mistakes status`, then removed the temp repo/build/NM_HOME directory.</code>
- <code>Cleanup checks: verified no `.x.*` transient directories remained and stopped the leftover test daemon process from the manual evidence run.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
