### PR TITLE
feat(cli): make concurrent runs addressable by run ID or branch name

### DIFF
--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -116,6 +116,7 @@ Agents can also call `no-mistakes axi` directly:
 ```sh
 no-mistakes axi run --intent "the user's goal"
 no-mistakes axi status
+no-mistakes axi status --run <id-or-branch>
 no-mistakes axi respond --action approve
 no-mistakes axi logs --step review --full
 no-mistakes axi abort
@@ -127,6 +128,7 @@ If it shows `active_run`, inspect that current-branch run with `no-mistakes axi 
 If it is parked at a gate, drive it with `no-mistakes axi respond`.
 Reattach an in-flight run by re-running `no-mistakes axi run` when it still matches your current `HEAD`.
 If it shows `other_branch_active_run`, they should leave that run alone and start validation for the current branch with `no-mistakes axi run --intent "..."`.
+To inspect a run other than the resolved one - for example a parked run on another branch - pass `--run` to `axi status` or `axi logs` with the run's ID or its branch name; `no-mistakes runs` lists recent runs with their IDs.
 Use `no-mistakes axi abort --run <id>` only when you need to cancel a specific active run by id from outside its worktree.
 
 When an agent starts a new run, `--intent` is required and should describe what the user wanted to accomplish, not what files changed.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -136,12 +136,14 @@ Show a run, preferring the current branch's active or most recent run before fal
 
 ```sh
 no-mistakes axi status
-no-mistakes axi status --run <id>
+no-mistakes axi status --run <id-or-branch>
 ```
 
 | Flag | Type | Default | Description |
 |---|---|---|---|
-| `--run` | `string` | resolved run | Inspect a specific run ID |
+| `--run` | `string` | resolved run | Inspect a specific run by ID or branch name |
+
+When the `--run` value is not a known run ID, it is treated as a branch name and resolves to that branch's active run, else its most recent run, so a parallel run on another branch can be targeted without copying its ID.
 
 When the resolved run is parked at an `awaiting_approval` or `fix_review` gate, its top-level `run:` object includes `awaiting_agent: parked <duration>` immediately after `status`.
 The field disappears after `axi respond`, on cancel, and on terminal outcomes; use it to distinguish a run waiting for the driving agent from one actively running, fixing, or watching CI.
@@ -153,15 +155,16 @@ Show the log output of one pipeline step.
 ```sh
 no-mistakes axi logs --step review
 no-mistakes axi logs --step review --full
-no-mistakes axi logs --step review --run <id>
+no-mistakes axi logs --step review --run <id-or-branch>
 ```
 
 | Flag | Type | Default | Description |
 |---|---|---|---|
 | `--step` | `string` | (none) | Step name; required |
-| `--run` | `string` | resolved run | Run ID to inspect |
+| `--run` | `string` | resolved run | Run ID or branch name to inspect |
 | `--full` | `bool` | `false` | Show the entire log instead of the tail |
 
+`--run` resolves the same way as `axi status --run`: a value that is not a known run ID is treated as a branch name.
 Without `--full`, long logs show the last 40 lines and a help hint for the full log.
 
 ## no-mistakes axi abort
@@ -250,7 +253,8 @@ no-mistakes runs [--limit <n>]
 |---|---|---|---|
 | `--limit` | `int` | `10` | Maximum number of runs to display |
 
-Shows runs newest-first with branch, status (styled), short SHA, timestamp, and PR URL if set.
+Shows runs newest-first with status (styled), branch, run ID, short SHA, timestamp, and PR URL if set.
+The run ID is what `axi status --run`, `axi logs --run`, `axi abort --run`, and `attach --run` accept.
 
 ## no-mistakes stats
 

--- a/internal/cli/axi_query.go
+++ b/internal/cli/axi_query.go
@@ -38,7 +38,7 @@ func newAxiStatusCmd() *cobra.Command {
 			})
 		},
 	}
-	cmd.Flags().StringVar(&runID, "run", "", "inspect a specific run ID (default: active or most recent)")
+	cmd.Flags().StringVar(&runID, "run", "", "inspect a specific run by ID or branch name (default: active or most recent)")
 	return cmd
 }
 
@@ -56,7 +56,7 @@ func runAxiStatus(cmd *cobra.Command, runID string) error {
 
 	if run == nil {
 		if runID != "" {
-			return emitError(cmd, 1, fmt.Sprintf("run %q not found", runID))
+			return emitError(cmd, 1, fmt.Sprintf("no run found for id or branch %q", runID))
 		}
 		emitDoc(cmd,
 			toon.Field{Key: "runs", Value: "0 runs yet in this repository"},
@@ -111,7 +111,7 @@ func newAxiLogsCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&step, "step", "", "step name: intent, rebase, review, test, document, lint, push, pr, ci (required)")
-	cmd.Flags().StringVar(&runID, "run", "", "run ID (default: active or most recent)")
+	cmd.Flags().StringVar(&runID, "run", "", "run ID or branch name (default: active or most recent)")
 	cmd.Flags().BoolVar(&full, "full", false, "show the entire log instead of the tail")
 	return cmd
 }
@@ -187,32 +187,29 @@ func logRows(lines []string) []logRow {
 	return rows
 }
 
-// resolveRun picks the run to inspect: an explicit ID, else the active run,
-// else the most recent run for the repo. Returns (nil, nil) when none exist.
+// resolveRun picks the run to inspect: an explicit ID (or branch name), else
+// the active run, else the most recent run for the repo. Returns (nil, nil)
+// when none exist.
 func resolveRun(env *axiEnv, runID, branch string) (*db.Run, error) {
 	if runID != "" {
 		run, err := env.d.GetRun(runID)
 		if err != nil {
 			return nil, fmt.Errorf("get run: %w", err)
 		}
-		return run, nil
+		if run != nil {
+			return run, nil
+		}
+		// Not a known run ID: treat the value as a branch name so a parallel
+		// run on another branch can be targeted without copying its ULID.
+		return runForBranch(env, runID)
 	}
 	if branch != "" {
-		active, err := env.d.GetActiveRun(env.repo.ID, branch)
+		run, err := runForBranch(env, branch)
 		if err != nil {
-			return nil, fmt.Errorf("get active run: %w", err)
+			return nil, err
 		}
-		if active != nil {
-			return active, nil
-		}
-		runs, err := env.d.GetRunsByRepo(env.repo.ID)
-		if err != nil {
-			return nil, fmt.Errorf("list runs: %w", err)
-		}
-		for _, run := range runs {
-			if run.Branch == branch {
-				return run, nil
-			}
+		if run != nil {
+			return run, nil
 		}
 	}
 	active, err := env.d.GetActiveRun(env.repo.ID, "")
@@ -230,6 +227,28 @@ func resolveRun(env *axiEnv, runID, branch string) (*db.Run, error) {
 		return nil, nil
 	}
 	return runs[0], nil
+}
+
+// runForBranch returns the branch's active run, else its most recent run,
+// else (nil, nil).
+func runForBranch(env *axiEnv, branch string) (*db.Run, error) {
+	active, err := env.d.GetActiveRun(env.repo.ID, branch)
+	if err != nil {
+		return nil, fmt.Errorf("get active run: %w", err)
+	}
+	if active != nil {
+		return active, nil
+	}
+	runs, err := env.d.GetRunsByRepo(env.repo.ID)
+	if err != nil {
+		return nil, fmt.Errorf("list runs: %w", err)
+	}
+	for _, run := range runs {
+		if run.Branch == branch {
+			return run, nil
+		}
+	}
+	return nil, nil
 }
 
 func currentBranchForRunResolve(ctx context.Context) string {

--- a/internal/cli/axi_query.go
+++ b/internal/cli/axi_query.go
@@ -138,6 +138,9 @@ func runAxiLogs(cmd *cobra.Command, step, runID string, full bool) error {
 		return emitError(cmd, 1, err.Error())
 	}
 	if run == nil {
+		if runID != "" {
+			return emitError(cmd, 1, fmt.Sprintf("no run found for id or branch %q", runID))
+		}
 		return emitError(cmd, 1, "no run found to read logs from",
 			noRunLogsHelp())
 	}

--- a/internal/cli/axi_test.go
+++ b/internal/cli/axi_test.go
@@ -501,6 +501,93 @@ func TestResolveRunPrefersCurrentBranchLatestRun(t *testing.T) {
 	}
 }
 
+// TestResolveRunAcceptsBranchName covers targeting a parallel run by branch
+// name: --run values that are not a known run ID fall back to the branch's
+// active (else most recent) run, so an agent can reach a parked run on another
+// branch without copying its ULID.
+func TestResolveRunAcceptsBranchName(t *testing.T) {
+	database := openTestDB(t)
+	repo, err := database.InsertRepo(t.TempDir(), "origin", "main")
+	if err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+	parked, err := database.InsertRun(repo.ID, "feature/parked", "head-parked", "base")
+	if err != nil {
+		t.Fatalf("insert parked run: %v", err)
+	}
+	if err := database.UpdateRunStatus(parked.ID, types.RunRunning); err != nil {
+		t.Fatalf("mark parked run running: %v", err)
+	}
+	newer, err := database.InsertRun(repo.ID, "feature/newer", "head-newer", "base")
+	if err != nil {
+		t.Fatalf("insert newer run: %v", err)
+	}
+	if err := database.UpdateRunStatus(newer.ID, types.RunRunning); err != nil {
+		t.Fatalf("mark newer run running: %v", err)
+	}
+
+	env := &axiEnv{d: database, repo: repo}
+
+	got, err := resolveRun(env, "feature/parked", "")
+	if err != nil {
+		t.Fatalf("resolve by branch name: %v", err)
+	}
+	if got == nil || got.ID != parked.ID {
+		t.Fatalf("resolved run = %#v, want parked branch run %s", got, parked.ID)
+	}
+
+	// A real run ID must keep winning over the branch fallback.
+	got, err = resolveRun(env, parked.ID, "")
+	if err != nil {
+		t.Fatalf("resolve by id: %v", err)
+	}
+	if got == nil || got.ID != parked.ID {
+		t.Fatalf("resolved run = %#v, want run %s by id", got, parked.ID)
+	}
+
+	// A value that is neither an ID nor a branch resolves to nothing.
+	got, err = resolveRun(env, "no-such-run-or-branch", "")
+	if err != nil {
+		t.Fatalf("resolve unknown: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("resolved run = %#v, want nil for unknown id/branch", got)
+	}
+}
+
+// TestResolveRunBranchNamePicksLatestWhenInactive: with no active run on the
+// named branch, the fallback returns that branch's most recent run instead of
+// leaking another branch's run.
+func TestResolveRunBranchNamePicksLatestWhenInactive(t *testing.T) {
+	database := openTestDB(t)
+	repo, err := database.InsertRepo(t.TempDir(), "origin", "main")
+	if err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+	done, err := database.InsertRun(repo.ID, "feature/done", "head-done", "base")
+	if err != nil {
+		t.Fatalf("insert done run: %v", err)
+	}
+	if err := database.UpdateRunStatus(done.ID, types.RunCompleted); err != nil {
+		t.Fatalf("complete done run: %v", err)
+	}
+	active, err := database.InsertRun(repo.ID, "feature/active", "head-active", "base")
+	if err != nil {
+		t.Fatalf("insert active run: %v", err)
+	}
+	if err := database.UpdateRunStatus(active.ID, types.RunRunning); err != nil {
+		t.Fatalf("mark active run running: %v", err)
+	}
+
+	got, err := resolveRun(&axiEnv{d: database, repo: repo}, "feature/done", "")
+	if err != nil {
+		t.Fatalf("resolve by branch name: %v", err)
+	}
+	if got == nil || got.ID != done.ID {
+		t.Fatalf("resolved run = %#v, want completed run %s for its branch", got, done.ID)
+	}
+}
+
 func openTestDB(t *testing.T) *db.DB {
 	t.Helper()
 	database, err := db.Open(filepath.Join(t.TempDir(), "no-mistakes.db"))

--- a/internal/cli/axi_test.go
+++ b/internal/cli/axi_test.go
@@ -555,6 +555,59 @@ func TestResolveRunAcceptsBranchName(t *testing.T) {
 	}
 }
 
+// TestAxiStatusAndLogsUnknownExplicitRun: an explicit --run value that matches
+// neither a run ID nor a branch must name the bad value instead of suggesting
+// the user start a new run, on both the status and logs surfaces.
+func TestAxiStatusAndLogsUnknownExplicitRun(t *testing.T) {
+	repoDir := t.TempDir()
+	nmHome := t.TempDir()
+	t.Setenv("NM_HOME", nmHome)
+	run(t, repoDir, "git", "init")
+	run(t, repoDir, "git", "config", "user.email", "test@test.com")
+	run(t, repoDir, "git", "config", "user.name", "Test")
+	run(t, repoDir, "git", "commit", "--allow-empty", "-m", "initial")
+	rawRoot, err := filepath.EvalSymlinks(repoDir)
+	if err != nil {
+		rawRoot = repoDir
+	}
+	chdir(t, rawRoot)
+
+	p := paths.WithRoot(nmHome)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	database, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+	if _, err := database.InsertRepoWithID("repo-1", rawRoot, "origin", "main"); err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+
+	for name, invoke := range map[string]func(cmd *cobra.Command) error{
+		"status": func(cmd *cobra.Command) error { return runAxiStatus(cmd, "no-such-run") },
+		"logs":   func(cmd *cobra.Command) error { return runAxiLogs(cmd, "review", "no-such-run", false) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			var out bytes.Buffer
+			cmd := &cobra.Command{}
+			cmd.SetContext(context.Background())
+			cmd.SetOut(&out)
+			if err := invoke(cmd); err == nil {
+				t.Fatalf("expected error for unknown --run, got output:\n%s", out.String())
+			}
+			got := out.String()
+			if !strings.Contains(got, "no run found for id or branch") || !strings.Contains(got, "no-such-run") {
+				t.Fatalf("expected id-or-branch error in output, got:\n%s", got)
+			}
+			if strings.Contains(got, "axi run --intent") {
+				t.Fatalf("unknown --run must not suggest starting a new run, got:\n%s", got)
+			}
+		})
+	}
+}
+
 // TestResolveRunBranchNamePicksLatestWhenInactive: with no active run on the
 // named branch, the fallback returns that branch's most recent run instead of
 // leaking another branch's run.

--- a/internal/cli/runs.go
+++ b/internal/cli/runs.go
@@ -75,5 +75,5 @@ func printRunLine(w io.Writer, r *db.Run) {
 	if r.PRURL != nil {
 		pr = fmt.Sprintf("  %s", *r.PRURL)
 	}
-	fmt.Fprintf(w, "  %-12s %-20s %s  %s%s\n", runStatusStyle(r.Status), r.Branch, sDim.Render(sha), sDim.Render(ts), pr)
+	fmt.Fprintf(w, "  %-12s %-20s %s  %s  %s%s\n", runStatusStyle(r.Status), r.Branch, sDim.Render(r.ID), sDim.Render(sha), sDim.Render(ts), pr)
 }

--- a/internal/cli/runs_test.go
+++ b/internal/cli/runs_test.go
@@ -1,0 +1,34 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// TestPrintRunLineShowsRunID: `no-mistakes runs` must surface the run ID so a
+// parallel run (e.g. an older parked one) can be targeted with
+// `axi status --run <id>` without querying the database by hand.
+func TestPrintRunLineShowsRunID(t *testing.T) {
+	run := &db.Run{
+		ID:        "01HZEXAMPLERUNID000000000",
+		Branch:    "feature/parked",
+		HeadSHA:   "abcdef1234567890",
+		Status:    types.RunRunning,
+		CreatedAt: 1700000000,
+	}
+
+	var out bytes.Buffer
+	printRunLine(&out, run)
+
+	got := out.String()
+	if !strings.Contains(got, run.ID) {
+		t.Fatalf("runs line missing run ID %q, got:\n%s", run.ID, got)
+	}
+	if !strings.Contains(got, run.Branch) {
+		t.Fatalf("runs line missing branch %q, got:\n%s", run.Branch, got)
+	}
+}


### PR DESCRIPTION
## Intent

The developer was exploring the no-mistakes Go CLI repository, first asking for a high-level overview, the pipeline definition, and a concrete end-to-end execution walkthrough. While investigating, they discovered a usability gap: with two concurrent runs in one repo, `no-mistakes axi status` only surfaced the newest active run, `axi status --run` only accepted run IDs (not branch names), and `no-mistakes runs` did not print run IDs, leaving an older parked run unreachable via any built-in command. They then explicitly asked to contribute a fix for this: show run IDs in the `runs` command output and make `axi status --run` (and the shared `axi logs --run` resolver) accept a branch name as a fallback when the value is not a known run ID. They expected the change to be verified with tests, formatting, lint, and the race-detector suite, then committed and pushed through the project's own gate via their fork.

## What Changed

- `axi status --run` and `axi logs --run` now accept a branch name as a fallback when the value is not a known run ID, resolving to the latest run for that branch; an unknown value fails with a clear "no run found for id or branch %q" error in both commands.
- `no-mistakes runs` output now includes each run's ID, so concurrent runs (e.g. an older parked run alongside a newer active one) can be discovered and targeted directly.
- Documented run IDs in the `runs` output and the id-or-branch `--run` behavior in the CLI reference and agents guide.

## Risk Assessment

✅ Low: Small, well-tested, read-only discoverability change: the branch-name fallback only affects the read-only status/logs resolver, preserves existing ID precedence and current-branch semantics via a faithful extraction, and the round-1 finding was properly fixed in the follow-up commit.

## Testing

Beyond the green race-detector baseline and the branch's new unit tests, I built the binary and reproduced the original usability gap with two seeded concurrent runs, then captured a CLI transcript showing `no-mistakes runs` printing run IDs, `axi status`/`axi logs --run` resolving the parked run by branch name (including its gate and step log), run-ID lookup still working, and the improved not-found error; everything behaved as intended.

<details>
<summary>Evidence: CLI transcript: parked run reachable via runs IDs and --run &lt;branch&gt;</summary>

<code>$ no-mistakes runs&#10;running feature/fresh-work 01KWMEKJXESNBK7S9335EWZC9C ffff6666 2026-07-03 18:57&#10;running feature/parked-fix 01KWMEKJXD7Q3CKEQNH7XN368G aaaa1111 2026-07-03 18:57&#10;&#10;$ no-mistakes axi status --run feature/parked-fix&#10;run:&#10;id: &#34;01KWMEKJXD7Q3CKEQNH7XN368G&#34;&#10;branch: feature/parked-fix&#10;status: running&#10;awaiting_agent: parked 18s&#10;...&#10;gate:&#10;step: review&#10;status: awaiting_approval&#10;&#10;$ no-mistakes axi logs --step review --run feature/parked-fix&#10;step: review&#10;run: &#34;01KWMEKJXD7Q3CKEQNH7XN368G&#34;&#10;log[1]{line}:&#10;&#34;review: 1 blocking finding - retry loop swallows errors&#34;&#10;&#10;$ no-mistakes axi status --run no-such-thing&#10;error: &#34;no run found for id or branch \&#34;no-such-thing\&#34;&#34;</code>

```text
# Scenario: two concurrent runs in one repo. Current branch: feature/fresh-work.
# An older run is parked at the review gate on feature/parked-fix.

$ no-mistakes axi status        # defaults to the newest active run - the parked run is invisible here
run:
  id: "01KWMEKJXESNBK7S9335EWZC9C"
  branch: feature/fresh-work
  status: running
  head: ffff6666
  findings: none
  steps[0]:

$ no-mistakes runs              # NEW: run IDs are printed so the parked run is addressable
  running      feature/fresh-work   01KWMEKJXESNBK7S9335EWZC9C  ffff6666  2026-07-03 18:57
  running      feature/parked-fix   01KWMEKJXD7Q3CKEQNH7XN368G  aaaa1111  2026-07-03 18:57

$ no-mistakes axi status --run feature/parked-fix    # NEW: --run accepts a branch name
run:
  id: "01KWMEKJXD7Q3CKEQNH7XN368G"
  branch: feature/parked-fix
  status: running
  awaiting_agent: parked 18s
  head: aaaa1111
  findings: none
  steps[1]{step,status,findings,duration_ms}:
    review,awaiting_approval,0,0
gate:
  step: review
  status: awaiting_approval
  note: "Review auto-fix is disabled by default (`auto_fix.review: 0`; a repo or global `auto_fix.review > 0` override re-enables it), so blocking and ask-user review findings park for your decision rather than being silently self-fixed."
  findings[0]:
help[5]: Run `no-mistakes axi respond --action approve` to accept this step and continue,Run `no-mistakes axi respond --action fix --findings <ids>` to have the pipeline fix the selected findings (do not edit files yourself),Run `no-mistakes axi respond --action skip` to skip this step,Run `no-mistakes axi logs --step review --full` to read the full step log,"A long-running call is working, not stalled - background it if your harness needs to, but the run never advances past a gate on its own. Read every return; on a `gate:`, respond; loop until an `outcome:`."

$ no-mistakes axi status --run 01KWMEKJXD7Q3CKEQNH7XN368G    # run ID still works
run:
  id: "01KWMEKJXD7Q3CKEQNH7XN368G"
  branch: feature/parked-fix
  status: running
  awaiting_agent: parked 18s
  head: aaaa1111
  findings: none
  steps[1]{step,status,findings,duration_ms}:
    review,awaiting_approval,0,0
gate:
  step: review
  status: awaiting_approval
  note: "Review auto-fix is disabled by default (`auto_fix.review: 0`; a repo or global `auto_fix.review > 0` override re-enables it), so blocking and ask-user review findings park for your decision rather than being silently self-fixed."
  findings[0]:
help[5]: Run `no-mistakes axi respond --action approve` to accept this step and continue,Run `no-mistakes axi respond --action fix --findings <ids>` to have the pipeline fix the selected findings (do not edit files yourself),Run `no-mistakes axi respond --action skip` to skip this step,Run `no-mistakes axi logs --step review --full` to read the full step log,"A long-running call is working, not stalled - background it if your harness needs to, but the run never advances past a gate on its own. Read every return; on a `gate:`, respond; loop until an `outcome:`."

$ no-mistakes axi logs --step review --run feature/parked-fix    # NEW: logs resolver accepts a branch too
step: review
run: "01KWMEKJXD7Q3CKEQNH7XN368G"
lines: 1 total
log[1]{line}:
  "review: 1 blocking finding - retry loop swallows errors"

$ no-mistakes axi status --run no-such-thing    # unknown value names itself instead of "run not found"
error: "no run found for id or branch \"no-such-thing\""
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ℹ️ `internal/cli/axi_query.go:141` - `axi status` with an unknown explicit --run now emits the clearer &#34;no run found for id or branch %q&#34; error, but `axi logs` in the same situation still returns the generic &#34;no run found to read logs from&#34; plus help suggesting starting a new run — misleading when the user passed a bad --run value. Consider mirroring the id-or-branch error message in runAxiLogs.
- ℹ️ `internal/cli/attach.go:197` - The attach command&#39;s run picker prints the same run-line layout as printRunLine but without the run ID, and `attach --run` (attach.go:254) remains ID-only without the new branch-name fallback. The discoverability gap this change fixes for status/logs persists for attach; fine as follow-up scope, just noting the divergence.

🔧 Fix: Mirror id-or-branch not-found error in axi logs
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`
- <code>Baseline `go test -race ./...` (ran green before this step)</code>
- `go test -race ./internal/cli -run 'TestResolveRunAcceptsBranchName|TestAxiStatusAndLogsUnknownExplicitRun|TestResolveRunBranchNamePicksLatestWhenInactive|TestPrintRunLineShowsRunID|TestResolveRunPrefersCurrentBranchLatestRun'`
- <code>Manual end-to-end check with the built binary: seeded a demo NM_HOME with two concurrent runs (one parked at the review gate), then ran `no-mistakes runs`, `axi status --run &lt;branch&gt;`, `axi status --run &lt;run-id&gt;`, `axi logs --step review --run &lt;branch&gt;`, and `axi status --run no-such-thing`, verifying the parked run resolves by branch name, run IDs are printed, and the unknown-value error names the bad value</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
