### PR TITLE
refactor(scm): centralize PR identity selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ Safest local verification sequence after non-trivial changes:
 
 **`gh` PR-Targeting From the Bare Gate Repo (`internal/scm/github`)**
 
-- The daemon runs `gh` from the detached bare gate repo whose HEAD is the default branch, so every PR-targeting command must name the exact PR explicitly: an empty positional makes `gh pr <verb>` infer the cwd branch (`main`) and return `no pull requests found for branch main` even when the feature PR's checks are green. `GetChecks`, `GetPRState`, `GetMergeableState`, and `UpdatePR` route through the shared `prSelector` (number, else URL, else fail closed) — never append a bare `pr.Number`/`pr.URL` that can be empty. This is the `gh` analogue of the git bare-gate-repo trap above.
+- The daemon runs `gh` from the detached bare gate repo whose HEAD is the default branch, so every PR-targeting command must name the exact PR explicitly: an empty positional makes `gh pr <verb>` infer the cwd branch (`main`) and return `no pull requests found for branch main` even when the feature PR's checks are green. `GetChecks`, `GetPRState`, `GetMergeableState`, and `UpdatePR` route through `scm.PRSelector` (number, else URL, else fail closed) — never append a bare `pr.Number`/`pr.URL` that can be empty. This is the `gh` analogue of the git bare-gate-repo trap above.
 - Regressions: `TestGetChecksTargetsKnownPRByURLWhenNumberMissing`, `TestPRTargetingReadsFailClosedWithoutIdentity`, `TestPRStateAndMergeableTargetKnownPRByURL`, `TestUpdatePRTargetsKnownPRByURLWhenNumberMissing`, `TestUpdatePRFailsClosedWithoutIdentity`.
 
 **Post-Receive Hook Gate Path Resolution (`internal/git/hook.go`)**

--- a/internal/bitbucket/host.go
+++ b/internal/bitbucket/host.go
@@ -57,9 +57,9 @@ func (h *Host) CreatePR(ctx context.Context, branch, base string, content scm.PR
 }
 
 func (h *Host) UpdatePR(ctx context.Context, pr *scm.PR, content scm.PRContent) (*scm.PR, error) {
-	id, err := strconv.Atoi(pr.Number)
+	id, err := bitbucketPRID(pr)
 	if err != nil {
-		return nil, fmt.Errorf("invalid Bitbucket PR number %q: %w", pr.Number, err)
+		return nil, err
 	}
 	updated, err := h.client.UpdatePR(ctx, h.repo, id, content.Title, content.Body)
 	if err != nil {
@@ -69,7 +69,7 @@ func (h *Host) UpdatePR(ctx context.Context, pr *scm.PR, content scm.PRContent) 
 }
 
 func (h *Host) GetPRState(ctx context.Context, pr *scm.PR) (scm.PRState, error) {
-	id, err := strconv.Atoi(pr.Number)
+	id, err := bitbucketPRID(pr)
 	if err != nil {
 		return "", err
 	}
@@ -84,7 +84,7 @@ func (h *Host) GetPRState(ctx context.Context, pr *scm.PR) (scm.PRState, error) 
 }
 
 func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
-	id, err := strconv.Atoi(pr.Number)
+	id, err := bitbucketPRID(pr)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func (h *Host) FetchFailedCheckLogs(ctx context.Context, pr *scm.PR, _ string, h
 	if h.client == nil {
 		return "", nil
 	}
-	id, err := strconv.Atoi(pr.Number)
+	id, err := bitbucketPRID(pr)
 	if err != nil {
 		return "", err
 	}
@@ -152,6 +152,18 @@ func (h *Host) FetchFailedCheckLogs(ctx context.Context, pr *scm.PR, _ string, h
 		}
 	}
 	return "", nil
+}
+
+func bitbucketPRID(pr *scm.PR) (int, error) {
+	number, err := scm.PRNumber(pr)
+	if err != nil {
+		return 0, err
+	}
+	id, err := strconv.Atoi(number)
+	if err != nil {
+		return 0, fmt.Errorf("invalid Bitbucket PR number %q: %w", number, err)
+	}
+	return id, nil
 }
 
 func (h *Host) toPR(pr *PullRequest) *scm.PR {

--- a/internal/scm/azuredevops/azuredevops.go
+++ b/internal/scm/azuredevops/azuredevops.go
@@ -294,16 +294,8 @@ func (h *Host) showPR(ctx context.Context, pr *scm.PR) (*azPR, error) {
 }
 
 func (h *Host) prID(pr *scm.PR) string {
-	if pr == nil {
-		return ""
-	}
-	if id := strings.TrimSpace(pr.Number); id != "" {
-		return id
-	}
-	if num, err := scm.ExtractPRNumber(pr.URL); err == nil {
-		return num
-	}
-	return ""
+	id, _ := scm.PRNumber(pr)
+	return id
 }
 
 func (h *Host) toPR(raw *azPR) *scm.PR {

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -120,26 +120,6 @@ func (h *Host) repoArgs() []string {
 	return []string{"--repo", h.repo}
 }
 
-// prSelector returns the explicit gh PR selector for pr, preferring the numeric
-// PR number and falling back to the canonical PR URL; both name the exact pull
-// request to gh regardless of the process working directory. It fails closed
-// when neither is known: an empty positional makes `gh pr <verb>` fall back to
-// resolving the current branch of the cwd, and the daemon runs from a detached
-// bare gate repo whose HEAD is the default branch (main), so an inferred
-// selector silently targets the wrong PR (or none — "no pull requests found for
-// branch main") instead of the feature PR the pipeline already knows.
-func prSelector(pr *scm.PR) (string, error) {
-	if pr != nil {
-		if n := strings.TrimSpace(pr.Number); n != "" {
-			return n, nil
-		}
-		if u := strings.TrimSpace(pr.URL); u != "" {
-			return u, nil
-		}
-	}
-	return "", errors.New("no PR number or URL known; refusing to run gh with a cwd-inferred branch")
-}
-
 func (h *Host) headRef(branch string) string {
 	if h.forkOwner == "" {
 		return branch
@@ -262,7 +242,7 @@ func (h *Host) CreatePR(ctx context.Context, branch, base string, content scm.PR
 }
 
 func (h *Host) UpdatePR(ctx context.Context, pr *scm.PR, content scm.PRContent) (*scm.PR, error) {
-	selector, err := prSelector(pr)
+	selector, err := scm.PRSelector(pr)
 	if err != nil {
 		return nil, err
 	}
@@ -277,7 +257,7 @@ func (h *Host) UpdatePR(ctx context.Context, pr *scm.PR, content scm.PRContent) 
 }
 
 func (h *Host) GetPRState(ctx context.Context, pr *scm.PR) (scm.PRState, error) {
-	selector, err := prSelector(pr)
+	selector, err := scm.PRSelector(pr)
 	if err != nil {
 		return "", err
 	}
@@ -292,7 +272,7 @@ func (h *Host) GetPRState(ctx context.Context, pr *scm.PR) (scm.PRState, error) 
 }
 
 func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
-	selector, err := prSelector(pr)
+	selector, err := scm.PRSelector(pr)
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +309,7 @@ func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
 }
 
 func (h *Host) GetMergeableState(ctx context.Context, pr *scm.PR) (scm.MergeableState, error) {
-	selector, err := prSelector(pr)
+	selector, err := scm.PRSelector(pr)
 	if err != nil {
 		return "", err
 	}

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -211,14 +211,9 @@ func (h *Host) CreatePR(ctx context.Context, branch, base string, content scm.PR
 }
 
 func (h *Host) UpdatePR(ctx context.Context, pr *scm.PR, content scm.PRContent) (*scm.PR, error) {
-	id := pr.Number
-	if id == "" && pr != nil {
-		if num, err := scm.ExtractPRNumber(pr.URL); err == nil {
-			id = num
-		}
-	}
-	if id == "" && pr != nil {
-		id = pr.URL
+	id, err := scm.PRNumber(pr)
+	if err != nil {
+		return nil, err
 	}
 	cmd := h.cmd(ctx, "glab", "mr", "update", id,
 		"--title", content.Title,
@@ -232,7 +227,11 @@ func (h *Host) UpdatePR(ctx context.Context, pr *scm.PR, content scm.PRContent) 
 }
 
 func (h *Host) GetPRState(ctx context.Context, pr *scm.PR) (scm.PRState, error) {
-	mr, err := h.viewMR(ctx, pr.Number)
+	id, err := scm.PRNumber(pr)
+	if err != nil {
+		return "", err
+	}
+	mr, err := h.viewMR(ctx, id)
 	if err != nil {
 		return "", err
 	}
@@ -240,7 +239,11 @@ func (h *Host) GetPRState(ctx context.Context, pr *scm.PR) (scm.PRState, error) 
 }
 
 func (h *Host) GetMergeableState(ctx context.Context, pr *scm.PR) (scm.MergeableState, error) {
-	mr, err := h.viewMR(ctx, pr.Number)
+	id, err := scm.PRNumber(pr)
+	if err != nil {
+		return "", err
+	}
+	mr, err := h.viewMR(ctx, id)
 	if err != nil {
 		return "", err
 	}
@@ -278,15 +281,19 @@ func (h *Host) viewMR(ctx context.Context, id string) (mrPayload, error) {
 }
 
 func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
+	id, err := scm.PRNumber(pr)
+	if err != nil {
+		return nil, err
+	}
 	// glab ci status --mr <id> --output json lists jobs for the MR's latest pipeline.
 	// Not all glab versions support --mr; fall back to listing pipelines by branch via view.
-	cmd := h.cmd(ctx, "glab", "ci", "status", "--mr", pr.Number, "--output", "json")
+	cmd := h.cmd(ctx, "glab", "ci", "status", "--mr", id, "--output", "json")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		if !isUnsupportedMRFlagError(out) {
 			return nil, fmt.Errorf("glab ci status: %s: %w", strings.TrimSpace(string(out)), err)
 		}
-		return h.getChecksFallback(ctx, pr)
+		return h.getChecksFallback(ctx, id)
 	}
 	return parseGitlabJobs(out)
 }
@@ -315,9 +322,9 @@ func isUnsupportedMRFlagError(out []byte) bool {
 	return false
 }
 
-func (h *Host) getChecksFallback(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
+func (h *Host) getChecksFallback(ctx context.Context, id string) ([]scm.Check, error) {
 	// Try fetching the MR's pipeline and listing its jobs.
-	cmd := h.cmd(ctx, "glab", "mr", "view", pr.Number, "--output", "json")
+	cmd := h.cmd(ctx, "glab", "mr", "view", id, "--output", "json")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("glab mr view: %s: %w", strings.TrimSpace(string(out)), err)
@@ -349,8 +356,12 @@ func (h *Host) FetchFailedCheckLogs(ctx context.Context, pr *scm.PR, _ string, _
 	if len(failingNames) == 0 {
 		return "", nil
 	}
+	id, err := scm.PRNumber(pr)
+	if err != nil {
+		return "", err
+	}
 	// Get the MR's pipeline jobs, find a failed one whose name matches, trace it.
-	viewCmd := h.cmd(ctx, "glab", "mr", "view", pr.Number, "--output", "json")
+	viewCmd := h.cmd(ctx, "glab", "mr", "view", id, "--output", "json")
 	viewOut, err := viewCmd.CombinedOutput()
 	if err != nil {
 		return "", nil

--- a/internal/scm/gitlab/gitlab_test.go
+++ b/internal/scm/gitlab/gitlab_test.go
@@ -83,6 +83,61 @@ func TestGetMergeableStateTreatsBlockedStatusesAsResolved(t *testing.T) {
 	}
 }
 
+func TestPRTargetingFailsClosedWithoutIdentity(t *testing.T) {
+	t.Parallel()
+
+	host := New(failIfGitLabCommandRuns(t), nil, "", "")
+	ctx := context.Background()
+	pr := &scm.PR{}
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "update",
+			run: func() error {
+				_, err := host.UpdatePR(ctx, pr, scm.PRContent{})
+				return err
+			},
+		},
+		{
+			name: "state",
+			run: func() error {
+				_, err := host.GetPRState(ctx, pr)
+				return err
+			},
+		},
+		{
+			name: "checks",
+			run: func() error {
+				_, err := host.GetChecks(ctx, pr)
+				return err
+			},
+		},
+		{
+			name: "mergeable state",
+			run: func() error {
+				_, err := host.GetMergeableState(ctx, pr)
+				return err
+			},
+		},
+		{
+			name: "failed logs",
+			run: func() error {
+				_, err := host.FetchFailedCheckLogs(ctx, pr, "", "", []string{"build"})
+				return err
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.run(); err == nil {
+				t.Fatal("expected missing PR identity error")
+			}
+		})
+	}
+}
+
 func TestGetChecksFallbackParsesMRJSONAfterPreamble(t *testing.T) {
 	t.Parallel()
 
@@ -95,7 +150,7 @@ func TestGetChecksFallbackParsesMRJSONAfterPreamble(t *testing.T) {
 		},
 	}), nil, "", "")
 
-	checks, err := host.getChecksFallback(context.Background(), &scm.PR{Number: "123"})
+	checks, err := host.getChecksFallback(context.Background(), "123")
 	if err != nil {
 		t.Fatalf("getChecksFallback() error = %v", err)
 	}
@@ -312,7 +367,7 @@ func TestGetChecksFallbackRequestsJobDetails(t *testing.T) {
 		},
 	}), nil, "", "")
 
-	checks, err := host.getChecksFallback(context.Background(), &scm.PR{Number: "123"})
+	checks, err := host.getChecksFallback(context.Background(), "123")
 	if err != nil {
 		t.Fatalf("getChecksFallback() error = %v", err)
 	}
@@ -599,6 +654,14 @@ type gitlabTestResponse struct {
 	stdout string
 	stderr string
 	code   int
+}
+
+func failIfGitLabCommandRuns(t *testing.T) CmdFactory {
+	t.Helper()
+	return func(_ context.Context, name string, args ...string) *exec.Cmd {
+		t.Fatalf("glab should not run without a known PR identity; got: %s %s", name, strings.Join(args, " "))
+		return nil
+	}
 }
 
 func gitlabTestCmdFactory(responses map[string]gitlabTestResponse) CmdFactory {

--- a/internal/scm/gitlab/gitlab_test.go
+++ b/internal/scm/gitlab/gitlab_test.go
@@ -138,6 +138,15 @@ func TestPRTargetingFailsClosedWithoutIdentity(t *testing.T) {
 	}
 }
 
+func TestPRTargetingRejectsInvalidNumberBeforeStartingGlab(t *testing.T) {
+	t.Parallel()
+
+	host := New(failIfGitLabCommandRuns(t), nil, "", "")
+	if _, err := host.UpdatePR(context.Background(), &scm.PR{Number: "--help"}, scm.PRContent{}); err == nil {
+		t.Fatal("UpdatePR() error = nil, want invalid PR number error")
+	}
+}
+
 func TestGetChecksFallbackParsesMRJSONAfterPreamble(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scm/host.go
+++ b/internal/scm/host.go
@@ -91,6 +91,37 @@ type PR struct {
 	URL    string
 }
 
+// PRSelector returns an explicit provider selector for a known PR.
+// It prefers the numeric identifier. It falls back to the canonical URL.
+// It rejects missing identity so providers never infer a PR from their cwd.
+func PRSelector(pr *PR) (string, error) {
+	if pr != nil {
+		if number := strings.TrimSpace(pr.Number); number != "" {
+			return number, nil
+		}
+		if url := strings.TrimSpace(pr.URL); url != "" {
+			return url, nil
+		}
+	}
+	return "", errors.New("no PR number or URL known")
+}
+
+// PRNumber returns a numeric provider identifier for a known PR.
+// It reads the number first. It extracts the trailing number from the URL.
+func PRNumber(pr *PR) (string, error) {
+	if pr != nil {
+		if number := strings.TrimSpace(pr.Number); number != "" {
+			return number, nil
+		}
+		if url := strings.TrimSpace(pr.URL); url != "" {
+			if number, err := ExtractPRNumber(url); err == nil {
+				return number, nil
+			}
+		}
+	}
+	return "", errors.New("no numeric PR identity known")
+}
+
 // PRContent is the title + body for creating or updating a PR.
 type PRContent struct {
 	Title string

--- a/internal/scm/host.go
+++ b/internal/scm/host.go
@@ -79,10 +79,19 @@ func ExtractPRNumber(prURL string) (string, error) {
 	if num == "" {
 		return "", fmt.Errorf("invalid PR URL: %s", prURL)
 	}
-	if _, err := strconv.Atoi(num); err != nil {
+	if _, ok := positivePRNumber(num); !ok {
 		return "", fmt.Errorf("invalid PR number %q in URL: %s", num, prURL)
 	}
 	return num, nil
+}
+
+func positivePRNumber(raw string) (string, bool) {
+	number := strings.TrimSpace(raw)
+	value, err := strconv.ParseUint(number, 10, 64)
+	if err != nil || value == 0 {
+		return "", false
+	}
+	return number, true
 }
 
 // PR identifies a pull/merge request on a provider.
@@ -110,7 +119,7 @@ func PRSelector(pr *PR) (string, error) {
 // It reads the number first. It extracts the trailing number from the URL.
 func PRNumber(pr *PR) (string, error) {
 	if pr != nil {
-		if number := strings.TrimSpace(pr.Number); number != "" {
+		if number, ok := positivePRNumber(pr.Number); ok {
 			return number, nil
 		}
 		if url := strings.TrimSpace(pr.URL); url != "" {

--- a/internal/scm/host_test.go
+++ b/internal/scm/host_test.go
@@ -82,7 +82,12 @@ func TestPRNumberUsesURLWhenNumberIsAbsent(t *testing.T) {
 	}{
 		{name: "number", pr: &PR{Number: " 123 "}, want: "123", ok: true},
 		{name: "URL", pr: &PR{URL: "https://gitlab.example.test/group/project/-/merge_requests/42"}, want: "42", ok: true},
+		{name: "invalid number falls back to URL", pr: &PR{Number: "latest", URL: "https://gitlab.example.test/group/project/-/merge_requests/42"}, want: "42", ok: true},
 		{name: "invalid URL", pr: &PR{URL: "https://example.test/pull/latest"}, ok: false},
+		{name: "negative number", pr: &PR{Number: "-1"}, ok: false},
+		{name: "zero number", pr: &PR{Number: "0"}, ok: false},
+		{name: "number suffix", pr: &PR{Number: "12x"}, ok: false},
+		{name: "option-like number", pr: &PR{Number: "--help"}, ok: false},
 		{name: "empty", pr: &PR{}, ok: false},
 		{name: "nil", pr: nil, ok: false},
 	}

--- a/internal/scm/host_test.go
+++ b/internal/scm/host_test.go
@@ -38,6 +38,73 @@ func TestExtractHost(t *testing.T) {
 	}
 }
 
+func TestPRSelectorPrefersNumberAndFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		pr   *PR
+		want string
+		ok   bool
+	}{
+		{name: "number", pr: &PR{Number: " 123 ", URL: "https://example.test/pull/456"}, want: "123", ok: true},
+		{name: "URL", pr: &PR{URL: " https://example.test/pull/123 "}, want: "https://example.test/pull/123", ok: true},
+		{name: "empty", pr: &PR{}, ok: false},
+		{name: "nil", pr: nil, ok: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := PRSelector(tt.pr)
+			if tt.ok {
+				if err != nil {
+					t.Fatalf("PRSelector() error = %v", err)
+				}
+				if got != tt.want {
+					t.Fatalf("PRSelector() = %q, want %q", got, tt.want)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("PRSelector() = %q, want error", got)
+			}
+		})
+	}
+}
+
+func TestPRNumberUsesURLWhenNumberIsAbsent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		pr   *PR
+		want string
+		ok   bool
+	}{
+		{name: "number", pr: &PR{Number: " 123 "}, want: "123", ok: true},
+		{name: "URL", pr: &PR{URL: "https://gitlab.example.test/group/project/-/merge_requests/42"}, want: "42", ok: true},
+		{name: "invalid URL", pr: &PR{URL: "https://example.test/pull/latest"}, ok: false},
+		{name: "empty", pr: &PR{}, ok: false},
+		{name: "nil", pr: nil, ok: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := PRNumber(tt.pr)
+			if tt.ok {
+				if err != nil {
+					t.Fatalf("PRNumber() error = %v", err)
+				}
+				if got != tt.want {
+					t.Fatalf("PRNumber() = %q, want %q", got, tt.want)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("PRNumber() = %q, want error", got)
+			}
+		})
+	}
+}
+
 func TestCheckBucketHelpers(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
Closes #531

## What changed

- Add shared `scm.PRSelector` and `scm.PRNumber` helpers.
- Reuse the helpers in GitHub, GitLab, Azure DevOps, and Bitbucket adapters.
- Make GitLab PR-targeting calls fail closed before `glab` runs.
- Add shared identity tests and GitLab fail-closed tests.
- Update the agent guidance to name `scm.PRSelector`.

## Why

Each adapter previously parsed PR identity independently. This could produce different behavior when only a PR URL exists or identity is missing.

## Validation

- `make lint`
- `go test -race ./...`
- `go test ./internal/scm/... ./internal/bitbucket`
- `git diff --check`