### PR TITLE
feat(agent): route opencode --model override to message API, not serve

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,10 @@ Safest local verification sequence after non-trivial changes:
 - `internal/git`, `internal/ipc`, `internal/config`, `internal/db`, `internal/paths`, `internal/types`: shared infrastructure
 - `internal/tui`: terminal UI
 
+**OpenCode Model Override**
+
+- `opencode serve` does not accept top-level run/tui flags like `--model`/`-m`. The OpenCode adapter parses `agent_args_override` entries of the form `--model <provider/model>`, `--model=<provider/model>`, `-m <provider/model>`, or `-m=<provider/model>` in `opencodeModelOverrideFromArgs` (`internal/agent/opencode_http.go`), strips them from the serve argv via `stripOpencodeModelArgs` so only serve-compatible extras (e.g. `--log-level`) reach `serve`, and sends the override on the message API payload as `model.providerID`/`model.modelID`. With no `--model` present, behavior is unchanged. Do not forward `--model`/`-m` to `serve` and do not swap OpenCode for another agent to set a model.
+
 **Fork Routing**
 
 - `repos.upstream_url` is the parent repository used for PR base routing.

--- a/internal/agent/opencode_http.go
+++ b/internal/agent/opencode_http.go
@@ -30,13 +30,78 @@ func (a *opencodeAgent) ensureServer(ctx context.Context, cwd string) (string, e
 }
 
 // buildOpencodeServeArgs builds `opencode serve`'s argv with user-supplied
-// extras inserted after the "serve" subcommand and before the managed flags.
+// server extras inserted after the "serve" subcommand and before the managed
+// flags. Top-level run/tui flags such as --model are handled on the message
+// request instead of being forwarded to `serve`, which does not accept them.
 func buildOpencodeServeArgs(extraArgs []string, port int) []string {
-	args := make([]string, 0, len(extraArgs)+6)
+	serverArgs := stripOpencodeModelArgs(extraArgs)
+	args := make([]string, 0, len(serverArgs)+6)
 	args = append(args, "serve")
-	args = append(args, extraArgs...)
+	args = append(args, serverArgs...)
 	args = append(args, "--hostname", "127.0.0.1", "--port", fmt.Sprintf("%d", port), "--print-logs")
 	return args
+}
+
+type opencodeModelOverride struct {
+	providerID string
+	modelID    string
+}
+
+// stripOpencodeModelArgs drops --model/-m (and their values) from extraArgs so
+// `opencode serve` never receives run/tui-only flags it does not understand.
+func stripOpencodeModelArgs(extraArgs []string) []string {
+	if len(extraArgs) == 0 {
+		return nil
+	}
+	filtered := make([]string, 0, len(extraArgs))
+	for i := 0; i < len(extraArgs); i++ {
+		arg := extraArgs[i]
+		switch {
+		case arg == "--model" || arg == "-m":
+			if i+1 < len(extraArgs) {
+				i++
+			}
+			continue
+		case strings.HasPrefix(arg, "--model=") || strings.HasPrefix(arg, "-m="):
+			continue
+		default:
+			filtered = append(filtered, arg)
+		}
+	}
+	return filtered
+}
+
+// opencodeModelOverrideFromArgs parses the first --model/-m (in long, equals,
+// or short form) into a provider/model override. It returns nil when no model
+// flag is present so callers can preserve the default behavior.
+func opencodeModelOverrideFromArgs(extraArgs []string) (*opencodeModelOverride, error) {
+	var model string
+	for i := 0; i < len(extraArgs); i++ {
+		arg := extraArgs[i]
+		switch {
+		case arg == "--model" || arg == "-m":
+			if i+1 >= len(extraArgs) {
+				return nil, fmt.Errorf("opencode %s requires a provider/model value", arg)
+			}
+			i++
+			model = strings.TrimSpace(extraArgs[i])
+		case strings.HasPrefix(arg, "--model="):
+			model = strings.TrimSpace(strings.TrimPrefix(arg, "--model="))
+		case strings.HasPrefix(arg, "-m="):
+			model = strings.TrimSpace(strings.TrimPrefix(arg, "-m="))
+		}
+	}
+	if model == "" {
+		return nil, nil
+	}
+	parts := strings.SplitN(model, "/", 2)
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return nil, fmt.Errorf("opencode --model must be provider/model, got %q", model)
+	}
+	return &opencodeModelOverride{
+		providerID: strings.TrimSpace(parts[0]),
+		modelID:    strings.TrimSpace(parts[1]),
+	}, nil
 }
 
 func (a *opencodeAgent) createSession(ctx context.Context, baseURL, cwd string) (string, error) {
@@ -85,6 +150,16 @@ func (a *opencodeAgent) sendMessage(ctx context.Context, baseURL, sessionID, pro
 	body := map[string]any{
 		"role":  "user",
 		"parts": []map[string]string{{"type": "text", "text": prompt}},
+	}
+	model, err := opencodeModelOverrideFromArgs(a.extraArgs)
+	if err != nil {
+		return nil, err
+	}
+	if model != nil {
+		body["model"] = map[string]string{
+			"providerID": model.providerID,
+			"modelID":    model.modelID,
+		}
 	}
 	if len(schema) > 0 {
 		body["format"] = map[string]any{

--- a/internal/agent/opencode_test.go
+++ b/internal/agent/opencode_test.go
@@ -105,6 +105,62 @@ func TestOpencodeAgent_FullFlow(t *testing.T) {
 	}
 }
 
+func TestOpencodeAgent_MessageUsesModelOverride(t *testing.T) {
+	messageBodies := make(chan map[string]any, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/session" && r.Method == http.MethodPost:
+			fmt.Fprint(w, `{"id":"s1"}`)
+
+		case r.URL.Path == "/global/event" && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "text/event-stream")
+			fmt.Fprint(w, "data: {\"payload\":{\"type\":\"session.idle\"}}\n\n")
+
+		case r.URL.Path == "/session/s1/message" && r.Method == http.MethodPost:
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode message body: %v", err)
+			}
+			messageBodies <- body
+			fmt.Fprint(w, `{"info":{"id":"msg1","role":"assistant"},"parts":[{"type":"text","text":"done"}]}`)
+
+		case r.URL.Path == "/session/s1" && r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	a := &opencodeAgent{
+		bin:       "opencode",
+		extraArgs: []string{"--model", "litellm/gpt-5.4-xhigh"},
+		server:    &managedServer{port: mustParsePort(server.URL)},
+	}
+
+	result, err := a.Run(context.Background(), RunOpts{
+		Prompt: "hello",
+		CWD:    t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Text != "done" {
+		t.Fatalf("expected result text done, got %q", result.Text)
+	}
+
+	body := <-messageBodies
+	model, ok := body["model"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected model object in message body, got %#v", body["model"])
+	}
+	if model["providerID"] != "litellm" || model["modelID"] != "gpt-5.4-xhigh" {
+		t.Fatalf("model = %#v, want litellm/gpt-5.4-xhigh", model)
+	}
+}
+
 func TestOpencodeAgent_BackfillsAssistantTextWhenStreamCannotClassifyOrphans(t *testing.T) {
 	calledPaths := make(map[string]bool)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/agent/servearg_test.go
+++ b/internal/agent/servearg_test.go
@@ -39,15 +39,104 @@ func TestBuildOpencodeServeArgs_Default(t *testing.T) {
 }
 
 func TestBuildOpencodeServeArgs_ExtraArgsInserted(t *testing.T) {
-	got := buildOpencodeServeArgs([]string{"--model", "gpt-5"}, 9999)
+	got := buildOpencodeServeArgs([]string{"--log-level", "DEBUG"}, 9999)
 	want := []string{
 		"serve",
-		"--model", "gpt-5",
+		"--log-level", "DEBUG",
 		"--hostname", "127.0.0.1",
 		"--port", "9999",
 		"--print-logs",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("buildOpencodeServeArgs = %v, want %v", got, want)
+	}
+}
+
+func TestBuildOpencodeServeArgs_ModelArgsNotPassedToServe(t *testing.T) {
+	got := buildOpencodeServeArgs([]string{"--model", "litellm/gpt-5.4-xhigh", "--log-level", "DEBUG"}, 9999)
+	want := []string{
+		"serve",
+		"--log-level", "DEBUG",
+		"--hostname", "127.0.0.1",
+		"--port", "9999",
+		"--print-logs",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildOpencodeServeArgs = %v, want %v", got, want)
+	}
+}
+
+func TestOpencodeModelOverrideFromArgs(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		wantProvider string
+		wantModel    string
+		wantErr      bool
+	}{
+		{
+			name:         "long form",
+			args:         []string{"--model", "litellm/gpt-5.4-xhigh"},
+			wantProvider: "litellm",
+			wantModel:    "gpt-5.4-xhigh",
+		},
+		{
+			name:         "equals form",
+			args:         []string{"--model=litellm/glm-5.2-xhigh"},
+			wantProvider: "litellm",
+			wantModel:    "glm-5.2-xhigh",
+		},
+		{
+			name:         "short form",
+			args:         []string{"-m", "litellm/kimi-k2.7-code"},
+			wantProvider: "litellm",
+			wantModel:    "kimi-k2.7-code",
+		},
+		{
+			name:         "short equals form",
+			args:         []string{"-m=litellm/gpt-5.4-xhigh"},
+			wantProvider: "litellm",
+			wantModel:    "gpt-5.4-xhigh",
+		},
+		{
+			name: "absent",
+			args: []string{"--log-level", "DEBUG"},
+		},
+		{
+			name:    "missing value",
+			args:    []string{"--model"},
+			wantErr: true,
+		},
+		{
+			name:    "invalid value",
+			args:    []string{"--model", "gpt-5.4-xhigh"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := opencodeModelOverrideFromArgs(tt.args)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantProvider == "" && tt.wantModel == "" {
+				if got != nil {
+					t.Fatalf("expected nil model override, got %#v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected model override")
+			}
+			if got.providerID != tt.wantProvider || got.modelID != tt.wantModel {
+				t.Fatalf("model override = %#v, want provider=%q model=%q", got, tt.wantProvider, tt.wantModel)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

`opencode serve` rejects top-level run/tui flags like `--model`/`-m`, so configuring the OpenCode agent with an `agent_args_override` such as `--model litellm/gpt-5.4-xhigh` broke `serve` entirely. This routes the override correctly instead.

## Changes

- Parse `--model <provider/model>`, `--model=<provider/model>`, `-m <provider/model>`, and `-m=<provider/model>` from `agent_args_override` (`opencodeModelOverrideFromArgs`).
- Strip those flags from the `opencode serve` argv (`stripOpencodeModelArgs`) so only serve-compatible extras (e.g. `--log-level`) reach `serve`. `--model`/`-m` are never forwarded to `serve`.
- Send the parsed override on the OpenCode message API payload as `model.providerID` / `model.modelID`.
- Preserve existing behavior when no `--model` is configured (returns `nil`, no payload field, no stripping).
- OpenCode is not swapped for Codex or any other agent.

## Tests

- `TestBuildOpencodeServeArgs_ModelArgsNotPassedToServe` — serve-arg filtering.
- `TestBuildOpencodeModelOverrideFromArgs` — long/equals/short/short-equals/absent/missing-value/invalid-value parsing.
- `TestOpencodeAgent_MessageUsesModelOverride` — message API payload carries `model.providerID`/`model.modelID`.

## Validation

- `gofmt -l .` clean; `go vet ./...` clean; `make lint` (skill drift + vet) green.
- `go test -race ./internal/agent ./internal/config ./cmd/no-mistakes` — pass.
- `go test -race ./...` — pass (exit 0, 31 packages ok, no failures).
- `go build -o ./bin/no-mistakes ./cmd/no-mistakes` — pass.

## Notes

- Built on top of the current default branch, which already includes #375 (bumped `format.retryCount` 1→2 and added `TestOpencodeAgent_StructuredOutputError`). That change is preserved as-is; this PR only adds the model-override routing.