### PR TITLE
fix(scm/github): support legacy gh check polling

### DIFF
--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -8,8 +8,11 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"sync/atomic"
 	"time"
+	"unicode/utf8"
 
+	"github.com/kunchenguid/no-mistakes/internal/safeurl"
 	"github.com/kunchenguid/no-mistakes/internal/scm"
 )
 
@@ -23,6 +26,10 @@ type Host struct {
 	host         string // repo's GitHub hostname; scopes the auth check
 	repo         string // "owner/name" slug for --repo; empty when unknown
 	forkOwner    string // fork owner for cross-repository PR heads
+
+	// checksJSONUnsupported is set after an older gh rejects `pr checks
+	// --json`, so later polls use the compatible status rollup directly.
+	checksJSONUnsupported atomic.Bool
 }
 
 // New builds a Host. cliAvailable reports whether the gh binary is
@@ -286,26 +293,83 @@ func (h *Host) GetPRState(ctx context.Context, pr *scm.PR) (scm.PRState, error) 
 	cmd := h.cmd(ctx, "gh", args...)
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("gh pr view: %w", err)
+		return "", ghCLIError("gh pr view", err)
 	}
 	return normalizePRState(strings.TrimSpace(string(out))), nil
 }
 
+// GetChecks prefers the structured `gh pr checks --json` interface. GitHub
+// CLI added that flag in v2.50.0; older packaged versions reject it before
+// making a request, so the Host detects that one capability error and uses the
+// older `gh pr view --json statusCheckRollup` interface for the rest of the run.
 func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
 	selector, err := prSelector(pr)
 	if err != nil {
 		return nil, err
 	}
+	if h.checksJSONUnsupported.Load() {
+		return h.getChecksViaStatusRollup(ctx, selector)
+	}
 	args := append([]string{"pr", "checks", selector}, h.repoArgs()...)
 	args = append(args, "--json", "name,state,bucket,completedAt")
 	cmd := h.cmd(ctx, "gh", args...)
-	out, err := cmd.CombinedOutput()
+	out, err := cmd.Output()
 	if err != nil {
-		if strings.Contains(string(out), "no checks reported") {
+		stderr := commandStderr(err)
+		if strings.Contains(string(out)+string(stderr), "no checks reported") {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("gh pr checks: %w", err)
+		if strings.Contains(string(stderr), "unknown flag: --json") {
+			h.checksJSONUnsupported.Store(true)
+			return h.getChecksViaStatusRollup(ctx, selector)
+		}
+		return nil, ghCLIError("gh pr checks", err)
 	}
+	return parseChecksJSON(out)
+}
+
+// getChecksViaStatusRollup preserves structured states and completion times on
+// gh versions that predate `pr checks --json`. The rollup is a GraphQL union of
+// CheckRun and StatusContext values, which expose different name/state fields.
+func (h *Host) getChecksViaStatusRollup(ctx context.Context, selector string) ([]scm.Check, error) {
+	args := append([]string{"pr", "view", selector}, h.repoArgs()...)
+	args = append(args, "--json", "statusCheckRollup")
+	out, err := h.cmd(ctx, "gh", args...).Output()
+	if err != nil {
+		return nil, ghCLIError("gh pr view statusCheckRollup", err)
+	}
+	var payload struct {
+		StatusCheckRollup []struct {
+			Typename    string `json:"__typename"`
+			Name        string `json:"name"`
+			Context     string `json:"context"`
+			Conclusion  string `json:"conclusion"`
+			Status      string `json:"status"`
+			State       string `json:"state"`
+			CompletedAt string `json:"completedAt"`
+		} `json:"statusCheckRollup"`
+	}
+	if err := json.Unmarshal(out, &payload); err != nil {
+		return nil, fmt.Errorf("parse CI checks: %w", err)
+	}
+	checks := make([]scm.Check, 0, len(payload.StatusCheckRollup))
+	for _, item := range payload.StatusCheckRollup {
+		name, state := item.Name, item.Conclusion
+		if item.Typename == "StatusContext" {
+			name, state = item.Context, item.State
+		} else if state == "" {
+			state = item.Status
+		}
+		checks = append(checks, scm.Check{
+			Name:        name,
+			Bucket:      normalizedCheckBucketOrPending("", state),
+			CompletedAt: parseCheckCompletedAt(item.CompletedAt),
+		})
+	}
+	return checks, nil
+}
+
+func parseChecksJSON(out []byte) ([]scm.Check, error) {
 	var raw []struct {
 		Name        string `json:"name"`
 		State       string `json:"state"`
@@ -317,15 +381,70 @@ func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
 	}
 	checks := make([]scm.Check, 0, len(raw))
 	for _, r := range raw {
-		var completedAt time.Time
-		if r.CompletedAt != "" {
-			if parsed, parseErr := time.Parse(time.RFC3339, r.CompletedAt); parseErr == nil {
-				completedAt = parsed
-			}
-		}
-		checks = append(checks, scm.Check{Name: r.Name, Bucket: normalizeCheckBucket(r.Bucket, r.State), CompletedAt: completedAt})
+		checks = append(checks, scm.Check{
+			Name:        r.Name,
+			Bucket:      normalizedCheckBucketOrPending(r.Bucket, r.State),
+			CompletedAt: parseCheckCompletedAt(r.CompletedAt),
+		})
 	}
 	return checks, nil
+}
+
+// commandStderr returns stderr captured by exec.Cmd.Output for a failed child.
+func commandStderr(err error) []byte {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.Stderr
+	}
+	return nil
+}
+
+func ghCLIError(op string, err error) error {
+	if detail := compactCLIError(commandStderr(err)); detail != "" {
+		return fmt.Errorf("%s: %w: %s", op, err, detail)
+	}
+	return fmt.Errorf("%s: %w", op, err)
+}
+
+// compactCLIError keeps provider warnings useful without allowing raw,
+// credentialled, or unbounded subprocess output into the CI step log.
+func compactCLIError(stderr []byte) string {
+	const maxLen = 200
+	for _, line := range strings.Split(string(stderr), "\n") {
+		line = safeurl.RedactText(strings.TrimSpace(line))
+		if line == "" {
+			continue
+		}
+		if len(line) > maxLen {
+			cut := maxLen
+			for cut > 0 && !utf8.RuneStart(line[cut]) {
+				cut--
+			}
+			line = line[:cut]
+		}
+		return line
+	}
+	return ""
+}
+
+func parseCheckCompletedAt(raw string) time.Time {
+	if raw == "" {
+		return time.Time{}
+	}
+	parsed, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed
+}
+
+// normalizedCheckBucketOrPending fails safe when GitHub adds a state: an
+// unknown value must keep the monitor waiting rather than look successful.
+func normalizedCheckBucketOrPending(bucket, state string) scm.CheckBucket {
+	if normalized := normalizeCheckBucket(bucket, state); normalized != "" {
+		return normalized
+	}
+	return scm.CheckBucketPending
 }
 
 func (h *Host) GetMergeableState(ctx context.Context, pr *scm.PR) (scm.MergeableState, error) {
@@ -338,7 +457,7 @@ func (h *Host) GetMergeableState(ctx context.Context, pr *scm.PR) (scm.Mergeable
 	cmd := h.cmd(ctx, "gh", args...)
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("gh pr view mergeable: %w", err)
+		return "", ghCLIError("gh pr view mergeable", err)
 	}
 	return normalizeMergeableState(strings.TrimSpace(string(out))), nil
 }
@@ -488,7 +607,9 @@ func normalizeMergeableState(raw string) scm.MergeableState {
 }
 
 func normalizeCheckBucket(bucket, state string) scm.CheckBucket {
-	if normalized := scm.CheckBucket(strings.TrimSpace(bucket)); normalized != "" {
+	switch normalized := scm.CheckBucket(strings.TrimSpace(bucket)); normalized {
+	case scm.CheckBucketPass, scm.CheckBucketFail, scm.CheckBucketPending,
+		scm.CheckBucketCancel, scm.CheckBucketSkip:
 		return normalized
 	}
 

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/kunchenguid/no-mistakes/internal/scm"
 )
@@ -369,6 +370,226 @@ func TestPRStateAndMergeableTargetKnownPRByURL(t *testing.T) {
 	}
 	if len(mergeArgs) != 1 || len(mergeArgs[0]) < 4 || mergeArgs[0][3] != prURL {
 		t.Fatalf("GetMergeableState selector = %v, want %q at argv[3]", mergeArgs, prURL)
+	}
+}
+
+func TestGetChecksFallsBackWhenJSONFlagUnsupported(t *testing.T) {
+	t.Parallel()
+
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		"gh pr checks 123 --repo test/repo --json name,state,bucket,completedAt": {
+			stderr: "unknown flag: --json\n",
+			code:   1,
+		},
+		"gh pr view 123 --repo test/repo --json statusCheckRollup": {
+			stdout: `{"statusCheckRollup":[` +
+				`{"__typename":"CheckRun","name":"build","conclusion":"SUCCESS","completedAt":"2026-04-24T04:15:00Z"},` +
+				`{"__typename":"CheckRun","name":"deploy","status":"IN_PROGRESS"},` +
+				`{"__typename":"StatusContext","context":"ci/legacy","state":"FAILURE"}` +
+				`]}` + "\n",
+		},
+	}), nil, "", "test/repo")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
+	if err != nil {
+		t.Fatalf("GetChecks() error = %v", err)
+	}
+	if len(checks) != 3 {
+		t.Fatalf("len(checks) = %d, want 3: %+v", len(checks), checks)
+	}
+	if checks[0].Name != "build" || checks[0].Bucket != scm.CheckBucketPass {
+		t.Fatalf("checks[0] = %+v, want passing build check", checks[0])
+	}
+	wantCompletedAt := time.Date(2026, 4, 24, 4, 15, 0, 0, time.UTC)
+	if !checks[0].CompletedAt.Equal(wantCompletedAt) {
+		t.Fatalf("checks[0].CompletedAt = %v, want %v", checks[0].CompletedAt, wantCompletedAt)
+	}
+	if checks[1].Name != "deploy" || checks[1].Bucket != scm.CheckBucketPending {
+		t.Fatalf("checks[1] = %+v, want pending deploy check", checks[1])
+	}
+	if checks[2].Name != "ci/legacy" || checks[2].Bucket != scm.CheckBucketFail {
+		t.Fatalf("checks[2] = %+v, want failing legacy status", checks[2])
+	}
+}
+
+func TestGetChecksMemoizesUnsupportedJSONFlag(t *testing.T) {
+	responses := map[string]githubTestResponse{
+		"gh pr checks 123 --json name,state,bucket,completedAt": {
+			stderr: "unknown flag: --json\n",
+			code:   1,
+		},
+		"gh pr view 123 --json statusCheckRollup": {
+			stdout: `{"statusCheckRollup":[]}` + "\n",
+		},
+	}
+	counts := map[string]int{}
+	baseFactory := githubTestCmdFactory(responses)
+	host := New(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		key := strings.TrimSpace(name + " " + strings.Join(args, " "))
+		counts[key]++
+		return baseFactory(ctx, name, args...)
+	}, nil, "", "")
+
+	for i := 0; i < 2; i++ {
+		if _, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"}); err != nil {
+			t.Fatalf("GetChecks() call %d error = %v", i+1, err)
+		}
+	}
+	if got := counts["gh pr checks 123 --json name,state,bucket,completedAt"]; got != 1 {
+		t.Fatalf("unsupported gh pr checks calls = %d, want 1", got)
+	}
+	if got := counts["gh pr view 123 --json statusCheckRollup"]; got != 2 {
+		t.Fatalf("fallback calls = %d, want 2", got)
+	}
+}
+
+func TestGetChecksLegacyFallbackPreservesExplicitPRTargeting(t *testing.T) {
+	t.Parallel()
+
+	const prURL = "https://github.com/parent/repo/pull/42"
+	cases := []struct {
+		name        string
+		pr          *scm.PR
+		repo        string
+		forkRepo    string
+		primaryKey  string
+		fallbackKey string
+	}{
+		{
+			name:        "URL selector when number missing",
+			pr:          &scm.PR{URL: prURL},
+			repo:        "parent/repo",
+			primaryKey:  "gh pr checks " + prURL + " --repo parent/repo --json name,state,bucket,completedAt",
+			fallbackKey: "gh pr view " + prURL + " --repo parent/repo --json statusCheckRollup",
+		},
+		{
+			name:        "fork PR scoped to parent repo",
+			pr:          &scm.PR{Number: "42", URL: prURL},
+			repo:        "parent/repo",
+			forkRepo:    "contributor/repo",
+			primaryKey:  "gh pr checks 42 --repo parent/repo --json name,state,bucket,completedAt",
+			fallbackKey: "gh pr view 42 --repo parent/repo --json statusCheckRollup",
+		},
+		{
+			name:        "enterprise host-prefixed repo",
+			pr:          &scm.PR{Number: "42", URL: "https://ghe.example/org/repo/pull/42"},
+			repo:        "ghe.example/org/repo",
+			primaryKey:  "gh pr checks 42 --repo ghe.example/org/repo --json name,state,bucket,completedAt",
+			fallbackKey: "gh pr view 42 --repo ghe.example/org/repo --json statusCheckRollup",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			responses := map[string]githubTestResponse{
+				tc.primaryKey:  {stderr: "unknown flag: --json\n", code: 1},
+				tc.fallbackKey: {stdout: `{"statusCheckRollup":[]}` + "\n"},
+			}
+			host := NewWithFork(githubTestCmdFactory(responses), nil, "", tc.repo, tc.forkRepo)
+			checks, err := host.GetChecks(context.Background(), tc.pr)
+			if err != nil {
+				t.Fatalf("GetChecks() error = %v", err)
+			}
+			if len(checks) != 0 {
+				t.Fatalf("checks = %+v, want empty rollup", checks)
+			}
+		})
+	}
+}
+
+func TestGetChecksUnknownStateRemainsPending(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		responses map[string]githubTestResponse
+	}{
+		{
+			name: "primary JSON",
+			responses: map[string]githubTestResponse{
+				"gh pr checks 123 --json name,state,bucket,completedAt": {
+					stdout: `[{"name":"future","state":"FUTURE_STATE","bucket":"future-bucket"}]` + "\n",
+				},
+			},
+		},
+		{
+			name: "status rollup fallback",
+			responses: map[string]githubTestResponse{
+				"gh pr checks 123 --json name,state,bucket,completedAt": {
+					stderr: "unknown flag: --json\n",
+					code:   1,
+				},
+				"gh pr view 123 --json statusCheckRollup": {
+					stdout: `{"statusCheckRollup":[{"__typename":"CheckRun","name":"future","conclusion":"FUTURE_STATE"}]}` + "\n",
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			host := New(githubTestCmdFactory(tc.responses), nil, "", "")
+			checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
+			if err != nil {
+				t.Fatalf("GetChecks() error = %v", err)
+			}
+			if len(checks) != 1 || checks[0].Bucket != scm.CheckBucketPending {
+				t.Fatalf("checks = %+v, want one pending check", checks)
+			}
+		})
+	}
+}
+
+func TestGetChecksErrorIncludesBoundedRedactedStderr(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		stderr     string
+		wantDetail string
+	}{
+		{
+			name:       "credentialled URL is redacted",
+			stderr:     "authentication failed for https://user:secret@example.com/org/repo\nsecond line is omitted\n",
+			wantDetail: "authentication failed for https://redacted@example.com/org/repo",
+		},
+		{
+			name:       "oversized UTF-8 is bounded",
+			stderr:     "provider rejected request " + strings.Repeat("é", 150) + "\n",
+			wantDetail: "provider rejected request",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			host := New(githubTestCmdFactory(map[string]githubTestResponse{
+				"gh pr checks 123 --json name,state,bucket,completedAt": {
+					stderr: tc.stderr,
+					code:   1,
+				},
+			}), nil, "", "")
+			_, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
+			if err == nil {
+				t.Fatal("GetChecks() error = nil, want error")
+			}
+			got := err.Error()
+			if !strings.Contains(got, tc.wantDetail) {
+				t.Fatalf("GetChecks() error = %q, want useful detail %q", got, tc.wantDetail)
+			}
+			if strings.Contains(got, "secret") {
+				t.Fatalf("GetChecks() error leaked credential: %q", got)
+			}
+			detail := strings.TrimPrefix(got, "gh pr checks: exit status 1: ")
+			if len(detail) > 200 {
+				t.Fatalf("stderr detail length = %d, want <= 200", len(detail))
+			}
+			if !utf8.ValidString(detail) {
+				t.Fatalf("stderr detail is invalid UTF-8: %q", detail)
+			}
+			if strings.Contains(detail, "second line") {
+				t.Fatalf("stderr detail included later line: %q", detail)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix the GitHub CI monitor on packaged `gh` versions older than 2.50, which reject `gh pr checks --json` before querying GitHub and leave otherwise-green PRs polling until the CI idle timeout.

Addresses the CI-polling portion of #380. This is a focused revival of the provider compatibility and diagnostics work from #393 and #410, adapted to current main and its explicit PR selector boundary. Unlike #393, it does not include unrelated required-workflow, doctor, daemon, timeout, or routing changes.

## Root cause and reproduction

On Ubuntu `gh` 2.45.0, no-mistakes builds the correctly targeted command:

```text
gh pr checks 18 --repo julesLubrano/Senhau --json name,state,bucket,completedAt
```

but the local CLI returns:

```text
unknown flag: --json
exit status 1
```

The PR identity and base repository are explicit; branch-upstream inference is not involved. The old implementation discarded the captured stderr, so the CI log exposed only `gh pr checks: exit status 1` and retried it as if it were transient.

## Changes

- retain `gh pr checks <selector> --repo <base> --json ...` as the preferred path;
- narrowly detect the older CLI's `unknown flag: --json`, memoize that capability per GitHub Host, and use structured `gh pr view <selector> --repo <base> --json statusCheckRollup` on later polls;
- parse both `CheckRun` and `StatusContext`, preserving completion timestamps and treating unknown states as pending rather than successful;
- preserve URL-only selectors, parent-repository scoping for fork PRs, and host-prefixed GitHub Enterprise repositories;
- surface only the first bounded, UTF-8-safe, credential-redacted stderr line in provider errors.

## Validation

- `go test -race ./internal/scm/github -count=1`
- `make lint`
- `go test -race ./...`
- `go build -buildvcs=false -o ./bin/no-mistakes ./cmd/no-mistakes`

The final build disables VCS stamping only because this disposable linked worktree's Git metadata lives outside the worktree hierarchy; compilation succeeds and the full race suite is green.

The focused regressions cover the gh 2.45 rejection/fallback, per-Host memoization, empty rollups, explicit URL/fork/GHES targeting, CheckRun and StatusContext parsing, unknown-state fail-safe behavior, timestamps, and bounded credential-redacted stderr.
