### PR TITLE
fix(git): copy effective git identity into worktrees

### DIFF
--- a/internal/cli/helpers_test.go
+++ b/internal/cli/helpers_test.go
@@ -92,6 +92,12 @@ func TestMain(m *testing.M) {
 	_ = os.Setenv("HOME", home)
 	_ = os.Setenv("NO_MISTAKES_TELEMETRY", "off")
 	_ = os.Setenv("NO_MISTAKES_NO_UPDATE_CHECK", "1")
+	// Tests that start a real daemon poll for it to become responsive. The
+	// production default (5s) is too tight for loaded CI runners (macOS in
+	// particular has been seen taking ~6s), so give the package a generous
+	// default. Individual tests that assert on a short timeout still override
+	// this via t.Setenv.
+	_ = os.Setenv("NM_TEST_DAEMON_START_TIMEOUT", "60s")
 
 	code := m.Run()
 

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -675,7 +675,7 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 		trackStartFailure("create_worktree")
 		return "", fmt.Errorf("create worktree: %w", err)
 	}
-	if err := git.CopyLocalUserIdentity(ctx, repo.WorkingPath, wtDir); err != nil {
+	if err := git.CopyEffectiveUserIdentity(ctx, repo.WorkingPath, wtDir); err != nil {
 		m.db.UpdateRunError(run.ID, fmt.Sprintf("configure worktree git identity: %s", err))
 		trackStartFailure("configure_worktree_identity")
 		return "", fmt.Errorf("configure worktree git identity: %w", err)

--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -236,11 +236,10 @@ func TestPushReceivedCopiesEffectiveConditionalGitIdentity(t *testing.T) {
 	// Match the canonical git dir path. Git resolves the gitdir to its real path
 	// before matching includeIf "gitdir:" (symlinks on macOS: /var -> /private/var;
 	// 8.3 short names on Windows: RUNNER~1 -> runneradmin), so build the pattern
-	// from the resolved path or the condition never matches on those platforms.
-	gitDir, err := filepath.EvalSymlinks(filepath.Join(repo.WorkingPath, ".git"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	// from git's own reported git dir. Go's filepath.EvalSymlinks diverges from
+	// git's resolution on Windows (drive-letter case, short-name handling), so
+	// asking git for --absolute-git-dir is the only form guaranteed to match.
+	gitDir := gitOutput(t, repo.WorkingPath, "rev-parse", "--absolute-git-dir")
 	globalConfig := fmt.Sprintf("[includeIf \"gitdir:%s\"]\n\tpath = %s\n", filepath.ToSlash(gitDir), filepath.ToSlash(includePath))
 	if err := os.WriteFile(globalPath, []byte(globalConfig), 0o644); err != nil {
 		t.Fatal(err)

--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -233,7 +233,15 @@ func TestPushReceivedCopiesEffectiveConditionalGitIdentity(t *testing.T) {
 		t.Fatal(err)
 	}
 	globalPath := filepath.Join(t.TempDir(), "gitconfig")
-	globalConfig := fmt.Sprintf("[includeIf \"gitdir:%s\"]\n\tpath = %s\n", filepath.ToSlash(filepath.Join(repo.WorkingPath, ".git")), filepath.ToSlash(includePath))
+	// Match the canonical git dir path. Git resolves the gitdir to its real path
+	// before matching includeIf "gitdir:" (symlinks on macOS: /var -> /private/var;
+	// 8.3 short names on Windows: RUNNER~1 -> runneradmin), so build the pattern
+	// from the resolved path or the condition never matches on those platforms.
+	gitDir, err := filepath.EvalSymlinks(filepath.Join(repo.WorkingPath, ".git"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	globalConfig := fmt.Sprintf("[includeIf \"gitdir:%s\"]\n\tpath = %s\n", filepath.ToSlash(gitDir), filepath.ToSlash(includePath))
 	if err := os.WriteFile(globalPath, []byte(globalConfig), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -194,6 +195,84 @@ type notifyBlockStep struct {
 	started chan<- string
 }
 
+type capturedGitIdentity struct {
+	name  string
+	email string
+}
+
+type captureGitIdentityStep struct {
+	identity chan<- capturedGitIdentity
+}
+
+func (s *captureGitIdentityStep) Name() types.StepName { return types.StepReview }
+func (s *captureGitIdentityStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, error) {
+	name, err := git.Run(sctx.Ctx, sctx.WorkDir, "config", "--get", "user.name")
+	if err != nil {
+		return nil, err
+	}
+	email, err := git.Run(sctx.Ctx, sctx.WorkDir, "config", "--get", "user.email")
+	if err != nil {
+		return nil, err
+	}
+	s.identity <- capturedGitIdentity{name: name, email: email}
+	return &pipeline.StepOutcome{}, nil
+}
+
+func TestPushReceivedCopiesEffectiveConditionalGitIdentity(t *testing.T) {
+	identities := make(chan capturedGitIdentity, 1)
+	p, d := startTestDaemonWithSteps(t, func() []pipeline.Step {
+		return []pipeline.Step{&captureGitIdentityStep{identity: identities}}
+	})
+
+	repo, headSHA := setupTestGitRepo(t, p, d, "conditional-identity-repo")
+	gitCmd(t, repo.WorkingPath, "config", "--local", "--unset", "user.name")
+	gitCmd(t, repo.WorkingPath, "config", "--local", "--unset", "user.email")
+
+	includePath := filepath.Join(t.TempDir(), "identity.gitconfig")
+	if err := os.WriteFile(includePath, []byte("[user]\n\tname = Conditional User\n\temail = conditional@example.com\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	globalPath := filepath.Join(t.TempDir(), "gitconfig")
+	globalConfig := fmt.Sprintf("[includeIf \"gitdir:%s\"]\n\tpath = %s\n", filepath.ToSlash(filepath.Join(repo.WorkingPath, ".git")), filepath.ToSlash(includePath))
+	if err := os.WriteFile(globalPath, []byte(globalConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GIT_CONFIG_GLOBAL", globalPath)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+
+	client, err := ipc.Dial(p.Socket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	var result ipc.PushReceivedResult
+	if err := client.Call(ipc.MethodPushReceived, &ipc.PushReceivedParams{
+		Gate: p.RepoDir(repo.ID),
+		Ref:  "refs/heads/main",
+		Old:  "0000000000000000000000000000000000000000",
+		New:  headSHA,
+	}, &result); err != nil {
+		t.Fatal(err)
+	}
+
+	var identity capturedGitIdentity
+	select {
+	case identity = <-identities:
+	case <-time.After(3 * time.Second):
+		t.Fatal("pipeline did not report its Git identity")
+	}
+	if identity.name != "Conditional User" {
+		t.Fatalf("pipeline user.name = %q, want %q", identity.name, "Conditional User")
+	}
+	if identity.email != "conditional@example.com" {
+		t.Fatalf("pipeline user.email = %q, want %q", identity.email, "conditional@example.com")
+	}
+	if run := waitForRunTerminalState(t, d, result.RunID); run.Status != types.RunCompleted {
+		t.Fatalf("run status = %q, want %q", run.Status, types.RunCompleted)
+	}
+}
+
 func (s *notifyBlockStep) Name() types.StepName { return s.name }
 
 func (s *notifyBlockStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, error) {
@@ -225,7 +304,7 @@ func waitForStartedBranch(t *testing.T, started <-chan string, branch string) {
 // creation and git-identity setup concurrently. All runs share one gate bare
 // repo, so writing identity with `git config --local` (which targets the bare's
 // shared config) made the two startups race on <bare>/config.lock and fail one
-// run with "could not lock config file ...: File exists". CopyLocalUserIdentity
+// run with "could not lock config file ...: File exists". CopyEffectiveUserIdentity
 // now writes per-worktree, so the startups no longer contend. The race window
 // is during synchronous startRun, so a failure surfaces directly as the
 // push_received call's error. macOS-only in practice (Linux file locking and

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -527,8 +527,10 @@ func CommitAll(ctx context.Context, dir, message string) error {
 	return err
 }
 
-// CopyLocalUserIdentity copies local user.name and user.email from srcDir into
-// dstDir. Missing values in srcDir are ignored.
+// CopyEffectiveUserIdentity copies the effective user.name and user.email from
+// srcDir into dstDir. This honors Git's normal config precedence, including
+// conditional includes and repository-local overrides. Missing values in
+// srcDir are ignored.
 //
 // The write into dstDir uses per-worktree scope (`git config --worktree`) when
 // the repository has worktree config enabled. dstDir is typically a linked
@@ -539,9 +541,9 @@ func CommitAll(ctx context.Context, dir, message string) error {
 // config: File exists". Writing per-worktree puts each run's identity in its own
 // <bare>/worktrees/<id>/config.worktree, so concurrent startups never contend.
 // Older Git without `--worktree` support falls back to `--local`.
-func CopyLocalUserIdentity(ctx context.Context, srcDir, dstDir string) error {
+func CopyEffectiveUserIdentity(ctx context.Context, srcDir, dstDir string) error {
 	for _, key := range []string{"user.name", "user.email"} {
-		value, err := Run(ctx, srcDir, "config", "--local", "--get", "--default", "", key)
+		value, err := Run(ctx, srcDir, "config", "--get", "--default", "", key)
 		if err != nil {
 			return err
 		}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -138,7 +139,7 @@ func TestRemoveRemote(t *testing.T) {
 	}
 }
 
-func TestCopyLocalUserIdentity(t *testing.T) {
+func TestCopyEffectiveUserIdentityFromLocalConfig(t *testing.T) {
 	ctx := context.Background()
 	src := initTestRepo(t)
 	dst := initTestRepo(t)
@@ -146,8 +147,8 @@ func TestCopyLocalUserIdentity(t *testing.T) {
 	run(t, dst, "git", "config", "--local", "--unset", "user.name")
 	run(t, dst, "git", "config", "--local", "--unset", "user.email")
 
-	if err := CopyLocalUserIdentity(ctx, src, dst); err != nil {
-		t.Fatalf("CopyLocalUserIdentity failed: %v", err)
+	if err := CopyEffectiveUserIdentity(ctx, src, dst); err != nil {
+		t.Fatalf("CopyEffectiveUserIdentity failed: %v", err)
 	}
 
 	if got := run(t, dst, "git", "config", "--local", "--get", "user.name"); got != "Test" {
@@ -155,6 +156,34 @@ func TestCopyLocalUserIdentity(t *testing.T) {
 	}
 	if got := run(t, dst, "git", "config", "--local", "--get", "user.email"); got != "test@test.com" {
 		t.Fatalf("user.email = %q, want %q", got, "test@test.com")
+	}
+}
+
+func TestCopyEffectiveUserIdentityUsesConditionalConfig(t *testing.T) {
+	ctx := context.Background()
+	src := initTestRepo(t)
+	dst := initTestRepo(t)
+
+	run(t, src, "git", "config", "--local", "--unset", "user.name")
+	run(t, src, "git", "config", "--local", "--unset", "user.email")
+	run(t, dst, "git", "config", "--local", "--unset", "user.name")
+	run(t, dst, "git", "config", "--local", "--unset", "user.email")
+
+	includePath := filepath.Join(t.TempDir(), "identity.gitconfig")
+	writeFile(t, includePath, "[user]\n\tname = Conditional User\n\temail = conditional@example.com\n")
+	globalPath := filepath.Join(t.TempDir(), "gitconfig")
+	writeFile(t, globalPath, fmt.Sprintf("[includeIf \"gitdir:%s\"]\n\tpath = %s\n", filepath.ToSlash(filepath.Join(src, ".git")), filepath.ToSlash(includePath)))
+	t.Setenv("GIT_CONFIG_GLOBAL", globalPath)
+
+	if err := CopyEffectiveUserIdentity(ctx, src, dst); err != nil {
+		t.Fatalf("CopyEffectiveUserIdentity failed: %v", err)
+	}
+
+	if got := run(t, dst, "git", "config", "--local", "--get", "user.name"); got != "Conditional User" {
+		t.Fatalf("user.name = %q, want %q", got, "Conditional User")
+	}
+	if got := run(t, dst, "git", "config", "--local", "--get", "user.email"); got != "conditional@example.com" {
+		t.Fatalf("user.email = %q, want %q", got, "conditional@example.com")
 	}
 }
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -175,11 +175,10 @@ func TestCopyEffectiveUserIdentityUsesConditionalConfig(t *testing.T) {
 	// Match the canonical git dir path. Git resolves the gitdir to its real path
 	// before matching includeIf "gitdir:" (symlinks on macOS: /var -> /private/var;
 	// 8.3 short names on Windows: RUNNER~1 -> runneradmin), so build the pattern
-	// from the resolved path or the condition never matches on those platforms.
-	gitDir, err := filepath.EvalSymlinks(filepath.Join(src, ".git"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	// from git's own reported git dir. Go's filepath.EvalSymlinks diverges from
+	// git's resolution on Windows (drive-letter case, short-name handling), so
+	// asking git for --absolute-git-dir is the only form guaranteed to match.
+	gitDir := run(t, src, "git", "rev-parse", "--absolute-git-dir")
 	writeFile(t, globalPath, fmt.Sprintf("[includeIf \"gitdir:%s\"]\n\tpath = %s\n", filepath.ToSlash(gitDir), filepath.ToSlash(includePath)))
 	t.Setenv("GIT_CONFIG_GLOBAL", globalPath)
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -172,7 +172,15 @@ func TestCopyEffectiveUserIdentityUsesConditionalConfig(t *testing.T) {
 	includePath := filepath.Join(t.TempDir(), "identity.gitconfig")
 	writeFile(t, includePath, "[user]\n\tname = Conditional User\n\temail = conditional@example.com\n")
 	globalPath := filepath.Join(t.TempDir(), "gitconfig")
-	writeFile(t, globalPath, fmt.Sprintf("[includeIf \"gitdir:%s\"]\n\tpath = %s\n", filepath.ToSlash(filepath.Join(src, ".git")), filepath.ToSlash(includePath)))
+	// Match the canonical git dir path. Git resolves the gitdir to its real path
+	// before matching includeIf "gitdir:" (symlinks on macOS: /var -> /private/var;
+	// 8.3 short names on Windows: RUNNER~1 -> runneradmin), so build the pattern
+	// from the resolved path or the condition never matches on those platforms.
+	gitDir, err := filepath.EvalSymlinks(filepath.Join(src, ".git"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, globalPath, fmt.Sprintf("[includeIf \"gitdir:%s\"]\n\tpath = %s\n", filepath.ToSlash(gitDir), filepath.ToSlash(includePath)))
 	t.Setenv("GIT_CONFIG_GLOBAL", globalPath)
 
 	if err := CopyEffectiveUserIdentity(ctx, src, dst); err != nil {


### PR DESCRIPTION
## Intent

Make linked worktrees inherit the repository's effective Git user identity, including includeIf-based identity, so daemon-created commits and rebases use the same author configuration as the source repository while preserving existing behavior.

## What Changed

- Renamed `git.CopyLocalUserIdentity` to `git.CopyEffectiveUserIdentity` and switched its `user.name`/`user.email` lookup from `git config --local --get` to `git config --get`, so it now resolves the repository's effective identity through normal config precedence (including `includeIf` conditional includes and local overrides) rather than only repo-local values.
- Updated `RunManager.startRun` to call the effective-identity copy when provisioning a linked worktree, so daemon-created commits and rebases author with the same identity as the source repository.

## Risk Assessment

✅ Low: A one-line, well-tested change that drops --local so worktrees inherit the source repo's effective (includeIf-aware) git identity, preserving prior behavior when local config is set and fully satisfying the stated intent.

## Testing

Ran the targeted git and daemon unit/integration tests for the identity-copy change (all pass, including the new includeIf-conditional cases and the preserved concurrency regression), then reproduced the end-user scenario manually: an includeIf-based identity that is invisible to `git config --local` (what the old code read) but resolved by `git config --get` (what the fix reads), copied into a linked worktree via per-worktree scope, producing a commit correctly authored by the inherited work identity. This is a git/daemon behavioral change with no UI surface, so evidence is a CLI transcript rather than a screenshot. Overall result: intent satisfied and existing behavior preserved.

<details>
<summary>Evidence: End-to-end includeIf identity → worktree commit transcript</summary>

<code>=== 1. Source repo has NO repo-local user identity ===&#10;git config --local --get user.name =&gt; &lt;unset&gt;&#10;=&gt; the OLD CopyLocalUserIdentity (config --local) would copy NOTHING&#10;&#10;=== 2. Effective identity resolves via includeIf — what CopyEffectiveUserIdentity reads (config --get) ===&#10;user.name =&gt; Work Identity&#10;user.email =&gt; work@example.com&#10;&#10;=== 3. Daemon creates a linked worktree; copies EFFECTIVE identity in (per-worktree scope) ===&#10;worktree user.name =&gt; Work Identity&#10;worktree user.email =&gt; work@example.com&#10;&#10;=== 4. Commit created in the worktree carries the inherited identity ===&#10;Author =&gt; Work Identity &lt;work@example.com&gt;</code>

```text
=== 1. Source repo has NO repo-local user identity ===
  git config --local --get user.name => <unset>
  => the OLD CopyLocalUserIdentity (config --local) would copy NOTHING

=== 2. Effective identity resolves via includeIf — what CopyEffectiveUserIdentity reads (config --get) ===
  user.name  => Work Identity
  user.email => work@example.com

=== 3. Daemon creates a linked worktree; copies EFFECTIVE identity in (per-worktree scope) ===
  worktree user.name  => Work Identity
  worktree user.email => work@example.com

=== 4. Commit created in the worktree carries the inherited identity ===
  Author => Work Identity <work@example.com>
```
</details>
<details>
<summary>Evidence: Daemon push→pipeline test proving effective identity reaches the worktree step</summary>

```text
=== RUN TestPushReceivedCopiesEffectiveConditionalGitIdentity
... pipeline completed run_id=01KY5RZBSDFH3QG2WE4MM3NW6E
--- PASS: TestPushReceivedCopiesEffectiveConditionalGitIdentity (0.56s)
PASS
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`go test -race ./internal/git/ -run TestCopyEffectiveUserIdentity -v` — both the local-config and includeIf-conditional cases pass</code>
- <code>`go test -race ./internal/daemon/ -run TestPushReceivedCopiesEffectiveConditionalGitIdentity -v` — full push→pipeline path confirms a worktree step observes `Conditional User &lt;conditional@example.com&gt;` resolved via includeIf, run completes</code>
- <code>`go test -race ./internal/daemon/ -run TestPushReceivedConcurrentDifferentBranchRunsAvoidSharedConfigLock` — preserved existing per-worktree config-lock concurrency behavior</code>
- <code>Manual CLI repro: created a repo with no `--local` identity but an `includeIf gitdir:` global config, showed `git config --local` returns unset (old behavior copied nothing) while `git config --get` resolves the conditional identity, copied it into a linked worktree per-worktree, and confirmed a commit is authored by `Work Identity &lt;work@example.com&gt;`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>



## Relationship to #521

This PR implements the Git-authorship half of #521. Rather than storing `user.name` and `user.email` in a forge execution profile, it reuses the repository effective Git configuration—including `includeIf` and normal precedence—and copies the resolved identity into each daemon-created worktree. PR #548 provides the complementary repository-scoped forge-authentication routing. The rationale for keeping these ownership boundaries separate is documented in [the issue discussion](https://github.com/kunchenguid/no-mistakes/issues/521#issuecomment-5054593100).

Addresses part of #521.
