### PR TITLE
fix(skill): narrow automatic pipeline trigger

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+skills/no-mistakes/SKILL.md text eol=lf

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -16,8 +16,8 @@ const Name = "no-mistakes"
 
 // Description is the trigger-shaped frontmatter description: what the skill
 // does and when to use it. It is the single most important field for the
-// agent's decision to load the skill, so it leads with outcomes and keywords.
-const Description = "Validate your code changes through the no-mistakes pipeline - automated code review, tests, lint, docs, push, PR, and CI - before they reach the configured push target. Use when the user asks to run no-mistakes, gate or ship or validate their changes, push safely, asks you to do a task and then validate it, or invokes /no-mistakes."
+// agent's decision to load the skill, so it defines a narrow risk boundary.
+const Description = "Use this skill when the user explicitly invokes /no-mistakes or explicitly requests the full no-mistakes gate, and automatically for high-risk changes involving security, authentication/authorization, privacy/PHI, destructive data or schema behavior, billing/payments, migrations, production deploy or infrastructure, complex workflows, or broad high-blast-radius changes. Medium-risk behavior changes use the review-only lane. Routine work uses repository-native checks and CI."
 
 // Markdown returns the complete SKILL.md document (YAML frontmatter plus body).
 // The output is deterministic so it can be regenerated and diff-checked. It is

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -36,6 +36,21 @@ func TestMarkdownFrontmatter(t *testing.T) {
 	}
 }
 
+func TestGeneratedSkillUsesNarrowRiskTrigger(t *testing.T) {
+	generated := Markdown()
+	assertNarrowRiskTrigger(t, generated)
+
+	committedPath := filepath.Join("..", "..", "skills", Name, "SKILL.md")
+	committed, err := os.ReadFile(committedPath)
+	if err != nil {
+		t.Fatalf("read committed skill: %v", err)
+	}
+	if string(committed) != generated {
+		t.Fatalf("committed skill does not match Markdown(); run `go run ./cmd/genskill`")
+	}
+	assertNarrowRiskTrigger(t, string(committed))
+}
+
 func TestBodyDocumentsTaskFirstFlow(t *testing.T) {
 	md := Markdown()
 	for _, want := range []string{
@@ -98,9 +113,10 @@ func TestInstallWritesBothPaths(t *testing.T) {
 	}
 }
 
-// TestInstallUserWritesUnderHome proves the init entry point resolves the
-// user's home directory and installs there, never into the working directory.
-func TestInstallUserWritesUnderHome(t *testing.T) {
+// TestInstallUserWritesSourceIdenticalNarrowSkill proves the init entry point
+// resolves the user's home directory and installs the canonical narrow skill,
+// never a stale broad-trigger copy or content from the working directory.
+func TestInstallUserWritesSourceIdenticalNarrowSkill(t *testing.T) {
 	home := t.TempDir()
 	// os.UserHomeDir reads HOME on Unix and USERPROFILE on Windows; set both
 	// so the test isolates the real home directory on every platform.
@@ -122,6 +138,7 @@ func TestInstallUserWritesUnderHome(t *testing.T) {
 		if string(data) != Markdown() {
 			t.Errorf("%s content does not match Markdown()", base)
 		}
+		assertNarrowRiskTrigger(t, string(data))
 	}
 }
 
@@ -257,6 +274,60 @@ func TestInstallRejectsSymlinkCycle(t *testing.T) {
 
 	if _, err := Install(root); err == nil {
 		t.Fatalf("Install succeeded with cyclic skill directory symlinks")
+	}
+}
+
+func assertNarrowRiskTrigger(t *testing.T, md string) {
+	t.Helper()
+
+	const prefix = "description: "
+	var description string
+	for line := range strings.SplitSeq(md, "\n") {
+		if strings.HasPrefix(line, prefix) {
+			description = strings.TrimPrefix(line, prefix)
+			break
+		}
+	}
+	if description == "" {
+		t.Fatal("skill frontmatter has no description")
+	}
+
+	lower := strings.ToLower(description)
+	for _, forbidden := range []string{
+		"commit",
+		"push",
+		"push safely",
+		"ship",
+		"open pr",
+		"open-pr",
+		"validate their changes",
+		"task and then validate",
+	} {
+		if strings.Contains(lower, forbidden) {
+			t.Errorf("skill description restores broad trigger phrase %q: %q", forbidden, description)
+		}
+	}
+	for _, required := range []string{
+		"explicitly",
+		"/no-mistakes",
+		"full no-mistakes gate",
+		"automatically",
+		"high-risk",
+		"security",
+		"authentication/authorization",
+		"privacy/phi",
+		"destructive data or schema",
+		"billing/payments",
+		"migrations",
+		"production deploy or infrastructure",
+		"complex workflows",
+		"broad high-blast-radius",
+		"review-only lane",
+		"repository-native checks and ci",
+	} {
+		if !strings.Contains(lower, required) {
+			t.Errorf("skill description missing narrow trigger phrase %q: %q", required, description)
+		}
 	}
 }
 

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: no-mistakes
-description: Validate your code changes through the no-mistakes pipeline - automated code review, tests, lint, docs, push, PR, and CI - before they reach the configured push target. Use when the user asks to run no-mistakes, gate or ship or validate their changes, push safely, asks you to do a task and then validate it, or invokes /no-mistakes.
+description: Use this skill when the user explicitly invokes /no-mistakes or explicitly requests the full no-mistakes gate, and automatically for high-risk changes involving security, authentication/authorization, privacy/PHI, destructive data or schema behavior, billing/payments, migrations, production deploy or infrastructure, complex workflows, or broad high-blast-radius changes. Medium-risk behavior changes use the review-only lane. Routine work uses repository-native checks and CI.
 user-invocable: true
 ---
 


### PR DESCRIPTION
## Summary

- narrow the canonical skill trigger to explicit full-gate requests and risk-based use
- route medium-risk behavior changes to the review-only lane and routine work to repository-native checks and CI
- regenerate the committed skill without changing its 290-line body
- lock generator and init-install output to the same narrow source rendering

## Rationale

The previous frontmatter matched routine delivery wording such as ship, push safely, and task-plus-validation requests. Because init overwrites user-level copies from the canonical generator, that broad trigger could return after any refresh. Narrowing the authoritative Description fixes the reversion path without changing pipeline steps, defaults, gates, prompts, configuration, or updater behavior.

## Tests

- make lint
- go test -race ./...
- go build -o ./bin/no-mistakes ./cmd/no-mistakes