### PR TITLE
fix(pipeline): preserve GitHub CI status provenance

### DIFF
--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -202,6 +202,7 @@ Monitors PR health after creation and auto-fixes CI failures. Mergeability polli
 
 **Behavior:**
 - Polls provider CI status at increasing intervals: every 30s for the first 5 minutes, every 60s for 5-15 minutes, every 120s after that
+- On GitHub, reads native Check Runs and legacy commit statuses for the PR's current head separately and processes every result page. A pending legacy status without a link is advisory only when GitHub's readable branch-protection and ruleset policy confirms that its context is not required; native checks, linked or required legacy statuses, and any unreadable or unresolved policy remain blocking
 - Continues its normal monitoring loop until the PR is merged, closed, declined, or the configured `ci_timeout` idle window elapses, then parks at an approval gate instead of ending the run
 - The [`ci_timeout` reference](/no-mistakes/reference/global-config/#ci_timeout) owns idle re-arming, unlimited monitoring, and fail-closed reconciliation while that gate is parked
 - On GitHub, GitLab, and Azure DevOps, polls provider mergeability alongside CI checks while the PR remains open

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -203,6 +203,7 @@ Monitors PR health after creation and auto-fixes CI failures. Mergeability polli
 **Behavior:**
 - Polls provider CI status at increasing intervals: every 30s for the first 5 minutes, every 60s for 5-15 minutes, every 120s after that
 - On GitHub, reads native Check Runs and legacy commit statuses for the PR's current head separately and processes every result page. A pending legacy status without a link is advisory only when GitHub's readable branch-protection and ruleset policy confirms that its context is not required; native checks, linked or required legacy statuses, and any unreadable or unresolved policy remain blocking
+- On GitHub, if the PR head changes outside the pipeline run, stops CI monitoring and pauses for approval; rerun the pipeline on that new head before applying CI fixes
 - Continues its normal monitoring loop until the PR is merged, closed, declined, or the configured `ci_timeout` idle window elapses, then parks at an approval gate instead of ending the run
 - The [`ci_timeout` reference](/no-mistakes/reference/global-config/#ci_timeout) owns idle re-arming, unlimited monitoring, and fail-closed reconciliation while that gate is parked
 - On GitHub, GitLab, and Azure DevOps, polls provider mergeability alongside CI checks while the PR remains open

--- a/internal/branchsync/recover_test.go
+++ b/internal/branchsync/recover_test.go
@@ -234,6 +234,7 @@ func TestRecoverFastForwardRechecksCurrentBranchBeforeMerge(t *testing.T) {
 func TestRecoverReportsDirtyFinalStateWhenPostMergeHookMutatesWorktree(t *testing.T) {
 	f := newRecoverFixture(t, types.RunCancelled)
 	hooks := filepath.Join(f.local, ".git", "hooks")
+	mustRun(t, f.local, "config", "core.hooksPath", hooks)
 	hook := filepath.Join(hooks, "post-merge")
 	mustWrite(t, hook, "#!/bin/sh\nprintf hook > hook-output.txt\nexit 1\n")
 	if err := os.Chmod(hook, 0o755); err != nil {

--- a/internal/branchsync/sync_test.go
+++ b/internal/branchsync/sync_test.go
@@ -500,6 +500,7 @@ func TestApplyEmptyLocalUniquenessStillUsesStrictBehindFastForward(t *testing.T)
 func TestApplyReportsHonestFinalStateWhenPostMergeHookMutatesWorktree(t *testing.T) {
 	f := newSyncFixture(t)
 	hooks := filepath.Join(f.local, ".git", "hooks")
+	mustRun(t, f.local, "config", "core.hooksPath", hooks)
 	hook := filepath.Join(hooks, "post-merge")
 	mustWrite(t, hook, "#!/bin/sh\nprintf hook > hook-output.txt\nexit 1\n")
 	if err := os.Chmod(hook, 0o755); err != nil {

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -211,6 +211,7 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 		}
 		return ciMonitoringTimeoutOutcome(), nil
 	}
+	lastObservedPRHead := pr.HeadSHA
 
 	for {
 		if err := ctx.Err(); err != nil {
@@ -271,6 +272,19 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 				return nil, err
 			}
 		}
+		if provider == scm.ProviderGitHub {
+			if pr.HeadSHA != "" && pr.HeadSHA != lastObservedPRHead {
+				clearCIMonitorReady(sctx)
+				lastMonitorLog = ""
+				s.lastFixedChecks = ""
+				s.lastFixedCompletedAt = nil
+			}
+			if pr.HeadSHA != "" {
+				lastObservedPRHead = pr.HeadSHA
+			}
+		} else {
+			pr.HeadSHA = sctx.Run.HeadSHA
+		}
 
 		// Check mergeable state if the provider supports it
 		mergeConflict := false
@@ -296,7 +310,6 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 
 		// Check CI status - wait for all checks to complete before fixing
 		ciFixLimit := sctx.Config.AutoFix.CI
-		pr.HeadSHA = sctx.Run.HeadSHA
 		checks, err := host.GetChecks(ctx, pr)
 		if err != nil {
 			clearCIMonitorReady(sctx)

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -278,6 +278,10 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 				lastMonitorLog = ""
 				s.lastFixedChecks = ""
 				s.lastFixedCompletedAt = nil
+				if pr.HeadSHA != sctx.Run.HeadSHA {
+					sctx.Log("PR head changed outside this run; stopping CI monitoring")
+					return ciForeignHeadOutcome(), nil
+				}
 			}
 			if pr.HeadSHA != "" {
 				lastObservedPRHead = pr.HeadSHA

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -159,7 +159,12 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 	if err != nil {
 		return nil, fmt.Errorf("extract PR number: %w", err)
 	}
-	pr := &scm.PR{Number: prNumber, URL: prURL}
+	pr := &scm.PR{
+		Number:     prNumber,
+		URL:        prURL,
+		HeadSHA:    sctx.Run.HeadSHA,
+		BaseBranch: sctx.Repo.DefaultBranch,
+	}
 
 	// CITimeout semantics: <0 (or "unlimited" in config) means never
 	// self-terminate; 0 means the value was never configured, so fall back

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -276,9 +276,9 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 			if pr.HeadSHA != "" && pr.HeadSHA != lastObservedPRHead {
 				clearCIMonitorReady(sctx)
 				lastMonitorLog = ""
-				s.lastFixedChecks = ""
-				s.lastFixedCompletedAt = nil
 				if pr.HeadSHA != sctx.Run.HeadSHA {
+					s.lastFixedChecks = ""
+					s.lastFixedCompletedAt = nil
 					sctx.Log("PR head changed outside this run; stopping CI monitoring")
 					return ciForeignHeadOutcome(), nil
 				}

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -296,6 +296,7 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 
 		// Check CI status - wait for all checks to complete before fixing
 		ciFixLimit := sctx.Config.AutoFix.CI
+		pr.HeadSHA = sctx.Run.HeadSHA
 		checks, err := host.GetChecks(ctx, pr)
 		if err != nil {
 			clearCIMonitorReady(sctx)

--- a/internal/pipeline/steps/ci_autofix_test.go
+++ b/internal/pipeline/steps/ci_autofix_test.go
@@ -106,6 +106,84 @@ func TestCIStep_CIFailureAutoFix(t *testing.T) {
 	}
 }
 
+func TestCIStep_RefreshesGitHubProvenanceHeadAfterAutoFixPush(t *testing.T) {
+	t.Parallel()
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "init.txt"), []byte("init"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "initial")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	if err := os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	env, headLog := fakeCIGHProvenance(t, headSHA)
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(_ context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			if err := os.WriteFile(filepath.Join(opts.CWD, "ci-fix.txt"), []byte("fixed"), 0o644); err != nil {
+				return nil, err
+			}
+			return &agent.Result{}, nil
+		},
+	}
+
+	prURL := "https://github.com/test/repo/pull/42"
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+	sctx.Repo.UpstreamURL = "https://github.com/test/repo.git"
+	sctx.Repo.ForkURL = upstream
+	sctx.Config.CITimeout = time.Hour
+	sctx.Config.AutoFix = config.AutoFix{CI: 1}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+	polls := 0
+	step := &CIStep{
+		baseBranchTip: func(context.Context) (string, bool) { return "", false },
+		waitForNextPoll: func(ctx context.Context, _ time.Duration) error {
+			polls++
+			if polls == 2 {
+				cancel()
+			}
+			return ctx.Err()
+		},
+	}
+	_, err := step.Execute(sctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Execute() error = %v, want context.Canceled", err)
+	}
+	if sctx.Run.HeadSHA == headSHA {
+		t.Fatal("CI auto-fix did not update the run head")
+	}
+	headCalls, err := os.ReadFile(headLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(headCalls), "/commits/"+headSHA+"/") || !strings.Contains(string(headCalls), "/commits/"+sctx.Run.HeadSHA+"/") {
+		t.Fatalf("provenance head calls = %q, want initial and updated heads", headCalls)
+	}
+}
+
 func TestCIStep_CIAutoFixDisabledWithZero(t *testing.T) {
 	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)

--- a/internal/pipeline/steps/ci_checks.go
+++ b/internal/pipeline/steps/ci_checks.go
@@ -201,3 +201,19 @@ func ciMonitoringTimeoutOutcome() *pipeline.StepOutcome {
 		Findings:      string(findingsJSON),
 	}
 }
+
+func ciForeignHeadOutcome() *pipeline.StepOutcome {
+	findings := Findings{
+		Summary: "CI monitoring stopped after the PR head changed outside this run",
+		Items: []Finding{{
+			Severity:    "warning",
+			Description: "The PR head changed outside this run; rerun the pipeline on the new head before applying CI fixes",
+			Action:      types.ActionAskUser,
+		}},
+	}
+	findingsJSON, _ := json.Marshal(findings)
+	return &pipeline.StepOutcome{
+		NeedsApproval: true,
+		Findings:      string(findingsJSON),
+	}
+}

--- a/internal/pipeline/steps/ci_checks_test.go
+++ b/internal/pipeline/steps/ci_checks_test.go
@@ -6,6 +6,19 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/scm"
 )
 
+func TestHasPendingChecksIgnoresOnlyExplicitAdvisoryLegacyStatus(t *testing.T) {
+	t.Parallel()
+	if hasPendingChecks([]scm.Check{{Name: "CodeRabbit", Bucket: scm.CheckBucketPending, Source: scm.CheckSourceLegacy, BlocksPending: false}}) {
+		t.Fatal("advisory legacy status must not keep CI running")
+	}
+	if !hasPendingChecks([]scm.Check{{Name: "CodeRabbit", Bucket: scm.CheckBucketPending, Source: scm.CheckSourceLegacy, BlocksPending: true}}) {
+		t.Fatal("protected legacy status must keep CI running")
+	}
+	if !hasPendingChecks([]scm.Check{{Name: "unit", Bucket: scm.CheckBucketPending, Source: scm.CheckSourceNative, BlocksPending: true}}) {
+		t.Fatal("native pending check must keep CI running")
+	}
+}
+
 func TestPendingCheckMatchesLastFixed_SpecialCheckNames(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pipeline/steps/ci_fix.go
+++ b/internal/pipeline/steps/ci_fix.go
@@ -111,7 +111,13 @@ CI logs:
 		return false, fmt.Errorf("agent CI fix: %w", err)
 	}
 
-	return s.commitAndPush(sctx)
+	pushed, err := s.commitAndPush(sctx)
+	if err == nil && pr != nil && sctx.Run.HeadSHA != "" {
+		// Keep the next poll pinned to the head this run just pushed even if
+		// refreshing the PR state is temporarily unavailable.
+		pr.HeadSHA = sctx.Run.HeadSHA
+	}
+	return pushed, err
 }
 
 // commitAndPush commits any uncommitted changes and force-pushes to the

--- a/internal/pipeline/steps/ci_test.go
+++ b/internal/pipeline/steps/ci_test.go
@@ -392,6 +392,48 @@ func TestCIStep_AllChecksPassingKeepsMonitoringOpenPR(t *testing.T) {
 	}
 }
 
+func TestCIStep_ClearsReadinessWhenGitHubPRHeadChanges(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	env := fakeCIGHSequenceWithHeads(t, "OPEN", []string{
+		`[{"name":"build","state":"SUCCESS","bucket":"pass"}]`,
+		`[{"name":"build","state":"PENDING","bucket":"pending"}]`,
+	}, []string{headSHA, "external-head"})
+	prURL := "https://github.com/test/repo/pull/42"
+	sctx := newTestContextWithDBRecords(t, &mockAgent{name: "test"}, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+	sctx.Config.CITimeout = 10 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+	polls := 0
+	step := &CIStep{
+		baseBranchTip: func(context.Context) (string, bool) { return "", false },
+		waitForNextPoll: func(ctx context.Context, _ time.Duration) error {
+			polls++
+			if polls == 2 {
+				cancel()
+			}
+			return ctx.Err()
+		},
+	}
+
+	_, err := step.Execute(sctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Execute() error = %v, want context.Canceled", err)
+	}
+	run, err := sctx.DB.GetRun(sctx.Run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.CIReadyAt != nil {
+		t.Fatalf("CI readiness = %v, want cleared after PR head change", run.CIReadyAt)
+	}
+}
+
 func TestCIStep_UnprotectedLinklessLegacyPendingReportsChecksPassed(t *testing.T) {
 	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)

--- a/internal/pipeline/steps/ci_test.go
+++ b/internal/pipeline/steps/ci_test.go
@@ -392,7 +392,7 @@ func TestCIStep_AllChecksPassingKeepsMonitoringOpenPR(t *testing.T) {
 	}
 }
 
-func TestCIStep_ClearsReadinessWhenGitHubPRHeadChanges(t *testing.T) {
+func TestCIStep_ParksWhenGitHubPRHeadChangesExternally(t *testing.T) {
 	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
@@ -401,7 +401,8 @@ func TestCIStep_ClearsReadinessWhenGitHubPRHeadChanges(t *testing.T) {
 		`[{"name":"build","state":"PENDING","bucket":"pending"}]`,
 	}, []string{headSHA, "external-head"})
 	prURL := "https://github.com/test/repo/pull/42"
-	sctx := newTestContextWithDBRecords(t, &mockAgent{name: "test"}, dir, baseSHA, headSHA, config.Commands{})
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Env = env
 	sctx.Run.PRURL = &prURL
 	sctx.Config.CITimeout = 10 * time.Second
@@ -414,16 +415,16 @@ func TestCIStep_ClearsReadinessWhenGitHubPRHeadChanges(t *testing.T) {
 		baseBranchTip: func(context.Context) (string, bool) { return "", false },
 		waitForNextPoll: func(ctx context.Context, _ time.Duration) error {
 			polls++
-			if polls == 2 {
-				cancel()
-			}
 			return ctx.Err()
 		},
 	}
 
-	_, err := step.Execute(sctx)
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("Execute() error = %v, want context.Canceled", err)
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatalf("Execute() error = %v, want approval outcome", err)
+	}
+	if outcome == nil || !outcome.NeedsApproval {
+		t.Fatalf("Execute() outcome = %#v, want approval after external PR head change", outcome)
 	}
 	run, err := sctx.DB.GetRun(sctx.Run.ID)
 	if err != nil {
@@ -431,6 +432,12 @@ func TestCIStep_ClearsReadinessWhenGitHubPRHeadChanges(t *testing.T) {
 	}
 	if run.CIReadyAt != nil {
 		t.Fatalf("CI readiness = %v, want cleared after PR head change", run.CIReadyAt)
+	}
+	if polls != 1 {
+		t.Fatalf("polls = %d, want one wait before parking", polls)
+	}
+	if len(ag.calls) != 0 {
+		t.Fatalf("agent calls = %d, want no auto-fix after external PR head change", len(ag.calls))
 	}
 }
 

--- a/internal/pipeline/steps/ci_test.go
+++ b/internal/pipeline/steps/ci_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
+	"github.com/kunchenguid/no-mistakes/internal/cimonitor"
 	"github.com/kunchenguid/no-mistakes/internal/config"
 	"github.com/kunchenguid/no-mistakes/internal/scm"
 )
@@ -389,6 +390,43 @@ func TestCIStep_AllChecksPassingKeepsMonitoringOpenPR(t *testing.T) {
 	if !found {
 		t.Fatalf("expected continued-monitoring CI log, got: %v", logs)
 	}
+}
+
+func TestCIStep_UnprotectedLinklessLegacyPendingReportsChecksPassed(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	env := fakeCIGH(t, "OPEN", "[]")
+	env = append(env, `FAKE_CLI_LEGACY_STATUSES=[{"context":"legacy-bot","state":"pending","target_url":null}]`)
+
+	prURL := "https://github.com/test/repo/pull/42"
+	sctx := newTestContext(t, &mockAgent{name: "test"}, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Run.PRURL = &prURL
+	sctx.Config.CITimeout = 10 * time.Second
+
+	var logs []string
+	sctx.Log = func(s string) { logs = append(logs, s) }
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sctx.Ctx = ctx
+
+	step := &CIStep{waitForNextPoll: func(ctx context.Context, _ time.Duration) error {
+		cancel()
+		return ctx.Err()
+	}}
+	if _, err := step.Execute(sctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected monitoring to continue after reporting readiness, got %v", err)
+	}
+	if !cimonitor.ChecksPassed(logs) {
+		t.Fatalf("expected the monitor to report checks passed, got logs: %v", logs)
+	}
+	for _, log := range logs {
+		if log == ciChecksRunningMsg {
+			t.Fatalf("advisory legacy status must not report checks still running: %v", logs)
+		}
+	}
+	t.Logf("CI monitor output: %s", cimonitor.ParseActivity(logs).LastEvent)
 }
 
 func TestCIStep_CIWarningAllowsChecksPassedToBeReannounced(t *testing.T) {

--- a/internal/pipeline/steps/headcontinuity_repro_test.go
+++ b/internal/pipeline/steps/headcontinuity_repro_test.go
@@ -139,7 +139,11 @@ func TestCommitAgentFixes_RefusesResetDuringCommit(t *testing.T) {
 	if !filepath.IsAbs(gitDir) {
 		gitDir = filepath.Join(dir, gitDir)
 	}
-	hook := filepath.Join(gitDir, "hooks", "post-commit")
+	hooksDir := filepath.Join(gitDir, "hooks")
+	// The test must use its local hook rather than an ambient core.hooksPath
+	// configured by an agent harness or developer environment.
+	gitCmd(t, dir, "config", "core.hooksPath", hooksDir)
+	hook := filepath.Join(hooksDir, "post-commit")
 	hookBody := "#!/bin/sh\ngit reset --hard " + baseSHA + "\n"
 	if err := os.WriteFile(hook, []byte(hookBody), 0o755); err != nil {
 		t.Fatal(err)

--- a/internal/pipeline/steps/helpers_test.go
+++ b/internal/pipeline/steps/helpers_test.go
@@ -496,6 +496,10 @@ func fakeCIGHSequenceMergeable(t *testing.T, state string, checks []string, merg
 }
 
 func fakeCIGHSequence(t *testing.T, state string, checks []string) []string {
+	return fakeCIGHSequenceWithHeads(t, state, checks, nil)
+}
+
+func fakeCIGHSequenceWithHeads(t *testing.T, state string, checks, heads []string) []string {
 	t.Helper()
 	binDir := fakeCLIBinDir(t)
 	linkTestBinary(t, binDir, "gh")
@@ -510,12 +514,20 @@ func fakeCIGHSequence(t *testing.T, state string, checks []string) []string {
 		t.Fatalf("write checks index: %v", err)
 	}
 
-	return fakeCLIEnv(binDir, map[string]string{
+	vars := map[string]string{
 		"FAKE_CLI_MODE":              "ci-gh-seq",
 		"FAKE_CLI_STATE":             state,
 		"FAKE_CLI_CHECKS_PATH":       checksPath,
 		"FAKE_CLI_CHECKS_INDEX_PATH": indexPath,
-	})
+	}
+	if len(heads) > 0 {
+		headPath := filepath.Join(t.TempDir(), "heads.txt")
+		if err := os.WriteFile(headPath, []byte(strings.Join(heads, "\n")), 0o644); err != nil {
+			t.Fatalf("write head sequence: %v", err)
+		}
+		vars["FAKE_CLI_HEADS_PATH"] = headPath
+	}
+	return fakeCLIEnv(binDir, vars)
 }
 
 func fakeCIGHProvenance(t *testing.T, initialHead string) ([]string, string) {

--- a/internal/pipeline/steps/helpers_test.go
+++ b/internal/pipeline/steps/helpers_test.go
@@ -518,6 +518,18 @@ func fakeCIGHSequence(t *testing.T, state string, checks []string) []string {
 	})
 }
 
+func fakeCIGHProvenance(t *testing.T, initialHead string) ([]string, string) {
+	t.Helper()
+	binDir := fakeCLIBinDir(t)
+	linkTestBinary(t, binDir, "gh")
+	headLog := filepath.Join(t.TempDir(), "heads.log")
+	return fakeCLIEnv(binDir, map[string]string{
+		"FAKE_CLI_MODE":         "ci-gh-provenance",
+		"FAKE_CLI_INITIAL_HEAD": initialHead,
+		"FAKE_CLI_HEAD_LOG":     headLog,
+	}), headLog
+}
+
 func fakeCIGHNoChecks(t *testing.T) []string {
 	t.Helper()
 	binDir := fakeCLIBinDir(t)

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -370,7 +370,12 @@ func fakeCIGHSequenceHandler(args []string) {
 		os.Exit(0)
 	}
 	if strings.Contains(joined, "pr view") && strings.Contains(joined, "--json state") {
-		fmt.Println(state)
+		if headsPath := os.Getenv("FAKE_CLI_HEADS_PATH"); headsPath != "" {
+			head := currentFakeCIGHHead(headsPath, indexPath)
+			fmt.Printf("{\"state\":%q,\"headRefOid\":%q}\n", state, head)
+		} else {
+			fmt.Println(state)
+		}
 		os.Exit(0)
 	}
 	if strings.Contains(joined, "/check-runs?per_page=100") {
@@ -390,6 +395,28 @@ func fakeCIGHSequenceHandler(args []string) {
 		os.Exit(0)
 	}
 	os.Exit(1)
+}
+
+func currentFakeCIGHHead(headsPath, indexPath string) string {
+	data, err := os.ReadFile(headsPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	entries := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(entries) == 0 || entries[0] == "" {
+		return ""
+	}
+	index := 0
+	if rawIndex, err := os.ReadFile(indexPath); err == nil {
+		if parsed, err := strconv.Atoi(strings.TrimSpace(string(rawIndex))); err == nil {
+			index = parsed
+		}
+	}
+	if index >= len(entries) {
+		index = len(entries) - 1
+	}
+	return entries[index]
 }
 
 func nextFakeCIGHChecks(checksPath, indexPath string) string {

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -1,6 +1,7 @@
 package steps
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -328,6 +329,9 @@ func fakeCIGHHandler(args []string) {
 		fmt.Println(state)
 		os.Exit(0)
 	}
+	if serveFakeGitHubProvenanceAPI(args, checksJSON) {
+		os.Exit(0)
+	}
 	if strings.Contains(joined, "pr checks") {
 		if checksErr != "" {
 			fmt.Fprintln(os.Stderr, checksErr)
@@ -369,32 +373,16 @@ func fakeCIGHSequenceHandler(args []string) {
 		fmt.Println(state)
 		os.Exit(0)
 	}
-	if strings.Contains(joined, "pr checks") {
-		data, err := os.ReadFile(checksPath)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
-		}
-		entries := strings.Split(strings.TrimSpace(string(data)), "\n")
-		if len(entries) == 0 || entries[0] == "" {
-			fmt.Println("[]")
+	if strings.Contains(joined, "/check-runs?per_page=100") {
+		if serveFakeGitHubProvenanceAPI(args, nextFakeCIGHChecks(checksPath, indexPath)) {
 			os.Exit(0)
 		}
-
-		index := 0
-		if rawIndex, err := os.ReadFile(indexPath); err == nil {
-			if parsed, err := strconv.Atoi(strings.TrimSpace(string(rawIndex))); err == nil {
-				index = parsed
-			}
-		}
-		if index >= len(entries) {
-			index = len(entries) - 1
-		}
-		if err := os.WriteFile(indexPath, []byte(strconv.Itoa(index+1)), 0o644); err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
-		}
-		fmt.Println(entries[index])
+	}
+	if serveFakeGitHubProvenanceAPI(args, "") {
+		os.Exit(0)
+	}
+	if strings.Contains(joined, "pr checks") {
+		fmt.Println(nextFakeCIGHChecks(checksPath, indexPath))
 		os.Exit(0)
 	}
 	if strings.Contains(joined, "run view") {
@@ -402,6 +390,127 @@ func fakeCIGHSequenceHandler(args []string) {
 		os.Exit(0)
 	}
 	os.Exit(1)
+}
+
+func nextFakeCIGHChecks(checksPath, indexPath string) string {
+	data, err := os.ReadFile(checksPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	entries := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(entries) == 0 || entries[0] == "" {
+		return "[]"
+	}
+
+	index := 0
+	if rawIndex, err := os.ReadFile(indexPath); err == nil {
+		if parsed, err := strconv.Atoi(strings.TrimSpace(string(rawIndex))); err == nil {
+			index = parsed
+		}
+	}
+	if index >= len(entries) {
+		index = len(entries) - 1
+	}
+	if err := os.WriteFile(indexPath, []byte(strconv.Itoa(index+1)), 0o644); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	return entries[index]
+}
+
+func serveFakeGitHubProvenanceAPI(args []string, checksJSON string) bool {
+	joined := strings.Join(args, " ")
+	switch {
+	case strings.Contains(joined, "/protection/required_status_checks"):
+		fmt.Fprintln(os.Stderr, "Branch not protected")
+		os.Exit(1)
+		return false
+	case strings.Contains(joined, "/rules/branches/"):
+		fmt.Println("[]")
+		return true
+	case strings.Contains(joined, "/statuses?per_page=100"):
+		fmt.Println("[]")
+		return true
+	case strings.Contains(joined, "/check-runs?per_page=100"):
+		fmt.Println(fakeGitHubCheckRunsJSON(checksJSON))
+		return true
+	default:
+		return false
+	}
+}
+
+func fakeGitHubCheckRunsJSON(checksJSON string) string {
+	var checks []struct {
+		Name        string `json:"name"`
+		State       string `json:"state"`
+		Status      string `json:"status"`
+		Conclusion  string `json:"conclusion"`
+		Bucket      string `json:"bucket"`
+		CompletedAt string `json:"completedAt"`
+	}
+	if err := json.Unmarshal([]byte(checksJSON), &checks); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	runs := make([]struct {
+		Name        string `json:"name"`
+		Status      string `json:"status"`
+		Conclusion  string `json:"conclusion,omitempty"`
+		CompletedAt string `json:"completed_at,omitempty"`
+	}, 0, len(checks))
+	for _, check := range checks {
+		status, conclusion := fakeGitHubCheckRunState(check)
+		runs = append(runs, struct {
+			Name        string `json:"name"`
+			Status      string `json:"status"`
+			Conclusion  string `json:"conclusion,omitempty"`
+			CompletedAt string `json:"completed_at,omitempty"`
+		}{
+			Name: check.Name, Status: status, Conclusion: conclusion, CompletedAt: check.CompletedAt,
+		})
+	}
+
+	encoded, err := json.Marshal(struct {
+		CheckRuns any `json:"check_runs"`
+	}{CheckRuns: runs})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	return string(encoded)
+}
+
+func fakeGitHubCheckRunState(check struct {
+	Name        string `json:"name"`
+	State       string `json:"state"`
+	Status      string `json:"status"`
+	Conclusion  string `json:"conclusion"`
+	Bucket      string `json:"bucket"`
+	CompletedAt string `json:"completedAt"`
+}) (string, string) {
+	if check.Status != "" {
+		return strings.ToLower(check.Status), strings.ToLower(check.Conclusion)
+	}
+	switch strings.ToLower(check.Bucket) {
+	case "pending":
+		return "in_progress", ""
+	case "pass":
+		return "completed", "success"
+	case "fail":
+		return "completed", "failure"
+	case "cancel":
+		return "completed", "cancelled"
+	case "skipping":
+		return "completed", "skipped"
+	}
+	switch strings.ToUpper(check.State) {
+	case "PENDING", "QUEUED", "IN_PROGRESS", "WAITING", "REQUESTED", "EXPECTED":
+		return "in_progress", ""
+	default:
+		return "completed", strings.ToLower(check.State)
+	}
 }
 
 func fakeCIGHProvenanceHandler(args []string) {
@@ -560,6 +669,9 @@ func fakeCIGHNoChecksHandler(args []string) {
 	joined := strings.Join(args, " ")
 
 	if len(args) >= 2 && args[0] == "auth" && args[1] == "status" {
+		os.Exit(0)
+	}
+	if serveFakeGitHubProvenanceAPI(args, "[]") {
 		os.Exit(0)
 	}
 	if strings.Contains(joined, "pr checks") {

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -430,7 +430,11 @@ func serveFakeGitHubProvenanceAPI(args []string, checksJSON string) bool {
 		fmt.Println("[]")
 		return true
 	case strings.Contains(joined, "/statuses?per_page=100"):
-		fmt.Println("[]")
+		legacyStatuses := os.Getenv("FAKE_CLI_LEGACY_STATUSES")
+		if legacyStatuses == "" {
+			legacyStatuses = "[]"
+		}
+		fmt.Println(legacyStatuses)
 		return true
 	case strings.Contains(joined, "/check-runs?per_page=100"):
 		fmt.Println(fakeGitHubCheckRunsJSON(checksJSON))

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -58,6 +58,8 @@ func handleFakeCLI(mode string) {
 		fakeCIGHHandler(args)
 	case "ci-gh-seq":
 		fakeCIGHSequenceHandler(args)
+	case "ci-gh-provenance":
+		fakeCIGHProvenanceHandler(args)
 	case "ci-gh-nochecks":
 		fakeCIGHNoChecksHandler(args)
 	case "ci-glab":
@@ -397,6 +399,44 @@ func fakeCIGHSequenceHandler(args []string) {
 	}
 	if strings.Contains(joined, "run view") {
 		fmt.Println("error log output")
+		os.Exit(0)
+	}
+	os.Exit(1)
+}
+
+func fakeCIGHProvenanceHandler(args []string) {
+	joined := strings.Join(args, " ")
+	if len(args) >= 2 && args[0] == "auth" && args[1] == "status" {
+		os.Exit(0)
+	}
+	if strings.Contains(joined, "pr view") && strings.Contains(joined, "--json mergeable") {
+		fmt.Println("MERGEABLE")
+		os.Exit(0)
+	}
+	if strings.Contains(joined, "pr view") && strings.Contains(joined, "--json state") {
+		fmt.Println("OPEN")
+		os.Exit(0)
+	}
+	if strings.Contains(joined, "branches/main/protection/required_status_checks") {
+		fmt.Fprintln(os.Stderr, "Branch not protected")
+		os.Exit(1)
+	}
+	if strings.Contains(joined, "rules/branches/main") || strings.Contains(joined, "/statuses?per_page=100") || strings.Contains(joined, "run list") {
+		fmt.Println("[]")
+		os.Exit(0)
+	}
+	if strings.Contains(joined, "/check-runs?per_page=100") {
+		if logPath := os.Getenv("FAKE_CLI_HEAD_LOG"); logPath != "" {
+			if f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644); err == nil {
+				fmt.Fprintln(f, joined)
+				f.Close()
+			}
+		}
+		if strings.Contains(joined, "/commits/"+os.Getenv("FAKE_CLI_INITIAL_HEAD")+"/") {
+			fmt.Println(`{"check_runs":[{"name":"build","status":"completed","conclusion":"failure"}]}`)
+		} else {
+			fmt.Println(`{"check_runs":[{"name":"build","status":"in_progress"}]}`)
+		}
 		os.Exit(0)
 	}
 	os.Exit(1)

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -504,7 +504,7 @@ func (h *Host) requiredStatusContexts(ctx context.Context, repo, branch string) 
 
 func isUnprotectedBranchError(err error) bool {
 	message := strings.ToLower(err.Error())
-	return strings.Contains(message, "branch not protected") || strings.Contains(message, "status: 404")
+	return strings.Contains(message, "branch not protected")
 }
 
 func (h *Host) GetMergeableState(ctx context.Context, pr *scm.PR) (scm.MergeableState, error) {

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -473,7 +473,7 @@ func (h *Host) requiredStatusContexts(ctx context.Context, repo, branch string) 
 		}
 	}
 
-	var rules []struct {
+	var rulePages [][]struct {
 		Type       string `json:"type"`
 		Parameters struct {
 			RequiredStatusChecks []struct {
@@ -481,19 +481,21 @@ func (h *Host) requiredStatusContexts(ctx context.Context, repo, branch string) 
 			} `json:"required_status_checks"`
 		} `json:"parameters"`
 	}
-	if err := h.apiJSON(ctx, "repos/"+repo+"/rules/branches/"+branch, &rules); err != nil {
+	if err := h.apiJSONPages(ctx, "repos/"+repo+"/rules/branches/"+branch, &rulePages); err != nil {
 		return nil, false
 	}
-	for _, rule := range rules {
-		if rule.Type == "workflows" {
-			return nil, false
-		}
-		if rule.Type != "required_status_checks" {
-			continue
-		}
-		for _, check := range rule.Parameters.RequiredStatusChecks {
-			if check.Context != "" {
-				required[check.Context] = true
+	for _, rules := range rulePages {
+		for _, rule := range rules {
+			if rule.Type == "workflows" {
+				return nil, false
+			}
+			if rule.Type != "required_status_checks" {
+				continue
+			}
+			for _, check := range rule.Parameters.RequiredStatusChecks {
+				if check.Context != "" {
+					required[check.Context] = true
+				}
 			}
 		}
 	}

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -2,11 +2,14 @@
 package github
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os/exec"
+	"reflect"
 	"strings"
 	"time"
 
@@ -262,6 +265,15 @@ func (h *Host) GetPRState(ctx context.Context, pr *scm.PR) (scm.PRState, error) 
 }
 
 func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
+	if pr != nil && pr.HeadSHA != "" && pr.BaseBranch != "" && githubAPIRepo(h.repo) != "" {
+		return h.getChecksWithProvenance(ctx, pr)
+	}
+	return h.getChecksFromPR(ctx, pr)
+}
+
+// getChecksFromPR is the compatibility path for providers and callers that
+// cannot supply the PR head and base branch needed for source-aware checks.
+func (h *Host) getChecksFromPR(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
 	args := append([]string{"pr", "checks", pr.Number}, h.repoArgs()...)
 	args = append(args, "--json", "name,state,bucket,completedAt")
 	cmd := h.cmd(ctx, "gh", args...)
@@ -289,9 +301,208 @@ func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
 				completedAt = parsed
 			}
 		}
-		checks = append(checks, scm.Check{Name: r.Name, Bucket: normalizeCheckBucket(r.Bucket, r.State), CompletedAt: completedAt})
+		checks = append(checks, scm.Check{Name: r.Name, Bucket: normalizeCheckBucket(r.Bucket, r.State), CompletedAt: completedAt, Source: scm.CheckSourceUnknown, BlocksPending: true})
 	}
 	return checks, nil
+}
+
+// getChecksWithProvenance keeps native Check Runs and legacy commit statuses
+// separate. A linkless legacy pending status is advisory only after GitHub's
+// active protection rules positively show that its context is not required.
+func (h *Host) getChecksWithProvenance(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
+	repo := githubAPIRepo(h.repo)
+	required, policyKnown := h.requiredStatusContexts(ctx, repo, pr.BaseBranch)
+
+	var nativePages []struct {
+		CheckRuns []struct {
+			Name        string `json:"name"`
+			Status      string `json:"status"`
+			Conclusion  string `json:"conclusion"`
+			CompletedAt string `json:"completed_at"`
+		} `json:"check_runs"`
+	}
+	if err := h.apiJSONPages(ctx, "repos/"+repo+"/commits/"+pr.HeadSHA+"/check-runs?per_page=100", &nativePages); err != nil {
+		return nil, err
+	}
+
+	var legacyPages [][]struct {
+		Context   string `json:"context"`
+		State     string `json:"state"`
+		TargetURL string `json:"target_url"`
+		CreatedAt string `json:"created_at"`
+	}
+	if err := h.apiJSONPages(ctx, "repos/"+repo+"/commits/"+pr.HeadSHA+"/statuses?per_page=100", &legacyPages); err != nil {
+		return nil, err
+	}
+
+	checks := make([]scm.Check, 0)
+	for _, native := range nativePages {
+		for _, run := range native.CheckRuns {
+			bucket := normalizeCheckBucket("", run.Status)
+			if strings.EqualFold(run.Status, "completed") {
+				bucket = normalizeCheckBucket("", run.Conclusion)
+				if bucket == "" {
+					bucket = scm.CheckBucketPending
+				}
+			}
+			checks = append(checks, scm.Check{
+				Name: run.Name, Bucket: bucket,
+				CompletedAt: parseGitHubTime(run.CompletedAt), Source: scm.CheckSourceNative, BlocksPending: true,
+			})
+		}
+	}
+	seen := map[string]bool{}
+	for _, legacy := range legacyPages {
+		for _, status := range legacy {
+			if status.Context == "" || seen[status.Context] {
+				continue
+			}
+			seen[status.Context] = true // GitHub returns latest statuses first.
+			bucket := normalizeCheckBucket("", status.State)
+			blocksPending := true
+			if bucket == scm.CheckBucketPending && policyKnown && status.TargetURL == "" && !required[status.Context] {
+				blocksPending = false
+			}
+			checks = append(checks, scm.Check{
+				Name: status.Context, Bucket: bucket, CompletedAt: parseGitHubTime(status.CreatedAt),
+				Source: scm.CheckSourceLegacy, BlocksPending: blocksPending,
+			})
+		}
+	}
+	if !policyKnown {
+		// A required workflow can exist before GitHub has emitted its first
+		// check run. Keep CI conservatively pending rather than treating an
+		// unreadable or unresolvable requirement policy as "no checks passed".
+		checks = append(checks, scm.Check{
+			Name: "GitHub required-check policy unresolved", Bucket: scm.CheckBucketPending,
+			Source: scm.CheckSourceUnknown, BlocksPending: true,
+		})
+	}
+	return checks, nil
+}
+
+func githubAPIRepo(repo string) string {
+	parts := strings.Split(repo, "/")
+	if len(parts) < 2 {
+		return ""
+	}
+	return strings.Join(parts[len(parts)-2:], "/")
+}
+
+func (h *Host) apiJSON(ctx context.Context, endpoint string, target any) error {
+	args := h.apiArgs(endpoint, false)
+	cmd := h.cmd(ctx, "gh", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gh api %s: %s: %w", endpoint, strings.TrimSpace(string(out)), err)
+	}
+	if err := json.Unmarshal(out, target); err != nil {
+		return fmt.Errorf("parse GitHub API %s: %w", endpoint, err)
+	}
+	return nil
+}
+
+// apiJSONPages decodes every JSON page emitted by `gh api --paginate`.
+// This prevents a pending or failed check beyond GitHub's first page from
+// disappearing and producing a false green CI result.
+func (h *Host) apiJSONPages(ctx context.Context, endpoint string, target any) error {
+	args := h.apiArgs(endpoint, true)
+	cmd := h.cmd(ctx, "gh", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gh api %s: %s: %w", endpoint, strings.TrimSpace(string(out)), err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(out))
+	value := reflect.ValueOf(target)
+	if value.Kind() != reflect.Ptr || value.Elem().Kind() != reflect.Slice {
+		return errors.New("paginated GitHub API target must be a slice pointer")
+	}
+	for {
+		page := reflect.New(value.Elem().Type().Elem())
+		err := decoder.Decode(page.Interface())
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("parse paginated GitHub API %s: %w", endpoint, err)
+		}
+		value.Elem().Set(reflect.Append(value.Elem(), page.Elem()))
+	}
+	return nil
+}
+
+func (h *Host) apiArgs(endpoint string, paginate bool) []string {
+	args := []string{"api"}
+	if paginate {
+		args = append(args, "--paginate")
+	}
+	if h.host != "" && !strings.EqualFold(h.host, "github.com") {
+		args = append(args, "--hostname", h.host)
+	}
+	return append(args, endpoint)
+}
+
+func parseGitHubTime(value string) time.Time {
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed
+}
+
+func (h *Host) requiredStatusContexts(ctx context.Context, repo, branch string) (map[string]bool, bool) {
+	required := map[string]bool{}
+	var protection struct {
+		Contexts []string `json:"contexts"`
+		Checks   []struct {
+			Context string `json:"context"`
+		} `json:"checks"`
+	}
+	if err := h.apiJSON(ctx, "repos/"+repo+"/branches/"+branch+"/protection/required_status_checks", &protection); err != nil {
+		if !isUnprotectedBranchError(err) {
+			return nil, false
+		}
+	} else {
+		for _, context := range protection.Contexts {
+			required[context] = true
+		}
+		for _, check := range protection.Checks {
+			if check.Context != "" {
+				required[check.Context] = true
+			}
+		}
+	}
+
+	var rules []struct {
+		Type       string `json:"type"`
+		Parameters struct {
+			RequiredStatusChecks []struct {
+				Context string `json:"context"`
+			} `json:"required_status_checks"`
+		} `json:"parameters"`
+	}
+	if err := h.apiJSON(ctx, "repos/"+repo+"/rules/branches/"+branch, &rules); err != nil {
+		return nil, false
+	}
+	for _, rule := range rules {
+		if rule.Type == "workflows" {
+			return nil, false
+		}
+		if rule.Type != "required_status_checks" {
+			continue
+		}
+		for _, check := range rule.Parameters.RequiredStatusChecks {
+			if check.Context != "" {
+				required[check.Context] = true
+			}
+		}
+	}
+	return required, true
+}
+
+func isUnprotectedBranchError(err error) bool {
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "branch not protected") || strings.Contains(message, "status: 404")
 }
 
 func (h *Host) GetMergeableState(ctx context.Context, pr *scm.PR) (scm.MergeableState, error) {

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os/exec"
 	"reflect"
 	"strings"
@@ -255,11 +256,21 @@ func (h *Host) UpdatePR(ctx context.Context, pr *scm.PR, content scm.PRContent) 
 
 func (h *Host) GetPRState(ctx context.Context, pr *scm.PR) (scm.PRState, error) {
 	args := append([]string{"pr", "view", pr.Number}, h.repoArgs()...)
-	args = append(args, "--json", "state", "--jq", ".state")
+	args = append(args, "--json", "state,headRefOid")
 	cmd := h.cmd(ctx, "gh", args...)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("gh pr view: %w", err)
+	}
+	var view struct {
+		State      string `json:"state"`
+		HeadRefOID string `json:"headRefOid"`
+	}
+	if err := json.Unmarshal(out, &view); err == nil {
+		if view.HeadRefOID != "" {
+			pr.HeadSHA = view.HeadRefOID
+		}
+		return normalizePRState(view.State), nil
 	}
 	return normalizePRState(strings.TrimSpace(string(out))), nil
 }
@@ -452,13 +463,14 @@ func parseGitHubTime(value string) time.Time {
 
 func (h *Host) requiredStatusContexts(ctx context.Context, repo, branch string) (map[string]bool, bool) {
 	required := map[string]bool{}
+	escapedBranch := url.PathEscape(branch)
 	var protection struct {
 		Contexts []string `json:"contexts"`
 		Checks   []struct {
 			Context string `json:"context"`
 		} `json:"checks"`
 	}
-	if err := h.apiJSON(ctx, "repos/"+repo+"/branches/"+branch+"/protection/required_status_checks", &protection); err != nil {
+	if err := h.apiJSON(ctx, "repos/"+repo+"/branches/"+escapedBranch+"/protection/required_status_checks", &protection); err != nil {
 		if !isUnprotectedBranchError(err) {
 			return nil, false
 		}
@@ -481,7 +493,7 @@ func (h *Host) requiredStatusContexts(ctx context.Context, repo, branch string) 
 			} `json:"required_status_checks"`
 		} `json:"parameters"`
 	}
-	if err := h.apiJSONPages(ctx, "repos/"+repo+"/rules/branches/"+branch, &rulePages); err != nil {
+	if err := h.apiJSONPages(ctx, "repos/"+repo+"/rules/branches/"+escapedBranch, &rulePages); err != nil {
 		return nil, false
 	}
 	for _, rules := range rulePages {

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -280,6 +280,23 @@ func TestGetChecksFailsClosedWhenProtectionCannotBeRead(t *testing.T) {
 	}
 }
 
+func TestGetChecksFailsClosedWhenProtectionReturnsArbitrary404(t *testing.T) {
+	t.Parallel()
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		"gh api repos/test/repo/branches/main/protection/required_status_checks": {stderr: "HTTP 404: resource unavailable", code: 1},
+		"gh api --paginate repos/test/repo/commits/abc/check-runs?per_page=100":  {stdout: `{"check_runs":[]}` + "\n"},
+		"gh api --paginate repos/test/repo/commits/abc/statuses?per_page=100":    {stdout: "[]\n"},
+	}), nil, "", "test/repo")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{HeadSHA: "abc", BaseBranch: "main"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(checks) != 1 || !checks[0].BlocksPending || !checks[0].Pending() {
+		t.Fatalf("checks = %+v, want fail-closed blocking policy check", checks)
+	}
+}
+
 func TestGetChecksReadsEveryPaginatedNativeCheckPage(t *testing.T) {
 	t.Parallel()
 	host := New(githubTestCmdFactory(map[string]githubTestResponse{

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -220,7 +220,7 @@ func TestGetChecksMarksOnlyUnprotectedLinklessLegacyPendingAsAdvisory(t *testing
 	t.Parallel()
 	host := New(githubTestCmdFactory(map[string]githubTestResponse{
 		"gh api repos/test/repo/branches/main/protection/required_status_checks": {stderr: "Branch not protected", code: 1},
-		"gh api repos/test/repo/rules/branches/main":                             {stdout: "[]\n"},
+		"gh api --paginate repos/test/repo/rules/branches/main":                  {stdout: "[]\n"},
 		"gh api --paginate repos/test/repo/commits/abc/check-runs?per_page=100":  {stdout: `{"check_runs":[{"name":"unit","status":"completed","conclusion":"success"}]}` + "\n"},
 		"gh api --paginate repos/test/repo/commits/abc/statuses?per_page=100":    {stdout: `[{"context":"CodeRabbit","state":"pending","target_url":null}]` + "\n"},
 	}), nil, "", "test/repo")
@@ -249,7 +249,7 @@ func TestGetChecksKeepsProtectedOrLinkedLegacyPendingBlocking(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			host := New(githubTestCmdFactory(map[string]githubTestResponse{
 				"gh api repos/test/repo/branches/main/protection/required_status_checks": {stdout: tc.protection + "\n"},
-				"gh api repos/test/repo/rules/branches/main":                             {stdout: "[]\n"},
+				"gh api --paginate repos/test/repo/rules/branches/main":                  {stdout: "[]\n"},
 				"gh api --paginate repos/test/repo/commits/abc/check-runs?per_page=100":  {stdout: `{"check_runs":[]}` + "\n"},
 				"gh api --paginate repos/test/repo/commits/abc/statuses?per_page=100":    {stdout: `[{"context":"CodeRabbit","state":"pending","target_url":"` + tc.targetURL + `"}]` + "\n"},
 			}), nil, "", "test/repo")
@@ -284,7 +284,7 @@ func TestGetChecksReadsEveryPaginatedNativeCheckPage(t *testing.T) {
 	t.Parallel()
 	host := New(githubTestCmdFactory(map[string]githubTestResponse{
 		"gh api repos/test/repo/branches/main/protection/required_status_checks": {stderr: "Branch not protected", code: 1},
-		"gh api repos/test/repo/rules/branches/main":                             {stdout: "[]\n"},
+		"gh api --paginate repos/test/repo/rules/branches/main":                  {stdout: "[]\n"},
 		"gh api --paginate repos/test/repo/commits/abc/check-runs?per_page=100":  {stdout: `{"check_runs":[]}` + "\n" + `{"check_runs":[{"name":"late-pending","status":"in_progress","conclusion":null}]}` + "\n"},
 		"gh api --paginate repos/test/repo/commits/abc/statuses?per_page=100":    {stdout: "[]\n"},
 	}), nil, "", "test/repo")
@@ -301,7 +301,7 @@ func TestGetChecksFailsClosedForWorkflowRules(t *testing.T) {
 	t.Parallel()
 	host := New(githubTestCmdFactory(map[string]githubTestResponse{
 		"gh api repos/test/repo/branches/main/protection/required_status_checks": {stderr: "Branch not protected", code: 1},
-		"gh api repos/test/repo/rules/branches/main":                             {stdout: `[{"type":"workflows","parameters":{}}]` + "\n"},
+		"gh api --paginate repos/test/repo/rules/branches/main":                  {stdout: `[{"type":"workflows","parameters":{}}]` + "\n"},
 		"gh api --paginate repos/test/repo/commits/abc/check-runs?per_page=100":  {stdout: `{"check_runs":[]}` + "\n"},
 		"gh api --paginate repos/test/repo/commits/abc/statuses?per_page=100":    {stdout: "[]\n"},
 	}), nil, "", "test/repo")
@@ -311,6 +311,27 @@ func TestGetChecksFailsClosedForWorkflowRules(t *testing.T) {
 	}
 	if len(checks) != 1 || checks[0].Name != "GitHub required-check policy unresolved" || !checks[0].Pending() {
 		t.Fatalf("checks = %+v, want fail-closed policy pending", checks)
+	}
+}
+
+func TestGetChecksReadsEveryPaginatedBranchRulePage(t *testing.T) {
+	t.Parallel()
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		"gh api repos/test/repo/branches/main/protection/required_status_checks": {stderr: "Branch not protected", code: 1},
+		"gh api --paginate repos/test/repo/rules/branches/main": {
+			stdout: `[{"type":"pull_request","parameters":{}}]` + "\n" +
+				`[{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"CodeRabbit"}]}}]` + "\n",
+		},
+		"gh api --paginate repos/test/repo/commits/abc/check-runs?per_page=100": {stdout: `{"check_runs":[]}` + "\n"},
+		"gh api --paginate repos/test/repo/commits/abc/statuses?per_page=100":   {stdout: `[{"context":"CodeRabbit","state":"pending","target_url":null}]` + "\n"},
+	}), nil, "", "test/repo")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{HeadSHA: "abc", BaseBranch: "main"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(checks) != 1 || checks[0].Name != "CodeRabbit" || !checks[0].BlocksPending || !checks[0].Pending() {
+		t.Fatalf("checks = %+v, want late-page required legacy pending check", checks)
 	}
 }
 

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -216,6 +216,104 @@ func TestGetChecksParsesCompletedAt(t *testing.T) {
 	}
 }
 
+func TestGetChecksMarksOnlyUnprotectedLinklessLegacyPendingAsAdvisory(t *testing.T) {
+	t.Parallel()
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		"gh api repos/test/repo/branches/main/protection/required_status_checks": {stderr: "Branch not protected", code: 1},
+		"gh api repos/test/repo/rules/branches/main":                             {stdout: "[]\n"},
+		"gh api --paginate repos/test/repo/commits/abc/check-runs?per_page=100":  {stdout: `{"check_runs":[{"name":"unit","status":"completed","conclusion":"success"}]}` + "\n"},
+		"gh api --paginate repos/test/repo/commits/abc/statuses?per_page=100":    {stdout: `[{"context":"CodeRabbit","state":"pending","target_url":null}]` + "\n"},
+	}), nil, "", "test/repo")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123", HeadSHA: "abc", BaseBranch: "main"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(checks) != 2 {
+		t.Fatalf("checks = %+v, want native + legacy", checks)
+	}
+	if checks[0].Source != scm.CheckSourceNative || !checks[0].BlocksPending {
+		t.Fatalf("native check = %+v, want blocking native provenance", checks[0])
+	}
+	if checks[1].Source != scm.CheckSourceLegacy || checks[1].BlocksPending || checks[1].Pending() {
+		t.Fatalf("ghost legacy check = %+v, want non-blocking advisory", checks[1])
+	}
+}
+
+func TestGetChecksKeepsProtectedOrLinkedLegacyPendingBlocking(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct{ name, protection, targetURL string }{
+		{"protected", `{"contexts":["CodeRabbit"]}`, ""},
+		{"linked", `{"contexts":[]}`, "https://example.test/review"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			host := New(githubTestCmdFactory(map[string]githubTestResponse{
+				"gh api repos/test/repo/branches/main/protection/required_status_checks": {stdout: tc.protection + "\n"},
+				"gh api repos/test/repo/rules/branches/main":                             {stdout: "[]\n"},
+				"gh api --paginate repos/test/repo/commits/abc/check-runs?per_page=100":  {stdout: `{"check_runs":[]}` + "\n"},
+				"gh api --paginate repos/test/repo/commits/abc/statuses?per_page=100":    {stdout: `[{"context":"CodeRabbit","state":"pending","target_url":"` + tc.targetURL + `"}]` + "\n"},
+			}), nil, "", "test/repo")
+			checks, err := host.GetChecks(context.Background(), &scm.PR{HeadSHA: "abc", BaseBranch: "main"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(checks) != 1 || !checks[0].BlocksPending || !checks[0].Pending() {
+				t.Fatalf("checks = %+v, want blocking legacy pending", checks)
+			}
+		})
+	}
+}
+
+func TestGetChecksFailsClosedWhenProtectionCannotBeRead(t *testing.T) {
+	t.Parallel()
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		"gh api repos/test/repo/branches/main/protection/required_status_checks": {stderr: "HTTP 403", code: 1},
+		"gh api --paginate repos/test/repo/commits/abc/check-runs?per_page=100":  {stdout: `{"check_runs":[]}` + "\n"},
+		"gh api --paginate repos/test/repo/commits/abc/statuses?per_page=100":    {stdout: "[]\n"},
+	}), nil, "", "test/repo")
+	checks, err := host.GetChecks(context.Background(), &scm.PR{HeadSHA: "abc", BaseBranch: "main"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(checks) != 1 || !checks[0].BlocksPending || !checks[0].Pending() {
+		t.Fatalf("checks = %+v, want fail-closed blocking legacy pending", checks)
+	}
+}
+
+func TestGetChecksReadsEveryPaginatedNativeCheckPage(t *testing.T) {
+	t.Parallel()
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		"gh api repos/test/repo/branches/main/protection/required_status_checks": {stderr: "Branch not protected", code: 1},
+		"gh api repos/test/repo/rules/branches/main":                             {stdout: "[]\n"},
+		"gh api --paginate repos/test/repo/commits/abc/check-runs?per_page=100":  {stdout: `{"check_runs":[]}` + "\n" + `{"check_runs":[{"name":"late-pending","status":"in_progress","conclusion":null}]}` + "\n"},
+		"gh api --paginate repos/test/repo/commits/abc/statuses?per_page=100":    {stdout: "[]\n"},
+	}), nil, "", "test/repo")
+	checks, err := host.GetChecks(context.Background(), &scm.PR{HeadSHA: "abc", BaseBranch: "main"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(checks) != 1 || checks[0].Name != "late-pending" || !checks[0].Pending() {
+		t.Fatalf("checks = %+v, want page-two pending check", checks)
+	}
+}
+
+func TestGetChecksFailsClosedForWorkflowRules(t *testing.T) {
+	t.Parallel()
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		"gh api repos/test/repo/branches/main/protection/required_status_checks": {stderr: "Branch not protected", code: 1},
+		"gh api repos/test/repo/rules/branches/main":                             {stdout: `[{"type":"workflows","parameters":{}}]` + "\n"},
+		"gh api --paginate repos/test/repo/commits/abc/check-runs?per_page=100":  {stdout: `{"check_runs":[]}` + "\n"},
+		"gh api --paginate repos/test/repo/commits/abc/statuses?per_page=100":    {stdout: "[]\n"},
+	}), nil, "", "test/repo")
+	checks, err := host.GetChecks(context.Background(), &scm.PR{HeadSHA: "abc", BaseBranch: "main"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(checks) != 1 || checks[0].Name != "GitHub required-check policy unresolved" || !checks[0].Pending() {
+		t.Fatalf("checks = %+v, want fail-closed policy pending", checks)
+	}
+}
+
 func TestFetchFailedCheckLogsSelectsMatchingRunForHeadSHA(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -106,17 +106,21 @@ func TestGetPRStatePassesRepoFlag(t *testing.T) {
 	t.Parallel()
 
 	host := New(githubTestCmdFactory(map[string]githubTestResponse{
-		"gh pr view 123 --repo test/repo --json state --jq .state": {
-			stdout: "MERGED\n",
+		"gh pr view 123 --repo test/repo --json state,headRefOid": {
+			stdout: `{"state":"MERGED","headRefOid":"abc123"}` + "\n",
 		},
 	}), nil, "", "test/repo")
 
-	state, err := host.GetPRState(context.Background(), &scm.PR{Number: "123"})
+	pr := &scm.PR{Number: "123"}
+	state, err := host.GetPRState(context.Background(), pr)
 	if err != nil {
 		t.Fatalf("GetPRState() error = %v", err)
 	}
 	if state != scm.PRStateMerged {
 		t.Fatalf("GetPRState() = %q, want %q", state, scm.PRStateMerged)
+	}
+	if pr.HeadSHA != "abc123" {
+		t.Fatalf("GetPRState() HeadSHA = %q, want %q", pr.HeadSHA, "abc123")
 	}
 }
 
@@ -261,6 +265,24 @@ func TestGetChecksKeepsProtectedOrLinkedLegacyPendingBlocking(t *testing.T) {
 				t.Fatalf("checks = %+v, want blocking legacy pending", checks)
 			}
 		})
+	}
+}
+
+func TestGetChecksEscapesPolicyBranchPaths(t *testing.T) {
+	t.Parallel()
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		"gh api repos/test/repo/branches/release%2F1.0/protection/required_status_checks": {stderr: "Branch not protected", code: 1},
+		"gh api --paginate repos/test/repo/rules/branches/release%2F1.0":                  {stdout: "[]\n"},
+		"gh api --paginate repos/test/repo/commits/abc/check-runs?per_page=100":           {stdout: `{"check_runs":[]}` + "\n"},
+		"gh api --paginate repos/test/repo/commits/abc/statuses?per_page=100":             {stdout: "[]\n"},
+	}), nil, "", "test/repo")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{HeadSHA: "abc", BaseBranch: "release/1.0"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(checks) != 0 {
+		t.Fatalf("checks = %+v, want no checks", checks)
 	}
 }
 

--- a/internal/scm/host.go
+++ b/internal/scm/host.go
@@ -87,8 +87,10 @@ func ExtractPRNumber(prURL string) (string, error) {
 
 // PR identifies a pull/merge request on a provider.
 type PR struct {
-	Number string
-	URL    string
+	Number     string
+	URL        string
+	HeadSHA    string
+	BaseBranch string
 }
 
 // PRContent is the title + body for creating or updating a PR.
@@ -135,18 +137,35 @@ const (
 	CheckBucketSkip    CheckBucket = "skipping"
 )
 
+// CheckSource preserves where a GitHub result originated. Native check runs
+// and legacy commit statuses have different safety semantics while pending.
+type CheckSource string
+
+const (
+	CheckSourceUnknown CheckSource = "unknown"
+	CheckSourceNative  CheckSource = "native"
+	CheckSourceLegacy  CheckSource = "legacy"
+)
+
 // Check is a single CI check result on a PR.
 type Check struct {
 	Name        string
 	Bucket      CheckBucket
 	CompletedAt time.Time // zero when unknown; used to detect CI re-runs between polls
+	Source      CheckSource
+	// BlocksPending is false only when a provider has positively established
+	// that this pending result cannot be a required check. The zero value is
+	// intentionally conservative for providers that do not expose provenance.
+	BlocksPending bool
 }
 
 // Failing reports whether the check is in a failed bucket.
 func (c Check) Failing() bool { return c.Bucket == CheckBucketFail }
 
 // Pending reports whether the check is still running or queued.
-func (c Check) Pending() bool { return c.Bucket == CheckBucketPending }
+func (c Check) Pending() bool {
+	return c.Bucket == CheckBucketPending && (c.Source != CheckSourceLegacy || c.BlocksPending)
+}
 
 // Capabilities declares which optional Host methods return meaningful data.
 // Callers must consult Capabilities before invoking optional methods.

--- a/internal/scm/host_test.go
+++ b/internal/scm/host_test.go
@@ -49,6 +49,7 @@ func TestCheckBucketHelpers(t *testing.T) {
 		{"pass", Check{Bucket: CheckBucketPass}, false, false},
 		{"fail", Check{Bucket: CheckBucketFail}, true, false},
 		{"pending", Check{Bucket: CheckBucketPending}, false, true},
+		{"advisory legacy pending", Check{Bucket: CheckBucketPending, Source: CheckSourceLegacy, BlocksPending: false}, false, false},
 		{"cancel", Check{Bucket: CheckBucketCancel}, false, false},
 		{"skip", Check{Bucket: CheckBucketSkip}, false, false},
 	}


### PR DESCRIPTION
## What Changed

- Track GitHub PR head provenance through CI polling and auto-fix pushes; pause the run when an external head change is detected.
- Query paginated native Check Runs and legacy commit statuses separately, treating legacy pending statuses as advisory only when GitHub policy confirms they are not required.
- Fail closed when GitHub branch-protection or ruleset policy cannot be resolved, URL-escape default branch names in policy requests, and document the CI behavior.

## Risk Assessment

⚠️ Medium: Der aktuelle Fix parkt nun sicher bei externen PR-Head-Wechseln; die Änderung bleibt jedoch wegen der zusätzlichen GitHub-Provenienz- und API-Fallback-Pfade komplex.

## Testing

Completed 1 recorded test check.

- Outcome: 🔧 1 issue found → auto-fixed (2) ✅ across 3 runs (16m7s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (2) ✅</summary>

- 🚨 `internal/pipeline/steps/ci.go:299` - Der Monitor fragt bei jedem Poll nur den in der Run-Datenbank gespeicherten SHA ab. Wird der offene PR danach extern von H1 auf H2 aktualisiert, können die grünen Checks von H1 weiterhin `CIReady` setzen, obwohl H2 noch läuft oder fehlschlägt. Den aktuellen `headRefOid` des PR pro Poll lesen und bei Abweichung die Readiness löschen bzw. den fremden Head explizit behandeln.
- ⚠️ `internal/scm/github/github.go:461` - `BaseBranch` wird roh in beide GitHub-REST-Pfade eingesetzt. Ein gültiger Default-Branch wie `release/1.0` wird als mehrere Pfadsegmente interpretiert; die Policy-Abfragen schlagen fehl und der synthetische Pending-Check hält CI bis zum Timeout offen. Den Branch einmal mit `url.PathEscape` kodieren und für beide Endpunkte verwenden.

🔧 Fix: Fix CI head provenance and GitHub policy URL escaping
2 issues (1 error, 1 warning) still open:
- 🚨 `internal/pipeline/steps/ci.go:275` - Die GitHub-Provenienz bindet `pr.HeadSHA` nach einem eigenen Fix-Push nicht mehr an den neuen Run-Head. Falls `GetPRState` den Plaintext-Fallback nutzt und kein `headRefOid` schreibt, bleibt `pr.HeadSHA` auf H1, obwohl `sctx.Run.HeadSHA` auf H2 steigt; `GetChecks` fragt danach weiter H1 ab und kann falsche Fixes oder Readiness liefern. Den lokal gepushten SHA nach dem Push in das PR-Objekt propagieren, ohne einen frisch gemeldeten Remote-Head zu überschreiben.
- ⚠️ `internal/pipeline/steps/ci.go:276` - Bei einem erkannten externen PR-Head-Wechsel wird nur die Readiness gelöscht; anschließend läuft der Monitor mit demselben lokalen Worktree und `sctx.Run.HeadSHA` weiter in `autoFixCI`. Fehler des neuen Remote-Heads können dadurch Agent-Prompts und Logs für den alten Commit verwenden und stale lokale Änderungen erzeugen. Nach einem fremden Head sollte der Monitor vor Auto-Fix parken/abbrechen oder den Worktree ausdrücklich auf diesen Head synchronisieren.

🔧 Fix: Park CI when PR head changes externally
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 tests failed with exit code 1
- `go test -race ./...`

🔧 Fix: Refresh CI head after autofix pushes
1 error still open:
- 🚨 tests failed with exit code 1
- `go test -race ./...`

🔧 Fix: Preserve CI retry guard after own pushes
✅ Re-checked - no issues remain.
- `go test -race ./...`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
