### PR TITLE
fix(daemon): detect stray daemons by resolved root before start

### DIFF
--- a/internal/daemon/collision.go
+++ b/internal/daemon/collision.go
@@ -1,0 +1,202 @@
+package daemon
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/kunchenguid/no-mistakes/internal/paths"
+)
+
+// daemonProcessInfo describes a running `no-mistakes daemon run --root <root>`
+// process discovered via the OS process list.
+type daemonProcessInfo struct {
+	PID  int
+	Root string // raw --root value exactly as it appeared on the command line
+}
+
+// daemonListDaemonProcesses enumerates no-mistakes managed-daemon processes. It
+// is a package var so tests can stub the process list deterministically.
+var daemonListDaemonProcesses = listDaemonProcesses
+
+// errDaemonCollisionHealthy signals that Start refused to launch because a
+// healthy daemon for the same logical root is already running under a different
+// path spelling (e.g. a symlinked NM_HOME).
+var errDaemonCollisionHealthy = errors.New("daemon already running")
+
+// daemonProcessLineSplitter extracts a (pid, command line) pair from one line
+// of platform-specific process-listing output.
+type daemonProcessLineSplitter func(line string) (pid int, command string, ok bool)
+
+// parseDaemonProcessOutput walks a process listing and returns every line that
+// looks like `no-mistakes daemon run --root <root>`, extracting the pid and the
+// raw --root value. The splitter normalizes each platform's output into a pid
+// plus the full command line.
+func parseDaemonProcessOutput(output string, split daemonProcessLineSplitter) []daemonProcessInfo {
+	var infos []daemonProcessInfo
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimRight(line, "\r")
+		pid, command, ok := split(line)
+		if !ok {
+			continue
+		}
+		if !looksLikeDaemonRunCommand(command) {
+			continue
+		}
+		root, hasRoot := extractRootFromCommand(command)
+		if !hasRoot {
+			continue
+		}
+		infos = append(infos, daemonProcessInfo{PID: pid, Root: root})
+	}
+	return infos
+}
+
+// looksLikeDaemonRunCommand reports whether a command line is a no-mistakes
+// managed-daemon invocation (`... daemon run ...`). Detached daemons re-execute
+// the binary bare (no `daemon run` argv) and are deliberately excluded: they
+// bind the canonical socket for their root, so the socket-keyed health check in
+// Start already accounts for them.
+func looksLikeDaemonRunCommand(command string) bool {
+	tokens := splitCommandLineTokens(command)
+	hasDaemon, hasRun := false, false
+	for _, token := range tokens {
+		switch strings.ToLower(token) {
+		case "daemon":
+			hasDaemon = true
+		case "run":
+			hasRun = true
+		}
+	}
+	return hasDaemon && hasRun
+}
+
+// extractRootFromCommand pulls the --root value out of a command line, accepting
+// both `--root <value>` and `--root=<value>`, with or without shell quoting.
+func extractRootFromCommand(command string) (string, bool) {
+	tokens := splitCommandLineTokens(command)
+	for i := 0; i < len(tokens); i++ {
+		switch {
+		case tokens[i] == "--root":
+			if i+1 < len(tokens) {
+				return tokens[i+1], true
+			}
+			return "", false
+		case strings.HasPrefix(tokens[i], "--root="):
+			return strings.TrimPrefix(tokens[i], "--root="), true
+		}
+	}
+	return "", false
+}
+
+// splitCommandLineTokens splits a command line into argv-style tokens, honoring
+// double-quote grouping and backslash escapes the way a POSIX shell / Windows
+// command line roughly would. It is intentionally permissive: the goal is to
+// recover the --root argument from ps/CIM output, not to be a flawless shell
+// parser.
+func splitCommandLineTokens(command string) []string {
+	var tokens []string
+	var current strings.Builder
+	inQuotes := false
+	escaped := false
+	flush := func() {
+		if current.Len() > 0 {
+			tokens = append(tokens, current.String())
+			current.Reset()
+		}
+	}
+	for i := 0; i < len(command); i++ {
+		ch := command[i]
+		switch {
+		case escaped:
+			current.WriteByte(ch)
+			escaped = false
+		case ch == '\\':
+			escaped = true
+		case ch == '"':
+			inQuotes = !inQuotes
+		case (ch == ' ' || ch == '\t') && !inQuotes:
+			flush()
+		default:
+			current.WriteByte(ch)
+		}
+	}
+	flush()
+	return tokens
+}
+
+// reconcileCollidingDaemons detects no-mistakes daemons already running for the
+// same logical root as p but started under a different path spelling (e.g. a
+// symlinked or relative NM_HOME). The socket-keyed health check in Start cannot
+// see those: paths.Paths stores the raw root string and derives its socket from
+// it, so two spellings of the same directory produce two different sockets.
+//
+// Behaviour:
+//   - No collision: return nil so Start proceeds.
+//   - Healthy collision (a daemon already serves this root): refuse to start a
+//     duplicate.
+//   - Stale collision (process exists but is unresponsive, e.g. a crash-looping
+//     managed unit whose binary died): kill the processes, stop the managed
+//     service so systemd's Restart=always cannot immediately revive the dead
+//     binary, and clear failed-unit state. Start then installs and starts a
+//     fresh daemon.
+//
+// Enumeration failures fail open (a warning is logged) so an environment
+// without ps/CIM does not lose the existing pidfile and socket guards.
+func reconcileCollidingDaemons(p *paths.Paths) error {
+	want := canonicalRoot(p.Root())
+	if want == "" {
+		return nil
+	}
+	procs, err := daemonListDaemonProcesses()
+	if err != nil {
+		slog.Warn("daemon collision check skipped: process enumeration failed", "error", err)
+		return nil
+	}
+
+	self := os.Getpid()
+	type candidate struct {
+		pid  int
+		root string
+	}
+	var matches []candidate
+	for _, info := range procs {
+		if info.PID == self {
+			continue
+		}
+		if info.Root == "" || canonicalRoot(info.Root) != want {
+			continue
+		}
+		matches = append(matches, candidate{pid: info.PID, root: info.Root})
+	}
+	if len(matches) == 0 {
+		return nil
+	}
+
+	for _, m := range matches {
+		if alive, _ := daemonHealthCheck(paths.WithRoot(m.root)); alive {
+			slog.Info("daemon already running under alternate root path", "pid", m.pid, "root", m.root)
+			return fmt.Errorf("%w (pid %d)", errDaemonCollisionHealthy, m.pid)
+		}
+	}
+
+	for _, m := range matches {
+		if killErr := daemonKillPID(m.pid); killErr != nil {
+			slog.Warn("kill stale colliding daemon", "pid", m.pid, "error", killErr)
+		}
+	}
+	// Stop the managed unit so Restart=always cannot revive a dead binary while
+	// Start re-installs and re-starts it. Best-effort: install/start below will
+	// reinstall the unit even if this returns an error.
+	if _, err := stopManagedService(p); err != nil {
+		slog.Warn("stop managed service before fresh daemon start", "error", err)
+	}
+	resetFailedManagedService(p)
+	for _, m := range matches {
+		cleanupDaemonArtifacts(paths.WithRoot(m.root))
+	}
+	cleanupDaemonArtifacts(p)
+	return nil
+}

--- a/internal/daemon/collision_test.go
+++ b/internal/daemon/collision_test.go
@@ -1,0 +1,348 @@
+package daemon
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/paths"
+)
+
+func TestSplitCommandLineTokens(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{name: "plain", in: `/x/no-mistakes daemon run --root /a/b`, want: []string{"/x/no-mistakes", "daemon", "run", "--root", "/a/b"}},
+		{name: "equals form", in: `/x/no-mistakes daemon run --root=/a/b`, want: []string{"/x/no-mistakes", "daemon", "run", "--root=/a/b"}},
+		{name: "quoted spaced root", in: `"/x no-mistakes" daemon run --root "/a b/c"`, want: []string{"/x no-mistakes", "daemon", "run", "--root", "/a b/c"}},
+		{name: "escaped quote", in: `daemon run --root a\"b`, want: []string{"daemon", "run", "--root", `a"b`}},
+		{name: "empty", in: ``, want: []string(nil)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := splitCommandLineTokens(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("splitCommandLineTokens(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("splitCommandLineTokens(%q)[%d] = %q, want %q", tc.in, i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestLooksLikeDaemonRunCommand(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{`/x/no-mistakes daemon run --root /a`, true},
+		{`/x/no-mistakes run daemon --root /a`, true}, // order-insensitive
+		{`/x/no-mistakes`, false},                     // detached: bare exe
+		{`postgres --root /a daemon`, false},          // missing "run"
+		{`no-mistakes daemon --root /a`, false},       // missing "run"
+		{``, false},
+	}
+	for _, tc := range tests {
+		if got := looksLikeDaemonRunCommand(tc.in); got != tc.want {
+			t.Errorf("looksLikeDaemonRunCommand(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestExtractRootFromCommand(t *testing.T) {
+	tests := []struct {
+		in     string
+		want   string
+		wantOk bool
+	}{
+		{`daemon run --root /a/b`, "/a/b", true},
+		{`daemon run --root=/a/b`, "/a/b", true},
+		{`daemon run --root "/a b/c"`, "/a b/c", true},
+		{`daemon run`, "", false},
+		{`daemon run --root`, "", false}, // flag with no value
+	}
+	for _, tc := range tests {
+		got, ok := extractRootFromCommand(tc.in)
+		if got != tc.want || ok != tc.wantOk {
+			t.Errorf("extractRootFromCommand(%q) = (%q,%v), want (%q,%v)", tc.in, got, ok, tc.want, tc.wantOk)
+		}
+	}
+}
+
+func TestParseDaemonProcessOutput(t *testing.T) {
+	output := strings.Join([]string{
+		"1234 /home/u/no-mistakes daemon run --root /home/u/.no-mistakes",
+		"  5678 \t/usr/bin/no-mistakes daemon run --root=/tmp/link",
+		`9 "/x no-mistakes" daemon run --root "/a b/c"`,
+		`10 /x/no-mistakes`,             // detached daemon, must be skipped
+		`11 other --root /x daemon run`, // recovered but still daemon-run; root=/x
+		`12 postgres daemon`,            // not daemon-run
+		`bogus not a pid line`,          // unparseable pid
+		``,                              // blank
+	}, "\n")
+	splitter := func(line string) (int, string, bool) {
+		line = strings.TrimLeft(line, " \t")
+		if line == "" {
+			return 0, "", false
+		}
+		sep := strings.IndexAny(line, " \t")
+		if sep < 0 {
+			return 0, "", false
+		}
+		pid, err := strconv.Atoi(line[:sep])
+		if err != nil || pid <= 0 {
+			return 0, "", false
+		}
+		return pid, strings.TrimLeft(line[sep:], " \t"), true
+	}
+	got := parseDaemonProcessOutput(output, splitter)
+	wantRoots := map[int]string{
+		1234: "/home/u/.no-mistakes",
+		5678: "/tmp/link",
+		9:    "/a b/c",
+		11:   "/x",
+	}
+	if len(got) != len(wantRoots) {
+		t.Fatalf("parseDaemonProcessOutput returned %d entries %v, want %d", len(got), got, len(wantRoots))
+	}
+	for _, info := range got {
+		if want, ok := wantRoots[info.PID]; !ok || want != info.Root {
+			t.Errorf("entry %+v mismatch, want root %q", info, want)
+		}
+	}
+}
+
+// --- reconcileCollidingDaemons ---
+
+// stubCollisionVars replaces the process enumeration, health check, and kill
+// seams with closures backed by the caller's maps. It returns a cleanup that
+// restores the originals. It deliberately does NOT touch serviceManagerBypassed
+// (tests that need the managed path use stubServiceRuntime).
+func stubCollisionVars(t *testing.T, procs []daemonProcessInfo, enumErr error, health func(root string) bool, killErr error) (*map[int]bool, func()) {
+	t.Helper()
+	oldList := daemonListDaemonProcesses
+	oldHealth := daemonHealthCheck
+	oldKill := daemonKillPID
+	killed := map[int]bool{}
+	daemonListDaemonProcesses = func() ([]daemonProcessInfo, error) { return procs, enumErr }
+	daemonHealthCheck = func(p *paths.Paths) (bool, error) {
+		if health == nil {
+			return false, nil
+		}
+		return health(p.Root()), nil
+	}
+	daemonKillPID = func(pid int) error {
+		killed[pid] = true
+		return killErr
+	}
+	return &killed, func() {
+		daemonListDaemonProcesses = oldList
+		daemonHealthCheck = oldHealth
+		daemonKillPID = oldKill
+	}
+}
+
+func TestReconcileCollidingDaemons_NoMatchIsNoOp(t *testing.T) {
+	root := t.TempDir()
+	p := paths.WithRoot(root)
+	procs := []daemonProcessInfo{{PID: 4242, Root: filepath.Join(t.TempDir(), "other")}}
+	_, restore := stubCollisionVars(t, procs, nil, nil, nil)
+	defer restore()
+
+	killed := false
+	daemonKillPID = func(int) error { killed = true; return nil }
+
+	if err := reconcileCollidingDaemons(p); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if killed {
+		t.Fatal("no matching root, but a process was killed")
+	}
+}
+
+func TestReconcileCollidingDaemons_SelfPidExcluded(t *testing.T) {
+	root := t.TempDir()
+	p := paths.WithRoot(root)
+	procs := []daemonProcessInfo{{PID: selfPID(), Root: root}}
+	_, restore := stubCollisionVars(t, procs, nil, func(string) bool { return true }, nil)
+	defer restore()
+
+	// Self is healthy but must not trip the "already running" refusal.
+	if err := reconcileCollidingDaemons(p); err != nil {
+		t.Fatalf("self pid must be excluded, got %v", err)
+	}
+}
+
+func TestReconcileCollidingDaemons_RefusesWhenHealthyStrayExists(t *testing.T) {
+	root := t.TempDir()
+	link := filepath.Join(t.TempDir(), "link")
+	if err := os.Symlink(root, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	p := paths.WithRoot(root) // canonical start uses the real path
+	strayRoot := link         // stray was started via the symlink spelling
+
+	procs := []daemonProcessInfo{{PID: 99999, Root: strayRoot}}
+	_, restore := stubCollisionVars(t, procs, nil, func(r string) bool { return r == strayRoot }, nil)
+	defer restore()
+
+	err := reconcileCollidingDaemons(p)
+	if !errors.Is(err, errDaemonCollisionHealthy) {
+		t.Fatalf("expected errDaemonCollisionHealthy, got %v", err)
+	}
+}
+
+func TestReconcileCollidingDaemons_ReapsStaleStrayAndResetsManagedUnit(t *testing.T) {
+	root := t.TempDir()
+	p := paths.WithRoot(root)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	// A socket file the stale stray left behind; cleanup must remove it.
+	if err := os.WriteFile(p.Socket(), []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	procs := []daemonProcessInfo{{PID: 8888, Root: root}}
+	killed, restore := stubCollisionVars(t, procs, nil, func(string) bool { return false }, nil)
+	defer restore()
+
+	// Engage the real managed-service plumbing so stopManagedService actually
+	// issues systemctl commands we can observe, and so resetFailed runs.
+	svcRestore := stubServiceRuntime(t)
+	defer svcRestore()
+	runtimeGOOS = "linux"
+	home := t.TempDir()
+	serviceUserHomeDir = func() (string, error) { return home, nil }
+	// Pretend the managed unit is installed so stopManagedService reaches the
+	// systemctl stop call instead of short-circuiting.
+	if err := os.MkdirAll(filepath.Dir(systemdUserServicePath(p)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(systemdUserServicePath(p), []byte("[Service]\nExecStart=/x daemon run\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var svcCmds []string
+	serviceCommandRunner = func(name string, args ...string) ([]byte, error) {
+		svcCmds = append(svcCmds, name+" "+strings.Join(args, " "))
+		return nil, nil
+	}
+
+	if err := reconcileCollidingDaemons(p); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+
+	if !(*killed)[8888] {
+		t.Error("stale stray pid 8888 was not killed")
+	}
+	if _, err := os.Stat(p.Socket()); !os.IsNotExist(err) {
+		t.Errorf("stale socket should have been cleaned up, stat err=%v", err)
+	}
+	unit := systemdServiceName(p)
+	if !containsCmd(svcCmds, "systemctl --user stop "+unit) {
+		t.Errorf("expected systemctl stop for %s in %v", unit, svcCmds)
+	}
+	if !containsCmd(svcCmds, "systemctl --user reset-failed "+unit) {
+		t.Errorf("expected systemctl reset-failed for %s in %v", unit, svcCmds)
+	}
+}
+
+func TestReconcileCollidingDaemons_FailsOpenOnEnumerationError(t *testing.T) {
+	root := t.TempDir()
+	p := paths.WithRoot(root)
+	_, restore := stubCollisionVars(t, nil, errors.New("ps missing"), nil, nil)
+	defer restore()
+
+	if err := reconcileCollidingDaemons(p); err != nil {
+		t.Fatalf("enumeration error must fail open, got %v", err)
+	}
+}
+
+func TestReconcileCollidingDaemons_EmptyRootIsNoOp(t *testing.T) {
+	called := false
+	daemonListDaemonProcesses = func() ([]daemonProcessInfo, error) {
+		called = true
+		return nil, nil
+	}
+	defer func() { daemonListDaemonProcesses = listDaemonProcesses }()
+
+	if err := reconcileCollidingDaemons(paths.WithRoot("")); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if called {
+		t.Fatal("empty root must skip enumeration")
+	}
+}
+
+func containsCmd(cmds []string, want string) bool {
+	for _, c := range cmds {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}
+
+func selfPID() int { return os.Getpid() }
+
+// TestListDaemonProcesses_FindsSpawnedDaemonRunHelper spawns the test binary
+// with an argv that looks exactly like a managed daemon (`daemon run --root X`)
+// and confirms the real ps-based collector rediscovers it. Unix-only: Windows
+// enumerates via PowerShell CIM.
+func TestListDaemonProcesses_FindsSpawnedDaemonRunHelper(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("ps-based enumeration is unix-only")
+	}
+	if _, err := exec.LookPath("ps"); err != nil {
+		t.Skipf("ps unavailable: %v", err)
+	}
+
+	root := t.TempDir()
+	// TestMain in helpers_test.go parks processes with NM_DAEMON_HELPER_PROCESS
+	// set, so the helper stays alive (sleeps) regardless of its argv. Its
+	// command line still reads "<testbin> daemon run --root <root>".
+	helper := exec.Command(os.Args[0], "daemon", "run", "--root", root)
+	helper.Env = append(os.Environ(), "NM_DAEMON_HELPER_PROCESS=block")
+	if err := helper.Start(); err != nil {
+		t.Fatalf("start helper: %v", err)
+	}
+	defer func() {
+		_ = helper.Process.Kill()
+		_, _ = helper.Process.Wait()
+	}()
+
+	deadline := time.Now().Add(3 * time.Second)
+	var found bool
+	for time.Now().Before(deadline) && !found {
+		infos, err := listDaemonProcesses()
+		if err != nil {
+			t.Fatalf("listDaemonProcesses: %v", err)
+		}
+		for _, info := range infos {
+			if info.PID == helper.Process.Pid {
+				if info.Root != root {
+					t.Fatalf("found helper pid %d but root %q != %q", info.PID, info.Root, root)
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+	if !found {
+		t.Fatalf("ps enumeration did not find helper pid %d with root %q", helper.Process.Pid, root)
+	}
+}

--- a/internal/daemon/proc_unix.go
+++ b/internal/daemon/proc_unix.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -14,6 +15,39 @@ import (
 
 func setSysProcAttr(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}
+
+// listDaemonProcesses enumerates running processes via ps and returns the ones
+// that look like `no-mistakes daemon run --root <root>`. It powers the
+// pgrep-style collision detection in reconcileCollidingDaemons. `ps` is used
+// (rather than /proc) so the same approach works on Linux and macOS.
+func listDaemonProcesses() ([]daemonProcessInfo, error) {
+	cmd := exec.Command(psExecutable(), "-ww", "-eo", "pid=,command=")
+	env := upsertEnv(os.Environ(), "LC_ALL", "C")
+	cmd.Env = upsertEnv(env, "LANG", "C")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("enumerate processes: %w", err)
+	}
+	return parseDaemonProcessOutput(string(out), splitUnixProcessLine), nil
+}
+
+// splitUnixProcessLine parses one line of `ps -eo pid=,command=` output into a
+// pid and the trailing command line.
+func splitUnixProcessLine(line string) (int, string, bool) {
+	trimmed := strings.TrimLeft(line, " \t")
+	if trimmed == "" {
+		return 0, "", false
+	}
+	sep := strings.IndexAny(trimmed, " \t")
+	if sep < 0 {
+		return 0, "", false
+	}
+	pid, err := strconv.Atoi(trimmed[:sep])
+	if err != nil || pid <= 0 {
+		return 0, "", false
+	}
+	return pid, strings.TrimLeft(trimmed[sep:], " \t"), true
 }
 
 func processRunning(pid int) (bool, error) {

--- a/internal/daemon/proc_windows.go
+++ b/internal/daemon/proc_windows.go
@@ -3,7 +3,10 @@
 package daemon
 
 import (
+	"fmt"
 	"os/exec"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -11,6 +14,40 @@ import (
 )
 
 const windowsStillActive = 259
+
+// psListDaemonProcessesScript is the PowerShell that emits one
+// "<pid>\t<commandline>" line per process with a command line, consumed by
+// listDaemonProcesses. The backtick-t is PowerShell's tab inside the
+// double-quoted interpolated string.
+const psListDaemonProcessesScript = "$ErrorActionPreference='SilentlyContinue'; Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -ne $null } | ForEach-Object { \"$($_.ProcessId)`t$($_.CommandLine)\" }"
+
+// listDaemonProcesses enumerates running processes via PowerShell CIM and
+// returns the ones that look like `no-mistakes daemon run --root <root>`. It
+// powers the collision detection in reconcileCollidingDaemons on Windows.
+// Failures (e.g. PowerShell absent) fail open in the caller.
+func listDaemonProcesses() ([]daemonProcessInfo, error) {
+	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", psListDaemonProcessesScript)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("enumerate processes: %w", err)
+	}
+	return parseDaemonProcessOutput(string(out), splitWindowsProcessLine), nil
+}
+
+// splitWindowsProcessLine parses one "<pid>\t<commandline>" line emitted by the
+// PowerShell CIM script.
+func splitWindowsProcessLine(line string) (int, string, bool) {
+	trimmed := strings.TrimLeft(line, " \t")
+	idx := strings.IndexByte(trimmed, '\t')
+	if idx <= 0 {
+		return 0, "", false
+	}
+	pid, err := strconv.Atoi(trimmed[:idx])
+	if err != nil || pid <= 0 {
+		return 0, "", false
+	}
+	return pid, strings.TrimLeft(trimmed[idx+1:], " \t"), true
+}
 
 // detachedDaemonCreationFlags detaches the spawned daemon from the parent's
 // console and process group so the parent CLI can exit cleanly even if the

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -69,6 +69,14 @@ func Start(p *paths.Paths) error {
 		}
 		return fmt.Errorf("daemon already running")
 	}
+	// Canonical socket is dead. A daemon for the same logical root may still be
+	// alive under a different path spelling (symlinked or relative NM_HOME),
+	// which the socket-keyed health check above cannot see. Detect via the OS
+	// process list: refuse if a healthy stray is serving this root, or reap a
+	// stale stray (including a crash-looping managed unit) before starting.
+	if err := reconcileCollidingDaemons(p); err != nil {
+		return err
+	}
 	if managed, err := installManagedService(p); err == nil {
 		if managed {
 			if err := startManagedDaemon(p); err == nil {

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -87,22 +87,34 @@ func serviceInstanceSuffix(p *paths.Paths) string {
 	if p != nil {
 		root = p.Root()
 	}
-	if root != "" {
-		if !filepath.IsAbs(root) {
-			if absRoot, err := filepath.Abs(root); err == nil {
-				root = absRoot
-			}
+	sum := sha256.Sum256([]byte(canonicalRoot(root)))
+	return hex.EncodeToString(sum[:4])
+}
+
+// canonicalRoot collapses a root path to its stable physical form so two
+// spellings of the same directory (absolute vs relative, symlinked vs real,
+// trailing-slash variants, and case on Windows) compare equal. It mirrors the
+// normalization serviceInstanceSuffix hashes, so the managed-service identifier
+// and the daemon-collision key (reconcileCollidingDaemons) agree on what
+// "same root" means. Resolution is best-effort: if symlinks cannot be evaluated
+// the cleaned input is returned unchanged.
+func canonicalRoot(root string) string {
+	if root == "" {
+		return ""
+	}
+	if !filepath.IsAbs(root) {
+		if abs, err := filepath.Abs(root); err == nil {
+			root = abs
 		}
-		if resolved, err := filepath.EvalSymlinks(root); err == nil {
-			root = resolved
-		}
+	}
+	if resolved, err := filepath.EvalSymlinks(root); err == nil {
+		root = resolved
 	}
 	root = filepath.Clean(root)
 	if runtimeGOOS == "windows" {
 		root = strings.ToLower(root)
 	}
-	sum := sha256.Sum256([]byte(root))
-	return hex.EncodeToString(sum[:4])
+	return root
 }
 
 func launchdServiceLabel(p *paths.Paths) string {
@@ -198,6 +210,22 @@ func stopManagedService(p *paths.Paths) (bool, error) {
 		return true, stopWindowsTask(p)
 	default:
 		return false, nil
+	}
+}
+
+// resetFailedManagedService clears failed-unit bookkeeping for the daemon's
+// managed service. A crash-looping systemd unit (Restart=always on a dead
+// binary) is held by the manager in a failed/backoff state that keeps emitting
+// journal entries even after the process is gone. Clearing it lets the fresh
+// install in Start() begin from a clean slate. No-op on platforms without an
+// equivalent and when the service manager is bypassed.
+func resetFailedManagedService(p *paths.Paths) {
+	if serviceManagerBypassed() {
+		return
+	}
+	switch runtimeGOOS {
+	case "linux":
+		_, _ = serviceCommandRunner("systemctl", "--user", "reset-failed", systemdServiceName(p))
 	}
 }
 


### PR DESCRIPTION
Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

## Pipeline

Driven through `git push no-mistakes` (`fix/daemon-collision-and-unit-leak`). Non-agent steps ran in the gate:

- intent: completed
- rebase: completed
- lint (`make lint` = skill-check + `go vet ./...`): completed, clean
- push: completed (branch pushed to fork)
- review / test / document / pr: **skipped or could not complete** — the configured `opencode` agent hangs on the daemon's session/SSE request path in this environment (idle server, no model connection, reproducible across runs; `opencode run` in isolation works). Environmental tooling issue, not a change defect. Tests validated locally (`go test -race ./...` all pass) and re-validated by CI below.

## Summary

Fixes the daemon-collision + reliability failures: duplicate no-mistakes daemons spawning on the same root, crash-loops burning CPU, and journal spam.

## Root cause

`daemon start` only health-checked the **canonical socket**, whose path is derived from the raw `--root` string. A managed daemon started under a symlinked or relative `NM_HOME` (same logical root, different spelling) binds a **different socket**, so the check missed it and `Start` spawned a duplicate on top of the same systemd unit. Two daemons fighting over one unit then crash-looped (`Restart=always`), burning CPU and spamming the journal.

## Fix

Process-list collision detection keyed on the **resolved** root:

- Before starting, enumerate `no-mistakes daemon run --root <root>` processes via `ps` (unix) / CIM (windows) and match by `canonicalRoot`.
- **Healthy stray** for the same root -> refuse to start a duplicate.
- **Stale stray** (incl. a crash-looping managed unit) -> kill it, stop the managed unit so systemd cannot revive the dead binary, and `systemctl reset-failed` to clear journal backoff.

Factored the existing stable per-root unit naming (#84) into a shared `canonicalRoot` so the unit name and the collision key agree on "same root". The stable per-root unit naming was already in place; this closes the detection gap that let duplicates form. Enumeration fails open (warn + proceed) so environments without `ps`/CIM keep the pidfile/socket guards.

## Validation

- `go test -race ./...` — all packages pass, incl. new `internal/daemon/collision_test.go` with a real `ps` integration test that spawns a helper posing as a managed daemon.
- `make lint` (skill-check + `go vet ./...`) — clean.
- `gofmt` — clean.
- CI (this PR) — `test (ubuntu/macos/windows)`, `check`, `e2e`.