### PR TITLE
fix(agent): spill oversized copilot prompt to a temp file on Windows (CreateProcess arg-length limit)

### DIFF
--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -6,12 +6,55 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"sync"
 
 	"github.com/kunchenguid/no-mistakes/internal/shellenv"
 )
+
+// copilotMaxInlinePromptWindows caps how large a prompt is passed inline via the
+// -p argument on Windows. Windows CreateProcess rejects a command line longer
+// than ~32,767 chars with "The filename or extension is too long"; the Copilot
+// CLI has no stdin prompt mode (-p - is treated as the literal prompt "-"), so a
+// prompt that would overflow the limit is instead written to a temp file that
+// the agent reads with its own tools. The cap leaves ample headroom for the
+// other managed flags and shell quoting overhead. Non-Windows platforms have a
+// far larger ARG_MAX and keep passing the prompt inline unchanged.
+const copilotMaxInlinePromptWindows = 28000
+
+// copilotPromptArg returns the value to pass to the copilot -p flag for the
+// given prompt, whether the prompt was spilled to a temp file, and a cleanup
+// func to remove that file. On Windows a prompt that would overflow the
+// command-line limit is written to a temp file and replaced with a short
+// instruction telling the agent to read that file and follow it exactly, so the
+// full text is delivered off the command line. Everywhere else the prompt is
+// returned unchanged.
+func copilotPromptArg(prompt string) (arg string, spilled bool, cleanup func(), err error) {
+	if runtime.GOOS != "windows" || len(prompt) <= copilotMaxInlinePromptWindows {
+		return prompt, false, nil, nil
+	}
+	f, err := os.CreateTemp("", "no-mistakes-copilot-prompt-*.md")
+	if err != nil {
+		return "", false, nil, err
+	}
+	name := f.Name()
+	if _, err := f.WriteString(prompt); err != nil {
+		f.Close()
+		os.Remove(name)
+		return "", false, nil, err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(name)
+		return "", false, nil, err
+	}
+	instr := "Your complete task prompt, including the required final output contract, is stored in this file:\n" +
+		name + "\n\nRead that entire file now and follow it exactly, as if its full contents had been given to you directly here. " +
+		"Base your work and your final response solely on the instructions in that file."
+	return instr, true, func() { os.Remove(name) }, nil
+}
 
 // copilotAgent spawns the GitHub Copilot CLI for each invocation. Copilot
 // runs non-interactively with `copilot -p <prompt> --output-format json`,
@@ -34,7 +77,19 @@ func (a *copilotAgent) Close() error { return nil }
 
 func (a *copilotAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 	prompt := buildCopilotPrompt(opts.Prompt, opts.JSONSchema)
-	args := a.buildArgs(prompt)
+	promptArg, spilled, cleanup, err := copilotPromptArg(prompt)
+	if err != nil {
+		return nil, fmt.Errorf("copilot prompt: %w", err)
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+	args := a.buildArgs(promptArg)
+	if spilled {
+		// The spilled prompt lives in a temp file outside the working dir, so the
+		// agent needs unrestricted path access to read it.
+		args = append(args, "--allow-all-paths")
+	}
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD
 	cmd.Stdin = nil

--- a/internal/agent/copilot_test.go
+++ b/internal/agent/copilot_test.go
@@ -479,3 +479,66 @@ func TestCopilotAgent_RunRecoversJSONWhenFinalMessageIsProse(t *testing.T) {
 		t.Fatalf("output = %s, want recovered summary 'done'", string(result.Output))
 	}
 }
+
+func TestCopilotPromptArg_SmallPromptStaysInline(t *testing.T) {
+	arg, spilled, cleanup, err := copilotPromptArg("fix the bug")
+	if err != nil {
+		t.Fatalf("copilotPromptArg error = %v", err)
+	}
+	if spilled || cleanup != nil {
+		t.Fatalf("small prompt should not spill: spilled=%v cleanup!=nil=%v", spilled, cleanup != nil)
+	}
+	if arg != "fix the bug" {
+		t.Errorf("prompt should be unchanged, got %q", arg)
+	}
+}
+
+func TestCopilotPromptArg_LargePromptSpilledOnWindows(t *testing.T) {
+	big := strings.Repeat("x", copilotMaxInlinePromptWindows+1)
+	arg, spilled, cleanup, err := copilotPromptArg(big)
+	if err != nil {
+		t.Fatalf("copilotPromptArg error = %v", err)
+	}
+
+	if runtime.GOOS != "windows" {
+		if spilled || cleanup != nil {
+			t.Fatalf("non-windows must never spill the prompt")
+		}
+		if arg != big {
+			t.Errorf("non-windows large prompt should stay inline")
+		}
+		return
+	}
+
+	if !spilled || cleanup == nil {
+		t.Fatalf("windows large prompt should spill: spilled=%v cleanup!=nil=%v", spilled, cleanup != nil)
+	}
+	if len(arg) >= len(big) {
+		t.Errorf("delegating instruction (%d) should be far shorter than the prompt (%d)", len(arg), len(big))
+	}
+
+	var path string
+	for _, line := range strings.Split(arg, "\n") {
+		if line = strings.TrimSpace(line); strings.HasSuffix(line, ".md") {
+			path = line
+			break
+		}
+	}
+	if path == "" {
+		t.Fatalf("delegating instruction did not reference a spilled file: %q", arg)
+	}
+	defer os.Remove(path)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("spilled prompt file not readable: %v", err)
+	}
+	if string(data) != big {
+		t.Errorf("spilled file holds %d bytes, want %d", len(data), len(big))
+	}
+
+	cleanup()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("cleanup should remove the spilled file, stat err = %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

On Windows, `no-mistakes` cannot run the **Copilot** fix/review agent for any non-trivial change. The agent process fails to start with:

```
copilot start: fork/exec ...\copilot.exe: The filename or extension is too long.
```

That is Windows error 206 (`ERROR_FILENAME_EXCED_RANGE`), which `CreateProcess` returns when the **total command line exceeds ~32,767 characters**.

`internal/agent/copilot.go` passes the entire prompt to the Copilot CLI as a single `-p <prompt>` argument (`buildArgs`), and that prompt embeds the review/fix context (findings, instructions, diff). For a moderately sized change the prompt exceeds 32 KB and the process never launches. The Copilot CLI has **no stdin prompt mode** — `copilot -p -` is treated as the literal prompt `-` (verified), so the prompt cannot simply be piped in.

## Fix

On Windows only, when the prompt would exceed a conservative cap (`copilotMaxInlinePromptWindows = 28000`, well under the 32,767 limit with headroom for the other managed flags and shell quoting), spill the prompt to a temp file and pass the agent a short instruction to read that file, adding `--allow-all-paths` so it can. The full prompt text never lands on the command line.

Non-Windows platforms (with a far larger `ARG_MAX`) are unaffected — the prompt is passed inline exactly as before.

## Verification

- Reproduced at the CLI: `copilot -p "<~40 KB string>"` fails with "The filename or extension is too long"; a short spilled `-p` does not.
- Confirmed the Copilot CLI ignores stdin for the prompt (`copilot -p -` treats `-` as the literal prompt).
- New unit tests in `internal/agent/copilot_test.go` cover both paths: a small prompt stays inline; a large prompt on Windows is spilled to a readable temp file that holds the full text and is cleaned up.
- Verified **end-to-end on Windows**: a real `no-mistakes` review fix round that previously died at `copilot start` now launches the agent and applies the fixes.
- `gofmt`, `go vet ./internal/agent/`, and `go test ./internal/agent/` all pass.
