### PR TITLE
feat(cli): report applied fixes in successful AXI output

### DIFF
--- a/.agents/skills/no-mistakes/SKILL.md
+++ b/.agents/skills/no-mistakes/SKILL.md
@@ -145,6 +145,13 @@ The CI step deliberately watches the PR until it is merged or closed, so
 `axi run` returns `checks-passed` the moment checks are green rather than
 blocking on the human merge. Never poll or re-run waiting for the merge yourself.
 
+On a successful outcome (`checks-passed` or `passed`), close the loop with the
+user: summarize what happened during the pipeline in a concise, easily readable
+format - what was validated and what was found. If the output includes a
+`fixes` table, the pipeline fixed findings your original change missed:
+acknowledge those misses and explicitly list each fix so the user can easily
+review them.
+
 ## Escalate `ask-user` findings
 
 A gate whose findings are all `auto-fix` or `no-op` is safe to drive on your

--- a/.no-mistakes/evidence/feat/axi-success-fix-reporting/axi-success-output.txt
+++ b/.no-mistakes/evidence/feat/axi-success-fix-reporting/axi-success-output.txt
@@ -1,0 +1,37 @@
+=== RUN   TestEvidenceAXISuccessFixReporting
+=== RUN   TestEvidenceAXISuccessFixReporting/checks-passed_with_fixes
+    axi_success_evidence_test.go:58: 
+        run:
+          id: run-1
+          branch: feature/axi-success-fix-reporting
+          status: running
+          head: 99a5b03f
+          pr: "https://github.com/kunchenguid/no-mistakes/pull/123"
+          findings: none
+          steps[3]{step,status,findings,duration_ms}:
+            review,completed,0,0
+            test,completed,0,0
+            ci,running,0,0
+        outcome: checks-passed
+        fixes[2]{step,summary}:
+          review,handle nil pointer in executor
+          test,fix applied (no summary recorded)
+        help[3]: "CI checks passed - the PR is ready. Ask the user to review and merge it: https://github.com/kunchenguid/no-mistakes/pull/123","Summarize this pipeline run for the user in a concise, easily readable format: what was validated and what was found.",The pipeline fixed findings the original change missed (see `fixes`) - acknowledge the misses and list each fix so the user can review them.
+=== RUN   TestEvidenceAXISuccessFixReporting/terminal_passed_without_fixes
+    axi_success_evidence_test.go:58: 
+        run:
+          id: run-2
+          branch: feature/axi-success-fix-reporting
+          status: completed
+          head: 99a5b03f
+          findings: none
+          steps[2]{step,status,findings,duration_ms}:
+            review,completed,0,0
+            ci,completed,0,0
+        outcome: passed
+        help[1]: "Summarize this pipeline run for the user in a concise, easily readable format: what was validated and what was found."
+--- PASS: TestEvidenceAXISuccessFixReporting (0.00s)
+    --- PASS: TestEvidenceAXISuccessFixReporting/checks-passed_with_fixes (0.00s)
+    --- PASS: TestEvidenceAXISuccessFixReporting/terminal_passed_without_fixes (0.00s)
+PASS
+ok  	github.com/kunchenguid/no-mistakes/internal/cli	0.313s

--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -56,7 +56,7 @@ That is a core design choice, not an implementation detail.
 6. If a step pauses, you can attach with the TUI or use `no-mistakes axi respond` to approve, fix, skip, or abort.
 7. After local checks pass, the push step forwards the branch upstream and the PR step creates or updates the pull request.
 8. The CI step keeps watching the open PR until it is merged or closed, and can auto-fix failures or merge conflicts when supported.
-   While it watches, the TUI and terminal title surface a `Checks passed` signal once checks are green and the PR is mergeable, and `no-mistakes axi` returns `outcome: checks-passed` so agents stop and ask you to review and merge it.
+   While it watches, the TUI and terminal title surface a `Checks passed` signal once checks are green and the PR is mergeable, and `no-mistakes axi` returns `outcome: checks-passed` with instructions to summarize the run and list any pipeline fixes, so agents stop and ask you to review and merge it.
 
 **Key design decisions:**
 

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -96,7 +96,8 @@ Re-run `no-mistakes init` in an already-initialized repo to refresh or reinstall
 The skill drives `no-mistakes axi`, a non-interactive command surface that prints TOON to stdout and progress to stderr.
 When CI is green but the PR is still open, `axi run` and `axi respond` return `outcome: checks-passed` with a help line pointing at the PR instead of waiting for a human merge.
 That is a successful agent stopping point: report that the PR is ready and ask the user to review and merge it.
-Successful outcomes also instruct the agent to summarize the run for the user, and include a `fixes` table listing every fix the pipeline applied, so the agent can acknowledge what it missed and the user can review each fix.
+Successful outcomes also instruct the agent to summarize the run for the user.
+When the pipeline applied fixes, successful outcomes include a `fixes` table listing each fix so the agent can acknowledge what it missed and the user can review them.
 
 In task-first mode, if the repo is on the default branch, the skill tells the agent to create a feature branch before committing because the gate validates committed history on a non-default branch.
 The agent should inspect `git status` before changing or committing anything, preserve unrelated pre-existing uncommitted changes, and commit only the changes that belong to the user's task.
@@ -118,7 +119,7 @@ Approval gates are exposed as `gate:` objects with finding IDs, severities, file
 An agent should resolve `action: auto-fix` findings on its own judgment, ignore `action: no-op` findings when approving, and stop on `action: ask-user` findings unless it is running with explicit `--yes` consent.
 When it stops for `ask-user`, it should relay each finding's ID, file, and full description to the user before choosing `approve`, `fix`, or `skip`.
 Resolving a finding always means responding with `no-mistakes axi respond --action fix`, which has the pipeline apply the fix and re-review it - the agent must not edit the code itself while a run is active.
-Successful outputs can be `outcome: passed` for a completed run or `outcome: checks-passed` when CI has passed and the daemon is still monitoring the unmerged PR for humans.
+Successful outputs can be `outcome: passed` for a completed run or `outcome: checks-passed` when CI has passed and the daemon is still monitoring the unmerged PR for humans, and may include a `fixes` table when the pipeline applied fixes.
 
 ## Binary resolution
 

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -96,6 +96,7 @@ Re-run `no-mistakes init` in an already-initialized repo to refresh or reinstall
 The skill drives `no-mistakes axi`, a non-interactive command surface that prints TOON to stdout and progress to stderr.
 When CI is green but the PR is still open, `axi run` and `axi respond` return `outcome: checks-passed` with a help line pointing at the PR instead of waiting for a human merge.
 That is a successful agent stopping point: report that the PR is ready and ask the user to review and merge it.
+Successful outcomes also instruct the agent to summarize the run for the user, and include a `fixes` table listing every fix the pipeline applied, so the agent can acknowledge what it missed and the user can review each fix.
 
 In task-first mode, if the repo is on the default branch, the skill tells the agent to create a feature branch before committing because the gate validates committed history on a non-default branch.
 The agent should inspect `git status` before changing or committing anything, preserve unrelated pre-existing uncommitted changes, and commit only the changes that belong to the user's task.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -78,6 +78,7 @@ Gates with no findings or only `action: no-op` findings are approved as-is, and 
 Without `--yes`, an agent driving `axi run` should stop when a gate contains `action: ask-user` findings and relay each finding's ID, file, and full description to the user before responding.
 When the CI step is still monitoring an open PR and checks are green, `axi run` exits successfully with `outcome: checks-passed` instead of waiting for a human merge.
 Treat that as the agent stopping point: ask the user to review and merge the PR from the `help` line.
+Successful outcomes (`checks-passed` and `passed`) also carry a `fixes` table listing each fix the pipeline applied, plus `help` instructions telling the agent to summarize the run and list those fixes for the user's review.
 
 ## no-mistakes axi respond
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -78,7 +78,8 @@ Gates with no findings or only `action: no-op` findings are approved as-is, and 
 Without `--yes`, an agent driving `axi run` should stop when a gate contains `action: ask-user` findings and relay each finding's ID, file, and full description to the user before responding.
 When the CI step is still monitoring an open PR and checks are green, `axi run` exits successfully with `outcome: checks-passed` instead of waiting for a human merge.
 Treat that as the agent stopping point: ask the user to review and merge the PR from the `help` line.
-Successful outcomes (`checks-passed` and `passed`) also carry a `fixes` table listing each fix the pipeline applied, plus `help` instructions telling the agent to summarize the run and list those fixes for the user's review.
+Successful outcomes (`checks-passed` and `passed`) also carry `help` instructions telling the agent to summarize the run.
+When the pipeline applied fixes, they include a `fixes` table and a `help` instruction to acknowledge the misses and list those fixes for the user's review.
 
 ## no-mistakes axi respond
 
@@ -101,6 +102,7 @@ no-mistakes axi respond --action skip
 | `-y`, `--yes` | `bool` | `false` | Auto-resolve every subsequent gate until a decision point or outcome |
 
 After the explicit response, `--yes` uses the same auto-resolution behavior as `axi run --yes`: have the pipeline fix `auto-fix` and `ask-user` findings once, approve the fix review, approve gates that only contain non-actionable `no-op` findings, and stop at `outcome: checks-passed` when CI is green but the PR still needs a human merge.
+The same successful-output reporting instructions apply to `axi respond` results.
 
 ## no-mistakes axi status
 

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -171,7 +171,7 @@ Monitors PR health after creation and auto-fixes CI failures. Mergeability polli
 - Polls provider CI status at increasing intervals: every 30s for the first 5 minutes, every 60s for 5-15 minutes, every 120s after that
 - Continues monitoring an open PR until it is merged, closed, declined, or times out, even after CI checks are currently healthy
 - On GitHub and GitLab, polls provider mergeability alongside CI checks while the PR remains open
-- While the PR stays open, the TUI and terminal title show `Checks passed` once checks are green and known mergeability is clear, and `no-mistakes axi` returns `outcome: checks-passed` so agents can ask the user to review and merge instead of waiting
+- While the PR stays open, the TUI and terminal title show `Checks passed` once checks are green and known mergeability is clear, and `no-mistakes axi` returns `outcome: checks-passed` with successful-output reporting instructions so agents can summarize the run, ask the user to review and merge, and list any pipeline fixes instead of waiting
 - The ready signal clears if checks start running again, new failures appear, provider state becomes uncertain, or the PR is merged, closed, or declined
 - Waits a 60s grace period before trusting empty results (CI checks may not have registered yet)
 - If CI failures or, on GitHub or GitLab, a merge conflict are already known while other checks are still pending: waits for all checks to finish before attempting an auto-fix

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -456,7 +456,9 @@ func sleepCtx(ctx context.Context, d time.Duration) error {
 // renderDriveResult prints the run snapshot plus one of: the active gate (exit
 // 0, a normal decision point), a checks-passed outcome (exit 0, CI is green and
 // the PR is ready for a human to merge), or the terminal outcome (exit 0 when
-// passed, exit 1 when blocked, failed, or cancelled).
+// passed, exit 1 when blocked, failed, or cancelled). Successful outcomes also
+// carry the fixes the pipeline applied and reporting instructions, so the agent
+// closes the loop with the user instead of stopping at "it passed".
 func renderDriveResult(cmd *cobra.Command, run *ipc.RunInfo, ciReady bool) error {
 	rv := runViewFromIPC(run)
 	fields := []toon.Field{runObjectField(rv)}
@@ -470,7 +472,9 @@ func renderDriveResult(cmd *cobra.Command, run *ipc.RunInfo, ciReady bool) error
 		if rv.PRURL != "" {
 			merge = fmt.Sprintf("CI checks passed - the PR is ready. Ask the user to review and merge it: %s", rv.PRURL)
 		}
-		fields = append(fields, toon.Field{Key: "help", Value: []string{merge}})
+		fixes := rv.fixRows()
+		fields = appendFixesField(fields, fixes)
+		fields = append(fields, toon.Field{Key: "help", Value: append([]string{merge}, successReportHelp(fixes)...)})
 		emitDoc(cmd, fields...)
 		return nil
 	}
@@ -485,15 +489,44 @@ func renderDriveResult(cmd *cobra.Command, run *ipc.RunInfo, ciReady bool) error
 	if run.Error != nil && *run.Error != "" {
 		fields = append(fields, toon.Field{Key: "error", Value: *run.Error})
 	}
+
+	if rv.Status == string(types.RunCompleted) {
+		fixes := rv.fixRows()
+		fields = appendFixesField(fields, fixes)
+		var help []string
+		if rv.PRURL != "" {
+			help = append(help, fmt.Sprintf("Open the PR: %s", rv.PRURL))
+		}
+		help = append(help, successReportHelp(fixes)...)
+		fields = append(fields, toon.Field{Key: "help", Value: help})
+		emitDoc(cmd, fields...)
+		return nil
+	}
+
 	if rv.PRURL != "" {
 		fields = append(fields, toon.Field{Key: "help", Value: []string{fmt.Sprintf("Open the PR: %s", rv.PRURL)}})
 	}
 	emitDoc(cmd, fields...)
-
-	if rv.Status == string(types.RunCompleted) {
-		return nil
-	}
 	return &exitError{code: 1}
+}
+
+// appendFixesField adds a fixes table when the pipeline applied any fixes.
+func appendFixesField(fields []toon.Field, fixes []fixRow) []toon.Field {
+	if len(fixes) == 0 {
+		return fields
+	}
+	return append(fields, toon.Field{Key: "fixes", Value: fixes})
+}
+
+// successReportHelp returns the reporting instructions for a successful
+// outcome: always summarize the run for the user, and when the pipeline
+// applied fixes, own the misses and list every fix for the user's review.
+func successReportHelp(fixes []fixRow) []string {
+	help := []string{"Summarize this pipeline run for the user in a concise, easily readable format: what was validated and what was found."}
+	if len(fixes) > 0 {
+		help = append(help, "The pipeline fixed findings the original change missed (see `fixes`) - acknowledge the misses and list each fix so the user can review them.")
+	}
+	return help
 }
 
 func newAxiRespondCmd() *cobra.Command {

--- a/internal/cli/axi_drive_test.go
+++ b/internal/cli/axi_drive_test.go
@@ -181,6 +181,7 @@ func TestRenderDriveResult_ChecksPassed(t *testing.T) {
 		"outcome: checks-passed",
 		"https://github.com/user/repo/pull/42",
 		"merge",
+		"Summarize this pipeline run for the user",
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("checks-passed output missing %q in:\n%s", want, got)
@@ -188,6 +189,50 @@ func TestRenderDriveResult_ChecksPassed(t *testing.T) {
 	}
 	if strings.Contains(got, "outcome: passed\n") {
 		t.Errorf("checks-passed must not report a terminal passed outcome:\n%s", got)
+	}
+	// No fixes were applied, so neither the fixes table nor the
+	// acknowledge-your-misses instruction should appear.
+	for _, reject := range []string{"fixes[", "acknowledge"} {
+		if strings.Contains(got, reject) {
+			t.Errorf("checks-passed output without fixes must not contain %q:\n%s", reject, got)
+		}
+	}
+}
+
+func TestRenderDriveResult_ChecksPassedWithFixes(t *testing.T) {
+	run := &ipc.RunInfo{
+		ID:      "run-1",
+		Branch:  "feature/x",
+		Status:  types.RunRunning,
+		HeadSHA: "abcdef1234567890",
+		PRURL:   strptr("https://github.com/user/repo/pull/42"),
+		Steps: []ipc.StepResultInfo{
+			{StepName: types.StepReview, Status: types.StepStatusCompleted, FixSummaries: []string{"handle nil pointer in executor"}},
+			{StepName: types.StepTest, Status: types.StepStatusCompleted, FixSummaries: []string{""}},
+			{StepName: types.StepCI, Status: types.StepStatusRunning},
+		},
+	}
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&out)
+
+	if err := renderDriveResult(cmd, run, true); err != nil {
+		t.Fatalf("checks-passed must exit 0, got error: %v", err)
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		"outcome: checks-passed",
+		"fixes[2]{step,summary}:",
+		"review,handle nil pointer in executor",
+		"test,fix applied (no summary recorded)",
+		"Summarize this pipeline run for the user",
+		"acknowledge the misses and list each fix so the user can review them",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("checks-passed output missing %q in:\n%s", want, got)
+		}
 	}
 }
 
@@ -205,7 +250,64 @@ func TestRenderDriveResult_TerminalPassedUnaffected(t *testing.T) {
 	if err := renderDriveResult(cmd, run, false); err != nil {
 		t.Fatalf("terminal passed must exit 0, got error: %v", err)
 	}
-	if got := out.String(); !strings.Contains(got, "outcome: passed") {
+	got := out.String()
+	if !strings.Contains(got, "outcome: passed") {
 		t.Errorf("expected terminal passed outcome, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Summarize this pipeline run for the user") {
+		t.Errorf("terminal passed output missing the summarize instruction:\n%s", got)
+	}
+}
+
+func TestRenderDriveResult_TerminalPassedWithFixes(t *testing.T) {
+	run := &ipc.RunInfo{
+		ID:     "run-1",
+		Branch: "feature/x",
+		Status: types.RunCompleted,
+		Steps: []ipc.StepResultInfo{
+			{StepName: types.StepLint, Status: types.StepStatusCompleted, FixSummaries: []string{"remove unused import"}},
+			{StepName: types.StepCI, Status: types.StepStatusCompleted},
+		},
+	}
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&out)
+
+	if err := renderDriveResult(cmd, run, false); err != nil {
+		t.Fatalf("terminal passed must exit 0, got error: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"outcome: passed",
+		"fixes[1]{step,summary}:",
+		"lint,remove unused import",
+		"acknowledge the misses and list each fix so the user can review them",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("terminal passed output missing %q in:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderDriveResult_FailedHasNoSummarizeInstruction(t *testing.T) {
+	run := &ipc.RunInfo{
+		ID:     "run-1",
+		Branch: "feature/x",
+		Status: types.RunFailed,
+		Steps: []ipc.StepResultInfo{
+			{StepName: types.StepTest, Status: types.StepStatusFailed, FixSummaries: []string{"partial fix"}},
+		},
+	}
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&out)
+
+	err := renderDriveResult(cmd, run, false)
+	if err == nil {
+		t.Fatal("failed outcome must exit non-zero")
+	}
+	got := out.String()
+	if strings.Contains(got, "Summarize this pipeline run for the user") {
+		t.Errorf("failed outcome must not carry the success summary instruction:\n%s", got)
 	}
 }

--- a/internal/cli/axi_render.go
+++ b/internal/cli/axi_render.go
@@ -47,6 +47,13 @@ type logRow struct {
 	Line string `toon:"line"`
 }
 
+// fixRow is one fix the pipeline applied: the step it ran under and the
+// agent's one-line summary of the change.
+type fixRow struct {
+	Step    string `toon:"step"`
+	Summary string `toon:"summary"`
+}
+
 // stepView is a render-ready view of a single pipeline step, decoupled from
 // whether it came from the daemon (ipc) or the local database.
 type stepView struct {
@@ -54,6 +61,7 @@ type stepView struct {
 	Status       string
 	DurationMS   int64
 	FindingsJSON string
+	FixSummaries []string
 }
 
 // runView is a render-ready view of a pipeline run.
@@ -77,7 +85,7 @@ func runViewFromIPC(r *ipc.RunInfo) runView {
 		rv.PRURL = *r.PRURL
 	}
 	for _, s := range r.Steps {
-		sv := stepView{Name: string(s.StepName), Status: string(s.Status)}
+		sv := stepView{Name: string(s.StepName), Status: string(s.Status), FixSummaries: s.FixSummaries}
 		if s.DurationMS != nil {
 			sv.DurationMS = *s.DurationMS
 		}
@@ -180,6 +188,23 @@ func (rv runView) findingsTally() string {
 		return "none"
 	}
 	return joinComma(parts)
+}
+
+// fixRows flattens the fixes the pipeline applied across all steps into
+// renderable rows, in step then round order. A fix round that recorded no
+// summary still produced a fix commit, so it gets an explicit placeholder
+// rather than being dropped.
+func (rv runView) fixRows() []fixRow {
+	var rows []fixRow
+	for _, s := range rv.Steps {
+		for _, summary := range s.FixSummaries {
+			if summary == "" {
+				summary = "fix applied (no summary recorded)"
+			}
+			rows = append(rows, fixRow{Step: s.Name, Summary: summary})
+		}
+	}
+	return rows
 }
 
 func joinComma(parts []string) string {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -508,5 +508,8 @@ func stepToInfo(d *db.DB, s *db.StepResult) ipc.StepResultInfo {
 		info.ReportedFindings = stats.ReportedFindings
 		info.FixedFindings = stats.FixedFindings
 	}
+	if summaries, err := d.StepFixSummaries(s.ID); err == nil {
+		info.FixSummaries = summaries
+	}
 	return info
 }

--- a/internal/daemon/runinfo_test.go
+++ b/internal/daemon/runinfo_test.go
@@ -1,0 +1,73 @@
+package daemon
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+func TestStepToInfoIncludesFixSummaries(t *testing.T) {
+	d, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer d.Close()
+
+	repo, err := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")
+	if err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+	run, err := d.InsertRun(repo.ID, "feature", "abc", "def")
+	if err != nil {
+		t.Fatalf("insert run: %v", err)
+	}
+	step, err := d.InsertStepResult(run.ID, types.StepReview)
+	if err != nil {
+		t.Fatalf("insert step: %v", err)
+	}
+
+	findings := `{"findings":[{"id":"review-1","severity":"warning","description":"x"}],"summary":"1"}`
+	if _, err := d.InsertStepRound(step.ID, 1, "initial", &findings, nil, 100); err != nil {
+		t.Fatalf("insert round 1: %v", err)
+	}
+	sum := "handle nil pointer in executor"
+	if _, err := d.InsertStepRound(step.ID, 2, "auto_fix", nil, &sum, 100); err != nil {
+		t.Fatalf("insert round 2: %v", err)
+	}
+
+	info := stepToInfo(d, step)
+	if len(info.FixSummaries) != 1 || info.FixSummaries[0] != sum {
+		t.Errorf("fix summaries = %v, want [%q]", info.FixSummaries, sum)
+	}
+}
+
+func TestStepToInfoNoFixSummariesWithoutFixRounds(t *testing.T) {
+	d, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer d.Close()
+
+	repo, err := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")
+	if err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+	run, err := d.InsertRun(repo.ID, "feature", "abc", "def")
+	if err != nil {
+		t.Fatalf("insert run: %v", err)
+	}
+	step, err := d.InsertStepResult(run.ID, types.StepLint)
+	if err != nil {
+		t.Fatalf("insert step: %v", err)
+	}
+	if _, err := d.InsertStepRound(step.ID, 1, "initial", nil, nil, 100); err != nil {
+		t.Fatalf("insert round: %v", err)
+	}
+
+	info := stepToInfo(d, step)
+	if len(info.FixSummaries) != 0 {
+		t.Errorf("fix summaries = %v, want none", info.FixSummaries)
+	}
+}

--- a/internal/db/round.go
+++ b/internal/db/round.go
@@ -35,6 +35,33 @@ type StepRound struct {
 	CreatedAt  int64
 }
 
+// IsFixRound reports whether this round was a fix attempt. Legacy "user_fix"
+// rounds count: they were fix rounds dispatched by an explicit user selection.
+func (r *StepRound) IsFixRound() bool {
+	return r.Trigger == "auto_fix" || r.Trigger == "user_fix"
+}
+
+// StepFixSummaries returns one entry per fix round for a step, in round order:
+// the agent's one-line fix summary, or "" when the round recorded none.
+func (d *DB) StepFixSummaries(stepResultID string) ([]string, error) {
+	rounds, err := d.GetRoundsByStep(stepResultID)
+	if err != nil {
+		return nil, err
+	}
+	var summaries []string
+	for _, r := range rounds {
+		if !r.IsFixRound() {
+			continue
+		}
+		summary := ""
+		if r.FixSummary != nil {
+			summary = *r.FixSummary
+		}
+		summaries = append(summaries, summary)
+	}
+	return summaries, nil
+}
+
 // InsertStepRound creates a new round record for a step result. fixSummary may
 // be nil for non-fix rounds or when the agent produced no summary.
 func (d *DB) InsertStepRound(stepResultID string, round int, trigger string, findingsJSON *string, fixSummary *string, durationMS int64) (*StepRound, error) {

--- a/internal/db/round_test.go
+++ b/internal/db/round_test.go
@@ -123,6 +123,52 @@ func TestGetRoundsByStepEmpty(t *testing.T) {
 	}
 }
 
+func TestStepFixSummaries(t *testing.T) {
+	d := openTestDB(t)
+	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")
+	run, _ := d.InsertRun(repo.ID, "feature", "abc", "def")
+	step, _ := d.InsertStepResult(run.ID, types.StepReview)
+
+	findings := `{"findings":[{"id":"review-1","severity":"warning","description":"x"}],"summary":"1"}`
+	d.InsertStepRound(step.ID, 1, "initial", &findings, nil, 100)
+	s1 := "handle nil pointer in executor"
+	d.InsertStepRound(step.ID, 2, "auto_fix", nil, &s1, 100)
+	// Legacy fix round without a recorded summary still counts as a fix.
+	d.InsertStepRound(step.ID, 3, "user_fix", nil, nil, 100)
+	s2 := "tighten log path validation"
+	d.InsertStepRound(step.ID, 4, "auto_fix", nil, &s2, 100)
+
+	got, err := d.StepFixSummaries(step.ID)
+	if err != nil {
+		t.Fatalf("step fix summaries: %v", err)
+	}
+	want := []string{s1, "", s2}
+	if len(got) != len(want) {
+		t.Fatalf("got %d summaries %v, want %d %v", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("summary[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestStepFixSummariesNoFixRounds(t *testing.T) {
+	d := openTestDB(t)
+	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")
+	run, _ := d.InsertRun(repo.ID, "feature", "abc", "def")
+	step, _ := d.InsertStepResult(run.ID, types.StepLint)
+	d.InsertStepRound(step.ID, 1, "initial", nil, nil, 100)
+
+	got, err := d.StepFixSummaries(step.ID)
+	if err != nil {
+		t.Fatalf("step fix summaries: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v, want no summaries", got)
+	}
+}
+
 func TestStepRoundCascadeDelete(t *testing.T) {
 	d := openTestDB(t)
 	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -204,9 +204,13 @@ type StepResultInfo struct {
 	FindingsJSON     *string          `json:"findings_json,omitempty"`
 	ReportedFindings int              `json:"reported_findings,omitempty"`
 	FixedFindings    int              `json:"fixed_findings,omitempty"`
-	Error            *string          `json:"error,omitempty"`
-	StartedAt        *int64           `json:"started_at,omitempty"`
-	CompletedAt      *int64           `json:"completed_at,omitempty"`
+	// FixSummaries holds one entry per fix round the pipeline ran for this
+	// step, in round order: the agent's one-line fix summary, or "" when the
+	// round recorded none. Agent surfaces use it to report applied fixes.
+	FixSummaries []string `json:"fix_summaries,omitempty"`
+	Error        *string  `json:"error,omitempty"`
+	StartedAt    *int64   `json:"started_at,omitempty"`
+	CompletedAt  *int64   `json:"completed_at,omitempty"`
 }
 
 // --- Events (for subscribe stream) ---

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -1004,10 +1004,7 @@ func buildFixResultText(rounds []*db.StepRound) string {
 	// Categorize fix rounds. Legacy "user_fix" rounds are rendered as auto-fix.
 	autoFixRounds := 0
 	for _, r := range rounds[1:] {
-		switch r.Trigger {
-		case "auto_fix":
-			autoFixRounds++
-		case "user_fix":
+		if r.IsFixRound() {
 			autoFixRounds++
 		}
 	}
@@ -1050,7 +1047,7 @@ func buildStepDetails(summaryLine string, sr *db.StepResult, rounds []*db.StepRo
 	missingRoundFindingsData := sr.FindingsJSON != nil && !roundsHaveFindings(rounds) && !roundsHaveParseFailure(rounds)
 
 	for _, r := range rounds {
-		isFixRound := r.Trigger == "auto_fix" || r.Trigger == "user_fix"
+		isFixRound := r.IsFixRound()
 		if isFixRound {
 			b.WriteString(fixRoundLine(r))
 			b.WriteString("\n")

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -176,6 +176,13 @@ The CI step deliberately watches the PR until it is merged or closed, so
 ` + "`axi run`" + ` returns ` + "`checks-passed`" + ` the moment checks are green rather than
 blocking on the human merge. Never poll or re-run waiting for the merge yourself.
 
+On a successful outcome (` + "`checks-passed`" + ` or ` + "`passed`" + `), close the loop with the
+user: summarize what happened during the pipeline in a concise, easily readable
+format - what was validated and what was found. If the output includes a
+` + "`fixes`" + ` table, the pipeline fixed findings your original change missed:
+acknowledge those misses and explicitly list each fix so the user can easily
+review them.
+
 ## Escalate ` + "`ask-user`" + ` findings
 
 A gate whose findings are all ` + "`auto-fix`" + ` or ` + "`no-op`" + ` is safe to drive on your

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -145,6 +145,13 @@ The CI step deliberately watches the PR until it is merged or closed, so
 `axi run` returns `checks-passed` the moment checks are green rather than
 blocking on the human merge. Never poll or re-run waiting for the merge yourself.
 
+On a successful outcome (`checks-passed` or `passed`), close the loop with the
+user: summarize what happened during the pipeline in a concise, easily readable
+format - what was validated and what was found. If the output includes a
+`fixes` table, the pipeline fixed findings your original change missed:
+acknowledge those misses and explicitly list each fix so the user can easily
+review them.
+
 ## Escalate `ask-user` findings
 
 A gate whose findings are all `auto-fix` or `no-op` is safe to drive on your


### PR DESCRIPTION
## Intent

When the axi commands (axi run / axi respond) return a successful outcome to the driving agent (checks-passed, and the analogous terminal passed outcome), the output should instruct the agent to summarize what happened during the pipeline to the user in a concise, easily readable format. If the pipeline applied legitimate fixes during the run, the agent should acknowledge its misses and explicitly list out each fix the no-mistakes pipeline made so the user can easily review them. To make that instruction actionable, the output now includes the data: a fixes table (step + one-line fix summary) sourced from the fix rounds already recorded in step_rounds (fix_summary column), exposed over IPC as StepResultInfo.fix_summaries. Decisions made: the acknowledge-the-misses help line and the fixes table only appear when fixes were actually applied; the summarize instruction appears on both successful outcomes but deliberately not on failed/cancelled (those flows already have their own guidance); a fix round that recorded no summary is rendered as 'fix applied (no summary recorded)' rather than silently dropped, mirroring prsummary's fixRoundLine fallback; legacy user_fix rounds count as fix rounds via a new StepRound.IsFixRound() helper which prsummary.go now also reuses instead of duplicating the trigger check. The generated skill (internal/skill/skill.go, regenerated via make skill) and docs (guides/agents.md, reference/cli.md) were updated to match. Developed TDD: tests written first across db, daemon, and cli layers; verified with make lint, go test -race ./..., make e2e, and a clean build.

## What Changed

- AXI success responses now tell driving agents to summarize successful pipeline outcomes, and include an applied-fixes table when recorded fix rounds exist.
- Fix-round summaries are now surfaced from stored step rounds through daemon run info and IPC, with fallback text for fix rounds that did not record a summary.
- Updated the no-mistakes skill and docs to describe the new success reporting behavior.

## Risk Assessment

✅ Low: The change is narrowly scoped to carrying existing fix-round summaries through IPC and rendering additional success guidance, with tests covering the main DB, daemon, and AXI output paths and no material merge-blocking issues found.

## Testing

Focused DB, daemon, CLI, and pipeline-step tests passed, and an evidence-producing CLI render check captured the actual `axi` success output showing both `checks-passed` with fix summaries and terminal `passed` without fixes; the only remaining working tree artifact is the intentional evidence file.

<details>
<summary>Evidence: Rendered axi success output</summary>

Source: [Rendered axi success output](https://github.com/kunchenguid/no-mistakes/blob/a1736d0220206a03b93b076000fe236aebacc70b/.no-mistakes/evidence/feat/axi-success-fix-reporting/axi-success-output.txt)

```text
The transcript shows `outcome: checks-passed` with `fixes[2]{step,summary}:`, `review,handle nil pointer in executor`, `test,fix applied (no summary recorded)`, and the acknowledge-the-misses help line. It also shows terminal `outcome: passed` without a fixes table while still including the summarize instruction.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/db ./internal/daemon ./internal/cli -run 'TestStepFixSummaries|TestStepToInfoIncludesFixSummaries|TestStepToInfoNoFixSummariesWithoutFixRounds|TestRenderDriveResult_(ChecksPassed|ChecksPassedWithFixes|TerminalPassedUnaffected|TerminalPassedWithFixes|FailedHasNoSummarizeInstruction)$' -count=1`
- `go test ./internal/cli -run '^TestEvidenceAXISuccessFixReporting$' -count=1 -v > .no-mistakes/evidence/feat/axi-success-fix-reporting/axi-success-output.txt`
- `go test -race ./internal/db ./internal/daemon ./internal/cli`
- `go test -race ./internal/pipeline/steps`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
