### PR TITLE
fix(daemon): preserve test daemon PATH for e2e

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -59,6 +60,10 @@ func Run() error {
 
 func prepareDaemonEnvironment() error {
 	nmHome := os.Getenv("NM_HOME")
+	testDaemonPath := ""
+	if os.Getenv("NM_TEST_START_DAEMON") == "1" {
+		testDaemonPath = os.Getenv("PATH")
+	}
 	for _, key := range []string{
 		"CLAUDECODE",
 		"CLAUDE_CODE_ENTRYPOINT",
@@ -72,6 +77,11 @@ func prepareDaemonEnvironment() error {
 	}
 	if err := applyShellEnvToProcess(); err != nil {
 		return fmt.Errorf("apply login shell environment: %w", err)
+	}
+	if testDaemonPath != "" {
+		if err := prependPathEntries(testDaemonPath); err != nil {
+			return fmt.Errorf("preserve test daemon PATH: %w", err)
+		}
 	}
 	if nmHome != "" {
 		if err := os.Setenv("NM_HOME", nmHome); err != nil {
@@ -87,6 +97,29 @@ func prepareDaemonEnvironment() error {
 // daemon log alone. We emit it via slog.Default because this runs before
 // initLogger; the default handler still writes to stderr, which launchd and
 // systemd redirect into the daemon log file.
+func prependPathEntries(prefixPath string) error {
+	merged := mergePathLists(prefixPath, os.Getenv("PATH"))
+	return os.Setenv("PATH", merged)
+}
+
+func mergePathLists(pathValues ...string) string {
+	seen := map[string]struct{}{}
+	var merged []string
+	for _, pathValue := range pathValues {
+		for _, entry := range filepath.SplitList(pathValue) {
+			if entry == "" {
+				continue
+			}
+			if _, ok := seen[entry]; ok {
+				continue
+			}
+			seen[entry] = struct{}{}
+			merged = append(merged, entry)
+		}
+	}
+	return strings.Join(merged, string(os.PathListSeparator))
+}
+
 func logDaemonPathSummary() {
 	path := os.Getenv("PATH")
 	entries := 0

--- a/internal/daemon/env_test.go
+++ b/internal/daemon/env_test.go
@@ -51,6 +51,26 @@ func TestPrepareDaemonEnvironment_RemovesClaudeSessionVarsAndAppliesShellEnv(t *
 	}
 }
 
+func TestPrepareDaemonEnvironment_PreservesTestDaemonPathBeforeShellPath(t *testing.T) {
+	t.Setenv("NM_TEST_START_DAEMON", "1")
+	t.Setenv("PATH", "/tmp/fake-bin:/process/bin")
+
+	oldApply := applyShellEnvToProcess
+	defer func() { applyShellEnvToProcess = oldApply }()
+
+	applyShellEnvToProcess = func() error {
+		return os.Setenv("PATH", "/resolved/bin:/usr/bin")
+	}
+
+	if err := prepareDaemonEnvironment(); err != nil {
+		t.Fatal(err)
+	}
+	wantPrefix := "/tmp/fake-bin:/process/bin:/resolved/bin:/usr/bin"
+	if got := os.Getenv("PATH"); !strings.HasPrefix(got, wantPrefix) {
+		t.Fatalf("PATH = %q, want test daemon inherited entries before shell entries prefix %q", got, wantPrefix)
+	}
+}
+
 func TestPrepareDaemonEnvironment_PreservesExistingNMHome(t *testing.T) {
 	t.Setenv("NM_HOME", "/service/root")
 	t.Setenv("PATH", os.Getenv("PATH"))


### PR DESCRIPTION
## Intent

Repair the upstream make e2e baseline so the fork-routing e2e test uses the test daemon fake provider CLI instead of losing it during daemon environment setup.

## What Changed
- Preserve inherited PATH entries ahead of the shell-resolved PATH when the test daemon mode is active, so e2e fake provider CLIs remain visible to daemon-run steps.
- Add a daemon environment regression test for the test-daemon PATH handoff.

## Risk Assessment

✅ Low: no risks detected in the diff

## Testing

local validation passed

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `local validation completed before opening PR`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

## Linked Issue

Fixes #325.

## Local Validation

```sh
go test ./internal/daemon ./internal/shellenv -count=1
go test -tags=e2e -count=1 -timeout 240s ./internal/e2e -run '^(TestForkRouting|TestUserJourney)$' -v
make e2e
make lint
make test
make build
```

Disclosure: This field report was written with AI-assisted editing and summarization. The underlying diagnostic run, repair branch, PR status, validation commands, and technical claims come from my own Scarab/SDS field-test work and were reviewed manually by me before pushing it.
