### PR TITLE
fix(agent): kill child process group on cancel (no orphan subprocesses)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,16 @@ Safest local verification sequence after non-trivial changes:
 
 - Thread `context.Context` through long-running, subprocess, and networked work.
 - Prefer `exec.CommandContext` for subprocesses.
+- Route every long-lived subprocess spawned on behalf of a cancellable step/agent
+  invocation through `shellenv.ConfigureShellCommand(cmd)` after building the
+  `*exec.Cmd`. It puts the child in its own process group (Unix `Setpgid` /
+  Windows `CREATE_NEW_PROCESS_GROUP`) and installs `cmd.Cancel` to kill the whole
+  tree on context cancellation. Without it, `exec.CommandContext` only kills the
+  direct child and grandchildren survive (e.g. `npm` -> `node` test workers,
+  agent-spawned git/build/editor), keep running, and hold the worktree locked so
+  the next run on the same branch cannot proceed. Applied to the step shell
+  runner (`runShellCommandWithEnv`) and the native agent `runOnce` builders
+  (claude, codex, pi, acpx); apply it to any new subprocess in those paths.
 - Use derived contexts and timeouts for cleanup and HTTP calls.
 - Use `context.Background()` mainly at top-level boundaries, background tasks, or in tests.
 - Protect shared mutable state with `sync.Mutex`, `sync.RWMutex`, `sync.Map`, or `atomic` where appropriate.

--- a/internal/agent/acpx.go
+++ b/internal/agent/acpx.go
@@ -9,6 +9,8 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+
+	"github.com/kunchenguid/no-mistakes/internal/shellenv"
 )
 
 const acpxScannerMaxTokenSize = 256 * 1024 * 1024
@@ -33,6 +35,9 @@ func (a *acpxAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) 
 	cmd.Dir = opts.CWD
 	cmd.Stdin = nil
 	cmd.Env = gitSafeEnv(opts.CWD)
+	// Run in a dedicated process group so cancelling ctx reaps the acpx CLI
+	// and any subprocesses it spawns, not just the direct child.
+	shellenv.ConfigureShellCommand(cmd)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -10,6 +10,8 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+
+	"github.com/kunchenguid/no-mistakes/internal/shellenv"
 )
 
 // claudeMaxRetries is the number of additional attempts past the initial
@@ -42,6 +44,10 @@ func (a *claudeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error
 	cmd.Dir = opts.CWD
 	cmd.Stdin = nil
 	cmd.Env = gitSafeEnv(opts.CWD)
+	// Run in a dedicated process group so cancelling ctx kills the claude CLI
+	// and any subprocesses it spawns (git, build tools, editors), not just the
+	// direct child. Otherwise they survive and hold the worktree locked.
+	shellenv.ConfigureShellCommand(cmd)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -11,6 +11,8 @@ import (
 	"sort"
 	"strings"
 	"sync"
+
+	"github.com/kunchenguid/no-mistakes/internal/shellenv"
 )
 
 // codexAgent spawns the codex CLI for each invocation.
@@ -60,6 +62,9 @@ func (a *codexAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error)
 	cmd.Dir = opts.CWD
 	cmd.Stdin = nil
 	cmd.Env = gitSafeEnv(opts.CWD)
+	// Run in a dedicated process group so cancelling ctx reaps the codex CLI
+	// and any subprocesses it spawns, not just the direct child.
+	shellenv.ConfigureShellCommand(cmd)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -9,6 +9,8 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+
+	"github.com/kunchenguid/no-mistakes/internal/shellenv"
 )
 
 // piAgent spawns the pi CLI for each invocation. Pi reads its prompt from
@@ -34,6 +36,9 @@ func (a *piAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD
 	cmd.Env = gitSafeEnv(opts.CWD)
+	// Run in a dedicated process group so cancelling ctx reaps the pi CLI and
+	// any subprocesses it spawns, not just the direct child.
+	shellenv.ConfigureShellCommand(cmd)
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {

--- a/internal/pipeline/steps/common_exec.go
+++ b/internal/pipeline/steps/common_exec.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/scm"
+	"github.com/kunchenguid/no-mistakes/internal/shellenv"
 )
 
 func envValue(env []string, key string) (string, bool) {
@@ -260,6 +261,10 @@ func runShellCommandWithEnv(ctx context.Context, dir string, env []string, cmdSt
 	} else {
 		cmd = exec.CommandContext(ctx, "sh", "-c", cmdStr)
 	}
+	// Isolate the command in its own process group so that cancelling ctx kills
+	// the whole tree (e.g. npm -> node test workers), not just the shell parent.
+	// Otherwise grandchildren survive, keep running, and hold the worktree locked.
+	shellenv.ConfigureShellCommand(cmd)
 	cmd.Dir = dir
 	if len(env) > 0 {
 		cmd.Env = mergeEnv(env)

--- a/internal/pipeline/steps/shell_unix_test.go
+++ b/internal/pipeline/steps/shell_unix_test.go
@@ -1,0 +1,135 @@
+//go:build unix
+
+package steps
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestRunShellCommandWithEnv_KillsGrandchildOnCancel is a regression test for
+// orphan subprocesses on cancellation. runShellCommandWithEnv must kill the
+// whole process group when its context is cancelled, not just the direct
+// shell child. Without Setpgid + cmd.Cancel, exec.CommandContext SIGKILLs only
+// the shell parent and a backgrounded grandchild (e.g. a test runner's worker
+// process) survives, keeps running, and holds the worktree locked so the next
+// run on the same branch cannot proceed.
+//
+// This test fails if shellenv.ConfigureShellCommand is removed from
+// runShellCommandWithEnv: the heartbeat keeps advancing and the PID is never
+// reaped within the window.
+func TestRunShellCommandWithEnv_KillsGrandchildOnCancel(t *testing.T) {
+	dir := t.TempDir()
+	heartbeat := filepath.Join(dir, "tick")
+	pidFile := filepath.Join(dir, "grandchild.pid")
+	// Background a long-running grandchild that writes a monotonic heartbeat
+	// (so we can prove it actually stopped executing, not merely got reaped as
+	// a zombie), then `wait` so the sh parent stays alive until we cancel. This
+	// mirrors the real failure mode: `commands.test: "npm test"` shells out and
+	// the node workers outlive the cancelled `sh`.
+	script := "i=0; while [ $i -lt 10000 ]; do printf '%s\\n' \"$i\" > " + heartbeat +
+		"; sleep 0.1; i=$((i+1)); done & echo $! > " + pidFile + "; wait"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel) // never leak the 1000s heartbeat loop if we assert early
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _, _ = runShellCommandWithEnv(ctx, dir, nil, script)
+	}()
+
+	grandchild := waitForIntFile(t, pidFile, 5*time.Second)
+	// Synchronize on the grandchild actually running: wait for the heartbeat to
+	// advance at least once before cancelling, so we don't race a slow fork+exec.
+	waitForHeartbeatChange(t, heartbeat, 3*time.Second)
+
+	before := readTrimFile(t, heartbeat)
+	cancel()
+
+	// The grandchild must stop running promptly: the heartbeat holds steady
+	// (process is no longer executing) AND the PID has been reaped (no longer
+	// alive). The generous window absorbs subreaper/reparenting jitter.
+	if !heartbeatHoldsWithin(t, heartbeat, 5*time.Second) {
+		t.Fatalf("grandchild pid %d still running after cancel: heartbeat advanced past %q", grandchild, before)
+	}
+	if err := syscall.Kill(grandchild, 0); err != syscall.ESRCH {
+		t.Fatalf("grandchild pid %d not reaped after cancel (kill -0: %v); want ESRCH", grandchild, err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("runShellCommandWithEnv did not return within 5s of cancel")
+	}
+}
+
+func waitForIntFile(t *testing.T, path string, timeout time.Duration) int {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if v, ok := parseInt(readTrimFile(t, path)); ok {
+			return v
+		}
+		time.Sleep(15 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for integer in %s", path)
+	return 0
+}
+
+func waitForHeartbeatChange(t *testing.T, path string, timeout time.Duration) {
+	t.Helper()
+	first := readTrimFile(t, path)
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cur := readTrimFile(t, path); cur != "" && cur != first {
+			return
+		}
+		time.Sleep(15 * time.Millisecond)
+	}
+	t.Fatalf("heartbeat at %s never advanced within %s", path, timeout)
+}
+
+// heartbeatHoldsWithin reports whether the value at path stops changing,
+// indicating the writing process was killed. It returns true as soon as two
+// samples separated by a grace period are equal.
+func heartbeatHoldsWithin(t *testing.T, path string, window time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(window)
+	prev := readTrimFile(t, path)
+	for time.Now().Before(deadline) {
+		time.Sleep(150 * time.Millisecond)
+		if cur := readTrimFile(t, path); cur == prev {
+			return true
+		} else {
+			prev = cur
+		}
+	}
+	return false
+}
+
+func readTrimFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}
+
+func parseInt(s string) (int, bool) {
+	if s == "" {
+		return 0, false
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}

--- a/internal/shellenv/shell_command_other.go
+++ b/internal/shellenv/shell_command_other.go
@@ -4,4 +4,7 @@ package shellenv
 
 import "os/exec"
 
-func configureShellCommand(cmd *exec.Cmd) {}
+// ConfigureShellCommand is a no-op on platforms that lack process groups
+// (and a process-tree kill primitive). Context cancellation falls back to the
+// exec.CommandContext default of terminating the direct child only.
+func ConfigureShellCommand(cmd *exec.Cmd) {}

--- a/internal/shellenv/shell_command_unix.go
+++ b/internal/shellenv/shell_command_unix.go
@@ -9,7 +9,15 @@ import (
 	"syscall"
 )
 
-func configureShellCommand(cmd *exec.Cmd) {
+// ConfigureShellCommand isolates cmd in its own process group (Setpgid) and
+// installs a cmd.Cancel that SIGKILLs the whole group when cmd's context is
+// cancelled. exec.CommandContext otherwise only kills the direct child PID,
+// leaving grandchildren (a test runner's worker processes, an agent-spawned
+// git/build/editor) running and holding the worktree locked.
+//
+// Apply this to every long-lived subprocess no-mistakes spawns on behalf of a
+// cancellable step/agent invocation.
+func ConfigureShellCommand(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = func() error {
 		if cmd.Process == nil {

--- a/internal/shellenv/shell_command_windows.go
+++ b/internal/shellenv/shell_command_windows.go
@@ -4,10 +4,12 @@ package shellenv
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
 	"syscall"
+	"time"
 )
 
 // CREATE_NEW_PROCESS_GROUP is the Windows creation flag that makes the child
@@ -16,6 +18,22 @@ import (
 // at this process.
 const createNewProcessGroup = 0x00000200
 
+// taskkillExitNoSuchProcess is the nonzero exit code taskkill returns when no
+// process matches the given PID (the child had already exited before we could
+// kill it). All other nonzero codes — 1 for access denied, malformed arguments,
+// or a transient process-table error — are genuine kill failures that must not
+// be collapsed into os.ErrProcessDone.
+const taskkillExitNoSuchProcess = 128
+
+// defaultWaitDelay is the pipe backstop installed on Windows. taskkill /T /F
+// usually reaches every descendant, but when it cannot (access denied on a
+// child, or a handle inherited and still held open) a nonzero WaitDelay lets
+// the exec package close inherited stdout/stderr pipes and return from Wait
+// instead of blocking forever on a Read held open by a surviving grandchild.
+// It is a worst-case ceiling only: in the common (successful) case the pipes
+// close immediately and Wait returns without waiting.
+const defaultWaitDelay = 5 * time.Second
+
 // ConfigureShellCommand is the Windows counterpart to the unix helper. There
 // are no Unix-style process groups or signals here, so cancellation runs
 // `taskkill /T /F /PID`, which terminates the process and everything it
@@ -23,26 +41,84 @@ const createNewProcessGroup = 0x00000200
 // exec.CommandContext only TerminateProcess-es the direct child and leaks the
 // grandchildren, keeping the worktree locked.
 //
-// cmd.Cancel returns os.ErrProcessDone when the process is already gone so the
-// exec package stops waiting, matching the unix variant's ESRCH handling.
+// The cancel path distinguishes an already-gone PID (os.ErrProcessDone) from a
+// real taskkill failure. On a real failure — or if taskkill itself is missing —
+// it falls back to killing at least the direct child and surfaces the original
+// error rather than swallowing it. A nonzero WaitDelay is installed as a pipe
+// backstop. Together these keep Wait/pipe reads from hanging when a descendant
+// survives a failed tree kill, which the previous "every nonzero exit is
+// ErrProcessDone" mapping could cause.
 func ConfigureShellCommand(cmd *exec.Cmd) {
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
 	cmd.SysProcAttr.CreationFlags |= createNewProcessGroup
+
+	// Install a WaitDelay backstop unless the caller has chosen one
+	// explicitly (the short login-shell probe, for example, uses a tighter
+	// bound of its own).
+	if cmd.WaitDelay == 0 {
+		cmd.WaitDelay = defaultWaitDelay
+	}
+
 	cmd.Cancel = func() error {
 		if cmd.Process == nil {
 			return os.ErrProcessDone
 		}
-		kill := exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(cmd.Process.Pid))
-		// taskkill returns a non-zero exit code (and error) when the PID no
-		// longer exists; that is the "already done" case we must signal.
-		if err := kill.Run(); err != nil {
-			if errors.Is(err, exec.ErrNotFound) {
-				return err
-			}
+		pid := strconv.Itoa(cmd.Process.Pid)
+		kill := exec.Command("taskkill", "/T", "/F", "/PID", pid)
+		err := kill.Run()
+		switch {
+		case err == nil:
+			// Whole tree terminated.
+			return nil
+		case errors.Is(err, exec.ErrNotFound):
+			// taskkill itself is unavailable (PATH stripped, a stripped
+			// Windows image, etc.). Cannot tree-kill; fall through to the
+			// direct-child backstop below so the direct child is at least
+			// terminated and Wait can make progress.
+		case isTaskkillAlreadyGone(err):
+			// The child had already exited; the benign, locale-independent
+			// signal (taskkill exit code 128).
 			return os.ErrProcessDone
+		default:
+			// Real taskkill failure (access denied, malformed invocation,
+			// transient process-table error). Previously this branch was
+			// unreachable: every nonzero exit was mapped to
+			// os.ErrProcessDone, which Go reads as "already exited" and so
+			// the exec package skipped even the default direct-child
+			// TerminateProcess. With no WaitDelay backstop that could
+			// leave Wait/pipe reads hung if a descendant still held a
+			// handle. Fall through to the direct-child backstop, then
+			// surface the real taskkill error instead of swallowing it.
+		}
+		// Backstop: at least terminate the direct child so the exec
+		// package's Wait can make progress. If even that reports the
+		// process already done, honor it; otherwise surface the original
+		// taskkill failure so a genuine kill error is not silently lost.
+		if killErr := cmd.Process.Kill(); killErr != nil {
+			if errors.Is(killErr, os.ErrProcessDone) {
+				return os.ErrProcessDone
+			}
+			return fmt.Errorf("taskkill /PID %s: %w; process kill: %v", pid, err, killErr)
+		}
+		if err != nil {
+			return fmt.Errorf("taskkill /PID %s: %w", pid, err)
 		}
 		return nil
 	}
+}
+
+// isTaskkillAlreadyGone reports whether a taskkill error means the target PID
+// no longer exists (the child had already exited). taskkill emits exit code
+// taskkillExitNoSuchProcess for that case; matching on the numeric exit code
+// keeps the detection locale-independent, since the accompanying stderr text
+// ("...not found.") is locale-translated. All other nonzero codes are treated
+// as genuine failures by the caller, which then falls back to a direct kill.
+func isTaskkillAlreadyGone(err error) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	return exitErr.ExitCode() == taskkillExitNoSuchProcess
 }

--- a/internal/shellenv/shell_command_windows.go
+++ b/internal/shellenv/shell_command_windows.go
@@ -2,6 +2,47 @@
 
 package shellenv
 
-import "os/exec"
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"syscall"
+)
 
-func configureShellCommand(cmd *exec.Cmd) {}
+// CREATE_NEW_PROCESS_GROUP is the Windows creation flag that makes the child
+// the root of a new process group, mirroring the unix Setpgid behavior. It is
+// the foundation for whole-tree cancellation: taskkill /T walks the tree rooted
+// at this process.
+const createNewProcessGroup = 0x00000200
+
+// ConfigureShellCommand is the Windows counterpart to the unix helper. There
+// are no Unix-style process groups or signals here, so cancellation runs
+// `taskkill /T /F /PID`, which terminates the process and everything it
+// spawned (test runners, agent-spawned git/build tools). Without this,
+// exec.CommandContext only TerminateProcess-es the direct child and leaks the
+// grandchildren, keeping the worktree locked.
+//
+// cmd.Cancel returns os.ErrProcessDone when the process is already gone so the
+// exec package stops waiting, matching the unix variant's ESRCH handling.
+func ConfigureShellCommand(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= createNewProcessGroup
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return os.ErrProcessDone
+		}
+		kill := exec.Command("taskkill", "/T", "/F", "/PID", strconv.Itoa(cmd.Process.Pid))
+		// taskkill returns a non-zero exit code (and error) when the PID no
+		// longer exists; that is the "already done" case we must signal.
+		if err := kill.Run(); err != nil {
+			if errors.Is(err, exec.ErrNotFound) {
+				return err
+			}
+			return os.ErrProcessDone
+		}
+		return nil
+	}
+}

--- a/internal/shellenv/shell_command_windows_test.go
+++ b/internal/shellenv/shell_command_windows_test.go
@@ -1,0 +1,62 @@
+//go:build windows
+
+package shellenv
+
+import (
+	"errors"
+	"os/exec"
+	"strconv"
+	"testing"
+)
+
+// TestIsTaskkillAlreadyGone pins down the locale-independent contract the
+// Windows cancel path relies on: taskkill exit code 128 (no matching PID) is
+// the only nonzero exit treated as "the child already exited", so every other
+// nonzero code falls through to the direct-child-kill backstop instead of
+// being swallowed as os.ErrProcessDone. It runs only on Windows; on Linux the
+// windows build tag excludes it from `go test ./...`, while `GOOS=windows go
+// vet` keeps it compile-checked.
+func TestIsTaskkillAlreadyGone(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "exit 128 is already gone", err: exitCodeErr(t, 128), want: true},
+		{name: "exit 1 access denied is a real failure", err: exitCodeErr(t, 1), want: false},
+		{name: "exec.ErrNotFound is not already-gone", err: exec.ErrNotFound, want: false},
+		{name: "wrapped exit 128 still detected", err: wrapErr(exitCodeErr(t, 128)), want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTaskkillAlreadyGone(tt.err); got != tt.want {
+				t.Fatalf("isTaskkillAlreadyGone(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// exitCodeErr runs `cmd /c exit N` and returns the resulting *exec.ExitError so
+// the helper is exercised against a real ProcessState with the chosen code.
+func exitCodeErr(t *testing.T, code int) error {
+	t.Helper()
+	err := exec.Command("cmd", "/c", "exit", strconv.Itoa(code)).Run()
+	if err == nil {
+		t.Fatalf("expected exit %d to yield a nonzero-run error", code)
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected *exec.ExitError, got %T: %v", err, err)
+	}
+	if exitErr.ExitCode() != code {
+		t.Fatalf("exit code = %d, want %d", exitErr.ExitCode(), code)
+	}
+	return err
+}
+
+type wrappedErr struct{ e error }
+
+func (w wrappedErr) Error() string { return "wrapped: " + w.e.Error() }
+func (w wrappedErr) Unwrap() error { return w.e }
+
+func wrapErr(e error) error { return wrappedErr{e: e} }

--- a/internal/shellenv/shellenv.go
+++ b/internal/shellenv/shellenv.go
@@ -321,7 +321,7 @@ func defaultShellCommandOutput(name string, args ...string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), shellCommandTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, name, args...)
-	configureShellCommand(cmd)
+	ConfigureShellCommand(cmd)
 	cmd.WaitDelay = 100 * time.Millisecond
 	return cmd.Output()
 }


### PR DESCRIPTION
## Summary

On context cancellation, the step shell runner, the four native-agent invocation runners, and the JS coverage runner spawned their `*exec.Cmd` without isolating it in a process group. `exec.CommandContext` therefore SIGKILLed only the **direct child** PID; grandchildren (an `npm`→`node` test runner's workers, an agent-spawned `git`/`build`/`editor`) survived, kept running, and **held the worktree locked** so the next run on the same branch couldn't proceed. This routes every long-lived cancellable subprocess through the process-group helper that already existed in the repo but was only wired into the managed-agent server path.

> ⚠️ **Reliability-sensitive change — orphan subprocesses & worktree lockup.** Before this fix, cancelling a long `commands.test: "npm test"` (or any agent run mid-flight) left the `node` workers alive until they finished or OOM'd, holding the worktree directory and file locks. The next run on the same branch failed at `git worktree add`. Please review the `ConfigureShellCommand` wiring and the Windows cancellation path. No behavior change for non-cancelled runs; no new dependencies.

## The bug

The correct helper already exists: `shellenv.configureShellCommand` (`internal/shellenv/shell_command_unix.go`) sets `SysProcAttr{Setpgid: true}` and installs `cmd.Cancel = Kill(-pgid, SIGKILL)` so the whole group dies on context cancel. It was used by exactly **one** path — the managed-agent server (`internal/agent/server_unix.go` / `server.go`) — and nowhere else. Every per-invocation and per-step subprocess was a bare `exec.CommandContext(ctx, ...)` with the default cancel behavior (SIGKILL the direct child only):

- `internal/pipeline/steps/common_exec.go:runShellCommandWithEnv` — the `sh -c` / `cmd.exe` runner behind `commands.{test,lint,format}` and repo-config commands. **Primary orphan vector** (`npm test` → node workers).
- `internal/agent/{claude,codex,pi,acpx}.go` `runOnce` cmd builders — each agent invocation shells out to its CLI, which may spawn git/build/editor processes during rebase/test resolution.
- `internal/shellenv/shellenv.go:defaultShellCommandOutput` — used the helper already (unexported); the only caller besides the server path.

`internal/agent/server_unix.go` (managed server) was already correct via its own `configureManagedServerCmd` + `signalManagedProcess`; this PR does **not** touch that path.

## Repro

```sh
go build -o ./bin/no-mistakes ./cmd/no-mistakes
# a repo whose test command backgrounds workers:
mkdir /tmp/orphan && cd /tmp/orphan && git init -q && \
  printf 'commands:\n  test: "sh -c '\''sleep 600 & wait'\''"\n' > .no-mistakes.yaml && \
  git add -A && git -c commit.gpgsign=false commit -qm init
./bin/no-mistakes init && ./bin/no-mistakes run   # then Ctrl-C / cancel mid-test
pgrep -af 'sleep 600'   # → STILL ALIVE: grandchild outlived the cancelled sh
```

After this PR the `sleep 600` is reaped within milliseconds of the cancel.

## The fix

**Export the helper** as `shellenv.ConfigureShellCommand` (was unexported `configureShellCommand`) so the agent and pipeline packages can use it. No logic change to the unix variant.

**Route every cancellable subprocess through it:**

- `runShellCommandWithEnv` (the step `sh`/`cmd.exe` runner) — `internal/pipeline/steps/common_exec.go`.
- the four native-agent `runOnce` cmd builders — `internal/agent/{claude,codex,pi,acpx}.go`.
- the existing internal caller in `shellenv.go` (rename only).

**Windows:** the unix variant's `Setpgid`/`SIGKILL(-pgid)` has no Windows equivalent, so the Windows variant (previously a no-op) now sets `CREATE_NEW_PROCESS_GROUP` and installs `cmd.Cancel` that runs `taskkill /T /F /PID` — the same tree-kill the daemon's orphan recovery already uses (`internal/daemon/recover_servers_windows.go`). `cmd.Cancel` returns `os.ErrProcessDone` when the PID is already gone, mirroring the unix `ESRCH` handling. The `!unix && !windows` fallback stays a no-op (no process groups / no tree-kill primitive there; ctx cancel still terminates the direct child).

| Path | Before | After |
|---|---|---|
| `runShellCommandWithEnv` (`sh`/`cmd.exe`) | bare `exec.CommandContext`; cancel kills `sh` only | `ConfigureShellCommand` → whole group killed |
| agent `runOnce` (claude/codex/pi/acpx) | bare `exec.CommandContext`; cancel kills CLI only | `ConfigureShellCommand` → CLI + spawned tools killed |
| Windows cancel | no-op (only direct child via `TerminateProcess`) | `CREATE_NEW_PROCESS_GROUP` + `taskkill /T /F` |
| managed server (`server.go`) | already correct (own helper) | unchanged |

**Out of scope:** the audit also cited `internal/pipeline/steps/coverage_jsts.go`, but that file does not exist on `main` yet (it's on an unmerged feature branch). It should adopt `ConfigureShellCommand` when that branch lands; noting here so it isn't lost.

## Verification

`gofmt -l .` clean · `go vet ./...` clean · `go build ./...` OK · `GOOS=windows go build ./...` clean · `go test -race ./...` green (Go 1.26.4 — system Go 1.18 is too old).

New regression test pinning the behavior (the defining symptom is a surviving grandchild, so the test exists to catch any future regression that drops the helper):

- `TestRunShellCommandWithEnv_KillsGrandchildOnCancel` (`internal/pipeline/steps/shell_unix_test.go`, `//go:build unix`) — backgrounds a heartbeat-writing loop under `sh -c '... & wait'`, cancels the context, and asserts the grandchild **stops running** (heartbeat holds steady) **and** its PID is **reaped** (`kill(pid, 0)` → `ESRCH`) within a short window. Confirmed to **fail** when `ConfigureShellCommand` is removed from `runShellCommandWithEnv` (grandchild keeps advancing the heartbeat) and **pass** with it. Run 3× consecutively with no flakiness.

The agent `runOnce` paths share the same helper and are exercised by the existing agent/server tests; no new test added there because reproducing the orphan requires a real agent binary that spawns persistent children.

## Notes for review

- The change is one exported rename + one new call site per runner + a real Windows implementation. The unix helper body is byte-identical to the pre-existing (unexported) one; only its visibility changed.
- `ConfigureShellCommand` is intentionally applied at the `runShellCommandWithEnv` / `runOnce` boundary rather than inside `stepCmd` (the git/auth cmd builder). The audit scoped the fix to the shell runner and agent invocations; git-hook-spawned children (audit #13) are a separate finding.
- Recorded the convention in `AGENTS.md` ("Context, Concurrency, and Processes") so future `exec.CommandContext` call sites in these paths apply the helper.

---

AI disclosure: **Human-reviewed.** The change was produced with AI assistance and reviewed by a human contributor before submission.