### PR TITLE
fix(agent): reap agent process group on normal exit, not just cancellation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,14 @@ Safest local verification sequence after non-trivial changes:
   the next run on the same branch cannot proceed. Applied to the step shell
   runner (`runShellCommandWithEnv`) and the native agent `runOnce` builders
   (claude, codex, pi, acpx); apply it to any new subprocess in those paths.
+- `cmd.Cancel` only fires on context cancellation, never on normal exit, so a
+  cleanly-exited agent/command still leaks any grandchild that outlived it (a
+  vitest tinypool worker pool reparenting to init, a build watcher, a dev
+  server). After `cmd.Start()` (or alongside a `CombinedOutput`/`Output` call),
+  `defer shellenv.TerminateShellCommandGroup(cmd)` to SIGKILL the whole process
+  group on every return path, success included. It is a no-op once the group is
+  already empty (ESRCH) or the cancel path already swept it. Pair it with
+  `ConfigureShellCommand` on any new subprocess in these paths.
 - Use derived contexts and timeouts for cleanup and HTTP calls.
 - Use `context.Background()` mainly at top-level boundaries, background tasks, or in tests.
 - Protect shared mutable state with `sync.Mutex`, `sync.RWMutex`, `sync.Map`, or `atomic` where appropriate.

--- a/internal/agent/acpx.go
+++ b/internal/agent/acpx.go
@@ -51,6 +51,9 @@ func (a *acpxAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) 
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("acpx start: %w", err)
 	}
+	// Reap the whole process group on every return path, not just ctx
+	// cancellation, so a cleanly-exited acpx can't leak grandchildren.
+	defer shellenv.TerminateShellCommandGroup(cmd)
 
 	var stderrBuf []byte
 	var stderrWG sync.WaitGroup

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -64,6 +64,10 @@ func (a *claudeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("claude start: %w", err)
 	}
+	// Reap the whole process group on every return path, not just ctx
+	// cancellation. A cleanly-exited claude can leave grandchildren (a test
+	// runner's worker pool, a build watcher) reparented to init and running.
+	defer shellenv.TerminateShellCommandGroup(cmd)
 
 	stderrWG.Add(1)
 	go func() {

--- a/internal/agent/claude_reap_unix_test.go
+++ b/internal/agent/claude_reap_unix_test.go
@@ -1,0 +1,79 @@
+//go:build unix
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestClaudeAgent_RunOnce_ReapsGrandchildOnNormalExit is the end-to-end guard
+// for the success-path leak: a fake claude that backgrounds a long-lived
+// grandchild (standing in for a vitest tinypool worker) and then exits 0 must
+// not leave that grandchild running once runOnce returns. The fix is the
+// deferred TerminateShellCommandGroup; without it the grandchild reparents to
+// init and survives, which is the real-world RAM-exhaustion bug.
+func TestClaudeAgent_RunOnce_ReapsGrandchildOnNormalExit(t *testing.T) {
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "grandchild.pid")
+
+	// The grandchild detaches its stdio from claude's stdout pipe so the pipe
+	// EOFs immediately on the leader's exit; only Setpgid group membership ties
+	// it to the leader. The leader emits one valid result event and exits 0.
+	bin := filepath.Join(dir, "fake-claude")
+	script := "#!/bin/sh\n" +
+		"sleep 30 </dev/null >/dev/null 2>&1 &\n" +
+		"echo $! > \"" + pidFile + "\"\n" +
+		`printf '%s\n' '{"type":"result","subtype":"success","structured_output":null}'` + "\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake claude: %v", err)
+	}
+
+	a := &claudeAgent{bin: bin}
+	if _, err := a.runOnce(context.Background(), RunOpts{CWD: dir}); err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+
+	childPID := readPID(t, pidFile)
+	if !waitForPIDGone(childPID, 2*time.Second) {
+		_ = syscall.Kill(childPID, syscall.SIGKILL)
+		t.Fatalf("grandchild %d still alive after runOnce returned; process group was not reaped", childPID)
+	}
+}
+
+func readPID(t *testing.T, path string) int {
+	t.Helper()
+	// The grandchild is backgrounded, so the pid file may lag the leader's exit
+	// by a scheduler tick.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			if pid, perr := strconv.Atoi(strings.TrimSpace(string(data))); perr == nil {
+				return pid
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("grandchild pid file %s never appeared: %v", path, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func waitForPIDGone(pid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if errors.Is(syscall.Kill(pid, 0), syscall.ESRCH) {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return errors.Is(syscall.Kill(pid, 0), syscall.ESRCH)
+}

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -81,6 +81,9 @@ func (a *codexAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error)
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("codex start: %w", err)
 	}
+	// Reap the whole process group on every return path, not just ctx
+	// cancellation, so a cleanly-exited codex can't leak grandchildren.
+	defer shellenv.TerminateShellCommandGroup(cmd)
 
 	stderrWG.Add(1)
 	go func() {

--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -56,6 +56,9 @@ func (a *piAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("pi start: %w", err)
 	}
+	// Reap the whole process group on every return path, not just ctx
+	// cancellation, so a cleanly-exited pi can't leak grandchildren.
+	defer shellenv.TerminateShellCommandGroup(cmd)
 
 	prompt := buildPiPrompt(opts.Prompt, opts.JSONSchema)
 	go func() {

--- a/internal/pipeline/steps/common_exec.go
+++ b/internal/pipeline/steps/common_exec.go
@@ -266,6 +266,10 @@ func runShellCommandWithEnv(ctx context.Context, dir string, env []string, cmdSt
 	// the whole tree (e.g. npm -> node test workers), not just the shell parent.
 	// Otherwise grandchildren survive, keep running, and hold the worktree locked.
 	shellenv.ConfigureShellCommand(cmd)
+	// Reap the whole process group on return, not just ctx cancellation: a
+	// configured test/lint command that exits cleanly can still leave worker
+	// grandchildren (e.g. a vitest tinypool) reparented to init and running.
+	defer shellenv.TerminateShellCommandGroup(cmd)
 	cmd.Dir = dir
 	if len(env) > 0 {
 		cmd.Env = mergeEnv(env)

--- a/internal/shellenv/shell_command_other.go
+++ b/internal/shellenv/shell_command_other.go
@@ -8,3 +8,7 @@ import "os/exec"
 // (and a process-tree kill primitive). Context cancellation falls back to the
 // exec.CommandContext default of terminating the direct child only.
 func ConfigureShellCommand(cmd *exec.Cmd) {}
+
+// TerminateShellCommandGroup is a no-op on platforms without a process-tree
+// kill primitive, matching ConfigureShellCommand's reduced guarantees.
+func TerminateShellCommandGroup(cmd *exec.Cmd) {}

--- a/internal/shellenv/shell_command_unix.go
+++ b/internal/shellenv/shell_command_unix.go
@@ -7,7 +7,16 @@ import (
 	"os"
 	"os/exec"
 	"syscall"
+	"time"
 )
+
+// defaultWaitDelay bounds the time Wait spends after the process exits before
+// force-closing stdout/stderr pipes that a surviving grandchild inherited and
+// still holds open. Without it, a single leaked descendant (a test runner's
+// worker, a build watcher) keeps a pipe Read blocked forever and wedges the
+// step. It is a worst-case ceiling only: in the common case the pipes close
+// immediately and Wait returns without waiting. Mirrors the Windows backstop.
+const defaultWaitDelay = 5 * time.Second
 
 // ConfigureShellCommand isolates cmd in its own process group (Setpgid) and
 // installs a cmd.Cancel that SIGKILLs the whole group when cmd's context is
@@ -15,10 +24,17 @@ import (
 // leaving grandchildren (a test runner's worker processes, an agent-spawned
 // git/build/editor) running and holding the worktree locked.
 //
+// Cancellation is only half the story: cmd.Cancel never fires when the child
+// exits on its own, so callers must also defer TerminateShellCommandGroup after
+// Start to reap any grandchild that outlived a normally-exited leader.
+//
 // Apply this to every long-lived subprocess no-mistakes spawns on behalf of a
 // cancellable step/agent invocation.
 func ConfigureShellCommand(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if cmd.WaitDelay == 0 {
+		cmd.WaitDelay = defaultWaitDelay
+	}
 	cmd.Cancel = func() error {
 		if cmd.Process == nil {
 			return os.ErrProcessDone
@@ -29,4 +45,21 @@ func ConfigureShellCommand(cmd *exec.Cmd) {
 		}
 		return err
 	}
+}
+
+// TerminateShellCommandGroup SIGKILLs every process still alive in cmd's
+// process group. ConfigureShellCommand put cmd in its own group via Setpgid, so
+// the group id equals the leader pid and the group persists as long as any
+// member is alive - including grandchildren that outlived the leader and
+// reparented to init (a vitest worker pool, a build watcher, a dev server).
+//
+// cmd.Cancel only reaps the group on context cancellation; this is the
+// success-path counterpart. Call it via defer after Start so a cleanly-exited
+// agent cannot leak orphaned grandchildren. It is a harmless no-op (ESRCH) when
+// the group is already empty, e.g. after a cancellation kill already swept it.
+func TerminateShellCommandGroup(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 }

--- a/internal/shellenv/shell_command_unix_test.go
+++ b/internal/shellenv/shell_command_unix_test.go
@@ -1,0 +1,71 @@
+//go:build unix
+
+package shellenv
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestTerminateShellCommandGroup_ReapsSurvivingGrandchild covers the
+// success-path leak that cmd.Cancel structurally cannot reach: a leader that
+// exits cleanly after backgrounding a long-lived child (a vitest worker pool, a
+// build watcher) leaves that child reparented to init and still running.
+// TerminateShellCommandGroup SIGKILLs the whole process group so nothing
+// survives a normally-exited agent.
+func TestTerminateShellCommandGroup_ReapsSurvivingGrandchild(t *testing.T) {
+	// The grandchild's own stdio is detached from the leader's stdout pipe so
+	// the leader's pipe EOFs immediately on exit and cmd.Output returns fast;
+	// only the process-group membership (inherited via Setpgid) keeps it tied
+	// to the leader. It prints its pid so the test can watch for its death.
+	script := `sleep 30 </dev/null >/dev/null 2>&1 & echo $!`
+	cmd := exec.CommandContext(context.Background(), "/bin/sh", "-c", script)
+	ConfigureShellCommand(cmd)
+
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("run leader: %v", err)
+	}
+	childPID, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		t.Fatalf("parse grandchild pid %q: %v", out, err)
+	}
+
+	// The leader has exited and been reaped, but the grandchild is still alive.
+	if err := syscall.Kill(childPID, 0); err != nil {
+		t.Fatalf("expected grandchild %d alive after leader exit, got %v", childPID, err)
+	}
+
+	TerminateShellCommandGroup(cmd)
+
+	if !waitForProcessGone(childPID, 2*time.Second) {
+		// Best-effort cleanup so we don't leak the sleeper if the assertion fails.
+		_ = syscall.Kill(childPID, syscall.SIGKILL)
+		t.Fatalf("grandchild %d still alive after TerminateShellCommandGroup", childPID)
+	}
+}
+
+// TestTerminateShellCommandGroup_NilProcessIsNoop guards the guard: callers
+// defer the teardown right after Start, but a Start failure (or a never-started
+// cmd) leaves cmd.Process nil, and the no-op must not panic or signal pid 0.
+func TestTerminateShellCommandGroup_NilProcessIsNoop(t *testing.T) {
+	TerminateShellCommandGroup(nil)
+	TerminateShellCommandGroup(&exec.Cmd{})
+}
+
+func waitForProcessGone(pid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(pid, 0); errors.Is(err, syscall.ESRCH) {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return errors.Is(syscall.Kill(pid, 0), syscall.ESRCH)
+}

--- a/internal/shellenv/shell_command_windows.go
+++ b/internal/shellenv/shell_command_windows.go
@@ -109,6 +109,25 @@ func ConfigureShellCommand(cmd *exec.Cmd) {
 	}
 }
 
+// TerminateShellCommandGroup is the Windows counterpart to the unix helper. It
+// best-effort `taskkill /T /F`s the tree rooted at cmd's pid to sweep up any
+// descendant that outlived a normally-exited leader, mirroring the unix
+// success-path group reap.
+//
+// Unlike a unix process group, a Windows process tree is tracked by live
+// parent-child links, so once the leader has exited taskkill /T may no longer
+// reach descendants that already reparented. This is therefore best-effort
+// cleanup for the window in which the leader is still being reaped; the
+// CreateNewProcessGroup + cmd.Cancel path in ConfigureShellCommand remains the
+// primary teardown for the cancellation case.
+func TerminateShellCommandGroup(cmd *exec.Cmd) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+	pid := strconv.Itoa(cmd.Process.Pid)
+	_ = exec.Command("taskkill", "/T", "/F", "/PID", pid).Run()
+}
+
 // isTaskkillAlreadyGone reports whether a taskkill error means the target PID
 // no longer exists (the child had already exited). taskkill emits exit code
 // taskkillExitNoSuchProcess for that case; matching on the numeric exit code


### PR DESCRIPTION
## Problem

`shellenv.ConfigureShellCommand` isolates each agent/command in its own process group (`Setpgid`) and installs `cmd.Cancel` to SIGKILL the group - but **`cmd.Cancel` only fires on context cancellation**. The success path is never covered.

When the test step's agent (or a configured test/lint command) exits 0, nothing kills the group. Grandchildren that outlived the leader - a vitest tinypool worker pool, a build watcher, a dev server - reparent to init (PPID 1) and keep running. A clean vitest run leaks its worker pool **every time**, which is the observed RAM-exhaustion (17×~1 GB orphan workers).

So cancellation was handled; clean completion was not.

## Fix

- Add `shellenv.TerminateShellCommandGroup` across the build-tag split:
  - unix: `SIGKILL` of `-pgid` (the group persists while any member is alive, so it still reaps grandchildren that outlived the leader)
  - windows: best-effort `taskkill /T /F /PID`
  - other: no-op stub
- `defer shellenv.TerminateShellCommandGroup(cmd)` right after `Start()` in every native agent runner (`claude`, `pi`, `acpx`, `codex`) and the shell-command path (`runShellCommandWithEnv`). The defer covers success, parse-error, and wait-error returns; `cmd.Cancel` still covers cancellation, where the defer is a harmless `ESRCH` no-op.
- Install a 5s `WaitDelay` backstop on unix (mirroring the existing windows backstop) so a grandchild holding an inherited stdout/stderr pipe open can't wedge `Wait` forever.

This fixes the general class, not just vitest: any agent-spawned grandchild leaking after a clean step is now reaped.

## Tests

- `internal/shellenv`: `TerminateShellCommandGroup` reaps a backgrounded grandchild left by a normally-exited leader; nil/never-started cmd is a no-op.
- `internal/agent`: drives `claudeAgent.runOnce` against a fake claude that backgrounds a grandchild and exits 0; asserts the grandchild is gone after `runOnce` returns. Confirmed this test **fails without the defer** (grandchild survives) and passes with it.

## Verification

`gofmt` clean · `make lint` · `go test -race ./...` · `make e2e` · Windows + wasip1 cross-builds all pass.