### PR TITLE
fix(scm/github): target known PR explicitly from bare gate repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,11 @@ Safest local verification sequence after non-trivial changes:
 - Agent harnesses and hardened CI inject `safe.bareRepository=explicit`, which forbids cwd-based discovery of bare repositories. Route every gate git call through `git.Run`, which detects a bare git dir and prepends `--git-dir=<dir>`; never shell out to git in a bare gate repo relying on `cmd.Dir` or `-C` discovery (issue #362).
 - Regressions: `TestRunOnBareRepoUnderSafeBareRepositoryExplicit`, `TestWorktreeAddRemoveOnBareRepoUnderSafeBareRepositoryExplicit`, `TestInitUnderSafeBareRepositoryExplicit`.
 
+**`gh` PR-Targeting From the Bare Gate Repo (`internal/scm/github`)**
+
+- The daemon runs `gh` from the detached bare gate repo whose HEAD is the default branch, so PR-targeting reads must name the exact PR explicitly: an empty positional makes `gh pr <verb>` infer the cwd branch (`main`) and return `no pull requests found for branch main` even when the feature PR's checks are green. `GetChecks`, `GetPRState`, and `GetMergeableState` route through the shared `prSelector` (number, else URL, else fail closed) — never append a bare `pr.Number` that can be empty. This is the `gh` analogue of the git bare-gate-repo trap above.
+- Regressions: `TestGetChecksTargetsKnownPRByURLWhenNumberMissing`, `TestPRTargetingReadsFailClosedWithoutIdentity`, `TestPRStateAndMergeableTargetKnownPRByURL`.
+
 **Post-Receive Hook Gate Path Resolution (`internal/git/hook.go`)**
 
 - The hook's `--gate` value must never come from a bare `$(pwd)`: Git can invoke `post-receive` from a cwd that collapses to `.` (issue #269), which the daemon rejects and the pipeline silently never starts. The hook script resolves an absolute gate dir (git first, hook location fallback), and `normalizeNotifyGatePath` in `internal/cli/daemon_cmd.go` is an independent second layer that absolutizes whatever an already-installed older hook sends.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,8 +60,8 @@ Safest local verification sequence after non-trivial changes:
 
 **`gh` PR-Targeting From the Bare Gate Repo (`internal/scm/github`)**
 
-- The daemon runs `gh` from the detached bare gate repo whose HEAD is the default branch, so PR-targeting reads must name the exact PR explicitly: an empty positional makes `gh pr <verb>` infer the cwd branch (`main`) and return `no pull requests found for branch main` even when the feature PR's checks are green. `GetChecks`, `GetPRState`, and `GetMergeableState` route through the shared `prSelector` (number, else URL, else fail closed) — never append a bare `pr.Number` that can be empty. This is the `gh` analogue of the git bare-gate-repo trap above.
-- Regressions: `TestGetChecksTargetsKnownPRByURLWhenNumberMissing`, `TestPRTargetingReadsFailClosedWithoutIdentity`, `TestPRStateAndMergeableTargetKnownPRByURL`.
+- The daemon runs `gh` from the detached bare gate repo whose HEAD is the default branch, so every PR-targeting command must name the exact PR explicitly: an empty positional makes `gh pr <verb>` infer the cwd branch (`main`) and return `no pull requests found for branch main` even when the feature PR's checks are green. `GetChecks`, `GetPRState`, `GetMergeableState`, and `UpdatePR` route through the shared `prSelector` (number, else URL, else fail closed) — never append a bare `pr.Number`/`pr.URL` that can be empty. This is the `gh` analogue of the git bare-gate-repo trap above.
+- Regressions: `TestGetChecksTargetsKnownPRByURLWhenNumberMissing`, `TestPRTargetingReadsFailClosedWithoutIdentity`, `TestPRStateAndMergeableTargetKnownPRByURL`, `TestUpdatePRTargetsKnownPRByURLWhenNumberMissing`, `TestUpdatePRFailsClosedWithoutIdentity`.
 
 **Post-Receive Hook Gate Path Resolution (`internal/git/hook.go`)**
 

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -114,6 +114,26 @@ func (h *Host) repoArgs() []string {
 	return []string{"--repo", h.repo}
 }
 
+// prSelector returns the explicit gh PR selector for pr, preferring the numeric
+// PR number and falling back to the canonical PR URL; both name the exact pull
+// request to gh regardless of the process working directory. It fails closed
+// when neither is known: an empty positional makes `gh pr <verb>` fall back to
+// resolving the current branch of the cwd, and the daemon runs from a detached
+// bare gate repo whose HEAD is the default branch (main), so an inferred
+// selector silently targets the wrong PR (or none — "no pull requests found for
+// branch main") instead of the feature PR the pipeline already knows.
+func prSelector(pr *scm.PR) (string, error) {
+	if pr != nil {
+		if n := strings.TrimSpace(pr.Number); n != "" {
+			return n, nil
+		}
+		if u := strings.TrimSpace(pr.URL); u != "" {
+			return u, nil
+		}
+	}
+	return "", errors.New("no PR number or URL known; refusing to run gh with a cwd-inferred branch")
+}
+
 func (h *Host) headRef(branch string) string {
 	if h.forkOwner == "" {
 		return branch
@@ -251,7 +271,11 @@ func (h *Host) UpdatePR(ctx context.Context, pr *scm.PR, content scm.PRContent) 
 }
 
 func (h *Host) GetPRState(ctx context.Context, pr *scm.PR) (scm.PRState, error) {
-	args := append([]string{"pr", "view", pr.Number}, h.repoArgs()...)
+	selector, err := prSelector(pr)
+	if err != nil {
+		return "", err
+	}
+	args := append([]string{"pr", "view", selector}, h.repoArgs()...)
 	args = append(args, "--json", "state", "--jq", ".state")
 	cmd := h.cmd(ctx, "gh", args...)
 	out, err := cmd.Output()
@@ -262,7 +286,11 @@ func (h *Host) GetPRState(ctx context.Context, pr *scm.PR) (scm.PRState, error) 
 }
 
 func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
-	args := append([]string{"pr", "checks", pr.Number}, h.repoArgs()...)
+	selector, err := prSelector(pr)
+	if err != nil {
+		return nil, err
+	}
+	args := append([]string{"pr", "checks", selector}, h.repoArgs()...)
 	args = append(args, "--json", "name,state,bucket,completedAt")
 	cmd := h.cmd(ctx, "gh", args...)
 	out, err := cmd.CombinedOutput()
@@ -295,7 +323,11 @@ func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
 }
 
 func (h *Host) GetMergeableState(ctx context.Context, pr *scm.PR) (scm.MergeableState, error) {
-	args := append([]string{"pr", "view", pr.Number}, h.repoArgs()...)
+	selector, err := prSelector(pr)
+	if err != nil {
+		return "", err
+	}
+	args := append([]string{"pr", "view", selector}, h.repoArgs()...)
 	args = append(args, "--json", "mergeable", "--jq", ".mergeable")
 	cmd := h.cmd(ctx, "gh", args...)
 	out, err := cmd.Output()

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -256,11 +256,11 @@ func (h *Host) CreatePR(ctx context.Context, branch, base string, content scm.PR
 }
 
 func (h *Host) UpdatePR(ctx context.Context, pr *scm.PR, content scm.PRContent) (*scm.PR, error) {
-	id := pr.Number
-	if id == "" {
-		id = pr.URL
+	selector, err := prSelector(pr)
+	if err != nil {
+		return nil, err
 	}
-	args := append([]string{"pr", "edit", id}, h.repoArgs()...)
+	args := append([]string{"pr", "edit", selector}, h.repoArgs()...)
 	args = append(args, "--title", content.Title, "--body-file", "-")
 	cmd := h.cmd(ctx, "gh", args...)
 	cmd.Stdin = strings.NewReader(content.Body)

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -190,6 +190,135 @@ func TestGetChecksFallsBackToStateWhenBucketMissing(t *testing.T) {
 	}
 }
 
+// recordingCmdFactory captures the argv of every gh invocation into recorded
+// and replies with a fixed successful stdout, so tests can assert exactly which
+// PR selector reached gh instead of matching a whole command string.
+func recordingCmdFactory(stdout string, recorded *[][]string) CmdFactory {
+	return func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		*recorded = append(*recorded, append([]string{name}, args...))
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestGitHubHelperProcess", "--", "recorded")
+		cmd.Env = append(os.Environ(),
+			"GITHUB_TEST_HELPER=1",
+			"GITHUB_TEST_STDOUT="+stdout,
+			"GITHUB_TEST_EXIT_CODE=0",
+		)
+		return cmd
+	}
+}
+
+// failIfInvokedCmdFactory fails the test if gh is invoked at all. It proves that
+// a PR-targeting call fails closed (never shelling out) when the PR identity is
+// unknown, instead of running an argument-less gh that infers the cwd branch.
+func failIfInvokedCmdFactory(t *testing.T) CmdFactory {
+	t.Helper()
+	return func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		t.Fatalf("gh should not be invoked without a known PR identity; got: %s %s", name, strings.Join(args, " "))
+		return nil
+	}
+}
+
+// The final CI check lookup must target the exact PR the pipeline already knows.
+//
+// Trigger: the CI monitor calls GetChecks with a PR the pipeline identifies by
+// URL (Number can be empty when the identity was carried as a URL only).
+// Masking condition: the daemon runs gh from the detached bare gate repo whose
+// HEAD is the default branch (main).
+// Symptom: appending an empty pr.Number produced an argument-less
+// `gh pr checks --repo <slug>`, so gh fell back to resolving the cwd branch
+// (main) and reported "no pull requests found for branch main" even though the
+// feature PR's exact-head checks are green — certification could never finish.
+//
+// The fix passes the canonical PR URL as the explicit selector when the number
+// is absent, so the target is always the known PR, never an inferred branch.
+func TestGetChecksTargetsKnownPRByURLWhenNumberMissing(t *testing.T) {
+	t.Parallel()
+
+	var recorded [][]string
+	host := New(recordingCmdFactory("[]\n", &recorded), nil, "", "test/repo")
+
+	prURL := "https://github.com/test/repo/pull/123"
+	if _, err := host.GetChecks(context.Background(), &scm.PR{URL: prURL}); err != nil {
+		t.Fatalf("GetChecks() error = %v", err)
+	}
+	if len(recorded) != 1 {
+		t.Fatalf("expected exactly one gh invocation, got %d: %v", len(recorded), recorded)
+	}
+	got := recorded[0]
+	// argv is: gh pr checks <selector> --repo ...
+	if len(got) < 4 || got[1] != "pr" || got[2] != "checks" {
+		t.Fatalf("unexpected argv: %v", got)
+	}
+	selector := got[3]
+	if selector != prURL {
+		t.Fatalf("check selector = %q, want the known PR URL %q (empty selector makes gh resolve the cwd branch)", selector, prURL)
+	}
+}
+
+// Compare with the proven explicit-PR invocation: when the number is known it is
+// passed verbatim as the selector, exactly as before.
+func TestGetChecksTargetsKnownPRByNumber(t *testing.T) {
+	t.Parallel()
+
+	var recorded [][]string
+	host := New(recordingCmdFactory("[]\n", &recorded), nil, "", "test/repo")
+
+	if _, err := host.GetChecks(context.Background(), &scm.PR{Number: "123", URL: "https://github.com/test/repo/pull/123"}); err != nil {
+		t.Fatalf("GetChecks() error = %v", err)
+	}
+	if len(recorded) != 1 || len(recorded[0]) < 4 {
+		t.Fatalf("unexpected invocations: %v", recorded)
+	}
+	if selector := recorded[0][3]; selector != "123" {
+		t.Fatalf("check selector = %q, want %q", selector, "123")
+	}
+}
+
+// Missing/invalid PR identity must stop safely rather than checking main or some
+// other PR: with neither number nor URL, the PR-targeting reads refuse to shell
+// out at all.
+func TestPRTargetingReadsFailClosedWithoutIdentity(t *testing.T) {
+	t.Parallel()
+
+	host := New(failIfInvokedCmdFactory(t), nil, "", "test/repo")
+	pr := &scm.PR{}
+
+	if _, err := host.GetChecks(context.Background(), pr); err == nil {
+		t.Fatal("GetChecks() with no PR identity: expected error, got nil")
+	}
+	if _, err := host.GetPRState(context.Background(), pr); err == nil {
+		t.Fatal("GetPRState() with no PR identity: expected error, got nil")
+	}
+	if _, err := host.GetMergeableState(context.Background(), pr); err == nil {
+		t.Fatal("GetMergeableState() with no PR identity: expected error, got nil")
+	}
+}
+
+// GetPRState and GetMergeableState share the same selector boundary as
+// GetChecks, so a URL-only PR must target the URL there too.
+func TestPRStateAndMergeableTargetKnownPRByURL(t *testing.T) {
+	t.Parallel()
+
+	prURL := "https://github.com/test/repo/pull/123"
+
+	var stateArgs [][]string
+	stateHost := New(recordingCmdFactory("OPEN\n", &stateArgs), nil, "", "test/repo")
+	if _, err := stateHost.GetPRState(context.Background(), &scm.PR{URL: prURL}); err != nil {
+		t.Fatalf("GetPRState() error = %v", err)
+	}
+	if len(stateArgs) != 1 || len(stateArgs[0]) < 4 || stateArgs[0][3] != prURL {
+		t.Fatalf("GetPRState selector = %v, want %q at argv[3]", stateArgs, prURL)
+	}
+
+	var mergeArgs [][]string
+	mergeHost := New(recordingCmdFactory("MERGEABLE\n", &mergeArgs), nil, "", "test/repo")
+	if _, err := mergeHost.GetMergeableState(context.Background(), &scm.PR{URL: prURL}); err != nil {
+		t.Fatalf("GetMergeableState() error = %v", err)
+	}
+	if len(mergeArgs) != 1 || len(mergeArgs[0]) < 4 || mergeArgs[0][3] != prURL {
+		t.Fatalf("GetMergeableState selector = %v, want %q at argv[3]", mergeArgs, prURL)
+	}
+}
+
 func TestGetChecksParsesCompletedAt(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -166,6 +166,49 @@ func TestUpdatePRStreamsBodyThroughStdin(t *testing.T) {
 	}
 }
 
+// UpdatePR shares the same explicit-PR selector boundary as the read methods:
+// when the number is absent it must target the canonical PR URL, never an empty
+// positional that makes `gh pr edit` resolve the cwd branch (main) from the
+// detached bare gate repo and edit the wrong PR.
+func TestUpdatePRTargetsKnownPRByURLWhenNumberMissing(t *testing.T) {
+	t.Parallel()
+
+	var recorded [][]string
+	host := New(recordingCmdFactory("", &recorded), nil, "", "test/repo")
+
+	prURL := "https://github.com/test/repo/pull/123"
+	if _, err := host.UpdatePR(context.Background(), &scm.PR{URL: prURL}, scm.PRContent{
+		Title: "fix: cap body",
+		Body:  "body",
+	}); err != nil {
+		t.Fatalf("UpdatePR() error = %v", err)
+	}
+	if len(recorded) != 1 {
+		t.Fatalf("expected exactly one gh invocation, got %d: %v", len(recorded), recorded)
+	}
+	got := recorded[0]
+	// argv is: gh pr edit <selector> --repo ...
+	if len(got) < 4 || got[1] != "pr" || got[2] != "edit" {
+		t.Fatalf("unexpected argv: %v", got)
+	}
+	if selector := got[3]; selector != prURL {
+		t.Fatalf("edit selector = %q, want the known PR URL %q (empty selector makes gh resolve the cwd branch)", selector, prURL)
+	}
+}
+
+// UpdatePR must fail closed exactly like the read methods: with neither number
+// nor URL it refuses to shell out rather than running an argument-less
+// `gh pr edit` that would edit the inferred cwd branch's PR.
+func TestUpdatePRFailsClosedWithoutIdentity(t *testing.T) {
+	t.Parallel()
+
+	host := New(failIfInvokedCmdFactory(t), nil, "", "test/repo")
+
+	if _, err := host.UpdatePR(context.Background(), &scm.PR{}, scm.PRContent{Title: "t", Body: "b"}); err == nil {
+		t.Fatal("UpdatePR() with no PR identity: expected error, got nil")
+	}
+}
+
 func TestGetChecksFallsBackToStateWhenBucketMissing(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Intent

The developer (Chris, operating as an autonomous crewmate agent under firstmate supervision) was directed to fix a no-mistakes bug where the shipping validator's final GitHub check lookup relied on repository/branch inference from the gate's bare repository instead of explicitly targeting the already-known pull request. The concrete failure: when the daemon runs `gh pr checks` from the detached bare gate repo whose HEAD is `main` and the PR is known only by URL (empty `Number`), the argument-less command resolves `main` and returns "no pull requests found for branch main" even though the feature PR's checks are green, so certification can never finish. Requirements were to reproduce with a safe fixture separating trigger/masking/symptom, inspect all GitHub provider/command paths so the fix lands at the earliest shared boundary (not one call site), implement the smallest change passing the canonical PR number or URL explicitly, and add regression coverage proving the check targets the known PR when local HEAD is unrelated and that missing/invalid PR identity fails closed rather than checking main. Explicit constraints: preserve the full validation lifecycle and authority boundaries (never weaken, skip, or auto-accept review/test/CI/push/merge), keep secrets out of tests, never push to default or merge, and use the no-mistakes pipeline to ship without `--yes`. The fix added a shared `prSelector` helper routing `GetChecks`, `GetPRState`, and `GetMergeableState` through number-then-URL-then-fail-closed selection, with regression tests and an AGENTS.md note; after a transient test-step agent flake and a push 403 resolved by configuring an approved fork, the developer was told to rerun the pipeline through PR creation/CI.

## What Changed

- Added a shared `prSelector` helper in `internal/scm/github/github.go` that resolves `gh` PR-targeting commands to the canonical PR number, else its URL, else fails closed — routing `GetChecks`, `GetPRState`, `GetMergeableState`, and `UpdatePR` through it so they never emit a bare empty positional that `gh` would resolve to the detached bare gate repo's cwd branch (`main`).
- Added regression tests in `github_test.go` proving each method targets the known PR by URL when `Number` is empty, targets by number when present, and fails closed on missing/invalid PR identity instead of falling back to the local `main` branch.
- Documented the `gh` bare-gate-repo PR-targeting trap and its regression tests in `AGENTS.md` alongside the existing git bare-gate-repo guidance.

## Risk Assessment

✅ Low: The follow-up unifies UpdatePR onto the same fail-closed prSelector boundary already proven for the read methods, with matching regression coverage and no happy-path behavior change.

## Testing

The baseline `go test -race ./...` already passed. I ran the six new regression tests (green) and the full github package suite (green), then produced a product-level transcript of the exact `gh` argv the daemon builds: for a PR known only by URL (empty Number, as carried through the pipeline from the detached bare gate repo whose HEAD is main), every command — `gh pr checks/view/edit` — targets `https://github.com/test/repo/pull/123` explicitly rather than an inferred `main` branch, and with no PR identity all four fail closed with "no PR number or URL known; refusing to run gh with a cwd-inferred branch" without invoking gh. This is a daemon/CLI backend change with no UI surface, so the gh-argv transcript is the appropriate end-user-facing artifact. Overall result: the intended behavior is demonstrated working end-to-end.

<details>
<summary>Evidence: gh PR-targeting argv transcript (fix demonstrated end-to-end)</summary>

<code>SCENARIO: daemon runs gh from detached bare gate repo (HEAD=main); PR known only by URL&#10;PR identity: Number=&#34;&#34; (empty) URL=&#34;https://github.com/test/repo/pull/123&#34;&#10;&#10;GetChecks -&gt; gh pr checks https://github.com/test/repo/pull/123 --repo test/repo --json name,state,bucket,completedAt ✔ explicit PR, NOT cwd branch&#10;GetPRState -&gt; gh pr view https://github.com/test/repo/pull/123 --repo test/repo --json state --jq .state ✔&#10;GetMergeable-&gt; gh pr view https://github.com/test/repo/pull/123 --repo test/repo --json mergeable --jq .mergeable ✔&#10;UpdatePR -&gt; gh pr edit https://github.com/test/repo/pull/123 --repo test/repo --title t --body-file - ✔&#10;&#10;SCENARIO: PR identity unknown (Number=&#34;&#34;, URL=&#34;&#34;) -&gt; fail closed, never touch gh&#10;GetChecks/GetPRState/GetMergeableState/UpdatePR -&gt; refused: no PR number or URL known; refusing to run gh with a cwd-inferred branch</code>

```text
=== RUN   TestEvidence_ExplicitPRTargeting
=== SCENARIO: daemon runs gh from detached bare gate repo (HEAD=main); PR known only by URL ===

PR identity carried by pipeline: Number="" (empty)  URL="https://github.com/test/repo/pull/123"

  GetChecks   (CI certification)     -> gh pr checks https://github.com/test/repo/pull/123 --repo test/repo --json name,state,bucket,completedAt
                                        selector = "https://github.com/test/repo/pull/123"  ✔ explicit PR, NOT cwd branch

  GetPRState  (open/merged/closed)   -> gh pr view https://github.com/test/repo/pull/123 --repo test/repo --json state --jq .state
                                        selector = "https://github.com/test/repo/pull/123"  ✔ explicit PR, NOT cwd branch

  GetMergeableState                  -> gh pr view https://github.com/test/repo/pull/123 --repo test/repo --json mergeable --jq .mergeable
                                        selector = "https://github.com/test/repo/pull/123"  ✔ explicit PR, NOT cwd branch

  UpdatePR    (edit title/body)      -> gh pr edit https://github.com/test/repo/pull/123 --repo test/repo --title t --body-file -
                                        selector = "https://github.com/test/repo/pull/123"  ✔ explicit PR, NOT cwd branch

=== SCENARIO: PR identity unknown (Number="", URL="") -> must fail closed, never touch gh ===

  GetChecks          -> refused: no PR number or URL known; refusing to run gh with a cwd-inferred branch
  GetPRState         -> refused: no PR number or URL known; refusing to run gh with a cwd-inferred branch
  GetMergeableState  -> refused: no PR number or URL known; refusing to run gh with a cwd-inferred branch
  UpdatePR           -> refused: no PR number or URL known; refusing to run gh with a cwd-inferred branch

RESULT: every PR-targeting command names the known PR explicitly; unknown identity fails closed.
--- PASS: TestEvidence_ExplicitPRTargeting (0.01s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/scm/github	0.008s
```
</details>
<details>
<summary>Evidence: Regression test run (6 tests, all pass)</summary>

```text
=== RUN   TestUpdatePRTargetsKnownPRByURLWhenNumberMissing
=== PAUSE TestUpdatePRTargetsKnownPRByURLWhenNumberMissing
=== RUN   TestUpdatePRFailsClosedWithoutIdentity
=== PAUSE TestUpdatePRFailsClosedWithoutIdentity
=== RUN   TestGetChecksTargetsKnownPRByURLWhenNumberMissing
=== PAUSE TestGetChecksTargetsKnownPRByURLWhenNumberMissing
=== RUN   TestGetChecksTargetsKnownPRByNumber
=== PAUSE TestGetChecksTargetsKnownPRByNumber
=== RUN   TestPRTargetingReadsFailClosedWithoutIdentity
=== PAUSE TestPRTargetingReadsFailClosedWithoutIdentity
=== RUN   TestPRStateAndMergeableTargetKnownPRByURL
=== PAUSE TestPRStateAndMergeableTargetKnownPRByURL
=== CONT  TestPRStateAndMergeableTargetKnownPRByURL
=== CONT  TestGetChecksTargetsKnownPRByURLWhenNumberMissing
=== CONT  TestGetChecksTargetsKnownPRByNumber
=== CONT  TestUpdatePRFailsClosedWithoutIdentity
--- PASS: TestUpdatePRFailsClosedWithoutIdentity (0.00s)
=== CONT  TestPRTargetingReadsFailClosedWithoutIdentity
--- PASS: TestPRTargetingReadsFailClosedWithoutIdentity (0.00s)
=== CONT  TestUpdatePRTargetsKnownPRByURLWhenNumberMissing
--- PASS: TestGetChecksTargetsKnownPRByNumber (1.01s)
--- PASS: TestGetChecksTargetsKnownPRByURLWhenNumberMissing (1.01s)
--- PASS: TestUpdatePRTargetsKnownPRByURLWhenNumberMissing (1.01s)
--- PASS: TestPRStateAndMergeableTargetKnownPRByURL (2.02s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/scm/github	3.045s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `internal/scm/github/github.go:259` - UpdatePR (github.go:258-263) still uses the same inline number-else-URL selection but does NOT fail closed: if both pr.Number and pr.URL are empty, it runs `gh pr edit &#34;&#34;` with an empty positional, which from the detached bare gate repo infers the cwd branch (main) — the exact trap this change eliminates for the read methods. It could target the wrong PR instead of erroring. This is a pre-existing latent gap (not introduced here, and in practice CreatePR always sets URL), but routing UpdatePR through prSelector would close it and unify the selection logic. Flagged ask-user because switching it to fail-closed changes behavior on the empty-identity edge.

🔧 Fix: route UpdatePR through fail-closed prSelector with regression coverage
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`
- <code>`go test -race -v -run &#39;TestGetChecksTargetsKnownPRByURLWhenNumberMissing|TestGetChecksTargetsKnownPRByNumber|TestPRTargetingReadsFailClosedWithoutIdentity|TestPRStateAndMergeableTargetKnownPRByURL|TestUpdatePRTargetsKnownPRByURLWhenNumberMissing|TestUpdatePRFailsClosedWithoutIdentity&#39; ./internal/scm/github/` — all 6 regression tests pass</code>
- <code>`go test -race ./internal/scm/github/` — full package suite passes</code>
- <code>Wrote a throwaway `TestEvidence_ExplicitPRTargeting` that drives the four PR-targeting methods through a recording gh factory with a URL-only PR (empty Number) and a blank PR, printing the exact gh argv; captured the transcript then removed the throwaway file (working tree clean)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
