### PR TITLE
fix(paths): guard default daemon root under go test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ Safest local verification sequence after non-trivial changes:
 - The e2e suite is behind the `e2e` build tag; `make e2e` sweeps `./internal/e2e/...` and `./internal/pipeline/steps/...`, so keep new step-local e2e tests behind the tag too.
 - Packages whose tests shell out to git unset `GIT_CONFIG_COUNT` in `TestMain` so ambient `GIT_CONFIG_*` injection from agent harnesses cannot leak in; a test exercising injected config re-sets it with `t.Setenv` (see `internal/git`, `internal/gate`, `internal/daemon`, `internal/pipeline/steps`).
 - Packages whose tests can start a daemon or touch ambient state (`cmd/no-mistakes`, `internal/cli`, `internal/update`) use a package-wide `TestMain` that points `NM_HOME` and `HOME` at fresh temp dirs and disables telemetry/update-check env vars, so a full test run never touches a real `~/.no-mistakes`. Follow the same pattern in new such packages.
+- `paths.New()` refuses the default `~/.no-mistakes` root under `go test`; tests that touch app state must set `NM_HOME` to a temp dir, and only the production-default path test may opt in with `NO_MISTAKES_ALLOW_DEFAULT_ROOT_IN_TESTS=1`.
 - Isolate filesystem and environment state with `t.TempDir()` and `t.Setenv()`.
 
 **Repo Config Trust Boundary (security)**

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
+	"testing"
 )
 
 // Paths provides access to all no-mistakes filesystem locations.
@@ -19,7 +19,7 @@ func New() (*Paths, error) {
 	if env := os.Getenv("NM_HOME"); env != "" {
 		return &Paths{root: env}, nil
 	}
-	if runningUnderGoTest() && os.Getenv("NO_MISTAKES_ALLOW_DEFAULT_ROOT_IN_TESTS") != "1" {
+	if testing.Testing() && os.Getenv("NO_MISTAKES_ALLOW_DEFAULT_ROOT_IN_TESTS") != "1" {
 		return nil, fmt.Errorf("NM_HOME must be set under go test to avoid touching the real no-mistakes daemon root")
 	}
 	home, err := os.UserHomeDir()
@@ -27,11 +27,6 @@ func New() (*Paths, error) {
 		return nil, err
 	}
 	return &Paths{root: filepath.Join(home, ".no-mistakes")}, nil
-}
-
-func runningUnderGoTest() bool {
-	name := filepath.Base(os.Args[0])
-	return strings.HasSuffix(name, ".test") || strings.HasSuffix(name, ".test.exe")
 }
 
 // WithRoot returns Paths rooted at a custom directory (for testing).

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -1,8 +1,10 @@
 package paths
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // Paths provides access to all no-mistakes filesystem locations.
@@ -17,11 +19,19 @@ func New() (*Paths, error) {
 	if env := os.Getenv("NM_HOME"); env != "" {
 		return &Paths{root: env}, nil
 	}
+	if runningUnderGoTest() && os.Getenv("NO_MISTAKES_ALLOW_DEFAULT_ROOT_IN_TESTS") != "1" {
+		return nil, fmt.Errorf("NM_HOME must be set under go test to avoid touching the real no-mistakes daemon root")
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil, err
 	}
 	return &Paths{root: filepath.Join(home, ".no-mistakes")}, nil
+}
+
+func runningUnderGoTest() bool {
+	name := filepath.Base(os.Args[0])
+	return strings.HasSuffix(name, ".test") || strings.HasSuffix(name, ".test.exe")
 }
 
 // WithRoot returns Paths rooted at a custom directory (for testing).

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -79,8 +79,19 @@ func TestNewWithEnvOverride(t *testing.T) {
 	}
 }
 
+func TestNewRejectsDefaultRootInTests(t *testing.T) {
+	t.Setenv("NM_HOME", "")
+	t.Setenv("NO_MISTAKES_ALLOW_DEFAULT_ROOT_IN_TESTS", "")
+
+	_, err := New()
+	if err == nil {
+		t.Fatal("New() should reject the default root under go test")
+	}
+}
+
 func TestNewDefault(t *testing.T) {
 	t.Setenv("NM_HOME", "")
+	t.Setenv("NO_MISTAKES_ALLOW_DEFAULT_ROOT_IN_TESTS", "1")
 
 	p, err := New()
 	if err != nil {


### PR DESCRIPTION
## Intent

Make the no-mistakes test suite hermetic with respect to the real machine-wide no-mistakes daemon. No test may send lifecycle commands or other state-mutating calls to the real daemon, socket, or root. The implementation should provide a suite-wide structural guard, not only per-test fixes, so future tests fail closed if they forget an isolated NM_HOME. Keep the diff single-purpose and include proof that the real daemon cli.log lifecycle-line count does not change after the full uncached test suite and e2e suite.

## What Changed

- `paths.New()` now fails closed under `go test` (detected via `testing.Testing()`) when `NM_HOME` is unset, returning an error instead of silently resolving to the real `~/.no-mistakes` root, so a test that forgets to isolate `NM_HOME` can no longer send lifecycle/state calls to the real machine-wide daemon.
- Added an explicit opt-in escape hatch, `NO_MISTAKES_ALLOW_DEFAULT_ROOT_IN_TESTS=1`, reserved for the one test (`TestNewDefault`) that intentionally exercises the production-default path.
- Added `TestNewRejectsDefaultRootInTests` covering the new fail-closed behavior, and documented the guard and opt-in variable in `AGENTS.md`.
- The initial detection heuristic (checking `os.Args[0]` for a `.test`/`.test.exe` suffix) was replaced with the stdlib `testing.Testing()` call during review, since the suffix check misses custom-named test binaries (e.g. `go test -c -o <name>`).

## Risk Assessment

✅ Low: The prior finding was fixed by swapping to the stdlib testing.Testing() call, matching an existing identical pattern in internal/daemon/service.go, and no other code changed — the diff remains small, single-purpose, and additive with no production call sites affected.

## Testing

Baseline `go test -race ./...` had already passed; on top of that I ran the full suite uncached (`-count=1`) and the tagged e2e suite with NM_HOME explicitly unset to simulate a clean dev/CI shell — both fully green — and confirmed via targeted unit tests plus a temporary throwaway probe test that paths.New() fails closed when a test forgets to isolate NM_HOME. The strongest evidence is direct: I captured the real daemon's cli.log lifecycle-line count before and after this run and it is byte-identical (81 total lines, 15 lifecycle lines), while the log itself contains prior incident evidence (2026-07-06 and 2026-07-08 entries tagged parent_cmdline=\"go test -race ./...\") proving that before this guard existed, un-isolated test runs really did leak lifecycle commands into the real, machine-wide daemon — exactly the failure mode this change closes.

<details>
<summary>Evidence: cli.log hermeticity proof (before/after full uncached suite + e2e suite)</summary>

<code>Real daemon cli.log: 81 total lines / 15 lifecycle lines, unchanged before and after running `env -u NM_HOME go test -race -count=1 ./...` and `env -u NM_HOME go test -tags=e2e -count=1 -timeout 300s ./internal/e2e/... ./internal/pipeline/steps/...`. Log also contains pre-existing evidence of the actual incident this fix closes: lifecycle=update lines from 2026-07-06 and 2026-07-08 tagged parent_cmdline=&#34;go test -race ./...&#34;, proving un-isolated test runs previously did leak into the real daemon.</code>

```text
=== Real daemon cli.log hermeticity proof ===
Path: /Users/mielyemitchell/.no-mistakes/logs/cli.log

BEFORE running target-commit test suite (captured prior to this run):
  total lines: 81
  lifecycle lines: 15

AFTER running 'env -u NM_HOME go test -race -count=1 ./...' (full uncached suite)
AND 'env -u NM_HOME go test -tags=e2e -count=1 -timeout 300s ./internal/e2e/... ./internal/pipeline/steps/...' (e2e suite):
  total lines: 81
  lifecycle lines: 15

=== Pre-existing pollution evidence (from before this fix landed) ===
Lines already in cli.log showing prior go-test runs leaked lifecycle commands to the real daemon:
2026-07-06T23:22:15-07:00 lifecycle command=update force=false pid=16687 ppid=16661 parent_cmdline="go test ./internal/cli ./internal/update ./internal/lifecycle -count=1"
2026-07-06T23:22:15-07:00 lifecycle command=update force=false pid=16687 ppid=16661 parent_cmdline="go test ./internal/cli ./internal/update ./internal/lifecycle -count=1"
2026-07-06T23:22:15-07:00 lifecycle command=update force=false pid=16687 ppid=16661 parent_cmdline="go test ./internal/cli ./internal/update ./internal/lifecycle -count=1"
2026-07-06T23:22:42-07:00 lifecycle command=update force=false pid=20805 ppid=20018 parent_cmdline="go test -race ./..."
2026-07-06T23:22:42-07:00 lifecycle command=update force=false pid=20805 ppid=20018 parent_cmdline="go test -race ./..."
2026-07-06T23:22:42-07:00 lifecycle command=update force=false pid=20805 ppid=20018 parent_cmdline="go test -race ./..."
2026-07-06T23:34:02-07:00 lifecycle command=update force=false pid=71962 ppid=71946 parent_cmdline="go test -race ./internal/cli ./internal/update ./internal/lifecycle -count=1"
2026-07-06T23:34:02-07:00 lifecycle command=update force=false pid=71962 ppid=71946 parent_cmdline="go test -race ./internal/cli ./internal/update ./internal/lifecycle -count=1"
2026-07-06T23:34:02-07:00 lifecycle command=update force=false pid=71962 ppid=71946 parent_cmdline="go test -race ./internal/cli ./internal/update ./internal/lifecycle -count=1"
2026-07-06T23:52:49-07:00 lifecycle command=update force=false pid=32967 ppid=32495 parent_cmdline="go test -race ./..."
2026-07-06T23:52:49-07:00 lifecycle command=update force=false pid=32967 ppid=32495 parent_cmdline="go test -race ./..."
2026-07-06T23:52:49-07:00 lifecycle command=update force=false pid=32967 ppid=32495 parent_cmdline="go test -race ./..."
2026-07-08T10:37:09-07:00 lifecycle command=update force=false pid=78399 ppid=78295 parent_cmdline="go test -race ./..."
2026-07-08T10:37:09-07:00 lifecycle command=update force=false pid=78399 ppid=78295 parent_cmdline="go test -race ./..."
2026-07-08T10:37:09-07:00 lifecycle command=update force=false pid=78399 ppid=78295 parent_cmdline="go test -race ./..."

=== Structural guard probe (temporary test, added then removed) ===
internal/paths/zz_probe_test.go: New() with NM_HOME cleared under go test
Result: guard correctly refused: NM_HOME must be set under go test to avoid touching the real no-mistakes daemon root
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `internal/paths/paths.go:32` - runningUnderGoTest() detects test binaries by checking whether os.Args[0] ends in &#34;.test&#34;/&#34;.test.exe&#34;. That&#39;s a naming heuristic, not a reliable test-detection mechanism: a test binary compiled with a custom output name (`go test -c -o &lt;name&gt;`, or the binary names some IDE test-debuggers use, e.g. VS Code Go / GoLand &#34;debug test&#34;) won&#39;t match the suffix, so the guard silently doesn&#39;t fire and New() falls through to the real ~/.no-mistakes root — defeating the exact fail-closed guarantee this PR is adding. The codebase already has a more robust, stdlib-backed detector for this identical problem: internal/daemon/service.go:199 uses `testing.Testing()`, which reports true for any binary built by `go test` regardless of its file name. runningUnderGoTest() should call testing.Testing() instead of reimplementing a weaker heuristic.

🔧 Fix: fix(paths): use testing.Testing() for robust go-test detection
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`
- <code>`go test -run &#39;TestNewRejectsDefaultRootInTests|TestNewDefault|TestNewWithEnvOverride&#39; -v ./internal/paths/...` — all pass</code>
- `Temporary probe test (added then removed) simulating a test author forgetting NM_HOME isolation with NM_HOME/opt-in vars cleared via t.Setenv — confirmed New() fails closed with the expected error instead of silently returning the real root`
- <code>`env -u NM_HOME go test -race -count=1 ./...` (full uncached suite, all packages) — all pass</code>
- <code>`env -u NM_HOME go test -tags=e2e -count=1 -timeout 300s ./internal/e2e/... ./internal/pipeline/steps/...` (e2e suite) — all pass</code>
- <code>Compared real `$HOME/.no-mistakes/logs/cli.log` line counts (total and `lifecycle command=` lines) before and after the full uncached suite + e2e suite run — identical (81 total / 15 lifecycle) with zero new entries</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
