### PR TITLE
feat(agent): add omp (oh-my-pi) as a pipeline agent backend

### DIFF
--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -52,7 +52,7 @@ Everything else can usually wait.
 # Default agent for all repos and setup-wizard suggestions.
 # "auto" picks the first available native agent on PATH.
 # You can also use an ordered fallback list, for example: [codex, claude].
-agent: auto # auto | claude | codex | rovodev | opencode | pi | copilot | acp:<target>
+agent: auto # auto | claude | codex | rovodev | opencode | pi | copilot | omp | acp:<target>
 
 # Optional acpx path and target command overrides for agent: acp:<target>.
 acpx_path: acpx
@@ -179,7 +179,7 @@ See [Repo Config Reference](/no-mistakes/reference/repo-config/) for the full fi
 ## Precedence
 
 - Repo `agent` overrides global `agent`, including the full ordered fallback list when one is configured.
-- Global `agent: auto` resolves by checking `claude`, `codex`, `opencode`, `acli` for `rovodev`, `pi`, then `copilot` on `PATH`.
+- Global `agent: auto` resolves by checking `claude`, `codex`, `opencode`, `acli` for `rovodev`, `pi`, `copilot`, then `omp` on `PATH`.
 - ACP agents are opt-in with `agent: acp:<target>` and are not considered by `agent: auto`.
 - `agent_path_override`, `agent_args_override`, `acpx_path`, and `acp_registry_overrides` are global-only fields.
 - `ci_timeout`, `step_quiet_warning`, and `log_level` are global-only fields.

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -69,10 +69,10 @@ Default agent for all repos and setup-wizard suggestions. Can be overridden per-
 |         |                                                                                   |
 | ------- | --------------------------------------------------------------------------------- |
 | Type    | `string` or `string[]`                                                            |
-| Values  | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `acp:<target>` |
+| Values  | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `omp`, `acp:<target>` |
 | Default | `auto`                                                                            |
 
-`auto` resolves to the first supported native agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, `pi`, then `copilot`.
+`auto` resolves to the first supported native agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, `pi`, `copilot`, then `omp`.
 `acp:<target>` uses the user-installed `acpx` binary to run an ACP target, for example `acp:gemini`.
 ACP agents are opt-in and are not considered by `agent: auto`.
 The effective agent configuration must resolve to a runnable runner before a new validation gate starts.
@@ -138,7 +138,7 @@ Default native binary names when no override is set:
 | `opencode` | `opencode` |
 | `pi`       | `pi`       |
 | `copilot`  | `copilot`  |
-
+| `omp`      | `omp`      |
 ### agent_args_override
 
 Extra CLI flags to pass to each native agent.
@@ -147,7 +147,7 @@ Use this to set model selection, service tier, reasoning effort, permission mode
 |         |                                                           |
 | ------- | --------------------------------------------------------- |
 | Type    | `map[string][]string`                                     |
-| Keys    | `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot` |
+| Keys    | `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `omp` |
 | Default | Empty (no extra flags)                                    |
 
 User-supplied flags are inserted ahead of no-mistakes' managed flags, so your choices usually take precedence. A few flags are reserved because no-mistakes depends on them to communicate with the agent - setting any of these returns a config error on load:
@@ -160,6 +160,7 @@ User-supplied flags are inserted ahead of no-mistakes' managed flags, so your ch
 | `opencode` | `serve`, `--hostname`, `--port`, `--print-logs`                  |
 | `pi`       | `--mode`, `--no-session`                                         |
 | `copilot`  | `-p`, `--prompt`, `--output-format`, `--no-color`                |
+| `omp`      | `--mode`, `--no-session`                                         |
 
 For structured `codex` runs, no-mistakes also appends its own `--output-schema <tempfile>` after your overrides. Treat that flag as managed even though config validation does not currently reject it.
 
@@ -296,8 +297,7 @@ When enabled and no intent was supplied directly for the run, no-mistakes can re
 | `intent.threshold`        | `float`    | `0.2`   | Minimum raw match score for selecting a transcript session |
 | `intent.slack_days`       | `int`      | `3`     | Extra days to look back before the change window           |
 | `intent.disabled_readers` | `string[]` | Empty   | Transcript readers to disable                              |
-
-Valid `disabled_readers` values are `claude`, `codex`, `opencode`, `rovodev`, `pi`, and `copilot`.
+Valid `disabled_readers` values are `claude`, `codex`, `opencode`, `rovodev`, `pi`, `copilot`, and `omp`.
 
 The match score is the share of matching files mentioned in a transcript session; deleted files are ignored when the diff also contains non-deleted changes.
 All-deletion diffs still match against the deleted changed files.

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -54,10 +54,10 @@ Override the default agent for this repo and its setup-wizard suggestions.
 | | |
 |---|---|
 | Type | `string` or `string[]` |
-| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `acp:<target>` |
+| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `omp`, `acp:<target>` |
 | Default | Inherits from global config |
 
-`auto` resolves to the first supported native agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, `pi`, then `copilot`.
+`auto` resolves to the first supported native agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, `pi`, `copilot`, then `omp`.
 `acp:<target>` uses the user-installed `acpx` binary configured in global config.
 ACP agents are opt-in and are not considered by `agent: auto`.
 The effective agent configuration must resolve to a runnable runner before a new validation gate starts.
@@ -182,7 +182,7 @@ Fields not set here inherit from global config and then the built-in defaults.
 | `intent.slack_days` | `int` | Inherits from global (default `3`) |
 | `intent.disabled_readers` | `string[]` | Adds to globally disabled readers |
 
-Valid `disabled_readers` values are `claude`, `codex`, `opencode`, `rovodev`, `pi`, and `copilot`.
+Valid `disabled_readers` values are `claude`, `codex`, `opencode`, `rovodev`, `pi`, `copilot`, and `omp`.
 
 ### test.evidence
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -615,11 +615,13 @@ func NewWithOptions(name types.AgentName, bin string, extraArgs []string, opts O
 		return &piAgent{bin: bin, extraArgs: extraArgs}, nil
 	case types.AgentCopilot:
 		return &copilotAgent{bin: bin, extraArgs: extraArgs}, nil
+	case types.AgentOMP:
+		return &ompAgent{bin: bin, extraArgs: extraArgs}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, copilot, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
+		return nil, fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, copilot, omp, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
 	}
-}
 
+}
 func acpTarget(name types.AgentName) (string, bool) {
 	value := string(name)
 	if !strings.HasPrefix(value, "acp:") {

--- a/internal/agent/omp.go
+++ b/internal/agent/omp.go
@@ -1,0 +1,135 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+
+	"github.com/kunchenguid/no-mistakes/internal/shellenv"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// ompAgent spawns the omp CLI for each invocation. omp is a fork of Pi that
+// reads its prompt from stdin and emits JSONL on stdout when --mode json is
+// set. The lifecycle is identical to piAgent: one process per Run, no managed
+// server.
+type ompAgent struct {
+	bin       string
+	extraArgs []string
+}
+
+func (a *ompAgent) Name() string { return "omp" }
+
+func (a *ompAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
+	return runWithRetry(ctx, "omp", opts, claudeMaxRetries, classifyTransient, nil, func() (*Result, error) {
+		return a.runOnce(ctx, opts)
+	})
+}
+
+func (a *ompAgent) Close() error { return nil }
+
+func (a *ompAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
+	args := a.buildArgs()
+	cmd := exec.CommandContext(ctx, a.bin, args...)
+	cmd.Dir = opts.CWD
+	cmd.Env = gitSafeEnv(opts.CWD)
+	shellenv.ConfigureShellCommand(cmd)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("omp stdin pipe: %w", err)
+	}
+
+	started, err := startNativeAgentCommand(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("omp start: %w", err)
+	}
+	defer started.closePipes()
+	pid := started.pid()
+	emitAgentStarted(opts, "omp", pid)
+
+	prompt := buildOMPPrompt(opts.Prompt, opts.JSONSchema)
+	go func() {
+		defer stdin.Close()
+		_, _ = io.WriteString(stdin, prompt)
+	}()
+
+	var stderrBuf []byte
+	var stderrWG sync.WaitGroup
+	stderrWG.Add(1)
+	go func() {
+		defer stderrWG.Done()
+		stderrBuf, _ = io.ReadAll(started.stderr)
+	}()
+
+	pp := &piParser{onChunk: opts.OnChunk}
+	if err := pp.parse(ctx, started.stdout); err != nil {
+		err = started.waitAfterParseError(err)
+		stderrWG.Wait()
+		retErr := fmt.Errorf("omp parse events: %w", err)
+		emitAgentExited(opts, "omp", pid, retErr)
+		return nil, retErr
+	}
+
+	waitErr := started.wait()
+	stderrWG.Wait()
+	if waitErr != nil {
+		stderr := strings.TrimSpace(string(stderrBuf))
+		if stderr != "" {
+			retErr := fmt.Errorf("omp exited: %w: %s", waitErr, stderr)
+			emitAgentExited(opts, "omp", pid, retErr)
+			return nil, retErr
+		}
+		retErr := fmt.Errorf("omp exited: %w", waitErr)
+		emitAgentExited(opts, "omp", pid, retErr)
+		return nil, retErr
+	}
+
+	if pp.assistantError != "" {
+		retErr := fmt.Errorf("omp reported error: %s", pp.assistantError)
+		emitAgentExited(opts, "omp", pid, retErr)
+		return nil, retErr
+	}
+
+	text := pp.finalText()
+	res, err := finalizeTextResult("omp", text, opts.JSONSchema, pp.usage)
+	emitAgentExited(opts, "omp", pid, err)
+	return res, err
+}
+
+// buildArgs returns the omp argv for one invocation. User extras come first
+// (so user --provider/--model take effect), then the managed flags that
+// no-mistakes requires for JSONL parsing.
+func (a *ompAgent) buildArgs() []string {
+	args := make([]string, 0, len(a.extraArgs)+4)
+	args = append(args, a.extraArgs...)
+	args = append(args, "--mode", "json", "--no-session")
+	return args
+}
+
+// buildOMPPrompt appends a JSON-output contract to the user prompt when a
+// schema is provided. omp has no --output-schema flag, so we inline the
+// schema in the prompt the same way we do for Pi.
+func buildOMPPrompt(prompt string, schema json.RawMessage) string {
+	if len(schema) == 0 {
+		return prompt
+	}
+	pretty, err := json.MarshalIndent(json.RawMessage(schema), "", "  ")
+	if err != nil {
+		pretty = []byte(schema)
+	}
+	return prompt + "\n\n## no-mistakes final output contract\n\n" +
+		"When the iteration is complete, your final assistant response must be only valid JSON matching this JSON Schema. " +
+		"Do not wrap it in Markdown fences. Do not include prose before or after the JSON object.\n\n" +
+		string(pretty)
+}
+
+// compile-time check that ompAgent implements Agent.
+var _ Agent = (*ompAgent)(nil)
+
+// ensure types import is used.
+var _ types.AgentName = types.AgentOMP

--- a/internal/agent/omp_test.go
+++ b/internal/agent/omp_test.go
@@ -1,0 +1,212 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+func TestOMPAgent_BuildArgs(t *testing.T) {
+	oa := &ompAgent{bin: "omp"}
+	args := oa.buildArgs()
+
+	expected := []string{"--mode", "json", "--no-session"}
+
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("arg[%d]: expected %q, got %q", i, want, args[i])
+		}
+	}
+}
+
+func TestOMPAgent_BuildArgs_PrependsExtraArgs(t *testing.T) {
+	oa := &ompAgent{bin: "omp", extraArgs: []string{"--model", "sonnet"}}
+	args := oa.buildArgs()
+
+	expected := []string{"--model", "sonnet", "--mode", "json", "--no-session"}
+
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("arg[%d]: expected %q, got %q", i, want, args[i])
+		}
+	}
+}
+
+func TestOMPAgent_BuildPromptIncludesSchema(t *testing.T) {
+	schema := json.RawMessage(`{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"]}`)
+	prompt := buildOMPPrompt("do a thing", schema)
+	if !strings.Contains(prompt, "do a thing") {
+		t.Errorf("prompt missing user prompt: %s", prompt)
+	}
+	if !strings.Contains(prompt, "no-mistakes final output contract") {
+		t.Errorf("prompt missing contract header: %s", prompt)
+	}
+	if !strings.Contains(prompt, "summary") {
+		t.Errorf("prompt missing schema property: %s", prompt)
+	}
+}
+
+func TestOMPAgent_BuildPromptOmitsContractWhenSchemaEmpty(t *testing.T) {
+	prompt := buildOMPPrompt("do a thing", nil)
+	if prompt != "do a thing" {
+		t.Errorf("expected raw prompt when no schema, got: %q", prompt)
+	}
+}
+
+func writeFakeOMP(t *testing.T, dir, posixScript, windowsScript string) string {
+	t.Helper()
+
+	name := "omp"
+	script := posixScript
+	if runtime.GOOS == "windows" {
+		name = "omp.cmd"
+		script = windowsScript
+	}
+
+	bin := filepath.Join(dir, name)
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake omp: %v", err)
+	}
+	return bin
+}
+
+func TestOMPAgent_RunParsesAssistantContentAndUsage(t *testing.T) {
+	dir := t.TempDir()
+	bin := writeFakeOMP(t, dir, `#!/bin/sh
+cat > /dev/null
+printf '%s\n' '{"type":"message_update","message":{"role":"assistant","responseId":"r1"},"assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"{\"ok"}}'
+printf '%s\n' '{"type":"message_update","message":{"role":"assistant","responseId":"r1"},"assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"\":true}"}}'
+printf '%s\n' '{"type":"message_end","message":{"role":"assistant","responseId":"r1","content":[{"type":"text","text":"{\"ok\":true}"}],"usage":{"input":11,"output":7,"cacheRead":3,"cacheWrite":1}}}'
+printf '%s\n' '{"type":"agent_end","messages":[]}'
+`, strings.Join([]string{
+		"@echo off",
+		"more > nul",
+		"echo {\"type\":\"message_update\",\"message\":{\"role\":\"assistant\",\"responseId\":\"r1\"},\"assistantMessageEvent\":{\"type\":\"text_delta\",\"contentIndex\":0,\"delta\":\"{\\\"ok\"}}",
+		"echo {\"type\":\"message_update\",\"message\":{\"role\":\"assistant\",\"responseId\":\"r1\"},\"assistantMessageEvent\":{\"type\":\"text_delta\",\"contentIndex\":0,\"delta\":\"\\\":true}\"}}",
+		"echo {\"type\":\"message_end\",\"message\":{\"role\":\"assistant\",\"responseId\":\"r1\",\"content\":[{\"type\":\"text\",\"text\":\"{\\\"ok\\\":true}\"}],\"usage\":{\"input\":11,\"output\":7,\"cacheRead\":3,\"cacheWrite\":1}}}",
+		"echo {\"type\":\"agent_end\",\"messages\":[]}",
+	}, "\r\n"))
+
+	schema := json.RawMessage(`{"type":"object","properties":{"ok":{"type":"boolean"}},"required":["ok"]}`)
+	oa := &ompAgent{bin: bin}
+
+	var chunks []string
+	result, err := oa.Run(context.Background(), RunOpts{
+		Prompt:     "review",
+		CWD:        t.TempDir(),
+		JSONSchema: schema,
+		OnChunk:    func(s string) { chunks = append(chunks, s) },
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result.Output) != `{"ok":true}` {
+		t.Fatalf("unexpected output: %s", string(result.Output))
+	}
+	if result.Usage.InputTokens != 11 || result.Usage.OutputTokens != 7 ||
+		result.Usage.CacheReadTokens != 3 || result.Usage.CacheCreationTokens != 1 {
+		t.Fatalf("unexpected usage: %+v", result.Usage)
+	}
+	if len(chunks) == 0 {
+		t.Fatal("expected onChunk to receive streaming text")
+	}
+	wantChunks := []string{`{"ok`, `":true}`}
+	if len(chunks) != len(wantChunks) {
+		t.Fatalf("expected %d delta chunks, got %d: %v", len(wantChunks), len(chunks), chunks)
+	}
+	for i, want := range wantChunks {
+		if chunks[i] != want {
+			t.Errorf("chunk[%d] = %q, want %q", i, chunks[i], want)
+		}
+	}
+}
+
+func TestOMPAgent_RunFallsBackToAgentEndMessages(t *testing.T) {
+	dir := t.TempDir()
+	bin := writeFakeOMP(t, dir, `#!/bin/sh
+cat > /dev/null
+printf '%s\n' '{"type":"agent_end","messages":[{"role":"user","content":"prompt"},{"role":"assistant","content":"{\"ok\":true}"}]}'
+`, strings.Join([]string{
+		"@echo off",
+		"more > nul",
+		"echo {\"type\":\"agent_end\",\"messages\":[{\"role\":\"user\",\"content\":\"prompt\"},{\"role\":\"assistant\",\"content\":\"{\\\"ok\\\":true}\"}]}",
+	}, "\r\n"))
+
+	schema := json.RawMessage(`{"type":"object","properties":{"ok":{"type":"boolean"}},"required":["ok"]}`)
+	oa := &ompAgent{bin: bin}
+	result, err := oa.Run(context.Background(), RunOpts{
+		Prompt:     "review",
+		CWD:        t.TempDir(),
+		JSONSchema: schema,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result.Output) != `{"ok":true}` {
+		t.Fatalf("unexpected output: %s", string(result.Output))
+	}
+}
+
+func TestOMPAgent_RunReportsAssistantError(t *testing.T) {
+	dir := t.TempDir()
+	bin := writeFakeOMP(t, dir, `#!/bin/sh
+cat > /dev/null
+printf '%s\n' '{"type":"message_end","message":{"role":"assistant","responseId":"r1","stopReason":"error","errorMessage":"model overloaded"}}'
+printf '%s\n' '{"type":"agent_end","messages":[]}'
+`, strings.Join([]string{
+		"@echo off",
+		"more > nul",
+		"echo {\"type\":\"message_end\",\"message\":{\"role\":\"assistant\",\"responseId\":\"r1\",\"stopReason\":\"error\",\"errorMessage\":\"model overloaded\"}}",
+		"echo {\"type\":\"agent_end\",\"messages\":[]}",
+	}, "\r\n"))
+
+	oa := &ompAgent{bin: bin}
+	_, err := oa.Run(context.Background(), RunOpts{
+		Prompt: "review",
+		CWD:    t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("expected error for assistant error")
+	}
+	if !strings.Contains(err.Error(), "model overloaded") {
+		t.Errorf("expected error to contain 'model overloaded', got: %v", err)
+	}
+}
+
+func TestNew_OMP(t *testing.T) {
+	a, err := New(types.AgentOMP, "omp", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a.Name() != "omp" {
+		t.Errorf("expected name %q, got %q", "omp", a.Name())
+	}
+}
+
+func TestOMPAgent_BuildArgs_WithMultipleExtraArgs(t *testing.T) {
+	oa := &ompAgent{bin: "omp", extraArgs: []string{"--provider", "anthropic", "--thinking", "high"}}
+	args := oa.buildArgs()
+
+	expected := []string{"--provider", "anthropic", "--thinking", "high", "--mode", "json", "--no-session"}
+
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("arg[%d]: expected %q, got %q", i, want, args[i])
+		}
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -108,6 +108,7 @@ func newDoctorCmd() *cobra.Command {
 					{"opencode", "opencode"},
 					{"pi", "pi"},
 					{"copilot", "copilot"},
+					{"omp", "omp"},
 					{"acpx", "acpx"},
 				}
 				fmt.Fprintln(w)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -264,7 +264,7 @@ const defaultConfigYAML = `# no-mistakes global configuration
 
 # Agent to use for code generation. This may also be an ordered fallback list,
 # for example: agent: [codex, claude]
-# Options: auto, claude, codex, rovodev, opencode, pi, copilot, acp:<target>
+# Options: auto, claude, codex, rovodev, opencode, pi, copilot, omp, acp:<target>
 # "auto" detects the first available native agent on your system
 # Use acp:<target> to run an optional user-installed acpx target, for example acp:gemini
 agent: auto
@@ -353,9 +353,9 @@ var defaultBinary = map[types.AgentName]string{
 	types.AgentOpenCode: "opencode",
 	types.AgentPi:       "pi",
 	types.AgentCopilot:  "copilot",
+	types.AgentOMP:      "omp",
 }
 
-// agentProbeOrder is the priority order for auto-detecting agents.
 var agentProbeOrder = []types.AgentName{
 	types.AgentClaude,
 	types.AgentCodex,
@@ -363,6 +363,7 @@ var agentProbeOrder = []types.AgentName{
 	types.AgentRovoDev,
 	types.AgentPi,
 	types.AgentCopilot,
+	types.AgentOMP,
 }
 
 func isACPAgent(name types.AgentName) bool {
@@ -530,7 +531,7 @@ func (c *Config) resolveConfiguredAgent(ctx context.Context, name types.AgentNam
 		return resolved, err == nil, "auto", err
 	}
 	if _, ok := defaultBinary[name]; !ok && !isACPAgent(name) {
-		return "", false, string(name), fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, copilot, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
+		return "", false, string(name), fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, copilot, omp, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
 	}
 	bin := c.AgentPathFor(name)
 	resolvedBin, err := lookPath(bin)
@@ -591,7 +592,6 @@ func (c *Config) AgentArgsFor(name types.AgentName) []string {
 }
 
 // agentArgsOverrideAgents lists native agent names accepted as keys in
-// agent_args_override.
 var agentArgsOverrideAgents = map[string]bool{
 	string(types.AgentClaude):   true,
 	string(types.AgentCodex):    true,
@@ -599,6 +599,7 @@ var agentArgsOverrideAgents = map[string]bool{
 	string(types.AgentOpenCode): true,
 	string(types.AgentPi):       true,
 	string(types.AgentCopilot):  true,
+	string(types.AgentOMP):      true,
 }
 
 // reservedAgentArgs lists flags that no-mistakes manages internally and that
@@ -638,6 +639,10 @@ var reservedAgentArgs = map[string]map[string]bool{
 		"--output-format": true,
 		"--no-color":      true,
 	},
+	string(types.AgentOMP): {
+		"--mode":       true,
+		"--no-session": true,
+	},
 }
 
 // validateAgentArgsOverride ensures each agent key is a known agent name and
@@ -646,7 +651,7 @@ var reservedAgentArgs = map[string]map[string]bool{
 func validateAgentArgsOverride(override map[string][]string) error {
 	for name, args := range override {
 		if !agentArgsOverrideAgents[name] {
-			return fmt.Errorf("invalid agent name in agent_args_override: %q (valid: claude, codex, rovodev, opencode, pi, copilot)", name)
+			return fmt.Errorf("invalid agent name in agent_args_override: %q (valid: claude, codex, rovodev, opencode, pi, copilot, omp)", name)
 		}
 		reserved := reservedAgentArgs[name]
 		for i, arg := range args {

--- a/internal/config/config_agent_test.go
+++ b/internal/config/config_agent_test.go
@@ -313,7 +313,7 @@ func TestResolveAgent_AutoSkipsRovoDevWithoutSubcommand(t *testing.T) {
 
 	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
 		switch bin {
-		case "claude", "codex", "opencode", "pi", "copilot":
+		case "claude", "codex", "opencode", "pi", "copilot", "omp":
 			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
 		case "acli":
 			return "/usr/bin/acli", nil

--- a/internal/config/config_args_override_test.go
+++ b/internal/config/config_args_override_test.go
@@ -98,6 +98,14 @@ func TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected(t *testing.T) {
 		{"opencode", "--hostname"},
 		{"opencode", "--port"},
 		{"opencode", "--print-logs"},
+		{"pi", "--mode"},
+		{"pi", "--no-session"},
+		{"copilot", "-p"},
+		{"copilot", "--prompt"},
+		{"copilot", "--output-format"},
+		{"copilot", "--no-color"},
+		{"omp", "--mode"},
+		{"omp", "--no-session"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.agent+"_"+tt.arg, func(t *testing.T) {

--- a/internal/intent/reader_omp.go
+++ b/internal/intent/reader_omp.go
@@ -1,0 +1,294 @@
+package intent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// OMPReaderName is the agent name used in cache keys and DB rows.
+const OMPReaderName = "omp"
+
+const ompScannerMaxTokenSize = 256 * 1024 * 1024
+
+// ompReader reads omp coding-agent transcripts from ~/.omp/agent/sessions/.
+type ompReader struct{}
+
+// NewOMPReader returns a Reader for omp coding-agent transcripts.
+func NewOMPReader() Reader { return &ompReader{} }
+
+func (r *ompReader) Name() string { return OMPReaderName }
+
+func (r *ompReader) Discover(ctx context.Context, opts DiscoverOpts) ([]*Session, error) {
+	home, err := resolveHome(opts.HomeDir)
+	if err != nil {
+		return nil, err
+	}
+	root := filepath.Join(home, ".omp", "agent", "sessions")
+	repoDirs, err := os.ReadDir(root)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("omp sessions: %w", err)
+	}
+
+	matcher := newRepoMatcher(ctx, opts.OriginCWD)
+	var out []*Session
+	for _, repoDir := range repoDirs {
+		if ctx.Err() != nil {
+			return out, ctx.Err()
+		}
+		if !repoDir.IsDir() {
+			continue
+		}
+		dirPath := filepath.Join(root, repoDir.Name())
+		files, err := os.ReadDir(dirPath)
+		if err != nil {
+			continue
+		}
+		for _, f := range files {
+			if f.IsDir() || !strings.HasSuffix(f.Name(), ".jsonl") {
+				continue
+			}
+			info, err := f.Info()
+			if err != nil {
+				continue
+			}
+			modTime := info.ModTime()
+			if !opts.WindowStart.IsZero() && modTime.Before(opts.WindowStart) {
+				continue
+			}
+			if !opts.WindowEnd.IsZero() && modTime.After(opts.WindowEnd.Add(time.Hour)) {
+				continue
+			}
+			path := filepath.Join(dirPath, f.Name())
+			meta, err := ompPeekMetadata(path)
+			if err != nil || meta == nil {
+				continue
+			}
+			if !matcher.matches(ctx, meta.cwd) {
+				continue
+			}
+			sessionID := meta.id
+			if sessionID == "" {
+				sessionID = strings.TrimSuffix(f.Name(), ".jsonl")
+			}
+			session := &Session{
+				AgentName:     OMPReaderName,
+				SessionID:     sessionID,
+				CWD:           meta.cwd,
+				StartedAt:     meta.startedAt,
+				LastActivity:  modTime,
+				LastMsgKey:    modTime.UTC().Format(time.RFC3339Nano),
+				startedAtPath: path,
+			}
+			session.LastMsgKey = path + "|" + session.LastMsgKey
+			out = append(out, session)
+		}
+	}
+	return out, nil
+}
+
+func (r *ompReader) Load(_ context.Context, s *Session) error {
+	if s.startedAtPath == "" {
+		return fmt.Errorf("omp: session has no path")
+	}
+	f, err := os.Open(s.startedAtPath)
+	if err != nil {
+		return fmt.Errorf("omp open: %w", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), ompScannerMaxTokenSize)
+	seen := make(map[string]struct{})
+	seenLive := make(map[string]struct{})
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		msgs, aggregate, ok := parseOMPRecord(line)
+		if !ok {
+			continue
+		}
+		priorSeen := seen
+		if aggregate {
+			priorSeen = make(map[string]struct{}, len(seen))
+			for key := range seen {
+				priorSeen[key] = struct{}{}
+			}
+		}
+		for _, msg := range msgs {
+			if !aggregate && msg.identity != "" {
+				if _, ok := seenLive[msg.identity]; ok {
+					continue
+				}
+				seenLive[msg.identity] = struct{}{}
+			}
+			key := ompMessageKey(msg.Message)
+			if aggregate {
+				if _, ok := priorSeen[key]; ok {
+					continue
+				}
+			}
+			seen[key] = struct{}{}
+			s.Messages = append(s.Messages, msg.Message)
+		}
+	}
+	return scanner.Err()
+}
+
+// ompParsedMessage wraps a Message with a deduplication identity.
+type ompParsedMessage struct {
+	Message
+	identity string
+}
+
+// ompSessionMeta holds the metadata peeked from the first line of a session file.
+type ompSessionMeta struct {
+	id        string
+	cwd       string
+	startedAt time.Time
+}
+
+func ompPeekMetadata(path string) (*ompSessionMeta, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), ompScannerMaxTokenSize)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var raw map[string]any
+		if err := json.Unmarshal(line, &raw); err != nil {
+			continue
+		}
+		meta := &ompSessionMeta{}
+		if v, ok := raw["sessionId"].(string); ok {
+			meta.id = v
+		}
+		if v, ok := raw["cwd"].(string); ok {
+			meta.cwd = v
+		}
+		if v, ok := raw["directory"].(string); ok && meta.cwd == "" {
+			meta.cwd = v
+		}
+		if v, ok := raw["startedAt"].(string); ok {
+			if t, err := time.Parse(time.RFC3339, v); err == nil {
+				meta.startedAt = t
+			}
+		}
+		return meta, nil
+	}
+	return nil, scanner.Err()
+}
+
+// parseOMPRecord parses one JSONL line from an omp session file.
+// omp session format uses the same event types as Pi: message_update,
+// message_end, turn_end, agent_end.
+func parseOMPRecord(line []byte) ([]ompParsedMessage, bool, bool) {
+	var raw map[string]any
+	if err := json.Unmarshal(line, &raw); err != nil {
+		return nil, false, false
+	}
+
+	typ, _ := raw["type"].(string)
+	switch typ {
+	case "message_update", "message_end", "turn_end":
+		msg, ok := raw["message"].(map[string]any)
+		if !ok {
+			return nil, false, false
+		}
+		role, _ := msg["role"].(string)
+		if role != "assistant" && role != "user" {
+			return nil, false, false
+		}
+		text := ompExtractText(msg)
+		if text == "" {
+			return nil, false, false
+		}
+		id, _ := msg["responseId"].(string)
+		pm := ompParsedMessage{
+			Message: Message{
+				Role: Role(role),
+				Text: text,
+			},
+			identity: id,
+		}
+		return []ompParsedMessage{pm}, false, true
+
+	case "agent_end":
+		msgs, ok := raw["messages"].([]any)
+		if !ok {
+			return nil, false, false
+		}
+		var out []ompParsedMessage
+		for _, m := range msgs {
+			msg, ok := m.(map[string]any)
+			if !ok {
+				continue
+			}
+			role, _ := msg["role"].(string)
+			if role != "assistant" && role != "user" {
+				continue
+			}
+			text := ompExtractText(msg)
+			if text == "" {
+				continue
+			}
+			id, _ := msg["responseId"].(string)
+			out = append(out, ompParsedMessage{
+				Message: Message{
+					Role: Role(role),
+					Text: text,
+				},
+				identity: id,
+			})
+		}
+		return out, true, true
+	}
+	return nil, false, false
+}
+
+// ompExtractText extracts text content from an omp message object.
+func ompExtractText(msg map[string]any) string {
+	if text, ok := msg["content"].(string); ok && text != "" {
+		return text
+	}
+	blocks, ok := msg["content"].([]any)
+	if !ok {
+		return ""
+	}
+	var parts []string
+	for _, b := range blocks {
+		block, ok := b.(map[string]any)
+		if !ok {
+			continue
+		}
+		if block["type"] == "text" {
+			if text, ok := block["text"].(string); ok && text != "" {
+				parts = append(parts, text)
+			}
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func ompMessageKey(msg Message) string {
+	return string(msg.Role) + ":" + msg.Text
+}

--- a/internal/intent/readers.go
+++ b/internal/intent/readers.go
@@ -11,6 +11,7 @@ func AllReaders(disabled map[string]bool) []Reader {
 		NewRovoDevReader(),
 		NewPiReader(),
 		NewCopilotReader(),
+		NewOMPReader(),
 	}
 	if len(disabled) == 0 {
 		return all

--- a/internal/intent/readers_test.go
+++ b/internal/intent/readers_test.go
@@ -4,14 +4,14 @@ import "testing"
 
 func TestAllReaders_NoDisabled(t *testing.T) {
 	got := AllReaders(nil)
-	if len(got) != 6 {
+	if len(got) != 7 {
 		t.Errorf("expected 6 readers, got %d", len(got))
 	}
 }
 
 func TestAllReaders_Disabled(t *testing.T) {
 	got := AllReaders(map[string]bool{"codex": true, "rovodev": true})
-	if len(got) != 4 {
+	if len(got) != 5 {
 		t.Errorf("expected 4 readers, got %d", len(got))
 	}
 	for _, r := range got {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -140,4 +140,5 @@ const (
 	AgentOpenCode AgentName = "opencode"
 	AgentPi       AgentName = "pi"
 	AgentCopilot  AgentName = "copilot"
+	AgentOMP      AgentName = "omp"
 )


### PR DESCRIPTION
## Summary

Add [omp (oh-my-pi)](https://github.com/can1357/oh-my-pi) as a first-class pipeline agent backend alongside claude, codex, pi, copilot, rovodev, and opencode.

omp is a fork of Pi that supports `--mode json --no-session` for JSONL output, so the implementation reuses `piParser` for event parsing and follows the established `piAgent` pattern exactly.

## Changes

### Core agent (`feat(agent)`)
- `internal/types/types.go` — `AgentOMP AgentName = "omp"`
- `internal/agent/omp.go` — `ompAgent` implementation: stdin pipe, `startNativeAgentCommand` lifecycle, stderr capture, `claudeMaxRetries` retry, `buildOMPPrompt` for schema-in-prompt
- `internal/agent/agent.go` — wire `types.AgentOMP` → `ompAgent` in `NewWithOptions`
- `internal/config/config.go` — add to `defaultBinary`, `agentProbeOrder`, `agentArgsOverrideAgents`, `reservedAgentArgs` (`--mode`, `--no-session`), error messages

### Tests (`test(agent)`)
- `internal/agent/omp_test.go` — 8 tests: buildArgs, schema prompt, full JSONL run, agent_end fallback, error propagation, New() wiring
- `internal/config/config_agent_test.go` — add omp to lookPath
- `internal/config/config_args_override_test.go` — add reserved args for pi, copilot, omp

### Intent reader (`feat(intent)`)
- `internal/intent/reader_omp.go` — discover and load omp sessions from `~/.omp/agent/sessions/`
- `internal/intent/readers.go` — register `NewOMPReader()`
- `internal/intent/readers_test.go` — update reader counts
- `internal/cli/doctor.go` — add omp to agent check list

### Docs (`docs(agent)`)
- `docs/src/content/docs/guides/configuration.md`
- `docs/src/content/docs/reference/global-config.md`
- `docs/src/content/docs/reference/repo-config.md`

## Verification

```
go vet ./...
go test -race ./internal/agent/ ./internal/config/ ./internal/intent/
go build ./...
```

All pass cleanly.