### PR TITLE
ci(e2e): sweep step-local e2e tests in make e2e

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,7 @@ Safest local verification sequence after non-trivial changes:
 - Unit-test pure helpers and tightly scoped package behavior where speed and failure localization are worth more than full-product realism.
 - Prefer targeted package tests while iterating, then finish with `go test -race ./...` and `make e2e` when your change affects those process or I/O boundaries.
 - The e2e suite lives behind the `e2e` build tag, so it is excluded from `go test ./...` and runs separately in CI via `make e2e`.
+- `make e2e` sweeps both `./internal/e2e/...` (full journey suite) and `./internal/pipeline/steps/...`, so step-local e2e tests (e.g. `internal/pipeline/steps/*_e2e_test.go`, gated by `//go:build e2e`) are also covered. Keep new step-local e2e tests behind the `e2e` tag so `go test ./...` still skips them.
 
 **Repo Config Trust Boundary (security)**
 

--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,12 @@ test:
 
 # End-to-end suite: drives the real no-mistakes binary against a fake
 # agent through the full push -> pipeline -> push journey for each
-# e2e-covered agent backend. Excluded from `make test` because it is
-# behind the `e2e` build tag and rebuilds binaries on each run.
+# e2e-covered agent backend, plus the step-local e2e tests that live
+# next to the pipeline-step code (e.g. coverage provider journeys).
+# Excluded from `make test` because it is behind the `e2e` build tag and
+# rebuilds binaries on each run.
 e2e:
-	go test -tags=e2e -count=1 -timeout 300s ./internal/e2e/...
+	go test -tags=e2e -count=1 -timeout 300s ./internal/e2e/... ./internal/pipeline/steps/...
 
 # Re-record fixtures from the real claude/codex/opencode CLIs and overwrite
 # internal/e2e/fixtures/. Spends real API quota — run only when the upstream


### PR DESCRIPTION
## Intent

The developer wanted to extend no-mistakes' Makefile `e2e` target so it sweeps `internal/pipeline/steps/*_e2e_test.go` (the step-local JS/Swift provider e2e tests) in addition to the existing `./internal/e2e/...` sweep, which currently misses them. The change had to be minimal, keep existing tests unaffected, and be verified by running `make e2e`. Explicit constraints: branch off `origin/main` (not the diverged local main), stay inside the worktree, and — per the overriding Rules and Definition-of-Done sections — ship local-only with no push, no PR, and no merge, keeping the branch a clean fast-forward onto the default branch on `fm/nm-e2e-makefile-j4`. Any durable project knowledge gained should be recorded in AGENTS.md, proportionate to the change.

## What Changed
- Extended the Makefile `e2e` target to sweep `./internal/pipeline/steps/...` alongside `./internal/e2e/...`, so step-local e2e tests (e.g. `internal/pipeline/steps/*_e2e_test.go`, gated by `//go:build e2e`) now run under `make e2e` instead of being silently missed.
- Updated the `e2e` target's comment to document the broader sweep.
- Added an AGENTS.md note recording that `make e2e` covers both locations and that step-local e2e tests must stay behind the `e2e` tag so `go test ./...` still skips them.

## Risk Assessment

✅ Low: A two-file, forward-looking change to a test-invocation target that adds a package pattern and matching documentation; the side effect (re-running unit tests in parallel) is acknowledged, bounded by the existing 300s timeout, and introduces no correctness or security risk.

## Testing

The full `make e2e` passes with the new `./internal/pipeline/steps/...` path included (internal/e2e 82.5s, internal/pipeline/steps 42.2s, exit 0), confirming existing tests are unaffected. Because no committed step-local `*_e2e_test.go` files exist yet, I added a temporary e2e-tagged probe in `internal/pipeline/steps/` and showed it is excluded from the plain `go test ./...` sweep but listed and executed under `make e2e`'s `-tags=e2e` invocation, directly proving the stated intent; the probe was then removed and the tree left clean with only the Makefile + AGENTS.md changes committed.

<details>
<summary>Evidence: make e2e full run output</summary>

<code>go test -tags=e2e -count=1 -timeout 300s ./internal/e2e/... ./internal/pipeline/steps/...&#10;ok github.com/kunchenguid/no-mistakes/internal/e2e 82.452s&#10;ok github.com/kunchenguid/no-mistakes/internal/pipeline/steps 42.197s&#10;===make e2e exit: 0</code>

```text
go test -tags=e2e -count=1 -timeout 300s ./internal/e2e/... ./internal/pipeline/steps/...
ok  	github.com/kunchenguid/no-mistakes/internal/e2e	82.452s
ok  	github.com/kunchenguid/no-mistakes/internal/pipeline/steps	42.197s
```
</details>
<details>
<summary>Evidence: step-local e2e sweep proof (probe excluded from go test ./..., run by make e2e)</summary>

<code>Makefile e2e target: go test -tags=e2e -count=1 -timeout 300s ./internal/e2e/... ./internal/pipeline/steps/...&#10;Committed *_e2e_test.go under internal/pipeline/steps: 0&#10;1) go test ./... (no tag) -&gt; probe NOT listed (excluded)&#10;2) make e2e invocation (-tags=e2e) -&gt; probe RUN and PASS:&#10;=== RUN TestStepLocalE2eSweptByMakeE2e&#10;step-local e2e-tagged test reached by make e2e&#10;--- PASS: TestStepLocalE2eSweptByMakeE2e (0.00s)&#10;PASS</code>

```text
## Probe: e2e-tagged step-local test sweep

### Makefile e2e target (post-change):
e2e:
	go test -tags=e2e -count=1 -timeout 300s ./internal/e2e/... ./internal/pipeline/steps/...

### Confirm no committed *_e2e_test.go exist in internal/pipeline/steps (pre-probe):
(git-tracked e2e test files under steps:) 0

### Temporary probe file created: internal/pipeline/steps/sweep_probe_e2e_test.go
    build constraint: //go:build e2e

### 1) go test ./... sweep must EXCLUDE probe (no -tags=e2e):
ok  	github.com/kunchenguid/no-mistakes/internal/pipeline/steps	0.015s

### 2) make e2e's invocation (-tags=e2e) must INCLUDE + RUN probe:
=== RUN   TestStepLocalE2eSweptByMakeE2e
    sweep_probe_e2e_test.go:10: step-local e2e-tagged test reached by make e2e
--- PASS: TestStepLocalE2eSweptByMakeE2e (0.00s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/pipeline/steps	0.016s

### 3) Full 'make e2e' result (this run):
    internal/e2e        ok  82.452s
    internal/pipeline/steps  ok  42.197s   (newly swept by e2e target)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`
- <code>`make e2e` (full suite: `go test -tags=e2e -count=1 -timeout 300s ./internal/e2e/... ./internal/pipeline/steps/...`) -&gt; ok internal/e2e 82.5s, ok internal/pipeline/steps 42.2s, exit 0</code>
- <code>`go test ./internal/pipeline/steps/... -list &#39;TestStepLocalE2eSweptByMakeE2e&#39;` (no -tags=e2e) -&gt; probe NOT listed, confirms e2e-tagged step-local tests stay excluded from the normal `go test ./...` sweep</code>
- <code>`go test -tags=e2e ./internal/pipeline/steps/... -list &#39;TestStepLocalE2eSweptByMakeE2e&#39;` -&gt; probe LISTED, confirms it is compiled under the e2e tag that `make e2e` uses</code>
- <code>`go test -tags=e2e -count=1 -timeout 300s -run &#39;^TestStepLocalE2eSweptByMakeE2e$&#39; ./internal/pipeline/steps/... -v` -&gt; PASS, confirms `make e2e`&#39;s exact invocation runs the step-local e2e-tagged test</code>
- <code>baseline `go test -race ./...` (already ran successfully per task context)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
