### PR TITLE
fix(pipeline): escape bare HTML-like tags in PR intent text

### DIFF
--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 	"unicode/utf8"
 
@@ -940,11 +941,58 @@ func prependIntentSection(body string, sctx *pipeline.StepContext) string {
 	if cleaned == "" {
 		return body
 	}
-	section := "## Intent\n\n" + cleaned
+	section := "## Intent\n\n" + escapeBareAngleBrackets(cleaned)
 	if strings.TrimSpace(body) == "" {
 		return section
 	}
 	return section + "\n\n" + body
+}
+
+var inlineCodeSpanRe = regexp.MustCompile("`[^`\n]*`")
+
+// escapeBareAngleBrackets HTML-escapes "<" and ">" in text so a stray
+// HTML-like tag (e.g. a literal <select> pasted into free-form intent text)
+// cannot be interpreted as real HTML by GitHub's markdown renderer, which
+// otherwise swallows every later heading and paragraph break into an
+// unclosed tag. Angle brackets already inside an inline code span or a
+// fenced code block are left untouched, since those already render as
+// literal text.
+func escapeBareAngleBrackets(text string) string {
+	lines := strings.Split(text, "\n")
+	inFence := false
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
+		lines[i] = escapeAngleBracketsOutsideCodeSpans(line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func escapeAngleBracketsOutsideCodeSpans(line string) string {
+	matches := inlineCodeSpanRe.FindAllStringIndex(line, -1)
+	if len(matches) == 0 {
+		return escapeAngleBrackets(line)
+	}
+	var b strings.Builder
+	last := 0
+	for _, m := range matches {
+		b.WriteString(escapeAngleBrackets(line[last:m[0]]))
+		b.WriteString(line[m[0]:m[1]])
+		last = m[1]
+	}
+	b.WriteString(escapeAngleBrackets(line[last:]))
+	return b.String()
+}
+
+func escapeAngleBrackets(s string) string {
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	return s
 }
 
 func fallbackPRContent(sctx *pipeline.StepContext, branch, commitLog, riskLine, testingMD, pipelineMD string, bodyLimit int) prContent {

--- a/internal/pipeline/steps/pr_test.go
+++ b/internal/pipeline/steps/pr_test.go
@@ -1493,6 +1493,43 @@ func TestPRStep_OmitsIntentSectionWhenIntentEmpty(t *testing.T) {
 	}
 }
 
+func TestPrependIntentSection_EscapesBareHTMLLikeTags(t *testing.T) {
+	t.Parallel()
+	// Regression: https://github.com/jbb-codes/expense-tracking-system/pull/11
+	// rendered as one unstructured block because the intent text contained a
+	// bare, unclosed-looking <select> that GitHub's markdown renderer treated
+	// as literal HTML, swallowing every later heading into the tag.
+	sctx := &pipeline.StepContext{UserIntent: "Add a <select> with <option> entries for the category dropdown"}
+
+	got := prependIntentSection("## What Changed\n\n- add dropdown", sctx)
+
+	if strings.Contains(got, "<select>") || strings.Contains(got, "<option>") {
+		t.Fatalf("expected bare HTML-like tags to be escaped, got:\n%s", got)
+	}
+	if !strings.Contains(got, "&lt;select&gt;") || !strings.Contains(got, "&lt;option&gt;") {
+		t.Fatalf("expected escaped tag entities in intent section, got:\n%s", got)
+	}
+	intentIdx := strings.Index(got, "## Intent")
+	whatChangedIdx := strings.Index(got, "## What Changed")
+	if intentIdx < 0 || whatChangedIdx < 0 || intentIdx > whatChangedIdx {
+		t.Fatalf("expected ## Intent before ## What Changed, got:\n%s", got)
+	}
+}
+
+func TestPrependIntentSection_PreservesBacktickWrappedTags(t *testing.T) {
+	t.Parallel()
+	sctx := &pipeline.StepContext{UserIntent: "Style the `<select>` element consistently with `<input>`"}
+
+	got := prependIntentSection("## What Changed\n\n- style dropdown", sctx)
+
+	if !strings.Contains(got, "`<select>`") || !strings.Contains(got, "`<input>`") {
+		t.Fatalf("expected backtick-wrapped tags to survive unescaped, got:\n%s", got)
+	}
+	if strings.Contains(got, "&lt;") {
+		t.Fatalf("expected no escaping inside existing code spans, got:\n%s", got)
+	}
+}
+
 func TestPRStep_StripsAgentEmittedIntentBeforePrepend(t *testing.T) {
 	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)


### PR DESCRIPTION
## Intent

Developer (via autonomous crewmate agent) tasked fixing a bug where PR descriptions generated by the no-mistakes pipeline could render as unstructured text on GitHub: a user-supplied `--intent` string containing raw, unescaped HTML-like tags (e.g. `<select>`, `<option>`) got spliced verbatim into the PR body's `## Intent` section, causing GitHub's markdown renderer to treat them as literal HTML and collapse the document's structure. Root cause was identified as `cleanedUserIntent` (intent_prompt.go) sanitizing/redacting the intent text but never escaping stray angle-bracket sequences before `prependIntentSection` (pr.go) inserted it into the PR body. Requirements: follow TDD (write a failing regression test reproducing the bug first, add it under `internal/pipeline/steps/`), then implement a minimal fix — an escaping pass over bare `<...>` sequences outside existing code spans/fences, mirroring the existing `html.EscapeString` pattern already used in `prsummary.go` rather than inventing a new mechanism. Scope was explicitly constrained to the intent-splicing path only, not the agent-drafted "What Changed" section, and no unrelated PR-body assembly code was to be refactored. The agent implemented `escapeBareAngleBrackets` in pr.go, added regression tests, verified tests/lint/build passed, committed on branch `fm/nm-1-escape-html-in-pr-body`, then ran the no-mistakes validation pipeline; a push permission gap was resolved by the developer providing a fork URL (https://github.com/jbb-codes/no-mistakes.git) to route the push through.

## What Changed

- Added `escapeBareAngleBrackets` in `internal/pipeline/steps/pr.go`, which escapes stray `<...>` sequences (e.g. raw `<select>`/`<option>` tags) in user-supplied intent text before it is spliced into the PR body's `## Intent` section, preventing GitHub's markdown renderer from interpreting them as literal HTML and collapsing the document structure.
- Applied the escaping pass in `prependIntentSection`, scoped to the intent-splicing path only (no changes to the agent-drafted "What Changed" section or other PR-body assembly code).
- Added regression tests in `internal/pipeline/steps/pr_test.go` covering intent text with unescaped HTML-like tags.

## Risk Assessment

✅ Low: Small, well-scoped escaping fix confined to prependIntentSection with regression tests covering both the escape case and code-span preservation; no other code paths touched.

## Testing

<code>All targeted pr.go tests pass including the two new regression tests (TestPrependIntentSection_EscapesBareHTMLLikeTags, TestPrependIntentSection_PreservesBacktickWrappedTags); a manual render of the PR body with a raw `&lt;select&gt;`/`&lt;option&gt;` intent string confirms the fix produces escaped entities and preserves markdown heading structure end-to-end, matching the intended bug fix.</code>

<details>
<summary>Evidence: Rendered PR body with escaped intent tags</summary>

```text
Rendered PR body produced by prependIntentSection() with a user --intent
string containing raw HTML-like tags "<select>" / "<option>":

----BEGIN RENDERED PR BODY----
## Intent

Add a &lt;select&gt; with &lt;option&gt; entries for the category dropdown

## What Changed

- add dropdown menu
- wire onChange handler
----END RENDERED PR BODY----

Tags are escaped to &lt;select&gt; / &lt;option&gt; so GitHub's markdown
renderer treats them as literal text instead of unclosed HTML, preserving
the ## Intent / ## What Changed heading structure.

Captured by temporarily adding a demo test (prependIntentSection call) in
internal/pipeline/steps, running `go test -run TestZZDemoRenderedPRBody -v`,
then removing the temp file (worktree left clean, git status confirmed empty).
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/pipeline/steps/... -run 'TestPrependIntentSection|TestPRStep' -v`
- `manual: temporary test invoking prependIntentSection() with UserIntent containing raw <select>/<option> tags, printed rendered body, confirmed escaping, then removed temp file (git status clean after)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
