### PR TITLE
fix: neutralize Copilot project instructions

### DIFF
--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -118,7 +118,7 @@ Suppress project-level agent settings and instructions for every gate-agent star
 
 This opt-in is intended for agent-orchestration repositories whose `AGENTS.md`, `CLAUDE.md`, or harness-specific project settings would give a validation agent an operator identity and authority that it must not adopt.
 When enabled, no-mistakes suppresses the target checkout's project settings for every agent-driven gate step while preserving user-level agent configuration.
-Codex and Claude are the currently verified agents: Codex receives `project_doc_max_bytes=0` and `--ignore-rules`, while Claude loads only its user setting source.
+Codex, Claude, and Copilot are the currently verified agents: Codex receives `project_doc_max_bytes=0` and `--ignore-rules`, Claude loads only its user setting source, and Copilot receives `--no-custom-instructions`.
 The setting applies to both new and resumed sessions.
 
 The gate fails before launching an agent if any resolved agent or fallback lacks a verified suppression mechanism.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -156,8 +156,8 @@ func NeutralizesGateInstructions(a Agent) bool {
 // the target checkout does not neutralize that checkout's project
 // agent-instruction files. Callers must invoke it before launching any gate
 // agent so an unverified harness is refused with a clear error rather than run
-// unneutralized in the target checkout. Only codex and claude have a verified
-// neutralization knob today.
+// unneutralized in the target checkout. Only Codex, Claude, and Copilot have a
+// verified neutralization knob today.
 func EnsureGateNeutralized(a Agent) error {
 	if a == nil {
 		return fmt.Errorf("no gate agent configured")
@@ -167,8 +167,9 @@ func EnsureGateNeutralized(a Agent) error {
 	}
 	return fmt.Errorf("gate agent %q does not neutralize the target repository's project "+
 		"agent-instruction files (AGENTS.md/CLAUDE.md); refusing to launch it in the target "+
-		"checkout. Only codex and claude have a verified neutralization knob (and only when it "+
-		"is not overridden by agent_args_override); set 'agent' to codex or claude in "+
+		"checkout. Only codex, claude, and copilot have a verified neutralization knob "+
+		"(and codex/claude only when it is not overridden by agent_args_override); set "+
+		"'agent' to codex, claude, or copilot in "+
 		"~/.no-mistakes/config.yaml", a.Name())
 }
 
@@ -248,7 +249,7 @@ type InvocationWorkload struct {
 type Options struct {
 	ACPRegistryOverrides map[string]string
 	// DisableProjectSettings, when true, asks a supported adapter (codex,
-	// claude) to launch with the target repo's project-level agent
+	// claude, copilot) to launch with the target repo's project-level agent
 	// settings/instructions suppressed. It is the resolved, trusted-only opt-out
 	// from config.Config; adapters without a verified suppression knob ignore it
 	// and are refused separately by EnsureGateNeutralized when the opt-out is on.
@@ -807,7 +808,7 @@ func NewWithOptions(name types.AgentName, bin string, extraArgs []string, opts O
 	case types.AgentPi:
 		return &piAgent{bin: bin, extraArgs: extraArgs}, nil
 	case types.AgentCopilot:
-		return &copilotAgent{bin: bin, extraArgs: extraArgs}, nil
+		return &copilotAgent{bin: bin, extraArgs: extraArgs, disableProjectSettings: opts.DisableProjectSettings}, nil
 	default:
 		return nil, fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, copilot, cursor, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
 	}

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -20,11 +20,25 @@ import (
 type copilotAgent struct {
 	bin       string
 	extraArgs []string
+	// disableProjectSettings is the resolved, trusted-only opt-out. When true,
+	// buildArgs suppresses Copilot's custom project instructions.
+	disableProjectSettings bool
 }
 
 func (a *copilotAgent) Name() string { return "copilot" }
 
 func (a *copilotAgent) ReportsAgentAttempts() bool { return true }
+
+// NeutralizesGateInstructions reports whether Copilot is currently launched
+// with the target repo's custom project instructions suppressed. It is
+// meaningful only under the opt-out (disableProjectSettings): buildArgs appends
+// --no-custom-instructions to every invocation, after user extraArgs, so the
+// effective command cannot load AGENTS.md or CLAUDE.md. Verified empirically:
+// with custom instructions loaded Copilot adopts the target repository's agent
+// identity; with --no-custom-instructions it honors the pipeline prompt instead.
+func (a *copilotAgent) NeutralizesGateInstructions() bool {
+	return a.disableProjectSettings
+}
 
 func (a *copilotAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
 	return runWithRetry(ctx, "copilot", opts, claudeMaxRetries, classifyTransient, nil, func() (*Result, error) {
@@ -144,7 +158,7 @@ func copilotErrorDetail(copilotErr, stderr string) string {
 // added; --no-ask-user is always added so the agent never blocks waiting for
 // interactive input.
 func (a *copilotAgent) buildArgs(prompt string) []string {
-	args := make([]string, 0, len(a.extraArgs)+8)
+	args := make([]string, 0, len(a.extraArgs)+9)
 	args = append(args, a.extraArgs...)
 	args = append(args,
 		"-p", prompt,
@@ -156,6 +170,15 @@ func (a *copilotAgent) buildArgs(prompt string) []string {
 	}
 	if !copilotUserSetPermissionMode(a.extraArgs) {
 		args = append(args, "--allow-all-tools")
+	}
+	// Project-settings opt-out (trusted-only; see config.DisableProjectSettings):
+	// --no-custom-instructions suppresses the target checkout's AGENTS.md and
+	// CLAUDE.md, which could otherwise install a governing identity on the gate
+	// agent. Append it after user extraArgs so every opt-out invocation has the
+	// verified suppression, while non-opt-out invocations retain Copilot's
+	// existing project-instruction behavior.
+	if a.disableProjectSettings {
+		args = append(args, "--no-custom-instructions")
 	}
 	return args
 }

--- a/internal/agent/copilot_test.go
+++ b/internal/agent/copilot_test.go
@@ -53,6 +53,28 @@ func TestCopilotAgent_BuildArgs_ExtraArgsFirst(t *testing.T) {
 	}
 }
 
+func TestCopilotAgent_BuildArgs_DisableProjectSettings(t *testing.T) {
+	ca := &copilotAgent{bin: "copilot", disableProjectSettings: true}
+	args := ca.buildArgs("fix the bug")
+
+	expected := []string{
+		"-p", "fix the bug",
+		"--output-format", "json",
+		"--no-color",
+		"--no-ask-user",
+		"--allow-all-tools",
+		"--no-custom-instructions",
+	}
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("arg[%d]: expected %q, got %q", i, want, args[i])
+		}
+	}
+}
+
 func TestCopilotAgent_BuildArgs_UserPermissionSuppressesDefault(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/agent/gateneutralize_test.go
+++ b/internal/agent/gateneutralize_test.go
@@ -19,17 +19,17 @@ func optOutAgent(t *testing.T, name types.AgentName, extraArgs []string) Agent {
 }
 
 // TestNeutralizesGateInstructions_OnlyVerifiedHarnessesUnderOptOut is the core
-// fail-closed contract: under the opt-out, only codex and claude (whose
-// suppression knobs are empirically verified) neutralize the target repo's
-// project agent settings/instructions; every other harness reports false and is
-// refused rather than launched with project instructions loaded.
+// fail-closed contract: under the opt-out, only adapters whose suppression knobs
+// are empirically verified neutralize the target repo's project agent
+// settings/instructions; every other harness reports false and is refused rather
+// than launched with project instructions loaded.
 func TestNeutralizesGateInstructions_OnlyVerifiedHarnessesUnderOptOut(t *testing.T) {
-	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude} {
+	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentCopilot} {
 		if !NeutralizesGateInstructions(optOutAgent(t, name, nil)) {
 			t.Errorf("%s must neutralize under the opt-out with its default knob", name)
 		}
 	}
-	unverified := []types.AgentName{types.AgentOpenCode, types.AgentPi, types.AgentCopilot, types.AgentRovoDev}
+	unverified := []types.AgentName{types.AgentOpenCode, types.AgentPi, types.AgentRovoDev}
 	for _, name := range unverified {
 		if NeutralizesGateInstructions(optOutAgent(t, name, nil)) {
 			t.Errorf("%s has no verified knob; must NOT report neutralized", name)
@@ -50,11 +50,11 @@ func TestNeutralizesGateInstructions_OnlyVerifiedHarnessesUnderOptOut(t *testing
 	}
 }
 
-// TestNeutralizesGateInstructions_FalseWithoutOptOut proves codex/claude do NOT
-// claim neutralization when the repo did not opt out - the gate only consults
+// TestNeutralizesGateInstructions_FalseWithoutOptOut proves verified adapters do
+// NOT claim neutralization when the repo did not opt out - the gate only consults
 // this under the opt-out, but the value must be honest.
 func TestNeutralizesGateInstructions_FalseWithoutOptOut(t *testing.T) {
-	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude} {
+	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentCopilot} {
 		a, err := NewWithOptions(name, string(name), nil, Options{}) // no opt-out
 		if err != nil {
 			t.Fatalf("NewWithOptions(%s): %v", name, err)
@@ -66,13 +66,13 @@ func TestNeutralizesGateInstructions_FalseWithoutOptOut(t *testing.T) {
 }
 
 // TestEnsureGateNeutralized_RefusesUnsupportedUnderOptOut proves the gate fails
-// closed for an unsupported harness with a clear error, and admits codex/claude.
+// closed for an unsupported harness with a clear error, and admits verified
+// adapters.
 func TestEnsureGateNeutralized_RefusesUnsupportedUnderOptOut(t *testing.T) {
-	if err := EnsureGateNeutralized(optOutAgent(t, types.AgentCodex, nil)); err != nil {
-		t.Errorf("codex must pass the gate under opt-out: %v", err)
-	}
-	if err := EnsureGateNeutralized(optOutAgent(t, types.AgentClaude, nil)); err != nil {
-		t.Errorf("claude must pass the gate under opt-out: %v", err)
+	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentCopilot} {
+		if err := EnsureGateNeutralized(optOutAgent(t, name, nil)); err != nil {
+			t.Errorf("%s must pass the gate under opt-out: %v", name, err)
+		}
 	}
 	err := EnsureGateNeutralized(optOutAgent(t, types.AgentOpenCode, nil))
 	if err == nil {
@@ -100,9 +100,10 @@ func TestNeutralizesGateInstructions_ThroughProductionWrapping(t *testing.T) {
 	allVerified := NewFallback([]Agent{
 		WithSteering(optOutAgent(t, types.AgentCodex, nil)),
 		WithSteering(optOutAgent(t, types.AgentClaude, nil)),
+		WithSteering(optOutAgent(t, types.AgentCopilot, nil)),
 	})
 	if err := EnsureGateNeutralized(allVerified); err != nil {
-		t.Errorf("fallback [codex, claude] must pass under opt-out: %v", err)
+		t.Errorf("fallback [codex, claude, copilot] must pass under opt-out: %v", err)
 	}
 	oneUnverified := NewFallback([]Agent{
 		WithSteering(optOutAgent(t, types.AgentCodex, nil)),

--- a/internal/daemon/gateneutralize_test.go
+++ b/internal/daemon/gateneutralize_test.go
@@ -18,7 +18,7 @@ func fakeLookPath(bin string) (string, error) { return "/fake/bin/" + bin, nil }
 // opt-out (disable_project_settings=true), a verified harness passes the gate and
 // its pipeline agent reports neutralized.
 func TestNewPipelineAgent_OptOut_AdmitsVerifiedHarness(t *testing.T) {
-	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude} {
+	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentCopilot} {
 		cfg := &config.Config{Agent: name, DisableProjectSettings: true}
 		ag, err := newPipelineAgent(context.Background(), cfg, fakeLookPath)
 		if err != nil {
@@ -36,7 +36,7 @@ func TestNewPipelineAgent_OptOut_AdmitsVerifiedHarness(t *testing.T) {
 // verified neutralization knob is refused rather than launched with project
 // instructions loaded.
 func TestNewPipelineAgent_OptOut_RefusesUnverifiedHarness(t *testing.T) {
-	for _, name := range []types.AgentName{types.AgentOpenCode, types.AgentPi, types.AgentCopilot} {
+	for _, name := range []types.AgentName{types.AgentOpenCode, types.AgentPi} {
 		cfg := &config.Config{Agent: name, DisableProjectSettings: true}
 		if _, err := newPipelineAgent(context.Background(), cfg, fakeLookPath); err == nil {
 			t.Fatalf("%s must be refused under opt-out", name)
@@ -51,7 +51,7 @@ func TestNewPipelineAgent_OptOut_RefusesUnverifiedHarness(t *testing.T) {
 // no suppression knob - is admitted and runs exactly as before.
 func TestNewPipelineAgent_NoOptOut_AdmitsEveryHarness(t *testing.T) {
 	// rovodev is omitted: its resolution runs a real version probe that a fake
-	// binary path cannot satisfy. opencode/pi/copilot already prove that an
+	// binary path cannot satisfy. opencode/pi already prove that an
 	// unverified adapter is admitted when the repo did not opt out.
 	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentOpenCode, types.AgentPi, types.AgentCopilot} {
 		cfg := &config.Config{Agent: name} // DisableProjectSettings defaults false
@@ -85,7 +85,7 @@ func TestNewPipelineAgent_OptOut_FallbackRefusesAnyUnverifiedMember(t *testing.T
 	if _, err := newPipelineAgent(context.Background(), cfg, fakeLookPath); err == nil {
 		t.Fatal("a fallback list containing an unverified harness must be refused under opt-out")
 	}
-	cfg = &config.Config{Agents: []types.AgentName{types.AgentCodex, types.AgentClaude}, DisableProjectSettings: true}
+	cfg = &config.Config{Agents: []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentCopilot}, DisableProjectSettings: true}
 	if ag, err := newPipelineAgent(context.Background(), cfg, fakeLookPath); err != nil {
 		t.Fatalf("a fallback list of only verified harnesses must pass under opt-out, got: %v", err)
 	} else {


### PR DESCRIPTION
## Summary
- Pass `disable_project_settings` into the Copilot CLI adapter and append its verified `--no-custom-instructions` flag to every opted-out invocation.
- Admit Copilot through the fail-closed gate-neutralization contract while preserving Codex, Claude, and unsupported-adapter behavior.
- Document the verified Copilot suppression mechanism.

This enables verified Copilot CLI instruction neutralization and unblocks Copilot-only validation of Firstmate.

## Validation
- `go test ./internal/agent ./internal/daemon -count=1`
- `go vet ./internal/agent ./internal/daemon`