### PR TITLE
fix(config): fail gate validation when no pipeline agent is runnable

### DIFF
--- a/.no-mistakes/evidence/fm/nm-agentless-skip-a8/agentless-gate-transcript.md
+++ b/.no-mistakes/evidence/fm/nm-agentless-skip-a8/agentless-gate-transcript.md
@@ -1,0 +1,83 @@
+# Agentless gate transcript
+
+This manual verification used the target `no-mistakes` binary against an isolated local Git repository and daemon.
+`PATH` contained only the system Git tools, with explicit nonexistent paths used where needed to guarantee that no runnable pipeline agent existed.
+
+## Doctor reports that the configured native runner cannot validate
+
+Configuration: `agent: claude`.
+
+```text
+$ no-mistakes doctor
+  System
+  ✓ git             git version 2.50.1 (Apple Git-155)
+  – gh              not found (optional, needed for PR/CI)
+  – az              not found (optional, needed for Azure DevOps PR/CI)
+  ✓ data directory  …/.nm
+  ✓ database        ok
+  ✓ daemon          running
+
+  Agents
+  – claude          not found
+  – codex           not found
+  – rovodev         not found
+  – opencode        not found
+  – pi              not found
+  – copilot         not found
+  – acpx            not found
+  ✗ gate validation  no runnable agent found for configured agent claude (looked for: claude); the gate cannot validate without an agent; install a supported native agent, choose an available agent in ~/.no-mistakes/config.yaml, or configure agent: acp:<target> with acpx installed
+
+  some checks failed
+```
+
+## Explicit native agent fails before any validation step
+
+```text
+$ no-mistakes axi run --intent 'Verify unavailable agent blocks all validation work'
+run: failed
+run:
+  id: "01KX4TA5HPSTR2E3HBZN4BTS8D"
+  branch: feature/agentless
+  status: failed
+  head: c753da8d
+  findings: none
+  steps[0]:
+outcome: failed
+error: "no runnable agent found for configured agent claude (looked for: claude); the gate cannot validate without an agent; install a supported native agent, choose an available agent in ~/.no-mistakes/config.yaml, or configure agent: acp:<target> with acpx installed"
+```
+
+## Automatic selection fails before any validation step
+
+Configuration: `agent: auto`, with every supported native runner overridden to a nonexistent `/no-runner/...` path.
+
+```text
+$ no-mistakes axi run --intent 'Verify automatic agent selection blocks all validation work when no runner is installed'
+run: failed
+run:
+  id: "01KX4TCSJHZ4P7RPANSD4401ET"
+  branch: feature/agentless
+  status: failed
+  head: dac55cf5
+  findings: none
+  steps[0]:
+outcome: failed
+error: "no runnable agent found for configured agent auto (looked for: /no-runner/claude, /no-runner/codex, /no-runner/opencode, /no-runner/acli, /no-runner/pi, /no-runner/copilot); the gate cannot validate without an agent; install a supported native agent, choose an available agent in ~/.no-mistakes/config.yaml, or configure agent: acp:<target> with acpx installed"
+```
+
+## ACP configuration fails before any validation step when the bridge is missing
+
+Configuration: `agent: acp:gemini` and `acpx_path: /no-runner/acpx`.
+
+```text
+$ no-mistakes axi run --intent 'Verify a missing ACP bridge blocks all validation work'
+run: failed
+run:
+  id: "01KX4TDE07D96QXPA83G03D46P"
+  branch: feature/agentless
+  status: failed
+  head: e1e1b916
+  findings: none
+  steps[0]:
+outcome: failed
+error: "no runnable agent found for configured agent acp:gemini (looked for: /no-runner/acpx); the gate cannot validate without an agent; install a supported native agent, choose an available agent in ~/.no-mistakes/config.yaml, or configure agent: acp:<target> with acpx installed"
+```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 Push to `no-mistakes` instead of `origin`, and it spins up a disposable worktree, runs an AI-driven validation pipeline, forwards the branch to the configured push target only after every check passes, and opens a clean PR automatically.
 
 - **Non-blocking** - the pipeline runs in an isolated worktree without disrupting your work.
-- **Agent-agnostic** - `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, or `acp:<target>` via `acpx`, with ordered fallbacks.
+- **Agent-agnostic** - `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, or `acp:<target>` via `acpx`, with ordered fallbacks; every gate requires a runnable configured pipeline agent.
 - **Agent-native** - `/no-mistakes` lets your coding agent do a task and gate it, or gate existing committed work: it runs the pipeline, has the pipeline apply safe fixes, and escalates the rest to you.
 - **Human stays in charge** - auto-fix or review findings, your call.
 - **Clean PRs by default** - push, open PR, watch CI, and auto-fix failures in one shot.

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -3,9 +3,13 @@ title: Choosing an Agent
 description: Supported AI agents, how to pick one, and how they integrate.
 ---
 
-`no-mistakes` is agent-agnostic by design. The gate should mean the same thing
-regardless of which agent you prefer. The default `agent: auto` setting picks
-the first supported native agent available on your system.
+`no-mistakes` is pipeline-agent-agnostic by design: the gate should mean the same thing regardless of which supported agent backend you prefer.
+It is not runner-free.
+Every validation run requires either a supported native agent binary or `acpx` configured for an ACP target.
+The default `agent: auto` setting picks the first supported native agent available on your system.
+
+The coding agent that calls `no-mistakes axi` drives approval gates, but it does not automatically become the pipeline agent that performs review, evidence testing, documentation, lint discovery, or fixes.
+Those jobs run in the daemon's disposable worktree through the configured pipeline agent.
 
 The agent is responsible for the parts of the gate that benefit from judgment:
 code review, evidence-oriented test validation, test or lint detection when you
@@ -42,6 +46,44 @@ By default that directory is temporary and local to the machine; repos can opt i
 | Pi | `pi` | Subprocess per invocation, JSONL events |
 | Copilot | `copilot` | Subprocess per invocation, JSONL events |
 | ACP target | `acpx` | Optional user-installed ACP bridge |
+
+## Runner requirements
+
+A complete gate never degrades silently when its configured pipeline agent is unavailable.
+The daemon resolves the effective agent before creating pipeline step records, and the run fails immediately with setup guidance if the configured binary cannot run.
+This refusal also applies when deterministic test or lint commands are configured because review and documentation always require agent judgment, while rebase, PR, and CI paths may need an agent to resolve conflicts, generate content, or fix failures.
+
+| Surface or capability | Works without a runnable pipeline agent? | Behavior |
+|---|---:|---|
+| Install, `init`, daemon lifecycle, `status`, `runs`, and `doctor` | Yes | Local setup and diagnostics remain available. `doctor` reports that gate validation is unavailable. |
+| Start or rerun a validation gate | No | The run fails before any pipeline step starts. |
+| Review | No | Requires agent judgment and structured findings. |
+| Test with `commands.test` | No, as part of a full gate | The command is deterministic, but the gate refuses before steps start rather than presenting command-only validation as a complete pass. |
+| Test without `commands.test`, or evidence validation with user intent | No | Requires the agent to discover checks and gather end-to-end evidence. |
+| Document | No | Requires the agent to discover and update documentation gaps. |
+| Lint with `commands.lint` | No, as part of a full gate | The command is deterministic, but the full gate still requires an agent. |
+| Lint without `commands.lint` and all fix rounds | No | Requires agent discovery or code changes. |
+| Push, PR, and CI as part of a gate | No | They run only after the required validation steps, and PR or CI paths may invoke the agent themselves. |
+
+### Antigravity and Gemini setups
+
+Running the gate from Antigravity or another Gemini-based coding environment does not make that calling model available to the daemon automatically.
+Choose one of these supported setups:
+
+1. Install any supported native agent CLI and leave `agent: auto`, or select it explicitly in `~/.no-mistakes/config.yaml`.
+2. Install `acpx`, confirm that the Gemini ACP target works locally, and configure `agent: acp:gemini`.
+
+```yaml
+# ~/.no-mistakes/config.yaml
+agent: acp:gemini
+
+# Optional when acpx is not on PATH.
+acpx_path: C:\path\to\acpx.exe
+```
+
+Run `no-mistakes doctor` afterward and look for a successful `gate validation` line.
+Doctor checks the global agent configuration; each run performs the authoritative check again after applying any trusted repository-level agent override.
+If the calling environment exposes neither a supported native CLI nor a working ACP target, it can still inspect and respond to existing AXI state, but it cannot start an honest validation gate by itself.
 
 ## Setting the agent
 

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -349,7 +349,7 @@ Structured output is handled by appending the requested JSON schema to the promp
 
 ## Checking agent availability
 
-Run `no-mistakes doctor` to see which native agent binaries are installed and available:
+Run `no-mistakes doctor` to inspect individual native and ACP runner binaries and to check the effective global agent configuration:
 
 ```
 $ no-mistakes doctor
@@ -360,13 +360,17 @@ $ no-mistakes doctor
   ✓ daemon running
   ✓ claude
   – codex (not found)
-  – acli (not found)
+  – rovodev (not found)
   – opencode (not found)
   – pi (not found)
   – copilot (not found)
+  – acpx (not found)
+  ✓ gate validation claude is runnable
 ```
 
 `✓` = available, `–` = not found (optional), `✗` = problem detected.
+The `gate validation` line is the decisive result: when the configured global runner is unavailable, doctor fails because a complete gate cannot validate without it.
 
-For `agent: acp:<target>`, make sure `acpx` is installed on `PATH` or set `acpx_path` in global config.
-`no-mistakes doctor` does not validate ACP targets.
+For `agent: acp:<target>`, doctor verifies that `acpx` is installed on `PATH` or resolves through `acpx_path` in global config.
+It does not invoke the target or test its credentials.
+Every new validation run resolves its effective agent again after applying any trusted repository-level override.

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -124,6 +124,10 @@ test:
 
 See [Global Config Reference](/no-mistakes/reference/global-config/) for the full field listing.
 
+Before a new validation gate starts, its effective agent configuration must resolve to a runnable native agent or ACP bridge.
+If `agent: auto`, an explicit agent, or every entry in a fallback list is unavailable, the gate fails before its first pipeline step, even when `commands.test` or `commands.lint` are configured.
+Run `no-mistakes doctor` to check the global runner; every run repeats the check after applying a trusted repository-level `agent` override.
+
 ## Environment variables
 
 Bitbucket Cloud PR creation and CI monitoring use environment variables instead of a provider CLI:

--- a/docs/src/content/docs/guides/setup-wizard.md
+++ b/docs/src/content/docs/guides/setup-wizard.md
@@ -111,5 +111,6 @@ The wizard requires:
   If you already have a branch and clean working tree, or you enter those values yourself in the interactive flow, the wizard can continue without agent suggestions.
 
 If any of those are missing, the wizard reports the problem and exits.
-`no-mistakes doctor` is the fastest way to check native agent availability.
-For ACP targets, verify `acpx_path` yourself.
+`no-mistakes doctor` is the fastest way to check whether the configured global runner can start a validation gate.
+For ACP targets, it verifies that `acpx_path` resolves but does not invoke the target or test its credentials.
+The wizard can proceed without an agent when it does not need a suggestion, but the pushed validation gate still fails before its first step unless the effective pipeline-agent configuration resolves to a runnable runner.

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -98,7 +98,10 @@ no-mistakes update
 
 ## Agent binary not detected
 
-Symptom: `doctor` shows `–` for your native agent, or the pipeline errors with "agent binary not found."
+Symptom: `doctor` reports that gate validation is unavailable, or a run fails before its first pipeline step because no runnable agent was found.
+
+This is a hard failure, not a degraded validation mode.
+`no-mistakes` will not silently skip review, test evidence, documentation, or agent-assisted lint and report the remaining work as a passed gate.
 
 ### Check PATH
 
@@ -116,6 +119,9 @@ For `agent: acp:<target>`, set `acpx_path` instead:
 ```yaml
 acpx_path: /Users/you/.local/bin/acpx
 ```
+
+For Antigravity or Gemini-based driving agents, install a supported native agent CLI separately or configure a working ACP target such as `agent: acp:gemini` with `acpx` installed.
+The calling agent is the AXI driver, not an implicit pipeline-agent backend.
 
 The daemon logs its effective `PATH` at startup in `~/.no-mistakes/logs/daemon.log` with the message `daemon environment ready`. If the log contains `login shell environment resolution failed` or `login shell environment resolution returned no entries`, the daemon used a degraded fallback `PATH` that may omit version-manager directories such as nvm, fnm, or volta, so tools like `pnpm` may be missing.
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -292,11 +292,13 @@ Checks:
 - Data directory (`~/.no-mistakes/`)
 - SQLite database
 - Daemon status
-- Native agent binaries: `claude`, `codex`, `acli`, `opencode`, `pi`, `copilot`
+- Agent runners: native binaries `claude`, `codex`, `acli`, `opencode`, `pi`, and `copilot`, plus the optional ACP bridge `acpx`
+- Effective global agent configuration, reported as `gate validation`; an unavailable configured runner is a failed check because the gate cannot validate without it
 
 Uses indicators: `✓` (available), `–` (not found, optional), `✗` (problem detected).
 
-`doctor` does not validate `acpx` or ACP targets. For `agent: acp:<target>`, verify `acpx_path` yourself.
+For `agent: acp:<target>`, `doctor` verifies that `acpx` resolves but does not invoke the target or test its credentials.
+Each validation run performs the authoritative agent resolution again after applying any trusted repository-level override.
 
 `doctor` checks `gh` and `az` availability. For GitLab PR and CI steps, install and authenticate `glab`. For Bitbucket Cloud PR and CI steps, set `NO_MISTAKES_BITBUCKET_EMAIL` and `NO_MISTAKES_BITBUCKET_API_TOKEN`. For Azure DevOps PR and CI steps, install the `azure-devops` extension and provide a PAT.
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -58,6 +58,7 @@ Skill installation is best-effort: if the skill write fails, init reports it and
 Agent eXperience Interface for non-interactive agents.
 Most agent workflows use the installed `/no-mistakes` skill, which drives this command surface underneath.
 It prints TOON to stdout, prints progress to stderr, and uses structured stdout errors with exit code `1` for operational failures and `2` for bad usage.
+The calling agent drives AXI approval gates but does not replace the configured pipeline agent that performs validation.
 
 ```sh
 no-mistakes axi
@@ -96,6 +97,8 @@ Err on the side of completeness: include the goal, important decisions and trade
 When starting a new run, `axi run` refuses the default branch and uncommitted working trees with actionable errors instead of auto-branching or auto-committing.
 Reattaching to an in-flight run does not require `--intent`.
 Reattaching to an in-flight run can proceed while the daemon is already running even if the global config file has become invalid, but starting a fresh run still requires valid global config.
+Starting a fresh run also requires a runnable effective pipeline agent.
+If the configured native agent or ACP bridge is unavailable, the run fails before any pipeline step starts instead of reporting command-only validation as a passed gate.
 With `--yes`, `axi run` treats both `action: auto-fix` and `action: ask-user` findings as standing consent for the pipeline to fix them by selecting every finding, then accepts the resulting fix review.
 Gates with no findings or only `action: no-op` findings are approved as-is, and each step is fixed at most once so unresolved findings do not loop forever.
 Without `--yes`, an agent driving `axi run` should stop when a gate contains `action: ask-user` findings and relay each finding's ID, file, and full description to the user before responding.

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -75,6 +75,9 @@ Default agent for all repos and setup-wizard suggestions. Can be overridden per-
 `auto` resolves to the first supported native agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, `pi`, then `copilot`.
 `acp:<target>` uses the user-installed `acpx` binary to run an ACP target, for example `acp:gemini`.
 ACP agents are opt-in and are not considered by `agent: auto`.
+The effective agent configuration must resolve to a runnable runner before a new validation gate starts.
+If an explicit agent is unavailable, `auto` finds no native agent, or no fallback-list entry is available, the gate fails before its first pipeline step rather than reporting a partial command-only validation as passed.
+`no-mistakes doctor` checks the global configuration, while every run repeats resolution after applying any trusted repository-level `agent` override.
 
 You can also set an ordered fallback list:
 
@@ -82,7 +85,10 @@ You can also set an ordered fallback list:
 agent: [codex, claude]
 ```
 
-The list is filtered to entries available to the daemon at run startup, and the first available entry becomes the primary agent. If a pipeline invocation fails because that agent process cannot start or exits with an error, no-mistakes retries that invocation with the next available fallback. Structured findings and schema/output validation problems do not trigger fallback.
+The list is filtered to entries available to the daemon at run startup, and the first available entry becomes the primary agent.
+If no entry is available, the gate fails before its first pipeline step.
+If a pipeline invocation fails because that agent process cannot start or exits with an error, no-mistakes retries that invocation with the next available fallback.
+Structured findings and schema/output validation problems do not trigger fallback.
 
 ### acpx_path
 

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -60,6 +60,8 @@ Override the default agent for this repo and its setup-wizard suggestions.
 `auto` resolves to the first supported native agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, `pi`, then `copilot`.
 `acp:<target>` uses the user-installed `acpx` binary configured in global config.
 ACP agents are opt-in and are not considered by `agent: auto`.
+The effective agent configuration must resolve to a runnable runner before a new validation gate starts.
+If the selected explicit agent or `auto` is unavailable, the gate fails before its first pipeline step rather than reporting partial validation as passed.
 
 You can also set an ordered fallback list:
 
@@ -67,7 +69,11 @@ You can also set an ordered fallback list:
 agent: [codex, claude]
 ```
 
-The list is filtered to entries available to the daemon at run startup, and the first available entry becomes the primary agent. If a pipeline invocation fails because that agent process cannot start or exits with an error, no-mistakes retries that invocation with the next available fallback. Structured findings and schema/output validation problems do not trigger fallback. This per-repo `agent` value, including every fallback entry, is still read from the trusted default-branch `.no-mistakes.yaml` unless `allow_repo_commands` is enabled there.
+The list is filtered to entries available to the daemon at run startup, and the first available entry becomes the primary agent.
+If no entry is available, the gate fails before its first pipeline step.
+If a pipeline invocation fails because that agent process cannot start or exits with an error, no-mistakes retries that invocation with the next available fallback.
+Structured findings and schema/output validation problems do not trigger fallback.
+This per-repo `agent` value, including every fallback entry, is still read from the trusted default-branch `.no-mistakes.yaml` unless `allow_repo_commands` is enabled there.
 
 ### allow_repo_commands
 

--- a/docs/src/content/docs/start-here/installation.md
+++ b/docs/src/content/docs/start-here/installation.md
@@ -54,8 +54,9 @@ make install
   - `NO_MISTAKES_BITBUCKET_EMAIL` and `NO_MISTAKES_BITBUCKET_API_TOKEN` (Bitbucket Cloud)
   - `az` CLI with the `azure-devops` extension (Azure DevOps)
 
-Run `no-mistakes doctor` to check native agents and provider tools.
-For ACP agents, verify `acpx` or `acpx_path` separately because `doctor` does not validate ACP targets.
+Run `no-mistakes doctor` to check native agents, provider tools, and whether the configured global runner can start a validation gate.
+For `agent: acp:<target>`, doctor verifies that `acpx` or `acpx_path` resolves, but does not invoke the target or test its credentials.
+Every validation gate requires a runnable pipeline agent and otherwise fails before its first pipeline step.
 
 See [Provider Integration](/no-mistakes/guides/provider-integration/) for PR and CI setup per host.
 

--- a/docs/src/content/docs/start-here/introduction.md
+++ b/docs/src/content/docs/start-here/introduction.md
@@ -70,7 +70,7 @@ When a branch passes the gate, it means:
 ## What you get
 
 - A fixed, opinionated pipeline: `intent → rebase → review → test → document → lint → push → pr → ci`. Order is not configurable; what each step runs is.
-- Choice of agent: `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, or `acp:<target>` via `acpx`, with per-repo override and ordered fallbacks.
+- Choice of agent: `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, or `acp:<target>` via `acpx`, with per-repo override and ordered fallbacks; every gate requires a runnable configured pipeline agent.
 - A TUI to watch, approve, fix, skip, or abort any step.
 - A `/no-mistakes` agent skill so a coding agent can do a task and gate it, or gate existing committed work, backed by a non-interactive `no-mistakes axi` interface.
 - A setup wizard when you run bare `no-mistakes` with no active run on the current branch - it walks you through creating a branch, committing, and pushing through the gate, then attaches if the daemon registers the new run.

--- a/docs/src/content/docs/start-here/quick-start.md
+++ b/docs/src/content/docs/start-here/quick-start.md
@@ -27,7 +27,9 @@ You need:
 - One supported agent binary (`claude`, `codex`, `acli` for Rovo Dev, `opencode`, `pi`, or `copilot`), or a separately installed `acpx` binary for `agent: acp:<target>`
 - For PRs and CI: `gh` (GitHub), `glab` (GitLab), Bitbucket Cloud credentials, or `az` with the `azure-devops` extension (Azure DevOps)
 
-For ACP agents, verify `acpx` or `acpx_path` separately because `no-mistakes doctor` does not validate ACP targets.
+`no-mistakes doctor` reports whether the configured global runner can start a validation gate.
+For `agent: acp:<target>`, it verifies that `acpx` or `acpx_path` resolves, but does not invoke the target or test its credentials.
+Every validation gate requires a runnable pipeline agent and otherwise fails before its first pipeline step.
 
 See [Provider Integration](/no-mistakes/guides/provider-integration/) for PR/CI setup.
 

--- a/internal/cli/axi.go
+++ b/internal/cli/axi.go
@@ -215,6 +215,7 @@ func runAxiHome(cmd *cobra.Command) error {
 		help = append(help, "Run `no-mistakes axi status` to inspect the active run")
 	}
 	help = append(help, preserveGateFixCommitsGuidance)
+	help = append(help, "The calling agent drives AXI gates but does not replace the configured pipeline agent; run `no-mistakes doctor` if no native agent or ACP runner is available")
 	help = append(help, "How to drive the pipeline: `no-mistakes axi run --help`, or the `/no-mistakes` skill (loaded when you invoke `/no-mistakes`)")
 	fields = append(fields, toon.Field{Key: "help", Value: help})
 

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -224,9 +224,15 @@ func triggerRun(ctx context.Context, env *axiEnv, branch, headSHA string, skipSt
 	if opt := formatIntentPushOption(intent); opt != "" {
 		pushOptions = append(pushOptions, opt)
 	}
+	priorRunIDs, err := runIDsForRepo(env.client, env.repo.ID)
+	if err != nil {
+		// An active run can still be found below. Without a baseline, however,
+		// a matching terminal run may predate this push, so do not attach to it.
+		priorRunIDs = nil
+	}
 	pushErr := git.PushWithOptions(ctx, ".", gate.RemoteName, "refs/heads/"+branch, "", false, pushOptions)
 
-	if run, _ := waitForActiveRunForHead(ctx, env.client, env.repo.ID, branch, headSHA, triggerWaitTimeout); run != nil {
+	if run, _ := waitForTriggeredRunForHead(ctx, env.client, env.repo.ID, branch, headSHA, priorRunIDs, triggerWaitTimeout); run != nil {
 		return run.ID, nil
 	}
 	if !shouldRerunAfterNoActiveRun(pushErr) {
@@ -242,7 +248,23 @@ func triggerRun(ctx context.Context, env *axiEnv, branch, headSHA string, skipSt
 	return rr.RunID, nil
 }
 
-func waitForActiveRunForHead(ctx context.Context, client *ipc.Client, repoID, branch, headSHA string, timeout time.Duration) (*ipc.RunInfo, error) {
+func runIDsForRepo(client *ipc.Client, repoID string) (map[string]struct{}, error) {
+	var result ipc.GetRunsResult
+	if err := client.Call(ipc.MethodGetRuns, &ipc.GetRunsParams{RepoID: repoID}, &result); err != nil {
+		return nil, err
+	}
+	ids := make(map[string]struct{}, len(result.Runs))
+	for _, run := range result.Runs {
+		ids[run.ID] = struct{}{}
+	}
+	return ids, nil
+}
+
+// waitForTriggeredRunForHead waits for the run created by this trigger. The
+// active-run lookup handles normal execution; the all-runs lookup catches a
+// run that fails before it can be observed as active. priorRunIDs prevents an
+// up-to-date push from attaching to a terminal run created by an earlier one.
+func waitForTriggeredRunForHead(ctx context.Context, client *ipc.Client, repoID, branch, headSHA string, priorRunIDs map[string]struct{}, timeout time.Duration) (*ipc.RunInfo, error) {
 	deadline := time.NewTimer(timeout)
 	defer deadline.Stop()
 
@@ -259,6 +281,22 @@ func waitForActiveRunForHead(ctx context.Context, client *ipc.Client, repoID, br
 		}
 		if run := activeRunInfoForHead(result.Run, headSHA); run != nil {
 			return run, nil
+		}
+		if priorRunIDs != nil {
+			var runs ipc.GetRunsResult
+			if err := client.Call(ipc.MethodGetRuns, &ipc.GetRunsParams{RepoID: repoID}, &runs); err != nil {
+				return nil, err
+			}
+			for i := range runs.Runs {
+				run := &runs.Runs[i]
+				if run.Branch != branch || run.HeadSHA != headSHA {
+					continue
+				}
+				if _, existed := priorRunIDs[run.ID]; !existed {
+					return run, nil
+				}
+				break
+			}
 		}
 		select {
 		case <-ctx.Done():

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -71,6 +71,9 @@ func newAxiRunCmd() *cobra.Command {
 			"--intent is required when starting a new run: pass what the user set out\n" +
 			"to accomplish (the goal behind the change, not a description of the diff)\n" +
 			"so no-mistakes uses it directly instead of inferring it from transcripts.\n\n" +
+			"The calling agent drives AXI approval gates but does not become the pipeline\n" +
+			"agent. The daemon requires a supported native agent binary or a configured\n" +
+			"ACP target through acpx, and fails before the first step when none can run.\n\n" +
 			preserveGateFixCommitsGuidance,
 		Args:          cobra.NoArgs,
 		SilenceErrors: true,

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -224,7 +224,7 @@ func triggerRun(ctx context.Context, env *axiEnv, branch, headSHA string, skipSt
 	if opt := formatIntentPushOption(intent); opt != "" {
 		pushOptions = append(pushOptions, opt)
 	}
-	priorRunIDs, err := runIDsForRepo(env.client, env.repo.ID)
+	priorRunIDs, err := runIDsForHead(env.client, env.repo.ID, branch, headSHA)
 	if err != nil {
 		// An active run can still be found below. Without a baseline, however,
 		// a matching terminal run may predate this push, so do not attach to it.
@@ -248,21 +248,34 @@ func triggerRun(ctx context.Context, env *axiEnv, branch, headSHA string, skipSt
 	return rr.RunID, nil
 }
 
-func runIDsForRepo(client *ipc.Client, repoID string) (map[string]struct{}, error) {
-	var result ipc.GetRunsResult
-	if err := client.Call(ipc.MethodGetRuns, &ipc.GetRunsParams{RepoID: repoID}, &result); err != nil {
+// runIDsForHead snapshots the run IDs already present for a repo's exact branch
+// and head SHA before a push, so waitForTriggeredRunForHead can tell a run this
+// push created apart from a terminal run an earlier push left behind. Scoping to
+// the head keeps this lookup, and the poll that reuses the same method, bounded
+// to the handful of runs for one head rather than the repo's whole history.
+func runIDsForHead(client *ipc.Client, repoID, branch, headSHA string) (map[string]struct{}, error) {
+	runs, err := runsForHead(client, repoID, branch, headSHA)
+	if err != nil {
 		return nil, err
 	}
-	ids := make(map[string]struct{}, len(result.Runs))
-	for _, run := range result.Runs {
+	ids := make(map[string]struct{}, len(runs))
+	for _, run := range runs {
 		ids[run.ID] = struct{}{}
 	}
 	return ids, nil
 }
 
+func runsForHead(client *ipc.Client, repoID, branch, headSHA string) ([]ipc.RunInfo, error) {
+	var result ipc.GetRunsResult
+	if err := client.Call(ipc.MethodGetRunsForHead, &ipc.GetRunsForHeadParams{RepoID: repoID, Branch: branch, HeadSHA: headSHA}, &result); err != nil {
+		return nil, err
+	}
+	return result.Runs, nil
+}
+
 // waitForTriggeredRunForHead waits for the run created by this trigger. The
-// active-run lookup handles normal execution; the all-runs lookup catches a
-// run that fails before it can be observed as active. priorRunIDs prevents an
+// active-run lookup handles normal execution; the head lookup catches a run
+// that fails before it can be observed as active. priorRunIDs prevents an
 // up-to-date push from attaching to a terminal run created by an earlier one.
 func waitForTriggeredRunForHead(ctx context.Context, client *ipc.Client, repoID, branch, headSHA string, priorRunIDs map[string]struct{}, timeout time.Duration) (*ipc.RunInfo, error) {
 	deadline := time.NewTimer(timeout)
@@ -283,15 +296,12 @@ func waitForTriggeredRunForHead(ctx context.Context, client *ipc.Client, repoID,
 			return run, nil
 		}
 		if priorRunIDs != nil {
-			var runs ipc.GetRunsResult
-			if err := client.Call(ipc.MethodGetRuns, &ipc.GetRunsParams{RepoID: repoID}, &runs); err != nil {
+			runs, err := runsForHead(client, repoID, branch, headSHA)
+			if err != nil {
 				return nil, err
 			}
-			for i := range runs.Runs {
-				run := &runs.Runs[i]
-				if run.Branch != branch || run.HeadSHA != headSHA {
-					continue
-				}
+			for i := range runs {
+				run := &runs[i]
 				if _, existed := priorRunIDs[run.ID]; !existed {
 					return run, nil
 				}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/kunchenguid/no-mistakes/internal/config"
 	"github.com/kunchenguid/no-mistakes/internal/daemon"
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
@@ -107,6 +108,7 @@ func newDoctorCmd() *cobra.Command {
 					{"opencode", "opencode"},
 					{"pi", "pi"},
 					{"copilot", "copilot"},
+					{"acpx", "acpx"},
 				}
 				fmt.Fprintln(w)
 				fmt.Fprintf(w, "  %s\n", sCyan.Render("Agents"))
@@ -116,6 +118,25 @@ func newDoctorCmd() *cobra.Command {
 						warn(label, "not found")
 					} else {
 						ok(label, path)
+					}
+				}
+
+				if p == nil {
+					fail("gate validation", "unavailable: data directory could not be resolved")
+					allOK = false
+				} else {
+					globalCfg, err := config.LoadGlobal(p.ConfigFile())
+					if err != nil {
+						fail("gate validation", fmt.Sprintf("unavailable: load config (%v)", err))
+						allOK = false
+					} else {
+						cfg := config.Merge(globalCfg, &config.RepoConfig{})
+						if err := cfg.ResolveAgent(cmd.Context(), exec.LookPath); err != nil {
+							fail("gate validation", err.Error())
+							allOK = false
+						} else {
+							ok("gate validation", fmt.Sprintf("%s is runnable", cfg.Agent))
+						}
 					}
 				}
 

--- a/internal/cli/doctor_agentless_test.go
+++ b/internal/cli/doctor_agentless_test.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/telemetry"
+)
+
+func TestDoctorReportsGateCannotValidateWithoutAgent(t *testing.T) {
+	restore := telemetry.SetDefaultForTesting(&telemetryRecorder{})
+	defer restore()
+
+	t.Setenv("NM_HOME", t.TempDir())
+	binDir := t.TempDir()
+	writeDoctorGitBinary(t, binDir)
+	t.Setenv("PATH", binDir)
+
+	out, err := executeCmd("doctor")
+	if err != nil {
+		t.Fatalf("doctor failed: %v\n%s", err, out)
+	}
+	for _, want := range []string{"gate validation", "no runnable agent", "gate cannot validate", "some checks failed"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("doctor output should contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestDoctorAcceptsConfiguredACPBridge(t *testing.T) {
+	restore := telemetry.SetDefaultForTesting(&telemetryRecorder{})
+	defer restore()
+
+	nmHome := t.TempDir()
+	t.Setenv("NM_HOME", nmHome)
+	if err := os.WriteFile(filepath.Join(nmHome, "config.yaml"), []byte("agent: acp:gemini\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	binDir := t.TempDir()
+	writeDoctorGitBinary(t, binDir)
+	writeDoctorStubBinary(t, binDir, "acpx")
+	t.Setenv("PATH", binDir)
+
+	out, err := executeCmd("doctor")
+	if err != nil {
+		t.Fatalf("doctor failed: %v\n%s", err, out)
+	}
+	for _, want := range []string{"acpx", "gate validation", "acp:gemini is runnable"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("doctor output should contain %q, got:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "some checks failed") {
+		t.Errorf("doctor should accept configured ACP bridge, got:\n%s", out)
+	}
+}
+
+func writeDoctorGitBinary(t *testing.T, dir string) {
+	t.Helper()
+	name := "git"
+	contents := "#!/bin/sh\necho 'git version test'\n"
+	if runtime.GOOS == "windows" {
+		name = "git.cmd"
+		contents = "@echo off\r\necho git version test\r\n"
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(contents), 0o755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+}
+
+func writeDoctorStubBinary(t *testing.T, dir, base string) {
+	t.Helper()
+	name := base
+	contents := "#!/bin/sh\nexit 0\n"
+	if runtime.GOOS == "windows" {
+		name += ".cmd"
+		contents = "@echo off\r\nexit /b 0\r\n"
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(contents), 0o755); err != nil {
+		t.Fatalf("write fake %s: %v", base, err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -405,20 +405,29 @@ var probeRovoDevSupport = func(ctx context.Context, bin string) (bool, error) {
 }
 
 // ResolveAgent resolves configured agent names to available agents. A single
-// explicit agent is preserved; auto is probed into the first available native
-// agent; an ordered list is filtered to available agents and kept as fallbacks.
+// explicit agent must be runnable; auto is probed into the first available
+// native agent; an ordered list is filtered to available agents and kept as fallbacks.
 // The lookPath function should behave like exec.LookPath.
 func (c *Config) ResolveAgent(ctx context.Context, lookPath func(string) (string, error)) error {
 	candidates := c.configuredAgents()
 	if len(candidates) <= 1 {
 		c.Agent = firstAgent(candidates)
 		c.Agents = copyAgents(candidates)
-		if c.Agent != types.AgentAuto {
+		if c.Agent == types.AgentAuto {
+			name, err := c.resolveAutoAgent(ctx, lookPath)
+			if err != nil {
+				return err
+			}
+			c.Agent = name
+			c.Agents = []types.AgentName{name}
 			return nil
 		}
-		name, err := c.resolveAutoAgent(ctx, lookPath)
+		name, ok, probe, err := c.resolveConfiguredAgent(ctx, c.Agent, lookPath)
 		if err != nil {
 			return err
+		}
+		if !ok {
+			return noRunnableAgentError([]types.AgentName{c.Agent}, []string{probe})
 		}
 		c.Agent = name
 		c.Agents = []types.AgentName{name}
@@ -473,7 +482,7 @@ func (c *Config) resolveAutoAgent(ctx context.Context, lookPath func(string) (st
 			return "", fmt.Errorf("resolve %s agent from %q: %w", name, bin, err)
 		}
 	}
-	return "", fmt.Errorf("no supported agent found in PATH (looked for: %s); install one or set 'agent' in ~/.no-mistakes/config.yaml", strings.Join(probed, ", "))
+	return "", noRunnableAgentError([]types.AgentName{types.AgentAuto}, probed)
 }
 
 func (c *Config) resolveAgentList(ctx context.Context, candidates []types.AgentName, lookPath func(string) (string, error)) ([]types.AgentName, error) {
@@ -495,15 +504,27 @@ func (c *Config) resolveAgentList(ctx context.Context, candidates []types.AgentN
 		resolved = append(resolved, name)
 	}
 	if len(resolved) == 0 {
-		return nil, fmt.Errorf("no configured agent found in PATH (looked for: %s)", strings.Join(probed, ", "))
+		return nil, noRunnableAgentError(candidates, probed)
 	}
 	return resolved, nil
+}
+
+func noRunnableAgentError(configured []types.AgentName, probed []string) error {
+	names := make([]string, 0, len(configured))
+	for _, name := range configured {
+		names = append(names, string(name))
+	}
+	return fmt.Errorf(
+		"no runnable agent found for configured agent %s (looked for: %s); the gate cannot validate without an agent; install a supported native agent, choose an available agent in ~/.no-mistakes/config.yaml, or configure agent: acp:<target> with acpx installed",
+		strings.Join(names, ", "),
+		strings.Join(probed, ", "),
+	)
 }
 
 func (c *Config) resolveConfiguredAgent(ctx context.Context, name types.AgentName, lookPath func(string) (string, error)) (types.AgentName, bool, string, error) {
 	if name == types.AgentAuto {
 		resolved, err := c.resolveAutoAgent(ctx, lookPath)
-		if err != nil && strings.HasPrefix(err.Error(), "no supported agent found in PATH") {
+		if err != nil && strings.HasPrefix(err.Error(), "no runnable agent found") {
 			return "", false, "auto", nil
 		}
 		return resolved, err == nil, "auto", err

--- a/internal/config/config_agent_test.go
+++ b/internal/config/config_agent_test.go
@@ -85,11 +85,12 @@ func TestParseLogLevel(t *testing.T) {
 }
 
 func TestResolveAgent_ExplicitAgent(t *testing.T) {
-	// When agent is explicitly set (not auto), ResolveAgent returns it as-is.
 	cfg := &Config{Agent: types.AgentCodex}
-	err := cfg.ResolveAgent(context.Background(), func(string) (string, error) {
-		t.Fatal("lookPath should not be called for explicit agent")
-		return "", nil
+	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
+		if bin != "codex" {
+			t.Fatalf("lookPath(%q), want codex", bin)
+		}
+		return "/usr/local/bin/codex", nil
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -99,17 +100,49 @@ func TestResolveAgent_ExplicitAgent(t *testing.T) {
 	}
 }
 
+func TestResolveAgent_ExplicitAgentMustBeRunnable(t *testing.T) {
+	cfg := &Config{Agent: types.AgentCodex}
+	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
+		return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
+	})
+	if err == nil {
+		t.Fatal("expected unavailable explicit agent to fail resolution")
+	}
+	for _, want := range []string{"no runnable agent", "codex", "gate cannot validate"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("ResolveAgent() error should contain %q, got: %v", want, err)
+		}
+	}
+}
+
 func TestResolveAgent_ExplicitACPAgent(t *testing.T) {
 	cfg := &Config{Agent: "acp:gemini"}
-	err := cfg.ResolveAgent(context.Background(), func(string) (string, error) {
-		t.Fatal("lookPath should not be called for explicit acp agent")
-		return "", nil
+	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
+		if bin != "acpx" {
+			t.Fatalf("lookPath(%q), want acpx", bin)
+		}
+		return "/usr/local/bin/acpx", nil
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if cfg.Agent != "acp:gemini" {
 		t.Errorf("agent = %q, want %q", cfg.Agent, "acp:gemini")
+	}
+}
+
+func TestResolveAgent_ExplicitACPAgentMustHaveACPX(t *testing.T) {
+	cfg := &Config{Agent: "acp:gemini"}
+	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
+		return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
+	})
+	if err == nil {
+		t.Fatal("expected ACP agent without acpx to fail resolution")
+	}
+	for _, want := range []string{"no runnable agent", "acp:gemini", "acpx", "gate cannot validate"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("ResolveAgent() error should contain %q, got: %v", want, err)
+		}
 	}
 }
 
@@ -361,8 +394,8 @@ func TestResolveAgent_AutoNoneAvailable(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when no agents found")
 	}
-	if !strings.Contains(err.Error(), "no supported agent found") {
-		t.Errorf("expected 'no supported agent found' in error, got: %v", err)
+	if !strings.Contains(err.Error(), "no runnable agent found") {
+		t.Errorf("expected 'no runnable agent found' in error, got: %v", err)
 	}
 	if !strings.Contains(err.Error(), "config") {
 		t.Errorf("expected config guidance in error, got: %v", err)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -432,6 +432,26 @@ func registerHandlers(srv *ipc.Server, mgr *RunManager, d *db.DB, shutdown func(
 		return &ipc.GetRunsResult{Runs: infos}, nil
 	})
 
+	srv.Handle(ipc.MethodGetRunsForHead, func(_ context.Context, params json.RawMessage) (interface{}, error) {
+		var p ipc.GetRunsForHeadParams
+		if err := json.Unmarshal(params, &p); err != nil {
+			return nil, fmt.Errorf("invalid params: %w", err)
+		}
+		runs, err := d.GetRunsByRepoHead(p.RepoID, p.Branch, p.HeadSHA)
+		if err != nil {
+			return nil, fmt.Errorf("get runs for head: %w", err)
+		}
+		infos := make([]ipc.RunInfo, 0, len(runs))
+		for _, r := range runs {
+			steps, err := d.GetStepsByRun(r.ID)
+			if err != nil {
+				return nil, fmt.Errorf("get steps for run %s: %w", r.ID, err)
+			}
+			infos = append(infos, *runToInfo(d, r, steps))
+		}
+		return &ipc.GetRunsResult{Runs: infos}, nil
+	})
+
 	srv.Handle(ipc.MethodGetActiveRun, func(_ context.Context, params json.RawMessage) (interface{}, error) {
 		var p ipc.GetActiveRunParams
 		if err := json.Unmarshal(params, &p); err != nil {

--- a/internal/db/run.go
+++ b/internal/db/run.go
@@ -99,6 +99,30 @@ func (d *DB) GetRunsByRepo(repoID string) ([]*Run, error) {
 	return runs, rows.Err()
 }
 
+// GetRunsByRepoHead returns the runs for a repo matching an exact branch and
+// head SHA, newest first. It lets a caller detect the run created by a specific
+// push without scanning (and rebuilding step data for) the repo's entire run
+// history, so the cost stays bounded to the handful of runs for one head.
+func (d *DB) GetRunsByRepoHead(repoID, branch, headSHA string) ([]*Run, error) {
+	rows, err := d.sql.Query(
+		`SELECT `+runColumns+` FROM runs WHERE repo_id = ? AND branch = ? AND head_sha = ? ORDER BY created_at DESC, id DESC`,
+		repoID, branch, headSHA,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get runs by repo head: %w", err)
+	}
+	defer rows.Close()
+	var runs []*Run
+	for rows.Next() {
+		r := &Run{}
+		if err := scanRun(rows, r); err != nil {
+			return nil, fmt.Errorf("scan run: %w", err)
+		}
+		runs = append(runs, r)
+	}
+	return runs, rows.Err()
+}
+
 // GetActiveRun returns the currently active run (pending or running) for a repo,
 // if any. When branch is non-empty, only a run on that exact branch is returned
 // - the setup wizard relies on this to decide whether a new run is needed for

--- a/internal/db/run_test.go
+++ b/internal/db/run_test.go
@@ -133,6 +133,36 @@ func TestRunsByRepo(t *testing.T) {
 	}
 }
 
+func TestRunsByRepoHead(t *testing.T) {
+	d := openTestDB(t)
+	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")
+
+	older, _ := d.InsertRun(repo.ID, "feature", "head-1", "base")
+	d.InsertRun(repo.ID, "feature", "head-2", "base") // same branch, other head
+	d.InsertRun(repo.ID, "other", "head-1", "base")   // same head, other branch
+	newer, _ := d.InsertRun(repo.ID, "feature", "head-1", "base")
+
+	runs, err := d.GetRunsByRepoHead(repo.ID, "feature", "head-1")
+	if err != nil {
+		t.Fatalf("get runs by repo head: %v", err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("got %d runs for feature/head-1, want 2: %+v", len(runs), runs)
+	}
+	// newest first
+	if runs[0].ID != newer.ID || runs[1].ID != older.ID {
+		t.Errorf("runs = [%s %s], want [%s %s] (newest first)", runs[0].ID, runs[1].ID, newer.ID, older.ID)
+	}
+
+	none, err := d.GetRunsByRepoHead(repo.ID, "feature", "missing")
+	if err != nil {
+		t.Fatalf("get runs by repo head (missing): %v", err)
+	}
+	if len(none) != 0 {
+		t.Errorf("got %d runs for unknown head, want 0", len(none))
+	}
+}
+
 func TestActiveRun(t *testing.T) {
 	d := openTestDB(t)
 	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")

--- a/internal/e2e/axi_journey_test.go
+++ b/internal/e2e/axi_journey_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
@@ -173,6 +174,55 @@ func TestAxiAgentJourney(t *testing.T) {
 	}
 	if autoRun := h.WaitForRun("feature/axi-yes", 60*time.Second); autoRun.Status != types.RunCompleted {
 		t.Fatalf("feature/axi-yes run status = %s, want completed", autoRun.Status)
+	}
+}
+
+func TestAxiRunReportsImmediateAgentlessFailureWithoutRerun(t *testing.T) {
+	h := NewHarness(t, SetupOpts{Agent: "claude", Scenario: cleanReviewScenario(t)})
+
+	h.CommitChange("init-axi-agentless", "seed.txt", "seed\n", "seed for axi init")
+	initWorktree := h.AddWorktree("init-axi-agentless")
+	if out, err := h.RunInDir(initWorktree, "init"); err != nil {
+		t.Fatalf("nm init: %v\n%s", err, out)
+	}
+
+	for _, name := range []string{"claude", "codex", "opencode"} {
+		if err := os.Remove(filepath.Join(h.BinDir, name)); err != nil {
+			t.Fatalf("remove fake %s agent: %v", name, err)
+		}
+	}
+
+	h.CommitChange("feature/axi-agentless", "feature.txt", "change\n", "add agentless change")
+	fw := h.AddWorktree("feature/axi-agentless")
+
+	out, err := h.RunInDir(fw, "axi", "run", "--intent", "validate agentless failure")
+	if err == nil {
+		t.Fatalf("axi run should return the failed outcome:\n%s", out)
+	}
+	for _, want := range []string{"outcome: failed", "no runnable agent", "gate cannot validate"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("axi run output missing %q in:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "no run started") {
+		t.Errorf("axi run should return the push-triggered failure instead of rerunning:\n%s", out)
+	}
+
+	runs := h.Runs()
+	var branchRuns []ipc.RunInfo
+	for _, run := range runs {
+		if run.Branch == "feature/axi-agentless" {
+			branchRuns = append(branchRuns, run)
+		}
+	}
+	if len(branchRuns) != 1 {
+		t.Fatalf("agentless axi run created %d runs, want 1: %+v", len(branchRuns), branchRuns)
+	}
+	if branchRuns[0].Status != types.RunFailed {
+		t.Errorf("agentless axi run status = %s, want failed", branchRuns[0].Status)
+	}
+	if len(branchRuns[0].Steps) != 0 {
+		t.Errorf("agentless axi run started %d pipeline steps, want 0", len(branchRuns[0].Steps))
 	}
 }
 

--- a/internal/e2e/journey_test.go
+++ b/internal/e2e/journey_test.go
@@ -53,6 +53,38 @@ func TestUserJourney(t *testing.T) {
 	}
 }
 
+func TestAgentlessRunFailsBeforePipelineStarts(t *testing.T) {
+	h := NewHarness(t, SetupOpts{Agent: "claude", Scenario: cleanReviewScenario(t)})
+	for _, name := range []string{"claude", "codex", "opencode"} {
+		if err := os.Remove(filepath.Join(h.BinDir, name)); err != nil {
+			t.Fatalf("remove fake %s agent: %v", name, err)
+		}
+	}
+
+	out, err := h.Run("init")
+	if err != nil {
+		t.Fatalf("nm init: %v\n%s", err, out)
+	}
+	h.CommitChange("agentless", "agentless.txt", "agentless validation\n", "test agentless validation")
+	h.PushToGate("agentless")
+	run := h.WaitForRun("agentless", 60*time.Second)
+
+	if run.Status != types.RunFailed {
+		t.Fatalf("agentless run status = %s, want failed", run.Status)
+	}
+	if run.Error == nil {
+		t.Fatal("agentless run should explain why validation cannot start")
+	}
+	for _, want := range []string{"no runnable agent", "gate cannot validate"} {
+		if !strings.Contains(*run.Error, want) {
+			t.Errorf("agentless run error should contain %q, got %q", want, *run.Error)
+		}
+	}
+	if len(run.Steps) != 0 {
+		t.Fatalf("agentless run started %d pipeline steps, want fail-fast before steps: %+v", len(run.Steps), run.Steps)
+	}
+}
+
 func runHappyPath(t *testing.T, agentName string) {
 	h := NewHarness(t, SetupOpts{Agent: agentName, Scenario: cleanReviewScenario(t)})
 

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -9,16 +9,17 @@ import (
 
 // JSON-RPC 2.0 method names.
 const (
-	MethodPushReceived = "push_received"
-	MethodGetRun       = "get_run"
-	MethodGetRuns      = "get_runs"
-	MethodGetActiveRun = "get_active_run"
-	MethodRerun        = "rerun"
-	MethodSubscribe    = "subscribe"
-	MethodRespond      = "respond"
-	MethodCancelRun    = "cancel_run"
-	MethodHealth       = "health"
-	MethodShutdown     = "shutdown"
+	MethodPushReceived   = "push_received"
+	MethodGetRun         = "get_run"
+	MethodGetRuns        = "get_runs"
+	MethodGetRunsForHead = "get_runs_for_head"
+	MethodGetActiveRun   = "get_active_run"
+	MethodRerun          = "rerun"
+	MethodSubscribe      = "subscribe"
+	MethodRespond        = "respond"
+	MethodCancelRun      = "cancel_run"
+	MethodHealth         = "health"
+	MethodShutdown       = "shutdown"
 )
 
 // JSON-RPC 2.0 error codes.
@@ -78,6 +79,16 @@ type GetRunParams struct {
 // GetRunsParams requests all runs for a repo.
 type GetRunsParams struct {
 	RepoID string `json:"repo_id"`
+}
+
+// GetRunsForHeadParams requests the runs for a repo on an exact branch and head
+// SHA. It backs a lightweight lookup that avoids scanning the repo's whole run
+// history, so a caller polling for the run created by a specific push does not
+// re-fetch every run (and its steps) on each poll.
+type GetRunsForHeadParams struct {
+	RepoID  string `json:"repo_id"`
+	Branch  string `json:"branch"`
+	HeadSHA string `json:"head_sha"`
 }
 
 // GetActiveRunParams requests the active run for a repo.

--- a/internal/ipc/protocol_test.go
+++ b/internal/ipc/protocol_test.go
@@ -394,6 +394,7 @@ func TestMethodConstants(t *testing.T) {
 		MethodPushReceived,
 		MethodGetRun,
 		MethodGetRuns,
+		MethodGetRunsForHead,
 		MethodGetActiveRun,
 		MethodRerun,
 		MethodSubscribe,
@@ -412,8 +413,8 @@ func TestMethodConstants(t *testing.T) {
 		}
 		seen[m] = true
 	}
-	if len(methods) != 10 {
-		t.Errorf("expected 10 methods, got %d", len(methods))
+	if len(methods) != 11 {
+		t.Errorf("expected 11 methods, got %d", len(methods))
 	}
 }
 

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -88,6 +88,10 @@ the same way once the work is committed on a feature branch.
   validates committed history, not your uncommitted working tree.
 - You must be on a **feature branch**, not the repository's default branch.
 - The repository must already be initialized with ` + "`no-mistakes init`" + `.
+- The daemon must have a runnable configured pipeline agent: a supported native
+  agent binary, or ` + "`acpx`" + ` for an ` + "`acp:<target>`" + `. You are the AXI driver, not
+  an implicit pipeline-agent backend. If none is available, the run fails
+  before its first step; ` + "`no-mistakes doctor`" + ` reports the configuration problem.
 
 If any of these is not met, ` + "`axi run`" + ` returns an ` + "`error:`" + ` with the exact command
 to fix it - read it and act on it (commit your work, or create a branch). If the

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -49,6 +49,10 @@ the same way once the work is committed on a feature branch.
   validates committed history, not your uncommitted working tree.
 - You must be on a **feature branch**, not the repository's default branch.
 - The repository must already be initialized with `no-mistakes init`.
+- The daemon must have a runnable configured pipeline agent: a supported native
+  agent binary, or `acpx` for an `acp:<target>`. You are the AXI driver, not
+  an implicit pipeline-agent backend. If none is available, the run fails
+  before its first step; `no-mistakes doctor` reports the configuration problem.
 
 If any of these is not met, `axi run` returns an `error:` with the exact command
 to fix it - read it and act on it (commit your work, or create a branch). If the


### PR DESCRIPTION
## Summary

Fixes the agentless-gate trust bug reported via the captain's Discord (reporter: ctlavender; setup: Windows, Antigravity 2.0 with Gemini as the driving agent, where `no-mistakes doctor` shows zero native agents found).

## Before / after

**Before:** On a machine with no runnable native agent binary on PATH, `no-mistakes` let the run start, silently **skipped** its core steps (review, test, document, lint), and reported partial completion as if the change had been validated. A gate that silently skips its gates is worse than no gate: it hands back false confidence. `no-mistakes doctor` compounded this by reporting success with zero runnable agents.

**After:** A runnable pipeline agent is now a **startup invariant**. When no native agent (or `acpx` for an `acp:` target) can run for the configured steps, the run **fails fast before its first step**, with a clear explanation and the exact ways to fix it: install a native agent, pick an available one, or configure an `acp:` target with `acpx`. It never presents partial completion as success. `doctor` now carries a "gate validation" check that plainly states whether the gate can validate with the current configuration.

## Calling-agent drivability (assessed; intentionally deferred)

The brief asked whether the *calling* agent (Gemini/Antigravity itself) could drive the review/fix steps, which is the natural reading of the "agent-agnostic" claim. This was assessed and deliberately **not built here**, because a correct AXI prompt/result handoff is a protocol-level design, not a small adapter:

- **Full calling-agent execution** needs worktree ownership, structured result submission, fix-round state, and disconnected-CI recovery. That is a larger follow-up, not a drop-in.
- **A generic `command` adapter** is smaller, but it still requires a runnable subprocess, so it does not remove the "needs a runnable agent" requirement anyway.
- **A degraded, command-only "success" mode** would re-open the exact silent-skip weakness this PR closes, so it is intentionally **not** offered.

This PR is scoped to the honest-refusal fix plus docs; the above is the follow-up design space, kept out of this change on purpose.

## Docs

Added a support matrix of what needs a native agent binary vs. what works without one, plus Antigravity/Gemini setup guidance, across the user guides and reference. An evidence transcript of the agentless-gate scenario is committed under `.no-mistakes/evidence/`.

---

## What Changed

- `Config.ResolveAgent` now requires an explicitly configured agent to actually be runnable instead of preserving the name unchecked, routing every unresolved case (explicit, `auto`, and list) through a single `noRunnableAgentError` that tells the user to install a native agent, pick an available one, or configure an `acp:` target with `acpx`; `doctor` grows a "gate validation" check that resolves the merged config's agent and reports whether it can run.
- Added a bounded triggered-run lookup so the `axi run` post-push poll no longer re-fetches the repo's entire run history each iteration: new `get_runs_for_head` IPC method backed by `db.GetRunsByRepoHead` (exact repo + branch + head SHA, newest first), consumed by `waitForTriggeredRunForHead`, which snapshots prior run IDs to avoid attaching an up-to-date push to a terminal run from an earlier one.
- Updated the skill body, live `axi` home/run help strings, and the docs guides/reference to state that the calling agent drives AXI approval gates but does not replace the configured pipeline agent, plus an evidence transcript for the agentless-gate scenario.

## Risk Assessment

✅ Low: The change is well-bounded and correct: it resolves the round-1 performance finding with a head-scoped query and a sound priorRunIDs guard, and the agent-runnability tightening is an intentional fail-fast backed by matching tests and in-sync docs/skill surfaces.

## Testing

Completed 1 recorded test check.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `internal/cli/axi_drive.go:286` - waitForTriggeredRunForHead calls MethodGetRuns on every 150ms poll iteration when the active-run lookup is nil. The daemon&#39;s GetRuns handler rebuilds full RunInfo (a GetStepsByRun query per run) for the repo&#39;s entire run history each time, so in the up-to-date-push case (no new run created) it re-fetches all runs+steps up to ~33 times within the 5s window, with cost that grows unbounded as the repo accumulates runs. Consider a lightweight targeted lookup (e.g. runs matching branch+head, or only new IDs) instead of re-fetching the whole history each poll.

🔧 Fix: Bound axi triggered-run poll to exact branch and head
1 info still open:
- ℹ️ `internal/cli/axi_drive.go:303` - In waitForTriggeredRunForHead the head-lookup uses `for i := range runs { ...; break }`, which unconditionally examines only runs[0] and always breaks. Because runsForHead returns newest-first, this is functionally equivalent to `if len(runs) &gt; 0 { run := &amp;runs[0]; if _, existed := priorRunIDs[run.ID]; !existed { return run, nil } }`. The loop-with-unconditional-break reads as an iteration but is not one; rewriting it as an explicit single-element check would make the newest-run-only intent obvious. Correct as written; purely a clarity improvement.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

