### PR TITLE
fix(config): reject unknown YAML keys + validate agent name at load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,3 +99,4 @@ Safest local verification sequence after non-trivial changes:
 
 - Whenever you must bring in new dependencies, check latest documentation for knowledge, and discuss with the user.
 - Always use test driven development for bug fixes and feature development.
+- Both config loaders (`config.LoadGlobal` and `config.LoadRepo`) decode with `yaml.NewDecoder(...).KnownFields(true)` and validate the `agent` field. When adding a new YAML field, declare it on `globalConfigRaw`/`RepoConfig` (or it will be rejected as unknown), and add an accepted-value test alongside it.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -237,6 +238,59 @@ func isACPAgent(name types.AgentName) bool {
 	return target != "" && !strings.ContainsAny(target, " \t\r\n")
 }
 
+// knownAgentNames lists the non-ACP agent names accepted by ValidateAgentName.
+// "auto" resolves at runtime; the rest map to native agent binaries.
+var knownAgentNames = map[types.AgentName]bool{
+	types.AgentAuto:     true,
+	types.AgentClaude:   true,
+	types.AgentCodex:    true,
+	types.AgentRovoDev:  true,
+	types.AgentOpenCode: true,
+	types.AgentPi:       true,
+}
+
+// validAgentValues is the human-readable list of accepted agent values,
+// used in error messages.
+var validAgentValues = "auto, claude, codex, rovodev, opencode, pi, or acp:<target>"
+
+// validateAgentName returns an error if name is not a recognized agent value.
+// Empty is allowed (means "use default"/"inherit"); explicit-empty detection
+// is the caller's responsibility.
+func validateAgentName(name types.AgentName) error {
+	if name == "" {
+		return nil
+	}
+	if knownAgentNames[name] {
+		return nil
+	}
+	if isACPAgent(name) {
+		return nil
+	}
+	return fmt.Errorf("agent %q is not recognized (valid: %s)", name, validAgentValues)
+}
+
+// detectExplicitAgentEmpty reports whether the YAML document contained an
+// `agent:` key whose value decodes to an empty string. This distinguishes
+// "key absent" (use default) from "key present but empty" (user error).
+// Errors are swallowed; malformed YAML is already caught by the strict decoder.
+func detectExplicitAgentEmpty(data []byte) bool {
+	var probe map[string]any
+	if err := yaml.Unmarshal(data, &probe); err != nil {
+		return false
+	}
+	v, ok := probe["agent"]
+	if !ok {
+		return false
+	}
+	if v == nil {
+		return true
+	}
+	if s, ok := v.(string); ok {
+		return s == ""
+	}
+	return false
+}
+
 var probeRovoDevSupport = func(ctx context.Context, bin string) (bool, error) {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
@@ -438,8 +492,14 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 	}
 
 	var raw globalConfigRaw
-	if err := yaml.Unmarshal(data, &raw); err != nil {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&raw); err != nil {
 		return nil, fmt.Errorf("parse global config: %w", err)
+	}
+
+	if err := validateGlobalAgent(data, raw.Agent, path); err != nil {
+		return nil, err
 	}
 
 	if raw.Agent != "" {
@@ -484,6 +544,19 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 	return cfg, nil
 }
 
+// validateGlobalAgent rejects unknown/typo agent values and explicit-empty
+// `agent:` entries in the global config. Empty values produced by an absent
+// key are allowed (default to AgentAuto).
+func validateGlobalAgent(data []byte, rawAgent types.AgentName, path string) error {
+	if err := validateAgentName(rawAgent); err != nil {
+		return fmt.Errorf("global config %s: %w", path, err)
+	}
+	if rawAgent == "" && detectExplicitAgentEmpty(data) {
+		return fmt.Errorf("global config %s: agent must not be empty (valid: %s)", path, validAgentValues)
+	}
+	return nil
+}
+
 // LoadRepo reads per-repo config from dir/.no-mistakes.yaml.
 // Returns zero-value config if file doesn't exist.
 func LoadRepo(dir string) (*RepoConfig, error) {
@@ -498,14 +571,31 @@ func LoadRepo(dir string) (*RepoConfig, error) {
 		return nil, fmt.Errorf("read repo config: %w", err)
 	}
 
-	if err := yaml.Unmarshal(data, cfg); err != nil {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(cfg); err != nil {
 		return nil, fmt.Errorf("parse repo config: %w", err)
 	}
+
+	if err := validateRepoAgent(cfg.Agent, path); err != nil {
+		return nil, err
+	}
+
 	if cfg.AutoFix.CI == nil {
 		cfg.AutoFix.CI = cfg.AutoFix.Babysit
 	}
 
 	return cfg, nil
+}
+
+// validateRepoAgent rejects unknown/typo agent values in repo config.
+// Unlike the global config, an empty value means "inherit from global", so
+// explicit-empty `agent:` is tolerated here (and resolves to inherit).
+func validateRepoAgent(rawAgent types.AgentName, path string) error {
+	if err := validateAgentName(rawAgent); err != nil {
+		return fmt.Errorf("repo config %s: %w", path, err)
+	}
+	return nil
 }
 
 // ParseLogLevel converts a log level string to slog.Level.

--- a/internal/config/config_strict_test.go
+++ b/internal/config/config_strict_test.go
@@ -1,0 +1,358 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+func writeGlobalConfig(t *testing.T, data string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+func writeRepoConfig(t *testing.T, data string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".no-mistakes.yaml")
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatalf("write repo config: %v", err)
+	}
+	return dir
+}
+
+func TestLoadGlobal_RejectsUnknownTopLevelKey(t *testing.T) {
+	cases := map[string]string{
+		"citimeout typo":     `citimeout: "4h"`,
+		"agent_type typo":    `agent_type: claud`,
+		"commands_top_level": `commands: { tst: "go test" }`,
+	}
+	for name, data := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := writeGlobalConfig(t, data)
+			_, err := LoadGlobal(path)
+			if err == nil {
+				t.Fatalf("expected error for unknown key, got nil")
+			}
+			if !strings.Contains(err.Error(), "parse global config") {
+				t.Errorf("error should reference parse failure, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadGlobal_RejectsUnknownNestedKey(t *testing.T) {
+	cases := map[string]string{
+		"auto_fix.babysit_typo": `auto_fix: { rebase: 3 }` + "\n" + `auto_fix: { rebas: 3 }`,
+		"intent.thresh":         `intent: { thresh: 0.2 }`,
+		"auto_fix_unknown":      `auto_fix: { rebse: 3 }`,
+		"test_evidence_unknown": `test: { evidence: { dirr: foo } }`,
+	}
+	for name, data := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := writeGlobalConfig(t, data)
+			_, err := LoadGlobal(path)
+			if err == nil {
+				t.Fatalf("expected error for unknown nested key, got nil")
+			}
+			if !strings.Contains(err.Error(), "parse global config") {
+				t.Errorf("error should reference parse failure, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadGlobal_AcceptsAllDocumentedKeys(t *testing.T) {
+	data := `agent: claude
+acpx_path: /opt/bin/acpx
+acp_registry_overrides:
+  local-gemini: node /tmp/mock-acp.mjs
+agent_path_override:
+  claude: /usr/local/bin/claude
+agent_args_override:
+  codex:
+    - -m
+    - gpt-5.4
+ci_timeout: "4h"
+babysit_timeout: "90m"
+log_level: info
+auto_fix:
+  rebase: 3
+  lint: 3
+  test: 3
+  review: 0
+  document: 3
+  ci: 3
+  babysit: 2
+intent:
+  enabled: true
+  threshold: 0.2
+  slack_days: 3
+  disabled_readers: [codex]
+test:
+  evidence:
+    store_in_repo: true
+    dir: .no-mistakes/evidence
+`
+	path := writeGlobalConfig(t, data)
+	cfg, err := LoadGlobal(path)
+	if err != nil {
+		t.Fatalf("expected documented keys to load cleanly, got: %v", err)
+	}
+	if cfg.Agent != types.AgentClaude {
+		t.Errorf("agent = %q, want claude", cfg.Agent)
+	}
+}
+
+func TestLoadGlobal_RejectsAgentTypo(t *testing.T) {
+	path := writeGlobalConfig(t, `agent: claud`)
+	_, err := LoadGlobal(path)
+	if err == nil {
+		t.Fatalf("expected error for typo'd agent, got nil")
+	}
+	for _, want := range []string{"agent", "claud", "global config"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+func TestLoadGlobal_RejectsAgentEmpty(t *testing.T) {
+	path := writeGlobalConfig(t, `agent: ""`)
+	_, err := LoadGlobal(path)
+	if err == nil {
+		t.Fatalf("expected error for explicit empty agent, got nil")
+	}
+	for _, want := range []string{"agent", "empty", "global config"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+func TestLoadGlobal_RejectsAgentBareEmpty(t *testing.T) {
+	path := writeGlobalConfig(t, "agent:\n")
+	_, err := LoadGlobal(path)
+	if err == nil {
+		t.Fatalf("expected error for bare empty agent, got nil")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("error should mention empty, got: %v", err)
+	}
+}
+
+func TestLoadGlobal_RejectsACPEmptyTarget(t *testing.T) {
+	path := writeGlobalConfig(t, `agent: "acp:"`)
+	_, err := LoadGlobal(path)
+	if err == nil {
+		t.Fatalf("expected error for acp: with empty target, got nil")
+	}
+	for _, want := range []string{"agent", "acp:", "global config"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+func TestLoadGlobal_RejectsACPWhitespaceTarget(t *testing.T) {
+	path := writeGlobalConfig(t, `agent: "acp: foo"`)
+	_, err := LoadGlobal(path)
+	if err == nil {
+		t.Fatalf("expected error for acp: with whitespace target, got nil")
+	}
+	for _, want := range []string{"agent", "acp: foo", "global config"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+func TestLoadGlobal_AcceptsValidAgents(t *testing.T) {
+	cases := map[string]types.AgentName{
+		"auto":     types.AgentAuto,
+		"claude":   types.AgentClaude,
+		"codex":    types.AgentCodex,
+		"rovodev":  types.AgentRovoDev,
+		"opencode": types.AgentOpenCode,
+		"pi":       types.AgentPi,
+		"acp":      "acp:gemini",
+	}
+	for name, want := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := writeGlobalConfig(t, "agent: "+string(want))
+			cfg, err := LoadGlobal(path)
+			if err != nil {
+				t.Fatalf("expected %q to load cleanly, got: %v", name, err)
+			}
+			if cfg.Agent != want {
+				t.Errorf("agent = %q, want %q", cfg.Agent, want)
+			}
+		})
+	}
+}
+
+func TestLoadGlobal_MissingAgentKeyUsesDefault(t *testing.T) {
+	path := writeGlobalConfig(t, `log_level: debug`)
+	cfg, err := LoadGlobal(path)
+	if err != nil {
+		t.Fatalf("missing agent key should default to auto, got: %v", err)
+	}
+	if cfg.Agent != types.AgentAuto {
+		t.Errorf("agent = %q, want auto (default)", cfg.Agent)
+	}
+}
+
+func TestLoadRepo_RejectsUnknownTopLevelKey(t *testing.T) {
+	dir := writeRepoConfig(t, `citimeout: "4h"`)
+	_, err := LoadRepo(dir)
+	if err == nil {
+		t.Fatalf("expected error for unknown repo key, got nil")
+	}
+	if !strings.Contains(err.Error(), "parse repo config") {
+		t.Errorf("error should reference parse failure, got: %v", err)
+	}
+}
+
+func TestLoadRepo_RejectsUnknownNestedKey(t *testing.T) {
+	cases := map[string]string{
+		"commands_typo": `commands: { tst: "go test" }`,
+		"auto_fix_typo": `auto_fix: { rebse: 3 }`,
+		"intent_typo":   `intent: { thresh: 0.2 }`,
+		"evidence_typo": `test: { evidence: { dirr: foo } }`,
+	}
+	for name, data := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := writeRepoConfig(t, data)
+			_, err := LoadRepo(dir)
+			if err == nil {
+				t.Fatalf("expected error for unknown nested repo key, got nil")
+			}
+			if !strings.Contains(err.Error(), "parse repo config") {
+				t.Errorf("error should reference parse failure, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadRepo_RejectsAgentTypo(t *testing.T) {
+	dir := writeRepoConfig(t, `agent: claud`)
+	_, err := LoadRepo(dir)
+	if err == nil {
+		t.Fatalf("expected error for typo'd repo agent, got nil")
+	}
+	for _, want := range []string{"agent", "claud", "repo config"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+}
+
+func TestLoadRepo_RejectsACPEmptyTarget(t *testing.T) {
+	dir := writeRepoConfig(t, `agent: "acp:"`)
+	_, err := LoadRepo(dir)
+	if err == nil {
+		t.Fatalf("expected error for acp: with empty target in repo config, got nil")
+	}
+}
+
+func TestLoadRepo_AcceptsEmptyAgentAsInherit(t *testing.T) {
+	// Repo config: empty agent means "inherit from global". Both absent key
+	// and explicit empty are tolerated.
+	t.Run("absent", func(t *testing.T) {
+		dir := writeRepoConfig(t, `commands: { test: "go test" }`)
+		cfg, err := LoadRepo(dir)
+		if err != nil {
+			t.Fatalf("absent agent key should load cleanly, got: %v", err)
+		}
+		if cfg.Agent != "" {
+			t.Errorf("agent = %q, want empty", cfg.Agent)
+		}
+	})
+	t.Run("explicit_empty", func(t *testing.T) {
+		dir := writeRepoConfig(t, `agent: ""`)
+		cfg, err := LoadRepo(dir)
+		if err != nil {
+			t.Fatalf("explicit empty agent in repo config should be tolerated as inherit, got: %v", err)
+		}
+		if cfg.Agent != "" {
+			t.Errorf("agent = %q, want empty", cfg.Agent)
+		}
+	})
+}
+
+func TestLoadRepo_AcceptsAllDocumentedKeys(t *testing.T) {
+	data := `agent: codex
+commands:
+  lint: "golangci-lint run ./..."
+  test: "go test -race ./..."
+  format: "gofmt -w ."
+ignore_patterns:
+  - "*.generated.go"
+auto_fix:
+  rebase: 3
+  review: 3
+  test: 3
+  document: 3
+  lint: 5
+  ci: 3
+  babysit: 2
+intent:
+  enabled: true
+  threshold: 0.2
+  slack_days: 3
+  disabled_readers: [codex]
+test:
+  evidence:
+    store_in_repo: true
+    dir: .no-mistakes/evidence
+`
+	dir := writeRepoConfig(t, data)
+	cfg, err := LoadRepo(dir)
+	if err != nil {
+		t.Fatalf("expected documented repo keys to load cleanly, got: %v", err)
+	}
+	if cfg.Agent != types.AgentCodex {
+		t.Errorf("agent = %q, want codex", cfg.Agent)
+	}
+}
+
+func TestValidateAgentName(t *testing.T) {
+	cases := []struct {
+		name    string
+		agent   types.AgentName
+		wantErr bool
+	}{
+		{"empty", "", false},
+		{"auto", types.AgentAuto, false},
+		{"claude", types.AgentClaude, false},
+		{"codex", types.AgentCodex, false},
+		{"rovodev", types.AgentRovoDev, false},
+		{"opencode", types.AgentOpenCode, false},
+		{"pi", types.AgentPi, false},
+		{"acp_gemini", "acp:gemini", false},
+		{"typo_claud", "claud", true},
+		{"typo_codexx", "codexx", true},
+		{"acp_empty", "acp:", true},
+		{"acp_whitespace", "acp: foo", true},
+		{"acp_tab", "acp:\tfoo", true},
+		{"random", "some-other-thing", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateAgentName(tc.agent)
+			if tc.wantErr && err == nil {
+				t.Errorf("validateAgentName(%q) = nil, want error", tc.agent)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("validateAgentName(%q) = %v, want nil", tc.agent, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes the silent-misconfiguration gap in no-mistakes' config layer. Both config loaders now reject unknown YAML keys at parse time, and the `agent` field is validated at load — so typos and bad values fail loudly with a config-line error instead of silently disabling features or surfacing as a generic error at run start.

Matches audit v5 §14 (unknown YAML keys silently ignored) and §15 (agent name not validated at load) — the last item in the v5 robustness ship set.

## The bug

Both loaders used plain `yaml.Unmarshal`, the loosest decoder in `gopkg.in/yaml.v3`. The only field-level validation in the whole package was `validateAgentArgsOverride` (`config.go:384`). Two classes of silent misconfiguration slipped through:

1. **Unknown YAML keys silently ignored (§14).** Typos like these all parsed cleanly, applied defaults, and ran as if the field weren't set — features just didn't activate, with no error anywhere:
   - `agent: claud`
   - `citimeout: "4h"` (the canonical key is `ci_timeout`)
   - `auto_fix: { rebase: 3 }` vs `auto_fix: { rebas: 3 }`
   - `commands: { tst: "go test" }` (the only field-level validation is on `agent_args_override`)
   - `intent: { thresh: 0.2 }`

2. **Agent name not validated at load (§15).** `ResolveAgent` only probes when `agent: auto`; for any explicit value it returned nil immediately. `isACPAgent` (`config.go:231`) and the agent-name→binary map (`config.go:214`) existed but were never consulted at load. So `agent: claud` (typo), `agent: ""` (empty), `agent: "acp:"` (empty target), and `agent: "acp: foo"` (whitespace) all parsed cleanly. The user only found out when a run started — through a generic error from `agent.NewWithOptions`, not a config-line error.

This amplifies every other typo class: a config that looks correct stays silent, and the resulting "feature didn't activate" symptoms are hard to attribute.

## The fix

**Strict decoding.** Both `LoadGlobal` and `LoadRepo` now decode via `yaml.NewDecoder(r).KnownFields(true)`. Unknown keys produce a parse error of the form `parse global config: field X not found in type globalConfigRaw`, with the file path and field name. The legacy `babysit_timeout` / `auto_fix.babysit` aliases keep working because they're declared fields on `globalConfigRaw` / `AutoFixRaw`.

**Agent validation at load.** New `validateAgentName` helper encodes the accepted set:
- `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi` (via the existing `defaultBinary` map).
- `acp:<target>` for any non-empty, whitespace-free target (via the existing `isACPAgent`).
- Empty is allowed (means default/inherit).

`LoadGlobal` calls `validateGlobalAgent` after the strict decode: it rejects typo/unknown values, and also rejects an explicit `agent: ""` (distinguished from an absent `agent:` key via a one-shot `map[string]any` probe) so a user who explicitly cleared the field gets a clear error rather than a silent fallback to `auto`. `LoadRepo` calls `validateRepoAgent`, which rejects typos but keeps empty-as-inherit (the documented semantics — repo agent inherits from global).

Errors are wrapped with the file path and the `agent` field name, e.g. `global config /home/user/.no-mistakes/config.yaml: agent "claud" is not recognized (valid: auto, claude, codex, rovodev, opencode, pi, or acp:<target>)`.

## Verification

`gofmt -l .` clean · `go vet ./...` clean · `go build ./...` OK · `go test -race ./...` green (Go 1.26.4 — system Go 1.18 is too old).

New tests in `internal/config/config_strict_test.go`:

- **Typo rejection:** `TestLoadGlobal_RejectsUnknownTopLevelKey`, `TestLoadGlobal_RejectsUnknownNestedKey`, `TestLoadRepo_RejectsUnknownTopLevelKey`, `TestLoadRepo_RejectsUnknownNestedKey` — confirm `citimeout: "4h"`, `commands: { tst: ... }`, `auto_fix: { rebse: 3 }`, `intent: { thresh: 0.2 }`, `test: { evidence: { dirr: foo } }` all fail to load with a parse error (was: silently accepted).
- **Agent validation:** `TestLoadGlobal_RejectsAgentTypo`, `TestLoadGlobal_RejectsAgentEmpty`, `TestLoadGlobal_RejectsAgentBareEmpty`, `TestLoadGlobal_RejectsACPEmptyTarget`, `TestLoadGlobal_RejectsACPWhitespaceTarget`, `TestLoadRepo_RejectsAgentTypo`, `TestLoadRepo_RejectsACPEmptyTarget`.
- **No regression:** `TestLoadGlobal_AcceptsValidAgents` (all 5 native agents + `auto` + `acp:gemini`), `TestLoadGlobal_AcceptsAllDocumentedKeys`, `TestLoadRepo_AcceptsAllDocumentedKeys` (exercises legacy `babysit_timeout` / `auto_fix.babysit` aliases), `TestLoadGlobal_MissingAgentKeyUsesDefault`, `TestLoadRepo_AcceptsEmptyAgentAsInherit` (absent + explicit empty), `TestValidateAgentName` (table-driven unit test on the helper).
- **Existing config tests** (`TestLoadGlobal_*`, `TestLoadRepo_*`, `TestLoadGlobal_ACPConfig`, `TestDefaultConfigYAML_MatchesGoDefaults`, `TestLoadGlobal_Legacy*`) continue to pass unchanged, confirming the strict decoder doesn't reject any documented field.

## Notes for review

- The default config template (`defaultConfigYAML`) and the e2e harness's generated configs only ever used known keys, so strict mode is a no-op on existing valid configs. The only behavior change is for configs that were previously silently broken.
- I went with the strict-decoder path (rather than the warning-on-diff fallback the audit mentions as an alternative) because the package already had a `KnownFields(true)`-friendly schema (every legacy alias is a declared struct field), so there's no migration surface. If this breaks a user config in the wild that I missed, the fix is mechanical: declare the field on `globalConfigRaw` / `RepoConfig`.
- I made repo-config `agent: ""` (explicit empty) tolerated rather than rejected, because the documented semantics are "empty = inherit from global." Global config's `agent: ""` is rejected because there's no parent to inherit from — the silent fallback to `auto` is the bug §15 calls out.
- `AGENTS.md` gains one line recording the strict-decoding convention so future contributors know to declare new YAML fields on the raw struct (or they'll be rejected as unknown).

---

AI disclosure: **Human-reviewed.** The change was produced with AI assistance and reviewed by a human contributor before submission.
