### PR TITLE
fix: recursively checkout git submodules in worktree

### DIFF
--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -648,6 +648,11 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 		trackStartFailure("create_worktree")
 		return "", fmt.Errorf("create worktree: %w", err)
 	}
+	if err := git.SubmoduleUpdate(ctx, wtDir); err != nil {
+		m.db.UpdateRunError(run.ID, fmt.Sprintf("update submodules: %s", err))
+		trackStartFailure("update_submodules")
+		return "", fmt.Errorf("update submodules: %w", err)
+	}
 	if err := git.CopyLocalUserIdentity(ctx, repo.WorkingPath, wtDir); err != nil {
 		m.db.UpdateRunError(run.ID, fmt.Sprintf("configure worktree git identity: %s", err))
 		trackStartFailure("configure_worktree_identity")

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -498,6 +498,12 @@ func WorktreeAdd(ctx context.Context, repoDir, wtPath, sha string) error {
 	return err
 }
 
+// SubmoduleUpdate recursively initializes and updates git submodules in a worktree.
+func SubmoduleUpdate(ctx context.Context, wtPath string) error {
+	_, err := Run(ctx, wtPath, "submodule", "update", "--init", "--recursive")
+	return err
+}
+
 // WorktreeRemove removes a worktree at the given path.
 func WorktreeRemove(ctx context.Context, repoDir, wtPath string) error {
 	_, err := Run(ctx, repoDir, "worktree", "remove", "--force", wtPath)


### PR DESCRIPTION
This PR fixes an issue where the validation pipeline performs a checkout of the main repository but fails to pull in the code from Git sub-repositories (submodules). It adds `git submodule update --init --recursive` during the worktree setup process.