### PR TITLE
fix(cli): resolve repo by filesystem identity when stored path spelling differs

### DIFF
--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -175,3 +175,4 @@ Everything lives under `~/.no-mistakes/` by default. Set `NM_HOME` to relocate i
 
 New repo IDs are the first 6 bytes (12 hex chars) of `sha256(absolute_working_path)`.
 When an initialized working repo is renamed or moved, `init` preserves the existing repo ID instead of deriving a new one from the new path.
+Commands resolve the current directory to its registered repo by its git root, and when that path spells the stored working path differently — a case-only variant on case-insensitive filesystems (macOS/Windows) or a symlink alias — they still match it by filesystem identity instead of reporting `repo not initialized`.

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/kunchenguid/no-mistakes/internal/buildinfo"
@@ -110,26 +111,64 @@ func findRepo(d *db.DB) (*db.Repo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("not in a git repository")
 	}
-	repo, err := d.GetRepoByPath(gitRoot)
+	candidates := []string{gitRoot}
+	// Try the main worktree root too (handles git worktrees).
+	if mainRoot, err := git.FindMainRepoRoot("."); err == nil && mainRoot != gitRoot {
+		candidates = append(candidates, mainRoot)
+	}
+	for _, path := range candidates {
+		repo, err := d.GetRepoByPath(path)
+		if err != nil {
+			return nil, fmt.Errorf("get repo: %w", err)
+		}
+		if repo != nil {
+			return repo, nil
+		}
+	}
+	// Exact string lookup missed, but the stored working path can spell the
+	// same directory differently: a case variant on case-insensitive
+	// filesystems (macOS/Windows — e.g. `git rev-parse --git-common-dir`
+	// preserves whatever casing the worktree was created with), or an
+	// unresolved symlink alias. Fall back to filesystem identity.
+	repo, err := repoByPathIdentity(d, candidates)
 	if err != nil {
-		return nil, fmt.Errorf("get repo: %w", err)
-	}
-	if repo != nil {
-		return repo, nil
-	}
-	// Try the main worktree root (handles git worktrees).
-	mainRoot, err := git.FindMainRepoRoot(".")
-	if err != nil || mainRoot == gitRoot {
-		return nil, fmt.Errorf("repo not initialized (run 'no-mistakes init' first)")
-	}
-	repo, err = d.GetRepoByPath(mainRoot)
-	if err != nil {
-		return nil, fmt.Errorf("get repo: %w", err)
+		return nil, err
 	}
 	if repo == nil {
 		return nil, fmt.Errorf("repo not initialized (run 'no-mistakes init' first)")
 	}
 	return repo, nil
+}
+
+// repoByPathIdentity scans registered repos for one whose working path
+// refers to the same directory as any candidate path, using os.SameFile so
+// casing differences and symlink aliases resolve without string assumptions.
+func repoByPathIdentity(d *db.DB, candidates []string) (*db.Repo, error) {
+	repos, err := d.ListRepos()
+	if err != nil {
+		return nil, fmt.Errorf("list repos: %w", err)
+	}
+	if len(repos) == 0 {
+		return nil, nil
+	}
+	stats := make([]os.FileInfo, 0, len(candidates))
+	for _, path := range candidates {
+		if fi, err := os.Stat(path); err == nil {
+			stats = append(stats, fi)
+		}
+	}
+	for _, repo := range repos {
+		fi, err := os.Stat(repo.WorkingPath)
+		if err != nil {
+			continue
+		}
+		for _, candidate := range stats {
+			if os.SameFile(fi, candidate) {
+				return repo, nil
+			}
+		}
+	}
+	return nil, nil
 }
 
 // openResources initializes paths, ensures directories exist, and opens the DB.

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -3,6 +3,9 @@ package cli
 import (
 	"context"
 	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -302,4 +305,59 @@ func TestRootYesStopsWaitingForRunWhenContextCanceled(t *testing.T) {
 	if elapsed := time.Since(start); elapsed >= time.Second {
 		t.Fatalf("executeCmdWithContext(-y) took %v after cancellation, want under %v", elapsed, time.Second)
 	}
+}
+
+func TestFindRepoResolvesAliasedWorkingPath(t *testing.T) {
+	base := t.TempDir()
+	repoDir := filepath.Join(base, "repo")
+	if err := os.Mkdir(repoDir, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	if out, err := exec.Command("git", "init", repoDir).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	t.Chdir(repoDir)
+
+	t.Run("symlink alias", func(t *testing.T) {
+		database := openTestDB(t)
+		alias := filepath.Join(base, "alias")
+		if err := os.Symlink(repoDir, alias); err != nil {
+			t.Fatalf("symlink: %v", err)
+		}
+		want, err := database.InsertRepo(alias, "origin", "main")
+		if err != nil {
+			t.Fatalf("insert repo: %v", err)
+		}
+		got, err := findRepo(database)
+		if err != nil {
+			t.Fatalf("findRepo: %v", err)
+		}
+		if got.ID != want.ID {
+			t.Fatalf("findRepo = %q, want %q", got.ID, want.ID)
+		}
+	})
+
+	t.Run("case variant", func(t *testing.T) {
+		database := openTestDB(t)
+		variant := filepath.Join(filepath.Dir(repoDir), "REPO")
+		fi, err := os.Stat(variant)
+		if err != nil {
+			t.Skipf("filesystem is case-sensitive: %v", err)
+		}
+		real, err := os.Stat(repoDir)
+		if err != nil || !os.SameFile(fi, real) {
+			t.Skip("filesystem is case-sensitive")
+		}
+		want, err := database.InsertRepo(variant, "origin", "main")
+		if err != nil {
+			t.Fatalf("insert repo: %v", err)
+		}
+		got, err := findRepo(database)
+		if err != nil {
+			t.Fatalf("findRepo: %v", err)
+		}
+		if got.ID != want.ID {
+			t.Fatalf("findRepo = %q, want %q", got.ID, want.ID)
+		}
+	})
 }

--- a/internal/db/repo.go
+++ b/internal/db/repo.go
@@ -117,3 +117,23 @@ func (d *DB) DeleteRepo(id string) error {
 	}
 	return nil
 }
+
+// ListRepos returns all registered repos.
+func (d *DB) ListRepos() ([]*Repo, error) {
+	rows, err := d.sql.Query(
+		`SELECT id, working_path, upstream_url, default_branch, created_at FROM repos`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list repos: %w", err)
+	}
+	defer rows.Close()
+	var repos []*Repo
+	for rows.Next() {
+		r := &Repo{}
+		if err := rows.Scan(&r.ID, &r.WorkingPath, &r.UpstreamURL, &r.DefaultBranch, &r.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan repo: %w", err)
+		}
+		repos = append(repos, r)
+	}
+	return repos, rows.Err()
+}


### PR DESCRIPTION
## What Changed

- Reworked `findRepo` to collect candidate roots (git root plus the main worktree root), attempt exact path lookups against each, then fall back to a new `repoByPathIdentity` helper that matches a registered repo via `os.SameFile` instead of erroring with `repo not initialized`.
- This makes commands resolve the current directory to its registered repo even when the stored working path spells the same directory differently — a case-only variant on case-insensitive filesystems (macOS/Windows) or an unresolved symlink alias.
- Added `db.ListRepos` to enumerate registered repos for the identity fallback, and documented the command-time resolution behavior in the gate-model concepts doc.

## Risk Assessment

✅ Low: A small, well-bounded fix that only adds a filesystem-identity fallback on the already-failing lookup path, using os.SameFile semantics that cannot false-match unrelated directories, with targeted tests covering both the symlink and case-variant cases.

## Testing

Reviewed the diff and confirmed HEAD is the target commit, then drove the actual end-user surface: I built the base and target binaries and exercised the documented bug through the real `no-mistakes runs` command against the real product SQLite DB, seeding a registered repo whose stored path spelled the same directory differently (symlink alias and case variant). The captured CLI transcripts show the exact before→after flip — base errors with "repo not initialized" (exit 1), target resolves the repo and prints "no runs yet…" (exit 0). I also ran the new unit test (both subtests pass, including the case-variant path that confirms this filesystem is case-insensitive), the affected packages under the race detector, and the full `go test -race ./...` suite — all green. Transient build binaries were removed and the working tree is clean.

<details>
<summary>Evidence: CLI before/after — symlink-alias stored path (no-mistakes runs)</summary>

<code>stored repo working_path : .../work-alias (symlink -&gt; same dir)&#10;=== BEFORE FIX (4893e32) ===&#10;$ cd &lt;repo&gt; &amp;&amp; no-mistakes runs&#10;repo not initialized (run &#39;no-mistakes init&#39; first)&#10;[exit 1]&#10;=== AFTER FIX (9990d1a) ===&#10;$ cd &lt;repo&gt; &amp;&amp; no-mistakes runs&#10;no runs yet. Push through the gate to start a pipeline:&#10;git push no-mistakes &lt;branch&gt;&#10;[exit 0]</code>

```text
Scenario: a registered repo whose stored working_path spells the directory
differently than 'git rev-parse' reports at command time (worktree casing /
symlink alias). Here the stored path is a symlink alias of the same directory.

  git reports at command time : /private/var/folders/tn/q2gv576569z3m_j_g29fzf5m0000gn/T/tmp.uHJew8JEEn/work
  stored repo working_path    : /var/folders/tn/q2gv576569z3m_j_g29fzf5m0000gn/T/tmp.uHJew8JEEn/work-alias  (symlink -> same dir)

=================== BEFORE FIX  (base 4893e32) ===================
stored working_path in DB: /var/folders/tn/q2gv576569z3m_j_g29fzf5m0000gn/T/tmp.uHJew8JEEn/work-alias
$ cd <repo> && no-mistakes runs
repo not initialized (run 'no-mistakes init' first)
[exit 1]

=================== AFTER FIX   (target 9990d1a) ===================
stored working_path in DB: /var/folders/tn/q2gv576569z3m_j_g29fzf5m0000gn/T/tmp.uHJew8JEEn/work-alias
$ cd <repo> && no-mistakes runs
  no runs yet. Push through the gate to start a pipeline:
  git push no-mistakes <branch>
[exit 0]
```
</details>
<details>
<summary>Evidence: CLI before/after — case-variant stored path (no-mistakes runs)</summary>

<code>stored repo working_path : .../WORK (case variant of same dir)&#10;=== BEFORE FIX (4893e32) ===&#10;$ cd &lt;repo&gt; &amp;&amp; no-mistakes runs&#10;repo not initialized (run &#39;no-mistakes init&#39; first)&#10;[exit 1]&#10;=== AFTER FIX (9990d1a) ===&#10;$ cd &lt;repo&gt; &amp;&amp; no-mistakes runs&#10;no runs yet. Push through the gate to start a pipeline:&#10;git push no-mistakes &lt;branch&gt;&#10;[exit 0]</code>

```text
Scenario: stored working_path is a CASE VARIANT of the directory git reports
(macOS/Windows case-insensitive filesystems; 'git rev-parse --git-common-dir'
preserves whatever casing the worktree was created with).

  git reports at command time : /private/var/folders/tn/q2gv576569z3m_j_g29fzf5m0000gn/T/tmp.umCp12tNl9/work
  stored repo working_path    : /private/var/folders/tn/q2gv576569z3m_j_g29fzf5m0000gn/T/tmp.umCp12tNl9/WORK  (case variant of same dir)

=================== BEFORE FIX  (base 4893e32) ===================
stored working_path in DB: /private/var/folders/tn/q2gv576569z3m_j_g29fzf5m0000gn/T/tmp.umCp12tNl9/WORK
$ cd <repo> && no-mistakes runs
repo not initialized (run 'no-mistakes init' first)
[exit 1]

=================== AFTER FIX   (target 9990d1a) ===================
stored working_path in DB: /private/var/folders/tn/q2gv576569z3m_j_g29fzf5m0000gn/T/tmp.umCp12tNl9/WORK
$ cd <repo> && no-mistakes runs
  no runs yet. Push through the gate to start a pipeline:
  git push no-mistakes <branch>
[exit 0]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `internal/cli/root.go:160` - In repoByPathIdentity the loop iterates `for each repo { for each candidate }`, so a repo aliasing mainRoot can be returned before one aliasing gitRoot, losing the gitRoot-first preference the exact-match loop enforces. This only matters if two distinct repo records both have string-mismatched (case/symlink) paths resolving to gitRoot and mainRoot simultaneously — effectively impossible given init normalizes to the resolved main root and reattachRelocatedRepo prevents duplicates. Also note ListRepos has no ORDER BY, so iteration order is unspecified. No action needed; documenting the subtlety.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Built before/after binaries: `go build -o ./bin/nm-target ./cmd/no-mistakes` (HEAD 9990d1a) and the same against reverted base source (4893e32) → ./bin/nm-base</code>
- <code>Manual product transcript (symlink alias): seeded a `repos` row via `sqlite3` with working_path = symlink alias of the git root, then ran `no-mistakes runs` from inside the repo with both binaries — base printed &#39;repo not initialized&#39; (exit 1), target resolved and printed &#39;no runs yet…&#39; (exit 0)</code>
- `Manual product transcript (case variant): same flow with working_path = case variant (.../WORK vs .../work) — base failed, target resolved`
- <code>`go test ./internal/cli -run &#39;^TestFindRepoResolvesAliasedWorkingPath$&#39; -v -count=1` (symlink_alias and case_variant subtests both PASS; case_variant not skipped, so os.SameFile path exercised)</code>
- `go test -race ./internal/cli ./internal/db -count=1`
- <code>`go test -race ./...` (full suite, all packages ok)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
