### PR TITLE
fix(pipeline): keep local Test validation targeted

### DIFF
--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -1,12 +1,13 @@
 # no-mistakes' own dogfood config.
-# Makes the gate deterministic: every gated PR runs the exact test/lint/format
-# commands the maintainers run locally, instead of leaving it to agent
-# auto-detection. `go test -race` is the key addition — concurrency races (the
-# #1311 class) are caught automatically on every push.
-# See docs/src/content/docs/reference/repo-config.md
+# Local Test is intentionally empty: the Test step is targeted validation of the
+# requested intent (agent-driven smallest relevant checks + evidence), never a
+# repository-wide regression suite. Broad race-enabled Go coverage stays in
+# remote CI (`go test -race ./...` in .github/workflows/ci.yml) and remains
+# mandatory before a PR is ready. See docs/src/content/docs/reference/repo-config.md
+# (commands.test) and docs/src/content/docs/reference/pipeline-steps.md (Test).
+# Lint and format stay explicit so those gates stay deterministic.
 
 commands:
-  test: "go test -race ./..."
   lint: "make lint"
   format: "gofmt -w ."
 

--- a/.no-mistakes/evidence/fm/nm-targeted-test-step/targeted-test-validation.md
+++ b/.no-mistakes/evidence/fm/nm-targeted-test-step/targeted-test-validation.md
@@ -1,0 +1,60 @@
+# Targeted local Test validation
+
+Validated target `f027af1f66a182c00356e0a7c725e8959b321c29` against the explicit intent that local Test selects focused checks and evidence while remote CI retains broad regression.
+
+## End-to-end product journey
+
+The real e2e harness initialized no-mistakes, pushed through the gate, started the daemon, invoked the Codex adapter as a subprocess, persisted pipeline state, and read it back over IPC:
+
+```text
+$ go test -tags=e2e ./internal/e2e -run '^TestUserJourney/codex$' -count=1 -v
+=== RUN   TestUserJourney/codex
+agent invocations: 14
+step outcomes:
+  1 intent    skipped
+  2 rebase    completed
+  3 review    completed
+  4 test      completed
+  5 document  completed
+  6 lint      completed
+  7 push      completed
+  8 pr        skipped
+  9 ci        skipped
+rerun outcome: 01KY3PGEYEAB7C4NJ8N4TQ2FX5 completed
+--- PASS: TestUserJourney/codex
+```
+
+The e2e fake-agent fixture only matches the Test invocation when the runtime prompt begins:
+
+```text
+You are validating a code change by testing it. Examine the repository and run the smallest relevant tests yourself.
+```
+
+That journey completed both the initial pipeline and rerun with the new prompt.
+
+## Runtime prompt boundaries exercised
+
+Focused `TestStep.Execute` regressions captured the actual prompts sent to the agent and verified these clauses:
+
+| Path | Runtime contract demonstrated |
+|---|---|
+| Normal Test agent | Run the smallest relevant tests; do not run the complete repository suite; remote CI owns broad regression; write a focused test, gather manual evidence, or report an honest missing-evidence warning instead of running nothing. |
+| Test repair agent | Reproduce the specific failing case, fix its root cause, and rerun only that focused verification. |
+| Conflicting driver instruction | A previous finding containing `confirm the full suite path for this failure is green` remains visible to the agent, while the same runtime prompt explicitly says generic broad/full-suite requests do not override focused verification. |
+| No targeted evidence | A warning with `action: ask-user` produces `NeedsApproval`, so the pipeline does not manufacture a pass. |
+| Configured targeted command plus intent | The configured command executes first, then the evidence agent runs and persists its `tested`, `testing_summary`, and artifact fields. |
+
+## Local and remote ownership
+
+The repository config was loaded through the product config parser and returned an empty `commands.test`, enabling agent-selected targeted validation. The CI workflow still contains:
+
+```yaml
+- if: runner.os != 'Windows'
+  run: go test -race ./...
+```
+
+The focused static guards also verified that the authoritative `commands.test` docs define targeted local validation, reject CI-parity wording, and explicitly avoid shell-command heuristics.
+
+## Lifecycle regression protection
+
+Focused clean-exit and escaped-pipe tests passed for the Codex agent, native agent command, and shared shell-command helper. This preserves #357 process-group reaping and Unix `WaitDelay` while returning local Test to the agent-driven path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,15 @@ Safest local verification sequence after non-trivial changes:
   This is a prompt contract, not an enforced sandbox.
   Regression: `TestReviewStep_FixMode_FocusedVerificationContract`.
 
+**Local Test Is Targeted Validation (`internal/pipeline/steps/test.go`)**
+
+- Local Test (normal evidence agent and Test-repair agent) validates the requested intent with the smallest relevant checks and end-user-aligned evidence; it is never a repository-wide regression-suite walk.
+  Broad regression belongs to remote CI (`go test -race ./...` in `.github/workflows/ci.yml`) and remains mandatory before a PR is ready.
+  `commands.test` is the same contract when set: targeted baseline, not CI-parity complete-suite configuration; docs owner is `docs/src/content/docs/reference/repo-config.md` (`commands.test`), step behavior owner is `docs/src/content/docs/reference/pipeline-steps.md` (Test).
+  This repository dogfoods an empty `commands.test` so the agent-driven targeted path is the default; do not reintroduce `go test -race ./...` as a local Test override.
+  Process-group reaping on clean/error exit (#357) and Unix WaitDelay remain the lifecycle safety net when agents spawn test workers - restoring the agent-driven path must not revive the daemon OOM leak.
+  Regressions: `TestTestStep_InitialAgent_TargetedValidationContract`, `TestTestStep_FixMode_TargetedVerificationContract`, `TestTestStep_FixMode_DriverFullSuiteInstructionDoesNotOverrideContract`, `TestTestStep_InitialAgent_NoTargetedEvidenceRequiresHonestFinding`, `TestDogfoodConfig_NoBroadLocalTestCommand`, `TestCIWorkflow_RetainsFullRaceSuiteAsBroadRegressionOwner`, plus the existing #357 reap/WaitDelay tests.
+
 **Intent Provenance & Conformance (`internal/pipeline/steps/intent_prompt.go`)**
 
 - Intent carries provenance: an explicit `axi run --intent` persists `Source==db.RunIntentSourceAgent` ("agent", score 1); a transcript match persists the agent name ("claude"/"codex"/...). The executor propagates it as `StepContext.IntentSource` alongside `UserIntent` (`executor.go`).

--- a/docs/src/content/docs/concepts/pipeline.md
+++ b/docs/src/content/docs/concepts/pipeline.md
@@ -38,7 +38,7 @@ The pipeline is opinionated so that "passed the gate" has a stable meaning:
 | 1 | **Intent** | Use supplied intent or infer it from recent local agent transcripts | n/a |
 | 2 | **Rebase** | Fetch fresh remote upstream and the configured branch target, then rebase your branch onto them | `3` |
 | 3 | **Review** | AI code review of your diff | `0` (requires approval) |
-| 4 | **Test** | Run baseline tests and gather evidence for available intent | `3` |
+| 4 | **Test** | Targeted local validation of the change and intent (not a full CI suite), plus evidence when intent is available | `3` |
 | 5 | **Document** | Update docs when needed and report unresolved gaps | initial pass |
 | 6 | **Lint** | Run lint/static analysis; shares the document step's initial housekeeping pass when no lint command is configured | `3` |
 | 7 | **Push** | Safely push the validated branch to the configured target | n/a |
@@ -76,7 +76,7 @@ See [Auto-Fix Loop](/no-mistakes/concepts/auto-fix/) for how the fix cycle works
 You can't reorder steps. You *can*:
 
 - Swap the agent, or configure an ordered fallback list, globally or per-repo.
-- Set explicit `commands.test`, `commands.lint`, `commands.format`.
+- Set explicit `commands.lint`, `commands.format`, and an optional **targeted** `commands.test` (local intent validation only; not a full CI suite).
 - Store test evidence locally by default or opt into committed in-repo evidence with `test.evidence.store_in_repo`.
 - Control auto-fix limits per step.
 - Ignore paths during review and documentation checks.

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -27,7 +27,7 @@ Testing prompts also ask agents to remove transient working-tree artifacts they 
 - Leave `agent: auto` if one good agent is already installed and you do not need repo-specific behavior.
 - Set a repo-level `agent` override when one codebase clearly works better with a different tool.
 - Use an ordered fallback list when you prefer one agent but want no-mistakes to try another if the first process is unavailable.
-- Set explicit `commands.test` and `commands.lint` if you want deterministic baseline command execution regardless of agent choice.
+- Set explicit `commands.lint` and a **targeted** `commands.test` if you want deterministic local baseline command execution regardless of agent choice; leave `commands.test` empty for agent-selected smallest relevant checks. Do not configure a complete-suite walk as local Test - remote CI owns broad regression.
 
 That last point matters: the agent helps fill in gaps, but explicit repo
 commands are still the strongest way to make the baseline gate predictable.

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -42,7 +42,7 @@ local.
 
 If you are not sure where to start, configure these in this order:
 
-1. Set `commands.test` and `commands.lint` in repo config so the gate runs the exact commands your repo expects.
+1. Set `commands.lint` (and a **targeted** `commands.test` only when you want a deterministic local baseline - not a full CI suite) so the gate runs the exact local checks your repo expects.
 2. Override `agent` per repo only when one codebase clearly works better with a different tool or fallback order.
 3. Tune `auto_fix` after you have seen how much automation you actually want.
 
@@ -60,10 +60,10 @@ The rest of this page covers only the cross-cutting rules that involve both file
 
 ## Explicit commands versus agent detection
 
-Explicit `commands.test` and `commands.lint` give you deterministic baseline behavior, while leaving either empty asks the configured agent to fill the gap: empty `commands.test` has the agent detect and run tests, and empty `commands.lint` folds lint into the document step's combined housekeeping pass.
+Explicit `commands.test` and `commands.lint` give you deterministic local baseline behavior, while leaving either empty asks the configured agent to fill the gap: empty `commands.test` has the agent select the smallest relevant tests under the targeted-validation contract (broad regression stays in remote CI), and empty `commands.lint` folds lint into the document step's combined housekeeping pass.
 An empty `commands.format` runs no separate formatter, so configure it explicitly when the push step must format agent changes.
 Either way, available user intent can trigger an evidence-oriented agent follow-up after a successful test baseline, and evidence stays in a temporary local directory unless the repo opts into `test.evidence.store_in_repo`.
-The [Repo Config Reference](/no-mistakes/reference/repo-config/) owns the exact per-command semantics, including command process lifetime and the `ignore_patterns` match rules.
+The [Repo Config Reference](/no-mistakes/reference/repo-config/) owns the exact per-command semantics (including that `commands.test` is targeted, not CI-parity), command process lifetime, and the `ignore_patterns` match rules.
 
 Before a new validation gate starts, its effective agent configuration must resolve to a runnable native agent or ACP runner; otherwise the gate fails before its first pipeline step, even when explicit commands are configured.
 Run `no-mistakes doctor` to check the global runner, and see [Choosing an Agent](/no-mistakes/guides/agents/) for how agent selection and fallback lists behave.

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -85,11 +85,14 @@ Follow-up review passes use the history to avoid re-reporting user-ignored findi
 
 ## Test
 
-Runs baseline tests and gathers evidence for the intended behavior.
+Runs **targeted** local validation of the change and requested intent, then gathers evidence for that intent.
+Local Test is never a repository-wide regression-suite substitute; broad regression is owned by remote CI and remains mandatory before a PR is ready.
+[`commands.test`](/no-mistakes/reference/repo-config/#commandstest) owns the configuration contract for any explicit baseline command.
 
 **Behavior:**
-- If `commands.test` is set in repo config: runs it first as a baseline via the platform shell (`sh -c` on POSIX, `cmd.exe /c` on Windows) and captures output. Non-zero exit produces `error` findings.
-- If `commands.test` is empty, or user intent is available after the baseline command passes: the agent validates the change with evidence-oriented tests or manual checks, returning structured findings with severity, description, and `action` (`no-op`, `auto-fix`, `ask-user`). For UI, HTML, CSS, browser, visual layout, or copy-placement changes, the agent attempts reviewer-visible visual evidence and explains in `testing_summary` when screenshots, images, videos, GIFs, or rendered HTML artifacts are not captured.
+- If `commands.test` is set in repo config: runs it first as a baseline via the platform shell (`sh -c` on POSIX, `cmd.exe /c` on Windows) and captures output. Non-zero exit produces `error` findings. Configure a **targeted** command here (see repo-config); do not treat this field as CI-parity complete-suite configuration.
+- If `commands.test` is empty, or user intent is available after the baseline command passes: the agent validates the change with the **smallest relevant** evidence-oriented tests or manual checks, returning structured findings with severity, description, and `action` (`no-op`, `auto-fix`, `ask-user`). Both the normal evidence agent and the Test-repair agent are instructed not to run the complete repository test suite; a generic driver instruction asking for broad or full-suite confirmation does not override that product boundary. For UI, HTML, CSS, browser, visual layout, or copy-placement changes, the agent attempts reviewer-visible visual evidence and explains in `testing_summary` when screenshots, images, videos, GIFs, or rendered HTML artifacts are not captured.
+- "Do not run everything" is not "run nothing": when no targeted check can establish the intent, the agent must write or improve a focused test, perform manual verification with evidence, or report a warning finding that sufficient targeted evidence is not possible.
 - The step records the exact tests and checks it exercised in a `tested` array, may include a short natural-language `testing_summary`, and includes an `artifacts` array for reviewer-visible evidence; `path` artifacts may be repository-relative paths or absolute paths under the temporary `no-mistakes-evidence/<runID>` directory, `url` artifacts must be externally visible, and `content` artifacts should be short logs or command output shown directly in the PR.
 - By default, evidence is stored under the temporary `no-mistakes-evidence/<runID>` directory. With `test.evidence.store_in_repo: true`, evidence is stored under `<test.evidence.dir>/<branch-slug>` inside the worktree, staged during push, and published with the branch. Unsafe, symlinked, or Git-ignored evidence directories fall back to temporary storage for that run.
 - Before finishing, test agents are instructed to remove transient working-tree artifacts they created, such as downloaded models, caches, build outputs, large binaries, or generated data directories, while preserving intentional source or test-file changes and evidence files under the dedicated evidence directory.
@@ -98,7 +101,7 @@ Runs baseline tests and gathers evidence for the intended behavior.
 
 **Approval:** test findings with `action: ask-user` pause for approval, including missing-evidence warnings for user intent. `action: auto-fix` findings stay eligible for the fix loop. `action: no-op` findings are informational only.
 
-**Auto-fix:** the agent receives the previous test findings plus any per-finding user notes, any selected user-authored findings from the TUI or AXI interface, and a sanitized history of prior rounds for that step, including earlier fix summaries and any findings the user left unselected in prior approval cycles, then tests run again.
+**Auto-fix:** the agent receives the previous test findings plus any per-finding user notes, any selected user-authored findings from the TUI or AXI interface, and a sanitized history of prior rounds for that step, including earlier fix summaries and any findings the user left unselected in prior approval cycles. Repair mode reproduces the specific failure, applies a root-cause fix, and re-runs only focused verification - not a complete-suite confirmation - then the step's configured baseline (if any) and evidence path run again.
 
 **Default auto-fix limit:** `3`.
 

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -24,7 +24,8 @@ agent: codex
 
 commands:
   lint: "golangci-lint run ./..."
-  test: "go test -race ./..."
+  # Targeted local validation only - not a full-repo CI-parity suite.
+  test: "go test ./internal/cli -run '^TestDoctor' -count=1"
   format: "gofmt -w ."
 
 ignore_patterns:
@@ -131,16 +132,20 @@ If the trusted commit or its present config file cannot be read and parsed, the 
 
 ### commands.test
 
-Explicit test command. Run via the platform shell - `sh -c` on POSIX, `cmd.exe /c` on Windows.
+Explicit **targeted** local test command. Run via the platform shell - `sh -c` on POSIX, `cmd.exe /c` on Windows.
 
 | | |
 |---|---|
 | Type | `string` |
-| Default | Empty (agent auto-detects tests and evidence checks) |
+| Default | Empty (agent selects the smallest relevant tests and evidence checks) |
+
+`commands.test` is local **targeted validation** of the change and requested intent, not a CI-parity repository-wide regression command.
+Broad regression belongs in remote CI and remains mandatory before a PR is ready; do not put a complete-suite walk here just to mirror CI.
+no-mistakes does not guess whether an arbitrary shell string is "too broad" - the contract is documented and dogfooded, not enforced with language- or filename-specific heuristics.
 
 When set, the test step runs this exact command first as the baseline and checks the exit code.
-When empty, the agent detects and runs relevant tests itself.
-When user intent is available, the agent may still run after a successful baseline command to gather evidence-oriented validation.
+When empty, the agent detects and runs the smallest relevant tests itself (and is instructed never to run the complete repository suite).
+When user intent is available, the agent may still run after a successful baseline command to gather evidence-oriented validation, still under the same targeted-validation contract.
 
 ### commands.lint
 

--- a/dogfood_test_contract_test.go
+++ b/dogfood_test_contract_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/config"
+)
+
+// Local Test is targeted validation of the requested intent. This repository
+// must not dogfood a complete-suite commands.test override (historically
+// go test -race ./...), which burned multi-hour local walks while remote CI
+// already owns the race-enabled full suite.
+func TestDogfoodConfig_NoBroadLocalTestCommand(t *testing.T) {
+	t.Parallel()
+
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := config.LoadRepo(root)
+	if err != nil {
+		t.Fatalf("LoadRepo: %v", err)
+	}
+	if got := strings.TrimSpace(cfg.Commands.Test); got != "" {
+		t.Fatalf("dogfood commands.test = %q, want empty so local Test stays agent-targeted; put broad regression in remote CI", got)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(root, ".no-mistakes.yaml"))
+	if err != nil {
+		t.Fatalf("read .no-mistakes.yaml: %v", err)
+	}
+	content := string(raw)
+	for _, forbid := range []string{
+		`test: "go test -race ./..."`,
+		`test: 'go test -race ./...'`,
+		`test: go test -race ./...`,
+	} {
+		if strings.Contains(content, forbid) {
+			t.Fatalf(".no-mistakes.yaml still configures broad local Test %q", forbid)
+		}
+	}
+}
+
+// commands.test contract ownership lives in repo-config.md: targeted local
+// validation, not CI-parity complete-suite configuration, and no brittle
+// shell-heuristics claiming to detect "broad" commands.
+func TestRepoConfigDocs_CommandsTestIsTargetedContract(t *testing.T) {
+	t.Parallel()
+
+	data, err := os.ReadFile(filepath.Join("docs", "src", "content", "docs", "reference", "repo-config.md"))
+	if err != nil {
+		t.Fatalf("read repo-config.md: %v", err)
+	}
+	content := string(data)
+	for _, want := range []string{
+		"### commands.test",
+		"targeted validation",
+		"not a CI-parity repository-wide regression command",
+		"Broad regression belongs in remote CI",
+		"does not guess whether an arbitrary shell string is \"too broad\"",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("repo-config.md commands.test contract missing %q", want)
+		}
+	}
+}
+
+// Remote CI must keep the complete race-enabled Go suite as the broad
+// regression owner after local Test stops duplicating it.
+func TestCIWorkflow_RetainsFullRaceSuiteAsBroadRegressionOwner(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join(".github", "workflows", "ci.yml"))
+	if err != nil {
+		t.Fatalf("read ci.yml: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "run: go test -race ./...") {
+		t.Fatal("CI workflow must still run go test -race ./... as the broad regression owner")
+	}
+	if !strings.Contains(content, "if: runner.os != 'Windows'") {
+		t.Fatal("CI workflow must keep the Unix race-test branch")
+	}
+}

--- a/internal/e2e/journey_test.go
+++ b/internal/e2e/journey_test.go
@@ -445,7 +445,7 @@ func cleanReviewScenario(t *testing.T) string {
         - "fakeagent: simulated test run"
       testing_summary: "simulated tests passed"
       artifacts: []
-  - match: "You are validating a code change by testing it. Examine the repository and run the appropriate tests yourself.\n\nContext:\n- branch: test-agent-new-test-file"
+  - match: "You are validating a code change by testing it. Examine the repository and run the smallest relevant tests yourself.\n\nContext:\n- branch: test-agent-new-test-file"
     text: "tests passed after adding a regression test"
     edits:
       - path: "agent_test.py"
@@ -459,13 +459,13 @@ func cleanReviewScenario(t *testing.T) string {
         - "fakeagent: simulated test run"
       testing_summary: "simulated tests passed"
       artifacts: []
-  - match: "You are validating a code change by testing it. Examine the repository and run the appropriate tests yourself.\n\nContext:\n- branch: test-malformed-structured-output"
+  - match: "You are validating a code change by testing it. Examine the repository and run the smallest relevant tests yourself.\n\nContext:\n- branch: test-malformed-structured-output"
     text: "tests found some issues"
     structured_raw: '{"summary":123}'
   - match: "Detect the linting and formatting tools for this project, run the relevant checks yourself, apply safe fixes, and verify the result.\n\nContext:\n- branch: lint-malformed-structured-output"
     text: "lint found some issues"
     structured_raw: '{"summary":123}'
-  - match: "You are validating a code change by testing it. Examine the repository and run the appropriate tests yourself.\n\nContext:\n- branch: test-agent-staged-new-test-file"
+  - match: "You are validating a code change by testing it. Examine the repository and run the smallest relevant tests yourself.\n\nContext:\n- branch: test-agent-staged-new-test-file"
     text: "tests passed after staging a regression test"
     edits:
       - path: "agent_staged_test.go"
@@ -479,7 +479,7 @@ func cleanReviewScenario(t *testing.T) string {
         - "fakeagent: simulated test run"
       testing_summary: "simulated tests passed"
       artifacts: []
-  - match: "You are validating a code change by testing it. Examine the repository and run the appropriate tests yourself."
+  - match: "You are validating a code change by testing it. Examine the repository and run the smallest relevant tests yourself."
     text: "tests passed with no evidence artifacts"
     structured:
       findings: []

--- a/internal/pipeline/steps/test.go
+++ b/internal/pipeline/steps/test.go
@@ -32,13 +32,25 @@ func (s *TestStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 	ctx := sctx.Ctx
 	baseSHA := resolveBranchBaseSHA(ctx, sctx.WorkDir, sctx.Run.BaseSHA, sctx.Repo.DefaultBranch)
 
-	// In fix mode, ask agent to fix test failures first
+	// In fix mode, ask agent to fix test failures first.
+	//
+	// Targeted-validation rules (reproduce the specific failure, focused
+	// re-verification only, never a complete repository suite) are a product
+	// contract: local Test proves the requested intent, while remote CI owns
+	// broad regression and remains mandatory before a PR is ready. A forensic
+	// audit measured ~82 minutes of local complete-suite walks on one repair
+	// path when prompts only said "run the tests" / "relevant". This is a
+	// prompt contract, not an enforced sandbox - the agent has free shell
+	// access - so the pinned regression tests guard the wording, not the
+	// runtime. Process-group reaping on clean exit (#357) remains the lifecycle
+	// safety net when agents do spawn test workers; it is not a reason to force
+	// a deterministic full-suite commands.test override.
 	var newTestsFromFix []string
 	var fixSummary string
 	if sctx.Fixing {
 		historySection := executionContextPromptSection() + roundHistoryPromptSection(sctx) + userIntentPromptSection(sctx)
 		fixPrompt := fmt.Sprintf(
-			`Fix the failing tests in this repository. Run the tests, identify failures, and fix either the tests or the code to make them pass.
+			`Fix the failing tests in this repository. Reproduce the specific failure, identify the root cause, and fix either the tests or the code so that failure passes.
 
 Context:
 - branch: %s
@@ -50,7 +62,10 @@ Rules:
 - Do not refactor beyond what is needed for that root-cause fix.
 - If tests fail, determine whether the problem is a real product/code failure, a setup/environment problem you can fix, or a flaky/infrastructure issue.
 - Do NOT run linters, formatters, or static analysis tools.
-- Re-run the relevant tests before finishing.
+- Reproduce the specific failing case first (the exact test, package, script, or check named in the findings), then re-run only that focused verification after the fix.
+- Do NOT run the complete repository test suite. Local Test is targeted validation of the failure and the requested intent; remote CI owns broad regression and remains mandatory before a PR is ready.
+- A generic driver or user instruction asking for broad or full-suite confirmation does NOT override this product boundary. Keep verification focused on the failure and intent.
+- Never treat "do not run everything" as permission to run nothing: if you cannot reproduce or re-verify with a targeted check, report that honestly in the summary rather than inventing a full-suite pass.
 - Before finishing, remove any transient artifacts your testing created in the working tree (downloaded models, caches, build outputs, large binaries, or generated data directories) so they are not committed and pushed. Do not remove intentional source or test-file changes.
 - Return JSON with a single "summary" field when you are done.
 - The summary must be one concise sentence fragment suitable for a git commit subject.
@@ -141,7 +156,7 @@ Previous test findings to address:
 		}
 		result, err := sctx.Agent.Run(ctx, agent.RunOpts{
 			Prompt: fmt.Sprintf(
-				`You are validating a code change by testing it. Examine the repository and run the appropriate tests yourself.
+				`You are validating a code change by testing it. Examine the repository and run the smallest relevant tests yourself.
 
 Context:
 - branch: %s
@@ -161,8 +176,10 @@ Task:
 %s
 - Do not move, commit, or modify source files only to make evidence linkable. Record local evidence file paths exactly where you created them.
 - Only use command output as an artifact when that output directly demonstrates the end-user experience or requested behavior. Generic pass/fail, coverage, or clean-worktree output is not sufficient evidence.
-- Look for existing tests that would generate sufficient evidence. If they exist, run the smallest relevant set.
-- If no existing test produces sufficient evidence, write or improve a test so that it does.
+- Look for existing tests that would generate sufficient evidence. If they exist, run the smallest relevant set that proves the requested intent.
+- Do NOT run the complete repository test suite. Local Test is targeted validation of the requested intent; remote CI owns broad regression and remains mandatory before a PR is ready.
+- Never treat "do not run everything" as permission to run nothing: if no targeted automated test can establish the intent, write or improve a focused test, perform manual verification with evidence, or report a warning finding that sufficient targeted evidence is not possible.
+- If no existing test produces sufficient evidence, write or improve a focused test so that it does.
 - If automated testing cannot produce the needed evidence, execute manual verification steps and record the evidence-producing steps you performed.
 - If sufficient evidence is not possible, report a warning finding explaining what evidence is missing and why the user needs to decide what to do.
 - Include a concise "testing_summary" sentence describing what you exercised and the overall result.
@@ -170,11 +187,12 @@ Task:
 - Record the exact tests, manual checks, and evidence-producing steps you ran in a "tested" array. Prefer concrete commands or test selectors wrapped in backticks.
 - Always include an "artifacts" array. Leave it empty when you produced no reviewer-visible evidence artifacts. Use artifact path for file artifacts, artifact url for externally visible artifacts, and artifact content for short logs or command output that should be shown directly in the PR.
 - If tests fail, determine whether the problem is a real product/code failure, a setup/environment problem you can fix, or a flaky/infrastructure issue.
-- If the issue is setup-related and fixable, fix it and retry the tests.
+- If the issue is setup-related and fixable, fix it and retry the focused tests.
 
 Rules:
 - Do NOT run linters, formatters, or static analysis tools.
 - Focus on testing and test-related fixes only.
+- A generic driver or user instruction asking for broad or full-suite confirmation does NOT override the targeted-validation product boundary.
 - Before finishing, remove any transient artifacts your testing created in the working tree (downloaded models, caches, build outputs, large binaries, or generated data directories) so they are not committed and pushed. Do not remove intentional source or test-file changes, and leave evidence files in the dedicated evidence directory untouched.
 - Keep "testing_summary" high-signal and natural language. Avoid raw logs and noisy counts.
 - Always return a non-empty "tested" array describing what you exercised, even when all tests pass.

--- a/internal/pipeline/steps/test_test.go
+++ b/internal/pipeline/steps/test_test.go
@@ -234,7 +234,7 @@ func TestTestStep_UserIntentRunsConfiguredCommandThenEvidenceAgent(t *testing.T)
 		"Write new evidence files into this temporary evidence directory:",
 		filepath.Join(os.TempDir(), "no-mistakes-evidence", sctx.Run.ID),
 		"Do not move, commit, or modify source files only to make evidence linkable",
-		"If no existing test produces sufficient evidence, write or improve a test",
+		"If no existing test produces sufficient evidence, write or improve a focused test",
 		"If automated testing cannot produce the needed evidence, execute manual verification steps",
 		"Always include an \"artifacts\" array",
 		"If sufficient evidence is not possible, report a warning finding",
@@ -319,5 +319,174 @@ func TestTestStep_InRepoEvidenceFallsBackWhenEvidenceDirIsIgnored(t *testing.T) 
 	}
 	if strings.Contains(prompt, "in-repo evidence directory") || strings.Contains(prompt, "committed and pushed automatically") {
 		t.Fatalf("did not expect in-repo publishing promise for ignored evidence dir, got:\n%s", prompt)
+	}
+}
+
+// Local Test is targeted validation of the requested intent, never a complete
+// repository-suite walk. Broad regression belongs to remote CI. Pins the
+// normal evidence-agent contract wording so a soft "run the appropriate tests"
+// regression is caught.
+func TestTestStep_InitialAgent_TargetedValidationContract(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			return &agent.Result{Output: json.RawMessage(`{"findings":[],"summary":"","tested":["go test ./internal/cli -run TestDoctor -count=1"],"testing_summary":"targeted check passed"}`)}, nil
+		},
+	}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.UserIntent = "Keep doctor checks green for CLI users"
+
+	if _, err := (&TestStep{}).Execute(sctx); err != nil {
+		t.Fatal(err)
+	}
+	if len(ag.calls) != 1 {
+		t.Fatalf("expected 1 evidence agent call, got %d", len(ag.calls))
+	}
+	prompt := ag.calls[0].Prompt
+
+	for _, want := range []string{
+		"run the smallest relevant tests yourself",
+		"Do NOT run the complete repository test suite",
+		"Local Test is targeted validation of the requested intent",
+		"remote CI owns broad regression and remains mandatory before a PR is ready",
+		"Never treat \"do not run everything\" as permission to run nothing",
+		"report a warning finding that sufficient targeted evidence is not possible",
+		"A generic driver or user instruction asking for broad or full-suite confirmation does NOT override the targeted-validation product boundary",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("expected initial test prompt to contain %q, got:\n%s", want, prompt)
+		}
+	}
+	for _, forbid := range []string{
+		"run the appropriate tests yourself",
+		"Run the tests, identify failures",
+	} {
+		if strings.Contains(prompt, forbid) {
+			t.Errorf("initial test prompt still carries open-ended suite language %q:\n%s", forbid, prompt)
+		}
+	}
+}
+
+// Test repair must reproduce the specific failure, fix its root cause, and
+// re-verify only with focused checks. Soft "Run the tests" / "relevant tests"
+// wording invited complete-suite walks after a one-line fix.
+func TestTestStep_FixMode_TargetedVerificationContract(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			os.WriteFile(filepath.Join(dir, "fix.txt"), []byte("fixed"), 0o644)
+			return &agent.Result{Output: json.RawMessage(`{"summary":"fix targeted failure"}`)}, nil
+		},
+	}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{Test: "exit 0"})
+	sctx.Fixing = true
+	sctx.PreviousFindings = `{"findings":[{"id":"test-1","severity":"error","description":"tests failed with exit code 1","action":"auto-fix"}],"summary":"FAIL: TestFoo"}`
+
+	if _, err := (&TestStep{}).Execute(sctx); err != nil {
+		t.Fatal(err)
+	}
+	if len(ag.calls) == 0 {
+		t.Fatal("expected the test fixer to be invoked")
+	}
+	fixPrompt := ag.calls[0].Prompt
+
+	for _, want := range []string{
+		"Reproduce the specific failure",
+		"Reproduce the specific failing case first",
+		"re-run only that focused verification after the fix",
+		"Do NOT run the complete repository test suite",
+		"Local Test is targeted validation of the failure and the requested intent",
+		"remote CI owns broad regression and remains mandatory before a PR is ready",
+		"A generic driver or user instruction asking for broad or full-suite confirmation does NOT override this product boundary",
+		"Never treat \"do not run everything\" as permission to run nothing",
+	} {
+		if !strings.Contains(fixPrompt, want) {
+			t.Errorf("expected test fixer prompt to contain %q, got:\n%s", want, fixPrompt)
+		}
+	}
+	for _, forbid := range []string{
+		"Run the tests, identify failures, and fix either the tests or the code to make them pass",
+		"Re-run the relevant tests before finishing",
+	} {
+		if strings.Contains(fixPrompt, forbid) {
+			t.Errorf("test fixer prompt still carries open-ended suite language %q:\n%s", forbid, fixPrompt)
+		}
+	}
+}
+
+// A driver/user instruction that asks for full-suite confirmation must still
+// be accompanied by the hard product boundary so the repair agent does not
+// treat that instruction as license to expand scope.
+func TestTestStep_FixMode_DriverFullSuiteInstructionDoesNotOverrideContract(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			os.WriteFile(filepath.Join(dir, "fix.txt"), []byte("fixed"), 0o644)
+			return &agent.Result{Output: json.RawMessage(`{"summary":"fix focused failure"}`)}, nil
+		},
+	}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{Test: "exit 0"})
+	sctx.Fixing = true
+	sctx.PreviousFindings = `{"findings":[{"id":"test-1","severity":"error","description":"tests failed with exit code 1","action":"auto-fix","user_instructions":"confirm the full suite path for this failure is green"}],"summary":"FAIL: TestFoo"}`
+
+	if _, err := (&TestStep{}).Execute(sctx); err != nil {
+		t.Fatal(err)
+	}
+	fixPrompt := ag.calls[0].Prompt
+	if !strings.Contains(fixPrompt, "confirm the full suite path for this failure is green") {
+		t.Fatalf("expected previous findings to still carry the driver instruction, got:\n%s", fixPrompt)
+	}
+	if !strings.Contains(fixPrompt, "A generic driver or user instruction asking for broad or full-suite confirmation does NOT override this product boundary") {
+		t.Fatalf("expected product boundary to outrank the driver full-suite instruction, got:\n%s", fixPrompt)
+	}
+	if !strings.Contains(fixPrompt, "Do NOT run the complete repository test suite") {
+		t.Fatalf("expected explicit no-full-suite rule in repair prompt, got:\n%s", fixPrompt)
+	}
+}
+
+// Honest failure reporting when no targeted check can establish intent must
+// remain mandatory; the no-full-suite rule must not collapse into "skip tests".
+func TestTestStep_InitialAgent_NoTargetedEvidenceRequiresHonestFinding(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+			return &agent.Result{Output: json.RawMessage(`{"findings":[{"severity":"warning","description":"no targeted test can prove the intent","action":"ask-user"}],"summary":"missing evidence","tested":["manual review of changed packages"],"testing_summary":"could not produce targeted evidence"}`)}, nil
+		},
+	}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.UserIntent = "Prove the checkout success screen works end-to-end"
+
+	outcome, err := (&TestStep{}).Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !outcome.NeedsApproval {
+		t.Fatal("expected missing targeted evidence to require approval")
+	}
+	prompt := ag.calls[0].Prompt
+	for _, want := range []string{
+		"Never treat \"do not run everything\" as permission to run nothing",
+		"write or improve a focused test",
+		"perform manual verification with evidence",
+		"report a warning finding that sufficient targeted evidence is not possible",
+		"If sufficient evidence is not possible, report a warning finding",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("expected no-targeted-evidence guidance %q in prompt:\n%s", want, prompt)
+		}
 	}
 }


### PR DESCRIPTION
## Intent

Correct no-mistakes so local Test is always targeted validation of the requested intent, never a repository-wide regression suite. Broad regression stays mandatory in remote CI.

Measured evidence from Firstmate audits: one run spent ~82 minutes across three local complete-suite walks; PR #453 only tightened Review repair wording while Test/Lint were never covered despite a coverage claim; the old Firstmate full-suite commands.test workaround was for an agent process-group leak that no-mistakes #357/v1.32.2 already fixed.

Required product boundary: both the normal Test agent and Test-repair agent must prominently forbid complete-suite runs and choose the smallest relevant tests plus end-user-aligned evidence; repair must reproduce the specific failure, fix root cause, and re-verify only with focused checks; a generic driver instruction asking for full-suite confirmation must not override that boundary; never turn "do not run everything" into "run nothing" - report honestly when no targeted evidence can establish intent.

Config contract: commands.test is targeted local validation, not CI-parity regression; no language/framework/filename heuristics guessing whether a shell command is broad. Dogfood by removing this repo's go test -race ./... local Test override while keeping the full race-enabled suite in remote CI. Preserve #357 clean/error-exit process-group reaping and Unix WaitDelay. Scope stays on Test unless one coherent shared change is required; do not redesign the pipeline.

Deliver focused regressions for initial Test, Test repair, driver scope-expansion attempts, configured-command contract/docs, no-targeted-evidence honesty, and retention of full CI coverage; update authoritative docs/project memory with one owner per fact.

## What Changed

- Constrains normal Test and Test-repair agents to the smallest intent-focused checks, end-user-aligned evidence, and honest reporting when targeted validation is unavailable.
- Defines `commands.test` as a targeted local baseline, removes this repository’s full-suite dogfood override, and keeps broad race-enabled regression in remote CI.
- Updates the Test contract documentation and adds focused prompt, configuration, CI-retention, and end-to-end regressions.

## Risk Assessment

✅ Low: The change is well-bounded and consistently establishes targeted local Test validation while retaining broad race-enabled regression in remote CI.

## Testing

The supplied full race baseline, focused normal and repair Test contracts, driver-override and missing-evidence behavior, configured-command/docs/CI ownership guards, process cleanup regressions, and a real Codex daemon-to-agent pipeline journey all passed; the reviewer-visible transcript and prompt evidence are recorded in the attached report.

- Evidence: [Targeted Test validation report](https://github.com/kunchenguid/no-mistakes/blob/082c0f96b1e4ba82631f6232fd3f0c86f2fc4e0b/.no-mistakes/evidence/fm/nm-targeted-test-step/targeted-test-validation.md)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./...`
- <code>Baseline supplied by the test driver: `go test -race ./...`</code>
- `go test ./internal/pipeline/steps -run '^(TestTestStep_(UserIntentRunsConfiguredCommandThenEvidenceAgent|InitialAgent_TargetedValidationContract|FixMode_TargetedVerificationContract|FixMode_DriverFullSuiteInstructionDoesNotOverrideContract|InitialAgent_NoTargetedEvidenceRequiresHonestFinding))$' -count=1 -v`
- `go test . -run '^(TestDogfoodConfig_NoBroadLocalTestCommand|TestRepoConfigDocs_CommandsTestIsTargetedContract|TestCIWorkflow_RetainsFullRaceSuiteAsBroadRegressionOwner)$' -count=1 -v`
- `go test ./internal/agent ./internal/shellenv -run '^(TestCodexAgent_Run_ReapsLeakedGrandchildOnCleanExit|TestNativeAgentCommand_WaitDelayClosesEscapedPipeHolder|TestCombinedOutputShellCommand_WaitDelayBoundsEscapedPipeHolder)$' -count=1 -v`
- `go test -tags=e2e ./internal/e2e -run '^TestUserJourney/codex$' -count=1 -v`
- <code>Inspected `.no-mistakes.yaml` through the config regression and confirmed `.github/workflows/ci.yml` retains Unix `go test -race ./...`.</code>
- `Recorded the runtime prompt contracts and end-to-end pipeline transcript in the evidence report.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
