### PR TITLE
fix: handle oversized Claude repair prompts

### DIFF
--- a/.no-mistakes/evidence/fm/nm-claude-stdin-bounds-f1/validation.md
+++ b/.no-mistakes/evidence/fm/nm-claude-stdin-bounds-f1/validation.md
@@ -1,0 +1,44 @@
+# Oversized Claude and configured-command validation
+
+Validated target: `723b7c32457f6b98db06e069fc378c3fd1b8ab49`
+
+## Direct Claude transport
+
+The focused race-enabled adapter test exercised both a cold call and a resumed session with the same prompt:
+
+```text
+prompt bytes: 2,097,188
+prompt SHA-256: cb8ec8c685522dc5c6abf9b66a7eae8775d9d9e9db6e890a9371b6060bd746d1
+stdin EOF observed: yes
+cold argv contains prompt marker: no
+resumed argv contains prompt marker: no
+resumed session flag preserved: --resume session-123
+fixed flags/schema/settings preserved: yes
+```
+
+The same focused run exercised a child that exits without reading the 2 MiB stdin payload, cancellation while stdin is blocked, and a clean-exit child with a grandchild holding inherited pipes. Every case returned within its bound, and the process-tree test verified that the grandchild did not survive.
+
+## Test and Lint through AXI
+
+The real E2E harness built and ran the product binary, pushed separate Test and Lint branches through the daemon, waited for each configured command failure to park, invoked `no-mistakes axi status`, then submitted:
+
+```text
+no-mistakes axi respond --action fix --findings test-1
+no-mistakes axi respond --action fix --findings lint-1
+```
+
+Both steps reached `fix_review`. For each 2,097,243-byte configured-command output, the checks directly observed:
+
+```text
+bounded findings: HEAD_MARKER context line ... TAIL_MARKER 最后的错误🙂
+original byte count: 2097243
+omitted byte count: 2032219
+full-log pointer: no-mistakes axi logs --step <test|lint> --full
+omitted middle marker in findings/repair prompt: no
+omitted middle marker in authoritative step log: yes
+authoritative step log size: at least 2 MiB
+AXI scanner overflow: no
+argv size failure during fix transition: no
+```
+
+No screenshot was produced because this change has no rendered UI surface. The end-user surface is the CLI and daemon pipeline, which the E2E harness exercised directly.

--- a/cmd/fakeagent/claude.go
+++ b/cmd/fakeagent/claude.go
@@ -4,11 +4,16 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 )
 
-func runClaude(args []string, scenario *Scenario) int {
-	prompt := extractClaudePrompt(args)
+func runClaude(args []string, promptReader io.Reader, scenario *Scenario) int {
+	prompt, err := extractClaudePrompt(args, promptReader)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fakeagent: claude prompt: %v\n", err)
+		return 1
+	}
 	logInvocation("claude", prompt, args)
 
 	action := scenario.Match(prompt)
@@ -205,39 +210,24 @@ func hasClaudeSchema(args []string) bool {
 	return false
 }
 
-// extractClaudePrompt scans for the value following -p, matching the real
-// claude CLI's argv shape (claude -p "<prompt>" --verbose ...). Other
-// flags carrying values are skipped explicitly so we don't accidentally
-// pick up e.g. --output-format's argument.
-func extractClaudePrompt(args []string) string {
-	flagsWithValues := map[string]bool{
-		"--output-format":    true,
-		"--json-schema":      true,
-		"--permission-mode":  true,
-		"--model":            true,
-		"-m":                 true,
-		"--max-turns":        true,
-		"--system":           true,
-		"--allowed-tools":    true,
-		"--disallowed-tools": true,
-		"--mcp-config":       true,
-		"--continue":         true,
-		"--resume":           true,
-		"--cwd":              true,
-		"--add-dir":          true,
-	}
-	for i := 0; i < len(args); i++ {
-		switch args[i] {
-		case "-p", "--print":
-			if i+1 < len(args) {
-				return args[i+1]
-			}
-			return ""
-		}
-		if flagsWithValues[args[i]] {
-			i++ // skip the value
+// extractClaudePrompt mirrors Claude Code's documented print-mode contract:
+// -p selects non-interactive mode and the text user prompt is read to EOF from
+// stdin. Keeping the e2e fake on this shape ensures prompts cannot regress into
+// process argv unnoticed.
+func extractClaudePrompt(args []string, promptReader io.Reader) (string, error) {
+	foundPrint := false
+	for _, arg := range args {
+		if arg == "-p" || arg == "--print" {
+			foundPrint = true
+			break
 		}
 	}
-	fmt.Fprintln(os.Stderr, "fakeagent: claude prompt missing (no -p found)")
-	return ""
+	if !foundPrint {
+		return "", fmt.Errorf("missing -p")
+	}
+	prompt, err := io.ReadAll(promptReader)
+	if err != nil {
+		return "", fmt.Errorf("read stdin: %w", err)
+	}
+	return string(prompt), nil
 }

--- a/cmd/fakeagent/main.go
+++ b/cmd/fakeagent/main.go
@@ -36,7 +36,7 @@ func run(argv []string) int {
 
 	switch name {
 	case "claude":
-		return runClaude(args, scenario)
+		return runClaude(args, os.Stdin, scenario)
 	case "codex":
 		return runCodex(args, scenario)
 	case "opencode":

--- a/cmd/fakeagent/scenario_test.go
+++ b/cmd/fakeagent/scenario_test.go
@@ -163,7 +163,7 @@ func TestRunClaudeFailsWhenScenarioEditReplacementMissing(t *testing.T) {
 		Edits: []Edit{{Path: "note.txt", Old: "missing", New: "after"}},
 	}}}
 
-	if code := runClaude([]string{"-p", "fix it"}, scenario); code != 1 {
+	if code := runClaude([]string{"-p"}, strings.NewReader("fix it"), scenario); code != 1 {
 		t.Fatalf("exit code = %d, want 1", code)
 	}
 

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -251,7 +251,7 @@ Use `intent.disabled_readers` to disable specific transcript sources, or set `in
 
 ## Claude
 
-Spawns a `claude` subprocess for each invocation with `--output-format stream-json`. By default it also adds `--dangerously-skip-permissions`, unless you already set your own Claude permission flag through `agent_args_override`. Reads JSONL events from stdout. Supports native structured output via `--json-schema`.
+Spawns a `claude` subprocess for each invocation with `--output-format stream-json`. The print-mode user prompt is sent as text on stdin rather than placed in the process arguments. By default it also adds `--dangerously-skip-permissions`, unless you already set your own Claude permission flag through `agent_args_override`. Reads JSONL events from stdout. Supports native structured output via `--json-schema`.
 For review-loop reuse, Claude starts a stream-json session and resumes it with `claude -p --resume <id>`.
 
 ## Codex

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -15,6 +15,7 @@ Every pipeline agent invocation is prompt-steered to keep intentional writes ins
 This is a soft boundary, not OS-level sandbox enforcement.
 The steering still allows requested test evidence under the managed temporary `no-mistakes-evidence` directory or the configured in-repo evidence directory, plus incidental temp or cache writes from normal development tools.
 Configured shell commands and one-shot agent subprocesses are scoped to their step: when the invocation exits, fails, or is cancelled, no-mistakes terminates remaining child processes it spawned so background workers do not outlive the run.
+When configured Test or Lint command output exceeds 64 KiB, the complete output remains in the authoritative step log while findings, IPC responses, and repair prompts receive a valid-UTF-8 head-and-tail projection capped at 64 KiB. The truncation marker reports the exact original and omitted byte counts and points to `no-mistakes axi logs --step <step> --full` for the complete output.
 Commits created by the shared Review, Test, Document, and Lint fix path use the configurable [`commit.fix_message`](/no-mistakes/reference/global-config/#commitfix_message) template.
 
 ## Intent

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -69,10 +69,14 @@ func (a *claudeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error
 	if opts.Session != nil {
 		resumeID = opts.Session.ID
 	}
-	args := a.buildArgs(opts.Prompt, opts.JSONSchema, resumeID)
+	args := a.buildArgs(opts.JSONSchema, resumeID)
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD
-	cmd.Stdin = nil
+	// Claude Code print mode documents text stdin as its non-interactive
+	// prompt transport. Giving os/exec an in-memory reader keeps user prompt
+	// bytes out of argv and lets Cmd own the bounded concurrent copy, including
+	// EOF, early-child-exit, cancellation, and WaitDelay cleanup paths.
+	cmd.Stdin = strings.NewReader(opts.Prompt)
 	cmd.Env = gitSafeEnv(opts.CWD)
 	shellenv.ConfigureShellCommand(cmd)
 
@@ -166,11 +170,11 @@ func finalizeClaudeResult(result *claudeResult, schema json.RawMessage, usage To
 // is not added. A non-empty resumeID continues that session via --resume
 // (never --fork-session: the session identity must stay stable so later
 // turns keep resuming the same conversation).
-func (a *claudeAgent) buildArgs(prompt string, schema json.RawMessage, resumeID string) []string {
-	args := make([]string, 0, len(a.extraArgs)+12)
+func (a *claudeAgent) buildArgs(schema json.RawMessage, resumeID string) []string {
+	args := make([]string, 0, len(a.extraArgs)+11)
 	args = append(args, a.extraArgs...)
 	args = append(args,
-		"-p", prompt,
+		"-p",
 		"--verbose",
 		"--output-format", "stream-json",
 	)

--- a/internal/agent/claude_test.go
+++ b/internal/agent/claude_test.go
@@ -3,21 +3,30 @@ package agent
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestClaudeAgent_BuildArgs(t *testing.T) {
 	ca := &claudeAgent{bin: "/usr/bin/claude"}
 	schema := json.RawMessage(`{"type":"object"}`)
-	args := ca.buildArgs("do something", schema, "")
+	args := ca.buildArgs(schema, "")
 
 	// Default (no opt-out): pristine args, no setting-sources restriction -
 	// ordinary repos keep loading project CLAUDE.md/AGENTS.md (backward-compat).
 	expected := []string{
-		"-p", "do something",
+		"-p",
 		"--verbose",
 		"--output-format", "stream-json",
 		"--json-schema", `{"type":"object"}`,
@@ -36,7 +45,7 @@ func TestClaudeAgent_BuildArgs(t *testing.T) {
 
 func TestClaudeAgent_BuildArgs_NoSchema(t *testing.T) {
 	ca := &claudeAgent{bin: "claude"}
-	args := ca.buildArgs("prompt", nil, "")
+	args := ca.buildArgs(nil, "")
 
 	// Without schema, should not include --json-schema flag
 	for _, arg := range args {
@@ -45,18 +54,18 @@ func TestClaudeAgent_BuildArgs_NoSchema(t *testing.T) {
 		}
 	}
 	// Should still have core args
-	if args[0] != "-p" || args[1] != "prompt" {
+	if args[0] != "-p" {
 		t.Error("missing -p flag")
 	}
 }
 
 func TestClaudeAgent_BuildArgs_ExtraArgsPrepended(t *testing.T) {
 	ca := &claudeAgent{bin: "claude", extraArgs: []string{"--model", "sonnet"}}
-	args := ca.buildArgs("do it", nil, "")
+	args := ca.buildArgs(nil, "")
 
 	expected := []string{
 		"--model", "sonnet",
-		"-p", "do it",
+		"-p",
 		"--verbose",
 		"--output-format", "stream-json",
 		"--dangerously-skip-permissions",
@@ -79,7 +88,7 @@ func TestClaudeAgent_BuildArgs_UserPermissionModeSuppressesDefault(t *testing.T)
 	}
 	for _, extra := range tests {
 		ca := &claudeAgent{bin: "claude", extraArgs: extra}
-		args := ca.buildArgs("p", nil, "")
+		args := ca.buildArgs(nil, "")
 
 		dangerCount := 0
 		for _, a := range args {
@@ -458,7 +467,7 @@ func TestParseClaudeEvents_ResultCapturesRawEvent(t *testing.T) {
 // does not.
 func TestClaudeAgent_BuildArgs_SuppressesProjectMemoryUnderOptOut(t *testing.T) {
 	ca := &claudeAgent{bin: "claude", disableProjectSettings: true}
-	args := ca.buildArgs("review the diff", nil, "")
+	args := ca.buildArgs(nil, "")
 	if !claudeArgsContainPair(args, "--setting-sources", "user") {
 		t.Errorf("buildArgs = %v, want a `--setting-sources user` pair", args)
 	}
@@ -469,7 +478,7 @@ func TestClaudeAgent_BuildArgs_SuppressesProjectMemoryUnderOptOut(t *testing.T) 
 // loads its project memory exactly as before.
 func TestClaudeAgent_BuildArgs_NoSuppressionWithoutOptOut(t *testing.T) {
 	ca := &claudeAgent{bin: "claude"}
-	args := ca.buildArgs("review the diff", nil, "")
+	args := ca.buildArgs(nil, "")
 	for _, a := range args {
 		if a == "--setting-sources" {
 			t.Errorf("buildArgs = %v, must not restrict setting-sources when the repo did not opt out", args)
@@ -481,10 +490,244 @@ func TestClaudeAgent_BuildArgs_NoSuppressionWithoutOptOut(t *testing.T) {
 // who pinned their own --setting-sources is not double-set even under opt-out.
 func TestClaudeAgent_BuildArgs_UserSettingSourcesOverrideWins(t *testing.T) {
 	ca := &claudeAgent{bin: "claude", disableProjectSettings: true, extraArgs: []string{"--setting-sources", "user,project"}}
-	args := ca.buildArgs("p", nil, "")
+	args := ca.buildArgs(nil, "")
 	if claudeArgsContainPair(args, "--setting-sources", "user") {
 		t.Errorf("buildArgs = %v, must not add default over a user --setting-sources", args)
 	}
+}
+
+type claudeStdinObservation struct {
+	Args   []string `json:"args"`
+	Bytes  int      `json:"bytes"`
+	SHA256 string   `json:"sha256"`
+	EOF    bool     `json:"eof"`
+}
+
+func TestClaudeAgent_LargePromptUsesExactStdinForColdAndResumedRuns(t *testing.T) {
+	marker := "CLAUDE_STDIN_SECRET_MARKER_7f9c_"
+	prompt := marker + strings.Repeat("x", 2*1024*1024) + "_END"
+	sum := sha256.Sum256([]byte(prompt))
+	wantHash := hex.EncodeToString(sum[:])
+	schema := json.RawMessage(`{"type":"object","required":["ok"]}`)
+
+	for _, tc := range []struct {
+		name      string
+		sessionID string
+	}{
+		{name: "cold"},
+		{name: "resumed", sessionID: "session-123"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			observationPath := filepath.Join(t.TempDir(), "observation.json")
+			t.Setenv("NM_CLAUDE_STDIN_HELPER", "read")
+			t.Setenv("NM_CLAUDE_STDIN_OBSERVATION", observationPath)
+			a := newClaudeStdinHelperAgent(t)
+			opts := RunOpts{Prompt: prompt, CWD: t.TempDir(), JSONSchema: schema}
+			if tc.sessionID != "" {
+				opts.Session = &SessionRef{ID: tc.sessionID}
+			}
+
+			result, err := a.runOnce(context.Background(), opts)
+			if err != nil {
+				t.Fatalf("runOnce with 2 MiB prompt: %v", err)
+			}
+			if result.SessionID != "helper-session" {
+				t.Fatalf("session ID = %q, want helper-session", result.SessionID)
+			}
+
+			data, err := os.ReadFile(observationPath)
+			if err != nil {
+				t.Fatalf("read helper observation: %v", err)
+			}
+			var got claudeStdinObservation
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatalf("parse helper observation: %v", err)
+			}
+			if got.Bytes != len(prompt) || got.SHA256 != wantHash || !got.EOF {
+				t.Fatalf("stdin observation = %+v, want bytes=%d sha256=%s EOF", got, len(prompt), wantHash)
+			}
+			for _, arg := range got.Args {
+				if strings.Contains(arg, marker) || strings.Contains(arg, prompt[len(prompt)-32:]) {
+					t.Fatalf("prompt bytes leaked into argv: arg length %d", len(arg))
+				}
+			}
+			for _, pair := range [][2]string{{"--output-format", "stream-json"}, {"--json-schema", string(schema)}, {"--setting-sources", "user"}} {
+				if !claudeArgsContainPair(got.Args, pair[0], pair[1]) {
+					t.Errorf("argv %v missing %q %q", got.Args, pair[0], pair[1])
+				}
+			}
+			for _, flag := range []string{"-p", "--verbose", "--dangerously-skip-permissions"} {
+				if !slicesContain(got.Args, flag) {
+					t.Errorf("argv %v missing %q", got.Args, flag)
+				}
+			}
+			if tc.sessionID == "" {
+				if slicesContain(got.Args, "--resume") {
+					t.Fatalf("cold argv unexpectedly contains --resume: %v", got.Args)
+				}
+			} else if !claudeArgsContainPair(got.Args, "--resume", tc.sessionID) {
+				t.Fatalf("resumed argv %v missing session ID", got.Args)
+			}
+		})
+	}
+}
+
+func TestClaudeAgent_EarlyExitWithoutReadingLargeStdinDoesNotLeakGoroutines(t *testing.T) {
+	t.Setenv("NM_CLAUDE_STDIN_HELPER", "exit-early")
+	a := newClaudeStdinHelperAgent(t)
+	prompt := strings.Repeat("e", 2*1024*1024)
+	before := runtime.NumGoroutine()
+
+	for i := 0; i < 8; i++ {
+		started := time.Now()
+		_, err := a.runOnce(context.Background(), RunOpts{Prompt: prompt, CWD: t.TempDir()})
+		if err == nil {
+			t.Fatal("early helper exit unexpectedly succeeded")
+		}
+		if time.Since(started) > 3*time.Second {
+			t.Fatalf("early helper exit took too long: %v", time.Since(started))
+		}
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for runtime.NumGoroutine() > before+2 && time.Now().Before(deadline) {
+		runtime.Gosched()
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got := runtime.NumGoroutine(); got > before+2 {
+		t.Fatalf("goroutines grew from %d to %d after early stdin exits", before, got)
+	}
+}
+
+func TestClaudeAgent_CancellationWithBlockedStdinAndInheritedPipesIsBounded(t *testing.T) {
+	for _, mode := range []string{"block", "spawn-grandchild"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Setenv("NM_CLAUDE_STDIN_HELPER", mode)
+			ready := filepath.Join(t.TempDir(), "ready")
+			t.Setenv("NM_CLAUDE_STDIN_READY", ready)
+			t.Setenv("NM_CLAUDE_STDIN_PID", filepath.Join(t.TempDir(), "grandchild.pid"))
+			a := newClaudeStdinHelperAgent(t)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			done := make(chan error, 1)
+			go func() {
+				_, err := a.runOnce(ctx, RunOpts{Prompt: strings.Repeat("p", 2*1024*1024), CWD: t.TempDir()})
+				done <- err
+			}()
+
+			waitForClaudeHelperFile(t, ready, 5*time.Second)
+			if mode == "block" {
+				cancel()
+			}
+			select {
+			case <-done:
+			case <-time.After(6 * time.Second):
+				cancel()
+				t.Fatal("Claude run did not complete after cancellation or clean leader exit")
+			}
+		})
+	}
+}
+
+func newClaudeStdinHelperAgent(t *testing.T) *claudeAgent {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("current test executable: %v", err)
+	}
+	return &claudeAgent{
+		bin:                    exe,
+		extraArgs:              []string{"-test.run=^TestClaudeStdinHelper$", "--"},
+		disableProjectSettings: true,
+	}
+}
+
+func TestClaudeStdinHelper(t *testing.T) {
+	mode := os.Getenv("NM_CLAUDE_STDIN_HELPER")
+	if mode == "" {
+		return
+	}
+	args := argsAfterDoubleDash(os.Args)
+	switch mode {
+	case "exit-early":
+		os.Exit(0)
+	case "block":
+		_ = os.WriteFile(os.Getenv("NM_CLAUDE_STDIN_READY"), []byte("ready"), 0o644)
+		for {
+			time.Sleep(time.Second)
+		}
+	case "spawn-grandchild":
+		child := exec.Command(os.Args[0], "-test.run=^TestClaudeStdinHelper$")
+		child.Env = append(os.Environ(), "NM_CLAUDE_STDIN_HELPER=grandchild")
+		child.Stdout = os.Stdout
+		child.Stderr = os.Stderr
+		if err := child.Start(); err != nil {
+			os.Exit(2)
+		}
+		_ = os.WriteFile(os.Getenv("NM_CLAUDE_STDIN_PID"), []byte(strconv.Itoa(child.Process.Pid)), 0o644)
+		_ = os.WriteFile(os.Getenv("NM_CLAUDE_STDIN_READY"), []byte("ready"), 0o644)
+		emitClaudeHelperResult()
+		return
+	case "grandchild":
+		for {
+			time.Sleep(time.Second)
+		}
+	case "read":
+		prompt, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			os.Exit(3)
+		}
+		sum := sha256.Sum256(prompt)
+		observation := claudeStdinObservation{
+			Args:   args,
+			Bytes:  len(prompt),
+			SHA256: hex.EncodeToString(sum[:]),
+			EOF:    true,
+		}
+		data, _ := json.Marshal(observation)
+		if err := os.WriteFile(os.Getenv("NM_CLAUDE_STDIN_OBSERVATION"), data, 0o644); err != nil {
+			os.Exit(4)
+		}
+		emitClaudeHelperResult()
+		return
+	default:
+		os.Exit(5)
+	}
+}
+
+func emitClaudeHelperResult() {
+	_, _ = io.WriteString(os.Stdout, `{"type":"assistant","session_id":"helper-session","message":{"model":"helper-model","usage":{"input_tokens":1,"output_tokens":1},"content":[{"type":"text","text":"ok"}]}}`+"\n")
+	_, _ = io.WriteString(os.Stdout, `{"type":"result","subtype":"success","session_id":"helper-session","structured_output":{"ok":true}}`+"\n")
+}
+
+func argsAfterDoubleDash(args []string) []string {
+	for i, arg := range args {
+		if arg == "--" {
+			return append([]string(nil), args[i+1:]...)
+		}
+	}
+	return nil
+}
+
+func waitForClaudeHelperFile(t *testing.T, path string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for helper file %s", path)
+}
+
+func slicesContain(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func claudeArgsContainPair(args []string, flag, value string) bool {

--- a/internal/agent/reap_unix_test.go
+++ b/internal/agent/reap_unix_test.go
@@ -154,6 +154,33 @@ exit 0
 	}
 }
 
+func TestClaudeAgent_LargeStdinReapsGrandchildHoldingPipesOnLeaderExit(t *testing.T) {
+	dir := t.TempDir()
+	readyFile := filepath.Join(dir, "ready")
+	pidFile := filepath.Join(dir, "grandchild.pid")
+	t.Setenv("NM_CLAUDE_STDIN_HELPER", "spawn-grandchild")
+	t.Setenv("NM_CLAUDE_STDIN_READY", readyFile)
+	t.Setenv("NM_CLAUDE_STDIN_PID", pidFile)
+
+	a := newClaudeStdinHelperAgent(t)
+	result, err := a.runOnce(context.Background(), RunOpts{
+		Prompt: strings.Repeat("p", 2*1024*1024),
+		CWD:    dir,
+	})
+	if err != nil {
+		t.Fatalf("Claude run with inherited-pipe holder: %v", err)
+	}
+	if result.Text != "ok" {
+		t.Fatalf("Claude result text = %q, want ok", result.Text)
+	}
+
+	grandchild := waitForPidFile(t, pidFile, 5*time.Second)
+	if !pidGoneWithin(grandchild, 5*time.Second) {
+		_ = syscall.Kill(grandchild, syscall.SIGKILL)
+		t.Fatalf("Claude grandchild pid %d survived clean leader exit", grandchild)
+	}
+}
+
 func TestCodexAgent_Run_ReapsGrandchildHoldingStdoutPipeOnLeaderExit(t *testing.T) {
 	dir := t.TempDir()
 	pidFile := filepath.Join(dir, "grandchild.pid")

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -36,14 +36,17 @@ func TestSupportsSessionResume_PerAdapter(t *testing.T) {
 
 func TestClaudeAgent_BuildArgs_Resume(t *testing.T) {
 	ca := &claudeAgent{bin: "claude"}
-	args := ca.buildArgs("re-review the branch", nil, "sess-1234")
+	args := ca.buildArgs(nil, "sess-1234")
 
 	joined := strings.Join(args, " ")
 	if !strings.Contains(joined, "--resume sess-1234") {
 		t.Fatalf("resume args missing --resume <id>: %v", args)
 	}
-	if !strings.Contains(joined, "-p re-review the branch") {
-		t.Fatalf("resume args must keep print-mode prompt: %v", args)
+	if !strings.Contains(joined, "-p") {
+		t.Fatalf("resume args must keep print mode: %v", args)
+	}
+	if strings.Contains(joined, "re-review the branch") {
+		t.Fatalf("resume prompt must not appear in argv: %v", args)
 	}
 	if strings.Contains(joined, "--fork-session") {
 		t.Fatalf("resume must continue the same session, not fork: %v", args)
@@ -52,7 +55,7 @@ func TestClaudeAgent_BuildArgs_Resume(t *testing.T) {
 
 func TestClaudeAgent_BuildArgs_NoResumeByDefault(t *testing.T) {
 	ca := &claudeAgent{bin: "claude"}
-	args := ca.buildArgs("review", nil, "")
+	args := ca.buildArgs(nil, "")
 	for _, a := range args {
 		if a == "--resume" {
 			t.Fatalf("cold invocation must not pass --resume: %v", args)

--- a/internal/e2e/large_configured_command_output_test.go
+++ b/internal/e2e/large_configured_command_output_test.go
@@ -1,0 +1,130 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+const largeCommandMiddleMarker = "OMITTED_SECRET_MIDDLE_MARKER_7f9c"
+
+func TestLargeConfiguredTestAndLintFailuresRemainUsableThroughAXIFix(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		step       types.StepName
+		branch     string
+		commandKey string
+		findingID  string
+	}{
+		{name: "test", step: types.StepTest, branch: "large-test-output", commandKey: "test", findingID: "test-1"},
+		{name: "lint", step: types.StepLint, branch: "large-lint-output", commandKey: "lint", findingID: "lint-1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := NewHarness(t, SetupOpts{Agent: "claude"})
+			if out, err := h.Run("init"); err != nil {
+				t.Fatalf("init: %v\n%s", err, out)
+			}
+
+			commandName := "nm-large-" + tc.name + "-failure"
+			commandPath := filepath.Join(h.BinDir, commandName)
+			script := `#!/bin/sh
+printf 'HEAD_MARKER context line\n'
+head -c 1048576 /dev/zero | tr '\000' A
+printf '` + largeCommandMiddleMarker + `'
+head -c 1048576 /dev/zero | tr '\000' B
+printf '\nTAIL_MARKER 最后的错误🙂\n'
+exit 1
+`
+			if err := os.WriteFile(commandPath, []byte(script), 0o755); err != nil {
+				t.Fatalf("write large failure command: %v", err)
+			}
+
+			config := "allow_repo_commands: true\ncommands:\n  test: true\n  lint: true\n"
+			config = strings.Replace(config, "  "+tc.commandKey+": true", "  "+tc.commandKey+": "+commandName, 1)
+			h.CommitChange(tc.branch, ".no-mistakes.yaml", config, "configure large "+tc.name+" failure")
+			h.PushToGate(tc.branch)
+			run := waitForStepStatus(t, h, tc.branch, tc.step, types.StepStatusAwaitingApproval, 60*time.Second)
+
+			step, ok := findStep(run.Steps, tc.step)
+			if !ok || step.FindingsJSON == nil {
+				t.Fatalf("%s findings missing", tc.step)
+			}
+			findings, err := types.ParseFindingsJSON(*step.FindingsJSON)
+			if err != nil {
+				t.Fatalf("parse %s findings: %v", tc.step, err)
+			}
+			wantOriginalBytes := len("HEAD_MARKER context line\n") + 2*1048576 + len(largeCommandMiddleMarker) + len("\nTAIL_MARKER 最后的错误🙂\n")
+			for _, want := range []string{
+				"HEAD_MARKER context line",
+				"TAIL_MARKER 最后的错误🙂",
+				fmt.Sprintf("original byte count: %d", wantOriginalBytes),
+				"complete output: " + strings.ToUpper(tc.name[:1]) + tc.name[1:] + " step log",
+			} {
+				if !strings.Contains(findings.Summary, want) {
+					t.Errorf("%s bounded summary missing %q", tc.step, want)
+				}
+			}
+			if strings.Contains(findings.Summary, largeCommandMiddleMarker) {
+				t.Fatalf("%s findings retained omitted middle output", tc.step)
+			}
+			if len(*step.FindingsJSON) >= 128*1024 {
+				t.Fatalf("%s findings payload is still oversized: %d bytes", tc.step, len(*step.FindingsJSON))
+			}
+
+			status, err := h.Run("axi", "status")
+			if err != nil {
+				t.Fatalf("axi status failed for bounded %s findings: %v\n%s", tc.step, err, status)
+			}
+			if strings.Contains(status, "bufio.Scanner: token too long") {
+				t.Fatalf("AXI scanner still overflowed:\n%s", status)
+			}
+
+			response, err := h.Run("axi", "respond", "--action", "fix", "--findings", tc.findingID)
+			if err != nil {
+				t.Fatalf("AXI fix response for large %s output failed: %v\n%s", tc.step, err, response)
+			}
+			if strings.Contains(response, "argument list too long") || strings.Contains(response, "bufio.Scanner: token too long") {
+				t.Fatalf("large %s fix hit an old size limit:\n%s", tc.step, response)
+			}
+			fixed := waitForStepStatus(t, h, tc.branch, tc.step, types.StepStatusFixReview, 60*time.Second)
+			if fixed.Status != types.RunRunning {
+				t.Fatalf("run status after %s fix = %s", tc.step, fixed.Status)
+			}
+
+			logData := readStepLog(t, h, run.ID, string(tc.step))
+			for _, want := range []string{"HEAD_MARKER context line", largeCommandMiddleMarker, "TAIL_MARKER 最后的错误🙂"} {
+				if !strings.Contains(logData, want) {
+					t.Errorf("full %s log missing %q", tc.step, want)
+				}
+			}
+			if len(logData) < 2*1024*1024 {
+				t.Fatalf("full %s log was truncated to %d bytes", tc.step, len(logData))
+			}
+
+			var repairPrompt string
+			for _, invocation := range h.AgentInvocations() {
+				if strings.Contains(invocation.Prompt, "Previous "+tc.name+" findings to address") {
+					repairPrompt = invocation.Prompt
+				}
+			}
+			if repairPrompt == "" {
+				t.Fatalf("no %s repair prompt recorded", tc.step)
+			}
+			for _, want := range []string{"HEAD_MARKER context line", "TAIL_MARKER 最后的错误🙂", fmt.Sprintf("--step %s --full", tc.name)} {
+				if !strings.Contains(repairPrompt, want) {
+					t.Errorf("%s repair prompt missing %q", tc.step, want)
+				}
+			}
+			if strings.Contains(repairPrompt, largeCommandMiddleMarker) {
+				t.Fatalf("%s repair prompt retained omitted middle output", tc.step)
+			}
+		})
+	}
+}

--- a/internal/pipeline/steps/command_failure_output.go
+++ b/internal/pipeline/steps/command_failure_output.go
@@ -1,0 +1,94 @@
+package steps
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// configuredCommandFailureSummaryMaxBytes is the fixed upper bound for the
+// Test/Lint command-output projection that may enter findings, persisted round
+// data, IPC, and repair prompts. 64 KiB leaves ample room below IPC's 1 MiB
+// message ceiling for findings metadata and the rest of an AXI response. It is
+// deliberately independent of host argv limits. The complete output remains in
+// the authoritative step log.
+const configuredCommandFailureSummaryMaxBytes = 64 * 1024
+
+const configuredCommandFailureMarkerReserve = 512
+const configuredCommandFailureLineSearchBytes = 4 * 1024
+
+func configuredCommandFailureSummary(output string, step types.StepName) string {
+	if len(output) <= configuredCommandFailureSummaryMaxBytes {
+		return strings.ToValidUTF8(output, "?")
+	}
+
+	contentBudget := configuredCommandFailureSummaryMaxBytes - configuredCommandFailureMarkerReserve
+	headEnd := utf8SafePrefixEnd(output, contentBudget/2)
+	tailStart := utf8SafeTailStart(output, len(output)-(contentBudget-contentBudget/2))
+	if tailStart < headEnd {
+		tailStart = headEnd
+	}
+
+	head := strings.ToValidUTF8(output[:headEnd], "?")
+	tail := strings.ToValidUTF8(output[tailStart:], "?")
+	omitted := tailStart - headEnd
+	stepLabel := configuredCommandStepLabel(step)
+	marker := fmt.Sprintf(
+		"\n\n[configured %s output truncated: original byte count: %d; omitted byte count: %d; complete output: %s step log (`no-mistakes axi logs --step %s --full`)]\n\n",
+		stepLabel,
+		len(output),
+		omitted,
+		stepLabel,
+		step,
+	)
+	return head + marker + tail
+}
+
+func configuredCommandStepLabel(step types.StepName) string {
+	switch step {
+	case types.StepTest:
+		return "Test"
+	case types.StepLint:
+		return "Lint"
+	default:
+		return string(step)
+	}
+}
+
+func utf8SafePrefixEnd(output string, target int) int {
+	if target >= len(output) {
+		return len(output)
+	}
+	end := target
+	for end > 0 && !utf8.RuneStart(output[end]) {
+		end--
+	}
+	searchStart := end - configuredCommandFailureLineSearchBytes
+	if searchStart < 0 {
+		searchStart = 0
+	}
+	if newline := strings.LastIndexByte(output[searchStart:end], '\n'); newline >= 0 {
+		return searchStart + newline + 1
+	}
+	return end
+}
+
+func utf8SafeTailStart(output string, target int) int {
+	if target <= 0 {
+		return 0
+	}
+	start := target
+	for start < len(output) && !utf8.RuneStart(output[start]) {
+		start++
+	}
+	searchEnd := start + configuredCommandFailureLineSearchBytes
+	if searchEnd > len(output) {
+		searchEnd = len(output)
+	}
+	if newline := strings.IndexByte(output[start:searchEnd], '\n'); newline >= 0 {
+		return start + newline + 1
+	}
+	return start
+}

--- a/internal/pipeline/steps/command_failure_output.go
+++ b/internal/pipeline/steps/command_failure_output.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
@@ -18,6 +19,17 @@ const configuredCommandFailureSummaryMaxBytes = 64 * 1024
 
 const configuredCommandFailureMarkerReserve = 512
 const configuredCommandFailureLineSearchBytes = 4 * 1024
+
+func logConfiguredCommandOutput(sctx *pipeline.StepContext, output string, step types.StepName) string {
+	projection := configuredCommandFailureSummary(output, step)
+	if projection == output {
+		sctx.Log(output)
+		return projection
+	}
+	sctx.LogFile(output)
+	sctx.Log(projection)
+	return projection
+}
 
 func configuredCommandFailureSummary(output string, step types.StepName) string {
 	if len(output) <= configuredCommandFailureSummaryMaxBytes {

--- a/internal/pipeline/steps/command_failure_output_test.go
+++ b/internal/pipeline/steps/command_failure_output_test.go
@@ -7,8 +7,46 @@ import (
 	"testing"
 	"unicode/utf8"
 
+	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
+
+func TestLogConfiguredCommandOutputKeepsFullFileLogAndBoundsIPC(t *testing.T) {
+	for _, step := range []types.StepName{types.StepTest, types.StepLint} {
+		t.Run(string(step), func(t *testing.T) {
+			middle := "IPC_MUST_OMIT_THIS_MIDDLE"
+			output := "HEAD\n" + strings.Repeat("a", configuredCommandFailureSummaryMaxBytes) + middle + strings.Repeat("b", configuredCommandFailureSummaryMaxBytes) + "\nTAIL🙂\n"
+			var fileLog strings.Builder
+			var ipcPayloads []string
+			sctx := &pipeline.StepContext{
+				Log: func(text string) {
+					ipcPayloads = append(ipcPayloads, text)
+					fileLog.WriteString(text)
+				},
+				LogFile: func(text string) {
+					fileLog.WriteString(text)
+				},
+			}
+
+			projection := logConfiguredCommandOutput(sctx, output, step)
+			if len(ipcPayloads) != 1 {
+				t.Fatalf("IPC payload count = %d, want 1", len(ipcPayloads))
+			}
+			if ipcPayloads[0] != projection {
+				t.Fatal("IPC payload differs from findings projection")
+			}
+			if len(ipcPayloads[0]) > configuredCommandFailureSummaryMaxBytes {
+				t.Fatalf("IPC payload has %d bytes, cap is %d", len(ipcPayloads[0]), configuredCommandFailureSummaryMaxBytes)
+			}
+			if strings.Contains(ipcPayloads[0], middle) {
+				t.Fatal("IPC payload contains omitted middle output")
+			}
+			if !strings.Contains(fileLog.String(), output) {
+				t.Fatal("file-backed step log does not contain complete output")
+			}
+		})
+	}
+}
 
 func TestConfiguredCommandFailureSummaryBoundsHeadTailAndUTF8(t *testing.T) {
 	head := "HEAD_MARKER context before failure\n"

--- a/internal/pipeline/steps/command_failure_output_test.go
+++ b/internal/pipeline/steps/command_failure_output_test.go
@@ -1,0 +1,84 @@
+package steps
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+func TestConfiguredCommandFailureSummaryBoundsHeadTailAndUTF8(t *testing.T) {
+	head := "HEAD_MARKER context before failure\n"
+	tail := "\nTAIL_MARKER 最后的错误🙂\n"
+	output := head + strings.Repeat("middle diagnostic line αβγ\n", 10000) + tail
+
+	got := configuredCommandFailureSummary(output, types.StepTest)
+	if len(got) > configuredCommandFailureSummaryMaxBytes {
+		t.Fatalf("summary has %d bytes, cap is %d", len(got), configuredCommandFailureSummaryMaxBytes)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatal("summary is not valid UTF-8")
+	}
+	for _, want := range []string{
+		"HEAD_MARKER context before failure",
+		"TAIL_MARKER 最后的错误🙂",
+		fmt.Sprintf("original byte count: %d", len(output)),
+		"complete output: Test step log",
+		"no-mistakes axi logs --step test --full",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("summary missing %q", want)
+		}
+	}
+
+	omitted := parseOmittedByteCount(t, got)
+	markerStart := strings.Index(got, "\n\n[configured Test output truncated:")
+	markerEnd := strings.Index(got, "]\n\n")
+	if markerStart < 0 || markerEnd < 0 {
+		t.Fatalf("truncation marker missing from summary")
+	}
+	retainedBytes := markerStart + len(got[markerEnd+3:])
+	if omitted != len(output)-retainedBytes {
+		t.Fatalf("omitted byte count = %d, want exact %d", omitted, len(output)-retainedBytes)
+	}
+}
+
+func TestConfiguredCommandFailureSummaryUsesLintLogAndLeavesSmallOutputIntact(t *testing.T) {
+	small := "lint failed at file.go:10\n"
+	if got := configuredCommandFailureSummary(small, types.StepLint); got != small {
+		t.Fatalf("small output changed: %q", got)
+	}
+
+	large := "LINT_HEAD\n" + strings.Repeat("x\n", configuredCommandFailureSummaryMaxBytes) + "LINT_TAIL\n"
+	got := configuredCommandFailureSummary(large, types.StepLint)
+	for _, want := range []string{"LINT_HEAD", "LINT_TAIL", "complete output: Lint step log", "--step lint --full"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("lint summary missing %q", want)
+		}
+	}
+	if len(got) > configuredCommandFailureSummaryMaxBytes {
+		t.Fatalf("lint summary has %d bytes, cap is %d", len(got), configuredCommandFailureSummaryMaxBytes)
+	}
+}
+
+func parseOmittedByteCount(t *testing.T, summary string) int {
+	t.Helper()
+	const prefix = "omitted byte count: "
+	start := strings.Index(summary, prefix)
+	if start < 0 {
+		t.Fatal("summary has no omitted byte count")
+	}
+	start += len(prefix)
+	end := start
+	for end < len(summary) && summary[end] >= '0' && summary[end] <= '9' {
+		end++
+	}
+	value, err := strconv.Atoi(summary[start:end])
+	if err != nil {
+		t.Fatalf("parse omitted byte count: %v", err)
+	}
+	return value
+}

--- a/internal/pipeline/steps/lint.go
+++ b/internal/pipeline/steps/lint.go
@@ -163,7 +163,7 @@ Previous lint findings to address:
 				Severity:    "warning",
 				Description: fmt.Sprintf("linter found issues (exit code %d)", exitCode),
 			}},
-			Summary: output,
+			Summary: configuredCommandFailureSummary(output, types.StepLint),
 		}
 		findingsJSON, _ := json.Marshal(findings)
 		return &pipeline.StepOutcome{

--- a/internal/pipeline/steps/lint.go
+++ b/internal/pipeline/steps/lint.go
@@ -155,7 +155,7 @@ Previous lint findings to address:
 		return nil, fmt.Errorf("run lint command: %w", err)
 	}
 
-	sctx.Log(output)
+	projectedOutput := logConfiguredCommandOutput(sctx, output, types.StepLint)
 
 	if exitCode != 0 {
 		findings := Findings{
@@ -163,7 +163,7 @@ Previous lint findings to address:
 				Severity:    "warning",
 				Description: fmt.Sprintf("linter found issues (exit code %d)", exitCode),
 			}},
-			Summary: configuredCommandFailureSummary(output, types.StepLint),
+			Summary: projectedOutput,
 		}
 		findingsJSON, _ := json.Marshal(findings)
 		return &pipeline.StepOutcome{

--- a/internal/pipeline/steps/test.go
+++ b/internal/pipeline/steps/test.go
@@ -92,7 +92,7 @@ Previous test findings to address:
 		}
 		tested = append(tested, testCmd)
 
-		sctx.Log(output)
+		projectedOutput := logConfiguredCommandOutput(sctx, output, types.StepTest)
 
 		if exitCode != 0 {
 			findings := Findings{
@@ -100,7 +100,7 @@ Previous test findings to address:
 					Severity:    "error",
 					Description: fmt.Sprintf("tests failed with exit code %d", exitCode),
 				}},
-				Summary: configuredCommandFailureSummary(output, types.StepTest),
+				Summary: projectedOutput,
 				Tested:  tested,
 			}
 			findingsJSON, _ := json.Marshal(findings)

--- a/internal/pipeline/steps/test.go
+++ b/internal/pipeline/steps/test.go
@@ -100,7 +100,7 @@ Previous test findings to address:
 					Severity:    "error",
 					Description: fmt.Sprintf("tests failed with exit code %d", exitCode),
 				}},
-				Summary: output,
+				Summary: configuredCommandFailureSummary(output, types.StepTest),
 				Tested:  tested,
 			}
 			findingsJSON, _ := json.Marshal(findings)


### PR DESCRIPTION
## Intent

Ship the confirmed fix for oversized direct-Claude Test and Lint repair prompts. Move only the direct Claude adapter user prompt from argv to Claude Code documented text stdin while preserving all fixed flags, schema, permission/settings behavior, session resume, concurrent stream draining, cancellation, wait-delay, and process-tree cleanup without shells or temporary files. Independently retain complete configured Test/Lint command output in the authoritative step log while projecting a deterministic fixed-cap valid-UTF-8 head and tail, with exact original and omitted byte counts and a full-log pointer, before findings persistence, IPC, and repair prompts. Cover cold and resumed 2 MiB Claude prompts, exact stdin bytes/hash/EOF and argv secrecy, early exit/cancellation/process cleanup, and real 2 MiB Test and Lint fix transitions through AXI. Keep other agent transports unchanged and treat Codex/ACP/Copilot migrations only as future contract-specific follow-ups.

## What Changed

- Send direct Claude print-mode prompts through text stdin for cold and resumed sessions, keeping prompt contents out of process arguments while preserving existing flags, streaming, cancellation, and process cleanup.
- Keep complete configured Test and Lint output in step logs while sending a deterministic, valid-UTF-8 64 KiB head-and-tail projection to IPC, findings, and repair prompts, including exact byte counts and a full-log pointer.
- Add regression coverage for 2 MiB Claude prompts, early exit and cancellation cleanup, output projection, and end-to-end Test and Lint repair transitions; document the updated transport and truncation behavior.

## Risk Assessment

✅ Low: The follow-up correctly keeps complete Test and Lint command output in the file-only log while sending the same bounded UTF-8 projection to IPC, findings persistence, and repair prompts; the remaining Claude transport changes are narrow and preserve the reviewed adapter contracts.

## Testing

The successful race baseline was supplemented by focused 2 MiB cold/resumed Claude stdin, cancellation and process-cleanup tests, bounded UTF-8 projection tests, and real Test/Lint AXI fix transitions. Both CLI journeys reached fix review while preserving full step logs and bounded repair context. Reviewer-visible CLI evidence is recorded in `validation.md`; no screenshot was applicable because there is no rendered UI.

- Evidence: [Oversized Claude and AXI validation report](https://github.com/kunchenguid/no-mistakes/blob/31304c10e7a507cf8c09eb631191ba665a2a7f85/.no-mistakes/evidence/fm/nm-claude-stdin-bounds-f1/validation.md)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `internal/pipeline/steps/test.go:103` - The required criterion says the bounded projection must occur &#34;before findings persistence, IPC, and repair prompts,&#34; but the full output is first passed to `sctx.Log(output)` at line 95, which emits an IPC `log_chunk`; this new summary call therefore bounds findings and repair prompts only. Write the complete output through the file-only logger and emit only the bounded projection to the user-visible logger. The analogous Lint path has the same issue.

🔧 Fix: Bound Test and Lint output before IPC
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`
- <code>Baseline previously passed: `go test -race ./...`</code>
- `go test -race -count=1 ./internal/agent -run 'TestClaudeAgent_(LargePromptUsesExactStdinForColdAndResumedRuns|EarlyExitWithoutReadingLargeStdinDoesNotLeakGoroutines|CancellationWithBlockedStdinAndInheritedPipesIsBounded|LargeStdinReapsGrandchildHoldingPipesOnLeaderExit)$'`
- `go test -race -count=1 ./internal/pipeline/steps -run 'Test(ConfiguredCommandFailureSummary|LogConfiguredCommandOutput)'`
- `go test -tags=e2e -count=1 -timeout 180s ./internal/e2e -run '^TestLargeConfiguredTestAndLintFailuresRemainUsableThroughAXIFix$' -v`
- `Verified the evidence directory contains only the intentional validation report and that no transient build or test artifacts remain in the worktree.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
