### PR TITLE
fix: preserve externally managed skill links

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -54,7 +54,7 @@ func newInitCmd() *cobra.Command {
 				// Install the agent skill at user level so agents can drive
 				// no-mistakes via `/no-mistakes` in any repo. Best-effort: a
 				// skill write failure must not undo a successful gate setup.
-				_, skillErr := skill.InstallUser()
+				skillResult, skillErr := skill.InstallUser()
 
 				w := cmd.OutOrStdout()
 				fmt.Fprintln(w, sCyan.Render(banner))
@@ -79,6 +79,9 @@ func newInitCmd() *cobra.Command {
 					fmt.Fprintf(w, "  %s  %s\n", sDim.Render(" skill"), sYellow.Render("skipped: "+skillErr.Error()))
 				} else {
 					fmt.Fprintf(w, "  %s  %s %s\n", sDim.Render(" skill"), sGreen.Render("/no-mistakes"), sDim.Render("installed for agents at user level"))
+					if len(skillResult.Managed) > 0 {
+						fmt.Fprintf(w, "  %s  %s\n", sDim.Render("  note"), sDim.Render("externally managed skill path left unchanged ("+strings.Join(skillResult.Managed, ", ")+")"))
+					}
 				}
 				if legacy := skill.Vendored(repo.WorkingPath); len(legacy) > 0 {
 					fmt.Fprintf(w, "  %s  %s\n", sDim.Render("  note"), sDim.Render("vendored skill copy ("+strings.Join(legacy, ", ")+") is no longer needed and can be removed"))

--- a/internal/e2e/init_test.go
+++ b/internal/e2e/init_test.go
@@ -104,6 +104,66 @@ func TestInitLegacyNotice(t *testing.T) {
 	}
 }
 
+// TestInitPreservesExternallyManagedSkill proves init does not follow an
+// individual no-mistakes skill symlink into a canonical dotfiles checkout.
+func TestInitPreservesExternallyManagedSkill(t *testing.T) {
+	h := NewHarness(t, SetupOpts{Agent: "claude"})
+	ctx := context.Background()
+	external := filepath.Join(t.TempDir(), "canonical-no-mistakes")
+	if err := os.MkdirAll(external, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	original := []byte("---\nname: no-mistakes\n---\nexternally managed\n")
+	if err := os.WriteFile(filepath.Join(external, "SKILL.md"), original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := h.runGit(ctx, external, "init", "--initial-branch=main"); err != nil {
+		t.Fatalf("init external git repo: %v\n%s", err, out)
+	}
+	if out, err := h.runGit(ctx, external, "add", "SKILL.md"); err != nil {
+		t.Fatalf("stage external skill: %v\n%s", err, out)
+	}
+	if out, err := h.runGit(ctx, external, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "seed"); err != nil {
+		t.Fatalf("commit external skill: %v\n%s", err, out)
+	}
+
+	logicalDir := filepath.Join(h.HomeDir, ".claude", "skills", "no-mistakes")
+	if err := os.MkdirAll(filepath.Dir(logicalDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(external, logicalDir); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	out, err := h.RunInDir(h.WorkDir, "init")
+	if err != nil {
+		t.Fatalf("init: %v\n%s", err, out)
+	}
+	wantPath := filepath.Join(".claude", "skills", "no-mistakes")
+	if !strings.Contains(out, "externally managed skill path left unchanged") || !strings.Contains(out, wantPath) {
+		t.Fatalf("init did not report managed path %s:\n%s", wantPath, out)
+	}
+	if data, err := os.ReadFile(filepath.Join(external, "SKILL.md")); err != nil {
+		t.Fatal(err)
+	} else if string(data) != string(original) {
+		t.Fatalf("external SKILL.md changed: %q", data)
+	}
+	if status, err := h.runGit(ctx, external, "status", "--porcelain"); err != nil {
+		t.Fatalf("external git status: %v\n%s", err, status)
+	} else if strings.TrimSpace(string(status)) != "" {
+		t.Fatalf("init dirtied external git worktree:\n%s", status)
+	}
+	if _, err := os.ReadFile(filepath.Join(logicalDir, "SKILL.md")); err != nil {
+		t.Fatalf("managed skill is not readable through logical path: %v", err)
+	}
+	regular := filepath.Join(h.HomeDir, ".agents", "skills", "no-mistakes", "SKILL.md")
+	if data, err := os.ReadFile(regular); err != nil {
+		t.Fatalf("regular skill install missing: %v", err)
+	} else if !strings.Contains(string(data), "name: no-mistakes") {
+		t.Fatalf("regular skill install has invalid content")
+	}
+}
+
 // TestInitRepoRename proves that a user who renames or moves their repo
 // directory can re-run `init` from the new location and get their existing
 // gate back, instead of the historical failure:

--- a/internal/skill/install.go
+++ b/internal/skill/install.go
@@ -17,48 +17,76 @@ var InstallBases = []string{
 	filepath.Join(".agents", "skills"),
 }
 
+// InstallResult reports which logical user-level paths Install refreshed and
+// which it left to an external manager because the per-skill directory is a
+// symlink.
+type InstallResult struct {
+	Written []string
+	Managed []string
+}
+
 // InstallUser installs the skill into the agent skill directories under the
-// current user's home directory. It returns the home-relative paths written.
-func InstallUser() ([]string, error) {
+// current user's home directory.
+func InstallUser() (InstallResult, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return nil, fmt.Errorf("resolve home directory: %w", err)
+		return InstallResult{}, fmt.Errorf("resolve home directory: %w", err)
 	}
 	return Install(home)
 }
 
 // Install writes SKILL.md into each agent skills directory under root
 // (normally the user's home directory), creating directories as needed. It
-// returns the root-relative paths written so the caller can report them.
+// reports both refreshed paths and externally managed per-skill symlinks.
 // Writing is idempotent: re-running overwrites with identical content
 // (refreshing a stale SKILL.md from an older version).
 //
 // Users may consolidate the two bases with a symlink - `.claude/skills` ->
 // `.agents/skills`, the whole `.claude` dir -> `.agents`, or the reverse. Install
-// follows such links transparently, including when the symlinked target dir does
-// not exist yet (a plain os.MkdirAll would fail with "file exists" on a dangling
-// symlink). Both logical bases stay readable afterward via the link.
-func Install(root string) ([]string, error) {
+// follows such parent links transparently, including when the symlinked target
+// dir does not exist yet (a plain os.MkdirAll would fail with "file exists" on
+// a dangling symlink). A symlink at the individual `no-mistakes` directory is
+// externally managed: Install verifies it is readable but never changes its
+// target.
+func Install(root string) (InstallResult, error) {
 	content := []byte(Markdown())
-	written := make([]string, 0, len(InstallBases))
+	result := InstallResult{
+		Written: make([]string, 0, len(InstallBases)),
+		Managed: make([]string, 0, len(InstallBases)),
+	}
 	for _, base := range InstallBases {
 		rel := filepath.Join(base, Name, "SKILL.md")
-		path := filepath.Join(root, rel)
-		// Resolve any symlink components to a real directory before creating
-		// it, so a dangling symlink in the path does not collide with MkdirAll.
-		realDir, err := resolveThroughSymlinks(filepath.Dir(path))
+		// Resolve only the parent skill base. The final per-skill component is
+		// inspected separately so an external-manager symlink is not followed
+		// and overwritten.
+		realBase, err := resolveThroughSymlinks(filepath.Join(root, base))
 		if err != nil {
-			return written, err
+			return result, err
 		}
-		if err := os.MkdirAll(realDir, 0o755); err != nil {
-			return written, err
+		if err := os.MkdirAll(realBase, 0o755); err != nil {
+			return result, err
 		}
-		if err := os.WriteFile(filepath.Join(realDir, "SKILL.md"), content, 0o644); err != nil {
-			return written, err
+		skillDir := filepath.Join(realBase, Name)
+		info, err := os.Lstat(skillDir)
+		if err == nil && info.Mode()&os.ModeSymlink != 0 {
+			if _, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md")); err != nil {
+				return result, fmt.Errorf("externally managed skill %s is not readable: %w", filepath.Join(base, Name), err)
+			}
+			result.Managed = append(result.Managed, filepath.Join(base, Name))
+			continue
 		}
-		written = append(written, rel)
+		if err != nil && !os.IsNotExist(err) {
+			return result, err
+		}
+		if err := os.MkdirAll(skillDir, 0o755); err != nil {
+			return result, err
+		}
+		if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), content, 0o644); err != nil {
+			return result, err
+		}
+		result.Written = append(result.Written, rel)
 	}
-	return written, nil
+	return result, nil
 }
 
 // Vendored reports the repo-relative paths of legacy vendored skill copies

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -73,7 +73,7 @@ func TestBodyDocumentsAxiGateGuidance(t *testing.T) {
 
 func TestInstallWritesBothPaths(t *testing.T) {
 	root := t.TempDir()
-	written, err := Install(root)
+	result, err := Install(root)
 	if err != nil {
 		t.Fatalf("Install: %v", err)
 	}
@@ -81,12 +81,12 @@ func TestInstallWritesBothPaths(t *testing.T) {
 		filepath.Join(".claude", "skills", Name, "SKILL.md"),
 		filepath.Join(".agents", "skills", Name, "SKILL.md"),
 	}
-	if len(written) != len(wantRel) {
-		t.Fatalf("written = %v, want %v", written, wantRel)
+	if len(result.Written) != len(wantRel) {
+		t.Fatalf("written = %v, want %v", result.Written, wantRel)
 	}
 	for i, rel := range wantRel {
-		if written[i] != rel {
-			t.Errorf("written[%d] = %q, want %q", i, written[i], rel)
+		if result.Written[i] != rel {
+			t.Errorf("written[%d] = %q, want %q", i, result.Written[i], rel)
 		}
 		data, err := os.ReadFile(filepath.Join(root, rel))
 		if err != nil {
@@ -111,8 +111,8 @@ func TestInstallUserWritesUnderHome(t *testing.T) {
 	if err != nil {
 		t.Fatalf("InstallUser: %v", err)
 	}
-	if len(written) != len(InstallBases) {
-		t.Fatalf("written = %v, want one path per base", written)
+	if len(written.Written) != len(InstallBases) {
+		t.Fatalf("written = %v, want one path per base", written.Written)
 	}
 	for _, base := range InstallBases {
 		data, err := os.ReadFile(filepath.Join(home, base, Name, "SKILL.md"))
@@ -196,13 +196,13 @@ func TestInstallSymlinkLayouts(t *testing.T) {
 			root := t.TempDir()
 			tt.setup(t, root)
 
-			written, err := Install(root)
+			result, err := Install(root)
 			if err != nil {
 				t.Fatalf("Install: %v", err)
 			}
 
 			// Every reported path must be readable with current content.
-			for _, rel := range written {
+			for _, rel := range result.Written {
 				data, err := os.ReadFile(filepath.Join(root, rel))
 				if err != nil {
 					t.Fatalf("read reported %s: %v", rel, err)
@@ -225,6 +225,64 @@ func TestInstallSymlinkLayouts(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestInstallLeavesPerSkillSymlinkTargetsUnchanged(t *testing.T) {
+	root := t.TempDir()
+	external := filepath.Join(t.TempDir(), "canonical-no-mistakes")
+	mkdirAll(t, external)
+	original := []byte("---\nname: no-mistakes\n---\nexternally managed\n")
+	if err := os.WriteFile(filepath.Join(external, "SKILL.md"), original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(external, "manager-marker")
+	if err := os.WriteFile(marker, []byte("unchanged"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mkdirAll(t, filepath.Join(root, ".claude", "skills"))
+	symlink(t, external, filepath.Join(root, ".claude", "skills", Name))
+
+	result, err := Install(root)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	wantManaged := filepath.Join(".claude", "skills", Name)
+	if len(result.Managed) != 1 || result.Managed[0] != wantManaged {
+		t.Fatalf("managed = %v, want [%s]", result.Managed, wantManaged)
+	}
+	if data, err := os.ReadFile(filepath.Join(external, "SKILL.md")); err != nil {
+		t.Fatal(err)
+	} else if string(data) != string(original) {
+		t.Fatalf("external SKILL.md changed: %q", data)
+	}
+	if data, err := os.ReadFile(marker); err != nil {
+		t.Fatal(err)
+	} else if string(data) != "unchanged" {
+		t.Fatalf("external marker changed: %q", data)
+	}
+	if data, err := os.ReadFile(filepath.Join(root, wantManaged, "SKILL.md")); err != nil {
+		t.Fatalf("managed skill is not readable through logical path: %v", err)
+	} else if string(data) != string(original) {
+		t.Fatalf("logical managed skill content = %q", data)
+	}
+
+	// The other, real install base is still refreshed normally.
+	if data, err := os.ReadFile(filepath.Join(root, ".agents", "skills", Name, "SKILL.md")); err != nil {
+		t.Fatalf("read regular install: %v", err)
+	} else if string(data) != Markdown() {
+		t.Fatalf("regular install was not refreshed")
+	}
+}
+
+func TestInstallRejectsUnreadablePerSkillSymlink(t *testing.T) {
+	root := t.TempDir()
+	mkdirAll(t, filepath.Join(root, ".claude", "skills"))
+	symlink(t, filepath.Join(t.TempDir(), "missing"), filepath.Join(root, ".claude", "skills", Name))
+
+	if _, err := Install(root); err == nil || !strings.Contains(err.Error(), "externally managed skill") {
+		t.Fatalf("Install error = %v, want externally managed skill readability error", err)
 	}
 }
 


### PR DESCRIPTION
Closes #479

Follows parent skill-base symlinks as before, but treats an individual no-mistakes skill-directory symlink as externally managed. Init verifies the managed path is readable, reports it, and never changes its target.

Tests:
- make lint
- make test
- make e2e
- make docs-build
- git diff --check