### PR TITLE
fix(cli): clarify stale CI monitor guidance

### DIFF
--- a/.no-mistakes/evidence/fm/nm-rebase-clarify-c5/checks-passed-axi-output.txt
+++ b/.no-mistakes/evidence/fm/nm-rebase-clarify-c5/checks-passed-axi-output.txt
@@ -1,0 +1,16 @@
+=== RUN   TestEvidenceChecksPassedGuidanceOutput
+    axi_guidance_evidence_test.go:32: rendered checks-passed AXI output:
+        run:
+          id: run-1
+          branch: feature/x
+          status: running
+          head: abcdef12
+          pr: "https://github.com/user/repo/pull/42"
+          findings: none
+          steps[1]{step,status,findings,duration_ms}:
+            ci,running,0,0
+        outcome: checks-passed
+        help[3]: "CI checks passed - the PR is ready. Ask the user to review and merge it: https://github.com/user/repo/pull/42","Summarize this pipeline run for the user in a concise, easily readable format: what was validated and what was found.","If this PR later falls behind the default branch or hits a merge conflict, the CI monitor rebases onto the base, resolves it, and re-pushes the branch automatically - run no command and never hand-rebase. Only when that monitor is no longer running (PR closed, run aborted, idle-timeout, or auto-fix exhausted) recover with `no-mistakes rerun`."
+--- PASS: TestEvidenceChecksPassedGuidanceOutput (0.00s)
+PASS
+ok  	github.com/kunchenguid/no-mistakes/internal/cli	0.291s

--- a/.no-mistakes/evidence/fm/nm-rebase-clarify-c5/cross-surface-guidance-excerpts.txt
+++ b/.no-mistakes/evidence/fm/nm-rebase-clarify-c5/cross-surface-guidance-excerpts.txt
@@ -1,0 +1,55 @@
+internal/cli/axi_guidance.go-1-package cli
+internal/cli/axi_guidance.go-2-
+internal/cli/axi_guidance.go-3-// staleMonitorGuidance is the canonical, point-of-use guidance an agent reads
+internal/cli/axi_guidance.go-4-// when `axi run` returns `checks-passed`: what to do if that PR later falls
+internal/cli/axi_guidance.go-5-// behind the default branch or hits a merge conflict (commonly because another
+internal/cli/axi_guidance.go-6-// PR merged first). The live CI monitor keeps running after checks pass and
+internal/cli/axi_guidance.go:7:// auto-rebases onto the base, resolves the conflict, and re-pushes the branch
+internal/cli/axi_guidance.go:8:// itself, so the agent runs no command and never hand-rebases. `no-mistakes
+internal/cli/axi_guidance.go-9-// rerun` is only the recovery for a monitor that is no longer running.
+internal/cli/axi_guidance.go-10-//
+internal/cli/axi_guidance.go-11-// This same guidance is mirrored in the skill body (internal/skill/skill.go)
+internal/cli/axi_guidance.go-12-// and the published agents guide (docs/.../guides/agents.md); the repo treats
+internal/cli/axi_guidance.go-13-// agent-driving guidance as a multi-surface contract, and
+internal/cli/axi_guidance.go-14-// TestStaleMonitorGuidance_SyncedAcrossSurfaces keeps the three in sync.
+internal/cli/axi_guidance.go:15:const staleMonitorGuidance = "If this PR later falls behind the default branch or hits a merge conflict, the CI monitor rebases onto the base, resolves it, and re-pushes the branch automatically - run no command and never hand-rebase. Only when that monitor is no longer running (PR closed, run aborted, idle-timeout, or auto-fix exhausted) recover with `no-mistakes rerun`."
+--
+docs/src/content/docs/guides/agents.md-99-The skill drives `no-mistakes axi`, a non-interactive command surface that prints TOON to stdout and progress to stderr.
+docs/src/content/docs/guides/agents.md-100-When CI is green but the PR is still open, `axi run` and `axi respond` return `outcome: checks-passed` with a help line pointing at the PR instead of waiting for a human merge.
+docs/src/content/docs/guides/agents.md-101-That is a successful agent stopping point: report that the PR is ready and ask the user to review and merge it.
+docs/src/content/docs/guides/agents.md-102-Successful outcomes also instruct the agent to summarize the run for the user.
+docs/src/content/docs/guides/agents.md-103-When the pipeline applied fixes, successful outcomes include a `fixes` table listing each fix so the agent can acknowledge what it missed and the user can review them.
+docs/src/content/docs/guides/agents.md-104-
+docs/src/content/docs/guides/agents.md:105:If that PR later falls behind the default branch or hits a merge conflict - commonly because another PR merged first - the agent runs no command and must never hand-rebase.
+docs/src/content/docs/guides/agents.md:106:The CI monitor stays live in the background after checks pass, and when it sees an actual conflict it rebases onto the base, resolves it, and re-pushes the branch itself, so no agent or user action is needed.
+docs/src/content/docs/guides/agents.md-107-A PR that is merely behind but still clean needs nothing either, since the platform merges it.
+docs/src/content/docs/guides/agents.md-108-The one exception is when that monitor is no longer running - the PR was closed, the run was aborted or superseded, it idle-timed-out, or its auto-fix attempts were exhausted - in which case the agent recovers with `no-mistakes rerun`, which cancels the stale monitor and re-runs the full pipeline including a deterministic rebase step.
+docs/src/content/docs/guides/agents.md:109:The agent must not use `no-mistakes axi run` to refresh a still-active PR: after `checks-passed` it reattaches to the running monitor with HEAD unchanged and returns the monitor output without rebasing.
+docs/src/content/docs/guides/agents.md-110-
+docs/src/content/docs/guides/agents.md-111-In task-first mode, if the repo is on the default branch, the skill tells the agent to create a feature branch before committing because the gate validates committed history on a non-default branch.
+docs/src/content/docs/guides/agents.md-112-The agent should inspect `git status` before changing or committing anything, preserve unrelated pre-existing uncommitted changes, and commit only the changes that belong to the user's task.
+docs/src/content/docs/guides/agents.md-113-
+docs/src/content/docs/guides/agents.md-114-Agents can also call `no-mistakes axi` directly:
+docs/src/content/docs/guides/agents.md-115-
+--
+skills/no-mistakes/SKILL.md-170-The CI step deliberately keeps watching the PR after checks pass, so
+skills/no-mistakes/SKILL.md-171-`axi run` returns `checks-passed` the moment checks are green rather than
+skills/no-mistakes/SKILL.md-172-blocking on the human merge. Never poll or re-run waiting for the merge yourself.
+skills/no-mistakes/SKILL.md-173-
+skills/no-mistakes/SKILL.md-174-Because that monitor stays live, a PR that falls behind the default branch or
+skills/no-mistakes/SKILL.md-175-hits a merge conflict after checks pass - commonly because another PR merged
+skills/no-mistakes/SKILL.md:176:first - needs **no command from you**: never hand-rebase. When the CI monitor
+skills/no-mistakes/SKILL.md:177:sees an actual conflict it **rebases onto the base, resolves it, and re-pushes
+skills/no-mistakes/SKILL.md-178-the branch itself**; a PR that is merely behind but still clean needs nothing
+skills/no-mistakes/SKILL.md-179-either, since the platform merges it. The one exception is when that monitor is
+skills/no-mistakes/SKILL.md-180-no longer running - the PR was closed, the run was aborted or superseded, it
+skills/no-mistakes/SKILL.md-181-idle-timed-out, or its auto-fix attempts were exhausted - in which case recover
+skills/no-mistakes/SKILL.md-182-with `no-mistakes rerun`, which cancels the stale monitor and re-runs the full
+skills/no-mistakes/SKILL.md-183-pipeline including a deterministic rebase step. Do **not** reach for
+skills/no-mistakes/SKILL.md:184:`no-mistakes axi run` to refresh a still-active PR: after `checks-passed` it
+skills/no-mistakes/SKILL.md-185-reattaches to the running monitor (HEAD unchanged) and returns its output
+skills/no-mistakes/SKILL.md-186-without rebasing.
+skills/no-mistakes/SKILL.md-187-
+skills/no-mistakes/SKILL.md-188-On a successful outcome (`checks-passed` or `passed`), close the loop with the
+skills/no-mistakes/SKILL.md-189-user: summarize what happened during the pipeline in a concise, easily readable
+skills/no-mistakes/SKILL.md-190-format - what was validated and what was found. If the output includes a

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -102,6 +102,12 @@ That is a successful agent stopping point: report that the PR is ready and ask t
 Successful outcomes also instruct the agent to summarize the run for the user.
 When the pipeline applied fixes, successful outcomes include a `fixes` table listing each fix so the agent can acknowledge what it missed and the user can review them.
 
+If that PR later falls behind the default branch or hits a merge conflict - commonly because another PR merged first - the agent runs no command and must never hand-rebase.
+The CI monitor stays live in the background after checks pass, and when it sees an actual conflict it rebases onto the base, resolves it, and re-pushes the branch itself, so no agent or user action is needed.
+A PR that is merely behind but still clean needs nothing either, since the platform merges it.
+The one exception is when that monitor is no longer running - the PR was closed, the run was aborted or superseded, it idle-timed-out, or its auto-fix attempts were exhausted - in which case the agent recovers with `no-mistakes rerun`, which cancels the stale monitor and re-runs the full pipeline including a deterministic rebase step.
+The agent must not use `no-mistakes axi run` to refresh a still-active PR: after `checks-passed` it reattaches to the running monitor with HEAD unchanged and returns the monitor output without rebasing.
+
 In task-first mode, if the repo is on the default branch, the skill tells the agent to create a feature branch before committing because the gate validates committed history on a non-default branch.
 The agent should inspect `git status` before changing or committing anything, preserve unrelated pre-existing uncommitted changes, and commit only the changes that belong to the user's task.
 

--- a/docs/src/content/docs/guides/provider-integration.md
+++ b/docs/src/content/docs/guides/provider-integration.md
@@ -69,7 +69,7 @@ For PR and workflow-run commands, no-mistakes passes the repository slug from th
 - PR creation and update on pushes
 - CI check polling with exponential backoff (30s → 60s → 120s) until the PR is merged, closed, or the configured `ci_timeout` idle window elapses
 - Failed job log fetching (`gh run view --log-failed`) for the CI auto-fix step
-- PR mergeability polling, and agent-driven merge-conflict resolution when the branch falls behind
+- PR mergeability polling, and agent-driven resolution when the provider reports an actual merge conflict
 
 ### GitHub fork contributions
 

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -200,7 +200,8 @@ Check the [Provider Integration](/no-mistakes/guides/provider-integration/) requ
 Symptom: CI step keeps monitoring an open PR longer than expected, or pauses after the idle timeout.
 
 `ci_timeout` defaults to `168h` (7 days) and is an idle timeout.
-It re-arms whenever the upstream default branch advances, so an active long-lived PR keeps being watched and rebased.
+It re-arms whenever the upstream default branch advances, so an active long-lived PR keeps being watched.
+If the provider later reports an actual GitHub or GitLab merge conflict, the CI auto-fix path rebases and re-pushes the branch; a clean behind PR needs no command.
 Set it in `~/.no-mistakes/config.yaml` to choose a different idle window:
 
 ```yaml

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -99,6 +99,9 @@ Long-running `axi run` calls are working, not stalled; if one returns a `gate:`,
 Backgrounding a call is fine for an agent harness, but the run never advances past a gate on its own.
 When the CI step is still monitoring an open PR and checks are green, `axi run` exits successfully with `outcome: checks-passed` instead of waiting for a human merge.
 Treat that as the agent stopping point: ask the user to review and merge the PR from the `help` line.
+If that PR later falls behind the default branch or hits a merge conflict, do not run `axi run`, `rerun`, or a manual rebase while the CI monitor is still running.
+The monitor auto-rebases onto the base, resolves actual conflicts, and re-pushes the branch; a PR that is merely behind but clean needs no command.
+Use `no-mistakes rerun` only after that monitor is no longer running, such as a closed PR, aborted or superseded run, idle timeout, or exhausted CI auto-fix attempts.
 Successful outcomes (`checks-passed` and `passed`) also carry `help` instructions telling the agent to summarize the run.
 When the pipeline applied fixes, they include a `fixes` table and a `help` instruction to acknowledge the misses and list those fixes for the user's review.
 

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -186,7 +186,9 @@ How long the CI step monitors an open PR, including provider CI status and on Gi
 Accepts any Go `time.ParseDuration` string: `30m`, `2h`, `4h30m`, etc.
 
 This is an idle timeout, not an absolute deadline: every time the base branch advances, the monitor re-arms it.
-So an actively-updated green PR keeps its monitor (and keeps getting rebased) no matter how long it stays open, while a genuinely idle/abandoned PR is still reaped after the timeout elapses.
+So an actively-updated green PR keeps its monitor no matter how long it stays open.
+If it later develops an actual GitHub or GitLab merge conflict, the CI auto-fix path rebases and re-pushes it, while a clean behind PR needs no command.
+A genuinely idle/abandoned PR is still reaped after the timeout elapses.
 
 Set it to `unlimited` (`none`, `off`, and `never` are accepted aliases), `0`, or any non-positive duration to monitor until the PR is merged, closed, or the run is aborted with `no-mistakes axi abort --run <id>`.
 

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -187,6 +187,7 @@ Monitors PR health after creation and auto-fixes CI failures. Mergeability polli
 - Treats `ci_timeout` as an idle timeout: each upstream default-branch advance re-arms the timer, and `ci_timeout: "unlimited"` disables self-termination
 - On GitHub and GitLab, polls provider mergeability alongside CI checks while the PR remains open
 - While the PR stays open, the TUI and terminal title show `Checks passed` once checks are green and known mergeability is clear, and `no-mistakes axi` returns `outcome: checks-passed` with successful-output reporting instructions so agents can summarize the run, ask the user to review and merge, and list any pipeline fixes instead of waiting
+- If the default branch moves after `checks-passed`, keeps watching the same PR; a clean behind PR needs no action, while an actual GitHub or GitLab merge conflict is auto-fixed by rebasing onto the base and re-pushing through the force-push safety guard
 - The ready signal clears if checks start running again, new failures appear, provider state becomes uncertain, or the PR is merged, closed, or declined
 - Waits a 60s grace period before trusting empty results (CI checks may not have registered yet)
 - If CI failures or, on GitHub or GitLab, a merge conflict are already known while other checks are still pending: waits for all checks to finish before attempting an auto-fix

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -476,7 +476,9 @@ func renderDriveResult(cmd *cobra.Command, run *ipc.RunInfo, ciReady bool) error
 		}
 		fixes := rv.fixRows()
 		fields = appendFixesField(fields, fixes)
-		fields = append(fields, toon.Field{Key: "help", Value: append([]string{merge}, successReportHelp(fixes)...)})
+		help := append([]string{merge}, successReportHelp(fixes)...)
+		help = append(help, staleMonitorGuidance)
+		fields = append(fields, toon.Field{Key: "help", Value: help})
 		emitDoc(cmd, fields...)
 		return nil
 	}

--- a/internal/cli/axi_guidance.go
+++ b/internal/cli/axi_guidance.go
@@ -1,0 +1,15 @@
+package cli
+
+// staleMonitorGuidance is the canonical, point-of-use guidance an agent reads
+// when `axi run` returns `checks-passed`: what to do if that PR later falls
+// behind the default branch or hits a merge conflict (commonly because another
+// PR merged first). The live CI monitor keeps running after checks pass and
+// auto-rebases onto the base, resolves the conflict, and re-pushes the branch
+// itself, so the agent runs no command and never hand-rebases. `no-mistakes
+// rerun` is only the recovery for a monitor that is no longer running.
+//
+// This same guidance is mirrored in the skill body (internal/skill/skill.go)
+// and the published agents guide (docs/.../guides/agents.md); the repo treats
+// agent-driving guidance as a multi-surface contract, and
+// TestStaleMonitorGuidance_SyncedAcrossSurfaces keeps the three in sync.
+const staleMonitorGuidance = "If this PR later falls behind the default branch or hits a merge conflict, the CI monitor rebases onto the base, resolves it, and re-pushes the branch automatically - run no command and never hand-rebase. Only when that monitor is no longer running (PR closed, run aborted, idle-timeout, or auto-fix exhausted) recover with `no-mistakes rerun`."

--- a/internal/cli/axi_guidance_test.go
+++ b/internal/cli/axi_guidance_test.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kunchenguid/no-mistakes/internal/ipc"
+	"github.com/kunchenguid/no-mistakes/internal/skill"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// canonicalStaleMonitorPhrases are the load-bearing claims of the corrected
+// "PR fell behind / conflicted after checks pass" guidance: the live CI monitor
+// auto-rebases and re-pushes such a PR, so the agent runs no command and never
+// hand-rebases, and `no-mistakes rerun` is only the dead-monitor recovery.
+var canonicalStaleMonitorPhrases = []string{
+	"never hand-rebase",
+	"re-pushes",
+	"no-mistakes rerun",
+}
+
+// TestStaleMonitorGuidance_SyncedAcrossSurfaces guards the repo invariant that
+// agent-driving guidance stays in sync across its three surfaces: the skill
+// body, the published agents guide, and the live axi help string. The earlier
+// wrong wording (telling agents to re-run a stale PR with `axi run`) shipped to
+// only one surface; this keeps the corrected guidance present on all three.
+func TestStaleMonitorGuidance_SyncedAcrossSurfaces(t *testing.T) {
+	surfaces := map[string]string{
+		"skill body":      skill.Markdown(),
+		"agents guide":    readAgentsGuide(t),
+		"axi help string": staleMonitorGuidance,
+	}
+	for name, content := range surfaces {
+		for _, phrase := range canonicalStaleMonitorPhrases {
+			if !strings.Contains(content, phrase) {
+				t.Errorf("%s is missing the canonical stale-monitor guidance phrase %q", name, phrase)
+			}
+		}
+	}
+
+	// The discarded wrong framing must not creep back into any surface.
+	for name, content := range surfaces {
+		if strings.Contains(content, "rebase step integrates the latest") {
+			t.Errorf("%s still carries the discarded 'rebase step integrates the latest default branch' wording", name)
+		}
+	}
+}
+
+// TestStaleMonitorGuidance_InChecksPassedOutput ensures the guidance reaches the
+// agent at its point of use: the `checks-passed` axi output, where the agent
+// decides what to do about the still-monitored PR.
+func TestStaleMonitorGuidance_InChecksPassedOutput(t *testing.T) {
+	run := &ipc.RunInfo{
+		ID:      "run-1",
+		Branch:  "feature/x",
+		Status:  types.RunRunning, // not terminal: daemon keeps monitoring until merge
+		HeadSHA: "abcdef1234567890",
+		PRURL:   strptr("https://github.com/user/repo/pull/42"),
+		Steps: []ipc.StepResultInfo{
+			{StepName: types.StepCI, Status: types.StepStatusRunning},
+		},
+	}
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&out)
+	if err := renderDriveResult(cmd, run, true); err != nil {
+		t.Fatalf("checks-passed must exit 0, got error: %v", err)
+	}
+
+	got := out.String()
+	for _, phrase := range canonicalStaleMonitorPhrases {
+		if !strings.Contains(got, phrase) {
+			t.Errorf("checks-passed output missing stale-monitor guidance phrase %q in:\n%s", phrase, got)
+		}
+	}
+}
+
+func readAgentsGuide(t *testing.T) string {
+	t.Helper()
+	// internal/cli -> repo root is two levels up.
+	path := filepath.Join("..", "..", "docs", "src", "content", "docs", "guides", "agents.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read agents guide %s: %v", path, err)
+	}
+	return string(data)
+}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -210,6 +210,20 @@ The CI step deliberately keeps watching the PR after checks pass, so
 ` + "`axi run`" + ` returns ` + "`checks-passed`" + ` the moment checks are green rather than
 blocking on the human merge. Never poll or re-run waiting for the merge yourself.
 
+Because that monitor stays live, a PR that falls behind the default branch or
+hits a merge conflict after checks pass - commonly because another PR merged
+first - needs **no command from you**: never hand-rebase. When the CI monitor
+sees an actual conflict it **rebases onto the base, resolves it, and re-pushes
+the branch itself**; a PR that is merely behind but still clean needs nothing
+either, since the platform merges it. The one exception is when that monitor is
+no longer running - the PR was closed, the run was aborted or superseded, it
+idle-timed-out, or its auto-fix attempts were exhausted - in which case recover
+with ` + "`no-mistakes rerun`" + `, which cancels the stale monitor and re-runs the full
+pipeline including a deterministic rebase step. Do **not** reach for
+` + "`no-mistakes axi run`" + ` to refresh a still-active PR: after ` + "`checks-passed`" + ` it
+reattaches to the running monitor (HEAD unchanged) and returns its output
+without rebasing.
+
 On a successful outcome (` + "`checks-passed`" + ` or ` + "`passed`" + `), close the loop with the
 user: summarize what happened during the pipeline in a concise, easily readable
 format - what was validated and what was found. If the output includes a

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -171,6 +171,20 @@ The CI step deliberately keeps watching the PR after checks pass, so
 `axi run` returns `checks-passed` the moment checks are green rather than
 blocking on the human merge. Never poll or re-run waiting for the merge yourself.
 
+Because that monitor stays live, a PR that falls behind the default branch or
+hits a merge conflict after checks pass - commonly because another PR merged
+first - needs **no command from you**: never hand-rebase. When the CI monitor
+sees an actual conflict it **rebases onto the base, resolves it, and re-pushes
+the branch itself**; a PR that is merely behind but still clean needs nothing
+either, since the platform merges it. The one exception is when that monitor is
+no longer running - the PR was closed, the run was aborted or superseded, it
+idle-timed-out, or its auto-fix attempts were exhausted - in which case recover
+with `no-mistakes rerun`, which cancels the stale monitor and re-runs the full
+pipeline including a deterministic rebase step. Do **not** reach for
+`no-mistakes axi run` to refresh a still-active PR: after `checks-passed` it
+reattaches to the running monitor (HEAD unchanged) and returns its output
+without rebasing.
+
 On a successful outcome (`checks-passed` or `passed`), close the loop with the
 user: summarize what happened during the pipeline in a concise, easily readable
 format - what was validated and what was found. If the output includes a


### PR DESCRIPTION
## Intent

Close a documentation gap in the no-mistakes agent-driving guidance: what an agent (or supervising tool) should do when a previously-green PR falls behind the default branch or develops a merge conflict because the default branch moved under it (commonly because a sibling PR merged first). The gap caused agents to reach for a manual git rebase, or for a 'no-mistakes axi run'/'rerun', when none of those is correct.

CORRECT behavior (verified by reading the code - internal/pipeline/steps/ci.go and ci_fix.go): the CI monitor keeps looping in the background after checks pass (the run stays non-terminal while the agent receives checks-passed). On each poll it reads the PR mergeable state, and on an ACTUAL merge conflict it auto-rebases onto the base, resolves it, and re-pushes the branch itself (autoFixCI -> commitAndPush, lease-guarded via resolveForcePushDecision; AutoFix.CI defaults to 3). So the agent runs NO command and NEVER hand-rebases. A merely behind-but-clean PR needs nothing; the platform merges it.

The single exception is a monitor that is no longer running (PR closed, run aborted/superseded, idle-timeout with no base advance, or auto-fix attempts exhausted): recover with 'no-mistakes rerun', which cancels the stale monitor and re-runs the full pipeline including a deterministic rebase step. The guidance also explicitly says NOT to use 'no-mistakes axi run' to refresh a still-active PR, because with HEAD unchanged runAxiRun reattaches to the running monitor (activeRunInfoForHead) and returns its output without rebasing.

This is captain-approved 'Option B' and intentionally CORRECTS an earlier wrong framing (an earlier draft told agents to re-run the pipeline with axi run/rerun to refresh a stale PR, which is wrong); the branch history was amended to a single clean commit. The earlier review of this work already adjudicated the axi-run-vs-rerun nuance, so it is deliberate, not an oversight.

DECISIONS a reviewer should know: (1) skills/no-mistakes/SKILL.md is GENERATED from the body constant in internal/skill/skill.go; I edited the source and regenerated via 'make skill' - both change together by design, never hand-edit SKILL.md. (2) The repo treats agent-driving guidance as a multi-surface contract, so the same guidance is applied to ALL THREE synced surfaces: the skill body, the published agents guide (docs/src/content/docs/guides/agents.md), and a new shared axi help string (internal/cli/axi_guidance.go) surfaced at the checks-passed outcome help in renderDriveResult. (3) Added a cross-surface regression test (internal/cli/axi_guidance_test.go) asserting the canonical phrases appear on all three surfaces and reach the checks-passed axi output, and that the discarded wrong wording does not return. (4) Kept the wording general (no GitHub/GitLab/Bitbucket specifics) per the captain. No runtime behavior change; documentation/help-string plus test only. gofmt, make lint, go test -race ./..., go build, and make e2e all pass locally.

## What Changed
- Clarified agent-facing guidance that a still-running CI monitor handles stale or conflicted PR refreshes itself, and that agents should not hand-rebase or use `no-mistakes axi run` for that case.
- Added shared AXI guidance surfaced from the checks-passed outcome, plus regression coverage to keep the live AXI output, generated skill, and published agents guide in sync.
- Updated related docs references and regenerated `skills/no-mistakes/SKILL.md` from `internal/skill/skill.go`.

## Risk Assessment

✅ Low: The branch is limited to synchronized agent guidance, one checks-passed help string, and focused regression coverage with no substantive runtime behavior changes.

## Testing

The baseline full race suite was already green; I reran the focused CLI and skill race tests, captured the actual `checks-passed` AXI output an agent would see, and recorded the matching docs/skill guidance excerpts. All validation passed and the only remaining working-tree additions are the intended evidence files.

- Evidence: [checks-passed AXI output](https://github.com/kunchenguid/no-mistakes/blob/0bbdd1ba98dd9735e66bb603c51a6280aa3c8f5e/.no-mistakes/evidence/fm/nm-rebase-clarify-c5/checks-passed-axi-output.txt)
- Evidence: [cross-surface guidance excerpts](https://github.com/kunchenguid/no-mistakes/blob/0bbdd1ba98dd9735e66bb603c51a6280aa3c8f5e/.no-mistakes/evidence/fm/nm-rebase-clarify-c5/cross-surface-guidance-excerpts.txt)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`
- <code>Baseline provided by the harness before this validation: `go test -race ./...`</code>
- `go test -race ./internal/cli -run 'Test(StaleMonitorGuidance|RenderDriveResult_ChecksPassed)' -count=1`
- `go test -race ./internal/skill -run 'Test(MarkdownFrontmatter|BodyDocumentsAxiGateGuidance|Vendored)' -count=1`
- <code>Temporarily added a logging test harness, ran `go test ./internal/cli -run &#39;^TestEvidenceChecksPassedGuidanceOutput$&#39; -count=1 -v | tee .no-mistakes/evidence/fm/nm-rebase-clarify-c5/checks-passed-axi-output.txt`, then removed the harness.</code>
- `rg -n -C 6 'never hand-rebase|no-mistakes axi run.*refresh|re-pushes' docs/src/content/docs/guides/agents.md skills/no-mistakes/SKILL.md internal/cli/axi_guidance.go | tee .no-mistakes/evidence/fm/nm-rebase-clarify-c5/cross-surface-guidance-excerpts.txt`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
