### PR TITLE
fix(cli): keep axi status visible at fix review gates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/mattn/go-isatty v0.0.20
 	github.com/muesli/termenv v0.16.0
 	github.com/oklog/ulid/v2 v2.1.1
@@ -20,7 +21,6 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
-	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect

--- a/internal/cli/axi_query.go
+++ b/internal/cli/axi_query.go
@@ -63,10 +63,12 @@ func runAxiStatus(cmd *cobra.Command, runID string) (string, error) {
 		if runID != "" {
 			return "", emitError(cmd, 1, fmt.Sprintf("run %q not found", runID))
 		}
-		emitDoc(cmd,
+		if err := emitStatusDoc(cmd,
 			toon.Field{Key: "runs", Value: "0 runs yet in this repository"},
 			toon.Field{Key: "help", Value: []string{startRunHelp()}},
-		)
+		); err != nil {
+			return "", err
+		}
 		return env.repo.ID + "|no-runs", nil
 	}
 
@@ -85,7 +87,9 @@ func runAxiStatus(cmd *cobra.Command, runID string) (string, error) {
 			fields = append(fields, toon.Field{Key: "error", Value: *run.Error})
 		}
 	}
-	emitDoc(cmd, fields...)
+	if err := emitStatusDoc(cmd, fields...); err != nil {
+		return "", err
+	}
 	return runStateFingerprint(rv), nil
 }
 

--- a/internal/cli/axi_render.go
+++ b/internal/cli/axi_render.go
@@ -2,8 +2,11 @@ package cli
 
 import (
 	"fmt"
+	"io"
+	"strings"
 	"time"
 
+	"github.com/charmbracelet/x/ansi"
 	toon "github.com/toon-format/toon-go"
 
 	"github.com/kunchenguid/no-mistakes/internal/db"
@@ -433,14 +436,14 @@ func runObjectFieldWithKey(key string, rv runView) toon.Field {
 func gateFields(gate stepView) []toon.Field {
 	parsed, _ := types.ParseFindingsJSON(gate.FindingsJSON)
 	gfields := []toon.Field{
-		{Key: "step", Value: gate.Name},
-		{Key: "status", Value: gate.Status},
+		{Key: "step", Value: safeAXIText(gate.Name)},
+		{Key: "status", Value: safeAXIText(gate.Status)},
 	}
 	if parsed.Summary != "" {
-		gfields = append(gfields, toon.Field{Key: "summary", Value: parsed.Summary})
+		gfields = append(gfields, toon.Field{Key: "summary", Value: safeAXIText(parsed.Summary)})
 	}
 	if parsed.RiskLevel != "" {
-		gfields = append(gfields, toon.Field{Key: "risk", Value: parsed.RiskLevel})
+		gfields = append(gfields, toon.Field{Key: "risk", Value: safeAXIText(parsed.RiskLevel)})
 	}
 	// Point-of-use reminder at the review gate: review auto-fix defaults to
 	// disabled, so agents should expect blocking and ask-user findings to park
@@ -451,11 +454,11 @@ func gateFields(gate stepView) []toon.Field {
 	rows := make([]findingRow, 0, len(parsed.Items))
 	for _, f := range parsed.Items {
 		rows = append(rows, findingRow{
-			ID:          f.ID,
-			Severity:    f.Severity,
-			File:        f.File,
-			Action:      f.Action,
-			Description: truncate(f.Description, maxFindingDesc),
+			ID:          safeAXIText(f.ID),
+			Severity:    safeAXIText(f.Severity),
+			File:        safeAXIText(f.File),
+			Action:      safeAXIText(f.Action),
+			Description: truncate(safeAXIText(f.Description), maxFindingDesc),
 		})
 	}
 	gfields = append(gfields, toon.Field{Key: "findings", Value: rows})
@@ -473,6 +476,20 @@ func gateFields(gate stepView) []toon.Field {
 	}
 }
 
+// safeAXIText removes terminal escape sequences and control bytes that are
+// meaningful in a TTY but invalid in TOON. Agent findings can quote raw test
+// output, including colored diagnostics; one such description must not make
+// the entire status document unrenderable.
+func safeAXIText(s string) string {
+	s = ansi.Strip(s)
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 && r != '\n' && r != '\r' && r != '\t' {
+			return -1
+		}
+		return r
+	}, s)
+}
+
 // truncate shortens s to limit runes, appending a disclosure of the full size
 // when it actually trims, per the AXI content-truncation convention.
 func truncate(s string, limit int) string {
@@ -485,20 +502,44 @@ func truncate(s string, limit int) string {
 
 // --- output helpers ---
 
-// axiDoc marshals an ordered set of TOON fields into a document with a trailing
-// newline. Encoding errors are impossible for the value shapes we build here,
-// so a failure degrades to an empty document rather than propagating.
-func axiDoc(fields ...toon.Field) string {
+// marshalAXIDoc marshals an ordered set of TOON fields into a document with a
+// trailing newline. Callers that produce command output must propagate its
+// error; otherwise an unsupported value becomes an empty, successful response.
+func marshalAXIDoc(fields ...toon.Field) (string, error) {
 	out, err := toon.MarshalString(toon.NewObject(fields...))
+	if err != nil {
+		return "", err
+	}
+	return out + "\n", nil
+}
+
+// axiDoc is the concise rendering helper used by shape-focused tests.
+func axiDoc(fields ...toon.Field) string {
+	out, err := marshalAXIDoc(fields...)
 	if err != nil {
 		return ""
 	}
-	return out + "\n"
+	return out
 }
 
 // emitDoc writes a finished TOON document to stdout.
 func emitDoc(cmd *cobra.Command, fields ...toon.Field) {
 	fmt.Fprint(cmd.OutOrStdout(), axiDoc(fields...))
+}
+
+// emitStatusDoc enforces the status command's no-silent-empty contract. A
+// renderer or writer failure is reported on stderr and exits non-zero so an
+// agent cannot confuse blindness with an idle repository.
+func emitStatusDoc(cmd *cobra.Command, fields ...toon.Field) error {
+	out, err := marshalAXIDoc(fields...)
+	if err == nil {
+		_, err = io.WriteString(cmd.OutOrStdout(), out)
+	}
+	if err == nil {
+		return nil
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(), "render axi status: %v\n", err)
+	return &exitError{code: 1}
 }
 
 // emitError renders a structured TOON error to stdout and returns an exitError

--- a/internal/cli/axi_test.go
+++ b/internal/cli/axi_test.go
@@ -304,6 +304,243 @@ func TestWriteGateShape(t *testing.T) {
 	}
 }
 
+func TestWriteFixReviewGateShape(t *testing.T) {
+	gate := stepView{
+		Name:   "test",
+		Status: string(types.StepStatusFixReview),
+		FindingsJSON: findingsJSON(t, []types.Finding{
+			{ID: "test-1", Severity: "error", File: "main.go", Action: types.ActionAskUser, Description: "the fix still fails: \x1b[31mregression\x1b[0m"},
+		}, "fix needs review"),
+	}
+	rv := runView{
+		ID:      "run-fix-review",
+		Branch:  "feature/fix-review",
+		Status:  string(types.RunRunning),
+		HeadSHA: "abcdef1234567890",
+		Steps:   []stepView{gate},
+	}
+	out := axiDoc(append([]toon.Field{runObjectField(rv)}, gateFields(gate)...)...)
+
+	for _, want := range []string{
+		"run:\n",
+		"test,fix_review,1,0\n",
+		"gate:\n",
+		"  step: test\n",
+		"  status: fix_review\n",
+		"  summary: fix needs review\n",
+		"test-1,error,main.go,ask-user",
+		"the fix still fails: regression",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("fix_review gate missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestEmitStatusDocReportsUnrenderableStatus(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := emitStatusDoc(cmd, toon.Field{Key: "run", Value: "invalid \x00 status"})
+	if err == nil {
+		t.Fatal("emitStatusDoc should fail when TOON cannot render the status")
+	}
+	var exitErr *exitError
+	if !errors.As(err, &exitErr) || exitErr.code == 0 {
+		t.Fatalf("emitStatusDoc error = %T %v, want non-zero exitError", err, err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("unrenderable status wrote stdout %q, want empty", stdout.String())
+	}
+	if got := stderr.String(); !strings.Contains(got, "render axi status") || !strings.Contains(got, "unsupported control character") {
+		t.Fatalf("unrenderable status stderr = %q, want descriptive render error", got)
+	}
+}
+
+func TestAxiStatusRendersParkedFixReviewRun(t *testing.T) {
+	database, dbRun := setupAxiStatusRun(t, "feature/fix-review")
+	step, err := database.InsertStepResult(dbRun.ID, types.StepTest)
+	if err != nil {
+		t.Fatalf("insert test step: %v", err)
+	}
+	findings := findingsJSON(t, []types.Finding{
+		{ID: "test-1", Severity: "error", File: "main.go", Action: types.ActionAskUser, Description: "still failing: \x1b[31mregression\x1b[0m"},
+	}, "fix needs review")
+	if err := database.SetStepFindings(step.ID, findings); err != nil {
+		t.Fatalf("set findings: %v", err)
+	}
+	if err := database.UpdateStepStatusWithDuration(step.ID, types.StepStatusFixReview, 1234); err != nil {
+		t.Fatalf("park step at fix_review: %v", err)
+	}
+	if err := database.SetRunAwaitingAgent(dbRun.ID); err != nil {
+		t.Fatalf("park run: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	if _, err := runAxiStatus(cmd, dbRun.ID); err != nil {
+		t.Fatalf("axi status: %v\nstderr:\n%s\nstdout:\n%s", err, stderr.String(), stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("axi status stderr = %q, want empty", stderr.String())
+	}
+	got := stdout.String()
+	for _, want := range []string{
+		"run:\n",
+		"status: running\n",
+		"awaiting_agent: parked ",
+		"test,fix_review,1,1234",
+		"gate:\n",
+		"step: test\n",
+		"status: fix_review\n",
+		"test-1,error,main.go,ask-user",
+		"still failing: regression",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("axi status missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "\x1b") {
+		t.Fatalf("axi status leaked terminal escapes:\n%s", got)
+	}
+}
+
+func TestAxiStatusUnrenderableRunFailsLoudly(t *testing.T) {
+	_, dbRun := setupAxiStatusRun(t, "feature/bad\x00branch")
+
+	var stdout, stderr bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	_, err := runAxiStatus(cmd, dbRun.ID)
+	if err == nil {
+		t.Fatal("axi status should fail when the selected run cannot be rendered")
+	}
+	var exitErr *exitError
+	if !errors.As(err, &exitErr) || exitErr.code == 0 {
+		t.Fatalf("axi status error = %T %v, want non-zero exitError", err, err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("unrenderable status wrote stdout %q, want empty", stdout.String())
+	}
+	if got := stderr.String(); !strings.Contains(got, "render axi status") || !strings.Contains(got, "unsupported control character") {
+		t.Fatalf("unrenderable status stderr = %q, want descriptive render error", got)
+	}
+}
+
+func TestAxiStatusRendersEveryStepStatus(t *testing.T) {
+	statuses := []types.StepStatus{
+		types.StepStatusPending,
+		types.StepStatusRunning,
+		types.StepStatusAwaitingApproval,
+		types.StepStatusFixing,
+		types.StepStatusFixReview,
+		types.StepStatusCompleted,
+		types.StepStatusSkipped,
+		types.StepStatusFailed,
+	}
+	for _, status := range statuses {
+		t.Run(string(status), func(t *testing.T) {
+			gateStatus := status == types.StepStatusAwaitingApproval || status == types.StepStatusFixReview
+			step := stepView{Name: "test", Status: string(status)}
+			if gateStatus {
+				step.FindingsJSON = findingsJSON(t, []types.Finding{{ID: "test-1", Severity: "error", Action: types.ActionAskUser, Description: "needs review"}}, "gate")
+			}
+			rv := runView{ID: "run-1", Branch: "feature/state", Status: string(types.RunRunning), HeadSHA: "abcdef1234567890", Steps: []stepView{step}}
+			fields := []toon.Field{runObjectField(rv)}
+			if gateStatus {
+				fields = append(fields, gateFields(step)...)
+			}
+
+			var stdout, stderr bytes.Buffer
+			cmd := &cobra.Command{}
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&stderr)
+			if err := emitStatusDoc(cmd, fields...); err != nil {
+				t.Fatalf("render status %s: %v\nstderr: %s", status, err, stderr.String())
+			}
+			if stdout.Len() == 0 {
+				t.Fatalf("render status %s produced empty output", status)
+			}
+			if !strings.Contains(stdout.String(), "test,"+string(status)) {
+				t.Fatalf("render status %s missing step row:\n%s", status, stdout.String())
+			}
+			if gateStatus && !strings.Contains(stdout.String(), "gate:\n") {
+				t.Fatalf("render status %s missing gate:\n%s", status, stdout.String())
+			}
+		})
+	}
+}
+
+func TestAxiStatusRendersEveryRunStatus(t *testing.T) {
+	statuses := []types.RunStatus{
+		types.RunPending,
+		types.RunRunning,
+		types.RunCompleted,
+		types.RunFailed,
+		types.RunCancelled,
+	}
+	for _, status := range statuses {
+		t.Run(string(status), func(t *testing.T) {
+			rv := runView{ID: "run-1", Branch: "feature/state", Status: string(status), HeadSHA: "abcdef1234567890"}
+			var stdout, stderr bytes.Buffer
+			cmd := &cobra.Command{}
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&stderr)
+			if err := emitStatusDoc(cmd, runObjectField(rv)); err != nil {
+				t.Fatalf("render run status %s: %v\nstderr: %s", status, err, stderr.String())
+			}
+			if stdout.Len() == 0 || !strings.Contains(stdout.String(), "status: "+string(status)) {
+				t.Fatalf("render run status %s produced invalid output:\n%s", status, stdout.String())
+			}
+		})
+	}
+}
+
+func setupAxiStatusRun(t *testing.T, branch string) (*db.DB, *db.Run) {
+	t.Helper()
+	repoDir := t.TempDir()
+	nmHome := makeSocketSafeTempDir(t)
+	t.Setenv("NM_HOME", nmHome)
+	run(t, repoDir, "git", "init")
+	run(t, repoDir, "git", "config", "user.email", "test@test.com")
+	run(t, repoDir, "git", "config", "user.name", "Test")
+	run(t, repoDir, "git", "commit", "--allow-empty", "-m", "initial")
+	rawRoot, err := filepath.EvalSymlinks(repoDir)
+	if err != nil {
+		rawRoot = repoDir
+	}
+	chdir(t, rawRoot)
+
+	p := paths.WithRoot(nmHome)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	database, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	repo, err := database.InsertRepoWithID("repo-1", rawRoot, "origin", "main")
+	if err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+	dbRun, err := database.InsertRun(repo.ID, branch, "abcdef1234567890", "base")
+	if err != nil {
+		t.Fatalf("insert run: %v", err)
+	}
+	if err := database.UpdateRunStatus(dbRun.ID, types.RunRunning); err != nil {
+		t.Fatalf("mark run running: %v", err)
+	}
+	return database, dbRun
+}
+
 // TestGateNote_ReviewOnly verifies the review-auto-fix-disabled note appears
 // only at the review gate, while the keep-driving reminder appears at every
 // gate.

--- a/internal/e2e/axi_journey_test.go
+++ b/internal/e2e/axi_journey_test.go
@@ -57,6 +57,116 @@ func axiScenario(t *testing.T) string {
 	return path
 }
 
+func axiFixReviewScenario(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "axi-fix-review-scenario.yaml")
+	content := `actions:
+  - match: "whose job is to REFUTE"
+    text: "the evidence supports the claim"
+    structured:
+      verdict: CONFIRMED
+      rationale: "fakeagent: the captured evidence supports the claim"
+  - match: "review scope: current worktree and HEAD changes relative"
+    text: "the attempted fix still needs review"
+    structured:
+      findings:
+        - id: "review-after-fix-1"
+          severity: error
+          file: "feature.txt"
+          line: 1
+          description: "the fix still fails: \e[31mregression\e[0m"
+          action: ask-user
+      summary: "fix needs review"
+      risk_level: high
+      risk_rationale: "the regression remains"
+  - match: "Investigate previous review findings and address legitimate ones."
+    text: "applied the requested fix"
+    edits:
+      - path: "feature.txt"
+        old: "change"
+        new: "fixed"
+    structured:
+      summary: "address review finding"
+  - match: "Review the code changes and return structured findings"
+    text: "review found a fixable issue"
+    structured:
+      findings:
+        - id: "review-1"
+          severity: warning
+          file: "feature.txt"
+          line: 1
+          description: "fix this issue"
+          action: ask-user
+      summary: "found 1 issue"
+      risk_level: medium
+      risk_rationale: "warning requires review"
+  - text: "no issues found"
+    structured:
+      findings: []
+      summary: "no issues found"
+      risk_level: low
+      risk_rationale: "no risks detected in the diff"
+      tested:
+        - "fakeagent: simulated test run"
+      testing_summary: "simulated tests passed"
+      title: "feat: fakeagent change"
+      body: "fakeagent canned PR body"
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write axi fix-review scenario: %v", err)
+	}
+	return path
+}
+
+func TestAxiStatusShowsRealParkedFixReviewRun(t *testing.T) {
+	h := NewHarness(t, SetupOpts{Agent: "claude", Scenario: axiFixReviewScenario(t)})
+
+	h.CommitChange("init-axi-fix-review", "seed.txt", "seed\n", "seed for axi fix review")
+	initWorktree := h.AddWorktree("init-axi-fix-review")
+	if out, err := h.RunInDir(initWorktree, "init"); err != nil {
+		t.Fatalf("nm init: %v\n%s", err, out)
+	}
+
+	h.CommitChange("feature/axi-fix-review", "feature.txt", "change\n", "add feature change")
+	fw := h.AddWorktree("feature/axi-fix-review")
+	if out, err := h.RunInDir(fw, "axi", "run", "--intent", axiIntent); err != nil {
+		t.Fatalf("axi run: %v\n%s", err, out)
+	}
+	if gated := waitForStepStatus(t, h, "feature/axi-fix-review", types.StepReview, types.StepStatusAwaitingApproval, 60*time.Second); gated == nil {
+		t.Fatal("expected initial review gate")
+	}
+
+	fixOut, err := h.RunInDir(fw, "axi", "respond", "--action", "fix", "--findings", "review-1")
+	if err != nil {
+		t.Fatalf("axi respond fix: %v\n%s", err, fixOut)
+	}
+	if gated := waitForStepStatus(t, h, "feature/axi-fix-review", types.StepReview, types.StepStatusFixReview, 60*time.Second); gated == nil {
+		t.Fatal("expected fix_review gate")
+	}
+
+	statusOut, err := h.RunInDir(fw, "axi", "status")
+	if err != nil {
+		t.Fatalf("axi status at fix_review: %v\n%s", err, statusOut)
+	}
+	t.Logf("real parked fix_review status output:\n%s", statusOut)
+	for _, want := range []string{
+		"run:\n",
+		"review,fix_review,1",
+		"gate:\n",
+		"step: review\n",
+		"status: fix_review\n",
+		"review-after-fix-1,error,feature.txt,ask-user",
+		"the fix still fails: regression",
+	} {
+		if !strings.Contains(statusOut, want) {
+			t.Errorf("axi status missing %q in:\n%s", want, statusOut)
+		}
+	}
+	if strings.Contains(statusOut, "\x1b") {
+		t.Fatalf("axi status leaked terminal escapes:\n%s", statusOut)
+	}
+}
+
 // TestAxiAgentJourney proves an autonomous agent can drive a full no-mistakes
 // pipeline headlessly through the `no-mistakes axi` surface in an isolated
 // dummy environment: init installs the skill, the home view reports state,


### PR DESCRIPTION
## Summary

- strip terminal escape/control bytes from agent finding text before TOON rendering, so colored diagnostics cannot blank an entire fix_review status
- make axi status propagate TOON/render/write failures as a non-zero stderr error instead of returning empty stdout with exit 0
- cover every run/step status plus a real daemon-driven awaiting_approval -> fix -> fix_review journey

## Root cause

A finding could quote raw colored test output. TOON rejects the ESC control byte, while axiDoc swallowed the marshal error and returned an empty string. fix_review findings commonly contain second-pass test diagnostics, making that gate the reproducible trigger.

## Verification

Passed:
- make lint
- go test -race ./...
- go test -race ./internal/cli after transplanting onto GitHub upstream/main
- go build -o ./bin/no-mistakes ./cmd/no-mistakes
- go test -tags=e2e ./internal/e2e -run TestAxiStatusShowsRealParkedFixReviewRun -count=1 -v

The targeted real parked-run e2e reached review/fix_review through axi respond --action fix. axi status printed the run and step table, then:

    gate:
      step: review
      status: fix_review
      summary: fix needs review
      risk: high
      findings[1]{id,severity,file,action,description}:
        review-after-fix-1,error,feature.txt,ask-user,"the fix still fails: regression"

## Existing e2e baseline failures

The full make e2e run passed the new targeted journey but failed two PR harness tests unrelated to AXI rendering. On this branch:

    --- FAIL: TestForkRouting
        PR URL = <nil>, want parent repository PR URL
    --- FAIL: TestPRHandsOffToWatchRun
        step pr skipped
        the gate run opened no PR, so there is nothing to hand off

I stashed all changes, detached at clean main c903cdb, and ran the exact comparison command:

    go test -tags=e2e -count=1 -timeout 300s ./internal/e2e -run "TestForkRouting|TestPRHandsOffToWatchRun" -v

Clean main failed identically:

    --- FAIL: TestForkRouting
        PR URL = <nil>, want parent repository PR URL
    --- FAIL: TestPRHandsOffToWatchRun
        step pr skipped
        the gate run opened no PR, so there is nothing to hand off

Therefore those two failures are pre-existing environment/harness failures, not regressions from this change.