### PR TITLE
docs(config): document Codex speed and effort overrides

### DIFF
--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -205,8 +205,9 @@ acpx_path: /Users/you/bin/acpx
 
 You can also set extra CLI flags for native agents in global config with
 `agent_args_override`. This is useful for things like model selection,
-reasoning level, or permission mode. Keep this in global config only, since it
+service tier, reasoning level, or permission mode. Keep this in global config only, since it
 reflects your local agent setup rather than repo policy.
+For example, Codex users can pass `-c service_tier="priority"` to request the priority speed lane and separately pass `-c model_reasoning_effort="low"` to reduce reasoning depth. no-mistakes reloads global config while setting up each run, so you can adjust this file before a run or use separately initialized `NM_HOME` roots as named profiles.
 
 ## Agent interface
 
@@ -258,6 +259,7 @@ Spawns a `claude` subprocess for each invocation with `--output-format stream-js
 ## Codex
 
 Spawns a `codex` subprocess for each invocation with `exec --json`. When structured output is requested, no-mistakes also writes a normalized schema file and passes it with `--output-schema`. By default it also adds `--dangerously-bypass-approvals-and-sandbox`, unless you already set your own Codex approval or sandbox flag through `agent_args_override`. Reads JSONL events. Structured output is returned from the final `agent_message` text, with fallback parsing that accepts JSON fences, inline fence markers, or a final bare JSON object after prose, then validates the result against the normalized schema.
+Codex model and config overrides, such as `-m gpt-5.4`, `-c service_tier="priority"`, or `-c model_reasoning_effort="low"`, belong in global `agent_args_override.codex`.
 
 ## Rovo Dev
 

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -205,9 +205,10 @@ acpx_path: /Users/you/bin/acpx
 
 You can also set extra CLI flags for native agents in global config with
 `agent_args_override`. This is useful for things like model selection,
-service tier, reasoning level, or permission mode. Keep this in global config only, since it
+service tier, reasoning depth, or permission mode. Keep this in global config only, since it
 reflects your local agent setup rather than repo policy.
-For example, Codex users can pass `-c service_tier="priority"` to request the priority speed lane and separately pass `-c model_reasoning_effort="low"` to reduce reasoning depth. no-mistakes reloads global config while setting up each run, so you can adjust this file before a run or use separately initialized `NM_HOME` roots as named profiles.
+
+For example, Codex users can pass `-c service_tier="priority"` to request the priority speed lane and separately pass `-c model_reasoning_effort="low"` to reduce reasoning depth. no-mistakes reloads global config while setting up each run, so edit this file before starting a run. For repeatable fast or deep profiles, use separately initialized `NM_HOME` roots; each root has its own config and no-mistakes state.
 
 ## Agent interface
 

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -74,7 +74,10 @@ agent_args_override:
   codex:
     - -m
     - gpt-5.4
-    - --full-auto
+    - -c
+    - service_tier="priority"
+    - -c
+    - model_reasoning_effort="low"
 
 # How long the CI step monitors an open PR (provider CI status plus GitHub/GitLab
 # mergeability) with no base-branch movement before giving up. Each base-branch
@@ -171,6 +174,8 @@ See [Repo Config Reference](/no-mistakes/reference/repo-config/) for the full fi
 - ACP agents are opt-in with `agent: acp:<target>` and are not considered by `agent: auto`.
 - `agent_path_override`, `agent_args_override`, `acpx_path`, and `acp_registry_overrides` are global-only fields.
 - `ci_timeout`, `step_quiet_warning`, and `log_level` are global-only fields.
+- For Codex-backed pipeline agents, `service_tier` controls the speed or priority lane and `model_reasoning_effort` controls reasoning depth. Set both through `agent_args_override.codex` with separate `-c` entries.
+- no-mistakes reloads global config while setting up each run. To adjust Codex behavior for the next run, edit `~/.no-mistakes/config.yaml` before starting it. For repeatable profiles such as fast or deep, use separately initialized `NM_HOME` roots; `NM_HOME` moves all no-mistakes state, not just config.
 - `auto_fix` from the repo config overlays global auto_fix. Fields not set in the repo config fall through to the global default.
 - `intent` from the repo config overlays global intent settings. Fields not set in the repo config fall through to the global default, except `intent.disabled_readers`, which adds to globally disabled readers.
 - `test.evidence` from the repo config overlays global test evidence settings. Fields not set in the repo config fall through to the global default.

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -27,7 +27,10 @@ agent_args_override:
   codex:
     - -m
     - gpt-5.4
-    - --full-auto
+    - -c
+    - service_tier="priority"
+    - -c
+    - model_reasoning_effort="low"
 
 ci_timeout: "168h"
 
@@ -131,7 +134,7 @@ Default native binary names when no override is set:
 ### agent_args_override
 
 Extra CLI flags to pass to each native agent.
-Use this to set model selection, reasoning effort, permission mode, or any other flag the underlying agent supports.
+Use this to set model selection, service tier, reasoning effort, permission mode, or any other flag the underlying agent supports.
 
 | | |
 |---|---|
@@ -172,7 +175,10 @@ agent_args_override:
   codex:
     - -m
     - gpt-5.4
-    - --full-auto
+    - -c
+    - service_tier="priority"
+    - -c
+    - model_reasoning_effort="low"
   rovodev:
     - --profile
     - work
@@ -183,6 +189,8 @@ agent_args_override:
     - --provider
     - google
 ```
+
+For Codex, `service_tier` and `model_reasoning_effort` tune different things: `service_tier` selects the speed or priority lane, while `model_reasoning_effort` selects reasoning depth. no-mistakes reloads global config while setting up each run, so edits made before `no-mistakes axi run` apply to that run. For repeatable profiles, use separately initialized `NM_HOME` directories; each has its own `config.yaml` and no-mistakes state.
 
 ### ci_timeout
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -293,6 +293,7 @@ log_level: info
 #   codex: /opt/codex
 
 # Extra native agent CLI flags (optional, global only)
+# Codex service_tier controls speed/priority; model_reasoning_effort controls reasoning depth.
 # agent_args_override:
 #   codex:
 #     - -m

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -297,6 +297,10 @@ log_level: info
 #   codex:
 #     - -m
 #     - gpt-5.4
+#     - -c
+#     - service_tier="priority"
+#     - -c
+#     - model_reasoning_effort="low"
 #
 # Maximum follow-up auto-fix attempts per step (0 = disabled after the initial pass)
 # Document fixes are attempted during the initial document pass.

--- a/internal/config/config_args_override_test.go
+++ b/internal/config/config_args_override_test.go
@@ -21,7 +21,10 @@ agent_args_override:
   codex:
     - -m
     - gpt-5.4
-    - --full-auto
+    - -c
+    - service_tier="priority"
+    - -c
+    - model_reasoning_effort="low"
   rovodev:
     - --profile
     - work
@@ -40,7 +43,7 @@ agent_args_override:
 
 	cases := map[string][]string{
 		"claude":   {"--permission-mode", "acceptEdits"},
-		"codex":    {"-m", "gpt-5.4", "--full-auto"},
+		"codex":    {"-m", "gpt-5.4", "-c", `service_tier="priority"`, "-c", `model_reasoning_effort="low"`},
 		"rovodev":  {"--profile", "work"},
 		"opencode": {"--model", "gpt-5"},
 	}


### PR DESCRIPTION
## Intent

Document Codex no-mistakes agent config overrides correctly: `service_tier` is the speed or priority setting, `model_reasoning_effort` is reasoning depth, examples should show both through global `agent_args_override.codex`, and docs should explain how users can adjust global config before starting a run or use separately initialized `NM_HOME` roots for repeatable fast/deep profiles.

## What Changed

- Documented Codex `service_tier` and `model_reasoning_effort` overrides across the agent, configuration, and global config docs.
- Updated the default global config comments to show Codex priority and reasoning-depth settings through `agent_args_override.codex`.
- Adjusted config override tests to match the documented Codex override examples.

## Risk Assessment

Low: this clarifies docs and commented example config for existing Codex override behavior, with no material runtime behavior change beyond a test fixture update.

## Testing

- `go test ./internal/config`
- `make docs-build`
- `make lint`
- `go test ./...`
- no-mistakes run `01KWX727CR2W2W1KY3SZNMV830`: intent, rebase, review, test, document, lint, push, and PR steps passed; outcome `checks-passed`.
- Rendered-docs evidence checked for `service_tier`, `model_reasoning_effort`, priority lane, reasoning depth, `NM_HOME`, and `agent_args_override`. Local artifact paths and rendered HTML are intentionally omitted from the PR body.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.

- `go test -race ./...`
- `go test -race ./internal/config -run 'TestAgentArgsOverride|TestDefaultConfigYAML' -count=1`
- `npm ci` in `docs/`
- `npm run build` in `docs/`
- Rendered-docs scan for `service_tier`, `model_reasoning_effort`, priority lane, reasoning depth, `NM_HOME`, and `agent_args_override`
- `git status --short` after cleanup

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
