### PR TITLE
feat(cli): surface AXI step activity and auto-fix diagnostics

### DIFF
--- a/.no-mistakes/evidence/fm/nm-review-wedge-b6/axi-wedge-observability-transcript.txt
+++ b/.no-mistakes/evidence/fm/nm-review-wedge-b6/axi-wedge-observability-transcript.txt
@@ -1,0 +1,52 @@
+# AXI wedge observability transcript
+
+Synthetic executor run is still active in review auto-fix while these commands are captured.
+
+$ NM_HOME=.no-mistakes/evidence/fm/nm-review-wedge-b6/scratch/nmhome-live no-mistakes axi status --run 01KWXEBZEXXRRZ0HHK6HA47T43
+run:
+  id: "01KWXEBZEXXRRZ0HHK6HA47T43"
+  branch: fm/nm-review-wedge-b6
+  status: running
+  head: f688b96d
+  findings: 1 auto-fix
+  steps[1]{step,status,findings,duration_ms}:
+    review,fixing,1,0
+  active_steps[1]{step,status,active_for,last_activity,agent_pid,round}:
+    review,fixing,2s,"quiet 2s ago: log: codex started pid=4242","4242",auto-fix 1/2
+
+$ NM_HOME=.no-mistakes/evidence/fm/nm-review-wedge-b6/scratch/nmhome-live no-mistakes axi logs --run 01KWXEBZEXXRRZ0HHK6HA47T43 --step review --full   # while auto-fix is active
+step: review
+run: "01KWXEBZEXXRRZ0HHK6HA47T43"
+lines: 5 total
+log[5]{line}:
+  review agent found a fixable issue
+  ""
+  auto-fix round 1/2 starting after round 1 (1 finding)
+  ""
+  codex started pid=4242
+
+$ NM_HOME=.no-mistakes/evidence/fm/nm-review-wedge-b6/scratch/nmhome-live no-mistakes axi logs --run 01KWXEBZEXXRRZ0HHK6HA47T43 --step review --full   # after the native agent exits
+step: review
+run: "01KWXEBZEXXRRZ0HHK6HA47T43"
+lines: 7 total
+log[7]{line}:
+  review agent found a fixable issue
+  ""
+  auto-fix round 1/2 starting after round 1 (1 finding)
+  ""
+  codex started pid=4242
+  ""
+  codex exited pid=4242 status=success
+
+$ legacy-style row with no last_activity_at uses the review log mtime as activity fallback
+$ NM_HOME=.no-mistakes/evidence/fm/nm-review-wedge-b6/scratch/nmhome-mtime no-mistakes axi status --run 01KWXEET3BFZQ1QG2T3695T4CW
+run:
+  id: "01KWXEET3BFZQ1QG2T3695T4CW"
+  branch: fm/nm-review-wedge-b6
+  status: running
+  head: f688b96d
+  findings: none
+  steps[1]{step,status,findings,duration_ms}:
+    review,running,0,0
+  active_steps[1]{step,status,active_for,last_activity,agent_pid,round}:
+    review,running,4s,"quiet 3s ago: step log updated","",starting

--- a/docs/src/content/docs/concepts/auto-fix.md
+++ b/docs/src/content/docs/concepts/auto-fix.md
@@ -111,6 +111,8 @@ The push step commits any remaining uncommitted changes with `no-mistakes: apply
 Each execution of a step (initial run or follow-up auto-fix run) is recorded as a "round" in the database.
 A round stores its findings, duration, any selected finding IDs and whether that selection came from the user or auto-fix filtering, the merged finding payload actually sent to the fix agent for that round, and any one-line fix summary from that execution.
 That merged payload can include per-finding user notes and user-authored findings added from the TUI or AXI interface.
+AXI status uses the same round history and the persisted auto-fix limit to show the active fix attempt, for example `auto-fix 1/3` or `fix 2`.
+The step log records a marker when each automatic or user-triggered fix round starts.
 The PR body's deterministic risk assessment, testing, and pipeline sections are built from these rounds, giving reviewers visibility into test results, review risk, what was fixed, and how many attempts it took.
 In PR pipeline details, auto-fix rounds are rendered as an issue -> fix -> verification narrative instead of a round-numbered log: each fix summary is followed by either a successful re-check or the findings still open after that fix.
 On very long runs, the PR body uses a 63,488-byte safety cap, which leaves a 2 KB buffer below GitHub's 65,536-character body limit.

--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -58,6 +58,7 @@ That is a core design choice, not an implementation detail.
 6. If a step pauses, you can attach with the TUI or use `no-mistakes axi respond` to approve, fix, or skip.
    Use `no-mistakes axi abort` only when you mean to cancel the whole run.
    AXI run objects show `awaiting_agent: parked <duration>` while a non-terminal run is parked at that gate, so a supervising agent can distinguish a waiting run from active work in one status read.
+   While a step is actively running or fixing, AXI run objects can also show `active_steps` with the active duration, latest activity, native agent PID, and current execution or fix round.
 7. After local checks pass, the push step forwards the branch to the configured push target only after verifying that the update will not discard unincorporated commits already on that target, and the PR step creates or updates the pull request.
    For GitHub fork routing, the push target is the fork and the PR base repository is the parent from `origin`.
 8. The CI step keeps watching the open PR until it is merged, closed, or its configured idle timeout elapses with no base-branch movement, and can auto-fix failures or merge conflicts when supported.
@@ -149,6 +150,8 @@ branch, marking the remaining steps as skipped.
 
 While the executor is paused at an approval or fix-review gate, it persists a run-level awaiting-agent timestamp that AXI renders as `awaiting_agent: parked <duration>`.
 That timestamp is observability only and does not alter approval behavior.
+While a step is running or fixing, the executor also records the latest meaningful step activity from log lines and native subprocess lifecycle events.
+AXI renders that activity in `active_steps`, including a quiet prefix when no activity has arrived for longer than the configured `step_quiet_warning`.
 
 ### IPC
 
@@ -156,19 +159,14 @@ Communication between the CLI and daemon uses JSON-RPC 2.0 over the Unix socket.
 
 ### Database
 
-SQLite at `~/.no-mistakes/state.sqlite` tracks repos, runs, step results, step
-rounds, and derived intent summaries. Step rounds record each execution attempt
-(initial, auto-fix) with its own findings and duration, plus selected finding
-IDs, whether the selection came from the user or auto-fix filtering, the merged
-finding payload actually sent to the fix agent for that round, and the one-line
-fix summary for fix rounds. That merged payload can include per-finding user
-notes and user-authored findings from the TUI or AXI interface. Intent stores
-the summary, source, session ID, and match score on each run when transcript
-matching is used, plus cached summaries for matching transcript sessions. An
-agent-supplied AXI intent is stored directly on the run. Raw transcript text is
-not stored in this database. Legacy `user_fix` rounds are still read as
-`auto-fix` for backward
-compatibility.
+SQLite at `~/.no-mistakes/state.sqlite` tracks repos, runs, step results, step rounds, and derived intent summaries.
+Step rounds record each execution attempt (initial, auto-fix) with its own findings and duration, plus selected finding IDs, whether the selection came from the user or auto-fix filtering, the merged finding payload actually sent to the fix agent for that round, and the one-line fix summary for fix rounds.
+Step results also store the last active timestamp, last activity text, native agent PID while a subprocess is active, and the effective auto-fix limit used by AXI status.
+That merged payload can include per-finding user notes and user-authored findings from the TUI or AXI interface.
+Intent stores the summary, source, session ID, and match score on each run when transcript matching is used, plus cached summaries for matching transcript sessions.
+An agent-supplied AXI intent is stored directly on the run.
+Raw transcript text is not stored in this database.
+Legacy `user_fix` rounds are still read as `auto-fix` for backward compatibility.
 Run records also store the nullable `awaiting_agent_since` timestamp used only to render the AXI parked signal while a gate is waiting for the driving agent.
 Repo records store the parent `upstream_url` and an optional `fork_url`; branch pushes use `fork_url` when present, while PR and CI provider context stays anchored to the parent.
 

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -146,6 +146,9 @@ Approval gates are exposed as `gate:` objects with finding IDs, severities, file
 While a non-terminal run is parked at an `awaiting_approval` or `fix_review` gate, the run object also includes `awaiting_agent: parked <duration>`.
 Use that field in `axi status` output to tell in one read that the run is waiting for the driving agent to send `axi respond`, not actively running, fixing, or watching CI.
 It is observability only: it does not auto-resume the run, change gate resolution, or make `--yes` the default.
+While a step is actively `running` or `fixing`, `axi status` also includes `active_steps` with `active_for`, `last_activity`, native `agent_pid` when a subprocess agent is running, and the current round such as `round 1`, `auto-fix 1/3`, or `fix 2`.
+If `last_activity` is prefixed with `quiet`, no step-log or native-agent lifecycle activity has arrived for longer than `step_quiet_warning`.
+Treat that as a liveness clue for investigation, not as permission to cancel, rerun, or edit the worktree yourself.
 A long-running `axi run` or `axi respond` call is working, not stalled, and an agent may background it if its harness needs to, but the run never advances past a gate on its own, so the agent must read every return and respond at each `gate:`, looping until an `outcome:`, and never idle-wait for the run to move forward by itself.
 An agent should resolve `action: auto-fix` findings on its own judgment, ignore `action: no-op` findings when approving, and stop on `action: ask-user` findings unless it is running with explicit `--yes` consent.
 Review auto-fix is disabled by default (`auto_fix.review: 0`; a repo or global `auto_fix.review > 0` override re-enables it), so blocking and ask-user review findings park for your decision rather than being silently self-fixed.
@@ -214,6 +217,7 @@ All agents implement the same interface. Each invocation receives:
 - **Environment** - the daemon environment plus non-interactive Git overrides (`GIT_EDITOR=true`, `GIT_SEQUENCE_EDITOR=true`, and `GIT_TERMINAL_PROMPT=0`) so agent-invoked Git commands do not hang on editors or credential prompts
 - **JSONSchema** - optional structured output schema for typed responses
 - **OnChunk** - callback for streaming text output to the TUI
+- **OnLifecycle** - callback for native subprocess start, exit, and retry activity that is recorded in step logs and AXI active-step status
 
 Each invocation returns:
 
@@ -223,9 +227,10 @@ Each invocation returns:
 
 One-shot subprocess agents (Claude, Codex, Pi, Copilot CLI, and acpx) are invocation-scoped.
 After no-mistakes starts one, it terminates any remaining child processes when the invocation exits, fails, or is cancelled, so agent-spawned test workers, build watchers, and dev servers do not survive the step.
+Step logs record their process lifecycle, including start and exit lines with the PID, and AXI status exposes that PID while the subprocess is still active.
 Persistent server agents (Rovo Dev and OpenCode) use their managed server lifecycle instead.
 
-Transient API and network failures are retried up to three times with exponential backoff. Retry messages are streamed through the same `OnChunk` path shown in the TUI.
+Transient API and network failures are retried up to three times with exponential backoff. Retry messages are recorded as lifecycle activity for native subprocess agents, falling back to the streaming text path for direct callers that do not supply `OnLifecycle`.
 
 ## Intent extraction
 

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -14,6 +14,7 @@ work. Config exists for the parts that genuinely vary by machine or repo:
 - which test or lint commands are the canonical ones for this repo
 - where test evidence artifacts should be stored
 - how aggressive the auto-fix loop should be
+- how soon AXI should call an active step quiet
 - whether no-mistakes should infer intent from recent local agent transcripts
 
 Config is split across two files:
@@ -81,6 +82,10 @@ agent_args_override:
 # Use "unlimited" (or aliases "none", "off", "never", or any non-positive
 # duration) to monitor until the PR is merged, closed, or aborted.
 ci_timeout: "168h"  # any Go duration string, or an unlimited keyword
+
+# How long AXI status waits without step-log or native-agent lifecycle activity
+# before marking a running/fixing step as quiet. This is observability only.
+step_quiet_warning: "10m"
 
 # Daemon log verbosity.
 log_level: info  # debug | info | warn | error
@@ -165,6 +170,7 @@ See [Repo Config Reference](/no-mistakes/reference/repo-config/) for the full fi
 - Global `agent: auto` resolves by checking `claude`, `codex`, `opencode`, `acli` for `rovodev`, `pi`, then `copilot` on `PATH`.
 - ACP agents are opt-in with `agent: acp:<target>` and are not considered by `agent: auto`.
 - `agent_path_override`, `agent_args_override`, `acpx_path`, and `acp_registry_overrides` are global-only fields.
+- `ci_timeout`, `step_quiet_warning`, and `log_level` are global-only fields.
 - `auto_fix` from the repo config overlays global auto_fix. Fields not set in the repo config fall through to the global default.
 - `intent` from the repo config overlays global intent settings. Fields not set in the repo config fall through to the global default, except `intent.disabled_readers`, which adds to globally disabled readers.
 - `test.evidence` from the repo config overlays global test evidence settings. Fields not set in the repo config fall through to the global default.

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -240,6 +240,26 @@ If the PR is still open at the timeout, the step pauses for approval with findin
 You can approve, fix, or skip from the TUI or `no-mistakes axi respond`.
 Use `no-mistakes axi abort` only when you mean to cancel the whole active run.
 
+## Step looks quiet or wedged
+
+Symptom: `no-mistakes axi status` shows an active step with `last_activity` prefixed by `quiet`, or a review/test/lint step appears to run for longer than expected.
+
+`quiet` means the step has not recorded a step-log line or native-agent lifecycle event for longer than `step_quiet_warning` in `~/.no-mistakes/config.yaml`.
+It is only a liveness signal.
+It does not cancel the step, fail the run, or mean the pipeline is safe to bypass.
+
+Start by reading the active run and the step log:
+
+```sh
+no-mistakes axi status
+no-mistakes axi logs --step <step> --full
+```
+
+The `active_steps` table shows how long the step has been active, the latest activity, the native subprocess PID when one is running, and the current round such as `round 1`, `auto-fix 1/3`, or `fix 2`.
+The step log records native subprocess start, exit, and retry lines plus markers for automatic and user-triggered fix rounds.
+If the step is parked at a gate, use `no-mistakes axi respond` instead of waiting.
+If the run is genuinely stuck and you want to discard it, use `no-mistakes axi abort` and then start a new run.
+
 ## Worktree won't clean up
 
 Symptom: `~/.no-mistakes/worktrees/<repoID>/<runID>/` sticks around after a run ends.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -67,6 +67,7 @@ With no subcommand, shows the executable path, description, repo, current branch
 When the current branch has an active run, that run appears as `active_run` with any approval gate and help for `axi respond` when it is parked or `axi status` when it is still running.
 If an active run object is parked at a decision gate, it includes `awaiting_agent: parked <duration>` immediately after `status`.
 That field is observability only; the `gate:` object still tells the agent which response to send.
+If a step is actively `running` or `fixing`, the run object can also include an `active_steps` table with `active_for`, `last_activity`, native `agent_pid` when one is currently running, and the current execution or fix round.
 When only another branch has an active run, that run appears as `other_branch_active_run`; the help tells agents to leave it alone and start validation for the current branch.
 
 ## no-mistakes axi run
@@ -91,6 +92,7 @@ It is the user's goal or request, and no-mistakes uses it verbatim instead of tr
 Err on the side of completeness: include the goal, important decisions and tradeoffs, constraints or approaches ruled in or out, and explicit requests that might otherwise look surprising in the diff.
 When starting a new run, `axi run` refuses the default branch and uncommitted working trees with actionable errors instead of auto-branching or auto-committing.
 Reattaching to an in-flight run does not require `--intent`.
+Reattaching to an in-flight run can proceed while the daemon is already running even if the global config file has become invalid, but starting a fresh run still requires valid global config.
 With `--yes`, `axi run` treats both `action: auto-fix` and `action: ask-user` findings as standing consent for the pipeline to fix them by selecting every finding, then accepts the resulting fix review.
 Gates with no findings or only `action: no-op` findings are approved as-is, and each step is fixed at most once so unresolved findings do not loop forever.
 Without `--yes`, an agent driving `axi run` should stop when a gate contains `action: ask-user` findings and relay each finding's ID, file, and full description to the user before responding.
@@ -128,6 +130,7 @@ no-mistakes axi respond --action skip
 After the explicit response, `--yes` uses the same auto-resolution behavior as `axi run --yes`: have the pipeline fix `auto-fix` and `ask-user` findings once, approve the fix review, approve gates that only contain non-actionable `no-op` findings, and stop at `outcome: checks-passed` when CI is green but the PR still needs a human merge.
 Each `axi respond` blocks until the next gate, CI-ready decision point, or final outcome.
 If it returns another `gate:`, answer that gate; do not idle-wait for the run to move forward by itself.
+When the daemon is already running, `axi respond` can continue an active run even if the global config file has become invalid, because it is not starting a fresh run.
 The same successful-output reporting instructions apply to `axi respond` results.
 
 ## no-mistakes axi status
@@ -145,6 +148,10 @@ no-mistakes axi status --run <id>
 
 When the resolved run is parked at an `awaiting_approval` or `fix_review` gate, its top-level `run:` object includes `awaiting_agent: parked <duration>` immediately after `status`.
 The field disappears after `axi respond`, on cancel, and on terminal outcomes; use it to distinguish a run waiting for the driving agent from one actively running, fixing, or watching CI.
+When the resolved run has a `running` or `fixing` step, the run object includes `active_steps`.
+Each row reports how long the step has been active, the latest meaningful log or native-agent lifecycle activity, the native agent PID if one is currently running, and the current round such as `round 1`, `auto-fix 1/3`, or `fix 2`.
+If no activity arrives for longer than `step_quiet_warning`, `last_activity` is prefixed with `quiet`; this is only a liveness signal and does not cancel the step.
+For older active runs with no recorded activity timestamp, AXI falls back to the step log file modification time.
 
 ## no-mistakes axi logs
 
@@ -163,6 +170,8 @@ no-mistakes axi logs --step review --run <id>
 | `--full` | `bool` | `false` | Show the entire log instead of the tail |
 
 Without `--full`, long logs show the last 40 lines and a help hint for the full log.
+Step logs include native subprocess agent lifecycle lines such as `codex started pid=4242`, `codex exited pid=4242 status=success`, and transient retry messages when the selected agent supports lifecycle events.
+They also include fix-loop markers such as `auto-fix round 1/3 starting after round 1` and `user-fix round starting after round 2`.
 
 ## no-mistakes axi abort
 
@@ -184,6 +193,7 @@ no-mistakes axi abort --run <id>
 `--run` does not need a repo, branch, or worktree, so it works from anywhere.
 Use it to reap an orphaned CI monitor whose worktree was torn down before the PR merged - the run id is shown in `axi run` output and in the `axi` home view.
 Aborting an id that is not an active run is a successful no-op.
+When the daemon is already running, `axi abort` can cancel an active run even if the global config file has become invalid, because it is not starting a fresh run.
 While a run is active, do not use `axi abort` or `no-mistakes rerun` to go fix a finding yourself.
 That cancels the pipeline's in-flight work and forces a full re-validation; use `axi respond --action fix` at the gate so the pipeline applies and re-checks the fix.
 

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -31,6 +31,8 @@ agent_args_override:
 
 ci_timeout: "168h"
 
+step_quiet_warning: "10m"
+
 log_level: info
 
 auto_fix:
@@ -201,6 +203,23 @@ A genuinely idle/abandoned PR is still reaped after the timeout elapses.
 Set it to `unlimited` (`none`, `off`, and `never` are accepted aliases), `0`, or any non-positive duration to monitor until the PR is merged, closed, or the run is aborted with `no-mistakes axi abort --run <id>`.
 
 Legacy alias: `babysit_timeout`.
+
+### step_quiet_warning
+
+How long a running or fixing step can go without recorded step-log or native-agent lifecycle activity before AXI status marks the step as quiet.
+
+| | |
+|---|---|
+| Type | `string` (Go duration) |
+| Default | `10m` |
+
+Accepts any positive Go `time.ParseDuration` string: `30s`, `5m`, `1h`, etc.
+Non-positive values are ignored and keep the default.
+
+This is observability only.
+It does not cancel the step, change auto-fix behavior, or mark the run failed.
+AXI renders the quiet signal in the `active_steps` table as part of `last_activity`, for example `quiet 12m3s ago: codex started pid=4242`.
+For older active runs that do not yet have activity rows, AXI falls back to the step log file's modification time.
 
 ### log_level
 

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -228,3 +228,6 @@ Each step progresses through these statuses:
 
 When a non-terminal run has a step in `awaiting_approval` or `fix_review`, AXI run objects also expose `awaiting_agent: parked <duration>` as a run-level observability signal.
 The signal clears as soon as the approval wait ends, including `axi respond` and cancellation, and does not change how gates resolve.
+When a step is `running` or `fixing`, AXI run objects expose an `active_steps` table with active duration, latest activity, native subprocess PID when present, and the current round such as `round 1`, `auto-fix 1/3`, or `fix 2`.
+If the latest activity is older than `step_quiet_warning`, AXI prefixes it with `quiet` to make possible wedges visible without changing the run state.
+Step logs also record native subprocess start, exit, and retry lifecycle lines plus explicit auto-fix and user-fix round markers.

--- a/internal/agent/acpx.go
+++ b/internal/agent/acpx.go
@@ -42,6 +42,8 @@ func (a *acpxAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) 
 		return nil, fmt.Errorf("acpx start: %w", err)
 	}
 	defer started.closePipes()
+	pid := started.pid()
+	emitAgentStarted(opts, a.Name(), pid)
 
 	var stderrBuf []byte
 	var stderrWG sync.WaitGroup
@@ -56,17 +58,23 @@ func (a *acpxAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) 
 	if err != nil {
 		err = started.waitAfterParseError(err)
 		stderrWG.Wait()
-		return nil, fmt.Errorf("acpx parse events: %w", err)
+		retErr := fmt.Errorf("acpx parse events: %w", err)
+		emitAgentExited(opts, a.Name(), pid, retErr)
+		return nil, retErr
 	}
 	waitErr := started.wait()
 	stderrWG.Wait()
 	if waitErr != nil {
-		return nil, fmt.Errorf("acpx exited: %w: %s", waitErr, acpxProcessErrorOutput(stderrBuf, stdoutErr))
+		retErr := fmt.Errorf("acpx exited: %w: %s", waitErr, acpxProcessErrorOutput(stderrBuf, stdoutErr))
+		emitAgentExited(opts, a.Name(), pid, retErr)
+		return nil, retErr
 	}
 	if usage.OutputTokens == 0 {
 		usage.OutputTokens = estimateAcpxTokens(len(text))
 	}
-	return finalizeTextResult(a.Name(), text, opts.JSONSchema, usage)
+	res, err := finalizeTextResult(a.Name(), text, opts.JSONSchema, usage)
+	emitAgentExited(opts, a.Name(), pid, err)
+	return res, err
 }
 
 func (a *acpxAgent) Close() error { return nil }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -21,10 +21,20 @@ type Agent interface {
 
 // RunOpts configures a single agent invocation.
 type RunOpts struct {
-	Prompt     string
-	CWD        string
-	JSONSchema json.RawMessage   // structured output schema (optional)
-	OnChunk    func(text string) // streaming text callback (optional)
+	Prompt      string
+	CWD         string
+	JSONSchema  json.RawMessage      // structured output schema (optional)
+	OnChunk     func(text string)    // streaming text callback (optional)
+	OnLifecycle func(LifecycleEvent) // native agent lifecycle callback (optional)
+}
+
+// LifecycleEvent describes process-level activity for an agent invocation.
+// The pipeline records these as step log lines and active-step heartbeats.
+type LifecycleEvent struct {
+	Agent   string
+	Phase   string
+	PID     int
+	Message string
 }
 
 // Result holds the output of an agent invocation.

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -53,6 +53,8 @@ func (a *claudeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error
 		return nil, fmt.Errorf("claude start: %w", err)
 	}
 	defer started.closePipes()
+	pid := started.pid()
+	emitAgentStarted(opts, "claude", pid)
 
 	stderrWG.Add(1)
 	go func() {
@@ -65,17 +67,23 @@ func (a *claudeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error
 	if err := parseClaudeEvents(ctx, started.stdout, opts.OnChunk, &usage, &result); err != nil {
 		err = started.waitAfterParseError(err)
 		stderrWG.Wait()
-		return nil, fmt.Errorf("claude parse events: %w", err)
+		retErr := fmt.Errorf("claude parse events: %w", err)
+		emitAgentExited(opts, "claude", pid, retErr)
+		return nil, retErr
 	}
 
 	waitErr := started.wait()
 	stderrWG.Wait()
 	if waitErr != nil {
-		return nil, fmt.Errorf("claude exited: %w: %s", waitErr, string(stderrBuf))
+		retErr := fmt.Errorf("claude exited: %w: %s", waitErr, string(stderrBuf))
+		emitAgentExited(opts, "claude", pid, retErr)
+		return nil, retErr
 	}
 
 	if result == nil {
-		return nil, fmt.Errorf("claude returned no result event")
+		retErr := fmt.Errorf("claude returned no result event")
+		emitAgentExited(opts, "claude", pid, retErr)
+		return nil, retErr
 	}
 
 	res, err := finalizeClaudeResult(result, opts.JSONSchema, usage)
@@ -84,6 +92,7 @@ func (a *claudeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error
 			result.Subtype, len(result.text), usage.InputTokens, usage.OutputTokens))
 		opts.OnChunk(fmt.Sprintf("raw result event: %s", string(result.rawEvent)))
 	}
+	emitAgentExited(opts, "claude", pid, err)
 	return res, err
 }
 

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -71,6 +71,8 @@ func (a *codexAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error)
 		return nil, fmt.Errorf("codex start: %w", err)
 	}
 	defer started.closePipes()
+	pid := started.pid()
+	emitAgentStarted(opts, "codex", pid)
 
 	stderrWG.Add(1)
 	go func() {
@@ -84,7 +86,9 @@ func (a *codexAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error)
 	if err := parseCodexEvents(ctx, started.stdout, opts.OnChunk, &usage, &lastMessage, &codexErr); err != nil {
 		err = started.waitAfterParseError(err)
 		stderrWG.Wait()
-		return nil, fmt.Errorf("codex parse events: %w", err)
+		retErr := fmt.Errorf("codex parse events: %w", err)
+		emitAgentExited(opts, "codex", pid, retErr)
+		return nil, retErr
 	}
 
 	waitErr := started.wait()
@@ -97,10 +101,14 @@ func (a *codexAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error)
 		} else if detail == "" {
 			detail = stderr
 		}
-		return nil, fmt.Errorf("codex exited: %w: %s", waitErr, detail)
+		retErr := fmt.Errorf("codex exited: %w: %s", waitErr, detail)
+		emitAgentExited(opts, "codex", pid, retErr)
+		return nil, retErr
 	}
 
-	return finalizeTextResult("codex", lastMessage, validationSchema, usage)
+	res, err := finalizeTextResult("codex", lastMessage, validationSchema, usage)
+	emitAgentExited(opts, "codex", pid, err)
+	return res, err
 }
 
 func (a *codexAgent) Close() error { return nil }

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -48,6 +48,8 @@ func (a *copilotAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, erro
 		return nil, fmt.Errorf("copilot start: %w", err)
 	}
 	defer started.closePipes()
+	pid := started.pid()
+	emitAgentStarted(opts, "copilot", pid)
 
 	stderrWG.Add(1)
 	go func() {
@@ -62,7 +64,9 @@ func (a *copilotAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, erro
 	if err := parseCopilotEvents(ctx, started.stdout, opts.OnChunk, &usage, &messages, &copilotErr, &exitCode); err != nil {
 		err = started.waitAfterParseError(err)
 		stderrWG.Wait()
-		return nil, fmt.Errorf("copilot parse events: %w", err)
+		retErr := fmt.Errorf("copilot parse events: %w", err)
+		emitAgentExited(opts, "copilot", pid, retErr)
+		return nil, retErr
 	}
 
 	waitErr := started.wait()
@@ -71,18 +75,28 @@ func (a *copilotAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, erro
 	detail := copilotErrorDetail(copilotErr, string(stderrBuf))
 	if waitErr != nil {
 		if detail != "" {
-			return nil, fmt.Errorf("copilot exited: %w: %s", waitErr, detail)
+			retErr := fmt.Errorf("copilot exited: %w: %s", waitErr, detail)
+			emitAgentExited(opts, "copilot", pid, retErr)
+			return nil, retErr
 		}
-		return nil, fmt.Errorf("copilot exited: %w", waitErr)
+		retErr := fmt.Errorf("copilot exited: %w", waitErr)
+		emitAgentExited(opts, "copilot", pid, retErr)
+		return nil, retErr
 	}
 	if exitCode != 0 {
 		if detail != "" {
-			return nil, fmt.Errorf("copilot reported exit code %d: %s", exitCode, detail)
+			retErr := fmt.Errorf("copilot reported exit code %d: %s", exitCode, detail)
+			emitAgentExited(opts, "copilot", pid, retErr)
+			return nil, retErr
 		}
-		return nil, fmt.Errorf("copilot reported exit code %d", exitCode)
+		retErr := fmt.Errorf("copilot reported exit code %d", exitCode)
+		emitAgentExited(opts, "copilot", pid, retErr)
+		return nil, retErr
 	}
 
-	return finalizeCopilotResult(messages, opts.JSONSchema, usage)
+	res, err := finalizeCopilotResult(messages, opts.JSONSchema, usage)
+	emitAgentExited(opts, "copilot", pid, err)
+	return res, err
 }
 
 // finalizeCopilotResult converts the assistant messages emitted during a run

--- a/internal/agent/lifecycle.go
+++ b/internal/agent/lifecycle.go
@@ -3,8 +3,11 @@ package agent
 import "fmt"
 
 const (
+	// LifecyclePhaseStart marks native subprocess startup.
 	LifecyclePhaseStart = "start"
-	LifecyclePhaseExit  = "exit"
+	// LifecyclePhaseExit marks native subprocess exit.
+	LifecyclePhaseExit = "exit"
+	// LifecyclePhaseRetry marks a transient retry before the next subprocess attempt.
 	LifecyclePhaseRetry = "retry"
 )
 

--- a/internal/agent/lifecycle.go
+++ b/internal/agent/lifecycle.go
@@ -1,0 +1,52 @@
+package agent
+
+import "fmt"
+
+const (
+	LifecyclePhaseStart = "start"
+	LifecyclePhaseExit  = "exit"
+	LifecyclePhaseRetry = "retry"
+)
+
+func emitAgentStarted(opts RunOpts, name string, pid int) {
+	emitLifecycle(opts, LifecycleEvent{
+		Agent:   name,
+		Phase:   LifecyclePhaseStart,
+		PID:     pid,
+		Message: fmt.Sprintf("%s started pid=%d", name, pid),
+	})
+}
+
+func emitAgentExited(opts RunOpts, name string, pid int, err error) {
+	message := fmt.Sprintf("%s exited pid=%d status=success", name, pid)
+	if err != nil {
+		message = fmt.Sprintf("%s exited pid=%d error=%s", name, pid, err.Error())
+	}
+	emitLifecycle(opts, LifecycleEvent{
+		Agent:   name,
+		Phase:   LifecyclePhaseExit,
+		PID:     pid,
+		Message: message,
+	})
+}
+
+func emitAgentRetry(opts RunOpts, name string, label string, attempt, max int) {
+	message := fmt.Sprintf("%s retrying after transient error %q (attempt %d/%d)", name, label, attempt, max)
+	if opts.OnLifecycle != nil {
+		emitLifecycle(opts, LifecycleEvent{
+			Agent:   name,
+			Phase:   LifecyclePhaseRetry,
+			Message: message,
+		})
+		return
+	}
+	if opts.OnChunk != nil {
+		opts.OnChunk(message)
+	}
+}
+
+func emitLifecycle(opts RunOpts, event LifecycleEvent) {
+	if opts.OnLifecycle != nil {
+		opts.OnLifecycle(event)
+	}
+}

--- a/internal/agent/native_command.go
+++ b/internal/agent/native_command.go
@@ -96,6 +96,13 @@ func (c *nativeAgentCommand) markPipeDone() {
 	}
 }
 
+func (c *nativeAgentCommand) pid() int {
+	if c == nil || c.cmd == nil || c.cmd.Process == nil {
+		return 0
+	}
+	return c.cmd.Process.Pid
+}
+
 func (c *nativeAgentCommand) waitForPipes(waitErr error) error {
 	if c.cmd.WaitDelay <= 0 {
 		<-c.pipesDone

--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -48,6 +48,8 @@ func (a *piAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 		return nil, fmt.Errorf("pi start: %w", err)
 	}
 	defer started.closePipes()
+	pid := started.pid()
+	emitAgentStarted(opts, "pi", pid)
 
 	prompt := buildPiPrompt(opts.Prompt, opts.JSONSchema)
 	go func() {
@@ -67,7 +69,9 @@ func (a *piAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 	if err := pp.parse(ctx, started.stdout); err != nil {
 		err = started.waitAfterParseError(err)
 		stderrWG.Wait()
-		return nil, fmt.Errorf("pi parse events: %w", err)
+		retErr := fmt.Errorf("pi parse events: %w", err)
+		emitAgentExited(opts, "pi", pid, retErr)
+		return nil, retErr
 	}
 
 	waitErr := started.wait()
@@ -75,17 +79,25 @@ func (a *piAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 	if waitErr != nil {
 		stderr := strings.TrimSpace(string(stderrBuf))
 		if stderr != "" {
-			return nil, fmt.Errorf("pi exited: %w: %s", waitErr, stderr)
+			retErr := fmt.Errorf("pi exited: %w: %s", waitErr, stderr)
+			emitAgentExited(opts, "pi", pid, retErr)
+			return nil, retErr
 		}
-		return nil, fmt.Errorf("pi exited: %w", waitErr)
+		retErr := fmt.Errorf("pi exited: %w", waitErr)
+		emitAgentExited(opts, "pi", pid, retErr)
+		return nil, retErr
 	}
 
 	if pp.assistantError != "" {
-		return nil, fmt.Errorf("pi reported error: %s", pp.assistantError)
+		retErr := fmt.Errorf("pi reported error: %s", pp.assistantError)
+		emitAgentExited(opts, "pi", pid, retErr)
+		return nil, retErr
 	}
 
 	text := pp.finalText()
-	return finalizeTextResult("pi", text, opts.JSONSchema, pp.usage)
+	res, err := finalizeTextResult("pi", text, opts.JSONSchema, pp.usage)
+	emitAgentExited(opts, "pi", pid, err)
+	return res, err
 }
 
 // buildArgs returns the Pi argv for one invocation. User extras come first

--- a/internal/agent/retry.go
+++ b/internal/agent/retry.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math/rand"
 	"regexp"
 	"strings"
@@ -53,7 +52,8 @@ func transientBackoffBaseDuration(attempt int, base time.Duration) time.Duration
 // runWithRetry invokes runOnce up to maxRetries+1 times, retrying when the
 // classifier marks the error as retriable. Between retries it sleeps with
 // exponential backoff (via transientBackoff) and respects ctx cancellation.
-// The retry attempt and classification label are surfaced to opts.OnChunk.
+// The retry attempt and classification label are surfaced to opts.OnLifecycle,
+// falling back to opts.OnChunk for older direct callers.
 func runWithRetry(
 	ctx context.Context,
 	name string,
@@ -67,12 +67,7 @@ func runWithRetry(
 	var lastLabel string
 	for attempt := 0; attempt <= maxRetries; attempt++ {
 		if attempt > 0 {
-			if opts.OnChunk != nil {
-				opts.OnChunk(fmt.Sprintf(
-					"%s retrying after transient error %q (attempt %d/%d)",
-					name, lastLabel, attempt+1, maxRetries+1,
-				))
-			}
+			emitAgentRetry(opts, name, lastLabel, attempt+1, maxRetries+1)
 			if err := transientBackoff(ctx, attempt); err != nil {
 				return nil, err
 			}

--- a/internal/agent/retry_test.go
+++ b/internal/agent/retry_test.go
@@ -178,6 +178,41 @@ func TestRunWithRetry_RetriesTransientThenSucceeds(t *testing.T) {
 	}
 }
 
+func TestRunWithRetry_EmitsRetryLifecycleWhenConfigured(t *testing.T) {
+	defer withFastBackoff(t)()
+
+	calls := 0
+	var chunks []string
+	var events []LifecycleEvent
+	opts := RunOpts{
+		OnChunk:     func(s string) { chunks = append(chunks, s) },
+		OnLifecycle: func(e LifecycleEvent) { events = append(events, e) },
+	}
+
+	_, err := runWithRetry(context.Background(), "codex", opts, 1, classifyTransient, nil, func() (*Result, error) {
+		calls++
+		if calls == 1 {
+			return nil, errors.New("API Error: 503 overloaded")
+		}
+		return &Result{Text: "ok"}, nil
+	})
+	if err != nil {
+		t.Fatalf("expected success after retry, got %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %v, want one retry lifecycle event", events)
+	}
+	if events[0].Agent != "codex" || events[0].Phase != LifecyclePhaseRetry {
+		t.Fatalf("event = %+v, want codex retry", events[0])
+	}
+	if !strings.Contains(events[0].Message, "attempt 2/2") || !strings.Contains(events[0].Message, "503") {
+		t.Fatalf("retry message = %q, want attempt and label", events[0].Message)
+	}
+	if len(chunks) != 0 {
+		t.Fatalf("OnChunk should not duplicate retry lifecycle events, got %v", chunks)
+	}
+}
+
 func TestRunWithRetry_CallsRetryRecoveryBeforeRetry(t *testing.T) {
 	defer withFastBackoff(t)()
 

--- a/internal/cli/axi.go
+++ b/internal/cli/axi.go
@@ -83,8 +83,12 @@ func openAxiEnv(ensureDaemonConn bool) (*axiEnv, error) {
 	return openAxiEnvWithOptions(axiEnvOptions{ensureDaemonConn: ensureDaemonConn})
 }
 
-func openAxiRunEnv() (*axiEnv, error) {
+func openAxiDaemonEnv() (*axiEnv, error) {
 	return openAxiEnvWithOptions(axiEnvOptions{ensureDaemonConn: true, deferGlobalConfigErrorForRunningDaemon: true})
+}
+
+func openAxiRunEnv() (*axiEnv, error) {
+	return openAxiDaemonEnv()
 }
 
 func openAxiEnvWithOptions(opts axiEnvOptions) (*axiEnv, error) {

--- a/internal/cli/axi.go
+++ b/internal/cli/axi.go
@@ -53,16 +53,17 @@ func newAxiCmd() *cobra.Command {
 // axiEnv bundles the resources an axi subcommand needs. Most are DB-backed and
 // do not require the daemon; commands that mutate run state ensure it.
 type axiEnv struct {
-	p      *paths.Paths
-	d      *db.DB
-	repo   *db.Repo
-	cfg    *config.GlobalConfig
-	client *ipc.Client
+	p               *paths.Paths
+	d               *db.DB
+	repo            *db.Repo
+	cfg             *config.GlobalConfig
+	globalConfigErr error
+	client          *ipc.Client
 }
 
 type axiEnvOptions struct {
-	ensureDaemonConn    bool
-	requireGlobalConfig bool
+	ensureDaemonConn                       bool
+	deferGlobalConfigErrorForRunningDaemon bool
 }
 
 func (e *axiEnv) close() {
@@ -83,7 +84,7 @@ func openAxiEnv(ensureDaemonConn bool) (*axiEnv, error) {
 }
 
 func openAxiRunEnv() (*axiEnv, error) {
-	return openAxiEnvWithOptions(axiEnvOptions{ensureDaemonConn: true, requireGlobalConfig: true})
+	return openAxiEnvWithOptions(axiEnvOptions{ensureDaemonConn: true, deferGlobalConfigErrorForRunningDaemon: true})
 }
 
 func openAxiEnvWithOptions(opts axiEnvOptions) (*axiEnv, error) {
@@ -93,13 +94,19 @@ func openAxiEnvWithOptions(opts axiEnvOptions) (*axiEnv, error) {
 	}
 	globalCfg, err := config.LoadGlobal(p.ConfigFile())
 	if err != nil {
-		if opts.requireGlobalConfig {
+		if opts.deferGlobalConfigErrorForRunningDaemon {
+			alive, _ := daemon.IsRunning(p)
+			if !alive {
+				d.Close()
+				return nil, err
+			}
+		} else if opts.ensureDaemonConn {
 			d.Close()
 			return nil, err
 		}
 		globalCfg = config.DefaultGlobalConfig()
 	}
-	env := &axiEnv{p: p, d: d, cfg: globalCfg}
+	env := &axiEnv{p: p, d: d, cfg: globalCfg, globalConfigErr: err}
 	repo, err := findRepo(d)
 	if err != nil {
 		d.Close()

--- a/internal/cli/axi.go
+++ b/internal/cli/axi.go
@@ -80,8 +80,7 @@ func openAxiEnv(ensureDaemonConn bool) (*axiEnv, error) {
 	}
 	globalCfg, err := config.LoadGlobal(p.ConfigFile())
 	if err != nil {
-		d.Close()
-		return nil, fmt.Errorf("load global config: %w", err)
+		globalCfg = config.DefaultGlobalConfig()
 	}
 	env := &axiEnv{p: p, d: d, cfg: globalCfg}
 	repo, err := findRepo(d)

--- a/internal/cli/axi.go
+++ b/internal/cli/axi.go
@@ -60,6 +60,11 @@ type axiEnv struct {
 	client *ipc.Client
 }
 
+type axiEnvOptions struct {
+	ensureDaemonConn    bool
+	requireGlobalConfig bool
+}
+
 func (e *axiEnv) close() {
 	if e.client != nil {
 		e.client.Close()
@@ -74,12 +79,24 @@ func (e *axiEnv) close() {
 // the daemon, populating client. Errors are returned for the caller to render
 // as structured TOON.
 func openAxiEnv(ensureDaemonConn bool) (*axiEnv, error) {
+	return openAxiEnvWithOptions(axiEnvOptions{ensureDaemonConn: ensureDaemonConn})
+}
+
+func openAxiRunEnv() (*axiEnv, error) {
+	return openAxiEnvWithOptions(axiEnvOptions{ensureDaemonConn: true, requireGlobalConfig: true})
+}
+
+func openAxiEnvWithOptions(opts axiEnvOptions) (*axiEnv, error) {
 	p, d, err := openResources()
 	if err != nil {
 		return nil, err
 	}
 	globalCfg, err := config.LoadGlobal(p.ConfigFile())
 	if err != nil {
+		if opts.requireGlobalConfig {
+			d.Close()
+			return nil, err
+		}
 		globalCfg = config.DefaultGlobalConfig()
 	}
 	env := &axiEnv{p: p, d: d, cfg: globalCfg}
@@ -89,7 +106,7 @@ func openAxiEnv(ensureDaemonConn bool) (*axiEnv, error) {
 		return nil, err
 	}
 	env.repo = repo
-	if ensureDaemonConn {
+	if opts.ensureDaemonConn {
 		if err := daemon.EnsureDaemon(p); err != nil {
 			env.close()
 			return nil, fmt.Errorf("start daemon: %w", err)

--- a/internal/cli/axi.go
+++ b/internal/cli/axi.go
@@ -8,6 +8,7 @@ import (
 
 	toon "github.com/toon-format/toon-go"
 
+	"github.com/kunchenguid/no-mistakes/internal/config"
 	"github.com/kunchenguid/no-mistakes/internal/daemon"
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
@@ -55,6 +56,7 @@ type axiEnv struct {
 	p      *paths.Paths
 	d      *db.DB
 	repo   *db.Repo
+	cfg    *config.GlobalConfig
 	client *ipc.Client
 }
 
@@ -76,7 +78,12 @@ func openAxiEnv(ensureDaemonConn bool) (*axiEnv, error) {
 	if err != nil {
 		return nil, err
 	}
-	env := &axiEnv{p: p, d: d}
+	globalCfg, err := config.LoadGlobal(p.ConfigFile())
+	if err != nil {
+		d.Close()
+		return nil, fmt.Errorf("load global config: %w", err)
+	}
+	env := &axiEnv{p: p, d: d, cfg: globalCfg}
 	repo, err := findRepo(d)
 	if err != nil {
 		d.Close()
@@ -149,6 +156,7 @@ func runAxiHome(cmd *cobra.Command) error {
 	if currentActive != nil {
 		steps, _ := env.d.GetStepsByRun(currentActive.ID)
 		rv := runViewFromDB(currentActive, steps)
+		annotateRunView(env, &rv)
 		fields = append(fields, runObjectFieldWithKey("active_run", rv))
 		if gate, ok := rv.awaitingStep(); ok {
 			gated = true
@@ -157,6 +165,7 @@ func runAxiHome(cmd *cobra.Command) error {
 	} else if otherActive != nil {
 		steps, _ := env.d.GetStepsByRun(otherActive.ID)
 		rv := runViewFromDB(otherActive, steps)
+		annotateRunView(env, &rv)
 		fields = append(fields, runObjectFieldWithKey("other_branch_active_run", rv))
 	}
 

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -603,7 +603,7 @@ func runAxiRespond(cmd *cobra.Command, ra respondArgs) error {
 			"Valid actions: approve, fix, skip")
 	}
 
-	env, err := openAxiEnv(true)
+	env, err := openAxiDaemonEnv()
 	if err != nil {
 		return emitError(cmd, 1, err.Error(), repoInitHelp(err)...)
 	}
@@ -725,7 +725,7 @@ func runAxiAbort(cmd *cobra.Command, runID string) error {
 	}
 
 	ctx := cmd.Context()
-	env, err := openAxiEnv(true)
+	env, err := openAxiDaemonEnv()
 	if err != nil {
 		return emitError(cmd, 1, err.Error(), repoInitHelp(err)...)
 	}

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -119,6 +119,9 @@ func runAxiRun(cmd *cobra.Command, autoYes bool, skipSteps []types.StepName, int
 
 	runID := activeRunID(env, branch, headSHA)
 	if runID == "" {
+		if err := configErrorForFreshAxiRun(env, runID); err != nil {
+			return emitError(cmd, 1, err.Error(), repoInitHelp(err)...)
+		}
 		// Intent is mandatory when starting a run: the agent driving this knows
 		// the change's intent, so we take it directly instead of inferring it
 		// from transcripts. Reattaching to an in-flight run does not need it.
@@ -146,6 +149,13 @@ func runAxiRun(cmd *cobra.Command, autoYes bool, skipSteps []types.StepName, int
 		return emitError(cmd, 1, fmt.Sprintf("drive run: %v", err))
 	}
 	return renderDriveResult(cmd, run, ciReady)
+}
+
+func configErrorForFreshAxiRun(env *axiEnv, runID string) error {
+	if runID != "" {
+		return nil
+	}
+	return env.globalConfigErr
 }
 
 // activeRunID returns the ID of a non-terminal run for branch and head, or "" if none.

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -97,7 +97,7 @@ func newAxiRunCmd() *cobra.Command {
 
 func runAxiRun(cmd *cobra.Command, autoYes bool, skipSteps []types.StepName, intent string) error {
 	ctx := cmd.Context()
-	env, err := openAxiEnv(true)
+	env, err := openAxiRunEnv()
 	if err != nil {
 		return emitError(cmd, 1, err.Error(), repoInitHelp(err)...)
 	}

--- a/internal/cli/axi_query.go
+++ b/internal/cli/axi_query.go
@@ -12,7 +12,6 @@ import (
 
 	toon "github.com/toon-format/toon-go"
 
-	"github.com/kunchenguid/no-mistakes/internal/config"
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
@@ -94,11 +93,11 @@ func annotateRunView(env *axiEnv, rv *runView) {
 	for i := range rv.Steps {
 		step := &rv.Steps[i]
 		step.QuietWarning = quietWarning
-		step.AutoFixLimit = autoFixLimitForStatus(env, types.StepName(step.Name))
 		if step.ID != "" {
 			if stats, err := env.d.StepRoundStats(step.ID); err == nil {
 				step.RoundCount = stats.TotalRounds
 				step.FixRoundCount = stats.FixRounds
+				step.PendingFixSource = stats.PendingFixSource
 			}
 		}
 		if step.LastActivityAt == nil {
@@ -117,17 +116,6 @@ func configQuietWarning(env *axiEnv) time.Duration {
 		return 0
 	}
 	return env.cfg.StepQuietWarning
-}
-
-func autoFixLimitForStatus(env *axiEnv, step types.StepName) int {
-	if env == nil || env.cfg == nil {
-		return 0
-	}
-	cfg := config.Merge(env.cfg, &config.RepoConfig{})
-	if cfg == nil {
-		return 0
-	}
-	return cfg.AutoFixLimit(step)
 }
 
 func startRunHelp() string {

--- a/internal/cli/axi_query.go
+++ b/internal/cli/axi_query.go
@@ -8,9 +8,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	toon "github.com/toon-format/toon-go"
 
+	"github.com/kunchenguid/no-mistakes/internal/config"
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
@@ -70,6 +72,7 @@ func runAxiStatus(cmd *cobra.Command, runID string) error {
 		return emitError(cmd, 1, fmt.Sprintf("load steps: %v", err))
 	}
 	rv := runViewFromDB(run, steps)
+	annotateRunView(env, &rv)
 	fields := []toon.Field{runObjectField(rv)}
 	if gate, ok := rv.awaitingStep(); ok {
 		fields = append(fields, gateFields(gate)...)
@@ -81,6 +84,50 @@ func runAxiStatus(cmd *cobra.Command, runID string) error {
 	}
 	emitDoc(cmd, fields...)
 	return nil
+}
+
+func annotateRunView(env *axiEnv, rv *runView) {
+	if env == nil || rv == nil {
+		return
+	}
+	quietWarning := configQuietWarning(env)
+	for i := range rv.Steps {
+		step := &rv.Steps[i]
+		step.QuietWarning = quietWarning
+		step.AutoFixLimit = autoFixLimitForStatus(env, types.StepName(step.Name))
+		if step.ID != "" {
+			if stats, err := env.d.StepRoundStats(step.ID); err == nil {
+				step.RoundCount = stats.TotalRounds
+				step.FixRoundCount = stats.FixRounds
+			}
+		}
+		if step.LastActivityAt == nil {
+			logPath := filepath.Join(env.p.RunLogDir(rv.ID), step.Name+".log")
+			if info, err := os.Stat(logPath); err == nil {
+				ts := info.ModTime().Unix()
+				step.LastActivityAt = &ts
+				step.LastActivity = "step log updated"
+			}
+		}
+	}
+}
+
+func configQuietWarning(env *axiEnv) time.Duration {
+	if env == nil || env.cfg == nil || env.cfg.StepQuietWarning <= 0 {
+		return 0
+	}
+	return env.cfg.StepQuietWarning
+}
+
+func autoFixLimitForStatus(env *axiEnv, step types.StepName) int {
+	if env == nil || env.cfg == nil {
+		return 0
+	}
+	cfg := config.Merge(env.cfg, &config.RepoConfig{})
+	if cfg == nil {
+		return 0
+	}
+	return cfg.AutoFixLimit(step)
 }
 
 func startRunHelp() string {

--- a/internal/cli/axi_render.go
+++ b/internal/cli/axi_render.go
@@ -30,6 +30,15 @@ type stepRow struct {
 	DurationMS int64  `toon:"duration_ms"`
 }
 
+type activeStepRow struct {
+	Step         string `toon:"step"`
+	Status       string `toon:"status"`
+	ActiveFor    string `toon:"active_for"`
+	LastActivity string `toon:"last_activity"`
+	AgentPID     string `toon:"agent_pid"`
+	Round        string `toon:"round"`
+}
+
 type findingRow struct {
 	ID          string `toon:"id"`
 	Severity    string `toon:"severity"`
@@ -62,11 +71,20 @@ type fixRow struct {
 // stepView is a render-ready view of a single pipeline step, decoupled from
 // whether it came from the daemon (ipc) or the local database.
 type stepView struct {
-	Name         string
-	Status       string
-	DurationMS   int64
-	FindingsJSON string
-	FixSummaries []string
+	ID             string
+	Name           string
+	Status         string
+	DurationMS     int64
+	FindingsJSON   string
+	FixSummaries   []string
+	StartedAt      *int64
+	LastActivityAt *int64
+	LastActivity   string
+	AgentPID       *int
+	RoundCount     int
+	FixRoundCount  int
+	AutoFixLimit   int
+	QuietWarning   time.Duration
 }
 
 // runView is a render-ready view of a pipeline run.
@@ -95,7 +113,20 @@ func runViewFromIPC(r *ipc.RunInfo) runView {
 		rv.PRURL = *r.PRURL
 	}
 	for _, s := range r.Steps {
-		sv := stepView{Name: string(s.StepName), Status: string(s.Status), FixSummaries: s.FixSummaries}
+		sv := stepView{
+			ID:             s.ID,
+			Name:           string(s.StepName),
+			Status:         string(s.Status),
+			FixSummaries:   s.FixSummaries,
+			StartedAt:      s.StartedAt,
+			LastActivityAt: s.LastActivityAt,
+			AgentPID:       s.AgentPID,
+			RoundCount:     s.RoundCount,
+			FixRoundCount:  s.FixRoundCount,
+		}
+		if s.LastActivity != nil {
+			sv.LastActivity = *s.LastActivity
+		}
 		if s.DurationMS != nil {
 			sv.DurationMS = *s.DurationMS
 		}
@@ -119,7 +150,17 @@ func runViewFromDB(r *db.Run, steps []*db.StepResult) runView {
 		rv.PRURL = *r.PRURL
 	}
 	for _, s := range steps {
-		sv := stepView{Name: string(s.StepName), Status: string(s.Status)}
+		sv := stepView{
+			ID:             s.ID,
+			Name:           string(s.StepName),
+			Status:         string(s.Status),
+			StartedAt:      s.StartedAt,
+			LastActivityAt: s.LastActivityAt,
+			AgentPID:       s.AgentPID,
+		}
+		if s.LastActivity != nil {
+			sv.LastActivity = *s.LastActivity
+		}
 		if s.DurationMS != nil {
 			sv.DurationMS = *s.DurationMS
 		}
@@ -240,6 +281,93 @@ func (rv runView) fixRows() []fixRow {
 	return rows
 }
 
+func (rv runView) activeRows() []activeStepRow {
+	var rows []activeStepRow
+	for _, s := range rv.Steps {
+		if s.Status != string(types.StepStatusRunning) && s.Status != string(types.StepStatusFixing) {
+			continue
+		}
+		rows = append(rows, activeStepRow{
+			Step:         s.Name,
+			Status:       s.Status,
+			ActiveFor:    s.activeFor(),
+			LastActivity: s.lastActivitySummary(),
+			AgentPID:     s.agentPIDString(),
+			Round:        s.roundSummary(),
+		})
+	}
+	return rows
+}
+
+func (s stepView) activeFor() string {
+	if s.StartedAt == nil {
+		return ""
+	}
+	return formatDurationSince(*s.StartedAt)
+}
+
+func (s stepView) lastActivitySummary() string {
+	if s.LastActivityAt == nil {
+		return "unknown"
+	}
+	prefix := formatDurationSince(*s.LastActivityAt) + " ago"
+	secs := nowUnix() - *s.LastActivityAt
+	if secs < 0 {
+		secs = 0
+	}
+	if s.QuietWarning > 0 && time.Duration(secs)*time.Second >= s.QuietWarning {
+		prefix = "quiet " + prefix
+	}
+	if s.LastActivity == "" {
+		return prefix
+	}
+	return prefix + ": " + s.LastActivity
+}
+
+func (s stepView) agentPIDString() string {
+	if s.AgentPID == nil || *s.AgentPID == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d", *s.AgentPID)
+}
+
+func (s stepView) roundSummary() string {
+	if s.Status == string(types.StepStatusFixing) {
+		if s.AutoFixLimit > 0 && s.FixRoundCount > 0 {
+			return fmt.Sprintf("auto-fix %d/%d", s.FixRoundCount, s.AutoFixLimit)
+		}
+		if s.FixRoundCount > 0 {
+			return fmt.Sprintf("fix %d", s.FixRoundCount)
+		}
+		return "fixing"
+	}
+	if s.RoundCount > 0 {
+		return fmt.Sprintf("round %d", s.RoundCount)
+	}
+	return "starting"
+}
+
+func formatDurationSince(sinceUnix int64) string {
+	secs := nowUnix() - sinceUnix
+	if secs < 0 {
+		secs = 0
+	}
+	return formatCompactDuration(time.Duration(secs) * time.Second)
+}
+
+func formatCompactDuration(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm%ds", int(d.Minutes()), int(d.Seconds())%60)
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh%dm", int(d.Hours()), int(d.Minutes())%60)
+	default:
+		return fmt.Sprintf("%dd%dh", int(d.Hours())/24, int(d.Hours())%24)
+	}
+}
+
 func joinComma(parts []string) string {
 	out := ""
 	for i, p := range parts {
@@ -281,6 +409,9 @@ func runObjectFieldWithKey(key string, rv runView) toon.Field {
 		rows = append(rows, stepRow{Step: s.Name, Status: s.Status, Findings: s.findingCount(), DurationMS: s.DurationMS})
 	}
 	fields = append(fields, toon.Field{Key: "steps", Value: rows})
+	if activeRows := rv.activeRows(); len(activeRows) > 0 {
+		fields = append(fields, toon.Field{Key: "active_steps", Value: activeRows})
+	}
 	return toon.Field{Key: key, Value: toon.NewObject(fields...)}
 }
 

--- a/internal/cli/axi_render.go
+++ b/internal/cli/axi_render.go
@@ -71,20 +71,21 @@ type fixRow struct {
 // stepView is a render-ready view of a single pipeline step, decoupled from
 // whether it came from the daemon (ipc) or the local database.
 type stepView struct {
-	ID             string
-	Name           string
-	Status         string
-	DurationMS     int64
-	FindingsJSON   string
-	FixSummaries   []string
-	StartedAt      *int64
-	LastActivityAt *int64
-	LastActivity   string
-	AgentPID       *int
-	RoundCount     int
-	FixRoundCount  int
-	AutoFixLimit   int
-	QuietWarning   time.Duration
+	ID               string
+	Name             string
+	Status           string
+	DurationMS       int64
+	FindingsJSON     string
+	FixSummaries     []string
+	StartedAt        *int64
+	LastActivityAt   *int64
+	LastActivity     string
+	AgentPID         *int
+	RoundCount       int
+	FixRoundCount    int
+	AutoFixLimit     int
+	PendingFixSource string
+	QuietWarning     time.Duration
 }
 
 // runView is a render-ready view of a pipeline run.
@@ -114,15 +115,17 @@ func runViewFromIPC(r *ipc.RunInfo) runView {
 	}
 	for _, s := range r.Steps {
 		sv := stepView{
-			ID:             s.ID,
-			Name:           string(s.StepName),
-			Status:         string(s.Status),
-			FixSummaries:   s.FixSummaries,
-			StartedAt:      s.StartedAt,
-			LastActivityAt: s.LastActivityAt,
-			AgentPID:       s.AgentPID,
-			RoundCount:     s.RoundCount,
-			FixRoundCount:  s.FixRoundCount,
+			ID:               s.ID,
+			Name:             string(s.StepName),
+			Status:           string(s.Status),
+			FixSummaries:     s.FixSummaries,
+			StartedAt:        s.StartedAt,
+			LastActivityAt:   s.LastActivityAt,
+			AgentPID:         s.AgentPID,
+			RoundCount:       s.RoundCount,
+			FixRoundCount:    s.FixRoundCount,
+			AutoFixLimit:     s.AutoFixLimit,
+			PendingFixSource: s.PendingFixSource,
 		}
 		if s.LastActivity != nil {
 			sv.LastActivity = *s.LastActivity
@@ -157,6 +160,9 @@ func runViewFromDB(r *db.Run, steps []*db.StepResult) runView {
 			StartedAt:      s.StartedAt,
 			LastActivityAt: s.LastActivityAt,
 			AgentPID:       s.AgentPID,
+		}
+		if s.AutoFixLimit != nil {
+			sv.AutoFixLimit = *s.AutoFixLimit
 		}
 		if s.LastActivity != nil {
 			sv.LastActivity = *s.LastActivity
@@ -333,11 +339,18 @@ func (s stepView) agentPIDString() string {
 
 func (s stepView) roundSummary() string {
 	if s.Status == string(types.StepStatusFixing) {
-		if s.AutoFixLimit > 0 && s.FixRoundCount > 0 {
-			return fmt.Sprintf("auto-fix %d/%d", s.FixRoundCount, s.AutoFixLimit)
+		attempt := s.FixRoundCount
+		if s.PendingFixSource != "" {
+			attempt++
 		}
-		if s.FixRoundCount > 0 {
-			return fmt.Sprintf("fix %d", s.FixRoundCount)
+		if s.PendingFixSource == db.RoundSelectionSourceAutoFix {
+			if s.AutoFixLimit > 0 {
+				return fmt.Sprintf("auto-fix %d/%d", attempt, s.AutoFixLimit)
+			}
+			return fmt.Sprintf("auto-fix %d", attempt)
+		}
+		if attempt > 0 {
+			return fmt.Sprintf("fix %d", attempt)
 		}
 		return "fixing"
 	}

--- a/internal/cli/axi_test.go
+++ b/internal/cli/axi_test.go
@@ -427,6 +427,18 @@ func TestActiveRunInfoForHeadRequiresMatchingHead(t *testing.T) {
 	}
 }
 
+func TestConfigErrorForFreshAxiRunAllowsReattach(t *testing.T) {
+	configErr := errors.New("parse global config: bad yaml")
+	env := &axiEnv{globalConfigErr: configErr}
+
+	if err := configErrorForFreshAxiRun(env, "run-1"); err != nil {
+		t.Fatalf("reattaching to an active run should not require global config: %v", err)
+	}
+	if err := configErrorForFreshAxiRun(env, ""); !errors.Is(err, configErr) {
+		t.Fatalf("fresh run config error = %v, want %v", err, configErr)
+	}
+}
+
 func TestRerunParamsIncludeSkipSteps(t *testing.T) {
 	params := rerunParams("repo-1", "feature/x", []types.StepName{types.StepReview}, "user goal")
 	if params.RepoID != "repo-1" || params.Branch != "feature/x" || params.Intent != "user goal" {

--- a/internal/cli/axi_test.go
+++ b/internal/cli/axi_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	toon "github.com/toon-format/toon-go"
@@ -145,6 +146,47 @@ func TestRunObjectRendersAwaitingAgent(t *testing.T) {
 	rv.Status = string(types.RunCompleted)
 	if out := axiDoc(runObjectField(rv)); strings.Contains(out, "awaiting_agent") {
 		t.Errorf("terminal run should not render awaiting_agent in:\n%s", out)
+	}
+}
+
+func TestRunObjectRendersActiveStepDiagnostics(t *testing.T) {
+	restore := nowUnix
+	nowUnix = func() int64 { return 1_000_000 }
+	defer func() { nowUnix = restore }()
+
+	started := int64(1_000_000 - 20*60)
+	last := int64(1_000_000 - 11*60)
+	pid := 4242
+	rv := runView{
+		ID:      "run-1",
+		Branch:  "feature/x",
+		Status:  string(types.RunRunning),
+		HeadSHA: "abcdef1234567890",
+		Steps: []stepView{
+			{
+				Name:           "review",
+				Status:         string(types.StepStatusFixing),
+				StartedAt:      &started,
+				LastActivityAt: &last,
+				LastActivity:   "codex started pid=4242",
+				AgentPID:       &pid,
+				FixRoundCount:  1,
+				AutoFixLimit:   3,
+				QuietWarning:   10 * time.Minute,
+			},
+		},
+	}
+	out := axiDoc(runObjectField(rv))
+
+	for _, want := range []string{
+		"active_steps[1]{step,status,active_for,last_activity,agent_pid,round}:\n",
+		"review,fixing,20m0s",
+		"quiet 11m0s ago: codex started pid=4242",
+		`,"4242",auto-fix 1/3`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("active diagnostics missing %q in:\n%s", want, out)
+		}
 	}
 }
 

--- a/internal/cli/axi_test.go
+++ b/internal/cli/axi_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	toon "github.com/toon-format/toon-go"
 
+	"github.com/kunchenguid/no-mistakes/internal/config"
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
@@ -164,15 +166,16 @@ func TestRunObjectRendersActiveStepDiagnostics(t *testing.T) {
 		HeadSHA: "abcdef1234567890",
 		Steps: []stepView{
 			{
-				Name:           "review",
-				Status:         string(types.StepStatusFixing),
-				StartedAt:      &started,
-				LastActivityAt: &last,
-				LastActivity:   "codex started pid=4242",
-				AgentPID:       &pid,
-				FixRoundCount:  1,
-				AutoFixLimit:   3,
-				QuietWarning:   10 * time.Minute,
+				Name:             "review",
+				Status:           string(types.StepStatusFixing),
+				StartedAt:        &started,
+				LastActivityAt:   &last,
+				LastActivity:     "codex started pid=4242",
+				AgentPID:         &pid,
+				FixRoundCount:    0,
+				AutoFixLimit:     3,
+				PendingFixSource: db.RoundSelectionSourceAutoFix,
+				QuietWarning:     10 * time.Minute,
 			},
 		},
 	}
@@ -187,6 +190,61 @@ func TestRunObjectRendersActiveStepDiagnostics(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("active diagnostics missing %q in:\n%s", want, out)
 		}
+	}
+}
+
+func TestStatusRendersCurrentAutoFixAttemptWithPersistedLimit(t *testing.T) {
+	database := openTestDB(t)
+	repo, err := database.InsertRepo(t.TempDir(), "origin", "main")
+	if err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+	run, err := database.InsertRun(repo.ID, "feature/current", "abcdef1234567890", "base")
+	if err != nil {
+		t.Fatalf("insert run: %v", err)
+	}
+	if err := database.UpdateRunStatus(run.ID, types.RunRunning); err != nil {
+		t.Fatalf("mark run running: %v", err)
+	}
+	step, err := database.InsertStepResult(run.ID, types.StepReview)
+	if err != nil {
+		t.Fatalf("insert step: %v", err)
+	}
+	if err := database.UpdateStepStatus(step.ID, types.StepStatusFixing); err != nil {
+		t.Fatalf("mark step fixing: %v", err)
+	}
+	if err := database.SetStepAutoFixLimit(step.ID, 2); err != nil {
+		t.Fatalf("set auto-fix limit: %v", err)
+	}
+	findings := findingsJSON(t, []types.Finding{{ID: "review-1", Action: types.ActionAutoFix, Description: "x"}}, "one")
+	round, err := database.InsertStepRound(step.ID, 1, "initial", &findings, nil, 10)
+	if err != nil {
+		t.Fatalf("insert round: %v", err)
+	}
+	selected := `["review-1"]`
+	if err := database.SetStepRoundSelection(round.ID, &selected, db.RoundSelectionSourceAutoFix); err != nil {
+		t.Fatalf("set selected findings: %v", err)
+	}
+
+	steps, err := database.GetStepsByRun(run.ID)
+	if err != nil {
+		t.Fatalf("load steps: %v", err)
+	}
+	rv := runViewFromDB(run, steps)
+	reviewLimit := 9
+	annotateRunView(&axiEnv{
+		d: database,
+		p: paths.WithRoot(t.TempDir()),
+		cfg: &config.GlobalConfig{
+			AutoFix: config.AutoFixRaw{Review: &reviewLimit},
+		},
+	}, &rv)
+	out := axiDoc(runObjectField(rv))
+	if !strings.Contains(out, `review,fixing`) || !strings.Contains(out, `auto-fix 1/2`) {
+		t.Fatalf("status should render the in-flight first auto-fix attempt with persisted limit, got:\n%s", out)
+	}
+	if strings.Contains(out, `auto-fix 1/9`) {
+		t.Fatalf("status should not use the current global config limit, got:\n%s", out)
 	}
 }
 
@@ -486,6 +544,66 @@ func TestAxiHomeStartsCurrentBranchWhenOtherBranchIsActive(t *testing.T) {
 	} {
 		if strings.Contains(got, forbidden) {
 			t.Fatalf("axi home should not tell the agent to act on another branch via %q, got:\n%s", forbidden, got)
+		}
+	}
+}
+
+func TestAxiStatusIgnoresInvalidGlobalConfig(t *testing.T) {
+	repoDir := t.TempDir()
+	nmHome := t.TempDir()
+	t.Setenv("NM_HOME", nmHome)
+	run(t, repoDir, "git", "init")
+	run(t, repoDir, "git", "config", "user.email", "test@test.com")
+	run(t, repoDir, "git", "config", "user.name", "Test")
+	run(t, repoDir, "git", "commit", "--allow-empty", "-m", "initial")
+	rawRoot, err := filepath.EvalSymlinks(repoDir)
+	if err != nil {
+		rawRoot = repoDir
+	}
+	chdir(t, rawRoot)
+
+	p := paths.WithRoot(nmHome)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	if err := os.WriteFile(p.ConfigFile(), []byte("agent: [\n"), 0o644); err != nil {
+		t.Fatalf("write invalid config: %v", err)
+	}
+	database, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+	repo, err := database.InsertRepoWithID("repo-1", rawRoot, "origin", "main")
+	if err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+	dbRun, err := database.InsertRun(repo.ID, "main", "head", "base")
+	if err != nil {
+		t.Fatalf("insert run: %v", err)
+	}
+	if err := database.UpdateRunStatus(dbRun.ID, types.RunCompleted); err != nil {
+		t.Fatalf("mark run completed: %v", err)
+	}
+	step, err := database.InsertStepResult(dbRun.ID, types.StepReview)
+	if err != nil {
+		t.Fatalf("insert step: %v", err)
+	}
+	if err := database.CompleteStep(step.ID, 0, 10, ""); err != nil {
+		t.Fatalf("complete step: %v", err)
+	}
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&out)
+	if err := runAxiStatus(cmd, dbRun.ID); err != nil {
+		t.Fatalf("axi status should not fail on invalid global config: %v\n%s", err, out.String())
+	}
+	got := out.String()
+	for _, want := range []string{"run:", `id: "` + dbRun.ID + `"`, "status: completed"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("axi status missing %q in:\n%s", want, got)
 		}
 	}
 }

--- a/internal/cli/axi_test.go
+++ b/internal/cli/axi_test.go
@@ -608,6 +608,55 @@ func TestAxiStatusIgnoresInvalidGlobalConfig(t *testing.T) {
 	}
 }
 
+func TestAxiRunReportsInvalidGlobalConfig(t *testing.T) {
+	repoDir := t.TempDir()
+	nmHome := makeSocketSafeTempDir(t)
+	t.Setenv("NM_HOME", nmHome)
+	t.Setenv("NM_TEST_DAEMON_START_TIMEOUT", "100ms")
+	t.Setenv("NM_TEST_DAEMON_START_POLL_INTERVAL", "10ms")
+	run(t, repoDir, "git", "init")
+	run(t, repoDir, "git", "config", "user.email", "test@test.com")
+	run(t, repoDir, "git", "config", "user.name", "Test")
+	run(t, repoDir, "git", "commit", "--allow-empty", "-m", "initial")
+	run(t, repoDir, "git", "checkout", "-b", "feature/config")
+	rawRoot, err := filepath.EvalSymlinks(repoDir)
+	if err != nil {
+		rawRoot = repoDir
+	}
+	chdir(t, rawRoot)
+
+	p := paths.WithRoot(nmHome)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	if err := os.WriteFile(p.ConfigFile(), []byte("agent: [\n"), 0o644); err != nil {
+		t.Fatalf("write invalid config: %v", err)
+	}
+	database, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer database.Close()
+	if _, err := database.InsertRepoWithID("repo-1", rawRoot, "origin", "main"); err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&out)
+	if err := runAxiRun(cmd, false, nil, "user goal"); err == nil {
+		t.Fatalf("axi run should fail on invalid global config:\n%s", out.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "parse global config") {
+		t.Fatalf("axi run should report the config parse error, got:\n%s", got)
+	}
+	if strings.Contains(got, "start daemon") {
+		t.Fatalf("axi run should fail before daemon startup, got:\n%s", got)
+	}
+}
+
 // TestAxiAbortByRunIDNoOpWhenDaemonStopped covers the abort-by-id path when no
 // daemon is running: a run only exists in a live daemon's memory, so there is
 // nothing to cancel and the command reports a successful no-op without needing

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -646,15 +646,20 @@ func EnsureDefaultGlobalConfig(path string) {
 	}
 }
 
-// LoadGlobal reads global config from path. Returns defaults if file doesn't exist.
-func LoadGlobal(path string) (*GlobalConfig, error) {
-	cfg := &GlobalConfig{
+// DefaultGlobalConfig returns the built-in global defaults.
+func DefaultGlobalConfig() *GlobalConfig {
+	return &GlobalConfig{
 		Agent:            types.AgentAuto,
 		Agents:           []types.AgentName{types.AgentAuto},
 		CITimeout:        DefaultCITimeout,
 		StepQuietWarning: DefaultStepQuietWarning,
 		LogLevel:         "info",
 	}
+}
+
+// LoadGlobal reads global config from path. Returns defaults if file doesn't exist.
+func LoadGlobal(path string) (*GlobalConfig, error) {
+	cfg := DefaultGlobalConfig()
 
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,9 @@ import (
 const (
 	// DefaultCITimeout is the monitor's idle timeout when ci_timeout is unset.
 	DefaultCITimeout = 7 * 24 * time.Hour
+	// DefaultStepQuietWarning is how long a running/fixing step can go without
+	// a new log or lifecycle activity before AXI status marks it quiet.
+	DefaultStepQuietWarning = 10 * time.Minute
 	// CITimeoutUnlimited is the sentinel meaning "monitor until the PR is
 	// merged, closed, or the run is aborted - never self-terminate".
 	// Any non-positive ci_timeout, or the keywords "unlimited", "none",
@@ -46,6 +49,7 @@ type GlobalConfig struct {
 	AgentPathOverride    map[string]string   `yaml:"agent_path_override"`
 	AgentArgsOverride    map[string][]string `yaml:"agent_args_override"`
 	CITimeout            time.Duration       `yaml:"-"`
+	StepQuietWarning     time.Duration       `yaml:"-"`
 	LogLevel             string              `yaml:"log_level"`
 	AutoFix              AutoFixRaw
 	Intent               IntentRaw
@@ -61,6 +65,7 @@ type globalConfigRaw struct {
 	AgentArgsOverride    map[string][]string `yaml:"agent_args_override"`
 	CITimeout            string              `yaml:"ci_timeout"`
 	BabysitTimeout       string              `yaml:"babysit_timeout"`
+	StepQuietWarning     string              `yaml:"step_quiet_warning"`
 	LogLevel             string              `yaml:"log_level"`
 	AutoFix              AutoFixRaw          `yaml:"auto_fix"`
 	Intent               IntentRaw           `yaml:"intent"`
@@ -149,6 +154,7 @@ type Config struct {
 	AgentPathOverride    map[string]string
 	AgentArgsOverride    map[string][]string
 	CITimeout            time.Duration
+	StepQuietWarning     time.Duration
 	LogLevel             string
 	Commands             Commands
 	IgnorePatterns       []string
@@ -271,6 +277,11 @@ agent: auto
 # non-positive duration to monitor until the PR is merged, closed, or the run is
 # aborted with: no-mistakes axi abort --run <id>
 ci_timeout: "168h"
+
+# AXI status marks a running/fixing step as quiet when no step log or native
+# agent lifecycle activity has appeared for this long. This is observability
+# only; it never cancels work.
+step_quiet_warning: "10m"
 
 # Log level for daemon output
 # Options: debug, info, warn, error
@@ -638,10 +649,11 @@ func EnsureDefaultGlobalConfig(path string) {
 // LoadGlobal reads global config from path. Returns defaults if file doesn't exist.
 func LoadGlobal(path string) (*GlobalConfig, error) {
 	cfg := &GlobalConfig{
-		Agent:     types.AgentAuto,
-		Agents:    []types.AgentName{types.AgentAuto},
-		CITimeout: DefaultCITimeout,
-		LogLevel:  "info",
+		Agent:            types.AgentAuto,
+		Agents:           []types.AgentName{types.AgentAuto},
+		CITimeout:        DefaultCITimeout,
+		StepQuietWarning: DefaultStepQuietWarning,
+		LogLevel:         "info",
 	}
 
 	data, err := os.ReadFile(path)
@@ -688,6 +700,15 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 			return nil, err
 		}
 		cfg.CITimeout = d
+	}
+	if raw.StepQuietWarning != "" {
+		d, err := time.ParseDuration(raw.StepQuietWarning)
+		if err != nil {
+			return nil, fmt.Errorf("parse step_quiet_warning %q: %w", raw.StepQuietWarning, err)
+		}
+		if d > 0 {
+			cfg.StepQuietWarning = d
+		}
 	}
 	if raw.LogLevel != "" {
 		cfg.LogLevel = raw.LogLevel
@@ -947,6 +968,7 @@ func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 		AgentPathOverride:    global.AgentPathOverride,
 		AgentArgsOverride:    global.AgentArgsOverride,
 		CITimeout:            global.CITimeout,
+		StepQuietWarning:     global.StepQuietWarning,
 		LogLevel:             global.LogLevel,
 		Commands:             repo.Commands,
 		IgnorePatterns:       repo.IgnorePatterns,

--- a/internal/config/config_global_test.go
+++ b/internal/config/config_global_test.go
@@ -23,6 +23,9 @@ func TestLoadGlobal_Defaults(t *testing.T) {
 	if cfg.CITimeout != DefaultCITimeout {
 		t.Errorf("ci_timeout = %v, want %v", cfg.CITimeout, DefaultCITimeout)
 	}
+	if cfg.StepQuietWarning != DefaultStepQuietWarning {
+		t.Errorf("step_quiet_warning = %v, want %v", cfg.StepQuietWarning, DefaultStepQuietWarning)
+	}
 	if cfg.LogLevel != "info" {
 		t.Errorf("log_level = %q, want %q", cfg.LogLevel, "info")
 	}
@@ -45,6 +48,7 @@ func TestEnsureDefaultGlobalConfig_CreatesFile(t *testing.T) {
 	for _, want := range []string{
 		"agent: auto",
 		"ci_timeout:",
+		"step_quiet_warning:",
 		"log_level: info",
 		"# agent_path_override:",
 	} {
@@ -70,8 +74,27 @@ func TestEnsureDefaultGlobalConfig_CreatedConfigIsLoadable(t *testing.T) {
 	if cfg.CITimeout != DefaultCITimeout {
 		t.Errorf("ci_timeout = %v, want %v", cfg.CITimeout, DefaultCITimeout)
 	}
+	if cfg.StepQuietWarning != DefaultStepQuietWarning {
+		t.Errorf("step_quiet_warning = %v, want %v", cfg.StepQuietWarning, DefaultStepQuietWarning)
+	}
 	if cfg.LogLevel != "info" {
 		t.Errorf("log_level = %q, want %q", cfg.LogLevel, "info")
+	}
+}
+
+func TestLoadGlobal_StepQuietWarning(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("step_quiet_warning: 90s\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadGlobal(path)
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	if cfg.StepQuietWarning != 90*time.Second {
+		t.Fatalf("step_quiet_warning = %v, want 90s", cfg.StepQuietWarning)
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -564,6 +564,9 @@ func stepToInfo(d *db.DB, s *db.StepResult) ipc.StepResultInfo {
 		LastActivity:   s.LastActivity,
 		AgentPID:       s.AgentPID,
 	}
+	if s.AutoFixLimit != nil {
+		info.AutoFixLimit = *s.AutoFixLimit
+	}
 	if stats, err := d.StepFindingStats(s); err == nil {
 		info.ReportedFindings = stats.ReportedFindings
 		info.FixedFindings = stats.FixedFindings
@@ -574,6 +577,7 @@ func stepToInfo(d *db.DB, s *db.StepResult) ipc.StepResultInfo {
 	if rounds, err := d.StepRoundStats(s.ID); err == nil {
 		info.RoundCount = rounds.TotalRounds
 		info.FixRoundCount = rounds.FixRounds
+		info.PendingFixSource = rounds.PendingFixSource
 	}
 	return info
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -549,17 +549,20 @@ func runToInfo(d *db.DB, r *db.Run, steps []*db.StepResult) *ipc.RunInfo {
 
 func stepToInfo(d *db.DB, s *db.StepResult) ipc.StepResultInfo {
 	info := ipc.StepResultInfo{
-		ID:           s.ID,
-		RunID:        s.RunID,
-		StepName:     s.StepName,
-		StepOrder:    s.StepOrder,
-		Status:       s.Status,
-		ExitCode:     s.ExitCode,
-		DurationMS:   s.DurationMS,
-		FindingsJSON: s.FindingsJSON,
-		Error:        s.Error,
-		StartedAt:    s.StartedAt,
-		CompletedAt:  s.CompletedAt,
+		ID:             s.ID,
+		RunID:          s.RunID,
+		StepName:       s.StepName,
+		StepOrder:      s.StepOrder,
+		Status:         s.Status,
+		ExitCode:       s.ExitCode,
+		DurationMS:     s.DurationMS,
+		FindingsJSON:   s.FindingsJSON,
+		Error:          s.Error,
+		StartedAt:      s.StartedAt,
+		CompletedAt:    s.CompletedAt,
+		LastActivityAt: s.LastActivityAt,
+		LastActivity:   s.LastActivity,
+		AgentPID:       s.AgentPID,
 	}
 	if stats, err := d.StepFindingStats(s); err == nil {
 		info.ReportedFindings = stats.ReportedFindings
@@ -567,6 +570,10 @@ func stepToInfo(d *db.DB, s *db.StepResult) ipc.StepResultInfo {
 	}
 	if summaries, err := d.StepFixSummaries(s.ID); err == nil {
 		info.FixSummaries = summaries
+	}
+	if rounds, err := d.StepRoundStats(s.ID); err == nil {
+		info.RoundCount = rounds.TotalRounds
+		info.FixRoundCount = rounds.FixRounds
 	}
 	return info
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -41,6 +41,11 @@ func TestOpenCreatesSchema(t *testing.T) {
 	if !hasColumn(t, d, "repos", "fork_url") {
 		t.Fatal("repos.fork_url column missing from fresh schema")
 	}
+	for _, column := range []string{"last_activity_at", "last_activity", "agent_pid"} {
+		if !hasColumn(t, d, "step_results", column) {
+			t.Fatalf("step_results.%s column missing from fresh schema", column)
+		}
+	}
 }
 
 func TestOpenCreatesStepRoundsTable(t *testing.T) {
@@ -162,6 +167,49 @@ func TestOpenMigratesReposForkURLColumn(t *testing.T) {
 	}
 	if updated.ForkURL != "git@github.com:fork/repo.git" {
 		t.Fatalf("fork url after update = %q, want fork URL", updated.ForkURL)
+	}
+}
+
+func TestOpenMigratesStepActivityColumns(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "test.sqlite")
+
+	legacyDB, err := sql.Open("sqlite", dbPath+"?_pragma=journal_mode(wal)&_pragma=foreign_keys(on)")
+	if err != nil {
+		t.Fatalf("open legacy db: %v", err)
+	}
+	if _, err := legacyDB.Exec(`
+		CREATE TABLE step_results (
+			id TEXT PRIMARY KEY,
+			run_id TEXT NOT NULL,
+			step_name TEXT NOT NULL,
+			step_order INTEGER NOT NULL,
+			status TEXT NOT NULL DEFAULT 'pending',
+			exit_code INTEGER,
+			duration_ms INTEGER,
+			log_path TEXT,
+			findings_json TEXT,
+			error TEXT,
+			started_at INTEGER,
+			completed_at INTEGER
+		);
+	`); err != nil {
+		legacyDB.Close()
+		t.Fatalf("create legacy step_results table: %v", err)
+	}
+	if err := legacyDB.Close(); err != nil {
+		t.Fatalf("close legacy db: %v", err)
+	}
+
+	d, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open migrated db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+
+	for _, column := range []string{"last_activity_at", "last_activity", "agent_pid"} {
+		if !hasColumn(t, d, "step_results", column) {
+			t.Fatalf("expected migrated column %q", column)
+		}
 	}
 }
 

--- a/internal/db/round.go
+++ b/internal/db/round.go
@@ -49,6 +49,7 @@ type StepRoundStats struct {
 	LatestFixRoundAt   int64
 	SelectedForFix     bool
 	AutoSelectedForFix bool
+	PendingFixSource   string
 }
 
 // IsFixRound reports whether this round was a fix attempt. Legacy "user_fix"
@@ -85,6 +86,8 @@ func (d *DB) StepRoundStats(stepResultID string) (StepRoundStats, error) {
 		return StepRoundStats{}, err
 	}
 	var stats StepRoundStats
+	latestSelectedRound := 0
+	latestSelectedSource := ""
 	for _, r := range rounds {
 		stats.TotalRounds++
 		stats.LatestRound = r.Round
@@ -96,12 +99,17 @@ func (d *DB) StepRoundStats(stepResultID string) (StepRoundStats, error) {
 		if r.SelectedFindingIDs != nil && *r.SelectedFindingIDs != "" {
 			stats.SelectedForFix = true
 			stats.AutoSelectedForFix = r.SelectionSource != nil && *r.SelectionSource == RoundSelectionSourceAutoFix
+			latestSelectedRound = r.Round
+			latestSelectedSource = stats.LatestSelection
 		}
 		if r.IsFixRound() {
 			stats.FixRounds++
 			stats.LatestFixRound = stats.FixRounds
 			stats.LatestFixRoundAt = r.CreatedAt
 		}
+	}
+	if latestSelectedRound == stats.LatestRound {
+		stats.PendingFixSource = latestSelectedSource
 	}
 	return stats, nil
 }

--- a/internal/db/round.go
+++ b/internal/db/round.go
@@ -35,6 +35,22 @@ type StepRound struct {
 	CreatedAt  int64
 }
 
+// StepRoundStats summarizes execution rounds for a step. It lets status
+// surfaces show whether a running/fixing step is in an initial pass or a fix
+// pass without reloading every round in callers.
+type StepRoundStats struct {
+	TotalRounds        int
+	FixRounds          int
+	LatestRound        int
+	LatestTrigger      string
+	LatestSelection    string
+	LatestRoundAt      int64
+	LatestFixRound     int
+	LatestFixRoundAt   int64
+	SelectedForFix     bool
+	AutoSelectedForFix bool
+}
+
 // IsFixRound reports whether this round was a fix attempt. Legacy "user_fix"
 // rounds count: they were fix rounds dispatched by an explicit user selection.
 func (r *StepRound) IsFixRound() bool {
@@ -60,6 +76,34 @@ func (d *DB) StepFixSummaries(stepResultID string) ([]string, error) {
 		summaries = append(summaries, summary)
 	}
 	return summaries, nil
+}
+
+// StepRoundStats returns aggregate round information for a step result.
+func (d *DB) StepRoundStats(stepResultID string) (StepRoundStats, error) {
+	rounds, err := d.GetRoundsByStep(stepResultID)
+	if err != nil {
+		return StepRoundStats{}, err
+	}
+	var stats StepRoundStats
+	for _, r := range rounds {
+		stats.TotalRounds++
+		stats.LatestRound = r.Round
+		stats.LatestTrigger = r.Trigger
+		stats.LatestRoundAt = r.CreatedAt
+		if r.SelectionSource != nil {
+			stats.LatestSelection = *r.SelectionSource
+		}
+		if r.SelectedFindingIDs != nil && *r.SelectedFindingIDs != "" {
+			stats.SelectedForFix = true
+			stats.AutoSelectedForFix = r.SelectionSource != nil && *r.SelectionSource == RoundSelectionSourceAutoFix
+		}
+		if r.IsFixRound() {
+			stats.FixRounds++
+			stats.LatestFixRound = stats.FixRounds
+			stats.LatestFixRoundAt = r.CreatedAt
+		}
+	}
+	return stats, nil
 }
 
 // InsertStepRound creates a new round record for a step result. fixSummary may

--- a/internal/db/round_test.go
+++ b/internal/db/round_test.go
@@ -153,6 +153,39 @@ func TestStepFixSummaries(t *testing.T) {
 	}
 }
 
+func TestStepRoundStats(t *testing.T) {
+	d := openTestDB(t)
+	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")
+	run, _ := d.InsertRun(repo.ID, "feature", "abc", "def")
+	step, _ := d.InsertStepResult(run.ID, types.StepLint)
+
+	findings := `{"findings":[{"id":"lint-1","action":"auto-fix","description":"missing check"}]}`
+	round1, _ := d.InsertStepRound(step.ID, 1, "initial", &findings, nil, 800)
+	selected := `["lint-1"]`
+	if err := d.SetStepRoundSelection(round1.ID, &selected, RoundSelectionSourceAutoFix); err != nil {
+		t.Fatalf("set selection: %v", err)
+	}
+	fixSummary := "fix missing check"
+	d.InsertStepRound(step.ID, 2, "auto_fix", nil, &fixSummary, 600)
+
+	stats, err := d.StepRoundStats(step.ID)
+	if err != nil {
+		t.Fatalf("step round stats: %v", err)
+	}
+	if stats.TotalRounds != 2 {
+		t.Fatalf("total rounds = %d, want 2", stats.TotalRounds)
+	}
+	if stats.FixRounds != 1 {
+		t.Fatalf("fix rounds = %d, want 1", stats.FixRounds)
+	}
+	if stats.LatestRound != 2 || stats.LatestTrigger != "auto_fix" {
+		t.Fatalf("latest = round %d trigger %q, want round 2 auto_fix", stats.LatestRound, stats.LatestTrigger)
+	}
+	if !stats.SelectedForFix || !stats.AutoSelectedForFix {
+		t.Fatalf("selection flags = selected %v auto %v, want both true", stats.SelectedForFix, stats.AutoSelectedForFix)
+	}
+}
+
 func TestStepFixSummariesNoFixRounds(t *testing.T) {
 	d := openTestDB(t)
 	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -39,7 +39,8 @@ CREATE TABLE IF NOT EXISTS step_results (
     completed_at     INTEGER,
     last_activity_at INTEGER,
     last_activity    TEXT,
-    agent_pid        INTEGER
+    agent_pid        INTEGER,
+    auto_fix_limit   INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS step_rounds (
@@ -82,4 +83,5 @@ var migrationStatements = []string{
 	`ALTER TABLE step_results ADD COLUMN last_activity_at INTEGER`,
 	`ALTER TABLE step_results ADD COLUMN last_activity TEXT`,
 	`ALTER TABLE step_results ADD COLUMN agent_pid INTEGER`,
+	`ALTER TABLE step_results ADD COLUMN auto_fix_limit INTEGER`,
 }

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -25,18 +25,21 @@ CREATE TABLE IF NOT EXISTS runs (
 );
 
 CREATE TABLE IF NOT EXISTS step_results (
-    id            TEXT PRIMARY KEY,
-    run_id        TEXT NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
-    step_name     TEXT NOT NULL,
-    step_order    INTEGER NOT NULL,
-    status        TEXT NOT NULL DEFAULT 'pending',
-    exit_code     INTEGER,
-    duration_ms   INTEGER,
-    log_path      TEXT,
-    findings_json TEXT,
-    error         TEXT,
-    started_at    INTEGER,
-    completed_at  INTEGER
+    id               TEXT PRIMARY KEY,
+    run_id           TEXT NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+    step_name        TEXT NOT NULL,
+    step_order       INTEGER NOT NULL,
+    status           TEXT NOT NULL DEFAULT 'pending',
+    exit_code        INTEGER,
+    duration_ms      INTEGER,
+    log_path         TEXT,
+    findings_json    TEXT,
+    error            TEXT,
+    started_at       INTEGER,
+    completed_at     INTEGER,
+    last_activity_at INTEGER,
+    last_activity    TEXT,
+    agent_pid        INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS step_rounds (
@@ -76,4 +79,7 @@ var migrationStatements = []string{
 	`ALTER TABLE runs ADD COLUMN intent_session_id TEXT`,
 	`ALTER TABLE runs ADD COLUMN intent_score REAL`,
 	`ALTER TABLE runs ADD COLUMN awaiting_agent_since INTEGER`,
+	`ALTER TABLE step_results ADD COLUMN last_activity_at INTEGER`,
+	`ALTER TABLE step_results ADD COLUMN last_activity TEXT`,
+	`ALTER TABLE step_results ADD COLUMN agent_pid INTEGER`,
 }

--- a/internal/db/step.go
+++ b/internal/db/step.go
@@ -24,9 +24,10 @@ type StepResult struct {
 	LastActivityAt *int64
 	LastActivity   *string
 	AgentPID       *int
+	AutoFixLimit   *int
 }
 
-const stepResultColumns = `id, run_id, step_name, step_order, status, exit_code, duration_ms, log_path, findings_json, error, started_at, completed_at, last_activity_at, last_activity, agent_pid`
+const stepResultColumns = `id, run_id, step_name, step_order, status, exit_code, duration_ms, log_path, findings_json, error, started_at, completed_at, last_activity_at, last_activity, agent_pid, auto_fix_limit`
 
 // InsertStepResult creates a new step result record.
 func (d *DB) InsertStepResult(runID string, stepName types.StepName) (*StepResult, error) {
@@ -52,7 +53,7 @@ func (d *DB) GetStepResult(id string) (*StepResult, error) {
 	s := &StepResult{}
 	err := d.sql.QueryRow(
 		`SELECT `+stepResultColumns+` FROM step_results WHERE id = ?`, id,
-	).Scan(&s.ID, &s.RunID, &s.StepName, &s.StepOrder, &s.Status, &s.ExitCode, &s.DurationMS, &s.LogPath, &s.FindingsJSON, &s.Error, &s.StartedAt, &s.CompletedAt, &s.LastActivityAt, &s.LastActivity, &s.AgentPID)
+	).Scan(&s.ID, &s.RunID, &s.StepName, &s.StepOrder, &s.Status, &s.ExitCode, &s.DurationMS, &s.LogPath, &s.FindingsJSON, &s.Error, &s.StartedAt, &s.CompletedAt, &s.LastActivityAt, &s.LastActivity, &s.AgentPID, &s.AutoFixLimit)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -74,7 +75,7 @@ func (d *DB) GetStepsByRun(runID string) ([]*StepResult, error) {
 	var steps []*StepResult
 	for rows.Next() {
 		s := &StepResult{}
-		if err := rows.Scan(&s.ID, &s.RunID, &s.StepName, &s.StepOrder, &s.Status, &s.ExitCode, &s.DurationMS, &s.LogPath, &s.FindingsJSON, &s.Error, &s.StartedAt, &s.CompletedAt, &s.LastActivityAt, &s.LastActivity, &s.AgentPID); err != nil {
+		if err := rows.Scan(&s.ID, &s.RunID, &s.StepName, &s.StepOrder, &s.Status, &s.ExitCode, &s.DurationMS, &s.LogPath, &s.FindingsJSON, &s.Error, &s.StartedAt, &s.CompletedAt, &s.LastActivityAt, &s.LastActivity, &s.AgentPID, &s.AutoFixLimit); err != nil {
 			return nil, fmt.Errorf("scan step result: %w", err)
 		}
 		steps = append(steps, s)
@@ -102,12 +103,30 @@ func (d *DB) UpdateStepStatusWithDuration(id string, status types.StepStatus, du
 
 // StartStep marks a step as running with a started_at timestamp.
 func (d *DB) StartStep(id string) error {
+	return d.StartStepWithAutoFixLimit(id, 0)
+}
+
+func (d *DB) StartStepWithAutoFixLimit(id string, autoFixLimit int) error {
 	ts := now()
-	_, err := d.sql.Exec(`UPDATE step_results SET status = ?, started_at = ?, last_activity_at = ?, last_activity = ?, agent_pid = NULL WHERE id = ?`, types.StepStatusRunning, ts, ts, "step started", id)
+	_, err := d.sql.Exec(`UPDATE step_results SET status = ?, started_at = ?, last_activity_at = ?, last_activity = ?, agent_pid = NULL, auto_fix_limit = ? WHERE id = ?`, types.StepStatusRunning, ts, ts, "step started", autoFixLimitDBValue(autoFixLimit), id)
 	if err != nil {
 		return fmt.Errorf("start step: %w", err)
 	}
 	return nil
+}
+
+func (d *DB) SetStepAutoFixLimit(id string, autoFixLimit int) error {
+	if _, err := d.sql.Exec(`UPDATE step_results SET auto_fix_limit = ? WHERE id = ?`, autoFixLimitDBValue(autoFixLimit), id); err != nil {
+		return fmt.Errorf("set step auto-fix limit: %w", err)
+	}
+	return nil
+}
+
+func autoFixLimitDBValue(autoFixLimit int) any {
+	if autoFixLimit <= 0 {
+		return nil
+	}
+	return autoFixLimit
 }
 
 // CompleteStep marks a step as completed with timing and result info.

--- a/internal/db/step.go
+++ b/internal/db/step.go
@@ -106,6 +106,8 @@ func (d *DB) StartStep(id string) error {
 	return d.StartStepWithAutoFixLimit(id, 0)
 }
 
+// StartStepWithAutoFixLimit marks a step as running and records the effective
+// auto-fix limit that status surfaces use while the step is active.
 func (d *DB) StartStepWithAutoFixLimit(id string, autoFixLimit int) error {
 	ts := now()
 	_, err := d.sql.Exec(`UPDATE step_results SET status = ?, started_at = ?, last_activity_at = ?, last_activity = ?, agent_pid = NULL, auto_fix_limit = ? WHERE id = ?`, types.StepStatusRunning, ts, ts, "step started", autoFixLimitDBValue(autoFixLimit), id)

--- a/internal/db/step.go
+++ b/internal/db/step.go
@@ -9,19 +9,24 @@ import (
 
 // StepResult represents the result of a pipeline step execution.
 type StepResult struct {
-	ID           string
-	RunID        string
-	StepName     types.StepName
-	StepOrder    int
-	Status       types.StepStatus
-	ExitCode     *int
-	DurationMS   *int64
-	LogPath      *string
-	FindingsJSON *string
-	Error        *string
-	StartedAt    *int64
-	CompletedAt  *int64
+	ID             string
+	RunID          string
+	StepName       types.StepName
+	StepOrder      int
+	Status         types.StepStatus
+	ExitCode       *int
+	DurationMS     *int64
+	LogPath        *string
+	FindingsJSON   *string
+	Error          *string
+	StartedAt      *int64
+	CompletedAt    *int64
+	LastActivityAt *int64
+	LastActivity   *string
+	AgentPID       *int
 }
+
+const stepResultColumns = `id, run_id, step_name, step_order, status, exit_code, duration_ms, log_path, findings_json, error, started_at, completed_at, last_activity_at, last_activity, agent_pid`
 
 // InsertStepResult creates a new step result record.
 func (d *DB) InsertStepResult(runID string, stepName types.StepName) (*StepResult, error) {
@@ -46,8 +51,8 @@ func (d *DB) InsertStepResult(runID string, stepName types.StepName) (*StepResul
 func (d *DB) GetStepResult(id string) (*StepResult, error) {
 	s := &StepResult{}
 	err := d.sql.QueryRow(
-		`SELECT id, run_id, step_name, step_order, status, exit_code, duration_ms, log_path, findings_json, error, started_at, completed_at FROM step_results WHERE id = ?`, id,
-	).Scan(&s.ID, &s.RunID, &s.StepName, &s.StepOrder, &s.Status, &s.ExitCode, &s.DurationMS, &s.LogPath, &s.FindingsJSON, &s.Error, &s.StartedAt, &s.CompletedAt)
+		`SELECT `+stepResultColumns+` FROM step_results WHERE id = ?`, id,
+	).Scan(&s.ID, &s.RunID, &s.StepName, &s.StepOrder, &s.Status, &s.ExitCode, &s.DurationMS, &s.LogPath, &s.FindingsJSON, &s.Error, &s.StartedAt, &s.CompletedAt, &s.LastActivityAt, &s.LastActivity, &s.AgentPID)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -60,7 +65,7 @@ func (d *DB) GetStepResult(id string) (*StepResult, error) {
 // GetStepsByRun returns all step results for a run, in execution order.
 func (d *DB) GetStepsByRun(runID string) ([]*StepResult, error) {
 	rows, err := d.sql.Query(
-		`SELECT id, run_id, step_name, step_order, status, exit_code, duration_ms, log_path, findings_json, error, started_at, completed_at FROM step_results WHERE run_id = ? ORDER BY step_order`, runID,
+		`SELECT `+stepResultColumns+` FROM step_results WHERE run_id = ? ORDER BY step_order`, runID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("get steps by run: %w", err)
@@ -69,7 +74,7 @@ func (d *DB) GetStepsByRun(runID string) ([]*StepResult, error) {
 	var steps []*StepResult
 	for rows.Next() {
 		s := &StepResult{}
-		if err := rows.Scan(&s.ID, &s.RunID, &s.StepName, &s.StepOrder, &s.Status, &s.ExitCode, &s.DurationMS, &s.LogPath, &s.FindingsJSON, &s.Error, &s.StartedAt, &s.CompletedAt); err != nil {
+		if err := rows.Scan(&s.ID, &s.RunID, &s.StepName, &s.StepOrder, &s.Status, &s.ExitCode, &s.DurationMS, &s.LogPath, &s.FindingsJSON, &s.Error, &s.StartedAt, &s.CompletedAt, &s.LastActivityAt, &s.LastActivity, &s.AgentPID); err != nil {
 			return nil, fmt.Errorf("scan step result: %w", err)
 		}
 		steps = append(steps, s)
@@ -79,7 +84,7 @@ func (d *DB) GetStepsByRun(runID string) ([]*StepResult, error) {
 
 // UpdateStepStatus updates a step's status.
 func (d *DB) UpdateStepStatus(id string, status types.StepStatus) error {
-	_, err := d.sql.Exec(`UPDATE step_results SET status = ? WHERE id = ?`, status, id)
+	_, err := d.sql.Exec(`UPDATE step_results SET status = ?, last_activity_at = ?, last_activity = ? WHERE id = ?`, status, now(), fmt.Sprintf("status: %s", status), id)
 	if err != nil {
 		return fmt.Errorf("update step status: %w", err)
 	}
@@ -88,7 +93,7 @@ func (d *DB) UpdateStepStatus(id string, status types.StepStatus) error {
 
 // UpdateStepStatusWithDuration updates a step's status and execution duration together.
 func (d *DB) UpdateStepStatusWithDuration(id string, status types.StepStatus, durationMS int64) error {
-	_, err := d.sql.Exec(`UPDATE step_results SET status = ?, duration_ms = ? WHERE id = ?`, status, durationMS, id)
+	_, err := d.sql.Exec(`UPDATE step_results SET status = ?, duration_ms = ?, last_activity_at = ?, last_activity = ? WHERE id = ?`, status, durationMS, now(), fmt.Sprintf("status: %s", status), id)
 	if err != nil {
 		return fmt.Errorf("update step status with duration: %w", err)
 	}
@@ -97,7 +102,8 @@ func (d *DB) UpdateStepStatusWithDuration(id string, status types.StepStatus, du
 
 // StartStep marks a step as running with a started_at timestamp.
 func (d *DB) StartStep(id string) error {
-	_, err := d.sql.Exec(`UPDATE step_results SET status = ?, started_at = ? WHERE id = ?`, types.StepStatusRunning, now(), id)
+	ts := now()
+	_, err := d.sql.Exec(`UPDATE step_results SET status = ?, started_at = ?, last_activity_at = ?, last_activity = ?, agent_pid = NULL WHERE id = ?`, types.StepStatusRunning, ts, ts, "step started", id)
 	if err != nil {
 		return fmt.Errorf("start step: %w", err)
 	}
@@ -112,8 +118,8 @@ func (d *DB) CompleteStep(id string, exitCode int, durationMS int64, logPath str
 // CompleteStepWithStatus marks a step as finished with timing and result info.
 func (d *DB) CompleteStepWithStatus(id string, status types.StepStatus, exitCode int, durationMS int64, logPath string) error {
 	_, err := d.sql.Exec(
-		`UPDATE step_results SET status = ?, exit_code = ?, duration_ms = ?, log_path = ?, completed_at = ? WHERE id = ?`,
-		status, exitCode, durationMS, logPath, now(), id,
+		`UPDATE step_results SET status = ?, exit_code = ?, duration_ms = ?, log_path = ?, completed_at = ?, last_activity_at = ?, last_activity = ?, agent_pid = NULL WHERE id = ?`,
+		status, exitCode, durationMS, logPath, now(), now(), fmt.Sprintf("status: %s", status), id,
 	)
 	if err != nil {
 		return fmt.Errorf("complete step: %w", err)
@@ -124,11 +130,31 @@ func (d *DB) CompleteStepWithStatus(id string, status types.StepStatus, exitCode
 // FailStep marks a step as failed with an error message and duration.
 func (d *DB) FailStep(id string, errMsg string, durationMS int64) error {
 	_, err := d.sql.Exec(
-		`UPDATE step_results SET status = ?, error = ?, duration_ms = ?, completed_at = ? WHERE id = ?`,
-		types.StepStatusFailed, errMsg, durationMS, now(), id,
+		`UPDATE step_results SET status = ?, error = ?, duration_ms = ?, completed_at = ?, last_activity_at = ?, last_activity = ?, agent_pid = NULL WHERE id = ?`,
+		types.StepStatusFailed, errMsg, durationMS, now(), now(), "step failed: "+errMsg, id,
 	)
 	if err != nil {
 		return fmt.Errorf("fail step: %w", err)
+	}
+	return nil
+}
+
+// TouchStepActivity records the latest meaningful activity for an active step
+// without changing its status or current agent pid.
+func (d *DB) TouchStepActivity(id string, text string) error {
+	_, err := d.sql.Exec(`UPDATE step_results SET last_activity_at = ?, last_activity = ? WHERE id = ?`, now(), text, id)
+	if err != nil {
+		return fmt.Errorf("touch step activity: %w", err)
+	}
+	return nil
+}
+
+// SetStepAgentActivity records an agent lifecycle activity and replaces the
+// active agent pid. Passing nil clears the pid after the process exits.
+func (d *DB) SetStepAgentActivity(id string, text string, agentPID *int) error {
+	_, err := d.sql.Exec(`UPDATE step_results SET last_activity_at = ?, last_activity = ?, agent_pid = ? WHERE id = ?`, now(), text, agentPID, id)
+	if err != nil {
+		return fmt.Errorf("set step agent activity: %w", err)
 	}
 	return nil
 }

--- a/internal/db/step_test.go
+++ b/internal/db/step_test.go
@@ -112,6 +112,53 @@ func TestStartStep(t *testing.T) {
 	if got.StartedAt == nil {
 		t.Error("expected non-nil started_at")
 	}
+	if got.LastActivityAt == nil {
+		t.Error("expected non-nil last_activity_at")
+	}
+	if got.LastActivity == nil || *got.LastActivity != "step started" {
+		t.Errorf("last_activity = %v, want step started", got.LastActivity)
+	}
+}
+
+func TestStepActivity(t *testing.T) {
+	d := openTestDB(t)
+	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")
+	run, _ := d.InsertRun(repo.ID, "feature", "abc", "def")
+	step, _ := d.InsertStepResult(run.ID, types.StepReview)
+
+	if err := d.StartStep(step.ID); err != nil {
+		t.Fatalf("start step: %v", err)
+	}
+	pid := 12345
+	if err := d.SetStepAgentActivity(step.ID, "codex started pid=12345", &pid); err != nil {
+		t.Fatalf("set agent activity: %v", err)
+	}
+	got, _ := d.GetStepResult(step.ID)
+	if got.AgentPID == nil || *got.AgentPID != pid {
+		t.Fatalf("agent_pid = %v, want %d", got.AgentPID, pid)
+	}
+	if got.LastActivity == nil || *got.LastActivity != "codex started pid=12345" {
+		t.Fatalf("last_activity = %v, want codex start", got.LastActivity)
+	}
+
+	if err := d.TouchStepActivity(step.ID, "log: still working"); err != nil {
+		t.Fatalf("touch activity: %v", err)
+	}
+	got, _ = d.GetStepResult(step.ID)
+	if got.AgentPID == nil || *got.AgentPID != pid {
+		t.Fatalf("touch should preserve agent_pid, got %v", got.AgentPID)
+	}
+	if got.LastActivity == nil || *got.LastActivity != "log: still working" {
+		t.Fatalf("last_activity = %v, want log activity", got.LastActivity)
+	}
+
+	if err := d.SetStepAgentActivity(step.ID, "codex exited pid=12345 status=success", nil); err != nil {
+		t.Fatalf("clear agent activity: %v", err)
+	}
+	got, _ = d.GetStepResult(step.ID)
+	if got.AgentPID != nil {
+		t.Fatalf("agent_pid = %v, want nil after exit", *got.AgentPID)
+	}
 }
 
 func TestCompleteStep(t *testing.T) {

--- a/internal/e2e/axi_journey_test.go
+++ b/internal/e2e/axi_journey_test.go
@@ -244,6 +244,60 @@ func TestAxiParkedAwaitingAgentSignal(t *testing.T) {
 	}
 }
 
+func TestAxiAttachCommandsIgnoreInvalidConfigWhenDaemonRunning(t *testing.T) {
+	h := NewHarness(t, SetupOpts{Agent: "claude", Scenario: axiScenario(t)})
+
+	h.CommitChange("init-invalid-config-attach", "seed.txt", "seed\n", "seed for invalid config attach")
+	initWorktree := h.AddWorktree("init-invalid-config-attach")
+	if out, err := h.RunInDir(initWorktree, "init"); err != nil {
+		t.Fatalf("nm init: %v\n%s", err, out)
+	}
+
+	h.CommitChange("feature/respond-invalid-config", "respond.txt", "change\n", "add respond invalid config")
+	respondWorktree := h.AddWorktree("feature/respond-invalid-config")
+	if out, err := h.RunInDir(respondWorktree, "axi", "run", "--intent", axiIntent); err != nil {
+		t.Fatalf("axi run respond branch: %v\n%s", err, out)
+	}
+	if gated := waitForStepStatus(t, h, "feature/respond-invalid-config", types.StepReview, types.StepStatusAwaitingApproval, 60*time.Second); gated == nil {
+		t.Fatal("expected respond branch to be awaiting approval")
+	}
+
+	h.CommitChange("feature/abort-invalid-config", "abort.txt", "change\n", "add abort invalid config")
+	abortWorktree := h.AddWorktree("feature/abort-invalid-config")
+	if out, err := h.RunInDir(abortWorktree, "axi", "run", "--intent", axiIntent); err != nil {
+		t.Fatalf("axi run abort branch: %v\n%s", err, out)
+	}
+	if gated := waitForStepStatus(t, h, "feature/abort-invalid-config", types.StepReview, types.StepStatusAwaitingApproval, 60*time.Second); gated == nil {
+		t.Fatal("expected abort branch to be awaiting approval")
+	}
+
+	if err := os.WriteFile(filepath.Join(h.NMHome, "config.yaml"), []byte("agent: [\n"), 0o644); err != nil {
+		t.Fatalf("write invalid config: %v", err)
+	}
+
+	doneOut, err := h.RunInDir(respondWorktree, "axi", "respond", "--action", "approve")
+	if err != nil {
+		t.Fatalf("axi respond with invalid config: %v\n%s", err, doneOut)
+	}
+	if !strings.Contains(doneOut, "outcome: passed") {
+		t.Fatalf("axi respond with invalid config did not complete:\n%s", doneOut)
+	}
+
+	abortOut, err := h.RunInDir(abortWorktree, "axi", "abort")
+	if err != nil {
+		t.Fatalf("axi abort with invalid config: %v\n%s", err, abortOut)
+	}
+	for _, want := range []string{"aborted: true", "branch: feature/abort-invalid-config"} {
+		if !strings.Contains(abortOut, want) {
+			t.Fatalf("axi abort output missing %q:\n%s", want, abortOut)
+		}
+	}
+	cancelled := h.WaitForRun("feature/abort-invalid-config", 60*time.Second)
+	if cancelled.Status != types.RunCancelled {
+		t.Fatalf("abort branch status = %s, want cancelled", cancelled.Status)
+	}
+}
+
 // TestAxiRunPreflightGuards proves `axi run` refuses to start a run with
 // structured, actionable errors instead of silently doing the wrong thing:
 // missing intent, the default branch, and an uncommitted working tree.

--- a/internal/e2e/harness.go
+++ b/internal/e2e/harness.go
@@ -668,9 +668,21 @@ func (h *Harness) shutdown() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, h.NMBin, "daemon", "stop")
-	cmd.Dir = h.WorkDir
+	cmd.Dir = h.daemonStopDir()
 	cmd.Env = os.Environ()
 	_ = cmd.Run()
+}
+
+func (h *Harness) daemonStopDir() string {
+	for _, dir := range []string{h.WorkDir, h.HomeDir, os.TempDir()} {
+		if dir == "" {
+			continue
+		}
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			return dir
+		}
+	}
+	return "."
 }
 
 // ---- Binary build cache ----

--- a/internal/e2e/harness_test.go
+++ b/internal/e2e/harness_test.go
@@ -97,6 +97,16 @@ func TestCommitChangeCreatesMissingBranchFromMain(t *testing.T) {
 	}
 }
 
+func TestDaemonStopDirFallsBackWhenWorkDirMoved(t *testing.T) {
+	workDir := filepath.Join(t.TempDir(), "missing-work")
+	homeDir := t.TempDir()
+	h := &Harness{WorkDir: workDir, HomeDir: homeDir}
+
+	if got := h.daemonStopDir(); got != homeDir {
+		t.Fatalf("daemonStopDir() = %q, want home dir %q", got, homeDir)
+	}
+}
+
 func TestWaitForRunPrefersNewestRunOnBranch(t *testing.T) {
 	nmHome, err := os.MkdirTemp("/tmp", "nm-e2e-")
 	if err != nil {

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -213,15 +213,17 @@ type StepResultInfo struct {
 	// FixSummaries holds one entry per fix round the pipeline ran for this
 	// step, in round order: the agent's one-line fix summary, or "" when the
 	// round recorded none. Agent surfaces use it to report applied fixes.
-	FixSummaries   []string `json:"fix_summaries,omitempty"`
-	RoundCount     int      `json:"round_count,omitempty"`
-	FixRoundCount  int      `json:"fix_round_count,omitempty"`
-	Error          *string  `json:"error,omitempty"`
-	StartedAt      *int64   `json:"started_at,omitempty"`
-	CompletedAt    *int64   `json:"completed_at,omitempty"`
-	LastActivityAt *int64   `json:"last_activity_at,omitempty"`
-	LastActivity   *string  `json:"last_activity,omitempty"`
-	AgentPID       *int     `json:"agent_pid,omitempty"`
+	FixSummaries     []string `json:"fix_summaries,omitempty"`
+	RoundCount       int      `json:"round_count,omitempty"`
+	FixRoundCount    int      `json:"fix_round_count,omitempty"`
+	AutoFixLimit     int      `json:"auto_fix_limit,omitempty"`
+	PendingFixSource string   `json:"pending_fix_source,omitempty"`
+	Error            *string  `json:"error,omitempty"`
+	StartedAt        *int64   `json:"started_at,omitempty"`
+	CompletedAt      *int64   `json:"completed_at,omitempty"`
+	LastActivityAt   *int64   `json:"last_activity_at,omitempty"`
+	LastActivity     *string  `json:"last_activity,omitempty"`
+	AgentPID         *int     `json:"agent_pid,omitempty"`
 }
 
 // --- Events (for subscribe stream) ---

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -213,10 +213,15 @@ type StepResultInfo struct {
 	// FixSummaries holds one entry per fix round the pipeline ran for this
 	// step, in round order: the agent's one-line fix summary, or "" when the
 	// round recorded none. Agent surfaces use it to report applied fixes.
-	FixSummaries []string `json:"fix_summaries,omitempty"`
-	Error        *string  `json:"error,omitempty"`
-	StartedAt    *int64   `json:"started_at,omitempty"`
-	CompletedAt  *int64   `json:"completed_at,omitempty"`
+	FixSummaries   []string `json:"fix_summaries,omitempty"`
+	RoundCount     int      `json:"round_count,omitempty"`
+	FixRoundCount  int      `json:"fix_round_count,omitempty"`
+	Error          *string  `json:"error,omitempty"`
+	StartedAt      *int64   `json:"started_at,omitempty"`
+	CompletedAt    *int64   `json:"completed_at,omitempty"`
+	LastActivityAt *int64   `json:"last_activity_at,omitempty"`
+	LastActivity   *string  `json:"last_activity,omitempty"`
+	AgentPID       *int     `json:"agent_pid,omitempty"`
 }
 
 // --- Events (for subscribe stream) ---

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
 	"github.com/kunchenguid/no-mistakes/internal/config"
@@ -573,27 +575,34 @@ const (
 )
 
 func stepActivityFromLog(text string) string {
-	trimmed := strings.TrimSpace(text)
-	if trimmed == "" {
+	end := len(text)
+	for end > 0 {
+		r, size := utf8.DecodeLastRuneInString(text[:end])
+		if !unicode.IsSpace(r) {
+			break
+		}
+		end -= size
+	}
+	if end == 0 {
 		return ""
 	}
-	lines := strings.Split(trimmed, "\n")
-	for i := len(lines) - 1; i >= 0; i-- {
-		line := strings.TrimSpace(lines[i])
-		if line == "" {
-			continue
-		}
-		return "log: " + truncateActivity(line)
-	}
-	return ""
+	start := strings.LastIndexByte(text[:end], '\n') + 1
+	line := strings.TrimSpace(text[start:end])
+	return "log: " + truncateActivity(line)
 }
 
 func truncateActivity(text string) string {
-	runes := []rune(text)
-	if len(runes) <= maxStepActivityText {
+	if len(text) <= maxStepActivityText {
 		return text
 	}
-	return string(runes[:maxStepActivityText]) + "..."
+	runeCount := 0
+	for i := range text {
+		if runeCount == maxStepActivityText {
+			return text[:i] + "..."
+		}
+		runeCount++
+	}
+	return text
 }
 
 func pluralize(n int, singular, plural string) string {

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -212,8 +212,14 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 	if run != nil && run.Intent != nil {
 		userIntent = *run.Intent
 	}
-	touchLogActivity := func(text string) {
+	lastLogActivityAt := time.Time{}
+	touchLogActivity := func(text string, force bool) {
 		if activity := stepActivityFromLog(text); activity != "" {
+			now := time.Now()
+			if !force && !lastLogActivityAt.IsZero() && now.Sub(lastLogActivityAt) < stepActivityThrottleInterval {
+				return
+			}
+			lastLogActivityAt = now
 			if dbErr := e.db.TouchStepActivity(sr.ID, activity); dbErr != nil {
 				slog.Warn("failed to touch step activity in db", "step", stepName, "error", dbErr)
 			}
@@ -230,7 +236,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 		}
 		e.emitLogChunk(run, repo, stepName, text)
 		fmt.Fprint(logFile, text)
-		touchLogActivity(text)
+		touchLogActivity(text, true)
 	}
 	writeLogChunk := func(text string) {
 		if text != "" {
@@ -238,7 +244,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 		}
 		e.emitLogChunk(run, repo, stepName, text)
 		fmt.Fprint(logFile, text)
-		touchLogActivity(text)
+		touchLogActivity(text, strings.Contains(text, "\n"))
 	}
 	onAgentLifecycle := func(event agent.LifecycleEvent) {
 		text := event.Message
@@ -280,7 +286,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 		LogChunk:     writeLogChunk,
 		LogFile: func(text string) {
 			fmt.Fprintln(logFile, text)
-			touchLogActivity(text)
+			touchLogActivity(text, true)
 		},
 	}
 
@@ -303,7 +309,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			// stderr from a rejected push); without this the step log shows the
 			// work starting but never why it stopped.
 			fmt.Fprintf(logFile, "\nerror: %s\n", err.Error())
-			touchLogActivity("error: " + err.Error())
+			touchLogActivity("error: "+err.Error(), true)
 			if dbErr := e.db.FailStep(sr.ID, err.Error(), durationMS); dbErr != nil {
 				slog.Warn("failed to mark step as failed in db", "step", stepName, "error", dbErr)
 			}
@@ -561,7 +567,10 @@ func (a *lifecycleAgent) Close() error {
 	return a.inner.Close()
 }
 
-const maxStepActivityText = 240
+const (
+	maxStepActivityText          = 240
+	stepActivityThrottleInterval = time.Second
+)
 
 func stepActivityFromLog(text string) string {
 	trimmed := strings.TrimSpace(text)

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -208,37 +208,75 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 	if run != nil && run.Intent != nil {
 		userIntent = *run.Intent
 	}
+	touchLogActivity := func(text string) {
+		if activity := stepActivityFromLog(text); activity != "" {
+			if dbErr := e.db.TouchStepActivity(sr.ID, activity); dbErr != nil {
+				slog.Warn("failed to touch step activity in db", "step", stepName, "error", dbErr)
+			}
+		}
+	}
+	writeLog := func(text string) {
+		if text != "" {
+			prefix := ""
+			if !lastChunkNewline {
+				prefix = "\n"
+			}
+			text = prefix + strings.TrimRight(text, "\n") + "\n\n"
+			lastChunkNewline = true
+		}
+		e.emitLogChunk(run, repo, stepName, text)
+		fmt.Fprint(logFile, text)
+		touchLogActivity(text)
+	}
+	writeLogChunk := func(text string) {
+		if text != "" {
+			lastChunkNewline = strings.HasSuffix(text, "\n")
+		}
+		e.emitLogChunk(run, repo, stepName, text)
+		fmt.Fprint(logFile, text)
+		touchLogActivity(text)
+	}
+	onAgentLifecycle := func(event agent.LifecycleEvent) {
+		text := event.Message
+		if text == "" {
+			text = fmt.Sprintf("%s %s", event.Agent, event.Phase)
+		}
+		switch event.Phase {
+		case agent.LifecyclePhaseStart:
+			pid := event.PID
+			if dbErr := e.db.SetStepAgentActivity(sr.ID, text, &pid); dbErr != nil {
+				slog.Warn("failed to set step agent activity in db", "step", stepName, "error", dbErr)
+			}
+		case agent.LifecyclePhaseExit:
+			if dbErr := e.db.SetStepAgentActivity(sr.ID, text, nil); dbErr != nil {
+				slog.Warn("failed to set step agent activity in db", "step", stepName, "error", dbErr)
+			}
+		default:
+			if dbErr := e.db.TouchStepActivity(sr.ID, text); dbErr != nil {
+				slog.Warn("failed to touch step activity in db", "step", stepName, "error", dbErr)
+			}
+		}
+		writeLog(text)
+	}
+	stepAgent := e.agent
+	if stepAgent != nil {
+		stepAgent = &lifecycleAgent{inner: stepAgent, onLifecycle: onAgentLifecycle}
+	}
 	sctx := &StepContext{
 		Ctx:          ctx,
 		Run:          run,
 		Repo:         repo,
 		WorkDir:      workDir,
-		Agent:        e.agent,
+		Agent:        stepAgent,
 		Config:       e.config,
 		DB:           e.db,
 		StepResultID: sr.ID,
 		UserIntent:   userIntent,
-		Log: func(text string) {
-			if text != "" {
-				prefix := ""
-				if !lastChunkNewline {
-					prefix = "\n"
-				}
-				text = prefix + strings.TrimRight(text, "\n") + "\n\n"
-				lastChunkNewline = true
-			}
-			e.emitLogChunk(run, repo, stepName, text)
-			fmt.Fprint(logFile, text)
-		},
-		LogChunk: func(text string) {
-			if text != "" {
-				lastChunkNewline = strings.HasSuffix(text, "\n")
-			}
-			e.emitLogChunk(run, repo, stepName, text)
-			fmt.Fprint(logFile, text)
-		},
+		Log:          writeLog,
+		LogChunk:     writeLogChunk,
 		LogFile: func(text string) {
 			fmt.Fprintln(logFile, text)
+			touchLogActivity(text)
 		},
 	}
 
@@ -266,6 +304,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			// stderr from a rejected push); without this the step log shows the
 			// work starting but never why it stopped.
 			fmt.Fprintf(logFile, "\nerror: %s\n", err.Error())
+			touchLogActivity("error: " + err.Error())
 			if dbErr := e.db.FailStep(sr.ID, err.Error(), durationMS); dbErr != nil {
 				slog.Warn("failed to mark step as failed in db", "step", stepName, "error", dbErr)
 			}
@@ -321,6 +360,8 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 				telemetry.Track("fix", e.fixTelemetryFields("auto", stepName, findingsCount(fixableFindings), autoFixAttempts))
 				slog.Info("auto-fixing step", "step", stepName, "attempt", autoFixAttempts, "max", autoFixLimit)
 				executionMS += time.Since(phaseStart).Milliseconds()
+				fixCount := findingsCount(fixableFindings)
+				writeLog(fmt.Sprintf("auto-fix round %d/%d starting after round %d (%d %s)", autoFixAttempts, autoFixLimit, roundNum, fixCount, pluralize(fixCount, "finding", "findings")))
 				if dbErr := e.db.UpdateStepStatus(sr.ID, types.StepStatusFixing); dbErr != nil {
 					slog.Warn("failed to update step status in db", "step", stepName, "status", "fixing", "error", dbErr)
 				}
@@ -441,6 +482,8 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			telemetry.Track("fix", e.fixTelemetryFields("user", stepName, selectedFindingCount(outcome.Findings, response.findingIDs), 0))
 			// Fix - mark step as fixing, resume execution timer, re-execute.
 			phaseStart = time.Now()
+			selectedCount := selectedFindingCount(outcome.Findings, response.findingIDs)
+			writeLog(fmt.Sprintf("user-fix round starting after round %d (%d %s selected)", roundNum, selectedCount, pluralize(selectedCount, "finding", "findings")))
 			if dbErr := e.db.UpdateStepStatus(sr.ID, types.StepStatusFixing); dbErr != nil {
 				slog.Warn("failed to update step status in db", "step", stepName, "status", "fixing", "error", dbErr)
 			}
@@ -491,6 +534,65 @@ func roundInsertID(_ string, inserted *db.StepRound, err error) string {
 		return ""
 	}
 	return inserted.ID
+}
+
+type lifecycleAgent struct {
+	inner       agent.Agent
+	onLifecycle func(agent.LifecycleEvent)
+}
+
+func (a *lifecycleAgent) Name() string {
+	return a.inner.Name()
+}
+
+func (a *lifecycleAgent) Run(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+	previous := opts.OnLifecycle
+	opts.OnLifecycle = func(event agent.LifecycleEvent) {
+		if previous != nil {
+			previous(event)
+		}
+		if a.onLifecycle != nil {
+			a.onLifecycle(event)
+		}
+	}
+	return a.inner.Run(ctx, opts)
+}
+
+func (a *lifecycleAgent) Close() error {
+	return a.inner.Close()
+}
+
+const maxStepActivityText = 240
+
+func stepActivityFromLog(text string) string {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return ""
+	}
+	lines := strings.Split(trimmed, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		return "log: " + truncateActivity(line)
+	}
+	return ""
+}
+
+func truncateActivity(text string) string {
+	runes := []rune(text)
+	if len(runes) <= maxStepActivityText {
+		return text
+	}
+	return string(runes[:maxStepActivityText]) + "..."
+}
+
+func pluralize(n int, singular, plural string) string {
+	if n == 1 {
+		return singular
+	}
+	return plural
 }
 
 // waitForApproval blocks until a user action arrives or context is cancelled.

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -181,9 +181,13 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 	stepName := step.Name()
 	logPath := filepath.Join(logDir, string(stepName)+".log")
 	finalExitCode := 0
+	autoFixLimit := 0
+	if e.config != nil {
+		autoFixLimit = e.config.AutoFixLimit(stepName)
+	}
 
 	// Mark step as running
-	if err := e.db.StartStep(sr.ID); err != nil {
+	if err := e.db.StartStepWithAutoFixLimit(sr.ID, autoFixLimit); err != nil {
 		return false, fmt.Errorf("start step %s: %w", stepName, err)
 	}
 	e.emitStepEvent(ipc.EventStepStarted, run, repo, stepName, string(types.StepStatusRunning))
@@ -280,11 +284,6 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 		},
 	}
 
-	// Determine auto-fix limit for this step
-	autoFixLimit := 0
-	if e.config != nil {
-		autoFixLimit = e.config.AutoFixLimit(stepName)
-	}
 	autoFixAttempts := 0
 	roundNum := 0
 	nextTrigger := "initial"

--- a/internal/pipeline/executor_autofix_test.go
+++ b/internal/pipeline/executor_autofix_test.go
@@ -57,6 +57,35 @@ func TestExecutor_AutoFixTriggersWithoutApproval(t *testing.T) {
 	}
 }
 
+func TestExecutor_PersistsEffectiveAutoFixLimit(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+	cfg := &config.Config{AutoFix: config.AutoFix{Review: 2}}
+
+	step := &adaptiveCallStep{
+		name: types.StepReview,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			return &StepOutcome{ExitCode: 0}, nil
+		},
+	}
+
+	exec := NewExecutor(database, p, cfg, nil, []Step{step}, nil)
+	if err := exec.Execute(context.Background(), run, repo, workDir); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	steps, err := database.GetStepsByRun(run.ID)
+	if err != nil {
+		t.Fatalf("get steps: %v", err)
+	}
+	if len(steps) != 1 {
+		t.Fatalf("steps = %d, want 1", len(steps))
+	}
+	if steps[0].AutoFixLimit == nil || *steps[0].AutoFixLimit != 2 {
+		t.Fatalf("auto-fix limit = %v, want 2", steps[0].AutoFixLimit)
+	}
+}
+
 func TestExecutor_AutoFixRespectsMaxAttempts(t *testing.T) {
 	database, p, run, repo := setupTest(t)
 	workDir := t.TempDir()

--- a/internal/pipeline/executor_logging_test.go
+++ b/internal/pipeline/executor_logging_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -78,6 +79,50 @@ func TestExecutor_LogCallbackTouchesStepActivity(t *testing.T) {
 	exec := NewExecutor(database, p, nil, nil, []Step{step}, nil)
 	if err := exec.Execute(context.Background(), run, repo, workDir); err != nil {
 		t.Fatalf("execute: %v", err)
+	}
+}
+
+func TestExecutor_LogChunkThrottlesStepActivityWrites(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	counterDB, err := sql.Open("sqlite", p.DB()+"?_pragma=journal_mode(wal)&_pragma=foreign_keys(on)&_pragma=busy_timeout(5000)")
+	if err != nil {
+		t.Fatalf("open counter db: %v", err)
+	}
+	defer counterDB.Close()
+	if _, err := counterDB.Exec(`
+		CREATE TABLE step_activity_update_count (n INTEGER NOT NULL);
+		INSERT INTO step_activity_update_count (n) VALUES (0);
+		CREATE TRIGGER count_step_activity_update AFTER UPDATE OF last_activity_at, last_activity ON step_results
+		BEGIN
+			UPDATE step_activity_update_count SET n = n + 1;
+		END;
+	`); err != nil {
+		t.Fatalf("install activity counter: %v", err)
+	}
+
+	step := &adaptiveCallStep{
+		name: types.StepReview,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			for i := 0; i < 100; i++ {
+				sctx.LogChunk(fmt.Sprintf("delta-%03d ", i))
+			}
+			return &StepOutcome{ExitCode: 0}, nil
+		},
+	}
+
+	exec := NewExecutor(database, p, nil, nil, []Step{step}, nil)
+	if err := exec.Execute(context.Background(), run, repo, workDir); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	var updates int
+	if err := counterDB.QueryRow(`SELECT n FROM step_activity_update_count`).Scan(&updates); err != nil {
+		t.Fatalf("read activity update count: %v", err)
+	}
+	if updates > 5 {
+		t.Fatalf("step activity updates = %d, want throttled count <= 5", updates)
 	}
 }
 

--- a/internal/pipeline/executor_logging_test.go
+++ b/internal/pipeline/executor_logging_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"testing"
@@ -123,6 +125,38 @@ func TestExecutor_LogChunkThrottlesStepActivityWrites(t *testing.T) {
 	}
 	if updates > 5 {
 		t.Fatalf("step activity updates = %d, want throttled count <= 5", updates)
+	}
+}
+
+func TestStepActivityFromLogUsesBoundedAllocationForLargeLogs(t *testing.T) {
+	lastLine := strings.Repeat("x", maxStepActivityText+100)
+	largeLog := strings.Repeat("noise line\n", 8192) + lastLine + "\n\n"
+	want := "log: " + strings.Repeat("x", maxStepActivityText) + "..."
+
+	if got := stepActivityFromLog(largeLog); got != want {
+		t.Fatalf("stepActivityFromLog() = %q, want %q", got, want)
+	}
+
+	oldGC := debug.SetGCPercent(-1)
+	defer debug.SetGCPercent(oldGC)
+	runtime.GC()
+
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	const iterations = 25
+	for i := 0; i < iterations; i++ {
+		if got := stepActivityFromLog(largeLog); got != want {
+			t.Fatalf("stepActivityFromLog() = %q, want %q", got, want)
+		}
+	}
+
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	allocatedPerCall := (after.TotalAlloc - before.TotalAlloc) / iterations
+	if allocatedPerCall > 4*1024 {
+		t.Fatalf("stepActivityFromLog allocated %d bytes per call, want <= 4096", allocatedPerCall)
 	}
 }
 

--- a/internal/pipeline/executor_logging_test.go
+++ b/internal/pipeline/executor_logging_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/kunchenguid/no-mistakes/internal/agent"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
@@ -52,6 +53,84 @@ func TestExecutor_LogCallback(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected log message 'hello from review' in events, got: %v", logMessages)
+	}
+}
+
+func TestExecutor_LogCallbackTouchesStepActivity(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	step := &adaptiveCallStep{
+		name: types.StepReview,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			sctx.Log("heartbeat marker")
+			got, err := database.GetStepResult(sctx.StepResultID)
+			if err != nil {
+				t.Fatalf("get step result: %v", err)
+			}
+			if got.LastActivity == nil || !strings.Contains(*got.LastActivity, "heartbeat marker") {
+				t.Fatalf("last_activity = %v, want heartbeat marker", got.LastActivity)
+			}
+			return &StepOutcome{ExitCode: 0}, nil
+		},
+	}
+
+	exec := NewExecutor(database, p, nil, nil, []Step{step}, nil)
+	if err := exec.Execute(context.Background(), run, repo, workDir); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+}
+
+type lifecycleTestAgent struct{}
+
+func (lifecycleTestAgent) Name() string { return "codex" }
+
+func (lifecycleTestAgent) Run(_ context.Context, opts agent.RunOpts) (*agent.Result, error) {
+	if opts.OnLifecycle != nil {
+		opts.OnLifecycle(agent.LifecycleEvent{Agent: "codex", Phase: "start", PID: 4242, Message: "codex started pid=4242"})
+		opts.OnLifecycle(agent.LifecycleEvent{Agent: "codex", Phase: "exit", PID: 4242, Message: "codex exited pid=4242 status=success"})
+	}
+	return &agent.Result{Text: "ok"}, nil
+}
+
+func (lifecycleTestAgent) Close() error { return nil }
+
+func TestExecutor_AgentLifecycleLoggedAndClearsPID(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	step := &adaptiveCallStep{
+		name: types.StepReview,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			if _, err := sctx.Agent.Run(sctx.Ctx, agent.RunOpts{Prompt: "work", CWD: sctx.WorkDir}); err != nil {
+				t.Fatalf("agent run: %v", err)
+			}
+			return &StepOutcome{ExitCode: 0}, nil
+		},
+	}
+
+	exec := NewExecutor(database, p, nil, lifecycleTestAgent{}, []Step{step}, nil)
+	if err := exec.Execute(context.Background(), run, repo, workDir); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	logPath := filepath.Join(p.RunLogDir(run.ID), "review.log")
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	content := string(data)
+	for _, want := range []string{"codex started pid=4242", "codex exited pid=4242 status=success"} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("log missing %q in:\n%s", want, content)
+		}
+	}
+	steps, err := database.GetStepsByRun(run.ID)
+	if err != nil {
+		t.Fatalf("get steps: %v", err)
+	}
+	if steps[0].AgentPID != nil {
+		t.Fatalf("agent pid = %v, want nil after exit", steps[0].AgentPID)
 	}
 }
 

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -140,6 +140,13 @@ Run the pipeline and decide on its findings as they come up:
    the run is parked at an approval or fix-review gate and waiting for you to
    send ` + "`axi respond`" + `. The field is observability only: it does not change
    gate resolution, auto-resume the run, or make ` + "`--yes`" + ` the default.
+   While a step is actively ` + "`running`" + ` or ` + "`fixing`" + `, ` + "`axi status`" + ` may include
+   ` + "`active_steps`" + ` with ` + "`active_for`" + `, ` + "`last_activity`" + `, a native ` + "`agent_pid`" + ` when
+   a subprocess agent is running, and the current round such as ` + "`round 1`" + `,
+   ` + "`auto-fix 1/3`" + `, or ` + "`fix 2`" + `. If ` + "`last_activity`" + ` is prefixed with
+   ` + "`quiet`" + `, no step log or native-agent lifecycle activity has arrived for
+   longer than ` + "`step_quiet_warning`" + `. Treat that as a liveness clue, not as
+   permission to cancel, rerun, or edit the worktree yourself.
 2. If the output contains a ` + "`gate:`" + ` object, the pipeline is waiting on you.
    Read its ` + "`findings`" + ` table. Each finding has an ` + "`id`" + `, ` + "`severity`" + `,
    ` + "`file`" + `, ` + "`description`" + `, and an ` + "`action`" + ` that tells you how the
@@ -273,6 +280,7 @@ no-mistakes axi abort --run <id>   # cancel a specific run by id (works outside 
 
 - Output is TOON: ` + "`key: value`" + ` pairs, ` + "`name[N]{cols}:`" + ` tables, and ` + "`help[N]:`" + ` hints.
 - A non-terminal run object may include ` + "`awaiting_agent: parked <duration>`" + ` immediately after ` + "`status`" + `; that means the run is parked at a gate awaiting your ` + "`axi respond`" + `.
+- A run object with a ` + "`running`" + ` or ` + "`fixing`" + ` step may include an ` + "`active_steps`" + ` table. Use it to see the active duration, latest activity, native agent PID, and current execution or fix round.
 - The ` + "`help`" + ` list at the bottom of most responses tells you the next commands to run.
 - Errors are printed as ` + "`error: ...`" + ` on stdout with a ` + "`help`" + ` list; act on the suggestion.
 - Exit codes: ` + "`0`" + ` success, no-op, or normal decision gates, ` + "`1`" + ` failed or cancelled final outcomes, ` + "`2`" + ` bad usage.

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -101,6 +101,13 @@ Run the pipeline and decide on its findings as they come up:
    the run is parked at an approval or fix-review gate and waiting for you to
    send `axi respond`. The field is observability only: it does not change
    gate resolution, auto-resume the run, or make `--yes` the default.
+   While a step is actively `running` or `fixing`, `axi status` may include
+   `active_steps` with `active_for`, `last_activity`, a native `agent_pid` when
+   a subprocess agent is running, and the current round such as `round 1`,
+   `auto-fix 1/3`, or `fix 2`. If `last_activity` is prefixed with
+   `quiet`, no step log or native-agent lifecycle activity has arrived for
+   longer than `step_quiet_warning`. Treat that as a liveness clue, not as
+   permission to cancel, rerun, or edit the worktree yourself.
 2. If the output contains a `gate:` object, the pipeline is waiting on you.
    Read its `findings` table. Each finding has an `id`, `severity`,
    `file`, `description`, and an `action` that tells you how the
@@ -234,6 +241,7 @@ no-mistakes axi abort --run <id>   # cancel a specific run by id (works outside 
 
 - Output is TOON: `key: value` pairs, `name[N]{cols}:` tables, and `help[N]:` hints.
 - A non-terminal run object may include `awaiting_agent: parked <duration>` immediately after `status`; that means the run is parked at a gate awaiting your `axi respond`.
+- A run object with a `running` or `fixing` step may include an `active_steps` table. Use it to see the active duration, latest activity, native agent PID, and current execution or fix round.
 - The `help` list at the bottom of most responses tells you the next commands to run.
 - Errors are printed as `error: ...` on stdout with a `help` list; act on the suggestion.
 - Exit codes: `0` success, no-op, or normal decision gates, `1` failed or cancelled final outcomes, `2` bad usage.


### PR DESCRIPTION
## Intent

Implement review-step wedge observability: step activity heartbeat in status, native-agent lifecycle lines in step logs, auto-fix round visibility in AXI status, and the e2e daemon cleanup found during validation. Fixes 3 and 5 from the scout report are intentionally out of scope; preserve the no-migration MVP semantics for active_for from started_at plus step-log mtime quiet-age fallback, with a configurable quiet-warning threshold.

## What Changed

- Added persisted step activity diagnostics, quiet-age fallback behavior, configurable quiet-warning handling, and AXI status rendering for active steps, auto-fix rounds, attempts, and selected findings.
- Logged native-agent lifecycle and retry activity into step logs, while throttling and bounding activity persistence so large command output does not inflate daemon memory use.
- Made AXI attach commands tolerate invalid global config when reconnecting to an existing daemon, updated docs and generated skill guidance, and covered the behavior with targeted unit and e2e tests.

## Risk Assessment

⚠️ Medium: The change is mostly observability-oriented and I found no material defects, but it touches daemon attach behavior, DB schema, agent lifecycle callbacks, and AXI rendering across several boundaries.

## Testing

The baseline full race suite was already green; I added targeted race tests for the changed DB, executor, agent, and AXI rendering paths, ran the relevant e2e selectors for parked status, invalid-config attach/respond, and daemon stop fallback, then captured a CLI transcript showing active step heartbeat, quiet warning, auto-fix round visibility, native-agent lifecycle log lines, and log-mtime fallback behavior. All checks passed, and transient helper/build artifacts were removed.

- Evidence: [AXI wedge observability transcript](https://github.com/kunchenguid/no-mistakes/blob/868ff45857e985d24a18618d2fc054897f477346/.no-mistakes/evidence/fm/nm-review-wedge-b6/axi-wedge-observability-transcript.txt)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ `internal/pipeline/executor.go:580` - `stepActivityFromLog` splits the entire log text just to find the last non-empty line. Several steps pass full command output through `sctx.Log(output)`, so large test or lint output now allocates a large extra slice on top of the captured log and can increase daemon memory pressure. Scan backward for the last non-empty line and truncate during iteration instead.

🔧 Fix: Bound step activity log allocation
1 warning still open:
- ⚠️ `internal/cli/axi.go:103` - `openAxiEnv(true)` now returns a global config parse error before dialing an already-running daemon unless the caller uses `openAxiRunEnv`. `axi respond` and branch-scoped `axi abort` still use this path, so a malformed config can leave an in-flight gated run inspectable but not selectively answerable or cancellable through the normal commands. Defer config errors for daemon-attach commands too, and only surface them when starting a fresh run or daemon.

🔧 Fix: Keep daemon attach commands config-tolerant
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`
- <code>Baseline provided: `go test -race ./...` had already run successfully before this validation.</code>
- `go test -race ./internal/cli -run 'TestRunObjectRendersActiveStepDiagnostics|TestStatusRendersCurrentAutoFixAttemptWithPersistedLimit|TestAxiStatusIgnoresInvalidGlobalConfig|TestConfigErrorForFreshAxiRunAllowsReattach' -count=1`
- `go test -race ./internal/pipeline -run 'TestExecutor_(LogCallbackTouchesStepActivity|LogChunkThrottlesStepActivityWrites|AgentLifecycleLoggedAndClearsPID|PersistsEffectiveAutoFixLimit|AutoFixRespectsMaxAttempts|AutoFixTriggersWithoutApproval|AutoFixRecordsSelectedFindingIDs|FixPersistsFollowUpRoundAsAutoFix)|TestStepActivityFromLogUsesBoundedAllocationForLargeLogs' -count=1`
- `go test -race ./internal/db -run 'TestOpenMigratesStepActivityColumns|TestStepActivity|TestStepRoundStats' -count=1`
- `go test -race ./internal/agent -run 'TestRunWithRetry_EmitsRetryLifecycleWhenConfigured' -count=1`
- `go test -tags=e2e ./internal/e2e -run 'TestAxiParkedAwaitingAgentSignal|TestAxiAttachCommandsIgnoreInvalidConfigWhenDaemonRunning|TestDaemonStopDirFallsBackWhenWorkDirMoved' -count=1`
- <code>Evidence capture with a throwaway in-repo helper and binary: real executor entered review auto-fix, then `no-mistakes axi status --run &lt;run&gt;` and `no-mistakes axi logs --run &lt;run&gt; --step review --full` were saved to the transcript artifact.</code>
- <code>Evidence capture for the legacy activity fallback: created a running step with no `last_activity_at`, set `review.log` mtime, and captured `no-mistakes axi status --run &lt;run&gt;` showing `step log updated` quiet-age fallback.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
