### PR TITLE
fix(scm): resolve SSH host aliases for provider routing

### DIFF
--- a/docs/src/content/docs/guides/provider-integration.md
+++ b/docs/src/content/docs/guides/provider-integration.md
@@ -205,6 +205,12 @@ Running `glab auth login --hostname your-gitlab.example.com` is enough to make d
 
 The GitLab backend is pinned against `glab v1.5x`. Self-hosted detection and the merge-request and CI steps rely on its current flag and API surface, so keep `glab` reasonably up to date.
 
+## SSH host aliases
+
+SSH remotes that use a host alias from your SSH configuration (for example `git@github-personal:owner/repo` or `git@gitlab-work:group/repo`, where `github-personal`/`gitlab-work` map to a real `HostName` via `~/.ssh/config`) are supported. `no-mistakes` resolves the alias through `ssh -G` to its real host name and uses that host only for provider detection and for scoping the provider CLI (`gh`/`glab`) to the right instance. The original Git remote URL is left untouched, so authentication and pushes continue to use the alias exactly as your SSH configuration expects.
+
+If `ssh -G` is unavailable or the alias does not resolve, detection falls back to the literal host in the remote URL rather than failing the run.
+
 ## Unsupported hosts
 
 If your upstream isn't GitHub, GitLab, Bitbucket Cloud, or Azure DevOps:

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -83,7 +83,7 @@ func InitWithFork(ctx context.Context, d *db.DB, p *paths.Paths, workDir, forkUR
 		return nil, false, fmt.Errorf("get origin url: %w", err)
 	}
 	if forkURL != "" {
-		if err := validateForkRouting(upstreamURL, forkURL); err != nil {
+		if err := validateForkRouting(ctx, upstreamURL, forkURL); err != nil {
 			return nil, false, err
 		}
 	}
@@ -137,9 +137,9 @@ func InitWithFork(ctx context.Context, d *db.DB, p *paths.Paths, workDir, forkUR
 	return repo, true, nil
 }
 
-func validateForkRouting(upstreamURL, forkURL string) error {
-	parentProvider := scm.DetectProvider(upstreamURL)
-	forkProvider := scm.DetectProvider(forkURL)
+func validateForkRouting(ctx context.Context, upstreamURL, forkURL string) error {
+	parentProvider := scm.DetectProviderContext(ctx, upstreamURL)
+	forkProvider := scm.DetectProviderContext(ctx, forkURL)
 	if parentProvider == scm.ProviderGitHub && forkProvider == scm.ProviderGitHub {
 		if github.RepoSlug(upstreamURL) == "" || github.RepoSlug(forkURL) == "" {
 			return fmt.Errorf("fork URL routing requires GitHub parent and fork remotes with owner/repo paths")

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -57,9 +57,9 @@ func (s *CIStep) ReconcileApprovalGate(sctx *pipeline.StepContext) (bool, error)
 	if err := sctx.Ctx.Err(); err != nil {
 		return false, err
 	}
-	provider := scm.DetectProvider(sctx.Repo.UpstreamURL)
+	provider := scm.DetectProviderContext(sctx.Ctx, sctx.Repo.UpstreamURL)
 	if provider == scm.ProviderUnknown && sctx.Run.PRURL != nil {
-		provider = scm.DetectProvider(*sctx.Run.PRURL)
+		provider = scm.DetectProviderContext(sctx.Ctx, *sctx.Run.PRURL)
 	}
 	host, skipReason := buildHost(sctx, provider)
 	if host == nil {
@@ -123,9 +123,9 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	provider := scm.DetectProvider(sctx.Repo.UpstreamURL)
+	provider := scm.DetectProviderContext(ctx, sctx.Repo.UpstreamURL)
 	if provider == scm.ProviderUnknown && sctx.Run.PRURL != nil {
-		provider = scm.DetectProvider(*sctx.Run.PRURL)
+		provider = scm.DetectProviderContext(ctx, *sctx.Run.PRURL)
 	}
 	host, skipReason := buildHost(sctx, provider)
 	if host == nil {

--- a/internal/pipeline/steps/host.go
+++ b/internal/pipeline/steps/host.go
@@ -30,12 +30,13 @@ func buildHost(sctx *pipeline.StepContext, provider scm.Provider) (scm.Host, str
 		// the upstream remote URL is unavailable. The hostname also scopes
 		// the auth-status check so a stale token on any other configured gh
 		// host cannot make this repo look unauthenticated.
-		host := scm.ExtractHost(sctx.Repo.UpstreamURL)
-		repo := github.HostPrefixedSlug(sctx.Repo.UpstreamURL)
+		host := scm.ResolveHost(sctx.Ctx, sctx.Repo.UpstreamURL)
+		repo := github.HostPrefixedSlugForHost(sctx.Repo.UpstreamURL, host)
 		if repo == "" && sctx.Run.PRURL != nil {
-			repo = github.HostPrefixedSlug(*sctx.Run.PRURL)
+			prHost := scm.ResolveHost(sctx.Ctx, *sctx.Run.PRURL)
+			repo = github.HostPrefixedSlugForHost(*sctx.Run.PRURL, prHost)
 			if host == "" {
-				host = scm.ExtractHost(*sctx.Run.PRURL)
+				host = prHost
 			}
 		}
 		forkRepo := ""
@@ -55,7 +56,7 @@ func buildHost(sctx *pipeline.StepContext, provider scm.Provider) (scm.Host, str
 		return gitlab.New(
 			cmdFactory,
 			func() bool { return stepCLIAvailable(sctx, provider) },
-			scm.ExtractHost(sctx.Repo.UpstreamURL),
+			scm.ResolveHost(sctx.Ctx, sctx.Repo.UpstreamURL),
 			gitlab.ProjectPath(sctx.Repo.UpstreamURL),
 		), ""
 	case scm.ProviderBitbucket:

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -61,7 +61,7 @@ func (s *PRStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 		sctx.Log(fmt.Sprintf("skipping PR creation on default branch %s", branch))
 		return &pipeline.StepOutcome{Skipped: true}, nil
 	}
-	provider := scm.DetectProvider(sctx.Repo.UpstreamURL)
+	provider := scm.DetectProviderContext(ctx, sctx.Repo.UpstreamURL)
 	host, skipReason := buildHost(sctx, provider)
 	if host == nil {
 		sctx.Log(fmt.Sprintf("skipping PR creation: %s", skipReason))

--- a/internal/pipeline/steps/pr_test.go
+++ b/internal/pipeline/steps/pr_test.go
@@ -1647,6 +1647,7 @@ func TestPRStep_SkipsWhenProviderCLIUnavailable(t *testing.T) {
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Repo.UpstreamURL = "https://gitlab.com/test/repo.git"
+	sctx.Env = []string{"PATH=" + t.TempDir()}
 
 	step := &PRStep{}
 	outcome, err := step.Execute(sctx)

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -94,11 +94,17 @@ func RepoSlug(remoteURL string) string {
 // instances and plain "owner/name" for github.com. This is the format that
 // the gh CLI's --repo flag requires for GHE.
 func HostPrefixedSlug(remoteURL string) string {
+	return HostPrefixedSlugForHost(remoteURL, scm.ExtractHost(remoteURL))
+}
+
+// HostPrefixedSlugForHost is HostPrefixedSlug using an already-resolved host.
+// This lets callers honor SSH HostName aliases without rewriting the remote.
+func HostPrefixedSlugForHost(remoteURL, host string) string {
 	slug := RepoSlug(remoteURL)
 	if slug == "" {
 		return ""
 	}
-	host := scm.ExtractHost(remoteURL)
+	host = strings.ToLower(strings.TrimSpace(host))
 	if host == "" || strings.EqualFold(host, "github.com") {
 		return slug
 	}

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -84,6 +84,16 @@ func TestHostPrefixedSlug(t *testing.T) {
 	}
 }
 
+func TestHostPrefixedSlugForHost_SSHAlias(t *testing.T) {
+	remote := "git@github-personal:owner/repo.git"
+	if got := HostPrefixedSlugForHost(remote, "github.com"); got != "owner/repo" {
+		t.Fatalf("HostPrefixedSlugForHost() = %q, want owner/repo", got)
+	}
+	if got := HostPrefixedSlugForHost(remote, "ghe.example.com"); got != "ghe.example.com/owner/repo" {
+		t.Fatalf("HostPrefixedSlugForHost() = %q, want ghe.example.com/owner/repo", got)
+	}
+}
+
 func TestGetChecksPassesRepoFlag(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scm/scm.go
+++ b/internal/scm/scm.go
@@ -134,6 +134,7 @@ func lookupSSHHostname(ctx context.Context, alias string) (string, error) {
 	defer cancel()
 
 	cmd := exec.CommandContext(lookupCtx, "ssh", "-G", "--", alias)
+	shellenv.ConfigureShellCommand(cmd)
 	out, err := shellenv.OutputShellCommand(cmd)
 	if err != nil {
 		return "", err

--- a/internal/scm/scm.go
+++ b/internal/scm/scm.go
@@ -6,7 +6,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
+	"github.com/kunchenguid/no-mistakes/internal/shellenv"
 	"github.com/kunchenguid/no-mistakes/internal/winproc"
 	"gopkg.in/yaml.v3"
 )
@@ -21,7 +23,33 @@ const (
 	ProviderUnknown     Provider = "unknown"
 )
 
+type sshHostnameLookup func(context.Context, string) (string, error)
+
+// DetectProvider identifies the SCM provider for url. SSH host aliases are
+// resolved through the user's SSH configuration before detection falls back to
+// ProviderUnknown.
 func DetectProvider(url string) Provider {
+	return DetectProviderContext(context.Background(), url)
+}
+
+// DetectProviderContext is DetectProvider with caller-controlled cancellation.
+func DetectProviderContext(ctx context.Context, url string) Provider {
+	return detectProvider(ctx, url, lookupSSHHostname)
+}
+
+func detectProvider(ctx context.Context, url string, lookup sshHostnameLookup) Provider {
+	if provider := detectProviderWithoutSSH(url); provider != ProviderUnknown {
+		return provider
+	}
+
+	host := resolveHost(ctx, url, lookup)
+	if host == "" || strings.EqualFold(host, ExtractHost(url)) {
+		return ProviderUnknown
+	}
+	return detectProviderWithoutSSH(host)
+}
+
+func detectProviderWithoutSSH(url string) Provider {
 	lower := strings.ToLower(url)
 	switch {
 	case strings.Contains(lower, "github.com"):
@@ -55,6 +83,68 @@ func DetectProvider(url string) Provider {
 	}
 
 	return ProviderUnknown
+}
+
+// ResolveHost returns the canonical host for a remote. For SSH remotes it
+// honors HostName mappings from the user's SSH configuration while preserving
+// the original remote URL for all Git operations.
+func ResolveHost(ctx context.Context, remote string) string {
+	return resolveHost(ctx, remote, lookupSSHHostname)
+}
+
+func resolveHost(ctx context.Context, remote string, lookup sshHostnameLookup) string {
+	host := ExtractHost(remote)
+	if host == "" || !isSSHRemote(remote) || lookup == nil {
+		return host
+	}
+
+	resolved, err := lookup(ctx, host)
+	if err != nil {
+		return host
+	}
+	resolved = strings.ToLower(strings.TrimSpace(stripPort(resolved)))
+	if resolved == "" {
+		return host
+	}
+	return resolved
+}
+
+func isSSHRemote(remote string) bool {
+	remote = strings.TrimSpace(remote)
+	lower := strings.ToLower(remote)
+	if strings.HasPrefix(lower, "ssh://") {
+		return true
+	}
+	if strings.Contains(remote, "://") {
+		return false
+	}
+	colon := strings.IndexByte(remote, ':')
+	if colon <= 0 {
+		return false
+	}
+	if colon == 1 && len(remote) >= 3 && ((remote[0] >= 'a' && remote[0] <= 'z') || (remote[0] >= 'A' && remote[0] <= 'Z')) && (remote[2] == '/' || remote[2] == '\\') {
+		return false
+	}
+	slash := strings.IndexAny(remote, `/\\`)
+	return slash < 0 || colon < slash
+}
+
+func lookupSSHHostname(ctx context.Context, alias string) (string, error) {
+	lookupCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(lookupCtx, "ssh", "-G", "--", alias)
+	out, err := shellenv.OutputShellCommand(cmd)
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && strings.EqualFold(fields[0], "hostname") {
+			return fields[1], nil
+		}
+	}
+	return "", nil
 }
 
 // glabKnowsHost reports whether host appears in glab's configured hosts map,

--- a/internal/scm/scm_test.go
+++ b/internal/scm/scm_test.go
@@ -1,6 +1,8 @@
 package scm
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,6 +34,85 @@ func TestDetectProvider(t *testing.T) {
 			t.Errorf("DetectProvider(%q) = %q, want %q", tt.url, got, tt.want)
 		}
 	}
+}
+
+func TestDetectProvider_SSHHostAlias(t *testing.T) {
+	t.Setenv("GLAB_CONFIG_DIR", t.TempDir())
+	t.Setenv("GH_CONFIG_DIR", t.TempDir())
+
+	tests := []struct {
+		name     string
+		url      string
+		hostname string
+		want     Provider
+	}{
+		{
+			name:     "GitHub scp remote",
+			url:      "git@github-personal:owner/repo.git",
+			hostname: "github.com",
+			want:     ProviderGitHub,
+		},
+		{
+			name:     "GitLab SSH URL",
+			url:      "ssh://git@gitlab-work/group/repo.git",
+			hostname: "gitlab.com",
+			want:     ProviderGitLab,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectProvider(context.Background(), tt.url, func(context.Context, string) (string, error) {
+				return tt.hostname, nil
+			})
+			if got != tt.want {
+				t.Fatalf("detectProvider(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveHost_SSHConfigLookup(t *testing.T) {
+	t.Run("canonical hostname", func(t *testing.T) {
+		got := resolveHost(context.Background(), "git@github-personal:owner/repo.git", func(_ context.Context, alias string) (string, error) {
+			if alias != "github-personal" {
+				t.Fatalf("alias = %q, want github-personal", alias)
+			}
+			return "GitHub.COM", nil
+		})
+		if got != "github.com" {
+			t.Fatalf("resolveHost() = %q, want github.com", got)
+		}
+	})
+
+	t.Run("lookup failure preserves alias", func(t *testing.T) {
+		got := resolveHost(context.Background(), "git@github-personal:owner/repo.git", func(context.Context, string) (string, error) {
+			return "", errors.New("ssh unavailable")
+		})
+		if got != "github-personal" {
+			t.Fatalf("resolveHost() = %q, want github-personal", got)
+		}
+	})
+
+	t.Run("HTTPS does not invoke SSH", func(t *testing.T) {
+		got := resolveHost(context.Background(), "https://code.example.com/owner/repo.git", func(context.Context, string) (string, error) {
+			t.Fatal("SSH lookup invoked for HTTPS remote")
+			return "", nil
+		})
+		if got != "code.example.com" {
+			t.Fatalf("resolveHost() = %q, want code.example.com", got)
+		}
+	})
+
+	t.Run("Windows path does not invoke SSH", func(t *testing.T) {
+		got := resolveHost(context.Background(), `C:\repo`, func(context.Context, string) (string, error) {
+			t.Fatal("SSH lookup invoked for Windows path")
+			return "", nil
+		})
+		if got != "c" {
+			t.Fatalf("resolveHost() = %q, want c", got)
+		}
+	})
 }
 
 // writeGlabConfig writes a synthetic glab config.yml into a temp dir and points

--- a/internal/telemetry/config_test.go
+++ b/internal/telemetry/config_test.go
@@ -22,6 +22,7 @@ func TestDefaultUsesDotEnvInDevBuildWhenEnvMissing(t *testing.T) {
 	buildinfo.TelemetryHost = ""
 	buildinfo.TelemetryWebsiteID = ""
 
+	t.Setenv(telemetryEnv, "")
 	t.Setenv(umamiHostEnv, "")
 	t.Setenv(umamiWebsiteIDEnv, "")
 
@@ -71,6 +72,7 @@ func TestDefaultPrefersEnvVarsOverDotEnvAndEmbeddedConfig(t *testing.T) {
 	buildinfo.Version = "v1.2.3"
 	buildinfo.TelemetryWebsiteID = "embedded-website"
 
+	t.Setenv(telemetryEnv, "")
 	t.Setenv(umamiHostEnv, "https://env.example")
 	t.Setenv(umamiWebsiteIDEnv, "website-from-env")
 
@@ -120,6 +122,7 @@ func TestDefaultUsesEmbeddedTelemetryHostAndWebsiteID(t *testing.T) {
 	buildinfo.Version = "v1.2.3"
 	buildinfo.TelemetryWebsiteID = "embedded-website"
 
+	t.Setenv(telemetryEnv, "")
 	t.Setenv(umamiHostEnv, "")
 	t.Setenv(umamiWebsiteIDEnv, "")
 
@@ -153,6 +156,7 @@ func TestDefaultUsesSelfHostedHostWhenHostConfigMissing(t *testing.T) {
 	buildinfo.Version = "v1.2.3"
 	buildinfo.TelemetryWebsiteID = "embedded-website"
 
+	t.Setenv(telemetryEnv, "")
 	t.Setenv(umamiHostEnv, "")
 	t.Setenv(umamiWebsiteIDEnv, "")
 


### PR DESCRIPTION
## Intent

Contribute upstream support for standard SSH host aliases such as github-personal and gitlab-work. Resolve aliases through ssh -G only for provider classification and provider CLI hostname scoping, keep original Git remote URLs unchanged for authentication and pushes, fail safely when SSH resolution is unavailable, use caller cancellation, and cover GitHub, GitLab, canonical remotes, lookup failures, HTTPS remotes, and local Windows paths with deterministic tests. Validate the change fully, push it to the rudingma/no-mistakes fork, and create an upstream pull request to kunchenguid/no-mistakes. Also prove the patched binary works locally as the temporary workaround.

## What Changed

- Added `ResolveHost`/`lookupSSHHostname` in `internal/scm/scm.go` to resolve SSH host aliases (e.g. `github-personal`, `gitlab-work`) via `ssh -G`, used only for provider classification and provider-CLI hostname scoping while leaving the original Git remote URL untouched for auth and pushes; the `ssh -G` lookup uses caller cancellation, runs through the `shellenv` helper, and fails safe to the raw alias when resolution is unavailable or the remote is HTTPS/local Windows path.
- Wired the resolved host through the gate, CI, host, PR, and GitHub SCM steps so provider detection and `gh`/`glab` hostname scoping honor the canonical host.
- Added deterministic tests covering GitHub scp-form, GitLab ssh aliases, canonical remotes, lookup failure, HTTPS, and Windows-path remotes; isolated ambient `PATH` and telemetry env in affected tests; documented the behavior in the provider-integration guide.

## Risk Assessment

✅ Low: The only new change is the one-line shellenv.ConfigureShellCommand fix that resolves the sole prior finding, matching the repo's established one-shot-command pattern and preserving existing timeout behavior; the rest of the well-bounded, fail-safe, tested change was already reviewed clean.

## Testing

Baseline `go test -race ./...` already passed. On top of that I ran the targeted deterministic suites covering every case the intent names (GitHub, GitLab, canonical remotes, lookup failures, HTTPS remotes, local Windows paths) and the two ambient-env test fixes, all green. To prove the intent end-to-end the way an end user hits it, I ran the actual production functions (ResolveHost/DetectProviderContext, which shell out to a real `ssh -G`) against this machine's real `github-personal` SSH alias: the alias resolved to host github.com and classified as the GitHub provider, while the raw remote URL `git@github-personal:rudingma/no-mistakes.git` stayed unchanged (auth/push preserved) — matching "resolve only for classification/scoping, keep remote URLs intact." No screenshot applies; this is a CLI/library-level change, so the evidence is the captured `ssh -G` output and production-code test transcript. Delivery steps in the intent (push to the rudingma fork, open the upstream PR) are pipeline delivery-phase actions outside this test step's scope and were not performed here. No issues found.

<details>
<summary>Evidence: SSH alias end-to-end evidence transcript</summary>

```text
# SSH host alias resolution — end-to-end evidence

## 1. Real `ssh -G` resolves the machine's github-personal alias
$ ssh -G -- github-personal | grep -i ^hostname
hostname github.com

## 2. Production Go path (ResolveHost / DetectProviderContext -> real lookupSSHHostname -> real ssh -G)
    evidence_e2e_test.go:19: remote (unchanged for auth/push): git@github-personal:rudingma/no-mistakes.git
    evidence_e2e_test.go:20: ResolveHost -> "github.com"
    evidence_e2e_test.go:21: DetectProviderContext -> "github"
    evidence_e2e_test.go:22: ExtractHost (raw alias, no ssh) -> "github-personal"
--- PASS: TestEvidence_RealSSHAliasEndToEnd (0.03s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/scm	(cached)

## 3. Deterministic unit coverage (GitHub, GitLab, canonical, lookup failure, HTTPS, Windows path)
--- PASS: TestDetectProvider_SSHHostAlias (0.00s)
    --- PASS: TestDetectProvider_SSHHostAlias/GitHub_scp_remote (0.00s)
    --- PASS: TestDetectProvider_SSHHostAlias/GitLab_SSH_URL (0.00s)
--- PASS: TestResolveHost_SSHConfigLookup (0.00s)
    --- PASS: TestResolveHost_SSHConfigLookup/canonical_hostname (0.00s)
    --- PASS: TestResolveHost_SSHConfigLookup/lookup_failure_preserves_alias (0.00s)
    --- PASS: TestResolveHost_SSHConfigLookup/HTTPS_does_not_invoke_SSH (0.00s)
    --- PASS: TestResolveHost_SSHConfigLookup/Windows_path_does_not_invoke_SSH (0.00s)
ok  	github.com/kunchenguid/no-mistakes/internal/scm	1.263s
ok  	github.com/kunchenguid/no-mistakes/internal/scm/azuredevops	1.557s [no tests to run]
--- PASS: TestHostPrefixedSlugForHost_SSHAlias (0.00s)
ok  	github.com/kunchenguid/no-mistakes/internal/scm/github	1.671s
ok  	github.com/kunchenguid/no-mistakes/internal/scm/gitlab	1.857s [no tests to run]
```
</details>
<details>
<summary>Evidence: Real production path resolving the real github-personal alias</summary>

```text
$ ssh -G -- github-personal | grep -i ^hostname
hostname github.com

# production Go path (real ssh -G, no injected fake):
remote (unchanged for auth/push): git@github-personal:rudingma/no-mistakes.git
ResolveHost -> "github.com"
DetectProviderContext -> "github"
ExtractHost (raw) -> "github-personal" # remote URL left intact
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (14m36s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `internal/scm/scm.go:137` - lookupSSHHostname (internal/scm/scm.go:132-140) builds the `ssh -G` command with exec.CommandContext and passes it directly to shellenv.OutputShellCommand without first calling shellenv.ConfigureShellCommand(cmd). Both other one-shot callers of these helpers call ConfigureShellCommand first (internal/pipeline/steps/common_exec.go:255, internal/shellenv/shellenv.go:324), and the helper doc comments state StartShellCommand expects it. Consequences: on Windows the console-less daemon spawns ssh.exe without winproc.Harden, flashing a console window per invocation (regression of #287) — and ResolveHost/DetectProviderContext run several times per run for an SSH-alias remote, so it flashes repeatedly; the kill-on-close job object and WaitDelay backstop are also skipped. Fix: call shellenv.ConfigureShellCommand(cmd) after constructing cmd (the 2s WithTimeout can stay).

🔧 Fix: configure ssh -G lookup command via shellenv helper
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- 🚨 tests failed with exit code 1
- `go test -race ./...`

🔧 Fix: isolate ambient PATH and telemetry env in tests
✅ Re-checked - no issues remain.
- `go test -race ./...`
- <code>`go test -race -v -run &#39;TestDetectProvider|TestResolveHost&#39; ./internal/scm/` — GitHub scp + GitLab ssh alias classification, canonical hostname, lookup-failure-preserves-alias, HTTPS-does-not-invoke-ssh, Windows-path-does-not-invoke-ssh</code>
- <code>`go test -race -v -run TestHostPrefixedSlugForHost_SSHAlias ./internal/scm/github/` — CLI hostname scoping honors resolved host without rewriting the remote</code>
- <code>`go test -race -v -run &#39;Client&#39; ./internal/telemetry/` and `-run TestPRStep_SkipsWhenProviderCLIUnavailable ./internal/pipeline/steps/` — the two ambient-env isolation fixes from commit 0ef31c6</code>
- <code>Manual end-to-end: temporary test exercising the real production path ResolveHost/DetectProviderContext -&gt; real lookupSSHHostname -&gt; real `ssh -G` against the machine&#39;s actual `git@github-personal:...` remote (resolved host github.com, provider github, raw remote unchanged); temp test removed afterward, worktree left clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
