### PR TITLE
fix(agent): align OpenCode format with v1.17.x, add agent_model config and install-local.sh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,28 @@ This builds with version info and replaces `~/.no-mistakes/bin/no-mistakes`
 (the real path behind the `/usr/local/bin/no-mistakes` symlink), backing up
 the old binary as `no-mistakes.bak` in the same directory.
 
+**Per-step model overrides**
+
+`agent_model` lets you pin a specific model for individual pipeline steps.
+The YAML key is a two-level map: `agent_name -> step_name -> model_string`.
+
+```yaml
+agent_model:
+  opencode:
+    review:   "github-copilot/claude-sonnet-4.6"
+    document: "github-copilot/claude-sonnet-4.6"
+    test:     "opencode/gpt-5.1"
+```
+
+When the step runs, the model string is sent as `info.model` in the agent
+request body. Supported step names: `review`, `document`, `test`.
+The config can be set globally (`~/.no-mistakes/config.yaml`) or per-repo
+(`.no-mistakes.yaml`); repo values override global at the per-agent-per-step
+granularity (see `config.mergeAgentModel` in `internal/config/config.go`).
+The agent name key must match the agent configured for the repo
+(e.g. `opencode` when `agent: opencode`). Steps that don't have an entry
+in the map send no model override.
+
 **Project Layout**
 
 - `cmd/no-mistakes`: process entrypoint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,18 @@ Safest local verification sequence after non-trivial changes:
 - `make e2e` when touching agent integrations, the e2e harness, or recorded fixtures
 - `go build -o ./bin/no-mistakes ./cmd/no-mistakes`
 
+**Local install**
+
+Install the current checkout system-wide:
+
+```sh
+./scripts/install-local.sh
+```
+
+This builds with version info and replaces `~/.no-mistakes/bin/no-mistakes`
+(the real path behind the `/usr/local/bin/no-mistakes` symlink), backing up
+the old binary as `no-mistakes.bak` in the same directory.
+
 **Project Layout**
 
 - `cmd/no-mistakes`: process entrypoint

--- a/README.md
+++ b/README.md
@@ -102,6 +102,25 @@ Once every check is green, the gate forwards your branch to the configured push 
 Prefer to let your coding agent drive the same flow headlessly?
 Use `/no-mistakes` (see below).
 
+## Per-step model overrides
+
+Override the model used by OpenCode (or other agents) for specific pipeline steps.
+Set `agent_model` in `~/.no-mistakes/config.yaml` (global) or `.no-mistakes.yaml` (per-repo);
+repo values override global at the per-agent-per-step level.
+
+```yaml
+agent_model:
+  opencode:
+    review:   "github-copilot/claude-sonnet-4.6"
+    document: "github-copilot/claude-sonnet-4.6"
+    test:     "opencode/gpt-5.1"
+```
+
+The first-level key is the agent name (`opencode`, `claude`, `codex`, etc.),
+the second-level keys are pipeline step names (`review`, `document`, `test`).
+When the pipeline runs a step for the configured agent, the model string is sent
+as `info.model` in the agent request.
+
 ## Three ways to trigger the gate
 
 Every change runs through the same pipeline. Pick the entry point that fits how you're working when the change is ready:

--- a/README.md
+++ b/README.md
@@ -132,6 +132,16 @@ See `Makefile` for the full target list.
 
 `make e2e-record` overwrites `internal/e2e/fixtures/` from the real `claude`, `codex`, and `opencode` CLIs, spends real API quota, and should be reviewed before committing.
 
+### Local install
+
+```sh
+./scripts/install-local.sh
+```
+
+Builds from the current checkout and installs the binary to `~/.no-mistakes/bin/no-mistakes`
+(the target that `/usr/local/bin/no-mistakes` symlinks to). Existing binary is backed up
+as `no-mistakes.bak` in the same directory.
+
 ## Star History
 
 <a href="https://www.star-history.com/?repos=kunchenguid%2Fno-mistakes&type=date&legend=top-left">

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -25,6 +25,7 @@ type RunOpts struct {
 	CWD        string
 	JSONSchema json.RawMessage   // structured output schema (optional)
 	OnChunk    func(text string) // streaming text callback (optional)
+	Model      string            // optional per-step model override (opencode info.model)
 }
 
 // Result holds the output of an agent invocation.

--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -76,7 +76,7 @@ func (a *opencodeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, err
 	defer msgCancel()
 	msgCh := make(chan messageResult, 1)
 	go func() {
-		resp, err := a.sendMessage(msgCtx, baseURL, sessionID, prompt, opts.JSONSchema)
+		resp, err := a.sendMessage(msgCtx, baseURL, sessionID, prompt, opts.JSONSchema, opts.Model)
 		msgCh <- messageResult{resp: resp, err: err}
 	}()
 

--- a/internal/agent/opencode_http.go
+++ b/internal/agent/opencode_http.go
@@ -81,17 +81,23 @@ func (a *opencodeAgent) connectEventStream(ctx context.Context, baseURL string) 
 	return resp.Body, nil
 }
 
-func (a *opencodeAgent) sendMessage(ctx context.Context, baseURL, sessionID, prompt string, schema json.RawMessage) (*opencodeMessageResponse, error) {
+func (a *opencodeAgent) sendMessage(ctx context.Context, baseURL, sessionID, prompt string, schema json.RawMessage, model string) (*opencodeMessageResponse, error) {
 	body := map[string]any{
 		"role":  "user",
 		"parts": []map[string]string{{"type": "text", "text": prompt}},
 	}
-	if len(schema) > 0 {
-		body["format"] = map[string]any{
-			"type":       "json_schema",
-			"schema":     json.RawMessage(schema),
-			"retryCount": 1,
+	if len(schema) > 0 || model != "" {
+		info := map[string]any{}
+		if len(schema) > 0 {
+			info["format"] = map[string]any{
+				"type":   "json_schema",
+				"schema": json.RawMessage(schema),
+			}
 		}
+		if model != "" {
+			info["model"] = model
+		}
+		body["info"] = info
 	}
 
 	respBytes, err := doJSON(ctx, http.MethodPost, baseURL+"/session/"+sessionID+"/message", nil, body)

--- a/internal/agent/opencode_test.go
+++ b/internal/agent/opencode_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -408,6 +409,182 @@ func TestOpencodeAgent_NoSchema(t *testing.T) {
 }
 
 // TestOpencodeAgent_FinalAnswerPreferred tests that final_answer phase text is preferred.
+// TestOpencodeAgent_RequestBodyShape verifies the POST /session/{id}/message
+// body uses info.format (not root format), omits retryCount, and sets
+// info.model when RunOpts.Model is non-empty.
+func TestOpencodeAgent_RequestBodyShape(t *testing.T) {
+	t.Run("schema sets info.format, no root format", func(t *testing.T) {
+		var requestBody []byte
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/session/test-session-456/message" && r.Method == http.MethodPost {
+				var err error
+				requestBody, err = io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatalf("failed to read request body: %v", err)
+				}
+			}
+			switch {
+			case r.URL.Path == "/session" && r.Method == http.MethodPost:
+				fmt.Fprint(w, `{"id":"test-session-456"}`)
+			case r.URL.Path == "/global/event" && r.Method == http.MethodGet:
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, "data: {\"payload\":{\"type\":\"message.part.delta\",\"properties\":{\"sessionID\":\"test-session-456\",\"field\":\"text\",\"partID\":\"p1\",\"delta\":\"ok\"}}}\n\n")
+				fmt.Fprint(w, "data: {\"payload\":{\"type\":\"session.idle\"}}\n\n")
+			case r.URL.Path == "/session/test-session-456/message" && r.Method == http.MethodPost:
+				fmt.Fprint(w, `{"info":{"id":"msg1","role":"assistant","structured":{"ok":true}},"parts":[{"type":"text","text":"ok"}]}`)
+			case r.URL.Path == "/session/test-session-456" && r.Method == http.MethodDelete:
+				w.WriteHeader(http.StatusOK)
+			default:
+				w.WriteHeader(http.StatusOK)
+			}
+		}))
+		defer server.Close()
+
+		a := &opencodeAgent{
+			bin:    "opencode",
+			server: &managedServer{port: mustParsePort(server.URL)},
+		}
+		_, err := a.Run(context.Background(), RunOpts{
+			Prompt:     "test",
+			CWD:        t.TempDir(),
+			JSONSchema: json.RawMessage(`{"type":"object"}`),
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var body map[string]any
+		if err := json.Unmarshal(requestBody, &body); err != nil {
+			t.Fatalf("failed to parse request body: %v", err)
+		}
+
+		// info.format must exist
+		info, ok := body["info"].(map[string]any)
+		if !ok {
+			t.Fatal("expected body.info to be present")
+		}
+		format, ok := info["format"].(map[string]any)
+		if !ok {
+			t.Fatal("expected body.info.format to be present")
+		}
+		if format["type"] != "json_schema" {
+			t.Errorf("expected format.type = json_schema, got %v", format["type"])
+		}
+		// retryCount must NOT be present
+		if _, ok := format["retryCount"]; ok {
+			t.Error("retryCount should not be present in format")
+		}
+		// root format must NOT be present
+		if _, ok := body["format"]; ok {
+			t.Error("root body.format should not be present")
+		}
+	})
+
+	t.Run("model sets info.model", func(t *testing.T) {
+		var requestBody []byte
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/session/test-session-789/message" && r.Method == http.MethodPost {
+				var err error
+				requestBody, err = io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatalf("failed to read request body: %v", err)
+				}
+			}
+			switch {
+			case r.URL.Path == "/session" && r.Method == http.MethodPost:
+				fmt.Fprint(w, `{"id":"test-session-789"}`)
+			case r.URL.Path == "/global/event" && r.Method == http.MethodGet:
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, "data: {\"payload\":{\"type\":\"message.part.delta\",\"properties\":{\"sessionID\":\"test-session-789\",\"field\":\"text\",\"partID\":\"p1\",\"delta\":\"done\"}}}\n\n")
+				fmt.Fprint(w, "data: {\"payload\":{\"type\":\"session.idle\"}}\n\n")
+			case r.URL.Path == "/session/test-session-789/message" && r.Method == http.MethodPost:
+				fmt.Fprint(w, `{"info":{"id":"msg1","role":"assistant"},"parts":[{"type":"text","text":"done"}]}`)
+			case r.URL.Path == "/session/test-session-789" && r.Method == http.MethodDelete:
+				w.WriteHeader(http.StatusOK)
+			default:
+				w.WriteHeader(http.StatusOK)
+			}
+		}))
+		defer server.Close()
+
+		a := &opencodeAgent{
+			bin:    "opencode",
+			server: &managedServer{port: mustParsePort(server.URL)},
+		}
+		_, err := a.Run(context.Background(), RunOpts{
+			Prompt: "test",
+			CWD:    t.TempDir(),
+			Model:  "github-copilot/claude-sonnet-4.6",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var body map[string]any
+		if err := json.Unmarshal(requestBody, &body); err != nil {
+			t.Fatalf("failed to parse request body: %v", err)
+		}
+		info, ok := body["info"].(map[string]any)
+		if !ok {
+			t.Fatal("expected body.info to be present")
+		}
+		if info["model"] != "github-copilot/claude-sonnet-4.6" {
+			t.Errorf("expected info.model = %q, got %v", "github-copilot/claude-sonnet-4.6", info["model"])
+		}
+	})
+
+	t.Run("no schema, no model: no info field", func(t *testing.T) {
+		var requestBody []byte
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/session/s1/message" && r.Method == http.MethodPost {
+				var err error
+				requestBody, err = io.ReadAll(r.Body)
+				if err != nil {
+					t.Fatalf("failed to read request body: %v", err)
+				}
+			}
+			switch {
+			case r.URL.Path == "/session" && r.Method == http.MethodPost:
+				fmt.Fprint(w, `{"id":"s1"}`)
+			case r.URL.Path == "/global/event" && r.Method == http.MethodGet:
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprint(w, "data: {\"payload\":{\"type\":\"message.part.delta\",\"properties\":{\"sessionID\":\"s1\",\"field\":\"text\",\"partID\":\"p1\",\"delta\":\"ok\"}}}\n\n")
+				fmt.Fprint(w, "data: {\"payload\":{\"type\":\"session.idle\"}}\n\n")
+			case r.URL.Path == "/session/s1/message" && r.Method == http.MethodPost:
+				fmt.Fprint(w, `{"info":{"id":"msg1","role":"assistant"},"parts":[{"type":"text","text":"ok"}]}`)
+			case r.URL.Path == "/session/s1" && r.Method == http.MethodDelete:
+				w.WriteHeader(http.StatusOK)
+			default:
+				w.WriteHeader(http.StatusOK)
+			}
+		}))
+		defer server.Close()
+
+		a := &opencodeAgent{
+			bin:    "opencode",
+			server: &managedServer{port: mustParsePort(server.URL)},
+		}
+		_, err := a.Run(context.Background(), RunOpts{
+			Prompt: "hello",
+			CWD:    t.TempDir(),
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var body map[string]any
+		if err := json.Unmarshal(requestBody, &body); err != nil {
+			t.Fatalf("failed to parse request body: %v", err)
+		}
+		if _, ok := body["info"]; ok {
+			t.Error("body.info should not be present when neither schema nor model are set")
+		}
+	})
+}
+
 func TestOpencodeAgent_FinalAnswerPreferred(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,13 +39,14 @@ const (
 
 // GlobalConfig represents ~/.no-mistakes/config.yaml.
 type GlobalConfig struct {
-	Agent                types.AgentName     `yaml:"agent"`
-	ACPXPath             string              `yaml:"acpx_path"`
-	ACPRegistryOverrides map[string]string   `yaml:"acp_registry_overrides"`
-	AgentPathOverride    map[string]string   `yaml:"agent_path_override"`
-	AgentArgsOverride    map[string][]string `yaml:"agent_args_override"`
-	CITimeout            time.Duration       `yaml:"-"`
-	LogLevel             string              `yaml:"log_level"`
+	Agent                types.AgentName              `yaml:"agent"`
+	ACPXPath             string                       `yaml:"acpx_path"`
+	ACPRegistryOverrides map[string]string            `yaml:"acp_registry_overrides"`
+	AgentPathOverride    map[string]string            `yaml:"agent_path_override"`
+	AgentArgsOverride    map[string][]string          `yaml:"agent_args_override"`
+	AgentModel           map[string]map[string]string `yaml:"agent_model"`
+	CITimeout            time.Duration                `yaml:"-"`
+	LogLevel             string                       `yaml:"log_level"`
 	AutoFix              AutoFixRaw
 	Intent               IntentRaw
 	Test                 TestRaw
@@ -53,24 +54,26 @@ type GlobalConfig struct {
 
 // globalConfigRaw is the on-disk YAML representation with duration as string.
 type globalConfigRaw struct {
-	Agent                types.AgentName     `yaml:"agent"`
-	ACPXPath             string              `yaml:"acpx_path"`
-	ACPRegistryOverrides map[string]string   `yaml:"acp_registry_overrides"`
-	AgentPathOverride    map[string]string   `yaml:"agent_path_override"`
-	AgentArgsOverride    map[string][]string `yaml:"agent_args_override"`
-	CITimeout            string              `yaml:"ci_timeout"`
-	BabysitTimeout       string              `yaml:"babysit_timeout"`
-	LogLevel             string              `yaml:"log_level"`
-	AutoFix              AutoFixRaw          `yaml:"auto_fix"`
-	Intent               IntentRaw           `yaml:"intent"`
-	Test                 TestRaw             `yaml:"test"`
+	Agent                types.AgentName              `yaml:"agent"`
+	ACPXPath             string                       `yaml:"acpx_path"`
+	ACPRegistryOverrides map[string]string            `yaml:"acp_registry_overrides"`
+	AgentPathOverride    map[string]string            `yaml:"agent_path_override"`
+	AgentArgsOverride    map[string][]string          `yaml:"agent_args_override"`
+	AgentModel           map[string]map[string]string `yaml:"agent_model"`
+	CITimeout            string                       `yaml:"ci_timeout"`
+	BabysitTimeout       string                       `yaml:"babysit_timeout"`
+	LogLevel             string                       `yaml:"log_level"`
+	AutoFix              AutoFixRaw                   `yaml:"auto_fix"`
+	Intent               IntentRaw                    `yaml:"intent"`
+	Test                 TestRaw                      `yaml:"test"`
 }
 
 // RepoConfig represents .no-mistakes.yaml in a repo root.
 type RepoConfig struct {
-	Agent          types.AgentName `yaml:"agent"`
-	Commands       Commands        `yaml:"commands"`
-	IgnorePatterns []string        `yaml:"ignore_patterns"`
+	Agent          types.AgentName              `yaml:"agent"`
+	AgentModel     map[string]map[string]string `yaml:"agent_model"`
+	Commands       Commands                     `yaml:"commands"`
+	IgnorePatterns []string                     `yaml:"ignore_patterns"`
 	// AllowRepoCommands opts in to honoring the code-executing selection
 	// fields (commands.{test,lint,format} and agent) from a contributor's
 	// pushed branch instead of the trusted default-branch copy. It is read
@@ -120,6 +123,7 @@ type Config struct {
 	ACPRegistryOverrides map[string]string
 	AgentPathOverride    map[string]string
 	AgentArgsOverride    map[string][]string
+	AgentModel           map[string]map[string]string
 	CITimeout            time.Duration
 	LogLevel             string
 	Commands             Commands
@@ -495,6 +499,9 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 		}
 		cfg.AgentArgsOverride = raw.AgentArgsOverride
 	}
+	if raw.AgentModel != nil {
+		cfg.AgentModel = raw.AgentModel
+	}
 	timeoutValue := raw.CITimeout
 	if timeoutValue == "" {
 		timeoutValue = raw.BabysitTimeout
@@ -759,6 +766,7 @@ func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 		ACPRegistryOverrides: global.ACPRegistryOverrides,
 		AgentPathOverride:    global.AgentPathOverride,
 		AgentArgsOverride:    global.AgentArgsOverride,
+		AgentModel:           mergeAgentModel(global.AgentModel, repo.AgentModel),
 		CITimeout:            global.CITimeout,
 		LogLevel:             global.LogLevel,
 		Commands:             repo.Commands,
@@ -773,4 +781,37 @@ func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 	}
 
 	return cfg
+}
+
+// mergeAgentModel merges repo agent_model over global. Repo entries override
+// global at the per-agent-per-step granularity.
+func mergeAgentModel(global, repo map[string]map[string]string) map[string]map[string]string {
+	if repo == nil {
+		return global
+	}
+	if global == nil {
+		return repo
+	}
+	out := make(map[string]map[string]string, len(global))
+	for agentKey, steps := range global {
+		stepCopy := make(map[string]string, len(steps))
+		for k, v := range steps {
+			stepCopy[k] = v
+		}
+		out[agentKey] = stepCopy
+	}
+	for agentKey, steps := range repo {
+		if existing, ok := out[agentKey]; ok {
+			for stepKey, model := range steps {
+				existing[stepKey] = model
+			}
+		} else {
+			stepCopy := make(map[string]string, len(steps))
+			for k, v := range steps {
+				stepCopy[k] = v
+			}
+			out[agentKey] = stepCopy
+		}
+	}
+	return out
 }

--- a/internal/config/config_global_test.go
+++ b/internal/config/config_global_test.go
@@ -376,6 +376,41 @@ func TestLoadGlobal_AutoFixFromFile(t *testing.T) {
 	}
 }
 
+func TestLoadGlobal_AgentModel(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	data := `agent_model:
+  opencode:
+    review: "github-copilot/claude-sonnet-4.6"
+    document: "github-copilot/claude-sonnet-4.6"
+    test: "opencode/gpt-5.1"
+`
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadGlobal(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.AgentModel == nil {
+		t.Fatal("agent_model should be loaded")
+	}
+	opencode, ok := cfg.AgentModel["opencode"]
+	if !ok {
+		t.Fatal("expected opencode key in agent_model")
+	}
+	if opencode["review"] != "github-copilot/claude-sonnet-4.6" {
+		t.Errorf("review model = %q", opencode["review"])
+	}
+	if opencode["document"] != "github-copilot/claude-sonnet-4.6" {
+		t.Errorf("document model = %q", opencode["document"])
+	}
+	if opencode["test"] != "opencode/gpt-5.1" {
+		t.Errorf("test model = %q", opencode["test"])
+	}
+}
+
 func TestLoadGlobal_AutoFixPartial(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")

--- a/internal/config/config_merge_test.go
+++ b/internal/config/config_merge_test.go
@@ -152,6 +152,57 @@ func TestMerge_AutoFixRepoOverridesGlobal(t *testing.T) {
 	}
 }
 
+func TestMerge_AgentModel(t *testing.T) {
+	t.Run("global only", func(t *testing.T) {
+		global := &GlobalConfig{
+			Agent:      types.AgentClaude,
+			CITimeout:  4 * time.Hour,
+			LogLevel:   "info",
+			AgentModel: map[string]map[string]string{"opencode": {"review": "m1"}},
+		}
+		cfg := Merge(global, &RepoConfig{})
+		if cfg.AgentModel == nil {
+			t.Fatal("agent_model should be present")
+		}
+		if cfg.AgentModel["opencode"]["review"] != "m1" {
+			t.Errorf("review model = %q", cfg.AgentModel["opencode"]["review"])
+		}
+	})
+	t.Run("repo overrides global", func(t *testing.T) {
+		global := &GlobalConfig{
+			Agent:      types.AgentOpenCode,
+			CITimeout:  4 * time.Hour,
+			LogLevel:   "info",
+			AgentModel: map[string]map[string]string{"opencode": {"review": "global-model"}},
+		}
+		repo := &RepoConfig{
+			AgentModel: map[string]map[string]string{"opencode": {"review": "repo-model"}},
+		}
+		cfg := Merge(global, repo)
+		if cfg.AgentModel["opencode"]["review"] != "repo-model" {
+			t.Errorf("review model = %q, want repo-model", cfg.AgentModel["opencode"]["review"])
+		}
+	})
+	t.Run("repo adds new agent key", func(t *testing.T) {
+		global := &GlobalConfig{
+			Agent:      types.AgentOpenCode,
+			CITimeout:  4 * time.Hour,
+			LogLevel:   "info",
+			AgentModel: map[string]map[string]string{"opencode": {"review": "m1"}},
+		}
+		repo := &RepoConfig{
+			AgentModel: map[string]map[string]string{"codex": {"test": "m2"}},
+		}
+		cfg := Merge(global, repo)
+		if cfg.AgentModel["opencode"]["review"] != "m1" {
+			t.Errorf("opencode.review = %q", cfg.AgentModel["opencode"]["review"])
+		}
+		if cfg.AgentModel["codex"]["test"] != "m2" {
+			t.Errorf("codex.test = %q", cfg.AgentModel["codex"]["test"])
+		}
+	})
+}
+
 func TestAutoFixLimit(t *testing.T) {
 	cfg := &Config{
 		AutoFix: AutoFix{Lint: 5, Test: 2, Review: 0, Document: 1, CI: 3, Rebase: 4},

--- a/internal/pipeline/steps/common.go
+++ b/internal/pipeline/steps/common.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"encoding/json"
 
+	"github.com/kunchenguid/no-mistakes/internal/config"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
@@ -120,6 +121,20 @@ var reviewFindingsSchema = json.RawMessage(`{
 	},
 	"required": ["findings", "risk_level", "risk_rationale"]
 }`)
+
+// lookupAgentModel returns the per-step model override for the configured
+// agent, or empty string when none is set.
+func lookupAgentModel(cfg *config.Config, stepName string) string {
+	if cfg.AgentModel == nil {
+		return ""
+	}
+	agentName := string(cfg.Agent)
+	steps, ok := cfg.AgentModel[agentName]
+	if !ok {
+		return ""
+	}
+	return steps[stepName]
+}
 
 // AllSteps returns the fixed pipeline step sequence.
 // When NM_DEMO=1, it returns mock steps for demo recordings.

--- a/internal/pipeline/steps/common_fix.go
+++ b/internal/pipeline/steps/common_fix.go
@@ -19,6 +19,7 @@ type fixExecutionOptions struct {
 	Prompt                  string
 	ErrorPrefix             string
 	FallbackSummary         string
+	Model                   string
 	AfterAgentRun           func(*agent.Result) error
 }
 
@@ -116,6 +117,7 @@ func executeFixMode(sctx *pipeline.StepContext, stepName types.StepName, opts fi
 		CWD:        sctx.WorkDir,
 		JSONSchema: commitSummarySchema,
 		OnChunk:    sctx.LogChunk,
+		Model:      opts.Model,
 	})
 	if err != nil {
 		return "", fmt.Errorf("%s: %w", opts.ErrorPrefix, err)

--- a/internal/pipeline/steps/document.go
+++ b/internal/pipeline/steps/document.go
@@ -37,6 +37,8 @@ func (s *DocumentStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcom
 
 	sctx.Log("updating documentation...")
 
+	model := lookupAgentModel(sctx.Config, string(types.StepDocument))
+
 	historySection := executionContextPromptSection() + roundHistoryPromptSection(sctx) + userIntentPromptSection(sctx)
 	prompt := fmt.Sprintf(
 		`Bring the project documentation fully in sync with the code changes. Discover every documentation gap, fix all of them yourself, verify your edits, and report only what you could not resolve.
@@ -96,6 +98,7 @@ Previous documentation findings to address:
 		CWD:        sctx.WorkDir,
 		JSONSchema: findingsSchema,
 		OnChunk:    sctx.LogChunk,
+		Model:      model,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("agent document: %w", err)

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -30,6 +30,8 @@ func (s *ReviewStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome,
 		reviewScope = fmt.Sprintf("current worktree and HEAD changes relative to base commit %s (starting head %s)", baseSHA, sctx.Run.HeadSHA)
 	}
 
+	model := lookupAgentModel(sctx.Config, string(types.StepReview))
+
 	// In fix mode, ask the agent to fix issues first
 	var fixSummary string
 	if sctx.Fixing {
@@ -77,6 +79,7 @@ Previous review findings to address:
 			Prompt:                  fixPrompt,
 			ErrorPrefix:             "agent fix",
 			FallbackSummary:         "address review findings",
+			Model:                   model,
 		})
 		if err != nil {
 			return nil, err
@@ -184,6 +187,7 @@ Risk assessment (after listing all findings):
 		CWD:        sctx.WorkDir,
 		JSONSchema: reviewFindingsSchema,
 		OnChunk:    sctx.LogChunk,
+		Model:      model,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("agent review: %w", err)

--- a/internal/pipeline/steps/test.go
+++ b/internal/pipeline/steps/test.go
@@ -32,6 +32,8 @@ func (s *TestStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 	ctx := sctx.Ctx
 	baseSHA := resolveBranchBaseSHA(ctx, sctx.WorkDir, sctx.Run.BaseSHA, sctx.Repo.DefaultBranch)
 
+	model := lookupAgentModel(sctx.Config, string(types.StepTest))
+
 	// In fix mode, ask agent to fix test failures first
 	var newTestsFromFix []string
 	var fixSummary string
@@ -71,6 +73,7 @@ Previous test findings to address:
 			Prompt:          fixPrompt,
 			ErrorPrefix:     "agent fix tests",
 			FallbackSummary: "fix test failures",
+			Model:           model,
 			AfterAgentRun: func(*agent.Result) error {
 				newTestsFromFix = detectNewTestFiles(ctx, sctx.WorkDir)
 				return nil
@@ -140,6 +143,7 @@ Previous test findings to address:
 			configuredTestCommand = fmt.Sprintf("\nConfigured test command already ran successfully as baseline: `%s`\n", testCmd)
 		}
 		result, err := sctx.Agent.Run(ctx, agent.RunOpts{
+			Model: model,
 			Prompt: fmt.Sprintf(
 				`You are validating a code change by testing it. Examine the repository and run the appropriate tests yourself.
 

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# install-local.sh — Build no-mistakes from this repo and install it.
+#
+# Usage:  ./scripts/install-local.sh
+#
+# Installs to the directory that /usr/local/bin/no-mistakes symlinks to
+# (default: ~/.no-mistakes/bin/no-mistakes). The existing binary is backed
+# up as no-mistakes.bak in the same directory.
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TARGET="$(readlink -f /usr/local/bin/no-mistakes 2>/dev/null || echo "$HOME/.no-mistakes/bin/no-mistakes")"
+TARGET_DIR="$(dirname "$TARGET")"
+
+VERSION="$(cd "$REPO_DIR" && git describe --tags --always --dirty 2>/dev/null || echo dev)"
+COMMIT="$(cd "$REPO_DIR" && git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# back up existing binary
+if [ -f "$TARGET" ]; then
+  cp "$TARGET" "$TARGET_DIR/no-mistakes.bak"
+  echo "backed up $TARGET -> $TARGET_DIR/no-mistakes.bak"
+fi
+
+mkdir -p "$TARGET_DIR"
+
+cd "$REPO_DIR"
+go build \
+  -ldflags "-X github.com/kunchenguid/no-mistakes/internal/buildinfo.Version=$VERSION -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Commit=$COMMIT -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Date=$DATE" \
+  -o "$TARGET" \
+  ./cmd/no-mistakes
+
+echo "installed no-mistakes ($VERSION, commit $COMMIT) to $TARGET"


### PR DESCRIPTION
## Summary

Update the agent's OpenCode integration to match v1.17.x schema requirements, add per-step model routing via `agent_model` config, and include a convenience install-local.sh script.

## Key changes

- **fix(agent):** Nest JSON schema under `info`, drop `retryCount`, add per-step model via `info.model` — aligns with OpenCode >= 1.17.x (fixes #321, #277)
- **docs:** Add `agent_model` config documentation to README and AGENTS.md
- **chore:** Add `install-local.sh` script and document it in README and AGENTS.md