### PR TITLE
feat(agent): add Hermes as native agent backend

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -710,8 +710,10 @@ func NewWithOptions(name types.AgentName, bin string, extraArgs []string, opts O
 		return &piAgent{bin: bin, extraArgs: extraArgs}, nil
 	case types.AgentCopilot:
 		return &copilotAgent{bin: bin, extraArgs: extraArgs}, nil
+	case types.AgentHermes:
+		return &hermesAgent{bin: bin, extraArgs: extraArgs}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, copilot, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
+		return nil, fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, copilot, hermes, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
 	}
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -25,6 +25,7 @@ func TestNew_KnownAgents(t *testing.T) {
 		{name: "opencode", agent: types.AgentOpenCode, bin: "opencode", wantName: "opencode"},
 		{name: "pi", agent: types.AgentPi, bin: "pi", wantName: "pi"},
 		{name: "copilot", agent: types.AgentCopilot, bin: "copilot", wantName: "copilot"},
+		{name: "hermes", agent: types.AgentHermes, bin: "hermes", wantName: "hermes"},
 	}
 
 	for _, tt := range tests {

--- a/internal/agent/hermes.go
+++ b/internal/agent/hermes.go
@@ -1,0 +1,189 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/kunchenguid/no-mistakes/internal/shellenv"
+)
+
+// hermesAgent spawns the Hermes CLI for each invocation. Hermes runs
+// non-interactively with `hermes -z <prompt> --yolo`, printing only the final
+// response text to stdout. The lifecycle is one process per Run, no managed
+// server, no JSONL event stream — Hermes emits plain text, so parsing is a
+// single stdout read rather than event-by-event dispatch.
+type hermesAgent struct {
+	bin       string
+	extraArgs []string
+}
+
+func (a *hermesAgent) Name() string { return "hermes" }
+
+func (a *hermesAgent) ReportsAgentAttempts() bool { return true }
+
+func (a *hermesAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
+	return runWithRetry(ctx, "hermes", opts, claudeMaxRetries, classifyTransient, nil, func() (*Result, error) {
+		return a.runOnce(ctx, opts)
+	})
+}
+
+func (a *hermesAgent) Close() error { return nil }
+
+func (a *hermesAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
+	prompt := buildHermesPrompt(opts.Prompt, opts.JSONSchema)
+	args := a.buildArgs(prompt)
+	cmd := exec.CommandContext(ctx, a.bin, args...)
+	cmd.Dir = opts.CWD
+	cmd.Stdin = nil
+	cmd.Env = gitSafeEnv(opts.CWD)
+	shellenv.ConfigureShellCommand(cmd)
+
+	started, err := startNativeAgentCommand(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("hermes start: %w", err)
+	}
+	defer started.closePipes()
+	pid := started.pid()
+	emitAgentStarted(opts, "hermes", pid)
+
+	// Hermes prints plain text to stdout. We read it fully rather than
+	// streaming JSONL events like codex/copilot/pi. If an OnChunk callback is
+	// registered, forward the captured text after the run completes so the
+	// TUI/log pipeline still records the output.
+	var stdoutBuf bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := started.stdout.Read(buf)
+			if n > 0 {
+				stdoutBuf.Write(buf[:n])
+			}
+			if readErr != nil {
+				return
+			}
+		}
+	}()
+
+	var stderrBuf []byte
+	stderrDone := make(chan struct{})
+	go func() {
+		defer close(stderrDone)
+		// Read stderr in chunks; nativeAgentPipe.Close() ends this.
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := started.stderr.Read(buf)
+			if n > 0 {
+				stderrBuf = append(stderrBuf, buf[:n]...)
+			}
+			if readErr != nil {
+				return
+			}
+		}
+	}()
+
+	waitErr := started.wait()
+	<-done
+	<-stderrDone
+
+	text := stdoutBuf.String()
+	if opts.OnChunk != nil && text != "" {
+		emitHermesChunks(opts.OnChunk, text)
+	}
+
+	if waitErr != nil {
+		stderr := strings.TrimSpace(string(stderrBuf))
+		var retErr error
+		if stderr != "" {
+			retErr = fmt.Errorf("hermes exited: %w: %s", waitErr, stderr)
+		} else {
+			retErr = fmt.Errorf("hermes exited: %w", waitErr)
+		}
+		emitAgentExited(opts, "hermes", pid, retErr)
+		return nil, retErr
+	}
+
+	res, err := finalizeTextResult("hermes", text, opts.JSONSchema, TokenUsage{})
+	emitAgentExited(opts, "hermes", pid, err)
+	return res, err
+}
+
+// buildArgs constructs the Hermes CLI arguments. User-supplied extraArgs
+// (from agent_args_override) are inserted ahead of the managed flags so user
+// choices (e.g. --model, --provider) win over no-mistakes' defaults.
+//
+// --ignore-rules is always added: no-mistakes needs Hermes as a clean-slate
+// code agent, not the user's full SOUL.md/router/skills personality. Without
+// it, Hermes may route a code-review prompt to a weather skill or delegation
+// profile and return non-JSON output that fails schema parsing.
+//
+// --ignore-user-config is NOT added because it also suppresses provider/model
+// configuration and credential resolution, causing Hermes to fail with "No
+// inference provider configured" or auth errors. --ignore-rules alone is
+// sufficient to suppress SOUL.md/AGENTS.md routing without breaking auth.
+func (a *hermesAgent) buildArgs(prompt string) []string {
+	args := make([]string, 0, len(a.extraArgs)+5)
+	args = append(args, a.extraArgs...)
+	args = append(args,
+		"-z", prompt,
+		"--ignore-rules",
+	)
+	if !hermesUserSetApproval(a.extraArgs) {
+		args = append(args, "--yolo")
+	}
+	return args
+}
+
+// hermesUserSetApproval reports whether extraArgs already grant auto-approval,
+// in which case buildArgs skips its default --yolo.
+func hermesUserSetApproval(extraArgs []string) bool {
+	for _, arg := range extraArgs {
+		switch {
+		case arg == "--yolo":
+			return true
+		case arg == "--safe-mode":
+			return true
+		case strings.HasPrefix(arg, "--safe-mode="):
+			return true
+		}
+	}
+	return false
+}
+
+// buildHermesPrompt appends a JSON-output contract to the user prompt when a
+// schema is provided. The Hermes CLI has no structured-output flag, so we
+// inline the schema in the prompt the same way pi, copilot, and rovodev do,
+// then parse the final text with finalizeTextResult.
+func buildHermesPrompt(prompt string, schema json.RawMessage) string {
+	if len(schema) == 0 {
+		return prompt
+	}
+	pretty, err := json.MarshalIndent(json.RawMessage(schema), "", "  ")
+	if err != nil {
+		pretty = []byte(schema)
+	}
+	return prompt + "\n\n## no-mistakes final output contract\n\n" +
+		"When the task is complete, your final response must be only valid JSON matching this JSON Schema. " +
+		"Do not wrap it in Markdown fences. Do not include prose before or after the JSON object.\n\n" +
+		string(pretty)
+}
+
+// emitHermesChunks forwards the captured plain-text output to the streaming
+// callback. Since Hermes does not emit incremental events, the text arrives as
+// a single block after process exit; we deliver it in bounded chunks so very
+// large outputs do not produce one giant callback payload.
+func emitHermesChunks(onChunk func(string), text string) {
+	const chunkSize = 8192
+	for len(text) > chunkSize {
+		onChunk(text[:chunkSize])
+		text = text[chunkSize:]
+	}
+	if text != "" {
+		onChunk(text)
+	}
+}

--- a/internal/agent/hermes_test.go
+++ b/internal/agent/hermes_test.go
@@ -1,0 +1,137 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestHermesAgent_BuildArgs(t *testing.T) {
+	ha := &hermesAgent{bin: "hermes"}
+	args := ha.buildArgs("review the diff")
+
+	expected := []string{
+		"-z", "review the diff",
+		"--ignore-rules",
+		"--yolo",
+	}
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("arg[%d]: expected %q, got %q", i, want, args[i])
+		}
+	}
+}
+
+func TestHermesAgent_BuildArgs_ExtraArgsFirst(t *testing.T) {
+	ha := &hermesAgent{bin: "hermes", extraArgs: []string{"--model", "glm-5.2"}}
+	args := ha.buildArgs("fix it")
+
+	expected := []string{
+		"--model", "glm-5.2",
+		"-z", "fix it",
+		"--ignore-rules",
+		"--yolo",
+	}
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("arg[%d]: expected %q, got %q", i, want, args[i])
+		}
+	}
+}
+
+func TestHermesAgent_BuildArgs_UserYoloSuppressesDefault(t *testing.T) {
+	// Each case verifies that the managed --yolo is not duplicated when the
+	// user already provided an approval-related flag. expectedYolo is the
+	// total number of --yolo occurrences in the final argv.
+	tests := []struct {
+		name         string
+		extra        []string
+		expectedYolo int
+	}{
+		{"yolo", []string{"--yolo"}, 1},           // user's own, managed default suppressed
+		{"safe-mode", []string{"--safe-mode"}, 0}, // suppresses default, no --yolo at all
+		{"safe-mode-eq", []string{"--safe-mode=true"}, 0},
+		{"model-only", []string{"--model", "glm-5.2"}, 1}, // managed default added
+		{"empty", []string{}, 1},                          // managed default added
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ha := &hermesAgent{bin: "hermes", extraArgs: tt.extra}
+			args := ha.buildArgs("p")
+
+			count := 0
+			for _, a := range args {
+				if a == "--yolo" {
+					count++
+				}
+			}
+			if count != tt.expectedYolo {
+				t.Errorf("expected %d --yolo occurrence(s), got %d in %v", tt.expectedYolo, count, args)
+			}
+		})
+	}
+}
+
+func TestHermesAgent_Name(t *testing.T) {
+	ha := &hermesAgent{bin: "hermes"}
+	if ha.Name() != "hermes" {
+		t.Errorf("Name() = %q, want %q", ha.Name(), "hermes")
+	}
+}
+
+func TestBuildHermesPrompt_NoSchema(t *testing.T) {
+	got := buildHermesPrompt("do the thing", nil)
+	if got != "do the thing" {
+		t.Errorf("expected unchanged prompt, got %q", got)
+	}
+}
+
+func TestBuildHermesPrompt_WithSchema(t *testing.T) {
+	schema := json.RawMessage(`{"type":"object","properties":{"ok":{"type":"boolean"}}}`)
+	got := buildHermesPrompt("review", schema)
+	if got == "review" {
+		t.Fatal("expected prompt to be extended with schema contract")
+	}
+	if !contains(got, "JSON Schema") {
+		t.Errorf("expected schema contract text in prompt")
+	}
+	if !contains(got, `"type":"object"`) && !contains(got, `"type": "object"`) {
+		t.Errorf("expected schema JSON in prompt")
+	}
+}
+
+func TestEmitHermesChunks(t *testing.T) {
+	var collected []string
+	onChunk := func(s string) { collected = append(collected, s) }
+
+	// Exactly one chunk-size boundary
+	emitHermesChunks(onChunk, "hello world")
+	if len(collected) != 1 || collected[0] != "hello world" {
+		t.Fatalf("expected single chunk %q, got %v", "hello world", collected)
+	}
+
+	// Empty string produces no callbacks
+	collected = nil
+	emitHermesChunks(onChunk, "")
+	if len(collected) != 0 {
+		t.Fatalf("expected no chunks for empty string, got %v", collected)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (indexOf(s, substr) >= 0)
+}
+
+func indexOf(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -108,6 +108,7 @@ func newDoctorCmd() *cobra.Command {
 					{"opencode", "opencode"},
 					{"pi", "pi"},
 					{"copilot", "copilot"},
+					{"hermes", "hermes"},
 					{"acpx", "acpx"},
 				}
 				fmt.Fprintln(w)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -295,7 +295,7 @@ const defaultConfigYAML = `# no-mistakes global configuration
 
 # Agent to use for code generation. This may also be an ordered fallback list,
 # for example: agent: [codex, claude]
-# Options: auto, claude, codex, rovodev, opencode, pi, copilot, acp:<target>
+# Options: auto, claude, codex, rovodev, opencode, pi, copilot, hermes, acp:<target>
 # "auto" detects the first available native agent on your system
 # Use acp:<target> to run an optional user-installed acpx target, for example acp:gemini
 agent: auto
@@ -391,6 +391,7 @@ var defaultBinary = map[types.AgentName]string{
 	types.AgentOpenCode: "opencode",
 	types.AgentPi:       "pi",
 	types.AgentCopilot:  "copilot",
+	types.AgentHermes:   "hermes",
 }
 
 // agentProbeOrder is the priority order for auto-detecting agents.
@@ -401,6 +402,7 @@ var agentProbeOrder = []types.AgentName{
 	types.AgentRovoDev,
 	types.AgentPi,
 	types.AgentCopilot,
+	types.AgentHermes,
 }
 
 func isACPAgent(name types.AgentName) bool {
@@ -568,7 +570,7 @@ func (c *Config) resolveConfiguredAgent(ctx context.Context, name types.AgentNam
 		return resolved, err == nil, "auto", err
 	}
 	if _, ok := defaultBinary[name]; !ok && !isACPAgent(name) {
-		return "", false, string(name), fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, copilot, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
+		return "", false, string(name), fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, copilot, hermes, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
 	}
 	bin := c.AgentPathFor(name)
 	resolvedBin, err := lookPath(bin)
@@ -637,6 +639,7 @@ var agentArgsOverrideAgents = map[string]bool{
 	string(types.AgentOpenCode): true,
 	string(types.AgentPi):       true,
 	string(types.AgentCopilot):  true,
+	string(types.AgentHermes):   true,
 }
 
 // reservedAgentArgs lists flags that no-mistakes manages internally and that
@@ -689,6 +692,12 @@ var reservedAgentArgs = map[string]map[string]bool{
 		"--output-format": true,
 		"--no-color":      true,
 	},
+	string(types.AgentHermes): {
+		"-z":             true,
+		"--oneshot":      true,
+		"--yolo":         true,
+		"--ignore-rules": true,
+	},
 }
 
 // validateAgentArgsOverride ensures each agent key is a known agent name and
@@ -697,7 +706,7 @@ var reservedAgentArgs = map[string]map[string]bool{
 func validateAgentArgsOverride(override map[string][]string) error {
 	for name, args := range override {
 		if !agentArgsOverrideAgents[name] {
-			return fmt.Errorf("invalid agent name in agent_args_override: %q (valid: claude, codex, rovodev, opencode, pi, copilot)", name)
+			return fmt.Errorf("invalid agent name in agent_args_override: %q (valid: claude, codex, rovodev, opencode, pi, copilot, hermes)", name)
 		}
 		reserved := reservedAgentArgs[name]
 		for i, arg := range args {

--- a/internal/config/config_agent_test.go
+++ b/internal/config/config_agent_test.go
@@ -313,7 +313,7 @@ func TestResolveAgent_AutoSkipsRovoDevWithoutSubcommand(t *testing.T) {
 
 	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
 		switch bin {
-		case "claude", "codex", "opencode", "pi", "copilot":
+		case "claude", "codex", "opencode", "pi", "copilot", "hermes":
 			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
 		case "acli":
 			return "/usr/bin/acli", nil

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -140,4 +140,5 @@ const (
 	AgentOpenCode AgentName = "opencode"
 	AgentPi       AgentName = "pi"
 	AgentCopilot  AgentName = "copilot"
+	AgentHermes   AgentName = "hermes"
 )


### PR DESCRIPTION
## What does this PR do?

Adds [Hermes Agent](https://hermes-agent.nousresearch.com) as a first-class native agent backend in no-mistakes, alongside the existing claude, codex, copilot, opencode, pi, and rovodev agents.

Hermes runs non-interactively via `hermes -z <prompt> --yolo`, printing only the final response text to stdout. This makes it the simplest agent adapter in the codebase — no JSONL event stream to parse, just plain text in/out.

## Why Hermes?

Hermes is a personal AI agent with tool-calling, memory, skills, and multi-provider support. Adding it as a no-mistakes agent lets users who already run Hermes use it as their code-review/test/lint backend without needing claude, codex, or copilot installed separately.

## Managed flags

```
hermes -z <prompt> --ignore-rules --yolo
```

- `-z` / `--oneshot`: one-shot mode, print only the final response text
- `--ignore-rules`: suppress SOUL.md/AGENTS.md routing so Hermes acts as a pure code agent (not the user's full personality with weather routing, delegation profiles, etc.)
- `--yolo`: bypass approval prompts (suppressible via `--safe-mode` in `agent_args_override`)

```diff
- agent: auto
+ agent: hermes
```

## Structured output

Hermes has no `--output-schema` flag, so JSON schemas are inlined into the prompt via `buildHermesPrompt` (same pattern as pi, copilot, and rovodev) and the final text is parsed by `finalizeTextResult`.

## Changes

| File | Change |
|------|--------|
| `internal/types/types.go` | Add `AgentHermes` constant |
| `internal/agent/hermes.go` | **New** — full `Agent` interface impl (178 lines) |
| `internal/agent/agent.go` | Add case in `NewWithOptions` switch, update error messages |
| `internal/config/config.go` | Add hermes to `defaultBinary`, `agentProbeOrder`, `agentArgsOverrideAgents`, `reservedAgentArgs`, config comment, 3 error messages |
| `internal/cli/doctor.go` | Add hermes to the agent binary detection list |
| Tests | `hermes_test.go` (new), `agent_test.go` table case, `config_agent_test.go` probe list |

## Design notes

### Why `--ignore-rules` and not `--ignore-user-config`?

`--ignore-user-config` also suppresses provider/model configuration and credential resolution. During live testing, Hermes with `--ignore-user-config` failed with `No inference provider configured` because it couldn't read the provider/model from config.yaml or resolve API keys from `.env`. `--ignore-rules` alone is sufficient to prevent skill/AGENTS.md routing without breaking authentication.

### Lifecycle

Uses the same `startNativeAgentCommand` + `emitAgentStarted`/`emitAgentExited` lifecycle emission pattern as copilot and codex. Implements `ReportsAgentAttempts() bool { return true }`.

## Verification

- `make fmt` — clean
- `make lint` (`go vet ./...` + skill-check) — passed
- `make test` (`go test -race ./...`) — 30 packages, 0 failures
- `make build` — passed
- Live E2E: `no-mistakes axi run --intent 'test hermes agent backend' --yes` → `outcome: passed`, all steps completed (intent, rebase, review, test, document, lint, push)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🤖 Adds a new agent backend

## Checklist

- [x] Code follows the project's style (gofmt, go vet)
- [x] Self-review completed
- [x] Tests added and passing
- [x] Documentation updated (agent help text, error messages, config comment)
- [x] Live-tested end-to-end with `axi run`