### PR TITLE
feat(agent): add gated Windows spawn diagnostics

### DIFF
--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -179,6 +179,7 @@ The [CLI reference](/no-mistakes/reference/cli/) documents each `axi` command an
 
 When the daemon is running through a managed service, its `PATH` comes from your login shell environment on macOS and Linux plus common user, Homebrew, and system binary directories; on Windows it reuses the current process environment.
 If native agent discovery does not resolve the binary you expect, check `~/.no-mistakes/logs/daemon.log` and set an explicit override; [Environment the daemon sees](/no-mistakes/reference/environment/#environment-the-daemon-sees) owns the full resolution story.
+On Windows or Cygwin, where a `.cmd` shim can be launched in place of the native `.exe`, enable [`NM_SPAWN_DIAG`](/no-mistakes/reference/environment/#nm_spawn_diag) to log the resolved binary path and the tracked process image name.
 
 Three global config fields tune resolution and invocation, and the [Global Config Reference](/no-mistakes/reference/global-config/) owns each one:
 

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -290,5 +290,6 @@ Wedged state often means a run is stuck `pending` or `running`, so `daemon stop`
 ## Still stuck
 
 - Check `~/.no-mistakes/logs/daemon.log` at `log_level: debug`
+- Debugging a native agent that fails to spawn (especially on Windows/Cygwin)? Enable [`NM_SPAWN_DIAG`](/no-mistakes/reference/environment/#nm_spawn_diag), or drop a `<NM_HOME>/spawn-diag` file to toggle it against the running daemon, then reproduce and read the `spawn-diag[claude]` lines in the step and daemon logs.
 - File an issue: <https://github.com/kunchenguid/no-mistakes/issues>
 - Discord: <https://discord.gg/Wsy2NpnZDu>

--- a/docs/src/content/docs/reference/environment.md
+++ b/docs/src/content/docs/reference/environment.md
@@ -191,7 +191,7 @@ Enable verbose agent-spawn diagnostics for troubleshooting native agent launches
 
 |         |                                                       |
 | ------- | ----------------------------------------------------- |
-| Type    | any non-empty value to enable                         |
+| Type    | set to `1` to enable; any other value or unset is off |
 | Default | unset (diagnostics off, zero overhead)                |
 
 When enabled, the claude native agent invocation emits `spawn-diag[claude]` trace lines to the step output and the daemon log covering the resolved binary and redacted argv, the tracked PID and its OS image name (which exposes a `.cmd` wrapper being tracked instead of the native process), stdout volume and a leading snippet, raw stderr, and the exact exit path. Prompt and JSON-schema values are replaced with their lengths, so a diagnostic run never writes prompt content or the schema into the logs.

--- a/docs/src/content/docs/reference/environment.md
+++ b/docs/src/content/docs/reference/environment.md
@@ -185,6 +185,19 @@ Disable telemetry collection.
 
 When set to a disabling value, telemetry stays off even if a runtime or embedded website ID is available.
 
+## `NM_SPAWN_DIAG`
+
+Enable verbose agent-spawn diagnostics for troubleshooting native agent launches, primarily failing agent invocations on Windows/Cygwin ([issue #427](https://github.com/kunchenguid/no-mistakes/issues/427)).
+
+|         |                                                       |
+| ------- | ----------------------------------------------------- |
+| Type    | any non-empty value to enable                         |
+| Default | unset (diagnostics off, zero overhead)                |
+
+When enabled, the claude native agent invocation emits `spawn-diag[claude]` trace lines to the step output and the daemon log covering the resolved binary and redacted argv, the tracked PID and its OS image name (which exposes a `.cmd` wrapper being tracked instead of the native process), stdout volume and a leading snippet, raw stderr, and the exact exit path. Prompt and JSON-schema values are replaced with their lengths, so a diagnostic run never writes prompt content or the schema into the logs.
+
+Because the managed daemon runs with a curated environment that a shell-set variable does not reach, you can also toggle diagnostics with a sentinel file: create `<NM_HOME>/spawn-diag` (stat-checked once per spawn), reproduce the failure, then remove it. The env variable and the sentinel file are independent; either one turns diagnostics on.
+
 ## Environment the daemon sees
 
 When the daemon runs through a managed service (launchd, systemd user service, Task Scheduler), the macOS and Linux service definitions include a default `PATH` with common user and system binary directories. They also bake in any proxy variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, `ALL_PROXY`) that were set when you installed or refreshed the service, so the daemon and the agents it spawns can reach the network through your proxy even when the login-shell probe is unavailable. Once baked in, the values are preserved across later service refreshes and restarts even when the proxy variables are not exported in that shell, so a routine `daemon restart` or a binary upgrade will not strip them; export the variables again only when you need to change or remove them. Both the upper- and lower-case spellings are forwarded exactly as you set them, because tooling is inconsistent about which it reads (curl, for example, honors only the lower-case `http_proxy` for plain-HTTP requests). Because a proxy URL can embed credentials (for example `http://user:pass@host`), the generated service file is restricted to owner-only `0600` permissions whenever proxy values are forwarded into it. When no proxy variables are set, the generated definition is unchanged and keeps the conventional `0644` mode. Windows Task Scheduler inherits your logon environment and needs no forwarding. At daemon startup, the daemon resolves environment from your login shell on macOS and Linux, preserves your shell `PATH` order, and appends any missing well-known directories such as `~/.local/bin`, `~/go/bin`, `~/.cargo/bin`, `~/bin`, `/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin`, and `/bin`. If login-shell resolution fails or returns no entries, the daemon logs a warning and uses an augmented process-environment fallback that may omit version-manager directories such as nvm, fnm, or volta. On Windows it reuses the current process environment.

--- a/docs/src/content/docs/reference/environment.md
+++ b/docs/src/content/docs/reference/environment.md
@@ -192,7 +192,7 @@ Enable verbose agent-spawn diagnostics for troubleshooting native agent launches
 |         |                                                       |
 | ------- | ----------------------------------------------------- |
 | Type    | set to `1` to enable; any other value or unset is off |
-| Default | unset (diagnostics off, zero overhead)                |
+| Default | unset (off, aside from a per-spawn sentinel stat)     |
 
 When enabled, the claude native agent invocation emits `spawn-diag[claude]` trace lines to the step output and the daemon log covering the resolved binary and redacted argv, the tracked PID and its OS image name (which exposes a `.cmd` wrapper being tracked instead of the native process), stdout volume and a leading snippet, raw stderr, and the exact exit path. Prompt and JSON-schema values are replaced with their lengths, so a diagnostic run never writes prompt content or the schema into the logs.
 

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -57,14 +57,18 @@ func (a *claudeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error
 	cmd.Env = gitSafeEnv(opts.CWD)
 	shellenv.ConfigureShellCommand(cmd)
 
+	diag := newSpawnDiag("claude", a.bin, args, opts)
+
 	var stderrBuf []byte
 	var stderrWG sync.WaitGroup
 	started, err := startNativeAgentCommand(cmd)
 	if err != nil {
+		diag.logStartError(err)
 		return nil, fmt.Errorf("claude start: %w", err)
 	}
 	defer started.closePipes()
 	pid := started.pid()
+	diag.logStarted(pid)
 	emitAgentStarted(opts, "claude", pid)
 
 	stderrWG.Add(1)
@@ -75,9 +79,10 @@ func (a *claudeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error
 
 	var usage TokenUsage
 	var result *claudeResult
-	if err := parseClaudeEvents(ctx, started.stdout, opts.OnChunk, &usage, &result); err != nil {
+	if err := parseClaudeEvents(ctx, diag.wrapStdout(started.stdout), opts.OnChunk, &usage, &result); err != nil {
 		err = started.waitAfterParseError(err)
 		stderrWG.Wait()
+		diag.logExit(pid, "parse-error", err, result != nil, stderrBuf)
 		retErr := fmt.Errorf("claude parse events: %w", err)
 		emitAgentExited(opts, "claude", pid, retErr)
 		return nil, retErr
@@ -86,16 +91,20 @@ func (a *claudeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error
 	waitErr := started.wait()
 	stderrWG.Wait()
 	if waitErr != nil {
+		diag.logExit(pid, "wait-error", waitErr, result != nil, stderrBuf)
 		retErr := fmt.Errorf("claude exited: %w: %s", waitErr, string(stderrBuf))
 		emitAgentExited(opts, "claude", pid, retErr)
 		return nil, retErr
 	}
 
 	if result == nil {
+		diag.logExit(pid, "no-result-event", nil, false, stderrBuf)
 		retErr := fmt.Errorf("claude returned no result event")
 		emitAgentExited(opts, "claude", pid, retErr)
 		return nil, retErr
 	}
+
+	diag.logExit(pid, "ok", nil, true, stderrBuf)
 
 	res, err := finalizeClaudeResult(result, opts.JSONSchema, usage)
 	if res != nil {

--- a/internal/agent/spawn_diag.go
+++ b/internal/agent/spawn_diag.go
@@ -16,8 +16,9 @@ import (
 // agent invocation on Windows/Cygwin (issue #427): the resolved binary, the
 // tracked PID and its OS image name (to expose a .cmd wrapper being tracked
 // instead of the native process), stdout volume, raw stderr, and the exact exit
-// path. Unset (and no sentinel present) and spawnDiag is a no-op with zero
-// overhead.
+// path. Only the exact value 1 enables it; any other value (including 0 or
+// false) and unset leave it disabled. With diagnostics off and no sentinel
+// present, spawnDiag is a no-op with zero overhead.
 const spawnDiagEnv = "NM_SPAWN_DIAG"
 
 // spawnDiagSentinel is a file under NM_HOME that also enables diagnostics. The
@@ -31,7 +32,7 @@ const spawnDiagSentinel = "spawn-diag"
 // via either the environment variable or the sentinel file. The sentinel is
 // stat-checked once per spawn, which is negligible against launching a process.
 func spawnDiagEnabled() bool {
-	if os.Getenv(spawnDiagEnv) != "" {
+	if os.Getenv(spawnDiagEnv) == "1" {
 		return true
 	}
 	if root := diagHome(); root != "" {

--- a/internal/agent/spawn_diag.go
+++ b/internal/agent/spawn_diag.go
@@ -1,0 +1,183 @@
+package agent
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// spawnDiagEnv gates verbose agent-spawn diagnostics via an environment
+// variable. Set NM_SPAWN_DIAG=1 in the daemon's environment to trace a failing
+// agent invocation on Windows/Cygwin (issue #427): the resolved binary, the
+// tracked PID and its OS image name (to expose a .cmd wrapper being tracked
+// instead of the native process), stdout volume, raw stderr, and the exact exit
+// path. Unset (and no sentinel present) and spawnDiag is a no-op with zero
+// overhead.
+const spawnDiagEnv = "NM_SPAWN_DIAG"
+
+// spawnDiagSentinel is a file under NM_HOME that also enables diagnostics. The
+// managed daemon runs with a curated environment, so an env var set in a shell
+// does not reach it; dropping this file lets you toggle diagnostics against the
+// running service without changing its env or restarting it. Create
+// <NM_HOME>/spawn-diag, reproduce the failure, then remove it.
+const spawnDiagSentinel = "spawn-diag"
+
+// spawnDiagEnabled reports whether to emit diagnostics for this invocation,
+// via either the environment variable or the sentinel file. The sentinel is
+// stat-checked once per spawn, which is negligible against launching a process.
+func spawnDiagEnabled() bool {
+	if os.Getenv(spawnDiagEnv) != "" {
+		return true
+	}
+	if root := diagHome(); root != "" {
+		if _, err := os.Stat(filepath.Join(root, spawnDiagSentinel)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// diagHome mirrors paths.New: NM_HOME, or ~/.no-mistakes. Kept inline so the
+// diagnostic stays a leaf with no dependency on the paths package.
+func diagHome() string {
+	if env := os.Getenv("NM_HOME"); env != "" {
+		return env
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".no-mistakes")
+}
+
+// spawnDiag records diagnostics for one native agent invocation. The zero value
+// is a valid disabled instance; every method is safe to call on it.
+type spawnDiag struct {
+	enabled bool
+	agent   string
+	onChunk func(string)
+	start   time.Time
+	capture *diagCapture
+}
+
+// newSpawnDiag returns an enabled diagnostic only when NM_SPAWN_DIAG is set,
+// and logs the resolved binary and (redacted) argv up front. bin is the
+// configured binary name; args is the full argv passed to it.
+func newSpawnDiag(agentName, bin string, args []string, opts RunOpts) *spawnDiag {
+	if !spawnDiagEnabled() {
+		return &spawnDiag{}
+	}
+	d := &spawnDiag{
+		enabled: true,
+		agent:   agentName,
+		onChunk: opts.OnChunk,
+		start:   time.Now(),
+		capture: &diagCapture{limit: 8192},
+	}
+	resolved, lookErr := exec.LookPath(bin)
+	d.emit(fmt.Sprintf("bin=%q resolved=%q lookErr=%s argv=[%s]", bin, resolved, errStr(lookErr), redactArgv(args)))
+	return d
+}
+
+func (d *spawnDiag) logStarted(pid int) {
+	if !d.enabled {
+		return
+	}
+	d.emit(fmt.Sprintf("started pid=%d image=%q", pid, processImageName(pid)))
+}
+
+func (d *spawnDiag) logStartError(err error) {
+	if !d.enabled {
+		return
+	}
+	d.emit("start-error: " + errStr(err))
+}
+
+// wrapStdout tees the agent's stdout through a capped capture so the exit log
+// can report how much was produced and show a leading snippet. When disabled it
+// returns the reader unchanged.
+func (d *spawnDiag) wrapStdout(r io.Reader) io.Reader {
+	if !d.enabled {
+		return r
+	}
+	return io.TeeReader(r, d.capture)
+}
+
+// logExit records how the invocation ended: which branch (ok, no-result-event,
+// parse-error, wait-error), the error, whether a result was parsed, stdout
+// volume and head, and full stderr.
+func (d *spawnDiag) logExit(pid int, path string, pathErr error, gotResult bool, stderr []byte) {
+	if !d.enabled {
+		return
+	}
+	d.emit(fmt.Sprintf("exit path=%s pid=%d image=%q dur=%s err=%s gotResult=%t stdoutBytes=%d",
+		path, pid, processImageName(pid), time.Since(d.start).Round(time.Millisecond), errStr(pathErr), gotResult, d.capture.n))
+	d.emit(fmt.Sprintf("stdout-head=%q", d.capture.head()))
+	d.emit(fmt.Sprintf("stderr=%q", strings.TrimSpace(string(stderr))))
+}
+
+func (d *spawnDiag) emit(msg string) {
+	line := "spawn-diag[" + d.agent + "] " + msg
+	if d.onChunk != nil {
+		d.onChunk(line)
+	}
+	slog.Warn(line)
+}
+
+func errStr(err error) string {
+	if err == nil {
+		return "<nil>"
+	}
+	return err.Error()
+}
+
+// redactArgv renders argv for logging while replacing the prompt and schema
+// values (which follow -p and --json-schema) with their lengths, so a
+// diagnostic run never dumps prompt content or the schema into logs.
+func redactArgv(args []string) string {
+	parts := make([]string, 0, len(args))
+	redactNext := false
+	for _, arg := range args {
+		if redactNext {
+			parts = append(parts, fmt.Sprintf("<redacted len=%d>", len(arg)))
+			redactNext = false
+			continue
+		}
+		parts = append(parts, arg)
+		if arg == "-p" || arg == "--json-schema" {
+			redactNext = true
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+// diagCapture counts every byte written and retains the first limit bytes.
+type diagCapture struct {
+	n     int64
+	buf   []byte
+	limit int
+}
+
+func (c *diagCapture) Write(p []byte) (int, error) {
+	c.n += int64(len(p))
+	if len(c.buf) < c.limit {
+		room := c.limit - len(c.buf)
+		if room > len(p) {
+			room = len(p)
+		}
+		c.buf = append(c.buf, p[:room]...)
+	}
+	return len(p), nil
+}
+
+func (c *diagCapture) head() string {
+	if c == nil {
+		return ""
+	}
+	return string(c.buf)
+}

--- a/internal/agent/spawn_diag.go
+++ b/internal/agent/spawn_diag.go
@@ -110,13 +110,16 @@ func (d *spawnDiag) wrapStdout(r io.Reader) io.Reader {
 
 // logExit records how the invocation ended: which branch (ok, no-result-event,
 // parse-error, wait-error), the error, whether a result was parsed, stdout
-// volume and head, and full stderr.
+// volume and head, and full stderr. It does not report the process image name:
+// by the time any exit branch runs the child has already been reaped (every
+// path follows started.wait or waitAfterParseError), so a lookup would report
+// "gone" or, worse, a reused PID. The live image is captured by logStarted.
 func (d *spawnDiag) logExit(pid int, path string, pathErr error, gotResult bool, stderr []byte) {
 	if !d.enabled {
 		return
 	}
-	d.emit(fmt.Sprintf("exit path=%s pid=%d image=%q dur=%s err=%s gotResult=%t stdoutBytes=%d",
-		path, pid, processImageName(pid), time.Since(d.start).Round(time.Millisecond), errStr(pathErr), gotResult, d.capture.n))
+	d.emit(fmt.Sprintf("exit path=%s pid=%d dur=%s err=%s gotResult=%t stdoutBytes=%d",
+		path, pid, time.Since(d.start).Round(time.Millisecond), errStr(pathErr), gotResult, d.capture.n))
 	d.emit(fmt.Sprintf("stdout-head=%q", d.capture.head()))
 	d.emit(fmt.Sprintf("stderr=%q", strings.TrimSpace(string(stderr))))
 }

--- a/internal/agent/spawn_diag.go
+++ b/internal/agent/spawn_diag.go
@@ -19,6 +19,14 @@ import (
 // path. Only the exact value 1 enables it; any other value (including 0 or
 // false) and unset leave it disabled. With diagnostics off and no sentinel
 // present, spawnDiag is a no-op with zero overhead.
+//
+// WARNING: when enabled, the diagnostic writes the agent's raw stdout head and
+// its full stderr to the daemon log verbatim. The argv prompt and JSON schema
+// are redacted, but the captured streams are not: stdout reflects the model's
+// response (and may carry the structured-output JSON) and stderr can carry
+// secrets. Enable this only for a controlled, short-lived debug session, then
+// unset the variable or remove the sentinel. Do not leave it on in a shared or
+// long-running deployment.
 const spawnDiagEnv = "NM_SPAWN_DIAG"
 
 // spawnDiagSentinel is a file under NM_HOME that also enables diagnostics. The
@@ -115,6 +123,9 @@ func (d *spawnDiag) wrapStdout(r io.Reader) io.Reader {
 // by the time any exit branch runs the child has already been reaped (every
 // path follows started.wait or waitAfterParseError), so a lookup would report
 // "gone" or, worse, a reused PID. The live image is captured by logStarted.
+//
+// The stdout head and stderr are logged verbatim; see the spawnDiagEnv warning
+// about enabling this only for a controlled debug session.
 func (d *spawnDiag) logExit(pid int, path string, pathErr error, gotResult bool, stderr []byte) {
 	if !d.enabled {
 		return

--- a/internal/agent/spawn_diag.go
+++ b/internal/agent/spawn_diag.go
@@ -17,16 +17,19 @@ import (
 // tracked PID and its OS image name (to expose a .cmd wrapper being tracked
 // instead of the native process), stdout volume, raw stderr, and the exact exit
 // path. Only the exact value 1 enables it; any other value (including 0 or
-// false) and unset leave it disabled. With diagnostics off and no sentinel
-// present, spawnDiag is a no-op with zero overhead.
+// false) and unset leave it disabled. When disabled, spawnDiag adds no work to
+// the spawn beyond the single sentinel stat that spawnDiagEnabled does per
+// invocation (negligible against launching a process); every log method and the
+// stdout wrap are no-ops.
 //
 // WARNING: when enabled, the diagnostic writes the agent's raw stdout head and
-// its full stderr to the daemon log verbatim. The argv prompt and JSON schema
-// are redacted, but the captured streams are not: stdout reflects the model's
-// response (and may carry the structured-output JSON) and stderr can carry
-// secrets. Enable this only for a controlled, short-lived debug session, then
-// unset the variable or remove the sentinel. Do not leave it on in a shared or
-// long-running deployment.
+// its full stderr verbatim to the daemon log and, when the caller sets an
+// OnChunk sink, to that sink (the step output stream) as well. The argv prompt
+// and JSON schema are redacted, but the captured streams are not: stdout
+// reflects the model's response (and may carry the structured-output JSON) and
+// stderr can carry secrets. Enable this only for a controlled, short-lived
+// debug session, then unset the variable or remove the sentinel. Do not leave
+// it on in a shared or long-running deployment.
 const spawnDiagEnv = "NM_SPAWN_DIAG"
 
 // spawnDiagSentinel is a file under NM_HOME that also enables diagnostics. The

--- a/internal/agent/spawn_diag_other.go
+++ b/internal/agent/spawn_diag_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package agent
+
+// processImageName is Windows-only; the .cmd-wrapper tracking problem it
+// diagnoses (issue #427) does not exist elsewhere, so this is a stub.
+func processImageName(pid int) string { return "" }

--- a/internal/agent/spawn_diag_test.go
+++ b/internal/agent/spawn_diag_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -21,6 +22,32 @@ func TestRedactArgv_HidesPromptAndSchema(t *testing.T) {
 	for _, want := range []string{"--model", "sonnet", "-p", "--verbose", "--json-schema", "<redacted len=18>"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("redactArgv = %q, want to contain %q", got, want)
+		}
+	}
+}
+
+// TestRedactArgv_RedactsClaudeBuildArgs pins the coupling between buildArgs and
+// redactArgv: redaction hides the prompt and schema only because buildArgs
+// emits them as the flag-then-value pairs redactArgv scans for. If buildArgs
+// ever moves to a "-p=<prompt>" form or reorders these, redaction would silently
+// leak, so exercise the real argv here rather than a hand-built one.
+func TestRedactArgv_RedactsClaudeBuildArgs(t *testing.T) {
+	const prompt = "PROMPT-SENTINEL-do-not-log"
+	const schema = `{"type":"object","title":"SCHEMA-SENTINEL"}`
+
+	a := &claudeAgent{extraArgs: []string{"--model", "sonnet"}}
+	args := a.buildArgs(prompt, json.RawMessage(schema), "")
+	got := redactArgv(args)
+
+	if strings.Contains(got, prompt) {
+		t.Errorf("prompt leaked through buildArgs into %q", got)
+	}
+	if strings.Contains(got, "SCHEMA-SENTINEL") {
+		t.Errorf("schema leaked through buildArgs into %q", got)
+	}
+	for _, want := range []string{"-p", "--json-schema", "<redacted len="} {
+		if !strings.Contains(got, want) {
+			t.Errorf("redactArgv(buildArgs) = %q, want to contain %q", got, want)
 		}
 	}
 }

--- a/internal/agent/spawn_diag_test.go
+++ b/internal/agent/spawn_diag_test.go
@@ -1,0 +1,72 @@
+package agent
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRedactArgv_HidesPromptAndSchema(t *testing.T) {
+	args := []string{"--model", "sonnet", "-p", "secret prompt text", "--verbose", "--json-schema", `{"type":"object"}`}
+	got := redactArgv(args)
+
+	if strings.Contains(got, "secret prompt text") {
+		t.Errorf("prompt leaked into %q", got)
+	}
+	if strings.Contains(got, `{"type":"object"}`) {
+		t.Errorf("schema leaked into %q", got)
+	}
+	for _, want := range []string{"--model", "sonnet", "-p", "--verbose", "--json-schema", "<redacted len=18>"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("redactArgv = %q, want to contain %q", got, want)
+		}
+	}
+}
+
+func TestDiagCapture_CountsAllBytesCapsBuffer(t *testing.T) {
+	c := &diagCapture{limit: 4}
+	io.Copy(c, strings.NewReader("hello world"))
+
+	if c.n != 11 {
+		t.Errorf("n = %d, want 11 (all bytes counted)", c.n)
+	}
+	if c.head() != "hell" {
+		t.Errorf("head = %q, want %q (capped at limit)", c.head(), "hell")
+	}
+}
+
+func TestSpawnDiag_DisabledByDefaultIsNoop(t *testing.T) {
+	t.Setenv(spawnDiagEnv, "")
+	t.Setenv("NM_HOME", t.TempDir()) // isolate: no sentinel present
+
+	d := newSpawnDiag("claude", "claude", []string{"-p", "x"}, RunOpts{})
+	if d.enabled {
+		t.Fatal("diag should be disabled when NM_SPAWN_DIAG is empty and no sentinel exists")
+	}
+	// All methods must be safe on a disabled instance.
+	r := strings.NewReader("payload")
+	if got := d.wrapStdout(r); got != io.Reader(r) {
+		t.Error("wrapStdout should return the reader unchanged when disabled")
+	}
+	d.logStarted(123)
+	d.logStartError(io.EOF)
+	d.logExit(123, "ok", nil, true, nil)
+}
+
+func TestSpawnDiag_EnabledBySentinelFile(t *testing.T) {
+	t.Setenv(spawnDiagEnv, "")
+	home := t.TempDir()
+	t.Setenv("NM_HOME", home)
+
+	if spawnDiagEnabled() {
+		t.Fatal("should be disabled before the sentinel is created")
+	}
+	if err := os.WriteFile(filepath.Join(home, spawnDiagSentinel), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !spawnDiagEnabled() {
+		t.Fatal("sentinel file under NM_HOME should enable diagnostics")
+	}
+}

--- a/internal/agent/spawn_diag_windows.go
+++ b/internal/agent/spawn_diag_windows.go
@@ -24,16 +24,23 @@ func processImageName(pid int) string {
 	if err != nil {
 		return "unknown(" + err.Error() + ")"
 	}
+	return parseTasklistImageName(out)
+}
+
+// parseTasklistImageName extracts the image name from `tasklist ... /FO CSV /NH`
+// output. A match is a CSV row whose first field is the quoted image name. When
+// nothing matches, tasklist prints a "no tasks" info line instead of a CSV row;
+// that message is localized, so rather than key on the English "INFO:" prefix,
+// treat any output that is not a quoted CSV row (including empty output) as the
+// process being gone.
+func parseTasklistImageName(out []byte) string {
 	line := strings.TrimSpace(string(out))
-	// tasklist prints an "INFO: No tasks..." line to stdout when nothing matches.
-	if line == "" || strings.HasPrefix(line, "INFO:") {
+	if !strings.HasPrefix(line, "\"") {
 		return "gone"
 	}
 	// CSV row: "Image Name","PID","Session Name",...  Take the first field.
-	if strings.HasPrefix(line, "\"") {
-		if end := strings.IndexByte(line[1:], '"'); end >= 0 {
-			return line[1 : 1+end]
-		}
+	if end := strings.IndexByte(line[1:], '"'); end >= 0 {
+		return line[1 : 1+end]
 	}
-	return line
+	return "gone"
 }

--- a/internal/agent/spawn_diag_windows.go
+++ b/internal/agent/spawn_diag_windows.go
@@ -1,0 +1,39 @@
+//go:build windows
+
+package agent
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/kunchenguid/no-mistakes/internal/winproc"
+)
+
+// processImageName returns the executable image name for pid via tasklist, so a
+// diagnostic run can reveal when the tracked process is the cmd.exe .cmd-shim
+// wrapper rather than the native agent (issue #427). Returns "gone" when no
+// process matches (it already exited), or an error marker on failure.
+func processImageName(pid int) string {
+	if pid <= 0 {
+		return ""
+	}
+	cmd := exec.Command("tasklist", "/FI", fmt.Sprintf("PID eq %d", pid), "/FO", "CSV", "/NH")
+	winproc.Harden(cmd)
+	out, err := cmd.Output()
+	if err != nil {
+		return "unknown(" + err.Error() + ")"
+	}
+	line := strings.TrimSpace(string(out))
+	// tasklist prints an "INFO: No tasks..." line to stdout when nothing matches.
+	if line == "" || strings.HasPrefix(line, "INFO:") {
+		return "gone"
+	}
+	// CSV row: "Image Name","PID","Session Name",...  Take the first field.
+	if strings.HasPrefix(line, "\"") {
+		if end := strings.IndexByte(line[1:], '"'); end >= 0 {
+			return line[1 : 1+end]
+		}
+	}
+	return line
+}

--- a/internal/agent/spawn_diag_windows_test.go
+++ b/internal/agent/spawn_diag_windows_test.go
@@ -20,6 +20,29 @@ func TestProcessImageName_CurrentProcess(t *testing.T) {
 	}
 }
 
+func TestParseTasklistImageName(t *testing.T) {
+	cases := []struct {
+		name string
+		out  string
+		want string
+	}{
+		{"match", `"claude.exe","1234","Console","1","12,345 K"`, "claude.exe"},
+		{"match with trailing newline", "\"cmd.exe\",\"5678\",\"Console\",\"1\",\"1 K\"\r\n", "cmd.exe"},
+		{"empty output", "", "gone"},
+		{"english no-match", "INFO: No tasks are running which match the specified criteria.", "gone"},
+		// A localized "no tasks" line does not start with a quoted CSV field, so
+		// it must read as gone rather than being mistaken for an image name.
+		{"localized no-match", "INFORMATION: Es werden keine Tasks ausgefuehrt.", "gone"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseTasklistImageName([]byte(tc.out)); got != tc.want {
+				t.Errorf("parseTasklistImageName(%q) = %q, want %q", tc.out, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestSpawnDiag_EndToEndCmdShim drives runOnce against a fake claude .cmd shim
 // (as npm installs on Windows) with NM_SPAWN_DIAG set, and asserts the
 // diagnostic surfaces the tracked image, stdout volume, and exit path. This is

--- a/internal/agent/spawn_diag_windows_test.go
+++ b/internal/agent/spawn_diag_windows_test.go
@@ -1,0 +1,66 @@
+//go:build windows
+
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestProcessImageName_CurrentProcess(t *testing.T) {
+	got := processImageName(os.Getpid())
+	if got == "" || got == "gone" || strings.HasPrefix(got, "unknown(") {
+		t.Fatalf("processImageName(self) = %q, want a real image name", got)
+	}
+	if !strings.HasSuffix(strings.ToLower(got), ".exe") {
+		t.Errorf("processImageName(self) = %q, want a .exe image", got)
+	}
+}
+
+// TestSpawnDiag_EndToEndCmdShim drives runOnce against a fake claude .cmd shim
+// (as npm installs on Windows) with NM_SPAWN_DIAG set, and asserts the
+// diagnostic surfaces the tracked image, stdout volume, and exit path. This is
+// the observability the issue #427 investigation needed: the tracked process is
+// the cmd.exe wrapper, exposed here without any live API call.
+func TestSpawnDiag_EndToEndCmdShim(t *testing.T) {
+	t.Setenv(spawnDiagEnv, "1")
+	dir := t.TempDir()
+
+	jsonPath := filepath.Join(dir, "events.jsonl")
+	events := `{"type":"assistant","message":{"usage":{"input_tokens":1,"output_tokens":1},"content":[{"type":"text","text":"ok"}]}}` + "\r\n" +
+		`{"type":"result","subtype":"success","is_error":false}` + "\r\n"
+	if err := os.WriteFile(jsonPath, []byte(events), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	shim := filepath.Join(dir, "claude.cmd")
+	if err := os.WriteFile(shim, []byte("@echo off\r\ntype \""+jsonPath+"\"\r\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var lines []string
+	a := &claudeAgent{bin: shim}
+	res, err := a.runOnce(context.Background(), RunOpts{
+		Prompt:  "hello",
+		CWD:     dir,
+		OnChunk: func(text string) { lines = append(lines, text) },
+	})
+	if err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if res == nil {
+		t.Fatal("expected a result")
+	}
+
+	joined := strings.Join(lines, "\n")
+	for _, want := range []string{"spawn-diag[claude]", "image=", "path=ok", "stdoutBytes="} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("diagnostics missing %q in:\n%s", want, joined)
+		}
+	}
+	if strings.Contains(joined, "hello") {
+		t.Errorf("prompt should be redacted from diagnostics:\n%s", joined)
+	}
+}


### PR DESCRIPTION
## Intent

Add an opt-in diagnostic that traces the claude native-agent spawn in internal/agent. It root-caused issue #427 (a console-less .cmd shim being tracked in place of the native claude.exe on Windows/Cygwin), but the tracer itself is general: most of what it captures helps diagnose any claude spawn failure on any platform, not only the Windows one. This is a standalone change, separate from the #427 fix.

When enabled, the diagnostic logs, on every platform: the resolved binary path from exec.LookPath (which exposes a wrong or shimmed binary, whether a Windows .cmd wrapper or any misresolved executable elsewhere), whether the process started and any start error, the redacted argv, the stdout byte volume with a leading snippet (zero bytes means the CLI emitted nothing), the full stderr (the CLI's own error text), and the exact exit branch the invocation took (ok, no-result-event, parse-error, wait-error). Together those separate the failure modes hiding behind a "claude returned no result event" symptom: a wrong binary, a crash, non-JSON output, a non-zero exit, or a silent hang.

One piece is Windows-specific: the OS image-name lookup via tasklist, which names the process actually tracked and so reveals a cmd.exe wrapper standing in for the wrapped claude.exe. That is the #427 signal. Off Windows the lookup is a no-op stub, so only the image= field is blank while every other field still works.

The diagnostic is off by default. When disabled it adds nothing to the spawn beyond the single sentinel stat the gate check runs per invocation, and the spawn path is byte-for-byte the prior behavior. Enable it per invocation with NM_SPAWN_DIAG=1, or by dropping a spawn-diag sentinel file under NM_HOME (the sentinel reaches the managed daemon, whose curated environment a shell export does not). Prompt and JSON-schema values in the argv are redacted to their lengths, so a run never writes prompt content or the schema to logs. The raw stdout head and full stderr are logged verbatim when enabled, so it is meant for a controlled, short-lived debug session, not a permanent setting.

Scope: the wiring lives only in claudeAgent.runOnce, so it traces the claude agent. The other agents (codex, copilot, pi, acpx) and the shared server-spawn path are not wired up here. New code is split across spawn_diag.go, a Windows implementation in spawn_diag_windows.go, and a no-op stub in spawn_diag_other.go, with unit tests for redaction, capture, gating, the buildArgs/redactArgv coupling, and the tasklist image-name parsing.

Why the test step is skipped: this branch is validated on a Cygwin/Windows box where the Go suite has pre-existing environmental failures unrelated to this change that also fail on an unmodified main: filepath.EvalSymlinks returning "" for Cygwin temp paths (internal/git FindGitRoot), "fork/exec git: The directory name is invalid" for tests that set cmd.Dir under the Cygwin temp tree (internal/cli, internal/pipeline/steps), and Cygwin git's "hardlink different from source" during local clones. None are caused by this diff. The affected package (internal/agent, including the new spawn_diag tests) passes locally, and the full suite runs cleanly on the Linux/macOS/Windows CI, which is the authoritative test gate.

## What Changed

- Add an opt-in diagnostic that traces the claude native-agent spawn in `internal/agent`. It is general, not Windows-only: on every platform it logs the `exec.LookPath`-resolved binary path (exposing a wrong or shimmed binary), whether the process started and any start error, the redacted argv, stdout byte volume with a leading snippet, full stderr, and the exact exit branch taken (ok, no-result-event, parse-error, wait-error). Those separate the failure modes behind a "claude returned no result event" symptom on any OS. Prompt and JSON-schema argv values are redacted to their lengths.
- Make the OS image-name lookup the one Windows-specific part: `spawn_diag_windows.go` reads the tracked process image via `tasklist` to reveal a `.cmd`/cmd.exe wrapper standing in for the native `.exe` (the issue #427 signal), and `spawn_diag_other.go` stubs it to a no-op so off Windows only the `image=` field is blank. The core `spawn_diag.go` and the wiring compile and run everywhere.
- Wire the diagnostic into `claudeAgent.runOnce` only (the claude agent; other agents and the server-spawn path are untouched). With diagnostics disabled the spawn path is byte-for-byte the prior behavior, costing only the per-invocation sentinel stat. Enable per invocation via `NM_SPAWN_DIAG=1` or a `spawn-diag` sentinel file under `NM_HOME`.
- Add unit tests for redaction, capture, gating, the `buildArgs`/`redactArgv` coupling, and the tasklist image-name parsing, and document `NM_SPAWN_DIAG` in the environment reference with cross-references from the agents and troubleshooting guides, including a warning that an enabled run logs raw stdout and stderr.

Note: the Test step is skipped because this branch is validated on a Cygwin/Windows box with pre-existing environmental suite failures unrelated to this change (they also fail on an unmodified main); the affected `internal/agent` package including the new tests passes locally, and CI is the authoritative gate.

## Risk Assessment

✅ Low: The change is additive, off-by-default diagnostics that compile to a no-op when disabled and off Windows, with synchronized stderr access, correct redaction pinned by tests, and a well-documented opt-in exposure tradeoff.

## Testing

Completed 1 recorded test check.

- Outcome: ⏭️ skipped across 1 run (2m55s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

- 🚨 tests failed with exit code 1
- `go test -race ./...`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
