### PR TITLE
docs(cli): sync gate-preservation guidance

### DIFF
--- a/.no-mistakes/evidence/fm/nm-incremental-fix-doc-i5/agents-guide-excerpt.md
+++ b/.no-mistakes/evidence/fm/nm-incremental-fix-doc-i5/agents-guide-excerpt.md
@@ -1,0 +1,7 @@
+Use `no-mistakes axi abort --run <id>` only when you need to cancel a specific active run by id from outside its worktree.
+
+When an agent makes an additional fix after a gate round has already produced fix commits - a newly surfaced finding, a reviewer or pre-merge request, or any other post-completion change - it should commit the fix on top of the existing branch and run `no-mistakes axi run --intent "..."` with the original user intent.
+Never abort-and-restart, reset the branch, or open a new branch in a way that drops prior gate-fix commits, including the pipeline's own `no-mistakes(review|document|lint): ...` commits.
+A fresh run re-validates the branch's current state, so already-resolved findings do not re-surface.
+
+When an agent starts a new run, `--intent` is required and should describe what the user wanted to accomplish, not what files changed.

--- a/.no-mistakes/evidence/fm/nm-incremental-fix-doc-i5/axi-abort-help.txt
+++ b/.no-mistakes/evidence/fm/nm-incremental-fix-doc-i5/axi-abort-help.txt
@@ -1,0 +1,18 @@
+Cancel a pipeline run. With no flags, cancels the active run on the
+current branch. Pass --run <id> to cancel a specific run by its id from
+anywhere - including outside its worktree - so an orphaned CI monitor
+(e.g. after a worktree was torn down) can be reaped deterministically.
+
+While a run is active, do NOT abort (or rerun) to go fix a finding
+yourself - that discards the pipeline's in-flight work and forces a full
+re-validation. abort and rerun are for between runs (after a failed or
+cancelled outcome), never to circumvent a gate.
+
+When you make an additional fix after a gate round has already produced fix commits, commit it on top of the existing branch and run `no-mistakes axi run --intent "..."` with the original user intent. Never abort-and-restart, reset the branch, or open a new branch in a way that drops prior gate-fix commits. A fresh run re-validates the branch's current state, so already-resolved findings do not re-surface.
+
+Usage:
+  no-mistakes axi abort [flags]
+
+Flags:
+  -h, --help         help for abort
+      --run string   cancel this run id directly, without resolving the current branch or worktree

--- a/.no-mistakes/evidence/fm/nm-incremental-fix-doc-i5/axi-respond-help.txt
+++ b/.no-mistakes/evidence/fm/nm-incremental-fix-doc-i5/axi-respond-help.txt
@@ -1,0 +1,16 @@
+Sends approve/fix/skip for the step currently awaiting approval, then
+blocks until the next gate, CI-ready decision point, or final outcome.
+
+When you make an additional fix after a gate round has already produced fix commits, commit it on top of the existing branch and run `no-mistakes axi run --intent "..."` with the original user intent. Never abort-and-restart, reset the branch, or open a new branch in a way that drops prior gate-fix commits. A fresh run re-validates the branch's current state, so already-resolved findings do not re-surface.
+
+Usage:
+  no-mistakes axi respond [flags]
+
+Flags:
+      --action string         approve | fix | skip (required)
+      --add-finding string    JSON finding object to add and fix (with --action fix)
+      --findings string       comma-separated finding IDs to fix (with --action fix)
+  -h, --help                  help for respond
+      --instructions string   guidance applied to the selected findings (with --action fix)
+      --step string           step to respond to (default: the step awaiting approval)
+  -y, --yes                   auto-resolve every subsequent gate until a decision point or outcome

--- a/.no-mistakes/evidence/fm/nm-incremental-fix-doc-i5/axi-run-help.txt
+++ b/.no-mistakes/evidence/fm/nm-incremental-fix-doc-i5/axi-run-help.txt
@@ -1,0 +1,20 @@
+Triggers a pipeline run for the current branch and drives it. Without
+--yes it blocks until the first approval gate, CI-ready point, or final outcome and
+prints it. With --yes it auto-resolves every gate (fixing actionable
+findings - including ask-user findings, with no escalation - then
+accepting the result) until a decision point or outcome.
+
+--intent is required when starting a new run: pass what the user set out
+to accomplish (the goal behind the change, not a description of the diff)
+so no-mistakes uses it directly instead of inferring it from transcripts.
+
+When you make an additional fix after a gate round has already produced fix commits, commit it on top of the existing branch and run `no-mistakes axi run --intent "..."` with the original user intent. Never abort-and-restart, reset the branch, or open a new branch in a way that drops prior gate-fix commits. A fresh run re-validates the branch's current state, so already-resolved findings do not re-surface.
+
+Usage:
+  no-mistakes axi run [flags]
+
+Flags:
+  -h, --help            help for run
+      --intent string   what the user set out to accomplish (not a description of the diff); used instead of inferring from transcripts (required to start a run)
+      --skip string     comma-separated pipeline steps to skip
+  -y, --yes             auto-resolve every gate (fix findings, then accept) until a decision point or outcome

--- a/.no-mistakes/evidence/fm/nm-incremental-fix-doc-i5/generated-skill-validate-excerpt.md
+++ b/.no-mistakes/evidence/fm/nm-incremental-fix-doc-i5/generated-skill-validate-excerpt.md
@@ -1,0 +1,10 @@
+
+The same applies to any additional fix that comes after a gate round has
+already produced fix commits - a newly surfaced finding, a reviewer's
+pre-merge request, or any other post-completion change: commit it on top of
+the existing branch and re-run `no-mistakes axi run --intent "..."` with the original user intent.
+Never abort-and-restart, reset the branch, or open a new branch in a way that drops the prior gate-fix commits (including the pipeline's own
+`no-mistakes(review|document|lint): ...` commits) - a re-run only
+re-validates the branch's current state, so those commits stay on the branch
+and already-resolved findings do not re-surface.
+

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -139,6 +139,10 @@ Reattach an in-flight run by re-running `no-mistakes axi run` when it still matc
 If it shows `other_branch_active_run`, they should leave that run alone and start validation for the current branch with `no-mistakes axi run --intent "..."`.
 Use `no-mistakes axi abort --run <id>` only when you need to cancel a specific active run by id from outside its worktree.
 
+When an agent makes an additional fix after a gate round has already produced fix commits - a newly surfaced finding, a reviewer or pre-merge request, or any other post-completion change - it should commit the fix on top of the existing branch and run `no-mistakes axi run --intent "..."` with the original user intent.
+Never abort-and-restart, reset the branch, or open a new branch in a way that drops prior gate-fix commits, including the pipeline's own `no-mistakes(review|document|lint): ...` commits.
+A fresh run re-validates the branch's current state, so already-resolved findings do not re-surface.
+
 When an agent starts a new run, `--intent` is required and should describe what the user wanted to accomplish, not what files changed.
 Agents should prefer a few complete sentences over a terse summary, capturing user decisions, tradeoffs, constraints, ruled-out approaches, and explicit requests that would not be obvious from the diff alone.
 If the repo is on the default branch or has uncommitted changes, direct `axi run` returns a structured error with the command the agent should run instead of silently creating a branch or commit.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -69,6 +69,9 @@ If an active run object is parked at a decision gate, it includes `awaiting_agen
 That field is observability only; the `gate:` object still tells the agent which response to send.
 If a step is actively `running` or `fixing`, the run object can also include an `active_steps` table with `active_for`, `last_activity`, native `agent_pid` when one is currently running, and the current execution or fix round.
 When only another branch has an active run, that run appears as `other_branch_active_run`; the help tells agents to leave it alone and start validation for the current branch.
+AXI help and outputs also repeat the preserve-prior-gate-progress contract: after a gate round has already produced fix commits, additional fixes belong on the same branch followed by a fresh `no-mistakes axi run --intent "..."` with the original user intent.
+Agents must not abort-and-restart, reset, or create a replacement branch in a way that drops prior gate-fix commits.
+A fresh run re-validates the current branch state, so already-resolved findings do not re-surface.
 
 ## no-mistakes axi run
 

--- a/internal/cli/axi.go
+++ b/internal/cli/axi.go
@@ -214,6 +214,7 @@ func runAxiHome(cmd *cobra.Command) error {
 	default:
 		help = append(help, "Run `no-mistakes axi status` to inspect the active run")
 	}
+	help = append(help, preserveGateFixCommitsGuidance)
 	help = append(help, "How to drive the pipeline: `no-mistakes axi run --help`, or the `/no-mistakes` skill (loaded when you invoke `/no-mistakes`)")
 	fields = append(fields, toon.Field{Key: "help", Value: help})
 

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -70,7 +70,8 @@ func newAxiRunCmd() *cobra.Command {
 			"accepting the result) until a decision point or outcome.\n\n" +
 			"--intent is required when starting a new run: pass what the user set out\n" +
 			"to accomplish (the goal behind the change, not a description of the diff)\n" +
-			"so no-mistakes uses it directly instead of inferring it from transcripts.",
+			"so no-mistakes uses it directly instead of inferring it from transcripts.\n\n" +
+			preserveGateFixCommitsGuidance,
 		Args:          cobra.NoArgs,
 		SilenceErrors: true,
 		SilenceUsage:  true,
@@ -517,9 +518,11 @@ func renderDriveResult(cmd *cobra.Command, run *ipc.RunInfo, ciReady bool) error
 		return nil
 	}
 
+	help := []string{preserveGateFixCommitsGuidance}
 	if rv.PRURL != "" {
-		fields = append(fields, toon.Field{Key: "help", Value: []string{fmt.Sprintf("Open the PR: %s", rv.PRURL)}})
+		help = append([]string{fmt.Sprintf("Open the PR: %s", rv.PRURL)}, help...)
 	}
+	fields = append(fields, toon.Field{Key: "help", Value: help})
 	emitDoc(cmd, fields...)
 	return &exitError{code: 1}
 }
@@ -540,6 +543,7 @@ func successReportHelp(fixes []fixRow) []string {
 	if len(fixes) > 0 {
 		help = append(help, "The pipeline fixed findings the original change missed (see `fixes`) - acknowledge the misses and list each fix so the user can review them.")
 	}
+	help = append(help, preserveGateFixCommitsGuidance)
 	return help
 }
 
@@ -551,7 +555,8 @@ func newAxiRespondCmd() *cobra.Command {
 		Use:   "respond",
 		Short: "Answer the current approval gate and continue the run",
 		Long: "Sends approve/fix/skip for the step currently awaiting approval, then\n" +
-			"blocks until the next gate, CI-ready decision point, or final outcome.",
+			"blocks until the next gate, CI-ready decision point, or final outcome.\n\n" +
+			preserveGateFixCommitsGuidance,
 		Args:          cobra.NoArgs,
 		SilenceErrors: true,
 		SilenceUsage:  true,
@@ -619,7 +624,7 @@ func runAxiRespond(cmd *cobra.Command, ra respondArgs) error {
 	}
 	if active.Run == nil {
 		return emitError(cmd, 1, "no active run to respond to",
-			"Run `no-mistakes axi run` to start one")
+			"Run `no-mistakes axi run --intent \"...\"` to start one")
 	}
 	runID := active.Run.ID
 
@@ -705,7 +710,8 @@ func newAxiAbortCmd() *cobra.Command {
 			"While a run is active, do NOT abort (or rerun) to go fix a finding\n" +
 			"yourself - that discards the pipeline's in-flight work and forces a full\n" +
 			"re-validation. abort and rerun are for between runs (after a failed or\n" +
-			"cancelled outcome), never to circumvent a gate.",
+			"cancelled outcome), never to circumvent a gate.\n\n" +
+			preserveGateFixCommitsGuidance,
 		Args:          cobra.NoArgs,
 		SilenceErrors: true,
 		SilenceUsage:  true,

--- a/internal/cli/axi_guidance.go
+++ b/internal/cli/axi_guidance.go
@@ -14,4 +14,11 @@ package cli
 // TestStaleMonitorGuidance_SyncedAcrossSurfaces keeps the three in sync.
 const staleMonitorGuidance = "If this PR later falls behind the default branch or hits a merge conflict, the CI monitor rebases onto the base, resolves it, and re-pushes the branch automatically - run no command and never hand-rebase. Only when that monitor is no longer running (PR closed, run aborted, idle-timeout, or auto-fix exhausted) recover with `no-mistakes rerun`."
 
+// preserveGateFixCommitsGuidance is the canonical, point-of-use guidance an
+// agent reads when it needs to make another fix after a gate round already
+// produced fix commits: keep those commits on the same branch and start a fresh
+// validation run, instead of aborting, resetting, or switching branches in a way
+// that drops prior pipeline work. This same guidance is mirrored in the skill
+// body and the published agents guide, with CLI-reference coverage in
+// docs/.../reference/cli.md.
 const preserveGateFixCommitsGuidance = "When you make an additional fix after a gate round has already produced fix commits, commit it on top of the existing branch and run `no-mistakes axi run --intent \"...\"` with the original user intent. Never abort-and-restart, reset the branch, or open a new branch in a way that drops prior gate-fix commits. A fresh run re-validates the branch's current state, so already-resolved findings do not re-surface."

--- a/internal/cli/axi_guidance.go
+++ b/internal/cli/axi_guidance.go
@@ -13,3 +13,5 @@ package cli
 // agent-driving guidance as a multi-surface contract, and
 // TestStaleMonitorGuidance_SyncedAcrossSurfaces keeps the three in sync.
 const staleMonitorGuidance = "If this PR later falls behind the default branch or hits a merge conflict, the CI monitor rebases onto the base, resolves it, and re-pushes the branch automatically - run no command and never hand-rebase. Only when that monitor is no longer running (PR closed, run aborted, idle-timeout, or auto-fix exhausted) recover with `no-mistakes rerun`."
+
+const preserveGateFixCommitsGuidance = "When you make an additional fix after a gate round has already produced fix commits, commit it on top of the existing branch and run `no-mistakes axi run --intent \"...\"` with the original user intent. Never abort-and-restart, reset the branch, or open a new branch in a way that drops prior gate-fix commits. A fresh run re-validates the branch's current state, so already-resolved findings do not re-surface."

--- a/internal/cli/axi_guidance_test.go
+++ b/internal/cli/axi_guidance_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,6 +23,13 @@ var canonicalStaleMonitorPhrases = []string{
 	"never hand-rebase",
 	"re-pushes",
 	"no-mistakes rerun",
+}
+
+var canonicalPreserveGateFixPhrases = []string{
+	"no-mistakes axi run --intent",
+	"Never abort-and-restart",
+	"prior gate-fix commits",
+	"already-resolved findings do not re-surface",
 }
 
 // TestStaleMonitorGuidance_SyncedAcrossSurfaces guards the repo invariant that
@@ -79,6 +87,69 @@ func TestStaleMonitorGuidance_InChecksPassedOutput(t *testing.T) {
 			t.Errorf("checks-passed output missing stale-monitor guidance phrase %q in:\n%s", phrase, got)
 		}
 	}
+}
+
+func TestPreserveGateFixGuidance_SyncedAcrossSurfaces(t *testing.T) {
+	surfaces := map[string]string{
+		"skill body":       skill.Markdown(),
+		"agents guide":     readAgentsGuide(t),
+		"axi run help":     newAxiRunCmd().Long,
+		"axi respond help": newAxiRespondCmd().Long,
+		"axi abort help":   newAxiAbortCmd().Long,
+	}
+	for name, content := range surfaces {
+		for _, phrase := range canonicalPreserveGateFixPhrases {
+			if !strings.Contains(content, phrase) {
+				t.Errorf("%s is missing the canonical preserve-gate-fix guidance phrase %q", name, phrase)
+			}
+		}
+	}
+}
+
+func TestPreserveGateFixGuidance_InPointOfUseOutputs(t *testing.T) {
+	gate := stepView{
+		Name:   "review",
+		Status: "awaiting_approval",
+		FindingsJSON: findingsJSON(t, []types.Finding{
+			{ID: "review-1", Severity: "warning", File: "main.go", Action: types.ActionAskUser, Description: "calls os.Exit"},
+		}, "1 blocking issue"),
+	}
+	surfaces := map[string]string{
+		"gate output":          axiDoc(gateFields(gate)...),
+		"checks-passed output": renderDriveResultForGuidanceTest(t, true, types.RunRunning),
+		"failed output":        renderDriveResultForGuidanceTest(t, false, types.RunFailed),
+	}
+	for name, content := range surfaces {
+		for _, phrase := range canonicalPreserveGateFixPhrases {
+			if !strings.Contains(content, phrase) {
+				t.Errorf("%s is missing the canonical preserve-gate-fix guidance phrase %q in:\n%s", name, phrase, content)
+			}
+		}
+	}
+}
+
+func renderDriveResultForGuidanceTest(t *testing.T, ciReady bool, status types.RunStatus) string {
+	t.Helper()
+	run := &ipc.RunInfo{
+		ID:      "run-1",
+		Branch:  "feature/x",
+		Status:  status,
+		HeadSHA: "abcdef1234567890",
+		PRURL:   strptr("https://github.com/user/repo/pull/42"),
+		Steps: []ipc.StepResultInfo{
+			{StepName: types.StepCI, Status: types.StepStatusRunning},
+		},
+	}
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&out)
+	err := renderDriveResult(cmd, run, ciReady)
+	var exit *exitError
+	if err != nil && !errors.As(err, &exit) {
+		t.Fatalf("renderDriveResult returned unexpected error: %v", err)
+	}
+	return out.String()
 }
 
 func readAgentsGuide(t *testing.T) string {

--- a/internal/cli/axi_render.go
+++ b/internal/cli/axi_render.go
@@ -468,6 +468,7 @@ func gateFields(gate stepView) []toon.Field {
 			"Run `no-mistakes axi respond --action skip` to skip this step",
 			fmt.Sprintf("Run `no-mistakes axi logs --step %s --full` to read the full step log", gate.Name),
 			"A long-running call is working, not stalled - background it if your harness needs to, but the run never advances past a gate on its own. Read every return; on a `gate:`, respond; loop until an `outcome:`.",
+			preserveGateFixCommitsGuidance,
 		}},
 	}
 }

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -216,9 +216,8 @@ Run the pipeline and decide on its findings as they come up:
 The same applies to any additional fix that comes after a gate round has
 already produced fix commits - a newly surfaced finding, a reviewer's
 pre-merge request, or any other post-completion change: commit it on top of
-the existing branch and re-run ` + "`no-mistakes axi run`" + `. Never abort-and-restart,
-reset the branch, or open a new branch in a way that drops the prior gate-fix
-commits (including the pipeline's own
+the existing branch and re-run ` + "`no-mistakes axi run --intent \"...\"`" + ` with the original user intent.
+Never abort-and-restart, reset the branch, or open a new branch in a way that drops the prior gate-fix commits (including the pipeline's own
 ` + "`no-mistakes(review|document|lint): ...`" + ` commits) - a re-run only
 re-validates the branch's current state, so those commits stay on the branch
 and already-resolved findings do not re-surface.

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -213,6 +213,16 @@ Run the pipeline and decide on its findings as they come up:
      never mid-run to circumvent a gate. Do not leave the user at a ` + "`failed`" + `
      outcome without either retrying or explaining what blocks it.
 
+The same applies to any additional fix that comes after a gate round has
+already produced fix commits - a newly surfaced finding, a reviewer's
+pre-merge request, or any other post-completion change: commit it on top of
+the existing branch and re-run ` + "`no-mistakes axi run`" + `. Never abort-and-restart,
+reset the branch, or open a new branch in a way that drops the prior gate-fix
+commits (including the pipeline's own
+` + "`no-mistakes(review|document|lint): ...`" + ` commits) - a re-run only
+re-validates the branch's current state, so those commits stay on the branch
+and already-resolved findings do not re-surface.
+
 The CI step deliberately keeps watching the PR after checks pass, so
 ` + "`axi run`" + ` returns ` + "`checks-passed`" + ` the moment checks are green rather than
 blocking on the human merge. Never poll or re-run waiting for the merge yourself.

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -302,10 +302,13 @@ note: Review auto-fix is disabled by default (auto_fix.review: 0; a repo or glob
 findings[2]{id,severity,file,line,action,description}:
   r1,warning,internal/pipeline/executor.go,,auto-fix,Error from os.Remove is ignored
   r2,error,cmd/no-mistakes/main.go,,ask-user,New --force flag bypasses the confirm prompt
-help[3]:
-  no-mistakes axi respond --action fix --findings r1
-  no-mistakes axi respond --action approve
-  A long-running call is working, not stalled - background it if your harness needs to, but the run never advances past a gate on its own. Read every return; on a gate, respond; loop until an outcome.
+help[6]:
+  Run ` + "`no-mistakes axi respond --action approve`" + ` to accept this step and continue
+  Run ` + "`no-mistakes axi respond --action fix --findings <ids>`" + ` to have the pipeline fix the selected findings (do not edit files yourself)
+  Run ` + "`no-mistakes axi respond --action skip`" + ` to skip this step
+  Run ` + "`no-mistakes axi logs --step review --full`" + ` to read the full step log
+  A long-running call is working, not stalled - background it if your harness needs to, but the run never advances past a gate on its own. Read every return; on a ` + "`gate:`" + `, respond; loop until an ` + "`outcome:`" + `.
+  When you make an additional fix after a gate round has already produced fix commits, commit it on top of the existing branch and run ` + "`no-mistakes axi run --intent \"...\"`" + ` with the original user intent. Never abort-and-restart, reset the branch, or open a new branch in a way that drops prior gate-fix commits. A fresh run re-validates the branch's current state, so already-resolved findings do not re-surface.
 ` + "```" + `
 
 Read the ` + "`action`" + ` column per row: decide ` + "`r1`" + ` (auto-fix) on your own

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -263,10 +263,13 @@ note: Review auto-fix is disabled by default (auto_fix.review: 0; a repo or glob
 findings[2]{id,severity,file,line,action,description}:
   r1,warning,internal/pipeline/executor.go,,auto-fix,Error from os.Remove is ignored
   r2,error,cmd/no-mistakes/main.go,,ask-user,New --force flag bypasses the confirm prompt
-help[3]:
-  no-mistakes axi respond --action fix --findings r1
-  no-mistakes axi respond --action approve
-  A long-running call is working, not stalled - background it if your harness needs to, but the run never advances past a gate on its own. Read every return; on a gate, respond; loop until an outcome.
+help[6]:
+  Run `no-mistakes axi respond --action approve` to accept this step and continue
+  Run `no-mistakes axi respond --action fix --findings <ids>` to have the pipeline fix the selected findings (do not edit files yourself)
+  Run `no-mistakes axi respond --action skip` to skip this step
+  Run `no-mistakes axi logs --step review --full` to read the full step log
+  A long-running call is working, not stalled - background it if your harness needs to, but the run never advances past a gate on its own. Read every return; on a `gate:`, respond; loop until an `outcome:`.
+  When you make an additional fix after a gate round has already produced fix commits, commit it on top of the existing branch and run `no-mistakes axi run --intent "..."` with the original user intent. Never abort-and-restart, reset the branch, or open a new branch in a way that drops prior gate-fix commits. A fresh run re-validates the branch's current state, so already-resolved findings do not re-surface.
 ```
 
 Read the `action` column per row: decide `r1` (auto-fix) on your own

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -174,6 +174,16 @@ Run the pipeline and decide on its findings as they come up:
      never mid-run to circumvent a gate. Do not leave the user at a `failed`
      outcome without either retrying or explaining what blocks it.
 
+The same applies to any additional fix that comes after a gate round has
+already produced fix commits - a newly surfaced finding, a reviewer's
+pre-merge request, or any other post-completion change: commit it on top of
+the existing branch and re-run `no-mistakes axi run`. Never abort-and-restart,
+reset the branch, or open a new branch in a way that drops the prior gate-fix
+commits (including the pipeline's own
+`no-mistakes(review|document|lint): ...` commits) - a re-run only
+re-validates the branch's current state, so those commits stay on the branch
+and already-resolved findings do not re-surface.
+
 The CI step deliberately keeps watching the PR after checks pass, so
 `axi run` returns `checks-passed` the moment checks are green rather than
 blocking on the human merge. Never poll or re-run waiting for the merge yourself.

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -177,9 +177,8 @@ Run the pipeline and decide on its findings as they come up:
 The same applies to any additional fix that comes after a gate round has
 already produced fix commits - a newly surfaced finding, a reviewer's
 pre-merge request, or any other post-completion change: commit it on top of
-the existing branch and re-run `no-mistakes axi run`. Never abort-and-restart,
-reset the branch, or open a new branch in a way that drops the prior gate-fix
-commits (including the pipeline's own
+the existing branch and re-run `no-mistakes axi run --intent "..."` with the original user intent.
+Never abort-and-restart, reset the branch, or open a new branch in a way that drops the prior gate-fix commits (including the pipeline's own
 `no-mistakes(review|document|lint): ...` commits) - a re-run only
 re-validates the branch's current state, so those commits stay on the branch
 and already-resolved findings do not re-surface.


### PR DESCRIPTION
## Intent

Document the preserve-prior-gate-progress contract in the no-mistakes agent skill: when an agent applies an additional fix after a gate round already produced fix commits (a newly-surfaced finding, a reviewer/pre-merge request, or any post-completion change), the correct move is to commit the new fix on top of the existing branch and re-run no-mistakes axi run - never abort-and-restart, reset the branch, or open a new branch in a way that drops prior gate-fix commits. This is safe because a re-run only re-validates the branch's current state, so already-resolved findings (already fixed in the committed code) do not re-surface. This is a docs-only change: edited the body constant in internal/skill/skill.go (the source of truth per AGENTS.md) and regenerated skills/no-mistakes/SKILL.md via make skill, placing the new guidance right after the existing outcomes/re-run guidance in the Validate and decide section, alongside the active_steps re-run observability guidance already there. No executor, gate-resolution, or run-model behavior was changed. Verified go vet, gofmt, make lint (skill drift check), and go test -race ./... all pass; one test (TestRebaseStep_ForkSyncsPushBranchBeforeDefaultBranch) segfaulted once under full-suite race-detector load but was confirmed pre-existing/flaky and unrelated - it passes reliably in isolation (3/3) and reproduces identically with this change stashed out.

## What Changed

- Added agent guidance for preserving prior gate-fix commits when applying follow-up fixes after a gate round.
- Synced that guidance across the skill source, generated skill, live `axi` help surfaces, and agent/CLI docs.
- Added CLI guidance coverage and committed validation excerpts for the updated help and docs wording.

## Risk Assessment

✅ Low: The change is limited to synchronized agent guidance text plus focused coverage for those surfaces, with no pipeline execution behavior changed.

## Testing

The pre-run full race baseline was green; I ran focused race tests for AXI guidance and skill install/Markdown behavior, then captured CLI help plus generated skill/docs excerpts that show agents are told to commit additional fixes on the same branch and rerun `no-mistakes axi run --intent "..."` without dropping prior gate-fix commits. All checks passed, and only the requested evidence files were left in the working tree.

- Evidence: [AXI run help transcript](https://github.com/kunchenguid/no-mistakes/blob/4be1a19e5c73621b85b1ccbaf7900ada6e21f3c0/.no-mistakes/evidence/fm/nm-incremental-fix-doc-i5/axi-run-help.txt)
- Evidence: [AXI respond help transcript](https://github.com/kunchenguid/no-mistakes/blob/4be1a19e5c73621b85b1ccbaf7900ada6e21f3c0/.no-mistakes/evidence/fm/nm-incremental-fix-doc-i5/axi-respond-help.txt)
- Evidence: [AXI abort help transcript](https://github.com/kunchenguid/no-mistakes/blob/4be1a19e5c73621b85b1ccbaf7900ada6e21f3c0/.no-mistakes/evidence/fm/nm-incremental-fix-doc-i5/axi-abort-help.txt)
- Evidence: [Generated skill Validate and decide excerpt](https://github.com/kunchenguid/no-mistakes/blob/4be1a19e5c73621b85b1ccbaf7900ada6e21f3c0/.no-mistakes/evidence/fm/nm-incremental-fix-doc-i5/generated-skill-validate-excerpt.md)
- Evidence: [Published agents guide excerpt](https://github.com/kunchenguid/no-mistakes/blob/4be1a19e5c73621b85b1ccbaf7900ada6e21f3c0/.no-mistakes/evidence/fm/nm-incremental-fix-doc-i5/agents-guide-excerpt.md)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `internal/skill/skill.go:219` - This new command example omits `--intent`, but after the agent commits an additional fix the active run no longer matches the current HEAD, so `axi run` starts a fresh run and `runAxiRun` rejects it without `--intent`. Spell this as `no-mistakes axi run --intent &#34;...&#34;` or say to reuse the original intent.
- ⚠️ `internal/skill/skill.go:216` - This adds new agent-driving guidance only to the skill body/generated skill. The repo treats this guidance as a three-surface contract, but the matching live `axi` help and `docs/src/content/docs/guides/agents.md` text do not mention preserving prior gate-fix commits, so agents using those point-of-use surfaces can still miss the contract.

🔧 Fix: Sync gate-fix preservation guidance
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`
- <code>Baseline already completed before this validation: `go test -race ./...`</code>
- `go test -race ./internal/cli -run 'TestPreserveGateFixGuidance|TestStaleMonitorGuidance' -count=1`
- `go test -race ./internal/skill -run 'TestBodyDocumentsAxiGateGuidance|TestMarkdown|TestInstall' -count=1`
- `go run ./cmd/no-mistakes axi run --help > .no-mistakes/evidence/fm/nm-incremental-fix-doc-i5/axi-run-help.txt`
- `go run ./cmd/no-mistakes axi respond --help > .no-mistakes/evidence/fm/nm-incremental-fix-doc-i5/axi-respond-help.txt`
- `go run ./cmd/no-mistakes axi abort --help > .no-mistakes/evidence/fm/nm-incremental-fix-doc-i5/axi-abort-help.txt`
- `awk 'NR>=176 && NR<=185 {print}' skills/no-mistakes/SKILL.md > .no-mistakes/evidence/fm/nm-incremental-fix-doc-i5/generated-skill-validate-excerpt.md`
- `awk 'NR>=140 && NR<=146 {print}' docs/src/content/docs/guides/agents.md > .no-mistakes/evidence/fm/nm-incremental-fix-doc-i5/agents-guide-excerpt.md`
- `rg -n "additional fix|gate round|prior gate-fix|already-resolved|abort-and-restart|original user intent" .no-mistakes/evidence/fm/nm-incremental-fix-doc-i5`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
