### PR TITLE
Harden No Mistakes core reliability and routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,12 @@ Safest local verification sequence after non-trivial changes:
 - `codex exec resume` has a narrower flag surface than `codex exec`, so an unsupported override fails the resume and falls back; the e2e fakeagent must keep parsing both codex argv shapes (`extractCodexPrompt`).
 - Regressions: `internal/pipeline/sessions_test.go`, `internal/pipeline/steps/review_session_test.go`, `internal/agent/session_test.go`.
 
+**Routing Evidence & Recovery**
+
+- `route_decisions` is immutable pre-launch evidence recorded once per concrete adapter attempt; `route_results` is immutable post-result evidence for completed review classifications. Approval-gate recovery must prefer the latest valid review result so risk upgrades, downgrades, and high-risk confirmation eligibility survive restart.
+- Effective model/effort fields describe only controls the concrete adapter actually received. Non-Codex attempts keep them empty, fallback rows are attributed to each attempted adapter, and a Codex-effective route fails closed before an unenforceable fallback launches. Inspect both evidence streams through the read-only `no-mistakes axi route-evidence` surface.
+- Regressions: `internal/pipeline/executor_auth_test.go`, `internal/pipeline/executor_perf_test.go`, `internal/routing/routing_test.go`, `internal/cli/axi_route_test.go`, and e2e `TestAxiAgentJourney`.
+
 **Review Fixer Verification Discipline (`internal/pipeline/steps/review.go`)**
 
 - The review-fix prompt requires all fixes before one focused verification limited to the changed area and forbids the whole repository test/lint suite during the fix round.

--- a/cmd/fakeagent/claude.go
+++ b/cmd/fakeagent/claude.go
@@ -4,11 +4,21 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
+	"strings"
 )
 
 func runClaude(args []string, scenario *Scenario) int {
 	prompt := extractClaudePrompt(args)
+	if prompt == "" {
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "fakeagent: read stdin prompt: %v\n", err)
+			return 1
+		}
+		prompt = string(data)
+	}
 	logInvocation("claude", prompt, args)
 
 	action := scenario.Match(prompt)
@@ -230,6 +240,9 @@ func extractClaudePrompt(args []string) string {
 		switch args[i] {
 		case "-p", "--print":
 			if i+1 < len(args) {
+				if strings.HasPrefix(args[i+1], "-") {
+					return ""
+				}
 				return args[i+1]
 			}
 			return ""

--- a/cmd/fakeagent/claude_test.go
+++ b/cmd/fakeagent/claude_test.go
@@ -6,6 +6,12 @@ import (
 	"testing"
 )
 
+func TestExtractClaudePromptRecognizesStdinTransport(t *testing.T) {
+	if got := extractClaudePrompt([]string{"-p", "--verbose", "--output-format", "stream-json"}); got != "" {
+		t.Fatalf("prompt = %q, want empty for stdin transport", got)
+	}
+}
+
 func TestPatchClaudeFixtureStructuredRunRewritesAssistantText(t *testing.T) {
 	t.Helper()
 

--- a/cmd/fakeagent/codex.go
+++ b/cmd/fakeagent/codex.go
@@ -4,12 +4,21 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 )
 
 func runCodex(args []string, scenario *Scenario) int {
 	prompt := extractCodexPrompt(args)
+	if prompt == "" {
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "fakeagent: read stdin prompt: %v\n", err)
+			return 1
+		}
+		prompt = string(data)
+	}
 	logInvocation("codex", prompt, args)
 
 	action := scenario.Match(prompt)
@@ -184,7 +193,7 @@ func extractCodexPrompt(args []string) string {
 		"--config": true, "--profile": true,
 		"--output-schema":    true,
 		"--reasoning-effort": true, "--reasoning-summary": true,
-		"-c": true, "--cd": true,
+		"-c": true, "--cd": true, "--color": true,
 	}
 	start := 0
 	for i, a := range args {

--- a/cmd/fakeagent/codex_test.go
+++ b/cmd/fakeagent/codex_test.go
@@ -196,3 +196,14 @@ func TestExtractCodexPromptSkipsOutputSchemaValue(t *testing.T) {
 		t.Fatalf("prompt = %q, want %q", got, "review this diff")
 	}
 }
+
+func TestExtractCodexPromptRecognizesStdinTransport(t *testing.T) {
+	args := []string{
+		"exec", "--json", "--output-schema", "/tmp/schema.json",
+		"--dangerously-bypass-approvals-and-sandbox", "--color", "never",
+		"-m", "gpt-5.6-luna", "-c", "model_reasoning_effort=xhigh",
+	}
+	if got := extractCodexPrompt(args); got != "" {
+		t.Fatalf("prompt = %q, want empty for stdin transport", got)
+	}
+}

--- a/cmd/fakeagent/scenario.go
+++ b/cmd/fakeagent/scenario.go
@@ -91,6 +91,7 @@ func defaultScenario() *Scenario {
 				"risk_rationale":  "no risks detected in the diff",
 				"tested":          []string{"fakeagent: simulated test run"},
 				"testing_summary": "simulated tests passed",
+				"artifacts":       []any{},
 				"title":           "feat: fakeagent change",
 				"body":            "## Summary\nfakeagent canned PR body",
 			},

--- a/docs/src/content/docs/concepts/daemon.md
+++ b/docs/src/content/docs/concepts/daemon.md
@@ -75,10 +75,31 @@ As an independent safety layer, the daemon also refuses to bind the Unix socket 
 
 When a push arrives via the post-receive hook:
 
-1. Creates a detached worktree at `~/.no-mistakes/worktrees/<repoID>/<runID>/`
-2. Starts the pipeline executor in that worktree
-3. Streams events to any connected TUI clients and serves request/response state to AXI clients
-4. Cleans up the worktree when the run finishes (success or failure)
+1. Records the run and queues detached-worktree provisioning
+2. Provisions a detached worktree at `~/.no-mistakes/worktrees/<repoID>/<runID>/` in a bounded background worker
+3. Starts the pipeline executor after provisioning completes
+4. Streams events to any connected TUI clients and serves request/response state to AXI clients
+5. Cleans up the worktree when the run finishes (success or failure)
+
+Run creation returns after the provisioning request is persisted; `axi status`
+shows the durable provisioning phase and progress while a slow checkout is in
+flight. Cancellation stops queued or active provisioning, and a daemon restart
+re-queues unfinished provisioning after removing only its partial worktree.
+
+Agent routing is owned by No Mistakes and is independent of repository-owned
+manifests or any external project router. The default and initial phases use
+GPT-5.6 Luna with `xhigh`; medium/high-risk non-review phases use GPT-5.6 Terra
+with `high`; GPT-5.6 Sol with `high` is eligible only for a review confirmation
+after the initial review has classified the change as high risk. Each invocation
+stores its requested/effective route, policy generation, phase, reason, and
+bounded source fingerprint in the local database.
+
+If Codex reports `AuthorizationRequired`, the run is parked with an explicit
+authentication blockage instead of being mislabeled as an ordinary agent
+failure or daemon shutdown. Log into the intended Codex account, then approve
+the parked gate with `no-mistakes axi respond --action approve`. The failure and
+subsequent recovery remain in the append-only lifecycle event history; an
+unknown-completion fixer turn is never blindly replayed by crash recovery.
 
 Pipeline agents are prompted to keep intentional writes inside that detached worktree and avoid changing system state outside it, such as Homebrew packages, apps under `/Applications`, or global tool configuration.
 That reduces surprising machine-level side effects and macOS App Management prompts, but it is prompt steering rather than a true sandbox.
@@ -100,7 +121,9 @@ reason about in one long-lived process than inside independent hook invocations.
 
 ## Crash recovery
 
-On startup, the daemon checks for runs that were left in `pending` or `running` status (which means the daemon crashed while they were active):
+On startup, the daemon checks for runs that were left in `pending`, `provisioning`,
+`running`, or `awaiting_auth` status (which means the daemon crashed while they
+were active):
 
 - Resumes only fully recorded parked approval gates whose worktree and step history can be validated; incomplete or ambiguous active runs fail closed
 - Before resuming a parked CI gate, re-checks its persisted PR URL through the configured provider; a currently merged or closed PR completes the stale gate, while an open, unknown, or unreachable PR remains parked
@@ -111,6 +134,7 @@ On startup, the daemon checks for runs that were left in `pending` or `running` 
 - Reapplies per-worktree gate hook-path isolation to existing bare repos when Git supports `config --worktree`, so shared `core.hookspath` writes cannot disable `post-receive`
 - Enables Git push-option support on existing gate repos so per-push options like `no-mistakes.skip=...` keep working after upgrades
 - Clears any parked-awaiting-agent marker so a recovered failed run is not shown as still waiting for `axi respond`
+- Preserves authorization-blocked runs and their worktrees for explicit recovery; it never replays an agent turn solely because the daemon restarted
 
 ## Logging
 

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -250,6 +250,7 @@ Spawns a `codex` subprocess for each invocation with `exec --json`. When structu
 Codex model and config overrides, such as `-m gpt-5.4`, `-c service_tier="priority"`, or `-c model_reasoning_effort="low"`, belong in global `agent_args_override.codex`.
 For review-loop reuse, Codex resumes the reported thread with `codex exec resume <id> <prompt>`.
 That resume command has a narrower flag surface than `codex exec`, so a resume that rejects an override falls back to a fresh same-role session rather than skipping the review turn.
+No Mistakes supplies the phase-aware policy route for each invocation: Luna/`xhigh` for initial/default work, Terra/`high` for medium/high-risk non-review work, and Sol/`high` only for a high-risk review confirmation after the initial review classification. Full prompts are transported through stdin; they are not placed in process argv. If Codex returns `AuthorizationRequired`, the run parks for explicit account recovery and approval rather than replaying an unknown-completion fixer turn.
 
 ## Rovo Dev
 

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -248,7 +248,7 @@ For review-loop reuse, Claude starts a stream-json session and resumes it with `
 
 Spawns a `codex` subprocess for each invocation with `exec --json`. When structured output is requested, no-mistakes also writes a normalized schema file and passes it with `--output-schema`. By default it also adds `--dangerously-bypass-approvals-and-sandbox`, unless you already set your own Codex approval or sandbox flag through `agent_args_override`. Reads JSONL events. Structured output is returned from the final `agent_message` text, with fallback parsing that accepts JSON fences, inline fence markers, or a final bare JSON object after prose, then validates the result against the normalized schema.
 Codex model and config overrides, such as `-m gpt-5.4`, `-c service_tier="priority"`, or `-c model_reasoning_effort="low"`, belong in global `agent_args_override.codex`.
-For review-loop reuse, Codex resumes the reported thread with `codex exec resume <id> <prompt>`.
+For review-loop reuse, Codex resumes the reported thread with `codex exec resume <id> -` and reads the prompt from stdin.
 That resume command has a narrower flag surface than `codex exec`, so a resume that rejects an override falls back to a fresh same-role session rather than skipping the review turn.
 No Mistakes supplies the phase-aware policy route for each invocation: Luna/`xhigh` for initial/default work, Terra/`high` for medium/high-risk non-review work, and Sol/`high` only for a high-risk review confirmation after the initial review classification. Full prompts are transported through stdin; they are not placed in process argv. If Codex returns `AuthorizationRequired`, the run parks for explicit account recovery and approval rather than replaying an unknown-completion fixer turn.
 

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -162,7 +162,24 @@ No Mistakes owns routing in core and records a bounded routing generation with e
    grep -q 'nm-routing-v2' "$CANARY_ROOT/route-evidence.toon"
    grep -q 'gpt-5.6-luna' "$CANARY_ROOT/route-evidence.toon"
    grep -q 'xhigh' "$CANARY_ROOT/route-evidence.toon"
-   grep -q 'configuration_generation' "$CANARY_ROOT/route-evidence.toon"
+   awk -F',' '
+     /^route_decisions\[1\]\{/ {
+       header = $0
+       sub(/^.*\{/, "", header)
+       sub(/\}:$/, "", header)
+       column_count = split(header, columns, ",")
+       for (i = 1; i <= column_count; i++) {
+         if (columns[i] == "configuration_generation") generation_column = i
+       }
+       next
+     }
+     generation_column && /^[[:space:]]/ {
+       generation = $generation_column
+       gsub(/^["[:space:]]+|["[:space:]]+$/, "", generation)
+       if (generation ~ /^[0-9a-f]{24}$/) found = 1
+     }
+     END { exit found ? 0 : 1 }
+   ' "$CANARY_ROOT/route-evidence.toon"
    test -s "$CANARY_INVOCATIONS"
    ```
    Inspect `route_decisions` for the requested/effective harness, model, effort, `policy_version`, and `configuration_generation`, and inspect `review_results` for the completed classification. Codex rows should show the No Mistakes GPT policy; non-Codex rows must leave effective model and effort empty. The output must contain no external router name or process. This is a real agent invocation inside the disposable repository, not a log-only daemon check.

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -109,22 +109,30 @@ No Mistakes owns routing in core and records a bounded routing generation with e
    no-mistakes runs
    ```
 2. Let pending or running pipeline runs finish. `daemon restart` and `update` refuse by default while active runs exist; do not pass `--force` for this migration path.
-3. Canary the new binary from an isolated home before touching the shared daemon:
+3. Create named temporary homes once, then canary the new binary against those exact paths before touching the shared daemon:
    ```sh
-   NM_HOME="$(mktemp -d)" HOME="$(mktemp -d)" /path/to/new/no-mistakes doctor
-   NM_HOME="$(mktemp -d)" HOME="$(mktemp -d)" /path/to/new/no-mistakes daemon start
+   CANARY_HOME="$(mktemp -d)"
+   CANARY_NM_HOME="$(mktemp -d)"
+   HOME="$CANARY_HOME" NM_HOME="$CANARY_NM_HOME" /path/to/new/no-mistakes doctor
+   HOME="$CANARY_HOME" NM_HOME="$CANARY_NM_HOME" /path/to/new/no-mistakes daemon start
    ```
-4. Verify the canary daemon does not invoke the removed router by checking its local logs and route evidence:
+4. Verify the exact canary daemon does not invoke the removed router by checking its local logs and route evidence:
    ```sh
-   NM_HOME=<canary-home> /path/to/new/no-mistakes daemon status
-   grep -R "Flow" "$NM_HOME/logs" || true
+   HOME="$CANARY_HOME" NM_HOME="$CANARY_NM_HOME" /path/to/new/no-mistakes daemon status
+   grep -R "Flow" "$CANARY_NM_HOME/logs" || true
    ```
    Route decisions should show No Mistakes model/effort policy and a `configuration_generation`, not an external router path.
-5. Restart the real daemon only after the run list is drained:
+5. Stop the canary explicitly and remove both temporary homes before touching the active installation:
+   ```sh
+   HOME="$CANARY_HOME" NM_HOME="$CANARY_NM_HOME" /path/to/new/no-mistakes daemon stop || true
+   rm -rf "$CANARY_HOME" "$CANARY_NM_HOME"
+   unset CANARY_HOME CANARY_NM_HOME
+   ```
+6. Restart the real daemon only after the run list is drained:
    ```sh
    /path/to/new/no-mistakes daemon restart
    ```
-6. Roll back by running the previous exact binary's `daemon restart` after the same drain check. If active runs appear during rollback, stop and inspect them instead of forcing the restart.
+7. Roll back by running the previous exact binary's `daemon restart` after the same drain check. If active runs appear during rollback, stop and inspect them instead of forcing the restart.
 
 The only place Flow is relevant here is migration history: current No Mistakes routing must not depend on a Flow path, manifest, or process.
 

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -109,24 +109,47 @@ No Mistakes owns routing in core and records a bounded routing generation with e
    no-mistakes runs
    ```
 2. Let pending or running pipeline runs finish. `daemon restart` and `update` refuse by default while active runs exist; do not pass `--force` for this migration path.
-3. Create named temporary homes once, then canary the new binary against those exact paths before touching the shared daemon:
+3. Create a disposable repository, named temporary homes, and an explicit Codex binary path. The workload is isolated and skips every delivery step, so it cannot push, open a PR, or touch the shared daemon:
    ```sh
+   CANARY_ROOT="$(mktemp -d)"
+   CANARY_REPO="$CANARY_ROOT/repo"
+   CANARY_ORIGIN="$CANARY_ROOT/origin.git"
    CANARY_HOME="$(mktemp -d)"
    CANARY_NM_HOME="$(mktemp -d)"
-   HOME="$CANARY_HOME" NM_HOME="$CANARY_NM_HOME" /path/to/new/no-mistakes doctor
-   HOME="$CANARY_HOME" NM_HOME="$CANARY_NM_HOME" /path/to/new/no-mistakes daemon start
+   CANARY_CODEX="$(command -v codex)"
+   test -n "$CANARY_CODEX"
+   git init --bare --initial-branch=main "$CANARY_ORIGIN"
+   git init -b main "$CANARY_REPO"
+   git -C "$CANARY_REPO" config user.email canary@example.invalid
+   git -C "$CANARY_REPO" config user.name canary
+   printf 'route canary\n' > "$CANARY_REPO/README.md"
+   git -C "$CANARY_REPO" add README.md
+   git -C "$CANARY_REPO" commit -m 'canary: route evidence'
+   git -C "$CANARY_REPO" remote add origin "$CANARY_ORIGIN"
+   git -C "$CANARY_REPO" push origin main
+   git -C "$CANARY_REPO" switch -c route-canary
+   mkdir -p "$CANARY_NM_HOME"
+   cat > "$CANARY_NM_HOME/config.yaml" <<EOF
+   agent: codex
+   agent_path_override:
+     codex: $CANARY_CODEX
+   EOF
+   (cd "$CANARY_REPO" && HOME="$CANARY_HOME" NM_HOME="$CANARY_NM_HOME" /path/to/new/no-mistakes init)
    ```
-4. Verify the exact canary daemon does not invoke the removed router by checking its local logs and route evidence:
+4. Start the exact canary daemon, run one review-only workload, and inspect the supported route-evidence surface. The command defaults to the active or most recent run; pass `--run <id>` when auditing a specific one:
    ```sh
-   HOME="$CANARY_HOME" NM_HOME="$CANARY_NM_HOME" /path/to/new/no-mistakes daemon status
-   grep -R "Flow" "$CANARY_NM_HOME/logs" || true
+   (cd "$CANARY_REPO" && HOME="$CANARY_HOME" NM_HOME="$CANARY_NM_HOME" /path/to/new/no-mistakes daemon start)
+   (cd "$CANARY_REPO" && HOME="$CANARY_HOME" NM_HOME="$CANARY_NM_HOME" /path/to/new/no-mistakes axi run \
+     --intent 'verify the isolated route policy and evidence' \
+     --skip rebase,test,document,lint,push,pr,ci --yes)
+   (cd "$CANARY_REPO" && HOME="$CANARY_HOME" NM_HOME="$CANARY_NM_HOME" /path/to/new/no-mistakes axi route-evidence)
    ```
-   Route decisions should show No Mistakes model/effort policy and a `configuration_generation`, not an external router path.
+   Inspect `route_decisions` for the requested/effective harness, model, effort, `policy_version`, and `configuration_generation`, and inspect `review_results` for the completed classification. Codex rows should show the No Mistakes GPT policy; non-Codex rows must leave effective model and effort empty. The output must contain no external router name or process. This is a real agent invocation inside the disposable repository, not a log-only daemon check.
 5. Stop the canary explicitly and remove both temporary homes before touching the active installation:
    ```sh
-   HOME="$CANARY_HOME" NM_HOME="$CANARY_NM_HOME" /path/to/new/no-mistakes daemon stop || true
-   rm -rf "$CANARY_HOME" "$CANARY_NM_HOME"
-   unset CANARY_HOME CANARY_NM_HOME
+   (cd "$CANARY_REPO" && HOME="$CANARY_HOME" NM_HOME="$CANARY_NM_HOME" /path/to/new/no-mistakes daemon stop) || true
+   rm -rf "$CANARY_ROOT" "$CANARY_HOME" "$CANARY_NM_HOME"
+   unset CANARY_ROOT CANARY_REPO CANARY_ORIGIN CANARY_HOME CANARY_NM_HOME CANARY_CODEX
    ```
 6. Restart the real daemon only after the run list is drained:
    ```sh

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -111,13 +111,25 @@ No Mistakes owns routing in core and records a bounded routing generation with e
 2. Let pending or running pipeline runs finish. `daemon restart` and `update` refuse by default while active runs exist; do not pass `--force` for this migration path.
 3. Create a disposable repository, named temporary homes, and an explicit Codex binary path. The workload is isolated and skips every delivery step, so it cannot push, open a PR, or touch the shared daemon:
    ```sh
-   CANARY_ROOT="$(mktemp -d)"
+   CANARY_TMP_BASE="${TMPDIR:-/tmp}"
+   CANARY_TMP_BASE="${CANARY_TMP_BASE%/}"
+   CANARY_ROOT="$(mktemp -d "$CANARY_TMP_BASE/no-mistakes-route-canary.XXXXXX")"
    CANARY_REPO="$CANARY_ROOT/repo"
    CANARY_ORIGIN="$CANARY_ROOT/origin.git"
    CANARY_HOME="$(mktemp -d)"
    CANARY_NM_HOME="$(mktemp -d)"
-   CANARY_CODEX="$(command -v codex)"
-   test -n "$CANARY_CODEX"
+   CANARY_CODEX="$CANARY_ROOT/fake-codex"
+   CANARY_INVOCATIONS="$CANARY_ROOT/codex-invocations.log"
+   export CANARY_INVOCATIONS
+   cat > "$CANARY_CODEX" <<'EOF'
+   #!/bin/sh
+   set -eu
+   cat >/dev/null
+   printf '%s\n' invoked >> "$CANARY_INVOCATIONS"
+   printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"{\"findings\":[],\"tested\":[\"fake Codex canary\"],\"testing_summary\":\"passed\",\"risk_level\":\"low\",\"risk_rationale\":\"local canary\",\"risk_scope\":\"source-or-external\"}"}}'
+   printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":1,"cached_input_tokens":0,"output_tokens":1}}'
+   EOF
+   chmod 755 "$CANARY_CODEX"
    git init --bare --initial-branch=main "$CANARY_ORIGIN"
    git init -b main "$CANARY_REPO"
    git -C "$CANARY_REPO" config user.email canary@example.invalid
@@ -128,6 +140,9 @@ No Mistakes owns routing in core and records a bounded routing generation with e
    git -C "$CANARY_REPO" remote add origin "$CANARY_ORIGIN"
    git -C "$CANARY_REPO" push origin main
    git -C "$CANARY_REPO" switch -c route-canary
+   printf 'post-branch reviewable change\n' > "$CANARY_REPO/route-canary.txt"
+   git -C "$CANARY_REPO" add route-canary.txt
+   git -C "$CANARY_REPO" commit -m 'canary: review route change'
    mkdir -p "$CANARY_NM_HOME"
    cat > "$CANARY_NM_HOME/config.yaml" <<EOF
    agent: codex
@@ -142,14 +157,22 @@ No Mistakes owns routing in core and records a bounded routing generation with e
    (cd "$CANARY_REPO" && HOME="$CANARY_HOME" NM_HOME="$CANARY_NM_HOME" /path/to/new/no-mistakes axi run \
      --intent 'verify the isolated route policy and evidence' \
      --skip rebase,test,document,lint,push,pr,ci --yes)
-   (cd "$CANARY_REPO" && HOME="$CANARY_HOME" NM_HOME="$CANARY_NM_HOME" /path/to/new/no-mistakes axi route-evidence)
+   (cd "$CANARY_REPO" && HOME="$CANARY_HOME" NM_HOME="$CANARY_NM_HOME" /path/to/new/no-mistakes axi route-evidence) > "$CANARY_ROOT/route-evidence.toon"
+   grep -q 'route_decisions\[1\]' "$CANARY_ROOT/route-evidence.toon"
+   grep -q 'nm-routing-v2' "$CANARY_ROOT/route-evidence.toon"
+   grep -q 'gpt-5.6-luna' "$CANARY_ROOT/route-evidence.toon"
+   grep -q 'xhigh' "$CANARY_ROOT/route-evidence.toon"
+   grep -q 'configuration_generation' "$CANARY_ROOT/route-evidence.toon"
+   test -s "$CANARY_INVOCATIONS"
    ```
    Inspect `route_decisions` for the requested/effective harness, model, effort, `policy_version`, and `configuration_generation`, and inspect `review_results` for the completed classification. Codex rows should show the No Mistakes GPT policy; non-Codex rows must leave effective model and effort empty. The output must contain no external router name or process. This is a real agent invocation inside the disposable repository, not a log-only daemon check.
 5. Stop the canary explicitly and remove both temporary homes before touching the active installation:
    ```sh
    (cd "$CANARY_REPO" && HOME="$CANARY_HOME" NM_HOME="$CANARY_NM_HOME" /path/to/new/no-mistakes daemon stop) || true
-   rm -rf "$CANARY_ROOT" "$CANARY_HOME" "$CANARY_NM_HOME"
-   unset CANARY_ROOT CANARY_REPO CANARY_ORIGIN CANARY_HOME CANARY_NM_HOME CANARY_CODEX
+   test -n "$CANARY_ROOT" -a -n "$CANARY_HOME" -a -n "$CANARY_NM_HOME"
+   case "$CANARY_ROOT" in "$CANARY_TMP_BASE"/*) ;; *) echo "refusing unsafe canary cleanup" >&2; exit 1 ;; esac
+   rm -rf -- "$CANARY_ROOT" "$CANARY_HOME" "$CANARY_NM_HOME"
+   unset CANARY_TMP_BASE CANARY_ROOT CANARY_REPO CANARY_ORIGIN CANARY_HOME CANARY_NM_HOME CANARY_CODEX CANARY_INVOCATIONS
    ```
 6. Restart the real daemon only after the run list is drained:
    ```sh

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -99,6 +99,35 @@ no-mistakes daemon stop --force
 no-mistakes update
 ```
 
+### Replace a daemon that cached removed routing code
+
+No Mistakes owns routing in core and records a bounded routing generation with each agent invocation. If you are migrating from an old private build that cached an external Flow router, replace the daemon quiescently instead of forcing a live restart:
+
+1. Check the exact binary and active work:
+   ```sh
+   no-mistakes daemon status
+   no-mistakes runs
+   ```
+2. Let pending or running pipeline runs finish. `daemon restart` and `update` refuse by default while active runs exist; do not pass `--force` for this migration path.
+3. Canary the new binary from an isolated home before touching the shared daemon:
+   ```sh
+   NM_HOME="$(mktemp -d)" HOME="$(mktemp -d)" /path/to/new/no-mistakes doctor
+   NM_HOME="$(mktemp -d)" HOME="$(mktemp -d)" /path/to/new/no-mistakes daemon start
+   ```
+4. Verify the canary daemon does not invoke the removed router by checking its local logs and route evidence:
+   ```sh
+   NM_HOME=<canary-home> /path/to/new/no-mistakes daemon status
+   grep -R "Flow" "$NM_HOME/logs" || true
+   ```
+   Route decisions should show No Mistakes model/effort policy and a `configuration_generation`, not an external router path.
+5. Restart the real daemon only after the run list is drained:
+   ```sh
+   /path/to/new/no-mistakes daemon restart
+   ```
+6. Roll back by running the previous exact binary's `daemon restart` after the same drain check. If active runs appear during rollback, stop and inspect them instead of forcing the restart.
+
+The only place Flow is relevant here is migration history: current No Mistakes routing must not depend on a Flow path, manifest, or process.
+
 ## Agent binary not detected
 
 Symptom: `doctor` reports that gate validation is unavailable, or a run fails before its first pipeline step because no runnable agent was found.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -153,6 +153,7 @@ no-mistakes axi status --run <id>
 | `--run` | `string` | resolved run | Inspect a specific run ID |
 
 When the resolved run is parked at an `awaiting_approval` or `fix_review` gate, its top-level `run:` object includes `awaiting_agent: parked <duration>` immediately after `status`.
+During slow checkout or agent setup, `status` may be `provisioning`; the run also reports persisted `provisioning_phase` and `provisioning_progress`, and can be cancelled with `axi abort --run <id>`. When Codex reports `AuthorizationRequired`, the run is parked as `awaiting_auth` with a `blocked_reason`. Log into a healthy account and explicitly approve one bounded retry with `axi respond --action approve`; do not blindly replay a fixer turn whose completion is unknown.
 The field disappears after `axi respond`, on cancel, and on terminal outcomes; use it to distinguish a run waiting for the driving agent from one actively running, fixing, or watching CI.
 When the resolved run has a `running` or `fixing` step, the run object includes `active_steps`.
 Each row reports how long the step has been active, the latest meaningful log or native-agent lifecycle activity, the native agent PID if one is currently running, and the current round such as `round 1`, `auto-fix 1/3`, or `fix 2`.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -160,6 +160,21 @@ Each row reports how long the step has been active, the latest meaningful log or
 If no activity arrives for longer than `step_quiet_warning`, `last_activity` is prefixed with `quiet`; this is only a liveness signal and does not cancel the step.
 For older active runs with no recorded activity timestamp, AXI falls back to the step log file modification time.
 
+## no-mistakes axi route-evidence
+
+Read the immutable route decisions and completed review classifications for a run. This is a local, read-only database surface and does not start or contact the daemon.
+
+```sh
+no-mistakes axi route-evidence
+no-mistakes axi route-evidence --run <id>
+```
+
+| Flag | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `--run` | `string` | resolved run | Inspect a specific run ID; otherwise use the active or most recent run |
+
+The output has stable `route_decisions` and `review_results` arrays. Each route row includes requested/effective harness, model, effort, policy version, phase, risk, source configuration, and configuration generation. `review_results` is the post-result classification used by restart recovery; it is distinct from the pre-launch route input.
+
 ## no-mistakes axi logs
 
 Show the log output of one pipeline step.

--- a/docs/src/content/docs/reference/environment.md
+++ b/docs/src/content/docs/reference/environment.md
@@ -171,6 +171,7 @@ Everything sent remotely is low-cardinality: command names, statuses, durations,
 Run IDs, repository paths, branch names, session identities, prompts, model outputs, diffs, and per-invocation performance records are never sent.
 
 Detailed performance evidence stays on the machine in the local state database (`<NM_HOME>/state.sqlite`): one `agent_invocations` row per agent invocation, plus each run's accumulated parked-at-gate time.
+The same database keeps append-only lifecycle events and route decisions. Route records capture requested/effective harness, model, effort, policy version, phase, risk reason, configuration generation, canonical repository, and a prompt hash/byte count/transport without storing prompt content. A later cancellation, supersession, shutdown, or recovery changes the current run projection but does not erase the earlier failure event.
 Each row records run and step identity, purpose (such as review/review-fix/housekeeping), the reported model and its provider, the cold/started/resumed/fallback session mode, a truncated session-identity hash, timestamps, duration, exit status, and failure category, alongside the session-fidelity metrics below.
 It never stores prompts, model outputs, diffs, raw command arguments, secret values, or credentials - only bounded counts, low-cardinality categories, and durations.
 

--- a/internal/agent/acpx.go
+++ b/internal/agent/acpx.go
@@ -32,10 +32,14 @@ func (a *acpxAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
 }
 
 func (a *acpxAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
-	args := a.buildArgs(opts)
+	args := a.buildArgsTransport(opts)
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD
-	cmd.Stdin = nil
+	prompt := opts.Prompt
+	if len(opts.JSONSchema) > 0 {
+		prompt = buildACPStructuredPrompt(prompt, opts.JSONSchema)
+	}
+	cmd.Stdin = strings.NewReader(prompt)
 	cmd.Env = gitSafeEnv(opts.CWD)
 	shellenv.ConfigureShellCommand(cmd)
 
@@ -86,7 +90,15 @@ func (a *acpxAgent) buildArgs(opts RunOpts) []string {
 	if len(opts.JSONSchema) > 0 {
 		prompt = buildACPStructuredPrompt(prompt, opts.JSONSchema)
 	}
+	args := a.buildArgsWithoutPrompt(opts)
+	return append(args, prompt)
+}
 
+func (a *acpxAgent) buildArgsTransport(opts RunOpts) []string {
+	return a.buildArgsWithoutPrompt(opts)
+}
+
+func (a *acpxAgent) buildArgsWithoutPrompt(opts RunOpts) []string {
 	args := make([]string, 0, 12)
 	if a.rawCommand != "" {
 		args = append(args, "--agent", a.rawCommand)
@@ -104,7 +116,7 @@ func (a *acpxAgent) buildArgs(opts RunOpts) []string {
 	if a.rawCommand == "" {
 		args = append(args, a.target)
 	}
-	args = append(args, "exec", prompt)
+	args = append(args, "exec")
 	return args
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -59,6 +59,10 @@ type RunOpts struct {
 	// fallback-provider attempts, after it completes. It is instrumentation
 	// only and must not change invocation behavior.
 	OnAttempt func(Attempt)
+	// OnRoute receives the route bound to a concrete adapter immediately before
+	// launch. Fallback wrappers use it once per candidate so route evidence is
+	// immutable and attributable to the actual adapter.
+	OnRoute func(routing.Decision) error
 }
 
 // PromptTransport names the bounded transport used by the native adapter.
@@ -86,6 +90,7 @@ type Attempt struct {
 	CompletedAt     time.Time
 	Session         *SessionRef
 	SessionFallback bool
+	Routing         routing.Decision
 }
 
 // SessionRef identifies a durable adapter-native session for RunOpts.Session.
@@ -140,6 +145,18 @@ type AttemptReporter interface {
 func ReportsAgentAttempts(a Agent) bool {
 	r, ok := a.(AttemptReporter)
 	return ok && r.ReportsAgentAttempts()
+}
+
+// RouteReporter reports whether an adapter wrapper calls OnRoute at each
+// concrete launch boundary. Native adapters do not implement this; the
+// instrumentation layer emits their route once before Run.
+type RouteReporter interface {
+	ReportsAgentRoutes() bool
+}
+
+func ReportsAgentRoutes(a Agent) bool {
+	r, ok := a.(RouteReporter)
+	return ok && r.ReportsAgentRoutes()
 }
 
 // GateInstructionNeutralizer is the optional adapter capability that reports the

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kunchenguid/no-mistakes/internal/routing"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
@@ -48,6 +49,12 @@ type RunOpts struct {
 	// can be normalized without external git archaeology. Instrumentation only;
 	// adapters ignore it.
 	Workload *InvocationWorkload
+	// Routing is selected by the no-mistakes core before launch. Adapters may
+	// use only the bounded effective model/effort fields; they must not consult
+	// project-owned manifests or routers.
+	Routing                 routing.Decision
+	RouteRisk               routing.Risk
+	RouteReviewConfirmation bool
 	// OnAttempt receives each concrete adapter attempt, including retries and
 	// fallback-provider attempts, after it completes. It is instrumentation
 	// only and must not change invocation behavior.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -61,6 +61,20 @@ type RunOpts struct {
 	OnAttempt func(Attempt)
 }
 
+// PromptTransport names the bounded transport used by the native adapter.
+// It is evidence only; routing never depends on this value.
+func PromptTransport(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	switch {
+	case name == "codex", name == "claude", name == "copilot", name == "pi", strings.HasPrefix(name, "acp:"):
+		return "stdin"
+	case name == "opencode", name == "rovodev":
+		return "http-body"
+	default:
+		return "unknown"
+	}
+}
+
 // Attempt describes one completed concrete adapter attempt for an agent
 // invocation. An Agent may make several attempts when it retries transient
 // failures or moves to a fallback provider.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -179,9 +179,12 @@ func TestACPAgentRunParsesAcpxJSONOutput(t *testing.T) {
 	dir := t.TempDir()
 	script := filepath.Join(dir, "acpx")
 	argLog := filepath.Join(dir, "args.txt")
+	promptLog := filepath.Join(dir, "prompt.txt")
 	t.Setenv("ARG_LOG", argLog)
+	t.Setenv("PROMPT_LOG", promptLog)
 	contents := `#!/bin/sh
 printf '%s\n' "$@" > "$ARG_LOG"
+cat > "$PROMPT_LOG"
 printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"usage_update","used":123,"size":1000}}}'
 printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"{\"done\":true}"}}}}'
 `
@@ -221,10 +224,17 @@ printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"s
 		t.Fatalf("read args: %v", err)
 	}
 	argsText := string(argsData)
-	for _, want := range []string{"--cwd\n" + dir, "--format\njson", "--json-strict", "gemini", "do work"} {
+	for _, want := range []string{"--cwd\n" + dir, "--format\njson", "--json-strict", "gemini"} {
 		if !strings.Contains(argsText, want) {
 			t.Errorf("args missing %q in:\n%s", want, argsText)
 		}
+	}
+	prompt, err := os.ReadFile(promptLog)
+	if err != nil {
+		t.Fatalf("read prompt: %v", err)
+	}
+	if !strings.Contains(string(prompt), "do work") {
+		t.Fatalf("prompt was not transported through stdin: %q", prompt)
 	}
 }
 

--- a/internal/agent/auth.go
+++ b/internal/agent/auth.go
@@ -1,0 +1,50 @@
+package agent
+
+import (
+	"errors"
+	"strings"
+)
+
+var ErrAuthorizationRequired = errors.New("agent authorization required")
+
+type AuthorizationRequiredError struct {
+	Agent  string
+	Detail string
+}
+
+func (e *AuthorizationRequiredError) Error() string {
+	if e == nil || strings.TrimSpace(e.Detail) == "" {
+		return ErrAuthorizationRequired.Error()
+	}
+	return ErrAuthorizationRequired.Error() + ": " + e.Detail
+}
+
+func (e *AuthorizationRequiredError) Unwrap() error { return ErrAuthorizationRequired }
+
+func IsAuthorizationRequired(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrAuthorizationRequired) {
+		return true
+	}
+	text := strings.ToLower(err.Error())
+	return authorizationRequiredText(text)
+}
+
+func authorizationRequiredText(text string) bool {
+	text = strings.ToLower(text)
+	for _, needle := range []string{
+		"authorizationrequired", "authorization required", "auth(authorizationrequired)",
+		"not authenticated", "authentication required", "reauthenticate",
+	} {
+		if strings.Contains(text, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func authorizationError(detail string) error {
+	return &AuthorizationRequiredError{Detail: strings.TrimSpace(detail)}
+}

--- a/internal/agent/auth_test.go
+++ b/internal/agent/auth_test.go
@@ -1,0 +1,36 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestAuthorizationRequiredClassification(t *testing.T) {
+	for _, text := range []string{
+		"Transport channel closed, when Auth(AuthorizationRequired)",
+		"provider says authentication required",
+		"not authenticated; please reauthenticate",
+	} {
+		if !IsAuthorizationRequired(errors.New(text)) {
+			t.Errorf("%q was not classified as authorization-required", text)
+		}
+	}
+	if _, ok := authorizationError("account transition").(*AuthorizationRequiredError); !ok {
+		t.Fatal("authorizationError did not return typed error")
+	}
+}
+
+func TestRunWithRetryDoesNotRetryAuthorizationRequired(t *testing.T) {
+	calls := 0
+	_, err := runWithRetry(context.Background(), "codex", RunOpts{}, 3, classifyTransient, nil, func() (*Result, error) {
+		calls++
+		return nil, &AuthorizationRequiredError{Agent: "codex", Detail: "account rotation"}
+	})
+	if !IsAuthorizationRequired(err) {
+		t.Fatalf("error = %v, want authorization-required", err)
+	}
+	if calls != 1 {
+		t.Fatalf("authorization error caused %d attempts, want 1", calls)
+	}
+}

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -69,10 +69,10 @@ func (a *claudeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error
 	if opts.Session != nil {
 		resumeID = opts.Session.ID
 	}
-	args := a.buildArgs(opts.Prompt, opts.JSONSchema, resumeID)
+	args := a.buildArgsTransport(opts.JSONSchema, resumeID)
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD
-	cmd.Stdin = nil
+	cmd.Stdin = strings.NewReader(opts.Prompt)
 	cmd.Env = gitSafeEnv(opts.CWD)
 	shellenv.ConfigureShellCommand(cmd)
 
@@ -169,11 +169,11 @@ func finalizeClaudeResult(result *claudeResult, schema json.RawMessage, usage To
 func (a *claudeAgent) buildArgs(prompt string, schema json.RawMessage, resumeID string) []string {
 	args := make([]string, 0, len(a.extraArgs)+12)
 	args = append(args, a.extraArgs...)
-	args = append(args,
-		"-p", prompt,
-		"--verbose",
-		"--output-format", "stream-json",
-	)
+	args = append(args, "-p")
+	if prompt != "" {
+		args = append(args, prompt)
+	}
+	args = append(args, "--verbose", "--output-format", "stream-json")
 	// Project-settings opt-out (trusted-only; see config.DisableProjectSettings):
 	// load only user-level settings and memory, never the target repo's
 	// project/local CLAUDE.md/AGENTS.md, .claude/settings.json, or
@@ -197,6 +197,10 @@ func (a *claudeAgent) buildArgs(prompt string, schema json.RawMessage, resumeID 
 		args = append(args, "--dangerously-skip-permissions")
 	}
 	return args
+}
+
+func (a *claudeAgent) buildArgsTransport(schema json.RawMessage, resumeID string) []string {
+	return a.buildArgs("", schema, resumeID)
 }
 
 // claudeUserSetSettingSources reports whether extraArgs pin --setting-sources at

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kunchenguid/no-mistakes/internal/routing"
 	"github.com/kunchenguid/no-mistakes/internal/shellenv"
 )
 
@@ -89,10 +90,13 @@ func (a *codexAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error)
 	if opts.Session != nil {
 		resumeID = opts.Session.ID
 	}
-	args := a.buildArgs(opts.Prompt, schemaPath, resumeID)
+	args := a.buildArgsTransport(opts, schemaPath, resumeID)
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD
-	cmd.Stdin = nil
+	// Codex reads the task prompt from stdin when no positional prompt is
+	// supplied. Keeping the full payload out of argv avoids macOS E2BIG and
+	// keeps process listings free of source and test evidence.
+	cmd.Stdin = strings.NewReader(opts.Prompt)
 	cmd.Env = gitSafeEnv(opts.CWD)
 	shellenv.ConfigureShellCommand(cmd)
 
@@ -121,6 +125,12 @@ func (a *codexAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error)
 		err = started.waitAfterParseError(err)
 		stderrWG.Wait()
 		retErr := fmt.Errorf("codex parse events: %w", err)
+		if authorizationRequiredText(codexErr) {
+			retErr = authorizationError(codexErr)
+		}
+		if authorizationRequiredText(codexErr) || authorizationRequiredText(string(stderrBuf)) {
+			retErr = authorizationError(firstNonEmpty(codexErr, string(stderrBuf)))
+		}
 		emitAgentExited(opts, "codex", pid, retErr)
 		return nil, retErr
 	}
@@ -136,8 +146,16 @@ func (a *codexAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error)
 			detail = stderr
 		}
 		retErr := fmt.Errorf("codex exited: %w: %s", waitErr, detail)
+		if authorizationRequiredText(detail) {
+			retErr = authorizationError(detail)
+		}
 		emitAgentExited(opts, "codex", pid, retErr)
 		return nil, retErr
+	}
+	if authorizationRequiredText(codexErr) {
+		err := authorizationError(codexErr)
+		emitAgentExited(opts, "codex", pid, err)
+		return nil, err
 	}
 
 	res, err := finalizeTextResult("codex", lastMessage, validationSchema, usage)
@@ -167,6 +185,14 @@ func (a *codexAgent) Close() error { return nil }
 // -s/--sandbox as of codex 0.144): unsupported user extraArgs make the
 // invocation fail fast and the caller's cold fallback preserves correctness.
 func (a *codexAgent) buildArgs(prompt, schemaPath, resumeID string) []string {
+	return a.buildArgsWithPrompt(prompt, schemaPath, resumeID, routing.Decision{}, true)
+}
+
+func (a *codexAgent) buildArgsTransport(opts RunOpts, schemaPath, resumeID string) []string {
+	return a.buildArgsWithPrompt("", schemaPath, resumeID, opts.Routing, false)
+}
+
+func (a *codexAgent) buildArgsWithPrompt(prompt, schemaPath, resumeID string, route routing.Decision, includePrompt bool) []string {
 	args := make([]string, 0, len(a.extraArgs)+11)
 	args = append(args, "exec")
 	if resumeID != "" {
@@ -176,7 +202,10 @@ func (a *codexAgent) buildArgs(prompt, schemaPath, resumeID string) []string {
 	if resumeID != "" {
 		args = append(args, resumeID)
 	}
-	args = append(args, prompt, "--json")
+	if includePrompt {
+		args = append(args, prompt)
+	}
+	args = append(args, "--json")
 	if schemaPath != "" {
 		args = append(args, "--output-schema", schemaPath)
 	}
@@ -212,6 +241,12 @@ func (a *codexAgent) buildArgs(prompt, schemaPath, resumeID string) []string {
 		if !codexArgsContain(a.extraArgs, "--ignore-rules") {
 			args = append(args, "--ignore-rules")
 		}
+	}
+	if route.EffectiveModel != "" {
+		args = append(args, "-m", route.EffectiveModel)
+	}
+	if route.EffectiveEffort != "" {
+		args = append(args, "-c", "model_reasoning_effort="+route.EffectiveEffort)
 	}
 	return args
 }

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -180,7 +180,10 @@ func (a *codexAgent) Close() error { return nil }
 // inserted between "exec" and the prompt so user flags (e.g. -m, --sandbox)
 // take effect. If the user declared their own execution-mode flag, the
 // default --dangerously-bypass-approvals-and-sandbox is not added.
-// A non-empty resumeID routes through `codex exec resume <id> <prompt>`,
+// A non-empty resumeID routes through `codex exec resume <id> <prompt>` for
+// the legacy positional helper, and `codex exec resume <id> -` for the stdin
+// transport path used by Run. The "-" marker is required by resume's narrower
+// CLI contract to read the prompt from stdin.
 // which exposes a narrower flag surface than `codex exec` (no --color, no
 // -s/--sandbox as of codex 0.144): unsupported user extraArgs make the
 // invocation fail fast and the caller's cold fallback preserves correctness.
@@ -204,6 +207,8 @@ func (a *codexAgent) buildArgsWithPrompt(prompt, schemaPath, resumeID string, ro
 	}
 	if includePrompt {
 		args = append(args, prompt)
+	} else if resumeID != "" {
+		args = append(args, "-")
 	}
 	args = append(args, "--json")
 	if schemaPath != "" {

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -54,6 +54,28 @@ func TestCodexAgent_TransportArgsCarryEffectiveRouteWithoutPrompt(t *testing.T) 
 	}
 }
 
+func TestCodexAgent_ResumeTransportUsesStdinPromptMarker(t *testing.T) {
+	ca := &codexAgent{bin: "codex"}
+	args := ca.buildArgsTransport(RunOpts{
+		Prompt:  strings.Repeat("resume prompt ", 1024),
+		Routing: routing.Decision{EffectiveModel: routing.ModelSol, EffectiveEffort: routing.EffortHigh},
+	}, "", "thread-99")
+	wantPrefix := []string{"exec", "resume", "thread-99", "-"}
+	if len(args) < len(wantPrefix) {
+		t.Fatalf("resume args too short: %v", args)
+	}
+	for i, want := range wantPrefix {
+		if args[i] != want {
+			t.Fatalf("resume arg[%d] = %q, want %q in %v", i, args[i], want, args)
+		}
+	}
+	for _, arg := range args {
+		if strings.Contains(arg, "resume prompt") {
+			t.Fatalf("resume prompt leaked into argv: %v", args)
+		}
+	}
+}
+
 func TestCodexAgent_LargePromptUsesStdinAndBoundedArgv(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell fixture is Unix-only")
@@ -318,6 +340,51 @@ printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens
 	}
 	if result.Text != "ok" {
 		t.Fatalf("result text = %q, want ok", result.Text)
+	}
+	got, err := os.ReadFile(capture)
+	if err != nil {
+		t.Fatalf("read captured prompt: %v", err)
+	}
+	if len(got) != len(prompt) {
+		t.Fatalf("captured prompt bytes = %d, want %d", len(got), len(prompt))
+	}
+}
+
+func TestCodexAgent_RunResumeTransportsThreeMiBPromptThroughStdin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("posix fake Codex fixture")
+	}
+	dir := t.TempDir()
+	bin := writeFakeCodex(t, dir, `#!/bin/sh
+if [ "$1" != "exec" ] || [ "$2" != "resume" ] || [ "$3" != "thread-99" ] || [ "$4" != "-" ]; then
+  printf 'unexpected args: %s\n' "$*" >&2
+  exit 93
+fi
+for arg do
+  case "$arg" in
+    *xxxxxxxx*) exit 94 ;;
+  esac
+done
+cat > "$PROMPT_CAPTURE"
+printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"ok"}}'
+printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}'
+`, "")
+	capture := filepath.Join(dir, "resume-prompt.txt")
+	t.Setenv("PROMPT_CAPTURE", capture)
+	prompt := strings.Repeat("x", 3*1024*1024)
+	result, err := (&codexAgent{bin: bin}).Run(context.Background(), RunOpts{
+		Prompt: prompt,
+		CWD:    t.TempDir(),
+		Session: &SessionRef{
+			Agent: "codex",
+			ID:    "thread-99",
+		},
+	})
+	if err != nil {
+		t.Fatalf("resumed three MiB prompt failed: %v", err)
+	}
+	if result.Text != "ok" || !result.Resumed {
+		t.Fatalf("result = %+v, want ok resumed", result)
 	}
 	got, err := os.ReadFile(capture)
 	if err != nil {

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -8,6 +8,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/routing"
 )
 
 func TestCodexAgent_BuildArgs(t *testing.T) {
@@ -30,6 +32,59 @@ func TestCodexAgent_BuildArgs(t *testing.T) {
 		if args[i] != want {
 			t.Errorf("arg[%d]: expected %q, got %q", i, want, args[i])
 		}
+	}
+}
+
+func TestCodexAgent_TransportArgsCarryEffectiveRouteWithoutPrompt(t *testing.T) {
+	ca := &codexAgent{bin: "codex"}
+	args := ca.buildArgsTransport(RunOpts{
+		Prompt:  "do not put this in argv",
+		Routing: routing.Decision{EffectiveModel: routing.ModelSol, EffectiveEffort: routing.EffortHigh},
+	}, "", "")
+	for _, arg := range args {
+		if strings.Contains(arg, "do not put this") {
+			t.Fatalf("prompt leaked into transport argv: %v", args)
+		}
+	}
+	joined := strings.Join(args, " ")
+	for _, want := range []string{"-m gpt-5.6-sol", "model_reasoning_effort=high"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("route argument %q missing from %v", want, args)
+		}
+	}
+}
+
+func TestCodexAgent_LargePromptUsesStdinAndBoundedArgv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-only")
+	}
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "codex")
+	script := "#!/bin/sh\n" +
+		"for arg do\n" +
+		"  if [ \"${#arg}\" -gt 65536 ]; then exit 91; fi\n" +
+		"done\n" +
+		"wc -c <&0 | tr -d '[:space:]' > \"$PROMPT_BYTES\"\n" +
+		"printf '%s\\n' '{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"ok\"}}'\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	bytesPath := filepath.Join(dir, "prompt.bytes")
+	t.Setenv("PROMPT_BYTES", bytesPath)
+	prompt := strings.Repeat("x", 3*1024*1024)
+	result, err := (&codexAgent{bin: bin}).Run(context.Background(), RunOpts{Prompt: prompt, CWD: dir})
+	if err != nil {
+		t.Fatalf("large prompt failed: %v", err)
+	}
+	if string(result.Text) != "ok" {
+		t.Fatalf("result text = %q", result.Text)
+	}
+	got, err := os.ReadFile(bytesPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(got)) != "3145728" {
+		t.Fatalf("stdin prompt bytes = %q, want 3145728", got)
 	}
 }
 
@@ -241,6 +296,35 @@ exit 1
 	}
 	if !strings.Contains(err.Error(), "schema rejected by codex") {
 		t.Fatalf("expected JSONL error in message, got %v", err)
+	}
+}
+
+func TestCodexAgent_RunTransportsThreeMiBPromptThroughStdin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("posix fake Codex fixture")
+	}
+	dir := t.TempDir()
+	bin := writeFakeCodex(t, dir, `#!/bin/sh
+cat > "$PROMPT_CAPTURE"
+printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"ok"}}'
+printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}'
+`, "")
+	capture := filepath.Join(dir, "prompt.txt")
+	t.Setenv("PROMPT_CAPTURE", capture)
+	prompt := strings.Repeat("x", 3*1024*1024)
+	result, err := (&codexAgent{bin: bin}).Run(context.Background(), RunOpts{Prompt: prompt, CWD: t.TempDir()})
+	if err != nil {
+		t.Fatalf("three MiB prompt failed: %v", err)
+	}
+	if result.Text != "ok" {
+		t.Fatalf("result text = %q, want ok", result.Text)
+	}
+	got, err := os.ReadFile(capture)
+	if err != nil {
+		t.Fatalf("read captured prompt: %v", err)
+	}
+	if len(got) != len(prompt) {
+		t.Fatalf("captured prompt bytes = %d, want %d", len(got), len(prompt))
 	}
 }
 

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -36,10 +36,10 @@ func (a *copilotAgent) Close() error { return nil }
 
 func (a *copilotAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 	prompt := buildCopilotPrompt(opts.Prompt, opts.JSONSchema)
-	args := a.buildArgs(prompt)
+	args := a.buildArgsTransport()
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD
-	cmd.Stdin = nil
+	cmd.Stdin = strings.NewReader(prompt)
 	cmd.Env = gitSafeEnv(opts.CWD)
 	shellenv.ConfigureShellCommand(cmd)
 
@@ -151,6 +151,19 @@ func (a *copilotAgent) buildArgs(prompt string) []string {
 		"--output-format", "json",
 		"--no-color",
 	)
+	if !copilotUserSetAskUser(a.extraArgs) {
+		args = append(args, "--no-ask-user")
+	}
+	if !copilotUserSetPermissionMode(a.extraArgs) {
+		args = append(args, "--allow-all-tools")
+	}
+	return args
+}
+
+func (a *copilotAgent) buildArgsTransport() []string {
+	args := make([]string, 0, len(a.extraArgs)+7)
+	args = append(args, a.extraArgs...)
+	args = append(args, "--output-format", "json", "--no-color")
 	if !copilotUserSetAskUser(a.extraArgs) {
 		args = append(args, "--no-ask-user")
 	}

--- a/internal/agent/fallback.go
+++ b/internal/agent/fallback.go
@@ -86,6 +86,9 @@ func (a *fallbackAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) 
 	}
 	var lastErr error
 	for i, current := range candidates {
+		if opts.Routing.EffectiveModel != "" && !strings.EqualFold(current.Name(), "codex") {
+			return nil, fmt.Errorf("agent %q cannot enforce the Codex routing policy; refusing fallback", current.Name())
+		}
 		currentOpts := opts
 		if currentOpts.Session != nil && currentOpts.Session.ID == "" && !SupportsSessionResume(current) {
 			currentOpts.Session = nil

--- a/internal/agent/fallback.go
+++ b/internal/agent/fallback.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/routing"
 )
 
 type fallbackAgent struct {
@@ -53,6 +55,8 @@ func (a *fallbackAgent) SupportsSessionProvider(provider string) bool {
 
 func (a *fallbackAgent) ReportsAgentAttempts() bool { return true }
 
+func (a *fallbackAgent) ReportsAgentRoutes() bool { return true }
+
 // NeutralizesGateInstructions fails closed over the whole fallback set: the
 // wrapper may invoke any member, so it neutralizes the target repo's project
 // agent-instruction files only if EVERY member does. A single unverified member
@@ -90,11 +94,17 @@ func (a *fallbackAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) 
 			return nil, fmt.Errorf("agent %q cannot enforce the Codex routing policy; refusing fallback", current.Name())
 		}
 		currentOpts := opts
+		currentOpts.Routing = routing.ForAdapter(opts.Routing, current.Name())
 		if currentOpts.Session != nil && currentOpts.Session.ID == "" && !SupportsSessionResume(current) {
 			currentOpts.Session = nil
 			currentOpts.SessionFallback = false
 		}
 		startedAt := time.Now()
+		if currentOpts.OnRoute != nil {
+			if err := currentOpts.OnRoute(currentOpts.Routing); err != nil {
+				return nil, fmt.Errorf("record route for agent %q: %w", current.Name(), err)
+			}
+		}
 		result, err := current.Run(ctx, currentOpts)
 		if !ReportsAgentAttempts(current) {
 			emitAgentAttempt(currentOpts, current.Name(), result, err, startedAt, time.Now())

--- a/internal/agent/retry.go
+++ b/internal/agent/retry.go
@@ -74,6 +74,9 @@ func runWithRetry(
 		}
 		startedAt := time.Now()
 		result, err := runOnce()
+		if err != nil && authorizationRequiredText(err.Error()) && !IsAuthorizationRequired(err) {
+			err = authorizationError(name + ": " + err.Error())
+		}
 		emitAgentAttempt(opts, name, result, err, startedAt, time.Now())
 		if err == nil {
 			return result, nil
@@ -152,6 +155,12 @@ var transientNeedles = []struct {
 func classifyTransient(err error) (string, bool) {
 	if err == nil {
 		return "", false
+	}
+	// Account transitions are operator-recoverable, not transient transport
+	// errors. Retrying here can replay a mutating fixer turn repeatedly while
+	// the provider is still unauthenticated.
+	if IsAuthorizationRequired(err) {
+		return "authorization required", false
 	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return "", false

--- a/internal/agent/retry.go
+++ b/internal/agent/retry.go
@@ -106,6 +106,7 @@ func emitAgentAttempt(opts RunOpts, name string, result *Result, err error, star
 		CompletedAt:     completedAt,
 		Session:         cloneSessionRef(opts.Session),
 		SessionFallback: opts.SessionFallback,
+		Routing:         opts.Routing,
 	})
 }
 

--- a/internal/cli/axi.go
+++ b/internal/cli/axi.go
@@ -47,6 +47,7 @@ func newAxiCmd() *cobra.Command {
 	cmd.AddCommand(newAxiRespondCmd())
 	cmd.AddCommand(newAxiStatusCmd())
 	cmd.AddCommand(newAxiLogsCmd())
+	cmd.AddCommand(newAxiRouteEvidenceCmd())
 	cmd.AddCommand(newAxiAbortCmd())
 	return cmd
 }

--- a/internal/cli/axi_render.go
+++ b/internal/cli/axi_render.go
@@ -206,6 +206,13 @@ func (rv runView) awaitingStep() (stepView, bool) {
 			return s, true
 		}
 	}
+	if rv.Status == string(types.RunAwaitingAuth) {
+		for _, s := range rv.Steps {
+			if s.Status == string(types.StepStatusRunning) {
+				return s, true
+			}
+		}
+	}
 	return stepView{}, false
 }
 

--- a/internal/cli/axi_render.go
+++ b/internal/cli/axi_render.go
@@ -90,11 +90,15 @@ type stepView struct {
 
 // runView is a render-ready view of a pipeline run.
 type runView struct {
-	ID      string
-	Branch  string
-	Status  string
-	HeadSHA string
-	PRURL   string
+	ID                   string
+	Branch               string
+	Status               string
+	HeadSHA              string
+	PRURL                string
+	ProvisioningPhase    string
+	ProvisioningProgress int
+	ProvisioningError    string
+	BlockedReason        string
 	// AwaitingAgentSince is the unix-seconds time the run parked at a gate
 	// awaiting the driving agent, or nil when the run is not parked. It powers
 	// the top-level parked signal in the run object.
@@ -104,14 +108,22 @@ type runView struct {
 
 func runViewFromIPC(r *ipc.RunInfo) runView {
 	rv := runView{
-		ID:                 r.ID,
-		Branch:             r.Branch,
-		Status:             string(r.Status),
-		HeadSHA:            r.HeadSHA,
-		AwaitingAgentSince: r.AwaitingAgentSince,
+		ID:                   r.ID,
+		Branch:               r.Branch,
+		Status:               string(r.Status),
+		HeadSHA:              r.HeadSHA,
+		ProvisioningPhase:    r.ProvisioningPhase,
+		ProvisioningProgress: r.ProvisioningProgress,
+		AwaitingAgentSince:   r.AwaitingAgentSince,
 	}
 	if r.PRURL != nil {
 		rv.PRURL = *r.PRURL
+	}
+	if r.ProvisioningError != nil {
+		rv.ProvisioningError = *r.ProvisioningError
+	}
+	if r.BlockedReason != nil {
+		rv.BlockedReason = *r.BlockedReason
 	}
 	for _, s := range r.Steps {
 		sv := stepView{
@@ -143,14 +155,22 @@ func runViewFromIPC(r *ipc.RunInfo) runView {
 
 func runViewFromDB(r *db.Run, steps []*db.StepResult) runView {
 	rv := runView{
-		ID:                 r.ID,
-		Branch:             r.Branch,
-		Status:             string(r.Status),
-		HeadSHA:            r.HeadSHA,
-		AwaitingAgentSince: r.AwaitingAgentSince,
+		ID:                   r.ID,
+		Branch:               r.Branch,
+		Status:               string(r.Status),
+		HeadSHA:              r.HeadSHA,
+		ProvisioningPhase:    r.ProvisioningPhase,
+		ProvisioningProgress: r.ProvisioningProgress,
+		AwaitingAgentSince:   r.AwaitingAgentSince,
 	}
 	if r.PRURL != nil {
 		rv.PRURL = *r.PRURL
+	}
+	if r.ProvisioningError != nil {
+		rv.ProvisioningError = *r.ProvisioningError
+	}
+	if r.BlockedReason != nil {
+		rv.BlockedReason = *r.BlockedReason
 	}
 	for _, s := range steps {
 		sv := stepView{
@@ -410,6 +430,15 @@ func runObjectFieldWithKey(key string, rv runView) toon.Field {
 	// while genuinely parked (non-nil marker on a non-terminal run).
 	if rv.AwaitingAgentSince != nil && !terminalStatus(rv.Status) {
 		fields = append(fields, toon.Field{Key: "awaiting_agent", Value: formatParkedFor(*rv.AwaitingAgentSince)})
+	}
+	if rv.ProvisioningPhase != "" {
+		fields = append(fields, toon.Field{Key: "provisioning", Value: fmt.Sprintf("%s (%d%%)", rv.ProvisioningPhase, rv.ProvisioningProgress)})
+	}
+	if rv.ProvisioningError != "" {
+		fields = append(fields, toon.Field{Key: "provisioning_error", Value: rv.ProvisioningError})
+	}
+	if rv.BlockedReason != "" {
+		fields = append(fields, toon.Field{Key: "blocked_reason", Value: rv.BlockedReason})
 	}
 	fields = append(fields, toon.Field{Key: "head", Value: shortSHA(rv.HeadSHA)})
 	if rv.PRURL != "" {

--- a/internal/cli/axi_route.go
+++ b/internal/cli/axi_route.go
@@ -37,6 +37,7 @@ type routeResultRow struct {
 	Round     int    `toon:"round"`
 	Phase     string `toon:"phase"`
 	Risk      string `toon:"risk"`
+	AppendSeq int64  `toon:"append_seq"`
 	CreatedAt int64  `toon:"created_at"`
 }
 
@@ -100,7 +101,7 @@ func runAxiRouteEvidence(cmd *cobra.Command, runID string) (string, error) {
 	for _, result := range results {
 		resultRows = append(resultRows, routeResultRow{
 			ID: result.ID, Step: result.StepName, Round: result.Round,
-			Phase: result.Phase, Risk: result.Risk, CreatedAt: result.CreatedAt,
+			Phase: result.Phase, Risk: result.Risk, AppendSeq: result.AppendSeq, CreatedAt: result.CreatedAt,
 		})
 	}
 	emitDoc(cmd,

--- a/internal/cli/axi_route.go
+++ b/internal/cli/axi_route.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	toon "github.com/toon-format/toon-go"
+
+	"github.com/kunchenguid/no-mistakes/internal/telemetry"
+	"github.com/spf13/cobra"
+)
+
+type routeDecisionRow struct {
+	ID              string `toon:"id"`
+	Step            string `toon:"step"`
+	Round           int    `toon:"round"`
+	RequestedAgent  string `toon:"requested_harness"`
+	EffectiveAgent  string `toon:"effective_harness"`
+	RequestedModel  string `toon:"requested_model"`
+	EffectiveModel  string `toon:"effective_model"`
+	RequestedEffort string `toon:"requested_effort"`
+	EffectiveEffort string `toon:"effective_effort"`
+	Policy          string `toon:"policy_version"`
+	Phase           string `toon:"phase"`
+	Risk            string `toon:"risk"`
+	Reason          string `toon:"reason"`
+	SourceConfig    string `toon:"source_configuration"`
+	Generation      string `toon:"configuration_generation"`
+	Repository      string `toon:"repository"`
+	PromptTransport string `toon:"prompt_transport"`
+	CreatedAt       int64  `toon:"created_at"`
+}
+
+type routeResultRow struct {
+	ID        string `toon:"id"`
+	Step      string `toon:"step"`
+	Round     int    `toon:"round"`
+	Phase     string `toon:"phase"`
+	Risk      string `toon:"risk"`
+	CreatedAt int64  `toon:"created_at"`
+}
+
+func newAxiRouteEvidenceCmd() *cobra.Command {
+	var runID string
+	cmd := &cobra.Command{
+		Use:           "route-evidence",
+		Short:         "Show immutable route decisions and completed review classifications",
+		Args:          cobra.NoArgs,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return trackReadSurface("axi-route-evidence", telemetry.Fields{
+				"explicit_run_id": strings.TrimSpace(runID) != "",
+			}, func() (string, string, error) {
+				fingerprint, err := runAxiRouteEvidence(cmd, runID)
+				return fingerprint, "", err
+			})
+		},
+	}
+	cmd.Flags().StringVar(&runID, "run", "", "run ID (default: active or most recent)")
+	return cmd
+}
+
+func runAxiRouteEvidence(cmd *cobra.Command, runID string) (string, error) {
+	env, err := openAxiEnv(false)
+	if err != nil {
+		return "", emitError(cmd, 1, err.Error(), repoInitHelp(err)...)
+	}
+	defer env.close()
+
+	run, err := resolveRun(env, runID, currentBranchForRunResolve(cmd.Context()))
+	if err != nil {
+		return "", emitError(cmd, 1, err.Error())
+	}
+	if run == nil {
+		return "", emitError(cmd, 1, "no run found to read route evidence from", startRunHelp())
+	}
+	decisions, err := env.d.RouteDecisions(run.ID)
+	if err != nil {
+		return "", emitError(cmd, 1, fmt.Sprintf("load route decisions: %v", err))
+	}
+	results, err := env.d.RouteResults(run.ID)
+	if err != nil {
+		return "", emitError(cmd, 1, fmt.Sprintf("load route results: %v", err))
+	}
+	decisionRows := make([]routeDecisionRow, 0, len(decisions))
+	for _, decision := range decisions {
+		decisionRows = append(decisionRows, routeDecisionRow{
+			ID: decision.ID, Step: decision.StepName, Round: decision.Round,
+			RequestedAgent: decision.RequestedHarness, EffectiveAgent: decision.EffectiveHarness,
+			RequestedModel: decision.RequestedModel, EffectiveModel: decision.EffectiveModel,
+			RequestedEffort: decision.RequestedEffort, EffectiveEffort: decision.EffectiveEffort,
+			Policy: decision.PolicyVersion, Phase: decision.Phase, Risk: decision.Risk,
+			Reason: decision.Reason, SourceConfig: decision.SourceConfiguration,
+			Generation: decision.ConfigurationGeneration, Repository: decision.Repository,
+			PromptTransport: decision.PromptTransport, CreatedAt: decision.CreatedAt,
+		})
+	}
+	resultRows := make([]routeResultRow, 0, len(results))
+	for _, result := range results {
+		resultRows = append(resultRows, routeResultRow{
+			ID: result.ID, Step: result.StepName, Round: result.Round,
+			Phase: result.Phase, Risk: result.Risk, CreatedAt: result.CreatedAt,
+		})
+	}
+	emitDoc(cmd,
+		toon.Field{Key: "run", Value: run.ID},
+		toon.Field{Key: "route_decisions", Value: decisionRows},
+		toon.Field{Key: "review_results", Value: resultRows},
+	)
+	return run.ID + "|route-decisions:" + fmt.Sprint(len(decisionRows)) + "|review-results:" + fmt.Sprint(len(resultRows)), nil
+}

--- a/internal/cli/axi_route_test.go
+++ b/internal/cli/axi_route_test.go
@@ -64,7 +64,7 @@ func TestAxiRouteEvidenceRendersStableDecisionAndPostResultArrays(t *testing.T) 
 	for _, want := range []string{
 		"run: \"" + run.ID + "\"",
 		"route_decisions[1]{id,step,round,requested_harness,effective_harness,requested_model,effective_model,requested_effort,effective_effort,policy_version,phase,risk,reason,source_configuration,configuration_generation,repository,prompt_transport,created_at}:",
-		"review_results[1]{id,step,round,phase,risk,created_at}:",
+		"review_results[1]{id,step,round,phase,risk,append_seq,created_at}:",
 		"cfg",
 		"gen-1",
 		"medium",

--- a/internal/cli/axi_route_test.go
+++ b/internal/cli/axi_route_test.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/git"
+	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/routing"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+	"github.com/spf13/cobra"
+)
+
+func TestAxiRouteEvidenceRendersStableDecisionAndPostResultArrays(t *testing.T) {
+	setupTestRepo(t)
+	p := paths.WithRoot(os.Getenv("NM_HOME"))
+	database, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer database.Close()
+	gitRoot, err := git.FindGitRoot(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo, err := database.InsertRepoWithID("repo-route", gitRoot, "origin", "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := database.InsertRun(repo.ID, "route-canary", "head", "base")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.InsertRouteDecision(db.RouteDecision{
+		RunID: run.ID, StepName: string(types.StepReview), Round: 1,
+		RequestedHarness: "codex", EffectiveHarness: "codex",
+		RequestedModel: routing.ModelLuna, EffectiveModel: routing.ModelLuna,
+		RequestedEffort: routing.EffortXHigh, EffectiveEffort: routing.EffortXHigh,
+		PolicyVersion: routing.PolicyVersion, Phase: "review", Risk: "unknown",
+		Reason: "default initial/default work", SourceConfiguration: "cfg",
+		ConfigurationGeneration: "gen-1", Repository: "github.com/example/repo",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.InsertRouteResult(db.RouteResult{
+		RunID: run.ID, StepName: string(types.StepReview), Round: 1,
+		Phase: "review", Risk: string(routing.RiskMedium),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&out)
+	if _, err := runAxiRouteEvidence(cmd, run.ID); err != nil {
+		t.Fatalf("route evidence: %v\n%s", err, out.String())
+	}
+	got := out.String()
+	for _, want := range []string{
+		"run: \"" + run.ID + "\"",
+		"route_decisions[1]{id,step,round,requested_harness,effective_harness,requested_model,effective_model,requested_effort,effective_effort,policy_version,phase,risk,reason,source_configuration,configuration_generation,repository,prompt_transport,created_at}:",
+		"review_results[1]{id,step,round,phase,risk,created_at}:",
+		"cfg",
+		"gen-1",
+		"medium",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("route evidence missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/cli/telemetry_test.go
+++ b/internal/cli/telemetry_test.go
@@ -86,6 +86,9 @@ func (r *telemetryRecorder) find(name, field string, want any) *recordedTelemetr
 }
 
 func TestInitTracksCommandTelemetry(t *testing.T) {
+	// Starting the child daemon can exceed the production default while this
+	// package is race-instrumented and the host is under concurrent load.
+	t.Setenv("NM_TEST_DAEMON_START_TIMEOUT", "30s")
 	setupTestRepo(t)
 
 	recorder := &telemetryRecorder{}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -421,8 +421,8 @@ var defaultBinary = map[types.AgentName]string{
 
 // agentProbeOrder is the priority order for auto-detecting agents.
 var agentProbeOrder = []types.AgentName{
-	types.AgentClaude,
 	types.AgentCodex,
+	types.AgentClaude,
 	types.AgentOpenCode,
 	types.AgentRovoDev,
 	types.AgentPi,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kunchenguid/no-mistakes/internal/routing"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 	"github.com/kunchenguid/no-mistakes/internal/winproc"
 	"gopkg.in/yaml.v3"
@@ -61,9 +62,12 @@ type GlobalConfig struct {
 	// separate durable fixer session across fix turns). Default true; set
 	// session_reuse: false to force every invocation cold.
 	SessionReuse bool `yaml:"-"`
-	AutoFix      AutoFixRaw
-	Intent       IntentRaw
-	Test         TestRaw
+	// RoutingGeneration is derived from the exact loaded file (or built-in
+	// defaults), never supplied by project metadata.
+	RoutingGeneration string `yaml:"-"`
+	AutoFix           AutoFixRaw
+	Intent            IntentRaw
+	Test              TestRaw
 }
 
 // globalConfigRaw is the on-disk YAML representation with duration as string.
@@ -209,6 +213,10 @@ type Config struct {
 	// project-level settings/instructions suppressed; the daemon fails the run
 	// closed if the resolved harness has no verified suppression knob.
 	DisableProjectSettings bool
+	// RoutingGeneration is the explicit configuration generation captured when
+	// the daemon loads this config. It prevents a long-lived daemon from making
+	// route decisions without an auditable source generation.
+	RoutingGeneration string
 }
 
 // Document is the resolved document-step config. Instructions come from the
@@ -772,10 +780,12 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
+			cfg.RoutingGeneration = routing.ConfigFingerprint("builtin-global-defaults")
 			return cfg, nil
 		}
 		return nil, fmt.Errorf("read global config: %w", err)
 	}
+	cfg.RoutingGeneration = routing.ConfigFingerprint(string(data))
 
 	var raw globalConfigRaw
 	dec := yaml.NewDecoder(bytes.NewReader(data))
@@ -1132,6 +1142,7 @@ func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 		// repo is the EffectiveRepoConfig result, so this value is already
 		// trusted-only (EffectiveRepoConfig sourced it from the trusted copy).
 		DisableProjectSettings: repo.DisableProjectSettings,
+		RoutingGeneration:      global.RoutingGeneration,
 	}
 
 	if repo.Agent != "" {

--- a/internal/config/config_global_test.go
+++ b/internal/config/config_global_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kunchenguid/no-mistakes/internal/routing"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 	"gopkg.in/yaml.v3"
 )
@@ -34,6 +35,33 @@ func TestLoadGlobal_Defaults(t *testing.T) {
 	}
 	if len(cfg.AgentPathOverride) != 0 {
 		t.Errorf("agent_path_override = %v, want empty", cfg.AgentPathOverride)
+	}
+	if cfg.RoutingGeneration == "" {
+		t.Fatal("missing built-in routing generation")
+	}
+}
+
+func TestLoadGlobalRoutingGenerationChangesWithSource(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("agent: auto\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	first, err := LoadGlobal(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.RoutingGeneration != routing.ConfigFingerprint("agent: auto\n") {
+		t.Fatalf("generation = %q, want source fingerprint", first.RoutingGeneration)
+	}
+	if err := os.WriteFile(path, []byte("agent: codex\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	second, err := LoadGlobal(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.RoutingGeneration == second.RoutingGeneration {
+		t.Fatalf("stale routing generation reused: %q", first.RoutingGeneration)
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -273,6 +273,24 @@ func recoverOnStartup(d *db.DB, p *paths.Paths, mgr *RunManager) {
 	for _, plan := range plans {
 		preserved[plan.run.ID] = struct{}{}
 	}
+	// Authorization parks are deliberately not reconstructed into a live
+	// executor. Replaying an agent turn with unknown completion could repeat a
+	// mutating fixer, so keep the run and worktree durable for explicit resume.
+	if active, err := d.GetActiveRuns(); err == nil {
+		for _, run := range active {
+			if run.Status == types.RunAwaitingAuth {
+				preserved[run.ID] = struct{}{}
+			}
+		}
+	}
+	provisioning, provisionErr := d.GetProvisioningRuns()
+	if provisionErr != nil {
+		slog.Error("failed to inspect provisioning runs", "error", provisionErr)
+	} else {
+		for _, run := range provisioning {
+			preserved[run.ID] = struct{}{}
+		}
+	}
 	count, err := d.RecoverStaleRunsExcept("daemon crashed during execution", preserved)
 	if err != nil {
 		slog.Error("failed to recover stale runs", "error", err)
@@ -286,6 +304,9 @@ func recoverOnStartup(d *db.DB, p *paths.Paths, mgr *RunManager) {
 	}
 
 	cleanupOrphanWorktrees(d, p)
+	if provisionErr == nil {
+		mgr.resumeProvisioningRuns(provisioning)
+	}
 	mgr.resumeRecoveredRuns(plans)
 }
 
@@ -355,7 +376,7 @@ func skipWorktreeCleanup(d *db.DB, runID string) (bool, string) {
 	if err != nil {
 		return true, fmt.Sprintf("failed to look up run %s: %v", runID, err)
 	}
-	if run != nil && (run.Status == types.RunPending || run.Status == types.RunRunning) {
+	if run != nil && (run.Status == types.RunPending || run.Status == types.RunProvisioning || run.Status == types.RunRunning || run.Status == types.RunAwaitingAuth || run.BlockedReason != nil) {
 		return true, fmt.Sprintf("run %s is %s", runID, run.Status)
 	}
 	return false, ""
@@ -554,18 +575,22 @@ func registerHandlers(srv *ipc.Server, mgr *RunManager, d *db.DB, shutdown func(
 
 func runToInfo(d *db.DB, r *db.Run, steps []*db.StepResult) *ipc.RunInfo {
 	info := &ipc.RunInfo{
-		ID:                 r.ID,
-		RepoID:             r.RepoID,
-		Branch:             r.Branch,
-		HeadSHA:            r.HeadSHA,
-		BaseSHA:            r.BaseSHA,
-		Status:             r.Status,
-		PRURL:              r.PRURL,
-		Error:              r.Error,
-		AwaitingAgent:      r.AwaitingAgentSince != nil,
-		AwaitingAgentSince: r.AwaitingAgentSince,
-		CreatedAt:          r.CreatedAt,
-		UpdatedAt:          r.UpdatedAt,
+		ID:                   r.ID,
+		RepoID:               r.RepoID,
+		Branch:               r.Branch,
+		HeadSHA:              r.HeadSHA,
+		BaseSHA:              r.BaseSHA,
+		Status:               r.Status,
+		ProvisioningPhase:    r.ProvisioningPhase,
+		ProvisioningProgress: r.ProvisioningProgress,
+		ProvisioningError:    r.ProvisioningError,
+		PRURL:                r.PRURL,
+		Error:                r.Error,
+		BlockedReason:        r.BlockedReason,
+		AwaitingAgent:        r.AwaitingAgentSince != nil,
+		AwaitingAgentSince:   r.AwaitingAgentSince,
+		CreatedAt:            r.CreatedAt,
+		UpdatedAt:            r.UpdatedAt,
 	}
 	if len(steps) > 0 {
 		info.Steps = make([]ipc.StepResultInfo, 0, len(steps))

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -273,9 +273,9 @@ func recoverOnStartup(d *db.DB, p *paths.Paths, mgr *RunManager) {
 	for _, plan := range plans {
 		preserved[plan.run.ID] = struct{}{}
 	}
-	// Authorization parks are deliberately not reconstructed into a live
-	// executor. Replaying an agent turn with unknown completion could repeat a
-	// mutating fixer, so keep the run and worktree durable for explicit resume.
+	// Authorization parks are reconstructed only as a waiting executor. The
+	// parked provider turn is never replayed during startup; an operator must
+	// explicitly approve/fix after refreshing authentication.
 	if active, err := d.GetActiveRuns(); err == nil {
 		for _, run := range active {
 			if run.Status == types.RunAwaitingAuth {

--- a/internal/daemon/lifecycle_test.go
+++ b/internal/daemon/lifecycle_test.go
@@ -559,7 +559,10 @@ func TestWaitForProcessExitRetriesTransientInspectionErrors(t *testing.T) {
 		daemonProcessRunning = originalProcessRunning
 	})
 
-	waitForProcessExit(4242, 50*time.Millisecond)
+	// Race-instrumented test binaries can be descheduled between the transient
+	// inspection error and the retry that observes the process exit. Keep the
+	// assertion about retrying, but leave enough time for that scheduling.
+	waitForProcessExit(4242, 500*time.Millisecond)
 
 	if checks < 3 {
 		t.Fatalf("waitForProcessExit stopped after %d checks, want at least 3", checks)

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/paths"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline/steps"
+	"github.com/kunchenguid/no-mistakes/internal/routing"
 	"github.com/kunchenguid/no-mistakes/internal/telemetry"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
@@ -33,15 +34,17 @@ var fetchRecoveredRemoteBranch = git.FetchRemoteBranch
 
 // RunManager tracks active pipeline executors and manages run lifecycle.
 type RunManager struct {
-	mu           sync.Mutex
-	executors    map[string]*pipeline.Executor      // runID → executor
-	cancels      map[string]context.CancelCauseFunc // runID → cancel function with cause
-	dones        map[string]chan struct{}           // runID → closed when goroutine exits
-	wg           sync.WaitGroup                     // tracks background run goroutines
-	shuttingDown atomic.Bool                        // prevents new runs during shutdown
-	db           *db.DB
-	paths        *paths.Paths
-	steps        StepFactory
+	mu               sync.Mutex
+	executors        map[string]*pipeline.Executor      // runID → executor
+	cancels          map[string]context.CancelCauseFunc // runID → cancel function with cause
+	dones            map[string]chan struct{}           // runID → closed when goroutine exits
+	wg               sync.WaitGroup                     // tracks background run goroutines
+	provisionCancels map[string]context.CancelCauseFunc
+	provisionSlots   chan struct{}
+	shuttingDown     atomic.Bool // prevents new runs during shutdown
+	db               *db.DB
+	paths            *paths.Paths
+	steps            StepFactory
 
 	branchLocks sync.Map // repoID+"/"+branch → *sync.Mutex
 
@@ -57,14 +60,16 @@ func NewRunManager(database *db.DB, p *paths.Paths, stepFactory StepFactory) *Ru
 		stepFactory = func() []pipeline.Step { return steps.AllSteps() }
 	}
 	return &RunManager{
-		executors:     make(map[string]*pipeline.Executor),
-		cancels:       make(map[string]context.CancelCauseFunc),
-		dones:         make(map[string]chan struct{}),
-		db:            database,
-		paths:         p,
-		steps:         stepFactory,
-		subscribers:   make(map[string][]chan<- ipc.Event),
-		completedRuns: make(map[string]bool),
+		executors:        make(map[string]*pipeline.Executor),
+		cancels:          make(map[string]context.CancelCauseFunc),
+		dones:            make(map[string]chan struct{}),
+		provisionCancels: make(map[string]context.CancelCauseFunc),
+		provisionSlots:   make(chan struct{}, 2),
+		db:               database,
+		paths:            p,
+		steps:            stepFactory,
+		subscribers:      make(map[string][]chan<- ipc.Event),
+		completedRuns:    make(map[string]bool),
 	}
 }
 
@@ -105,7 +110,7 @@ func (m *RunManager) recoverableParkedRuns(ctx context.Context) []recoveredRunPl
 }
 
 func (m *RunManager) prepareRecoveredRun(ctx context.Context, run *db.Run) (*recoveredRunPlan, error) {
-	if run == nil || run.Status != types.RunRunning || run.AwaitingAgentSince == nil || run.Branch == "" {
+	if run == nil || (run.Status != types.RunRunning && run.Status != types.RunAwaitingAuth) || run.AwaitingAgentSince == nil || run.Branch == "" {
 		return nil, fmt.Errorf("run is not a parked running run")
 	}
 	repo, err := m.db.GetRepo(run.RepoID)
@@ -275,6 +280,52 @@ func (m *RunManager) resumeRecoveredRuns(plans []recoveredRunPlan) {
 	}
 }
 
+// resumeProvisioningRuns re-queues durable setup rows after a daemon restart.
+// Any partially materialized checkout is removed first; no pipeline agent has
+// been launched until provisioning reaches the ready projection.
+func (m *RunManager) resumeProvisioningRuns(runs []*db.Run) {
+	for _, run := range runs {
+		repo, err := m.db.GetRepo(run.RepoID)
+		if err != nil || repo == nil {
+			slog.Error("cannot recover provisioning run repository", "run_id", run.ID, "error", err)
+			continue
+		}
+		ctx, cancel := context.WithCancelCause(context.Background())
+		m.mu.Lock()
+		m.provisionCancels[run.ID] = cancel
+		m.mu.Unlock()
+		m.wg.Add(1)
+		go func(run *db.Run, repo *db.Repo, ctx context.Context) {
+			defer m.wg.Done()
+			defer func() {
+				m.mu.Lock()
+				delete(m.provisionCancels, run.ID)
+				m.mu.Unlock()
+			}()
+			select {
+			case m.provisionSlots <- struct{}{}:
+			case <-ctx.Done():
+				return
+			}
+			defer func() { <-m.provisionSlots }()
+			gateDir := m.paths.RepoDir(repo.ID)
+			wtDir := m.paths.WorktreeDir(repo.ID, run.ID)
+			_ = git.WorktreeRemove(context.Background(), gateDir, wtDir)
+			branchRole := telemetryBranchRole(run.Branch, repo.DefaultBranch)
+			track := func(stage string) {
+				telemetry.Track("run", telemetry.Fields{"action": "start_failed", "trigger": "restart", "branch_role": branchRole, "stage": stage})
+			}
+			if err := m.provisionRun(ctx, repo, run.Branch, run.HeadSHA, run.BaseSHA, "restart", nil, run, branchRole, track); err != nil {
+				if cause := context.Cause(ctx); cause != nil {
+					_ = m.db.UpdateRunErrorStatus(run.ID, cause.Error(), types.RunCancelled)
+				} else {
+					_ = m.db.FailRunProvisioning(run.ID, "failed", err)
+				}
+			}
+		}(run, repo, ctx)
+	}
+}
+
 func (m *RunManager) resumeRecoveredRun(plan recoveredRunPlan) {
 	if m.shuttingDown.Load() {
 		_ = plan.agent.Close()
@@ -282,6 +333,9 @@ func (m *RunManager) resumeRecoveredRun(plan recoveredRunPlan) {
 	}
 	runCtx, cancel := context.WithCancelCause(context.Background())
 	executor := pipeline.NewExecutor(m.db, m.paths, plan.cfg, plan.agent, plan.steps, m.broadcast)
+	executor.SetRouteContext(plan.repo.UpstreamURL, routing.ConfigFingerprint(
+		string(plan.cfg.Agent), strings.Join(agentNames(plan.cfg.Agents), ","),
+		plan.cfg.RoutingGeneration, plan.cfg.AgentPathFor(plan.cfg.Agent)), plan.cfg.RoutingGeneration)
 	done := make(chan struct{})
 	m.mu.Lock()
 	m.executors[plan.run.ID] = executor
@@ -306,8 +360,12 @@ func (m *RunManager) resumeRecoveredRun(plan recoveredRunPlan) {
 			cancel(nil)
 			_ = plan.agent.Close()
 			m.closeSubscribers(plan.run.ID)
-			if err := git.WorktreeRemove(context.Background(), plan.gateDir, plan.workDir); err != nil {
-				slog.Warn("failed to remove recovered worktree", "path", plan.workDir, "error", err)
+			if plan.run.BlockedReason == nil && plan.run.Status != types.RunAwaitingAuth {
+				if err := git.WorktreeRemove(context.Background(), plan.gateDir, plan.workDir); err != nil {
+					slog.Warn("failed to remove recovered worktree", "path", plan.workDir, "error", err)
+				}
+			} else {
+				slog.Info("preserving parked authorization worktree", "run_id", plan.run.ID, "path", plan.workDir)
 			}
 			m.mu.Lock()
 			delete(m.executors, plan.run.ID)
@@ -587,9 +645,10 @@ func (m *RunManager) HandleRerun(ctx context.Context, repoID, branch string, ski
 	return m.startRun(ctx, repo, branch, headSHA, baseSHA, "rerun", skipSteps, intent)
 }
 
-// startRun creates a run, sets up a worktree, and launches pipeline execution.
-// A non-empty intent is stamped onto the run as agent-supplied, so the intent
-// step uses it instead of inferring from transcripts.
+// startRun admits a run and returns after durable provisioning has been
+// queued. Worktree checkout, trusted-config loading, and agent construction
+// run outside the IPC request so slow repositories cannot hold the daemon
+// request open.
 func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSHA, baseSHA, trigger string, skipSteps []types.StepName, intent string) (string, error) {
 	branchRole := telemetryBranchRole(branch, repo.DefaultBranch)
 	trackStartFailure := func(stage string) {
@@ -606,28 +665,21 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 		return "", fmt.Errorf("daemon is shutting down")
 	}
 
-	// Serialize per repo+branch to prevent two concurrent pushes from both
-	// passing cancelActiveRuns and creating duplicate pipelines.
+	// Serialize only admission. Provisioning itself is bounded separately and
+	// must not hold this lock for the duration of a checkout.
 	lockKey := repo.ID + "/" + branch
 	lockVal, _ := m.branchLocks.LoadOrStore(lockKey, &sync.Mutex{})
 	branchMu := lockVal.(*sync.Mutex)
 	branchMu.Lock()
 	defer branchMu.Unlock()
 
-	// Cancel any active run for this repo+branch.
 	m.cancelActiveRuns(repo.ID, branch)
-
-	// Create run record.
 	run, err := m.db.InsertRun(repo.ID, branch, headSHA, baseSHA)
 	if err != nil {
 		trackStartFailure("create_run")
 		return "", fmt.Errorf("create run: %w", err)
 	}
 
-	// Stamp an agent-supplied intent onto the run before the pipeline starts,
-	// so the intent step finds it already present and skips transcript-based
-	// inference. A persist failure is non-fatal: the intent step would simply
-	// fall back to inference.
 	if trimmed := strings.TrimSpace(intent); trimmed != "" {
 		if err := m.db.UpdateRunIntent(run.ID, db.RunIntent{Summary: trimmed, Source: db.RunIntentSourceAgent, Score: 1}); err != nil {
 			slog.Warn("failed to persist agent-supplied intent", "run_id", run.ID, "error", err)
@@ -639,6 +691,48 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 			run.IntentScore = &score
 		}
 	}
+	if err := m.db.SetRunProvisioning(run.ID, "queued", 0, ""); err != nil {
+		return "", fmt.Errorf("record provisioning: %w", err)
+	}
+	provisionCtx, cancelProvision := context.WithCancelCause(context.Background())
+	m.mu.Lock()
+	m.provisionCancels[run.ID] = cancelProvision
+	m.mu.Unlock()
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		defer func() {
+			m.mu.Lock()
+			delete(m.provisionCancels, run.ID)
+			m.mu.Unlock()
+		}()
+		select {
+		case m.provisionSlots <- struct{}{}:
+		case <-provisionCtx.Done():
+			cause := context.Cause(provisionCtx)
+			if cause == nil {
+				cause = context.Canceled
+			}
+			_ = m.db.UpdateRunErrorStatus(run.ID, cause.Error(), types.RunCancelled)
+			return
+		}
+		defer func() { <-m.provisionSlots }()
+		if err := m.provisionRun(provisionCtx, repo, branch, headSHA, baseSHA, trigger, skipSteps, run, branchRole, trackStartFailure); err != nil {
+			if cause := context.Cause(provisionCtx); cause != nil {
+				_ = m.db.UpdateRunErrorStatus(run.ID, cause.Error(), types.RunCancelled)
+			} else if run.Status == types.RunProvisioning || run.Status == types.RunPending {
+				_ = m.db.FailRunProvisioning(run.ID, "failed", err)
+			}
+			slog.Error("run provisioning failed", "run_id", run.ID, "error", err)
+		}
+	}()
+	return run.ID, nil
+}
+
+func (m *RunManager) provisionRun(ctx context.Context, repo *db.Repo, branch, headSHA, baseSHA, trigger string, skipSteps []types.StepName, run *db.Run, branchRole string, trackStartFailure func(string)) error {
+	if err := m.db.SetRunProvisioning(run.ID, "worktree", 5, ""); err != nil {
+		return err
+	}
 
 	// Create worktree from the gate bare repo.
 	gateDir := m.paths.RepoDir(repo.ID)
@@ -646,12 +740,12 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 	if err := git.WorktreeAdd(ctx, gateDir, wtDir, headSHA); err != nil {
 		m.db.UpdateRunError(run.ID, fmt.Sprintf("create worktree: %s", err))
 		trackStartFailure("create_worktree")
-		return "", fmt.Errorf("create worktree: %w", err)
+		return fmt.Errorf("create worktree: %w", err)
 	}
 	if err := git.CopyLocalUserIdentity(ctx, repo.WorkingPath, wtDir); err != nil {
 		m.db.UpdateRunError(run.ID, fmt.Sprintf("configure worktree git identity: %s", err))
 		trackStartFailure("configure_worktree_identity")
-		return "", fmt.Errorf("configure worktree git identity: %w", err)
+		return fmt.Errorf("configure worktree git identity: %w", err)
 	}
 	// Fetch the trusted default branch and resolve it to an exact commit SHA
 	// before any read. Reading the trusted config at this pinned SHA (rather
@@ -688,13 +782,13 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 	if err != nil {
 		m.db.UpdateRunError(run.ID, fmt.Sprintf("load config: %s", err))
 		trackStartFailure("load_global_config")
-		return "", fmt.Errorf("load global config: %w", err)
+		return fmt.Errorf("load global config: %w", err)
 	}
 	repoCfg, err := config.LoadRepo(wtDir)
 	if err != nil {
 		m.db.UpdateRunError(run.ID, fmt.Sprintf("load config: %s", err))
 		trackStartFailure("load_repo_config")
-		return "", fmt.Errorf("load repo config: %w", err)
+		return fmt.Errorf("load repo config: %w", err)
 	}
 	// SECURITY: load the code-executing selection fields (commands.* and
 	// agent) from the trusted default-branch copy of .no-mistakes.yaml rather
@@ -715,7 +809,7 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 	if err := assertGateTrustedConfigReadable(ctx, wtDir, repo.DefaultBranch, trustedSHA); err != nil {
 		m.db.UpdateRunError(run.ID, err.Error())
 		trackStartFailure("trusted_config_unreadable")
-		return "", err
+		return err
 	}
 	trustedRepoCfg := loadTrustedRepoConfig(ctx, wtDir, trustedSHA, run.ID)
 	allowRepoCommands := trustedRepoCfg != nil && trustedRepoCfg.AllowRepoCommands
@@ -738,7 +832,7 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 		if err := cfg.ResolveAgent(ctx, exec.LookPath); err != nil {
 			m.db.UpdateRunError(run.ID, err.Error())
 			trackStartFailure("resolve_agent")
-			return "", err
+			return err
 		}
 		agents := cfg.Agents
 		if len(agents) == 0 {
@@ -753,7 +847,7 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 			if agErr != nil {
 				m.db.UpdateRunError(run.ID, fmt.Sprintf("create agent %s: %s", name, agErr))
 				trackStartFailure("create_agent")
-				return "", fmt.Errorf("create agent %s: %w", name, agErr)
+				return fmt.Errorf("create agent %s: %w", name, agErr)
 			}
 			// Steer every pipeline agent to keep writes inside the worktree and
 			// avoid mutating system state (e.g. brew/Homebrew touching
@@ -770,10 +864,19 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 			if err := agent.EnsureGateNeutralized(ag); err != nil {
 				m.db.UpdateRunError(run.ID, err.Error())
 				trackStartFailure("gate_not_neutralized")
-				return "", err
+				return err
 			}
 		}
 	}
+	if err := m.db.SetRunProvisioning(run.ID, "agent-ready", 85, ""); err != nil {
+		_ = ag.Close()
+		return err
+	}
+	if err := m.db.CompleteRunProvisioning(run.ID); err != nil {
+		_ = ag.Close()
+		return err
+	}
+	run.Status = types.RunPending
 
 	execSteps := m.steps()
 	telemetry.Track("run", telemetry.Fields{
@@ -788,6 +891,9 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 	// Create executor with event broadcast.
 	runCtx, cancel := context.WithCancelCause(context.Background())
 	executor := pipeline.NewExecutor(m.db, m.paths, cfg, ag, execSteps, m.broadcast)
+	executor.SetRouteContext(repo.UpstreamURL, routing.ConfigFingerprint(
+		string(cfg.Agent), strings.Join(agentNames(cfg.Agents), ","),
+		cfg.RoutingGeneration, cfg.AgentPathFor(cfg.Agent)), cfg.RoutingGeneration)
 	executor.SetSkippedSteps(skipSteps)
 
 	// Track executor.
@@ -833,12 +939,16 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 				}
 			}
 			cancel(nil)
-			ag.Close()
+			_ = ag.Close()
 			// Close subscriber channels for this run.
 			m.closeSubscribers(run.ID)
 			// Clean up worktree.
-			if rmErr := git.WorktreeRemove(context.Background(), gateDir, wtDir); rmErr != nil {
-				slog.Warn("failed to remove worktree", "path", wtDir, "error", rmErr)
+			if run.BlockedReason == nil {
+				if rmErr := git.WorktreeRemove(context.Background(), gateDir, wtDir); rmErr != nil {
+					slog.Warn("failed to remove worktree", "path", wtDir, "error", rmErr)
+				}
+			} else {
+				slog.Info("retaining worktree for recoverable blocked run", "run_id", run.ID, "path", wtDir)
 			}
 			// Remove tracking.
 			m.mu.Lock()
@@ -882,7 +992,7 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 		}
 	}()
 
-	return run.ID, nil
+	return nil
 }
 
 // addRunPerformanceSummary attaches the bounded per-run performance rollup
@@ -907,6 +1017,14 @@ func telemetryBranchRole(branch, defaultBranch string) string {
 		return "default"
 	}
 	return "feature"
+}
+
+func agentNames(names []types.AgentName) []string {
+	result := make([]string, 0, len(names))
+	for _, name := range names {
+		result = append(result, string(name))
+	}
+	return result
 }
 
 func telemetryFailedStepName(database *db.DB, runID string) string {
@@ -945,7 +1063,6 @@ func (m *RunManager) HandleRespondWithOverrides(runID string, step types.StepNam
 // orphaned goroutines from continuing agent calls and git operations.
 func (m *RunManager) Shutdown() {
 	m.shuttingDown.Store(true)
-
 	m.mu.Lock()
 	cancels := make(map[string]context.CancelCauseFunc, len(m.cancels))
 	for id, cancel := range m.cancels {
@@ -956,6 +1073,16 @@ func (m *RunManager) Shutdown() {
 	for id, cancel := range cancels {
 		cancel(fmt.Errorf("daemon shutting down"))
 		slog.Info("cancelled run on shutdown", "run_id", id)
+	}
+	m.mu.Lock()
+	provisionCancels := make(map[string]context.CancelCauseFunc, len(m.provisionCancels))
+	for id, cancel := range m.provisionCancels {
+		provisionCancels[id] = cancel
+	}
+	m.mu.Unlock()
+	for id, cancel := range provisionCancels {
+		cancel(fmt.Errorf("daemon shutting down"))
+		slog.Info("cancelled provisioning on shutdown", "run_id", id)
 	}
 
 	done := make(chan struct{})
@@ -974,6 +1101,9 @@ func (m *RunManager) Shutdown() {
 func (m *RunManager) HandleCancel(runID string) error {
 	m.mu.Lock()
 	cancel, ok := m.cancels[runID]
+	if !ok {
+		cancel, ok = m.provisionCancels[runID]
+	}
 	m.mu.Unlock()
 
 	if !ok {
@@ -1001,15 +1131,22 @@ func (m *RunManager) cancelActiveRuns(repoID, branch string) {
 		if run.Branch != branch {
 			continue
 		}
-		if run.Status != types.RunPending && run.Status != types.RunRunning {
+		if run.Status != types.RunPending && run.Status != types.RunProvisioning && run.Status != types.RunRunning && run.Status != types.RunAwaitingAuth {
 			continue
 		}
 
 		m.mu.Lock()
 		cancel, ok := m.cancels[run.ID]
+		if !ok {
+			cancel = m.provisionCancels[run.ID]
+			ok = cancel != nil
+		}
 		done := m.dones[run.ID]
 		m.mu.Unlock()
 		if !ok {
+			if run.Status == types.RunAwaitingAuth {
+				_ = m.db.UpdateRunErrorStatus(run.ID, types.RunCancelReasonSuperseded, types.RunCancelled)
+			}
 			continue
 		}
 

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -41,6 +41,7 @@ type RunManager struct {
 	wg               sync.WaitGroup                     // tracks background run goroutines
 	provisionCancels map[string]context.CancelCauseFunc
 	provisionSlots   chan struct{}
+	provisionQueue   chan struct{}
 	shuttingDown     atomic.Bool // prevents new runs during shutdown
 	db               *db.DB
 	paths            *paths.Paths
@@ -65,6 +66,7 @@ func NewRunManager(database *db.DB, p *paths.Paths, stepFactory StepFactory) *Ru
 		dones:            make(map[string]chan struct{}),
 		provisionCancels: make(map[string]context.CancelCauseFunc),
 		provisionSlots:   make(chan struct{}, 2),
+		provisionQueue:   make(chan struct{}, 16),
 		db:               database,
 		paths:            p,
 		steps:            stepFactory,
@@ -294,9 +296,20 @@ func (m *RunManager) resumeProvisioningRuns(runs []*db.Run) {
 		m.mu.Lock()
 		m.provisionCancels[run.ID] = cancel
 		m.mu.Unlock()
+		select {
+		case m.provisionQueue <- struct{}{}:
+		default:
+			slog.Warn("provisioning recovery queue is full", "run_id", run.ID)
+			cancel(fmt.Errorf("provisioning recovery queue is full"))
+			m.mu.Lock()
+			delete(m.provisionCancels, run.ID)
+			m.mu.Unlock()
+			continue
+		}
 		m.wg.Add(1)
 		go func(run *db.Run, repo *db.Repo, ctx context.Context) {
 			defer m.wg.Done()
+			defer func() { <-m.provisionQueue }()
 			defer func() {
 				m.mu.Lock()
 				delete(m.provisionCancels, run.ID)
@@ -694,6 +707,12 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 	if err := m.db.SetRunProvisioning(run.ID, "queued", 0, ""); err != nil {
 		return "", fmt.Errorf("record provisioning: %w", err)
 	}
+	select {
+	case m.provisionQueue <- struct{}{}:
+	default:
+		_ = m.db.UpdateRunErrorStatus(run.ID, "provisioning queue is full", types.RunFailed)
+		return "", fmt.Errorf("provisioning queue is full")
+	}
 	provisionCtx, cancelProvision := context.WithCancelCause(context.Background())
 	m.mu.Lock()
 	m.provisionCancels[run.ID] = cancelProvision
@@ -701,6 +720,7 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 	m.wg.Add(1)
 	go func() {
 		defer m.wg.Done()
+		defer func() { <-m.provisionQueue }()
 		defer func() {
 			m.mu.Lock()
 			delete(m.provisionCancels, run.ID)

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -35,6 +35,7 @@ var fetchRecoveredRemoteBranch = git.FetchRemoteBranch
 // RunManager tracks active pipeline executors and manages run lifecycle.
 type RunManager struct {
 	mu               sync.Mutex
+	admissionMu      sync.RWMutex                       // serializes run admission with shutdown's Wait
 	executors        map[string]*pipeline.Executor      // runID → executor
 	cancels          map[string]context.CancelCauseFunc // runID → cancel function with cause
 	dones            map[string]chan struct{}           // runID → closed when goroutine exits
@@ -295,6 +296,12 @@ func (m *RunManager) resumeProvisioningRuns(runs []*db.Run) {
 		}
 		ctx, cancel := context.WithCancelCause(context.Background())
 		done := make(chan struct{})
+		m.admissionMu.RLock()
+		if m.shuttingDown.Load() {
+			m.admissionMu.RUnlock()
+			cancel(fmt.Errorf("daemon shutting down"))
+			continue
+		}
 		m.mu.Lock()
 		m.provisionCancels[run.ID] = cancel
 		m.dones[run.ID] = done
@@ -308,9 +315,11 @@ func (m *RunManager) resumeProvisioningRuns(runs []*db.Run) {
 			delete(m.provisionCancels, run.ID)
 			delete(m.dones, run.ID)
 			m.mu.Unlock()
+			m.admissionMu.RUnlock()
 			continue
 		}
 		m.wg.Add(1)
+		m.admissionMu.RUnlock()
 		go func(run *db.Run, repo *db.Repo, ctx context.Context, done chan struct{}) {
 			launched := false
 			defer m.wg.Done()
@@ -355,7 +364,9 @@ func (m *RunManager) resumeProvisioningRuns(runs []*db.Run) {
 }
 
 func (m *RunManager) resumeRecoveredRun(plan recoveredRunPlan) {
+	m.admissionMu.RLock()
 	if m.shuttingDown.Load() {
+		m.admissionMu.RUnlock()
 		_ = plan.agent.Close()
 		return
 	}
@@ -372,6 +383,7 @@ func (m *RunManager) resumeRecoveredRun(plan recoveredRunPlan) {
 	m.mu.Unlock()
 
 	m.wg.Add(1)
+	m.admissionMu.RUnlock()
 	go func() {
 		startedAt := time.Now()
 		defer m.wg.Done()
@@ -678,6 +690,11 @@ func (m *RunManager) HandleRerun(ctx context.Context, repoID, branch string, ski
 // run outside the IPC request so slow repositories cannot hold the daemon
 // request open.
 func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSHA, baseSHA, trigger string, skipSteps []types.StepName, intent string) (string, error) {
+	// Keep the read side held through branch-lock admission and wg.Add. This
+	// prevents Shutdown from completing its Wait while an already-admitted
+	// caller is still able to launch provisioning.
+	m.admissionMu.RLock()
+	defer m.admissionMu.RUnlock()
 	branchRole := telemetryBranchRole(branch, repo.DefaultBranch)
 	trackStartFailure := func(stage string) {
 		telemetry.Track("run", telemetry.Fields{
@@ -734,6 +751,8 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 	m.provisionCancels[run.ID] = cancelProvision
 	m.dones[run.ID] = done
 	m.mu.Unlock()
+	// startRun holds admissionMu through this Add, so shutdown cannot begin a
+	// Wait concurrently with this pipeline launch.
 	m.wg.Add(1)
 	go func() {
 		launched := false
@@ -1119,7 +1138,11 @@ func (m *RunManager) HandleRespondWithOverrides(runID string, step types.StepNam
 // Shutdown cancels all active runs. Called during daemon shutdown to prevent
 // orphaned goroutines from continuing agent calls and git operations.
 func (m *RunManager) Shutdown() {
+	// No new startRun caller may pass its admission point after shutdown begins.
+	// Release before cancelling/waiting so admitted work can drain normally.
+	m.admissionMu.Lock()
 	m.shuttingDown.Store(true)
+	m.admissionMu.Unlock()
 	m.mu.Lock()
 	cancels := make(map[string]context.CancelCauseFunc, len(m.cancels))
 	for id, cancel := range m.cancels {

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -112,7 +112,7 @@ func (m *RunManager) recoverableParkedRuns(ctx context.Context) []recoveredRunPl
 }
 
 func (m *RunManager) prepareRecoveredRun(ctx context.Context, run *db.Run) (*recoveredRunPlan, error) {
-	if run == nil || (run.Status != types.RunRunning && run.Status != types.RunAwaitingAuth) || run.AwaitingAgentSince == nil || run.Branch == "" {
+	if run == nil || (run.Status == types.RunRunning && run.AwaitingAgentSince == nil) || (run.Status != types.RunRunning && run.Status != types.RunAwaitingAuth) || run.Branch == "" {
 		return nil, fmt.Errorf("run is not a parked running run")
 	}
 	repo, err := m.db.GetRepo(run.RepoID)

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -42,6 +42,7 @@ type RunManager struct {
 	provisionCancels map[string]context.CancelCauseFunc
 	provisionSlots   chan struct{}
 	provisionQueue   chan struct{}
+	provisionHook    func(context.Context, string, *db.Run, string) error
 	shuttingDown     atomic.Bool // prevents new runs during shutdown
 	db               *db.DB
 	paths            *paths.Paths
@@ -293,8 +294,10 @@ func (m *RunManager) resumeProvisioningRuns(runs []*db.Run) {
 			continue
 		}
 		ctx, cancel := context.WithCancelCause(context.Background())
+		done := make(chan struct{})
 		m.mu.Lock()
 		m.provisionCancels[run.ID] = cancel
+		m.dones[run.ID] = done
 		m.mu.Unlock()
 		select {
 		case m.provisionQueue <- struct{}{}:
@@ -303,16 +306,26 @@ func (m *RunManager) resumeProvisioningRuns(runs []*db.Run) {
 			cancel(fmt.Errorf("provisioning recovery queue is full"))
 			m.mu.Lock()
 			delete(m.provisionCancels, run.ID)
+			delete(m.dones, run.ID)
 			m.mu.Unlock()
 			continue
 		}
 		m.wg.Add(1)
-		go func(run *db.Run, repo *db.Repo, ctx context.Context) {
+		go func(run *db.Run, repo *db.Repo, ctx context.Context, done chan struct{}) {
+			launched := false
 			defer m.wg.Done()
+			defer func() {
+				if !launched {
+					close(done)
+				}
+			}()
 			defer func() { <-m.provisionQueue }()
 			defer func() {
 				m.mu.Lock()
 				delete(m.provisionCancels, run.ID)
+				if !launched {
+					delete(m.dones, run.ID)
+				}
 				m.mu.Unlock()
 			}()
 			select {
@@ -323,19 +336,21 @@ func (m *RunManager) resumeProvisioningRuns(runs []*db.Run) {
 			defer func() { <-m.provisionSlots }()
 			gateDir := m.paths.RepoDir(repo.ID)
 			wtDir := m.paths.WorktreeDir(repo.ID, run.ID)
-			_ = git.WorktreeRemove(context.Background(), gateDir, wtDir)
+			removeProvisioningWorktree(gateDir, wtDir)
 			branchRole := telemetryBranchRole(run.Branch, repo.DefaultBranch)
 			track := func(stage string) {
 				telemetry.Track("run", telemetry.Fields{"action": "start_failed", "trigger": "restart", "branch_role": branchRole, "stage": stage})
 			}
-			if err := m.provisionRun(ctx, repo, run.Branch, run.HeadSHA, run.BaseSHA, "restart", nil, run, branchRole, track); err != nil {
+			var err error
+			launched, err = m.provisionRun(ctx, repo, run.Branch, run.HeadSHA, run.BaseSHA, "restart", nil, run, branchRole, track, done)
+			if err != nil {
 				if cause := context.Cause(ctx); cause != nil {
 					_ = m.db.UpdateRunErrorStatus(run.ID, cause.Error(), types.RunCancelled)
 				} else {
 					_ = m.db.FailRunProvisioning(run.ID, "failed", err)
 				}
 			}
-		}(run, repo, ctx)
+		}(run, repo, ctx, done)
 	}
 }
 
@@ -714,16 +729,27 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 		return "", fmt.Errorf("provisioning queue is full")
 	}
 	provisionCtx, cancelProvision := context.WithCancelCause(context.Background())
+	done := make(chan struct{})
 	m.mu.Lock()
 	m.provisionCancels[run.ID] = cancelProvision
+	m.dones[run.ID] = done
 	m.mu.Unlock()
 	m.wg.Add(1)
 	go func() {
+		launched := false
 		defer m.wg.Done()
+		defer func() {
+			if !launched {
+				close(done)
+			}
+		}()
 		defer func() { <-m.provisionQueue }()
 		defer func() {
 			m.mu.Lock()
 			delete(m.provisionCancels, run.ID)
+			if !launched {
+				delete(m.dones, run.ID)
+			}
 			m.mu.Unlock()
 		}()
 		select {
@@ -737,7 +763,9 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 			return
 		}
 		defer func() { <-m.provisionSlots }()
-		if err := m.provisionRun(provisionCtx, repo, branch, headSHA, baseSHA, trigger, skipSteps, run, branchRole, trackStartFailure); err != nil {
+		var err error
+		launched, err = m.provisionRun(provisionCtx, repo, branch, headSHA, baseSHA, trigger, skipSteps, run, branchRole, trackStartFailure, done)
+		if err != nil {
 			if cause := context.Cause(provisionCtx); cause != nil {
 				_ = m.db.UpdateRunErrorStatus(run.ID, cause.Error(), types.RunCancelled)
 			} else if run.Status == types.RunProvisioning || run.Status == types.RunPending {
@@ -749,23 +777,36 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 	return run.ID, nil
 }
 
-func (m *RunManager) provisionRun(ctx context.Context, repo *db.Repo, branch, headSHA, baseSHA, trigger string, skipSteps []types.StepName, run *db.Run, branchRole string, trackStartFailure func(string)) error {
+func (m *RunManager) provisionRun(ctx context.Context, repo *db.Repo, branch, headSHA, baseSHA, trigger string, skipSteps []types.StepName, run *db.Run, branchRole string, trackStartFailure func(string), done chan struct{}) (bool, error) {
 	if err := m.db.SetRunProvisioning(run.ID, "worktree", 5, ""); err != nil {
-		return err
+		return false, err
 	}
 
 	// Create worktree from the gate bare repo.
 	gateDir := m.paths.RepoDir(repo.ID)
 	wtDir := m.paths.WorktreeDir(repo.ID, run.ID)
+	// Track whether the background goroutine takes ownership of worktree cleanup.
+	// If setup fails before the goroutine launches, we must clean up here.
+	bgOwnsWorktree := false
+	defer func() {
+		if !bgOwnsWorktree {
+			removeProvisioningWorktree(gateDir, wtDir)
+		}
+	}()
 	if err := git.WorktreeAdd(ctx, gateDir, wtDir, headSHA); err != nil {
 		m.db.UpdateRunError(run.ID, fmt.Sprintf("create worktree: %s", err))
 		trackStartFailure("create_worktree")
-		return fmt.Errorf("create worktree: %w", err)
+		return false, fmt.Errorf("create worktree: %w", err)
+	}
+	if m.provisionHook != nil {
+		if err := m.provisionHook(ctx, "after_worktree", run, wtDir); err != nil {
+			return false, err
+		}
 	}
 	if err := git.CopyLocalUserIdentity(ctx, repo.WorkingPath, wtDir); err != nil {
 		m.db.UpdateRunError(run.ID, fmt.Sprintf("configure worktree git identity: %s", err))
 		trackStartFailure("configure_worktree_identity")
-		return fmt.Errorf("configure worktree git identity: %w", err)
+		return false, fmt.Errorf("configure worktree git identity: %w", err)
 	}
 	// Fetch the trusted default branch and resolve it to an exact commit SHA
 	// before any read. Reading the trusted config at this pinned SHA (rather
@@ -787,28 +828,17 @@ func (m *RunManager) provisionRun(ctx context.Context, repo *db.Repo, branch, he
 		}
 	}
 
-	// Track whether the background goroutine takes ownership of worktree cleanup.
-	// If setup fails before the goroutine launches, we must clean up here.
-	bgOwnsWorktree := false
-	defer func() {
-		if !bgOwnsWorktree {
-			if rmErr := git.WorktreeRemove(context.Background(), gateDir, wtDir); rmErr != nil {
-				slog.Warn("failed to remove worktree during setup cleanup", "path", wtDir, "error", rmErr)
-			}
-		}
-	}()
-
 	globalCfg, err := config.LoadGlobal(m.paths.ConfigFile())
 	if err != nil {
 		m.db.UpdateRunError(run.ID, fmt.Sprintf("load config: %s", err))
 		trackStartFailure("load_global_config")
-		return fmt.Errorf("load global config: %w", err)
+		return false, fmt.Errorf("load global config: %w", err)
 	}
 	repoCfg, err := config.LoadRepo(wtDir)
 	if err != nil {
 		m.db.UpdateRunError(run.ID, fmt.Sprintf("load config: %s", err))
 		trackStartFailure("load_repo_config")
-		return fmt.Errorf("load repo config: %w", err)
+		return false, fmt.Errorf("load repo config: %w", err)
 	}
 	// SECURITY: load the code-executing selection fields (commands.* and
 	// agent) from the trusted default-branch copy of .no-mistakes.yaml rather
@@ -829,7 +859,7 @@ func (m *RunManager) provisionRun(ctx context.Context, repo *db.Repo, branch, he
 	if err := assertGateTrustedConfigReadable(ctx, wtDir, repo.DefaultBranch, trustedSHA); err != nil {
 		m.db.UpdateRunError(run.ID, err.Error())
 		trackStartFailure("trusted_config_unreadable")
-		return err
+		return false, err
 	}
 	trustedRepoCfg := loadTrustedRepoConfig(ctx, wtDir, trustedSHA, run.ID)
 	allowRepoCommands := trustedRepoCfg != nil && trustedRepoCfg.AllowRepoCommands
@@ -852,7 +882,7 @@ func (m *RunManager) provisionRun(ctx context.Context, repo *db.Repo, branch, he
 		if err := cfg.ResolveAgent(ctx, exec.LookPath); err != nil {
 			m.db.UpdateRunError(run.ID, err.Error())
 			trackStartFailure("resolve_agent")
-			return err
+			return false, err
 		}
 		agents := cfg.Agents
 		if len(agents) == 0 {
@@ -867,7 +897,7 @@ func (m *RunManager) provisionRun(ctx context.Context, repo *db.Repo, branch, he
 			if agErr != nil {
 				m.db.UpdateRunError(run.ID, fmt.Sprintf("create agent %s: %s", name, agErr))
 				trackStartFailure("create_agent")
-				return fmt.Errorf("create agent %s: %w", name, agErr)
+				return false, fmt.Errorf("create agent %s: %w", name, agErr)
 			}
 			// Steer every pipeline agent to keep writes inside the worktree and
 			// avoid mutating system state (e.g. brew/Homebrew touching
@@ -884,17 +914,17 @@ func (m *RunManager) provisionRun(ctx context.Context, repo *db.Repo, branch, he
 			if err := agent.EnsureGateNeutralized(ag); err != nil {
 				m.db.UpdateRunError(run.ID, err.Error())
 				trackStartFailure("gate_not_neutralized")
-				return err
+				return false, err
 			}
 		}
 	}
 	if err := m.db.SetRunProvisioning(run.ID, "agent-ready", 85, ""); err != nil {
 		_ = ag.Close()
-		return err
+		return false, err
 	}
 	if err := m.db.CompleteRunProvisioning(run.ID); err != nil {
 		_ = ag.Close()
-		return err
+		return false, err
 	}
 	run.Status = types.RunPending
 
@@ -917,11 +947,9 @@ func (m *RunManager) provisionRun(ctx context.Context, repo *db.Repo, branch, he
 	executor.SetSkippedSteps(skipSteps)
 
 	// Track executor.
-	done := make(chan struct{})
 	m.mu.Lock()
 	m.executors[run.ID] = executor
 	m.cancels[run.ID] = cancel
-	m.dones[run.ID] = done
 	m.mu.Unlock()
 
 	// Background goroutine now owns worktree cleanup.
@@ -1012,7 +1040,16 @@ func (m *RunManager) provisionRun(ctx context.Context, repo *db.Repo, branch, he
 		}
 	}()
 
-	return nil
+	return true, nil
+}
+
+func removeProvisioningWorktree(gateDir, wtDir string) {
+	if rmErr := git.WorktreeRemove(context.Background(), gateDir, wtDir); rmErr != nil {
+		slog.Warn("failed to remove worktree during setup cleanup", "path", wtDir, "error", rmErr)
+	}
+	if rmErr := os.RemoveAll(wtDir); rmErr != nil {
+		slog.Warn("failed to remove provisioning worktree directory", "path", wtDir, "error", rmErr)
+	}
 }
 
 // addRunPerformanceSummary attaches the bounded per-run performance rollup

--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
+	"github.com/kunchenguid/no-mistakes/internal/paths"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/telemetry"
 	"github.com/kunchenguid/no-mistakes/internal/types"
@@ -421,6 +425,236 @@ func TestPushReceivedReturnsBeforeIntentSummarization(t *testing.T) {
 	}
 
 	waitForRunTerminalState(t, d, result.RunID)
+}
+
+func TestStartRunReturnsWhileProvisionerBlockedThirtySeconds(t *testing.T) {
+	p, d := newProvisioningManagerDB(t)
+	repo, headSHA := setupTestGitRepo(t, p, d, "blocked-provision-repo")
+	blocked := make(chan string, 1)
+	exited := make(chan struct{})
+	m := NewRunManager(d, p, func() []pipeline.Step { return []pipeline.Step{&mockPassStep{name: types.StepReview}} })
+	m.provisionHook = func(ctx context.Context, phase string, run *db.Run, _ string) error {
+		if phase != "after_worktree" {
+			return nil
+		}
+		blocked <- run.ID
+		defer close(exited)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	t.Cleanup(m.Shutdown)
+
+	started := time.Now()
+	runID, err := m.startRun(context.Background(), repo, "main", headSHA, headSHA, "push", nil, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(started); elapsed > 2*time.Second {
+		t.Fatalf("startRun took %s with blocked provisioner, want prompt admission", elapsed)
+	}
+	select {
+	case got := <-blocked:
+		if got != runID {
+			t.Fatalf("blocked run = %s, want %s", got, runID)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("provisioner did not reach blocking hook")
+	}
+	select {
+	case <-exited:
+		t.Fatal("provisioner exited before proving a 30 second blockage")
+	case <-time.After(30 * time.Second):
+	}
+	if err := m.HandleCancel(runID); err != nil {
+		t.Fatal(err)
+	}
+	waitForChannel(t, exited, 5*time.Second, "blocked provisioner exit")
+	waitForManagerIdle(t, m, 5*time.Second)
+	if _, err := os.Stat(p.WorktreeDir(repo.ID, runID)); !os.IsNotExist(err) {
+		t.Fatalf("cancelled provisioning worktree still exists or stat failed: %v", err)
+	}
+}
+
+func TestProvisioningSupersessionWaitsForCancelledProvisioner(t *testing.T) {
+	p, d := newProvisioningManagerDB(t)
+	repo, headSHA := setupTestGitRepo(t, p, d, "supersede-provision-repo")
+	firstBlocked := make(chan struct{})
+	firstCancelled := make(chan struct{})
+	allowFirstExit := make(chan struct{})
+	var firstRun atomic.Bool
+	m := NewRunManager(d, p, func() []pipeline.Step { return []pipeline.Step{&mockPassStep{name: types.StepReview}} })
+	m.provisionHook = func(ctx context.Context, phase string, _ *db.Run, _ string) error {
+		if phase != "after_worktree" {
+			return nil
+		}
+		if firstRun.CompareAndSwap(false, true) {
+			close(firstBlocked)
+			<-ctx.Done()
+			close(firstCancelled)
+			<-allowFirstExit
+			return ctx.Err()
+		}
+		return nil
+	}
+	t.Cleanup(m.Shutdown)
+
+	firstID, err := m.startRun(context.Background(), repo, "main", headSHA, headSHA, "push", nil, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitForChannel(t, firstBlocked, 5*time.Second, "first provisioning block")
+	secondDone := make(chan error, 1)
+	go func() {
+		_, err := m.startRun(context.Background(), repo, "main", headSHA, headSHA, "push", nil, "")
+		secondDone <- err
+	}()
+	waitForChannel(t, firstCancelled, 5*time.Second, "first provisioning cancel")
+	select {
+	case err := <-secondDone:
+		t.Fatalf("second run returned before cancelled provisioner exited: %v", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+	close(allowFirstExit)
+	if err := <-secondDone; err != nil {
+		t.Fatalf("second run after provisioner exit: %v", err)
+	}
+	waitForManagerIdle(t, m, 5*time.Second)
+	if _, err := os.Stat(p.WorktreeDir(repo.ID, firstID)); !os.IsNotExist(err) {
+		t.Fatalf("superseded provisioning worktree still exists or stat failed: %v", err)
+	}
+}
+
+func TestProvisioningWorkerSlotsBoundActiveSetup(t *testing.T) {
+	p, d := newProvisioningManagerDB(t)
+	repo, headSHA := setupTestGitRepo(t, p, d, "bounded-provision-repo")
+	started := make(chan string, 3)
+	release := make(chan struct{})
+	m := NewRunManager(d, p, func() []pipeline.Step { return []pipeline.Step{&mockPassStep{name: types.StepReview}} })
+	m.provisionHook = func(ctx context.Context, phase string, run *db.Run, _ string) error {
+		if phase != "after_worktree" {
+			return nil
+		}
+		started <- run.Branch
+		select {
+		case <-release:
+			return os.ErrClosed
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	t.Cleanup(m.Shutdown)
+
+	for _, branch := range []string{"feature/one", "feature/two", "feature/three"} {
+		if _, err := m.startRun(context.Background(), repo, branch, headSHA, headSHA, "push", nil, ""); err != nil {
+			t.Fatalf("start %s: %v", branch, err)
+		}
+	}
+	seen := map[string]bool{}
+	for i := 0; i < 2; i++ {
+		select {
+		case branch := <-started:
+			seen[branch] = true
+		case <-time.After(5 * time.Second):
+			t.Fatal("expected two active provisioning workers")
+		}
+	}
+	select {
+	case branch := <-started:
+		t.Fatalf("third provisioning worker started before slot release: %s", branch)
+	case <-time.After(200 * time.Millisecond):
+	}
+	release <- struct{}{}
+	select {
+	case branch := <-started:
+		if seen[branch] {
+			t.Fatalf("duplicate started branch %s", branch)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("third provisioning worker did not start after slot release")
+	}
+	close(release)
+	waitForManagerIdle(t, m, 5*time.Second)
+}
+
+func TestResumeProvisioningRunsRegistersWaitHandleBeforeRequeue(t *testing.T) {
+	p, d := newProvisioningManagerDB(t)
+	repo, headSHA := setupTestGitRepo(t, p, d, "restart-provision-repo")
+	run, err := d.InsertRun(repo.ID, "main", headSHA, headSHA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := d.SetRunProvisioning(run.ID, "worktree", 5, ""); err != nil {
+		t.Fatal(err)
+	}
+	blocked := make(chan struct{})
+	m := NewRunManager(d, p, func() []pipeline.Step { return []pipeline.Step{&mockPassStep{name: types.StepReview}} })
+	m.provisionHook = func(ctx context.Context, phase string, _ *db.Run, _ string) error {
+		if phase != "after_worktree" {
+			return nil
+		}
+		close(blocked)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	t.Cleanup(m.Shutdown)
+
+	m.resumeProvisioningRuns([]*db.Run{run})
+	m.mu.Lock()
+	done := m.dones[run.ID]
+	m.mu.Unlock()
+	if done == nil {
+		t.Fatal("restart requeue did not register a done channel before provisioning resumed")
+	}
+	waitForChannel(t, blocked, 5*time.Second, "requeued provisioning block")
+	if err := m.HandleCancel(run.ID); err != nil {
+		t.Fatal(err)
+	}
+	waitForChannel(t, done, 5*time.Second, "requeued provisioning done")
+	waitForManagerIdle(t, m, 5*time.Second)
+}
+
+func newProvisioningManagerDB(t *testing.T) (*paths.Paths, *db.DB) {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "dtest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tmpDir) })
+	p := paths.WithRoot(tmpDir)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	mockClaude := writeMockClaude(t, t.TempDir())
+	if err := os.WriteFile(p.ConfigFile(), []byte("agent: claude\nagent_path_override:\n  claude: "+mockClaude+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return p, d
+}
+
+func waitForChannel(t *testing.T, ch <-chan struct{}, timeout time.Duration, label string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(timeout):
+		buf := make([]byte, 1<<20)
+		n := runtime.Stack(buf, true)
+		t.Fatalf("timed out waiting for %s\n%s", label, buf[:n])
+	}
+}
+
+func waitForManagerIdle(t *testing.T, m *RunManager, timeout time.Duration) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		m.wg.Wait()
+		close(done)
+	}()
+	waitForChannel(t, done, timeout, "run manager goroutines")
 }
 
 func writeManagerClaudeFixture(t *testing.T, home, repoCWD string, lines []string) {

--- a/internal/daemon/provisioning_test.go
+++ b/internal/daemon/provisioning_test.go
@@ -1,0 +1,188 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/git"
+	"github.com/kunchenguid/no-mistakes/internal/ipc"
+	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/pipeline"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+func TestPushReceivedReturnsWhileProvisioningQueued(t *testing.T) {
+	p, d, mgr, repo, headSHA := newProvisioningTestManager(t, "provisioning-queued")
+	fillProvisionSlots(t, mgr)
+
+	type result struct {
+		runID string
+		err   error
+	}
+	done := make(chan result, 1)
+	go func() {
+		runID, err := mgr.HandlePushReceived(context.Background(), &ipc.PushReceivedParams{
+			Gate: p.RepoDir(repo.ID),
+			Ref:  "refs/heads/main",
+			Old:  "0000000000000000000000000000000000000000",
+			New:  headSHA,
+		})
+		done <- result{runID: runID, err: err}
+	}()
+
+	var got result
+	select {
+	case got = <-done:
+	case <-time.After(750 * time.Millisecond):
+		t.Fatal("push admission waited for provisioning instead of returning after queueing")
+	}
+	if got.err != nil {
+		t.Fatal(got.err)
+	}
+	run, err := d.GetRun(got.runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Status != types.RunProvisioning || run.ProvisioningPhase != "queued" {
+		t.Fatalf("queued run projection = %+v", run)
+	}
+
+	releaseOneProvisionSlot(t, mgr)
+	if terminal := waitForRunTerminalState(t, d, got.runID); terminal.Status != types.RunCompleted {
+		t.Fatalf("terminal run = %+v", terminal)
+	}
+}
+
+func TestCancelQueuedProvisioningPersistsCancelledRun(t *testing.T) {
+	p, d, mgr, repo, headSHA := newProvisioningTestManager(t, "provisioning-cancel")
+	fillProvisionSlots(t, mgr)
+
+	runID, err := mgr.HandlePushReceived(context.Background(), &ipc.PushReceivedParams{
+		Gate: p.RepoDir(repo.ID),
+		Ref:  "refs/heads/main",
+		Old:  "0000000000000000000000000000000000000000",
+		New:  headSHA,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := mgr.HandleCancel(runID); err != nil {
+		t.Fatal(err)
+	}
+	run := waitForRunStatus(t, d, runID, types.RunCancelled)
+	if run.Error == nil || !strings.Contains(*run.Error, types.RunCancelReasonAbortedByUser) {
+		t.Fatalf("cancelled run error = %+v", run.Error)
+	}
+	if _, err := os.Stat(p.WorktreeDir(repo.ID, runID)); !os.IsNotExist(err) {
+		t.Fatalf("queued cancellation created worktree, stat err=%v", err)
+	}
+}
+
+func TestResumeProvisioningRunsRequeuesAfterRestart(t *testing.T) {
+	p, d, mgr, repo, headSHA := newProvisioningTestManager(t, "provisioning-restart")
+	run, err := d.InsertRun(repo.ID, "main", headSHA, headSHA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := d.SetRunProvisioning(run.ID, "worktree", 5, ""); err != nil {
+		t.Fatal(err)
+	}
+	partialWorktree := p.WorktreeDir(repo.ID, run.ID)
+	if err := git.WorktreeAdd(context.Background(), p.RepoDir(repo.ID), partialWorktree, headSHA); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr.resumeProvisioningRuns([]*db.Run{run})
+	if terminal := waitForRunTerminalState(t, d, run.ID); terminal.Status != types.RunCompleted {
+		t.Fatalf("terminal run = %+v", terminal)
+	}
+	events, err := d.LifecycleEvents(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, event := range events {
+		if event.EventType == "provisioning_completed" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("missing provisioning_completed event: %+v", events)
+	}
+}
+
+func newProvisioningTestManager(t *testing.T, repoID string) (*paths.Paths, *db.DB, *RunManager, *db.Repo, string) {
+	t.Helper()
+	tmpDir, err := os.MkdirTemp("", "dtest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := paths.WithRoot(tmpDir)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	mockClaude := writeMockClaude(t, t.TempDir())
+	if err := os.WriteFile(p.ConfigFile(), []byte("agent: claude\nagent_path_override:\n  claude: "+mockClaude+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo, headSHA := setupTestGitRepo(t, p, d, repoID)
+	mgr := NewRunManager(d, p, func() []pipeline.Step {
+		return []pipeline.Step{&mockPassStep{name: types.StepReview}}
+	})
+	t.Cleanup(func() {
+		mgr.Shutdown()
+		_ = d.Close()
+		_ = os.RemoveAll(tmpDir)
+	})
+	return p, d, mgr, repo, headSHA
+}
+
+func fillProvisionSlots(t *testing.T, mgr *RunManager) {
+	t.Helper()
+	for i := 0; i < cap(mgr.provisionSlots); i++ {
+		mgr.provisionSlots <- struct{}{}
+	}
+	t.Cleanup(func() {
+		for {
+			select {
+			case <-mgr.provisionSlots:
+			default:
+				return
+			}
+		}
+	})
+}
+
+func releaseOneProvisionSlot(t *testing.T, mgr *RunManager) {
+	t.Helper()
+	select {
+	case <-mgr.provisionSlots:
+	case <-time.After(1 * time.Second):
+		t.Fatal("provision slot was not held")
+	}
+}
+
+func waitForRunStatus(t *testing.T, d *db.DB, runID string, want types.RunStatus) *db.Run {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		run, err := d.GetRun(runID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if run != nil && run.Status == want {
+			return run
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("run %s did not reach status %s", runID, want)
+	return nil
+}

--- a/internal/db/agent_invocation.go
+++ b/internal/db/agent_invocation.go
@@ -1,6 +1,9 @@
 package db
 
-import "fmt"
+import (
+	"database/sql"
+	"fmt"
+)
 
 // Agent invocation session modes recorded for local performance telemetry.
 const (
@@ -107,7 +110,18 @@ type AgentInvocation struct {
 	WorkloadLines *int
 	// FindingCount is the number of findings in this invocation's structured
 	// output. Nil when the output is not findings-shaped.
-	FindingCount *int
+	FindingCount                 *int
+	RequestedHarness             string
+	EffectiveHarness             string
+	RequestedModel               string
+	EffectiveModel               string
+	RequestedEffort              string
+	EffectiveEffort              string
+	RoutePolicyVersion           string
+	RoutePhase                   string
+	RouteReason                  string
+	RouteSourceConfiguration     string
+	RouteConfigurationGeneration string
 }
 
 // agentInvocationColumns is the canonical column order shared by insert and
@@ -120,7 +134,23 @@ const agentInvocationColumns = `id, run_id, step_name, round, purpose, agent, mo
 	delta_input_tokens, delta_output_tokens, delta_cache_read_tokens,
 	model_roundtrips, tool_calls,
 	tool_wait_calls, tool_test_lint_calls, tool_edit_calls, tool_read_calls, tool_git_calls, tool_other_calls,
-	workload_files, workload_lines, finding_count`
+	workload_files, workload_lines, finding_count,
+	requested_harness, effective_harness, requested_model, effective_model,
+	requested_effort, effective_effort, route_policy_version, route_phase,
+	route_reason, route_source_config, route_generation`
+
+const agentInvocationSelectColumns = `id, run_id, step_name, round, purpose, agent, model, model_provider,
+	session_mode, session_key, fallback_reason,
+	started_at, completed_at, duration_ms, subprocess_wait_ms, exit_status, failure_category,
+	input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+	fresh_input_tokens, reasoning_tokens,
+	delta_input_tokens, delta_output_tokens, delta_cache_read_tokens,
+	model_roundtrips, tool_calls,
+	tool_wait_calls, tool_test_lint_calls, tool_edit_calls, tool_read_calls, tool_git_calls, tool_other_calls,
+	workload_files, workload_lines, finding_count,
+	requested_harness, effective_harness, requested_model, effective_model,
+	requested_effort, effective_effort, route_policy_version, route_phase,
+	route_reason, route_source_config, route_generation`
 
 // agentInvocationInsertPlaceholders has one '?' per agentInvocationColumns entry.
 const agentInvocationInsertPlaceholders = `?, ?, ?, ?, ?, ?, ?, ?,
@@ -131,6 +161,9 @@ const agentInvocationInsertPlaceholders = `?, ?, ?, ?, ?, ?, ?, ?,
 	?, ?, ?,
 	?, ?,
 	?, ?, ?, ?, ?, ?,
+	?, ?, ?,
+	?, ?, ?, ?,
+	?, ?, ?, ?,
 	?, ?, ?`
 
 // InsertAgentInvocation records one completed agent invocation. Nil pointer
@@ -149,6 +182,9 @@ func (d *DB) InsertAgentInvocation(inv AgentInvocation) (*AgentInvocation, error
 		inv.ModelRoundtrips, inv.ToolCalls,
 		inv.ToolWaitCalls, inv.ToolTestLintCalls, inv.ToolEditCalls, inv.ToolReadCalls, inv.ToolGitCalls, inv.ToolOtherCalls,
 		inv.WorkloadFiles, inv.WorkloadLines, inv.FindingCount,
+		inv.RequestedHarness, inv.EffectiveHarness, inv.RequestedModel, inv.EffectiveModel,
+		inv.RequestedEffort, inv.EffectiveEffort, inv.RoutePolicyVersion, inv.RoutePhase,
+		inv.RouteReason, inv.RouteSourceConfiguration, inv.RouteConfigurationGeneration,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("insert agent invocation: %w", err)
@@ -159,7 +195,7 @@ func (d *DB) InsertAgentInvocation(inv AgentInvocation) (*AgentInvocation, error
 // GetAgentInvocationsByRun returns a run's invocations in execution order.
 func (d *DB) GetAgentInvocationsByRun(runID string) ([]AgentInvocation, error) {
 	rows, err := d.sql.Query(
-		`SELECT `+agentInvocationColumns+` FROM agent_invocations WHERE run_id = ? ORDER BY started_at, id`,
+		`SELECT `+agentInvocationSelectColumns+` FROM agent_invocations WHERE run_id = ? ORDER BY started_at, id`,
 		runID,
 	)
 	if err != nil {
@@ -184,6 +220,9 @@ type scanner interface {
 
 func scanAgentInvocation(row scanner) (AgentInvocation, error) {
 	var inv AgentInvocation
+	var requestedHarness, effectiveHarness, requestedModel, effectiveModel sql.NullString
+	var requestedEffort, effectiveEffort, policyVersion, phase sql.NullString
+	var routeReason, routeSource, routeGeneration sql.NullString
 	if err := row.Scan(
 		&inv.ID, &inv.RunID, &inv.StepName, &inv.Round, &inv.Purpose, &inv.Agent, &inv.Model, &inv.ModelProvider,
 		&inv.SessionMode, &inv.SessionKey, &inv.FallbackReason,
@@ -194,9 +233,23 @@ func scanAgentInvocation(row scanner) (AgentInvocation, error) {
 		&inv.ModelRoundtrips, &inv.ToolCalls,
 		&inv.ToolWaitCalls, &inv.ToolTestLintCalls, &inv.ToolEditCalls, &inv.ToolReadCalls, &inv.ToolGitCalls, &inv.ToolOtherCalls,
 		&inv.WorkloadFiles, &inv.WorkloadLines, &inv.FindingCount,
+		&requestedHarness, &effectiveHarness, &requestedModel, &effectiveModel,
+		&requestedEffort, &effectiveEffort, &policyVersion, &phase,
+		&routeReason, &routeSource, &routeGeneration,
 	); err != nil {
 		return AgentInvocation{}, fmt.Errorf("scan agent invocation: %w", err)
 	}
+	inv.RequestedHarness = requestedHarness.String
+	inv.EffectiveHarness = effectiveHarness.String
+	inv.RequestedModel = requestedModel.String
+	inv.EffectiveModel = effectiveModel.String
+	inv.RequestedEffort = requestedEffort.String
+	inv.EffectiveEffort = effectiveEffort.String
+	inv.RoutePolicyVersion = policyVersion.String
+	inv.RoutePhase = phase.String
+	inv.RouteReason = routeReason.String
+	inv.RouteSourceConfiguration = routeSource.String
+	inv.RouteConfigurationGeneration = routeGeneration.String
 	return inv, nil
 }
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -29,15 +29,26 @@ func Open(path string) (*DB, error) {
 		return nil, fmt.Errorf("open db: %w", err)
 	}
 	sqlDB.SetMaxOpenConns(1)
-	if _, err := sqlDB.Exec(schemaSQL); err != nil {
+	tx, err := sqlDB.Begin()
+	if err != nil {
+		sqlDB.Close()
+		return nil, fmt.Errorf("begin migration: %w", err)
+	}
+	if _, err := tx.Exec(schemaSQL); err != nil {
+		_ = tx.Rollback()
 		sqlDB.Close()
 		return nil, fmt.Errorf("migrate db: %w", err)
 	}
 	for _, stmt := range migrationStatements {
-		if _, err := sqlDB.Exec(stmt); err != nil && !isDuplicateColumnErr(err) {
+		if _, err := tx.Exec(stmt); err != nil && !isDuplicateColumnErr(err) {
+			_ = tx.Rollback()
 			sqlDB.Close()
 			return nil, fmt.Errorf("migrate db: %w", err)
 		}
+	}
+	if err := tx.Commit(); err != nil {
+		sqlDB.Close()
+		return nil, fmt.Errorf("commit migration: %w", err)
 	}
 	return &DB{sql: sqlDB}, nil
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -4,6 +4,8 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"fmt"
+	"math"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -46,11 +48,133 @@ func Open(path string) (*DB, error) {
 			return nil, fmt.Errorf("migrate db: %w", err)
 		}
 	}
+	needsRepair, err := routeResultSequenceNeedsRepair(tx)
+	if err != nil {
+		_ = tx.Rollback()
+		sqlDB.Close()
+		return nil, fmt.Errorf("migrate db: inspect route result sequence authority: %w", err)
+	}
+	if needsRepair {
+		if err := repairRouteResultAppendSequences(tx); err != nil {
+			_ = tx.Rollback()
+			sqlDB.Close()
+			return nil, fmt.Errorf("migrate db: %w", err)
+		}
+		if _, err := tx.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_route_results_append_seq ON route_results (append_seq)`); err != nil {
+			_ = tx.Rollback()
+			sqlDB.Close()
+			return nil, fmt.Errorf("migrate db: create route result append index: %w", err)
+		}
+	}
 	if err := tx.Commit(); err != nil {
 		sqlDB.Close()
 		return nil, fmt.Errorf("commit migration: %w", err)
 	}
 	return &DB{sql: sqlDB}, nil
+}
+
+// routeResultSequenceNeedsRepair keeps the migration's write-heavy repair
+// path one-time. Once both the unique index and its authority row exist,
+// normal DB opens must not rewrite route_results or contend with active
+// writers merely to re-check an already repaired database.
+func routeResultSequenceNeedsRepair(tx *sql.Tx) (bool, error) {
+	var indexCount int
+	if err := tx.QueryRow(`SELECT count(*) FROM sqlite_master
+		WHERE type = 'index' AND name = 'idx_route_results_append_seq'`).Scan(&indexCount); err != nil {
+		return false, err
+	}
+	var authorityCount int
+	if err := tx.QueryRow(`SELECT count(*) FROM route_result_sequence WHERE id = 1`).Scan(&authorityCount); err != nil {
+		return false, err
+	}
+	return indexCount == 0 || authorityCount == 0, nil
+}
+
+// repairRouteResultAppendSequences upgrades legacy route-result rows to a
+// durable insertion order before the unique index is installed. Existing
+// positive integer sequences are preserved on their first occurrence; null,
+// malformed, non-positive, and duplicate values are reassigned after the
+// valid maximum in the old created_at/id order.
+func repairRouteResultAppendSequences(tx *sql.Tx) error {
+	if _, err := tx.Exec(`INSERT OR IGNORE INTO route_result_sequence (id, next_seq) VALUES (1, 0)`); err != nil {
+		return fmt.Errorf("initialize route result sequence: %w", err)
+	}
+	rows, err := tx.Query(`SELECT id, CAST(append_seq AS TEXT)
+		FROM route_results
+		ORDER BY CASE WHEN typeof(created_at) IN ('integer','real') THEN 0 ELSE 1 END,
+		         CASE WHEN typeof(created_at) IN ('integer','real') THEN CAST(created_at AS INTEGER) ELSE 0 END,
+		         id`)
+	if err != nil {
+		return fmt.Errorf("read route result append sequences: %w", err)
+	}
+	type routeResultSequence struct {
+		id  string
+		seq string
+	}
+	var ordered []routeResultSequence
+	for rows.Next() {
+		var item routeResultSequence
+		var seq sql.NullString
+		if err := rows.Scan(&item.id, &seq); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan route result append sequence: %w", err)
+		}
+		if seq.Valid {
+			item.seq = seq.String
+		}
+		ordered = append(ordered, item)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close route result append sequence rows: %w", err)
+	}
+
+	seen := make(map[int64]struct{}, len(ordered))
+	assigned := make(map[string]int64, len(ordered))
+	var maxSeq int64
+	for i := range ordered {
+		seq, ok := parsePositiveSequence(ordered[i].seq)
+		if !ok {
+			continue
+		}
+		if _, duplicate := seen[seq]; duplicate {
+			continue
+		}
+		seen[seq] = struct{}{}
+		assigned[ordered[i].id] = seq
+		if seq > maxSeq {
+			maxSeq = seq
+		}
+	}
+	for _, item := range ordered {
+		if _, ok := assigned[item.id]; ok {
+			continue
+		}
+		if maxSeq == math.MaxInt64 {
+			return fmt.Errorf("route result sequence exhausted while repairing %q", item.id)
+		}
+		maxSeq++
+		assigned[item.id] = maxSeq
+	}
+	for _, item := range ordered {
+		if _, err := tx.Exec(`UPDATE route_results SET append_seq = ? WHERE id = ?`, assigned[item.id], item.id); err != nil {
+			return fmt.Errorf("repair route result append sequence: %w", err)
+		}
+	}
+	var current int64
+	if err := tx.QueryRow(`SELECT next_seq FROM route_result_sequence WHERE id = 1`).Scan(&current); err != nil {
+		return fmt.Errorf("read route result sequence authority: %w", err)
+	}
+	if current < maxSeq {
+		if _, err := tx.Exec(`UPDATE route_result_sequence SET next_seq = ? WHERE id = 1`, maxSeq); err != nil {
+			return fmt.Errorf("update route result sequence authority: %w", err)
+		}
+	}
+	return nil
+}
+
+func parsePositiveSequence(raw string) (int64, bool) {
+	seq, err := strconv.ParseInt(strings.TrimSpace(raw), 10, 64)
+	return seq, err == nil && seq > 0
 }
 
 // isDuplicateColumnErr reports whether err is SQLite's "duplicate column name"

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -117,6 +117,68 @@ func TestOpenMigratesExistingStepRoundsColumns(t *testing.T) {
 	}
 }
 
+func TestOpenBackfillsLegacyRouteResultsBeforeInstallingSequenceAuthority(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "legacy-route-results.sqlite")
+	legacy, err := sql.Open("sqlite", dbPath+"?_pragma=journal_mode(wal)&_pragma=foreign_keys(on)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := legacy.Exec(`
+		CREATE TABLE route_results (
+			id TEXT PRIMARY KEY,
+			run_id TEXT NOT NULL,
+			step_name TEXT NOT NULL,
+			round INTEGER NOT NULL,
+			phase TEXT NOT NULL,
+			risk TEXT NOT NULL,
+			created_at INTEGER NOT NULL
+		);
+		INSERT INTO route_results (id, run_id, step_name, round, phase, risk, created_at)
+		VALUES
+			('legacy-high', 'run-1', 'review', 1, 'review-fix', 'high', 200),
+			('legacy-low', 'run-1', 'review', 2, 'review-fix', 'low', 100),
+			('legacy-medium', 'run-1', 'review', 3, 'review-fix', 'medium', 100);
+	`); err != nil {
+		legacy.Close()
+		t.Fatal(err)
+	}
+	if err := legacy.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("open legacy route-results database: %v", err)
+	}
+	defer d.Close()
+	results, err := d.RouteResults("run-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("backfilled route results = %+v", results)
+	}
+	for i, want := range []string{"low", "medium", "high"} {
+		if results[i].Risk != want || results[i].AppendSeq != int64(i+1) {
+			t.Fatalf("backfilled result[%d] = %+v, want %s sequence %d", i, results[i], want, i+1)
+		}
+	}
+	if _, err := d.sql.Exec(`INSERT INTO route_results (id, run_id, step_name, round, phase, risk, created_at, append_seq)
+		VALUES ('legacy-next', 'run-1', 'review', 4, 'review-fix', 'low', 1, 1)`); err == nil {
+		t.Fatal("duplicate append sequence was accepted after migration")
+	}
+	if err := d.InsertRouteResult(RouteResult{ID: "legacy-next", RunID: "run-1", StepName: "review", Round: 4, Phase: "review-fix", Risk: "low", CreatedAt: 1}); err != nil {
+		t.Fatal(err)
+	}
+	results, err = d.RouteResults("run-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if results[len(results)-1].AppendSeq != 4 {
+		t.Fatalf("post-migration append sequence = %d, want 4", results[len(results)-1].AppendSeq)
+	}
+}
+
 func TestOpenMigratesReposForkURLColumn(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "test.sqlite")
 

--- a/internal/db/events.go
+++ b/internal/db/events.go
@@ -23,6 +23,14 @@ type LifecycleEvent struct {
 }
 
 func (d *DB) AppendLifecycleEvent(event LifecycleEvent) error {
+	return d.appendLifecycleEvent(d.sql, event)
+}
+
+type lifecycleExecutor interface {
+	Exec(query string, args ...any) (sql.Result, error)
+}
+
+func (d *DB) appendLifecycleEvent(exec lifecycleExecutor, event LifecycleEvent) error {
 	metadata := ""
 	if event.Metadata != nil {
 		encoded, err := json.Marshal(event.Metadata)
@@ -37,12 +45,27 @@ func (d *DB) AppendLifecycleEvent(event LifecycleEvent) error {
 	if event.CreatedAt == 0 {
 		event.CreatedAt = now()
 	}
-	_, err := d.sql.Exec(`INSERT INTO lifecycle_events
+	_, err := exec.Exec(`INSERT INTO lifecycle_events
 		(id, run_id, step_name, event_type, status, error, metadata, created_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, event.ID, nullable(event.RunID), nullable(event.StepName),
 		nullable(event.EventType), nullable(event.Status), nullable(event.Error), nullable(metadata), event.CreatedAt)
 	if err != nil {
 		return fmt.Errorf("append lifecycle event: %w", err)
+	}
+	return nil
+}
+
+func (d *DB) withLifecycleTx(fn func(*sql.Tx) error) error {
+	tx, err := d.sql.Begin()
+	if err != nil {
+		return fmt.Errorf("begin lifecycle transaction: %w", err)
+	}
+	if err := fn(tx); err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit lifecycle transaction: %w", err)
 	}
 	return nil
 }

--- a/internal/db/events.go
+++ b/internal/db/events.go
@@ -1,0 +1,162 @@
+package db
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+)
+
+// LifecycleEvent is immutable operational evidence. The current run/step
+// rows are projections; these records are never updated or deleted as a run
+// is cancelled, superseded, recovered, or restarted.
+type LifecycleEvent struct {
+	ID        string
+	RunID     string
+	StepName  string
+	EventType string
+	Status    string
+	Error     string
+	Metadata  map[string]any
+	CreatedAt int64
+}
+
+func (d *DB) AppendLifecycleEvent(event LifecycleEvent) error {
+	metadata := ""
+	if event.Metadata != nil {
+		encoded, err := json.Marshal(event.Metadata)
+		if err != nil {
+			return fmt.Errorf("marshal lifecycle metadata: %w", err)
+		}
+		metadata = string(encoded)
+	}
+	if event.ID == "" {
+		event.ID = newID()
+	}
+	if event.CreatedAt == 0 {
+		event.CreatedAt = now()
+	}
+	_, err := d.sql.Exec(`INSERT INTO lifecycle_events
+		(id, run_id, step_name, event_type, status, error, metadata, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, event.ID, nullable(event.RunID), nullable(event.StepName),
+		nullable(event.EventType), nullable(event.Status), nullable(event.Error), nullable(metadata), event.CreatedAt)
+	if err != nil {
+		return fmt.Errorf("append lifecycle event: %w", err)
+	}
+	return nil
+}
+
+func (d *DB) LifecycleEvents(runID string) ([]LifecycleEvent, error) {
+	rows, err := d.sql.Query(`SELECT id, COALESCE(run_id,''), COALESCE(step_name,''), event_type,
+		COALESCE(status,''), COALESCE(error,''), COALESCE(metadata,''), created_at
+		FROM lifecycle_events WHERE run_id = ? ORDER BY created_at, id`, runID)
+	if err != nil {
+		return nil, fmt.Errorf("get lifecycle events: %w", err)
+	}
+	defer rows.Close()
+	var events []LifecycleEvent
+	for rows.Next() {
+		var e LifecycleEvent
+		var metadata string
+		if err := rows.Scan(&e.ID, &e.RunID, &e.StepName, &e.EventType, &e.Status, &e.Error, &metadata, &e.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan lifecycle event: %w", err)
+		}
+		if metadata != "" {
+			_ = json.Unmarshal([]byte(metadata), &e.Metadata)
+		}
+		events = append(events, e)
+	}
+	return events, rows.Err()
+}
+
+type RouteDecision struct {
+	ID                      string
+	RunID                   string
+	StepName                string
+	Round                   int
+	RequestedHarness        string
+	EffectiveHarness        string
+	RequestedModel          string
+	EffectiveModel          string
+	RequestedEffort         string
+	EffectiveEffort         string
+	PolicyVersion           string
+	Phase                   string
+	Risk                    string
+	Reason                  string
+	SourceConfiguration     string
+	ConfigurationGeneration string
+	Repository              string
+	PromptSHA256            string
+	PromptBytes             int
+	PromptTransport         string
+	CreatedAt               int64
+}
+
+func (d *DB) InsertRouteDecision(decision RouteDecision) error {
+	if decision.ID == "" {
+		decision.ID = newID()
+	}
+	if decision.CreatedAt == 0 {
+		decision.CreatedAt = now()
+	}
+	if decision.Risk == "" {
+		decision.Risk = "unknown"
+	}
+	query := `INSERT INTO route_decisions
+		(id, run_id, step_name, round, requested_harness, effective_harness,
+		 requested_model, effective_model, requested_effort, effective_effort,
+		 policy_version, phase, risk, reason, source_configuration, configuration_generation,
+		 repository, prompt_sha256, prompt_bytes, prompt_transport, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+	_, err := d.sql.Exec(query,
+		decision.ID, decision.RunID, nullable(decision.StepName), decision.Round,
+		decision.RequestedHarness, decision.EffectiveHarness, nullable(decision.RequestedModel), nullable(decision.EffectiveModel),
+		nullable(decision.RequestedEffort), nullable(decision.EffectiveEffort), decision.PolicyVersion, decision.Phase, decision.Risk,
+		decision.Reason, nullable(decision.SourceConfiguration), nullable(decision.ConfigurationGeneration), nullable(decision.Repository),
+		nullable(decision.PromptSHA256), decision.PromptBytes, nullable(decision.PromptTransport), decision.CreatedAt)
+	if err != nil {
+		return fmt.Errorf("insert route decision: %w", err)
+	}
+	return nil
+}
+
+func (d *DB) RouteDecisions(runID string) ([]RouteDecision, error) {
+	rows, err := d.sql.Query(`SELECT id, run_id, COALESCE(step_name,''), round,
+		requested_harness, effective_harness, COALESCE(requested_model,''), COALESCE(effective_model,''),
+		COALESCE(requested_effort,''), COALESCE(effective_effort,''), policy_version, phase, COALESCE(risk,'unknown'), reason,
+		COALESCE(source_configuration,''), COALESCE(configuration_generation,''), COALESCE(repository,''),
+		COALESCE(prompt_sha256,''), COALESCE(prompt_bytes,0), COALESCE(prompt_transport,'stdin'), created_at
+		FROM route_decisions WHERE run_id = ? ORDER BY created_at, id`, runID)
+	if err != nil {
+		return nil, fmt.Errorf("get route decisions: %w", err)
+	}
+	defer rows.Close()
+	var decisions []RouteDecision
+	for rows.Next() {
+		var d RouteDecision
+		if err := rows.Scan(&d.ID, &d.RunID, &d.StepName, &d.Round, &d.RequestedHarness, &d.EffectiveHarness,
+			&d.RequestedModel, &d.EffectiveModel, &d.RequestedEffort, &d.EffectiveEffort, &d.PolicyVersion,
+			&d.Phase, &d.Risk, &d.Reason, &d.SourceConfiguration, &d.ConfigurationGeneration, &d.Repository,
+			&d.PromptSHA256, &d.PromptBytes, &d.PromptTransport, &d.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan route decision: %w", err)
+		}
+		decisions = append(decisions, d)
+	}
+	return decisions, rows.Err()
+}
+
+func nullable(value string) any {
+	if value == "" {
+		return sql.NullString{}
+	}
+	return value
+}
+
+// PromptEvidence returns content-free evidence suitable for route records.
+// The full prompt never enters the database or process argv.
+func PromptEvidence(prompt string) (string, int) {
+	sum := sha256.Sum256([]byte(prompt))
+	return hex.EncodeToString(sum[:]), len(prompt)
+}

--- a/internal/db/events.go
+++ b/internal/db/events.go
@@ -127,6 +127,9 @@ func (d *DB) InsertRouteDecision(decision RouteDecision) error {
 	if decision.Risk == "" {
 		decision.Risk = "unknown"
 	}
+	if decision.PromptTransport == "" {
+		decision.PromptTransport = "stdin"
+	}
 	query := `INSERT INTO route_decisions
 		(id, run_id, step_name, round, requested_harness, effective_harness,
 		 requested_model, effective_model, requested_effort, effective_effort,
@@ -168,6 +171,58 @@ func (d *DB) RouteDecisions(runID string) ([]RouteDecision, error) {
 		decisions = append(decisions, d)
 	}
 	return decisions, rows.Err()
+}
+
+// RouteResult is immutable post-result evidence for a review classification.
+// Route decisions are captured before launch; these rows record the completed
+// review/fix-review result that recovery must use as policy input.
+type RouteResult struct {
+	ID        string
+	RunID     string
+	StepName  string
+	Round     int
+	Phase     string
+	Risk      string
+	CreatedAt int64
+}
+
+func (d *DB) InsertRouteResult(result RouteResult) error {
+	if result.ID == "" {
+		result.ID = newID()
+	}
+	if result.Risk == "" {
+		result.Risk = "unknown"
+	}
+	if result.CreatedAt == 0 {
+		result.CreatedAt = now()
+	}
+	_, err := d.sql.Exec(`INSERT INTO route_results
+		(id, run_id, step_name, round, phase, risk, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`, result.ID, result.RunID, result.StepName,
+		result.Round, result.Phase, result.Risk, result.CreatedAt)
+	if err != nil {
+		return fmt.Errorf("insert route result: %w", err)
+	}
+	return nil
+}
+
+func (d *DB) RouteResults(runID string) ([]RouteResult, error) {
+	rows, err := d.sql.Query(`SELECT id, run_id, step_name, round, phase, risk, created_at
+		FROM route_results WHERE run_id = ? ORDER BY created_at, id`, runID)
+	if err != nil {
+		return nil, fmt.Errorf("get route results: %w", err)
+	}
+	defer rows.Close()
+	var results []RouteResult
+	for rows.Next() {
+		var result RouteResult
+		if err := rows.Scan(&result.ID, &result.RunID, &result.StepName, &result.Round,
+			&result.Phase, &result.Risk, &result.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan route result: %w", err)
+		}
+		results = append(results, result)
+	}
+	return results, rows.Err()
 }
 
 func nullable(value string) any {

--- a/internal/db/events.go
+++ b/internal/db/events.go
@@ -183,6 +183,7 @@ type RouteResult struct {
 	Round     int
 	Phase     string
 	Risk      string
+	AppendSeq int64
 	CreatedAt int64
 }
 
@@ -196,19 +197,41 @@ func (d *DB) InsertRouteResult(result RouteResult) error {
 	if result.CreatedAt == 0 {
 		result.CreatedAt = now()
 	}
-	_, err := d.sql.Exec(`INSERT INTO route_results
-		(id, run_id, step_name, round, phase, risk, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?)`, result.ID, result.RunID, result.StepName,
-		result.Round, result.Phase, result.Risk, result.CreatedAt)
+	tx, err := d.sql.Begin()
 	if err != nil {
-		return fmt.Errorf("insert route result: %w", err)
+		return fmt.Errorf("begin route result insert: %w", err)
+	}
+	rollback := func(err error) error {
+		_ = tx.Rollback()
+		return err
+	}
+	if _, err := tx.Exec(`INSERT OR IGNORE INTO route_result_sequence (id, next_seq) VALUES (1, 0)`); err != nil {
+		return rollback(fmt.Errorf("initialize route result sequence: %w", err))
+	}
+	if _, err := tx.Exec(`UPDATE route_result_sequence SET next_seq = next_seq + 1 WHERE id = 1`); err != nil {
+		return rollback(fmt.Errorf("advance route result sequence: %w", err))
+	}
+	if err := tx.QueryRow(`SELECT next_seq FROM route_result_sequence WHERE id = 1`).Scan(&result.AppendSeq); err != nil {
+		return rollback(fmt.Errorf("read route result sequence: %w", err))
+	}
+	if _, err := tx.Exec(`INSERT INTO route_results
+		(id, run_id, step_name, round, phase, risk, append_seq, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, result.ID, result.RunID, result.StepName,
+		result.Round, result.Phase, result.Risk, result.AppendSeq, result.CreatedAt); err != nil {
+		return rollback(fmt.Errorf("insert route result: %w", err))
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit route result: %w", err)
 	}
 	return nil
 }
 
 func (d *DB) RouteResults(runID string) ([]RouteResult, error) {
-	rows, err := d.sql.Query(`SELECT id, run_id, step_name, round, phase, risk, created_at
-		FROM route_results WHERE run_id = ? ORDER BY created_at, id`, runID)
+	rows, err := d.sql.Query(`SELECT id, run_id, step_name, round, phase, risk,
+		COALESCE(CAST(append_seq AS INTEGER), 0), created_at
+		FROM route_results WHERE run_id = ? ORDER BY
+			CASE WHEN COALESCE(CAST(append_seq AS INTEGER), 0) > 0 THEN 0 ELSE 1 END,
+			COALESCE(CAST(append_seq AS INTEGER), 0), id`, runID)
 	if err != nil {
 		return nil, fmt.Errorf("get route results: %w", err)
 	}
@@ -217,7 +240,7 @@ func (d *DB) RouteResults(runID string) ([]RouteResult, error) {
 	for rows.Next() {
 		var result RouteResult
 		if err := rows.Scan(&result.ID, &result.RunID, &result.StepName, &result.Round,
-			&result.Phase, &result.Risk, &result.CreatedAt); err != nil {
+			&result.Phase, &result.Risk, &result.AppendSeq, &result.CreatedAt); err != nil {
 			return nil, fmt.Errorf("scan route result: %w", err)
 		}
 		results = append(results, result)

--- a/internal/db/events_test.go
+++ b/internal/db/events_test.go
@@ -1,0 +1,69 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+func TestLifecycleEventsPreserveFailureAcrossCancellationProjection(t *testing.T) {
+	d, _, run := openSessionTestDB(t)
+	if err := d.UpdateRunErrorStatus(run.ID, "codex authorization required", types.RunFailed); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.UpdateRunErrorStatus(run.ID, types.RunCancelReasonSuperseded, types.RunCancelled); err != nil {
+		t.Fatal(err)
+	}
+	events, err := d.LifecycleEvents(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sawFailure, sawCancellation bool
+	for _, event := range events {
+		if event.EventType == "run_failure" && event.Error == "codex authorization required" {
+			sawFailure = true
+		}
+		if event.Status == string(types.RunCancelled) {
+			sawCancellation = true
+		}
+	}
+	if !sawFailure || !sawCancellation {
+		t.Fatalf("events lost transition history: %+v", events)
+	}
+}
+
+func TestRouteDecisionStoresPromptFingerprintWithoutPrompt(t *testing.T) {
+	d, _, run := openSessionTestDB(t)
+	hash, size := PromptEvidence("secret prompt")
+	if err := d.InsertRouteDecision(RouteDecision{RunID: run.ID, RequestedHarness: "codex", EffectiveHarness: "codex", PolicyVersion: "v1", Phase: "review", Reason: "test", PromptSHA256: hash, PromptBytes: size, PromptTransport: "stdin"}); err != nil {
+		t.Fatal(err)
+	}
+	decisions, err := d.RouteDecisions(run.ID)
+	if err != nil || len(decisions) != 1 {
+		t.Fatalf("decisions = %+v, err = %v", decisions, err)
+	}
+	if decisions[0].PromptSHA256 != hash || decisions[0].PromptBytes != size || decisions[0].PromptTransport != "stdin" {
+		t.Fatalf("prompt evidence = %+v", decisions[0])
+	}
+}
+
+func TestProvisioningProjectionIsRestartReadable(t *testing.T) {
+	d, _, run := openSessionTestDB(t)
+	if err := d.SetRunProvisioning(run.ID, "checkout", 42, ""); err != nil {
+		t.Fatal(err)
+	}
+	got, err := d.GetProvisioningRuns()
+	if err != nil || len(got) != 1 {
+		t.Fatalf("provisioning runs = %+v, err = %v", got, err)
+	}
+	if got[0].ProvisioningPhase != "checkout" || got[0].ProvisioningProgress != 42 {
+		t.Fatalf("projection = %+v", got[0])
+	}
+	if err := d.CompleteRunProvisioning(run.ID); err != nil {
+		t.Fatal(err)
+	}
+	gotRun, err := d.GetRun(run.ID)
+	if err != nil || gotRun.Status != types.RunPending || gotRun.ProvisioningProgress != 100 {
+		t.Fatalf("completed projection = %+v, err = %v", gotRun, err)
+	}
+}

--- a/internal/db/events_test.go
+++ b/internal/db/events_test.go
@@ -1,6 +1,11 @@
 package db
 
 import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"sync"
 	"testing"
 
 	"github.com/kunchenguid/no-mistakes/internal/types"
@@ -56,8 +61,155 @@ func TestRouteResultsPersistCompletedReviewClassification(t *testing.T) {
 	if err != nil || len(results) != 1 {
 		t.Fatalf("route results = %+v, err = %v", results, err)
 	}
-	if results[0].Phase != "review-fix" || results[0].Risk != "low" || results[0].Round != 2 {
+	if results[0].Phase != "review-fix" || results[0].Risk != "low" || results[0].Round != 2 || results[0].AppendSeq == 0 {
 		t.Fatalf("route result = %+v", results[0])
+	}
+}
+
+func TestRouteResultsUseDurableAppendOrderAcrossClockRollbackAndTies(t *testing.T) {
+	d, _, run := openSessionTestDB(t)
+	for _, result := range []RouteResult{
+		{RunID: run.ID, StepName: "review", Round: 1, Phase: "review-fix", Risk: "high", CreatedAt: 200},
+		{RunID: run.ID, StepName: "review", Round: 2, Phase: "review-fix", Risk: "low", CreatedAt: 100},
+		{RunID: run.ID, StepName: "review", Round: 3, Phase: "review-fix", Risk: "medium", CreatedAt: 100},
+		{RunID: run.ID, StepName: "review", Round: 4, Phase: "review-fix", Risk: "high", CreatedAt: 50},
+	} {
+		if err := d.InsertRouteResult(result); err != nil {
+			t.Fatal(err)
+		}
+	}
+	results, err := d.RouteResults(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"high", "low", "medium", "high"}
+	if len(results) != len(want) {
+		t.Fatalf("route results = %+v", results)
+	}
+	for i, risk := range want {
+		if results[i].Risk != risk || results[i].AppendSeq != int64(i+1) {
+			t.Fatalf("result[%d] = %+v, want risk %q and append sequence %d", i, results[i], risk, i+1)
+		}
+	}
+}
+
+func TestRouteResultsRepairMalformedAndDuplicateAppendSequencesDeterministically(t *testing.T) {
+	d, _, run := openSessionTestDB(t)
+	for i, risk := range []string{"high", "low", "medium"} {
+		if err := d.InsertRouteResult(RouteResult{ID: fmt.Sprintf("repair-%d", i), RunID: run.ID, StepName: "review", Round: i + 1, Phase: "review-fix", Risk: risk, CreatedAt: int64(10 + i)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	path := filepath.Join(t.TempDir(), "repair.sqlite")
+	// Copy the test database through SQLite so reopening exercises the same
+	// migration/repair path without reaching into DB internals.
+	if _, err := d.sql.Exec(`VACUUM INTO ?`, path); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Close(); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := sql.Open("sqlite", path+"?_pragma=journal_mode(wal)&_pragma=foreign_keys(on)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := raw.Exec(`DROP INDEX idx_route_results_append_seq`); err != nil {
+		raw.Close()
+		t.Fatal(err)
+	}
+	if _, err := raw.Exec(`UPDATE route_results SET append_seq = CASE round WHEN 1 THEN 'bad' WHEN 2 THEN 1 ELSE 1 END`); err != nil {
+		raw.Close()
+		t.Fatal(err)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	repaired, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer repaired.Close()
+	results, err := repaired.RouteResults(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("repaired results = %+v", results)
+	}
+	// The first valid sequence wins; malformed and duplicate rows are assigned
+	// monotonically after the valid maximum in legacy created_at,id order.
+	if results[0].Risk != "low" || results[1].Risk != "high" || results[2].Risk != "medium" {
+		t.Fatalf("repaired durable order = %+v", results)
+	}
+	seqs := make([]int64, 0, len(results))
+	for _, result := range results {
+		seqs = append(seqs, result.AppendSeq)
+	}
+	if !sort.SliceIsSorted(seqs, func(i, j int) bool { return seqs[i] < seqs[j] }) || seqs[0] != 1 || seqs[1] != 2 || seqs[2] != 3 {
+		t.Fatalf("repaired sequences = %v", seqs)
+	}
+}
+
+func TestRouteResultsConcurrentInsertionUsesUniqueMonotonicSequences(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "concurrent.sqlite")
+	first, err := Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo, err := first.InsertRepo("/tmp/concurrent-route-results", "https://github.com/test/concurrent", "main")
+	if err != nil {
+		first.Close()
+		t.Fatal(err)
+	}
+	run, err := first.InsertRun(repo.ID, "feature/concurrent", "head", "base")
+	if err != nil {
+		first.Close()
+		t.Fatal(err)
+	}
+	second, err := Open(path)
+	if err != nil {
+		first.Close()
+		t.Fatal(err)
+	}
+	defer first.Close()
+	defer second.Close()
+
+	const writers = 32
+	var wg sync.WaitGroup
+	errCh := make(chan error, writers)
+	for i := 0; i < writers; i++ {
+		writer := first
+		if i%2 == 1 {
+			writer = second
+		}
+		wg.Add(1)
+		go func(i int, writer *DB) {
+			defer wg.Done()
+			errCh <- writer.InsertRouteResult(RouteResult{
+				ID: fmt.Sprintf("concurrent-%02d", i), RunID: run.ID, StepName: "review",
+				Round: i + 1, Phase: "review-fix", Risk: "low", CreatedAt: 1,
+			})
+		}(i, writer)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	results, err := first.RouteResults(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != writers {
+		t.Fatalf("got %d concurrent results, want %d", len(results), writers)
+	}
+	for i, result := range results {
+		if result.AppendSeq != int64(i+1) {
+			t.Fatalf("result[%d] sequence = %d, want %d", i, result.AppendSeq, i+1)
+		}
 	}
 }
 

--- a/internal/db/events_test.go
+++ b/internal/db/events_test.go
@@ -47,6 +47,20 @@ func TestRouteDecisionStoresPromptFingerprintWithoutPrompt(t *testing.T) {
 	}
 }
 
+func TestRouteResultsPersistCompletedReviewClassification(t *testing.T) {
+	d, _, run := openSessionTestDB(t)
+	if err := d.InsertRouteResult(RouteResult{RunID: run.ID, StepName: "review", Round: 2, Phase: "review-fix", Risk: "low", CreatedAt: 10}); err != nil {
+		t.Fatal(err)
+	}
+	results, err := d.RouteResults(run.ID)
+	if err != nil || len(results) != 1 {
+		t.Fatalf("route results = %+v, err = %v", results, err)
+	}
+	if results[0].Phase != "review-fix" || results[0].Risk != "low" || results[0].Round != 2 {
+		t.Fatalf("route result = %+v", results[0])
+	}
+}
+
 func TestProvisioningProjectionIsRestartReadable(t *testing.T) {
 	d, _, run := openSessionTestDB(t)
 	if err := d.SetRunProvisioning(run.ID, "checkout", 42, ""); err != nil {

--- a/internal/db/reliability_test.go
+++ b/internal/db/reliability_test.go
@@ -1,0 +1,71 @@
+package db
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+func TestAuthorizationFailureSurvivesLaterCancellationProjection(t *testing.T) {
+	d, _, run := openSessionTestDB(t)
+	if err := d.ParkRunForAuthorization(run.ID, "review-fix", "Transport channel closed, when Auth(AuthorizationRequired)"); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.UpdateRunErrorStatus(run.ID, types.RunCancelReasonAbortedByUser, types.RunCancelled); err != nil {
+		t.Fatal(err)
+	}
+	events, err := d.LifecycleEvents(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundAuth := false
+	for _, event := range events {
+		if event.EventType == "authorization_required" && strings.Contains(event.Error, "AuthorizationRequired") {
+			foundAuth = true
+		}
+	}
+	if !foundAuth {
+		t.Fatalf("authorization event was lost: %#v", events)
+	}
+	current, err := d.GetRun(run.ID)
+	if err != nil || current.Status != types.RunCancelled {
+		t.Fatalf("current projection = %#v, err=%v", current, err)
+	}
+}
+
+func TestProvisioningProgressIsPersisted(t *testing.T) {
+	d, _, run := openSessionTestDB(t)
+	if err := d.SetRunProvisioning(run.ID, "checkout", 42, ""); err != nil {
+		t.Fatal(err)
+	}
+	got, err := d.GetRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != types.RunProvisioning || got.ProvisioningPhase != "checkout" || got.ProvisioningProgress != 42 {
+		t.Fatalf("provisioning projection = %#v", got)
+	}
+}
+
+func TestAuthorizationParkIsRestartPreservedWithoutGateTimer(t *testing.T) {
+	d, _, run := openSessionTestDB(t)
+	if err := d.ParkRunForAuthorization(run.ID, "review", "account rotation"); err != nil {
+		t.Fatal(err)
+	}
+	active, err := d.GetActiveRuns()
+	if err != nil || len(active) != 1 || active[0].Status != types.RunAwaitingAuth {
+		t.Fatalf("active authorization park = %+v, err = %v", active, err)
+	}
+	if active[0].AwaitingAgentSince != nil {
+		t.Fatalf("authorization park incorrectly has gate timer: %v", *active[0].AwaitingAgentSince)
+	}
+	count, err := d.RecoverStaleRunsExcept("daemon crashed during execution", map[string]struct{}{run.ID: {}})
+	if err != nil || count != 0 {
+		t.Fatalf("preserved authorization run recovery = %d, err = %v", count, err)
+	}
+	got, err := d.GetRun(run.ID)
+	if err != nil || got.Status != types.RunAwaitingAuth || got.BlockedReason == nil {
+		t.Fatalf("authorization park after restart projection = %+v, err = %v", got, err)
+	}
+}

--- a/internal/db/reliability_test.go
+++ b/internal/db/reliability_test.go
@@ -7,6 +7,36 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
+func TestRunProjectionRollsBackWhenLifecycleEvidenceFails(t *testing.T) {
+	d, _, run := openSessionTestDB(t)
+	var err error
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.sql.Exec(`CREATE TRIGGER fail_run_failure BEFORE INSERT ON lifecycle_events WHEN NEW.event_type = 'run_failure' BEGIN SELECT RAISE(ABORT, 'injected lifecycle failure'); END`); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.UpdateRunErrorStatus(run.ID, "boom", types.RunFailed); err == nil {
+		t.Fatal("UpdateRunErrorStatus unexpectedly succeeded")
+	}
+	got, err := d.GetRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != types.RunPending || got.Error != nil {
+		t.Fatalf("projection committed without lifecycle evidence: status=%s error=%v", got.Status, got.Error)
+	}
+	events, err := d.LifecycleEvents(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, event := range events {
+		if event.EventType == "run_failure" {
+			t.Fatalf("failed lifecycle event persisted: %+v", event)
+		}
+	}
+}
+
 func TestAuthorizationFailureSurvivesLaterCancellationProjection(t *testing.T) {
 	d, _, run := openSessionTestDB(t)
 	if err := d.ParkRunForAuthorization(run.ID, "review-fix", "Transport channel closed, when Auth(AuthorizationRequired)"); err != nil {

--- a/internal/db/reliability_test.go
+++ b/internal/db/reliability_test.go
@@ -32,6 +32,9 @@ func TestAuthorizationFailureSurvivesLaterCancellationProjection(t *testing.T) {
 	if err != nil || current.Status != types.RunCancelled {
 		t.Fatalf("current projection = %#v, err=%v", current, err)
 	}
+	if current.BlockedReason != nil {
+		t.Fatalf("terminal projection retained blocked reason: %#v", current.BlockedReason)
+	}
 }
 
 func TestProvisioningProgressIsPersisted(t *testing.T) {

--- a/internal/db/run.go
+++ b/internal/db/run.go
@@ -319,7 +319,7 @@ func (d *DB) ParkRunForAuthorization(id, step, detail string) error {
 		reason = "authorization required: " + strings.TrimSpace(detail)
 	}
 	ts := now()
-	_, err := d.sql.Exec(`UPDATE runs SET status = ?, blocked_reason = ?, error = ?, awaiting_agent_since = COALESCE(awaiting_agent_since, ?), updated_at = ? WHERE id = ?`, types.RunAwaitingAuth, reason, reason, ts, ts, id)
+	_, err := d.sql.Exec(`UPDATE runs SET status = ?, blocked_reason = ?, error = ?, updated_at = ? WHERE id = ?`, types.RunAwaitingAuth, reason, reason, ts, id)
 	if err != nil {
 		return fmt.Errorf("park run for authorization: %w", err)
 	}

--- a/internal/db/run.go
+++ b/internal/db/run.go
@@ -10,14 +10,20 @@ import (
 
 // Run represents a pipeline run.
 type Run struct {
-	ID      string
-	RepoID  string
-	Branch  string
-	HeadSHA string
-	BaseSHA string
-	Status  types.RunStatus
-	PRURL   *string
-	Error   *string
+	ID                      string
+	RepoID                  string
+	Branch                  string
+	HeadSHA                 string
+	BaseSHA                 string
+	Status                  types.RunStatus
+	ProvisioningPhase       string
+	ProvisioningProgress    int
+	ProvisioningError       *string
+	ProvisioningStartedAt   *int64
+	ProvisioningCompletedAt *int64
+	PRURL                   *string
+	Error                   *string
+	BlockedReason           *string
 	// AwaitingAgentSince is the unix-seconds timestamp at which the run parked
 	// at a gate awaiting the driving agent's response (an awaiting_approval or
 	// fix_review step). It is nil whenever the run is not parked: the executor
@@ -37,14 +43,15 @@ type Run struct {
 	UpdatedAt       int64
 }
 
-const runColumns = `id, repo_id, branch, head_sha, base_sha, status, pr_url, error, awaiting_agent_since, COALESCE(parked_ms, 0), intent, intent_source, intent_session_id, intent_score, created_at, updated_at`
+const runColumns = `id, repo_id, branch, head_sha, base_sha, status, provisioning_phase, provisioning_progress, provisioning_error, provisioning_started_at, provisioning_completed_at, pr_url, error, blocked_reason, awaiting_agent_since, COALESCE(parked_ms, 0), intent, intent_source, intent_session_id, intent_score, created_at, updated_at`
 
 func scanRun(row interface {
 	Scan(...any) error
 }, r *Run) error {
 	return row.Scan(
 		&r.ID, &r.RepoID, &r.Branch, &r.HeadSHA, &r.BaseSHA, &r.Status,
-		&r.PRURL, &r.Error, &r.AwaitingAgentSince, &r.ParkedMS,
+		&r.ProvisioningPhase, &r.ProvisioningProgress, &r.ProvisioningError, &r.ProvisioningStartedAt, &r.ProvisioningCompletedAt,
+		&r.PRURL, &r.Error, &r.BlockedReason, &r.AwaitingAgentSince, &r.ParkedMS,
 		&r.Intent, &r.IntentSource, &r.IntentSessionID, &r.IntentScore,
 		&r.CreatedAt, &r.UpdatedAt,
 	)
@@ -54,14 +61,15 @@ func scanRun(row interface {
 func (d *DB) InsertRun(repoID, branch, headSHA, baseSHA string) (*Run, error) {
 	ts := now()
 	r := &Run{
-		ID:        newID(),
-		RepoID:    repoID,
-		Branch:    branch,
-		HeadSHA:   headSHA,
-		BaseSHA:   baseSHA,
-		Status:    types.RunPending,
-		CreatedAt: ts,
-		UpdatedAt: ts,
+		ID:                newID(),
+		RepoID:            repoID,
+		Branch:            branch,
+		HeadSHA:           headSHA,
+		BaseSHA:           baseSHA,
+		Status:            types.RunPending,
+		CreatedAt:         ts,
+		UpdatedAt:         ts,
+		ProvisioningPhase: "created",
 	}
 	_, err := d.sql.Exec(
 		`INSERT INTO runs (id, repo_id, branch, head_sha, base_sha, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -70,7 +78,50 @@ func (d *DB) InsertRun(repoID, branch, headSHA, baseSHA string) (*Run, error) {
 	if err != nil {
 		return nil, fmt.Errorf("insert run: %w", err)
 	}
+	if err := d.AppendLifecycleEvent(LifecycleEvent{RunID: r.ID, EventType: "run_created", Status: string(r.Status), Metadata: map[string]any{"branch": branch, "head_sha": headSHA, "base_sha": baseSHA}}); err != nil {
+		return nil, err
+	}
 	return r, nil
+}
+
+func (d *DB) SetRunProvisioning(id, phase string, progress int, provisioningErr string) error {
+	if progress < 0 {
+		progress = 0
+	}
+	if progress > 100 {
+		progress = 100
+	}
+	ts := now()
+	_, err := d.sql.Exec(`UPDATE runs SET status = ?, provisioning_phase = ?, provisioning_progress = ?, provisioning_error = ?, provisioning_started_at = COALESCE(provisioning_started_at, ?), updated_at = ? WHERE id = ?`,
+		types.RunProvisioning, phase, progress, nullableString(provisioningErr), ts, ts, id)
+	if err != nil {
+		return fmt.Errorf("set run provisioning: %w", err)
+	}
+	return d.AppendLifecycleEvent(LifecycleEvent{RunID: id, EventType: "provisioning", Status: string(types.RunProvisioning), Error: provisioningErr, Metadata: map[string]any{"phase": phase, "progress": progress}})
+}
+
+func (d *DB) CompleteRunProvisioning(id string) error {
+	ts := now()
+	_, err := d.sql.Exec(`UPDATE runs SET status = ?, provisioning_phase = 'ready', provisioning_progress = 100, provisioning_error = NULL, provisioning_completed_at = ?, updated_at = ? WHERE id = ?`, types.RunPending, ts, ts, id)
+	if err != nil {
+		return fmt.Errorf("complete run provisioning: %w", err)
+	}
+	return d.AppendLifecycleEvent(LifecycleEvent{RunID: id, EventType: "provisioning_completed", Status: string(types.RunPending), Metadata: map[string]any{"progress": 100}})
+}
+
+func (d *DB) FailRunProvisioning(id, phase string, provisioningErr error) error {
+	message := "provisioning failed"
+	if provisioningErr != nil {
+		message = provisioningErr.Error()
+	}
+	if err := d.SetRunProvisioning(id, phase, 100, message); err != nil {
+		return err
+	}
+	_, err := d.sql.Exec(`UPDATE runs SET status = ?, error = ?, provisioning_error = ?, updated_at = ? WHERE id = ?`, types.RunFailed, message, message, now(), id)
+	if err != nil {
+		return fmt.Errorf("fail run provisioning: %w", err)
+	}
+	return d.AppendLifecycleEvent(LifecycleEvent{RunID: id, EventType: "provisioning_failure", Status: string(types.RunFailed), Error: message})
 }
 
 // GetRun returns a run by ID.
@@ -138,11 +189,11 @@ func (d *DB) GetActiveRun(repoID, branch string) (*Run, error) {
 	var err error
 	if branch == "" {
 		err = scanRun(d.sql.QueryRow(
-			`SELECT `+runColumns+` FROM runs WHERE repo_id = ? AND status IN ('pending', 'running') ORDER BY created_at DESC, id DESC LIMIT 1`, repoID,
+			`SELECT `+runColumns+` FROM runs WHERE repo_id = ? AND status IN ('pending', 'provisioning', 'running', 'awaiting_auth') ORDER BY created_at DESC, id DESC LIMIT 1`, repoID,
 		), r)
 	} else {
 		err = scanRun(d.sql.QueryRow(
-			`SELECT `+runColumns+` FROM runs WHERE repo_id = ? AND branch = ? AND status IN ('pending', 'running') ORDER BY created_at DESC, id DESC LIMIT 1`, repoID, branch,
+			`SELECT `+runColumns+` FROM runs WHERE repo_id = ? AND branch = ? AND status IN ('pending', 'provisioning', 'running', 'awaiting_auth') ORDER BY created_at DESC, id DESC LIMIT 1`, repoID, branch,
 		), r)
 	}
 	if err == sql.ErrNoRows {
@@ -157,8 +208,8 @@ func (d *DB) GetActiveRun(repoID, branch string) (*Run, error) {
 // GetActiveRuns returns all pending or running runs across all repos, newest first.
 func (d *DB) GetActiveRuns() ([]*Run, error) {
 	rows, err := d.sql.Query(
-		`SELECT `+runColumns+` FROM runs WHERE status IN (?, ?) ORDER BY created_at DESC, id DESC`,
-		types.RunPending, types.RunRunning,
+		`SELECT `+runColumns+` FROM runs WHERE status IN (?, ?, ?, ?) ORDER BY created_at DESC, id DESC`,
+		types.RunPending, types.RunProvisioning, types.RunRunning, types.RunAwaitingAuth,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("get active runs: %w", err)
@@ -176,11 +227,33 @@ func (d *DB) GetActiveRuns() ([]*Run, error) {
 	return runs, rows.Err()
 }
 
+// GetProvisioningRuns returns runs whose durable setup phase must be resumed
+// after a daemon restart.
+func (d *DB) GetProvisioningRuns() ([]*Run, error) {
+	rows, err := d.sql.Query(`SELECT `+runColumns+` FROM runs WHERE status = ? ORDER BY created_at, id`, types.RunProvisioning)
+	if err != nil {
+		return nil, fmt.Errorf("get provisioning runs: %w", err)
+	}
+	defer rows.Close()
+	var runs []*Run
+	for rows.Next() {
+		r := &Run{}
+		if err := scanRun(rows, r); err != nil {
+			return nil, fmt.Errorf("scan provisioning run: %w", err)
+		}
+		runs = append(runs, r)
+	}
+	return runs, rows.Err()
+}
+
 // UpdateRunStatus updates a run's status and updated_at timestamp.
 func (d *DB) UpdateRunStatus(id string, status types.RunStatus) error {
 	_, err := d.sql.Exec(`UPDATE runs SET status = ?, updated_at = ? WHERE id = ?`, status, now(), id)
 	if err != nil {
 		return fmt.Errorf("update run status: %w", err)
+	}
+	if err := d.AppendLifecycleEvent(LifecycleEvent{RunID: id, EventType: "run_status", Status: string(status)}); err != nil {
+		return err
 	}
 	return nil
 }
@@ -214,7 +287,53 @@ func (d *DB) UpdateRunErrorStatus(id, errMsg string, status types.RunStatus) err
 	if err != nil {
 		return fmt.Errorf("update run error: %w", err)
 	}
+	if err := d.AppendLifecycleEvent(LifecycleEvent{RunID: id, EventType: "run_failure", Status: string(status), Error: errMsg}); err != nil {
+		return err
+	}
 	return nil
+}
+
+// SetRunBlockedReason keeps a recoverable external blockage in the current
+// projection while the lifecycle ledger preserves every preceding failure.
+func (d *DB) SetRunBlockedReason(id, reason string) error {
+	_, err := d.sql.Exec(`UPDATE runs SET blocked_reason = ?, updated_at = ? WHERE id = ?`, reason, now(), id)
+	if err != nil {
+		return fmt.Errorf("set run blocked reason: %w", err)
+	}
+	return d.AppendLifecycleEvent(LifecycleEvent{RunID: id, EventType: "run_blocked", Status: string(types.RunRunning), Error: reason})
+}
+
+func (d *DB) ClearRunBlockedReason(id string) error {
+	_, err := d.sql.Exec(`UPDATE runs SET blocked_reason = NULL, updated_at = ? WHERE id = ?`, now(), id)
+	if err != nil {
+		return fmt.Errorf("clear run blocked reason: %w", err)
+	}
+	return d.AppendLifecycleEvent(LifecycleEvent{RunID: id, EventType: "run_unblocked", Status: string(types.RunRunning)})
+}
+
+// ParkRunForAuthorization records a recoverable provider-auth transition.
+// It intentionally does not clear any prior lifecycle events or session rows.
+func (d *DB) ParkRunForAuthorization(id, step, detail string) error {
+	reason := "authorization required"
+	if strings.TrimSpace(detail) != "" {
+		reason = "authorization required: " + strings.TrimSpace(detail)
+	}
+	ts := now()
+	_, err := d.sql.Exec(`UPDATE runs SET status = ?, blocked_reason = ?, error = ?, awaiting_agent_since = COALESCE(awaiting_agent_since, ?), updated_at = ? WHERE id = ?`, types.RunAwaitingAuth, reason, reason, ts, ts, id)
+	if err != nil {
+		return fmt.Errorf("park run for authorization: %w", err)
+	}
+	return d.AppendLifecycleEvent(LifecycleEvent{RunID: id, StepName: step, EventType: "authorization_required", Status: string(types.RunAwaitingAuth), Error: reason})
+}
+
+// ResumeRunAfterAuthorization clears only the current recoverable blockage.
+// The authorization_required lifecycle event remains immutable evidence.
+func (d *DB) ResumeRunAfterAuthorization(id, step string) error {
+	_, err := d.sql.Exec(`UPDATE runs SET status = ?, blocked_reason = NULL, error = NULL, updated_at = ? WHERE id = ?`, types.RunRunning, now(), id)
+	if err != nil {
+		return fmt.Errorf("resume run after authorization: %w", err)
+	}
+	return d.AppendLifecycleEvent(LifecycleEvent{RunID: id, StepName: step, EventType: "authorization_resumed", Status: string(types.RunRunning)})
 }
 
 // RunIntentSourceAgent is the intent_source value stamped when the driving
@@ -317,16 +436,36 @@ func (d *DB) RecoverStaleRunsExcept(errMsg string, preserved map[string]struct{}
 	defer tx.Rollback()
 
 	placeholders, args := recoveryExclusionClause(preserved)
+	recoveryStatuses := []any{types.RunPending, types.RunProvisioning, types.RunRunning, types.RunAwaitingAuth}
+	recoveryArgs := append(append([]any{}, recoveryStatuses...), args...)
+	rows, err := tx.Query(`SELECT id FROM runs WHERE status IN (?, ?, ?, ?)`+placeholders, recoveryArgs...)
+	if err != nil {
+		return 0, fmt.Errorf("list stale runs: %w", err)
+	}
+	var recoveredIDs []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return 0, fmt.Errorf("scan stale run: %w", err)
+		}
+		recoveredIDs = append(recoveredIDs, id)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return 0, fmt.Errorf("read stale runs: %w", err)
+	}
+	rows.Close()
 	stepArgs := []any{
 		types.StepStatusFailed, errMsg, ts,
 		types.StepStatusRunning, types.StepStatusAwaitingApproval, types.StepStatusFixing, types.StepStatusFixReview,
-		types.RunPending, types.RunRunning,
+		types.RunPending, types.RunProvisioning, types.RunRunning, types.RunAwaitingAuth,
 	}
 	stepArgs = append(stepArgs, args...)
 	_, err = tx.Exec(
 		`UPDATE step_results SET status = ?, error = ?, completed_at = ?
-		 WHERE status IN (?, ?, ?, ?) AND run_id IN (
-			SELECT id FROM runs WHERE status IN (?, ?)`+placeholders+`
+			 WHERE status IN (?, ?, ?, ?) AND run_id IN (
+			SELECT id FROM runs WHERE status IN (?, ?, ?, ?)`+placeholders+`
 		 )`,
 		stepArgs...,
 	)
@@ -338,18 +477,23 @@ func (d *DB) RecoverStaleRunsExcept(errMsg string, preserved map[string]struct{}
 	// failed) run is never reported as still parked awaiting the agent,
 	// accumulating the marker's elapsed time into the run's parked total so
 	// the parked evidence survives the crash.
-	runArgs := []any{types.RunFailed, errMsg, ts, ts, ts, types.RunPending, types.RunRunning}
+	runArgs := []any{types.RunFailed, errMsg, ts, ts, ts, types.RunPending, types.RunProvisioning, types.RunRunning, types.RunAwaitingAuth}
 	runArgs = append(runArgs, args...)
 	result, err := tx.Exec(
 		`UPDATE runs SET status = ?, error = ?,
 			parked_ms = COALESCE(parked_ms, 0) + CASE
 				WHEN awaiting_agent_since IS NOT NULL AND ? > awaiting_agent_since
 				THEN (? - awaiting_agent_since) * 1000 ELSE 0 END,
-			awaiting_agent_since = NULL, updated_at = ? WHERE status IN (?, ?)`+placeholders,
+		awaiting_agent_since = NULL, blocked_reason = NULL, updated_at = ? WHERE status IN (?, ?, ?, ?)`+placeholders,
 		runArgs...,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("recover stale runs: %w", err)
+	}
+	for _, id := range recoveredIDs {
+		if _, err := tx.Exec(`INSERT INTO lifecycle_events (id, run_id, event_type, status, error, created_at) VALUES (?, ?, ?, ?, ?, ?)`, newID(), id, "run_recovered", string(types.RunFailed), errMsg, ts); err != nil {
+			return 0, fmt.Errorf("record recovered run: %w", err)
+		}
 	}
 
 	count, err := result.RowsAffected()

--- a/internal/db/run.go
+++ b/internal/db/run.go
@@ -283,7 +283,7 @@ func (d *DB) UpdateRunError(id, errMsg string) error {
 
 // UpdateRunErrorStatus sets the error message and terminal status on a run.
 func (d *DB) UpdateRunErrorStatus(id, errMsg string, status types.RunStatus) error {
-	_, err := d.sql.Exec(`UPDATE runs SET error = ?, status = ?, updated_at = ? WHERE id = ?`, errMsg, status, now(), id)
+	_, err := d.sql.Exec(`UPDATE runs SET error = ?, status = ?, blocked_reason = NULL, updated_at = ? WHERE id = ?`, errMsg, status, now(), id)
 	if err != nil {
 		return fmt.Errorf("update run error: %w", err)
 	}

--- a/internal/db/run.go
+++ b/internal/db/run.go
@@ -71,14 +71,16 @@ func (d *DB) InsertRun(repoID, branch, headSHA, baseSHA string) (*Run, error) {
 		UpdatedAt:         ts,
 		ProvisioningPhase: "created",
 	}
-	_, err := d.sql.Exec(
-		`INSERT INTO runs (id, repo_id, branch, head_sha, base_sha, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		r.ID, r.RepoID, r.Branch, r.HeadSHA, r.BaseSHA, r.Status, r.CreatedAt, r.UpdatedAt,
-	)
+	err := d.withLifecycleTx(func(tx *sql.Tx) error {
+		if _, err := tx.Exec(
+			`INSERT INTO runs (id, repo_id, branch, head_sha, base_sha, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+			r.ID, r.RepoID, r.Branch, r.HeadSHA, r.BaseSHA, r.Status, r.CreatedAt, r.UpdatedAt,
+		); err != nil {
+			return fmt.Errorf("insert run: %w", err)
+		}
+		return d.appendLifecycleEvent(tx, LifecycleEvent{RunID: r.ID, EventType: "run_created", Status: string(r.Status), Metadata: map[string]any{"branch": branch, "head_sha": headSHA, "base_sha": baseSHA}})
+	})
 	if err != nil {
-		return nil, fmt.Errorf("insert run: %w", err)
-	}
-	if err := d.AppendLifecycleEvent(LifecycleEvent{RunID: r.ID, EventType: "run_created", Status: string(r.Status), Metadata: map[string]any{"branch": branch, "head_sha": headSHA, "base_sha": baseSHA}}); err != nil {
 		return nil, err
 	}
 	return r, nil
@@ -92,21 +94,24 @@ func (d *DB) SetRunProvisioning(id, phase string, progress int, provisioningErr 
 		progress = 100
 	}
 	ts := now()
-	_, err := d.sql.Exec(`UPDATE runs SET status = ?, provisioning_phase = ?, provisioning_progress = ?, provisioning_error = ?, provisioning_started_at = COALESCE(provisioning_started_at, ?), updated_at = ? WHERE id = ?`,
-		types.RunProvisioning, phase, progress, nullableString(provisioningErr), ts, ts, id)
-	if err != nil {
-		return fmt.Errorf("set run provisioning: %w", err)
-	}
-	return d.AppendLifecycleEvent(LifecycleEvent{RunID: id, EventType: "provisioning", Status: string(types.RunProvisioning), Error: provisioningErr, Metadata: map[string]any{"phase": phase, "progress": progress}})
+	err := d.withLifecycleTx(func(tx *sql.Tx) error {
+		if _, err := tx.Exec(`UPDATE runs SET status = ?, provisioning_phase = ?, provisioning_progress = ?, provisioning_error = ?, provisioning_started_at = COALESCE(provisioning_started_at, ?), updated_at = ? WHERE id = ?`,
+			types.RunProvisioning, phase, progress, nullableString(provisioningErr), ts, ts, id); err != nil {
+			return fmt.Errorf("set run provisioning: %w", err)
+		}
+		return d.appendLifecycleEvent(tx, LifecycleEvent{RunID: id, EventType: "provisioning", Status: string(types.RunProvisioning), Error: provisioningErr, Metadata: map[string]any{"phase": phase, "progress": progress}})
+	})
+	return err
 }
 
 func (d *DB) CompleteRunProvisioning(id string) error {
 	ts := now()
-	_, err := d.sql.Exec(`UPDATE runs SET status = ?, provisioning_phase = 'ready', provisioning_progress = 100, provisioning_error = NULL, provisioning_completed_at = ?, updated_at = ? WHERE id = ?`, types.RunPending, ts, ts, id)
-	if err != nil {
-		return fmt.Errorf("complete run provisioning: %w", err)
-	}
-	return d.AppendLifecycleEvent(LifecycleEvent{RunID: id, EventType: "provisioning_completed", Status: string(types.RunPending), Metadata: map[string]any{"progress": 100}})
+	return d.withLifecycleTx(func(tx *sql.Tx) error {
+		if _, err := tx.Exec(`UPDATE runs SET status = ?, provisioning_phase = 'ready', provisioning_progress = 100, provisioning_error = NULL, provisioning_completed_at = ?, updated_at = ? WHERE id = ?`, types.RunPending, ts, ts, id); err != nil {
+			return fmt.Errorf("complete run provisioning: %w", err)
+		}
+		return d.appendLifecycleEvent(tx, LifecycleEvent{RunID: id, EventType: "provisioning_completed", Status: string(types.RunPending), Metadata: map[string]any{"progress": 100}})
+	})
 }
 
 func (d *DB) FailRunProvisioning(id, phase string, provisioningErr error) error {
@@ -114,14 +119,16 @@ func (d *DB) FailRunProvisioning(id, phase string, provisioningErr error) error 
 	if provisioningErr != nil {
 		message = provisioningErr.Error()
 	}
-	if err := d.SetRunProvisioning(id, phase, 100, message); err != nil {
-		return err
-	}
-	_, err := d.sql.Exec(`UPDATE runs SET status = ?, error = ?, provisioning_error = ?, updated_at = ? WHERE id = ?`, types.RunFailed, message, message, now(), id)
-	if err != nil {
-		return fmt.Errorf("fail run provisioning: %w", err)
-	}
-	return d.AppendLifecycleEvent(LifecycleEvent{RunID: id, EventType: "provisioning_failure", Status: string(types.RunFailed), Error: message})
+	ts := now()
+	return d.withLifecycleTx(func(tx *sql.Tx) error {
+		if _, err := tx.Exec(`UPDATE runs SET status = ?, provisioning_phase = ?, provisioning_progress = 100, error = ?, provisioning_error = ?, provisioning_started_at = COALESCE(provisioning_started_at, ?), updated_at = ? WHERE id = ?`, types.RunFailed, phase, message, message, ts, ts, id); err != nil {
+			return fmt.Errorf("fail run provisioning: %w", err)
+		}
+		if err := d.appendLifecycleEvent(tx, LifecycleEvent{RunID: id, EventType: "provisioning", Status: string(types.RunProvisioning), Error: message, Metadata: map[string]any{"phase": phase, "progress": 100}}); err != nil {
+			return err
+		}
+		return d.appendLifecycleEvent(tx, LifecycleEvent{RunID: id, EventType: "provisioning_failure", Status: string(types.RunFailed), Error: message})
+	})
 }
 
 // GetRun returns a run by ID.
@@ -248,14 +255,12 @@ func (d *DB) GetProvisioningRuns() ([]*Run, error) {
 
 // UpdateRunStatus updates a run's status and updated_at timestamp.
 func (d *DB) UpdateRunStatus(id string, status types.RunStatus) error {
-	_, err := d.sql.Exec(`UPDATE runs SET status = ?, updated_at = ? WHERE id = ?`, status, now(), id)
-	if err != nil {
-		return fmt.Errorf("update run status: %w", err)
-	}
-	if err := d.AppendLifecycleEvent(LifecycleEvent{RunID: id, EventType: "run_status", Status: string(status)}); err != nil {
-		return err
-	}
-	return nil
+	return d.withLifecycleTx(func(tx *sql.Tx) error {
+		if _, err := tx.Exec(`UPDATE runs SET status = ?, updated_at = ? WHERE id = ?`, status, now(), id); err != nil {
+			return fmt.Errorf("update run status: %w", err)
+		}
+		return d.appendLifecycleEvent(tx, LifecycleEvent{RunID: id, EventType: "run_status", Status: string(status)})
+	})
 }
 
 // UpdateRunPRURL sets the PR URL on a run.
@@ -283,32 +288,32 @@ func (d *DB) UpdateRunError(id, errMsg string) error {
 
 // UpdateRunErrorStatus sets the error message and terminal status on a run.
 func (d *DB) UpdateRunErrorStatus(id, errMsg string, status types.RunStatus) error {
-	_, err := d.sql.Exec(`UPDATE runs SET error = ?, status = ?, blocked_reason = NULL, updated_at = ? WHERE id = ?`, errMsg, status, now(), id)
-	if err != nil {
-		return fmt.Errorf("update run error: %w", err)
-	}
-	if err := d.AppendLifecycleEvent(LifecycleEvent{RunID: id, EventType: "run_failure", Status: string(status), Error: errMsg}); err != nil {
-		return err
-	}
-	return nil
+	return d.withLifecycleTx(func(tx *sql.Tx) error {
+		if _, err := tx.Exec(`UPDATE runs SET error = ?, status = ?, blocked_reason = NULL, updated_at = ? WHERE id = ?`, errMsg, status, now(), id); err != nil {
+			return fmt.Errorf("update run error: %w", err)
+		}
+		return d.appendLifecycleEvent(tx, LifecycleEvent{RunID: id, EventType: "run_failure", Status: string(status), Error: errMsg})
+	})
 }
 
 // SetRunBlockedReason keeps a recoverable external blockage in the current
 // projection while the lifecycle ledger preserves every preceding failure.
 func (d *DB) SetRunBlockedReason(id, reason string) error {
-	_, err := d.sql.Exec(`UPDATE runs SET blocked_reason = ?, updated_at = ? WHERE id = ?`, reason, now(), id)
-	if err != nil {
-		return fmt.Errorf("set run blocked reason: %w", err)
-	}
-	return d.AppendLifecycleEvent(LifecycleEvent{RunID: id, EventType: "run_blocked", Status: string(types.RunRunning), Error: reason})
+	return d.withLifecycleTx(func(tx *sql.Tx) error {
+		if _, err := tx.Exec(`UPDATE runs SET blocked_reason = ?, updated_at = ? WHERE id = ?`, reason, now(), id); err != nil {
+			return fmt.Errorf("set run blocked reason: %w", err)
+		}
+		return d.appendLifecycleEvent(tx, LifecycleEvent{RunID: id, EventType: "run_blocked", Status: string(types.RunRunning), Error: reason})
+	})
 }
 
 func (d *DB) ClearRunBlockedReason(id string) error {
-	_, err := d.sql.Exec(`UPDATE runs SET blocked_reason = NULL, updated_at = ? WHERE id = ?`, now(), id)
-	if err != nil {
-		return fmt.Errorf("clear run blocked reason: %w", err)
-	}
-	return d.AppendLifecycleEvent(LifecycleEvent{RunID: id, EventType: "run_unblocked", Status: string(types.RunRunning)})
+	return d.withLifecycleTx(func(tx *sql.Tx) error {
+		if _, err := tx.Exec(`UPDATE runs SET blocked_reason = NULL, updated_at = ? WHERE id = ?`, now(), id); err != nil {
+			return fmt.Errorf("clear run blocked reason: %w", err)
+		}
+		return d.appendLifecycleEvent(tx, LifecycleEvent{RunID: id, EventType: "run_unblocked", Status: string(types.RunRunning)})
+	})
 }
 
 // ParkRunForAuthorization records a recoverable provider-auth transition.
@@ -319,21 +324,23 @@ func (d *DB) ParkRunForAuthorization(id, step, detail string) error {
 		reason = "authorization required: " + strings.TrimSpace(detail)
 	}
 	ts := now()
-	_, err := d.sql.Exec(`UPDATE runs SET status = ?, blocked_reason = ?, error = ?, updated_at = ? WHERE id = ?`, types.RunAwaitingAuth, reason, reason, ts, id)
-	if err != nil {
-		return fmt.Errorf("park run for authorization: %w", err)
-	}
-	return d.AppendLifecycleEvent(LifecycleEvent{RunID: id, StepName: step, EventType: "authorization_required", Status: string(types.RunAwaitingAuth), Error: reason})
+	return d.withLifecycleTx(func(tx *sql.Tx) error {
+		if _, err := tx.Exec(`UPDATE runs SET status = ?, blocked_reason = ?, error = ?, updated_at = ? WHERE id = ?`, types.RunAwaitingAuth, reason, reason, ts, id); err != nil {
+			return fmt.Errorf("park run for authorization: %w", err)
+		}
+		return d.appendLifecycleEvent(tx, LifecycleEvent{RunID: id, StepName: step, EventType: "authorization_required", Status: string(types.RunAwaitingAuth), Error: reason})
+	})
 }
 
 // ResumeRunAfterAuthorization clears only the current recoverable blockage.
 // The authorization_required lifecycle event remains immutable evidence.
 func (d *DB) ResumeRunAfterAuthorization(id, step string) error {
-	_, err := d.sql.Exec(`UPDATE runs SET status = ?, blocked_reason = NULL, error = NULL, updated_at = ? WHERE id = ?`, types.RunRunning, now(), id)
-	if err != nil {
-		return fmt.Errorf("resume run after authorization: %w", err)
-	}
-	return d.AppendLifecycleEvent(LifecycleEvent{RunID: id, StepName: step, EventType: "authorization_resumed", Status: string(types.RunRunning)})
+	return d.withLifecycleTx(func(tx *sql.Tx) error {
+		if _, err := tx.Exec(`UPDATE runs SET status = ?, blocked_reason = NULL, error = NULL, updated_at = ? WHERE id = ?`, types.RunRunning, now(), id); err != nil {
+			return fmt.Errorf("resume run after authorization: %w", err)
+		}
+		return d.appendLifecycleEvent(tx, LifecycleEvent{RunID: id, StepName: step, EventType: "authorization_resumed", Status: string(types.RunRunning)})
+	})
 }
 
 // RunIntentSourceAgent is the intent_source value stamped when the driving

--- a/internal/db/run_test.go
+++ b/internal/db/run_test.go
@@ -101,6 +101,19 @@ func TestRecoverStaleRunsClearsAwaitingAgent(t *testing.T) {
 	if got.AwaitingAgentSince != nil {
 		t.Errorf("AwaitingAgentSince = %d after recovery, want nil", *got.AwaitingAgentSince)
 	}
+	events, err := d.LifecycleEvents(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundRecovery := false
+	for _, event := range events {
+		if event.EventType == "run_recovered" && event.Error == "daemon restarted" {
+			foundRecovery = true
+		}
+	}
+	if !foundRecovery {
+		t.Fatalf("missing recovery evidence: %+v", events)
+	}
 }
 
 func TestRunGetNotFound(t *testing.T) {

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -176,6 +176,19 @@ CREATE TABLE IF NOT EXISTS route_decisions (
 
 CREATE INDEX IF NOT EXISTS idx_route_decisions_run_created
     ON route_decisions (run_id, created_at, id);
+
+CREATE TABLE IF NOT EXISTS route_results (
+    id         TEXT PRIMARY KEY,
+    run_id     TEXT NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+    step_name  TEXT NOT NULL,
+    round      INTEGER NOT NULL,
+    phase      TEXT NOT NULL,
+    risk       TEXT NOT NULL DEFAULT 'unknown',
+    created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_route_results_run_created
+    ON route_results (run_id, created_at, id);
 `
 
 // migrationStatements hold additive schema changes applied to databases that

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -184,11 +184,19 @@ CREATE TABLE IF NOT EXISTS route_results (
     round      INTEGER NOT NULL,
     phase      TEXT NOT NULL,
     risk       TEXT NOT NULL DEFAULT 'unknown',
+    append_seq INTEGER NOT NULL CHECK (append_seq > 0),
     created_at INTEGER NOT NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_route_results_run_created
     ON route_results (run_id, created_at, id);
+
+-- One row is the durable append-order authority for completed route results.
+-- It is advanced and consumed in the same transaction as each result insert.
+CREATE TABLE IF NOT EXISTS route_result_sequence (
+    id       INTEGER PRIMARY KEY CHECK (id = 1),
+    next_seq INTEGER NOT NULL
+);
 `
 
 // migrationStatements hold additive schema changes applied to databases that
@@ -252,4 +260,5 @@ var migrationStatements = []string{
 	`ALTER TABLE route_decisions ADD COLUMN prompt_bytes INTEGER NOT NULL DEFAULT 0`,
 	`ALTER TABLE route_decisions ADD COLUMN prompt_transport TEXT NOT NULL DEFAULT 'stdin'`,
 	`ALTER TABLE route_decisions ADD COLUMN risk TEXT NOT NULL DEFAULT 'unknown'`,
+	`ALTER TABLE route_results ADD COLUMN append_seq INTEGER`,
 }

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -17,8 +17,14 @@ CREATE TABLE IF NOT EXISTS runs (
     head_sha             TEXT NOT NULL,
     base_sha             TEXT NOT NULL,
     status               TEXT NOT NULL DEFAULT 'pending',
+    provisioning_phase   TEXT NOT NULL DEFAULT 'created',
+    provisioning_progress INTEGER NOT NULL DEFAULT 0,
+    provisioning_error   TEXT,
+    provisioning_started_at INTEGER,
+    provisioning_completed_at INTEGER,
     pr_url               TEXT,
     error                TEXT,
+    blocked_reason       TEXT,
     awaiting_agent_since INTEGER,
     parked_ms            INTEGER,
     created_at           INTEGER NOT NULL,
@@ -95,7 +101,18 @@ CREATE TABLE IF NOT EXISTS agent_invocations (
     tool_other_calls      INTEGER,
     workload_files        INTEGER,
     workload_lines        INTEGER,
-    finding_count         INTEGER
+    finding_count         INTEGER,
+    requested_harness     TEXT,
+    effective_harness     TEXT,
+    requested_model       TEXT,
+    effective_model       TEXT,
+    requested_effort      TEXT,
+    effective_effort      TEXT,
+    route_policy_version  TEXT,
+    route_phase           TEXT,
+    route_reason          TEXT,
+    route_source_config   TEXT,
+    route_generation      TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_agent_invocations_run_started_id
@@ -118,6 +135,47 @@ CREATE TABLE IF NOT EXISTS intent_cache (
     session_id  TEXT NOT NULL,
     created_at  INTEGER NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS lifecycle_events (
+    id          TEXT PRIMARY KEY,
+    run_id      TEXT,
+    step_name   TEXT,
+    event_type  TEXT NOT NULL,
+    status      TEXT,
+    error       TEXT,
+    metadata    TEXT,
+    created_at  INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_lifecycle_events_run_created
+    ON lifecycle_events (run_id, created_at, id);
+
+CREATE TABLE IF NOT EXISTS route_decisions (
+    id                    TEXT PRIMARY KEY,
+    run_id                TEXT NOT NULL,
+    step_name             TEXT,
+    round                 INTEGER NOT NULL,
+    requested_harness     TEXT NOT NULL,
+    effective_harness     TEXT NOT NULL,
+    requested_model       TEXT,
+    effective_model       TEXT,
+    requested_effort      TEXT,
+    effective_effort      TEXT,
+    policy_version        TEXT NOT NULL,
+    phase                 TEXT NOT NULL,
+    risk                  TEXT NOT NULL DEFAULT 'unknown',
+    reason                TEXT NOT NULL,
+    source_configuration  TEXT,
+    configuration_generation TEXT,
+    repository            TEXT,
+    prompt_sha256         TEXT,
+    prompt_bytes          INTEGER NOT NULL DEFAULT 0,
+    prompt_transport     TEXT NOT NULL DEFAULT 'stdin',
+    created_at            INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_route_decisions_run_created
+    ON route_decisions (run_id, created_at, id);
 `
 
 // migrationStatements hold additive schema changes applied to databases that
@@ -135,6 +193,12 @@ var migrationStatements = []string{
 	`ALTER TABLE runs ADD COLUMN intent_score REAL`,
 	`ALTER TABLE runs ADD COLUMN awaiting_agent_since INTEGER`,
 	`ALTER TABLE runs ADD COLUMN parked_ms INTEGER`,
+	`ALTER TABLE runs ADD COLUMN blocked_reason TEXT`,
+	`ALTER TABLE runs ADD COLUMN provisioning_phase TEXT NOT NULL DEFAULT 'created'`,
+	`ALTER TABLE runs ADD COLUMN provisioning_progress INTEGER NOT NULL DEFAULT 0`,
+	`ALTER TABLE runs ADD COLUMN provisioning_error TEXT`,
+	`ALTER TABLE runs ADD COLUMN provisioning_started_at INTEGER`,
+	`ALTER TABLE runs ADD COLUMN provisioning_completed_at INTEGER`,
 	`ALTER TABLE step_results ADD COLUMN last_activity_at INTEGER`,
 	`ALTER TABLE step_results ADD COLUMN last_activity TEXT`,
 	`ALTER TABLE step_results ADD COLUMN agent_pid INTEGER`,
@@ -160,4 +224,19 @@ var migrationStatements = []string{
 	`ALTER TABLE agent_invocations ADD COLUMN workload_files INTEGER`,
 	`ALTER TABLE agent_invocations ADD COLUMN workload_lines INTEGER`,
 	`ALTER TABLE agent_invocations ADD COLUMN finding_count INTEGER`,
+	`ALTER TABLE agent_invocations ADD COLUMN requested_harness TEXT`,
+	`ALTER TABLE agent_invocations ADD COLUMN effective_harness TEXT`,
+	`ALTER TABLE agent_invocations ADD COLUMN requested_model TEXT`,
+	`ALTER TABLE agent_invocations ADD COLUMN effective_model TEXT`,
+	`ALTER TABLE agent_invocations ADD COLUMN requested_effort TEXT`,
+	`ALTER TABLE agent_invocations ADD COLUMN effective_effort TEXT`,
+	`ALTER TABLE agent_invocations ADD COLUMN route_policy_version TEXT`,
+	`ALTER TABLE agent_invocations ADD COLUMN route_phase TEXT`,
+	`ALTER TABLE agent_invocations ADD COLUMN route_reason TEXT`,
+	`ALTER TABLE agent_invocations ADD COLUMN route_source_config TEXT`,
+	`ALTER TABLE agent_invocations ADD COLUMN route_generation TEXT`,
+	`ALTER TABLE route_decisions ADD COLUMN prompt_sha256 TEXT`,
+	`ALTER TABLE route_decisions ADD COLUMN prompt_bytes INTEGER NOT NULL DEFAULT 0`,
+	`ALTER TABLE route_decisions ADD COLUMN prompt_transport TEXT NOT NULL DEFAULT 'stdin'`,
+	`ALTER TABLE route_decisions ADD COLUMN risk TEXT NOT NULL DEFAULT 'unknown'`,
 }

--- a/internal/db/step.go
+++ b/internal/db/step.go
@@ -89,6 +89,11 @@ func (d *DB) UpdateStepStatus(id string, status types.StepStatus) error {
 	if err != nil {
 		return fmt.Errorf("update step status: %w", err)
 	}
+	if step, stepErr := d.GetStepResult(id); stepErr == nil && step != nil {
+		if eventErr := d.AppendLifecycleEvent(LifecycleEvent{RunID: step.RunID, StepName: string(step.StepName), EventType: "step_status", Status: string(status)}); eventErr != nil {
+			return eventErr
+		}
+	}
 	return nil
 }
 
@@ -97,6 +102,11 @@ func (d *DB) UpdateStepStatusWithDuration(id string, status types.StepStatus, du
 	_, err := d.sql.Exec(`UPDATE step_results SET status = ?, duration_ms = ?, last_activity_at = ?, last_activity = ? WHERE id = ?`, status, durationMS, now(), fmt.Sprintf("status: %s", status), id)
 	if err != nil {
 		return fmt.Errorf("update step status with duration: %w", err)
+	}
+	if step, stepErr := d.GetStepResult(id); stepErr == nil && step != nil {
+		if eventErr := d.AppendLifecycleEvent(LifecycleEvent{RunID: step.RunID, StepName: string(step.StepName), EventType: "step_status", Status: string(status)}); eventErr != nil {
+			return eventErr
+		}
 	}
 	return nil
 }
@@ -113,6 +123,11 @@ func (d *DB) StartStepWithAutoFixLimit(id string, autoFixLimit int) error {
 	_, err := d.sql.Exec(`UPDATE step_results SET status = ?, started_at = ?, last_activity_at = ?, last_activity = ?, agent_pid = NULL, auto_fix_limit = ? WHERE id = ?`, types.StepStatusRunning, ts, ts, "step started", autoFixLimitDBValue(autoFixLimit), id)
 	if err != nil {
 		return fmt.Errorf("start step: %w", err)
+	}
+	if step, stepErr := d.GetStepResult(id); stepErr == nil && step != nil {
+		if eventErr := d.AppendLifecycleEvent(LifecycleEvent{RunID: step.RunID, StepName: string(step.StepName), EventType: "step_started", Status: string(types.StepStatusRunning)}); eventErr != nil {
+			return eventErr
+		}
 	}
 	return nil
 }
@@ -145,6 +160,11 @@ func (d *DB) CompleteStepWithStatus(id string, status types.StepStatus, exitCode
 	if err != nil {
 		return fmt.Errorf("complete step: %w", err)
 	}
+	if step, stepErr := d.GetStepResult(id); stepErr == nil && step != nil {
+		if eventErr := d.AppendLifecycleEvent(LifecycleEvent{RunID: step.RunID, StepName: string(step.StepName), EventType: "step_completed", Status: string(status)}); eventErr != nil {
+			return eventErr
+		}
+	}
 	return nil
 }
 
@@ -156,6 +176,11 @@ func (d *DB) FailStep(id string, errMsg string, durationMS int64) error {
 	)
 	if err != nil {
 		return fmt.Errorf("fail step: %w", err)
+	}
+	if step, stepErr := d.GetStepResult(id); stepErr == nil && step != nil {
+		if eventErr := d.AppendLifecycleEvent(LifecycleEvent{RunID: step.RunID, StepName: string(step.StepName), EventType: "step_failure", Status: string(types.StepStatusFailed), Error: errMsg}); eventErr != nil {
+			return eventErr
+		}
 	}
 	return nil
 }

--- a/internal/e2e/axi_journey_test.go
+++ b/internal/e2e/axi_journey_test.go
@@ -48,6 +48,7 @@ func axiScenario(t *testing.T) string {
       tested:
         - "fakeagent: simulated test run"
       testing_summary: "simulated tests passed"
+      artifacts: []
       title: "feat: fakeagent change"
       body: "## Summary\nfakeagent canned PR body"
 `

--- a/internal/e2e/axi_journey_test.go
+++ b/internal/e2e/axi_journey_test.go
@@ -35,10 +35,15 @@ func axiScenario(t *testing.T) string {
           file: "feature.txt"
           line: 1
           description: "potential nil deref"
+          review_scope: source
           action: ask-user
       summary: "found 1 issue"
       risk_level: medium
       risk_rationale: "warning requires human review"
+      risk_scope: "source-or-external"
+      tested: []
+      testing_summary: "review-only journey"
+      artifacts: []
   - text: "no issues found"
     structured:
       findings: []
@@ -66,7 +71,9 @@ func axiScenario(t *testing.T) string {
 // proves the agent-supplied intent is used verbatim (no transcript inference)
 // and that `axi run --yes` auto-approves the gate end to end.
 func TestAxiAgentJourney(t *testing.T) {
-	h := NewHarness(t, SetupOpts{Agent: "claude", Scenario: axiScenario(t)})
+	// Use the isolated fake Codex adapter so route evidence proves a concrete
+	// policy-capable adapter was actually launched, not just a daemon path.
+	h := NewHarness(t, SetupOpts{Agent: "codex", Scenario: axiScenario(t)})
 
 	// Initialize the gate from a worktree, mirroring the real install flow.
 	h.CommitChange("init-axi", "seed.txt", "seed\n", "seed for axi init")
@@ -125,15 +132,21 @@ func TestAxiAgentJourney(t *testing.T) {
 		t.Fatalf("axi route-evidence: %v\n%s", err, routeOut)
 	}
 	for _, want := range []string{
-		"route_decisions[",
+		"route_decisions[1]",
 		"review_results[",
 		"policy_version",
 		"configuration_generation",
-		",review,1,review,medium,",
+		",review,1,review,medium,1,",
 	} {
 		if !strings.Contains(routeOut, want) {
 			t.Fatalf("axi route-evidence missing %q:\n%s", want, routeOut)
 		}
+	}
+	if strings.Contains(routeOut, "route_decisions[0]") {
+		t.Fatalf("axi route-evidence returned no concrete route decisions:\n%s", routeOut)
+	}
+	if findInvocationContaining(h.AgentInvocations(), "Review the code changes and return structured findings") == "" {
+		t.Fatal("axi route-evidence journey did not invoke the isolated Codex adapter")
 	}
 
 	doneOut, err := h.RunInDir(fw, "axi", "respond", "--action", "approve")

--- a/internal/e2e/axi_journey_test.go
+++ b/internal/e2e/axi_journey_test.go
@@ -116,6 +116,26 @@ func TestAxiAgentJourney(t *testing.T) {
 		t.Fatal("expected feature/axi run to be awaiting approval")
 	}
 
+	// The migration canary uses this same isolated init -> invocation -> read
+	// lifecycle. Prove the supported command reads the concrete pre-launch
+	// decision and completed post-result classification from the disposable
+	// database without relying on daemon logs.
+	routeOut, err := h.RunInDir(fw, "axi", "route-evidence")
+	if err != nil {
+		t.Fatalf("axi route-evidence: %v\n%s", err, routeOut)
+	}
+	for _, want := range []string{
+		"route_decisions[",
+		"review_results[",
+		"policy_version",
+		"configuration_generation",
+		",review,1,review,medium,",
+	} {
+		if !strings.Contains(routeOut, want) {
+			t.Fatalf("axi route-evidence missing %q:\n%s", want, routeOut)
+		}
+	}
+
 	doneOut, err := h.RunInDir(fw, "axi", "respond", "--action", "approve")
 	if err != nil {
 		t.Fatalf("axi respond approve (expected exit 0 on pass): %v\n%s", err, doneOut)

--- a/internal/e2e/axi_journey_test.go
+++ b/internal/e2e/axi_journey_test.go
@@ -10,12 +10,22 @@ import (
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
+	"github.com/kunchenguid/no-mistakes/internal/routing"
 	"github.com/kunchenguid/no-mistakes/internal/types"
+	toon "github.com/toon-format/toon-go"
 )
 
 // axiIntent is a distinctive intent string so we can prove it flowed all the
 // way into the pipeline's agent prompts rather than being inferred.
 const axiIntent = "wire the feature flag into the config loader"
+
+type axiRouteEvidence struct {
+	RouteDecisions []axiRouteDecision `toon:"route_decisions"`
+}
+
+type axiRouteDecision struct {
+	ConfigurationGeneration string `toon:"configuration_generation"`
+}
 
 // axiScenario gates exactly one step: the review step returns a single
 // ask-user finding (so the pipeline blocks for a human/agent decision), while
@@ -144,6 +154,23 @@ func TestAxiAgentJourney(t *testing.T) {
 	}
 	if strings.Contains(routeOut, "route_decisions[0]") {
 		t.Fatalf("axi route-evidence returned no concrete route decisions:\n%s", routeOut)
+	}
+	var routeEvidence axiRouteEvidence
+	if err := toon.UnmarshalString(routeOut, &routeEvidence); err != nil {
+		t.Fatalf("decode axi route-evidence: %v\n%s", err, routeOut)
+	}
+	if len(routeEvidence.RouteDecisions) != 1 {
+		t.Fatalf("axi route-evidence returned %d route decisions, want 1:\n%s", len(routeEvidence.RouteDecisions), routeOut)
+	}
+	configData, err := os.ReadFile(filepath.Join(h.NMHome, "config.yaml"))
+	if err != nil {
+		t.Fatalf("read loaded global config: %v", err)
+	}
+	wantGeneration := routing.ConfigFingerprint(string(configData))
+	if got := routeEvidence.RouteDecisions[0].ConfigurationGeneration; got == "" {
+		t.Fatalf("axi route-evidence returned an empty configuration_generation:\n%s", routeOut)
+	} else if got != wantGeneration {
+		t.Fatalf("axi route-evidence configuration_generation = %q, want loaded config fingerprint %q:\n%s", got, wantGeneration, routeOut)
 	}
 	if findInvocationContaining(h.AgentInvocations(), "Review the code changes and return structured findings") == "" {
 		t.Fatal("axi route-evidence journey did not invoke the isolated Codex adapter")

--- a/internal/e2e/daemon_run_test.go
+++ b/internal/e2e/daemon_run_test.go
@@ -56,6 +56,11 @@ func TestDaemonRunUsesProvidedRoot(t *testing.T) {
 			if cmd.Process != nil {
 				_ = cmd.Process.Kill()
 			}
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Errorf("daemon run process was not reaped after kill")
+			}
 		}
 	}()
 

--- a/internal/e2e/harness.go
+++ b/internal/e2e/harness.go
@@ -38,6 +38,7 @@ type Harness struct {
 	UpstreamDir string // bare repo serving as origin for the working clone
 	WorkDir     string // working clone where the user runs `no-mistakes init`
 	AgentLog    string // every fake-agent invocation appended here, one JSON per line
+	RootDir     string // short task-local root used to keep Unix socket paths safe
 	Scenario    string // optional path to a scenario yaml; empty = built-in default
 
 	agentName         string // claude / codex / opencode
@@ -81,7 +82,7 @@ func NewHarness(t *testing.T, opts SetupOpts) *Harness {
 
 	nmBin, fakeBin := buildBinaries(t)
 
-	root, err := os.MkdirTemp("", "nm-e2e-*")
+	root, err := os.MkdirTemp("/tmp", "nm-e2e-")
 	if err != nil {
 		t.Fatalf("mkdir e2e root: %v", err)
 	}
@@ -96,10 +97,14 @@ func NewHarness(t *testing.T, opts SetupOpts) *Harness {
 		UpstreamDir:       filepath.Join(root, "upstream.git"),
 		WorkDir:           filepath.Join(root, "work"),
 		AgentLog:          filepath.Join(root, "fakeagent.log"),
+		RootDir:           root,
 		Scenario:          opts.Scenario,
 		agentName:         opts.Agent,
 		allowRepoCommands: opts.AllowRepoCommands,
 	}
+	// Register cleanup before setup can fail: a fatal setup path must still
+	// stop and reap any daemon it managed to start.
+	t.Cleanup(h.shutdown)
 
 	for _, dir := range []string{h.BinDir, h.NMHome, h.HomeDir, h.WorkDir} {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -157,7 +162,6 @@ func NewHarness(t *testing.T, opts SetupOpts) *Harness {
 	h.writeGlobalConfig()
 	h.initGitRepos()
 
-	t.Cleanup(h.shutdown)
 	return h
 }
 
@@ -683,8 +687,44 @@ func (h *Harness) shutdown() {
 	defer cancel()
 	cmd := exec.CommandContext(ctx, h.NMBin, "daemon", "stop")
 	cmd.Dir = h.daemonStopDir()
-	cmd.Env = os.Environ()
+	cmd.Env = mergedEnv(os.Environ(), map[string]string{"NM_HOME": h.NMHome, "HOME": h.HomeDir})
 	_ = cmd.Run()
+	h.reapScopedProcesses()
+}
+
+// reapScopedProcesses is a last-resort cleanup for children left by an
+// interrupted stop. It only considers command lines rooted in this harness,
+// so historical or developer-owned processes cannot be touched.
+func (h *Harness) reapScopedProcesses() {
+	if runtime.GOOS == "windows" || h.RootDir == "" {
+		return
+	}
+	for attempt := 0; attempt < 20; attempt++ {
+		out, err := exec.Command("ps", "-axo", "pid=,command=").Output()
+		if err != nil {
+			return
+		}
+		found := false
+		for _, line := range strings.Split(string(out), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) < 2 || !strings.Contains(line, h.RootDir) {
+				continue
+			}
+			var pid int
+			if _, scanErr := fmt.Sscanf(fields[0], "%d", &pid); scanErr != nil || pid <= 0 || pid == os.Getpid() {
+				continue
+			}
+			found = true
+			if process, findErr := os.FindProcess(pid); findErr == nil {
+				_ = process.Kill()
+			}
+		}
+		if !found {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	h.t.Errorf("scoped e2e processes remain under %s", h.RootDir)
 }
 
 func (h *Harness) daemonStopDir() string {
@@ -714,7 +754,7 @@ var (
 func buildBinaries(t *testing.T) (nmBin, fakeBin string) {
 	t.Helper()
 	buildOnce.Do(func() {
-		dir, err := os.MkdirTemp("", "nm-e2e-bin-*")
+		dir, err := os.MkdirTemp("/tmp", "nm-e2e-bin-")
 		if err != nil {
 			buildErr = err
 			return

--- a/internal/e2e/intent_journey_test.go
+++ b/internal/e2e/intent_journey_test.go
@@ -219,6 +219,7 @@ func writeIntentScenario(t *testing.T) string {
       tested:
         - "fakeagent: simulated test run"
       testing_summary: "simulated tests passed"
+      artifacts: []
       title: "feat: fakeagent change"
       body: "## Summary\nfakeagent canned PR body"
 `

--- a/internal/e2e/journey_test.go
+++ b/internal/e2e/journey_test.go
@@ -476,6 +476,7 @@ func cleanReviewScenario(t *testing.T) string {
       tested:
         - "fakeagent: simulated test run"
       testing_summary: "simulated tests passed"
+      artifacts: []
       title: "feat: fakeagent change"
       body: "## Summary\nfakeagent canned PR body"
 `

--- a/internal/e2e/review_pipeline_delivery_test.go
+++ b/internal/e2e/review_pipeline_delivery_test.go
@@ -50,6 +50,7 @@ func writePipelineOwnedPRScenario(t *testing.T) string {
       tested:
         - "fakeagent: simulated test run"
       testing_summary: "simulated tests passed"
+      artifacts: []
       title: "feat: open PR A"
       body: "## Summary\nOpen PR A unmerged"
 `
@@ -85,6 +86,7 @@ func writeExternalPRScenario(t *testing.T) string {
       tested:
         - "fakeagent: simulated test run"
       testing_summary: "simulated tests passed"
+      artifacts: []
       title: "feat: change"
       body: "## Summary\nchange"
 `

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -191,14 +191,18 @@ type ShutdownResult struct {
 
 // RunInfo is the IPC representation of a pipeline run.
 type RunInfo struct {
-	ID      string          `json:"id"`
-	RepoID  string          `json:"repo_id"`
-	Branch  string          `json:"branch"`
-	HeadSHA string          `json:"head_sha"`
-	BaseSHA string          `json:"base_sha"`
-	Status  types.RunStatus `json:"status"`
-	PRURL   *string         `json:"pr_url,omitempty"`
-	Error   *string         `json:"error,omitempty"`
+	ID                   string          `json:"id"`
+	RepoID               string          `json:"repo_id"`
+	Branch               string          `json:"branch"`
+	HeadSHA              string          `json:"head_sha"`
+	BaseSHA              string          `json:"base_sha"`
+	Status               types.RunStatus `json:"status"`
+	ProvisioningPhase    string          `json:"provisioning_phase,omitempty"`
+	ProvisioningProgress int             `json:"provisioning_progress,omitempty"`
+	ProvisioningError    *string         `json:"provisioning_error,omitempty"`
+	PRURL                *string         `json:"pr_url,omitempty"`
+	Error                *string         `json:"error,omitempty"`
+	BlockedReason        *string         `json:"blocked_reason,omitempty"`
 	// AwaitingAgent is true while the run is parked at a gate awaiting the
 	// driving agent's response. AwaitingAgentSince is the unix-seconds time it
 	// parked, so a supervisor can read "parked for N seconds" in one call. Both

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -348,10 +348,8 @@ func (e *Executor) Resume(ctx context.Context, run *db.Run, repo *db.Repo, workD
 	)
 
 	response, reconciled, err := e.waitForApprovalOrReconcile(ctx, gate.step, reconcileCtx, false)
-	if run.Status != types.RunAwaitingAuth {
-		if dbErr := e.db.CompleteRunAwaitingAgent(run.ID, time.Since(parkStart).Milliseconds()); dbErr != nil {
-			slog.Warn("failed to complete awaiting-agent state in db", "step", gate.step.Name(), "run", run.ID, "error", dbErr)
-		}
+	if dbErr := e.db.CompleteRunAwaitingAgent(run.ID, time.Since(parkStart).Milliseconds()); dbErr != nil {
+		slog.Warn("failed to complete awaiting-agent state in db", "step", gate.step.Name(), "run", run.ID, "error", dbErr)
 	}
 	if err != nil {
 		if dbErr := e.db.FailStep(gate.stepResult.ID, err.Error(), duration); dbErr != nil {
@@ -1025,6 +1023,9 @@ func (e *Executor) parkForAuthorization(ctx context.Context, step Step, sctx *St
 		return err
 	}
 	run.BlockedReason = func() *string { v := reason; return &v }()
+	if err := e.db.SetRunAwaitingAgent(run.ID); err != nil {
+		return err
+	}
 	findings := `{"summary":"Codex authorization is required before this turn can continue","risk_level":"high","risk_rationale":"external authentication state is unavailable","findings":[]}`
 	if err := e.db.SetStepFindings(sr.ID, findings); err != nil {
 		return err
@@ -1043,6 +1044,7 @@ func (e *Executor) parkForAuthorization(ctx context.Context, step Step, sctx *St
 	e.waitingStep = step.Name()
 	e.mu.Unlock()
 	e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, step.Name(), string(types.StepStatusAwaitingApproval), "", "", reason, nil)
+	parkStart := time.Now()
 	response, _, err := e.waitForApprovalOrReconcile(ctx, step, sctx, false)
 	if err != nil {
 		cause := context.Cause(ctx)
@@ -1056,6 +1058,9 @@ func (e *Executor) parkForAuthorization(ctx context.Context, step Step, sctx *St
 	}
 	if !retryAllowed {
 		return errAuthorizationParked
+	}
+	if dbErr := e.db.CompleteRunAwaitingAgent(run.ID, time.Since(parkStart).Milliseconds()); dbErr != nil {
+		return dbErr
 	}
 	if dbErr := e.db.ResumeRunAfterAuthorization(run.ID, string(step.Name())); dbErr != nil {
 		return dbErr

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -1020,11 +1020,16 @@ func (e *Executor) parkForAuthorization(ctx context.Context, step Step, sctx *St
 	if err != nil {
 		return err
 	}
-	retryAllowed := attempts < authorizationRecoveryLimit
+	if attempts >= authorizationRecoveryLimit {
+		return fmt.Errorf("authorization recovery retry limit reached after %d parked attempt(s)", attempts)
+	}
 	if err := e.db.ParkRunForAuthorization(run.ID, string(step.Name()), reason); err != nil {
 		return err
 	}
 	run.BlockedReason = func() *string { v := reason; return &v }()
+	if err := e.db.SetRunAwaitingAgent(run.ID); err != nil {
+		return err
+	}
 	findings := `{"summary":"Codex authorization is required before this turn can continue","risk_level":"high","risk_rationale":"external authentication state is unavailable","findings":[]}`
 	if err := e.db.SetStepFindings(sr.ID, findings); err != nil {
 		return err
@@ -1043,6 +1048,7 @@ func (e *Executor) parkForAuthorization(ctx context.Context, step Step, sctx *St
 	e.waitingStep = step.Name()
 	e.mu.Unlock()
 	e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, step.Name(), string(types.StepStatusAwaitingApproval), "", "", reason, nil)
+	parkStart := time.Now()
 	response, _, err := e.waitForApprovalOrReconcile(ctx, step, sctx, false)
 	if err != nil {
 		cause := context.Cause(ctx)
@@ -1051,11 +1057,11 @@ func (e *Executor) parkForAuthorization(ctx context.Context, step Step, sctx *St
 		}
 		return err
 	}
+	if dbErr := e.db.CompleteRunAwaitingAgent(run.ID, time.Since(parkStart).Milliseconds()); dbErr != nil {
+		return dbErr
+	}
 	if response.action != types.ActionApprove && response.action != types.ActionFix {
 		return fmt.Errorf("authorization recovery requires approve or fix, got %q", response.action)
-	}
-	if !retryAllowed {
-		return errAuthorizationParked
 	}
 	if dbErr := e.db.ResumeRunAfterAuthorization(run.ID, string(step.Name())); dbErr != nil {
 		return dbErr

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -2,6 +2,8 @@ package pipeline
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -18,6 +20,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/routing"
 	"github.com/kunchenguid/no-mistakes/internal/telemetry"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
@@ -29,6 +32,10 @@ const (
 	defaultGateReconcileInterval = 2 * time.Minute
 	defaultGateReconcileTimeout  = 30 * time.Second
 )
+
+var errAuthorizationParked = errors.New("agent authorization required; run parked for authentication recovery")
+
+const authorizationRetryLimit = 2
 
 type approvalResponse struct {
 	action        types.ApprovalAction
@@ -58,8 +65,21 @@ type Executor struct {
 	waiting     bool                  // true when blocked on approval
 	waitingStep types.StepName        // which step is currently awaiting approval
 
-	gateReconcileInterval time.Duration
-	gateReconcileTimeout  time.Duration
+	gateReconcileInterval        time.Duration
+	gateReconcileTimeout         time.Duration
+	routeRepository              string
+	routeSourceConfiguration     string
+	routeConfigurationGeneration string
+	routeRisk                    routing.Risk
+	routeReviewConfirmed         bool
+}
+
+// SetRouteContext supplies repository identity and the loaded configuration
+// generation to the core routing/evidence wrapper.
+func (e *Executor) SetRouteContext(repository, sourceConfiguration, generation string) {
+	e.routeRepository = repository
+	e.routeSourceConfiguration = sourceConfiguration
+	e.routeConfigurationGeneration = generation
 }
 
 // SetSkippedSteps configures steps that should be marked skipped without running.
@@ -142,6 +162,8 @@ func (e *Executor) RespondWithOverrides(step types.StepName, action types.Approv
 // If the context is cancelled with a cause (via context.WithCancelCause),
 // the cause message is preserved as the run's error in the DB.
 func (e *Executor) Execute(ctx context.Context, run *db.Run, repo *db.Repo, workDir string) error {
+	e.routeRisk = routing.RiskUnknown
+	e.routeReviewConfirmed = false
 	// Mark run as running. Route write failures through failRun so the
 	// in-memory lifecycle and subscriber stream still become terminal instead
 	// of leaving a silent pending run.
@@ -185,6 +207,9 @@ func (e *Executor) Execute(ctx context.Context, run *db.Run, repo *db.Repo, work
 		}
 		skipRemaining, err := e.executeStep(ctx, step, sr, run, repo, workDir, logDir, stepExecutionState{})
 		if err != nil {
+			if errors.Is(err, errAuthorizationParked) {
+				return nil
+			}
 			return e.failRun(run, repo, err, ctx)
 		}
 		if skipRemaining {
@@ -236,7 +261,7 @@ type recoveredGate struct {
 }
 
 func ValidateRecoveredRun(database *db.DB, run *db.Run, steps []Step) error {
-	if run == nil || run.Status != types.RunRunning || run.AwaitingAgentSince == nil {
+	if run == nil || (run.Status != types.RunRunning && run.Status != types.RunAwaitingAuth) || run.AwaitingAgentSince == nil {
 		return fmt.Errorf("run is not a recoverable parked run")
 	}
 	_, err := (&Executor{db: database, steps: steps}).recoveredGate(run.ID)
@@ -262,6 +287,7 @@ func (e *Executor) Resume(ctx context.Context, run *db.Run, repo *db.Repo, workD
 		return e.failRun(run, repo, fmt.Errorf("create log dir: %w", err))
 	}
 	e.initializeRunScopes(run.ID)
+	e.restoreRouteState(run.ID)
 
 	parkStart := time.Unix(*run.AwaitingAgentSince, 0)
 	duration := recoveredStepDuration(gate.stepResult)
@@ -340,6 +366,30 @@ func (e *Executor) Resume(ctx context.Context, run *db.Run, repo *db.Repo, workD
 		approvalFields["selected_findings_count"] = selectedCount
 	}
 	telemetry.Track("approval", approvalFields)
+	if run.BlockedReason != nil && (response.action == types.ActionApprove || response.action == types.ActionFix) {
+		if dbErr := e.db.ClearRunBlockedReason(run.ID); dbErr != nil {
+			return e.failRun(run, repo, fmt.Errorf("clear authorization blockage: %w", dbErr), ctx)
+		}
+		run.BlockedReason = nil
+		if run.Status == types.RunAwaitingAuth {
+			if dbErr := e.db.UpdateRunStatus(run.ID, types.RunRunning); dbErr != nil {
+				return e.failRun(run, repo, fmt.Errorf("resume authorization-blocked run: %w", dbErr), ctx)
+			}
+			run.Status = types.RunRunning
+		}
+		state := stepExecutionState{roundNum: gate.round, fixing: gate.stepResult.Status == types.StepStatusFixReview, previousFindings: gate.findings}
+		skipRemaining, retryErr := e.executeStep(ctx, gate.step, gate.stepResult, run, repo, workDir, logDir, state)
+		if retryErr != nil {
+			if errors.Is(retryErr, errAuthorizationParked) {
+				return nil
+			}
+			return e.failRun(run, repo, retryErr, ctx)
+		}
+		if skipRemaining {
+			return e.skipRecoveredRemainder(run, repo, gate.index+1)
+		}
+		return e.executeRecoveredRemainder(ctx, run, repo, workDir, logDir, gate.index+1)
+	}
 	switch response.action {
 	case types.ActionApprove:
 		if err := e.db.CompleteStepWithStatus(gate.stepResult.ID, types.StepStatusCompleted, recoveredExitCode(gate.stepResult), duration, recoveredLogPath(gate.stepResult)); err != nil {
@@ -642,11 +692,16 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 	if stepAgent != nil {
 		stepAgent = &lifecycleAgent{inner: stepAgent, onLifecycle: onAgentLifecycle}
 		stepAgent = &perfRecordingAgent{
-			inner:    stepAgent,
-			db:       e.db,
-			runID:    run.ID,
-			stepName: stepName,
-			round:    func() int { return roundNum + 1 },
+			inner:                   stepAgent,
+			db:                      e.db,
+			runID:                   run.ID,
+			stepName:                stepName,
+			round:                   func() int { return roundNum + 1 },
+			repository:              e.routeRepository,
+			sourceConfiguration:     e.routeSourceConfiguration,
+			configurationGeneration: e.routeConfigurationGeneration,
+			risk:                    func() routing.Risk { return e.routeRisk },
+			reviewConfirmation:      func() bool { return stepName == types.StepReview && e.routeReviewConfirmed },
 		}
 	}
 	sctx := &StepContext{
@@ -679,6 +734,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 	skipRemaining := false
 	stepSkipped := false
 	currentRoundID := state.currentRoundID
+	authorizationRetries := 0
 
 	// Execute with possible fix loop
 	for {
@@ -686,6 +742,19 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 		roundNum++
 		roundDuration := time.Since(phaseStart).Milliseconds()
 		if err != nil {
+			if agent.IsAuthorizationRequired(err) {
+				authorizationRetries++
+				if authorizationRetries > authorizationRetryLimit {
+					err = fmt.Errorf("authorization recovery retry limit exceeded: %w", err)
+				} else if parkErr := e.parkForAuthorization(ctx, step, sctx, sr, run, repo, roundNum); parkErr == nil {
+					phaseStart = time.Now()
+					continue
+				} else if errors.Is(parkErr, errAuthorizationParked) {
+					return false, parkErr
+				} else {
+					err = fmt.Errorf("authorization recovery: %w", parkErr)
+				}
+			}
 			durationMS := executionMS + roundDuration
 			// Persist the failure reason to the step's own log file. The error
 			// often carries the only detail of why the step failed (e.g. git
@@ -701,6 +770,16 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 		}
 
 		outcome.Findings = normalizeFindingsJSON(outcome.Findings, string(stepName))
+		if stepName == types.StepReview {
+			if risk := routeRiskFromFindings(outcome.Findings); risk != routing.RiskUnknown {
+				e.routeRisk = risk
+				// The initial review is the bootstrap classifier. Only a later
+				// review turn may select Sol, and only after that classifier ran.
+				if sctx.Fixing && risk == routing.RiskHigh {
+					e.routeReviewConfirmed = true
+				}
+			}
+		}
 		finalExitCode = outcome.ExitCode
 		durationOverrideMS += outcome.DurationOverrideMS
 
@@ -930,6 +1009,58 @@ func roundInsertID(_ string, inserted *db.StepRound, err error) string {
 	return inserted.ID
 }
 
+func (e *Executor) parkForAuthorization(ctx context.Context, step Step, sctx *StepContext, sr *db.StepResult, run *db.Run, repo *db.Repo, round int) error {
+	const reason = "codex authorization required; log into a healthy Codex account, then approve to retry"
+	if err := e.db.ParkRunForAuthorization(run.ID, string(step.Name()), reason); err != nil {
+		return err
+	}
+	run.BlockedReason = func() *string { v := reason; return &v }()
+	if err := e.db.SetRunAwaitingAgent(run.ID); err != nil {
+		return err
+	}
+	findings := `{"summary":"Codex authorization is required before this turn can continue","risk_level":"high","risk_rationale":"external authentication state is unavailable","findings":[]}`
+	if err := e.db.SetStepFindings(sr.ID, findings); err != nil {
+		return err
+	}
+	if round < 1 {
+		round = 1
+	}
+	if _, err := e.db.InsertStepRound(sr.ID, round, "auth_required", &findings, nil, 0); err != nil {
+		return err
+	}
+	if err := e.db.UpdateStepStatusWithDuration(sr.ID, types.StepStatusAwaitingApproval, 0); err != nil {
+		return err
+	}
+	e.mu.Lock()
+	e.waiting = true
+	e.waitingStep = step.Name()
+	e.mu.Unlock()
+	e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, step.Name(), string(types.StepStatusAwaitingApproval), "", "", reason, nil)
+	parkStart := time.Now()
+	response, _, err := e.waitForApprovalOrReconcile(ctx, step, sctx, false)
+	if err != nil {
+		cause := context.Cause(ctx)
+		if cause == nil || errors.Is(cause, context.Canceled) || strings.Contains(strings.ToLower(err.Error()), "daemon shutting down") {
+			return errAuthorizationParked
+		}
+		return err
+	}
+	if dbErr := e.db.CompleteRunAwaitingAgent(run.ID, time.Since(parkStart).Milliseconds()); dbErr != nil {
+		return dbErr
+	}
+	if dbErr := e.db.ResumeRunAfterAuthorization(run.ID, string(step.Name())); dbErr != nil {
+		return dbErr
+	}
+	if response.action != types.ActionApprove && response.action != types.ActionFix {
+		return fmt.Errorf("authorization recovery requires approve or fix, got %q", response.action)
+	}
+	if err := e.db.UpdateStepStatus(sr.ID, types.StepStatusRunning); err != nil {
+		return err
+	}
+	sctx.Log("authentication recovered; retrying the same agent turn")
+	return nil
+}
+
 type lifecycleAgent struct {
 	inner       agent.Agent
 	onLifecycle func(agent.LifecycleEvent)
@@ -1111,6 +1242,16 @@ func (e *Executor) failRun(run *db.Run, repo *db.Repo, err error, ctxs ...contex
 			break
 		}
 	}
+	if agent.IsAuthorizationRequired(err) {
+		if dbErr := e.db.ParkRunForAuthorization(run.ID, string(e.currentStepName(run.ID)), errMsg); dbErr != nil {
+			slog.Error("failed to persist authorization blockage", "run", run.ID, "error", dbErr)
+		}
+		run.Status = types.RunAwaitingAuth
+		run.Error = &errMsg
+		run.BlockedReason = &errMsg
+		e.emitRunEvent(ipc.EventRunUpdated, run, repo)
+		return err
+	}
 	runStatus := types.RunFailed
 	if errMsg == types.RunCancelReasonAbortedByUser || errMsg == types.RunCancelReasonSuperseded {
 		runStatus = types.RunCancelled
@@ -1122,6 +1263,58 @@ func (e *Executor) failRun(run *db.Run, repo *db.Repo, err error, ctxs ...contex
 	run.Error = &errMsg
 	e.emitRunEvent(ipc.EventRunCompleted, run, repo)
 	return err
+}
+
+func (e *Executor) currentStepName(runID string) types.StepName {
+	if steps, err := e.db.GetStepsByRun(runID); err == nil {
+		for _, step := range steps {
+			if step.Status == types.StepStatusRunning || step.Status == types.StepStatusFailed {
+				return step.StepName
+			}
+		}
+	}
+	return "unknown"
+}
+
+// restoreRouteState recovers only durable policy state needed for a resumed
+// invocation. This keeps a daemon restart from silently downgrading or
+// re-bootstrapping a review route, while the route decision ledger remains the
+// audit source rather than a mutable project manifest.
+func (e *Executor) restoreRouteState(runID string) {
+	decisions, err := e.db.RouteDecisions(runID)
+	if err != nil {
+		return
+	}
+	for _, decision := range decisions {
+		if decision.Risk == string(routing.RiskHigh) {
+			e.routeRisk = routing.RiskHigh
+		}
+		if decision.Phase == "review-confirmation" && decision.EffectiveModel == routing.ModelSol {
+			e.routeReviewConfirmed = true
+		}
+	}
+}
+
+func routeRiskFromFindings(raw string) routing.Risk {
+	if strings.TrimSpace(raw) == "" {
+		return routing.RiskUnknown
+	}
+	var findings struct {
+		RiskLevel string `json:"risk_level"`
+	}
+	if err := json.Unmarshal([]byte(raw), &findings); err != nil {
+		return routing.RiskUnknown
+	}
+	switch strings.ToLower(strings.TrimSpace(findings.RiskLevel)) {
+	case "low":
+		return routing.RiskLow
+	case "medium":
+		return routing.RiskMedium
+	case "high":
+		return routing.RiskHigh
+	default:
+		return routing.RiskUnknown
+	}
 }
 
 // --- event helpers ---

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -496,7 +496,8 @@ func (e *Executor) recoveredGate(runID string) (*recoveredGate, error) {
 		if result.StepName != e.steps[index].Name() {
 			return nil, fmt.Errorf("recovered step %d is %q, want %q", index, result.StepName, e.steps[index].Name())
 		}
-		if result.Status == types.StepStatusAwaitingApproval || result.Status == types.StepStatusFixReview {
+		authGate := result.Status == types.StepStatusRunning && result.FindingsJSON != nil
+		if result.Status == types.StepStatusAwaitingApproval || result.Status == types.StepStatusFixReview || authGate {
 			if gate != nil || result.FindingsJSON == nil || result.StartedAt == nil || result.DurationMS == nil || result.AgentPID != nil {
 				return nil, fmt.Errorf("recovered approval gate is incomplete")
 			}
@@ -505,6 +506,9 @@ func (e *Executor) recoveredGate(runID string) (*recoveredGate, error) {
 				return nil, fmt.Errorf("recovered approval gate has no complete round")
 			}
 			latest := rounds[len(rounds)-1]
+			if authGate && latest.Trigger != "auth_required" {
+				return nil, fmt.Errorf("recovered running step %s is not an authorization gate", result.StepName)
+			}
 			if latest.FindingsJSON == nil || *latest.FindingsJSON != *result.FindingsJSON {
 				return nil, fmt.Errorf("recovered approval gate findings are incomplete")
 			}
@@ -1049,6 +1053,7 @@ func (e *Executor) parkForAuthorization(ctx context.Context, step Step, sctx *St
 	if err := e.db.ParkRunForAuthorization(run.ID, string(step.Name()), reason); err != nil {
 		return err
 	}
+	run.Status = types.RunAwaitingAuth
 	run.BlockedReason = func() *string { v := reason; return &v }()
 	findings := `{"summary":"Codex authorization is required before this turn can continue","risk_level":"high","risk_rationale":"external authentication state is unavailable","findings":[]}`
 	if err := e.db.SetStepFindings(sr.ID, findings); err != nil {
@@ -1060,7 +1065,7 @@ func (e *Executor) parkForAuthorization(ctx context.Context, step Step, sctx *St
 	if _, err := e.db.InsertStepRound(sr.ID, round, "auth_required", &findings, nil, 0); err != nil {
 		return err
 	}
-	if err := e.db.UpdateStepStatusWithDuration(sr.ID, types.StepStatusAwaitingApproval, 0); err != nil {
+	if err := e.db.UpdateStepStatusWithDuration(sr.ID, types.StepStatusRunning, 0); err != nil {
 		return err
 	}
 	e.mu.Lock()
@@ -1068,6 +1073,7 @@ func (e *Executor) parkForAuthorization(ctx context.Context, step Step, sctx *St
 	e.waitingStep = step.Name()
 	e.mu.Unlock()
 	e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, step.Name(), string(types.StepStatusAwaitingApproval), "", "", reason, nil)
+	parkStart := time.Now()
 	response, _, err := e.waitForApprovalOrReconcile(ctx, step, sctx, false)
 	if err != nil {
 		cause := context.Cause(ctx)
@@ -1085,10 +1091,12 @@ func (e *Executor) parkForAuthorization(ctx context.Context, step Step, sctx *St
 	if dbErr := e.db.ResumeRunAfterAuthorization(run.ID, string(step.Name())); dbErr != nil {
 		return dbErr
 	}
+	run.Status = types.RunRunning
+	run.BlockedReason = nil
 	if err := e.db.UpdateStepStatus(sr.ID, types.StepStatusRunning); err != nil {
 		return err
 	}
-	sctx.Log("authentication recovered; retrying the same agent turn")
+	sctx.Log(fmt.Sprintf("authentication recovered after explicit approval (%d ms parked); retrying the same agent turn", time.Since(parkStart).Milliseconds()))
 	return nil
 }
 

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -348,15 +348,31 @@ func (e *Executor) Resume(ctx context.Context, run *db.Run, repo *db.Repo, workD
 	)
 
 	response, reconciled, err := e.waitForApprovalOrReconcile(ctx, gate.step, reconcileCtx, false)
-	if dbErr := e.db.CompleteRunAwaitingAgent(run.ID, time.Since(parkStart).Milliseconds()); dbErr != nil {
-		slog.Warn("failed to complete awaiting-agent state in db", "step", gate.step.Name(), "run", run.ID, "error", dbErr)
-	}
 	if err != nil {
+		// An authorization-parked run is intentionally recoverable. A daemon
+		// shutdown while its recovered gate is waiting must leave that park
+		// intact so the next daemon can offer the same bounded retry; generic
+		// gate cancellation must not rewrite it as a terminal shutdown failure.
+		if run.Status == types.RunAwaitingAuth && preserveAuthorizationPark(ctx, err) {
+			return nil
+		}
+		if run.Status != types.RunAwaitingAuth {
+			if run.Status != types.RunAwaitingAuth {
+				if dbErr := e.db.CompleteRunAwaitingAgent(run.ID, time.Since(parkStart).Milliseconds()); dbErr != nil {
+					slog.Warn("failed to complete awaiting-agent state in db", "step", gate.step.Name(), "run", run.ID, "error", dbErr)
+				}
+			}
+		}
 		if dbErr := e.db.FailStep(gate.stepResult.ID, err.Error(), duration); dbErr != nil {
 			slog.Warn("failed to mark recovered step as failed in db", "step", gate.step.Name(), "error", dbErr)
 		}
 		e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, gate.step.Name(), string(types.StepStatusFailed), "", "", err.Error(), &duration)
 		return e.failRun(run, repo, fmt.Errorf("step %s: waiting for approval: %w", gate.step.Name(), err), ctx)
+	}
+	if run.Status != types.RunAwaitingAuth {
+		if dbErr := e.db.CompleteRunAwaitingAgent(run.ID, time.Since(parkStart).Milliseconds()); dbErr != nil {
+			slog.Warn("failed to complete awaiting-agent state in db", "step", gate.step.Name(), "run", run.ID, "error", dbErr)
+		}
 	}
 	if reconciled {
 		return completeReconciledGate()
@@ -456,6 +472,16 @@ func (e *Executor) Resume(ctx context.Context, run *db.Run, repo *db.Repo, workD
 	default:
 		return e.failRun(run, repo, fmt.Errorf("step %s: unsupported approval action %q", gate.step.Name(), response.action), ctx)
 	}
+}
+
+func preserveAuthorizationPark(ctx context.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+	cause := context.Cause(ctx)
+	return cause == nil || errors.Is(cause, context.Canceled) ||
+		errors.Is(err, context.Canceled) ||
+		strings.Contains(strings.ToLower(err.Error()), "daemon shutting down")
 }
 
 func (e *Executor) recoveredGate(runID string) (*recoveredGate, error) {
@@ -1023,9 +1049,6 @@ func (e *Executor) parkForAuthorization(ctx context.Context, step Step, sctx *St
 		return err
 	}
 	run.BlockedReason = func() *string { v := reason; return &v }()
-	if err := e.db.SetRunAwaitingAgent(run.ID); err != nil {
-		return err
-	}
 	findings := `{"summary":"Codex authorization is required before this turn can continue","risk_level":"high","risk_rationale":"external authentication state is unavailable","findings":[]}`
 	if err := e.db.SetStepFindings(sr.ID, findings); err != nil {
 		return err
@@ -1044,7 +1067,6 @@ func (e *Executor) parkForAuthorization(ctx context.Context, step Step, sctx *St
 	e.waitingStep = step.Name()
 	e.mu.Unlock()
 	e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, step.Name(), string(types.StepStatusAwaitingApproval), "", "", reason, nil)
-	parkStart := time.Now()
 	response, _, err := e.waitForApprovalOrReconcile(ctx, step, sctx, false)
 	if err != nil {
 		cause := context.Cause(ctx)
@@ -1058,9 +1080,6 @@ func (e *Executor) parkForAuthorization(ctx context.Context, step Step, sctx *St
 	}
 	if !retryAllowed {
 		return errAuthorizationParked
-	}
-	if dbErr := e.db.CompleteRunAwaitingAgent(run.ID, time.Since(parkStart).Milliseconds()); dbErr != nil {
-		return dbErr
 	}
 	if dbErr := e.db.ResumeRunAfterAuthorization(run.ID, string(step.Name())); dbErr != nil {
 		return dbErr

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -35,7 +35,7 @@ const (
 
 var errAuthorizationParked = errors.New("agent authorization required; run parked for authentication recovery")
 
-const authorizationRetryLimit = 2
+const authorizationRecoveryLimit = 1
 
 type approvalResponse struct {
 	action        types.ApprovalAction
@@ -742,8 +742,6 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 	skipRemaining := false
 	stepSkipped := false
 	currentRoundID := state.currentRoundID
-	authorizationRetries := 0
-
 	// Execute with possible fix loop
 	for {
 		outcome, err := step.Execute(sctx)
@@ -751,10 +749,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 		roundDuration := time.Since(phaseStart).Milliseconds()
 		if err != nil {
 			if agent.IsAuthorizationRequired(err) {
-				authorizationRetries++
-				if authorizationRetries > authorizationRetryLimit {
-					err = fmt.Errorf("authorization recovery retry limit exceeded: %w", err)
-				} else if parkErr := e.parkForAuthorization(ctx, step, sctx, sr, run, repo, roundNum); parkErr == nil {
+				if parkErr := e.parkForAuthorization(ctx, step, sctx, sr, run, repo, roundNum); parkErr == nil {
 					phaseStart = time.Now()
 					continue
 				} else if errors.Is(parkErr, errAuthorizationParked) {
@@ -1019,6 +1014,13 @@ func roundInsertID(_ string, inserted *db.StepRound, err error) string {
 
 func (e *Executor) parkForAuthorization(ctx context.Context, step Step, sctx *StepContext, sr *db.StepResult, run *db.Run, repo *db.Repo, round int) error {
 	const reason = "codex authorization required; log into a healthy Codex account, then approve to retry"
+	attempts, err := e.authorizationParkCount(run.ID)
+	if err != nil {
+		return err
+	}
+	if attempts >= authorizationRecoveryLimit {
+		return fmt.Errorf("authorization recovery retry limit reached after %d parked attempt(s)", attempts)
+	}
 	if err := e.db.ParkRunForAuthorization(run.ID, string(step.Name()), reason); err != nil {
 		return err
 	}
@@ -1056,17 +1058,31 @@ func (e *Executor) parkForAuthorization(ctx context.Context, step Step, sctx *St
 	if dbErr := e.db.CompleteRunAwaitingAgent(run.ID, time.Since(parkStart).Milliseconds()); dbErr != nil {
 		return dbErr
 	}
-	if dbErr := e.db.ResumeRunAfterAuthorization(run.ID, string(step.Name())); dbErr != nil {
-		return dbErr
-	}
 	if response.action != types.ActionApprove && response.action != types.ActionFix {
 		return fmt.Errorf("authorization recovery requires approve or fix, got %q", response.action)
+	}
+	if dbErr := e.db.ResumeRunAfterAuthorization(run.ID, string(step.Name())); dbErr != nil {
+		return dbErr
 	}
 	if err := e.db.UpdateStepStatus(sr.ID, types.StepStatusRunning); err != nil {
 		return err
 	}
 	sctx.Log("authentication recovered; retrying the same agent turn")
 	return nil
+}
+
+func (e *Executor) authorizationParkCount(runID string) (int, error) {
+	events, err := e.db.LifecycleEvents(runID)
+	if err != nil {
+		return 0, fmt.Errorf("count authorization recovery attempts: %w", err)
+	}
+	count := 0
+	for _, event := range events {
+		if event.EventType == "authorization_required" {
+			count++
+		}
+	}
+	return count, nil
 }
 
 type lifecycleAgent struct {

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -357,10 +357,8 @@ func (e *Executor) Resume(ctx context.Context, run *db.Run, repo *db.Repo, workD
 			return nil
 		}
 		if run.Status != types.RunAwaitingAuth {
-			if run.Status != types.RunAwaitingAuth {
-				if dbErr := e.db.CompleteRunAwaitingAgent(run.ID, time.Since(parkStart).Milliseconds()); dbErr != nil {
-					slog.Warn("failed to complete awaiting-agent state in db", "step", gate.step.Name(), "run", run.ID, "error", dbErr)
-				}
+			if dbErr := e.db.CompleteRunAwaitingAgent(run.ID, time.Since(parkStart).Milliseconds()); dbErr != nil {
+				slog.Warn("failed to complete awaiting-agent state in db", "step", gate.step.Name(), "run", run.ID, "error", dbErr)
 			}
 		}
 		if dbErr := e.db.FailStep(gate.stepResult.ID, err.Error(), duration); dbErr != nil {
@@ -1039,7 +1037,10 @@ func roundInsertID(_ string, inserted *db.StepRound, err error) string {
 }
 
 func (e *Executor) parkForAuthorization(ctx context.Context, step Step, sctx *StepContext, sr *db.StepResult, run *db.Run, repo *db.Repo, round int) error {
-	const reason = "codex authorization required; log into a healthy Codex account, then approve to retry"
+	reason := "codex authorization required; log into a healthy Codex account, then approve one bounded retry"
+	if sctx.Fixing {
+		reason = "codex authorization required; fixer turn completion is unknown; inspect the worktree and confirm the retry is idempotent before approving one bounded retry"
+	}
 	attempts, err := e.authorizationParkCount(run.ID)
 	if err != nil {
 		return err

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -1020,16 +1020,11 @@ func (e *Executor) parkForAuthorization(ctx context.Context, step Step, sctx *St
 	if err != nil {
 		return err
 	}
-	if attempts >= authorizationRecoveryLimit {
-		return fmt.Errorf("authorization recovery retry limit reached after %d parked attempt(s)", attempts)
-	}
+	retryAllowed := attempts < authorizationRecoveryLimit
 	if err := e.db.ParkRunForAuthorization(run.ID, string(step.Name()), reason); err != nil {
 		return err
 	}
 	run.BlockedReason = func() *string { v := reason; return &v }()
-	if err := e.db.SetRunAwaitingAgent(run.ID); err != nil {
-		return err
-	}
 	findings := `{"summary":"Codex authorization is required before this turn can continue","risk_level":"high","risk_rationale":"external authentication state is unavailable","findings":[]}`
 	if err := e.db.SetStepFindings(sr.ID, findings); err != nil {
 		return err
@@ -1048,7 +1043,6 @@ func (e *Executor) parkForAuthorization(ctx context.Context, step Step, sctx *St
 	e.waitingStep = step.Name()
 	e.mu.Unlock()
 	e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, step.Name(), string(types.StepStatusAwaitingApproval), "", "", reason, nil)
-	parkStart := time.Now()
 	response, _, err := e.waitForApprovalOrReconcile(ctx, step, sctx, false)
 	if err != nil {
 		cause := context.Cause(ctx)
@@ -1057,11 +1051,11 @@ func (e *Executor) parkForAuthorization(ctx context.Context, step Step, sctx *St
 		}
 		return err
 	}
-	if dbErr := e.db.CompleteRunAwaitingAgent(run.ID, time.Since(parkStart).Milliseconds()); dbErr != nil {
-		return dbErr
-	}
 	if response.action != types.ActionApprove && response.action != types.ActionFix {
 		return fmt.Errorf("authorization recovery requires approve or fix, got %q", response.action)
+	}
+	if !retryAllowed {
+		return errAuthorizationParked
 	}
 	if dbErr := e.db.ResumeRunAfterAuthorization(run.ID, string(step.Name())); dbErr != nil {
 		return dbErr

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -348,8 +348,10 @@ func (e *Executor) Resume(ctx context.Context, run *db.Run, repo *db.Repo, workD
 	)
 
 	response, reconciled, err := e.waitForApprovalOrReconcile(ctx, gate.step, reconcileCtx, false)
-	if dbErr := e.db.CompleteRunAwaitingAgent(run.ID, time.Since(parkStart).Milliseconds()); dbErr != nil {
-		slog.Warn("failed to complete awaiting-agent state in db", "step", gate.step.Name(), "run", run.ID, "error", dbErr)
+	if run.Status != types.RunAwaitingAuth {
+		if dbErr := e.db.CompleteRunAwaitingAgent(run.ID, time.Since(parkStart).Milliseconds()); dbErr != nil {
+			slog.Warn("failed to complete awaiting-agent state in db", "step", gate.step.Name(), "run", run.ID, "error", dbErr)
+		}
 	}
 	if err != nil {
 		if dbErr := e.db.FailStep(gate.stepResult.ID, err.Error(), duration); dbErr != nil {

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -819,6 +819,16 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 		outcome.Findings = normalizeFindingsJSON(outcome.Findings, string(stepName))
 		if stepName == types.StepReview {
 			if risk := routeRiskFromFindings(outcome.Findings); risk != routing.RiskUnknown {
+				phase := "review"
+				if sctx.Fixing {
+					phase = "review-fix"
+				}
+				if dbErr := e.db.InsertRouteResult(db.RouteResult{
+					RunID: run.ID, StepName: string(stepName), Round: roundNum,
+					Phase: phase, Risk: string(risk),
+				}); dbErr != nil {
+					return false, fmt.Errorf("persist completed review classification: %w", dbErr)
+				}
 				e.routeRisk = risk
 				// The initial review is the bootstrap classifier. Only a later
 				// review turn may select Sol, and only after that classifier ran.
@@ -1178,6 +1188,10 @@ func (a *lifecycleAgent) ReportsAgentAttempts() bool {
 	return agent.ReportsAgentAttempts(a.inner)
 }
 
+func (a *lifecycleAgent) ReportsAgentRoutes() bool {
+	return agent.ReportsAgentRoutes(a.inner)
+}
+
 const (
 	maxStepActivityText          = 240
 	stepActivityThrottleInterval = time.Second
@@ -1360,6 +1374,20 @@ func (e *Executor) currentStepName(runID string) types.StepName {
 func (e *Executor) restoreRouteState(runID string) {
 	e.routeRisk = routing.RiskUnknown
 	e.routeReviewConfirmed = false
+	if results, err := e.db.RouteResults(runID); err == nil && len(results) > 0 {
+		for i := len(results) - 1; i >= 0; i-- {
+			result := results[i]
+			if result.StepName != string(types.StepReview) {
+				continue
+			}
+			risk := routing.Risk(result.Risk)
+			if risk == routing.RiskLow || risk == routing.RiskMedium || risk == routing.RiskHigh {
+				e.routeRisk = risk
+				e.routeReviewConfirmed = result.Phase == "review-fix" && risk == routing.RiskHigh
+				return
+			}
+		}
+	}
 	decisions, err := e.db.RouteDecisions(runID)
 	if err != nil {
 		return

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -375,6 +375,22 @@ func (e *Executor) Resume(ctx context.Context, run *db.Run, repo *db.Repo, workD
 	if reconciled {
 		return completeReconciledGate()
 	}
+	// Authorization parking is durable. Approval after a restart is not a new
+	// allowance: the immutable lifecycle count is the sole retry budget. A
+	// fixer transport failure is even stricter because the prior mutating turn
+	// may already have completed; approval cannot prove that it did not.
+	if run.Status == types.RunAwaitingAuth {
+		authAttempts, countErr := e.authorizationParkCount(run.ID)
+		if countErr != nil {
+			return e.failRun(run, repo, countErr, ctx)
+		}
+		if authAttempts > authorizationRecoveryLimit || authorizationFixerCompletionUnknown(run) {
+			if response.action == types.ActionApprove || response.action == types.ActionFix {
+				slog.Warn("authorization approval cannot establish safe fixer retry; preserving operator reconciliation park", "run_id", run.ID)
+			}
+			return errAuthorizationParked
+		}
+	}
 
 	approvalFields := telemetry.Fields{
 		"step":       string(gate.step.Name()),
@@ -1049,7 +1065,10 @@ func (e *Executor) parkForAuthorization(ctx context.Context, step Step, sctx *St
 	if err != nil {
 		return err
 	}
-	retryAllowed := attempts < authorizationRecoveryLimit
+	// The initial failed turn is not a retry. Only a non-fixer turn with no
+	// prior authorization park may consume the single recovery retry. A fixer
+	// turn is never replayed without proof of non-completion.
+	retryAllowed := attempts < authorizationRecoveryLimit && !sctx.Fixing
 	if err := e.db.ParkRunForAuthorization(run.ID, string(step.Name()), reason); err != nil {
 		return err
 	}
@@ -1112,6 +1131,11 @@ func (e *Executor) authorizationParkCount(runID string) (int, error) {
 		}
 	}
 	return count, nil
+}
+
+func authorizationFixerCompletionUnknown(run *db.Run) bool {
+	return run != nil && run.BlockedReason != nil &&
+		strings.Contains(strings.ToLower(*run.BlockedReason), "fixer turn completion is unknown")
 }
 
 type lifecycleAgent struct {
@@ -1334,17 +1358,24 @@ func (e *Executor) currentStepName(runID string) types.StepName {
 // re-bootstrapping a review route, while the route decision ledger remains the
 // audit source rather than a mutable project manifest.
 func (e *Executor) restoreRouteState(runID string) {
+	e.routeRisk = routing.RiskUnknown
+	e.routeReviewConfirmed = false
 	decisions, err := e.db.RouteDecisions(runID)
 	if err != nil {
 		return
 	}
 	for _, decision := range decisions {
-		if decision.Risk == string(routing.RiskHigh) {
-			e.routeRisk = routing.RiskHigh
+		// RouteDecisions is ordered by durable creation time and id. Each
+		// decision carries the classification in force for that invocation, so
+		// assigning on every row restores the latest classification rather than
+		// making historical high risk permanently sticky.
+		switch routing.Risk(decision.Risk) {
+		case routing.RiskLow, routing.RiskMedium, routing.RiskHigh:
+			e.routeRisk = routing.Risk(decision.Risk)
+		case routing.RiskUnknown:
+			e.routeRisk = routing.RiskUnknown
 		}
-		if decision.Phase == "review-confirmation" && decision.EffectiveModel == routing.ModelSol {
-			e.routeReviewConfirmed = true
-		}
+		e.routeReviewConfirmed = decision.Phase == "review-confirmation" && decision.EffectiveModel == routing.ModelSol
 	}
 }
 

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -831,10 +831,10 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 				}
 				e.routeRisk = risk
 				// The initial review is the bootstrap classifier. Only a later
-				// review turn may select Sol, and only after that classifier ran.
-				if sctx.Fixing && risk == routing.RiskHigh {
-					e.routeReviewConfirmed = true
-				}
+				// high-risk review turn may select Sol. Assign on every completed
+				// classification so a downgrade revokes confirmation eligibility
+				// immediately, matching restart recovery from route_results.
+				e.routeReviewConfirmed = sctx.Fixing && risk == routing.RiskHigh
 			}
 		}
 		finalExitCode = outcome.ExitCode

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -261,8 +261,11 @@ type recoveredGate struct {
 }
 
 func ValidateRecoveredRun(database *db.DB, run *db.Run, steps []Step) error {
-	if run == nil || (run.Status != types.RunRunning && run.Status != types.RunAwaitingAuth) || run.AwaitingAgentSince == nil {
+	if run == nil || (run.Status == types.RunRunning && run.AwaitingAgentSince == nil) || (run.Status != types.RunRunning && run.Status != types.RunAwaitingAuth) {
 		return fmt.Errorf("run is not a recoverable parked run")
+	}
+	if run.Status == types.RunAwaitingAuth && run.BlockedReason == nil {
+		return fmt.Errorf("authorization-parked run has no blocked reason")
 	}
 	_, err := (&Executor{db: database, steps: steps}).recoveredGate(run.ID)
 	return err
@@ -289,7 +292,10 @@ func (e *Executor) Resume(ctx context.Context, run *db.Run, repo *db.Repo, workD
 	e.initializeRunScopes(run.ID)
 	e.restoreRouteState(run.ID)
 
-	parkStart := time.Unix(*run.AwaitingAgentSince, 0)
+	parkStart := time.Now()
+	if run.AwaitingAgentSince != nil {
+		parkStart = time.Unix(*run.AwaitingAgentSince, 0)
+	}
 	duration := recoveredStepDuration(gate.stepResult)
 	completeReconciledGate := func() error {
 		if err := e.db.CompleteStepWithStatus(gate.stepResult.ID, types.StepStatusCompleted, recoveredExitCode(gate.stepResult), duration, recoveredLogPath(gate.stepResult)); err != nil {
@@ -314,13 +320,15 @@ func (e *Executor) Resume(ctx context.Context, run *db.Run, repo *db.Repo, workD
 		LogChunk: func(string) {},
 		LogFile:  func(string) {},
 	}
-	if reconciled, reconcileErr := e.reconcileApprovalGate(ctx, gate.step, reconcileCtx); reconciled {
-		if dbErr := e.db.CompleteRunAwaitingAgent(run.ID, time.Since(parkStart).Milliseconds()); dbErr != nil {
-			return e.failRun(run, repo, fmt.Errorf("complete reconciled awaiting-agent state: %w", dbErr), ctx)
+	if run.Status != types.RunAwaitingAuth {
+		if reconciled, reconcileErr := e.reconcileApprovalGate(ctx, gate.step, reconcileCtx); reconciled {
+			if dbErr := e.db.CompleteRunAwaitingAgent(run.ID, time.Since(parkStart).Milliseconds()); dbErr != nil {
+				return e.failRun(run, repo, fmt.Errorf("complete reconciled awaiting-agent state: %w", dbErr), ctx)
+			}
+			return completeReconciledGate()
+		} else if reconcileErr != nil && ctx.Err() == nil {
+			slog.Warn("could not reconcile recovered approval gate; preserving it", "run_id", run.ID, "step", gate.step.Name(), "error", reconcileErr)
 		}
-		return completeReconciledGate()
-	} else if reconcileErr != nil && ctx.Err() == nil {
-		slog.Warn("could not reconcile recovered approval gate; preserving it", "run_id", run.ID, "step", gate.step.Name(), "error", reconcileErr)
 	}
 
 	e.mu.Lock()

--- a/internal/pipeline/executor_approval_test.go
+++ b/internal/pipeline/executor_approval_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
 	"github.com/kunchenguid/no-mistakes/internal/config"
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/routing"
 	"github.com/kunchenguid/no-mistakes/internal/telemetry"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
@@ -135,11 +137,17 @@ func TestExecutor_ResumeRestoresParkedGateAndReviewSessions(t *testing.T) {
 	if err := database.StartStep(stepResult.ID); err != nil {
 		t.Fatal(err)
 	}
-	findings := `{"findings":[{"id":"review-1","severity":"warning","description":"needs a fix","action":"ask-user"}],"summary":"one issue"}`
+	findings := `{"findings":[{"id":"review-1","severity":"warning","description":"needs a fix","action":"ask-user"}],"summary":"one issue","risk_level":"medium","risk_rationale":"medium canary risk","risk_scope":"source-or-external"}`
 	if err := database.SetStepFindings(stepResult.ID, findings); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := database.InsertStepRound(stepResult.ID, 1, "initial", &findings, nil, 25); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.InsertRouteResult(db.RouteResult{
+		RunID: run.ID, StepName: string(types.StepReview), Round: 1,
+		Phase: "review", Risk: string(routing.RiskMedium),
+	}); err != nil {
 		t.Fatal(err)
 	}
 	if err := database.UpdateStepStatusWithDuration(stepResult.ID, types.StepStatusAwaitingApproval, 25); err != nil {
@@ -148,10 +156,10 @@ func TestExecutor_ResumeRestoresParkedGateAndReviewSessions(t *testing.T) {
 	if err := database.SetRunAwaitingAgent(run.ID); err != nil {
 		t.Fatal(err)
 	}
-	if err := database.UpsertRunAgentSession(run.ID, string(SessionRoleReviewer), "fake", "reviewer-session"); err != nil {
+	if err := database.UpsertRunAgentSession(run.ID, string(SessionRoleReviewer), "codex", "reviewer-session"); err != nil {
 		t.Fatal(err)
 	}
-	if err := database.UpsertRunAgentSession(run.ID, string(SessionRoleFixer), "fake", "fixer-session"); err != nil {
+	if err := database.UpsertRunAgentSession(run.ID, string(SessionRoleFixer), "codex", "fixer-session"); err != nil {
 		t.Fatal(err)
 	}
 	run, err = database.GetRun(run.ID)
@@ -160,6 +168,7 @@ func TestExecutor_ResumeRestoresParkedGateAndReviewSessions(t *testing.T) {
 	}
 
 	fake := newFakeSessionAgent()
+	fake.name = "codex"
 	step := &adaptiveCallStep{
 		name: types.StepReview,
 		fn: func(sctx *StepContext) (*StepOutcome, error) {
@@ -209,6 +218,9 @@ func TestExecutor_ResumeRestoresParkedGateAndReviewSessions(t *testing.T) {
 	}
 	if fake.calls[1].session == nil || fake.calls[1].session.ID != "reviewer-session" {
 		t.Fatalf("reviewer session = %+v, want reviewer-session", fake.calls[1].session)
+	}
+	if fake.calls[0].routing.EffectiveModel != routing.ModelTerra || fake.calls[0].routing.EffectiveEffort != routing.EffortHigh {
+		t.Fatalf("recovered medium fixer route = %+v, want Terra/high", fake.calls[0].routing)
 	}
 	resumed, err := database.GetRun(run.ID)
 	if err != nil {

--- a/internal/pipeline/executor_auth_test.go
+++ b/internal/pipeline/executor_auth_test.go
@@ -67,6 +67,9 @@ func TestExecutorParksAuthorizationRequiredWithoutTerminalizingRun(t *testing.T)
 	if got.Status != types.RunAwaitingAuth || got.BlockedReason == nil {
 		t.Fatalf("run projection = %+v", got)
 	}
+	if got.AwaitingAgentSince == nil {
+		t.Fatal("authorization park did not persist awaiting-agent marker")
+	}
 	events, err := database.LifecycleEvents(run.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -116,6 +119,9 @@ func TestExecutorRequiresExplicitApprovalForEachAuthorizationRetry(t *testing.T)
 	}
 	if got.Status != types.RunAwaitingAuth || got.BlockedReason == nil {
 		t.Fatalf("run status = %s blocked=%v, want awaiting_auth", got.Status, got.BlockedReason)
+	}
+	if got.AwaitingAgentSince == nil {
+		t.Fatal("bounded authorization park did not retain awaiting-agent marker")
 	}
 	events, eventErr := database.LifecycleEvents(run.ID)
 	if eventErr != nil {

--- a/internal/pipeline/executor_auth_test.go
+++ b/internal/pipeline/executor_auth_test.go
@@ -183,6 +183,38 @@ func TestRecoveredAuthorizationParkSurvivesDaemonShutdown(t *testing.T) {
 	}
 }
 
+func TestAuthorizationParkNamesUnknownFixerCompletion(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	step := &adaptiveCallStep{name: types.StepReview, fn: func(sctx *StepContext) (*StepOutcome, error) {
+		if !sctx.Fixing {
+			return &StepOutcome{NeedsApproval: true, Findings: `{"summary":"needs a fix","risk_level":"high","findings":[]}`}, nil
+		}
+		_, err := sctx.Agent.Run(sctx.Ctx, agent.RunOpts{Prompt: "fix", Purpose: "review-fix"})
+		return nil, err
+	}}
+	exec := NewExecutor(database, p, nil, authorizationAgent{}, []Step{step}, nil)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(fmt.Errorf("test cleanup")) })
+	done := make(chan error, 1)
+	go func() { done <- exec.Execute(ctx, run, repo, t.TempDir()) }()
+	waitForStepStatus(t, database, run.ID, types.StepReview, types.StepStatusAwaitingApproval)
+	if err := exec.Respond(types.StepReview, types.ActionFix, nil); err != nil {
+		t.Fatal(err)
+	}
+	waitForAuthorizationGate(t, database, exec, run.ID, types.StepReview, 1)
+	got, err := database.GetRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.BlockedReason == nil || !strings.Contains(*got.BlockedReason, "completion is unknown") {
+		t.Fatalf("fixer authorization reason = %v", got.BlockedReason)
+	}
+	cancel(fmt.Errorf("daemon shutting down"))
+	if err := <-done; err != nil {
+		t.Fatalf("parked fixer execution = %v", err)
+	}
+}
+
 func waitForAuthorizationEvents(t *testing.T, database *db.DB, runID string, want int) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)

--- a/internal/pipeline/executor_auth_test.go
+++ b/internal/pipeline/executor_auth_test.go
@@ -68,6 +68,9 @@ func TestExecutorParksAuthorizationRequiredWithoutTerminalizingRun(t *testing.T)
 	if got.Status != types.RunAwaitingAuth || got.BlockedReason == nil {
 		t.Fatalf("run projection = %+v", got)
 	}
+	if got.AwaitingAgentSince != nil {
+		t.Fatalf("authorization park set gate timer: %v", *got.AwaitingAgentSince)
+	}
 	events, err := database.LifecycleEvents(run.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -178,7 +181,7 @@ func TestRecoveredAuthorizationParkSurvivesDaemonShutdown(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(steps) != 1 || steps[0].Status != types.StepStatusAwaitingApproval {
+	if len(steps) != 1 || steps[0].Status != types.StepStatusRunning {
 		t.Fatalf("recovered authorization step = %+v", steps)
 	}
 }

--- a/internal/pipeline/executor_auth_test.go
+++ b/internal/pipeline/executor_auth_test.go
@@ -1,0 +1,70 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/agent"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+type authorizationAgent struct{}
+
+func (authorizationAgent) Name() string { return "codex" }
+func (authorizationAgent) Close() error { return nil }
+func (authorizationAgent) Run(context.Context, agent.RunOpts) (*agent.Result, error) {
+	return nil, &agent.AuthorizationRequiredError{Agent: "codex", Detail: "account rotation"}
+}
+
+func TestExecutorParksAuthorizationRequiredWithoutTerminalizingRun(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	step := &adaptiveCallStep{name: types.StepReview, fn: func(sctx *StepContext) (*StepOutcome, error) {
+		_, err := sctx.Agent.Run(sctx.Ctx, agent.RunOpts{Prompt: "review", Purpose: "review"})
+		return nil, err
+	}}
+	exec := NewExecutor(database, p, nil, authorizationAgent{}, []Step{step}, nil)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- exec.Execute(ctx, run, repo, t.TempDir()) }()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		got, getErr := database.GetRun(run.ID)
+		if getErr != nil {
+			t.Fatal(getErr)
+		}
+		if got.Status == types.RunAwaitingAuth {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("run did not park for auth: %+v", got)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel(fmt.Errorf("daemon shutting down"))
+	err := <-errCh
+	if err != nil {
+		t.Fatalf("parked execution = %v", err)
+	}
+	got, getErr := database.GetRun(run.ID)
+	if getErr != nil {
+		t.Fatal(getErr)
+	}
+	if got.Status != types.RunAwaitingAuth || got.BlockedReason == nil {
+		t.Fatalf("run projection = %+v", got)
+	}
+	events, err := database.LifecycleEvents(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, event := range events {
+		if event.EventType == "authorization_required" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("missing authorization_required event: %+v", events)
+	}
+}

--- a/internal/pipeline/executor_auth_test.go
+++ b/internal/pipeline/executor_auth_test.go
@@ -300,6 +300,40 @@ func TestRestoreRouteStateUsesLatestDurableClassification(t *testing.T) {
 	}
 }
 
+func TestRestoreRouteStateUsesPostResultReviewClassification(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		risk        routing.Risk
+		phase       string
+		wantConfirm bool
+	}{
+		{"recovered medium", routing.RiskMedium, "review", false},
+		{"recovered downgrade", routing.RiskLow, "review-fix", false},
+		{"recovered high confirmation", routing.RiskHigh, "review-fix", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			database, p, run, _ := setupTest(t)
+			if err := database.InsertRouteDecision(db.RouteDecision{
+				RunID: run.ID, RequestedHarness: "codex", EffectiveHarness: "codex",
+				Risk: string(routing.RiskUnknown), Phase: "review", CreatedAt: 10,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if err := database.InsertRouteResult(db.RouteResult{
+				RunID: run.ID, StepName: string(types.StepReview), Round: 1,
+				Phase: tc.phase, Risk: string(tc.risk), CreatedAt: 20,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			exec := NewExecutor(database, p, nil, nil, nil, nil)
+			exec.restoreRouteState(run.ID)
+			if exec.routeRisk != tc.risk || exec.routeReviewConfirmed != tc.wantConfirm {
+				t.Fatalf("restored route = %q/%t, want %q/%t", exec.routeRisk, exec.routeReviewConfirmed, tc.risk, tc.wantConfirm)
+			}
+		})
+	}
+}
+
 func TestAuthorizationParkNamesUnknownFixerCompletion(t *testing.T) {
 	database, p, run, repo := setupTest(t)
 	step := &adaptiveCallStep{name: types.StepReview, fn: func(sctx *StepContext) (*StepOutcome, error) {

--- a/internal/pipeline/executor_auth_test.go
+++ b/internal/pipeline/executor_auth_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -67,9 +68,6 @@ func TestExecutorParksAuthorizationRequiredWithoutTerminalizingRun(t *testing.T)
 	if got.Status != types.RunAwaitingAuth || got.BlockedReason == nil {
 		t.Fatalf("run projection = %+v", got)
 	}
-	if got.AwaitingAgentSince == nil {
-		t.Fatal("authorization park did not persist awaiting-agent marker")
-	}
 	events, err := database.LifecycleEvents(run.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -120,9 +118,6 @@ func TestExecutorRequiresExplicitApprovalForEachAuthorizationRetry(t *testing.T)
 	if got.Status != types.RunAwaitingAuth || got.BlockedReason == nil {
 		t.Fatalf("run status = %s blocked=%v, want awaiting_auth", got.Status, got.BlockedReason)
 	}
-	if got.AwaitingAgentSince == nil {
-		t.Fatal("bounded authorization park did not retain awaiting-agent marker")
-	}
 	events, eventErr := database.LifecycleEvents(run.ID)
 	if eventErr != nil {
 		t.Fatal(eventErr)
@@ -135,6 +130,56 @@ func TestExecutorRequiresExplicitApprovalForEachAuthorizationRetry(t *testing.T)
 	}
 	if authEvents != 2 {
 		t.Fatalf("authorization events = %d, want initial and bounded recovery parks", authEvents)
+	}
+}
+
+func TestRecoveredAuthorizationParkSurvivesDaemonShutdown(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	step := &adaptiveCallStep{name: types.StepReview, fn: func(sctx *StepContext) (*StepOutcome, error) {
+		_, err := sctx.Agent.Run(sctx.Ctx, agent.RunOpts{Prompt: "review", Purpose: "review"})
+		return nil, err
+	}}
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	first := NewExecutor(database, p, nil, authorizationAgent{}, []Step{step}, nil)
+	done := make(chan error, 1)
+	go func() { done <- first.Execute(ctx, run, repo, t.TempDir()) }()
+	waitForAuthorizationGate(t, database, first, run.ID, types.StepReview, 1)
+	cancel(fmt.Errorf("daemon shutting down"))
+	if err := <-done; err != nil {
+		t.Fatalf("initial parked execution = %v", err)
+	}
+
+	recovered, err := database.GetRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recoveryCtx, recoveryCancel := context.WithCancelCause(context.Background())
+	second := NewExecutor(database, p, nil, authorizationAgent{}, []Step{step}, nil)
+	recoveredDone := make(chan error, 1)
+	go func() { recoveredDone <- second.Resume(recoveryCtx, recovered, repo, t.TempDir()) }()
+	waitForAuthorizationGate(t, database, second, run.ID, types.StepReview, 1)
+	recoveryCancel(fmt.Errorf("daemon shutting down"))
+	if err := <-recoveredDone; err != nil {
+		t.Fatalf("recovered parked execution = %v", err)
+	}
+
+	got, err := database.GetRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != types.RunAwaitingAuth || got.BlockedReason == nil {
+		t.Fatalf("recovered authorization projection = %+v", got)
+	}
+	if got.Error != nil && strings.Contains(strings.ToLower(*got.Error), "daemon shutting down") {
+		t.Fatalf("shutdown cause overwrote authorization evidence: %q", *got.Error)
+	}
+	steps, err := database.GetStepsByRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(steps) != 1 || steps[0].Status != types.StepStatusAwaitingApproval {
+		t.Fatalf("recovered authorization step = %+v", steps)
 	}
 }
 

--- a/internal/pipeline/executor_auth_test.go
+++ b/internal/pipeline/executor_auth_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -331,6 +332,118 @@ func TestRestoreRouteStateUsesPostResultReviewClassification(t *testing.T) {
 				t.Fatalf("restored route = %q/%t, want %q/%t", exec.routeRisk, exec.routeReviewConfirmed, tc.risk, tc.wantConfirm)
 			}
 		})
+	}
+}
+
+func TestRestoreRouteStateUsesAppendOrderAcrossClockRollbackAndTies(t *testing.T) {
+	database, p, run, _ := setupTest(t)
+	for _, result := range []db.RouteResult{
+		{RunID: run.ID, StepName: string(types.StepReview), Round: 1, Phase: "review-fix", Risk: string(routing.RiskHigh), CreatedAt: 200},
+		{RunID: run.ID, StepName: string(types.StepReview), Round: 2, Phase: "review-fix", Risk: string(routing.RiskLow), CreatedAt: 100},
+		{RunID: run.ID, StepName: string(types.StepReview), Round: 3, Phase: "review-fix", Risk: string(routing.RiskMedium), CreatedAt: 100},
+	} {
+		if err := database.InsertRouteResult(result); err != nil {
+			t.Fatal(err)
+		}
+	}
+	exec := NewExecutor(database, p, nil, nil, nil, nil)
+	exec.restoreRouteState(run.ID)
+	if exec.routeRisk != routing.RiskMedium || exec.routeReviewConfirmed {
+		t.Fatalf("restored route = %q/%t, want latest equal-clock medium/false", exec.routeRisk, exec.routeReviewConfirmed)
+	}
+
+	if err := database.InsertRouteResult(db.RouteResult{
+		RunID: run.ID, StepName: string(types.StepReview), Round: 4,
+		Phase: "review-fix", Risk: string(routing.RiskHigh), CreatedAt: 50,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	exec.restoreRouteState(run.ID)
+	if exec.routeRisk != routing.RiskHigh || !exec.routeReviewConfirmed {
+		t.Fatalf("restored later high route = %q/%t, want high/true", exec.routeRisk, exec.routeReviewConfirmed)
+	}
+}
+
+func TestExecutorClearsLiveConfirmationBeforeNextReview(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	if err := database.InsertRouteResult(db.RouteResult{
+		RunID: run.ID, StepName: string(types.StepReview), Round: 1,
+		Phase: "review", Risk: string(routing.RiskHigh), CreatedAt: 200,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	exec := NewExecutor(database, p, nil, &routingCaptureAgent{}, nil, nil)
+	exec.restoreRouteState(run.ID)
+	if exec.routeRisk != routing.RiskHigh || exec.routeReviewConfirmed {
+		t.Fatalf("initial recovered route = %q/%t", exec.routeRisk, exec.routeReviewConfirmed)
+	}
+	if err := os.MkdirAll(p.RunLogDir(run.ID), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	step := &adaptiveCallStep{name: types.StepReview, fn: func(sctx *StepContext) (*StepOutcome, error) {
+		if _, err := sctx.Agent.Run(sctx.Ctx, agent.RunOpts{Prompt: "review", Purpose: "review-fix"}); err != nil {
+			return nil, err
+		}
+		return &StepOutcome{Findings: fmt.Sprintf(`{"findings":[],"risk_level":"%s"}`, sctx.UserIntent)}, nil
+	}}
+	stepResult := func() *db.StepResult {
+		sr, err := database.InsertStepResult(run.ID, types.StepReview)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return sr
+	}
+	// A fixing high result confirms the route.
+	step.fn = func(sctx *StepContext) (*StepOutcome, error) {
+		if _, err := sctx.Agent.Run(sctx.Ctx, agent.RunOpts{Prompt: "high", Purpose: "review-fix"}); err != nil {
+			return nil, err
+		}
+		return &StepOutcome{Findings: `{"findings":[],"risk_level":"high"}`}, nil
+	}
+	if _, err := exec.executeStep(context.Background(), step, stepResult(), run, repo, t.TempDir(), p.RunLogDir(run.ID), stepExecutionState{fixing: true}); err != nil {
+		t.Fatal(err)
+	}
+	if !exec.routeReviewConfirmed {
+		t.Fatal("high fixing review did not confirm route")
+	}
+
+	// A later fixing low result must clear confirmation in the same live
+	// executor, before any daemon restart or recovery path runs.
+	step.fn = func(sctx *StepContext) (*StepOutcome, error) {
+		if _, err := sctx.Agent.Run(sctx.Ctx, agent.RunOpts{Prompt: "low", Purpose: "review-fix"}); err != nil {
+			return nil, err
+		}
+		return &StepOutcome{Findings: `{"findings":[],"risk_level":"low"}`}, nil
+	}
+	if _, err := exec.executeStep(context.Background(), step, stepResult(), run, repo, t.TempDir(), p.RunLogDir(run.ID), stepExecutionState{fixing: true}); err != nil {
+		t.Fatal(err)
+	}
+	if exec.routeReviewConfirmed {
+		t.Fatal("low fixing review left confirmation enabled")
+	}
+
+	// The next review must carry ordinary review evidence, not a false
+	// review-confirmation phase. Recovery must agree with that immutable state.
+	step.fn = func(sctx *StepContext) (*StepOutcome, error) {
+		if _, err := sctx.Agent.Run(sctx.Ctx, agent.RunOpts{Prompt: "next", Purpose: "review"}); err != nil {
+			return nil, err
+		}
+		return &StepOutcome{Findings: `{"findings":[],"risk_level":"low"}`}, nil
+	}
+	if _, err := exec.executeStep(context.Background(), step, stepResult(), run, repo, t.TempDir(), p.RunLogDir(run.ID), stepExecutionState{}); err != nil {
+		t.Fatal(err)
+	}
+	decisions, err := database.RouteDecisions(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decisions) != 3 || decisions[len(decisions)-1].Phase == "review-confirmation" {
+		t.Fatalf("route decisions = %+v", decisions)
+	}
+	exec.restoreRouteState(run.ID)
+	if exec.routeRisk != routing.RiskLow || exec.routeReviewConfirmed {
+		t.Fatalf("recovered post-downgrade route = %q/%t", exec.routeRisk, exec.routeReviewConfirmed)
 	}
 }
 

--- a/internal/pipeline/executor_auth_test.go
+++ b/internal/pipeline/executor_auth_test.go
@@ -99,13 +99,9 @@ func TestExecutorRequiresExplicitApprovalForEachAuthorizationRetry(t *testing.T)
 	if err := exec.Respond(types.StepReview, types.ActionApprove, nil); err != nil {
 		t.Fatalf("approve auth retry: %v", err)
 	}
-	waitForAuthorizationGate(t, database, exec, run.ID, types.StepReview, 2)
-	if err := exec.Respond(types.StepReview, types.ActionApprove, nil); err != nil {
-		t.Fatalf("approve bounded auth park: %v", err)
-	}
 	err := <-errCh
-	if err != nil {
-		t.Fatalf("bounded auth park = %v", err)
+	if err == nil || !strings.Contains(err.Error(), "authorization recovery retry limit reached") {
+		t.Fatalf("execution error = %v, want retry-limit failure", err)
 	}
 	if got := ag.attempts.Load(); got != 2 {
 		t.Fatalf("agent attempts = %d, want initial attempt plus one explicit retry", got)
@@ -114,8 +110,8 @@ func TestExecutorRequiresExplicitApprovalForEachAuthorizationRetry(t *testing.T)
 	if getErr != nil {
 		t.Fatal(getErr)
 	}
-	if got.Status != types.RunAwaitingAuth || got.BlockedReason == nil {
-		t.Fatalf("run status = %s blocked=%v, want awaiting_auth", got.Status, got.BlockedReason)
+	if got.Status != types.RunFailed {
+		t.Fatalf("run status = %s, want failed", got.Status)
 	}
 	events, eventErr := database.LifecycleEvents(run.ID)
 	if eventErr != nil {
@@ -127,8 +123,8 @@ func TestExecutorRequiresExplicitApprovalForEachAuthorizationRetry(t *testing.T)
 			authEvents++
 		}
 	}
-	if authEvents != 2 {
-		t.Fatalf("authorization events = %d, want initial and bounded recovery parks", authEvents)
+	if authEvents != 1 {
+		t.Fatalf("authorization events = %d, want one bounded park", authEvents)
 	}
 }
 

--- a/internal/pipeline/executor_auth_test.go
+++ b/internal/pipeline/executor_auth_test.go
@@ -3,7 +3,6 @@ package pipeline
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -100,9 +99,13 @@ func TestExecutorRequiresExplicitApprovalForEachAuthorizationRetry(t *testing.T)
 	if err := exec.Respond(types.StepReview, types.ActionApprove, nil); err != nil {
 		t.Fatalf("approve auth retry: %v", err)
 	}
+	waitForAuthorizationGate(t, database, exec, run.ID, types.StepReview, 2)
+	if err := exec.Respond(types.StepReview, types.ActionApprove, nil); err != nil {
+		t.Fatalf("approve bounded auth park: %v", err)
+	}
 	err := <-errCh
-	if err == nil || !strings.Contains(err.Error(), "authorization recovery retry limit reached") {
-		t.Fatalf("execution error = %v, want retry-limit failure", err)
+	if err != nil {
+		t.Fatalf("bounded auth park = %v", err)
 	}
 	if got := ag.attempts.Load(); got != 2 {
 		t.Fatalf("agent attempts = %d, want initial attempt plus one explicit retry", got)
@@ -111,8 +114,8 @@ func TestExecutorRequiresExplicitApprovalForEachAuthorizationRetry(t *testing.T)
 	if getErr != nil {
 		t.Fatal(getErr)
 	}
-	if got.Status != types.RunFailed {
-		t.Fatalf("run status = %s, want failed", got.Status)
+	if got.Status != types.RunAwaitingAuth || got.BlockedReason == nil {
+		t.Fatalf("run status = %s blocked=%v, want awaiting_auth", got.Status, got.BlockedReason)
 	}
 	events, eventErr := database.LifecycleEvents(run.ID)
 	if eventErr != nil {
@@ -124,8 +127,8 @@ func TestExecutorRequiresExplicitApprovalForEachAuthorizationRetry(t *testing.T)
 			authEvents++
 		}
 	}
-	if authEvents != 1 {
-		t.Fatalf("authorization events = %d, want one bounded park", authEvents)
+	if authEvents != 2 {
+		t.Fatalf("authorization events = %d, want initial and bounded recovery parks", authEvents)
 	}
 }
 

--- a/internal/pipeline/executor_auth_test.go
+++ b/internal/pipeline/executor_auth_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"

--- a/internal/pipeline/executor_auth_test.go
+++ b/internal/pipeline/executor_auth_test.go
@@ -3,10 +3,13 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
+	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
@@ -15,6 +18,17 @@ type authorizationAgent struct{}
 func (authorizationAgent) Name() string { return "codex" }
 func (authorizationAgent) Close() error { return nil }
 func (authorizationAgent) Run(context.Context, agent.RunOpts) (*agent.Result, error) {
+	return nil, &agent.AuthorizationRequiredError{Agent: "codex", Detail: "account rotation"}
+}
+
+type countingAuthorizationAgent struct {
+	attempts atomic.Int32
+}
+
+func (a *countingAuthorizationAgent) Name() string { return "codex" }
+func (a *countingAuthorizationAgent) Close() error { return nil }
+func (a *countingAuthorizationAgent) Run(context.Context, agent.RunOpts) (*agent.Result, error) {
+	a.attempts.Add(1)
 	return nil, &agent.AuthorizationRequiredError{Agent: "codex", Detail: "account rotation"}
 }
 
@@ -67,4 +81,96 @@ func TestExecutorParksAuthorizationRequiredWithoutTerminalizingRun(t *testing.T)
 	if !found {
 		t.Fatalf("missing authorization_required event: %+v", events)
 	}
+}
+
+func TestExecutorRequiresExplicitApprovalForEachAuthorizationRetry(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	step := &adaptiveCallStep{name: types.StepReview, fn: func(sctx *StepContext) (*StepOutcome, error) {
+		_, err := sctx.Agent.Run(sctx.Ctx, agent.RunOpts{Prompt: "review", Purpose: "review"})
+		return nil, err
+	}}
+	ag := &countingAuthorizationAgent{}
+	exec := NewExecutor(database, p, nil, ag, []Step{step}, nil)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	t.Cleanup(func() { cancel(fmt.Errorf("test cleanup")) })
+	errCh := make(chan error, 1)
+	go func() { errCh <- exec.Execute(ctx, run, repo, t.TempDir()) }()
+
+	waitForAuthorizationGate(t, database, exec, run.ID, types.StepReview, 1)
+	if err := exec.Respond(types.StepReview, types.ActionApprove, nil); err != nil {
+		t.Fatalf("approve auth retry: %v", err)
+	}
+	err := <-errCh
+	if err == nil || !strings.Contains(err.Error(), "authorization recovery retry limit reached") {
+		t.Fatalf("execution error = %v, want retry-limit failure", err)
+	}
+	if got := ag.attempts.Load(); got != 2 {
+		t.Fatalf("agent attempts = %d, want initial attempt plus one explicit retry", got)
+	}
+	got, getErr := database.GetRun(run.ID)
+	if getErr != nil {
+		t.Fatal(getErr)
+	}
+	if got.Status != types.RunFailed {
+		t.Fatalf("run status = %s, want failed", got.Status)
+	}
+	events, eventErr := database.LifecycleEvents(run.ID)
+	if eventErr != nil {
+		t.Fatal(eventErr)
+	}
+	authEvents := 0
+	for _, event := range events {
+		if event.EventType == "authorization_required" {
+			authEvents++
+		}
+	}
+	if authEvents != 1 {
+		t.Fatalf("authorization events = %d, want one bounded park", authEvents)
+	}
+}
+
+func waitForAuthorizationEvents(t *testing.T, database *db.DB, runID string, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if authorizationEventCount(t, database, runID) >= want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("authorization events = %d, want at least %d", authorizationEventCount(t, database, runID), want)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func waitForAuthorizationGate(t *testing.T, database *db.DB, exec *Executor, runID string, step types.StepName, wantEvents int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		exec.mu.Lock()
+		waiting := exec.waiting && exec.waitingStep == step
+		exec.mu.Unlock()
+		if waiting && authorizationEventCount(t, database, runID) >= wantEvents {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("authorization gate not ready: waiting=%v events=%d wantEvents=%d", waiting, authorizationEventCount(t, database, runID), wantEvents)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func authorizationEventCount(t *testing.T, database *db.DB, runID string) int {
+	t.Helper()
+	events, err := database.LifecycleEvents(runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := 0
+	for _, event := range events {
+		if event.EventType == "authorization_required" {
+			count++
+		}
+	}
+	return count
 }

--- a/internal/pipeline/executor_auth_test.go
+++ b/internal/pipeline/executor_auth_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync/atomic"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
 	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/routing"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
@@ -183,6 +185,118 @@ func TestRecoveredAuthorizationParkSurvivesDaemonShutdown(t *testing.T) {
 	}
 	if len(steps) != 1 || steps[0].Status != types.StepStatusRunning {
 		t.Fatalf("recovered authorization step = %+v", steps)
+	}
+}
+
+func TestRecoveredAuthorizationApprovalKeepsDurableRetryBound(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	step := &adaptiveCallStep{name: types.StepReview, fn: func(sctx *StepContext) (*StepOutcome, error) {
+		_, err := sctx.Agent.Run(sctx.Ctx, agent.RunOpts{Prompt: "review", Purpose: "review"})
+		return nil, err
+	}}
+	ag := &countingAuthorizationAgent{}
+	ctx, cancel := context.WithCancelCause(context.Background())
+	first := NewExecutor(database, p, nil, ag, []Step{step}, nil)
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- first.Execute(ctx, run, repo, t.TempDir()) }()
+	waitForAuthorizationGate(t, database, first, run.ID, types.StepReview, 1)
+	cancel(fmt.Errorf("daemon shutting down"))
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first parked execution = %v", err)
+	}
+
+	recovered, err := database.GetRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recoveryCtx, recoveryCancel := context.WithCancelCause(context.Background())
+	defer recoveryCancel(fmt.Errorf("test cleanup"))
+	second := NewExecutor(database, p, nil, ag, []Step{step}, nil)
+	secondDone := make(chan error, 1)
+	go func() { secondDone <- second.Resume(recoveryCtx, recovered, repo, t.TempDir()) }()
+	waitForAuthorizationGate(t, database, second, run.ID, types.StepReview, 1)
+	if err := second.Respond(types.StepReview, types.ActionApprove, nil); err != nil {
+		t.Fatal(err)
+	}
+	waitForAuthorizationGate(t, database, second, run.ID, types.StepReview, 2)
+	if err := second.Respond(types.StepReview, types.ActionApprove, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-secondDone; err != nil {
+		t.Fatalf("bounded recovered execution = %v", err)
+	}
+	if got := ag.attempts.Load(); got != 2 {
+		t.Fatalf("agent attempts after restart approvals = %d, want initial plus one retry", got)
+	}
+}
+
+func TestRecoveredUnknownFixerCompletionCannotBeApprovedIntoReplay(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	step := &adaptiveCallStep{name: types.StepReview, fn: func(sctx *StepContext) (*StepOutcome, error) {
+		if !sctx.Fixing {
+			return &StepOutcome{NeedsApproval: true, Findings: `{"summary":"needs a fix","risk_level":"high","findings":[]}`}, nil
+		}
+		_, err := sctx.Agent.Run(sctx.Ctx, agent.RunOpts{Prompt: "fix", Purpose: "review-fix"})
+		return nil, err
+	}}
+	ag := &countingAuthorizationAgent{}
+	ctx, cancel := context.WithCancelCause(context.Background())
+	first := NewExecutor(database, p, nil, ag, []Step{step}, nil)
+	done := make(chan error, 1)
+	go func() { done <- first.Execute(ctx, run, repo, t.TempDir()) }()
+	waitForStepStatus(t, database, run.ID, types.StepReview, types.StepStatusAwaitingApproval)
+	if err := first.Respond(types.StepReview, types.ActionFix, nil); err != nil {
+		t.Fatal(err)
+	}
+	waitForAuthorizationGate(t, database, first, run.ID, types.StepReview, 1)
+	cancel(fmt.Errorf("daemon shutting down"))
+	if err := <-done; err != nil {
+		t.Fatalf("first fixer park = %v", err)
+	}
+
+	recovered, err := database.GetRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx2, cancel2 := context.WithCancelCause(context.Background())
+	defer cancel2(fmt.Errorf("test cleanup"))
+	second := NewExecutor(database, p, nil, ag, []Step{step}, nil)
+	done2 := make(chan error, 1)
+	go func() { done2 <- second.Resume(ctx2, recovered, repo, t.TempDir()) }()
+	waitForAuthorizationGate(t, database, second, run.ID, types.StepReview, 1)
+	if err := second.Respond(types.StepReview, types.ActionApprove, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-done2; !errors.Is(err, errAuthorizationParked) {
+		t.Fatalf("recovered fixer park = %v, want recoverable operator park", err)
+	}
+	if got := ag.attempts.Load(); got != 1 {
+		t.Fatalf("fixer attempts after approval = %d, want no replay", got)
+	}
+	got, err := database.GetRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != types.RunAwaitingAuth || got.BlockedReason == nil || !strings.Contains(*got.BlockedReason, "completion is unknown") {
+		t.Fatalf("recovered fixer operator state = %+v", got)
+	}
+}
+
+func TestRestoreRouteStateUsesLatestDurableClassification(t *testing.T) {
+	database, p, run, _ := setupTest(t)
+	for _, decision := range []db.RouteDecision{
+		{RunID: run.ID, RequestedHarness: "codex", EffectiveHarness: "codex", Risk: string(routing.RiskHigh), Phase: "review", PromptTransport: "stdin", CreatedAt: 10},
+		{RunID: run.ID, RequestedHarness: "codex", EffectiveHarness: "codex", Risk: string(routing.RiskMedium), Phase: "test", PromptTransport: "stdin", CreatedAt: 20},
+		{RunID: run.ID, RequestedHarness: "codex", EffectiveHarness: "codex", Risk: string(routing.RiskLow), Phase: "test", PromptTransport: "stdin", CreatedAt: 30},
+	} {
+		if err := database.InsertRouteDecision(decision); err != nil {
+			t.Fatal(err)
+		}
+	}
+	exec := NewExecutor(database, p, nil, nil, nil, nil)
+	exec.restoreRouteState(run.ID)
+	if exec.routeRisk != routing.RiskLow {
+		t.Fatalf("restored risk = %q, want latest low classification", exec.routeRisk)
 	}
 }
 

--- a/internal/pipeline/executor_perf_test.go
+++ b/internal/pipeline/executor_perf_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -224,6 +225,79 @@ func TestPerfRecordingAgent_MixedFallbackRecordsActualProviderCold(t *testing.T)
 	}
 }
 
+func TestPerfRecordingAgent_MixedFallbackAttributesEveryConcreteAdapter(t *testing.T) {
+	database, _, run, _ := setupTest(t)
+	wrapped := &perfRecordingAgent{
+		inner: agent.NewFallback([]agent.Agent{
+			&fallbackUsageAgent{name: "pi", err: errors.New("pi start: executable not found")},
+			&fallbackUsageAgent{name: "claude", result: &agent.Result{Model: "claude-sonnet"}},
+		}),
+		db: database, runID: run.ID, stepName: types.StepReview,
+		round: func() int { return 1 },
+	}
+	if _, err := wrapped.Run(context.Background(), agent.RunOpts{Purpose: "review"}); err != nil {
+		t.Fatalf("fallback run: %v", err)
+	}
+	routes, err := database.RouteDecisions(run.ID)
+	if err != nil || len(routes) != 2 {
+		t.Fatalf("routes = %+v, err = %v", routes, err)
+	}
+	if routes[0].EffectiveHarness != "pi" || routes[1].EffectiveHarness != "claude" {
+		t.Fatalf("route providers = %q/%q", routes[0].EffectiveHarness, routes[1].EffectiveHarness)
+	}
+	invs, err := database.GetAgentInvocationsByRun(run.ID)
+	if err != nil || len(invs) != 2 {
+		t.Fatalf("invocations = %+v, err = %v", invs, err)
+	}
+	if invs[0].Agent != "pi" || invs[0].EffectiveHarness != "pi" || invs[0].ExitStatus != "error" {
+		t.Fatalf("failed Pi evidence = %+v", invs[0])
+	}
+	if invs[1].Agent != "claude" || invs[1].EffectiveHarness != "claude" || invs[1].EffectiveModel != "" {
+		t.Fatalf("successful Claude evidence = %+v", invs[1])
+	}
+}
+
+func TestPerfRecordingAgentDirectNonCodexRiskEvidenceIsTruthful(t *testing.T) {
+	adapters := []string{"claude", "pi", "grok", "opencode", "acp:copilot"}
+	for _, adapter := range adapters {
+		adapter := adapter
+		t.Run(adapter, func(t *testing.T) {
+			for _, tc := range []struct {
+				name      string
+				step      types.StepName
+				risk      routing.Risk
+				confirmed bool
+				purpose   string
+			}{
+				{"medium", types.StepTest, routing.RiskMedium, false, "test"},
+				{"high", types.StepTest, routing.RiskHigh, false, "test"},
+				{"confirmation", types.StepReview, routing.RiskHigh, true, "review"},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					database, _, run, _ := setupTest(t)
+					wrapped := &perfRecordingAgent{
+						inner: &fallbackUsageAgent{name: adapter, result: &agent.Result{Model: "provider-model"}},
+						db:    database, runID: run.ID, stepName: tc.step,
+						risk:               func() routing.Risk { return tc.risk },
+						reviewConfirmation: func() bool { return tc.confirmed },
+						round:              func() int { return 1 },
+					}
+					if _, err := wrapped.Run(context.Background(), agent.RunOpts{Purpose: tc.purpose}); err != nil {
+						t.Fatal(err)
+					}
+					invs, err := database.GetAgentInvocationsByRun(run.ID)
+					if err != nil || len(invs) != 1 {
+						t.Fatalf("invs = %+v, err = %v", invs, err)
+					}
+					if invs[0].EffectiveHarness != adapter || invs[0].EffectiveModel != "" || invs[0].EffectiveEffort != "" {
+						t.Fatalf("invocation evidence = %+v", invs[0])
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestPerfRecordingAgentClearsUnenforceableGPTEvidence(t *testing.T) {
 	database, _, run, _ := setupTest(t)
 	wrapped := &perfRecordingAgent{
@@ -246,6 +320,36 @@ func TestPerfRecordingAgentClearsUnenforceableGPTEvidence(t *testing.T) {
 	}
 	if invs[0].EffectiveHarness != "claude" || invs[0].EffectiveModel != "" || invs[0].EffectiveEffort != "" {
 		t.Fatalf("unenforceable route evidence = %+v", invs[0])
+	}
+}
+
+func TestPerfRecordingAgentFallbackRefusesUnenforceableGPTRoute(t *testing.T) {
+	database, _, run, _ := setupTest(t)
+	wrapped := &perfRecordingAgent{
+		inner: agent.NewFallback([]agent.Agent{
+			&fallbackUsageAgent{name: "pi", err: errors.New("pi start: executable not found")},
+			&fallbackUsageAgent{name: "claude", result: &agent.Result{Model: "claude-sonnet"}},
+		}),
+		db: database, runID: run.ID, stepName: types.StepReview,
+		round: func() int { return 1 },
+	}
+	_, err := wrapped.Run(context.Background(), agent.RunOpts{
+		Purpose: "review",
+		Routing: routing.Decision{
+			RequestedHarness: "codex", EffectiveHarness: "codex",
+			EffectiveModel: routing.ModelSol, EffectiveEffort: routing.EffortHigh,
+			PolicyVersion: routing.PolicyVersion, Phase: "review-confirmation", Risk: routing.RiskHigh,
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "cannot enforce") {
+		t.Fatalf("fallback error = %v, want fail-closed Codex policy error", err)
+	}
+	invs, err := database.GetAgentInvocationsByRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(invs) != 0 {
+		t.Fatalf("unenforceable fallback launched attempts: %+v", invs)
 	}
 }
 

--- a/internal/pipeline/executor_perf_test.go
+++ b/internal/pipeline/executor_perf_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/agent"
 	"github.com/kunchenguid/no-mistakes/internal/config"
 	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/routing"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
@@ -42,6 +43,52 @@ type fallbackUsageAgent struct {
 	name   string
 	result *agent.Result
 	err    error
+}
+
+type routingCaptureAgent struct {
+	seen []agent.RunOpts
+}
+
+func (a *routingCaptureAgent) Name() string { return "codex" }
+func (a *routingCaptureAgent) Close() error { return nil }
+func (a *routingCaptureAgent) Run(_ context.Context, opts agent.RunOpts) (*agent.Result, error) {
+	a.seen = append(a.seen, opts)
+	return &agent.Result{Text: "ok"}, nil
+}
+
+func TestPerfRecordingAgentRoutesSolOnlyForConfirmedReview(t *testing.T) {
+	database, _, run, _ := setupTest(t)
+	capture := &routingCaptureAgent{}
+	wrapped := &perfRecordingAgent{
+		inner: capture, db: database, runID: run.ID, stepName: types.StepReview,
+		repository:          "https://github.com/RaFoyer/no-mistakes.git",
+		sourceConfiguration: "cfg-fingerprint", configurationGeneration: "generation-1",
+		risk:               func() routing.Risk { return routing.RiskHigh },
+		reviewConfirmation: func() bool { return false },
+		round:              func() int { return 1 },
+	}
+	if _, err := wrapped.Run(context.Background(), agent.RunOpts{Prompt: "review", Purpose: "review", RouteReviewConfirmation: true}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := wrapped.Run(context.Background(), agent.RunOpts{Prompt: "test", Purpose: "test", RouteReviewConfirmation: true}); err != nil {
+		t.Fatal(err)
+	}
+	if len(capture.seen) != 2 {
+		t.Fatalf("captured %d invocations", len(capture.seen))
+	}
+	if got := capture.seen[0].Routing.EffectiveModel; got != routing.ModelSol || capture.seen[0].Routing.EffectiveEffort != routing.EffortHigh {
+		t.Fatalf("review route = %+v, want Sol/high", capture.seen[0].Routing)
+	}
+	if got := capture.seen[1].Routing.EffectiveModel; got != routing.ModelTerra || capture.seen[1].Routing.EffectiveEffort != routing.EffortHigh {
+		t.Fatalf("test route = %+v, want Terra/high", capture.seen[1].Routing)
+	}
+	decisions, err := database.RouteDecisions(run.ID)
+	if err != nil || len(decisions) != 2 {
+		t.Fatalf("route decisions = %+v, err = %v", decisions, err)
+	}
+	if decisions[0].SourceConfiguration != "cfg-fingerprint" || decisions[0].ConfigurationGeneration != "generation-1" || decisions[0].PromptBytes == 0 {
+		t.Fatalf("route evidence = %+v", decisions[0])
+	}
 }
 
 func (a *fallbackUsageAgent) Name() string { return a.name }

--- a/internal/pipeline/executor_perf_test.go
+++ b/internal/pipeline/executor_perf_test.go
@@ -92,6 +92,75 @@ func TestPerfRecordingAgentRoutesSolOnlyForConfirmedReview(t *testing.T) {
 	}
 }
 
+func TestExecutorReviewRiskDowngradeRevokesLiveSolConfirmation(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	capture := &routingCaptureAgent{}
+	callCount := 0
+	step := &adaptiveCallStep{
+		name: types.StepReview,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			callCount++
+			priorRisk := routeRiskFromFindings(sctx.PreviousFindings)
+			if _, err := sctx.Agent.Run(sctx.Ctx, agent.RunOpts{
+				Prompt:                  "review",
+				Purpose:                 "review",
+				RouteRisk:               priorRisk,
+				RouteReviewConfirmation: sctx.Fixing && priorRisk == routing.RiskHigh,
+			}); err != nil {
+				return nil, err
+			}
+
+			risk := "high"
+			if callCount >= 3 {
+				risk = "low"
+			}
+			needsApproval := callCount < 4
+			findings := `{"findings":[],"risk_level":"` + risk + `","risk_rationale":"route test","risk_scope":"source-or-external"}`
+			if needsApproval {
+				findings = `{"findings":[{"id":"route-finding","severity":"warning","description":"continue route test","action":"ask-user"}],"risk_level":"` + risk + `","risk_rationale":"route test","risk_scope":"source-or-external"}`
+			}
+			return &StepOutcome{NeedsApproval: needsApproval, Findings: findings}, nil
+		},
+	}
+	exec := NewExecutor(database, p, &config.Config{}, capture, []Step{step}, nil)
+	done := make(chan error, 1)
+	go func() { done <- exec.Execute(context.Background(), run, repo, t.TempDir()) }()
+
+	for wantResults := 1; wantResults <= 3; wantResults++ {
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			results, err := database.RouteResults(run.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(results) >= wantResults {
+				if err := exec.Respond(types.StepReview, types.ActionFix, nil); err == nil {
+					break
+				}
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("review round %d never reached its approval gate", wantResults)
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("executor timed out")
+	}
+	if len(capture.seen) != 4 {
+		t.Fatalf("review routes = %d, want four rounds", len(capture.seen))
+	}
+	if got := capture.seen[3].Routing; got.Phase != "review" || got.EffectiveModel != routing.ModelLuna || got.EffectiveEffort != routing.EffortXHigh {
+		t.Fatalf("post-downgrade review route = %+v, want ordinary Luna/xhigh review", got)
+	}
+}
+
 func (a *fallbackUsageAgent) Name() string { return a.name }
 
 func (a *fallbackUsageAgent) Run(context.Context, agent.RunOpts) (*agent.Result, error) {

--- a/internal/pipeline/executor_perf_test.go
+++ b/internal/pipeline/executor_perf_test.go
@@ -175,15 +175,15 @@ func TestPerfRecordingAgent_RecordsFallbackAttemptsSeparately(t *testing.T) {
 		round:    func() int { return 1 },
 	}
 
-	if _, err := wrapped.Run(context.Background(), agent.RunOpts{Purpose: "review"}); err != nil {
-		t.Fatalf("Run: %v", err)
+	if _, err := wrapped.Run(context.Background(), agent.RunOpts{Purpose: "review"}); err == nil {
+		t.Fatal("Codex policy must fail closed instead of falling back to Claude")
 	}
 	invocations, err := database.GetAgentInvocationsByRun(run.ID)
 	if err != nil {
 		t.Fatalf("get invocations: %v", err)
 	}
-	if len(invocations) != 2 {
-		t.Fatalf("got %d invocation rows, want 2", len(invocations))
+	if len(invocations) != 1 {
+		t.Fatalf("got %d invocation rows, want one attempted Codex route", len(invocations))
 	}
 	byAgent := map[string]db.AgentInvocation{}
 	for _, invocation := range invocations {
@@ -191,9 +191,6 @@ func TestPerfRecordingAgent_RecordsFallbackAttemptsSeparately(t *testing.T) {
 	}
 	if got := byAgent["codex"]; got.ExitStatus != "error" || got.FailureCategory != "spawn" {
 		t.Fatalf("codex invocation = %+v", got)
-	}
-	if got := byAgent["claude"]; got.ExitStatus != "ok" || got.Model != "test-model-2" {
-		t.Fatalf("claude invocation = %+v", got)
 	}
 }
 
@@ -224,6 +221,31 @@ func TestPerfRecordingAgent_MixedFallbackRecordsActualProviderCold(t *testing.T)
 	}
 	if got := invocations[0]; got.Agent != "pi" || got.SessionMode != db.InvocationModeCold {
 		t.Fatalf("invocation = %+v, want pi cold", got)
+	}
+}
+
+func TestPerfRecordingAgentClearsUnenforceableGPTEvidence(t *testing.T) {
+	database, _, run, _ := setupTest(t)
+	wrapped := &perfRecordingAgent{
+		inner:    &fallbackUsageAgent{name: "claude", result: &agent.Result{Model: "claude-sonnet"}},
+		db:       database,
+		runID:    run.ID,
+		stepName: types.StepReview,
+		round:    func() int { return 1 },
+	}
+	_, err := wrapped.Run(context.Background(), agent.RunOpts{
+		Purpose: "review",
+		Routing: routing.Decision{RequestedHarness: "claude", EffectiveHarness: "codex", EffectiveModel: routing.ModelSol, EffectiveEffort: routing.EffortHigh, PolicyVersion: routing.PolicyVersion},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	invs, err := database.GetAgentInvocationsByRun(run.ID)
+	if err != nil || len(invs) != 1 {
+		t.Fatalf("invocations = %+v, err=%v", invs, err)
+	}
+	if invs[0].EffectiveHarness != "claude" || invs[0].EffectiveModel != "" || invs[0].EffectiveEffort != "" {
+		t.Fatalf("unenforceable route evidence = %+v", invs[0])
 	}
 }
 

--- a/internal/pipeline/instrument.go
+++ b/internal/pipeline/instrument.go
@@ -50,14 +50,6 @@ func (a *perfRecordingAgent) SupportsSessionProvider(provider string) bool {
 }
 
 func (a *perfRecordingAgent) Run(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
-	// A caller may carry a precomputed route from a step or recovery path. Do
-	// not let that metadata claim GPT controls for a non-Codex adapter.
-	if !strings.EqualFold(a.inner.Name(), "codex") {
-		opts.Routing.EffectiveHarness = a.inner.Name()
-		opts.Routing.EffectiveModel = ""
-		opts.Routing.EffectiveEffort = ""
-		opts.Routing.Reason = "configured harness cannot enforce the Codex GPT routing policy"
-	}
 	if opts.Routing.PolicyVersion == "" {
 		risk := opts.RouteRisk
 		if a.risk != nil {
@@ -73,21 +65,25 @@ func (a *perfRecordingAgent) Run(ctx context.Context, opts agent.RunOpts) (*agen
 			SourceConfiguration:     a.sourceConfiguration,
 			ConfigurationGeneration: a.configurationGeneration,
 		})
+	} else if !agent.ReportsAgentRoutes(a.inner) {
+		// A caller may carry a precomputed route from a step or recovery path.
+		// Rebind it to the concrete adapter so stale GPT controls cannot survive
+		// a direct non-Codex adapter invocation. Fallback wrappers retain the
+		// policy-effective route so their own Codex guard can fail closed before
+		// trying an unenforceable candidate.
+		opts.Routing = routing.ForAdapter(opts.Routing, a.inner.Name())
 	}
-	if a.db != nil {
-		promptSHA, promptBytes := db.PromptEvidence(opts.Prompt)
-		if err := a.db.InsertRouteDecision(db.RouteDecision{
-			RunID: a.runID, StepName: string(a.stepName), Round: a.round(),
-			RequestedHarness: opts.Routing.RequestedHarness, EffectiveHarness: opts.Routing.EffectiveHarness,
-			RequestedModel: opts.Routing.RequestedModel, EffectiveModel: opts.Routing.EffectiveModel,
-			RequestedEffort: opts.Routing.RequestedEffort, EffectiveEffort: opts.Routing.EffectiveEffort,
-			PolicyVersion: opts.Routing.PolicyVersion, Phase: opts.Routing.Phase, Reason: opts.Routing.Reason,
-			Risk:                    string(opts.Routing.Risk),
-			SourceConfiguration:     opts.Routing.SourceConfiguration,
-			ConfigurationGeneration: opts.Routing.ConfigurationGeneration,
-			Repository:              opts.Routing.Repository,
-			PromptSHA256:            promptSHA, PromptBytes: promptBytes, PromptTransport: agent.PromptTransport(a.inner.Name()),
-		}); err != nil {
+	previousRoute := opts.OnRoute
+	opts.OnRoute = func(route routing.Decision) error {
+		if previousRoute != nil {
+			if err := previousRoute(route); err != nil {
+				return err
+			}
+		}
+		return a.recordRoute(route, opts)
+	}
+	if !agent.ReportsAgentRoutes(a.inner) {
+		if err := opts.OnRoute(opts.Routing); err != nil {
 			return nil, fmt.Errorf("record route decision before agent launch: %w", err)
 		}
 	}
@@ -101,14 +97,39 @@ func (a *perfRecordingAgent) Run(ctx context.Context, opts agent.RunOpts) (*agen
 		attemptOpts := opts
 		attemptOpts.Session = attempt.Session
 		attemptOpts.SessionFallback = attempt.SessionFallback
+		if attempt.Routing.PolicyVersion != "" {
+			attemptOpts.Routing = attempt.Routing
+		}
 		a.record(ctx, attemptOpts, attempt.Agent, attempt.Result, attempt.Err, attempt.StartedAt, attempt.CompletedAt)
 	}
 	start := time.Now()
 	result, err := a.inner.Run(ctx, opts)
-	if attempts == 0 {
+	if attempts == 0 && !agent.ReportsAgentAttempts(a.inner) {
 		a.record(ctx, opts, a.inner.Name(), result, err, start, time.Now())
 	}
 	return result, err
+}
+
+func (a *perfRecordingAgent) recordRoute(route routing.Decision, opts agent.RunOpts) error {
+	if a.db == nil {
+		return nil
+	}
+	promptSHA, promptBytes := db.PromptEvidence(opts.Prompt)
+	if err := a.db.InsertRouteDecision(db.RouteDecision{
+		RunID: a.runID, StepName: string(a.stepName), Round: a.round(),
+		RequestedHarness: route.RequestedHarness, EffectiveHarness: route.EffectiveHarness,
+		RequestedModel: route.RequestedModel, EffectiveModel: route.EffectiveModel,
+		RequestedEffort: route.RequestedEffort, EffectiveEffort: route.EffectiveEffort,
+		PolicyVersion: route.PolicyVersion, Phase: route.Phase, Reason: route.Reason,
+		Risk:                    string(route.Risk),
+		SourceConfiguration:     route.SourceConfiguration,
+		ConfigurationGeneration: route.ConfigurationGeneration,
+		Repository:              route.Repository,
+		PromptSHA256:            promptSHA, PromptBytes: promptBytes, PromptTransport: agent.PromptTransport(route.EffectiveHarness),
+	}); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (a *perfRecordingAgent) record(ctx context.Context, opts agent.RunOpts, agentName string, result *agent.Result, runErr error, startedAt, completedAt time.Time) {
@@ -145,6 +166,19 @@ func (a *perfRecordingAgent) record(ctx context.Context, opts agent.RunOpts, age
 		RouteReason:                  opts.Routing.Reason,
 		RouteSourceConfiguration:     opts.Routing.SourceConfiguration,
 		RouteConfigurationGeneration: opts.Routing.ConfigurationGeneration,
+	}
+	if attemptRoute := opts.Routing; attemptRoute.PolicyVersion != "" {
+		inv.RequestedHarness = attemptRoute.RequestedHarness
+		inv.EffectiveHarness = attemptRoute.EffectiveHarness
+		inv.RequestedModel = attemptRoute.RequestedModel
+		inv.EffectiveModel = attemptRoute.EffectiveModel
+		inv.RequestedEffort = attemptRoute.RequestedEffort
+		inv.EffectiveEffort = attemptRoute.EffectiveEffort
+		inv.RoutePolicyVersion = attemptRoute.PolicyVersion
+		inv.RoutePhase = attemptRoute.Phase
+		inv.RouteReason = attemptRoute.Reason
+		inv.RouteSourceConfiguration = attemptRoute.SourceConfiguration
+		inv.RouteConfigurationGeneration = attemptRoute.ConfigurationGeneration
 	}
 	if opts.SessionFallback && opts.SessionFallbackReason != "" {
 		reason := opts.SessionFallbackReason

--- a/internal/pipeline/instrument.go
+++ b/internal/pipeline/instrument.go
@@ -77,7 +77,7 @@ func (a *perfRecordingAgent) Run(ctx context.Context, opts agent.RunOpts) (*agen
 			SourceConfiguration:     opts.Routing.SourceConfiguration,
 			ConfigurationGeneration: opts.Routing.ConfigurationGeneration,
 			Repository:              opts.Routing.Repository,
-			PromptSHA256:            promptSHA, PromptBytes: promptBytes, PromptTransport: "stdin",
+			PromptSHA256:            promptSHA, PromptBytes: promptBytes, PromptTransport: agent.PromptTransport(a.inner.Name()),
 		}); err != nil {
 			slog.Warn("failed to record route decision", "step", a.stepName, "error", err)
 		}

--- a/internal/pipeline/instrument.go
+++ b/internal/pipeline/instrument.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"time"
@@ -19,7 +20,7 @@ import (
 // perfRecordingAgent decorates the step agent to persist one local
 // agent_invocations row per invocation: identity, purpose, session mode,
 // timing, exit status, and token usage. Recording is local-only and
-// best-effort: a failed insert never fails the invocation, and no
+// required: a failed route insert prevents the invocation, and no
 // per-invocation record leaves the machine.
 type perfRecordingAgent struct {
 	inner                   agent.Agent
@@ -49,6 +50,14 @@ func (a *perfRecordingAgent) SupportsSessionProvider(provider string) bool {
 }
 
 func (a *perfRecordingAgent) Run(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+	// A caller may carry a precomputed route from a step or recovery path. Do
+	// not let that metadata claim GPT controls for a non-Codex adapter.
+	if !strings.EqualFold(a.inner.Name(), "codex") {
+		opts.Routing.EffectiveHarness = a.inner.Name()
+		opts.Routing.EffectiveModel = ""
+		opts.Routing.EffectiveEffort = ""
+		opts.Routing.Reason = "configured harness cannot enforce the Codex GPT routing policy"
+	}
 	if opts.Routing.PolicyVersion == "" {
 		risk := opts.RouteRisk
 		if a.risk != nil {
@@ -79,7 +88,7 @@ func (a *perfRecordingAgent) Run(ctx context.Context, opts agent.RunOpts) (*agen
 			Repository:              opts.Routing.Repository,
 			PromptSHA256:            promptSHA, PromptBytes: promptBytes, PromptTransport: agent.PromptTransport(a.inner.Name()),
 		}); err != nil {
-			slog.Warn("failed to record route decision", "step", a.stepName, "error", err)
+			return nil, fmt.Errorf("record route decision before agent launch: %w", err)
 		}
 	}
 	attempts := 0
@@ -171,9 +180,6 @@ func (a *perfRecordingAgent) recordResult(inv *db.AgentInvocation, sessionKey st
 		return
 	}
 	inv.Model = result.Model
-	if inv.EffectiveModel == "" {
-		inv.EffectiveModel = result.Model
-	}
 	if result.ModelProvider != "" {
 		provider := result.ModelProvider
 		inv.ModelProvider = &provider

--- a/internal/pipeline/instrument.go
+++ b/internal/pipeline/instrument.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
 	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/routing"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
@@ -21,10 +22,15 @@ import (
 // best-effort: a failed insert never fails the invocation, and no
 // per-invocation record leaves the machine.
 type perfRecordingAgent struct {
-	inner    agent.Agent
-	db       *db.DB
-	runID    string
-	stepName types.StepName
+	inner                   agent.Agent
+	db                      *db.DB
+	runID                   string
+	stepName                types.StepName
+	repository              string
+	sourceConfiguration     string
+	configurationGeneration string
+	risk                    func() routing.Risk
+	reviewConfirmation      func() bool
 	// round returns the 1-based round the current invocation belongs to.
 	round func() int
 }
@@ -43,6 +49,39 @@ func (a *perfRecordingAgent) SupportsSessionProvider(provider string) bool {
 }
 
 func (a *perfRecordingAgent) Run(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+	if opts.Routing.PolicyVersion == "" {
+		risk := opts.RouteRisk
+		if a.risk != nil {
+			risk = a.risk()
+		}
+		confirmation := opts.RouteReviewConfirmation
+		if a.reviewConfirmation != nil {
+			confirmation = confirmation || a.reviewConfirmation()
+		}
+		opts.Routing = routing.Decide(routing.Input{
+			Harness: a.inner.Name(), Purpose: opts.Purpose, Repository: a.repository,
+			Risk: risk, ReviewConfirmation: confirmation,
+			SourceConfiguration:     a.sourceConfiguration,
+			ConfigurationGeneration: a.configurationGeneration,
+		})
+	}
+	if a.db != nil {
+		promptSHA, promptBytes := db.PromptEvidence(opts.Prompt)
+		if err := a.db.InsertRouteDecision(db.RouteDecision{
+			RunID: a.runID, StepName: string(a.stepName), Round: a.round(),
+			RequestedHarness: opts.Routing.RequestedHarness, EffectiveHarness: opts.Routing.EffectiveHarness,
+			RequestedModel: opts.Routing.RequestedModel, EffectiveModel: opts.Routing.EffectiveModel,
+			RequestedEffort: opts.Routing.RequestedEffort, EffectiveEffort: opts.Routing.EffectiveEffort,
+			PolicyVersion: opts.Routing.PolicyVersion, Phase: opts.Routing.Phase, Reason: opts.Routing.Reason,
+			Risk:                    string(opts.Routing.Risk),
+			SourceConfiguration:     opts.Routing.SourceConfiguration,
+			ConfigurationGeneration: opts.Routing.ConfigurationGeneration,
+			Repository:              opts.Routing.Repository,
+			PromptSHA256:            promptSHA, PromptBytes: promptBytes, PromptTransport: "stdin",
+		}); err != nil {
+			slog.Warn("failed to record route decision", "step", a.stepName, "error", err)
+		}
+	}
 	attempts := 0
 	previous := opts.OnAttempt
 	opts.OnAttempt = func(attempt agent.Attempt) {
@@ -75,17 +114,28 @@ func (a *perfRecordingAgent) record(ctx context.Context, opts agent.RunOpts, age
 
 	sessionKey := invocationSessionKey(opts, result)
 	inv := db.AgentInvocation{
-		RunID:       a.runID,
-		StepName:    string(a.stepName),
-		Round:       a.round(),
-		Purpose:     purpose,
-		Agent:       agentName,
-		SessionMode: invocationSessionMode(opts),
-		SessionKey:  sessionKey,
-		StartedAt:   startedAt.Unix(),
-		CompletedAt: completedAt.Unix(),
-		DurationMS:  completedAt.Sub(startedAt).Milliseconds(),
-		ExitStatus:  "ok",
+		RunID:                        a.runID,
+		StepName:                     string(a.stepName),
+		Round:                        a.round(),
+		Purpose:                      purpose,
+		Agent:                        agentName,
+		SessionMode:                  invocationSessionMode(opts),
+		SessionKey:                   sessionKey,
+		StartedAt:                    startedAt.Unix(),
+		CompletedAt:                  completedAt.Unix(),
+		DurationMS:                   completedAt.Sub(startedAt).Milliseconds(),
+		ExitStatus:                   "ok",
+		RequestedHarness:             opts.Routing.RequestedHarness,
+		EffectiveHarness:             opts.Routing.EffectiveHarness,
+		RequestedModel:               opts.Routing.RequestedModel,
+		EffectiveModel:               opts.Routing.EffectiveModel,
+		RequestedEffort:              opts.Routing.RequestedEffort,
+		EffectiveEffort:              opts.Routing.EffectiveEffort,
+		RoutePolicyVersion:           opts.Routing.PolicyVersion,
+		RoutePhase:                   opts.Routing.Phase,
+		RouteReason:                  opts.Routing.Reason,
+		RouteSourceConfiguration:     opts.Routing.SourceConfiguration,
+		RouteConfigurationGeneration: opts.Routing.ConfigurationGeneration,
 	}
 	if opts.SessionFallback && opts.SessionFallbackReason != "" {
 		reason := opts.SessionFallbackReason
@@ -121,6 +171,9 @@ func (a *perfRecordingAgent) recordResult(inv *db.AgentInvocation, sessionKey st
 		return
 	}
 	inv.Model = result.Model
+	if inv.EffectiveModel == "" {
+		inv.EffectiveModel = result.Model
+	}
 	if result.ModelProvider != "" {
 		provider := result.ModelProvider
 		inv.ModelProvider = &provider

--- a/internal/pipeline/sessions_test.go
+++ b/internal/pipeline/sessions_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
 	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/routing"
 )
 
 // sessionCall records one invocation the fake adapter received.
@@ -17,6 +18,7 @@ type sessionCall struct {
 	prompt   string
 	session  *agent.SessionRef
 	fallback bool
+	routing  routing.Decision
 }
 
 // fakeSessionAgent is a session-capable adapter that mints deterministic
@@ -49,7 +51,7 @@ func (f *fakeSessionAgent) Close() error { return nil }
 func (f *fakeSessionAgent) Run(_ context.Context, opts agent.RunOpts) (*agent.Result, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.calls = append(f.calls, sessionCall{prompt: opts.Prompt, session: opts.Session, fallback: opts.SessionFallback})
+	f.calls = append(f.calls, sessionCall{prompt: opts.Prompt, session: opts.Session, fallback: opts.SessionFallback, routing: opts.Routing})
 
 	if f.failNext != nil {
 		err := f.failNext

--- a/internal/pipeline/steps/common_fix.go
+++ b/internal/pipeline/steps/common_fix.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/agent"
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
+	"github.com/kunchenguid/no-mistakes/internal/routing"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
@@ -28,7 +29,8 @@ type fixExecutionOptions struct {
 	Purpose string
 	// Workload records the bounded size of the change under fix for local
 	// telemetry. Optional; nil leaves the invocation's workload unknown.
-	Workload *agent.InvocationWorkload
+	Workload  *agent.InvocationWorkload
+	RouteRisk routing.Risk
 }
 
 type commitSummary struct {
@@ -193,6 +195,7 @@ func executeFixMode(sctx *pipeline.StepContext, stepName types.StepName, opts fi
 		OnChunk:    sctx.LogChunk,
 		Purpose:    purpose,
 		Workload:   opts.Workload,
+		RouteRisk:  opts.RouteRisk,
 	}
 	var result *agent.Result
 	var err error

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/agent"
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
+	"github.com/kunchenguid/no-mistakes/internal/routing"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
@@ -53,6 +54,7 @@ func (s *ReviewStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome,
 	// not an enforced sandbox - the agent has free shell access - so the pinned
 	// regression tests guard the wording, not the runtime.
 	var fixSummary string
+	priorRisk := reviewRisk(sctx.PreviousFindings)
 	if sctx.Fixing {
 		previousFindings := sanitizedPreviousFindingsForPrompt(sctx.PreviousFindings)
 		historySection := executionContextPromptSection() + roundHistoryPromptSection(sctx) + userIntentPromptSection(sctx)
@@ -103,6 +105,7 @@ Previous review findings to address:
 			SessionRole:             pipeline.SessionRoleFixer,
 			Purpose:                 "review-fix",
 			Workload:                workload,
+			RouteRisk:               priorRisk,
 		})
 		if err != nil {
 			return nil, err
@@ -234,12 +237,14 @@ Risk assessment (after listing all findings):
 	// session only carries the reviewer's own prior context, never the
 	// fixer's (that role has its own isolated session in executeFixMode).
 	result, err := sctx.RunAgentSession(pipeline.SessionRoleReviewer, agent.RunOpts{
-		Prompt:     prompt,
-		CWD:        sctx.WorkDir,
-		JSONSchema: reviewFindingsSchema,
-		OnChunk:    sctx.LogChunk,
-		Purpose:    "review",
-		Workload:   workload,
+		Prompt:                  prompt,
+		CWD:                     sctx.WorkDir,
+		JSONSchema:              reviewFindingsSchema,
+		OnChunk:                 sctx.LogChunk,
+		Purpose:                 "review",
+		Workload:                workload,
+		RouteRisk:               priorRisk,
+		RouteReviewConfirmation: sctx.Fixing && priorRisk == routing.RiskHigh,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("agent review: %w", err)
@@ -272,6 +277,26 @@ Risk assessment (after listing all findings):
 		Findings:      string(findingsJSON),
 		FixSummary:    fixSummary,
 	}, nil
+}
+
+func reviewRisk(raw string) routing.Risk {
+	if strings.TrimSpace(raw) == "" {
+		return routing.RiskUnknown
+	}
+	var f Findings
+	if err := json.Unmarshal([]byte(raw), &f); err != nil {
+		return routing.RiskUnknown
+	}
+	switch strings.ToLower(strings.TrimSpace(f.RiskLevel)) {
+	case "high":
+		return routing.RiskHigh
+	case "medium":
+		return routing.RiskMedium
+	case "low":
+		return routing.RiskLow
+	default:
+		return routing.RiskUnknown
+	}
 }
 
 func sanitizedPreviousFindingsForPrompt(raw string) string {

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -1,0 +1,173 @@
+// Package routing owns the model policy used by no-mistakes. It deliberately
+// has no repository or project-specific dependencies: project metadata is an
+// input to a bounded fingerprint, never executable routing authority.
+package routing
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+)
+
+const PolicyVersion = "nm-routing-v1"
+
+const (
+	ModelLuna   = "gpt-5.6-luna"
+	ModelTerra  = "gpt-5.6-terra"
+	ModelSol    = "gpt-5.6-sol"
+	EffortXHigh = "xhigh"
+	EffortHigh  = "high"
+)
+
+type Risk string
+
+const (
+	RiskUnknown Risk = "unknown"
+	RiskLow     Risk = "low"
+	RiskMedium  Risk = "medium"
+	RiskHigh    Risk = "high"
+)
+
+type Input struct {
+	Harness                 string
+	Purpose                 string
+	Repository              string
+	Risk                    Risk
+	ReviewConfirmation      bool
+	SourceConfiguration     string
+	ConfigurationGeneration string
+}
+
+type Decision struct {
+	RequestedHarness        string
+	EffectiveHarness        string
+	RequestedModel          string
+	EffectiveModel          string
+	RequestedEffort         string
+	EffectiveEffort         string
+	PolicyVersion           string
+	Phase                   string
+	Risk                    Risk
+	Reason                  string
+	SourceConfiguration     string
+	ConfigurationGeneration string
+	Repository              string
+}
+
+func Decide(in Input) Decision {
+	harness := strings.TrimSpace(in.Harness)
+	if harness == "" {
+		harness = "unknown"
+	}
+	phase := phaseForPurpose(in.Purpose)
+	if phase == "review" && in.ReviewConfirmation {
+		phase = "review-confirmation"
+	}
+	risk := in.Risk
+	if risk == "" {
+		risk = RiskUnknown
+	}
+	d := Decision{
+		RequestedHarness:        harness,
+		EffectiveHarness:        harness,
+		RequestedModel:          ModelLuna,
+		EffectiveModel:          ModelLuna,
+		RequestedEffort:         EffortXHigh,
+		EffectiveEffort:         EffortXHigh,
+		PolicyVersion:           PolicyVersion,
+		Phase:                   phase,
+		Risk:                    risk,
+		SourceConfiguration:     bounded(in.SourceConfiguration, 512),
+		ConfigurationGeneration: bounded(in.ConfigurationGeneration, 128),
+		Repository:              CanonicalRepository(in.Repository),
+		Reason:                  "default initial/default work",
+	}
+	// The first review is the bootstrap classifier. Any caller-supplied risk
+	// is deliberately ignored until that review has produced its own result.
+	if phase == "review" && !in.ReviewConfirmation {
+		return d
+	}
+	if (risk == RiskMedium || risk == RiskHigh) && phase != "review" && phase != "review-confirmation" {
+		d.EffectiveModel = ModelTerra
+		d.EffectiveEffort = EffortHigh
+		d.Reason = "medium-high risk policy"
+	}
+	// Bootstrap is explicit: the first review has no risk classification yet,
+	// so it always remains Luna. Sol is legal only for a later review turn
+	// after the earlier review classified the change as high risk.
+	if phase == "review-confirmation" && in.ReviewConfirmation && risk == RiskHigh {
+		d.EffectiveModel = ModelSol
+		d.EffectiveEffort = EffortHigh
+		d.Reason = "high-risk review confirmation"
+	}
+	return d
+}
+
+func phaseForPurpose(purpose string) string {
+	switch strings.ToLower(strings.TrimSpace(purpose)) {
+	case "review-confirmation", "review-confirm":
+		return "review-confirmation"
+	case "review":
+		return "review"
+	case "review-fix":
+		return "review-fix"
+	case "test-evidence", "test":
+		return "test"
+	case "document", "lint", "housekeeping":
+		return "housekeeping"
+	default:
+		return "default"
+	}
+}
+
+func ReviewConfirmation(in Input) Input {
+	in.ReviewConfirmation = true
+	in.Purpose = "review-confirmation"
+	return in
+}
+
+func ConfigFingerprint(parts ...string) string {
+	h := sha256.New()
+	for _, part := range parts {
+		part = boundedFingerprintInput(part)
+		h.Write([]byte{0})
+		h.Write([]byte(part))
+	}
+	return hex.EncodeToString(h.Sum(nil)[:12])
+}
+
+func boundedFingerprintInput(part string) string {
+	const edge = 512
+	if len(part) <= edge*2 {
+		return part
+	}
+	// Include length plus both edges. This is bounded, deterministic, and
+	// avoids silently treating edits in the tail of a large config as stale.
+	return part[:edge] + "\x00len=" + strconv.Itoa(len(part)) + "\x00" + part[len(part)-edge:]
+}
+
+func CanonicalRepository(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "unknown"
+	}
+	if u, err := url.Parse(raw); err == nil && u.Host != "" {
+		host := strings.ToLower(strings.TrimSuffix(u.Host, "."))
+		p := strings.Trim(path.Clean(u.Path), "/")
+		p = strings.TrimSuffix(p, ".git")
+		return host + "/" + strings.ToLower(p)
+	}
+	raw = strings.TrimPrefix(raw, "git@")
+	raw = strings.TrimSuffix(raw, ".git")
+	return strings.ToLower(strings.Trim(strings.ReplaceAll(raw, ":", "/"), "/"))
+}
+
+func bounded(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -58,7 +58,7 @@ type Decision struct {
 }
 
 func Decide(in Input) Decision {
-	harness := strings.TrimSpace(in.Harness)
+	harness := bounded(strings.TrimSpace(in.Harness), 128)
 	if harness == "" {
 		harness = "unknown"
 	}
@@ -66,10 +66,7 @@ func Decide(in Input) Decision {
 	if phase == "review" && in.ReviewConfirmation {
 		phase = "review-confirmation"
 	}
-	risk := in.Risk
-	if risk == "" {
-		risk = RiskUnknown
-	}
+	risk := normalizeRisk(in.Risk)
 	d := Decision{
 		RequestedHarness:        harness,
 		EffectiveHarness:        harness,
@@ -82,7 +79,7 @@ func Decide(in Input) Decision {
 		Risk:                    risk,
 		SourceConfiguration:     bounded(in.SourceConfiguration, 512),
 		ConfigurationGeneration: bounded(in.ConfigurationGeneration, 128),
-		Repository:              CanonicalRepository(in.Repository),
+		Repository:              bounded(CanonicalRepository(in.Repository), 512),
 		Reason:                  "default initial/default work",
 	}
 	// The first review is the bootstrap classifier. Any caller-supplied risk
@@ -104,6 +101,15 @@ func Decide(in Input) Decision {
 		d.Reason = "high-risk review confirmation"
 	}
 	return d
+}
+
+func normalizeRisk(risk Risk) Risk {
+	switch risk {
+	case RiskLow, RiskMedium, RiskHigh:
+		return risk
+	default:
+		return RiskUnknown
+	}
 }
 
 func phaseForPurpose(purpose string) string {
@@ -158,11 +164,11 @@ func CanonicalRepository(raw string) string {
 		host := strings.ToLower(strings.TrimSuffix(u.Host, "."))
 		p := strings.Trim(path.Clean(u.Path), "/")
 		p = strings.TrimSuffix(p, ".git")
-		return host + "/" + strings.ToLower(p)
+		return bounded(host+"/"+strings.ToLower(p), 512)
 	}
 	raw = strings.TrimPrefix(raw, "git@")
 	raw = strings.TrimSuffix(raw, ".git")
-	return strings.ToLower(strings.Trim(strings.ReplaceAll(raw, ":", "/"), "/"))
+	return bounded(strings.ToLower(strings.Trim(strings.ReplaceAll(raw, ":", "/"), "/")), 512)
 }
 
 func bounded(s string, n int) string {

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -8,11 +8,11 @@ import (
 	"encoding/hex"
 	"net/url"
 	"path"
-	"strconv"
 	"strings"
 )
 
-const PolicyVersion = "nm-routing-v1"
+const PolicyVersion = "nm-routing-v2"
+const ConfigFingerprintVersion = "nm-config-fingerprint-v2"
 
 const (
 	ModelLuna   = "gpt-5.6-luna"
@@ -82,6 +82,15 @@ func Decide(in Input) Decision {
 		Repository:              bounded(CanonicalRepository(in.Repository), 512),
 		Reason:                  "default initial/default work",
 	}
+	// The approved GPT policy is enforceable only by Codex. Other adapters may
+	// still be explicitly configured, but their evidence must never claim that
+	// a GPT model or reasoning effort was effective when the adapter did not
+	// receive those controls.
+	if !strings.EqualFold(harness, "codex") {
+		d.EffectiveModel = ""
+		d.EffectiveEffort = ""
+		d.Reason = "configured harness cannot enforce the Codex GPT routing policy"
+	}
 	// The first review is the bootstrap classifier. Any caller-supplied risk
 	// is deliberately ignored until that review has produced its own result.
 	if phase == "review" && !in.ReviewConfirmation {
@@ -137,22 +146,12 @@ func ReviewConfirmation(in Input) Input {
 
 func ConfigFingerprint(parts ...string) string {
 	h := sha256.New()
+	h.Write([]byte(ConfigFingerprintVersion))
 	for _, part := range parts {
-		part = boundedFingerprintInput(part)
 		h.Write([]byte{0})
 		h.Write([]byte(part))
 	}
 	return hex.EncodeToString(h.Sum(nil)[:12])
-}
-
-func boundedFingerprintInput(part string) string {
-	const edge = 512
-	if len(part) <= edge*2 {
-		return part
-	}
-	// Include length plus both edges. This is bounded, deterministic, and
-	// avoids silently treating edits in the tail of a large config as stale.
-	return part[:edge] + "\x00len=" + strconv.Itoa(len(part)) + "\x00" + part[len(part)-edge:]
 }
 
 func CanonicalRepository(raw string) string {

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -94,7 +94,7 @@ func Decide(in Input) Decision {
 	// The first review is the bootstrap classifier. Any caller-supplied risk
 	// is deliberately ignored until that review has produced its own result.
 	if phase == "review" && !in.ReviewConfirmation {
-		return d
+		return enforceAdapterEvidence(d)
 	}
 	if (risk == RiskMedium || risk == RiskHigh) && phase != "review" && phase != "review-confirmation" {
 		d.EffectiveModel = ModelTerra
@@ -109,6 +109,41 @@ func Decide(in Input) Decision {
 		d.EffectiveEffort = EffortHigh
 		d.Reason = "high-risk review confirmation"
 	}
+	return enforceAdapterEvidence(d)
+}
+
+// ForAdapter binds a policy decision to the concrete adapter that will make
+// the attempt. RequestedHarness remains the configured route, while the
+// effective fields describe only controls the concrete adapter can enforce.
+// Fallback instrumentation uses this at the attempt boundary so immutable
+// route and invocation evidence cannot retain the failed candidate.
+func ForAdapter(decision Decision, harness string) Decision {
+	actual := bounded(strings.TrimSpace(harness), 128)
+	if actual == "" {
+		actual = "unknown"
+	}
+	next := Decide(Input{
+		Harness:                 actual,
+		Purpose:                 decision.Phase,
+		Risk:                    decision.Risk,
+		ReviewConfirmation:      decision.Phase == "review-confirmation",
+		SourceConfiguration:     decision.SourceConfiguration,
+		ConfigurationGeneration: decision.ConfigurationGeneration,
+		Repository:              decision.Repository,
+	})
+	if decision.RequestedHarness != "" {
+		next.RequestedHarness = decision.RequestedHarness
+	}
+	return next
+}
+
+func enforceAdapterEvidence(d Decision) Decision {
+	if strings.EqualFold(d.EffectiveHarness, "codex") {
+		return d
+	}
+	d.EffectiveModel = ""
+	d.EffectiveEffort = ""
+	d.Reason = "configured harness cannot enforce the Codex GPT routing policy"
 	return d
 }
 

--- a/internal/routing/routing_test.go
+++ b/internal/routing/routing_test.go
@@ -26,10 +26,10 @@ func TestDecideAllowsSolOnlyAfterHighRiskReviewClassification(t *testing.T) {
 		want   string
 		effort string
 	}{
-		{"first high-risk review", Input{Purpose: "review", Risk: RiskHigh}, ModelLuna, EffortXHigh},
-		{"high-risk fixer", Input{Purpose: "review-fix", Risk: RiskHigh}, ModelTerra, EffortHigh},
-		{"confirmation", ReviewConfirmation(Input{Risk: RiskHigh}), ModelSol, EffortHigh},
-		{"test never inherits Sol", Input{Purpose: "test", Risk: RiskHigh, ReviewConfirmation: true}, ModelTerra, EffortHigh},
+		{"first high-risk review", Input{Harness: "codex", Purpose: "review", Risk: RiskHigh}, ModelLuna, EffortXHigh},
+		{"high-risk fixer", Input{Harness: "codex", Purpose: "review-fix", Risk: RiskHigh}, ModelTerra, EffortHigh},
+		{"confirmation", ReviewConfirmation(Input{Harness: "codex", Risk: RiskHigh}), ModelSol, EffortHigh},
+		{"test never inherits Sol", Input{Harness: "codex", Purpose: "test", Risk: RiskHigh, ReviewConfirmation: true}, ModelTerra, EffortHigh},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got := Decide(tc.in)
@@ -47,7 +47,7 @@ func TestDecideAllowsSolOnlyAfterHighRiskReviewClassification(t *testing.T) {
 	}
 }
 
-func TestConfigFingerprintIsBoundedAndDeterministic(t *testing.T) {
+func TestConfigFingerprintIsStreamingAndDeterministic(t *testing.T) {
 	a := ConfigFingerprint(string(make([]byte, 10_000)))
 	b := ConfigFingerprint(string(make([]byte, 10_000)))
 	if a == "" || a != b || len(a) != 24 {
@@ -56,10 +56,22 @@ func TestConfigFingerprintIsBoundedAndDeterministic(t *testing.T) {
 	changedTail := string(make([]byte, 10_000))
 	changedTail = changedTail[:9_999] + "x"
 	if a == ConfigFingerprint(changedTail) {
-		t.Fatal("bounded fingerprint ignored a tail configuration change")
+		t.Fatal("fingerprint ignored a tail configuration change")
+	}
+	changedMiddle := string(make([]byte, 10_000))
+	changedMiddle = changedMiddle[:5_000] + "x" + changedMiddle[5_001:]
+	if a == ConfigFingerprint(changedMiddle) {
+		t.Fatal("same-length middle configuration edit did not change fingerprint")
 	}
 	if got := CanonicalRepository("git@GitHub.com:RaFoyer/No-Mistakes.git"); got != "github.com/rafoyer/no-mistakes" {
 		t.Fatalf("canonical repository = %q", got)
+	}
+}
+
+func TestDecideDoesNotClaimGPTRouteForNonCodexHarness(t *testing.T) {
+	d := Decide(Input{Harness: "claude", Purpose: "review", Risk: RiskUnknown})
+	if d.EffectiveModel != "" || d.EffectiveEffort != "" {
+		t.Fatalf("non-Codex route = %s/%s, want no unreceived GPT controls", d.EffectiveModel, d.EffectiveEffort)
 	}
 }
 

--- a/internal/routing/routing_test.go
+++ b/internal/routing/routing_test.go
@@ -1,0 +1,64 @@
+package routing
+
+import "testing"
+
+func TestDecideBootstrapsReviewOnLuna(t *testing.T) {
+	d := Decide(Input{Harness: "codex", Purpose: "review", Risk: RiskUnknown, Repository: "https://GitHub.com/RaFoyer/no-mistakes.git"})
+	if d.EffectiveModel != ModelLuna || d.EffectiveEffort != EffortXHigh {
+		t.Fatalf("initial review route = %s/%s, want Luna/xhigh", d.EffectiveModel, d.EffectiveEffort)
+	}
+	if d.Phase != "review" || d.Repository != "github.com/rafoyer/no-mistakes" {
+		t.Fatalf("route metadata = %+v", d)
+	}
+}
+
+func TestDecideUsesTerraForMediumHighNonReviewWork(t *testing.T) {
+	d := Decide(Input{Harness: "codex", Purpose: "test-evidence", Risk: RiskMedium})
+	if d.EffectiveModel != ModelTerra || d.EffectiveEffort != EffortHigh {
+		t.Fatalf("medium-risk route = %s/%s, want Terra/high", d.EffectiveModel, d.EffectiveEffort)
+	}
+}
+
+func TestDecideAllowsSolOnlyAfterHighRiskReviewClassification(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		in     Input
+		want   string
+		effort string
+	}{
+		{"first high-risk review", Input{Purpose: "review", Risk: RiskHigh}, ModelLuna, EffortXHigh},
+		{"high-risk fixer", Input{Purpose: "review-fix", Risk: RiskHigh}, ModelTerra, EffortHigh},
+		{"confirmation", ReviewConfirmation(Input{Risk: RiskHigh}), ModelSol, EffortHigh},
+		{"test never inherits Sol", Input{Purpose: "test", Risk: RiskHigh, ReviewConfirmation: true}, ModelTerra, EffortHigh},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Decide(tc.in)
+			if got.EffectiveModel != tc.want {
+				t.Fatalf("route = %s/%s, want %s", got.EffectiveModel, got.EffectiveEffort, tc.want)
+			}
+			wantEffort := tc.effort
+			if wantEffort == "" {
+				wantEffort = EffortXHigh
+			}
+			if got.EffectiveEffort != wantEffort {
+				t.Fatalf("effort = %s, want %s", got.EffectiveEffort, wantEffort)
+			}
+		})
+	}
+}
+
+func TestConfigFingerprintIsBoundedAndDeterministic(t *testing.T) {
+	a := ConfigFingerprint(string(make([]byte, 10_000)))
+	b := ConfigFingerprint(string(make([]byte, 10_000)))
+	if a == "" || a != b || len(a) != 24 {
+		t.Fatalf("fingerprint = %q, want deterministic 24 hex chars", a)
+	}
+	changedTail := string(make([]byte, 10_000))
+	changedTail = changedTail[:9_999] + "x"
+	if a == ConfigFingerprint(changedTail) {
+		t.Fatal("bounded fingerprint ignored a tail configuration change")
+	}
+	if got := CanonicalRepository("git@GitHub.com:RaFoyer/No-Mistakes.git"); got != "github.com/rafoyer/no-mistakes" {
+		t.Fatalf("canonical repository = %q", got)
+	}
+}

--- a/internal/routing/routing_test.go
+++ b/internal/routing/routing_test.go
@@ -62,3 +62,18 @@ func TestConfigFingerprintIsBoundedAndDeterministic(t *testing.T) {
 		t.Fatalf("canonical repository = %q", got)
 	}
 }
+
+func TestDecideBoundsAndValidatesUntrustedRouteMetadata(t *testing.T) {
+	d := Decide(Input{
+		Harness:    string(make([]byte, 10_000)),
+		Risk:       Risk("unexpected-risk"),
+		Repository: "https://example.com/" + string(make([]byte, 10_000)),
+		Purpose:    "test",
+	})
+	if d.Risk != RiskUnknown {
+		t.Fatalf("risk = %q, want unknown", d.Risk)
+	}
+	if len(d.RequestedHarness) > 128 || len(d.Repository) > 512 {
+		t.Fatalf("untrusted route metadata was not bounded: harness=%d repository=%d", len(d.RequestedHarness), len(d.Repository))
+	}
+}

--- a/internal/routing/routing_test.go
+++ b/internal/routing/routing_test.go
@@ -75,6 +75,35 @@ func TestDecideDoesNotClaimGPTRouteForNonCodexHarness(t *testing.T) {
 	}
 }
 
+func TestDecideClearsNonCodexEffectiveControlsAfterEveryRiskBranch(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   Input
+	}{
+		{"medium work", Input{Harness: "claude", Purpose: "test", Risk: RiskMedium}},
+		{"high work", Input{Harness: "pi", Purpose: "review-fix", Risk: RiskHigh}},
+		{"confirmation", ReviewConfirmation(Input{Harness: "acp:copilot", Risk: RiskHigh})},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Decide(tc.in)
+			if got.EffectiveHarness == "codex" || got.EffectiveModel != "" || got.EffectiveEffort != "" {
+				t.Fatalf("non-Codex effective evidence = %+v", got)
+			}
+		})
+	}
+}
+
+func TestForAdapterPreservesRequestedRouteButRebindsEffectiveProvider(t *testing.T) {
+	base := Decide(Input{Harness: "pi", Purpose: "review-fix", Risk: RiskHigh})
+	got := ForAdapter(base, "claude")
+	if got.RequestedHarness != "pi" || got.EffectiveHarness != "claude" {
+		t.Fatalf("provider attribution = %+v", got)
+	}
+	if got.EffectiveModel != "" || got.EffectiveEffort != "" {
+		t.Fatalf("non-Codex controls = %+v", got)
+	}
+}
+
 func TestDecideBoundsAndValidatesUntrustedRouteMetadata(t *testing.T) {
 	d := Decide(Input{
 		Harness:    string(make([]byte, 10_000)),

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -289,10 +289,31 @@ no-mistakes axi abort         # cancel the current-branch active run
 no-mistakes axi abort --run <id>   # cancel a specific run by id (works outside its worktree)
 ` + "```" + `
 
+## Reliability and recovery
+
+Run creation is asynchronous: after the run row is durable, ` + "`axi status`" + `
+shows the persisted provisioning phase and progress while the daemon prepares
+the worktree. A cancellation can stop queued or active provisioning, and a
+daemon restart safely re-queues unfinished setup.
+
+No Mistakes owns agent routing. Initial/default work uses GPT-5.6 Luna with
+` + "`xhigh`" + `; medium/high-risk non-review work uses GPT-5.6 Terra with
+` + "`high`" + `; GPT-5.6 Sol is used only for a high-risk review confirmation and
+always with ` + "`high`" + `. The initial review is the bootstrap risk classifier,
+so it cannot select Sol for itself. Tests, docs, lint, and other phases do not
+inherit Sol from a high-risk run.
+
+If Codex reports ` + "`AuthorizationRequired`" + `, the run parks with an
+authentication blockage. Log into a healthy Codex account and approve the gate
+with ` + "`no-mistakes axi respond --action approve`" + `. Do not blindly replay a
+fixer turn whose completion is unknown; restart recovery preserves the run,
+worktree, session metadata, and failure history for an explicit decision.
+
 ## Reading the output
 
 - Output is TOON: ` + "`key: value`" + ` pairs, ` + "`name[N]{cols}:`" + ` tables, and ` + "`help[N]:`" + ` hints.
 - A non-terminal run object may include ` + "`awaiting_agent: parked <duration>`" + ` immediately after ` + "`status`" + `; that means the run is parked at a gate awaiting your ` + "`axi respond`" + `.
+- During slow checkout or agent setup, ` + "`status`" + ` may be ` + "`provisioning`" + ` with persisted ` + "`provisioning_phase`" + ` and ` + "`provisioning_progress`" + `; cancel it with ` + "`axi abort --run <id>`" + `. If Codex reports ` + "`AuthorizationRequired`" + `, the run is parked as ` + "`awaiting_auth`" + ` with a ` + "`blocked_reason`" + `. Log into a healthy account, then use ` + "`axi respond --action approve`" + ` for one bounded retry; do not blindly replay a fixer whose completion is unknown.
 - A run object with a ` + "`running`" + ` or ` + "`fixing`" + ` step may include an ` + "`active_steps`" + ` table. Use it to see the active duration, latest activity, native agent PID, and current execution or fix round.
 - The ` + "`help`" + ` list at the bottom of most responses tells you the next commands to run.
 - Errors are printed as ` + "`error: ...`" + ` on stdout with a ` + "`help`" + ` list; act on the suggestion.

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -10,11 +10,13 @@ import (
 type RunStatus string
 
 const (
-	RunPending   RunStatus = "pending"
-	RunRunning   RunStatus = "running"
-	RunCompleted RunStatus = "completed"
-	RunFailed    RunStatus = "failed"
-	RunCancelled RunStatus = "cancelled"
+	RunPending      RunStatus = "pending"
+	RunProvisioning RunStatus = "provisioning"
+	RunRunning      RunStatus = "running"
+	RunCompleted    RunStatus = "completed"
+	RunFailed       RunStatus = "failed"
+	RunCancelled    RunStatus = "cancelled"
+	RunAwaitingAuth RunStatus = "awaiting_auth"
 )
 
 const (

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -934,6 +934,31 @@ func TestUpdaterMaybeNotifyAndCheck(t *testing.T) {
 	}
 }
 
+func TestUpdaterDoesNotNotifyForBaseReleaseOfDevelopmentBuild(t *testing.T) {
+	cachePath := filepath.Join(t.TempDir(), "update-check.json")
+	if err := writeCache(cachePath, &checkCache{
+		CheckedAt:     time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC),
+		LatestVersion: "v1.37.0",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	stderr := new(bytes.Buffer)
+	u := &updater{
+		appName:        "no-mistakes",
+		currentVersion: "v1.37.0-19-g285c8ee",
+		cachePath:      cachePath,
+		stderr:         stderr,
+		now:            func() time.Time { return time.Date(2026, 7, 16, 12, 1, 0, 0, time.UTC) },
+	}
+
+	u.maybeNotifyAndCheck([]string{"status"})
+
+	if stderr.Len() != 0 {
+		t.Fatalf("development build should not be offered its base release, got %q", stderr.String())
+	}
+}
+
 func TestUpdaterCheckLatestBetaUsesReleasesList(t *testing.T) {
 	allowInsecureDownloads = true
 	t.Cleanup(func() { allowInsecureDownloads = false })

--- a/internal/update/version.go
+++ b/internal/update/version.go
@@ -2,16 +2,23 @@ package update
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 )
 
 type semVersion struct {
-	major      int
-	minor      int
-	patch      int
-	prerelease []string
+	major       int
+	minor       int
+	patch       int
+	prerelease  []string
+	development bool
 }
+
+var (
+	gitDescribeSuffix = regexp.MustCompile(`-\d+-g[0-9a-fA-F]+$`)
+	gitDescribeMarker = regexp.MustCompile(`-\d+-g`)
+)
 
 func compareVersions(a, b string) (int, error) {
 	va, err := parseVersion(a)
@@ -32,12 +39,45 @@ func parseVersion(raw string) (semVersion, error) {
 		return semVersion{}, fmt.Errorf("parse version %q: empty", raw)
 	}
 
-	trimmed, _, _ = strings.Cut(trimmed, "+")
+	development := false
+	if strings.HasSuffix(trimmed, "-dirty") {
+		trimmed = strings.TrimSuffix(trimmed, "-dirty")
+		development = true
+	}
+	if match := gitDescribeSuffix.FindStringIndex(trimmed); match != nil {
+		trimmed = trimmed[:match[0]]
+		development = true
+	} else if gitDescribeMarker.MatchString(trimmed) {
+		return semVersion{}, fmt.Errorf("parse version %q: malformed git-describe suffix", raw)
+	}
+
+	v, err := parseSemVersion(trimmed, raw)
+	if err != nil {
+		return semVersion{}, err
+	}
+	v.development = development
+	return v, nil
+}
+
+func parseSemVersion(trimmed, raw string) (semVersion, error) {
+	if strings.Count(trimmed, "+") > 1 {
+		return semVersion{}, fmt.Errorf("parse version %q: invalid build metadata", raw)
+	}
+
+	if before, metadata, ok := strings.Cut(trimmed, "+"); ok {
+		if metadata == "" || !validVersionIdentifiers(metadata, true) {
+			return semVersion{}, fmt.Errorf("parse version %q: invalid build metadata", raw)
+		}
+		trimmed = before
+	}
 	core := trimmed
 	pre := ""
 	if before, after, ok := strings.Cut(trimmed, "-"); ok {
 		core = before
 		pre = after
+		if pre == "" {
+			return semVersion{}, fmt.Errorf("parse version %q: empty prerelease", raw)
+		}
 	}
 
 	parts := strings.Split(core, ".")
@@ -51,7 +91,7 @@ func parseVersion(raw string) (semVersion, error) {
 	}
 	ints := []*int{&v.major, &v.minor, &v.patch}
 	for i, part := range parts {
-		if part == "" {
+		if part == "" || (len(part) > 1 && part[0] == '0') {
 			return semVersion{}, fmt.Errorf("parse version %q: empty numeric segment", raw)
 		}
 		n, err := strconv.Atoi(part)
@@ -64,14 +104,57 @@ func parseVersion(raw string) (semVersion, error) {
 	if pre != "" {
 		idents := strings.Split(pre, ".")
 		for _, ident := range idents {
-			if ident == "" {
+			if ident == "" || !validVersionIdentifier(ident) {
 				return semVersion{}, fmt.Errorf("parse version %q: empty prerelease segment", raw)
+			}
+			if isNumericIdentifier(ident) && len(ident) > 1 && ident[0] == '0' {
+				return semVersion{}, fmt.Errorf("parse version %q: invalid numeric prerelease segment %q", raw, ident)
 			}
 			v.prerelease = append(v.prerelease, ident)
 		}
 	}
 
 	return v, nil
+}
+
+func validVersionIdentifiers(raw string, allowDots bool) bool {
+	if raw == "" {
+		return false
+	}
+	if allowDots {
+		for _, ident := range strings.Split(raw, ".") {
+			if !validVersionIdentifier(ident) {
+				return false
+			}
+		}
+		return true
+	}
+	return validVersionIdentifier(raw)
+}
+
+func validVersionIdentifier(ident string) bool {
+	if ident == "" {
+		return false
+	}
+	for i := 0; i < len(ident); i++ {
+		c := ident[i]
+		if (c < '0' || c > '9') && (c < 'A' || c > 'Z') && (c < 'a' || c > 'z') && c != '-' {
+			return false
+		}
+	}
+	return true
+}
+
+func isNumericIdentifier(ident string) bool {
+	if ident == "" {
+		return false
+	}
+	for i := 0; i < len(ident); i++ {
+		if ident[i] < '0' || ident[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func isDevVersion(version string) bool {
@@ -94,7 +177,7 @@ func (v semVersion) compare(other semVersion) int {
 	}
 
 	if len(v.prerelease) == 0 && len(other.prerelease) == 0 {
-		return 0
+		return cmpInt(boolInt(v.development), boolInt(other.development))
 	}
 	if len(v.prerelease) == 0 {
 		return 1
@@ -108,7 +191,17 @@ func (v semVersion) compare(other semVersion) int {
 			return diff
 		}
 	}
-	return cmpInt(len(v.prerelease), len(other.prerelease))
+	if diff := cmpInt(len(v.prerelease), len(other.prerelease)); diff != 0 {
+		return diff
+	}
+	return cmpInt(boolInt(v.development), boolInt(other.development))
+}
+
+func boolInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
 }
 
 func comparePrereleaseIdentifier(a, b string) int {

--- a/internal/update/version_test.go
+++ b/internal/update/version_test.go
@@ -25,6 +25,13 @@ func TestCompareVersions(t *testing.T) {
 		{name: "prerelease with build metadata", a: "v1.2.3-rc1+abc", b: "v1.2.3-rc1+def", wantCmp: 0},
 		{name: "different prerelease lengths", a: "v1.2.3-alpha.1", b: "v1.2.3-alpha", wantCmp: 1},
 		{name: "numeric prerelease less than string", a: "v1.2.3-1", b: "v1.2.3-alpha", wantCmp: -1},
+		{name: "ahead of release git describe is newer than its base", a: "v1.37.0-19-g285c8ee", b: "v1.37.0", wantCmp: 1},
+		{name: "dirty ahead of release git describe is newer than its base", a: "v1.37.0-19-g285c8ee-dirty", b: "v1.37.0", wantCmp: 1},
+		{name: "dirty tagged development build is newer than its base", a: "v1.37.0-dirty", b: "v1.37.0", wantCmp: 1},
+		{name: "ahead build still accepts a genuinely later release", a: "v1.37.0-19-g285c8ee", b: "v1.38.0", wantCmp: -1},
+		{name: "beta is older than its stable release", a: "v1.38.0-beta.1", b: "v1.38.0", wantCmp: -1},
+		{name: "beta policy can compare a later beta", a: "v1.37.0", b: "v1.38.0-beta.1", wantCmp: -1},
+		{name: "development build from beta tag stays ahead of that beta", a: "v1.38.0-beta.1-2-g285c8ee", b: "v1.38.0-beta.1", wantCmp: 1},
 	}
 
 	for _, tt := range tests {
@@ -41,7 +48,45 @@ func TestCompareVersions(t *testing.T) {
 }
 
 func TestCompareVersionsRejectsInvalid(t *testing.T) {
-	if _, err := compareVersions("dev", "v1.2.3"); err == nil {
-		t.Fatal("compareVersions should reject non-semver input")
+	tests := []struct {
+		name    string
+		current string
+		latest  string
+	}{
+		{name: "dev", current: "dev", latest: "v1.2.3"},
+		{name: "empty", current: "", latest: "v1.2.3"},
+		{name: "malformed git describe", current: "v1.37.0-19-gnot-a-commit", latest: "v1.37.0"},
+		{name: "empty prerelease", current: "v1.2.3-", latest: "v1.2.3"},
+		{name: "invalid build metadata", current: "v1.2.3+", latest: "v1.2.3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := compareVersions(tt.current, tt.latest); err == nil {
+				t.Fatalf("compareVersions(%q, %q) should reject malformed current version", tt.current, tt.latest)
+			}
+		})
+	}
+}
+
+func TestIsDevVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		{version: "dev", want: true},
+		{version: "285c8ee", want: true},
+		{version: "285c8ee-dirty", want: true},
+		{version: "v1.37.0-19-g285c8ee", want: false},
+		{version: "v1.37.0-19-g285c8ee-dirty", want: false},
+		{version: "v1.37.0", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			if got := isDevVersion(tt.version); got != tt.want {
+				t.Fatalf("isDevVersion(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
 	}
 }

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -250,10 +250,31 @@ no-mistakes axi abort         # cancel the current-branch active run
 no-mistakes axi abort --run <id>   # cancel a specific run by id (works outside its worktree)
 ```
 
+## Reliability and recovery
+
+Run creation is asynchronous: after the run row is durable, `axi status`
+shows the persisted provisioning phase and progress while the daemon prepares
+the worktree. A cancellation can stop queued or active provisioning, and a
+daemon restart safely re-queues unfinished setup.
+
+No Mistakes owns agent routing. Initial/default work uses GPT-5.6 Luna with
+`xhigh`; medium/high-risk non-review work uses GPT-5.6 Terra with
+`high`; GPT-5.6 Sol is used only for a high-risk review confirmation and
+always with `high`. The initial review is the bootstrap risk classifier,
+so it cannot select Sol for itself. Tests, docs, lint, and other phases do not
+inherit Sol from a high-risk run.
+
+If Codex reports `AuthorizationRequired`, the run parks with an
+authentication blockage. Log into a healthy Codex account and approve the gate
+with `no-mistakes axi respond --action approve`. Do not blindly replay a
+fixer turn whose completion is unknown; restart recovery preserves the run,
+worktree, session metadata, and failure history for an explicit decision.
+
 ## Reading the output
 
 - Output is TOON: `key: value` pairs, `name[N]{cols}:` tables, and `help[N]:` hints.
 - A non-terminal run object may include `awaiting_agent: parked <duration>` immediately after `status`; that means the run is parked at a gate awaiting your `axi respond`.
+- During slow checkout or agent setup, `status` may be `provisioning` with persisted `provisioning_phase` and `provisioning_progress`; cancel it with `axi abort --run <id>`. If Codex reports `AuthorizationRequired`, the run is parked as `awaiting_auth` with a `blocked_reason`. Log into a healthy account, then use `axi respond --action approve` for one bounded retry; do not blindly replay a fixer whose completion is unknown.
 - A run object with a `running` or `fixing` step may include an `active_steps` table. Use it to see the active duration, latest activity, native agent PID, and current execution or fix round.
 - The `help` list at the bottom of most responses tells you the next commands to run.
 - Errors are printed as `error: ...` on stdout with a `help` list; act on the suggestion.


### PR DESCRIPTION
## Summary

Implements the approved No Mistakes core reliability redesign from `fc0845a`, preserving safeguards already present on that revision and keeping routing entirely No Mistakes-owned.

- Adds deterministic, repository-neutral phase routing: Luna/xhigh for bootstrap and default work; Terra/high for medium/high-risk work; Sol/high only for a post-classification high-risk review confirmation. Every invocation records requested/effective harness, model, effort, policy, phase, reason, source configuration, generation, and privacy-safe prompt evidence. Untrusted route metadata is normalized and bounded.
- Adds additive, transactional SQLite migrations for append-only lifecycle/failure and route-decision evidence while retaining current-state projections. Historical infrastructure failures survive cancellation, supersession, recovery, and shutdown transitions.
- Classifies Codex authorization loss as recoverable infrastructure state, parks runs as `awaiting_auth`, persists blocked reasons across restart, requires explicit operator approval for bounded retry, preserves recovered auth parks during daemon shutdown, and explicitly calls out unknown fixer-turn completion/idempotency before retry.
- Moves full agent prompts to stdin or protected temporary files, bounds argv, cleans schema transport artifacts, and covers a 3 MiB prompt regression.
- Makes worktree provisioning asynchronous, persisted, cancellable, bounded, and restart-safe, with ownership and cleanup guards preserved.
- Updates daemon, CLI, agent documentation and regenerates the canonical skill.

## Migration and operation

Existing SQLite homes migrate additively and atomically on open; no historical event rows are deleted or rewritten. Persisted provisioning and authorization states are recovered after daemon restart. After Codex account refresh/login, the operator approves the bounded retry; an unknown-completion fixer turn is never automatically replayed. Routing configuration changes are represented by an explicit generation/fingerprint and captured in route evidence.

## Verification

Passed on the final branch in an isolated worktree/home:

- `gofmt -w .`
- `make lint`
- `go test ./...`
- `go test -race ./...`
- `make e2e`
- `go build -o ./bin/no-mistakes ./cmd/no-mistakes`
- Focused routing-policy, Sol/high bootstrap, bounded metadata, auth parking/retry/restart/shutdown, append-only evidence, prompt transport/3 MiB stdin, provisioning queue/cancel/restart, and migration compatibility tests

Initial Luna review classification: **high risk**, because this changes routing policy, daemon lifecycle, authentication recovery, prompt transport, and persistence. Sol/high is permitted only after that classification and only for the review-confirmation phase; tests, docs, lint, and unrelated phases cannot inherit Sol.

No Flow router, Flow checkout, Flow manifest, or Flow fingerprint is used by the implementation.

## Review boundary

Ready for independent adversarial review. This PR is intentionally unmerged; captain approval remains required.
