### PR TITLE
docs: document AGENTS.md maintenance guidance

### DIFF
--- a/.no-mistakes/evidence/fm/agmd-nm-g7/agents-guidance-validation.md
+++ b/.no-mistakes/evidence/fm/agmd-nm-g7/agents-guidance-validation.md
@@ -1,0 +1,30 @@
+# AGENTS.md reader-facing validation
+
+Validated target commit `d8f6439da0f500aeb57e5fee1a62ac754eaed529` against base `493fc69d62b3d6b841080233230ce90c5fcf7b6e`.
+
+An agent opening the project's guidance now sees a durable source-of-truth reference for the Go version:
+
+```markdown
+**Environment**
+
+- Go version: see `go.mod`
+```
+
+The referenced authoritative file currently declares:
+
+```go
+go 1.25.0
+```
+
+At the end of the same guidance file, the canonical self-governance preamble is present verbatim:
+
+```markdown
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.
+```
+
+The commit changes no other file and has no whitespace errors.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Most implementation code lives under `internal/`.
 
 **Environment**
 
-- Go version: `1.25.0` from `go.mod`
+- Go version: see `go.mod`
 - Build tooling: standard Go toolchain plus `Makefile`
 - CLI/UI libraries: `cobra`, `bubbletea`, `bubbles`, `lipgloss`
 - Database: SQLite via `modernc.org/sqlite`
@@ -200,3 +200,10 @@ Safest local verification sequence after non-trivial changes:
 
 - Whenever you must bring in new dependencies, check latest documentation for knowledge, and discuss with the user.
 - Always use test driven development for bug fixes and feature development.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.


### PR DESCRIPTION
## Intent

Add the canonical self-governance preamble (## Maintaining this file) to the project's existing AGENTS.md as part of a fleet-wide firstmate rollout. Keep the diff minimal: append the canonical wording only (do not rewrite it), and apply only surgical low-risk trims where content is obviously stale or literally repeats the codebase (here: point Go version at go.mod instead of hardcoding 1.25.0). No broad rewrite of AGENTS.md. Ship the small docs change through the normal PR path.

## What Changed

- Add AGENTS.md maintenance guidance for concise, source-of-truth agent instructions.
- Point the documented Go version to `go.mod`.
- Add validation evidence for the guidance update.

## Risk Assessment

✅ Low: The single-file documentation change is minimal, accurately delegates Go-version authority to go.mod, and appends the intended maintenance guidance without affecting runtime behavior.

## Testing

Validated the documentation-only change from the target commit and recorded the reader-visible AGENTS.md result. The supplied race-test baseline passed; no UI surface exists, so the Markdown evidence artifact is the appropriate reviewer-facing proof.

- Evidence: [Reader-facing AGENTS.md validation](https://github.com/kunchenguid/no-mistakes/blob/5f7116c8671f7a0a9cd611b6c1d79d19ad1fa81d/.no-mistakes/evidence/fm/agmd-nm-g7/agents-guidance-validation.md)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`
- <code>`go test -race ./...` (baseline supplied as already passed)</code>
- `git diff --check 493fc69d62b3d6b841080233230ce90c5fcf7b6e d8f6439da0f500aeb57e5fee1a62ac754eaed529`
- <code>Target-commit acceptance check verifying the one-file diff, `go.mod` version reference, verbatim preamble, and evidence-only working-tree change</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
