### PR TITLE
fix(git): name bare gate repos explicitly with --git-dir

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,10 @@ Safest local verification sequence after non-trivial changes:
 - Existing code typically uses `0o755` for directories and `0o644` for files such as logs.
 - On macOS, remember that path comparisons may need symlink resolution like `/var` vs `/private/var`.
 
+**Git on Bare Gate Repos (`safe.bareRepository`)**
+
+- Agent harnesses (e.g. Claude Code) and hardened CI inject `safe.bareRepository=explicit` via `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_n`/`GIT_CONFIG_VALUE_n`, which forbids cwd-based discovery of bare repositories. Every git operation on a gate repo must therefore name it explicitly: `git.Run` detects a bare git dir (`isBareGitDir`: `HEAD` file + `objects/` dir, no `.git` entry) and prepends `--git-dir=<dir>`; working trees and linked worktrees keep normal discovery. Route gate git calls through `git.Run` - never shell out to git in a bare gate repo relying only on `cmd.Dir` or `-C` discovery (issue #362). Regressions: `TestRunOnBareRepoUnderSafeBareRepositoryExplicit`, `TestWorktreeAddRemoveOnBareRepoUnderSafeBareRepositoryExplicit`, `TestInitUnderSafeBareRepositoryExplicit`.
+
 **Testing Conventions**
 
 - Tests live next to the code in `*_test.go` files.
@@ -131,6 +135,7 @@ Safest local verification sequence after non-trivial changes:
 - Use `t.TempDir()` for isolated filesystem state.
 - Use `t.Setenv()` for environment-dependent behavior.
 - Prefer creating real git repos in temp directories instead of relying on heavy mocking.
+- Packages whose tests shell out to git unset `GIT_CONFIG_COUNT` in `TestMain` so ambient `GIT_CONFIG_*` injection from agent harnesses cannot leak into tests; a test that exercises the injected config re-sets it with `t.Setenv` (see `internal/git`, `internal/gate`, `internal/daemon`, `internal/pipeline/steps`). Follow the same pattern in new git-spawning test packages.
 - CLI tests often capture output and assert with `strings.Contains`.
 - Prefer e2e tests, new or existing, for behavior that crosses a process or I/O boundary: CLI flags, config loading, git operations, agent spawning, daemon/process coordination, stdout/stderr, and recorded fixtures.
 - Unit-test pure helpers and tightly scoped package behavior where speed and failure localization are worth more than full-product realism.

--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -83,6 +83,11 @@ The local bare repo gives Git a normal place to receive pushes. That keeps the
 push path simple and lets a standard `post-receive` hook hand work off to the
 daemon.
 
+Git operations on the gate name the bare repo explicitly with `--git-dir`
+instead of relying on working-directory discovery, so hardened environments
+that set `safe.bareRepository=explicit` (common in agent harnesses and CI)
+work unchanged.
+
 ### Daemon
 
 The daemon owns long-running work: creating worktrees, running the pipeline,

--- a/internal/daemon/helpers_test.go
+++ b/internal/daemon/helpers_test.go
@@ -39,6 +39,10 @@ func TestMain(m *testing.M) {
 	if os.Getenv("NM_HOOK_HELPER") == "1" {
 		os.Exit(0)
 	}
+	// Agent harnesses inject git config (e.g. safe.bareRepository=explicit)
+	// via GIT_CONFIG_COUNT/KEY_n/VALUE_n; tests that need it re-set it with
+	// t.Setenv (issue #362).
+	os.Unsetenv("GIT_CONFIG_COUNT")
 	os.Exit(m.Run())
 }
 

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -14,6 +14,14 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/paths"
 )
 
+func TestMain(m *testing.M) {
+	// Agent harnesses inject git config (e.g. safe.bareRepository=explicit)
+	// via GIT_CONFIG_COUNT/KEY_n/VALUE_n; tests that need it re-set it with
+	// t.Setenv (issue #362).
+	os.Unsetenv("GIT_CONFIG_COUNT")
+	os.Exit(m.Run())
+}
+
 // resolveSymlinks resolves symlinks in a path (needed on macOS where
 // /var → /private/var but git returns resolved paths).
 func resolveSymlinks(t *testing.T, p string) string {

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -144,6 +144,41 @@ func TestInit(t *testing.T) {
 	}
 }
 
+func TestInitUnderSafeBareRepositoryExplicit(t *testing.T) {
+	// Agent harnesses (e.g. Claude Code) and hardened CI inject this git
+	// config, which forbids cwd-based discovery of bare repos, so every git
+	// operation on the gate must name it explicitly (issue #362).
+	t.Setenv("GIT_CONFIG_COUNT", "1")
+	t.Setenv("GIT_CONFIG_KEY_0", "safe.bareRepository")
+	t.Setenv("GIT_CONFIG_VALUE_0", "explicit")
+
+	workDir := setupTestRepo(t)
+	nmRoot := t.TempDir()
+	p := paths.WithRoot(nmRoot)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	d := openTestDB(t, p)
+	ctx := context.Background()
+
+	repo, created, err := Init(ctx, d, p, workDir)
+	if err != nil {
+		t.Fatalf("init under safe.bareRepository=explicit: %v", err)
+	}
+	if !created {
+		t.Error("expected a new gate to be created")
+	}
+
+	// Read the gate config naming the repo explicitly; -C discovery would
+	// itself fail under the injected setting.
+	bareDir := p.RepoDir(repo.ID)
+	if out, err := exec.Command("git", "--git-dir="+bareDir, "config", "--get", "receive.advertisePushOptions").Output(); err != nil {
+		t.Fatalf("get receive.advertisePushOptions: %v", err)
+	} else if got := string(out); got != "true\n" {
+		t.Fatalf("receive.advertisePushOptions = %q, want true", got)
+	}
+}
+
 func TestInitRepoID(t *testing.T) {
 	// Verify repo ID is deterministic based on path.
 	id1 := repoID("/some/path")

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -25,7 +26,16 @@ func IsZeroSHA(sha string) bool {
 
 // Run executes a git command in the given directory and returns trimmed stdout.
 // Returns an error that includes the command and stderr on failure.
+//
+// When dir is itself a bare repository (a gate repo), the repo is named
+// explicitly via --git-dir instead of relying on cwd-based discovery, which
+// safe.bareRepository=explicit forbids. Agent harnesses (e.g. Claude Code)
+// and hardened CI inject that setting, so gate operations must never depend
+// on discovering a bare repo from the working directory (issue #362).
 func Run(ctx context.Context, dir string, args ...string) (string, error) {
+	if isBareGitDir(dir) {
+		args = append([]string{"--git-dir=" + dir}, args...)
+	}
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
 	cmd.Env = NonInteractiveEnv(dir)
@@ -38,6 +48,24 @@ func Run(ctx context.Context, dir string, args ...string) (string, error) {
 		return "", fmt.Errorf("git %s: %w: %s", safeurl.RedactText(strings.Join(args, " ")), err, safeurl.RedactText(stderr))
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// isBareGitDir reports whether dir is itself a git directory (a bare repo),
+// as opposed to a working tree or linked worktree, which carry a .git entry
+// and keep using normal discovery. The check mirrors git's own git-dir
+// heuristic: a HEAD file plus an objects directory.
+func isBareGitDir(dir string) bool {
+	if dir == "" {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+		return false
+	}
+	if fi, err := os.Stat(filepath.Join(dir, "HEAD")); err != nil || fi.IsDir() {
+		return false
+	}
+	fi, err := os.Stat(filepath.Join(dir, "objects"))
+	return err == nil && fi.IsDir()
 }
 
 // InitBare creates a new bare git repository at the given path.

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -20,6 +20,12 @@ func TestMain(m *testing.M) {
 	if err := os.Setenv("GIT_CONFIG_NOSYSTEM", "1"); err != nil {
 		panic(err)
 	}
+	// Agent harnesses inject git config (e.g. safe.bareRepository=explicit)
+	// via GIT_CONFIG_COUNT/KEY_n/VALUE_n; tests that need it re-set it with
+	// t.Setenv (issue #362).
+	if err := os.Unsetenv("GIT_CONFIG_COUNT"); err != nil {
+		panic(err)
+	}
 	code := m.Run()
 	_ = os.RemoveAll(dir)
 	os.Exit(code)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -357,3 +357,64 @@ func TestIsDetachedHEADWhenDetached(t *testing.T) {
 		t.Fatal("expected detached HEAD after checking out a commit SHA")
 	}
 }
+
+// setSafeBareRepositoryExplicit injects the git config used by agent
+// harnesses (e.g. Claude Code) and hardened CI environments, which forbids
+// cwd-based discovery of bare repositories (issue #362).
+func setSafeBareRepositoryExplicit(t *testing.T) {
+	t.Helper()
+	t.Setenv("GIT_CONFIG_COUNT", "1")
+	t.Setenv("GIT_CONFIG_KEY_0", "safe.bareRepository")
+	t.Setenv("GIT_CONFIG_VALUE_0", "explicit")
+}
+
+func TestRunOnBareRepoUnderSafeBareRepositoryExplicit(t *testing.T) {
+	setSafeBareRepositoryExplicit(t)
+	ctx := context.Background()
+
+	bare := filepath.Join(t.TempDir(), "gate.git")
+	if err := InitBare(ctx, bare); err != nil {
+		t.Fatalf("init bare: %v", err)
+	}
+
+	if _, err := Run(ctx, bare, "config", "receive.advertisePushOptions", "true"); err != nil {
+		t.Fatalf("config write on bare repo: %v", err)
+	}
+	got, err := Run(ctx, bare, "config", "--get", "receive.advertisePushOptions")
+	if err != nil {
+		t.Fatalf("config read on bare repo: %v", err)
+	}
+	if got != "true" {
+		t.Fatalf("receive.advertisePushOptions = %q, want true", got)
+	}
+
+	// A working repo must keep using normal cwd discovery.
+	work := initTestRepo(t)
+	if out, err := Run(ctx, work, "rev-parse", "--is-inside-work-tree"); err != nil || out != "true" {
+		t.Fatalf("rev-parse in working repo = %q, %v; want true, nil", out, err)
+	}
+}
+
+func TestWorktreeAddRemoveOnBareRepoUnderSafeBareRepositoryExplicit(t *testing.T) {
+	setSafeBareRepositoryExplicit(t)
+	ctx := context.Background()
+
+	work := initTestRepo(t)
+	bare := filepath.Join(t.TempDir(), "gate.git")
+	if err := InitBare(ctx, bare); err != nil {
+		t.Fatalf("init bare: %v", err)
+	}
+	run(t, work, "git", "push", bare, "HEAD:refs/heads/main")
+	sha := run(t, work, "git", "rev-parse", "HEAD")
+
+	wt := filepath.Join(t.TempDir(), "wt")
+	if err := WorktreeAdd(ctx, bare, wt, sha); err != nil {
+		t.Fatalf("worktree add from bare repo: %v", err)
+	}
+	if got, err := Run(ctx, wt, "rev-parse", "HEAD"); err != nil || got != sha {
+		t.Fatalf("rev-parse in worktree = %q, %v; want %q, nil", got, err, sha)
+	}
+	if err := WorktreeRemove(ctx, bare, wt); err != nil {
+		t.Fatalf("worktree remove from bare repo: %v", err)
+	}
+}

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -19,6 +19,10 @@ func TestMain(m *testing.M) {
 		handleFakeCLI(mode)
 		return
 	}
+	// Agent harnesses inject git config (e.g. safe.bareRepository=explicit)
+	// via GIT_CONFIG_COUNT/KEY_n/VALUE_n; tests that need it re-set it with
+	// t.Setenv (issue #362).
+	os.Unsetenv("GIT_CONFIG_COUNT")
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
## What Changed

- `git.Run` now detects a bare git directory (`HEAD` file plus `objects/`, no `.git` entry) and prepends `--git-dir=<dir>`, so git operations on the bare gate repo keep working when agent harnesses or hardened CI inject `safe.bareRepository=explicit` via `GIT_CONFIG_*` environment variables, which forbids cwd-based discovery of bare repositories (issue #362). Working trees and linked worktrees keep normal discovery.
- Test packages that shell out to git (`internal/git`, `internal/gate`, `internal/daemon`, `internal/pipeline/steps`) now unset `GIT_CONFIG_COUNT` in `TestMain` so ambient `GIT_CONFIG_*` injection cannot leak into tests; the tests that exercise the injected config re-set it explicitly with `t.Setenv`. This was applied as a pipeline auto-fix after the test step caught the leak.
- Documented the bare-gate `--git-dir` invariant and the git-config test-isolation convention in `AGENTS.md` and the gate-model docs, with new regression tests covering `git.Run`, worktree add/remove, and init under `safe.bareRepository=explicit`.

## Risk Assessment

✅ Low: Small, additive, well-tested fix: the --git-dir injection is gated on a precise bare-repo check, all production gate call sites route through the fixed helper, and regression tests cover both the git primitive and the full gate Init under the hardened setting; the only findings are latent consistency nits.

## Testing

Completed 1 recorded test check.

- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (9m47s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `internal/git/git.go:37` - If Run is ever called with a relative bare-repo dir, the injected --git-dir=&lt;dir&gt; is resolved by git against the child process cwd (which is also dir), producing &lt;dir&gt;/&lt;dir&gt; and a spurious &#39;not a git repository&#39; failure — a case cwd discovery previously handled. All current callers pass absolute paths from paths.RepoDir, so this is latent; absolutize dir with filepath.Abs when building the flag, mirroring the PWD absolutization already done in NonInteractiveEnv (issue #269 / commit a84593c).
- ℹ️ `internal/git/git.go:403` - RefExists bypasses Run (it needs exit-code discrimination) and names the repo via `git -C &lt;dir&gt;`, so it would still fail on a bare gate dir under safe.bareRepository=explicit — contradicting the new invariant that every gate operation names the bare repo explicitly. It currently has no production caller passing a bare dir, but applying the same isBareGitDir/--git-dir injection there keeps the package consistent and future-proof.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 tests failed with exit code 1
- `go test -race ./...`

🔧 Fix: isolate tests from ambient GIT_CONFIG_* injection
✅ Re-checked - no issues remain.
- `go test -race ./...`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
