### PR TITLE
fix: keep CI monitors active and abortable by run id

### DIFF
--- a/.no-mistakes/evidence/fm/nm-warts-w4/ci-monitor-behavior-trace.txt
+++ b/.no-mistakes/evidence/fm/nm-warts-w4/ci-monitor-behavior-trace.txt
@@ -1,0 +1,21 @@
+=== RUN   TestEvidenceCIMonitorTimeoutTrace
+=== RUN   TestEvidenceCIMonitorTimeoutTrace/base_advance_re-arms_finite_timeout
+    ci_evidence_test.go:62: finite-timeout re-arm trace:
+        monitoring CI for PR #42 (timeout: 10s)...
+        all CI checks passed - still monitoring until merged or closed
+        base branch advanced (sha-old..sha-new), re-arming CI monitor timeout
+=== RUN   TestEvidenceCIMonitorTimeoutTrace/stable_base_still_times_out
+    ci_evidence_test.go:102: stable-base timeout trace:
+        monitoring CI for PR #42 (timeout: 10s)...
+        all CI checks passed - still monitoring until merged or closed
+        CI timeout reached
+=== RUN   TestEvidenceCIMonitorTimeoutTrace/unlimited_timeout_skips_deadline_and_base_polling
+    ci_evidence_test.go:146: unlimited-timeout trace with base tip resolver calls=0:
+        monitoring CI for PR #42 (no timeout, until merged or closed)...
+        all CI checks passed - still monitoring until merged or closed
+--- PASS: TestEvidenceCIMonitorTimeoutTrace (0.41s)
+    --- PASS: TestEvidenceCIMonitorTimeoutTrace/base_advance_re-arms_finite_timeout (0.29s)
+    --- PASS: TestEvidenceCIMonitorTimeoutTrace/stable_base_still_times_out (0.04s)
+    --- PASS: TestEvidenceCIMonitorTimeoutTrace/unlimited_timeout_skips_deadline_and_base_polling (0.07s)
+PASS
+ok  	github.com/kunchenguid/no-mistakes/internal/pipeline/steps	0.718s

--- a/.no-mistakes/evidence/fm/nm-warts-w4/e2e-codex-journey.txt
+++ b/.no-mistakes/evidence/fm/nm-warts-w4/e2e-codex-journey.txt
@@ -1,0 +1,36 @@
+=== RUN   TestUserJourney
+=== RUN   TestUserJourney/codex
+    journey_test.go:234: agent invocations: 18
+          0) codex: Workspace boundary (important):
+          1) codex: Workspace boundary (important):
+          2) codex: Workspace boundary (important):
+          3) codex: Workspace boundary (important):
+          4) codex: Workspace boundary (important):
+          5) codex: Workspace boundary (important):
+          6) codex: Workspace boundary (important):
+          7) codex: Workspace boundary (important):
+          8) codex: Workspace boundary (important):
+          9) codex: Workspace boundary (important):
+          10) codex: Workspace boundary (important):
+          11) codex: Workspace boundary (important):
+          12) codex: Workspace boundary (important):
+          13) codex: Workspace boundary (important):
+          14) codex: Workspace boundary (important):
+          15) codex: Workspace boundary (important):
+          16) codex: Workspace boundary (important):
+          17) codex: Workspace boundary (important):
+    journey_test.go:235: step outcomes:
+    journey_test.go:237:   1 intent    skipped
+    journey_test.go:237:   2 rebase    completed
+    journey_test.go:237:   3 review    completed
+    journey_test.go:237:   4 test      completed
+    journey_test.go:237:   5 document  completed
+    journey_test.go:237:   6 lint      completed
+    journey_test.go:237:   7 push      completed
+    journey_test.go:237:   8 pr        skipped
+    journey_test.go:237:   9 ci        skipped
+    journey_test.go:239: rerun outcome: 01KVV4WVCYMRKJG3V50S6TP7RV completed
+--- PASS: TestUserJourney (23.82s)
+    --- PASS: TestUserJourney/codex (23.82s)
+PASS
+ok  	github.com/kunchenguid/no-mistakes/internal/e2e	24.130s

--- a/.no-mistakes/evidence/fm/nm-warts-w4/focused-unit-tests.txt
+++ b/.no-mistakes/evidence/fm/nm-warts-w4/focused-unit-tests.txt
@@ -1,0 +1,48 @@
+=== RUN   TestLoadGlobal_CITimeoutUnlimited
+=== RUN   TestLoadGlobal_CITimeoutUnlimited/keyword
+=== RUN   TestLoadGlobal_CITimeoutUnlimited/keyword_none
+=== RUN   TestLoadGlobal_CITimeoutUnlimited/keyword_mixed_case
+=== RUN   TestLoadGlobal_CITimeoutUnlimited/zero
+=== RUN   TestLoadGlobal_CITimeoutUnlimited/zero_seconds
+=== RUN   TestLoadGlobal_CITimeoutUnlimited/negative
+--- PASS: TestLoadGlobal_CITimeoutUnlimited (0.00s)
+    --- PASS: TestLoadGlobal_CITimeoutUnlimited/keyword (0.00s)
+    --- PASS: TestLoadGlobal_CITimeoutUnlimited/keyword_none (0.00s)
+    --- PASS: TestLoadGlobal_CITimeoutUnlimited/keyword_mixed_case (0.00s)
+    --- PASS: TestLoadGlobal_CITimeoutUnlimited/zero (0.00s)
+    --- PASS: TestLoadGlobal_CITimeoutUnlimited/zero_seconds (0.00s)
+    --- PASS: TestLoadGlobal_CITimeoutUnlimited/negative (0.00s)
+=== RUN   TestDefaultConfigYAML_MatchesGoDefaults
+--- PASS: TestDefaultConfigYAML_MatchesGoDefaults (0.00s)
+PASS
+ok  	github.com/kunchenguid/no-mistakes/internal/config	1.362s
+=== RUN   TestAxiAbortByRunIDNoOpWhenDaemonStopped
+--- PASS: TestAxiAbortByRunIDNoOpWhenDaemonStopped (0.00s)
+PASS
+ok  	github.com/kunchenguid/no-mistakes/internal/cli	1.771s
+=== RUN   TestCIStep_BaseBranchAdvanceRearmsTimeout
+=== PAUSE TestCIStep_BaseBranchAdvanceRearmsTimeout
+=== RUN   TestCIStep_StableBaseStillTimesOut
+=== PAUSE TestCIStep_StableBaseStillTimesOut
+=== RUN   TestCIStep_UnresolvedFallbackBaseTipDoesNotRearmTimeout
+=== PAUSE TestCIStep_UnresolvedFallbackBaseTipDoesNotRearmTimeout
+=== RUN   TestCIStep_ExpiredTimeoutSkipsBaseTipResolver
+=== PAUSE TestCIStep_ExpiredTimeoutSkipsBaseTipResolver
+=== RUN   TestCIStep_BaseTipResolverDeadlineIsBoundedByRemainingTimeout
+=== PAUSE TestCIStep_BaseTipResolverDeadlineIsBoundedByRemainingTimeout
+=== RUN   TestCIStep_UnlimitedTimeoutNeverExpires
+=== PAUSE TestCIStep_UnlimitedTimeoutNeverExpires
+=== CONT  TestCIStep_StableBaseStillTimesOut
+=== CONT  TestCIStep_UnresolvedFallbackBaseTipDoesNotRearmTimeout
+=== CONT  TestCIStep_BaseTipResolverDeadlineIsBoundedByRemainingTimeout
+=== CONT  TestCIStep_UnlimitedTimeoutNeverExpires
+=== CONT  TestCIStep_ExpiredTimeoutSkipsBaseTipResolver
+=== CONT  TestCIStep_BaseBranchAdvanceRearmsTimeout
+--- PASS: TestCIStep_ExpiredTimeoutSkipsBaseTipResolver (4.77s)
+--- PASS: TestCIStep_StableBaseStillTimesOut (5.05s)
+--- PASS: TestCIStep_UnresolvedFallbackBaseTipDoesNotRearmTimeout (8.07s)
+--- PASS: TestCIStep_BaseTipResolverDeadlineIsBoundedByRemainingTimeout (8.14s)
+--- PASS: TestCIStep_UnlimitedTimeoutNeverExpires (8.48s)
+--- PASS: TestCIStep_BaseBranchAdvanceRearmsTimeout (11.69s)
+PASS
+ok  	github.com/kunchenguid/no-mistakes/internal/pipeline/steps	13.233s

--- a/.no-mistakes/evidence/fm/nm-warts-w4/manual-abort-by-run-id-transcript.txt
+++ b/.no-mistakes/evidence/fm/nm-warts-w4/manual-abort-by-run-id-transcript.txt
@@ -1,0 +1,91 @@
+$ go build -o <temp>/bin/no-mistakes ./cmd/no-mistakes
+$ git init local origin and worktree
+
+$ no-mistakes init
+_  _ ____    _  _ _ ____ ___ ____ _  _ ____ ____
+|\ | |  |    |\/| | [__   |  |__| |_/  |___ [__ 
+| \| |__|    |  | | ___]  |  |  | | \_ |___ ___]
+
+  ✓ Gate initialized
+
+    repo  /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/nm-abort-by-run-id.q0mqzZ/work
+    gate  no-mistakes → /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/nm-abort-by-run-id.q0mqzZ/nmhome/repos/2902f1051cf3.git
+  remote  /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//nm-abort-by-run-id.q0mqzZ/origin.git
+   skill  /no-mistakes installed for agents at user level
+
+  Push through the gate with:
+  git push no-mistakes <branch>
+
+$ no-mistakes axi run --skip=review,document,lint,push,pr,ci --intent "exercise abort by run id" &
+
+$ no-mistakes axi  # active run discovered in repo worktree
+bin: /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/nm-abort-by-run-id.q0mqzZ/bin/no-mistakes
+description: "Validate your code changes through the no-mistakes pipeline - automated code review, tests, lint, docs, push, PR, and CI - before they reach the configured push target. Use when the user asks to run no-mistakes, gate or ship or validate their changes, push safely, asks you to do a task and then validate it, or invokes /no-mistakes."
+repo: /private/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/nm-abort-by-run-id.q0mqzZ/work
+current_branch: abort-by-id
+daemon: running
+active_run:
+  id: "01KVV51JGDYEYD811FZKGJDZ66"
+  branch: abort-by-id
+  status: running
+  head: ee14068c
+  findings: none
+  steps[9]{step,status,findings,duration_ms}:
+    intent,completed,0,0
+    rebase,completed,0,103
+    review,skipped,0,0
+    test,running,0,0
+    document,pending,0,0
+    lint,pending,0,0
+    push,pending,0,0
+    pr,pending,0,0
+    ci,pending,0,0
+count: 1 of 1 total
+runs[1]{id,branch,status,head,pr}:
+  "01KVV51JGDYEYD811FZKGJDZ66",abort-by-id,running,ee14068c,""
+help[1]: Run `no-mistakes axi status` to inspect the active run
+
+$ (cd "$HOME" && no-mistakes axi abort --run 01KVV51JGDYEYD811FZKGJDZ66)
+aborted: true
+run: "01KVV51JGDYEYD811FZKGJDZ66"
+
+$ captured output from original axi run after cancellation
+run: running
+  intent: completed
+  rebase: running
+  rebase: completed
+  review: skipped
+  test: running
+run: cancelled
+  test: failed
+run:
+  id: "01KVV51JGDYEYD811FZKGJDZ66"
+  branch: abort-by-id
+  status: cancelled
+  head: ee14068c
+  findings: 1 info
+  steps[9]{step,status,findings,duration_ms}:
+    intent,completed,0,0
+    rebase,completed,0,103
+    review,skipped,0,0
+    test,failed,1,248
+    document,pending,0,0
+    lint,pending,0,0
+    push,pending,0,0
+    pr,pending,0,0
+    ci,pending,0,0
+outcome: cancelled
+error: "cancelled: aborted by user"
+
+$ (cd "$HOME" && no-mistakes axi abort --run nonexistent-run-id)
+aborted: false
+run: nonexistent-run-id
+detail: no active run with that id (no-op)
+
+$ no-mistakes daemon stop
+  ✓ daemon stopped
+
+$ (cd "$HOME" && no-mistakes axi abort --run stopped-daemon-run)
+aborted: false
+run: stopped-daemon-run
+detail: "daemon not running, so no active run to cancel (no-op)"

--- a/.no-mistakes/evidence/fm/nm-warts-w4/manual-abort-by-run-id-transcript.txt
+++ b/.no-mistakes/evidence/fm/nm-warts-w4/manual-abort-by-run-id-transcript.txt
@@ -3,7 +3,7 @@ $ git init local origin and worktree
 
 $ no-mistakes init
 _  _ ____    _  _ _ ____ ___ ____ _  _ ____ ____
-|\ | |  |    |\/| | [__   |  |__| |_/  |___ [__ 
+|\ | |  |    |\/| | [__   |  |__| |_/  |___ [__
 | \| |__|    |  | | ___]  |  |  | | \_ |___ ___]
 
   ✓ Gate initialized

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,13 @@ Safest local verification sequence after non-trivial changes:
 - `allow_repo_commands` is **per-repo, read from the trusted default-branch copy of `.no-mistakes.yaml`** (declared on `RepoConfig`), never the global config and never the pushed SHA. It defaults `false`; when `true` the maintainer has opted in to honoring the pushed branch's `commands` and `agent` wholesale. A contributor cannot self-enable it from a pushed branch. When changing this logic, keep `commands`/`agent` locked to the default branch and update the e2e test `TestRepoConfigCommandsFromDefaultBranch` (incl. the `pushed_branch_cannot_self_enable` subtest).
 - The e2e harness models a trusted single-developer environment, so it commits `allow_repo_commands: true` to the default-branch `.no-mistakes.yaml` via `SetupOpts.AllowRepoCommands`; security tests pass `false` to exercise the secure default.
 
+**CI Monitor Lifecycle**
+
+- The CI step (`internal/pipeline/steps/ci.go`) babysits an open PR until it is merged, closed, the run is cancelled, or `ci_timeout` elapses. It auto-fixes failing checks and rebases on merge conflicts via `autoFixCI`.
+- `ci_timeout` is an **idle timeout, not an absolute deadline**: it re-arms (`timeoutAnchor = now()`) every time the upstream default-branch tip advances, so an actively-rebased green PR keeps its monitor no matter how long it stays open. `started` stays fixed for poll-interval/grace-period pacing; only `timeoutAnchor` moves. Re-arm only ever extends the deadline, so a transient base-tip resolution failure is fail-safe. `baseBranchTip` is injectable for tests.
+- `config.CITimeout` semantics: `>0` finite, `0` = unset (step falls back to `config.DefaultCITimeout`, 7 days), `<0` = `config.CITimeoutUnlimited` (never self-terminate). Config keyword `ci_timeout: "unlimited"` (also `none`/`off`/`never`) or any non-positive duration resolves to the unlimited sentinel via `parseCITimeout`. Keep `config.DefaultCITimeout` and the `defaultConfigYAML` `ci_timeout` value in sync (`TestDefaultConfigYAML_MatchesGoDefaults`).
+- Reap a run by id from outside its worktree with `no-mistakes axi abort --run <id>` (`runAxiAbortByRunID`). It needs only `NM_HOME` + the daemon, not a repo/branch/worktree, because `ipc.MethodCancelRun` → `RunManager.HandleCancel` only cancels runs live in daemon memory. An unknown/inactive id, or a stopped daemon, is an idempotent no-op (`aborted: false`), not an error. This is how an orphaned monitor (worktree torn down before merge) gets reaped deterministically. Bare `axi abort` (no `--run`) stays worktree/branch-scoped.
+
 **When Making Changes**
 
 - Whenever you must bring in new dependencies, check latest documentation for knowledge, and discuss with the user.

--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -58,7 +58,7 @@ That is a core design choice, not an implementation detail.
 6. If a step pauses, you can attach with the TUI or use `no-mistakes axi respond` to approve, fix, skip, or abort.
 7. After local checks pass, the push step forwards the branch to the configured push target and the PR step creates or updates the pull request.
    For GitHub fork routing, the push target is the fork and the PR base repository is the parent from `origin`.
-8. The CI step keeps watching the open PR until it is merged or closed, and can auto-fix failures or merge conflicts when supported.
+8. The CI step keeps watching the open PR until it is merged, closed, or its configured idle timeout elapses with no base-branch movement, and can auto-fix failures or merge conflicts when supported.
    While it watches, the TUI and terminal title surface a `Checks passed` signal once checks are green and the PR is mergeable, and `no-mistakes axi` returns `outcome: checks-passed` with instructions to summarize the run and list any pipeline fixes, so agents stop and ask you to review and merge it.
 
 **Key design decisions:**

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -112,11 +112,13 @@ no-mistakes axi status
 no-mistakes axi respond --action approve
 no-mistakes axi logs --step review --full
 no-mistakes axi abort
+no-mistakes axi abort --run <id>
 ```
 
 Before starting validation, agents should run the `no-mistakes axi` home view.
 If it shows `active_run`, they should resume or abort that current-branch run instead of starting over.
 If it shows `other_branch_active_run`, they should leave that run alone and start validation for the current branch with `no-mistakes axi run --intent "..."`.
+Use `no-mistakes axi abort --run <id>` only when you need to cancel a specific active run by id from outside its worktree.
 
 When an agent starts a new run, `--intent` is required and should describe what the user wanted to accomplish, not what files changed.
 Agents should prefer a few complete sentences over a terse summary, capturing user decisions, tradeoffs, constraints, ruled-out approaches, and explicit requests that would not be obvious from the diff alone.

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -73,8 +73,11 @@ agent_args_override:
     - gpt-5.4
     - --full-auto
 
-# How long the CI step monitors an open PR, including provider CI status and GitHub/GitLab PR mergeability, before timing out.
-ci_timeout: "4h"  # any Go duration string
+# How long the CI step monitors an open PR (provider CI status plus GitHub/GitLab
+# mergeability) with no base-branch movement before giving up. Each base-branch
+# advance re-arms the timer, so an actively-updated green PR keeps its monitor.
+# Use "unlimited" (or 0) to monitor until the PR is merged, closed, or aborted.
+ci_timeout: "168h"  # any Go duration string, or "unlimited"
 
 # Daemon log verbosity.
 log_level: info  # debug | info | warn | error

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -76,8 +76,9 @@ agent_args_override:
 # How long the CI step monitors an open PR (provider CI status plus GitHub/GitLab
 # mergeability) with no base-branch movement before giving up. Each base-branch
 # advance re-arms the timer, so an actively-updated green PR keeps its monitor.
-# Use "unlimited" (or 0) to monitor until the PR is merged, closed, or aborted.
-ci_timeout: "168h"  # any Go duration string, or "unlimited"
+# Use "unlimited" (or aliases "none", "off", "never", or any non-positive
+# duration) to monitor until the PR is merged, closed, or aborted.
+ci_timeout: "168h"  # any Go duration string, or an unlimited keyword
 
 # Daemon log verbosity.
 log_level: info  # debug | info | warn | error

--- a/docs/src/content/docs/guides/provider-integration.md
+++ b/docs/src/content/docs/guides/provider-integration.md
@@ -37,7 +37,7 @@ Once the host is wired up, `no-mistakes` can keep owning the branch after it
 pushes to the configured target:
 
 - create or update the PR automatically
-- keep polling hosted CI until the PR is merged, closed, declined, or times out
+- keep polling hosted CI until the PR is merged, closed, declined, or the configured `ci_timeout` idle window elapses
 - fetch failing job logs for the CI auto-fix loop
 - on GitHub and GitLab, watch mergeability and fix merge conflicts when possible
 
@@ -67,7 +67,7 @@ For PR and workflow-run commands, no-mistakes passes the repository slug from th
 **What you get:**
 
 - PR creation and update on pushes
-- CI check polling with exponential backoff (30s → 60s → 120s) until the PR is merged, closed, or times out
+- CI check polling with exponential backoff (30s → 60s → 120s) until the PR is merged, closed, or the configured `ci_timeout` idle window elapses
 - Failed job log fetching (`gh run view --log-failed`) for the CI auto-fix step
 - PR mergeability polling, and agent-driven merge-conflict resolution when the branch falls behind
 
@@ -105,7 +105,7 @@ glab auth login
 **What you get:**
 
 - PR (merge request) creation and update
-- CI pipeline status polling until the merge request is merged, closed, or times out
+- CI pipeline status polling until the merge request is merged, closed, or the configured `ci_timeout` idle window elapses
 - Failed job trace fetching (`glab ci trace`) for the CI auto-fix step
 - Merge-conflict polling and auto-fix, same as GitHub
 
@@ -126,7 +126,7 @@ Get an API token from [Bitbucket account settings](https://bitbucket.org/account
 **What you get:**
 
 - PR creation and update
-- CI pipeline status polling until the PR is merged, declined, or times out
+- CI pipeline status polling until the PR is merged, declined, or the configured `ci_timeout` idle window elapses
 - Failed pipeline step log fetching for the CI auto-fix step
 
 **What you don't get (yet):**

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -180,13 +180,24 @@ Check the [Provider Integration](/no-mistakes/guides/provider-integration/) requ
 
 ## CI step stuck or timed out
 
-Symptom: CI step runs for 4 hours and pauses for approval.
+Symptom: CI step keeps monitoring an open PR longer than expected, or pauses after the idle timeout.
 
-`ci_timeout` defaults to `4h`. Raise it in `~/.no-mistakes/config.yaml`:
+`ci_timeout` defaults to `168h` (7 days) and is an idle timeout.
+It re-arms whenever the upstream default branch advances, so an active long-lived PR keeps being watched and rebased.
+Set it in `~/.no-mistakes/config.yaml` to choose a different idle window:
 
 ```yaml
-ci_timeout: "8h"
+ci_timeout: "24h"
 ```
+
+Set it to `unlimited` to monitor until the PR is merged, closed, or aborted:
+
+```yaml
+ci_timeout: "unlimited"
+```
+
+Older config files may still contain an explicit `ci_timeout: "4h"` value.
+Update that value if you want the newer default behavior.
 
 The CI step keeps monitoring while the PR remains open, even after checks are currently healthy, because a later default-branch update can make the PR conflict or rerun CI.
 Once checks are green and the PR is mergeable, the CI panel shows `✓ Checks passed` and the terminal title switches to `Checks passed`, so you can tell when to go merge the PR.

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -196,6 +196,8 @@ Set it to `unlimited` to monitor until the PR is merged, closed, or aborted:
 ci_timeout: "unlimited"
 ```
 
+`none`, `off`, `never`, `0`, and other non-positive durations are accepted too.
+
 Older config files may still contain an explicit `ci_timeout: "4h"` value.
 Update that value if you want the newer default behavior.
 

--- a/docs/src/content/docs/guides/tui.md
+++ b/docs/src/content/docs/guides/tui.md
@@ -129,6 +129,7 @@ While the CI step is active, the TUI shows a dedicated CI panel instead of the g
 It shows the PR label, the latest CI activity, and a log tail.
 When a real CI auto-fix attempt starts, the panel increments `CI auto-fixes: N`.
 Once checks are green and known mergeability is clear, the panel shows `✓ Checks passed` with `still monitoring until merged or closed`, and the terminal title switches to `Checks passed`.
+That text means the CI monitor is still active; it can still pause later if the configured idle timeout elapses with no base-branch movement.
 That ready signal clears if checks start running again, new failures appear, provider state becomes uncertain, or the PR is merged or closed.
 
 ### Footer

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -162,6 +162,16 @@ no-mistakes axi abort
 
 If there is no active run, this succeeds as a no-op.
 
+Pass `--run <id>` to cancel a specific run by its id instead of resolving the current branch:
+
+```sh
+no-mistakes axi abort --run <id>
+```
+
+`--run` does not need a repo, branch, or worktree, so it works from anywhere.
+Use it to reap an orphaned CI monitor whose worktree was torn down before the PR merged - the run id is shown in `axi run` output and in the `axi` home view.
+Aborting an id that is not an active run is a successful no-op.
+
 ## no-mistakes eject
 
 Remove the gate from the current repository.

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -28,7 +28,7 @@ agent_args_override:
     - gpt-5.4
     - --full-auto
 
-ci_timeout: "4h"
+ci_timeout: "168h"
 
 log_level: info
 
@@ -173,14 +173,19 @@ agent_args_override:
 
 ### ci_timeout
 
-How long the CI step monitors an open PR, including provider CI status and on GitHub or GitLab PR mergeability, before timing out.
+How long the CI step monitors an open PR, including provider CI status and on GitHub or GitLab PR mergeability, before giving up.
 
 | | |
 |---|---|
-| Type | `string` (Go duration) |
-| Default | `4h` |
+| Type | `string` (Go duration, or `unlimited`) |
+| Default | `168h` (7 days) |
 
 Accepts any Go `time.ParseDuration` string: `30m`, `2h`, `4h30m`, etc.
+
+This is an idle timeout, not an absolute deadline: every time the base branch advances, the monitor re-arms it.
+So an actively-updated green PR keeps its monitor (and keeps getting rebased) no matter how long it stays open, while a genuinely idle/abandoned PR is still reaped after the timeout elapses.
+
+Set it to `unlimited` (or `0`, or any non-positive duration) to monitor until the PR is merged, closed, or the run is aborted with `no-mistakes axi abort --run <id>`.
 
 Legacy alias: `babysit_timeout`.
 

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -177,7 +177,7 @@ How long the CI step monitors an open PR, including provider CI status and on Gi
 
 | | |
 |---|---|
-| Type | `string` (Go duration, or `unlimited`) |
+| Type | `string` (Go duration, or an unlimited keyword) |
 | Default | `168h` (7 days) |
 
 Accepts any Go `time.ParseDuration` string: `30m`, `2h`, `4h30m`, etc.
@@ -185,7 +185,7 @@ Accepts any Go `time.ParseDuration` string: `30m`, `2h`, `4h30m`, etc.
 This is an idle timeout, not an absolute deadline: every time the base branch advances, the monitor re-arms it.
 So an actively-updated green PR keeps its monitor (and keeps getting rebased) no matter how long it stays open, while a genuinely idle/abandoned PR is still reaped after the timeout elapses.
 
-Set it to `unlimited` (or `0`, or any non-positive duration) to monitor until the PR is merged, closed, or the run is aborted with `no-mistakes axi abort --run <id>`.
+Set it to `unlimited` (`none`, `off`, and `never` are accepted aliases), `0`, or any non-positive duration to monitor until the PR is merged, closed, or the run is aborted with `no-mistakes axi abort --run <id>`.
 
 Legacy alias: `babysit_timeout`.
 

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -175,7 +175,8 @@ Monitors PR health after creation and auto-fixes CI failures. Mergeability polli
 
 **Behavior:**
 - Polls provider CI status at increasing intervals: every 30s for the first 5 minutes, every 60s for 5-15 minutes, every 120s after that
-- Continues monitoring an open PR until it is merged, closed, declined, or times out, even after CI checks are currently healthy
+- Continues monitoring an open PR until it is merged, closed, declined, or the configured `ci_timeout` idle window elapses, even after CI checks are currently healthy
+- Treats `ci_timeout` as an idle timeout: each upstream default-branch advance re-arms the timer, and `ci_timeout: "unlimited"` disables self-termination
 - On GitHub and GitLab, polls provider mergeability alongside CI checks while the PR remains open
 - While the PR stays open, the TUI and terminal title show `Checks passed` once checks are green and known mergeability is clear, and `no-mistakes axi` returns `outcome: checks-passed` with successful-output reporting instructions so agents can summarize the run, ask the user to review and merge, and list any pipeline fixes instead of waiting
 - The ready signal clears if checks start running again, new failures appear, provider state becomes uncertain, or the PR is merged, closed, or declined
@@ -187,9 +188,9 @@ Monitors PR health after creation and auto-fixes CI failures. Mergeability polli
 - If a fix attempt produces no changes: automatic mode leaves the failure undeduplicated so it can retry until the auto-fix limit, while manual fix mode returns immediately for manual intervention
 - Deduplicates fix attempts only after a fix is actually committed and pushed
 - Exits cleanly when the PR is merged, closed, or declined
-- If the timeout is reached while the PR is still open: pauses for user approval, even when CI checks are currently healthy
-- If the timeout is reached while CI failures or, on GitHub or GitLab, a merge conflict are still known: pauses for user approval with findings for the remaining issues
-- If the timeout is reached while GitHub or GitLab PR mergeability is still unresolved: pauses for user approval with a finding describing the unresolved mergeability state
+- If the idle timeout is reached while the PR is still open: pauses for user approval, even when CI checks are currently healthy
+- If the idle timeout is reached while CI failures or, on GitHub or GitLab, a merge conflict are still known: pauses for user approval with findings for the remaining issues
+- If the idle timeout is reached while GitHub or GitLab PR mergeability is still unresolved: pauses for user approval with a finding describing the unresolved mergeability state
 - If CI failures or a GitHub or GitLab merge conflict persist after the auto-fix limit: pauses for user approval with findings listing each failing check and/or the merge conflict
 
 **Default auto-fix limit:** `3` total CI auto-fix attempts.

--- a/internal/cimonitor/cimonitor.go
+++ b/internal/cimonitor/cimonitor.go
@@ -15,10 +15,12 @@ import "strings"
 // consumers must reference these constants rather than spelling out literals.
 const (
 	// ChecksPassedMsg is logged when every CI check has passed but the PR is
-	// not yet merged or closed, so the monitor keeps watching.
+	// not yet merged or closed, so the monitor keeps watching subject to its
+	// configured timeout.
 	ChecksPassedMsg = "all CI checks passed - still monitoring until merged or closed"
 	// NoChecksPassedMsg is logged when the PR reports no CI checks at all and
-	// the monitor keeps watching for a merge or close.
+	// the monitor keeps watching for a merge or close, subject to its
+	// configured timeout.
 	NoChecksPassedMsg = "no CI checks reported - still monitoring until merged or closed"
 	// ChecksRunningMsg is logged when checks are (re-)running with no failures
 	// yet, which clears any previous passed-checks state.

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -12,6 +12,7 @@ import (
 	toon "github.com/toon-format/toon-go"
 
 	"github.com/kunchenguid/no-mistakes/internal/cimonitor"
+	"github.com/kunchenguid/no-mistakes/internal/daemon"
 	"github.com/kunchenguid/no-mistakes/internal/gate"
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
@@ -680,22 +681,32 @@ func gateStatusFor(rv runView, step string) string {
 }
 
 func newAxiAbortCmd() *cobra.Command {
+	var runID string
 	cmd := &cobra.Command{
-		Use:           "abort",
-		Short:         "Cancel the active pipeline run",
+		Use:   "abort",
+		Short: "Cancel the active pipeline run",
+		Long: "Cancel a pipeline run. With no flags, cancels the active run on the\n" +
+			"current branch. Pass --run <id> to cancel a specific run by its id from\n" +
+			"anywhere - including outside its worktree - so an orphaned CI monitor\n" +
+			"(e.g. after a worktree was torn down) can be reaped deterministically.",
 		Args:          cobra.NoArgs,
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return trackAxiSurface("axi-abort", "/axi/abort", nil, func() error {
-				return runAxiAbort(cmd)
+				return runAxiAbort(cmd, strings.TrimSpace(runID))
 			})
 		},
 	}
+	cmd.Flags().StringVar(&runID, "run", "", "cancel this run id directly, without resolving the current branch or worktree")
 	return cmd
 }
 
-func runAxiAbort(cmd *cobra.Command) error {
+func runAxiAbort(cmd *cobra.Command, runID string) error {
+	if runID != "" {
+		return runAxiAbortByRunID(cmd, runID)
+	}
+
 	ctx := cmd.Context()
 	env, err := openAxiEnv(true)
 	if err != nil {
@@ -729,6 +740,57 @@ func runAxiAbort(cmd *cobra.Command) error {
 		toon.Field{Key: "aborted", Value: true},
 		toon.Field{Key: "run", Value: active.Run.ID},
 		toon.Field{Key: "branch", Value: active.Run.Branch},
+	)
+	return nil
+}
+
+// runAxiAbortByRunID cancels a run by its id directly via the daemon, without
+// resolving a repo, branch, or worktree. This is how an orphaned monitor run -
+// one whose worktree was torn down before the PR merged - gets reaped from
+// outside. A run lives only in the running daemon's memory, so if the daemon is
+// not running, or the id is not an active run, there is nothing to cancel and
+// we report a successful no-op (the desired end state is already reached).
+func runAxiAbortByRunID(cmd *cobra.Command, runID string) error {
+	p, err := paths.New()
+	if err != nil {
+		return emitError(cmd, 1, fmt.Sprintf("resolve paths: %v", err))
+	}
+	if err := p.EnsureDirs(); err != nil {
+		return emitError(cmd, 1, fmt.Sprintf("create directories: %v", err))
+	}
+
+	if alive, _ := daemon.IsRunning(p); !alive {
+		emitDoc(cmd,
+			toon.Field{Key: "aborted", Value: false},
+			toon.Field{Key: "run", Value: runID},
+			toon.Field{Key: "detail", Value: "daemon not running, so no active run to cancel (no-op)"},
+		)
+		return nil
+	}
+
+	client, err := ipc.Dial(p.Socket())
+	if err != nil {
+		return emitError(cmd, 1, fmt.Sprintf("connect to daemon: %v", err))
+	}
+	defer client.Close()
+
+	var result ipc.CancelRunResult
+	if err := client.Call(ipc.MethodCancelRun, &ipc.CancelRunParams{RunID: runID}, &result); err != nil {
+		// The daemon reports an unknown/inactive run id as "no active run
+		// <id>". Treat that as an idempotent no-op: the run is already gone.
+		if strings.Contains(err.Error(), "no active run") {
+			emitDoc(cmd,
+				toon.Field{Key: "aborted", Value: false},
+				toon.Field{Key: "run", Value: runID},
+				toon.Field{Key: "detail", Value: "no active run with that id (no-op)"},
+			)
+			return nil
+		}
+		return emitError(cmd, 1, fmt.Sprintf("abort run: %v", err))
+	}
+	emitDoc(cmd,
+		toon.Field{Key: "aborted", Value: true},
+		toon.Field{Key: "run", Value: runID},
 	)
 	return nil
 }

--- a/internal/cli/axi_test.go
+++ b/internal/cli/axi_test.go
@@ -346,6 +346,29 @@ func TestAxiHomeStartsCurrentBranchWhenOtherBranchIsActive(t *testing.T) {
 	}
 }
 
+// TestAxiAbortByRunIDNoOpWhenDaemonStopped covers the abort-by-id path when no
+// daemon is running: a run only exists in a live daemon's memory, so there is
+// nothing to cancel and the command reports a successful no-op without needing
+// a repo or worktree.
+func TestAxiAbortByRunIDNoOpWhenDaemonStopped(t *testing.T) {
+	nmHome := t.TempDir()
+	t.Setenv("NM_HOME", nmHome)
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&out)
+	if err := runAxiAbortByRunID(cmd, "some-run-id"); err != nil {
+		t.Fatalf("abort by id: %v\n%s", err, out.String())
+	}
+	got := out.String()
+	for _, want := range []string{"aborted: false", "run: some-run-id", "daemon not running"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q in abort output, got:\n%s", want, got)
+		}
+	}
+}
+
 func TestResolveRunPrefersCurrentBranchLatestRun(t *testing.T) {
 	database := openTestDB(t)
 	repo, err := database.InsertRepo(t.TempDir(), "origin", "main")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,8 +31,9 @@ const (
 	// DefaultCITimeout is the monitor's idle timeout when ci_timeout is unset.
 	DefaultCITimeout = 7 * 24 * time.Hour
 	// CITimeoutUnlimited is the sentinel meaning "monitor until the PR is
-	// merged, closed, or the run is aborted - never self-terminate". Any
-	// non-positive ci_timeout, or the keyword "unlimited", resolves to this.
+	// merged, closed, or the run is aborted - never self-terminate".
+	// Any non-positive ci_timeout, or the keywords "unlimited", "none",
+	// "off", and "never", resolves to this.
 	CITimeoutUnlimited = time.Duration(-1)
 )
 
@@ -190,8 +191,9 @@ agent: auto
 # Maximum time the CI monitor babysits an open PR with no base-branch movement
 # before giving up. The monitor watches CI and auto-rebases when the base branch
 # advances; each base advance re-arms this timer, so an actively-updated green PR
-# keeps its monitor. Set to "unlimited" (or 0) to monitor until the PR is merged,
-# closed, or the run is aborted with: no-mistakes axi abort --run <id>
+# keeps its monitor. Set to "unlimited", "none", "off", "never", or any
+# non-positive duration to monitor until the PR is merged, closed, or the run is
+# aborted with: no-mistakes axi abort --run <id>
 ci_timeout: "168h"
 
 # Log level for daemon output

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,25 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// CI monitor timeout constants.
+//
+// CITimeout is interpreted by the CI step as the maximum time to babysit an
+// open PR with no base-branch movement before giving up. The monitor re-arms
+// this timer every time the base branch advances (see internal/pipeline/steps
+// ci.go), so an actively-rebased PR keeps its monitor. The value is
+// deliberately long because a green PR can legitimately wait days on a
+// dependency PR or on review; a torn-down or abandoned run is reaped
+// explicitly via `no-mistakes axi abort --run <id>` rather than by a short
+// timeout.
+const (
+	// DefaultCITimeout is the monitor's idle timeout when ci_timeout is unset.
+	DefaultCITimeout = 7 * 24 * time.Hour
+	// CITimeoutUnlimited is the sentinel meaning "monitor until the PR is
+	// merged, closed, or the run is aborted - never self-terminate". Any
+	// non-positive ci_timeout, or the keyword "unlimited", resolves to this.
+	CITimeoutUnlimited = time.Duration(-1)
+)
+
 // GlobalConfig represents ~/.no-mistakes/config.yaml.
 type GlobalConfig struct {
 	Agent                types.AgentName     `yaml:"agent"`
@@ -168,8 +187,12 @@ agent: auto
 # acp_registry_overrides:
 #   local-gemini: node /opt/mock-acp-agent.mjs
 
-# Maximum time to monitor CI before timing out
-ci_timeout: "4h"
+# Maximum time the CI monitor babysits an open PR with no base-branch movement
+# before giving up. The monitor watches CI and auto-rebases when the base branch
+# advances; each base advance re-arms this timer, so an actively-updated green PR
+# keeps its monitor. Set to "unlimited" (or 0) to monitor until the PR is merged,
+# closed, or the run is aborted with: no-mistakes axi abort --run <id>
+ci_timeout: "168h"
 
 # Log level for daemon output
 # Options: debug, info, warn, error
@@ -433,7 +456,7 @@ func EnsureDefaultGlobalConfig(path string) {
 func LoadGlobal(path string) (*GlobalConfig, error) {
 	cfg := &GlobalConfig{
 		Agent:     types.AgentAuto,
-		CITimeout: 4 * time.Hour,
+		CITimeout: DefaultCITimeout,
 		LogLevel:  "info",
 	}
 
@@ -475,9 +498,9 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 		timeoutValue = raw.BabysitTimeout
 	}
 	if timeoutValue != "" {
-		d, err := time.ParseDuration(timeoutValue)
+		d, err := parseCITimeout(timeoutValue)
 		if err != nil {
-			return nil, fmt.Errorf("parse ci_timeout %q: %w", timeoutValue, err)
+			return nil, err
 		}
 		cfg.CITimeout = d
 	}
@@ -492,6 +515,25 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 	cfg.Test = raw.Test
 
 	return cfg, nil
+}
+
+// parseCITimeout interprets the ci_timeout config value. The keyword
+// "unlimited" (also "none"/"off"/"never"), or any non-positive duration,
+// resolves to CITimeoutUnlimited so the monitor never self-terminates;
+// otherwise the value is parsed as a Go duration.
+func parseCITimeout(value string) (time.Duration, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "unlimited", "none", "off", "never":
+		return CITimeoutUnlimited, nil
+	}
+	d, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("parse ci_timeout %q: %w", value, err)
+	}
+	if d <= 0 {
+		return CITimeoutUnlimited, nil
+	}
+	return d, nil
 }
 
 // LoadRepo reads per-repo config from dir/.no-mistakes.yaml.

--- a/internal/config/config_global_test.go
+++ b/internal/config/config_global_test.go
@@ -20,8 +20,8 @@ func TestLoadGlobal_Defaults(t *testing.T) {
 	if cfg.Agent != types.AgentAuto {
 		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentAuto)
 	}
-	if cfg.CITimeout != 4*time.Hour {
-		t.Errorf("ci_timeout = %v, want %v", cfg.CITimeout, 4*time.Hour)
+	if cfg.CITimeout != DefaultCITimeout {
+		t.Errorf("ci_timeout = %v, want %v", cfg.CITimeout, DefaultCITimeout)
 	}
 	if cfg.LogLevel != "info" {
 		t.Errorf("log_level = %q, want %q", cfg.LogLevel, "info")
@@ -67,8 +67,8 @@ func TestEnsureDefaultGlobalConfig_CreatedConfigIsLoadable(t *testing.T) {
 	if cfg.Agent != types.AgentAuto {
 		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentAuto)
 	}
-	if cfg.CITimeout != 4*time.Hour {
-		t.Errorf("ci_timeout = %v, want %v", cfg.CITimeout, 4*time.Hour)
+	if cfg.CITimeout != DefaultCITimeout {
+		t.Errorf("ci_timeout = %v, want %v", cfg.CITimeout, DefaultCITimeout)
 	}
 	if cfg.LogLevel != "info" {
 		t.Errorf("log_level = %q, want %q", cfg.LogLevel, "info")
@@ -194,8 +194,8 @@ func TestLoadGlobal_PartialOverride(t *testing.T) {
 	if cfg.Agent != types.AgentOpenCode {
 		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentOpenCode)
 	}
-	if cfg.CITimeout != 4*time.Hour {
-		t.Errorf("ci_timeout = %v, want %v (should be default)", cfg.CITimeout, 4*time.Hour)
+	if cfg.CITimeout != DefaultCITimeout {
+		t.Errorf("ci_timeout = %v, want %v (should be default)", cfg.CITimeout, DefaultCITimeout)
 	}
 	if cfg.LogLevel != "info" {
 		t.Errorf("log_level = %q, want %q (should be default)", cfg.LogLevel, "info")
@@ -225,6 +225,36 @@ func TestLoadGlobal_InvalidDuration(t *testing.T) {
 	_, err := LoadGlobal(path)
 	if err == nil {
 		t.Fatal("expected error for invalid duration")
+	}
+}
+
+func TestLoadGlobal_CITimeoutUnlimited(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+	}{
+		{"keyword", `ci_timeout: "unlimited"`},
+		{"keyword_none", `ci_timeout: "none"`},
+		{"keyword_mixed_case", `ci_timeout: "Unlimited"`},
+		{"zero", `ci_timeout: "0"`},
+		{"zero_seconds", `ci_timeout: "0s"`},
+		{"negative", `ci_timeout: "-5m"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "config.yaml")
+			if err := os.WriteFile(path, []byte(tc.value), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := LoadGlobal(path)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg.CITimeout != CITimeoutUnlimited {
+				t.Fatalf("ci_timeout = %v, want CITimeoutUnlimited (%v)", cfg.CITimeout, CITimeoutUnlimited)
+			}
+		})
 	}
 }
 
@@ -276,8 +306,8 @@ func TestDefaultConfigYAML_MatchesGoDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("YAML ci_timeout %q is not a valid duration: %v", raw.CITimeout, err)
 	}
-	if d != 4*time.Hour {
-		t.Errorf("YAML ci_timeout = %v, Go default = %v", d, 4*time.Hour)
+	if d != DefaultCITimeout {
+		t.Errorf("YAML ci_timeout = %v, Go default = %v", d, DefaultCITimeout)
 	}
 	if raw.LogLevel != "info" {
 		t.Errorf("YAML log_level = %q, Go default = %q", raw.LogLevel, "info")

--- a/internal/e2e/harness.go
+++ b/internal/e2e/harness.go
@@ -81,7 +81,11 @@ func NewHarness(t *testing.T, opts SetupOpts) *Harness {
 
 	nmBin, fakeBin := buildBinaries(t)
 
-	root := t.TempDir()
+	root, err := os.MkdirTemp("", "nm-e2e-*")
+	if err != nil {
+		t.Fatalf("mkdir e2e root: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
 	h := &Harness{
 		t:                 t,
 		NMBin:             nmBin,
@@ -130,11 +134,11 @@ func NewHarness(t *testing.T, opts SetupOpts) *Harness {
 	// the directory contains <agent>/structured.{jsonl,*}, the fake
 	// replays those bytes verbatim instead of generating synthetic
 	// output. This is what makes the e2e a real wire-format check.
-	root, err := defaultFixtureRoot()
+	fixtureRoot, err := defaultFixtureRoot()
 	if err != nil {
 		t.Fatalf("fixture root: %v", err)
 	}
-	t.Setenv("FAKEAGENT_FIXTURE", root)
+	t.Setenv("FAKEAGENT_FIXTURE", fixtureRoot)
 	// Skip launchd/systemd/schtasks installation in the daemon. Without
 	// this the daemon would touch the developer's real launch agents.
 	t.Setenv("NM_TEST_START_DAEMON", "1")

--- a/internal/e2e/journey_test.go
+++ b/internal/e2e/journey_test.go
@@ -203,6 +203,7 @@ func runHappyPath(t *testing.T, agentName string) {
 	assertConfiguredCommandRun(t, h)
 	assertSupersededRunCancellation(t, h)
 	assertCancelRunStopsActivePipeline(t, h)
+	assertAbortByRunIDReapsRunFromOutsideWorktree(t, h)
 	assertRespondNoWaitingStepRun(t, h)
 	assertFailingTestCommandRun(t, h)
 	assertFailingLintCommandRun(t, h)
@@ -1955,6 +1956,46 @@ func assertCancelRunStopsActivePipeline(t *testing.T, h *Harness) {
 	cancelled := waitForRunIDStatus(t, h, run.ID, types.RunCancelled, 60*time.Second)
 	if cancelled.Error == nil || !strings.Contains(*cancelled.Error, "aborted by user") {
 		t.Fatalf("expected cancelled run error to mention aborted by user, got %q", deref(cancelled.Error))
+	}
+}
+
+// assertAbortByRunIDReapsRunFromOutsideWorktree verifies `axi abort --run <id>`
+// cancels a specific run from outside its worktree (the orphaned-monitor reap
+// path), and that aborting an unknown id is an idempotent no-op rather than an
+// error.
+func assertAbortByRunIDReapsRunFromOutsideWorktree(t *testing.T, h *Harness) {
+	t.Helper()
+	slowCommand := filepath.Join(h.BinDir, "nm-abort-byid-test-e2e")
+	if err := os.WriteFile(slowCommand, []byte("#!/bin/sh\nsleep 10\n"), 0o755); err != nil {
+		t.Fatalf("write abort-by-id slow test command: %v", err)
+	}
+	config := "ignore_patterns:\n  - '*.generated.go'\n  - 'vendor/**'\ncommands:\n  test: nm-abort-byid-test-e2e\n  lint: true\n"
+	h.CommitChange("abort-by-id", ".no-mistakes.yaml", config, "configure abort-by-id slow test")
+	h.PushToGate("abort-by-id")
+	run := waitForStepStatus(t, h, "abort-by-id", types.StepTest, types.StepStatusRunning, 60*time.Second)
+
+	// Reap the run by id from a directory that is not the repo worktree, with no
+	// branch context - the way an external supervisor cancels an orphaned run.
+	out, err := h.RunInDir(h.HomeDir, "axi", "abort", "--run", run.ID)
+	if err != nil {
+		t.Fatalf("axi abort --run %s from outside worktree failed: %v\n%s", run.ID, err, out)
+	}
+	if !strings.Contains(out, "aborted: true") || !strings.Contains(out, run.ID) {
+		t.Fatalf("expected abort-by-id to confirm cancellation of %s, got:\n%s", run.ID, out)
+	}
+
+	cancelled := waitForRunIDStatus(t, h, run.ID, types.RunCancelled, 60*time.Second)
+	if cancelled.Error == nil || !strings.Contains(*cancelled.Error, "aborted by user") {
+		t.Fatalf("expected abort-by-id cancellation error to mention aborted by user, got %q", deref(cancelled.Error))
+	}
+
+	// Aborting an unknown id is a successful no-op, not an error.
+	out, err = h.RunInDir(h.HomeDir, "axi", "abort", "--run", "nonexistent-run-id")
+	if err != nil {
+		t.Fatalf("axi abort --run of an unknown id should be a no-op, got error: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "aborted: false") {
+		t.Fatalf("expected unknown-id abort to report a no-op, got:\n%s", out)
 	}
 }
 

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -14,7 +14,10 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
-const defaultChecksGracePeriod = 60 * time.Second
+const (
+	defaultChecksGracePeriod          = 60 * time.Second
+	defaultBaseBranchTipResolveWindow = 30 * time.Second
+)
 
 // CI monitoring status messages. These are surfaced to the user and parsed by
 // the TUI and the agent-facing axi commands to distinguish passed checks from
@@ -129,10 +132,24 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 	timeoutFailingChecks := []string{}
 	timeoutMergeConflict := false
 	lastMonitorLog := ""
+	timeoutOutcome := func() (*pipeline.StepOutcome, error) {
+		sctx.Log("CI timeout reached")
+		if len(timeoutFailingChecks) > 0 || timeoutMergeConflict {
+			return ciFailureOutcome(timeoutFailingChecks, timeoutMergeConflict, "CI timed out with known failures still present"), nil
+		}
+		if mergeabilityBlockedReason != "" {
+			return ciMergeabilityOutcome("mergeability check timed out", mergeabilityBlockedReason), nil
+		}
+		return ciMonitoringTimeoutOutcome(), nil
+	}
 
 	for {
 		if err := ctx.Err(); err != nil {
 			return nil, err
+		}
+
+		if !unlimited && now().Sub(timeoutAnchor) >= timeout {
+			return timeoutOutcome()
 		}
 
 		// Re-arm the timeout whenever the base branch advances. A green PR can
@@ -143,7 +160,16 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 		// returns a fallback SHA is harmless. Skipped when unlimited, since
 		// there is no deadline to re-arm.
 		if !unlimited {
-			if tip := baseBranchTip(ctx); tip != "" {
+			resolveWindow := defaultBaseBranchTipResolveWindow
+			if remaining := timeout - now().Sub(timeoutAnchor); remaining <= 0 {
+				return timeoutOutcome()
+			} else if remaining < resolveWindow {
+				resolveWindow = remaining
+			}
+			tipCtx, cancel := context.WithTimeout(ctx, resolveWindow)
+			tip := baseBranchTip(tipCtx)
+			cancel()
+			if tip != "" {
 				if lastBaseTip == "" {
 					lastBaseTip = tip
 				} else if tip != lastBaseTip {
@@ -156,14 +182,7 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 
 		elapsed := now().Sub(started)
 		if !unlimited && now().Sub(timeoutAnchor) >= timeout {
-			sctx.Log("CI timeout reached")
-			if len(timeoutFailingChecks) > 0 || timeoutMergeConflict {
-				return ciFailureOutcome(timeoutFailingChecks, timeoutMergeConflict, "CI timed out with known failures still present"), nil
-			}
-			if mergeabilityBlockedReason != "" {
-				return ciMergeabilityOutcome("mergeability check timed out", mergeabilityBlockedReason), nil
-			}
-			return ciMonitoringTimeoutOutcome(), nil
+			return timeoutOutcome()
 		}
 
 		// Check PR state (merged/closed -> exit)

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/cimonitor"
+	"github.com/kunchenguid/no-mistakes/internal/config"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/scm"
 	"github.com/kunchenguid/no-mistakes/internal/types"
@@ -34,6 +35,11 @@ type CIStep struct {
 	pollIntervalOverride time.Duration        // if set, overrides computed poll interval (for testing)
 	waitForNextPoll      func(context.Context, time.Duration) error
 	now                  func() time.Time
+	// baseBranchTip resolves the current tip SHA of the upstream default
+	// branch. When it advances, the monitor re-arms its timeout so a
+	// long-held green PR keeps getting rebased. Overridable for testing;
+	// defaults to fetching the upstream default branch.
+	baseBranchTip func(context.Context) string
 }
 
 func (s *CIStep) Name() types.StepName { return types.StepCI }
@@ -88,17 +94,36 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 	}
 	pr := &scm.PR{Number: prNumber, URL: prURL}
 
+	// CITimeout semantics: <0 (or "unlimited" in config) means never
+	// self-terminate; 0 means the value was never configured, so fall back
+	// to the default; >0 is an explicit finite idle timeout.
 	timeout := sctx.Config.CITimeout
+	unlimited := timeout < 0
 	if timeout == 0 {
-		timeout = 4 * time.Hour
+		timeout = config.DefaultCITimeout
 	}
 
-	sctx.Log(fmt.Sprintf("monitoring CI for PR #%s (timeout: %s)...", prNumber, timeout))
+	if unlimited {
+		sctx.Log(fmt.Sprintf("monitoring CI for PR #%s (no timeout, until merged or closed)...", prNumber))
+	} else {
+		sctx.Log(fmt.Sprintf("monitoring CI for PR #%s (timeout: %s)...", prNumber, timeout))
+	}
 	now := s.now
 	if now == nil {
 		now = time.Now
 	}
+	baseBranchTip := s.baseBranchTip
+	if baseBranchTip == nil {
+		baseBranchTip = func(ctx context.Context) string {
+			return resolveDefaultBranchTipSHA(ctx, sctx.WorkDir, sctx.Repo.UpstreamURL, sctx.Run.BaseSHA, sctx.Repo.DefaultBranch)
+		}
+	}
 	started := now()
+	// timeoutAnchor is the point the idle timeout is measured from. It re-arms
+	// to now() whenever the base branch advances, while started stays fixed so
+	// poll-interval and grace-period pacing are unaffected by re-arming.
+	timeoutAnchor := started
+	lastBaseTip := ""
 	manualFixAttempted := false
 	mergeabilityBlockedReason := ""
 	timeoutFailingChecks := []string{}
@@ -110,8 +135,27 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 			return nil, err
 		}
 
+		// Re-arm the timeout whenever the base branch advances. A green PR can
+		// outlive any finite timeout while waiting on a dependency PR or review;
+		// as long as its base keeps moving (the only thing that makes it go
+		// stale), the monitor stays alive to keep rebasing it. Re-arming only
+		// ever extends the deadline, so a transient resolution failure that
+		// returns a fallback SHA is harmless. Skipped when unlimited, since
+		// there is no deadline to re-arm.
+		if !unlimited {
+			if tip := baseBranchTip(ctx); tip != "" {
+				if lastBaseTip == "" {
+					lastBaseTip = tip
+				} else if tip != lastBaseTip {
+					sctx.Log(fmt.Sprintf("base branch advanced (%s..%s), re-arming CI monitor timeout", shortSHA(lastBaseTip), shortSHA(tip)))
+					timeoutAnchor = now()
+					lastBaseTip = tip
+				}
+			}
+		}
+
 		elapsed := now().Sub(started)
-		if elapsed >= timeout {
+		if !unlimited && now().Sub(timeoutAnchor) >= timeout {
 			sctx.Log("CI timeout reached")
 			if len(timeoutFailingChecks) > 0 || timeoutMergeConflict {
 				return ciFailureOutcome(timeoutFailingChecks, timeoutMergeConflict, "CI timed out with known failures still present"), nil
@@ -270,9 +314,11 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 		if interval == 0 {
 			interval = pollInterval(now().Sub(started))
 		}
-		remaining := timeout - now().Sub(started)
-		if remaining < interval {
-			interval = remaining
+		if !unlimited {
+			remaining := timeout - now().Sub(timeoutAnchor)
+			if remaining < interval {
+				interval = remaining
+			}
 		}
 		waitForNextPoll := s.waitForNextPoll
 		if waitForNextPoll == nil {

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -39,10 +39,10 @@ type CIStep struct {
 	waitForNextPoll      func(context.Context, time.Duration) error
 	now                  func() time.Time
 	// baseBranchTip resolves the current tip SHA of the upstream default
-	// branch. When it advances, the monitor re-arms its timeout so a
-	// long-held green PR keeps getting rebased. Overridable for testing;
-	// defaults to fetching the upstream default branch.
-	baseBranchTip func(context.Context) string
+	// branch. The bool is false when the SHA is a fallback/unknown value and
+	// must not re-arm the timeout. Overridable for testing; defaults to
+	// fetching the upstream default branch.
+	baseBranchTip func(context.Context) (string, bool)
 }
 
 func (s *CIStep) Name() types.StepName { return types.StepCI }
@@ -117,8 +117,8 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 	}
 	baseBranchTip := s.baseBranchTip
 	if baseBranchTip == nil {
-		baseBranchTip = func(ctx context.Context) string {
-			return resolveDefaultBranchTipSHA(ctx, sctx.WorkDir, sctx.Repo.UpstreamURL, sctx.Run.BaseSHA, sctx.Repo.DefaultBranch)
+		baseBranchTip = func(ctx context.Context) (string, bool) {
+			return resolveDefaultBranchTip(ctx, sctx.WorkDir, sctx.Repo.UpstreamURL, sctx.Run.BaseSHA, sctx.Repo.DefaultBranch)
 		}
 	}
 	started := now()
@@ -152,13 +152,7 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 			return timeoutOutcome()
 		}
 
-		// Re-arm the timeout whenever the base branch advances. A green PR can
-		// outlive any finite timeout while waiting on a dependency PR or review;
-		// as long as its base keeps moving (the only thing that makes it go
-		// stale), the monitor stays alive to keep rebasing it. Re-arming only
-		// ever extends the deadline, so a transient resolution failure that
-		// returns a fallback SHA is harmless. Skipped when unlimited, since
-		// there is no deadline to re-arm.
+		// Re-arm the timeout whenever the base branch advances.
 		if !unlimited {
 			resolveWindow := defaultBaseBranchTipResolveWindow
 			if remaining := timeout - now().Sub(timeoutAnchor); remaining <= 0 {
@@ -167,9 +161,9 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 				resolveWindow = remaining
 			}
 			tipCtx, cancel := context.WithTimeout(ctx, resolveWindow)
-			tip := baseBranchTip(tipCtx)
+			tip, resolved := baseBranchTip(tipCtx)
 			cancel()
-			if tip != "" {
+			if resolved && tip != "" {
 				if lastBaseTip == "" {
 					lastBaseTip = tip
 				} else if tip != lastBaseTip {

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -29,7 +29,8 @@ const (
 	ciChecksRunningMsg  = cimonitor.ChecksRunningMsg
 )
 
-// CIStep monitors an open PR until it is merged or closed, auto-fixing CI failures.
+// CIStep monitors an open PR until it is merged, closed, or its configured idle
+// timeout elapses, auto-fixing CI failures.
 type CIStep struct {
 	lastFixedChecks      string               // sorted check names from last fix attempt, to avoid re-fixing
 	lastFixedCompletedAt map[string]time.Time // failing check completion times seen before the last fix attempt

--- a/internal/pipeline/steps/ci_test.go
+++ b/internal/pipeline/steps/ci_test.go
@@ -636,3 +636,196 @@ func TestCIStep_NonEmptyPassingChecksSkipGracePeriodAndContinueMonitoring(t *tes
 		t.Fatalf("expected continued-monitoring pass log, got: %v", logs)
 	}
 }
+
+// TestCIStep_BaseBranchAdvanceRearmsTimeout verifies the monitor survives past
+// its original idle timeout when the base branch advances mid-monitoring: each
+// advance re-arms the deadline so a long-held green PR keeps getting watched
+// and rebased instead of being silently dropped.
+func TestCIStep_BaseBranchAdvanceRearmsTimeout(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	env := fakeCIGH(t, "OPEN", `[{"name":"build","state":"SUCCESS","bucket":"pass"}]`)
+
+	prURL := "https://github.com/test/repo/pull/42"
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+	sctx.Config.CITimeout = 10 * time.Second
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+
+	started := time.Date(2026, time.January, 1, 12, 0, 0, 0, time.UTC)
+	current := started
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
+	tipCalls := 0
+	pollCount := 0
+	step := &CIStep{
+		now: func() time.Time { return current },
+		baseBranchTip: func(context.Context) string {
+			tipCalls++
+			if tipCalls == 1 {
+				return "sha-old"
+			}
+			return "sha-new"
+		},
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			pollCount++
+			switch pollCount {
+			case 1:
+				current = started.Add(8 * time.Second)
+			case 2:
+				// 16s since start is past the 10s timeout, but the base advanced
+				// at 8s and re-armed the deadline, so monitoring must continue.
+				current = started.Add(16 * time.Second)
+			default:
+				cancel()
+				return ctx.Err()
+			}
+			return nil
+		},
+	}
+
+	if _, err := step.Execute(sctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected monitoring to continue past the original timeout after re-arm, got %v", err)
+	}
+
+	rearmed := false
+	for _, l := range logs {
+		if strings.Contains(l, "re-arming CI monitor timeout") {
+			rearmed = true
+		}
+		if strings.Contains(l, "CI timeout reached") {
+			t.Fatalf("monitor timed out despite a base-branch advance re-arm; logs: %v", logs)
+		}
+	}
+	if !rearmed {
+		t.Fatalf("expected a re-arm log after the base branch advanced; logs: %v", logs)
+	}
+}
+
+// TestCIStep_StableBaseStillTimesOut verifies the timeout still fires normally
+// for a PR whose base branch never moves, preserving the bounded-monitoring
+// behavior for genuinely idle/abandoned PRs.
+func TestCIStep_StableBaseStillTimesOut(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	env := fakeCIGH(t, "OPEN", `[{"name":"build","state":"SUCCESS","bucket":"pass"}]`)
+
+	prURL := "https://github.com/test/repo/pull/42"
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+	sctx.Config.CITimeout = 10 * time.Second
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+
+	started := time.Date(2026, time.January, 1, 12, 0, 0, 0, time.UTC)
+	current := started
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
+	step := &CIStep{
+		now:           func() time.Time { return current },
+		baseBranchTip: func(context.Context) string { return "sha-stable" },
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			current = started.Add(12 * time.Second)
+			return nil
+		},
+	}
+
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatalf("expected timeout outcome, got error %v", err)
+	}
+	if outcome == nil || !outcome.NeedsApproval {
+		t.Fatalf("expected timeout to surface a needs-approval outcome, got %+v", outcome)
+	}
+	found := false
+	for _, l := range logs {
+		if strings.Contains(l, "CI timeout reached") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected 'CI timeout reached' log for a stable base, got: %v", logs)
+	}
+}
+
+// TestCIStep_UnlimitedTimeoutNeverExpires verifies that an unlimited timeout
+// (ci_timeout: "unlimited" / non-positive) makes the monitor watch until the
+// PR merges or closes, never self-terminating, and skips base-tip polling.
+func TestCIStep_UnlimitedTimeoutNeverExpires(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	env := fakeCIGH(t, "OPEN", `[{"name":"build","state":"SUCCESS","bucket":"pass"}]`)
+
+	prURL := "https://github.com/test/repo/pull/42"
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+	sctx.Config.CITimeout = config.CITimeoutUnlimited
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+
+	started := time.Date(2026, time.January, 1, 12, 0, 0, 0, time.UTC)
+	current := started
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
+	tipCalls := 0
+	pollCount := 0
+	step := &CIStep{
+		now:           func() time.Time { return current },
+		baseBranchTip: func(context.Context) string { tipCalls++; return "sha" },
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			pollCount++
+			if pollCount >= 2 {
+				cancel()
+				return ctx.Err()
+			}
+			// Jump far past any finite default timeout to prove it never fires.
+			current = started.Add(30 * 24 * time.Hour)
+			return nil
+		},
+	}
+
+	if _, err := step.Execute(sctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected unlimited monitoring to continue indefinitely, got %v", err)
+	}
+	if tipCalls != 0 {
+		t.Fatalf("expected no base-tip polling under an unlimited timeout, got %d calls", tipCalls)
+	}
+	timeoutLog, noTimeoutLog := false, false
+	for _, l := range logs {
+		if strings.Contains(l, "CI timeout reached") {
+			timeoutLog = true
+		}
+		if strings.Contains(l, "no timeout, until merged or closed") {
+			noTimeoutLog = true
+		}
+	}
+	if timeoutLog {
+		t.Fatalf("unlimited monitor must not time out; logs: %v", logs)
+	}
+	if !noTimeoutLog {
+		t.Fatalf("expected the no-timeout monitoring log, got: %v", logs)
+	}
+}

--- a/internal/pipeline/steps/ci_test.go
+++ b/internal/pipeline/steps/ci_test.go
@@ -668,12 +668,12 @@ func TestCIStep_BaseBranchAdvanceRearmsTimeout(t *testing.T) {
 	pollCount := 0
 	step := &CIStep{
 		now: func() time.Time { return current },
-		baseBranchTip: func(context.Context) string {
+		baseBranchTip: func(context.Context) (string, bool) {
 			tipCalls++
 			if tipCalls == 1 {
-				return "sha-old"
+				return "sha-old", true
 			}
-			return "sha-new"
+			return "sha-new", true
 		},
 		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
 			pollCount++
@@ -738,7 +738,7 @@ func TestCIStep_StableBaseStillTimesOut(t *testing.T) {
 
 	step := &CIStep{
 		now:           func() time.Time { return current },
-		baseBranchTip: func(context.Context) string { return "sha-stable" },
+		baseBranchTip: func(context.Context) (string, bool) { return "sha-stable", true },
 		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
 			current = started.Add(12 * time.Second)
 			return nil
@@ -764,6 +764,73 @@ func TestCIStep_StableBaseStillTimesOut(t *testing.T) {
 	}
 }
 
+func TestCIStep_UnresolvedFallbackBaseTipDoesNotRearmTimeout(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	env := fakeCIGH(t, "OPEN", `[{"name":"build","state":"SUCCESS","bucket":"pass"}]`)
+
+	prURL := "https://github.com/test/repo/pull/42"
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+	sctx.Config.CITimeout = 10 * time.Second
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+
+	started := time.Date(2026, time.January, 1, 12, 0, 0, 0, time.UTC)
+	current := started
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
+	tipCalls := 0
+	pollCount := 0
+	step := &CIStep{
+		now: func() time.Time { return current },
+		baseBranchTip: func(context.Context) (string, bool) {
+			tipCalls++
+			switch tipCalls {
+			case 1:
+				return "sha-remote", true
+			case 2:
+				return baseSHA, false
+			default:
+				return "sha-remote", true
+			}
+		},
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			pollCount++
+			switch pollCount {
+			case 1:
+				current = started.Add(8 * time.Second)
+			case 2:
+				current = started.Add(16 * time.Second)
+			default:
+				cancel()
+				return ctx.Err()
+			}
+			return nil
+		},
+	}
+
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatalf("expected timeout outcome, got error %v", err)
+	}
+	if outcome == nil || !outcome.NeedsApproval {
+		t.Fatalf("expected timeout to surface a needs-approval outcome, got %+v", outcome)
+	}
+	for _, l := range logs {
+		if strings.Contains(l, "re-arming CI monitor timeout") {
+			t.Fatalf("fallback base SHA must not re-arm timeout; logs: %v", logs)
+		}
+	}
+}
+
 func TestCIStep_ExpiredTimeoutSkipsBaseTipResolver(t *testing.T) {
 	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
@@ -783,12 +850,12 @@ func TestCIStep_ExpiredTimeoutSkipsBaseTipResolver(t *testing.T) {
 	tipCalls := 0
 	step := &CIStep{
 		now: func() time.Time { return current },
-		baseBranchTip: func(context.Context) string {
+		baseBranchTip: func(context.Context) (string, bool) {
 			tipCalls++
 			if tipCalls > 1 {
 				t.Fatal("base tip resolver should not run after timeout expiry")
 			}
-			return "sha-stable"
+			return "sha-stable", true
 		},
 		waitForNextPoll: func(context.Context, time.Duration) error {
 			current = started.Add(11 * time.Second)
@@ -831,10 +898,10 @@ func TestCIStep_BaseTipResolverDeadlineIsBoundedByRemainingTimeout(t *testing.T)
 	tipCalls := 0
 	step := &CIStep{
 		now: func() time.Time { return current },
-		baseBranchTip: func(ctx context.Context) string {
+		baseBranchTip: func(ctx context.Context) (string, bool) {
 			tipCalls++
 			if tipCalls == 1 {
-				return "sha-stable"
+				return "sha-stable", true
 			}
 			deadline, ok := ctx.Deadline()
 			if !ok {
@@ -843,7 +910,7 @@ func TestCIStep_BaseTipResolverDeadlineIsBoundedByRemainingTimeout(t *testing.T)
 			if remaining := time.Until(deadline); remaining > 2*time.Second {
 				t.Fatalf("base tip resolver deadline = %v from now, want no more than 2s", remaining)
 			}
-			return "sha-stable"
+			return "sha-stable", true
 		},
 		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
 			if tipCalls == 1 {
@@ -890,7 +957,7 @@ func TestCIStep_UnlimitedTimeoutNeverExpires(t *testing.T) {
 	pollCount := 0
 	step := &CIStep{
 		now:           func() time.Time { return current },
-		baseBranchTip: func(context.Context) string { tipCalls++; return "sha" },
+		baseBranchTip: func(context.Context) (string, bool) { tipCalls++; return "sha", true },
 		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
 			pollCount++
 			if pollCount >= 2 {

--- a/internal/pipeline/steps/ci_test.go
+++ b/internal/pipeline/steps/ci_test.go
@@ -764,6 +764,102 @@ func TestCIStep_StableBaseStillTimesOut(t *testing.T) {
 	}
 }
 
+func TestCIStep_ExpiredTimeoutSkipsBaseTipResolver(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	env := fakeCIGH(t, "OPEN", `[{"name":"build","state":"SUCCESS","bucket":"pass"}]`)
+
+	prURL := "https://github.com/test/repo/pull/42"
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+	sctx.Config.CITimeout = 10 * time.Second
+
+	started := time.Date(2026, time.January, 1, 12, 0, 0, 0, time.UTC)
+	current := started
+
+	tipCalls := 0
+	step := &CIStep{
+		now: func() time.Time { return current },
+		baseBranchTip: func(context.Context) string {
+			tipCalls++
+			if tipCalls > 1 {
+				t.Fatal("base tip resolver should not run after timeout expiry")
+			}
+			return "sha-stable"
+		},
+		waitForNextPoll: func(context.Context, time.Duration) error {
+			current = started.Add(11 * time.Second)
+			return nil
+		},
+	}
+
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatalf("expected timeout outcome, got error %v", err)
+	}
+	if outcome == nil || !outcome.NeedsApproval {
+		t.Fatalf("expected timeout to surface a needs-approval outcome, got %+v", outcome)
+	}
+	if tipCalls != 1 {
+		t.Fatalf("base tip resolver calls = %d, want 1", tipCalls)
+	}
+}
+
+func TestCIStep_BaseTipResolverDeadlineIsBoundedByRemainingTimeout(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	env := fakeCIGH(t, "OPEN", `[{"name":"build","state":"SUCCESS","bucket":"pass"}]`)
+
+	prURL := "https://github.com/test/repo/pull/42"
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContext(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+	sctx.Config.CITimeout = 10 * time.Second
+
+	started := time.Date(2026, time.January, 1, 12, 0, 0, 0, time.UTC)
+	current := started
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
+	tipCalls := 0
+	step := &CIStep{
+		now: func() time.Time { return current },
+		baseBranchTip: func(ctx context.Context) string {
+			tipCalls++
+			if tipCalls == 1 {
+				return "sha-stable"
+			}
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				t.Fatal("expected base tip resolver context to have a deadline")
+			}
+			if remaining := time.Until(deadline); remaining > 2*time.Second {
+				t.Fatalf("base tip resolver deadline = %v from now, want no more than 2s", remaining)
+			}
+			return "sha-stable"
+		},
+		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
+			if tipCalls == 1 {
+				current = started.Add(8 * time.Second)
+				return nil
+			}
+			cancel()
+			return ctx.Err()
+		},
+	}
+
+	if _, err := step.Execute(sctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected cancellation after deadline inspection, got %v", err)
+	}
+}
+
 // TestCIStep_UnlimitedTimeoutNeverExpires verifies that an unlimited timeout
 // (ci_timeout: "unlimited" / non-positive) makes the monitor watch until the
 // PR merges or closes, never self-terminating, and skips base-tip polling.

--- a/internal/pipeline/steps/common_git.go
+++ b/internal/pipeline/steps/common_git.go
@@ -32,26 +32,35 @@ func resolveBranchBaseSHA(ctx context.Context, workDir, fallbackBaseSHA, default
 }
 
 func resolveDefaultBranchTipSHA(ctx context.Context, workDir, upstreamURL, fallbackBaseSHA, defaultBranch string) string {
+	sha, _ := resolveDefaultBranchTip(ctx, workDir, upstreamURL, fallbackBaseSHA, defaultBranch)
+	return sha
+}
+
+func resolveDefaultBranchTip(ctx context.Context, workDir, upstreamURL, fallbackBaseSHA, defaultBranch string) (string, bool) {
 	if strings.TrimSpace(defaultBranch) != "" {
 		remoteName := resolveUpstreamRemoteName(ctx, workDir, upstreamURL)
 		if err := git.FetchRemoteBranch(ctx, workDir, remoteName, defaultBranch); err != nil {
-			if !git.IsZeroSHA(fallbackBaseSHA) {
-				return fallbackBaseSHA
-			}
-			sha, localErr := git.Run(ctx, workDir, "rev-parse", "--verify", defaultBranch)
-			if localErr == nil && strings.TrimSpace(sha) != "" {
-				return strings.TrimSpace(sha)
-			}
-			return git.EmptyTreeSHA
+			return unresolvedDefaultBranchTip(ctx, workDir, fallbackBaseSHA, defaultBranch), false
 		}
 		for _, ref := range []string{remoteName + "/" + defaultBranch, defaultBranch} {
 			sha, err := git.Run(ctx, workDir, "rev-parse", "--verify", ref)
 			if err == nil && strings.TrimSpace(sha) != "" {
-				return strings.TrimSpace(sha)
+				return strings.TrimSpace(sha), true
 			}
 		}
 	}
-	return resolveBaseSHA(ctx, workDir, fallbackBaseSHA, defaultBranch)
+	return resolveBaseSHA(ctx, workDir, fallbackBaseSHA, defaultBranch), false
+}
+
+func unresolvedDefaultBranchTip(ctx context.Context, workDir, fallbackBaseSHA, defaultBranch string) string {
+	if !git.IsZeroSHA(fallbackBaseSHA) {
+		return fallbackBaseSHA
+	}
+	sha, localErr := git.Run(ctx, workDir, "rev-parse", "--verify", defaultBranch)
+	if localErr == nil && strings.TrimSpace(sha) != "" {
+		return strings.TrimSpace(sha)
+	}
+	return git.EmptyTreeSHA
 }
 
 func resolveUpstreamRemoteName(ctx context.Context, workDir, upstreamURL string) string {

--- a/internal/pipeline/steps/common_test.go
+++ b/internal/pipeline/steps/common_test.go
@@ -138,6 +138,13 @@ func TestResolveDefaultBranchTipSHA_FetchesRemoteTip(t *testing.T) {
 		t.Fatal("expected origin/main to be stale before resolveDefaultBranchTipSHA")
 	}
 
+	tip, resolved := resolveDefaultBranchTip(context.Background(), workDir, upstream, staleOriginTip, "main")
+	if !resolved {
+		t.Fatal("resolveDefaultBranchTip reported unresolved after fetching remote tip")
+	}
+	if tip != remoteTip {
+		t.Fatalf("resolveDefaultBranchTip = %q, want remote tip %q", tip, remoteTip)
+	}
 	got := resolveDefaultBranchTipSHA(context.Background(), workDir, upstream, staleOriginTip, "main")
 	if got != remoteTip {
 		t.Fatalf("resolveDefaultBranchTipSHA = %q, want remote tip %q", got, remoteTip)
@@ -232,6 +239,13 @@ func TestResolveDefaultBranchTipSHA_FetchFailureAvoidsStaleOriginRef(t *testing.
 	gitCmd(t, workDir, "remote", "set-url", "origin", filepath.Join(upstream, "missing"))
 
 	fallbackBaseSHA := "abc123"
+	tip, resolved := resolveDefaultBranchTip(context.Background(), workDir, upstream, fallbackBaseSHA, "main")
+	if resolved {
+		t.Fatal("resolveDefaultBranchTip reported resolved after fetch failure")
+	}
+	if tip != fallbackBaseSHA {
+		t.Fatalf("resolveDefaultBranchTip = %q, want fallback base %q when fetch fails", tip, fallbackBaseSHA)
+	}
 	got := resolveDefaultBranchTipSHA(context.Background(), workDir, upstream, fallbackBaseSHA, "main")
 	if got != fallbackBaseSHA {
 		t.Fatalf("resolveDefaultBranchTipSHA = %q, want fallback base %q when fetch fails", got, fallbackBaseSHA)
@@ -284,6 +298,13 @@ func TestResolveDefaultBranchTipSHA_FetchFailureAvoidsStaleLocalBranch(t *testin
 	gitCmd(t, workDir, "remote", "set-url", "origin", filepath.Join(upstream, "missing"))
 
 	fallbackBaseSHA := "abc123"
+	tip, resolved := resolveDefaultBranchTip(context.Background(), workDir, upstream, fallbackBaseSHA, "main")
+	if resolved {
+		t.Fatal("resolveDefaultBranchTip reported resolved after fetch failure")
+	}
+	if tip != fallbackBaseSHA {
+		t.Fatalf("resolveDefaultBranchTip = %q, want fallback base %q when fetch fails", tip, fallbackBaseSHA)
+	}
 	got := resolveDefaultBranchTipSHA(context.Background(), workDir, upstream, fallbackBaseSHA, "main")
 	if got != fallbackBaseSHA {
 		t.Fatalf("resolveDefaultBranchTipSHA = %q, want fallback base %q when fetch fails", got, fallbackBaseSHA)

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -227,6 +227,7 @@ no-mistakes axi               # home view: current branch, active runs, next ste
 no-mistakes axi status        # full detail of the resolved run
 no-mistakes axi logs --step <name> --full   # full log output of one step
 no-mistakes axi abort         # cancel the current-branch active run
+no-mistakes axi abort --run <id>   # cancel a specific run by id (works outside its worktree)
 ` + "```" + `
 
 ## Reading the output

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -171,7 +171,8 @@ Run the pipeline and decide on its findings as they come up:
      not merged yet. **You are done driving the pipeline.** Do not wait for the
      merge: tell the user the PR is ready and ask them to review and merge it
      (the PR link is in the ` + "`help`" + ` line). no-mistakes keeps monitoring the PR
-     in the background, so a human can watch it in the TUI.
+     in the background until it is merged, closed, or its configured idle
+     timeout elapses, so a human can watch it in the TUI.
    - ` + "`passed`" + ` - the changes cleared the gate and the PR was merged or closed.
    - ` + "`failed`" + ` or ` + "`cancelled`" + ` - they did not; read the output and address it.
      Fix whatever the output points at (a failing test, a lint error, a finding
@@ -181,7 +182,7 @@ Run the pipeline and decide on its findings as they come up:
      leave the user at a ` + "`failed`" + ` outcome without either retrying or explaining
      what blocks it.
 
-The CI step deliberately watches the PR until it is merged or closed, so
+The CI step deliberately keeps watching the PR after checks pass, so
 ` + "`axi run`" + ` returns ` + "`checks-passed`" + ` the moment checks are green rather than
 blocking on the human merge. Never poll or re-run waiting for the merge yourself.
 

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -132,7 +132,8 @@ Run the pipeline and decide on its findings as they come up:
      not merged yet. **You are done driving the pipeline.** Do not wait for the
      merge: tell the user the PR is ready and ask them to review and merge it
      (the PR link is in the `help` line). no-mistakes keeps monitoring the PR
-     in the background, so a human can watch it in the TUI.
+     in the background until it is merged, closed, or its configured idle
+     timeout elapses, so a human can watch it in the TUI.
    - `passed` - the changes cleared the gate and the PR was merged or closed.
    - `failed` or `cancelled` - they did not; read the output and address it.
      Fix whatever the output points at (a failing test, a lint error, a finding
@@ -142,7 +143,7 @@ Run the pipeline and decide on its findings as they come up:
      leave the user at a `failed` outcome without either retrying or explaining
      what blocks it.
 
-The CI step deliberately watches the PR until it is merged or closed, so
+The CI step deliberately keeps watching the PR after checks pass, so
 `axi run` returns `checks-passed` the moment checks are green rather than
 blocking on the human merge. Never poll or re-run waiting for the merge yourself.
 

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -188,6 +188,7 @@ no-mistakes axi               # home view: current branch, active runs, next ste
 no-mistakes axi status        # full detail of the resolved run
 no-mistakes axi logs --step <name> --full   # full log output of one step
 no-mistakes axi abort         # cancel the current-branch active run
+no-mistakes axi abort --run <id>   # cancel a specific run by id (works outside its worktree)
 ```
 
 ## Reading the output


### PR DESCRIPTION
## Intent

Fix two until-merge CI monitor / daemon lifecycle gaps found in production.

GAP 1: The finite ~4h ci_timeout dropped the auto-rebase babysitter on long-lived green PRs (e.g. waiting on a dependency PR or captain review), so they stopped auto-rebasing when the base advanced and silently went stale. Fix: ci_timeout is now an idle timeout that re-arms (resets timeoutAnchor=now()) every time the upstream default-branch tip advances - the only thing that makes a PR go stale - so an actively-rebased green PR keeps its monitor for as long as it stays open. 'started' stays fixed so poll-interval/grace-period pacing is unchanged; only timeoutAnchor moves. Re-arm only ever EXTENDS the deadline, so a transient base-tip resolution failure is fail-safe (never drops a PR early). The default was raised 4h->168h (7 days) via config.DefaultCITimeout, and ci_timeout: "unlimited" (or 0 / any non-positive duration -> config.CITimeoutUnlimited sentinel) monitors until the PR merges/closes/aborts. CITimeout semantics chosen deliberately: >0 finite, 0 = unset (step falls back to default), <0 = unlimited. base-tip resolution is injectable (baseBranchTip field) for tests and skipped entirely when unlimited (no deadline to re-arm). Short-lived PRs are intentionally unaffected.

GAP 2: axi abort was worktree-scoped, so a torn-down crewmate orphaned its monitor run until superseded or timed out. Fix: added 'axi abort --run <id>' (runAxiAbortByRunID) which cancels a specific run via the daemon WITHOUT resolving a repo/branch/worktree, so an orphaned monitor (worktree gone, run still live in daemon memory) is reaped deterministically from outside. Deliberate choices: an unknown/inactive id or a stopped daemon is an idempotent no-op (aborted: false), not an error, so an external reaper can call it blindly; bare 'axi abort' stays branch-scoped. The IPC MethodCancelRun already accepted a run id - this just exposes it on the CLI.

Kept the two fixes in one coherent change set with TDD: config unlimited-parsing tests, CI-monitor re-arm/stable-timeout/unlimited tests, an abort-by-id no-op unit test, and an e2e test that reaps a run from outside its worktree. Docs (global-config, cli, configuration guide), the generated agent skill, and AGENTS.md were updated to match.

## What Changed

- Changes CI monitoring to use a 168h idle timeout that re-arms only when the resolved upstream default branch tip advances, with bounded base-tip resolution and no re-arm on unresolved fallback SHAs.
- Adds `ci_timeout` unlimited handling and exposes `no-mistakes axi abort --run <id>` so live daemon runs can be cancelled by id from outside their worktree, with stopped-daemon and unknown-run cases treated as no-op.
- Updates the CLI/config/docs/generated skill guidance and adds focused unit/e2e coverage plus committed evidence for the CI monitor and abort-by-run-id lifecycle behavior.

## Risk Assessment

🚨 High: The central CI-monitor lifecycle change still does not act on the base-branch movement it now detects, so the core production failure mode can persist.

## Testing

No separate baseline command was provided. I exercised the CI monitor idle-timeout behavior with focused race-enabled tests and a log trace showing base advance re-arms the timeout, stable bases still time out, and unlimited skips deadlines/base-tip polling; I exercised abort-by-run-id through the codex e2e journey plus a manual isolated CLI run that cancelled an active run from outside its worktree and confirmed unknown-id/stopped-daemon no-ops. The broader changed packages also passed under race.

- Evidence: [Focused unit test transcript](https://github.com/kunchenguid/no-mistakes/blob/99fdb0fd47fbb725291e88f51e424aae6c2382c3/.no-mistakes/evidence/fm/nm-warts-w4/focused-unit-tests.txt)
- Evidence: [CI monitor timeout behavior trace](https://github.com/kunchenguid/no-mistakes/blob/99fdb0fd47fbb725291e88f51e424aae6c2382c3/.no-mistakes/evidence/fm/nm-warts-w4/ci-monitor-behavior-trace.txt)
- Evidence: [Abort-by-run-id manual CLI transcript](https://github.com/kunchenguid/no-mistakes/blob/99fdb0fd47fbb725291e88f51e424aae6c2382c3/.no-mistakes/evidence/fm/nm-warts-w4/manual-abort-by-run-id-transcript.txt)
- Evidence: [Codex e2e journey transcript](https://github.com/kunchenguid/no-mistakes/blob/99fdb0fd47fbb725291e88f51e424aae6c2382c3/.no-mistakes/evidence/fm/nm-warts-w4/e2e-codex-journey.txt)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 error</summary>

- ⚠️ `internal/config/config.go:459` - Raising `DefaultCITimeout` only affects missing configs or configs without `ci_timeout`. Existing installs with the generated `ci_timeout: &#34;4h&#34;` file keep that explicit value because default config files are never overwritten, so upgraded users can still hit the 4h idle timeout this change is meant to retire unless there is a migration or clear upgrade note.
- ⚠️ `internal/pipeline/steps/ci.go:146` - The loop resolves `baseBranchTip` before checking whether the idle timeout has already elapsed, and the default resolver runs `git fetch` on the step context with no shorter deadline. A slow or stuck fetch can prevent a finite `ci_timeout` from firing; check the timeout first and bound the base-tip fetch with a derived timeout.
- ⚠️ `docs/src/content/docs/guides/troubleshooting.md:185` - This troubleshooting page still says the CI timeout defaults to 4h and recommends raising it to 8h, which conflicts with the new 168h idle-timeout behavior and unlimited option. Update this section so users do not follow stale guidance.

🔧 Fix: Harden CI timeout and e2e startup
2 issues (1 error, 1 warning) still open:
- 🚨 `internal/pipeline/steps/ci.go:175` - The base-advance path only re-arms `timeoutAnchor`; it never rebases or pushes the PR branch. For a behind-but-mergeable GitHub PR, `mergeable` can remain `MERGEABLE` and checks can stay passed, so `hasIssues` stays false and `autoFixCI` is never called. That leaves the production gap described by the change: long-lived green PRs can still go stale after the base advances, just with a longer-lived monitor.
- ⚠️ `internal/pipeline/steps/ci.go:170` - The monitor treats every non-empty `baseBranchTip` value as a real default-branch tip, but the default resolver returns the run&#39;s fallback base SHA when fetch fails. After one successful poll, a transient fetch failure can look like a tip change and re-arm the finite timeout; the next successful poll flips back and re-arms again. Use a resolver result that distinguishes &#34;resolved tip&#34; from &#34;fallback/unknown&#34; so fetch failures do not extend idle monitors indefinitely.

🔧 Fix: Prevent CI fallback timeout re-arms
1 error still open:
- 🚨 `internal/pipeline/steps/ci.go:170` - The base-advance path only re-arms `timeoutAnchor`; it never rebases or otherwise updates/pushes the PR branch. Since `autoFixCI` only runs for failing checks or reported merge conflicts, a cleanly-behind PR with passing checks can stay stale indefinitely while the monitor logs checks-passed, which leaves the production stale-base gap unresolved.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./internal/config ./internal/cli ./internal/pipeline/steps -run 'TestLoadGlobal_CITimeoutUnlimited|TestDefaultConfigYAML_MatchesGoDefaults|TestAxiAbortByRunIDNoOpWhenDaemonStopped|TestCIStep_(BaseBranchAdvanceRearmsTimeout|StableBaseStillTimesOut|UnresolvedFallbackBaseTipDoesNotRearmTimeout|ExpiredTimeoutSkipsBaseTipResolver|BaseTipResolverDeadlineIsBoundedByRemainingTimeout|UnlimitedTimeoutNeverExpires)$' -count=1 -v`
- `go test -tags e2e ./internal/e2e -run '^TestUserJourney/codex$' -count=1 -v`
- <code>Manual isolated CLI check: built `./cmd/no-mistakes`, initialized a local repo/gate/daemon, started `no-mistakes axi run --skip=review,document,lint,push,pr,ci --intent &#39;exercise abort by run id&#39;`, cancelled it from outside the worktree with `no-mistakes axi abort --run &lt;id&gt;`, then checked unknown-run and stopped-daemon no-op outputs.</code>
- <code>Temporary evidence-only check: `go test ./internal/pipeline/steps -run &#39;^TestEvidenceCIMonitorTimeoutTrace$&#39; -count=1 -v`; the temporary test file was removed afterward.</code>
- `go test -race ./internal/config ./internal/cli ./internal/pipeline/steps -count=1`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
