### PR TITLE
feat(agent): add first-class Cursor support via cursor-agent acp

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -590,8 +590,19 @@ func NewWithOptions(name types.AgentName, bin string, extraArgs []string, opts O
 		return &opencodeAgent{bin: bin, extraArgs: extraArgs}, nil
 	case types.AgentPi:
 		return &piAgent{bin: bin, extraArgs: extraArgs}, nil
+	case types.AgentCursor:
+		// Cursor runs via the acpx shim against cursor-agent's ACP server.
+		// The registry override lets users point to a non-standard cursor-agent path;
+		// the default is the standard "cursor-agent acp" invocation.
+		rawCommand := "cursor-agent acp"
+		if opts.ACPRegistryOverrides != nil {
+			if override, ok := opts.ACPRegistryOverrides["cursor"]; ok && override != "" {
+				rawCommand = override
+			}
+		}
+		return &acpxAgent{bin: bin, target: "cursor", rawCommand: rawCommand}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
+		return nil, fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, cursor, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
 	}
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -24,6 +24,7 @@ func TestNew_KnownAgents(t *testing.T) {
 		{name: "rovodev", agent: types.AgentRovoDev, bin: "acli", wantName: "rovodev"},
 		{name: "opencode", agent: types.AgentOpenCode, bin: "opencode", wantName: "opencode"},
 		{name: "pi", agent: types.AgentPi, bin: "pi", wantName: "pi"},
+		{name: "cursor", agent: types.AgentCursor, bin: "acpx", wantName: "acp:cursor"},
 	}
 
 	for _, tt := range tests {
@@ -67,6 +68,44 @@ func TestNewWithOptions_ACPRegistryOverride(t *testing.T) {
 	}
 	if strings.Contains(joined, "\x00local-gemini\x00") {
 		t.Fatalf("args = %q, should not include target subcommand when override is used", args)
+	}
+}
+
+func TestCursorAgentUsesDefaultCursorAgentCommand(t *testing.T) {
+	a, err := New(types.AgentCursor, "acpx", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	acpx, ok := a.(*acpxAgent)
+	if !ok {
+		t.Fatalf("agent type = %T, want *acpxAgent", a)
+	}
+	if acpx.target != "cursor" {
+		t.Errorf("target = %q, want %q", acpx.target, "cursor")
+	}
+	if acpx.rawCommand != "cursor-agent acp" {
+		t.Errorf("rawCommand = %q, want %q", acpx.rawCommand, "cursor-agent acp")
+	}
+	args := acpx.buildArgs(RunOpts{Prompt: "do work"})
+	joined := strings.Join(args, "\x00")
+	if !strings.Contains(joined, "--agent\x00cursor-agent acp") {
+		t.Fatalf("args = %q, want --agent cursor-agent acp", args)
+	}
+}
+
+func TestCursorAgentRegistryOverrideRespected(t *testing.T) {
+	a, err := NewWithOptions(types.AgentCursor, "acpx", nil, Options{
+		ACPRegistryOverrides: map[string]string{"cursor": "/opt/cursor/cursor-agent acp --profile work"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	acpx, ok := a.(*acpxAgent)
+	if !ok {
+		t.Fatalf("agent type = %T, want *acpxAgent", a)
+	}
+	if acpx.rawCommand != "/opt/cursor/cursor-agent acp --profile work" {
+		t.Errorf("rawCommand = %q, want override value", acpx.rawCommand)
 	}
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -97,6 +97,7 @@ func newDoctorCmd() *cobra.Command {
 					{"rovodev", "acli"},
 					{"opencode", "opencode"},
 					{"pi", "pi"},
+					{"cursor", "cursor-agent"},
 				}
 				fmt.Fprintln(w)
 				fmt.Fprintf(w, "  %s\n", sCyan.Render("Agents"))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -176,8 +176,9 @@ type Intent struct {
 const defaultConfigYAML = `# no-mistakes global configuration
 
 # Agent to use for code generation
-# Options: auto, claude, codex, rovodev, opencode, pi, acp:<target>
+# Options: auto, claude, codex, rovodev, opencode, pi, cursor, acp:<target>
 # "auto" detects the first available native agent on your system
+# "cursor" uses the Cursor AI editor's headless agent (cursor-agent) via acpx
 # Use acp:<target> to run an optional user-installed acpx target, for example acp:gemini
 agent: auto
 
@@ -250,6 +251,7 @@ var defaultBinary = map[types.AgentName]string{
 	types.AgentRovoDev:  "acli",
 	types.AgentOpenCode: "opencode",
 	types.AgentPi:       "pi",
+	types.AgentCursor:   "cursor-agent",
 }
 
 // agentProbeOrder is the priority order for auto-detecting agents.
@@ -259,6 +261,7 @@ var agentProbeOrder = []types.AgentName{
 	types.AgentOpenCode,
 	types.AgentRovoDev,
 	types.AgentPi,
+	types.AgentCursor,
 }
 
 func isACPAgent(name types.AgentName) bool {
@@ -339,10 +342,10 @@ func (c *Config) ResolveAgent(ctx context.Context, lookPath func(string) (string
 }
 
 // AgentPath returns the binary path for the configured agent.
-// ACP agents use acpx_path if set, otherwise acpx.
+// ACP agents and the cursor agent use acpx_path if set, otherwise acpx.
 // Native agents use agent_path_override if set, otherwise the default binary name.
 func (c *Config) AgentPath() string {
-	if isACPAgent(c.Agent) {
+	if isACPAgent(c.Agent) || c.Agent == types.AgentCursor {
 		if c.ACPXPath != "" {
 			return c.ACPXPath
 		}

--- a/internal/config/config_agent_test.go
+++ b/internal/config/config_agent_test.go
@@ -52,6 +52,8 @@ func TestAgentPath_ACPUsesAcpxPath(t *testing.T) {
 	}{
 		{name: "default", cfg: &Config{Agent: "acp:gemini"}, want: "acpx"},
 		{name: "override", cfg: &Config{Agent: "acp:gemini", ACPXPath: "/opt/bin/acpx"}, want: "/opt/bin/acpx"},
+		{name: "cursor-default", cfg: &Config{Agent: types.AgentCursor}, want: "acpx"},
+		{name: "cursor-override", cfg: &Config{Agent: types.AgentCursor, ACPXPath: "/opt/bin/acpx"}, want: "/opt/bin/acpx"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -231,7 +233,7 @@ func TestResolveAgent_AutoSkipsRovoDevWithoutSubcommand(t *testing.T) {
 
 	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
 		switch bin {
-		case "claude", "codex", "opencode", "pi":
+		case "claude", "codex", "opencode", "pi", "cursor-agent":
 			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
 		case "acli":
 			return "/usr/bin/acli", nil
@@ -263,7 +265,7 @@ func TestResolveAgent_AutoReturnsRovoDevProbeExitError(t *testing.T) {
 
 	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
 		switch bin {
-		case "claude", "codex", "opencode", "pi":
+		case "claude", "codex", "opencode", "pi", "cursor-agent":
 			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
 		case "acli":
 			return script, nil
@@ -364,7 +366,7 @@ func TestResolveAgent_AutoPassesContextToRovoDevProbe(t *testing.T) {
 
 	err := cfg.ResolveAgent(ctx, func(bin string) (string, error) {
 		switch bin {
-		case "claude", "codex", "opencode", "pi":
+		case "claude", "codex", "opencode", "pi", "cursor-agent":
 			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
 		case "acli":
 			return "/usr/bin/acli", nil

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -139,4 +139,5 @@ const (
 	AgentRovoDev  AgentName = "rovodev"
 	AgentOpenCode AgentName = "opencode"
 	AgentPi       AgentName = "pi"
+	AgentCursor   AgentName = "cursor"
 )


### PR DESCRIPTION
## Problem

Fixes #292

Users who wanted to use Cursor AI as their agent backend had to manually configure three settings:

\`\`\`yaml
agent: acp:cursor
acpx_path: /path/to/acpx
acp_registry_overrides:
  cursor: /path/to/cursor-agent acp
\`\`\`

## Solution

Add `agent: cursor` as a first-class named agent that automatically uses `cursor-agent acp` via the acpx shim. Setting `agent: cursor` in `~/.no-mistakes/config.yaml` is now sufficient.

**How it works**: Cursor exposes its AI capabilities through the ACP protocol via the `cursor-agent acp` command. The acpx binary acts as a transport shim — the same approach used by `acp:<target>` agents. By registering `cursor` as a typed agent that maps to `acpxAgent{target:"cursor", rawCommand:"cursor-agent acp"}`, users get a clean `agent: cursor` config option while reusing the existing ACP infrastructure.

Users who need a custom cursor-agent path can still override it:
\`\`\`yaml
agent: cursor
acp_registry_overrides:
  cursor: /opt/cursor/cursor-agent acp --profile work
\`\`\`

## Changes

- **`internal/types/types.go`**: add `AgentCursor = "cursor"` constant
- **`internal/config/config.go`**: add cursor to probe order (checks for `cursor-agent` binary), set `AgentPath()` to return `acpx` for cursor (same as ACP agents), update default config comment
- **`internal/agent/agent.go`**: handle `AgentCursor` in factory — creates acpxAgent with `rawCommand: "cursor-agent acp"`, overridable via `acp_registry_overrides.cursor`
- **`internal/cli/doctor.go`**: show `cursor-agent` availability in the agent health table

## Test plan

- [x] `TestNew_KnownAgents` — cursor creates an acpxAgent with name "acp:cursor"
- [x] `TestCursorAgentUsesDefaultCursorAgentCommand` — default rawCommand is "cursor-agent acp"
- [x] `TestCursorAgentRegistryOverrideRespected` — `acp_registry_overrides.cursor` overrides rawCommand
- [x] `TestAgentPath_ACPUsesAcpxPath` — `AgentPath()` returns acpx for cursor (default + override)
- [x] existing rovodev auto-detect tests updated to handle cursor-agent probe