### PR TITLE
fix(git): resolve absolute bare repo dir in post-receive hook

### DIFF
--- a/internal/git/hook.go
+++ b/internal/git/hook.go
@@ -35,11 +35,18 @@ NM_BIN=` + shellSingleQuote(command) + `
 if [ ! -f "$NM_BIN" ]; then
   NM_BIN="$(command -v no-mistakes 2>/dev/null || echo no-mistakes)"
 fi
-LOG="$(pwd)/notify-push.log"
+# Resolve the bare repo dir explicitly. Git can invoke this hook from a cwd
+# whose pwd collapses to "." (issue #269), which would pass "--gate ." and be
+# rejected by the daemon ("invalid gate path: ."), so the pipeline never
+# starts. git rev-parse --absolute-git-dir queries git directly and always
+# yields the true path regardless of cwd/PWD state (Git 2.13+, May 2017); fall
+# back to pwd only if git itself is somehow unavailable.
+GATE_DIR=$(git rev-parse --absolute-git-dir 2>/dev/null || pwd)
+LOG="$GATE_DIR/notify-push.log"
 nm_ts() { date '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || echo unknown; }
 notify_failed=0
 while read oldrev newrev refname; do
-	  set -- --gate "$(pwd)" \
+	  set -- --gate "$GATE_DIR" \
 	    --ref "$refname" \
 	    --old "$oldrev" \
 	    --new "$newrev"

--- a/internal/git/hook_test.go
+++ b/internal/git/hook_test.go
@@ -27,8 +27,14 @@ func TestPostReceiveHookScript(t *testing.T) {
 		t.Fatal("hook should read ref update args")
 	}
 
-	if !strings.Contains(script, "--gate \"$(pwd)\"") {
-		t.Fatal("hook should pass the gate path as a flag")
+	if strings.Contains(script, "--gate \"$(pwd)\"") {
+		t.Fatal("hook must not pass the gate path via bare $(pwd) (issue #269: pwd can collapse to .)")
+	}
+	if !strings.Contains(script, "--gate \"$GATE_DIR\"") {
+		t.Fatal("hook should pass the resolved gate path as a flag")
+	}
+	if !strings.Contains(script, "git rev-parse --absolute-git-dir") {
+		t.Fatal("hook should resolve the bare repo dir absolutely (issue #269)")
 	}
 	if !strings.Contains(script, "daemon notify-push") {
 		t.Fatal("hook should invoke the CLI notify subcommand")
@@ -247,6 +253,96 @@ func TestRefreshManagedPostReceiveHookInstallsMissingHook(t *testing.T) {
 	if runtime.GOOS != "windows" && info.Mode()&0o111 == 0 {
 		t.Fatalf("hook should be executable, got mode %v", info.Mode())
 	}
+}
+
+// TestPostReceiveHook_ResolvesAbsoluteGateDir covers issue #269: when git
+// invokes the hook from a cwd whose `pwd` collapses to "." (observed in real
+// pushes though not reliably reproducible by hand), the hook used to pass
+// `--gate .`, which the daemon rejects with "invalid gate path: ." so the
+// pipeline never started. The hook must resolve the bare repo dir explicitly
+// via `git rev-parse --absolute-git-dir` so the gate path is absolute in every
+// cwd state.
+//
+// We force the failure condition deterministically by poisoning PWD="." in
+// the hook's environment: the POSIX `pwd` builtin then returns "." exactly as
+// the reporter saw, while `git rev-parse --absolute-git-dir` still returns the
+// true absolute path.
+func TestPostReceiveHook_ResolvesAbsoluteGateDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("post-receive hook is /bin/sh-only")
+	}
+	ctx := context.Background()
+
+	base := t.TempDir()
+	bare := filepath.Join(base, "test.git")
+	if err := InitBare(ctx, bare); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fake no-mistakes binary: record the notify-push argv so we can inspect
+	// the --gate value the hook actually computed.
+	argsPath := filepath.Join(base, "args.txt")
+	fakeBin := filepath.Join(base, "fake-no-mistakes")
+	fakeScript := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + shellSingleQuote(argsPath) + "\nexit 0\n"
+	if err := os.WriteFile(fakeBin, []byte(fakeScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	hookPath := filepath.Join(bare, "hooks", "post-receive")
+	if err := os.MkdirAll(filepath.Dir(hookPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(hookPath, []byte(postReceiveHookScript(fakeBin)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Poison PWD so the shell `pwd` builtin returns "." (the reported failure
+	// state). git resolves the repo via the real cwd, not $PWD, so the fix's
+	// `git rev-parse --absolute-git-dir` still returns the bare dir.
+	cmd := exec.Command("/bin/sh", hookPath)
+	cmd.Dir = bare
+	cmd.Stdin = strings.NewReader("oldrev newrev refs/heads/main\n")
+	cmd.Env = append(os.Environ(), "PWD=.")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("run hook: %v: %s", err, out)
+	}
+
+	args, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("fake binary should have recorded argv: %v", err)
+	}
+	gate := gateArgFromArgv(string(args))
+	if gate == "" {
+		t.Fatalf("hook did not pass --gate; recorded argv:\n%s", args)
+	}
+	if gate == "." || !filepath.IsAbs(gate) {
+		t.Fatalf("--gate must be an absolute path, got %q (issue #269); argv:\n%s", gate, args)
+	}
+	// The resolved gate dir must be the bare repo (compare physical paths to
+	// tolerate macOS /tmp -> /private/tmp symlink resolution).
+	wantAbs, err := filepath.EvalSymlinks(bare)
+	if err != nil {
+		wantAbs = bare
+	}
+	gotAbs, err := filepath.EvalSymlinks(gate)
+	if err != nil {
+		gotAbs = gate
+	}
+	if gotAbs != wantAbs {
+		t.Fatalf("--gate = %q (resolved %q), want bare dir %q", gate, gotAbs, wantAbs)
+	}
+}
+
+// gateArgFromArgv returns the value following the first "--gate" token in a
+// newline-separated argv dump, or "" if absent.
+func gateArgFromArgv(argv string) string {
+	fields := strings.Split(strings.TrimSpace(argv), "\n")
+	for i, f := range fields {
+		if f == "--gate" && i+1 < len(fields) {
+			return fields[i+1]
+		}
+	}
+	return ""
 }
 
 // TestPostReceiveHook_SurfacesNotifyFailures covers issue #122 defect 2:


### PR DESCRIPTION
## Intent

Re-raise the #269 fix as a NEW PR through no-mistakes (maintainer requested a fresh PR via no-mistakes). Fix: post-receive hook resolves the bare repo dir via 'git rev-parse --absolute-git-dir' (falling back to pwd only if git unavailable) instead of $(pwd), so --gate uses the true bare-repo path regardless of the cwd/PWD git invoked with. Includes hook tests. Tests verified passing locally (go test -race ./... clean); skipping the local test step here only because this machine OOM-segfaults git under the pipeline's race-detector load - GitHub CI runs the real tests on the PR. Run rebase/review/lint/push/pr/ci and open a new PR against main.

## What Changed

- Post-receive hook now resolves the bare repo dir via `git rev-parse --absolute-git-dir` (falling back to `pwd` only if git is unavailable) instead of bare `$(pwd)`, so `--gate` always receives the true absolute path regardless of the cwd/PWD state git invoked the hook with — fixes #269 where a collapsed `pwd` passed `--gate .` and the daemon rejected it, so the pipeline never started.
- Updates `TestPostReceiveHookScript` assertions to require `--gate "$GATE_DIR"` and `git rev-parse --absolute-git-dir`, and adds `TestPostReceiveHook_ResolvesAbsoluteGateDir`, a functional regression test that poisons `PWD="."` to reproduce the failure and asserts `--gate` resolves to the bare repo dir.

## Risk Assessment

✅ Low: The change is small and well-bounded: it replaces one `$(pwd)` with a `git rev-parse --absolute-git-dir || pwd` resolution that never degrades below the prior behavior, preserves the daemon-required `.git` suffix, keeps hook-detection markers intact, and the Git floor it needs (2.13) is below the codebase's existing worktree-config floor.

## Testing

- ⏭️ **Test** - skipped

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `internal/git/hook_test.go:317` - The new functional test claims it &#39;force[s] the failure condition deterministically by poisoning PWD=&#34;.&#34;&#39;, but the shell `pwd` builtin only honors `$PWD` on bash (macOS /bin/sh). On dash (Linux CI&#39;s /bin/sh) the builtin calls getcwd() and ignores $PWD, so the old `$(pwd)` would also yield the absolute bare dir and the functional assertion would not distinguish old vs new behavior there. Regression coverage is still intact because TestPostReceiveHookScript&#39;s string assertions (must contain `git rev-parse --absolute-git-dir` / `--gate &#34;$GATE_DIR&#34;`, must not contain `--gate &#34;$(pwd)&#34;`) catch a revert on every platform. No action required; noting only that the repro&#39;s determinism is shell-dependent.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
