### PR TITLE
fix(daemon): HandleRerun recovers when gate ref exists but no run was recorded

### DIFF
--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -240,13 +240,28 @@ func (m *RunManager) HandleRerun(ctx context.Context, repoID, branch string, ski
 			break
 		}
 	}
+	var baseSHA string
 	if latestForBranch == nil {
-		return "", fmt.Errorf("no previous run for branch %s", branch)
-	}
-
-	baseSHA := latestForBranch.BaseSHA
-	if matchingHead != nil {
-		baseSHA = matchingHead.BaseSHA
+		// Gate has a ref for this branch but no recorded pipeline run. This
+		// happens when the user's earlier push was a no-op (same SHA) so the
+		// post-receive hook never fired. Recover by computing the base from the
+		// gate's default branch instead of refusing outright.
+		defaultRef := "refs/heads/" + repo.DefaultBranch
+		baseSHA, err = git.Run(ctx, gateDir, "merge-base", headSHA, defaultRef)
+		if err != nil {
+			// Default branch ref may not exist in the gate yet; fall back to its head.
+			baseSHA, err = git.Run(ctx, gateDir, "rev-parse", defaultRef+"^{commit}")
+		}
+		if err != nil {
+			return "", fmt.Errorf("no previous run for branch %s: gate ref exists but no pipeline was ever triggered"+
+				" and base branch %q is also missing; repair with: git push no-mistakes :%s && git push no-mistakes HEAD:%s",
+				branch, repo.DefaultBranch, branch, branch)
+		}
+	} else {
+		baseSHA = latestForBranch.BaseSHA
+		if matchingHead != nil {
+			baseSHA = matchingHead.BaseSHA
+		}
 	}
 
 	return m.startRun(ctx, repo, branch, headSHA, baseSHA, "rerun", skipSteps, intent)

--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -268,6 +268,33 @@ func TestRerunSkipStepsConfiguresExecutor(t *testing.T) {
 	}
 }
 
+func TestRerunRecoveryWhenNoPreviousRunExists(t *testing.T) {
+	// Regression test for issue #294: if the gate ref exists but no pipeline
+	// run was ever recorded for that branch, HandleRerun should recover by
+	// computing baseSHA from the default branch rather than returning an error.
+	p, d := startTestDaemon(t)
+	_, _ = setupTestGitRepo(t, p, d, "recovery-repo")
+
+	// Do NOT call MethodPushReceived — simulate the stuck state where the gate
+	// ref was created out-of-band (e.g. a prior no-op push) so no run exists.
+	client, err := ipc.Dial(p.Socket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	var result ipc.RerunResult
+	if err := client.Call(ipc.MethodRerun, &ipc.RerunParams{
+		RepoID: "recovery-repo",
+		Branch: "main",
+	}, &result); err != nil {
+		t.Fatalf("HandleRerun should recover from missing run, got error: %v", err)
+	}
+	if result.RunID == "" {
+		t.Fatal("expected non-empty RunID from recovery rerun")
+	}
+}
+
 func TestPushReceivedReturnsBeforeIntentSummarization(t *testing.T) {
 	fakeHome := t.TempDir()
 	t.Setenv("HOME", fakeHome)


### PR DESCRIPTION
## Summary

Fixes #294.

### Root cause

When a `git push no-mistakes HEAD` is a no-op (same commit already in the bare gate repo), git returns `Everything up-to-date` **without** triggering the `post-receive` hook. The daemon never sees the push, no pipeline run is created.

A subsequent `axi run` eventually calls `HandleRerun`. The old code returned `"no previous run for branch <branch>"` when `latestForBranch == nil`, leaving the user stuck until they manually deleted and recreated the gate ref.

### Fix

When `latestForBranch == nil` but `git rev-parse refs/heads/<branch>^{commit}` succeeds (i.e. the gate ref **does** exist), infer `baseSHA` by running `git merge-base <headSHA> refs/heads/<DefaultBranch>`. That gives the correct branch point without requiring a prior run record. A fresh run is then started normally.

Fallback chain:
1. `git merge-base <headSHA> refs/heads/<DefaultBranch>` — preferred
2. `git rev-parse refs/heads/<DefaultBranch>^{commit}` — if default branch ref is missing too
3. Return error with the exact repair command (`git push no-mistakes :<branch> && git push no-mistakes HEAD:<branch>`) — only if both fail

### Test

`TestRerunRecoveryWhenNoPreviousRunExists`:
- Sets up the gate bare repo and registers the repo in the DB (so the gate ref exists)
- Does **not** call `MethodPushReceived` (no run is ever recorded)
- Calls `MethodRerun` and asserts a non-empty `RunID` is returned instead of an error

## Test plan

- [x] `go test ./internal/daemon/... -run TestRerunRecovery` — passes
- [x] `go test ./internal/daemon/...` — full suite passes (23s)