### PR TITLE
fix(security): redact embedded credentials from upstream URLs in logs and errors

### DIFF
--- a/cmd/no-mistakes/main.go
+++ b/cmd/no-mistakes/main.go
@@ -97,7 +97,7 @@ func cliLogWriter() io.Writer {
 	if err != nil {
 		return io.Discard
 	}
-	f, err := os.OpenFile(p.CLILog(), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	f, err := os.OpenFile(p.CLILog(), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return io.Discard
 	}

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -294,7 +294,7 @@ func runWizardWithMode(ctx context.Context, p *paths.Paths, state *repoState, sk
 func captureAgentServerOutput(p *paths.Paths) func() {
 	_ = os.MkdirAll(p.LogsDir(), 0o755)
 	logPath := filepath.Join(p.LogsDir(), "wizard-agent.log")
-	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		agent.SetManagedServerOutput(discardWriter{})
 		return func() { agent.SetManagedServerOutput(nil) }

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -222,7 +222,7 @@ func startDetachedDaemon(p *paths.Paths) error {
 		return fmt.Errorf("resolve executable: %w", err)
 	}
 
-	logFile, err := os.OpenFile(p.DaemonLog(), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	logFile, err := os.OpenFile(p.DaemonLog(), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return fmt.Errorf("open daemon log: %w", err)
 	}

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -66,6 +66,12 @@ func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Re
 	if err != nil {
 		return nil, false, fmt.Errorf("get origin url: %w", err)
 	}
+	// Redact embedded credentials for everything that is persisted, logged,
+	// or surfaced to the user. The bare gate keeps the full URL on its
+	// "origin" remote (via provisionGate below) so worktrees carved from it
+	// can still authenticate pushes; the push step resolves that credential
+	// at run time instead of trusting the DB copy.
+	redactedUpstreamURL := git.RedactURL(upstreamURL)
 
 	id := repoID(absRoot)
 	if existing != nil {
@@ -90,7 +96,7 @@ func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Re
 	branch := git.DefaultBranch(ctx, absRoot, "origin")
 
 	if existing != nil {
-		repo, err := d.UpdateRepoMetadata(existing.ID, upstreamURL, branch)
+		repo, err := d.UpdateRepoMetadata(existing.ID, redactedUpstreamURL, branch)
 		if err != nil {
 			return nil, false, fmt.Errorf("update repo metadata: %w", err)
 		}
@@ -99,7 +105,7 @@ func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Re
 	}
 
 	// Insert repo record with deterministic ID.
-	repo, err := d.InsertRepoWithID(id, absRoot, upstreamURL, branch)
+	repo, err := d.InsertRepoWithID(id, absRoot, redactedUpstreamURL, branch)
 	if err != nil {
 		// Rollback: remove remote and bare repo.
 		git.RemoveRemote(ctx, absRoot, RemoteName)
@@ -107,7 +113,7 @@ func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Re
 		return nil, false, fmt.Errorf("insert repo: %w", err)
 	}
 
-	slog.Info("gate initialized", "repo_id", id, "path", absRoot, "upstream", upstreamURL)
+	slog.Info("gate initialized", "repo_id", id, "path", absRoot, "upstream", redactedUpstreamURL)
 	return repo, true, nil
 }
 

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kunchenguid/no-mistakes/internal/db"
@@ -842,5 +843,63 @@ func TestInit_PostReceiveSurvivesHooksPathPoisoning(t *testing.T) {
 
 	if _, err := os.Stat(marker); err != nil {
 		t.Fatalf("post-receive did not fire after husky poisoned core.hookspath: %v", err)
+	}
+}
+
+// TestInitRedactsCredentialURL asserts that an origin URL carrying embedded
+// credentials (e.g. a fine-grained PAT) is stored redacted in the DB and in
+// the returned repo record, while the bare gate's "origin" remote keeps the
+// full credentialled URL so worktrees can still authenticate pushes.
+//
+// The upstream host is an unreachable loopback address so DefaultBranch's
+// ls-remote fails fast and falls back to "main" without any real network I/O.
+func TestInitRedactsCredentialURL(t *testing.T) {
+	workDir := setupTestRepo(t)
+	const token = "ghp_secret_DO_NOT_LEAK"
+	credURL := "https://x-access-token:" + token + "@127.0.0.1:1/o/r.git"
+	if out, err := exec.Command("git", "-C", workDir, "remote", "set-url", "origin", credURL).CombinedOutput(); err != nil {
+		t.Fatalf("set credentialled origin: %v: %s", err, out)
+	}
+
+	nmRoot := t.TempDir()
+	p := paths.WithRoot(nmRoot)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	d := openTestDB(t, p)
+	ctx := context.Background()
+
+	repo, _, err := Init(ctx, d, p, workDir)
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	// The returned repo record (and thus anything logged from it) must not
+	// carry the credential.
+	if strings.Contains(repo.UpstreamURL, token) {
+		t.Errorf("returned repo.UpstreamURL leaked credential: %q", repo.UpstreamURL)
+	}
+	if !strings.Contains(repo.UpstreamURL, "***@127.0.0.1:1/o/r.git") {
+		t.Errorf("expected redacted URL, got %q", repo.UpstreamURL)
+	}
+
+	// The persisted DB row must match the redacted form.
+	dbRepo, err := d.GetRepo(repo.ID)
+	if err != nil {
+		t.Fatalf("get repo: %v", err)
+	}
+	if strings.Contains(dbRepo.UpstreamURL, token) {
+		t.Errorf("DB repo.UpstreamURL leaked credential: %q", dbRepo.UpstreamURL)
+	}
+
+	// The bare gate's origin must still carry the full credential so pushes
+	// from carved worktrees can authenticate.
+	bareDir := p.RepoDir(repo.ID)
+	gateOrigin, err := gitpkg.GetRemoteURL(ctx, bareDir, "origin")
+	if err != nil {
+		t.Fatalf("get gate origin: %v", err)
+	}
+	if gateOrigin != credURL {
+		t.Errorf("gate origin = %q, want full credentialled URL %q (credential must be preserved for pushes)", gateOrigin, credURL)
 	}
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -20,8 +21,33 @@ func IsZeroSHA(sha string) bool {
 	return sha == "0000000000000000000000000000000000000000"
 }
 
+// embeddedCredentialRe matches the "scheme://userinfo@" prefix of a URL,
+// where userinfo is "user", "user:password", or a bare token. It requires a
+// valid scheme so scp-like SSH URLs (git@host:path), local paths, refs, and
+// flags are left untouched. The password character class excludes '@' and
+// whitespace since literal '@' in a password must be percent-encoded.
+var embeddedCredentialRe = regexp.MustCompile(`([a-zA-Z][a-zA-Z0-9+.\-]*://)([^\s/@:]+(:[^\s/@]+)?@)`)
+
+// RedactURL strips embedded credentials (the userinfo before the first '@')
+// from URL-looking strings, replacing them with "***". It operates on any
+// text, so it is safe to apply to argv joined into an error string or to git
+// stderr that echoes a remote URL. Strings without a "scheme://userinfo@"
+// sequence (local paths, scp-like SSH URLs, refs, flags) are returned unchanged.
+//
+// Use RedactURL whenever an upstream URL may be logged, persisted to the
+// database, echoed to the user, or wrapped into an error. The full URL must
+// only ever reach the actual git push/ls-remote argv, which needs the
+// credential to authenticate.
+func RedactURL(s string) string {
+	return embeddedCredentialRe.ReplaceAllString(s, "${1}***@")
+}
+
 // Run executes a git command in the given directory and returns trimmed stdout.
 // Returns an error that includes the command and stderr on failure.
+//
+// Both the interpolated argv and stderr are passed through RedactURL so an
+// embedded-credential remote URL (e.g. a fine-grained PAT in an https origin)
+// can never leak via the error string into step logs or the daemon log.
 func Run(ctx context.Context, dir string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
@@ -32,7 +58,7 @@ func Run(ctx context.Context, dir string, args ...string) (string, error) {
 		if ee, ok := err.(*exec.ExitError); ok {
 			stderr = strings.TrimSpace(string(ee.Stderr))
 		}
-		return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, stderr)
+		return "", fmt.Errorf("git %s: %w: %s", RedactURL(strings.Join(args, " ")), err, RedactURL(stderr))
 	}
 	return strings.TrimSpace(string(out)), nil
 }

--- a/internal/git/redact_test.go
+++ b/internal/git/redact_test.go
@@ -1,0 +1,129 @@
+package git
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestRedactURL(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "fine-grained PAT user and token",
+			in:   "https://x-access-token:ghp_secret@github.com/o/r.git",
+			want: "https://***@github.com/o/r.git",
+		},
+		{
+			name: "bare token userinfo",
+			in:   "https://ghp_secret@github.com/o/r.git",
+			want: "https://***@github.com/o/r.git",
+		},
+		{
+			name: "username and long token",
+			in:   "https://ci-bot:x-access-token:ghp_xABCD1234567890@github.com/owner/repo.git",
+			want: "https://***@github.com/owner/repo.git",
+		},
+		{
+			name: "no userinfo is unchanged",
+			in:   "https://github.com/o/r.git",
+			want: "https://github.com/o/r.git",
+		},
+		{
+			name: "scp-like ssh url unchanged (no scheme)",
+			in:   "git@github.com:owner/repo.git",
+			want: "git@github.com:owner/repo.git",
+		},
+		{
+			name: "ssh scheme without userinfo unchanged",
+			in:   "ssh://git@github.com/owner/repo.git",
+			want: "ssh://***@github.com/owner/repo.git",
+		},
+		{
+			name: "local path unchanged",
+			in:   "/home/user/repos/no-mistakes.git",
+			want: "/home/user/repos/no-mistakes.git",
+		},
+		{
+			name: "relative ref unchanged",
+			in:   "refs/heads/main",
+			want: "refs/heads/main",
+		},
+		{
+			name: "empty string unchanged",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "url embedded in text (stderr)",
+			in:   "fatal: could not read Username for 'https://x-access-token:ghp_secret@github.com/o/r.git': terminal",
+			want: "fatal: could not read Username for 'https://***@github.com/o/r.git': terminal",
+		},
+		{
+			name: "multiple credentialled urls in one string",
+			in:   "push https://token:secret@host/a.git then https://u:p@host/b.git",
+			want: "push https://***@host/a.git then https://***@host/b.git",
+		},
+		{
+			name: "gitlab deploy token shape",
+			in:   "https://oauth2:glpat-xxxxxxxxxxxxxxxxxxxx@gitlab.com/o/r.git",
+			want: "https://***@gitlab.com/o/r.git",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := RedactURL(tc.in)
+			if got != tc.want {
+				t.Errorf("RedactURL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+			if strings.Contains(got, "ghp_secret") || strings.Contains(got, "secret") && tc.in != got && !strings.Contains(tc.want, "secret") {
+				t.Errorf("RedactURL(%q) leaked credential: %q", tc.in, got)
+			}
+		})
+	}
+}
+
+// TestRedactURLNeverLeaksToken feeds a representative credentialled URL and
+// asserts the secret never survives redaction regardless of surrounding text.
+func TestRedactURLNeverLeaksToken(t *testing.T) {
+	t.Parallel()
+	const token = "ghp_secret"
+	urls := []string{
+		"https://x-access-token:" + token + "@github.com/o/r.git",
+		"https://" + token + "@github.com/o/r.git",
+		"pushing to https://x-access-token:" + token + "@github.com/o/r.git (refs/heads/main)",
+		"git push https://x-access-token:" + token + "@github.com/o/r.git HEAD:refs/heads/main: fatal",
+	}
+	for _, in := range urls {
+		if strings.Contains(RedactURL(in), token) {
+			t.Errorf("RedactURL leaked token %q in: %s -> %s", token, in, RedactURL(in))
+		}
+	}
+}
+
+// TestRunRedactsURLInError triggers a failing git command that carries a
+// credentialled URL as an argument and asserts the token never reaches the
+// returned error string. Uses `git remote set-url` against a nonexistent
+// remote so it fails fast with no network.
+func TestRunRedactsURLInError(t *testing.T) {
+	t.Parallel()
+	dir := initTestRepo(t)
+	const token = "ghp_secret_DO_NOT_LEAK"
+	credURL := "https://x-access-token:" + token + "@github.com/o/r.git"
+
+	_, err := Run(context.Background(), dir, "remote", "set-url", "no-such-remote", credURL)
+	if err == nil {
+		t.Fatal("expected error from git remote set-url on nonexistent remote")
+	}
+	if strings.Contains(err.Error(), token) {
+		t.Fatalf("git.Run error leaked credential: %v", err)
+	}
+	if !strings.Contains(err.Error(), "***@github.com/o/r.git") {
+		t.Fatalf("expected redacted URL marker in error, got: %v", err)
+	}
+}

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -193,8 +193,12 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 	var executionMS int64
 	var durationOverrideMS int64 // sum of step-reported overrides (demo mode)
 
-	// Open log file for persistent step logging
-	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	// Open log file for persistent step logging. Mode 0o600 keeps secrets that
+	// leak through a step's own output (e.g. an agent dumping env / netrc, or a
+	// credentialled upstream URL echoed by git) from being world-readable. Step
+	// logs are append-mode, so the tight mode is what stops a leaked token from
+	// accumulating in a world-readable file across runs.
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
 		return false, fmt.Errorf("create step log file %s: %w", stepName, err)
 	}
@@ -264,8 +268,10 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			// Persist the failure reason to the step's own log file. The error
 			// often carries the only detail of why the step failed (e.g. git
 			// stderr from a rejected push); without this the step log shows the
-			// work starting but never why it stopped.
-			fmt.Fprintf(logFile, "\nerror: %s\n", err.Error())
+			// work starting but never why it stopped. Redact defensively so a
+			// credentialled upstream URL that slipped into a wrapped error can
+			// never land in the log file.
+			fmt.Fprintf(logFile, "\nerror: %s\n", git.RedactURL(err.Error()))
 			if dbErr := e.db.FailStep(sr.ID, err.Error(), durationMS); dbErr != nil {
 				slog.Warn("failed to mark step as failed in db", "step", stepName, "error", dbErr)
 			}

--- a/internal/pipeline/executor_logging_test.go
+++ b/internal/pipeline/executor_logging_test.go
@@ -162,6 +162,36 @@ func TestExecutor_LogFileWritten(t *testing.T) {
 	}
 }
 
+// TestExecutor_StepLogFileModeIsRestrictive verifies step log files are
+// created 0o600 so secrets that leak into a step's output (e.g. a
+// credentialled upstream URL echoed by git, or an agent dumping env/netrc)
+// are not world-readable. 0o600 has no group/other bits, so the result is
+// independent of the process umask.
+func TestExecutor_StepLogFileModeIsRestrictive(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	step := &adaptiveCallStep{
+		name: types.StepReview,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			sctx.Log("line that forces the log file to be created")
+			return &StepOutcome{}, nil
+		},
+	}
+
+	exec := NewExecutor(database, p, nil, nil, []Step{step}, nil)
+	exec.Execute(context.Background(), run, repo, workDir)
+
+	logPath := filepath.Join(p.RunLogDir(run.ID), "review.log")
+	info, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatalf("expected log file at %s: %v", logPath, err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("step log file mode = %o, want 0o600 (no group/other access)", got)
+	}
+}
+
 func TestExecutor_LogFileWritten_OnStepError(t *testing.T) {
 	database, p, run, repo := setupTest(t)
 	workDir := t.TempDir()

--- a/internal/pipeline/steps/ci_bitbucket.go
+++ b/internal/pipeline/steps/ci_bitbucket.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/bitbucket"
+	"github.com/kunchenguid/no-mistakes/internal/git"
 )
 
 // resolveBitbucketRepoRef parses a Bitbucket repo reference from the upstream
@@ -16,7 +17,7 @@ func resolveBitbucketRepoRef(upstreamURL string, prURL *string) (bitbucket.RepoR
 	if prURL != nil && strings.TrimSpace(*prURL) != "" {
 		return bitbucket.ParseRepoRef(*prURL)
 	}
-	return bitbucket.RepoRef{}, fmt.Errorf("resolve Bitbucket repository from upstream %q", upstreamURL)
+	return bitbucket.RepoRef{}, fmt.Errorf("resolve Bitbucket repository from upstream %q", git.RedactURL(upstreamURL))
 }
 
 // trimLogOutput truncates log output to the last maxBytes bytes, respecting

--- a/internal/pipeline/steps/ci_fix.go
+++ b/internal/pipeline/steps/ci_fix.go
@@ -141,7 +141,10 @@ func (s *CIStep) commitAndPush(sctx *pipeline.StepContext) (bool, error) {
 func (s *CIStep) pushUpdatedHeadSHA(sctx *pipeline.StepContext, newHeadSHA string) (bool, error) {
 	ref := normalizedBranchRef(sctx.Run.Branch)
 
-	upstreamSHA, lsErr := stepGitLsRemote(sctx, sctx.Repo.UpstreamURL, ref)
+	// Resolve the credentialled upstream URL from the worktree's "origin"
+	// remote; the DB copy is redacted and cannot authenticate the push.
+	upstream := resolveUpstreamURL(sctx)
+	upstreamSHA, lsErr := stepGitLsRemote(sctx, upstream, ref)
 	if lsErr != nil {
 		slog.Warn("ls-remote failed, pushing without force-with-lease", "ref", ref, "error", lsErr)
 	} else if upstreamSHA == newHeadSHA {
@@ -154,7 +157,7 @@ func (s *CIStep) pushUpdatedHeadSHA(sctx *pipeline.StepContext, newHeadSHA strin
 		}
 		return false, nil
 	}
-	if err := stepGitPush(sctx, sctx.Repo.UpstreamURL, ref, upstreamSHA, upstreamSHA != ""); err != nil {
+	if err := stepGitPush(sctx, upstream, ref, upstreamSHA, upstreamSHA != ""); err != nil {
 		if lsErr != nil {
 			return false, fmt.Errorf("push (ls-remote failed: %v): %w", lsErr, err)
 		}

--- a/internal/pipeline/steps/common_exec.go
+++ b/internal/pipeline/steps/common_exec.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/scm"
 )
@@ -174,7 +175,9 @@ func stepGitRun(sctx *pipeline.StepContext, args ...string) (string, error) {
 		if ee, ok := err.(*exec.ExitError); ok {
 			stderr = strings.TrimSpace(string(ee.Stderr))
 		}
-		return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, stderr)
+		// Redact embedded credentials so a credentialled remote URL passed
+		// as an arg (e.g. the push target) can never leak via this error.
+		return "", fmt.Errorf("git %s: %w: %s", git.RedactURL(strings.Join(args, " ")), err, git.RedactURL(stderr))
 	}
 	return strings.TrimSpace(string(out)), nil
 }

--- a/internal/pipeline/steps/common_git.go
+++ b/internal/pipeline/steps/common_git.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/git"
+	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 )
 
 // resolveBaseSHA returns a usable base SHA for diff/log operations.
@@ -69,6 +70,22 @@ func resolveUpstreamRemoteName(ctx context.Context, workDir, upstreamURL string)
 		}
 	}
 	return "origin"
+}
+
+// resolveUpstreamURL returns the credentialled upstream URL to push or query.
+// It prefers the worktree's configured "origin" remote, which inherits the
+// full upstream URL (including any embedded credentials) from the gate's bare
+// repo via the shared common config. It falls back to the repo record's
+// upstream URL when origin cannot be resolved (e.g. an older gate whose DB
+// still carries the full URL, or a test worktree without origin).
+//
+// This separation lets the database and logs store a redacted URL while the
+// credential still reaches the git push/ls-remote argv that needs it.
+func resolveUpstreamURL(sctx *pipeline.StepContext) string {
+	if url, err := git.GetRemoteURL(sctx.Ctx, sctx.WorkDir, "origin"); err == nil && strings.TrimSpace(url) != "" {
+		return url
+	}
+	return sctx.Repo.UpstreamURL
 }
 
 func mergeBaseWithDefaultBranch(ctx context.Context, workDir, defaultBranch string) string {

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -54,8 +54,11 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 
 	ref := normalizedBranchRef(sctx.Run.Branch)
 
-	upstream := sctx.Repo.UpstreamURL
-	sctx.Log(fmt.Sprintf("pushing to %s (%s)...", upstream, ref))
+	// Resolve the credentialled upstream URL from the worktree's "origin"
+	// remote; the DB copy is redacted. The full URL is needed for the actual
+	// git push/ls-remote argv, while only the redacted form is logged.
+	upstream := resolveUpstreamURL(sctx)
+	sctx.Log(fmt.Sprintf("pushing to %s (%s)...", git.RedactURL(upstream), ref))
 
 	// Query upstream for current ref SHA to enable safe --force-with-lease.
 	// Without an explicit SHA, --force-with-lease offers no protection when

--- a/internal/pipeline/steps/upstream_test.go
+++ b/internal/pipeline/steps/upstream_test.go
@@ -1,0 +1,152 @@
+package steps
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/config"
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/git"
+	"github.com/kunchenguid/no-mistakes/internal/pipeline"
+)
+
+// minimalStepContext builds a StepContext with just enough fields for the
+// upstream-resolution helpers, without spinning up a database.
+func minimalStepContext(t *testing.T, workDir, upstreamURL string) *pipeline.StepContext {
+	t.Helper()
+	return &pipeline.StepContext{
+		Ctx:     context.Background(),
+		WorkDir: workDir,
+		Repo:    &db.Repo{UpstreamURL: upstreamURL},
+	}
+}
+
+// TestResolveUpstreamURL_PreservesCredential is the "pushes keep working" half
+// of the redaction fix: the DB stores a redacted URL, but the credential must
+// still reach the git push/ls-remote argv. The credential is recovered from
+// the worktree's "origin" remote (inherited from the gate's bare repo), so
+// resolveUpstreamURL must return the full credentialled URL verbatim.
+func TestResolveUpstreamURL_PreservesCredential(t *testing.T) {
+	t.Parallel()
+	const token = "ghp_secret_DO_NOT_LEAK"
+	credURL := "https://x-access-token:" + token + "@github.com/o/r.git"
+	redacted := git.RedactURL(credURL)
+
+	dir := t.TempDir()
+	if out, err := exec.Command("git", "init", "-q", dir).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", dir, "remote", "add", "origin", credURL).CombinedOutput(); err != nil {
+		t.Fatalf("git remote add: %v: %s", err, out)
+	}
+
+	sctx := minimalStepContext(t, dir, redacted)
+	got := resolveUpstreamURL(sctx)
+	if got != credURL {
+		t.Errorf("resolveUpstreamURL = %q, want full credentialled URL %q (credential must reach the push argv)", got, credURL)
+	}
+	if !strings.Contains(got, token) {
+		t.Errorf("resolveUpstreamURL stripped the credential: got %q", got)
+	}
+}
+
+// TestResolveUpstreamURL_FallsBackToRecordedURL verifies that when a worktree
+// has no resolvable "origin" remote, resolveUpstreamURL falls back to the repo
+// record's upstream URL (the historical behavior, and the path old gates whose
+// DB still carries the full URL take).
+func TestResolveUpstreamURL_FallsBackToRecordedURL(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if out, err := exec.Command("git", "init", "-q", dir).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	// No "origin" remote configured.
+	recorded := "https://github.com/o/r.git"
+	sctx := minimalStepContext(t, dir, recorded)
+	if got := resolveUpstreamURL(sctx); got != recorded {
+		t.Errorf("resolveUpstreamURL fallback = %q, want %q", got, recorded)
+	}
+}
+
+// TestResolveUpstreamURL_FallsBackForCredentialledRecordedURL covers the
+// backward-compat case: a gate created before this fix has the full
+// credentialled URL still in the DB, and a worktree without an origin remote
+// must still push using that recorded URL.
+func TestResolveUpstreamURL_FallsBackForCredentialledRecordedURL(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if out, err := exec.Command("git", "init", "-q", dir).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	recorded := "https://x-access-token:ghp_legacy@github.com/o/r.git"
+	sctx := minimalStepContext(t, dir, recorded)
+	if got := resolveUpstreamURL(sctx); got != recorded {
+		t.Errorf("resolveUpstreamURL legacy fallback = %q, want %q", got, recorded)
+	}
+}
+
+// TestPushStepRedactsCredentialURL runs the push step against a worktree whose
+// origin carries an embedded credential, and asserts the credential never
+// appears in either the user-visible step log or the step's returned error
+// (which carries the git ls-remote failure). The unreachable loopback origin
+// makes ls-remote fail fast without real network I/O.
+func TestPushStepRedactsCredentialURL(t *testing.T) {
+	t.Parallel()
+	const token = "ghp_secret_DO_NOT_LEAK"
+	credURL := "https://x-access-token:" + token + "@127.0.0.1:1/o/r.git"
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	baseSHA := gitCmd(t, dir, "rev-parse", "main")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "remote", "add", "origin", credURL)
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Repo.UpstreamURL = credURL // DB record also credentialled (old style)
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+
+	step := &PushStep{}
+	_, err := step.Execute(sctx)
+	// ls-remote to an unreachable origin is expected to fail; the point of
+	// the test is that the failure does not leak the credential.
+	if err == nil {
+		t.Fatal("expected push step to fail against unreachable credentialled origin")
+	}
+	if strings.Contains(err.Error(), token) {
+		t.Errorf("push step error leaked credential: %v", err)
+	}
+	for _, l := range logs {
+		if strings.Contains(l, token) {
+			t.Errorf("push step log leaked credential: %q", l)
+		}
+	}
+	// Sanity: the redacted "pushing to" line was actually emitted.
+	var sawPushLog bool
+	for _, l := range logs {
+		if strings.Contains(l, "pushing to") {
+			sawPushLog = true
+			if !strings.Contains(l, "***@127.0.0.1:1") {
+				t.Errorf("push log not redacted as expected: %q", l)
+			}
+		}
+	}
+	if !sawPushLog {
+		t.Errorf("expected a 'pushing to' log line, got: %v", logs)
+	}
+}


### PR DESCRIPTION
## Summary

Redacts embedded credentials (e.g. `https://x-access-token:ghp_…@github.com/o/r.git`, common with fine-grained PATs and CI checkouts) from every site where the upstream URL is persisted, logged, or wrapped into an error. The credential still reaches the `git push`/`ls-remote` argv so pushes keep working. Also tightens daemon / step / CLI / wizard log files to `0o600`.

> ⚠️ **Security-sensitive change — credential disclosure.** Before this fix, an upstream URL carrying an embedded token was written in plaintext to the `repos.upstream_url` DB column, the daemon log, and the **world-readable (`0o644`), append-mode** step logs (including inside `git push <url>` error strings). Step logs accumulate across runs, so a leaked PAT persisted indefinitely and was readable by any local user on the host. Please review the redaction sites and log-file mode changes carefully. No format change to anything stored remotely; no new dependencies.

## The bug

`gate.Init` captured the raw `origin` URL via `git.GetRemoteURL` and stored / logged it verbatim. The URL flowed to:

- `slog.Info("gate initialized", …, "upstream", upstreamURL)` → **daemon.log** (`internal/gate/gate.go`)
- the SQLite **`repos.upstream_url` column** (same)
- `sctx.Log(fmt.Sprintf("pushing to %s …", upstream, ref))` → the **step log** (`internal/pipeline/steps/push.go`)
- `git.Push` passing the URL as a bare arg → `git.Run`'s error format `"git %s: %w: %s"` (joined args) → the step-failure write to the step log on rejection (`internal/git/git.go`, `internal/pipeline/executor.go`)

Step log files were created `0o644` and opened in append mode, so the token was world-readable and accumulated across runs. The existing `intent/redact.go` secret patterns were never applied to URLs or log paths. The same `git.Run`-style error format in `stepGitRun` (`internal/pipeline/steps/common_exec.go`) and the Bitbucket "resolve repo" error (`ci_bitbucket.go`) echoed the raw URL too.

## Repro

```sh
git clone https://github.com/o/r.git && cd r
git remote set-url origin https://x-access-token:ghp_xABCD1234@github.com/o/r.git
go build -o ./bin/no-mistakes ./cmd/no-mistakes && ./bin/no-mistakes init
# push a branch so the gate runs the pipeline:
git switch -c scout/repro && git commit --allow-empty -m scout && git push no-mistakes HEAD
grep -R "ghp_xABCD1234" ~/.no-mistakes   # → token found in daemon.log and logs/<runID>/push.log (0o644)
sqlite3 ~/.no-mistakes/no-mistakes.db 'select upstream_url from repos'  # → token in DB
```

After this PR each of those reads `https://***@github.com/o/r.git`; the credential no longer appears anywhere persisted or logged.

## The fix

**`git.RedactURL`** (`internal/git/git.go`): a single regex-based helper that replaces the `scheme://userinfo@` prefix with `scheme://***@`. It operates on arbitrary text (so it's safe on argv joined into an error string or on git stderr), and leaves local paths, scp-like SSH URLs (`git@host:path`), refs, and flags untouched.

**Redact at every persisted / logged / errored site, keep the credential only for the argv:**

- `gate.Init` stores and `slog`s the **redacted** URL. The bare gate's own `origin` remote still carries the **full** credentialled URL (unchanged), so worktrees carved from it inherit it via git's shared common config — verified empirically.
- New `resolveUpstreamURL(sctx)` (`common_git.go`) recovers the credentialled URL from the worktree's `origin` remote at run time, falling back to the DB record for old gates / worktrees without `origin`. The push step (`push.go`) and CI auto-fix push path (`ci_fix.go`) call it for the actual `git push`/`ls-remote` argv, while logging only the redacted form.
- `git.Run` and `stepGitRun` redact URL-looking args **and** stderr in their error strings; the executor's step-failure write to the step log redacts defensively too.
- `resolveBitbucketRepoRef`'s error no longer echoes the raw URL.

**Log file mode `0o600`** (audit #23): daemon log (`selfexec.go`), step logs (`executor.go`), CLI log (`main.go`), and wizard agent log (`wizard.go`). A secret that reaches a log through any path (e.g. an agent dumping `env` / `~/.netrc`) is no longer world-readable. `0o600` has no group/other bits, so the result is independent of the process umask.

**Backward compatibility:** old DB rows that still hold a full credentialled URL keep working — `resolveUpstreamURL` falls back to the recorded URL when a worktree has no `origin`. The redaction is a no-op for local-path and scp-like upstreams (all existing tests and the e2e harness), so there is no behavior change for non-credentialled repos.

| Site | Before | After |
|---|---|---|
| `gate.Init` DB + slog | full credentialled URL | `https://***@…` (bare gate `origin` keeps the credential) |
| push / CI-fix argv | full URL (correct) | full URL, recovered from worktree `origin` via `resolveUpstreamURL` |
| push step log | `pushing to https://token@…/r.git` | `pushing to https://***@…/r.git` |
| `git.Run` / `stepGitRun` error | `git push https://token@…/r.git …: <stderr>` | args + stderr redacted |
| log files | `0o644` (world-readable, append) | `0o600` |

## Verification

`gofmt -l .` clean · `go vet ./...` clean · `go run ./cmd/genskill --check` up to date · `go build ./...` OK · `go test -race ./...` green (Go 1.26.4 — system Go 1.18 is too old).

New tests pinning the behavior (the defining symptom is a silent credential write, so these exist to catch regressions):

- `TestRedactURL` / `TestRedactURLNeverLeaksToken` (`internal/git/redact_test.go`) — table-driven over PAT / bare-token / no-userinfo / scp-like / local-path / URL-in-text / multi-URL / GitLab shapes, plus a leak guard.
- `TestRunRedactsURLInError` (`internal/git/redact_test.go`) — a failing git command carrying a credentialled URL arg never leaks the token in the error.
- `TestInitRedactsCredentialURL` (`internal/gate/gate_test.go`) — `Init` stores/returns the redacted URL **and** the bare gate's `origin` keeps the full credential (pushes still authenticate).
- `TestResolveUpstreamURL_PreservesCredential` + fallback tests (`internal/pipeline/steps/upstream_test.go`) — the credential still reaches the push argv (pushes keep working); old credentialled DB rows fall back correctly.
- `TestPushStepRedactsCredentialURL` (`internal/pipeline/steps/upstream_test.go`) — the push step's user-visible log **and** returned error never contain the token.
- `TestExecutor_StepLogFileModeIsRestrictive` (`internal/pipeline/executor_logging_test.go`) — step log files are `0o600`.

The e2e harness uses local-path upstreams (redaction is a no-op there) and asserts no log-file modes, so recorded journeys are unaffected.

## Notes for review

- This change touches `push.go` and `ci_fix.go`, which the open fork-routing PR (#296 / `Repo.PushURL()`) also touches. The two fixes are orthogonal (credential redaction vs. fork→parent routing); if both land the maintainer will reconcile `resolveUpstreamURL` with `Repo.PushURL()` so the credentialled **fork** URL is the one recovered from git config. No coordination needed for this PR to be correct on current `main`.
- Defense-in-depth only: the credential is still present in the user's own `origin` config and the bare gate's `origin` config (both under the user's home). This PR removes it from everything no-mistakes *writes* (DB, logs, errors). Rotating any PAT that may have leaked into a pre-existing `0o644` log before upgrading is recommended.

---

AI disclosure: **Human-reviewed.** The change was produced with AI assistance and reviewed by a human contributor before submission.