### PR TITLE
fix(scm): pass Azure DevOps PR description via temp file to avoid Windows truncation

### DIFF
--- a/internal/scm/azuredevops/azuredevops.go
+++ b/internal/scm/azuredevops/azuredevops.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -143,16 +144,54 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 	return h.toPR(&prs[0]), nil
 }
 
-func (h *Host) CreatePR(ctx context.Context, branch, base string, content scm.PRContent) (*scm.PR, error) {
-	args := []string{"repos", "pr", "create",
-		"--source-branch", branch,
-		"--target-branch", base,
-		"--title", content.Title,
-		"--description", clampDescription(content.Body),
+// runWithDescription runs an az PR command whose description is supplied
+// out-of-band through a temp file referenced as `--description @<file>`, and
+// returns the command's JSON stdout. buildArgs receives the `@<file>` token and
+// returns the full az argv, placing that token where --description's value
+// belongs. The (clamped) body is written to the file before the command runs
+// and the file is always removed afterward.
+//
+// Why a file instead of passing the body inline as `--description <body>`: on
+// Windows the az CLI is a batch shim (az.cmd) that Go executes through cmd.exe.
+// cmd.exe terminates each argument at the first newline, so a multi-line body
+// was truncated to just its first line (e.g. "## Intent"), silently dropping the
+// rest of the PR description - a Windows-only data loss (#501). A file path is a
+// single newline-free token that survives cmd.exe intact, and az reads the
+// description from the file via the "@" convention (see `az repos pr create
+// --help`). The file form additionally sidesteps Python argparse misreading body
+// lines that begin with "-"/"--"/"---" (markdown horizontal rules, diff
+// "--- a/file" hunks) as new options, which a naive per-line split would break on.
+//
+// The body is clamped to Azure DevOps' description cap before it is written, so
+// az never sees an over-length description no matter how the body was produced.
+func (h *Host) runWithDescription(ctx context.Context, body string, buildArgs func(descArg string) []string) ([]byte, error) {
+	f, err := os.CreateTemp("", "nm-pr-desc-*.md")
+	if err != nil {
+		return nil, fmt.Errorf("create PR description temp file: %w", err)
 	}
-	args = append(args, h.scopeArgs()...)
-	args = append(args, "--output", "json")
-	out, err := outputJSON(h.cmd(ctx, "az", args...))
+	path := f.Name()
+	defer os.Remove(path)
+	if _, err := f.WriteString(clampDescription(body)); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("write PR description temp file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return nil, fmt.Errorf("close PR description temp file: %w", err)
+	}
+	return outputJSON(h.cmd(ctx, "az", buildArgs("@"+path)...))
+}
+
+func (h *Host) CreatePR(ctx context.Context, branch, base string, content scm.PRContent) (*scm.PR, error) {
+	out, err := h.runWithDescription(ctx, content.Body, func(descArg string) []string {
+		args := []string{"repos", "pr", "create",
+			"--source-branch", branch,
+			"--target-branch", base,
+			"--title", content.Title,
+			"--description", descArg,
+		}
+		args = append(args, h.scopeArgs()...)
+		return append(args, "--output", "json")
+	})
 	if err != nil {
 		return nil, fmt.Errorf("az repos pr create: %w", err)
 	}
@@ -168,13 +207,14 @@ func (h *Host) UpdatePR(ctx context.Context, pr *scm.PR, content scm.PRContent) 
 	if id == "" {
 		return nil, errors.New("az repos pr update: missing PR id")
 	}
-	args := []string{"repos", "pr", "update", "--id", id,
-		"--title", content.Title,
-		"--description", clampDescription(content.Body),
-	}
-	args = append(args, h.orgArgs()...)
-	args = append(args, "--output", "json")
-	if _, err := outputJSON(h.cmd(ctx, "az", args...)); err != nil {
+	if _, err := h.runWithDescription(ctx, content.Body, func(descArg string) []string {
+		args := []string{"repos", "pr", "update", "--id", id,
+			"--title", content.Title,
+			"--description", descArg,
+		}
+		args = append(args, h.orgArgs()...)
+		return append(args, "--output", "json")
+	}); err != nil {
 		return nil, fmt.Errorf("az repos pr update: %w", err)
 	}
 	return pr, nil

--- a/internal/scm/azuredevops/azuredevops_test.go
+++ b/internal/scm/azuredevops/azuredevops_test.go
@@ -144,11 +144,10 @@ func TestFindPRReportsParseError(t *testing.T) {
 func TestCreatePRConstructsURL(t *testing.T) {
 	t.Parallel()
 
-	h := newTestHost(map[string]azdoTestResponse{
-		"az repos pr create --source-branch feature --target-branch main --title T --description B --organization " + testOrg + " --project " + testProject + " --repository " + testRepo + " --output json": {
-			// az returns an _apis/... url in the top-level field; it must NOT be used.
-			stdout: `{"pullRequestId":7,"url":"https://dev.azure.com/myorg/_apis/git/repositories/abc/pullRequests/7"}` + "\n",
-		},
+	var rec []capturedCmd
+	h := newCapturingHost(&rec, azdoTestResponse{
+		// az returns an _apis/... url in the top-level field; it must NOT be used.
+		stdout: `{"pullRequestId":7,"url":"https://dev.azure.com/myorg/_apis/git/repositories/abc/pullRequests/7"}` + "\n",
 	})
 
 	pr, err := h.CreatePR(context.Background(), "feature", "main", scm.PRContent{Title: "T", Body: "B"})
@@ -161,25 +160,40 @@ func TestCreatePRConstructsURL(t *testing.T) {
 	if pr.URL != "https://dev.azure.com/myorg/myproject/_git/myrepo/pullrequest/7" {
 		t.Fatalf("CreatePR() URL = %q, want constructed browsable URL", pr.URL)
 	}
+	// The command still carries the full create scope; the description is now a
+	// temp-file reference (@<path>) rather than the inline body.
+	if len(rec) != 1 {
+		t.Fatalf("recorded %d commands, want 1", len(rec))
+	}
+	got := strings.Join(append([]string{rec[0].name}, rec[0].args...), " ")
+	wantPrefix := "az repos pr create --source-branch feature --target-branch main --title T --description @"
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Fatalf("command = %q, want prefix %q", got, wantPrefix)
+	}
+	wantSuffix := " --organization " + testOrg + " --project " + testProject + " --repository " + testRepo + " --output json"
+	if !strings.HasSuffix(got, wantSuffix) {
+		t.Fatalf("command = %q, want suffix %q", got, wantSuffix)
+	}
+	if rec[0].descContent != "B" {
+		t.Fatalf("description file content = %q, want %q", rec[0].descContent, "B")
+	}
 }
 
 func TestCreatePRTruncatesOverlongDescription(t *testing.T) {
 	t.Parallel()
 
-	// A body well over Azure DevOps' 4000-character description cap. Before the
-	// clamp, CreatePR passed this verbatim and az rejected it with
-	// "Invalid argument value. ... must not be longer than 4000 characters".
+	// A body well over Azure DevOps' 4000-character description cap. The
+	// connector clamps it before writing the temp file, so az never sees an
+	// over-length description ("Invalid argument value. ... must not be longer
+	// than 4000 characters").
 	body := strings.Repeat("x", 5000)
 	clamped := scm.ClampPRBody(body, scm.MaxPRBodyChars(scm.ProviderAzureDevOps))
 	if scm.PRBodyLen(clamped) > 4000 {
 		t.Fatalf("clamped description left %d units, want <= 4000", scm.PRBodyLen(clamped))
 	}
 
-	key := "az repos pr create --source-branch feature --target-branch main --title T --description " + clamped +
-		" --organization " + testOrg + " --project " + testProject + " --repository " + testRepo + " --output json"
-	h := newTestHost(map[string]azdoTestResponse{
-		key: {stdout: `{"pullRequestId":7}` + "\n"},
-	})
+	var rec []capturedCmd
+	h := newCapturingHost(&rec, azdoTestResponse{stdout: `{"pullRequestId":7}` + "\n"})
 
 	pr, err := h.CreatePR(context.Background(), "feature", "main", scm.PRContent{Title: "T", Body: body})
 	if err != nil {
@@ -187,6 +201,84 @@ func TestCreatePRTruncatesOverlongDescription(t *testing.T) {
 	}
 	if pr.Number != "7" {
 		t.Fatalf("CreatePR() number = %q, want 7", pr.Number)
+	}
+	if len(rec) != 1 {
+		t.Fatalf("recorded %d commands, want 1", len(rec))
+	}
+	if rec[0].descContent != clamped {
+		t.Fatalf("description file content len = %d, want clamped len %d", len(rec[0].descContent), len(clamped))
+	}
+}
+
+// multilineDescriptionBody is a realistic PR body that would break a naive
+// approach: a markdown heading, blank lines, prose, a bare horizontal rule
+// (`---`), and a diff-style line (`--- a/file.go`). Passed inline on Windows the
+// newlines truncate it; split per-line the `---`/`--- a/...` lines get misread
+// as az options.
+const multilineDescriptionBody = "## Intent\n" +
+	"\n" +
+	"Route the PR description through a temp file so multi-line bodies survive.\n" +
+	"\n" +
+	"---\n" +
+	"\n" +
+	"--- a/file.go\n" +
+	"+++ b/file.go\n"
+
+func TestCreatePRWritesMultilineDescriptionToFile(t *testing.T) {
+	t.Parallel()
+
+	var rec []capturedCmd
+	h := newCapturingHost(&rec, azdoTestResponse{stdout: `{"pullRequestId":7}` + "\n"})
+
+	if _, err := h.CreatePR(context.Background(), "feature", "main", scm.PRContent{Title: "T", Body: multilineDescriptionBody}); err != nil {
+		t.Fatalf("CreatePR() error = %v", err)
+	}
+	assertDescriptionRoundTrips(t, rec, multilineDescriptionBody)
+}
+
+func TestUpdatePRWritesMultilineDescriptionToFile(t *testing.T) {
+	t.Parallel()
+
+	var rec []capturedCmd
+	h := newCapturingHost(&rec, azdoTestResponse{stdout: `{"pullRequestId":42}` + "\n"})
+
+	if _, err := h.UpdatePR(context.Background(), &scm.PR{Number: "42"}, scm.PRContent{Title: "T", Body: multilineDescriptionBody}); err != nil {
+		t.Fatalf("UpdatePR() error = %v", err)
+	}
+	assertDescriptionRoundTrips(t, rec, multilineDescriptionBody)
+}
+
+// assertDescriptionRoundTrips verifies the recorded az command passed its PR
+// description through a temp file (not inline): the --description value is an
+// @<file> reference, the file held exactly body while the command ran, no
+// argument contained a newline (which cmd.exe would truncate) or the raw body,
+// and the temp file was cleaned up once the call returned.
+func assertDescriptionRoundTrips(t *testing.T, rec []capturedCmd, body string) {
+	t.Helper()
+	if len(rec) != 1 {
+		t.Fatalf("recorded %d commands, want 1", len(rec))
+	}
+	c := rec[0]
+	if !strings.HasPrefix(c.descPath, "@") {
+		t.Fatalf("--description value = %q, want an @<file> reference", c.descPath)
+	}
+	if !c.descExists {
+		t.Fatal("description temp file did not exist while the command ran")
+	}
+	if c.descContent != body {
+		t.Fatalf("description file content = %q, want %q", c.descContent, body)
+	}
+	for _, a := range c.args {
+		if strings.Contains(a, "\n") {
+			t.Fatalf("arg %q contains a newline; cmd.exe would truncate it at the first line", a)
+		}
+		if strings.Contains(a, body) {
+			t.Fatalf("raw body leaked into arg %q; it must travel via the temp file", a)
+		}
+	}
+	path := strings.TrimPrefix(c.descPath, "@")
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("temp file %q still exists after the call (stat err = %v); cleanup is missing", path, err)
 	}
 }
 
@@ -363,6 +455,50 @@ type azdoTestResponse struct {
 	stdout string
 	stderr string
 	code   int
+}
+
+// capturedCmd records one az invocation for tests that need to inspect how the
+// PR description was passed. descContent is read from the @<file> reference at
+// invocation time, while the temp file still exists (it is removed once the call
+// returns), so tests can assert the body round-tripped exactly.
+type capturedCmd struct {
+	name        string
+	args        []string
+	descPath    string // the value following --description, including the leading "@"
+	descContent string // contents of the temp file the description referenced
+	descExists  bool   // whether that file existed and was readable during the run
+}
+
+func newCapturingHost(rec *[]capturedCmd, response azdoTestResponse) *Host {
+	return New(capturingCmdFactory(rec, response), func() bool { return true }, testOrg, testProject, testRepo)
+}
+
+// capturingCmdFactory records every invocation (and the referenced description
+// file's contents) into rec, and answers each one with the same fixed response.
+func capturingCmdFactory(rec *[]capturedCmd, response azdoTestResponse) CmdFactory {
+	return func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		c := capturedCmd{name: name, args: append([]string(nil), args...)}
+		for i, a := range args {
+			if a == "--description" && i+1 < len(args) {
+				c.descPath = args[i+1]
+				if p := strings.TrimPrefix(c.descPath, "@"); p != c.descPath {
+					if data, err := os.ReadFile(p); err == nil {
+						c.descContent = string(data)
+						c.descExists = true
+					}
+				}
+			}
+		}
+		*rec = append(*rec, c)
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestAzdoHelperProcess", "--")
+		cmd.Env = append(os.Environ(),
+			"AZDO_TEST_HELPER=1",
+			"AZDO_TEST_STDOUT="+response.stdout,
+			"AZDO_TEST_STDERR="+response.stderr,
+			fmt.Sprintf("AZDO_TEST_EXIT_CODE=%d", response.code),
+		)
+		return cmd
+	}
 }
 
 func azdoTestCmdFactory(responses map[string]azdoTestResponse) CmdFactory {


### PR DESCRIPTION
## Intent

Fix issue #501: on Windows, no-mistakes silently truncates multi-line Azure DevOps PR descriptions to their first line. Root cause: Go runs the az CLI as az.cmd via cmd.exe, which terminates each argument at the first newline, so the inline '--description <body>' argument lost everything after the first line (e.g. only '## Intent' survived) - Windows-only data loss. Fix: write the clamped body to a temp file and pass '--description @<file>'; az reads the description from the file via the @ convention, which survives cmd.exe as a single newline-free token and also avoids Python argparse misreading body lines starting with -/--/--- (markdown rules, diff hunks) as options. Deliberate decisions: chose the temp-file @file approach over a per-line split (argparse edge cases) or stdin; kept the existing clampDescription cap applied before writing; fail closed on temp-file write/close errors rather than falling back to the broken inline form; always remove the temp file. The scm.Host interface is unchanged. This branch is a clean cherry-pick of ONLY the fix commit onto upstream/main - no vendoring/ost-patch artifacts - intended for upstreaming against the maintainer-endorsed approach in issue #501 (triage wheelhouse#1410). Tests in azuredevops_test.go cover the temp-file lifecycle, the @file argument, clamping, no-newline-in-args, and cleanup.

## What Changed

- Write the clamped Azure DevOps PR description to a temp file and pass `--description @<file>` instead of inlining the body, so multi-line descriptions survive `az.cmd` invocation through `cmd.exe` on Windows (which previously terminated the argument at the first newline, dropping everything after the first line) and avoid `argparse` misreading lines starting with `-`/`--`/`---`.
- Fail closed on temp-file write/close errors rather than falling back to the broken inline argument, and always remove the temp file after the CLI call; `clampDescription` is still applied before writing and the `scm.Host` interface is unchanged.
- Expanded `azuredevops_test.go` to cover the temp-file lifecycle, the `@file` argument form, clamping, absence of newlines in the argument list, and cleanup.

## Risk Assessment

✅ Low: Well-bounded Windows-only bugfix that faithfully implements the endorsed temp-file @file approach, preserves existing clamping, fails closed on errors, cleans up the temp file, leaves the scm.Host interface unchanged, and is thoroughly covered by new tests.

## Testing

<code>The baseline `go test -race ./...` already passed; I re-ran the full azuredevops package under the race detector and the change&#39;s targeted tests, all green. To show the fix end-to-end the way an end user hits it on Windows, I wrote a throwaway test that runs a real `az.cmd` stub through cmd.exe (the actual truncation culprit): with the OLD inline `--description &lt;body&gt;`, cmd.exe delivered only `...--description &#34;## Intent` — everything after the first newline was dropped, reproducing #501 live; with the connector&#39;s NEW `--description @&lt;file&gt;` path, the stub received the full 120-byte multi-line body byte-for-byte (heading, blank lines, the bare `---`, and the `--- a/file.go`/`+++ b/file.go` diff lines that argparse would otherwise misread). CLI transcripts of both runs are saved as evidence. This is a CLI/backend change with no rendered UI surface, so the appropriate reviewer-visible artifact is the command-line transcript rather than a screenshot. The transient test was copied into the evidence directory and removed from the working tree (clean git status).</code>

<details>
<summary>Evidence: End-to-end cmd.exe reproduction transcript (old inline truncates at first newline; @file delivers full body)</summary>

<code>OLD inline: full command line az.cmd received via cmd.exe (97 bytes):&#10;&#34;repos pr create --source-branch feature --target-branch main --title T --description \&#34;## Intent\r\n&#34;&#10;NEW --description @&lt;file&gt; =&gt; az received 120 bytes:&#10;&#34;## Intent\n\nRoute the PR description through a temp file so multi-line bodies survive.\n\n---\n\n--- a/file.go\n+++ b/file.go\n&#34;&#10;CreatePR returned PR #7&#10;RESULT: inline command line truncated (later lines dropped); the @file form delivered the full 120-byte multi-line description.&#10;--- PASS: TestEvidenceE2ECmdExe</code>

```text
=== RUN   TestEvidenceE2ECmdExe
    zz_evidence_e2e_test.go:91: OLD inline: full command line az.cmd received via cmd.exe (97 bytes):
        "repos pr create --source-branch feature --target-branch main --title T --description \"## Intent\r\n"
    zz_evidence_e2e_test.go:112: NEW --description @<file> => az received 120 bytes:
        "## Intent\n\nRoute the PR description through a temp file so multi-line bodies survive.\n\n---\n\n--- a/file.go\n+++ b/file.go\n"
    zz_evidence_e2e_test.go:113: CreatePR returned PR #7
    zz_evidence_e2e_test.go:125: RESULT: inline command line reaching az was truncated to 97 bytes (later lines dropped); the @file form delivered the full 120-byte multi-line description.
--- PASS: TestEvidenceE2ECmdExe (0.09s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/scm/azuredevops	1.542s
```
</details>
<details>
<summary>Evidence: Transient end-to-end evidence test source (removed from working tree)</summary>

```text
package azuredevops_test

// This is a transient evidence test (not part of the change under review). It
// exercises the #501 fix end-to-end through a REAL cmd.exe on Windows using a
// stub `az.cmd` that mimics az's @file convention, and contrasts it with the
// old inline `--description <body>` form to reproduce the data loss.

import (
	"context"
	"os"
	"os/exec"
	"path/filepath"
	"runtime"
	"strings"
	"testing"

	"github.com/kunchenguid/no-mistakes/internal/scm"
	"github.com/kunchenguid/no-mistakes/internal/scm/azuredevops"
)

const e2eBody = "## Intent\n" +
	"\n" +
	"Route the PR description through a temp file so multi-line bodies survive.\n" +
	"\n" +
	"---\n" +
	"\n" +
	"--- a/file.go\n" +
	"+++ b/file.go\n"

// azStub mimics `az repos pr create`: it locates the --description value and, if
// it starts with "@", copies the referenced file's contents to AZ_STUB_OUT
// (az's @file convention); otherwise it writes the literal value. Then it prints
// stub JSON. This is exactly how the real az CLI resolves the two forms.
const azStub = `@echo off
setlocal enabledelayedexpansion
:parse
if "%~1"=="" goto emit
if "%~1"=="--description" (
  set "DESC=%~2"
  set "FIRST=!DESC:~0,1!"
  if "!FIRST!"=="@" (
    set "FPATH=!DESC:~1!"
    copy /y "!FPATH!" "%AZ_STUB_OUT%" >nul
  ) else (
    > "%AZ_STUB_OUT%" echo|set /p="!DESC!"
  )
)
shift
goto parse
:emit
echo {"pullRequestId":7}
`

// azDump records the entire command line it received (%*) to AZ_STUB_OUT, so the
// control can show exactly how much of the inline description survived cmd.exe.
const azDump = `@echo off
> "%AZ_STUB_OUT%" echo %*
`

func TestEvidenceE2ECmdExe(t *testing.T) {
	if runtime.GOOS != "windows" {
		t.Skip("reproduces the Windows-only cmd.exe truncation")
	}

	dir := t.TempDir()
	stubPath := filepath.Join(dir, "az.cmd")
	if err := os.WriteFile(stubPath, []byte(azStub), 0o755); err != nil {
		t.Fatal(err)
	}
	dumpPath := filepath.Join(dir, "azdump.cmd")
	if err := os.WriteFile(dumpPath, []byte(azDump), 0o755); err != nil {
		t.Fatal(err)
	}

	// --- CONTROL: the OLD inline form, run through the same real cmd.exe. The
	// dump stub records the entire command line az.cmd actually received, so we
	// can see exactly what cmd.exe delivered. ---
	oldOut := filepath.Join(dir, "old.txt")
	oldCmd := exec.Command(dumpPath,
		"repos", "pr", "create",
		"--source-branch", "feature", "--target-branch", "main",
		"--title", "T",
		"--description", e2eBody, // inline multi-line body, as before the fix
		"--output", "json",
	)
	oldCmd.Env = append(os.Environ(), "AZ_STUB_OUT="+oldOut)
	// CombinedOutput errors are irrelevant here: cmd.exe truncation may leave a
	// malformed command line. We only care what reached the stub.
	_, _ = oldCmd.CombinedOutput()
	oldGot, _ := os.ReadFile(oldOut)
	t.Logf("OLD inline: full command line az.cmd received via cmd.exe (%d bytes):\n%q", len(oldGot), string(oldGot))

	// --- FIX: drive the real connector, which writes a temp file and passes
	// --description @<file>, resolved through the same real cmd.exe. ---
	newOut := filepath.Join(dir, "new.txt")
	factory := func(ctx context.Context, name string, args ...string) *exec.Cmd {
		// Emulate production: exec "az" -> resolves az.cmd via cmd.exe. We point
		// at our stub explicitly and inject AZ_STUB_OUT.
		c := exec.CommandContext(ctx, stubPath, args...)
		c.Env = append(os.Environ(), "AZ_STUB_OUT="+newOut)
		return c
	}
	h := azuredevops.New(factory, func() bool { return true },
		"https://dev.azure.com/myorg", "myproject", "myrepo")

	pr, err := h.CreatePR(context.Background(), "feature", "main",
		scm.PRContent{Title: "T", Body: e2eBody})
	if err != nil {
		t.Fatalf("CreatePR: %v", err)
	}
	newGot, _ := os.ReadFile(newOut)
	t.Logf("NEW --description @<file> => az received %d bytes:\n%q", len(newGot), string(newGot))
	t.Logf("CreatePR returned PR #%s", pr.Number)

	// Assertions that make this evidence self-certifying.
	// The inline body's later lines must NOT have survived cmd.exe: the second
	// content line and the diff hunk are gone.
	if strings.Contains(string(oldGot), "Route the PR") || strings.Contains(string(oldGot), "+++ b/file.go") {
		t.Errorf("old inline form unexpectedly preserved later lines; truncation not reproduced: %q", string(oldGot))
	}
	// The fix must deliver the body byte-for-byte.
	if string(newGot) != e2eBody {
		t.Errorf("fix did not round-trip full body.\n got: %q\nwant: %q", string(newGot), e2eBody)
	}
	t.Logf("RESULT: inline command line reaching az was truncated to %d bytes (later lines dropped); "+
		"the @file form delivered the full %d-byte multi-line description.", len(oldGot), len(newGot))
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`
- <code>`go test -race ./internal/scm/azuredevops/` (full package, race detector) — pass</code>
- <code>`go test -race -v -run &#39;TestCreatePR|TestUpdatePR&#39; ./internal/scm/azuredevops/` — pass (multiline round-trip, @file argument, clamping, cleanup)</code>
- <code>Authored a transient end-to-end test `TestEvidenceE2ECmdExe` driving `azuredevops.Host.CreatePR` through a real `az.cmd` stub invoked via cmd.exe, contrasting the old inline form against the new @file form; run then removed from the tree</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
