### PR TITLE
fix(scm): fail closed on invalid PR listings

### DIFF
--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -174,6 +174,7 @@ Creates or updates a pull request.
 **Behavior:**
 - Checks for an existing PR on the branch
 - If one exists, updates it. If not, creates a new one.
+- If existing-PR discovery fails or its provider output is not valid JSON, stops instead of treating the result as no PR and creating a duplicate.
 - Uses the provider CLI for GitHub/GitLab, the `az` CLI for Azure DevOps, and the Bitbucket API for Bitbucket Cloud
 - For GitHub fork routing, keeps `gh --repo` pointed at the parent repository from `origin`, checks existing PRs with the bare branch name, filters matching PRs by head owner, and creates PRs with `--head <fork-owner>:<branch>`
 - PR title: agent-generated with user intent when available, in conventional commit format (`type(scope): description` or `type: description`); user-facing product impact should use `feat` or `fix` so release automation can pick it up; when a scope is used, it should be the primary affected real module/package from the changed paths and kept broad rather than file-level

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -174,7 +174,7 @@ Creates or updates a pull request.
 **Behavior:**
 - Checks for an existing PR on the branch
 - If one exists, updates it. If not, creates a new one.
-- If existing-PR discovery fails or its provider output is not valid JSON, stops instead of treating the result as no PR and creating a duplicate.
+- If existing-PR discovery fails or its provider response cannot be decoded as the expected PR listing, stops instead of treating the result as no PR and creating a duplicate.
 - Uses the provider CLI for GitHub/GitLab, the `az` CLI for Azure DevOps, and the Bitbucket API for Bitbucket Cloud
 - For GitHub fork routing, keeps `gh --repo` pointed at the parent repository from `origin`, checks existing PRs with the bare branch name, filters matching PRs by head owner, and creates PRs with `--head <fork-owner>:<branch>`
 - PR title: agent-generated with user intent when available, in conventional commit format (`type(scope): description` or `type: description`); user-facing product impact should use `feat` or `fix` so release automation can pick it up; when a scope is used, it should be the primary affected real module/package from the changed paths and kept broad rather than file-level

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -218,7 +218,7 @@ Creates or updates a pull request.
 **Behavior:**
 - Checks for an existing PR on the branch, matching by branch alone rather than filtering by base, so a still-open PR against a since-changed [`pr.base_branch`](/no-mistakes/reference/repo-config/#prbase_branch) is found and updated instead of orphaned behind a duplicate
 - If one exists, updates it. If not, creates a new one against the configured base branch.
-- If existing-PR discovery fails or its provider response cannot be decoded as the expected PR listing, stops instead of treating the result as no PR and creating a duplicate.
+- If existing-PR discovery fails or its provider response cannot be decoded and validated as a PR listing for the configured repository, stops instead of treating the result as no PR and creating a duplicate.
 - Uses `gh` for GitHub, `glab` for GitLab, `forgejo-axi` for Forgejo, the Bitbucket API for Bitbucket Cloud, and `az` for Azure DevOps
 - For GitHub fork routing, keeps `gh --repo` pointed at the parent repository from `origin`, checks existing PRs with the bare branch name, filters matching PRs by head owner, and creates PRs with `--head <fork-owner>:<branch>`
 - PR title: agent-generated from the final branch delta with user intent when available, in conventional commit format (`type(scope): description` or `type: description`); user-facing product impact should use `feat` or `fix` so release automation can pick it up; when a scope is used, it should be the primary affected real module/package from the changed paths and kept broad rather than file-level. If drafting fails, the fallback uses the neutral title `chore: update pull request` rather than inferring scope from earlier commits.

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -218,7 +218,7 @@ Creates or updates a pull request.
 **Behavior:**
 - Checks for an existing PR on the branch, matching by branch alone rather than filtering by base, so a still-open PR against a since-changed [`pr.base_branch`](/no-mistakes/reference/repo-config/#prbase_branch) is found and updated instead of orphaned behind a duplicate
 - If one exists, updates it. If not, creates a new one against the configured base branch.
-- If existing-PR discovery fails or its provider output is not valid JSON, stops instead of treating the result as no PR and creating a duplicate.
+- If existing-PR discovery fails or its provider response cannot be decoded as the expected PR listing, stops instead of treating the result as no PR and creating a duplicate.
 - Uses `gh` for GitHub, `glab` for GitLab, `forgejo-axi` for Forgejo, the Bitbucket API for Bitbucket Cloud, and `az` for Azure DevOps
 - For GitHub fork routing, keeps `gh --repo` pointed at the parent repository from `origin`, checks existing PRs with the bare branch name, filters matching PRs by head owner, and creates PRs with `--head <fork-owner>:<branch>`
 - PR title: agent-generated from the final branch delta with user intent when available, in conventional commit format (`type(scope): description` or `type: description`); user-facing product impact should use `feat` or `fix` so release automation can pick it up; when a scope is used, it should be the primary affected real module/package from the changed paths and kept broad rather than file-level. If drafting fails, the fallback uses the neutral title `chore: update pull request` rather than inferring scope from earlier commits.

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -218,6 +218,7 @@ Creates or updates a pull request.
 **Behavior:**
 - Checks for an existing PR on the branch, matching by branch alone rather than filtering by base, so a still-open PR against a since-changed [`pr.base_branch`](/no-mistakes/reference/repo-config/#prbase_branch) is found and updated instead of orphaned behind a duplicate
 - If one exists, updates it. If not, creates a new one against the configured base branch.
+- If existing-PR discovery fails or its provider output is not valid JSON, stops instead of treating the result as no PR and creating a duplicate.
 - Uses `gh` for GitHub, `glab` for GitLab, `forgejo-axi` for Forgejo, the Bitbucket API for Bitbucket Cloud, and `az` for Azure DevOps
 - For GitHub fork routing, keeps `gh --repo` pointed at the parent repository from `origin`, checks existing PRs with the bare branch name, filters matching PRs by head owner, and creates PRs with `--head <fork-owner>:<branch>`
 - PR title: agent-generated from the final branch delta with user intent when available, in conventional commit format (`type(scope): description` or `type: description`); user-facing product impact should use `feat` or `fix` so release automation can pick it up; when a scope is used, it should be the primary affected real module/package from the changed paths and kept broad rather than file-level. If drafting fails, the fallback uses the neutral title `chore: update pull request` rather than inferring scope from earlier commits.

--- a/internal/bitbucket/client.go
+++ b/internal/bitbucket/client.go
@@ -125,11 +125,14 @@ func (c *Client) FindOpenPRBySourceBranch(ctx context.Context, repo RepoRef, bra
 	clauses = append(clauses, fmt.Sprintf(`state=%q`, "OPEN"))
 	query.Set("q", strings.Join(clauses, " AND "))
 
-	var response struct {
+	var response *struct {
 		Values []bitbucketPullRequest `json:"values"`
 	}
 	if err := c.doJSON(ctx, http.MethodGet, repoPRPath(repo), query, nil, &response); err != nil {
 		return nil, err
+	}
+	if response == nil || response.Values == nil {
+		return nil, fmt.Errorf("decode Bitbucket PR list: expected values array")
 	}
 	if len(response.Values) == 0 {
 		return nil, nil

--- a/internal/bitbucket/client.go
+++ b/internal/bitbucket/client.go
@@ -403,8 +403,12 @@ func (c *Client) doJSONPathOrURL(ctx context.Context, method, pathOrURL string, 
 	if responseBody == nil {
 		return nil
 	}
-	if err := json.NewDecoder(resp.Body).Decode(responseBody); err != nil {
+	decoder := json.NewDecoder(resp.Body)
+	if err := decoder.Decode(responseBody); err != nil {
 		return fmt.Errorf("decode Bitbucket response: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return fmt.Errorf("decode Bitbucket response: expected a single JSON value")
 	}
 	return nil
 }

--- a/internal/bitbucket/client.go
+++ b/internal/bitbucket/client.go
@@ -137,9 +137,14 @@ func (c *Client) FindOpenPRBySourceBranch(ctx context.Context, repo RepoRef, bra
 	if len(response.Values) == 0 {
 		return nil, nil
 	}
-	for i, candidate := range response.Values {
+	for i := range response.Values {
+		candidate := &response.Values[i]
 		if candidate.ID <= 0 {
 			return nil, fmt.Errorf("decode Bitbucket PR list: entry %d missing positive id", i)
+		}
+		candidate.Links.HTML.Href = prURL(repo, candidate.ID, "")
+		if candidate.Links.HTML.Href == "" {
+			return nil, fmt.Errorf("decode Bitbucket PR list: entry %d missing configured repository identity", i)
 		}
 	}
 	return response.Values[0].toPullRequest(), nil

--- a/internal/bitbucket/client.go
+++ b/internal/bitbucket/client.go
@@ -137,6 +137,11 @@ func (c *Client) FindOpenPRBySourceBranch(ctx context.Context, repo RepoRef, bra
 	if len(response.Values) == 0 {
 		return nil, nil
 	}
+	for i, candidate := range response.Values {
+		if candidate.ID <= 0 {
+			return nil, fmt.Errorf("decode Bitbucket PR list: entry %d missing positive id", i)
+		}
+	}
 	return response.Values[0].toPullRequest(), nil
 }
 

--- a/internal/bitbucket/client_test.go
+++ b/internal/bitbucket/client_test.go
@@ -165,6 +165,43 @@ func TestFindOpenPRBySourceAndDestinationBranchFiltersSourceRepo(t *testing.T) {
 	}
 }
 
+func TestFindOpenPRBySourceBranchRejectsInvalidResponse(t *testing.T) {
+	repo := RepoRef{Workspace: "test", RepoSlug: "repo"}
+
+	for _, tc := range []struct {
+		name     string
+		response string
+	}{
+		{name: "null", response: "null"},
+		{name: "missing values", response: `{}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tc.response))
+			}))
+			defer server.Close()
+
+			client := &Client{
+				baseURL: server.URL,
+				email:   "test@example.com",
+				token:   "token",
+				httpClient: &http.Client{
+					Timeout: time.Second,
+				},
+			}
+
+			pr, err := client.FindOpenPRBySourceBranch(context.Background(), repo, "feature", "main")
+			if err == nil {
+				t.Fatal("FindOpenPRBySourceBranch() error = nil, want response error")
+			}
+			if pr != nil {
+				t.Fatalf("FindOpenPRBySourceBranch() = %#v, want nil", pr)
+			}
+		})
+	}
+}
+
 func TestListPipelinesByCommitFollowsPagination(t *testing.T) {
 	repo := RepoRef{Workspace: "test", RepoSlug: "repo"}
 	var pageCalls int

--- a/internal/bitbucket/client_test.go
+++ b/internal/bitbucket/client_test.go
@@ -174,6 +174,7 @@ func TestFindOpenPRBySourceBranchRejectsInvalidResponse(t *testing.T) {
 	}{
 		{name: "null", response: "null"},
 		{name: "missing values", response: `{}`},
+		{name: "trailing data", response: `{"values":[]}garbage`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/bitbucket/client_test.go
+++ b/internal/bitbucket/client_test.go
@@ -175,6 +175,11 @@ func TestFindOpenPRBySourceBranchRejectsInvalidResponse(t *testing.T) {
 		{name: "null", response: "null"},
 		{name: "missing values", response: `{}`},
 		{name: "trailing data", response: `{"values":[]}garbage`},
+		{name: "missing identity", response: `{"values":[{}]}`},
+		{
+			name:     "later missing identity",
+			response: `{"values":[{"id":42,"links":{"html":{"href":"https://bitbucket.org/test/repo/pull-requests/42"}}},{}]}`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -195,6 +200,9 @@ func TestFindOpenPRBySourceBranchRejectsInvalidResponse(t *testing.T) {
 			pr, err := client.FindOpenPRBySourceBranch(context.Background(), repo, "feature", "main")
 			if err == nil {
 				t.Fatal("FindOpenPRBySourceBranch() error = nil, want response error")
+			}
+			if !strings.Contains(err.Error(), "Bitbucket") {
+				t.Fatalf("FindOpenPRBySourceBranch() error = %v, want provider parse context", err)
 			}
 			if pr != nil {
 				t.Fatalf("FindOpenPRBySourceBranch() = %#v, want nil", pr)

--- a/internal/bitbucket/client_test.go
+++ b/internal/bitbucket/client_test.go
@@ -165,6 +165,36 @@ func TestFindOpenPRBySourceAndDestinationBranchFiltersSourceRepo(t *testing.T) {
 	}
 }
 
+func TestFindOpenPRBySourceBranchCanonicalizesForeignHTMLLink(t *testing.T) {
+	repo := RepoRef{Workspace: "test", RepoSlug: "repo"}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"values":[{"id":42,"links":{"html":{"href":"https://bitbucket.org/other/repo/pull-requests/99"}}}]}`))
+	}))
+	defer server.Close()
+
+	client := &Client{
+		baseURL: server.URL,
+		email:   "test@example.com",
+		token:   "token",
+		httpClient: &http.Client{
+			Timeout: time.Second,
+		},
+	}
+
+	pr, err := client.FindOpenPRBySourceBranch(context.Background(), repo, "feature", "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pr == nil || pr.ID != 42 {
+		t.Fatalf("pr = %#v, want id 42", pr)
+	}
+	if pr.URL != "https://bitbucket.org/test/repo/pull-requests/42" {
+		t.Fatalf("pr.URL = %q, want configured canonical URL", pr.URL)
+	}
+}
+
 func TestFindOpenPRBySourceBranchRejectsInvalidResponse(t *testing.T) {
 	repo := RepoRef{Workspace: "test", RepoSlug: "repo"}
 

--- a/internal/pipeline/steps/pr_test.go
+++ b/internal/pipeline/steps/pr_test.go
@@ -98,6 +98,46 @@ func TestPRStep_UpdatesExistingPR(t *testing.T) {
 	}
 }
 
+func TestPRStep_MalformedPRListFailsClosed(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	env, logFile := fakeGH(t, "")
+	env = append(env, "FAKE_CLI_PR_LIST_JSON=[{")
+
+	sctx := newTestContextWithDBRecords(t, &mockAgent{name: "test"}, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+
+	_, err := (&PRStep{}).Execute(sctx)
+	if err == nil {
+		t.Fatal("Execute() error = nil, want malformed PR-list error")
+	}
+	if !strings.Contains(err.Error(), "parse gh pr list JSON") {
+		t.Fatalf("Execute() error = %v, want GitHub parse context", err)
+	}
+
+	logData, readErr := os.ReadFile(logFile)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	ghLog := string(logData)
+	if !strings.Contains(ghLog, "pr list --head feature ") || !strings.Contains(ghLog, "--state open --json number,url,baseRefName") {
+		t.Fatalf("expected production PR lookup command, got:\n%s", ghLog)
+	}
+	if strings.Contains(ghLog, "pr create") || strings.Contains(ghLog, "pr edit") {
+		t.Fatalf("malformed lookup must stop before PR mutation, got:\n%s", ghLog)
+	}
+
+	run, readErr := sctx.DB.GetRun(sctx.Run.ID)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if run.PRURL != nil {
+		t.Fatalf("PR URL = %q, want nil after malformed lookup", *run.PRURL)
+	}
+	t.Logf("gh transcript:\n%sobserved pipeline error: %v\nstored PR URL: <nil>", ghLog, err)
+}
+
 func TestPRStep_BitbucketUpdatesExistingPR(t *testing.T) {
 	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -117,10 +117,15 @@ func fakeRecordSuccessHandler() {
 func fakeGHHandler(args []string) {
 	prURL := os.Getenv("FAKE_CLI_PR_URL")
 	prBase := os.Getenv("FAKE_CLI_PR_BASE")
+	prListJSON, hasPRListJSON := os.LookupEnv("FAKE_CLI_PR_LIST_JSON")
 	if len(args) >= 2 && args[0] == "auth" && args[1] == "status" {
 		os.Exit(0)
 	}
 	if len(args) >= 2 && args[0] == "pr" && args[1] == "list" {
+		if hasPRListJSON {
+			fmt.Print(prListJSON)
+			os.Exit(0)
+		}
 		if prURL == "" {
 			fmt.Println("[]")
 			os.Exit(0)

--- a/internal/scm/azuredevops/azuredevops.go
+++ b/internal/scm/azuredevops/azuredevops.go
@@ -130,12 +130,16 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 	if err != nil {
 		return nil, fmt.Errorf("az repos pr list: %w", err)
 	}
-	if len(bytes.TrimSpace(out)) == 0 {
-		return nil, nil
+	trimmed := bytes.TrimSpace(out)
+	if len(trimmed) == 0 {
+		return nil, errors.New("az repos pr list: parse response: expected array")
 	}
 	var prs []azPR
-	if err := json.Unmarshal(out, &prs); err != nil {
+	if err := json.Unmarshal(trimmed, &prs); err != nil {
 		return nil, fmt.Errorf("az repos pr list: parse response: %w", err)
+	}
+	if prs == nil {
+		return nil, errors.New("az repos pr list: parse response: expected array")
 	}
 	if len(prs) == 0 {
 		return nil, nil

--- a/internal/scm/azuredevops/azuredevops.go
+++ b/internal/scm/azuredevops/azuredevops.go
@@ -131,12 +131,16 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 	if err != nil {
 		return nil, fmt.Errorf("az repos pr list: %w", err)
 	}
-	if len(bytes.TrimSpace(out)) == 0 {
-		return nil, nil
+	trimmed := bytes.TrimSpace(out)
+	if len(trimmed) == 0 {
+		return nil, errors.New("az repos pr list: parse response: expected array")
 	}
 	var prs []azPR
-	if err := json.Unmarshal(out, &prs); err != nil {
+	if err := json.Unmarshal(trimmed, &prs); err != nil {
 		return nil, fmt.Errorf("az repos pr list: parse response: %w", err)
+	}
+	if prs == nil {
+		return nil, errors.New("az repos pr list: parse response: expected array")
 	}
 	if len(prs) == 0 {
 		return nil, nil

--- a/internal/scm/azuredevops/azuredevops.go
+++ b/internal/scm/azuredevops/azuredevops.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"strconv"
@@ -146,11 +147,52 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 		return nil, nil
 	}
 	for i, candidate := range prs {
-		if candidate.PullRequestID <= 0 {
-			return nil, fmt.Errorf("az repos pr list: parse response: entry %d missing positive pullRequestId", i)
+		if err := h.validateListedPR(candidate); err != nil {
+			return nil, fmt.Errorf("az repos pr list: parse response: entry %d: %w", i, err)
 		}
 	}
 	return h.toPR(&prs[0]), nil
+}
+
+func (h *Host) validateListedPR(candidate azPR) error {
+	if candidate.PullRequestID <= 0 {
+		return errors.New("missing positive pullRequestId")
+	}
+	org, project, repo, ok := ParseRemote(candidate.Repository.WebURL)
+	if !ok {
+		return errors.New("missing valid repository.webUrl")
+	}
+	if !strings.EqualFold(azureOrganizationName(org), azureOrganizationName(h.org)) {
+		return fmt.Errorf("repository organization %q does not match configured organization %q", org, h.org)
+	}
+	if !strings.EqualFold(project, h.project) {
+		return fmt.Errorf("repository project %q does not match configured project %q", project, h.project)
+	}
+	if !strings.EqualFold(repo, h.repo) {
+		return fmt.Errorf("repository name %q does not match configured repository %q", repo, h.repo)
+	}
+	if name := strings.TrimSpace(candidate.Repository.Name); name != "" && !strings.EqualFold(name, h.repo) {
+		return fmt.Errorf("repository metadata name %q does not match configured repository %q", name, h.repo)
+	}
+	if name := strings.TrimSpace(candidate.Repository.Project.Name); name != "" && !strings.EqualFold(name, h.project) {
+		return fmt.Errorf("repository metadata project %q does not match configured project %q", name, h.project)
+	}
+	return nil
+}
+
+func azureOrganizationName(raw string) string {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return ""
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if host == "dev.azure.com" {
+		parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+		if len(parts) > 0 {
+			return parts[0]
+		}
+	}
+	return strings.TrimSuffix(host, ".visualstudio.com")
 }
 
 // runWithDescription runs an az PR command whose description is supplied

--- a/internal/scm/azuredevops/azuredevops.go
+++ b/internal/scm/azuredevops/azuredevops.go
@@ -145,6 +145,11 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 	if len(prs) == 0 {
 		return nil, nil
 	}
+	for i, candidate := range prs {
+		if candidate.PullRequestID <= 0 {
+			return nil, fmt.Errorf("az repos pr list: parse response: entry %d missing positive pullRequestId", i)
+		}
+	}
 	return h.toPR(&prs[0]), nil
 }
 

--- a/internal/scm/azuredevops/azuredevops.go
+++ b/internal/scm/azuredevops/azuredevops.go
@@ -158,9 +158,9 @@ func (h *Host) validateListedPR(candidate azPR) error {
 	if candidate.PullRequestID <= 0 {
 		return errors.New("missing positive pullRequestId")
 	}
-	org, project, repo, ok := ParseRemote(candidate.Repository.WebURL)
-	if !ok {
-		return errors.New("missing valid repository.webUrl")
+	org, project, repo, err := parseRepositoryWebURL(candidate.Repository.WebURL)
+	if err != nil {
+		return err
 	}
 	if !strings.EqualFold(azureOrganizationName(org), azureOrganizationName(h.org)) {
 		return fmt.Errorf("repository organization %q does not match configured organization %q", org, h.org)
@@ -178,6 +178,36 @@ func (h *Host) validateListedPR(candidate azPR) error {
 		return fmt.Errorf("repository metadata project %q does not match configured project %q", name, h.project)
 	}
 	return nil
+}
+
+func parseRepositoryWebURL(raw string) (string, string, string, error) {
+	trimmed := strings.TrimSpace(raw)
+	parsed, err := url.Parse(trimmed)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", "", "", errors.New("missing valid repository.webUrl")
+	}
+	if !strings.EqualFold(parsed.Scheme, "http") && !strings.EqualFold(parsed.Scheme, "https") {
+		return "", "", "", errors.New("repository.webUrl must be HTTP")
+	}
+	if parsed.ForceQuery || parsed.RawQuery != "" || strings.Contains(trimmed, "#") {
+		return "", "", "", errors.New("repository.webUrl must not contain query or fragment")
+	}
+	segments := splitDecodePath(parsed.EscapedPath())
+	gitIndex := -1
+	for i, segment := range segments {
+		if segment == "_git" {
+			gitIndex = i
+			break
+		}
+	}
+	if gitIndex < 1 || gitIndex+2 != len(segments) {
+		return "", "", "", errors.New("repository.webUrl must end at the repository path")
+	}
+	org, project, repo, ok := ParseRemote(trimmed)
+	if !ok {
+		return "", "", "", errors.New("missing valid repository.webUrl")
+	}
+	return org, project, repo, nil
 }
 
 func azureOrganizationName(raw string) string {
@@ -367,7 +397,7 @@ func (h *Host) toPR(raw *azPR) *scm.PR {
 	}
 	return &scm.PR{
 		Number:     id,
-		URL:        webPRURL(h.org, h.project, h.repo, raw.Repository.WebURL, id),
+		URL:        webPRURL(h.org, h.project, h.repo, "", id),
 		BaseBranch: strings.TrimPrefix(strings.TrimSpace(raw.TargetRefName), "refs/heads/"),
 	}
 }

--- a/internal/scm/azuredevops/azuredevops_test.go
+++ b/internal/scm/azuredevops/azuredevops_test.go
@@ -123,21 +123,32 @@ func TestFindPRIgnoresStderrChatter(t *testing.T) {
 	}
 }
 
-func TestFindPRReportsParseError(t *testing.T) {
+func TestFindPRRejectsInvalidJSON(t *testing.T) {
 	t.Parallel()
 
-	h := newTestHost(map[string]azdoTestResponse{
-		"az repos pr list --source-branch feature --status active --target-branch main --organization " + testOrg + " --project " + testProject + " --repository " + testRepo + " --output json": {
-			stdout: "not json at all\n",
-		},
-	})
+	for _, tc := range []struct {
+		name   string
+		output string
+	}{
+		{name: "malformed", output: "not json at all\n"},
+		{name: "missing", output: "\n"},
+		{name: "null", output: "null\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHost(map[string]azdoTestResponse{
+				"az repos pr list --source-branch feature --status active --target-branch main --organization " + testOrg + " --project " + testProject + " --repository " + testRepo + " --output json": {
+					stdout: tc.output,
+				},
+			})
 
-	pr, err := h.FindPR(context.Background(), "feature", "main")
-	if err == nil {
-		t.Fatalf("FindPR() error = nil, want parse error (must not be silently treated as no-PR)")
-	}
-	if pr != nil {
-		t.Fatalf("FindPR() = %+v, want nil on parse failure", pr)
+			pr, err := h.FindPR(context.Background(), "feature", "main")
+			if err == nil {
+				t.Fatal("FindPR() error = nil, want parse error")
+			}
+			if pr != nil {
+				t.Fatalf("FindPR() = %+v, want nil on parse failure", pr)
+			}
+		})
 	}
 }
 

--- a/internal/scm/azuredevops/azuredevops_test.go
+++ b/internal/scm/azuredevops/azuredevops_test.go
@@ -102,6 +102,9 @@ func TestFindPRAcceptsEquivalentOrganizationURLForms(t *testing.T) {
 	if pr == nil || pr.Number != "42" {
 		t.Fatalf("FindPR() = %+v, want PR 42", pr)
 	}
+	if pr.URL != "https://myorg.visualstudio.com/myproject/_git/myrepo/pullrequest/42" {
+		t.Fatalf("FindPR() URL = %q, want configured canonical URL", pr.URL)
+	}
 }
 
 func TestFindPRNoMatch(t *testing.T) {
@@ -165,6 +168,18 @@ func TestFindPRRejectsInvalidResponse(t *testing.T) {
 		{
 			name:   "foreign repository",
 			output: `[{"pullRequestId":42,"repository":{"webUrl":"https://dev.azure.com/myorg/myproject/_git/other"}}]` + "\n",
+		},
+		{
+			name:   "query suffix",
+			output: `[{"pullRequestId":42,"repository":{"webUrl":"https://dev.azure.com/myorg/myproject/_git/myrepo?view=files"}}]` + "\n",
+		},
+		{
+			name:   "fragment suffix",
+			output: `[{"pullRequestId":42,"repository":{"webUrl":"https://dev.azure.com/myorg/myproject/_git/myrepo#discussion"}}]` + "\n",
+		},
+		{
+			name:   "pull request suffix",
+			output: `[{"pullRequestId":42,"repository":{"webUrl":"https://dev.azure.com/myorg/myproject/_git/myrepo/pullrequest/99"}}]` + "\n",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/scm/azuredevops/azuredevops_test.go
+++ b/internal/scm/azuredevops/azuredevops_test.go
@@ -123,9 +123,10 @@ func TestFindPRIgnoresStderrChatter(t *testing.T) {
 	}
 }
 
-func TestFindPRRejectsInvalidJSON(t *testing.T) {
+func TestFindPRRejectsInvalidResponse(t *testing.T) {
 	t.Parallel()
 
+	valid := `{"pullRequestId":42,"repository":{"webUrl":"https://dev.azure.com/myorg/myproject/_git/myrepo"}}`
 	for _, tc := range []struct {
 		name   string
 		output string
@@ -133,6 +134,8 @@ func TestFindPRRejectsInvalidJSON(t *testing.T) {
 		{name: "malformed", output: "not json at all\n"},
 		{name: "missing", output: "\n"},
 		{name: "null", output: "null\n"},
+		{name: "missing identity", output: "[{}]\n"},
+		{name: "later missing identity", output: "[" + valid + ",{}]\n"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			h := newTestHost(map[string]azdoTestResponse{
@@ -144,6 +147,9 @@ func TestFindPRRejectsInvalidJSON(t *testing.T) {
 			pr, err := h.FindPR(context.Background(), "feature", "main")
 			if err == nil {
 				t.Fatal("FindPR() error = nil, want parse error")
+			}
+			if !strings.Contains(err.Error(), "az repos pr list: parse response") {
+				t.Fatalf("FindPR() error = %v, want provider parse context", err)
 			}
 			if pr != nil {
 				t.Fatalf("FindPR() = %+v, want nil on parse failure", pr)

--- a/internal/scm/azuredevops/azuredevops_test.go
+++ b/internal/scm/azuredevops/azuredevops_test.go
@@ -86,6 +86,24 @@ func TestFindPRReturnsBrowsableURL(t *testing.T) {
 	}
 }
 
+func TestFindPRAcceptsEquivalentOrganizationURLForms(t *testing.T) {
+	t.Parallel()
+
+	h := New(azdoTestCmdFactory(map[string]azdoTestResponse{
+		"az repos pr list --source-branch feature --status active --target-branch main --organization https://myorg.visualstudio.com --project " + testProject + " --repository " + testRepo + " --output json": {
+			stdout: `[{"pullRequestId":42,"status":"active","repository":{"webUrl":"https://dev.azure.com/myorg/myproject/_git/myrepo"}}]` + "\n",
+		},
+	}), func() bool { return true }, "https://myorg.visualstudio.com", testProject, testRepo)
+
+	pr, err := h.FindPR(context.Background(), "feature", "main")
+	if err != nil {
+		t.Fatalf("FindPR() error = %v", err)
+	}
+	if pr == nil || pr.Number != "42" {
+		t.Fatalf("FindPR() = %+v, want PR 42", pr)
+	}
+}
+
 func TestFindPRNoMatch(t *testing.T) {
 	t.Parallel()
 
@@ -136,6 +154,18 @@ func TestFindPRRejectsInvalidResponse(t *testing.T) {
 		{name: "null", output: "null\n"},
 		{name: "missing identity", output: "[{}]\n"},
 		{name: "later missing identity", output: "[" + valid + ",{}]\n"},
+		{
+			name:   "foreign organization",
+			output: `[{"pullRequestId":42,"repository":{"webUrl":"https://dev.azure.com/other/myproject/_git/myrepo"}}]` + "\n",
+		},
+		{
+			name:   "foreign project",
+			output: `[{"pullRequestId":42,"repository":{"webUrl":"https://dev.azure.com/myorg/other/_git/myrepo"}}]` + "\n",
+		},
+		{
+			name:   "foreign repository",
+			output: `[{"pullRequestId":42,"repository":{"webUrl":"https://dev.azure.com/myorg/myproject/_git/other"}}]` + "\n",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			h := newTestHost(map[string]azdoTestResponse{

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -179,7 +179,10 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 			Login string `json:"login"`
 		} `json:"headRepositoryOwner"`
 	}
-	if err := json.Unmarshal(out, &prs); err != nil || len(prs) == 0 {
+	if err := json.Unmarshal(out, &prs); err != nil {
+		return nil, fmt.Errorf("parse gh pr list JSON: %w", err)
+	}
+	if len(prs) == 0 {
 		return nil, nil
 	}
 	for _, candidate := range prs {

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -182,6 +182,9 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 	if err := json.Unmarshal(out, &prs); err != nil {
 		return nil, fmt.Errorf("parse gh pr list JSON: %w", err)
 	}
+	if prs == nil {
+		return nil, errors.New("parse gh pr list JSON: expected array")
+	}
 	if len(prs) == 0 {
 		return nil, nil
 	}

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -181,7 +181,10 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 			Login string `json:"login"`
 		} `json:"headRepositoryOwner"`
 	}
-	if err := json.Unmarshal(out, &prs); err != nil || len(prs) == 0 {
+	if err := json.Unmarshal(out, &prs); err != nil {
+		return nil, fmt.Errorf("parse gh pr list JSON: %w", err)
+	}
+	if len(prs) == 0 {
 		return nil, nil
 	}
 	for _, candidate := range prs {

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -156,6 +157,28 @@ func (h *Host) Available(ctx context.Context) error {
 	return nil
 }
 
+func parsePullRequestURL(raw, expectedHost string) (int, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return 0, errors.New("expected absolute GitHub pull request URL")
+	}
+	if !strings.EqualFold(parsed.Scheme, "http") && !strings.EqualFold(parsed.Scheme, "https") {
+		return 0, errors.New("expected HTTP GitHub pull request URL")
+	}
+	if expectedHost != "" && !strings.EqualFold(parsed.Hostname(), expectedHost) {
+		return 0, fmt.Errorf("URL host %q does not match GitHub host %q", parsed.Hostname(), expectedHost)
+	}
+	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(segments) < 4 || segments[len(segments)-2] != "pull" {
+		return 0, errors.New("expected GitHub /owner/repo/pull/number URL")
+	}
+	number, err := strconv.Atoi(segments[len(segments)-1])
+	if err != nil || number <= 0 {
+		return 0, errors.New("expected positive GitHub pull request number")
+	}
+	return number, nil
+}
+
 func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error) {
 	args := []string{"pr", "list", "--head", branch}
 	if strings.TrimSpace(base) != "" {
@@ -196,17 +219,17 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 		if url == "" {
 			return nil, fmt.Errorf("parse gh pr list JSON: entry %d missing PR URL", i)
 		}
-		number, err := scm.ExtractPRNumber(url)
+		number, err := parsePullRequestURL(url, h.host)
 		if err != nil {
 			return nil, fmt.Errorf("parse gh pr list JSON: entry %d invalid PR URL: %w", i, err)
 		}
-		if candidate.Number != 0 && fmt.Sprintf("%d", candidate.Number) != number {
-			return nil, fmt.Errorf("parse gh pr list JSON: entry %d PR number %d does not match URL number %s", i, candidate.Number, number)
+		if candidate.Number != 0 && candidate.Number != number {
+			return nil, fmt.Errorf("parse gh pr list JSON: entry %d PR number %d does not match URL number %d", i, candidate.Number, number)
 		}
 		if candidate.Number > 0 {
 			prNumbers[i] = fmt.Sprintf("%d", candidate.Number)
 		} else {
-			prNumbers[i] = number
+			prNumbers[i] = strconv.Itoa(number)
 		}
 		if h.forkOwner != "" {
 			if strings.TrimSpace(candidate.HeadRefName) == "" {

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -190,6 +190,11 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 	if len(prs) == 0 {
 		return nil, nil
 	}
+	for i, candidate := range prs {
+		if strings.TrimSpace(candidate.URL) == "" {
+			return nil, fmt.Errorf("parse gh pr list JSON: entry %d missing PR URL", i)
+		}
+	}
 	for _, candidate := range prs {
 		if !h.matchesHead(candidate.HeadRefName, candidate.HeadRepositoryOwner, branch) {
 			continue
@@ -199,9 +204,6 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 			pr.Number = fmt.Sprintf("%d", candidate.Number)
 		} else if num, nerr := scm.ExtractPRNumber(pr.URL); nerr == nil {
 			pr.Number = num
-		}
-		if pr.URL == "" {
-			return nil, nil
 		}
 		return pr, nil
 	}

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -157,7 +157,7 @@ func (h *Host) Available(ctx context.Context) error {
 	return nil
 }
 
-func parsePullRequestURL(raw, expectedHost string) (int, error) {
+func parsePullRequestURL(raw, expectedHost, expectedRepo string) (int, error) {
 	parsed, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
 		return 0, errors.New("expected absolute GitHub pull request URL")
@@ -169,10 +169,20 @@ func parsePullRequestURL(raw, expectedHost string) (int, error) {
 		return 0, fmt.Errorf("URL host %q does not match GitHub host %q", parsed.Hostname(), expectedHost)
 	}
 	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
-	if len(segments) < 4 || segments[len(segments)-2] != "pull" {
+	if len(segments) != 4 || segments[2] != "pull" {
 		return 0, errors.New("expected GitHub /owner/repo/pull/number URL")
 	}
-	number, err := strconv.Atoi(segments[len(segments)-1])
+	for _, segment := range segments[:2] {
+		if segment == "" || segment == "." || segment == ".." {
+			return 0, errors.New("expected unambiguous GitHub owner/repository path")
+		}
+	}
+	actualRepo := segments[0] + "/" + segments[1]
+	expectedRepo = strings.Trim(strings.TrimSpace(expectedRepo), "/")
+	if expectedRepo != "" && !strings.EqualFold(actualRepo, expectedRepo) {
+		return 0, fmt.Errorf("URL repository %q does not match GitHub repository %q", actualRepo, expectedRepo)
+	}
+	number, err := strconv.Atoi(segments[3])
 	if err != nil || number <= 0 {
 		return 0, errors.New("expected positive GitHub pull request number")
 	}
@@ -219,7 +229,7 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 		if url == "" {
 			return nil, fmt.Errorf("parse gh pr list JSON: entry %d missing PR URL", i)
 		}
-		number, err := parsePullRequestURL(url, h.host)
+		number, err := parsePullRequestURL(url, h.host, h.repoSlug())
 		if err != nil {
 			return nil, fmt.Errorf("parse gh pr list JSON: entry %d invalid PR URL: %w", i, err)
 		}

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -184,6 +184,9 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 	if err := json.Unmarshal(out, &prs); err != nil {
 		return nil, fmt.Errorf("parse gh pr list JSON: %w", err)
 	}
+	if prs == nil {
+		return nil, errors.New("parse gh pr list JSON: expected array")
+	}
 	if len(prs) == 0 {
 		return nil, nil
 	}

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -190,20 +190,41 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 	if len(prs) == 0 {
 		return nil, nil
 	}
+	prNumbers := make([]string, len(prs))
 	for i, candidate := range prs {
-		if strings.TrimSpace(candidate.URL) == "" {
+		url := strings.TrimSpace(candidate.URL)
+		if url == "" {
 			return nil, fmt.Errorf("parse gh pr list JSON: entry %d missing PR URL", i)
 		}
+		number, err := scm.ExtractPRNumber(url)
+		if err != nil {
+			return nil, fmt.Errorf("parse gh pr list JSON: entry %d invalid PR URL: %w", i, err)
+		}
+		if candidate.Number != 0 && fmt.Sprintf("%d", candidate.Number) != number {
+			return nil, fmt.Errorf("parse gh pr list JSON: entry %d PR number %d does not match URL number %s", i, candidate.Number, number)
+		}
+		if candidate.Number > 0 {
+			prNumbers[i] = fmt.Sprintf("%d", candidate.Number)
+		} else {
+			prNumbers[i] = number
+		}
+		if h.forkOwner != "" {
+			if strings.TrimSpace(candidate.HeadRefName) == "" {
+				return nil, fmt.Errorf("parse gh pr list JSON: entry %d missing headRefName", i)
+			}
+			if candidate.HeadRepositoryOwner == nil || strings.TrimSpace(candidate.HeadRepositoryOwner.Login) == "" {
+				return nil, fmt.Errorf("parse gh pr list JSON: entry %d missing headRepositoryOwner login", i)
+			}
+		}
 	}
-	for _, candidate := range prs {
+	for i, candidate := range prs {
 		if !h.matchesHead(candidate.HeadRefName, candidate.HeadRepositoryOwner, branch) {
 			continue
 		}
-		pr := &scm.PR{URL: strings.TrimSpace(candidate.URL), BaseBranch: strings.TrimSpace(candidate.BaseRefName)}
-		if candidate.Number > 0 {
-			pr.Number = fmt.Sprintf("%d", candidate.Number)
-		} else if num, nerr := scm.ExtractPRNumber(pr.URL); nerr == nil {
-			pr.Number = num
+		pr := &scm.PR{
+			Number:     prNumbers[i],
+			URL:        strings.TrimSpace(candidate.URL),
+			BaseBranch: strings.TrimSpace(candidate.BaseRefName),
 		}
 		return pr, nil
 	}

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -158,7 +158,8 @@ func (h *Host) Available(ctx context.Context) error {
 }
 
 func parsePullRequestURL(raw, expectedHost, expectedRepo string) (int, error) {
-	parsed, err := url.Parse(strings.TrimSpace(raw))
+	trimmed := strings.TrimSpace(raw)
+	parsed, err := url.Parse(trimmed)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
 		return 0, errors.New("expected absolute GitHub pull request URL")
 	}
@@ -185,6 +186,13 @@ func parsePullRequestURL(raw, expectedHost, expectedRepo string) (int, error) {
 	number, err := strconv.Atoi(segments[3])
 	if err != nil || number <= 0 {
 		return 0, errors.New("expected positive GitHub pull request number")
+	}
+	escapedSegments := strings.Split(strings.Trim(parsed.EscapedPath(), "/"), "/")
+	if len(escapedSegments) != len(segments) || escapedSegments[len(escapedSegments)-1] != strconv.Itoa(number) {
+		return 0, errors.New("expected canonical GitHub pull request number path")
+	}
+	if parsed.ForceQuery || parsed.RawQuery != "" || strings.Contains(trimmed, "#") {
+		return 0, errors.New("expected GitHub pull request URL without query or fragment")
 	}
 	return number, nil
 }

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -225,6 +225,9 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 	}
 	prNumbers := make([]string, len(prs))
 	for i, candidate := range prs {
+		if candidate.Number <= 0 {
+			return nil, fmt.Errorf("parse gh pr list JSON: entry %d missing positive PR number", i)
+		}
 		url := strings.TrimSpace(candidate.URL)
 		if url == "" {
 			return nil, fmt.Errorf("parse gh pr list JSON: entry %d missing PR URL", i)
@@ -233,14 +236,10 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 		if err != nil {
 			return nil, fmt.Errorf("parse gh pr list JSON: entry %d invalid PR URL: %w", i, err)
 		}
-		if candidate.Number != 0 && candidate.Number != number {
+		if candidate.Number != number {
 			return nil, fmt.Errorf("parse gh pr list JSON: entry %d PR number %d does not match URL number %d", i, candidate.Number, number)
 		}
-		if candidate.Number > 0 {
-			prNumbers[i] = fmt.Sprintf("%d", candidate.Number)
-		} else {
-			prNumbers[i] = strconv.Itoa(number)
-		}
+		prNumbers[i] = strconv.Itoa(candidate.Number)
 		if h.forkOwner != "" {
 			if strings.TrimSpace(candidate.HeadRefName) == "" {
 				return nil, fmt.Errorf("parse gh pr list JSON: entry %d missing headRefName", i)

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -321,6 +321,27 @@ func TestFindPRReturnsCLIError(t *testing.T) {
 	}
 }
 
+func TestFindPRReturnsJSONError(t *testing.T) {
+	t.Parallel()
+
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		"gh pr list --head feature/refactor --base main --state open --json number,url": {
+			stdout: "[{\n",
+		},
+	}), nil, "", "")
+
+	pr, err := host.FindPR(context.Background(), "feature/refactor", "main")
+	if err == nil {
+		t.Fatal("FindPR() error = nil, want JSON error")
+	}
+	if !strings.Contains(err.Error(), "parse gh pr list") {
+		t.Fatalf("FindPR() error = %v, want parse context", err)
+	}
+	if pr != nil {
+		t.Fatalf("FindPR() PR = %+v, want nil", pr)
+	}
+}
+
 func TestAvailableScopesAuthToConfiguredHost(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -324,21 +324,23 @@ func TestFindPRReturnsCLIError(t *testing.T) {
 func TestFindPRReturnsJSONError(t *testing.T) {
 	t.Parallel()
 
-	host := New(githubTestCmdFactory(map[string]githubTestResponse{
-		"gh pr list --head feature/refactor --base main --state open --json number,url": {
-			stdout: "[{\n",
-		},
-	}), nil, "", "")
+	for _, output := range []string{"[{\n", "null\n"} {
+		host := New(githubTestCmdFactory(map[string]githubTestResponse{
+			"gh pr list --head feature/refactor --base main --state open --json number,url": {
+				stdout: output,
+			},
+		}), nil, "", "")
 
-	pr, err := host.FindPR(context.Background(), "feature/refactor", "main")
-	if err == nil {
-		t.Fatal("FindPR() error = nil, want JSON error")
-	}
-	if !strings.Contains(err.Error(), "parse gh pr list") {
-		t.Fatalf("FindPR() error = %v, want parse context", err)
-	}
-	if pr != nil {
-		t.Fatalf("FindPR() PR = %+v, want nil", pr)
+		pr, err := host.FindPR(context.Background(), "feature/refactor", "main")
+		if err == nil {
+			t.Fatal("FindPR() error = nil, want JSON error")
+		}
+		if !strings.Contains(err.Error(), "parse gh pr list") {
+			t.Fatalf("FindPR() error = %v, want parse context", err)
+		}
+		if pr != nil {
+			t.Fatalf("FindPR() PR = %+v, want nil", pr)
+		}
 	}
 }
 

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -941,6 +941,27 @@ func TestFindPRReturnsCLIError(t *testing.T) {
 	}
 }
 
+func TestFindPRRejectsURLForDifferentRepository(t *testing.T) {
+	t.Parallel()
+
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		"gh pr list --head feature/refactor --base main --repo parent/repo --state open --json number,url,baseRefName": {
+			stdout: `[{"number":42,"url":"https://github.com/other/repo/pull/42","baseRefName":"main"}]` + "\n",
+		},
+	}), nil, "github.com", "parent/repo")
+
+	pr, err := host.FindPR(context.Background(), "feature/refactor", "main")
+	if err == nil {
+		t.Fatal("FindPR() error = nil, want repository mismatch error")
+	}
+	if !strings.Contains(err.Error(), "parse gh pr list") {
+		t.Fatalf("FindPR() error = %v, want parse context", err)
+	}
+	if pr != nil {
+		t.Fatalf("FindPR() PR = %+v, want nil", pr)
+	}
+}
+
 func TestFindPRReturnsJSONError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -944,21 +944,23 @@ func TestFindPRReturnsCLIError(t *testing.T) {
 func TestFindPRReturnsJSONError(t *testing.T) {
 	t.Parallel()
 
-	host := New(githubTestCmdFactory(map[string]githubTestResponse{
-		"gh pr list --head feature/refactor --base main --state open --json number,url": {
-			stdout: "[{\n",
-		},
-	}), nil, "", "")
+	for _, output := range []string{"[{\n", "null\n"} {
+		host := New(githubTestCmdFactory(map[string]githubTestResponse{
+			"gh pr list --head feature/refactor --base main --state open --json number,url": {
+				stdout: output,
+			},
+		}), nil, "", "")
 
-	pr, err := host.FindPR(context.Background(), "feature/refactor", "main")
-	if err == nil {
-		t.Fatal("FindPR() error = nil, want JSON error")
-	}
-	if !strings.Contains(err.Error(), "parse gh pr list") {
-		t.Fatalf("FindPR() error = %v, want parse context", err)
-	}
-	if pr != nil {
-		t.Fatalf("FindPR() PR = %+v, want nil", pr)
+		pr, err := host.FindPR(context.Background(), "feature/refactor", "main")
+		if err == nil {
+			t.Fatal("FindPR() error = nil, want JSON error")
+		}
+		if !strings.Contains(err.Error(), "parse gh pr list") {
+			t.Fatalf("FindPR() error = %v, want parse context", err)
+		}
+		if pr != nil {
+			t.Fatalf("FindPR() PR = %+v, want nil", pr)
+		}
 	}
 }
 

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -980,13 +980,21 @@ func TestFindPRReturnsJSONError(t *testing.T) {
 		`[{"number":42,"url":"https://github.example.com/org/repo/pull/42#discussion","baseRefName":"main"}]` + "\n",
 		`[{"number":42,"url":"https://github.example.com/org/repo/pull/%34%32","baseRefName":"main"}]` + "\n",
 	} {
-		host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		var invokedCommand string
+		factory := githubTestCmdFactory(map[string]githubTestResponse{
 			findPRListCommand: {
 				stdout: output,
 			},
-		}), nil, "", "")
+		})
+		host := New(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+			invokedCommand = strings.TrimSpace(name + " " + strings.Join(args, " "))
+			return factory(ctx, name, args...)
+		}, nil, "", "")
 
 		pr, err := host.FindPR(context.Background(), "feature/refactor", "main")
+		if invokedCommand != findPRListCommand {
+			t.Fatalf("FindPR() command = %q, want %q", invokedCommand, findPRListCommand)
+		}
 		if err == nil {
 			t.Fatal("FindPR() error = nil, want JSON error")
 		}

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -923,7 +923,7 @@ func TestFindPRReturnsCLIError(t *testing.T) {
 	t.Parallel()
 
 	host := New(githubTestCmdFactory(map[string]githubTestResponse{
-		"gh pr list --head feature/refactor --base main --state open --json number,url": {
+		"gh pr list --head feature/refactor --base main --state open --json number,url,baseRefName": {
 			stderr: "api unavailable\n",
 			code:   1,
 		},
@@ -946,7 +946,7 @@ func TestFindPRReturnsJSONError(t *testing.T) {
 
 	for _, output := range []string{"[{\n", "null\n"} {
 		host := New(githubTestCmdFactory(map[string]githubTestResponse{
-			"gh pr list --head feature/refactor --base main --state open --json number,url": {
+			"gh pr list --head feature/refactor --base main --state open --json number,url,baseRefName": {
 				stdout: output,
 			},
 		}), nil, "", "")

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -944,7 +944,13 @@ func TestFindPRReturnsCLIError(t *testing.T) {
 func TestFindPRReturnsJSONError(t *testing.T) {
 	t.Parallel()
 
-	for _, output := range []string{"[{\n", "null\n"} {
+	valid := `{"number":42,"url":"https://github.example.com/org/repo/pull/42","baseRefName":"main"}`
+	for _, output := range []string{
+		"[{\n",
+		"null\n",
+		"[{}]\n",
+		"[" + valid + ",{}]\n",
+	} {
 		host := New(githubTestCmdFactory(map[string]githubTestResponse{
 			"gh pr list --head feature/refactor --base main --state open --json number,url,baseRefName": {
 				stdout: output,

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -980,21 +980,13 @@ func TestFindPRReturnsJSONError(t *testing.T) {
 		`[{"number":42,"url":"https://github.example.com/org/repo/pull/42#discussion","baseRefName":"main"}]` + "\n",
 		`[{"number":42,"url":"https://github.example.com/org/repo/pull/%34%32","baseRefName":"main"}]` + "\n",
 	} {
-		var invokedCommand string
-		factory := githubTestCmdFactory(map[string]githubTestResponse{
+		host := New(githubTestCmdFactory(map[string]githubTestResponse{
 			findPRListCommand: {
 				stdout: output,
 			},
-		})
-		host := New(func(ctx context.Context, name string, args ...string) *exec.Cmd {
-			invokedCommand = strings.TrimSpace(name + " " + strings.Join(args, " "))
-			return factory(ctx, name, args...)
-		}, nil, "", "")
+		}), nil, "", "")
 
 		pr, err := host.FindPR(context.Background(), "feature/refactor", "main")
-		if invokedCommand != findPRListCommand {
-			t.Fatalf("FindPR() command = %q, want %q", invokedCommand, findPRListCommand)
-		}
 		if err == nil {
 			t.Fatal("FindPR() error = nil, want JSON error")
 		}

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -973,6 +973,7 @@ func TestFindPRReturnsJSONError(t *testing.T) {
 		"[" + valid + ",{}]\n",
 		`[{"number":42,"url":"https://github.example.com/org/repo/pull/43","baseRefName":"main"}]` + "\n",
 		`[{"number":-1,"url":"https://github.example.com/org/repo/pull/-1","baseRefName":"main"}]` + "\n",
+		`[{"number":0,"url":"https://github.example.com/org/repo/pull/42","baseRefName":"main"}]` + "\n",
 		`[{"number":42,"url":"42","baseRefName":"main"}]` + "\n",
 	} {
 		host := New(githubTestCmdFactory(map[string]githubTestResponse{

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -975,6 +975,9 @@ func TestFindPRReturnsJSONError(t *testing.T) {
 		`[{"number":-1,"url":"https://github.example.com/org/repo/pull/-1","baseRefName":"main"}]` + "\n",
 		`[{"number":0,"url":"https://github.example.com/org/repo/pull/42","baseRefName":"main"}]` + "\n",
 		`[{"number":42,"url":"42","baseRefName":"main"}]` + "\n",
+		`[{"number":42,"url":"https://github.example.com/org/repo/pull/42?view=files","baseRefName":"main"}]` + "\n",
+		`[{"number":42,"url":"https://github.example.com/org/repo/pull/42#discussion","baseRefName":"main"}]` + "\n",
+		`[{"number":42,"url":"https://github.example.com/org/repo/pull/%34%32","baseRefName":"main"}]` + "\n",
 	} {
 		host := New(githubTestCmdFactory(map[string]githubTestResponse{
 			"gh pr list --head feature/refactor --base main --state open --json number,url,baseRefName": {

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -951,6 +951,8 @@ func TestFindPRReturnsJSONError(t *testing.T) {
 		"[{}]\n",
 		"[" + valid + ",{}]\n",
 		`[{"number":42,"url":"https://github.example.com/org/repo/pull/43","baseRefName":"main"}]` + "\n",
+		`[{"number":-1,"url":"https://github.example.com/org/repo/pull/-1","baseRefName":"main"}]` + "\n",
+		`[{"number":42,"url":"42","baseRefName":"main"}]` + "\n",
 	} {
 		host := New(githubTestCmdFactory(map[string]githubTestResponse{
 			"gh pr list --head feature/refactor --base main --state open --json number,url,baseRefName": {

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -941,6 +941,27 @@ func TestFindPRReturnsCLIError(t *testing.T) {
 	}
 }
 
+func TestFindPRReturnsJSONError(t *testing.T) {
+	t.Parallel()
+
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		"gh pr list --head feature/refactor --base main --state open --json number,url": {
+			stdout: "[{\n",
+		},
+	}), nil, "", "")
+
+	pr, err := host.FindPR(context.Background(), "feature/refactor", "main")
+	if err == nil {
+		t.Fatal("FindPR() error = nil, want JSON error")
+	}
+	if !strings.Contains(err.Error(), "parse gh pr list") {
+		t.Fatalf("FindPR() error = %v, want parse context", err)
+	}
+	if pr != nil {
+		t.Fatalf("FindPR() PR = %+v, want nil", pr)
+	}
+}
+
 func TestAvailableScopesAuthToConfiguredHost(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -950,6 +950,7 @@ func TestFindPRReturnsJSONError(t *testing.T) {
 		"null\n",
 		"[{}]\n",
 		"[" + valid + ",{}]\n",
+		`[{"number":42,"url":"https://github.example.com/org/repo/pull/43","baseRefName":"main"}]` + "\n",
 	} {
 		host := New(githubTestCmdFactory(map[string]githubTestResponse{
 			"gh pr list --head feature/refactor --base main --state open --json number,url,baseRefName": {
@@ -967,6 +968,45 @@ func TestFindPRReturnsJSONError(t *testing.T) {
 		if pr != nil {
 			t.Fatalf("FindPR() PR = %+v, want nil", pr)
 		}
+	}
+}
+
+func TestFindPRForkRejectsMissingHeadIdentity(t *testing.T) {
+	t.Parallel()
+
+	branch := "feature/refactor"
+	tests := []struct {
+		name   string
+		output string
+	}{
+		{
+			name:   "missing head ref",
+			output: `[{"number":42,"url":"https://github.com/parent/repo/pull/42","headRepositoryOwner":{"login":"fork-owner"}}]`,
+		},
+		{
+			name:   "missing head owner",
+			output: `[{"number":42,"url":"https://github.com/parent/repo/pull/42","headRefName":"feature/refactor","headRepositoryOwner":null}]`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			host := NewWithFork(githubTestCmdFactory(map[string]githubTestResponse{
+				"gh pr list --head " + branch + " --base main --repo parent/repo --state open --json number,url,baseRefName,headRefName,headRepositoryOwner": {
+					stdout: tc.output + "\n",
+				},
+			}), nil, "", "parent/repo", "fork-owner/repo")
+
+			pr, err := host.FindPR(context.Background(), branch, "main")
+			if err == nil {
+				t.Fatal("FindPR() error = nil, want head identity error")
+			}
+			if !strings.Contains(err.Error(), "parse gh pr list") {
+				t.Fatalf("FindPR() error = %v, want parse context", err)
+			}
+			if pr != nil {
+				t.Fatalf("FindPR() PR = %+v, want nil", pr)
+			}
+		})
 	}
 }
 

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -965,6 +965,7 @@ func TestFindPRRejectsURLForDifferentRepository(t *testing.T) {
 func TestFindPRReturnsJSONError(t *testing.T) {
 	t.Parallel()
 
+	const findPRListCommand = "gh pr list --head feature/refactor --base main --state open --json number,url,baseRefName"
 	valid := `{"number":42,"url":"https://github.example.com/org/repo/pull/42","baseRefName":"main"}`
 	for _, output := range []string{
 		"[{\n",
@@ -980,7 +981,7 @@ func TestFindPRReturnsJSONError(t *testing.T) {
 		`[{"number":42,"url":"https://github.example.com/org/repo/pull/%34%32","baseRefName":"main"}]` + "\n",
 	} {
 		host := New(githubTestCmdFactory(map[string]githubTestResponse{
-			"gh pr list --head feature/refactor --base main --state open --json number,url,baseRefName": {
+			findPRListCommand: {
 				stdout: output,
 			},
 		}), nil, "", "")

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -177,10 +177,13 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 	}
 	trimmed := bytesTrimToJSON(out)
 	if len(trimmed) == 0 {
-		return nil, nil
+		return nil, errors.New("parse glab mr list JSON: no JSON found")
 	}
 	var mrs []mrPayload
-	if err := json.Unmarshal(trimmed, &mrs); err != nil || len(mrs) == 0 {
+	if err := json.Unmarshal(trimmed, &mrs); err != nil {
+		return nil, fmt.Errorf("parse glab mr list JSON: %w", err)
+	}
+	if len(mrs) == 0 {
 		return nil, nil
 	}
 	pr := mrs[0].toPR()

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -178,10 +178,13 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 	}
 	trimmed := bytesTrimToJSON(out)
 	if len(trimmed) == 0 {
-		return nil, nil
+		return nil, errors.New("parse glab mr list JSON: no JSON found")
 	}
 	var mrs []mrPayload
-	if err := json.Unmarshal(trimmed, &mrs); err != nil || len(mrs) == 0 {
+	if err := json.Unmarshal(trimmed, &mrs); err != nil {
+		return nil, fmt.Errorf("parse glab mr list JSON: %w", err)
+	}
+	if len(mrs) == 0 {
 		return nil, nil
 	}
 	pr := mrs[0].toPR()

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -139,7 +139,7 @@ func (h *Host) Available(ctx context.Context) error {
 	return nil
 }
 
-func parseMergeRequestURL(raw, expectedHost string) (int, error) {
+func parseMergeRequestURL(raw, expectedHost, expectedProject string) (int, error) {
 	parsed, err := url.Parse(strings.TrimSpace(raw))
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
 		return 0, errors.New("expected absolute GitLab merge request URL")
@@ -153,6 +153,17 @@ func parseMergeRequestURL(raw, expectedHost string) (int, error) {
 	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
 	if len(segments) < 5 || segments[len(segments)-3] != "-" || segments[len(segments)-2] != "merge_requests" {
 		return 0, errors.New("expected GitLab /group/project/-/merge_requests/number URL")
+	}
+	projectSegments := segments[:len(segments)-3]
+	for _, segment := range projectSegments {
+		if segment == "" || segment == "." || segment == ".." {
+			return 0, errors.New("expected unambiguous GitLab project path")
+		}
+	}
+	actualProject := strings.Join(projectSegments, "/")
+	expectedProject = strings.Trim(strings.TrimSpace(expectedProject), "/")
+	if expectedProject != "" && !strings.EqualFold(actualProject, expectedProject) {
+		return 0, fmt.Errorf("URL project %q does not match GitLab project %q", actualProject, expectedProject)
 	}
 	number, err := strconv.Atoi(segments[len(segments)-1])
 	if err != nil || number <= 0 {
@@ -218,7 +229,7 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 		if url == "" {
 			return nil, fmt.Errorf("parse glab mr list JSON: entry %d missing merge request URL", i)
 		}
-		number, err := parseMergeRequestURL(url, h.host)
+		number, err := parseMergeRequestURL(url, h.host, h.projectPath)
 		if err != nil {
 			return nil, fmt.Errorf("parse glab mr list JSON: entry %d invalid merge request URL: %w", i, err)
 		}

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -188,8 +188,19 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 		return nil, nil
 	}
 	for i, candidate := range mrs {
-		if strings.TrimSpace(candidate.WebURL) == "" && strings.TrimSpace(candidate.URL) == "" {
+		url := strings.TrimSpace(candidate.WebURL)
+		if url == "" {
+			url = strings.TrimSpace(candidate.URL)
+		}
+		if url == "" {
 			return nil, fmt.Errorf("parse glab mr list JSON: entry %d missing merge request URL", i)
+		}
+		number, err := scm.ExtractPRNumber(url)
+		if err != nil {
+			return nil, fmt.Errorf("parse glab mr list JSON: entry %d invalid merge request URL: %w", i, err)
+		}
+		if candidate.IID != 0 && fmt.Sprintf("%d", candidate.IID) != number {
+			return nil, fmt.Errorf("parse glab mr list JSON: entry %d IID %d does not match URL number %s", i, candidate.IID, number)
 		}
 	}
 	pr := mrs[0].toPR()

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -140,7 +140,8 @@ func (h *Host) Available(ctx context.Context) error {
 }
 
 func parseMergeRequestURL(raw, expectedHost, expectedProject string) (int, error) {
-	parsed, err := url.Parse(strings.TrimSpace(raw))
+	trimmed := strings.TrimSpace(raw)
+	parsed, err := url.Parse(trimmed)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
 		return 0, errors.New("expected absolute GitLab merge request URL")
 	}
@@ -168,6 +169,13 @@ func parseMergeRequestURL(raw, expectedHost, expectedProject string) (int, error
 	number, err := strconv.Atoi(segments[len(segments)-1])
 	if err != nil || number <= 0 {
 		return 0, errors.New("expected positive GitLab merge request number")
+	}
+	escapedSegments := strings.Split(strings.Trim(parsed.EscapedPath(), "/"), "/")
+	if len(escapedSegments) != len(segments) || escapedSegments[len(escapedSegments)-1] != strconv.Itoa(number) {
+		return 0, errors.New("expected canonical GitLab merge request number path")
+	}
+	if parsed.ForceQuery || parsed.RawQuery != "" || strings.Contains(trimmed, "#") {
+		return 0, errors.New("expected GitLab merge request URL without query or fragment")
 	}
 	return number, nil
 }
@@ -217,6 +225,9 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 	var mrs []mrPayload
 	if err := json.Unmarshal(trimmed, &mrs); err != nil {
 		return nil, fmt.Errorf("parse glab mr list JSON: %w", err)
+	}
+	if mrs == nil {
+		return nil, errors.New("parse glab mr list JSON: expected array")
 	}
 	if len(mrs) == 0 {
 		return nil, nil

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/url"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -138,6 +139,28 @@ func (h *Host) Available(ctx context.Context) error {
 	return nil
 }
 
+func parseMergeRequestURL(raw, expectedHost string) (int, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return 0, errors.New("expected absolute GitLab merge request URL")
+	}
+	if !strings.EqualFold(parsed.Scheme, "http") && !strings.EqualFold(parsed.Scheme, "https") {
+		return 0, errors.New("expected HTTP GitLab merge request URL")
+	}
+	if expectedHost != "" && !strings.EqualFold(parsed.Hostname(), expectedHost) {
+		return 0, fmt.Errorf("URL host %q does not match GitLab host %q", parsed.Hostname(), expectedHost)
+	}
+	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(segments) < 5 || segments[len(segments)-3] != "-" || segments[len(segments)-2] != "merge_requests" {
+		return 0, errors.New("expected GitLab /group/project/-/merge_requests/number URL")
+	}
+	number, err := strconv.Atoi(segments[len(segments)-1])
+	if err != nil || number <= 0 {
+		return 0, errors.New("expected positive GitLab merge request number")
+	}
+	return number, nil
+}
+
 type mrPayload struct {
 	IID                 int    `json:"iid"`
 	WebURL              string `json:"web_url"`
@@ -195,12 +218,12 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 		if url == "" {
 			return nil, fmt.Errorf("parse glab mr list JSON: entry %d missing merge request URL", i)
 		}
-		number, err := scm.ExtractPRNumber(url)
+		number, err := parseMergeRequestURL(url, h.host)
 		if err != nil {
 			return nil, fmt.Errorf("parse glab mr list JSON: entry %d invalid merge request URL: %w", i, err)
 		}
-		if candidate.IID != 0 && fmt.Sprintf("%d", candidate.IID) != number {
-			return nil, fmt.Errorf("parse glab mr list JSON: entry %d IID %d does not match URL number %s", i, candidate.IID, number)
+		if candidate.IID != 0 && candidate.IID != number {
+			return nil, fmt.Errorf("parse glab mr list JSON: entry %d IID %d does not match URL number %d", i, candidate.IID, number)
 		}
 	}
 	pr := mrs[0].toPR()

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -187,10 +187,12 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 	if len(mrs) == 0 {
 		return nil, nil
 	}
-	pr := mrs[0].toPR()
-	if pr.URL == "" {
-		return nil, nil
+	for i, candidate := range mrs {
+		if strings.TrimSpace(candidate.WebURL) == "" && strings.TrimSpace(candidate.URL) == "" {
+			return nil, fmt.Errorf("parse glab mr list JSON: entry %d missing merge request URL", i)
+		}
 	}
+	pr := mrs[0].toPR()
 	return pr, nil
 }
 

--- a/internal/scm/gitlab/gitlab_test.go
+++ b/internal/scm/gitlab/gitlab_test.go
@@ -300,6 +300,39 @@ func TestFindPRReturnsCLIError(t *testing.T) {
 	}
 }
 
+func TestFindPRReturnsJSONError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		output string
+	}{
+		{name: "no JSON", output: "not-json\n"},
+		{name: "malformed JSON", output: "[{\n"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			host := New(gitlabTestCmdFactory(map[string]gitlabTestResponse{
+				"glab mr list --source-branch feature/refactor --target-branch main --output json": {
+					stdout: tc.output,
+				},
+			}), nil, "", "")
+
+			pr, err := host.FindPR(context.Background(), "feature/refactor", "main")
+			if err == nil {
+				t.Fatal("FindPR() error = nil, want JSON error")
+			}
+			if !strings.Contains(err.Error(), "parse glab mr list") {
+				t.Fatalf("FindPR() error = %v, want parse context", err)
+			}
+			if pr != nil {
+				t.Fatalf("FindPR() PR = %+v, want nil", pr)
+			}
+		})
+	}
+}
+
 func TestGetChecksFallbackRequestsJobDetails(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scm/gitlab/gitlab_test.go
+++ b/internal/scm/gitlab/gitlab_test.go
@@ -309,6 +309,7 @@ func TestFindPRReturnsJSONError(t *testing.T) {
 	}{
 		{name: "no JSON", output: "not-json\n"},
 		{name: "malformed JSON", output: "[{\n"},
+		{name: "null", output: "null\n"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/scm/gitlab/gitlab_test.go
+++ b/internal/scm/gitlab/gitlab_test.go
@@ -310,6 +310,11 @@ func TestFindPRReturnsJSONError(t *testing.T) {
 		{name: "no JSON", output: "not-json\n"},
 		{name: "malformed JSON", output: "[{\n"},
 		{name: "null", output: "null\n"},
+		{name: "missing identity", output: "notice\n[{}]\n"},
+		{
+			name:   "later missing identity",
+			output: `[{"iid":42,"web_url":"https://gitlab.example.com/group/project/-/merge_requests/42"},{}]` + "\n",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/scm/gitlab/gitlab_test.go
+++ b/internal/scm/gitlab/gitlab_test.go
@@ -323,6 +323,14 @@ func TestFindPRReturnsJSONError(t *testing.T) {
 			name:   "IID URL mismatch",
 			output: `[{"iid":42,"web_url":"https://gitlab.example.com/group/project/-/merge_requests/43"}]` + "\n",
 		},
+		{
+			name:   "negative identity",
+			output: `[{"iid":-1,"web_url":"https://gitlab.example.com/group/project/-/merge_requests/-1"}]` + "\n",
+		},
+		{
+			name:   "bare identity",
+			output: `[{"iid":42,"web_url":"42"}]` + "\n",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/scm/gitlab/gitlab_test.go
+++ b/internal/scm/gitlab/gitlab_test.go
@@ -352,6 +352,18 @@ func TestFindPRReturnsJSONError(t *testing.T) {
 			name:   "bare identity",
 			output: `[{"iid":42,"web_url":"42"}]` + "\n",
 		},
+		{
+			name:   "query suffix",
+			output: `[{"iid":42,"web_url":"https://gitlab.example.com/group/project/-/merge_requests/42?view=files"}]` + "\n",
+		},
+		{
+			name:   "fragment suffix",
+			output: `[{"iid":42,"web_url":"https://gitlab.example.com/group/project/-/merge_requests/42#discussion"}]` + "\n",
+		},
+		{
+			name:   "encoded identity",
+			output: `[{"iid":42,"web_url":"https://gitlab.example.com/group/project/-/merge_requests/%34%32"}]` + "\n",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/scm/gitlab/gitlab_test.go
+++ b/internal/scm/gitlab/gitlab_test.go
@@ -315,6 +315,14 @@ func TestFindPRReturnsJSONError(t *testing.T) {
 			name:   "later missing identity",
 			output: `[{"iid":42,"web_url":"https://gitlab.example.com/group/project/-/merge_requests/42"},{}]` + "\n",
 		},
+		{
+			name:   "invalid URL",
+			output: `[{"web_url":"not-a-merge-request-url"}]` + "\n",
+		},
+		{
+			name:   "IID URL mismatch",
+			output: `[{"iid":42,"web_url":"https://gitlab.example.com/group/project/-/merge_requests/43"}]` + "\n",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/scm/gitlab/gitlab_test.go
+++ b/internal/scm/gitlab/gitlab_test.go
@@ -261,7 +261,7 @@ func TestFindPRFiltersByBaseBranch(t *testing.T) {
 		"glab mr list --source-branch feature/refactor --target-branch release/1.0 --output json": {
 			stdout: `[{"iid":42,"web_url":"https://gitlab.example.com/group/project/-/merge_requests/42"}]` + "\n",
 		},
-	}), nil, "", "")
+	}), nil, "gitlab.example.com", "group/project")
 
 	pr, err := host.FindPR(context.Background(), "feature/refactor", "release/1.0")
 	if err != nil {
@@ -294,6 +294,27 @@ func TestFindPRReturnsCLIError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "glab mr list") {
 		t.Fatalf("FindPR() error = %v, want glab mr list context", err)
+	}
+	if pr != nil {
+		t.Fatalf("FindPR() PR = %+v, want nil", pr)
+	}
+}
+
+func TestFindPRRejectsURLForDifferentProject(t *testing.T) {
+	t.Parallel()
+
+	host := New(gitlabTestCmdFactory(map[string]gitlabTestResponse{
+		"glab mr list --source-branch feature/refactor --target-branch main --output json": {
+			stdout: `[{"iid":42,"web_url":"https://gitlab.example.com/group/other/-/merge_requests/42"}]` + "\n",
+		},
+	}), nil, "gitlab.example.com", "group/project")
+
+	pr, err := host.FindPR(context.Background(), "feature/refactor", "main")
+	if err == nil {
+		t.Fatal("FindPR() error = nil, want project mismatch error")
+	}
+	if !strings.Contains(err.Error(), "parse glab mr list") {
+		t.Fatalf("FindPR() error = %v, want parse context", err)
 	}
 	if pr != nil {
 		t.Fatalf("FindPR() PR = %+v, want nil", pr)

--- a/internal/scm/host.go
+++ b/internal/scm/host.go
@@ -170,10 +170,11 @@ type Host interface {
 	// error explaining why it is not (missing CLI, unauthenticated, etc).
 	Available(ctx context.Context) error
 
-	// FindPR returns the open PR for the source branch, or nil only when a valid
-	// provider response contains no matching PR. It returns an error for lookup
-	// or response-decoding failures so callers do not create a duplicate PR
-	// after an indeterminate lookup.
+	// FindPR returns the open PR for the source branch, or nil only when a
+	// successfully decoded PR listing contains no matching PR. It returns an
+	// error for lookup or response-decoding failures (including empty,
+	// malformed, or null payloads) so callers do not create a duplicate PR after
+	// an indeterminate lookup.
 	FindPR(ctx context.Context, branch, base string) (*PR, error)
 	CreatePR(ctx context.Context, branch, base string, content PRContent) (*PR, error)
 	UpdatePR(ctx context.Context, pr *PR, content PRContent) (*PR, error)

--- a/internal/scm/host.go
+++ b/internal/scm/host.go
@@ -170,7 +170,10 @@ type Host interface {
 	// error explaining why it is not (missing CLI, unauthenticated, etc).
 	Available(ctx context.Context) error
 
-	// FindPR returns the open PR for the source branch, or nil if none exists.
+	// FindPR returns the open PR for the source branch, or nil only when a valid
+	// provider response contains no matching PR. It returns an error for lookup
+	// or response-decoding failures so callers do not create a duplicate PR
+	// after an indeterminate lookup.
 	FindPR(ctx context.Context, branch, base string) (*PR, error)
 	CreatePR(ctx context.Context, branch, base string, content PRContent) (*PR, error)
 	UpdatePR(ctx context.Context, pr *PR, content PRContent) (*PR, error)

--- a/internal/scm/host.go
+++ b/internal/scm/host.go
@@ -214,10 +214,11 @@ type Host interface {
 	// error explaining why it is not (missing CLI, unauthenticated, etc).
 	Available(ctx context.Context) error
 
-	// FindPR returns the open PR for the source branch, or nil only when a valid
-	// provider response contains no matching PR. It returns an error for lookup
-	// or response-decoding failures so callers do not create a duplicate PR
-	// after an indeterminate lookup.
+	// FindPR returns the open PR for the source branch, or nil only when a
+	// successfully decoded PR listing contains no matching PR. It returns an
+	// error for lookup or response-decoding failures (including empty,
+	// malformed, or null payloads) so callers do not create a duplicate PR after
+	// an indeterminate lookup.
 	FindPR(ctx context.Context, branch, base string) (*PR, error)
 	CreatePR(ctx context.Context, branch, base string, content PRContent) (*PR, error)
 	UpdatePR(ctx context.Context, pr *PR, content PRContent) (*PR, error)

--- a/internal/scm/host.go
+++ b/internal/scm/host.go
@@ -215,10 +215,10 @@ type Host interface {
 	Available(ctx context.Context) error
 
 	// FindPR returns the open PR for the source branch, or nil only when a
-	// successfully decoded PR listing contains no matching PR. It returns an
-	// error for lookup or response-decoding failures (including empty,
-	// malformed, or null payloads) so callers do not create a duplicate PR after
-	// an indeterminate lookup.
+	// successfully decoded and validated PR listing contains no matching PR. It
+	// returns an error for lookup, response-decoding, or validation failures
+	// (including empty, malformed, null, or incoherent payloads) so callers do
+	// not create a duplicate PR after an indeterminate lookup.
 	FindPR(ctx context.Context, branch, base string) (*PR, error)
 	CreatePR(ctx context.Context, branch, base string, content PRContent) (*PR, error)
 	UpdatePR(ctx context.Context, pr *PR, content PRContent) (*PR, error)

--- a/internal/scm/host.go
+++ b/internal/scm/host.go
@@ -214,7 +214,10 @@ type Host interface {
 	// error explaining why it is not (missing CLI, unauthenticated, etc).
 	Available(ctx context.Context) error
 
-	// FindPR returns the open PR for the source branch, or nil if none exists.
+	// FindPR returns the open PR for the source branch, or nil only when a valid
+	// provider response contains no matching PR. It returns an error for lookup
+	// or response-decoding failures so callers do not create a duplicate PR
+	// after an indeterminate lookup.
 	FindPR(ctx context.Context, branch, base string) (*PR, error)
 	CreatePR(ctx context.Context, branch, base string, content PRContent) (*PR, error)
 	UpdatePR(ctx context.Context, pr *PR, content PRContent) (*PR, error)


### PR DESCRIPTION
## Intent

Сделать то, что просит maintainer в PR #470: исправить drift тестовых fixture после merge main, чтобы GitHub FindPR JSON-error regression mock ожидал фактический gh pr list --json number,url,baseRefName; сохранить production-команду и fail-closed поведение, не добавлять несвязанные изменения, добиться зелёных обязательных CI checks.

## What Changed

- Reject empty, malformed, null, or incoherent existing-PR responses across GitHub, GitLab, Azure DevOps, and Bitbucket instead of treating indeterminate lookups as no match.
- Validate returned PR/MR identifiers and URLs against the configured provider and repository, producing canonical Bitbucket and Azure DevOps PR URLs.
- Add provider and pipeline regressions—including GitHub’s `number,url,baseRefName` fixture—and document the fail-closed `FindPR` contract.

## Risk Assessment

✅ Low: The change is well-bounded, preserves the production GitHub command, and consistently fails closed before PR mutation for malformed or invalid provider listings.

## Testing

Clean target preflight, focused GitHub adapter regressions, and the executable PR-step journey all passed; captured CLI/DB evidence demonstrates the corrected JSON fields and fail-closed outcome, with no transient worktree artifacts remaining.

<details>
<summary>Evidence: GitHub FindPR fail-closed CLI transcript</summary>

<code>auth status --hostname github.com&#10;pr list --head feature --repo test/repo --state open --json number,url,baseRefName&#10;observed pipeline error: parse gh pr list JSON: unexpected end of JSON input&#10;stored PR URL: &lt;nil&gt;</code>

```text
=== RUN   TestPRStep_MalformedPRListFailsClosed
=== PAUSE TestPRStep_MalformedPRListFailsClosed
=== CONT  TestPRStep_MalformedPRListFailsClosed
    pr_test.go:138: gh transcript:
        auth status --hostname github.com
        pr list --head feature --repo test/repo --state open --json number,url,baseRefName
        observed pipeline error: parse gh pr list JSON: unexpected end of JSON input
        stored PR URL: <nil>
--- PASS: TestPRStep_MalformedPRListFailsClosed (3.46s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/pipeline/steps	4.778s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ceb415751a918a98b39b9233a48b70bdacef38e5","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Rebase** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `docs/src/content/docs/reference/pipeline-steps.md` - merge conflict rebasing onto refs/remotes/no-mistakes-push/fix/scm-find-pr-json-errors
- ⚠️ `internal/scm/host.go` - merge conflict rebasing onto refs/remotes/no-mistakes-push/fix/scm-find-pr-json-errors

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git status -sb` and `git rev-parse HEAD`</code>
- `git diff --stat 59c8a730b7a9b0a92ecaacdd81dde79e0bacf5c1..c5bd68c8b3eb50b036dbedf7805f67c88dba2922`
- `go test ./internal/scm/github -run '^(TestFindPRReturnsCLIError|TestFindPRReturnsJSONError)$' -count=1 -v`
- <code>`go test ./internal/pipeline/steps -run &#39;^TestPRStep_MalformedPRListFailsClosed$&#39; -count=1 -v` with output captured to the evidence artifact</code>
- <code>Final `git status -sb` and evidence-file inspection</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
