### PR TITLE
fix: read live PR body for provenance checks

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: no-mistakes-required-${{ github.event.pull_request.number }}
@@ -28,11 +29,12 @@ jobs:
     steps:
       - name: Verify no-mistakes signature in PR body
         env:
-          PR_BODY: ${{ github.event.pull_request.body }}
+          GH_TOKEN: ${{ github.token }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -eu
+          PR_BODY=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.body // ""')
           marker='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
           if printf '%s' "${PR_BODY:-}" | grep -qF -- "$marker"; then
             echo "Found no-mistakes signature in PR #${PR_NUMBER} body."

--- a/internal/pipeline/steps/ci_autofix_test.go
+++ b/internal/pipeline/steps/ci_autofix_test.go
@@ -331,6 +331,7 @@ func TestCIStep_CIAutoFixRetriesAfterChecksRerun(t *testing.T) {
 
 	pollCount := 0
 	step := &CIStep{
+		now: func() time.Time { return time.Time{} },
 		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
 			pollCount++
 			return nil
@@ -778,6 +779,7 @@ func TestCIStep_RetriesMergeConflictAfterRerun(t *testing.T) {
 	sctx.Log = func(s string) { logs = append(logs, s) }
 
 	step := &CIStep{
+		now: func() time.Time { return time.Time{} },
 		waitForNextPoll: func(ctx context.Context, interval time.Duration) error {
 			return nil
 		},

--- a/workflow_no_mistakes_required_test.go
+++ b/workflow_no_mistakes_required_test.go
@@ -53,21 +53,27 @@ func TestNoMistakesRequiredWorkflowChecksSignatureMarker(t *testing.T) {
 	}
 }
 
-// TestNoMistakesRequiredWorkflowReadsPRBodyViaEnv pins the shell-injection-safe
-// pattern: the PR body must be piped through an env var, not interpolated
-// directly into the shell script body.
-func TestNoMistakesRequiredWorkflowReadsPRBodyViaEnv(t *testing.T) {
+// TestNoMistakesRequiredWorkflowReadsCurrentPRBody pins the live lookup that
+// avoids evaluating the stale pull_request event snapshot when a fork workflow
+// waits for approval while the no-mistakes PR step updates the body.
+func TestNoMistakesRequiredWorkflowReadsCurrentPRBody(t *testing.T) {
 	data, err := os.ReadFile(".github/workflows/no-mistakes-required.yml")
 	if err != nil {
 		t.Fatalf("read workflow: %v", err)
 	}
 	content := string(data)
 
-	if !strings.Contains(content, "PR_BODY: ${{ github.event.pull_request.body }}") {
-		t.Errorf("workflow must expose PR body via the PR_BODY env var")
+	if !strings.Contains(content, "pull-requests: read") {
+		t.Errorf("workflow must grant read access for the live PR lookup")
 	}
-	if strings.Contains(content, "${{ github.event.pull_request.body }}\n          run:") {
-		t.Errorf("workflow must not interpolate PR body directly into run: script (injection risk)")
+	if !strings.Contains(content, "GH_TOKEN: ${{ github.token }}") {
+		t.Errorf("workflow must authenticate the live PR lookup")
+	}
+	if !strings.Contains(content, `gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.body // ""'`) {
+		t.Errorf("workflow must fetch the current PR body at job execution time")
+	}
+	if strings.Contains(content, "github.event.pull_request.body") {
+		t.Errorf("workflow must not rely on the potentially stale event PR body")
 	}
 }
 


### PR DESCRIPTION
## Intent

Split-out fix for a race in the Require no-mistakes provenance workflow, extracted from PR #513 so that PR stays scoped to its two pipeline fixes. The .github/workflows/no-mistakes-required.yml check previously read the PR body from the frozen GitHub event payload; a push event fires before the no-mistakes pipeline writes its signature section into the PR body, so the check evaluates a stale body and fails wrongly, and re-runs of such a workflow run reuse the stale payload forever. Observed live on PR #513 on 2026-07-18 and again on 2026-07-21. The fix reads the live PR body via the GitHub API (gh api repos/.../pulls/N --jq .body) with pull-requests read permission added, so any run or re-run evaluates the current body. workflow_no_mistakes_required_test.go is updated to pin the live-read contract. This commit was originally produced by the no-mistakes ci fix round on PR #513 (commit 538f38e) and is deliberately resubmitted as its own single-commit PR cherry-picked onto latest main. Expected pipeline behavior: push to the Blakeolson21/no-mistakes fork and open a new PR against kunchenguid/no-mistakes main.

## What Changed

- Fetch the current PR body through the authenticated GitHub API so provenance checks and reruns do not evaluate a stale event payload.
- Grant pull request read access and pin the live-body lookup contract in workflow tests.
- Stabilize CI auto-fix retry tests by using a deterministic clock.

✅ closeable

## Risk Assessment

✅ Low: The change is a small, well-bounded workflow fix that satisfies the live PR-body lookup contract without introducing material source, security, or lifecycle risk.

## Testing

<code>The successful full race baseline was supplemented with focused workflow and CI regression tests, an end-to-end re-run simulation using the exact workflow shell, and a real read-only GitHub API check showing PR #513’s current body contains the signature. This is a GitHub Actions/CLI change with no rendered UI, so transcript and API-response artifacts are the appropriate reviewer-visible evidence.&#10;✅ closeable</code>

<details>
<summary>Evidence: Frozen-event re-run workflow transcript</summary>

```text
Scenario: identical frozen event payload across initial run and re-run
Frozen event PR body: Frozen event payload: no pipeline signature yet

INITIAL RUN, live API body has no signature
LIVE API REQUEST: GET /repos/kunchenguid/no-mistakes/pulls/513 (authenticated)
::error::This PR was not raised through no-mistakes.

Contributions to this repository must be submitted via 'git push no-mistakes'.
That pipeline runs the required review/test/lint/CI steps and writes a
deterministic '## Pipeline' section into the PR body containing:

    Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

See CONTRIBUTING.md for setup and the full workflow.

PR author: contributor
Initial workflow exit: 1 (expected rejection)

RE-RUN, frozen event body is unchanged; live API body now has signature
LIVE API REQUEST: GET /repos/kunchenguid/no-mistakes/pulls/513 (authenticated)
Found no-mistakes signature in PR #513 body.
Re-run workflow exit: 0 (expected acceptance)

RESULT: the same workflow event recovers on re-run because the check uses the current API body.
```
</details>
<details>
<summary>Evidence: Live GitHub API response for PR #513</summary>

`{"has_signature":true,"number":513,"state":"open"}`

```text
{"has_signature":true,"number":513,"state":"open"}
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed (2) ✅ across 3 runs (41m55s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 tests failed with exit code 1
- `go test -race ./...`

🔧 Fix: Confirm provenance tests pass after transient timeout
1 error still open:
- 🚨 tests failed with exit code 1
- `go test -race ./...`

🔧 Fix: Stabilize CI auto-fix retry tests
✅ Re-checked - no issues remain.
- `go test -race ./...`
- <code>Baseline supplied as already successful: `go test -race ./...`</code>
- `go test . -run '^TestNoMistakesRequiredWorkflow' -count=1`
- `go test ./internal/pipeline/steps -run 'Test(NoMistakesRequiredWorkflowChecksPipelineSignature|CIStep_CIAutoFixRetriesAfterChecksRerun|CIStep_RetriesMergeConflictAfterRerun)$' -count=1`
- <code>Extracted and executed the workflow’s actual `run:` block twice against a controlled `gh api`, keeping the event body frozen while changing the live PR body from unsigned to signed</code>
- `gh api repos/kunchenguid/no-mistakes/pulls/513 --jq '{number: .number, state: .state, has_signature: ((.body // "") | contains("Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)"))}'`
- <code>`git status --short` confirmed testing left the worktree unchanged</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
