### PR TITLE
feat(agent): add native grok agent backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 Push to `no-mistakes` instead of `origin`, and it spins up a disposable worktree, runs an AI-driven validation pipeline, forwards the branch to the configured push target only after every check passes, and opens a clean PR automatically.
 
 - **Non-blocking** - the pipeline runs in an isolated worktree without disrupting your work.
-- **Agent-agnostic** - `claude`, `codex`, `rovodev`, `opencode`, `pi`, or `acp:<target>` via `acpx`.
+- **Agent-agnostic** - `claude`, `codex`, `rovodev`, `opencode`, `pi`, `grok`, or `acp:<target>` via `acpx`.
 - **Agent-native** - `/no-mistakes` lets your coding agent do a task and gate it, or gate existing committed work: it runs the pipeline, has the pipeline apply safe fixes, and escalates the rest to you.
 - **Human stays in charge** - auto-fix or review findings, your call.
 - **Clean PRs by default** - push, open PR, watch CI, and auto-fix failures in one shot.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -34,7 +34,7 @@
 把分支推给 `no-mistakes` 而不是 `origin`，它会拉起一个用完即弃的 worktree，跑一条 AI 驱动的校验流水线，**只有每一项检查都通过后**才把分支转发到配置的推送目标，并自动开出一个干净的 PR。
 
 - **不阻塞** —— 流水线在隔离的 worktree 里跑，不打断你手头的工作。
-- **不挑 agent** —— 支持 `claude`、`codex`、`rovodev`、`opencode`、`pi`，或通过 `acpx` 用 `acp:<target>`。
+- **不挑 agent** —— 支持 `claude`、`codex`、`rovodev`、`opencode`、`pi`、`grok`，或通过 `acpx` 用 `acp:<target>`。
 - **agent 原生** —— `/no-mistakes` 既能让编码 agent 完成一个任务再过网关，也能直接为已提交的工作过网关：它跑完流水线、让流水线应用安全的修复，剩下的升级给你。
 - **人始终说了算** —— 自动修复，还是逐条审查 findings，你决定。
 - **默认就是干净 PR** —— 推送、开 PR、盯 CI、自动修复失败，一气呵成。

--- a/cmd/fakeagent/grok.go
+++ b/cmd/fakeagent/grok.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func runGrok(args []string, scenario *Scenario) int {
+	prompt, err := extractGrokPrompt(args)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fakeagent: grok prompt: %v\n", err)
+		return 1
+	}
+	logInvocation("grok", prompt, args)
+
+	action := scenario.Match(prompt)
+	if err := applyAction(action); err != nil {
+		return 1
+	}
+
+	body := action.textOrDefault()
+	if action.hasStructuredOutput() {
+		body = fmt.Sprintf("```json\n%s\n```", action.structuredJSON())
+	}
+
+	fmt.Fprint(os.Stdout, body)
+	return 0
+}
+
+// extractGrokPrompt reads the prompt from --prompt-file. Real grok argv is
+// `grok [user-flags...] --prompt-file <path> --cwd <dir> ...`.
+func extractGrokPrompt(args []string) (string, error) {
+	path := extractGrokPromptFile(args)
+	if path == "" {
+		return "", fmt.Errorf("missing --prompt-file")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read prompt file %q: %w", path, err)
+	}
+	return string(data), nil
+}
+
+func extractGrokPromptFile(args []string) string {
+	for i, a := range args {
+		switch {
+		case a == "--prompt-file" && i+1 < len(args):
+			return args[i+1]
+		case strings.HasPrefix(a, "--prompt-file="):
+			return strings.TrimPrefix(a, "--prompt-file=")
+		}
+	}
+	return ""
+}

--- a/cmd/fakeagent/main.go
+++ b/cmd/fakeagent/main.go
@@ -41,6 +41,8 @@ func run(argv []string) int {
 		return runCodex(args, scenario)
 	case "opencode":
 		return runOpencode(args, scenario)
+	case "grok":
+		return runGrok(args, scenario)
 	case "gh":
 		return runGhStub(args)
 	default:

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -39,6 +39,7 @@ By default that directory is temporary and local to the machine; repos can opt i
 | Rovo Dev | `acli` | Persistent HTTP server, SSE streaming |
 | OpenCode | `opencode` | Persistent HTTP server, SSE streaming |
 | Pi | `pi` | Subprocess per invocation, JSONL events |
+| Grok | `grok` | Subprocess per invocation, plain text |
 | ACP target | `acpx` | Optional user-installed ACP bridge |
 
 ## Setting the agent
@@ -90,7 +91,7 @@ Use bare `/no-mistakes` to validate existing committed work.
 Use `/no-mistakes <task>` to have the agent first do the task, commit only that task's changes on a feature branch, then run the pipeline with the task text as `--intent`.
 In both modes, it resolves low-risk findings on its own and stops to relay anything that needs your decision.
 
-`no-mistakes init` installs that skill at user level: `~/.claude/skills/no-mistakes/SKILL.md` for Claude Code and `~/.agents/skills/no-mistakes/SKILL.md` for Codex, OpenCode, Rovo Dev, and Pi.
+`no-mistakes init` installs that skill at user level: `~/.claude/skills/no-mistakes/SKILL.md` for Claude Code and `~/.agents/skills/no-mistakes/SKILL.md` for Codex, OpenCode, Rovo Dev, Pi, and Grok.
 One install makes the skill available to every supported agent in every repo, without committing tool-generated files to any repo.
 If your home directory consolidates `.claude` and `.agents` with symlinks, `init` follows the links and keeps the skill reachable from both logical paths.
 Re-run `no-mistakes init` after an upgrade to refresh that skill, including overwriting stale `SKILL.md` content from an older binary.
@@ -137,6 +138,8 @@ By default, `no-mistakes` resolves `agent: auto` by checking for supported nativ
 4. `acli` with `rovodev` support
 5. `pi`
 
+`agent: auto` does not probe `grok`; set `agent: grok` explicitly when that is your preferred tool.
+
 The default binary names are:
 
 | Agent | Default binary name |
@@ -146,6 +149,7 @@ The default binary names are:
 | `rovodev` | `acli` |
 | `opencode` | `opencode` |
 | `pi` | `pi` |
+| `grok` | `grok` |
 | `acp:<target>` | `acpx` |
 
 When the daemon is running through a managed service, that `PATH` comes from your login shell environment on macOS and Linux plus common user, Homebrew, and system binary directories. If login-shell resolution fails, the daemon logs a warning and uses a degraded fallback `PATH` that may omit version-manager shim directories. On Windows it reuses the current process environment instead of reloading a login shell. If native agent discovery still does not resolve the binary you expect, check `~/.no-mistakes/logs/daemon.log` and use an explicit `agent_path_override`.
@@ -159,6 +163,7 @@ agent_path_override:
   rovodev: /usr/local/bin/acli
   opencode: /usr/local/bin/opencode
   pi: /usr/local/bin/pi
+  grok: /usr/local/bin/grok
 ```
 
 For ACP targets, set `acpx_path` instead of `agent_path_override`:
@@ -199,7 +204,7 @@ It matches sessions against non-deleted changed files when present, falls back t
 Transcript readers collect user and assistant text messages but exclude tool call output.
 They read Claude Code transcripts from `~/.claude/projects`, Codex metadata from `~/.codex/state_*.sqlite` plus referenced rollout files, OpenCode messages from `$XDG_DATA_HOME/opencode/opencode.db` or `~/.local/share/opencode/opencode.db`, Rovo Dev sessions from `~/.rovodev/sessions`, and Pi transcripts from `~/.pi/agent/sessions`.
 Sessions are eligible when they come from the same working directory or an equivalent Git checkout with the same common Git directory or normalized remote URL.
-ACP transcripts are not currently read for intent extraction.
+Grok and ACP transcripts are not currently read for intent extraction.
 When deterministic matching leaves multiple plausible sessions, no-mistakes may ask the configured pipeline agent to choose among them using the matching file paths and sanitized transcript packet files.
 The selected transcript text is then sent to the configured pipeline agent for summarization during the `intent` step, so intent extraction may incur additional agent or API invocations.
 Before disambiguation or summarization, no-mistakes excludes tool output, redacts likely secrets, strips common prompt-control markers, and clamps long transcripts while preserving the beginning and end.
@@ -232,6 +237,15 @@ Any `agent_args_override.pi` flags are inserted before no-mistakes' managed flag
 Reads JSONL events from stdout and streams incremental text deltas to the TUI.
 When structured output is requested, no-mistakes injects the JSON schema into the prompt and validates the final text response.
 
+## Grok
+
+Spawns a `grok` subprocess for each invocation.
+Any `agent_args_override.grok` flags are inserted before no-mistakes' managed flags.
+no-mistakes writes the prompt to a temporary file and passes `--prompt-file`, `--cwd`, `--permission-mode bypassPermissions`, and `--output-format plain`.
+Reads plain text from stdout and streams it to the TUI.
+When structured output is requested, no-mistakes injects the JSON schema into the prompt and validates the final text response.
+Set `agent: grok` explicitly; `agent: auto` does not probe for the `grok` binary.
+
 ## ACP via acpx
 
 ACP support is optional and requires a separately installed `acpx` binary.
@@ -261,7 +275,8 @@ $ no-mistakes doctor
   ✓ daemon running
   ✓ claude
   – codex (not found)
-  – acli (not found)
+  – grok (not found)
+  – rovodev (not found)
   – opencode (not found)
   – pi (not found)
 ```

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -50,7 +50,7 @@ Everything else can usually wait.
 
 # Default agent for all repos and setup-wizard suggestions.
 # "auto" picks the first available native agent on PATH.
-agent: auto  # auto | claude | codex | rovodev | opencode | pi | acp:<target>
+agent: auto  # auto | claude | codex | rovodev | opencode | pi | grok | acp:<target>
 
 # Optional acpx path and target command overrides for agent: acp:<target>.
 acpx_path: acpx
@@ -64,6 +64,7 @@ agent_path_override:
   rovodev: /usr/local/bin/acli
   opencode: /usr/local/bin/opencode
   pi: /usr/local/bin/pi
+  grok: /usr/local/bin/grok
 
 # Optional extra CLI flags per native agent.
 # This is global-only.
@@ -155,6 +156,7 @@ See [Repo Config Reference](/no-mistakes/reference/repo-config/) for the full fi
 
 - Repo `agent` overrides global `agent`.
 - Global `agent: auto` resolves by checking `claude`, `codex`, `opencode`, `acli` for `rovodev`, then `pi` on `PATH`.
+- `grok` is opt-in with `agent: grok` and is not considered by `agent: auto`.
 - ACP agents are opt-in with `agent: acp:<target>` and are not considered by `agent: auto`.
 - `agent_path_override`, `agent_args_override`, `acpx_path`, and `acp_registry_overrides` are global-only fields.
 - `auto_fix` from the repo config overlays global auto_fix. Fields not set in the repo config fall through to the global default.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -35,7 +35,7 @@ no-mistakes init --fork-url git@github.com:you/my-repo.git
 | `--fork-url` | `string` | (none) | GitHub fork remote URL to push branches to while opening PRs against `origin` |
 
 Creates or refreshes a local bare repo, installs the post-receive hook, best-effort isolates the gate repo's hook path from shared git config changes when Git supports `config --worktree`, adds or repairs the `no-mistakes` git remote, detects the default branch, records or updates the repo in SQLite, installs the `/no-mistakes` agent skill at user level into `~/.claude/skills/no-mistakes/SKILL.md` and `~/.agents/skills/no-mistakes/SKILL.md`, and ensures the daemon is running, installing the managed service when available and falling back to a detached daemon otherwise.
-`init` writes no skill files into the repo; the user-level copies cover every supported agent (`~/.claude/skills` for Claude Code, `~/.agents/skills` for Codex, OpenCode, Rovo Dev, and Pi) across all repos.
+`init` writes no skill files into the repo; the user-level copies cover every supported agent (`~/.claude/skills` for Claude Code, `~/.agents/skills` for Codex, OpenCode, Rovo Dev, Pi, and Grok) across all repos.
 If the home `.claude` links to `.agents`, `.claude/skills` links to `.agents/skills`, or the reverse, `init` follows that layout and still makes the skill readable from both logical paths.
 If the repo still contains a vendored skill copy written by an older no-mistakes version, `init` leaves it untouched and prints a notice that it is no longer needed and can be removed.
 The gate advertises Git push-option support, so you can skip steps for one push with `git push -o no-mistakes.skip=test,lint no-mistakes <branch>`.
@@ -249,7 +249,7 @@ Checks:
 - Data directory (`~/.no-mistakes/`)
 - SQLite database
 - Daemon status
-- Native agent binaries: `claude`, `codex`, `acli`, `opencode`, `pi`
+- Native agent binaries: `claude`, `codex`, `grok`, `acli`, `opencode`, `pi`
 
 Uses indicators: `✓` (available), `–` (not found, optional), `✗` (problem detected).
 

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -21,6 +21,7 @@ agent_path_override:
   rovodev: /usr/local/bin/acli
   opencode: /usr/local/bin/opencode
   pi: /usr/local/bin/pi
+  grok: /usr/local/bin/grok
 
 agent_args_override:
   codex:
@@ -61,10 +62,11 @@ Default agent for all repos and setup-wizard suggestions. Can be overridden per-
 | | |
 |---|---|
 | Type | `string` |
-| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `acp:<target>` |
+| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `grok`, `acp:<target>` |
 | Default | `auto` |
 
 `auto` resolves to the first supported native agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, then `pi`.
+`grok` is opt-in and is not considered by `agent: auto`; set `agent: grok` explicitly.
 `acp:<target>` uses the user-installed `acpx` binary to run an ACP target, for example `acp:gemini`.
 ACP agents are opt-in and are not considered by `agent: auto`.
 
@@ -115,6 +117,7 @@ Default native binary names when no override is set:
 | `rovodev` | `acli` |
 | `opencode` | `opencode` |
 | `pi` | `pi` |
+| `grok` | `grok` |
 
 ### agent_args_override
 
@@ -124,7 +127,7 @@ Use this to set model selection, reasoning effort, permission mode, or any other
 | | |
 |---|---|
 | Type | `map[string][]string` |
-| Keys | `claude`, `codex`, `rovodev`, `opencode`, `pi` |
+| Keys | `claude`, `codex`, `rovodev`, `opencode`, `pi`, `grok` |
 | Default | Empty (no extra flags) |
 
 User-supplied flags are inserted ahead of no-mistakes' managed flags, so your choices usually take precedence. A few flags are reserved because no-mistakes depends on them to communicate with the agent - setting any of these returns a config error on load:
@@ -136,6 +139,7 @@ User-supplied flags are inserted ahead of no-mistakes' managed flags, so your ch
 | `rovodev` | `rovodev`, `serve`, `--disable-session-token` |
 | `opencode` | `serve`, `--hostname`, `--port`, `--print-logs` |
 | `pi` | `--mode`, `--no-session` |
+| `grok` | `-p`, `--single`, `--prompt-file`, `--prompt-json`, `--cwd`, `--permission-mode`, `--output-format`, `--effort` |
 
 For structured `codex` runs, no-mistakes also appends its own `--output-schema <tempfile>` after your overrides. Treat that flag as managed even though config validation does not currently reject it.
 
@@ -169,6 +173,9 @@ agent_args_override:
   pi:
     - --provider
     - google
+  grok:
+    - --model
+    - grok-3
 ```
 
 ### ci_timeout

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -54,10 +54,11 @@ Override the default agent for this repo and its setup-wizard suggestions.
 | | |
 |---|---|
 | Type | `string` |
-| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `acp:<target>` |
+| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `grok`, `acp:<target>` |
 | Default | Inherits from global config |
 
 `auto` resolves to the first supported native agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, then `pi`.
+`grok` is opt-in and is not considered by `agent: auto`; set `agent: grok` explicitly.
 `acp:<target>` uses the user-installed `acpx` binary configured in global config.
 ACP agents are opt-in and are not considered by `agent: auto`.
 

--- a/docs/src/content/docs/start-here/installation.md
+++ b/docs/src/content/docs/start-here/installation.md
@@ -47,7 +47,7 @@ make install
 ## Prerequisites
 
 - **git** - required
-- **One supported agent binary** - `claude`, `codex`, `acli` (Rovo Dev), `opencode`, or `pi`, or a separately installed `acpx` binary for `agent: acp:<target>`
+- **One supported agent binary** - `claude`, `codex`, `grok`, `acli` (Rovo Dev), `opencode`, or `pi`, or a separately installed `acpx` binary for `agent: acp:<target>`
 - **Optional, for PRs and CI:**
   - `gh` CLI (GitHub)
   - `glab` CLI (GitLab)

--- a/docs/src/content/docs/start-here/introduction.md
+++ b/docs/src/content/docs/start-here/introduction.md
@@ -70,7 +70,7 @@ When a branch passes the gate, it means:
 ## What you get
 
 - A fixed, opinionated pipeline: `intent → rebase → review → test → document → lint → push → pr → ci`. Order is not configurable; what each step runs is.
-- Choice of agent: `claude`, `codex`, `rovodev`, `opencode`, `pi`, or `acp:<target>` via `acpx`, with per-repo override.
+- Choice of agent: `claude`, `codex`, `rovodev`, `opencode`, `pi`, `grok`, or `acp:<target>` via `acpx`, with per-repo override.
 - A TUI to watch, approve, fix, skip, or abort any step.
 - A `/no-mistakes` agent skill so a coding agent can do a task and gate it, or gate existing committed work, backed by a non-interactive `no-mistakes axi` interface.
 - A setup wizard when you run bare `no-mistakes` with no active run on the current branch - it walks you through creating a branch, committing, and pushing through the gate, then attaches if the daemon registers the new run.

--- a/docs/src/content/docs/start-here/quick-start.md
+++ b/docs/src/content/docs/start-here/quick-start.md
@@ -24,7 +24,7 @@ no-mistakes doctor
 You need:
 
 - `git`
-- One supported agent binary (`claude`, `codex`, `acli` for Rovo Dev, `opencode`, or `pi`), or a separately installed `acpx` binary for `agent: acp:<target>`
+- One supported agent binary (`claude`, `codex`, `grok`, `acli` for Rovo Dev, `opencode`, or `pi`), or a separately installed `acpx` binary for `agent: acp:<target>`
 - For PRs and CI: `gh` (GitHub), `glab` (GitLab), or Bitbucket Cloud credentials
 
 For ACP agents, verify `acpx` or `acpx_path` separately because `no-mistakes doctor` does not validate ACP targets.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -590,8 +590,10 @@ func NewWithOptions(name types.AgentName, bin string, extraArgs []string, opts O
 		return &opencodeAgent{bin: bin, extraArgs: extraArgs}, nil
 	case types.AgentPi:
 		return &piAgent{bin: bin, extraArgs: extraArgs}, nil
+	case types.AgentGrok:
+		return &grokAgent{bin: bin, extraArgs: extraArgs}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
+		return nil, fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, grok, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
 	}
 }
 

--- a/internal/agent/grok.go
+++ b/internal/agent/grok.go
@@ -10,6 +10,8 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+
+	"github.com/kunchenguid/no-mistakes/internal/shellenv"
 )
 
 // grokMaxRetries is the number of additional attempts past the initial
@@ -56,6 +58,9 @@ func (a *grokAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) 
 	cmd.Dir = opts.CWD
 	cmd.Stdin = nil
 	cmd.Env = gitSafeEnv(opts.CWD)
+	// Run in a dedicated process group so cancelling ctx reaps the grok CLI and
+	// any subprocesses it spawns, not just the direct child.
+	shellenv.ConfigureShellCommand(cmd)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/internal/agent/grok.go
+++ b/internal/agent/grok.go
@@ -85,12 +85,9 @@ func (a *grokAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) 
 	}()
 
 	var textBuf strings.Builder
-	// Stream stdout line-by-line with a bufio.Reader instead of bufio.Scanner:
-	// the scanner requires a fixed max-token buffer, and a single very long line
-	// (e.g. minified JSON) would force a large up-front allocation. ReadString
-	// grows incrementally with no fixed cap.
-	reader := bufio.NewReader(stdout)
-	for {
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), 256*1024*1024)
+	for scanner.Scan() {
 		select {
 		case <-ctx.Done():
 			stderrWG.Wait()
@@ -98,28 +95,22 @@ func (a *grokAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) 
 			return nil, ctx.Err()
 		default:
 		}
-		line, readErr := reader.ReadString('\n')
-		if len(line) > 0 {
-			line = strings.TrimRight(line, "\r\n")
-			if textBuf.Len() > 0 {
-				textBuf.WriteByte('\n')
-				if opts.OnChunk != nil {
-					opts.OnChunk("\n")
-				}
-			}
-			textBuf.WriteString(line)
+		line := strings.TrimRight(scanner.Text(), "\r\n")
+		if textBuf.Len() > 0 {
+			textBuf.WriteByte('\n')
 			if opts.OnChunk != nil {
-				opts.OnChunk(line)
+				opts.OnChunk("\n")
 			}
 		}
-		if readErr != nil {
-			if readErr == io.EOF {
-				break
-			}
-			stderrWG.Wait()
-			_ = cmd.Wait()
-			return nil, fmt.Errorf("grok read stdout: %w", readErr)
+		textBuf.WriteString(line)
+		if opts.OnChunk != nil {
+			opts.OnChunk(line)
 		}
+	}
+	if err := scanner.Err(); err != nil {
+		stderrWG.Wait()
+		_ = cmd.Wait()
+		return nil, fmt.Errorf("grok read stdout: %w", err)
 	}
 
 	stderrWG.Wait()
@@ -135,10 +126,9 @@ func (a *grokAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) 
 }
 
 // buildGrokArgs constructs the grok CLI arguments. extraArgs are placed first,
-// followed by the managed flags; grok treats the last occurrence of a flag as
-// authoritative, so the managed flags take precedence. These flags are reserved
-// in config (users cannot supply them), keeping the gate's invocation contract
-// intact.
+// followed by the managed flags. Those managed flags are reserved in config
+// (validateAgentArgsOverride rejects them in agent_args_override), so extraArgs
+// cannot collide with them and the managed values are authoritative.
 func buildGrokArgs(promptPath string, extraArgs []string, cwd string) []string {
 	args := make([]string, 0, len(extraArgs)+8)
 	args = append(args, extraArgs...)

--- a/internal/agent/grok.go
+++ b/internal/agent/grok.go
@@ -80,9 +80,12 @@ func (a *grokAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) 
 	}()
 
 	var textBuf strings.Builder
-	scanner := bufio.NewScanner(stdout)
-	scanner.Buffer(make([]byte, 0, 64*1024), 256*1024*1024)
-	for scanner.Scan() {
+	// Stream stdout line-by-line with a bufio.Reader instead of bufio.Scanner:
+	// the scanner requires a fixed max-token buffer, and a single very long line
+	// (e.g. minified JSON) would force a large up-front allocation. ReadString
+	// grows incrementally with no fixed cap.
+	reader := bufio.NewReader(stdout)
+	for {
 		select {
 		case <-ctx.Done():
 			stderrWG.Wait()
@@ -90,22 +93,28 @@ func (a *grokAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) 
 			return nil, ctx.Err()
 		default:
 		}
-		line := scanner.Text()
-		if textBuf.Len() > 0 {
-			textBuf.WriteByte('\n')
+		line, readErr := reader.ReadString('\n')
+		if len(line) > 0 {
+			line = strings.TrimRight(line, "\r\n")
+			if textBuf.Len() > 0 {
+				textBuf.WriteByte('\n')
+				if opts.OnChunk != nil {
+					opts.OnChunk("\n")
+				}
+			}
+			textBuf.WriteString(line)
 			if opts.OnChunk != nil {
-				opts.OnChunk("\n")
+				opts.OnChunk(line)
 			}
 		}
-		textBuf.WriteString(line)
-		if opts.OnChunk != nil {
-			opts.OnChunk(line)
+		if readErr != nil {
+			if readErr == io.EOF {
+				break
+			}
+			stderrWG.Wait()
+			_ = cmd.Wait()
+			return nil, fmt.Errorf("grok read stdout: %w", readErr)
 		}
-	}
-	if err := scanner.Err(); err != nil {
-		stderrWG.Wait()
-		_ = cmd.Wait()
-		return nil, fmt.Errorf("grok read stdout: %w", err)
 	}
 
 	stderrWG.Wait()
@@ -120,8 +129,11 @@ func (a *grokAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) 
 	return finalizeTextResult("grok", textBuf.String(), opts.JSONSchema, TokenUsage{})
 }
 
-// buildGrokArgs constructs the grok CLI arguments. User-supplied extraArgs are
-// inserted ahead of the managed flags so user choices take precedence.
+// buildGrokArgs constructs the grok CLI arguments. extraArgs are placed first,
+// followed by the managed flags; grok treats the last occurrence of a flag as
+// authoritative, so the managed flags take precedence. These flags are reserved
+// in config (users cannot supply them), keeping the gate's invocation contract
+// intact.
 func buildGrokArgs(promptPath string, extraArgs []string, cwd string) []string {
 	args := make([]string, 0, len(extraArgs)+8)
 	args = append(args, extraArgs...)

--- a/internal/agent/grok.go
+++ b/internal/agent/grok.go
@@ -1,0 +1,153 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+// grokMaxRetries is the number of additional attempts past the initial
+// invocation. With 2 retries the agent makes up to 3 total attempts before
+// surfacing a transient API error to the pipeline.
+const grokMaxRetries = 2
+
+// grokAgent spawns the grok CLI for each invocation.
+type grokAgent struct {
+	bin       string
+	extraArgs []string
+}
+
+func (a *grokAgent) Name() string { return "grok" }
+
+func (a *grokAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
+	return runWithRetry(ctx, "grok", opts, grokMaxRetries, classifyTransient, nil, func() (*Result, error) {
+		return a.runOnce(ctx, opts)
+	})
+}
+
+func (a *grokAgent) Close() error { return nil }
+
+func (a *grokAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
+	prompt := buildGrokPrompt(opts.Prompt, opts.JSONSchema)
+
+	f, err := os.CreateTemp("", "nm-grok-*.md")
+	if err != nil {
+		return nil, fmt.Errorf("grok prompt temp file: %w", err)
+	}
+	promptPath := f.Name()
+	defer os.Remove(promptPath)
+
+	if _, err := f.WriteString(prompt); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("grok prompt temp file write: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return nil, fmt.Errorf("grok prompt temp file close: %w", err)
+	}
+
+	args := buildGrokArgs(promptPath, a.extraArgs, opts.CWD)
+	cmd := exec.CommandContext(ctx, a.bin, args...)
+	cmd.Dir = opts.CWD
+	cmd.Stdin = nil
+	cmd.Env = gitSafeEnv(opts.CWD)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("grok stdout pipe: %w", err)
+	}
+
+	var stderrBuf []byte
+	var stderrWG sync.WaitGroup
+	stderrR, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("grok stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("grok start: %w", err)
+	}
+
+	stderrWG.Add(1)
+	go func() {
+		defer stderrWG.Done()
+		stderrBuf, _ = io.ReadAll(stderrR)
+	}()
+
+	var textBuf strings.Builder
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), 256*1024*1024)
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			stderrWG.Wait()
+			_ = cmd.Wait()
+			return nil, ctx.Err()
+		default:
+		}
+		line := scanner.Text()
+		if textBuf.Len() > 0 {
+			textBuf.WriteByte('\n')
+			if opts.OnChunk != nil {
+				opts.OnChunk("\n")
+			}
+		}
+		textBuf.WriteString(line)
+		if opts.OnChunk != nil {
+			opts.OnChunk(line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		stderrWG.Wait()
+		_ = cmd.Wait()
+		return nil, fmt.Errorf("grok read stdout: %w", err)
+	}
+
+	stderrWG.Wait()
+	if err := cmd.Wait(); err != nil {
+		stderr := strings.TrimSpace(string(stderrBuf))
+		if stderr != "" {
+			return nil, fmt.Errorf("grok exited: %w: %s", err, stderr)
+		}
+		return nil, fmt.Errorf("grok exited: %w", err)
+	}
+
+	return finalizeTextResult("grok", textBuf.String(), opts.JSONSchema, TokenUsage{})
+}
+
+// buildGrokArgs constructs the grok CLI arguments. User-supplied extraArgs are
+// inserted ahead of the managed flags so user choices take precedence.
+func buildGrokArgs(promptPath string, extraArgs []string, cwd string) []string {
+	args := make([]string, 0, len(extraArgs)+8)
+	args = append(args, extraArgs...)
+	args = append(args,
+		"--prompt-file", promptPath,
+		"--cwd", cwd,
+		"--permission-mode", "bypassPermissions",
+		"--output-format", "plain",
+	)
+	return args
+}
+
+// buildGrokPrompt prepends a JSON-output contract to the user prompt when a
+// schema is provided. Grok has no structured-output flag, so we inline the
+// schema in the prompt and ask for a fenced JSON block.
+func buildGrokPrompt(prompt string, schema json.RawMessage) string {
+	if len(schema) == 0 {
+		return prompt
+	}
+	pretty, err := json.MarshalIndent(json.RawMessage(schema), "", "  ")
+	if err != nil {
+		pretty = []byte(schema)
+	}
+	contract := "## no-mistakes final output contract\n\n" +
+		"When the iteration is complete, your final assistant response must include valid JSON matching this JSON Schema, wrapped in a Markdown ```json code fence. " +
+		"Do not include prose after the fenced JSON block.\n\n" +
+		string(pretty)
+	return contract + "\n\n" + prompt
+}

--- a/internal/agent/grok_test.go
+++ b/internal/agent/grok_test.go
@@ -1,0 +1,91 @@
+package agent
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+func TestNew_GrokAgent(t *testing.T) {
+	a, err := New(types.AgentGrok, "grok", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a.Name() != "grok" {
+		t.Errorf("expected name %q, got %q", "grok", a.Name())
+	}
+	if _, ok := a.(*grokAgent); !ok {
+		t.Fatalf("agent type = %T, want *grokAgent", a)
+	}
+}
+
+func TestNewWithOptions_GrokAgent(t *testing.T) {
+	a, err := NewWithOptions(types.AgentGrok, "/home/falk/.grok/bin/grok", []string{"--model", "grok-3"}, Options{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ga, ok := a.(*grokAgent)
+	if !ok {
+		t.Fatalf("agent type = %T, want *grokAgent", a)
+	}
+	if ga.bin != "/home/falk/.grok/bin/grok" {
+		t.Errorf("bin = %q, want override path", ga.bin)
+	}
+	if len(ga.extraArgs) != 2 || ga.extraArgs[0] != "--model" || ga.extraArgs[1] != "grok-3" {
+		t.Errorf("extraArgs = %v, want [--model grok-3]", ga.extraArgs)
+	}
+}
+
+func TestBuildGrokArgs_Ordering(t *testing.T) {
+	args := buildGrokArgs("/tmp/prompt.md", []string{"--model", "grok-3"}, "/repo")
+
+	want := []string{
+		"--model", "grok-3",
+		"--prompt-file", "/tmp/prompt.md",
+		"--cwd", "/repo",
+		"--permission-mode", "bypassPermissions",
+		"--output-format", "plain",
+	}
+	if len(args) != len(want) {
+		t.Fatalf("expected %d args, got %d: %v", len(want), len(args), args)
+	}
+	for i, expected := range want {
+		if args[i] != expected {
+			t.Errorf("arg[%d]: expected %q, got %q", i, expected, args[i])
+		}
+	}
+	for _, arg := range args {
+		if arg == "--effort" || strings.HasPrefix(arg, "--effort=") {
+			t.Fatalf("args must not include --effort, got %v", args)
+		}
+	}
+}
+
+func TestBuildGrokPromptIncludesSchemaContract(t *testing.T) {
+	schema := json.RawMessage(`{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"]}`)
+	prompt := buildGrokPrompt("do a thing", schema)
+	if !strings.Contains(prompt, "do a thing") {
+		t.Errorf("prompt missing user prompt: %s", prompt)
+	}
+	if !strings.Contains(prompt, "no-mistakes final output contract") {
+		t.Errorf("prompt missing contract header: %s", prompt)
+	}
+	if !strings.Contains(prompt, "```json") {
+		t.Errorf("prompt missing fenced-json instruction: %s", prompt)
+	}
+	if !strings.Contains(prompt, "summary") {
+		t.Errorf("prompt missing schema property: %s", prompt)
+	}
+	if !strings.HasPrefix(prompt, "## no-mistakes final output contract") {
+		t.Errorf("expected schema contract prepended, got: %q", prompt)
+	}
+}
+
+func TestBuildGrokPromptOmitsContractWhenSchemaEmpty(t *testing.T) {
+	prompt := buildGrokPrompt("do a thing", nil)
+	if prompt != "do a thing" {
+		t.Errorf("expected raw prompt when no schema, got: %q", prompt)
+	}
+}

--- a/internal/agent/grok_test.go
+++ b/internal/agent/grok_test.go
@@ -22,7 +22,7 @@ func TestNew_GrokAgent(t *testing.T) {
 }
 
 func TestNewWithOptions_GrokAgent(t *testing.T) {
-	a, err := NewWithOptions(types.AgentGrok, "/home/falk/.grok/bin/grok", []string{"--model", "grok-3"}, Options{})
+	a, err := NewWithOptions(types.AgentGrok, "/path/to/grok", []string{"--model", "grok-3"}, Options{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -30,7 +30,7 @@ func TestNewWithOptions_GrokAgent(t *testing.T) {
 	if !ok {
 		t.Fatalf("agent type = %T, want *grokAgent", a)
 	}
-	if ga.bin != "/home/falk/.grok/bin/grok" {
+	if ga.bin != "/path/to/grok" {
 		t.Errorf("bin = %q, want override path", ga.bin)
 	}
 	if len(ga.extraArgs) != 2 || ga.extraArgs[0] != "--model" || ga.extraArgs[1] != "grok-3" {

--- a/internal/agent/grok_test.go
+++ b/internal/agent/grok_test.go
@@ -1,7 +1,11 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -83,9 +87,119 @@ func TestBuildGrokPromptIncludesSchemaContract(t *testing.T) {
 	}
 }
 
+func TestGrokPromptTempFileOwnerOnly(t *testing.T) {
+	f, err := os.CreateTemp("", "nm-grok-*.md")
+	if err != nil {
+		t.Fatalf("create temp: %v", err)
+	}
+	path := f.Name()
+	defer os.Remove(path)
+	if err := f.Close(); err != nil {
+		t.Fatalf("close temp: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat temp: %v", err)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		t.Errorf("prompt temp file should be owner-only, got mode %o", info.Mode().Perm())
+	}
+}
+
 func TestBuildGrokPromptOmitsContractWhenSchemaEmpty(t *testing.T) {
 	prompt := buildGrokPrompt("do a thing", nil)
 	if prompt != "do a thing" {
 		t.Errorf("expected raw prompt when no schema, got: %q", prompt)
+	}
+}
+
+func strconvQuote(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `\"`) + `"`
+}
+
+func writeFakeGrok(t *testing.T, dir, posixScript, windowsScript string) string {
+	t.Helper()
+
+	name := "grok"
+	script := posixScript
+	if runtime.GOOS == "windows" {
+		name = "grok.cmd"
+		script = windowsScript
+	}
+
+	bin := filepath.Join(dir, name)
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake grok: %v", err)
+	}
+	return bin
+}
+
+func TestGrokAgent_RunParsesFencedJSONAndUsesManagedFlags(t *testing.T) {
+	dir := t.TempDir()
+	argvLog := filepath.Join(dir, "argv.log")
+	fenceOpen := "```json"
+	fenceClose := "```"
+	posixScript := strings.Join([]string{
+		"#!/bin/sh",
+		"printf '%s\\n' \"$@\" > " + strconvQuote(argvLog),
+		"printf '%s\\n' '" + fenceOpen + "'",
+		"printf '%s\\n' '{\"ok\":true}'",
+		"printf '%s\\n' '" + fenceClose + "'",
+	}, "\n")
+	bin := writeFakeGrok(t, dir, posixScript, strings.Join([]string{
+		"@echo off",
+		"echo %* > \"" + strings.ReplaceAll(argvLog, "/", "\\") + "\"",
+		"echo " + fenceOpen,
+		"echo {\"ok\":true}",
+		"echo " + fenceClose,
+	}, "\r\n"))
+
+	schema := json.RawMessage(`{"type":"object","properties":{"ok":{"type":"boolean"}},"required":["ok"]}`)
+	ga := &grokAgent{bin: bin, extraArgs: []string{"--model", "grok-3"}}
+	cwd := t.TempDir()
+
+	var chunks []string
+	result, err := ga.Run(context.Background(), RunOpts{
+		Prompt:     "review the diff",
+		CWD:        cwd,
+		JSONSchema: schema,
+		OnChunk:    func(s string) { chunks = append(chunks, s) },
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result.Output) != `{"ok":true}` {
+		t.Fatalf("unexpected output: %s", string(result.Output))
+	}
+	if len(chunks) == 0 {
+		t.Fatal("expected onChunk to receive streaming text")
+	}
+
+	argvBytes, err := os.ReadFile(argvLog)
+	if err != nil {
+		t.Fatalf("read argv log: %v", err)
+	}
+	argv := strings.Fields(string(argvBytes))
+	want := []string{
+		"--model", "grok-3",
+		"--prompt-file", "PROMPT_PATH",
+		"--cwd", cwd,
+		"--permission-mode", "bypassPermissions",
+		"--output-format", "plain",
+	}
+	if len(argv) != len(want) {
+		t.Fatalf("argv len = %d, want %d: %v", len(argv), len(want), argv)
+	}
+	for i, expected := range want {
+		got := argv[i]
+		if expected == "PROMPT_PATH" {
+			if !strings.HasPrefix(filepath.Base(got), "nm-grok-") || !strings.HasSuffix(got, ".md") {
+				t.Errorf("argv[%d]: expected managed temp prompt path, got %q", i, got)
+			}
+			continue
+		}
+		if got != expected {
+			t.Errorf("argv[%d]: got %q, want %q", i, got, expected)
+		}
 	}
 }

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -94,6 +94,7 @@ func newDoctorCmd() *cobra.Command {
 				}{
 					{"claude", "claude"},
 					{"codex", "codex"},
+					{"grok", "grok"},
 					{"rovodev", "acli"},
 					{"opencode", "opencode"},
 					{"pi", "pi"},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -225,6 +225,7 @@ var defaultBinary = map[types.AgentName]string{
 	types.AgentRovoDev:  "acli",
 	types.AgentOpenCode: "opencode",
 	types.AgentPi:       "pi",
+	types.AgentGrok:     "grok",
 }
 
 // agentProbeOrder is the priority order for auto-detecting agents.
@@ -351,6 +352,7 @@ var agentArgsOverrideAgents = map[string]bool{
 	string(types.AgentRovoDev):  true,
 	string(types.AgentOpenCode): true,
 	string(types.AgentPi):       true,
+	string(types.AgentGrok):     true,
 }
 
 // reservedAgentArgs lists flags that no-mistakes manages internally and that
@@ -384,6 +386,15 @@ var reservedAgentArgs = map[string]map[string]bool{
 		"--mode":       true,
 		"--no-session": true,
 	},
+	string(types.AgentGrok): {
+		"-p":                true,
+		"--prompt":          true,
+		"--prompt-file":     true,
+		"--cwd":             true,
+		"--permission-mode": true,
+		"--output-format":   true,
+		"--effort":          true,
+	},
 }
 
 // validateAgentArgsOverride ensures each agent key is a known agent name and
@@ -392,7 +403,7 @@ var reservedAgentArgs = map[string]map[string]bool{
 func validateAgentArgsOverride(override map[string][]string) error {
 	for name, args := range override {
 		if !agentArgsOverrideAgents[name] {
-			return fmt.Errorf("invalid agent name in agent_args_override: %q (valid: claude, codex, rovodev, opencode, pi)", name)
+			return fmt.Errorf("invalid agent name in agent_args_override: %q (valid: claude, codex, rovodev, opencode, pi, grok)", name)
 		}
 		reserved := reservedAgentArgs[name]
 		for i, arg := range args {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -388,8 +388,9 @@ var reservedAgentArgs = map[string]map[string]bool{
 	},
 	string(types.AgentGrok): {
 		"-p":                true,
-		"--prompt":          true,
+		"--single":          true,
 		"--prompt-file":     true,
+		"--prompt-json":     true,
 		"--cwd":             true,
 		"--permission-mode": true,
 		"--output-format":   true,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -156,7 +156,7 @@ type Intent struct {
 const defaultConfigYAML = `# no-mistakes global configuration
 
 # Agent to use for code generation
-# Options: auto, claude, codex, rovodev, opencode, pi, acp:<target>
+# Options: auto, claude, codex, rovodev, opencode, pi, grok, acp:<target>
 # "auto" detects the first available native agent on your system
 # Use acp:<target> to run an optional user-installed acpx target, for example acp:gemini
 agent: auto

--- a/internal/config/config_args_override_test.go
+++ b/internal/config/config_args_override_test.go
@@ -95,6 +95,14 @@ func TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected(t *testing.T) {
 		{"opencode", "--hostname"},
 		{"opencode", "--port"},
 		{"opencode", "--print-logs"},
+		{"grok", "-p"},
+		{"grok", "--single"},
+		{"grok", "--prompt-file"},
+		{"grok", "--prompt-json"},
+		{"grok", "--cwd"},
+		{"grok", "--permission-mode"},
+		{"grok", "--output-format"},
+		{"grok", "--effort"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.agent+"_"+tt.arg, func(t *testing.T) {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -139,4 +139,5 @@ const (
 	AgentRovoDev  AgentName = "rovodev"
 	AgentOpenCode AgentName = "opencode"
 	AgentPi       AgentName = "pi"
+	AgentGrok     AgentName = "grok"
 )


### PR DESCRIPTION
## Intent

The developer asked for a security vulnerability review of a committed change that adds Grok as a new agent type in the no-mistakes pipeline. The change wires the grok CLI into agent spawning, configuration validation, doctor diagnostics, types, and a fakeagent test stub, following the same patterns as existing agents such as Claude and Pi. They provided the list of changed files and the unified diff so every new code path could be inspected. They explicitly requested investigation using the assistant's security review methodology and a findings list of any vulnerabilities discovered. The review was scoped to the supplied diff, with implicit focus on subprocess invocation, reserved CLI flags, temp prompt files, permission modes, and whether user-supplied agent arguments could bypass managed invocation controls.

## What Changed

- Add a native `grok` agent backend that writes prompts to a temp file, invokes the grok CLI with pipeline-managed flags (`--prompt-file`, `--cwd`, `--permission-mode`, `--output-format`), streams plain-text stdout with a 256MB per-line cap, and retries transient failures.
- Register `grok` as a selectable agent type, reject reserved grok CLI flags (including `--single` and `--prompt-json`) in `agent_args_override`, and include grok in `no-mistakes doctor` availability checks.
- Document grok agent setup and configuration across README and docs; add a `fakeagent grok` stub for pipeline and integration tests.

## Risk Assessment

✅ Low: Grok integration mirrors established native-agent patterns with reserved managed flags, forced bypassPermissions, 256MB-bounded stdout scanning, process-group cleanup, and global-only agent_args_override, and the prior review hardening addressed the only substantive gaps.

## Testing

Exercised Grok unit and integration tests (including a new run-once test that records exact child argv), all eight grok reserved-flag rejection cases in config validation, a fakeagent grok end-to-end invocation that logged managed flags and returned fenced JSON, and doctor output confirming grok is listed when present on PATH. No security regressions or test failures were observed.

<details>
<summary>Evidence: Fakeagent grok invocation log (managed argv + prompt)</summary>

`{"agent":"grok","args":["--model","grok-3","--prompt-file","/tmp/nm-grok-manual-QCeE.md","--cwd","/home/falk/.nm-grok/worktrees/d250dc19c698/01KVR3V1D2X5EPMKPEQKNGJHXX","--permission-mode","bypassPermissions","--output-format","plain"]}`

```text
{"time":"2026-06-22T17:03:58.492551346Z","agent":"grok","args":["--model","grok-3","--prompt-file","/tmp/nm-grok-manual-QCeE.md","--cwd","/home/falk/.nm-grok/worktrees/d250dc19c698/01KVR3V1D2X5EPMKPEQKNGJHXX","--permission-mode","bypassPermissions","--output-format","plain"],"prompt":"## no-mistakes final output contract\n\nReview this change for security issues.\n","cwd":"/home/falk/.nm-grok/worktrees/d250dc19c698/01KVR3V1D2X5EPMKPEQKNGJHXX"}
```
</details>
<details>
<summary>Evidence: Fakeagent grok stdout (fenced JSON response)</summary>

```text
`` `json
{"body":"## Summary\nfakeagent canned PR body","findings":[],"risk_level":"low","risk_rationale":"no risks detected in the diff","summary":"no issues found","tested":["fakeagent: simulated test run"],"testing_summary":"simulated tests passed","title":"feat: fakeagent change"}
`` `
```
</details>
<details>
<summary>Evidence: Doctor output listing grok agent</summary>

`✓ grok /tmp/no-mistakes-evidence/01KVR3V1D2X5EPMKPEQKNGJHXX/grok`

```text
  System
  ✓ git             git version 2.54.0
  ✓ gh              ok
  ✓ data directory  /tmp/no-mistakes-evidence/01KVR3V1D2X5EPMKPEQKNGJHXX/nmhome
  – database        not found (will be created on first use)
  – daemon          stopped

  Agents
  ✓ claude          /home/falk/.local/bin/claude
  ✓ codex           /home/falk/.local/bin/codex
  ✓ grok            /tmp/no-mistakes-evidence/01KVR3V1D2X5EPMKPEQKNGJHXX/grok
  – rovodev         not found
  ✓ opencode        /home/falk/.local/bin/opencode
  ✓ pi              /home/falk/.local/bin/pi
```
</details>
<details>
<summary>Evidence: Grok agent integration test (argv + fenced JSON parsing)</summary>

```text
=== RUN   TestNew_GrokAgent
--- PASS: TestNew_GrokAgent (0.00s)
=== RUN   TestNewWithOptions_GrokAgent
--- PASS: TestNewWithOptions_GrokAgent (0.00s)
=== RUN   TestBuildGrokArgs_Ordering
--- PASS: TestBuildGrokArgs_Ordering (0.00s)
=== RUN   TestBuildGrokPromptIncludesSchemaContract
--- PASS: TestBuildGrokPromptIncludesSchemaContract (0.00s)
=== RUN   TestGrokPromptTempFileOwnerOnly
--- PASS: TestGrokPromptTempFileOwnerOnly (0.00s)
=== RUN   TestBuildGrokPromptOmitsContractWhenSchemaEmpty
--- PASS: TestBuildGrokPromptOmitsContractWhenSchemaEmpty (0.00s)
=== RUN   TestGrokAgent_RunParsesFencedJSONAndUsesManagedFlags
--- PASS: TestGrokAgent_RunParsesFencedJSONAndUsesManagedFlags (0.01s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/agent	0.011s
```
</details>
<details>
<summary>Evidence: Reserved grok flags rejection tests</summary>

```text
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/claude_-p
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/claude_--print
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/claude_--verbose
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/claude_--output-format
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/claude_--output-format=stream-json
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/claude_--json-schema
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/codex_exec
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/codex_--json
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/codex_--color
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/codex_--color=never
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/rovodev_rovodev
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/rovodev_serve
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/rovodev_--disable-session-token
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/opencode_serve
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/opencode_--hostname
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/opencode_--port
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/opencode_--print-logs
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/grok_-p
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/grok_--single
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/grok_--prompt-file
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/grok_--prompt-json
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/grok_--cwd
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/grok_--permission-mode
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/grok_--output-format
=== RUN   TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/grok_--effort
--- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected (0.00s)
    --- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/claude_-p (0.00s)
    --- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/claude_--print (0.00s)
    --- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/claude_--verbose (0.00s)
    --- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/claude_--output-format (0.00s)
    --- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/claude_--output-format=stream-json (0.00s)
    --- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/claude_--json-schema (0.00s)
    --- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/codex_exec (0.00s)
    --- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/codex_--json (0.00s)
    --- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/codex_--color (0.00s)
    --- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/codex_--color=never (0.00s)
    --- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/rovodev_rovodev (0.00s)
    --- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/rovodev_serve (0.00s)
    --- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/rovodev_--disable-session-token (0.00s)
    --- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/opencode_serve (0.00s)
    --- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/opencode_--hostname (0.00s)
    --- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/opencode_--port (0.00s)
    --- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/opencode_--print-logs (0.00s)
    --- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/grok_-p (0.00s)
    --- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/grok_--single (0.00s)
    --- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/grok_--prompt-file (0.00s)
    --- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/grok_--prompt-json (0.00s)
    --- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/grok_--cwd (0.00s)
    --- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/grok_--permission-mode (0.00s)
    --- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/grok_--output-format (0.00s)
    --- PASS: TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected/grok_--effort (0.00s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/config	0.004s
```
</details>
<details>
<summary>Evidence: Security review summary</summary>

```text
Grok agent security validation (feat/grok-agent)

Verified controls:
- agent_args_override rejects all grok managed flags (-p, --single, --prompt-file,
  --prompt-json, --cwd, --permission-mode, --output-format, --effort) including
  --flag=value forms
- buildGrokArgs places user extraArgs first, then authoritative managed flags
- Prompt written to owner-only temp file (nm-grok-*.md), removed after invocation
- Subprocess spawned via exec.CommandContext with nil stdin, gitSafeEnv, and
  shellenv.ConfigureShellCommand for cancellable process-group teardown
- Stdout scanner capped at 256 MiB per line to limit memory exhaustion
- No shell interpolation of user-supplied args (argv array, not sh -c)

End-to-end evidence:
- fakeagent grok symlink accepted managed argv and returned fenced JSON
- no-mistakes doctor lists grok agent when grok is on PATH
- Integration test confirms grokAgent.Run passes exact argv to child process

Result: no security vulnerabilities identified in the scoped diff.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `internal/agent/grok.go` - merge conflict rebasing onto refs/remotes/no-mistakes-push/feat/grok-agent

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `internal/config/config.go:389` - reservedAgentArgs for grok blocks -p/--prompt-file but not the CLI&#39;s actual alternate prompt flags --single and --prompt-json. A maintainer who adds either to agent_args_override will get a hard grok CLI error at runtime (the CLI mutually excludes these with --prompt-file), but config load will not catch it early.
- ⚠️ `internal/agent/grok.go:87` - Stdout is accumulated in a strings.Builder via unbounded ReadString(&#39;\n&#39;) with no total-size cap. A single very long line (e.g. minified JSON) can grow memory without limit and OOM the daemon; pi caps scanner output at 256MB.
- ℹ️ `internal/agent/grok.go:137` - buildGrokArgs comment claims grok treats the last duplicate flag as authoritative, but the real grok CLI rejects duplicate flags (--model, --permission-mode, --prompt-file) with a hard error. The reserved-arg validation is what actually protects managed flags, not last-wins semantics.

🔧 Fix: Harden grok reserved flags and stdout bounds
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/agent -run 'Grok' -count=1 -v`
- `go test ./internal/config -run 'ReservedArgsRejected' -count=1 -v`
- <code>`go build -buildvcs=false -o /tmp/no-mistakes-evidence/01KVR3V1D2X5EPMKPEQKNGJHXX/fakeagent ./cmd/fakeagent` then fakeagent grok symlink invocation with `--prompt-file`, `--cwd`, `--permission-mode`, `--output-format`</code>
- <code>`go build -buildvcs=false -o /tmp/no-mistakes-evidence/01KVR3V1D2X5EPMKPEQKNGJHXX/no-mistakes ./cmd/no-mistakes` then `no-mistakes doctor` with grok on PATH</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
