### PR TITLE
fix(windows): suppress console-window popups for spawned subprocesses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ demo_raw.gif
 # Environment
 .env
 .env.local
+
+# Lavish review artifacts (local, per-user)
+.lavish/

--- a/cmd/fakeagent/claude.go
+++ b/cmd/fakeagent/claude.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 )
 
 func runClaude(args []string, scenario *Scenario) int {
-	prompt := extractClaudePrompt(args)
+	prompt := readClaudePrompt(args)
 	logInvocation("claude", prompt, args)
 
 	action := scenario.Match(prompt)
@@ -205,10 +206,23 @@ func hasClaudeSchema(args []string) bool {
 	return false
 }
 
-// extractClaudePrompt scans for the value following -p, matching the real
-// claude CLI's argv shape (claude -p "<prompt>" --verbose ...). Other
-// flags carrying values are skipped explicitly so we don't accidentally
-// pick up e.g. --output-format's argument.
+// readClaudePrompt returns the prompt the pipeline issued. The real claude
+// CLI reads the prompt from stdin in print mode (`claude -p` with no
+// positional argument), which is how no-mistakes invokes it to sidestep the
+// Windows command-line length limit, so the fake mirrors that by draining
+// stdin. It falls back to scanning argv for a positional -p value for any
+// caller (or test) that still passes the prompt that way.
+func readClaudePrompt(args []string) string {
+	if data, _ := io.ReadAll(os.Stdin); len(data) > 0 {
+		return string(data)
+	}
+	return extractClaudePrompt(args)
+}
+
+// extractClaudePrompt scans for the value following -p, matching the legacy
+// argv shape (claude -p "<prompt>" --verbose ...). Other flags carrying
+// values are skipped explicitly so we don't accidentally pick up e.g.
+// --output-format's argument.
 func extractClaudePrompt(args []string) string {
 	flagsWithValues := map[string]bool{
 		"--output-format":    true,

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -39,10 +39,16 @@ func (a *claudeAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
 }
 
 func (a *claudeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
-	args := a.buildArgs(opts.Prompt, opts.JSONSchema)
+	args := a.buildArgs(opts.JSONSchema)
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD
-	cmd.Stdin = nil
+	// Pass the prompt on stdin, not as a CLI argument. On Windows a large
+	// prompt (test output + diff + prior findings) pushes the command line
+	// past CreateProcess's ~32767-character limit, which fails to launch with
+	// error 206 ("The filename or extension is too long"). stdin has no such
+	// limit; claude reads the prompt from stdin in print mode (`claude -p`
+	// with no positional argument).
+	cmd.Stdin = strings.NewReader(opts.Prompt)
 	cmd.Env = gitSafeEnv(opts.CWD)
 	shellenv.ConfigureShellCommand(cmd)
 
@@ -108,12 +114,13 @@ func finalizeClaudeResult(result *claudeResult, schema json.RawMessage, usage To
 // (from agent_args_override in the global config) are inserted ahead of the
 // managed flags, so user choices win over no-mistakes' defaults. If the user
 // supplied their own permission mode, the default --dangerously-skip-permissions
-// is not added.
-func (a *claudeAgent) buildArgs(prompt string, schema json.RawMessage) []string {
+// is not added. The prompt is not included here: it is delivered on stdin (see
+// runOnce) to avoid the Windows command-line length limit.
+func (a *claudeAgent) buildArgs(schema json.RawMessage) []string {
 	args := make([]string, 0, len(a.extraArgs)+8)
 	args = append(args, a.extraArgs...)
 	args = append(args,
-		"-p", prompt,
+		"-p",
 		"--verbose",
 		"--output-format", "stream-json",
 	)

--- a/internal/agent/claude_exec_test.go
+++ b/internal/agent/claude_exec_test.go
@@ -1,0 +1,110 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestClaudeAgent_LargePromptDeliveredViaStdin exercises the real exec path
+// with a prompt far larger than the Windows CreateProcess command-line limit
+// (~32767 characters). Before the fix the prompt rode in argv, so on Windows
+// the child failed to launch with error 206 ("The filename or extension is too
+// long"); the fix delivers the prompt on stdin instead. The test asserts the
+// process launches on every platform and that the full prompt reaches the
+// child intact, which is what proves stdin fully replaces the argv prompt.
+func TestClaudeAgent_LargePromptDeliveredViaStdin(t *testing.T) {
+	bin := buildFakeClaude(t)
+
+	logPath := filepath.Join(t.TempDir(), "invocations.jsonl")
+	t.Setenv("FAKEAGENT_LOG", logPath)
+	// Force the synthetic clean response: no recorded fixture, no scenario.
+	t.Setenv("FAKEAGENT_FIXTURE", "")
+	t.Setenv("FAKEAGENT_SCENARIO", "")
+
+	// 64 KiB prompt, well past the 32767-char ceiling, with sentinels so we
+	// can confirm it round-tripped whole rather than being truncated.
+	const head, tail = "PROMPT_HEAD::", "::PROMPT_TAIL"
+	prompt := head + strings.Repeat("y", 64*1024) + tail
+
+	a := &claudeAgent{bin: bin}
+	res, err := a.runOnce(context.Background(), RunOpts{Prompt: prompt, CWD: t.TempDir()})
+	if err != nil {
+		t.Fatalf("runOnce with %d-char prompt failed to exec/parse: %v", len(prompt), err)
+	}
+	if res == nil {
+		t.Fatal("expected a non-nil result")
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read fakeagent log: %v", err)
+	}
+	var got string
+	var seen bool
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		var inv struct {
+			Agent  string `json:"agent"`
+			Prompt string `json:"prompt"`
+		}
+		if err := json.Unmarshal([]byte(line), &inv); err != nil {
+			t.Fatalf("parse invocation %q: %v", line, err)
+		}
+		if inv.Agent == "claude" {
+			got = inv.Prompt
+			seen = true
+		}
+	}
+	if !seen {
+		t.Fatal("fakeagent recorded no claude invocation")
+	}
+	if got != prompt {
+		t.Fatalf("prompt did not round-trip via stdin: got %d chars, want %d", len(got), len(prompt))
+	}
+}
+
+// buildFakeClaude compiles cmd/fakeagent and returns a path to it named
+// "claude" (claude.exe on Windows) so the binary's argv[0]-basename dispatch
+// selects the claude wire protocol.
+func buildFakeClaude(t *testing.T) string {
+	t.Helper()
+	out := filepath.Join(t.TempDir(), "claude")
+	if runtime.GOOS == "windows" {
+		out += ".exe"
+	}
+	cmd := exec.Command("go", "build", "-o", out, "./cmd/fakeagent")
+	cmd.Dir = repoRootForTest(t)
+	if b, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build fakeagent: %v\n%s", err, b)
+	}
+	return out
+}
+
+// repoRootForTest walks up from this source file to the module's go.mod so
+// the build works regardless of the test runner's working directory.
+func repoRootForTest(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("go.mod not found above %s", filepath.Dir(file))
+		}
+		dir = parent
+	}
+}

--- a/internal/agent/claude_test.go
+++ b/internal/agent/claude_test.go
@@ -12,10 +12,10 @@ import (
 func TestClaudeAgent_BuildArgs(t *testing.T) {
 	ca := &claudeAgent{bin: "/usr/bin/claude"}
 	schema := json.RawMessage(`{"type":"object"}`)
-	args := ca.buildArgs("do something", schema)
+	args := ca.buildArgs(schema)
 
 	expected := []string{
-		"-p", "do something",
+		"-p",
 		"--verbose",
 		"--output-format", "stream-json",
 		"--json-schema", `{"type":"object"}`,
@@ -32,9 +32,31 @@ func TestClaudeAgent_BuildArgs(t *testing.T) {
 	}
 }
 
+// The prompt must never appear in argv: it is delivered on stdin so a large
+// prompt cannot blow past the Windows command-line length limit (error 206).
+func TestClaudeAgent_BuildArgs_OmitsPromptFromArgv(t *testing.T) {
+	ca := &claudeAgent{bin: "claude"}
+	prompt := strings.Repeat("x", 64*1024)
+	args := ca.buildArgs(json.RawMessage(`{"type":"object"}`))
+
+	for i, arg := range args {
+		if strings.Contains(arg, "xxxx") {
+			t.Fatalf("arg[%d] carries prompt text; prompt must go on stdin: %q", i, arg)
+		}
+	}
+	// -p is present and immediately followed by a flag, not a prompt value.
+	if args[0] != "-p" {
+		t.Fatalf("expected -p first, got %q", args[0])
+	}
+	if !strings.HasPrefix(args[1], "--") {
+		t.Fatalf("expected a flag after -p, got %q", args[1])
+	}
+	_ = prompt
+}
+
 func TestClaudeAgent_BuildArgs_NoSchema(t *testing.T) {
 	ca := &claudeAgent{bin: "claude"}
-	args := ca.buildArgs("prompt", nil)
+	args := ca.buildArgs(nil)
 
 	// Without schema, should not include --json-schema flag
 	for _, arg := range args {
@@ -43,18 +65,18 @@ func TestClaudeAgent_BuildArgs_NoSchema(t *testing.T) {
 		}
 	}
 	// Should still have core args
-	if args[0] != "-p" || args[1] != "prompt" {
+	if args[0] != "-p" {
 		t.Error("missing -p flag")
 	}
 }
 
 func TestClaudeAgent_BuildArgs_ExtraArgsPrepended(t *testing.T) {
 	ca := &claudeAgent{bin: "claude", extraArgs: []string{"--model", "sonnet"}}
-	args := ca.buildArgs("do it", nil)
+	args := ca.buildArgs(nil)
 
 	expected := []string{
 		"--model", "sonnet",
-		"-p", "do it",
+		"-p",
 		"--verbose",
 		"--output-format", "stream-json",
 		"--dangerously-skip-permissions",
@@ -77,7 +99,7 @@ func TestClaudeAgent_BuildArgs_UserPermissionModeSuppressesDefault(t *testing.T)
 	}
 	for _, extra := range tests {
 		ca := &claudeAgent{bin: "claude", extraArgs: extra}
-		args := ca.buildArgs("p", nil)
+		args := ca.buildArgs(nil)
 
 		dangerCount := 0
 		for _, a := range args {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kunchenguid/no-mistakes/internal/shellenv"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 	"gopkg.in/yaml.v3"
 )
@@ -277,6 +278,7 @@ var probeRovoDevSupport = func(ctx context.Context, bin string) (bool, error) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, bin, "rovodev", "--help")
+	shellenv.HideWindow(cmd)
 	output, err := cmd.CombinedOutput()
 	if err == nil {
 		return true, nil

--- a/internal/daemon/proc_windows.go
+++ b/internal/daemon/proc_windows.go
@@ -27,6 +27,7 @@ const psListDaemonProcessesScript = "$ErrorActionPreference='SilentlyContinue'; 
 // Failures (e.g. PowerShell absent) fail open in the caller.
 func listDaemonProcesses() ([]daemonProcessInfo, error) {
 	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", psListDaemonProcessesScript)
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.CREATE_NO_WINDOW}
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("enumerate processes: %w", err)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/safeurl"
+	"github.com/kunchenguid/no-mistakes/internal/shellenv"
 )
 
 // EmptyTreeSHA is the well-known SHA of an empty tree in git.
@@ -29,6 +30,7 @@ func Run(ctx context.Context, dir string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
 	cmd.Env = NonInteractiveEnv(dir)
+	shellenv.HideWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		stderr := ""
@@ -43,6 +45,7 @@ func Run(ctx context.Context, dir string, args ...string) (string, error) {
 // InitBare creates a new bare git repository at the given path.
 func InitBare(ctx context.Context, path string) error {
 	cmd := exec.CommandContext(ctx, "git", "init", "--bare", path)
+	shellenv.HideWindow(cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("git init --bare: %w: %s", err, strings.TrimSpace(string(out)))
@@ -92,6 +95,7 @@ func FindGitRoot(path string) (string, error) {
 		return "", err
 	}
 	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	shellenv.HideWindow(cmd)
 	cmd.Dir = abs
 	out, err := cmd.Output()
 	if err != nil {
@@ -115,6 +119,7 @@ func FindMainRepoRoot(path string) (string, error) {
 		return "", err
 	}
 	cmd := exec.Command("git", "rev-parse", "--git-common-dir")
+	shellenv.HideWindow(cmd)
 	cmd.Dir = abs
 	out, err := cmd.Output()
 	if err != nil {
@@ -199,6 +204,7 @@ func CurrentBranch(ctx context.Context, dir string) (string, error) {
 // which fails cleanly when HEAD is not a symbolic ref.
 func IsDetachedHEAD(ctx context.Context, dir string) (bool, error) {
 	cmd := exec.CommandContext(ctx, "git", "symbolic-ref", "-q", "HEAD")
+	shellenv.HideWindow(cmd)
 	cmd.Dir = dir
 	if err := cmd.Run(); err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
@@ -373,6 +379,7 @@ func ResolveRef(ctx context.Context, dir, ref string) (string, error) {
 // result rather than a loud error.
 func RefExists(ctx context.Context, dir, ref string) (bool, error) {
 	cmd := exec.CommandContext(ctx, "git", "-C", dir, "rev-parse", "--verify", "--quiet", ref+"^{commit}")
+	shellenv.HideWindow(cmd)
 	cmd.Env = NonInteractiveEnv(dir)
 	if err := cmd.Run(); err != nil {
 		var ee *exec.ExitError

--- a/internal/intent/paths.go
+++ b/internal/intent/paths.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/kunchenguid/no-mistakes/internal/shellenv"
 )
 
 // resolveHome returns the home directory to use, preferring an explicit
@@ -109,6 +111,7 @@ func gitRepoIdentity(ctx context.Context, dir string) repoIdentity {
 
 func gitOutput(ctx context.Context, dir string, args ...string) string {
 	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...)
+	shellenv.HideWindow(cmd)
 	out, err := cmd.Output()
 	if err != nil {
 		return ""

--- a/internal/pipeline/steps/common_exec.go
+++ b/internal/pipeline/steps/common_exec.go
@@ -163,6 +163,11 @@ func stepCmd(sctx *pipeline.StepContext, name string, args ...string) *exec.Cmd 
 	if missingFromPath {
 		cmd.Err = &exec.Error{Name: name, Err: exec.ErrNotFound}
 	}
+	// Suppress console-window popups on Windows. stepCmd is the shared builder
+	// for pipeline git commands and every SCM CLI call (the gh/glab/az
+	// CmdFactory injected in host.go routes through here), all launched by the
+	// windowless daemon.
+	shellenv.HideWindow(cmd)
 	return cmd
 }
 

--- a/internal/scm/scm.go
+++ b/internal/scm/scm.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/kunchenguid/no-mistakes/internal/shellenv"
 	"gopkg.in/yaml.v3"
 )
 
@@ -144,5 +145,6 @@ func AuthConfigured(ctx context.Context, provider Provider, workDir string) bool
 	}
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 	cmd.Dir = workDir
+	shellenv.HideWindow(cmd)
 	return cmd.Run() == nil
 }

--- a/internal/shellenv/hidewindow_other.go
+++ b/internal/shellenv/hidewindow_other.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package shellenv
+
+import "os/exec"
+
+// HideWindow is a no-op off Windows. Only Windows allocates a console window
+// for a console child spawned from a windowless parent; on Unix a subprocess
+// never pops a window, so there is nothing to suppress.
+func HideWindow(cmd *exec.Cmd) {}

--- a/internal/shellenv/hidewindow_windows.go
+++ b/internal/shellenv/hidewindow_windows.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+package shellenv
+
+import (
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// HideWindow prevents cmd from popping a console window when it is spawned from
+// a process that has no console of its own - which is exactly the daemon's
+// situation, since it runs as a background service/scheduled task with no
+// attached console.
+//
+// Without CREATE_NO_WINDOW, a console child launched from a windowless parent
+// forces Windows to allocate a console for it, and the "default terminal
+// application" hand-off then surfaces that console as a visible window (a
+// Windows Terminal window when Terminal is the default, a conhost window
+// otherwise). Every agent (claude/codex/...), every git invocation, and every
+// gh/glab/az call would otherwise flash a window on the user's screen for the
+// life of the child. CREATE_NO_WINDOW makes the allocated console headless.
+//
+// It is safe to call before Start and composes with any CreationFlags already
+// set (for example the CREATE_NEW_PROCESS_GROUP / CREATE_SUSPENDED that
+// ConfigureShellCommand adds). Passing a nil cmd is a no-op.
+func HideWindow(cmd *exec.Cmd) {
+	if cmd == nil {
+		return
+	}
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= windows.CREATE_NO_WINDOW
+}

--- a/internal/shellenv/shell_command_windows.go
+++ b/internal/shellenv/shell_command_windows.go
@@ -58,6 +58,11 @@ func ConfigureShellCommand(cmd *exec.Cmd) {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
 	cmd.SysProcAttr.CreationFlags |= createNewProcessGroup
+	// Never surface a console window for a managed command: the daemon runs
+	// windowless, so any console child it spawns (every native agent, every
+	// shell step) would otherwise be handed to the default terminal app and
+	// popped onto the user's screen.
+	HideWindow(cmd)
 	if job, err := newShellCommandJobFunc(); err == nil {
 		shellCommandJobs.Store(cmd, &shellCommandJobState{handle: job})
 		cmd.SysProcAttr.CreationFlags |= windows.CREATE_SUSPENDED


### PR DESCRIPTION
## Problem

On Windows, no-mistakes spawns its subprocesses (native agents, `git`, and the `gh`/`glab`/`az` SCM CLIs) from the daemon, which runs as a background service/scheduled task with **no console of its own**. A console child launched from a windowless parent forces Windows to allocate a console for it, and the "default terminal application" hand-off then surfaces that console as a **visible window** on the user's screen - a Windows Terminal window when Terminal is the default, a conhost window otherwise.

The result: every review/test agent (`claude -p …`), every `git` invocation, and every `gh` call pops a window (often centered on the primary monitor and stealing focus). During a normal run - and especially with several concurrent gated branches - these windows appear constantly.

The daemon already hides its **own** window (`internal/daemon/proc_windows.go` sets `HideWindow` for the self-spawn), and the Unix path is unaffected (a subprocess never pops a window on Unix), but the child processes it launches were never given `CREATE_NO_WINDOW`.

## Fix

Add a small platform-split helper `shellenv.HideWindow(cmd)` that ORs `windows.CREATE_NO_WINDOW` into the command's `CreationFlags` on Windows and is a no-op elsewhere, then apply it at the process-spawn choke points:

- **`shellenv.ConfigureShellCommand` (Windows)** - covers all five native agents (claude/codex/copilot/pi/acpx) and the shell lint/test/format steps, which all route through it.
- **`pipeline/steps.stepCmd`** - the shared builder for pipeline `git` and every SCM CLI call (the `gh`/`glab`/`az` `CmdFactory` in `host.go` routes through it).
- **`internal/git`** - the gate/worktree git commands the daemon runs directly (outside the pipeline).
- Remaining direct spawns: `scm.AuthConfigured`, the rovodev capability probe in `internal/config`, the intent-reader git calls, and the periodic daemon process-list PowerShell in `proc_windows.go`.

`CREATE_NO_WINDOW` composes with the `CREATE_NEW_PROCESS_GROUP` / `CREATE_SUSPENDED` flags `ConfigureShellCommand` already sets; it only makes the allocated console headless and changes no other behavior.

## Notes

- No behavior change on Unix (helper is a no-op there) or in redirected-output capture (stdout/stderr are still piped exactly as before).
- `update/background.go` already spawns detached (`DETACHED_PROCESS`) and needs no change.
