### PR TITLE
feat(auth): add opt-in managed runtime authorization

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -52,6 +52,7 @@ export default defineConfig({
             { label: "Global Config", slug: "reference/global-config" },
             { label: "Repo Config", slug: "reference/repo-config" },
             { label: "Environment Variables", slug: "reference/environment" },
+            { label: "Managed Authorization", slug: "reference/managed-authorization" },
           ],
         },
       ],

--- a/docs/src/content/docs/reference/environment.md
+++ b/docs/src/content/docs/reference/environment.md
@@ -23,6 +23,31 @@ When set, everything else moves under this root:
 - Managed agent server PID records: `$NM_HOME/servers/`
 - Managed service names get a short stable suffix derived from `$NM_HOME` so multiple installs don't collide.
 
+## Managed authorization
+
+These variables opt one process into the [versioned managed authorization protocol](/no-mistakes/reference/managed-authorization/).
+The presence of any variable in the selected family activates managed parsing, and an incomplete family fails closed.
+They are transient capabilities and must not be stored in shell profiles, git configuration, repository files, or daemon service definitions.
+
+Provider-neutral integrations set:
+
+| Variable | Value |
+| -------- | ----- |
+| `NO_MISTAKES_AUTHORIZATION_MODE` | `managed` |
+| `NO_MISTAKES_AUTHORIZATION_URL` | Verifier HTTP URL |
+| `NO_MISTAKES_AUTHORIZATION_TOKEN` | Short-lived bearer token |
+| `NO_MISTAKES_AUTHORIZATION_TASK_ID` | Durable task ID |
+| `NO_MISTAKES_AUTHORIZATION_RUNTIME_GENERATION` | Live runtime generation |
+| `NO_MISTAKES_AUTHORIZATION_SESSION_ID` | Live session ID |
+| `NO_MISTAKES_AUTHORIZATION_PROJECT` | Canonical project path |
+| `NO_MISTAKES_AUTHORIZATION_REPOSITORY` | Canonical credential-free repository identity |
+| `NO_MISTAKES_AUTHORIZATION_WORKTREE` | Canonical worktree path |
+| `NO_MISTAKES_AUTHORIZATION_BRANCH` | Exact branch |
+| `NO_MISTAKES_AUTHORIZATION_DURABLE_MODE` | `no-mistakes` |
+
+The built-in Perch adapter reads `PERCH_HOOK_URL`, `PERCH_HOOK_TOKEN`, `PERCH_SESSION_ID`, `PERCH_TASK_ID`, `PERCH_RUNTIME_GENERATION`, `PERCH_TASK_PROJECT`, `PERCH_TASK_REPOSITORY`, `PERCH_TASK_WORKTREE`, `PERCH_TASK_BRANCH`, and `PERCH_TASK_MODE`.
+It derives the verifier endpoint from `PERCH_HOOK_URL` and uses the existing hook-token headers.
+
 ## `NM_DAEMON_CONNECT_TIMEOUT`
 
 Override how long a CLI client waits for an existing daemon socket to accept a connection before failing instead of hanging.

--- a/docs/src/content/docs/reference/managed-authorization.md
+++ b/docs/src/content/docs/reference/managed-authorization.md
@@ -1,0 +1,129 @@
+---
+title: Managed Authorization
+description: Opt-in external authorization for orchestrator-managed no-mistakes runs.
+---
+
+Managed authorization lets an external orchestrator decide whether one live task runtime may start or continue the no-mistakes pipeline.
+It is opt-in and versioned.
+Ordinary standalone use is unchanged when no managed environment is present, and unmanaged commands do not contact an authorization service.
+
+## Protected boundaries
+
+A managed run obtains a fresh decision at each expensive or irreversible boundary:
+
+1. `no-mistakes axi run` authorizes `run` before a gate push or rerun request can create a run.
+2. The gate receiver authorizes `gate-push` before `HandlePushReceived` inserts a run row.
+3. Every concrete external-agent attempt authorizes `agent-launch` immediately before the subprocess starts.
+
+Retries, fallback providers, and fresh or resumed agent sessions each authorize again.
+Authorization decisions are never cached.
+
+The daemon persists only a `managed_authorization` marker on the run.
+It does not persist verifier URLs, credentials, task IDs, runtime generations, session IDs, project paths, repository identities, worktree paths, branches, request IDs, or decisions.
+Managed runs cannot resume after a daemon restart because their in-memory capability is intentionally unrecoverable.
+The replacement orchestrator runtime must start a new run with fresh live authorization.
+
+## Protocol version 1
+
+The canonical protocol version is `authorization.ProtocolVersion` in `internal/authorization`.
+`no-mistakes --version` exposes both the build version and `authorization-protocol=1` so a distributor can reject an incompatible binary before activation.
+
+Each request contains:
+
+```json
+{
+  "protocolVersion": "1",
+  "requestId": "one-use-random-identifier",
+  "operation": "run",
+  "taskId": "task-identifier",
+  "runtimeGeneration": 7,
+  "sessionId": "live-session-identifier",
+  "projectPath": "/canonical/project",
+  "repository": "github.com/owner/repository",
+  "worktreePath": "/canonical/project-worktree",
+  "branch": "feature/branch",
+  "durableMode": "no-mistakes"
+}
+```
+
+`operation` is `run`, `gate-push`, or `agent-launch`.
+`requestId` is a one-use nonce generated for each verifier call.
+
+The verifier response must echo every request field and add `allowed` plus a compact `reason`:
+
+```json
+{
+  "protocolVersion": "1",
+  "requestId": "one-use-random-identifier",
+  "operation": "run",
+  "taskId": "task-identifier",
+  "runtimeGeneration": 7,
+  "sessionId": "live-session-identifier",
+  "projectPath": "/canonical/project",
+  "repository": "github.com/owner/repository",
+  "worktreePath": "/canonical/project-worktree",
+  "branch": "feature/branch",
+  "durableMode": "no-mistakes",
+  "allowed": true,
+  "reason": "authorized"
+}
+```
+
+The client proceeds only after HTTP 200, `allowed: true`, durable mode `no-mistakes`, protocol version `1`, and an exact echo of the request scope.
+Missing verifiers, timeouts, connection failures, non-200 responses, denials, malformed JSON, unsupported protocols, stale generations, replayed request IDs, and any scope mismatch fail closed.
+Errors are compact and never include credentials or raw response bodies.
+
+The verifier must atomically reject a previously used `requestId` within the live task/runtime generation.
+It must also independently resolve and verify the durable task mode, current runtime generation, live session, canonical project and repository, worktree, branch, and requested operation.
+Request claims are not authority.
+
+## Configuration
+
+The environment variables are documented in [Environment Variables](/no-mistakes/reference/environment/#managed-authorization).
+The provider-neutral `NO_MISTAKES_AUTHORIZATION_*` form uses an HTTP bearer token.
+The Perch adapter reuses its short-lived task hook token and sends it as `x-perch-token` with `x-perch-session`.
+
+The presence of any recognized managed variable opts the process into managed mode.
+An incomplete managed environment is a denial, not a fallback to standalone behavior.
+The git hook and local daemon IPC carry the minimum transient capability needed for the receiver and agent-launch checks.
+The hook does not put authorization data in git push options, git configuration, or the gate log.
+
+Review-agent child environments remove every `PERCH_*` and `NO_MISTAKES_AUTHORIZATION_*` value.
+Credentials are not included in prompts, SQLite, telemetry, snapshots, crash reports, or user-facing errors.
+
+## Perch integration
+
+Perch should expose the existing task and hook variables plus `PERCH_TASK_REPOSITORY` and `PERCH_RUNTIME_GENERATION` to the task worker.
+`PERCH_TASK_REPOSITORY` must be the canonical credential-free repository identity, such as `github.com/owner/repository`.
+`PERCH_RUNTIME_GENERATION` must be the durable generation of the live runtime that owns `PERCH_SESSION_ID`.
+
+For protocol version 1, Perch's authorization endpoint must accept and validate `protocolVersion`, `requestId`, `operation`, `taskId`, `runtimeGeneration`, `sessionId`, `projectPath`, `repository`, `worktreePath`, `branch`, and `durableMode`.
+It must echo all of those fields with `allowed` and `reason`.
+It must reject reused request IDs, stale generations, non-live runtimes, session mismatches, repository or path aliases that do not canonicalize to the durable project, branch mismatches, and durable modes other than `no-mistakes`.
+
+The companion Perch pull request must be amended before integration because its initial response omits `protocolVersion`, `requestId`, `operation`, `sessionId`, `projectPath`, `repository`, `worktreePath`, and `branch`, and its worker environment omits repository identity and runtime generation.
+Those fields are required for exact response validation and replay rejection.
+
+Perch `direct-PR` and `local-only` tasks must receive a denial before run creation, gate acceptance, and agent launch.
+Only the exact live task whose durable mode is `no-mistakes` may receive an allow decision.
+
+## Threat model
+
+Managed authorization prevents prompt text, repository state, gate configuration, PATH selection, or a stale worker credential from granting pipeline access.
+It binds each decision to a live task runtime and the exact project, repository, worktree, branch, session, operation, and protocol version.
+It does not make a compromised verifier trustworthy, and it does not replace operating-system protection of the local daemon socket or orchestrator token.
+
+The gate is inside the upstream CLI, receiver, daemon, and agent launch path.
+A PATH wrapper is not sufficient because an absolute binary path could bypass it.
+
+## Distribution and updates
+
+A distributor should pin the first stable upstream release containing protocol version 1 by exact tag and commit.
+It should verify the release asset against `checksums.txt`, record the GitHub release asset digest, and verify the macOS Developer ID signature, fixed Team ID, signing identifier, hardened runtime, secure timestamp, and architecture before repackaging.
+Checksums without authenticated release metadata are not a signing mechanism.
+
+The packaged manifest should record the upstream tag, commit, asset URL, SHA-256, release digest, signing identity, architecture, build version, and authorization protocol version.
+Activation should compare that manifest with `no-mistakes --version` and refuse any mismatch.
+
+`no-mistakes update` refuses self-update whenever managed context is present.
+The orchestrator owns replacement of a pinned managed runtime.

--- a/docs/src/content/docs/reference/managed-authorization.md
+++ b/docs/src/content/docs/reference/managed-authorization.md
@@ -118,12 +118,31 @@ A PATH wrapper is not sufficient because an absolute binary path could bypass it
 
 ## Distribution and updates
 
-A distributor should pin the first stable upstream release containing protocol version 1 by exact tag and commit.
+A distributor should pin an immutable release from the maintained authorization fork by exact tag and commit.
+It should also record the exact upstream base commit included by that fork release.
 It should verify the release asset against `checksums.txt`, record the GitHub release asset digest, and verify the macOS Developer ID signature, fixed Team ID, signing identifier, hardened runtime, secure timestamp, and architecture before repackaging.
 Checksums without authenticated release metadata are not a signing mechanism.
 
-The packaged manifest should record the upstream tag, commit, asset URL, SHA-256, release digest, signing identity, architecture, build version, and authorization protocol version.
+The packaged manifest should record the fork repository, fork tag and commit, upstream base commit, asset URL, SHA-256, release digest, signing identity, architecture, build version, and authorization protocol version.
 Activation should compare that manifest with `no-mistakes --version` and refuse any mismatch.
 
 `no-mistakes update` refuses self-update whenever managed context is present.
 The orchestrator owns replacement of a pinned managed runtime.
+
+## Maintaining the authorization fork
+
+Treat fork synchronization as a reviewed release operation, not an automatic update of the protected default branch.
+Configure the original repository as a read-only `upstream` remote and keep the fork as `origin`.
+
+For each selected upstream stable tag or commit:
+
+1. Fetch upstream branches and tags without changing the fork default branch.
+2. Create a `maintenance/upstream-<version>` branch from the current fork default branch.
+3. Merge the selected upstream commit into that branch without rewriting published fork history.
+4. Review conflicts specifically at the CLI, hook, IPC, daemon, database, recovery, update, and agent-launch authorization boundaries.
+5. Re-run formatting, generated-file drift checks, vet, full race tests, fake-agent E2E, documentation build, native build, and the supported architecture build matrix.
+6. Open a pull request against the fork default branch that records the previous fork commit, selected upstream commit, resulting merge commit, protocol version, changed boundary files, and verification evidence.
+7. After review, build any fork release from the exact merged commit, create new immutable checksums and signing metadata, and update the orchestrator manifest only after those artifacts verify.
+
+Never move or replace an existing fork release tag, reuse old checksums for rebuilt artifacts, or point the orchestrator at a floating branch.
+If an upstream change removes or bypasses a protected boundary, keep the fork pinned to the previous verified release until the authorization integration is restored and the full matrix passes.

--- a/internal/agent/acpx.go
+++ b/internal/agent/acpx.go
@@ -32,6 +32,9 @@ func (a *acpxAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
 }
 
 func (a *acpxAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
+	if err := authorizeLaunch(ctx, opts); err != nil {
+		return nil, err
+	}
 	args := a.buildArgs(opts)
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -52,6 +52,9 @@ type RunOpts struct {
 	// fallback-provider attempts, after it completes. It is instrumentation
 	// only and must not change invocation behavior.
 	OnAttempt func(Attempt)
+	// AuthorizeLaunch is called immediately before every concrete external
+	// agent attempt, including retries and fallback-provider attempts.
+	AuthorizeLaunch func(context.Context) error
 }
 
 // Attempt describes one completed concrete adapter attempt for an agent

--- a/internal/agent/authorization.go
+++ b/internal/agent/authorization.go
@@ -1,0 +1,46 @@
+package agent
+
+import "context"
+
+func authorizeLaunch(ctx context.Context, opts RunOpts) error {
+	if opts.AuthorizeLaunch == nil {
+		return nil
+	}
+	return opts.AuthorizeLaunch(ctx)
+}
+
+type launchAuthorizedAgent struct {
+	Agent
+	authorize func(context.Context) error
+}
+
+func (a launchAuthorizedAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
+	opts.AuthorizeLaunch = a.authorize
+	return a.Agent.Run(ctx, opts)
+}
+
+func (a launchAuthorizedAgent) SupportsSessionResume() bool {
+	return SupportsSessionResume(a.Agent)
+}
+
+func (a launchAuthorizedAgent) SupportsSessionProvider(provider string) bool {
+	return SupportsSessionProvider(a.Agent, provider)
+}
+
+func (a launchAuthorizedAgent) ReportsAgentAttempts() bool {
+	return ReportsAgentAttempts(a.Agent)
+}
+
+func (a launchAuthorizedAgent) NeutralizesGateInstructions() bool {
+	return NeutralizesGateInstructions(a.Agent)
+}
+
+// WithLaunchAuthorization injects a fresh authorization call into every
+// concrete adapter attempt. Adapter retries and fallback providers receive the
+// callback in RunOpts, so each subprocess launch reauthorizes independently.
+func WithLaunchAuthorization(a Agent, authorize func(context.Context) error) Agent {
+	if a == nil || authorize == nil {
+		return a
+	}
+	return launchAuthorizedAgent{Agent: a, authorize: authorize}
+}

--- a/internal/agent/authorization_test.go
+++ b/internal/agent/authorization_test.go
@@ -1,0 +1,68 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type authorizationProbeAgent struct {
+	attempts int
+}
+
+func (a *authorizationProbeAgent) Name() string { return "probe" }
+func (a *authorizationProbeAgent) Close() error { return nil }
+func (a *authorizationProbeAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
+	for i := 0; i < 2; i++ {
+		if err := authorizeLaunch(ctx, opts); err != nil {
+			return nil, err
+		}
+		a.attempts++
+	}
+	return &Result{}, nil
+}
+
+func TestWithLaunchAuthorizationReauthorizesEveryConcreteAttempt(t *testing.T) {
+	probe := &authorizationProbeAgent{}
+	authorizations := 0
+	agent := WithLaunchAuthorization(probe, func(context.Context) error {
+		authorizations++
+		return nil
+	})
+	if _, err := agent.Run(context.Background(), RunOpts{}); err != nil {
+		t.Fatal(err)
+	}
+	if authorizations != 2 || probe.attempts != 2 {
+		t.Fatalf("authorizations=%d attempts=%d, want 2 each", authorizations, probe.attempts)
+	}
+}
+
+func TestLaunchAuthorizationDenialPreventsAttempt(t *testing.T) {
+	probe := &authorizationProbeAgent{}
+	agent := WithLaunchAuthorization(probe, func(context.Context) error {
+		return errors.New("managed authorization denied")
+	})
+	if _, err := agent.Run(context.Background(), RunOpts{}); err == nil {
+		t.Fatal("expected denial")
+	}
+	if probe.attempts != 0 {
+		t.Fatalf("agent attempted %d launches after denial", probe.attempts)
+	}
+}
+
+func TestGitSafeEnvScrubsManagedCredentialsAndScope(t *testing.T) {
+	t.Setenv("PERCH_HOOK_TOKEN", "secret-perch-token")
+	t.Setenv("PERCH_TASK_ID", "task-1")
+	t.Setenv("NO_MISTAKES_AUTHORIZATION_TOKEN", "secret-generic-token")
+	env := gitSafeEnv(t.TempDir())
+	joined := strings.Join(env, "\n")
+	for _, forbidden := range []string{"secret-perch-token", "secret-generic-token", "PERCH_TASK_ID", "PERCH_HOOK_TOKEN", "NO_MISTAKES_AUTHORIZATION_TOKEN"} {
+		if strings.Contains(joined, forbidden) {
+			t.Fatalf("child environment leaked %q: %s", forbidden, joined)
+		}
+	}
+	if !strings.Contains(joined, GateRoleEnvVar+"=1") {
+		t.Fatal("gate role marker missing")
+	}
+}

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -65,6 +65,9 @@ func (a *claudeAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
 }
 
 func (a *claudeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
+	if err := authorizeLaunch(ctx, opts); err != nil {
+		return nil, err
+	}
 	resumeID := ""
 	if opts.Session != nil {
 		resumeID = opts.Session.ID

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -58,6 +58,9 @@ func (a *codexAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
 }
 
 func (a *codexAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
+	if err := authorizeLaunch(ctx, opts); err != nil {
+		return nil, err
+	}
 	schemaPath := ""
 	validationSchema := opts.JSONSchema
 	if len(opts.JSONSchema) > 0 {

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -35,6 +35,9 @@ func (a *copilotAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
 func (a *copilotAgent) Close() error { return nil }
 
 func (a *copilotAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
+	if err := authorizeLaunch(ctx, opts); err != nil {
+		return nil, err
+	}
 	prompt := buildCopilotPrompt(opts.Prompt, opts.JSONSchema)
 	args := a.buildArgs(prompt)
 	cmd := exec.CommandContext(ctx, a.bin, args...)

--- a/internal/agent/env.go
+++ b/internal/agent/env.go
@@ -1,6 +1,9 @@
 package agent
 
-import "github.com/kunchenguid/no-mistakes/internal/git"
+import (
+	"github.com/kunchenguid/no-mistakes/internal/authorization"
+	"github.com/kunchenguid/no-mistakes/internal/git"
+)
 
 // GateRoleEnvVar is exported into every spawned gate agent's environment as an
 // unspoofable-from-outside marker that the process is a no-mistakes gate agent
@@ -27,5 +30,5 @@ const GateRoleEnvVar = "NO_MISTAKES_GATE"
 // dir must be the value assigned to cmd.Dir so PWD stays coupled to the working
 // directory; see git.NonInteractiveEnv for why this matters.
 func gitSafeEnv(dir string) []string {
-	return append(git.NonInteractiveEnv(dir), GateRoleEnvVar+"=1")
+	return append(authorization.ScrubEnvironment(git.NonInteractiveEnv(dir)), GateRoleEnvVar+"=1")
 }

--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -40,6 +40,9 @@ func (a *opencodeAgent) recoverTransientRetry(label string) {
 }
 
 func (a *opencodeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
+	if err := authorizeLaunch(ctx, opts); err != nil {
+		return nil, err
+	}
 	// Start server on first invocation (synchronized)
 	baseURL, err := a.ensureServer(ctx, opts.CWD)
 	if err != nil {

--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -34,6 +34,9 @@ func (a *piAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
 func (a *piAgent) Close() error { return nil }
 
 func (a *piAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
+	if err := authorizeLaunch(ctx, opts); err != nil {
+		return nil, err
+	}
 	args := a.buildArgs()
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD

--- a/internal/agent/rovodev.go
+++ b/internal/agent/rovodev.go
@@ -45,6 +45,9 @@ func (a *rovodevAgent) recoverTransientRetry(label string) {
 }
 
 func (a *rovodevAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
+	if err := authorizeLaunch(ctx, opts); err != nil {
+		return nil, err
+	}
 	// Start server on first invocation (synchronized)
 	baseURL, err := a.ensureServer(ctx, opts.CWD)
 	if err != nil {

--- a/internal/authorization/authorization.go
+++ b/internal/authorization/authorization.go
@@ -1,0 +1,423 @@
+// Package authorization implements the opt-in external authorization protocol
+// used by orchestrators that manage no-mistakes runs. Unmanaged callers never
+// contact a verifier and retain the ordinary standalone behavior.
+package authorization
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	ProtocolVersion = "1"
+
+	OperationRun         Operation = "run"
+	OperationGatePush    Operation = "gate-push"
+	OperationAgentLaunch Operation = "agent-launch"
+
+	defaultTimeout  = 2 * time.Second
+	maxResponseBody = 32 << 10
+)
+
+// Operation is a protected no-mistakes boundary.
+type Operation string
+
+// Context is the in-memory authorization capability for one managed runtime.
+// Token is intentionally never persisted, logged, placed in git configuration,
+// or forwarded to review-agent processes.
+type Context struct {
+	Managed           bool
+	VerifierURL       string
+	Token             string
+	TaskID            string
+	RuntimeGeneration int64
+	SessionID         string
+	ProjectPath       string
+	Repository        string
+	WorktreePath      string
+	Branch            string
+	DurableMode       string
+	Timeout           time.Duration
+	provider          string
+}
+
+// WireContext is the minimum transient context carried over the local daemon
+// IPC channel. It must never be written to diagnostics or durable storage.
+type WireContext struct {
+	Managed           bool   `json:"managed"`
+	VerifierURL       string `json:"verifier_url,omitempty"`
+	Token             string `json:"token,omitempty"`
+	TaskID            string `json:"task_id,omitempty"`
+	RuntimeGeneration int64  `json:"runtime_generation,omitempty"`
+	SessionID         string `json:"session_id,omitempty"`
+	ProjectPath       string `json:"project_path,omitempty"`
+	Repository        string `json:"repository,omitempty"`
+	WorktreePath      string `json:"worktree_path,omitempty"`
+	Branch            string `json:"branch,omitempty"`
+	DurableMode       string `json:"durable_mode,omitempty"`
+	Provider          string `json:"provider,omitempty"`
+}
+
+func (w WireContext) String() string {
+	return FromWire(&w).String()
+}
+
+func (w WireContext) GoString() string {
+	return FromWire(&w).String()
+}
+
+// Request is protocol version 1's exact authorization request.
+type Request struct {
+	ProtocolVersion   string    `json:"protocolVersion"`
+	RequestID         string    `json:"requestId"`
+	Operation         Operation `json:"operation"`
+	TaskID            string    `json:"taskId"`
+	RuntimeGeneration int64     `json:"runtimeGeneration"`
+	SessionID         string    `json:"sessionId"`
+	ProjectPath       string    `json:"projectPath"`
+	Repository        string    `json:"repository"`
+	WorktreePath      string    `json:"worktreePath"`
+	Branch            string    `json:"branch"`
+	DurableMode       string    `json:"durableMode"`
+}
+
+// Response must echo the complete request scope. RequestID is a one-use nonce;
+// the verifier owns replay detection and returns a denial for a reused value.
+type Response struct {
+	ProtocolVersion   string    `json:"protocolVersion"`
+	RequestID         string    `json:"requestId"`
+	Operation         Operation `json:"operation"`
+	TaskID            string    `json:"taskId"`
+	RuntimeGeneration int64     `json:"runtimeGeneration"`
+	SessionID         string    `json:"sessionId"`
+	ProjectPath       string    `json:"projectPath"`
+	Repository        string    `json:"repository"`
+	WorktreePath      string    `json:"worktreePath"`
+	Branch            string    `json:"branch"`
+	DurableMode       string    `json:"durableMode"`
+	Allowed           bool      `json:"allowed"`
+	Reason            string    `json:"reason"`
+}
+
+// FromEnvironment recognizes Perch's authenticated hook environment and a
+// provider-neutral NO_MISTAKES_AUTHORIZATION_* equivalent. Any partial managed
+// context fails closed instead of silently reverting to standalone behavior.
+func FromEnvironment(environ []string) (Context, error) {
+	env := envMap(environ)
+	perch := hasAnyPrefix(env, "PERCH_TASK_", "PERCH_HOOK_", "PERCH_SESSION_ID", "PERCH_RUNTIME_GENERATION")
+	generic := env["NO_MISTAKES_AUTHORIZATION_MODE"] != "" || hasAnyPrefix(env, "NO_MISTAKES_AUTHORIZATION_")
+	if !perch && !generic {
+		return Context{}, nil
+	}
+
+	var c Context
+	if perch {
+		c = Context{
+			Managed:      true,
+			VerifierURL:  perchVerifierURL(env["PERCH_HOOK_URL"]),
+			Token:        env["PERCH_HOOK_TOKEN"],
+			TaskID:       env["PERCH_TASK_ID"],
+			SessionID:    env["PERCH_SESSION_ID"],
+			ProjectPath:  env["PERCH_TASK_PROJECT"],
+			Repository:   env["PERCH_TASK_REPOSITORY"],
+			WorktreePath: env["PERCH_TASK_WORKTREE"],
+			Branch:       env["PERCH_TASK_BRANCH"],
+			DurableMode:  env["PERCH_TASK_MODE"],
+			provider:     "perch",
+		}
+		generation, err := strconv.ParseInt(env["PERCH_RUNTIME_GENERATION"], 10, 64)
+		if err != nil {
+			return Context{}, errors.New("managed authorization denied: invalid runtime generation")
+		}
+		c.RuntimeGeneration = generation
+	} else {
+		if env["NO_MISTAKES_AUTHORIZATION_MODE"] != "managed" {
+			return Context{}, errors.New("managed authorization denied: invalid mode")
+		}
+		c = Context{
+			Managed:      true,
+			VerifierURL:  env["NO_MISTAKES_AUTHORIZATION_URL"],
+			Token:        env["NO_MISTAKES_AUTHORIZATION_TOKEN"],
+			TaskID:       env["NO_MISTAKES_AUTHORIZATION_TASK_ID"],
+			SessionID:    env["NO_MISTAKES_AUTHORIZATION_SESSION_ID"],
+			ProjectPath:  env["NO_MISTAKES_AUTHORIZATION_PROJECT"],
+			Repository:   env["NO_MISTAKES_AUTHORIZATION_REPOSITORY"],
+			WorktreePath: env["NO_MISTAKES_AUTHORIZATION_WORKTREE"],
+			Branch:       env["NO_MISTAKES_AUTHORIZATION_BRANCH"],
+			DurableMode:  env["NO_MISTAKES_AUTHORIZATION_DURABLE_MODE"],
+			provider:     "generic",
+		}
+		generation, err := strconv.ParseInt(env["NO_MISTAKES_AUTHORIZATION_RUNTIME_GENERATION"], 10, 64)
+		if err != nil {
+			return Context{}, errors.New("managed authorization denied: invalid runtime generation")
+		}
+		c.RuntimeGeneration = generation
+	}
+	if err := c.validate(); err != nil {
+		return Context{}, err
+	}
+	c.ProjectPath = canonicalPath(c.ProjectPath)
+	c.Repository = CanonicalRepository(c.Repository)
+	c.WorktreePath = canonicalPath(c.WorktreePath)
+	return c, nil
+}
+
+// IsManagedEnvironment reports whether any explicit managed-provider marker is
+// present. It is used by mutation surfaces such as self-update, which must
+// refuse even when the rest of a damaged managed context is incomplete.
+func IsManagedEnvironment(environ []string) bool {
+	env := envMap(environ)
+	return hasAnyPrefix(env, "PERCH_TASK_", "PERCH_HOOK_", "PERCH_SESSION_ID", "PERCH_RUNTIME_GENERATION") ||
+		env["NO_MISTAKES_AUTHORIZATION_MODE"] != "" || hasAnyPrefix(env, "NO_MISTAKES_AUTHORIZATION_")
+}
+
+func perchVerifierURL(hookURL string) string {
+	base := strings.TrimRight(strings.TrimSpace(hookURL), "/")
+	if strings.HasSuffix(base, "/hooks") {
+		return base + "/no-mistakes/authorize"
+	}
+	return base + "/hooks/no-mistakes/authorize"
+}
+
+func envMap(environ []string) map[string]string {
+	result := make(map[string]string, len(environ))
+	for _, entry := range environ {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			result[key] = value
+		}
+	}
+	return result
+}
+
+func hasAnyPrefix(env map[string]string, prefixes ...string) bool {
+	for key := range env {
+		for _, prefix := range prefixes {
+			if key == prefix || strings.HasPrefix(key, prefix) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (c Context) validate() error {
+	if !c.Managed {
+		return nil
+	}
+	if c.VerifierURL == "" || c.Token == "" || c.TaskID == "" || c.SessionID == "" || c.ProjectPath == "" || c.Repository == "" || c.WorktreePath == "" || c.Branch == "" || c.DurableMode == "" {
+		return errors.New("managed authorization denied: incomplete verifier context")
+	}
+	parsed, err := url.Parse(c.VerifierURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.User != nil {
+		return errors.New("managed authorization denied: invalid verifier URL")
+	}
+	if c.RuntimeGeneration < 0 {
+		return errors.New("managed authorization denied: invalid runtime generation")
+	}
+	return nil
+}
+
+// Authorize performs a fresh verifier call for exactly one protected operation.
+// Decisions are deliberately never cached.
+func (c Context) Authorize(ctx context.Context, operation Operation) error {
+	if !c.Managed {
+		return nil
+	}
+	if err := c.validate(); err != nil {
+		return err
+	}
+	if operation != OperationRun && operation != OperationGatePush && operation != OperationAgentLaunch {
+		return errors.New("managed authorization denied: unsupported operation")
+	}
+	requestID, err := newRequestID()
+	if err != nil {
+		return errors.New("managed authorization denied: request identity unavailable")
+	}
+	request := Request{
+		ProtocolVersion: ProtocolVersion, RequestID: requestID, Operation: operation,
+		TaskID: c.TaskID, RuntimeGeneration: c.RuntimeGeneration, SessionID: c.SessionID,
+		ProjectPath: canonicalPath(c.ProjectPath), Repository: CanonicalRepository(c.Repository), WorktreePath: canonicalPath(c.WorktreePath),
+		Branch: c.Branch, DurableMode: c.DurableMode,
+	}
+	payload, err := json.Marshal(request)
+	if err != nil {
+		return errors.New("managed authorization denied: request encoding failed")
+	}
+	timeout := c.Timeout
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	httpRequest, err := http.NewRequestWithContext(requestCtx, http.MethodPost, c.VerifierURL, bytes.NewReader(payload))
+	if err != nil {
+		return errors.New("managed authorization denied: verifier request failed")
+	}
+	httpRequest.Header.Set("content-type", "application/json")
+	if c.provider == "perch" {
+		httpRequest.Header.Set("x-perch-session", c.SessionID)
+		httpRequest.Header.Set("x-perch-token", c.Token)
+	} else {
+		httpRequest.Header.Set("authorization", "Bearer "+c.Token)
+	}
+	client := &http.Client{
+		Timeout: timeout,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	response, err := client.Do(httpRequest)
+	if err != nil {
+		return errors.New("managed authorization denied: verifier unavailable")
+	}
+	defer response.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxResponseBody))
+	if err != nil {
+		return errors.New("managed authorization denied: verifier response unreadable")
+	}
+	var decision Response
+	if err := json.Unmarshal(body, &decision); err != nil {
+		return errors.New("managed authorization denied: malformed verifier response")
+	}
+	if err := validateEcho(request, decision); err != nil {
+		return err
+	}
+	if response.StatusCode != http.StatusOK || !decision.Allowed || decision.DurableMode != "no-mistakes" {
+		return fmt.Errorf("managed authorization denied: %s", safeReason(decision.Reason, c.Token))
+	}
+	return nil
+}
+
+func validateEcho(request Request, response Response) error {
+	if response.ProtocolVersion != request.ProtocolVersion || response.RequestID != request.RequestID ||
+		response.Operation != request.Operation || response.TaskID != request.TaskID ||
+		response.RuntimeGeneration != request.RuntimeGeneration || response.SessionID != request.SessionID ||
+		response.ProjectPath != request.ProjectPath || response.Repository != request.Repository ||
+		response.WorktreePath != request.WorktreePath || response.Branch != request.Branch {
+		return errors.New("managed authorization denied: verifier scope mismatch")
+	}
+	return nil
+}
+
+func safeReason(reason, credential string) string {
+	if reason == "" || len(reason) > 64 || (credential != "" && strings.Contains(reason, credential)) {
+		return "not_authorized"
+	}
+	for _, char := range reason {
+		if (char < 'a' || char > 'z') && (char < '0' || char > '9') && char != '_' && char != '-' && char != '.' {
+			return "not_authorized"
+		}
+	}
+	return reason
+}
+
+func newRequestID() (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(value[:]), nil
+}
+
+// ValidateLocalScope rejects obvious task/repository/worktree/branch replay
+// before contacting the verifier. The verifier remains authoritative.
+func (c Context) ValidateLocalScope(projectPath, repository, worktreePath, branch string) error {
+	if !c.Managed {
+		return nil
+	}
+	if canonicalPath(c.ProjectPath) != canonicalPath(projectPath) || canonicalPath(c.WorktreePath) != canonicalPath(worktreePath) ||
+		CanonicalRepository(c.Repository) != CanonicalRepository(repository) || c.Branch != branch || c.DurableMode != "no-mistakes" {
+		return errors.New("managed authorization denied: local scope mismatch")
+	}
+	return nil
+}
+
+func canonicalPath(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return ""
+	}
+	path, err := filepath.Abs(value)
+	if err != nil {
+		return filepath.Clean(value)
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return filepath.Clean(resolved)
+	}
+	return filepath.Clean(path)
+}
+
+// CanonicalRepository normalizes common Git URL forms without credentials.
+func CanonicalRepository(value string) string {
+	value = strings.TrimSpace(strings.TrimSuffix(value, ".git"))
+	if strings.Contains(value, "://") {
+		if parsed, err := url.Parse(value); err == nil && parsed.Host != "" {
+			return strings.ToLower(parsed.Host) + "/" + strings.TrimPrefix(parsed.Path, "/")
+		}
+	}
+	if at := strings.LastIndex(value, "@"); at >= 0 {
+		value = value[at+1:]
+	}
+	value = strings.Replace(value, ":", "/", 1)
+	return strings.ToLower(strings.TrimPrefix(value, "/"))
+}
+
+func (c Context) Wire() *WireContext {
+	if !c.Managed {
+		return nil
+	}
+	return &WireContext{Managed: true, VerifierURL: c.VerifierURL, Token: c.Token, TaskID: c.TaskID,
+		RuntimeGeneration: c.RuntimeGeneration, SessionID: c.SessionID, ProjectPath: canonicalPath(c.ProjectPath),
+		Repository: CanonicalRepository(c.Repository), WorktreePath: canonicalPath(c.WorktreePath), Branch: c.Branch,
+		DurableMode: c.DurableMode, Provider: c.provider}
+}
+
+func FromWire(w *WireContext) Context {
+	if w == nil || !w.Managed {
+		return Context{}
+	}
+	return Context{Managed: true, VerifierURL: w.VerifierURL, Token: w.Token, TaskID: w.TaskID,
+		RuntimeGeneration: w.RuntimeGeneration, SessionID: w.SessionID, ProjectPath: w.ProjectPath,
+		Repository: w.Repository, WorktreePath: w.WorktreePath, Branch: w.Branch,
+		DurableMode: w.DurableMode, provider: w.Provider}
+}
+
+type redactedContext struct{ Context }
+
+func (c Context) Redacted() redactedContext {
+	c.Token = "<redacted>"
+	return redactedContext{Context: c}
+}
+
+func (c Context) String() string   { return c.Redacted().String() }
+func (c Context) GoString() string { return c.Redacted().String() }
+func (c redactedContext) String() string {
+	return fmt.Sprintf("authorization.Context{Managed:%t TaskID:%q RuntimeGeneration:%d SessionID:%q ProjectPath:%q Repository:%q WorktreePath:%q Branch:%q DurableMode:%q Token:<redacted>}",
+		c.Managed, c.TaskID, c.RuntimeGeneration, c.SessionID, c.ProjectPath, c.Repository, c.WorktreePath, c.Branch, c.DurableMode)
+}
+
+// ScrubEnvironment removes managed-orchestrator credentials and scope from a
+// child process environment.
+func ScrubEnvironment(environ []string) []string {
+	result := make([]string, 0, len(environ))
+	for _, entry := range environ {
+		key, _, _ := strings.Cut(entry, "=")
+		if strings.HasPrefix(key, "PERCH_") || strings.HasPrefix(key, "NO_MISTAKES_AUTHORIZATION_") {
+			continue
+		}
+		result = append(result, entry)
+	}
+	return result
+}

--- a/internal/authorization/authorization_test.go
+++ b/internal/authorization/authorization_test.go
@@ -1,0 +1,261 @@
+package authorization
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func managedContext(url string) Context {
+	return Context{
+		Managed:           true,
+		VerifierURL:       url,
+		Token:             "super-secret-token",
+		TaskID:            "task-1",
+		RuntimeGeneration: 7,
+		SessionID:         "session-1",
+		ProjectPath:       "/repo",
+		Repository:        "github.com/acme/repo",
+		WorktreePath:      "/repo-worktree",
+		Branch:            "feature/auth",
+		DurableMode:       "no-mistakes",
+	}
+}
+
+func matchingResponse(request Request) Response {
+	return Response{
+		ProtocolVersion:   ProtocolVersion,
+		RequestID:         request.RequestID,
+		Operation:         request.Operation,
+		TaskID:            request.TaskID,
+		RuntimeGeneration: request.RuntimeGeneration,
+		SessionID:         request.SessionID,
+		ProjectPath:       request.ProjectPath,
+		Repository:        request.Repository,
+		WorktreePath:      request.WorktreePath,
+		Branch:            request.Branch,
+		DurableMode:       request.DurableMode,
+		Allowed:           true,
+		Reason:            "authorized",
+	}
+}
+
+func TestAuthorizeAllowsOnlyExactEcho(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("authorization"); got != "Bearer super-secret-token" {
+			t.Fatalf("authorization header = %q", got)
+		}
+		var request Request
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatal(err)
+		}
+		if request.Repository != "github.com/acme/repo" {
+			t.Fatalf("repository was not canonicalized: %q", request.Repository)
+		}
+		_ = json.NewEncoder(w).Encode(matchingResponse(request))
+	}))
+	defer server.Close()
+
+	ctx := managedContext(server.URL)
+	ctx.Repository = "https://user:repository-secret@github.com/acme/repo.git"
+	if err := ctx.Authorize(context.Background(), OperationRun); err != nil {
+		t.Fatalf("Authorize: %v", err)
+	}
+}
+
+func TestAuthorizeFailsClosedOnMismatchDenialReplayAndMalformedResponse(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Response)
+		body   string
+		status int
+	}{
+		{name: "protocol", mutate: func(r *Response) { r.ProtocolVersion = "v999" }},
+		{name: "operation", mutate: func(r *Response) { r.Operation = OperationGatePush }},
+		{name: "task", mutate: func(r *Response) { r.TaskID = "other" }},
+		{name: "runtime", mutate: func(r *Response) { r.RuntimeGeneration++ }},
+		{name: "session", mutate: func(r *Response) { r.SessionID = "other" }},
+		{name: "project", mutate: func(r *Response) { r.ProjectPath = "/other" }},
+		{name: "repository", mutate: func(r *Response) { r.Repository = "github.com/acme/other" }},
+		{name: "worktree", mutate: func(r *Response) { r.WorktreePath = "/other" }},
+		{name: "branch", mutate: func(r *Response) { r.Branch = "other" }},
+		{name: "mode", mutate: func(r *Response) { r.DurableMode = "direct-PR" }},
+		{name: "replay", mutate: func(r *Response) { r.RequestID = "already-used" }},
+		{name: "denied direct-pr", mutate: func(r *Response) {
+			r.Allowed = false
+			r.DurableMode = "direct-PR"
+			r.Reason = "durable_task_mode_denied"
+		}, status: http.StatusForbidden},
+		{name: "denied local-only", mutate: func(r *Response) {
+			r.Allowed = false
+			r.DurableMode = "local-only"
+			r.Reason = "durable_task_mode_denied"
+		}, status: http.StatusForbidden},
+		{name: "untrusted reason", mutate: func(r *Response) {
+			r.Allowed = false
+			r.Reason = "super-secret-token"
+		}, status: http.StatusForbidden},
+		{name: "malformed", body: "not-json"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var request Request
+				_ = json.NewDecoder(r.Body).Decode(&request)
+				if tt.status != 0 {
+					w.WriteHeader(tt.status)
+				}
+				if tt.body != "" {
+					_, _ = w.Write([]byte(tt.body))
+					return
+				}
+				response := matchingResponse(request)
+				tt.mutate(&response)
+				_ = json.NewEncoder(w).Encode(response)
+			}))
+			defer server.Close()
+			err := managedContext(server.URL).Authorize(context.Background(), OperationRun)
+			if err == nil {
+				t.Fatal("expected denial")
+			}
+			if strings.Contains(err.Error(), "super-secret-token") {
+				t.Fatalf("error leaked token: %v", err)
+			}
+		})
+	}
+}
+
+func TestAuthorizeFailsClosedOnMissingVerifierAndTimeout(t *testing.T) {
+	ctx := managedContext("")
+	if err := ctx.Authorize(context.Background(), OperationRun); err == nil {
+		t.Fatal("missing verifier should fail")
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+	}))
+	defer server.Close()
+	ctx = managedContext(server.URL)
+	ctx.Timeout = 10 * time.Millisecond
+	if err := ctx.Authorize(context.Background(), OperationRun); err == nil {
+		t.Fatal("timeout should fail")
+	}
+}
+
+func TestAuthorizeDoesNotForwardCredentialAcrossRedirect(t *testing.T) {
+	redirected := false
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirected = true
+		if got := r.Header.Get("authorization"); got != "" {
+			t.Fatalf("redirect forwarded credential: %q", got)
+		}
+	}))
+	defer target.Close()
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusTemporaryRedirect)
+	}))
+	defer source.Close()
+
+	err := managedContext(source.URL).Authorize(context.Background(), OperationRun)
+	if err == nil {
+		t.Fatal("redirected verifier should fail closed")
+	}
+	if redirected {
+		t.Fatal("verifier redirect was followed")
+	}
+}
+
+func TestUnmanagedAuthorizeHasNoNetworkSideEffect(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true }))
+	defer server.Close()
+	ctx := Context{VerifierURL: server.URL}
+	if err := ctx.Authorize(context.Background(), OperationRun); err != nil {
+		t.Fatal(err)
+	}
+	if called {
+		t.Fatal("unmanaged authorization contacted verifier")
+	}
+}
+
+func TestValidateLocalScopeRejectsNonManagedDurableModesBeforeVerifier(t *testing.T) {
+	for _, mode := range []string{"direct-PR", "local-only"} {
+		t.Run(mode, func(t *testing.T) {
+			called := false
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true }))
+			defer server.Close()
+			ctx := managedContext(server.URL)
+			ctx.DurableMode = mode
+			if err := ctx.ValidateLocalScope("/repo", "github.com/acme/repo", "/repo-worktree", "feature/auth"); err == nil {
+				t.Fatal("non-no-mistakes durable mode should fail local validation")
+			}
+			if called {
+				t.Fatal("local durable-mode rejection contacted verifier")
+			}
+		})
+	}
+}
+
+func TestFromEnvironmentManagedPerchAndGenericModes(t *testing.T) {
+	perch := []string{
+		"PERCH_TASK_ID=task-1",
+		"PERCH_TASK_MODE=no-mistakes",
+		"PERCH_TASK_PROJECT=/repo",
+		"PERCH_TASK_REPOSITORY=github.com/acme/repo",
+		"PERCH_TASK_WORKTREE=/repo-wt",
+		"PERCH_TASK_BRANCH=feature/auth",
+		"PERCH_RUNTIME_GENERATION=7",
+		"PERCH_SESSION_ID=session-1",
+		"PERCH_HOOK_URL=http://127.0.0.1:8787/hooks",
+		"PERCH_HOOK_TOKEN=secret",
+	}
+	ctx, err := FromEnvironment(perch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ctx.Managed || ctx.VerifierURL != "http://127.0.0.1:8787/hooks/no-mistakes/authorize" {
+		t.Fatalf("unexpected Perch context: %#v", ctx.Redacted())
+	}
+
+	generic := []string{
+		"NO_MISTAKES_AUTHORIZATION_MODE=managed",
+		"NO_MISTAKES_AUTHORIZATION_URL=http://127.0.0.1/auth",
+		"NO_MISTAKES_AUTHORIZATION_TOKEN=secret",
+		"NO_MISTAKES_AUTHORIZATION_TASK_ID=task-1",
+		"NO_MISTAKES_AUTHORIZATION_RUNTIME_GENERATION=7",
+		"NO_MISTAKES_AUTHORIZATION_SESSION_ID=session-1",
+		"NO_MISTAKES_AUTHORIZATION_PROJECT=/repo",
+		"NO_MISTAKES_AUTHORIZATION_REPOSITORY=github.com/acme/repo",
+		"NO_MISTAKES_AUTHORIZATION_WORKTREE=/repo-wt",
+		"NO_MISTAKES_AUTHORIZATION_BRANCH=feature/auth",
+		"NO_MISTAKES_AUTHORIZATION_DURABLE_MODE=no-mistakes",
+	}
+	if ctx, err = FromEnvironment(generic); err != nil || !ctx.Managed {
+		t.Fatalf("generic context = %#v, %v", ctx.Redacted(), err)
+	}
+}
+
+func TestFromEnvironmentRejectsPartialManagedContext(t *testing.T) {
+	for _, env := range [][]string{
+		{"PERCH_TASK_ID=task-1"},
+		{"PERCH_HOOK_TOKEN=secret"},
+		{"NO_MISTAKES_AUTHORIZATION_MODE=managed"},
+	} {
+		if _, err := FromEnvironment(env); err == nil {
+			t.Fatalf("partial context should fail: %v", env)
+		}
+	}
+}
+
+func TestRedactedRepresentationsNeverExposeToken(t *testing.T) {
+	ctx := managedContext("http://127.0.0.1/auth")
+	for _, rendered := range []string{ctx.String(), ctx.GoString(), ctx.Redacted().String(), ctx.Wire().String(), ctx.Wire().GoString()} {
+		if strings.Contains(rendered, ctx.Token) {
+			t.Fatalf("rendered context leaked token: %s", rendered)
+		}
+	}
+}

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -11,6 +11,7 @@ import (
 
 	toon "github.com/toon-format/toon-go"
 
+	"github.com/kunchenguid/no-mistakes/internal/authorization"
 	"github.com/kunchenguid/no-mistakes/internal/cimonitor"
 	"github.com/kunchenguid/no-mistakes/internal/daemon"
 	"github.com/kunchenguid/no-mistakes/internal/gate"
@@ -122,7 +123,12 @@ func runAxiRun(cmd *cobra.Command, autoYes bool, skipSteps []types.StepName, int
 	}
 
 	runID := activeRunID(env, branch, headSHA)
+	var authContext authorization.Context
 	if runID == "" {
+		authContext, err = authorization.FromEnvironment(os.Environ())
+		if err != nil {
+			return emitError(cmd, 1, err.Error())
+		}
 		if err := configErrorForFreshAxiRun(env, runID); err != nil {
 			return emitError(cmd, 1, err.Error(), repoInitHelp(err)...)
 		}
@@ -141,8 +147,17 @@ func runAxiRun(cmd *cobra.Command, autoYes bool, skipSteps []types.StepName, int
 		if guard := preflightGuard(ctx, env, branch); guard != nil {
 			return guard(cmd)
 		}
-		var err error
-		runID, err = triggerRun(ctx, env, branch, headSHA, skipSteps, intent)
+		worktreePath, err := git.FindGitRoot(".")
+		if err != nil {
+			return emitError(cmd, 1, fmt.Sprintf("resolve managed worktree: %v", err))
+		}
+		if err := authContext.ValidateLocalScope(env.repo.WorkingPath, env.repo.UpstreamURL, worktreePath, branch); err != nil {
+			return emitError(cmd, 1, err.Error())
+		}
+		if err := authContext.Authorize(ctx, authorization.OperationRun); err != nil {
+			return emitError(cmd, 1, err.Error())
+		}
+		runID, err = triggerRun(ctx, env, branch, headSHA, skipSteps, intent, authContext)
 		if err != nil {
 			return emitError(cmd, 1, err.Error())
 		}
@@ -219,7 +234,7 @@ func preflightGuard(ctx context.Context, env *axiEnv, branch string) func(*cobra
 // the gate to trigger a pipeline, and falls back to a rerun when the push was a
 // no-op (the gate already had this commit). Callers must check for an existing
 // active run first (see activeRunID) and apply pre-flight guards.
-func triggerRun(ctx context.Context, env *axiEnv, branch, headSHA string, skipSteps []types.StepName, intent string) (string, error) {
+func triggerRun(ctx context.Context, env *axiEnv, branch, headSHA string, skipSteps []types.StepName, intent string, authContext authorization.Context) (string, error) {
 	pushOptions := formatSkipPushOptions(skipSteps)
 	if opt := formatIntentPushOption(intent); opt != "" {
 		pushOptions = append(pushOptions, opt)
@@ -242,7 +257,7 @@ func triggerRun(ctx context.Context, env *axiEnv, branch, headSHA string, skipSt
 	// No run appeared: the push was likely up-to-date. Rerun the latest gate
 	// head so `axi run` is still useful when there are no new commits.
 	var rr ipc.RerunResult
-	if err := env.client.Call(ipc.MethodRerun, rerunParams(env.repo.ID, branch, skipSteps, intent), &rr); err != nil {
+	if err := env.client.Call(ipc.MethodRerun, rerunParams(env.repo.ID, branch, skipSteps, intent, authContext), &rr); err != nil {
 		return "", fmt.Errorf("no run started for %q: %v", branch, err)
 	}
 	return rr.RunID, nil
@@ -326,8 +341,12 @@ func activeRunLookupParams(repoID, branch string) *ipc.GetActiveRunParams {
 	return &ipc.GetActiveRunParams{RepoID: repoID, Branch: branch}
 }
 
-func rerunParams(repoID, branch string, skipSteps []types.StepName, intent string) *ipc.RerunParams {
-	return &ipc.RerunParams{RepoID: repoID, Branch: branch, SkipSteps: skipSteps, Intent: intent}
+func rerunParams(repoID, branch string, skipSteps []types.StepName, intent string, authContexts ...authorization.Context) *ipc.RerunParams {
+	params := &ipc.RerunParams{RepoID: repoID, Branch: branch, SkipSteps: skipSteps, Intent: intent}
+	if len(authContexts) > 0 {
+		params.Authorization = authContexts[0].Wire()
+	}
+	return params
 }
 
 // driveRun polls a run until it reaches an approval gate, a terminal state, or

--- a/internal/cli/daemon_cmd.go
+++ b/internal/cli/daemon_cmd.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/kunchenguid/no-mistakes/internal/authorization"
 	"github.com/kunchenguid/no-mistakes/internal/daemon"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/lifecycle"
@@ -52,6 +53,10 @@ func newDaemonNotifyPushCmd() *cobra.Command {
 		Hidden: true,
 		Args:   cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			authContext, err := authorization.FromEnvironment(os.Environ())
+			if err != nil {
+				return err
+			}
 			skipSteps, err := parseSkipPushOptions(pushOptions)
 			if err != nil {
 				return err
@@ -78,12 +83,13 @@ func newDaemonNotifyPushCmd() *cobra.Command {
 
 			var result ipc.PushReceivedResult
 			return client.Call(ipc.MethodPushReceived, &ipc.PushReceivedParams{
-				Gate:      gatePath,
-				Ref:       ref,
-				Old:       oldSHA,
-				New:       newSHA,
-				SkipSteps: skipSteps,
-				Intent:    intent,
+				Gate:          gatePath,
+				Ref:           ref,
+				Old:           oldSHA,
+				New:           newSHA,
+				SkipSteps:     skipSteps,
+				Intent:        intent,
+				Authorization: authContext.Wire(),
 			}, &result)
 		},
 	}

--- a/internal/cli/helpers_test.go
+++ b/internal/cli/helpers_test.go
@@ -61,6 +61,15 @@ func init() {
 }
 
 func TestMain(m *testing.M) {
+	// Managed orchestration context from the process running `go test` must not
+	// reinterpret standalone CLI tests. Individual managed tests set their own
+	// complete or deliberately partial context with t.Setenv.
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		if strings.HasPrefix(key, "PERCH_") || strings.HasPrefix(key, "NO_MISTAKES_AUTHORIZATION_") {
+			_ = os.Unsetenv(key)
+		}
+	}
 	base := os.TempDir()
 	if runtime.GOOS != "windows" {
 		base = "/tmp"

--- a/internal/cli/managed_version_test.go
+++ b/internal/cli/managed_version_test.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/authorization"
+)
+
+func TestVersionExposesBuildAndAuthorizationProtocol(t *testing.T) {
+	version := newRootCmd().Version
+	if !strings.Contains(version, "authorization-protocol="+authorization.ProtocolVersion) {
+		t.Fatalf("version %q does not expose protocol %s", version, authorization.ProtocolVersion)
+	}
+}
+
+func TestManagedUpdateRefusesSelfMutation(t *testing.T) {
+	t.Setenv("NO_MISTAKES_AUTHORIZATION_MODE", "managed")
+	cmd := newUpdateCmd()
+	cmd.SetContext(context.Background())
+	err := cmd.RunE(cmd, nil)
+	if err == nil || !strings.Contains(err.Error(), "managed runtime") {
+		t.Fatalf("managed update error = %v", err)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/kunchenguid/no-mistakes/internal/authorization"
 	"github.com/kunchenguid/no-mistakes/internal/buildinfo"
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/git"
@@ -57,7 +58,7 @@ func newRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "no-mistakes",
 		Short:   "Local Git proxy that validates code before pushing to the configured target",
-		Version: buildinfo.String(),
+		Version: buildinfo.String() + " authorization-protocol=" + authorization.ProtocolVersion,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			setColorProfileForOutput(cmd.OutOrStdout())
 		},

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,6 +1,10 @@
 package cli
 
 import (
+	"fmt"
+	"os"
+
+	"github.com/kunchenguid/no-mistakes/internal/authorization"
 	"github.com/kunchenguid/no-mistakes/internal/update"
 	"github.com/spf13/cobra"
 )
@@ -14,6 +18,9 @@ func newUpdateCmd() *cobra.Command {
 		Short: "Update no-mistakes and reset the daemon",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if authorization.IsManagedEnvironment(os.Environ()) {
+				return fmt.Errorf("self-update is disabled for a managed runtime; update it through the orchestrator package")
+			}
 			logLifecycleInvocation("update", force)
 			return trackCommand("update", func() error {
 				return update.Run(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), update.RunOptions{Beta: beta, Yes: yes, Force: force, Stdin: cmd.InOrStdin()})

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
+	"github.com/kunchenguid/no-mistakes/internal/authorization"
 	"github.com/kunchenguid/no-mistakes/internal/config"
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/git"
@@ -267,6 +268,7 @@ func writeDaemonPIDFile(path string, record daemonPIDFile) error {
 func recoverOnStartup(d *db.DB, p *paths.Paths, mgr *RunManager) {
 	reapOrphanedServers(p)
 	migrateGateConfigs(context.Background(), p)
+	failManagedRunsOnStartup(d)
 
 	plans := mgr.recoverableParkedRuns(context.Background())
 	preserved := make(map[string]struct{}, len(plans))
@@ -287,6 +289,22 @@ func recoverOnStartup(d *db.DB, p *paths.Paths, mgr *RunManager) {
 
 	cleanupOrphanWorktrees(d, p)
 	mgr.resumeRecoveredRuns(plans)
+}
+
+func failManagedRunsOnStartup(d *db.DB) {
+	runs, err := d.GetActiveRuns()
+	if err != nil {
+		slog.Error("failed to inspect managed runs during recovery", "error", err)
+		return
+	}
+	for _, run := range runs {
+		if !run.ManagedAuthorization {
+			continue
+		}
+		if err := d.UpdateRunError(run.ID, "managed authorization unavailable after daemon restart; start a new managed run"); err != nil {
+			slog.Error("failed to deny managed run recovery", "run_id", run.ID, "error", err)
+		}
+	}
 }
 
 // cleanupOrphanWorktrees removes worktree directories left behind by runs
@@ -485,7 +503,7 @@ func registerHandlers(srv *ipc.Server, mgr *RunManager, d *db.DB, shutdown func(
 		if err := json.Unmarshal(params, &p); err != nil {
 			return nil, fmt.Errorf("invalid params: %w", err)
 		}
-		runID, err := mgr.HandleRerun(ctx, p.RepoID, p.Branch, p.SkipSteps, p.Intent)
+		runID, err := mgr.HandleRerun(ctx, p.RepoID, p.Branch, p.SkipSteps, p.Intent, authorization.FromWire(p.Authorization))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
+	"github.com/kunchenguid/no-mistakes/internal/authorization"
 	"github.com/kunchenguid/no-mistakes/internal/config"
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/git"
@@ -105,6 +106,9 @@ func (m *RunManager) recoverableParkedRuns(ctx context.Context) []recoveredRunPl
 }
 
 func (m *RunManager) prepareRecoveredRun(ctx context.Context, run *db.Run) (*recoveredRunPlan, error) {
+	if run != nil && run.ManagedAuthorization {
+		return nil, fmt.Errorf("managed authorization is unavailable after daemon restart; start a new managed run")
+	}
 	if run == nil || run.Status != types.RunRunning || run.AwaitingAgentSince == nil || run.Branch == "" {
 		return nil, fmt.Errorf("run is not a parked running run")
 	}
@@ -516,6 +520,23 @@ func assertGateTrustedConfigReadable(ctx context.Context, wtDir, defaultBranch, 
 // HandlePushReceived processes a push notification from the post-receive hook.
 // It creates a run, sets up a worktree, and launches pipeline execution in the background.
 func (m *RunManager) HandlePushReceived(ctx context.Context, params *ipc.PushReceivedParams) (string, error) {
+	authContext := authorization.FromWire(params.Authorization)
+	if authContext.Managed {
+		repoID, err := repoIDFromGatePath(params.Gate)
+		if err != nil {
+			return "", err
+		}
+		repo, err := m.db.GetRepo(repoID)
+		if err != nil || repo == nil {
+			return "", fmt.Errorf("managed authorization denied: repository unavailable")
+		}
+		if err := authContext.ValidateLocalScope(repo.WorkingPath, repo.UpstreamURL, authContext.WorktreePath, branchFromRef(params.Ref)); err != nil {
+			return "", err
+		}
+		if err := authContext.Authorize(ctx, authorization.OperationGatePush); err != nil {
+			return "", err
+		}
+	}
 	// Ref deletion (git push remote :branch) sends new SHA as all-zeros.
 	// Nothing to validate - skip pipeline.
 	if git.IsZeroSHA(params.New) {
@@ -536,18 +557,30 @@ func (m *RunManager) HandlePushReceived(ctx context.Context, params *ipc.PushRec
 	}
 
 	branch := branchFromRef(params.Ref)
-	return m.startRun(ctx, repo, branch, params.New, params.Old, "push", params.SkipSteps, params.Intent)
+	return m.startRun(ctx, repo, branch, params.New, params.Old, "push", params.SkipSteps, params.Intent, authContext)
 }
 
 // HandleRerun creates a new run for the latest gate head on a branch. An
 // optional intent is stamped onto the new run.
-func (m *RunManager) HandleRerun(ctx context.Context, repoID, branch string, skipSteps []types.StepName, intent string) (string, error) {
+func (m *RunManager) HandleRerun(ctx context.Context, repoID, branch string, skipSteps []types.StepName, intent string, authContexts ...authorization.Context) (string, error) {
 	repo, err := m.db.GetRepo(repoID)
 	if err != nil {
 		return "", fmt.Errorf("get repo: %w", err)
 	}
 	if repo == nil {
 		return "", fmt.Errorf("unknown repo %s", repoID)
+	}
+	var authContext authorization.Context
+	if len(authContexts) > 0 {
+		authContext = authContexts[0]
+	}
+	if authContext.Managed {
+		if err := authContext.ValidateLocalScope(repo.WorkingPath, repo.UpstreamURL, authContext.WorktreePath, branch); err != nil {
+			return "", err
+		}
+		if err := authContext.Authorize(ctx, authorization.OperationRun); err != nil {
+			return "", err
+		}
 	}
 
 	gateDir := m.paths.RepoDir(repo.ID)
@@ -584,13 +617,13 @@ func (m *RunManager) HandleRerun(ctx context.Context, repoID, branch string, ski
 		baseSHA = matchingHead.BaseSHA
 	}
 
-	return m.startRun(ctx, repo, branch, headSHA, baseSHA, "rerun", skipSteps, intent)
+	return m.startRun(ctx, repo, branch, headSHA, baseSHA, "rerun", skipSteps, intent, authContext)
 }
 
 // startRun creates a run, sets up a worktree, and launches pipeline execution.
 // A non-empty intent is stamped onto the run as agent-supplied, so the intent
 // step uses it instead of inferring from transcripts.
-func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSHA, baseSHA, trigger string, skipSteps []types.StepName, intent string) (string, error) {
+func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSHA, baseSHA, trigger string, skipSteps []types.StepName, intent string, authContext authorization.Context) (string, error) {
 	branchRole := telemetryBranchRole(branch, repo.DefaultBranch)
 	trackStartFailure := func(stage string) {
 		telemetry.Track("run", telemetry.Fields{
@@ -618,7 +651,7 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 	m.cancelActiveRuns(repo.ID, branch)
 
 	// Create run record.
-	run, err := m.db.InsertRun(repo.ID, branch, headSHA, baseSHA)
+	run, err := m.db.InsertRunWithManagedAuthorization(repo.ID, branch, headSHA, baseSHA, authContext.Managed)
 	if err != nil {
 		trackStartFailure("create_run")
 		return "", fmt.Errorf("create run: %w", err)
@@ -761,6 +794,11 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 			created = append(created, agent.WithSteering(next))
 		}
 		ag = agent.NewFallback(created)
+		if authContext.Managed {
+			ag = agent.WithLaunchAuthorization(ag, func(ctx context.Context) error {
+				return authContext.Authorize(ctx, authorization.OperationAgentLaunch)
+			})
+		}
 		// Fail closed ONLY under the trusted opt-out: when the repo asked to
 		// disable project settings, refuse any resolved harness that lacks a
 		// verified suppression knob rather than launch it with the target repo's

--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -2,6 +2,9 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,12 +12,98 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kunchenguid/no-mistakes/internal/authorization"
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/telemetry"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
+
+func TestManagedPushDenialHappensBeforeRunRow(t *testing.T) {
+	p, d := startTestDaemonWithSteps(t, func() []pipeline.Step {
+		return []pipeline.Step{&mockPassStep{name: types.StepReview}}
+	})
+	repo, headSHA := setupTestGitRepo(t, p, d, "managed-denied-repo")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request authorization.Request
+		_ = json.NewDecoder(r.Body).Decode(&request)
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(authorization.Response{
+			ProtocolVersion: request.ProtocolVersion, RequestID: request.RequestID, Operation: request.Operation,
+			TaskID: request.TaskID, RuntimeGeneration: request.RuntimeGeneration, SessionID: request.SessionID,
+			ProjectPath: request.ProjectPath, Repository: request.Repository, WorktreePath: request.WorktreePath,
+			Branch: request.Branch, DurableMode: "direct-PR", Allowed: false, Reason: "durable_task_mode_denied",
+		})
+	}))
+	defer server.Close()
+	authContext := authorization.Context{
+		Managed: true, VerifierURL: server.URL, Token: "secret", TaskID: "task-1", RuntimeGeneration: 1,
+		SessionID: "session-1", ProjectPath: repo.WorkingPath, Repository: authorization.CanonicalRepository(repo.UpstreamURL),
+		WorktreePath: repo.WorkingPath, Branch: "main", DurableMode: "no-mistakes",
+	}
+	client, err := ipc.Dial(p.Socket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	var result ipc.PushReceivedResult
+	err = client.Call(ipc.MethodPushReceived, &ipc.PushReceivedParams{
+		Gate: p.RepoDir(repo.ID), Ref: "refs/heads/main", Old: strings.Repeat("0", 40), New: headSHA,
+		Authorization: authContext.Wire(),
+	}, &result)
+	if err == nil {
+		t.Fatal("managed direct push should be denied")
+	}
+	runs, err := d.GetRunsByRepo(repo.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runs) != 0 {
+		t.Fatalf("denied push created %d run rows", len(runs))
+	}
+}
+
+func TestManagedPushAllowsExactScopeAndMarksRunManaged(t *testing.T) {
+	p, d := startTestDaemonWithSteps(t, func() []pipeline.Step {
+		return []pipeline.Step{&mockPassStep{name: types.StepReview}}
+	})
+	repo, headSHA := setupTestGitRepo(t, p, d, "managed-allowed-repo")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request authorization.Request
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatal(err)
+		}
+		_ = json.NewEncoder(w).Encode(authorization.Response{
+			ProtocolVersion: request.ProtocolVersion, RequestID: request.RequestID, Operation: request.Operation,
+			TaskID: request.TaskID, RuntimeGeneration: request.RuntimeGeneration, SessionID: request.SessionID,
+			ProjectPath: request.ProjectPath, Repository: request.Repository, WorktreePath: request.WorktreePath,
+			Branch: request.Branch, DurableMode: request.DurableMode, Allowed: true, Reason: "authorized",
+		})
+	}))
+	defer server.Close()
+	authContext := authorization.Context{
+		Managed: true, VerifierURL: server.URL, Token: "secret", TaskID: "task-1", RuntimeGeneration: 1,
+		SessionID: "session-1", ProjectPath: repo.WorkingPath, Repository: authorization.CanonicalRepository(repo.UpstreamURL),
+		WorktreePath: repo.WorkingPath, Branch: "main", DurableMode: "no-mistakes",
+	}
+	client, err := ipc.Dial(p.Socket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	var result ipc.PushReceivedResult
+	if err := client.Call(ipc.MethodPushReceived, &ipc.PushReceivedParams{
+		Gate: p.RepoDir(repo.ID), Ref: "refs/heads/main", Old: strings.Repeat("0", 40), New: headSHA,
+		Authorization: authContext.Wire(),
+	}, &result); err != nil {
+		t.Fatal(err)
+	}
+	run := waitForRunTerminalState(t, d, result.RunID)
+	if !run.ManagedAuthorization {
+		t.Fatal("allowed managed run was not marked managed")
+	}
+}
 
 // --- RunManager integration tests ---
 

--- a/internal/daemon/startup_recovery_test.go
+++ b/internal/daemon/startup_recovery_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"errors"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/kunchenguid/no-mistakes/internal/db"
@@ -84,6 +85,39 @@ func TestRecoverOnStartup_DoesNotDeleteActiveRunWorktree(t *testing.T) {
 	}
 	if got.Status != types.RunPending {
 		t.Fatalf("expected active run to remain pending, got %s", got.Status)
+	}
+}
+
+func TestManagedRunRecoveryFailsClosedWithoutLiveAuthorization(t *testing.T) {
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	d, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+	repo, err := d.InsertRepoWithID("managed-repo", "/repo", "https://github.com/acme/repo", "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := d.InsertRunWithManagedAuthorization(repo.ID, "feature", "head", "base", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := d.UpdateRunStatus(run.ID, types.RunRunning); err != nil {
+		t.Fatal(err)
+	}
+
+	failManagedRunsOnStartup(d)
+
+	got, err := d.GetRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != types.RunFailed || got.Error == nil || !strings.Contains(*got.Error, "managed authorization unavailable") {
+		t.Fatalf("managed recovery result = %#v", got)
 	}
 }
 

--- a/internal/db/run.go
+++ b/internal/db/run.go
@@ -28,6 +28,7 @@ type Run struct {
 	LastPushedAt          *int64
 	PushGeneration        *int64
 	PushActive            bool
+	ManagedAuthorization  bool
 	// CustodyReturnedAt is non-nil once a guarded branch-sync recovery
 	// explicitly ended this run's ownership of an unpublished pipeline head
 	// (terminal run whose head was never successfully pushed, or moved after
@@ -54,7 +55,7 @@ type Run struct {
 	UpdatedAt       int64
 }
 
-const runColumns = `id, repo_id, branch, head_sha, base_sha, submitted_head_sha, status, pr_url, pr_state, pr_state_observed_at, ci_ready_at, last_pushed_sha, push_target_kind, push_target_fingerprint, push_ref, last_pushed_at, push_generation, COALESCE(push_active, 0), custody_returned_at, error, awaiting_agent_since, COALESCE(parked_ms, 0), intent, intent_source, intent_session_id, intent_score, created_at, updated_at`
+const runColumns = `id, repo_id, branch, head_sha, base_sha, submitted_head_sha, status, pr_url, pr_state, pr_state_observed_at, ci_ready_at, last_pushed_sha, push_target_kind, push_target_fingerprint, push_ref, last_pushed_at, push_generation, COALESCE(push_active, 0), COALESCE(managed_authorization, 0), custody_returned_at, error, awaiting_agent_since, COALESCE(parked_ms, 0), intent, intent_source, intent_session_id, intent_score, created_at, updated_at`
 
 func scanRun(row interface {
 	Scan(...any) error
@@ -64,7 +65,7 @@ func scanRun(row interface {
 		&r.PRURL, &r.PRState, &r.PRStateObservedAt, &r.CIReadyAt,
 		&r.LastPushedSHA, &r.PushTargetKind, &r.PushTargetFingerprint, &r.PushRef,
 		&r.LastPushedAt, &r.PushGeneration, &r.PushActive,
-		&r.CustodyReturnedAt, &r.Error, &r.AwaitingAgentSince, &r.ParkedMS,
+		&r.ManagedAuthorization, &r.CustodyReturnedAt, &r.Error, &r.AwaitingAgentSince, &r.ParkedMS,
 		&r.Intent, &r.IntentSource, &r.IntentSessionID, &r.IntentScore,
 		&r.CreatedAt, &r.UpdatedAt,
 	)
@@ -72,21 +73,28 @@ func scanRun(row interface {
 
 // InsertRun creates a new run record.
 func (d *DB) InsertRun(repoID, branch, headSHA, baseSHA string) (*Run, error) {
+	return d.InsertRunWithManagedAuthorization(repoID, branch, headSHA, baseSHA, false)
+}
+
+// InsertRunWithManagedAuthorization atomically records whether this run needs
+// a live external verifier. It never persists the verifier token or scope.
+func (d *DB) InsertRunWithManagedAuthorization(repoID, branch, headSHA, baseSHA string, managed bool) (*Run, error) {
 	ts := now()
 	r := &Run{
-		ID:               newID(),
-		RepoID:           repoID,
-		Branch:           branch,
-		HeadSHA:          headSHA,
-		BaseSHA:          baseSHA,
-		SubmittedHeadSHA: &headSHA,
-		Status:           types.RunPending,
-		CreatedAt:        ts,
-		UpdatedAt:        ts,
+		ID:                   newID(),
+		RepoID:               repoID,
+		Branch:               branch,
+		HeadSHA:              headSHA,
+		BaseSHA:              baseSHA,
+		SubmittedHeadSHA:     &headSHA,
+		Status:               types.RunPending,
+		ManagedAuthorization: managed,
+		CreatedAt:            ts,
+		UpdatedAt:            ts,
 	}
 	_, err := d.sql.Exec(
-		`INSERT INTO runs (id, repo_id, branch, head_sha, base_sha, submitted_head_sha, status, pr_state, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, 'none', ?, ?)`,
-		r.ID, r.RepoID, r.Branch, r.HeadSHA, r.BaseSHA, headSHA, r.Status, r.CreatedAt, r.UpdatedAt,
+		`INSERT INTO runs (id, repo_id, branch, head_sha, base_sha, submitted_head_sha, status, pr_state, managed_authorization, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, 'none', ?, ?, ?)`,
+		r.ID, r.RepoID, r.Branch, r.HeadSHA, r.BaseSHA, headSHA, r.Status, r.ManagedAuthorization, r.CreatedAt, r.UpdatedAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("insert run: %w", err)

--- a/internal/db/run_test.go
+++ b/internal/db/run_test.go
@@ -1,10 +1,42 @@
 package db
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
+
+func TestInsertManagedRunPersistsOnlyManagedMarker(t *testing.T) {
+	d := openTestDB(t)
+	repo, err := d.InsertRepo("/repo", "https://github.com/acme/repo.git", "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := d.InsertRunWithManagedAuthorization(repo.ID, "feature", "abc123", "def456", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !run.ManagedAuthorization {
+		t.Fatal("managed marker was not returned")
+	}
+	loaded, err := d.GetRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded == nil || !loaded.ManagedAuthorization {
+		t.Fatalf("managed marker was not persisted: %#v", loaded)
+	}
+	var schema string
+	if err := d.sql.QueryRow("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'runs'").Scan(&schema); err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"token", "credential", "verifier_url", "authorization_task", "authorization_session"} {
+		if strings.Contains(strings.ToLower(schema), forbidden) {
+			t.Fatalf("runs schema persists managed secret/scope field %q: %s", forbidden, schema)
+		}
+	}
+}
 
 func TestRunInsertAndGet(t *testing.T) {
 	d := openTestDB(t)

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -29,6 +29,7 @@ CREATE TABLE IF NOT EXISTS runs (
     last_pushed_at          INTEGER,
     push_generation         INTEGER,
     push_active             INTEGER NOT NULL DEFAULT 0,
+    managed_authorization   INTEGER NOT NULL DEFAULT 0,
     error                   TEXT,
     awaiting_agent_since INTEGER,
     parked_ms            INTEGER,
@@ -163,6 +164,9 @@ var migrationStatements = []string{
 	// unpublished head this run produced; a timestamp means an explicit
 	// guarded recovery ended that ownership (internal/branchsync).
 	`ALTER TABLE runs ADD COLUMN custody_returned_at INTEGER`,
+	// Only the non-secret managed marker is durable. Verifier credentials and
+	// scope stay in daemon memory and are deliberately unrecoverable.
+	`ALTER TABLE runs ADD COLUMN managed_authorization INTEGER NOT NULL DEFAULT 0`,
 	`ALTER TABLE step_results ADD COLUMN last_activity_at INTEGER`,
 	`ALTER TABLE step_results ADD COLUMN last_activity TEXT`,
 	`ALTER TABLE step_results ADD COLUMN agent_pid INTEGER`,

--- a/internal/e2e/main_test.go
+++ b/internal/e2e/main_test.go
@@ -1,0 +1,22 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	// The E2E suite models standalone no-mistakes unless an individual test
+	// explicitly supplies managed authorization context. Do not let the
+	// orchestrator running `go test` change the child binaries' mode.
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		if strings.HasPrefix(key, "PERCH_") || strings.HasPrefix(key, "NO_MISTAKES_AUTHORIZATION_") {
+			_ = os.Unsetenv(key)
+		}
+	}
+	os.Exit(m.Run())
+}

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -2,8 +2,10 @@ package ipc
 
 import (
 	"encoding/json"
+	"fmt"
 	"sync/atomic"
 
+	"github.com/kunchenguid/no-mistakes/internal/authorization"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
@@ -70,7 +72,17 @@ type PushReceivedParams struct {
 	New       string           `json:"new"`
 	SkipSteps []types.StepName `json:"skip_steps,omitempty"`
 	Intent    string           `json:"intent,omitempty"`
+	// Authorization is transient local-IPC capability context. It is never
+	// returned by diagnostic APIs or persisted in the run database.
+	Authorization *authorization.WireContext `json:"authorization,omitempty"`
 }
+
+func (p PushReceivedParams) String() string {
+	return fmt.Sprintf("PushReceivedParams{Gate:%q Ref:%q Old:%q New:%q SkipSteps:%v IntentSet:%t Managed:%t}",
+		p.Gate, p.Ref, p.Old, p.New, p.SkipSteps, p.Intent != "", p.Authorization != nil && p.Authorization.Managed)
+}
+
+func (p PushReceivedParams) GoString() string { return p.String() }
 
 // GetRunParams requests a single run by ID.
 type GetRunParams struct {
@@ -102,11 +114,19 @@ type GetActiveRunParams struct {
 // RerunParams requests a new run for the latest gate head on a branch.
 // Intent, when set, is stamped onto the new run like PushReceivedParams.Intent.
 type RerunParams struct {
-	RepoID    string           `json:"repo_id"`
-	Branch    string           `json:"branch"`
-	SkipSteps []types.StepName `json:"skip_steps,omitempty"`
-	Intent    string           `json:"intent,omitempty"`
+	RepoID        string                     `json:"repo_id"`
+	Branch        string                     `json:"branch"`
+	SkipSteps     []types.StepName           `json:"skip_steps,omitempty"`
+	Intent        string                     `json:"intent,omitempty"`
+	Authorization *authorization.WireContext `json:"authorization,omitempty"`
 }
+
+func (p RerunParams) String() string {
+	return fmt.Sprintf("RerunParams{RepoID:%q Branch:%q SkipSteps:%v IntentSet:%t Managed:%t}",
+		p.RepoID, p.Branch, p.SkipSteps, p.Intent != "", p.Authorization != nil && p.Authorization.Managed)
+}
+
+func (p RerunParams) GoString() string { return p.String() }
 
 // SubscribeParams starts an event stream for a run.
 type SubscribeParams struct {

--- a/internal/ipc/protocol_test.go
+++ b/internal/ipc/protocol_test.go
@@ -2,9 +2,12 @@ package ipc
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/kunchenguid/no-mistakes/internal/authorization"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
@@ -125,11 +128,12 @@ func TestResponseError(t *testing.T) {
 
 func TestPushReceivedParams(t *testing.T) {
 	params := PushReceivedParams{
-		Gate:      "/path/to/gate.git",
-		Ref:       "refs/heads/main",
-		Old:       "aaa",
-		New:       "bbb",
-		SkipSteps: []types.StepName{types.StepTest, types.StepLint},
+		Gate:          "/path/to/gate.git",
+		Ref:           "refs/heads/main",
+		Old:           "aaa",
+		New:           "bbb",
+		SkipSteps:     []types.StepName{types.StepTest, types.StepLint},
+		Authorization: (&authorization.Context{Managed: true, Token: "ipc-secret"}).Wire(),
 	}
 	data, _ := json.Marshal(params)
 	var got PushReceivedParams
@@ -141,6 +145,12 @@ func TestPushReceivedParams(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got.SkipSteps, params.SkipSteps) {
 		t.Errorf("skip_steps = %+v, want %+v", got.SkipSteps, params.SkipSteps)
+	}
+	if got.Authorization == nil || got.Authorization.Token != "ipc-secret" {
+		t.Fatal("transient authorization context did not cross IPC encoding")
+	}
+	if rendered := fmt.Sprintf("%#v", params); strings.Contains(rendered, "ipc-secret") {
+		t.Fatalf("IPC diagnostic leaked credential: %s", rendered)
 	}
 }
 

--- a/managed_authorization_contract_test.go
+++ b/managed_authorization_contract_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/authorization"
+)
+
+func TestManagedAuthorizationVersionSurfacesStayInSync(t *testing.T) {
+	docs, err := os.ReadFile("docs/src/content/docs/reference/managed-authorization.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"Protocol version " + authorization.ProtocolVersion,
+		"authorization-protocol=" + authorization.ProtocolVersion,
+		`"protocolVersion": "` + authorization.ProtocolVersion + `"`,
+	} {
+		if !strings.Contains(string(docs), want) {
+			t.Fatalf("managed authorization docs missing canonical version surface %q", want)
+		}
+	}
+
+	manifest, err := os.ReadFile(".release-please-manifest.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var versions map[string]string
+	if err := json.Unmarshal(manifest, &versions); err != nil {
+		t.Fatal(err)
+	}
+	if !regexp.MustCompile(`^\d+\.\d+\.\d+(?:[-+].+)?$`).MatchString(versions["."]) {
+		t.Fatalf("release manifest version is not semver: %q", versions["."])
+	}
+
+	workflow, err := os.ReadFile(".github/workflows/release.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"ref: ${{ needs.release-please.outputs.tag_name }}",
+		"buildinfo.Version=${TAG}",
+		"sha256sum no-mistakes-* > ../checksums.txt",
+	} {
+		if !strings.Contains(string(workflow), want) {
+			t.Fatalf("release workflow missing version/artifact binding %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This adds an opt-in, provider-neutral managed authorization boundary for orchestrators that run no-mistakes on behalf of a durable task runtime.
Standalone no-mistakes behavior is unchanged when managed authorization variables are absent, and unmanaged use performs no verifier network request.

Protocol version 1 binds each fresh decision to the operation, one-use request ID, task ID, runtime generation, live session, canonical project path, canonical credential-free repository, canonical worktree path, exact branch, and durable mode.
The build exposes `authorization-protocol=1` in `no-mistakes --version` so distributors can reject incompatible binaries.

## Security boundaries

- `no-mistakes axi run` authorizes `run` before a gate push or rerun can create a run.
- The gate receiver authorizes `gate-push` before `HandlePushReceived` inserts a run row.
- Every concrete native agent attempt authorizes `agent-launch` immediately before launch, including retries and fallback providers.
- Decisions are never cached, and verifier redirects are rejected so credentials cannot cross an HTTP redirect.
- CLI, hook, and local IPC carry only transient capability context.
- SQLite stores only a non-secret `managed_authorization` marker.
- Agent child environments remove all `PERCH_*` and `NO_MISTAKES_AUTHORIZATION_*` values.
- Managed runs fail closed on daemon restart because the live capability is intentionally not persisted.
- Managed self-update is disabled so an orchestrator remains responsible for the pinned binary.

Errors use compact fixed messages or restricted reason codes and never include credentials or raw verifier bodies.

## Protocol and Perch coordination

The generic provider uses `NO_MISTAKES_AUTHORIZATION_*` variables and a bearer token.
The Perch adapter reuses the authenticated local hook channel and derives `/hooks/no-mistakes/authorize` from `PERCH_HOOK_URL`.

The response must echo `protocolVersion`, `requestId`, `operation`, `taskId`, `runtimeGeneration`, `sessionId`, `projectPath`, `repository`, `worktreePath`, `branch`, and `durableMode`, then add `allowed` and `reason`.
The verifier must independently validate the live durable state and atomically reject reused request IDs.

Companion Perch PR https://github.com/zoidz123/perch/pull/3 requires an amendment before integration.
At its inspected head `256c6283aa77f06f0a3022faf836d178485c4434`, Perch must additionally export `PERCH_TASK_REPOSITORY` and `PERCH_RUNTIME_GENERATION`, accept and validate the complete request above, echo every field, and reject replay.
The current response omits `protocolVersion`, `requestId`, `operation`, `sessionId`, `projectPath`, `repository`, `worktreePath`, and `branch`.

The integration and threat model are documented in `docs/src/content/docs/reference/managed-authorization.md`.

## Compatibility

Managed mode activates only when a recognized managed environment is present.
Any incomplete managed environment fails closed instead of silently becoming standalone.
Existing unmanaged CLI, hook, IPC, daemon, database, agent, update, and recovery behavior remains compatible.

## Verification

All verifier and agent tests use local fake HTTP servers and fake agents.
No real Claude, Codex, AXI gate, or authenticated review agent was launched.

- `make fmt`
- `make lint`
- `go test ./...`
- `go test -race ./...`
- `make e2e`
- `npm ci && npm run build` in `docs/`
- `make build` and `./bin/no-mistakes --version`
- `CGO_ENABLED=0 go build` for darwin, linux, and windows on amd64 and arm64

The complete E2E suite passed in 204.884 seconds for `internal/e2e` and 51.667 seconds for `internal/pipeline/steps`.
The docs build produced the managed authorization route successfully.

Upstream base: `0a2c82f993b9467c5ab84992313dfd13b66830af`.
Contribution head: `1ffd1403ad482bfb01c6ddb5828b44622d23c2a3`.
