### PR TITLE
feat(agent): add Hermes as native agent backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 Push to `no-mistakes` instead of `origin`, and it spins up a disposable worktree, runs an AI-driven validation pipeline, forwards the branch to the configured push target only after every check passes, and opens a clean PR automatically.
 
 - **Non-blocking** - the pipeline runs in an isolated worktree without disrupting your work.
-- **Agent-agnostic** - `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, or `acp:<target>` via `acpx`, with ordered fallbacks; every gate requires a runnable configured pipeline agent.
+- **Agent-agnostic** - `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `hermes`, or `acp:<target>` via `acpx`, with ordered fallbacks; every gate requires a runnable configured pipeline agent.
 - **Agent-native** - `/no-mistakes` lets your coding agent do a task and gate it, or gate existing committed work: it runs the pipeline, has the pipeline apply safe fixes, and escalates the rest to you.
 - **Human stays in charge** - auto-fix or review findings, your call.
 - **Clean PRs by default** - push, open PR, watch CI, and auto-fix failures in one shot.

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -45,6 +45,7 @@ By default that directory is temporary and local to the machine; repos can opt i
 | OpenCode | `opencode` | Persistent HTTP server, SSE streaming |
 | Pi | `pi` | Subprocess per invocation, JSONL events |
 | Copilot | `copilot` | Subprocess per invocation, JSONL events |
+| Hermes | `hermes` | Subprocess per invocation, plain-text output |
 | ACP target | `acpx` | Optional user-installed ACP bridge |
 
 ## Runner requirements
@@ -274,6 +275,17 @@ Any `agent_args_override.copilot` flags are inserted before no-mistakes' managed
 Reads JSONL events from stdout, streaming incremental `assistant.message_delta` text to the TUI and capturing the final `assistant.message` content.
 The Copilot CLI has no output-schema flag, so when structured output is requested no-mistakes injects the JSON schema into the prompt and validates the final text response with the same JSON fence and bare-object fallback used by Pi and Rovo Dev.
 
+## Hermes
+
+Spawns a `hermes` subprocess for each invocation with `-z <prompt> --yolo`.
+It also adds `--ignore-rules` so Hermes runs as a clean-slate code agent rather than loading your full `SOUL.md` router, skills, and delegation profiles; without it, a code-review prompt can route to an unrelated skill and return non-JSON output that fails schema parsing.
+`--ignore-user-config` is intentionally not added, because it also suppresses provider, model, and credential resolution and would make Hermes fail to authenticate.
+Any `agent_args_override.hermes` flags, such as `--model` or `--provider`, are inserted ahead of no-mistakes' managed flags, so your choices take precedence.
+The default `--yolo` is suppressed when you already supply `--yolo` or `--safe-mode`.
+Hermes prints plain text to stdout instead of a JSONL event stream, so no-mistakes reads the full response after the process exits.
+The Hermes CLI has no structured-output flag, so when structured output is requested no-mistakes injects the JSON schema into the prompt and validates the final text response with the same JSON fence and bare-object fallback used by Pi, Copilot, and Rovo Dev.
+Hermes has no durable session capability, so every review-loop turn runs cold with no reviewer/fixer session reuse.
+
 ## ACP via acpx
 
 ACP support is optional and requires a separately installed `acpx` binary.
@@ -307,6 +319,7 @@ $ no-mistakes doctor
   – opencode (not found)
   – pi (not found)
   – copilot (not found)
+  – hermes (not found)
   – acpx (not found)
   ✓ gate validation claude is runnable
 ```

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -307,7 +307,7 @@ Checks:
 - Data directory (`~/.no-mistakes/`)
 - SQLite database
 - Daemon status
-- Agent runners: native binaries `claude`, `codex`, `acli`, `opencode`, `pi`, and `copilot`, plus the optional ACP bridge `acpx`
+- Agent runners: native binaries `claude`, `codex`, `acli`, `opencode`, `pi`, `copilot`, and `hermes`, plus the optional ACP bridge `acpx`
 - Effective global agent configuration, reported as `gate validation`; an unavailable configured runner is a failed check because the gate cannot validate without it
 
 Uses indicators: `✓` (available), `–` (not found, optional), `✗` (problem detected).

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -22,6 +22,7 @@ agent_path_override:
   opencode: /usr/local/bin/opencode
   pi: /usr/local/bin/pi
   copilot: /usr/local/bin/copilot
+  hermes: /usr/local/bin/hermes
 
 agent_args_override:
   codex:
@@ -68,13 +69,13 @@ test:
 
 Default agent for all repos and setup-wizard suggestions. Can be overridden per-repo.
 
-|         |                                                                                   |
-| ------- | --------------------------------------------------------------------------------- |
-| Type    | `string` or `string[]`                                                            |
-| Values  | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `acp:<target>` |
-| Default | `auto`                                                                            |
+|         |                                                                                             |
+| ------- | ------------------------------------------------------------------------------------------- |
+| Type    | `string` or `string[]`                                                                      |
+| Values  | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `hermes`, `acp:<target>` |
+| Default | `auto`                                                                                      |
 
-`auto` resolves to the first supported native agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, `pi`, then `copilot`.
+`auto` resolves to the first supported native agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, `pi`, `copilot`, then `hermes`.
 `acp:<target>` uses the user-installed `acpx` binary to run an ACP target, for example `acp:gemini`.
 ACP agents are opt-in and are not considered by `agent: auto`.
 The effective agent configuration must resolve to a runnable runner before a new validation gate starts.
@@ -140,28 +141,30 @@ Default native binary names when no override is set:
 | `opencode` | `opencode` |
 | `pi`       | `pi`       |
 | `copilot`  | `copilot`  |
+| `hermes`   | `hermes`   |
 
 ### agent_args_override
 
 Extra CLI flags to pass to each native agent.
 Use this to set model selection, service tier, reasoning effort, permission mode, or any other flag the underlying agent supports.
 
-|         |                                                           |
-| ------- | --------------------------------------------------------- |
-| Type    | `map[string][]string`                                     |
-| Keys    | `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot` |
-| Default | Empty (no extra flags)                                    |
+|         |                                                                     |
+| ------- | ------------------------------------------------------------------- |
+| Type    | `map[string][]string`                                               |
+| Keys    | `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `hermes` |
+| Default | Empty (no extra flags)                                              |
 
 User-supplied flags are inserted ahead of no-mistakes' managed flags, so your choices usually take precedence. A few flags are reserved because no-mistakes depends on them to communicate with the agent - setting any of these returns a config error on load:
 
-| Agent      | Reserved flags                                                                                              |
-| ---------- | ----------------------------------------------------------------------------------------------------------- |
+| Agent      | Reserved flags                                                                                                                           |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | `claude`   | `-p`, `--print`, `--verbose`, `--output-format`, `--json-schema`, `-r`, `--resume`, `--session-id`, `-c`, `--continue`, `--fork-session` |
-| `codex`    | `exec`, `resume`, `--resume`, `--session`, `--session-id`, `--thread`, `--thread-id`, `--last`, `--json`, `--color` |
-| `rovodev`  | `rovodev`, `serve`, `--disable-session-token`                                                               |
-| `opencode` | `serve`, `--hostname`, `--port`, `--print-logs`                                                             |
-| `pi`       | `--mode`, `--no-session`                                                                                    |
-| `copilot`  | `-p`, `--prompt`, `--output-format`, `--no-color`                                                          |
+| `codex`    | `exec`, `resume`, `--resume`, `--session`, `--session-id`, `--thread`, `--thread-id`, `--last`, `--json`, `--color`                      |
+| `rovodev`  | `rovodev`, `serve`, `--disable-session-token`                                                                                            |
+| `opencode` | `serve`, `--hostname`, `--port`, `--print-logs`                                                                                          |
+| `pi`       | `--mode`, `--no-session`                                                                                                                 |
+| `copilot`  | `-p`, `--prompt`, `--output-format`, `--no-color`                                                                                        |
+| `hermes`   | `-z`, `--oneshot`, `--yolo`, `--ignore-rules`                                                                                            |
 
 For structured `codex` runs, no-mistakes also appends its own `--output-schema <tempfile>` after your overrides. Treat that flag as managed even though config validation does not currently reject it.
 The Claude and Codex session-control forms are reserved so no-mistakes can keep reviewer and fixer conversations role-isolated.

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -59,10 +59,10 @@ Override the default agent for this repo and its setup-wizard suggestions.
 | | |
 |---|---|
 | Type | `string` or `string[]` |
-| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `acp:<target>` |
+| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `hermes`, `acp:<target>` |
 | Default | Inherits from global config |
 
-`auto` resolves to the first supported native agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, `pi`, then `copilot`.
+`auto` resolves to the first supported native agent found on `PATH` in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, `pi`, `copilot`, then `hermes`.
 `acp:<target>` uses the user-installed `acpx` binary configured in global config.
 ACP agents are opt-in and are not considered by `agent: auto`.
 The effective agent configuration must resolve to a runnable runner before a new validation gate starts.

--- a/docs/src/content/docs/start-here/installation.md
+++ b/docs/src/content/docs/start-here/installation.md
@@ -47,7 +47,7 @@ make install
 ## Prerequisites
 
 - **git** - required
-- **One supported agent binary** - `claude`, `codex`, `acli` (Rovo Dev), `opencode`, `pi`, or `copilot`, or a separately installed `acpx` binary for `agent: acp:<target>`
+- **One supported agent binary** - `claude`, `codex`, `acli` (Rovo Dev), `opencode`, `pi`, `copilot`, or `hermes`, or a separately installed `acpx` binary for `agent: acp:<target>`
 - **Optional, for PRs and CI:**
   - `gh` CLI (GitHub)
   - `glab` CLI (GitLab)

--- a/docs/src/content/docs/start-here/introduction.md
+++ b/docs/src/content/docs/start-here/introduction.md
@@ -70,7 +70,7 @@ When a branch passes the gate, it means:
 ## What you get
 
 - A fixed, opinionated pipeline: `intent → rebase → review → test → document → lint → push → pr → ci`. Order is not configurable; what each step runs is.
-- Choice of agent: `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, or `acp:<target>` via `acpx`, with per-repo override and ordered fallbacks; every gate requires a runnable configured pipeline agent.
+- Choice of agent: `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `hermes`, or `acp:<target>` via `acpx`, with per-repo override and ordered fallbacks; every gate requires a runnable configured pipeline agent.
 - A TUI to watch, approve, fix, skip, or abort any step.
 - A `/no-mistakes` agent skill so a coding agent can do a task and gate it, or gate existing committed work, backed by a non-interactive `no-mistakes axi` interface.
 - A setup wizard when you run bare `no-mistakes` with no active run on the current branch - it walks you through creating a branch, committing, and pushing through the gate, then attaches if the daemon registers the new run.

--- a/docs/src/content/docs/start-here/quick-start.md
+++ b/docs/src/content/docs/start-here/quick-start.md
@@ -24,7 +24,7 @@ no-mistakes doctor
 You need:
 
 - `git`
-- One supported agent binary (`claude`, `codex`, `acli` for Rovo Dev, `opencode`, `pi`, or `copilot`), or a separately installed `acpx` binary for `agent: acp:<target>`
+- One supported agent binary (`claude`, `codex`, `acli` for Rovo Dev, `opencode`, `pi`, `copilot`, or `hermes`), or a separately installed `acpx` binary for `agent: acp:<target>`
 - For PRs and CI: `gh` (GitHub), `glab` (GitLab), Bitbucket Cloud credentials, or `az` with the `azure-devops` extension (Azure DevOps)
 
 `no-mistakes doctor` reports whether the configured global runner can start a validation gate.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -752,8 +752,10 @@ func NewWithOptions(name types.AgentName, bin string, extraArgs []string, opts O
 		return &piAgent{bin: bin, extraArgs: extraArgs}, nil
 	case types.AgentCopilot:
 		return &copilotAgent{bin: bin, extraArgs: extraArgs}, nil
+	case types.AgentHermes:
+		return &hermesAgent{bin: bin, extraArgs: extraArgs}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, copilot, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
+		return nil, fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, copilot, hermes, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
 	}
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -25,6 +25,7 @@ func TestNew_KnownAgents(t *testing.T) {
 		{name: "opencode", agent: types.AgentOpenCode, bin: "opencode", wantName: "opencode"},
 		{name: "pi", agent: types.AgentPi, bin: "pi", wantName: "pi"},
 		{name: "copilot", agent: types.AgentCopilot, bin: "copilot", wantName: "copilot"},
+		{name: "hermes", agent: types.AgentHermes, bin: "hermes", wantName: "hermes"},
 	}
 
 	for _, tt := range tests {

--- a/internal/agent/hermes.go
+++ b/internal/agent/hermes.go
@@ -1,0 +1,189 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/kunchenguid/no-mistakes/internal/shellenv"
+)
+
+// hermesAgent spawns the Hermes CLI for each invocation. Hermes runs
+// non-interactively with `hermes -z <prompt> --yolo`, printing only the final
+// response text to stdout. The lifecycle is one process per Run, no managed
+// server, no JSONL event stream — Hermes emits plain text, so parsing is a
+// single stdout read rather than event-by-event dispatch.
+type hermesAgent struct {
+	bin       string
+	extraArgs []string
+}
+
+func (a *hermesAgent) Name() string { return "hermes" }
+
+func (a *hermesAgent) ReportsAgentAttempts() bool { return true }
+
+func (a *hermesAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
+	return runWithRetry(ctx, "hermes", opts, claudeMaxRetries, classifyTransient, nil, func() (*Result, error) {
+		return a.runOnce(ctx, opts)
+	})
+}
+
+func (a *hermesAgent) Close() error { return nil }
+
+func (a *hermesAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
+	prompt := buildHermesPrompt(opts.Prompt, opts.JSONSchema)
+	args := a.buildArgs(prompt)
+	cmd := exec.CommandContext(ctx, a.bin, args...)
+	cmd.Dir = opts.CWD
+	cmd.Stdin = nil
+	cmd.Env = gitSafeEnv(opts.CWD)
+	shellenv.ConfigureShellCommand(cmd)
+
+	started, err := startNativeAgentCommand(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("hermes start: %w", err)
+	}
+	defer started.closePipes()
+	pid := started.pid()
+	emitAgentStarted(opts, "hermes", pid)
+
+	// Hermes prints plain text to stdout. We read it fully rather than
+	// streaming JSONL events like codex/copilot/pi. If an OnChunk callback is
+	// registered, forward the captured text after the run completes so the
+	// TUI/log pipeline still records the output.
+	var stdoutBuf bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := started.stdout.Read(buf)
+			if n > 0 {
+				stdoutBuf.Write(buf[:n])
+			}
+			if readErr != nil {
+				return
+			}
+		}
+	}()
+
+	var stderrBuf []byte
+	stderrDone := make(chan struct{})
+	go func() {
+		defer close(stderrDone)
+		// Read stderr in chunks; nativeAgentPipe.Close() ends this.
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := started.stderr.Read(buf)
+			if n > 0 {
+				stderrBuf = append(stderrBuf, buf[:n]...)
+			}
+			if readErr != nil {
+				return
+			}
+		}
+	}()
+
+	waitErr := started.wait()
+	<-done
+	<-stderrDone
+
+	text := stdoutBuf.String()
+	if opts.OnChunk != nil && text != "" {
+		emitHermesChunks(opts.OnChunk, text)
+	}
+
+	if waitErr != nil {
+		stderr := strings.TrimSpace(string(stderrBuf))
+		var retErr error
+		if stderr != "" {
+			retErr = fmt.Errorf("hermes exited: %w: %s", waitErr, stderr)
+		} else {
+			retErr = fmt.Errorf("hermes exited: %w", waitErr)
+		}
+		emitAgentExited(opts, "hermes", pid, retErr)
+		return nil, retErr
+	}
+
+	res, err := finalizeTextResult("hermes", text, opts.JSONSchema, TokenUsage{})
+	emitAgentExited(opts, "hermes", pid, err)
+	return res, err
+}
+
+// buildArgs constructs the Hermes CLI arguments. User-supplied extraArgs
+// (from agent_args_override) are inserted ahead of the managed flags so user
+// choices (e.g. --model, --provider) win over no-mistakes' defaults.
+//
+// --ignore-rules is always added: no-mistakes needs Hermes as a clean-slate
+// code agent, not the user's full SOUL.md/router/skills personality. Without
+// it, Hermes may route a code-review prompt to a weather skill or delegation
+// profile and return non-JSON output that fails schema parsing.
+//
+// --ignore-user-config is NOT added because it also suppresses provider/model
+// configuration and credential resolution, causing Hermes to fail with "No
+// inference provider configured" or auth errors. --ignore-rules alone is
+// sufficient to suppress SOUL.md/AGENTS.md routing without breaking auth.
+func (a *hermesAgent) buildArgs(prompt string) []string {
+	args := make([]string, 0, len(a.extraArgs)+5)
+	args = append(args, a.extraArgs...)
+	args = append(args,
+		"-z", prompt,
+		"--ignore-rules",
+	)
+	if !hermesUserSetApproval(a.extraArgs) {
+		args = append(args, "--yolo")
+	}
+	return args
+}
+
+// hermesUserSetApproval reports whether extraArgs already grant auto-approval,
+// in which case buildArgs skips its default --yolo.
+func hermesUserSetApproval(extraArgs []string) bool {
+	for _, arg := range extraArgs {
+		switch {
+		case arg == "--yolo":
+			return true
+		case arg == "--safe-mode":
+			return true
+		case strings.HasPrefix(arg, "--safe-mode="):
+			return true
+		}
+	}
+	return false
+}
+
+// buildHermesPrompt appends a JSON-output contract to the user prompt when a
+// schema is provided. The Hermes CLI has no structured-output flag, so we
+// inline the schema in the prompt the same way pi, copilot, and rovodev do,
+// then parse the final text with finalizeTextResult.
+func buildHermesPrompt(prompt string, schema json.RawMessage) string {
+	if len(schema) == 0 {
+		return prompt
+	}
+	pretty, err := json.MarshalIndent(json.RawMessage(schema), "", "  ")
+	if err != nil {
+		pretty = []byte(schema)
+	}
+	return prompt + "\n\n## no-mistakes final output contract\n\n" +
+		"When the task is complete, your final response must be only valid JSON matching this JSON Schema. " +
+		"Do not wrap it in Markdown fences. Do not include prose before or after the JSON object.\n\n" +
+		string(pretty)
+}
+
+// emitHermesChunks forwards the captured plain-text output to the streaming
+// callback. Since Hermes does not emit incremental events, the text arrives as
+// a single block after process exit; we deliver it in bounded chunks so very
+// large outputs do not produce one giant callback payload.
+func emitHermesChunks(onChunk func(string), text string) {
+	const chunkSize = 8192
+	for len(text) > chunkSize {
+		onChunk(text[:chunkSize])
+		text = text[chunkSize:]
+	}
+	if text != "" {
+		onChunk(text)
+	}
+}

--- a/internal/agent/hermes_test.go
+++ b/internal/agent/hermes_test.go
@@ -1,0 +1,137 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestHermesAgent_BuildArgs(t *testing.T) {
+	ha := &hermesAgent{bin: "hermes"}
+	args := ha.buildArgs("review the diff")
+
+	expected := []string{
+		"-z", "review the diff",
+		"--ignore-rules",
+		"--yolo",
+	}
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("arg[%d]: expected %q, got %q", i, want, args[i])
+		}
+	}
+}
+
+func TestHermesAgent_BuildArgs_ExtraArgsFirst(t *testing.T) {
+	ha := &hermesAgent{bin: "hermes", extraArgs: []string{"--model", "glm-5.2"}}
+	args := ha.buildArgs("fix it")
+
+	expected := []string{
+		"--model", "glm-5.2",
+		"-z", "fix it",
+		"--ignore-rules",
+		"--yolo",
+	}
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("arg[%d]: expected %q, got %q", i, want, args[i])
+		}
+	}
+}
+
+func TestHermesAgent_BuildArgs_UserYoloSuppressesDefault(t *testing.T) {
+	// Each case verifies that the managed --yolo is not duplicated when the
+	// user already provided an approval-related flag. expectedYolo is the
+	// total number of --yolo occurrences in the final argv.
+	tests := []struct {
+		name         string
+		extra        []string
+		expectedYolo int
+	}{
+		{"yolo", []string{"--yolo"}, 1},           // user's own, managed default suppressed
+		{"safe-mode", []string{"--safe-mode"}, 0}, // suppresses default, no --yolo at all
+		{"safe-mode-eq", []string{"--safe-mode=true"}, 0},
+		{"model-only", []string{"--model", "glm-5.2"}, 1}, // managed default added
+		{"empty", []string{}, 1},                          // managed default added
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ha := &hermesAgent{bin: "hermes", extraArgs: tt.extra}
+			args := ha.buildArgs("p")
+
+			count := 0
+			for _, a := range args {
+				if a == "--yolo" {
+					count++
+				}
+			}
+			if count != tt.expectedYolo {
+				t.Errorf("expected %d --yolo occurrence(s), got %d in %v", tt.expectedYolo, count, args)
+			}
+		})
+	}
+}
+
+func TestHermesAgent_Name(t *testing.T) {
+	ha := &hermesAgent{bin: "hermes"}
+	if ha.Name() != "hermes" {
+		t.Errorf("Name() = %q, want %q", ha.Name(), "hermes")
+	}
+}
+
+func TestBuildHermesPrompt_NoSchema(t *testing.T) {
+	got := buildHermesPrompt("do the thing", nil)
+	if got != "do the thing" {
+		t.Errorf("expected unchanged prompt, got %q", got)
+	}
+}
+
+func TestBuildHermesPrompt_WithSchema(t *testing.T) {
+	schema := json.RawMessage(`{"type":"object","properties":{"ok":{"type":"boolean"}}}`)
+	got := buildHermesPrompt("review", schema)
+	if got == "review" {
+		t.Fatal("expected prompt to be extended with schema contract")
+	}
+	if !contains(got, "JSON Schema") {
+		t.Errorf("expected schema contract text in prompt")
+	}
+	if !contains(got, `"type":"object"`) && !contains(got, `"type": "object"`) {
+		t.Errorf("expected schema JSON in prompt")
+	}
+}
+
+func TestEmitHermesChunks(t *testing.T) {
+	var collected []string
+	onChunk := func(s string) { collected = append(collected, s) }
+
+	// Exactly one chunk-size boundary
+	emitHermesChunks(onChunk, "hello world")
+	if len(collected) != 1 || collected[0] != "hello world" {
+		t.Fatalf("expected single chunk %q, got %v", "hello world", collected)
+	}
+
+	// Empty string produces no callbacks
+	collected = nil
+	emitHermesChunks(onChunk, "")
+	if len(collected) != 0 {
+		t.Fatalf("expected no chunks for empty string, got %v", collected)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (indexOf(s, substr) >= 0)
+}
+
+func indexOf(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -108,6 +108,7 @@ func newDoctorCmd() *cobra.Command {
 					{"opencode", "opencode"},
 					{"pi", "pi"},
 					{"copilot", "copilot"},
+					{"hermes", "hermes"},
 					{"acpx", "acpx"},
 				}
 				fmt.Fprintln(w)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -295,7 +295,7 @@ const defaultConfigYAML = `# no-mistakes global configuration
 
 # Agent to use for code generation. This may also be an ordered fallback list,
 # for example: agent: [codex, claude]
-# Options: auto, claude, codex, rovodev, opencode, pi, copilot, acp:<target>
+# Options: auto, claude, codex, rovodev, opencode, pi, copilot, hermes, acp:<target>
 # "auto" detects the first available native agent on your system
 # Use acp:<target> to run an optional user-installed acpx target, for example acp:gemini
 agent: auto
@@ -391,6 +391,7 @@ var defaultBinary = map[types.AgentName]string{
 	types.AgentOpenCode: "opencode",
 	types.AgentPi:       "pi",
 	types.AgentCopilot:  "copilot",
+	types.AgentHermes:   "hermes",
 }
 
 // agentProbeOrder is the priority order for auto-detecting agents.
@@ -401,6 +402,7 @@ var agentProbeOrder = []types.AgentName{
 	types.AgentRovoDev,
 	types.AgentPi,
 	types.AgentCopilot,
+	types.AgentHermes,
 }
 
 func isACPAgent(name types.AgentName) bool {
@@ -568,7 +570,7 @@ func (c *Config) resolveConfiguredAgent(ctx context.Context, name types.AgentNam
 		return resolved, err == nil, "auto", err
 	}
 	if _, ok := defaultBinary[name]; !ok && !isACPAgent(name) {
-		return "", false, string(name), fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, copilot, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
+		return "", false, string(name), fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, copilot, hermes, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
 	}
 	bin := c.AgentPathFor(name)
 	resolvedBin, err := lookPath(bin)
@@ -637,6 +639,7 @@ var agentArgsOverrideAgents = map[string]bool{
 	string(types.AgentOpenCode): true,
 	string(types.AgentPi):       true,
 	string(types.AgentCopilot):  true,
+	string(types.AgentHermes):   true,
 }
 
 // reservedAgentArgs lists flags that no-mistakes manages internally and that
@@ -689,6 +692,12 @@ var reservedAgentArgs = map[string]map[string]bool{
 		"--output-format": true,
 		"--no-color":      true,
 	},
+	string(types.AgentHermes): {
+		"-z":             true,
+		"--oneshot":      true,
+		"--yolo":         true,
+		"--ignore-rules": true,
+	},
 }
 
 // validateAgentArgsOverride ensures each agent key is a known agent name and
@@ -697,7 +706,7 @@ var reservedAgentArgs = map[string]map[string]bool{
 func validateAgentArgsOverride(override map[string][]string) error {
 	for name, args := range override {
 		if !agentArgsOverrideAgents[name] {
-			return fmt.Errorf("invalid agent name in agent_args_override: %q (valid: claude, codex, rovodev, opencode, pi, copilot)", name)
+			return fmt.Errorf("invalid agent name in agent_args_override: %q (valid: claude, codex, rovodev, opencode, pi, copilot, hermes)", name)
 		}
 		reserved := reservedAgentArgs[name]
 		for i, arg := range args {

--- a/internal/config/config_agent_test.go
+++ b/internal/config/config_agent_test.go
@@ -313,7 +313,7 @@ func TestResolveAgent_AutoSkipsRovoDevWithoutSubcommand(t *testing.T) {
 
 	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
 		switch bin {
-		case "claude", "codex", "opencode", "pi", "copilot":
+		case "claude", "codex", "opencode", "pi", "copilot", "hermes":
 			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
 		case "acli":
 			return "/usr/bin/acli", nil

--- a/internal/daemon/helpers_test.go
+++ b/internal/daemon/helpers_test.go
@@ -83,6 +83,18 @@ func startTestDaemon(t *testing.T) (*paths.Paths, *db.DB) {
 		time.Sleep(20 * time.Millisecond)
 	}
 
+	// Wait for the daemon to accept IPC connections. On Windows the endpoint
+	// file exists before the serve loop calls Accept, so a caller that
+	// immediately dials (e.g. Stop) races the startup and can fall through to
+	// PID-based shutdown, which refuses to kill the in-process test daemon.
+	readyDeadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(readyDeadline) {
+		if alive, _ := IsRunning(p); alive {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
 	t.Cleanup(func() {
 		// Ensure daemon stops.
 		client, err := ipc.Dial(p.Socket())

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -140,4 +140,5 @@ const (
 	AgentOpenCode AgentName = "opencode"
 	AgentPi       AgentName = "pi"
 	AgentCopilot  AgentName = "copilot"
+	AgentHermes   AgentName = "hermes"
 )


### PR DESCRIPTION
## What Changed

- Add `internal/agent/hermes.go` implementing a native Hermes agent adapter (prompt construction, command invocation, stdout/stderr capture), with unit tests in `internal/agent/hermes_test.go`.
- Register the `hermes` agent type across the adapter registry (`internal/agent/agent.go`), config defaults and validation (`internal/config/config.go`), `internal/types/types.go`, and the `doctor` health check.
- Document the Hermes backend across the docs site (agents guide, global-config, repo-config, CLI reference, installation/introduction/quick-start) and the README agent list.

## Risk Assessment

✅ Low: The change is a well-bounded new adapter that faithfully follows the established copilot/pi adapter patterns (startNativeAgentCommand, runWithRetry+classifyTransient, schema-in-prompt via finalizeTextResult, reservedAgentArgs wiring); all findings are minor non-functional simplifications with no correctness, security, or performance concerns.

## Testing

Completed 1 recorded test check.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ℹ️ `internal/agent/hermes.go:57` - The manual 4096-byte chunk read loops for stdout (lines 57-71) and stderr (lines 73-88) reinvent io.ReadAll/io.Copy. The sibling copilot adapter (copilot.go:57-60) and pi adapter (pi.go:64-68) capture stderr with io.ReadAll + sync.WaitGroup in ~4 lines each. The two custom goroutines + two unbuffered done channels can be collapsed to the same io.ReadAll/WaitGroup pattern, removing ~15 lines of boilerplate and making the adapter consistent with its peers. There is no functional difference: both approaches block until EOF then surface the full buffer, and the happens-before edges (channel close vs WaitGroup.Done) are equivalent.
- ℹ️ `internal/agent/hermes_test.go:126` - The package-level helpers contains() and indexOf() (lines 126-135) reimplement strings.Contains and strings.Index. Every other test file in this package imports and uses strings.Contains directly (50+ call sites across codex_test.go, pi_test.go, agent_test.go, etc.). These two helpers add an inconsistent local dialect for no benefit and can be replaced with strings.Contains calls in TestBuildHermesPrompt_WithSchema.
- ℹ️ `internal/agent/session_test.go:13` - TestSupportsSessionResume_PerAdapter is the exhaustive per-adapter pin that AGENTS.md cites as the regression guard for session-fidelity (&#39;every other adapter must run cold so the pipeline&#39;s fallback path records the cold invocation instead of assuming reuse&#39;). The new hermes adapter is absent from the table. hermesAgent does not implement SessionResumer, so SupportsSessionResume correctly returns false at runtime, but the pin test no longer guards that invariant for hermes — a future change adding a SupportsSessionResume method to hermesAgent would not be caught. Adding {&#34;hermes&#34;, &amp;hermesAgent{bin: &#34;hermes&#34;}, false} closes the gap.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
