### PR TITLE
test(bitbucket): add host.go state-mapping tests

### DIFF
--- a/internal/bitbucket/host_test.go
+++ b/internal/bitbucket/host_test.go
@@ -1,0 +1,390 @@
+package bitbucket
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/scm"
+)
+
+func TestNormalizePRState(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want scm.PRState
+	}{
+		{"open canonical", "OPEN", scm.PRStateOpen},
+		{"open lowercase", "open", scm.PRStateOpen},
+		{"open mixed case", "Open", scm.PRStateOpen},
+		{"open with surrounding whitespace", "  OPEN  ", scm.PRStateOpen},
+		{"merged canonical", "MERGED", scm.PRStateMerged},
+		{"merged lowercase", "merged", scm.PRStateMerged},
+		{"merged with whitespace", "\tMERGED\n", scm.PRStateMerged},
+		{"declined canonical", "DECLINED", scm.PRStateClosed},
+		{"declined lowercase", "declined", scm.PRStateClosed},
+		{"closed canonical", "CLOSED", scm.PRStateClosed},
+		{"closed lowercase", "closed", scm.PRStateClosed},
+		{"superseded canonical", "SUPERSEDED", scm.PRStateClosed},
+		{"superseded lowercase", "superseded", scm.PRStateClosed},
+
+		// The default branch returns the raw string verbatim: no trim, no case fold.
+		// Unknown lifecycle states pass through untouched so callers can surface them.
+		{"unknown state passes through raw", "DRAFT", "DRAFT"},
+		{"unknown state preserves original casing", "Draft", "Draft"},
+		{"unknown state preserves original whitespace", "  Draft  ", "  Draft  "},
+		{"empty string stays empty", "", ""},
+		{"whitespace-only with no recognized token returns raw", "   ", "   "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizePRState(tt.raw)
+			if got != tt.want {
+				t.Fatalf("normalizePRState(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStatusName(t *testing.T) {
+	tests := []struct {
+		name   string
+		status CommitStatus
+		want   string
+	}{
+		{"name present", CommitStatus{Name: "build", Key: "build-key"}, "build"},
+		{"name takes precedence over key", CommitStatus{Name: "build", Key: "other"}, "build"},
+		{"name empty falls back to key", CommitStatus{Name: "", Key: "build-key"}, "build-key"},
+		{"name whitespace-only falls back to key", CommitStatus{Name: "   ", Key: "build-key"}, "build-key"},
+		{"name trimmed when returned", CommitStatus{Name: "  build  ", Key: ""}, "build"},
+		{"key trimmed when used as fallback", CommitStatus{Name: "", Key: "  build-key  "}, "build-key"},
+		{"both empty returns empty", CommitStatus{}, ""},
+		{"both whitespace-only returns empty", CommitStatus{Name: "  ", Key: "  "}, ""},
+		{"neither name nor key set but state populated returns empty", CommitStatus{State: "SUCCESSFUL"}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := statusName(tt.status)
+			if got != tt.want {
+				t.Fatalf("statusName(%#v) = %q, want %q", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStatusBucket(t *testing.T) {
+	tests := []struct {
+		name  string
+		state string
+		want  scm.CheckBucket
+	}{
+		{"successful canonical", "SUCCESSFUL", scm.CheckBucketPass},
+		{"success alias", "SUCCESS", scm.CheckBucketPass},
+		{"successful lowercase", "successful", scm.CheckBucketPass},
+		{"successful mixed case", "Successful", scm.CheckBucketPass},
+		{"successful with whitespace", "  SUCCESSFUL  ", scm.CheckBucketPass},
+
+		{"failed canonical", "FAILED", scm.CheckBucketFail},
+		{"failure alias", "FAILURE", scm.CheckBucketFail},
+		{"error alias", "ERROR", scm.CheckBucketFail},
+		{"failed lowercase", "failed", scm.CheckBucketFail},
+
+		{"stopped maps to cancel", "STOPPED", scm.CheckBucketCancel},
+		{"stopped lowercase", "stopped", scm.CheckBucketCancel},
+
+		{"inprogress no underscore", "INPROGRESS", scm.CheckBucketPending},
+		{"in_progress with underscore", "IN_PROGRESS", scm.CheckBucketPending},
+		{"pending", "PENDING", scm.CheckBucketPending},
+		{"inprogress lowercase", "inprogress", scm.CheckBucketPending},
+
+		{"unknown returns empty", "UNKNOWN", ""},
+		{"empty returns empty", "", ""},
+		{"whitespace-only returns empty", "   ", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := statusBucket(tt.state)
+			if got != tt.want {
+				t.Fatalf("statusBucket(%q) = %q, want %q", tt.state, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizePipelineUUID(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"already lowercase", "abc-def-123", "abc-def-123"},
+		{"uppercase lowered", "ABC-DEF-123", "abc-def-123"},
+		{"mixed case lowered", "AbC-dEf", "abc-def"},
+		{"with braces stripped", "{abc-def-123}", "abc-def-123"},
+		{"with braces uppercase", "{ABC-DEF}", "abc-def"},
+		{"with surrounding spaces trimmed", "  abc-def  ", "abc-def"},
+		{"spaces and braces combined", "  {abc-def}  ", "abc-def"},
+
+		// strings.Trim with cutset "{}" strips all leading/trailing { and } chars,
+		// not just one matched pair.
+		{"nested braces collapse", "{{abc-def}}", "abc-def"},
+		{"only leading brace stripped", "{abc-def", "abc-def"},
+		{"only trailing brace stripped", "abc-def}", "abc-def"},
+		{"triple trailing braces", "abc-def}}}", "abc-def"},
+		{"interior braces preserved", "a{b}c", "a{b}c"},
+
+		{"empty returns empty", "", ""},
+		{"whitespace-only returns empty", "   ", ""},
+		{"empty braces return empty", "{}", ""},
+		{"braces with whitespace return empty", "  {}  ", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizePipelineUUID(tt.raw)
+			if got != tt.want {
+				t.Fatalf("normalizePipelineUUID(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPipelineUUIDFromStatusURL(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "valid results URL with braces",
+			raw:  "https://bitbucket.org/ws/repo/pipelines/results/{abc-def-123}",
+			want: "abc-def-123",
+		},
+		{
+			name: "UUID without braces",
+			raw:  "https://bitbucket.org/ws/repo/pipelines/results/abc-def",
+			want: "abc-def",
+		},
+		{
+			name: "uppercase UUID normalized to lowercase",
+			raw:  "https://bitbucket.org/ws/repo/pipelines/results/{ABC-DEF}",
+			want: "abc-def",
+		},
+		{
+			name: "URL with query string strips query",
+			raw:  "https://bitbucket.org/ws/repo/pipelines/results/{abc-def}?tab=logs",
+			want: "abc-def",
+		},
+		{
+			name: "URL with trailing path segment stops at first slash",
+			raw:  "https://bitbucket.org/ws/repo/pipelines/results/{abc-def}/steps",
+			want: "abc-def",
+		},
+		{
+			name: "fragment consulted before path",
+			raw:  "https://bitbucket.org/ws/pipelines/results/path-uuid#/pipelines/results/frag-uuid",
+			want: "frag-uuid",
+		},
+		{
+			name: "last results segment wins when duplicated",
+			raw:  "https://bitbucket.org/results/early/results/late",
+			want: "late",
+		},
+		{
+			name: "URL without results segment returns empty",
+			raw:  "https://bitbucket.org/ws/repo/pipelines",
+			want: "",
+		},
+		{
+			name: "URL whose path lacks results but fragment has it extracts fragment UUID",
+			raw:  "https://bitbucket.org/ws/repo#/pipelines/results/{frag-only}",
+			want: "frag-only",
+		},
+		{
+			name: "empty string returns empty",
+			raw:  "",
+			want: "",
+		},
+		{
+			name: "whitespace-only returns empty",
+			raw:  "   ",
+			want: "",
+		},
+		{
+			name: "plain string with no URL structure returns empty",
+			raw:  "not-a-url",
+			want: "",
+		},
+		{
+			// An invalid percent-escape makes url.Parse fail outright; the helper
+			// must return empty rather than panic or surface the parse error.
+			name: "malformed URL with invalid percent escape returns empty",
+			raw:  "https://bitbucket.org/x/results/{abc}%xx",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pipelineUUIDFromStatusURL(tt.raw)
+			if got != tt.want {
+				t.Fatalf("pipelineUUIDFromStatusURL(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFailedPipelineUUIDs(t *testing.T) {
+	resultsURL := func(uuid string) string {
+		return "https://bitbucket.org/ws/repo/pipelines/results/{" + uuid + "}"
+	}
+
+	tests := []struct {
+		name         string
+		statuses     []CommitStatus
+		failingNames []string
+		wantNil      bool
+		want         []string // pre-sorted UUIDs expected in the returned map
+	}{
+		{
+			name:         "no failing names returns nil",
+			failingNames: nil,
+			wantNil:      true,
+		},
+		{
+			name:         "empty failing names slice returns nil",
+			failingNames: []string{},
+			wantNil:      true,
+		},
+		{
+			name:         "failing names all whitespace returns nil",
+			failingNames: []string{"  ", ""},
+			wantNil:      true,
+		},
+		{
+			name:         "no statuses returns nil",
+			statuses:     nil,
+			failingNames: []string{"build"},
+			wantNil:      true,
+		},
+		{
+			name: "no status name matches a failing name returns nil",
+			statuses: []CommitStatus{
+				{Name: "lint", URL: resultsURL("lint-uuid")},
+			},
+			failingNames: []string{"build"},
+			wantNil:      true,
+		},
+		{
+			name: "matching status with no results URL returns nil",
+			statuses: []CommitStatus{
+				{Name: "build", URL: "https://bitbucket.org/ws/repo/build"},
+			},
+			failingNames: []string{"build"},
+			wantNil:      true,
+		},
+		{
+			name: "matching status with empty URL returns nil",
+			statuses: []CommitStatus{
+				{Name: "build", URL: ""},
+			},
+			failingNames: []string{"build"},
+			wantNil:      true,
+		},
+		{
+			name: "single match extracts UUID",
+			statuses: []CommitStatus{
+				{Name: "build", URL: resultsURL("abc")},
+			},
+			failingNames: []string{"build"},
+			want:         []string{"abc"},
+		},
+		{
+			name: "multiple distinct failing names map to distinct UUIDs",
+			statuses: []CommitStatus{
+				{Name: "build", URL: resultsURL("abc")},
+				{Name: "tests", URL: resultsURL("def")},
+			},
+			failingNames: []string{"build", "tests"},
+			want:         []string{"abc", "def"},
+		},
+		{
+			name: "duplicate UUIDs collapse into a single target",
+			statuses: []CommitStatus{
+				{Name: "build", URL: resultsURL("abc")},
+				{Name: "tests", URL: resultsURL("abc")},
+			},
+			failingNames: []string{"build", "tests"},
+			want:         []string{"abc"},
+		},
+		{
+			name: "only the requested failing names contribute UUIDs",
+			statuses: []CommitStatus{
+				{Name: "build", URL: resultsURL("abc")},
+				{Name: "lint", URL: resultsURL("def")},
+			},
+			failingNames: []string{"build", "nonexistent"},
+			want:         []string{"abc"},
+		},
+		{
+			name: "failing name with surrounding whitespace matches trimmed status name",
+			statuses: []CommitStatus{
+				{Name: "build", URL: resultsURL("abc")},
+			},
+			failingNames: []string{"  build  "},
+			want:         []string{"abc"},
+		},
+		{
+			name: "status matched by key when name is empty",
+			statuses: []CommitStatus{
+				{Key: "build", URL: resultsURL("abc")},
+			},
+			failingNames: []string{"build"},
+			want:         []string{"abc"},
+		},
+		{
+			name: "uppercase UUIDs in URLs are normalized",
+			statuses: []CommitStatus{
+				{Name: "build", URL: resultsURL("ABC-DEF")},
+			},
+			failingNames: []string{"build"},
+			want:         []string{"abc-def"},
+		},
+		{
+			name: "LatestStatuses dedup happens before UUID collection",
+			statuses: []CommitStatus{
+				{Name: "build", Key: "build", URL: resultsURL("first")},
+				{Name: "build", Key: "build", URL: resultsURL("second")},
+			},
+			failingNames: []string{"build"},
+			want:         []string{"first"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := failedPipelineUUIDs(tt.statuses, tt.failingNames)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("failedPipelineUUIDs = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("failedPipelineUUIDs = nil, want %v", tt.want)
+			}
+			keys := make([]string, 0, len(got))
+			for k := range got {
+				keys = append(keys, k)
+			}
+			slices.Sort(keys)
+			want := slices.Clone(tt.want)
+			slices.Sort(want)
+			if !slices.Equal(keys, want) {
+				t.Fatalf("failedPipelineUUIDs keys = %v, want %v", keys, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Intent

The developer's goal was to add test coverage to internal/bitbucket/host.go (~300 lines) which had zero tests, targeting six pure state-mapping helpers (normalizePRState, statusName, statusBucket, normalizePipelineUUID, pipelineUUIDFromStatusURL, failedPipelineUUIDs) that drive Bitbucket CI status interpretation and gate resolution. Requirements were to write table-driven tests with t.Run subtests focused on edge cases (malformed inputs, empty strings, unexpected values), follow the existing test conventions in internal/bitbucket/, and not modify host.go. Explicit constraints included branching off origin/main rather than local main, pushing to the e-jung/no-mistakes fork, opening a cross-repo PR to kunchenguid/no-mistakes with the specific title "test(bitbucket): add host.go state-mapping tests (300 lines, 0 covered)" and AI disclosure set to Human-reviewed, running go test ./internal/bitbucket/... -v, and not merging the PR. The developer also required staying within the worktree, reporting status via a status file, and leaving the merge decision to the maintainer.

## What Changed
- Added `internal/bitbucket/host_test.go` (390 lines) with table-driven tests covering the six pure state-mapping helpers in `host.go`: `normalizePRState`, `statusName`, `statusBucket`, `normalizePipelineUUID`, `pipelineUUIDFromStatusURL`, and `failedPipelineUUIDs`.
- Tests target edge cases (malformed inputs, empty strings, unexpected values) across 89 subtests using `t.Run`, raising these helpers from 0% to covered.
- No changes to `host.go` or production behavior; test-only addition following existing `internal/bitbucket` test conventions.

## Risk Assessment

✅ Low: Test-only addition (no production code changed); all assertions trace correctly against the six pure helpers, conventions match existing tests, and go vet is clean.

## Testing

Baseline `go test -race ./...` was already green. The added change is purely the new internal/bitbucket/host_test.go (390 lines), confirmed as the only diff vs base and with host.go untouched. `go test ./internal/bitbucket/... -v` passes all six new functions (TestNormalizePRState, TestStatusName, TestStatusBucket, TestNormalizePipelineUUID, TestPipelineUUIDFromStatusURL, TestFailedPipelineUUIDs) and every one of their 89 edge-case subtests (malformed/invalid-percent-escape URLs, empty/whitespace inputs, strings.Trim brace-cutset behavior, fragment-before-path URL parsing, nil/empty/dedup map results), and the race detector is clean. Coverage shows each of the six targeted helpers at exactly 100% (LatestStatuses transitively at 85.7%, not the target). Beyond pass/fail, three source mutations (forcing statusBucket's fail bucket to pass, dropping normalizePipelineUUID's ToLower, and reversing pipelineUUIDFromStatusURL's fragment/path order) were each caught by their corresponding test, proving the coverage is meaningful rather than vacuous; all mutations were reverted and host.go was restored to its committed state before finishing. No issues found; the user intent (add zero-previously-covered test coverage to host.go's six helpers, without modifying host.go) is satisfied.

<details>
<summary>Evidence: Verbose bitbucket test transcript (6 new fns, 89 subtests)</summary>

`All 6 new test functions PASS with all subtests: TestNormalizePRState (18), TestStatusName (9), TestStatusBucket (18), TestNormalizePipelineUUID (16), TestPipelineUUIDFromStatusURL (13), TestFailedPipelineUUIDs (15). Final: PASS / ok github.com/kunchenguid/no-mistakes/internal/bitbucket`

```text
=== RUN   TestNewClientFromEnvReadsAmbientEnvironment
--- PASS: TestNewClientFromEnvReadsAmbientEnvironment (0.00s)
=== RUN   TestNewClientFromEnvPrefersExplicitEnvironment
--- PASS: TestNewClientFromEnvPrefersExplicitEnvironment (0.00s)
=== RUN   TestParseRepoRefRejectsLookalikeHosts
=== RUN   TestParseRepoRefRejectsLookalikeHosts/rejects_lookalike_host
=== RUN   TestParseRepoRefRejectsLookalikeHosts/accepts_exact_host
=== RUN   TestParseRepoRefRejectsLookalikeHosts/accepts_subdomain_host
--- PASS: TestParseRepoRefRejectsLookalikeHosts (0.00s)
=== RUN   TestListPRStatusesFollowsPagination
--- PASS: TestListPRStatusesFollowsPagination (0.00s)
=== RUN   TestListPRStatusesRejectsCrossOriginPagination
--- PASS: TestListPRStatusesRejectsCrossOriginPagination (0.00s)
=== RUN   TestFindOpenPRBySourceAndDestinationBranchFiltersSourceRepo
--- PASS: TestFindOpenPRBySourceAndDestinationBranchFiltersSourceRepo (0.00s)
=== RUN   TestListPipelinesByCommitFollowsPagination
--- PASS: TestListPipelinesByCommitFollowsPagination (0.00s)
=== RUN   TestListPipelineStepsFollowsPagination
--- PASS: TestListPipelineStepsFollowsPagination (0.00s)
=== RUN   TestGetStepLogCapsResponseToTail
--- PASS: TestGetStepLogCapsResponseToTail (0.00s)
=== RUN   TestNormalizePRState
=== RUN   TestNormalizePRState/open_canonical
=== RUN   TestNormalizePRState/open_lowercase
=== RUN   TestNormalizePRState/open_mixed_case
=== RUN   TestNormalizePRState/open_with_surrounding_whitespace
=== RUN   TestNormalizePRState/merged_canonical
=== RUN   TestNormalizePRState/merged_lowercase
=== RUN   TestNormalizePRState/merged_with_whitespace
=== RUN   TestNormalizePRState/declined_canonical
=== RUN   TestNormalizePRState/declined_lowercase
=== RUN   TestNormalizePRState/closed_canonical
=== RUN   TestNormalizePRState/closed_lowercase
=== RUN   TestNormalizePRState/superseded_canonical
=== RUN   TestNormalizePRState/superseded_lowercase
=== RUN   TestNormalizePRState/unknown_state_passes_through_raw
=== RUN   TestNormalizePRState/unknown_state_preserves_original_casing
=== RUN   TestNormalizePRState/unknown_state_preserves_original_whitespace
=== RUN   TestNormalizePRState/empty_string_stays_empty
=== RUN   TestNormalizePRState/whitespace-only_with_no_recognized_token_returns_raw
--- PASS: TestNormalizePRState (0.00s)
=== RUN   TestStatusName
=== RUN   TestStatusName/name_present
=== RUN   TestStatusName/name_takes_precedence_over_key
=== RUN   TestStatusName/name_empty_falls_back_to_key
=== RUN   TestStatusName/name_whitespace-only_falls_back_to_key
=== RUN   TestStatusName/name_trimmed_when_returned
=== RUN   TestStatusName/key_trimmed_when_used_as_fallback
=== RUN   TestStatusName/both_empty_returns_empty
=== RUN   TestStatusName/both_whitespace-only_returns_empty
=== RUN   TestStatusName/neither_name_nor_key_set_but_state_populated_returns_empty
--- PASS: TestStatusName (0.00s)
=== RUN   TestStatusBucket
=== RUN   TestStatusBucket/successful_canonical
=== RUN   TestStatusBucket/success_alias
=== RUN   TestStatusBucket/successful_lowercase
=== RUN   TestStatusBucket/successful_mixed_case
=== RUN   TestStatusBucket/successful_with_whitespace
=== RUN   TestStatusBucket/failed_canonical
=== RUN   TestStatusBucket/failure_alias
=== RUN   TestStatusBucket/error_alias
=== RUN   TestStatusBucket/failed_lowercase
=== RUN   TestStatusBucket/stopped_maps_to_cancel
=== RUN   TestStatusBucket/stopped_lowercase
=== RUN   TestStatusBucket/inprogress_no_underscore
=== RUN   TestStatusBucket/in_progress_with_underscore
=== RUN   TestStatusBucket/pending
=== RUN   TestStatusBucket/inprogress_lowercase
=== RUN   TestStatusBucket/unknown_returns_empty
=== RUN   TestStatusBucket/empty_returns_empty
=== RUN   TestStatusBucket/whitespace-only_returns_empty
--- PASS: TestStatusBucket (0.00s)
=== RUN   TestNormalizePipelineUUID
=== RUN   TestNormalizePipelineUUID/already_lowercase
=== RUN   TestNormalizePipelineUUID/uppercase_lowered
=== RUN   TestNormalizePipelineUUID/mixed_case_lowered
=== RUN   TestNormalizePipelineUUID/with_braces_stripped
=== RUN   TestNormalizePipelineUUID/with_braces_uppercase
=== RUN   TestNormalizePipelineUUID/with_surrounding_spaces_trimmed
=== RUN   TestNormalizePipelineUUID/spaces_and_braces_combined
=== RUN   TestNormalizePipelineUUID/nested_braces_collapse
=== RUN   TestNormalizePipelineUUID/only_leading_brace_stripped
=== RUN   TestNormalizePipelineUUID/only_trailing_brace_stripped
=== RUN   TestNormalizePipelineUUID/triple_trailing_braces
=== RUN   TestNormalizePipelineUUID/interior_braces_preserved
=== RUN   TestNormalizePipelineUUID/empty_returns_empty
=== RUN   TestNormalizePipelineUUID/whitespace-only_returns_empty
=== RUN   TestNormalizePipelineUUID/empty_braces_return_empty
=== RUN   TestNormalizePipelineUUID/braces_with_whitespace_return_empty
--- PASS: TestNormalizePipelineUUID (0.00s)
=== RUN   TestPipelineUUIDFromStatusURL
=== RUN   TestPipelineUUIDFromStatusURL/valid_results_URL_with_braces
=== RUN   TestPipelineUUIDFromStatusURL/UUID_without_braces
=== RUN   TestPipelineUUIDFromStatusURL/uppercase_UUID_normalized_to_lowercase
=== RUN   TestPipelineUUIDFromStatusURL/URL_with_query_string_strips_query
=== RUN   TestPipelineUUIDFromStatusURL/URL_with_trailing_path_segment_stops_at_first_slash
=== RUN   TestPipelineUUIDFromStatusURL/fragment_consulted_before_path
=== RUN   TestPipelineUUIDFromStatusURL/last_results_segment_wins_when_duplicated
=== RUN   TestPipelineUUIDFromStatusURL/URL_without_results_segment_returns_empty
=== RUN   TestPipelineUUIDFromStatusURL/URL_whose_path_lacks_results_but_fragment_has_it_extracts_fragment_UUID
=== RUN   TestPipelineUUIDFromStatusURL/empty_string_returns_empty
=== RUN   TestPipelineUUIDFromStatusURL/whitespace-only_returns_empty
=== RUN   TestPipelineUUIDFromStatusURL/plain_string_with_no_URL_structure_returns_empty
=== RUN   TestPipelineUUIDFromStatusURL/malformed_URL_with_invalid_percent_escape_returns_empty
--- PASS: TestPipelineUUIDFromStatusURL (0.00s)
=== RUN   TestFailedPipelineUUIDs
=== RUN   TestFailedPipelineUUIDs/no_failing_names_returns_nil
=== RUN   TestFailedPipelineUUIDs/empty_failing_names_slice_returns_nil
=== RUN   TestFailedPipelineUUIDs/failing_names_all_whitespace_returns_nil
=== RUN   TestFailedPipelineUUIDs/no_statuses_returns_nil
=== RUN   TestFailedPipelineUUIDs/no_status_name_matches_a_failing_name_returns_nil
=== RUN   TestFailedPipelineUUIDs/matching_status_with_no_results_URL_returns_nil
=== RUN   TestFailedPipelineUUIDs/matching_status_with_empty_URL_returns_nil
=== RUN   TestFailedPipelineUUIDs/single_match_extracts_UUID
=== RUN   TestFailedPipelineUUIDs/multiple_distinct_failing_names_map_to_distinct_UUIDs
=== RUN   TestFailedPipelineUUIDs/duplicate_UUIDs_collapse_into_a_single_target
=== RUN   TestFailedPipelineUUIDs/only_the_requested_failing_names_contribute_UUIDs
=== RUN   TestFailedPipelineUUIDs/failing_name_with_surrounding_whitespace_matches_trimmed_status_name
=== RUN   TestFailedPipelineUUIDs/status_matched_by_key_when_name_is_empty
=== RUN   TestFailedPipelineUUIDs/uppercase_UUIDs_in_URLs_are_normalized
=== RUN   TestFailedPipelineUUIDs/LatestStatuses_dedup_happens_before_UUID_collection
--- PASS: TestFailedPipelineUUIDs (0.00s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/bitbucket	(cached)
```
</details>
<details>
<summary>Evidence: host.go per-function coverage (6 targeted helpers = 100%)</summary>

```text
normalizePRState 100.0% | statusName 100.0% | statusBucket 100.0% | normalizePipelineUUID 100.0% | pipelineUUIDFromStatusURL 100.0% | failedPipelineUUIDs 100.0% | LatestStatuses 85.7% (transitive). Package total: 59.9% of statements.
```
</details>
<details>
<summary>Evidence: Mutation-test evidence (tests catch regressions)</summary>

```text
M1 statusBucket->pass => FAIL TestStatusBucket/failed_canonical (want fail, got pass). M2 drop ToLower => FAIL TestNormalizePipelineUUID/uppercase_lowered (+2). M3 swap frag/path order => FAIL TestPipelineUUIDFromStatusURL/fragment_consulted_before_path. All reverted; host.go restored to committed state.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`
- `go test ./internal/bitbucket/... -v (all 6 new test fns + existing bitbucket tests pass, 89 new subtests)`
- `go test -race ./internal/bitbucket/... (clean)`
- `go test ./internal/bitbucket/ -coverprofile (verified normalizePRState/statusName/statusBucket/normalizePipelineUUID/pipelineUUIDFromStatusURL/failedPipelineUUIDs each at 100%)`
- `Mutation test: statusBucket FAILED-case -> pass (TestStatusBucket caught it), then reverted`
- `Mutation test: normalizePipelineUUID drop ToLower (TestNormalizePipelineUUID caught it), then reverted`
- `Mutation test: pipelineUUIDFromStatusURL swap fragment/path order (TestPipelineUUIDFromStatusURL caught it), then reverted`
- `git diff 1432f3b..07a5c6f --stat (confirms only host_test.go added; host.go unchanged)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
