### PR TITLE
fix(git): FindMainRepoRoot returns submodule root, not superproject .git/modules path

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -109,11 +109,25 @@ func FindGitRoot(path string) (string, error) {
 // repository. For a regular repo this is the same as FindGitRoot. For a
 // worktree it resolves back to the main repository root by inspecting
 // git's common dir.
+//
+// Git submodules are NOT treated as linked worktrees: their common-dir lives
+// under the superproject's .git/modules/ tree, so taking its parent would
+// give the wrong path. Submodules are detected via
+// --show-superproject-working-tree and resolved using --show-toplevel instead.
 func FindMainRepoRoot(path string) (string, error) {
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		return "", err
 	}
+
+	// Detect git submodules: if --show-superproject-working-tree is non-empty
+	// we are inside a submodule and should treat it as its own repo root.
+	superCmd := exec.Command("git", "rev-parse", "--show-superproject-working-tree")
+	superCmd.Dir = abs
+	if superOut, err := superCmd.Output(); err == nil && strings.TrimSpace(string(superOut)) != "" {
+		return FindGitRoot(abs)
+	}
+
 	cmd := exec.Command("git", "rev-parse", "--git-common-dir")
 	cmd.Dir = abs
 	out, err := cmd.Output()

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -183,6 +183,50 @@ func TestFindGitRootNotFound(t *testing.T) {
 	}
 }
 
+// TestFindMainRepoRoot_Submodule verifies that FindMainRepoRoot returns the
+// submodule working tree root, not a path inside the superproject's
+// .git/modules/ directory (issue #328).
+func TestFindMainRepoRoot_Submodule(t *testing.T) {
+	// Create the superproject.
+	superDir := initTestRepo(t)
+
+	// Create the sub-repo that will be embedded as a submodule.
+	subRepoDir := initTestRepo(t)
+
+	// Newer Git versions block file:// submodule clones by default.
+	// Allow it only for this test by overriding the protocol allowlist.
+	runWithEnv := func(dir string, env []string, name string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(name, args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(), env...)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%s %v failed: %v\n%s", name, args, err, out)
+		}
+	}
+
+	// Add subRepoDir as a submodule inside the superproject.
+	runWithEnv(superDir, []string{"GIT_CONFIG_COUNT=1", "GIT_CONFIG_KEY_0=protocol.file.allow", "GIT_CONFIG_VALUE_0=always"},
+		"git", "submodule", "add", subRepoDir, "sub")
+	run(t, superDir, "git", "commit", "-m", "add submodule")
+
+	// The submodule working tree is at superDir/sub.
+	submoduleDir := filepath.Join(superDir, "sub")
+
+	got, err := FindMainRepoRoot(submoduleDir)
+	if err != nil {
+		t.Fatalf("FindMainRepoRoot in submodule failed: %v", err)
+	}
+
+	want, _ := filepath.EvalSymlinks(submoduleDir)
+	gotResolved, _ := filepath.EvalSymlinks(got)
+
+	if gotResolved != want {
+		t.Fatalf("FindMainRepoRoot in submodule = %q, want %q (submodule working tree, not superproject .git/modules path)", gotResolved, want)
+	}
+}
+
 func TestHasUncommittedChangesClean(t *testing.T) {
 	dir := initTestRepo(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Fixes #328.

### Root cause

`FindMainRepoRoot` uses `git rev-parse --git-common-dir` and takes its `filepath.Dir` to find the repo root. This is correct for linked worktrees (where the common-dir is a .git directory inside the main checkout), but wrong for **git submodules**:

In a submodule, `--git-common-dir` points under the superproject's `.git/modules/` tree:
```
/superproject/.git/modules/sub  ← common-dir
/superproject/.git/modules      ← filepath.Dir of above (WRONG)
```

So `no-mistakes init` recorded a path under the superproject's git internals and picked up the superproject's remote instead of the submodule's own remote.

### Fix

Before falling through to the common-dir logic, check `git rev-parse --show-superproject-working-tree`. A non-empty result means the current directory is a submodule — in that case, delegate to `FindGitRoot` (`--show-toplevel`) which correctly returns the submodule working tree path.

Linked worktrees are unaffected: their `--show-superproject-working-tree` output is empty.

### Test

`TestFindMainRepoRoot_Submodule` creates a superproject, adds a sub-repo as a git submodule, then asserts that `FindMainRepoRoot` from inside the submodule returns the submodule working tree (not a path under `.git/modules/`).

## Test plan

- [x] `go test ./internal/git/... -run TestFindMainRepoRoot` — all pass
- [x] `go test ./internal/git/...` — full suite passes