### PR TITLE
fix(cli): keep AXI output readable with control bytes

### DIFF
--- a/.no-mistakes/evidence/fm/nm-test-step-completion-hang-d1/axi-control-byte-e2e.txt
+++ b/.no-mistakes/evidence/fm/nm-test-step-completion-hang-d1/axi-control-byte-e2e.txt
@@ -1,0 +1,92 @@
+Command: go test -tags=e2e ./internal/e2e -run '^TestAXIControlByteFailureGateRemainsReadable$' -count=1 -v
+
+End-user `no-mistakes axi status --run 01KY0S6XJN4XAWXTPQXHPTYAZN` output:
+
+run:
+  id: "01KY0S6XJN4XAWXTPQXHPTYAZN"
+  branch: control-byte-test-gate
+  status: running
+  awaiting_agent: parked 0s
+  head: ff000c41
+  findings: 2 info
+  steps[9]{step,status,findings,duration_ms}:
+    intent,skipped,0,44
+    rebase,completed,0,122
+    review,completed,1,213
+    test,awaiting_approval,1,111
+    document,pending,0,0
+    lint,pending,0,0
+    push,pending,0,0
+    pr,pending,0,0
+    ci,pending,0,0
+gate:
+  step: test
+  status: awaiting_approval
+  summary: "bad\\x1Fvalue\nlater-00\nlater-01\nlater-02\nlater-03\nlater-04\nlater-05\nlater-06\nlater-07\nlater-08\nlater-09\nlater-10\nlater-11\nlater-12\nlater-13\nlater-14\nlater-15\nlater-16\nlater-17\nlater-18\nlater-19\nlater-20\nlater-21\nlater-22\nlater-23\nlater-24\nlater-25\nlater-26\nlater-27\nlater-28\nlater-29\nlater-30\nlater-31\nlater-32\nlater-33\nlater-34\nlater-35\nlater-36\nlater-37\nlater-38\nlater-39\nlater-40\nlater-41\nlater-42\nlater-43\nlater-44\n"
+  findings[1]{id,severity,file,action,description}:
+    test-1,error,"","",tests failed with exit code 1
+help[6]: Run `no-mistakes axi respond --action approve` to accept this step and continue,Run `no-mistakes axi respond --action fix --findings <ids>` to have the pipeline fix the selected findings (do not edit files yourself),Run `no-mistakes axi respond --action skip` to skip this step,Run `no-mistakes axi logs --step test --full` to read the full step log,"A long-running call is working, not stalled - background it if your harness needs to, but the run never advances past a gate on its own. Read every return; on a `gate:`, respond; loop until an `outcome:`.","Commit post-pipeline follow-up work on top of the existing branch so every pipeline fix commit remains present. Never abort-and-restart, reset, or replace the branch in a way that drops prior gate-fix commits."
+
+End-user `no-mistakes axi logs --run 01KY0S6XJN4XAWXTPQXHPTYAZN --step test --full` output:
+
+step: test
+run: "01KY0S6XJN4XAWXTPQXHPTYAZN"
+lines: 48 total
+log[48]{line}:
+  "running tests: nm-control-byte-test-e2e"
+  ""
+  "bad\\x1Fvalue"
+  later-00
+  later-01
+  later-02
+  later-03
+  later-04
+  later-05
+  later-06
+  later-07
+  later-08
+  later-09
+  later-10
+  later-11
+  later-12
+  later-13
+  later-14
+  later-15
+  later-16
+  later-17
+  later-18
+  later-19
+  later-20
+  later-21
+  later-22
+  later-23
+  later-24
+  later-25
+  later-26
+  later-27
+  later-28
+  later-29
+  later-30
+  later-31
+  later-32
+  later-33
+  later-34
+  later-35
+  later-36
+  later-37
+  later-38
+  later-39
+  later-40
+  later-41
+  later-42
+  later-43
+  later-44
+
+Direct durable-state checks in the same isolated journey:
+
+raw test.log contains U+001F: true
+document: pending
+lint: pending
+push: pending
+
+Result: PASS

--- a/.no-mistakes/evidence/fm/nm-test-step-completion-hang-d1/axi-oversized-gate-e2e.txt
+++ b/.no-mistakes/evidence/fm/nm-test-step-completion-hang-d1/axi-oversized-gate-e2e.txt
@@ -1,0 +1,36 @@
+Evidence-producing variation: the same isolated real-process journey emitted 145 test-output lines so the default Test gate summary exceeded its inline limit.
+
+End-user `no-mistakes axi status --run 01KY0S8104G0490XKB1G86XST8` output excerpt:
+
+run:
+  id: "01KY0S8104G0490XKB1G86XST8"
+  branch: control-byte-test-gate
+  status: running
+  awaiting_agent: parked 1s
+  findings: 2 info
+  steps[9]{step,status,findings,duration_ms}:
+    intent,skipped,0,45
+    rebase,completed,0,121
+    review,completed,1,272
+    test,awaiting_approval,1,253
+    document,pending,0,0
+    lint,pending,0,0
+    push,pending,0,0
+    pr,pending,0,0
+    ci,pending,0,0
+gate:
+  step: test
+  status: awaiting_approval
+  summary: "bad\\x1Fvalue\nlater-000\nlater-001\nlater-002\nlater-003\nlater-004\nlater-005\nlater-006\nlater-007\nlater-008\nlater-009\nlater-010\nlater-011\nlater-012\nlater-013\nlater-014\nlater-015\nlater-016\nlater-017\nlater-018\nlater-019\nlater-020\nlater-021\nlater-022\nlater-023\nlater-024\nlater-025\nlater-026\nlater-027\nlater-028\nlater-029\nlater-030\nlater-031\nlater-032\nlater-033\nlater-034\nlater-035\nlater-036\nlater-037\nlater-038\nlater-039\nlater-040\nlater-041\nlater-042\nlater-043\nlater-044\nlater-045\nlater-046\nlater-047\nlater-048\nlater-049\nlater-050\nlater-051\nlater-052\nlater-053\nlater-054\nlater-055\nlater-056\nlater-057\nlater-058\nlater-059\nlater-060\nlater-061\nlater-062\nlater-063\nlater-064\nlater-065\nlater-066\nlater-067\nlater-068\nlater-069\nlater-070\nlater-071\nlater-072\nlater-073\nlater-074\nlater-075\nlater-076\nlater-077\nlater-078\nlater-079\nlater-080\nlater-081\nlater-082\nlater-083\nlater-084\nlater-085\nlater-086\nlater-087\nlater-088\nlater-089\nlater-090\nlater-091\nlater-092\nlater-093\nlater-094\nlater-095\nlater-096\nlater-097\nlater-098\nlater-099\nlater-100\nlater-101\nlater-102\nlater-103\nlater-104\nlater-105\nlater-106\nlater-107\nlater-108\nlater-109\nlater-110\nlater-111\nlater-112\nlater-113\nlater-114\nlater-115\nlater-116\nlater-117\nlater-118\n… (truncated, 1460 chars total)"
+  findings[1]{id,severity,file,action,description}:
+    test-1,error,"","",tests failed with exit code 1
+help[6]: Run `no-mistakes axi respond --action approve` to accept this step and continue,Run `no-mistakes axi respond --action fix --findings <ids>` to have the pipeline fix the selected findings (do not edit files yourself),Run `no-mistakes axi respond --action skip` to skip this step,Run `no-mistakes axi logs --step test --full` to read the full step log,"A long-running call is working, not stalled - background it if your harness needs to, but the run never advances past a gate on its own. Read every return; on a `gate:`, respond; loop until an `outcome:`.","Commit post-pipeline follow-up work on top of the existing branch so every pipeline fix commit remains present. Never abort-and-restart, reset, or replace the branch in a way that drops prior gate-fix commits."
+
+Direct durable-state checks in the same isolated journey:
+
+raw test.log contains U+001F: true
+document: pending
+lint: pending
+push: pending
+
+Result: PASS

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -58,6 +58,8 @@ Skill installation is best-effort: if the skill write fails, init reports it and
 Agent eXperience Interface for non-interactive agents.
 Most agent workflows use the installed `/no-mistakes` skill, which drives this command surface underneath.
 It prints TOON to stdout, prints progress to stderr, and uses structured stdout errors with exit code `1` for operational failures and `2` for bad usage.
+At the TOON output boundary, unsupported C0 control bytes are rendered as visible `\xNN` escapes while tabs, carriage returns, newlines, printable Unicode, and the underlying durable logs remain unchanged.
+If TOON encoding still fails, AXI prints a structured error instead of returning successful empty stdout.
 The calling agent drives AXI approval gates but does not replace the configured pipeline agent that performs validation.
 
 ```sh
@@ -162,6 +164,7 @@ When the resolved run has a `running` or `fixing` step, the run object includes 
 Each row reports how long the step has been active, the latest meaningful log or native-agent lifecycle activity, the native agent PID if one is currently running, and the current round such as `round 1`, `auto-fix 1/3`, or `fix 2`.
 If no activity arrives for longer than `step_quiet_warning`, `last_activity` is prefixed with `quiet`; this is only a liveness signal and does not cancel the step.
 For older active runs with no recorded activity timestamp, AXI falls back to the step log file modification time.
+Gate summaries and finding descriptions are bounded in this default status view; truncated values disclose their original length, and the gate help points to `no-mistakes axi logs --step <step> --full` for the complete step log.
 Relevant current-branch states also include a cached `branch_sync` object with full SHAs, the run's status, the persisted pipeline push binding, target kind and ref, relation, safety result, PR lifecycle, and a structured next action.
 Cached home and status rendering performs no network read and labels the remote observation `pipeline_push`; only explicit sync check or apply reports `live` freshness.
 

--- a/internal/cli/axi_render.go
+++ b/internal/cli/axi_render.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"fmt"
+	"reflect"
+	"strings"
 	"time"
 
 	toon "github.com/toon-format/toon-go"
@@ -19,7 +21,10 @@ var nowUnix = func() int64 { return time.Now().Unix() }
 // maxFindingDesc caps a finding description rendered inline. Findings are the
 // decision content at a gate, so the limit is generous; only pathological
 // descriptions get truncated, with the full length disclosed.
-const maxFindingDesc = 600
+const (
+	maxFindingDesc = 600
+	maxGateSummary = 1200
+)
 
 // Row types carry `toon` tags so the encoder renders a []row slice as a
 // tabular array (name[N]{cols}:) with one comma-delimited line per element.
@@ -437,7 +442,7 @@ func gateFields(gate stepView) []toon.Field {
 		{Key: "status", Value: gate.Status},
 	}
 	if parsed.Summary != "" {
-		gfields = append(gfields, toon.Field{Key: "summary", Value: parsed.Summary})
+		gfields = append(gfields, toon.Field{Key: "summary", Value: truncate(parsed.Summary, maxGateSummary)})
 	}
 	if parsed.RiskLevel != "" {
 		gfields = append(gfields, toon.Field{Key: "risk", Value: parsed.RiskLevel})
@@ -486,12 +491,127 @@ func truncate(s string, limit int) string {
 // --- output helpers ---
 
 // axiDoc marshals an ordered set of TOON fields into a document with a trailing
-// newline. Encoding errors are impossible for the value shapes we build here,
-// so a failure degrades to an empty document rather than propagating.
+// newline. AXI fields can include arbitrary subprocess output, findings, and
+// provider data. TOON intentionally rejects most C0 controls, so make those
+// bytes visible before encoding instead of dropping the entire document.
 func axiDoc(fields ...toon.Field) string {
-	out, err := toon.MarshalString(toon.NewObject(fields...))
+	value := sanitizeTOONValue(toon.NewObject(fields...))
+	out, err := toon.MarshalString(value)
 	if err != nil {
-		return ""
+		return axiEncodingError(err)
+	}
+	return out + "\n"
+}
+
+// escapeUnsupportedTOONControls converts only C0 bytes the TOON encoder cannot
+// represent. Byte-wise copying preserves all printable Unicode and arbitrary
+// non-ASCII evidence exactly; tab, carriage return, and newline keep TOON's
+// supported escaping semantics.
+func escapeUnsupportedTOONControls(s string) string {
+	first := -1
+	for i := 0; i < len(s); i++ {
+		if unsupportedTOONControl(s[i]) {
+			first = i
+			break
+		}
+	}
+	if first < 0 {
+		return s
+	}
+
+	var b strings.Builder
+	b.Grow(len(s) + 3)
+	b.WriteString(s[:first])
+	for i := first; i < len(s); i++ {
+		if unsupportedTOONControl(s[i]) {
+			fmt.Fprintf(&b, `\x%02X`, s[i])
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+func unsupportedTOONControl(b byte) bool {
+	return b < 0x20 && b != '\t' && b != '\r' && b != '\n'
+}
+
+// sanitizeTOONValue recursively copies the render value while escaping strings.
+// Keeping each concrete type intact preserves TOON's existing ordered objects,
+// struct field names, and tabular-array rendering.
+func sanitizeTOONValue(value any) any {
+	return sanitizeTOONReflect(reflect.ValueOf(value)).Interface()
+}
+
+func sanitizeTOONReflect(value reflect.Value) reflect.Value {
+	if !value.IsValid() {
+		return value
+	}
+
+	switch value.Kind() {
+	case reflect.String:
+		out := reflect.New(value.Type()).Elem()
+		out.SetString(escapeUnsupportedTOONControls(value.String()))
+		return out
+	case reflect.Interface:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		out := reflect.New(value.Type()).Elem()
+		out.Set(sanitizeTOONReflect(value.Elem()))
+		return out
+	case reflect.Pointer:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		out := reflect.New(value.Type().Elem())
+		out.Elem().Set(sanitizeTOONReflect(value.Elem()))
+		return out
+	case reflect.Struct:
+		out := reflect.New(value.Type()).Elem()
+		out.Set(value)
+		for i := 0; i < value.NumField(); i++ {
+			if value.Type().Field(i).PkgPath != "" {
+				continue
+			}
+			out.Field(i).Set(sanitizeTOONReflect(value.Field(i)))
+		}
+		return out
+	case reflect.Slice:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		out := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
+		for i := 0; i < value.Len(); i++ {
+			out.Index(i).Set(sanitizeTOONReflect(value.Index(i)))
+		}
+		return out
+	case reflect.Array:
+		out := reflect.New(value.Type()).Elem()
+		for i := 0; i < value.Len(); i++ {
+			out.Index(i).Set(sanitizeTOONReflect(value.Index(i)))
+		}
+		return out
+	case reflect.Map:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		out := reflect.MakeMapWithSize(value.Type(), value.Len())
+		iter := value.MapRange()
+		for iter.Next() {
+			out.SetMapIndex(iter.Key(), sanitizeTOONReflect(iter.Value()))
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+func axiEncodingError(err error) string {
+	message := "encode AXI output: " + escapeUnsupportedTOONControls(err.Error())
+	out, fallbackErr := toon.MarshalString(toon.NewObject(toon.Field{Key: "error", Value: message}))
+	if fallbackErr != nil {
+		return "error: \"encode AXI output failed\"\n"
 	}
 	return out + "\n"
 }

--- a/internal/cli/axi_test.go
+++ b/internal/cli/axi_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -304,6 +305,45 @@ func TestWriteGateShape(t *testing.T) {
 	}
 }
 
+func TestGateSummaryUsesBoundedDisclosure(t *testing.T) {
+	summary := strings.Repeat("s", maxGateSummary+25)
+	gate := stepView{
+		Name:         "test",
+		Status:       "awaiting_approval",
+		FindingsJSON: findingsJSON(t, nil, summary),
+	}
+	out := axiDoc(gateFields(gate)...)
+
+	if strings.Contains(out, summary) {
+		t.Fatalf("gate status should not render the complete oversized summary:\n%s", out)
+	}
+	if !strings.Contains(out, strings.Repeat("s", maxGateSummary)) ||
+		!strings.Contains(out, fmt.Sprintf("truncated, %d chars total", len(summary))) {
+		t.Fatalf("gate status should disclose summary truncation:\n%s", out)
+	}
+	if !strings.Contains(out, "no-mistakes axi logs --step test --full") {
+		t.Fatalf("truncated gate should point to the complete step log:\n%s", out)
+	}
+}
+
+func TestEscapeUnsupportedTOONControlsPreservesSupportedBytesAndUnicode(t *testing.T) {
+	input := "π\tline\r\n😀\x00\x07\x1f\x7f"
+	want := "π\tline\r\n😀\\x00\\x07\\x1F\x7f"
+	if got := escapeUnsupportedTOONControls(input); got != want {
+		t.Fatalf("escaped control bytes = %q, want %q", got, want)
+	}
+}
+
+func TestAxiDocEncodingFailureIsNeverSilent(t *testing.T) {
+	out := axiDoc(toon.Field{Key: "unsupported", Value: make(chan int)})
+	if strings.TrimSpace(out) == "" {
+		t.Fatal("AXI encoding failure returned successful empty output")
+	}
+	if !strings.Contains(out, "error:") || !strings.Contains(out, "encode AXI output") {
+		t.Fatalf("AXI encoding failure should return a structured error, got:\n%s", out)
+	}
+}
+
 // TestGateNote_ReviewOnly verifies the review-auto-fix-disabled note appears
 // only at the review gate, while the keep-driving reminder appears at every
 // gate.
@@ -596,6 +636,99 @@ func TestRenderedRunsFingerprintChangesForEveryDisplayedRun(t *testing.T) {
 	}
 }
 
+func TestAxiStatusEscapesControlBytesInAwaitingTestGate(t *testing.T) {
+	repoDir, p, database, repo := setupAxiQueryRepo(t)
+	chdir(t, repoDir)
+
+	dbRun, err := database.InsertRun(repo.ID, "feature/control-byte", "head", "base")
+	if err != nil {
+		t.Fatalf("insert run: %v", err)
+	}
+	if err := database.UpdateRunStatus(dbRun.ID, types.RunRunning); err != nil {
+		t.Fatalf("mark run running: %v", err)
+	}
+	step, err := database.InsertStepResult(dbRun.ID, types.StepTest)
+	if err != nil {
+		t.Fatalf("insert step: %v", err)
+	}
+	if err := database.UpdateStepStatus(step.ID, types.StepStatusAwaitingApproval); err != nil {
+		t.Fatalf("mark step awaiting: %v", err)
+	}
+	findings := findingsJSON(t, []types.Finding{{
+		ID:          "test-1\x1fcontrol",
+		Severity:    "error",
+		File:        "test\x00.log",
+		Description: "bad\x1fvalue",
+	}}, "configured test failed: bad\x1fvalue")
+	if err := database.SetStepFindings(step.ID, findings); err != nil {
+		t.Fatalf("set findings: %v", err)
+	}
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&out)
+	if _, err := runAxiStatus(cmd, dbRun.ID); err != nil {
+		t.Fatalf("axi status: %v\n%s", err, out.String())
+	}
+	got := out.String()
+	for _, want := range []string{"gate:\n", "step: test", "status: awaiting_approval", `bad\\x1Fvalue`, `test-1\\x1Fcontrol`, `test\\x00.log`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("axi status missing %q in:\n%s", want, got)
+		}
+	}
+	if strings.ContainsRune(got, '\x1f') || strings.ContainsRune(got, '\x00') {
+		t.Fatalf("axi status retained unsupported raw control bytes: %q", got)
+	}
+	if _, err := os.Stat(filepath.Join(p.LogsDir(), dbRun.ID)); err == nil {
+		t.Fatal("status rendering should not rewrite or create durable logs")
+	}
+}
+
+func TestAxiLogsFullEscapesControlByteOutsideTailWithoutRewritingLog(t *testing.T) {
+	repoDir, p, database, repo := setupAxiQueryRepo(t)
+	chdir(t, repoDir)
+
+	dbRun, err := database.InsertRun(repo.ID, "feature/control-log", "head", "base")
+	if err != nil {
+		t.Fatalf("insert run: %v", err)
+	}
+	if err := database.UpdateRunStatus(dbRun.ID, types.RunRunning); err != nil {
+		t.Fatalf("mark run running: %v", err)
+	}
+	logDir := p.RunLogDir(dbRun.ID)
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		t.Fatalf("mkdir log dir: %v", err)
+	}
+	raw := []byte("bad\x1fvalue\n" + strings.Repeat("later passing line\n", logTailLines+5))
+	logPath := filepath.Join(logDir, "test.log")
+	if err := os.WriteFile(logPath, raw, 0o644); err != nil {
+		t.Fatalf("write test log: %v", err)
+	}
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&out)
+	if _, err := runAxiLogs(cmd, "test", dbRun.ID, true); err != nil {
+		t.Fatalf("axi logs --full: %v\n%s", err, out.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, `bad\\x1Fvalue`) || !strings.Contains(got, "lines: 46 total") {
+		t.Fatalf("full logs should visibly escape the control byte and retain all lines:\n%s", got)
+	}
+	if strings.ContainsRune(got, '\x1f') {
+		t.Fatalf("full logs retained the raw control byte: %q", got)
+	}
+	after, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read durable log: %v", err)
+	}
+	if !bytes.Equal(after, raw) {
+		t.Fatal("AXI rendering rewrote durable raw log evidence")
+	}
+}
+
 func TestAxiStatusIgnoresInvalidGlobalConfig(t *testing.T) {
 	repoDir := t.TempDir()
 	nmHome := t.TempDir()
@@ -756,6 +889,36 @@ func TestResolveRunPrefersCurrentBranchLatestRun(t *testing.T) {
 	if got == nil || got.ID != current.ID {
 		t.Fatalf("resolved run = %#v, want current branch run %s", got, current.ID)
 	}
+}
+
+func setupAxiQueryRepo(t *testing.T) (string, *paths.Paths, *db.DB, *db.Repo) {
+	t.Helper()
+	repoDir := t.TempDir()
+	nmHome := t.TempDir()
+	t.Setenv("NM_HOME", nmHome)
+	run(t, repoDir, "git", "init")
+	run(t, repoDir, "git", "config", "user.email", "test@test.com")
+	run(t, repoDir, "git", "config", "user.name", "Test")
+	run(t, repoDir, "git", "commit", "--allow-empty", "-m", "initial")
+	rawRoot, err := filepath.EvalSymlinks(repoDir)
+	if err != nil {
+		rawRoot = repoDir
+	}
+
+	p := paths.WithRoot(nmHome)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	database, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	repo, err := database.InsertRepoWithID("repo-1", rawRoot, "origin", "main")
+	if err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+	return rawRoot, p, database, repo
 }
 
 func openTestDB(t *testing.T) *db.DB {

--- a/internal/e2e/journey_test.go
+++ b/internal/e2e/journey_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"os"
@@ -50,6 +51,63 @@ func TestUserJourney(t *testing.T) {
 		t.Run(agentName, func(t *testing.T) {
 			runHappyPath(t, agentName)
 		})
+	}
+}
+
+func TestAXIControlByteFailureGateRemainsReadable(t *testing.T) {
+	h := NewHarness(t, SetupOpts{Agent: "claude", Scenario: cleanReviewScenario(t)})
+	out, err := h.Run("init")
+	if err != nil {
+		t.Fatalf("nm init: %v\n%s", err, out)
+	}
+
+	failingCommand := filepath.Join(h.BinDir, "nm-control-byte-test-e2e")
+	script := "#!/bin/sh\nprintf 'bad\\037value\\n'\ni=0\nwhile [ \"$i\" -lt 45 ]; do printf 'later-%02d\\n' \"$i\"; i=$((i + 1)); done\nexit 1\n"
+	if err := os.WriteFile(failingCommand, []byte(script), 0o755); err != nil {
+		t.Fatalf("write control-byte test command: %v", err)
+	}
+	config := "ignore_patterns:\n  - '*.generated.go'\n  - 'vendor/**'\ncommands:\n  test: nm-control-byte-test-e2e\n  lint: true\n"
+	h.CommitChange("control-byte-test-gate", ".no-mistakes.yaml", config, "configure control-byte test failure")
+	h.PushToGate("control-byte-test-gate")
+	run := waitForStepStatus(t, h, "control-byte-test-gate", types.StepTest, types.StepStatusAwaitingApproval, 60*time.Second)
+
+	statusOut, err := h.Run("axi", "status", "--run", run.ID)
+	if err != nil {
+		t.Fatalf("axi status should render the Test gate: %v\n%s", err, statusOut)
+	}
+	for _, want := range []string{"gate:", "step: test", "status: awaiting_approval", `bad\\x1Fvalue`} {
+		if !strings.Contains(statusOut, want) {
+			t.Fatalf("axi status missing %q in:\n%s", want, statusOut)
+		}
+	}
+	if strings.ContainsRune(statusOut, '\x1f') {
+		t.Fatalf("axi status retained raw U+001F: %q", statusOut)
+	}
+
+	logsOut, err := h.Run("axi", "logs", "--run", run.ID, "--step", "test", "--full")
+	if err != nil {
+		t.Fatalf("axi logs --full should render the raw-evidence escape: %v\n%s", err, logsOut)
+	}
+	if !strings.Contains(logsOut, `bad\\x1Fvalue`) || !strings.Contains(logsOut, "later-44") {
+		t.Fatalf("full logs should include escaped early failure and late tail:\n%s", logsOut)
+	}
+	if strings.ContainsRune(logsOut, '\x1f') {
+		t.Fatalf("full logs retained raw U+001F: %q", logsOut)
+	}
+
+	logPath := filepath.Join(h.NMHome, "logs", run.ID, "test.log")
+	rawLog, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read durable test log: %v", err)
+	}
+	if !bytes.Contains(rawLog, []byte("bad\x1fvalue")) {
+		t.Fatal("durable Test log should preserve the raw control byte")
+	}
+	for _, stepName := range []types.StepName{types.StepDocument, types.StepLint, types.StepPush} {
+		step, ok := findStep(run.Steps, stepName)
+		if !ok || step.Status != types.StepStatusPending {
+			t.Fatalf("%s should remain pending at the readable Test gate, got %+v", stepName, step)
+		}
 	}
 }
 


### PR DESCRIPTION
## Intent

Ensure every AXI surface remains readable when external status, finding, or full-log strings contain unsupported C0 control bytes. Convert only unsupported C0 controls to deterministic visible escapes at the single TOON output boundary without rewriting durable evidence; preserve tab, carriage return, newline, printable Unicode, and existing rendering semantics. Encoding failures must never produce successful empty stdout. Add unit and isolated end-to-end coverage for an awaiting Test gate and full logs containing U+001F while Document stays pending. Keep oversized default gate summaries concise through the existing truncation disclosure and full-log pointer.

## What Changed

- Escape unsupported C0 control bytes as visible `\xNN` sequences at the AXI TOON boundary while preserving supported whitespace, Unicode, and durable logs; encoding failures now return a structured error.
- Bound default gate summaries with explicit truncation disclosure and a pointer to the complete step log.
- Document the rendering behavior and add unit and isolated end-to-end coverage for control bytes in awaiting Test gates, full logs, and oversized summaries.

## Risk Assessment

✅ Low: The centralized output-boundary sanitization is well-bounded, preserves supported characters and durable evidence, provides a non-empty encoding fallback, and has focused unit and isolated end-to-end coverage.

## Testing

The supplied race-test baseline, focused AXI unit coverage, and isolated real-process e2e journey all passed; captured CLI transcripts demonstrate readable escaped U+001F output, unchanged durable evidence, a pending Document step at the Test gate, complete full logs, and concise oversized-summary truncation with its full-log pointer.

- Evidence: [AXI control-byte end-to-end transcript](https://github.com/kunchenguid/no-mistakes/blob/d9a94b23a02043eb8fc83e8def8dec0b7994332f/.no-mistakes/evidence/fm/nm-test-step-completion-hang-d1/axi-control-byte-e2e.txt)
- Evidence: [Oversized Test gate truncation transcript](https://github.com/kunchenguid/no-mistakes/blob/d9a94b23a02043eb8fc83e8def8dec0b7994332f/.no-mistakes/evidence/fm/nm-test-step-completion-hang-d1/axi-oversized-gate-e2e.txt)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`
- <code>Baseline supplied by the pipeline: `go test -race ./...`</code>
- `go test ./internal/cli -run 'Test(GateSummaryUsesBoundedDisclosure|EscapeUnsupportedTOONControlsPreservesSupportedBytesAndUnicode|AxiDocEncodingFailureIsNeverSilent|AxiStatusEscapesControlBytesInAwaitingTestGate|AxiLogsFullEscapesControlByteOutsideTailWithoutRewritingLog)$' -count=1`
- `go test -tags=e2e ./internal/e2e -run '^TestAXIControlByteFailureGateRemainsReadable$' -count=1 -v`
- `Repeated the isolated e2e journey with an evidence-only 145-line failing command to exercise the 1,200-rune gate-summary limit, truncation disclosure, and full-log pointer`
- <code>Verified the end-user AXI output contains visible `\x1F`, no raw U+001F, Test awaiting approval, and Document/Lint/Push pending</code>
- <code>Verified `axi logs --full` retained the early escaped failure through the final output line while the durable `test.log` still contained raw U+001F</code>
- <code>Confirmed the worktree matches target commit `694515a290a2d7d31c5b99ac8809e3d8642d36d7` outside the dedicated evidence directory</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
