### PR TITLE
feat(scm): add Azure DevOps provider support

### DIFF
--- a/internal/bitbucket/host.go
+++ b/internal/bitbucket/host.go
@@ -290,3 +290,11 @@ func failedPipelineUUIDs(statuses []CommitStatus, failingNames []string) map[str
 	}
 	return targets
 }
+
+func (h *Host) GetReviewPass(ctx context.Context, pr *scm.PR, reviewerIdentity string) (*scm.ReviewPass, error) {
+	return nil, scm.ErrUnsupported
+}
+
+func (h *Host) GetReviewThreads(ctx context.Context, pr *scm.PR) ([]scm.ReviewThread, error) {
+	return nil, scm.ErrUnsupported
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,7 @@ type GlobalConfig struct {
 	AutoFix              AutoFixRaw
 	Intent               IntentRaw
 	Test                 TestRaw
+	AIReview             AIReviewRaw
 }
 
 // globalConfigRaw is the on-disk YAML representation with duration as string.
@@ -64,6 +65,7 @@ type globalConfigRaw struct {
 	AutoFix              AutoFixRaw          `yaml:"auto_fix"`
 	Intent               IntentRaw           `yaml:"intent"`
 	Test                 TestRaw             `yaml:"test"`
+	AIReview             AIReviewRaw         `yaml:"ai_review"`
 }
 
 // RepoConfig represents .no-mistakes.yaml in a repo root.
@@ -77,10 +79,11 @@ type RepoConfig struct {
 	// ONLY from the trusted default-branch copy of .no-mistakes.yaml (never
 	// the pushed SHA), so a contributor cannot self-enable. Default false:
 	// the pushed branch controls nothing that executes.
-	AllowRepoCommands bool       `yaml:"allow_repo_commands"`
-	AutoFix           AutoFixRaw `yaml:"auto_fix"`
-	Intent            IntentRaw  `yaml:"intent"`
-	Test              TestRaw    `yaml:"test"`
+	AllowRepoCommands bool        `yaml:"allow_repo_commands"`
+	AutoFix           AutoFixRaw  `yaml:"auto_fix"`
+	Intent            IntentRaw   `yaml:"intent"`
+	Test              TestRaw     `yaml:"test"`
+	AIReview          AIReviewRaw `yaml:"ai_review"`
 }
 
 // Commands holds optional per-repo command overrides.
@@ -127,6 +130,7 @@ type Config struct {
 	AutoFix              AutoFix
 	Intent               Intent
 	Test                 Test
+	AIReview             AIReview
 }
 
 // TestRaw is the YAML representation of test-step settings.
@@ -170,6 +174,29 @@ type Intent struct {
 	Threshold       float64
 	SlackDays       int
 	DisabledReaders map[string]bool
+}
+
+// AIReviewRaw is the YAML representation of AI-review monitor settings.
+// Pointer fields distinguish "not set" (nil) from explicit zero/false values.
+type AIReviewRaw struct {
+	Enabled        *bool  `yaml:"enabled"`
+	Identity       string `yaml:"identity"`
+	PolicyName     string `yaml:"policy_name"`
+	GitHubCheck    string `yaml:"github_check"`
+	MaxIterations  *int   `yaml:"max_iterations"`
+	PassTimeout    string `yaml:"pass_timeout"`
+	ResolveThreads *bool  `yaml:"resolve_threads"`
+}
+
+// AIReview is the resolved AI-review monitor config.
+type AIReview struct {
+	Enabled        bool
+	Identity       string
+	PolicyName     string
+	GitHubCheck    string
+	MaxIterations  int
+	PassTimeout    time.Duration
+	ResolveThreads bool
 }
 
 // defaultConfigYAML is the template written when no global config file exists.
@@ -704,6 +731,43 @@ func autoFixDefaults() AutoFix {
 	}
 }
 
+func aiReviewDefaults() AIReview {
+	return AIReview{
+		Enabled:       true,
+		Identity:      "Product Build Service (talroo)",
+		PolicyName:    "Ai Review",
+		GitHubCheck:   "AI Review",
+		MaxIterations: 3,
+		PassTimeout:   30 * time.Minute,
+	}
+}
+
+func applyAIReviewOverrides(dst *AIReview, src *AIReviewRaw) {
+	if src.Enabled != nil {
+		dst.Enabled = *src.Enabled
+	}
+	if strings.TrimSpace(src.Identity) != "" {
+		dst.Identity = strings.TrimSpace(src.Identity)
+	}
+	if strings.TrimSpace(src.PolicyName) != "" {
+		dst.PolicyName = strings.TrimSpace(src.PolicyName)
+	}
+	if strings.TrimSpace(src.GitHubCheck) != "" {
+		dst.GitHubCheck = strings.TrimSpace(src.GitHubCheck)
+	}
+	if src.MaxIterations != nil {
+		dst.MaxIterations = *src.MaxIterations
+	}
+	if strings.TrimSpace(src.PassTimeout) != "" {
+		if d, err := parseCITimeout(strings.TrimSpace(src.PassTimeout)); err == nil {
+			dst.PassTimeout = d
+		}
+	}
+	if src.ResolveThreads != nil {
+		dst.ResolveThreads = *src.ResolveThreads
+	}
+}
+
 // applyAutoFixOverrides applies non-nil raw values onto resolved defaults.
 func applyAutoFixOverrides(dst *AutoFix, src *AutoFixRaw) {
 	if src.Lint != nil {
@@ -762,6 +826,10 @@ func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 	applyTestOverrides(&test, &global.Test)
 	applyTestOverrides(&test, &repo.Test)
 
+	aiReview := aiReviewDefaults()
+	applyAIReviewOverrides(&aiReview, &global.AIReview)
+	applyAIReviewOverrides(&aiReview, &repo.AIReview)
+
 	cfg := &Config{
 		Agent:                global.Agent,
 		ACPXPath:             global.ACPXPath,
@@ -775,6 +843,7 @@ func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 		AutoFix:              af,
 		Intent:               intent,
 		Test:                 test,
+		AIReview:             aiReview,
 	}
 
 	if repo.Agent != "" {

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -44,6 +44,10 @@ type CIStep struct {
 	// must not re-arm the timeout. Overridable for testing; defaults to
 	// fetching the upstream default branch.
 	baseBranchTip func(context.Context) (string, bool)
+	// AI-review monitor state
+	reviewFixAttempts int    // number of AI-review fix rounds
+	lastReviewedSHA   string // head SHA the last observed review pass covered
+	lastPushedSHA     string // head SHA of the most recent push (for pass-timeout measurement)
 }
 
 func (s *CIStep) Name() types.StepName { return types.StepCI }
@@ -318,7 +322,14 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 				case len(checks) == 0:
 					lastMonitorLog = logCIMonitorStatus(sctx, ciNoChecksPassedMsg, lastMonitorLog)
 				default:
-					lastMonitorLog = logCIMonitorStatus(sctx, ciChecksPassedMsg, lastMonitorLog)
+					// CI checks are green. Before declaring "checks passed",
+					// gate on the AI-review monitor if the host supports it.
+					if s.aiReviewGate(sctx, host, pr, now(), started, &lastMonitorLog) {
+						// The gate emitted a message (or escalated); skip the
+						// default ChecksPassedMsg emission.
+					} else {
+						lastMonitorLog = logCIMonitorStatus(sctx, ciChecksPassedMsg, lastMonitorLog)
+					}
 				}
 			}
 		}

--- a/internal/pipeline/steps/ci_review_fix.go
+++ b/internal/pipeline/steps/ci_review_fix.go
@@ -1,0 +1,183 @@
+package steps
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/agent"
+	"github.com/kunchenguid/no-mistakes/internal/pipeline"
+	"github.com/kunchenguid/no-mistakes/internal/scm"
+)
+
+// aiReviewGate returns true when it handled the "checks passed" decision
+// (either by suppressing the ChecksPassedMsg emission until the AI reviewer
+// finishes, or by escalating to a human). Returns false when the pipeline
+// should proceed with the normal ChecksPassedMsg emission (no reviewer
+// configured, reviewer disabled, or a clean pass).
+func (s *CIStep) aiReviewGate(
+	sctx *pipeline.StepContext,
+	host scm.Host,
+	pr *scm.PR,
+	now time.Time,
+	started time.Time,
+	lastMonitorLog *string,
+) bool {
+	cfg := sctx.Config.AIReview
+	if !cfg.Enabled || !host.Capabilities().ReviewComments {
+		return false
+	}
+
+	reviewerIdentity := cfg.PolicyName
+	if reviewerIdentity == "" {
+		reviewerIdentity = cfg.Identity
+	}
+
+	pass, err := host.GetReviewPass(sctx.Ctx, pr, reviewerIdentity)
+	if err != nil {
+		if err == scm.ErrUnsupported {
+			return false
+		}
+		sctx.Log(fmt.Sprintf("warning: could not read AI review pass: %v", err))
+		return false
+	}
+
+	if s.lastPushedSHA == "" {
+		s.lastPushedSHA = sctx.Run.HeadSHA
+	}
+
+	pushElapsed := now.Sub(started)
+	if s.lastPushedSHA != sctx.Run.HeadSHA {
+		pushElapsed = now.Sub(started)
+	}
+
+	passTimeout := cfg.PassTimeout
+	if passTimeout <= 0 {
+		passTimeout = 30 * time.Minute
+	}
+
+	switch {
+	case !pass.Ran:
+		// Reviewer not configured or hasn't queued yet.
+		if pushElapsed > passTimeout {
+			sctx.Log(fmt.Sprintf("AI reviewer did not run within %s, proceeding without it", passTimeout))
+			return false
+		}
+		sctx.Log("waiting for AI reviewer to start...")
+		*lastMonitorLog = ""
+		return true
+
+	case !pass.Complete || pass.ForSHA != sctx.Run.HeadSHA:
+		// A pass is running, or the completed pass is stale (covers an older SHA).
+		if pushElapsed > passTimeout {
+			sctx.Log(fmt.Sprintf("AI review pass did not complete within %s, proceeding", passTimeout))
+			return false
+		}
+		sctx.Log(fmt.Sprintf("AI review pass in progress for %s...", shortSHA(pass.ForSHA)))
+		*lastMonitorLog = ""
+		return true
+
+	default:
+		// A complete pass covering the current head.
+		threads, err := host.GetReviewThreads(sctx.Ctx, pr)
+		if err != nil {
+			sctx.Log(fmt.Sprintf("warning: could not read AI review threads: %v", err))
+			return false
+		}
+		var unresolved []scm.ReviewThread
+		for _, t := range threads {
+			if t.IsBot && !t.Resolved {
+				unresolved = append(unresolved, t)
+			}
+		}
+		if len(unresolved) == 0 {
+			return false
+		}
+		if s.reviewFixAttempts >= cfg.MaxIterations {
+			sctx.Log(fmt.Sprintf("AI review still has %d comments after %d fix rounds, escalating to human",
+				len(unresolved), s.reviewFixAttempts))
+			return true
+		}
+		if s.lastReviewedSHA == sctx.Run.HeadSHA {
+			sctx.Log("fix already pushed for this head, waiting for next AI review pass...")
+			*lastMonitorLog = ""
+			return true
+		}
+		s.reviewFixAttempts++
+		sctx.Log(fmt.Sprintf("AI review left %d comment(s), fixing (round %d/%d)...",
+			len(unresolved), s.reviewFixAttempts, cfg.MaxIterations))
+		pushed, err := s.autoFixReview(sctx, host, pr, unresolved)
+		if err != nil {
+			sctx.Log(fmt.Sprintf("warning: AI review fix failed: %v", err))
+		} else if pushed || sctx.Run.HeadSHA != s.lastPushedSHA {
+			s.lastReviewedSHA = sctx.Run.HeadSHA
+			s.lastPushedSHA = sctx.Run.HeadSHA
+		} else {
+			sctx.Log("AI review fix produced no changes, escalating")
+			return true
+		}
+		*lastMonitorLog = ""
+		return true
+	}
+}
+
+// autoFixReview runs the agent to fix AI-reviewer comments and pushes.
+// Returns (true, nil) when changes were committed and pushed, (false, nil)
+// when the agent produced no changes, or (false, err) on failure.
+func (s *CIStep) autoFixReview(
+	sctx *pipeline.StepContext,
+	host scm.Host,
+	pr *scm.PR,
+	threads []scm.ReviewThread,
+) (bool, error) {
+	ctx := sctx.Ctx
+
+	var commentSummaries []string
+	for _, t := range threads {
+		loc := t.File
+		if t.Line > 0 {
+			loc = fmt.Sprintf("%s:%d", t.File, t.Line)
+		}
+		commentSummaries = append(commentSummaries, fmt.Sprintf("- %s: %s", loc, t.Body))
+	}
+
+	prompt := fmt.Sprintf(`The CI/CD AI reviewer left the following comments on this PR. Address each comment.
+
+Context:
+- branch: %s
+- target commit: %s
+- PR number: %s
+
+AI reviewer comments:
+%s
+
+Rules:
+- You MUST produce file changes that address the reviewer's comments. Do not conclude that nothing needs to change.
+- Make the smallest correct root-cause fix for each comment.
+- Do not refactor beyond what is needed to address the comments.
+- Verify the fix by running the most relevant commands locally before finishing.
+%s`,
+		sctx.Run.Branch,
+		sctx.Run.HeadSHA,
+		pr.Number,
+		strings.Join(commentSummaries, "\n"),
+		userIntentPromptSection(sctx),
+	)
+
+	sctx.Log("running agent to fix AI review comments...")
+	_, err := sctx.Agent.Run(ctx, agent.RunOpts{
+		Prompt:  prompt,
+		CWD:     sctx.WorkDir,
+		OnChunk: sctx.LogChunk,
+	})
+	if err != nil {
+		return false, fmt.Errorf("agent AI review fix: %w", err)
+	}
+
+	pushed, err := s.commitAndPush(sctx)
+	if err != nil {
+		slog.Warn("AI review fix push failed", "err", err)
+	}
+	return pushed, err
+}

--- a/internal/pipeline/steps/host.go
+++ b/internal/pipeline/steps/host.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/bitbucket"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/scm"
+	"github.com/kunchenguid/no-mistakes/internal/scm/azuredevops"
 	"github.com/kunchenguid/no-mistakes/internal/scm/github"
 	"github.com/kunchenguid/no-mistakes/internal/scm/gitlab"
 )
@@ -63,6 +64,19 @@ func buildHost(sctx *pipeline.StepContext, provider scm.Provider) (scm.Host, str
 			return nil, err.Error()
 		}
 		return bitbucket.NewHost(client, repo), ""
+	case scm.ProviderAzureDevOps:
+		if sctx.Repo.ForkURL != "" {
+			return nil, "fork PR routing for Azure DevOps is not implemented"
+		}
+		org, project, repoName := azuredevops.OrgProjectRepo(sctx.Repo.UpstreamURL)
+		if project == "" || repoName == "" {
+			return nil, "could not parse Azure DevOps project and repository from remote URL"
+		}
+		return azuredevops.New(
+			cmdFactory,
+			func() bool { return stepCLIAvailable(sctx, provider) },
+			org, project, repoName,
+		), ""
 	default:
 		return nil, fmt.Sprintf("provider %s is not supported yet", provider)
 	}

--- a/internal/scm/azuredevops/azuredevops.go
+++ b/internal/scm/azuredevops/azuredevops.go
@@ -1,0 +1,624 @@
+// Package azuredevops implements scm.Host backed by the az CLI.
+package azuredevops
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/scm"
+)
+
+// CmdFactory builds an exec.Cmd in the caller's workdir with the caller's env.
+type CmdFactory func(ctx context.Context, name string, args ...string) *exec.Cmd
+
+// Host talks to Azure DevOps through the az CLI.
+type Host struct {
+	cmd          CmdFactory
+	cliAvailable func() bool
+	org          string // "https://dev.azure.com/talroo"
+	project      string // "Product"
+	repoName     string // "ai-knowledge-base" (name, not GUID)
+	repoID       string // GUID, lazily resolved
+	repoIDFn     func(ctx context.Context) (string, error)
+	now          func() time.Time
+}
+
+// New builds a Host. org is the Azure DevOps organization URL
+// (e.g. "https://dev.azure.com/talroo"). project is the project name
+// (e.g. "Product"). repoName is the repository name (e.g. "ai-knowledge-base").
+func New(cmd CmdFactory, cliAvailable func() bool, org, project, repoName string) *Host {
+	h := &Host{
+		cmd:          cmd,
+		cliAvailable: cliAvailable,
+		org:          strings.TrimSpace(org),
+		project:      strings.TrimSpace(project),
+		repoName:     strings.TrimSpace(repoName),
+		now:          time.Now,
+	}
+	h.repoIDFn = func(ctx context.Context) (string, error) {
+		return h.resolveRepoID(ctx)
+	}
+	return h
+}
+
+// OrgProjectRepo extracts the Azure DevOps organization URL, project, and
+// repository name from a remote URL. It handles SSH scp-style
+// (git@ssh.dev.azure.com:v3/org/project/repo), HTTPS
+// (https://org@dev.azure.com/org/project/_git/repo), and legacy
+// visualstudio.com URLs. Returns ("", "", "") when the input is not an
+// Azure DevOps URL or cannot be parsed.
+func OrgProjectRepo(remoteURL string) (org, project, repo string) {
+	raw := strings.TrimSpace(remoteURL)
+	if raw == "" {
+		return "", "", ""
+	}
+	lower := strings.ToLower(raw)
+
+	// SSH scp-style: git@ssh.dev.azure.com:v3/org/project/repo
+	if strings.Contains(lower, "ssh.dev.azure.com") {
+		colon := strings.Index(raw, ":")
+		if colon < 0 {
+			return "", "", ""
+		}
+		path := raw[colon+1:]
+		path = strings.TrimPrefix(path, "v3/")
+		path = strings.Trim(path, "/")
+		parts := strings.Split(path, "/")
+		if len(parts) >= 3 {
+			return orgURL(parts[0]), parts[1], parts[2]
+		}
+		return "", "", ""
+	}
+
+	// HTTPS or SSH URL form
+	if strings.Contains(lower, "dev.azure.com") {
+		return parseAzureHTTPSURL(raw)
+	}
+
+	// Legacy visualstudio.com: https://org.visualstudio.com/project/_git/repo
+	if strings.Contains(lower, ".visualstudio.com") {
+		return parseVisualStudioURL(raw)
+	}
+
+	return "", "", ""
+}
+
+func parseAzureHTTPSURL(raw string) (org, project, repo string) {
+	// Format: https://[user@]dev.azure.com/org/project/_git/repo
+	// or ssh://git@ssh.dev.azure.com:v3/org/project/repo (already handled above)
+	schemeEnd := strings.Index(raw, "://")
+	if schemeEnd < 0 {
+		return "", "", ""
+	}
+	rest := raw[schemeEnd+3:]
+	// Strip userinfo
+	if at := strings.LastIndex(rest, "@"); at >= 0 {
+		rest = rest[at+1:]
+	}
+	// rest is now "dev.azure.com/org/project/_git/repo"
+	slash := strings.Index(rest, "/")
+	if slash < 0 {
+		return "", "", ""
+	}
+	rest = rest[slash+1:] // "org/project/_git/repo"
+	parts := strings.Split(rest, "/")
+	if len(parts) >= 4 && parts[2] == "_git" {
+		return orgURL(parts[0]), parts[1], parts[3]
+	}
+	return "", "", ""
+}
+
+func parseVisualStudioURL(raw string) (org, project, repo string) {
+	// Format: https://org.visualstudio.com/project/_git/repo
+	schemeEnd := strings.Index(raw, "://")
+	if schemeEnd < 0 {
+		return "", "", ""
+	}
+	rest := raw[schemeEnd+3:]
+	// Strip userinfo
+	if at := strings.LastIndex(rest, "@"); at >= 0 {
+		rest = rest[at+1:]
+	}
+	// rest is "org.visualstudio.com/project/_git/repo"
+	dot := strings.Index(rest, ".visualstudio.com")
+	if dot < 0 {
+		return "", "", ""
+	}
+	orgName := rest[:dot]
+	rest = rest[strings.Index(rest, "/")+1:]
+	parts := strings.Split(rest, "/")
+	if len(parts) >= 3 && parts[1] == "_git" {
+		return orgURL(orgName), parts[0], parts[2]
+	}
+	return "", "", ""
+}
+
+func orgURL(org string) string {
+	return "https://dev.azure.com/" + strings.TrimPrefix(strings.TrimSpace(org), "/")
+}
+
+func (h *Host) Provider() scm.Provider { return scm.ProviderAzureDevOps }
+
+func (h *Host) Capabilities() scm.Capabilities {
+	return scm.Capabilities{
+		MergeableState:  true,
+		FailedCheckLogs: true,
+		ReviewComments:  true,
+	}
+}
+
+func (h *Host) Available(ctx context.Context) error {
+	if h.cliAvailable != nil && !h.cliAvailable() {
+		return errors.New("az CLI is not installed")
+	}
+	if err := h.cmd(ctx, "az", "account", "show").Run(); err != nil {
+		return errors.New("az CLI is not authenticated")
+	}
+	return nil
+}
+
+func (h *Host) orgArgs() []string {
+	var args []string
+	if h.org != "" {
+		args = append(args, "--org", h.org)
+	}
+	return args
+}
+
+func (h *Host) projectArgs() []string {
+	var args []string
+	if h.project != "" {
+		args = append(args, "--project", h.project)
+	}
+	return args
+}
+
+func (h *Host) repoArgs() []string {
+	var args []string
+	if h.repoName != "" {
+		args = append(args, "--repository", h.repoName)
+	}
+	return args
+}
+
+// resolveRepoID resolves the repository GUID from the name. Needed for
+// az devops invoke route parameters that require the GUID.
+func (h *Host) resolveRepoID(ctx context.Context) (string, error) {
+	if h.repoID != "" {
+		return h.repoID, nil
+	}
+	args := append([]string{"repos", "show"}, h.repoArgs()...)
+	args = append(args, h.orgArgs()...)
+	args = append(args, "-o", "json")
+	cmd := h.cmd(ctx, "az", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("az repos show: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	var payload struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(out, &payload); err != nil {
+		return "", fmt.Errorf("parse repo ID: %w", err)
+	}
+	h.repoID = payload.ID
+	return h.repoID, nil
+}
+
+// Azure PR JSON shapes
+type azPR struct {
+	PullRequestID   int    `json:"pullRequestId"`
+	Status          string `json:"status"`
+	MergeStatus     string `json:"mergeStatus"`
+	SourceRefName   string `json:"sourceRefName"`
+	TargetRefName   string `json:"targetRefName"`
+	WebURL          string `json:"url"`
+	IsDraft         bool   `json:"isDraft"`
+	LastMergeCommit struct {
+		CommitID string `json:"commitId"`
+	} `json:"lastMergeSourceCommit"`
+}
+
+func (p azPR) toPR() *scm.PR {
+	pr := &scm.PR{URL: strings.TrimSpace(p.WebURL)}
+	if p.PullRequestID > 0 {
+		pr.Number = strconv.Itoa(p.PullRequestID)
+	}
+	return pr
+}
+
+func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error) {
+	args := []string{"repos", "pr", "list", "--status", "active"}
+	args = append(args, h.repoArgs()...)
+	args = append(args, h.projectArgs()...)
+	args = append(args, h.orgArgs()...)
+	if strings.TrimSpace(branch) != "" {
+		args = append(args, "--source-branch", branch)
+	}
+	if strings.TrimSpace(base) != "" {
+		args = append(args, "--target-branch", base)
+	}
+	args = append(args, "-o", "json")
+	cmd := h.cmd(ctx, "az", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("az repos pr list: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	var prs []azPR
+	if err := json.Unmarshal(out, &prs); err != nil || len(prs) == 0 {
+		return nil, nil
+	}
+	return prs[0].toPR(), nil
+}
+
+func (h *Host) CreatePR(ctx context.Context, branch, base string, content scm.PRContent) (*scm.PR, error) {
+	args := []string{"repos", "pr", "create",
+		"--source-branch", branch,
+		"--target-branch", base,
+		"--title", content.Title,
+		"--description", content.Body,
+	}
+	args = append(args, h.repoArgs()...)
+	args = append(args, h.projectArgs()...)
+	args = append(args, h.orgArgs()...)
+	args = append(args, "-o", "json")
+	cmd := h.cmd(ctx, "az", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("az repos pr create: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	var pr azPR
+	if err := json.Unmarshal(out, &pr); err != nil {
+		return nil, fmt.Errorf("parse az repos pr create response: %w", err)
+	}
+	return pr.toPR(), nil
+}
+
+func (h *Host) UpdatePR(ctx context.Context, pr *scm.PR, content scm.PRContent) (*scm.PR, error) {
+	args := []string{"repos", "pr", "update",
+		"--id", pr.Number,
+		"--title", content.Title,
+		"--description", content.Body,
+	}
+	args = append(args, h.orgArgs()...)
+	cmd := h.cmd(ctx, "az", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("az repos pr update: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return pr, nil
+}
+
+func (h *Host) GetPRState(ctx context.Context, pr *scm.PR) (scm.PRState, error) {
+	az, err := h.showPR(ctx, pr.Number)
+	if err != nil {
+		return "", err
+	}
+	return normalizePRState(az.Status), nil
+}
+
+func (h *Host) GetMergeableState(ctx context.Context, pr *scm.PR) (scm.MergeableState, error) {
+	az, err := h.showPR(ctx, pr.Number)
+	if err != nil {
+		return "", err
+	}
+	return normalizeMergeableState(az.MergeStatus), nil
+}
+
+func (h *Host) showPR(ctx context.Context, id string) (azPR, error) {
+	args := []string{"repos", "pr", "show", "--id", id}
+	args = append(args, h.orgArgs()...)
+	args = append(args, "-o", "json")
+	cmd := h.cmd(ctx, "az", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return azPR{}, fmt.Errorf("az repos pr show: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	var pr azPR
+	if err := json.Unmarshal(out, &pr); err != nil {
+		return azPR{}, fmt.Errorf("parse az repos pr show response: %w", err)
+	}
+	return pr, nil
+}
+
+// Azure policy JSON shape
+type azPolicy struct {
+	Status        string `json:"status"`
+	Configuration struct {
+		IsBlocking bool `json:"isBlocking"`
+		IsEnabled  bool `json:"isEnabled"`
+		Type       struct {
+			DisplayName string `json:"displayName"`
+		} `json:"type"`
+		Settings struct {
+			DisplayName       string `json:"displayName"`
+			BuildDefinitionID int    `json:"buildDefinitionId"`
+		} `json:"settings"`
+	} `json:"configuration"`
+	Context struct {
+		BuildID                 int    `json:"buildId"`
+		BuildIsNotCurrent       bool   `json:"buildIsNotCurrent"`
+		LastMergeSourceCommitID string `json:"lastMergeSourceCommitId"`
+		BuildStartedUTC         string `json:"buildStartedUtc"`
+	} `json:"context"`
+}
+
+func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
+	policies, err := h.listPolicies(ctx, pr.Number)
+	if err != nil {
+		return nil, err
+	}
+	if len(policies) == 0 {
+		return nil, nil
+	}
+	now := h.now
+	if now == nil {
+		now = time.Now
+	}
+	nowTime := now()
+	checks := make([]scm.Check, 0, len(policies))
+	for _, p := range policies {
+		if !p.Configuration.IsEnabled {
+			continue
+		}
+		name := strings.TrimSpace(p.Configuration.Settings.DisplayName)
+		if name == "" {
+			name = strings.TrimSpace(p.Configuration.Type.DisplayName)
+		}
+		bucket := policyStatusToBucket(p.Status)
+		var completedAt time.Time
+		if bucket != scm.CheckBucketPending && bucket != "" {
+			completedAt = nowTime
+		}
+		checks = append(checks, scm.Check{
+			Name:        name,
+			Bucket:      bucket,
+			CompletedAt: completedAt,
+		})
+	}
+	return checks, nil
+}
+
+func (h *Host) listPolicies(ctx context.Context, prNumber string) ([]azPolicy, error) {
+	args := []string{"repos", "pr", "policy", "list", "--id", prNumber}
+	args = append(args, h.orgArgs()...)
+	args = append(args, "-o", "json")
+	cmd := h.cmd(ctx, "az", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("az repos pr policy list: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	var policies []azPolicy
+	if err := json.Unmarshal(out, &policies); err != nil {
+		return nil, fmt.Errorf("parse policy list: %w", err)
+	}
+	return policies, nil
+}
+
+func (h *Host) FetchFailedCheckLogs(ctx context.Context, pr *scm.PR, _ string, _ string, failingNames []string) (string, error) {
+	if len(failingNames) == 0 {
+		return "", nil
+	}
+	policies, err := h.listPolicies(ctx, pr.Number)
+	if err != nil {
+		return "", nil
+	}
+	targets := make(map[string]struct{}, len(failingNames))
+	for _, name := range failingNames {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			targets[name] = struct{}{}
+		}
+	}
+	for _, p := range policies {
+		if p.Status != "rejected" {
+			continue
+		}
+		name := strings.TrimSpace(p.Configuration.Settings.DisplayName)
+		if name == "" {
+			name = strings.TrimSpace(p.Configuration.Type.DisplayName)
+		}
+		if len(targets) > 0 {
+			if _, ok := targets[name]; !ok {
+				continue
+			}
+		}
+		if p.Context.BuildID == 0 {
+			continue
+		}
+		logs := h.fetchBuildLogs(ctx, p.Context.BuildID)
+		if logs != "" {
+			return logs, nil
+		}
+	}
+	return "", nil
+}
+
+func (h *Host) fetchBuildLogs(ctx context.Context, buildID int) string {
+	args := []string{"pipelines", "runs", "show", "--id", strconv.Itoa(buildID)}
+	args = append(args, h.projectArgs()...)
+	args = append(args, h.orgArgs()...)
+	args = append(args, "-o", "json")
+	cmd := h.cmd(ctx, "az", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return ""
+	}
+	var payload struct {
+		Logs struct {
+			URL string `json:"url"`
+		} `json:"logs"`
+		BuildNumber string `json:"buildNumber"`
+		Result      string `json:"result"`
+	}
+	if err := json.Unmarshal(out, &payload); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// Azure thread JSON shape
+type azThread struct {
+	ID            int    `json:"id"`
+	Status        string `json:"status"`
+	ThreadContext *struct {
+		FilePath       string `json:"filePath"`
+		RightFileStart *struct {
+			Line int `json:"line"`
+		} `json:"rightFileStart"`
+	} `json:"threadContext"`
+	Comments []struct {
+		Author struct {
+			DisplayName string `json:"displayName"`
+		} `json:"author"`
+		CommentType string `json:"commentType"`
+		Content     string `json:"content"`
+	} `json:"comments"`
+}
+
+func (h *Host) GetReviewThreads(ctx context.Context, pr *scm.PR) ([]scm.ReviewThread, error) {
+	repoID, err := h.repoIDFn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolve repo ID for threads: %w", err)
+	}
+	args := []string{
+		"devops", "invoke",
+		"--area", "git",
+		"--resource", "pullRequestThreads",
+		"--route-parameters", "project=" + h.project, "repositoryId=" + repoID, "pullRequestId=" + pr.Number,
+		"--org", h.org,
+		"--api-version", "7.1",
+		"-o", "json",
+	}
+	cmd := h.cmd(ctx, "az", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("az devops invoke pullRequestThreads: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	var payload struct {
+		Value []azThread `json:"value"`
+	}
+	if err := json.Unmarshal(out, &payload); err != nil {
+		// Some az versions return a bare array instead of {value: [...]}
+		var threads []azThread
+		if err2 := json.Unmarshal(out, &threads); err2 != nil {
+			return nil, fmt.Errorf("parse pullRequestThreads: %w", err)
+		}
+		payload.Value = threads
+	}
+	result := make([]scm.ReviewThread, 0, len(payload.Value))
+	for _, t := range payload.Value {
+		if len(t.Comments) == 0 {
+			continue
+		}
+		c := t.Comments[0]
+		if c.CommentType == "system" {
+			continue
+		}
+		thread := scm.ReviewThread{
+			ID:       strconv.Itoa(t.ID),
+			Author:   strings.TrimSpace(c.Author.DisplayName),
+			Body:     strings.TrimSpace(c.Content),
+			Resolved: isThreadResolved(t.Status),
+		}
+		if t.ThreadContext != nil {
+			thread.File = strings.TrimSpace(t.ThreadContext.FilePath)
+			if t.ThreadContext.RightFileStart != nil {
+				thread.Line = t.ThreadContext.RightFileStart.Line
+			}
+		}
+		result = append(result, thread)
+	}
+	return result, nil
+}
+
+func (h *Host) GetReviewPass(ctx context.Context, pr *scm.PR, reviewerIdentity string) (*scm.ReviewPass, error) {
+	policies, err := h.listPolicies(ctx, pr.Number)
+	if err != nil {
+		return nil, err
+	}
+	pass := &scm.ReviewPass{}
+	for _, p := range policies {
+		name := strings.TrimSpace(p.Configuration.Settings.DisplayName)
+		if name == "" {
+			continue
+		}
+		// Match by policy display name or reviewer identity.
+		// The caller passes the configured policy_name; if empty, match any
+		// Build policy whose comments come from the reviewer identity.
+		if reviewerIdentity != "" && !strings.EqualFold(name, reviewerIdentity) {
+			continue
+		}
+		pass.Ran = true
+		pass.ForSHA = strings.TrimSpace(p.Context.LastMergeSourceCommitID)
+		switch strings.ToLower(strings.TrimSpace(p.Status)) {
+		case "approved", "rejected", "notapplicable":
+			pass.Complete = true
+		case "queued", "running":
+			pass.Complete = false
+		default:
+			pass.Complete = false
+		}
+		if !p.Context.BuildIsNotCurrent {
+			// Build is current - this is the latest pass
+			return pass, nil
+		}
+	}
+	return pass, nil
+}
+
+func isThreadResolved(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "active", "pending", "":
+		return false
+	default:
+		return true
+	}
+}
+
+func normalizePRState(raw string) scm.PRState {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "active":
+		return scm.PRStateOpen
+	case "completed":
+		return scm.PRStateMerged
+	case "abandoned":
+		return scm.PRStateClosed
+	default:
+		return scm.PRState(strings.ToUpper(raw))
+	}
+}
+
+func normalizeMergeableState(raw string) scm.MergeableState {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "succeeded":
+		return scm.MergeableOK
+	case "conflicts", "rejectedbypolicy":
+		return scm.MergeableConflict
+	case "queued", "notset", "":
+		return scm.MergeablePending
+	default:
+		return scm.MergeablePending
+	}
+}
+
+func policyStatusToBucket(status string) scm.CheckBucket {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "approved":
+		return scm.CheckBucketPass
+	case "rejected":
+		return scm.CheckBucketFail
+	case "queued", "running":
+		return scm.CheckBucketPending
+	case "notapplicable", "broken":
+		return scm.CheckBucketSkip
+	default:
+		return ""
+	}
+}

--- a/internal/scm/azuredevops/azuredevops_test.go
+++ b/internal/scm/azuredevops/azuredevops_test.go
@@ -1,0 +1,523 @@
+package azuredevops
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/scm"
+)
+
+func TestOrgProjectRepo(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		remoteURL   string
+		wantOrg     string
+		wantProject string
+		wantRepo    string
+	}{
+		{
+			name:        "ssh scp-style",
+			remoteURL:   "git@ssh.dev.azure.com:v3/talroo/Product/ai-knowledge-base",
+			wantOrg:     "https://dev.azure.com/talroo",
+			wantProject: "Product",
+			wantRepo:    "ai-knowledge-base",
+		},
+		{
+			name:        "https",
+			remoteURL:   "https://dev.azure.com/talroo/Product/_git/ai-knowledge-base",
+			wantOrg:     "https://dev.azure.com/talroo",
+			wantProject: "Product",
+			wantRepo:    "ai-knowledge-base",
+		},
+		{
+			name:        "https with userinfo",
+			remoteURL:   "https://user@dev.azure.com/talroo/Product/_git/my-repo",
+			wantOrg:     "https://dev.azure.com/talroo",
+			wantProject: "Product",
+			wantRepo:    "my-repo",
+		},
+		{
+			name:        "visualstudio.com legacy",
+			remoteURL:   "https://talroo.visualstudio.com/Product/_git/ai-knowledge-base",
+			wantOrg:     "https://dev.azure.com/talroo",
+			wantProject: "Product",
+			wantRepo:    "ai-knowledge-base",
+		},
+		{
+			name:        "empty",
+			remoteURL:   "",
+			wantOrg:     "",
+			wantProject: "",
+			wantRepo:    "",
+		},
+		{
+			name:        "not azure",
+			remoteURL:   "https://github.com/user/repo.git",
+			wantOrg:     "",
+			wantProject: "",
+			wantRepo:    "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			org, project, repo := OrgProjectRepo(tc.remoteURL)
+			if org != tc.wantOrg {
+				t.Errorf("OrgProjectRepo(%q) org = %q, want %q", tc.remoteURL, org, tc.wantOrg)
+			}
+			if project != tc.wantProject {
+				t.Errorf("OrgProjectRepo(%q) project = %q, want %q", tc.remoteURL, project, tc.wantProject)
+			}
+			if repo != tc.wantRepo {
+				t.Errorf("OrgProjectRepo(%q) repo = %q, want %q", tc.remoteURL, repo, tc.wantRepo)
+			}
+		})
+	}
+}
+
+func TestFindPR(t *testing.T) {
+	t.Parallel()
+
+	host := New(azTestCmdFactory(map[string]azTestResponse{
+		"az repos pr list --status active --repository my-repo --project MyProject --org https://dev.azure.com/myorg --source-branch feat/test --target-branch main -o json": {
+			stdout: `[{"pullRequestId": 42, "url": "https://dev.azure.com/myorg/MyProject/_git/my-repo/pullrequest/42"}]` + "\n",
+		},
+	}), nil, "https://dev.azure.com/myorg", "MyProject", "my-repo")
+
+	pr, err := host.FindPR(context.Background(), "feat/test", "main")
+	if err != nil {
+		t.Fatalf("FindPR() error = %v", err)
+	}
+	if pr == nil {
+		t.Fatal("FindPR() returned nil PR")
+	}
+	if pr.Number != "42" {
+		t.Fatalf("PR.Number = %q, want 42", pr.Number)
+	}
+}
+
+func TestFindPR_NoResults(t *testing.T) {
+	t.Parallel()
+
+	host := New(azTestCmdFactory(map[string]azTestResponse{
+		"az repos pr list --status active --repository my-repo --project MyProject --org https://dev.azure.com/myorg --source-branch feat/test --target-branch main -o json": {
+			stdout: "[]\n",
+		},
+	}), nil, "https://dev.azure.com/myorg", "MyProject", "my-repo")
+
+	pr, err := host.FindPR(context.Background(), "feat/test", "main")
+	if err != nil {
+		t.Fatalf("FindPR() error = %v", err)
+	}
+	if pr != nil {
+		t.Fatalf("FindPR() = %+v, want nil", pr)
+	}
+}
+
+func TestCreatePR(t *testing.T) {
+	t.Parallel()
+
+	host := New(azTestCmdFactory(map[string]azTestResponse{
+		"az repos pr create --source-branch feat/test --target-branch main --title fix: test --description body --repository my-repo --project MyProject --org https://dev.azure.com/myorg -o json": {
+			stdout: `{"pullRequestId": 99, "url": "https://dev.azure.com/myorg/MyProject/_git/my-repo/pullrequest/99"}` + "\n",
+		},
+	}), nil, "https://dev.azure.com/myorg", "MyProject", "my-repo")
+
+	pr, err := host.CreatePR(context.Background(), "feat/test", "main", scm.PRContent{
+		Title: "fix: test",
+		Body:  "body",
+	})
+	if err != nil {
+		t.Fatalf("CreatePR() error = %v", err)
+	}
+	if pr == nil || pr.Number != "99" {
+		t.Fatalf("CreatePR() PR = %+v, want #99", pr)
+	}
+}
+
+func TestGetPRState(t *testing.T) {
+	t.Parallel()
+
+	host := New(azTestCmdFactory(map[string]azTestResponse{
+		"az repos pr show --id 42 --org https://dev.azure.com/myorg -o json": {
+			stdout: `{"pullRequestId": 42, "status": "completed", "mergeStatus": "succeeded"}` + "\n",
+		},
+	}), nil, "https://dev.azure.com/myorg", "MyProject", "my-repo")
+
+	state, err := host.GetPRState(context.Background(), &scm.PR{Number: "42"})
+	if err != nil {
+		t.Fatalf("GetPRState() error = %v", err)
+	}
+	if state != scm.PRStateMerged {
+		t.Fatalf("GetPRState() = %q, want %q", state, scm.PRStateMerged)
+	}
+}
+
+func TestGetPRState_Active(t *testing.T) {
+	t.Parallel()
+
+	host := New(azTestCmdFactory(map[string]azTestResponse{
+		"az repos pr show --id 42 --org https://dev.azure.com/myorg -o json": {
+			stdout: `{"pullRequestId": 42, "status": "active", "mergeStatus": "succeeded"}` + "\n",
+		},
+	}), nil, "https://dev.azure.com/myorg", "MyProject", "my-repo")
+
+	state, _ := host.GetPRState(context.Background(), &scm.PR{Number: "42"})
+	if state != scm.PRStateOpen {
+		t.Fatalf("GetPRState() = %q, want %q", state, scm.PRStateOpen)
+	}
+}
+
+func TestGetMergeableState(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		mergeStatus string
+		want        scm.MergeableState
+	}{
+		{"succeeded", "succeeded", scm.MergeableOK},
+		{"conflicts", "conflicts", scm.MergeableConflict},
+		{"rejectedByPolicy", "rejectedByPolicy", scm.MergeableConflict},
+		{"queued", "queued", scm.MergeablePending},
+		{"notSet", "notSet", scm.MergeablePending},
+		{"empty", "", scm.MergeablePending},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			host := New(azTestCmdFactory(map[string]azTestResponse{
+				"az repos pr show --id 42 --org https://dev.azure.com/myorg -o json": {
+					stdout: fmt.Sprintf(`{"pullRequestId": 42, "status": "active", "mergeStatus": "%s"}`+"\n", tc.mergeStatus),
+				},
+			}), nil, "https://dev.azure.com/myorg", "MyProject", "my-repo")
+
+			state, _ := host.GetMergeableState(context.Background(), &scm.PR{Number: "42"})
+			if state != tc.want {
+				t.Fatalf("GetMergeableState() = %q, want %q", state, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetChecks(t *testing.T) {
+	t.Parallel()
+
+	host := New(azTestCmdFactory(map[string]azTestResponse{
+		"az repos pr policy list --id 42 --org https://dev.azure.com/myorg -o json": {
+			stdout: `[{"status":"approved","configuration":{"isBlocking":false,"isEnabled":true,"type":{"displayName":"Build"},"settings":{"displayName":"Ai Review","buildDefinitionId":351}},"context":{"buildId":85144,"buildIsNotCurrent":false,"lastMergeSourceCommitId":"abc123"}}]` + "\n",
+		},
+	}), nil, "https://dev.azure.com/myorg", "MyProject", "my-repo")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "42"})
+	if err != nil {
+		t.Fatalf("GetChecks() error = %v", err)
+	}
+	if len(checks) != 1 {
+		t.Fatalf("len(checks) = %d, want 1", len(checks))
+	}
+	if checks[0].Name != "Ai Review" {
+		t.Fatalf("checks[0].Name = %q, want Ai Review", checks[0].Name)
+	}
+	if checks[0].Bucket != scm.CheckBucketPass {
+		t.Fatalf("checks[0].Bucket = %q, want pass", checks[0].Bucket)
+	}
+	if checks[0].CompletedAt.IsZero() {
+		t.Fatalf("checks[0].CompletedAt should be non-zero for terminal status")
+	}
+}
+
+func TestGetChecks_Rejected(t *testing.T) {
+	t.Parallel()
+
+	host := New(azTestCmdFactory(map[string]azTestResponse{
+		"az repos pr policy list --id 42 --org https://dev.azure.com/myorg -o json": {
+			stdout: `[{"status":"rejected","configuration":{"isBlocking":true,"isEnabled":true,"type":{"displayName":"Build"},"settings":{"displayName":"CI Build","buildDefinitionId":352}},"context":{"buildId":85145,"buildIsNotCurrent":false,"lastMergeSourceCommitId":"abc123"}}]` + "\n",
+		},
+	}), nil, "https://dev.azure.com/myorg", "MyProject", "my-repo")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "42"})
+	if err != nil {
+		t.Fatalf("GetChecks() error = %v", err)
+	}
+	if len(checks) != 1 {
+		t.Fatalf("len(checks) = %d, want 1", len(checks))
+	}
+	if checks[0].Bucket != scm.CheckBucketFail {
+		t.Fatalf("checks[0].Bucket = %q, want fail", checks[0].Bucket)
+	}
+}
+
+func TestGetChecks_NoPolicies(t *testing.T) {
+	t.Parallel()
+
+	host := New(azTestCmdFactory(map[string]azTestResponse{
+		"az repos pr policy list --id 42 --org https://dev.azure.com/myorg -o json": {
+			stdout: "[]\n",
+		},
+	}), nil, "https://dev.azure.com/myorg", "MyProject", "my-repo")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "42"})
+	if err != nil {
+		t.Fatalf("GetChecks() error = %v", err)
+	}
+	if len(checks) != 0 {
+		t.Fatalf("len(checks) = %d, want 0", len(checks))
+	}
+}
+
+func TestGetReviewPass(t *testing.T) {
+	t.Parallel()
+
+	host := New(azTestCmdFactory(map[string]azTestResponse{
+		"az repos pr policy list --id 42 --org https://dev.azure.com/myorg -o json": {
+			stdout: `[{"status":"approved","configuration":{"isBlocking":false,"isEnabled":true,"type":{"displayName":"Build"},"settings":{"displayName":"Ai Review","buildDefinitionId":351}},"context":{"buildId":85144,"buildIsNotCurrent":false,"lastMergeSourceCommitId":"abc123"}}]` + "\n",
+		},
+	}), nil, "https://dev.azure.com/myorg", "MyProject", "my-repo")
+
+	pass, err := host.GetReviewPass(context.Background(), &scm.PR{Number: "42"}, "Ai Review")
+	if err != nil {
+		t.Fatalf("GetReviewPass() error = %v", err)
+	}
+	if !pass.Ran {
+		t.Fatal("pass.Ran = false, want true")
+	}
+	if !pass.Complete {
+		t.Fatal("pass.Complete = false, want true")
+	}
+	if pass.ForSHA != "abc123" {
+		t.Fatalf("pass.ForSHA = %q, want abc123", pass.ForSHA)
+	}
+}
+
+func TestGetReviewPass_Running(t *testing.T) {
+	t.Parallel()
+
+	host := New(azTestCmdFactory(map[string]azTestResponse{
+		"az repos pr policy list --id 42 --org https://dev.azure.com/myorg -o json": {
+			stdout: `[{"status":"running","configuration":{"isBlocking":false,"isEnabled":true,"type":{"displayName":"Build"},"settings":{"displayName":"Ai Review","buildDefinitionId":351}},"context":{"buildId":85144,"buildIsNotCurrent":false,"lastMergeSourceCommitId":"abc123"}}]` + "\n",
+		},
+	}), nil, "https://dev.azure.com/myorg", "MyProject", "my-repo")
+
+	pass, _ := host.GetReviewPass(context.Background(), &scm.PR{Number: "42"}, "Ai Review")
+	if !pass.Ran {
+		t.Fatal("pass.Ran = false, want true")
+	}
+	if pass.Complete {
+		t.Fatal("pass.Complete = true, want false")
+	}
+}
+
+func TestGetReviewPass_NotFound(t *testing.T) {
+	t.Parallel()
+
+	host := New(azTestCmdFactory(map[string]azTestResponse{
+		"az repos pr policy list --id 42 --org https://dev.azure.com/myorg -o json": {
+			stdout: `[]` + "\n",
+		},
+	}), nil, "https://dev.azure.com/myorg", "MyProject", "my-repo")
+
+	pass, _ := host.GetReviewPass(context.Background(), &scm.PR{Number: "42"}, "Ai Review")
+	if pass.Ran {
+		t.Fatal("pass.Ran = true, want false")
+	}
+}
+
+func TestGetReviewThreads(t *testing.T) {
+	t.Parallel()
+
+	host := New(azTestCmdFactory(map[string]azTestResponse{
+		"az repos show --repository my-repo --org https://dev.azure.com/myorg -o json": {
+			stdout: `{"id": "repo-guid-123"}` + "\n",
+		},
+		"az devops invoke --area git --resource pullRequestThreads --route-parameters project=MyProject repositoryId=repo-guid-123 pullRequestId=42 --org https://dev.azure.com/myorg --api-version 7.1 -o json": {
+			stdout: `{"value":[
+				{"id":282696,"status":"fixed","threadContext":{"filePath":"/scripts/run.sh","rightFileStart":{"line":42}},"comments":[{"author":{"displayName":"Product Build Service (talroo)"},"commentType":"text","content":"BETA: fix this"}]},
+				{"id":282707,"status":null,"threadContext":null,"comments":[{"author":{"displayName":"Microsoft.VisualStudio.Services.TFS"},"commentType":"system","content":"ref updated"}]},
+				{"id":282708,"status":"active","threadContext":{"filePath":"/src/main.go","rightFileStart":{"line":10}},"comments":[{"author":{"displayName":"Product Build Service (talroo)"},"commentType":"text","content":"unresolved issue"}]}
+			]}` + "\n",
+		},
+	}), nil, "https://dev.azure.com/myorg", "MyProject", "my-repo")
+
+	threads, err := host.GetReviewThreads(context.Background(), &scm.PR{Number: "42"})
+	if err != nil {
+		t.Fatalf("GetReviewThreads() error = %v", err)
+	}
+	// system comment filtered out, so 2 text threads
+	if len(threads) != 2 {
+		t.Fatalf("len(threads) = %d, want 2", len(threads))
+	}
+
+	// First thread: fixed, bot
+	if threads[0].ID != "282696" {
+		t.Fatalf("threads[0].ID = %q, want 282696", threads[0].ID)
+	}
+	if !threads[0].Resolved {
+		t.Fatal("threads[0].Resolved = false, want true (fixed)")
+	}
+	if threads[0].File != "/scripts/run.sh" {
+		t.Fatalf("threads[0].File = %q, want /scripts/run.sh", threads[0].File)
+	}
+	if threads[0].Line != 42 {
+		t.Fatalf("threads[0].Line = %d, want 42", threads[0].Line)
+	}
+	if threads[0].Author != "Product Build Service (talroo)" {
+		t.Fatalf("threads[0].Author = %q", threads[0].Author)
+	}
+
+	// Second thread: active, unresolved
+	if threads[1].ID != "282708" {
+		t.Fatalf("threads[1].ID = %q, want 282708", threads[1].ID)
+	}
+	if threads[1].Resolved {
+		t.Fatal("threads[1].Resolved = true, want false (active)")
+	}
+}
+
+func TestCapabilities(t *testing.T) {
+	t.Parallel()
+
+	host := New(nil, nil, "", "", "")
+	caps := host.Capabilities()
+	if !caps.MergeableState {
+		t.Error("MergeableState should be true")
+	}
+	if !caps.FailedCheckLogs {
+		t.Error("FailedCheckLogs should be true")
+	}
+	if !caps.ReviewComments {
+		t.Error("ReviewComments should be true")
+	}
+}
+
+func TestProvider(t *testing.T) {
+	t.Parallel()
+
+	host := New(nil, nil, "", "", "")
+	if host.Provider() != scm.ProviderAzureDevOps {
+		t.Fatalf("Provider() = %q, want %q", host.Provider(), scm.ProviderAzureDevOps)
+	}
+}
+
+func TestNormalizePRState(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		input string
+		want  scm.PRState
+	}{
+		{"active", scm.PRStateOpen},
+		{"completed", scm.PRStateMerged},
+		{"abandoned", scm.PRStateClosed},
+		{"ACTIVE", scm.PRStateOpen},
+	}
+	for _, tc := range cases {
+		if got := normalizePRState(tc.input); got != tc.want {
+			t.Errorf("normalizePRState(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestPolicyStatusToBucket(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		input string
+		want  scm.CheckBucket
+	}{
+		{"approved", scm.CheckBucketPass},
+		{"rejected", scm.CheckBucketFail},
+		{"queued", scm.CheckBucketPending},
+		{"running", scm.CheckBucketPending},
+		{"notApplicable", scm.CheckBucketSkip},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := policyStatusToBucket(tc.input); got != tc.want {
+			t.Errorf("policyStatusToBucket(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestIsThreadResolved(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		input string
+		want  bool
+	}{
+		{"active", false},
+		{"pending", false},
+		{"", false},
+		{"fixed", true},
+		{"closed", true},
+		{"wontFix", true},
+		{"byDesign", true},
+	}
+	for _, tc := range cases {
+		if got := isThreadResolved(tc.input); got != tc.want {
+			t.Errorf("isThreadResolved(%q) = %v, want %v", tc.input, got, tc.want)
+		}
+	}
+}
+
+// --- test infrastructure ---
+
+type azTestResponse struct {
+	stdout string
+	stderr string
+	code   int
+}
+
+func azTestCmdFactory(responses map[string]azTestResponse) CmdFactory {
+	return func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		key := strings.TrimSpace(name + " " + strings.Join(args, " "))
+		response, ok := responses[key]
+		if !ok {
+			response = azTestResponse{stderr: "unexpected command: " + key, code: 1}
+		}
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestAzureDevOpsHelperProcess", "--", key)
+		cmd.Env = append(os.Environ(),
+			"AZ_TEST_HELPER=1",
+			"AZ_TEST_STDOUT="+response.stdout,
+			"AZ_TEST_STDERR="+response.stderr,
+			fmt.Sprintf("AZ_TEST_EXIT_CODE=%d", response.code),
+		)
+		return cmd
+	}
+}
+
+func TestAzureDevOpsHelperProcess(t *testing.T) {
+	if os.Getenv("AZ_TEST_HELPER") != "1" {
+		return
+	}
+	if _, err := fmt.Fprint(os.Stdout, os.Getenv("AZ_TEST_STDOUT")); err != nil {
+		os.Exit(1)
+	}
+	if _, err := fmt.Fprint(os.Stderr, os.Getenv("AZ_TEST_STDERR")); err != nil {
+		os.Exit(1)
+	}
+	code := 0
+	if c := os.Getenv("AZ_TEST_EXIT_CODE"); c != "" {
+		if n, err := fmt.Sscanf(c, "%d", &code); err != nil || n != 1 {
+			code = 0
+		}
+	}
+	if code != 0 {
+		os.Exit(code)
+	}
+	// drain stdin so callers that pipe data don't get SIGPIPE
+	io.Copy(io.Discard, os.Stdin)
+	os.Exit(0)
+}
+
+// ensure time is imported
+var _ = time.Now

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -433,3 +433,11 @@ func normalizeCheckBucket(bucket, state string) scm.CheckBucket {
 		return ""
 	}
 }
+
+func (h *Host) GetReviewPass(ctx context.Context, pr *scm.PR, reviewerIdentity string) (*scm.ReviewPass, error) {
+	return nil, scm.ErrUnsupported
+}
+
+func (h *Host) GetReviewThreads(ctx context.Context, pr *scm.PR) ([]scm.ReviewThread, error) {
+	return nil, scm.ErrUnsupported
+}

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -567,3 +567,11 @@ func extractMRURL(raw []byte) string {
 	}
 	return ""
 }
+
+func (h *Host) GetReviewPass(ctx context.Context, pr *scm.PR, reviewerIdentity string) (*scm.ReviewPass, error) {
+	return nil, scm.ErrUnsupported
+}
+
+func (h *Host) GetReviewThreads(ctx context.Context, pr *scm.PR) ([]scm.ReviewThread, error) {
+	return nil, scm.ErrUnsupported
+}

--- a/internal/scm/host.go
+++ b/internal/scm/host.go
@@ -152,6 +152,7 @@ func (c Check) Pending() bool { return c.Bucket == CheckBucketPending }
 type Capabilities struct {
 	MergeableState  bool
 	FailedCheckLogs bool
+	ReviewComments  bool
 }
 
 // ErrUnsupported is returned by optional Host methods that the provider
@@ -184,4 +185,30 @@ type Host interface {
 	// FetchFailedCheckLogs is optional; returns "" when no logs can be retrieved
 	// and ErrUnsupported when the provider has no log-fetching support at all.
 	FetchFailedCheckLogs(ctx context.Context, pr *PR, branch, headSHA string, failingNames []string) (string, error)
+
+	// GetReviewPass is optional; gate on Capabilities().ReviewComments.
+	// Returns the AI-review pass status keyed to the current PR head SHA.
+	GetReviewPass(ctx context.Context, pr *PR, reviewerIdentity string) (*ReviewPass, error)
+
+	// GetReviewThreads is optional; gate on Capabilities().ReviewComments.
+	// Returns all review comment threads on the PR.
+	GetReviewThreads(ctx context.Context, pr *PR) ([]ReviewThread, error)
+}
+
+// ReviewThread is a normalized PR comment thread from an AI reviewer.
+type ReviewThread struct {
+	ID       string
+	Author   string
+	File     string
+	Line     int
+	Body     string
+	Resolved bool
+	IsBot    bool
+}
+
+// ReviewPass is the status of an AI-review pass on a PR.
+type ReviewPass struct {
+	Ran      bool   // a review pass exists for this PR
+	Complete bool   // terminal status (approved/rejected/notApplicable)
+	ForSHA   string // source commit the pass evaluated
 }

--- a/internal/scm/host_test.go
+++ b/internal/scm/host_test.go
@@ -130,3 +130,9 @@ func (fakeHost) GetMergeableState(context.Context, *PR) (MergeableState, error) 
 func (fakeHost) FetchFailedCheckLogs(context.Context, *PR, string, string, []string) (string, error) {
 	return "", ErrUnsupported
 }
+func (fakeHost) GetReviewPass(context.Context, *PR, string) (*ReviewPass, error) {
+	return nil, ErrUnsupported
+}
+func (fakeHost) GetReviewThreads(context.Context, *PR) ([]ReviewThread, error) {
+	return nil, ErrUnsupported
+}

--- a/internal/scm/scm.go
+++ b/internal/scm/scm.go
@@ -13,10 +13,11 @@ import (
 type Provider string
 
 const (
-	ProviderGitHub    Provider = "github"
-	ProviderGitLab    Provider = "gitlab"
-	ProviderBitbucket Provider = "bitbucket"
-	ProviderUnknown   Provider = "unknown"
+	ProviderGitHub      Provider = "github"
+	ProviderGitLab      Provider = "gitlab"
+	ProviderBitbucket   Provider = "bitbucket"
+	ProviderAzureDevOps Provider = "azuredevops"
+	ProviderUnknown     Provider = "unknown"
 )
 
 func DetectProvider(url string) Provider {
@@ -28,6 +29,10 @@ func DetectProvider(url string) Provider {
 		return ProviderGitLab
 	case strings.Contains(lower, "bitbucket.org"):
 		return ProviderBitbucket
+	case strings.Contains(lower, "dev.azure.com"),
+		strings.Contains(lower, "ssh.dev.azure.com"),
+		strings.Contains(lower, ".visualstudio.com"):
+		return ProviderAzureDevOps
 	}
 
 	// Fallback for self-hosted GitLab instances whose hostname carries no
@@ -101,6 +106,8 @@ func (p Provider) CLIName() string {
 		return "glab"
 	case ProviderBitbucket:
 		return "bb"
+	case ProviderAzureDevOps:
+		return "az"
 	default:
 		return ""
 	}
@@ -114,6 +121,8 @@ func (p Provider) AuthCheckCommand() []string {
 		return []string{"glab", "auth", "status"}
 	case ProviderBitbucket:
 		return []string{"bb", "profile", "which"}
+	case ProviderAzureDevOps:
+		return []string{"az", "account", "show"}
 	default:
 		return nil
 	}

--- a/internal/scm/scm_test.go
+++ b/internal/scm/scm_test.go
@@ -20,6 +20,9 @@ func TestDetectProvider(t *testing.T) {
 		{"https://gitlab.com/user/repo.git", ProviderGitLab},
 		{"https://gitlab.mycorp.com/group/repo.git", ProviderGitLab},
 		{"https://bitbucket.org/user/repo.git", ProviderBitbucket},
+		{"https://dev.azure.com/talroo/Product/_git/ai-knowledge-base", ProviderAzureDevOps},
+		{"git@ssh.dev.azure.com:v3/talroo/Product/ai-knowledge-base", ProviderAzureDevOps},
+		{"https://talroo.visualstudio.com/Product/_git/ai-knowledge-base", ProviderAzureDevOps},
 		{"https://example.com/user/repo.git", ProviderUnknown},
 	}
 


### PR DESCRIPTION
## What Changed

- Add first-class Azure DevOps SCM provider (`ProviderAzureDevOps`) so the full no-mistakes pipeline runs on Azure DevOps repos alongside GitHub, GitLab, and Bitbucket.
- New `internal/scm/azuredevops` package implementing `scm.Host` over the `az` CLI:
  - PR operations via `az repos pr create/list/show/update`
  - CI checks via `az repos pr policy list` (branch policies as checks)
  - AI-review comment threads via `az devops invoke pullRequestThreads`
  - `GetReviewPass` / `GetReviewThreads` for the AI-review monitor
- Host detection: `DetectProvider` now recognizes `dev.azure.com`, `ssh.dev.azure.com`, and `*.visualstudio.com` remote URLs. Existing GitHub behavior is unchanged.
- AI-review monitor+iterate loop: after CI is green, gates `ChecksPassedMsg` on a clean AI-review pass. Waits for the reviewer, reads unresolved bot-authored threads, runs the agent to fix them, pushes, repeats until clean or `max_iterations`. Degrades gracefully when no reviewer is configured.
- New `ai_review` config block with sensible defaults.
- All existing providers implement the new optional methods as `ErrUnsupported` stubs.

## Testing

- `go build ./...` passes
- `go test -race ./...` passes (all existing + new tests)
- `go vet ./...` passes
- `gofmt -l .` clean
- `make lint` passes (skill-check + vet)
- New unit tests: `internal/scm/azuredevops/azuredevops_test.go` (URL parsing, FindPR, CreatePR, GetPRState, GetMergeableState, GetChecks, GetReviewPass, GetReviewThreads, state mapping)
- New `DetectProvider` test cases for Azure URL formats

## Risk Assessment

Medium - adds a new SCM provider and extends the `scm.Host` interface with two optional methods. The interface change is non-breaking (existing providers return `ErrUnsupported`). The AI-review gate in the CI step only activates when `Capabilities().ReviewComments` is true and `ai_review.enabled` is true (default true but degrades gracefully).

## Intent

Enable no-mistakes to run its full pipeline (PR, CI, auto-fix) on Azure DevOps repos like Talroo's, and add an optional AI-review monitor that waits for the CI/CD AI reviewer and iterates on its comments until clean.