### PR TITLE
feat(cli): expose parked awaiting-agent status

### DIFF
--- a/.no-mistakes/evidence/fm/nm-park-signal-p7/axi_respond_approve.toon
+++ b/.no-mistakes/evidence/fm/nm-park-signal-p7/axi_respond_approve.toon
@@ -1,0 +1,30 @@
+run: running
+  intent: completed
+  rebase: completed
+  review: completed
+  test: running
+run: completed
+  test: completed
+  document: completed
+  lint: completed
+  push: completed
+  pr: skipped
+  ci: skipped
+run:
+  id: "01KW1AW3NR19DV8EXM8DNPASGK"
+  branch: feature/park-evidence
+  status: completed
+  head: ea863f88
+  findings: 1 awaiting
+  steps[9]{step,status,findings,duration_ms}:
+    intent,completed,0,0
+    rebase,completed,0,87
+    review,completed,1,316
+    test,completed,0,18
+    document,completed,0,23
+    lint,completed,0,17
+    push,completed,0,71
+    pr,skipped,0,0
+    ci,skipped,0,0
+outcome: passed
+help[1]: "Summarize this pipeline run for the user in a concise, easily readable format: what was validated and what was found."

--- a/.no-mistakes/evidence/fm/nm-park-signal-p7/axi_run_gate.toon
+++ b/.no-mistakes/evidence/fm/nm-park-signal-p7/axi_run_gate.toon
@@ -1,0 +1,31 @@
+run: running
+  intent: completed
+  rebase: running
+  rebase: completed
+  review: running
+  review: awaiting_approval
+run:
+  id: "01KW1AW3NR19DV8EXM8DNPASGK"
+  branch: feature/park-evidence
+  status: running
+  awaiting_agent: parked 0s
+  head: ea863f88
+  findings: 1 awaiting
+  steps[9]{step,status,findings,duration_ms}:
+    intent,completed,0,0
+    rebase,completed,0,87
+    review,awaiting_approval,1,316
+    test,pending,0,0
+    document,pending,0,0
+    lint,pending,0,0
+    push,pending,0,0
+    pr,pending,0,0
+    ci,pending,0,0
+gate:
+  step: review
+  status: awaiting_approval
+  summary: found 1 issue
+  risk: medium
+  findings[1]{id,severity,file,action,description}:
+    axi-1,warning,feature.txt,ask-user,potential nil deref
+help[4]: Run `no-mistakes axi respond --action approve` to accept this step and continue,Run `no-mistakes axi respond --action fix --findings <ids>` to have the pipeline fix the selected findings (do not edit files yourself),Run `no-mistakes axi respond --action skip` to skip this step,Run `no-mistakes axi logs --step review --full` to read the full step log

--- a/.no-mistakes/evidence/fm/nm-park-signal-p7/axi_status_after_respond.toon
+++ b/.no-mistakes/evidence/fm/nm-park-signal-p7/axi_status_after_respond.toon
@@ -1,0 +1,17 @@
+run:
+  id: "01KW1AW3NR19DV8EXM8DNPASGK"
+  branch: feature/park-evidence
+  status: completed
+  head: ea863f88
+  findings: 1 awaiting
+  steps[9]{step,status,findings,duration_ms}:
+    intent,completed,0,0
+    rebase,completed,0,87
+    review,completed,1,316
+    test,completed,0,18
+    document,completed,0,23
+    lint,completed,0,17
+    push,completed,0,71
+    pr,skipped,0,0
+    ci,skipped,0,0
+outcome: passed

--- a/.no-mistakes/evidence/fm/nm-park-signal-p7/axi_status_parked.toon
+++ b/.no-mistakes/evidence/fm/nm-park-signal-p7/axi_status_parked.toon
@@ -1,0 +1,25 @@
+run:
+  id: "01KW1AW3NR19DV8EXM8DNPASGK"
+  branch: feature/park-evidence
+  status: running
+  awaiting_agent: parked 0s
+  head: ea863f88
+  findings: 1 awaiting
+  steps[9]{step,status,findings,duration_ms}:
+    intent,completed,0,0
+    rebase,completed,0,87
+    review,awaiting_approval,1,316
+    test,pending,0,0
+    document,pending,0,0
+    lint,pending,0,0
+    push,pending,0,0
+    pr,pending,0,0
+    ci,pending,0,0
+gate:
+  step: review
+  status: awaiting_approval
+  summary: found 1 issue
+  risk: medium
+  findings[1]{id,severity,file,action,description}:
+    axi-1,warning,feature.txt,ask-user,potential nil deref
+help[4]: Run `no-mistakes axi respond --action approve` to accept this step and continue,Run `no-mistakes axi respond --action fix --findings <ids>` to have the pipeline fix the selected findings (do not edit files yourself),Run `no-mistakes axi respond --action skip` to skip this step,Run `no-mistakes axi logs --step review --full` to read the full step log

--- a/.no-mistakes/evidence/fm/nm-park-signal-p7/parked_signal_cli_transcript.md
+++ b/.no-mistakes/evidence/fm/nm-park-signal-p7/parked_signal_cli_transcript.md
@@ -1,0 +1,131 @@
+# Parked Awaiting-Agent CLI Evidence
+
+This transcript was captured from the real no-mistakes CLI against a disposable git repo and fake Claude agent.
+It demonstrates the end-user AXI surface for a run parked at a review gate, then shows the signal clears after approval.
+
+## no-mistakes axi run --intent ...
+
+```toon
+run: running
+  intent: completed
+  rebase: running
+  rebase: completed
+  review: running
+  review: awaiting_approval
+run:
+  id: "01KW1AW3NR19DV8EXM8DNPASGK"
+  branch: feature/park-evidence
+  status: running
+  awaiting_agent: parked 0s
+  head: ea863f88
+  findings: 1 awaiting
+  steps[9]{step,status,findings,duration_ms}:
+    intent,completed,0,0
+    rebase,completed,0,87
+    review,awaiting_approval,1,316
+    test,pending,0,0
+    document,pending,0,0
+    lint,pending,0,0
+    push,pending,0,0
+    pr,pending,0,0
+    ci,pending,0,0
+gate:
+  step: review
+  status: awaiting_approval
+  summary: found 1 issue
+  risk: medium
+  findings[1]{id,severity,file,action,description}:
+    axi-1,warning,feature.txt,ask-user,potential nil deref
+help[4]: Run `no-mistakes axi respond --action approve` to accept this step and continue,Run `no-mistakes axi respond --action fix --findings <ids>` to have the pipeline fix the selected findings (do not edit files yourself),Run `no-mistakes axi respond --action skip` to skip this step,Run `no-mistakes axi logs --step review --full` to read the full step log
+
+```
+
+## no-mistakes axi status while parked
+
+```toon
+run:
+  id: "01KW1AW3NR19DV8EXM8DNPASGK"
+  branch: feature/park-evidence
+  status: running
+  awaiting_agent: parked 0s
+  head: ea863f88
+  findings: 1 awaiting
+  steps[9]{step,status,findings,duration_ms}:
+    intent,completed,0,0
+    rebase,completed,0,87
+    review,awaiting_approval,1,316
+    test,pending,0,0
+    document,pending,0,0
+    lint,pending,0,0
+    push,pending,0,0
+    pr,pending,0,0
+    ci,pending,0,0
+gate:
+  step: review
+  status: awaiting_approval
+  summary: found 1 issue
+  risk: medium
+  findings[1]{id,severity,file,action,description}:
+    axi-1,warning,feature.txt,ask-user,potential nil deref
+help[4]: Run `no-mistakes axi respond --action approve` to accept this step and continue,Run `no-mistakes axi respond --action fix --findings <ids>` to have the pipeline fix the selected findings (do not edit files yourself),Run `no-mistakes axi respond --action skip` to skip this step,Run `no-mistakes axi logs --step review --full` to read the full step log
+
+```
+
+## no-mistakes axi respond --action approve
+
+```toon
+run: running
+  intent: completed
+  rebase: completed
+  review: completed
+  test: running
+run: completed
+  test: completed
+  document: completed
+  lint: completed
+  push: completed
+  pr: skipped
+  ci: skipped
+run:
+  id: "01KW1AW3NR19DV8EXM8DNPASGK"
+  branch: feature/park-evidence
+  status: completed
+  head: ea863f88
+  findings: 1 awaiting
+  steps[9]{step,status,findings,duration_ms}:
+    intent,completed,0,0
+    rebase,completed,0,87
+    review,completed,1,316
+    test,completed,0,18
+    document,completed,0,23
+    lint,completed,0,17
+    push,completed,0,71
+    pr,skipped,0,0
+    ci,skipped,0,0
+outcome: passed
+help[1]: "Summarize this pipeline run for the user in a concise, easily readable format: what was validated and what was found."
+
+```
+
+## no-mistakes axi status after respond
+
+```toon
+run:
+  id: "01KW1AW3NR19DV8EXM8DNPASGK"
+  branch: feature/park-evidence
+  status: completed
+  head: ea863f88
+  findings: 1 awaiting
+  steps[9]{step,status,findings,duration_ms}:
+    intent,completed,0,0
+    rebase,completed,0,87
+    review,completed,1,316
+    test,completed,0,18
+    document,completed,0,23
+    lint,completed,0,17
+    push,completed,0,71
+    pr,skipped,0,0
+    ci,skipped,0,0
+outcome: passed
+
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,14 @@ Safest local verification sequence after non-trivial changes:
 - `config.CITimeout` semantics: `>0` finite, `0` = unset (step falls back to `config.DefaultCITimeout`, 7 days), `<0` = `config.CITimeoutUnlimited` (never self-terminate). Config keyword `ci_timeout: "unlimited"` (also `none`/`off`/`never`) or any non-positive duration resolves to the unlimited sentinel via `parseCITimeout`. Keep `config.DefaultCITimeout` and the `defaultConfigYAML` `ci_timeout` value in sync (`TestDefaultConfigYAML_MatchesGoDefaults`).
 - Reap a run by id from outside its worktree with `no-mistakes axi abort --run <id>` (`runAxiAbortByRunID`). It needs only `NM_HOME` + the daemon, not a repo/branch/worktree, because `ipc.MethodCancelRun` → `RunManager.HandleCancel` only cancels runs live in daemon memory. An unknown/inactive id, or a stopped daemon, is an idempotent no-op (`aborted: false`), not an error. This is how an orphaned monitor (worktree torn down before merge) gets reaped deterministically. Bare `axi abort` (no `--run`) stays worktree/branch-scoped.
 
+**Parked / Awaiting-Agent Signal**
+
+- A run carries a pollable "parked, awaiting the driving agent" marker so a supervisor can tell in one `axi status` read whether a run is waiting for the agent to drive a gate versus actively running/fixing/ci. It is **observability only**: it does not change gate resolution, auto-resume, or the `--yes` default.
+- Storage: `runs.awaiting_agent_since` (unix seconds, nullable) on `db.Run.AwaitingAgentSince`. `ipc.RunInfo` exposes both `AwaitingAgent bool` (= since != nil) and `AwaitingAgentSince *int64`; `runToInfo` derives them.
+- Invariant: `awaiting_agent_since` is non-nil **iff a step is actually parked** at an `awaiting_approval`/`fix_review` gate. The executor (`internal/pipeline/executor.go`) sets it via `db.SetRunAwaitingAgent` on gate entry (right before the step status flips to the gate state, so it is already set once pollers observe the gate) and clears it via `db.ClearRunAwaitingAgent` the moment `waitForApproval` returns - covering both the agent's `axi respond` and a cancel. `RecoverStaleRuns` also clears it so a crash-recovered (failed) run is never reported as parked.
+- Surface: the `run:` TOON object adds `awaiting_agent: parked <duration>` right after `status`, rendered only while `AwaitingAgentSince != nil` and the run is non-terminal (`internal/cli/axi_render.go` `runObjectFieldWithKey` + `formatParkedFor`). The render clock is the injectable `nowUnix` package var so parked-duration tests are deterministic.
+- Tests: db set/clear + recovery (`internal/db/run_test.go`), executor flips-on-gate/clears-on-respond (`internal/pipeline/executor_approval_test.go`), formatter + render shape (`internal/cli/axi_test.go`), and e2e `TestAxiParkedAwaitingAgentSignal`.
+
 **When Making Changes**
 
 - Whenever you must bring in new dependencies, check latest documentation for knowledge, and discuss with the user.

--- a/docs/src/content/docs/concepts/daemon.md
+++ b/docs/src/content/docs/concepts/daemon.md
@@ -97,6 +97,7 @@ On startup, the daemon checks for runs that were left in `pending` or `running` 
 - Refreshes legacy no-mistakes-managed `post-receive` hooks, installs missing managed hooks, and leaves custom hooks untouched
 - Reapplies per-worktree gate hook-path isolation to existing bare repos when Git supports `config --worktree`, so shared `core.hookspath` writes cannot disable `post-receive`
 - Enables Git push-option support on existing gate repos so per-push options like `no-mistakes.skip=...` keep working after upgrades
+- Clears any parked-awaiting-agent marker so a recovered failed run is not shown as still waiting for `axi respond`
 
 ## Logging
 

--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -56,6 +56,7 @@ That is a core design choice, not an implementation detail.
 4. The daemon creates a detached worktree for this run.
 5. The pipeline runs in order: `intent -> rebase -> review -> test -> document -> lint -> push -> pr -> ci`.
 6. If a step pauses, you can attach with the TUI or use `no-mistakes axi respond` to approve, fix, skip, or abort.
+   AXI run objects show `awaiting_agent: parked <duration>` while a non-terminal run is parked at that gate, so a supervising agent can distinguish a waiting run from active work in one status read.
 7. After local checks pass, the push step forwards the branch to the configured push target and the PR step creates or updates the pull request.
    For GitHub fork routing, the push target is the fork and the PR base repository is the parent from `origin`.
 8. The CI step keeps watching the open PR until it is merged, closed, or its configured idle timeout elapses with no base-branch movement, and can auto-fix failures or merge conflicts when supported.
@@ -137,6 +138,9 @@ branch, marking the remaining steps as skipped.
 3. If blocking findings remain, or any finding has `action: ask-user`, pause and wait for user action
 4. `action: no-op` findings are informational only; the user can approve, fix selected findings, skip, or abort when the step pauses
 
+While the executor is paused at an approval or fix-review gate, it persists a run-level awaiting-agent timestamp that AXI renders as `awaiting_agent: parked <duration>`.
+That timestamp is observability only and does not alter approval behavior.
+
 ### IPC
 
 Communication between the CLI and daemon uses JSON-RPC 2.0 over the Unix socket. The `subscribe` method streams real-time events (step progress, log chunks, findings) to the TUI, while the `axi` commands use request/response IPC for non-interactive agent control.
@@ -156,6 +160,7 @@ agent-supplied AXI intent is stored directly on the run. Raw transcript text is
 not stored in this database. Legacy `user_fix` rounds are still read as
 `auto-fix` for backward
 compatibility.
+Run records also store the nullable `awaiting_agent_since` timestamp used only to render the AXI parked signal while a gate is waiting for the driving agent.
 Repo records store the parent `upstream_url` and an optional `fork_url`; branch pushes use `fork_url` when present, while PR and CI provider context stays anchored to the parent.
 
 ## Local state

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -124,6 +124,9 @@ When an agent starts a new run, `--intent` is required and should describe what 
 Agents should prefer a few complete sentences over a terse summary, capturing user decisions, tradeoffs, constraints, ruled-out approaches, and explicit requests that would not be obvious from the diff alone.
 If the repo is on the default branch or has uncommitted changes, direct `axi run` returns a structured error with the command the agent should run instead of silently creating a branch or commit.
 Approval gates are exposed as `gate:` objects with finding IDs, severities, files, actions, descriptions, and help commands for `no-mistakes axi respond`.
+While a non-terminal run is parked at an `awaiting_approval` or `fix_review` gate, the run object also includes `awaiting_agent: parked <duration>`.
+Use that field in `axi status` output to tell in one read that the run is waiting for the driving agent to send `axi respond`, not actively running, fixing, or watching CI.
+It is observability only: it does not auto-resume the run, change gate resolution, or make `--yes` the default.
 An agent should resolve `action: auto-fix` findings on its own judgment, ignore `action: no-op` findings when approving, and stop on `action: ask-user` findings unless it is running with explicit `--yes` consent.
 When it stops for `ask-user`, it should relay each finding's ID, file, and full description to the user before choosing `approve`, `fix`, or `skip`.
 Resolving a finding always means responding with `no-mistakes axi respond --action fix`, which has the pipeline apply the fix and re-review it - the agent must not edit the code itself while a run is active.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -65,6 +65,8 @@ no-mistakes axi
 
 With no subcommand, shows the executable path, description, repo, current branch, daemon state, recent runs, and next-step help.
 When the current branch has an active run, that run appears as `active_run` with any approval gate and help for `axi respond` or `axi abort`.
+If an active run object is parked at a decision gate, it includes `awaiting_agent: parked <duration>` immediately after `status`.
+That field is observability only; the `gate:` object still tells the agent which response to send.
 When only another branch has an active run, that run appears as `other_branch_active_run`; the help tells agents to leave it alone and start validation for the current branch.
 
 ## no-mistakes axi run
@@ -132,6 +134,9 @@ no-mistakes axi status --run <id>
 | Flag | Type | Default | Description |
 |---|---|---|---|
 | `--run` | `string` | resolved run | Inspect a specific run ID |
+
+When the resolved run is parked at an `awaiting_approval` or `fix_review` gate, its top-level `run:` object includes `awaiting_agent: parked <duration>` immediately after `status`.
+The field disappears after `axi respond`, on cancel, and on terminal outcomes; use it to distinguish a run waiting for the driving agent from one actively running, fixing, or watching CI.
 
 ## no-mistakes axi logs
 

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -209,3 +209,6 @@ Each step progresses through these statuses:
 | `completed` | Finished successfully |
 | `skipped` | Pre-skipped for the run, skipped by the user, or skipped automatically by the pipeline |
 | `failed` | Step failed; the step log includes the returned error message so command stderr and provider errors are visible in the per-step log, not only in the daemon log |
+
+When a non-terminal run has a step in `awaiting_approval` or `fix_review`, AXI run objects also expose `awaiting_agent: parked <duration>` as a run-level observability signal.
+The signal clears as soon as the approval wait ends, including `axi respond` and cancellation, and does not change how gates resolve.

--- a/internal/cli/axi_render.go
+++ b/internal/cli/axi_render.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"time"
 
 	toon "github.com/toon-format/toon-go"
 
@@ -10,6 +11,10 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/types"
 	"github.com/spf13/cobra"
 )
+
+// nowUnix returns the current time in unix seconds. It is a package var so tests
+// can pin the clock when asserting how long a run has been parked.
+var nowUnix = func() int64 { return time.Now().Unix() }
 
 // maxFindingDesc caps a finding description rendered inline. Findings are the
 // decision content at a gate, so the limit is generous; only pathological
@@ -71,15 +76,20 @@ type runView struct {
 	Status  string
 	HeadSHA string
 	PRURL   string
-	Steps   []stepView
+	// AwaitingAgentSince is the unix-seconds time the run parked at a gate
+	// awaiting the driving agent, or nil when the run is not parked. It powers
+	// the top-level parked signal in the run object.
+	AwaitingAgentSince *int64
+	Steps              []stepView
 }
 
 func runViewFromIPC(r *ipc.RunInfo) runView {
 	rv := runView{
-		ID:      r.ID,
-		Branch:  r.Branch,
-		Status:  string(r.Status),
-		HeadSHA: r.HeadSHA,
+		ID:                 r.ID,
+		Branch:             r.Branch,
+		Status:             string(r.Status),
+		HeadSHA:            r.HeadSHA,
+		AwaitingAgentSince: r.AwaitingAgentSince,
 	}
 	if r.PRURL != nil {
 		rv.PRURL = *r.PRURL
@@ -99,10 +109,11 @@ func runViewFromIPC(r *ipc.RunInfo) runView {
 
 func runViewFromDB(r *db.Run, steps []*db.StepResult) runView {
 	rv := runView{
-		ID:      r.ID,
-		Branch:  r.Branch,
-		Status:  string(r.Status),
-		HeadSHA: r.HeadSHA,
+		ID:                 r.ID,
+		Branch:             r.Branch,
+		Status:             string(r.Status),
+		HeadSHA:            r.HeadSHA,
+		AwaitingAgentSince: r.AwaitingAgentSince,
 	}
 	if r.PRURL != nil {
 		rv.PRURL = *r.PRURL
@@ -129,6 +140,28 @@ func (rv runView) awaitingStep() (stepView, bool) {
 		}
 	}
 	return stepView{}, false
+}
+
+// formatParkedFor renders how long a run has been parked awaiting the agent,
+// given the unix-seconds time it parked. The phrasing reports the elapsed
+// duration so a supervisor can tell a fresh park ("parked 4s") from a stalled
+// one ("parked 18m20s") in a single `axi status` read.
+func formatParkedFor(sinceUnix int64) string {
+	secs := nowUnix() - sinceUnix
+	if secs < 0 {
+		secs = 0
+	}
+	d := time.Duration(secs) * time.Second
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("parked %ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("parked %dm%ds", int(d.Minutes()), int(d.Seconds())%60)
+	case d < 24*time.Hour:
+		return fmt.Sprintf("parked %dh%dm", int(d.Hours()), int(d.Minutes())%60)
+	default:
+		return fmt.Sprintf("parked %dd%dh", int(d.Hours())/24, int(d.Hours())%24)
+	}
 }
 
 // shortSHA trims a commit SHA for display.
@@ -228,8 +261,16 @@ func runObjectFieldWithKey(key string, rv runView) toon.Field {
 		{Key: "id", Value: rv.ID},
 		{Key: "branch", Value: rv.Branch},
 		{Key: "status", Value: rv.Status},
-		{Key: "head", Value: shortSHA(rv.HeadSHA)},
 	}
+	// Surface the parked-awaiting-agent signal right after status so one read
+	// distinguishes a run waiting for the agent to drive a gate from one that
+	// is actively running/fixing/ci. The value reports how long it has been
+	// parked, which separates a fresh park from a stalled one. Present only
+	// while genuinely parked (non-nil marker on a non-terminal run).
+	if rv.AwaitingAgentSince != nil && !terminalStatus(rv.Status) {
+		fields = append(fields, toon.Field{Key: "awaiting_agent", Value: formatParkedFor(*rv.AwaitingAgentSince)})
+	}
+	fields = append(fields, toon.Field{Key: "head", Value: shortSHA(rv.HeadSHA)})
 	if rv.PRURL != "" {
 		fields = append(fields, toon.Field{Key: "pr", Value: rv.PRURL})
 	}

--- a/internal/cli/axi_test.go
+++ b/internal/cli/axi_test.go
@@ -108,6 +108,71 @@ func TestWriteRunObjectShape(t *testing.T) {
 	}
 }
 
+func TestRunObjectRendersAwaitingAgent(t *testing.T) {
+	// Pin the clock so the parked duration is deterministic.
+	restore := nowUnix
+	nowUnix = func() int64 { return 1_000_000 }
+	defer func() { nowUnix = restore }()
+
+	parkedSince := int64(1_000_000 - 150) // 2m30s ago
+	rv := runView{
+		ID:                 "run-1",
+		Branch:             "feature/x",
+		Status:             string(types.RunRunning),
+		HeadSHA:            "abcdef1234567890",
+		AwaitingAgentSince: &parkedSince,
+		Steps: []stepView{
+			{Name: "review", Status: "awaiting_approval"},
+		},
+	}
+	out := axiDoc(runObjectField(rv))
+	if !strings.Contains(out, "awaiting_agent: parked 2m30s\n") {
+		t.Errorf("run object missing parked signal in:\n%s", out)
+	}
+	// The signal sits right after status so one read distinguishes parked.
+	if !strings.Contains(out, "status: running\n  awaiting_agent: parked 2m30s\n") {
+		t.Errorf("awaiting_agent should follow status in:\n%s", out)
+	}
+
+	// A run that is not parked omits the signal entirely.
+	rv.AwaitingAgentSince = nil
+	if out := axiDoc(runObjectField(rv)); strings.Contains(out, "awaiting_agent") {
+		t.Errorf("non-parked run should not render awaiting_agent in:\n%s", out)
+	}
+
+	// A terminal run never renders as parked even if a stale marker survives.
+	rv.AwaitingAgentSince = &parkedSince
+	rv.Status = string(types.RunCompleted)
+	if out := axiDoc(runObjectField(rv)); strings.Contains(out, "awaiting_agent") {
+		t.Errorf("terminal run should not render awaiting_agent in:\n%s", out)
+	}
+}
+
+func TestFormatParkedFor(t *testing.T) {
+	restore := nowUnix
+	nowUnix = func() int64 { return 1_000_000 }
+	defer func() { nowUnix = restore }()
+
+	tests := []struct {
+		name    string
+		agoSecs int64
+		want    string
+	}{
+		{"fresh seconds", 4, "parked 4s"},
+		{"minutes and seconds", 150, "parked 2m30s"},
+		{"hours and minutes", 3*3600 + 12*60, "parked 3h12m"},
+		{"days and hours", 2*86400 + 5*3600, "parked 2d5h"},
+		{"clock skew clamps to zero", -10, "parked 0s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatParkedFor(1_000_000 - tt.agoSecs); got != tt.want {
+				t.Errorf("formatParkedFor = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestWriteGateShape(t *testing.T) {
 	gate := stepView{
 		Name:   "review",

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -470,16 +470,18 @@ func registerHandlers(srv *ipc.Server, mgr *RunManager, d *db.DB, shutdown func(
 
 func runToInfo(d *db.DB, r *db.Run, steps []*db.StepResult) *ipc.RunInfo {
 	info := &ipc.RunInfo{
-		ID:        r.ID,
-		RepoID:    r.RepoID,
-		Branch:    r.Branch,
-		HeadSHA:   r.HeadSHA,
-		BaseSHA:   r.BaseSHA,
-		Status:    r.Status,
-		PRURL:     r.PRURL,
-		Error:     r.Error,
-		CreatedAt: r.CreatedAt,
-		UpdatedAt: r.UpdatedAt,
+		ID:                 r.ID,
+		RepoID:             r.RepoID,
+		Branch:             r.Branch,
+		HeadSHA:            r.HeadSHA,
+		BaseSHA:            r.BaseSHA,
+		Status:             r.Status,
+		PRURL:              r.PRURL,
+		Error:              r.Error,
+		AwaitingAgent:      r.AwaitingAgentSince != nil,
+		AwaitingAgentSince: r.AwaitingAgentSince,
+		CreatedAt:          r.CreatedAt,
+		UpdatedAt:          r.UpdatedAt,
 	}
 	if len(steps) > 0 {
 		info.Steps = make([]ipc.StepResultInfo, 0, len(steps))

--- a/internal/db/run.go
+++ b/internal/db/run.go
@@ -9,30 +9,37 @@ import (
 
 // Run represents a pipeline run.
 type Run struct {
-	ID              string
-	RepoID          string
-	Branch          string
-	HeadSHA         string
-	BaseSHA         string
-	Status          types.RunStatus
-	PRURL           *string
-	Error           *string
-	Intent          *string
-	IntentSource    *string
-	IntentSessionID *string
-	IntentScore     *float64
-	CreatedAt       int64
-	UpdatedAt       int64
+	ID      string
+	RepoID  string
+	Branch  string
+	HeadSHA string
+	BaseSHA string
+	Status  types.RunStatus
+	PRURL   *string
+	Error   *string
+	// AwaitingAgentSince is the unix-seconds timestamp at which the run parked
+	// at a gate awaiting the driving agent's response (an awaiting_approval or
+	// fix_review step). It is nil whenever the run is not parked: the executor
+	// sets it on gate entry and clears it the moment the agent responds (or the
+	// wait is cancelled). It is observability only and does not affect gate
+	// resolution.
+	AwaitingAgentSince *int64
+	Intent             *string
+	IntentSource       *string
+	IntentSessionID    *string
+	IntentScore        *float64
+	CreatedAt          int64
+	UpdatedAt          int64
 }
 
-const runColumns = `id, repo_id, branch, head_sha, base_sha, status, pr_url, error, intent, intent_source, intent_session_id, intent_score, created_at, updated_at`
+const runColumns = `id, repo_id, branch, head_sha, base_sha, status, pr_url, error, awaiting_agent_since, intent, intent_source, intent_session_id, intent_score, created_at, updated_at`
 
 func scanRun(row interface {
 	Scan(...any) error
 }, r *Run) error {
 	return row.Scan(
 		&r.ID, &r.RepoID, &r.Branch, &r.HeadSHA, &r.BaseSHA, &r.Status,
-		&r.PRURL, &r.Error,
+		&r.PRURL, &r.Error, &r.AwaitingAgentSince,
 		&r.Intent, &r.IntentSource, &r.IntentSessionID, &r.IntentScore,
 		&r.CreatedAt, &r.UpdatedAt,
 	)
@@ -201,6 +208,31 @@ func (d *DB) UpdateRunIntent(id string, intent RunIntent) error {
 	return nil
 }
 
+// SetRunAwaitingAgent marks a run as parked awaiting the driving agent,
+// stamping awaiting_agent_since with the current time. Called by the executor
+// when a step enters a gate (awaiting_approval / fix_review). This is a pollable
+// observability signal only; it does not change gate resolution.
+func (d *DB) SetRunAwaitingAgent(id string) error {
+	ts := now()
+	_, err := d.sql.Exec(`UPDATE runs SET awaiting_agent_since = ?, updated_at = ? WHERE id = ?`, ts, ts, id)
+	if err != nil {
+		return fmt.Errorf("set run awaiting agent: %w", err)
+	}
+	return nil
+}
+
+// ClearRunAwaitingAgent clears the awaiting-agent marker on a run. Called by the
+// executor the moment the agent responds (or the approval wait is cancelled) and
+// the run resumes, so awaiting_agent_since is non-nil exactly while a gate is
+// actually parked.
+func (d *DB) ClearRunAwaitingAgent(id string) error {
+	_, err := d.sql.Exec(`UPDATE runs SET awaiting_agent_since = NULL, updated_at = ? WHERE id = ?`, now(), id)
+	if err != nil {
+		return fmt.Errorf("clear run awaiting agent: %w", err)
+	}
+	return nil
+}
+
 // RecoverStaleRuns marks any runs stuck in pending/running status as failed
 // and fails any in-progress steps. This is called at daemon startup to clean
 // up after a previous crash. Returns the number of recovered runs.
@@ -223,9 +255,10 @@ func (d *DB) RecoverStaleRuns(errMsg string) (int, error) {
 		return 0, fmt.Errorf("recover stale steps: %w", err)
 	}
 
-	// Fail stale runs.
+	// Fail stale runs. Clear any awaiting-agent marker so a recovered (now
+	// failed) run is never reported as still parked awaiting the agent.
 	result, err := tx.Exec(
-		`UPDATE runs SET status = ?, error = ?, updated_at = ? WHERE status IN (?, ?)`,
+		`UPDATE runs SET status = ?, error = ?, awaiting_agent_since = NULL, updated_at = ? WHERE status IN (?, ?)`,
 		types.RunFailed, errMsg, ts,
 		types.RunPending, types.RunRunning,
 	)

--- a/internal/db/run_test.go
+++ b/internal/db/run_test.go
@@ -33,6 +33,76 @@ func TestRunInsertAndGet(t *testing.T) {
 	}
 }
 
+func TestRunAwaitingAgentSetAndClear(t *testing.T) {
+	d := openTestDB(t)
+	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")
+	run, err := d.InsertRun(repo.ID, "feature", "abc123", "def456")
+	if err != nil {
+		t.Fatalf("insert run: %v", err)
+	}
+
+	// A fresh run is not parked.
+	if run.AwaitingAgentSince != nil {
+		t.Fatalf("new run AwaitingAgentSince = %v, want nil", *run.AwaitingAgentSince)
+	}
+
+	// Entering a gate stamps the marker with a recent timestamp.
+	before := now()
+	if err := d.SetRunAwaitingAgent(run.ID); err != nil {
+		t.Fatalf("set awaiting agent: %v", err)
+	}
+	got, err := d.GetRun(run.ID)
+	if err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if got.AwaitingAgentSince == nil {
+		t.Fatal("AwaitingAgentSince = nil after SetRunAwaitingAgent, want a timestamp")
+	}
+	if *got.AwaitingAgentSince < before {
+		t.Errorf("AwaitingAgentSince = %d, want >= %d", *got.AwaitingAgentSince, before)
+	}
+
+	// Responding clears the marker.
+	if err := d.ClearRunAwaitingAgent(run.ID); err != nil {
+		t.Fatalf("clear awaiting agent: %v", err)
+	}
+	got, err = d.GetRun(run.ID)
+	if err != nil {
+		t.Fatalf("get run after clear: %v", err)
+	}
+	if got.AwaitingAgentSince != nil {
+		t.Errorf("AwaitingAgentSince = %d after clear, want nil", *got.AwaitingAgentSince)
+	}
+}
+
+func TestRecoverStaleRunsClearsAwaitingAgent(t *testing.T) {
+	d := openTestDB(t)
+	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")
+	run, _ := d.InsertRun(repo.ID, "feature", "abc123", "def456")
+	if err := d.UpdateRunStatus(run.ID, types.RunRunning); err != nil {
+		t.Fatalf("set running: %v", err)
+	}
+	if err := d.SetRunAwaitingAgent(run.ID); err != nil {
+		t.Fatalf("set awaiting agent: %v", err)
+	}
+
+	// Crash recovery must fail the run and drop the parked marker so a dead run
+	// is never reported as still awaiting the agent.
+	if _, err := d.RecoverStaleRuns("daemon restarted"); err != nil {
+		t.Fatalf("recover stale runs: %v", err)
+	}
+	got, err := d.GetRun(run.ID)
+	if err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if got.Status != types.RunFailed {
+		t.Errorf("status = %q, want failed", got.Status)
+	}
+	if got.AwaitingAgentSince != nil {
+		t.Errorf("AwaitingAgentSince = %d after recovery, want nil", *got.AwaitingAgentSince)
+	}
+}
+
 func TestRunGetNotFound(t *testing.T) {
 	d := openTestDB(t)
 	got, err := d.GetRun("nonexistent")

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -11,16 +11,17 @@ CREATE TABLE IF NOT EXISTS repos (
 );
 
 CREATE TABLE IF NOT EXISTS runs (
-    id         TEXT PRIMARY KEY,
-    repo_id    TEXT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
-    branch     TEXT NOT NULL,
-    head_sha   TEXT NOT NULL,
-    base_sha   TEXT NOT NULL,
-    status     TEXT NOT NULL DEFAULT 'pending',
-    pr_url     TEXT,
-    error      TEXT,
-    created_at INTEGER NOT NULL,
-    updated_at INTEGER NOT NULL
+    id                   TEXT PRIMARY KEY,
+    repo_id              TEXT NOT NULL REFERENCES repos(id) ON DELETE CASCADE,
+    branch               TEXT NOT NULL,
+    head_sha             TEXT NOT NULL,
+    base_sha             TEXT NOT NULL,
+    status               TEXT NOT NULL DEFAULT 'pending',
+    pr_url               TEXT,
+    error                TEXT,
+    awaiting_agent_since INTEGER,
+    created_at           INTEGER NOT NULL,
+    updated_at           INTEGER NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS step_results (
@@ -74,4 +75,5 @@ var migrationStatements = []string{
 	`ALTER TABLE runs ADD COLUMN intent_source TEXT`,
 	`ALTER TABLE runs ADD COLUMN intent_session_id TEXT`,
 	`ALTER TABLE runs ADD COLUMN intent_score REAL`,
+	`ALTER TABLE runs ADD COLUMN awaiting_agent_since INTEGER`,
 }

--- a/internal/e2e/axi_journey_test.go
+++ b/internal/e2e/axi_journey_test.go
@@ -176,6 +176,74 @@ func TestAxiAgentJourney(t *testing.T) {
 	}
 }
 
+// TestAxiParkedAwaitingAgentSignal proves the parked / awaiting-agent signal is
+// observable end to end: when a run stops at a gate it reports awaiting_agent
+// (with how long it has been parked) in a single `axi status` read and over IPC,
+// and the moment the agent responds the signal clears. This is observability
+// only - the drive/resolve behavior is unchanged.
+func TestAxiParkedAwaitingAgentSignal(t *testing.T) {
+	h := NewHarness(t, SetupOpts{Agent: "claude", Scenario: axiScenario(t)})
+
+	h.CommitChange("init-park", "seed.txt", "seed\n", "seed for park signal")
+	initWorktree := h.AddWorktree("init-park")
+	if out, err := h.RunInDir(initWorktree, "init"); err != nil {
+		t.Fatalf("nm init: %v\n%s", err, out)
+	}
+
+	h.CommitChange("feature/park", "feature.txt", "change\n", "add feature change")
+	fw := h.AddWorktree("feature/park")
+
+	if out, err := h.RunInDir(fw, "axi", "run", "--intent", axiIntent); err != nil {
+		t.Fatalf("axi run (expected to stop at gate, exit 0): %v\n%s", err, out)
+	}
+
+	// The run parks at the review gate. The pollable signal is set on gate entry.
+	gated := waitForStepStatus(t, h, "feature/park", types.StepReview, types.StepStatusAwaitingApproval, 60*time.Second)
+	if gated == nil {
+		t.Fatal("expected feature/park run to be awaiting approval")
+	}
+	if !gated.AwaitingAgent {
+		t.Error("RunInfo.AwaitingAgent = false while parked at gate, want true")
+	}
+	if gated.AwaitingAgentSince == nil {
+		t.Error("RunInfo.AwaitingAgentSince = nil while parked at gate, want a timestamp")
+	}
+
+	// One `axi status` read shows the run is parked awaiting the agent and for
+	// how long, distinguishing it from an actively running/fixing/ci run.
+	statusOut, err := h.RunInDir(fw, "axi", "status")
+	if err != nil {
+		t.Fatalf("axi status (parked): %v\n%s", err, statusOut)
+	}
+	if !strings.Contains(statusOut, "awaiting_agent: parked ") {
+		t.Errorf("axi status did not surface the parked signal while parked:\n%s", statusOut)
+	}
+
+	// Responding clears the signal as the run resumes and completes.
+	if out, err := h.RunInDir(fw, "axi", "respond", "--action", "approve"); err != nil {
+		t.Fatalf("axi respond approve: %v\n%s", err, out)
+	}
+	completed := h.WaitForRun("feature/park", 60*time.Second)
+	if completed.Status != types.RunCompleted {
+		t.Fatalf("feature/park run status = %s, want completed", completed.Status)
+	}
+	if completed.AwaitingAgent {
+		t.Error("RunInfo.AwaitingAgent = true after respond, want false")
+	}
+	if completed.AwaitingAgentSince != nil {
+		t.Errorf("RunInfo.AwaitingAgentSince = %d after respond, want nil", *completed.AwaitingAgentSince)
+	}
+
+	// And the cleared signal is absent from a fresh `axi status` read.
+	doneStatus, err := h.RunInDir(fw, "axi", "status")
+	if err != nil {
+		t.Fatalf("axi status (done): %v\n%s", err, doneStatus)
+	}
+	if strings.Contains(doneStatus, "awaiting_agent") {
+		t.Errorf("axi status still shows the parked signal after completion:\n%s", doneStatus)
+	}
+}
+
 // TestAxiRunPreflightGuards proves `axi run` refuses to start a run with
 // structured, actionable errors instead of silently doing the wrong thing:
 // missing intent, the default branch, and an uncommitted working tree.

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -179,17 +179,23 @@ type ShutdownResult struct {
 
 // RunInfo is the IPC representation of a pipeline run.
 type RunInfo struct {
-	ID        string           `json:"id"`
-	RepoID    string           `json:"repo_id"`
-	Branch    string           `json:"branch"`
-	HeadSHA   string           `json:"head_sha"`
-	BaseSHA   string           `json:"base_sha"`
-	Status    types.RunStatus  `json:"status"`
-	PRURL     *string          `json:"pr_url,omitempty"`
-	Error     *string          `json:"error,omitempty"`
-	Steps     []StepResultInfo `json:"steps,omitempty"`
-	CreatedAt int64            `json:"created_at"`
-	UpdatedAt int64            `json:"updated_at"`
+	ID      string          `json:"id"`
+	RepoID  string          `json:"repo_id"`
+	Branch  string          `json:"branch"`
+	HeadSHA string          `json:"head_sha"`
+	BaseSHA string          `json:"base_sha"`
+	Status  types.RunStatus `json:"status"`
+	PRURL   *string         `json:"pr_url,omitempty"`
+	Error   *string         `json:"error,omitempty"`
+	// AwaitingAgent is true while the run is parked at a gate awaiting the
+	// driving agent's response. AwaitingAgentSince is the unix-seconds time it
+	// parked, so a supervisor can read "parked for N seconds" in one call. Both
+	// are observability only and clear the moment the agent responds.
+	AwaitingAgent      bool             `json:"awaiting_agent,omitempty"`
+	AwaitingAgentSince *int64           `json:"awaiting_agent_since,omitempty"`
+	Steps              []StepResultInfo `json:"steps,omitempty"`
+	CreatedAt          int64            `json:"created_at"`
+	UpdatedAt          int64            `json:"updated_at"`
 }
 
 // StepResultInfo is the IPC representation of a step result.

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -373,6 +373,14 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 		e.waitingStep = stepName
 		e.mu.Unlock()
 
+		// Surface the park as a pollable, run-level signal so a supervisor can
+		// tell in one `axi status` read that the run is waiting for the agent
+		// to drive this gate (versus actively running/fixing/ci). Observability
+		// only: it does not change the wait below. Cleared once the wait ends.
+		if dbErr := e.db.SetRunAwaitingAgent(run.ID); dbErr != nil {
+			slog.Warn("failed to set awaiting-agent marker in db", "step", stepName, "run", run.ID, "error", dbErr)
+		}
+
 		// Step needs approval - store execution-only duration and wait for user action.
 		if dbErr := e.db.UpdateStepStatusWithDuration(sr.ID, approvalStatus, executionMS); dbErr != nil {
 			slog.Warn("failed to update step status and duration in db", "step", stepName, "status", approvalStatus, "error", dbErr)
@@ -380,6 +388,12 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 		e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(approvalStatus), outcome.Findings, diffText, "", &executionMS)
 
 		response, err := e.waitForApproval(ctx, stepName)
+		// The wait has ended (the agent responded, or it was cancelled): the run
+		// is no longer parked awaiting the agent. Clear the pollable marker
+		// before resuming so awaiting_agent_since is non-nil only while parked.
+		if dbErr := e.db.ClearRunAwaitingAgent(run.ID); dbErr != nil {
+			slog.Warn("failed to clear awaiting-agent marker in db", "step", stepName, "run", run.ID, "error", dbErr)
+		}
 		if err != nil {
 			if dbErr := e.db.FailStep(sr.ID, err.Error(), executionMS); dbErr != nil {
 				slog.Warn("failed to mark step as failed in db", "step", stepName, "error", dbErr)

--- a/internal/pipeline/executor_approval_test.go
+++ b/internal/pipeline/executor_approval_test.go
@@ -68,6 +68,60 @@ func TestExecutor_ApprovalFix(t *testing.T) {
 	}
 }
 
+func TestExecutor_AwaitingAgentMarkerSetOnGateClearedOnRespond(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	step := &adaptiveCallStep{
+		name: types.StepReview,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			return &StepOutcome{
+				NeedsApproval: true,
+				Findings:      `{"findings":[{"severity":"warning","description":"needs a human","action":"ask-user"}],"summary":"1 issue"}`,
+			}, nil
+		},
+	}
+
+	exec := NewExecutor(database, p, nil, nil, []Step{step}, nil)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- exec.Execute(context.Background(), run, repo, workDir)
+	}()
+
+	// Entering the gate flips the pollable parked marker on.
+	waitForStepStatus(t, database, run.ID, types.StepReview, types.StepStatusAwaitingApproval)
+	parked, err := database.GetRun(run.ID)
+	if err != nil {
+		t.Fatalf("get run while parked: %v", err)
+	}
+	if parked.AwaitingAgentSince == nil {
+		t.Fatal("AwaitingAgentSince = nil while parked at gate, want a timestamp")
+	}
+
+	// Responding clears it as the run resumes, so the marker is non-nil only
+	// while the run is actually parked awaiting the agent.
+	if err := exec.Respond(types.StepReview, types.ActionApprove, nil); err != nil {
+		t.Fatalf("respond: %v", err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("executor error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("executor timed out")
+	}
+
+	resumed, err := database.GetRun(run.ID)
+	if err != nil {
+		t.Fatalf("get run after respond: %v", err)
+	}
+	if resumed.AwaitingAgentSince != nil {
+		t.Errorf("AwaitingAgentSince = %d after respond, want nil", *resumed.AwaitingAgentSince)
+	}
+}
+
 func TestExecutor_TracksApprovalAndUserFixTelemetry(t *testing.T) {
 	database, p, run, repo := setupTest(t)
 	workDir := t.TempDir()

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -129,6 +129,10 @@ Run the pipeline and decide on its findings as they come up:
    return for a while. That is normal; allow a long timeout and do not cancel
    or re-issue the command because it seems slow. To check progress without
    disturbing the run, use ` + "`no-mistakes axi status`" + ` from a separate call.
+   When that status output includes ` + "`awaiting_agent: parked <duration>`" + ` under the run,
+   the run is parked at an approval or fix-review gate and waiting for you to
+   send ` + "`axi respond`" + `. The field is observability only: it does not change
+   gate resolution, auto-resume the run, or make ` + "`--yes`" + ` the default.
 2. If the output contains a ` + "`gate:`" + ` object, the pipeline is waiting on you.
    Read its ` + "`findings`" + ` table. Each finding has an ` + "`id`" + `, ` + "`severity`" + `,
    ` + "`file`" + `, ` + "`description`" + `, and an ` + "`action`" + ` that tells you how the
@@ -234,6 +238,7 @@ no-mistakes axi abort --run <id>   # cancel a specific run by id (works outside 
 ## Reading the output
 
 - Output is TOON: ` + "`key: value`" + ` pairs, ` + "`name[N]{cols}:`" + ` tables, and ` + "`help[N]:`" + ` hints.
+- A non-terminal run object may include ` + "`awaiting_agent: parked <duration>`" + ` immediately after ` + "`status`" + `; that means the run is parked at a gate awaiting your ` + "`axi respond`" + `.
 - The ` + "`help`" + ` list at the bottom of most responses tells you the next commands to run.
 - Errors are printed as ` + "`error: ...`" + ` on stdout with a ` + "`help`" + ` list; act on the suggestion.
 - Exit codes: ` + "`0`" + ` success, no-op, or normal decision gates, ` + "`1`" + ` failed or cancelled final outcomes, ` + "`2`" + ` bad usage.

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -90,6 +90,10 @@ Run the pipeline and decide on its findings as they come up:
    return for a while. That is normal; allow a long timeout and do not cancel
    or re-issue the command because it seems slow. To check progress without
    disturbing the run, use `no-mistakes axi status` from a separate call.
+   When that status output includes `awaiting_agent: parked <duration>` under the run,
+   the run is parked at an approval or fix-review gate and waiting for you to
+   send `axi respond`. The field is observability only: it does not change
+   gate resolution, auto-resume the run, or make `--yes` the default.
 2. If the output contains a `gate:` object, the pipeline is waiting on you.
    Read its `findings` table. Each finding has an `id`, `severity`,
    `file`, `description`, and an `action` that tells you how the
@@ -195,6 +199,7 @@ no-mistakes axi abort --run <id>   # cancel a specific run by id (works outside 
 ## Reading the output
 
 - Output is TOON: `key: value` pairs, `name[N]{cols}:` tables, and `help[N]:` hints.
+- A non-terminal run object may include `awaiting_agent: parked <duration>` immediately after `status`; that means the run is parked at a gate awaiting your `axi respond`.
 - The `help` list at the bottom of most responses tells you the next commands to run.
 - Errors are printed as `error: ...` on stdout with a `help` list; act on the suggestion.
 - Exit codes: `0` success, no-op, or normal decision gates, `1` failed or cancelled final outcomes, `2` bad usage.


### PR DESCRIPTION
## Intent

Add a pollable 'parked / awaiting-agent' observability signal to a no-mistakes run so a supervising agent (firstmate) can tell in ONE cheap `axi status` read whether a run is parked waiting for the agent to drive a findings gate (awaiting_approval / fix_review) versus actively working (running/fixing/ci). This is the observability half of the gate-park-deadlock fix (recommendation B2 from a prior design investigation).

Deliberate decisions and tradeoffs (so the diff is not misread):
- OBSERVABILITY ONLY by design: it intentionally does NOT change gate resolution, does NOT auto-resume, and does NOT make --yes the default. Behavior is unchanged; it only exposes state that already existed internally. The executor's actual wait/resolve logic is untouched.
- Persist the signal as a nullable runs.awaiting_agent_since column (unix seconds) on db.Run, rather than in-memory executor state, because axi status reads from the shared SQLite DB; persisting keeps the signal correct across the stateless RunInfo rebuild, daemon restart, and poll. Invariant: awaiting_agent_since is non-nil IFF a step is actually parked at a gate. The executor sets it via SetRunAwaitingAgent right before the step status flips to the gate state (so pollers never see a gate without the marker), and clears it via ClearRunAwaitingAgent the moment waitForApproval returns - covering BOTH the agent's respond and a cancel. RecoverStaleRuns also nulls it so a crash-recovered (failed) run is never reported as still parked.
- Surface AwaitingAgent bool + AwaitingAgentSince *int64 on ipc.RunInfo (derived in runToInfo). Render 'awaiting_agent: parked <duration>' right after status in the axi status run object, gated on non-nil marker AND non-terminal status, so a fresh park ('parked 4s') is distinguishable from a stalled one ('parked 18m20s'). Duration uses an injectable nowUnix package var so the parked-duration render is deterministic in tests.
- Added the column via an additive ALTER TABLE migration following the existing intent-column pattern (named SELECT projection means physical column order is irrelevant).
- Tests: db set/clear + recovery, executor flips-true-on-gate/clears-on-respond, cli formatter boundaries + render shape (present while parked, absent when not parked and when terminal), and e2e TestAxiParkedAwaitingAgentSignal driving run->gate->status->respond->cleared.

## What Changed

- Added a persisted `awaiting_agent_since` run marker that is set while approval/fix-review gates are parked and cleared on response, cancellation, or stale-run recovery.
- Exposed `AwaitingAgent` state through IPC and rendered `awaiting_agent: parked <duration>` in `axi status` for non-terminal parked runs.
- Documented the parked/awaiting-agent signal in the agent skill and docs, with coverage across DB, executor, CLI rendering, and e2e status flow.

## Risk Assessment

✅ Low: The change is additive and well-scoped across DB persistence, IPC, rendering, and gate lifecycle handling, with no material correctness risks found in the reviewed diff.

## Testing

Inspected the parked-signal diff, ran targeted DB/executor/CLI tests, the dedicated AXI e2e journey, and the full race-enabled suite; after an initial hand-rolled evidence harness timed out before exercising product behavior, I generated the disposable-repo CLI transcript through the repo e2e harness, and all product verification passed.

- Evidence: [CLI transcript for parked signal journey](https://github.com/kunchenguid/no-mistakes/blob/084d7de93477a191f0bd0a12df0bb5d7add76d8d/.no-mistakes/evidence/fm/nm-park-signal-p7/parked_signal_cli_transcript.md)
- Evidence: [AXI status while parked](https://github.com/kunchenguid/no-mistakes/blob/084d7de93477a191f0bd0a12df0bb5d7add76d8d/.no-mistakes/evidence/fm/nm-park-signal-p7/axi_status_parked.toon)
- Evidence: [AXI status after approval](https://github.com/kunchenguid/no-mistakes/blob/084d7de93477a191f0bd0a12df0bb5d7add76d8d/.no-mistakes/evidence/fm/nm-park-signal-p7/axi_status_after_respond.toon)
- Evidence: [AXI run gate output](https://github.com/kunchenguid/no-mistakes/blob/084d7de93477a191f0bd0a12df0bb5d7add76d8d/.no-mistakes/evidence/fm/nm-park-signal-p7/axi_run_gate.toon)
- Evidence: [AXI approve output](https://github.com/kunchenguid/no-mistakes/blob/084d7de93477a191f0bd0a12df0bb5d7add76d8d/.no-mistakes/evidence/fm/nm-park-signal-p7/axi_respond_approve.toon)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/db -run 'TestRunAwaitingAgentSetAndClear|TestRecoverStaleRunsClearsAwaitingAgent' -count=1`
- `go test ./internal/pipeline -run '^TestExecutor_AwaitingAgentMarkerSetOnGateClearedOnRespond$' -count=1`
- `go test ./internal/cli -run 'TestRunObjectRendersAwaitingAgent|TestFormatParkedFor' -count=1`
- `go test -tags=e2e ./internal/e2e -run '^TestAxiParkedAwaitingAgentSignal$' -count=1 -timeout 300s -v`
- `go test -race ./...`
- <code>`NM_EVIDENCE_DIR=&#34;$PWD/.no-mistakes/evidence/fm/nm-park-signal-p7&#34; go test -tags=e2e ./internal/e2e -run &#39;^TestEvidenceAxiParkedAwaitingAgentSignal$&#39; -count=1 -timeout 300s -v` with a temporary evidence-only test that was removed afterward</code>
- <code>`git status --short` to confirm only the intended evidence directory remained</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
