### PR TITLE
fix(gate): make missing origin errors actionable

### DIFF
--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -25,6 +25,8 @@ Valid step names are `intent`, `rebase`, `review`, `test`, `document`, `lint`, `
 
 Initialize or refresh the gate for the current repository.
 
+`init` requires an `origin` remote to identify the upstream repository: later pipeline steps push validated branches to the configured target and open pull requests against that upstream. If `origin` is missing, add it with `git remote add origin <url>`, replacing `<url>` with the upstream repository's URL, then re-run `init`.
+
 ```sh
 no-mistakes init
 no-mistakes init --fork-url git@github.com:you/my-repo.git

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -81,6 +81,18 @@ func InitWithFork(ctx context.Context, d *db.DB, p *paths.Paths, workDir, forkUR
 	}
 	upstreamURL, err := getOriginURL(ctx, absRoot, "origin")
 	if err != nil {
+		// A missing "origin" is a normal state for a fresh `git init` repo, so
+		// give an actionable message instead of leaking git plumbing. Only
+		// substitute it when origin is genuinely absent; any other git failure
+		// keeps its original error.
+		if !git.HasRemote(ctx, absRoot, "origin") {
+			return nil, false, fmt.Errorf(
+				"no 'origin' remote in %s\n\n"+
+					"no-mistakes pushes your branch and opens a pull request, so it needs a remote to push to.\n"+
+					"Add one, then re-run:\n\n"+
+					"  git remote add origin <url>",
+				absRoot)
+		}
 		return nil, false, fmt.Errorf("get origin url: %w", err)
 	}
 	if forkURL != "" {

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -85,7 +85,8 @@ func InitWithFork(ctx context.Context, d *db.DB, p *paths.Paths, workDir, forkUR
 		// give an actionable message instead of leaking git plumbing. Only
 		// substitute it when origin is genuinely absent; any other git failure
 		// keeps its original error.
-		if !git.HasRemote(ctx, absRoot, "origin") {
+		hasOrigin, listErr := git.HasRemote(ctx, absRoot, "origin")
+		if listErr == nil && !hasOrigin {
 			return nil, false, fmt.Errorf(
 				"no 'origin' remote in %s\n\n"+
 					"no-mistakes pushes your branch and opens a pull request, so it needs a remote to push to.\n"+

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -771,6 +771,16 @@ func TestInitNoOrigin(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when no origin remote")
 	}
+	// The error must be actionable, not a raw git-plumbing leak: a fresh
+	// `git init` repo with no remote yet is a normal state, so tell the user
+	// how to fix it instead of surfacing `git remote get-url` exit codes.
+	msg := err.Error()
+	if !strings.Contains(msg, "git remote add origin") {
+		t.Errorf("error should tell the user how to add an origin remote; got: %q", msg)
+	}
+	if strings.Contains(msg, "get origin url") || strings.Contains(msg, "exit status") {
+		t.Errorf("error leaked raw git plumbing; got: %q", msg)
+	}
 }
 
 func TestInitNotGitRepo(t *testing.T) {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -115,6 +115,22 @@ func GetConfiguredRemoteURL(ctx context.Context, dir, name string) (string, erro
 	return Run(ctx, dir, "config", "--get", "remote."+name+".url")
 }
 
+// HasRemote reports whether a remote named name is configured in the repo at
+// dir. It lets callers distinguish a genuinely missing remote (an actionable
+// user error) from other git failures, without matching on git error text.
+func HasRemote(ctx context.Context, dir, name string) bool {
+	out, err := Run(ctx, dir, "remote")
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.TrimSpace(line) == name {
+			return true
+		}
+	}
+	return false
+}
+
 // FindGitRoot walks up from path to find the git repository root.
 // Resolves symlinks for consistency on macOS (e.g. /tmp -> /private/tmp).
 func FindGitRoot(path string) (string, error) {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -116,19 +116,18 @@ func GetConfiguredRemoteURL(ctx context.Context, dir, name string) (string, erro
 }
 
 // HasRemote reports whether a remote named name is configured in the repo at
-// dir. It lets callers distinguish a genuinely missing remote (an actionable
-// user error) from other git failures, without matching on git error text.
-func HasRemote(ctx context.Context, dir, name string) bool {
+// dir, returning an error if the remote list cannot be read.
+func HasRemote(ctx context.Context, dir, name string) (bool, error) {
 	out, err := Run(ctx, dir, "remote")
 	if err != nil {
-		return false
+		return false, err
 	}
 	for _, line := range strings.Split(out, "\n") {
 		if strings.TrimSpace(line) == name {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // FindGitRoot walks up from path to find the git repository root.


### PR DESCRIPTION
## Intent

Fix `no-mistakes init` so that running it in a git repo with no `origin` remote gives a clear, actionable error instead of leaking a raw git error (`get origin url: git remote get-url origin: exit status 2: error: No such remote 'origin'`). A fresh `git init` repo with no remote yet is a completely normal state, so the raw plumbing leak is poor UX.

Deliberate decisions (so the reviewer does not flag these as mistakes):
- Keep the by-design requirement that no-mistakes needs a remote: it pushes a branch and opens a PR, so origin is genuinely required. This change ONLY improves the error message; it does not add a no-remote/local-only mode.
- Detect a genuinely-absent origin with a new `git.HasRemote` helper that lists remotes (`git remote`) rather than matching on git error text, because the two lookup paths (`git remote get-url` vs `git config --get`) fail differently and string-matching would be fragile.
- Substitute the friendly message ONLY when the origin lookup fails AND origin is truly absent; the happy path is untouched and any other git failure keeps its original error. This is why the check lives inside the existing error branch, not as an unconditional up-front call.
- The message tells the user exactly how to fix it: `git remote add origin <url>`.

TDD: the repo already had `TestInitNoOrigin` asserting only that an error occurs; I strengthened it to assert the message is actionable (contains `git remote add origin`) and free of raw plumbing (no `get origin url` / `exit status`). Verified: TestInitNoOrigin red->green, full `go test -race ./...` (32 pkgs, 0 fail), `make lint` clean, and E2E both paths on the built binary.

## What Changed

- Detect a genuinely missing `origin` remote during gate initialization without matching fragile Git error text.
- Replace raw Git plumbing errors with an actionable `git remote add origin <url>` message while preserving unrelated remote lookup failures.
- Document the `origin` requirement and strengthen regression coverage for the user-facing error.

## Risk Assessment

✅ Low: The change is narrowly scoped, satisfies the actionable no-origin requirement, and now preserves the original lookup error whenever the remote listing fails or confirms that origin exists.

## Testing

The supplied full race-suite baseline and focused regression passed; end-to-end CLI transcripts verified both missing-origin paths, preservation of unrelated Git failures, and successful valid-origin initialization, with no screenshot needed because the changed user surface is terminal output.

<details>
<summary>Evidence: Fresh repository without origin</summary>

`Friendly actionable error with repair command; exit_code=1.`

```text
init: no 'origin' remote in /tmp/no-mistakes-evidence/01KY2SSZVZ7ZDFJG7PBY2HXDF7/no-origin-repo

no-mistakes pushes your branch and opens a pull request, so it needs a remote to push to.
Add one, then re-run:

  git remote add origin <url>

exit_code=1
```
</details>
<details>
<summary>Evidence: Missing origin with fork option</summary>

`Friendly error through the --fork-url lookup path; exit_code=1.`

```text
init: no 'origin' remote in /tmp/no-mistakes-evidence/01KY2SSZVZ7ZDFJG7PBY2HXDF7/no-origin-fork-repo

no-mistakes pushes your branch and opens a pull request, so it needs a remote to push to.
Add one, then re-run:

  git remote add origin <url>

exit_code=1
```
</details>
<details>
<summary>Evidence: Valid origin initialization</summary>

`Gate initialized against the expected upstream; exit_code=0.`

```text
_  _ ____    _  _ _ ____ ___ ____ _  _ ____ ____
|\ | |  |    |\/| | [__   |  |__| |_/  |___ [__ 
| \| |__|    |  | | ___]  |  |  | | \_ |___ ___]

  ✓ Gate initialized

    repo  /tmp/no-mistakes-evidence/01KY2SSZVZ7ZDFJG7PBY2HXDF7/valid-origin-repo
    gate  no-mistakes → /tmp/no-mistakes-evidence/01KY2SSZVZ7ZDFJG7PBY2HXDF7/nm-home-valid-origin/repos/4f2cb4acbcc4.git
  remote  /tmp/no-mistakes-evidence/01KY2SSZVZ7ZDFJG7PBY2HXDF7/upstream.git
   skill  /no-mistakes installed for agents at user level

  Push through the gate with:
  git push no-mistakes <branch>

exit_code=0
```
</details>
<details>
<summary>Evidence: Non-absence Git failure</summary>

`Original simulated Git diagnostic retained; exit_code=1.`

```text
init: get origin url: git remote get-url origin: exit status 128: fatal: simulated origin lookup failure

exit_code=1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `internal/gate/gate.go:88` - `HasRemote` returns false when `git remote` itself fails, so a canceled context or another Git/configuration failure can be misreported as a missing origin even when origin exists. This contradicts the required criterion that substitution occur &#34;ONLY when the origin lookup fails AND origin is truly absent&#34; and that other Git failures retain their original error. Return `(bool, error)` from `HasRemote` and use the friendly message only when the listing succeeds and reports no origin.

🔧 Fix: preserve remote-list errors during init
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`
- <code>Supplied baseline: `go test -race ./...`</code>
- `go test -race ./internal/gate -run '^TestInitNoOrigin$' -count=1 -v`
- `go build -o /tmp/no-mistakes-evidence/01KY2SSZVZ7ZDFJG7PBY2HXDF7/no-mistakes ./cmd/no-mistakes`
- <code>Ran built `no-mistakes init` in a fresh no-origin repository; asserted exit 1, `git remote add origin &lt;url&gt;`, and absence of `get origin url`, `exit status`, and `No such remote`</code>
- <code>Ran built `no-mistakes init --fork-url https://github.com/example/fork.git` without origin; asserted the same friendly behavior through the configured-URL lookup path</code>
- <code>Ran built `no-mistakes init` with a controlled `git remote get-url origin` failure while origin remained listed; asserted the original diagnostic was retained</code>
- <code>Created a local bare upstream, pushed `main`, ran built `no-mistakes init`, and verified exit 0 plus configured `origin` and `no-mistakes` remotes</code>
- <code>Stopped isolated test daemons and verified `git status --porcelain=v1` was clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
