### PR TITLE
feat: Developer ID sign macOS release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,15 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  build-and-upload:
-    runs-on: ubuntu-latest
+  # macOS artifacts are built and Developer ID signed on a macOS runner (codesign
+  # is macOS-only). Signing happens before archiving and before the checksums job
+  # so the published tarball and its SHA-256 both cover the signed binary. The
+  # signing certificate is gated behind the release-signing environment and never
+  # leaves the runner. The "macOS Release Signing" section of AGENTS.md owns the
+  # permanent-identity invariant and the full signing contract.
+  build-darwin:
+    runs-on: macos-latest
+    environment: release-signing
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     strategy:
@@ -39,6 +46,187 @@ jobs:
             goarch: amd64
           - goos: darwin
             goarch: arm64
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Build darwin binary
+        env:
+          GOOS: darwin
+          GOARCH: ${{ matrix.goarch }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+          UMAMI_HOST: https://a.kunchenguid.com
+          UMAMI_WEBSITE_ID: f959e889-92f5-4121-8a1f-571b10861198
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          COMMIT="$(git rev-parse --short=7 HEAD)"
+          CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" \
+            go build -ldflags "-X github.com/kunchenguid/no-mistakes/internal/buildinfo.Version=${TAG} -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Commit=${COMMIT} -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Date=${DATE} -X github.com/kunchenguid/no-mistakes/internal/buildinfo.TelemetryHost=${UMAMI_HOST} -X github.com/kunchenguid/no-mistakes/internal/buildinfo.TelemetryWebsiteID=${UMAMI_WEBSITE_ID}" \
+            -o "dist/no-mistakes" ./cmd/no-mistakes
+
+      # Import the Developer ID Application cert into an ephemeral keychain locked
+      # with a runtime-generated password, discover exactly one signing identity
+      # (fail closed otherwise), and sign with a fixed identifier, hardened runtime,
+      # and secure timestamp. The cert (CSC_LINK) is base64 and only ever touches
+      # a RUNNER_TEMP file that is deleted immediately after import.
+      - name: Import Developer ID certificate and sign
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          TEAM_ID="9T2J7MNUP9"
+          if [ -z "${CSC_LINK:-}" ] || [ -z "${CSC_KEY_PASSWORD:-}" ]; then
+            echo "::error::CSC_LINK/CSC_KEY_PASSWORD signing secrets are missing; refusing to publish an unsigned macOS artifact" >&2
+            exit 1
+          fi
+          KEYCHAIN_PATH="$RUNNER_TEMP/nm-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+          CERT_PATH="$RUNNER_TEMP/nm-developer-id.p12"
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+
+          # Reconstruct the cert from the base64 secret into RUNNER_TEMP only.
+          printf '%s' "$CSC_LINK" | tr -d '[:space:]' | openssl base64 -A -d > "$CERT_PATH"
+
+          # Ephemeral keychain: create, unlock, import scoped to codesign, and add
+          # to the search list so codesign can find the private key.
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -P "$CSC_KEY_PASSWORD" -f pkcs12 \
+            -k "$KEYCHAIN_PATH" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" >/dev/null
+          # Prepend the ephemeral keychain to the user search list, preserving the
+          # existing (space-free) entries. Word splitting here is intentional.
+          # shellcheck disable=SC2046
+          security list-keychains -d user -s "$KEYCHAIN_PATH" \
+            $(security list-keychains -d user | sed 's/["]//g')
+          rm -f "$CERT_PATH"
+
+          # Fail closed unless exactly one Developer ID Application identity for the
+          # expected Team ID is present.
+          IDENTITIES="$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+            | grep 'Developer ID Application' || true)"
+          COUNT="$(printf '%s\n' "$IDENTITIES" | grep -c 'Developer ID Application' || true)"
+          if [ "$COUNT" -ne 1 ]; then
+            echo "::error::expected exactly one Developer ID Application identity, found $COUNT" >&2
+            exit 1
+          fi
+          if ! printf '%s\n' "$IDENTITIES" | grep -q "($TEAM_ID)"; then
+            echo "::error::signing identity does not belong to Team ID $TEAM_ID" >&2
+            exit 1
+          fi
+          IDENTITY_HASH="$(printf '%s\n' "$IDENTITIES" | awk 'NR==1 {print $2}')"
+
+          codesign --force --timestamp --options runtime \
+            --identifier com.kunchenguid.no-mistakes \
+            --keychain "$KEYCHAIN_PATH" \
+            --sign "$IDENTITY_HASH" \
+            "dist/no-mistakes"
+
+      # Strict verification gate: any missing or ambiguous property fails the
+      # release before the artifact is archived or uploaded.
+      - name: Verify Developer ID signature
+        env:
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          set -euo pipefail
+          TEAM_ID="9T2J7MNUP9"
+          BIN="dist/no-mistakes"
+
+          case "$GOARCH" in
+            amd64) EXPECTED_ARCH="x86_64" ;;
+            arm64) EXPECTED_ARCH="arm64" ;;
+            *) echo "::error::unexpected GOARCH $GOARCH" >&2; exit 1 ;;
+          esac
+
+          # 1. Signature valid and strict.
+          codesign --verify --strict --verbose=2 "$BIN"
+
+          # 2. Developer ID identity + Team ID + permanent identifier, not ad-hoc.
+          SIG="$(codesign -dvvv "$BIN" 2>&1)"
+          printf '%s\n' "$SIG"
+          grep -q 'Authority=Developer ID Application' <<<"$SIG"
+          grep -q "TeamIdentifier=$TEAM_ID" <<<"$SIG"
+          grep -q 'Identifier=com.kunchenguid.no-mistakes' <<<"$SIG"
+          if grep -qi 'adhoc' <<<"$SIG"; then
+            echo "::error::signature is ad-hoc" >&2; exit 1
+          fi
+
+          # 3. Hardened runtime enabled.
+          if ! grep -Eq 'flags=0x[0-9a-f]+\([^)]*runtime[^)]*\)' <<<"$SIG"; then
+            echo "::error::hardened runtime flag not set" >&2; exit 1
+          fi
+
+          # 4. Secure (RFC-3161) timestamp present.
+          grep -q 'Timestamp=' <<<"$SIG"
+
+          # 5. Designated requirement is identity-based, never a content hash.
+          DR="$(codesign -d -r- "$BIN" 2>&1)"
+          printf '%s\n' "$DR"
+          grep -q 'anchor apple generic' <<<"$DR"
+          # The Team ID starts with a digit so codesign quotes it, but accept the
+          # unquoted form too so a codesign quirk cannot fail a valid release.
+          grep -Eq "leaf\[subject.OU][[:space:]]*=[[:space:]]*\"?$TEAM_ID\"?" <<<"$DR"
+          grep -q 'identifier "com.kunchenguid.no-mistakes"' <<<"$DR"
+          if grep -q 'cdhash H' <<<"$DR"; then
+            echo "::error::designated requirement is content-based (cdhash), not identity-based" >&2; exit 1
+          fi
+
+          # 6. Correct architecture for this matrix leg.
+          ARCHS="$(lipo -archs "$BIN")"
+          if [ "$ARCHS" != "$EXPECTED_ARCH" ]; then
+            echo "::error::architecture mismatch: got '$ARCHS', want '$EXPECTED_ARCH'" >&2; exit 1
+          fi
+
+      - name: Archive signed binary
+        env:
+          GOOS: darwin
+          GOARCH: ${{ matrix.goarch }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          ARCHIVE="dist/no-mistakes-${TAG}-${GOOS}-${GOARCH}.tar.gz"
+          tar -C dist -czf "$ARCHIVE" no-mistakes
+          echo "ARCHIVE=$ARCHIVE" >> "$GITHUB_ENV"
+
+      - name: Upload release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: gh release upload "$TAG" "$ARCHIVE" --clobber
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: archive-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: ${{ env.ARCHIVE }}
+
+      # Tear down the ephemeral keychain on success and failure alike.
+      - name: Clean up signing keychain
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ -n "${KEYCHAIN_PATH:-}" ]; then
+            security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
+          fi
+          rm -f "$RUNNER_TEMP/nm-developer-id.p12" 2>/dev/null || true
+
+  build-and-upload:
+    runs-on: ubuntu-latest
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - goos: linux
             goarch: amd64
           - goos: linux
@@ -104,10 +292,12 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - release-please
+      - build-darwin
       - build-and-upload
     if: |
       !cancelled() &&
       needs.release-please.result == 'success' &&
+      needs.build-darwin.result == 'success' &&
       needs.build-and-upload.result == 'success' &&
       needs.release-please.outputs.release_created == 'true'
     steps:
@@ -135,11 +325,13 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - release-please
+      - build-darwin
       - build-and-upload
       - checksums
     if: |
       !cancelled() &&
       needs.release-please.result == 'success' &&
+      needs.build-darwin.result == 'success' &&
       needs.build-and-upload.result == 'success' &&
       needs.checksums.result == 'success' &&
       needs.release-please.outputs.release_created == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,7 +167,10 @@ jobs:
           fi
 
           # 4. Secure (RFC-3161) timestamp present.
-          grep -q 'Timestamp=' <<<"$SIG"
+          TIMESTAMP="$(sed -n 's/^Timestamp=//p' <<<"$SIG")"
+          if [[ -z "$TIMESTAMP" ]] || grep -qi '^none$' <<<"$TIMESTAMP"; then
+            echo "::error::secure timestamp is missing" >&2; exit 1
+          fi
 
           # 5. Designated requirement is identity-based, never a content hash.
           DR="$(codesign -d -r- "$BIN" 2>&1)"

--- a/.no-mistakes/evidence/fm/nm-macos-signing-s8/macos-release-signing-verification.md
+++ b/.no-mistakes/evidence/fm/nm-macos-signing-s8/macos-release-signing-verification.md
@@ -1,0 +1,48 @@
+# macOS release signing verification
+
+The release workflow contract tests passed for both macOS architectures, secret scoping, fail-closed verification, sign-before-archive ordering, cleanup, artifact compatibility, and the deliberately limited Phase 1 scope.
+
+```text
+$ go test . -run '^TestReleaseWorkflow' -count=1 -v
+=== RUN   TestReleaseWorkflowSignsDarwinArtifactsWithDeveloperID
+--- PASS: TestReleaseWorkflowSignsDarwinArtifactsWithDeveloperID
+=== RUN   TestReleaseWorkflowSignsBothDarwinArches
+--- PASS: TestReleaseWorkflowSignsBothDarwinArches
+=== RUN   TestReleaseWorkflowScopesSigningSecretsToDarwin
+--- PASS: TestReleaseWorkflowScopesSigningSecretsToDarwin
+=== RUN   TestReleaseWorkflowSignsBeforeArchiveAndChecksum
+--- PASS: TestReleaseWorkflowSignsBeforeArchiveAndChecksum
+=== RUN   TestReleaseWorkflowFailsClosedOnBadSignature
+--- PASS: TestReleaseWorkflowFailsClosedOnBadSignature
+=== RUN   TestReleaseWorkflowCleansUpKeychainAlways
+--- PASS: TestReleaseWorkflowCleansUpKeychainAlways
+=== RUN   TestReleaseWorkflowPreservesArtifactContract
+--- PASS: TestReleaseWorkflowPreservesArtifactContract
+=== RUN   TestReleaseWorkflowStaysPhase1NoNotarization
+--- PASS: TestReleaseWorkflowStaysPhase1NoNotarization
+PASS
+```
+
+A release-shaped local build and archive exercise preserved the updater-facing filenames and confirmed that each tarball contains a thin binary for the intended architecture.
+
+```text
+artifact=no-mistakes-vTEST-darwin-amd64.tar.gz
+no-mistakes
+no-mistakes: Mach-O 64-bit executable x86_64
+
+artifact=no-mistakes-vTEST-darwin-arm64.tar.gz
+no-mistakes
+no-mistakes: Mach-O 64-bit executable arm64
+```
+
+The same exercise reproduced the unsafe inputs that motivated the change.
+The amd64 binary had no signature metadata, while the Go-produced arm64 binary was ad-hoc with no stable identifier or Team ID:
+
+```text
+Identifier=a.out
+Signature=adhoc
+TeamIdentifier=not set
+```
+
+The changed workflow places Developer ID signing and strict verification before tarball creation, so neither reproduced input can reach the archive/upload step.
+An actual Developer ID signature was not produced locally because `CSC_LINK` is deliberately not configured for this PR and publishing a release is explicitly out of scope.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,15 @@ Safest local verification sequence after non-trivial changes:
 - `lastSeenSHA` must stay the head the run last **observed**, never the live remote tip: the rebase step refreshes `origin/<branch>` only on a normal push, NOT on a force push, and the CI step passes `Run.HeadSHA`. Anchoring the lease to a SHA read immediately before pushing is the original #281 bug (it always passes and protects nothing); always-fetching the branch on force push recreates it. Never reintroduce either.
 - Regressions: `TestCIStep_CommitAndPush_RefusesToClobberUnseenUpstreamCommit` (#281), `TestPushStep_RefusesToClobberAdvancedUpstreamBranch` (#305), `TestForcePushRun_RefusesToClobberOutOfBandBranchCommit`, `TestRebaseStep_DetectsUnpushedLocalDefaultBranchCommits` (#283), `TestResolveForcePushDecision_*`.
 
+**macOS Release Signing (permanent identity)**
+
+- Every official macOS release artifact - both `darwin/arm64` and `darwin/amd64` - is Developer ID Application signed on a macOS runner with a fixed identifier, hardened runtime, secure timestamp, and no entitlements, then strictly verified before it is archived or checksummed; the Linux and Windows release paths are unchanged.
+- The executable identifier `com.kunchenguid.no-mistakes` and Team ID `9T2J7MNUP9` are the permanent Developer ID identity and MUST NEVER change: they are the invariant of the identity-based designated requirement that lets macOS permission grants survive `no-mistakes update`, so changing either resets every grant once.
+- Signing runs only in the darwin build job gated behind the `release-signing` GitHub environment; the certificate is the base64 `CSC_LINK` secret unlocked with `CSC_KEY_PASSWORD`, imported into an ephemeral keychain with a runtime-generated password that is deleted on success and failure, and no other job may reference those secrets.
+- Signing happens before tarball creation and checksum generation, and the verify gate fails the release closed on any missing or ambiguous signature, wrong Team ID, non-permanent identifier, content-based (`cdhash`) requirement, missing hardened runtime or timestamp, or wrong architecture.
+- Mechanics live in `.github/workflows/release.yml`; the contract is pinned by the root `TestReleaseWorkflow*` static tests in `workflow_release_signing_test.go`, and secret values are never recorded here or in any test fixture.
+- Notarization, stapling, a PKG, Homebrew, and universal binaries are intentionally out of scope for this phase.
+
 **When Making Changes**
 
 - Whenever you must bring in new dependencies, check latest documentation for knowledge, and discuss with the user.

--- a/workflow_release_signing_test.go
+++ b/workflow_release_signing_test.go
@@ -1,0 +1,569 @@
+package main
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// These static tests pin the macOS Developer ID code-signing contract of
+// .github/workflows/release.yml. The workflow cannot be exercised end to end
+// from `go test` (it signs on a GitHub macOS runner with a Developer ID cert
+// that only exists in CI), so the invariant "every official macOS artifact is
+// Developer ID signed with a permanent identifier, verified before archive" is
+// guarded here. Against the pre-signing workflow these fail because the darwin
+// legs cross-compile on ubuntu with no codesign (arm64 ad-hoc, amd64 unsigned) -
+// that failing run is the reproduction. The permanent-identity invariant and the
+// signing contract are owned by the "macOS Release Signing" section of AGENTS.md.
+
+// The permanent signing identity. These MUST NEVER change once the first signed
+// release ships: the executable identifier and Team ID are the invariant part of
+// the Developer ID designated requirement that lets macOS permissions survive
+// `no-mistakes update`.
+const (
+	signingIdentifier = "com.kunchenguid.no-mistakes"
+	signingTeamID     = "9T2J7MNUP9"
+
+	cscLinkSecret    = "CSC_LINK"
+	cscKeyPassSecret = "CSC_KEY_PASSWORD"
+	signingEnv       = "release-signing"
+)
+
+// signingDarwinArches is the set of macOS architectures every official release
+// must ship as a signed thin binary.
+var signingDarwinArches = []string{"amd64", "arm64"}
+
+// expectedLipoArch maps a Go GOARCH to the name `lipo -archs` prints, which the
+// signing job asserts per matrix leg.
+var expectedLipoArch = map[string]string{"amd64": "x86_64", "arm64": "arm64"}
+
+// wfDoc is a minimal typed view of the workflow, capturing only the fields the
+// signing contract cares about. Flexible fields (runs-on, environment, needs)
+// are decoded as any and normalized by the helpers below.
+type wfDoc struct {
+	Jobs map[string]*wfJob `yaml:"jobs"`
+}
+
+type wfJob struct {
+	name        string
+	RunsOn      any        `yaml:"runs-on"`
+	Environment any        `yaml:"environment"`
+	Needs       any        `yaml:"needs"`
+	If          string     `yaml:"if"`
+	Strategy    wfStrategy `yaml:"strategy"`
+	Steps       []wfStep   `yaml:"steps"`
+}
+
+type wfStrategy struct {
+	Matrix struct {
+		Include []map[string]string `yaml:"include"`
+	} `yaml:"matrix"`
+}
+
+type wfStep struct {
+	Name string            `yaml:"name"`
+	Uses string            `yaml:"uses"`
+	If   string            `yaml:"if"`
+	Env  map[string]string `yaml:"env"`
+	Run  string            `yaml:"run"`
+	With map[string]string `yaml:"with"`
+}
+
+func loadReleaseWorkflowDoc(t *testing.T) *wfDoc {
+	t.Helper()
+	raw, err := os.ReadFile(".github/workflows/release.yml")
+	if err != nil {
+		t.Fatalf("read release workflow: %v", err)
+	}
+	var wf wfDoc
+	if err := yaml.Unmarshal(raw, &wf); err != nil {
+		t.Fatalf("parse release workflow: %v", err)
+	}
+	for name, job := range wf.Jobs {
+		job.name = name
+	}
+	return &wf
+}
+
+func wfScalar(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case map[string]any:
+		if n, ok := t["name"].(string); ok {
+			return n
+		}
+	}
+	return ""
+}
+
+func wfList(v any) []string {
+	switch t := v.(type) {
+	case string:
+		return []string{t}
+	case []any:
+		out := make([]string, 0, len(t))
+		for _, e := range t {
+			if s, ok := e.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+func (j *wfJob) runsOn() string    { return wfScalar(j.RunsOn) }
+func (j *wfJob) environ() string   { return wfScalar(j.Environment) }
+func (j *wfJob) needs() []string   { return wfList(j.Needs) }
+func (j *wfJob) runsOnMacOS() bool { return strings.Contains(j.runsOn(), "macos") }
+
+func (j *wfJob) allRun() string {
+	var b strings.Builder
+	for _, s := range j.Steps {
+		b.WriteString(s.Run)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func (j *wfJob) coversDarwinArch(goarch string) bool {
+	for _, e := range j.Strategy.Matrix.Include {
+		if e["goos"] == "darwin" && e["goarch"] == goarch {
+			return true
+		}
+	}
+	return false
+}
+
+func (j *wfJob) coversAnyDarwin() bool {
+	for _, e := range j.Strategy.Matrix.Include {
+		if e["goos"] == "darwin" {
+			return true
+		}
+	}
+	return false
+}
+
+func (wf *wfDoc) darwinBuildJobs() []*wfJob {
+	var out []*wfJob
+	for _, job := range wf.Jobs {
+		if job.coversAnyDarwin() {
+			out = append(out, job)
+		}
+	}
+	return out
+}
+
+// darwinJobForArch returns the single darwin build job covering goarch, or nil
+// if none or more than one (ambiguity is itself a failure).
+func (wf *wfDoc) darwinJobForArch(goarch string) *wfJob {
+	var found *wfJob
+	for _, job := range wf.Jobs {
+		if job.coversDarwinArch(goarch) {
+			if found != nil {
+				return nil
+			}
+			found = job
+		}
+	}
+	return found
+}
+
+func (wf *wfDoc) nonDarwinBuildJob() *wfJob {
+	for _, job := range wf.Jobs {
+		if job.coversAnyDarwin() {
+			continue
+		}
+		for _, e := range job.Strategy.Matrix.Include {
+			if e["goos"] == "linux" || e["goos"] == "windows" {
+				return job
+			}
+		}
+	}
+	return nil
+}
+
+func (wf *wfDoc) jobByRunContains(substrs ...string) *wfJob {
+	for _, job := range wf.Jobs {
+		if wfContainsAll(job.allRun(), substrs...) {
+			return job
+		}
+	}
+	return nil
+}
+
+func wfStepIndex(steps []wfStep, substrs ...string) int {
+	for i, s := range steps {
+		if wfContainsAll(s.Run, substrs...) {
+			return i
+		}
+	}
+	return -1
+}
+
+func wfContainsAll(hay string, needles ...string) bool {
+	for _, n := range needles {
+		if !strings.Contains(hay, n) {
+			return false
+		}
+	}
+	return true
+}
+
+var wfSecretRefRe = regexp.MustCompile(`secrets\.([A-Za-z0-9_]+)`)
+
+func (j *wfJob) secretRefs() map[string]bool {
+	refs := map[string]bool{}
+	add := func(s string) {
+		for _, m := range wfSecretRefRe.FindAllStringSubmatch(s, -1) {
+			refs[m[1]] = true
+		}
+	}
+	add(wfScalar(j.Environment))
+	for _, st := range j.Steps {
+		add(st.Run)
+		for k, v := range st.Env {
+			add(k)
+			add(v)
+		}
+		for k, v := range st.With {
+			add(k)
+			add(v)
+		}
+	}
+	return refs
+}
+
+func signStepIndex(j *wfJob) int {
+	return wfStepIndex(j.Steps, "codesign", "--sign", "--options runtime",
+		"--identifier", signingIdentifier, "--timestamp")
+}
+
+func verifyStepIndex(j *wfJob) int {
+	return wfStepIndex(j.Steps, "codesign --verify", "anchor apple generic")
+}
+
+func archiveStepIndex(j *wfJob) int {
+	return wfStepIndex(j.Steps, "tar", "czf", ".tar.gz")
+}
+
+func uploadStepIndex(j *wfJob) int {
+	return wfStepIndex(j.Steps, "gh release upload")
+}
+
+// TestReleaseWorkflowSignsDarwinArtifactsWithDeveloperID is the primary
+// reproduction/regression: it fails on any workflow that can publish an ad-hoc
+// or unsigned macOS artifact.
+func TestReleaseWorkflowSignsDarwinArtifactsWithDeveloperID(t *testing.T) {
+	wf := loadReleaseWorkflowDoc(t)
+
+	for _, arch := range signingDarwinArches {
+		job := wf.darwinJobForArch(arch)
+		if job == nil {
+			t.Fatalf("darwin/%s has no single dedicated build job; macOS artifacts would ship unsigned", arch)
+		}
+		if !job.runsOnMacOS() {
+			t.Errorf("darwin/%s build job %q runs on %q, not a macOS runner; codesign cannot run and the artifact ships ad-hoc/unsigned",
+				arch, job.name, job.runsOn())
+		}
+		if signStepIndex(job) < 0 {
+			t.Errorf("darwin/%s build job %q has no Developer ID codesign step (--sign --options runtime --identifier %s --timestamp)",
+				arch, job.name, signingIdentifier)
+		}
+		if verifyStepIndex(job) < 0 {
+			t.Errorf("darwin/%s build job %q has no post-sign verification step", arch, job.name)
+		}
+	}
+}
+
+// TestReleaseWorkflowSignsBothDarwinArches pins that BOTH arm64 and amd64 go
+// through the signing path (the audit stressed the two arches start in different
+// states) and that each leg asserts its expected architecture.
+func TestReleaseWorkflowSignsBothDarwinArches(t *testing.T) {
+	wf := loadReleaseWorkflowDoc(t)
+
+	for _, arch := range signingDarwinArches {
+		job := wf.darwinJobForArch(arch)
+		if job == nil {
+			t.Fatalf("no single darwin build job covers goarch=%s", arch)
+		}
+		if !job.runsOnMacOS() {
+			t.Errorf("darwin/%s job %q must run on macOS", arch, job.name)
+		}
+		if !strings.Contains(job.allRun(), expectedLipoArch[arch]) {
+			t.Errorf("darwin/%s job %q never asserts expected architecture %q (lipo -archs)", arch, job.name, expectedLipoArch[arch])
+		}
+	}
+
+	built := map[string]bool{}
+	for _, job := range wf.darwinBuildJobs() {
+		for _, e := range job.Strategy.Matrix.Include {
+			if e["goos"] == "darwin" {
+				built[e["goarch"]] = true
+			}
+		}
+	}
+	for _, arch := range signingDarwinArches {
+		if !built[arch] {
+			t.Errorf("darwin/%s missing from the signed build matrix", arch)
+		}
+	}
+}
+
+// TestReleaseWorkflowScopesSigningSecretsToDarwin enforces that the cert secrets
+// are gated behind the release-signing environment and referenced only by the
+// darwin signing job, and that the CI keychain password is generated at runtime
+// rather than stored as a secret.
+func TestReleaseWorkflowScopesSigningSecretsToDarwin(t *testing.T) {
+	wf := loadReleaseWorkflowDoc(t)
+
+	darwinJobs := map[string]bool{}
+	for _, job := range wf.darwinBuildJobs() {
+		darwinJobs[job.name] = true
+
+		if job.environ() != signingEnv {
+			t.Errorf("darwin signing job %q must be gated behind environment %q, got %q", job.name, signingEnv, job.environ())
+		}
+		refs := job.secretRefs()
+		if !refs[cscLinkSecret] || !refs[cscKeyPassSecret] {
+			t.Errorf("darwin signing job %q must reference both %s and %s", job.name, cscLinkSecret, cscKeyPassSecret)
+		}
+		for name := range refs {
+			if name != cscLinkSecret && name != cscKeyPassSecret {
+				t.Errorf("darwin signing job %q references unexpected secret %q; the keychain password must be runtime-generated, not a secret", job.name, name)
+			}
+		}
+		if !strings.Contains(job.allRun(), "openssl rand") {
+			t.Errorf("darwin signing job %q must generate the ephemeral keychain password at runtime (openssl rand)", job.name)
+		}
+	}
+
+	for _, job := range wf.Jobs {
+		if darwinJobs[job.name] {
+			continue
+		}
+		refs := job.secretRefs()
+		if refs[cscLinkSecret] || refs[cscKeyPassSecret] {
+			t.Errorf("job %q references signing secrets but is not the darwin signing job; secrets must stay scoped", job.name)
+		}
+		if job.environ() == signingEnv {
+			t.Errorf("job %q is gated behind %q but does not sign; the environment must scope only the signing job", job.name, signingEnv)
+		}
+	}
+}
+
+// TestReleaseWorkflowSignsBeforeArchiveAndChecksum enforces the load-bearing
+// ordering: sign -> verify -> archive -> upload within the darwin job, and the
+// checksums job depending on the darwin build job so checksums cover signed
+// archives.
+func TestReleaseWorkflowSignsBeforeArchiveAndChecksum(t *testing.T) {
+	wf := loadReleaseWorkflowDoc(t)
+
+	for _, arch := range signingDarwinArches {
+		job := wf.darwinJobForArch(arch)
+		if job == nil {
+			t.Fatalf("no darwin build job for %s", arch)
+		}
+		sign := signStepIndex(job)
+		verify := verifyStepIndex(job)
+		archive := archiveStepIndex(job)
+		upload := uploadStepIndex(job)
+		if sign < 0 || verify < 0 || archive < 0 || upload < 0 {
+			t.Fatalf("darwin job %q missing a required step (sign=%d verify=%d archive=%d upload=%d)", job.name, sign, verify, archive, upload)
+		}
+		if sign >= verify {
+			t.Errorf("darwin job %q: signing (step %d) must come before verification (step %d)", job.name, sign, verify)
+		}
+		if verify >= archive {
+			t.Errorf("darwin job %q: verification (step %d) must come before archiving (step %d)", job.name, verify, archive)
+		}
+		if archive >= upload {
+			t.Errorf("darwin job %q: archiving (step %d) must come before upload (step %d)", job.name, archive, upload)
+		}
+	}
+
+	checksums := wf.jobByRunContains("sha256sum", "checksums.txt")
+	if checksums == nil {
+		t.Fatal("no checksums job found")
+	}
+	for _, arch := range signingDarwinArches {
+		darwinJob := wf.darwinJobForArch(arch)
+		found := false
+		for _, dep := range checksums.needs() {
+			if dep == darwinJob.name {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("checksums job must depend on darwin build job %q so checksums are computed over signed archives", darwinJob.name)
+		}
+	}
+}
+
+// TestReleaseWorkflowFailsClosedOnBadSignature verifies the gate refuses to
+// publish when secrets, identity discovery, signing, or verification is missing
+// or ambiguous.
+func TestReleaseWorkflowFailsClosedOnBadSignature(t *testing.T) {
+	wf := loadReleaseWorkflowDoc(t)
+
+	for _, arch := range signingDarwinArches {
+		job := wf.darwinJobForArch(arch)
+		if job == nil {
+			t.Fatalf("no darwin build job for %s", arch)
+		}
+		run := job.allRun()
+
+		if !strings.Contains(run, "set -euo pipefail") {
+			t.Errorf("darwin job %q scripts must use `set -euo pipefail` to fail closed", job.name)
+		}
+		if !wfContainsAll(run, cscLinkSecret, cscKeyPassSecret) {
+			t.Errorf("darwin job %q must check both signing secrets are present", job.name)
+		}
+		if !regexp.MustCompile(`(?s)-z.*CSC_LINK`).MatchString(run) ||
+			!strings.Contains(run, "exit 1") {
+			t.Errorf("darwin job %q must abort when CSC_LINK is empty", job.name)
+		}
+
+		// Identity discovery must fail closed on anything but exactly one
+		// Developer ID Application identity.
+		if !strings.Contains(run, "Developer ID Application") {
+			t.Errorf("darwin job %q must discover a Developer ID Application identity", job.name)
+		}
+		if !regexp.MustCompile(`-ne 1|!= 1|-eq 0`).MatchString(run) {
+			t.Errorf("darwin job %q must fail closed unless exactly one signing identity is found", job.name)
+		}
+
+		verifyAsserts := []string{
+			"codesign --verify --strict",
+			signingTeamID,
+			signingIdentifier,
+			"anchor apple generic",
+			"subject.OU",
+		}
+		for _, a := range verifyAsserts {
+			if !strings.Contains(run, a) {
+				t.Errorf("darwin job %q verification missing assertion %q", job.name, a)
+			}
+		}
+		if !strings.Contains(run, "adhoc") {
+			t.Errorf("darwin job %q must reject an ad-hoc signature", job.name)
+		}
+		if !strings.Contains(run, "cdhash H") {
+			t.Errorf("darwin job %q must reject a content-based (cdhash) designated requirement", job.name)
+		}
+		if !strings.Contains(run, "runtime") {
+			t.Errorf("darwin job %q must assert the hardened runtime flag", job.name)
+		}
+		if !strings.Contains(run, "Timestamp=") {
+			t.Errorf("darwin job %q must assert a secure timestamp", job.name)
+		}
+	}
+}
+
+// TestReleaseWorkflowCleansUpKeychainAlways requires the ephemeral keychain to be
+// torn down on both success and failure paths.
+func TestReleaseWorkflowCleansUpKeychainAlways(t *testing.T) {
+	wf := loadReleaseWorkflowDoc(t)
+
+	for _, arch := range signingDarwinArches {
+		job := wf.darwinJobForArch(arch)
+		if job == nil {
+			t.Fatalf("no darwin build job for %s", arch)
+		}
+		cleanup := -1
+		for i, st := range job.Steps {
+			if strings.Contains(st.Run, "delete-keychain") {
+				cleanup = i
+				if !strings.Contains(strings.ReplaceAll(st.If, " ", ""), "always()") {
+					t.Errorf("darwin job %q keychain cleanup step must run with if: always(), got %q", job.name, st.If)
+				}
+			}
+		}
+		if cleanup < 0 {
+			t.Errorf("darwin job %q has no keychain cleanup step (security delete-keychain)", job.name)
+		}
+	}
+}
+
+// TestReleaseWorkflowPreservesArtifactContract pins the installer/updater and
+// checksum contracts: per-arch tarball names, an unchanged linux/windows path,
+// and finalize still publishing a prerelease.
+func TestReleaseWorkflowPreservesArtifactContract(t *testing.T) {
+	wf := loadReleaseWorkflowDoc(t)
+
+	for _, arch := range signingDarwinArches {
+		job := wf.darwinJobForArch(arch)
+		if job == nil {
+			t.Fatalf("no darwin build job for %s", arch)
+		}
+		run := job.allRun()
+		if !strings.Contains(run, "no-mistakes-") || !strings.Contains(run, "${GOOS}-${GOARCH}.tar.gz") {
+			t.Errorf("darwin job %q must preserve the no-mistakes-<tag>-<goos>-<goarch>.tar.gz name", job.name)
+		}
+	}
+
+	lw := wf.nonDarwinBuildJob()
+	if lw == nil {
+		t.Fatal("no linux/windows build job found")
+	}
+	if !strings.Contains(lw.runsOn(), "ubuntu") {
+		t.Errorf("linux/windows job %q must stay on ubuntu, got %q", lw.name, lw.runsOn())
+	}
+	wantTargets := map[string]bool{
+		"linux/amd64": true, "linux/arm64": true,
+		"windows/amd64": true, "windows/arm64": true,
+	}
+	gotTargets := map[string]bool{}
+	for _, e := range lw.Strategy.Matrix.Include {
+		gotTargets[e["goos"]+"/"+e["goarch"]] = true
+	}
+	if len(gotTargets) != len(wantTargets) {
+		t.Errorf("linux/windows job %q matrix = %v, want %v", lw.name, gotTargets, wantTargets)
+	}
+	for target := range wantTargets {
+		if !gotTargets[target] {
+			t.Errorf("linux/windows job %q missing target %s", lw.name, target)
+		}
+	}
+	if strings.Contains(lw.allRun(), "codesign") {
+		t.Errorf("linux/windows job %q must not sign", lw.name)
+	}
+	if uploadStepIndex(lw) < 0 {
+		t.Errorf("linux/windows job %q must still upload the release asset", lw.name)
+	}
+
+	checksums := wf.jobByRunContains("sha256sum", "checksums.txt")
+	if checksums == nil || !strings.Contains(checksums.allRun(), "sha256sum no-mistakes-*") {
+		t.Error("checksums job must still compute `sha256sum no-mistakes-*`")
+	}
+
+	finalize := wf.jobByRunContains("--prerelease=true")
+	if finalize == nil || !wfContainsAll(finalize.allRun(), "--draft=false", "--prerelease=true") {
+		t.Error("finalize job must still run `gh release edit --draft=false --prerelease=true`")
+	}
+}
+
+// TestReleaseWorkflowStaysPhase1NoNotarization enforces the Phase 1 scope:
+// signing only, no notarization/stapling/pkg/homebrew/universal binaries.
+func TestReleaseWorkflowStaysPhase1NoNotarization(t *testing.T) {
+	wf := loadReleaseWorkflowDoc(t)
+
+	var blob strings.Builder
+	for _, job := range wf.Jobs {
+		blob.WriteString(job.allRun())
+		blob.WriteString("\n")
+	}
+	lower := strings.ToLower(blob.String())
+	for _, f := range []string{
+		"notarytool", "stapler", "pkgbuild", "productbuild",
+		"lipo -create", "--universal", "brew ", "homebrew",
+	} {
+		if strings.Contains(lower, strings.ToLower(f)) {
+			t.Errorf("release workflow must not add out-of-scope tooling %q in Phase 1", f)
+		}
+	}
+}

--- a/workflow_release_signing_test.go
+++ b/workflow_release_signing_test.go
@@ -458,8 +458,9 @@ func TestReleaseWorkflowFailsClosedOnBadSignature(t *testing.T) {
 		if !strings.Contains(run, "runtime") {
 			t.Errorf("darwin job %q must assert the hardened runtime flag", job.name)
 		}
-		if !strings.Contains(run, "Timestamp=") {
-			t.Errorf("darwin job %q must assert a secure timestamp", job.name)
+		if !regexp.MustCompile(`(?s)TIMESTAMP=.*Timestamp=.*-z "\$TIMESTAMP"`).MatchString(run) ||
+			!regexp.MustCompile(`(?i)grep -qi ['"]?\^none\$`).MatchString(run) {
+			t.Errorf("darwin job %q must reject an empty or none secure timestamp", job.name)
 		}
 	}
 }


### PR DESCRIPTION
## Intent

Phase 1: Developer ID sign every official no-mistakes macOS release artifact so macOS permission grants survive 'no-mistakes update'. Today darwin/arm64 ships only ad-hoc linker-signed and darwin/amd64 unsigned, so the code identity (a content-based cdhash designated requirement) changes on every build/update and macOS re-prompts for every permission. Fix: sign both darwin arches on a macOS runner with one Developer ID Application identity, a FIXED --identifier com.kunchenguid.no-mistakes (Team ID 9T2J7MNUP9), hardened runtime, secure timestamp, and NO entitlements, then strictly verify before archiving/checksums.

Approved, deliberate decisions (not mistakes): (1) reuse Hi Bit's existing Developer ID Application cert and account; (2) the identifier com.kunchenguid.no-mistakes and Team ID 9T2J7MNUP9 are PERMANENT and must never change - they are the invariant of the identity-based requirement that lets grants survive updates. (3) A SEPARATE build-darwin job on macos-latest is used (rather than a per-leg runner inside the existing matrix) specifically so the release-signing GitHub environment and its cert secrets are scoped to only the darwin signing job; the certificate is the base64 CSC_LINK secret unlocked by CSC_KEY_PASSWORD, imported into an ephemeral keychain locked with a RUNTIME-GENERATED password (openssl rand), and the keychain is torn down on success and failure. No other job may reference those secrets. (4) The verify gate fails closed on missing/ambiguous signature, non-Developer-ID/ad-hoc, wrong Team ID, non-permanent identifier, content-based (cdhash) requirement, missing hardened runtime or timestamp, or wrong architecture; identity discovery fails closed unless exactly one Developer ID Application identity is found. The subject.OU grep is intentionally quote-tolerant because the digit-leading Team ID is quoted by codesign but a version quirk must not false-fail a valid release. (5) Signing happens BEFORE tarball creation and checksum generation so the tarball and its SHA-256 both cover the signed binary.

Deliberately preserved / unchanged: Linux and Windows release paths (still ubuntu, unchanged steps), the per-architecture tarball names, installer/updater asset selection, the checksums.txt contract, release-please behavior, prerelease finalization, and the held stable release PR #449. Deliberately OUT OF SCOPE for this phase (intentional omissions, not gaps): notarization, stapling, a PKG, Homebrew, and universal binaries.

Testing: deterministic static tests live at the repo root in package main (workflow_release_signing_test.go) to MATCH the existing workflow_*_test.go convention, not a new internal package; they pin both arches signed, secret scoping to the darwin job, sign-before-archive ordering, fail-closed identity verification, and installer/updater artifact compatibility, and they fail on the pre-signing workflow (the reproduction). Docs: the permanent-identifier invariant and signing contract are recorded in the 'macOS Release Signing' section of AGENTS.md (CLAUDE.md is a symlink to it), pointing to release.yml and the tests, with no secret values.

Captain constraints for THIS PR: CSC_LINK is intentionally NOT set yet - the environment secret is required only for the first signed release, not for reviewing this PR; a separate gh-axi parity fix will add safe stdin-only environment-secret support, after which CSC_LINK will be set and the release proof performed. The workflow fails closed (refuses to publish) if the secret is absent, which is the desired behavior. Do NOT publish a release in this task and do not weaken tests. The already-published v1.35.1-beta.1 remains unchanged and unsigned.

## What Changed

- Build and Developer ID sign both macOS release architectures in a dedicated, environment-gated macOS job before archiving and checksumming.
- Fail releases closed unless the signature has the permanent identifier and Team ID, hardened runtime, secure timestamp, identity-based requirement, and expected architecture.
- Add static workflow contract tests and documentation covering secret isolation, ephemeral keychain cleanup, artifact compatibility, and the permanent signing identity.

## Risk Assessment

✅ Low: The follow-up correctly makes timestamp verification fail closed for both empty and case-insensitive `none` values, strengthens the static contract test, and introduces no additional material risks.

## Testing

The race-test baseline and focused release-workflow tests passed. A realistic packaging exercise preserved both macOS artifact names and architectures while reproducing the unsigned amd64 and ad-hoc arm64 inputs that the new gate rejects. Actual Developer ID signing was intentionally not exercised because CSC_LINK is not configured and publishing a release is out of scope for this PR.

- Evidence: [macOS release signing verification](https://github.com/kunchenguid/no-mistakes/blob/776ee3ffe52d8fde0da8de6cdecf4bb8f9533ed3/.no-mistakes/evidence/fm/nm-macos-signing-s8/macos-release-signing-verification.md)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `.github/workflows/release.yml:170` - The required verify gate must fail closed on a missing secure timestamp, but `grep -q &#39;Timestamp=&#39;` also accepts `Timestamp=none`. Replace this with a check that explicitly rejects `Timestamp=none` and requires a non-empty RFC-3161 timestamp. This contradicts the criterion: &#34;The verify gate fails closed on ... missing hardened runtime or timestamp.&#34;

🔧 Fix: Reject missing macOS signing timestamps
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`
- <code>Baseline already completed: `go test -race ./...`</code>
- `go test . -run '^TestReleaseWorkflow' -count=1 -v`
- <code>Cross-built `darwin/amd64` and `darwin/arm64`, created release-shaped tarballs, listed their contents, and inspected their Mach-O architecture and pre-signing `codesign` state</code>
- <code>Removed transient binaries and tarballs from `.tmp-release-evidence` after capturing the evidence</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
