### PR TITLE
fix(agent): pass acpx prompt via temp file to avoid Windows CLI length limit

### DIFF
--- a/internal/agent/acpx.go
+++ b/internal/agent/acpx.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -30,7 +31,28 @@ func (a *acpxAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
 }
 
 func (a *acpxAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
-	args := a.buildArgs(opts)
+	// Write the prompt to a temp file so that large prompts don't exceed the
+	// OS command-line length limit (notably 8191 chars on Windows). acpx
+	// accepts "exec -f <file>" as an alternative to passing the text inline.
+	prompt := opts.Prompt
+	if len(opts.JSONSchema) > 0 {
+		prompt = buildACPStructuredPrompt(prompt, opts.JSONSchema)
+	}
+	promptFile, err := os.CreateTemp("", "nm-acpx-prompt-*.txt")
+	if err != nil {
+		return nil, fmt.Errorf("acpx prompt file: %w", err)
+	}
+	promptPath := promptFile.Name()
+	defer os.Remove(promptPath)
+	if _, err := promptFile.WriteString(prompt); err != nil {
+		promptFile.Close()
+		return nil, fmt.Errorf("acpx prompt file write: %w", err)
+	}
+	if err := promptFile.Close(); err != nil {
+		return nil, fmt.Errorf("acpx prompt file close: %w", err)
+	}
+
+	args := a.buildArgs(opts, promptPath)
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD
 	cmd.Stdin = nil
@@ -78,13 +100,8 @@ func (a *acpxAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) 
 
 func (a *acpxAgent) Close() error { return nil }
 
-func (a *acpxAgent) buildArgs(opts RunOpts) []string {
-	prompt := opts.Prompt
-	if len(opts.JSONSchema) > 0 {
-		prompt = buildACPStructuredPrompt(prompt, opts.JSONSchema)
-	}
-
-	args := make([]string, 0, 12)
+func (a *acpxAgent) buildArgs(opts RunOpts, promptFile string) []string {
+	args := make([]string, 0, 14)
 	if a.rawCommand != "" {
 		args = append(args, "--agent", a.rawCommand)
 	}
@@ -101,7 +118,7 @@ func (a *acpxAgent) buildArgs(opts RunOpts) []string {
 	if a.rawCommand == "" {
 		args = append(args, a.target)
 	}
-	args = append(args, "exec", prompt)
+	args = append(args, "exec", "-f", promptFile)
 	return args
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -60,7 +60,7 @@ func TestNewWithOptions_ACPRegistryOverride(t *testing.T) {
 	if !ok {
 		t.Fatalf("agent type = %T, want *acpxAgent", a)
 	}
-	args := acpx.buildArgs(RunOpts{Prompt: "do work", CWD: "/repo"})
+	args := acpx.buildArgs(RunOpts{Prompt: "do work", CWD: "/repo"}, "/tmp/prompt.txt")
 	joined := strings.Join(args, "\x00")
 	if !strings.Contains(joined, "--agent\x00node /tmp/mock-acp.mjs") {
 		t.Fatalf("args = %q, want raw --agent override", args)
@@ -72,10 +72,11 @@ func TestNewWithOptions_ACPRegistryOverride(t *testing.T) {
 
 func TestACPAgentBuildArgsUsesExecMode(t *testing.T) {
 	a := &acpxAgent{target: "gemini"}
-	args := a.buildArgs(RunOpts{Prompt: "do work"})
+	args := a.buildArgs(RunOpts{Prompt: "do work"}, "/tmp/prompt.txt")
 
-	if got, want := args[len(args)-3:], []string{"gemini", "exec", "do work"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
-		t.Fatalf("trailing args = %q, want %q", got, want)
+	// Trailing args should be: ... gemini exec -f /tmp/prompt.txt
+	if got, want := args[len(args)-4:], []string{"gemini", "exec", "-f", "/tmp/prompt.txt"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("trailing args[-4:] = %q, want %q", got, want)
 	}
 }
 
@@ -180,7 +181,17 @@ func TestACPAgentRunParsesAcpxJSONOutput(t *testing.T) {
 	argLog := filepath.Join(dir, "args.txt")
 	t.Setenv("ARG_LOG", argLog)
 	contents := `#!/bin/sh
+# Log all CLI args.
 printf '%s\n' "$@" > "$ARG_LOG"
+# Also log the prompt file content (the arg after -f) so we can assert on it.
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "-f" ]; then
+    cat "$arg" >> "$ARG_LOG"
+    break
+  fi
+  prev="$arg"
+done
 printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"usage_update","used":123,"size":1000}}}'
 printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"{\"done\":true}"}}}}'
 `
@@ -220,7 +231,9 @@ printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"s
 		t.Fatalf("read args: %v", err)
 	}
 	argsText := string(argsData)
-	for _, want := range []string{"--cwd\n" + dir, "--format\njson", "--json-strict", "gemini", "do work"} {
+	// The prompt is now written to a temp file and passed via -f; the file
+	// content is also appended to ARG_LOG by the test script above.
+	for _, want := range []string{"--cwd\n" + dir, "--format\njson", "--json-strict", "gemini", "-f", "do work"} {
 		if !strings.Contains(argsText, want) {
 			t.Errorf("args missing %q in:\n%s", want, argsText)
 		}


### PR DESCRIPTION
## Summary

Fixes #315.

### Root cause

`acpxAgent.buildArgs` appended the full prompt as a positional CLI argument:
```
acpx [flags] gemini exec <prompt-text>
```

On Windows, `CreateProcess` caps the entire command line at **8191 characters**. Large prompts (diff + JSON schema + workspace preamble) are silently truncated at that boundary. The truncated text ends mid-sentence, so acpx responds in plain prose ("Your message looks cut off...") and no-mistakes fails to parse the expected JSON object:

```
acp:cursor output parse: invalid character 'Y' looking for beginning of value
```

Short prompts work; large ones (review, document) do not.

### Fix

Write the prompt to a named temp file before starting the subprocess, then invoke:
```
acpx [flags] gemini exec -f <tempfile>
```

acpx has supported `exec -f <file>` since at least v0.11.0 (the version in the bug report). The temp file is removed via `defer os.Remove` after `cmd.Wait()` returns.

This change is platform-agnostic: no prompt size can exceed OS limits via args any more.

### Tests

- Updated `TestACPAgentBuildArgsUsesExecMode` to assert trailing args are `[..., "exec", "-f", "<path>"]`
- Updated `TestACPAgentRunParsesAcpxJSONOutput` shell script to log prompt file content so the assertion can still verify the prompt text reaches acpx
- Full `go test ./internal/agent/...` passes

## Test plan

- [x] `go test ./internal/agent/... -run TestACPAgent` — all pass
- [x] `go test ./internal/agent/...` — full suite passes