### PR TITLE
fix(update): make --version a side-effect-free read-only probe

### DIFF
--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -322,7 +322,7 @@ On macOS, removes the quarantine extended attribute.
 
 Because `update` installs the latest official release binary, the replacement binary includes the default self-hosted telemetry host and website ID. Disable telemetry with `NO_MISTAKES_TELEMETRY=0`, or override the host and website ID with `NO_MISTAKES_UMAMI_HOST` and `NO_MISTAKES_UMAMI_WEBSITE_ID`.
 
-Background update checks run automatically on each CLI invocation (except `update` itself). If a newer version is available, a notification is printed to stderr. Suppressed for dev builds or when `NO_MISTAKES_NO_UPDATE_CHECK=1` is set.
+Background update checks run automatically on each CLI invocation (except `update` itself and version queries `--version` / `-v`, which stay side-effect-free). If a newer version is available, a notification is printed to stderr. Suppressed for dev builds or when `NO_MISTAKES_NO_UPDATE_CHECK=1` is set.
 
 ## no-mistakes daemon start
 

--- a/docs/src/content/docs/reference/environment.md
+++ b/docs/src/content/docs/reference/environment.md
@@ -76,7 +76,7 @@ Disable background update checks.
 | Type    | `1` to disable, anything else to leave enabled |
 | Default | unset (checks enabled)                         |
 
-Update checks run on every CLI invocation except `update` itself, hit GitHub releases, cache the result in `$NM_HOME/update-check.json`, and print a one-line notification to stderr when a newer version is available. Dev builds (non-semver versions) suppress the check automatically.
+Update checks run on every CLI invocation except `update` itself and version queries (`--version` / `-v`, which stay side-effect-free), hit GitHub releases, cache the result in `$NM_HOME/update-check.json`, and print a one-line notification to stderr when a newer version is available. Dev builds (non-semver versions) suppress the check automatically.
 
 ## `XDG_DATA_HOME`
 

--- a/docs/src/content/docs/start-here/installation.md
+++ b/docs/src/content/docs/start-here/installation.md
@@ -81,7 +81,7 @@ Pass `-y` or `--yes` to continue through these prompts while still printing warn
 If the daemon executable path cannot be determined, the update aborts before replacing the binary.
 If the daemon does not come back cleanly after a successful replacement, the new binary stays installed but the command reports the daemon reset failure.
 
-Background update checks run automatically on each CLI invocation (except `update` itself). Suppress with `NO_MISTAKES_NO_UPDATE_CHECK=1`.
+Background update checks run automatically on each CLI invocation (except `update` itself and version queries `--version` / `-v`, which stay side-effect-free). Suppress with `NO_MISTAKES_NO_UPDATE_CHECK=1`.
 
 ## Remove from a repo
 

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -155,7 +155,11 @@ func (u *updater) maybeNotifyAndCheck(args []string) {
 	if u.disableBackground || isDevVersion(u.currentVersion) || os.Getenv(noUpdateCheckEnv) == "1" {
 		return
 	}
-	if len(args) > 0 && (args[0] == "update" || args[0] == backgroundFlag) {
+	// Informational commands must be side-effect-free probes: `update` and the
+	// background refresh must not re-enter it, and a version query (`--version`
+	// / `-v`) must never print a notice or spawn a background refresh so that
+	// supervision scripts can call it as an innocuous health check (#401).
+	if len(args) > 0 && (args[0] == "update" || args[0] == backgroundFlag || args[0] == "--version" || args[0] == "-v") {
 		return
 	}
 	cache := readCache(u.cachePath)

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -879,6 +879,22 @@ func TestUpdaterMaybeNotifyAndCheck(t *testing.T) {
 	if spawned {
 		t.Fatal("update command should not spawn background refresh")
 	}
+
+	// Version queries are informational health checks: they must stay
+	// side-effect-free even with a stale cache and a newer version available
+	// (never print a notice, never spawn a background refresh) so callers can
+	// probe `--version` without turning it into an execution engine (#401).
+	for _, versionArgs := range [][]string{{"--version"}, {"-v"}} {
+		stderr.Reset()
+		spawned = false
+		u.maybeNotifyAndCheck(versionArgs)
+		if stderr.Len() != 0 {
+			t.Fatalf("%v should not notify, got %q", versionArgs, stderr.String())
+		}
+		if spawned {
+			t.Fatalf("%v should not spawn background refresh", versionArgs)
+		}
+	}
 }
 
 func TestUpdaterCheckLatestBetaUsesReleasesList(t *testing.T) {


### PR DESCRIPTION
## Intent

Fixes #401: make 'no-mistakes --version' a fast, read-only health-check probe that never spawns background work or otherwise does more than report the version, so supervision scripts can call it safely.

## What Changed

- Guarded `MaybeNotifyAndCheck` in `internal/update/update.go` so that when the leading arg is `--version`/`-v`, it returns early without printing the update notice or spawning the detached background update check, making `no-mistakes --version` a fast, read-only probe.
- Added test coverage asserting `--version`/`-v` never notify or spawn a background refresh.
- Updated the CLI, environment, and installation reference docs to note that `--version`/`-v` skip background update checks.

## Risk Assessment

✅ Low: A single-line guard extension mirroring an established pattern, backed by a targeted test, with no behavioral risk to existing commands.

## Testing

Baseline `go test -race ./...` was already green. I ran the targeted unit test `TestUpdaterMaybeNotifyAndCheck` (passes) and then demonstrated the fix at the product level: built the CLI at a non-dev version so the update-notify path is active, and in an isolated NM_HOME contrasted `no-mistakes --version`/`-v` against the normal `doctor` command. With a cache advertising a newer version, `doctor` prints the "new version available" notice on stderr but `--version` prints only the version with empty stderr; with a stale cache, `doctor` spawns the detached `--update-check` child that observably rewrites update-check.json (checked_at→2026, latest_version→real v1.34.0) whereas `--version`/`-v` leave the cache untouched, proving no background work is spawned. This is a CLI (non-visual) change, so the evidence is a saved CLI transcript rather than a screenshot. Build output was removed and the worktree is clean.

<details>
<summary>Evidence: CLI transcript: --version is a side-effect-free probe (notice + background-spawn suppression, with doctor as control)</summary>

```text
# Issue #401 — 'no-mistakes --version' is a side-effect-free read-only probe
# Binary built with VERSION=v1.0.0 (non-dev, so the update-notify path is active).
# A normal command ('doctor') is used as the control for each behaviour.

================================================================
PART A — Update notice suppression (fresh cache advertising v9.9.9)
================================================================
$ no-mistakes doctor        # control: normal command SHOULD warn
  stderr (update notice) ->
      A new version of no-mistakes is available: v1.0.0 -> v9.9.9
      Run "no-mistakes update" to update

$ no-mistakes --version     # probe: must print ONLY the version
  stdout -> no-mistakes version v1.0.0 (unknown) unknown
  stderr -> <empty: 0 bytes>   ✅ no notice

================================================================
PART B — Background refresh child suppression (STALE cache => refresh due)
         Proof: the detached child rewrites update-check.json
         (checked_at -> 2026, latest_version -> real v1.34.0 from GitHub).
================================================================
$ no-mistakes --version     # probe: must NOT spawn background refresh
  cache before -> {"checked_at":"2020-01-01T00:00:00Z","latest_version":"v1.0.0"}
  RESULT -> no child spawned, cache UNCHANGED   ✅
  cache after  -> {"checked_at":"2020-01-01T00:00:00Z","latest_version":"v1.0.0"}

$ no-mistakes doctor        # control: normal command DOES refresh in background
  cache before -> {"checked_at":"2020-01-01T00:00:00Z","latest_version":"v1.0.0"}
  RESULT -> child SPAWNED, cache refreshed   ✅ (expected for normal cmd)
  cache after  -> {"checked_at":"2026-07-08T15:47:52.067699+05:30","latest_version":"v1.34.0"}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `internal/update/update.go:162` - The probe guard only inspects args[0], matching the existing update/backgroundFlag pattern. Cobra parses --version/-v in any position (e.g. `no-mistakes --skip x --version`), but MaybeNotifyAndCheck runs before cobra and would still spawn the background refresh / print the notice for those non-leading placements. For the intended supervision use case (`no-mistakes --version` as sole arg) this is fully covered, so it&#39;s a benign, pre-existing limitation rather than a regression.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`
- <code>`go test ./internal/update -run &#39;^TestUpdaterMaybeNotifyAndCheck$&#39; -count=1` (asserts --version/-v never notify or spawn)</code>
- <code>Baseline `go test -race ./...` (already green before this run)</code>
- <code>Built `go build -ldflags &#39;-X ...buildinfo.Version=v1.0.0&#39;` and ran `no-mistakes --version` / `-v` / `doctor` under an isolated temp NM_HOME (NM_DAEMON unset)</code>
- <code>Notice suppression: fresh cache advertising v9.9.9 — `doctor` prints the update notice on stderr; `--version` stdout shows only the version, stderr is 0 bytes</code>
- <code>Spawn suppression: stale cache (2020 timestamp) — `--version` leaves update-check.json unchanged (no background child), while `doctor` triggers the detached child that refreshes it to a 2026 timestamp / real v1.34.0</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
