### PR TITLE
fix(git): write worktree identity per-worktree to avoid shared config.lock race

### DIFF
--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -1,12 +1,15 @@
 package daemon
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/telemetry"
@@ -209,6 +212,93 @@ func waitForStartedBranch(t *testing.T, started <-chan string, branch string) {
 			}
 		case <-timeout:
 			t.Fatalf("run for branch %s did not start", branch)
+		}
+	}
+}
+
+// TestPushReceivedConcurrentDifferentBranchRunsAvoidSharedConfigLock fires two
+// branch pushes for the same repo at the same time so both runs hit worktree
+// creation and git-identity setup concurrently. All runs share one gate bare
+// repo, so writing identity with `git config --local` (which targets the bare's
+// shared config) made the two startups race on <bare>/config.lock and fail one
+// run with "could not lock config file ...: File exists". CopyLocalUserIdentity
+// now writes per-worktree, so the startups no longer contend. The race window
+// is during synchronous startRun, so a failure surfaces directly as the
+// push_received call's error. macOS-only in practice (Linux file locking and
+// timing hide it), but the assertion is platform-independent.
+func TestPushReceivedConcurrentDifferentBranchRunsAvoidSharedConfigLock(t *testing.T) {
+	started := make(chan string, 2)
+	p, d := startTestDaemonWithSteps(t, func() []pipeline.Step {
+		return []pipeline.Step{&notifyBlockStep{name: types.StepReview, started: started}}
+	})
+
+	const repoID = "concurrent-config-lock-repo"
+	_, headSHA := setupTestGitRepo(t, p, d, repoID)
+
+	// Mirror a real gate: enable the per-worktree config isolation that
+	// `no-mistakes init` installs, which is what lets identity writes avoid the
+	// shared config.lock.
+	if err := git.IsolateHooksPath(context.Background(), p.RepoDir(repoID)); err != nil {
+		t.Fatalf("isolate hooks path: %v", err)
+	}
+
+	branches := []string{"feature/one", "feature/two"}
+	errs := make([]error, len(branches))
+	var wg sync.WaitGroup
+	for i, br := range branches {
+		wg.Add(1)
+		go func(i int, br string) {
+			defer wg.Done()
+			// A dedicated client per goroutine: a single client serializes
+			// calls, which would defeat the concurrency we are testing.
+			client, err := ipc.Dial(p.Socket())
+			if err != nil {
+				errs[i] = err
+				return
+			}
+			defer client.Close()
+			var res ipc.PushReceivedResult
+			errs[i] = client.Call(ipc.MethodPushReceived, &ipc.PushReceivedParams{
+				Gate: p.RepoDir(repoID),
+				Ref:  "refs/heads/" + br,
+				Old:  "0000000000000000000000000000000000000000",
+				New:  headSHA,
+			}, &res)
+		}(i, br)
+	}
+	wg.Wait()
+
+	for i, br := range branches {
+		if errs[i] != nil {
+			t.Fatalf("concurrent push for %s failed: %v", br, errs[i])
+		}
+	}
+
+	// Drain both start signals regardless of which run won the race to begin,
+	// then confirm both branches have a live, error-free run.
+	gotStarted := make(map[string]bool, len(branches))
+	for range branches {
+		select {
+		case b := <-started:
+			gotStarted[b] = true
+		case <-time.After(3 * time.Second):
+			t.Fatalf("a concurrent run did not start (started so far: %v)", gotStarted)
+		}
+	}
+
+	for _, br := range branches {
+		if !gotStarted[br] {
+			t.Fatalf("run for branch %s did not start", br)
+		}
+		active, err := d.GetActiveRun(repoID, br)
+		if err != nil {
+			t.Fatalf("get active run for %s: %v", br, err)
+		}
+		if active == nil {
+			t.Fatalf("expected active run for %s", br)
+		}
+		if active.Status != types.RunRunning {
+			t.Fatalf("active run for %s status = %s, want running (error: %v)", br, active.Status, active.Error)
 		}
 	}
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -327,6 +327,16 @@ func CommitAll(ctx context.Context, dir, message string) error {
 
 // CopyLocalUserIdentity copies local user.name and user.email from srcDir into
 // dstDir. Missing values in srcDir are ignored.
+//
+// The write into dstDir uses per-worktree scope (`git config --worktree`) when
+// the repository has worktree config enabled. dstDir is typically a linked
+// worktree of the shared gate bare repo, where an unscoped `git config --local`
+// write lands in the bare's shared config and takes <bare>/config.lock. Two
+// runs starting concurrently on different branches of the same repo then race
+// on that single lock and one fails with "could not lock config file ...
+// config: File exists". Writing per-worktree puts each run's identity in its own
+// <bare>/worktrees/<id>/config.worktree, so concurrent startups never contend.
+// Older Git without `--worktree` support falls back to `--local`.
 func CopyLocalUserIdentity(ctx context.Context, srcDir, dstDir string) error {
 	for _, key := range []string{"user.name", "user.email"} {
 		value, err := Run(ctx, srcDir, "config", "--local", "--get", "--default", "", key)
@@ -336,11 +346,35 @@ func CopyLocalUserIdentity(ctx context.Context, srcDir, dstDir string) error {
 		if value == "" {
 			continue
 		}
-		if _, err := Run(ctx, dstDir, "config", "--local", key, value); err != nil {
-			return err
+		if _, err := Run(ctx, dstDir, "config", "--worktree", key, value); err != nil {
+			if !isWorktreeConfigWriteUnavailable(err) {
+				return err
+			}
+			// Per-worktree config is not usable here (Git too old for the
+			// flag, or the repo has multiple worktrees without
+			// extensions.worktreeConfig enabled). Fall back to the shared
+			// local config. Such gates also lack per-worktree isolation, so
+			// this matches the legacy behavior.
+			if _, err := Run(ctx, dstDir, "config", "--local", key, value); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
+}
+
+// isWorktreeConfigWriteUnavailable reports whether a `git config --worktree`
+// write failed because per-worktree config cannot be used on this repo: either
+// the installed Git is too old for the flag (isWorktreeConfigUnsupported), or
+// the repo has more than one worktree without extensions.worktreeConfig enabled
+// ("--worktree cannot be used with multiple working trees unless the config
+// extension worktreeConfig is enabled"). Both mean the caller should fall back
+// to the shared --local config.
+func isWorktreeConfigWriteUnavailable(err error) bool {
+	if isWorktreeConfigUnsupported(err) {
+		return true
+	}
+	return strings.Contains(err.Error(), "worktreeConfig")
 }
 
 // WorktreeAdd creates a detached worktree at wtPath checked out to the given SHA.


### PR DESCRIPTION
## What Changed

- `CopyLocalUserIdentity` now writes `user.name`/`user.email` with per-worktree scope (`git config --worktree`) instead of the shared `git config --local`, so concurrent runs on different branches of the same gate bare repo no longer contend on `<bare>/config.lock` and fail with "could not lock config file ...: File exists".
- Added `isWorktreeConfigWriteUnavailable` to detect when per-worktree config cannot be used (Git too old for the flag, or multiple worktrees without `extensions.worktreeConfig`) and fall back to the legacy `--local` write.
- Added regression coverage: a daemon test firing two concurrent same-repo branch pushes through the config-lock race window, and a `NonInteractiveEnv` test asserting a relative `dir` resolves to an absolute `PWD`.

## Risk Assessment

✅ Low: The change is a small, well-targeted concurrency fix with a safe fallback that preserves legacy behavior, is backed by a focused concurrency regression test, and introduces no behavioral regression for existing callers.

## Testing

Completed 1 recorded test check.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `internal/git/env.go` - merge conflict rebasing onto origin/main
- ⚠️ `internal/git/env_test.go` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `internal/git/git.go:377` - isWorktreeConfigWriteUnavailable relies on substring matching git&#39;s English error text (&#34;worktreeConfig&#34;), consistent with the existing isWorktreeConfigUnsupported (&#34;unknown option&#34;) pattern. Under a non-English git locale the fallback to --local may not trigger, surfacing a hard error instead of degrading gracefully. NonInteractiveEnv does not force a C locale, but this mirrors a pre-existing accepted pattern in the package, so it is low risk.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
