### PR TITLE
fix(pipeline): robust terminal-state writes + no silent pending/agent-work loss

### DIFF
--- a/internal/db/run.go
+++ b/internal/db/run.go
@@ -213,11 +213,14 @@ func (d *DB) RecoverStaleRuns(errMsg string) (int, error) {
 	}
 	defer tx.Rollback()
 
-	// Fail stale steps first (running, awaiting_approval, fixing, fix_review).
+	// Fail stale steps first. Pending is included so that a mid-pipeline
+	// failure (which leaves unstarted subsequent steps pending) does not
+	// orphan rows that render as "pending" in the PR body. The other four
+	// statuses are the in-flight step states a crash can interrupt.
 	_, err = tx.Exec(
-		`UPDATE step_results SET status = ?, error = ?, completed_at = ? WHERE status IN (?, ?, ?, ?)`,
+		`UPDATE step_results SET status = ?, error = ?, completed_at = ? WHERE status IN (?, ?, ?, ?, ?)`,
 		types.StepStatusFailed, errMsg, ts,
-		types.StepStatusRunning, types.StepStatusAwaitingApproval, types.StepStatusFixing, types.StepStatusFixReview,
+		types.StepStatusPending, types.StepStatusRunning, types.StepStatusAwaitingApproval, types.StepStatusFixing, types.StepStatusFixReview,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("recover stale steps: %w", err)

--- a/internal/db/run_test.go
+++ b/internal/db/run_test.go
@@ -330,6 +330,8 @@ func TestRecoverStaleRunsMarksStepsFailed(t *testing.T) {
 	}
 
 	// Running, awaiting_approval, fixing should be failed.
+	// Pending steps are now also recovered (previously orphaned, rendering as
+	// "⏳ pending" in the PR body after a mid-pipeline crash).
 	for _, tc := range []struct {
 		id   string
 		name string
@@ -339,7 +341,7 @@ func TestRecoverStaleRunsMarksStepsFailed(t *testing.T) {
 		{awaitingStep.ID, "awaiting", types.StepStatusFailed},
 		{fixingStep.ID, "fixing", types.StepStatusFailed},
 		{completedStep.ID, "completed", types.StepStatusCompleted},
-		{pendingStep.ID, "pending", types.StepStatusPending},
+		{pendingStep.ID, "pending", types.StepStatusFailed},
 	} {
 		got, _ := d.GetStepResult(tc.id)
 		if got.Status != tc.want {

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -112,9 +112,11 @@ func (e *Executor) RespondWithOverrides(step types.StepName, action types.Approv
 // If the context is cancelled with a cause (via context.WithCancelCause),
 // the cause message is preserved as the run's error in the DB.
 func (e *Executor) Execute(ctx context.Context, run *db.Run, repo *db.Repo, workDir string) error {
-	// Mark run as running
+	// Mark run as running. A failure here must route through failRun so the run
+	// never lingers in RunPending (a zombie that only RecoverStaleRuns would
+	// relabel later as "daemon crashed during execution").
 	if err := e.db.UpdateRunStatus(run.ID, types.RunRunning); err != nil {
-		return fmt.Errorf("update run status: %w", err)
+		return e.failRun(run, repo, fmt.Errorf("update run status: %w", err))
 	}
 	run.Status = types.RunRunning
 	e.emitRunEvent(ipc.EventRunUpdated, run, repo)
@@ -151,24 +153,34 @@ func (e *Executor) Execute(ctx context.Context, run *db.Run, repo *db.Repo, work
 		}
 		skipRemaining, err := e.executeStep(ctx, step, sr, run, repo, workDir, logDir)
 		if err != nil {
+			// Mark unstarted subsequent steps as skipped so they are not left
+			// pending in the DB (pending rows render as "pending" in the PR
+			// body). Best-effort: the run is already failing.
+			if skipErr := e.markRemainingSkipped(run, repo, stepRecords, i+1); skipErr != nil {
+				slog.Warn("failed to mark subsequent steps skipped after failure", "error", skipErr)
+			}
 			return e.failRun(run, repo, err, ctx)
 		}
 		if skipRemaining {
-			// Mark all subsequent steps as skipped
-			for _, remaining := range e.steps[i+1:] {
-				rsr := stepRecords[remaining.Name()]
-				if dbErr := e.db.CompleteStepWithStatus(rsr.ID, types.StepStatusSkipped, 0, 0, ""); dbErr != nil {
-					slog.Warn("failed to finalize skipped step", "step", remaining.Name(), "error", dbErr)
-				}
-				e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, remaining.Name(), string(types.StepStatusSkipped), "", "", "", nil)
+			// Mark all subsequent steps as skipped. A DB write failure here is
+			// fatal (mirrors the configured-skip write above): otherwise the
+			// remaining step rows stay pending and surface as "pending" in the
+			// PR body.
+			if skipErr := e.markRemainingSkipped(run, repo, stepRecords, i+1); skipErr != nil {
+				return e.failRun(run, repo, skipErr, ctx)
 			}
 			break
 		}
 	}
 
-	// Mark run as completed
+	// Mark run as completed. This is the only terminal-state write that used to
+	// return a raw error: every step already completed, but if this single
+	// SQLite write failed the run stayed RunRunning forever and
+	// EventRunCompleted never fired. Route through failRun so a transient DB
+	// error marks the run terminal and emits the completion event instead of
+	// leaving a zombie.
 	if err := e.db.UpdateRunStatus(run.ID, types.RunCompleted); err != nil {
-		return fmt.Errorf("update run status: %w", err)
+		return e.failRun(run, repo, fmt.Errorf("update run status: %w", err))
 	}
 	run.Status = types.RunCompleted
 	e.emitRunEvent(ipc.EventRunCompleted, run, repo)
@@ -374,8 +386,18 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 		e.mu.Unlock()
 
 		// Step needs approval - store execution-only duration and wait for user action.
+		// This status write is load-bearing: DB-polling clients (status cmd,
+		// gh-axi, integrations) rely on it to know approval is being waited on.
+		// If it fails, do NOT emit the event or block on waitForApproval — that
+		// would desync the DB (prior status) from the event stream (awaiting).
+		// Fail the step instead so the divergence never opens.
 		if dbErr := e.db.UpdateStepStatusWithDuration(sr.ID, approvalStatus, executionMS); dbErr != nil {
-			slog.Warn("failed to update step status and duration in db", "step", stepName, "status", approvalStatus, "error", dbErr)
+			failMsg := fmt.Sprintf("persist %s status: %s", approvalStatus, dbErr)
+			if failErr := e.db.FailStep(sr.ID, failMsg, executionMS); failErr != nil {
+				slog.Warn("failed to mark step as failed in db", "step", stepName, "error", failErr)
+			}
+			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFailed), "", "", failMsg, &executionMS)
+			return false, fmt.Errorf("step %s: %s", stepName, failMsg)
 		}
 		e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(approvalStatus), outcome.Findings, diffText, "", &executionMS)
 
@@ -524,6 +546,26 @@ func (e *Executor) failRun(run *db.Run, repo *db.Repo, err error, ctxs ...contex
 	run.Error = &errMsg
 	e.emitRunEvent(ipc.EventRunCompleted, run, repo)
 	return err
+}
+
+// markRemainingSkipped marks every step from e.steps[startIndex] onward as
+// skipped in the DB and emits a skipped event for each. It is used on the
+// step-failure and skip-remaining paths so unstarted steps are never left
+// pending — pending rows render as "⏳ pending" in the PR body. Returns an
+// error if any status write fails (caller decides whether that is fatal).
+func (e *Executor) markRemainingSkipped(run *db.Run, repo *db.Repo, stepRecords map[types.StepName]*db.StepResult, startIndex int) error {
+	for j := startIndex; j < len(e.steps); j++ {
+		remaining := e.steps[j]
+		rsr := stepRecords[remaining.Name()]
+		if rsr == nil {
+			continue
+		}
+		if dbErr := e.db.CompleteStepWithStatus(rsr.ID, types.StepStatusSkipped, 0, 0, ""); dbErr != nil {
+			return fmt.Errorf("skip step %s: %w", remaining.Name(), dbErr)
+		}
+		e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, remaining.Name(), string(types.StepStatusSkipped), "", "", "", nil)
+	}
+	return nil
 }
 
 // --- event helpers ---

--- a/internal/pipeline/executor_robustness_test.go
+++ b/internal/pipeline/executor_robustness_test.go
@@ -1,0 +1,252 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/ipc"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// TestExecutor_StartWriteFailureMarksRunFailed ensures that when the initial
+// UpdateRunStatus(RunRunning) write fails, the run is routed through failRun
+// (terminal event emitted, run marked failed) rather than returning a raw
+// error that leaves the run zombieed in RunPending.
+func TestExecutor_StartWriteFailureMarksRunFailed(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	exec := NewExecutor(database, p, nil, nil, []Step{newPassStep(types.StepReview)}, nil)
+	events := collectEvents(exec)
+
+	// Simulate a transient SQLite failure by closing the connection before
+	// Execute runs. The start status write is the first DB operation Execute
+	// performs, so this targets exactly that write.
+	if err := database.Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	err := exec.Execute(context.Background(), run, repo, workDir)
+	if err == nil {
+		t.Fatal("expected error from failed start write, got nil")
+	}
+
+	// failRun must have emitted the terminal event (the bug: raw-error return
+	// emits nothing, leaving subscribers waiting forever).
+	if e := events.findRunEvent(ipc.EventRunCompleted); e == nil {
+		t.Fatal("expected run_completed event after start-write failure")
+	}
+
+	// The in-memory run must be terminal (failed), not still pending/running.
+	if run.Status != types.RunFailed {
+		t.Errorf("run status = %q, want %q", run.Status, types.RunFailed)
+	}
+}
+
+// TestExecutor_FinalWriteFailureMarksRunFailed ensures that when the final
+// UpdateRunStatus(RunCompleted) write fails (after every step succeeded), the
+// run is routed through failRun instead of returning a raw error that leaves
+// it zombieed in RunRunning with EventRunCompleted never firing.
+func TestExecutor_FinalWriteFailureMarksRunFailed(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	// Empty steps: Execute does the start write, skips the loop, then performs
+	// the final completed write. Closing the DB right after the start write
+	// (observed via the "running" run_updated event) isolates the final write.
+	ec := &eventCollector{}
+	closed := false
+	exec := NewExecutor(database, p, nil, nil, nil, func(e ipc.Event) {
+		ec.handler(e)
+		if !closed && e.Type == ipc.EventRunUpdated && e.StepName == nil &&
+			e.Status != nil && *e.Status == string(types.RunRunning) {
+			closed = true
+			if err := database.Close(); err != nil {
+				t.Errorf("close db: %v", err)
+			}
+		}
+	})
+
+	err := exec.Execute(context.Background(), run, repo, workDir)
+	if err == nil {
+		t.Fatal("expected error from failed final write, got nil")
+	}
+	if !closed {
+		t.Fatal("expected DB to be closed after the running event")
+	}
+
+	completed := ec.findRunEvent(ipc.EventRunCompleted)
+	if completed == nil {
+		t.Fatal("expected run_completed event after final-write failure (the bug never emitted one)")
+	}
+	if completed.Status == nil || *completed.Status != string(types.RunFailed) {
+		got := "<nil>"
+		if completed.Status != nil {
+			got = *completed.Status
+		}
+		t.Errorf("run_completed status = %q, want %q", got, types.RunFailed)
+	}
+
+	// The run must not be left in the zombie RunRunning state.
+	if run.Status != types.RunFailed {
+		t.Errorf("run status = %q, want %q", run.Status, types.RunFailed)
+	}
+}
+
+// TestExecutor_FailedStepMarksSubsequentSkipped ensures that a mid-pipeline
+// step failure marks unstarted subsequent steps as skipped, not pending.
+// Pending rows render as "⏳ pending" in the PR body, implying work that will
+// still happen on a run that has already failed.
+func TestExecutor_FailedStepMarksSubsequentSkipped(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	steps := []Step{
+		newPassStep(types.StepReview),
+		newFailStep(types.StepTest, errors.New("tests crashed")),
+		newPassStep(types.StepLint), // unstarted after failure
+		newPassStep(types.StepPush), // unstarted after failure
+	}
+
+	exec := NewExecutor(database, p, nil, nil, steps, nil)
+	events := collectEvents(exec)
+
+	if err := exec.Execute(context.Background(), run, repo, workDir); err == nil {
+		t.Fatal("expected error from failing step, got nil")
+	}
+
+	dbSteps, _ := database.GetStepsByRun(run.ID)
+	if len(dbSteps) != 4 {
+		t.Fatalf("expected 4 step rows, got %d", len(dbSteps))
+	}
+	if dbSteps[0].Status != types.StepStatusCompleted {
+		t.Errorf("review: expected %q, got %q", types.StepStatusCompleted, dbSteps[0].Status)
+	}
+	if dbSteps[1].Status != types.StepStatusFailed {
+		t.Errorf("test: expected %q, got %q", types.StepStatusFailed, dbSteps[1].Status)
+	}
+	// Subsequent unstarted steps must be skipped, never pending.
+	for _, s := range dbSteps[2:] {
+		if s.Status != types.StepStatusSkipped {
+			t.Errorf("step %s: expected %q, got %q", s.StepName, types.StepStatusSkipped, s.Status)
+		}
+	}
+
+	// A skipped completion event should be emitted for each subsequent step.
+	if e := events.find(ipc.EventStepCompleted, types.StepLint); e == nil || e.Status == nil || *e.Status != string(types.StepStatusSkipped) {
+		t.Errorf("expected skipped event for lint, got %v", e)
+	}
+	if e := events.find(ipc.EventStepCompleted, types.StepPush); e == nil || e.Status == nil || *e.Status != string(types.StepStatusSkipped) {
+		t.Errorf("expected skipped event for push, got %v", e)
+	}
+}
+
+// TestExecutor_AwaitingApprovalWriteFailureFailsStep ensures that a failure of
+// the awaiting_approval DB write fails the step instead of desyncing the DB
+// (prior status) from the event stream (awaiting) and blocking on
+// waitForApproval with no durable record of the wait.
+func TestExecutor_AwaitingApprovalWriteFailureFailsStep(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	// The step returns a NeedsApproval outcome and, before doing so, breaks the
+	// DB so the subsequent awaiting_approval status write fails. StartStep runs
+	// before step.Execute, so the connection is still open for it.
+	step := &adaptiveCallStep{
+		name: types.StepReview,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			if err := sctx.DB.Close(); err != nil {
+				t.Errorf("close db: %v", err)
+			}
+			return &StepOutcome{
+				NeedsApproval: true,
+				Findings:      `{"findings":[{"severity":"error","description":"bug","action":"fix"}],"summary":"1 issue"}`,
+			}, nil
+		},
+	}
+
+	exec := NewExecutor(database, p, nil, nil, []Step{step}, nil)
+	events := collectEvents(exec)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- exec.Execute(context.Background(), run, repo, workDir)
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected error from awaiting_approval write failure, got nil")
+		}
+	case <-time.After(5 * time.Second):
+		// The bug: the executor logs the DB error, emits the awaiting event,
+		// and blocks forever on waitForApproval. The fix returns promptly.
+		t.Fatal("executor blocked on waitForApproval after awaiting_approval write failure")
+	}
+
+	// The step must be reported failed, not awaiting_approval.
+	failedEvent := events.find(ipc.EventStepCompleted, types.StepReview)
+	if failedEvent == nil || failedEvent.Status == nil {
+		t.Fatal("expected step_completed event for review")
+	}
+	if *failedEvent.Status != string(types.StepStatusFailed) {
+		t.Errorf("review status = %q, want %q", *failedEvent.Status, types.StepStatusFailed)
+	}
+
+	// No awaiting_approval event must have been emitted (that would desync the
+	// event stream from the DB, which still holds the prior status).
+	for _, e := range events.all() {
+		if e.Type == ipc.EventStepCompleted && e.Status != nil && *e.Status == string(types.StepStatusAwaitingApproval) {
+			t.Errorf("did not expect awaiting_approval event after write failure: %+v", e)
+		}
+	}
+
+	// The run must be terminal.
+	if run.Status != types.RunFailed {
+		t.Errorf("run status = %q, want %q", run.Status, types.RunFailed)
+	}
+}
+
+// TestExecutor_SkipRemainingDBErrorFailsRun ensures that a DB error while
+// marking subsequent steps skipped (on the skip-remaining path) is treated as
+// fatal rather than logged-and-swallowed, which previously left the remaining
+// step row pending.
+func TestExecutor_SkipRemainingDBErrorFailsRun(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	// First step signals skip-remaining; the callback closes the DB once the
+	// first step has completed so that marking the second step skipped fails.
+	ec := &eventCollector{}
+	closed := false
+	exec := NewExecutor(database, p, nil, nil, []Step{
+		&mockStep{name: types.StepRebase, outcome: &StepOutcome{ExitCode: 0, SkipRemaining: true}},
+		newPassStep(types.StepReview),
+	}, func(e ipc.Event) {
+		ec.handler(e)
+		if !closed && e.Type == ipc.EventStepCompleted && e.StepName != nil &&
+			*e.StepName == types.StepRebase && e.Status != nil && *e.Status == string(types.StepStatusCompleted) {
+			closed = true
+			if err := database.Close(); err != nil {
+				t.Errorf("close db: %v", err)
+			}
+		}
+	})
+
+	err := exec.Execute(context.Background(), run, repo, workDir)
+	if err == nil {
+		t.Fatal("expected error from skip-remaining DB write failure, got nil")
+	}
+	if !closed {
+		t.Fatal("expected DB to be closed after the rebase step completed")
+	}
+	if run.Status != types.RunFailed {
+		t.Errorf("run status = %q, want %q", run.Status, types.RunFailed)
+	}
+	if !strings.Contains(err.Error(), "skip step") {
+		t.Errorf("expected error to mention skip step, got %q", err)
+	}
+}

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -179,13 +179,14 @@ func TestExecutor_StepError_FailsRun(t *testing.T) {
 		t.Errorf("expected run status %q, got %q", types.RunFailed, updated.Status)
 	}
 
-	// Second step should be failed, third should be pending
+	// Second step should be failed, third should be skipped (not left pending,
+	// which would render as "⏳ pending" in the PR body).
 	dbSteps, _ := database.GetStepsByRun(run.ID)
 	if dbSteps[1].Status != types.StepStatusFailed {
 		t.Errorf("step test: expected %q, got %q", types.StepStatusFailed, dbSteps[1].Status)
 	}
-	if dbSteps[2].Status != types.StepStatusPending {
-		t.Errorf("step lint: expected %q, got %q", types.StepStatusPending, dbSteps[2].Status)
+	if dbSteps[2].Status != types.StepStatusSkipped {
+		t.Errorf("step lint: expected %q, got %q", types.StepStatusSkipped, dbSteps[2].Status)
 	}
 }
 

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -35,7 +35,15 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 	if err := s.stageInRepoEvidence(sctx); err != nil {
 		return nil, err
 	}
-	status, _ := git.Run(ctx, sctx.WorkDir, "status", "--porcelain")
+	status, err := git.Run(ctx, sctx.WorkDir, "status", "--porcelain")
+	if err != nil {
+		// Propagate instead of discarding: on error status is "", the
+		// "commit agent changes" block is skipped, and uncommitted agent
+		// edits are never committed/pushed — then destroyed when the
+		// worktree is removed. The PR would ship from stale state while the
+		// user believes the agent's fixes landed.
+		return nil, fmt.Errorf("check worktree status: %w", err)
+	}
 	if strings.TrimSpace(status) != "" {
 		sctx.Log("committing agent changes...")
 		if _, err := git.Run(ctx, sctx.WorkDir, "add", "-A"); err != nil {

--- a/internal/pipeline/steps/push_test.go
+++ b/internal/pipeline/steps/push_test.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kunchenguid/no-mistakes/internal/config"
@@ -139,5 +140,28 @@ func TestPushStep_DoesNotForceAddIgnoredEvidenceDirectory(t *testing.T) {
 	}
 	if status := gitStatusPorcelain(t, dir); status != "" {
 		t.Fatalf("ignored evidence directory was staged: %q", status)
+	}
+}
+
+// TestPushStep_PropagatesGitStatusError ensures a failure of `git status
+// --porcelain` is propagated rather than discarded. Discarding it made status
+// "" which skipped the "commit agent changes" block, dropping uncommitted
+// agent edits when the worktree was removed — silent data loss.
+func TestPushStep_PropagatesGitStatusError(t *testing.T) {
+	t.Parallel()
+	// A directory that is not a git repository: `git status --porcelain` fails.
+	nonRepo := t.TempDir()
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, nonRepo, "abc", "def", config.Commands{})
+	sctx.Run.Branch = "feature"
+
+	step := &PushStep{}
+	_, err := step.Execute(sctx)
+	if err == nil {
+		t.Fatal("expected error from git status failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "check worktree status") {
+		t.Fatalf("expected error to contain 'check worktree status', got %q", err)
 	}
 }


### PR DESCRIPTION
Ship 4 of the robustness audit (findings §5–§8). Four MED pipeline-correctness bugs: zombie runs after a transient SQLite write failure, orphaned `pending` step rows after a mid-pipeline failure, DB/event desync on the `awaiting_approval` write, and silent agent-work data loss in the push step.

## The bugs

**§5 — Zombie runs.** The start (`executor.go:116`) and end (`executor.go:170`) `UpdateRunStatus` writes were the **only** terminal-state writes in `Execute` that returned a raw error instead of calling `failRun`. Every step already completed, but if that single SQLite write failed (DB busy, transient I/O), `Execute` returned the error, the manager only logged `"pipeline failed"`, the run row stayed `running`/`pending` forever, and `EventRunCompleted` never fired — until daemon restart, where `RecoverStaleRuns` mislabeled it `"daemon crashed during execution"` despite every step having succeeded.

**§6 — Orphan pending step rows.** `RecoverStaleRuns` (`db/run.go:217`) only transitioned steps in `(running, awaiting_approval, fixing, fix_review)` — **not** `pending`. A mid-pipeline failure leaves all subsequent steps `pending` permanently; `prsummary.go:800` renders them as `⏳ <step> - pending` in the PR body. The same happens on the `skipRemaining` path if the `CompleteStepWithStatus` DB write at `executor.go:160` failed — that failure was only `slog.Warn`'d.

**§7 — DB/event desync.** The `awaiting_approval` DB write (`executor.go:371-389`) was logged-and-swallowed. On failure the executor still set `waiting=true`, emitted the `awaiting_approval` event, and blocked on `waitForApproval`. DB-polling clients (`status` cmd, `gh-axi run`, integrations) saw the prior status and had no idea approval was being waited on — a live divergence between the DB and the event stream.

**§8 — Silent agent-work data loss.** `push.go:38` did `status, _ := git.Run(... "status","--porcelain")` — error discarded. On error `status=""`, the "commit agent changes" block was skipped, uncommitted agent edits were never committed/pushed, and were destroyed when the worktree was removed. The PR shipped from stale state while the user believed the agent's fixes landed.

## Approach

- **§5** — Both the start (`RunRunning`) and end (`RunCompleted`) `UpdateRunStatus` writes now route through `failRun(run, repo, err)`. A transient DB error marks the run terminal (`failed`) and emits `EventRunCompleted` instead of leaving a zombie. `failRun` still attempts `UpdateRunErrorStatus` (best-effort) and emits the terminal event unconditionally.
- **§6** — Two complementary fixes:
  - `RecoverStaleRuns` (`db/run.go`) now includes `StepStatusPending` in its stale-step `UPDATE`, so a daemon crash mid-pipeline no longer orphans subsequent pending rows (crash-recovery path).
  - `Execute`'s step-failure path now marks unstarted subsequent steps `skipped` (best-effort) via a shared `markRemainingSkipped` helper, and the `skipRemaining` path treats the skipped-step DB write as **fatal** (matching the configured-skip sibling at `:146`) — so a live mid-pipeline failure no longer leaves downstream steps pending in the PR body.
- **§7** — The `awaiting_approval`/`fix_review` status write (`UpdateStepStatusWithDuration`) is now load-bearing: on failure the step is marked failed, a failed event is emitted, and the executor returns an error (failing the run) **before** emitting the awaiting event or blocking on `waitForApproval`. The DB/event divergence never opens.
- **§8** — The `git status --porcelain` error is propagated: `return nil, fmt.Errorf("check worktree status: %w", err)`.

## Scope

- `internal/pipeline/executor.go` — start/end `UpdateRunStatus` routed through `failRun`; new `markRemainingSkipped` helper used by both failure and skip-remaining paths; skip-remaining DB error made fatal; `awaiting_approval` write made load-bearing.
- `internal/db/run.go` — `RecoverStaleRuns` step `UPDATE` includes `StepStatusPending`.
- `internal/pipeline/steps/push.go` — `git status --porcelain` error propagated.

## Risk

- **Behavior change for downstream steps on a failed run.** Previously, a step failure left subsequent steps `pending`; they now show as `skipped`. This is the intended fix — `pending` implied work that would still happen on an already-failed run. The existing `TestExecutor_StepError_FailsRun` is updated accordingly.
- **`RecoverStaleRuns` now transitions `pending` steps to `failed`.** Existing `TestRecoverStaleRunsMarksStepsFailed` is updated. This only affects crash recovery (runs stuck in `pending`/`running`); already-terminal runs are untouched.
- **The `awaiting_approval` write is now a run-ending failure if the DB is unreachable.** This is correct: the approval protocol fundamentally depends on the status being durable for DB-polling clients. The previous behavior (log, emit, block) silently desynced the DB from the event stream.
- **No new failure paths for healthy runs** — all four fixes only change behavior when a DB/git write already failed.

## Verification

`gofmt -l .` clean · `go vet ./...` clean · `go build ./...` OK · `go test -race ./...` green (Go 1.26.4, all 31 packages).

New tests (`internal/pipeline/executor_robustness_test.go`, `internal/pipeline/steps/push_test.go`):

- **`TestExecutor_StartWriteFailureMarksRunFailed`** — start `UpdateRunStatus` failure routes through `failRun`: terminal event emitted, run marked `failed` (not left `pending`).
- **`TestExecutor_FinalWriteFailureMarksRunFailed`** — final `UpdateRunStatus(RunCompleted)` failure (after all steps succeed) routes through `failRun`: `EventRunCompleted` emitted with `failed` status (previously never emitted).
- **`TestExecutor_FailedStepMarksSubsequentSkipped`** — a mid-pipeline failure marks unstarted subsequent steps `skipped`, not `pending`, and emits skipped events for each.
- **`TestExecutor_AwaitingApprovalWriteFailureFailsStep`** — `awaiting_approval` DB write failure fails the step and returns promptly (does not block on `waitForApproval`, does not emit an awaiting event).
- **`TestExecutor_SkipRemainingDBErrorFailsRun`** — a DB error marking subsequent steps skipped (skip-remaining path) is fatal.
- **`TestPushStep_PropagatesGitStatusError`** — a failing `git status --porcelain` propagates `check worktree status: ...` instead of being discarded.

Updated: `TestExecutor_StepError_FailsRun` (subsequent step now `skipped`), `TestRecoverStaleRunsMarksStepsFailed` (`pending` step now recovered to `failed`).

---

AI disclosure: **Human-reviewed.** The change was produced with AI assistance and reviewed by a human contributor before submission.