### PR TITLE
fix(scm): fall back to statusCheckRollup and surface gh stderr when polling PR checks

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: no-mistakes-required-${{ github.event.pull_request.number }}
@@ -31,6 +32,8 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -eu
           marker='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
@@ -38,6 +41,21 @@ jobs:
             echo "Found no-mistakes signature in PR #${PR_NUMBER} body."
             exit 0
           fi
+          # The event payload carries a body snapshot taken when the event
+          # fired. The no-mistakes pipeline pushes the branch (synchronize)
+          # before its PR step rewrites the PR description, so the snapshot
+          # can be momentarily stale, and the follow-up edited event is not
+          # guaranteed to be delivered. Poll the live body before declaring
+          # a violation.
+          echo "Signature not in the event snapshot; polling the live PR body..."
+          for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
+            sleep 20
+            live_body="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' 2>/dev/null || true)"
+            if printf '%s' "$live_body" | grep -qF -- "$marker"; then
+              echo "Found no-mistakes signature in PR #${PR_NUMBER} body (live body, attempt ${attempt})."
+              exit 0
+            fi
+          done
           {
             echo "::error::This PR was not raised through no-mistakes."
             echo

--- a/docs/src/content/docs/guides/provider-integration.md
+++ b/docs/src/content/docs/guides/provider-integration.md
@@ -63,7 +63,7 @@ Verify:
 gh auth status
 ```
 
-`no-mistakes doctor` also checks for `gh` availability.
+`no-mistakes doctor` also checks for `gh` availability, and warns when it predates the version the [CI step](/no-mistakes/reference/pipeline-steps/#ci) needs for its preferred check-polling call.
 For PR and workflow-run commands, no-mistakes passes the repository slug from the recorded upstream remote or PR URL to `gh`, so daemon-run commands do not depend on the daemon's current working directory.
 
 **What you get:**

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -227,6 +227,7 @@ Symptom: CI step keeps monitoring an open PR longer than expected, or pauses aft
 
 Monitoring while the PR remains open - even after checks are currently healthy - is intended behavior, because a later default-branch update can make the PR conflict or rerun CI.
 Once checks are green and the PR is mergeable, the CI panel shows `✓ Checks passed` and the terminal title switches to `Checks passed`, so you can tell when to go merge the PR; the signal clears automatically if checks start re-running or a new failure appears.
+If checks never read green, look at the step log at `~/.no-mistakes/logs/<runID>/ci.log` for `warning: could not check CI` lines; see the [CI step reference](/no-mistakes/reference/pipeline-steps/#ci) for the `gh` version fallback and poll-error detail it documents.
 
 How long the monitor runs is controlled by `ci_timeout` in `~/.no-mistakes/config.yaml`, an idle timeout that re-arms whenever the upstream default branch advances; the [`ci_timeout` field reference](/no-mistakes/reference/global-config/#ci_timeout) owns the default, the `unlimited` keyword and its aliases, and the exact re-arm semantics.
 Older config files may still contain an explicit `ci_timeout: "4h"` value; update it if you want the newer default behavior.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -310,6 +310,8 @@ Checks:
 
 Uses indicators: `✓` (available), `–` (not found, optional), `✗` (problem detected).
 
+When `gh` is present but older than 2.50.0, `doctor` warns that the [CI step](/no-mistakes/reference/pipeline-steps/#ci) will use its `statusCheckRollup` fallback; this is informational, not a failure.
+
 For `agent: acp:<target>`, `doctor` verifies that `acpx` resolves but does not invoke the target or test its credentials.
 Each validation run performs the authoritative agent resolution again after applying any trusted repository-level override.
 

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -196,6 +196,9 @@ Monitors PR health after creation and auto-fixes CI failures. Mergeability polli
 
 **Behavior:**
 - Polls provider CI status at increasing intervals: every 30s for the first 5 minutes, every 60s for 5-15 minutes, every 120s after that
+- On GitHub, reads check results with `gh pr checks --json` on `gh` 2.50.0 or newer, and falls back to `gh pr view --json statusCheckRollup` on older `gh` (detected once per run, then remembered); `no-mistakes doctor` warns when the installed `gh` will use the fallback
+- On GitHub, a check state `gh` reports but no-mistakes does not recognize counts as pending, so an unknown state keeps the step polling instead of counting as passed
+- GitHub poll errors written to the step log include the first line of `gh`'s stderr, so authentication and API failures are diagnosable from the CI step log
 - Continues monitoring an open PR until it is merged, closed, declined, or the configured `ci_timeout` idle window elapses, even after CI checks are currently healthy
 - Treats `ci_timeout` as an idle timeout: each upstream default-branch advance re-arms the timer, and `ci_timeout: "unlimited"` disables self-termination
 - On GitHub, GitLab, and Azure DevOps, polls provider mergeability alongside CI checks while the PR remains open

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/config"
@@ -13,6 +15,31 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/winproc"
 	"github.com/spf13/cobra"
 )
+
+// ghVersionRE extracts the dotted version from `gh --version`'s first line,
+// e.g. "gh version 2.45.0 (2025-07-18 ...)" -> "2" "45" "0".
+var ghVersionRE = regexp.MustCompile(`gh version (\d+)\.(\d+)\.(\d+)`)
+
+// ghVersionPredatesChecksJSON reports whether raw (the output of
+// `gh --version`) is older than gh v2.50.0, the release that added
+// `gh pr checks --json` (cli/cli#9079). no-mistakes' CI monitoring falls back
+// to the statusCheckRollup path on older gh either way, so this is purely an
+// informational doctor notice, never a failure. An unparseable version
+// string is treated as current (predates=false) so doctor never warns on a
+// gh variant it doesn't understand.
+func ghVersionPredatesChecksJSON(raw string) (version string, predates bool) {
+	m := ghVersionRE.FindStringSubmatch(raw)
+	if m == nil {
+		return "", false
+	}
+	version = fmt.Sprintf("%s.%s.%s", m[1], m[2], m[3])
+	major, _ := strconv.Atoi(m[1])
+	minor, _ := strconv.Atoi(m[2])
+	if major > 2 || (major == 2 && minor >= 50) {
+		return version, false
+	}
+	return version, true
+}
 
 func newDoctorCmd() *cobra.Command {
 	return &cobra.Command{
@@ -55,6 +82,15 @@ func newDoctorCmd() *cobra.Command {
 					warn("gh            ", "not found "+sDim.Render("(optional, needed for PR/CI)"))
 				} else {
 					ok("gh            ", "ok")
+					ghCmd := exec.Command("gh", "--version")
+					winproc.Harden(ghCmd)
+					if out, verr := ghCmd.Output(); verr == nil {
+						if version, predates := ghVersionPredatesChecksJSON(string(out)); predates {
+							warn("gh version    ", fmt.Sprintf(
+								"%s: 'pr checks --json' unavailable (added in 2.50.0); CI monitoring will use the statusCheckRollup fallback",
+								version))
+						}
+					}
 				}
 
 				if _, err := exec.LookPath("az"); err != nil {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1,0 +1,71 @@
+package cli
+
+import "testing"
+
+func TestGhVersionPredatesChecksJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		raw          string
+		wantVersion  string
+		wantPredates bool
+	}{
+		{
+			name:         "older minor predates",
+			raw:          "gh version 2.49.2 (2024-05-13)\nhttps://github.com/cli/cli/releases/tag/v2.49.2\n",
+			wantVersion:  "2.49.2",
+			wantPredates: true,
+		},
+		{
+			name:         "much older release predates",
+			raw:          "gh version 2.4.0 (2021-12-21)\n",
+			wantVersion:  "2.4.0",
+			wantPredates: true,
+		},
+		{
+			name:         "exact boundary 2.50.0 does not predate",
+			raw:          "gh version 2.50.0 (2024-05-29)\n",
+			wantVersion:  "2.50.0",
+			wantPredates: false,
+		},
+		{
+			name:         "newer minor does not predate",
+			raw:          "gh version 2.63.1 (2025-01-10)\n",
+			wantVersion:  "2.63.1",
+			wantPredates: false,
+		},
+		{
+			name:         "newer major does not predate",
+			raw:          "gh version 3.0.0 (2026-02-01)\n",
+			wantVersion:  "3.0.0",
+			wantPredates: false,
+		},
+		{
+			name:         "unparseable output fails safe to no warning",
+			raw:          "gh (homebrew build, version unknown)\n",
+			wantVersion:  "",
+			wantPredates: false,
+		},
+		{
+			name:         "empty output fails safe to no warning",
+			raw:          "",
+			wantVersion:  "",
+			wantPredates: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			version, predates := ghVersionPredatesChecksJSON(tt.raw)
+			if version != tt.wantVersion {
+				t.Fatalf("ghVersionPredatesChecksJSON(%q) version = %q, want %q", tt.raw, version, tt.wantVersion)
+			}
+			if predates != tt.wantPredates {
+				t.Fatalf("ghVersionPredatesChecksJSON(%q) predates = %v, want %v", tt.raw, predates, tt.wantPredates)
+			}
+		})
+	}
+}

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 
 	"github.com/kunchenguid/no-mistakes/internal/scm"
 )
@@ -440,7 +441,11 @@ func compactCLIError(stderr []byte) string {
 			continue
 		}
 		if len(line) > maxLen {
-			line = line[:maxLen]
+			cut := maxLen
+			for cut > 0 && !utf8.RuneStart(line[cut]) {
+				cut--
+			}
+			line = line[:cut]
 		}
 		return line
 	}

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -256,7 +256,7 @@ func (h *Host) GetPRState(ctx context.Context, pr *scm.PR) (scm.PRState, error) 
 	cmd := h.cmd(ctx, "gh", args...)
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("gh pr view: %w", err)
+		return "", fmt.Errorf("gh pr view: %w: %s", err, compactCLIError(exitStderr(err)))
 	}
 	return normalizePRState(strings.TrimSpace(string(out))), nil
 }
@@ -265,13 +265,31 @@ func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
 	args := append([]string{"pr", "checks", pr.Number}, h.repoArgs()...)
 	args = append(args, "--json", "name,state,bucket,completedAt")
 	cmd := h.cmd(ctx, "gh", args...)
-	out, err := cmd.CombinedOutput()
+	out, err := cmd.Output()
 	if err != nil {
-		if strings.Contains(string(out), "no checks reported") {
+		stderr := exitStderr(err)
+		if strings.Contains(string(out)+string(stderr), "no checks reported") {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("gh pr checks: %w", err)
+		return nil, fmt.Errorf("gh pr checks: %w: %s", err, compactCLIError(stderr))
 	}
+	return parseChecksJSON(out)
+}
+
+func (h *Host) GetMergeableState(ctx context.Context, pr *scm.PR) (scm.MergeableState, error) {
+	args := append([]string{"pr", "view", pr.Number}, h.repoArgs()...)
+	args = append(args, "--json", "mergeable", "--jq", ".mergeable")
+	cmd := h.cmd(ctx, "gh", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("gh pr view mergeable: %w: %s", err, compactCLIError(exitStderr(err)))
+	}
+	return normalizeMergeableState(strings.TrimSpace(string(out))), nil
+}
+
+// parseChecksJSON decodes the `gh pr checks --json name,state,bucket,completedAt`
+// payload into normalized checks.
+func parseChecksJSON(out []byte) ([]scm.Check, error) {
 	var raw []struct {
 		Name        string `json:"name"`
 		State       string `json:"state"`
@@ -294,15 +312,32 @@ func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
 	return checks, nil
 }
 
-func (h *Host) GetMergeableState(ctx context.Context, pr *scm.PR) (scm.MergeableState, error) {
-	args := append([]string{"pr", "view", pr.Number}, h.repoArgs()...)
-	args = append(args, "--json", "mergeable", "--jq", ".mergeable")
-	cmd := h.cmd(ctx, "gh", args...)
-	out, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("gh pr view mergeable: %w", err)
+// exitStderr returns the child process's captured stderr when err is an
+// *exec.ExitError, or nil otherwise. Output() only populates ExitError.Stderr
+// when cmd.Stderr was nil at Start time (true for every gh invocation here).
+func exitStderr(err error) []byte {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.Stderr
 	}
-	return normalizeMergeableState(strings.TrimSpace(string(out))), nil
+	return nil
+}
+
+// compactCLIError collapses a gh CLI stderr capture to its first non-empty
+// line, capped to keep ci.log one line per poll.
+func compactCLIError(stderr []byte) string {
+	const maxLen = 200
+	for _, line := range strings.Split(string(stderr), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if len(line) > maxLen {
+			line = line[:maxLen]
+		}
+		return line
+	}
+	return ""
 }
 
 func (h *Host) FetchFailedCheckLogs(ctx context.Context, _ *scm.PR, branch, headSHA string, failingNames []string) (string, error) {

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -264,7 +264,7 @@ func (h *Host) GetPRState(ctx context.Context, pr *scm.PR) (scm.PRState, error) 
 	cmd := h.cmd(ctx, "gh", args...)
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("gh pr view: %w: %s", err, compactCLIError(exitStderr(err)))
+		return "", ghCLIError("gh pr view", err)
 	}
 	return normalizePRState(strings.TrimSpace(string(out))), nil
 }
@@ -303,7 +303,7 @@ func (h *Host) getChecksViaFlag(ctx context.Context, pr *scm.PR) (checks []scm.C
 		if strings.Contains(string(stderr), "unknown flag: --json") {
 			return nil, nil, true
 		}
-		return nil, fmt.Errorf("gh pr checks: %w: %s", cmdErr, compactCLIError(stderr)), false
+		return nil, ghCLIError("gh pr checks", cmdErr), false
 	}
 	checks, err = parseChecksJSON(out)
 	return checks, err, false
@@ -320,7 +320,7 @@ func (h *Host) getChecksViaStatusRollup(ctx context.Context, pr *scm.PR) ([]scm.
 	cmd := h.cmd(ctx, "gh", args...)
 	out, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("gh pr view statusCheckRollup: %w: %s", err, compactCLIError(exitStderr(err)))
+		return nil, ghCLIError("gh pr view statusCheckRollup", err)
 	}
 	var payload struct {
 		StatusCheckRollup []struct {
@@ -370,7 +370,7 @@ func (h *Host) GetMergeableState(ctx context.Context, pr *scm.PR) (scm.Mergeable
 	cmd := h.cmd(ctx, "gh", args...)
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("gh pr view mergeable: %w: %s", err, compactCLIError(exitStderr(err)))
+		return "", ghCLIError("gh pr view mergeable", err)
 	}
 	return normalizeMergeableState(strings.TrimSpace(string(out))), nil
 }
@@ -407,6 +407,16 @@ func parseChecksJSON(out []byte) ([]scm.Check, error) {
 		checks = append(checks, scm.Check{Name: r.Name, Bucket: bucket, CompletedAt: completedAt})
 	}
 	return checks, nil
+}
+
+// ghCLIError wraps a failed gh invocation, appending the compacted stderr
+// capture only when there is one, so errors without stderr (context canceled,
+// binary not found, silent nonzero exit) don't carry a dangling colon.
+func ghCLIError(op string, err error) error {
+	if detail := compactCLIError(exitStderr(err)); detail != "" {
+		return fmt.Errorf("%s: %w: %s", op, err, detail)
+	}
+	return fmt.Errorf("%s: %w", op, err)
 }
 
 // exitStderr returns the child process's captured stderr when err is an
@@ -582,7 +592,9 @@ func normalizeMergeableState(raw string) scm.MergeableState {
 }
 
 func normalizeCheckBucket(bucket, state string) scm.CheckBucket {
-	if normalized := scm.CheckBucket(strings.TrimSpace(bucket)); normalized != "" {
+	switch normalized := scm.CheckBucket(strings.TrimSpace(bucket)); normalized {
+	case scm.CheckBucketPass, scm.CheckBucketFail, scm.CheckBucketPending,
+		scm.CheckBucketCancel, scm.CheckBucketSkip:
 		return normalized
 	}
 

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/scm"
@@ -23,6 +24,12 @@ type Host struct {
 	host         string // repo's GitHub hostname; scopes the auth check
 	repo         string // "owner/name" slug for --repo; empty when unknown
 	forkOwner    string // fork owner for cross-repository PR heads
+
+	// checksJSONUnsupported memoizes that `gh pr checks --json` isn't
+	// supported by the resolved gh binary (added in gh v2.50.0, cli/cli#9079),
+	// so GetChecks stops retrying it and goes straight to the
+	// statusCheckRollup fallback. Attempted at most once per process.
+	checksJSONUnsupported atomic.Bool
 }
 
 // New builds a Host. cliAvailable reports whether the gh binary is
@@ -261,19 +268,98 @@ func (h *Host) GetPRState(ctx context.Context, pr *scm.PR) (scm.PRState, error) 
 	return normalizePRState(strings.TrimSpace(string(out))), nil
 }
 
+// GetChecks reports each check's normalized state for pr. On gh >= 2.50.0 it
+// runs `gh pr checks --json` directly. On older gh, that flag doesn't exist
+// (cli/cli#9079 added it in 2.50.0); the first time that's detected via its
+// stderr ("unknown flag: --json"), it's memoized on h so every later call on
+// this Host goes straight to the statusCheckRollup fallback instead of
+// re-attempting a flag that will never work until the daemon restarts.
 func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
+	if !h.checksJSONUnsupported.Load() {
+		checks, err, unsupported := h.getChecksViaFlag(ctx, pr)
+		if !unsupported {
+			return checks, err
+		}
+		h.checksJSONUnsupported.Store(true)
+	}
+	return h.getChecksViaStatusRollup(ctx, pr)
+}
+
+// getChecksViaFlag runs `gh pr checks --json`. unsupported is true only when
+// gh rejected --json itself (stderr "unknown flag: --json"), signaling the
+// caller should fall back rather than treat this as a real error.
+func (h *Host) getChecksViaFlag(ctx context.Context, pr *scm.PR) (checks []scm.Check, err error, unsupported bool) {
 	args := append([]string{"pr", "checks", pr.Number}, h.repoArgs()...)
 	args = append(args, "--json", "name,state,bucket,completedAt")
 	cmd := h.cmd(ctx, "gh", args...)
+	out, cmdErr := cmd.Output()
+	if cmdErr != nil {
+		stderr := exitStderr(cmdErr)
+		if strings.Contains(string(out)+string(stderr), "no checks reported") {
+			return nil, nil, false
+		}
+		if strings.Contains(string(stderr), "unknown flag: --json") {
+			return nil, nil, true
+		}
+		return nil, fmt.Errorf("gh pr checks: %w: %s", cmdErr, compactCLIError(stderr)), false
+	}
+	checks, err = parseChecksJSON(out)
+	return checks, err, false
+}
+
+// getChecksViaStatusRollup is the compatibility fallback for gh < 2.50.0: it
+// reads the same information through `gh pr view --json statusCheckRollup`,
+// which has been stable since long before `pr checks --json` existed and
+// exits 0 with well-formed JSON regardless of check state (unlike `pr
+// checks`, which uses nonzero exits to signal pending/failing checks).
+func (h *Host) getChecksViaStatusRollup(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
+	args := append([]string{"pr", "view", pr.Number}, h.repoArgs()...)
+	args = append(args, "--json", "statusCheckRollup")
+	cmd := h.cmd(ctx, "gh", args...)
 	out, err := cmd.Output()
 	if err != nil {
-		stderr := exitStderr(err)
-		if strings.Contains(string(out)+string(stderr), "no checks reported") {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("gh pr checks: %w: %s", err, compactCLIError(stderr))
+		return nil, fmt.Errorf("gh pr view statusCheckRollup: %w: %s", err, compactCLIError(exitStderr(err)))
 	}
-	return parseChecksJSON(out)
+	var payload struct {
+		StatusCheckRollup []struct {
+			Typename    string `json:"__typename"`
+			Name        string `json:"name"`
+			Context     string `json:"context"`
+			Conclusion  string `json:"conclusion"`
+			Status      string `json:"status"`
+			State       string `json:"state"`
+			CompletedAt string `json:"completedAt"`
+		} `json:"statusCheckRollup"`
+	}
+	if err := json.Unmarshal(out, &payload); err != nil {
+		return nil, fmt.Errorf("parse CI checks: %w", err)
+	}
+	checks := make([]scm.Check, 0, len(payload.StatusCheckRollup))
+	for _, item := range payload.StatusCheckRollup {
+		name, state := item.Name, item.Conclusion
+		if item.Typename == "StatusContext" {
+			name, state = item.Context, item.State
+		} else if state == "" {
+			state = item.Status
+		}
+		// normalizeCheckBucket's default is the EMPTY bucket, which
+		// downstream counts as neither Failing() nor Pending() and so
+		// is treated as PASSED (ci.go's aggregation default branch).
+		// An unrecognized future state must keep polling, never
+		// silently green-light the merge gate.
+		bucket := normalizeCheckBucket("", state)
+		if bucket == "" {
+			bucket = scm.CheckBucketPending
+		}
+		var completedAt time.Time
+		if item.CompletedAt != "" {
+			if parsed, parseErr := time.Parse(time.RFC3339, item.CompletedAt); parseErr == nil {
+				completedAt = parsed
+			}
+		}
+		checks = append(checks, scm.Check{Name: name, Bucket: bucket, CompletedAt: completedAt})
+	}
+	return checks, nil
 }
 
 func (h *Host) GetMergeableState(ctx context.Context, pr *scm.PR) (scm.MergeableState, error) {

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -28,7 +28,8 @@ type Host struct {
 	// checksJSONUnsupported memoizes that `gh pr checks --json` isn't
 	// supported by the resolved gh binary (added in gh v2.50.0, cli/cli#9079),
 	// so GetChecks stops retrying it and goes straight to the
-	// statusCheckRollup fallback. Attempted at most once per process.
+	// statusCheckRollup fallback. Attempted at most once per Host; a fresh
+	// Host is built per CI-step run, so the memo lasts for that run.
 	checksJSONUnsupported atomic.Bool
 }
 
@@ -273,7 +274,8 @@ func (h *Host) GetPRState(ctx context.Context, pr *scm.PR) (scm.PRState, error) 
 // (cli/cli#9079 added it in 2.50.0); the first time that's detected via its
 // stderr ("unknown flag: --json"), it's memoized on h so every later call on
 // this Host goes straight to the statusCheckRollup fallback instead of
-// re-attempting a flag that will never work until the daemon restarts.
+// re-attempting a flag that will never work; the memo is per-Host, and a
+// fresh Host is built for each CI-step run.
 func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
 	if !h.checksJSONUnsupported.Load() {
 		checks, err, unsupported := h.getChecksViaFlag(ctx, pr)
@@ -393,7 +395,16 @@ func parseChecksJSON(out []byte) ([]scm.Check, error) {
 				completedAt = parsed
 			}
 		}
-		checks = append(checks, scm.Check{Name: r.Name, Bucket: normalizeCheckBucket(r.Bucket, r.State), CompletedAt: completedAt})
+		// Same hardening as getChecksViaStatusRollup: the EMPTY bucket is
+		// counted as neither Failing() nor Pending() downstream and so is
+		// treated as PASSED (ci.go's aggregation default branch). An
+		// unrecognized future state must keep polling, never silently
+		// green-light the merge gate.
+		bucket := normalizeCheckBucket(r.Bucket, r.State)
+		if bucket == "" {
+			bucket = scm.CheckBucketPending
+		}
+		checks = append(checks, scm.Check{Name: r.Name, Bucket: bucket, CompletedAt: completedAt})
 	}
 	return checks, nil
 }

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/kunchenguid/no-mistakes/internal/scm"
 )
@@ -430,6 +431,43 @@ func TestGetChecksErrorWithoutStderrHasNoTrailingColon(t *testing.T) {
 	}
 	if strings.HasSuffix(err.Error(), ": ") || strings.HasSuffix(err.Error(), ":") {
 		t.Fatalf("GetChecks() error = %q, want no dangling colon when gh emitted no stderr", err.Error())
+	}
+}
+
+func TestCompactCLIErrorTruncatesOnRuneBoundary(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		stderr string
+		want   string
+	}{
+		{"empty", "", ""},
+		{"blank lines only", "\n  \n\t\n", ""},
+		{"first non-empty line", "\nerror: bad flag\nsecond line\n", "error: bad flag"},
+		{"short line untouched", "fehler: ungültig", "fehler: ungültig"},
+		{
+			"ascii truncated at cap",
+			strings.Repeat("a", 250),
+			strings.Repeat("a", 200),
+		},
+		{
+			"multibyte rune not split",
+			strings.Repeat("a", 199) + "é" + strings.Repeat("b", 50),
+			strings.Repeat("a", 199),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := compactCLIError([]byte(tc.stderr))
+			if got != tc.want {
+				t.Fatalf("compactCLIError(%q) = %q, want %q", tc.stderr, got, tc.want)
+			}
+			if !utf8.ValidString(got) {
+				t.Fatalf("compactCLIError(%q) = %q, want valid UTF-8", tc.stderr, got)
+			}
+		})
 	}
 }
 

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -190,6 +190,51 @@ func TestGetChecksFallsBackToStateWhenBucketMissing(t *testing.T) {
 	}
 }
 
+func TestGetChecksSurfacesStderrInError(t *testing.T) {
+	t.Parallel()
+
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		"gh pr checks 123 --json name,state,bucket,completedAt": {
+			stderr: "authentication required, run `gh auth login`\n",
+			code:   1,
+		},
+	}), nil, "", "")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
+	if err == nil {
+		t.Fatal("GetChecks() error = nil, want CLI error")
+	}
+	if !strings.Contains(err.Error(), "authentication required") {
+		t.Fatalf("GetChecks() error = %v, want it to surface gh's stderr", err)
+	}
+	if checks != nil {
+		t.Fatalf("GetChecks() checks = %+v, want nil", checks)
+	}
+}
+
+func TestGetChecksNoChecksReportedStillNil(t *testing.T) {
+	t.Parallel()
+
+	// gh v2.45.0 emits "no checks reported" as an *error* (checks.go:274),
+	// which cobra prints to stderr, not stdout. Detection must scan both
+	// streams; a stdout-only scan would miss this and turn every CI-less
+	// repo into an until-timeout warning-poller.
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		"gh pr checks 123 --json name,state,bucket,completedAt": {
+			stderr: "no checks reported on the 'main' branch\n",
+			code:   1,
+		},
+	}), nil, "", "")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
+	if err != nil {
+		t.Fatalf("GetChecks() error = %v, want nil", err)
+	}
+	if checks != nil {
+		t.Fatalf("GetChecks() checks = %+v, want nil", checks)
+	}
+}
+
 func TestGetChecksParsesCompletedAt(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -390,6 +390,49 @@ func TestGetChecksPrimaryPathUnknownStatePends(t *testing.T) {
 	}
 }
 
+func TestGetChecksPrimaryPathUnknownBucketPends(t *testing.T) {
+	t.Parallel()
+
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		"gh pr checks 123 --json name,state,bucket,completedAt": {
+			stdout: `[{"name":"future-check","state":"SOME_FUTURE_STATE","bucket":"exotic"}]` + "\n",
+		},
+	}), nil, "", "")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
+	if err != nil {
+		t.Fatalf("GetChecks() error = %v", err)
+	}
+	if len(checks) != 1 {
+		t.Fatalf("len(checks) = %d, want 1", len(checks))
+	}
+	// A non-empty bucket outside the five gh emits today must not pass
+	// through verbatim: downstream aggregation treats anything that is
+	// neither "fail" nor "pending" as PASSED, so an unrecognized future
+	// bucket value must coerce to pending and keep polling.
+	if checks[0].Bucket != scm.CheckBucketPending {
+		t.Fatalf("checks[0].Bucket = %q, want %q", checks[0].Bucket, scm.CheckBucketPending)
+	}
+}
+
+func TestGetChecksErrorWithoutStderrHasNoTrailingColon(t *testing.T) {
+	t.Parallel()
+
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		"gh pr checks 123 --json name,state,bucket,completedAt": {
+			code: 1,
+		},
+	}), nil, "", "")
+
+	_, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
+	if err == nil {
+		t.Fatal("GetChecks() error = nil, want CLI error")
+	}
+	if strings.HasSuffix(err.Error(), ": ") || strings.HasSuffix(err.Error(), ":") {
+		t.Fatalf("GetChecks() error = %q, want no dangling colon when gh emitted no stderr", err.Error())
+	}
+}
+
 func TestGetChecksParsesCompletedAt(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -365,6 +365,31 @@ func TestGetChecksFallbackUnknownStatePends(t *testing.T) {
 	}
 }
 
+func TestGetChecksPrimaryPathUnknownStatePends(t *testing.T) {
+	t.Parallel()
+
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		"gh pr checks 123 --json name,state,bucket,completedAt": {
+			stdout: `[{"name":"future-check","state":"SOME_FUTURE_STATE","bucket":""}]` + "\n",
+		},
+	}), nil, "", "")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
+	if err != nil {
+		t.Fatalf("GetChecks() error = %v", err)
+	}
+	if len(checks) != 1 {
+		t.Fatalf("len(checks) = %d, want 1", len(checks))
+	}
+	// Same invariant as the statusCheckRollup fallback: an unmapped bucket
+	// must never surface as "" (downstream aggregation treats it as PASSED);
+	// it must coerce to pending so an unrecognized future gh enum value
+	// keeps polling instead of green-lighting the merge gate.
+	if checks[0].Bucket != scm.CheckBucketPending {
+		t.Fatalf("checks[0].Bucket = %q, want %q", checks[0].Bucket, scm.CheckBucketPending)
+	}
+}
+
 func TestGetChecksParsesCompletedAt(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -235,6 +235,136 @@ func TestGetChecksNoChecksReportedStillNil(t *testing.T) {
 	}
 }
 
+func TestGetChecksFallsBackWhenJSONFlagUnsupported(t *testing.T) {
+	t.Parallel()
+
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		"gh pr checks 123 --json name,state,bucket,completedAt": {
+			stderr: "unknown flag: --json\n",
+			code:   1,
+		},
+		"gh pr view 123 --json statusCheckRollup": {
+			stdout: `{"statusCheckRollup":[` +
+				`{"__typename":"CheckRun","name":"build","conclusion":"SUCCESS","completedAt":"2026-04-24T04:15:00Z"},` +
+				`{"__typename":"CheckRun","name":"deploy","conclusion":"","status":"IN_PROGRESS"},` +
+				`{"__typename":"StatusContext","context":"ci/circleci","state":"FAILURE","completedAt":"2026-04-24T04:16:00Z"},` +
+				`{"__typename":"StatusContext","context":"ci/legacy","state":"PENDING"}` +
+				`]}` + "\n",
+		},
+	}), nil, "", "")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
+	if err != nil {
+		t.Fatalf("GetChecks() error = %v", err)
+	}
+	if len(checks) != 4 {
+		t.Fatalf("len(checks) = %d, want 4: %+v", len(checks), checks)
+	}
+
+	wantBuildCompletedAt := time.Date(2026, 4, 24, 4, 15, 0, 0, time.UTC)
+	if checks[0].Name != "build" || checks[0].Bucket != scm.CheckBucketPass {
+		t.Fatalf("checks[0] = %+v, want passing build check", checks[0])
+	}
+	if !checks[0].CompletedAt.Equal(wantBuildCompletedAt) {
+		t.Fatalf("checks[0].CompletedAt = %v, want %v", checks[0].CompletedAt, wantBuildCompletedAt)
+	}
+	if checks[1].Name != "deploy" || checks[1].Bucket != scm.CheckBucketPending {
+		t.Fatalf("checks[1] = %+v, want pending deploy check (empty conclusion, in-progress status)", checks[1])
+	}
+	wantCIRCompletedAt := time.Date(2026, 4, 24, 4, 16, 0, 0, time.UTC)
+	if checks[2].Name != "ci/circleci" || checks[2].Bucket != scm.CheckBucketFail {
+		t.Fatalf("checks[2] = %+v, want failing ci/circleci check", checks[2])
+	}
+	if !checks[2].CompletedAt.Equal(wantCIRCompletedAt) {
+		t.Fatalf("checks[2].CompletedAt = %v, want %v", checks[2].CompletedAt, wantCIRCompletedAt)
+	}
+	if checks[3].Name != "ci/legacy" || checks[3].Bucket != scm.CheckBucketPending {
+		t.Fatalf("checks[3] = %+v, want pending ci/legacy check", checks[3])
+	}
+}
+
+func TestGetChecksMemoizesJSONUnsupported(t *testing.T) {
+	t.Parallel()
+
+	counts := map[string]*int{}
+	host := New(githubTestCmdFactoryWithCounts(map[string]githubTestResponse{
+		"gh pr checks 123 --json name,state,bucket,completedAt": {
+			stderr: "unknown flag: --json\n",
+			code:   1,
+		},
+		"gh pr view 123 --json statusCheckRollup": {
+			stdout: `{"statusCheckRollup":[]}` + "\n",
+		},
+	}, counts), nil, "", "")
+
+	if _, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"}); err != nil {
+		t.Fatalf("GetChecks() #1 error = %v", err)
+	}
+	if _, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"}); err != nil {
+		t.Fatalf("GetChecks() #2 error = %v", err)
+	}
+
+	prChecksKey := "gh pr checks 123 --json name,state,bucket,completedAt"
+	if got := countOf(counts, prChecksKey); got != 1 {
+		t.Fatalf("gh pr checks attempted %d times, want exactly 1 (memoized)", got)
+	}
+	rollupKey := "gh pr view 123 --json statusCheckRollup"
+	if got := countOf(counts, rollupKey); got != 2 {
+		t.Fatalf("gh pr view statusCheckRollup attempted %d times, want 2", got)
+	}
+}
+
+func TestGetChecksFallbackEmptyRollup(t *testing.T) {
+	t.Parallel()
+
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		"gh pr checks 123 --json name,state,bucket,completedAt": {
+			stderr: "unknown flag: --json\n",
+			code:   1,
+		},
+		"gh pr view 123 --json statusCheckRollup": {
+			stdout: `{"statusCheckRollup":[]}` + "\n",
+		},
+	}), nil, "", "")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
+	if err != nil {
+		t.Fatalf("GetChecks() error = %v", err)
+	}
+	if len(checks) != 0 {
+		t.Fatalf("checks = %+v, want empty slice", checks)
+	}
+}
+
+func TestGetChecksFallbackUnknownStatePends(t *testing.T) {
+	t.Parallel()
+
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		"gh pr checks 123 --json name,state,bucket,completedAt": {
+			stderr: "unknown flag: --json\n",
+			code:   1,
+		},
+		"gh pr view 123 --json statusCheckRollup": {
+			stdout: `{"statusCheckRollup":[{"__typename":"CheckRun","name":"future-check","conclusion":"SOME_FUTURE_STATE"}]}` + "\n",
+		},
+	}), nil, "", "")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
+	if err != nil {
+		t.Fatalf("GetChecks() error = %v", err)
+	}
+	if len(checks) != 1 {
+		t.Fatalf("len(checks) = %d, want 1", len(checks))
+	}
+	// An unmapped bucket must never surface as "" (which downstream
+	// aggregation treats as PASSED); it must coerce to pending so an
+	// unrecognized future gh enum value keeps polling instead of
+	// green-lighting the merge gate.
+	if checks[0].Bucket != scm.CheckBucketPending {
+		t.Fatalf("checks[0].Bucket = %q, want %q", checks[0].Bucket, scm.CheckBucketPending)
+	}
+}
+
 func TestGetChecksParsesCompletedAt(t *testing.T) {
 	t.Parallel()
 
@@ -421,6 +551,31 @@ func githubTestCmdFactory(responses map[string]githubTestResponse) CmdFactory {
 		)
 		return cmd
 	}
+}
+
+// githubTestCmdFactoryWithCounts wraps githubTestCmdFactory, additionally
+// recording how many times each exact "name args..." command line was
+// invoked, keyed the same way as the responses map. Used to assert
+// memoization (a command attempted at most once) rather than just its
+// eventual output.
+func githubTestCmdFactoryWithCounts(responses map[string]githubTestResponse, counts map[string]*int) CmdFactory {
+	inner := githubTestCmdFactory(responses)
+	return func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		key := strings.TrimSpace(name + " " + strings.Join(args, " "))
+		if counts[key] == nil {
+			n := 0
+			counts[key] = &n
+		}
+		*counts[key]++
+		return inner(ctx, name, args...)
+	}
+}
+
+func countOf(counts map[string]*int, key string) int {
+	if n := counts[key]; n != nil {
+		return *n
+	}
+	return 0
 }
 
 func TestGitHubHelperProcess(t *testing.T) {

--- a/workflow_no_mistakes_required_test.go
+++ b/workflow_no_mistakes_required_test.go
@@ -71,6 +71,31 @@ func TestNoMistakesRequiredWorkflowReadsPRBodyViaEnv(t *testing.T) {
 	}
 }
 
+// TestNoMistakesRequiredWorkflowRechecksLiveBody pins the stale-snapshot
+// fallback: the no-mistakes pipeline pushes the branch (firing synchronize)
+// before its PR step rewrites the PR description, so the event payload's body
+// snapshot can be momentarily stale. The check must poll the live PR body via
+// the API before declaring a violation, rather than relying on a follow-up
+// edited event being delivered.
+func TestNoMistakesRequiredWorkflowRechecksLiveBody(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/no-mistakes-required.yml")
+	if err != nil {
+		t.Fatalf("read workflow: %v", err)
+	}
+	content := string(data)
+
+	needles := []string{
+		`gh api "repos/${REPO}/pulls/${PR_NUMBER}"`,
+		"GH_TOKEN: ${{ github.token }}",
+		"pull-requests: read",
+	}
+	for _, needle := range needles {
+		if !strings.Contains(content, needle) {
+			t.Errorf("workflow must re-check the live PR body before failing; missing %q", needle)
+		}
+	}
+}
+
 // TestNoMistakesRequiredWorkflowTriggersOnRelevantPREvents ensures the check
 // re-runs when the PR body is edited so a contributor cannot bypass by opening
 // clean then editing the body.


### PR DESCRIPTION
## What Changed

- `GetChecks` now detects gh CLIs older than v2.50.0 (which lack `gh pr checks --json`) via the `unknown flag: --json` stderr, memoizes that per Host, and reads checks through `gh pr view --json statusCheckRollup` instead; on both paths, check buckets are whitelisted and unrecognized or empty states coerce to pending so a future gh state keeps polling rather than silently green-lighting the merge gate.
- CI-poll errors from gh (`pr view`, `pr checks`, `statusCheckRollup`, mergeable) now append the first non-empty stderr line, compacted to 200 bytes with UTF-8 rune-boundary truncation, instead of a bare exit status; `no-mistakes doctor` additionally warns when the installed gh predates 2.50.0 and names the fallback.
- The `no-mistakes-required` workflow now polls the live PR body (12×20s via `gh api`) before declaring a violation, tolerating stale event-payload body snapshots; reference docs cover the fallback, the doctor warning, and the richer poll errors.

## Risk Assessment

✅ Low: A well-bounded gh-CLI compatibility fallback whose failure modes are all fail-safe (unknown states pend rather than pass, fetch errors surface as warnings), with thorough unit coverage of the boundary version, both unknown-state paths, memoization, and error formatting; only minor cleanup-level findings remain.

## Testing

Completed 1 recorded test check.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ℹ️ `internal/scm/github/github.go:353` - The empty-bucket-to-pending coercion (and its multi-line safety comment) is duplicated at both call sites of normalizeCheckBucket (lines 348-356 and 398-408). These are the only two callers and &#34;&#34; is now the only fallthrough value after the whitelist rewrite, so the pending default and rationale can move into normalizeCheckBucket&#39;s default branch, deleting both duplicated blocks.
- ℹ️ `.github/workflows/no-mistakes-required.yml:53` - The live-body poll runs `gh api ... 2&gt;/dev/null || true`, so if all 12 attempts fail due to a token or API error the job declares a no-mistakes violation with no trace that the API calls were failing. Logging the gh api failure (e.g. echoing stderr or a per-attempt failure note) would keep a false violation diagnosable, consistent with this branch&#39;s goal of surfacing gh stderr in poll errors.
- ℹ️ `.github/workflows/no-mistakes-required.yml:49` - The 12x20s live-body polling loop runs to exhaustion on every PR that genuinely lacks the marker, so the required check now takes ~4 minutes to fail (and consumes runner time) on every external/non-no-mistakes PR push instead of failing immediately. This is a deliberate tradeoff to tolerate the stale event-snapshot race and is explained in the workflow comment; noting the cost only.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
