### PR TITLE
feat(agent): add Cursor as a first-class ACP alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 Push to `no-mistakes` instead of `origin`, and it spins up a disposable worktree, runs an AI-driven validation pipeline, forwards the branch to the configured push target only after every check passes, and opens a clean PR automatically.
 
 - **Non-blocking** - the pipeline runs in an isolated worktree without disrupting your work.
-- **Agent-agnostic** - `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, or `acp:<target>` via `acpx`, with ordered fallbacks; every gate requires a runnable configured pipeline agent.
+- **Agent-agnostic** - `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `cursor`, or `acp:<target>` via `acpx`, with ordered fallbacks; every gate requires a runnable configured pipeline agent.
 - **Agent-native** - `/no-mistakes` lets your coding agent do a task and gate it, or gate existing committed work: it runs the pipeline, has the pipeline apply safe fixes, and escalates the rest to you.
 - **Human stays in charge** - auto-fix or review findings, your call.
 - **Clean PRs by default** - push, open PR, watch CI, and auto-fix failures in one shot.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 Push to `no-mistakes` instead of `origin`, and it spins up a disposable worktree, runs an AI-driven validation pipeline, forwards the branch to the configured push target only after every check passes, and opens a clean PR automatically.
 
 - **Non-blocking** - the pipeline runs in an isolated worktree without disrupting your work.
-- **Agent-agnostic** - `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `cursor`, or `acp:<target>` via `acpx`, with ordered fallbacks; every gate requires a runnable configured pipeline agent.
+- **Agent-agnostic** - `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, or `cursor` / `acp:<target>` via `acpx`, with ordered fallbacks; every gate requires a runnable configured pipeline agent.
 - **Agent-native** - `/no-mistakes` lets your coding agent do a task and gate it, or gate existing committed work: it runs the pipeline, has the pipeline apply safe fixes, and escalates the rest to you.
 - **Human stays in charge** - auto-fix or review findings, your call.
 - **Clean PRs by default** - push, open PR, watch CI, and auto-fix failures in one shot.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -38,7 +38,7 @@
 把分支推给 `no-mistakes` 而不是 `origin`，它会拉起一个用完即弃的 worktree，跑一条 AI 驱动的校验流水线，**只有每一项检查都通过后**才把分支转发到配置的推送目标，并自动开出一个干净的 PR。
 
 - **不阻塞** —— 流水线在隔离的 worktree 里跑，不打断你手头的工作。
-- **不挑 agent** —— 支持 `claude`、`codex`、`rovodev`、`opencode`、`pi`、`copilot`，或通过 `acpx` 用 `acp:<target>`，并支持有序 fallback。
+- **不挑 agent** —— 支持 `claude`、`codex`、`rovodev`、`opencode`、`pi`、`copilot`、`cursor`，或通过 `acpx` 用 `acp:<target>`，并支持有序 fallback。
 - **agent 原生** —— `/no-mistakes` 既能让编码 agent 完成一个任务再过网关，也能直接为已提交的工作过网关：它跑完流水线、让流水线应用安全的修复，剩下的升级给你。
 - **人始终说了算** —— 自动修复，还是逐条审查 findings，你决定。
 - **默认就是干净 PR** —— 推送、开 PR、盯 CI、自动修复失败，一气呵成。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -38,7 +38,7 @@
 把分支推给 `no-mistakes` 而不是 `origin`，它会拉起一个用完即弃的 worktree，跑一条 AI 驱动的校验流水线，**只有每一项检查都通过后**才把分支转发到配置的推送目标，并自动开出一个干净的 PR。
 
 - **不阻塞** —— 流水线在隔离的 worktree 里跑，不打断你手头的工作。
-- **不挑 agent** —— 支持 `claude`、`codex`、`rovodev`、`opencode`、`pi`、`copilot`、`cursor`，或通过 `acpx` 用 `acp:<target>`，并支持有序 fallback。
+- **不挑 agent** —— 支持 `claude`、`codex`、`rovodev`、`opencode`、`pi`、`copilot`，也可通过 `acpx` 使用 `cursor` / `acp:<target>`，并支持有序 fallback。
 - **agent 原生** —— `/no-mistakes` 既能让编码 agent 完成一个任务再过网关，也能直接为已提交的工作过网关：它跑完流水线、让流水线应用安全的修复，剩下的升级给你。
 - **人始终说了算** —— 自动修复，还是逐条审查 findings，你决定。
 - **默认就是干净 PR** —— 推送、开 PR、盯 CI、自动修复失败，一气呵成。

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -5,7 +5,7 @@ description: Supported AI agents, how to pick one, and how they integrate.
 
 `no-mistakes` is pipeline-agent-agnostic by design: the gate should mean the same thing regardless of which supported agent backend you prefer.
 It is not runner-free.
-Every validation run requires either a supported native agent binary or a configured ACP runner.
+Every validation run requires a supported native agent binary, the `agent: cursor` ACP alias, or an explicit `acp:<target>` through `acpx`.
 The default `agent: auto` setting picks the first supported native agent or ACP alias available on your system.
 
 The coding agent that calls `no-mistakes axi` drives approval gates, but it does not automatically become the pipeline agent that performs review, evidence testing, documentation, combined documentation-and-lint housekeeping, or fixes.

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -5,8 +5,8 @@ description: Supported AI agents, how to pick one, and how they integrate.
 
 `no-mistakes` is pipeline-agent-agnostic by design: the gate should mean the same thing regardless of which supported agent backend you prefer.
 It is not runner-free.
-Every validation run requires either a supported native agent binary or `acpx` configured for an ACP target.
-The default `agent: auto` setting picks the first supported native agent available on your system.
+Every validation run requires either a supported native agent binary or a configured ACP runner.
+The default `agent: auto` setting picks the first supported native agent or ACP alias available on your system.
 
 The coding agent that calls `no-mistakes axi` drives approval gates, but it does not automatically become the pipeline agent that performs review, evidence testing, documentation, combined documentation-and-lint housekeeping, or fixes.
 Those jobs run in the daemon's disposable worktree through the configured pipeline agent.
@@ -45,6 +45,7 @@ By default that directory is temporary and local to the machine; repos can opt i
 | OpenCode | `opencode` | Persistent HTTP server, SSE streaming |
 | Pi | `pi` | Subprocess per invocation, JSONL events |
 | Copilot | `copilot` | Subprocess per invocation, JSONL events |
+| Cursor | `cursor-agent` + `acpx` | `cursor-agent acp` through the ACP bridge |
 | ACP target | `acpx` | Optional user-installed ACP bridge |
 
 ## Runner requirements
@@ -113,7 +114,7 @@ agent: [codex, claude]
 ### Optional ACP target
 
 If you install `acpx` separately, you can opt into any ACP target with the `acp:` prefix, for example `agent: acp:gemini`.
-`agent: auto` only probes native agents and never auto-selects ACP targets.
+`agent: auto` probes native agents and first-class ACP aliases (such as `cursor`), and never auto-selects arbitrary `acp:<target>` entries.
 
 The [`agent` field reference](/no-mistakes/reference/global-config/#agent) owns the exact resolution order, fallback-list filtering and retry semantics, and the failure behavior when no entry is runnable.
 
@@ -279,18 +280,22 @@ Any `agent_args_override.copilot` flags are inserted before no-mistakes' managed
 Reads JSONL events from stdout, streaming incremental `assistant.message_delta` text to the TUI and capturing the final `assistant.message` content.
 The Copilot CLI has no output-schema flag, so when structured output is requested no-mistakes injects the JSON schema into the prompt and validates the final text response with the same JSON fence and bare-object fallback used by Pi and Rovo Dev.
 
+## ACP aliases
+
+ACP aliases are first-class agent names that resolve to ACP targets.
+`agent: cursor` is the first alias: it is shorthand for the `cursor` ACP target with the default raw command `cursor-agent acp`, not a separate native backend.
+`agent: acp:cursor` uses that same default command, so either spelling works without an `acp_registry_overrides.cursor` entry.
+
+Because aliases still run through acpx, they use `acpx_path` for the bridge binary and share the same ACP prompt and structured-output behavior as `agent: acp:<target>`.
+Unlike arbitrary `acp:<target>` entries, aliases may participate in `agent: auto` when their required binaries are present.
+The [Global Config Reference](/no-mistakes/reference/global-config/) owns ACP availability, bridge-path, command-override, and equivalent-spelling deduplication rules.
+
 ## ACP via acpx
 
 ACP support is optional and requires a separately installed `acpx` binary.
 Use `agent: acp:<target>` to run a target known to acpx, for example `agent: acp:gemini`.
-
-For custom ACP target commands, define a global override:
-
-```yaml
-agent: acp:local-gemini
-acp_registry_overrides:
-  local-gemini: node /opt/mock-acp-agent.mjs
-```
+When the target matches a first-class alias such as `acp:cursor`, no-mistakes supplies that alias' default raw command.
+Configure custom target commands in the [Global Config Reference](/no-mistakes/reference/global-config/#acp_registry_overrides).
 
 no-mistakes invokes acpx with JSON output, approve-all permissions, denied non-interactive permission prompts, and the repo worktree as `--cwd`.
 Structured output is handled by appending the requested JSON schema to the prompt and validating the final assistant text.
@@ -313,12 +318,12 @@ $ no-mistakes doctor
   – pi (not found)
   – copilot (not found)
   – acpx (not found)
+  – cursor (not found (cursor-agent, acpx))
   ✓ gate validation claude is runnable
 ```
 
 `✓` = available, `–` = not found (optional), `✗` = problem detected.
+The standalone `acpx` and `cursor` rows inspect the default binary names.
 The `gate validation` line is the decisive result: when the configured global runner is unavailable, doctor fails because a complete gate cannot validate without it.
-
-For `agent: acp:<target>`, doctor verifies that `acpx` is installed on `PATH` or resolves through `acpx_path` in global config.
-It does not invoke the target or test its credentials.
+See the [Global Config Reference](/no-mistakes/reference/global-config/) for ACP availability and probing behavior.
 Every new validation run resolves its effective agent again after applying any trusted repository-level override.

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -72,7 +72,8 @@ Running the gate from Antigravity or another Gemini-based coding environment doe
 Choose one of these supported setups:
 
 1. Install any supported native agent CLI and leave `agent: auto`, or select it explicitly in `~/.no-mistakes/config.yaml`.
-2. Install `acpx`, confirm that the Gemini ACP target works locally, and configure `agent: acp:gemini`.
+2. Install both `cursor-agent` and `acpx`, then leave `agent: auto` or select `agent: cursor`.
+3. Install `acpx`, confirm that the Gemini ACP target works locally, and configure `agent: acp:gemini`.
 
 ```yaml
 # ~/.no-mistakes/config.yaml
@@ -186,10 +187,12 @@ The [CLI reference](/no-mistakes/reference/cli/) documents each `axi` command an
 When the daemon is running through a managed service, its `PATH` comes from your login shell environment on macOS and Linux plus common user, Homebrew, and system binary directories; on Windows it reuses the current process environment.
 If native agent discovery does not resolve the binary you expect, check `~/.no-mistakes/logs/daemon.log` and set an explicit override; [Environment the daemon sees](/no-mistakes/reference/environment/#environment-the-daemon-sees) owns the full resolution story.
 
-Three global config fields tune resolution and invocation, and the [Global Config Reference](/no-mistakes/reference/global-config/) owns each one:
+Five global config fields tune resolution and invocation, and the [Global Config Reference](/no-mistakes/reference/global-config/) owns each one:
 
-- [`agent_path_override`](/no-mistakes/reference/global-config/#agent_path_override) - custom binary paths per native agent, plus the default binary-name table ([`acpx_path`](/no-mistakes/reference/global-config/#acpx_path) is the ACP equivalent).
+- [`agent_path_override`](/no-mistakes/reference/global-config/#agent_path_override) - custom binary paths per native agent, plus the default native binary-name table.
 - [`agent_args_override`](/no-mistakes/reference/global-config/#agent_args_override) - extra CLI flags per native agent for model selection, service tier, reasoning depth, or permission mode, including the reserved-flag rules and smart defaults. Keep it global-only; it reflects your local agent setup rather than repo policy.
+- [`acpx_path`](/no-mistakes/reference/global-config/#acpx_path) - the bridge binary path for explicit ACP targets and first-class ACP aliases.
+- [`acp_registry_overrides`](/no-mistakes/reference/global-config/#acp_registry_overrides) - raw ACP target commands, including replacements for alias defaults such as `cursor-agent acp`, plus their availability-probing rules.
 - [`agent`](/no-mistakes/reference/global-config/#agent) - the `auto` resolution order and ordered fallback-list semantics.
 
 ## Review session reuse
@@ -287,7 +290,7 @@ ACP aliases are first-class agent names that resolve to ACP targets.
 `agent: acp:cursor` uses that same default command, so either spelling works without an `acp_registry_overrides.cursor` entry.
 
 Because aliases still run through acpx, they use `acpx_path` for the bridge binary and share the same ACP prompt and structured-output behavior as `agent: acp:<target>`.
-Unlike arbitrary `acp:<target>` entries, aliases may participate in `agent: auto` when their required binaries are present.
+Unlike arbitrary `acp:<target>` entries, aliases may participate in `agent: auto` when their availability checks pass.
 The [Global Config Reference](/no-mistakes/reference/global-config/) owns ACP availability, bridge-path, command-override, and equivalent-spelling deduplication rules.
 
 ## ACP via acpx

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -4,7 +4,7 @@ description: Global and per-repo configuration options.
 ---
 
 Configuration is optional. Without any config files, `no-mistakes` defaults to
-`agent: auto`, which picks the first supported native agent available on your system,
+`agent: auto`, which picks the first supported native agent or ACP alias available on your system,
 with sensible defaults for everything else.
 
 The goal is not to make you configure a mini CI system. The default path should
@@ -64,5 +64,5 @@ An empty `commands.format` runs no separate formatter, so configure it explicitl
 Either way, available user intent can trigger an evidence-oriented agent follow-up after a successful test baseline, and evidence stays in a temporary local directory unless the repo opts into `test.evidence.store_in_repo`.
 The [Repo Config Reference](/no-mistakes/reference/repo-config/) owns the exact per-command semantics, including command process lifetime and the `ignore_patterns` match rules.
 
-Before a new validation gate starts, its effective agent configuration must resolve to a runnable native agent or ACP bridge; otherwise the gate fails before its first pipeline step, even when explicit commands are configured.
+Before a new validation gate starts, its effective agent configuration must resolve to a runnable native agent or ACP runner; otherwise the gate fails before its first pipeline step, even when explicit commands are configured.
 Run `no-mistakes doctor` to check the global runner, and see [Choosing an Agent](/no-mistakes/guides/agents/) for how agent selection and fallback lists behave.

--- a/docs/src/content/docs/guides/setup-wizard.md
+++ b/docs/src/content/docs/guides/setup-wizard.md
@@ -107,10 +107,9 @@ The wizard requires:
 
 - The gate to be initialized (`no-mistakes init` has run).
 - A clean enough state to commit and push.
-- A configured native agent binary available on `PATH` (or via `agent_path_override`), or `acpx` available on `PATH` (or via `acpx_path`) for `agent: acp:<target>`, only when the wizard needs to suggest a branch name or commit subject. For an ordered fallback list, at least one configured entry must be available.
+- A configured native or ACP agent, only when the wizard needs to suggest a branch name or commit subject. For an ordered fallback list, at least one configured entry must be available. See the [Global Config Reference](/no-mistakes/reference/global-config/) for ACP aliases such as `agent: cursor` and target requirements.
   If you already have a branch and clean working tree, or you enter those values yourself in the interactive flow, the wizard can continue without agent suggestions.
 
 If any of those are missing, the wizard reports the problem and exits.
 `no-mistakes doctor` is the fastest way to check whether the configured global runner can start a validation gate.
-For ACP targets, it verifies that `acpx_path` resolves but does not invoke the target or test its credentials.
 The wizard can proceed without an agent when it does not need a suggestion, but the pushed validation gate still fails before its first step unless the effective pipeline-agent configuration resolves to a runnable runner.

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -117,10 +117,13 @@ agent_path_override:
   claude: /Users/you/.local/bin/claude
 ```
 
-For `agent: acp:<target>`, set `acpx_path` instead:
+For `agent: acp:<target>` and ACP aliases such as `agent: cursor`, set `acpx_path` for the bridge.
+If the raw target command is also outside `PATH`, set its target key in `acp_registry_overrides`; `agent_path_override` applies only to native agents:
 
 ```yaml
 acpx_path: /Users/you/.local/bin/acpx
+acp_registry_overrides:
+  cursor: /Users/you/.local/bin/cursor-agent acp
 ```
 
 For Antigravity or Gemini-based driving agents, install a supported native agent CLI separately or configure a working ACP target such as `agent: acp:gemini` with `acpx` installed.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -99,7 +99,7 @@ When starting a new run, `axi run` refuses the default branch and uncommitted wo
 Reattaching to an in-flight run does not require `--intent`.
 Reattaching to an in-flight run can proceed while the daemon is already running even if the global config file has become invalid, but starting a fresh run still requires valid global config.
 Starting a fresh run also requires a runnable effective pipeline agent.
-If the configured native agent or ACP bridge is unavailable, the run fails before any pipeline step starts instead of reporting command-only validation as a passed gate.
+If the configured native agent or ACP runner is unavailable, the run fails before any pipeline step starts instead of reporting command-only validation as a passed gate.
 With `--yes`, `axi run` treats both `action: auto-fix` and `action: ask-user` findings as standing consent for the pipeline to fix them by selecting every finding, then accepts the resulting fix review.
 Gates with no findings or only `action: no-op` findings are approved as-is, and each step is fixed at most once so unresolved findings do not loop forever.
 Without `--yes`, an agent driving `axi run` should stop when a gate contains `action: ask-user` findings and relay each finding's ID, file, and full description to the user before responding.
@@ -370,11 +370,13 @@ Checks:
 - SQLite database
 - Daemon status
 - Agent runners: native binaries `claude`, `codex`, `acli`, `opencode`, `pi`, and `copilot`, plus the optional ACP bridge `acpx`
+- ACP alias default binaries: `cursor-agent` plus `acpx` for `cursor`
 - Effective global agent configuration, reported as `gate validation`; an unavailable configured runner is a failed check because the gate cannot validate without it
 
 Uses indicators: `✓` (available), `–` (not found, optional), `✗` (problem detected).
 
-For `agent: acp:<target>`, `doctor` verifies that `acpx` resolves but does not invoke the target or test its credentials.
+The standalone runner rows inspect default binary names; the `cursor` row reports whichever of `cursor-agent` and `acpx` are missing.
+The [Global Config Reference](/no-mistakes/reference/global-config/) owns ACP gate-validation availability and probing semantics.
 Each validation run performs the authoritative agent resolution again after applying any trusted repository-level override.
 
 `doctor` checks `gh` and `az` availability. For GitLab PR and CI steps, install and authenticate `glab`. For Bitbucket Cloud PR and CI steps, set `NO_MISTAKES_BITBUCKET_EMAIL` and `NO_MISTAKES_BITBUCKET_API_TOKEN`. For Azure DevOps PR and CI steps, install the `azure-devops` extension and provide a PAT.

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -68,17 +68,19 @@ test:
 
 Default agent for all repos and setup-wizard suggestions. Can be overridden per-repo.
 
-|         |                                                                                   |
-| ------- | --------------------------------------------------------------------------------- |
-| Type    | `string` or `string[]`                                                            |
-| Values  | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `acp:<target>` |
-| Default | `auto`                                                                            |
+|         |                                                                                             |
+| ------- | ------------------------------------------------------------------------------------------- |
+| Type    | `string` or `string[]`                                                                      |
+| Values  | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `cursor`, `acp:<target>` |
+| Default | `auto`                                                                                      |
 
-`auto` resolves to the first supported native agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, `pi`, then `copilot`.
-`acp:<target>` uses the user-installed `acpx` binary to run an ACP target, for example `acp:gemini`.
-ACP agents are opt-in and are not considered by `agent: auto`.
+`auto` resolves to the first supported native agent or ACP alias in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, `pi`, `copilot`, then `cursor`.
+`cursor` is an ACP alias for the `cursor` target with default command `cursor-agent acp`.
+With default paths, `auto` only selects it when both `cursor-agent` and `acpx` resolve; `acp_registry_overrides.cursor` and `acpx_path` replace those respective defaults during availability checks.
+`acp:<target>` uses the user-installed `acpx` binary to run an ACP target, for example `acp:gemini`; `acp:cursor` uses the same default command as `cursor`.
+Arbitrary `acp:<target>` agents are opt-in and are not considered by `agent: auto`.
 The effective agent configuration must resolve to a runnable runner before a new validation gate starts.
-If an explicit agent is unavailable, `auto` finds no native agent, or no fallback-list entry is available, the gate fails before its first pipeline step rather than reporting a partial command-only validation as passed.
+If an explicit agent is unavailable, `auto` finds no native agent or ACP alias, or no fallback-list entry is available, the gate fails before its first pipeline step rather than reporting a partial command-only validation as passed.
 `no-mistakes doctor` checks the global configuration, while every run repeats resolution after applying any trusted repository-level `agent` override.
 
 You can also set an ordered fallback list:
@@ -88,13 +90,14 @@ agent: [codex, claude]
 ```
 
 The list is filtered to entries available to the daemon at run startup, and the first available entry becomes the primary agent.
+After resolving `auto`, entries that resolve to the same ACP target are deduplicated in list order, so `cursor` and `acp:cursor` provide one fallback and preserve whichever spelling appears first.
 If no entry is available, the gate fails before its first pipeline step.
 If a pipeline invocation fails because that agent process cannot start or exits with an error, no-mistakes retries that invocation with the next available fallback.
 Structured findings and schema/output validation problems do not trigger fallback.
 
 ### acpx_path
 
-Path to the user-installed `acpx` binary used for `agent: acp:<target>`.
+Path to the user-installed `acpx` binary used for `agent: acp:<target>` and ACP aliases such as `agent: cursor`.
 
 |         |          |
 | ------- | -------- |
@@ -105,6 +108,9 @@ Path to the user-installed `acpx` binary used for `agent: acp:<target>`.
 
 Map an ACP target name to a raw ACP agent command.
 When `agent: acp:<target>` matches an override key, no-mistakes runs `acpx --agent <command>` instead of `acpx <target>`.
+ACP aliases use the same target keys. For example, `agent: cursor` and `agent: acp:cursor` resolve to the `cursor` target, so set `cursor` to override the default `cursor-agent acp` command.
+Values are trimmed; a blank or whitespace-only value behaves as no override, so an alias keeps its default command.
+Availability checks always resolve `acpx_path`. They also probe the executable named first in the effective non-blank raw command when it is a bare command name or clean absolute path. Relative, quoted, or escaped raw commands are not pre-probed; `acpx` executes them from the worktree. These checks do not invoke the ACP target or test its credentials.
 
 |         |                     |
 | ------- | ------------------- |
@@ -123,7 +129,7 @@ acp_registry_overrides:
 
 Custom binary paths for native agents.
 When set, `no-mistakes` uses this path instead of looking up the binary on `PATH`.
-ACP agents use `acpx_path` instead.
+ACP agents and aliases use `acpx_path` for the bridge; use `acp_registry_overrides` to replace a raw target command such as `cursor-agent acp`.
 
 |         |                                   |
 | ------- | --------------------------------- |

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -6,7 +6,7 @@ description: All fields for .no-mistakes.yaml.
 Per-repo configuration lives in `.no-mistakes.yaml` at the root of your repository.
 
 :::caution[Security: gate-control fields are read from the default branch]
-`commands.*` execute arbitrary shell on the daemon host via `sh -c` / `cmd.exe /c`, and `agent` selects which process launches there (including ordered fallback lists and `acp:` targets) with the maintainer's credentials.
+`commands.*` execute arbitrary shell on the daemon host via `sh -c` / `cmd.exe /c`, and `agent` selects which process launches there (including ordered fallback lists, ACP aliases such as `cursor`, and `acp:` targets) with the maintainer's credentials.
 To prevent a supply-chain attack where a contributor lands a hostile value on a gated branch, the daemon always reads **`commands` and `agent` from your default branch** (e.g. `origin/main`), never from the pushed SHA, and reads them at the exact commit a fresh fetch resolved (so a stale `origin/<default>` ref cannot serve a value the live default branch removed).
 The daemon also reads `document.instructions` and `disable_project_settings` only from that trusted copy.
 If the default branch cannot be fetched and resolved to a readable commit, or its present `.no-mistakes.yaml` cannot be read and parsed, the run aborts before launching an agent.
@@ -69,12 +69,14 @@ Override the default agent for this repo and its setup-wizard suggestions.
 | | |
 |---|---|
 | Type | `string` or `string[]` |
-| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `acp:<target>` |
+| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `cursor`, `acp:<target>` |
 | Default | Inherits from global config |
 
-`auto` resolves to the first supported native agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, `pi`, then `copilot`.
-`acp:<target>` uses the user-installed `acpx` binary configured in global config.
-ACP agents are opt-in and are not considered by `agent: auto`.
+`auto` resolves to the first supported native agent or ACP alias in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, `pi`, `copilot`, then `cursor`.
+`cursor` is an ACP alias for the `cursor` target with default command `cursor-agent acp`.
+Its availability uses the global `acpx_path` and `acp_registry_overrides.cursor` settings when present.
+`acp:<target>` uses the user-installed `acpx` binary configured in global config; `acp:cursor` uses the same default command as `cursor`.
+Arbitrary `acp:<target>` agents are opt-in and are not considered by `agent: auto`.
 The effective agent configuration must resolve to a runnable runner before a new validation gate starts.
 If the selected explicit agent or `auto` is unavailable, the gate fails before its first pipeline step rather than reporting partial validation as passed.
 
@@ -85,6 +87,7 @@ agent: [codex, claude]
 ```
 
 The list is filtered to entries available to the daemon at run startup, and the first available entry becomes the primary agent.
+After resolving `auto`, entries that resolve to the same ACP target are deduplicated in list order, so `cursor` and `acp:cursor` provide one fallback and preserve whichever spelling appears first.
 If no entry is available, the gate fails before its first pipeline step.
 If a pipeline invocation fails because that agent process cannot start or exits with an error, no-mistakes retries that invocation with the next available fallback.
 Structured findings and schema/output validation problems do not trigger fallback.

--- a/docs/src/content/docs/start-here/installation.md
+++ b/docs/src/content/docs/start-here/installation.md
@@ -47,15 +47,14 @@ make install
 ## Prerequisites
 
 - **git** - required
-- **One supported agent binary** - `claude`, `codex`, `acli` (Rovo Dev), `opencode`, `pi`, or `copilot`, or a separately installed `acpx` binary for `agent: acp:<target>`
+- **One supported agent runner** - `claude`, `codex`, `acli` (Rovo Dev), `opencode`, `pi`, or `copilot`, or a configured Cursor/ACP runner such as `agent: cursor`; see [Global Config](/no-mistakes/reference/global-config/) for ACP requirements
 - **Optional, for PRs and CI:**
   - `gh` CLI (GitHub)
   - `glab` CLI (GitLab)
   - `NO_MISTAKES_BITBUCKET_EMAIL` and `NO_MISTAKES_BITBUCKET_API_TOKEN` (Bitbucket Cloud)
   - `az` CLI with the `azure-devops` extension (Azure DevOps)
 
-Run `no-mistakes doctor` to check native agents, provider tools, and whether the configured global runner can start a validation gate.
-For `agent: acp:<target>`, doctor verifies that `acpx` or `acpx_path` resolves, but does not invoke the target or test its credentials.
+Run `no-mistakes doctor` to check native agents, ACP aliases such as `cursor`, provider tools, and whether the configured global runner can start a validation gate.
 Every validation gate requires a runnable pipeline agent and otherwise fails before its first pipeline step.
 
 See [Provider Integration](/no-mistakes/guides/provider-integration/) for PR and CI setup per host.

--- a/docs/src/content/docs/start-here/introduction.md
+++ b/docs/src/content/docs/start-here/introduction.md
@@ -70,7 +70,7 @@ When a branch passes the gate, it means:
 ## What you get
 
 - A fixed, opinionated pipeline: `intent → rebase → review → test → document → lint → push → pr → ci`. Order is not configurable; what each step runs is.
-- Choice of agent: `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, or `acp:<target>` via `acpx`, with per-repo override and ordered fallbacks; every gate requires a runnable configured pipeline agent.
+- Choice of agent: `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `cursor`, or `acp:<target>` via `acpx`, with per-repo override and ordered fallbacks; every gate requires a runnable configured pipeline agent.
 - A TUI to watch, approve, fix, skip, or abort any step.
 - A `/no-mistakes` agent skill so a coding agent can do a task and gate it, or gate existing committed work, backed by a non-interactive `no-mistakes axi` interface.
 - A setup wizard when you run bare `no-mistakes` with no active run on the current branch - it walks you through creating a branch, committing, and pushing through the gate, then attaches if the daemon registers the new run.

--- a/docs/src/content/docs/start-here/introduction.md
+++ b/docs/src/content/docs/start-here/introduction.md
@@ -70,7 +70,7 @@ When a branch passes the gate, it means:
 ## What you get
 
 - A fixed, opinionated pipeline: `intent → rebase → review → test → document → lint → push → pr → ci`. Order is not configurable; what each step runs is.
-- Choice of agent: `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `cursor`, or `acp:<target>` via `acpx`, with per-repo override and ordered fallbacks; every gate requires a runnable configured pipeline agent.
+- Choice of agent: `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, or `cursor` / `acp:<target>` via `acpx`, with per-repo override and ordered fallbacks; every gate requires a runnable configured pipeline agent.
 - A TUI to watch, approve, fix, skip, or abort any step.
 - A `/no-mistakes` agent skill so a coding agent can do a task and gate it, or gate existing committed work, backed by a non-interactive `no-mistakes axi` interface.
 - A setup wizard when you run bare `no-mistakes` with no active run on the current branch - it walks you through creating a branch, committing, and pushing through the gate, then attaches if the daemon registers the new run.

--- a/docs/src/content/docs/start-here/quick-start.md
+++ b/docs/src/content/docs/start-here/quick-start.md
@@ -24,11 +24,10 @@ no-mistakes doctor
 You need:
 
 - `git`
-- One supported agent binary (`claude`, `codex`, `acli` for Rovo Dev, `opencode`, `pi`, or `copilot`), or a separately installed `acpx` binary for `agent: acp:<target>`
+- One supported agent runner (`claude`, `codex`, `acli` for Rovo Dev, `opencode`, `pi`, or `copilot`), or a configured Cursor/ACP runner such as `agent: cursor`; see [Global Config](/no-mistakes/reference/global-config/) for ACP requirements
 - For PRs and CI: `gh` (GitHub), `glab` (GitLab), Bitbucket Cloud credentials, or `az` with the `azure-devops` extension (Azure DevOps)
 
 `no-mistakes doctor` reports whether the configured global runner can start a validation gate.
-For `agent: acp:<target>`, it verifies that `acpx` or `acpx_path` resolves, but does not invoke the target or test its credentials.
 Every validation gate requires a runnable pipeline agent and otherwise fails before its first pipeline step.
 
 See [Provider Integration](/no-mistakes/guides/provider-integration/) for PR/CI setup.

--- a/internal/agent/acpx_spawn_test.go
+++ b/internal/agent/acpx_spawn_test.go
@@ -1,0 +1,79 @@
+//go:build unix
+
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// writeStubAcpx writes a stub acpx binary that records its argv (one arg per
+// line) to the file named by NM_TEST_ACPX_ARGS_FILE and emits a minimal valid
+// acpx JSON event stream.
+func writeStubAcpx(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "acpx")
+	script := `#!/bin/sh
+printf '%s\n' "$@" > "$NM_TEST_ACPX_ARGS_FILE"
+printf '{"method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","text":"cursor stub reply"}}}\n'
+`
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestAcpxAgent_Run_CursorSpawnsDefaultCommandWithoutOverrides proves both
+// spellings of the Cursor agent drive a real acpx spawn with the alias
+// default raw command — no acp_registry_overrides entry configured.
+func TestAcpxAgent_Run_CursorSpawnsDefaultCommandWithoutOverrides(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		agent types.AgentName
+	}{
+		{name: "cursor alias", agent: types.AgentCursor},
+		{name: "explicit acp:cursor target", agent: "acp:cursor"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			argsFile := filepath.Join(dir, "argv.txt")
+			t.Setenv("NM_TEST_ACPX_ARGS_FILE", argsFile)
+			stub := writeStubAcpx(t, dir)
+
+			a, err := New(tc.agent, stub, nil)
+			if err != nil {
+				t.Fatalf("New(%q): %v", tc.agent, err)
+			}
+			res, err := a.Run(context.Background(), RunOpts{Prompt: "review this change", CWD: dir})
+			if err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+			if res.Text != "cursor stub reply" {
+				t.Errorf("result text = %q, want stub acpx output", res.Text)
+			}
+
+			data, err := os.ReadFile(argsFile)
+			if err != nil {
+				t.Fatalf("stub acpx never recorded argv: %v", err)
+			}
+			argv := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+			if len(argv) < 2 || argv[0] != "--agent" || argv[1] != "cursor-agent acp" {
+				t.Errorf("spawned argv = %q, want leading --agent \"cursor-agent acp\"", argv)
+			}
+			if len(argv) < 2 || argv[len(argv)-2] != "exec" || argv[len(argv)-1] != "review this change" {
+				t.Errorf("spawned argv = %q, want trailing exec <prompt>", argv)
+			}
+			for _, arg := range argv {
+				if arg == "cursor" {
+					t.Errorf("spawned argv = %q, must not pass the bare target when the default command is supplied", argv)
+				}
+			}
+			t.Logf("spawned: acpx %s", strings.Join(argv, " "))
+		})
+	}
+}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -789,11 +789,8 @@ func New(name types.AgentName, bin string, extraArgs []string) (Agent, error) {
 
 // NewWithOptions creates an agent by name with additional backend-specific options.
 func NewWithOptions(name types.AgentName, bin string, extraArgs []string, opts Options) (Agent, error) {
-	if target, ok := acpTarget(name); ok {
-		rawCommand := ""
-		if opts.ACPRegistryOverrides != nil {
-			rawCommand = opts.ACPRegistryOverrides[target]
-		}
+	if target, ok := types.ACPTargetFor(name); ok {
+		rawCommand := types.ACPRawCommand(target, opts.ACPRegistryOverrides)
 		return &acpxAgent{bin: bin, target: target, rawCommand: rawCommand}, nil
 	}
 	switch name {
@@ -810,20 +807,8 @@ func NewWithOptions(name types.AgentName, bin string, extraArgs []string, opts O
 	case types.AgentCopilot:
 		return &copilotAgent{bin: bin, extraArgs: extraArgs}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, copilot, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
+		return nil, fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, copilot, cursor, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
 	}
-}
-
-func acpTarget(name types.AgentName) (string, bool) {
-	value := string(name)
-	if !strings.HasPrefix(value, "acp:") {
-		return "", false
-	}
-	target := strings.TrimPrefix(value, "acp:")
-	if target == "" || strings.ContainsAny(target, " \t\r\n") {
-		return "", false
-	}
-	return target, true
 }
 
 // NewNoop returns an agent that does nothing. Used for demo mode where

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -243,7 +243,8 @@ type InvocationWorkload struct {
 }
 
 // Options configures backend-specific agent construction behavior.
-// ACPRegistryOverrides maps acpx target names to raw ACP agent commands.
+// ACPRegistryOverrides maps acpx target names, including first-class alias
+// targets, to raw ACP agent commands.
 type Options struct {
 	ACPRegistryOverrides map[string]string
 	// DisableProjectSettings, when true, asks a supported adapter (codex,
@@ -782,7 +783,8 @@ func (u *TokenUsage) Add(other TokenUsage) {
 // New creates an agent by name with the given binary path.
 // For native agents, extraArgs are user CLI flags from agent_args_override that
 // are injected into the underlying tool's argv ahead of no-mistakes' managed flags.
-// ACP agents ignore extraArgs; use NewWithOptions to provide registry overrides.
+// ACP agents and aliases ignore extraArgs; use NewWithOptions to provide
+// registry overrides.
 func New(name types.AgentName, bin string, extraArgs []string) (Agent, error) {
 	return NewWithOptions(name, bin, extraArgs, Options{})
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -25,6 +25,7 @@ func TestNew_KnownAgents(t *testing.T) {
 		{name: "opencode", agent: types.AgentOpenCode, bin: "opencode", wantName: "opencode"},
 		{name: "pi", agent: types.AgentPi, bin: "pi", wantName: "pi"},
 		{name: "copilot", agent: types.AgentCopilot, bin: "copilot", wantName: "copilot"},
+		{name: "cursor alias", agent: types.AgentCursor, bin: "acpx", wantName: "acp:cursor"},
 	}
 
 	for _, tt := range tests {
@@ -68,6 +69,82 @@ func TestNewWithOptions_ACPRegistryOverride(t *testing.T) {
 	}
 	if strings.Contains(joined, "\x00local-gemini\x00") {
 		t.Fatalf("args = %q, should not include target subcommand when override is used", args)
+	}
+}
+
+func TestACPAliasUsesDefaultCommand(t *testing.T) {
+	a, err := New(types.AgentCursor, "acpx", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	acpx, ok := a.(*acpxAgent)
+	if !ok {
+		t.Fatalf("agent type = %T, want *acpxAgent", a)
+	}
+	if acpx.target != "cursor" {
+		t.Errorf("target = %q, want cursor", acpx.target)
+	}
+	if acpx.rawCommand != "cursor-agent acp" {
+		t.Errorf("rawCommand = %q, want cursor-agent acp", acpx.rawCommand)
+	}
+	args := acpx.buildArgs(RunOpts{Prompt: "do work"})
+	joined := strings.Join(args, "\x00")
+	if !strings.Contains(joined, "--agent\x00cursor-agent acp") {
+		t.Fatalf("args = %q, want alias default command", args)
+	}
+}
+
+func TestACPTargetUsesAliasDefaultCommand(t *testing.T) {
+	a, err := New("acp:cursor", "acpx", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	acpx, ok := a.(*acpxAgent)
+	if !ok {
+		t.Fatalf("agent type = %T, want *acpxAgent", a)
+	}
+	if acpx.target != "cursor" {
+		t.Errorf("target = %q, want cursor", acpx.target)
+	}
+	if acpx.rawCommand != "cursor-agent acp" {
+		t.Errorf("rawCommand = %q, want cursor-agent acp", acpx.rawCommand)
+	}
+	args := acpx.buildArgs(RunOpts{Prompt: "do work"})
+	joined := strings.Join(args, "\x00")
+	if !strings.Contains(joined, "--agent\x00cursor-agent acp") {
+		t.Fatalf("args = %q, want target default command", args)
+	}
+}
+
+func TestACPAliasRegistryOverrideRespected(t *testing.T) {
+	a, err := NewWithOptions(types.AgentCursor, "acpx", nil, Options{
+		ACPRegistryOverrides: map[string]string{"cursor": "/opt/cursor/cursor-agent acp --profile work"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	acpx, ok := a.(*acpxAgent)
+	if !ok {
+		t.Fatalf("agent type = %T, want *acpxAgent", a)
+	}
+	if acpx.rawCommand != "/opt/cursor/cursor-agent acp --profile work" {
+		t.Errorf("rawCommand = %q, want override value", acpx.rawCommand)
+	}
+}
+
+func TestACPAliasBlankRegistryOverrideUsesDefaultCommand(t *testing.T) {
+	a, err := NewWithOptions(types.AgentCursor, "acpx", nil, Options{
+		ACPRegistryOverrides: map[string]string{"cursor": " \t"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	acpx, ok := a.(*acpxAgent)
+	if !ok {
+		t.Fatalf("agent type = %T, want *acpxAgent", a)
+	}
+	if acpx.rawCommand != "cursor-agent acp" {
+		t.Errorf("rawCommand = %q, want cursor-agent acp", acpx.rawCommand)
 	}
 }
 

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -72,8 +72,9 @@ func newAxiRunCmd() *cobra.Command {
 			"to accomplish (the goal behind the change, not a description of the diff)\n" +
 			"so no-mistakes uses it directly instead of inferring it from transcripts.\n\n" +
 			"The calling agent drives AXI approval gates but does not become the pipeline\n" +
-			"agent. The daemon requires a supported native agent binary or a configured\n" +
-			"ACP target through acpx, and fails before the first step when none can run.\n\n" +
+			"agent. The daemon requires a supported native agent binary, the `agent: cursor`\n" +
+			"ACP alias, or an explicit `acp:<target>` through `acpx`, and fails before the\n" +
+			"first step when none can run.\n\n" +
 			preserveGateFixCommitsGuidance,
 		Args:          cobra.NoArgs,
 		SilenceErrors: true,

--- a/internal/cli/axi_guidance_test.go
+++ b/internal/cli/axi_guidance_test.go
@@ -44,6 +44,8 @@ var canonicalBranchSyncPhrases = []string{
 	"preserved in the local gate",
 }
 
+const canonicalPipelineAgentPrerequisite = "a supported native agent binary, the `agent: cursor` ACP alias, or an explicit `acp:<target>` through `acpx`"
+
 // TestStaleMonitorGuidance_SyncedAcrossSurfaces guards the repo invariant that
 // agent-driving guidance stays in sync across its three surfaces: the skill
 // body, the published agents guide, and the live axi help string. The earlier
@@ -129,6 +131,20 @@ func TestBranchSyncGuidance_SyncedAcrossStaticAndLiveSurfaces(t *testing.T) {
 			if !strings.Contains(content, phrase) {
 				t.Errorf("%s is missing branch-sync guidance phrase %q", name, phrase)
 			}
+		}
+	}
+}
+
+func TestPipelineAgentPrerequisiteGuidance_SyncedAcrossSurfaces(t *testing.T) {
+	surfaces := map[string]string{
+		"skill body":   skill.Markdown(),
+		"agents guide": readAgentsGuide(t),
+		"axi run help": newAxiRunCmd().Long,
+	}
+	for name, content := range surfaces {
+		normalized := strings.Join(strings.Fields(content), " ")
+		if !strings.Contains(normalized, canonicalPipelineAgentPrerequisite) {
+			t.Errorf("%s is missing the canonical pipeline-agent prerequisite %q", name, canonicalPipelineAgentPrerequisite)
 		}
 	}
 }

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -10,9 +10,15 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/daemon"
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/types"
 	"github.com/kunchenguid/no-mistakes/internal/winproc"
 	"github.com/spf13/cobra"
 )
+
+type doctorAgentCheck struct {
+	name     string
+	binaries []string
+}
 
 func newDoctorCmd() *cobra.Command {
 	return &cobra.Command{
@@ -98,26 +104,26 @@ func newDoctorCmd() *cobra.Command {
 					}
 				}
 
-				agents := []struct {
-					name   string
-					binary string
-				}{
-					{"claude", "claude"},
-					{"codex", "codex"},
-					{"rovodev", "acli"},
-					{"opencode", "opencode"},
-					{"pi", "pi"},
-					{"copilot", "copilot"},
-					{"acpx", "acpx"},
-				}
+				agents := doctorAgentChecks()
 				fmt.Fprintln(w)
 				fmt.Fprintf(w, "  %s\n", sCyan.Render("Agents"))
 				for _, a := range agents {
 					label := fmt.Sprintf("%-14s", a.name)
-					if path, err := exec.LookPath(a.binary); err != nil {
+					var found, missing []string
+					for _, bin := range a.binaries {
+						if path, err := exec.LookPath(bin); err != nil {
+							missing = append(missing, bin)
+						} else {
+							found = append(found, path)
+						}
+					}
+					switch {
+					case len(missing) == 0:
+						ok(label, strings.Join(found, ", "))
+					case len(a.binaries) > 1:
+						warn(label, "not found ("+strings.Join(missing, ", ")+")")
+					default:
 						warn(label, "not found")
-					} else {
-						ok(label, path)
 					}
 				}
 
@@ -150,4 +156,26 @@ func newDoctorCmd() *cobra.Command {
 			})
 		},
 	}
+}
+
+func doctorAgentChecks() []doctorAgentCheck {
+	agents := []doctorAgentCheck{
+		{"claude", []string{"claude"}},
+		{"codex", []string{"codex"}},
+		{"rovodev", []string{"acli"}},
+		{"opencode", []string{"opencode"}},
+		{"pi", []string{"pi"}},
+		{"copilot", []string{"copilot"}},
+		{"acpx", []string{"acpx"}},
+	}
+	for _, alias := range types.ACPAliases() {
+		agents = append(agents, doctorAgentCheck{
+			name: string(alias.Name),
+			binaries: []string{
+				alias.DefaultCommandBinary(),
+				"acpx",
+			},
+		})
+	}
+	return agents
 }

--- a/internal/cli/doctor_cursor_test.go
+++ b/internal/cli/doctor_cursor_test.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/telemetry"
+)
+
+func TestDoctorACPAliasRequiresBothBinaries(t *testing.T) {
+	restore := telemetry.SetDefaultForTesting(&telemetryRecorder{})
+	defer restore()
+
+	t.Setenv("NM_HOME", t.TempDir())
+
+	binDir := t.TempDir()
+	writeFakeBinary(t, binDir, "cursor-agent")
+	t.Setenv("PATH", binDir)
+
+	out, err := executeCmd("doctor")
+	if err != nil {
+		t.Fatalf("doctor failed: %v\n%s", err, out)
+	}
+
+	line := doctorAgentLine(t, out, "cursor")
+	if !strings.Contains(line, "acpx") {
+		t.Fatalf("cursor alias row should name the missing acpx binary:\n%s", line)
+	}
+}
+
+func TestDoctorACPAliasDetectedWithBothBinaries(t *testing.T) {
+	restore := telemetry.SetDefaultForTesting(&telemetryRecorder{})
+	defer restore()
+
+	t.Setenv("NM_HOME", t.TempDir())
+
+	binDir := t.TempDir()
+	cursorPath := writeFakeBinary(t, binDir, "cursor-agent")
+	acpxPath := writeFakeBinary(t, binDir, "acpx")
+	t.Setenv("PATH", binDir)
+
+	out, err := executeCmd("doctor")
+	if err != nil {
+		t.Fatalf("doctor failed: %v\n%s", err, out)
+	}
+
+	line := doctorAgentLine(t, out, "cursor")
+	for _, want := range []string{cursorPath, acpxPath} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("cursor alias row did not report binary %q:\n%s", want, line)
+		}
+	}
+}
+
+func doctorAgentLine(t *testing.T, out, agent string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		for i, f := range strings.Fields(line) {
+			if i >= 1 && f == agent {
+				return line
+			}
+		}
+	}
+	t.Fatalf("no %q row in doctor output:\n%s", agent, out)
+	return ""
+}
+
+func writeFakeBinary(t *testing.T, dir, name string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		dst := filepath.Join(dir, name+".cmd")
+		if err := os.WriteFile(dst, []byte("@echo off\r\nexit /b 0\r\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return dst
+	}
+	dst := filepath.Join(dir, name)
+	if err := os.WriteFile(dst, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dst
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -313,17 +313,20 @@ const defaultConfigYAML = `# no-mistakes global configuration
 
 # Agent to use for code generation. This may also be an ordered fallback list,
 # for example: agent: [codex, claude]
-# Options: auto, claude, codex, rovodev, opencode, pi, copilot, acp:<target>
-# "auto" detects the first available native agent on your system
+# Options: auto, claude, codex, rovodev, opencode, pi, copilot, cursor, acp:<target>
+# "auto" detects the first available native agent or ACP alias on your system
+# "cursor" is an ACP alias for acp:cursor using cursor-agent acp via acpx
+# "acp:cursor" also uses that Cursor default command
 # Use acp:<target> to run an optional user-installed acpx target, for example acp:gemini
 agent: auto
 
-# Optional path to the user-installed acpx binary for acp:<target> agents
+# Optional path to the user-installed acpx binary for acp:<target> agents and ACP aliases
 # acpx_path: acpx
 
-# Optional ACP target command overrides for acp:<target> agents
+# Optional ACP target command overrides for acp:<target> agents and ACP aliases
 # acp_registry_overrides:
 #   local-gemini: node /opt/mock-acp-agent.mjs
+#   cursor: cursor-agent acp
 
 # Maximum time the CI monitor babysits an open PR with no base-branch movement
 # before giving up. The monitor watches CI and auto-rebases when the base branch
@@ -411,8 +414,8 @@ var defaultBinary = map[types.AgentName]string{
 	types.AgentCopilot:  "copilot",
 }
 
-// agentProbeOrder is the priority order for auto-detecting agents.
-var agentProbeOrder = []types.AgentName{
+// nativeAgentProbeOrder is the priority order for auto-detecting native agents.
+var nativeAgentProbeOrder = []types.AgentName{
 	types.AgentClaude,
 	types.AgentCodex,
 	types.AgentOpenCode,
@@ -422,12 +425,8 @@ var agentProbeOrder = []types.AgentName{
 }
 
 func isACPAgent(name types.AgentName) bool {
-	value := string(name)
-	if !strings.HasPrefix(value, "acp:") {
-		return false
-	}
-	target := strings.TrimPrefix(value, "acp:")
-	return target != "" && !strings.ContainsAny(target, " \t\r\n")
+	_, ok := types.ACPTargetFor(name)
+	return ok
 }
 
 var probeRovoDevSupport = func(ctx context.Context, bin string) (bool, error) {
@@ -461,9 +460,10 @@ var probeRovoDevSupport = func(ctx context.Context, bin string) (bool, error) {
 }
 
 // ResolveAgent resolves configured agent names to available agents. A single
-// explicit agent must be runnable; auto is probed into the first available
-// native agent; an ordered list is filtered to available agents and kept as fallbacks.
-// The lookPath function should behave like exec.LookPath.
+// explicit agent must be runnable; auto probes native agents, then ACP aliases;
+// an ordered list is filtered to available agents, deduplicated by resolved
+// identity, and kept as fallbacks. The lookPath function should behave like
+// exec.LookPath.
 func (c *Config) ResolveAgent(ctx context.Context, lookPath func(string) (string, error)) error {
 	candidates := c.configuredAgents()
 	if len(candidates) <= 1 {
@@ -510,8 +510,8 @@ func (c *Config) configuredAgents() []types.AgentName {
 }
 
 func (c *Config) resolveAutoAgent(ctx context.Context, lookPath func(string) (string, error)) (types.AgentName, error) {
-	probed := make([]string, 0, len(agentProbeOrder))
-	for _, name := range agentProbeOrder {
+	probed := make([]string, 0, len(nativeAgentProbeOrder)+len(types.ACPAliases())+1)
+	for _, name := range nativeAgentProbeOrder {
 		bin := string(name)
 		if b, ok := defaultBinary[name]; ok {
 			bin = b
@@ -538,12 +538,22 @@ func (c *Config) resolveAutoAgent(ctx context.Context, lookPath func(string) (st
 			return "", fmt.Errorf("resolve %s agent from %q: %w", name, bin, err)
 		}
 	}
+	for _, alias := range types.ACPAliases() {
+		available, bins, err := c.acpAvailable(alias.Name, lookPath)
+		probed = append(probed, bins...)
+		if err != nil {
+			return "", err
+		}
+		if available {
+			return alias.Name, nil
+		}
+	}
 	return "", noRunnableAgentError([]types.AgentName{types.AgentAuto}, probed)
 }
 
 func (c *Config) resolveAgentList(ctx context.Context, candidates []types.AgentName, lookPath func(string) (string, error)) ([]types.AgentName, error) {
 	resolved := make([]types.AgentName, 0, len(candidates))
-	seen := map[types.AgentName]bool{}
+	seen := map[string]bool{}
 	probed := make([]string, 0, len(candidates))
 	for _, candidate := range candidates {
 		name, ok, probe, err := c.resolveConfiguredAgent(ctx, candidate, lookPath)
@@ -553,16 +563,27 @@ func (c *Config) resolveAgentList(ctx context.Context, candidates []types.AgentN
 		if err != nil {
 			return nil, err
 		}
-		if !ok || seen[name] {
+		if !ok {
 			continue
 		}
-		seen[name] = true
+		identity := resolvedAgentIdentity(name)
+		if seen[identity] {
+			continue
+		}
+		seen[identity] = true
 		resolved = append(resolved, name)
 	}
 	if len(resolved) == 0 {
 		return nil, noRunnableAgentError(candidates, probed)
 	}
 	return resolved, nil
+}
+
+func resolvedAgentIdentity(name types.AgentName) string {
+	if target, ok := types.ACPTargetFor(name); ok {
+		return "acp:" + target
+	}
+	return "native:" + string(name)
 }
 
 func noRunnableAgentError(configured []types.AgentName, probed []string) error {
@@ -586,7 +607,15 @@ func (c *Config) resolveConfiguredAgent(ctx context.Context, name types.AgentNam
 		return resolved, err == nil, "auto", err
 	}
 	if _, ok := defaultBinary[name]; !ok && !isACPAgent(name) {
-		return "", false, string(name), fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, copilot, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
+		return "", false, string(name), fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, copilot, cursor, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
+	}
+	if isACPAgent(name) {
+		available, bins, err := c.acpAvailable(name, lookPath)
+		probe := strings.Join(bins, ", ")
+		if err != nil {
+			return "", false, probe, err
+		}
+		return name, available, probe, nil
 	}
 	bin := c.AgentPathFor(name)
 	resolvedBin, err := lookPath(bin)
@@ -609,7 +638,7 @@ func (c *Config) resolveConfiguredAgent(ctx context.Context, name types.AgentNam
 }
 
 // AgentPath returns the binary path for the configured agent.
-// ACP agents use acpx_path if set, otherwise acpx.
+// ACP agents and ACP aliases use acpx_path if set, otherwise acpx.
 // Native agents use agent_path_override if set, otherwise the default binary name.
 func (c *Config) AgentPath() string {
 	return c.AgentPathFor(c.Agent)
@@ -631,6 +660,51 @@ func (c *Config) AgentPathFor(name types.AgentName) string {
 		return b
 	}
 	return string(name)
+}
+
+// acpAvailable reports whether the acpx shim and any probeable raw-command
+// executable can be resolved. Only bare command names and clean absolute paths
+// are probeable; relative, quoted, or escaped raw commands are left for acpx to
+// execute from the worktree. It returns the binaries it considered for diagnostics.
+func (c *Config) acpAvailable(name types.AgentName, lookPath func(string) (string, error)) (bool, []string, error) {
+	bins := c.acpBinaries(name)
+	for _, bin := range bins {
+		if _, err := lookPath(bin); err != nil {
+			if errors.Is(err, exec.ErrNotFound) || errors.Is(err, fs.ErrNotExist) {
+				return false, bins, nil
+			}
+			return false, bins, fmt.Errorf("resolve %s agent from %q: %w", name, bin, err)
+		}
+	}
+	return true, bins, nil
+}
+
+func (c *Config) acpBinaries(name types.AgentName) []string {
+	bins := make([]string, 0, 2)
+	if target, ok := types.ACPTargetFor(name); ok {
+		if bin, probeable := acpCommandBinaryForProbe(types.ACPRawCommand(target, c.ACPRegistryOverrides)); probeable {
+			bins = append(bins, bin)
+		}
+	}
+	return append(bins, c.AgentPathFor(name))
+}
+
+func acpCommandBinaryForProbe(command string) (string, bool) {
+	if strings.ContainsAny(command, `"'\`) {
+		return "", false
+	}
+	fields := strings.Fields(command)
+	if len(fields) == 0 {
+		return "", false
+	}
+	bin := fields[0]
+	if filepath.IsAbs(bin) {
+		return bin, true
+	}
+	if strings.ContainsAny(bin, `/\`) {
+		return "", false
+	}
+	return bin, true
 }
 
 // AgentArgs returns extra CLI args for the configured native agent, as declared in

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -690,7 +691,14 @@ func (c *Config) acpBinaries(name types.AgentName) []string {
 }
 
 func acpCommandBinaryForProbe(command string) (string, bool) {
-	if strings.ContainsAny(command, `"'\`) {
+	return acpCommandBinaryForProbeForOS(command, runtime.GOOS)
+}
+
+func acpCommandBinaryForProbeForOS(command, goos string) (string, bool) {
+	if strings.ContainsAny(command, `"'`) {
+		return "", false
+	}
+	if goos != "windows" && strings.ContainsRune(command, '\\') {
 		return "", false
 	}
 	fields := strings.Fields(command)
@@ -698,13 +706,45 @@ func acpCommandBinaryForProbe(command string) (string, bool) {
 		return "", false
 	}
 	bin := fields[0]
-	if filepath.IsAbs(bin) {
+	if isAbsolutePathForProbe(bin, goos) {
 		return bin, true
 	}
-	if strings.ContainsAny(bin, `/\`) {
+	if containsPathSeparatorForProbe(bin, goos) {
 		return "", false
 	}
 	return bin, true
+}
+
+func isAbsolutePathForProbe(path, goos string) bool {
+	if goos == runtime.GOOS {
+		return filepath.IsAbs(path)
+	}
+	if goos == "windows" {
+		return isWindowsAbsolutePath(path)
+	}
+	return strings.HasPrefix(path, "/")
+}
+
+func isWindowsAbsolutePath(path string) bool {
+	if len(path) >= 3 && isASCIILetter(path[0]) && path[1] == ':' && isWindowsPathSeparator(path[2]) {
+		return true
+	}
+	return len(path) >= 3 && isWindowsPathSeparator(path[0]) && isWindowsPathSeparator(path[1])
+}
+
+func isASCIILetter(value byte) bool {
+	return value >= 'A' && value <= 'Z' || value >= 'a' && value <= 'z'
+}
+
+func isWindowsPathSeparator(value byte) bool {
+	return value == '\\' || value == '/'
+}
+
+func containsPathSeparatorForProbe(path, goos string) bool {
+	if goos == "windows" {
+		return strings.ContainsAny(path, `/\`)
+	}
+	return strings.ContainsRune(path, '/')
 }
 
 // AgentArgs returns extra CLI args for the configured native agent, as declared in

--- a/internal/config/config_agent_test.go
+++ b/internal/config/config_agent_test.go
@@ -45,7 +45,7 @@ func TestAgentPath_DefaultBinaries(t *testing.T) {
 	}
 }
 
-func TestAgentPath_ACPUsesAcpxPath(t *testing.T) {
+func TestAgentPath_ACPAndAliasesUseAcpxPath(t *testing.T) {
 	tests := []struct {
 		name string
 		cfg  *Config
@@ -53,6 +53,8 @@ func TestAgentPath_ACPUsesAcpxPath(t *testing.T) {
 	}{
 		{name: "default", cfg: &Config{Agent: "acp:gemini"}, want: "acpx"},
 		{name: "override", cfg: &Config{Agent: "acp:gemini", ACPXPath: "/opt/bin/acpx"}, want: "/opt/bin/acpx"},
+		{name: "alias-default", cfg: &Config{Agent: types.AgentCursor}, want: "acpx"},
+		{name: "alias-override", cfg: &Config{Agent: types.AgentCursor, ACPXPath: "/opt/bin/acpx"}, want: "/opt/bin/acpx"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -217,6 +219,41 @@ func TestResolveAgent_ListPicksFirstAvailableAndKeepsFallbacks(t *testing.T) {
 	}
 }
 
+func TestResolveAgent_ListDeduplicatesEquivalentACPTargets(t *testing.T) {
+	tests := []struct {
+		name       string
+		candidates []types.AgentName
+		want       types.AgentName
+	}{
+		{name: "alias before target", candidates: []types.AgentName{types.AgentCursor, "acp:cursor"}, want: types.AgentCursor},
+		{name: "target before alias", candidates: []types.AgentName{"acp:cursor", types.AgentCursor}, want: "acp:cursor"},
+		{name: "auto before target", candidates: []types.AgentName{types.AgentAuto, "acp:cursor"}, want: types.AgentCursor},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{Agents: tt.candidates}
+			err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
+				switch bin {
+				case "cursor-agent", "acpx":
+					return "/usr/bin/" + bin, nil
+				default:
+					return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
+				}
+			})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg.Agent != tt.want {
+				t.Errorf("agent = %q, want %q", cfg.Agent, tt.want)
+			}
+			if len(cfg.Agents) != 1 || cfg.Agents[0] != tt.want {
+				t.Fatalf("agents = %v, want [%s]", cfg.Agents, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveAgent_ListSkipsUnavailableAuto(t *testing.T) {
 	cfg := &Config{Agents: []types.AgentName{types.AgentAuto, "acp:gemini"}}
 
@@ -313,7 +350,7 @@ func TestResolveAgent_AutoSkipsRovoDevWithoutSubcommand(t *testing.T) {
 
 	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
 		switch bin {
-		case "claude", "codex", "opencode", "pi", "copilot":
+		case "claude", "codex", "opencode", "pi", "copilot", "cursor-agent", "acpx":
 			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
 		case "acli":
 			return "/usr/bin/acli", nil
@@ -423,6 +460,215 @@ func TestResolveAgent_AutoNoneAvailableIncludesOverridePaths(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("expected error to mention %q, got: %v", want, err)
 		}
+	}
+}
+
+func TestResolveAgent_AutoSkipsACPAliasWithoutAcpx(t *testing.T) {
+	// cursor is an ACP alias. Its underlying command is on PATH, but the acpx
+	// shim it runs through is not, so auto must not select it.
+	cfg := &Config{Agent: types.AgentAuto}
+	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
+		if bin == "cursor-agent" {
+			return "/usr/bin/cursor-agent", nil
+		}
+		return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
+	})
+	if err == nil {
+		t.Fatalf("expected error when acpx is missing, got agent %q", cfg.Agent)
+	}
+	if !strings.Contains(err.Error(), "no runnable agent found") {
+		t.Errorf("expected 'no runnable agent found', got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "acpx") {
+		t.Errorf("expected error to list the missing acpx binary, got: %v", err)
+	}
+}
+
+func TestResolveAgent_AutoPicksACPAliasWhenBinariesPresent(t *testing.T) {
+	cfg := &Config{Agent: types.AgentAuto}
+	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
+		switch bin {
+		case "cursor-agent":
+			return "/usr/bin/cursor-agent", nil
+		case "acpx":
+			return "/usr/bin/acpx", nil
+		default:
+			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Agent != types.AgentCursor {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentCursor)
+	}
+}
+
+func TestResolveAgent_ListSkipsACPAliasMissingCommandBinary(t *testing.T) {
+	cfg := &Config{Agents: []types.AgentName{types.AgentCursor, types.AgentClaude}}
+	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
+		switch bin {
+		case "acpx", "claude":
+			return "/usr/bin/" + bin, nil
+		default:
+			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Agent != types.AgentClaude {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentClaude)
+	}
+	if len(cfg.Agents) != 1 || cfg.Agents[0] != types.AgentClaude {
+		t.Fatalf("agents = %v, want [claude]", cfg.Agents)
+	}
+}
+
+func TestResolveAgent_ListPicksACPAliasWhenBinariesPresent(t *testing.T) {
+	cfg := &Config{Agents: []types.AgentName{types.AgentCursor}}
+	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
+		switch bin {
+		case "acpx", "cursor-agent":
+			return "/usr/bin/" + bin, nil
+		default:
+			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Agent != types.AgentCursor {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentCursor)
+	}
+}
+
+func TestResolveAgent_ListSkipsACPTargetMissingCommandBinary(t *testing.T) {
+	// acp:cursor runs the same raw command as the cursor alias, so list
+	// resolution must skip it when cursor-agent is missing even though acpx
+	// is present.
+	cfg := &Config{Agents: []types.AgentName{"acp:cursor", types.AgentClaude}}
+	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
+		switch bin {
+		case "acpx", "claude":
+			return "/usr/bin/" + bin, nil
+		default:
+			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Agent != types.AgentClaude {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentClaude)
+	}
+	if len(cfg.Agents) != 1 || cfg.Agents[0] != types.AgentClaude {
+		t.Fatalf("agents = %v, want [claude]", cfg.Agents)
+	}
+}
+
+func TestResolveAgent_ListKeepsACPTargetWhenBinariesPresent(t *testing.T) {
+	cfg := &Config{Agents: []types.AgentName{"acp:cursor", types.AgentClaude}}
+	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
+		switch bin {
+		case "acpx", "cursor-agent", "claude":
+			return "/usr/bin/" + bin, nil
+		default:
+			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Agent != "acp:cursor" {
+		t.Errorf("agent = %q, want acp:cursor", cfg.Agent)
+	}
+}
+
+func TestResolveAgent_ACPTargetRegistryOverrideBinaryProbed(t *testing.T) {
+	// A registry override makes acp:gemini run `acpx --agent "gemini-cli acp"`,
+	// so the override's binary must be probed alongside acpx.
+	cfg := &Config{
+		Agents:               []types.AgentName{"acp:gemini", types.AgentClaude},
+		ACPRegistryOverrides: map[string]string{"gemini": "gemini-cli acp"},
+	}
+	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
+		switch bin {
+		case "acpx", "claude":
+			return "/usr/bin/" + bin, nil
+		default:
+			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Agent != types.AgentClaude {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentClaude)
+	}
+}
+
+func TestResolveAgent_ACPAliasRegistryOverrideBinaryProbed(t *testing.T) {
+	cfg := &Config{
+		Agents:               []types.AgentName{types.AgentCursor},
+		ACPRegistryOverrides: map[string]string{"cursor": "/opt/cursor/cursor-agent acp --profile work"},
+	}
+	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
+		switch bin {
+		case "acpx", "/opt/cursor/cursor-agent":
+			return bin, nil
+		case "cursor-agent":
+			t.Fatalf("must probe the override binary, not the default cursor-agent")
+			return "", nil
+		default:
+			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
+		}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Agent != types.AgentCursor {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentCursor)
+	}
+}
+
+func TestResolveAgent_ACPAliasCommandAvailability(t *testing.T) {
+	tests := []struct {
+		name       string
+		override   string
+		wantErr    bool
+		wantProbes string
+	}{
+		{name: "default requires command binary", wantErr: true, wantProbes: "cursor-agent"},
+		{name: "relative override skips command probe", override: "./bin/local-agent acp", wantProbes: "acpx"},
+		{name: "quoted override skips command probe", override: `"/opt/Cursor Agent/cursor-agent" acp`, wantProbes: "acpx"},
+		{name: "escaped absolute override skips command probe", override: `/opt/Cursor\ Agent/cursor-agent acp`, wantProbes: "acpx"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{Agent: types.AgentCursor}
+			if tt.override != "" {
+				cfg.ACPRegistryOverrides = map[string]string{"cursor": tt.override}
+			}
+			var probes []string
+			err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
+				probes = append(probes, bin)
+				if bin == "acpx" {
+					return "/usr/bin/acpx", nil
+				}
+				return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
+			})
+			if tt.wantErr && err == nil {
+				t.Fatal("expected unavailable agent to fail resolution")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := strings.Join(probes, ", "); got != tt.wantProbes {
+				t.Errorf("probes = %q, want %q", got, tt.wantProbes)
+			}
+		})
 	}
 }
 

--- a/internal/config/config_agent_test.go
+++ b/internal/config/config_agent_test.go
@@ -672,6 +672,36 @@ func TestResolveAgent_ACPAliasCommandAvailability(t *testing.T) {
 	}
 }
 
+func TestACPCommandBinaryForProbeForOS(t *testing.T) {
+	tests := []struct {
+		name    string
+		goos    string
+		command string
+		wantBin string
+		wantOK  bool
+	}{
+		{name: "windows drive path", goos: "windows", command: `C:\tools\cursor-agent.exe acp`, wantBin: `C:\tools\cursor-agent.exe`, wantOK: true},
+		{name: "windows UNC path", goos: "windows", command: `\\host\share\cursor-agent.exe acp`, wantBin: `\\host\share\cursor-agent.exe`, wantOK: true},
+		{name: "unix absolute path", goos: "linux", command: "/opt/cursor-agent acp", wantBin: "/opt/cursor-agent", wantOK: true},
+		{name: "unix escaped space", goos: "linux", command: `/opt/Cursor\ Agent/cursor-agent acp`},
+		{name: "windows double-quoted path", goos: "windows", command: `"C:\Program Files\cursor-agent.exe" acp`},
+		{name: "windows single-quoted path", goos: "windows", command: `'C:\Program Files\cursor-agent.exe' acp`},
+		{name: "unix double-quoted path", goos: "linux", command: `"/opt/Cursor Agent/cursor-agent" acp`},
+		{name: "unix single-quoted path", goos: "linux", command: `'/opt/Cursor Agent/cursor-agent' acp`},
+		{name: "relative path", goos: "linux", command: "./bin/x acp"},
+		{name: "bare command", goos: "linux", command: "cursor-agent acp", wantBin: "cursor-agent", wantOK: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotBin, gotOK := acpCommandBinaryForProbeForOS(tt.command, tt.goos)
+			if gotBin != tt.wantBin || gotOK != tt.wantOK {
+				t.Errorf("acpCommandBinaryForProbeForOS(%q, %q) = (%q, %t), want (%q, %t)", tt.command, tt.goos, gotBin, gotOK, tt.wantBin, tt.wantOK)
+			}
+		})
+	}
+}
+
 func TestResolveAgent_AutoPassesContextToRovoDevProbe(t *testing.T) {
 	cfg := &Config{Agent: types.AgentAuto}
 	originalProbe := probeRovoDevSupport

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -89,7 +89,8 @@ the same way once the work is committed on a feature branch.
 - You must be on a **feature branch**, not the repository's default branch.
 - The repository must already be initialized with ` + "`no-mistakes init`" + `.
 - The daemon must have a runnable configured pipeline agent: a supported native
-  agent binary, or ` + "`acpx`" + ` for an ` + "`acp:<target>`" + `. You are the AXI driver, not
+  agent binary, the ` + "`agent: cursor`" + ` ACP alias, or an explicit ` + "`acp:<target>`" + ` through
+  ` + "`acpx`" + `. You are the AXI driver, not
   an implicit pipeline-agent backend. If none is available, the run fails
   before its first step; ` + "`no-mistakes doctor`" + ` reports the configuration problem.
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -4,6 +4,7 @@ import (
 	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // RunStatus represents the lifecycle state of a pipeline run.
@@ -128,8 +129,8 @@ const (
 	ActionAbort   ApprovalAction = "abort"
 )
 
-// AgentName identifies a supported agent backend.
-// ACP agent names use dynamic acp:<target> values instead of constants.
+// AgentName identifies a supported agent backend. Explicit ACP targets use
+// dynamic acp:<target> values; first-class ACP aliases have constants below.
 type AgentName string
 
 const (
@@ -140,4 +141,84 @@ const (
 	AgentOpenCode AgentName = "opencode"
 	AgentPi       AgentName = "pi"
 	AgentCopilot  AgentName = "copilot"
+	AgentCursor   AgentName = "cursor"
 )
+
+// ACPAlias describes a first-class agent name that resolves to an ACP target.
+type ACPAlias struct {
+	Name           AgentName
+	Target         string
+	DefaultCommand string
+}
+
+var acpAliases = []ACPAlias{
+	{Name: AgentCursor, Target: "cursor", DefaultCommand: "cursor-agent acp"},
+}
+
+// ACPAliasFor returns the ACP alias metadata for a first-class agent name.
+func ACPAliasFor(name AgentName) (ACPAlias, bool) {
+	for _, alias := range acpAliases {
+		if alias.Name == name {
+			return alias, true
+		}
+	}
+	return ACPAlias{}, false
+}
+
+// ACPAliasForTarget returns the ACP alias metadata for a raw ACP target.
+func ACPAliasForTarget(target string) (ACPAlias, bool) {
+	for _, alias := range acpAliases {
+		if alias.Target == target {
+			return alias, true
+		}
+	}
+	return ACPAlias{}, false
+}
+
+// ACPAliases returns all first-class ACP aliases.
+func ACPAliases() []ACPAlias {
+	out := make([]ACPAlias, len(acpAliases))
+	copy(out, acpAliases)
+	return out
+}
+
+// DefaultCommandBinary returns the executable named by the alias default command.
+func (a ACPAlias) DefaultCommandBinary() string {
+	fields := strings.Fields(a.DefaultCommand)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
+}
+
+// ACPTargetFor resolves the ACP target an agent name drives: the alias target
+// for a first-class alias, or the parsed target of an explicit acp:<target>
+// name. Returns false for non-ACP agent names.
+func ACPTargetFor(name AgentName) (string, bool) {
+	if alias, ok := ACPAliasFor(name); ok {
+		return alias.Target, true
+	}
+	value := string(name)
+	if !strings.HasPrefix(value, "acp:") {
+		return "", false
+	}
+	target := strings.TrimPrefix(value, "acp:")
+	if target == "" || strings.ContainsAny(target, " \t\r\n") {
+		return "", false
+	}
+	return target, true
+}
+
+// ACPRawCommand resolves the raw command acpx runs for an ACP target: a
+// registry override is trimmed and wins when non-blank, otherwise the alias
+// default command is used.
+// Empty means acpx dispatches the target through its own registry.
+func ACPRawCommand(target string, overrides map[string]string) string {
+	if override := strings.TrimSpace(overrides[target]); override != "" {
+		return override
+	}
+	if alias, ok := ACPAliasForTarget(target); ok {
+		return alias.DefaultCommand
+	}
+	return ""
+}

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -52,3 +52,84 @@ func TestStepNameUnmarshalJSON_LegacyBabysit(t *testing.T) {
 		t.Fatalf("step = %q, want %q", step, StepCI)
 	}
 }
+
+func TestACPAliasFor(t *testing.T) {
+	alias, ok := ACPAliasFor(AgentCursor)
+	if !ok {
+		t.Fatal("cursor should be registered as an ACP alias")
+	}
+	if alias.Target != "cursor" {
+		t.Fatalf("target = %q, want cursor", alias.Target)
+	}
+	if alias.DefaultCommand != "cursor-agent acp" {
+		t.Fatalf("default command = %q, want cursor-agent acp", alias.DefaultCommand)
+	}
+	if alias.DefaultCommandBinary() != "cursor-agent" {
+		t.Fatalf("default command binary = %q, want cursor-agent", alias.DefaultCommandBinary())
+	}
+	targetAlias, ok := ACPAliasForTarget("cursor")
+	if !ok {
+		t.Fatal("cursor target should resolve to an ACP alias")
+	}
+	if targetAlias.Name != AgentCursor {
+		t.Fatalf("target alias name = %q, want %q", targetAlias.Name, AgentCursor)
+	}
+
+	aliases := ACPAliases()
+	if len(aliases) != 1 {
+		t.Fatalf("aliases = %v, want only cursor", aliases)
+	}
+	aliases[0].Target = "mutated"
+	alias, _ = ACPAliasFor(AgentCursor)
+	if alias.Target != "cursor" {
+		t.Fatalf("ACPAliases should return a copy, target = %q", alias.Target)
+	}
+}
+
+func TestACPTargetFor(t *testing.T) {
+	tests := []struct {
+		name       string
+		agent      AgentName
+		wantTarget string
+		wantOK     bool
+	}{
+		{name: "alias name", agent: AgentCursor, wantTarget: "cursor", wantOK: true},
+		{name: "explicit acp alias target", agent: "acp:cursor", wantTarget: "cursor", wantOK: true},
+		{name: "explicit acp target", agent: "acp:gemini", wantTarget: "gemini", wantOK: true},
+		{name: "native agent", agent: AgentClaude, wantTarget: "", wantOK: false},
+		{name: "empty target", agent: "acp:", wantTarget: "", wantOK: false},
+		{name: "whitespace in target", agent: "acp:foo bar", wantTarget: "", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target, ok := ACPTargetFor(tt.agent)
+			if target != tt.wantTarget || ok != tt.wantOK {
+				t.Fatalf("ACPTargetFor(%q) = (%q, %v), want (%q, %v)", tt.agent, target, ok, tt.wantTarget, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestACPRawCommand(t *testing.T) {
+	tests := []struct {
+		name      string
+		target    string
+		overrides map[string]string
+		want      string
+	}{
+		{name: "alias default without overrides", target: "cursor", overrides: nil, want: "cursor-agent acp"},
+		{name: "override wins over alias default", target: "cursor", overrides: map[string]string{"cursor": "/opt/cursor/cursor-agent acp"}, want: "/opt/cursor/cursor-agent acp"},
+		{name: "override is trimmed", target: "cursor", overrides: map[string]string{"cursor": "  cursor-agent acp  "}, want: "cursor-agent acp"},
+		{name: "blank override falls back to alias default", target: "cursor", overrides: map[string]string{"cursor": " \t"}, want: "cursor-agent acp"},
+		{name: "unknown target without override", target: "gemini", overrides: nil, want: ""},
+		{name: "blank override for unknown target", target: "gemini", overrides: map[string]string{"gemini": "   "}, want: ""},
+		{name: "override for unknown target", target: "gemini", overrides: map[string]string{"gemini": "node /tmp/mock-acp.mjs"}, want: "node /tmp/mock-acp.mjs"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ACPRawCommand(tt.target, tt.overrides); got != tt.want {
+				t.Fatalf("ACPRawCommand(%q, %v) = %q, want %q", tt.target, tt.overrides, got, tt.want)
+			}
+		})
+	}
+}

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -50,7 +50,8 @@ the same way once the work is committed on a feature branch.
 - You must be on a **feature branch**, not the repository's default branch.
 - The repository must already be initialized with `no-mistakes init`.
 - The daemon must have a runnable configured pipeline agent: a supported native
-  agent binary, or `acpx` for an `acp:<target>`. You are the AXI driver, not
+  agent binary, the `agent: cursor` ACP alias, or an explicit `acp:<target>` through
+  `acpx`. You are the AXI driver, not
   an implicit pipeline-agent backend. If none is available, the run fails
   before its first step; `no-mistakes doctor` reports the configuration problem.
 


### PR DESCRIPTION
## Intent

Add cursor as a first-class agent alias of the ACP backend (agent: cursor == acp:cursor) running cursor-agent acp via acpx. cursor is modeled as an ACP alias (types.ACPAlias); override+availability probing are unified/derived from the resolved raw command so both spellings probe the same binaries; agent: auto selects cursor only when both cursor-agent and acpx are present; equivalent ACP spellings are deduplicated in ordered fallback lists preserving the first; conservative probing only pre-probes bare-name or clean-absolute executables (relative/quoted/escaped are left for acpx); doctor gains a cursor row alongside acpx. Docs document the alias with the probing/override contract centralized in the global-config reference. This is upstream PR #422 rebased onto latest upstream/main (v1.37.0), already gated to 0 review findings; this run is to have no-mistakes generate and write the upstream PR body via the pr step.

## What Changed

- Add `cursor` as a first-class alias for `acp:cursor`, running `cursor-agent acp` through `acpx` with shared path and registry overrides.
- Extend agent resolution to auto-select runnable ACP aliases, deduplicate equivalent ACP fallbacks, and safely probe command binaries across platforms.
- Add Cursor diagnostics to `doctor` and document the alias, configuration, and availability behavior across user and agent guidance.

## Risk Assessment

✅ Low: The alias, availability probing, fallback deduplication, spawn behavior, diagnostics, and documentation are consistent and introduce no substantiated material issues.

## Testing

The supplied full race baseline, fresh targeted race tests, tagged end-to-end suite, real user-facing doctor checks, and both `cursor`/`acp:cursor` spawn checks passed. CLI transcripts are the reviewer-visible surface for this non-graphical change.

<details>
<summary>Evidence: Auto selects Cursor with both binaries</summary>

```text
  System
  ✓ git             git version 2.34.1
  – gh              not found (optional, needed for PR/CI)
  – az              not found (optional, needed for Azure DevOps PR/CI)
  ✓ data directory  /tmp/no-mistakes-evidence/01KXHPVKNY5SS3S1HSSMQEDGS3/nm-home-auto
  – database        not found (will be created on first use)
  – daemon          stopped

  Agents
  – claude          not found
  – codex           not found
  – rovodev         not found
  – opencode        not found
  – pi              not found
  – copilot         not found
  ✓ acpx            /tmp/no-mistakes-evidence/01KXHPVKNY5SS3S1HSSMQEDGS3/path-cursor-both/acpx
  ✓ cursor          /tmp/no-mistakes-evidence/01KXHPVKNY5SS3S1HSSMQEDGS3/path-cursor-both/cursor-agent, /tmp/no-mistakes-evidence/01KXHPVKNY5SS3S1HSSMQEDGS3/path-cursor-both/acpx
  ✓ gate validation  cursor is runnable
```
</details>
<details>
<summary>Evidence: Auto rejects Cursor without acpx</summary>

```text
  System
  ✓ git             git version 2.34.1
  – gh              not found (optional, needed for PR/CI)
  – az              not found (optional, needed for Azure DevOps PR/CI)
  ✓ data directory  /tmp/no-mistakes-evidence/01KXHPVKNY5SS3S1HSSMQEDGS3/nm-home-auto
  – database        not found (will be created on first use)
  – daemon          stopped

  Agents
  – claude          not found
  – codex           not found
  – rovodev         not found
  – opencode        not found
  – pi              not found
  – copilot         not found
  – acpx            not found
  – cursor          not found (acpx)
  ✗ gate validation  no runnable agent found for configured agent auto (looked for: claude, codex, opencode, acli, pi, copilot, cursor-agent, acpx); the gate cannot validate without an agent; install a supported native agent, choose an available agent in ~/.no-mistakes/config.yaml, or configure agent: acp:<target> with acpx installed

  some checks failed
```
</details>
<details>
<summary>Evidence: Equivalent Cursor ACP spawn commands</summary>

```text
=== RUN   TestAcpxAgent_Run_CursorSpawnsDefaultCommandWithoutOverrides
=== RUN   TestAcpxAgent_Run_CursorSpawnsDefaultCommandWithoutOverrides/cursor_alias
    acpx_spawn_test.go:76: spawned: acpx --agent cursor-agent acp --cwd /tmp/TestAcpxAgent_Run_CursorSpawnsDefaultCommandWithoutOverridescur1579884978/001 --format json --json-strict --approve-all --non-interactive-permissions deny --suppress-reads exec review this change
=== RUN   TestAcpxAgent_Run_CursorSpawnsDefaultCommandWithoutOverrides/explicit_acp:cursor_target
    acpx_spawn_test.go:76: spawned: acpx --agent cursor-agent acp --cwd /tmp/TestAcpxAgent_Run_CursorSpawnsDefaultCommandWithoutOverridesexp2181818449/001 --format json --json-strict --approve-all --non-interactive-permissions deny --suppress-reads exec review this change
--- PASS: TestAcpxAgent_Run_CursorSpawnsDefaultCommandWithoutOverrides (0.00s)
    --- PASS: TestAcpxAgent_Run_CursorSpawnsDefaultCommandWithoutOverrides/cursor_alias (0.00s)
    --- PASS: TestAcpxAgent_Run_CursorSpawnsDefaultCommandWithoutOverrides/explicit_acp:cursor_target (0.00s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/agent	1.012s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ `internal/config/config.go:693` - On Windows, normal absolute paths such as `C:\tools\cursor-agent.exe acp` contain backslashes, so this guard classifies them as unprobeable before `filepath.IsAbs` runs. Agent resolution can therefore report Cursor runnable when only `acpx` exists, contrary to the effective-command availability contract. Recognize platform-native absolute executable paths before rejecting escaped commands, and cover Windows drive/UNC paths.

🔧 Fix: Fix Windows ACP command probing
1 warning still open:
- ⚠️ `docs/src/content/docs/guides/agents.md:8` - This alias-aware prerequisite was not propagated to the authoritative agent-driving surfaces. `internal/skill/skill.go:91` and `internal/cli/axi_drive.go:75` still describe only native binaries or explicit `acp:&lt;target&gt;` runners, so installed guidance can imply that valid `agent: cursor` setups are unsupported. Update both, regenerate `skills/no-mistakes/SKILL.md`, and pin the shared wording in `axi_guidance_test.go`.

🔧 Fix: Synchronize Cursor alias guidance across agent surfaces
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`
- <code>Supplied baseline: `go test -race ./...`</code>
- `go test -race -count=1 ./internal/types ./internal/config ./internal/agent ./internal/cli`
- `go test -race -count=1 -run '^TestAcpxAgent_Run_CursorSpawnsDefaultCommandWithoutOverrides$' -v ./internal/agent`
- `make e2e`
- <code>Built the real CLI and ran `no-mistakes doctor` with controlled `agent: auto` environments containing `cursor-agent` both with and without `acpx`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
