### PR TITLE
fix(cli): clarify pipeline-owned finding fixes

### DIFF
--- a/.agents/skills/no-mistakes/SKILL.md
+++ b/.agents/skills/no-mistakes/SKILL.md
@@ -93,7 +93,8 @@ Run the pipeline and decide on its findings as they come up:
    Read its `findings` table. Each finding has an `id`, `severity`,
    `file`, `description`, and an `action` that tells you how the
    pipeline classified it:
-   - `auto-fix` - a mechanical, low-risk fix you can safely make yourself.
+   - `auto-fix` - mechanical and low-risk; you can authorize the fix on
+     your own judgment by responding with `--action fix`.
    - `no-op` - informational only; nothing to do.
    - `ask-user` - the finding challenges the user's deliberate intent or
      touches product behavior. This is a call only the user can make - see
@@ -110,6 +111,11 @@ Run the pipeline and decide on its findings as they come up:
    # skip this step
    no-mistakes axi respond --action skip
    ```
+   While a run is active, never fix findings by editing the code yourself -
+   the pipeline owns both the findings and the fixes. Your job at a gate is to
+   decide and respond; `--action fix` has the pipeline apply the fix and
+   re-review the result.
+
     Each `respond` blocks until the next `gate:`, `checks-passed` decision point, or final outcome.
 
     Two extra flags are available on `respond` when you need them:
@@ -142,7 +148,8 @@ blocking on the human merge. Never poll or re-run waiting for the merge yourself
 ## Escalate `ask-user` findings
 
 A gate whose findings are all `auto-fix` or `no-op` is safe to drive on your
-own judgment: fix or approve as appropriate. But a finding marked
+own judgment: respond with `--action fix` or `--action approve` as
+appropriate. But a finding marked
 `ask-user` is a decision that belongs to the user, not you - the pipeline
 flagged it because it challenges their deliberate intent or changes product
 behavior. Do not approve, fix, or skip it on your own. Instead, stop and bring
@@ -196,8 +203,10 @@ help[2]:
   no-mistakes axi respond --action approve
 ```
 
-Read the `action` column per row: drive `r1` (auto-fix) yourself, but stop
-and escalate `r2` (ask-user) to the user before responding. A final state
+Read the `action` column per row: decide `r1` (auto-fix) on your own
+judgment - `respond --action fix --findings r1` hands it to the pipeline to
+fix - but stop and escalate `r2` (ask-user) to the user before responding. A
+final state
 instead shows `outcome: <checks-passed|passed|failed|cancelled>` with no
 `findings` table. Field names and exact columns can vary by step and version,
 so read the actual `findings` header rather than assuming this layout.

--- a/.agents/skills/no-mistakes/SKILL.md
+++ b/.agents/skills/no-mistakes/SKILL.md
@@ -105,7 +105,7 @@ Run the pipeline and decide on its findings as they come up:
    # accept the step as-is and continue
    no-mistakes axi respond --action approve
 
-   # have the agent fix specific findings, then continue
+   # have the pipeline fix specific findings, then continue
    no-mistakes axi respond --action fix --findings <id1,id2> --instructions "<optional guidance>"
 
    # skip this step

--- a/.no-mistakes/evidence/fix/pipeline-owns-fixes/axi-status-gate-output.txt
+++ b/.no-mistakes/evidence/fix/pipeline-owns-fixes/axi-status-gate-output.txt
@@ -1,0 +1,15 @@
+run:
+  id: "01KTQXTYWB68KZ482Q5QETK3PT"
+  branch: fix/pipeline-owns-fixes
+  status: running
+  head: 2efbd7a2
+  findings: 1 auto-fix
+  steps[1]{step,status,findings,duration_ms}:
+    review,awaiting_approval,1,0
+gate:
+  step: review
+  status: awaiting_approval
+  summary: 1 wording issue for the pipeline to fix
+  findings[1]{id,severity,file,action,description}:
+    review-1,warning,internal/cli/axi_render.go,auto-fix,Gate wording must say pipeline applies fixes during active runs
+help[4]: Run `no-mistakes axi respond --action approve` to accept this step and continue,Run `no-mistakes axi respond --action fix --findings <ids>` to have the pipeline fix the selected findings (do not edit files yourself),Run `no-mistakes axi respond --action skip` to skip this step,Run `no-mistakes axi logs --step review --full` to read the full step log

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 - **Non-blocking** - the pipeline runs in an isolated worktree without disrupting your work.
 - **Agent-agnostic** - `claude`, `codex`, `rovodev`, `opencode`, `pi`, or `acp:<target>` via `acpx`.
-- **Agent-native** - `/no-mistakes` lets your coding agent do a task and gate it, or gate existing committed work: it runs the pipeline, applies the safe fixes, and escalates the rest to you.
+- **Agent-native** - `/no-mistakes` lets your coding agent do a task and gate it, or gate existing committed work: it runs the pipeline, has the pipeline apply safe fixes, and escalates the rest to you.
 - **Human stays in charge** - auto-fix or review findings, your call.
 - **Clean PRs by default** - push, open PR, watch CI, and auto-fix failures in one shot.
 
@@ -100,7 +100,7 @@ Every change runs through the same pipeline. Pick the entry point that fits how 
 
 - **`git push no-mistakes`** - the explicit Git path. Push a committed branch to the gate remote instead of `origin`.
 - **`no-mistakes`** - the TUI. Run it after making changes (no commit needed) and a wizard walks you through creating a branch, committing, and pushing through the gate, then attaches to the run. `no-mistakes -y` does all of that automatically.
-- **`/no-mistakes`** - the agent skill. Tell the coding agent to do a task and gate it with `/no-mistakes <task>`, or use bare `/no-mistakes` to gate existing committed work. It runs the pipeline, applies the safe fixes itself, and stops to ask you about anything that needs a human call.
+- **`/no-mistakes`** - the agent skill. Tell the coding agent to do a task and gate it with `/no-mistakes <task>`, or use bare `/no-mistakes` to gate existing committed work. It runs the pipeline, has the pipeline apply safe fixes, and stops to ask you about anything that needs a human call.
 
 `no-mistakes init` installs the `/no-mistakes` skill for Claude Code and other agents. Under the hood the skill drives `no-mistakes axi`, a non-interactive TOON interface to the same approval flow.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -34,7 +34,7 @@
 
 - **不阻塞** —— 流水线在隔离的 worktree 里跑，不打断你手头的工作。
 - **不挑 agent** —— 支持 `claude`、`codex`、`rovodev`、`opencode`、`pi`，或通过 `acpx` 用 `acp:<target>`。
-- **agent 原生** —— `/no-mistakes` 既能让编码 agent 完成一个任务再过网关，也能直接为已提交的工作过网关：它跑完流水线、应用安全的修复，剩下的升级给你。
+- **agent 原生** —— `/no-mistakes` 既能让编码 agent 完成一个任务再过网关，也能直接为已提交的工作过网关：它跑完流水线、让流水线应用安全的修复，剩下的升级给你。
 - **人始终说了算** —— 自动修复，还是逐条审查 findings，你决定。
 - **默认就是干净 PR** —— 推送、开 PR、盯 CI、自动修复失败，一气呵成。
 
@@ -100,7 +100,7 @@ $ no-mistakes
 
 - **`git push no-mistakes`** —— 显式的 Git 路径。把已提交的分支推给网关 remote，而不是 `origin`。
 - **`no-mistakes`** —— TUI。改完之后运行它（无需先提交），向导会带你建分支、提交、推过网关，然后挂到这次运行上。`no-mistakes -y` 会把这一切自动做完。
-- **`/no-mistakes`** —— agent skill。用 `/no-mistakes <task>` 让编码 agent 完成一个任务再过网关，或用裸 `/no-mistakes` 为已提交的工作过网关。它跑完流水线、自己应用安全的修复，并在任何需要人来拍板的地方停下来问你。
+- **`/no-mistakes`** —— agent skill。用 `/no-mistakes <task>` 让编码 agent 完成一个任务再过网关，或用裸 `/no-mistakes` 为已提交的工作过网关。它跑完流水线、让流水线应用安全的修复，并在任何需要人来拍板的地方停下来问你。
 
 `no-mistakes init` 会为 Claude Code 及其他 agent 安装 `/no-mistakes` skill。底层上这个 skill 驱动的是 `no-mistakes axi` —— 同一套审批流程的非交互式 TOON 接口。
 

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -116,6 +116,7 @@ If the repo is on the default branch or has uncommitted changes, direct `axi run
 Approval gates are exposed as `gate:` objects with finding IDs, severities, files, actions, descriptions, and help commands for `no-mistakes axi respond`.
 An agent should resolve `action: auto-fix` findings on its own judgment, ignore `action: no-op` findings when approving, and stop on `action: ask-user` findings unless it is running with explicit `--yes` consent.
 When it stops for `ask-user`, it should relay each finding's ID, file, and full description to the user before choosing `approve`, `fix`, or `skip`.
+Resolving a finding always means responding with `no-mistakes axi respond --action fix`, which has the pipeline apply the fix and re-review it - the agent must not edit the code itself while a run is active.
 Successful outputs can be `outcome: passed` for a completed run or `outcome: checks-passed` when CI has passed and the daemon is still monitoring the unmerged PR for humans.
 
 ## Binary resolution

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -73,7 +73,7 @@ It is the user's goal or request, and no-mistakes uses it verbatim instead of tr
 Err on the side of completeness: include the goal, important decisions and tradeoffs, constraints or approaches ruled in or out, and explicit requests that might otherwise look surprising in the diff.
 When starting a new run, `axi run` refuses the default branch and uncommitted working trees with actionable errors instead of auto-branching or auto-committing.
 Reattaching to an in-flight run does not require `--intent`.
-With `--yes`, `axi run` treats both `action: auto-fix` and `action: ask-user` findings as standing consent to fix them by selecting every finding, then accepts the resulting fix review.
+With `--yes`, `axi run` treats both `action: auto-fix` and `action: ask-user` findings as standing consent for the pipeline to fix them by selecting every finding, then accepts the resulting fix review.
 Gates with no findings or only `action: no-op` findings are approved as-is, and each step is fixed at most once so unresolved findings do not loop forever.
 Without `--yes`, an agent driving `axi run` should stop when a gate contains `action: ask-user` findings and relay each finding's ID, file, and full description to the user before responding.
 When the CI step is still monitoring an open PR and checks are green, `axi run` exits successfully with `outcome: checks-passed` instead of waiting for a human merge.
@@ -99,7 +99,7 @@ no-mistakes axi respond --action skip
 | `--add-finding` | `string` | (none) | JSON finding object to add and fix |
 | `-y`, `--yes` | `bool` | `false` | Auto-resolve every subsequent gate until a decision point or outcome |
 
-After the explicit response, `--yes` uses the same auto-resolution behavior as `axi run --yes`: fix `auto-fix` and `ask-user` findings once, approve the fix review, approve gates that only contain non-actionable `no-op` findings, and stop at `outcome: checks-passed` when CI is green but the PR still needs a human merge.
+After the explicit response, `--yes` uses the same auto-resolution behavior as `axi run --yes`: have the pipeline fix `auto-fix` and `ask-user` findings once, approve the fix review, approve gates that only contain non-actionable `no-op` findings, and stop at `outcome: checks-passed` when CI is green but the PR still needs a human merge.
 
 ## no-mistakes axi status
 

--- a/internal/cli/axi_render.go
+++ b/internal/cli/axi_render.go
@@ -244,7 +244,7 @@ func gateFields(gate stepView) []toon.Field {
 		{Key: "gate", Value: toon.NewObject(gfields...)},
 		{Key: "help", Value: []string{
 			"Run `no-mistakes axi respond --action approve` to accept this step and continue",
-			"Run `no-mistakes axi respond --action fix --findings <ids>` to fix selected findings",
+			"Run `no-mistakes axi respond --action fix --findings <ids>` to have the pipeline fix the selected findings (do not edit files yourself)",
 			"Run `no-mistakes axi respond --action skip` to skip this step",
 			fmt.Sprintf("Run `no-mistakes axi logs --step %s --full` to read the full step log", gate.Name),
 		}},

--- a/internal/cli/axi_test.go
+++ b/internal/cli/axi_test.go
@@ -125,6 +125,7 @@ func TestWriteGateShape(t *testing.T) {
 		"  findings[1]{id,severity,file,action,description}:\n",
 		`    review-1,warning,main.go,ask-user,"calls os.Exit, leaks fd"`,
 		"no-mistakes axi respond --action approve",
+		"to have the pipeline fix the selected findings (do not edit files yourself)",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("gate missing %q in:\n%s", want, out)

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -136,7 +136,7 @@ Run the pipeline and decide on its findings as they come up:
    # accept the step as-is and continue
    no-mistakes axi respond --action approve
 
-   # have the agent fix specific findings, then continue
+   # have the pipeline fix specific findings, then continue
    no-mistakes axi respond --action fix --findings <id1,id2> --instructions "<optional guidance>"
 
    # skip this step

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -124,7 +124,8 @@ Run the pipeline and decide on its findings as they come up:
    Read its ` + "`findings`" + ` table. Each finding has an ` + "`id`" + `, ` + "`severity`" + `,
    ` + "`file`" + `, ` + "`description`" + `, and an ` + "`action`" + ` that tells you how the
    pipeline classified it:
-   - ` + "`auto-fix`" + ` - a mechanical, low-risk fix you can safely make yourself.
+   - ` + "`auto-fix`" + ` - mechanical and low-risk; you can authorize the fix on
+     your own judgment by responding with ` + "`--action fix`" + `.
    - ` + "`no-op`" + ` - informational only; nothing to do.
    - ` + "`ask-user`" + ` - the finding challenges the user's deliberate intent or
      touches product behavior. This is a call only the user can make - see
@@ -141,6 +142,11 @@ Run the pipeline and decide on its findings as they come up:
    # skip this step
    no-mistakes axi respond --action skip
    ` + "```" + `
+   While a run is active, never fix findings by editing the code yourself -
+   the pipeline owns both the findings and the fixes. Your job at a gate is to
+   decide and respond; ` + "`--action fix`" + ` has the pipeline apply the fix and
+   re-review the result.
+
     Each ` + "`respond`" + ` blocks until the next ` + "`gate:`" + `, ` + "`checks-passed`" + ` decision point, or final outcome.
 
     Two extra flags are available on ` + "`respond`" + ` when you need them:
@@ -173,7 +179,8 @@ blocking on the human merge. Never poll or re-run waiting for the merge yourself
 ## Escalate ` + "`ask-user`" + ` findings
 
 A gate whose findings are all ` + "`auto-fix`" + ` or ` + "`no-op`" + ` is safe to drive on your
-own judgment: fix or approve as appropriate. But a finding marked
+own judgment: respond with ` + "`--action fix`" + ` or ` + "`--action approve`" + ` as
+appropriate. But a finding marked
 ` + "`ask-user`" + ` is a decision that belongs to the user, not you - the pipeline
 flagged it because it challenges their deliberate intent or changes product
 behavior. Do not approve, fix, or skip it on your own. Instead, stop and bring
@@ -227,8 +234,10 @@ help[2]:
   no-mistakes axi respond --action approve
 ` + "```" + `
 
-Read the ` + "`action`" + ` column per row: drive ` + "`r1`" + ` (auto-fix) yourself, but stop
-and escalate ` + "`r2`" + ` (ask-user) to the user before responding. A final state
+Read the ` + "`action`" + ` column per row: decide ` + "`r1`" + ` (auto-fix) on your own
+judgment - ` + "`respond --action fix --findings r1`" + ` hands it to the pipeline to
+fix - but stop and escalate ` + "`r2`" + ` (ask-user) to the user before responding. A
+final state
 instead shows ` + "`outcome: <checks-passed|passed|failed|cancelled>`" + ` with no
 ` + "`findings`" + ` table. Field names and exact columns can vary by step and version,
 so read the actual ` + "`findings`" + ` header rather than assuming this layout.

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -93,7 +93,8 @@ Run the pipeline and decide on its findings as they come up:
    Read its `findings` table. Each finding has an `id`, `severity`,
    `file`, `description`, and an `action` that tells you how the
    pipeline classified it:
-   - `auto-fix` - a mechanical, low-risk fix you can safely make yourself.
+   - `auto-fix` - mechanical and low-risk; you can authorize the fix on
+     your own judgment by responding with `--action fix`.
    - `no-op` - informational only; nothing to do.
    - `ask-user` - the finding challenges the user's deliberate intent or
      touches product behavior. This is a call only the user can make - see
@@ -110,6 +111,11 @@ Run the pipeline and decide on its findings as they come up:
    # skip this step
    no-mistakes axi respond --action skip
    ```
+   While a run is active, never fix findings by editing the code yourself -
+   the pipeline owns both the findings and the fixes. Your job at a gate is to
+   decide and respond; `--action fix` has the pipeline apply the fix and
+   re-review the result.
+
     Each `respond` blocks until the next `gate:`, `checks-passed` decision point, or final outcome.
 
     Two extra flags are available on `respond` when you need them:
@@ -142,7 +148,8 @@ blocking on the human merge. Never poll or re-run waiting for the merge yourself
 ## Escalate `ask-user` findings
 
 A gate whose findings are all `auto-fix` or `no-op` is safe to drive on your
-own judgment: fix or approve as appropriate. But a finding marked
+own judgment: respond with `--action fix` or `--action approve` as
+appropriate. But a finding marked
 `ask-user` is a decision that belongs to the user, not you - the pipeline
 flagged it because it challenges their deliberate intent or changes product
 behavior. Do not approve, fix, or skip it on your own. Instead, stop and bring
@@ -196,8 +203,10 @@ help[2]:
   no-mistakes axi respond --action approve
 ```
 
-Read the `action` column per row: drive `r1` (auto-fix) yourself, but stop
-and escalate `r2` (ask-user) to the user before responding. A final state
+Read the `action` column per row: decide `r1` (auto-fix) on your own
+judgment - `respond --action fix --findings r1` hands it to the pipeline to
+fix - but stop and escalate `r2` (ask-user) to the user before responding. A
+final state
 instead shows `outcome: <checks-passed|passed|failed|cancelled>` with no
 `findings` table. Field names and exact columns can vary by step and version,
 so read the actual `findings` header rather than assuming this layout.

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -105,7 +105,7 @@ Run the pipeline and decide on its findings as they come up:
    # accept the step as-is and continue
    no-mistakes axi respond --action approve
 
-   # have the agent fix specific findings, then continue
+   # have the pipeline fix specific findings, then continue
    no-mistakes axi respond --action fix --findings <id1,id2> --instructions "<optional guidance>"
 
    # skip this step


### PR DESCRIPTION
## Intent

Kun asked whether no-mistakes makes it clear to driving agents that they should not fix pipeline findings by editing code themselves mid-run, but should instead respond with a decision and let the pipeline handle the fixes. The audit found the structure already funnels agents toward axi respond, but the wording in three places undercut it: the skill described auto-fix findings as 'a mechanical, low-risk fix you can safely make yourself', the example walkthrough said 'drive r1 (auto-fix) yourself', and the gate help line said 'to fix selected findings' without saying who fixes. Kun confirmed the design intent: the agent must NOT do fixes in the middle of a pipeline run; the pipeline owns both findings and fixes. So this change rewords agent-facing text only, with no behavior change: (1) internal/skill/skill.go - auto-fix is now 'you can authorize the fix on your own judgment by responding with --action fix', plus a new explicit rule after the response options that while a run is active the agent must never fix findings by editing code itself, and matching rewording in the escalate section and the example walkthrough; (2) internal/cli/axi_render.go - the gate help line now reads 'to have the pipeline fix the selected findings (do not edit files yourself)', because mid-run agents may not have the skill in context; (3) docs/src/content/docs/guides/agents.md - one added sentence keeping the human-facing spec in sync. The committed skills/no-mistakes/SKILL.md and .agents/skills/no-mistakes/SKILL.md were regenerated/synced from the skill.go source of truth via make skill (both copies were byte-identical at HEAD, so the installed copy was updated to match). TestWriteGateShape was extended TDD-style to assert the new help-line wording. The auto-fix semantics deliberately remain 'agent may authorize without asking the user' - only the question of who applies the fix changed. The post-run failed-outcome guidance (agent fixes and commits on the branch after the run ends) is intentionally unchanged; the no-direct-edits rule applies only while a run is active. Verified with gofmt, make lint (skill drift check), go test -race ./..., and make e2e, all green.

## What Changed

- Clarifies agent-facing CLI gate output so active runs direct agents to have the pipeline fix selected findings instead of editing files themselves.
- Updates the no-mistakes skill source and synced skill copies to state that agents may authorize fixes with `--action fix`, while the pipeline owns applying fixes during an active run.
- Aligns README and docs wording with the pipeline-owned fix flow and adds test/evidence coverage for the updated AXI status gate text.

## Risk Assessment

✅ Low: The change is limited to agent-facing wording, generated documentation, and one assertion update, with no behavioral code changes beyond clarified help text.

## Testing

Targeted and package-level tests passed, and the evidence-producing CLI check exercised the real `axi status` gate surface for an active run, showing `auto-fix` findings now instruct agents to have the pipeline fix selected findings and not edit files themselves; the temporary seeded NM_HOME and harness were removed, leaving only the intended transcript artifact.

<details>
<summary>Evidence: CLI gate output showing pipeline-owned fix wording</summary>

Source: [CLI gate output showing pipeline-owned fix wording](https://github.com/kunchenguid/no-mistakes/blob/ea1d7d13ee5eaaa916b3aab22ac9ed7566fe02d9/.no-mistakes/evidence/fix/pipeline-owns-fixes/axi-status-gate-output.txt)

```text
help[4]: Run `no-mistakes axi respond --action approve` to accept this step and continue,Run `no-mistakes axi respond --action fix --findings <ids>` to have the pipeline fix the selected findings (do not edit files yourself),Run `no-mistakes axi respond --action skip` to skip this step,Run `no-mistakes axi logs --step review --full` to read the full step log
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `internal/skill/skill.go:139` - The command example still says &#34;have the agent fix specific findings&#34;, so regenerated installed skills keep an agent-facing instruction that conflicts with the new rule that the pipeline owns fixes while a run is active. Reword this example to say the pipeline fixes the selected findings and regenerate the skill copies.

🔧 Fix: Clarify pipeline-owned finding fixes
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/cli -run '^TestWriteGateShape$' -count=1 -v`
- <code>Seeded a disposable active run in `NM_HOME=./.no-mistakes/evidence/fix/pipeline-owns-fixes/nm-home` and ran `env NM_HOME=./.no-mistakes/evidence/fix/pipeline-owns-fixes/nm-home go run ./cmd/no-mistakes axi status &gt; ./.no-mistakes/evidence/fix/pipeline-owns-fixes/axi-status-gate-output.txt` to capture the real CLI gate/help output</code>
- `go test ./internal/cli -count=1`
- `go test ./internal/skill -count=1`
- <code>Searched committed skill copies for `While a run is active, never fix findings by editing`, `you can authorize the fix on`, and `pipeline owns both the findings and the fixes`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
