### PR TITLE
fix(git): headless-friendly signing + fail-fast on hung hooks/SSH

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ Safest local verification sequence after non-trivial changes:
 - Use `context.Background()` mainly at top-level boundaries, background tasks, or in tests.
 - Protect shared mutable state with `sync.Mutex`, `sync.RWMutex`, `sync.Map`, or `atomic` where appropriate.
 - Be explicit about ownership and cleanup of goroutines, worktrees, temp dirs, and channels.
+- Autofix `git commit`/`git push` must stay headless-safe: route them through `steps.autofixCommit`/`autofixPush`, which disable `commit.gpgsign`, apply `git.NonInteractiveEnv` (incl. `SSH_ASKPASS_REQUIRE=never`), and run under a short scoped timeout so a hung hook or SSH passphrase prompt fails fast. Do not regress these to bare `git.Run`/`git.Push`.
 
 **Filesystem and Paths**
 

--- a/internal/git/env.go
+++ b/internal/git/env.go
@@ -19,6 +19,12 @@ import (
 // overrides are appended last so they win over any ambient values (exec
 // resolves duplicate keys using the last occurrence).
 //
+// SSH_ASKPASS_REQUIRE=never makes ssh refuse to delegate passphrase prompts to
+// an askpass program; in a headless run with no controlling TTY this causes
+// ssh to fail fast instead of opening /dev/tty and blocking on a passphrase
+// (e.g. a passphrased key with no agent). It does not affect the happy path
+// where an agent holds the key.
+//
 // Pass the same directory assigned to cmd.Dir (or "" when it is unset). When
 // cmd.Env is left nil, os/exec injects PWD=cmd.Dir automatically; assigning
 // cmd.Env disables that, so callers must thread the working directory through
@@ -29,6 +35,7 @@ func NonInteractiveEnv(dir string) []string {
 		"GIT_EDITOR=true",
 		"GIT_SEQUENCE_EDITOR=true",
 		"GIT_TERMINAL_PROMPT=0",
+		"SSH_ASKPASS_REQUIRE=never",
 	)
 	// Mirror os/exec, which only injects PWD when Cmd.Env is nil and skips it
 	// on these platforms.

--- a/internal/git/env_test.go
+++ b/internal/git/env_test.go
@@ -27,6 +27,7 @@ func TestNonInteractiveEnv_SetsGitOverrides(t *testing.T) {
 		"GIT_EDITOR":          "true",
 		"GIT_SEQUENCE_EDITOR": "true",
 		"GIT_TERMINAL_PROMPT": "0",
+		"SSH_ASKPASS_REQUIRE": "never",
 	}
 	for k, v := range want {
 		if got[k] != v {
@@ -39,6 +40,7 @@ func TestNonInteractiveEnv_OverridesAmbientEditor(t *testing.T) {
 	t.Setenv("GIT_EDITOR", "vim")
 	t.Setenv("GIT_SEQUENCE_EDITOR", "nano")
 	t.Setenv("GIT_TERMINAL_PROMPT", "1")
+	t.Setenv("SSH_ASKPASS_REQUIRE", "prefer")
 
 	got := resolveEnv(NonInteractiveEnv(""))
 
@@ -50,6 +52,9 @@ func TestNonInteractiveEnv_OverridesAmbientEditor(t *testing.T) {
 	}
 	if got["GIT_TERMINAL_PROMPT"] != "0" {
 		t.Errorf("GIT_TERMINAL_PROMPT = %q, want \"0\"", got["GIT_TERMINAL_PROMPT"])
+	}
+	if got["SSH_ASKPASS_REQUIRE"] != "never" {
+		t.Errorf("SSH_ASKPASS_REQUIRE = %q, want \"never\" (ambient must be overridden)", got["SSH_ASKPASS_REQUIRE"])
 	}
 }
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -328,6 +328,19 @@ func CopyLocalUserIdentity(ctx context.Context, srcDir, dstDir string) error {
 	return nil
 }
 
+// CommitSigningEnabled reports whether commit.gpgsign resolves to true in dir,
+// taking local, global, system, and include config into account. no-mistakes
+// uses it to detect orgs that mandate signing (which cannot complete
+// headlessly) and route autofix commits through commit.gpgsign=false instead.
+// Returns false on any error (including the key being unset).
+func CommitSigningEnabled(ctx context.Context, dir string) bool {
+	out, err := Run(ctx, dir, "config", "--get", "--type=bool", "commit.gpgsign")
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(out), "true")
+}
+
 // WorktreeAdd creates a detached worktree at wtPath checked out to the given SHA.
 func WorktreeAdd(ctx context.Context, repoDir, wtPath, sha string) error {
 	_, err := Run(ctx, repoDir, "worktree", "add", "--detach", wtPath, sha)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -136,6 +136,33 @@ func TestCopyLocalUserIdentity(t *testing.T) {
 	}
 }
 
+func TestCommitSigningEnabled(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("unset returns false", func(t *testing.T) {
+		dir := initTestRepo(t)
+		if CommitSigningEnabled(ctx, dir) {
+			t.Fatal("expected CommitSigningEnabled=false when commit.gpgsign is unset")
+		}
+	})
+
+	t.Run("local true returns true", func(t *testing.T) {
+		dir := initTestRepo(t)
+		run(t, dir, "git", "config", "commit.gpgsign", "true")
+		if !CommitSigningEnabled(ctx, dir) {
+			t.Fatal("expected CommitSigningEnabled=true after local commit.gpgsign=true")
+		}
+	})
+
+	t.Run("explicit false returns false", func(t *testing.T) {
+		dir := initTestRepo(t)
+		run(t, dir, "git", "config", "commit.gpgsign", "false")
+		if CommitSigningEnabled(ctx, dir) {
+			t.Fatal("expected CommitSigningEnabled=false after local commit.gpgsign=false")
+		}
+	})
+}
+
 func TestGetRemoteURLNotFound(t *testing.T) {
 	dir := initTestRepo(t)
 	ctx := context.Background()

--- a/internal/pipeline/steps/autofix.go
+++ b/internal/pipeline/steps/autofix.go
@@ -1,0 +1,91 @@
+package steps
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/git"
+	"github.com/kunchenguid/no-mistakes/internal/pipeline"
+)
+
+// autofixGitTimeout caps how long a single autofix git commit or push may run.
+// It is intentionally far shorter than the run's CI timeout so that a hung
+// pre-commit/pre-push hook, an interactive commit-msg hook, or an SSH
+// passphrase prompt fails the step quickly instead of wedging the pipeline
+// for hours. The derived context still inherits cancellation from the run
+// context, so a cancelled run cancels an in-flight autofix op too.
+//
+// It is a package-level variable (not a constant) so tests can shrink it to
+// assert fail-fast behavior without waiting minutes.
+var autofixGitTimeout = 2 * time.Minute
+
+// autofixCommit runs `git commit` for an autofix with two headless-safety
+// guarantees:
+//
+//  1. Signing is disabled via `-c commit.gpgsign=false`. Many enterprises set
+//     `commit.gpgsign=true` org-wide; an autofix commit cannot be signed
+//     headlessly (gpg fails with "Inappropriate ioctl for device" or pinentry
+//     hangs until its timeout), so the commit must land unsigned. This is the
+//     correct behavior for machine-generated commits. When signing was
+//     effectively enabled the user is warned so the unsigned autofix is not a
+//     silent surprise.
+//
+//  2. The commit runs under a short deadline (autofixGitTimeout) so a hook
+//     that blocks on stdin (interactive confirmation, 2FA) fails the step
+//     quickly instead of hanging until the run's CI timeout.
+func autofixCommit(sctx *pipeline.StepContext, message string) error {
+	if git.CommitSigningEnabled(sctx.Ctx, sctx.WorkDir) {
+		sctx.Log("warning: commit.gpgsign is enabled; no-mistakes autofix commits will be unsigned")
+	}
+	ctx, cancel := context.WithTimeout(sctx.Ctx, autofixGitTimeout)
+	defer cancel()
+	_, err := autofixGitRun(ctx, sctx, "-c", "commit.gpgsign=false", "commit", "-m", message)
+	if err != nil {
+		return fmt.Errorf("commit agent changes: %w", err)
+	}
+	return nil
+}
+
+// autofixPush runs `git push` for an autofix under a short deadline so a hung
+// pre-push hook or SSH passphrase prompt fails fast instead of blocking until
+// the run's CI timeout.
+func autofixPush(sctx *pipeline.StepContext, remote, ref, expectedSHA string, forceWithLease bool) error {
+	ctx, cancel := context.WithTimeout(sctx.Ctx, autofixGitTimeout)
+	defer cancel()
+	args := []string{"push", remote}
+	if forceWithLease {
+		if expectedSHA != "" {
+			args = append(args, fmt.Sprintf("--force-with-lease=%s:%s", ref, expectedSHA))
+		} else {
+			args = append(args, "--force-with-lease")
+		}
+	}
+	args = append(args, "HEAD:"+ref)
+	_, err := autofixGitRun(ctx, sctx, args...)
+	return err
+}
+
+// autofixGitRun runs a git command for an autofix commit or push. Unlike
+// stepGitRunCtx it always applies git.NonInteractiveEnv (so headless git
+// semantics — no editor, no credential prompt, no SSH askpass — hold even when
+// sctx.Env is empty in production) while still layering sctx.Env on top so
+// tests can inject a fake git binary.
+func autofixGitRun(ctx context.Context, sctx *pipeline.StepContext, args ...string) (string, error) {
+	cmd := stepCmdCtx(ctx, sctx, "git", args...)
+	// stepCmdCtx leaves cmd.Env nil when sctx.Env is empty; in both cases layer
+	// NonInteractiveEnv underneath sctx.Env so the headless overrides always
+	// apply, with test-provided sctx.Env winning on conflict.
+	cmd.Env = mergeEnv(append(git.NonInteractiveEnv(sctx.WorkDir), sctx.Env...))
+	out, err := cmd.Output()
+	if err != nil {
+		stderr := ""
+		if ee, ok := err.(*exec.ExitError); ok {
+			stderr = strings.TrimSpace(string(ee.Stderr))
+		}
+		return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, stderr)
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/internal/pipeline/steps/autofix_test.go
+++ b/internal/pipeline/steps/autofix_test.go
@@ -1,0 +1,128 @@
+package steps
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/config"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// TestCommitAgentFixes_GpgSignEnabledCommitsUnsignedWithWarning proves the
+// headless-signing fix (audit §4): when commit.gpgsign=true is configured (as
+// many enterprise policies require), an autofix commit must still land —
+// routed through `git -c commit.gpgsign=false` — and emit a one-time warning
+// that the autofix will be unsigned, rather than failing with
+// "gpg: signing failed: Inappropriate ioctl for device" or hanging on pinentry.
+func TestCommitAgentFixes_GpgSignEnabledCommitsUnsignedWithWarning(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	// Simulate an enterprise policy that mandates signed commits. With this
+	// set, a plain `git commit` would attempt to sign and fail headlessly.
+	gitCmd(t, dir, "config", "commit.gpgsign", "true")
+
+	// Agent produced uncommitted changes.
+	if err := os.WriteFile(filepath.Join(dir, "fix.txt"), []byte("fixed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var logs strings.Builder
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Log = func(s string) { logs.WriteString(s + "\n") }
+
+	if err := commitAgentFixes(sctx, types.StepReview, "address review findings", "apply review fixes"); err != nil {
+		t.Fatalf("commitAgentFixes with gpgsign=true failed: %v", err)
+	}
+
+	// The warning must surface so the unsigned autofix is not a silent surprise.
+	if !strings.Contains(logs.String(), "commit.gpgsign") || !strings.Contains(logs.String(), "unsigned") {
+		t.Fatalf("expected unsigned-commit warning in logs, got:\n%s", logs.String())
+	}
+
+	// The commit must have landed and be unsigned (signature status "N").
+	gotMsg := gitCmd(t, dir, "log", "-1", "--pretty=%s")
+	wantMsg := "no-mistakes(review): address review findings"
+	if gotMsg != wantMsg {
+		t.Fatalf("commit message = %q, want %q", gotMsg, wantMsg)
+	}
+	sigStatus := gitCmd(t, dir, "log", "-1", "--pretty=%G?")
+	if sigStatus != "N" {
+		t.Fatalf("autofix commit signature status = %q, want \"N\" (no signature); the commit must be unsigned", sigStatus)
+	}
+
+	// HeadSHA must advance and be persisted.
+	newHead := gitCmd(t, dir, "rev-parse", "HEAD")
+	if newHead == headSHA {
+		t.Fatal("expected HEAD to advance after the autofix commit")
+	}
+	if sctx.Run.HeadSHA != newHead {
+		t.Fatalf("Run.HeadSHA = %s, want %s", sctx.Run.HeadSHA, newHead)
+	}
+}
+
+// TestCommitAgentFixes_HungHookFailsFast proves the fail-fast fix (audit §13):
+// when a commit would hang (interactive pre-commit hook, SSH passphrase prompt,
+// 2FA), the scoped timeout on the autofix commit must fail the step within
+// seconds instead of wedging the pipeline until the run's CI timeout.
+//
+// It routes the commit through a fake `git` binary (the test binary) that
+// blocks forever on the commit subcommand, so the timeout cancellation kills
+// the direct child cleanly with no orphaned subprocess.
+//
+// This test is intentionally NOT parallel: it temporarily mutates the
+// package-level autofixGitTimeout, and commitAgentFixes (used by other tests
+// in this package) reads it, so concurrent run/restore would race.
+func TestCommitAgentFixes_HungHookFailsFast(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	// Uncommitted agent changes for commitAgentFixes to commit.
+	if err := os.WriteFile(filepath.Join(dir, "fix.txt"), []byte("fixed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	binDir := fakeCLIBinDir(t)
+	linkTestBinary(t, binDir, "git")
+	env := fakeCLIEnv(binDir, map[string]string{
+		"FAKE_CLI_MODE":     "git-commit-hang",
+		"FAKE_CLI_REAL_GIT": realGit,
+	})
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Env = env
+
+	// Shrink the autofix timeout so the test fails fast rather than waiting
+	// minutes. Restore the production default afterwards.
+	prev := autofixGitTimeout
+	autofixGitTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { autofixGitTimeout = prev })
+
+	start := time.Now()
+	err = commitAgentFixes(sctx, types.StepReview, "address review findings", "apply review fixes")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected commitAgentFixes to fail when the commit hangs, got nil")
+	}
+	// Must fail within a small bound, far below the hung process's lifetime and
+	// far below any realistic run/CI timeout. Allow generous slack for CI.
+	if elapsed > 5*time.Second {
+		t.Fatalf("commit did not fail fast: elapsed %s (timeout 300ms)", elapsed)
+	}
+	// And the commit must not have actually landed (HEAD unchanged).
+	if got := gitCmd(t, dir, "rev-parse", "HEAD"); got != headSHA {
+		t.Fatalf("HEAD advanced to %s despite the hung commit; want unchanged %s", got, headSHA)
+	}
+}

--- a/internal/pipeline/steps/ci_fix.go
+++ b/internal/pipeline/steps/ci_fix.go
@@ -127,8 +127,8 @@ func (s *CIStep) commitAndPush(sctx *pipeline.StepContext) (bool, error) {
 	if _, err := stepGitRun(sctx, "add", "-A"); err != nil {
 		return false, fmt.Errorf("stage CI changes: %w", err)
 	}
-	if _, err := stepGitRun(sctx, "commit", "-m", "no-mistakes: apply CI fixes"); err != nil {
-		return false, fmt.Errorf("commit: %w", err)
+	if err := autofixCommit(sctx, "no-mistakes: apply CI fixes"); err != nil {
+		return false, err
 	}
 	headSHA, err := stepGitHeadSHA(sctx)
 	if err != nil {
@@ -154,7 +154,7 @@ func (s *CIStep) pushUpdatedHeadSHA(sctx *pipeline.StepContext, newHeadSHA strin
 		}
 		return false, nil
 	}
-	if err := stepGitPush(sctx, sctx.Repo.UpstreamURL, ref, upstreamSHA, upstreamSHA != ""); err != nil {
+	if err := autofixPush(sctx, sctx.Repo.UpstreamURL, ref, upstreamSHA, upstreamSHA != ""); err != nil {
 		if lsErr != nil {
 			return false, fmt.Errorf("push (ls-remote failed: %v): %w", lsErr, err)
 		}

--- a/internal/pipeline/steps/common_exec.go
+++ b/internal/pipeline/steps/common_exec.go
@@ -143,6 +143,13 @@ func missingFromCustomPath(env []string, name string) string {
 // When sctx.Env overrides PATH, the binary is resolved from the overridden PATH
 // so that tests can inject fake binaries without modifying the process environment.
 func stepCmd(sctx *pipeline.StepContext, name string, args ...string) *exec.Cmd {
+	return stepCmdCtx(sctx.Ctx, sctx, name, args...)
+}
+
+// stepCmdCtx is like stepCmd but with an explicit context, so callers can scope
+// a command to a shorter deadline than the run's context (e.g. an autofix
+// commit that must fail fast on a hung hook).
+func stepCmdCtx(ctx context.Context, sctx *pipeline.StepContext, name string, args ...string) *exec.Cmd {
 	resolved := name
 	missingFromPath := false
 	if len(sctx.Env) > 0 && !strings.Contains(name, string(filepath.Separator)) {
@@ -153,7 +160,7 @@ func stepCmd(sctx *pipeline.StepContext, name string, args ...string) *exec.Cmd 
 			missingFromPath = true
 		}
 	}
-	cmd := exec.CommandContext(sctx.Ctx, resolved, args...)
+	cmd := exec.CommandContext(ctx, resolved, args...)
 	cmd.Dir = sctx.WorkDir
 	if len(sctx.Env) > 0 {
 		cmd.Env = mergeEnv(sctx.Env)
@@ -167,7 +174,12 @@ func stepCmd(sctx *pipeline.StepContext, name string, args ...string) *exec.Cmd 
 // stepGitRun runs a git command using the StepContext's environment.
 // It is like git.Run but respects sctx.Env so that tests can inject a fake git binary.
 func stepGitRun(sctx *pipeline.StepContext, args ...string) (string, error) {
-	cmd := stepCmd(sctx, "git", args...)
+	return stepGitRunCtx(sctx.Ctx, sctx, args...)
+}
+
+// stepGitRunCtx is like stepGitRun but with an explicit context.
+func stepGitRunCtx(ctx context.Context, sctx *pipeline.StepContext, args ...string) (string, error) {
+	cmd := stepCmdCtx(ctx, sctx, "git", args...)
 	out, err := cmd.Output()
 	if err != nil {
 		stderr := ""
@@ -196,20 +208,6 @@ func stepGitLsRemote(sctx *pipeline.StepContext, remote, ref string) (string, er
 		return "", nil
 	}
 	return parts[0], nil
-}
-
-func stepGitPush(sctx *pipeline.StepContext, remote, ref, expectedSHA string, forceWithLease bool) error {
-	args := []string{"push", remote}
-	if forceWithLease {
-		if expectedSHA != "" {
-			args = append(args, fmt.Sprintf("--force-with-lease=%s:%s", ref, expectedSHA))
-		} else {
-			args = append(args, "--force-with-lease")
-		}
-	}
-	args = append(args, "HEAD:"+ref)
-	_, err := stepGitRun(sctx, args...)
-	return err
 }
 
 // stepCLIAvailable checks whether the provider CLI binary is available,

--- a/internal/pipeline/steps/common_fix.go
+++ b/internal/pipeline/steps/common_fix.go
@@ -58,8 +58,8 @@ func commitAgentFixes(sctx *pipeline.StepContext, stepName types.StepName, summa
 		summary = fallbackSummary
 	}
 	commitMessage := deterministicFixCommitMessage(stepName, summary)
-	if _, err := git.Run(ctx, sctx.WorkDir, "commit", "-m", commitMessage); err != nil {
-		return fmt.Errorf("commit %s changes: %w", stepName, err)
+	if err := autofixCommit(sctx, commitMessage); err != nil {
+		return err
 	}
 	headSHA, err := git.HeadSHA(ctx, sctx.WorkDir)
 	if err != nil {

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -41,9 +41,8 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 		if _, err := git.Run(ctx, sctx.WorkDir, "add", "-A"); err != nil {
 			return nil, fmt.Errorf("stage agent changes: %w", err)
 		}
-		_, err := git.Run(ctx, sctx.WorkDir, "commit", "-m", "no-mistakes: apply agent fixes")
-		if err != nil {
-			return nil, fmt.Errorf("commit agent changes: %w", err)
+		if err := autofixCommit(sctx, "no-mistakes: apply agent fixes"); err != nil {
+			return nil, err
 		}
 		headSHA, err := git.HeadSHA(ctx, sctx.WorkDir)
 		if err != nil {
@@ -66,12 +65,12 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 	}
 	if upstreamSHA != "" {
 		// Existing branch: force-with-lease with explicit expected SHA
-		if err := git.Push(ctx, sctx.WorkDir, upstream, ref, upstreamSHA, true); err != nil {
+		if err := autofixPush(sctx, upstream, ref, upstreamSHA, true); err != nil {
 			return nil, fmt.Errorf("push to upstream: %w", err)
 		}
 	} else {
 		// New branch: regular push (no force needed)
-		if err := git.Push(ctx, sctx.WorkDir, upstream, ref, "", false); err != nil {
+		if err := autofixPush(sctx, upstream, ref, "", false); err != nil {
 			return nil, fmt.Errorf("push to upstream: %w", err)
 		}
 	}

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -44,6 +44,8 @@ func handleFakeCLI(mode string) {
 		fakeGitPassthroughHandler(args)
 	case "git-status-error":
 		fakeGitStatusErrorHandler(args)
+	case "git-commit-hang":
+		fakeGitCommitHangHandler(args)
 	case "ci-gh":
 		fakeCIGHHandler(args)
 	case "ci-gh-seq":
@@ -113,6 +115,25 @@ func fakeGitStatusErrorHandler(args []string) {
 
 func fakeGitPassthroughHandler(args []string) {
 	realGit := os.Getenv("FAKE_CLI_REAL_GIT")
+	fakeGitForward(args, realGit)
+}
+
+// fakeGitCommitHangHandler forwards every git subcommand to real git except
+// `commit`, which it blocks on indefinitely. It models a hung pre-commit hook
+// or an interactive hook reading stdin, so tests can assert that an autofix
+// commit fails fast under its scoped timeout instead of wedging the pipeline.
+func fakeGitCommitHangHandler(args []string) {
+	realGit := os.Getenv("FAKE_CLI_REAL_GIT")
+	// Locate the git subcommand token, skipping leading `-c <value>` option
+	// pairs (e.g. `-c commit.gpgsign=false`), so we only hang on an actual
+	// commit subcommand and forward add/status/config/etc. to real git.
+	i := 0
+	for i+1 < len(args) && args[i] == "-c" {
+		i += 2
+	}
+	if i < len(args) && args[i] == "commit" {
+		select {}
+	}
 	fakeGitForward(args, realGit)
 }
 


### PR DESCRIPTION
## Summary

Makes no-mistakes' autofix git operations headless-safe and fail-fast, so two real-world hang/failure modes stop wedging the pipeline until the run's CI timeout:

1. **Commit signing fails headlessly (audit v5 §4, HIGH for enterprise).** All autofix commits were plain `git commit -m`. `CopyLocalUserIdentity` copies only `user.name`/`user.email`, so `commit.gpgsign=true` (mandated by many enterprise policies) stays inherited. Every autofix commit then attempted to sign and failed with `gpg: signing failed: Inappropriate ioctl for device` or hung to pinentry-timeout. The e2e harness already works around this (`harness.go: git config commit.gpgsign false`), confirming the failure exists in the wild.
2. **Hooks / SSH passphrase prompts hang the pipeline (audit v5 §13, MED).** `NonInteractiveEnv` set `GIT_TERMINAL_PROMPT=0` but not `SSH_ASKPASS_REQUIRE=never`, so an SSH passphrase prompt (passphrased key, no agent) opened `/dev/tty` and blocked for hours. Interactive user-installed hooks (confirmations, 2FA) inherited via the worktree's common dir hung the same way.

## The bug

Autofix commits and pushes lived at three sites, each calling bare `git commit`/`git push` under the run's long-lived context with no headless safeguards beyond `GIT_TERMINAL_PROMPT`:

- `internal/pipeline/steps/common_fix.go` — `commitAgentFixes` (review/test/lint/document fix): `git.Run(..., "commit", "-m", msg)`.
- `internal/pipeline/steps/push.go` — `PushStep`: `git.Run(..., "commit", ...)` + `git.Push(...)`.
- `internal/pipeline/steps/ci_fix.go` — `CIStep.commitAndPush`/`pushUpdatedHeadSHA`: `stepGitRun(..., "commit", ...)` + `stepGitPush(...)`.

None disabled signing, none imposed a per-op deadline, and the CI path (`stepGitRun`) didn't even apply `NonInteractiveEnv` in production (it relied on the parent process env). So a signing policy or a single blocking hook/SSH prompt stalled the whole run.

## The fix

Option (a) — the small, ships-fast path recommended in the audit. All three autofix sites now funnel through two new helpers in `internal/pipeline/steps/autofix.go`:

- **`autofixCommit(sctx, message)`** — runs `git -c commit.gpgsign=false commit -m <msg>`, and when `git.CommitSigningEnabled` resolves true, logs a one-time warning that the autofix will be unsigned. Signing is the correct behavior to skip for machine-generated commits, and it's the only thing that works headlessly.
- **`autofixPush(sctx, remote, ref, expectedSHA, forceWithLease)`** — runs the force-with-lease push with the same safeguards as the commit.

Both helpers:

- Derive a short `context.WithTimeout(sctx.Ctx, autofixGitTimeout)` (default 2m, far below any CI timeout) that still inherits run cancellation, so a hung pre-commit/pre-push hook or SSH prompt fails the step in seconds instead of hours.
- Always apply `git.NonInteractiveEnv` (merged under `sctx.Env` so tests can still inject a fake `git`), closing the latent gap where the CI-fix path ran without headless env.

Supporting changes:

- **`git.NonInteractiveEnv`** now sets `SSH_ASKPASS_REQUIRE=never` so ssh fails fast instead of blocking on a passphrase prompt. The happy path (agent holds the key) is unaffected.
- **`git.CommitSigningEnabled(ctx, dir)`** reads the effective `commit.gpgsign` (local/global/system/includes via `--type=bool`); returns false on any error including the key being unset.
- **`common_exec.go`**: `stepCmd`/`stepGitRun` gained explicit-context variants (`stepCmdCtx`/`stepGitRunCtx`) so the autofix helpers can scope a shorter deadline. The now-unused `stepGitPush` wrapper was removed.

The e2e harness's own `git config commit.gpgsign false` is left in place — it covers the harness's direct setup commits, and is now redundant (not wrong) for the autofix path.

## Verification

`gofmt -l .` clean · `go vet ./...` clean · `go run ./cmd/genskill --check` up to date · `go build ./...` OK · `go test -race ./...` green (Go 1.26.4 — system Go 1.18 is too old).

New tests pinning each fix (the defining symptoms are a hang and a headless signing failure, so these exist to catch regressions):

- `TestCommitAgentFixes_GpgSignEnabledCommitsUnsignedWithWarning` (`internal/pipeline/steps/autofix_test.go`) — with `commit.gpgsign=true` set, an autofix commit lands successfully, emits the unsigned warning, and the resulting commit is verified unsigned (`git log -1 --pretty=%G?` → `N`); HEAD advances and is persisted.
- `TestCommitAgentFixes_HungHookFailsFast` (`internal/pipeline/steps/autofix_test.go`) — a commit that would hang (a fake `git` binary that blocks forever on the `commit` subcommand) fails within the scoped timeout (~300ms) rather than blocking; HEAD does not advance. Uses the existing fake-CLI harness so the timeout cancellation kills the direct child with no orphaned subprocess.
- `TestNonInteractiveEnv_SetsGitOverrides` / `_OverridesAmbientEditor` (`internal/git/env_test.go`) — `SSH_ASKPASS_REQUIRE=never` is present and overrides ambient values.
- `TestCommitSigningEnabled` (`internal/git/git_test.go`) — unset → false, local `true` → true, explicit `false` → false.

Existing `commitAndPush` / push-step tests (including the fake-git `sctx.Env` injection tests) continue to pass unchanged, confirming the refactor is behavior-preserving on the happy path.

## Notes for review

- The 2-minute default ceiling on autofix commit/push is a balance: generous for a legit pre-commit/pre-push hook on a large repo, but far below the run's CI timeout so a genuinely stuck op fails fast. It's a package-level `var` (not a const) purely so the fail-fast test can shrink it; happy-path commits finish in well under the ceiling. If a maintainer prefers a different value or separate commit vs. push ceilings, it's a one-line change.
- I went with option (a) (sign-out the autofix) rather than option (b) (copy signing config + forward `GPG_TTY`/`SSH_AUTH_SOCK`) deliberately: autofix commits are machine-generated, can't be signed headlessly in the general case, and (a) is the small ships-fast path the audit recommends. If the project ever wants signed autofix commits, (b) is an additive follow-up on top of this.
- This change touches `push.go` and `ci_fix.go`, which other open fork PRs also touch; the fixes are orthogonal to credential redaction (#299) and fork→parent routing (#293). No coordination needed for this PR to be correct on current `main`.
- `AGENTS.md` gains one line recording the convention that autofix commit/push must stay headless-safe (route through `autofixCommit`/`autofixPush`), to prevent future regressions to bare `git.Run`/`git.Push`.

---

AI disclosure: **Human-reviewed.** The change was produced with AI assistance and reviewed by a human contributor before submission.
