### PR TITLE
fix(windows): codex prompt on stdin, suppress console pop-ups, surface codex failure reasons

### DIFF
--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -57,10 +57,15 @@ func (a *codexAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error)
 		defer os.Remove(schemaPath)
 	}
 
-	args := a.buildArgs(opts.Prompt, schemaPath)
+	args := a.buildArgs(schemaPath)
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD
-	cmd.Stdin = nil
+	// Deliver the prompt on stdin (the "-" arg in buildArgs) rather than as a
+	// command-line argument. Review/test prompts embed the full diff, which on
+	// Windows can push the command line past the ~32 KB CreateProcess limit and
+	// fail with "The command line is too long" (or make codex emit no output at
+	// all). stdin has no such limit, so this is the robust cross-platform path.
+	cmd.Stdin = strings.NewReader(opts.Prompt)
 	cmd.Env = gitSafeEnv(opts.CWD)
 	shellenv.ConfigureShellCommand(cmd)
 
@@ -100,20 +105,32 @@ func (a *codexAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error)
 		return nil, fmt.Errorf("codex exited: %w: %s", waitErr, detail)
 	}
 
+	// codex can exit 0 yet produce no agent message - e.g. a usage-limit or
+	// turn.failed event. Surface that reason instead of the opaque
+	// "codex returned no text output", so a failing pipeline step says *why*.
+	if lastMessage == "" {
+		if detail := strings.TrimSpace(codexErr); detail != "" {
+			return nil, fmt.Errorf("codex: %s", detail)
+		}
+	}
+
 	return finalizeTextResult("codex", lastMessage, validationSchema, usage)
 }
 
 func (a *codexAgent) Close() error { return nil }
 
 // buildArgs constructs the codex CLI arguments. User-supplied extraArgs are
-// inserted between "exec" and the prompt so user flags (e.g. -m, --sandbox)
-// take effect. If the user declared their own execution-mode flag, the
+// inserted between "exec" and the prompt-source flag so user flags (e.g. -m,
+// --sandbox) take effect. The prompt itself is delivered on stdin: the "-"
+// argument tells codex to read its instructions from stdin, which sidesteps the
+// Windows command-line length limit that a large diff embedded in the prompt
+// would otherwise hit. If the user declared their own execution-mode flag, the
 // default --dangerously-bypass-approvals-and-sandbox is not added.
-func (a *codexAgent) buildArgs(prompt, schemaPath string) []string {
+func (a *codexAgent) buildArgs(schemaPath string) []string {
 	args := make([]string, 0, len(a.extraArgs)+8)
 	args = append(args, "exec")
 	args = append(args, a.extraArgs...)
-	args = append(args, prompt, "--json")
+	args = append(args, "-", "--json")
 	if schemaPath != "" {
 		args = append(args, "--output-schema", schemaPath)
 	}
@@ -147,6 +164,13 @@ type codexEvent struct {
 	Item    *codexItem  `json:"item,omitempty"`
 	Usage   *codexUsage `json:"usage,omitempty"`
 	Message string      `json:"message,omitempty"`
+	Error   *codexError `json:"error,omitempty"`
+}
+
+// codexError carries the message from a turn.failed event, where the reason is
+// nested under "error" rather than at the top level like an "error" event.
+type codexError struct {
+	Message string `json:"message"`
 }
 
 type codexItem struct {
@@ -187,6 +211,11 @@ func parseCodexEvents(ctx context.Context, r io.Reader, onChunk func(string), us
 		case "error":
 			if event.Message != "" && codexErr != nil {
 				*codexErr = event.Message
+			}
+
+		case "turn.failed":
+			if event.Error != nil && event.Error.Message != "" && codexErr != nil {
+				*codexErr = event.Error.Message
 			}
 
 		case "item.completed":

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -12,10 +12,10 @@ import (
 
 func TestCodexAgent_BuildArgs(t *testing.T) {
 	ca := &codexAgent{bin: "codex"}
-	args := ca.buildArgs("fix the bug", "")
+	args := ca.buildArgs("")
 
 	expected := []string{
-		"exec", "fix the bug",
+		"exec", "-",
 		"--json",
 		"--dangerously-bypass-approvals-and-sandbox",
 		"--color", "never",
@@ -33,12 +33,12 @@ func TestCodexAgent_BuildArgs(t *testing.T) {
 
 func TestCodexAgent_BuildArgs_ExtraArgsAfterExec(t *testing.T) {
 	ca := &codexAgent{bin: "codex", extraArgs: []string{"-m", "gpt-5.4"}}
-	args := ca.buildArgs("fix it", "")
+	args := ca.buildArgs("")
 
 	expected := []string{
 		"exec",
 		"-m", "gpt-5.4",
-		"fix it",
+		"-",
 		"--json",
 		"--dangerously-bypass-approvals-and-sandbox",
 		"--color", "never",
@@ -62,7 +62,7 @@ func TestCodexAgent_BuildArgs_UserExecutionModeSuppressesBypass(t *testing.T) {
 	}
 	for _, extra := range tests {
 		ca := &codexAgent{bin: "codex", extraArgs: extra}
-		args := ca.buildArgs("p", "")
+		args := ca.buildArgs("")
 
 		bypassCount := 0
 		for _, a := range args {
@@ -82,10 +82,10 @@ func TestCodexAgent_BuildArgs_UserExecutionModeSuppressesBypass(t *testing.T) {
 
 func TestCodexAgent_BuildArgs_WithOutputSchema(t *testing.T) {
 	ca := &codexAgent{bin: "codex"}
-	args := ca.buildArgs("review", "/tmp/schema.json")
+	args := ca.buildArgs("/tmp/schema.json")
 
 	want := []string{
-		"exec", "review",
+		"exec", "-",
 		"--json",
 		"--output-schema", "/tmp/schema.json",
 		"--dangerously-bypass-approvals-and-sandbox",
@@ -116,6 +116,41 @@ func writeFakeCodex(t *testing.T, dir, posixScript, windowsScript string) string
 		t.Fatalf("write fake codex: %v", err)
 	}
 	return bin
+}
+
+// TestCodexAgent_RunSendsPromptOnStdin locks in the Windows-safety fix: the
+// prompt (which embeds the full diff) must reach codex on stdin, not as a
+// command-line argument that could blow the OS command-line length limit.
+func TestCodexAgent_RunSendsPromptOnStdin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("stdin-capture fake uses a POSIX shell script")
+	}
+	dir := t.TempDir()
+	stdinFile := filepath.Join(dir, "stdin.txt")
+	bin := filepath.Join(dir, "codex")
+	script := "#!/bin/sh\ncat > \"" + stdinFile + "\"\n" +
+		`printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"ok"}}'` + "\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake codex: %v", err)
+	}
+
+	ca := &codexAgent{bin: bin}
+	const prompt = "review this very large diff that would overflow argv"
+	result, err := ca.Run(context.Background(), RunOpts{Prompt: prompt, CWD: t.TempDir()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Text != "ok" {
+		t.Fatalf("unexpected text: %q", result.Text)
+	}
+
+	got, err := os.ReadFile(stdinFile)
+	if err != nil {
+		t.Fatalf("read stdin capture: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != prompt {
+		t.Fatalf("prompt not delivered on stdin: got %q", string(got))
+	}
 }
 
 func TestCodexAgent_RunWritesOutputSchemaFile(t *testing.T) {
@@ -239,6 +274,55 @@ exit 1
 	}
 	if !strings.Contains(err.Error(), "schema rejected by codex") {
 		t.Fatalf("expected JSONL error in message, got %v", err)
+	}
+}
+
+// TestCodexAgent_RunSurfacesErrorWhenNoMessage verifies that when codex exits 0
+// but emits no agent message (e.g. a usage-limit / turn.failed), the failure
+// reason is surfaced instead of the opaque "codex returned no text output".
+func TestCodexAgent_RunSurfacesErrorWhenNoMessage(t *testing.T) {
+	dir := t.TempDir()
+	bin := writeFakeCodex(t, dir, `#!/bin/sh
+printf '%s\n' '{"type":"turn.failed","error":{"message":"You'"'"'ve hit your usage limit."}}'
+exit 0
+`, strings.Join([]string{
+		"@echo off",
+		"echo {\"type\":\"turn.failed\",\"error\":{\"message\":\"You've hit your usage limit.\"}}",
+		"exit /b 0",
+	}, "\r\n"))
+
+	ca := &codexAgent{bin: bin}
+	_, err := ca.Run(context.Background(), RunOpts{Prompt: "review", CWD: t.TempDir()})
+	if err == nil {
+		t.Fatal("expected error when codex produced no message")
+	}
+	if !strings.Contains(err.Error(), "usage limit") {
+		t.Fatalf("expected usage-limit reason in error, got %v", err)
+	}
+	if strings.Contains(err.Error(), "no text output") {
+		t.Fatalf("expected the specific reason, not the opaque message, got %v", err)
+	}
+}
+
+func TestParseCodexEvents_TurnFailedCapturesError(t *testing.T) {
+	events := strings.Join([]string{
+		`{"type":"turn.started"}`,
+		`{"type":"turn.failed","error":{"message":"rate limited"}}`,
+		"",
+	}, "\n")
+
+	var usage TokenUsage
+	var lastMessage string
+	var codexErr string
+	err := parseCodexEvents(context.Background(), strings.NewReader(events), nil, &usage, &lastMessage, &codexErr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if lastMessage != "" {
+		t.Fatalf("expected no message, got %q", lastMessage)
+	}
+	if codexErr != "rate limited" {
+		t.Fatalf("expected captured turn.failed reason, got %q", codexErr)
 	}
 }
 

--- a/internal/agent/server_windows.go
+++ b/internal/agent/server_windows.go
@@ -2,9 +2,17 @@
 
 package agent
 
-import "os/exec"
+import (
+	"os/exec"
 
-func configureManagedServerCmd(cmd *exec.Cmd) {}
+	"github.com/kunchenguid/no-mistakes/internal/shellenv"
+)
+
+func configureManagedServerCmd(cmd *exec.Cmd) {
+	// Keep managed agent servers (opencode, rovodev) from popping a console
+	// window; their stdout/stderr are already routed to the configured sink.
+	shellenv.HideWindow(cmd)
+}
 
 func signalManagedProcess(cmd *exec.Cmd, force bool) error {
 	if cmd == nil || cmd.Process == nil {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/safeurl"
+	"github.com/kunchenguid/no-mistakes/internal/shellenv"
 )
 
 // EmptyTreeSHA is the well-known SHA of an empty tree in git.
@@ -29,6 +30,7 @@ func Run(ctx context.Context, dir string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
 	cmd.Env = NonInteractiveEnv(dir)
+	shellenv.HideWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		stderr := ""
@@ -43,6 +45,7 @@ func Run(ctx context.Context, dir string, args ...string) (string, error) {
 // InitBare creates a new bare git repository at the given path.
 func InitBare(ctx context.Context, path string) error {
 	cmd := exec.CommandContext(ctx, "git", "init", "--bare", path)
+	shellenv.HideWindow(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("git init --bare: %w: %s", err, strings.TrimSpace(string(out)))
@@ -93,6 +96,7 @@ func FindGitRoot(path string) (string, error) {
 	}
 	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
 	cmd.Dir = abs
+	shellenv.HideWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("not a git repository: %s", abs)
@@ -116,6 +120,7 @@ func FindMainRepoRoot(path string) (string, error) {
 	}
 	cmd := exec.Command("git", "rev-parse", "--git-common-dir")
 	cmd.Dir = abs
+	shellenv.HideWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("not a git repository: %s", abs)
@@ -200,6 +205,7 @@ func CurrentBranch(ctx context.Context, dir string) (string, error) {
 func IsDetachedHEAD(ctx context.Context, dir string) (bool, error) {
 	cmd := exec.CommandContext(ctx, "git", "symbolic-ref", "-q", "HEAD")
 	cmd.Dir = dir
+	shellenv.HideWindow(cmd)
 	if err := cmd.Run(); err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
 			// Exit 1 means HEAD is not a symbolic ref — detached.
@@ -374,6 +380,7 @@ func ResolveRef(ctx context.Context, dir, ref string) (string, error) {
 func RefExists(ctx context.Context, dir, ref string) (bool, error) {
 	cmd := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--verify", "--quiet", ref+"^{commit}")
 	cmd.Env = NonInteractiveEnv(dir)
+	shellenv.HideWindow(cmd)
 	if err := cmd.Run(); err != nil {
 		var ee *exec.ExitError
 		if errors.As(err, &ee) && ee.ExitCode() == 1 {

--- a/internal/shellenv/hidewindow_other.go
+++ b/internal/shellenv/hidewindow_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package shellenv
+
+import "os/exec"
+
+// HideWindow is a no-op off Windows, where console subprocesses do not pop their
+// own windows.
+func HideWindow(cmd *exec.Cmd) {}

--- a/internal/shellenv/hidewindow_windows.go
+++ b/internal/shellenv/hidewindow_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package shellenv
+
+import (
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// HideWindow stops cmd from flashing its own console window when started. Use it
+// for one-shot console programs (git, helper tools) that are spawned directly
+// with os/exec rather than through ConfigureShellCommand, which already sets
+// this flag. The caller is expected to redirect the command's stdio, so no
+// visible console is ever needed. Safe to call on a nil-SysProcAttr command and
+// idempotent.
+func HideWindow(cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= windows.CREATE_NO_WINDOW
+}

--- a/internal/shellenv/shell_command_windows.go
+++ b/internal/shellenv/shell_command_windows.go
@@ -58,6 +58,11 @@ func ConfigureShellCommand(cmd *exec.Cmd) {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
 	cmd.SysProcAttr.CreationFlags |= createNewProcessGroup
+	// CREATE_NO_WINDOW keeps spawned console programs (the agent CLIs, git,
+	// taskkill) from flashing their own console window. Their stdio is always
+	// redirected to pipes here, so no visible console is ever needed; without
+	// this flag every subprocess pops a terminal window on Windows.
+	cmd.SysProcAttr.CreationFlags |= windows.CREATE_NO_WINDOW
 	if job, err := newShellCommandJobFunc(); err == nil {
 		shellCommandJobs.Store(cmd, &shellCommandJobState{handle: job})
 		cmd.SysProcAttr.CreationFlags |= windows.CREATE_SUSPENDED
@@ -81,6 +86,7 @@ func ConfigureShellCommand(cmd *exec.Cmd) {
 		}
 		pid := strconv.Itoa(cmd.Process.Pid)
 		kill := exec.Command("taskkill", "/T", "/F", "/PID", pid)
+		HideWindow(kill)
 		err := kill.Run()
 		switch {
 		case err == nil:
@@ -140,7 +146,9 @@ func TerminateShellCommandGroup(cmd *exec.Cmd) {
 		return
 	}
 	pid := strconv.Itoa(cmd.Process.Pid)
-	_ = exec.Command("taskkill", "/T", "/F", "/PID", pid).Run()
+	kill := exec.Command("taskkill", "/T", "/F", "/PID", pid)
+	HideWindow(kill)
+	_ = kill.Run()
 }
 
 func newShellCommandJob() (windows.Handle, error) {


### PR DESCRIPTION
## Summary

Three Windows-specific issues hit while running the pipeline with the **codex** agent on Windows. The first is a correctness bug: it made review/test steps fail on non-trivial diffs, so the change went through without a real review.

### 1. codex prompt overflows the Windows command-line limit
The prompt (which embeds the full diff) was passed as a command-line argument to `codex exec <prompt>`. On a non-trivial diff this overflows the ~32 KB `CreateProcess` command-line limit, so the step fails with **"The command line is too long"** (and on borderline sizes codex can emit no output at all, surfacing later as a blank "no text output").

**Fix:** deliver the prompt on **stdin** using codex's documented `-` convention (`codex exec -`, "instructions are read from stdin"). stdin has no length limit, so diff size no longer matters. Cross-platform; no behavior change on macOS/Linux.

Verified by piping a 40 KB prompt through the exact post-fix invocation (`codex exec - --json --dangerously-bypass-approvals-and-sandbox --color never`): codex starts the thread with no command-line error.

### 2. Console windows pop up for every spawned subprocess
On Windows, the agent CLIs, `git`, `taskkill`, and managed servers each flashed their own terminal window, because no spawn set `CREATE_NO_WINDOW`. Their stdio is always redirected to pipes, so a visible console is never needed.

**Fix:** set `CREATE_NO_WINDOW` in `ConfigureShellCommand` (covers the agent + pipeline shell steps), and add a small `shellenv.HideWindow` helper applied to the direct `exec.Command` spawns in `internal/git`, the managed-server path, and the internal `taskkill` cleanups. No-op off Windows.

### 3. "no text output" hides the real reason
When codex exited 0 but produced no agent message (e.g. a usage-limit or `turn.failed` event), the step failed with the opaque **"codex returned no text output"**, giving no hint why review/test "skipped".

**Fix:** capture `turn.failed` reasons and surface codex's actual error message (e.g. "You've hit your usage limit") instead of the blank message.

## Tests
- New: `TestCodexAgent_RunSendsPromptOnStdin`, `TestCodexAgent_RunSurfacesErrorWhenNoMessage`, `TestParseCodexEvents_TurnFailedCapturesError`.
- Updated the `buildArgs` tests for the `-` (stdin) argument.
- `go build ./...`, `go vet ./...`, and `go test ./...` all green on `windows/amd64` (Go 1.26).

## Notes
Scope is intentionally the **codex** agent for the prompt-on-stdin change (that's the agent exercised here); the `CREATE_NO_WINDOW` / `HideWindow` change is agent-agnostic. The same prompt-on-stdin treatment could later be applied to the other native agents if they hit the same limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
