### PR TITLE
fix(gitlab): replace removed glab mr list --state flag

### DIFF
--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -70,7 +70,7 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 	if strings.TrimSpace(base) != "" {
 		args = append(args, "--target-branch", base)
 	}
-	args = append(args, "--state", "opened", "--output", "json")
+	args = append(args, "--output", "json")
 	cmd := h.cmd(ctx, "glab", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/scm/gitlab/gitlab_test.go
+++ b/internal/scm/gitlab/gitlab_test.go
@@ -185,7 +185,7 @@ func TestFindPRWithoutIIDKeepsNumberEmptyAndUpdatesByNumberFromURL(t *testing.T)
 	branch := "feature/refactor"
 	url := "https://gitlab.example.com/group/project/-/merge_requests/42"
 	host := New(gitlabTestCmdFactory(map[string]gitlabTestResponse{
-		"glab mr list --source-branch " + branch + " --target-branch main --state opened --output json": {
+		"glab mr list --source-branch " + branch + " --target-branch main --output json": {
 			stdout: fmt.Sprintf(`[{"web_url":%q}]`+"\n", url),
 		},
 		"glab mr update 42 --title updated --description body --yes": {
@@ -220,7 +220,7 @@ func TestFindPRFiltersByBaseBranch(t *testing.T) {
 	t.Parallel()
 
 	host := New(gitlabTestCmdFactory(map[string]gitlabTestResponse{
-		"glab mr list --source-branch feature/refactor --target-branch release/1.0 --state opened --output json": {
+		"glab mr list --source-branch feature/refactor --target-branch release/1.0 --output json": {
 			stdout: `[{"iid":42,"web_url":"https://gitlab.example.com/group/project/-/merge_requests/42"}]` + "\n",
 		},
 	}), nil)
@@ -244,7 +244,7 @@ func TestFindPRReturnsCLIError(t *testing.T) {
 	t.Parallel()
 
 	host := New(gitlabTestCmdFactory(map[string]gitlabTestResponse{
-		"glab mr list --source-branch feature/refactor --target-branch main --state opened --output json": {
+		"glab mr list --source-branch feature/refactor --target-branch main --output json": {
 			stderr: "gitlab unavailable\n",
 			code:   1,
 		},


### PR DESCRIPTION
## Summary

Fixes #313.

`glab` v1.103.0 removed the `--state` flag from `mr list`. The `FindPR` path only ever queries for **open** MRs, and open is the default when no flag is given — so the fix is simply removing `--state opened` from the argument list.

The new glab flag mapping for reference:
| old | new |
|-----|-----|
| `--state opened` | *(default — omit flag)* |
| `--state closed` | `--closed` |
| `--state merged` | `--merged` |
| `--state all` | `--all` |

## Changes

- `internal/scm/gitlab/gitlab.go` — drop `"--state", "opened"` from the `glab mr list` args
- `internal/scm/gitlab/gitlab_test.go` — update the fake-command key strings to match

## Test plan

- [x] `go test ./internal/scm/gitlab/...` passes