### PR TITLE
fix(pipeline): prevent clobbered HEAD from shipping unreviewed fixes

### DIFF
--- a/.no-mistakes/evidence/fm/nm-fixer-dropped-instructions-forensic-f6/head-continuity-regression.md
+++ b/.no-mistakes/evidence/fm/nm-fixer-dropped-instructions-forensic-f6/head-continuity-regression.md
@@ -1,0 +1,32 @@
+# HEAD continuity incident reproduction
+
+The focused race-enabled regression exercises the user-visible failure boundary at the pipeline commit operation.
+It first commits the reviewed fix, moves the live worktree HEAD to a divergent sibling commit that omits that fix, and then attempts the document-step commit.
+The operation refuses the divergent history, leaves the live HEAD at the clobber commit without layering a document commit on it, and preserves the recorded reviewed-head anchor.
+
+Command:
+
+```text
+go test -race -v ./internal/pipeline/steps -run 'TestCommitAgentFixes_(RefusesToCommitOnOutOfBandResetHead|RefusesOnBackwardReset|RefusesResetDuringCommit|AllowsForwardAgentCommit)|TestAssertPipelineHeadContinuity_AnchorIsRecordedReviewedHead'
+```
+
+Observed output:
+
+```text
+=== RUN   TestCommitAgentFixes_RefusesToCommitOnOutOfBandResetHead
+    headcontinuity_repro_test.go:91: guard refused divergent clobber: reviewed fix at 18ab4d2b protected
+--- PASS: TestCommitAgentFixes_RefusesToCommitOnOutOfBandResetHead (0.31s)
+=== RUN   TestCommitAgentFixes_RefusesOnBackwardReset
+--- PASS: TestCommitAgentFixes_RefusesOnBackwardReset (0.16s)
+=== RUN   TestCommitAgentFixes_RefusesResetDuringCommit
+--- PASS: TestCommitAgentFixes_RefusesResetDuringCommit (0.41s)
+=== RUN   TestCommitAgentFixes_AllowsForwardAgentCommit
+--- PASS: TestCommitAgentFixes_AllowsForwardAgentCommit (0.19s)
+=== RUN   TestAssertPipelineHeadContinuity_AnchorIsRecordedReviewedHead
+--- PASS: TestAssertPipelineHeadContinuity_AnchorIsRecordedReviewedHead (0.12s)
+PASS
+ok  github.com/kunchenguid/no-mistakes/internal/pipeline/steps  2.823s
+```
+
+This also demonstrates that backward resets and resets racing the commit are refused, while a legitimate forward agent commit remains accepted.
+The anchor-specific check confirms that restoring the live worktree to the recorded reviewed SHA makes the same guard pass.

--- a/docs/src/content/docs/concepts/auto-fix.md
+++ b/docs/src/content/docs/concepts/auto-fix.md
@@ -81,6 +81,9 @@ Yolo and AXI `--yes` approve that fix review automatically after their one fix r
 
 Each auto-fix cycle commits its changes with a descriptive message. The combined document-and-lint housekeeping pass runs in the Document step, so its documentation and safe lint fixes use the Document prefix; configured-command lint fixes use the Lint prefix:
 
+Before a step-specific fix commit, the pipeline verifies that the live worktree HEAD still descends from the head recorded after its previous commit.
+It allows a legitimate forward commit made by an agent, but aborts the run if an out-of-band backward or divergent reset would drop the reviewed history.
+
 | Step | Commit prefix |
 |---|---|
 | Rebase | `no-mistakes(rebase): <summary>` |

--- a/internal/pipeline/steps/common_fix.go
+++ b/internal/pipeline/steps/common_fix.go
@@ -133,6 +133,9 @@ func commitAgentFixes(sctx *pipeline.StepContext, stepName types.StepName, summa
 	if err != nil {
 		return fmt.Errorf("resolve head after %s commit: %w", stepName, err)
 	}
+	if err := assertPipelineHeadContinuity(sctx, stepName); err != nil {
+		return err
+	}
 	ref := normalizedBranchRef(sctx.Run.Branch)
 	if _, err := git.Run(ctx, sctx.WorkDir, "update-ref", ref, headSHA); err != nil {
 		return fmt.Errorf("update local branch ref: %w", err)

--- a/internal/pipeline/steps/common_fix.go
+++ b/internal/pipeline/steps/common_fix.go
@@ -53,8 +53,67 @@ func hasBlockingFindings(items []Finding) bool {
 	return false
 }
 
+// assertPipelineHeadContinuity fails closed when the worktree HEAD is no longer
+// a descendant of the head the pipeline itself last recorded (sctx.Run.HeadSHA).
+//
+// The pipeline advances HEAD only through its own commits, each of which updates
+// sctx.Run.HeadSHA in lockstep. If HEAD has diverged from that recorded head -
+// e.g. a concurrent process reset the shared worktree to a different commit -
+// then the reviewed change the pipeline approved is no longer in HEAD's history,
+// and committing on top of it would ship an unreviewed tree. The whole job of
+// this tool is to not lose people's code, so we refuse rather than proceed.
+//
+// Anchor integrity: sctx.Run.HeadSHA is the correct, un-clobberable anchor. It
+// is the *recorded* head the pipeline itself produced at its last commit - held
+// in the single daemon process's in-memory Run struct (one shared pointer per
+// run, never re-read from the DB mid-pipeline) and written only by no-mistakes
+// commit code (commit_fix / rebase / ci_fix / push). An out-of-band `git reset`
+// mutates the worktree HEAD on disk but cannot touch this field, so at the check
+// point the anchor still holds the reviewed head even after a clobber. The guard
+// deliberately compares the *recorded* head against the *live* worktree HEAD
+// (git.HeadSHA); it never derives the anchor from the mutable worktree, which
+// would be circular and defeatable. Because the guard sits at the very top of
+// commitAgentFixes - before any commit that would advance sctx.Run.HeadSHA - the
+// first pipeline commit after a clobber is caught while the anchor is still the
+// pre-clobber reviewed head; the anchor can never be advanced into a clobbered
+// lineage without first passing this check.
+//
+// This is what happened in run 01KXC3SD5NZYMERGDS68Z1C8ER: the review step
+// committed a correct fix, a sibling worktree sharing the bare repo reset HEAD
+// to a divergent commit that lacked it, and the document step committed on the
+// clobber and shipped it. A forward-only agent commit (git rebase --continue,
+// etc.) keeps the recorded head as an ancestor and is allowed; a divergent
+// (sibling) reset or a backward reset both trip this guard. On any failure the
+// error propagates out of commitAgentFixes, so the step and the whole run abort
+// (executor.failRun) before push - nothing is committed or shipped.
+func assertPipelineHeadContinuity(sctx *pipeline.StepContext, stepName types.StepName) error {
+	recorded := strings.TrimSpace(sctx.Run.HeadSHA)
+	if recorded == "" {
+		return nil
+	}
+	currentHead, err := git.HeadSHA(sctx.Ctx, sctx.WorkDir)
+	if err != nil {
+		return fmt.Errorf("resolve head before %s commit: %w", stepName, err)
+	}
+	if currentHead == recorded {
+		return nil
+	}
+	// Fail closed: refuse unless the recorded head is genuinely an ancestor of the
+	// live HEAD (a legitimate forward move). A non-ancestor result OR any git error
+	// (e.g. an unknown recorded object) aborts rather than proceeds.
+	if _, err := git.Run(sctx.Ctx, sctx.WorkDir, "merge-base", "--is-ancestor", recorded, currentHead); err != nil {
+		return fmt.Errorf("refusing to commit %s changes: worktree HEAD %s is not a descendant of the pipeline's recorded head %s; "+
+			"the reviewed change was rewritten out-of-band and would be lost - aborting to protect it",
+			stepName, currentHead, recorded)
+	}
+	return nil
+}
+
 func commitAgentFixes(sctx *pipeline.StepContext, stepName types.StepName, summary, fallbackSummary string) error {
 	ctx := sctx.Ctx
+	if err := assertPipelineHeadContinuity(sctx, stepName); err != nil {
+		return err
+	}
 	status, _ := git.Run(ctx, sctx.WorkDir, "status", "--porcelain")
 	if strings.TrimSpace(status) == "" {
 		sctx.Log("no agent changes to commit")

--- a/internal/pipeline/steps/headcontinuity_repro_test.go
+++ b/internal/pipeline/steps/headcontinuity_repro_test.go
@@ -128,6 +128,41 @@ func TestCommitAgentFixes_RefusesOnBackwardReset(t *testing.T) {
 	}
 }
 
+func TestCommitAgentFixes_RefusesResetDuringCommit(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
+
+	sctx := newTestContext(t, &mockAgent{name: "codex"}, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Fixing = true
+
+	gitDir := gitCmd(t, dir, "rev-parse", "--git-dir")
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(dir, gitDir)
+	}
+	hook := filepath.Join(gitDir, "hooks", "post-commit")
+	hookBody := "#!/bin/sh\ngit reset --hard " + baseSHA + "\n"
+	if err := os.WriteFile(hook, []byte(hookBody), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "fix.txt"), []byte("reviewed fix\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := commitAgentFixes(sctx, types.StepDocument, "update docs", "fallback")
+	if err == nil {
+		t.Fatal("expected refusal when HEAD is reset during commit")
+	}
+	if !strings.Contains(err.Error(), "not a descendant") {
+		t.Fatalf("expected a head-divergence error, got: %v", err)
+	}
+	if got := gitCmd(t, dir, "rev-parse", "HEAD"); got != baseSHA {
+		t.Fatalf("expected hook to reset HEAD to %s, got %s", baseSHA, got)
+	}
+	if sctx.Run.HeadSHA != headSHA {
+		t.Fatalf("recorded head changed to %s; expected %s", sctx.Run.HeadSHA, headSHA)
+	}
+}
+
 // TestCommitAgentFixes_AllowsForwardAgentCommit confirms the guard does not
 // false-positive when an agent legitimately advances HEAD forward (e.g. a
 // `git rebase --continue` during conflict resolution) before the pipeline

--- a/internal/pipeline/steps/headcontinuity_repro_test.go
+++ b/internal/pipeline/steps/headcontinuity_repro_test.go
@@ -1,0 +1,198 @@
+package steps
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/config"
+	"github.com/kunchenguid/no-mistakes/internal/git"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// These tests are the regression for incident run 01KXC3SD5NZYMERGDS68Z1C8ER:
+// the review step committed a CORRECT fix (reviewed head R = incident 04b5f5d),
+// a concurrent process (a sibling worktree sharing the bare repo) then reset the
+// worktree HEAD to a divergent commit D that lacked the fix (incident a876550),
+// and the pipeline's next commit (document) built on D and shipped it. R was not
+// even an ancestor of what shipped.
+//
+// commitAgentFixes must refuse to commit whenever the worktree HEAD is no longer
+// a descendant of the head the pipeline itself recorded, so the reviewed change
+// cannot be silently lost - while still allowing a legitimate forward agent
+// commit (e.g. git rebase --continue).
+
+// TestCommitAgentFixes_RefusesToCommitOnOutOfBandResetHead reproduces the
+// incident shape: a concurrent / divergent-sibling reset. It also proves the
+// anchor integrity requirement - sctx.Run.HeadSHA at the commit point is the
+// reviewed head and is NOT corrupted by the out-of-band reset.
+func TestCommitAgentFixes_RefusesToCommitOnOutOfBandResetHead(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
+
+	sctx := newTestContext(t, &mockAgent{name: "codex"}, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Fixing = true
+
+	guard := filepath.Join(dir, "guard.sh")
+
+	// 1) Review-fix applies the CORRECT change; the pipeline commits it (04b5f5d).
+	if err := os.WriteFile(guard, []byte("FORCE_INCLUDE marker-inversion\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := commitAgentFixes(sctx, types.StepReview, "guard linked secondmate homes correctly", "address review findings"); err != nil {
+		t.Fatalf("review-fix commit: %v", err)
+	}
+	reviewedHead := sctx.Run.HeadSHA
+	if reviewedHead == headSHA {
+		t.Fatal("review-fix did not advance head")
+	}
+
+	// 2) Out-of-band clobber: a concurrent sibling worktree resets HEAD to a
+	//    DIVERGENT commit built from base that does not contain the fix (a876550).
+	gitCmd(t, dir, "checkout", "--detach", baseSHA)
+	if err := os.WriteFile(guard, []byte("REMOVE_ONLY\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "crew minimal r2")
+	clobber := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	// Anchor integrity (captain requirement b): the recorded reviewed head is NOT
+	// overwritten by the out-of-band worktree reset - it still names 04b5f5d while
+	// the worktree HEAD now names the clobber.
+	if sctx.Run.HeadSHA != reviewedHead {
+		t.Fatalf("anchor corrupted: recorded head %s != reviewed head %s after clobber", sctx.Run.HeadSHA, reviewedHead)
+	}
+	if clobber == reviewedHead {
+		t.Fatal("test setup: clobber must differ from reviewed head")
+	}
+
+	// 3) Document step edits docs and tries to commit. It MUST refuse loudly.
+	if err := os.WriteFile(filepath.Join(dir, "docs.md"), []byte("corrected docs\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := commitAgentFixes(sctx, types.StepDocument, "correct secondmate guard documentation", "update docs")
+	if err == nil {
+		t.Fatal("expected commitAgentFixes to refuse committing on an out-of-band-reset HEAD, got nil")
+	}
+	if !strings.Contains(err.Error(), "not a descendant") {
+		t.Fatalf("expected a head-divergence error, got: %v", err)
+	}
+
+	// Nothing shipped: the worktree HEAD is still the clobber (no doc commit was
+	// layered on), and the recorded head is unchanged (reviewed fix preserved).
+	if got := gitCmd(t, dir, "rev-parse", "HEAD"); got != clobber {
+		t.Fatalf("guard must not have committed: HEAD moved from %s to %s", clobber, got)
+	}
+	if sctx.Run.HeadSHA != reviewedHead {
+		t.Fatalf("recorded head changed to %s; reviewed head %s must be preserved on refusal", sctx.Run.HeadSHA, reviewedHead)
+	}
+	t.Logf("guard refused divergent clobber: reviewed fix at %s protected", reviewedHead[:8])
+}
+
+// TestCommitAgentFixes_RefusesOnBackwardReset covers the other out-of-band shape
+// (captain requirement d): a reset BACKWARD to an ancestor of the reviewed head.
+// The recorded head is a descendant of the live HEAD, not an ancestor, so the
+// guard must still refuse - a backward reset would also silently drop the fix.
+func TestCommitAgentFixes_RefusesOnBackwardReset(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
+
+	sctx := newTestContext(t, &mockAgent{name: "codex"}, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Fixing = true
+
+	if err := os.WriteFile(filepath.Join(dir, "guard.sh"), []byte("FORCE_INCLUDE\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := commitAgentFixes(sctx, types.StepReview, "apply fix", "fallback"); err != nil {
+		t.Fatalf("review-fix commit: %v", err)
+	}
+	reviewedHead := sctx.Run.HeadSHA
+
+	// Out-of-band backward reset to base (an ancestor of the reviewed head).
+	gitCmd(t, dir, "reset", "--hard", baseSHA)
+
+	if err := os.WriteFile(filepath.Join(dir, "docs.md"), []byte("docs\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := commitAgentFixes(sctx, types.StepDocument, "docs", "fallback")
+	if err == nil {
+		t.Fatal("expected refusal on a backward-reset HEAD, got nil")
+	}
+	if !strings.Contains(err.Error(), "not a descendant") {
+		t.Fatalf("expected a head-divergence error, got: %v", err)
+	}
+	if sctx.Run.HeadSHA != reviewedHead {
+		t.Fatalf("recorded head must be preserved on refusal, got %s", sctx.Run.HeadSHA)
+	}
+}
+
+// TestCommitAgentFixes_AllowsForwardAgentCommit confirms the guard does not
+// false-positive when an agent legitimately advances HEAD forward (e.g. a
+// `git rebase --continue` during conflict resolution) before the pipeline
+// commits its own fixes: the recorded head stays an ancestor, so committing is
+// allowed.
+func TestCommitAgentFixes_AllowsForwardAgentCommit(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
+
+	sctx := newTestContext(t, &mockAgent{name: "codex"}, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Fixing = true
+
+	// Agent makes its own forward commit (descendant of the recorded head).
+	if err := os.WriteFile(filepath.Join(dir, "agent.txt"), []byte("agent commit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "agent forward commit")
+	forward := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	// Pipeline then commits its own working-tree edits on top - must succeed.
+	if err := os.WriteFile(filepath.Join(dir, "fix.txt"), []byte("pipeline fix\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := commitAgentFixes(sctx, types.StepReview, "apply fix", "fallback"); err != nil {
+		t.Fatalf("forward agent commit should be allowed, got: %v", err)
+	}
+	if _, err := git.Run(sctx.Ctx, dir, "merge-base", "--is-ancestor", forward, sctx.Run.HeadSHA); err != nil {
+		t.Fatalf("expected forward commit %s to be an ancestor of new head %s", forward, sctx.Run.HeadSHA)
+	}
+}
+
+// TestAssertPipelineHeadContinuity_AnchorIsRecordedReviewedHead directly
+// exercises the guard (captain requirement b): it anchors on the recorded
+// reviewed head (sctx.Run.HeadSHA), NOT on the mutable worktree, and an
+// out-of-band reset leaves that anchor intact so the guard still fires.
+func TestAssertPipelineHeadContinuity_AnchorIsRecordedReviewedHead(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
+
+	sctx := newTestContext(t, &mockAgent{name: "codex"}, dir, baseSHA, headSHA, config.Commands{})
+
+	// Record a reviewed head, then clobber the worktree out from under it.
+	sctx.Run.HeadSHA = headSHA
+	gitCmd(t, dir, "checkout", "--detach", baseSHA)
+	if err := os.WriteFile(filepath.Join(dir, "x.txt"), []byte("divergent\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "divergent")
+
+	// The recorded anchor is untouched by the worktree reset.
+	if sctx.Run.HeadSHA != headSHA {
+		t.Fatalf("anchor must be the recorded reviewed head %s, got %s", headSHA, sctx.Run.HeadSHA)
+	}
+	// The guard, comparing the recorded anchor against the live (clobbered) HEAD,
+	// refuses.
+	if err := assertPipelineHeadContinuity(sctx, types.StepDocument); err == nil {
+		t.Fatal("expected guard to refuse when live HEAD diverged from the recorded head")
+	}
+
+	// Restoring the worktree to the recorded head makes the guard pass again,
+	// proving it is anchored on that exact recorded SHA.
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
+	if err := assertPipelineHeadContinuity(sctx, types.StepDocument); err != nil {
+		t.Fatalf("guard should pass when HEAD equals the recorded head, got %v", err)
+	}
+}


### PR DESCRIPTION
## Intent

Fix a data-loss defect in no-mistakes: an authorized exact --action fix change was silently replaced by a different, unreviewed change and still shipped green (incident run 01KXC3SD5NZYMERGDS68Z1C8ER). Root cause: the pipeline advances the worktree HEAD only through its own commits but never checks that HEAD is still the head it reviewed, so when a concurrent process (a sibling worktree sharing the bare repo) reset HEAD off the reviewed fix onto a divergent commit, the document step committed on the clobber and pushed it; the reviewed commit was not even an ancestor of what shipped.

The fix adds a fail-closed HEAD-continuity guard (assertPipelineHeadContinuity) at the top of commitAgentFixes: it refuses to commit when the live worktree HEAD is no longer a descendant of the head the pipeline recorded (sctx.Run.HeadSHA), so the run aborts loudly instead of shipping an unreviewed tree.

Deliberate decisions a diff-only reviewer would not know: (1) The anchor is intentionally sctx.Run.HeadSHA - the in-memory, single-writer, never-re-read-from-DB record of the last head the pipeline itself produced; it is genuinely the reviewed head at the commit point and cannot be clobbered by an out-of-band worktree reset, so no separate durable field was added (proven with a dedicated anchor-integrity test). (2) The guard is deliberately scoped to commitAgentFixes only - the earliest catch point for this incident (the document commit); extending the invariant to the push step and each executor step boundary is a deliberately-deferred follow-up, intentionally NOT in this minimal change. (3) The descendant invariant intentionally ALLOWS a legitimate forward agent commit (git rebase --continue keeps the recorded head an ancestor) and only refuses divergent-sibling or backward resets; it fails closed on any git error or unknown object. (4) Four regression tests deliberately cover the divergent-sibling reset (incident shape), a backward reset, anchor integrity, and no false positive on a forward agent commit; two are named exactly as required and both fail on origin/main without the guard and pass with it.

Scope is exactly two files: internal/pipeline/steps/common_fix.go and internal/pipeline/steps/headcontinuity_repro_test.go. No behavior change for normal runs where HEAD stays on the pipeline's own commits.

## What Changed

- Add a fail-closed HEAD continuity check around agent fix commits, aborting when an out-of-band reset removes the pipeline’s recorded reviewed history.
- Preserve legitimate forward agent commits while rejecting divergent, backward, unknown, or concurrently clobbered HEAD states.
- Add regression coverage and documentation for the continuity guard and its supported behavior.

## Risk Assessment

✅ Low: The added post-commit continuity check closes the previously identified reset-during-commit window while preserving the intended descendant behavior and two-file scope.

## Testing

The supplied full race baseline passed, and a focused race-enabled incident reproduction confirmed that clobbered HEAD histories abort before another pipeline commit while valid forward history remains accepted; reviewer-visible forensic evidence was recorded as a Markdown transcript because this is a non-UI pipeline safety change.

- Evidence: [HEAD continuity incident reproduction](https://github.com/kunchenguid/no-mistakes/blob/d86c61d53fff4651ea589aef553ec6d5b50cc868/.no-mistakes/evidence/fm/nm-fixer-dropped-instructions-forensic-f6/head-continuity-regression.md)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `internal/pipeline/steps/common_fix.go:114` - The continuity check is vulnerable to a TOCTOU race: an out-of-band reset can occur after this check succeeds but before `git commit`, causing the commit to use the clobbered HEAD and recreating the data-loss path. The tests perform the reset before entering `commitAgentFixes`, so they do not cover this window. Make the commit/update conditional on the verified HEAD atomically, or revalidate the committed parent before recording or shipping the new head.

🔧 Fix: Close HEAD continuity race during fix commits
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`
- <code>Baseline supplied as successful: `go test -race ./...`</code>
- <code>Inspected `git diff --stat 8ec98db2a39a054a90071dfd0c8175785c6343a9..8c2d5691a7bbb9e17fa9e88e7438cbfdd5429351` and confirmed the product change is exactly the two intended files.</code>
- `go test -race -v ./internal/pipeline/steps -run 'TestCommitAgentFixes_(RefusesToCommitOnOutOfBandResetHead|RefusesOnBackwardReset|RefusesResetDuringCommit|AllowsForwardAgentCommit)|TestAssertPipelineHeadContinuity_AnchorIsRecordedReviewedHead'`
- <code>Verified the evidence file exists and is non-empty with `test -s .no-mistakes/evidence/fm/nm-fixer-dropped-instructions-forensic-f6/head-continuity-regression.md`.</code>
- <code>Checked `git status --short` and confirmed testing left only the intentional evidence directory, with no transient build or generated artifacts.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
