### PR TITLE
fix(git): resolve main repo root inside submodules

### DIFF
--- a/internal/e2e/init_test.go
+++ b/internal/e2e/init_test.go
@@ -148,6 +148,104 @@ func TestInitRepoRename(t *testing.T) {
 	}
 }
 
+// TestInitInSubmoduleRegistersSubmoduleOwnOrigin reproduces issue #328:
+// `no-mistakes init` from inside a Git submodule checkout must register the
+// gate against the submodule's own origin, not the superproject's. Before the
+// fix, FindMainRepoRoot took the parent of --git-common-dir, which for an
+// absorbed submodule is <super>/.git/modules/<name>. The gate then read its
+// origin from that wrong root and recorded the superproject's URL as the
+// upstream — a "push would land in the wrong repository" data-loss hazard.
+func TestInitInSubmoduleRegistersSubmoduleOwnOrigin(t *testing.T) {
+	h := NewHarness(t, SetupOpts{Agent: "claude"})
+	ctx := context.Background()
+
+	// Second bare repo serving as the submodule's "origin", distinct from
+	// the superproject's upstream (h.UpstreamDir) so the assertion below can
+	// tell which one the gate recorded.
+	subUpstream := filepath.Join(filepath.Dir(h.UpstreamDir), "sub-upstream.git")
+	if err := os.MkdirAll(subUpstream, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := h.runGit(ctx, subUpstream, "init", "--bare", "--initial-branch=main"); err != nil {
+		t.Fatalf("init sub upstream: %v\n%s", err, out)
+	}
+	// Seed the submodule's upstream with a real commit so `submodule add`
+	// can clone and check out a branch. Without it, the empty-repo clone
+	// dies with "fatal: You are on a branch yet to be born".
+	subSeed := filepath.Join(t.TempDir(), "sub-seed")
+	if err := os.MkdirAll(subSeed, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := h.runGit(ctx, subSeed, "init", "--initial-branch=main"); err != nil {
+		t.Fatalf("init sub seed: %v\n%s", err, out)
+	}
+	if err := os.WriteFile(filepath.Join(subSeed, "README.md"), []byte("# submodule upstream\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := h.runGit(ctx, subSeed, "add", "."); err != nil {
+		t.Fatalf("add sub seed: %v\n%s", err, out)
+	}
+	if out, err := h.runGit(ctx, subSeed, "commit", "-m", "initial"); err != nil {
+		t.Fatalf("commit sub seed: %v\n%s", err, out)
+	}
+	if out, err := h.runGit(ctx, subSeed, "remote", "add", "origin", subUpstream); err != nil {
+		t.Fatalf("remote add sub seed: %v\n%s", err, out)
+	}
+	if out, err := h.runGit(ctx, subSeed, "push", "-u", "origin", "main"); err != nil {
+		t.Fatalf("push sub seed: %v\n%s", err, out)
+	}
+
+	// Build the submodule in <work>/sub pointing at subUpstream.
+	if out, err := h.runGit(ctx, h.WorkDir, "-c", "protocol.file.allow=always", "submodule", "add", subUpstream, "sub"); err != nil {
+		t.Fatalf("submodule add: %v\n%s", err, out)
+	}
+	if out, err := h.runGit(ctx, h.WorkDir, "-c", "protocol.file.allow=always", "submodule", "init", "sub"); err != nil {
+		t.Fatalf("submodule init: %v\n%s", err, out)
+	}
+	if out, err := h.runGit(ctx, h.WorkDir, "-c", "protocol.file.allow=always", "submodule", "update", "sub"); err != nil {
+		t.Fatalf("submodule update: %v\n%s", err, out)
+	}
+	if out, err := h.runGit(ctx, h.WorkDir, "add", ".gitmodules", "sub"); err != nil {
+		t.Fatalf("git add submodule: %v\n%s", err, out)
+	}
+	if out, err := h.runGit(ctx, h.WorkDir, "commit", "-m", "add sub submodule"); err != nil {
+		t.Fatalf("commit submodule: %v\n%s", err, out)
+	}
+
+	subWorktree := filepath.Join(h.WorkDir, "sub")
+
+	// Run init from the submodule checkout. The pre-fix behavior writes the
+	// superproject's upstream into the gate row; the post-fix behavior must
+	// write the submodule's own.
+	if out, err := h.RunInDir(subWorktree, "init"); err != nil {
+		t.Fatalf("init in submodule: %v\n%s", err, out)
+	}
+
+	p := paths.WithRoot(h.NMHome)
+	d, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer d.Close()
+
+	// Find the gate by its working path (the submodule's own working tree,
+	// not the superproject's). The pre-fix code stored the superproject path
+	// and never created a row for the submodule, so the by-path lookup
+	// returns nil; the post-fix code stores the submodule path and the
+	// recorded upstream must match the submodule's origin.
+	resolvedSub, _ := filepath.EvalSymlinks(subWorktree)
+	repo, err := d.GetRepoByPath(resolvedSub)
+	if err != nil {
+		t.Fatalf("get repo by path: %v", err)
+	}
+	if repo == nil {
+		t.Fatalf("no gate registered for submodule working tree %q; init must record the submodule's own path, not the superproject's", resolvedSub)
+	}
+	if repo.UpstreamURL != subUpstream {
+		t.Fatalf("gate upstream = %q, want %q (the submodule's own origin); recording the superproject's origin is the data-loss bug from issue #328", repo.UpstreamURL, subUpstream)
+	}
+}
+
 func TestInitRollsBackWhenDaemonStartFails(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows IPC does not use Unix socket path limits")

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -138,31 +138,85 @@ func FindGitRoot(path string) (string, error) {
 }
 
 // FindMainRepoRoot returns the root of the main working tree for a git
-// repository. For a regular repo this is the same as FindGitRoot. For a
-// worktree it resolves back to the main repository root by inspecting
-// git's common dir.
+// repository. Three layouts are supported:
+//
+//  1. A regular repository or a linked worktree: the git common dir is
+//     <root>/.git, so the main working tree is filepath.Dir(commonDir).
+//  2. An absorbed submodule (including nested .../modules/a/modules/b):
+//     the git common dir lives under the superproject's .git/modules/...
+//     and is detached from its working tree. Git writes core.worktree
+//     when it absorbs a submodule, pointing at the working tree whose
+//     remote.origin.url is the submodule's own origin (which is what
+//     callers like init and eject need).
+//  3. Exotic GIT_DIR layouts without a core.worktree: fall back to
+//     `git rev-parse --show-toplevel` from the original path, the same
+//     answer FindGitRoot returns.
+//
+// In every branch the returned path is run through filepath.EvalSymlinks
+// when possible so callers can compare it against other symlink-resolved
+// paths (notably on macOS, where /tmp and /private/tmp refer to the same
+// directory). Symlink resolution failures fall back to the unresolved
+// path, matching the historical behavior.
 func FindMainRepoRoot(path string) (string, error) {
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		return "", err
 	}
-	cmd := exec.Command("git", "rev-parse", "--git-common-dir")
-	cmd.Dir = abs
-	winproc.Harden(cmd)
-	out, err := cmd.Output()
+
+	// Resolve the git common dir.
+	commonDirCmd := exec.Command("git", "rev-parse", "--git-common-dir")
+	commonDirCmd.Dir = abs
+	winproc.Harden(commonDirCmd)
+	commonDirOut, err := commonDirCmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("not a git repository: %s", abs)
 	}
-	commonDir := strings.TrimSpace(string(out))
-	// Make absolute if relative (e.g. ".git" in the main repo itself).
+	commonDir := strings.TrimSpace(string(commonDirOut))
 	if !filepath.IsAbs(commonDir) {
 		commonDir = filepath.Join(abs, commonDir)
 	}
-	// commonDir is the .git directory (e.g. /path/to/repo/.git); parent is the repo root.
-	root := filepath.Dir(filepath.Clean(commonDir))
-	resolved, err := filepath.EvalSymlinks(root)
+
+	// Branch 1: regular repo or linked worktree. Linked worktrees share
+	// the main repo's <root>/.git, so the common dir's basename is still
+	// ".git" and its parent is the main working tree.
+	if filepath.Base(commonDir) == ".git" {
+		return resolveMainRoot(filepath.Dir(commonDir))
+	}
+
+	// Branch 2: detached git dir (absorbed submodule). Ask the git dir
+	// itself for its core.worktree, which git writes when it absorbs a
+	// submodule's git dir. The value is typically relative (e.g.
+	// "../../../sub"); resolve it against the common dir.
+	worktreeCmd := exec.Command("git", "--git-dir", commonDir, "config", "--get", "core.worktree")
+	winproc.Harden(worktreeCmd)
+	if worktreeOut, err := worktreeCmd.Output(); err == nil {
+		worktree := strings.TrimSpace(string(worktreeOut))
+		if worktree != "" {
+			if !filepath.IsAbs(worktree) {
+				worktree = filepath.Join(commonDir, worktree)
+			}
+			return resolveMainRoot(worktree)
+		}
+	}
+
+	// Branch 3: exotic GIT_DIR without a usable core.worktree. Defer to
+	// `git rev-parse --show-toplevel` from the original path.
+	topCmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	topCmd.Dir = abs
+	winproc.Harden(topCmd)
+	topOut, err := topCmd.Output()
 	if err != nil {
-		return root, nil
+		return "", fmt.Errorf("not a git repository: %s", abs)
+	}
+	return resolveMainRoot(strings.TrimSpace(string(topOut)))
+}
+
+// resolveMainRoot applies filepath.EvalSymlinks to path, falling back to
+// the unresolved path when symlink resolution fails.
+func resolveMainRoot(path string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return path, nil
 	}
 	return resolved, nil
 }

--- a/internal/git/git_branch_worktree_test.go
+++ b/internal/git/git_branch_worktree_test.go
@@ -101,6 +101,132 @@ func TestFindMainRepoRootNotFound(t *testing.T) {
 	}
 }
 
+// addSubmodule wires up an absorbed submodule at <super>/<name> pointing at
+// the repo at <remoteDir>, commits the new submodule, and returns the
+// submodule's working tree. The path layout matches `git submodule add`:
+//   - <super>/<name>                        working tree
+//   - <super>/.git/modules/<name>           absorbed git dir
+//   - core.worktree = ../../../../<name>    relative inside the absorbed git dir
+func addSubmodule(t *testing.T, superDir, name, remoteDir string) string {
+	t.Helper()
+	// Use an absolute path so the clone does not depend on the superproject
+	// having an "origin" remote (which would change the relative path's
+	// resolution base).
+	absRemote, err := filepath.Abs(remoteDir)
+	if err != nil {
+		t.Fatalf("abs remote: %v", err)
+	}
+	run(t, superDir, "git", "-c", "protocol.file.allow=always", "submodule", "add", absRemote, name)
+	run(t, superDir, "git", "-c", "protocol.file.allow=always", "submodule", "init", name)
+	run(t, superDir, "git", "-c", "protocol.file.allow=always", "submodule", "update", name)
+	run(t, superDir, "git", "add", ".gitmodules", name)
+	run(t, superDir, "git", "commit", "-m", "add "+name+" submodule")
+	return filepath.Join(superDir, name)
+}
+
+// TestFindMainRepoRootSubmodule reproduces issue #328: in an absorbed
+// submodule checkout, the git common dir is <super>/.git/modules/<name>, so
+// the historical "parent of commonDir" heuristic points at the superproject's
+// modules directory. The function must instead resolve to the submodule's
+// own working tree (via core.worktree) so callers read the submodule's
+// remotes, not the superproject's.
+func TestFindMainRepoRootSubmodule(t *testing.T) {
+	ctx := context.Background()
+	superDir := initTestRepo(t)
+	// Give the superproject its own distinct origin so the assertion below
+	// can tell the two apart — the bug is that the gate ends up reading
+	// the superproject's origin instead of the submodule's.
+	if err := AddRemote(ctx, superDir, "origin", "https://github.com/example/superproject.git"); err != nil {
+		t.Fatalf("add super origin: %v", err)
+	}
+	subRemote := initTestRepo(t)
+
+	subWorktree := addSubmodule(t, superDir, "sub", subRemote)
+	// Set the submodule's own origin on its working tree (the helper above
+	// clones subRemote, so without this the cloned submodule's "origin"
+	// would be subRemote's path, not the URL the gate should record).
+	// `git submodule add` already created an "origin" remote pointing at
+	// subRemote, so use EnsureRemote to overwrite it idempotently.
+	if err := EnsureRemote(ctx, subWorktree, "origin", "https://github.com/example/submodule.git"); err != nil {
+		t.Fatalf("add submodule origin: %v", err)
+	}
+
+	got, err := FindMainRepoRoot(subWorktree)
+	if err != nil {
+		t.Fatalf("FindMainRepoRoot from submodule: %v", err)
+	}
+	wantResolved, _ := filepath.EvalSymlinks(subWorktree)
+	gotResolved, _ := filepath.EvalSymlinks(got)
+	if gotResolved != wantResolved {
+		t.Fatalf("FindMainRepoRoot from submodule = %q, want %q (superproject's .git/modules would be wrong)", gotResolved, wantResolved)
+	}
+
+	// The dangerous half: callers (init, eject) read remotes by running git
+	// with cwd set to the returned root. If that root resolves to the
+	// superproject instead, the gate records the superproject's origin
+	// instead of the submodule's.
+	url, err := Run(ctx, got, "remote", "get-url", "origin")
+	if err != nil {
+		t.Fatalf("read origin from returned root: %v", err)
+	}
+	if url != "https://github.com/example/submodule.git" {
+		t.Fatalf("origin read from returned root = %q, want the submodule's origin", url)
+	}
+}
+
+// TestFindMainRepoRootNestedSubmodule is the same fix one level deeper:
+// a submodule inside a submodule has its git dir at
+// <super>/.git/modules/a/modules/b. The function must still resolve to the
+// innermost submodule's working tree.
+func TestFindMainRepoRootNestedSubmodule(t *testing.T) {
+	ctx := context.Background()
+	superDir := initTestRepo(t)
+	outerRemote := initTestRepo(t)
+	innerRemote := initTestRepo(t)
+
+	outerWorktree := addSubmodule(t, superDir, "outer", outerRemote)
+	innerWorktree := addSubmodule(t, outerWorktree, "inner", innerRemote)
+	if err := AddRemote(ctx, innerRemote, "origin", "https://github.com/example/inner.git"); err != nil {
+		t.Fatalf("add inner origin: %v", err)
+	}
+
+	got, err := FindMainRepoRoot(innerWorktree)
+	if err != nil {
+		t.Fatalf("FindMainRepoRoot from nested submodule: %v", err)
+	}
+	wantResolved, _ := filepath.EvalSymlinks(innerWorktree)
+	gotResolved, _ := filepath.EvalSymlinks(got)
+	if gotResolved != wantResolved {
+		t.Fatalf("FindMainRepoRoot from nested submodule = %q, want %q", gotResolved, wantResolved)
+	}
+}
+
+// TestFindMainRepoRootFromWorktreeStillResolvesToMain is the linked-worktree
+// regression guard for the three-way fix. Linked worktrees keep their git
+// common dir at <main>/.git, so the historical "parent of commonDir" answer
+// stays correct and must not regress.
+func TestFindMainRepoRootFromWorktreeStillResolvesToMain(t *testing.T) {
+	ctx := context.Background()
+	mainRepo := initTestRepo(t)
+	run(t, mainRepo, "git", "checkout", "-b", "wt-branch")
+	run(t, mainRepo, "git", "checkout", "-")
+	wtDir := filepath.Join(t.TempDir(), "worktree")
+	if err := WorktreeAdd(ctx, mainRepo, wtDir, "wt-branch"); err != nil {
+		t.Fatalf("WorktreeAdd: %v", err)
+	}
+	t.Cleanup(func() { WorktreeRemove(ctx, mainRepo, wtDir) })
+
+	got, err := FindMainRepoRoot(wtDir)
+	if err != nil {
+		t.Fatalf("FindMainRepoRoot from worktree: %v", err)
+	}
+	want, _ := filepath.EvalSymlinks(mainRepo)
+	gotResolved, _ := filepath.EvalSymlinks(got)
+	if gotResolved != want {
+		t.Fatalf("FindMainRepoRoot from worktree = %q, want %q", gotResolved, want)
+	}
+}
+
 func TestPush(t *testing.T) {
 	ctx := context.Background()
 	src := initTestRepo(t)

--- a/internal/git/git_branch_worktree_test.go
+++ b/internal/git/git_branch_worktree_test.go
@@ -116,6 +116,11 @@ func addSubmodule(t *testing.T, superDir, name, remoteDir string) string {
 	if err != nil {
 		t.Fatalf("abs remote: %v", err)
 	}
+	// superDir may itself be a submodule checkout (nested case), which never
+	// had a commit identity configured; set one so the commit below does not
+	// fail with "empty ident name" on runners without an ambient git identity.
+	run(t, superDir, "git", "config", "user.email", "test@test.com")
+	run(t, superDir, "git", "config", "user.name", "Test")
 	run(t, superDir, "git", "-c", "protocol.file.allow=always", "submodule", "add", absRemote, name)
 	run(t, superDir, "git", "-c", "protocol.file.allow=always", "submodule", "init", name)
 	run(t, superDir, "git", "-c", "protocol.file.allow=always", "submodule", "update", name)


### PR DESCRIPTION
## What Changed

- Rework `FindMainRepoRoot` in `internal/git/git.go` to handle three git-dir layouts explicitly: regular repos and linked worktrees (parent of the `.git` common dir), absorbed submodules including nested `.../modules/a/modules/b` (resolve the detached git dir's `core.worktree`), and exotic `GIT_DIR` setups without a usable `core.worktree` (fall back to `git rev-parse --show-toplevel`).
- Extract a shared `resolveMainRoot` helper that runs each candidate path through `filepath.EvalSymlinks`, falling back to the unresolved path so callers can still compare against symlink-resolved paths (e.g. `/tmp` vs `/private/tmp` on macOS).
- Add coverage for the new submodule and worktree resolution paths in `internal/git/git_branch_worktree_test.go` and `internal/e2e/init_test.go`.

## Risk Assessment

✅ Low: A well-bounded, correctly-implemented three-branch fix to FindMainRepoRoot for absorbed submodules, backed by targeted unit and e2e tests reproducing the #328 data-loss scenario, with no behavioral regression for regular repos or linked worktrees.

## Testing

Completed 1 recorded test check.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
