### PR TITLE
fix(git): absolutize PWD in NonInteractiveEnv

### DIFF
--- a/internal/git/env.go
+++ b/internal/git/env.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"os"
+	"path/filepath"
 	"runtime"
 )
 
@@ -30,10 +31,18 @@ func NonInteractiveEnv(dir string) []string {
 		"GIT_SEQUENCE_EDITOR=true",
 		"GIT_TERMINAL_PROMPT=0",
 	)
-	// Mirror os/exec, which only injects PWD when Cmd.Env is nil and skips it
-	// on these platforms.
+	// Mirror os/exec, which only injects PWD when Cmd.Env is nil, skips it on
+	// these platforms, and absolutizes Cmd.Dir first (go.dev/issue/50599):
+	// POSIX defines PWD as "an absolute pathname of the current working
+	// directory". Injecting a relative dir verbatim (for example ".") poisons
+	// every descendant that trusts PWD — macOS /bin/sh is bash 3.2, whose pwd
+	// builtin reports "." when PWD="." leaks through git receive-pack into a
+	// hook, which is how the post-receive hook of issue #269 ended up passing
+	// `--gate .`.
 	if dir != "" && runtime.GOOS != "windows" && runtime.GOOS != "plan9" {
-		env = append(env, "PWD="+dir)
+		if abs, err := filepath.Abs(dir); err == nil {
+			env = append(env, "PWD="+abs)
+		}
 	}
 	return env
 }

--- a/internal/git/env_test.go
+++ b/internal/git/env_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -81,6 +82,32 @@ func TestNonInteractiveEnv_SetsPWDToDir(t *testing.T) {
 
 	if got["PWD"] != "/work/dir" {
 		t.Errorf("PWD = %q, want \"/work/dir\"", got["PWD"])
+	}
+}
+
+// TestNonInteractiveEnv_AbsolutizesRelativeDir locks in that a relative dir is
+// absolutized before injection, matching os/exec (go.dev/issue/50599). POSIX
+// defines PWD as an absolute pathname; a relative value like "." propagates
+// through git receive-pack into hooks, where macOS /bin/sh (bash 3.2) trusts
+// it and `pwd` collapses to "." (issue #269).
+func TestNonInteractiveEnv_AbsolutizesRelativeDir(t *testing.T) {
+	t.Setenv("PWD", "/somewhere/else")
+
+	got := resolveEnv(NonInteractiveEnv("."))
+
+	if runtime.GOOS == "windows" || runtime.GOOS == "plan9" {
+		if got["PWD"] != "/somewhere/else" {
+			t.Errorf("PWD = %q, want ambient PWD on %s", got["PWD"], runtime.GOOS)
+		}
+		return
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if got["PWD"] != wd {
+		t.Errorf("PWD = %q, want absolute %q for relative dir \".\"", got["PWD"], wd)
 	}
 }
 


### PR DESCRIPTION
## Intent

Fix the producer side of issue #269: NonInteractiveEnv (internal/git/env.go) injects PWD=dir verbatim into every subprocess environment, so a relative cmd.Dir (for example '.') yields PWD='.' in descendants. POSIX defines PWD as an absolute pathname, and os/exec - which the function's own comment says it mirrors - absolutizes Cmd.Dir via filepath.Abs before injecting PWD (go.dev/issue/50599). The concrete field failure: PWD='.' flows through git receive-pack into the post-receive hook; macOS /bin/sh is bash 3.2, whose pwd builtin trusts an ambient PWD='.' (its dev/ino check trivially matches, and even pwd -P is fooled), so $(pwd) collapsed to '.' and the hook passed --gate '.', which the daemon rejected with 'invalid gate path: .' - the pipeline never started (reproduced on macOS with no-mistakes v1.31.2; zsh and dash are immune, which is why this bites macOS specifically). PR #358 already hardened the hook consumer via git rev-parse --absolute-git-dir; this change closes the source so no other PWD-trusting descendant (hooks, agents, shell tools that read PWD) can be poisoned the same way. The fix: absolutize dir with filepath.Abs before appending PWD, skipping injection on the (practically unreachable) Abs error rather than injecting a relative value; the existing dir=='' guard is preserved deliberately because filepath.Abs('') would return the cwd and the documented contract is to leave ambient PWD untouched when cmd.Dir is unset. Added TestNonInteractiveEnv_AbsolutizesRelativeDir mirroring the existing TestNonInteractiveEnv_SetsPWDToDir style, including the windows/plan9 ambient branch. Verified locally: gofmt clean, make lint green, go test -race ./... green except one pre-existing flaky test (TestCIStep_AllChecksPassingKeepsMonitoringOpenPR raced its real subprocess against a 10s wall-clock deadline under full-suite race-detector load; it passes 3x in isolation on both origin/main and this branch, so it is unrelated).

## What Changed

- `NonInteractiveEnv` (`internal/git/env.go`) now runs `filepath.Abs` on the target dir before injecting `PWD`, mirroring `os/exec`'s handling of `Cmd.Dir`, so a relative `cmd.Dir` (e.g. `.`) no longer propagates a relative `PWD` into subprocesses.
- On the (practically unreachable) `filepath.Abs` error, PWD injection is skipped rather than setting a relative value; the existing empty-`dir` guard is preserved so ambient `PWD` is left untouched when `cmd.Dir` is unset.
- Added `TestNonInteractiveEnv_AbsolutizesRelativeDir` covering the absolutization and the windows/plan9 ambient branch.

## Risk Assessment

✅ Low: Small, well-bounded fix that absolutizes PWD to mirror os/exec, preserves the existing empty-dir guard, fails safe on Abs error, and adds a matching regression test.

## Testing

Baseline `go test -race ./...` already passed. I ran the git env unit tests including the new regression test (all green), then produced end-to-end evidence on the exact platform that triggered issue #269: confirmed /bin/sh is bash 3.2, spawned a descendant shell the way a git hook does with the real NonInteractiveEnv(".") output, and showed its pwd now resolves to the absolute worktree path instead of collapsing to ".". A before/after transcript captures the old poisoning (`--gate .`, which the daemon rejects) versus the fixed absolute PWD. This is a non-UI CLI/env change, so the evidence is a CLI/shell transcript rather than a visual artifact. Overall: the user intent is demonstrated working.

<details>
<summary>Evidence: PWD absolutization before/after transcript (bash 3.2 descendant shell)</summary>

<code>BEFORE (PWD=.): descendant pwd = . -&gt; hook passes: --gate . (daemon rejects: invalid gate path: .)&#10;AFTER: NonInteractiveEnv(&#34;.&#34;) injects PWD=/…/internal/git; descendant bash 3.2 pwd-builtin and pwd -P both resolve to the absolute path. Test PASS.</code>

```text
# Issue #269 fix — PWD absolutization in NonInteractiveEnv
Host /bin/sh: bash 3.2.57 (macOS), the shell whose pwd builtin trusts ambient PWD.

## BEFORE (old code injected PWD=. verbatim) — reproduces the bug
  descendant pwd = .
  hook would pass: --gate .   <-- daemon rejects: invalid gate path: .

## AFTER (fix absolutizes dir before injecting PWD)
    zz_evidence_test.go:21: NonInteractiveEnv(".") injected: PWD=/Users/mikew/.no-mistakes/worktrees/09cae3b49c28/01KWJS3D8ACND8RX57RR7T9SPR/internal/git
        pwd-builtin=/Users/mikew/.no-mistakes/worktrees/09cae3b49c28/01KWJS3D8ACND8RX57RR7T9SPR/internal/git
        pwd-P=/Users/mikew/.no-mistakes/worktrees/09cae3b49c28/01KWJS3D8ACND8RX57RR7T9SPR/internal/git
--- PASS: TestEvidence_DescendantShellPWD (0.02s)
PASS
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (7m11s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 tests failed with exit code 1
- `go test -race ./...`

🔧 Fix: confirm passing tests; daemon-startup flake, no code change needed
✅ Re-checked - no issues remain.
- `go test -race ./...`
- <code>`go test -race ./internal/git/ -run TestNonInteractiveEnv -v -count=1` (all pass, incl. new TestNonInteractiveEnv_AbsolutizesRelativeDir)</code>
- <code>Confirmed host `/bin/sh` is bash 3.2.57 (the shell that trusts ambient PWD)</code>
- <code>E2E: spawned `/bin/sh -c &#39;pwd&#39;` with cmd.Dir=&#39;.&#39; and the real NonInteractiveEnv output — $(pwd)/$(pwd -P) resolve to the absolute worktree path</code>
- <code>Contrast: `env PWD=. /bin/sh -c &#39;echo $(pwd)&#39;` reproduces the old bug, collapsing to `--gate .`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
