### PR TITLE
fix(gate): redact embedded credentials from stored upstream URLs and error surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,9 +18,15 @@ Safest local verification sequence after non-trivial changes:
 
 - `repos.upstream_url` is the parent repository used for PR base routing; `repos.fork_url` is an optional GitHub fork push target.
 - `no-mistakes init --fork-url <url>` expects `origin` to point at the GitHub parent repository and `<url>` at the contributor fork; plain `no-mistakes init` preserves an existing fork URL on idempotent refresh.
-- Push code must use `Repo.PushURL()` so configured forks receive branch updates.
+- Push and CI auto-fix push code must resolve the push URL via `resolvePushURL` (`internal/pipeline/steps/common_git.go`) so configured forks still receive branch updates; the non-fork path recovers the credentialled upstream from the worktree's `origin` remote at run time because the DB `upstream_url` is stored redacted (see Credential Redaction below). `Repo.PushURL()` remains correct only for fork-only callers (e.g. `rebase.go`), since fork URLs carry no embedded credentials.
 - GitHub PR code must keep `--repo` pointed at the parent and use `--head <fork_owner>:<branch>` when `fork_url` is set; existing-PR lookup must list by the bare branch and filter head-owner fields, never pass `<owner>:<branch>` to `gh pr list --head`.
 - GitLab and Bitbucket fork MR/PR routing is intentionally out of scope until implemented end to end; if a legacy row has `fork_url` for those hosts, PR creation must skip instead of opening a self PR.
+
+**Credential Redaction in Stored URLs and Errors (security)**
+
+- `gate.InitWithFork` runs the upstream URL through `safeurl.Redact` before every DB persist (`UpdateRepoMetadata*`, `InsertRepoWithIDAndFork`) and the "gate initialized" log line; the bare gate's `origin` remote still carries the full credentialled URL (via `provisionGate`) so carved worktrees authenticate. Because the DB copy is redacted, push and CI auto-fix push must recover the credential from the worktree's `origin` remote at run time (`resolvePushURL`/`resolveUpstreamURL`), never from `Repo.UpstreamURL`/`Repo.PushURL()`.
+- Step-failure errors (`executor.go` `FailStep`/log/IPC emit) and the Bitbucket resolve-repo error are redacted via `safeurl.RedactText`/`safeurl.Redact` so a credentialled URL wrapped into an error can never reach a step log or `runs.error`. Reuse `internal/safeurl` for new redaction sites rather than adding a git-local helper; it is already wired into `git.Run`/step git-run error formatting.
+- Regressions: `TestInitRedactsCredentialURL`, `TestResolveUpstreamURL_PreservesCredential`, `TestResolveUpstreamURL_FallsBackToRecordedURL`, `TestResolvePushURL_ForkWinsOverCredential`.
 
 **GitLab Backend (`internal/scm/gitlab`)**
 

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -143,7 +143,7 @@ Pushes the validated branch to the configured push target.
 - If `commands.format` is set, runs it first
 - Stages in-repo test evidence artifacts when `test.evidence.store_in_repo` is enabled and the evidence directory is not ignored by Git
 - Commits any uncommitted agent changes with message `no-mistakes: apply agent fixes`
-- Without fork routing, the push target is `repos.upstream_url`, which comes from `origin`
+- Without fork routing, the push target is the credentialled upstream URL resolved from the worktree's `origin` remote at run time (the DB stores a redacted copy)
 - With GitHub fork routing, the push target is `repos.fork_url`
 - Re-reads the push target via `git ls-remote` before pushing
 - For existing branches, refuses to force-push when the live remote carries commits the pipeline has not incorporated by patch-id

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/safeurl"
 	"github.com/kunchenguid/no-mistakes/internal/scm"
 	"github.com/kunchenguid/no-mistakes/internal/scm/github"
 )
@@ -88,6 +89,13 @@ func InitWithFork(ctx context.Context, d *db.DB, p *paths.Paths, workDir, forkUR
 		}
 	}
 
+	// Redact embedded credentials for everything that is persisted, logged, or
+	// surfaced to the user. The bare gate keeps the full credentialled URL on
+	// its "origin" remote via provisionGate below so worktrees carved from it
+	// can still authenticate pushes; the push step resolves that credential
+	// from the worktree at run time instead of trusting the DB copy.
+	redactedUpstreamURL := safeurl.Redact(upstreamURL)
+
 	id := repoID(absRoot)
 	if existing != nil {
 		id = existing.ID
@@ -113,9 +121,9 @@ func InitWithFork(ctx context.Context, d *db.DB, p *paths.Paths, workDir, forkUR
 	if existing != nil {
 		var repo *db.Repo
 		if forkURL != "" {
-			repo, err = d.UpdateRepoMetadataWithFork(existing.ID, upstreamURL, forkURL, branch)
+			repo, err = d.UpdateRepoMetadataWithFork(existing.ID, redactedUpstreamURL, forkURL, branch)
 		} else {
-			repo, err = d.UpdateRepoMetadata(existing.ID, upstreamURL, branch)
+			repo, err = d.UpdateRepoMetadata(existing.ID, redactedUpstreamURL, branch)
 		}
 		if err != nil {
 			return nil, false, fmt.Errorf("update repo metadata: %w", err)
@@ -125,7 +133,7 @@ func InitWithFork(ctx context.Context, d *db.DB, p *paths.Paths, workDir, forkUR
 	}
 
 	// Insert repo record with deterministic ID.
-	repo, err := d.InsertRepoWithIDAndFork(id, absRoot, upstreamURL, forkURL, branch)
+	repo, err := d.InsertRepoWithIDAndFork(id, absRoot, redactedUpstreamURL, forkURL, branch)
 	if err != nil {
 		// Rollback: remove remote and bare repo.
 		git.RemoveRemote(ctx, absRoot, RemoteName)
@@ -133,7 +141,7 @@ func InitWithFork(ctx context.Context, d *db.DB, p *paths.Paths, workDir, forkUR
 		return nil, false, fmt.Errorf("insert repo: %w", err)
 	}
 
-	slog.Info("gate initialized", "repo_id", id, "path", absRoot, "upstream", upstreamURL)
+	slog.Info("gate initialized", "repo_id", id, "path", absRoot, "upstream", redactedUpstreamURL)
 	return repo, true, nil
 }
 

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/kunchenguid/no-mistakes/internal/db"
@@ -986,5 +987,63 @@ func TestInit_PostReceiveSurvivesHooksPathPoisoning(t *testing.T) {
 
 	if _, err := os.Stat(marker); err != nil {
 		t.Fatalf("post-receive did not fire after husky poisoned core.hookspath: %v", err)
+	}
+}
+
+// TestInitRedactsCredentialURL asserts that an origin URL carrying embedded
+// credentials (e.g. a fine-grained PAT) is stored redacted in the DB and in the
+// returned repo record, while the bare gate's "origin" remote keeps the full
+// credentialled URL so worktrees carved from it can still authenticate pushes.
+//
+// The upstream host is an unreachable loopback address so DefaultBranch's
+// ls-remote fails fast and falls back to "main" without real network I/O.
+func TestInitRedactsCredentialURL(t *testing.T) {
+	workDir := setupTestRepo(t)
+	const token = "ghp_secret_DO_NOT_LEAK"
+	credURL := "https://x-access-token:" + token + "@127.0.0.1:1/o/r.git"
+	if out, err := exec.Command("git", "-C", workDir, "remote", "set-url", "origin", credURL).CombinedOutput(); err != nil {
+		t.Fatalf("set credentialled origin: %v: %s", err, out)
+	}
+
+	nmRoot := t.TempDir()
+	p := paths.WithRoot(nmRoot)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	d := openTestDB(t, p)
+	ctx := context.Background()
+
+	repo, _, err := Init(ctx, d, p, workDir)
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	// The returned repo record (and thus anything logged from it) must not
+	// carry the credential.
+	if strings.Contains(repo.UpstreamURL, token) {
+		t.Errorf("returned repo.UpstreamURL leaked credential: %q", repo.UpstreamURL)
+	}
+	if !strings.Contains(repo.UpstreamURL, "redacted@127.0.0.1:1/o/r.git") {
+		t.Errorf("expected redacted URL, got %q", repo.UpstreamURL)
+	}
+
+	// The persisted DB row must match the redacted form.
+	dbRepo, err := d.GetRepo(repo.ID)
+	if err != nil {
+		t.Fatalf("get repo: %v", err)
+	}
+	if strings.Contains(dbRepo.UpstreamURL, token) {
+		t.Errorf("DB repo.UpstreamURL leaked credential: %q", dbRepo.UpstreamURL)
+	}
+
+	// The bare gate's origin must still carry the full credential so pushes
+	// from carved worktrees can authenticate.
+	bareDir := p.RepoDir(repo.ID)
+	gateOrigin, err := gitpkg.GetRemoteURL(ctx, bareDir, "origin")
+	if err != nil {
+		t.Fatalf("get gate origin: %v", err)
+	}
+	if gateOrigin != credURL {
+		t.Errorf("gate origin = %q, want full credentialled URL %q (credential must be preserved for pushes)", gateOrigin, credURL)
 	}
 }

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -641,7 +641,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 				slog.Warn("failed to mark step as failed in db", "step", stepName, "error", dbErr)
 			}
 			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFailed), "", "", redactedErr, &durationMS)
-			return false, fmt.Errorf("step %s failed: %w", stepName, err)
+			return false, fmt.Errorf("step %s failed: %s", stepName, redactedErr)
 		}
 
 		outcome.Findings = normalizeFindingsJSON(outcome.Findings, string(stepName))

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -637,10 +637,10 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			redactedErr := safeurl.RedactText(err.Error())
 			fmt.Fprintf(logFile, "\nerror: %s\n", redactedErr)
 			touchLogActivity("error: "+redactedErr, true)
-			if dbErr := e.db.FailStep(sr.ID, err.Error(), durationMS); dbErr != nil {
+			if dbErr := e.db.FailStep(sr.ID, redactedErr, durationMS); dbErr != nil {
 				slog.Warn("failed to mark step as failed in db", "step", stepName, "error", dbErr)
 			}
-			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFailed), "", "", err.Error(), &durationMS)
+			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFailed), "", "", redactedErr, &durationMS)
 			return false, fmt.Errorf("step %s failed: %w", stepName, err)
 		}
 

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/safeurl"
 	"github.com/kunchenguid/no-mistakes/internal/telemetry"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
@@ -630,9 +631,12 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			// Persist the failure reason to the step's own log file. The error
 			// often carries the only detail of why the step failed (e.g. git
 			// stderr from a rejected push); without this the step log shows the
-			// work starting but never why it stopped.
-			fmt.Fprintf(logFile, "\nerror: %s\n", err.Error())
-			touchLogActivity("error: "+err.Error(), true)
+			// work starting but never why it stopped. Redact defensively so a
+			// credentialled upstream URL that slipped into a wrapped error can
+			// never land in the log file.
+			redactedErr := safeurl.RedactText(err.Error())
+			fmt.Fprintf(logFile, "\nerror: %s\n", redactedErr)
+			touchLogActivity("error: "+redactedErr, true)
 			if dbErr := e.db.FailStep(sr.ID, err.Error(), durationMS); dbErr != nil {
 				slog.Warn("failed to mark step as failed in db", "step", stepName, "error", dbErr)
 			}

--- a/internal/pipeline/executor_logging_test.go
+++ b/internal/pipeline/executor_logging_test.go
@@ -344,6 +344,66 @@ func TestExecutor_LogFileWritten_OnStepError(t *testing.T) {
 	}
 }
 
+func TestExecutor_StepErrorRedactsCredentialURL(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	// A step error carrying a credentialled upstream URL (as a real git push
+	// rejection error would). It must be redacted before reaching the step log
+	// file, the DB error column, the returned executor error, and the IPC event.
+	const token = "ghp_secret_DO_NOT_LEAK"
+	credURL := "https://x-access-token:" + token + "@github.com/o/r.git"
+	stepErr := fmt.Errorf("push to upstream: git push %s: remote rejected: file exceeds 100.00 MB", credURL)
+
+	ec := &eventCollector{}
+	exec := NewExecutor(database, p, nil, nil, []Step{newFailStep(types.StepPush, stepErr)}, ec.handler)
+	err := exec.Execute(context.Background(), run, repo, workDir)
+	if err == nil {
+		t.Fatal("expected error from failing step")
+	}
+
+	// 1) Step log file must contain the redacted form, never the token.
+	logPath := filepath.Join(p.RunLogDir(run.ID), "push.log")
+	data, rerr := os.ReadFile(logPath)
+	if rerr != nil {
+		t.Fatalf("expected log file at %s: %v", logPath, rerr)
+	}
+	logContent := string(data)
+	if strings.Contains(logContent, token) {
+		t.Errorf("step log leaked credential: %s", logContent)
+	}
+	if !strings.Contains(logContent, "redacted@github.com/o/r.git") {
+		t.Errorf("step log missing redacted URL, got: %s", logContent)
+	}
+
+	// 2) DB step error column must not carry the token.
+	steps, _ := database.GetStepsByRun(run.ID)
+	if steps[0].Error == nil {
+		t.Fatal("expected step error to be persisted")
+	}
+	dbErr := *steps[0].Error
+	if strings.Contains(dbErr, token) {
+		t.Errorf("DB step error leaked credential: %q", dbErr)
+	}
+	if !strings.Contains(dbErr, "redacted@github.com/o/r.git") {
+		t.Errorf("DB step error missing redacted URL, got: %q", dbErr)
+	}
+
+	// 3) Returned executor error must not carry the token.
+	if strings.Contains(err.Error(), token) {
+		t.Errorf("returned error leaked credential: %q", err.Error())
+	}
+
+	// 4) IPC step-completed event error must not carry the token.
+	ev := ec.find(ipc.EventStepCompleted, types.StepPush)
+	if ev == nil {
+		t.Fatal("expected step completed event")
+	}
+	if ev.Error != nil && strings.Contains(*ev.Error, token) {
+		t.Errorf("IPC event error leaked credential: %q", *ev.Error)
+	}
+}
+
 func TestExecutor_LogFileMultipleSteps(t *testing.T) {
 	database, p, run, repo := setupTest(t)
 	workDir := t.TempDir()

--- a/internal/pipeline/steps/ci_bitbucket.go
+++ b/internal/pipeline/steps/ci_bitbucket.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/bitbucket"
+	"github.com/kunchenguid/no-mistakes/internal/safeurl"
 )
 
 // resolveBitbucketRepoRef parses a Bitbucket repo reference from the upstream
@@ -16,7 +17,7 @@ func resolveBitbucketRepoRef(upstreamURL string, prURL *string) (bitbucket.RepoR
 	if prURL != nil && strings.TrimSpace(*prURL) != "" {
 		return bitbucket.ParseRepoRef(*prURL)
 	}
-	return bitbucket.RepoRef{}, fmt.Errorf("resolve Bitbucket repository from upstream %q", upstreamURL)
+	return bitbucket.RepoRef{}, fmt.Errorf("resolve Bitbucket repository from upstream %q", safeurl.Redact(upstreamURL))
 }
 
 // trimLogOutput truncates log output to the last maxBytes bytes, respecting

--- a/internal/pipeline/steps/ci_bitbucket_test.go
+++ b/internal/pipeline/steps/ci_bitbucket_test.go
@@ -406,6 +406,25 @@ func TestCIStep_BitbucketAutoFixUsesMatchingPipelineLogs(t *testing.T) {
 	}
 }
 
+func TestResolveBitbucketRepoRef_RedactsCredentialInError(t *testing.T) {
+	t.Parallel()
+	const token = "ghp_secret_DO_NOT_LEAK"
+	// A non-Bitbucket host with embedded credentials: ParseRepoRef rejects the
+	// host, no PR URL is set, so the function returns its fallback error. That
+	// error surfaces the upstream URL and must not leak the embedded credential.
+	credURL := "https://x-access-token:" + token + "@example.com/w/r.git"
+	_, err := resolveBitbucketRepoRef(credURL, nil)
+	if err == nil {
+		t.Fatal("expected error for unresolved non-Bitbucket upstream")
+	}
+	if strings.Contains(err.Error(), token) {
+		t.Errorf("resolveBitbucketRepoRef error leaked credential: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "redacted@example.com/w/r.git") {
+		t.Errorf("error missing redacted URL, got: %q", err.Error())
+	}
+}
+
 func TestLatestBitbucketStatusesKeepsNewestStatusPerCheck(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pipeline/steps/ci_fix.go
+++ b/internal/pipeline/steps/ci_fix.go
@@ -142,7 +142,7 @@ func (s *CIStep) commitAndPush(sctx *pipeline.StepContext) (bool, error) {
 
 func (s *CIStep) pushUpdatedHeadSHA(sctx *pipeline.StepContext, newHeadSHA string) (bool, error) {
 	ref := normalizedBranchRef(sctx.Run.Branch)
-	pushURL := sctx.Repo.PushURL()
+	pushURL := resolvePushURL(sctx)
 
 	// Anchor the force-with-lease to the head the run last recorded for this
 	// branch (what the pipeline last pushed/observed), NOT to a SHA freshly read

--- a/internal/pipeline/steps/common_git.go
+++ b/internal/pipeline/steps/common_git.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
 	"github.com/kunchenguid/no-mistakes/internal/git"
+	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 )
 
 // reviewWorkload returns the bounded change size (files + net lines) between
@@ -130,4 +131,34 @@ func normalizedBranchRef(ref string) string {
 		return "refs/heads/" + ref
 	}
 	return ref
+}
+
+// resolveUpstreamURL returns the credentialled upstream URL to push or query.
+// It prefers the worktree's configured "origin" remote, which inherits the
+// full upstream URL (including any embedded credentials) from the gate's bare
+// repo via the shared common config. It falls back to the repo record's
+// upstream URL when origin cannot be resolved (e.g. a test worktree without
+// origin, or an older gate whose DB still carries the full URL).
+//
+// This separation lets the database and logs store a redacted URL while the
+// credential still reaches the git push/ls-remote argv that needs it.
+func resolveUpstreamURL(sctx *pipeline.StepContext) string {
+	if url, err := git.GetRemoteURL(sctx.Ctx, sctx.WorkDir, "origin"); err == nil && strings.TrimSpace(url) != "" {
+		return url
+	}
+	return sctx.Repo.UpstreamURL
+}
+
+// resolvePushURL returns the URL to push to: the fork when one is configured
+// (fork-based contributions, Repo.ForkURL set), else the credentialled upstream
+// resolved from the worktree's "origin" remote. The non-fork path resolves the
+// credential at run time so the redacted DB copy is never placed on the
+// push/ls-remote argv. Fork URLs carry no embedded credentials today, so the
+// fork path uses the repo record directly. In both cases callers wrap the URL
+// in safeurl.Redact before logging it.
+func resolvePushURL(sctx *pipeline.StepContext) string {
+	if sctx.Repo != nil && strings.TrimSpace(sctx.Repo.ForkURL) != "" {
+		return sctx.Repo.ForkURL
+	}
+	return resolveUpstreamURL(sctx)
 }

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -56,7 +56,7 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 	ref := normalizedBranchRef(sctx.Run.Branch)
 	branch := strings.TrimPrefix(ref, "refs/heads/")
 
-	pushURL := sctx.Repo.PushURL()
+	pushURL := resolvePushURL(sctx)
 	pushTarget := "upstream"
 	usingFork := strings.TrimSpace(sctx.Repo.ForkURL) != ""
 	if usingFork {

--- a/internal/pipeline/steps/upstream_test.go
+++ b/internal/pipeline/steps/upstream_test.go
@@ -1,0 +1,87 @@
+package steps
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/pipeline"
+)
+
+// minimalStepContext builds a StepContext with just enough fields for the
+// upstream-resolution helpers, without spinning up a database.
+func minimalStepContext(t *testing.T, workDir, upstreamURL string) *pipeline.StepContext {
+	t.Helper()
+	return &pipeline.StepContext{
+		Ctx:     context.Background(),
+		WorkDir: workDir,
+		Repo:    &db.Repo{UpstreamURL: upstreamURL},
+	}
+}
+
+// TestResolveUpstreamURL_PreservesCredential is the "pushes keep working" half
+// of the redaction fix: the DB stores a redacted URL, but the credential must
+// still reach the git push/ls-remote argv. The credential is recovered from the
+// worktree's "origin" remote (inherited from the gate's bare repo), so
+// resolveUpstreamURL must return the full credentialled URL verbatim.
+func TestResolveUpstreamURL_PreservesCredential(t *testing.T) {
+	t.Parallel()
+	const token = "ghp_secret_DO_NOT_LEAK"
+	credURL := "https://x-access-token:" + token + "@github.com/o/r.git"
+	// The DB copy is redacted (the form gate.Init now persists).
+	redacted := "https://redacted@github.com/o/r.git"
+
+	dir := t.TempDir()
+	if out, err := exec.Command("git", "init", "-q", dir).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", dir, "remote", "add", "origin", credURL).CombinedOutput(); err != nil {
+		t.Fatalf("git remote add: %v: %s", err, out)
+	}
+
+	sctx := minimalStepContext(t, dir, redacted)
+	got := resolveUpstreamURL(sctx)
+	if got != credURL {
+		t.Errorf("resolveUpstreamURL = %q, want full credentialled URL %q (credential must reach the push argv)", got, credURL)
+	}
+	if !strings.Contains(got, token) {
+		t.Errorf("resolveUpstreamURL stripped the credential: got %q", got)
+	}
+}
+
+// TestResolveUpstreamURL_FallsBackToRecordedURL verifies that when a worktree
+// has no resolvable "origin" remote, resolveUpstreamURL falls back to the repo
+// record's upstream URL (the path old gates whose DB still carries the full URL
+// take).
+func TestResolveUpstreamURL_FallsBackToRecordedURL(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if out, err := exec.Command("git", "init", "-q", dir).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	// No "origin" remote configured.
+	recorded := "https://github.com/o/r.git"
+	sctx := minimalStepContext(t, dir, recorded)
+	if got := resolveUpstreamURL(sctx); got != recorded {
+		t.Errorf("resolveUpstreamURL fallback = %q, want %q", got, recorded)
+	}
+}
+
+// TestResolvePushURL_ForkWinsOverCredential confirms the fork URL takes
+// precedence when set (fork-based contribution flow), since fork URLs carry no
+// embedded credentials today.
+func TestResolvePushURL_ForkWinsOverCredential(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if out, err := exec.Command("git", "init", "-q", dir).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	forkURL := "https://github.com/e-jung/no-mistakes.git"
+	sctx := minimalStepContext(t, dir, "https://redacted@github.com/o/r.git")
+	sctx.Repo.ForkURL = forkURL
+	if got := resolvePushURL(sctx); got != forkURL {
+		t.Errorf("resolvePushURL = %q, want fork URL %q", got, forkURL)
+	}
+}


### PR DESCRIPTION
## Intent

Redact embedded credentials (e.g. fine-grained PATs like https://x-access-token:ghp_...@host/...) from upstream/remote URLs so they never leak into the SQLite repos.upstream_url column, the 'gate initialized' daemon log line, step logs, or error strings. The DB and the gate-initialized slog line stored the raw credentialled upstream URL verbatim. Fix: gate.InitWithFork runs the upstream URL through safeurl.Redact before every DB persist (UpdateRepoMetadata*/InsertRepoWithIDAndFork) and the log line, while provisionGate still puts the full credentialled URL on the bare gate's own origin remote so carved worktrees can authenticate. Because the DB copy is now redacted, the push step and CI auto-fix push resolve the credential from the worktree's origin remote at run time (new resolvePushURL/resolveUpstreamURL helpers) instead of Repo.PushURL(), so the credential still reaches the git push/ls-remote argv. Also redact the Bitbucket resolve-repo error and the executor step-log error write defensively. Deliberate decisions: (1) reuse the existing internal/safeurl primitive rather than adding a new git.RedactURL, since upstream already wires safeurl into git.Run/stepGitRun errors and push-step logging - this complements rather than duplicates; (2) deliberately excluded the reference's unrelated 0o600 log-file-mode hardening to keep the PR focused purely on redaction; (3) rebase.go's remaining Repo.PushURL() use is fork-only (ForkURL carries no embedded credentials) and intentionally left unchanged.

## What Changed
- `gate.InitWithFork` now runs the upstream URL through `safeurl.Redact` before every DB persist (`UpdateRepoMetadata*`, `InsertRepoWithIDAndFork`) and the "gate initialized" log line, so credentials never reach the `repos.upstream_url` column or the daemon log; the bare gate's `origin` remote still carries the full credentialled URL so carved worktrees authenticate.
- Added `resolvePushURL`/`resolveUpstreamURL` helpers in `pipeline/steps/common_git.go` so push and CI auto-fix push recover the credential from the worktree's live `origin` remote at run time instead of `Repo.PushURL()`, since the DB copy is now redacted.
- Defensively redacted the Bitbucket resolve-repo error and the executor step-failure error strings (log file, `step_results.error` via `FailStep`, `runs.error` via `failRun`, and their IPC events) via `safeurl.RedactText`/`safeurl.Redact`.

## Risk Assessment

✅ Low: The redaction strategy is consistent and complete across all identified persistent and surfaced surfaces (DB column, gate log, step logs, error strings, IPC events), the credential is preserved on the bare gate origin for runtime resolution via tested helpers, and provider/host parsing is unaffected by the redacted URL form.

## Testing

Baseline `go test -race ./...` already passed. I ran the targeted redaction tests (gate init redaction, new resolveUpstreamURL/resolvePushURL helpers, push/CI error redaction, safeurl) and the full gate/pipeline/steps/db suites with -race — all green. I then demonstrated the intent as an end user would experience it: ran the real `no-mistakes init` binary against a repo with an embedded-PAT origin and confirmed the credential is absent from the CLI output, the "gate initialized" log line, and the SQLite repos.upstream_url column (all show https://redacted@...), while the bare gate origin remote keeps the full credentialled URL so pushes can still authenticate. I added two tests (executor step-failure error redaction across log/DB/returned-error/IPC-event, and Bitbucket resolve-repo error redaction) which pass. Cleaned up the spawned daemon; working tree contains only the two test-file additions.

<details>
<summary>Evidence: E2E redaction report (real no-mistakes init with credentialled origin)</summary>

<code>Credentialled origin: https://x-access-token:ghp_secret_DO_NOT_LEAK_2026@127.0.0.1:1/o/r.git&#10;&#10;SURFACE 1 - CLI stdout &#39;remote&#39; line:&#10;remote https://redacted@127.0.0.1:1/o/r.git&#10;&#10;SURFACE 2 - &#39;gate initialized&#39; slog line (cli.log):&#10;msg=&#34;gate initialized&#34; repo_id=ada4b8b3a5c3 upstream=https://redacted@127.0.0.1:1/o/r.git&#10;&#10;SURFACE 3 - SQLite repos.upstream_url column:&#10;ada4b8b3a5c3|https://redacted@127.0.0.1:1/o/r.git|&#10;&#10;SURFACE 4 - Bare gate &#39;origin&#39; remote (MUST keep full credential):&#10;https://x-access-token:ghp_secret_DO_NOT_LEAK_2026@127.0.0.1:1/o/r.git&#10;&#10;LEAK HUNT: token absent from every DB/log/stdout surface&#10;AUTH PRESERVED: full credentialled URL present on bare gate origin (pushes can authenticate)</code>

```text
############################################################
# E2E EVIDENCE: credential redaction across all surfaces   #
############################################################

Credentialled origin URL set on the working repo (the secret to hunt for):
  https://x-access-token:ghp_secret_DO_NOT_LEAK_2026@127.0.0.1:1/o/r.git
  token substring: ghp_secret_DO_NOT_LEAK_2026

================================================================
SURFACE 1 — CLI stdout (user-facing 'remote' line)
================================================================
  remote  https://redacted@127.0.0.1:1/o/r.git

================================================================
SURFACE 2 — 'gate initialized' slog line (cli.log)
================================================================
time=2026-07-13T18:30:36.859Z level=INFO msg="gate initialized" repo_id=ada4b8b3a5c3 path=/tmp/no-mistakes-evidence/01KXE9V8NHG1HMY2P2GBE6WWH2/repo upstream=https://redacted@127.0.0.1:1/o/r.git

================================================================
SURFACE 3 — SQLite repos.upstream_url column
================================================================
ada4b8b3a5c3|https://redacted@127.0.0.1:1/o/r.git|

================================================================
SURFACE 4 — Bare gate 'origin' remote (MUST keep full credential)
================================================================
bare dir: /tmp/no-mistakes-evidence/01KXE9V8NHG1HMY2P2GBE6WWH2/nm-home/repos/ada4b8b3a5c3.git
https://x-access-token:ghp_secret_DO_NOT_LEAK_2026@127.0.0.1:1/o/r.git

================================================================
LEAK HUNT: grep the token across every persisted/logged surface
================================================================
  RESULT: token absent from every DB/log/stdout surface

================================================================
AUTHENTICATION PRESERVED: credential reachable on bare origin
================================================================
  RESULT: full credentialled URL present on bare gate origin (pushes can authenticate)
```
</details>
<details>
<summary>Evidence: CLI init stdout showing redacted remote line</summary>

```text
_  _ ____    _  _ _ ____ ___ ____ _  _ ____ ____
|\ | |  |    |\/| | [__   |  |__| |_/  |___ [__ 
| \| |__|    |  | | ___]  |  |  | | \_ |___ ___]

  ✓ Gate initialized

    repo  /tmp/no-mistakes-evidence/01KXE9V8NHG1HMY2P2GBE6WWH2/repo
    gate  no-mistakes → /tmp/no-mistakes-evidence/01KXE9V8NHG1HMY2P2GBE6WWH2/nm-home/repos/ada4b8b3a5c3.git
  remote  https://redacted@127.0.0.1:1/o/r.git
   skill  /no-mistakes installed for agents at user level

  Push through the gate with:
  git push no-mistakes <branch>
```
</details>
<details>
<summary>Evidence: cli.log containing the redacted &#39;gate initialized&#39; line</summary>

```text
time=2026-07-13T18:30:36.859Z level=INFO msg="gate initialized" repo_id=ada4b8b3a5c3 path=/tmp/no-mistakes-evidence/01KXE9V8NHG1HMY2P2GBE6WWH2/repo upstream=https://redacted@127.0.0.1:1/o/r.git
time=2026-07-13T18:30:36.983Z level=INFO msg="daemon process started" pid=540502 log=/tmp/no-mistakes-evidence/01KXE9V8NHG1HMY2P2GBE6WWH2/nm-home/logs/daemon.log
time=2026-07-13T18:30:37.085Z level=INFO msg="daemon is responsive" pid=540502
2026-07-13T18:37:47Z lifecycle command=daemon.stop force=false pid=698557 ppid=698555 parent_cmdline="/bin/bash -c EVID=/tmp/no-mistakes-evidence/01KXE9V8NHG1HMY2P2GBE6WWH2 export NM_HOME=\"$EVID/nm-home\" export HOME=\"$EVID/fake-home\" /home/ubuntu/.no-mistakes/worktrees/8f91e2c7b6ba/01KXE9V8NHG1HMY2P2GBE6WWH2/bin/no-mistakes daemon stop 2>&1 || true echo \"--- daemon stopped ---\""
time=2026-07-13T18:37:47.136Z level=INFO msg="daemon stopped gracefully"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `internal/pipeline/executor.go:640` - The defensive redaction computes `redactedErr := safeurl.RedactText(err.Error())` and uses it for the log-file write (line 638) and touchLogActivity (line 639), but the immediately adjacent calls still pass the RAW `err.Error()`: `e.db.FailStep(sr.ID, err.Error(), ...)` (line 640) persists the unredacted string into BOTH `step_results.error` and `step_results.last_activity` SQLite columns (see FailStep in db/step.go:155), and `e.emitStepEventWithFindingsDiffAndError(..., err.Error(), ...)` (line 643) emits it on the IPC event&#39;s `Error` field surfaced to subscribers. The whole PR&#39;s goal is keeping credentials out of persistent/surfaced surfaces; for git-sourced errors git.Run already redacts at source (git.go:50) so all three paths are safe, but for non-git errors (agent, exec shell, HTTP) the very credential leak the line-638 redaction guards against lands unredacted in the DB row and event. Fix: reuse the already-computed `redactedErr` in the FailStep and emit calls.
- ℹ️ `internal/pipeline/steps/common_git.go:90` - resolveUpstreamRemoteName compares `upstreamURL` (now the redacted DB copy passed from ci.go:122 / ci_fix.go:20) against each remote&#39;s live URL (credentialled). For credentialled repos the comparison at line 90 (`TrimSpace(url) == TrimSpace(upstreamURL)`) never matches, so the function always falls back to returning &#34;origin&#34; (line 94). This is correct for the no-mistakes flow (the gate always names the upstream remote &#34;origin&#34;), so there is no functional regression, but the URL-matching loop is now effectively dead for credentialled repos and a future maintainer adding a non-&#34;origin&#34; upstream remote would silently lose the matching behavior.

🔧 Fix: redact executor step-failure error in FailStep and IPC emit
1 warning still open:
- ⚠️ `internal/pipeline/executor.go:644` - executeStep computes `redactedErr := safeurl.RedactText(err.Error())` (line 637) and correctly uses it for the log-file write (638), touchLogActivity (639), FailStep→step_results.error (640), and the step IPC event (643). But the immediately following return at line 644 still wraps the RAW error: `return false, fmt.Errorf(&#34;step %s failed: %w&#34;, stepName, err)`. All three callers (lines 164, 333, 417) pass this to `e.failRun(run, repo, err, ctx)`, where `errMsg := err.Error()` (line 983) extracts the raw text and `e.db.UpdateRunErrorStatus(run.ID, errMsg, ...)` (line 994) persists it unredacted to the `runs.error` SQLite column, while `run.Error = &amp;errMsg; e.emitRunEvent(...)` (lines 998-999) emits it on the run IPC event&#39;s `Error` field — both surfaced to users via `axi status`. For non-git errors (agent, exec shell, HTTP) that embed a credentialled upstream URL — the exact class the line-637 defensive redaction guards against — the credential lands unredacted in the run-level DB row and event even though the step-level surfaces are now scrubbed. This is a materially different surface than round 1&#39;s `executor-redaction-gap` (runs.error/run-event vs step_results.error/step-event). Fix: return the already-redacted string, e.g. `return false, fmt.Errorf(&#34;step %s failed: %s&#34;, stepName, redactedErr)`; no caller unwraps the returned error (all three pass it to failRun which only calls .Error()), so switching %w to %s is safe.

🔧 Fix: redact executor step-failed return error to scrub runs.error
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`
- `go test -race -run 'TestInitRedactsCredentialURL' ./internal/gate/...`
- `go test -race -run 'TestResolveUpstreamURL_PreservesCredential|TestResolveUpstreamURL_FallsBackToRecordedURL|TestResolvePushURL_ForkWinsOverCredential' ./internal/pipeline/steps/...`
- `go test -race -run 'TestCIStep_CommitAndPushRedactsForkURLInGitErrors|TestPushStep_RedactsForkURLInGitErrors' ./internal/pipeline/steps/...`
- `go test -race ./internal/safeurl/...`
- `go test -race -run 'TestExecutor_StepErrorRedactsCredentialURL' ./internal/pipeline/ (new test I added)`
- `go test -race -run 'TestResolveBitbucketRepoRef_RedactsCredentialInError' ./internal/pipeline/steps/ (new test I added)`
- `go test -race -timeout 400s ./internal/gate/... ./internal/pipeline/ ./internal/pipeline/steps/ ./internal/db/...`
- `go build -o ./bin/no-mistakes ./cmd/no-mistakes`
- <code>E2E manual: built the binary, created a git repo with origin=https://x-access-token:ghp_secret_DO_NOT_LEAK_2026@127.0.0.1:1/o/r.git, ran `no-mistakes init`, then inspected CLI stdout, cli.log &#39;gate initialized&#39; line, state.sqlite repos.upstream_url column, bare gate origin remote, and grepped every surface for the token</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
