### PR TITLE
chore(config): add .no-mistakes.yaml — run go test -race on every gated PR (eat our own dogfood)

### DIFF
--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -1,0 +1,11 @@
+# no-mistakes' own dogfood config.
+# Makes the gate deterministic: every gated PR runs the exact test/lint/format
+# commands the maintainers run locally, instead of leaving it to agent
+# auto-detection. `go test -race` is the key addition — concurrency races (the
+# #1311 class) are caught automatically on every push.
+# See docs/src/content/docs/reference/repo-config.md
+
+commands:
+  test: "go test -race ./..."
+  lint: "make lint"
+  format: "gofmt -w ."


### PR DESCRIPTION
## Summary

Commits a `.no-mistakes.yaml` to no-mistakes' own repo so it eats its own dogfood — every gated PR runs the exact test/lint/format commands maintainers run locally, deterministically, instead of relying on agent auto-detection.

The highest-leverage addition is `commands.test: "go test -race ./..."` as the baseline test command. With this pinned on `main`, the race detector runs on **every** gated push and catches `#1311`-class concurrency races automatically — no agent judgment in the critical path. This is the canonical example from the [repo-config docs](https://kunchenguid.github.io/no-mistakes/reference/repo-config) and matches the `Makefile` `test:` target.

## What's in the file

```yaml
commands:
  test: "go test -race ./..."
  lint: "make lint"
  format: "gofmt -w ."
```

These mirror what maintainers already run (no invented commands):

| Field | Value | Source |
| --- | --- | --- |
| `test` | `go test -race ./...` | `Makefile` `test:` |
| `lint` | `make lint` | `Makefile` `lint:` = `skill-check` + `go vet ./...` |
| `format` | `gofmt -w .` | `Makefile` `fmt:` |

Kept intentionally minimal — no `agent`, `ignore_patterns`, `auto_fix`, `intent`, or `test.evidence` overrides (all inherit global config / built-in defaults).

## Security

`allow_repo_commands` is intentionally left at its secure default (`false`). no-mistakes accepts external contributions, so the code-executing fields (`commands`, `agent`) must stay pinned to this default-branch copy — a contributor cannot inject shell or pick an agent from a pushed branch. This is exactly the supply-chain boundary described in `repo-config.md` and enforced by `EffectiveRepoConfig`.

## Why deterministic

Today the gate's test/lint steps fall back to agent auto-detection when `commands.*` are unset. That works, but it leaves the gate non-deterministic: the same diff could pass or fail depending on which tests the agent decides to run. Pinning the commands makes the gate reproducible and guarantees the race detector always runs — the whole point of a gate.

Refs: `docs/src/content/docs/reference/repo-config.md`, `data/nm-plugins-design-x6/report.md` §7.

---

**AI disclosure: Human-reviewed.** This change was authored with AI assistance and reviewed by a human contributor before submission. The diff is a single 11-line config file.

**Note on submission:** This PR was opened directly from a contributor fork rather than through `git push no-mistakes`, so the `Require no-mistakes` check will report as not-satisfied. This is the bootstrap config that makes future gated runs deterministic — once merged, subsequent PRs flow through the pipeline as normal. Flagging for your review.