### PR TITLE
fix(daemon): recover runless gate branches

### DIFF
--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -202,9 +202,10 @@ func preflightGuard(ctx context.Context, env *axiEnv, branch string) func(*cobra
 }
 
 // triggerRun starts a fresh run for branch: it pushes the current HEAD through
-// the gate to trigger a pipeline, and falls back to a rerun when the push was a
-// no-op (the gate already had this commit). Callers must check for an existing
-// active run first (see activeRunID) and apply pre-flight guards.
+// the gate to trigger a pipeline, and directly asks the daemon to start one
+// when the push produced no notification-backed run (for example, an
+// up-to-date retry after a prior notify-push failure). Callers must check for
+// an existing active run first (see activeRunID) and apply pre-flight guards.
 func triggerRun(ctx context.Context, env *axiEnv, branch, headSHA string, skipSteps []types.StepName, intent string) (string, error) {
 	pushOptions := formatSkipPushOptions(skipSteps)
 	if opt := formatIntentPushOption(intent); opt != "" {
@@ -219,13 +220,19 @@ func triggerRun(ctx context.Context, env *axiEnv, branch, headSHA string, skipSt
 		return "", fmt.Errorf("push %q to gate: %v", branch, pushErr)
 	}
 
-	// No run appeared: the push was likely up-to-date. Rerun the latest gate
-	// head so `axi run` is still useful when there are no new commits.
-	var rr ipc.RerunResult
-	if err := env.client.Call(ipc.MethodRerun, rerunParams(env.repo.ID, branch, skipSteps, intent), &rr); err != nil {
+	// No run appeared: the push was likely up-to-date, or an earlier
+	// post-receive notification failed after delivering the ref. Start a run
+	// directly against the already-present gate head so the branch is not stuck
+	// in delivered-but-runless limbo.
+	gatePath, err := canonicalNotifyGatePath(env.p.RepoDir(env.repo.ID))
+	if err != nil {
+		return "", err
+	}
+	var sr ipc.StartRunResult
+	if err := env.client.Call(ipc.MethodStartRun, startRunParams(gatePath, branch, headSHA, skipSteps, intent), &sr); err != nil {
 		return "", fmt.Errorf("no run started for %q: %v", branch, err)
 	}
-	return rr.RunID, nil
+	return sr.RunID, nil
 }
 
 func waitForActiveRunForHead(ctx context.Context, client *ipc.Client, repoID, branch, headSHA string, timeout time.Duration) (*ipc.RunInfo, error) {
@@ -266,6 +273,10 @@ func activeRunLookupParams(repoID, branch string) *ipc.GetActiveRunParams {
 
 func rerunParams(repoID, branch string, skipSteps []types.StepName, intent string) *ipc.RerunParams {
 	return &ipc.RerunParams{RepoID: repoID, Branch: branch, SkipSteps: skipSteps, Intent: intent}
+}
+
+func startRunParams(gate, branch, headSHA string, skipSteps []types.StepName, intent string) *ipc.StartRunParams {
+	return &ipc.StartRunParams{Gate: gate, Branch: branch, HeadSHA: headSHA, SkipSteps: skipSteps, Intent: intent}
 }
 
 // driveRun polls a run until it reaches an approval gate, a terminal state, or

--- a/internal/cli/axi_test.go
+++ b/internal/cli/axi_test.go
@@ -337,6 +337,16 @@ func TestRerunParamsIncludeSkipSteps(t *testing.T) {
 	}
 }
 
+func TestStartRunParamsIncludeGateHeadAndSkipSteps(t *testing.T) {
+	params := startRunParams("/tmp/repo.git", "feature/x", "abc123", []types.StepName{types.StepReview}, "user goal")
+	if params.Gate != "/tmp/repo.git" || params.Branch != "feature/x" || params.HeadSHA != "abc123" || params.Intent != "user goal" {
+		t.Fatalf("unexpected start run params: %#v", params)
+	}
+	if len(params.SkipSteps) != 1 || params.SkipSteps[0] != types.StepReview {
+		t.Fatalf("SkipSteps = %#v, want review", params.SkipSteps)
+	}
+}
+
 func TestPreflightGuardReportsWorkingTreeCheckError(t *testing.T) {
 	t.Chdir(t.TempDir())
 

--- a/internal/cli/daemon_cmd.go
+++ b/internal/cli/daemon_cmd.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/daemon"
@@ -57,6 +58,10 @@ func newDaemonNotifyPushCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			gatePath, err := canonicalNotifyGatePath(gate)
+			if err != nil {
+				return err
+			}
 
 			p, err := paths.New()
 			if err != nil {
@@ -71,7 +76,7 @@ func newDaemonNotifyPushCmd() *cobra.Command {
 
 			var result ipc.PushReceivedResult
 			return client.Call(ipc.MethodPushReceived, &ipc.PushReceivedParams{
-				Gate:      gate,
+				Gate:      gatePath,
 				Ref:       ref,
 				Old:       oldSHA,
 				New:       newSHA,
@@ -92,6 +97,20 @@ func newDaemonNotifyPushCmd() *cobra.Command {
 	_ = cmd.MarkFlagRequired("new")
 
 	return cmd
+}
+
+func canonicalNotifyGatePath(gate string) (string, error) {
+	if strings.TrimSpace(gate) == "" {
+		return "", fmt.Errorf("empty gate path")
+	}
+	abs, err := filepath.Abs(gate)
+	if err != nil {
+		return "", fmt.Errorf("resolve gate path %q: %w", gate, err)
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		abs = resolved
+	}
+	return filepath.Clean(abs), nil
 }
 
 func parseSkipPushOptions(options []string) ([]types.StepName, error) {

--- a/internal/cli/daemon_cmd_test.go
+++ b/internal/cli/daemon_cmd_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -25,6 +27,37 @@ func TestParseSkipPushOptionsRejectsUnknownStep(t *testing.T) {
 	_, err := parseSkipPushOptions([]string{"no-mistakes.skip=test,deploy"})
 	if err == nil {
 		t.Fatal("expected unknown step to fail")
+	}
+}
+
+func TestCanonicalNotifyGatePathResolvesRelativeGateFromHookCWD(t *testing.T) {
+	bare := filepath.Join(t.TempDir(), "repo.git")
+	if err := os.MkdirAll(bare, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(bare); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	got, err := canonicalNotifyGatePath(".")
+	if err != nil {
+		t.Fatalf("canonicalNotifyGatePath(.): %v", err)
+	}
+	if !filepath.IsAbs(got) {
+		t.Fatalf("canonical gate path = %q, want absolute", got)
+	}
+	want, err := filepath.EvalSymlinks(bare)
+	if err != nil {
+		want = bare
+	}
+	if got != want {
+		t.Fatalf("canonical gate path = %q, want %q", got, want)
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -421,6 +421,19 @@ func registerHandlers(srv *ipc.Server, mgr *RunManager, d *db.DB, shutdown func(
 		return &ipc.PushReceivedResult{RunID: runID}, nil
 	})
 
+	srv.Handle(ipc.MethodStartRun, func(ctx context.Context, params json.RawMessage) (interface{}, error) {
+		var p ipc.StartRunParams
+		if err := json.Unmarshal(params, &p); err != nil {
+			return nil, fmt.Errorf("invalid params: %w", err)
+		}
+		slog.Info("start run", "branch", p.Branch, "head", p.HeadSHA, "gate", p.Gate)
+		runID, err := mgr.HandleStartRun(ctx, &p)
+		if err != nil {
+			return nil, err
+		}
+		return &ipc.StartRunResult{RunID: runID}, nil
+	})
+
 	srv.Handle(ipc.MethodRespond, func(_ context.Context, params json.RawMessage) (interface{}, error) {
 		var p ipc.RespondParams
 		if err := json.Unmarshal(params, &p); err != nil {

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -139,11 +140,51 @@ func (m *RunManager) closeSubscribers(runID string) {
 // repoIDFromGatePath extracts the repo ID from a gate bare repo path.
 // Gate paths look like: <root>/repos/<id>.git
 func repoIDFromGatePath(gatePath string) (string, error) {
-	base := filepath.Base(gatePath)
+	clean := filepath.Clean(strings.TrimSpace(gatePath))
+	if clean == "." || !filepath.IsAbs(clean) {
+		return "", fmt.Errorf("invalid gate path: %s", gatePath)
+	}
+	base := filepath.Base(clean)
 	if !strings.HasSuffix(base, ".git") {
 		return "", fmt.Errorf("invalid gate path: %s", gatePath)
 	}
 	return strings.TrimSuffix(base, ".git"), nil
+}
+
+func sameGatePath(a, b string) bool {
+	cleanA := filepath.Clean(a)
+	cleanB := filepath.Clean(b)
+	if cleanA == cleanB {
+		return true
+	}
+	if resolvedA, err := filepath.EvalSymlinks(cleanA); err == nil {
+		cleanA = resolvedA
+	}
+	if resolvedB, err := filepath.EvalSymlinks(cleanB); err == nil {
+		cleanB = resolvedB
+	}
+	if cleanA == cleanB {
+		return true
+	}
+	infoA, errA := os.Stat(cleanA)
+	infoB, errB := os.Stat(cleanB)
+	return errA == nil && errB == nil && os.SameFile(infoA, infoB)
+}
+
+func (m *RunManager) repoFromGatePath(gatePath string) (*db.Repo, error) {
+	repoID, err := repoIDFromGatePath(gatePath)
+	if err != nil {
+		return nil, err
+	}
+
+	repo, err := m.db.GetRepo(repoID)
+	if err != nil {
+		return nil, fmt.Errorf("get repo: %w", err)
+	}
+	if repo == nil || !sameGatePath(gatePath, m.paths.RepoDir(repoID)) {
+		return nil, fmt.Errorf("unknown repo for gate %s", gatePath)
+	}
+	return repo, nil
 }
 
 // branchFromRef extracts the branch name from a full git ref.
@@ -199,21 +240,51 @@ func (m *RunManager) HandlePushReceived(ctx context.Context, params *ipc.PushRec
 		return "", fmt.Errorf("ref deletion push, no pipeline to run")
 	}
 
-	repoID, err := repoIDFromGatePath(params.Gate)
+	repo, err := m.repoFromGatePath(params.Gate)
 	if err != nil {
 		return "", err
 	}
 
-	repo, err := m.db.GetRepo(repoID)
-	if err != nil {
-		return "", fmt.Errorf("get repo: %w", err)
-	}
-	if repo == nil {
-		return "", fmt.Errorf("unknown repo for gate %s", params.Gate)
-	}
-
 	branch := branchFromRef(params.Ref)
 	return m.startRun(ctx, repo, branch, params.New, params.Old, "push", params.SkipSteps, params.Intent)
+}
+
+// HandleStartRun creates a run for a gate branch that is already present in
+// the bare repo. Unlike push_received, it does not depend on post-receive
+// firing for this request; it verifies the requested head against the gate ref
+// before creating the run.
+func (m *RunManager) HandleStartRun(ctx context.Context, params *ipc.StartRunParams) (string, error) {
+	repo, err := m.repoFromGatePath(params.Gate)
+	if err != nil {
+		return "", err
+	}
+
+	branch := branchFromRef(params.Branch)
+	if strings.TrimSpace(branch) == "" {
+		return "", fmt.Errorf("missing branch")
+	}
+	headSHA := strings.TrimSpace(params.HeadSHA)
+	if headSHA == "" || git.IsZeroSHA(headSHA) {
+		return "", fmt.Errorf("invalid head SHA: %s", params.HeadSHA)
+	}
+
+	gateHead, err := m.resolveGateHead(ctx, repo.ID, branch)
+	if err != nil {
+		return "", err
+	}
+	if gateHead != headSHA {
+		return "", fmt.Errorf("gate head mismatch for %s: gate has %s, requested %s", branch, gateHead, headSHA)
+	}
+
+	baseSHA := strings.TrimSpace(params.BaseSHA)
+	if baseSHA == "" {
+		baseSHA, err = m.baseForBranchHead(repo.ID, branch, headSHA)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return m.startRun(ctx, repo, branch, headSHA, baseSHA, "start_run", params.SkipSteps, params.Intent)
 }
 
 // HandleRerun creates a new run for the latest gate head on a branch. An
@@ -227,12 +298,29 @@ func (m *RunManager) HandleRerun(ctx context.Context, repoID, branch string, ski
 		return "", fmt.Errorf("unknown repo %s", repoID)
 	}
 
-	gateDir := m.paths.RepoDir(repo.ID)
+	headSHA, err := m.resolveGateHead(ctx, repo.ID, branch)
+	if err != nil {
+		return "", err
+	}
+
+	baseSHA, err := m.baseForBranchHead(repoID, branch, headSHA)
+	if err != nil {
+		return "", err
+	}
+
+	return m.startRun(ctx, repo, branch, headSHA, baseSHA, "rerun", skipSteps, intent)
+}
+
+func (m *RunManager) resolveGateHead(ctx context.Context, repoID, branch string) (string, error) {
+	gateDir := m.paths.RepoDir(repoID)
 	headSHA, err := git.Run(ctx, gateDir, "rev-parse", "refs/heads/"+branch+"^{commit}")
 	if err != nil {
 		return "", fmt.Errorf("resolve gate head: %w", err)
 	}
+	return headSHA, nil
+}
 
+func (m *RunManager) baseForBranchHead(repoID, branch, headSHA string) (string, error) {
 	runs, err := m.db.GetRunsByRepo(repoID)
 	if err != nil {
 		return "", fmt.Errorf("get runs: %w", err)
@@ -253,15 +341,12 @@ func (m *RunManager) HandleRerun(ctx context.Context, repoID, branch string, ski
 		}
 	}
 	if latestForBranch == nil {
-		return "", fmt.Errorf("no previous run for branch %s", branch)
+		return "0000000000000000000000000000000000000000", nil
 	}
-
-	baseSHA := latestForBranch.BaseSHA
 	if matchingHead != nil {
-		baseSHA = matchingHead.BaseSHA
+		return matchingHead.BaseSHA, nil
 	}
-
-	return m.startRun(ctx, repo, branch, headSHA, baseSHA, "rerun", skipSteps, intent)
+	return latestForBranch.BaseSHA, nil
 }
 
 // startRun creates a run, sets up a worktree, and launches pipeline execution.

--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -123,6 +124,81 @@ func TestPushReceivedSkipStepsConfiguresExecutor(t *testing.T) {
 		if step.StepName == types.StepReview && step.Status != types.StepStatusSkipped {
 			t.Fatalf("review status = %s, want %s", step.Status, types.StepStatusSkipped)
 		}
+	}
+}
+
+func TestPushReceivedAbsoluteGatePathStableAcrossManyCalls(t *testing.T) {
+	step := &mockPassStep{name: types.StepReview}
+	p, d := startTestDaemonWithSteps(t, func() []pipeline.Step {
+		return []pipeline.Step{step}
+	})
+
+	const repoID = "stable-gate-path-repo"
+	_, headSHA := setupTestGitRepo(t, p, d, repoID)
+
+	client, err := ipc.Dial(p.Socket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	gatePath := p.RepoDir(repoID)
+	for i := 0; i < 25; i++ {
+		branch := fmt.Sprintf("feature/stable-%02d", i)
+		var result ipc.PushReceivedResult
+		if err := client.Call(ipc.MethodPushReceived, &ipc.PushReceivedParams{
+			Gate: gatePath,
+			Ref:  "refs/heads/" + branch,
+			Old:  "0000000000000000000000000000000000000000",
+			New:  headSHA,
+		}, &result); err != nil {
+			t.Fatalf("push %d with absolute gate path failed: %v", i, err)
+		}
+
+		run := waitForRunTerminalState(t, d, result.RunID)
+		if run.RepoID != repoID {
+			t.Fatalf("run repo ID = %q, want %q", run.RepoID, repoID)
+		}
+		if run.Branch != branch {
+			t.Fatalf("run branch = %q, want %q", run.Branch, branch)
+		}
+	}
+	if got := step.execCnt.Load(); got != 25 {
+		t.Fatalf("step executed %d times, want 25", got)
+	}
+}
+
+func TestPushReceivedRejectsAbsoluteGateWithRegisteredBasenameDifferentPath(t *testing.T) {
+	p, d := startTestDaemonWithSteps(t, func() []pipeline.Step {
+		return []pipeline.Step{&mockPassStep{name: types.StepReview}}
+	})
+
+	const repoID = "same-basename-repo"
+	_, headSHA := setupTestGitRepo(t, p, d, repoID)
+
+	wrongGate := filepath.Join(t.TempDir(), repoID+".git")
+	if err := os.MkdirAll(wrongGate, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	client, err := ipc.Dial(p.Socket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	var result ipc.PushReceivedResult
+	err = client.Call(ipc.MethodPushReceived, &ipc.PushReceivedParams{
+		Gate: wrongGate,
+		Ref:  "refs/heads/main",
+		Old:  "0000000000000000000000000000000000000000",
+		New:  headSHA,
+	}, &result)
+	if err == nil {
+		t.Fatalf("push with wrong absolute gate path unexpectedly created run %q", result.RunID)
+	}
+	if !strings.Contains(err.Error(), "unknown repo for gate") {
+		t.Fatalf("error = %v, want unknown repo for gate", err)
 	}
 }
 
@@ -355,6 +431,45 @@ func TestRerunSkipStepsConfiguresExecutor(t *testing.T) {
 		if step.StepName == types.StepReview && step.Status != types.StepStatusSkipped {
 			t.Fatalf("review status = %s, want %s", step.Status, types.StepStatusSkipped)
 		}
+	}
+}
+
+func TestRerunStartsFirstRunForDeliveredRunlessBranch(t *testing.T) {
+	step := &mockPassStep{name: types.StepReview}
+	p, d := startTestDaemonWithSteps(t, func() []pipeline.Step {
+		return []pipeline.Step{step}
+	})
+
+	const repoID = "delivered-runless-repo"
+	_, headSHA := setupTestGitRepo(t, p, d, repoID)
+
+	client, err := ipc.Dial(p.Socket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	var result ipc.RerunResult
+	if err := client.Call(ipc.MethodRerun, &ipc.RerunParams{
+		RepoID: repoID,
+		Branch: "main",
+		Intent: "validate the delivered branch",
+	}, &result); err != nil {
+		t.Fatalf("rerun should create first run for delivered branch with no run row: %v", err)
+	}
+	if result.RunID == "" {
+		t.Fatal("expected rerun result to contain a run ID")
+	}
+
+	run := waitForRunTerminalState(t, d, result.RunID)
+	if run.HeadSHA != headSHA {
+		t.Fatalf("run head = %q, want %q", run.HeadSHA, headSHA)
+	}
+	if run.BaseSHA != "0000000000000000000000000000000000000000" {
+		t.Fatalf("first run base = %q, want zero SHA", run.BaseSHA)
+	}
+	if got := step.execCnt.Load(); got != 1 {
+		t.Fatalf("step executed %d times, want 1", got)
 	}
 }
 

--- a/internal/e2e/axi_journey_test.go
+++ b/internal/e2e/axi_journey_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -173,6 +174,38 @@ func TestAxiAgentJourney(t *testing.T) {
 	}
 	if autoRun := h.WaitForRun("feature/axi-yes", 60*time.Second); autoRun.Status != types.RunCompleted {
 		t.Fatalf("feature/axi-yes run status = %s, want completed", autoRun.Status)
+	}
+}
+
+func TestAxiRunCreatesRunForDeliveredRunlessBranch(t *testing.T) {
+	h := NewHarness(t, SetupOpts{Agent: "claude", Scenario: cleanReviewScenario(t)})
+
+	h.CommitChange("init-axi-runless", "seed.txt", "seed\n", "seed for axi runless init")
+	initWorktree := h.AddWorktree("init-axi-runless")
+	if out, err := h.RunInDir(initWorktree, "init"); err != nil {
+		t.Fatalf("nm init: %v\n%s", err, out)
+	}
+
+	const branch = "feature/axi-runless"
+	head := h.CommitChange(branch, "runless.txt", "change\n", "add runless change")
+	worktree := h.AddWorktree(branch)
+
+	gateDir := filepath.Join(h.NMHome, "repos", h.repoID()+".git")
+	if out, err := h.runGit(context.Background(), gateDir, "fetch", h.WorkDir, branch+":refs/heads/"+branch); err != nil {
+		t.Fatalf("seed delivered gate ref without post-receive: %v\n%s", err, out)
+	}
+
+	out, err := h.RunInDir(worktree, "axi", "run", "--yes", "--intent", "validate the already delivered branch")
+	if err != nil {
+		t.Fatalf("axi run should create a run for delivered-but-runless branch: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "outcome: passed") {
+		t.Fatalf("axi run output should report a passing outcome, got:\n%s", out)
+	}
+
+	run := h.WaitForRun(branch, 60*time.Second)
+	if run.HeadSHA != head {
+		t.Fatalf("run head = %q, want %q", run.HeadSHA, head)
 	}
 }
 

--- a/internal/e2e/journey_test.go
+++ b/internal/e2e/journey_test.go
@@ -784,15 +784,11 @@ func assertRunsEmpty(t *testing.T, h *Harness) {
 
 func assertRerunNoPreviousRun(t *testing.T, h *Harness) {
 	t.Helper()
-	gateDir := filepath.Join(h.NMHome, "repos", h.repoID()+".git")
-	if out, err := h.runGit(context.Background(), gateDir, "fetch", h.WorkDir, "main:refs/heads/main"); err != nil {
-		t.Fatalf("seed gate main ref before rerun: %v\n%s", err, out)
-	}
 	out, err := h.Run("rerun")
 	if err == nil {
 		t.Fatalf("nm rerun before any push should fail, got output:\n%s", out)
 	}
-	for _, want := range []string{"rerun pipeline", "no previous run"} {
+	for _, want := range []string{"rerun pipeline", "resolve gate head"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("rerun error output should contain %q before any push, got:\n%s", want, out)
 		}

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -10,6 +10,7 @@ import (
 // JSON-RPC 2.0 method names.
 const (
 	MethodPushReceived = "push_received"
+	MethodStartRun     = "start_run"
 	MethodGetRun       = "get_run"
 	MethodGetRuns      = "get_runs"
 	MethodGetActiveRun = "get_active_run"
@@ -66,6 +67,19 @@ type PushReceivedParams struct {
 	Ref       string           `json:"ref"`
 	Old       string           `json:"old"`
 	New       string           `json:"new"`
+	SkipSteps []types.StepName `json:"skip_steps,omitempty"`
+	Intent    string           `json:"intent,omitempty"`
+}
+
+// StartRunParams directly starts a run for a gate ref that already exists.
+// It is used when a branch was delivered to the gate bare repo but no
+// post-receive notification created a run, such as an up-to-date retry after a
+// prior notify-push failure.
+type StartRunParams struct {
+	Gate      string           `json:"gate"`
+	Branch    string           `json:"branch"`
+	HeadSHA   string           `json:"head_sha"`
+	BaseSHA   string           `json:"base_sha,omitempty"`
 	SkipSteps []types.StepName `json:"skip_steps,omitempty"`
 	Intent    string           `json:"intent,omitempty"`
 }
@@ -132,6 +146,11 @@ type ShutdownParams struct{}
 
 // PushReceivedResult confirms the push was accepted.
 type PushReceivedResult struct {
+	RunID string `json:"run_id"`
+}
+
+// StartRunResult confirms a direct run was created.
+type StartRunResult struct {
 	RunID string `json:"run_id"`
 }
 

--- a/internal/ipc/protocol_test.go
+++ b/internal/ipc/protocol_test.go
@@ -392,6 +392,7 @@ func TestNullableFieldsOmitted(t *testing.T) {
 func TestMethodConstants(t *testing.T) {
 	methods := []string{
 		MethodPushReceived,
+		MethodStartRun,
 		MethodGetRun,
 		MethodGetRuns,
 		MethodGetActiveRun,
@@ -412,8 +413,8 @@ func TestMethodConstants(t *testing.T) {
 		}
 		seen[m] = true
 	}
-	if len(methods) != 10 {
-		t.Errorf("expected 10 methods, got %d", len(methods))
+	if len(methods) != 11 {
+		t.Errorf("expected 11 methods, got %d", len(methods))
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes `no-mistakes axi run` getting stuck when a branch ref is already in the gate bare repo but no validation run row exists, and hardens gate path resolution so push notifications map only to the registered bare repo.

No UI changes; screenshots are not applicable.

## Fix

- Canonicalize `daemon notify-push --gate` before IPC, so relative hook values like `.` are resolved while the helper is still running in the hook cwd.
- Validate daemon gate paths against the registered bare repo path instead of trusting only the `<id>.git` basename.
- Add a direct `start_run` IPC path for `axi run` recovery when a successful push produces no active run.
- Keep `rerun` useful for delivered-but-runless branches by starting a first run with the zero SHA base when the gate ref exists but no prior run row does.

## Validation

- `make lint`
- `go test -race ./...`
- `make e2e`
- `go build -o ./bin/no-mistakes ./cmd/no-mistakes`
- `make build`
- Manual repro with the built binary in an isolated `.manual-repro` `NM_HOME`: initialized a throwaway origin/work repo, started the daemon via `no-mistakes init`, pushed 12 fresh branches through the gate, and confirmed each push created a run.
