### PR TITLE
fix(pipeline): don't gate the test step on informational new-test-file findings

### DIFF
--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -84,7 +84,7 @@ Runs baseline tests and gathers evidence for the intended behavior.
 - By default, evidence is stored under the temporary `no-mistakes-evidence/<runID>` directory. With `test.evidence.store_in_repo: true`, evidence is stored under `<test.evidence.dir>/<branch-slug>` inside the worktree, staged during push, and published with the branch. Unsafe, symlinked, or Git-ignored evidence directories fall back to temporary storage for that run.
 - Before finishing, test agents are instructed to remove transient working-tree artifacts they created, such as downloaded models, caches, build outputs, large binaries, or generated data directories, while preserving intentional source or test-file changes and evidence files under the dedicated evidence directory.
 - Missing evidence for user intent can be reported as a warning with `action: ask-user`.
-- If the agent creates new test files (detected via `git status --porcelain`), approval is required even if tests pass.
+- If the agent creates new test files (detected via `git status --porcelain`), they are recorded as informational `no-op` findings and do not require approval when tests pass.
 
 **Approval:** test findings with `action: ask-user` pause for approval, including missing-evidence warnings for user intent. `action: auto-fix` findings stay eligible for the fix loop. `action: no-op` findings are informational only.
 

--- a/internal/e2e/journey_test.go
+++ b/internal/e2e/journey_test.go
@@ -1687,10 +1687,19 @@ func assertTestAgentNewTestFileRun(t *testing.T, h *Harness) {
 	t.Helper()
 	h.CommitChange("test-agent-new-test-file", "test-agent-new-test-file.txt", "test agent new test file\n", "add test agent new test file")
 	h.PushToGate("test-agent-new-test-file")
-	run := waitForStepStatus(t, h, "test-agent-new-test-file", types.StepTest, types.StepStatusAwaitingApproval, 10*time.Second)
+	// Issue #140: a passing test run whose only finding is an informational
+	// "new test file written by agent" note must not gate on approval; the run
+	// proceeds automatically to completion.
+	run := h.WaitForRun("test-agent-new-test-file", 60*time.Second)
+	if run.Status != types.RunCompleted {
+		t.Fatalf("test-agent-new-test-file run status = %s, want completed; error=%v", run.Status, deref(run.Error))
+	}
 	testStep, ok := findStep(run.Steps, types.StepTest)
 	if !ok {
 		t.Fatal("expected test step in test-agent-new-test-file run")
+	}
+	if testStep.Status != types.StepStatusCompleted {
+		t.Fatalf("test step status = %s, want completed", testStep.Status)
 	}
 	if testStep.FindingsJSON == nil {
 		t.Fatal("expected test step to record findings JSON for new test file")
@@ -1706,16 +1715,14 @@ func assertTestAgentNewTestFileRun(t *testing.T, h *Harness) {
 	if item.Severity != "info" {
 		t.Fatalf("new test file finding severity = %q, want info", item.Severity)
 	}
+	if item.Action != types.ActionNoOp {
+		t.Fatalf("new test file finding action = %q, want no-op", item.Action)
+	}
 	if item.File != "agent_test.py" {
 		t.Fatalf("new test file finding file = %q, want agent_test.py", item.File)
 	}
 	if !strings.Contains(item.Description, "new test file written by agent: agent_test.py") {
 		t.Fatalf("new test file finding description = %q", item.Description)
-	}
-	h.Respond(run.ID, types.StepTest, types.ActionAbort)
-	completed := h.WaitForRun("test-agent-new-test-file", 60*time.Second)
-	if completed.Status != types.RunFailed {
-		t.Fatalf("test-agent-new-test-file run status after abort = %s, want failed", completed.Status)
 	}
 }
 
@@ -1723,10 +1730,18 @@ func assertTestAgentStagedNewTestFileRun(t *testing.T, h *Harness) {
 	t.Helper()
 	h.CommitChange("test-agent-staged-new-test-file", "test-agent-staged-new-test-file.txt", "test agent staged new test file\n", "add test agent staged new test file")
 	h.PushToGate("test-agent-staged-new-test-file")
-	run := waitForStepStatus(t, h, "test-agent-staged-new-test-file", types.StepTest, types.StepStatusAwaitingApproval, 10*time.Second)
+	// Issue #140: same as the untracked case, but the agent stages the new test
+	// file. It is still purely informational, so the run proceeds automatically.
+	run := h.WaitForRun("test-agent-staged-new-test-file", 60*time.Second)
+	if run.Status != types.RunCompleted {
+		t.Fatalf("test-agent-staged-new-test-file run status = %s, want completed; error=%v", run.Status, deref(run.Error))
+	}
 	testStep, ok := findStep(run.Steps, types.StepTest)
 	if !ok {
 		t.Fatal("expected test step in test-agent-staged-new-test-file run")
+	}
+	if testStep.Status != types.StepStatusCompleted {
+		t.Fatalf("test step status = %s, want completed", testStep.Status)
 	}
 	if testStep.FindingsJSON == nil {
 		t.Fatal("expected test step to record findings JSON for staged new test file")
@@ -1742,16 +1757,14 @@ func assertTestAgentStagedNewTestFileRun(t *testing.T, h *Harness) {
 	if item.Severity != "info" {
 		t.Fatalf("staged new test file finding severity = %q, want info", item.Severity)
 	}
+	if item.Action != types.ActionNoOp {
+		t.Fatalf("staged new test file finding action = %q, want no-op", item.Action)
+	}
 	if item.File != "agent_staged_test.go" {
 		t.Fatalf("staged new test file finding file = %q, want agent_staged_test.go", item.File)
 	}
 	if !strings.Contains(item.Description, "new test file written by agent: agent_staged_test.go") {
 		t.Fatalf("staged new test file finding description = %q", item.Description)
-	}
-	h.Respond(run.ID, types.StepTest, types.ActionAbort)
-	completed := h.WaitForRun("test-agent-staged-new-test-file", 60*time.Second)
-	if completed.Status != types.RunFailed {
-		t.Fatalf("test-agent-staged-new-test-file run status after abort = %s, want failed", completed.Status)
 	}
 }
 

--- a/internal/pipeline/steps/test.go
+++ b/internal/pipeline/steps/test.go
@@ -211,18 +211,17 @@ Rules:
 		needsApproval := hasBlockingFindings(findings.Items)
 		autoFixable := needsApproval
 
-		// Check if agent wrote new test files
+		// Record any new test files the agent wrote as informational (no-op)
+		// findings. Their presence alone is not an actionable problem, so they
+		// must not force the test step into approval when tests pass (issue #140).
 		newTests := detectNewTestFiles(ctx, sctx.WorkDir)
-		if len(newTests) > 0 {
-			needsApproval = true
-			autoFixable = false
-			for _, f := range newTests {
-				findings.Items = append(findings.Items, Finding{
-					Severity:    "info",
-					File:        f,
-					Description: fmt.Sprintf("new test file written by agent: %s", f),
-				})
-			}
+		for _, f := range newTests {
+			findings.Items = append(findings.Items, Finding{
+				Severity:    "info",
+				Action:      types.ActionNoOp,
+				File:        f,
+				Description: fmt.Sprintf("new test file written by agent: %s", f),
+			})
 		}
 
 		findingsJSON, _ := json.Marshal(findings)
@@ -234,7 +233,9 @@ Rules:
 		}, nil
 	}
 
-	// Check if agent wrote new test files (fix mode uses agent before running tests)
+	// In fix mode the agent may add new test files while making tests pass.
+	// Record them as informational (no-op) findings but do not gate on them:
+	// passing tests with only informational findings proceed automatically (issue #140).
 	if sctx.Fixing && len(newTestsFromFix) > 0 {
 		findings := Findings{
 			Summary: "tests passed, but agent wrote new test files",
@@ -243,13 +244,14 @@ Rules:
 		for _, f := range newTestsFromFix {
 			findings.Items = append(findings.Items, Finding{
 				Severity:    "info",
+				Action:      types.ActionNoOp,
 				File:        f,
 				Description: fmt.Sprintf("new test file written by agent: %s", f),
 			})
 		}
 		findingsJSON, _ := json.Marshal(findings)
 		return &pipeline.StepOutcome{
-			NeedsApproval: true,
+			NeedsApproval: false,
 			Findings:      string(findingsJSON),
 			FixSummary:    fixSummary,
 		}, nil

--- a/internal/pipeline/steps/test_test.go
+++ b/internal/pipeline/steps/test_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
 	"github.com/kunchenguid/no-mistakes/internal/config"
+	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
 func TestTestStep_FixMode(t *testing.T) {
@@ -104,7 +105,7 @@ func TestTestStep_FixMode_UsesFallbackSummaryWhenStructuredSummaryMalformed(t *t
 	}
 }
 
-func TestTestStep_FixMode_AgentWritesNewTests_NeedsApproval(t *testing.T) {
+func TestTestStep_FixMode_AgentWritesNewTests_ProceedsAutomatically(t *testing.T) {
 	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
@@ -126,8 +127,10 @@ func TestTestStep_FixMode_AgentWritesNewTests_NeedsApproval(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !outcome.NeedsApproval {
-		t.Error("expected approval needed when agent writes new test files in fix mode")
+	// Issue #140: a passing test run whose only finding is an informational
+	// "new test file written by agent" note must not require approval.
+	if outcome.NeedsApproval {
+		t.Error("expected no approval for an informational new-test-file finding when tests pass")
 	}
 	if callCount != 1 {
 		t.Errorf("expected 1 agent call in fix mode, got %d", callCount)
@@ -139,7 +142,9 @@ func TestTestStep_FixMode_AgentWritesNewTests_NeedsApproval(t *testing.T) {
 	for _, item := range f.Items {
 		if strings.Contains(item.Description, "component.spec.tsx") {
 			foundTestFile = true
-			break
+			if item.Action != types.ActionNoOp {
+				t.Errorf("expected new-test-file finding action %q, got %q", types.ActionNoOp, item.Action)
+			}
 		}
 	}
 	if !foundTestFile {


### PR DESCRIPTION
Fixes #140

## What Changed

- In `internal/pipeline/steps/test.go`, new test files the agent writes are now recorded as informational `no-op` findings instead of forcing `NeedsApproval`/`autoFixable`; both the non-fix path and the fix-mode path no longer gate on their presence, so a passing test run whose only findings are these notes proceeds automatically (issue #140).
- Updated the pipeline-steps reference doc to state that agent-created test files are logged as informational `no-op` findings rather than requiring approval when tests pass.
- Adjusted the unit test (`TestTestStep_FixMode_AgentWritesNewTests_ProceedsAutomatically`) and the e2e journey assertions to expect completion with a `no-op`-actioned finding instead of an awaiting-approval gate followed by abort.

## Risk Assessment

✅ Low: A tightly-scoped, well-tested bug fix that only reclassifies new-test-file notes from a blocking gate to informational no-op findings, verified consistent with the executor gate logic, finding serialization, and all guidance surfaces.

## Testing

Completed 1 recorded test check.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `internal/pipeline/steps/test.go:212` - Non-fix path now sets `autoFixable := needsApproval` unconditionally, dropping the old forced `autoFixable = false` when new test files exist. Side effect: an evidence-agent blocking finding whose action is `auto-fix` that coincides with a newly-written test file now enters the auto-fix loop (test auto-fix default is 3) instead of parking for approval as before. This is benign and consistent with the rest of the step (exit-code test failures already auto-fix), and the new-test-file no-op findings are never themselves auto-fixed (filtered by action), so it is an improvement rather than a regression — noted only because it is a non-obvious behavior delta of the refactor.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

