### PR TITLE
fix(pipeline): reconcile parked CI gates

### DIFF
--- a/.no-mistakes/evidence/fm/nm-active-runs-merged-g5/parked-ci-reconciliation.txt
+++ b/.no-mistakes/evidence/fm/nm-active-runs-merged-g5/parked-ci-reconciliation.txt
@@ -1,0 +1,16 @@
+=== RUN   TestEvidenceParkedCIGateLifecycle
+=== RUN   TestEvidenceParkedCIGateLifecycle/MERGED
+PR state OPEN - lifecycle guard sees 1 active run:
+active pipeline runs:
+  01KXJ413SFGDX4Q7QPSVW0NRRK  running  refs/heads/feature  2768bfe7
+PR state MERGED - run status=completed, awaiting_agent=false, lifecycle guard sees 0 active runs
+=== RUN   TestEvidenceParkedCIGateLifecycle/CLOSED
+PR state OPEN - lifecycle guard sees 1 active run:
+active pipeline runs:
+  01KXJ41DRRJVCNN2RBVBWEPS4P  running  refs/heads/feature  2768bfe7
+PR state CLOSED - run status=completed, awaiting_agent=false, lifecycle guard sees 0 active runs
+--- PASS: TestEvidenceParkedCIGateLifecycle (21.00s)
+    --- PASS: TestEvidenceParkedCIGateLifecycle/MERGED (10.34s)
+    --- PASS: TestEvidenceParkedCIGateLifecycle/CLOSED (10.66s)
+PASS
+ok  	github.com/kunchenguid/no-mistakes/internal/pipeline/steps	22.514s

--- a/docs/src/content/docs/concepts/daemon.md
+++ b/docs/src/content/docs/concepts/daemon.md
@@ -102,7 +102,9 @@ reason about in one long-lived process than inside independent hook invocations.
 
 On startup, the daemon checks for runs that were left in `pending` or `running` status (which means the daemon crashed while they were active):
 
-- Marks those runs as `failed` with the message "daemon crashed during execution"
+- Resumes only fully recorded parked approval gates whose worktree and step history can be validated; incomplete or ambiguous active runs fail closed
+- Before resuming a parked CI gate, re-checks its persisted PR URL through the configured provider; a currently merged or closed PR completes the stale gate, while an open, unknown, or unreachable PR remains parked
+- Marks every other stale active run as `failed` with the message "daemon crashed during execution"
 - Reaps orphaned managed agent servers left behind by a crashed daemon or setup wizard
 - Removes orphaned worktree directories via `git worktree remove --force` - but never one whose run is still `pending` or `running`; only leftovers from terminal runs or directories with no matching run record are removed
 - Refreshes legacy no-mistakes-managed `post-receive` hooks, installs missing managed hooks, and leaves custom hooks untouched

--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -139,8 +139,8 @@ The `-y` / `--yes` flag answers that executable-path prompt non-interactively; i
 If the daemon executable path cannot be determined, `update` aborts before replacing anything.
 You can also manage it explicitly with `no-mistakes daemon start|stop|restart|status`; `daemon stop` and `daemon restart` apply the same active-run guard and `--force` override.
 
-On startup, the daemon first reconstructs only unambiguous runs that were fully recorded as parked at an approval gate, including their local reviewer/fixer session metadata when available.
-It fails every other stuck or incomplete active run closed as a crash recovery, reaps orphaned managed agent servers, cleans up orphaned worktrees (never one whose run is still pending or running), refreshes legacy no-mistakes-managed `post-receive` hooks, enables push options for older gate repos, and reapplies gate hook-path isolation when Git supports `config --worktree`.
+On startup, the daemon validates crash-recovery state before resuming work.
+[Daemon & Worktrees](/no-mistakes/concepts/daemon/#crash-recovery) owns the exact restart, parked-gate reconciliation, cleanup, and fail-closed behavior.
 
 ### Pipeline executor
 

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -85,7 +85,14 @@ Symptom: `update` refuses because active pipeline runs are in progress, prompts 
 
 `update`, `daemon stop`, and `daemon restart` all refuse by default while pipeline runs are active and list the affected runs; [Daemon & Worktrees](/no-mistakes/concepts/daemon/#starting-and-stopping) owns the guard's exact rules, including why `-y`/`--yes` does not bypass it.
 
-Fix, once you have confirmed it is fine for the listed active runs to fail:
+First inspect each listed run with `no-mistakes axi status --run <id>`.
+A parked CI gate now keeps checking its PR read-only and clears itself when the provider reports that PR merged or closed, including after a daemon restart.
+Open, unknown, or unreachable PRs remain parked and must not be guessed complete.
+
+When upgrading from an older release that left a merged/closed PR at a stale CI gate, verify the PR state independently, check out the matching branch, and run `no-mistakes axi respond --action approve --step ci` before retrying the update.
+Do not edit `state.sqlite` directly.
+
+Only when you have confirmed it is acceptable for every remaining listed active run to fail, force the lifecycle operation:
 
 ```sh
 no-mistakes daemon stop --force

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -86,8 +86,8 @@ Symptom: `update` refuses because active pipeline runs are in progress, prompts 
 `update`, `daemon stop`, and `daemon restart` all refuse by default while pipeline runs are active and list the affected runs; [Daemon & Worktrees](/no-mistakes/concepts/daemon/#starting-and-stopping) owns the guard's exact rules, including why `-y`/`--yes` does not bypass it.
 
 First inspect each listed run with `no-mistakes axi status --run <id>`.
-A parked CI gate now keeps checking its PR read-only and clears itself when the provider reports that PR merged or closed, including after a daemon restart.
-Open, unknown, or unreachable PRs remain parked and must not be guessed complete.
+A parked CI gate can clear itself after its PR becomes terminal, including after a daemon restart.
+The [`ci_timeout` reference](/no-mistakes/reference/global-config/#ci_timeout) owns the exact fail-closed reconciliation rules, and [Daemon & Worktrees](/no-mistakes/concepts/daemon/#crash-recovery) owns restart behavior.
 
 When upgrading from an older release that left a merged/closed PR at a stale CI gate, verify the PR state independently, check out the matching branch, and run `no-mistakes axi respond --action approve --step ci` before retrying the update.
 Do not edit `state.sqlite` directly.

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -277,7 +277,7 @@ The roles never share a session, other pipeline steps stay session-isolated in t
 Every review turn still performs a full review of the complete branch diff; only the reviewer's own prior context is carried.
 When resume is unavailable or fails, the invocation falls back to a cold run or a fresh same-role session and the fallback is recorded in the local `agent_invocations` performance record.
 Session identities are persisted only as minimum local resume metadata, never as prompts or transcripts.
-After a daemon restart, no-mistakes resumes only fully recorded parked approval gates; incomplete or ambiguous active runs fail closed through normal crash recovery.
+The [daemon crash-recovery reference](/no-mistakes/concepts/daemon/#crash-recovery) owns which parked gates can resume or reconcile after a restart.
 Set `false` to force every agent invocation cold.
 
 ### auto_fix

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -217,7 +217,9 @@ Accepts any Go `time.ParseDuration` string: `30m`, `2h`, `4h30m`, etc.
 This is an idle timeout, not an absolute deadline: every time the base branch advances, the monitor re-arms it.
 So an actively-updated green PR keeps its monitor no matter how long it stays open.
 If it later develops an actual GitHub, GitLab, or Azure DevOps merge conflict, the CI auto-fix path rebases and re-pushes it, while a clean behind PR needs no command.
-A genuinely idle/abandoned PR is still reaped after the timeout elapses.
+A genuinely idle/abandoned PR still parks at an approval gate after the timeout elapses.
+While that CI gate is parked, the daemon continues bounded read-only PR-state checks.
+If the PR is merged or closed externally, the stale gate completes automatically; an open, unknown, or temporarily unreachable PR remains parked for a user decision.
 
 Set it to `unlimited` (`none`, `off`, and `never` are accepted aliases), `0`, or any non-positive duration to monitor until the PR is merged, closed, or the run is aborted with `no-mistakes axi abort --run <id>`.
 

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -200,8 +200,8 @@ Monitors PR health after creation and auto-fixes CI failures. Mergeability polli
 
 **Behavior:**
 - Polls provider CI status at increasing intervals: every 30s for the first 5 minutes, every 60s for 5-15 minutes, every 120s after that
-- Continues monitoring an open PR until it is merged, closed, declined, or the configured `ci_timeout` idle window elapses, even after CI checks are currently healthy
-- Treats `ci_timeout` as an idle timeout: each upstream default-branch advance re-arms the timer, and `ci_timeout: "unlimited"` disables self-termination
+- Continues its normal monitoring loop until the PR is merged, closed, declined, or the configured `ci_timeout` idle window elapses, then parks at an approval gate instead of ending the run
+- The [`ci_timeout` reference](/no-mistakes/reference/global-config/#ci_timeout) owns idle re-arming, unlimited monitoring, and fail-closed reconciliation while that gate is parked
 - On GitHub, GitLab, and Azure DevOps, polls provider mergeability alongside CI checks while the PR remains open
 - While the PR stays open, the TUI and terminal title show `Checks passed` once checks are green and known mergeability is clear, and `no-mistakes axi` returns `outcome: checks-passed` with successful-output reporting instructions so agents can summarize the run, ask the user to review and merge, and list any pipeline fixes instead of waiting
 - If the default branch moves after `checks-passed`, keeps watching the same PR; a clean behind PR needs no action, while an actual GitHub, GitLab, or Azure DevOps merge conflict is auto-fixed by rebasing onto the base and re-pushing through the force-push safety guard

--- a/internal/daemon/helpers_test.go
+++ b/internal/daemon/helpers_test.go
@@ -317,6 +317,36 @@ printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"structured
 	return path
 }
 
+func writeMockGHState(t *testing.T, dir, state string) (string, string) {
+	t.Helper()
+	logPath := filepath.Join(dir, "gh.log")
+	if runtime.GOOS == "windows" {
+		path := filepath.Join(dir, "gh.bat")
+		script := "@echo off\r\necho %*>>\"" + logPath + "\"\r\necho %* | findstr /C:\"auth status\" >nul && exit /b 0\r\necho %* | findstr /C:\"pr view 42\" >nul && (echo " + state + "& exit /b 0)\r\nexit /b 1\r\n"
+		if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return dir, logPath
+	}
+	path := filepath.Join(dir, "gh")
+	script := `#!/bin/sh
+printf '%s\n' "$*" >>` + shellQuoteForTest(logPath) + `
+case "$*" in
+  "auth status"*|"auth status --hostname "*) exit 0 ;;
+  "pr view 42 "*) printf '%s\n' ` + shellQuoteForTest(state) + `; exit 0 ;;
+esac
+exit 1
+`
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir, logPath
+}
+
+func shellQuoteForTest(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
 func writeSlowMockClaude(t *testing.T, dir string) string {
 	t.Helper()
 	if runtime.GOOS == "windows" {

--- a/internal/daemon/subscribe_recover_test.go
+++ b/internal/daemon/subscribe_recover_test.go
@@ -12,8 +12,10 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	gitpkg "github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
+	"github.com/kunchenguid/no-mistakes/internal/lifecycle"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
+	"github.com/kunchenguid/no-mistakes/internal/pipeline/steps"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
@@ -456,6 +458,106 @@ func TestRecoverOnStartup_ResumesParkedRun(t *testing.T) {
 			t.Fatalf("recovered worktree still exists after cleanup: %s", worktree)
 		}
 		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestRecoverOnStartup_ReconcilesHistoricalCIGateFromCurrentPRState(t *testing.T) {
+	for _, state := range []string{"MERGED", "CLOSED"} {
+		t.Run(state, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "dtest")
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+			p := paths.WithRoot(tmpDir)
+			if err := p.EnsureDirs(); err != nil {
+				t.Fatal(err)
+			}
+			mockClaude := writeMockClaude(t, t.TempDir())
+			if err := os.WriteFile(p.ConfigFile(), []byte("agent: claude\nagent_path_override:\n  claude: "+mockClaude+"\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			d, err := db.Open(p.DB())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer d.Close()
+			repo, headSHA := setupTestGitRepo(t, p, d, "reconcile-parked-ci-"+strings.ToLower(state))
+			run, err := d.InsertRun(repo.ID, "feature", headSHA, headSHA)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := d.UpdateRunStatus(run.ID, types.RunRunning); err != nil {
+				t.Fatal(err)
+			}
+			if err := d.UpdateRunPRURL(run.ID, "https://github.com/test/repo/pull/42"); err != nil {
+				t.Fatal(err)
+			}
+			prURL := "https://github.com/test/repo/pull/42"
+			run.PRURL = &prURL
+			worktree := p.WorktreeDir(repo.ID, run.ID)
+			if err := gitpkg.WorktreeAdd(context.Background(), p.RepoDir(repo.ID), worktree, headSHA); err != nil {
+				t.Fatal(err)
+			}
+			step, err := d.InsertStepResult(run.ID, types.StepCI)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := d.StartStep(step.ID); err != nil {
+				t.Fatal(err)
+			}
+			findings := `{"findings":[{"id":"ci-1","severity":"warning","description":"PR was still open when CI monitoring timed out","action":"ask-user"}],"summary":"CI monitoring timed out before PR was merged or closed"}`
+			if err := d.SetStepFindings(step.ID, findings); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := d.InsertStepRound(step.ID, 1, "initial", &findings, nil, 1); err != nil {
+				t.Fatal(err)
+			}
+			if err := d.UpdateStepStatusWithDuration(step.ID, types.StepStatusAwaitingApproval, 1); err != nil {
+				t.Fatal(err)
+			}
+			if err := d.SetRunAwaitingAgent(run.ID); err != nil {
+				t.Fatal(err)
+			}
+
+			ghDir, ghLog := writeMockGHState(t, t.TempDir(), state)
+			t.Setenv("PATH", ghDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+			errCh := make(chan error, 1)
+			go func() {
+				errCh <- RunWithOptions(p, d, func() []pipeline.Step { return []pipeline.Step{&steps.CIStep{}} })
+			}()
+			defer func() {
+				client, dialErr := ipc.Dial(p.Socket())
+				if dialErr == nil {
+					_ = client.Call(ipc.MethodShutdown, &ipc.ShutdownParams{}, nil)
+					_ = client.Close()
+				}
+				select {
+				case <-errCh:
+				case <-time.After(3 * time.Second):
+					t.Error("daemon did not stop")
+				}
+			}()
+
+			completed := waitForRunTerminalState(t, d, run.ID)
+			if completed.Status != types.RunCompleted || completed.AwaitingAgentSince != nil {
+				t.Fatalf("historical CI gate after %s reconciliation = status %s awaiting %v", state, completed.Status, completed.AwaitingAgentSince)
+			}
+			active, err := lifecycle.ActiveRuns(p)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(active) != 0 {
+				t.Fatalf("update guard still sees %d active runs after reconciliation", len(active))
+			}
+			logData, err := os.ReadFile(ghLog)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(logData), "pr view 42") {
+				t.Fatalf("startup reconciliation did not read current PR state: %s", logData)
+			}
+		})
 	}
 }
 

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -25,6 +25,11 @@ import (
 // EventFunc is called when a pipeline event occurs, for streaming to subscribers.
 type EventFunc func(ipc.Event)
 
+const (
+	defaultGateReconcileInterval = 2 * time.Minute
+	defaultGateReconcileTimeout  = 30 * time.Second
+)
+
 type approvalResponse struct {
 	action        types.ApprovalAction
 	findingIDs    []string
@@ -52,6 +57,9 @@ type Executor struct {
 	approvalCh  chan approvalResponse // buffered channel for approval responses
 	waiting     bool                  // true when blocked on approval
 	waitingStep types.StepName        // which step is currently awaiting approval
+
+	gateReconcileInterval time.Duration
+	gateReconcileTimeout  time.Duration
 }
 
 // SetSkippedSteps configures steps that should be marked skipped without running.
@@ -72,13 +80,28 @@ func NewExecutor(database *db.DB, p *paths.Paths, cfg *config.Config, ag agent.A
 		onEvent = func(ipc.Event) {}
 	}
 	return &Executor{
-		db:         database,
-		paths:      p,
-		config:     cfg,
-		agent:      ag,
-		steps:      steps,
-		onEvent:    onEvent,
-		approvalCh: make(chan approvalResponse, 1),
+		db:                    database,
+		paths:                 p,
+		config:                cfg,
+		agent:                 ag,
+		steps:                 steps,
+		onEvent:               onEvent,
+		approvalCh:            make(chan approvalResponse, 1),
+		gateReconcileInterval: defaultGateReconcileInterval,
+		gateReconcileTimeout:  defaultGateReconcileTimeout,
+	}
+}
+
+// SetGateReconcileTimings overrides the interval between approval-gate
+// reconciliation checks and the deadline for each check. It is primarily used
+// by deterministic tests and specialized embeddings; non-positive values keep
+// the production defaults.
+func (e *Executor) SetGateReconcileTimings(interval, timeout time.Duration) {
+	if interval > 0 {
+		e.gateReconcileInterval = interval
+	}
+	if timeout > 0 {
+		e.gateReconcileTimeout = timeout
 	}
 }
 
@@ -119,9 +142,11 @@ func (e *Executor) RespondWithOverrides(step types.StepName, action types.Approv
 // If the context is cancelled with a cause (via context.WithCancelCause),
 // the cause message is preserved as the run's error in the DB.
 func (e *Executor) Execute(ctx context.Context, run *db.Run, repo *db.Repo, workDir string) error {
-	// Mark run as running
+	// Mark run as running. Route write failures through failRun so the
+	// in-memory lifecycle and subscriber stream still become terminal instead
+	// of leaving a silent pending run.
 	if err := e.db.UpdateRunStatus(run.ID, types.RunRunning); err != nil {
-		return fmt.Errorf("update run status: %w", err)
+		return e.failRun(run, repo, fmt.Errorf("update run status: %w", err))
 	}
 	run.Status = types.RunRunning
 	e.emitRunEvent(ipc.EventRunUpdated, run, repo)
@@ -175,9 +200,10 @@ func (e *Executor) Execute(ctx context.Context, run *db.Run, repo *db.Repo, work
 		}
 	}
 
-	// Mark run as completed
+	// Mark run as completed. A failure here must emit a terminal failure rather
+	// than leaving a silent running row after every step has finished.
 	if err := e.db.UpdateRunStatus(run.ID, types.RunCompleted); err != nil {
-		return fmt.Errorf("update run status: %w", err)
+		return e.failRun(run, repo, fmt.Errorf("update run status: %w", err))
 	}
 	run.Status = types.RunCompleted
 	e.emitRunEvent(ipc.EventRunCompleted, run, repo)
@@ -237,6 +263,40 @@ func (e *Executor) Resume(ctx context.Context, run *db.Run, repo *db.Repo, workD
 	}
 	e.initializeRunScopes(run.ID)
 
+	parkStart := time.Unix(*run.AwaitingAgentSince, 0)
+	duration := recoveredStepDuration(gate.stepResult)
+	completeReconciledGate := func() error {
+		if err := e.db.CompleteStepWithStatus(gate.stepResult.ID, types.StepStatusCompleted, recoveredExitCode(gate.stepResult), duration, recoveredLogPath(gate.stepResult)); err != nil {
+			return e.failRun(run, repo, fmt.Errorf("complete reconciled step %s: %w", gate.step.Name(), err), ctx)
+		}
+		e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, gate.step.Name(), string(types.StepStatusCompleted), "", "", "", &duration)
+		return e.executeRecoveredRemainder(ctx, run, repo, workDir, logDir, gate.index+1)
+	}
+	reconcileCtx := &StepContext{
+		Ctx:      ctx,
+		Run:      run,
+		Repo:     repo,
+		WorkDir:  workDir,
+		Config:   e.config,
+		DB:       e.db,
+		Agent:    e.agent,
+		Sessions: e.sessions,
+		Shared:   e.shared,
+		Log: func(message string) {
+			slog.Info("recovered approval gate reconciliation", "run_id", run.ID, "step", gate.step.Name(), "message", message)
+		},
+		LogChunk: func(string) {},
+		LogFile:  func(string) {},
+	}
+	if reconciled, reconcileErr := e.reconcileApprovalGate(ctx, gate.step, reconcileCtx); reconciled {
+		if dbErr := e.db.CompleteRunAwaitingAgent(run.ID, time.Since(parkStart).Milliseconds()); dbErr != nil {
+			return e.failRun(run, repo, fmt.Errorf("complete reconciled awaiting-agent state: %w", dbErr), ctx)
+		}
+		return completeReconciledGate()
+	} else if reconcileErr != nil && ctx.Err() == nil {
+		slog.Warn("could not reconcile recovered approval gate; preserving it", "run_id", run.ID, "step", gate.step.Name(), "error", reconcileErr)
+	}
+
 	e.mu.Lock()
 	e.waiting = true
 	e.waitingStep = gate.step.Name()
@@ -253,21 +313,21 @@ func (e *Executor) Resume(ctx context.Context, run *db.Run, repo *db.Repo, workD
 		gate.stepResult.DurationMS,
 	)
 
-	parkStart := time.Unix(*run.AwaitingAgentSince, 0)
-	response, err := e.waitForApproval(ctx, gate.step.Name())
+	response, reconciled, err := e.waitForApprovalOrReconcile(ctx, gate.step, reconcileCtx, false)
 	if dbErr := e.db.CompleteRunAwaitingAgent(run.ID, time.Since(parkStart).Milliseconds()); dbErr != nil {
 		slog.Warn("failed to complete awaiting-agent state in db", "step", gate.step.Name(), "run", run.ID, "error", dbErr)
 	}
 	if err != nil {
-		duration := recoveredStepDuration(gate.stepResult)
 		if dbErr := e.db.FailStep(gate.stepResult.ID, err.Error(), duration); dbErr != nil {
 			slog.Warn("failed to mark recovered step as failed in db", "step", gate.step.Name(), "error", dbErr)
 		}
 		e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, gate.step.Name(), string(types.StepStatusFailed), "", "", err.Error(), &duration)
 		return e.failRun(run, repo, fmt.Errorf("step %s: waiting for approval: %w", gate.step.Name(), err), ctx)
 	}
+	if reconciled {
+		return completeReconciledGate()
+	}
 
-	duration := recoveredStepDuration(gate.stepResult)
 	approvalFields := telemetry.Fields{
 		"step":       string(gate.step.Name()),
 		"action":     string(response.action),
@@ -420,7 +480,7 @@ func (e *Executor) executeRecoveredRemainder(ctx context.Context, run *db.Run, r
 		}
 	}
 	if err := e.db.UpdateRunStatus(run.ID, types.RunCompleted); err != nil {
-		return fmt.Errorf("complete recovered run: %w", err)
+		return e.failRun(run, repo, fmt.Errorf("complete recovered run: %w", err), ctx)
 	}
 	run.Status = types.RunCompleted
 	e.emitRunEvent(ipc.EventRunCompleted, run, repo)
@@ -442,7 +502,7 @@ func (e *Executor) skipRecoveredRemainder(run *db.Run, repo *db.Repo, start int)
 		e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, e.steps[index].Name(), string(types.StepStatusSkipped), "", "", "", nil)
 	}
 	if err := e.db.UpdateRunStatus(run.ID, types.RunCompleted); err != nil {
-		return fmt.Errorf("complete recovered run: %w", err)
+		return e.failRun(run, repo, fmt.Errorf("complete recovered run: %w", err))
 	}
 	run.Status = types.RunCompleted
 	e.emitRunEvent(ipc.EventRunCompleted, run, repo)
@@ -761,7 +821,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 		}
 		e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(approvalStatus), outcome.Findings, diffText, "", &executionMS)
 
-		response, err := e.waitForApproval(ctx, stepName)
+		response, reconciled, err := e.waitForApprovalOrReconcile(ctx, step, sctx, true)
 		if dbErr := e.db.CompleteRunAwaitingAgent(run.ID, time.Since(parkStart).Milliseconds()); dbErr != nil {
 			slog.Warn("failed to complete awaiting-agent state in db", "step", stepName, "run", run.ID, "error", dbErr)
 		}
@@ -771,6 +831,10 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			}
 			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(types.StepStatusFailed), "", "", err.Error(), &executionMS)
 			return false, fmt.Errorf("step %s: waiting for approval: %w", stepName, err)
+		}
+		if reconciled {
+			phaseStart = time.Now()
+			goto done
 		}
 
 		approvalFields := telemetry.Fields{
@@ -949,27 +1013,77 @@ func pluralize(n int, singular, plural string) string {
 	return plural
 }
 
-// waitForApproval blocks until a user action arrives or context is cancelled.
+// waitForApprovalOrReconcile blocks until a user action arrives, the parked
+// gate's external source of truth makes it obsolete, or the context is
+// cancelled. Reconciliation runs synchronously under a bounded child context,
+// so no watcher goroutine can outlive approval, cancellation, or shutdown.
 // The caller must set e.waiting and e.waitingStep before calling this method.
-func (e *Executor) waitForApproval(ctx context.Context, stepName types.StepName) (approvalResponse, error) {
+func (e *Executor) waitForApprovalOrReconcile(ctx context.Context, step Step, sctx *StepContext, immediate bool) (approvalResponse, bool, error) {
 	defer func() {
 		e.mu.Lock()
 		e.waiting = false
 		e.waitingStep = ""
 		e.mu.Unlock()
-		// Drain any stale response that arrived after context cancellation
+		// Drain any stale response that arrived after context cancellation or
+		// raced with an external reconciliation.
 		select {
 		case <-e.approvalCh:
 		default:
 		}
 	}()
 
-	select {
-	case response := <-e.approvalCh:
-		return response, nil
-	case <-ctx.Done():
-		return approvalResponse{}, context.Cause(ctx)
+	if _, ok := step.(ApprovalGateReconciler); !ok {
+		select {
+		case response := <-e.approvalCh:
+			return response, false, nil
+		case <-ctx.Done():
+			return approvalResponse{}, false, context.Cause(ctx)
+		}
 	}
+
+	delay := e.gateReconcileInterval
+	if immediate {
+		delay = 0
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	for {
+		select {
+		case response := <-e.approvalCh:
+			return response, false, nil
+		case <-ctx.Done():
+			return approvalResponse{}, false, context.Cause(ctx)
+		case <-timer.C:
+			resolved, err := e.reconcileApprovalGate(ctx, step, sctx)
+			if resolved {
+				return approvalResponse{}, true, nil
+			}
+			if err != nil && ctx.Err() == nil {
+				if sctx != nil && sctx.Log != nil {
+					sctx.Log(fmt.Sprintf("warning: could not reconcile parked %s gate; preserving it: %v", step.Name(), err))
+				} else {
+					slog.Warn("could not reconcile parked approval gate; preserving it", "step", step.Name(), "error", err)
+				}
+			}
+			timer.Reset(e.gateReconcileInterval)
+		}
+	}
+}
+
+func (e *Executor) reconcileApprovalGate(ctx context.Context, step Step, sctx *StepContext) (bool, error) {
+	reconciler, ok := step.(ApprovalGateReconciler)
+	if !ok {
+		return false, nil
+	}
+	timeout := e.gateReconcileTimeout
+	if timeout <= 0 {
+		timeout = defaultGateReconcileTimeout
+	}
+	reconcileCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	copyCtx := *sctx
+	copyCtx.Ctx = reconcileCtx
+	return reconciler.ReconcileApprovalGate(&copyCtx)
 }
 
 // failRun marks a run as failed and returns the error.

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -1056,7 +1056,10 @@ func (e *Executor) waitForApprovalOrReconcile(ctx context.Context, step Step, sc
 		case <-timer.C:
 			resolved, err := e.reconcileApprovalGate(ctx, step, sctx)
 			if resolved {
-				return approvalResponse{}, true, nil
+				if e.claimGateReconciliation() {
+					return approvalResponse{}, true, nil
+				}
+				return <-e.approvalCh, false, nil
 			}
 			if err != nil && ctx.Err() == nil {
 				if sctx != nil && sctx.Log != nil {
@@ -1068,6 +1071,17 @@ func (e *Executor) waitForApprovalOrReconcile(ctx context.Context, step Step, sc
 			timer.Reset(e.gateReconcileInterval)
 		}
 	}
+}
+
+func (e *Executor) claimGateReconciliation() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if !e.waiting {
+		return false
+	}
+	e.waiting = false
+	e.waitingStep = ""
+	return true
 }
 
 func (e *Executor) reconcileApprovalGate(ctx context.Context, step Step, sctx *StepContext) (bool, error) {

--- a/internal/pipeline/executor_reconcile_test.go
+++ b/internal/pipeline/executor_reconcile_test.go
@@ -17,6 +17,7 @@ type reconcilingApprovalStep struct {
 	err       atomic.Pointer[error]
 	block     bool
 	started   chan struct{}
+	release   chan struct{}
 	startOnce atomic.Bool
 }
 
@@ -34,6 +35,9 @@ func (s *reconcilingApprovalStep) ReconcileApprovalGate(sctx *StepContext) (bool
 	if s.startOnce.CompareAndSwap(false, true) && s.started != nil {
 		close(s.started)
 	}
+	if s.release != nil {
+		<-s.release
+	}
 	if s.block {
 		<-sctx.Ctx.Done()
 		return false, sctx.Ctx.Err()
@@ -42,6 +46,48 @@ func (s *reconcilingApprovalStep) ReconcileApprovalGate(sctx *StepContext) (bool
 		return false, *ptr
 	}
 	return s.resolved.Load(), nil
+}
+
+func TestExecutor_AcceptedApprovalWinsReconciliationRace(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	step := &reconcilingApprovalStep{
+		name:    types.StepCI,
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	step.resolved.Store(true)
+	exec := NewExecutor(database, p, nil, nil, []Step{step}, nil)
+	exec.SetGateReconcileTimings(time.Hour, time.Second)
+
+	workDir := t.TempDir()
+	done := make(chan error, 1)
+	go func() { done <- exec.Execute(context.Background(), run, repo, workDir) }()
+	select {
+	case <-step.started:
+	case <-time.After(3 * time.Second):
+		t.Fatal("gate reconciliation did not start")
+	}
+	if err := exec.Respond(types.StepCI, types.ActionAbort, nil); err != nil {
+		t.Fatalf("Respond() error = %v", err)
+	}
+	close(step.release)
+
+	select {
+	case err := <-done:
+		if err == nil || err.Error() != "step ci: aborted by user" {
+			t.Fatalf("Execute() error = %v, want accepted abort", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("accepted abort did not complete")
+	}
+
+	got, err := database.GetRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != types.RunFailed {
+		t.Fatalf("run status = %s, want %s", got.Status, types.RunFailed)
+	}
 }
 
 func TestExecutor_ReconcilesParkedGateThroughNormalCompletionPath(t *testing.T) {

--- a/internal/pipeline/executor_reconcile_test.go
+++ b/internal/pipeline/executor_reconcile_test.go
@@ -1,0 +1,206 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+type reconcilingApprovalStep struct {
+	name      types.StepName
+	resolved  atomic.Bool
+	calls     atomic.Int64
+	err       atomic.Pointer[error]
+	block     bool
+	started   chan struct{}
+	startOnce atomic.Bool
+}
+
+func (s *reconcilingApprovalStep) Name() types.StepName { return s.name }
+
+func (s *reconcilingApprovalStep) Execute(*StepContext) (*StepOutcome, error) {
+	return &StepOutcome{
+		NeedsApproval: true,
+		Findings:      `{"findings":[{"id":"ci-1","severity":"warning","description":"waiting","action":"ask-user"}],"summary":"waiting"}`,
+	}, nil
+}
+
+func (s *reconcilingApprovalStep) ReconcileApprovalGate(sctx *StepContext) (bool, error) {
+	s.calls.Add(1)
+	if s.startOnce.CompareAndSwap(false, true) && s.started != nil {
+		close(s.started)
+	}
+	if s.block {
+		<-sctx.Ctx.Done()
+		return false, sctx.Ctx.Err()
+	}
+	if ptr := s.err.Load(); ptr != nil {
+		return false, *ptr
+	}
+	return s.resolved.Load(), nil
+}
+
+func TestExecutor_ReconcilesParkedGateThroughNormalCompletionPath(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	step := &reconcilingApprovalStep{name: types.StepCI}
+	exec := NewExecutor(database, p, nil, nil, []Step{step}, nil)
+	exec.SetGateReconcileTimings(10*time.Millisecond, 100*time.Millisecond)
+
+	workDir := t.TempDir()
+	done := make(chan error, 1)
+	go func() { done <- exec.Execute(context.Background(), run, repo, workDir) }()
+	waitForStepStatus(t, database, run.ID, types.StepCI, types.StepStatusAwaitingApproval)
+
+	step.resolved.Store(true)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("reconciled gate did not complete")
+	}
+
+	got, err := database.GetRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != types.RunCompleted || got.AwaitingAgentSince != nil {
+		t.Fatalf("run after reconciliation = status %s awaiting %v", got.Status, got.AwaitingAgentSince)
+	}
+	steps, err := database.GetStepsByRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(steps) != 1 || steps[0].Status != types.StepStatusCompleted {
+		t.Fatalf("steps after reconciliation = %+v", steps)
+	}
+}
+
+func TestExecutor_ReconcileErrorPreservesGateFailClosed(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	step := &reconcilingApprovalStep{name: types.StepCI}
+	reconcileErr := error(errors.New("provider unavailable"))
+	step.err.Store(&reconcileErr)
+	exec := NewExecutor(database, p, nil, nil, []Step{step}, nil)
+	exec.SetGateReconcileTimings(10*time.Millisecond, 50*time.Millisecond)
+
+	workDir := t.TempDir()
+	done := make(chan error, 1)
+	go func() { done <- exec.Execute(context.Background(), run, repo, workDir) }()
+	waitForStepStatus(t, database, run.ID, types.StepCI, types.StepStatusAwaitingApproval)
+	time.Sleep(40 * time.Millisecond)
+
+	got, err := database.GetRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != types.RunRunning || got.AwaitingAgentSince == nil {
+		t.Fatalf("reconcile error changed parked run: status %s awaiting %v", got.Status, got.AwaitingAgentSince)
+	}
+	if step.calls.Load() < 2 {
+		t.Fatalf("reconcile calls = %d, want repeated bounded checks", step.calls.Load())
+	}
+
+	if err := exec.Respond(types.StepCI, types.ActionApprove, nil); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Execute() after approval error = %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("approval did not complete preserved gate")
+	}
+}
+
+func TestExecutor_GateRecheckIsBoundedAndApprovalWinsAfterTimeout(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	step := &reconcilingApprovalStep{name: types.StepCI, block: true, started: make(chan struct{})}
+	exec := NewExecutor(database, p, nil, nil, []Step{step}, nil)
+	exec.SetGateReconcileTimings(time.Hour, 25*time.Millisecond)
+
+	workDir := t.TempDir()
+	done := make(chan error, 1)
+	go func() { done <- exec.Execute(context.Background(), run, repo, workDir) }()
+	select {
+	case <-step.started:
+	case <-time.After(3 * time.Second):
+		t.Fatal("gate reconciliation did not start")
+	}
+	if err := exec.Respond(types.StepCI, types.ActionApprove, nil); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Execute() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("blocking provider check was not bounded")
+	}
+}
+
+func TestExecutor_GateRecheckStopsAfterApprovalCancelAndShutdown(t *testing.T) {
+	tests := []struct {
+		name   string
+		finish func(*Executor, context.CancelCauseFunc) error
+	}{
+		{
+			name: "approval",
+			finish: func(exec *Executor, _ context.CancelCauseFunc) error {
+				return exec.Respond(types.StepCI, types.ActionApprove, nil)
+			},
+		},
+		{
+			name: "cancel",
+			finish: func(_ *Executor, cancel context.CancelCauseFunc) error {
+				cancel(errors.New(types.RunCancelReasonAbortedByUser))
+				return nil
+			},
+		},
+		{
+			name: "shutdown",
+			finish: func(_ *Executor, cancel context.CancelCauseFunc) error {
+				cancel(errors.New("daemon shutting down"))
+				return nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			database, p, run, repo := setupTest(t)
+			step := &reconcilingApprovalStep{name: types.StepCI}
+			exec := NewExecutor(database, p, nil, nil, []Step{step}, nil)
+			exec.SetGateReconcileTimings(5*time.Millisecond, 50*time.Millisecond)
+			ctx, cancel := context.WithCancelCause(context.Background())
+			workDir := t.TempDir()
+			done := make(chan error, 1)
+			go func() { done <- exec.Execute(ctx, run, repo, workDir) }()
+			waitForStepStatus(t, database, run.ID, types.StepCI, types.StepStatusAwaitingApproval)
+			deadline := time.Now().Add(time.Second)
+			for step.calls.Load() < 2 && time.Now().Before(deadline) {
+				time.Sleep(time.Millisecond)
+			}
+			if err := tt.finish(exec, cancel); err != nil {
+				t.Fatal(err)
+			}
+			select {
+			case <-done:
+			case <-time.After(3 * time.Second):
+				t.Fatal("executor did not finish")
+			}
+			settled := step.calls.Load()
+			time.Sleep(30 * time.Millisecond)
+			if got := step.calls.Load(); got != settled {
+				t.Fatalf("gate watcher leaked after %s: calls advanced from %d to %d", tt.name, settled, got)
+			}
+		})
+	}
+}

--- a/internal/pipeline/executor_terminal_write_test.go
+++ b/internal/pipeline/executor_terminal_write_test.go
@@ -1,0 +1,72 @@
+package pipeline
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/ipc"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+	_ "modernc.org/sqlite"
+)
+
+func TestExecutor_TerminalizesRunWhenInitialStatusWriteFails(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	installRunStatusFailureTrigger(t, p.DB(), string(types.RunRunning))
+	events := &eventCollector{}
+	exec := NewExecutor(database, p, nil, nil, []Step{newPassStep(types.StepReview)}, events.handler)
+
+	err := exec.Execute(context.Background(), run, repo, t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "update run status") {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	assertDurableFailedRunAndEvent(t, database, run.ID, events)
+}
+
+func TestExecutor_TerminalizesRunWhenFinalCompletedWriteFails(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	installRunStatusFailureTrigger(t, p.DB(), string(types.RunCompleted))
+	events := &eventCollector{}
+	exec := NewExecutor(database, p, nil, nil, []Step{newPassStep(types.StepReview)}, events.handler)
+
+	err := exec.Execute(context.Background(), run, repo, t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "update run status") {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	assertDurableFailedRunAndEvent(t, database, run.ID, events)
+}
+
+func installRunStatusFailureTrigger(t *testing.T, path, status string) {
+	t.Helper()
+	raw, err := sql.Open("sqlite", path+"?_pragma=busy_timeout(5000)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer raw.Close()
+	_, err = raw.Exec(`CREATE TRIGGER reject_test_run_status
+		BEFORE UPDATE OF status ON runs
+		WHEN NEW.status = '` + status + `'
+		BEGIN
+			SELECT RAISE(FAIL, 'injected status write failure');
+		END`)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertDurableFailedRunAndEvent(t *testing.T, database *db.DB, runID string, events *eventCollector) {
+	t.Helper()
+	got, err := database.GetRun(runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != types.RunFailed {
+		t.Fatalf("durable run status = %s, want failed", got.Status)
+	}
+	completed := events.findRunEvent(ipc.EventRunCompleted)
+	if completed == nil || completed.Status == nil || *completed.Status != string(types.RunFailed) {
+		t.Fatalf("terminal event = %+v, want failed run_completed", completed)
+	}
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -89,3 +89,12 @@ type Step interface {
 	// until the user responds with an approval action.
 	Execute(sctx *StepContext) (*StepOutcome, error)
 }
+
+// ApprovalGateReconciler is implemented by a step whose parked approval gate
+// can become obsolete when an external source of truth changes. The executor
+// invokes it with a bounded context while also waiting for an approval. A true
+// result completes the step through the normal success path; false or an error
+// leaves the gate parked. Implementations must be read-only and fail closed.
+type ApprovalGateReconciler interface {
+	ReconcileApprovalGate(sctx *StepContext) (resolved bool, err error)
+}

--- a/internal/pipeline/steps/active_runs_reconcile_test.go
+++ b/internal/pipeline/steps/active_runs_reconcile_test.go
@@ -1,0 +1,159 @@
+package steps
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/config"
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/lifecycle"
+	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/pipeline"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+type reconcileEnvStep struct {
+	step pipeline.Step
+	env  []string
+}
+
+func (s reconcileEnvStep) Name() types.StepName { return s.step.Name() }
+func (s reconcileEnvStep) Execute(ctx *pipeline.StepContext) (*pipeline.StepOutcome, error) {
+	ctx.Env = s.env
+	return s.step.Execute(ctx)
+}
+func (s reconcileEnvStep) ReconcileApprovalGate(ctx *pipeline.StepContext) (bool, error) {
+	ctx.Env = s.env
+	return s.step.(pipeline.ApprovalGateReconciler).ReconcileApprovalGate(ctx)
+}
+
+func TestCIGateReconciliationClearsActiveRunAfterPRBecomesTerminal(t *testing.T) {
+	for _, terminalState := range []string{"MERGED", "CLOSED"} {
+		t.Run(terminalState, func(t *testing.T) {
+			database, p, run, repo, dir, statePath, env := setupCIGateReconcileTest(t)
+			exec := pipeline.NewExecutor(database, p, &config.Config{Agent: types.AgentClaude, CITimeout: 80 * time.Millisecond}, &mockAgent{name: "test"}, []pipeline.Step{
+				reconcileEnvStep{step: &PRStep{}, env: env},
+				reconcileEnvStep{step: &CIStep{pollIntervalOverride: 10 * time.Millisecond}, env: env},
+			}, nil)
+			exec.SetGateReconcileTimings(20*time.Millisecond, 5*time.Second)
+
+			done := make(chan error, 1)
+			go func() { done <- exec.Execute(context.Background(), run, repo, dir) }()
+			waitForCIGate(t, database, run.ID)
+			if err := os.WriteFile(statePath, []byte(terminalState+"\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatalf("Execute() error = %v", err)
+				}
+			case <-time.After(10 * time.Second):
+				t.Fatalf("%s PR did not reconcile", terminalState)
+			}
+
+			persisted, err := database.GetRun(run.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			active, err := lifecycle.ActiveRuns(p)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if persisted.Status != types.RunCompleted || persisted.AwaitingAgentSince != nil || len(active) != 0 {
+				t.Fatalf("terminal PR reconciliation: status=%s awaiting=%v active=%d", persisted.Status, persisted.AwaitingAgentSince, len(active))
+			}
+		})
+	}
+}
+
+func TestCIGateReconciliationPreservesOpenErrorAndUnknownStates(t *testing.T) {
+	for _, state := range []string{"OPEN", "ERROR", "UNKNOWN"} {
+		t.Run(state, func(t *testing.T) {
+			database, p, run, repo, dir, statePath, env := setupCIGateReconcileTest(t)
+			exec := pipeline.NewExecutor(database, p, &config.Config{Agent: types.AgentClaude, CITimeout: 80 * time.Millisecond}, &mockAgent{name: "test"}, []pipeline.Step{
+				reconcileEnvStep{step: &PRStep{}, env: env},
+				reconcileEnvStep{step: &CIStep{pollIntervalOverride: 10 * time.Millisecond}, env: env},
+			}, nil)
+			exec.SetGateReconcileTimings(20*time.Millisecond, 5*time.Second)
+
+			done := make(chan error, 1)
+			go func() { done <- exec.Execute(context.Background(), run, repo, dir) }()
+			waitForCIGate(t, database, run.ID)
+			if err := os.WriteFile(statePath, []byte(state+"\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			time.Sleep(60 * time.Millisecond)
+
+			persisted, err := database.GetRun(run.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			active, err := lifecycle.ActiveRuns(p)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if persisted.Status != types.RunRunning || persisted.AwaitingAgentSince == nil || len(active) != 1 {
+				t.Fatalf("state %s did not fail closed: status=%s awaiting=%v active=%d", state, persisted.Status, persisted.AwaitingAgentSince, len(active))
+			}
+			if err := exec.Respond(types.StepCI, types.ActionApprove, nil); err != nil {
+				t.Fatal(err)
+			}
+			select {
+			case <-done:
+			case <-time.After(10 * time.Second):
+				t.Fatal("approval did not finish preserved gate")
+			}
+		})
+	}
+}
+
+func setupCIGateReconcileTest(t *testing.T) (*db.DB, *paths.Paths, *db.Run, *db.Repo, string, string, []string) {
+	t.Helper()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	database, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	repo, err := database.InsertRepo(dir, "https://github.com/test/repo", "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := database.InsertRun(repo.ID, "refs/heads/feature", headSHA, baseSHA)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := fakeCLIBinDir(t)
+	linkTestBinary(t, binDir, "gh")
+	statePath := filepath.Join(t.TempDir(), "pr-state")
+	if err := os.WriteFile(statePath, []byte("OPEN\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	env := fakeCLIEnv(binDir, map[string]string{
+		"FAKE_CLI_MODE":       "ci-gh-reconcile",
+		"FAKE_CLI_STATE_PATH": statePath,
+	})
+	return database, p, run, repo, dir, statePath, env
+}
+
+func waitForCIGate(t *testing.T, database *db.DB, runID string) {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		steps, err := database.GetStepsByRun(runID)
+		if err == nil && len(steps) == 2 && steps[1].Status == types.StepStatusAwaitingApproval {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("CI step did not reach awaiting_approval")
+}

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -48,6 +48,60 @@ type CIStep struct {
 
 func (s *CIStep) Name() types.StepName { return types.StepCI }
 
+// ReconcileApprovalGate re-checks the PR after the CI step has parked at an
+// approval gate. A PR can be merged or closed after a timeout/failure gate was
+// recorded; either terminal state supersedes the stale gate just as it does in
+// the normal CI polling loop. Open, unknown, and provider-error states remain
+// parked so reconciliation never guesses success.
+func (s *CIStep) ReconcileApprovalGate(sctx *pipeline.StepContext) (bool, error) {
+	if err := sctx.Ctx.Err(); err != nil {
+		return false, err
+	}
+	provider := scm.DetectProvider(sctx.Repo.UpstreamURL)
+	if provider == scm.ProviderUnknown && sctx.Run.PRURL != nil {
+		provider = scm.DetectProvider(*sctx.Run.PRURL)
+	}
+	host, skipReason := buildHost(sctx, provider)
+	if host == nil {
+		return false, fmt.Errorf("cannot check PR state: %s", skipReason)
+	}
+	if err := host.Available(sctx.Ctx); err != nil {
+		return false, err
+	}
+
+	prURL := ""
+	if sctx.Run.PRURL != nil {
+		prURL = strings.TrimSpace(*sctx.Run.PRURL)
+	}
+	if prURL == "" {
+		return false, fmt.Errorf("run has no PR URL")
+	}
+	prNumber, err := scm.ExtractPRNumber(prURL)
+	if err != nil {
+		return false, fmt.Errorf("extract PR number: %w", err)
+	}
+	state, err := host.GetPRState(sctx.Ctx, &scm.PR{Number: prNumber, URL: prURL})
+	if err != nil {
+		return false, err
+	}
+	switch state {
+	case scm.PRStateMerged:
+		if sctx.Log != nil {
+			sctx.Log("PR has been merged; clearing stale CI approval gate")
+		}
+		return true, nil
+	case scm.PRStateClosed:
+		if sctx.Log != nil {
+			sctx.Log("PR has been closed; clearing stale CI approval gate")
+		}
+		return true, nil
+	case scm.PRStateOpen:
+		return false, nil
+	default:
+		return false, fmt.Errorf("PR state is unresolved: %q", state)
+	}
+}
+
 func (s *CIStep) gracePeriod() time.Duration {
 	if s.checksGracePeriod > 0 {
 		return s.checksGracePeriod

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -62,6 +62,8 @@ func handleFakeCLI(mode string) {
 		fakeCIGlabHandler(args)
 	case "ci-glab-seq":
 		fakeCIGlabSequenceHandler(args)
+	case "ci-gh-reconcile":
+		fakeCIGHReconcileHandler(args)
 	default:
 		os.Exit(1)
 	}
@@ -225,6 +227,46 @@ func extractTrailingNumber(rawURL string) int {
 		return 0
 	}
 	return number
+}
+
+func fakeCIGHReconcileHandler(args []string) {
+	joined := strings.Join(args, " ")
+	if len(args) >= 2 && args[0] == "auth" && args[1] == "status" {
+		os.Exit(0)
+	}
+	if strings.Contains(joined, "pr list") {
+		fmt.Println("[]")
+		os.Exit(0)
+	}
+	if strings.Contains(joined, "pr create") {
+		fmt.Println("https://github.com/test/repo/pull/42")
+		os.Exit(0)
+	}
+	if strings.Contains(joined, "pr view") && strings.Contains(joined, "--json state") {
+		state, err := os.ReadFile(os.Getenv("FAKE_CLI_STATE_PATH"))
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		switch state := strings.TrimSpace(string(state)); state {
+		case "ERROR":
+			fmt.Fprintln(os.Stderr, "provider unavailable")
+			os.Exit(1)
+		default:
+			fmt.Println(state)
+			os.Exit(0)
+		}
+	}
+	if strings.Contains(joined, "pr view") && strings.Contains(joined, "--json mergeable") {
+		fmt.Println("MERGEABLE")
+		os.Exit(0)
+	}
+	if strings.Contains(joined, "pr checks") {
+		fmt.Println(`[{"name":"build","state":"SUCCESS","bucket":"pass"}]`)
+		os.Exit(0)
+	}
+	fmt.Fprintln(os.Stderr, "unsupported reconcile gh argv:", joined)
+	os.Exit(1)
 }
 
 func fakeCIGHHandler(args []string) {


### PR DESCRIPTION
## Intent

Fix the public bug where pull requests merged or closed after the CI monitor parks at an approval gate remain durably classified as active and can block updates. Keep reconciliation executor-owned: perform cancellable, bounded, read-only SCM state checks while parked and before resuming validated historical CI gates; complete merged/closed gates through the normal success path; preserve open, unknown, unavailable, non-CI, or otherwise unprovable gates fail-closed; do not leak watchers or blindly rewrite SQLite. Add regression coverage for merged, closed, open, provider errors, update-guard clearance, startup recovery, approval/cancel/shutdown cleanup, and terminal status-write failures. Document restart behavior and safe remediation without recommending direct database edits.

## What Changed

- Add bounded, cancellable reconciliation for live and recovered parked CI gates, completing merged or closed pull requests through the normal success path while preserving unverified states fail-closed.
- Make reconciliation atomic with accepted approval responses and terminalize runs when status writes fail, preventing stale active runs from continuing to block lifecycle operations.
- Add regression coverage for reconciliation, recovery, cleanup, and write failures, plus documentation for restart behavior and safe remediation without direct database edits.

## Risk Assessment

✅ Low: The change is well-bounded, satisfies the stated reconciliation invariants, and the prior approval race is fixed with an atomic gate claim.

## Testing

The supplied full race suite and focused regression suites passed; manual evidence capture demonstrated that open parked CI runs remain active, while merged and closed PRs complete the run, clear awaiting-agent state, and leave zero active runs for the update lifecycle guard.

- Evidence: [Parked CI reconciliation lifecycle transcript](https://github.com/kunchenguid/no-mistakes/blob/98dbd24ddaf5517afa00a15dcc7e732d71660bb4/.no-mistakes/evidence/fm/nm-active-runs-merged-g5/parked-ci-reconciliation.txt)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `internal/pipeline/executor.go:1057` - An accepted approval response can be silently discarded while the synchronous SCM check is running. `Respond` may successfully enqueue an abort, fix, or skip, but if the provider then reports a terminal PR, this branch returns reconciliation success and the deferred drain drops the acknowledged response. Make response acceptance and gate reconciliation atomic, ensuring an accepted user action wins or `Respond` reports that the gate already closed.

🔧 Fix: Honor accepted responses during gate reconciliation
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`
- <code>Baseline supplied by the test step: `go test -race ./...`</code>
- <code>Inspected `git diff 78e4dcb234274199717acafa90abca5cf7013993..f4679614ae5a489cd7977d519f8d1d04dc6f535d` against the authoritative intent</code>
- `go test -race ./internal/pipeline ./internal/pipeline/steps ./internal/daemon -run 'Test(Executor_(AcceptedApprovalWinsReconciliationRace|ReconcilesParkedGateThroughNormalCompletionPath|ReconcileErrorPreservesGateFailClosed|GateRecheckIsBoundedAndApprovalWinsAfterTimeout|GateRecheckStopsAfterApprovalCancelAndShutdown|TerminalizesRunWhenInitialStatusWriteFails|TerminalizesRunWhenFinalCompletedWriteFails)|CIGateReconciliation(ClearsActiveRunAfterPRBecomesTerminal|PreservesOpenErrorAndUnknownStates)|Recover.*(Merged|Closed|Terminal|Parked|Approval|CI))' -count=1 -v`
- <code>Created and removed a transient evidence harness, then ran `go test -race ./internal/pipeline/steps -run &#39;^TestEvidenceParkedCIGateLifecycle$&#39; -count=1 -v` to capture live OPEN-to-MERGED and OPEN-to-CLOSED lifecycle transitions</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
