### PR TITLE
fix(agent): send Claude prompts through stdin

### DIFF
--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -69,10 +69,10 @@ func (a *claudeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error
 	if opts.Session != nil {
 		resumeID = opts.Session.ID
 	}
-	args := a.buildArgs(opts.Prompt, opts.JSONSchema, resumeID)
+	args := a.buildArgs(opts.JSONSchema, resumeID)
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD
-	cmd.Stdin = nil
+	cmd.Stdin = strings.NewReader(opts.Prompt)
 	cmd.Env = gitSafeEnv(opts.CWD)
 	shellenv.ConfigureShellCommand(cmd)
 
@@ -166,11 +166,11 @@ func finalizeClaudeResult(result *claudeResult, schema json.RawMessage, usage To
 // is not added. A non-empty resumeID continues that session via --resume
 // (never --fork-session: the session identity must stay stable so later
 // turns keep resuming the same conversation).
-func (a *claudeAgent) buildArgs(prompt string, schema json.RawMessage, resumeID string) []string {
+func (a *claudeAgent) buildArgs(schema json.RawMessage, resumeID string) []string {
 	args := make([]string, 0, len(a.extraArgs)+12)
 	args = append(args, a.extraArgs...)
 	args = append(args,
-		"-p", prompt,
+		"-p",
 		"--verbose",
 		"--output-format", "stream-json",
 	)

--- a/internal/agent/claude_test.go
+++ b/internal/agent/claude_test.go
@@ -12,12 +12,12 @@ import (
 func TestClaudeAgent_BuildArgs(t *testing.T) {
 	ca := &claudeAgent{bin: "/usr/bin/claude"}
 	schema := json.RawMessage(`{"type":"object"}`)
-	args := ca.buildArgs("do something", schema, "")
+	args := ca.buildArgs(schema, "")
 
 	// Default (no opt-out): pristine args, no setting-sources restriction -
 	// ordinary repos keep loading project CLAUDE.md/AGENTS.md (backward-compat).
 	expected := []string{
-		"-p", "do something",
+		"-p",
 		"--verbose",
 		"--output-format", "stream-json",
 		"--json-schema", `{"type":"object"}`,
@@ -36,7 +36,7 @@ func TestClaudeAgent_BuildArgs(t *testing.T) {
 
 func TestClaudeAgent_BuildArgs_NoSchema(t *testing.T) {
 	ca := &claudeAgent{bin: "claude"}
-	args := ca.buildArgs("prompt", nil, "")
+	args := ca.buildArgs(nil, "")
 
 	// Without schema, should not include --json-schema flag
 	for _, arg := range args {
@@ -45,18 +45,18 @@ func TestClaudeAgent_BuildArgs_NoSchema(t *testing.T) {
 		}
 	}
 	// Should still have core args
-	if args[0] != "-p" || args[1] != "prompt" {
-		t.Error("missing -p flag")
+	if len(args) < 2 || args[0] != "-p" || args[1] != "--verbose" {
+		t.Errorf("expected bare -p print flag, got %v", args)
 	}
 }
 
 func TestClaudeAgent_BuildArgs_ExtraArgsPrepended(t *testing.T) {
 	ca := &claudeAgent{bin: "claude", extraArgs: []string{"--model", "sonnet"}}
-	args := ca.buildArgs("do it", nil, "")
+	args := ca.buildArgs(nil, "")
 
 	expected := []string{
 		"--model", "sonnet",
-		"-p", "do it",
+		"-p",
 		"--verbose",
 		"--output-format", "stream-json",
 		"--dangerously-skip-permissions",
@@ -79,7 +79,7 @@ func TestClaudeAgent_BuildArgs_UserPermissionModeSuppressesDefault(t *testing.T)
 	}
 	for _, extra := range tests {
 		ca := &claudeAgent{bin: "claude", extraArgs: extra}
-		args := ca.buildArgs("p", nil, "")
+		args := ca.buildArgs(nil, "")
 
 		dangerCount := 0
 		for _, a := range args {
@@ -458,7 +458,7 @@ func TestParseClaudeEvents_ResultCapturesRawEvent(t *testing.T) {
 // does not.
 func TestClaudeAgent_BuildArgs_SuppressesProjectMemoryUnderOptOut(t *testing.T) {
 	ca := &claudeAgent{bin: "claude", disableProjectSettings: true}
-	args := ca.buildArgs("review the diff", nil, "")
+	args := ca.buildArgs(nil, "")
 	if !claudeArgsContainPair(args, "--setting-sources", "user") {
 		t.Errorf("buildArgs = %v, want a `--setting-sources user` pair", args)
 	}
@@ -469,7 +469,7 @@ func TestClaudeAgent_BuildArgs_SuppressesProjectMemoryUnderOptOut(t *testing.T) 
 // loads its project memory exactly as before.
 func TestClaudeAgent_BuildArgs_NoSuppressionWithoutOptOut(t *testing.T) {
 	ca := &claudeAgent{bin: "claude"}
-	args := ca.buildArgs("review the diff", nil, "")
+	args := ca.buildArgs(nil, "")
 	for _, a := range args {
 		if a == "--setting-sources" {
 			t.Errorf("buildArgs = %v, must not restrict setting-sources when the repo did not opt out", args)
@@ -481,7 +481,7 @@ func TestClaudeAgent_BuildArgs_NoSuppressionWithoutOptOut(t *testing.T) {
 // who pinned their own --setting-sources is not double-set even under opt-out.
 func TestClaudeAgent_BuildArgs_UserSettingSourcesOverrideWins(t *testing.T) {
 	ca := &claudeAgent{bin: "claude", disableProjectSettings: true, extraArgs: []string{"--setting-sources", "user,project"}}
-	args := ca.buildArgs("p", nil, "")
+	args := ca.buildArgs(nil, "")
 	if claudeArgsContainPair(args, "--setting-sources", "user") {
 		t.Errorf("buildArgs = %v, must not add default over a user --setting-sources", args)
 	}

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -36,14 +36,17 @@ func TestSupportsSessionResume_PerAdapter(t *testing.T) {
 
 func TestClaudeAgent_BuildArgs_Resume(t *testing.T) {
 	ca := &claudeAgent{bin: "claude"}
-	args := ca.buildArgs("re-review the branch", nil, "sess-1234")
+	args := ca.buildArgs(nil, "sess-1234")
 
 	joined := strings.Join(args, " ")
 	if !strings.Contains(joined, "--resume sess-1234") {
 		t.Fatalf("resume args missing --resume <id>: %v", args)
 	}
-	if !strings.Contains(joined, "-p re-review the branch") {
-		t.Fatalf("resume args must keep print-mode prompt: %v", args)
+	if !strings.Contains(joined, "-p") {
+		t.Fatalf("resume args must keep print mode: %v", args)
+	}
+	if strings.Contains(joined, "re-review the branch") {
+		t.Fatalf("resume args must not include the prompt: %v", args)
 	}
 	if strings.Contains(joined, "--fork-session") {
 		t.Fatalf("resume must continue the same session, not fork: %v", args)
@@ -52,7 +55,7 @@ func TestClaudeAgent_BuildArgs_Resume(t *testing.T) {
 
 func TestClaudeAgent_BuildArgs_NoResumeByDefault(t *testing.T) {
 	ca := &claudeAgent{bin: "claude"}
-	args := ca.buildArgs("review", nil, "")
+	args := ca.buildArgs(nil, "")
 	for _, a := range args {
 		if a == "--resume" {
 			t.Fatalf("cold invocation must not pass --resume: %v", args)


### PR DESCRIPTION
## Summary

- send Claude print-mode prompts through standard input instead of a single `-p <prompt>` argument
- keep `-p`, streaming output, session resume, schemas, and permission flags intact
- update argument-construction tests to assert the prompt is absent from argv

Fixes #485

## Root cause

Large pipeline prompts, including captured test output, were passed as one command-line argument. On Linux a single argv entry has a much smaller limit than the total process argument budget, so large `fix-tests` prompts failed before Claude started with `E2BIG`.

## Validation

- `git diff --check`
- Static review of the focused agent package and its tests

`go`, `gofmt`, and the Makefile test targets could not run locally because this Windows environment has no Go toolchain installed. The repository CI should run the package and full-suite checks.
