### PR TITLE
fix(gitlab): drive self-hosted GitLab out-of-the-box with glab v1.5x

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,12 @@ Safest local verification sequence after non-trivial changes:
 - GitLab and Bitbucket fork MR/PR routing is intentionally out of scope until implemented end to end.
 - If a legacy or manually edited row has `fork_url` for GitLab or Bitbucket, PR creation must skip instead of opening a self PR.
 
+**GitLab Backend (`internal/scm/gitlab`)**
+
+- The GitLab `Host` is constructed via `gitlab.New(cmd, cliAvailable, host, projectPath)`, mirroring the GitHub backend's positional constructor. `host` is the repo's GitLab hostname (from `scm.ExtractHost(UpstreamURL)`); `projectPath` is the `group/project` path (subgroups allowed, from `gitlab.ProjectPath` - which lives in the gitlab package next to the `Host` that consumes it, mirroring `github.RepoSlug`). Both are optional; passing `"", ""` reproduces the legacy unscoped behavior used by unit tests.
+- glab's flag surface drifts between versions; the backend is pinned against `glab v1.5x`. Two flags bit us: `glab auth status` must be **host-scoped** with `--hostname <host>` (unscoped, it checks every configured instance and fails if ANY has a stale token, falsely reporting an authenticated repo as unauthenticated); and `glab mr list` no longer accepts `--state opened` (open is the default; v1.5x exposes `-c/--closed`, `-M/--merged`, `-A/--all`) - passing the removed flag fails the whole command. When the host is unknown, fall back to the unscoped auth check (fail-safe).
+- The daemon operates in a **detached-HEAD worktree** (it checks out the commit, not a branch). `glab ci get` refuses to run there ("you're not on any Git branch (a 'detached HEAD' state)") even with an explicit `--pipeline-id`. Read pipeline jobs via the branch-independent REST endpoint instead: `glab api projects/<url-encoded group%2Fproject>/pipelines/<id>/jobs` (`Host.pipelineJobsArgs`). The legacy `glab ci get` path is kept only as the fallback when no project path is supplied. The `glab api .../jobs` payload carries `finished_at`, mapped into `Check.CompletedAt` (needed for CI re-run detection).
+
 **Documentation**
 
 - Keep `README.md` concise and high-level. The bar needs to be extremely high for what has to show up there.

--- a/docs/src/content/docs/guides/provider-integration.md
+++ b/docs/src/content/docs/guides/provider-integration.md
@@ -140,6 +140,12 @@ These are GitHub and GitLab only right now.
 
 Self-hosted GitHub Enterprise and self-hosted GitLab instances work through the same `gh` and `glab` CLIs. Authenticate the CLI against your instance (`gh auth login --hostname your-ghe.example.com`, `glab auth login --hostname gitlab.example.com`) and `no-mistakes` will route through the CLI as usual.
 
+Self-hosted GitLab is detected out of the box even when the hostname carries no `gitlab` marker (for example `git.example.com`).
+When the hostname is not obviously GitLab, `no-mistakes` consults glab's configured hosts (`config.yml`, honoring `GLAB_CONFIG_DIR` then `XDG_CONFIG_HOME/glab-cli`, then `~/.config/glab-cli`) and treats the upstream as GitLab if its host appears there as a configured host or `api_host`.
+Running `glab auth login --hostname your-gitlab.example.com` is enough to make detection succeed; if glab is not configured for the host, detection fails closed and the upstream is treated as unsupported.
+
+The GitLab backend is pinned against `glab v1.5x`. Self-hosted detection and the merge-request and CI steps rely on its current flag and API surface, so keep `glab` reasonably up to date.
+
 ## Unsupported hosts
 
 If your upstream isn't GitHub, GitLab, or Bitbucket Cloud:

--- a/internal/pipeline/steps/host.go
+++ b/internal/pipeline/steps/host.go
@@ -41,7 +41,12 @@ func buildHost(sctx *pipeline.StepContext, provider scm.Provider) (scm.Host, str
 			// GitLab source-project routing is implemented end to end.
 			return nil, "fork PR routing for GitLab is not implemented"
 		}
-		return gitlab.New(cmdFactory, func() bool { return stepCLIAvailable(sctx, provider) }), ""
+		return gitlab.New(
+			cmdFactory,
+			func() bool { return stepCLIAvailable(sctx, provider) },
+			scm.ExtractHost(sctx.Repo.UpstreamURL),
+			gitlab.ProjectPath(sctx.Repo.UpstreamURL),
+		), ""
 	case scm.ProviderBitbucket:
 		if sctx.Repo.ForkURL != "" {
 			// Fork PR routing for Bitbucket is intentionally not half-wired.

--- a/internal/scm/auth_test.go
+++ b/internal/scm/auth_test.go
@@ -41,7 +41,9 @@ func TestCLIAvailable(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	// Set PATH to JUST the temp dir so a real glab installed on the host does
+	// not leak in and make the ProviderGitLab assertion below flaky.
+	t.Setenv("PATH", binDir)
 
 	if !CLIAvailable(ProviderGitHub) {
 		t.Fatal("expected gh to be available")

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -2,12 +2,16 @@
 package gitlab
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/url"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/scm"
 )
@@ -19,12 +23,76 @@ type CmdFactory func(ctx context.Context, name string, args ...string) *exec.Cmd
 type Host struct {
 	cmd          CmdFactory
 	cliAvailable func() bool
+	host         string // repo's GitLab hostname; scopes the auth check
+	projectPath  string // repo's "group/project" path; enables REST job reads
 }
 
 // New builds a Host. cliAvailable reports whether the glab binary is
-// resolvable on the caller's PATH (possibly overridden by env).
-func New(cmd CmdFactory, cliAvailable func() bool) *Host {
-	return &Host{cmd: cmd, cliAvailable: cliAvailable}
+// resolvable on the caller's PATH (possibly overridden by env). host is the
+// repo's GitLab hostname; when set the availability check is scoped to it via
+// --hostname so a stale credential for an unrelated configured glab host cannot
+// make this repo look unauthenticated. projectPath is the repo's "group/project"
+// path (subgroups allowed); when set, pipeline-job reads go through `glab api`
+// (REST), which is branch-independent and works in the daemon's detached-HEAD
+// worktree, where `glab ci get` refuses to run without a current branch. Both
+// are optional; empty reproduces the legacy unscoped behavior.
+func New(cmd CmdFactory, cliAvailable func() bool, host, projectPath string) *Host {
+	return &Host{
+		cmd:          cmd,
+		cliAvailable: cliAvailable,
+		host:         strings.TrimSpace(host),
+		projectPath:  strings.TrimSpace(projectPath),
+	}
+}
+
+// ProjectPath extracts the "group/project" path (no host, no trailing .git)
+// from a GitLab remote URL. GitLab projects can live under nested subgroups, so
+// the full path - not just the last two segments - is returned. It handles
+// HTTPS/ssh:// URLs and scp-style SSH (git@host:group/project.git). Returns ""
+// when no path can be determined; callers treat that as "unknown" and fall back
+// to branch-dependent porcelain.
+func ProjectPath(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	var path string
+	if strings.Contains(raw, "://") {
+		if u, err := url.Parse(raw); err == nil {
+			path = u.Path
+		}
+	} else if colon := strings.Index(raw, ":"); colon >= 0 {
+		// scp-style: [user@]host:group/project.git -> group/project. The first
+		// ':' separates host from path, so the path is recovered whether or not
+		// a "user@" prefix is present (e.g. gitlab.example.com:group/project.git).
+		path = raw[colon+1:]
+	}
+	path = strings.Trim(path, "/")
+	return strings.TrimSuffix(path, ".git")
+}
+
+// pipelineJobsArgs returns the glab invocation that lists a pipeline's jobs.
+// With a known project path it uses `glab api` (branch-independent, works in a
+// detached-HEAD worktree); otherwise it falls back to `glab ci get`, which
+// needs a current branch.
+func (h *Host) pipelineJobsArgs(pipelineID int) []string {
+	if h.projectPath != "" {
+		// GitLab's REST API wants the project as a single URL-encoded
+		// "group%2Fproject" path parameter. Escape each segment defensively and
+		// rejoin with %2F so any reserved character in a segment is encoded too,
+		// not just the separating slashes.
+		segments := strings.Split(h.projectPath, "/")
+		for i, seg := range segments {
+			segments[i] = url.PathEscape(seg)
+		}
+		enc := strings.Join(segments, "%2F")
+		// --paginate walks every page; a pipeline with more jobs than fit on one
+		// page (GitLab defaults to 20 per page) would otherwise silently drop the
+		// jobs on later pages and the CI verdict could miss a failed job. glab
+		// writes one JSON array per page, so the parser handles concatenated docs.
+		return []string{"api", "--paginate", fmt.Sprintf("projects/%s/pipelines/%d/jobs", enc, pipelineID)}
+	}
+	return []string{"ci", "get", "--pipeline-id", fmt.Sprintf("%d", pipelineID), "--output", "json", "--with-job-details"}
 }
 
 func (h *Host) Provider() scm.Provider { return scm.ProviderGitLab }
@@ -37,7 +105,17 @@ func (h *Host) Available(ctx context.Context) error {
 	if h.cliAvailable != nil && !h.cliAvailable() {
 		return errors.New("glab CLI is not installed")
 	}
-	if err := h.cmd(ctx, "glab", "auth", "status").Run(); err != nil {
+	// Scope the auth check to this repo's host. Unscoped `glab auth status`
+	// checks every configured instance and exits non-zero if ANY of them has a
+	// stale/expired token, even when this repo's own host is fully
+	// authenticated. Passing --hostname keeps an unrelated bad credential from
+	// poisoning availability for this repo. When the host is unknown we fall
+	// back to the unscoped check (fail-safe: same behavior as before).
+	authArgs := []string{"auth", "status"}
+	if h.host != "" {
+		authArgs = append(authArgs, "--hostname", h.host)
+	}
+	if err := h.cmd(ctx, "glab", authArgs...).Run(); err != nil {
 		return errors.New("glab CLI is not authenticated")
 	}
 	return nil
@@ -70,7 +148,11 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 	if strings.TrimSpace(base) != "" {
 		args = append(args, "--target-branch", base)
 	}
-	args = append(args, "--state", "opened", "--output", "json")
+	// `glab mr list` returns open MRs by default. Older glab accepted
+	// `--state opened`, but glab v1.5x removed it (it now exposes
+	// -c/--closed, -M/--merged, -A/--all); passing the unknown flag fails the
+	// whole command. Rely on the open-by-default behavior.
+	args = append(args, "--output", "json")
 	cmd := h.cmd(ctx, "glab", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -238,10 +320,10 @@ func (h *Host) getChecksFallback(ctx context.Context, pr *scm.PR) ([]scm.Check, 
 	if payload.HeadPipeline.ID == 0 {
 		return nil, nil
 	}
-	jobsCmd := h.cmd(ctx, "glab", "ci", "get", "--pipeline-id", fmt.Sprintf("%d", payload.HeadPipeline.ID), "--output", "json", "--with-job-details")
+	jobsCmd := h.cmd(ctx, "glab", h.pipelineJobsArgs(payload.HeadPipeline.ID)...)
 	jobsOut, err := jobsCmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("glab ci get: %s: %w", strings.TrimSpace(string(jobsOut)), err)
+		return nil, fmt.Errorf("glab pipeline jobs: %s: %w", strings.TrimSpace(string(jobsOut)), err)
 	}
 	return parseGitlabJobs(jobsOut)
 }
@@ -264,7 +346,7 @@ func (h *Host) FetchFailedCheckLogs(ctx context.Context, pr *scm.PR, _ string, _
 	if trimmed := bytesTrimToJSON(viewOut); len(trimmed) == 0 || json.Unmarshal(trimmed, &payload) != nil || payload.HeadPipeline.ID == 0 {
 		return "", nil
 	}
-	jobsCmd := h.cmd(ctx, "glab", "ci", "get", "--pipeline-id", fmt.Sprintf("%d", payload.HeadPipeline.ID), "--output", "json", "--with-job-details")
+	jobsCmd := h.cmd(ctx, "glab", h.pipelineJobsArgs(payload.HeadPipeline.ID)...)
 	jobsOut, err := jobsCmd.CombinedOutput()
 	if err != nil {
 		return "", nil
@@ -306,44 +388,92 @@ func bytesTrimToJSON(out []byte) []byte {
 }
 
 type gitlabJob struct {
-	ID     int    `json:"id"`
-	Name   string `json:"name"`
-	Status string `json:"status"`
-	Stage  string `json:"stage"`
+	ID         int    `json:"id"`
+	Name       string `json:"name"`
+	Status     string `json:"status"`
+	Stage      string `json:"stage"`
+	FinishedAt string `json:"finished_at"`
 }
 
-func parseGitlabJobs(out []byte) ([]scm.Check, error) {
+// completedAt parses the job's finished_at timestamp, returning the zero time
+// when it is absent or unparseable. GitLab emits RFC3339 (often with
+// fractional seconds and a 'Z' offset), which time.RFC3339 handles.
+func (j gitlabJob) completedAt() time.Time {
+	if strings.TrimSpace(j.FinishedAt) == "" {
+		return time.Time{}
+	}
+	if parsed, err := time.Parse(time.RFC3339, j.FinishedAt); err == nil {
+		return parsed
+	}
+	return time.Time{}
+}
+
+// decodeGitlabJobs reads every job from glab output. The output may contain a
+// single bare job array, a pipeline object with nested .jobs, or - when
+// `glab api --paginate` walks multiple pages - several JSON documents
+// concatenated back to back (one array per page). A streaming decoder reads
+// each top-level value in turn and accumulates the jobs across all of them.
+// It returns whatever was parsed plus a non-nil error when a document was
+// malformed: io.EOF terminates the stream cleanly, but any other decode error
+// means a corrupt page, which the caller can surface instead of mistaking it
+// for an empty result.
+func decodeGitlabJobs(out []byte) ([]gitlabJob, error) {
 	trimmed := bytesTrimToJSON(out)
 	if len(trimmed) == 0 {
 		return nil, nil
 	}
-	// glab may return a single pipeline object with nested jobs, or a bare job array.
-	var asArray []gitlabJob
-	if err := json.Unmarshal(trimmed, &asArray); err == nil && len(asArray) > 0 {
-		return jobsToChecks(asArray), nil
+	dec := json.NewDecoder(bytes.NewReader(trimmed))
+	var jobs []gitlabJob
+	for {
+		var raw json.RawMessage
+		err := dec.Decode(&raw)
+		if errors.Is(err, io.EOF) {
+			return jobs, nil
+		}
+		if err != nil {
+			// Malformed mid-stream document: stop, but keep what parsed so far
+			// and report the error rather than silently swallowing the page.
+			return jobs, fmt.Errorf("decode gitlab jobs: %w", err)
+		}
+		var asArray []gitlabJob
+		if err := json.Unmarshal(raw, &asArray); err == nil && len(asArray) > 0 {
+			jobs = append(jobs, asArray...)
+			continue
+		}
+		var asObject struct {
+			Jobs []gitlabJob `json:"jobs"`
+		}
+		if err := json.Unmarshal(raw, &asObject); err == nil && len(asObject.Jobs) > 0 {
+			jobs = append(jobs, asObject.Jobs...)
+		}
 	}
-	var asObject struct {
-		Jobs []gitlabJob `json:"jobs"`
+}
+
+func parseGitlabJobs(out []byte) ([]scm.Check, error) {
+	jobs, err := decodeGitlabJobs(out)
+	if len(jobs) == 0 {
+		return nil, err
 	}
-	if err := json.Unmarshal(trimmed, &asObject); err == nil && len(asObject.Jobs) > 0 {
-		return jobsToChecks(asObject.Jobs), nil
-	}
-	return nil, nil
+	// Surface any decode error even when some jobs parsed. A corrupt later page
+	// of paginated `glab api` output must not let a partial slice look
+	// authoritative: a failed job on the dropped page would otherwise be hidden
+	// and the CI verdict would read green.
+	return jobsToChecks(jobs), err
 }
 
 func jobsToChecks(jobs []gitlabJob) []scm.Check {
 	checks := make([]scm.Check, 0, len(jobs))
 	for _, job := range jobs {
-		checks = append(checks, scm.Check{Name: job.Name, Bucket: gitlabStatusBucket(job.Status)})
+		checks = append(checks, scm.Check{
+			Name:        job.Name,
+			Bucket:      gitlabStatusBucket(job.Status),
+			CompletedAt: job.completedAt(),
+		})
 	}
 	return checks
 }
 
 func findFailedJobID(out []byte, failingNames []string) int {
-	trimmed := bytesTrimToJSON(out)
-	if len(trimmed) == 0 {
-		return 0
-	}
 	targets := map[string]struct{}{}
 	for _, name := range failingNames {
 		name = strings.TrimSpace(name)
@@ -351,18 +481,9 @@ func findFailedJobID(out []byte, failingNames []string) int {
 			targets[name] = struct{}{}
 		}
 	}
-	var asArray []gitlabJob
-	jobs := asArray
-	if err := json.Unmarshal(trimmed, &asArray); err == nil && len(asArray) > 0 {
-		jobs = asArray
-	} else {
-		var asObject struct {
-			Jobs []gitlabJob `json:"jobs"`
-		}
-		if err := json.Unmarshal(trimmed, &asObject); err == nil {
-			jobs = asObject.Jobs
-		}
-	}
+	// Best effort: scan whatever jobs parsed; a corrupt later page does not
+	// prevent locating a failed job that already decoded.
+	jobs, _ := decodeGitlabJobs(out)
 	for _, job := range jobs {
 		if !strings.EqualFold(job.Status, "failed") {
 			continue

--- a/internal/scm/gitlab/gitlab_test.go
+++ b/internal/scm/gitlab/gitlab_test.go
@@ -7,9 +7,42 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/scm"
 )
+
+func TestProjectPath(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"https with .git", "https://gitlab.example.com/group/project.git", "group/project"},
+		{"https without .git", "https://gitlab.example.com/group/project", "group/project"},
+		{"https nested subgroups", "https://gitlab.example.com/group/sub/project.git", "group/sub/project"},
+		{"https trailing slash", "https://gitlab.example.com/group/project/", "group/project"},
+		{"scp ssh", "git@gitlab.example.com:group/project.git", "group/project"},
+		{"scp ssh nested", "git@gitlab.example.com:group/sub/project.git", "group/sub/project"},
+		// scp-style without a "user@" prefix must still yield the project path;
+		// an empty path here would drop the REST job read back to branch-dependent
+		// `glab ci get`, which fails in the daemon's detached-HEAD worktree.
+		{"scp ssh no user", "gitlab.example.com:group/project.git", "group/project"},
+		{"scp ssh no user nested", "gitlab.example.com:group/sub/project.git", "group/sub/project"},
+		{"ssh url", "ssh://git@gitlab.example.com:22/group/project.git", "group/project"},
+		{"empty", "", ""},
+		{"host only", "https://gitlab.example.com", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ProjectPath(tc.in); got != tc.want {
+				t.Fatalf("ProjectPath(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
 
 func TestGetMergeableStateTreatsBlockedStatusesAsResolved(t *testing.T) {
 	t.Parallel()
@@ -32,7 +65,7 @@ func TestGetMergeableStateTreatsBlockedStatusesAsResolved(t *testing.T) {
 				"glab mr view 123 --output json": {
 					stdout: fmt.Sprintf(`{"iid":123,"state":"opened","detailed_merge_status":"%s"}`+"\n", tt.status),
 				},
-			}), nil)
+			}), nil, "", "")
 
 			got, err := host.GetMergeableState(context.Background(), &scm.PR{Number: "123"})
 			if err != nil {
@@ -55,7 +88,7 @@ func TestGetChecksFallbackParsesMRJSONAfterPreamble(t *testing.T) {
 		"glab ci get --pipeline-id 77 --output json --with-job-details": {
 			stdout: `[{"name":"test","status":"success"}]` + "\n",
 		},
-	}), nil)
+	}), nil, "", "")
 
 	checks, err := host.getChecksFallback(context.Background(), &scm.PR{Number: "123"})
 	if err != nil {
@@ -100,12 +133,12 @@ func TestGetChecksReturnsFallbackErrors(t *testing.T) {
 				"glab mr view 123 --output json": {
 					stdout: `{"head_pipeline":{"id":77}}` + "\n",
 				},
-				"glab ci get --pipeline-id 77 --output json": {
+				"glab ci get --pipeline-id 77 --output json --with-job-details": {
 					stderr: "gitlab unavailable\n",
 					code:   1,
 				},
 			},
-			wantErrSub: "glab ci get",
+			wantErrSub: "glab pipeline jobs",
 		},
 	}
 
@@ -113,7 +146,7 @@ func TestGetChecksReturnsFallbackErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			host := New(gitlabTestCmdFactory(tt.responses), nil)
+			host := New(gitlabTestCmdFactory(tt.responses), nil, "", "")
 
 			checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
 			if err == nil {
@@ -137,7 +170,7 @@ func TestGetChecksReturnsPrimaryStatusErrorWhenMRFlagIsSupported(t *testing.T) {
 			stderr: "gitlab unavailable\n",
 			code:   1,
 		},
-	}), nil)
+	}), nil, "", "")
 
 	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
 	if err == nil {
@@ -165,7 +198,7 @@ func TestGetChecksFallsBackForVariantUnsupportedMRFlagErrors(t *testing.T) {
 		"glab ci get --pipeline-id 77 --output json --with-job-details": {
 			stdout: `[{"name":"test","status":"success"}]` + "\n",
 		},
-	}), nil)
+	}), nil, "", "")
 
 	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
 	if err != nil {
@@ -185,13 +218,13 @@ func TestFindPRWithoutIIDKeepsNumberEmptyAndUpdatesByNumberFromURL(t *testing.T)
 	branch := "feature/refactor"
 	url := "https://gitlab.example.com/group/project/-/merge_requests/42"
 	host := New(gitlabTestCmdFactory(map[string]gitlabTestResponse{
-		"glab mr list --source-branch " + branch + " --target-branch main --state opened --output json": {
+		"glab mr list --source-branch " + branch + " --target-branch main --output json": {
 			stdout: fmt.Sprintf(`[{"web_url":%q}]`+"\n", url),
 		},
 		"glab mr update 42 --title updated --description body --yes": {
 			stdout: "updated\n",
 		},
-	}), nil)
+	}), nil, "", "")
 
 	pr, err := host.FindPR(context.Background(), branch, "main")
 	if err != nil {
@@ -220,10 +253,10 @@ func TestFindPRFiltersByBaseBranch(t *testing.T) {
 	t.Parallel()
 
 	host := New(gitlabTestCmdFactory(map[string]gitlabTestResponse{
-		"glab mr list --source-branch feature/refactor --target-branch release/1.0 --state opened --output json": {
+		"glab mr list --source-branch feature/refactor --target-branch release/1.0 --output json": {
 			stdout: `[{"iid":42,"web_url":"https://gitlab.example.com/group/project/-/merge_requests/42"}]` + "\n",
 		},
-	}), nil)
+	}), nil, "", "")
 
 	pr, err := host.FindPR(context.Background(), "feature/refactor", "release/1.0")
 	if err != nil {
@@ -244,11 +277,11 @@ func TestFindPRReturnsCLIError(t *testing.T) {
 	t.Parallel()
 
 	host := New(gitlabTestCmdFactory(map[string]gitlabTestResponse{
-		"glab mr list --source-branch feature/refactor --target-branch main --state opened --output json": {
+		"glab mr list --source-branch feature/refactor --target-branch main --output json": {
 			stderr: "gitlab unavailable\n",
 			code:   1,
 		},
-	}), nil)
+	}), nil, "", "")
 
 	pr, err := host.FindPR(context.Background(), "feature/refactor", "main")
 	if err == nil {
@@ -272,7 +305,7 @@ func TestGetChecksFallbackRequestsJobDetails(t *testing.T) {
 		"glab ci get --pipeline-id 77 --output json --with-job-details": {
 			stdout: `{"jobs":[{"name":"lint","status":"failed"}]}` + "\n",
 		},
-	}), nil)
+	}), nil, "", "")
 
 	checks, err := host.getChecksFallback(context.Background(), &scm.PR{Number: "123"})
 	if err != nil {
@@ -299,7 +332,7 @@ func TestFetchFailedCheckLogsRequestsJobDetails(t *testing.T) {
 		"glab ci trace 55": {
 			stdout: "lint failed\n",
 		},
-	}), nil)
+	}), nil, "", "")
 
 	logs, err := host.FetchFailedCheckLogs(context.Background(), &scm.PR{Number: "123"}, "", "", []string{"lint"})
 	if err != nil {
@@ -323,7 +356,7 @@ func TestFetchFailedCheckLogsParsesMRJSONAfterPreamble(t *testing.T) {
 		"glab ci trace 55": {
 			stdout: "lint failed\n",
 		},
-	}), nil)
+	}), nil, "", "")
 
 	logs, err := host.FetchFailedCheckLogs(context.Background(), &scm.PR{Number: "123"}, "", "", []string{"lint"})
 	if err != nil {
@@ -339,6 +372,221 @@ func TestGitlabStatusBucketTreatsManualJobsAsSkipped(t *testing.T) {
 
 	if got := gitlabStatusBucket("manual"); got != scm.CheckBucketSkip {
 		t.Fatalf("gitlabStatusBucket(manual) = %q, want %q", got, scm.CheckBucketSkip)
+	}
+}
+
+func TestAvailableScopesAuthToConfiguredHost(t *testing.T) {
+	t.Parallel()
+
+	// With a known host, the auth check must be scoped via --hostname so a
+	// stale credential on some other configured glab instance cannot make this
+	// repo look unauthenticated. The unscoped form is treated as a failure
+	// here to prove the scoped form is the one actually invoked.
+	host := New(gitlabTestCmdFactory(map[string]gitlabTestResponse{
+		"glab auth status --hostname gitlab.example.com": {},
+		"glab auth status": {stderr: "gitlab.com: token invalid\n", code: 1},
+	}), func() bool { return true }, "gitlab.example.com", "")
+
+	if err := host.Available(context.Background()); err != nil {
+		t.Fatalf("Available() error = %v, want nil (scoped auth should pass)", err)
+	}
+}
+
+func TestAvailableFallsBackToUnscopedAuthWhenHostUnknown(t *testing.T) {
+	t.Parallel()
+
+	// No host -> behave as before: a bare `glab auth status`.
+	host := New(gitlabTestCmdFactory(map[string]gitlabTestResponse{
+		"glab auth status": {},
+	}), func() bool { return true }, "", "")
+
+	if err := host.Available(context.Background()); err != nil {
+		t.Fatalf("Available() error = %v, want nil", err)
+	}
+}
+
+func TestFindPRDoesNotPassRemovedStateFlag(t *testing.T) {
+	t.Parallel()
+
+	// glab v1.5x removed --state; the open-by-default list must be used. The
+	// fixture key omits --state, so a regression that re-adds it would fall
+	// through to the "unexpected command" error and fail this test.
+	host := New(gitlabTestCmdFactory(map[string]gitlabTestResponse{
+		"glab mr list --source-branch feature/x --target-branch main --output json": {
+			stdout: `[{"iid":7,"web_url":"https://gitlab.example.com/group/project/-/merge_requests/7"}]` + "\n",
+		},
+	}), nil, "", "")
+
+	pr, err := host.FindPR(context.Background(), "feature/x", "main")
+	if err != nil {
+		t.Fatalf("FindPR() error = %v", err)
+	}
+	if pr == nil || pr.Number != "7" {
+		t.Fatalf("FindPR() = %+v, want MR !7", pr)
+	}
+}
+
+func TestGetChecksReadsJobsViaAPIWhenProjectPathKnown(t *testing.T) {
+	t.Parallel()
+
+	// With a project path, pipeline jobs are read via `glab api` (REST), which
+	// is branch-independent and works in the daemon's detached-HEAD worktree.
+	// finished_at must be captured into CompletedAt.
+	host := New(gitlabTestCmdFactory(map[string]gitlabTestResponse{
+		"glab ci status --mr 123 --output json": {
+			stderr: "unknown flag: --mr\n",
+			code:   1,
+		},
+		"glab mr view 123 --output json": {
+			stdout: `{"head_pipeline":{"id":77}}` + "\n",
+		},
+		"glab api --paginate projects/group%2Fproject/pipelines/77/jobs": {
+			stdout: `[{"id":9,"name":"test","status":"success","finished_at":"2026-04-24T04:15:00.000Z"}]` + "\n",
+		},
+	}), nil, "gitlab.example.com", "group/project")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
+	if err != nil {
+		t.Fatalf("GetChecks() error = %v", err)
+	}
+	if len(checks) != 1 {
+		t.Fatalf("len(checks) = %d, want 1", len(checks))
+	}
+	if checks[0].Name != "test" || checks[0].Bucket != scm.CheckBucketPass {
+		t.Fatalf("checks[0] = %+v, want passing test job", checks[0])
+	}
+	wantCompletedAt := time.Date(2026, 4, 24, 4, 15, 0, 0, time.UTC)
+	if !checks[0].CompletedAt.Equal(wantCompletedAt) {
+		t.Fatalf("checks[0].CompletedAt = %v, want %v", checks[0].CompletedAt, wantCompletedAt)
+	}
+}
+
+func TestGetChecksLeavesCompletedAtZeroWhenFinishedAtMissingOrInvalid(t *testing.T) {
+	t.Parallel()
+
+	host := New(gitlabTestCmdFactory(map[string]gitlabTestResponse{
+		"glab ci status --mr 123 --output json": {
+			stderr: "unknown flag: --mr\n",
+			code:   1,
+		},
+		"glab mr view 123 --output json": {
+			stdout: `{"head_pipeline":{"id":77}}` + "\n",
+		},
+		"glab api --paginate projects/group%2Fproject/pipelines/77/jobs": {
+			stdout: `[{"name":"running","status":"running"},{"name":"bad","status":"success","finished_at":"not-a-time"}]` + "\n",
+		},
+	}), nil, "", "group/project")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
+	if err != nil {
+		t.Fatalf("GetChecks() error = %v", err)
+	}
+	if len(checks) != 2 {
+		t.Fatalf("len(checks) = %d, want 2", len(checks))
+	}
+	for _, c := range checks {
+		if !c.CompletedAt.IsZero() {
+			t.Fatalf("check %q CompletedAt = %v, want zero time", c.Name, c.CompletedAt)
+		}
+	}
+}
+
+func TestGetChecksPaginatesJobsAcrossConcatenatedPages(t *testing.T) {
+	t.Parallel()
+
+	// `glab api --paginate` walks every page and writes one JSON array per page,
+	// so the output is several arrays concatenated back to back. The parser must
+	// read all of them; otherwise a failed job on a later page is silently
+	// dropped and the CI verdict misses it. The map key also asserts that the
+	// `--paginate` flag is actually present on the jobs call.
+	page1 := `[{"id":1,"name":"build","status":"success"}]`
+	page2 := `[{"id":2,"name":"deploy","status":"failed"}]`
+	host := New(gitlabTestCmdFactory(map[string]gitlabTestResponse{
+		"glab ci status --mr 123 --output json": {
+			stderr: "unknown flag: --mr\n",
+			code:   1,
+		},
+		"glab mr view 123 --output json": {
+			stdout: `{"head_pipeline":{"id":77}}` + "\n",
+		},
+		"glab api --paginate projects/group%2Fproject/pipelines/77/jobs": {
+			stdout: page1 + "\n" + page2 + "\n",
+		},
+	}), nil, "", "group/project")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
+	if err != nil {
+		t.Fatalf("GetChecks() error = %v", err)
+	}
+	if len(checks) != 2 {
+		t.Fatalf("len(checks) = %d, want 2 (jobs from both pages)", len(checks))
+	}
+	var sawFailedDeploy bool
+	for _, c := range checks {
+		if c.Name == "deploy" && c.Bucket == scm.CheckBucketFail {
+			sawFailedDeploy = true
+		}
+	}
+	if !sawFailedDeploy {
+		t.Fatalf("failed job on the second page was dropped: %+v", checks)
+	}
+}
+
+func TestFindFailedJobIDScansConcatenatedPages(t *testing.T) {
+	t.Parallel()
+
+	// The failed job lives on the second concatenated page; findFailedJobID must
+	// still locate it across paginated output.
+	out := []byte(`[{"id":1,"name":"build","status":"success"}]` + "\n" +
+		`[{"id":2,"name":"deploy","status":"failed"}]` + "\n")
+	if got := findFailedJobID(out, []string{"deploy"}); got != 2 {
+		t.Fatalf("findFailedJobID() = %d, want 2", got)
+	}
+}
+
+func TestParseGitlabJobsSurfacesCorruptPayload(t *testing.T) {
+	t.Parallel()
+
+	// A wholly-malformed payload must surface a decode error rather than be
+	// mistaken for an empty (no-jobs) result.
+	if _, err := parseGitlabJobs([]byte(`[{"id":1`)); err == nil {
+		t.Fatal("parseGitlabJobs() error = nil, want decode error for corrupt payload")
+	}
+
+	// When a good page parses before a corrupt one, the parsed jobs are still
+	// returned, but the decode error must surface too: a failed job on the
+	// dropped page would otherwise be silently hidden and read as green.
+	out := []byte(`[{"id":1,"name":"build","status":"success"}]` + "\n" + `[{"id":2`)
+	checks, err := parseGitlabJobs(out)
+	if err == nil {
+		t.Fatal("parseGitlabJobs() error = nil, want decode error from the corrupt later page")
+	}
+	if len(checks) != 1 || checks[0].Name != "build" {
+		t.Fatalf("parseGitlabJobs() = %+v, want the single parsed build job alongside the error", checks)
+	}
+}
+
+func TestGetChecksSurfacesErrorWhenPaginatedPageIsCorrupt(t *testing.T) {
+	t.Parallel()
+
+	// End-to-end through GetChecks: a corrupt later page of paginated `glab api`
+	// output must fail the call rather than return a partial (potentially
+	// all-green) slice that hides a failed job on the dropped page.
+	host := New(gitlabTestCmdFactory(map[string]gitlabTestResponse{
+		"glab ci status --mr 123 --output json": {
+			stderr: "unknown flag: --mr\n",
+			code:   1,
+		},
+		"glab mr view 123 --output json": {
+			stdout: `{"head_pipeline":{"id":77}}` + "\n",
+		},
+		"glab api --paginate projects/group%2Fproject/pipelines/77/jobs": {
+			stdout: `[{"id":1,"name":"build","status":"success"}]` + "\n" + `[{"id":2`,
+		},
+	}), nil, "", "group/project")
+
+	if _, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"}); err == nil {
+		t.Fatal("GetChecks() error = nil, want decode error surfaced from the corrupt page")
 	}
 }
 

--- a/internal/scm/host.go
+++ b/internal/scm/host.go
@@ -9,6 +9,62 @@ import (
 	"time"
 )
 
+// ExtractHost returns the lowercased host (without any port) from a git
+// remote URL. It handles both scp-like syntax (git@host:group/project) and
+// URL forms (https://host/group/project, ssh://git@host:22/group/project).
+// It returns "" when no host can be determined.
+func ExtractHost(remote string) string {
+	s := strings.TrimSpace(remote)
+	if s == "" {
+		return ""
+	}
+	if i := strings.Index(s, "://"); i >= 0 {
+		// URL form: scheme://[user@]host[:port]/path. Split off the path at the
+		// first '/' before scanning for userinfo, so a '@' inside the path
+		// (e.g. .../group@prod/repo.git) cannot be mistaken for a "user@" prefix.
+		s = s[i+3:]
+		if slash := strings.Index(s, "/"); slash >= 0 {
+			s = s[:slash]
+		}
+		if at := strings.LastIndex(s, "@"); at >= 0 {
+			s = s[at+1:]
+		}
+		return strings.ToLower(stripPort(s))
+	}
+	// No scheme. scp-like syntax is [user@]host:path; the first ':' separates
+	// the host from the path. Split off the path first, then strip any userinfo
+	// prefix from the host segment only, so a '@' in the path (e.g.
+	// git@host:group@prod/repo.git) cannot collapse host extraction.
+	if c := strings.Index(s, ":"); c >= 0 {
+		s = s[:c]
+	} else if slash := strings.Index(s, "/"); slash >= 0 {
+		s = s[:slash]
+	}
+	if at := strings.LastIndex(s, "@"); at >= 0 {
+		s = s[at+1:]
+	}
+	return strings.ToLower(s)
+}
+
+// stripPort removes a trailing :port from a host, leaving bare hosts and
+// bracketed IPv6 literals intact.
+func stripPort(host string) string {
+	if strings.HasPrefix(host, "[") {
+		// IPv6 literal: [::1]:22 -> [::1]
+		if end := strings.Index(host, "]"); end >= 0 {
+			return host[:end+1]
+		}
+		return host
+	}
+	if c := strings.LastIndex(host, ":"); c >= 0 {
+		port := host[c+1:]
+		if port != "" && strings.IndexFunc(port, func(r rune) bool { return r < '0' || r > '9' }) < 0 {
+			return host[:c]
+		}
+	}
+	return host
+}
+
 // ExtractPRNumber returns the trailing numeric segment from a PR/MR URL.
 // Supports GitHub (/pull/N), GitLab (/-/merge_requests/N), and Bitbucket
 // (/pull-requests/N) URLs; all of them end in a digit path segment.

--- a/internal/scm/host_test.go
+++ b/internal/scm/host_test.go
@@ -6,6 +6,38 @@ import (
 	"testing"
 )
 
+func TestExtractHost(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		remote string
+		want   string
+	}{
+		{"https with .git", "https://github.com/user/repo.git", "github.com"},
+		{"scp ssh", "git@github.com:user/repo.git", "github.com"},
+		{"https self-hosted", "https://gitlab.example.com/group/repo.git", "gitlab.example.com"},
+		{"scp ssh nested path", "git@gitlab.example.com:group/sub/repo.git", "gitlab.example.com"},
+		{"ssh url with port", "ssh://git@code.example.com:2222/group/repo.git", "code.example.com"},
+		{"https userinfo and port", "https://user:token@code.example.com:8443/group/repo.git", "code.example.com"},
+		{"git protocol", "git://code.example.com/group/repo.git", "code.example.com"},
+		{"mixed case lowercased", "https://CODE.Example.COM/group/repo", "code.example.com"},
+		{"ipv6 literal with port", "ssh://git@[::1]:22/group/repo.git", "[::1]"},
+		// A '@' inside the path must not be mistaken for a "user@" userinfo
+		// prefix: host extraction has to split off the path first.
+		{"at-sign in path https", "https://code.example.com/group@prod/repo.git", "code.example.com"},
+		{"at-sign in path scp", "git@code.example.com:group@prod/repo.git", "code.example.com"},
+		{"at-sign in path with userinfo", "https://user:token@code.example.com/group@prod/repo.git", "code.example.com"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractHost(tt.remote); got != tt.want {
+				t.Errorf("ExtractHost(%q) = %q, want %q", tt.remote, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCheckBucketHelpers(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/scm/scm.go
+++ b/internal/scm/scm.go
@@ -2,8 +2,12 @@ package scm
 
 import (
 	"context"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 type Provider string
@@ -24,9 +28,69 @@ func DetectProvider(url string) Provider {
 		return ProviderGitLab
 	case strings.Contains(lower, "bitbucket.org"):
 		return ProviderBitbucket
-	default:
-		return ProviderUnknown
 	}
+
+	// Fallback for self-hosted GitLab instances whose hostname carries no
+	// "gitlab" marker: consult the glab CLI's configured hosts. If the remote's
+	// host (or a host's api_host) is one glab is configured to talk to, treat it
+	// as GitLab. This reads whatever the user configured at runtime; no host is
+	// hardcoded.
+	if host := ExtractHost(url); host != "" {
+		if glabKnowsHost(host) {
+			return ProviderGitLab
+		}
+	}
+
+	return ProviderUnknown
+}
+
+// glabKnowsHost reports whether host appears in glab's configured hosts map,
+// either as a top-level key or as a host's api_host. Any read/parse error is
+// treated as "not configured" so detection fails closed to ProviderUnknown.
+func glabKnowsHost(host string) bool {
+	path := glabConfigPath()
+	if path == "" {
+		return false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var cfg struct {
+		Hosts map[string]struct {
+			APIHost string `yaml:"api_host"`
+		} `yaml:"hosts"`
+	}
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return false
+	}
+	host = strings.ToLower(host)
+	for key, h := range cfg.Hosts {
+		if strings.ToLower(strings.TrimSpace(key)) == host {
+			return true
+		}
+		if api := strings.ToLower(strings.TrimSpace(h.APIHost)); api != "" && ExtractHost(api) == host {
+			return true
+		}
+	}
+	return false
+}
+
+// glabConfigPath resolves glab's config file location, preferring
+// $GLAB_CONFIG_DIR, then $XDG_CONFIG_HOME/glab-cli, then ~/.config/glab-cli.
+// It returns "" when no home/config directory can be determined.
+func glabConfigPath() string {
+	if dir := os.Getenv("GLAB_CONFIG_DIR"); dir != "" {
+		return filepath.Join(dir, "config.yml")
+	}
+	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
+		return filepath.Join(dir, "glab-cli", "config.yml")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".config", "glab-cli", "config.yml")
 }
 
 func (p Provider) CLIName() string {

--- a/internal/scm/scm_test.go
+++ b/internal/scm/scm_test.go
@@ -1,8 +1,16 @@
 package scm
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestDetectProvider(t *testing.T) {
+	// Point glab config at an empty temp dir so a real glab install on the host
+	// cannot influence the substring-based assertions below.
+	t.Setenv("GLAB_CONFIG_DIR", t.TempDir())
+
 	tests := []struct {
 		url  string
 		want Provider
@@ -19,5 +27,72 @@ func TestDetectProvider(t *testing.T) {
 		if got := DetectProvider(tt.url); got != tt.want {
 			t.Errorf("DetectProvider(%q) = %q, want %q", tt.url, got, tt.want)
 		}
+	}
+}
+
+// writeGlabConfig writes a synthetic glab config.yml into a temp dir and points
+// GLAB_CONFIG_DIR at it. The host names are placeholders only.
+func writeGlabConfig(t *testing.T, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "config.yml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GLAB_CONFIG_DIR", dir)
+}
+
+func TestDetectProvider_SelfHostedGitLabViaGlabConfig(t *testing.T) {
+	writeGlabConfig(t, `hosts:
+    gitlab.example.com:
+        token: xxx
+        api_host: gitlab.example.com
+        api_protocol: https
+`)
+
+	cases := []string{
+		"https://gitlab.example.com/group/repo.git",
+		"git@gitlab.example.com:group/repo.git",
+		"ssh://git@gitlab.example.com:22/group/repo.git",
+	}
+	for _, url := range cases {
+		if got := DetectProvider(url); got != ProviderGitLab {
+			t.Errorf("DetectProvider(%q) = %q, want %q", url, got, ProviderGitLab)
+		}
+	}
+
+	// A host not in the config still resolves to unknown.
+	if got := DetectProvider("https://other.example.org/group/repo.git"); got != ProviderUnknown {
+		t.Errorf("DetectProvider(unconfigured host) = %q, want %q", got, ProviderUnknown)
+	}
+}
+
+func TestDetectProvider_SelfHostedGitLabViaAPIHost(t *testing.T) {
+	// The remote host differs from the config key but matches api_host.
+	writeGlabConfig(t, `hosts:
+    git.example.com:
+        token: xxx
+        api_host: api.example.com
+`)
+
+	if got := DetectProvider("https://api.example.com/group/repo.git"); got != ProviderGitLab {
+		t.Errorf("DetectProvider(api_host match) = %q, want %q", got, ProviderGitLab)
+	}
+	if got := DetectProvider("https://git.example.com/group/repo.git"); got != ProviderGitLab {
+		t.Errorf("DetectProvider(host key match) = %q, want %q", got, ProviderGitLab)
+	}
+}
+
+func TestDetectProvider_GlabConfigMissingFailsClosed(t *testing.T) {
+	// GLAB_CONFIG_DIR points at an empty dir: no config file present.
+	t.Setenv("GLAB_CONFIG_DIR", t.TempDir())
+	if got := DetectProvider("https://selfhosted.example.com/group/repo.git"); got != ProviderUnknown {
+		t.Errorf("DetectProvider(no glab config) = %q, want %q", got, ProviderUnknown)
+	}
+}
+
+func TestDetectProvider_GlabConfigMalformedFailsClosed(t *testing.T) {
+	writeGlabConfig(t, "this: is: not: valid: yaml: ::::\n\t- broken")
+	if got := DetectProvider("https://selfhosted.example.com/group/repo.git"); got != ProviderUnknown {
+		t.Errorf("DetectProvider(malformed glab config) = %q, want %q", got, ProviderUnknown)
 	}
 }


### PR DESCRIPTION
## Summary

Makes `no-mistakes` drive a **self-hosted GitLab** instance out of the box for the direct `branch -> MR` flow, working with the current `glab v1.5x` CLI. No manual configuration beyond a normal `glab auth login`.

## Problem

On a machine with `glab v1.5x` and more than one configured glab host, the pipeline pushed the branch but then **silently skipped MR creation** and **never read CI** - the run still reported success, so it looked like it shipped. Three version-driven incompatibilities caused it:

- **Unscoped auth check.** `glab auth status` (no host) checks *every* configured instance and exits non-zero if *any* has a stale token, so a healthy repo is judged unauthenticated and the MR step skips.
- **Removed flag.** `glab mr list` no longer accepts `--state opened` (open is the default in v1.5x); the unknown flag fails the whole command.
- **Detached-HEAD worktree.** The daemon checks out a commit, not a branch. `glab ci get` refuses to run there, so CI checks can never be read.

## What this changes

1. **Host-scoped auth** - pass `--hostname <host>` to `glab auth status` so an unrelated instance's stale token can't poison this repo's check. Unknown host falls back to the unscoped check (fail-safe).
2. **Drop removed `--state`** - rely on `glab mr list`'s open-by-default behavior instead of the flag that v1.5x removed.
3. **Read CI jobs via `glab api` (REST)** - when the project path is known, list jobs through `glab api projects/<group%2Fproject>/pipelines/<id>/jobs`. This is branch-independent (works in the detached-HEAD worktree), paginated, and maps `finished_at` into `Check.CompletedAt` for CI re-run detection. The legacy `glab ci get` path stays as a fallback when no project path is known.

Plus:

- **Self-hosted detection** - when a remote's hostname has no `gitlab` marker (e.g. `git.example.com`), consult glab's configured hosts (`config.yml`, honoring `GLAB_CONFIG_DIR` / `XDG_CONFIG_HOME`) and treat it as GitLab if the host matches a configured host or its `api_host`. Reads only user config, hardcodes nothing, and fails closed to unsupported.
- **Project-path parser next to the Host** - the new `gitlab.ProjectPath` lives in the gitlab backend package, mirroring `github.RepoSlug`.
- **Positional constructor** - `gitlab.New(cmd, cliAvailable, host, projectPath)`, matching the GitHub backend's shape.

## Compatibility

- Constructor is positional: `New(cmd, cliAvailable, host, projectPath)`. Passing `"", ""` reproduces the legacy unscoped behavior.
- Unknown host -> unscoped auth check (fail-safe, unchanged behavior).
- A corrupt later page of paginated `glab api` output surfaces as an error rather than a silent partial that could hide a failed job.
- Fork MR routing for GitLab remains out of scope (unchanged).

## Testing

- `go test ./...`, `go vet ./...`, and `gofmt` are clean.
- Verified live against a self-hosted GitLab with `glab v1.53.0` and a multi-host glab config (one host carrying an unrelated stale token): the full `push -> MR -> CI` flow works end to end - host-scoped auth survives the stale token, the MR is created, and CI jobs are read via the paginated `glab api` path in the detached-HEAD worktree (MR mergeable, pipeline green).
