### PR TITLE
fix(scm/github): preserve safe check diagnostics

### DIFF
--- a/internal/pipeline/steps/ci_mergeable_test.go
+++ b/internal/pipeline/steps/ci_mergeable_test.go
@@ -308,7 +308,7 @@ func TestCIStep_TimeoutWithMergeConflictAndCheckLookupError_NeedsApproval(t *tes
 	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
-	env := fakeCIGHChecksError(t, "OPEN", "CONFLICTING", "gh checks failed")
+	env := fakeCIGHChecksError(t, "OPEN", "CONFLICTING", "gh checks failed for https://token:secret@example.com/test/repo")
 
 	prURL := "https://github.com/test/repo/pull/42"
 	ag := &mockAgent{name: "test"}
@@ -316,6 +316,10 @@ func TestCIStep_TimeoutWithMergeConflictAndCheckLookupError_NeedsApproval(t *tes
 	sctx.Env = env
 	sctx.Run.PRURL = &prURL
 	sctx.Config.CITimeout = 2 * time.Second
+	var logs []string
+	sctx.Log = func(message string) {
+		logs = append(logs, message)
+	}
 
 	started := time.Unix(1700000000, 0)
 	now := started
@@ -335,6 +339,14 @@ func TestCIStep_TimeoutWithMergeConflictAndCheckLookupError_NeedsApproval(t *tes
 	}
 	if !outcome.NeedsApproval {
 		t.Fatal("expected NeedsApproval when merge conflict remains known but checks lookup fails")
+	}
+	joinedLogs := strings.Join(logs, "\n")
+	const wantWarning = "warning: could not check CI: gh pr checks: exit status 1: gh checks failed for https://redacted@example.com/test/repo"
+	if !strings.Contains(joinedLogs, wantWarning) {
+		t.Fatalf("CI logs = %q, want warning %q", joinedLogs, wantWarning)
+	}
+	if strings.Contains(joinedLogs, "secret") {
+		t.Fatalf("CI logs exposed credential: %q", joinedLogs)
 	}
 
 	var findings Findings

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -9,9 +9,13 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+	"unicode/utf8"
 
+	"github.com/kunchenguid/no-mistakes/internal/safeurl"
 	"github.com/kunchenguid/no-mistakes/internal/scm"
 )
+
+const maxGHChecksDiagnosticBytes = 200
 
 // CmdFactory builds an exec.Cmd in the caller's workdir with the caller's env.
 type CmdFactory func(ctx context.Context, name string, args ...string) *exec.Cmd
@@ -304,6 +308,9 @@ func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
 		if strings.Contains(string(out), "no checks reported") {
 			return nil, nil
 		}
+		if diagnostic := compactGHChecksDiagnostic(out); diagnostic != "" {
+			return nil, fmt.Errorf("gh pr checks: %w: %s", err, diagnostic)
+		}
 		return nil, fmt.Errorf("gh pr checks: %w", err)
 	}
 	var raw []struct {
@@ -326,6 +333,27 @@ func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
 		checks = append(checks, scm.Check{Name: r.Name, Bucket: normalizeCheckBucket(r.Bucket, r.State), CompletedAt: completedAt})
 	}
 	return checks, nil
+}
+
+// compactGHChecksDiagnostic keeps repeated CI polling warnings useful without
+// allowing multiline, credentialled, or unbounded CLI output into step logs.
+func compactGHChecksDiagnostic(output []byte) string {
+	for _, line := range strings.Split(string(output), "\n") {
+		line = strings.ToValidUTF8(strings.TrimSpace(line), "�")
+		if line == "" {
+			continue
+		}
+		line = safeurl.RedactText(line)
+		if len(line) > maxGHChecksDiagnosticBytes {
+			end := maxGHChecksDiagnosticBytes
+			for end > 0 && !utf8.RuneStart(line[end]) {
+				end--
+			}
+			line = line[:end]
+		}
+		return line
+	}
+	return ""
 }
 
 func (h *Host) GetMergeableState(ctx context.Context, pr *scm.PR) (scm.MergeableState, error) {

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/kunchenguid/no-mistakes/internal/scm"
 )
@@ -369,6 +371,101 @@ func TestPRStateAndMergeableTargetKnownPRByURL(t *testing.T) {
 	}
 	if len(mergeArgs) != 1 || len(mergeArgs[0]) < 4 || mergeArgs[0][3] != prURL {
 		t.Fatalf("GetMergeableState selector = %v, want %q at argv[3]", mergeArgs, prURL)
+	}
+}
+
+func TestGetChecksFailureIncludesSafeDiagnosticAndWrappedError(t *testing.T) {
+	t.Parallel()
+
+	const command = "gh pr checks 123 --json name,state,bucket,completedAt"
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		command: {
+			stderr: "\n  authentication failed for https://token:ghp_secret@example.com/org/repo  \nignored detail\n",
+			code:   1,
+		},
+	}), nil, "", "")
+
+	_, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
+	if err == nil {
+		t.Fatal("GetChecks() error = nil, want error")
+	}
+	const want = "gh pr checks: exit status 1: authentication failed for https://redacted@example.com/org/repo"
+	if got := err.Error(); got != want {
+		t.Fatalf("GetChecks() error = %q, want %q", got, want)
+	}
+	if strings.Contains(err.Error(), "ghp_secret") || strings.Contains(err.Error(), "ignored detail") {
+		t.Fatalf("GetChecks() error exposed unsafe or later output: %q", err)
+	}
+
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("errors.As(%T) = false, want wrapped *exec.ExitError", err)
+	}
+	if got := exitErr.ExitCode(); got != 1 {
+		t.Fatalf("wrapped exit code = %d, want 1", got)
+	}
+}
+
+func TestGetChecksFailureDiagnosticIsBoundedAndValidUTF8(t *testing.T) {
+	t.Parallel()
+
+	const maxDiagnosticBytes = 200
+	const command = "gh pr checks 123 --json name,state,bucket,completedAt"
+	line := "request failed: \xff" + strings.Repeat("界", 100)
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		command: {stderr: line + "\n", code: 1},
+	}), nil, "", "")
+
+	_, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
+	if err == nil {
+		t.Fatal("GetChecks() error = nil, want error")
+	}
+	detail := strings.TrimPrefix(err.Error(), "gh pr checks: exit status 1: ")
+	if detail == err.Error() {
+		t.Fatalf("GetChecks() error = %q, want diagnostic detail", err)
+	}
+	if got := len(detail); got > maxDiagnosticBytes {
+		t.Fatalf("diagnostic length = %d bytes, want <= %d", got, maxDiagnosticBytes)
+	}
+	if !utf8.ValidString(detail) {
+		t.Fatalf("diagnostic is invalid UTF-8: %q", detail)
+	}
+	if !strings.HasPrefix(detail, "request failed: �") {
+		t.Fatalf("diagnostic = %q, want useful prefix", detail)
+	}
+}
+
+func TestGetChecksFailureWithEmptyOutputFormatsCleanly(t *testing.T) {
+	t.Parallel()
+
+	const command = "gh pr checks 123 --json name,state,bucket,completedAt"
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		command: {code: 1},
+	}), nil, "", "")
+
+	_, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
+	if err == nil {
+		t.Fatal("GetChecks() error = nil, want error")
+	}
+	if got, want := err.Error(), "gh pr checks: exit status 1"; got != want {
+		t.Fatalf("GetChecks() error = %q, want %q", got, want)
+	}
+}
+
+func TestGetChecksNoChecksReportedStillReturnsEmptySuccess(t *testing.T) {
+	t.Parallel()
+
+	const command = "gh pr checks 123 --json name,state,bucket,completedAt"
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		command: {stderr: "no checks reported on the 'feature' branch\n", code: 1},
+	}), nil, "", "")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
+	if err != nil {
+		t.Fatalf("GetChecks() error = %v, want nil", err)
+	}
+	if checks != nil {
+		t.Fatalf("GetChecks() checks = %+v, want nil", checks)
 	}
 }
 


### PR DESCRIPTION
## Intent

Make GitHub CI polling failures diagnostically useful by preserving the wrapped gh pr checks process error and adding one safe actionable diagnostic from captured CLI output. The diagnostic must use safeurl redaction, be bounded and UTF-8 safe, use the first useful non-empty line, omit cleanly for empty output, preserve the existing no checks reported exception, and appear in the operator-visible CI warning. Keep the contribution focused: do not add legacy gh fallbacks, change PR targeting or authorization, weaken CI gates, modify AGENTS.md, or address the unrelated ambient global Git config test-isolation defect. Deliver the focused branch to the contributor fork and open an upstream PR without merging it.

## What Changed

- `Host.GetChecks` now wraps the underlying `gh pr checks` process error together with a compacted diagnostic drawn from captured CLI output, so repeated CI polling failures surface an actionable reason instead of a bare error.
- Added `compactGHChecksDiagnostic`, which takes the first non-empty output line, redacts credentials via `safeurl.RedactText`, coerces to valid UTF-8, and truncates on a rune boundary to a 200-byte bound; it returns empty for empty output and keeps the existing `no checks reported` no-error path intact.
- Extended `github_test.go` with cases covering the safe-diagnostic path, bounded/UTF-8-safe truncation, empty output, and the no-checks-reported exception, and updated `ci_mergeable_test.go` to assert the redacted diagnostic reaches the operator-visible CI warning.

## Context and Scope

This observability gap was found while investigating the detached or bare-repository symptom that upstream PR [#522](https://github.com/kunchenguid/no-mistakes/pull/522) later fixed. The scopes are distinct: #522 fixed explicit PR selection, while this PR preserves bounded, redacted diagnostics for any future `gh pr checks` failure so operators can diagnose it faster.

This materially addresses the opaque-error symptom reported in [#380](https://github.com/kunchenguid/no-mistakes/issues/380), but it does not add or claim to close the legacy GitHub CLI compatibility fallback discussed there. PR targeting, authorization, and CI gate behavior are unchanged.

## Risk Assessment

✅ Low: A small, well-bounded change that adds a redacted, UTF-8-safe, length-bounded CI diagnostic while preserving the wrapped process error and existing exceptions, fully covered by focused tests and matching every intent criterion.

## Testing

Baseline unit tests for the new GitHub diagnostic all pass, and the operator-visible CI warning test confirms the redacted, wrapped diagnostic reaches the `warning: could not check CI:` line. I produced a CLI transcript artifact showing the exact operator-facing warning for credentialled auth failure (credential redacted to `redacted@`), rate-limit (first useful line after leading blanks), empty output (diagnostic omitted cleanly), and "no checks reported" (no warning, polling continues) - covering every intent constraint end-to-end. The wider `-race` run of the steps package showed two `TestRebaseStep_*NonConflictFailure*` failures that I traced to the ambient global `~/.gitconfig` `rebase.autostash=true`; both pass under a clean HOME, so they are the intent's explicitly out-of-scope test-isolation defect and are independent of this diff (which touches only the github package and two test files). This is a CLI/log surface with no rendered UI, so the reviewer evidence is the captured warning transcript rather than a screenshot.

<details>
<summary>Evidence: Operator-visible CI polling warning transcript (redaction, first-useful-line, empty-omit, no-checks-reported)</summary>

<code>### credentialled auth failure (redaction + wrapped exit status)&#10;raw gh stderr : &#34;\n authentication failed for https://token:ghp_SECRETVALUE@github.com/acme/widgets \nverbose stack line ignored\n&#34;&#10;operator sees : warning: could not check CI: gh pr checks: exit status 1: authentication failed for https://redacted@github.com/acme/widgets&#10;&#10;### rate limit (first useful non-empty line)&#10;operator sees : warning: could not check CI: gh pr checks: exit status 1: HTTP 403: API rate limit exceeded for user ID 12345&#10;&#10;### empty CLI output (diagnostic omitted cleanly)&#10;operator sees : warning: could not check CI: gh pr checks: exit status 1&#10;&#10;### no checks reported (preserved success exception)&#10;operator sees : (no warning) checks=[] -&gt; polling continues</code>

```text
Operator-visible CI polling warnings (source: ci.go -> sctx.Log)
================================================================

### credentialled auth failure (redaction + wrapped exit status)
  raw gh stderr : "\n  authentication failed for https://token:ghp_SECRETVALUE@github.com/acme/widgets  \nverbose stack line ignored\n"
  operator sees : warning: could not check CI: gh pr checks: exit status 1: authentication failed for https://redacted@github.com/acme/widgets

### rate limit (first useful non-empty line)
  raw gh stderr : "\n\nHTTP 403: API rate limit exceeded for user ID 12345\nDocumentation: https://docs.github.com/rest\n"
  operator sees : warning: could not check CI: gh pr checks: exit status 1: HTTP 403: API rate limit exceeded for user ID 12345

### empty CLI output (diagnostic omitted cleanly)
  raw gh stderr : ""
  operator sees : warning: could not check CI: gh pr checks: exit status 1

### no checks reported (preserved success exception)
  raw gh stderr : "no checks reported on the 'feature' branch\n"
  operator sees : (no warning) checks=[] -> polling continues
```
</details>
- Outcome: ⚠️ 1 info across 1 run (9m3s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `internal/pipeline/steps/rebase_test.go:301` - `go test -race ./internal/pipeline/steps/` fails two rebase tests (TestRebaseStep_FixModeNonConflictFailureReturnsError, TestRebaseStep_NonConflictFailureWithRebaseMetadataReturnsError) because the ambient global ~/.gitconfig sets rebase.autostash=true, which autostashes the tests&#39; deliberately-dirtied worktree so the rebase succeeds instead of failing. Confirmed pre-existing and unrelated to this diff: both pass with a clean HOME, and the intent explicitly scopes this ambient-git-config test-isolation defect out.
- <code>`go test ./internal/scm/github/ -run TestGetChecks -v` (all pass, incl. new safe-diagnostic/bounded-UTF8/empty-output/no-checks-reported tests)</code>
- <code>`go test ./internal/pipeline/steps/ -run TestCIStep_TimeoutWithMergeConflictAndCheckLookupError_NeedsApproval -v` (operator-visible redacted warning verified)</code>
- <code>`go test -race ./internal/scm/github/ ./internal/pipeline/steps/` (github clean; two unrelated rebase failures traced to ambient global rebase.autostash)</code>
- `Temporary evidence test driving GetChecks -> ci.go warning chain, capturing the exact operator warning strings for auth-failure/rate-limit/empty/no-checks scenarios`
- `Root-cause proof: reran the two failing rebase tests with a clean HOME (no ~/.gitconfig) -> both pass, confirming the ambient rebase.autostash=true test-isolation defect`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 2)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
