### PR TITLE
fix: execute every PR body compliance event

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -1,4 +1,5 @@
 name: Require no-mistakes
+run-name: "PR #${{ github.event.pull_request.number }} body compliance - ${{ github.event.action }} - event ${{ github.run_number }} (run ${{ github.run_id }})"
 
 on:
   pull_request:
@@ -9,8 +10,12 @@ on:
 permissions:
   contents: read
 
+# GitHub concurrency groups retain at most one pending run, replacing older
+# pending runs even when cancel-in-progress is false. Give body-bearing events
+# an immutable per-event group so first-time-fork approvals can never collapse
+# opened/edited checks. Keep synchronize/reopened coalescing as before.
 concurrency:
-  group: no-mistakes-required-${{ github.event.pull_request.number }}
+  group: no-mistakes-required-${{ github.event.pull_request.number }}-${{ (github.event.action == 'opened' || github.event.action == 'edited') && github.run_id || 'head-change' }}
   cancel-in-progress: true
 
 jobs:

--- a/.no-mistakes/evidence/fm/no-mistakes-body-compliance-events-p1/body-compliance-event-replay.md
+++ b/.no-mistakes/evidence/fm/no-mistakes-body-compliance-events-p1/body-compliance-event-replay.md
@@ -1,0 +1,74 @@
+# PR body compliance event replay
+
+This evidence replays the incident-shaped sequence from the focused regression:
+one signed `opened` event, one unsigned `edited` event, and one signed `edited`
+event, all for PR #549 at the same head SHA. The shell body was extracted
+directly from the workflow's `Verify no-mistakes signature in PR body` step and
+executed once per event.
+
+| Run ID | Run number | Action | Head SHA | Concurrency group | Status | Conclusion |
+| ---: | ---: | --- | --- | --- | --- | --- |
+| `29962844999` | 586 | opened | `same-head` | `no-mistakes-required-549-29962844999` | completed | success |
+| `29962943078` | 587 | edited | `same-head` | `no-mistakes-required-549-29962943078` | completed | failure |
+| `29965243268` | 588 | edited | `same-head` | `no-mistakes-required-549-29965243268` | completed | success |
+
+## Reviewer-visible run titles
+
+```text
+PR #549 body compliance - opened - event 586 (run 29962844999)
+PR #549 body compliance - edited - event 587 (run 29962943078)
+PR #549 body compliance - edited - event 588 (run 29965243268)
+```
+
+The increasing run numbers provide event ordering, while the run IDs remain the
+immutable identity surfaced in both the run title and body-event concurrency
+group.
+
+## Actual compliance-step output
+
+### Signed opened event
+
+```text
+Found no-mistakes signature in PR #549 body.
+```
+
+Exit status: `0` (`success`)
+
+### Unsigned edited event
+
+```text
+::error::This PR was not raised through no-mistakes.
+
+Contributions to this repository must be submitted via 'git push no-mistakes'.
+That pipeline runs the required review/test/lint/CI steps and writes a
+deterministic '## Pipeline' section into the PR body containing:
+
+    Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)
+
+See CONTRIBUTING.md for setup and the full workflow.
+
+PR author: first-time-fork-contributor
+```
+
+Exit status: `1` (`failure`)
+
+### Signed edited event
+
+```text
+Found no-mistakes signature in PR #549 body.
+```
+
+Exit status: `0` (`success`)
+
+## Focused automated contract checks
+
+The targeted Go tests also exercised:
+
+- GitHub's one-running/one-pending concurrency replacement behavior against all
+  three same-head body events
+- unique concurrency groups for `opened` and `edited`
+- preserved coalescing for `synchronize` and `reopened`
+- the stable check name and event identity in the run title
+- the `pull_request` boundary, `contents: read`, and absence of secrets,
+  checkout, and write permissions
+- the unchanged signature marker and shell-injection-safe PR-body transport

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for wanting to contribute. One rule up front:
 **All pull requests to this repository must be raised through `no-mistakes`.**
 
 This repo _is_ no-mistakes. Contributions should be done using the tool itself, which reduces the maintainer's burden of reviewing and merging contributions.
-A GitHub Actions check (`Require no-mistakes`) runs on every PR and fails if the body is missing the deterministic signature that no-mistakes writes. PRs without it will not be reviewed or merged.
+The `Require no-mistakes` GitHub Actions workflow runs on every PR and fails if the body is missing the deterministic signature that no-mistakes writes. PRs without it will not be reviewed or merged.
 
 Every `opened` or `edited` event gets an independent run, including first-time-fork runs that become actionable through GitHub's normal approval process. The integration contract for consumers such as Wheelhouse is:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,13 @@ Thanks for wanting to contribute. One rule up front:
 This repo _is_ no-mistakes. Contributions should be done using the tool itself, which reduces the maintainer's burden of reviewing and merging contributions.
 A GitHub Actions check (`Require no-mistakes`) runs on every PR and fails if the body is missing the deterministic signature that no-mistakes writes. PRs without it will not be reviewed or merged.
 
+Every `opened` or `edited` event gets an independent run, including first-time-fork runs that become actionable through GitHub's normal approval process. The integration contract for consumers such as Wheelhouse is:
+
+- The stable check name is `PR must be raised via no-mistakes`.
+- The workflow run's `display_title` identifies the PR number, event action, `run_number`, and immutable `run_id`. For a PR, increasing `run_number` orders distinct events; a re-run retains that event identity and increments `run_attempt`.
+- The run's `head_sha` binds the evidence to the reviewed commit. After the latest `opened` or `edited` run reaches `status: completed`, `conclusion: success` means that event's body contained the signature and `conclusion: failure` means it did not. `action_required` or `cancelled` is not compliance evidence and must be handled conservatively.
+- Fork runs stay on the `pull_request` boundary with read-only contents permission, no repository secrets, and no checkout or execution of fork code. Approval permits only this body check; it does not grant write authority.
+
 ## Workflow
 
 1. Fork the repo, then clone the parent repo or set your local `origin` back to the parent repo (`git@github.com:kunchenguid/no-mistakes.git`).

--- a/workflow_no_mistakes_required_test.go
+++ b/workflow_no_mistakes_required_test.go
@@ -1,9 +1,15 @@
 package main
 
 import (
+	"bytes"
 	"os"
+	"os/exec"
+	"slices"
+	"strconv"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 // TestNoMistakesRequiredWorkflowExemptsReleaseAutomation pins the exemption
@@ -86,4 +92,257 @@ func TestNoMistakesRequiredWorkflowTriggersOnRelevantPREvents(t *testing.T) {
 			t.Errorf("workflow must trigger on pull_request type %q", typ)
 		}
 	}
+}
+
+// TestNoMistakesRequiredWorkflowExecutesEveryBodyEvent reproduces the
+// first-time-fork incident in which an opened event and two same-head body
+// edits became actionable together. The scheduler fixture implements GitHub's
+// documented one-running/one-pending concurrency limit, including pending-run
+// replacement even when cancel-in-progress is false, and the exact
+// cancel-in-progress ordering observed in runs 29962844999, 29962943078, and
+// 29965243268. It then executes the workflow's real shell step for every job
+// that survives scheduling.
+func TestNoMistakesRequiredWorkflowExecutesEveryBodyEvent(t *testing.T) {
+	workflow := loadRequiredWorkflow(t)
+	marker := "Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)"
+	events := []requiredWorkflowEvent{
+		{Action: "opened", Body: "## Pipeline\n\n" + marker, HeadSHA: "same-head", PRNumber: 549, RunID: 29962844999, RunNumber: 586},
+		{Action: "edited", Body: "signature removed", HeadSHA: "same-head", PRNumber: 549, RunID: 29962943078, RunNumber: 587},
+		{Action: "edited", Body: "## Pipeline\n\n" + marker, HeadSHA: "same-head", PRNumber: 549, RunID: 29965243268, RunNumber: 588},
+	}
+
+	got := executeRequiredWorkflowFixture(t, workflow, events)
+	want := []requiredWorkflowResult{
+		{RunID: 29962844999, RunNumber: 586, Action: "opened", Executed: true, Conclusion: "success"},
+		{RunID: 29962943078, RunNumber: 587, Action: "edited", Executed: true, Conclusion: "failure"},
+		{RunID: 29965243268, RunNumber: 588, Action: "edited", Executed: true, Conclusion: "success"},
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("same-head body-event results =\n  %v\nwant every event executed to its own terminal result:\n  %v", got, want)
+	}
+}
+
+func TestNoMistakesRequiredWorkflowPreservesHeadEventCoalescing(t *testing.T) {
+	workflow := loadRequiredWorkflow(t)
+	events := []requiredWorkflowEvent{
+		{Action: "opened", PRNumber: 549, RunID: 1001},
+		{Action: "edited", PRNumber: 549, RunID: 1002},
+		{Action: "edited", PRNumber: 549, RunID: 1003},
+		{Action: "synchronize", PRNumber: 549, RunID: 1004},
+		{Action: "reopened", PRNumber: 549, RunID: 1005},
+	}
+	groups := make([]string, len(events))
+	for i, event := range events {
+		groups[i] = renderRequiredWorkflowTemplate(t, workflow.Concurrency.Group, event)
+	}
+	if groups[0] == groups[1] || groups[0] == groups[2] || groups[1] == groups[2] {
+		t.Fatalf("body-bearing event groups must be unique: %v", groups[:3])
+	}
+	if groups[3] != groups[4] {
+		t.Fatalf("synchronize/reopened groups = %q and %q, want preserved coalescing", groups[3], groups[4])
+	}
+	for _, bodyGroup := range groups[:3] {
+		if bodyGroup == groups[3] {
+			t.Fatalf("body event group %q can be canceled by a head event", bodyGroup)
+		}
+	}
+}
+
+func TestNoMistakesRequiredWorkflowPublishesStableEventIdentity(t *testing.T) {
+	workflow := loadRequiredWorkflow(t)
+	if workflow.Jobs["check"].Name != "PR must be raised via no-mistakes" {
+		t.Fatalf("required check name changed to %q", workflow.Jobs["check"].Name)
+	}
+
+	first := requiredWorkflowEvent{Action: "edited", PRNumber: 549, RunID: 29962943078, RunNumber: 587}
+	latest := requiredWorkflowEvent{Action: "edited", PRNumber: 549, RunID: 29965243268, RunNumber: 588}
+	firstName := renderRequiredWorkflowTemplate(t, workflow.RunName, first)
+	latestName := renderRequiredWorkflowTemplate(t, workflow.RunName, latest)
+	for _, want := range []string{"#549", "edited", "587", "29962943078"} {
+		if !strings.Contains(firstName, want) {
+			t.Errorf("first event run name %q does not expose %q", firstName, want)
+		}
+	}
+	for _, want := range []string{"#549", "edited", "588", "29965243268"} {
+		if !strings.Contains(latestName, want) {
+			t.Errorf("latest event run name %q does not expose %q", latestName, want)
+		}
+	}
+	if firstName == latestName {
+		t.Fatalf("distinct body events have ambiguous run name %q", firstName)
+	}
+	if first.RunNumber >= latest.RunNumber {
+		t.Fatalf("fixture event ordering is not monotonic: %d then %d", first.RunNumber, latest.RunNumber)
+	}
+}
+
+func TestNoMistakesRequiredWorkflowKeepsForkBoundaryReadOnly(t *testing.T) {
+	workflow := loadRequiredWorkflow(t)
+	if _, ok := workflow.On["pull_request"]; !ok {
+		t.Fatal("required workflow must retain the safe pull_request boundary")
+	}
+	if _, ok := workflow.On["pull_request_target"]; ok {
+		t.Fatal("required workflow must not gain pull_request_target write authority")
+	}
+	if got := workflow.Permissions["contents"]; got != "read" {
+		t.Fatalf("contents permission = %q, want read", got)
+	}
+	for permission, access := range workflow.Permissions {
+		if access == "write" {
+			t.Fatalf("permission %q unexpectedly grants write authority", permission)
+		}
+	}
+
+	data, err := os.ReadFile(".github/workflows/no-mistakes-required.yml")
+	if err != nil {
+		t.Fatalf("read workflow: %v", err)
+	}
+	lower := strings.ToLower(string(data))
+	if strings.Contains(lower, "secrets.") {
+		t.Fatal("required workflow must not expose secrets to fork runs")
+	}
+	if strings.Contains(lower, "actions/checkout") {
+		t.Fatal("required workflow must not check out or execute fork code")
+	}
+}
+
+type requiredWorkflow struct {
+	RunName     string                         `yaml:"run-name"`
+	On          map[string]any                 `yaml:"on"`
+	Permissions map[string]string              `yaml:"permissions"`
+	Concurrency requiredWorkflowConcurrency    `yaml:"concurrency"`
+	Jobs        map[string]requiredWorkflowJob `yaml:"jobs"`
+}
+
+type requiredWorkflowConcurrency struct {
+	Group            string `yaml:"group"`
+	CancelInProgress bool   `yaml:"cancel-in-progress"`
+}
+
+type requiredWorkflowJob struct {
+	Name  string                 `yaml:"name"`
+	Steps []requiredWorkflowStep `yaml:"steps"`
+}
+
+type requiredWorkflowStep struct {
+	Name string `yaml:"name"`
+	Run  string `yaml:"run"`
+}
+
+type requiredWorkflowEvent struct {
+	Action    string
+	Body      string
+	HeadSHA   string
+	PRNumber  int64
+	RunID     int64
+	RunNumber int64
+}
+
+type requiredWorkflowResult struct {
+	RunID      int64
+	RunNumber  int64
+	Action     string
+	Executed   bool
+	Conclusion string
+}
+
+func loadRequiredWorkflow(t *testing.T) requiredWorkflow {
+	t.Helper()
+	data, err := os.ReadFile(".github/workflows/no-mistakes-required.yml")
+	if err != nil {
+		t.Fatalf("read workflow: %v", err)
+	}
+	var workflow requiredWorkflow
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatalf("parse workflow: %v", err)
+	}
+	return workflow
+}
+
+func executeRequiredWorkflowFixture(t *testing.T, workflow requiredWorkflow, events []requiredWorkflowEvent) []requiredWorkflowResult {
+	t.Helper()
+	groups := make(map[string][]int)
+	for i, event := range events {
+		group := renderRequiredWorkflowTemplate(t, workflow.Concurrency.Group, event)
+		groups[group] = append(groups[group], i)
+	}
+
+	execute := make([]bool, len(events))
+	for _, indexes := range groups {
+		switch {
+		case len(indexes) == 1:
+			execute[indexes[0]] = true
+		case workflow.Concurrency.CancelInProgress:
+			// This is the ordering the real first-time-fork approval incident
+			// produced: the opened run executed and both waiting edits were
+			// canceled. GitHub does not guarantee concurrency-group ordering.
+			execute[indexes[0]] = true
+		default:
+			// GitHub permits one running and one pending run per group. A newer
+			// pending run replaces an older pending run even when in-progress
+			// cancellation is disabled.
+			execute[indexes[0]] = true
+			execute[indexes[len(indexes)-1]] = true
+		}
+	}
+
+	step := workflow.Jobs["check"].Steps[0]
+	results := make([]requiredWorkflowResult, len(events))
+	for i, event := range events {
+		result := requiredWorkflowResult{RunID: event.RunID, RunNumber: event.RunNumber, Action: event.Action}
+		if !execute[i] {
+			result.Conclusion = "cancelled"
+			results[i] = result
+			continue
+		}
+
+		cmd := exec.Command("bash", "-c", step.Run)
+		cmd.Env = append(os.Environ(),
+			"PR_BODY="+event.Body,
+			"PR_AUTHOR=first-time-fork-contributor",
+			"PR_NUMBER="+strconv.FormatInt(event.PRNumber, 10),
+		)
+		var output bytes.Buffer
+		cmd.Stdout = &output
+		cmd.Stderr = &output
+		err := cmd.Run()
+		result.Executed = true
+		if err == nil {
+			result.Conclusion = "success"
+		} else if _, ok := err.(*exec.ExitError); ok {
+			result.Conclusion = "failure"
+		} else {
+			t.Fatalf("execute compliance step for run %d: %v\n%s", event.RunID, err, output.String())
+		}
+		results[i] = result
+	}
+	return results
+}
+
+func renderRequiredWorkflowTemplate(t *testing.T, template string, event requiredWorkflowEvent) string {
+	t.Helper()
+	const bodyEventGroupExpression = "(github.event.action == 'opened' || github.event.action == 'edited') && github.run_id || 'head-change'"
+	bodyEventGroup := "head-change"
+	if event.Action == "opened" || event.Action == "edited" {
+		bodyEventGroup = strconv.FormatInt(event.RunID, 10)
+	}
+	template = strings.ReplaceAll(template, "${{ "+bodyEventGroupExpression+" }}", bodyEventGroup)
+
+	replacements := []struct {
+		expression string
+		value      string
+	}{
+		{expression: "github.event.action", value: event.Action},
+		{expression: "github.event.pull_request.number", value: strconv.FormatInt(event.PRNumber, 10)},
+		{expression: "github.event.pull_request.head.sha", value: event.HeadSHA},
+		{expression: "github.run_id", value: strconv.FormatInt(event.RunID, 10)},
+		{expression: "github.run_number", value: strconv.FormatInt(event.RunNumber, 10)},
+	}
+	for _, replacement := range replacements {
+		template = strings.ReplaceAll(template, "${{ "+replacement.expression+" }}", replacement.value)
+	}
+	if strings.Contains(template, "${{") {
+		t.Fatalf("fixture cannot evaluate workflow expression in %q", template)
+	}
+	return strings.Join(strings.Fields(template), " ")
 }


### PR DESCRIPTION
## Intent

Implement the no-mistakes repository half of the captain's current-body compliance decision. Every opened or edited pull-request body event, including independently approved first-time-contributor fork events on an unchanged head, must execute the existing signature check to a terminal success or failure instead of being canceled or replaced by same-PR concurrency. Preserve the safe pull_request boundary, read-only/no-secret/no-write posture, existing signature policy and check name, and preserve synchronize/reopened coalescing where possible. Expose a trustworthy immutable run identity plus monotonic event ordering and terminal outcome contract so Wheelhouse can select the latest PR-body event separately. Regress signed opened, unsigned edited, and signed edited on the same head with all three checks executed. Do not alter Wheelhouse, PR 549, ambient Git test isolation, or unrelated workflow behavior.

## What Changed

- Isolate `opened` and `edited` pull request events into immutable per-run concurrency groups so every body compliance check reaches a terminal result, while preserving `synchronize` and `reopened` coalescing.
- Expose the PR number, event action, monotonic run number, and immutable run ID in workflow run titles, and document the read-only fork compliance contract.
- Add focused regression coverage and replay evidence for signed, unsigned, and re-signed same-head body events, including fork safety boundaries and stable check identity.

## Risk Assessment

✅ Low: The workflow change cleanly isolates opened and edited events by immutable run ID while preserving head-event coalescing, existing signature policy, check identity, and the read-only pull_request security boundary.

## Testing

Focused automated checks passed, and a manual replay of the real workflow step completed all three same-head PR-body events with success, failure, and success. Reviewer-visible transcript evidence was recorded; screenshots were not applicable because this is a GitHub workflow behavior change with no rendered UI.

- Evidence: [Three-event PR body compliance replay](https://github.com/kunchenguid/no-mistakes/blob/bf51f006d0cf8fb675796a28382d85ff4f023ec7/.no-mistakes/evidence/fm/no-mistakes-body-compliance-events-p1/body-compliance-event-replay.md)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test . -run 'TestNoMistakesRequiredWorkflow(ExecutesEveryBodyEvent|PreservesHeadEventCoalescing|PublishesStableEventIdentity|KeepsForkBoundaryReadOnly|ChecksSignatureMarker|ReadsPRBodyViaEnv|TriggersOnRelevantPREvents)$' -count=1 -v`
- `Extracted and executed the workflow's real signature-check shell step for signed opened, unsigned edited, and signed edited events on the same head`
- `Verified distinct run IDs and concurrency groups, increasing run numbers, terminal success/failure/success outcomes, preserved synchronize/reopened coalescing, and the read-only fork boundary`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
