### PR TITLE
fix(cli): reattach active AXI runs by submitted head

### DIFF
--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -175,7 +175,8 @@ no-mistakes axi abort --run <id>
 Before any post-pipeline local commit or fresh run, read `branch_sync`.
 Only when its structured `next_action.code` is `sync`, run `no-mistakes axi sync` first.
 When `next_action.code` is `recover_custody` - a terminal run left unpublished pipeline commits preserved in the local gate - run `no-mistakes axi sync --recover` to return custody, or `no-mistakes rerun` to resume validating the preserved head.
-If synchronization is blocked or the pipeline still owns an unpublished update, process that state instead of improvising reset, stash, merge, rebase, force, or branch replacement.
+When `next_action.code` is `continue_active_run`, run the reported command and keep driving the active run.
+If synchronization is blocked, process that state instead of improvising reset, stash, merge, rebase, force, or branch replacement.
 Then commit follow-up work on top so every pipeline fix commit remains in the branch.
 
 The full driving protocol - how to read the home view and `gate:` objects, when to respond, fix, approve, or relay `ask-user` findings, and how to interpret `axi status` fields like `awaiting_agent` and `active_steps` - is owned by the skill itself and by the live `axi` output.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -97,6 +97,9 @@ It is the user's goal or request, and no-mistakes uses it verbatim instead of tr
 Err on the side of completeness: include the goal, important decisions and tradeoffs, constraints or approaches ruled in or out, and explicit requests that might otherwise look surprising in the diff.
 When starting a new run, `axi run` refuses the default branch and uncommitted working trees with actionable errors instead of auto-branching or auto-committing.
 Reattaching to an in-flight run does not require `--intent`.
+Reattachment accepts either the run's immutable submitted head or its current pipeline head, so pipeline-created fix commits do not detach an unchanged submitting worktree.
+When neither identity matches, `axi run` keeps the fresh-run path but refuses a gate push while `branch_sync` says the pipeline still owns the branch.
+That refusal returns the complete structured state and its `continue_active_run` or `recover_custody` next action instead of a raw Git non-fast-forward.
 Reattaching to an in-flight run can proceed while the daemon is already running even if the global config file has become invalid, but starting a fresh run still requires valid global config.
 Starting a fresh run also requires a runnable effective pipeline agent.
 If the configured native agent or ACP runner is unavailable, the run fails before any pipeline step starts instead of reporting command-only validation as a passed gate.
@@ -192,7 +195,8 @@ Run `axi sync` only when structured output offers `next_action.code: sync`; proc
 
 ### Custody recovery
 
-A run that goes terminal (cancelled, failed, or completed without a push stage) after moving the pipeline head leaves the branch `pipeline_owned` with `safety: blocked_pipeline_owned_recoverable`, the run's terminal `pipeline.status`, and `next_action.code: recover_custody`; while the run is still active the same state stays a plain wait with no action.
+A run that goes terminal (cancelled, failed, or completed without a push stage) after moving the pipeline head leaves the branch `pipeline_owned` with `safety: blocked_pipeline_owned_recoverable`, the run's terminal `pipeline.status`, and `next_action.code: recover_custody`.
+While the run is still active, the same state stays blocked and reports `next_action.code: continue_active_run` with `no-mistakes axi status`.
 `--recover` verifies the run is terminal, anchors the preserved head under `refs/no-mistakes/recover/<run>` in the invoking repository, and stamps custody returned so a fresh run can start.
 For equal or ahead worktrees where the preserved head is already locally reachable, recovery writes that anchor locally without gate access.
 For behind or diverged worktrees, recovery verifies the preserved head at the local gate branch and fetches it into the anchor before fast-forwarding only a clean behind worktree or refusing with the anchor named.
@@ -242,6 +246,8 @@ no-mistakes axi abort --run <id>
 Use it to reap an orphaned CI monitor whose worktree was torn down before the PR merged - the run id is shown in `axi run` output and in the `axi` home view.
 Aborting an id that is not an active run is a successful no-op.
 When the daemon is already running, `axi abort` can cancel an active run even if the global config file has become invalid, because it is not starting a fresh run.
+Branch-scoped abort waits for the cancellation state to persist, then renders the refreshed `branch_sync` object and its exact next action.
+Pipeline-created commits remain preserved in the gate and a recoverable cancellation points directly to `no-mistakes axi sync --recover`.
 While a run is active, do not use `axi abort` or `no-mistakes rerun` to go fix a finding yourself.
 That cancels the pipeline's in-flight work and forces a full re-validation; use `axi respond --action fix` at the gate so the pipeline applies and re-checks the fix.
 

--- a/internal/branchsync/recover_test.go
+++ b/internal/branchsync/recover_test.go
@@ -141,8 +141,11 @@ func TestTerminalPrePushRunSurfacesGuardedCustodyRecovery(t *testing.T) {
 func TestActivePrePushRunStaysBlockedWithoutRecovery(t *testing.T) {
 	f := newRecoverFixture(t, types.RunRunning)
 	state := f.service.InspectCached(f.ctx)
-	if state.State != StatePipelineOwned || state.Safety != "blocked_pipeline_owned" || state.NextAction != nil {
+	if state.State != StatePipelineOwned || state.Safety != "blocked_pipeline_owned" {
 		t.Fatalf("active run state = %#v", state)
+	}
+	if state.NextAction == nil || state.NextAction.Code != "continue_active_run" || state.NextAction.Command != "no-mistakes axi status" {
+		t.Fatalf("active run next action = %#v", state.NextAction)
 	}
 	if state.Pipeline.Status != "running" {
 		t.Fatalf("pipeline status = %q", state.Pipeline.Status)

--- a/internal/branchsync/sync.go
+++ b/internal/branchsync/sync.go
@@ -709,6 +709,7 @@ func (s *Service) inspect(ctx context.Context) (State, *db.Run, bool) {
 		state.State = StatePushInProgress
 		state.Safety = "blocked_push_in_progress"
 		state.Pipeline.Phase = "push"
+		state.NextAction = &NextAction{Code: "continue_active_run", Command: "no-mistakes axi status"}
 		return state, run, false
 	}
 	if run.LastPushedSHA == nil || run.PushTargetFingerprint == nil || run.PushRef == nil || run.PushGeneration == nil || run.SubmittedHeadSHA == nil {
@@ -986,6 +987,7 @@ func classifyPipelineOwned(state *State, run *db.Run, activeMessage string) {
 	}
 	state.Safety = "blocked_pipeline_owned"
 	state.Error = activeMessage
+	state.NextAction = &NextAction{Code: "continue_active_run", Command: "no-mistakes axi status"}
 }
 
 // classifyCustodyReturned reports a branch whose stranded terminal run was

--- a/internal/branchsync/sync_test.go
+++ b/internal/branchsync/sync_test.go
@@ -173,15 +173,21 @@ func TestInspectCachedPrePushAndPushInProgressAreNonSyncable(t *testing.T) {
 		t.Fatal(err)
 	}
 	state := f.service.InspectCached(f.ctx)
-	if state.State != StatePipelineOwned || state.NextAction != nil || !strings.Contains(state.Error, "do not make local follow-up commits") {
+	if state.State != StatePipelineOwned || !strings.Contains(state.Error, "do not make local follow-up commits") {
 		t.Fatalf("pre-push state = %#v", state)
+	}
+	if state.NextAction == nil || state.NextAction.Code != "continue_active_run" || state.NextAction.Command != "no-mistakes axi status" {
+		t.Fatalf("pre-push next action = %#v", state.NextAction)
 	}
 	if err := f.db.SetRunPushActive(active.ID, true); err != nil {
 		t.Fatal(err)
 	}
 	state = f.service.InspectCached(f.ctx)
-	if state.State != StatePushInProgress || state.NextAction != nil {
+	if state.State != StatePushInProgress {
 		t.Fatalf("push-in-progress state = %#v", state)
+	}
+	if state.NextAction == nil || state.NextAction.Code != "continue_active_run" || state.NextAction.Command != "no-mistakes axi status" {
+		t.Fatalf("push-in-progress next action = %#v", state.NextAction)
 	}
 	if err := f.db.SetRunPushActive(active.ID, false); err != nil {
 		t.Fatal(err)

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -11,6 +11,7 @@ import (
 
 	toon "github.com/toon-format/toon-go"
 
+	"github.com/kunchenguid/no-mistakes/internal/branchsync"
 	"github.com/kunchenguid/no-mistakes/internal/cimonitor"
 	"github.com/kunchenguid/no-mistakes/internal/daemon"
 	"github.com/kunchenguid/no-mistakes/internal/gate"
@@ -30,6 +31,10 @@ const drivePollInterval = 250 * time.Millisecond
 // triggerWaitTimeout bounds how long we wait for the daemon to register a run
 // after pushing to the gate before falling back to a rerun.
 const triggerWaitTimeout = 5 * time.Second
+
+// abortStateWaitTimeout bounds the post-cancel wait for the executor to
+// persist its terminal state before AXI renders refreshed custody guidance.
+const abortStateWaitTimeout = 10 * time.Second
 
 // terminalStatus reports whether a run has reached a final state.
 func terminalStatus(status string) bool {
@@ -145,6 +150,9 @@ func runAxiRun(cmd *cobra.Command, autoYes bool, skipSteps []types.StepName, int
 		var err error
 		runID, err = triggerRun(ctx, env, branch, headSHA, skipSteps, intent)
 		if err != nil {
+			if ownershipErr, ok := err.(*branchOwnershipError); ok {
+				return emitBranchOwnershipError(cmd, ownershipErr)
+			}
 			return emitError(cmd, 1, err.Error())
 		}
 	}
@@ -181,7 +189,11 @@ func activeRunIDForHead(active *ipc.GetActiveRunResult, headSHA string) string {
 }
 
 func activeRunInfoForHead(run *ipc.RunInfo, headSHA string) *ipc.RunInfo {
-	if run == nil || terminalStatus(string(run.Status)) || run.HeadSHA != headSHA {
+	if run == nil || terminalStatus(string(run.Status)) {
+		return nil
+	}
+	matchesSubmitted := run.SubmittedHeadSHA != nil && *run.SubmittedHeadSHA == headSHA
+	if run.HeadSHA != headSHA && !matchesSubmitted {
 		return nil
 	}
 	return run
@@ -216,6 +228,56 @@ func preflightGuard(ctx context.Context, env *axiEnv, branch string) func(*cobra
 	return nil
 }
 
+// branchOwnershipError carries the shared branch-sync classification that
+// blocked a fresh trigger. Keeping the state intact lets AXI render the exact
+// structured next action instead of reducing the refusal to a Git push error.
+type branchOwnershipError struct {
+	state branchsync.State
+}
+
+func (e *branchOwnershipError) Error() string {
+	if e.state.Error != "" {
+		return e.state.Error
+	}
+	return "the pipeline still owns this branch; no fresh run was started"
+}
+
+func emitBranchOwnershipError(cmd *cobra.Command, ownershipErr *branchOwnershipError) error {
+	state := ownershipErr.state
+	fields := []toon.Field{
+		{Key: "error", Value: ownershipErr.Error()},
+		branchSyncField(state),
+	}
+	if state.NextAction != nil {
+		fields = append(fields, toon.Field{Key: "help", Value: []string{
+			"Run `" + state.NextAction.Command + "`",
+			branchSyncAgentGuidance,
+		}})
+	}
+	emitDoc(cmd, fields...)
+	return &exitError{code: 1}
+}
+
+func inspectAxiBranchSync(ctx context.Context, env *axiEnv) branchsync.State {
+	service := &branchsync.Service{
+		DB:      env.d,
+		Repo:    env.repo,
+		WorkDir: ".",
+		GateDir: env.p.RepoDir(env.repo.ID),
+	}
+	return service.InspectCached(ctx)
+}
+
+func freshRunBranchOwnershipState(ctx context.Context, env *axiEnv) *branchsync.State {
+	state := inspectAxiBranchSync(ctx, env)
+	switch state.State {
+	case branchsync.StatePipelineOwned, branchsync.StatePushInProgress:
+		return &state
+	default:
+		return nil
+	}
+}
+
 // triggerRun starts a fresh run for branch: it pushes the current HEAD through
 // the gate to trigger a pipeline, and falls back to a rerun when the push was a
 // no-op (the gate already had this commit). Callers must check for an existing
@@ -231,7 +293,18 @@ func triggerRun(ctx context.Context, env *axiEnv, branch, headSHA string, skipSt
 		// a matching terminal run may predate this push, so do not attach to it.
 		priorRunIDs = nil
 	}
+	if state := freshRunBranchOwnershipState(ctx, env); state != nil {
+		return "", &branchOwnershipError{state: *state}
+	}
 	pushErr := git.PushWithOptions(ctx, ".", gate.RemoteName, "refs/heads/"+branch, "", false, pushOptions)
+	if pushErr != nil {
+		// Close the inspection-to-push race: if the pipeline advanced ownership
+		// after the pre-push check, preserve the structured branch-sync refusal
+		// instead of leaking the resulting Git non-fast-forward.
+		if state := freshRunBranchOwnershipState(ctx, env); state != nil {
+			return "", &branchOwnershipError{state: *state}
+		}
+	}
 
 	if run, _ := waitForTriggeredRunForHead(ctx, env.client, env.repo.ID, branch, headSHA, priorRunIDs, triggerWaitTimeout); run != nil {
 		return run.ID, nil
@@ -825,15 +898,53 @@ func runAxiAbort(cmd *cobra.Command, runID string) error {
 	if err := env.client.Call(ipc.MethodCancelRun, &ipc.CancelRunParams{RunID: active.Run.ID}, &result); err != nil {
 		return emitError(cmd, 1, fmt.Sprintf("abort run: %v", err))
 	}
-	emitDoc(cmd,
+	waitForTerminalRun(ctx, env.client, active.Run.ID, abortStateWaitTimeout)
+	fields := []toon.Field{
 		toon.Field{Key: "aborted", Value: true},
 		toon.Field{Key: "run", Value: active.Run.ID},
 		toon.Field{Key: "branch", Value: active.Run.Branch},
-		toon.Field{Key: "help", Value: []string{
-			"Run `no-mistakes axi sync --check` before any local follow-up commit - a cancelled run can leave unpublished pipeline commits preserved in the local gate, and the check offers the guarded custody recovery",
-		}},
+	}
+	state := inspectAxiBranchSync(ctx, env)
+	if state.Pipeline.RunID == active.Run.ID && relevantCachedSyncState(state) {
+		fields = append(fields, branchSyncField(state))
+	}
+	help := []string{
+		"Run `no-mistakes axi sync --check` before any local follow-up commit - a cancelled run can leave unpublished pipeline commits preserved in the local gate, and the check offers the guarded custody recovery",
+	}
+	if state.Pipeline.RunID == active.Run.ID && state.NextAction != nil {
+		help = []string{
+			"Run `" + state.NextAction.Command + "`",
+			branchSyncAgentGuidance,
+		}
+	}
+	fields = append(fields,
+		toon.Field{Key: "help", Value: help},
 	)
+	emitDoc(cmd, fields...)
 	return nil
+}
+
+func waitForTerminalRun(ctx context.Context, client *ipc.Client, runID string, timeout time.Duration) *ipc.RunInfo {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		run, err := getRunInfo(client, runID)
+		if err != nil {
+			return nil
+		}
+		if run != nil && terminalStatus(string(run.Status)) {
+			return run
+		}
+		select {
+		case <-ctx.Done():
+			return run
+		case <-timer.C:
+			return run
+		case <-ticker.C:
+		}
+	}
 }
 
 // runAxiAbortByRunID cancels a run by its id directly via the daemon, without

--- a/internal/cli/axi_test.go
+++ b/internal/cli/axi_test.go
@@ -395,34 +395,50 @@ func TestActiveRunLookupParamsIncludeBranch(t *testing.T) {
 	}
 }
 
-func TestActiveRunIDForHeadRequiresMatchingHead(t *testing.T) {
-	active := &ipc.GetActiveRunResult{Run: &ipc.RunInfo{ID: "run-old", Status: types.RunRunning, HeadSHA: "old-head"}}
+func TestActiveRunIDForHeadMatchesSubmittedOrCurrentHead(t *testing.T) {
+	submitted := "submitted-head"
+	active := &ipc.GetActiveRunResult{Run: &ipc.RunInfo{
+		ID:               "run-managed-fix",
+		Status:           types.RunRunning,
+		HeadSHA:          "pipeline-fix-head",
+		SubmittedHeadSHA: &submitted,
+	}}
 
-	if got := activeRunIDForHead(active, "new-head"); got != "" {
+	if got := activeRunIDForHead(active, "new-operator-head"); got != "" {
 		t.Fatalf("mismatched active run ID = %q, want empty", got)
 	}
-	if got := activeRunIDForHead(active, "old-head"); got != "run-old" {
-		t.Fatalf("matching active run ID = %q, want run-old", got)
+	for _, head := range []string{submitted, "pipeline-fix-head"} {
+		if got := activeRunIDForHead(active, head); got != "run-managed-fix" {
+			t.Fatalf("active run ID for %s = %q, want run-managed-fix", head, got)
+		}
 	}
 
 	active.Run.Status = types.RunCompleted
-	if got := activeRunIDForHead(active, "old-head"); got != "" {
+	if got := activeRunIDForHead(active, submitted); got != "" {
 		t.Fatalf("terminal active run ID = %q, want empty", got)
 	}
 }
 
-func TestActiveRunInfoForHeadRequiresMatchingHead(t *testing.T) {
-	run := &ipc.RunInfo{ID: "run-old", Status: types.RunRunning, HeadSHA: "old-head"}
+func TestActiveRunInfoForHeadMatchesSubmittedOrCurrentHead(t *testing.T) {
+	submitted := "submitted-head"
+	run := &ipc.RunInfo{
+		ID:               "run-managed-fix",
+		Status:           types.RunRunning,
+		HeadSHA:          "pipeline-fix-head",
+		SubmittedHeadSHA: &submitted,
+	}
 
-	if got := activeRunInfoForHead(run, "new-head"); got != nil {
+	if got := activeRunInfoForHead(run, "new-operator-head"); got != nil {
 		t.Fatalf("mismatched active run = %#v, want nil", got)
 	}
-	if got := activeRunInfoForHead(run, "old-head"); got == nil || got.ID != "run-old" {
-		t.Fatalf("matching active run = %#v, want run-old", got)
+	for _, head := range []string{submitted, "pipeline-fix-head"} {
+		if got := activeRunInfoForHead(run, head); got == nil || got.ID != "run-managed-fix" {
+			t.Fatalf("active run for %s = %#v, want run-managed-fix", head, got)
+		}
 	}
 
 	run.Status = types.RunCompleted
-	if got := activeRunInfoForHead(run, "old-head"); got != nil {
+	if got := activeRunInfoForHead(run, submitted); got != nil {
 		t.Fatalf("terminal active run = %#v, want nil", got)
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -558,6 +558,7 @@ func runToInfo(d *db.DB, r *db.Run, steps []*db.StepResult) *ipc.RunInfo {
 		RepoID:             r.RepoID,
 		Branch:             r.Branch,
 		HeadSHA:            r.HeadSHA,
+		SubmittedHeadSHA:   r.SubmittedHeadSHA,
 		BaseSHA:            r.BaseSHA,
 		Status:             r.Status,
 		PRURL:              r.PRURL,

--- a/internal/daemon/runinfo_test.go
+++ b/internal/daemon/runinfo_test.go
@@ -8,6 +8,38 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
+func TestRunToInfoIncludesImmutableSubmittedHead(t *testing.T) {
+	d, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer d.Close()
+
+	repo, err := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")
+	if err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+	run, err := d.InsertRun(repo.ID, "feature", "submitted-head", "base-head")
+	if err != nil {
+		t.Fatalf("insert run: %v", err)
+	}
+	if err := d.UpdateRunHeadSHA(run.ID, "pipeline-fix-head"); err != nil {
+		t.Fatalf("advance run head: %v", err)
+	}
+	run, err = d.GetRun(run.ID)
+	if err != nil {
+		t.Fatalf("reload run: %v", err)
+	}
+
+	info := runToInfo(d, run, nil)
+	if info.HeadSHA != "pipeline-fix-head" {
+		t.Fatalf("head = %q, want pipeline-fix-head", info.HeadSHA)
+	}
+	if info.SubmittedHeadSHA == nil || *info.SubmittedHeadSHA != "submitted-head" {
+		t.Fatalf("submitted head = %v, want submitted-head", info.SubmittedHeadSHA)
+	}
+}
+
 func TestStepToInfoIncludesFixSummaries(t *testing.T) {
 	d, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
 	if err != nil {

--- a/internal/e2e/axi_journey_test.go
+++ b/internal/e2e/axi_journey_test.go
@@ -186,6 +186,135 @@ func TestAxiBranchSyncJourney(t *testing.T) {
 	}
 }
 
+// TestAxiRunReattachesAfterManagedFix reproduces the v1.39.0 dogfood failure:
+// a review fix advances the active run and gate branch while the submitting
+// worktree remains at its immutable submitted head. A second axi run from that
+// unchanged worktree must reattach without pushing or creating another run.
+func TestAxiRunReattachesAfterManagedFix(t *testing.T) {
+	h := NewHarness(t, SetupOpts{Agent: "claude", Scenario: branchSyncScenario(t)})
+	h.CommitChange("init-reattach", "seed.txt", "seed\n", "seed reattach init")
+	initWorktree := h.AddWorktree("init-reattach")
+	if out, err := h.RunInDir(initWorktree, "init"); err != nil {
+		t.Fatalf("init: %v\n%s", err, out)
+	}
+
+	branch := "feature/reattach-managed-fix"
+	submitted := h.CommitChange(branch, "feature.txt", "unsafe\n", "add unsafe feature")
+	operator := h.AddWorktree(branch)
+	gateOut, err := h.RunInDir(operator, "axi", "run", "--intent", "guard the feature and preserve the submitting head")
+	if err != nil || !strings.Contains(gateOut, "sync-1") {
+		t.Fatalf("initial review gate: %v\n%s", err, gateOut)
+	}
+	originalRun := h.ActiveRun(branch)
+	if originalRun == nil {
+		t.Fatal("initial axi run did not leave an active run")
+	}
+
+	fixOut, err := h.RunInDir(operator, "axi", "respond", "--action", "fix", "--findings", "sync-1")
+	if err != nil || !strings.Contains(fixOut, "status: fix_review") {
+		t.Fatalf("review fix: %v\n%s", err, fixOut)
+	}
+	managed := h.ActiveRun(branch)
+	if managed == nil || managed.ID != originalRun.ID {
+		t.Fatalf("managed fix active run = %#v, want %s", managed, originalRun.ID)
+	}
+	if managed.HeadSHA == submitted {
+		t.Fatal("managed fix did not advance the pipeline head")
+	}
+	if got := strings.TrimSpace(h.WorktreeRefSHA(branch)); got != submitted {
+		t.Fatalf("submitting worktree moved to %s, want %s", got, submitted)
+	}
+
+	gateDir := filepath.Join(h.NMHome, "repos", h.repoID()+".git")
+	gateHeadBeforeBytes, gitErr := h.runGit(context.Background(), gateDir, "rev-parse", "refs/heads/"+branch)
+	if gitErr != nil {
+		t.Fatalf("gate head before reattach: %v\n%s", gitErr, gateHeadBeforeBytes)
+	}
+	gateHeadBefore := strings.TrimSpace(string(gateHeadBeforeBytes))
+	if gateHeadBefore != managed.HeadSHA {
+		t.Fatalf("gate head = %s, want managed head %s", gateHeadBefore, managed.HeadSHA)
+	}
+	runsBefore := len(h.Runs())
+	tracePath := filepath.Join(t.TempDir(), "git-trace.json")
+
+	reattachOut, err := h.RunInDirWithEnv(operator, map[string]string{"GIT_TRACE2_EVENT": tracePath}, "axi", "run", "--intent", "guard the feature and preserve the submitting head")
+	if err != nil {
+		t.Fatalf("reattach after managed fix: %v\n%s", err, reattachOut)
+	}
+	for _, want := range []string{originalRun.ID, "status: fix_review"} {
+		if !strings.Contains(reattachOut, want) {
+			t.Errorf("reattach output missing %q:\n%s", want, reattachOut)
+		}
+	}
+	for _, forbidden := range []string{"fetch first", "non-fast-forward"} {
+		if strings.Contains(reattachOut, forbidden) {
+			t.Errorf("reattach output contains %q:\n%s", forbidden, reattachOut)
+		}
+	}
+	trace, readErr := os.ReadFile(tracePath)
+	if readErr != nil {
+		t.Fatalf("read git trace: %v", readErr)
+	}
+	if strings.Contains(string(trace), `"argv":["git","push"`) {
+		t.Fatalf("reattach executed a fresh gate push:\n%s", trace)
+	}
+	if got := len(h.Runs()); got != runsBefore {
+		t.Fatalf("reattach changed run count from %d to %d", runsBefore, got)
+	}
+	stillActive := h.ActiveRun(branch)
+	if stillActive == nil || stillActive.ID != originalRun.ID || stillActive.Status != types.RunRunning {
+		t.Fatalf("original run was replaced or cancelled: %#v", stillActive)
+	}
+	gateHeadAfterBytes, gitErr := h.runGit(context.Background(), gateDir, "rev-parse", "refs/heads/"+branch)
+	if gitErr != nil || strings.TrimSpace(string(gateHeadAfterBytes)) != gateHeadBefore {
+		t.Fatalf("gate head after reattach = %s (err %v), want %s", strings.TrimSpace(string(gateHeadAfterBytes)), gitErr, gateHeadBefore)
+	}
+
+	// A genuinely new operator commit matches neither immutable submitted HEAD
+	// nor mutable pipeline HEAD. It must not reattach, but pipeline ownership
+	// must still block a colliding fresh push with a structured next action.
+	if err := os.WriteFile(filepath.Join(operator, "operator-work.txt"), []byte("new operator work\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, gitErr := h.runGit(context.Background(), operator, "add", "operator-work.txt"); gitErr != nil {
+		t.Fatalf("stage operator work: %v\n%s", gitErr, out)
+	}
+	if out, gitErr := h.runGit(context.Background(), operator, "commit", "-m", "new operator work"); gitErr != nil {
+		t.Fatalf("commit operator work: %v\n%s", gitErr, out)
+	}
+	mismatchTracePath := filepath.Join(t.TempDir(), "mismatch-git-trace.json")
+	blockedOut, blockedErr := h.RunInDirWithEnv(operator, map[string]string{"GIT_TRACE2_EVENT": mismatchTracePath}, "axi", "run", "--intent", "validate genuinely new operator work later")
+	if blockedErr == nil {
+		t.Fatalf("pipeline-owned fresh run should fail:\n%s", blockedOut)
+	}
+	for _, want := range []string{
+		"branch_sync:",
+		"state: pipeline_owned",
+		"status: running",
+		"safety: blocked_pipeline_owned",
+		"code: continue_active_run",
+		"command: no-mistakes axi status",
+	} {
+		if !strings.Contains(blockedOut, want) {
+			t.Errorf("pipeline-owned fresh run missing %q:\n%s", want, blockedOut)
+		}
+	}
+	mismatchTrace, readErr := os.ReadFile(mismatchTracePath)
+	if readErr != nil {
+		t.Fatalf("read mismatched-run git trace: %v", readErr)
+	}
+	if strings.Contains(string(mismatchTrace), `"argv":["git","push"`) {
+		t.Fatalf("pipeline-owned fresh run attempted a gate push:\n%s", mismatchTrace)
+	}
+	if got := len(h.Runs()); got != runsBefore {
+		t.Fatalf("pipeline-owned fresh run changed run count from %d to %d", runsBefore, got)
+	}
+	stillActive = h.ActiveRun(branch)
+	if stillActive == nil || stillActive.ID != originalRun.ID || stillActive.Status != types.RunRunning {
+		t.Fatalf("pipeline-owned fresh run replaced or cancelled the original: %#v", stillActive)
+	}
+}
+
 // TestAxiCustodyRecoveryJourney reproduces the first real dogfood catch of the
 // guarded branch sync (run 01KXN8YJ6DWF8XPP582DWQC3HV) with the real binary: a
 // run cancelled at the pre_push phase leaves the branch pipeline_owned with
@@ -213,12 +342,25 @@ func TestAxiCustodyRecoveryJourney(t *testing.T) {
 	}
 
 	// Cancel while the pipeline fix commit exists only in the gate branch.
-	if out, abortErr := h.RunInDir(operator, "axi", "abort"); abortErr != nil {
-		t.Fatalf("axi abort: %v\n%s", abortErr, out)
+	abortOut, abortErr := h.RunInDir(operator, "axi", "abort")
+	if abortErr != nil {
+		t.Fatalf("axi abort: %v\n%s", abortErr, abortOut)
 	}
 	run := h.WaitForRun("feature/recover-journey", 30*time.Second)
 	if run.Status != types.RunCancelled {
 		t.Fatalf("run status after abort = %s", run.Status)
+	}
+	for _, want := range []string{
+		"branch_sync:",
+		"state: pipeline_owned",
+		"status: cancelled",
+		"safety: blocked_pipeline_owned_recoverable",
+		"code: recover_custody",
+		"command: no-mistakes axi sync --recover",
+	} {
+		if !strings.Contains(abortOut, want) {
+			t.Errorf("abort output missing %q:\n%s", want, abortOut)
+		}
 	}
 
 	gateDir := filepath.Join(h.NMHome, "repos", h.repoID()+".git")
@@ -232,6 +374,38 @@ func TestAxiCustodyRecoveryJourney(t *testing.T) {
 	}
 	if got := strings.TrimSpace(h.WorktreeRefSHA("feature/recover-journey")); got != submitted {
 		t.Fatalf("operator branch moved without explicit recovery: %s", got)
+	}
+	runsBefore := len(h.Runs())
+	tracePath := filepath.Join(t.TempDir(), "blocked-run-git-trace.json")
+	blockedOut, blockedErr := h.RunInDirWithEnv(operator, map[string]string{"GIT_TRACE2_EVENT": tracePath}, "axi", "run", "--intent", "must recover custody before starting over")
+	if blockedErr == nil {
+		t.Fatalf("axi run before custody recovery should fail:\n%s", blockedOut)
+	}
+	for _, want := range []string{
+		"branch_sync:",
+		"state: pipeline_owned",
+		"status: cancelled",
+		"safety: blocked_pipeline_owned_recoverable",
+		"code: recover_custody",
+		"command: no-mistakes axi sync --recover",
+	} {
+		if !strings.Contains(blockedOut, want) {
+			t.Errorf("blocked fresh run missing %q:\n%s", want, blockedOut)
+		}
+	}
+	blockedTrace, readErr := os.ReadFile(tracePath)
+	if readErr != nil {
+		t.Fatalf("read blocked-run git trace: %v", readErr)
+	}
+	if strings.Contains(string(blockedTrace), `"argv":["git","push"`) {
+		t.Fatalf("blocked fresh run attempted a gate push:\n%s", blockedTrace)
+	}
+	if got := len(h.Runs()); got != runsBefore {
+		t.Fatalf("blocked fresh run changed run count from %d to %d", runsBefore, got)
+	}
+	preservedAfterBlockedRunBytes, gitErr := h.runGit(context.Background(), gateDir, "rev-parse", "refs/heads/feature/recover-journey")
+	if gitErr != nil || strings.TrimSpace(string(preservedAfterBlockedRunBytes)) != preserved {
+		t.Fatalf("blocked fresh run changed preserved gate head to %s (err %v), want %s", strings.TrimSpace(string(preservedAfterBlockedRunBytes)), gitErr, preserved)
 	}
 
 	// The stranded state must surface the recovery action instead of a dead end.
@@ -263,6 +437,10 @@ func TestAxiCustodyRecoveryJourney(t *testing.T) {
 	}
 	if got, gitErr := h.runGit(context.Background(), operator, "rev-parse", "HEAD"); gitErr != nil || strings.TrimSpace(string(got)) != preserved {
 		t.Fatalf("operator HEAD after recovery = %s (err %v), want preserved %s", strings.TrimSpace(string(got)), gitErr, preserved)
+	}
+	anchorRef := "refs/no-mistakes/recover/" + run.ID
+	if got, gitErr := h.runGit(context.Background(), operator, "rev-parse", anchorRef); gitErr != nil || strings.TrimSpace(string(got)) != preserved {
+		t.Fatalf("recovery anchor %s = %s (err %v), want preserved %s", anchorRef, strings.TrimSpace(string(got)), gitErr, preserved)
 	}
 
 	// Custody is back: commit a rescope on top of the preserved fix commits

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -191,15 +191,16 @@ type ShutdownResult struct {
 
 // RunInfo is the IPC representation of a pipeline run.
 type RunInfo struct {
-	ID      string          `json:"id"`
-	RepoID  string          `json:"repo_id"`
-	Branch  string          `json:"branch"`
-	HeadSHA string          `json:"head_sha"`
-	BaseSHA string          `json:"base_sha"`
-	Status  types.RunStatus `json:"status"`
-	PRURL   *string         `json:"pr_url,omitempty"`
-	Error   *string         `json:"error,omitempty"`
-	CIReady bool            `json:"ci_ready,omitempty"`
+	ID               string          `json:"id"`
+	RepoID           string          `json:"repo_id"`
+	Branch           string          `json:"branch"`
+	HeadSHA          string          `json:"head_sha"`
+	SubmittedHeadSHA *string         `json:"submitted_head_sha,omitempty"`
+	BaseSHA          string          `json:"base_sha"`
+	Status           types.RunStatus `json:"status"`
+	PRURL            *string         `json:"pr_url,omitempty"`
+	Error            *string         `json:"error,omitempty"`
+	CIReady          bool            `json:"ci_ready,omitempty"`
 	// AwaitingAgent is true while the run is parked at a gate awaiting the
 	// driving agent's response. AwaitingAgentSince is the unix-seconds time it
 	// parked, so a supervisor can read "parked for N seconds" in one call. Both

--- a/internal/ipc/protocol_test.go
+++ b/internal/ipc/protocol_test.go
@@ -238,16 +238,18 @@ func TestRespondParams(t *testing.T) {
 
 func TestRunInfoRoundTrip(t *testing.T) {
 	prURL := "https://github.com/user/repo/pull/42"
+	submittedHead := "submitted123"
 	info := RunInfo{
-		ID:        "run001",
-		RepoID:    "repo001",
-		Branch:    "feature",
-		HeadSHA:   "abc123",
-		BaseSHA:   "def456",
-		Status:    types.RunRunning,
-		PRURL:     &prURL,
-		CreatedAt: 1700000000,
-		UpdatedAt: 1700000001,
+		ID:               "run001",
+		RepoID:           "repo001",
+		Branch:           "feature",
+		HeadSHA:          "abc123",
+		SubmittedHeadSHA: &submittedHead,
+		BaseSHA:          "def456",
+		Status:           types.RunRunning,
+		PRURL:            &prURL,
+		CreatedAt:        1700000000,
+		UpdatedAt:        1700000001,
 	}
 	data, _ := json.Marshal(info)
 	var got RunInfo
@@ -259,6 +261,9 @@ func TestRunInfoRoundTrip(t *testing.T) {
 	}
 	if got.PRURL == nil || *got.PRURL != prURL {
 		t.Errorf("pr_url = %v, want %q", got.PRURL, prURL)
+	}
+	if got.SubmittedHeadSHA == nil || *got.SubmittedHeadSHA != submittedHead {
+		t.Errorf("submitted_head_sha = %v, want %q", got.SubmittedHeadSHA, submittedHead)
 	}
 }
 

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -102,7 +102,7 @@ wrong.
 Before starting, run ` + "`no-mistakes axi`" + ` (home view).
 If it shows an active run on your current branch, inspect it with ` + "`no-mistakes axi status`" + `.
 If it is parked at a gate, drive it with ` + "`no-mistakes axi respond`" + `.
-Reattach an in-flight run by re-running ` + "`no-mistakes axi run`" + ` when your current ` + "`HEAD`" + ` matches either the submitted head or the current pipeline head.
+Reattach an in-flight run by re-running ` + "`no-mistakes axi run`" + ` when it still matches your current ` + "`HEAD`" + ` - either as the submitted head or as the current pipeline head.
 Only ` + "`no-mistakes axi abort`" + ` it when you mean to discard that run before starting over; aborting is a between-runs action, never a way to take over or bypass a gate while a run is still going (see [Validate and decide](#validate-and-decide)).
 If it shows an active run on another branch, leave that run alone and start validation for your current branch with ` + "`no-mistakes axi run --intent \"...\"`" + `.
 

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -102,7 +102,7 @@ wrong.
 Before starting, run ` + "`no-mistakes axi`" + ` (home view).
 If it shows an active run on your current branch, inspect it with ` + "`no-mistakes axi status`" + `.
 If it is parked at a gate, drive it with ` + "`no-mistakes axi respond`" + `.
-Reattach an in-flight run by re-running ` + "`no-mistakes axi run`" + ` when it still matches your current ` + "`HEAD`" + `.
+Reattach an in-flight run by re-running ` + "`no-mistakes axi run`" + ` when your current ` + "`HEAD`" + ` matches either the submitted head or the current pipeline head.
 Only ` + "`no-mistakes axi abort`" + ` it when you mean to discard that run before starting over; aborting is a between-runs action, never a way to take over or bypass a gate while a run is still going (see [Validate and decide](#validate-and-decide)).
 If it shows an active run on another branch, leave that run alone and start validation for your current branch with ` + "`no-mistakes axi run --intent \"...\"`" + `.
 
@@ -221,7 +221,7 @@ Run the pipeline and decide on its findings as they come up:
 Before any post-pipeline local commit or fresh run, read the structured ` + "`branch_sync`" + ` object returned by AXI home, status, or a drive result.
 Only when its ` + "`next_action.code`" + ` is ` + "`sync`" + `, run ` + "`no-mistakes axi sync`" + ` first.
 That guarded sync may be a strict fast-forward or a content-equivalent diverged advance that anchors the pre-sync head before moving the branch with reset semantics; genuine divergence stays blocked.
-If it reports an unpublished pipeline-owned update while the run is active, wait and keep driving the run without making local follow-up commits.
+If it reports ` + "`next_action.code`" + ` is ` + "`continue_active_run`" + `, the pipeline still owns the branch: run the reported command, keep driving the active run, and do not make local follow-up commits.
 When ` + "`next_action.code`" + ` is ` + "`recover_custody`" + `, a terminal run left unpublished pipeline commits preserved in the local gate: run ` + "`no-mistakes axi sync --recover`" + ` to return custody and fast-forward to the preserved head, or ` + "`no-mistakes rerun`" + ` to resume validating it instead.
 A dirty or diverged worktree makes the recovery refuse with explicit choices; ` + "`--keep-local`" + ` keeps your current head while the preserved commits stay anchored under ` + "`refs/no-mistakes/recover/<run>`" + `.
 If synchronization is blocked, process that structured state instead of improvising reset, stash, merge, rebase, force, or branch replacement.

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -63,7 +63,7 @@ wrong.
 Before starting, run `no-mistakes axi` (home view).
 If it shows an active run on your current branch, inspect it with `no-mistakes axi status`.
 If it is parked at a gate, drive it with `no-mistakes axi respond`.
-Reattach an in-flight run by re-running `no-mistakes axi run` when it still matches your current `HEAD`.
+Reattach an in-flight run by re-running `no-mistakes axi run` when your current `HEAD` matches either the submitted head or the current pipeline head.
 Only `no-mistakes axi abort` it when you mean to discard that run before starting over; aborting is a between-runs action, never a way to take over or bypass a gate while a run is still going (see [Validate and decide](#validate-and-decide)).
 If it shows an active run on another branch, leave that run alone and start validation for your current branch with `no-mistakes axi run --intent "..."`.
 
@@ -182,7 +182,7 @@ Run the pipeline and decide on its findings as they come up:
 Before any post-pipeline local commit or fresh run, read the structured `branch_sync` object returned by AXI home, status, or a drive result.
 Only when its `next_action.code` is `sync`, run `no-mistakes axi sync` first.
 That guarded sync may be a strict fast-forward or a content-equivalent diverged advance that anchors the pre-sync head before moving the branch with reset semantics; genuine divergence stays blocked.
-If it reports an unpublished pipeline-owned update while the run is active, wait and keep driving the run without making local follow-up commits.
+If it reports `next_action.code` is `continue_active_run`, the pipeline still owns the branch: run the reported command, keep driving the active run, and do not make local follow-up commits.
 When `next_action.code` is `recover_custody`, a terminal run left unpublished pipeline commits preserved in the local gate: run `no-mistakes axi sync --recover` to return custody and fast-forward to the preserved head, or `no-mistakes rerun` to resume validating it instead.
 A dirty or diverged worktree makes the recovery refuse with explicit choices; `--keep-local` keeps your current head while the preserved commits stay anchored under `refs/no-mistakes/recover/<run>`.
 If synchronization is blocked, process that structured state instead of improvising reset, stash, merge, rebase, force, or branch replacement.

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -63,7 +63,7 @@ wrong.
 Before starting, run `no-mistakes axi` (home view).
 If it shows an active run on your current branch, inspect it with `no-mistakes axi status`.
 If it is parked at a gate, drive it with `no-mistakes axi respond`.
-Reattach an in-flight run by re-running `no-mistakes axi run` when your current `HEAD` matches either the submitted head or the current pipeline head.
+Reattach an in-flight run by re-running `no-mistakes axi run` when it still matches your current `HEAD` - either as the submitted head or as the current pipeline head.
 Only `no-mistakes axi abort` it when you mean to discard that run before starting over; aborting is a between-runs action, never a way to take over or bypass a gate while a run is still going (see [Validate and decide](#validate-and-decide)).
 If it shows an active run on another branch, leave that run alone and start validation for your current branch with `no-mistakes axi run --intent "..."`.
 


### PR DESCRIPTION
## Intent

Fix the AXI active-run reattachment bug by exposing immutable submitted_head_sha through IPC and reattaching a non-terminal run when local HEAD matches either the submitted head or the current pipeline head, while refusing attachment when neither matches. Before any fresh gate-trigger push, use the existing branch_sync pipeline-ownership classification so collisions return structured continue_active_run or recover_custody guidance instead of raw Git non-fast-forward. Preserve abort gate refs and guarded custody recovery unchanged, but make branch-scoped abort render refreshed branch_sync state and its exact next action. Include unit coverage and a real-CLI E2E journey where a managed fix advances the gate while the unchanged submitting worktree reattaches without a push, new run, cancellation, or non-fast-forward, plus proof that aborted pipeline commits remain anchored and recoverable by fast-forward. Keep the shared daemon lifecycle untouched and all Go formatting, vet, race, E2E, docs, and build checks clean.

## What Changed

- Exposes the immutable submitted head SHA through daemon run info IPC so AXI can compare the local worktree against both the originally submitted head and the current pipeline head.
- Updates `axi run` reattachment flow to continue compatible non-terminal active runs without pushing, while using branch sync ownership state to surface structured guidance for pipeline-owned, push-in-progress, and recoverable custody cases.
- Refreshes AXI agent/docs guidance and coverage around submitted-head reattachment, branch-scoped abort state refresh, and recoverable aborted pipeline commits.

## Risk Assessment

🚨 High: The change satisfies the submitted-head reattachment path but still permits a non-terminal same-branch run to be superseded when local HEAD matches neither accepted identity, contradicting an explicit acceptance criterion and risking cancellation of in-flight pipeline work.

## Testing

Completed 1 recorded test check.

- Outcome: ⚠️ 1 error across 2 runs (28m27s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Review** - skipped</summary>

- 🚨 `internal/cli/axi_drive.go:273` - Intent criterion says: &#34;reattaching a non-terminal run when local HEAD matches either the submitted head or the current pipeline head, while refusing attachment when neither matches.&#34; The new guard only blocks `StatePipelineOwned` and `StatePushInProgress`, so if the same-branch active run has already pushed its current pipeline head and the operator has a new clean local commit on top of that head, branch_sync classifies it as `StateLocalAhead`; `axi run` falls through to `git.PushWithOptions`, which can start a fresh run and supersede the non-terminal run instead of refusing the mismatch.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 tests failed with exit code 1
- `go test -race ./...`

🔧 Fix: No deterministic failures reproduced
1 error still open:
- 🚨 tests failed with exit code 1
- `go test -race ./...`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
