### PR TITLE
feat(agent): add GitHub Copilot CLI agent backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ Safest local verification sequence after non-trivial changes:
 - `internal/cli`: cobra commands and CLI wiring
 - `internal/daemon`: background daemon and run management
 - `internal/pipeline` and `internal/pipeline/steps`: orchestration plus review/test/lint/push/PR/CI steps
-- `internal/agent`: Claude, Codex, Rovo Dev, OpenCode, Pi, and ACP/acpx integrations
+- `internal/agent`: Claude, Codex, Rovo Dev, OpenCode, Pi, Copilot, and ACP/acpx integrations
 - `internal/git`, `internal/ipc`, `internal/config`, `internal/db`, `internal/paths`, `internal/types`: shared infrastructure
 - `internal/tui`: terminal UI
 
@@ -88,7 +88,7 @@ Safest local verification sequence after non-trivial changes:
   agent-spawned git/build/editor), keep running, and hold the worktree locked so
   the next run on the same branch cannot proceed. Applied to the step shell
   runner (`runShellCommandWithEnv`) and the native agent `runOnce` builders
-  (claude, codex, pi, acpx); apply it to any new subprocess in those paths.
+  (claude, codex, pi, copilot, acpx); apply it to any new subprocess in those paths.
 - Use derived contexts and timeouts for cleanup and HTTP calls.
 - Use `context.Background()` mainly at top-level boundaries, background tasks, or in tests.
 - Protect shared mutable state with `sync.Mutex`, `sync.RWMutex`, `sync.Map`, or `atomic` where appropriate.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 Push to `no-mistakes` instead of `origin`, and it spins up a disposable worktree, runs an AI-driven validation pipeline, forwards the branch to the configured push target only after every check passes, and opens a clean PR automatically.
 
 - **Non-blocking** - the pipeline runs in an isolated worktree without disrupting your work.
-- **Agent-agnostic** - `claude`, `codex`, `rovodev`, `opencode`, `pi`, or `acp:<target>` via `acpx`.
+- **Agent-agnostic** - `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, or `acp:<target>` via `acpx`.
 - **Agent-native** - `/no-mistakes` lets your coding agent do a task and gate it, or gate existing committed work: it runs the pipeline, has the pipeline apply safe fixes, and escalates the rest to you.
 - **Human stays in charge** - auto-fix or review findings, your call.
 - **Clean PRs by default** - push, open PR, watch CI, and auto-fix failures in one shot.

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -39,6 +39,7 @@ By default that directory is temporary and local to the machine; repos can opt i
 | Rovo Dev | `acli` | Persistent HTTP server, SSE streaming |
 | OpenCode | `opencode` | Persistent HTTP server, SSE streaming |
 | Pi | `pi` | Subprocess per invocation, JSONL events |
+| Copilot | `copilot` | Subprocess per invocation, JSONL events |
 | ACP target | `acpx` | Optional user-installed ACP bridge |
 
 ## Setting the agent
@@ -136,6 +137,7 @@ By default, `no-mistakes` resolves `agent: auto` by checking for supported nativ
 3. `opencode`
 4. `acli` with `rovodev` support
 5. `pi`
+6. `copilot`
 
 The default binary names are:
 
@@ -146,6 +148,7 @@ The default binary names are:
 | `rovodev` | `acli` |
 | `opencode` | `opencode` |
 | `pi` | `pi` |
+| `copilot` | `copilot` |
 | `acp:<target>` | `acpx` |
 
 When the daemon is running through a managed service, that `PATH` comes from your login shell environment on macOS and Linux plus common user, Homebrew, and system binary directories. If login-shell resolution fails, the daemon logs a warning and uses a degraded fallback `PATH` that may omit version-manager shim directories. On Windows it reuses the current process environment instead of reloading a login shell. If native agent discovery still does not resolve the binary you expect, check `~/.no-mistakes/logs/daemon.log` and use an explicit `agent_path_override`.
@@ -159,6 +162,7 @@ agent_path_override:
   rovodev: /usr/local/bin/acli
   opencode: /usr/local/bin/opencode
   pi: /usr/local/bin/pi
+  copilot: /usr/local/bin/copilot
 ```
 
 For ACP targets, set `acpx_path` instead of `agent_path_override`:
@@ -193,11 +197,11 @@ Transient API and network failures are retried up to three times with exponentia
 ## Intent extraction
 
 When an agent starts a run through `no-mistakes axi run --intent`, no-mistakes uses that supplied intent verbatim and skips transcript-based inference, even if `intent.enabled` is false.
-Otherwise, when `intent.enabled` is true, no-mistakes reads recent local transcripts from Claude Code, Codex, OpenCode, Rovo Dev, and Pi during the `intent` pipeline step.
+Otherwise, when `intent.enabled` is true, no-mistakes reads recent local transcripts from Claude Code, Codex, OpenCode, Rovo Dev, Pi, and the GitHub Copilot CLI during the `intent` pipeline step.
 It matches sessions against non-deleted changed files when present, falls back to all changed files for all-deletion diffs, summarizes the likely author intent with the configured pipeline agent, includes that summary as untrusted context in rebase fixes, review checks and fixes, test detection, evidence validation, and fixes, lint detection and fixes, documentation checks and fixes, CI auto-fixes, and PR prompts, and renders it in generated PR descriptions.
 
 Transcript readers collect user and assistant text messages but exclude tool call output.
-They read Claude Code transcripts from `~/.claude/projects`, Codex metadata from `~/.codex/state_*.sqlite` plus referenced rollout files, OpenCode messages from `$XDG_DATA_HOME/opencode/opencode.db` or `~/.local/share/opencode/opencode.db`, Rovo Dev sessions from `~/.rovodev/sessions`, and Pi transcripts from `~/.pi/agent/sessions`.
+They read Claude Code transcripts from `~/.claude/projects`, Codex metadata from `~/.codex/state_*.sqlite` plus referenced rollout files, OpenCode messages from `$XDG_DATA_HOME/opencode/opencode.db` or `~/.local/share/opencode/opencode.db`, Rovo Dev sessions from `~/.rovodev/sessions`, Pi transcripts from `~/.pi/agent/sessions`, and GitHub Copilot CLI sessions from `~/.copilot/session-state`.
 Sessions are eligible when they come from the same working directory or an equivalent Git checkout with the same common Git directory or normalized remote URL.
 ACP transcripts are not currently read for intent extraction.
 When deterministic matching leaves multiple plausible sessions, no-mistakes may ask the configured pipeline agent to choose among them using the matching file paths and sanitized transcript packet files.
@@ -232,6 +236,14 @@ Any `agent_args_override.pi` flags are inserted before no-mistakes' managed flag
 Reads JSONL events from stdout and streams incremental text deltas to the TUI.
 When structured output is requested, no-mistakes injects the JSON schema into the prompt and validates the final text response.
 
+## Copilot CLI
+
+Spawns a `copilot` subprocess for each invocation with `-p <prompt> --output-format json`.
+It also adds `--no-color` and `--no-ask-user` so the run is non-interactive, plus `--allow-all-tools` (required for non-interactive mode) unless you already set your own Copilot permission flag through `agent_args_override`.
+Any `agent_args_override.copilot` flags are inserted before no-mistakes' managed flags, so user choices such as `--model` or `--effort` take effect.
+Reads JSONL events from stdout, streaming incremental `assistant.message_delta` text to the TUI and capturing the final `assistant.message` content.
+The Copilot CLI has no output-schema flag, so when structured output is requested no-mistakes injects the JSON schema into the prompt and validates the final text response with the same JSON fence and bare-object fallback used by Pi and Rovo Dev.
+
 ## ACP via acpx
 
 ACP support is optional and requires a separately installed `acpx` binary.
@@ -264,6 +276,7 @@ $ no-mistakes doctor
   – acli (not found)
   – opencode (not found)
   – pi (not found)
+  – copilot (not found)
 ```
 
 `✓` = available, `–` = not found (optional), `✗` = problem detected.

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -50,7 +50,7 @@ Everything else can usually wait.
 
 # Default agent for all repos and setup-wizard suggestions.
 # "auto" picks the first available native agent on PATH.
-agent: auto  # auto | claude | codex | rovodev | opencode | pi | acp:<target>
+agent: auto  # auto | claude | codex | rovodev | opencode | pi | copilot | acp:<target>
 
 # Optional acpx path and target command overrides for agent: acp:<target>.
 acpx_path: acpx
@@ -64,6 +64,7 @@ agent_path_override:
   rovodev: /usr/local/bin/acli
   opencode: /usr/local/bin/opencode
   pi: /usr/local/bin/pi
+  copilot: /usr/local/bin/copilot
 
 # Optional extra CLI flags per native agent.
 # This is global-only.
@@ -154,7 +155,7 @@ See [Repo Config Reference](/no-mistakes/reference/repo-config/) for the full fi
 ## Precedence
 
 - Repo `agent` overrides global `agent`.
-- Global `agent: auto` resolves by checking `claude`, `codex`, `opencode`, `acli` for `rovodev`, then `pi` on `PATH`.
+- Global `agent: auto` resolves by checking `claude`, `codex`, `opencode`, `acli` for `rovodev`, `pi`, then `copilot` on `PATH`.
 - ACP agents are opt-in with `agent: acp:<target>` and are not considered by `agent: auto`.
 - `agent_path_override`, `agent_args_override`, `acpx_path`, and `acp_registry_overrides` are global-only fields.
 - `auto_fix` from the repo config overlays global auto_fix. Fields not set in the repo config fall through to the global default.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -249,7 +249,7 @@ Checks:
 - Data directory (`~/.no-mistakes/`)
 - SQLite database
 - Daemon status
-- Native agent binaries: `claude`, `codex`, `acli`, `opencode`, `pi`
+- Native agent binaries: `claude`, `codex`, `acli`, `opencode`, `pi`, `copilot`
 
 Uses indicators: `✓` (available), `–` (not found, optional), `✗` (problem detected).
 

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -21,6 +21,7 @@ agent_path_override:
   rovodev: /usr/local/bin/acli
   opencode: /usr/local/bin/opencode
   pi: /usr/local/bin/pi
+  copilot: /usr/local/bin/copilot
 
 agent_args_override:
   codex:
@@ -61,10 +62,10 @@ Default agent for all repos and setup-wizard suggestions. Can be overridden per-
 | | |
 |---|---|
 | Type | `string` |
-| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `acp:<target>` |
+| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `acp:<target>` |
 | Default | `auto` |
 
-`auto` resolves to the first supported native agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, then `pi`.
+`auto` resolves to the first supported native agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, `pi`, then `copilot`.
 `acp:<target>` uses the user-installed `acpx` binary to run an ACP target, for example `acp:gemini`.
 ACP agents are opt-in and are not considered by `agent: auto`.
 
@@ -115,6 +116,7 @@ Default native binary names when no override is set:
 | `rovodev` | `acli` |
 | `opencode` | `opencode` |
 | `pi` | `pi` |
+| `copilot` | `copilot` |
 
 ### agent_args_override
 
@@ -124,7 +126,7 @@ Use this to set model selection, reasoning effort, permission mode, or any other
 | | |
 |---|---|
 | Type | `map[string][]string` |
-| Keys | `claude`, `codex`, `rovodev`, `opencode`, `pi` |
+| Keys | `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot` |
 | Default | Empty (no extra flags) |
 
 User-supplied flags are inserted ahead of no-mistakes' managed flags, so your choices usually take precedence. A few flags are reserved because no-mistakes depends on them to communicate with the agent - setting any of these returns a config error on load:
@@ -136,6 +138,7 @@ User-supplied flags are inserted ahead of no-mistakes' managed flags, so your ch
 | `rovodev` | `rovodev`, `serve`, `--disable-session-token` |
 | `opencode` | `serve`, `--hostname`, `--port`, `--print-logs` |
 | `pi` | `--mode`, `--no-session` |
+| `copilot` | `-p`, `--prompt`, `--output-format`, `--no-color` |
 
 For structured `codex` runs, no-mistakes also appends its own `--output-schema <tempfile>` after your overrides. Treat that flag as managed even though config validation does not currently reject it.
 
@@ -233,7 +236,7 @@ When enabled and no intent was supplied directly for the run, no-mistakes can re
 | `intent.slack_days` | `int` | `3` | Extra days to look back before the change window |
 | `intent.disabled_readers` | `string[]` | Empty | Transcript readers to disable |
 
-Valid `disabled_readers` values are `claude`, `codex`, `opencode`, `rovodev`, and `pi`.
+Valid `disabled_readers` values are `claude`, `codex`, `opencode`, `rovodev`, `pi`, and `copilot`.
 
 The match score is the share of matching files mentioned in a transcript session; deleted files are ignored when the diff also contains non-deleted changes.
 All-deletion diffs still match against the deleted changed files.

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -17,7 +17,7 @@ The steering still allows requested test evidence under the managed temporary `n
 
 ## Intent
 
-Uses agent-supplied intent when a run provides it, otherwise infers the author's intent from recent local Claude Code, Codex, OpenCode, Rovo Dev, or Pi transcripts.
+Uses agent-supplied intent when a run provides it, otherwise infers the author's intent from recent local Claude Code, Codex, OpenCode, Rovo Dev, Pi, or GitHub Copilot CLI transcripts.
 This is best-effort context, and when available it is included in rebase fixes, review checks and fixes, test detection, evidence validation, and fixes, documentation checks and fixes, lint detection and fixes, CI auto-fixes, and PR drafting.
 
 **Behavior:**

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -54,10 +54,10 @@ Override the default agent for this repo and its setup-wizard suggestions.
 | | |
 |---|---|
 | Type | `string` |
-| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `acp:<target>` |
+| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `acp:<target>` |
 | Default | Inherits from global config |
 
-`auto` resolves to the first supported native agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, then `pi`.
+`auto` resolves to the first supported native agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, `pi`, then `copilot`.
 `acp:<target>` uses the user-installed `acpx` binary configured in global config.
 ACP agents are opt-in and are not considered by `agent: auto`.
 
@@ -162,7 +162,7 @@ Fields not set here inherit from global config and then the built-in defaults.
 | `intent.slack_days` | `int` | Inherits from global (default `3`) |
 | `intent.disabled_readers` | `string[]` | Adds to globally disabled readers |
 
-Valid `disabled_readers` values are `claude`, `codex`, `opencode`, `rovodev`, and `pi`.
+Valid `disabled_readers` values are `claude`, `codex`, `opencode`, `rovodev`, `pi`, and `copilot`.
 
 ### test.evidence
 

--- a/docs/src/content/docs/start-here/installation.md
+++ b/docs/src/content/docs/start-here/installation.md
@@ -47,7 +47,7 @@ make install
 ## Prerequisites
 
 - **git** - required
-- **One supported agent binary** - `claude`, `codex`, `acli` (Rovo Dev), `opencode`, or `pi`, or a separately installed `acpx` binary for `agent: acp:<target>`
+- **One supported agent binary** - `claude`, `codex`, `acli` (Rovo Dev), `opencode`, `pi`, or `copilot`, or a separately installed `acpx` binary for `agent: acp:<target>`
 - **Optional, for PRs and CI:**
   - `gh` CLI (GitHub)
   - `glab` CLI (GitLab)

--- a/docs/src/content/docs/start-here/introduction.md
+++ b/docs/src/content/docs/start-here/introduction.md
@@ -70,7 +70,7 @@ When a branch passes the gate, it means:
 ## What you get
 
 - A fixed, opinionated pipeline: `intent → rebase → review → test → document → lint → push → pr → ci`. Order is not configurable; what each step runs is.
-- Choice of agent: `claude`, `codex`, `rovodev`, `opencode`, `pi`, or `acp:<target>` via `acpx`, with per-repo override.
+- Choice of agent: `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, or `acp:<target>` via `acpx`, with per-repo override.
 - A TUI to watch, approve, fix, skip, or abort any step.
 - A `/no-mistakes` agent skill so a coding agent can do a task and gate it, or gate existing committed work, backed by a non-interactive `no-mistakes axi` interface.
 - A setup wizard when you run bare `no-mistakes` with no active run on the current branch - it walks you through creating a branch, committing, and pushing through the gate, then attaches if the daemon registers the new run.

--- a/docs/src/content/docs/start-here/quick-start.md
+++ b/docs/src/content/docs/start-here/quick-start.md
@@ -24,7 +24,7 @@ no-mistakes doctor
 You need:
 
 - `git`
-- One supported agent binary (`claude`, `codex`, `acli` for Rovo Dev, `opencode`, or `pi`), or a separately installed `acpx` binary for `agent: acp:<target>`
+- One supported agent binary (`claude`, `codex`, `acli` for Rovo Dev, `opencode`, `pi`, or `copilot`), or a separately installed `acpx` binary for `agent: acp:<target>`
 - For PRs and CI: `gh` (GitHub), `glab` (GitLab), or Bitbucket Cloud credentials
 
 For ACP agents, verify `acpx` or `acpx_path` separately because `no-mistakes doctor` does not validate ACP targets.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -590,8 +590,10 @@ func NewWithOptions(name types.AgentName, bin string, extraArgs []string, opts O
 		return &opencodeAgent{bin: bin, extraArgs: extraArgs}, nil
 	case types.AgentPi:
 		return &piAgent{bin: bin, extraArgs: extraArgs}, nil
+	case types.AgentCopilot:
+		return &copilotAgent{bin: bin, extraArgs: extraArgs}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
+		return nil, fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, copilot, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
 	}
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -63,10 +63,23 @@ func finalizeTextResult(agentName, text string, schema json.RawMessage, usage To
 
 	output, err := parseStructuredTextOutput(text, schema)
 	if err != nil {
-		return nil, fmt.Errorf("%s output parse: %w", agentName, err)
+		return nil, fmt.Errorf("%s output parse: %w (output snippet: %q)", agentName, err, outputSnippet(text))
 	}
 
 	return &Result{Output: output, Text: text, Usage: usage}, nil
+}
+
+// outputSnippet returns a trimmed, length-capped excerpt of agent output for
+// inclusion in parse-failure errors. Without it, errors like "invalid
+// character 'N'" are undiagnosable without separately capturing agent stdout.
+func outputSnippet(text string) string {
+	const max = 200
+	trimmed := strings.TrimSpace(text)
+	runes := []rune(trimmed)
+	if len(runes) > max {
+		return string(runes[:max]) + "…"
+	}
+	return trimmed
 }
 
 func parseStructuredTextOutput(text string, schema json.RawMessage) (json.RawMessage, error) {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -560,3 +560,28 @@ func TestFinalizeTextResult_WithSchemaIgnoresJSONInsideNonJSONFence(t *testing.T
 		t.Fatal("expected parse failure")
 	}
 }
+
+func TestFinalizeTextResult_ParseErrorIncludesOutputSnippet(t *testing.T) {
+	text := "Now I've applied all four fixes and verified the build passes."
+	_, err := finalizeTextResult("copilot", text, json.RawMessage(`{"type":"object"}`), TokenUsage{})
+	if err == nil {
+		t.Fatal("expected parse failure on prose output")
+	}
+	if !strings.Contains(err.Error(), "output snippet:") {
+		t.Errorf("error should include an output snippet, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "Now I've applied") {
+		t.Errorf("error should embed the offending text, got %v", err)
+	}
+}
+
+func TestOutputSnippet_TruncatesLongText(t *testing.T) {
+	long := strings.Repeat("x", 500)
+	got := outputSnippet(long)
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("expected ellipsis suffix on truncated snippet, got %q", got)
+	}
+	if runes := []rune(got); len(runes) != 201 {
+		t.Errorf("expected 200 runes plus ellipsis, got %d runes", len(runes))
+	}
+}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -24,6 +24,7 @@ func TestNew_KnownAgents(t *testing.T) {
 		{name: "rovodev", agent: types.AgentRovoDev, bin: "acli", wantName: "rovodev"},
 		{name: "opencode", agent: types.AgentOpenCode, bin: "opencode", wantName: "opencode"},
 		{name: "pi", agent: types.AgentPi, bin: "pi", wantName: "pi"},
+		{name: "copilot", agent: types.AgentCopilot, bin: "copilot", wantName: "copilot"},
 	}
 
 	for _, tt := range tests {

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -131,24 +131,22 @@ func (a *copilotAgent) buildArgs(prompt string) []string {
 	return args
 }
 
-// copilotUserSetPermissionMode reports whether extraArgs already declare a
-// permission flag, in which case buildArgs skips its default --allow-all-tools.
+// copilotUserSetPermissionMode reports whether extraArgs already grant tool
+// auto-approval, in which case buildArgs skips its default --allow-all-tools.
+// Only a blanket approval flag (--allow-all-tools, --allow-all, --yolo) or an
+// explicit allowlist (--allow-tool) counts. Flags that merely restrict the tool
+// set or filesystem paths (--available-tools, --excluded-tools, --deny-tool,
+// --allow-all-paths) do not grant approval, so the non-interactive -p run still
+// needs the default --allow-all-tools to avoid blocking on approval prompts.
 func copilotUserSetPermissionMode(extraArgs []string) bool {
 	for _, arg := range extraArgs {
 		switch {
 		case arg == "--allow-all-tools",
 			arg == "--allow-all",
 			arg == "--yolo",
-			arg == "--allow-tool",
-			arg == "--deny-tool",
-			arg == "--allow-all-paths",
-			arg == "--available-tools",
-			arg == "--excluded-tools":
+			arg == "--allow-tool":
 			return true
-		case strings.HasPrefix(arg, "--allow-tool="),
-			strings.HasPrefix(arg, "--deny-tool="),
-			strings.HasPrefix(arg, "--available-tools="),
-			strings.HasPrefix(arg, "--excluded-tools="):
+		case strings.HasPrefix(arg, "--allow-tool="):
 			return true
 		}
 	}

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -67,10 +67,10 @@ func (a *copilotAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, erro
 	}()
 
 	var usage TokenUsage
-	var lastMessage string
+	var messages []string
 	var copilotErr string
 	exitCode := 0
-	if err := parseCopilotEvents(ctx, stdout, opts.OnChunk, &usage, &lastMessage, &copilotErr, &exitCode); err != nil {
+	if err := parseCopilotEvents(ctx, stdout, opts.OnChunk, &usage, &messages, &copilotErr, &exitCode); err != nil {
 		stderrWG.Wait()
 		_ = cmd.Wait()
 		return nil, fmt.Errorf("copilot parse events: %w", err)
@@ -93,7 +93,31 @@ func (a *copilotAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, erro
 		return nil, fmt.Errorf("copilot reported exit code %d", exitCode)
 	}
 
-	return finalizeTextResult("copilot", lastMessage, opts.JSONSchema, usage)
+	return finalizeCopilotResult(messages, opts.JSONSchema, usage)
+}
+
+// finalizeCopilotResult converts the assistant messages emitted during a run
+// into a structured Result. With no schema it uses the final message verbatim.
+// With a schema it tries each assistant message newest-first and returns the
+// first that parses against it: Copilot is non-deterministic about honoring the
+// JSON-only output contract and frequently emits the schema JSON in an earlier
+// message, then closes with a prose summary (e.g. "Now I've applied all four
+// fixes…") that no extraction strategy can recover. If none parse it falls back
+// to the final message so the returned error reflects the actual final output.
+func finalizeCopilotResult(messages []string, schema json.RawMessage, usage TokenUsage) (*Result, error) {
+	lastMessage := ""
+	if len(messages) > 0 {
+		lastMessage = messages[len(messages)-1]
+	}
+	if len(schema) == 0 {
+		return finalizeTextResult("copilot", lastMessage, schema, usage)
+	}
+	for i := len(messages) - 1; i >= 0; i-- {
+		if result, err := finalizeTextResult("copilot", messages[i], schema, usage); err == nil {
+			return result, nil
+		}
+	}
+	return finalizeTextResult("copilot", lastMessage, schema, usage)
 }
 
 func copilotErrorDetail(copilotErr, stderr string) string {
@@ -201,15 +225,15 @@ type copilotEventData struct {
 }
 
 // parseCopilotEvents reads JSONL from the reader and dispatches events. It
-// streams assistant.message_delta content to onChunk, captures the last
-// assistant.message text as the final answer, accumulates output tokens, and
-// records the terminal result event's exit code.
+// streams assistant.message_delta content to onChunk, appends each non-empty
+// assistant.message text to messages (oldest first), accumulates output tokens,
+// and records the terminal result event's exit code.
 func parseCopilotEvents(
 	ctx context.Context,
 	r io.Reader,
 	onChunk func(string),
 	usage *TokenUsage,
-	lastMessage *string,
+	messages *[]string,
 	copilotErr *string,
 	exitCode *int,
 ) error {
@@ -244,8 +268,8 @@ func parseCopilotEvents(
 				continue
 			}
 			usage.Add(TokenUsage{OutputTokens: event.Data.OutputTokens})
-			if event.Data.Content != "" && lastMessage != nil {
-				*lastMessage = event.Data.Content
+			if event.Data.Content != "" && messages != nil {
+				*messages = append(*messages, event.Data.Content)
 			}
 
 		case "error", "assistant.abort":

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -1,0 +1,277 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+
+	"github.com/kunchenguid/no-mistakes/internal/shellenv"
+)
+
+// copilotAgent spawns the GitHub Copilot CLI for each invocation. Copilot
+// runs non-interactively with `copilot -p <prompt> --output-format json`,
+// emitting JSONL events on stdout. The lifecycle is codex/pi-shaped: one
+// process per Run, no managed server.
+type copilotAgent struct {
+	bin       string
+	extraArgs []string
+}
+
+func (a *copilotAgent) Name() string { return "copilot" }
+
+func (a *copilotAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
+	return runWithRetry(ctx, "copilot", opts, claudeMaxRetries, classifyTransient, nil, func() (*Result, error) {
+		return a.runOnce(ctx, opts)
+	})
+}
+
+func (a *copilotAgent) Close() error { return nil }
+
+func (a *copilotAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
+	prompt := buildCopilotPrompt(opts.Prompt, opts.JSONSchema)
+	args := a.buildArgs(prompt)
+	cmd := exec.CommandContext(ctx, a.bin, args...)
+	cmd.Dir = opts.CWD
+	cmd.Stdin = nil
+	cmd.Env = gitSafeEnv(opts.CWD)
+	// Run in a dedicated process group so cancelling ctx reaps the copilot CLI
+	// and any subprocesses it spawns (git, build tools), not just the direct
+	// child. Otherwise they survive and hold the worktree locked.
+	shellenv.ConfigureShellCommand(cmd)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("copilot stdout pipe: %w", err)
+	}
+
+	var stderrBuf []byte
+	var stderrWG sync.WaitGroup
+	stderrR, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("copilot stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("copilot start: %w", err)
+	}
+
+	stderrWG.Add(1)
+	go func() {
+		defer stderrWG.Done()
+		stderrBuf, _ = io.ReadAll(stderrR)
+	}()
+
+	var usage TokenUsage
+	var lastMessage string
+	var copilotErr string
+	exitCode := 0
+	if err := parseCopilotEvents(ctx, stdout, opts.OnChunk, &usage, &lastMessage, &copilotErr, &exitCode); err != nil {
+		stderrWG.Wait()
+		_ = cmd.Wait()
+		return nil, fmt.Errorf("copilot parse events: %w", err)
+	}
+
+	stderrWG.Wait()
+	waitErr := cmd.Wait()
+
+	detail := copilotErrorDetail(copilotErr, string(stderrBuf))
+	if waitErr != nil {
+		if detail != "" {
+			return nil, fmt.Errorf("copilot exited: %w: %s", waitErr, detail)
+		}
+		return nil, fmt.Errorf("copilot exited: %w", waitErr)
+	}
+	if exitCode != 0 {
+		if detail != "" {
+			return nil, fmt.Errorf("copilot reported exit code %d: %s", exitCode, detail)
+		}
+		return nil, fmt.Errorf("copilot reported exit code %d", exitCode)
+	}
+
+	return finalizeTextResult("copilot", lastMessage, opts.JSONSchema, usage)
+}
+
+func copilotErrorDetail(copilotErr, stderr string) string {
+	detail := strings.TrimSpace(copilotErr)
+	stderr = strings.TrimSpace(stderr)
+	if detail != "" && stderr != "" {
+		return detail + "; " + stderr
+	}
+	if detail != "" {
+		return detail
+	}
+	return stderr
+}
+
+// buildArgs constructs the copilot CLI arguments. User-supplied extraArgs
+// (from agent_args_override) are inserted ahead of the managed flags so user
+// choices (e.g. --model, --effort) win over no-mistakes' defaults. If the user
+// supplied their own permission flag, the default --allow-all-tools is not
+// added; --no-ask-user is always added so the agent never blocks waiting for
+// interactive input.
+func (a *copilotAgent) buildArgs(prompt string) []string {
+	args := make([]string, 0, len(a.extraArgs)+8)
+	args = append(args, a.extraArgs...)
+	args = append(args,
+		"-p", prompt,
+		"--output-format", "json",
+		"--no-color",
+	)
+	if !copilotUserSetAskUser(a.extraArgs) {
+		args = append(args, "--no-ask-user")
+	}
+	if !copilotUserSetPermissionMode(a.extraArgs) {
+		args = append(args, "--allow-all-tools")
+	}
+	return args
+}
+
+// copilotUserSetPermissionMode reports whether extraArgs already declare a
+// permission flag, in which case buildArgs skips its default --allow-all-tools.
+func copilotUserSetPermissionMode(extraArgs []string) bool {
+	for _, arg := range extraArgs {
+		switch {
+		case arg == "--allow-all-tools",
+			arg == "--allow-all",
+			arg == "--yolo",
+			arg == "--allow-tool",
+			arg == "--deny-tool",
+			arg == "--allow-all-paths",
+			arg == "--available-tools",
+			arg == "--excluded-tools":
+			return true
+		case strings.HasPrefix(arg, "--allow-tool="),
+			strings.HasPrefix(arg, "--deny-tool="),
+			strings.HasPrefix(arg, "--available-tools="),
+			strings.HasPrefix(arg, "--excluded-tools="):
+			return true
+		}
+	}
+	return false
+}
+
+// copilotUserSetAskUser reports whether extraArgs already control the ask_user
+// tool, in which case buildArgs skips its default --no-ask-user.
+func copilotUserSetAskUser(extraArgs []string) bool {
+	for _, arg := range extraArgs {
+		if arg == "--no-ask-user" {
+			return true
+		}
+	}
+	return false
+}
+
+// buildCopilotPrompt appends a JSON-output contract to the user prompt when a
+// schema is provided. The Copilot CLI has no equivalent of codex's
+// --output-schema flag, so we inline the schema in the prompt the same way pi
+// and rovodev do, then parse the final text with finalizeTextResult.
+func buildCopilotPrompt(prompt string, schema json.RawMessage) string {
+	if len(schema) == 0 {
+		return prompt
+	}
+	pretty, err := json.MarshalIndent(json.RawMessage(schema), "", "  ")
+	if err != nil {
+		pretty = []byte(schema)
+	}
+	return prompt + "\n\n## no-mistakes final output contract\n\n" +
+		"When the task is complete, your final assistant response must be only valid JSON matching this JSON Schema. " +
+		"Do not wrap it in Markdown fences. Do not include prose before or after the JSON object.\n\n" +
+		string(pretty)
+}
+
+// copilotEvent is the top-level JSONL event from the copilot CLI.
+type copilotEvent struct {
+	Type     string            `json:"type"`
+	Data     *copilotEventData `json:"data,omitempty"`
+	ExitCode *int              `json:"exitCode,omitempty"`
+}
+
+type copilotEventData struct {
+	// assistant.message_delta
+	DeltaContent string `json:"deltaContent,omitempty"`
+	// assistant.message
+	Content      string `json:"content,omitempty"`
+	OutputTokens int    `json:"outputTokens,omitempty"`
+	// error / abort events
+	Message string `json:"message,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+// parseCopilotEvents reads JSONL from the reader and dispatches events. It
+// streams assistant.message_delta content to onChunk, captures the last
+// assistant.message text as the final answer, accumulates output tokens, and
+// records the terminal result event's exit code.
+func parseCopilotEvents(
+	ctx context.Context,
+	r io.Reader,
+	onChunk func(string),
+	usage *TokenUsage,
+	lastMessage *string,
+	copilotErr *string,
+	exitCode *int,
+) error {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), claudeScannerMaxTokenSize)
+
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var event copilotEvent
+		if err := json.Unmarshal(line, &event); err != nil {
+			continue // skip malformed lines
+		}
+
+		switch event.Type {
+		case "assistant.message_delta":
+			if event.Data != nil && event.Data.DeltaContent != "" && onChunk != nil {
+				onChunk(event.Data.DeltaContent)
+			}
+
+		case "assistant.message":
+			if event.Data == nil {
+				continue
+			}
+			usage.Add(TokenUsage{OutputTokens: event.Data.OutputTokens})
+			if event.Data.Content != "" && lastMessage != nil {
+				*lastMessage = event.Data.Content
+			}
+
+		case "error", "assistant.abort":
+			if event.Data != nil && copilotErr != nil {
+				if msg := firstNonEmpty(event.Data.Message, event.Data.Error); msg != "" {
+					*copilotErr = msg
+				}
+			}
+
+		case "result":
+			if event.ExitCode != nil && exitCode != nil {
+				*exitCode = *event.ExitCode
+			}
+		}
+	}
+
+	return scanner.Err()
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/agent/copilot_test.go
+++ b/internal/agent/copilot_test.go
@@ -145,7 +145,8 @@ func TestParseCopilotEvents_FinalMessageAndUsage(t *testing.T) {
 
 	var chunks []string
 	var usage TokenUsage
-	var lastMessage, copilotErr string
+	var messages []string
+	var copilotErr string
 	exitCode := -1
 
 	err := parseCopilotEvents(
@@ -153,15 +154,15 @@ func TestParseCopilotEvents_FinalMessageAndUsage(t *testing.T) {
 		strings.NewReader(events),
 		func(text string) { chunks = append(chunks, text) },
 		&usage,
-		&lastMessage,
+		&messages,
 		&copilotErr,
 		&exitCode,
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if lastMessage != `{"ok":true}` {
-		t.Errorf("last message = %q, want final assistant content", lastMessage)
+	if got := lastOf(messages); got != `{"ok":true}` {
+		t.Errorf("last message = %q, want final assistant content", got)
 	}
 	if strings.Join(chunks, "") != "pong" {
 		t.Errorf("chunks = %v, want streamed deltas po+ng", chunks)
@@ -185,9 +186,10 @@ func TestParseCopilotEvents_CapturesErrorEvent(t *testing.T) {
 	}, "\n")
 
 	var usage TokenUsage
-	var lastMessage, copilotErr string
+	var messages []string
+	var copilotErr string
 	exitCode := 0
-	err := parseCopilotEvents(context.Background(), strings.NewReader(events), nil, &usage, &lastMessage, &copilotErr, &exitCode)
+	err := parseCopilotEvents(context.Background(), strings.NewReader(events), nil, &usage, &messages, &copilotErr, &exitCode)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -208,14 +210,15 @@ func TestParseCopilotEvents_SkipsMalformedAndSessionLines(t *testing.T) {
 	}, "\n")
 
 	var usage TokenUsage
-	var lastMessage, copilotErr string
+	var messages []string
+	var copilotErr string
 	exitCode := 0
-	err := parseCopilotEvents(context.Background(), strings.NewReader(events), nil, &usage, &lastMessage, &copilotErr, &exitCode)
+	err := parseCopilotEvents(context.Background(), strings.NewReader(events), nil, &usage, &messages, &copilotErr, &exitCode)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if lastMessage != "done" {
-		t.Errorf("last message = %q, want 'done'", lastMessage)
+	if got := lastOf(messages); got != "done" {
+		t.Errorf("last message = %q, want 'done'", got)
 	}
 	if usage.OutputTokens != 2 {
 		t.Errorf("output tokens = %d, want 2", usage.OutputTokens)
@@ -332,5 +335,147 @@ func TestCopilotAgent_RunReportsErrorOnNonZeroExit(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not authenticated") {
 		t.Fatalf("error = %v, want copilot error detail", err)
+	}
+}
+
+func lastOf(messages []string) string {
+	if len(messages) == 0 {
+		return ""
+	}
+	return messages[len(messages)-1]
+}
+
+func TestParseCopilotEvents_CollectsAllAssistantMessages(t *testing.T) {
+	events := strings.Join([]string{
+		`{"type":"assistant.message","data":{"content":"{\"ok\":true}","outputTokens":4}}`,
+		`{"type":"assistant.message","data":{"content":"","outputTokens":1}}`,
+		`{"type":"assistant.message","data":{"content":"Now I've applied the fix.","outputTokens":2}}`,
+		`{"type":"result","exitCode":0}`,
+		"",
+	}, "\n")
+
+	var usage TokenUsage
+	var messages []string
+	var copilotErr string
+	exitCode := 0
+	if err := parseCopilotEvents(context.Background(), strings.NewReader(events), nil, &usage, &messages, &copilotErr, &exitCode); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{`{"ok":true}`, "Now I've applied the fix."}
+	if len(messages) != len(want) {
+		t.Fatalf("messages = %v, want %v (empty content should be skipped)", messages, want)
+	}
+	for i := range want {
+		if messages[i] != want[i] {
+			t.Errorf("messages[%d] = %q, want %q", i, messages[i], want[i])
+		}
+	}
+}
+
+// TestFinalizeCopilotResult_RecoversJSONBeforeProseSummary is the core
+// regression for the fix-step parse bug: Copilot emitted the schema JSON in an
+// earlier assistant message, then closed with a prose summary beginning with
+// 'N'. The final message alone cannot be parsed, so scanning newest-first must
+// recover the earlier JSON object.
+func TestFinalizeCopilotResult_RecoversJSONBeforeProseSummary(t *testing.T) {
+	schema := json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"findings":{"type":"array"},
+			"summary":{"type":"string"}
+		},
+		"required":["findings","summary"]
+	}`)
+	messages := []string{
+		`{"findings":[],"summary":"applied four fixes"}`,
+		"Now I've applied all four fixes and verified the build passes.",
+	}
+
+	result, err := finalizeCopilotResult(messages, schema, TokenUsage{})
+	if err != nil {
+		t.Fatalf("expected recovery of earlier JSON message, got error: %v", err)
+	}
+	var output struct {
+		Summary string `json:"summary"`
+	}
+	if err := json.Unmarshal(result.Output, &output); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if output.Summary != "applied four fixes" {
+		t.Errorf("summary = %q, want recovered JSON summary", output.Summary)
+	}
+}
+
+func TestFinalizeCopilotResult_PrefersNewestParsingMessage(t *testing.T) {
+	schema := json.RawMessage(`{"type":"object","properties":{"n":{"type":"integer"}},"required":["n"]}`)
+	messages := []string{
+		`{"n":1}`,
+		`{"n":2}`,
+		"All done.",
+	}
+
+	result, err := finalizeCopilotResult(messages, schema, TokenUsage{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result.Output) != `{"n":2}` {
+		t.Errorf("output = %s, want newest parsing message {\"n\":2}", string(result.Output))
+	}
+}
+
+func TestFinalizeCopilotResult_NoSchemaUsesLastMessage(t *testing.T) {
+	messages := []string{"first", "second"}
+	result, err := finalizeCopilotResult(messages, nil, TokenUsage{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Text != "second" {
+		t.Errorf("text = %q, want last message", result.Text)
+	}
+}
+
+func TestFinalizeCopilotResult_NoneParseReturnsDebuggableError(t *testing.T) {
+	schema := json.RawMessage(`{"type":"object","properties":{"n":{"type":"integer"}},"required":["n"]}`)
+	messages := []string{
+		"Now I've applied all four fixes and verified the build passes.",
+	}
+
+	_, err := finalizeCopilotResult(messages, schema, TokenUsage{})
+	if err == nil {
+		t.Fatal("expected parse error when no message satisfies the schema")
+	}
+	if !strings.Contains(err.Error(), "output snippet:") {
+		t.Errorf("error should include an output snippet for debuggability, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "Now I've applied") {
+		t.Errorf("error snippet should reflect the final prose message, got %v", err)
+	}
+}
+
+func TestCopilotAgent_RunRecoversJSONWhenFinalMessageIsProse(t *testing.T) {
+	dir := t.TempDir()
+	bin := writeFakeCopilot(t, dir, []string{
+		`{"type":"assistant.message","data":{"content":"{\"findings\":[],\"summary\":\"done\"}","outputTokens":5}}`,
+		`{"type":"assistant.message","data":{"content":"Now I have applied the fixes.","outputTokens":3}}`,
+		`{"type":"result","exitCode":0}`,
+	}, 0)
+
+	ca := &copilotAgent{bin: bin}
+	result, err := ca.Run(context.Background(), RunOpts{
+		Prompt:     "fix it",
+		CWD:        t.TempDir(),
+		JSONSchema: json.RawMessage(`{"type":"object","properties":{"findings":{"type":"array"},"summary":{"type":"string"}},"required":["findings","summary"]}`),
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	var output struct {
+		Summary string `json:"summary"`
+	}
+	if err := json.Unmarshal(result.Output, &output); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if output.Summary != "done" {
+		t.Fatalf("output = %s, want recovered summary 'done'", string(result.Output))
 	}
 }

--- a/internal/agent/copilot_test.go
+++ b/internal/agent/copilot_test.go
@@ -54,31 +54,46 @@ func TestCopilotAgent_BuildArgs_ExtraArgsFirst(t *testing.T) {
 }
 
 func TestCopilotAgent_BuildArgs_UserPermissionSuppressesDefault(t *testing.T) {
-	tests := [][]string{
-		{"--allow-all"},
-		{"--yolo"},
-		{"--allow-tool", "write"},
-		{"--allow-tool=shell(git:*)"},
-		{"--deny-tool", "shell(rm)"},
-		{"--allow-all-tools"},
+	tests := []struct {
+		name     string
+		extra    []string
+		suppress bool
+	}{
+		{"allow-all-tools", []string{"--allow-all-tools"}, true},
+		{"allow-all", []string{"--allow-all"}, true},
+		{"yolo", []string{"--yolo"}, true},
+		{"allow-tool", []string{"--allow-tool", "write"}, true},
+		{"allow-tool-eq", []string{"--allow-tool=shell(git:*)"}, true},
+		{"excluded-tools", []string{"--excluded-tools", "shell"}, false},
+		{"available-tools", []string{"--available-tools", "write"}, false},
+		{"deny-tool", []string{"--deny-tool", "shell(rm)"}, false},
+		{"allow-all-paths", []string{"--allow-all-paths"}, false},
 	}
-	for _, extra := range tests {
-		ca := &copilotAgent{bin: "copilot", extraArgs: extra}
-		args := ca.buildArgs("p")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ca := &copilotAgent{bin: "copilot", extraArgs: tt.extra}
+			args := ca.buildArgs("p")
 
-		count := 0
-		for _, a := range args {
-			if a == "--allow-all-tools" {
-				count++
+			count := 0
+			for _, a := range args {
+				if a == "--allow-all-tools" {
+					count++
+				}
 			}
-		}
-		if len(extra) == 1 && extra[0] == "--allow-all-tools" {
-			if count != 1 {
-				t.Errorf("extra=%v expected single --allow-all-tools, got %d: %v", extra, count, args)
+			if tt.suppress {
+				want := 0
+				for _, e := range tt.extra {
+					if e == "--allow-all-tools" {
+						want = 1
+					}
+				}
+				if count != want {
+					t.Errorf("extra=%v expected %d --allow-all-tools, got %d: %v", tt.extra, want, count, args)
+				}
+			} else if count != 1 {
+				t.Errorf("extra=%v expected default --allow-all-tools to be added, got %d: %v", tt.extra, count, args)
 			}
-		} else if count != 0 {
-			t.Errorf("extra=%v expected no default --allow-all-tools, got: %v", extra, args)
-		}
+		})
 	}
 }
 

--- a/internal/agent/copilot_test.go
+++ b/internal/agent/copilot_test.go
@@ -1,0 +1,321 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestCopilotAgent_BuildArgs(t *testing.T) {
+	ca := &copilotAgent{bin: "copilot"}
+	args := ca.buildArgs("fix the bug")
+
+	expected := []string{
+		"-p", "fix the bug",
+		"--output-format", "json",
+		"--no-color",
+		"--no-ask-user",
+		"--allow-all-tools",
+	}
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("arg[%d]: expected %q, got %q", i, want, args[i])
+		}
+	}
+}
+
+func TestCopilotAgent_BuildArgs_ExtraArgsFirst(t *testing.T) {
+	ca := &copilotAgent{bin: "copilot", extraArgs: []string{"--model", "gpt-5.4"}}
+	args := ca.buildArgs("fix it")
+
+	expected := []string{
+		"--model", "gpt-5.4",
+		"-p", "fix it",
+		"--output-format", "json",
+		"--no-color",
+		"--no-ask-user",
+		"--allow-all-tools",
+	}
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("arg[%d]: expected %q, got %q", i, want, args[i])
+		}
+	}
+}
+
+func TestCopilotAgent_BuildArgs_UserPermissionSuppressesDefault(t *testing.T) {
+	tests := [][]string{
+		{"--allow-all"},
+		{"--yolo"},
+		{"--allow-tool", "write"},
+		{"--allow-tool=shell(git:*)"},
+		{"--deny-tool", "shell(rm)"},
+		{"--allow-all-tools"},
+	}
+	for _, extra := range tests {
+		ca := &copilotAgent{bin: "copilot", extraArgs: extra}
+		args := ca.buildArgs("p")
+
+		count := 0
+		for _, a := range args {
+			if a == "--allow-all-tools" {
+				count++
+			}
+		}
+		if len(extra) == 1 && extra[0] == "--allow-all-tools" {
+			if count != 1 {
+				t.Errorf("extra=%v expected single --allow-all-tools, got %d: %v", extra, count, args)
+			}
+		} else if count != 0 {
+			t.Errorf("extra=%v expected no default --allow-all-tools, got: %v", extra, args)
+		}
+	}
+}
+
+func TestCopilotAgent_BuildArgs_UserAskUserSuppressesDefault(t *testing.T) {
+	ca := &copilotAgent{bin: "copilot", extraArgs: []string{"--no-ask-user"}}
+	args := ca.buildArgs("p")
+
+	count := 0
+	for _, a := range args {
+		if a == "--no-ask-user" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected single --no-ask-user, got %d: %v", count, args)
+	}
+}
+
+func TestBuildCopilotPrompt_InlinesSchema(t *testing.T) {
+	schema := json.RawMessage(`{"type":"object","properties":{"ok":{"type":"boolean"}}}`)
+	prompt := buildCopilotPrompt("do the thing", schema)
+
+	if !strings.HasPrefix(prompt, "do the thing") {
+		t.Errorf("prompt should start with the user prompt, got %q", prompt)
+	}
+	if !strings.Contains(prompt, "final output contract") {
+		t.Errorf("prompt should include the output contract, got %q", prompt)
+	}
+	if !strings.Contains(prompt, `"ok"`) {
+		t.Errorf("prompt should embed the schema, got %q", prompt)
+	}
+}
+
+func TestBuildCopilotPrompt_NoSchemaIsUnchanged(t *testing.T) {
+	if got := buildCopilotPrompt("hi", nil); got != "hi" {
+		t.Errorf("expected unchanged prompt, got %q", got)
+	}
+}
+
+func TestParseCopilotEvents_FinalMessageAndUsage(t *testing.T) {
+	events := strings.Join([]string{
+		`{"type":"assistant.message_delta","data":{"deltaContent":"po"}}`,
+		`{"type":"assistant.message_delta","data":{"deltaContent":"ng"}}`,
+		`{"type":"assistant.message","data":{"content":"","outputTokens":3,"toolRequests":[{"name":"shell"}]}}`,
+		`{"type":"assistant.message","data":{"content":"{\"ok\":true}","outputTokens":4}}`,
+		`{"type":"result","exitCode":0,"usage":{"premiumRequests":1}}`,
+		"",
+	}, "\n")
+
+	var chunks []string
+	var usage TokenUsage
+	var lastMessage, copilotErr string
+	exitCode := -1
+
+	err := parseCopilotEvents(
+		context.Background(),
+		strings.NewReader(events),
+		func(text string) { chunks = append(chunks, text) },
+		&usage,
+		&lastMessage,
+		&copilotErr,
+		&exitCode,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if lastMessage != `{"ok":true}` {
+		t.Errorf("last message = %q, want final assistant content", lastMessage)
+	}
+	if strings.Join(chunks, "") != "pong" {
+		t.Errorf("chunks = %v, want streamed deltas po+ng", chunks)
+	}
+	if usage.OutputTokens != 7 {
+		t.Errorf("output tokens = %d, want 7 (3+4)", usage.OutputTokens)
+	}
+	if exitCode != 0 {
+		t.Errorf("exit code = %d, want 0", exitCode)
+	}
+	if copilotErr != "" {
+		t.Errorf("copilotErr = %q, want empty", copilotErr)
+	}
+}
+
+func TestParseCopilotEvents_CapturesErrorEvent(t *testing.T) {
+	events := strings.Join([]string{
+		`{"type":"error","data":{"message":"model overloaded"}}`,
+		`{"type":"result","exitCode":1}`,
+		"",
+	}, "\n")
+
+	var usage TokenUsage
+	var lastMessage, copilotErr string
+	exitCode := 0
+	err := parseCopilotEvents(context.Background(), strings.NewReader(events), nil, &usage, &lastMessage, &copilotErr, &exitCode)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if copilotErr != "model overloaded" {
+		t.Errorf("copilotErr = %q, want 'model overloaded'", copilotErr)
+	}
+	if exitCode != 1 {
+		t.Errorf("exit code = %d, want 1", exitCode)
+	}
+}
+
+func TestParseCopilotEvents_SkipsMalformedAndSessionLines(t *testing.T) {
+	events := strings.Join([]string{
+		"garbage",
+		`{"type":"session.mcp_server_status_changed","data":{"serverName":"x","status":"connected"}}`,
+		`{"type":"assistant.message","data":{"content":"done","outputTokens":2}}`,
+		"",
+	}, "\n")
+
+	var usage TokenUsage
+	var lastMessage, copilotErr string
+	exitCode := 0
+	err := parseCopilotEvents(context.Background(), strings.NewReader(events), nil, &usage, &lastMessage, &copilotErr, &exitCode)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if lastMessage != "done" {
+		t.Errorf("last message = %q, want 'done'", lastMessage)
+	}
+	if usage.OutputTokens != 2 {
+		t.Errorf("output tokens = %d, want 2", usage.OutputTokens)
+	}
+}
+
+// writeFakeCopilot writes a fake copilot binary that emits the given JSONL
+// lines on stdout (one echo per line) and exits with exitCode. It returns the
+// path to the fake binary.
+func writeFakeCopilot(t *testing.T, dir string, jsonlLines []string, exitCode int) string {
+	t.Helper()
+
+	name := "copilot"
+	if runtime.GOOS == "windows" {
+		name = "copilot.cmd"
+	}
+	bin := filepath.Join(dir, name)
+
+	var script string
+	if runtime.GOOS == "windows" {
+		lines := []string{"@echo off"}
+		for _, l := range jsonlLines {
+			lines = append(lines, "echo "+winEchoEscape(l))
+		}
+		lines = append(lines, "exit /b "+itoa(exitCode))
+		script = strings.Join(lines, "\r\n")
+	} else {
+		lines := []string{"#!/bin/sh"}
+		for _, l := range jsonlLines {
+			lines = append(lines, "printf '%s\\n' "+shellSingleQuote(l))
+		}
+		lines = append(lines, "exit "+itoa(exitCode))
+		script = strings.Join(lines, "\n") + "\n"
+	}
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake copilot: %v", err)
+	}
+	return bin
+}
+
+func itoa(n int) string { return strings.TrimSpace(jsonNumber(n)) }
+
+func jsonNumber(n int) string {
+	b, _ := json.Marshal(n)
+	return string(b)
+}
+
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// winEchoEscape escapes a JSON line so cmd.exe `echo` emits it verbatim. JSON
+// produced by these tests contains no cmd metacharacters except quotes, which
+// echo prints literally; escape the shell-significant ones defensively.
+func winEchoEscape(s string) string {
+	r := strings.NewReplacer(
+		"^", "^^",
+		"&", "^&",
+		"<", "^<",
+		">", "^>",
+		"|", "^|",
+	)
+	return r.Replace(s)
+}
+
+func TestCopilotAgent_RunParsesJSONOutput(t *testing.T) {
+	dir := t.TempDir()
+	bin := writeFakeCopilot(t, dir, []string{
+		`{"type":"assistant.message_delta","data":{"deltaContent":"{\"ok\":true}"}}`,
+		`{"type":"assistant.message","data":{"content":"{\"ok\":true}","outputTokens":4}}`,
+		`{"type":"result","exitCode":0}`,
+	}, 0)
+
+	var chunks []string
+	ca := &copilotAgent{bin: bin}
+	result, err := ca.Run(context.Background(), RunOpts{
+		Prompt:     "do work",
+		CWD:        t.TempDir(),
+		JSONSchema: json.RawMessage(`{"type":"object"}`),
+		OnChunk:    func(text string) { chunks = append(chunks, text) },
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	var output map[string]bool
+	if err := json.Unmarshal(result.Output, &output); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if !output["ok"] {
+		t.Fatalf("output = %s, want ok true", string(result.Output))
+	}
+	if result.Usage.OutputTokens != 4 {
+		t.Errorf("output tokens = %d, want 4", result.Usage.OutputTokens)
+	}
+	if len(chunks) != 1 || chunks[0] != `{"ok":true}` {
+		t.Errorf("chunks = %q", chunks)
+	}
+}
+
+func TestCopilotAgent_RunReportsErrorOnNonZeroExit(t *testing.T) {
+	dir := t.TempDir()
+	bin := writeFakeCopilot(t, dir, []string{
+		`{"type":"error","data":{"message":"not authenticated"}}`,
+		`{"type":"result","exitCode":1}`,
+	}, 1)
+
+	ca := &copilotAgent{bin: bin}
+	_, err := ca.Run(context.Background(), RunOpts{
+		Prompt: "do work",
+		CWD:    t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("expected error on non-zero exit")
+	}
+	if !strings.Contains(err.Error(), "not authenticated") {
+		t.Fatalf("error = %v, want copilot error detail", err)
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -97,6 +97,7 @@ func newDoctorCmd() *cobra.Command {
 					{"rovodev", "acli"},
 					{"opencode", "opencode"},
 					{"pi", "pi"},
+					{"copilot", "copilot"},
 				}
 				fmt.Fprintln(w)
 				fmt.Fprintf(w, "  %s\n", sCyan.Render("Agents"))

--- a/internal/cli/doctor_copilot_test.go
+++ b/internal/cli/doctor_copilot_test.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/telemetry"
+)
+
+// TestDoctorListsCopilotAgent exercises the user-facing `no-mistakes doctor`
+// report and verifies the GitHub Copilot CLI now appears in the Agents section
+// and is detected (LookPath) when its binary is on PATH, just like the other
+// first-class agents. The full rendered report is logged so it can be captured
+// as reviewer-visible evidence.
+func TestDoctorListsCopilotAgent(t *testing.T) {
+	restore := telemetry.SetDefaultForTesting(&telemetryRecorder{})
+	defer restore()
+
+	nmHome := t.TempDir()
+	t.Setenv("NM_HOME", nmHome)
+
+	binDir := t.TempDir()
+	copilotPath := writeFakeCopilotBinary(t, binDir)
+
+	// Prepend our fake bin dir so doctor's LookPath("copilot") resolves here,
+	// while git/gh still resolve from the inherited PATH.
+	sep := string(os.PathListSeparator)
+	t.Setenv("PATH", binDir+sep+os.Getenv("PATH"))
+
+	out, err := executeCmd("doctor")
+	if err != nil {
+		t.Fatalf("doctor failed: %v\n%s", err, out)
+	}
+
+	t.Logf("rendered `no-mistakes doctor` report:\n%s", out)
+
+	if !strings.Contains(out, "copilot") {
+		t.Fatalf("doctor report missing copilot agent entry:\n%s", out)
+	}
+	// The copilot line must show the detected fake binary path, proving doctor
+	// probes the copilot binary alongside claude/codex/rovodev/opencode/pi.
+	if !strings.Contains(out, copilotPath) {
+		t.Fatalf("doctor did not detect copilot at %q:\n%s", copilotPath, out)
+	}
+}
+
+// writeFakeCopilotBinary writes a stub `copilot` executable that doctor's
+// LookPath can resolve. doctor never executes it, so an empty no-op script is
+// enough.
+func writeFakeCopilotBinary(t *testing.T, dir string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		dst := filepath.Join(dir, "copilot.cmd")
+		if err := os.WriteFile(dst, []byte("@echo off\r\nexit /b 0\r\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return dst
+	}
+	dst := filepath.Join(dir, "copilot")
+	if err := os.WriteFile(dst, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dst
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -156,7 +156,7 @@ type Intent struct {
 const defaultConfigYAML = `# no-mistakes global configuration
 
 # Agent to use for code generation
-# Options: auto, claude, codex, rovodev, opencode, pi, acp:<target>
+# Options: auto, claude, codex, rovodev, opencode, pi, copilot, acp:<target>
 # "auto" detects the first available native agent on your system
 # Use acp:<target> to run an optional user-installed acpx target, for example acp:gemini
 agent: auto
@@ -197,10 +197,10 @@ auto_fix:
   ci: 3
 
 # User-intent extraction. When you push a branch, no-mistakes can read recent
-# transcripts from your local agent (Claude Code, Codex, OpenCode, Rovo Dev, Pi),
-# pick the session that produced the change, summarize the user intent, and
-# feed it to review, test, document, lint, and PR agents so they understand
-# what you were trying to do - not just the diff.
+# transcripts from your local agent (Claude Code, Codex, OpenCode, Rovo Dev, Pi,
+# Copilot CLI), pick the session that produced the change, summarize the user
+# intent, and feed it to review, test, document, lint, and PR agents so they
+# understand what you were trying to do - not just the diff.
 intent:
   enabled: true
   threshold: 0.2
@@ -225,6 +225,7 @@ var defaultBinary = map[types.AgentName]string{
 	types.AgentRovoDev:  "acli",
 	types.AgentOpenCode: "opencode",
 	types.AgentPi:       "pi",
+	types.AgentCopilot:  "copilot",
 }
 
 // agentProbeOrder is the priority order for auto-detecting agents.
@@ -234,6 +235,7 @@ var agentProbeOrder = []types.AgentName{
 	types.AgentOpenCode,
 	types.AgentRovoDev,
 	types.AgentPi,
+	types.AgentCopilot,
 }
 
 func isACPAgent(name types.AgentName) bool {
@@ -351,6 +353,7 @@ var agentArgsOverrideAgents = map[string]bool{
 	string(types.AgentRovoDev):  true,
 	string(types.AgentOpenCode): true,
 	string(types.AgentPi):       true,
+	string(types.AgentCopilot):  true,
 }
 
 // reservedAgentArgs lists flags that no-mistakes manages internally and that
@@ -384,6 +387,12 @@ var reservedAgentArgs = map[string]map[string]bool{
 		"--mode":       true,
 		"--no-session": true,
 	},
+	string(types.AgentCopilot): {
+		"-p":              true,
+		"--prompt":        true,
+		"--output-format": true,
+		"--no-color":      true,
+	},
 }
 
 // validateAgentArgsOverride ensures each agent key is a known agent name and
@@ -392,7 +401,7 @@ var reservedAgentArgs = map[string]map[string]bool{
 func validateAgentArgsOverride(override map[string][]string) error {
 	for name, args := range override {
 		if !agentArgsOverrideAgents[name] {
-			return fmt.Errorf("invalid agent name in agent_args_override: %q (valid: claude, codex, rovodev, opencode, pi)", name)
+			return fmt.Errorf("invalid agent name in agent_args_override: %q (valid: claude, codex, rovodev, opencode, pi, copilot)", name)
 		}
 		reserved := reservedAgentArgs[name]
 		for i, arg := range args {

--- a/internal/config/config_agent_test.go
+++ b/internal/config/config_agent_test.go
@@ -35,6 +35,7 @@ func TestAgentPath_DefaultBinaries(t *testing.T) {
 		{types.AgentRovoDev, "acli"},
 		{types.AgentOpenCode, "opencode"},
 		{types.AgentPi, "pi"},
+		{types.AgentCopilot, "copilot"},
 	}
 	for _, tt := range tests {
 		cfg := &Config{Agent: tt.agent}
@@ -231,7 +232,7 @@ func TestResolveAgent_AutoSkipsRovoDevWithoutSubcommand(t *testing.T) {
 
 	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
 		switch bin {
-		case "claude", "codex", "opencode", "pi":
+		case "claude", "codex", "opencode", "pi", "copilot":
 			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
 		case "acli":
 			return "/usr/bin/acli", nil

--- a/internal/intent/doc.go
+++ b/internal/intent/doc.go
@@ -1,6 +1,7 @@
 // Package intent extracts a short summary of the user's original intent
 // for a code change by reading recent transcripts from local coding agents
-// (Claude Code, Codex CLI, OpenCode, Rovo Dev) on the developer's machine.
+// (Claude Code, Codex CLI, OpenCode, Rovo Dev, Pi, and GitHub Copilot CLI) on
+// the developer's machine.
 //
 // Given the repo path, the diff filenames, and the commit time window, the
 // package discovers candidate sessions, picks the one with the strongest

--- a/internal/intent/reader_copilot.go
+++ b/internal/intent/reader_copilot.go
@@ -1,0 +1,275 @@
+package intent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// CopilotReaderName is the agent name used in cache keys and DB rows.
+const CopilotReaderName = "copilot"
+
+// copilotReader reads GitHub Copilot CLI sessions. Each session lives in
+// ~/.copilot/session-state/<id>/events.jsonl, a JSONL transcript. The
+// session.start event carries the cwd and start time we filter on; user and
+// assistant messages carry the turn text and tool file-path hints we need for
+// intent inference.
+type copilotReader struct{}
+
+// NewCopilotReader returns a Reader for GitHub Copilot CLI transcripts.
+func NewCopilotReader() Reader { return &copilotReader{} }
+
+func (r *copilotReader) Name() string { return CopilotReaderName }
+
+func (r *copilotReader) Discover(ctx context.Context, opts DiscoverOpts) ([]*Session, error) {
+	home, err := resolveHome(opts.HomeDir)
+	if err != nil {
+		return nil, err
+	}
+	root := filepath.Join(home, ".copilot", "session-state")
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read copilot sessions: %w", err)
+	}
+
+	matcher := newRepoMatcher(ctx, opts.OriginCWD)
+	var out []*Session
+
+	for _, dir := range entries {
+		if ctx.Err() != nil {
+			return out, ctx.Err()
+		}
+		if !dir.IsDir() {
+			continue
+		}
+		path := filepath.Join(root, dir.Name(), "events.jsonl")
+		info, err := os.Stat(path)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		modTime := info.ModTime()
+		if !opts.WindowStart.IsZero() && modTime.Before(opts.WindowStart) {
+			continue
+		}
+		if !opts.WindowEnd.IsZero() && modTime.After(opts.WindowEnd.Add(time.Hour)) {
+			continue
+		}
+		meta, err := copilotPeekMetadata(path)
+		if err != nil || meta == nil {
+			continue
+		}
+		if !matcher.matches(ctx, meta.cwd) {
+			continue
+		}
+		session := &Session{
+			AgentName:     CopilotReaderName,
+			SessionID:     dir.Name(),
+			CWD:           meta.cwd,
+			StartedAt:     meta.startedAt,
+			LastActivity:  modTime,
+			LastMsgKey:    path + "|" + modTime.UTC().Format(time.RFC3339Nano),
+			startedAtPath: path,
+		}
+		out = append(out, session)
+	}
+	return out, nil
+}
+
+func (r *copilotReader) Load(_ context.Context, s *Session) error {
+	if s.startedAtPath == "" {
+		return fmt.Errorf("copilot: session has no path")
+	}
+	f, err := os.Open(s.startedAtPath)
+	if err != nil {
+		return fmt.Errorf("copilot open: %w", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 64*1024*1024)
+	var lastID string
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		rec, ok := parseCopilotRecord(line)
+		if !ok {
+			continue
+		}
+		if rec.id != "" {
+			lastID = rec.id
+		}
+		if rec.message == nil {
+			continue
+		}
+		s.Messages = append(s.Messages, *rec.message)
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("copilot scan: %w", err)
+	}
+	if lastID != "" {
+		s.LastMsgKey = lastID
+	}
+	return nil
+}
+
+// copilotMetadata is the small subset returned by copilotPeekMetadata.
+type copilotMetadata struct {
+	cwd       string
+	startedAt time.Time
+}
+
+// copilotPeekMetadata reads the session.start event to extract the cwd and
+// start time without parsing the full transcript. Returns nil without an
+// error when the file has no parseable session.start record.
+func copilotPeekMetadata(path string) (*copilotMetadata, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 64*1024*1024)
+
+	for scanner.Scan() {
+		var ev struct {
+			Type string `json:"type"`
+			Data struct {
+				StartTime string `json:"startTime"`
+				Context   struct {
+					CWD string `json:"cwd"`
+				} `json:"context"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &ev); err != nil {
+			continue
+		}
+		if ev.Type != "session.start" || ev.Data.Context.CWD == "" {
+			continue
+		}
+		meta := &copilotMetadata{cwd: ev.Data.Context.CWD}
+		if ev.Data.StartTime != "" {
+			if t, err := time.Parse(time.RFC3339Nano, ev.Data.StartTime); err == nil {
+				meta.startedAt = t
+			}
+		}
+		return meta, nil
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+// copilotRecord is the parsed shape of one events.jsonl line we care about.
+type copilotRecord struct {
+	id      string
+	message *Message
+}
+
+// parseCopilotRecord returns a Message for user and assistant turns. It
+// returns ok=true with message=nil for records we track only for LastMsgKey.
+func parseCopilotRecord(line []byte) (copilotRecord, bool) {
+	var raw struct {
+		Type      string          `json:"type"`
+		ID        string          `json:"id"`
+		Timestamp string          `json:"timestamp"`
+		Data      json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(line, &raw); err != nil {
+		return copilotRecord{}, false
+	}
+
+	rec := copilotRecord{id: raw.ID}
+	ts, _ := time.Parse(time.RFC3339Nano, raw.Timestamp)
+
+	switch raw.Type {
+	case "user.message":
+		text := strings.TrimSpace(parseCopilotUserContent(raw.Data))
+		if text == "" || isCopilotSyntheticUserText(text) {
+			return rec, true
+		}
+		rec.message = &Message{
+			Role:      RoleUser,
+			Text:      text,
+			FilePaths: scanFilePathsInText(text),
+			Timestamp: ts,
+		}
+	case "assistant.message":
+		text, paths := parseCopilotAssistantContent(raw.Data)
+		text = strings.TrimSpace(text)
+		if text == "" && len(paths) == 0 {
+			return rec, true
+		}
+		rec.message = &Message{
+			Role:      RoleAssistant,
+			Text:      text,
+			FilePaths: paths,
+			Timestamp: ts,
+		}
+	default:
+		return rec, true
+	}
+	return rec, true
+}
+
+// parseCopilotUserContent extracts the genuine user text. It reads data.content
+// (the user's prompt) and deliberately ignores data.transformedContent, which
+// the CLI pads with injected agent/system instructions that are not user intent.
+func parseCopilotUserContent(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var data struct {
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return ""
+	}
+	return data.Content
+}
+
+// parseCopilotAssistantContent extracts assistant text and any file paths
+// referenced via tool request arguments. Reasoning text is dropped - only the
+// final assistant content is intent-relevant.
+func parseCopilotAssistantContent(raw json.RawMessage) (string, []string) {
+	if len(raw) == 0 {
+		return "", nil
+	}
+	var data struct {
+		Content      string `json:"content"`
+		ToolRequests []struct {
+			Arguments map[string]any `json:"arguments"`
+		} `json:"toolRequests"`
+	}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return "", nil
+	}
+	var paths []string
+	for _, req := range data.ToolRequests {
+		if req.Arguments != nil {
+			paths = append(paths, extractToolPaths(req.Arguments)...)
+		}
+	}
+	return data.Content, paths
+}
+
+// isCopilotSyntheticUserText filters out the synthetic "user" messages the
+// Copilot CLI inserts to feed skill context back into the model. These start
+// with a <skill-context ...> tag and are not user intent.
+func isCopilotSyntheticUserText(text string) bool {
+	t := strings.TrimSpace(text)
+	return strings.HasPrefix(t, "<skill-context")
+}

--- a/internal/intent/reader_copilot_test.go
+++ b/internal/intent/reader_copilot_test.go
@@ -1,0 +1,176 @@
+package intent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeCopilotFixture builds a Copilot-style session-state directory inside a
+// fake $HOME and returns the home path. The session id is fixed so tests can
+// assert on it.
+func writeCopilotFixture(t *testing.T, sessionID string, lines []string) string {
+	t.Helper()
+	home := t.TempDir()
+	dir := filepath.Join(home, ".copilot", "session-state", sessionID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "events.jsonl")
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+func TestCopilotReader_DiscoversAndLoadsRealMessages(t *testing.T) {
+	repoCWD := t.TempDir()
+	fooPath := filepath.Join(repoCWD, "internal", "foo.go")
+	home := writeCopilotFixture(t, "sess-1", []string{
+		`{"type":"session.start","data":{"context":{"cwd":` + jsonString(t, repoCWD) + `},"startTime":"2026-04-18T02:15:37.000Z"},"id":"e0","timestamp":"2026-04-18T02:15:37.000Z"}`,
+		`{"type":"user.message","data":{"content":"please add a foo helper to internal/foo.go","transformedContent":"<agent_instructions>ignore me</agent_instructions>please add a foo helper"},"id":"e1","timestamp":"2026-04-18T02:15:38.000Z"}`,
+		`{"type":"assistant.message","data":{"content":"got it","reasoningText":"thinking","toolRequests":[{"name":"edit","arguments":{"path":` + jsonString(t, fooPath) + `}}],"outputTokens":12},"id":"e2","timestamp":"2026-04-18T02:15:39.000Z"}`,
+		// Synthetic skill-context user message should be skipped.
+		`{"type":"user.message","data":{"content":"<skill-context name=\"repo-context\">base dir...</skill-context>"},"id":"e3","timestamp":"2026-04-18T02:15:40.000Z"}`,
+		// Non-message events should be skipped but still advance LastMsgKey.
+		`{"type":"tool.execution_complete","data":{"toolCallId":"t1"},"id":"e4","timestamp":"2026-04-18T02:15:41.000Z"}`,
+	})
+
+	r := NewCopilotReader()
+	sessions, err := r.Discover(context.Background(), DiscoverOpts{
+		HomeDir:     home,
+		OriginCWD:   repoCWD,
+		WindowStart: time.Now().Add(-24 * time.Hour),
+		WindowEnd:   time.Now().Add(24 * time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("discovered %d sessions, want 1: %+v", len(sessions), sessions)
+	}
+	s := sessions[0]
+	if s.SessionID != "sess-1" {
+		t.Errorf("SessionID = %q, want sess-1", s.SessionID)
+	}
+	if canonicalPath(s.CWD) != canonicalPath(repoCWD) {
+		t.Errorf("CWD = %q, want %q", s.CWD, repoCWD)
+	}
+
+	if err := r.Load(context.Background(), s); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(s.Messages) != 2 {
+		t.Fatalf("got %d messages, want 2 (synthetic + tool event skipped): %+v", len(s.Messages), s.Messages)
+	}
+	if s.Messages[0].Role != RoleUser || !strings.Contains(s.Messages[0].Text, "foo helper") {
+		t.Errorf("first message wrong: %+v", s.Messages[0])
+	}
+	// transformedContent must not leak into the user message text.
+	if strings.Contains(s.Messages[0].Text, "agent_instructions") {
+		t.Errorf("transformedContent leaked into user text: %q", s.Messages[0].Text)
+	}
+	if s.Messages[1].Role != RoleAssistant {
+		t.Errorf("second message not assistant: %+v", s.Messages[1])
+	}
+	foundPath := false
+	for _, p := range s.Messages[1].FilePaths {
+		if strings.HasSuffix(filepath.ToSlash(p), "internal/foo.go") {
+			foundPath = true
+		}
+	}
+	if !foundPath {
+		t.Errorf("expected tool path captured, got %v", s.Messages[1].FilePaths)
+	}
+	if strings.Contains(s.Messages[1].Text, "thinking") {
+		t.Error("reasoningText leaked into assistant text")
+	}
+	if s.LastMsgKey != "e4" {
+		t.Errorf("LastMsgKey = %q, want e4 (last id in file)", s.LastMsgKey)
+	}
+}
+
+func TestCopilotReader_FiltersByCWD(t *testing.T) {
+	repoA := t.TempDir()
+	repoB := t.TempDir()
+	home := writeCopilotFixture(t, "sess-a", []string{
+		`{"type":"session.start","data":{"context":{"cwd":` + jsonString(t, repoA) + `},"startTime":"2026-04-18T02:15:37.000Z"},"id":"e0","timestamp":"2026-04-18T02:15:37.000Z"}`,
+		`{"type":"user.message","data":{"content":"hi"},"id":"e1","timestamp":"2026-04-18T02:15:38.000Z"}`,
+	})
+
+	r := NewCopilotReader()
+	sessions, err := r.Discover(context.Background(), DiscoverOpts{
+		HomeDir:     home,
+		OriginCWD:   repoB,
+		WindowStart: time.Now().Add(-24 * time.Hour),
+		WindowEnd:   time.Now().Add(24 * time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Errorf("expected 0 sessions for unrelated cwd, got %d", len(sessions))
+	}
+}
+
+func TestCopilotReader_TimeWindow(t *testing.T) {
+	repoCWD := t.TempDir()
+	home := writeCopilotFixture(t, "sess-old", []string{
+		`{"type":"session.start","data":{"context":{"cwd":` + jsonString(t, repoCWD) + `}},"id":"e0","timestamp":"2020-01-01T00:00:00.000Z"}`,
+		`{"type":"user.message","data":{"content":"hi"},"id":"e1","timestamp":"2020-01-01T00:00:01.000Z"}`,
+	})
+
+	r := NewCopilotReader()
+	sessions, err := r.Discover(context.Background(), DiscoverOpts{
+		HomeDir:     home,
+		OriginCWD:   repoCWD,
+		WindowStart: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		WindowEnd:   time.Date(2020, 1, 2, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	// The fixture's events.jsonl was just written, so its mod time is "now",
+	// which is far outside the 2020 window: it must be excluded.
+	if len(sessions) != 0 {
+		t.Errorf("expected 0 sessions outside window, got %d", len(sessions))
+	}
+}
+
+func TestCopilotReader_NoHomeNoCrash(t *testing.T) {
+	r := NewCopilotReader()
+	sessions, err := r.Discover(context.Background(), DiscoverOpts{
+		HomeDir:   t.TempDir(), // exists but no .copilot/session-state/
+		OriginCWD: "/somewhere",
+	})
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Errorf("expected 0 sessions when session-state dir missing, got %d", len(sessions))
+	}
+}
+
+func TestCopilotReader_SkipsSessionWithoutStartEvent(t *testing.T) {
+	repoCWD := t.TempDir()
+	home := writeCopilotFixture(t, "sess-nostart", []string{
+		`{"type":"user.message","data":{"content":"hi"},"id":"e1","timestamp":"2026-04-18T02:15:38.000Z"}`,
+	})
+
+	r := NewCopilotReader()
+	sessions, err := r.Discover(context.Background(), DiscoverOpts{
+		HomeDir:     home,
+		OriginCWD:   repoCWD,
+		WindowStart: time.Now().Add(-24 * time.Hour),
+		WindowEnd:   time.Now().Add(24 * time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("discover: %v", err)
+	}
+	if len(sessions) != 0 {
+		t.Errorf("expected 0 sessions without session.start metadata, got %d", len(sessions))
+	}
+}

--- a/internal/intent/readers.go
+++ b/internal/intent/readers.go
@@ -10,6 +10,7 @@ func AllReaders(disabled map[string]bool) []Reader {
 		NewOpenCodeReader(),
 		NewRovoDevReader(),
 		NewPiReader(),
+		NewCopilotReader(),
 	}
 	if len(disabled) == 0 {
 		return all

--- a/internal/intent/readers_test.go
+++ b/internal/intent/readers_test.go
@@ -4,15 +4,15 @@ import "testing"
 
 func TestAllReaders_NoDisabled(t *testing.T) {
 	got := AllReaders(nil)
-	if len(got) != 5 {
-		t.Errorf("expected 5 readers, got %d", len(got))
+	if len(got) != 6 {
+		t.Errorf("expected 6 readers, got %d", len(got))
 	}
 }
 
 func TestAllReaders_Disabled(t *testing.T) {
 	got := AllReaders(map[string]bool{"codex": true, "rovodev": true})
-	if len(got) != 3 {
-		t.Errorf("expected 3 readers, got %d", len(got))
+	if len(got) != 4 {
+		t.Errorf("expected 4 readers, got %d", len(got))
 	}
 	for _, r := range got {
 		if r.Name() == "codex" || r.Name() == "rovodev" {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -139,4 +139,5 @@ const (
 	AgentRovoDev  AgentName = "rovodev"
 	AgentOpenCode AgentName = "opencode"
 	AgentPi       AgentName = "pi"
+	AgentCopilot  AgentName = "copilot"
 )


### PR DESCRIPTION
## Intent

Add the GitHub Copilot CLI as a first-class no-mistakes agent at full parity with the existing backends (subprocess agent running 'copilot -p' with JSONL output and inlined schema, plus a ~/.copilot/session-state transcript intent reader), wired into auto-detection, config, reserved flags, doctor, and docs. Re-running only push/pr/ci to open the PR and watch CI after switching to a GitHub account permitted to create the PR.

## What Changed

- Added a `copilot` agent backend (`internal/agent/copilot.go`) that runs `copilot -p` with JSONL output and an inlined response schema, plus a matching `~/.copilot/session-state` transcript intent reader (`internal/intent/reader_copilot.go`).
- Wired the new `AgentCopilot` type into auto-detection probe order, default binary mapping, `agent_args_override` with reserved flags (`-p`, `--prompt`, `--output-format`, `--no-color`), the `doctor` agent check, and the `auto` agent factory.
- Updated configuration defaults, AGENTS.md, the intent package doc comment, and the docs site to list Copilot CLI alongside the existing Claude, Codex, Rovo Dev, OpenCode, and Pi backends.

## Risk Assessment

✅ Low: The change is additive and well-bounded, faithfully mirrors the existing pi/claude agent and reader patterns with comprehensive unit tests and accurate docs, all call sites are wired, and the only prior actionable finding was correctly resolved with no new issues introduced.

## Testing

Baseline `go build ./...` is clean. Ran the targeted copilot agent and intent-reader suites plus the agent/config/types packages: every copilot-specific test passes, including two that spawn a real fake `copilot` process and exercise the full `copilot -p` JSONL streaming/parse path and non-zero-exit error surfacing, and reader tests that discover/load ~/.copilot/session-state transcripts with cwd/time filtering and synthetic-message exclusion. For reviewer-visible product evidence I added a portable in-process test that renders the actual `no-mistakes doctor` CLI report and confirms `copilot` is now a first-class Agents entry detected on PATH (captured as a transcript artifact). Two failing tests (internal/cli TestRoot*/telemetry and internal/intent symlink) are pre-existing, reproduced, environment-only issues (git 2.54 bare-repo config behavior; Windows symlink privilege) that the additive Copilot change does not touch. Transient build output (bin/) was removed; the new test file is intentionally kept.

<details>
<summary>Evidence: Rendered `no-mistakes doctor` report — copilot listed and detected as a first-class agent</summary>

<code>Agents&#10;– claude not found&#10;– codex not found&#10;– rovodev not found&#10;– opencode not found&#10;– pi not found&#10;✓ copilot &lt;bin&gt;\copilot.cmd (detected on PATH, same probe as the other agents)</code>

```text
=== RUN   TestDoctorListsCopilotAgent
    doctor_copilot_test.go:38: rendered `no-mistakes doctor` report:
          System
          ✓ git             git version 2.54.0.windows.1
          ✓ gh              ok
          ✓ data directory  C:\Users\kamick\AppData\Local\Temp\TestDoctorListsCopilotAgent740455664\001
          – database        not found (will be created on first use)
          – daemon          stopped
        
          Agents
          – claude          not found
          – codex           not found
          – rovodev         not found
          – opencode        not found
          – pi              not found
          ✓ copilot         C:\Users\kamick\AppData\Local\Temp\TestDoctorListsCopilotAgent740455664\002\copilot.cmd
--- PASS: TestDoctorListsCopilotAgent (0.17s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/cli	3.483s
```
</details>
<details>
<summary>Evidence: Copilot agent + transcript-reader test transcript (incl. real-subprocess copilot -p JSONL run)</summary>

```text
=== RUN   TestCopilotAgent_BuildArgs
--- PASS: TestCopilotAgent_BuildArgs (0.00s)
=== RUN   TestCopilotAgent_BuildArgs_ExtraArgsFirst
--- PASS: TestCopilotAgent_BuildArgs_ExtraArgsFirst (0.00s)
=== RUN   TestCopilotAgent_BuildArgs_UserPermissionSuppressesDefault
=== RUN   TestCopilotAgent_BuildArgs_UserPermissionSuppressesDefault/allow-all-tools
=== RUN   TestCopilotAgent_BuildArgs_UserPermissionSuppressesDefault/allow-all
=== RUN   TestCopilotAgent_BuildArgs_UserPermissionSuppressesDefault/yolo
=== RUN   TestCopilotAgent_BuildArgs_UserPermissionSuppressesDefault/allow-tool
=== RUN   TestCopilotAgent_BuildArgs_UserPermissionSuppressesDefault/allow-tool-eq
=== RUN   TestCopilotAgent_BuildArgs_UserPermissionSuppressesDefault/excluded-tools
=== RUN   TestCopilotAgent_BuildArgs_UserPermissionSuppressesDefault/available-tools
=== RUN   TestCopilotAgent_BuildArgs_UserPermissionSuppressesDefault/deny-tool
=== RUN   TestCopilotAgent_BuildArgs_UserPermissionSuppressesDefault/allow-all-paths
--- PASS: TestCopilotAgent_BuildArgs_UserPermissionSuppressesDefault (0.00s)
    --- PASS: TestCopilotAgent_BuildArgs_UserPermissionSuppressesDefault/allow-all-tools (0.00s)
    --- PASS: TestCopilotAgent_BuildArgs_UserPermissionSuppressesDefault/allow-all (0.00s)
    --- PASS: TestCopilotAgent_BuildArgs_UserPermissionSuppressesDefault/yolo (0.00s)
    --- PASS: TestCopilotAgent_BuildArgs_UserPermissionSuppressesDefault/allow-tool (0.00s)
    --- PASS: TestCopilotAgent_BuildArgs_UserPermissionSuppressesDefault/allow-tool-eq (0.00s)
    --- PASS: TestCopilotAgent_BuildArgs_UserPermissionSuppressesDefault/excluded-tools (0.00s)
    --- PASS: TestCopilotAgent_BuildArgs_UserPermissionSuppressesDefault/available-tools (0.00s)
    --- PASS: TestCopilotAgent_BuildArgs_UserPermissionSuppressesDefault/deny-tool (0.00s)
    --- PASS: TestCopilotAgent_BuildArgs_UserPermissionSuppressesDefault/allow-all-paths (0.00s)
=== RUN   TestCopilotAgent_BuildArgs_UserAskUserSuppressesDefault
--- PASS: TestCopilotAgent_BuildArgs_UserAskUserSuppressesDefault (0.00s)
=== RUN   TestBuildCopilotPrompt_InlinesSchema
--- PASS: TestBuildCopilotPrompt_InlinesSchema (0.00s)
=== RUN   TestBuildCopilotPrompt_NoSchemaIsUnchanged
--- PASS: TestBuildCopilotPrompt_NoSchemaIsUnchanged (0.00s)
=== RUN   TestParseCopilotEvents_FinalMessageAndUsage
--- PASS: TestParseCopilotEvents_FinalMessageAndUsage (0.00s)
=== RUN   TestParseCopilotEvents_CapturesErrorEvent
--- PASS: TestParseCopilotEvents_CapturesErrorEvent (0.00s)
=== RUN   TestParseCopilotEvents_SkipsMalformedAndSessionLines
--- PASS: TestParseCopilotEvents_SkipsMalformedAndSessionLines (0.00s)
=== RUN   TestCopilotAgent_RunParsesJSONOutput
--- PASS: TestCopilotAgent_RunParsesJSONOutput (0.19s)
=== RUN   TestCopilotAgent_RunReportsErrorOnNonZeroExit
--- PASS: TestCopilotAgent_RunReportsErrorOnNonZeroExit (0.18s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/agent	1.172s
=== RUN   TestCopilotReader_DiscoversAndLoadsRealMessages
--- PASS: TestCopilotReader_DiscoversAndLoadsRealMessages (0.31s)
=== RUN   TestCopilotReader_FiltersByCWD
--- PASS: TestCopilotReader_FiltersByCWD (0.61s)
=== RUN   TestCopilotReader_TimeWindow
--- PASS: TestCopilotReader_TimeWindow (0.25s)
=== RUN   TestCopilotReader_NoHomeNoCrash
--- PASS: TestCopilotReader_NoHomeNoCrash (0.00s)
=== RUN   TestCopilotReader_SkipsSessionWithoutStartEvent
--- PASS: TestCopilotReader_SkipsSessionWithoutStartEvent (0.29s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/intent	4.601s
testing: warning: no tests to run
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/config	2.777s [no tests to run]
```
</details>
- Outcome: ⚠️ 3 infos across 1 run (18m38s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `internal/agent/copilot.go:145` - copilotUserSetPermissionMode treats --available-tools/--excluded-tools as permission flags, so supplying only one of them via agent_args_override suppresses the default --allow-all-tools. Those flags restrict the available tool *set*, not the approval policy; without an approval grant the non-interactive `-p` run can block or fail on tool-approval prompts, because the always-added --no-ask-user only disables the ask_user tool, it does not auto-approve tool execution. Confirm whether --allow-all-tools should still be appended when the user supplied only tool-set (not approval) flags.
- ℹ️ `internal/agent/copilot.go:248` - parseCopilotEvents only accumulates OutputTokens; copilotEventData declares no input/cache token fields and the terminal `result` event&#39;s usage object (present in fixtures, e.g. {&#34;premiumRequests&#34;:1}) is ignored. Every other agent records InputTokens/cache tokens, so copilot usage/cost reporting will undercount. Likely acceptable given Copilot&#39;s premium-request billing model, but it is an intentional-looking asymmetry worth a quick confirm.
- ℹ️ `internal/agent/copilot.go:96` - The error message captured from `error`/`assistant.abort` events (copilotErr) is only surfaced when waitErr != nil or exitCode != 0. If copilot reports an error/abort but still exits 0 with no non-empty assistant.message content, finalizeTextResult returns a generic &#34;copilot returned no text output&#34; and the real reason is discarded. There is also no delta-accumulation fallback (unlike pi&#39;s finalText), so a final answer delivered only through assistant.message_delta would be lost. Consider surfacing copilotErr (and/or accumulated deltas) when lastMessage is empty.

🔧 Fix: Restrict copilot allow-all-tools suppression to approval grants
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 3 infos</summary>

- ℹ️ `internal/cli/root_test.go` - Pre-existing, environment-only failures unrelated to the Copilot change: internal/cli TestRoot* and TestInitTracksCommandTelemetry fail because git 2.54.0.windows.1 returns `fatal: not in a git directory` (exit 128) for `git config receive.advertisePushOptions true` against a bare repo (invoked by internal/gate and internal/daemon during init). Reproduced directly: `git init --bare &lt;dir&gt;; git -C &lt;dir&gt; config receive.advertisePushOptions true` =&gt; exit 128. The Copilot change touches none of gate/daemon/git/init, so these are not regressions; flagged for reviewer awareness so CI noise isn&#39;t mistaken for a Copilot defect.
- ℹ️ `internal/intent/disambiguator_test.go:234` - Pre-existing, environment-only failure unrelated to the Copilot change: internal/intent TestAgentDisambiguatorPreservesPreexistingIgnoredSymlink fails with `A required privilege is not held by the client` because creating a symlink on this Windows host requires Developer Mode/elevated privileges. All Copilot reader tests in the same package pass. Flagged for awareness only.
- ℹ️ `internal/cli/doctor_copilot_test.go` - new test file written by agent: internal/cli/doctor_copilot_test.go
- <code>`go build ./...` (clean)</code>
- <code>`go test -run &#39;Copilot&#39; -v ./internal/agent ./internal/intent ./internal/config` — all copilot agent + transcript-reader tests pass, including TestCopilotAgent_RunParsesJSONOutput and TestCopilotAgent_RunReportsErrorOnNonZeroExit which spawn a real fake `copilot` subprocess and parse its JSONL end-to-end</code>
- <code>`go test ./internal/agent ./internal/config ./internal/types` (green: agent registration, defaultBinary, auto-detect probe order, agent_args_override/reserved flags, AgentCopilot const)</code>
- <code>Added and ran new portable test `go test -run &#39;TestDoctorListsCopilotAgent&#39; -v ./internal/cli` — renders the real `no-mistakes doctor` report and asserts copilot appears in Agents and is detected at its on-PATH binary</code>
- <code>`go test -run &#39;TestDoctor&#39; -v ./internal/cli` (doctor telemetry test passes)</code>
- <code>Reproduced `git init --bare &lt;dir&gt;; git -C &lt;dir&gt; config receive.advertisePushOptions true` =&gt; `fatal: not in a git directory` (exit 128) to confirm the cli TestRoot*/telemetry failures are git 2.54 environment issues, not regressions</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
