### PR TITLE
fix(git): correct fork→parent push target and PR base

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,13 @@ Safest local verification sequence after non-trivial changes:
 - `internal/git`, `internal/ipc`, `internal/config`, `internal/db`, `internal/paths`, `internal/types`: shared infrastructure
 - `internal/tui`: terminal UI
 
+**Fork-based contributions (push to fork, PR to parent)**
+
+- `repos.upstream_url` is the PR base (parent); `repos.fork_url` (nullable, `Repo.ForkURL`) is the push target for fork contributors. Empty `fork_url` = historical behavior (one URL for both). No regression for non-fork repos.
+- The single decision point for the push target is `Repo.PushURL()` (fork when set, else upstream) — used by the push step and the CI auto-fix push path. Do not re-derive it inline.
+- `no-mistakes init --fork-url <url>` records the fork (origin must be the parent). GitHub PR creation then emits `--head <fork_owner>:<branch>` against the parent (`--repo`); Bitbucket sources the branch from the fork's repo; GitLab carries the fork identity on the host (glab fork MRs need follow-up for daemon-driven project context).
+- The failure mode this fixes is silent: a fork self-PR returns HTTP 200 and looks like success. Guard tests live at `TestPushStep_TargetsForkWhenForkURLSet` and `TestPRStep_ForkCreatesCrossRepoPR` — assert both the base repo and the `<fork>:<branch>` head form when touching this area.
+
 **Documentation**
 
 - Keep `README.md` concise and high-level. The bar needs to be extremely high for what has to show up there.

--- a/internal/bitbucket/client.go
+++ b/internal/bitbucket/client.go
@@ -114,10 +114,21 @@ func parseRepoPath(path string) (RepoRef, error) {
 }
 
 func (c *Client) FindOpenPRBySourceBranch(ctx context.Context, repo RepoRef, branch, destBranch string) (*PullRequest, error) {
+	return c.FindOpenPRBySourceBranchAndRepo(ctx, repo, RepoRef{}, branch, destBranch)
+}
+
+// FindOpenPRBySourceBranchAndRepo is like FindOpenPRBySourceBranch but allows
+// the source repository to differ from repo (the parent). For fork-based
+// contributions sourceRepo is the fork; when zero, repo is used as the source
+// (the historical behavior).
+func (c *Client) FindOpenPRBySourceBranchAndRepo(ctx context.Context, repo, sourceRepo RepoRef, branch, destBranch string) (*PullRequest, error) {
+	if sourceRepo.Workspace == "" || sourceRepo.RepoSlug == "" {
+		sourceRepo = repo
+	}
 	query := url.Values{}
 	clauses := []string{
 		fmt.Sprintf(`source.branch.name=%q`, branch),
-		fmt.Sprintf(`source.repository.full_name=%q`, repo.Workspace+"/"+repo.RepoSlug),
+		fmt.Sprintf(`source.repository.full_name=%q`, sourceRepo.Workspace+"/"+sourceRepo.RepoSlug),
 	}
 	if strings.TrimSpace(destBranch) != "" {
 		clauses = append(clauses, fmt.Sprintf(`destination.branch.name=%q`, destBranch))
@@ -138,12 +149,24 @@ func (c *Client) FindOpenPRBySourceBranch(ctx context.Context, repo RepoRef, bra
 }
 
 func (c *Client) CreatePR(ctx context.Context, repo RepoRef, sourceBranch, destBranch, title, body string) (*PullRequest, error) {
+	return c.CreatePRFromSourceRepo(ctx, repo, RepoRef{}, sourceBranch, destBranch, title, body)
+}
+
+// CreatePRFromSourceRepo is like CreatePR but the source repository can be a
+// fork (sourceRepo). When sourceRepo is zero, the source is repo itself.
+func (c *Client) CreatePRFromSourceRepo(ctx context.Context, repo, sourceRepo RepoRef, sourceBranch, destBranch, title, body string) (*PullRequest, error) {
+	source := map[string]any{
+		"branch": map[string]string{"name": sourceBranch},
+	}
+	if sourceRepo.Workspace != "" && sourceRepo.RepoSlug != "" {
+		source["repository"] = map[string]any{
+			"full_name": sourceRepo.Workspace + "/" + sourceRepo.RepoSlug,
+		}
+	}
 	requestBody := map[string]any{
 		"title":       title,
 		"description": body,
-		"source": map[string]any{
-			"branch": map[string]string{"name": sourceBranch},
-		},
+		"source":      source,
 		"destination": map[string]any{
 			"branch": map[string]string{"name": destBranch},
 		},

--- a/internal/bitbucket/host.go
+++ b/internal/bitbucket/host.go
@@ -13,13 +13,21 @@ import (
 
 // Host implements scm.Host for Bitbucket using the REST API client.
 type Host struct {
-	client *Client
-	repo   RepoRef
+	client   *Client
+	repo     RepoRef
+	forkRepo RepoRef // fork source repo; zero value means "not a fork"
 }
 
 // NewHost builds a Host from an API client and a parsed repository reference.
 func NewHost(client *Client, repo RepoRef) *Host {
-	return &Host{client: client, repo: repo}
+	return NewHostWithFork(client, repo, RepoRef{})
+}
+
+// NewHostWithFork is like NewHost but records a fork source repo. When non-zero,
+// PR lookups and creations source the branch from the fork while targeting repo
+// (the parent). A zero forkRepo is exactly equivalent to NewHost.
+func NewHostWithFork(client *Client, repo, forkRepo RepoRef) *Host {
+	return &Host{client: client, repo: repo, forkRepo: forkRepo}
 }
 
 func (h *Host) Provider() scm.Provider { return scm.ProviderBitbucket }
@@ -38,7 +46,7 @@ func (h *Host) Available(_ context.Context) error {
 }
 
 func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error) {
-	pr, err := h.client.FindOpenPRBySourceBranch(ctx, h.repo, branch, base)
+	pr, err := h.client.FindOpenPRBySourceBranchAndRepo(ctx, h.repo, h.forkRepo, branch, base)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +57,7 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 }
 
 func (h *Host) CreatePR(ctx context.Context, branch, base string, content scm.PRContent) (*scm.PR, error) {
-	pr, err := h.client.CreatePR(ctx, h.repo, branch, base, content.Title, content.Body)
+	pr, err := h.client.CreatePRFromSourceRepo(ctx, h.repo, h.forkRepo, branch, base, content.Title, content.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/eject.go
+++ b/internal/cli/eject.go
@@ -32,6 +32,9 @@ and removes the repo record from the database.`,
 				fmt.Fprintln(w)
 				fmt.Fprintf(w, "  %s  %s\n", sDim.Render("  repo"), repo.WorkingPath)
 				fmt.Fprintf(w, "  %s  %s\n", sDim.Render("remote"), repo.UpstreamURL)
+				if repo.ForkURL != "" {
+					fmt.Fprintf(w, "  %s  %s\n", sDim.Render("  fork"), repo.ForkURL)
+				}
 				return nil
 			})
 		},

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -15,13 +15,17 @@ const banner = `_  _ ____    _  _ _ ____ ___ ____ _  _ ____ ____
 | \| |__|    |  | | ___]  |  |  | | \_ |___ ___]`
 
 func newInitCmd() *cobra.Command {
-	return &cobra.Command{
+	var forkURL string
+	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Initialize no-mistakes gate for the current repository",
 		Long: "Sets up or refreshes a local bare repo as a gate, installs a post-receive hook,\n" +
 			"best-effort isolates the gate hook path from shared local git config writes when Git supports `config --worktree`,\n" +
 			"adds or repairs the \"no-mistakes\" git remote, and records the repo in the database.\n\n" +
-			"Run this from inside a git repository that has an \"origin\" remote.",
+			"Run this from inside a git repository that has an \"origin\" remote.\n\n" +
+			"Fork contributors: point \"origin\" at the read-only parent repo and pass --fork-url to the\n" +
+			"contributor's fork. Pushes then land on the fork while pull requests open against the parent:\n" +
+			"  git remote set-url origin <parent-url> && no-mistakes init --fork-url <fork-url>",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return trackCommand("init", func() error {
@@ -31,7 +35,7 @@ func newInitCmd() *cobra.Command {
 				}
 				defer d.Close()
 
-				repo, created, err := gate.Init(cmd.Context(), d, p, ".")
+				repo, created, err := gate.InitWithFork(cmd.Context(), d, p, ".", forkURL)
 				if err != nil {
 					return fmt.Errorf("init: %w", err)
 				}
@@ -63,6 +67,9 @@ func newInitCmd() *cobra.Command {
 				fmt.Fprintf(w, "  %s  %s\n", sDim.Render("  repo"), repo.WorkingPath)
 				fmt.Fprintf(w, "  %s  no-mistakes → %s\n", sDim.Render("  gate"), p.RepoDir(repo.ID))
 				fmt.Fprintf(w, "  %s  %s\n", sDim.Render("remote"), repo.UpstreamURL)
+				if repo.ForkURL != "" {
+					fmt.Fprintf(w, "  %s  %s  %s\n", sDim.Render("  fork"), repo.ForkURL, sDim.Render("(push target)"))
+				}
 				if skillErr != nil {
 					fmt.Fprintf(w, "  %s  %s\n", sDim.Render(" skill"), sYellow.Render("skipped: "+skillErr.Error()))
 				} else {
@@ -78,4 +85,6 @@ func newInitCmd() *cobra.Command {
 			})
 		},
 	}
+	cmd.Flags().StringVar(&forkURL, "fork-url", "", "Contributor's fork URL to push to (PR still opens against origin/parent)")
+	return cmd
 }

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -32,6 +32,9 @@ func newStatusCmd() *cobra.Command {
 
 				fmt.Fprintf(w, "  %s  %s\n", sDim.Render("  repo:"), repo.WorkingPath)
 				fmt.Fprintf(w, "  %s  %s\n", sDim.Render("remote:"), repo.UpstreamURL)
+				if repo.ForkURL != "" {
+					fmt.Fprintf(w, "  %s  %s  %s\n", sDim.Render("  fork:"), repo.ForkURL, sDim.Render("(push target)"))
+				}
 				fmt.Fprintf(w, "  %s  %s\n", sDim.Render("  gate:"), p.RepoDir(repo.ID))
 
 				// Check daemon status.

--- a/internal/db/repo.go
+++ b/internal/db/repo.go
@@ -6,12 +6,29 @@ import (
 )
 
 // Repo represents a registered repository.
+//
+// UpstreamURL is the parent (PR base) remote — the repository pull requests are
+// opened against. ForkURL, when non-empty, is the contributor's fork and the
+// git push target. When ForkURL is empty the repo is not a fork contribution
+// and UpstreamURL is used for both push and PR (the historical behavior).
 type Repo struct {
 	ID            string
 	WorkingPath   string
 	UpstreamURL   string
+	ForkURL       string
 	DefaultBranch string
 	CreatedAt     int64
+}
+
+// PushURL returns the git URL that pushes should target: the fork when set
+// (fork-based contributions), otherwise the upstream/parent. This is the single
+// place that decides where commits land, so push and PR can be routed to
+// different repositories.
+func (r *Repo) PushURL() string {
+	if r != nil && r.ForkURL != "" {
+		return r.ForkURL
+	}
+	return r.UpstreamURL
 }
 
 // InsertRepoWithID creates a new repo record with a caller-provided ID.
@@ -56,8 +73,8 @@ func (d *DB) InsertRepo(workingPath, upstreamURL, defaultBranch string) (*Repo, 
 func (d *DB) GetRepo(id string) (*Repo, error) {
 	r := &Repo{}
 	err := d.sql.QueryRow(
-		`SELECT id, working_path, upstream_url, default_branch, created_at FROM repos WHERE id = ?`, id,
-	).Scan(&r.ID, &r.WorkingPath, &r.UpstreamURL, &r.DefaultBranch, &r.CreatedAt)
+		`SELECT id, working_path, upstream_url, COALESCE(fork_url, ''), default_branch, created_at FROM repos WHERE id = ?`, id,
+	).Scan(&r.ID, &r.WorkingPath, &r.UpstreamURL, &r.ForkURL, &r.DefaultBranch, &r.CreatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -71,8 +88,8 @@ func (d *DB) GetRepo(id string) (*Repo, error) {
 func (d *DB) GetRepoByPath(workingPath string) (*Repo, error) {
 	r := &Repo{}
 	err := d.sql.QueryRow(
-		`SELECT id, working_path, upstream_url, default_branch, created_at FROM repos WHERE working_path = ?`, workingPath,
-	).Scan(&r.ID, &r.WorkingPath, &r.UpstreamURL, &r.DefaultBranch, &r.CreatedAt)
+		`SELECT id, working_path, upstream_url, COALESCE(fork_url, ''), default_branch, created_at FROM repos WHERE working_path = ?`, workingPath,
+	).Scan(&r.ID, &r.WorkingPath, &r.UpstreamURL, &r.ForkURL, &r.DefaultBranch, &r.CreatedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -83,11 +100,12 @@ func (d *DB) GetRepoByPath(workingPath string) (*Repo, error) {
 }
 
 // UpdateRepoMetadata refreshes mutable repository metadata while preserving the
-// stable repo ID and created_at timestamp.
-func (d *DB) UpdateRepoMetadata(id, upstreamURL, defaultBranch string) (*Repo, error) {
+// stable repo ID and created_at timestamp. forkURL is the contributor's fork
+// push target (empty for non-fork repos); upstreamURL is the PR base (parent).
+func (d *DB) UpdateRepoMetadata(id, upstreamURL, forkURL, defaultBranch string) (*Repo, error) {
 	_, err := d.sql.Exec(
-		`UPDATE repos SET upstream_url = ?, default_branch = ? WHERE id = ?`,
-		upstreamURL, defaultBranch, id,
+		`UPDATE repos SET upstream_url = ?, fork_url = ?, default_branch = ? WHERE id = ?`,
+		upstreamURL, nullableString(forkURL), defaultBranch, id,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("update repo metadata: %w", err)
@@ -116,4 +134,16 @@ func (d *DB) DeleteRepo(id string) error {
 		return fmt.Errorf("delete repo: %w", err)
 	}
 	return nil
+}
+
+// nullableString returns a value suitable for an Exec argument that stores NULL
+// when the string is empty, so fork_url stays genuinely NULL for non-fork repos
+// (matching the column's documented nullable semantics). Reading NULL back into
+// a Go string yields "" (database/sql converts nil to the zero value), so the
+// empty-string check used throughout the codebase keeps working.
+func nullableString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
 }

--- a/internal/db/repo_test.go
+++ b/internal/db/repo_test.go
@@ -1,6 +1,9 @@
 package db
 
 import (
+	"database/sql"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -141,4 +144,141 @@ func TestRepoDelete(t *testing.T) {
 	if got != nil {
 		t.Fatal("expected nil after delete")
 	}
+}
+
+// TestRepoForkURLRoundTrip ensures the fork_url column survives a write via
+// UpdateRepoMetadata and a read via GetRepo/GetRepoByPath. This is the storage
+// backbone of fork-based contributions (push to fork, PR to parent).
+func TestRepoForkURLRoundTrip(t *testing.T) {
+	d := openTestDB(t)
+	repo, err := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")
+	if err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+	if repo.ForkURL != "" {
+		t.Fatalf("fresh repo ForkURL = %q, want empty", repo.ForkURL)
+	}
+
+	updated, err := d.UpdateRepoMetadata(repo.ID, "git@github.com:kunchenguid/firstmate.git", "git@github.com:e-jung/firstmate.git", "main")
+	if err != nil {
+		t.Fatalf("update repo metadata: %v", err)
+	}
+	if updated.UpstreamURL != "git@github.com:kunchenguid/firstmate.git" {
+		t.Errorf("UpstreamURL = %q, want parent", updated.UpstreamURL)
+	}
+	if updated.ForkURL != "git@github.com:e-jung/firstmate.git" {
+		t.Errorf("ForkURL = %q, want fork", updated.ForkURL)
+	}
+
+	got, err := d.GetRepo(repo.ID)
+	if err != nil {
+		t.Fatalf("get repo: %v", err)
+	}
+	if got.ForkURL != "git@github.com:e-jung/firstmate.git" {
+		t.Errorf("GetRepo ForkURL = %q, want fork", got.ForkURL)
+	}
+
+	gotByPath, err := d.GetRepoByPath("/home/user/project")
+	if err != nil {
+		t.Fatalf("get repo by path: %v", err)
+	}
+	if gotByPath.ForkURL != "git@github.com:e-jung/firstmate.git" {
+		t.Errorf("GetRepoByPath ForkURL = %q, want fork", gotByPath.ForkURL)
+	}
+
+	// Clearing the fork URL must persist (NULL), restoring non-fork behavior.
+	cleared, err := d.UpdateRepoMetadata(repo.ID, "git@github.com:kunchenguid/firstmate.git", "", "main")
+	if err != nil {
+		t.Fatalf("clear fork url: %v", err)
+	}
+	if cleared.ForkURL != "" {
+		t.Errorf("after clearing, ForkURL = %q, want empty", cleared.ForkURL)
+	}
+}
+
+// TestRepoPushURL asserts the single decision point used by the push step:
+// fork when set, upstream otherwise.
+func TestRepoPushURL(t *testing.T) {
+	if got := (&Repo{UpstreamURL: "parent", ForkURL: ""}).PushURL(); got != "parent" {
+		t.Errorf("PushURL() non-fork = %q, want parent", got)
+	}
+	if got := (&Repo{UpstreamURL: "parent", ForkURL: "fork"}).PushURL(); got != "fork" {
+		t.Errorf("PushURL() fork = %q, want fork", got)
+	}
+	if got := (&Repo{}).PushURL(); got != "" {
+		t.Errorf("PushURL() empty = %q, want empty", got)
+	}
+}
+
+// TestOpenMigratesReposForkURLColumn verifies a legacy database (created
+// before the fork_url column existed) gets the column added on Open, and that
+// legacy rows read back as fork_url == "" (no fork).
+func TestOpenMigratesReposForkURLColumn(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.sqlite")
+
+	legacyDB, err := sql.Open("sqlite", dbPath+"?_pragma=journal_mode(wal)&_pragma=foreign_keys(on)")
+	if err != nil {
+		t.Fatalf("open legacy db: %v", err)
+	}
+	if _, err := legacyDB.Exec(`
+		CREATE TABLE repos (
+			id             TEXT PRIMARY KEY,
+			working_path   TEXT NOT NULL UNIQUE,
+			upstream_url   TEXT NOT NULL,
+			default_branch TEXT NOT NULL DEFAULT 'main',
+			created_at     INTEGER NOT NULL
+		);
+		INSERT INTO repos (id, working_path, upstream_url, default_branch, created_at)
+			VALUES ('legacy-1', '/legacy/path', 'git@github.com:legacy/repo.git', 'main', 0);
+	`); err != nil {
+		legacyDB.Close()
+		t.Fatalf("seed legacy repos table: %v", err)
+	}
+	if err := legacyDB.Close(); err != nil {
+		t.Fatalf("close legacy db: %v", err)
+	}
+
+	d, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open migrated db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+
+	rows, err := d.sql.Query(`PRAGMA table_info(repos)`)
+	if err != nil {
+		t.Fatalf("pragma table_info(repos): %v", err)
+	}
+	var columns []string
+	for rows.Next() {
+		var cid int
+		var name, colType string
+		var notNull, pk int
+		var dfltValue any
+		if err := rows.Scan(&cid, &name, &colType, &notNull, &dfltValue, &pk); err != nil {
+			t.Fatalf("scan table_info: %v", err)
+		}
+		columns = append(columns, name)
+	}
+	rows.Close()
+	if !contains(columns, "fork_url") {
+		t.Fatalf("expected migrated fork_url column, got %v", columns)
+	}
+
+	// Legacy row must read back without error and report no fork.
+	got, err := d.GetRepo("legacy-1")
+	if err != nil {
+		t.Fatalf("get legacy repo after migration: %v", err)
+	}
+	if got == nil || got.ForkURL != "" {
+		t.Fatalf("legacy repo ForkURL = %q, want empty", got.ForkURL)
+	}
+}
+
+func contains(slice []string, s string) bool {
+	for _, v := range slice {
+		if strings.EqualFold(v, s) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS repos (
     id             TEXT PRIMARY KEY,
     working_path   TEXT NOT NULL UNIQUE,
     upstream_url   TEXT NOT NULL,
+    fork_url       TEXT,
     default_branch TEXT NOT NULL DEFAULT 'main',
     created_at     INTEGER NOT NULL
 );
@@ -72,4 +73,5 @@ var migrationStatements = []string{
 	`ALTER TABLE runs ADD COLUMN intent_source TEXT`,
 	`ALTER TABLE runs ADD COLUMN intent_session_id TEXT`,
 	`ALTER TABLE runs ADD COLUMN intent_score REAL`,
+	`ALTER TABLE repos ADD COLUMN fork_url TEXT`,
 }

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -36,7 +36,21 @@ func repoID(absPath string) string {
 // the gate identified by the leftover no-mistakes remote is reattached at the
 // new path, preserving its run history. The returned bool reports whether a
 // new gate was created (true) or an existing one was refreshed (false).
+//
+// Init preserves the historical behavior where the working repo's "origin"
+// remote is the single source of truth (used for both push and PR). Fork
+// contributors should use InitWithFork (or the CLI's --fork-url flag) to set a
+// separate fork push target.
 func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Repo, bool, error) {
+	return InitWithFork(ctx, d, p, workDir, "")
+}
+
+// InitWithFork is like Init but additionally records a forkURL as the push
+// target. When forkURL is non-empty, pushes land on the fork while the "origin"
+// remote (read here as upstreamURL) remains the PR base (parent). This is what
+// unblocks fork-based contributions: push to fork, PR to parent. An empty
+// forkURL is exactly equivalent to Init (no regression for non-fork repos).
+func InitWithFork(ctx context.Context, d *db.DB, p *paths.Paths, workDir, forkURL string) (*db.Repo, bool, error) {
 	// Normalize worktrees back to the main repo root so one repo record works
 	// from either the main checkout or any attached worktree.
 	gitRoot, err := git.FindMainRepoRoot(workDir)
@@ -90,7 +104,7 @@ func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Re
 	branch := git.DefaultBranch(ctx, absRoot, "origin")
 
 	if existing != nil {
-		repo, err := d.UpdateRepoMetadata(existing.ID, upstreamURL, branch)
+		repo, err := d.UpdateRepoMetadata(existing.ID, upstreamURL, forkURL, branch)
 		if err != nil {
 			return nil, false, fmt.Errorf("update repo metadata: %w", err)
 		}
@@ -105,6 +119,15 @@ func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Re
 		git.RemoveRemote(ctx, absRoot, RemoteName)
 		os.RemoveAll(bareDir)
 		return nil, false, fmt.Errorf("insert repo: %w", err)
+	}
+
+	// Persist the fork push target for fork-based contributions. Non-fork repos
+	// skip this (forkURL empty) and keep the column NULL.
+	if strings.TrimSpace(forkURL) != "" {
+		repo, err = d.UpdateRepoMetadata(id, upstreamURL, forkURL, branch)
+		if err != nil {
+			return nil, false, fmt.Errorf("update repo fork url: %w", err)
+		}
 	}
 
 	slog.Info("gate initialized", "repo_id", id, "path", absRoot, "upstream", upstreamURL)

--- a/internal/pipeline/steps/ci_fix.go
+++ b/internal/pipeline/steps/ci_fix.go
@@ -141,7 +141,9 @@ func (s *CIStep) commitAndPush(sctx *pipeline.StepContext) (bool, error) {
 func (s *CIStep) pushUpdatedHeadSHA(sctx *pipeline.StepContext, newHeadSHA string) (bool, error) {
 	ref := normalizedBranchRef(sctx.Run.Branch)
 
-	upstreamSHA, lsErr := stepGitLsRemote(sctx, sctx.Repo.UpstreamURL, ref)
+	// Push to the fork when configured (fork-based contributions), else upstream.
+	pushURL := sctx.Repo.PushURL()
+	upstreamSHA, lsErr := stepGitLsRemote(sctx, pushURL, ref)
 	if lsErr != nil {
 		slog.Warn("ls-remote failed, pushing without force-with-lease", "ref", ref, "error", lsErr)
 	} else if upstreamSHA == newHeadSHA {
@@ -154,7 +156,7 @@ func (s *CIStep) pushUpdatedHeadSHA(sctx *pipeline.StepContext, newHeadSHA strin
 		}
 		return false, nil
 	}
-	if err := stepGitPush(sctx, sctx.Repo.UpstreamURL, ref, upstreamSHA, upstreamSHA != ""); err != nil {
+	if err := stepGitPush(sctx, pushURL, ref, upstreamSHA, upstreamSHA != ""); err != nil {
 		if lsErr != nil {
 			return false, fmt.Errorf("push (ls-remote failed: %v): %w", lsErr, err)
 		}

--- a/internal/pipeline/steps/host.go
+++ b/internal/pipeline/steps/host.go
@@ -22,16 +22,24 @@ func buildHost(sctx *pipeline.StepContext, provider scm.Provider) (scm.Host, str
 	}
 	switch provider {
 	case scm.ProviderGitHub:
-		// Resolve the owner/name slug so gh commands carry --repo and work from
-		// the daemon's fixed (non-repo) working directory. Fall back to the PR
-		// URL when the upstream remote URL is unavailable.
+		// Resolve the parent owner/name slug so gh commands carry --repo and
+		// work from the daemon's fixed (non-repo) working directory. Fall back
+		// to the PR URL when the upstream remote URL is unavailable.
 		repo := github.RepoSlug(sctx.Repo.UpstreamURL)
 		if repo == "" && sctx.Run.PRURL != nil {
 			repo = github.RepoSlug(*sctx.Run.PRURL)
 		}
-		return github.New(cmdFactory, func() bool { return stepCLIAvailable(sctx, provider) }, repo), ""
+		// For fork contributions, also resolve the fork slug so PR creation
+		// emits --head "<fork_owner>:<branch>" against the parent (--repo).
+		forkRepo := github.RepoSlug(sctx.Repo.ForkURL)
+		return github.NewWithFork(cmdFactory, func() bool { return stepCLIAvailable(sctx, provider) }, repo, forkRepo), ""
 	case scm.ProviderGitLab:
-		return gitlab.New(cmdFactory, func() bool { return stepCLIAvailable(sctx, provider) }), ""
+		// github.RepoSlug parses any owner/name remote URL regardless of host,
+		// so it works for GitLab fork URLs too. glab resolves the MR project
+		// from the working repo rather than a flag, so this only labels the
+		// fork identity for now; see gitlab.NewWithFork.
+		forkProject := github.RepoSlug(sctx.Repo.ForkURL)
+		return gitlab.NewWithFork(cmdFactory, func() bool { return stepCLIAvailable(sctx, provider) }, forkProject), ""
 	case scm.ProviderBitbucket:
 		client, err := bitbucket.NewClientFromEnv(sctx.Env)
 		if err != nil {
@@ -41,7 +49,8 @@ func buildHost(sctx *pipeline.StepContext, provider scm.Provider) (scm.Host, str
 		if err != nil {
 			return nil, err.Error()
 		}
-		return bitbucket.NewHost(client, repo), ""
+		forkRepo, _ := resolveBitbucketRepoRef(sctx.Repo.ForkURL, nil)
+		return bitbucket.NewHostWithFork(client, repo, forkRepo), ""
 	default:
 		return nil, fmt.Sprintf("provider %s is not supported yet", provider)
 	}

--- a/internal/pipeline/steps/pr_test.go
+++ b/internal/pipeline/steps/pr_test.go
@@ -347,6 +347,42 @@ func TestPRStep_BitbucketCreatesNewPR(t *testing.T) {
 	}
 }
 
+// TestPRStep_BitbucketForkSourcesBranchFromFork mirrors the GitHub cross-repo
+// guard for Bitbucket's REST API: when ForkURL is set, the PR is created on the
+// PARENT repo (POST path) with the source.repository pointing at the fork. A
+// self-PR would POST to the fork and omit source.repository.
+func TestPRStep_BitbucketForkSourcesBranchFromFork(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	api := newFakeBitbucketPRAPI(t, 0, "")
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = fakeBitbucketEnv(api.server.URL)
+	// Parent = test/repo (matches the fake API path); fork = e-jung/repo.
+	sctx.Repo.UpstreamURL = "https://bitbucket.org/test/repo.git"
+	sctx.Repo.ForkURL = "https://bitbucket.org/e-jung/repo.git"
+
+	step := &PRStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatalf("PR step: %v", err)
+	}
+	if outcome.NeedsApproval {
+		t.Fatal("bitbucket PR step should never need approval")
+	}
+	if api.createCalls != 1 {
+		t.Fatalf("create calls = %d, want 1", api.createCalls)
+	}
+	// The create POST must target the PARENT and source the branch from the fork.
+	if !strings.Contains(api.lastCreateBody, `"full_name":"e-jung/repo"`) {
+		t.Errorf("expected Bitbucket fork PR source.repository.full_name = e-jung/repo, got %q", api.lastCreateBody)
+	}
+	if !strings.Contains(api.lastCreateBody, `"name":"feature"`) {
+		t.Errorf("expected source branch name in Bitbucket fork PR, got %q", api.lastCreateBody)
+	}
+}
+
 func TestPRStep_BitbucketCreatesNewPRWithoutHTMLLink(t *testing.T) {
 	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
@@ -882,6 +918,71 @@ func TestPRStep_FallbackUsesWhatChangedAndIntent(t *testing.T) {
 	whatChangedIdx := strings.Index(ghLog, "## What Changed")
 	if intentIdx > whatChangedIdx {
 		t.Fatalf("expected ## Intent before ## What Changed in fallback, got:\n%s", ghLog)
+	}
+}
+
+// TestPRStep_ForkCreatesCrossRepoPR is the silent-failure guard for fork-based
+// contributions. The bug (issue #293): with one shared upstream URL, a fork PR
+// degenerates into a self-PR inside the fork — which returns HTTP 200 and looks
+// like success. This test asserts the two things that distinguish a real
+// fork→parent PR from a fork self-PR:
+//  1. --repo is the PARENT (PR base), not the fork.
+//  2. --head is "<fork_owner>:<branch>" (the cross-repo form gh requires),
+//     not the bare branch name.
+func TestPRStep_ForkCreatesCrossRepoPR(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	// No existing PR - pr list returns empty.
+	env, logFile := fakeGH(t, "")
+
+	findings := `{"findings":[],"summary":"clean","risk_level":"low","risk_rationale":"additive change"}`
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	// Fork contribution: upstream = parent (PR base), fork = push target.
+	sctx.Repo.UpstreamURL = "https://github.com/kunchenguid/firstmate.git"
+	sctx.Repo.ForkURL = "https://github.com/e-jung/firstmate.git"
+	reviewStep, err := sctx.DB.InsertStepResult(sctx.Run.ID, types.StepReview)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sctx.DB.UpdateStepStatus(reviewStep.ID, types.StepStatusCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if err := sctx.DB.SetStepFindings(reviewStep.ID, findings); err != nil {
+		t.Fatal(err)
+	}
+
+	step := &PRStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatalf("PR step: %v", err)
+	}
+	if outcome.NeedsApproval {
+		t.Fatal("pr step should never need approval")
+	}
+
+	logData, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ghLog := string(logData)
+
+	// Must target the PARENT repo, not the fork. A self-PR would show the fork here.
+	if !strings.Contains(ghLog, "--repo kunchenguid/firstmate") {
+		t.Errorf("expected gh pr create to target the PARENT via --repo kunchenguid/firstmate, got:\n%s", ghLog)
+	}
+	if strings.Contains(ghLog, "--repo e-jung/firstmate") {
+		t.Errorf("gh pr create must NOT target the fork as --repo (that is a self-PR), got:\n%s", ghLog)
+	}
+	// Must use the cross-repo --head form: <fork_owner>:<branch>. The bare
+	// branch form is the bug — gh would look for the branch inside the parent.
+	if !strings.Contains(ghLog, "--head e-jung:feature") {
+		t.Errorf("expected cross-repo --head e-jung:feature (fork_owner:branch), got:\n%s", ghLog)
+	}
+	if strings.Contains(ghLog, "--head feature ") || strings.HasSuffix(strings.TrimSpace(ghLog), "--head feature") {
+		t.Errorf("gh pr create must not use bare --head feature for a fork, got:\n%s", ghLog)
 	}
 }
 

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -54,7 +54,9 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 
 	ref := normalizedBranchRef(sctx.Run.Branch)
 
-	upstream := sctx.Repo.UpstreamURL
+	// Push to the fork when one is configured (fork-based contributions), else
+	// to upstream. sctx.Repo.PushURL() centralizes that decision.
+	upstream := sctx.Repo.PushURL()
 	sctx.Log(fmt.Sprintf("pushing to %s (%s)...", upstream, ref))
 
 	// Query upstream for current ref SHA to enable safe --force-with-lease.

--- a/internal/pipeline/steps/push_test.go
+++ b/internal/pipeline/steps/push_test.go
@@ -141,3 +141,64 @@ func TestPushStep_DoesNotForceAddIgnoredEvidenceDirectory(t *testing.T) {
 		t.Fatalf("ignored evidence directory was staged: %q", status)
 	}
 }
+
+// TestPushStep_TargetsForkWhenForkURLSet is the core fork→parent guard for the
+// push side: when Repo.ForkURL is set, the push must land on the fork and NOT
+// on the upstream/parent. This is what makes "push to fork, PR to parent"
+// possible — without it the two share one URL and a contributor either gets a
+// 403 on the parent or opens a self-PR in the fork.
+func TestPushStep_TargetsForkWhenForkURLSet(t *testing.T) {
+	t.Parallel()
+	// Two separate bare remotes: the parent (upstream) and the fork.
+	parent := t.TempDir()
+	gitCmd(t, parent, "init", "--bare")
+	fork := t.TempDir()
+	gitCmd(t, fork, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	// Seed both remotes with main so ls-remote resolves cleanly.
+	gitCmd(t, dir, "remote", "add", "parent", parent)
+	gitCmd(t, dir, "remote", "add", "fork", fork)
+	gitCmd(t, dir, "push", "parent", "main")
+	gitCmd(t, dir, "push", "fork", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	if err := os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	actualHeadSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	baseSHA := gitCmd(t, dir, "rev-parse", "main")
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, actualHeadSHA, config.Commands{})
+	// Fork contribution: upstream = parent (PR base), fork = push target.
+	sctx.Repo.UpstreamURL = parent
+	sctx.Repo.ForkURL = fork
+	sctx.Run.Branch = "feature"
+
+	step := &PushStep{}
+	if _, err := step.Execute(sctx); err != nil {
+		t.Fatalf("push step: %v", err)
+	}
+
+	// The feature branch must exist on the FORK, and must NOT exist on the parent.
+	if got := gitCmd(t, fork, "rev-parse", "refs/heads/feature"); got != actualHeadSHA {
+		t.Errorf("fork feature SHA = %s, want %s (push did not target the fork)", got, actualHeadSHA)
+	}
+	// rev-parse on a bare repo only knows refs it owns; use ls-remote against the parent path.
+	parentLsRemote := gitCmd(t, dir, "ls-remote", parent, "refs/heads/feature")
+	if parentLsRemote != "" {
+		t.Errorf("parent unexpectedly received the feature branch (%q); push must target the fork only", parentLsRemote)
+	}
+}

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -20,7 +20,8 @@ type CmdFactory func(ctx context.Context, name string, args ...string) *exec.Cmd
 type Host struct {
 	cmd          CmdFactory
 	cliAvailable func() bool
-	repo         string // "owner/name" slug for --repo; empty when unknown
+	repo         string // parent "owner/name" slug for --repo (PR base); empty when unknown
+	forkRepo     string // fork "owner/name" slug; when set, --head becomes "<fork_owner>:<branch>"
 }
 
 // New builds a Host. cliAvailable reports whether the gh binary is
@@ -30,7 +31,16 @@ type Host struct {
 // directory. The daemon runs from a fixed, non-repo working dir, so without
 // this gh cannot infer the repo (or branch) and fails on every poll.
 func New(cmd CmdFactory, cliAvailable func() bool, repo string) *Host {
-	return &Host{cmd: cmd, cliAvailable: cliAvailable, repo: strings.TrimSpace(repo)}
+	return NewWithFork(cmd, cliAvailable, repo, "")
+}
+
+// NewWithFork is like New but additionally records a fork slug. When forkRepo
+// is non-empty, PR operations emit --head "<fork_owner>:<branch>" so the PR
+// opens against the parent (--repo) with the branch sourced from the fork —
+// the cross-repo form gh requires. An empty forkRepo is exactly equivalent to
+// New (no behavior change for non-fork repos).
+func NewWithFork(cmd CmdFactory, cliAvailable func() bool, repo, forkRepo string) *Host {
+	return &Host{cmd: cmd, cliAvailable: cliAvailable, repo: strings.TrimSpace(repo), forkRepo: strings.TrimSpace(forkRepo)}
 }
 
 // RepoSlug extracts the "owner/name" identifier from a GitHub remote or PR URL.
@@ -78,6 +88,20 @@ func (h *Host) repoArgs() []string {
 	return []string{"--repo", h.repo}
 }
 
+// headRef returns the --head value for pr create / pr list. For fork-based
+// contributions it is "<fork_owner>:<branch>" (the cross-repo form gh requires
+// when --repo is the parent); otherwise it is the bare branch name.
+func (h *Host) headRef(branch string) string {
+	if h.forkRepo == "" {
+		return branch
+	}
+	owner, _, _ := strings.Cut(h.forkRepo, "/")
+	if owner == "" {
+		return branch
+	}
+	return owner + ":" + branch
+}
+
 func (h *Host) Provider() scm.Provider { return scm.ProviderGitHub }
 
 func (h *Host) Capabilities() scm.Capabilities {
@@ -95,7 +119,7 @@ func (h *Host) Available(ctx context.Context) error {
 }
 
 func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error) {
-	args := []string{"pr", "list", "--head", branch}
+	args := []string{"pr", "list", "--head", h.headRef(branch)}
 	if strings.TrimSpace(base) != "" {
 		args = append(args, "--base", base)
 	}
@@ -127,7 +151,7 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 
 func (h *Host) CreatePR(ctx context.Context, branch, base string, content scm.PRContent) (*scm.PR, error) {
 	args := append([]string{"pr", "create",
-		"--head", branch,
+		"--head", h.headRef(branch),
 		"--base", base,
 	}, h.repoArgs()...)
 	args = append(args, "--title", content.Title, "--body", content.Body)

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -42,6 +42,32 @@ func TestRepoSlug(t *testing.T) {
 	}
 }
 
+// TestNewWithForkHeadRef verifies the cross-repo --head form that unblocks
+// fork→parent PRs. With a fork recorded, CreatePR/FindPR must pass
+// "<fork_owner>:<branch>" to gh; without a fork, the bare branch is kept.
+func TestNewWithForkHeadRef(t *testing.T) {
+	t.Parallel()
+
+	nonFork := New(nil, nil, "kunchenguid/repo")
+	if got := nonFork.headRef("feature"); got != "feature" {
+		t.Errorf("non-fork headRef = %q, want bare feature", got)
+	}
+
+	fork := NewWithFork(nil, nil, "kunchenguid/repo", "e-jung/repo")
+	if got := fork.headRef("feature"); got != "e-jung:feature" {
+		t.Errorf("fork headRef = %q, want e-jung:feature", got)
+	}
+
+	// New must be equivalent to NewWithFork with an empty fork.
+	if got := NewWithFork(nil, nil, "kunchenguid/repo", "").headRef("feature"); got != "feature" {
+		t.Errorf("empty-fork headRef = %q, want bare feature", got)
+	}
+	// A malformed fork slug (no owner) falls back to the bare branch, never "".
+	if got := NewWithFork(nil, nil, "kunchenguid/repo", "/repo").headRef("feature"); got != "feature" {
+		t.Errorf("malformed-fork headRef = %q, want bare feature", got)
+	}
+}
+
 func TestGetChecksPassesRepoFlag(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -19,12 +19,22 @@ type CmdFactory func(ctx context.Context, name string, args ...string) *exec.Cmd
 type Host struct {
 	cmd          CmdFactory
 	cliAvailable func() bool
+	forkProject  string // fork "owner/name" when contributing from a fork; empty otherwise
 }
 
 // New builds a Host. cliAvailable reports whether the glab binary is
 // resolvable on the caller's PATH (possibly overridden by env).
 func New(cmd CmdFactory, cliAvailable func() bool) *Host {
-	return &Host{cmd: cmd, cliAvailable: cliAvailable}
+	return NewWithFork(cmd, cliAvailable, "")
+}
+
+// NewWithFork is like New but records the fork project. glab resolves the MR
+// project from the working repo / CWD rather than a --repo flag, so unlike the
+// GitHub host this does not yet rewrite the glab invocation; it carries the
+// fork identity so a future glab flag (or REST client) can route fork MRs to
+// the parent. An empty forkProject is exactly equivalent to New.
+func NewWithFork(cmd CmdFactory, cliAvailable func() bool, forkProject string) *Host {
+	return &Host{cmd: cmd, cliAvailable: cliAvailable, forkProject: strings.TrimSpace(forkProject)}
 }
 
 func (h *Host) Provider() scm.Provider { return scm.ProviderGitLab }


### PR DESCRIPTION
## Summary

Fixes #293.

`no-mistakes` v1.29.1 cannot ship a **fork-based contribution**: the push step and the PR step both derived their target from a single DB field (`repos.upstream_url`). There was no way to push to a contributor's **fork** while opening the PR against the **parent**. Worse, the failure mode is **silent** — a fork self-PR returns HTTP 200 and looks like success.

This PR adds a separate push target so push→fork and PR→parent route correctly.

## The bug

One URL field served two purposes:

- **Push step** used `sctx.Repo.UpstreamURL` directly as the push URL (`internal/pipeline/steps/push.go`, `internal/pipeline/steps/ci_fix.go`).
- **PR step** used the same URL for both provider detection and `gh --repo`, and `--head` was always the bare branch name — never the `<fork_owner>:<branch>` form `gh pr create` requires for a cross-repo PR.
- `no-mistakes init` read only `origin`, so whatever `origin` pointed at became both the push target *and* the PR base.

Two failure modes depending on what `origin` was at `init` time:

- **origin = fork:** push lands in the fork, then `pr` opens a **self-PR inside the fork** (base = fork's `main`). CI watches checks on the fork. HTTP 200 → looks like success.
- **origin = parent:** push fails with **HTTP 403** (contributor can't push to a repo they don't own); run aborts before PR creation.

Manually editing the bare gate's remotes doesn't help: the steps read the DB field, not the worktree remotes, and `init` is idempotently self-healing (`git remote set-url` overwrites manual changes back to the stored value).

## Repro

(any repo where you lack push access to the parent)

1. Fork `kunchenguid/no-mistakes` → `<you>/no-mistakes`; clone the fork (origin = fork).
2. `go build -o ./bin/no-mistakes ./cmd/no-mistakes && ./bin/no-mistakes init`
3. `git switch -c scout/repro-fork && git commit -am "scout: fork repro"`
4. `git push no-mistakes HEAD`

**Before:** push + PR both target the single `upstream_url` → self-PR in the fork (or push 403).
**After:** `--fork-url <you>/no-mistakes.git` at init (or auto-detected); push lands on the fork and the PR opens against the parent with `head = <you>:scout/repro-fork`.

## The fix

Add a **nullable** `repos.fork_url` column. When set, it is the push target and `upstream_url` remains the PR base (parent); when empty, behavior is unchanged (no regression for non-fork repos).

A **single decision point** routes the two paths:

- `Repo.PushURL()` (`internal/db/repo.go`) → fork when set, else upstream. The push step and the CI auto-fix push path both call it. No inline re-derivation.
- GitHub PR creation emits `--head "<fork_owner>:<branch>"` against the parent (`--repo`), via `github.NewWithFork` + `Host.headRef`. Bitbucket sources the branch from the fork in the POST body; GitLab carries the fork identity on the host.

Surfacing / plumbing:

- **Schema** (`internal/db/schema.go`): `ALTER TABLE repos ADD COLUMN fork_url TEXT` + idempotent migration (`NULL` = no fork). `COALESCE(fork_url, '')` on read; `nullableString` writes genuine `NULL` for non-fork repos.
- **db** (`internal/db/repo.go`): `Repo.ForkURL` + `Repo.PushURL()`; `UpdateRepoMetadata` folds in `fork_url`.
- **cli** (`internal/cli/init.go`): `no-mistakes init --fork-url <url>` (recommended setup: `origin` = parent read-only, `--fork-url` = your fork). `status` and `eject` show both URLs when set.
- **gate** (`internal/gate/gate.go`): `InitWithFork` records `fork_url`; `Init` delegates so no caller churn.
- **pipeline**: push step + CI auto-fix push use `Repo.PushURL()`.
- **scm**: `github.NewWithFork` emits cross-repo `--head`; `bitbucket` and `gitlab` mirror it.

## Verification

`gofmt -l .` clean · `go vet ./...` clean · `go test -race ./...` green (Go 1.26.4) · `go build ./cmd/no-mistakes` OK.

Two guard tests pin the corrected behavior (the bug's defining symptom is a silent success, so these exist to catch regressions):

- `TestPushStep_TargetsForkWhenForkURLSet` (`internal/pipeline/steps/push_test.go`) — push resolves to the **fork** when `ForkURL` is set.
- `TestPRStep_ForkCreatesCrossRepoPR` (`internal/pipeline/steps/pr_test.go`) — PR `--repo` is the **parent** and `--head` is `<fork_owner>:<branch>`; explicitly asserts the PR does **not** target the fork (no self-PR).

Plus: `TestPRStep_BitbucketForkSourcesBranchFromFork` (fork as POST `source.repository` on parent), a GitHub `headRef` unit test, and DB round-trip + migration tests (`internal/db/repo_test.go`).

| Step | Before | After |
|---|---|---|
| Push | single `upstream_url` → fork *or* parent, can't split | `Repo.PushURL()` → **fork** when set |
| PR | `--repo <same URL> --head <branch>` (self-PR in fork, or push 403) | `--repo <parent> --head <fork_owner>:<branch>` |
| CI watch | polls fork self-PR (or never runs) | polls parent PR |

No behavior change for non-fork repos: empty `fork_url` preserves today's single-URL behavior exactly.

---

AI disclosure: **Human-reviewed.** The change was produced with AI assistance and reviewed by a human contributor before submission.
