### PR TITLE
fix(cli): keep AXI runs branch-aware

### DIFF
--- a/.no-mistakes/evidence/fm/nm-concurrency-c3/axi-home-other-branch-active.txt
+++ b/.no-mistakes/evidence/fm/nm-concurrency-c3/axi-home-other-branch-active.txt
@@ -1,0 +1,19 @@
+$ cd /Users/kunchen/.no-mistakes/worktrees/9cb975a68535/01KV16T8QPK1QVBPNNSKTY63QR/.no-mistakes/evidence/fm/nm-concurrency-c3/axi-home-sandbox/repo
+$ NM_HOME=/Users/kunchen/.no-mistakes/worktrees/9cb975a68535/01KV16T8QPK1QVBPNNSKTY63QR/.no-mistakes/evidence/fm/nm-concurrency-c3/axi-home-sandbox/nm-home go run /Users/kunchen/.no-mistakes/worktrees/9cb975a68535/01KV16T8QPK1QVBPNNSKTY63QR/cmd/no-mistakes axi
+bin: /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/go-build1542504295/b001/exe/no-mistakes
+description: "Validate your code changes through the no-mistakes pipeline - automated code review, tests, lint, docs, push, PR, and CI - before they reach upstream. Use when the user asks to run no-mistakes, gate or ship or validate their changes, push safely, asks you to do a task and then validate it, or invokes /no-mistakes."
+repo: /Users/kunchen/.no-mistakes/worktrees/9cb975a68535/01KV16T8QPK1QVBPNNSKTY63QR/.no-mistakes/evidence/fm/nm-concurrency-c3/axi-home-sandbox/repo
+current_branch: feature/current
+daemon: stopped
+other_branch_active_run:
+  id: "01KV1711ZNKSASHJFJVWTP3KX9"
+  branch: feature/other
+  status: running
+  head: aaaaaaaa
+  findings: none
+  steps[1]{step,status,findings,duration_ms}:
+    review,awaiting_approval,0,0
+count: 1 of 1 total
+runs[1]{id,branch,status,head,pr}:
+  "01KV1711ZNKSASHJFJVWTP3KX9",feature/other,running,aaaaaaaa,""
+help[2]: "Run `no-mistakes axi run --intent \"<what the user set out to accomplish>\"` to validate your changes",Another active run is on feature/other; leave it alone unless you are working on that branch

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -114,6 +114,10 @@ no-mistakes axi logs --step review --full
 no-mistakes axi abort
 ```
 
+Before starting validation, agents should run the `no-mistakes axi` home view.
+If it shows `active_run`, they should resume or abort that current-branch run instead of starting over.
+If it shows `other_branch_active_run`, they should leave that run alone and start validation for the current branch with `no-mistakes axi run --intent "..."`.
+
 When an agent starts a new run, `--intent` is required and should describe what the user wanted to accomplish, not what files changed.
 Agents should prefer a few complete sentences over a terse summary, capturing user decisions, tradeoffs, constraints, ruled-out approaches, and explicit requests that would not be obvious from the diff alone.
 If the repo is on the default branch or has uncommitted changes, direct `axi run` returns a structured error with the command the agent should run instead of silently creating a branch or commit.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -52,11 +52,14 @@ It prints TOON to stdout, prints progress to stderr, and uses structured stdout 
 no-mistakes axi
 ```
 
-With no subcommand, shows the executable path, description, repo, daemon state, the active run when present, recent runs, and next-step help.
+With no subcommand, shows the executable path, description, repo, current branch, daemon state, recent runs, and next-step help.
+When the current branch has an active run, that run appears as `active_run` with any approval gate and help for `axi respond` or `axi abort`.
+When only another branch has an active run, that run appears as `other_branch_active_run`; the help tells agents to leave it alone and start validation for the current branch.
 
 ## no-mistakes axi run
 
 Start or reattach to validation for the current branch, blocking until the first approval gate, CI-ready decision point, or final outcome.
+An active run on another branch does not block starting validation for the current branch.
 
 ```sh
 no-mistakes axi run --intent "the user's goal"
@@ -108,7 +111,7 @@ The same successful-output reporting instructions apply to `axi respond` results
 
 ## no-mistakes axi status
 
-Show the active run, or the most recent run when none is active.
+Show a run, preferring the current branch's active or most recent run before falling back to repo-wide active or recent runs.
 
 ```sh
 no-mistakes axi status
@@ -117,7 +120,7 @@ no-mistakes axi status --run <id>
 
 | Flag | Type | Default | Description |
 |---|---|---|---|
-| `--run` | `string` | active or most recent | Inspect a specific run ID |
+| `--run` | `string` | resolved run | Inspect a specific run ID |
 
 ## no-mistakes axi logs
 
@@ -132,7 +135,7 @@ no-mistakes axi logs --step review --run <id>
 | Flag | Type | Default | Description |
 |---|---|---|---|
 | `--step` | `string` | (none) | Step name; required |
-| `--run` | `string` | active or most recent | Run ID to inspect |
+| `--run` | `string` | resolved run | Run ID to inspect |
 | `--full` | `bool` | `false` | Show the entire log instead of the tail |
 
 Without `--full`, long logs show the last 40 lines and a help hint for the full log.
@@ -140,6 +143,7 @@ Without `--full`, long logs show the last 40 lines and a help hint for the full 
 ## no-mistakes axi abort
 
 Cancel the active run for the current branch.
+Active runs on other branches are left alone.
 
 ```sh
 no-mistakes axi abort

--- a/internal/cli/axi.go
+++ b/internal/cli/axi.go
@@ -112,26 +112,52 @@ func runAxiHome(cmd *cobra.Command) error {
 	if alive, _ := daemon.IsRunning(env.p); alive {
 		daemonState = "running"
 	}
+	branch := currentBranchForRunResolve(cmd.Context())
+	branchDisplay := branch
+	if branchDisplay == "" {
+		branchDisplay = "unknown"
+	}
+
 	fields := []toon.Field{
 		{Key: "bin", Value: collapseHome(executablePath())},
 		{Key: "description", Value: skill.Description},
 		{Key: "repo", Value: env.repo.WorkingPath},
+		{Key: "current_branch", Value: branchDisplay},
 		{Key: "daemon", Value: daemonState},
 	}
 
-	active, err := env.d.GetActiveRun(env.repo.ID, "")
-	if err != nil {
-		return emitError(cmd, 1, fmt.Sprintf("check active run: %v", err))
+	var currentActive *db.Run
+	if branch != "" {
+		currentActive, err = env.d.GetActiveRun(env.repo.ID, branch)
+		if err != nil {
+			return emitError(cmd, 1, fmt.Sprintf("check current-branch active run: %v", err))
+		}
 	}
+
+	var otherActive *db.Run
+	if currentActive == nil {
+		otherActive, err = env.d.GetActiveRun(env.repo.ID, "")
+		if err != nil {
+			return emitError(cmd, 1, fmt.Sprintf("check repo active run: %v", err))
+		}
+		if otherActive != nil && otherActive.Branch == branch {
+			otherActive = nil
+		}
+	}
+
 	gated := false
-	if active != nil {
-		steps, _ := env.d.GetStepsByRun(active.ID)
-		rv := runViewFromDB(active, steps)
-		fields = append(fields, runObjectField(rv))
+	if currentActive != nil {
+		steps, _ := env.d.GetStepsByRun(currentActive.ID)
+		rv := runViewFromDB(currentActive, steps)
+		fields = append(fields, runObjectFieldWithKey("active_run", rv))
 		if gate, ok := rv.awaitingStep(); ok {
 			gated = true
 			fields = append(fields, gateFields(gate)...)
 		}
+	} else if otherActive != nil {
+		steps, _ := env.d.GetStepsByRun(otherActive.ID)
+		rv := runViewFromDB(otherActive, steps)
+		fields = append(fields, runObjectFieldWithKey("other_branch_active_run", rv))
 	}
 
 	runs, err := env.d.GetRunsByRepo(env.repo.ID)
@@ -142,8 +168,11 @@ func runAxiHome(cmd *cobra.Command) error {
 
 	help := []string{}
 	switch {
-	case active == nil:
+	case currentActive == nil:
 		help = append(help, `Run `+"`"+`no-mistakes axi run --intent "<what the user set out to accomplish>"`+"`"+` to validate your changes`)
+		if otherActive != nil {
+			help = append(help, fmt.Sprintf("Another active run is on %s; leave it alone unless you are working on that branch", otherActive.Branch))
+		}
 	case gated:
 		help = append(help, "Run `no-mistakes axi respond --action approve` to clear the current gate")
 	default:

--- a/internal/cli/axi_render.go
+++ b/internal/cli/axi_render.go
@@ -220,6 +220,10 @@ func joinComma(parts []string) string {
 
 // runObjectField renders a run as a TOON "run:" object with a steps table.
 func runObjectField(rv runView) toon.Field {
+	return runObjectFieldWithKey("run", rv)
+}
+
+func runObjectFieldWithKey(key string, rv runView) toon.Field {
 	fields := []toon.Field{
 		{Key: "id", Value: rv.ID},
 		{Key: "branch", Value: rv.Branch},
@@ -236,7 +240,7 @@ func runObjectField(rv runView) toon.Field {
 		rows = append(rows, stepRow{Step: s.Name, Status: s.Status, Findings: s.findingCount(), DurationMS: s.DurationMS})
 	}
 	fields = append(fields, toon.Field{Key: "steps", Value: rows})
-	return toon.Field{Key: "run", Value: toon.NewObject(fields...)}
+	return toon.Field{Key: key, Value: toon.NewObject(fields...)}
 }
 
 // gateFields renders the active approval gate: the awaiting step, its findings

--- a/internal/cli/axi_test.go
+++ b/internal/cli/axi_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
+	"github.com/kunchenguid/no-mistakes/internal/paths"
 	"github.com/kunchenguid/no-mistakes/internal/skill"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
@@ -266,6 +267,82 @@ func TestStatusEmptyHelpIncludesRequiredIntent(t *testing.T) {
 func TestLogsNoRunHelpIncludesRequiredIntent(t *testing.T) {
 	if !strings.Contains(noRunLogsHelp(), "--intent") {
 		t.Fatalf("no-run logs help must include required --intent, got %q", noRunLogsHelp())
+	}
+}
+
+func TestAxiHomeStartsCurrentBranchWhenOtherBranchIsActive(t *testing.T) {
+	repoDir := t.TempDir()
+	nmHome := t.TempDir()
+	t.Setenv("NM_HOME", nmHome)
+	run(t, repoDir, "git", "init")
+	run(t, repoDir, "git", "config", "user.email", "test@test.com")
+	run(t, repoDir, "git", "config", "user.name", "Test")
+	run(t, repoDir, "git", "commit", "--allow-empty", "-m", "initial")
+	run(t, repoDir, "git", "checkout", "-b", "feature/current")
+	rawRoot, err := filepath.EvalSymlinks(repoDir)
+	if err != nil {
+		rawRoot = repoDir
+	}
+	chdir(t, rawRoot)
+
+	p := paths.WithRoot(nmHome)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	database, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+	repo, err := database.InsertRepoWithID("repo-1", rawRoot, "origin", "main")
+	if err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+	other, err := database.InsertRun(repo.ID, "feature/other", "head-other", "base")
+	if err != nil {
+		t.Fatalf("insert other run: %v", err)
+	}
+	if err := database.UpdateRunStatus(other.ID, types.RunRunning); err != nil {
+		t.Fatalf("mark other run running: %v", err)
+	}
+	step, err := database.InsertStepResult(other.ID, types.StepReview)
+	if err != nil {
+		t.Fatalf("insert other step: %v", err)
+	}
+	if err := database.UpdateStepStatus(step.ID, types.StepStatusAwaitingApproval); err != nil {
+		t.Fatalf("mark other step awaiting: %v", err)
+	}
+	if err := database.SetStepFindings(step.ID, findingsJSON(t, nil, "other branch gate")); err != nil {
+		t.Fatalf("set other step findings: %v", err)
+	}
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&out)
+	if err := runAxiHome(cmd); err != nil {
+		t.Fatalf("axi home: %v\n%s", err, out.String())
+	}
+	got := out.String()
+	for _, want := range []string{
+		"current_branch: feature/current",
+		"other_branch_active_run:",
+		"branch: feature/other",
+		"no-mistakes axi run --intent",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("axi home missing %q in:\n%s", want, got)
+		}
+	}
+	for _, forbidden := range []string{
+		"\nactive_run:",
+		"gate:",
+		"no-mistakes axi respond --action approve",
+		"no-mistakes axi abort",
+	} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("axi home should not tell the agent to act on another branch via %q, got:\n%s", forbidden, got)
+		}
 	}
 }
 

--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -123,6 +123,96 @@ func TestPushReceivedSkipStepsConfiguresExecutor(t *testing.T) {
 	}
 }
 
+func TestPushReceivedAllowsDifferentBranchRunsConcurrently(t *testing.T) {
+	started := make(chan string, 2)
+	p, d := startTestDaemonWithSteps(t, func() []pipeline.Step {
+		return []pipeline.Step{&notifyBlockStep{name: types.StepReview, started: started}}
+	})
+
+	_, headSHA := setupTestGitRepo(t, p, d, "concurrent-branch-repo")
+
+	client, err := ipc.Dial(p.Socket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	var first ipc.PushReceivedResult
+	if err := client.Call(ipc.MethodPushReceived, &ipc.PushReceivedParams{
+		Gate: p.RepoDir("concurrent-branch-repo"),
+		Ref:  "refs/heads/feature/one",
+		Old:  "0000000000000000000000000000000000000000",
+		New:  headSHA,
+	}, &first); err != nil {
+		t.Fatal(err)
+	}
+	waitForStartedBranch(t, started, "feature/one")
+
+	var second ipc.PushReceivedResult
+	if err := client.Call(ipc.MethodPushReceived, &ipc.PushReceivedParams{
+		Gate: p.RepoDir("concurrent-branch-repo"),
+		Ref:  "refs/heads/feature/two",
+		Old:  "0000000000000000000000000000000000000000",
+		New:  headSHA,
+	}, &second); err != nil {
+		t.Fatal(err)
+	}
+	waitForStartedBranch(t, started, "feature/two")
+
+	for _, tc := range []struct {
+		branch string
+		runID  string
+	}{
+		{branch: "feature/one", runID: first.RunID},
+		{branch: "feature/two", runID: second.RunID},
+	} {
+		active, err := d.GetActiveRun("concurrent-branch-repo", tc.branch)
+		if err != nil {
+			t.Fatalf("get active run for %s: %v", tc.branch, err)
+		}
+		if active == nil {
+			t.Fatalf("expected active run for %s", tc.branch)
+		}
+		if active.ID != tc.runID {
+			t.Fatalf("active run for %s = %s, want %s", tc.branch, active.ID, tc.runID)
+		}
+		if active.Status != types.RunRunning {
+			t.Fatalf("active run for %s status = %s, want running", tc.branch, active.Status)
+		}
+	}
+}
+
+type notifyBlockStep struct {
+	name    types.StepName
+	started chan<- string
+}
+
+func (s *notifyBlockStep) Name() types.StepName { return s.name }
+
+func (s *notifyBlockStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, error) {
+	select {
+	case s.started <- sctx.Run.Branch:
+	default:
+	}
+	<-sctx.Ctx.Done()
+	return nil, sctx.Ctx.Err()
+}
+
+func waitForStartedBranch(t *testing.T, started <-chan string, branch string) {
+	t.Helper()
+	timeout := time.After(3 * time.Second)
+	for {
+		select {
+		case got := <-started:
+			if got == branch {
+				return
+			}
+		case <-timeout:
+			t.Fatalf("run for branch %s did not start", branch)
+		}
+	}
+}
+
 func TestRerunSkipStepsConfiguresExecutor(t *testing.T) {
 	review := &mockPassStep{name: types.StepReview}
 	testStep := &mockPassStep{name: types.StepTest}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -223,10 +223,10 @@ run without checking back.
 ## Inspecting state
 
 ` + "```sh" + `
-no-mistakes axi               # home view: active run, recent runs, next steps
-no-mistakes axi status        # full detail of the active (or most recent) run
+no-mistakes axi               # home view: current branch, active runs, next steps
+no-mistakes axi status        # full detail of the resolved run
 no-mistakes axi logs --step <name> --full   # full log output of one step
-no-mistakes axi abort         # cancel the active run
+no-mistakes axi abort         # cancel the current-branch active run
 ` + "```" + `
 
 ## Reading the output

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -93,9 +93,10 @@ If any of these is not met, ` + "`axi run`" + ` returns an ` + "`error:`" + ` wi
 to fix it - read it and act on it (commit your work, or create a branch). If the
 repository is not initialized, run ` + "`no-mistakes init`" + ` first; if the ` + "`no-mistakes`" + `
 command itself is missing or misbehaving, ` + "`no-mistakes doctor`" + ` reports what is
-wrong. Before starting, a quick ` + "`no-mistakes axi`" + ` (home view) shows whether a
-run is already active - resume or ` + "`axi abort`" + ` it rather than starting a second
-run on top of it.
+wrong.
+Before starting, run ` + "`no-mistakes axi`" + ` (home view).
+If it shows an active run on your current branch, resume it or use ` + "`axi abort`" + ` before starting over.
+If it shows an active run on another branch, leave that run alone and start validation for your current branch with ` + "`no-mistakes axi run --intent \"...\"`" + `.
 
 ## Intent is required
 

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -184,10 +184,10 @@ run without checking back.
 ## Inspecting state
 
 ```sh
-no-mistakes axi               # home view: active run, recent runs, next steps
-no-mistakes axi status        # full detail of the active (or most recent) run
+no-mistakes axi               # home view: current branch, active runs, next steps
+no-mistakes axi status        # full detail of the resolved run
 no-mistakes axi logs --step <name> --full   # full log output of one step
-no-mistakes axi abort         # cancel the active run
+no-mistakes axi abort         # cancel the current-branch active run
 ```
 
 ## Reading the output

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -54,9 +54,10 @@ If any of these is not met, `axi run` returns an `error:` with the exact command
 to fix it - read it and act on it (commit your work, or create a branch). If the
 repository is not initialized, run `no-mistakes init` first; if the `no-mistakes`
 command itself is missing or misbehaving, `no-mistakes doctor` reports what is
-wrong. Before starting, a quick `no-mistakes axi` (home view) shows whether a
-run is already active - resume or `axi abort` it rather than starting a second
-run on top of it.
+wrong.
+Before starting, run `no-mistakes axi` (home view).
+If it shows an active run on your current branch, resume it or use `axi abort` before starting over.
+If it shows an active run on another branch, leave that run alone and start validation for your current branch with `no-mistakes axi run --intent "..."`.
 
 ## Intent is required
 


### PR DESCRIPTION
## Intent

Ship the approved fuller fix for no-mistakes concurrency handling: make the agent-facing AXI home view branch-aware so a run active on another branch is displayed separately and does not block starting validation on the current branch, update the no-mistakes skill preflight to tell agents to resume or abort only current-branch active runs while leaving other-branch runs alone, and add tests proving AXI home does not instruct agents to respond to another branch plus daemon coverage that different-branch runs can be active concurrently.

## What Changed

- Updated the AXI home and run resolution flow to distinguish active runs on the current branch from runs active on other branches, so another branch no longer blocks starting validation.
- Adjusted AXI rendering, docs, and the no-mistakes skill preflight guidance to show other-branch runs separately and only resume or abort current-branch active runs.
- Added CLI and daemon coverage for current-branch run selection, non-blocking other-branch AXI home output, and concurrent active runs across different branches.

## Risk Assessment

✅ Low: The change is small and well-bounded to AXI home/skill guidance, uses existing branch-specific active-run lookup semantics, and includes targeted coverage for the intended concurrency behavior.

## Testing

Focused AXI tests, daemon concurrency coverage, and full relevant package tests all passed; the recorded CLI transcript demonstrates an end-user `no-mistakes axi` home view on `feature/current` that shows the active `feature/other` run separately, offers `axi run --intent`, and does not instruct responding to or aborting the other-branch gate.

<details>
<summary>Evidence: AXI home transcript with other branch active</summary>

Source: [AXI home transcript with other branch active](https://github.com/kunchenguid/no-mistakes/blob/c58aeec77fac5058f33f883ee6b059e38ccdec32/.no-mistakes/evidence/fm/nm-concurrency-c3/axi-home-other-branch-active.txt)

```text
Shows `current_branch: feature/current`, `other_branch_active_run` for `feature/other`, and help to run `no-mistakes axi run --intent ...`; no `axi respond` or `axi abort` instruction appears.
```
</details>
<details>
<summary>Evidence: Daemon concurrent branch test signal</summary>

```text
`TestPushReceivedAllowsDifferentBranchRunsConcurrently` pushed `refs/heads/feature/one` and `refs/heads/feature/two`; the daemon accepted both and the test verified both branch-specific active runs remained `running` concurrently.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/cli -run 'TestAxiHomeStartsCurrentBranchWhenOtherBranchIsActive|TestResolveRunPrefersCurrentBranchLatestRun' -count=1 -v`
- `go test ./internal/daemon -run 'TestPushReceivedAllowsDifferentBranchRunsConcurrently' -count=1 -v`
- `go test ./internal/cli ./internal/daemon -run 'TestAxiHomeStartsCurrentBranchWhenOtherBranchIsActive|TestResolveRunPrefersCurrentBranchLatestRun|TestPushReceivedAllowsDifferentBranchRunsConcurrently' -count=1`
- `go test ./internal/cli ./internal/daemon -count=1`
- <code>Manual evidence harness created an isolated git repo on `feature/current`, seeded the no-mistakes DB with a running gated `feature/other` run, invoked `go run &lt;repo&gt;/cmd/no-mistakes axi` with isolated `NM_HOME`, and recorded the AXI home output.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
