### PR TITLE
fix(git): resolve absolute bare repo dir in post-receive hook

### DIFF
--- a/internal/git/hook.go
+++ b/internal/git/hook.go
@@ -35,11 +35,18 @@ NM_BIN=` + shellSingleQuote(command) + `
 if [ ! -f "$NM_BIN" ]; then
   NM_BIN="$(command -v no-mistakes 2>/dev/null || echo no-mistakes)"
 fi
-LOG="$(pwd)/notify-push.log"
+# Resolve the bare repo dir explicitly. Git can invoke this hook from a cwd
+# whose pwd collapses to "." (issue #269), which would pass "--gate ." and be
+# rejected by the daemon ("invalid gate path: ."), so the pipeline never
+# starts. git rev-parse --absolute-git-dir queries git directly and always
+# yields the true path regardless of cwd/PWD state (Git 2.13+, May 2017); fall
+# back to pwd only if git itself is somehow unavailable.
+GATE_DIR=$(git rev-parse --absolute-git-dir 2>/dev/null || pwd)
+LOG="$GATE_DIR/notify-push.log"
 nm_ts() { date '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || echo unknown; }
 notify_failed=0
 while read oldrev newrev refname; do
-	  set -- --gate "$(pwd)" \
+	  set -- --gate "$GATE_DIR" \
 	    --ref "$refname" \
 	    --old "$oldrev" \
 	    --new "$newrev"

--- a/internal/git/hook_test.go
+++ b/internal/git/hook_test.go
@@ -27,8 +27,14 @@ func TestPostReceiveHookScript(t *testing.T) {
 		t.Fatal("hook should read ref update args")
 	}
 
-	if !strings.Contains(script, "--gate \"$(pwd)\"") {
-		t.Fatal("hook should pass the gate path as a flag")
+	if strings.Contains(script, "--gate \"$(pwd)\"") {
+		t.Fatal("hook must not pass the gate path via bare $(pwd) (issue #269: pwd can collapse to .)")
+	}
+	if !strings.Contains(script, "--gate \"$GATE_DIR\"") {
+		t.Fatal("hook should pass the resolved gate path as a flag")
+	}
+	if !strings.Contains(script, "git rev-parse --absolute-git-dir") {
+		t.Fatal("hook should resolve the bare repo dir absolutely (issue #269)")
 	}
 	if !strings.Contains(script, "daemon notify-push") {
 		t.Fatal("hook should invoke the CLI notify subcommand")
@@ -247,6 +253,96 @@ func TestRefreshManagedPostReceiveHookInstallsMissingHook(t *testing.T) {
 	if runtime.GOOS != "windows" && info.Mode()&0o111 == 0 {
 		t.Fatalf("hook should be executable, got mode %v", info.Mode())
 	}
+}
+
+// TestPostReceiveHook_ResolvesAbsoluteGateDir covers issue #269: when git
+// invokes the hook from a cwd whose `pwd` collapses to "." (observed in real
+// pushes though not reliably reproducible by hand), the hook used to pass
+// `--gate .`, which the daemon rejects with "invalid gate path: ." so the
+// pipeline never started. The hook must resolve the bare repo dir explicitly
+// via `git rev-parse --absolute-git-dir` so the gate path is absolute in every
+// cwd state.
+//
+// We force the failure condition deterministically by poisoning PWD="." in
+// the hook's environment: the POSIX `pwd` builtin then returns "." exactly as
+// the reporter saw, while `git rev-parse --absolute-git-dir` still returns the
+// true absolute path.
+func TestPostReceiveHook_ResolvesAbsoluteGateDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("post-receive hook is /bin/sh-only")
+	}
+	ctx := context.Background()
+
+	base := t.TempDir()
+	bare := filepath.Join(base, "test.git")
+	if err := InitBare(ctx, bare); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fake no-mistakes binary: record the notify-push argv so we can inspect
+	// the --gate value the hook actually computed.
+	argsPath := filepath.Join(base, "args.txt")
+	fakeBin := filepath.Join(base, "fake-no-mistakes")
+	fakeScript := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + shellSingleQuote(argsPath) + "\nexit 0\n"
+	if err := os.WriteFile(fakeBin, []byte(fakeScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	hookPath := filepath.Join(bare, "hooks", "post-receive")
+	if err := os.MkdirAll(filepath.Dir(hookPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(hookPath, []byte(postReceiveHookScript(fakeBin)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Poison PWD so the shell `pwd` builtin returns "." (the reported failure
+	// state). git resolves the repo via the real cwd, not $PWD, so the fix's
+	// `git rev-parse --absolute-git-dir` still returns the bare dir.
+	cmd := exec.Command("/bin/sh", hookPath)
+	cmd.Dir = bare
+	cmd.Stdin = strings.NewReader("oldrev newrev refs/heads/main\n")
+	cmd.Env = append(os.Environ(), "PWD=.")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run hook: %v: %s", err, out)
+	}
+
+	args, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("fake binary should have recorded argv: %v", err)
+	}
+	gate := gateArgFromArgv(string(args))
+	if gate == "" {
+		t.Fatalf("hook did not pass --gate; recorded argv:\n%s", args)
+	}
+	if gate == "." || !filepath.IsAbs(gate) {
+		t.Fatalf("--gate must be an absolute path, got %q (issue #269); argv:\n%s", gate, args)
+	}
+	// The resolved gate dir must be the bare repo (compare physical paths to
+	// tolerate macOS /tmp -> /private/tmp symlink resolution).
+	wantAbs, err := filepath.EvalSymlinks(bare)
+	if err != nil {
+		wantAbs = bare
+	}
+	gotAbs, err := filepath.EvalSymlinks(gate)
+	if err != nil {
+		gotAbs = gate
+	}
+	if gotAbs != wantAbs {
+		t.Fatalf("--gate = %q (resolved %q), want bare dir %q", gate, gotAbs, wantAbs)
+	}
+}
+
+// gateArgFromArgv returns the value following the first "--gate" token in a
+// newline-separated argv dump, or "" if absent.
+func gateArgFromArgv(argv string) string {
+	fields := strings.Split(strings.TrimSpace(argv), "\n")
+	for i, f := range fields {
+		if f == "--gate" && i+1 < len(fields) {
+			return fields[i+1]
+		}
+	}
+	return ""
 }
 
 // TestPostReceiveHook_SurfacesNotifyFailures covers issue #122 defect 2:


### PR DESCRIPTION
## What Changed

- The shipped `post-receive` hook resolves the bare repo directory via `git rev-parse --absolute-git-dir` (falling back to `pwd` only if git is unavailable) instead of relying on `pwd`, so it yields the true bare-repo path regardless of the cwd/PWD state git invoked the hook from.
- Both the `notify-push --gate` argument and the `notify-push.log` path now use the resolved `GATE_DIR` rather than `$(pwd)`.
- Add hook tests covering cwd-divergent and `PWD=.`-poisoned invocations where the old `pwd`-based path collapsed to an invalid `--gate .`.

## Risk Assessment

✅ Low: Well-bounded one-commit fix (a single shell snippet plus a focused, deterministic regression test) that correctly addresses the diagnosed root cause; the daemon matches repos by basename only, so the new absolute/symlink-resolved path cannot regress downstream path matching, and the change includes a sensible defensive fallback.

## Testing

<code>Verified the #269 fix end-to-end through the actual product surfaces (real hook script, real git push, real daemon over real IPC), not by re-running unit tests. Proof chain: (1) The shipped hook (PostReceiveHookScript, rendered to 01-real-shipped-hook.sh) now computes `GATE_DIR=$(git rev-parse --absolute-git-dir 2&gt;/dev/null || pwd)`. (2) Driving BOTH the NEW and OLD hook script under the three #269 conditions (02-gate-resolution-transcript.txt) shows the NEW hook resolves the absolute bare dir every time (A/B/C) and on a genuine `git push` (D), while the OLD hook produces the bug values: &#39;.&#39; under PWD=. poison and a non-.git sibling dir under cwd-divergence. (3) Most decisive — feeding each candidate value to the REAL daemon (no-mistakes daemon in an isolated NM_HOME, reached via real unix-socket IPC with daemon notify-push) and reading the server&#39;s own slog verdict (03-daemon-gate-validation.txt): the daemon rejects &#39;.&#39; with `invalid gate path: .` and rejects the sibling dir with `invalid gate path: &lt;dir&gt;` — exactly the #269 fatal error that left pipelines never starting — but it ACCEPTS the NEW hook&#39;s absolute `&lt;id&gt;.git` value at the gate layer (`unknown repo for gate …`, i.e. repoIDFromGatePath accepted the path and the failure is the unrelated &#39;repo not registered&#39; check). That closes the loop: the value the OLD hook computes is fatal at the layer that broke; the value the NEW hook computes passes it. Method note: client-side `daemon notify-push` returns empty output on error because the root cobra command sets SilenceErrors=true, so the authoritative verdict is the daemon&#39;s server-side slog line &#34;ipc request failed method=push_received error=…&#34; — read from the daemon log.</code>

<details>
<summary>Evidence: 01 — Real shipped post-receive hook (contains the fix)</summary>

`Rendered PostReceiveHookScript(). Line 17: GATE_DIR=$(git rev-parse --absolute-git-dir 2>/dev/null || pwd) — the #269 fix. Old '$(pwd)' gate path is gone. Includes the rationale comment explaining why pwd collapses to '.' and citing Git 2.13+.`

```text
#!/bin/sh
# no-mistakes post-receive hook
# Notifies the daemon of the push. Non-blocking: post-receive exit code is
# ignored by git, so we never reject the push here. Instead, failures are
# surfaced on stderr (so the pushing client sees them) and appended to
# notify-push.log inside the bare repo for later inspection.
NM_BIN='/var/folders/z4/lqr0grkx5szdkkqjhjyprljw0000gn/T/go-build434623105/b001/git.test'
if [ ! -f "$NM_BIN" ]; then
  NM_BIN="$(command -v no-mistakes 2>/dev/null || echo no-mistakes)"
fi
# Resolve the bare repo dir explicitly. Git can invoke this hook from a cwd
# whose pwd collapses to "." (issue #269), which would pass "--gate ." and be
# rejected by the daemon ("invalid gate path: ."), so the pipeline never
# starts. git rev-parse --absolute-git-dir queries git directly and always
# yields the true path regardless of cwd/PWD state (Git 2.13+, May 2017); fall
# back to pwd only if git itself is somehow unavailable.
GATE_DIR=$(git rev-parse --absolute-git-dir 2>/dev/null || pwd)
LOG="$GATE_DIR/notify-push.log"
nm_ts() { date '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || echo unknown; }
notify_failed=0
while read oldrev newrev refname; do
	  set -- --gate "$GATE_DIR" \
	    --ref "$refname" \
	    --old "$oldrev" \
	    --new "$newrev"
	  i=0
	  while [ "$i" -lt "${GIT_PUSH_OPTION_COUNT:-0}" ]; do
	    opt=$(printenv "GIT_PUSH_OPTION_$i" 2>/dev/null || :)
	    set -- "$@" --push-option "$opt"
	    i=$((i + 1))
	  done
	  out=$(NM_HOOK_HELPER=1 "$NM_BIN" daemon notify-push "$@" 2>&1)
  status=$?
  if [ $status -ne 0 ]; then
    notify_failed=1
    {
      printf '[%s] notify-push failed for %s (exit %d)\n' "$(nm_ts)" "$refname" "$status"
      printf '%s\n\n' "$out"
    } >> "$LOG"
    {
      printf 'no-mistakes: notify-push failed for %s (exit %d):\n' "$refname" "$status"
      printf '%s\n' "$out"
      printf 'See %s for full history.\n' "$LOG"
    } >&2
  fi
done

if [ "$notify_failed" -eq 0 ]; then
  cat >&2 <<'BANNER'
_  _ ____    _  _ _ ____ ___ ____ _  _ ____ ____
|\ | |  |    |\/| | [__   |  |__| |_/  |___ [__
| \| |__|    |  | | ___]  |  |  | | \_ |___ ___]

  * Pipeline started

  Run no-mistakes to review.

BANNER
fi
exit 0
```
</details>
<details>
<summary>Evidence: 02 — NEW vs OLD hook gate resolution under all three #269 conditions + genuine git push</summary>

<code>A) normal cwd — both correct. B) cwd diverges to sibling, GIT_DIR=bare — NEW resolves absolute bare dir; OLD yields non-.git sibling dir (daemon-rejectable). C) PWD=. poisoned — NEW resolves absolute bare dir; OLD yields &#39;.&#39; (the reported bug). D) genuine `git push` with real NEW hook installed — hook fires, records absolute push.git gate, push succeeds.</code>

```text
==============================================================
ISSUE #269 — post-receive --gate resolution: NEW(fixed) vs OLD(pre-fix)
recorder installed as 'no-mistakes' on PATH; hook reaches it via the
[ ! -f "$NM_BIN" ] fallback (the embedded path is the test binary, now gone).
bare-new = /var/folders/z4/lqr0grkx5szdkkqjhjyprljw0000gn/T/tmp.MK8hAWK7Fb/gate-new.git
bare-old = /var/folders/z4/lqr0grkx5szdkkqjhjyprljw0000gn/T/tmp.nti44GY2Oj/gate-old.git
==============================================================

A) NORMAL  — cwd == bare dir, no stress (even OLD is correct here)
   NEW --gate = /private/var/folders/z4/lqr0grkx5szdkkqjhjyprljw0000gn/T/tmp.MK8hAWK7Fb/gate-new.git
   OLD --gate = /var/folders/z4/lqr0grkx5szdkkqjhjyprljw0000gn/T/tmp.nti44GY2Oj/gate-old.git

B) STRESS #1 — cwd diverges from repo (cwd=sibling, GIT_DIR=bare)
   (the #269 'pwd no longer names the bare repo' failure class)
   NEW --gate = /private/var/folders/z4/lqr0grkx5szdkkqjhjyprljw0000gn/T/tmp.MK8hAWK7Fb/gate-new.git   (expect: bare dir  -> CORRECT)
   OLD --gate = /var/folders/z4/lqr0grkx5szdkkqjhjyprljw0000gn/T/tmp.nti44GY2Oj   (expect: sibling dir -> WRONG, not a .git path -> daemon rejects)

C) STRESS #2 — PWD=. poisoned, cwd=bare (author's deterministic repro from hook_test.go)
   NEW --gate = /private/var/folders/z4/lqr0grkx5szdkkqjhjyprljw0000gn/T/tmp.MK8hAWK7Fb/gate-new.git   (expect: bare dir  -> CORRECT)
   OLD --gate = .   (expect: '.' or wrong -> the reported bug)

--------------------------------------------------------------
RAW RESULTS  (val == basename of bare dir 'gate-new.git' => correct)
   NEW :  A=/private/var/folders/z4/lqr0grkx5szdkkqjhjyprljw0000gn/T/tmp.MK8hAWK7Fb/gate-new.git | B=/private/var/folders/z4/lqr0grkx5szdkkqjhjyprljw0000gn/T/tmp.MK8hAWK7Fb/gate-new.git | C=/private/var/folders/z4/lqr0grkx5szdkkqjhjyprljw0000gn/T/tmp.MK8hAWK7Fb/gate-new.git
   OLD :  A=/var/folders/z4/lqr0grkx5szdkkqjhjyprljw0000gn/T/tmp.nti44GY2Oj/gate-old.git | B=/var/folders/z4/lqr0grkx5szdkkqjhjyprljw0000gn/T/tmp.nti44GY2Oj | C=.
--------------------------------------------------------------

D) GENUINE 'git push' to a bare repo with the real shipped NEW hook installed
   hook fired on real push; recorded --gate = /private/var/folders/z4/lqr0grkx5szdkkqjhjyprljw0000gn/T/tmp.A2qf2zCDV2/push.git
   push succeeded and hook ran: YES
```
</details>
<details>
<summary>Evidence: 03 — Real daemon verdicts (decisive before/after proof)</summary>

`Real daemon server slog log. --gate '.' -> 'invalid gate path: .' (the #269 fatal). --gate sibling dir -> 'invalid gate path: <dir>'. --gate absolute '<id>.git' (NEW hook value) -> 'unknown repo for gate …' (ACCEPTED at gate layer; fails only for unrelated unregistered-repo reason).`

```text
Driving the REAL daemon (isolated NM_HOME) with each candidate --gate value.
The daemon (no-mistakes daemon) logs the server verdict via slog; we read its log.

  -> --gate '.'   [OLD hook #269 bug: pwd collapsed to '.']
  -> --gate '/var/folders/z4/lqr0grkx5szdkkqjhjyprljw0000gn/T'   [OLD hook wrong-dir: sibling dir, no .git suffix]
  -> --gate '/var/folders/z4/lqr0grkx5szdkkqjhjyprljw0000gn/T/tmp.URNsKol0UL/repos/example.git'   [NEW hook resolved: absolute <id>.git]

=== Real daemon server log (relevant lines) ===
time=2026-06-27T13:19:12.141+08:00 level=INFO msg="push received" ref=refs/heads/main old=0000000000000000000000000000000000000000 new=deadbeefdeadbeefdeadbeefdeadbeefdeadbeef gate=.
time=2026-06-27T13:19:12.141+08:00 level=INFO msg="ipc request failed" method=push_received error="invalid gate path: ."
time=2026-06-27T13:19:12.158+08:00 level=INFO msg="push received" ref=refs/heads/main old=0000000000000000000000000000000000000000 new=deadbeefdeadbeefdeadbeefdeadbeefdeadbeef gate=/var/folders/z4/lqr0grkx5szdkkqjhjyprljw0000gn/T
time=2026-06-27T13:19:12.158+08:00 level=INFO msg="ipc request failed" method=push_received error="invalid gate path: /var/folders/z4/lqr0grkx5szdkkqjhjyprljw0000gn/T"
time=2026-06-27T13:19:12.171+08:00 level=INFO msg="push received" ref=refs/heads/main old=0000000000000000000000000000000000000000 new=deadbeefdeadbeefdeadbeefdeadbeefdeadbeef gate=/var/folders/z4/lqr0grkx5szdkkqjhjyprljw0000gn/T/tmp.URNsKol0UL/repos/example.git
time=2026-06-27T13:19:12.172+08:00 level=INFO msg="ipc request failed" method=push_received error="unknown repo for gate /var/folders/z4/lqr0grkx5szdkkqjhjyprljw0000gn/T/tmp.URNsKol0UL/repos/example.git"

=== Verdict map ===
  server verdicts for the three pushes: invalid gate path: . invalid gate path: /var/folders/z4/lqr0grkx5szdkkqjhjyprljw0000gn/T|unknown repo for gate /var/folders/z4/lqr0grkx5szdkkqjhjyprljw0000gn/T/tmp.URNsKol0UL/repos/example.git
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `Shipped hook content: rendered PostReceiveHookScript() and confirmed line 'GATE_DIR=$(git rev-parse --absolute-git-dir 2>/dev/null || pwd)' plus the #269 rationale comment are present; old 'pwd' gate path is gone (01-real-shipped-hook.sh).`
- `NEW hook gate resolution — case A (normal, cwd==bare dir): resolves absolute bare dir. CORRECT.`
- `NEW hook gate resolution — case B (cwd diverges to a sibling dir while GIT_DIR points at the bare repo, the #269 'pwd no longer names the bare repo' class): resolves absolute bare dir. CORRECT (OLD hook yields the sibling dir, which is not a .git path).`
- `NEW hook gate resolution — case C (PWD=. poisoned with cwd==bare, the author's deterministic repro from hook_test.go): resolves absolute bare dir. CORRECT (OLD hook yields exactly '.').`
- <code>NEW hook gate resolution — case D (genuine `git push` to a bare repo with the real shipped NEW hook installed): hook fires on real push and records the absolute push.git gate; push succeeds. CORRECT.</code>
- `OLD (pre-fix) hook reproduction: confirmed it computes '.' under PWD=. poison and a non-.git sibling dir under cwd-divergence — reproducing the exact reported bug.`
- `Real daemon gate validation (isolated NM_HOME, real daemon process, real unix-socket IPC via daemon notify-push): --gate '.' -> 'invalid gate path: .' (fatal); --gate sibling dir -> 'invalid gate path: <dir>' (fatal); --gate absolute '<id>.git' (NEW hook value) -> 'unknown repo for gate …' (ACCEPTED at the gate layer; fails only for unrelated unregistered-repo reason).`
- <code>Worktree hygiene: removed throwaway zz_dump_hook_test.go and ./bin build output; verified `git status` clean and HEAD at 5369df6.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
