### PR TITLE
fix(scm): resolve SSH host aliases so pr and ci steps run

### DIFF
--- a/docs/src/content/docs/guides/provider-integration.md
+++ b/docs/src/content/docs/guides/provider-integration.md
@@ -205,6 +205,32 @@ Running `glab auth login --hostname your-gitlab.example.com` is enough to make d
 
 The GitLab backend is pinned against `glab v1.5x`. Self-hosted detection and the merge-request and CI steps rely on its current flag and API surface, so keep `glab` reasonably up to date.
 
+## SSH host aliases
+
+If your `origin` remote uses an SSH host alias (a `Host` block in `~/.ssh/config`
+that maps a made-up name to a real `HostName`), `no-mistakes` resolves the alias
+to its real host before detecting the provider, so PR creation and CI monitoring
+work instead of skipping.
+
+```
+# ~/.ssh/config
+Host github-work
+    HostName github.com
+    User git
+    IdentityFile ~/.ssh/id_work
+```
+
+```sh
+git remote set-url origin git@github-work:owner/repo.git
+```
+
+The push step already worked with aliases because git resolves them itself; the
+alias only tripped up the PR and CI steps, which now resolve it the same way git
+does (via `ssh -G`) and hand `gh`/`glab` the canonical host. Resolution is
+attempted only for `ssh://` and `git@host:path` remotes and fails closed: if the
+alias can't be resolved (for example `ssh` is unavailable), detection is left
+unchanged and the host is treated as-is.
+
 ## Unsupported hosts
 
 If your upstream isn't GitHub, GitLab, Bitbucket Cloud, or Azure DevOps:

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -213,6 +213,7 @@ Check the [Provider Integration](/no-mistakes/guides/provider-integration/) requ
 - Upstream is on a host that isn't supported (GitHub, GitLab, `bitbucket.org`, or Azure DevOps)
 - Self-hosted GitHub Enterprise on a hostname that is not `github.com` isn't detected because `gh` isn't configured for the host; run `gh auth login --hostname your-ghe.example.com` so detection finds it. Once detection succeeds, the availability check is host-scoped (`gh auth status --hostname your-ghe.example.com`), so a stale token on `github.com` or any other configured gh host can no longer falsely mark the GHE repo as unauthenticated.
 - Self-hosted GitLab on a hostname with no `gitlab` marker isn't detected because `glab` isn't configured for the host; run `glab auth login --hostname your-gitlab.example.com` so detection finds it. Once detection succeeds, the availability check is host-scoped (`glab auth status --hostname your-gitlab.example.com`), so a stale token on `gitlab.com` or any other configured glab host can no longer falsely mark the self-hosted repo as unauthenticated.
+- An SSH host alias (a `Host` block in `~/.ssh/config`) that `ssh -G` can't resolve to a real hostname; when resolution fails, detection is left unchanged and the aliased host is treated as unsupported. See [SSH host aliases](/no-mistakes/guides/provider-integration/#ssh-host-aliases).
 - A GitLab, Bitbucket, or Azure DevOps repo record has a fork URL set; fork MR/PR routing is currently GitHub-only
 - You pushed the default branch (PR step always skips on the default branch)
 

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -60,11 +60,12 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	provider := scm.DetectProvider(sctx.Repo.UpstreamURL)
+	upstreamURL := scm.CanonicalRemoteURL(sctx.Repo.UpstreamURL)
+	provider := scm.DetectProvider(upstreamURL)
 	if provider == scm.ProviderUnknown && sctx.Run.PRURL != nil {
 		provider = scm.DetectProvider(*sctx.Run.PRURL)
 	}
-	host, skipReason := buildHost(sctx, provider)
+	host, skipReason := buildHost(sctx, provider, upstreamURL)
 	if host == nil {
 		sctx.Log(fmt.Sprintf("skipping CI: %s", skipReason))
 		return &pipeline.StepOutcome{Skipped: true}, nil

--- a/internal/pipeline/steps/ci_merge_test.go
+++ b/internal/pipeline/steps/ci_merge_test.go
@@ -284,7 +284,7 @@ func TestCIStep_MergeConflictAutoFixPromptUsesBaseBranchTip(t *testing.T) {
 	sctx.Config.AutoFix = config.AutoFix{CI: 1}
 
 	step := &CIStep{}
-	host, skip := buildHost(sctx, scm.ProviderGitHub)
+	host, skip := buildHost(sctx, scm.ProviderGitHub, sctx.Repo.UpstreamURL)
 	if host == nil {
 		t.Fatalf("buildHost returned nil: %s", skip)
 	}

--- a/internal/pipeline/steps/ci_test.go
+++ b/internal/pipeline/steps/ci_test.go
@@ -316,7 +316,7 @@ func TestCIStep_GetCIChecksNoChecksReported(t *testing.T) {
 	sctx := newTestContext(t, ag, dir, "abc", "def", config.Commands{})
 	sctx.Env = env
 
-	host, skip := buildHost(sctx, scm.ProviderGitHub)
+	host, skip := buildHost(sctx, scm.ProviderGitHub, sctx.Repo.UpstreamURL)
 	if host == nil {
 		t.Fatalf("buildHost returned nil: %s", skip)
 	}

--- a/internal/pipeline/steps/host.go
+++ b/internal/pipeline/steps/host.go
@@ -17,7 +17,11 @@ import (
 // working directory and environment. When the host cannot be constructed
 // (unknown provider, missing Bitbucket config, etc) it returns nil and a
 // human-readable skip reason suitable for logging.
-func buildHost(sctx *pipeline.StepContext, provider scm.Provider) (scm.Host, string) {
+//
+// upstreamURL is the repo's upstream remote with any SSH host alias already
+// resolved to its real host (see scm.CanonicalRemoteURL), so gh/glab receive
+// the canonical host for their --hostname/--repo scoping (issue #290).
+func buildHost(sctx *pipeline.StepContext, provider scm.Provider, upstreamURL string) (scm.Host, string) {
 	cmdFactory := func(_ context.Context, name string, args ...string) *exec.Cmd {
 		return stepCmd(sctx, name, args...)
 	}
@@ -30,8 +34,8 @@ func buildHost(sctx *pipeline.StepContext, provider scm.Provider) (scm.Host, str
 		// the upstream remote URL is unavailable. The hostname also scopes
 		// the auth-status check so a stale token on any other configured gh
 		// host cannot make this repo look unauthenticated.
-		host := scm.ExtractHost(sctx.Repo.UpstreamURL)
-		repo := github.HostPrefixedSlug(sctx.Repo.UpstreamURL)
+		host := scm.ExtractHost(upstreamURL)
+		repo := github.HostPrefixedSlug(upstreamURL)
 		if repo == "" && sctx.Run.PRURL != nil {
 			repo = github.HostPrefixedSlug(*sctx.Run.PRURL)
 			if host == "" {
@@ -55,8 +59,8 @@ func buildHost(sctx *pipeline.StepContext, provider scm.Provider) (scm.Host, str
 		return gitlab.New(
 			cmdFactory,
 			func() bool { return stepCLIAvailable(sctx, provider) },
-			scm.ExtractHost(sctx.Repo.UpstreamURL),
-			gitlab.ProjectPath(sctx.Repo.UpstreamURL),
+			scm.ExtractHost(upstreamURL),
+			gitlab.ProjectPath(upstreamURL),
 		), ""
 	case scm.ProviderBitbucket:
 		if sctx.Repo.ForkURL != "" {
@@ -69,7 +73,7 @@ func buildHost(sctx *pipeline.StepContext, provider scm.Provider) (scm.Host, str
 		if err != nil {
 			return nil, err.Error()
 		}
-		repo, err := resolveBitbucketRepoRef(sctx.Repo.UpstreamURL, sctx.Run.PRURL)
+		repo, err := resolveBitbucketRepoRef(upstreamURL, sctx.Run.PRURL)
 		if err != nil {
 			return nil, err.Error()
 		}
@@ -82,7 +86,7 @@ func buildHost(sctx *pipeline.StepContext, provider scm.Provider) (scm.Host, str
 			// end to end.
 			return nil, "fork PR routing for Azure DevOps is not implemented"
 		}
-		org, project, repo, ok := azuredevops.ParseRemote(sctx.Repo.UpstreamURL)
+		org, project, repo, ok := azuredevops.ParseRemote(upstreamURL)
 		if !ok && sctx.Run.PRURL != nil {
 			org, project, repo, ok = azuredevops.ParseRemote(*sctx.Run.PRURL)
 		}

--- a/internal/pipeline/steps/host_test.go
+++ b/internal/pipeline/steps/host_test.go
@@ -1,0 +1,55 @@
+package steps
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/pipeline"
+	"github.com/kunchenguid/no-mistakes/internal/scm"
+)
+
+// TestBuildHostGitHubUsesCanonicalURL is the buildHost half of the issue #290
+// fix: given the canonical upstream URL (which pr/ci pass after resolving the
+// ssh alias via scm.CanonicalRemoteURL), gh must be scoped to the real
+// host/repo, never the ssh-config alias — even when sctx.Repo.UpstreamURL still
+// holds the alias form.
+func TestBuildHostGitHubUsesCanonicalURL(t *testing.T) {
+	env, logFile := fakeGH(t, "")
+	sctx := &pipeline.StepContext{
+		Ctx:     context.Background(),
+		WorkDir: t.TempDir(),
+		Repo:    &db.Repo{UpstreamURL: "git@github-acme:test/repo.git"}, // raw ssh alias
+		Run:     &db.Run{},
+		Env:     env,
+		Log:     func(string) {},
+	}
+
+	host, skip := buildHost(sctx, scm.ProviderGitHub, "git@github.com:test/repo.git")
+	if host == nil {
+		t.Fatalf("buildHost returned nil host, skip reason: %q", skip)
+	}
+	if err := host.Available(context.Background()); err != nil {
+		t.Fatalf("host.Available() = %v", err)
+	}
+	if _, err := host.FindPR(context.Background(), "feature", "main"); err != nil {
+		t.Fatalf("host.FindPR() = %v", err)
+	}
+
+	logData, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := string(logData)
+	if !strings.Contains(log, "--hostname github.com") {
+		t.Errorf("gh auth check not scoped to canonical host; gh log:\n%s", log)
+	}
+	if !strings.Contains(log, "--repo test/repo") {
+		t.Errorf("gh not scoped to canonical repo slug; gh log:\n%s", log)
+	}
+	if strings.Contains(log, "github-acme") {
+		t.Errorf("gh invoked with the ssh alias instead of the canonical host; gh log:\n%s", log)
+	}
+}

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -61,8 +61,9 @@ func (s *PRStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 		sctx.Log(fmt.Sprintf("skipping PR creation on default branch %s", branch))
 		return &pipeline.StepOutcome{Skipped: true}, nil
 	}
-	provider := scm.DetectProvider(sctx.Repo.UpstreamURL)
-	host, skipReason := buildHost(sctx, provider)
+	upstreamURL := scm.CanonicalRemoteURL(sctx.Repo.UpstreamURL)
+	provider := scm.DetectProvider(upstreamURL)
+	host, skipReason := buildHost(sctx, provider, upstreamURL)
 	if host == nil {
 		sctx.Log(fmt.Sprintf("skipping PR creation: %s", skipReason))
 		return &pipeline.StepOutcome{Skipped: true}, nil

--- a/internal/scm/scm.go
+++ b/internal/scm/scm.go
@@ -22,7 +22,51 @@ const (
 )
 
 func DetectProvider(url string) Provider {
-	lower := strings.ToLower(url)
+	if p := providerFromMarker(url); p != ProviderUnknown {
+		return p
+	}
+
+	// Fallback for self-hosted GitLab instances whose hostname carries no
+	// "gitlab" marker: consult the glab CLI's configured hosts. If the remote's
+	// host (or a host's api_host) is one glab is configured to talk to, treat it
+	// as GitLab. This reads whatever the user configured at runtime; no host is
+	// hardcoded.
+	//
+	// Fallback for GitHub Enterprise Server instances: consult the gh CLI's
+	// configured hosts (hosts.yml). If the remote's host is one gh is
+	// authenticated with, treat it as GitHub.
+	host := ExtractHost(url)
+	if host == "" {
+		return ProviderUnknown
+	}
+	if p := providerFromKnownHost(host); p != ProviderUnknown {
+		return p
+	}
+
+	// Fallback for SSH host aliases (a `Host github-work` block in ~/.ssh/config
+	// that maps to a real HostName). The push step works because git resolves
+	// the alias itself, but the literal host ("github-work") matches no marker,
+	// so pr/ci would silently skip (issue #290). Resolve the alias to its real
+	// host and re-classify. Only attempted for ssh/scp remotes, and fail-closed:
+	// an unresolved alias leaves detection unchanged.
+	if remoteUsesSSH(url) {
+		if resolved := ResolveHostAlias(host); !strings.EqualFold(resolved, host) {
+			if p := providerFromMarker(resolved); p != ProviderUnknown {
+				return p
+			}
+			if p := providerFromKnownHost(resolved); p != ProviderUnknown {
+				return p
+			}
+		}
+	}
+
+	return ProviderUnknown
+}
+
+// providerFromMarker classifies a remote URL or host by well-known hostname
+// markers. It returns ProviderUnknown when no marker matches.
+func providerFromMarker(s string) Provider {
+	lower := strings.ToLower(s)
 	switch {
 	case strings.Contains(lower, "github.com"):
 		return ProviderGitHub
@@ -35,25 +79,20 @@ func DetectProvider(url string) Provider {
 		// the legacy vs-ssh.visualstudio.com SSH host.
 		return ProviderAzureDevOps
 	}
+	return ProviderUnknown
+}
 
-	// Fallback for self-hosted GitLab instances whose hostname carries no
-	// "gitlab" marker: consult the glab CLI's configured hosts. If the remote's
-	// host (or a host's api_host) is one glab is configured to talk to, treat it
-	// as GitLab. This reads whatever the user configured at runtime; no host is
-	// hardcoded.
-	//
-	// Fallback for GitHub Enterprise Server instances: consult the gh CLI's
-	// configured hosts (hosts.yml). If the remote's host is one gh is
-	// authenticated with, treat it as GitHub.
-	if host := ExtractHost(url); host != "" {
-		if glabKnowsHost(host) {
-			return ProviderGitLab
-		}
-		if ghKnowsHost(host) {
-			return ProviderGitHub
-		}
+// providerFromKnownHost classifies a bare host by consulting the provider CLIs'
+// configured hosts (glab, then gh), for self-hosted GitLab / GitHub Enterprise
+// instances whose hostname carries no marker. It returns ProviderUnknown when
+// neither CLI recognizes the host.
+func providerFromKnownHost(host string) Provider {
+	if glabKnowsHost(host) {
+		return ProviderGitLab
 	}
-
+	if ghKnowsHost(host) {
+		return ProviderGitHub
+	}
 	return ProviderUnknown
 }
 

--- a/internal/scm/sshalias.go
+++ b/internal/scm/sshalias.go
@@ -1,0 +1,140 @@
+package scm
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/winproc"
+)
+
+// sshHostAliasResolver resolves an SSH host alias (a `Host` block in
+// ~/.ssh/config) to its effective HostName. It returns (resolvedHost, true) on
+// success and ("", false) when resolution is unavailable (e.g. ssh missing or
+// erroring), so callers fail closed to the unresolved host. It is a package
+// variable so tests can substitute a deterministic resolver instead of shelling
+// out to a real ssh.
+var sshHostAliasResolver = resolveHostAliasViaSSH
+
+// ResolveHostAlias returns the effective hostname for an SSH host alias,
+// resolving `Host`/`HostName` entries in the user's ssh config the same way git
+// does when it pushes. When the host is not an alias, resolution is
+// unavailable, or the result is empty, the input host is returned unchanged so
+// behavior never regresses.
+func ResolveHostAlias(host string) string {
+	h := strings.TrimSpace(host)
+	if h == "" {
+		return host
+	}
+	resolved, ok := sshHostAliasResolver(h)
+	if !ok {
+		return host
+	}
+	if resolved = strings.TrimSpace(resolved); resolved == "" {
+		return host
+	}
+	return resolved
+}
+
+// CanonicalRemoteURL rewrites an SSH remote whose host is an ssh-config alias so
+// that the host names the alias's real HostName. Only scp-style
+// (git@host:path) and ssh:// remotes are considered — ssh aliases do not apply
+// to https/git remotes, which are returned unchanged. Anything that cannot be
+// resolved is returned unchanged, so the result is always a usable remote URL.
+func CanonicalRemoteURL(remote string) string {
+	s := strings.TrimSpace(remote)
+	if s == "" || !remoteUsesSSH(s) {
+		return remote
+	}
+
+	// Locate the authority (host[:port]) region for the two SSH forms.
+	var authStart, authEnd int
+	if i := strings.Index(s, "://"); i >= 0 {
+		authStart = i + len("://")
+		authEnd = len(s)
+		if slash := strings.IndexByte(s[authStart:], '/'); slash >= 0 {
+			authEnd = authStart + slash
+		}
+	} else {
+		colon := strings.IndexByte(s, ':')
+		if colon < 0 {
+			return remote
+		}
+		authStart, authEnd = 0, colon
+	}
+
+	authority := s[authStart:authEnd]
+	// Preserve any userinfo ("git@") prefix; resolve only the host token.
+	userinfo := ""
+	if at := strings.LastIndexByte(authority, '@'); at >= 0 {
+		userinfo = authority[:at+1]
+		authority = authority[at+1:]
+	}
+	host, port := authority, ""
+	if !strings.HasPrefix(host, "[") { // leave IPv6 literals untouched
+		if c := strings.LastIndexByte(host, ':'); c >= 0 && isAllDigits(host[c+1:]) {
+			host, port = host[:c], host[c:]
+		}
+	}
+
+	resolved := ResolveHostAlias(host)
+	if resolved == "" || strings.EqualFold(resolved, host) {
+		return remote
+	}
+	return s[:authStart] + userinfo + resolved + port + s[authEnd:]
+}
+
+// remoteUsesSSH reports whether remote is an ssh:// URL or scp-style
+// (git@host:path) remote, the only forms an ssh-config alias applies to.
+func remoteUsesSSH(remote string) bool {
+	s := strings.TrimSpace(remote)
+	if i := strings.Index(s, "://"); i >= 0 {
+		return strings.EqualFold(s[:i], "ssh")
+	}
+	// scp-style requires a ':' host/path separator that comes before any '/'.
+	colon := strings.IndexByte(s, ':')
+	if colon < 0 {
+		return false
+	}
+	slash := strings.IndexByte(s, '/')
+	return slash < 0 || colon < slash
+}
+
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// resolveHostAliasViaSSH runs `ssh -G <host>` and returns the effective
+// HostName it reports. ssh echoes the input back for a non-aliased host, so an
+// unchanged result is indistinguishable from "no alias" — which is exactly the
+// fail-closed behavior callers want. Any error (ssh absent, config error,
+// timeout) reports (\"\", false).
+func resolveHostAliasViaSSH(host string) (string, bool) {
+	if _, err := exec.LookPath("ssh"); err != nil {
+		return "", false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "ssh", "-G", host)
+	winproc.Harden(cmd)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", false
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && strings.EqualFold(fields[0], "hostname") {
+			return fields[1], true
+		}
+	}
+	return "", false
+}

--- a/internal/scm/sshalias.go
+++ b/internal/scm/sshalias.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kunchenguid/no-mistakes/internal/winproc"
+	"github.com/kunchenguid/no-mistakes/internal/shellenv"
 )
 
 // sshHostAliasResolver resolves an SSH host alias (a `Host` block in
@@ -78,6 +78,13 @@ func CanonicalRemoteURL(remote string) string {
 		}
 	}
 
+	// A host that already carries a well-known provider marker is not an alias,
+	// so skip resolution and avoid spawning an ssh subprocess for the common
+	// literal-host remote.
+	if providerFromMarker(host) != ProviderUnknown {
+		return remote
+	}
+
 	resolved := ResolveHostAlias(host)
 	if resolved == "" || strings.EqualFold(resolved, host) {
 		return remote
@@ -119,14 +126,18 @@ func isAllDigits(s string) bool {
 // fail-closed behavior callers want. Any error (ssh absent, config error,
 // timeout) reports (\"\", false).
 func resolveHostAliasViaSSH(host string) (string, bool) {
+	// Reject a leading-dash host so ssh cannot parse it as a flag (e.g. -F/path).
+	if strings.HasPrefix(host, "-") {
+		return "", false
+	}
 	if _, err := exec.LookPath("ssh"); err != nil {
 		return "", false
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "ssh", "-G", host)
-	winproc.Harden(cmd)
-	out, err := cmd.Output()
+	shellenv.ConfigureShellCommand(cmd)
+	out, err := shellenv.OutputShellCommand(cmd)
 	if err != nil {
 		return "", false
 	}

--- a/internal/scm/sshalias_test.go
+++ b/internal/scm/sshalias_test.go
@@ -1,0 +1,141 @@
+package scm
+
+import "testing"
+
+// stubResolver installs a deterministic ssh-alias resolver for the duration of
+// the test, so unit tests never shell out to a real ssh. aliases maps an alias
+// to its resolved HostName; hosts absent from the map resolve to themselves
+// (mirroring `ssh -G` echoing a non-aliased host back).
+func stubResolver(t *testing.T, aliases map[string]string) {
+	t.Helper()
+	prev := sshHostAliasResolver
+	t.Cleanup(func() { sshHostAliasResolver = prev })
+	sshHostAliasResolver = func(host string) (string, bool) {
+		if resolved, ok := aliases[host]; ok {
+			return resolved, true
+		}
+		return host, true
+	}
+}
+
+func TestResolveHostAlias(t *testing.T) {
+	stubResolver(t, map[string]string{"github-acme": "github.com"})
+
+	if got := ResolveHostAlias("github-acme"); got != "github.com" {
+		t.Fatalf("ResolveHostAlias(github-acme) = %q, want github.com", got)
+	}
+	if got := ResolveHostAlias("github.com"); got != "github.com" {
+		t.Fatalf("ResolveHostAlias(github.com) = %q, want unchanged", got)
+	}
+	if got := ResolveHostAlias(""); got != "" {
+		t.Fatalf("ResolveHostAlias(\"\") = %q, want empty", got)
+	}
+}
+
+func TestResolveHostAliasFailsClosed(t *testing.T) {
+	prev := sshHostAliasResolver
+	t.Cleanup(func() { sshHostAliasResolver = prev })
+	sshHostAliasResolver = func(string) (string, bool) { return "", false } // ssh unavailable
+
+	if got := ResolveHostAlias("github-acme"); got != "github-acme" {
+		t.Fatalf("ResolveHostAlias with unavailable ssh = %q, want input unchanged", got)
+	}
+}
+
+func TestCanonicalRemoteURL(t *testing.T) {
+	stubResolver(t, map[string]string{
+		"github-acme": "github.com",
+		"gl-work":     "gitlab.com",
+	})
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"scp alias", "git@github-acme:acme/app.git", "git@github.com:acme/app.git"},
+		{"scp alias no user", "github-acme:acme/app.git", "github.com:acme/app.git"},
+		{"ssh url alias with port", "ssh://git@gl-work:22/grp/proj.git", "ssh://git@gitlab.com:22/grp/proj.git"},
+		{"ssh url alias no port", "ssh://git@gl-work/grp/proj.git", "ssh://git@gitlab.com/grp/proj.git"},
+		{"scp non-alias unchanged", "git@github.com:acme/app.git", "git@github.com:acme/app.git"},
+		{"https never rewritten", "https://github-acme/acme/app.git", "https://github-acme/acme/app.git"},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := CanonicalRemoteURL(tc.in); got != tc.want {
+				t.Fatalf("CanonicalRemoteURL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRemoteUsesSSH(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"git@github.com:acme/app.git", true},
+		{"ssh://git@github.com/acme/app.git", true},
+		{"https://github.com/acme/app.git", false},
+		{"http://github.com/acme/app.git", false},
+		{"/local/path", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := remoteUsesSSH(tc.in); got != tc.want {
+			t.Fatalf("remoteUsesSSH(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestDetectProvider_SSHAlias is the regression for issue #290: an ssh-alias
+// remote must classify to its real provider instead of ProviderUnknown, so the
+// pr/ci steps run instead of silently skipping.
+func TestDetectProvider_SSHAlias(t *testing.T) {
+	t.Setenv("GLAB_CONFIG_DIR", t.TempDir())
+	t.Setenv("GH_CONFIG_DIR", t.TempDir())
+	stubResolver(t, map[string]string{
+		"github-acme": "github.com",
+		"gl-work":     "gitlab.com",
+	})
+
+	cases := []struct {
+		name string
+		in   string
+		want Provider
+	}{
+		{"github ssh alias scp", "git@github-acme:acme/app.git", ProviderGitHub},
+		{"gitlab ssh alias url", "ssh://git@gl-work/grp/proj.git", ProviderGitLab},
+		{"unknown alias stays unknown", "git@some-random-alias:acme/app.git", ProviderUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := DetectProvider(tc.in); got != tc.want {
+				t.Fatalf("DetectProvider(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDetectProvider_LiteralHostSkipsAliasResolution guards the hot path: a
+// literal github.com/gitlab.com remote must classify without invoking the ssh
+// resolver at all.
+func TestDetectProvider_LiteralHostSkipsAliasResolution(t *testing.T) {
+	t.Setenv("GLAB_CONFIG_DIR", t.TempDir())
+	t.Setenv("GH_CONFIG_DIR", t.TempDir())
+	prev := sshHostAliasResolver
+	t.Cleanup(func() { sshHostAliasResolver = prev })
+	sshHostAliasResolver = func(host string) (string, bool) {
+		t.Fatalf("ssh resolver must not run for a literal host, got %q", host)
+		return "", false
+	}
+
+	if got := DetectProvider("git@github.com:acme/app.git"); got != ProviderGitHub {
+		t.Fatalf("DetectProvider(github.com) = %q, want github", got)
+	}
+	// https remote with an unknown host must not trigger ssh resolution either.
+	if got := DetectProvider("https://unknown-host.example/acme/app.git"); got != ProviderUnknown {
+		t.Fatalf("DetectProvider(https unknown) = %q, want unknown", got)
+	}
+}

--- a/internal/scm/sshalias_test.go
+++ b/internal/scm/sshalias_test.go
@@ -70,6 +70,31 @@ func TestCanonicalRemoteURL(t *testing.T) {
 	}
 }
 
+// TestCanonicalRemoteURL_LiteralHostSkipsAliasResolution guards the hot path: a
+// literal marker host must be returned unchanged without invoking the ssh
+// resolver.
+func TestCanonicalRemoteURL_LiteralHostSkipsAliasResolution(t *testing.T) {
+	prev := sshHostAliasResolver
+	t.Cleanup(func() { sshHostAliasResolver = prev })
+	sshHostAliasResolver = func(host string) (string, bool) {
+		t.Fatalf("ssh resolver must not run for a literal host, got %q", host)
+		return "", false
+	}
+
+	in := "git@github.com:acme/app.git"
+	if got := CanonicalRemoteURL(in); got != in {
+		t.Fatalf("CanonicalRemoteURL(%q) = %q, want unchanged", in, got)
+	}
+}
+
+// TestResolveHostAliasViaSSH_RejectsLeadingDashHost ensures a host that ssh
+// would parse as a flag never reaches the ssh invocation.
+func TestResolveHostAliasViaSSH_RejectsLeadingDashHost(t *testing.T) {
+	if resolved, ok := resolveHostAliasViaSSH("-F/etc/passwd"); ok || resolved != "" {
+		t.Fatalf("resolveHostAliasViaSSH(leading-dash) = (%q, %v), want (\"\", false)", resolved, ok)
+	}
+}
+
 func TestRemoteUsesSSH(t *testing.T) {
 	cases := []struct {
 		in   string


### PR DESCRIPTION
## Intent
Fixes #290
Make the pr and ci pipeline steps work for repos whose origin remote uses an SSH host alias (e.g. git@github-acme:owner/repo.git backed by a ~/.ssh/config Host block), instead of classifying the provider as unknown and silently skipping PR creation and CI monitoring.

## What Changed

- Added `internal/scm/sshalias.go` to canonicalize SSH remote hosts by resolving `~/.ssh/config` `Host` aliases via `ssh -G <host>`, so a remote like `git@github-acme:owner/repo.git` maps back to its real provider host instead of being classified as unknown (issue #290).
- Wired provider detection and canonical-URL resolution through the pr and ci pipeline steps (`internal/pipeline/steps/pr.go`, `ci.go`, `host.go`), so PR creation and CI monitoring no longer silently skip on alias-backed remotes; `buildHost` now scopes `gh` to the canonical host rather than the alias.
- Guarded the alias hot path (short-circuiting literal marker hosts to avoid spawning `ssh` on every common `git@github.com` remote), rejected leading-dash hosts, and routed the `ssh -G` invocation through the documented one-shot subprocess helper; added `sshalias_test.go`/`host_test.go` coverage and provider-integration docs.

## Risk Assessment

✅ Low: Well-bounded, fail-closed SSH-alias resolution that leaves all existing paths unchanged when resolution is unavailable; the three prior-round findings are fixed and no new material issues remain.

## Testing

Baseline `go test -race ./...` already passed. On top of that I ran the new stubbed regression tests (`TestDetectProvider_SSHAlias`, `TestCanonicalRemoteURL`, `TestBuildHostGitHubUsesCanonicalURL`) and the full `internal/scm` + `internal/pipeline/steps` packages under `-race`, all green. Because the unit tests stub the ssh resolver, I additionally exercised the real `resolveHostAliasViaSSH` subprocess path against a genuine `ssh -G` (OpenSSH 9.8p1) pointed at a controlled ssh config via a PATH shim: `git@github-acme:acme/app.git` resolved to canonical `git@github.com:acme/app.git` → provider github, `ssh://git@gl-work/grp/proj.git` → `ssh://git@gitlab.com/...` → gitlab, an unknown alias stayed unknown (fail-closed), and a literal github.com remote classified without invoking ssh — directly demonstrating the issue #290 behavior (previously these aliased remotes classified as Unknown and pr/ci silently skipped). This is a CLI/provider-detection change with no user-visible UI surface, so the reviewer-facing evidence is the CLI/transcript artifact rather than a screenshot. The throwaway evidence test was removed and the working tree is clean.

<details>
<summary>Evidence: Real `ssh -G` provider detection for SSH-alias remotes (issue #290)</summary>

<code>=== provider detection through the REAL ssh subprocess ===&#10;[OK] remote=git@github-acme:acme/app.git canonical=git@github.com:acme/app.git provider=github&#10;[OK] remote=ssh://git@gl-work/grp/proj.git canonical=ssh://git@gitlab.com/grp/proj.git provider=gitlab&#10;[OK] remote=git@some-random-alias:acme/app.git canonical=git@some-random-alias:acme/app.git provider=unknown&#10;[OK] remote=git@github.com:acme/app.git canonical=git@github.com:acme/app.git provider=github</code>

```text
=== RUN   TestEvidenceRealSSHAliasResolution
=== ssh config used by the real `ssh -G` invocation ===
Host github-acme
    HostName github.com
    User git

Host gl-work
    HostName gitlab.com
    User git
=== provider detection through the REAL ssh subprocess ===
[OK] remote=git@github-acme:acme/app.git           canonical=git@github.com:acme/app.git        provider=github
[OK] remote=ssh://git@gl-work/grp/proj.git         canonical=ssh://git@gitlab.com/grp/proj.git  provider=gitlab
[OK] remote=git@some-random-alias:acme/app.git     canonical=git@some-random-alias:acme/app.git provider=unknown
[OK] remote=git@github.com:acme/app.git            canonical=git@github.com:acme/app.git        provider=github
--- PASS: TestEvidenceRealSSHAliasResolution (0.47s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/scm	0.969s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `internal/scm/sshalias.go:81` - CanonicalRemoteURL calls ResolveHostAlias (which shells out `ssh -G &lt;host&gt;`) for every SSH remote, with no short-circuit for literal marker hosts. DetectProvider guards this hot path (see TestDetectProvider_LiteralHostSkipsAliasResolution), but pr.go/ci.go now call CanonicalRemoteURL unconditionally, so the common `git@github.com:owner/repo.git` remote spawns an ssh subprocess on every PR and CI step (up to the 2s timeout if ssh config has slow Match exec). Add a guard skipping resolution when providerFromMarker(host) != ProviderUnknown, mirroring DetectProvider.
- ℹ️ `internal/scm/sshalias.go:135` - host is passed as a positional arg to `ssh -G &lt;host&gt;`; a host beginning with &#39;-&#39; (e.g. `-F/path`) would be parsed by ssh as a flag. Low likelihood since upstream_url is maintainer-configured and -G does not execute ProxyCommand, but reject/escape leading-dash hosts before invoking ssh.
- ℹ️ `internal/scm/sshalias.go:137` - resolveHostAliasViaSSH uses cmd.Output() + winproc.Harden directly instead of shellenv.OutputShellCommand, which per AGENTS.md is the one-shot helper that reaps the process group on success/error paths. Marginal (ssh -G is short-lived) but inconsistent with the documented subprocess convention.

🔧 Fix: guard ssh-alias hot path, dash hosts, and shellenv use
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`
- <code>`go test ./internal/scm/ -run &#39;TestDetectProvider_SSHAlias|TestCanonicalRemoteURL|TestResolveHostAlias|TestRemoteUsesSSH|TestDetectProvider_LiteralHostSkipsAliasResolution&#39; -v` (stubbed-resolver regression coverage for issue #290)</code>
- <code>`go test ./internal/pipeline/steps/ -run TestBuildHostGitHubUsesCanonicalURL -v` (gh scoped to canonical host, never the alias)</code>
- <code>Real-binary end-to-end: wrote a throwaway test that spawned a genuine `ssh -G` (via a PATH shim pointing the real ssh at a controlled config) and drove `CanonicalRemoteURL`+`DetectProvider` — captured transcript, then removed the throwaway test</code>
- <code>`go test -race ./internal/scm/ ./internal/pipeline/steps/` (full affected packages, race detector)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
