### PR TITLE
feat(agent): support ordered fallback agent lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 Push to `no-mistakes` instead of `origin`, and it spins up a disposable worktree, runs an AI-driven validation pipeline, forwards the branch to the configured push target only after every check passes, and opens a clean PR automatically.
 
 - **Non-blocking** - the pipeline runs in an isolated worktree without disrupting your work.
-- **Agent-agnostic** - `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, or `acp:<target>` via `acpx`.
+- **Agent-agnostic** - `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, or `acp:<target>` via `acpx`, with ordered fallbacks.
 - **Agent-native** - `/no-mistakes` lets your coding agent do a task and gate it, or gate existing committed work: it runs the pipeline, has the pipeline apply safe fixes, and escalates the rest to you.
 - **Human stays in charge** - auto-fix or review findings, your call.
 - **Clean PRs by default** - push, open PR, watch CI, and auto-fix failures in one shot.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -34,7 +34,7 @@
 把分支推给 `no-mistakes` 而不是 `origin`，它会拉起一个用完即弃的 worktree，跑一条 AI 驱动的校验流水线，**只有每一项检查都通过后**才把分支转发到配置的推送目标，并自动开出一个干净的 PR。
 
 - **不阻塞** —— 流水线在隔离的 worktree 里跑，不打断你手头的工作。
-- **不挑 agent** —— 支持 `claude`、`codex`、`rovodev`、`opencode`、`pi`，或通过 `acpx` 用 `acp:<target>`。
+- **不挑 agent** —— 支持 `claude`、`codex`、`rovodev`、`opencode`、`pi`、`copilot`，或通过 `acpx` 用 `acp:<target>`，并支持有序 fallback。
 - **agent 原生** —— `/no-mistakes` 既能让编码 agent 完成一个任务再过网关，也能直接为已提交的工作过网关：它跑完流水线、让流水线应用安全的修复，剩下的升级给你。
 - **人始终说了算** —— 自动修复，还是逐条审查 findings，你决定。
 - **默认就是干净 PR** —— 推送、开 PR、盯 CI、自动修复失败，一气呵成。

--- a/docs/src/content/docs/concepts/pipeline.md
+++ b/docs/src/content/docs/concepts/pipeline.md
@@ -75,7 +75,7 @@ See [Auto-Fix Loop](/no-mistakes/concepts/auto-fix/) for how the fix cycle works
 
 You can't reorder steps. You *can*:
 
-- Swap the agent (global or per-repo).
+- Swap the agent, or configure an ordered fallback list, globally or per-repo.
 - Set explicit `commands.test`, `commands.lint`, `commands.format`.
 - Store test evidence locally by default or opt into committed in-repo evidence with `test.evidence.store_in_repo`.
 - Control auto-fix limits per step.

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -22,6 +22,7 @@ Testing prompts also ask agents to remove transient working-tree artifacts they 
 
 - Leave `agent: auto` if one good agent is already installed and you do not need repo-specific behavior.
 - Set a repo-level `agent` override when one codebase clearly works better with a different tool.
+- Use an ordered fallback list when you prefer one agent but want no-mistakes to try another if the first process is unavailable.
 - Set explicit `commands.test` and `commands.lint` if you want deterministic baseline command execution regardless of agent choice.
 
 That last point matters: the agent helps fill in gaps, but explicit repo
@@ -59,6 +60,15 @@ agent: codex
 ```
 
 Repo config takes precedence over global config.
+
+### Ordered fallback list
+
+```yaml
+# ~/.no-mistakes/config.yaml or .no-mistakes.yaml
+agent: [codex, claude]
+```
+
+no-mistakes filters the list to agents available on the daemon's `PATH`, uses the first available entry as the primary agent, and keeps later available entries as fallbacks. If an invocation fails because the current agent process cannot start or exits with an unavailable/error condition, that invocation is retried with the next fallback. Structured findings and schema/output validation failures do not trigger fallback.
 
 ### Optional ACP target
 
@@ -169,6 +179,8 @@ The default binary names are:
 | `acp:<target>` | `acpx` |
 
 When the daemon is running through a managed service, that `PATH` comes from your login shell environment on macOS and Linux plus common user, Homebrew, and system binary directories. If login-shell resolution fails, the daemon logs a warning and uses a degraded fallback `PATH` that may omit version-manager shim directories. On Windows it reuses the current process environment instead of reloading a login shell. If native agent discovery still does not resolve the binary you expect, check `~/.no-mistakes/logs/daemon.log` and use an explicit `agent_path_override`.
+
+For an ordered fallback list, no-mistakes checks each configured entry at run startup and drops unavailable entries. If none are available, the run fails before the pipeline starts.
 
 Override paths in global config:
 

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -10,7 +10,7 @@ with sensible defaults for everything else.
 The goal is not to make you configure a mini CI system. The default path should
 work. Config exists for the parts that genuinely vary by machine or repo:
 
-- which agent you prefer
+- which agent or ordered fallback list you prefer
 - which test or lint commands are the canonical ones for this repo
 - where test evidence artifacts should be stored
 - how aggressive the auto-fix loop should be
@@ -38,7 +38,7 @@ local.
 If you are not sure where to start, configure these in this order:
 
 1. Set `commands.test` and `commands.lint` in repo config so the gate runs the exact commands your repo expects.
-2. Override `agent` per repo only when one codebase clearly works better with a different tool.
+2. Override `agent` per repo only when one codebase clearly works better with a different tool or fallback order.
 3. Tune `auto_fix` after you have seen how much automation you actually want.
 
 Everything else can usually wait.
@@ -50,6 +50,7 @@ Everything else can usually wait.
 
 # Default agent for all repos and setup-wizard suggestions.
 # "auto" picks the first available native agent on PATH.
+# You can also use an ordered fallback list, for example: [codex, claude].
 agent: auto  # auto | claude | codex | rovodev | opencode | pi | copilot | acp:<target>
 
 # Optional acpx path and target command overrides for agent: acp:<target>.
@@ -125,7 +126,7 @@ Azure DevOps uses the `az` CLI with the `azure-devops` extension; for non-intera
 ```yaml
 # .no-mistakes.yaml (in repo root)
 
-# Override the agent for this repo and its setup-wizard suggestions.
+# Override the agent, or ordered fallback list, for this repo and its setup-wizard suggestions.
 agent: codex
 
 # Explicit commands for test/lint/format steps.
@@ -160,7 +161,7 @@ See [Repo Config Reference](/no-mistakes/reference/repo-config/) for the full fi
 
 ## Precedence
 
-- Repo `agent` overrides global `agent`.
+- Repo `agent` overrides global `agent`, including the full ordered fallback list when one is configured.
 - Global `agent: auto` resolves by checking `claude`, `codex`, `opencode`, `acli` for `rovodev`, `pi`, then `copilot` on `PATH`.
 - ACP agents are opt-in with `agent: acp:<target>` and are not considered by `agent: auto`.
 - `agent_path_override`, `agent_args_override`, `acpx_path`, and `acp_registry_overrides` are global-only fields.

--- a/docs/src/content/docs/guides/setup-wizard.md
+++ b/docs/src/content/docs/guides/setup-wizard.md
@@ -94,7 +94,7 @@ effects, so exiting should not be too easy once those side effects exist.
 
 ## Agent suggestions
 
-When you leave branch name or commit subject blank, the wizard invokes the configured agent (global or per-repo `agent` setting) to produce a suggestion. The agent sees the local diff and returns:
+When you leave branch name or commit subject blank, the wizard invokes the configured agent (global or per-repo `agent` setting, including fallback lists) to produce a suggestion. The agent sees the local diff and returns:
 
 - A kebab-case branch name prefixed with a type (`feat/`, `fix/`, `chore/`, etc.)
 - A conventional-commit subject line, using `feat` or `fix` for user-facing product impact so release automation can pick it up
@@ -107,7 +107,7 @@ The wizard requires:
 
 - The gate to be initialized (`no-mistakes init` has run).
 - A clean enough state to commit and push.
-- A configured native agent binary available on `PATH` (or via `agent_path_override`), or `acpx` available on `PATH` (or via `acpx_path`) for `agent: acp:<target>`, only when the wizard needs to suggest a branch name or commit subject.
+- A configured native agent binary available on `PATH` (or via `agent_path_override`), or `acpx` available on `PATH` (or via `acpx_path`) for `agent: acp:<target>`, only when the wizard needs to suggest a branch name or commit subject. For an ordered fallback list, at least one configured entry must be available.
   If you already have a branch and clean working tree, or you enter those values yourself in the interactive flow, the wizard can continue without agent suggestions.
 
 If any of those are missing, the wizard reports the problem and exits.

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -61,13 +61,21 @@ Default agent for all repos and setup-wizard suggestions. Can be overridden per-
 
 | | |
 |---|---|
-| Type | `string` |
+| Type | `string` or `string[]` |
 | Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `acp:<target>` |
 | Default | `auto` |
 
 `auto` resolves to the first supported native agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, `pi`, then `copilot`.
 `acp:<target>` uses the user-installed `acpx` binary to run an ACP target, for example `acp:gemini`.
 ACP agents are opt-in and are not considered by `agent: auto`.
+
+You can also set an ordered fallback list:
+
+```yaml
+agent: [codex, claude]
+```
+
+The first available entry is used as the primary agent. If a pipeline invocation fails because that agent process cannot start or exits with an error, no-mistakes retries that invocation with the next available fallback. Structured findings and schema/output validation problems do not trigger fallback.
 
 ### acpx_path
 

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -75,7 +75,7 @@ You can also set an ordered fallback list:
 agent: [codex, claude]
 ```
 
-The first available entry is used as the primary agent. If a pipeline invocation fails because that agent process cannot start or exits with an error, no-mistakes retries that invocation with the next available fallback. Structured findings and schema/output validation problems do not trigger fallback.
+The list is filtered to entries available to the daemon at run startup, and the first available entry becomes the primary agent. If a pipeline invocation fails because that agent process cannot start or exits with an error, no-mistakes retries that invocation with the next available fallback. Structured findings and schema/output validation problems do not trigger fallback.
 
 ### acpx_path
 

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -67,7 +67,7 @@ You can also set an ordered fallback list:
 agent: [codex, claude]
 ```
 
-The first available entry is used as the primary agent. If a pipeline invocation fails because that agent process cannot start or exits with an error, no-mistakes retries that invocation with the next available fallback. Structured findings and schema/output validation problems do not trigger fallback. This per-repo `agent` value, including every fallback entry, is still read from the trusted default-branch `.no-mistakes.yaml` unless `allow_repo_commands` is enabled there.
+The list is filtered to entries available to the daemon at run startup, and the first available entry becomes the primary agent. If a pipeline invocation fails because that agent process cannot start or exits with an error, no-mistakes retries that invocation with the next available fallback. Structured findings and schema/output validation problems do not trigger fallback. This per-repo `agent` value, including every fallback entry, is still read from the trusted default-branch `.no-mistakes.yaml` unless `allow_repo_commands` is enabled there.
 
 ### allow_repo_commands
 

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -6,7 +6,7 @@ description: All fields for .no-mistakes.yaml.
 Per-repo configuration lives in `.no-mistakes.yaml` at the root of your repository.
 
 :::caution[Security: code-executing fields are read from the default branch]
-`commands.*` execute arbitrary shell on the daemon host via `sh -c` / `cmd.exe /c`, and `agent` selects which process launches there (including `acp:` targets) with the maintainer's credentials. To prevent a supply-chain attack where a contributor lands a hostile value on a gated branch, the daemon always reads **`commands` and `agent` from your default branch** (e.g. `origin/main`), never from the pushed SHA, and reads them at the exact commit a fresh fetch resolved (so a stale `origin/<default>` ref cannot serve a value the live default branch removed). If the fetch fails, both fields are forced empty — the run proceeds on built-in defaults rather than falling back to a potentially stale or hostile copy. Commit the `commands` and `agent` you want the gate to run to your default branch. Non-executing fields (`ignore_patterns`, `auto_fix`, `intent`, `test`) are still read from the pushed branch.
+`commands.*` execute arbitrary shell on the daemon host via `sh -c` / `cmd.exe /c`, and `agent` selects which process launches there (including ordered fallback lists and `acp:` targets) with the maintainer's credentials. To prevent a supply-chain attack where a contributor lands a hostile value on a gated branch, the daemon always reads **`commands` and `agent` from your default branch** (e.g. `origin/main`), never from the pushed SHA, and reads them at the exact commit a fresh fetch resolved (so a stale `origin/<default>` ref cannot serve a value the live default branch removed). If the fetch fails, both fields are forced empty — the run proceeds on built-in defaults rather than falling back to a potentially stale or hostile copy. Commit the `commands` and `agent` you want the gate to run to your default branch. Non-executing fields (`ignore_patterns`, `auto_fix`, `intent`, `test`) are still read from the pushed branch.
 
 If you genuinely want per-branch `commands` and `agent` (for example, a single-developer repo where you trust your own feature branches), opt in with [`allow_repo_commands: true`](#allow_repo_commands) in this same file on your default branch. This re-enables the previous behavior with eyes open. The switch is read only from the trusted default-branch copy, so a contributor cannot self-enable it from a pushed branch.
 :::
@@ -53,13 +53,21 @@ Override the default agent for this repo and its setup-wizard suggestions.
 
 | | |
 |---|---|
-| Type | `string` |
+| Type | `string` or `string[]` |
 | Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `acp:<target>` |
 | Default | Inherits from global config |
 
 `auto` resolves to the first supported native agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, `pi`, then `copilot`.
 `acp:<target>` uses the user-installed `acpx` binary configured in global config.
 ACP agents are opt-in and are not considered by `agent: auto`.
+
+You can also set an ordered fallback list:
+
+```yaml
+agent: [codex, claude]
+```
+
+The first available entry is used as the primary agent. If a pipeline invocation fails because that agent process cannot start or exits with an error, no-mistakes retries that invocation with the next available fallback. Structured findings and schema/output validation problems do not trigger fallback. This per-repo `agent` value, including every fallback entry, is still read from the trusted default-branch `.no-mistakes.yaml` unless `allow_repo_commands` is enabled there.
 
 ### allow_repo_commands
 

--- a/docs/src/content/docs/start-here/introduction.md
+++ b/docs/src/content/docs/start-here/introduction.md
@@ -70,7 +70,7 @@ When a branch passes the gate, it means:
 ## What you get
 
 - A fixed, opinionated pipeline: `intent → rebase → review → test → document → lint → push → pr → ci`. Order is not configurable; what each step runs is.
-- Choice of agent: `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, or `acp:<target>` via `acpx`, with per-repo override.
+- Choice of agent: `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, or `acp:<target>` via `acpx`, with per-repo override and ordered fallbacks.
 - A TUI to watch, approve, fix, skip, or abort any step.
 - A `/no-mistakes` agent skill so a coding agent can do a task and gate it, or gate existing committed work, backed by a non-interactive `no-mistakes axi` interface.
 - A setup wizard when you run bare `no-mistakes` with no active run on the current branch - it walks you through creating a branch, committing, and pushing through the gate, then attaches if the daemon registers the new run.

--- a/internal/agent/fallback.go
+++ b/internal/agent/fallback.go
@@ -1,0 +1,98 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type fallbackAgent struct {
+	agents []Agent
+}
+
+// NewFallback returns an Agent that tries each agent in order when an
+// invocation fails because the current agent process is unavailable.
+func NewFallback(agents []Agent) Agent {
+	switch len(agents) {
+	case 0:
+		return nil
+	case 1:
+		return agents[0]
+	default:
+		copied := make([]Agent, len(agents))
+		copy(copied, agents)
+		return &fallbackAgent{agents: copied}
+	}
+}
+
+func (a *fallbackAgent) Name() string {
+	if len(a.agents) == 0 {
+		return ""
+	}
+	return a.agents[0].Name()
+}
+
+func (a *fallbackAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
+	var lastErr error
+	for i, current := range a.agents {
+		result, err := current.Run(ctx, opts)
+		if err == nil {
+			return result, nil
+		}
+		lastErr = err
+		if i == len(a.agents)-1 || !isAgentUnavailableError(err) {
+			return nil, err
+		}
+		next := a.agents[i+1]
+		if opts.OnChunk != nil {
+			opts.OnChunk(fmt.Sprintf("\nagent %s failed (%s); falling back to %s\n", current.Name(), fallbackReason(err), next.Name()))
+		}
+	}
+	return nil, lastErr
+}
+
+func (a *fallbackAgent) Close() error {
+	var errs []string
+	for _, ag := range a.agents {
+		if err := ag.Close(); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", ag.Name(), err))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("close fallback agents: %s", strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+func isAgentUnavailableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	unavailable := []string{
+		" start:",
+		"start server ",
+		" server: start server ",
+		" exited:",
+		" reported exit code ",
+	}
+	for _, needle := range unavailable {
+		if strings.Contains(msg, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func fallbackReason(err error) string {
+	if err == nil {
+		return "unknown error"
+	}
+	text := strings.Join(strings.Fields(err.Error()), " ")
+	const max = 160
+	if len([]rune(text)) <= max {
+		return text
+	}
+	runes := []rune(text)
+	return string(runes[:max]) + "..."
+}

--- a/internal/agent/fallback_test.go
+++ b/internal/agent/fallback_test.go
@@ -1,0 +1,106 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type fallbackTestAgent struct {
+	name  string
+	run   func() (*Result, error)
+	calls int
+}
+
+func (a *fallbackTestAgent) Name() string { return a.name }
+
+func (a *fallbackTestAgent) Run(context.Context, RunOpts) (*Result, error) {
+	a.calls++
+	return a.run()
+}
+
+func (a *fallbackTestAgent) Close() error { return nil }
+
+func TestFallbackAgentFallsBackOnLaunchFailure(t *testing.T) {
+	first := &fallbackTestAgent{
+		name: "codex",
+		run: func() (*Result, error) {
+			return nil, errors.New(`codex start: exec: "codex": executable file not found`)
+		},
+	}
+	second := &fallbackTestAgent{
+		name: "claude",
+		run: func() (*Result, error) {
+			return &Result{Text: "ok"}, nil
+		},
+	}
+	var chunks []string
+
+	result, err := NewFallback([]Agent{first, second}).Run(context.Background(), RunOpts{
+		OnChunk: func(text string) { chunks = append(chunks, text) },
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result == nil || result.Text != "ok" {
+		t.Fatalf("Run() result = %+v, want text ok", result)
+	}
+	if first.calls != 1 || second.calls != 1 {
+		t.Fatalf("calls = first %d second %d, want 1/1", first.calls, second.calls)
+	}
+	joined := strings.Join(chunks, "\n")
+	if !strings.Contains(joined, "agent codex failed") || !strings.Contains(joined, "falling back to claude") {
+		t.Fatalf("fallback log missing, got %q", joined)
+	}
+}
+
+func TestFallbackAgentDoesNotFallBackOnFindingsResult(t *testing.T) {
+	first := &fallbackTestAgent{
+		name: "codex",
+		run: func() (*Result, error) {
+			return &Result{Output: []byte(`{"findings":[{"severity":"warning","description":"issue"}],"summary":"1 issue"}`)}, nil
+		},
+	}
+	second := &fallbackTestAgent{
+		name: "claude",
+		run: func() (*Result, error) {
+			return &Result{Text: "should not run"}, nil
+		},
+	}
+
+	result, err := NewFallback([]Agent{first, second}).Run(context.Background(), RunOpts{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if string(result.Output) == "" {
+		t.Fatalf("Run() result = %+v, want findings output", result)
+	}
+	if first.calls != 1 || second.calls != 0 {
+		t.Fatalf("calls = first %d second %d, want 1/0", first.calls, second.calls)
+	}
+}
+
+func TestFallbackAgentDoesNotFallBackOnStructuredOutputError(t *testing.T) {
+	parseErr := errors.New(`codex output parse: invalid JSON (output snippet: "not json")`)
+	first := &fallbackTestAgent{
+		name: "codex",
+		run: func() (*Result, error) {
+			return nil, parseErr
+		},
+	}
+	second := &fallbackTestAgent{
+		name: "claude",
+		run: func() (*Result, error) {
+			return &Result{Text: "should not run"}, nil
+		},
+	}
+
+	_, err := NewFallback([]Agent{first, second}).Run(context.Background(), RunOpts{})
+	if !errors.Is(err, parseErr) {
+		t.Fatalf("Run() error = %v, want %v", err, parseErr)
+	}
+	if first.calls != 1 || second.calls != 0 {
+		t.Fatalf("calls = first %d second %d, want 1/0", first.calls, second.calls)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -250,7 +250,8 @@ func copyAgents(names []types.AgentName) []types.AgentName {
 // defaultConfigYAML is the template written when no global config file exists.
 const defaultConfigYAML = `# no-mistakes global configuration
 
-# Agent to use for code generation
+# Agent to use for code generation. This may also be an ordered fallback list,
+# for example: agent: [codex, claude]
 # Options: auto, claude, codex, rovodev, opencode, pi, copilot, acp:<target>
 # "auto" detects the first available native agent on your system
 # Use acp:<target> to run an optional user-installed acpx target, for example acp:gemini
@@ -376,9 +377,10 @@ var probeRovoDevSupport = func(ctx context.Context, bin string) (bool, error) {
 	return false, fmt.Errorf("probe rovodev support via %q: %w", bin, err)
 }
 
-// ResolveAgent resolves AgentAuto to a concrete agent by probing which binaries
-// are available on the system. If agent is already set to a specific value, this
-// is a no-op. The lookPath function should behave like exec.LookPath.
+// ResolveAgent resolves configured agent names to available agents. A single
+// explicit agent is preserved; auto is probed into the first available native
+// agent; an ordered list is filtered to available agents and kept as fallbacks.
+// The lookPath function should behave like exec.LookPath.
 func (c *Config) ResolveAgent(ctx context.Context, lookPath func(string) (string, error)) error {
 	candidates := c.configuredAgents()
 	if len(candidates) <= 1 {
@@ -760,17 +762,17 @@ func parseRepoConfig(data []byte) (*RepoConfig, error) {
 // given a pushed-branch copy and the trusted default-branch copy.
 //
 // The code-executing selection fields — Commands (run verbatim via sh -c on
-// the daemon host) and Agent (selects which process launches with the
-// maintainer's credentials, including acp: targets) — are taken only from
-// the trusted copy when it is present, so a contributor's pushed branch
-// cannot inject shell or pick an agent. When allowRepoCommands is true the
-// maintainer has explicitly opted in (via allow_repo_commands on the
+// the daemon host) and Agent/Agents (select which processes launch with the
+// maintainer's credentials, including fallback lists and acp: targets) — are
+// taken only from the trusted copy when it is present, so a contributor's
+// pushed branch cannot inject shell or pick an agent. When allowRepoCommands is
+// true the maintainer has explicitly opted in (via allow_repo_commands on the
 // TRUSTED default-branch copy) to honoring the pushed-branch copy wholesale.
 // When there is no trusted copy and the maintainer has not opted in, both
-// fields are forced empty (Agent "" inherits the global agent; Commands{}
-// yields built-in defaults) rather than falling back to the pushed branch —
-// this blocks the supply-chain vector for repos that ship .no-mistakes.yaml
-// only on feature branches.
+// fields are forced empty (Agent "" and nil Agents inherit the global agent;
+// Commands{} yields built-in defaults) rather than falling back to the pushed
+// branch — this blocks the supply-chain vector for repos that ship
+// .no-mistakes.yaml only on feature branches.
 //
 // Non-executing fields (ignore patterns, auto-fix, intent, test) are always
 // taken from the pushed copy, matching prior behavior, since they cannot
@@ -921,8 +923,9 @@ func (c *Config) AutoFixLimit(step types.StepName) int {
 	}
 }
 
-// Merge combines global and per-repo config. Per-repo agent overrides global
-// when non-empty. Commands and ignore patterns come from repo config only.
+// Merge combines global and per-repo config. Per-repo agent values, including
+// ordered fallback lists, override global agent values when non-empty. Commands
+// and ignore patterns come from repo config only.
 func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 	af := autoFixDefaults()
 	applyAutoFixOverrides(&af, &global.AutoFix)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,7 @@ const (
 // GlobalConfig represents ~/.no-mistakes/config.yaml.
 type GlobalConfig struct {
 	Agent                types.AgentName     `yaml:"agent"`
+	Agents               []types.AgentName   `yaml:"-"`
 	ACPXPath             string              `yaml:"acpx_path"`
 	ACPRegistryOverrides map[string]string   `yaml:"acp_registry_overrides"`
 	AgentPathOverride    map[string]string   `yaml:"agent_path_override"`
@@ -53,7 +54,7 @@ type GlobalConfig struct {
 
 // globalConfigRaw is the on-disk YAML representation with duration as string.
 type globalConfigRaw struct {
-	Agent                types.AgentName     `yaml:"agent"`
+	Agent                agentList           `yaml:"agent"`
 	ACPXPath             string              `yaml:"acpx_path"`
 	ACPRegistryOverrides map[string]string   `yaml:"acp_registry_overrides"`
 	AgentPathOverride    map[string]string   `yaml:"agent_path_override"`
@@ -68,9 +69,10 @@ type globalConfigRaw struct {
 
 // RepoConfig represents .no-mistakes.yaml in a repo root.
 type RepoConfig struct {
-	Agent          types.AgentName `yaml:"agent"`
-	Commands       Commands        `yaml:"commands"`
-	IgnorePatterns []string        `yaml:"ignore_patterns"`
+	Agent          types.AgentName   `yaml:"agent"`
+	Agents         []types.AgentName `yaml:"-"`
+	Commands       Commands          `yaml:"commands"`
+	IgnorePatterns []string          `yaml:"ignore_patterns"`
 	// AllowRepoCommands opts in to honoring the code-executing selection
 	// fields (commands.{test,lint,format} and agent) from a contributor's
 	// pushed branch instead of the trusted default-branch copy. It is read
@@ -81,6 +83,31 @@ type RepoConfig struct {
 	AutoFix           AutoFixRaw `yaml:"auto_fix"`
 	Intent            IntentRaw  `yaml:"intent"`
 	Test              TestRaw    `yaml:"test"`
+}
+
+func (c *RepoConfig) UnmarshalYAML(value *yaml.Node) error {
+	type repoConfigRaw struct {
+		Agent             agentList  `yaml:"agent"`
+		Commands          Commands   `yaml:"commands"`
+		IgnorePatterns    []string   `yaml:"ignore_patterns"`
+		AllowRepoCommands bool       `yaml:"allow_repo_commands"`
+		AutoFix           AutoFixRaw `yaml:"auto_fix"`
+		Intent            IntentRaw  `yaml:"intent"`
+		Test              TestRaw    `yaml:"test"`
+	}
+	var raw repoConfigRaw
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+	c.Agent = firstAgent(raw.Agent)
+	c.Agents = copyAgents(raw.Agent)
+	c.Commands = raw.Commands
+	c.IgnorePatterns = raw.IgnorePatterns
+	c.AllowRepoCommands = raw.AllowRepoCommands
+	c.AutoFix = raw.AutoFix
+	c.Intent = raw.Intent
+	c.Test = raw.Test
+	return nil
 }
 
 // Commands holds optional per-repo command overrides.
@@ -116,6 +143,7 @@ type AutoFix struct {
 // Config is the merged result of global + per-repo configuration.
 type Config struct {
 	Agent                types.AgentName
+	Agents               []types.AgentName
 	ACPXPath             string
 	ACPRegistryOverrides map[string]string
 	AgentPathOverride    map[string]string
@@ -170,6 +198,53 @@ type Intent struct {
 	Threshold       float64
 	SlackDays       int
 	DisabledReaders map[string]bool
+}
+
+type agentList []types.AgentName
+
+func (a *agentList) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Kind {
+	case yaml.ScalarNode:
+		name := strings.TrimSpace(value.Value)
+		if name == "" {
+			*a = nil
+			return nil
+		}
+		*a = []types.AgentName{types.AgentName(name)}
+		return nil
+	case yaml.SequenceNode:
+		names := make([]types.AgentName, 0, len(value.Content))
+		for i, item := range value.Content {
+			if item.Kind != yaml.ScalarNode {
+				return fmt.Errorf("agent[%d] must be a string", i)
+			}
+			name := strings.TrimSpace(item.Value)
+			if name == "" {
+				return fmt.Errorf("agent[%d] must not be empty", i)
+			}
+			names = append(names, types.AgentName(name))
+		}
+		*a = names
+		return nil
+	default:
+		return fmt.Errorf("agent must be a string or a list of strings")
+	}
+}
+
+func firstAgent(names []types.AgentName) types.AgentName {
+	if len(names) == 0 {
+		return ""
+	}
+	return names[0]
+}
+
+func copyAgents(names []types.AgentName) []types.AgentName {
+	if len(names) == 0 {
+		return nil
+	}
+	out := make([]types.AgentName, len(names))
+	copy(out, names)
+	return out
 }
 
 // defaultConfigYAML is the template written when no global config file exists.
@@ -305,9 +380,42 @@ var probeRovoDevSupport = func(ctx context.Context, bin string) (bool, error) {
 // are available on the system. If agent is already set to a specific value, this
 // is a no-op. The lookPath function should behave like exec.LookPath.
 func (c *Config) ResolveAgent(ctx context.Context, lookPath func(string) (string, error)) error {
-	if c.Agent != types.AgentAuto {
+	candidates := c.configuredAgents()
+	if len(candidates) <= 1 {
+		c.Agent = firstAgent(candidates)
+		c.Agents = copyAgents(candidates)
+		if c.Agent != types.AgentAuto {
+			return nil
+		}
+		name, err := c.resolveAutoAgent(ctx, lookPath)
+		if err != nil {
+			return err
+		}
+		c.Agent = name
+		c.Agents = []types.AgentName{name}
 		return nil
 	}
+
+	resolved, err := c.resolveAgentList(ctx, candidates, lookPath)
+	if err != nil {
+		return err
+	}
+	c.Agent = resolved[0]
+	c.Agents = resolved
+	return nil
+}
+
+func (c *Config) configuredAgents() []types.AgentName {
+	if len(c.Agents) > 0 {
+		return copyAgents(c.Agents)
+	}
+	if c.Agent != "" {
+		return []types.AgentName{c.Agent}
+	}
+	return []types.AgentName{types.AgentAuto}
+}
+
+func (c *Config) resolveAutoAgent(ctx context.Context, lookPath func(string) (string, error)) (types.AgentName, error) {
 	probed := make([]string, 0, len(agentProbeOrder))
 	for _, name := range agentProbeOrder {
 		bin := string(name)
@@ -325,49 +433,111 @@ func (c *Config) ResolveAgent(ctx context.Context, lookPath func(string) (string
 			if name == types.AgentRovoDev {
 				ok, probeErr := probeRovoDevSupport(ctx, resolvedBin)
 				if probeErr != nil {
-					return probeErr
+					return "", probeErr
 				}
 				if !ok {
 					continue
 				}
 			}
-			c.Agent = name
-			return nil
+			return name, nil
 		} else if !errors.Is(err, exec.ErrNotFound) && !errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("resolve %s agent from %q: %w", name, bin, err)
+			return "", fmt.Errorf("resolve %s agent from %q: %w", name, bin, err)
 		}
 	}
-	return fmt.Errorf("no supported agent found in PATH (looked for: %s); install one or set 'agent' in ~/.no-mistakes/config.yaml", strings.Join(probed, ", "))
+	return "", fmt.Errorf("no supported agent found in PATH (looked for: %s); install one or set 'agent' in ~/.no-mistakes/config.yaml", strings.Join(probed, ", "))
+}
+
+func (c *Config) resolveAgentList(ctx context.Context, candidates []types.AgentName, lookPath func(string) (string, error)) ([]types.AgentName, error) {
+	resolved := make([]types.AgentName, 0, len(candidates))
+	seen := map[types.AgentName]bool{}
+	probed := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		name, ok, probe, err := c.resolveConfiguredAgent(ctx, candidate, lookPath)
+		if probe != "" {
+			probed = append(probed, probe)
+		}
+		if err != nil {
+			return nil, err
+		}
+		if !ok || seen[name] {
+			continue
+		}
+		seen[name] = true
+		resolved = append(resolved, name)
+	}
+	if len(resolved) == 0 {
+		return nil, fmt.Errorf("no configured agent found in PATH (looked for: %s)", strings.Join(probed, ", "))
+	}
+	return resolved, nil
+}
+
+func (c *Config) resolveConfiguredAgent(ctx context.Context, name types.AgentName, lookPath func(string) (string, error)) (types.AgentName, bool, string, error) {
+	if name == types.AgentAuto {
+		resolved, err := c.resolveAutoAgent(ctx, lookPath)
+		if err != nil && strings.HasPrefix(err.Error(), "no supported agent found in PATH") {
+			return "", false, "auto", nil
+		}
+		return resolved, err == nil, "auto", err
+	}
+	if _, ok := defaultBinary[name]; !ok && !isACPAgent(name) {
+		return "", false, string(name), fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, copilot, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
+	}
+	bin := c.AgentPathFor(name)
+	resolvedBin, err := lookPath(bin)
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) || errors.Is(err, fs.ErrNotExist) {
+			return "", false, bin, nil
+		}
+		return "", false, bin, fmt.Errorf("resolve %s agent from %q: %w", name, bin, err)
+	}
+	if name == types.AgentRovoDev {
+		ok, probeErr := probeRovoDevSupport(ctx, resolvedBin)
+		if probeErr != nil {
+			return "", false, bin, probeErr
+		}
+		if !ok {
+			return "", false, bin, nil
+		}
+	}
+	return name, true, bin, nil
 }
 
 // AgentPath returns the binary path for the configured agent.
 // ACP agents use acpx_path if set, otherwise acpx.
 // Native agents use agent_path_override if set, otherwise the default binary name.
 func (c *Config) AgentPath() string {
-	if isACPAgent(c.Agent) {
+	return c.AgentPathFor(c.Agent)
+}
+
+func (c *Config) AgentPathFor(name types.AgentName) string {
+	if isACPAgent(name) {
 		if c.ACPXPath != "" {
 			return c.ACPXPath
 		}
 		return "acpx"
 	}
 	if c.AgentPathOverride != nil {
-		if p, ok := c.AgentPathOverride[string(c.Agent)]; ok {
+		if p, ok := c.AgentPathOverride[string(name)]; ok {
 			return p
 		}
 	}
-	if b, ok := defaultBinary[c.Agent]; ok {
+	if b, ok := defaultBinary[name]; ok {
 		return b
 	}
-	return string(c.Agent)
+	return string(name)
 }
 
 // AgentArgs returns extra CLI args for the configured native agent, as declared in
 // agent_args_override. Returns nil when no override is set for this agent.
 func (c *Config) AgentArgs() []string {
+	return c.AgentArgsFor(c.Agent)
+}
+
+func (c *Config) AgentArgsFor(name types.AgentName) []string {
 	if c.AgentArgsOverride == nil {
 		return nil
 	}
-	return c.AgentArgsOverride[string(c.Agent)]
+	return c.AgentArgsOverride[string(name)]
 }
 
 // agentArgsOverrideAgents lists native agent names accepted as keys in
@@ -467,6 +637,7 @@ func EnsureDefaultGlobalConfig(path string) {
 func LoadGlobal(path string) (*GlobalConfig, error) {
 	cfg := &GlobalConfig{
 		Agent:     types.AgentAuto,
+		Agents:    []types.AgentName{types.AgentAuto},
 		CITimeout: DefaultCITimeout,
 		LogLevel:  "info",
 	}
@@ -486,8 +657,9 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 		return nil, fmt.Errorf("parse global config: %w", err)
 	}
 
-	if raw.Agent != "" {
-		cfg.Agent = raw.Agent
+	if len(raw.Agent) > 0 {
+		cfg.Agents = copyAgents(raw.Agent)
+		cfg.Agent = firstAgent(cfg.Agents)
 	}
 	if raw.ACPXPath != "" {
 		cfg.ACPXPath = raw.ACPXPath
@@ -614,9 +786,11 @@ func EffectiveRepoConfig(pushed, trusted *RepoConfig, allowRepoCommands bool) *R
 	if trusted != nil {
 		effective.Commands = trusted.Commands
 		effective.Agent = trusted.Agent
+		effective.Agents = copyAgents(trusted.Agents)
 	} else {
 		effective.Commands = Commands{}
 		effective.Agent = ""
+		effective.Agents = nil
 	}
 	return &effective
 }
@@ -764,6 +938,7 @@ func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 
 	cfg := &Config{
 		Agent:                global.Agent,
+		Agents:               copyAgents(global.Agents),
 		ACPXPath:             global.ACPXPath,
 		ACPRegistryOverrides: global.ACPRegistryOverrides,
 		AgentPathOverride:    global.AgentPathOverride,
@@ -779,6 +954,10 @@ func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 
 	if repo.Agent != "" {
 		cfg.Agent = repo.Agent
+		cfg.Agents = copyAgents(repo.Agents)
+		if len(cfg.Agents) == 0 {
+			cfg.Agents = []types.AgentName{repo.Agent}
+		}
 	}
 
 	return cfg

--- a/internal/config/config_agent_test.go
+++ b/internal/config/config_agent_test.go
@@ -156,6 +156,54 @@ func TestResolveAgent_AutoPicksFirstAvailable(t *testing.T) {
 	}
 }
 
+func TestResolveAgent_ListPicksFirstAvailableAndKeepsFallbacks(t *testing.T) {
+	cfg := &Config{Agents: []types.AgentName{types.AgentClaude, types.AgentCodex, types.AgentPi}}
+
+	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
+		switch bin {
+		case "codex", "pi":
+			return "/usr/bin/" + bin, nil
+		default:
+			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Agent != types.AgentCodex {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentCodex)
+	}
+	want := []types.AgentName{types.AgentCodex, types.AgentPi}
+	if len(cfg.Agents) != len(want) {
+		t.Fatalf("agents = %v, want %v", cfg.Agents, want)
+	}
+	for i := range want {
+		if cfg.Agents[i] != want[i] {
+			t.Fatalf("agents = %v, want %v", cfg.Agents, want)
+		}
+	}
+}
+
+func TestResolveAgent_ListSkipsUnavailableAuto(t *testing.T) {
+	cfg := &Config{Agents: []types.AgentName{types.AgentAuto, "acp:gemini"}}
+
+	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
+		if bin == "acpx" {
+			return "/usr/bin/acpx", nil
+		}
+		return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Agent != "acp:gemini" {
+		t.Errorf("agent = %q, want acp:gemini", cfg.Agent)
+	}
+	if len(cfg.Agents) != 1 || cfg.Agents[0] != "acp:gemini" {
+		t.Fatalf("agents = %v, want [acp:gemini]", cfg.Agents)
+	}
+}
+
 func TestResolveAgent_AutoPicksClaude(t *testing.T) {
 	cfg := &Config{Agent: types.AgentAuto}
 	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {

--- a/internal/config/config_global_test.go
+++ b/internal/config/config_global_test.go
@@ -177,6 +177,54 @@ log_level: "debug"
 	}
 }
 
+func TestLoadGlobal_AgentAcceptsList(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	data := `agent: [codex, claude]
+`
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadGlobal(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Agent != types.AgentCodex {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentCodex)
+	}
+	want := []types.AgentName{types.AgentCodex, types.AgentClaude}
+	if len(cfg.Agents) != len(want) {
+		t.Fatalf("agents = %v, want %v", cfg.Agents, want)
+	}
+	for i := range want {
+		if cfg.Agents[i] != want[i] {
+			t.Fatalf("agents = %v, want %v", cfg.Agents, want)
+		}
+	}
+}
+
+func TestLoadGlobal_AgentStringPreservesSingleAgent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	data := `agent: codex
+`
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadGlobal(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Agent != types.AgentCodex {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentCodex)
+	}
+	if len(cfg.Agents) != 1 || cfg.Agents[0] != types.AgentCodex {
+		t.Fatalf("agents = %v, want [codex]", cfg.Agents)
+	}
+}
+
 func TestLoadGlobal_PartialOverride(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
@@ -299,7 +347,7 @@ func TestDefaultConfigYAML_MatchesGoDefaults(t *testing.T) {
 		t.Fatalf("defaultConfigYAML is not valid YAML: %v", err)
 	}
 
-	if raw.Agent != types.AgentAuto {
+	if len(raw.Agent) != 1 || raw.Agent[0] != types.AgentAuto {
 		t.Errorf("YAML agent = %q, Go default = %q", raw.Agent, types.AgentAuto)
 	}
 	d, err := time.ParseDuration(raw.CITimeout)

--- a/internal/config/config_repo_test.go
+++ b/internal/config/config_repo_test.go
@@ -74,6 +74,52 @@ ignore_patterns:
 	}
 }
 
+func TestLoadRepo_AgentAcceptsList(t *testing.T) {
+	dir := t.TempDir()
+	data := `agent: [codex, claude]
+`
+	if err := os.WriteFile(filepath.Join(dir, ".no-mistakes.yaml"), []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadRepo(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Agent != types.AgentCodex {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentCodex)
+	}
+	want := []types.AgentName{types.AgentCodex, types.AgentClaude}
+	if len(cfg.Agents) != len(want) {
+		t.Fatalf("agents = %v, want %v", cfg.Agents, want)
+	}
+	for i := range want {
+		if cfg.Agents[i] != want[i] {
+			t.Fatalf("agents = %v, want %v", cfg.Agents, want)
+		}
+	}
+}
+
+func TestLoadRepo_AgentStringPreservesSingleAgent(t *testing.T) {
+	dir := t.TempDir()
+	data := `agent: codex
+`
+	if err := os.WriteFile(filepath.Join(dir, ".no-mistakes.yaml"), []byte(data), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadRepo(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Agent != types.AgentCodex {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentCodex)
+	}
+	if len(cfg.Agents) != 1 || cfg.Agents[0] != types.AgentCodex {
+		t.Fatalf("agents = %v, want [codex]", cfg.Agents)
+	}
+}
+
 func TestLoadRepo_PartialCommands(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".no-mistakes.yaml")

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -63,6 +63,18 @@ func NewRunManager(database *db.DB, p *paths.Paths, stepFactory StepFactory) *Ru
 	}
 }
 
+func agentListsEqual(a, b []types.AgentName) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // Subscribe registers a channel to receive events for a run.
 // Returns the channel and an unsubscribe function.
 // If the run has already completed, the returned channel is immediately closed.
@@ -380,7 +392,7 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 	effectiveRepoCfg := config.EffectiveRepoConfig(repoCfg, trustedRepoCfg, allowRepoCommands)
 	if allowRepoCommands {
 		slog.Warn("allow_repo_commands is enabled on the default branch: honoring commands/agent from pushed branch", "run_id", run.ID, "branch", branch)
-	} else if repoCfg.Commands != effectiveRepoCfg.Commands || repoCfg.Agent != effectiveRepoCfg.Agent {
+	} else if repoCfg.Commands != effectiveRepoCfg.Commands || repoCfg.Agent != effectiveRepoCfg.Agent || !agentListsEqual(repoCfg.Agents, effectiveRepoCfg.Agents) {
 		// Surface the silent override so a maintainer who shipped a commands.*
 		// or agent change on a feature branch understands why it did not run.
 		// This is not an error: it is the secure default in action.
@@ -398,19 +410,26 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 			trackStartFailure("resolve_agent")
 			return "", err
 		}
-		var agErr error
-		ag, agErr = agent.NewWithOptions(cfg.Agent, cfg.AgentPath(), cfg.AgentArgs(), agent.Options{
-			ACPRegistryOverrides: cfg.ACPRegistryOverrides,
-		})
-		if agErr != nil {
-			m.db.UpdateRunError(run.ID, fmt.Sprintf("create agent: %s", agErr))
-			trackStartFailure("create_agent")
-			return "", fmt.Errorf("create agent: %w", agErr)
+		agents := cfg.Agents
+		if len(agents) == 0 {
+			agents = []types.AgentName{cfg.Agent}
 		}
-		// Steer every pipeline agent to keep writes inside the worktree and
-		// avoid mutating system state (e.g. brew/Homebrew touching
-		// /Applications), which triggers macOS App Management prompts.
-		ag = agent.WithSteering(ag)
+		created := make([]agent.Agent, 0, len(agents))
+		for _, name := range agents {
+			next, agErr := agent.NewWithOptions(name, cfg.AgentPathFor(name), cfg.AgentArgsFor(name), agent.Options{
+				ACPRegistryOverrides: cfg.ACPRegistryOverrides,
+			})
+			if agErr != nil {
+				m.db.UpdateRunError(run.ID, fmt.Sprintf("create agent %s: %s", name, agErr))
+				trackStartFailure("create_agent")
+				return "", fmt.Errorf("create agent %s: %w", name, agErr)
+			}
+			// Steer every pipeline agent to keep writes inside the worktree and
+			// avoid mutating system state (e.g. brew/Homebrew touching
+			// /Applications), which triggers macOS App Management prompts.
+			created = append(created, agent.WithSteering(next))
+		}
+		ag = agent.NewFallback(created)
 	}
 
 	execSteps := m.steps()

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -19,6 +19,7 @@ import (
 const (
 	maxEmbeddedArtifactBytes       = 16 * 1024
 	maxEmbeddedArtifactsTotalBytes = 32 * 1024
+	noMistakesPRSignature          = "Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)"
 )
 
 type testingArtifactRenderState struct {
@@ -59,7 +60,9 @@ func BuildPipelineSummary(steps []*db.StepResult, rounds map[string][]*db.StepRo
 	}
 
 	var b strings.Builder
-	b.WriteString("## Pipeline\n\nUpdates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)\n\n")
+	b.WriteString("## Pipeline\n\n")
+	b.WriteString(noMistakesPRSignature)
+	b.WriteString("\n\n")
 	for i, detail := range detailBlocks {
 		if i > 0 {
 			b.WriteString("\n")

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -12,6 +12,18 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
+func TestNoMistakesRequiredWorkflowChecksPipelineSignature(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := os.ReadFile(filepath.Join("..", "..", "..", ".github", "workflows", "no-mistakes-required.yml"))
+	if err != nil {
+		t.Fatalf("read required workflow: %v", err)
+	}
+	if !strings.Contains(string(workflow), "marker='"+noMistakesPRSignature+"'") {
+		t.Fatalf("required workflow does not check the generated PR signature %q", noMistakesPRSignature)
+	}
+}
+
 func TestBuildPipelineSummary_AllClean(t *testing.T) {
 	t.Parallel()
 	steps := []*db.StepResult{


### PR DESCRIPTION
## Intent

Re-raise PR #379 through the no-mistakes gate so the upstream provenance check recognizes it as pipeline-created. The branch implements ordered fallback agent lists for global and repo agent config while preserving existing single-agent, auto, and acp target behavior; this run is to validate and update the existing PR via the configured fork-to-upstream gate path.

## What Changed

- Added support for ordered agent fallback lists in global and repo config, including parsing, defaults, and effective config resolution while preserving existing single-agent, `auto`, and `acp:` target behavior.
- Added fallback agent selection logic and wired daemon startup to resolve the first available configured agent before running pipeline steps.
- Updated docs and setup guidance to describe list-based `agent` configuration and fallback behavior across global and repo config surfaces.

## Risk Assessment

⚠️ Medium: No concrete merge-blocking issues found, but this touches agent selection and fallback execution in the daemon, where string-based error classification has a broader blast radius than ordinary config parsing.

## Testing

Baseline `go test -race ./...` had already passed; I reran focused race tests for config/agent/daemon and completed a disposable gate smoke proving an ordered list falls back from a failing `codex` launch to `claude`, with CLI/log evidence saved. The first smoke attempt hit a setup-only Unix socket path-length failure under the evidence directory, so I retried with short `/tmp` runtime state, copied evidence back, and cleaned up the runtime tree.

<details>
<summary>Evidence: fallback gate smoke transcript</summary>

```text
fallback agent gate smoke
runtime: /tmp/nmfb.BjfTs8
evidence: /var/folders/ql/vwkrq94j4mq90s39twg74z7c0000gn/T/no-mistakes-evidence/01KWMF256GWZ1P84GXKZ4YSN3V/fallback-agent-gate-smoke.txt

[build]

[setup repo]
Initialized empty Git repository in /private/tmp/nmfb.BjfTs8/work/.git/
[main (root-commit) deb594e] initial commit
 2 files changed, 4 insertions(+)
 create mode 100644 .no-mistakes.yaml
 create mode 100644 README.md
Initialized empty Git repository in /private/tmp/nmfb.BjfTs8/upstream.git/
To /tmp/nmfb.BjfTs8/upstream.git
 * [new branch]      main -> main
branch 'main' set up to track 'origin/main'.

[init gate]
_  _ ____    _  _ _ ____ ___ ____ _  _ ____ ____
|\ | |  |    |\/| | [__   |  |__| |_/  |___ [__ 
| \| |__|    |  | | ___]  |  |  | | \_ |___ ___]

  ✓ Gate initialized

    repo  /private/tmp/nmfb.BjfTs8/work
    gate  no-mistakes → /tmp/nmfb.BjfTs8/nmhome/repos/32ee1ebc9358.git
  remote  /tmp/nmfb.BjfTs8/upstream.git
   skill  /no-mistakes installed for agents at user level

  Push through the gate with:
  git push no-mistakes <branch>

[push feature through gate]
Switched to a new branch 'fallback-list-smoke'
[fallback-list-smoke 0df7826] exercise fallback list
 1 file changed, 1 insertion(+)
 create mode 100644 change.txt
remote: _  _ ____    _  _ _ ____ ___ ____ _  _ ____ ____        
remote: |\ | |  |    |\/| | [__   |  |__| |_/  |___ [__        
remote: | \| |__|    |  | | ___]  |  |  | | \_ |___ ___]        
remote: 
remote:   * Pipeline started        
remote: 
remote:   Run no-mistakes to review.        
remote: 
To /tmp/nmfb.BjfTs8/nmhome/repos/32ee1ebc9358.git
 * [new branch]      fallback-list-smoke -> fallback-list-smoke

[poll run]
run:
  id: "01KWMFN3ZQP4C26CBTNCHPYTJ9"
  branch: fallback-list-smoke
  status: completed
  head: 0df78265
  findings: none
  steps[9]{step,status,findings,duration_ms}:
    intent,skipped,0,95
    rebase,completed,0,226
    review,completed,0,610
    test,completed,0,60
    document,completed,0,54
    lint,completed,0,37
    push,completed,0,124
    pr,skipped,0,0
    ci,skipped,0,0
outcome: passed

[review log evidence]
step: review
run: "01KWMFN3ZQP4C26CBTNCHPYTJ9"
lines: 5 total
log[5]{line}:
  reviewing changes...
  ""
  ""
  "agent codex failed (codex exited: exit status 1: simulated codex unavailable); falling back to claude"
  no issues found

[fake agent invocations]
{"time":"2026-07-03T17:15:38.426241Z","agent":"claude","args":["-p","Workspace boundary (important):\n- Confine source, project, user-data, and system file changes to the current working directory, which is a git worktree. Do not intentionally create, modify, move, or delete those files anywhere outside it.\n- Do not modify system state outside the worktree. In particular, do not install or upgrade system packages (for example brew install/upgrade, or other system package managers), do not modify applications under /Applications, and do not change global or user-level tool configuration.\n- This is prompt steering, not true enforcement: treat the worktree boundary as a soft boundary you must follow.\n- The only allowed out-of-worktree writes are test evidence files under /var/folders/ql/vwkrq94j4mq90s39twg74z7c0000gn/T/no-mistakes-evidence when a testing prompt explicitly asks for them.\n- Ephemeral temp/cache writes that are incidental side effects of running the project development toolchain are allowed outside the worktree for tests, linters, formatters, builds, and manual verification commands.\n- You may read files outside the worktree and run read-only commands, but every other intentional write must stay inside the worktree.\n\nReview the code changes and return structured findings with a risk assessment.\n\nContext:\n- branch: fallback-list-smoke\n- base commit: deb594e3f91a369908dc7058720e13f29b77b4c7\n- target commit: 0df78265c7b42af8cedd24d85f260abdc2bcd04b\n- review scope: branch changes between deb594e3f91a369908dc7058720e13f29b77b4c7 and 0df78265c7b42af8cedd24d85f260abdc2bcd04b\n- default branch: main\n- ignore patterns: *.generated.go\n\nTask:\n- Read the relevant history and diff yourself.\n- Focus findings on risks introduced by changed code, but inspect surrounding code, call sites, shared helpers, tests, and invariants when needed to understand root cause.\n- Do NOT run tests during review. The pipeline has a dedicated test step after review.\n- Analyze for bugs, risks, and code simplification opportunities.\n- \"Simplification\" means reducing code complexity through non-functional refactoring (e.g. deduplication, clearer control flow). It does NOT mean removing features, changing product behavior, or stripping intentional user-facing output.\n- Treat security issues, performance regressions, breaking changes, and insufficient error handling as risks.\n- Do a full review pass before returning. Do not stop after the first valid finding. Continue inspecting the rest of the changed code until you have enumerated all material issues you can substantiate.\n\nRules:\n- Anchor every finding to a specific file and one-indexed line number in the changed code when possible.\n- Use severity \"error\" for problems that should absolutely not get merged, \"warning\" for things that are worth addressing but can be done in a follow up, and \"info\" for things that are nice to have.\n- Be concise and actionable. No generic advice like \"add more tests\".\n- Only comment on things that genuinely matter.\n- Do NOT report styling, formatting, linting, compilation, or type-checking issues.\n- If the change is clean, return an empty findings array.\n- For each finding, set the action field to one of:\n  - \"ask-user\": the finding is about functional requirements or product behavior, or otherwise challenges the author's deliberate intent. Even if it seems obviously wrong, we should ask the user for review. Examples: \"this feature seems unnecessary\", \"this hardcoded value should be configurable\", \"this deletion looks wrong\". When in doubt, default to \"ask-user\".\n  - \"auto-fix\": the finding is a non-functional, non user-visible issue (correctness, error handling, security, performance, mechanical code quality) that can be safely fixed without any discussion about the author's intent.\n  - \"no-op\": the finding is informational and does not require any action (e.g. noting a pattern, acknowledging a tradeoff).\n\nRisk assessment (after listing all findings):\n- Set risk_level to \"low\" if the change is well-bounded, mostly cosmetic, or straightforward with little ambiguity.\n- Set risk_level to \"medium\" if the change has room to improve but is safe to merge first with concerns addressed as follow-ups.\n- Set risk_level to \"high\" if the change should not be merged without explicit human approval - it is fundamental, risky, ambiguous, or has strong negative signals.\n- Provide a one-sentence risk_rationale explaining why you chose that risk level.\nExecution context:\n- You are running inside an isolated git worktree at the current working directory.\n- The worktree's `.git` is a pointer file (not a directory) referencing a bare gate repository elsewhere on disk; this is standard git-worktree layout and all normal git commands work as expected.\n- The worktree is checked out to the change being processed; treat it as the project's source of truth for this run and do not search the filesystem for \"the real\" checkout - this is it.\n- Operate only within this working directory. Do not modify or read from the gate's bare repository or any other clone of this project.\n","--verbose","--output-format","stream-json","--json-schema","{\n\t\"type\": \"object\",\n\t\"properties\": {\n\t\t\"findings\": {\n\t\t\t\"type\": \"array\",\n\t\t\t\"items\": {\n\t\t\t\t\"type\": \"object\",\n\t\t\t\t\"properties\": {\n\t\t\t\t\t\"id\": {\"type\": \"string\"},\n\t\t\t\t\t\"severity\": {\"type\": \"string\", \"enum\": [\"error\", \"warning\", \"info\"]},\n\t\t\t\t\t\"file\": {\"type\": \"string\"},\n\t\t\t\t\t\"line\": {\"type\": \"integer\"},\n\t\t\t\t\t\"description\": {\"type\": \"string\"},\n\t\t\t\t\t\"action\": {\"type\": \"string\", \"enum\": [\"no-op\", \"auto-fix\", \"ask-user\"]}\n\t\t\t\t},\n\t\t\t\t\

... [29017 bytes truncated] ...

e every gap you can in this run.\n\n4. Report only what remains\n   - Return a finding only for documentation gaps you could not resolve yourself, or that need a human judgment call (e.g. ambiguous intent or conflicting docs).\n   - Do not report gaps you already fixed.\n   - If you fixed everything and no documentation work remains, return an empty findings array.\n\nRules:\n- Only edit documentation files or doc comments. Do not change executable behavior or tests.\n- The summary must be one concise sentence fragment suitable for a git commit subject.\n- Keep the summary under 10 words.\nExecution context:\n- You are running inside an isolated git worktree at the current working directory.\n- The worktree's `.git` is a pointer file (not a directory) referencing a bare gate repository elsewhere on disk; this is standard git-worktree layout and all normal git commands work as expected.\n- The worktree is checked out to the change being processed; treat it as the project's source of truth for this run and do not search the filesystem for \"the real\" checkout - this is it.\n- Operate only within this working directory. Do not modify or read from the gate's bare repository or any other clone of this project.\n","cwd":"/tmp/nmfb.BjfTs8/nmhome/worktrees/32ee1ebc9358/01KWMFN3ZQP4C26CBTNCHPYTJ9"}
{"time":"2026-07-03T17:15:38.566498Z","agent":"claude","args":["-p","Workspace boundary (important):\n- Confine source, project, user-data, and system file changes to the current working directory, which is a git worktree. Do not intentionally create, modify, move, or delete those files anywhere outside it.\n- Do not modify system state outside the worktree. In particular, do not install or upgrade system packages (for example brew install/upgrade, or other system package managers), do not modify applications under /Applications, and do not change global or user-level tool configuration.\n- This is prompt steering, not true enforcement: treat the worktree boundary as a soft boundary you must follow.\n- The only allowed out-of-worktree writes are test evidence files under /var/folders/ql/vwkrq94j4mq90s39twg74z7c0000gn/T/no-mistakes-evidence when a testing prompt explicitly asks for them.\n- Ephemeral temp/cache writes that are incidental side effects of running the project development toolchain are allowed outside the worktree for tests, linters, formatters, builds, and manual verification commands.\n- You may read files outside the worktree and run read-only commands, but every other intentional write must stay inside the worktree.\n\nDetect the linting and formatting tools for this project, run the relevant checks yourself, apply safe fixes, and verify the result.\n\nContext:\n- branch: fallback-list-smoke\n- base commit: deb594e3f91a369908dc7058720e13f29b77b4c7\n- target commit: 0df78265c7b42af8cedd24d85f260abdc2bcd04b\n\nTask:\n- Discover the configured linters and formatters for this repository.\n- Only lint or format the relevant changed files when possible.\n- Apply safe formatter, linter, and static-analysis fixes yourself.\n- Re-run the relevant checks after fixing.\n- Report only unresolved lint, format, or static-analysis issues as structured findings.\n- If everything is clean or fixed, return an empty findings array.\n\nRules:\n- Do not run tests or broader behavioral validation.\n- Focus on lint, format, and static-analysis issues only.\n- Do not report issues you already fixed.\n- The summary must be one concise sentence fragment suitable for a git commit subject.\n- Keep the summary under 10 words.\nExecution context:\n- You are running inside an isolated git worktree at the current working directory.\n- The worktree's `.git` is a pointer file (not a directory) referencing a bare gate repository elsewhere on disk; this is standard git-worktree layout and all normal git commands work as expected.\n- The worktree is checked out to the change being processed; treat it as the project's source of truth for this run and do not search the filesystem for \"the real\" checkout - this is it.\n- Operate only within this working directory. Do not modify or read from the gate's bare repository or any other clone of this project.\n","--verbose","--output-format","stream-json","--json-schema","{\n\t\"type\": \"object\",\n\t\"properties\": {\n\t\t\"findings\": {\n\t\t\t\"type\": \"array\",\n\t\t\t\"items\": {\n\t\t\t\t\"type\": \"object\",\n\t\t\t\t\"properties\": {\n\t\t\t\t\t\"id\": {\"type\": \"string\"},\n\t\t\t\t\t\"severity\": {\"type\": \"string\", \"enum\": [\"error\", \"warning\", \"info\"]},\n\t\t\t\t\t\"file\": {\"type\": \"string\"},\n\t\t\t\t\t\"line\": {\"type\": \"integer\"},\n\t\t\t\t\t\"description\": {\"type\": \"string\"},\n\t\t\t\t\t\"action\": {\"type\": \"string\", \"enum\": [\"no-op\", \"auto-fix\", \"ask-user\"]}\n\t\t\t\t},\n\t\t\t\t\"required\": [\"severity\", \"description\", \"action\"]\n\t\t\t}\n\t\t},\n\t\t\"summary\": {\"type\": \"string\"},\n\t\t\"tested\": {\n\t\t\t\"type\": \"array\",\n\t\t\t\"items\": {\"type\": \"string\"}\n\t\t},\n\t\t\"testing_summary\": {\n\t\t\t\"type\": \"string\"\n\t\t}\n\t},\n\t\"required\": [\"findings\", \"summary\"]\n}","--dangerously-skip-permissions"],"prompt":"Workspace boundary (important):\n- Confine source, project, user-data, and system file changes to the current working directory, which is a git worktree. Do not intentionally create, modify, move, or delete those files anywhere outside it.\n- Do not modify system state outside the worktree. In particular, do not install or upgrade system packages (for example brew install/upgrade, or other system package managers), do not modify applications under /Applications, and do not change global or user-level tool configuration.\n- This is prompt steering, not true enforcement: treat the worktree boundary as a soft boundary you must follow.\n- The only allowed out-of-worktree writes are test evidence files under /var/folders/ql/vwkrq94j4mq90s39twg74z7c0000gn/T/no-mistakes-evidence when a testing prompt explicitly asks for them.\n- Ephemeral temp/cache writes that are incidental side effects of running the project development toolchain are allowed outside the worktree for tests, linters, formatters, builds, and manual verification commands.\n- You may read files outside the worktree and run read-only commands, but every other intentional write must stay inside the worktree.\n\nDetect the linting and formatting tools for this project, run the relevant checks yourself, apply safe fixes, and verify the result.\n\nContext:\n- branch: fallback-list-smoke\n- base commit: deb594e3f91a369908dc7058720e13f29b77b4c7\n- target commit: 0df78265c7b42af8cedd24d85f260abdc2bcd04b\n\nTask:\n- Discover the configured linters and formatters for this repository.\n- Only lint or format the relevant changed files when possible.\n- Apply safe formatter, linter, and static-analysis fixes yourself.\n- Re-run the relevant checks after fixing.\n- Report only unresolved lint, format, or static-analysis issues as structured findings.\n- If everything is clean or fixed, return an empty findings array.\n\nRules:\n- Do not run tests or broader behavioral validation.\n- Focus on lint, format, and static-analysis issues only.\n- Do not report issues you already fixed.\n- The summary must be one concise sentence fragment suitable for a git commit subject.\n- Keep the summary under 10 words.\nExecution context:\n- You are running inside an isolated git worktree at the current working directory.\n- The worktree's `.git` is a pointer file (not a directory) referencing a bare gate repository elsewhere on disk; this is standard git-worktree layout and all normal git commands work as expected.\n- The worktree is checked out to the change being processed; treat it as the project's source of truth for this run and do not search the filesystem for \"the real\" checkout - this is it.\n- Operate only within this working directory. Do not modify or read from the gate's bare repository or any other clone of this project.\n","cwd":"/tmp/nmfb.BjfTs8/nmhome/worktrees/32ee1ebc9358/01KWMFN3ZQP4C26CBTNCHPYTJ9"}

[assertions]
PASS: codex launch failure fell back to claude and the run completed.
```
</details>
<details>
<summary>Evidence: review step fallback log</summary>

<code>step: review&#10;run: &#34;01KWMFN3ZQP4C26CBTNCHPYTJ9&#34;&#10;lines: 5 total&#10;log[5]{line}:&#10;reviewing changes...&#10;&#34;&#34;&#10;&#34;&#34;&#10;&#34;agent codex failed (codex exited: exit status 1: simulated codex unavailable); falling back to claude&#34;&#10;no issues found</code>

```text
step: review
run: "01KWMFN3ZQP4C26CBTNCHPYTJ9"
lines: 5 total
log[5]{line}:
  reviewing changes...
  ""
  ""
  "agent codex failed (codex exited: exit status 1: simulated codex unavailable); falling back to claude"
  no issues found
```
</details>
- Evidence: fake agent invocation log (local file: <code>/var/folders/ql/vwkrq94j4mq90s39twg74z7c0000gn/T/no-mistakes-evidence/01KWMF256GWZ1P84GXKZ4YSN3V/fallback-agent-invocations.jsonl</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - medium risk</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`
- <code>Baseline already completed before this validation: `go test -race ./...`</code>
- `go test -race ./internal/config ./internal/agent ./internal/daemon`
- <code>Manual gate smoke: built `cmd/no-mistakes` and `cmd/fakeagent`, initialized a disposable repo, configured `agent: [codex, claude]`, made `codex` exit 1, pushed `fallback-list-smoke` through `git push no-mistakes fallback-list-smoke`, polled `no-mistakes axi status`, and captured `no-mistakes axi logs --step review --full` plus fake-agent invocations</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
