### PR TITLE
feat: add run-scoped agent selection

### DIFF
--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -59,6 +59,7 @@ func newAxiRunCmd() *cobra.Command {
 	var autoYes bool
 	var skipValue string
 	var intent string
+	var agentValue string
 
 	cmd := &cobra.Command{
 		Use:   "run",
@@ -83,23 +84,29 @@ func newAxiRunCmd() *cobra.Command {
 				"auto_yes":   autoYes,
 				"has_intent": strings.TrimSpace(intent) != "",
 				"has_skip":   strings.TrimSpace(skipValue) != "",
+				"has_agent":  strings.TrimSpace(agentValue) != "",
 			}, func() error {
 				skipSteps, err := parseSkipSteps(skipValue)
 				if err != nil {
 					return emitError(cmd, 2, err.Error(),
 						"Valid steps: intent, rebase, review, test, document, lint, push, pr, ci")
 				}
-				return runAxiRun(cmd, autoYes, skipSteps, intent)
+				agentName, err := parseRunAgent(agentValue)
+				if err != nil {
+					return emitError(cmd, 2, err.Error())
+				}
+				return runAxiRun(cmd, autoYes, skipSteps, intent, agentName)
 			})
 		},
 	}
 	cmd.Flags().BoolVarP(&autoYes, "yes", "y", false, "auto-resolve every gate (fix findings, then accept) until a decision point or outcome")
 	cmd.Flags().StringVar(&skipValue, "skip", "", "comma-separated pipeline steps to skip")
 	cmd.Flags().StringVar(&intent, "intent", "", "what the user set out to accomplish (not a description of the diff); used instead of inferring from transcripts (required to start a run)")
+	cmd.Flags().StringVar(&agentValue, "agent", "", "pipeline agent for this run only (claude or codex)")
 	return cmd
 }
 
-func runAxiRun(cmd *cobra.Command, autoYes bool, skipSteps []types.StepName, intent string) error {
+func runAxiRun(cmd *cobra.Command, autoYes bool, skipSteps []types.StepName, intent string, agentName types.AgentName) error {
 	ctx := cmd.Context()
 	env, err := openAxiRunEnv()
 	if err != nil {
@@ -121,7 +128,14 @@ func runAxiRun(cmd *cobra.Command, autoYes bool, skipSteps []types.StepName, int
 		return emitError(cmd, 1, fmt.Sprintf("get current HEAD: %v", err))
 	}
 
-	runID := activeRunID(env, branch, headSHA)
+	active := activeRunInfo(env, branch, headSHA)
+	if conflict := activeRunAgentConflict(active, agentName); conflict != nil {
+		return emitError(cmd, 2, conflict.Error())
+	}
+	runID := ""
+	if active != nil {
+		runID = active.ID
+	}
 	if runID == "" {
 		if err := configErrorForFreshAxiRun(env, runID); err != nil {
 			return emitError(cmd, 1, err.Error(), repoInitHelp(err)...)
@@ -142,7 +156,7 @@ func runAxiRun(cmd *cobra.Command, autoYes bool, skipSteps []types.StepName, int
 			return guard(cmd)
 		}
 		var err error
-		runID, err = triggerRun(ctx, env, branch, headSHA, skipSteps, intent)
+		runID, err = triggerRun(ctx, env, branch, headSHA, skipSteps, intent, agentName)
 		if err != nil {
 			return emitError(cmd, 1, err.Error())
 		}
@@ -155,6 +169,35 @@ func runAxiRun(cmd *cobra.Command, autoYes bool, skipSteps []types.StepName, int
 	return renderDriveResult(cmd, run, ciReady)
 }
 
+func activeRunAgentConflict(active *ipc.RunInfo, agentName types.AgentName) error {
+	if active == nil || agentName == "" {
+		return nil
+	}
+	selected := active.ResolvedAgent
+	if active.RequestedAgent != nil {
+		selected = active.RequestedAgent
+	}
+	if selected == nil || *selected != string(agentName) {
+		return fmt.Errorf("active run %s uses agent %q; cannot reattach with --agent %s", active.ID, stringValue(selected), agentName)
+	}
+	return nil
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return "configured default"
+	}
+	return *value
+}
+
+func activeRunInfo(env *axiEnv, branch, headSHA string) *ipc.RunInfo {
+	var active ipc.GetActiveRunResult
+	if err := env.client.Call(ipc.MethodGetActiveRun, activeRunLookupParams(env.repo.ID, branch), &active); err != nil {
+		return nil
+	}
+	return activeRunInfoForHead(active.Run, headSHA)
+}
+
 func configErrorForFreshAxiRun(env *axiEnv, runID string) error {
 	if runID != "" {
 		return nil
@@ -164,11 +207,11 @@ func configErrorForFreshAxiRun(env *axiEnv, runID string) error {
 
 // activeRunID returns the ID of a non-terminal run for branch and head, or "" if none.
 func activeRunID(env *axiEnv, branch, headSHA string) string {
-	var active ipc.GetActiveRunResult
-	if err := env.client.Call(ipc.MethodGetActiveRun, activeRunLookupParams(env.repo.ID, branch), &active); err != nil {
+	run := activeRunInfo(env, branch, headSHA)
+	if run == nil {
 		return ""
 	}
-	return activeRunIDForHead(&active, headSHA)
+	return run.ID
 }
 
 func activeRunIDForHead(active *ipc.GetActiveRunResult, headSHA string) string {
@@ -219,9 +262,12 @@ func preflightGuard(ctx context.Context, env *axiEnv, branch string) func(*cobra
 // the gate to trigger a pipeline, and falls back to a rerun when the push was a
 // no-op (the gate already had this commit). Callers must check for an existing
 // active run first (see activeRunID) and apply pre-flight guards.
-func triggerRun(ctx context.Context, env *axiEnv, branch, headSHA string, skipSteps []types.StepName, intent string) (string, error) {
+func triggerRun(ctx context.Context, env *axiEnv, branch, headSHA string, skipSteps []types.StepName, intent string, agentName types.AgentName) (string, error) {
 	pushOptions := formatSkipPushOptions(skipSteps)
 	if opt := formatIntentPushOption(intent); opt != "" {
+		pushOptions = append(pushOptions, opt)
+	}
+	if opt := formatAgentPushOption(agentName); opt != "" {
 		pushOptions = append(pushOptions, opt)
 	}
 	priorRunIDs, err := runIDsForHead(env.client, env.repo.ID, branch, headSHA)
@@ -242,7 +288,7 @@ func triggerRun(ctx context.Context, env *axiEnv, branch, headSHA string, skipSt
 	// No run appeared: the push was likely up-to-date. Rerun the latest gate
 	// head so `axi run` is still useful when there are no new commits.
 	var rr ipc.RerunResult
-	if err := env.client.Call(ipc.MethodRerun, rerunParams(env.repo.ID, branch, skipSteps, intent), &rr); err != nil {
+	if err := env.client.Call(ipc.MethodRerun, rerunParams(env.repo.ID, branch, skipSteps, intent, agentName), &rr); err != nil {
 		return "", fmt.Errorf("no run started for %q: %v", branch, err)
 	}
 	return rr.RunID, nil
@@ -326,8 +372,8 @@ func activeRunLookupParams(repoID, branch string) *ipc.GetActiveRunParams {
 	return &ipc.GetActiveRunParams{RepoID: repoID, Branch: branch}
 }
 
-func rerunParams(repoID, branch string, skipSteps []types.StepName, intent string) *ipc.RerunParams {
-	return &ipc.RerunParams{RepoID: repoID, Branch: branch, SkipSteps: skipSteps, Intent: intent}
+func rerunParams(repoID, branch string, skipSteps []types.StepName, intent string, agentName types.AgentName) *ipc.RerunParams {
+	return &ipc.RerunParams{RepoID: repoID, Branch: branch, SkipSteps: skipSteps, Intent: intent, Agent: agentName}
 }
 
 // driveRun polls a run until it reaches an approval gate, a terminal state, or

--- a/internal/cli/axi_render.go
+++ b/internal/cli/axi_render.go
@@ -90,11 +90,13 @@ type stepView struct {
 
 // runView is a render-ready view of a pipeline run.
 type runView struct {
-	ID      string
-	Branch  string
-	Status  string
-	HeadSHA string
-	PRURL   string
+	ID             string
+	Branch         string
+	Status         string
+	HeadSHA        string
+	PRURL          string
+	RequestedAgent string
+	ResolvedAgent  string
 	// AwaitingAgentSince is the unix-seconds time the run parked at a gate
 	// awaiting the driving agent, or nil when the run is not parked. It powers
 	// the top-level parked signal in the run object.
@@ -109,6 +111,8 @@ func runViewFromIPC(r *ipc.RunInfo) runView {
 		Status:             string(r.Status),
 		HeadSHA:            r.HeadSHA,
 		AwaitingAgentSince: r.AwaitingAgentSince,
+		RequestedAgent:     stringValue(r.RequestedAgent),
+		ResolvedAgent:      stringValue(r.ResolvedAgent),
 	}
 	if r.PRURL != nil {
 		rv.PRURL = *r.PRURL
@@ -148,6 +152,8 @@ func runViewFromDB(r *db.Run, steps []*db.StepResult) runView {
 		Status:             string(r.Status),
 		HeadSHA:            r.HeadSHA,
 		AwaitingAgentSince: r.AwaitingAgentSince,
+		RequestedAgent:     stringValue(r.RequestedAgent),
+		ResolvedAgent:      stringValue(r.ResolvedAgent),
 	}
 	if r.PRURL != nil {
 		rv.PRURL = *r.PRURL
@@ -412,6 +418,9 @@ func runObjectFieldWithKey(key string, rv runView) toon.Field {
 		fields = append(fields, toon.Field{Key: "awaiting_agent", Value: formatParkedFor(*rv.AwaitingAgentSince)})
 	}
 	fields = append(fields, toon.Field{Key: "head", Value: shortSHA(rv.HeadSHA)})
+	if rv.ResolvedAgent != "configured default" {
+		fields = append(fields, toon.Field{Key: "agent", Value: rv.ResolvedAgent})
+	}
 	if rv.PRURL != "" {
 		fields = append(fields, toon.Field{Key: "pr", Value: rv.PRURL})
 	}

--- a/internal/cli/axi_test.go
+++ b/internal/cli/axi_test.go
@@ -440,12 +440,27 @@ func TestConfigErrorForFreshAxiRunAllowsReattach(t *testing.T) {
 }
 
 func TestRerunParamsIncludeSkipSteps(t *testing.T) {
-	params := rerunParams("repo-1", "feature/x", []types.StepName{types.StepReview}, "user goal")
+	params := rerunParams("repo-1", "feature/x", []types.StepName{types.StepReview}, "user goal", types.AgentCodex)
 	if params.RepoID != "repo-1" || params.Branch != "feature/x" || params.Intent != "user goal" {
 		t.Fatalf("unexpected rerun params: %#v", params)
 	}
 	if len(params.SkipSteps) != 1 || params.SkipSteps[0] != types.StepReview {
 		t.Fatalf("SkipSteps = %#v, want review", params.SkipSteps)
+	}
+	if params.Agent != types.AgentCodex {
+		t.Fatalf("Agent = %q, want codex", params.Agent)
+	}
+}
+
+func TestActiveRunAgentOverrideMustMatch(t *testing.T) {
+	codex := string(types.AgentCodex)
+	run := &ipc.RunInfo{ID: "run-1", Status: types.RunRunning, HeadSHA: "head", RequestedAgent: &codex, ResolvedAgent: &codex}
+
+	if got := activeRunAgentConflict(run, types.AgentCodex); got != nil {
+		t.Fatalf("matching override should reattach: %v", got)
+	}
+	if got := activeRunAgentConflict(run, types.AgentClaude); got == nil {
+		t.Fatal("conflicting override should fail")
 	}
 }
 
@@ -677,7 +692,7 @@ func TestAxiRunReportsInvalidGlobalConfig(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.SetContext(context.Background())
 	cmd.SetOut(&out)
-	if err := runAxiRun(cmd, false, nil, "user goal"); err == nil {
+	if err := runAxiRun(cmd, false, nil, "user goal", ""); err == nil {
 		t.Fatalf("axi run should fail on invalid global config:\n%s", out.String())
 	}
 	got := out.String()

--- a/internal/cli/daemon_cmd.go
+++ b/internal/cli/daemon_cmd.go
@@ -60,6 +60,10 @@ func newDaemonNotifyPushCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			agentName, err := parseAgentPushOptions(pushOptions)
+			if err != nil {
+				return err
+			}
 			gatePath, err := normalizeNotifyGatePath(gate)
 			if err != nil {
 				return err
@@ -84,6 +88,7 @@ func newDaemonNotifyPushCmd() *cobra.Command {
 				New:       newSHA,
 				SkipSteps: skipSteps,
 				Intent:    intent,
+				Agent:     agentName,
 			}, &result)
 		},
 	}
@@ -99,6 +104,42 @@ func newDaemonNotifyPushCmd() *cobra.Command {
 	_ = cmd.MarkFlagRequired("new")
 
 	return cmd
+}
+
+const agentPushOptionPrefix = "no-mistakes.agent="
+
+func parseRunAgent(value string) (types.AgentName, error) {
+	name := types.AgentName(strings.TrimSpace(value))
+	if name == "" || name == types.AgentClaude || name == types.AgentCodex {
+		return name, nil
+	}
+	return "", fmt.Errorf("unsupported run agent %q (valid: claude, codex)", value)
+}
+
+func formatAgentPushOption(name types.AgentName) string {
+	if name == "" {
+		return ""
+	}
+	return agentPushOptionPrefix + string(name)
+}
+
+func parseAgentPushOptions(options []string) (types.AgentName, error) {
+	var selected types.AgentName
+	for _, option := range options {
+		value, ok := strings.CutPrefix(option, agentPushOptionPrefix)
+		if !ok {
+			continue
+		}
+		name, err := parseRunAgent(value)
+		if err != nil {
+			return "", err
+		}
+		if selected != "" && selected != name {
+			return "", fmt.Errorf("conflicting run agents %q and %q", selected, name)
+		}
+		selected = name
+	}
+	return selected, nil
 }
 
 func normalizeNotifyGatePath(gate string) (string, error) {

--- a/internal/cli/daemon_cmd_test.go
+++ b/internal/cli/daemon_cmd_test.go
@@ -77,6 +77,34 @@ func TestFormatSkipPushOptions(t *testing.T) {
 	}
 }
 
+func TestAgentPushOptionRoundTrip(t *testing.T) {
+	for _, want := range []types.AgentName{types.AgentClaude, types.AgentCodex} {
+		got, err := parseAgentPushOptions([]string{"ci.skip", formatAgentPushOption(want)})
+		if err != nil {
+			t.Fatalf("parseAgentPushOptions(%q): %v", want, err)
+		}
+		if got != want {
+			t.Fatalf("parseAgentPushOptions(%q) = %q", want, got)
+		}
+	}
+}
+
+func TestParseAgentPushOptionsRejectsConflict(t *testing.T) {
+	_, err := parseAgentPushOptions([]string{
+		"no-mistakes.agent=claude",
+		"no-mistakes.agent=codex",
+	})
+	if err == nil {
+		t.Fatal("expected conflicting run agents to fail")
+	}
+}
+
+func TestParseRunAgentRejectsUnsupportedAgent(t *testing.T) {
+	if _, err := parseRunAgent("auto"); err == nil {
+		t.Fatal("expected auto to be rejected for a run-scoped override")
+	}
+}
+
 func TestIntentPushOptionRoundTrip(t *testing.T) {
 	// Multi-line, comma- and colon-bearing intent must survive the
 	// line-oriented push-option transport intact.

--- a/internal/cli/rerun.go
+++ b/internal/cli/rerun.go
@@ -7,16 +7,22 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/daemon"
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
+	"github.com/kunchenguid/no-mistakes/internal/types"
 	"github.com/spf13/cobra"
 )
 
 func newRerunCmd() *cobra.Command {
-	return &cobra.Command{
+	var agentValue string
+	cmd := &cobra.Command{
 		Use:   "rerun",
 		Short: "Rerun the pipeline for the current branch",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return trackCommand("rerun", func() error {
+				agentName, err := parseRunAgent(agentValue)
+				if err != nil {
+					return err
+				}
 				p, d, err := openResources()
 				if err != nil {
 					return err
@@ -47,7 +53,7 @@ func newRerunCmd() *cobra.Command {
 				defer client.Close()
 
 				var result ipc.RerunResult
-				if err := client.Call(ipc.MethodRerun, &ipc.RerunParams{RepoID: repo.ID, Branch: branch}, &result); err != nil {
+				if err := client.Call(ipc.MethodRerun, &ipc.RerunParams{RepoID: repo.ID, Branch: branch, Agent: types.AgentName(agentName)}, &result); err != nil {
 					return fmt.Errorf("rerun pipeline: %w", err)
 				}
 
@@ -56,4 +62,6 @@ func newRerunCmd() *cobra.Command {
 			})
 		},
 	}
+	cmd.Flags().StringVar(&agentValue, "agent", "", "pipeline agent for this rerun only (claude or codex); defaults to the previous run's explicit selection")
+	return cmd
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -485,7 +485,7 @@ func registerHandlers(srv *ipc.Server, mgr *RunManager, d *db.DB, shutdown func(
 		if err := json.Unmarshal(params, &p); err != nil {
 			return nil, fmt.Errorf("invalid params: %w", err)
 		}
-		runID, err := mgr.HandleRerun(ctx, p.RepoID, p.Branch, p.SkipSteps, p.Intent)
+		runID, err := mgr.HandleRerun(ctx, p.RepoID, p.Branch, p.SkipSteps, p.Intent, p.Agent)
 		if err != nil {
 			return nil, err
 		}
@@ -562,6 +562,8 @@ func runToInfo(d *db.DB, r *db.Run, steps []*db.StepResult) *ipc.RunInfo {
 		Status:             r.Status,
 		PRURL:              r.PRURL,
 		Error:              r.Error,
+		RequestedAgent:     r.RequestedAgent,
+		ResolvedAgent:      r.ResolvedAgent,
 		AwaitingAgent:      r.AwaitingAgentSince != nil,
 		AwaitingAgentSince: r.AwaitingAgentSince,
 		CreatedAt:          r.CreatedAt,

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -208,7 +208,21 @@ func (m *RunManager) loadRecoveredConfig(ctx context.Context, run *db.Run, repo 
 	}
 	trustedRepoCfg := loadTrustedRepoConfig(ctx, workDir, trustedSHA, run.ID)
 	allowRepoCommands := trustedRepoCfg != nil && trustedRepoCfg.AllowRepoCommands
-	return config.Merge(globalCfg, config.EffectiveRepoConfig(repoCfg, trustedRepoCfg, allowRepoCommands)), nil
+	cfg := config.Merge(globalCfg, config.EffectiveRepoConfig(repoCfg, trustedRepoCfg, allowRepoCommands))
+	applyRecoveredRunAgent(cfg, run)
+	return cfg, nil
+}
+
+// applyRecoveredRunAgent keeps an explicit run-scoped selection stable across
+// daemon restarts. Repository/global config may have changed since the run
+// started, but recovery must resume the adapter recorded for that run.
+func applyRecoveredRunAgent(cfg *config.Config, run *db.Run) {
+	if run.RequestedAgent == nil || run.ResolvedAgent == nil {
+		return
+	}
+	resolved := types.AgentName(*run.ResolvedAgent)
+	cfg.Agent = resolved
+	cfg.Agents = []types.AgentName{resolved}
 }
 
 func newPipelineAgent(ctx context.Context, cfg *config.Config, lookPath func(string) (string, error)) (agent.Agent, error) {
@@ -536,12 +550,12 @@ func (m *RunManager) HandlePushReceived(ctx context.Context, params *ipc.PushRec
 	}
 
 	branch := branchFromRef(params.Ref)
-	return m.startRun(ctx, repo, branch, params.New, params.Old, "push", params.SkipSteps, params.Intent)
+	return m.startRun(ctx, repo, branch, params.New, params.Old, "push", params.SkipSteps, params.Intent, params.Agent)
 }
 
 // HandleRerun creates a new run for the latest gate head on a branch. An
 // optional intent is stamped onto the new run.
-func (m *RunManager) HandleRerun(ctx context.Context, repoID, branch string, skipSteps []types.StepName, intent string) (string, error) {
+func (m *RunManager) HandleRerun(ctx context.Context, repoID, branch string, skipSteps []types.StepName, intent string, agentName types.AgentName) (string, error) {
 	repo, err := m.db.GetRepo(repoID)
 	if err != nil {
 		return "", fmt.Errorf("get repo: %w", err)
@@ -584,13 +598,16 @@ func (m *RunManager) HandleRerun(ctx context.Context, repoID, branch string, ski
 		baseSHA = matchingHead.BaseSHA
 	}
 
-	return m.startRun(ctx, repo, branch, headSHA, baseSHA, "rerun", skipSteps, intent)
+	if agentName == "" && latestForBranch.RequestedAgent != nil {
+		agentName = types.AgentName(*latestForBranch.RequestedAgent)
+	}
+	return m.startRun(ctx, repo, branch, headSHA, baseSHA, "rerun", skipSteps, intent, agentName)
 }
 
 // startRun creates a run, sets up a worktree, and launches pipeline execution.
 // A non-empty intent is stamped onto the run as agent-supplied, so the intent
 // step uses it instead of inferring from transcripts.
-func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSHA, baseSHA, trigger string, skipSteps []types.StepName, intent string) (string, error) {
+func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSHA, baseSHA, trigger string, skipSteps []types.StepName, intent string, agentName types.AgentName) (string, error) {
 	branchRole := telemetryBranchRole(branch, repo.DefaultBranch)
 	trackStartFailure := func(stage string) {
 		telemetry.Track("run", telemetry.Fields{
@@ -599,6 +616,10 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 			"branch_role": branchRole,
 			"stage":       stage,
 		})
+	}
+	if agentName != "" && agentName != types.AgentClaude && agentName != types.AgentCodex {
+		trackStartFailure("validate_agent")
+		return "", fmt.Errorf("unsupported run agent %q (valid: claude, codex)", agentName)
 	}
 
 	if m.shuttingDown.Load() {
@@ -729,6 +750,10 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 		slog.Info("repo commands/agent loaded from default branch, not pushed branch", "run_id", run.ID, "branch", branch, "default_branch", repo.DefaultBranch)
 	}
 	cfg := config.Merge(globalCfg, effectiveRepoCfg)
+	if agentName != "" {
+		cfg.Agent = agentName
+		cfg.Agents = []types.AgentName{agentName}
+	}
 
 	// Create agent. In demo mode, skip resolution and use a no-op agent.
 	var ag agent.Agent
@@ -739,6 +764,15 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 			m.db.UpdateRunError(run.ID, err.Error())
 			trackStartFailure("resolve_agent")
 			return "", err
+		}
+		if err := m.db.UpdateRunAgents(run.ID, string(agentName), string(cfg.Agent)); err != nil {
+			return "", err
+		}
+		resolved := string(cfg.Agent)
+		run.ResolvedAgent = &resolved
+		if agentName != "" {
+			requested := string(agentName)
+			run.RequestedAgent = &requested
 		}
 		agents := cfg.Agents
 		if len(agents) == 0 {
@@ -776,14 +810,19 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 	}
 
 	execSteps := m.steps()
-	telemetry.Track("run", telemetry.Fields{
-		"action":      "started",
-		"trigger":     trigger,
-		"agent":       string(cfg.Agent),
-		"branch_role": branchRole,
-		"step_count":  len(execSteps),
-		"demo_mode":   steps.IsDemoMode(),
-	})
+	startedFields := telemetry.Fields{
+		"action":         "started",
+		"trigger":        trigger,
+		"agent":          string(cfg.Agent),
+		"resolved_agent": string(cfg.Agent),
+		"branch_role":    branchRole,
+		"step_count":     len(execSteps),
+		"demo_mode":      steps.IsDemoMode(),
+	}
+	if agentName != "" {
+		startedFields["requested_agent"] = string(agentName)
+	}
+	telemetry.Track("run", startedFields)
 
 	// Create executor with event broadcast.
 	runCtx, cancel := context.WithCancelCause(context.Background())

--- a/internal/daemon/manager_trust_test.go
+++ b/internal/daemon/manager_trust_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
 func TestLoadRecoveredConfig_BoundsFetchAndFailsClosed(t *testing.T) {
@@ -62,6 +63,26 @@ func TestLoadRecoveredConfig_BoundsFetchAndFailsClosed(t *testing.T) {
 	}
 	if err := <-fetchResult; !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("fetch error = %v, want deadline exceeded", err)
+	}
+}
+
+func TestApplyRecoveredRunAgentPreservesExplicitSelection(t *testing.T) {
+	requested, resolved := "codex", "codex"
+	cfg := &config.Config{Agent: "claude", Agents: []types.AgentName{types.AgentClaude}}
+	applyRecoveredRunAgent(cfg, &db.Run{RequestedAgent: &requested, ResolvedAgent: &resolved})
+
+	if cfg.Agent != types.AgentCodex || len(cfg.Agents) != 1 || cfg.Agents[0] != types.AgentCodex {
+		t.Fatalf("recovered config agent = %q / %v, want codex only", cfg.Agent, cfg.Agents)
+	}
+}
+
+func TestApplyRecoveredRunAgentLeavesDefaultRunConfigAlone(t *testing.T) {
+	resolved := "claude"
+	cfg := &config.Config{Agent: types.AgentCodex, Agents: []types.AgentName{types.AgentCodex}}
+	applyRecoveredRunAgent(cfg, &db.Run{ResolvedAgent: &resolved})
+
+	if cfg.Agent != types.AgentCodex {
+		t.Fatalf("default run recovery changed current config to %q", cfg.Agent)
 	}
 }
 

--- a/internal/db/run.go
+++ b/internal/db/run.go
@@ -29,6 +29,8 @@ type Run struct {
 	// milliseconds across every gate wait (local performance telemetry;
 	// step duration_ms values exclude this time).
 	ParkedMS        int64
+	RequestedAgent  *string
+	ResolvedAgent   *string
 	Intent          *string
 	IntentSource    *string
 	IntentSessionID *string
@@ -37,7 +39,7 @@ type Run struct {
 	UpdatedAt       int64
 }
 
-const runColumns = `id, repo_id, branch, head_sha, base_sha, status, pr_url, error, awaiting_agent_since, COALESCE(parked_ms, 0), intent, intent_source, intent_session_id, intent_score, created_at, updated_at`
+const runColumns = `id, repo_id, branch, head_sha, base_sha, status, pr_url, error, awaiting_agent_since, COALESCE(parked_ms, 0), requested_agent, resolved_agent, intent, intent_source, intent_session_id, intent_score, created_at, updated_at`
 
 func scanRun(row interface {
 	Scan(...any) error
@@ -45,9 +47,20 @@ func scanRun(row interface {
 	return row.Scan(
 		&r.ID, &r.RepoID, &r.Branch, &r.HeadSHA, &r.BaseSHA, &r.Status,
 		&r.PRURL, &r.Error, &r.AwaitingAgentSince, &r.ParkedMS,
+		&r.RequestedAgent, &r.ResolvedAgent,
 		&r.Intent, &r.IntentSource, &r.IntentSessionID, &r.IntentScore,
 		&r.CreatedAt, &r.UpdatedAt,
 	)
+}
+
+// UpdateRunAgents records the run-scoped requested selection and the adapter
+// that configuration resolution actually launched.
+func (d *DB) UpdateRunAgents(id, requested, resolved string) error {
+	_, err := d.sql.Exec(`UPDATE runs SET requested_agent = ?, resolved_agent = ?, updated_at = ? WHERE id = ?`, nullableString(requested), nullableString(resolved), now(), id)
+	if err != nil {
+		return fmt.Errorf("update run agents: %w", err)
+	}
+	return nil
 }
 
 // InsertRun creates a new run record.

--- a/internal/db/run_test.go
+++ b/internal/db/run_test.go
@@ -6,6 +6,28 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
+func TestUpdateRunAgentsRoundTrip(t *testing.T) {
+	d := openTestDB(t)
+	repo, err := d.InsertRepo(t.TempDir(), "origin", "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := d.InsertRun(repo.ID, "feature", "head", "base")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := d.UpdateRunAgents(run.ID, "codex", "codex"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := d.GetRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.RequestedAgent == nil || *got.RequestedAgent != "codex" || got.ResolvedAgent == nil || *got.ResolvedAgent != "codex" {
+		t.Fatalf("agent selection did not round-trip: %#v", got)
+	}
+}
+
 func TestRunInsertAndGet(t *testing.T) {
 	d := openTestDB(t)
 	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -21,6 +21,8 @@ CREATE TABLE IF NOT EXISTS runs (
     error                TEXT,
     awaiting_agent_since INTEGER,
     parked_ms            INTEGER,
+    requested_agent       TEXT,
+    resolved_agent        TEXT,
     created_at           INTEGER NOT NULL,
     updated_at           INTEGER NOT NULL
 );
@@ -135,6 +137,8 @@ var migrationStatements = []string{
 	`ALTER TABLE runs ADD COLUMN intent_score REAL`,
 	`ALTER TABLE runs ADD COLUMN awaiting_agent_since INTEGER`,
 	`ALTER TABLE runs ADD COLUMN parked_ms INTEGER`,
+	`ALTER TABLE runs ADD COLUMN requested_agent TEXT`,
+	`ALTER TABLE runs ADD COLUMN resolved_agent TEXT`,
 	`ALTER TABLE step_results ADD COLUMN last_activity_at INTEGER`,
 	`ALTER TABLE step_results ADD COLUMN last_activity TEXT`,
 	`ALTER TABLE step_results ADD COLUMN agent_pid INTEGER`,

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -70,6 +70,7 @@ type PushReceivedParams struct {
 	New       string           `json:"new"`
 	SkipSteps []types.StepName `json:"skip_steps,omitempty"`
 	Intent    string           `json:"intent,omitempty"`
+	Agent     types.AgentName  `json:"agent,omitempty"`
 }
 
 // GetRunParams requests a single run by ID.
@@ -106,6 +107,7 @@ type RerunParams struct {
 	Branch    string           `json:"branch"`
 	SkipSteps []types.StepName `json:"skip_steps,omitempty"`
 	Intent    string           `json:"intent,omitempty"`
+	Agent     types.AgentName  `json:"agent,omitempty"`
 }
 
 // SubscribeParams starts an event stream for a run.
@@ -191,14 +193,16 @@ type ShutdownResult struct {
 
 // RunInfo is the IPC representation of a pipeline run.
 type RunInfo struct {
-	ID      string          `json:"id"`
-	RepoID  string          `json:"repo_id"`
-	Branch  string          `json:"branch"`
-	HeadSHA string          `json:"head_sha"`
-	BaseSHA string          `json:"base_sha"`
-	Status  types.RunStatus `json:"status"`
-	PRURL   *string         `json:"pr_url,omitempty"`
-	Error   *string         `json:"error,omitempty"`
+	ID             string          `json:"id"`
+	RepoID         string          `json:"repo_id"`
+	Branch         string          `json:"branch"`
+	HeadSHA        string          `json:"head_sha"`
+	BaseSHA        string          `json:"base_sha"`
+	Status         types.RunStatus `json:"status"`
+	PRURL          *string         `json:"pr_url,omitempty"`
+	Error          *string         `json:"error,omitempty"`
+	RequestedAgent *string         `json:"requested_agent,omitempty"`
+	ResolvedAgent  *string         `json:"resolved_agent,omitempty"`
 	// AwaitingAgent is true while the run is parked at a gate awaiting the
 	// driving agent's response. AwaitingAgentSince is the unix-seconds time it
 	// parked, so a supervisor can read "parked for N seconds" in one call. Both

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -55,6 +55,13 @@ asks for something specific, translate that request into the matching ` + "`axi 
 flags yourself - for example, "skip the lint step" becomes ` + "`--skip=lint`" + `. Run
 ` + "`no-mistakes axi run --help`" + ` to see the available flags.
 
+When the user invokes ` + "`/no-mistakes --codex`" + ` or ` + "`/no-mistakes --claude`" + `,
+translate that into ` + "`no-mistakes axi run --agent codex`" + ` or ` + "`--agent claude`" + `.
+The selection applies to this entire run, including every review and fix round,
+and disables configured agent fallback for the run. A bare ` + "`/no-mistakes`" + `
+keeps the configured agent selection. If reattaching, preserve the original
+selection; a conflicting ` + "`--agent`" + ` is an error rather than an agent switch.
+
 ## Two ways to invoke
 
 ` + "`/no-mistakes`" + ` works in two modes, depending on whether the user hands you a
@@ -129,7 +136,7 @@ Run the pipeline and decide on its findings as they come up:
 
 1. Start the run. It blocks until the first decision point or the end:
    ` + "```sh" + `
-   no-mistakes axi run --intent "<what the user set out to accomplish>"
+   no-mistakes axi run --intent "<what the user set out to accomplish>" [--agent codex|claude]
    ` + "```" + `
    ` + "`axi run`" + ` and every ` + "`axi respond`" + ` block synchronously - the review, test,
    and CI steps can each take **several minutes**, so a single call may not

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -16,6 +16,13 @@ asks for something specific, translate that request into the matching `axi run`
 flags yourself - for example, "skip the lint step" becomes `--skip=lint`. Run
 `no-mistakes axi run --help` to see the available flags.
 
+When the user invokes `/no-mistakes --codex` or `/no-mistakes --claude`,
+translate that into `no-mistakes axi run --agent codex` or `--agent claude`.
+The selection applies to this entire run, including every review and fix round,
+and disables configured agent fallback for the run. A bare `/no-mistakes`
+keeps the configured agent selection. If reattaching, preserve the original
+selection; a conflicting `--agent` is an error rather than an agent switch.
+
 ## Two ways to invoke
 
 `/no-mistakes` works in two modes, depending on whether the user hands you a
@@ -90,7 +97,7 @@ Run the pipeline and decide on its findings as they come up:
 
 1. Start the run. It blocks until the first decision point or the end:
    ```sh
-   no-mistakes axi run --intent "<what the user set out to accomplish>"
+   no-mistakes axi run --intent "<what the user set out to accomplish>" [--agent codex|claude]
    ```
    `axi run` and every `axi respond` block synchronously - the review, test,
    and CI steps can each take **several minutes**, so a single call may not


### PR DESCRIPTION
Closes #474

Adds persisted, run-scoped agent selection for run, rerun, and push without changing the configured default. Existing runs keep their selected agent through reattachment and restart.

Tests:
- go test ./internal/cli ./internal/db ./internal/agent ./internal/pipeline/... ./internal/types
- git diff --check upstream/main...HEAD