### PR TITLE
Add configurable cross-family multi-reviewer panel

### DIFF
--- a/internal/agent/fanout.go
+++ b/internal/agent/fanout.go
@@ -1,0 +1,65 @@
+package agent
+
+import (
+	"context"
+	"sync"
+)
+
+// FanOutResult pairs a reviewer agent with the outcome of running it. For a
+// completed agent exactly one of Result or Err is non-nil; Agent is always the
+// input agent for that slot so callers can attribute the outcome.
+type FanOutResult struct {
+	Agent  Agent
+	Result *Result
+	Err    error
+}
+
+// FanOut runs the same RunOpts against every agent concurrently and returns one
+// result slot per input agent, in input order. maxParallel bounds the number of
+// agents running at once; maxParallel <= 0 means unbounded. A per-agent failure
+// is captured in that agent's slot (Err) and never aborts the others - FanOut
+// itself returns no top-level error. Each goroutine writes only its own
+// preallocated slot, so the results slice needs no additional synchronization
+// beyond the WaitGroup.
+func FanOut(ctx context.Context, agents []Agent, opts RunOpts, maxParallel int) []FanOutResult {
+	results := make([]FanOutResult, len(agents))
+	if len(agents) == 0 {
+		return results
+	}
+
+	// A buffered semaphore caps concurrency. nil means unbounded.
+	var sem chan struct{}
+	if maxParallel > 0 {
+		sem = make(chan struct{}, maxParallel)
+	}
+
+	var wg sync.WaitGroup
+	for i, ag := range agents {
+		wg.Add(1)
+		go func(i int, ag Agent) {
+			defer wg.Done()
+			results[i].Agent = ag
+			// Honor cancellation while queued on the semaphore...
+			if sem != nil {
+				select {
+				case sem <- struct{}{}:
+					defer func() { <-sem }()
+				case <-ctx.Done():
+					results[i].Err = ctx.Err()
+					return
+				}
+			}
+			// ...and again before invoking Run, so an already-cancelled ctx
+			// short-circuits instead of spawning the agent.
+			if err := ctx.Err(); err != nil {
+				results[i].Err = err
+				return
+			}
+			res, err := ag.Run(ctx, opts)
+			results[i].Result = res
+			results[i].Err = err
+		}(i, ag)
+	}
+	wg.Wait()
+	return results
+}

--- a/internal/agent/fanout_test.go
+++ b/internal/agent/fanout_test.go
@@ -1,0 +1,199 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeAgent is a minimal in-test Agent. Run returns a result whose Text is the
+// agent name, or runErr if set.
+type fakeAgent struct {
+	name   string
+	runErr error
+}
+
+func (f *fakeAgent) Name() string { return f.name }
+
+func (f *fakeAgent) Run(_ context.Context, _ RunOpts) (*Result, error) {
+	if f.runErr != nil {
+		return nil, f.runErr
+	}
+	return &Result{Text: f.name}, nil
+}
+
+func (f *fakeAgent) Close() error { return nil }
+
+// blockingAgent signals each Run start on started and then blocks until release
+// is closed. It lets a test observe how many agents are running concurrently.
+type blockingAgent struct {
+	name    string
+	started chan struct{}
+	release chan struct{}
+}
+
+func (b *blockingAgent) Name() string { return b.name }
+
+func (b *blockingAgent) Run(_ context.Context, _ RunOpts) (*Result, error) {
+	b.started <- struct{}{}
+	<-b.release
+	return &Result{Text: b.name}, nil
+}
+
+func (b *blockingAgent) Close() error { return nil }
+
+func TestFanOut_ResultsInInputOrder(t *testing.T) {
+	agents := []Agent{
+		&fakeAgent{name: "codex"},
+		&fakeAgent{name: "claude"},
+		&fakeAgent{name: "pi"},
+	}
+
+	results := FanOut(context.Background(), agents, RunOpts{}, 0)
+
+	if len(results) != len(agents) {
+		t.Fatalf("got %d results, want %d", len(results), len(agents))
+	}
+	for i, want := range []string{"codex", "claude", "pi"} {
+		if results[i].Err != nil {
+			t.Errorf("results[%d].Err = %v, want nil", i, results[i].Err)
+		}
+		if results[i].Agent == nil || results[i].Agent.Name() != want {
+			t.Errorf("results[%d].Agent = %v, want %q", i, results[i].Agent, want)
+		}
+		if results[i].Result == nil || results[i].Result.Text != want {
+			t.Errorf("results[%d].Result = %v, want Text %q", i, results[i].Result, want)
+		}
+	}
+}
+
+func TestFanOut_Empty(t *testing.T) {
+	results := FanOut(context.Background(), nil, RunOpts{}, 2)
+	if len(results) != 0 {
+		t.Fatalf("got %d results, want 0", len(results))
+	}
+}
+
+func TestFanOut_OneAgentErrorIsolated(t *testing.T) {
+	wantErr := errors.New("boom")
+	agents := []Agent{
+		&fakeAgent{name: "codex"},
+		&fakeAgent{name: "claude", runErr: wantErr},
+		&fakeAgent{name: "pi"},
+	}
+
+	results := FanOut(context.Background(), agents, RunOpts{}, 0)
+
+	// The erroring agent's slot carries the error and a nil result.
+	if !errors.Is(results[1].Err, wantErr) {
+		t.Errorf("results[1].Err = %v, want %v", results[1].Err, wantErr)
+	}
+	if results[1].Result != nil {
+		t.Errorf("results[1].Result = %v, want nil for erroring agent", results[1].Result)
+	}
+	// The other agents are unaffected: results present, no error.
+	for _, i := range []int{0, 2} {
+		if results[i].Err != nil {
+			t.Errorf("results[%d].Err = %v, want nil", i, results[i].Err)
+		}
+		if results[i].Result == nil {
+			t.Errorf("results[%d].Result = nil, want a result", i)
+		}
+	}
+}
+
+// countingAgent records how many times Run was invoked.
+type countingAgent struct {
+	name string
+	ran  *atomic.Int32
+}
+
+func (c *countingAgent) Name() string { return c.name }
+
+func (c *countingAgent) Run(_ context.Context, _ RunOpts) (*Result, error) {
+	c.ran.Add(1)
+	return &Result{Text: c.name}, nil
+}
+
+func (c *countingAgent) Close() error { return nil }
+
+func TestFanOut_CancelledContextSkipsRun(t *testing.T) {
+	var ran atomic.Int32
+	agents := []Agent{
+		&countingAgent{name: "codex", ran: &ran},
+		&countingAgent{name: "claude", ran: &ran},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled before FanOut runs
+
+	results := FanOut(ctx, agents, RunOpts{}, 0)
+
+	if got := ran.Load(); got != 0 {
+		t.Errorf("Run invoked %d times, want 0 for a cancelled ctx", got)
+	}
+	for i := range results {
+		if !errors.Is(results[i].Err, context.Canceled) {
+			t.Errorf("results[%d].Err = %v, want context.Canceled", i, results[i].Err)
+		}
+		if results[i].Result != nil {
+			t.Errorf("results[%d].Result = %v, want nil", i, results[i].Result)
+		}
+		if results[i].Agent == nil {
+			t.Errorf("results[%d].Agent = nil, want the input agent attributed", i)
+		}
+	}
+}
+
+func TestFanOut_BoundedParallelism(t *testing.T) {
+	const n = 4
+	const maxParallel = 2
+
+	// started is buffered so the first maxParallel goroutines can record their
+	// start without blocking; goroutines beyond the limit are held at the
+	// semaphore and never reach Run, so they never signal started.
+	started := make(chan struct{}, n)
+	release := make(chan struct{})
+	agents := make([]Agent, n)
+	for i := range agents {
+		agents[i] = &blockingAgent{name: "r", started: started, release: release}
+	}
+
+	done := make(chan []FanOutResult, 1)
+	go func() {
+		done <- FanOut(context.Background(), agents, RunOpts{}, maxParallel)
+	}()
+
+	// Exactly maxParallel agents should start; the rest wait on the semaphore.
+	for i := 0; i < maxParallel; i++ {
+		select {
+		case <-started:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("only %d agents started, want %d", i, maxParallel)
+		}
+	}
+	select {
+	case <-started:
+		t.Fatalf("a %drd agent started; concurrency exceeded maxParallel=%d", maxParallel+1, maxParallel)
+	case <-time.After(100 * time.Millisecond):
+		// Expected: no further starts while the first batch is blocked.
+	}
+
+	// Release the panel and confirm every agent completes successfully.
+	close(release)
+	select {
+	case results := <-done:
+		if len(results) != n {
+			t.Fatalf("got %d results, want %d", len(results), n)
+		}
+		for i, r := range results {
+			if r.Err != nil {
+				t.Errorf("results[%d].Err = %v, want nil", i, r.Err)
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("FanOut did not return after release")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,7 @@ type GlobalConfig struct {
 	AutoFix              AutoFixRaw
 	Intent               IntentRaw
 	Test                 TestRaw
+	Review               ReviewRaw
 }
 
 // globalConfigRaw is the on-disk YAML representation with duration as string.
@@ -64,6 +65,7 @@ type globalConfigRaw struct {
 	AutoFix              AutoFixRaw          `yaml:"auto_fix"`
 	Intent               IntentRaw           `yaml:"intent"`
 	Test                 TestRaw             `yaml:"test"`
+	Review               ReviewRaw           `yaml:"review"`
 }
 
 // RepoConfig represents .no-mistakes.yaml in a repo root.
@@ -81,6 +83,7 @@ type RepoConfig struct {
 	AutoFix           AutoFixRaw `yaml:"auto_fix"`
 	Intent            IntentRaw  `yaml:"intent"`
 	Test              TestRaw    `yaml:"test"`
+	Review            ReviewRaw  `yaml:"review"`
 }
 
 // Commands holds optional per-repo command overrides.
@@ -127,6 +130,37 @@ type Config struct {
 	AutoFix              AutoFix
 	Intent               Intent
 	Test                 Test
+	Review               Review
+}
+
+// ReviewerSpec identifies one reviewer in the cross-family review panel. Agent
+// selects the reviewer family (a native agent name or acp:<target>). Args and
+// Path optionally override the per-agent CLI flags and binary path for this
+// reviewer, taking precedence over agent_args_override / agent_path_override
+// keyed by the agent name (so two same-family reviewers can run on different
+// models).
+type ReviewerSpec struct {
+	Agent types.AgentName `yaml:"agent"`
+	Args  []string        `yaml:"args"`
+	Path  string          `yaml:"path"`
+}
+
+// ReviewRaw is the YAML representation of the multi-reviewer panel. An empty
+// Reviewers list means the single-agent default (review runs once on the
+// configured agent), so behavior is unchanged when review is absent.
+type ReviewRaw struct {
+	Reviewers   []ReviewerSpec `yaml:"reviewers"`
+	MaxParallel int            `yaml:"max_parallel"`
+	FailOpen    *bool          `yaml:"fail_open"`
+}
+
+// Review is the resolved multi-reviewer panel config. FailOpen defaults to
+// false (fail-closed): a reviewer error fails the review step rather than
+// silently dropping a reviewer.
+type Review struct {
+	Reviewers   []ReviewerSpec
+	MaxParallel int
+	FailOpen    bool
 }
 
 // TestRaw is the YAML representation of test-step settings.
@@ -220,6 +254,20 @@ auto_fix:
   review: 0
   document: 3
   ci: 3
+
+# Cross-family review panel (optional). When set, each reviewer independently
+# reviews the same diff; all reports go to the single fix agent + the human to
+# reconcile. With no reviewers configured (the default), review runs once on the
+# 'agent' above, so behavior is unchanged. Per-reviewer path/args fall back to
+# agent_path_override / agent_args_override keyed by the reviewer's agent name;
+# set path/args per reviewer to run two same-family reviewers on different
+# models.
+# review:
+#   reviewers:
+#     - agent: codex
+#     - agent: claude
+#   max_parallel: 2   # bound concurrent reviewers; 0 = all at once
+#   fail_open: false  # any reviewer error fails the step (safe default)
 
 # User-intent extraction. When you push a branch, no-mistakes can read recent
 # transcripts from your local agent (Claude Code, Codex, OpenCode, Rovo Dev, Pi),
@@ -368,6 +416,93 @@ func (c *Config) AgentArgs() []string {
 	return c.AgentArgsOverride[string(c.Agent)]
 }
 
+// ResolveReviewers resolves the configured review panel into concrete reviewer
+// specs. It mirrors ResolveAgent: each spec's agent must be a concrete native
+// family or acp:<target>. A bare "auto" reviewer cannot itself probe the
+// system, so it is expanded to the already-resolved single agent (c.Agent) when
+// one exists and rejected otherwise. rovodev reviewers are validated with
+// probeRovoDevSupport (reusing the same lookPath the single-agent resolution
+// uses). Identical specs (same agent, path, args) are de-duplicated so a panel
+// never runs the same reviewer twice. The lookPath function should behave like
+// exec.LookPath. Returns nil when no reviewers are configured.
+func (c *Config) ResolveReviewers(ctx context.Context, lookPath func(string) (string, error)) ([]ReviewerSpec, error) {
+	if len(c.Review.Reviewers) == 0 {
+		return nil, nil
+	}
+	resolved := make([]ReviewerSpec, 0, len(c.Review.Reviewers))
+	seen := make(map[string]bool, len(c.Review.Reviewers))
+	for i, spec := range c.Review.Reviewers {
+		if spec.Agent == types.AgentAuto {
+			if c.Agent == "" || c.Agent == types.AgentAuto {
+				return nil, fmt.Errorf("review.reviewers[%d]: agent %q cannot be auto-resolved; set 'agent' to a concrete value or name the reviewer family explicitly", i, types.AgentAuto)
+			}
+			spec.Agent = c.Agent
+		}
+		if !isACPAgent(spec.Agent) && !isNativeAgent(spec.Agent) {
+			return nil, fmt.Errorf("review.reviewers[%d]: unknown agent %q; valid options: claude, codex, rovodev, opencode, pi, acp:<target>", i, spec.Agent)
+		}
+		if spec.Agent == types.AgentRovoDev {
+			bin := c.ReviewerPath(spec)
+			resolvedBin, err := lookPath(bin)
+			if err != nil {
+				return nil, fmt.Errorf("review.reviewers[%d]: resolve rovodev from %q: %w", i, bin, err)
+			}
+			ok, probeErr := probeRovoDevSupport(ctx, resolvedBin)
+			if probeErr != nil {
+				return nil, probeErr
+			}
+			if !ok {
+				return nil, fmt.Errorf("review.reviewers[%d]: %q does not support the rovodev subcommand", i, resolvedBin)
+			}
+		}
+		key := reviewerDedupKey(spec)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		resolved = append(resolved, spec)
+	}
+	return resolved, nil
+}
+
+// ReviewerPath returns the binary path for a reviewer spec. A per-spec Path
+// wins; otherwise it falls back to agent_path_override keyed by the agent name,
+// then the default binary name (or acpx for acp: targets) - mirroring
+// AgentPath.
+func (c *Config) ReviewerPath(spec ReviewerSpec) string {
+	if spec.Path != "" {
+		return spec.Path
+	}
+	if isACPAgent(spec.Agent) {
+		if c.ACPXPath != "" {
+			return c.ACPXPath
+		}
+		return "acpx"
+	}
+	if c.AgentPathOverride != nil {
+		if p, ok := c.AgentPathOverride[string(spec.Agent)]; ok {
+			return p
+		}
+	}
+	if b, ok := defaultBinary[spec.Agent]; ok {
+		return b
+	}
+	return string(spec.Agent)
+}
+
+// ReviewerArgs returns the extra native CLI args for a reviewer spec. Per-spec
+// Args win; otherwise they fall back to agent_args_override keyed by the agent
+// name - mirroring AgentArgs.
+func (c *Config) ReviewerArgs(spec ReviewerSpec) []string {
+	if len(spec.Args) > 0 {
+		return spec.Args
+	}
+	if c.AgentArgsOverride == nil {
+		return nil
+	}
+	return c.AgentArgsOverride[string(spec.Agent)]
+}
+
 // agentArgsOverrideAgents lists native agent names accepted as keys in
 // agent_args_override.
 var agentArgsOverrideAgents = map[string]bool{
@@ -434,6 +569,54 @@ func validateAgentArgsOverride(override map[string][]string) error {
 		}
 	}
 	return nil
+}
+
+// isNativeAgent reports whether name is a known native agent family (one with a
+// default binary), as opposed to "auto" or an acp:<target>.
+func isNativeAgent(name types.AgentName) bool {
+	_, ok := defaultBinary[name]
+	return ok
+}
+
+// validateReviewers checks the configured review panel. Each reviewer must name
+// a known native agent family or an acp:<target> ("auto" is permitted here and
+// resolved later by ResolveReviewers). Per-spec Args may not contain a flag
+// reserved by no-mistakes - the same reservation applied to agent_args_override
+// - nor an empty arg.
+func validateReviewers(reviewers []ReviewerSpec) error {
+	for i, spec := range reviewers {
+		name := string(spec.Agent)
+		if name == "" {
+			return fmt.Errorf("invalid review.reviewers[%d]: missing agent", i)
+		}
+		if spec.Agent == types.AgentAuto && len(spec.Args) > 0 {
+			return fmt.Errorf("invalid review.reviewers[%d].args: agent %q cannot use per-reviewer args; name the concrete reviewer family explicitly", i, types.AgentAuto)
+		}
+		if spec.Agent != types.AgentAuto && !isACPAgent(spec.Agent) && !isNativeAgent(spec.Agent) {
+			return fmt.Errorf("invalid review.reviewers[%d]: unknown agent %q (valid: auto, claude, codex, rovodev, opencode, pi, acp:<target>)", i, name)
+		}
+		reserved := reservedAgentArgs[name]
+		for j, arg := range spec.Args {
+			if strings.TrimSpace(arg) == "" {
+				return fmt.Errorf("invalid review.reviewers[%d].args[%d]: empty arg", i, j)
+			}
+			base := arg
+			if idx := strings.Index(arg, "="); idx > 0 {
+				base = arg[:idx]
+			}
+			if reserved[base] {
+				return fmt.Errorf("invalid review.reviewers[%d].args[%d]: %q is managed by no-mistakes and cannot be overridden", i, j, arg)
+			}
+		}
+	}
+	return nil
+}
+
+// reviewerDedupKey produces a stable identity for a reviewer spec so a panel
+// never runs two identical reviewers. Specs are identical when their agent,
+// path, and args all match.
+func reviewerDedupKey(spec ReviewerSpec) string {
+	return string(spec.Agent) + "\x00" + spec.Path + "\x00" + strings.Join(spec.Args, "\x01")
 }
 
 // EnsureDefaultGlobalConfig writes the default config file at path if it does
@@ -515,6 +698,10 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 	cfg.AutoFix = raw.AutoFix
 	cfg.Intent = raw.Intent
 	cfg.Test = raw.Test
+	if err := validateReviewers(raw.Review.Reviewers); err != nil {
+		return nil, err
+	}
+	cfg.Review = raw.Review
 
 	return cfg, nil
 }
@@ -552,7 +739,26 @@ func LoadRepo(dir string) (*RepoConfig, error) {
 		return nil, fmt.Errorf("read repo config: %w", err)
 	}
 
-	return parseRepoConfig(data)
+	return parseRepoConfig(data, true)
+}
+
+// LoadPushedRepo reads per-repo config from a pushed-branch worktree while
+// dropping code-executing review fields before typed parsing. The daemon uses
+// this when trusted allow_repo_commands is false, so malformed or invalid
+// pushed review config cannot fail a run before the trust filter strips it.
+func LoadPushedRepo(dir string) (*RepoConfig, error) {
+	cfg := &RepoConfig{}
+
+	path := filepath.Join(dir, ".no-mistakes.yaml")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return cfg, nil
+		}
+		return nil, fmt.Errorf("read repo config: %w", err)
+	}
+
+	return parsePushedRepoConfig(data)
 }
 
 // LoadRepoFromBytes parses per-repo config from raw YAML bytes. It is the
@@ -560,10 +766,10 @@ func LoadRepo(dir string) (*RepoConfig, error) {
 // specific git ref (e.g. the default branch) use this to avoid honoring a
 // contributor's checked-out copy.
 func LoadRepoFromBytes(data []byte) (*RepoConfig, error) {
-	return parseRepoConfig(data)
+	return parseRepoConfig(data, true)
 }
 
-func parseRepoConfig(data []byte) (*RepoConfig, error) {
+func parseRepoConfig(data []byte, validateReview bool) (*RepoConfig, error) {
 	cfg := &RepoConfig{}
 	if err := yaml.Unmarshal(data, cfg); err != nil {
 		return nil, fmt.Errorf("parse repo config: %w", err)
@@ -571,18 +777,63 @@ func parseRepoConfig(data []byte) (*RepoConfig, error) {
 	if cfg.AutoFix.CI == nil {
 		cfg.AutoFix.CI = cfg.AutoFix.Babysit
 	}
+	if validateReview {
+		if err := validateReviewers(cfg.Review.Reviewers); err != nil {
+			return nil, err
+		}
+	}
 
 	return cfg, nil
+}
+
+type pushedRepoConfigRaw struct {
+	AllowRepoCommands bool            `yaml:"allow_repo_commands"`
+	Commands          Commands        `yaml:"commands"`
+	IgnorePatterns    []string        `yaml:"ignore_patterns"`
+	Agent             types.AgentName `yaml:"agent"`
+	AutoFix           AutoFixRaw      `yaml:"auto_fix"`
+	Intent            IntentRaw       `yaml:"intent"`
+	Test              TestRaw         `yaml:"test"`
+	Review            any             `yaml:"review"`
+}
+
+func parsePushedRepoConfig(data []byte) (*RepoConfig, error) {
+	var raw pushedRepoConfigRaw
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parse repo config: %w", err)
+	}
+	if raw.AutoFix.CI == nil {
+		raw.AutoFix.CI = raw.AutoFix.Babysit
+	}
+	return &RepoConfig{
+		AllowRepoCommands: raw.AllowRepoCommands,
+		Commands:          raw.Commands,
+		IgnorePatterns:    raw.IgnorePatterns,
+		Agent:             raw.Agent,
+		AutoFix:           raw.AutoFix,
+		Intent:            raw.Intent,
+		Test:              raw.Test,
+	}, nil
+}
+
+// ValidateReview validates a review panel after trust filtering has selected
+// the copy that is actually allowed to launch reviewer binaries.
+func ValidateReview(review ReviewRaw) error {
+	if err := validateReviewers(review.Reviewers); err != nil {
+		return err
+	}
+	return nil
 }
 
 // EffectiveRepoConfig returns the repo config that should drive the pipeline
 // given a pushed-branch copy and the trusted default-branch copy.
 //
 // The code-executing selection fields — Commands (run verbatim via sh -c on
-// the daemon host) and Agent (selects which process launches with the
-// maintainer's credentials, including acp: targets) — are taken only from
-// the trusted copy when it is present, so a contributor's pushed branch
-// cannot inject shell or pick an agent. When allowRepoCommands is true the
+// the daemon host), Agent (selects which process launches with the
+// maintainer's credentials, including acp: targets), and Review (the review
+// panel, which likewise selects which reviewer binaries launch) — are taken
+// only from the trusted copy when it is present, so a contributor's pushed
+// branch cannot inject shell or pick an agent. When allowRepoCommands is true the
 // maintainer has explicitly opted in (via allow_repo_commands on the
 // TRUSTED default-branch copy) to honoring the pushed-branch copy wholesale.
 // When there is no trusted copy and the maintainer has not opted in, both
@@ -605,9 +856,14 @@ func EffectiveRepoConfig(pushed, trusted *RepoConfig, allowRepoCommands bool) *R
 	if trusted != nil {
 		effective.Commands = trusted.Commands
 		effective.Agent = trusted.Agent
+		// SECURITY: the review panel selects which reviewer binaries launch
+		// with the maintainer's credentials, so it is code-executing config.
+		// Take it from the trusted default-branch copy, never the pushed SHA.
+		effective.Review = trusted.Review
 	} else {
 		effective.Commands = Commands{}
 		effective.Agent = ""
+		effective.Review = ReviewRaw{}
 	}
 	return &effective
 }
@@ -683,6 +939,20 @@ func applyTestOverrides(dst *Test, src *TestRaw) {
 	}
 }
 
+// resolveReview converts a raw review panel into its resolved form. FailOpen
+// defaults to false (fail-closed) when unset.
+func resolveReview(raw ReviewRaw) Review {
+	failOpen := false
+	if raw.FailOpen != nil {
+		failOpen = *raw.FailOpen
+	}
+	return Review{
+		Reviewers:   raw.Reviewers,
+		MaxParallel: raw.MaxParallel,
+		FailOpen:    failOpen,
+	}
+}
+
 // autoFixDefaults returns the default auto-fix configuration.
 func autoFixDefaults() AutoFix {
 	return AutoFix{
@@ -753,6 +1023,16 @@ func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 	applyTestOverrides(&test, &global.Test)
 	applyTestOverrides(&test, &repo.Test)
 
+	// Default the review panel from global; a repo that configures its own
+	// reviewers overrides it wholesale. Both copies are trusted by the time
+	// they reach Merge (EffectiveRepoConfig strips a pushed-branch review
+	// block to the trusted default-branch copy). An empty Reviewers list keeps
+	// the single-agent default, so behavior is unchanged when review is absent.
+	review := resolveReview(global.Review)
+	if len(repo.Review.Reviewers) > 0 {
+		review = resolveReview(repo.Review)
+	}
+
 	cfg := &Config{
 		Agent:                global.Agent,
 		ACPXPath:             global.ACPXPath,
@@ -766,6 +1046,7 @@ func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 		AutoFix:              af,
 		Intent:               intent,
 		Test:                 test,
+		Review:               review,
 	}
 
 	if repo.Agent != "" {

--- a/internal/config/config_review_test.go
+++ b/internal/config/config_review_test.go
@@ -1,0 +1,480 @@
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// okLookPath is a lookPath stub that pretends every binary exists. ResolveReviewers
+// only consults lookPath for rovodev, but tests pass it for completeness.
+func okLookPath(bin string) (string, error) { return bin, nil }
+
+func TestLoadGlobal_ReviewParsesUnderStrictKnownFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	data := `agent: claude
+review:
+  reviewers:
+    - agent: codex
+    - agent: claude
+      args:
+        - -m
+        - opus
+      path: /opt/claude
+  max_parallel: 2
+  fail_open: true
+`
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadGlobal(path)
+	if err != nil {
+		t.Fatalf("LoadGlobal() error = %v", err)
+	}
+	if len(cfg.Review.Reviewers) != 2 {
+		t.Fatalf("reviewers = %d, want 2", len(cfg.Review.Reviewers))
+	}
+	if cfg.Review.Reviewers[0].Agent != types.AgentCodex {
+		t.Errorf("reviewers[0].Agent = %q, want codex", cfg.Review.Reviewers[0].Agent)
+	}
+	if cfg.Review.Reviewers[1].Agent != types.AgentClaude {
+		t.Errorf("reviewers[1].Agent = %q, want claude", cfg.Review.Reviewers[1].Agent)
+	}
+	if got := cfg.Review.Reviewers[1].Args; !reflect.DeepEqual(got, []string{"-m", "opus"}) {
+		t.Errorf("reviewers[1].Args = %v, want [-m opus]", got)
+	}
+	if cfg.Review.Reviewers[1].Path != "/opt/claude" {
+		t.Errorf("reviewers[1].Path = %q, want /opt/claude", cfg.Review.Reviewers[1].Path)
+	}
+	if cfg.Review.MaxParallel != 2 {
+		t.Errorf("max_parallel = %d, want 2", cfg.Review.MaxParallel)
+	}
+	if cfg.Review.FailOpen == nil || !*cfg.Review.FailOpen {
+		t.Errorf("fail_open = %v, want true", cfg.Review.FailOpen)
+	}
+}
+
+func TestLoadGlobal_ReviewUnknownKeyTripsKnownFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	data := `review:
+  reviewers:
+    - agent: codex
+  bogus: true
+`
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadGlobal(path); err == nil {
+		t.Fatal("expected error: unknown key under review must trip KnownFields(true)")
+	}
+}
+
+func TestLoadGlobal_ReviewUnknownReviewerKeyTripsKnownFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	data := `review:
+  reviewers:
+    - agent: codex
+      model: opus
+`
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadGlobal(path); err == nil {
+		t.Fatal("expected error: unknown reviewer key must trip KnownFields(true)")
+	}
+}
+
+func TestLoadGlobal_ReviewRejectsUnknownFamily(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	data := `review:
+  reviewers:
+    - agent: gpt5
+`
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadGlobal(path)
+	if err == nil {
+		t.Fatal("expected error for unknown reviewer family")
+	}
+	if !strings.Contains(err.Error(), "gpt5") {
+		t.Errorf("expected error to mention unknown family, got: %v", err)
+	}
+}
+
+func TestMerge_ReviewDefaultsEmptySingleAgentFallback(t *testing.T) {
+	global := &GlobalConfig{Agent: types.AgentClaude}
+	repo := &RepoConfig{}
+
+	cfg := Merge(global, repo)
+
+	if len(cfg.Review.Reviewers) != 0 {
+		t.Errorf("reviewers = %d, want 0 (single-agent fallback)", len(cfg.Review.Reviewers))
+	}
+	if cfg.Review.FailOpen {
+		t.Errorf("fail_open = true, want false by default")
+	}
+}
+
+func TestMerge_ReviewFromGlobal(t *testing.T) {
+	failOpen := true
+	global := &GlobalConfig{
+		Agent: types.AgentClaude,
+		Review: ReviewRaw{
+			Reviewers:   []ReviewerSpec{{Agent: types.AgentCodex}},
+			MaxParallel: 3,
+			FailOpen:    &failOpen,
+		},
+	}
+	repo := &RepoConfig{}
+
+	cfg := Merge(global, repo)
+
+	if len(cfg.Review.Reviewers) != 1 || cfg.Review.Reviewers[0].Agent != types.AgentCodex {
+		t.Errorf("reviewers = %v, want [codex] from global", cfg.Review.Reviewers)
+	}
+	if cfg.Review.MaxParallel != 3 {
+		t.Errorf("max_parallel = %d, want 3", cfg.Review.MaxParallel)
+	}
+	if !cfg.Review.FailOpen {
+		t.Errorf("fail_open = false, want true from global")
+	}
+}
+
+func TestMerge_ReviewRepoOverridesGlobal(t *testing.T) {
+	global := &GlobalConfig{
+		Agent: types.AgentClaude,
+		Review: ReviewRaw{
+			Reviewers:   []ReviewerSpec{{Agent: types.AgentCodex}},
+			MaxParallel: 1,
+		},
+	}
+	repo := &RepoConfig{
+		Review: ReviewRaw{
+			Reviewers:   []ReviewerSpec{{Agent: types.AgentClaude}, {Agent: types.AgentPi}},
+			MaxParallel: 5,
+		},
+	}
+
+	cfg := Merge(global, repo)
+
+	if len(cfg.Review.Reviewers) != 2 {
+		t.Fatalf("reviewers = %d, want 2 (repo override)", len(cfg.Review.Reviewers))
+	}
+	if cfg.Review.Reviewers[0].Agent != types.AgentClaude || cfg.Review.Reviewers[1].Agent != types.AgentPi {
+		t.Errorf("reviewers = %v, want [claude pi] from repo", cfg.Review.Reviewers)
+	}
+	if cfg.Review.MaxParallel != 5 {
+		t.Errorf("max_parallel = %d, want 5 from repo", cfg.Review.MaxParallel)
+	}
+}
+
+// TestEffectiveRepoConfig_StripsPushedReview proves the security gate: a review
+// panel pushed on a feature branch must never win - the effective panel comes
+// from the trusted default-branch copy (or is empty when there is no trusted
+// copy), because reviewers select which binaries launch with maintainer creds.
+func TestEffectiveRepoConfig_StripsPushedReview(t *testing.T) {
+	pushed := &RepoConfig{
+		Review: ReviewRaw{
+			Reviewers: []ReviewerSpec{{Agent: types.AgentCodex, Path: "/tmp/evil"}},
+		},
+	}
+	trusted := &RepoConfig{
+		Review: ReviewRaw{
+			Reviewers: []ReviewerSpec{{Agent: types.AgentClaude}},
+		},
+	}
+
+	got := EffectiveRepoConfig(pushed, trusted, false)
+
+	if len(got.Review.Reviewers) != 1 || got.Review.Reviewers[0].Agent != types.AgentClaude {
+		t.Errorf("review = %v, want trusted [claude]", got.Review.Reviewers)
+	}
+	if got.Review.Reviewers[0].Path != "" {
+		t.Errorf("review path = %q, want trusted (empty), not pushed /tmp/evil", got.Review.Reviewers[0].Path)
+	}
+	// The pushed config must not be mutated.
+	if pushed.Review.Reviewers[0].Path != "/tmp/evil" {
+		t.Errorf("pushed config was mutated: path = %q", pushed.Review.Reviewers[0].Path)
+	}
+}
+
+func TestEffectiveRepoConfig_NoTrustedDisablesReview(t *testing.T) {
+	pushed := &RepoConfig{
+		Review: ReviewRaw{
+			Reviewers: []ReviewerSpec{{Agent: types.AgentCodex}},
+		},
+	}
+
+	got := EffectiveRepoConfig(pushed, nil, false)
+
+	if len(got.Review.Reviewers) != 0 {
+		t.Errorf("review = %v, want empty (no trusted config)", got.Review.Reviewers)
+	}
+}
+
+func TestEffectiveRepoConfig_OptInHonorsPushedReview(t *testing.T) {
+	pushed := &RepoConfig{
+		Review: ReviewRaw{
+			Reviewers: []ReviewerSpec{{Agent: types.AgentCodex}},
+		},
+	}
+	trusted := &RepoConfig{
+		Review: ReviewRaw{
+			Reviewers: []ReviewerSpec{{Agent: types.AgentClaude}},
+		},
+	}
+
+	got := EffectiveRepoConfig(pushed, trusted, true)
+
+	if len(got.Review.Reviewers) != 1 || got.Review.Reviewers[0].Agent != types.AgentCodex {
+		t.Errorf("review = %v, want pushed [codex] under opt-in", got.Review.Reviewers)
+	}
+}
+
+func TestLoadPushedRepo_DoesNotValidateStrippedReview(t *testing.T) {
+	dir := t.TempDir()
+	repoYAML := "review:\n  reviewers:\n    - agent: gpt5\n"
+	if err := os.WriteFile(filepath.Join(dir, ".no-mistakes.yaml"), []byte(repoYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadPushedRepo(dir)
+	if err != nil {
+		t.Fatalf("LoadPushedRepo should parse pushed review config before trust filtering, got: %v", err)
+	}
+	if len(cfg.Review.Reviewers) != 0 {
+		t.Fatalf("pushed review config = %+v, want stripped review panel", cfg.Review.Reviewers)
+	}
+
+	effective := EffectiveRepoConfig(cfg, nil, false)
+	if err := ValidateReview(effective.Review); err != nil {
+		t.Fatalf("stripped pushed review should validate after trust filtering, got: %v", err)
+	}
+}
+
+func TestLoadPushedRepo_DoesNotParseMalformedStrippedReview(t *testing.T) {
+	dir := t.TempDir()
+	repoYAML := "ignore_patterns:\n  - '*.generated.go'\nreview: bad\n"
+	if err := os.WriteFile(filepath.Join(dir, ".no-mistakes.yaml"), []byte(repoYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadPushedRepo(dir)
+	if err != nil {
+		t.Fatalf("LoadPushedRepo should ignore malformed pushed review config before trust filtering, got: %v", err)
+	}
+	if len(cfg.Review.Reviewers) != 0 {
+		t.Fatalf("pushed review config = %+v, want stripped review panel", cfg.Review.Reviewers)
+	}
+	if len(cfg.IgnorePatterns) != 1 || cfg.IgnorePatterns[0] != "*.generated.go" {
+		t.Fatalf("ignore_patterns = %v, want pushed non-executing fields preserved", cfg.IgnorePatterns)
+	}
+}
+
+func TestValidateReview_RejectsEffectiveInvalidReview(t *testing.T) {
+	err := ValidateReview(ReviewRaw{Reviewers: []ReviewerSpec{{Agent: "gpt5"}}})
+	if err == nil {
+		t.Fatal("expected invalid effective review panel to be rejected")
+	}
+	if !strings.Contains(err.Error(), "gpt5") {
+		t.Errorf("expected error to mention gpt5, got: %v", err)
+	}
+}
+
+func TestLoadRepo_ReviewValidatesReservedArgs(t *testing.T) {
+	dir := t.TempDir()
+	repoYAML := "review:\n  reviewers:\n    - agent: codex\n      args:\n        - --json\n"
+	if err := os.WriteFile(filepath.Join(dir, ".no-mistakes.yaml"), []byte(repoYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadRepo(dir)
+	if err == nil {
+		t.Fatal("expected error: repo-level reviewer with reserved arg --json must be rejected")
+	}
+	if !strings.Contains(err.Error(), "managed by no-mistakes") {
+		t.Errorf("expected 'managed by no-mistakes' in error, got: %v", err)
+	}
+}
+
+func TestLoadRepoFromBytes_ReviewValidatesUnknownFamily(t *testing.T) {
+	data := []byte("review:\n  reviewers:\n    - agent: gpt5\n")
+	_, err := LoadRepoFromBytes(data)
+	if err == nil {
+		t.Fatal("expected error: repo-level reviewer with unknown family must be rejected")
+	}
+	if !strings.Contains(err.Error(), "gpt5") {
+		t.Errorf("expected error to mention unknown family, got: %v", err)
+	}
+}
+
+func TestLoadRepoFromBytes_ReviewValidatesEmptyArg(t *testing.T) {
+	data := []byte("review:\n  reviewers:\n    - agent: codex\n      args:\n        - \" \"\n")
+	_, err := LoadRepoFromBytes(data)
+	if err == nil {
+		t.Fatal("expected error: repo-level reviewer with empty arg must be rejected")
+	}
+	if !strings.Contains(err.Error(), "empty arg") {
+		t.Errorf("expected 'empty arg' in error, got: %v", err)
+	}
+}
+
+func TestValidateReviewers_RejectsUnknownFamily(t *testing.T) {
+	err := validateReviewers([]ReviewerSpec{{Agent: "gpt5"}})
+	if err == nil {
+		t.Fatal("expected error for unknown reviewer family")
+	}
+	if !strings.Contains(err.Error(), "gpt5") {
+		t.Errorf("expected error to mention unknown family, got: %v", err)
+	}
+}
+
+func TestValidateReviewers_RejectsMissingAgent(t *testing.T) {
+	if err := validateReviewers([]ReviewerSpec{{}}); err == nil {
+		t.Fatal("expected error for missing reviewer agent")
+	}
+}
+
+func TestValidateReviewers_RejectsReservedArgs(t *testing.T) {
+	cases := []struct {
+		agent types.AgentName
+		arg   string
+	}{
+		{types.AgentCodex, "exec"},
+		{types.AgentCodex, "--json"},
+		{types.AgentClaude, "-p"},
+		{types.AgentClaude, "--output-format=stream-json"},
+		{types.AgentOpenCode, "serve"},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.agent)+"_"+tc.arg, func(t *testing.T) {
+			err := validateReviewers([]ReviewerSpec{{Agent: tc.agent, Args: []string{tc.arg}}})
+			if err == nil {
+				t.Fatalf("expected error for reserved arg %q on %q", tc.arg, tc.agent)
+			}
+			if !strings.Contains(err.Error(), "managed by no-mistakes") {
+				t.Errorf("expected 'managed by no-mistakes' in error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateReviewers_RejectsAutoArgs(t *testing.T) {
+	err := validateReviewers([]ReviewerSpec{{Agent: types.AgentAuto, Args: []string{"--json"}}})
+	if err == nil {
+		t.Fatal("expected auto reviewer args to be rejected")
+	}
+	if !strings.Contains(err.Error(), "cannot use per-reviewer args") {
+		t.Errorf("expected auto args error, got: %v", err)
+	}
+}
+
+func TestValidateReviewers_AllowsAutoAndACP(t *testing.T) {
+	specs := []ReviewerSpec{
+		{Agent: types.AgentAuto},
+		{Agent: "acp:gemini"},
+		{Agent: types.AgentCodex},
+	}
+	if err := validateReviewers(specs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveReviewers_RejectsBareAutoWithoutConcreteAgent(t *testing.T) {
+	cfg := &Config{
+		Agent:  types.AgentAuto,
+		Review: Review{Reviewers: []ReviewerSpec{{Agent: types.AgentAuto}}},
+	}
+	_, err := cfg.ResolveReviewers(context.Background(), okLookPath)
+	if err == nil {
+		t.Fatal("expected error: bare auto reviewer cannot resolve without a concrete agent")
+	}
+}
+
+func TestResolveReviewers_ExpandsBareAutoToAgent(t *testing.T) {
+	cfg := &Config{
+		Agent:  types.AgentClaude,
+		Review: Review{Reviewers: []ReviewerSpec{{Agent: types.AgentAuto}}},
+	}
+	got, err := cfg.ResolveReviewers(context.Background(), okLookPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].Agent != types.AgentClaude {
+		t.Errorf("resolved = %v, want [claude] (auto expanded to agent)", got)
+	}
+}
+
+func TestResolveReviewers_Dedups(t *testing.T) {
+	cfg := &Config{
+		Agent: types.AgentClaude,
+		Review: Review{Reviewers: []ReviewerSpec{
+			{Agent: types.AgentCodex},
+			{Agent: types.AgentClaude},
+			{Agent: types.AgentCodex}, // duplicate of [0]
+		}},
+	}
+	got, err := cfg.ResolveReviewers(context.Background(), okLookPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("resolved = %d reviewers, want 2 after dedup", len(got))
+	}
+	if got[0].Agent != types.AgentCodex || got[1].Agent != types.AgentClaude {
+		t.Errorf("resolved = %v, want [codex claude] preserving first-occurrence order", got)
+	}
+}
+
+func TestResolveReviewers_EmptyReturnsNil(t *testing.T) {
+	cfg := &Config{Agent: types.AgentClaude}
+	got, err := cfg.ResolveReviewers(context.Background(), okLookPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("resolved = %v, want nil for empty panel", got)
+	}
+}
+
+func TestReviewerPathAndArgs_Precedence(t *testing.T) {
+	cfg := &Config{
+		Agent:             types.AgentClaude,
+		AgentPathOverride: map[string]string{"codex": "/opt/codex"},
+		AgentArgsOverride: map[string][]string{"codex": {"-m", "gpt-5"}},
+	}
+
+	// Falls back to agent_path_override / agent_args_override keyed by name.
+	fallback := ReviewerSpec{Agent: types.AgentCodex}
+	if got := cfg.ReviewerPath(fallback); got != "/opt/codex" {
+		t.Errorf("ReviewerPath fallback = %q, want /opt/codex", got)
+	}
+	if got := cfg.ReviewerArgs(fallback); !reflect.DeepEqual(got, []string{"-m", "gpt-5"}) {
+		t.Errorf("ReviewerArgs fallback = %v, want [-m gpt-5]", got)
+	}
+
+	// Per-spec Path/Args take precedence.
+	override := ReviewerSpec{Agent: types.AgentCodex, Path: "/custom/codex", Args: []string{"-m", "o3"}}
+	if got := cfg.ReviewerPath(override); got != "/custom/codex" {
+		t.Errorf("ReviewerPath per-spec = %q, want /custom/codex", got)
+	}
+	if got := cfg.ReviewerArgs(override); !reflect.DeepEqual(got, []string{"-m", "o3"}) {
+		t.Errorf("ReviewerArgs per-spec = %v, want [-m o3]", got)
+	}
+
+	// Default binary when no override.
+	def := ReviewerSpec{Agent: types.AgentPi}
+	if got := cfg.ReviewerPath(def); got != "pi" {
+		t.Errorf("ReviewerPath default = %q, want pi", got)
+	}
+}

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -140,6 +140,15 @@ func branchFromRef(ref string) string {
 	return strings.TrimPrefix(ref, "refs/heads/")
 }
 
+func stepIsSkipped(skipSteps []types.StepName, step types.StepName) bool {
+	for _, skipped := range skipSteps {
+		if skipped == step {
+			return true
+		}
+	}
+	return false
+}
+
 // loadTrustedRepoConfig reads .no-mistakes.yaml from the trusted
 // default-branch commit (trustedSHA — the exact SHA startRun just fetched and
 // resolved) in the worktree and parses it. Reading at a pinned SHA, rather
@@ -355,19 +364,13 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 		trackStartFailure("load_global_config")
 		return "", fmt.Errorf("load global config: %w", err)
 	}
-	repoCfg, err := config.LoadRepo(wtDir)
-	if err != nil {
-		m.db.UpdateRunError(run.ID, fmt.Sprintf("load config: %s", err))
-		trackStartFailure("load_repo_config")
-		return "", fmt.Errorf("load repo config: %w", err)
-	}
 	// SECURITY: load the code-executing selection fields (commands.* and
 	// agent) from the trusted default-branch copy of .no-mistakes.yaml rather
 	// than the pushed SHA. The worktree is checked out at headSHA (the
-	// contributor's branch), so reading repoCfg above would honor a
-	// contributor's commands/agent and let any pushed SHA run arbitrary shell
-	// (sh -c) or pick the launched agent (incl. acp: targets) on the daemon
-	// host with the maintainer's env (GH_TOKEN, SSH agent, ...).
+	// contributor's branch), so honoring its code-executing fields would let
+	// any pushed SHA run arbitrary shell (sh -c), pick the launched agent
+	// (incl. acp: targets), or choose reviewer binaries on the daemon host with
+	// the maintainer's env (GH_TOKEN, SSH agent, ...).
 	// EffectiveRepoConfig replaces commands + agent with the trusted
 	// default-branch values unless the maintainer has explicitly opted in.
 	//
@@ -377,7 +380,23 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 	// opt-in is false and commands/agent are forced empty — fail closed.
 	trustedRepoCfg := loadTrustedRepoConfig(ctx, wtDir, trustedSHA, run.ID)
 	allowRepoCommands := trustedRepoCfg != nil && trustedRepoCfg.AllowRepoCommands
+	var repoCfg *config.RepoConfig
+	if allowRepoCommands {
+		repoCfg, err = config.LoadRepo(wtDir)
+	} else {
+		repoCfg, err = config.LoadPushedRepo(wtDir)
+	}
+	if err != nil {
+		m.db.UpdateRunError(run.ID, fmt.Sprintf("load config: %s", err))
+		trackStartFailure("load_repo_config")
+		return "", fmt.Errorf("load repo config: %w", err)
+	}
 	effectiveRepoCfg := config.EffectiveRepoConfig(repoCfg, trustedRepoCfg, allowRepoCommands)
+	if err := config.ValidateReview(effectiveRepoCfg.Review); err != nil {
+		m.db.UpdateRunError(run.ID, fmt.Sprintf("load config: %s", err))
+		trackStartFailure("load_repo_config")
+		return "", fmt.Errorf("load config: %w", err)
+	}
 	if allowRepoCommands {
 		slog.Warn("allow_repo_commands is enabled on the default branch: honoring commands/agent from pushed branch", "run_id", run.ID, "branch", branch)
 	} else if repoCfg.Commands != effectiveRepoCfg.Commands || repoCfg.Agent != effectiveRepoCfg.Agent {
@@ -390,6 +409,7 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 
 	// Create agent. In demo mode, skip resolution and use a no-op agent.
 	var ag agent.Agent
+	var reviewerAgents []agent.Agent
 	if steps.IsDemoMode() {
 		ag = agent.NewNoop()
 	} else {
@@ -411,21 +431,53 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 		// avoid mutating system state (e.g. brew/Homebrew touching
 		// /Applications), which triggers macOS App Management prompts.
 		ag = agent.WithSteering(ag)
+
+		if !stepIsSkipped(skipSteps, types.StepReview) {
+			// Build the cross-family review panel (empty when review.reviewers is
+			// unset, leaving behavior unchanged). Reviewers use the SAME factory and
+			// steering as the impl agent. Any failure here must close what has been
+			// built so far before returning, since the cleanup defer below only runs
+			// once the background goroutine owns the run.
+			reviewerSpecs, revErr := cfg.ResolveReviewers(ctx, exec.LookPath)
+			if revErr != nil {
+				ag.Close()
+				m.db.UpdateRunError(run.ID, revErr.Error())
+				trackStartFailure("resolve_reviewers")
+				return "", revErr
+			}
+			for _, spec := range reviewerSpecs {
+				rev, rErr := agent.NewWithOptions(spec.Agent, cfg.ReviewerPath(spec), cfg.ReviewerArgs(spec), agent.Options{
+					ACPRegistryOverrides: cfg.ACPRegistryOverrides,
+				})
+				if rErr != nil {
+					for _, built := range reviewerAgents {
+						built.Close()
+					}
+					ag.Close()
+					m.db.UpdateRunError(run.ID, fmt.Sprintf("create reviewer agent: %s", rErr))
+					trackStartFailure("create_reviewer_agent")
+					return "", fmt.Errorf("create reviewer agent: %w", rErr)
+				}
+				reviewerAgents = append(reviewerAgents, agent.WithSteering(rev))
+			}
+		}
 	}
 
 	execSteps := m.steps()
 	telemetry.Track("run", telemetry.Fields{
-		"action":      "started",
-		"trigger":     trigger,
-		"agent":       string(cfg.Agent),
-		"branch_role": branchRole,
-		"step_count":  len(execSteps),
-		"demo_mode":   steps.IsDemoMode(),
+		"action":         "started",
+		"trigger":        trigger,
+		"agent":          string(cfg.Agent),
+		"branch_role":    branchRole,
+		"step_count":     len(execSteps),
+		"demo_mode":      steps.IsDemoMode(),
+		"reviewer_count": len(reviewerAgents),
 	})
 
 	// Create executor with event broadcast.
 	runCtx, cancel := context.WithCancelCause(context.Background())
 	executor := pipeline.NewExecutor(m.db, m.paths, cfg, ag, execSteps, m.broadcast)
+	executor.SetReviewers(reviewerAgents)
 	executor.SetSkippedSteps(skipSteps)
 
 	// Track executor.
@@ -471,6 +523,10 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 			}
 			cancel(nil)
 			ag.Close()
+			// Close every reviewer panel agent (no-op when none configured).
+			for _, rev := range reviewerAgents {
+				rev.Close()
+			}
 			// Close subscriber channels for this run.
 			m.closeSubscribers(run.ID)
 			// Clean up worktree.

--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -120,6 +121,62 @@ func TestPushReceivedSkipStepsConfiguresExecutor(t *testing.T) {
 		if step.StepName == types.StepReview && step.Status != types.StepStatusSkipped {
 			t.Fatalf("review status = %s, want %s", step.Status, types.StepStatusSkipped)
 		}
+	}
+}
+
+func TestPushReceivedSkipReviewDoesNotResolveReviewers(t *testing.T) {
+	review := &mockPassStep{name: types.StepReview}
+	testStep := &mockPassStep{name: types.StepTest}
+	p, d := startTestDaemonWithSteps(t, func() []pipeline.Step {
+		return []pipeline.Step{review, testStep}
+	})
+
+	repo, _ := setupTestGitRepo(t, p, d, "skip-review-reviewer-resolution-repo")
+	missingRovo := filepath.Join(t.TempDir(), "missing-rovodev")
+	configYAML := `auto_fix:
+  lint: 0
+  test: 0
+  review: 0
+review:
+  reviewers:
+    - agent: rovodev
+      path: ` + strconv.Quote(missingRovo) + `
+`
+	if err := os.WriteFile(filepath.Join(repo.WorkingPath, ".no-mistakes.yaml"), []byte(configYAML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, repo.WorkingPath, "add", ".no-mistakes.yaml")
+	gitCmd(t, repo.WorkingPath, "commit", "-m", "configure review panel")
+	gitCmd(t, repo.WorkingPath, "push", "gate", "HEAD:refs/heads/main")
+	headSHA := gitOutput(t, repo.WorkingPath, "rev-parse", "HEAD")
+
+	client, err := ipc.Dial(p.Socket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	var result ipc.PushReceivedResult
+	err = client.Call(ipc.MethodPushReceived, &ipc.PushReceivedParams{
+		Gate:      p.RepoDir("skip-review-reviewer-resolution-repo"),
+		Ref:       "refs/heads/main",
+		Old:       "0000000000000000000000000000000000000000",
+		New:       headSHA,
+		SkipSteps: []types.StepName{types.StepReview},
+	}, &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run := waitForRunTerminalState(t, d, result.RunID)
+	if run.Status != types.RunCompleted {
+		t.Fatalf("run status = %q, want %q", run.Status, types.RunCompleted)
+	}
+	if got := review.execCnt.Load(); got != 0 {
+		t.Fatalf("review executed %d times, want 0", got)
+	}
+	if got := testStep.execCnt.Load(); got != 1 {
+		t.Fatalf("test executed %d times, want 1", got)
 	}
 }
 

--- a/internal/e2e/harness.go
+++ b/internal/e2e/harness.go
@@ -40,8 +40,10 @@ type Harness struct {
 	AgentLog    string // every fake-agent invocation appended here, one JSON per line
 	Scenario    string // optional path to a scenario yaml; empty = built-in default
 
-	agentName         string // claude / codex / opencode
-	allowRepoCommands *bool  // mirrors SetupOpts.AllowRepoCommands
+	agentName         string   // claude / codex / opencode
+	allowRepoCommands *bool    // mirrors SetupOpts.AllowRepoCommands
+	reviewers         []string // mirrors SetupOpts.Reviewers (global config panel)
+	repoReviewers     []string // mirrors SetupOpts.RepoReviewers (trusted repo panel)
 }
 
 // SetupOpts controls per-test setup.
@@ -65,6 +67,18 @@ type SetupOpts struct {
 	// (commands must come from the trusted default branch) pass a pointer
 	// to false to exercise the secure default.
 	AllowRepoCommands *bool
+
+	// Reviewers, when non-empty, injects a cross-family review panel into the
+	// GLOBAL config (review.reviewers) via writeGlobalConfig. The global config
+	// is not security-gated, so this is the simplest way to make every run fan
+	// the review step out across the named agent families (e.g. claude, codex).
+	Reviewers []string
+
+	// RepoReviewers, when non-empty, injects a review panel into the TRUSTED
+	// default-branch .no-mistakes.yaml (via initGitRepos). Unlike a panel pushed
+	// on a feature branch, this trusted copy survives EffectiveRepoConfig, so it
+	// exercises the positive side of the review-panel security gate.
+	RepoReviewers []string
 }
 
 const e2eDaemonStartTimeout = "45s"
@@ -99,6 +113,8 @@ func NewHarness(t *testing.T, opts SetupOpts) *Harness {
 		Scenario:          opts.Scenario,
 		agentName:         opts.Agent,
 		allowRepoCommands: opts.AllowRepoCommands,
+		reviewers:         opts.Reviewers,
+		repoReviewers:     opts.RepoReviewers,
 	}
 
 	for _, dir := range []string{h.BinDir, h.NMHome, h.HomeDir, h.WorkDir} {
@@ -170,22 +186,68 @@ func (h *Harness) writeGlobalConfig() {
 	if err := os.MkdirAll(h.NMHome, 0o755); err != nil {
 		h.t.Fatalf("mkdir nm home: %v", err)
 	}
-	binLink := filepath.Join(h.BinDir, h.agentName)
+	// Pin an absolute fake-agent path for every family the run can launch: the
+	// impl agent AND every configured reviewer family. The daemon resolves a
+	// login-shell PATH at startup that does NOT contain BinDir, so a bare
+	// reviewer name (e.g. "codex") would otherwise resolve to a real system
+	// binary and hit the live API. Absolute overrides keep every family on the
+	// fake regardless of the daemon's PATH.
+	var overrides strings.Builder
+	for _, family := range h.pathOverrideFamilies() {
+		fmt.Fprintf(&overrides, "  %s: %s\n", family, filepath.Join(h.BinDir, family))
+	}
 	cfg := fmt.Sprintf(`agent: %s
 log_level: debug
 agent_path_override:
-  %s: %s
-auto_fix:
+%sauto_fix:
   rebase: 0
   lint: 0
   test: 0
   review: 0
   document: 0
   ci: 0
-`, h.agentName, h.agentName, binLink)
+`, h.agentName, overrides.String())
+	cfg += reviewPanelYAML(h.reviewers, 0)
 	if err := os.WriteFile(configPath, []byte(cfg), 0o644); err != nil {
 		h.t.Fatalf("write config: %v", err)
 	}
+}
+
+// pathOverrideFamilies returns the deduped set of agent families that need an
+// absolute fake-agent path override: the impl agent plus every reviewer family
+// configured on either the global panel or the trusted repo panel. Order is
+// deterministic (impl agent first) so the rendered config is stable.
+func (h *Harness) pathOverrideFamilies() []string {
+	var families []string
+	seen := map[string]bool{}
+	for _, name := range append([]string{h.agentName}, append(append([]string{}, h.reviewers...), h.repoReviewers...)...) {
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		families = append(families, name)
+	}
+	return families
+}
+
+// reviewPanelYAML renders a review-panel config block (review.reviewers +
+// max_parallel + fail_open) at the given indentation, or "" when no reviewers
+// are configured. The same shape is valid in both the global config and a
+// repo .no-mistakes.yaml, so both harness injection points reuse it.
+func reviewPanelYAML(reviewers []string, indent int) string {
+	if len(reviewers) == 0 {
+		return ""
+	}
+	pad := strings.Repeat(" ", indent)
+	var b strings.Builder
+	fmt.Fprintf(&b, "%sreview:\n", pad)
+	fmt.Fprintf(&b, "%s  reviewers:\n", pad)
+	for _, name := range reviewers {
+		fmt.Fprintf(&b, "%s    - agent: %s\n", pad, name)
+	}
+	fmt.Fprintf(&b, "%s  max_parallel: 2\n", pad)
+	fmt.Fprintf(&b, "%s  fail_open: false\n", pad)
+	return b.String()
 }
 
 // initGitRepos creates a bare upstream repo and a working clone with one
@@ -231,6 +293,10 @@ func (h *Harness) initGitRepos() {
 	}
 	repoConfig := filepath.Join(h.WorkDir, ".no-mistakes.yaml")
 	repoCfg := fmt.Sprintf("ignore_patterns:\n  - '*.generated.go'\n  - 'vendor/**'\nallow_repo_commands: %t\n", allowRepoCommands)
+	// A panel committed to the trusted default branch survives
+	// EffectiveRepoConfig and drives the pipeline, unlike one pushed only on a
+	// feature branch (which is stripped). This is the positive security case.
+	repoCfg += reviewPanelYAML(h.repoReviewers, 0)
 	if err := os.WriteFile(repoConfig, []byte(repoCfg), 0o644); err != nil {
 		h.t.Fatalf("write repo config: %v", err)
 	}

--- a/internal/e2e/repo_config_security_test.go
+++ b/internal/e2e/repo_config_security_test.go
@@ -75,6 +75,35 @@ func TestRepoConfigCommandsFromDefaultBranch(t *testing.T) {
 		}
 	})
 
+	t.Run("pushed_branch_review_blocked", func(t *testing.T) {
+		// The review panel selects which reviewer binaries launch with
+		// maintainer creds, so it is code-executing config locked to the
+		// trusted default-branch copy. A pushed branch that ships a review
+		// block must not override the trusted (empty) one. To detect a
+		// leak we push a rovodev reviewer pointing at a nonexistent
+		// binary: if the pushed config leaks through, ResolveReviewers
+		// calls exec.LookPath on the bogus path and the run fails; under
+		// the correct behavior the trusted empty review yields no
+		// reviewers and the run completes.
+		optOut := false
+		h := NewHarness(t, SetupOpts{Agent: "claude", Scenario: cleanReviewScenario(t), AllowRepoCommands: &optOut})
+
+		if out, err := h.Run("init"); err != nil {
+			t.Fatalf("nm init: %v\n%s", err, out)
+		}
+
+		branch := "review-blocked"
+		h.CommitChange(branch, branch+".txt", "change to gate\n", "add "+branch+" change")
+		maliciousReview := "ignore_patterns:\n  - 'vendor/**'\nreview:\n  reviewers:\n    - agent: rovodev\n      path: /nonexistent/evil-rovodev\n"
+		h.CommitChange(branch, ".no-mistakes.yaml", maliciousReview, "pushed-branch review panel")
+		h.PushToGate(branch)
+
+		run := h.WaitForRun(branch, 90*time.Second)
+		if run.Status != types.RunCompleted {
+			t.Fatalf("SECURITY REGRESSION: pushed-branch review config leaked through the trust boundary (run failed, likely exec.LookPath on the bogus reviewer path); status=%s error=%v", run.Status, deref(run.Error))
+		}
+	})
+
 	t.Run("pushed_branch_cannot_self_enable", func(t *testing.T) {
 		// Hard requirement of the per-repo move: allow_repo_commands is read
 		// ONLY from the trusted default-branch copy, never the pushed SHA. A

--- a/internal/e2e/reviewer_panel_test.go
+++ b/internal/e2e/reviewer_panel_test.go
@@ -1,0 +1,296 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// TestReviewerPanelJourney drives the mixed-family review panel end to end with
+// zero real API: the harness symlinks claude + codex to the fixture-replaying
+// fakeagent, and a global review.reviewers panel makes the review step fan out
+// across both families. The review action returns EMPTY-id findings so the
+// panel's NormalizeFindings stamps namespaced ids (review-codex-1 /
+// review-claude-1) and Source is the family name, which we assert on the
+// persisted, post-combine FindingsJSON.
+func TestReviewerPanelJourney(t *testing.T) {
+	h := NewHarness(t, SetupOpts{
+		Agent:     "claude",
+		Reviewers: []string{"claude", "codex"},
+		Scenario:  reviewerPanelScenario(t),
+	})
+
+	if out, err := h.Run("init"); err != nil {
+		t.Fatalf("nm init: %v\n%s", err, out)
+	}
+
+	branch := "reviewer-panel"
+	h.CommitChange(branch, "panel.go", "package panel\n\nfunc Panel() {}\n", "add panel change")
+	h.PushToGate(branch)
+
+	run := h.WaitForRun(branch, 90*time.Second)
+	if run.Status != types.RunCompleted {
+		t.Fatalf("panel run did not complete: status=%s error=%v", run.Status, deref(run.Error))
+	}
+
+	// Both families must have launched and carried the review prompt for this
+	// branch. codex is never the impl agent here, so every codex invocation is
+	// a reviewer launch; claude is also the impl agent, so we match the review
+	// preamble specifically rather than counting claude launches.
+	invs := h.AgentInvocations()
+	if !sawReviewInvocation(invs, "codex", branch) {
+		t.Fatalf("expected a codex reviewer launch carrying the review prompt for %s; invocations:\n%s", branch, summarisePrompts(invs))
+	}
+	if !sawReviewInvocation(invs, "claude", branch) {
+		t.Fatalf("expected a claude reviewer launch carrying the review prompt for %s; invocations:\n%s", branch, summarisePrompts(invs))
+	}
+
+	// The persisted review findings are the attributed union of both reviewers.
+	reviewStep, ok := findStep(run.Steps, types.StepReview)
+	if !ok {
+		t.Fatal("expected review step in panel run")
+	}
+	if reviewStep.FindingsJSON == nil {
+		t.Fatal("expected the panel review step to persist findings JSON")
+	}
+	findings, err := types.ParseFindingsJSON(*reviewStep.FindingsJSON)
+	if err != nil {
+		t.Fatalf("parse panel review findings: %v\n%s", err, *reviewStep.FindingsJSON)
+	}
+	if len(findings.Items) != 2 {
+		t.Fatalf("expected 2 attributed panel findings (one per family), got %d: %s", len(findings.Items), *reviewStep.FindingsJSON)
+	}
+
+	codexFinding, ok := findingFromSource(findings.Items, "codex")
+	if !ok {
+		t.Fatalf("expected a finding sourced from codex; got %s", *reviewStep.FindingsJSON)
+	}
+	if codexFinding.ID != "review-codex-1" {
+		t.Errorf("codex finding id = %q, want review-codex-1 (namespaced from an empty-id finding)", codexFinding.ID)
+	}
+	claudeFinding, ok := findingFromSource(findings.Items, "claude")
+	if !ok {
+		t.Fatalf("expected a finding sourced from claude; got %s", *reviewStep.FindingsJSON)
+	}
+	if claudeFinding.ID != "review-claude-1" {
+		t.Errorf("claude finding id = %q, want review-claude-1 (namespaced from an empty-id finding)", claudeFinding.ID)
+	}
+}
+
+// TestReviewerPanelSecurityGate proves the review panel is treated as
+// code-executing config by EffectiveRepoConfig: a panel on the TRUSTED default
+// branch launches every family, while a panel pushed ONLY on a feature branch
+// (without allow_repo_commands) is stripped to the single impl agent.
+func TestReviewerPanelSecurityGate(t *testing.T) {
+	t.Run("trusted_default_branch_panel_launches_both", func(t *testing.T) {
+		optOut := false
+		h := NewHarness(t, SetupOpts{
+			Agent:             "claude",
+			RepoReviewers:     []string{"claude", "codex"},
+			AllowRepoCommands: &optOut,
+			Scenario:          reviewerPanelScenario(t),
+		})
+
+		if out, err := h.Run("init"); err != nil {
+			t.Fatalf("nm init: %v\n%s", err, out)
+		}
+
+		branch := "panel-trusted"
+		h.CommitChange(branch, "trusted.go", "package trusted\n\nfunc Trusted() {}\n", "add trusted panel change")
+		h.PushToGate(branch)
+
+		run := h.WaitForRun(branch, 90*time.Second)
+		if run.Status != types.RunCompleted {
+			t.Fatalf("trusted-panel run did not complete: status=%s error=%v", run.Status, deref(run.Error))
+		}
+
+		invs := h.AgentInvocations()
+		if !sawReviewInvocation(invs, "codex", branch) {
+			t.Fatalf("trusted-branch panel should launch the codex family; invocations:\n%s", summarisePrompts(invs))
+		}
+		if !sawReviewInvocation(invs, "claude", branch) {
+			t.Fatalf("trusted-branch panel should launch the claude family; invocations:\n%s", summarisePrompts(invs))
+		}
+	})
+
+	t.Run("pushed_only_panel_stripped_to_single_agent", func(t *testing.T) {
+		// No trusted panel, no global panel, and allow_repo_commands is off. A
+		// panel that arrives ONLY on the pushed feature branch must be dropped
+		// by EffectiveRepoConfig, leaving the single impl agent to review.
+		optOut := false
+		h := NewHarness(t, SetupOpts{
+			Agent:             "claude",
+			AllowRepoCommands: &optOut,
+			Scenario:          reviewerPanelScenario(t),
+		})
+
+		if out, err := h.Run("init"); err != nil {
+			t.Fatalf("nm init: %v\n%s", err, out)
+		}
+
+		branch := "panel-pushed-only"
+		h.CommitChange(branch, "pushed.go", "package pushed\n\nfunc Pushed() {}\n", "add pushed panel change")
+		// The contributor injects a review panel on their own branch alongside
+		// the change. Without allow_repo_commands on the trusted branch this
+		// must be ignored.
+		pushedConfig := "ignore_patterns:\n  - 'vendor/**'\n" + reviewPanelYAML([]string{"claude", "codex"}, 0)
+		h.CommitChange(branch, ".no-mistakes.yaml", pushedConfig, "inject review panel on feature branch")
+		h.PushToGate(branch)
+
+		run := h.WaitForRun(branch, 90*time.Second)
+		if run.Status != types.RunCompleted {
+			t.Fatalf("pushed-only-panel run did not complete: status=%s error=%v", run.Status, deref(run.Error))
+		}
+
+		// The single impl agent (claude) must still review, but the stripped
+		// codex family must never have launched.
+		invs := h.AgentInvocations()
+		if !sawReviewInvocation(invs, "claude", branch) {
+			t.Fatalf("expected the single impl agent to review %s; invocations:\n%s", branch, summarisePrompts(invs))
+		}
+		for _, inv := range invs {
+			if inv.Agent == "codex" {
+				t.Fatalf("SECURITY REGRESSION: a feature-branch review panel launched the codex family (%v); review.reviewers must come from the trusted default branch", inv.Args)
+			}
+		}
+	})
+}
+
+// TestReviewerPanelFailClosed proves the panel honors the fail-closed default:
+// when every reviewer family errors (the shared review prompt routes both to an
+// erroring action), the review step and the run fail rather than silently
+// dropping reviewers.
+func TestReviewerPanelFailClosed(t *testing.T) {
+	h := NewHarness(t, SetupOpts{
+		Agent:     "claude",
+		Reviewers: []string{"claude", "codex"},
+		Scenario:  reviewerPanelFailScenario(t),
+	})
+
+	if out, err := h.Run("init"); err != nil {
+		t.Fatalf("nm init: %v\n%s", err, out)
+	}
+
+	branch := "panel-fail-closed"
+	h.CommitChange(branch, "failclosed.go", "package failclosed\n\nfunc FailClosed() {}\n", "add fail-closed panel change")
+	h.PushToGate(branch)
+
+	run := h.WaitForRun(branch, 90*time.Second)
+	if run.Status != types.RunFailed {
+		t.Fatalf("fail-closed panel run status = %s, want failed (error=%v)", run.Status, deref(run.Error))
+	}
+	reviewStep, ok := findStep(run.Steps, types.StepReview)
+	if !ok {
+		t.Fatal("expected review step in fail-closed run")
+	}
+	if reviewStep.Status != types.StepStatusFailed {
+		t.Fatalf("expected review step to fail closed, got %s", reviewStep.Status)
+	}
+}
+
+// sawReviewInvocation reports whether the named agent family launched with the
+// review prompt for the given branch.
+func sawReviewInvocation(invs []Invocation, agent, branch string) bool {
+	for _, inv := range invs {
+		if inv.Agent != agent {
+			continue
+		}
+		if strings.Contains(inv.Prompt, "Review the code changes and return structured findings") &&
+			strings.Contains(inv.Prompt, "branch: "+branch) {
+			return true
+		}
+	}
+	return false
+}
+
+func findingFromSource(items []types.Finding, source string) (types.Finding, bool) {
+	for _, item := range items {
+		if item.Source == source {
+			return item, true
+		}
+	}
+	return types.Finding{}, false
+}
+
+// reviewerPanelScenario returns a scenario whose review action emits a single
+// EMPTY-id, non-blocking finding (so the run completes without gating) while
+// every other step gets the standard clean catch-all. The empty id is what lets
+// the panel observe NormalizeFindings stamping review-<family>-1.
+func reviewerPanelScenario(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "panel-scenario.yaml")
+	// The finding carries an EMPTY id (id: "") plus every other field. codex's
+	// real agent rewrites the output schema so all properties are required
+	// (codexOutputSchema), so every field must be present; an empty id still
+	// passes (string type) yet is what NormalizeFindings stamps into
+	// review-<family>-1, which is exactly the namespacing we assert on.
+	content := `actions:
+  - match: "Review the code changes and return structured findings with a risk assessment."
+    text: "panel reviewer note"
+    structured:
+      findings:
+        - id: ""
+          severity: info
+          file: "panel.go"
+          line: 1
+          description: "panel reviewer observation"
+          action: no-op
+      risk_level: low
+      risk_rationale: "informational finding only"
+      tested:
+        - "fakeagent: simulated review"
+      testing_summary: "not run during review"
+  - text: "no issues found"
+    structured:
+      findings: []
+      summary: "no issues found"
+      risk_level: low
+      risk_rationale: "no risks detected in the diff"
+      tested:
+        - "fakeagent: simulated test run"
+      testing_summary: "simulated tests passed"
+      title: "feat: fakeagent change"
+      body: "## Summary\nfakeagent canned PR body"
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write panel scenario: %v", err)
+	}
+	return path
+}
+
+// reviewerPanelFailScenario returns a scenario whose review action makes the
+// agent process fail (an out-of-worktree edit is rejected by the fake), so
+// every reviewer family errors and the fail-closed panel fails the step.
+func reviewerPanelFailScenario(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "panel-fail-scenario.yaml")
+	content := fmt.Sprintf(`actions:
+  - match: "Review the code changes and return structured findings with a risk assessment."
+    text: "panel reviewer error"
+    edits:
+      - path: "/outside-workdir"
+        new: "should fail"
+  - text: "no issues found"
+    structured:
+      findings: []
+      summary: "no issues found"
+      risk_level: low
+      risk_rationale: "no risks detected in the diff"
+      tested:
+        - "fakeagent: simulated test run"
+      testing_summary: "simulated tests passed"
+      title: "feat: fakeagent change"
+      body: "## Summary\nfakeagent canned PR body"
+`)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write panel fail scenario: %v", err)
+	}
+	return path
+}

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -32,12 +32,13 @@ type approvalResponse struct {
 
 // Executor runs pipeline steps sequentially and coordinates approval interactions.
 type Executor struct {
-	db     *db.DB
-	paths  *paths.Paths
-	config *config.Config
-	agent  agent.Agent
-	steps  []Step
-	skips  map[types.StepName]bool
+	db        *db.DB
+	paths     *paths.Paths
+	config    *config.Config
+	agent     agent.Agent
+	reviewers []agent.Agent
+	steps     []Step
+	skips     map[types.StepName]bool
 
 	onEvent EventFunc
 
@@ -45,6 +46,14 @@ type Executor struct {
 	approvalCh  chan approvalResponse // buffered channel for approval responses
 	waiting     bool                  // true when blocked on approval
 	waitingStep types.StepName        // which step is currently awaiting approval
+}
+
+// SetReviewers configures the cross-family review panel agents. It is set after
+// NewExecutor (rather than as a constructor argument) to avoid churning the many
+// NewExecutor call sites. When empty (the default), the pipeline reviews with
+// the single impl agent, so behavior is unchanged.
+func (e *Executor) SetReviewers(reviewers []agent.Agent) {
+	e.reviewers = reviewers
 }
 
 // SetSkippedSteps configures steps that should be marked skipped without running.
@@ -208,12 +217,20 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 	if run != nil && run.Intent != nil {
 		userIntent = *run.Intent
 	}
+	// Default the review panel to the single impl agent when none is
+	// configured, so every step (including review) is byte-identical to the
+	// pre-panel behavior.
+	reviewers := e.reviewers
+	if len(reviewers) == 0 {
+		reviewers = []agent.Agent{e.agent}
+	}
 	sctx := &StepContext{
 		Ctx:          ctx,
 		Run:          run,
 		Repo:         repo,
 		WorkDir:      workDir,
 		Agent:        e.agent,
+		Reviewers:    reviewers,
 		Config:       e.config,
 		DB:           e.db,
 		StepResultID: sr.ID,

--- a/internal/pipeline/executor_reviewers_test.go
+++ b/internal/pipeline/executor_reviewers_test.go
@@ -1,0 +1,105 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/agent"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// stubReviewer is a minimal agent.Agent used only to assert identity and order
+// of the reviewers a step observes via StepContext.Reviewers. It never runs.
+type stubReviewer struct{ name string }
+
+func (s *stubReviewer) Name() string { return s.name }
+func (s *stubReviewer) Run(context.Context, agent.RunOpts) (*agent.Result, error) {
+	return &agent.Result{}, nil
+}
+func (s *stubReviewer) Close() error { return nil }
+
+// captureReviewers builds a one-step pipeline whose review step records the
+// reviewers it sees, runs it to completion, and returns the captured slice.
+// Running Execute in a goroutine mirrors the existing executor_context_test.go
+// style; the done channel establishes a happens-before with the capture so the
+// read below is race-free under -race.
+func captureReviewers(t *testing.T, ag agent.Agent, configure func(*Executor)) []agent.Agent {
+	t.Helper()
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	captured := make(chan []agent.Agent, 1)
+	step := &adaptiveCallStep{
+		name: types.StepReview,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			cp := make([]agent.Agent, len(sctx.Reviewers))
+			copy(cp, sctx.Reviewers)
+			captured <- cp
+			return &StepOutcome{ExitCode: 0}, nil
+		},
+	}
+
+	exec := NewExecutor(database, p, nil, ag, []Step{step}, nil)
+	if configure != nil {
+		configure(exec)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- exec.Execute(context.Background(), run, repo, workDir)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Execute returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("executor timed out")
+	}
+
+	select {
+	case got := <-captured:
+		return got
+	default:
+		t.Fatal("review step did not record reviewers")
+		return nil
+	}
+}
+
+// TestExecutor_ReviewersDefaultAndPassthrough pins the PR1 invariant: with no
+// SetReviewers the review panel defaults to exactly the single impl agent, and
+// after SetReviewers([a, b]) the two reviewers pass through to StepContext in
+// order. Both halves run deterministically with no real agent calls.
+func TestExecutor_ReviewersDefaultAndPassthrough(t *testing.T) {
+	t.Run("DefaultsToSingleImplAgent", func(t *testing.T) {
+		impl := &stubReviewer{name: "impl"}
+
+		got := captureReviewers(t, impl, nil) // no SetReviewers
+
+		if len(got) != 1 {
+			t.Fatalf("default reviewers len = %d, want 1 (the single impl agent)", len(got))
+		}
+		if got[0] != agent.Agent(impl) {
+			t.Errorf("default reviewer = %v (Name=%q), want the impl agent itself", got[0], got[0].Name())
+		}
+	})
+
+	t.Run("PassesConfiguredPanelInOrder", func(t *testing.T) {
+		impl := &stubReviewer{name: "impl"}
+		a := &stubReviewer{name: "a"}
+		b := &stubReviewer{name: "b"}
+
+		got := captureReviewers(t, impl, func(exec *Executor) {
+			exec.SetReviewers([]agent.Agent{a, b})
+		})
+
+		if len(got) != 2 {
+			t.Fatalf("panel reviewers len = %d, want 2", len(got))
+		}
+		if got[0] != agent.Agent(a) || got[1] != agent.Agent(b) {
+			t.Fatalf("panel reviewers = [%q, %q], want [a, b] in order", got[0].Name(), got[1].Name())
+		}
+	})
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -11,11 +11,17 @@ import (
 
 // StepContext provides shared resources to pipeline steps during execution.
 type StepContext struct {
-	Ctx              context.Context
-	Run              *db.Run
-	Repo             *db.Repo
-	WorkDir          string
-	Agent            agent.Agent
+	Ctx     context.Context
+	Run     *db.Run
+	Repo    *db.Repo
+	WorkDir string
+	Agent   agent.Agent
+	// Reviewers is the cross-family review panel for this run, a sibling of
+	// Agent: every entry reviews the same diff independently. An empty slice
+	// means the single-agent default - treat it as {Agent}. The executor
+	// always populates it (defaulting to {Agent}) so steps never special-case
+	// the empty case.
+	Reviewers        []agent.Agent
 	Config           *config.Config
 	DB               *db.DB
 	Log              func(string) // discrete log line (newline-terminated, user-visible + file)

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -50,6 +50,7 @@ Context:
 
 Rules:
 - Always start with double checking whether the findings are legitimate.
+- The findings may come from multiple independent reviewers (see each finding's source); reconcile their agreements and contradictions yourself and apply only the legitimate fixes.
 - Before changing code, identify whether each finding is a local defect or a symptom of a deeper design, abstraction, validation, ownership, or test-coverage flaw. Prefer the smallest correct root-cause fix within the changed area over patching only the reported line.
 - If a narrow fix would leave the same class of bug likely elsewhere, fix the deepest practical cause instead.
 - Avoid resolving a finding by removing or reverting the author's intentional code in their original 1st commit. If the original change introduced something on purpose, fix it forward (e.g. add validation, handle edge cases, tighten logic) rather than deleting it. Similarly, if the original change intentionally deleted or simplified code, do not restore or re-add the removed code unless the finding is a legitimate correctness, reliability, or security issue and the smallest reasonable fix happens to reintroduce a small amount of previously deleted logic. When in doubt about whether code is intentional, leave it and report the finding as unresolved.
@@ -179,23 +180,40 @@ Risk assessment (after listing all findings):
 		historySection,
 	)
 
-	result, err := sctx.Agent.Run(ctx, agent.RunOpts{
+	// The review panel reviews the same diff independently. An empty Reviewers
+	// slice (the single-agent default) collapses to the configured agent, so
+	// this call site runs in both the initial review and every post-fix
+	// re-review - the fix agent's own re-reviewed code gets the full panel too.
+	reviewers := sctx.Reviewers
+	if len(reviewers) == 0 {
+		reviewers = []agent.Agent{sctx.Agent}
+	}
+	configuredReviewPanel := sctx.Config != nil && len(sctx.Config.Review.Reviewers) > 0
+
+	opts := agent.RunOpts{
 		Prompt:     prompt,
 		CWD:        sctx.WorkDir,
 		JSONSchema: reviewFindingsSchema,
-		OnChunk:    sctx.LogChunk,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("agent review: %w", err)
 	}
 
-	// Parse structured findings
 	var findings Findings
-	if result.Output != nil {
-		if err := json.Unmarshal(result.Output, &findings); err != nil {
-			sctx.Log("could not parse structured output, using text response")
-			findings = Findings{Summary: result.Text}
+	if len(reviewers) <= 1 && !configuredReviewPanel {
+		// Implicit single reviewer: keep the exact streaming single-call path so
+		// behavior is byte-identical to the pre-panel pipeline. An explicitly
+		// configured one-reviewer panel still takes runReviewPanel so findings
+		// get reviewer Source attribution and review-<name>-N IDs.
+		opts.OnChunk = sctx.LogChunk
+		result, err := reviewers[0].Run(ctx, opts)
+		if err != nil {
+			return nil, fmt.Errorf("agent review: %w", err)
 		}
+		findings = parseReviewFindings(result, sctx.Log)
+	} else {
+		merged, err := runReviewPanel(sctx, reviewers, opts)
+		if err != nil {
+			return nil, err
+		}
+		findings = merged
 	}
 
 	needsApproval := hasBlockingFindings(findings.Items)
@@ -207,6 +225,21 @@ Risk assessment (after listing all findings):
 		Findings:      string(findingsJSON),
 		FixSummary:    fixSummary,
 	}, nil
+}
+
+// parseReviewFindings decodes a reviewer's structured output into Findings,
+// falling back to the raw text as a summary when the JSON cannot be parsed.
+// log receives a note on the fallback. This is the single parse used by both
+// the single-reviewer path and every reviewer in the panel.
+func parseReviewFindings(result *agent.Result, log func(string)) Findings {
+	var findings Findings
+	if result.Output != nil {
+		if err := json.Unmarshal(result.Output, &findings); err != nil {
+			log("could not parse structured output, using text response")
+			findings = Findings{Summary: result.Text}
+		}
+	}
+	return findings
 }
 
 func sanitizedPreviousFindingsForPrompt(raw string) string {

--- a/internal/pipeline/steps/review_fanout_test.go
+++ b/internal/pipeline/steps/review_fanout_test.go
@@ -1,0 +1,294 @@
+package steps
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/agent"
+	"github.com/kunchenguid/no-mistakes/internal/config"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// reviewReturning builds a mockAgent runFn that returns the given findings as
+// the agent's structured review output.
+func reviewReturning(f Findings) func(context.Context, agent.RunOpts) (*agent.Result, error) {
+	return func(_ context.Context, _ agent.RunOpts) (*agent.Result, error) {
+		j, _ := json.Marshal(f)
+		return &agent.Result{Output: j}, nil
+	}
+}
+
+func findingBySource(items []Finding, source string) (Finding, bool) {
+	for _, item := range items {
+		if item.Source == source {
+			return item, true
+		}
+	}
+	return Finding{}, false
+}
+
+func TestReviewStep_FanOut_InitialReviewMergesBothReviewers(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	codex := &mockAgent{name: "codex", runFn: reviewReturning(Findings{
+		Items:         []Finding{{Severity: "warning", Description: "codex issue", Action: "auto-fix"}},
+		RiskLevel:     "medium",
+		RiskRationale: "codex rationale",
+		Summary:       "codex summary",
+	})}
+	claude := &mockAgent{name: "claude", runFn: reviewReturning(Findings{
+		Items:         []Finding{{Severity: "error", Description: "claude issue", Action: "ask-user"}},
+		RiskLevel:     "high",
+		RiskRationale: "claude rationale",
+		Summary:       "claude summary",
+	})}
+	// The fix/implementation agent must never run during an initial review.
+	fixAgent := &mockAgent{name: "fixer", runFn: func(context.Context, agent.RunOpts) (*agent.Result, error) {
+		t.Fatal("fix agent must not run during the review pass")
+		return nil, nil
+	}}
+
+	sctx := newTestContext(t, fixAgent, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Reviewers = []agent.Agent{codex, claude}
+
+	step := &ReviewStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	merged, err := types.ParseFindingsJSON(outcome.Findings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(merged.Items) != 2 {
+		t.Fatalf("expected 2 merged findings, got %d: %+v", len(merged.Items), merged.Items)
+	}
+
+	codexFinding, ok := findingBySource(merged.Items, "codex")
+	if !ok {
+		t.Fatal("expected a finding sourced from codex")
+	}
+	if codexFinding.ID != "review-codex-1" {
+		t.Errorf("codex finding id = %q, want review-codex-1", codexFinding.ID)
+	}
+	claudeFinding, ok := findingBySource(merged.Items, "claude")
+	if !ok {
+		t.Fatal("expected a finding sourced from claude")
+	}
+	if claudeFinding.ID != "review-claude-1" {
+		t.Errorf("claude finding id = %q, want review-claude-1", claudeFinding.ID)
+	}
+
+	// RiskLevel is the max across reviewers; an error finding needs approval.
+	if merged.RiskLevel != "high" {
+		t.Errorf("merged RiskLevel = %q, want high", merged.RiskLevel)
+	}
+	if !outcome.NeedsApproval {
+		t.Error("expected NeedsApproval when a reviewer reports an error finding")
+	}
+
+	// Each reviewer ran exactly once, with streaming disabled in panel mode.
+	if len(codex.calls) != 1 || len(claude.calls) != 1 {
+		t.Fatalf("expected each reviewer to run once, got codex=%d claude=%d", len(codex.calls), len(claude.calls))
+	}
+	if codex.calls[0].OnChunk != nil || claude.calls[0].OnChunk != nil {
+		t.Error("expected OnChunk to be nil in panel mode (not goroutine-safe)")
+	}
+}
+
+func TestReviewStep_FanOut_SameFamilyReviewersHaveDistinctSourcesAndIDs(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	first := &mockAgent{name: "codex", runFn: reviewReturning(Findings{
+		Items: []Finding{{ID: "same", Severity: "warning", Description: "first codex", Action: "auto-fix"}},
+	})}
+	second := &mockAgent{name: "codex", runFn: reviewReturning(Findings{
+		Items: []Finding{{ID: "same", Severity: "warning", Description: "second codex", Action: "auto-fix"}},
+	})}
+	fixAgent := &mockAgent{name: "fixer"}
+
+	sctx := newTestContext(t, fixAgent, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Reviewers = []agent.Agent{first, second}
+
+	step := &ReviewStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	merged, err := types.ParseFindingsJSON(outcome.Findings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(merged.Items) != 2 {
+		t.Fatalf("expected 2 merged findings, got %d: %+v", len(merged.Items), merged.Items)
+	}
+	wantIDs := []string{"review-codex-1", "review-codex-2-1"}
+	wantSources := []string{"codex", "codex-2"}
+	for i, item := range merged.Items {
+		if item.ID != wantIDs[i] {
+			t.Errorf("item %d ID = %q, want %q", i, item.ID, wantIDs[i])
+		}
+		if item.Source != wantSources[i] {
+			t.Errorf("item %d Source = %q, want %q", i, item.Source, wantSources[i])
+		}
+	}
+}
+
+func TestReviewStep_ConfiguredSingleReviewerGetsPanelAttribution(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	codex := &mockAgent{name: "codex", runFn: reviewReturning(Findings{
+		Items: []Finding{{ID: "model-id", Severity: "warning", Description: "codex issue", Action: "auto-fix"}},
+	})}
+	fixAgent := &mockAgent{name: "fixer"}
+
+	sctx := newTestContext(t, fixAgent, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Reviewers = []agent.Agent{codex}
+	sctx.Config.Review.Reviewers = []config.ReviewerSpec{{Agent: types.AgentCodex}}
+
+	step := &ReviewStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	merged, err := types.ParseFindingsJSON(outcome.Findings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(merged.Items) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %+v", len(merged.Items), merged.Items)
+	}
+	if got := merged.Items[0].Source; got != "codex" {
+		t.Errorf("Source = %q, want codex", got)
+	}
+	if got := merged.Items[0].ID; got != "review-codex-1" {
+		t.Errorf("ID = %q, want review-codex-1", got)
+	}
+	if len(codex.calls) != 1 {
+		t.Fatalf("expected codex reviewer to run once, got %d", len(codex.calls))
+	}
+	if codex.calls[0].OnChunk != nil {
+		t.Error("expected configured one-reviewer panel to disable streaming callbacks")
+	}
+}
+
+func TestReviewStep_FanOut_RunsInFixMode(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
+
+	fixAgent := &mockAgent{name: "fixer", runFn: func(_ context.Context, _ agent.RunOpts) (*agent.Result, error) {
+		os.WriteFile(filepath.Join(dir, "fanout-fix.txt"), []byte("fixed"), 0o644)
+		return &agent.Result{Output: json.RawMessage(`{"summary":"address findings"}`)}, nil
+	}}
+	codex := &mockAgent{name: "codex", runFn: reviewReturning(Findings{
+		Items: []Finding{{Severity: "warning", Description: "codex issue", Action: "auto-fix"}},
+	})}
+	claude := &mockAgent{name: "claude", runFn: reviewReturning(Findings{
+		Items: []Finding{{Severity: "info", Description: "claude note", Action: "no-op"}},
+	})}
+
+	sctx := newTestContextWithDBRecords(t, fixAgent, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Reviewers = []agent.Agent{codex, claude}
+	sctx.Fixing = true
+	sctx.PreviousFindings = `{"findings":[{"id":"review-1","severity":"warning","description":"earlier","action":"auto-fix"}],"summary":"1 issue"}`
+
+	step := &ReviewStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The single fix agent ran once; the full panel re-reviewed the fixed code.
+	if len(fixAgent.calls) != 1 {
+		t.Errorf("expected fix agent to run once, got %d", len(fixAgent.calls))
+	}
+	if len(codex.calls) != 1 || len(claude.calls) != 1 {
+		t.Fatalf("expected each reviewer to re-review once in fix mode, got codex=%d claude=%d", len(codex.calls), len(claude.calls))
+	}
+	if outcome.FixSummary != "address findings" {
+		t.Errorf("FixSummary = %q, want 'address findings'", outcome.FixSummary)
+	}
+
+	merged, err := types.ParseFindingsJSON(outcome.Findings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := findingBySource(merged.Items, "codex"); !ok {
+		t.Error("expected a codex-sourced finding after fix-mode re-review")
+	}
+	if _, ok := findingBySource(merged.Items, "claude"); !ok {
+		t.Error("expected a claude-sourced finding after fix-mode re-review")
+	}
+}
+
+func TestReviewStep_FanOut_FailClosedFailsStep(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	codex := &mockAgent{name: "codex", runFn: reviewReturning(Findings{
+		Items: []Finding{{Severity: "warning", Description: "codex issue", Action: "auto-fix"}},
+	})}
+	claude := &mockAgent{name: "claude", runFn: func(context.Context, agent.RunOpts) (*agent.Result, error) {
+		return nil, errors.New("reviewer crashed")
+	}}
+	fixAgent := &mockAgent{name: "fixer"}
+
+	sctx := newTestContext(t, fixAgent, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Reviewers = []agent.Agent{codex, claude}
+	// Config.Review.FailOpen defaults to false (fail-closed).
+
+	step := &ReviewStep{}
+	_, err := step.Execute(sctx)
+	if err == nil {
+		t.Fatal("expected the step to fail closed when a reviewer errors")
+	}
+	if !strings.Contains(err.Error(), "claude") {
+		t.Errorf("error should name the failed reviewer family, got %q", err)
+	}
+}
+
+func TestReviewStep_FanOut_FailOpenContinues(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	codex := &mockAgent{name: "codex", runFn: reviewReturning(Findings{
+		Items:     []Finding{{Severity: "warning", Description: "codex issue", Action: "auto-fix"}},
+		RiskLevel: "medium",
+	})}
+	claude := &mockAgent{name: "claude", runFn: func(context.Context, agent.RunOpts) (*agent.Result, error) {
+		return nil, errors.New("reviewer crashed")
+	}}
+	fixAgent := &mockAgent{name: "fixer"}
+
+	sctx := newTestContext(t, fixAgent, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Reviewers = []agent.Agent{codex, claude}
+	sctx.Config.Review.FailOpen = true
+
+	step := &ReviewStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatalf("fail-open should survive a single reviewer error: %v", err)
+	}
+	merged, err := types.ParseFindingsJSON(outcome.Findings)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(merged.Items) != 1 {
+		t.Fatalf("expected only the surviving reviewer's finding, got %d", len(merged.Items))
+	}
+	if merged.Items[0].Source != "codex" {
+		t.Errorf("surviving finding source = %q, want codex", merged.Items[0].Source)
+	}
+}

--- a/internal/pipeline/steps/review_panel.go
+++ b/internal/pipeline/steps/review_panel.go
@@ -1,0 +1,184 @@
+package steps
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/kunchenguid/no-mistakes/internal/agent"
+	"github.com/kunchenguid/no-mistakes/internal/pipeline"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// reviewerReport is one reviewer's parsed findings after its IDs have been
+// namespaced (review-<name>-N) and every item's Source stamped with the
+// reviewer name, so the merged union stays attributable to its origin.
+type reviewerReport struct {
+	Name     string
+	Findings types.Findings
+}
+
+// runReviewPanel fans the review prompt out across every reviewer concurrently
+// and merges their reports into a single attributed union. opts carries the
+// shared review prompt/schema/CWD; its OnChunk is forced to nil because
+// StepContext.Log/LogChunk mutate shared state and are not goroutine-safe, so
+// all logging and merging happen serially on this goroutine after FanOut
+// returns. It enforces the fail policy: a reviewer error fails the step unless
+// review.fail_open is set.
+func runReviewPanel(sctx *pipeline.StepContext, reviewers []agent.Agent, opts agent.RunOpts) (Findings, error) {
+	opts.OnChunk = nil
+	reviewers = labelReviewers(reviewers)
+	results := agent.FanOut(sctx.Ctx, reviewers, opts, sctx.Config.Review.MaxParallel)
+
+	reports, err := processReviewerResults(results, sctx.Config.Review.FailOpen, sctx.Log, sctx.LogFile)
+	if err != nil {
+		return Findings{}, err
+	}
+
+	// Per-reviewer user-visible summary, emitted serially from the main
+	// goroutine now that every reviewer has finished.
+	for _, r := range reports {
+		risk := r.Findings.RiskLevel
+		if risk == "" {
+			risk = "none"
+		}
+		sctx.Log(fmt.Sprintf("[reviewer %s] %d finding(s), risk=%s", r.Name, len(r.Findings.Items), risk))
+	}
+
+	return combineReviewerFindings(reports), nil
+}
+
+// processReviewerResults turns FanOut results into attributed reviewer reports,
+// in reviewer (input) order. Each successful reviewer's findings are parsed with
+// the same parser the single-reviewer path uses, ID-rewritten to
+// review-<name>-N (collision-free across reviewers), Source-stamped with the
+// reviewer name, and its raw report written to the file-only audit log.
+//
+// Fail policy: when failOpen is false (the default) the first reviewer error
+// fails the step with an error naming that reviewer family. When failOpen is
+// true a failed reviewer is dropped with a loud, user-visible warning and the
+// step continues only if at least one reviewer succeeded. log is the
+// user-visible callback; logFile is the file-only audit callback. Both run on
+// the caller's goroutine.
+func processReviewerResults(results []agent.FanOutResult, failOpen bool, log, logFile func(string)) ([]reviewerReport, error) {
+	reports := make([]reviewerReport, 0, len(results))
+	var dropped []string
+	for _, res := range results {
+		name := res.Agent.Name()
+		if res.Err != nil {
+			if !failOpen {
+				return nil, fmt.Errorf("review panel: reviewer %q failed: %w", name, res.Err)
+			}
+			dropped = append(dropped, name)
+			log(fmt.Sprintf("WARNING: reviewer %q failed and was DROPPED (review.fail_open=true): %v", name, res.Err))
+			if logFile != nil {
+				logFile(fmt.Sprintf("[reviewer %s] ERROR: %v", name, res.Err))
+			}
+			continue
+		}
+		parsed := parseReviewFindings(res.Result, log)
+		parsed = rewriteReviewerFindingIDs(parsed, "review-"+name)
+		for i := range parsed.Items {
+			parsed.Items[i].Source = name
+		}
+		reports = append(reports, reviewerReport{Name: name, Findings: parsed})
+		if logFile != nil {
+			if raw, mErr := json.Marshal(parsed); mErr == nil {
+				logFile(fmt.Sprintf("[reviewer %s] report: %s", name, string(raw)))
+			}
+		}
+	}
+	if len(reports) == 0 {
+		return nil, fmt.Errorf("review panel: all reviewers failed (%s)", strings.Join(dropped, ", "))
+	}
+	return reports, nil
+}
+
+type labeledReviewer struct {
+	agent.Agent
+	name string
+}
+
+func (l labeledReviewer) Name() string { return l.name }
+
+func labelReviewers(reviewers []agent.Agent) []agent.Agent {
+	counts := make(map[string]int, len(reviewers))
+	seen := make(map[string]bool, len(reviewers))
+	labeled := make([]agent.Agent, 0, len(reviewers))
+	for _, reviewer := range reviewers {
+		base := sanitizeReviewerLabel(reviewer.Name())
+		name := base
+		for {
+			counts[base]++
+			if counts[base] == 1 {
+				name = base
+			} else {
+				name = fmt.Sprintf("%s-%d", base, counts[base])
+			}
+			if !seen[name] {
+				break
+			}
+		}
+		seen[name] = true
+		labeled = append(labeled, labeledReviewer{Agent: reviewer, name: name})
+	}
+	return labeled
+}
+
+func sanitizeReviewerLabel(name string) string {
+	var b strings.Builder
+	lastDash := false
+	for _, r := range strings.ToLower(strings.TrimSpace(name)) {
+		valid := (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if valid {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	label := strings.Trim(b.String(), "-")
+	if label == "" {
+		return "reviewer"
+	}
+	return label
+}
+
+func rewriteReviewerFindingIDs(findings types.Findings, prefix string) types.Findings {
+	for i := range findings.Items {
+		findings.Items[i].ID = fmt.Sprintf("%s-%d", prefix, i+1)
+	}
+	return findings
+}
+
+// combineReviewerFindings merges reviewer reports into a plain attributed union.
+// Items are concatenated in reviewer (input) order, each keeping the
+// review-<name>-N id and Source set by processReviewerResults - there is NO
+// fingerprint dedup, agreement-collapse, or severity-escalation. The scalar
+// fields are reconciled: RiskLevel is the maximum (low < medium < high) across
+// reports, while RiskRationale and Summary become per-reviewer labeled
+// concatenations ("[codex] ...; [claude] ...") so the fix agent and human can
+// see who said what.
+func combineReviewerFindings(reports []reviewerReport) types.Findings {
+	var merged types.Findings
+	rationales := make([]string, 0, len(reports))
+	summaries := make([]string, 0, len(reports))
+	for _, r := range reports {
+		merged.Items = append(merged.Items, r.Findings.Items...)
+		if types.RiskRank(r.Findings.RiskLevel) > types.RiskRank(merged.RiskLevel) {
+			merged.RiskLevel = r.Findings.RiskLevel
+		}
+		if s := strings.TrimSpace(r.Findings.RiskRationale); s != "" {
+			rationales = append(rationales, fmt.Sprintf("[%s] %s", r.Name, s))
+		}
+		if s := strings.TrimSpace(r.Findings.Summary); s != "" {
+			summaries = append(summaries, fmt.Sprintf("[%s] %s", r.Name, s))
+		}
+	}
+	merged.RiskRationale = strings.Join(rationales, "; ")
+	merged.Summary = strings.Join(summaries, "; ")
+	return merged
+}

--- a/internal/pipeline/steps/review_panel_test.go
+++ b/internal/pipeline/steps/review_panel_test.go
@@ -1,0 +1,316 @@
+package steps
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/agent"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+func report(name string, f Findings) reviewerReport {
+	return reviewerReport{Name: name, Findings: f}
+}
+
+func TestCombineReviewerFindings_UnionPreservesItems(t *testing.T) {
+	reports := []reviewerReport{
+		report("codex", Findings{
+			Items: []Finding{
+				{ID: "review-codex-1", Severity: "warning", Description: "codex A", Source: "codex"},
+				{ID: "review-codex-2", Severity: "info", Description: "codex B", Source: "codex"},
+			},
+		}),
+		report("claude", Findings{
+			Items: []Finding{
+				{ID: "review-claude-1", Severity: "error", Description: "claude A", Source: "claude"},
+			},
+		}),
+	}
+
+	merged := combineReviewerFindings(reports)
+
+	if len(merged.Items) != 3 {
+		t.Fatalf("expected 3 items in the union, got %d", len(merged.Items))
+	}
+	// Deterministic order: all of codex's items first, then claude's.
+	wantIDs := []string{"review-codex-1", "review-codex-2", "review-claude-1"}
+	wantSources := []string{"codex", "codex", "claude"}
+	for i, item := range merged.Items {
+		if item.ID != wantIDs[i] {
+			t.Errorf("item %d id = %q, want %q", i, item.ID, wantIDs[i])
+		}
+		if item.Source != wantSources[i] {
+			t.Errorf("item %d source = %q, want %q", i, item.Source, wantSources[i])
+		}
+	}
+}
+
+func TestCombineReviewerFindings_RiskLevelMax(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b string
+		want string
+	}{
+		{"low+high", "low", "high", "high"},
+		{"low+medium", "low", "medium", "medium"},
+		{"medium+low", "medium", "low", "medium"},
+		{"empty+low", "", "low", "low"},
+		{"high+empty", "high", "", "high"},
+		{"both empty", "", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			merged := combineReviewerFindings([]reviewerReport{
+				report("codex", Findings{RiskLevel: tc.a}),
+				report("claude", Findings{RiskLevel: tc.b}),
+			})
+			if merged.RiskLevel != tc.want {
+				t.Errorf("RiskLevel = %q, want %q", merged.RiskLevel, tc.want)
+			}
+		})
+	}
+}
+
+func TestCombineReviewerFindings_LabeledScalars(t *testing.T) {
+	merged := combineReviewerFindings([]reviewerReport{
+		report("codex", Findings{Summary: "codex summary", RiskRationale: "codex rationale"}),
+		report("claude", Findings{Summary: "claude summary", RiskRationale: "claude rationale"}),
+	})
+	if merged.Summary != "[codex] codex summary; [claude] claude summary" {
+		t.Errorf("Summary = %q", merged.Summary)
+	}
+	if merged.RiskRationale != "[codex] codex rationale; [claude] claude rationale" {
+		t.Errorf("RiskRationale = %q", merged.RiskRationale)
+	}
+}
+
+func TestCombineReviewerFindings_SkipsEmptyScalars(t *testing.T) {
+	merged := combineReviewerFindings([]reviewerReport{
+		report("codex", Findings{Summary: "only codex", RiskRationale: ""}),
+		report("claude", Findings{Summary: "", RiskRationale: "only claude"}),
+	})
+	if merged.Summary != "[codex] only codex" {
+		t.Errorf("Summary = %q, want only codex labeled", merged.Summary)
+	}
+	if merged.RiskRationale != "[claude] only claude" {
+		t.Errorf("RiskRationale = %q, want only claude labeled", merged.RiskRationale)
+	}
+}
+
+func TestCombineReviewerFindings_EmptyAndSingle(t *testing.T) {
+	if merged := combineReviewerFindings(nil); len(merged.Items) != 0 || merged.Summary != "" || merged.RiskLevel != "" {
+		t.Errorf("empty reports should yield zero-value findings, got %+v", merged)
+	}
+
+	single := combineReviewerFindings([]reviewerReport{
+		report("codex", Findings{
+			Items:         []Finding{{ID: "review-codex-1", Severity: "warning", Description: "x", Source: "codex"}},
+			RiskLevel:     "medium",
+			RiskRationale: "rationale",
+			Summary:       "summary",
+		}),
+	})
+	if len(single.Items) != 1 || single.Items[0].ID != "review-codex-1" || single.Items[0].Source != "codex" {
+		t.Errorf("single report item not preserved: %+v", single.Items)
+	}
+	if single.RiskLevel != "medium" {
+		t.Errorf("single report RiskLevel = %q, want medium", single.RiskLevel)
+	}
+	if single.Summary != "[codex] summary" || single.RiskRationale != "[codex] rationale" {
+		t.Errorf("single report scalars = %q / %q", single.Summary, single.RiskRationale)
+	}
+}
+
+func fanResult(name string, out json.RawMessage, err error) agent.FanOutResult {
+	res := &agent.Result{Output: out}
+	if err != nil {
+		res = nil
+	}
+	return agent.FanOutResult{Agent: &mockAgent{name: name}, Result: res, Err: err}
+}
+
+func TestProcessReviewerResults_NamespacesAndStampsSource(t *testing.T) {
+	codexOut, _ := json.Marshal(Findings{
+		Items:     []Finding{{Severity: "warning", Description: "no id here", Action: "auto-fix"}},
+		RiskLevel: "medium",
+	})
+	claudeOut, _ := json.Marshal(Findings{
+		Items:     []Finding{{ID: "keep-me", Severity: "error", Description: "has id", Action: "ask-user"}},
+		RiskLevel: "high",
+	})
+
+	var fileLogs []string
+	reports, err := processReviewerResults(
+		[]agent.FanOutResult{fanResult("codex", codexOut, nil), fanResult("claude", claudeOut, nil)},
+		false,
+		func(string) {},
+		func(s string) { fileLogs = append(fileLogs, s) },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reports) != 2 {
+		t.Fatalf("expected 2 reports, got %d", len(reports))
+	}
+	// Reviewer IDs are rewritten to globally unique panel IDs, even when the
+	// reviewer supplied its own ID.
+	if got := reports[0].Findings.Items[0].ID; got != "review-codex-1" {
+		t.Errorf("codex id = %q, want review-codex-1", got)
+	}
+	if got := reports[1].Findings.Items[0].ID; got != "review-claude-1" {
+		t.Errorf("claude id = %q, want review-claude-1", got)
+	}
+	// Source is stamped with the reviewer name on every item.
+	if reports[0].Findings.Items[0].Source != "codex" {
+		t.Errorf("codex source = %q", reports[0].Findings.Items[0].Source)
+	}
+	if reports[1].Findings.Items[0].Source != "claude" {
+		t.Errorf("claude source = %q", reports[1].Findings.Items[0].Source)
+	}
+	// Each reviewer's raw report is written to the file-only audit log.
+	if len(fileLogs) != 2 {
+		t.Fatalf("expected 2 audit log lines, got %d: %v", len(fileLogs), fileLogs)
+	}
+	if !strings.Contains(fileLogs[0], "[reviewer codex] report:") {
+		t.Errorf("first audit line = %q", fileLogs[0])
+	}
+}
+
+func TestProcessReviewerResults_RewritesCollidingReviewerIDs(t *testing.T) {
+	codexOut, _ := json.Marshal(Findings{
+		Items: []Finding{{ID: "same", Severity: "warning", Description: "codex issue"}},
+	})
+	claudeOut, _ := json.Marshal(Findings{
+		Items: []Finding{{ID: "same", Severity: "warning", Description: "claude issue"}},
+	})
+
+	reports, err := processReviewerResults(
+		[]agent.FanOutResult{fanResult("codex", codexOut, nil), fanResult("claude", claudeOut, nil)},
+		false,
+		func(string) {},
+		func(string) {},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := reports[0].Findings.Items[0].ID; got != "review-codex-1" {
+		t.Errorf("codex id = %q, want review-codex-1", got)
+	}
+	if got := reports[1].Findings.Items[0].ID; got != "review-claude-1" {
+		t.Errorf("claude id = %q, want review-claude-1", got)
+	}
+}
+
+func TestLabelReviewers_DistinguishesSameFamilyReviewers(t *testing.T) {
+	reviewers := []agent.Agent{
+		&mockAgent{name: "codex"},
+		&mockAgent{name: "codex"},
+		&mockAgent{name: "acp:gpt"},
+	}
+
+	labeled := labelReviewers(reviewers)
+	got := []string{labeled[0].Name(), labeled[1].Name(), labeled[2].Name()}
+	want := []string{"codex", "codex-2", "acp-gpt"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("labels = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestLabelReviewers_SkipsGeneratedLabelCollisions(t *testing.T) {
+	reviewers := []agent.Agent{
+		&mockAgent{name: "acp:foo"},
+		&mockAgent{name: "acp:foo"},
+		&mockAgent{name: "acp:foo-2"},
+	}
+
+	labeled := labelReviewers(reviewers)
+	got := []string{labeled[0].Name(), labeled[1].Name(), labeled[2].Name()}
+	want := []string{"acp-foo", "acp-foo-2", "acp-foo-2-2"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("labels = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestProcessReviewerResults_FailClosed(t *testing.T) {
+	ok, _ := json.Marshal(Findings{Items: []Finding{{Severity: "info", Description: "ok"}}})
+	_, err := processReviewerResults(
+		[]agent.FanOutResult{
+			fanResult("codex", ok, nil),
+			fanResult("claude", nil, errors.New("boom")),
+		},
+		false, // fail-closed
+		func(string) {},
+		func(string) {},
+	)
+	if err == nil {
+		t.Fatal("expected fail-closed error when a reviewer fails")
+	}
+	if !strings.Contains(err.Error(), "claude") {
+		t.Errorf("error should name the failed reviewer family, got %q", err)
+	}
+}
+
+func TestProcessReviewerResults_FailOpenDropsAndContinues(t *testing.T) {
+	ok, _ := json.Marshal(Findings{Items: []Finding{{Severity: "info", Description: "ok"}}})
+	var warnings []string
+	reports, err := processReviewerResults(
+		[]agent.FanOutResult{
+			fanResult("codex", ok, nil),
+			fanResult("claude", nil, errors.New("boom")),
+		},
+		true, // fail-open
+		func(s string) { warnings = append(warnings, s) },
+		func(string) {},
+	)
+	if err != nil {
+		t.Fatalf("fail-open should not error when one reviewer succeeds: %v", err)
+	}
+	if len(reports) != 1 || reports[0].Name != "codex" {
+		t.Fatalf("expected only the codex report to survive, got %+v", reports)
+	}
+	loud := false
+	for _, w := range warnings {
+		if strings.Contains(w, "claude") && strings.Contains(w, "DROPPED") {
+			loud = true
+		}
+	}
+	if !loud {
+		t.Errorf("expected a loud warning naming the dropped reviewer, got %v", warnings)
+	}
+}
+
+func TestProcessReviewerResults_FailOpenAllFail(t *testing.T) {
+	_, err := processReviewerResults(
+		[]agent.FanOutResult{
+			fanResult("codex", nil, errors.New("boom1")),
+			fanResult("claude", nil, errors.New("boom2")),
+		},
+		true, // fail-open, but nobody succeeds
+		func(string) {},
+		func(string) {},
+	)
+	if err == nil {
+		t.Fatal("expected an error when every reviewer fails even under fail-open")
+	}
+}
+
+func TestRiskRankAndSeverityRank(t *testing.T) {
+	if !(types.RiskRank("low") < types.RiskRank("medium") && types.RiskRank("medium") < types.RiskRank("high")) {
+		t.Error("expected low < medium < high risk ranks")
+	}
+	if types.RiskRank("") != 0 || types.RiskRank("bogus") != 0 {
+		t.Error("expected unknown/empty risk to rank lowest")
+	}
+	if !(types.SeverityRank("info") < types.SeverityRank("warning") && types.SeverityRank("warning") < types.SeverityRank("error")) {
+		t.Error("expected info < warning < error severity ranks")
+	}
+	if types.SeverityRank("") != 0 || types.SeverityRank("bogus") != 0 {
+		t.Error("expected unknown/empty severity to rank lowest")
+	}
+}

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -180,7 +180,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 					if byStep := m.findingInstructions[step.StepName]; byStep != nil {
 						existing = byStep[item.ID]
 					}
-					if item.Source == types.FindingSourceUser {
+					if isUserSource(item.Source) {
 						existing = item.UserInstructions
 					}
 					m.editor = newInstructionEditor(step.StepName, item.ID, existing)
@@ -198,7 +198,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "D":
 		if !m.showDiff {
 			if step := awaitingStep(m.steps); step != nil {
-				if item, ok := m.findingAtCursor(step.StepName); ok && item.Source == types.FindingSourceUser {
+				if item, ok := m.findingAtCursor(step.StepName); ok && isUserSource(item.Source) {
 					m.removeUserFinding(step.StepName, item.ID)
 					m.moveFindingCursor(step.StepName, 0)
 				}

--- a/internal/tui/review.go
+++ b/internal/tui/review.go
@@ -26,6 +26,25 @@ func parseFindings(raw string) (*findings, error) {
 	return &f, nil
 }
 
+// isUserSource reports whether a finding's Source is the true user sentinel.
+// Only user-authored findings are user-editable at the gate; reviewer-panel
+// sources (e.g. "codex", "claude") must not match.
+func isUserSource(source string) bool {
+	return source == nmtypes.FindingSourceUser
+}
+
+// reviewerSourceTag returns the bracketed provenance tag for a reviewer-panel
+// finding (e.g. "[codex]"), or "" when the source is unattributed: empty, the
+// agent sentinel, or the user sentinel (which renders its own [user] tag).
+func reviewerSourceTag(source string) string {
+	switch source {
+	case "", nmtypes.FindingSourceAgent, nmtypes.FindingSourceUser:
+		return ""
+	default:
+		return "[" + source + "]"
+	}
+}
+
 // severityIcon returns the visual indicator for a finding severity.
 func severityIcon(severity string) string {
 	switch severity {
@@ -268,6 +287,7 @@ func renderFindingsRange(f *findings, width int, cursor int, selected map[string
 	// Individual findings.
 	greenStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiGreen))
 	blueStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiBlue))
+	cyanStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(ansiCyan))
 	for idx := start; idx < end; idx++ {
 		item := f.Items[idx]
 		// Blank line between findings per DESIGN.md Gutter System.
@@ -295,10 +315,15 @@ func renderFindingsRange(f *findings, width int, cursor int, selected map[string
 		}
 		line := pointer + " " + checkbox + " " + iconStyled
 
-		// Tag user-authored findings right after the icon so they remain
-		// visible when unfocused and do not shift alignment of the ref.
-		if item.Source == nmtypes.FindingSourceUser {
+		// Tag the finding's provenance right after the icon so it stays visible
+		// when unfocused and does not shift the alignment of the ref. User
+		// findings get a [user] tag; reviewer-panel findings get a [<reviewer>]
+		// tag (e.g. [codex], [claude]) so each reviewer's findings are
+		// attributable at the gate.
+		if isUserSource(item.Source) {
 			line += " " + blueStyle.Render("[user]")
+		} else if tag := reviewerSourceTag(item.Source); tag != "" {
+			line += " " + cyanStyle.Render(tag)
 		}
 
 		// File:line reference, truncated to fit within content width.

--- a/internal/tui/review_source_test.go
+++ b/internal/tui/review_source_test.go
@@ -1,0 +1,65 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+	"github.com/muesli/termenv"
+)
+
+func TestReviewerSourceTag(t *testing.T) {
+	cases := []struct {
+		source string
+		want   string
+	}{
+		{"", ""},
+		{types.FindingSourceAgent, ""},
+		{types.FindingSourceUser, ""},
+		{"codex", "[codex]"},
+		{"claude", "[claude]"},
+	}
+	for _, tc := range cases {
+		if got := reviewerSourceTag(tc.source); got != tc.want {
+			t.Errorf("reviewerSourceTag(%q) = %q, want %q", tc.source, got, tc.want)
+		}
+	}
+}
+
+func TestIsUserSource(t *testing.T) {
+	if !isUserSource(types.FindingSourceUser) {
+		t.Error("expected the user sentinel to be a user source")
+	}
+	for _, s := range []string{"", types.FindingSourceAgent, "codex", "claude"} {
+		if isUserSource(s) {
+			t.Errorf("expected %q not to be treated as a user source", s)
+		}
+	}
+}
+
+func TestRenderFindings_ReviewerSourceTags(t *testing.T) {
+	lipgloss.SetColorProfile(termenv.ANSI)
+	raw := `{"findings":[
+		{"id":"review-codex-1","severity":"warning","file":"a.go","line":1,"description":"codex issue","source":"codex"},
+		{"id":"review-claude-1","severity":"error","file":"b.go","line":2,"description":"claude issue","source":"claude"},
+		{"id":"user-1","severity":"info","description":"user idea","source":"user"},
+		{"id":"agent-1","severity":"info","description":"plain agent finding","source":"agent"}
+	],"summary":"4 issues"}`
+
+	plain := stripANSI(renderFindings(raw, 80))
+
+	if !strings.Contains(plain, "[codex]") {
+		t.Error("expected a [codex] reviewer tag in the rendered findings")
+	}
+	if !strings.Contains(plain, "[claude]") {
+		t.Error("expected a [claude] reviewer tag in the rendered findings")
+	}
+	if !strings.Contains(plain, "[user]") {
+		t.Error("expected the [user] tag for user-authored findings")
+	}
+	// The agent sentinel and empty sources must not get an attribution tag.
+	if strings.Contains(plain, "[agent]") {
+		t.Error("did not expect an [agent] attribution tag")
+	}
+}

--- a/internal/types/findings.go
+++ b/internal/types/findings.go
@@ -13,7 +13,12 @@ const (
 	ActionAskUser = "ask-user"
 )
 
-// Finding source constants. An empty Source is treated as agent-produced.
+// Finding source constants. Source attributes who produced a finding. The two
+// sentinels below are special-cased by the UI (agent-authored and user-authored
+// findings). Any other non-empty value is a free-form provenance label - in
+// particular a reviewer's model/family name (e.g. "codex", "claude") stamped by
+// the multi-reviewer panel so each finding's origin is visible at the gate. An
+// empty Source is treated as agent-produced.
 const (
 	FindingSourceAgent = "agent"
 	FindingSourceUser  = "user"
@@ -318,4 +323,35 @@ func (f Finding) actionOrDefault() string {
 		return ActionAutoFix
 	}
 	return f.Action
+}
+
+// RiskRank maps a risk level to a comparable rank where higher means riskier
+// (low < medium < high). Unknown or empty levels rank lowest. The multi-reviewer
+// panel uses it to reconcile each reviewer's risk_level into the maximum.
+func RiskRank(level string) int {
+	switch strings.ToLower(strings.TrimSpace(level)) {
+	case "high":
+		return 3
+	case "medium":
+		return 2
+	case "low":
+		return 1
+	default:
+		return 0
+	}
+}
+
+// SeverityRank maps a finding severity to a comparable rank where higher means
+// more severe (info < warning < error). Unknown or empty severities rank lowest.
+func SeverityRank(severity string) int {
+	switch strings.ToLower(strings.TrimSpace(severity)) {
+	case "error":
+		return 3
+	case "warning":
+		return 2
+	case "info":
+		return 1
+	default:
+		return 0
+	}
 }


### PR DESCRIPTION
## Summary

Today no-mistakes drives the whole pipeline with a single agent, so the **review** step and the **fix** step are always the *same model family* — correlated blind spots. This PR lets the review step **fan out to N reviewers of mixed model families** (e.g. `codex` + `claude`) that review the *same* diff independently; their findings are merged into one **attributed union**, and the single configured `agent:` stays the **sole fixer/reconciler**.

**With no `review.reviewers` configured, behavior is byte-identical to today.** The panel is purely additive and opt-in.

## Configuration

```yaml
# ~/.no-mistakes/config.yaml
agent: claude            # unchanged: the ONE implementation/fix agent + reconciler
review:
  reviewers:
    - agent: codex       # cross-family reviewer #1
    - agent: claude      # independent pass #2
  max_parallel: 2        # bound concurrent reviewer agents (0/unset = all at once)
  fail_open: false       # safety default: any reviewer error fails the step
```

Per-reviewer `args`/`path` are supported and otherwise fall back to the existing `agent_args_override` / `agent_path_override` maps (so two same-family reviewers on different models work too).

## How it works

```mermaid
flowchart TD
    DIFF["same diff"] --> RV["review step"]
    RV --> R1["reviewer: codex"]
    RV --> R2["reviewer: claude"]
    R1 --> U["attributed union<br/>stamp Source · namespace ids · RiskLevel = max"]
    R2 --> U
    U --> GATE{"human gate<br/>tags: [codex] [claude]"}
    GATE -- "fix" --> FIX["single fix agent<br/>reconciles all reports"]
    FIX --> RV2["re-review: the panel runs AGAIN<br/>on the fix agent's own code"]
    RV2 -. converged .-> DONE["test → … → push → PR"]
```

- **Fan-out runs on *both* passes.** The panel reviews the initial diff *and* re-reviews the fix agent's own changes after every fix round — gated only on `len(reviewers) > 1`, never on "is this the first review". Otherwise the highest-risk, most-correlated code (the fixer's own) would get a single-family review.
- **Default path is untouched.** Empty/absent `review.reviewers` → `StepContext.Reviewers` defaults to `{agent}` and the review step takes the exact existing single-call streaming path (`OnChunk` preserved). Byte-identical, zero new goroutine.
- **Attributed union, not dedup.** Each reviewer's findings are stamped `Source = <family>` and id-namespaced (`review-codex-1`, `review-claude-1`); `RiskLevel` reconciles to the max across reviewers. The same issue found by two families surfaces as two attributed items — informative, reconciled downstream, not silently collapsed.
- **Single-writer fix.** Only the configured `agent:` writes the worktree and commits; reviewers are read-only. This is what decorrelates the reviewer family from the fixer family.
- **Fail-closed by default.** A reviewer error fails the step (don't silently lose eyes); `fail_open: true` degrades to the surviving reviewers with a loud warning, and still fails if *all* reviewers error.
- **Reusable `agent.FanOut` primitive** — `sync.WaitGroup` + a bounded semaphore (`max_parallel`), per-agent error isolation (one failure never aborts the others), and honors `ctx` cancellation.

## Security

`review.reviewers` selects which binaries run with maintainer credentials, so it's code-executing config and is honored **only from the trusted default-branch copy**: `EffectiveRepoConfig` strips a `review:` block pushed on a feature branch (covered by an e2e test). Without this, a pushed PR branch could choose which agent binaries to spawn.

## Tests

All new tests pass with `-race`; `gofmt` + `go vet` clean; **no new `go.mod` dependencies**.

- **Unit** — `agent.FanOut` (input-order, error isolation, cancellation, bounded parallelism); config parse + `ResolveReviewers` (dedup, bare-`auto` rejection) + the `EffectiveRepoConfig` trust boundary; `combineReviewerFindings` / `processReviewerResults` (attributed union, `RiskLevel=max`, namespacing, fail policies); `RiskRank` / `SeverityRank`.
- **Fan-out integration** (`mockAgent`, in-process) — two different-family reviewers on the same diff → two attributed reports; fan-out also runs in fix-mode re-review; fail-closed and fail-open.
- **e2e** (real binary vs the fixture-replaying `fakeagent`, **zero real API**) — `TestReviewerPanelJourney` (both `claude`+`codex` launch on the same diff → `review-codex-1` + `review-claude-1` persisted), `TestReviewerPanelSecurityGate` (trusted-branch panel launches both; feature-branch-only panel is stripped to the single agent), `TestReviewerPanelFailClosed`.
- Additionally smoke-tested end-to-end with **real** `codex` + `claude` on a throwaway diff: both models reviewed independently, the union preserved both findings, and `RiskLevel` reconciled to `max`.

## Notes

Squashed from a two-stage build (scaffolding with no behavior change → review-step fan-out behavior) into a single PR for review.

🤖 Co-developed with [Claude Code](https://claude.com/claude-code).
