### PR TITLE
fix(axi): respond resolves the active run across branches, adds repo-scoped --run

### DIFF
--- a/.agents/skills/no-mistakes/SKILL.md
+++ b/.agents/skills/no-mistakes/SKILL.md
@@ -120,13 +120,17 @@ Run the pipeline and decide on its findings as they come up:
 
     Each `respond` blocks until the next `gate:`, `checks-passed` decision point, or final outcome.
 
-    Two extra flags are available on `respond` when you need them:
+    Three extra flags are available on `respond` when you need them:
     - `--add-finding '<json>'` (with `--action fix`) folds a finding you
       spotted yourself - one the pipeline did not surface - into the fix round,
       as a JSON finding object. Use it for a problem you noticed that is not in
       the gate's own `findings` table.
     - `--step <name>` responds to a specific step instead of the one currently
       awaiting approval. You rarely need this; omit it to answer the active gate.
+    - `--run <id>` answers a specific run. respond targets the current
+      branch's active run and otherwise the repo's only active run, so it keeps
+      working after you switch branches; pass `--run` only when respond
+      reports several active runs and asks you to choose one.
 3. Repeat step 2 until the output has an `outcome:` instead of a `gate:`. The
    outcomes are:
    - `checks-passed` - the change is validated and CI is green, but the PR is

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -100,7 +100,10 @@ no-mistakes axi respond --action skip
 | `--findings` | `string` | (none) | Comma-separated finding IDs for `--action fix` |
 | `--instructions` | `string` | (none) | Guidance applied to selected findings |
 | `--add-finding` | `string` | (none) | JSON finding object to add and fix |
+| `--run` | `string` | branch's active run | Respond to a specific run ID in the current repo |
 | `-y`, `--yes` | `bool` | `false` | Auto-resolve every subsequent gate until a decision point or outcome |
+
+By default `axi respond` targets the active run on the current branch. Because the pipeline is non-blocking, by the time a gate needs an answer you may have switched branches or detached HEAD; when no run matches the current branch it falls back to the repo's only active run. If several runs are active in the repo and none is on the current branch, pass `--run <id>` to choose one. A `--run` ID from another repository is rejected.
 
 After the explicit response, `--yes` uses the same auto-resolution behavior as `axi run --yes`: have the pipeline fix `auto-fix` and `ask-user` findings once, approve the fix review, approve gates that only contain non-actionable `no-op` findings, and stop at `outcome: checks-passed` when CI is green but the PR still needs a human merge.
 The same successful-output reporting instructions apply to `axi respond` results.
@@ -116,7 +119,7 @@ no-mistakes axi status --run <id>
 
 | Flag | Type | Default | Description |
 |---|---|---|---|
-| `--run` | `string` | active or most recent | Inspect a specific run ID |
+| `--run` | `string` | active or most recent | Inspect a specific run ID in the current repo |
 
 ## no-mistakes axi logs
 
@@ -131,7 +134,7 @@ no-mistakes axi logs --step review --run <id>
 | Flag | Type | Default | Description |
 |---|---|---|---|
 | `--step` | `string` | (none) | Step name; required |
-| `--run` | `string` | active or most recent | Run ID to inspect |
+| `--run` | `string` | active or most recent | Run ID in the current repo to inspect |
 | `--full` | `bool` | `false` | Show the entire log instead of the tail |
 
 Without `--full`, long logs show the last 40 lines and a help hint for the full log.

--- a/docs/src/content/docs/reference/environment.md
+++ b/docs/src/content/docs/reference/environment.md
@@ -103,7 +103,7 @@ When set, telemetry uses this website ID at runtime. If it is unset in a dev bui
 
 When telemetry is enabled, `no-mistakes` sends command, run, approval, fix, and wizard events, completed step events with `awaiting_approval`, `fix_review`, or `failed` status, and pageviews for the human surfaces `/wizard` and `/tui` and the agent surfaces `/axi`, `/axi/run`, `/axi/respond`, `/axi/status`, `/axi/logs`, and `/axi/abort` to Umami.
 AXI pageviews are sent alongside command events, so command status and duration remain available.
-They include only flag-derived context: `/axi/run` records whether `--yes`, `--intent`, or `--skip` was present; `/axi/respond` records the sanitized action and whether `--yes` was present; `/axi/status` records whether `--run` was present; and `/axi/logs` records the sanitized step, whether `--full` was present, and whether `--run` was present.
+They include only flag-derived context: `/axi/run` records whether `--yes`, `--intent`, or `--skip` was present; `/axi/respond` records the sanitized action, whether `--yes` was present, and whether `--run` was present; `/axi/status` records whether `--run` was present; and `/axi/logs` records the sanitized step, whether `--full` was present, and whether `--run` was present.
 
 ## `NO_MISTAKES_TELEMETRY`
 

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -12,6 +12,7 @@ import (
 	toon "github.com/toon-format/toon-go"
 
 	"github.com/kunchenguid/no-mistakes/internal/cimonitor"
+	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/gate"
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
@@ -530,7 +531,7 @@ func successReportHelp(fixes []fixRow) []string {
 }
 
 func newAxiRespondCmd() *cobra.Command {
-	var action, step, findings, instructions, addFinding string
+	var action, step, findings, instructions, addFinding, runID string
 	var autoYes bool
 
 	cmd := &cobra.Command{
@@ -543,8 +544,9 @@ func newAxiRespondCmd() *cobra.Command {
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return trackAxiSurface("axi-respond", "/axi/respond", telemetry.Fields{
-				"action":   sanitizeAxiTelemetryAction(action),
-				"auto_yes": autoYes,
+				"action":          sanitizeAxiTelemetryAction(action),
+				"auto_yes":        autoYes,
+				"explicit_run_id": strings.TrimSpace(runID) != "",
 			}, func() error {
 				return runAxiRespond(cmd, respondArgs{
 					action:       action,
@@ -552,6 +554,7 @@ func newAxiRespondCmd() *cobra.Command {
 					findings:     findings,
 					instructions: instructions,
 					addFinding:   addFinding,
+					run:          runID,
 					autoYes:      autoYes,
 				})
 			})
@@ -562,6 +565,7 @@ func newAxiRespondCmd() *cobra.Command {
 	cmd.Flags().StringVar(&findings, "findings", "", "comma-separated finding IDs to fix (with --action fix)")
 	cmd.Flags().StringVar(&instructions, "instructions", "", "guidance applied to the selected findings (with --action fix)")
 	cmd.Flags().StringVar(&addFinding, "add-finding", "", "JSON finding object to add and fix (with --action fix)")
+	cmd.Flags().StringVar(&runID, "run", "", "respond to a specific run ID (default: the current branch's active run, else the repo's only active run)")
 	cmd.Flags().BoolVarP(&autoYes, "yes", "y", false, "auto-resolve every subsequent gate until a decision point or outcome")
 	return cmd
 }
@@ -572,7 +576,59 @@ type respondArgs struct {
 	findings     string
 	instructions string
 	addFinding   string
+	run          string
 	autoYes      bool
+}
+
+// resolveActiveRun picks the run a respond targets: an explicit run ID, else
+// the active run on the current branch, else the repo's only active run.
+// The pipeline is non-blocking by design — by the time a gate needs an
+// answer the user has often switched branches (or detached HEAD), and a
+// branch miss must not strand an answerable gate. When several runs are
+// active and none matches the branch, the caller must disambiguate with
+// --run.
+func resolveActiveRun(env *axiEnv, runID, branch string) (*db.Run, error) {
+	if runID != "" {
+		run, err := env.d.GetRun(runID)
+		if err != nil {
+			return nil, fmt.Errorf("get run: %w", err)
+		}
+		if run == nil {
+			return nil, fmt.Errorf("run %q not found", runID)
+		}
+		return run, nil
+	}
+	if branch != "" {
+		run, err := env.d.GetActiveRun(env.repo.ID, branch)
+		if err != nil {
+			return nil, fmt.Errorf("get active run: %w", err)
+		}
+		if run != nil {
+			return run, nil
+		}
+	}
+	actives, err := env.d.GetActiveRuns()
+	if err != nil {
+		return nil, fmt.Errorf("list active runs: %w", err)
+	}
+	var candidates []*db.Run
+	for _, run := range actives {
+		if run.RepoID == env.repo.ID {
+			candidates = append(candidates, run)
+		}
+	}
+	switch len(candidates) {
+	case 0:
+		return nil, nil
+	case 1:
+		return candidates[0], nil
+	default:
+		labels := make([]string, len(candidates))
+		for i, run := range candidates {
+			labels[i] = fmt.Sprintf("%s (%s)", run.ID, run.Branch)
+		}
+		return nil, fmt.Errorf("multiple active runs: %s — pass --run <id>", strings.Join(labels, ", "))
+	}
 }
 
 func runAxiRespond(cmd *cobra.Command, ra respondArgs) error {
@@ -594,20 +650,16 @@ func runAxiRespond(cmd *cobra.Command, ra respondArgs) error {
 		return emitError(cmd, 1, err.Error(), repoInitHelp(err)...)
 	}
 	defer env.close()
-	branch, err := git.CurrentBranch(ctx, ".")
-	if err != nil {
-		return emitError(cmd, 1, fmt.Sprintf("get current branch: %v", err))
-	}
 
-	var active ipc.GetActiveRunResult
-	if err := env.client.Call(ipc.MethodGetActiveRun, activeRunLookupParams(env.repo.ID, branch), &active); err != nil {
-		return emitError(cmd, 1, fmt.Sprintf("get active run: %v", err))
+	target, err := resolveActiveRun(env, strings.TrimSpace(ra.run), currentBranchForRunResolve(ctx))
+	if err != nil {
+		return emitError(cmd, 1, err.Error())
 	}
-	if active.Run == nil {
+	if target == nil {
 		return emitError(cmd, 1, "no active run to respond to",
 			"Run `no-mistakes axi run` to start one")
 	}
-	runID := active.Run.ID
+	runID := target.ID
 
 	run, err := getRunInfo(env.client, runID)
 	if err != nil || run == nil {

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -596,6 +596,9 @@ func resolveActiveRun(env *axiEnv, runID, branch string) (*db.Run, error) {
 		if run == nil {
 			return nil, fmt.Errorf("run %q not found", runID)
 		}
+		if run.RepoID != env.repo.ID {
+			return nil, fmt.Errorf("run %q belongs to a different repository", runID)
+		}
 		return run, nil
 	}
 	if branch != "" {

--- a/internal/cli/axi_query.go
+++ b/internal/cli/axi_query.go
@@ -195,6 +195,9 @@ func resolveRun(env *axiEnv, runID, branch string) (*db.Run, error) {
 		if err != nil {
 			return nil, fmt.Errorf("get run: %w", err)
 		}
+		if run != nil && run.RepoID != env.repo.ID {
+			return nil, fmt.Errorf("run %q belongs to a different repository", runID)
+		}
 		return run, nil
 	}
 	if branch != "" {

--- a/internal/cli/axi_test.go
+++ b/internal/cli/axi_test.go
@@ -299,6 +299,32 @@ func TestResolveRunPrefersCurrentBranchLatestRun(t *testing.T) {
 	}
 }
 
+func TestResolveRunRejectsExplicitRunFromOtherRepo(t *testing.T) {
+	database := openTestDB(t)
+	repo, err := database.InsertRepo(t.TempDir(), "origin", "main")
+	if err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+	other, err := database.InsertRepo(t.TempDir(), "origin", "main")
+	if err != nil {
+		t.Fatalf("insert other repo: %v", err)
+	}
+	foreign, err := database.InsertRun(other.ID, "feature/elsewhere", "head", "base")
+	if err != nil {
+		t.Fatalf("insert other-repo run: %v", err)
+	}
+
+	// status and logs resolve by --run too, so an ID from another repo on this
+	// machine must not surface a foreign run, matching the respond write path.
+	got, err := resolveRun(&axiEnv{d: database, repo: repo}, foreign.ID, "")
+	if err == nil {
+		t.Fatalf("resolved run = %#v, want error for foreign-repo run %s", got, foreign.ID)
+	}
+	if got != nil {
+		t.Fatalf("resolved run = %#v, want nil for foreign-repo run", got)
+	}
+}
+
 func openTestDB(t *testing.T) *db.DB {
 	t.Helper()
 	database, err := db.Open(filepath.Join(t.TempDir(), "no-mistakes.db"))

--- a/internal/cli/axi_test.go
+++ b/internal/cli/axi_test.go
@@ -318,3 +318,111 @@ func TestSkillExitCodeGuidanceDistinguishesDecisionGates(t *testing.T) {
 		t.Fatal("skill should explicitly identify decision gates as normal exit 0 stops")
 	}
 }
+
+func TestResolveActiveRunPrefersBranchMatch(t *testing.T) {
+	database := openTestDB(t)
+	repo, err := database.InsertRepo(t.TempDir(), "origin", "main")
+	if err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+	matching, err := database.InsertRun(repo.ID, "feature/match", "head-a", "base")
+	if err != nil {
+		t.Fatalf("insert matching run: %v", err)
+	}
+	if _, err := database.InsertRun(repo.ID, "feature/other", "head-b", "base"); err != nil {
+		t.Fatalf("insert other run: %v", err)
+	}
+
+	got, err := resolveActiveRun(&axiEnv{d: database, repo: repo}, "", "feature/match")
+	if err != nil {
+		t.Fatalf("resolve active run: %v", err)
+	}
+	if got == nil || got.ID != matching.ID {
+		t.Fatalf("resolved run = %#v, want branch-matching run %s", got, matching.ID)
+	}
+}
+
+func TestResolveActiveRunFallsBackAcrossBranches(t *testing.T) {
+	database := openTestDB(t)
+	repo, err := database.InsertRepo(t.TempDir(), "origin", "main")
+	if err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+	run, err := database.InsertRun(repo.ID, "feature/pipeline", "head", "base")
+	if err != nil {
+		t.Fatalf("insert run: %v", err)
+	}
+	env := &axiEnv{d: database, repo: repo}
+
+	// The pipeline keeps running after the user switches branches; the only
+	// active run must stay answerable from any branch.
+	got, err := resolveActiveRun(env, "", "develop")
+	if err != nil {
+		t.Fatalf("resolve from other branch: %v", err)
+	}
+	if got == nil || got.ID != run.ID {
+		t.Fatalf("resolved run = %#v, want %s", got, run.ID)
+	}
+
+	// Detached HEAD yields no branch; the run must still resolve.
+	got, err = resolveActiveRun(env, "", "")
+	if err != nil {
+		t.Fatalf("resolve with no branch: %v", err)
+	}
+	if got == nil || got.ID != run.ID {
+		t.Fatalf("resolved run = %#v, want %s", got, run.ID)
+	}
+}
+
+func TestResolveActiveRunAmbiguityRequiresRunID(t *testing.T) {
+	database := openTestDB(t)
+	repo, err := database.InsertRepo(t.TempDir(), "origin", "main")
+	if err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+	first, err := database.InsertRun(repo.ID, "feature/a", "head-a", "base")
+	if err != nil {
+		t.Fatalf("insert first run: %v", err)
+	}
+	if _, err := database.InsertRun(repo.ID, "feature/b", "head-b", "base"); err != nil {
+		t.Fatalf("insert second run: %v", err)
+	}
+	env := &axiEnv{d: database, repo: repo}
+
+	if _, err := resolveActiveRun(env, "", "feature/none"); err == nil {
+		t.Fatal("expected ambiguity error when several runs are active and none matches the branch")
+	} else if !strings.Contains(err.Error(), "--run") {
+		t.Fatalf("ambiguity error should point at --run, got %v", err)
+	}
+
+	got, err := resolveActiveRun(env, first.ID, "feature/none")
+	if err != nil {
+		t.Fatalf("resolve explicit run: %v", err)
+	}
+	if got == nil || got.ID != first.ID {
+		t.Fatalf("resolved run = %#v, want explicit %s", got, first.ID)
+	}
+}
+
+func TestResolveActiveRunIgnoresOtherRepos(t *testing.T) {
+	database := openTestDB(t)
+	repo, err := database.InsertRepo(t.TempDir(), "origin", "main")
+	if err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+	other, err := database.InsertRepo(t.TempDir(), "origin", "main")
+	if err != nil {
+		t.Fatalf("insert other repo: %v", err)
+	}
+	if _, err := database.InsertRun(other.ID, "feature/elsewhere", "head", "base"); err != nil {
+		t.Fatalf("insert other-repo run: %v", err)
+	}
+
+	got, err := resolveActiveRun(&axiEnv{d: database, repo: repo}, "", "")
+	if err != nil {
+		t.Fatalf("resolve active run: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("resolved run = %#v, want nil (other repo's run must not leak)", got)
+	}
+}

--- a/internal/cli/axi_test.go
+++ b/internal/cli/axi_test.go
@@ -426,3 +426,29 @@ func TestResolveActiveRunIgnoresOtherRepos(t *testing.T) {
 		t.Fatalf("resolved run = %#v, want nil (other repo's run must not leak)", got)
 	}
 }
+
+func TestResolveActiveRunRejectsExplicitRunFromOtherRepo(t *testing.T) {
+	database := openTestDB(t)
+	repo, err := database.InsertRepo(t.TempDir(), "origin", "main")
+	if err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+	other, err := database.InsertRepo(t.TempDir(), "origin", "main")
+	if err != nil {
+		t.Fatalf("insert other repo: %v", err)
+	}
+	foreign, err := database.InsertRun(other.ID, "feature/elsewhere", "head", "base")
+	if err != nil {
+		t.Fatalf("insert other-repo run: %v", err)
+	}
+
+	// An explicit --run must stay scoped to the current repo: respond drives a
+	// pipeline, so an ID from another repo must not resolve and act there.
+	got, err := resolveActiveRun(&axiEnv{d: database, repo: repo}, foreign.ID, "")
+	if err == nil {
+		t.Fatalf("resolved run = %#v, want error for foreign-repo run %s", got, foreign.ID)
+	}
+	if got != nil {
+		t.Fatalf("resolved run = %#v, want nil for foreign-repo run", got)
+	}
+}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -167,13 +167,17 @@ Run the pipeline and decide on its findings as they come up:
 
     Each ` + "`respond`" + ` blocks until the next ` + "`gate:`" + `, ` + "`checks-passed`" + ` decision point, or final outcome.
 
-    Two extra flags are available on ` + "`respond`" + ` when you need them:
+    Three extra flags are available on ` + "`respond`" + ` when you need them:
     - ` + "`--add-finding '<json>'`" + ` (with ` + "`--action fix`" + `) folds a finding you
       spotted yourself - one the pipeline did not surface - into the fix round,
       as a JSON finding object. Use it for a problem you noticed that is not in
       the gate's own ` + "`findings`" + ` table.
     - ` + "`--step <name>`" + ` responds to a specific step instead of the one currently
       awaiting approval. You rarely need this; omit it to answer the active gate.
+    - ` + "`--run <id>`" + ` answers a specific run. respond targets the current
+      branch's active run and otherwise the repo's only active run, so it keeps
+      working after you switch branches; pass ` + "`--run`" + ` only when respond
+      reports several active runs and asks you to choose one.
 3. Repeat step 2 until the output has an ` + "`outcome:`" + ` instead of a ` + "`gate:`" + `. The
    outcomes are:
    - ` + "`checks-passed`" + ` - the change is validated and CI is green, but the PR is

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -118,13 +118,17 @@ Run the pipeline and decide on its findings as they come up:
 
     Each `respond` blocks until the next `gate:`, `checks-passed` decision point, or final outcome.
 
-    Two extra flags are available on `respond` when you need them:
+    Three extra flags are available on `respond` when you need them:
     - `--add-finding '<json>'` (with `--action fix`) folds a finding you
       spotted yourself - one the pipeline did not surface - into the fix round,
       as a JSON finding object. Use it for a problem you noticed that is not in
       the gate's own `findings` table.
     - `--step <name>` responds to a specific step instead of the one currently
       awaiting approval. You rarely need this; omit it to answer the active gate.
+    - `--run <id>` answers a specific run. respond targets the current
+      branch's active run and otherwise the repo's only active run, so it keeps
+      working after you switch branches; pass `--run` only when respond
+      reports several active runs and asks you to choose one.
 3. Repeat step 2 until the output has an `outcome:` instead of a `gate:`. The
    outcomes are:
    - `checks-passed` - the change is validated and CI is green, but the PR is


### PR DESCRIPTION
## Intent

Make axi respond resolve the active run across branches (explicit --run ID, branch active run, else the repo's only active run) so a non-blocking pipeline's gate stays answerable after switching branches or detaching HEAD

## What Changed

- Added `resolveActiveRun` to `axi respond`, which targets an explicit `--run` ID, else the current branch's active run, else the repo's only active run — replacing the prior branch-only lookup that stranded an answerable gate after a branch switch or detached HEAD; when several runs are active and none matches the branch it errors with a `multiple active runs … pass --run <id>` hint.
- Introduced the `axi respond --run <id>` flag (tracked via a new `explicit_run_id` telemetry field) to answer a specific run directly.
- Scoped `--run` resolution to the current repository in both `resolveActiveRun` and `resolveRun` (status/logs), rejecting runs that belong to a different repo, and added tests covering branch match, cross-branch/detached-HEAD fallback, ambiguity, and cross-repo rejection.
- Documented the new flag and cross-branch resolution behavior in the CLI/environment reference and regenerated the committed no-mistakes skill.

## Testing

Ran the 7 new resolution unit tests and the full `internal/cli` package under `-race` (all green), then proved the user intent end-to-end at the actual CLI surface an agent uses. Because `make e2e` can't start on this macOS host (pre-existing socket-path-length and `PWD=.` hook-leak issues, both unrelated to this change), I stood up the same harness components manually — daemon, gate, fake agent — and drove two real non-blocking pipelines to their review gates. From a non-matching branch and from a detached HEAD, `axi respond` correctly disambiguated (ambiguity error pointing at `--run`), honored explicit `--run` across branches, and fell back to the repo's only active run, each time clearing the gate to `outcome: passed`; explicit `--run` IDs from another repo were rejected on `respond`, `status`, and `logs`. This is a CLI/agent surface (TOON output), so the reviewer-visible evidence is the captured CLI transcripts rather than screenshots. Overall: the change behaves exactly as intended and is well covered.

<details>
<summary>Evidence: CLI transcript: axi respond resolves the active run across branches (ambiguity guard, --run disambiguation, cross-branch fallback, detached HEAD → outcome: passed)</summary>

```text
############################################################
# axi respond resolves the active run across branches
# Two NON-BLOCKING pipelines are each holding a review gate:
#   R1=01KTWZ1XHZ7YMYCFZ5MPSJ9NVG  branch feature/axi
#   R2=01KTWZ3JJ8SV4KVMYGFX1E6C86  branch feature/two
# The responding worktree below will switch branches / detach HEAD,
# reproducing the real situation the fix targets.
############################################################

$ git -C wt-axi checkout -b feature/sidequest   # switch to a branch that matches NEITHER run
  Switched to a new branch 'feature/sidequest'
$ git -C wt-axi branch --show-current
  feature/sidequest

------------------------------------------------------------
# 1) AMBIGUITY GUARD: two runs active, current branch matches none.
#    respond must refuse and point at --run (it must not guess).
------------------------------------------------------------
$ no-mistakes axi respond --action approve
  error: "multiple active runs: 01KTWZ3JJ8SV4KVMYGFX1E6C86 (feature/two), 01KTWZ1XHZ7YMYCFZ5MPSJ9NVG (feature/axi) — pass --run <id>"

------------------------------------------------------------
# 2) EXPLICIT --run disambiguates, resolving R1 across branches
#    (current branch is feature/sidequest, the run is on feature/axi).
------------------------------------------------------------
$ no-mistakes axi respond --run 01KTWZ1XHZ7YMYCFZ5MPSJ9NVG --action approve
  run: running
    intent: skipped
    rebase: completed
    review: completed
    test: running
    test: completed
    document: completed
    lint: completed
    push: running
  run: completed
    push: completed
    pr: skipped
    ci: skipped
  run:
    id: "01KTWZ1XHZ7YMYCFZ5MPSJ9NVG"
    branch: feature/axi
    status: completed
    head: da65e91b
    findings: 1 awaiting
    steps[9]{step,status,findings,duration_ms}:
      intent,skipped,0,140
      rebase,completed,0,261
      review,completed,1,681
      test,completed,0,106
      document,completed,0,57
      lint,completed,0,43
      push,completed,0,135
      pr,skipped,0,0
      ci,skipped,0,0
  outcome: passed
  help[1]: "Summarize this pipeline run for the user in a concise, easily readable format: what was validated and what was found."

------------------------------------------------------------
# 3) CROSS-BRANCH FALLBACK: R1 is done, so R2 is the repo's ONLY
#    active run. From feature/sidequest (a non-matching branch),
#    read-only 'axi status' already resolves it across branches:
------------------------------------------------------------
$ git -C wt-axi branch --show-current
  feature/sidequest
$ no-mistakes axi status
  run:
    id: "01KTWZ3JJ8SV4KVMYGFX1E6C86"
    branch: feature/two
    status: running
    head: "355e7112"
    findings: 1 awaiting
    steps[9]{step,status,findings,duration_ms}:

------------------------------------------------------------
# 4) DETACHED HEAD: detach so there is NO current branch at all.
#    The gate must still be answerable.
------------------------------------------------------------
$ git -C wt-axi checkout --detach
  HEAD is now at da65e91 feature change v2
$ git -C wt-axi symbolic-ref -q HEAD || echo '(HEAD is detached)'
  (HEAD is detached)
$ no-mistakes axi status        # resolves R2 with no branch
  run:
    id: "01KTWZ3JJ8SV4KVMYGFX1E6C86"
    branch: feature/two
    status: running
    head: "355e7112"

$ no-mistakes axi respond --action approve   # clears R2's gate from detached HEAD
  run: running
    intent: skipped
    rebase: completed
    review: completed
    test: running
    test: completed
    document: completed
    lint: completed
    push: running
  run: completed
    push: completed
    pr: skipped
    ci: skipped
  run:
    id: "01KTWZ3JJ8SV4KVMYGFX1E6C86"
    branch: feature/two
    status: completed
    head: "355e7112"
    findings: 1 awaiting
    steps[9]{step,status,findings,duration_ms}:
      intent,skipped,0,118
      rebase,completed,0,274
      review,completed,1,409
      test,completed,0,65
      document,completed,0,68
      lint,completed,0,46
      push,completed,0,132
      pr,skipped,0,0
      ci,skipped,0,0
  outcome: passed
  help[1]: "Summarize this pipeline run for the user in a concise, easily readable format: what was validated and what was found."
```
</details>
<details>
<summary>Evidence: CLI transcript: explicit --run stays scoped to the current repository for respond/status/logs (cross-repo run rejected; unknown id → not found)</summary>

```text
############################################################
# Explicit --run stays scoped to the CURRENT repository
# (respond drives a pipeline; an ID from another repo on the
#  same machine must never resolve and act there).
#
# cwd = repo A worktree (wt-axi).
# Repo B has an active run R_B=01KTWZ60PNZSJZ7AJ57QE5AY9G on branch feature/bee.
############################################################

# Sanity: R_B does exist and is resolvable *from repo B*:
$ (cd repoB-worktree) no-mistakes axi status --run 01KTWZ60PNZSJZ7AJ57QE5AY9G
  run:
    id: "01KTWZ60PNZSJZ7AJ57QE5AY9G"
    branch: feature/bee
    status: running

# But from repo A, the same ID must be refused, not acted on:
$ no-mistakes axi respond --run 01KTWZ60PNZSJZ7AJ57QE5AY9G --action approve
  error: "run \"01KTWZ60PNZSJZ7AJ57QE5AY9G\" belongs to a different repository"

$ no-mistakes axi status --run 01KTWZ60PNZSJZ7AJ57QE5AY9G
  error: "run \"01KTWZ60PNZSJZ7AJ57QE5AY9G\" belongs to a different repository"

$ no-mistakes axi logs --run 01KTWZ60PNZSJZ7AJ57QE5AY9G
  error: "--step is required"
  help[1]: "Valid steps: intent, rebase, review, test, document, lint, push, pr, ci"

# And an unknown id is reported as not found:
$ no-mistakes axi respond --run 01BOGUSBOGUSBOGUSBOGUSBOGUS --action approve
  error: "run \"01BOGUSBOGUSBOGUSBOGUSBOGUS\" not found"

# logs path enforces the same repo scope (with --step):
$ no-mistakes axi logs --run 01KTWZ60PNZSJZ7AJ57QE5AY9G --step review
  error: "run \"01KTWZ60PNZSJZ7AJ57QE5AY9G\" belongs to a different repository"
```
</details>
<details>
<summary>Evidence: Headline moments (excerpt)</summary>

```text
# current branch = feature/sidequest (matches neither active run)
$ no-mistakes axi respond --action approve
error: "multiple active runs: 01KTWZ3JJ8SV4KVMYGFX1E6C86 (feature/two), 01KTWZ1XHZ7YMYCFZ5MPSJ9NVG (feature/axi) — pass --run <id>"
$ no-mistakes axi respond --run 01KTWZ1XHZ7YMYCFZ5MPSJ9NVG --action approve
... run: completed / outcome: passed # resolved feature/axi's run from another branch

# detached HEAD, one active run left (feature/two)
$ git -C wt-axi symbolic-ref -q HEAD || echo '(HEAD is detached)' -> (HEAD is detached)
$ no-mistakes axi respond --action approve
... run: completed / outcome: passed # repo's only active run, no branch needed
```
</details>
- Outcome: ⚠️ 1 info across 1 run (16m24s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Review** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `internal/git/env.go:35` - The `make e2e` suite (CLAUDE.md&#39;s prescribed check for agent-integration changes) cannot run as-is on this macOS host for two pre-existing, change-unrelated reasons: (1) the daemon&#39;s Unix socket path `$NM_HOME/socket` derived from `t.TempDir()` exceeds the macOS 104-char sun_path limit (`bind: invalid argument`); and (2) `git.NonInteractiveEnv` sets `PWD=.` for `axi run`&#39;s `dir=&#34;.&#34;` push, which leaks into the local-push post-receive hook where macOS `/bin/sh` trusts the relative `$PWD`, making `$(pwd)` return `.` so the daemon rejects `invalid gate path: .` (Linux CI uses dash, which ignores a relative PWD, so the harness passes there). Neither touches the resolveActiveRun/resolveRun code under review. I worked around both (short TMPDIR + triggering gates via a manual push from an absolute cwd) to demonstrate the change end-to-end, so this did not block evidence.
- <code>`go test ./internal/cli -run &#39;TestResolveActiveRun|TestResolveRun&#39; -count=1 -v` — 7 new resolution tests (branch match, cross-branch + detached-HEAD fallback, ambiguity→--run, ignores/rejects other-repo runs) all pass</code>
- <code>`go test -race ./internal/cli` — full package passes under the race detector</code>
- <code>Manual end-to-end via real daemon + gate (short TMPDIR workaround for macOS socket limit): pushed `feature/axi` and `feature/two` to leave two non-blocking pipelines `awaiting_approval` at the review gate</code>
- <code>From a worktree on `feature/sidequest` (matches neither run): `no-mistakes axi respond --action approve` → refused with `multiple active runs: … — pass --run &lt;id&gt;`; then `no-mistakes axi respond --run &lt;R1&gt; --action approve` resolved the feature/axi run across branches → `outcome: passed`</code>
- <code>With one active run remaining: `git checkout --detach` then `no-mistakes axi status` and `no-mistakes axi respond --action approve` resolved the repo&#39;s only active run with no current branch → `outcome: passed`</code>
- <code>Cross-repo scoping across two repos: `no-mistakes axi respond/status/logs --run &lt;repoB-run-id&gt;` from repo A → `belongs to a different repository`; `--run &lt;bogus&gt;` → `not found`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
