### PR TITLE
feat(agent): neutralize Cursor project instructions under disable_project_settings

### DIFF
--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -290,6 +290,9 @@ ACP aliases are first-class agent names that resolve to ACP targets.
 `agent: cursor` is the first alias: it is shorthand for the `cursor` ACP target with the default raw command `cursor-agent acp`, not a separate native backend.
 `agent: acp:cursor` uses that same default command, so either spelling works without an `acp_registry_overrides.cursor` entry.
 
+When a repository opts in with trusted `disable_project_settings: true`, Cursor is a verified gate-instruction neutralizer: each gate agent run quarantines the project instruction surfaces Cursor auto-loads (`AGENTS.md`, `CLAUDE.md`, and `.cursor/rules`) for the duration of the invocation and restores them afterward.
+Generic `acp:<other>` targets are not verified for that opt-out; see the [Repo Config Reference](/no-mistakes/reference/repo-config/#disable_project_settings).
+
 Because aliases still run through acpx, they use `acpx_path` for the bridge binary and share the same ACP prompt and structured-output behavior as `agent: acp:<target>`.
 Unlike arbitrary `acp:<target>` entries, aliases may participate in `agent: auto` when their availability checks pass.
 The [Global Config Reference](/no-mistakes/reference/global-config/) owns ACP availability, bridge-path, command-override, and equivalent-spelling deduplication rules.

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -290,8 +290,7 @@ ACP aliases are first-class agent names that resolve to ACP targets.
 `agent: cursor` is the first alias: it is shorthand for the `cursor` ACP target with the default raw command `cursor-agent acp`, not a separate native backend.
 `agent: acp:cursor` uses that same default command, so either spelling works without an `acp_registry_overrides.cursor` entry.
 
-When a repository opts in with trusted `disable_project_settings: true`, Cursor is a verified gate-instruction neutralizer: each gate agent run quarantines the project instruction surfaces Cursor auto-loads (`AGENTS.md`, `CLAUDE.md`, and `.cursor/rules`) for the duration of the invocation and restores them afterward.
-Generic `acp:<other>` targets are not verified for that opt-out; see the [Repo Config Reference](/no-mistakes/reference/repo-config/#disable_project_settings).
+Under trusted `disable_project_settings: true`, Cursor is a verified gate-instruction neutralizer; generic `acp:<other>` targets are not. See [`disable_project_settings`](/no-mistakes/reference/repo-config/#disable_project_settings).
 
 Because aliases still run through acpx, they use `acpx_path` for the bridge binary and share the same ACP prompt and structured-output behavior as `agent: acp:<target>`.
 Unlike arbitrary `acp:<target>` entries, aliases may participate in `agent: auto` when their availability checks pass.

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -119,7 +119,12 @@ Suppress project-level agent settings and instructions for every gate-agent star
 
 This opt-in is intended for agent-orchestration repositories whose `AGENTS.md`, `CLAUDE.md`, or harness-specific project settings would give a validation agent an operator identity and authority that it must not adopt.
 When enabled, no-mistakes suppresses the target checkout's project settings for every agent-driven gate step while preserving user-level agent configuration.
-Codex and Claude are the currently verified agents: Codex receives `project_doc_max_bytes=0` and `--ignore-rules`, while Claude loads only its user setting source.
+Verified agents today:
+
+- **Codex** receives `project_doc_max_bytes=0` and `--ignore-rules`
+- **Claude** loads only its user setting source
+- **Cursor** (`agent: cursor` / `acp:cursor`) quarantines project instruction surfaces Cursor auto-loads (`AGENTS.md`, `CLAUDE.md`, and `.cursor/rules`) for the duration of each gate agent run, then restores them; unrelated `.cursor/` content is left in place
+
 The setting applies to both new and resumed sessions.
 
 The gate fails before launching an agent if any resolved agent or fallback lacks a verified suppression mechanism.

--- a/internal/agent/acpx.go
+++ b/internal/agent/acpx.go
@@ -19,13 +19,46 @@ type acpxAgent struct {
 	bin        string
 	target     string
 	rawCommand string
+	// disableProjectSettings is the resolved, trusted-only opt-out. When true
+	// and this agent is Cursor, Run quarantines Cursor's auto-loaded project
+	// instruction surfaces for the duration of the invocation.
+	disableProjectSettings bool
 }
 
 func (a *acpxAgent) Name() string { return "acp:" + a.target }
 
 func (a *acpxAgent) ReportsAgentAttempts() bool { return true }
 
-func (a *acpxAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
+// NeutralizesGateInstructions reports whether this ACP agent suppresses the
+// target repo's project agent-instruction files during a gate run. Only Cursor
+// (cursor / acp:cursor) has a verified neutralization path today: managed
+// quarantine of AGENTS.md, CLAUDE.md, and .cursor/rules while the opt-out is
+// on. Generic acp:<other> targets always report false. Honest when the opt-out
+// is off: false even for Cursor.
+func (a *acpxAgent) NeutralizesGateInstructions() bool {
+	return a.disableProjectSettings && isCursorGateTarget(a.target)
+}
+
+func (a *acpxAgent) shouldQuarantineCursorInstructions() bool {
+	return a.NeutralizesGateInstructions()
+}
+
+func (a *acpxAgent) Run(ctx context.Context, opts RunOpts) (res *Result, err error) {
+	if a.shouldQuarantineCursorInstructions() {
+		q, qerr := beginCursorInstructionQuarantine(opts.CWD)
+		if qerr != nil {
+			return nil, fmt.Errorf("cursor gate instruction quarantine: %w", qerr)
+		}
+		defer func() {
+			if rerr := q.Restore(); rerr != nil {
+				if err != nil {
+					err = fmt.Errorf("%w (also restore quarantine: %v)", err, rerr)
+				} else {
+					err = fmt.Errorf("restore cursor gate instruction quarantine: %w", rerr)
+				}
+			}
+		}()
+	}
 	return runWithRetry(ctx, a.Name(), opts, claudeMaxRetries, classifyTransient, nil, func() (*Result, error) {
 		return a.runOnce(ctx, opts)
 	})

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -156,8 +156,8 @@ func NeutralizesGateInstructions(a Agent) bool {
 // the target checkout does not neutralize that checkout's project
 // agent-instruction files. Callers must invoke it before launching any gate
 // agent so an unverified harness is refused with a clear error rather than run
-// unneutralized in the target checkout. Only codex and claude have a verified
-// neutralization knob today.
+// unneutralized in the target checkout. Verified harnesses today: codex, claude,
+// and cursor (acp:cursor via instruction-file quarantine).
 func EnsureGateNeutralized(a Agent) error {
 	if a == nil {
 		return fmt.Errorf("no gate agent configured")
@@ -167,9 +167,9 @@ func EnsureGateNeutralized(a Agent) error {
 	}
 	return fmt.Errorf("gate agent %q does not neutralize the target repository's project "+
 		"agent-instruction files (AGENTS.md/CLAUDE.md); refusing to launch it in the target "+
-		"checkout. Only codex and claude have a verified neutralization knob (and only when it "+
-		"is not overridden by agent_args_override); set 'agent' to codex or claude in "+
-		"~/.no-mistakes/config.yaml", a.Name())
+		"checkout. Only codex, claude, and cursor have a verified neutralization path (and only "+
+		"when it is not overridden by agent_args_override for native agents); set 'agent' to "+
+		"codex, claude, or cursor in ~/.no-mistakes/config.yaml", a.Name())
 }
 
 // LifecycleEvent describes process-level activity for an agent invocation.
@@ -248,7 +248,7 @@ type InvocationWorkload struct {
 type Options struct {
 	ACPRegistryOverrides map[string]string
 	// DisableProjectSettings, when true, asks a supported adapter (codex,
-	// claude) to launch with the target repo's project-level agent
+	// claude, cursor) to launch with the target repo's project-level agent
 	// settings/instructions suppressed. It is the resolved, trusted-only opt-out
 	// from config.Config; adapters without a verified suppression knob ignore it
 	// and are refused separately by EnsureGateNeutralized when the opt-out is on.
@@ -793,7 +793,12 @@ func New(name types.AgentName, bin string, extraArgs []string) (Agent, error) {
 func NewWithOptions(name types.AgentName, bin string, extraArgs []string, opts Options) (Agent, error) {
 	if target, ok := types.ACPTargetFor(name); ok {
 		rawCommand := types.ACPRawCommand(target, opts.ACPRegistryOverrides)
-		return &acpxAgent{bin: bin, target: target, rawCommand: rawCommand}, nil
+		return &acpxAgent{
+			bin:                    bin,
+			target:                 target,
+			rawCommand:             rawCommand,
+			disableProjectSettings: opts.DisableProjectSettings,
+		}, nil
 	}
 	switch name {
 	case types.AgentClaude:

--- a/internal/agent/cursor_quarantine.go
+++ b/internal/agent/cursor_quarantine.go
@@ -93,9 +93,11 @@ func sanitizeQuarantineName(rel string, isDir bool) string {
 
 // Restore renames every quarantined surface back to its original path and
 // removes the quarantine directory only after every parked item is restored.
-// It is safe to call multiple times and on a nil receiver. Partial restore
-// failures are reported; failed items stay parked and remain in q.items so a
-// later Restore can retry without losing the only remaining bytes.
+// Parked bytes are authoritative: a destination recreated during the run is
+// displaced before rename. It is safe to call multiple times and on a nil
+// receiver. Partial restore failures are reported; failed items stay parked
+// and remain in q.items so a later Restore can retry without losing the only
+// remaining bytes.
 func (q *cursorInstructionQuarantine) Restore() error {
 	if q == nil {
 		return nil
@@ -106,6 +108,12 @@ func (q *cursorInstructionQuarantine) Restore() error {
 		if err := os.MkdirAll(filepath.Dir(item.original), 0o755); err != nil {
 			if firstErr == nil {
 				firstErr = fmt.Errorf("restore mkdir %s: %w", item.original, err)
+			}
+			continue
+		}
+		if err := displaceRestoreDestination(item.original); err != nil {
+			if firstErr == nil {
+				firstErr = err
 			}
 			continue
 		}
@@ -125,6 +133,22 @@ func (q *cursorInstructionQuarantine) Restore() error {
 			return fmt.Errorf("remove quarantine dir: %w", err)
 		}
 		q.dir = ""
+	}
+	return nil
+}
+
+// displaceRestoreDestination removes an existing restore target so the parked
+// rename can proceed. Missing destinations are a no-op.
+func displaceRestoreDestination(original string) error {
+	_, err := os.Lstat(original)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("restore stat %s: %w", original, err)
+	}
+	if err := os.RemoveAll(original); err != nil {
+		return fmt.Errorf("restore clear %s: %w", original, err)
 	}
 	return nil
 }

--- a/internal/agent/cursor_quarantine.go
+++ b/internal/agent/cursor_quarantine.go
@@ -1,0 +1,125 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// cursorQuarantineDirPrefix names the private, collision-proof directory created
+// under the agent CWD while a Cursor gate run suppresses project instruction
+// surfaces. Cursor CLI has no --no-project-instructions flag; empirical canaries
+// show it auto-loads root AGENTS.md / CLAUDE.md and .cursor/rules when present,
+// and stops loading them when those paths are absent for the duration of the run.
+const cursorQuarantineDirPrefix = ".no-mistakes-cursor-quarantine-"
+
+// cursorInstructionSurfaces are the project paths Cursor auto-loads. Only
+// .cursor/rules is quarantined under .cursor/ — hooks, mcp.json, and other
+// sibling content must remain visible.
+func cursorInstructionSurfaces() []string {
+	return []string{
+		"AGENTS.md",
+		"CLAUDE.md",
+		filepath.Join(".cursor", "rules"),
+	}
+}
+
+// isCursorGateTarget reports whether this ACP agent is Cursor: the first-class
+// cursor alias or an explicit acp:cursor target. Generic acp:<other> targets
+// never qualify, even if a registry override happens to name cursor-agent.
+func isCursorGateTarget(target string) bool {
+	return target == "cursor"
+}
+
+type quarantinedItem struct {
+	original string
+	parked   string
+}
+
+// cursorInstructionQuarantine holds rename-backed moves of Cursor instruction
+// surfaces so they can be restored byte-exact after the agent exits.
+type cursorInstructionQuarantine struct {
+	dir   string
+	items []quarantinedItem
+}
+
+// beginCursorInstructionQuarantine renames present instruction surfaces out of
+// cwd into a private quarantine directory. Missing surfaces are skipped. On any
+// failure, already-moved items are restored before the error is returned.
+func beginCursorInstructionQuarantine(cwd string) (*cursorInstructionQuarantine, error) {
+	q := &cursorInstructionQuarantine{}
+	if strings.TrimSpace(cwd) == "" {
+		return q, nil
+	}
+	dir, err := os.MkdirTemp(cwd, cursorQuarantineDirPrefix+"*")
+	if err != nil {
+		return nil, fmt.Errorf("create quarantine dir: %w", err)
+	}
+	q.dir = dir
+
+	for _, rel := range cursorInstructionSurfaces() {
+		src := filepath.Join(cwd, rel)
+		fi, err := os.Lstat(src)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			_ = q.Restore()
+			return nil, fmt.Errorf("stat %s: %w", rel, err)
+		}
+		parked := filepath.Join(dir, strconv.Itoa(len(q.items))+"-"+sanitizeQuarantineName(rel, fi.IsDir()))
+		if err := os.Rename(src, parked); err != nil {
+			_ = q.Restore()
+			return nil, fmt.Errorf("quarantine %s: %w", rel, err)
+		}
+		q.items = append(q.items, quarantinedItem{original: src, parked: parked})
+	}
+	if len(q.items) == 0 {
+		_ = os.Remove(dir)
+		q.dir = ""
+	}
+	return q, nil
+}
+
+func sanitizeQuarantineName(rel string, isDir bool) string {
+	name := strings.ReplaceAll(rel, string(filepath.Separator), "_")
+	if isDir {
+		return name + ".dir"
+	}
+	return name
+}
+
+// Restore renames every quarantined surface back to its original path and
+// removes the quarantine directory. It is safe to call multiple times and on a
+// nil receiver. Partial restore failures are reported; remaining items are still
+// attempted.
+func (q *cursorInstructionQuarantine) Restore() error {
+	if q == nil {
+		return nil
+	}
+	var firstErr error
+	for i := len(q.items) - 1; i >= 0; i-- {
+		item := q.items[i]
+		if err := os.MkdirAll(filepath.Dir(item.original), 0o755); err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("restore mkdir %s: %w", item.original, err)
+			}
+			continue
+		}
+		if err := os.Rename(item.parked, item.original); err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("restore %s: %w", item.original, err)
+			}
+		}
+	}
+	q.items = nil
+	if q.dir != "" {
+		if err := os.RemoveAll(q.dir); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("remove quarantine dir: %w", err)
+		}
+		q.dir = ""
+	}
+	return firstErr
+}

--- a/internal/agent/cursor_quarantine.go
+++ b/internal/agent/cursor_quarantine.go
@@ -92,9 +92,10 @@ func sanitizeQuarantineName(rel string, isDir bool) string {
 }
 
 // Restore renames every quarantined surface back to its original path and
-// removes the quarantine directory. It is safe to call multiple times and on a
-// nil receiver. Partial restore failures are reported; remaining items are still
-// attempted.
+// removes the quarantine directory only after every parked item is restored.
+// It is safe to call multiple times and on a nil receiver. Partial restore
+// failures are reported; failed items stay parked and remain in q.items so a
+// later Restore can retry without losing the only remaining bytes.
 func (q *cursorInstructionQuarantine) Restore() error {
 	if q == nil {
 		return nil
@@ -112,14 +113,18 @@ func (q *cursorInstructionQuarantine) Restore() error {
 			if firstErr == nil {
 				firstErr = fmt.Errorf("restore %s: %w", item.original, err)
 			}
+			continue
 		}
+		q.items = append(q.items[:i], q.items[i+1:]...)
 	}
-	q.items = nil
+	if len(q.items) > 0 {
+		return firstErr
+	}
 	if q.dir != "" {
-		if err := os.RemoveAll(q.dir); err != nil && firstErr == nil {
-			firstErr = fmt.Errorf("remove quarantine dir: %w", err)
+		if err := os.RemoveAll(q.dir); err != nil {
+			return fmt.Errorf("remove quarantine dir: %w", err)
 		}
 		q.dir = ""
 	}
-	return firstErr
+	return nil
 }

--- a/internal/agent/cursor_quarantine_run_test.go
+++ b/internal/agent/cursor_quarantine_run_test.go
@@ -1,0 +1,218 @@
+//go:build unix
+
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// writeStubAcpxAssertingQuarantine writes a stub acpx that fails if Cursor
+// instruction surfaces are still visible at CWD, and records whether AGENTS.md
+// was absent during the run.
+func writeStubAcpxAssertingQuarantine(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "acpx")
+	script := `#!/bin/sh
+# argv includes --cwd <path>; find it.
+cwd=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "--cwd" ]; then
+    cwd="$arg"
+    break
+  fi
+  prev="$arg"
+done
+if [ -z "$cwd" ]; then
+  echo "missing --cwd" >&2
+  exit 1
+fi
+visible=""
+if [ -e "$cwd/AGENTS.md" ]; then visible="${visible}AGENTS.md "; fi
+if [ -e "$cwd/CLAUDE.md" ]; then visible="${visible}CLAUDE.md "; fi
+if [ -e "$cwd/.cursor/rules" ]; then visible="${visible}.cursor/rules "; fi
+if [ -n "$visible" ]; then
+  echo "instruction surfaces still visible: $visible" >&2
+  exit 1
+fi
+# Unrelated .cursor content must remain.
+if [ ! -f "$cwd/.cursor/mcp.json" ]; then
+  echo "unrelated .cursor/mcp.json was removed" >&2
+  exit 1
+fi
+printf '%s\n' "$@" > "$NM_TEST_ACPX_ARGS_FILE"
+printf '{"method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","text":"quarantine-ok"}}}\n'
+`
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestAcpxAgent_Run_CursorQuarantinesInstructionFilesUnderOptOut(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		agent types.AgentName
+	}{
+		{name: "cursor alias", agent: types.AgentCursor},
+		{name: "acp:cursor", agent: "acp:cursor"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			argsFile := filepath.Join(dir, "argv.txt")
+			t.Setenv("NM_TEST_ACPX_ARGS_FILE", argsFile)
+			stub := writeStubAcpxAssertingQuarantine(t, dir)
+
+			if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("AYE_CAPTAIN_CANARY\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte("claude-canary\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(filepath.Join(dir, ".cursor", "rules"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, ".cursor", "rules", "x.mdc"), []byte("rule\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, ".cursor", "mcp.json"), []byte("{}"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			a, err := NewWithOptions(tc.agent, stub, nil, Options{DisableProjectSettings: true})
+			if err != nil {
+				t.Fatalf("NewWithOptions: %v", err)
+			}
+			if !NeutralizesGateInstructions(a) {
+				t.Fatal("cursor under opt-out must neutralize")
+			}
+			res, err := a.Run(context.Background(), RunOpts{Prompt: "ping", CWD: dir})
+			if err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+			if res.Text != "quarantine-ok" {
+				t.Errorf("text = %q", res.Text)
+			}
+
+			// Restored after Run.
+			for _, rel := range []string{"AGENTS.md", "CLAUDE.md", filepath.Join(".cursor", "rules")} {
+				if _, err := os.Lstat(filepath.Join(dir, rel)); err != nil {
+					t.Errorf("%s not restored: %v", rel, err)
+				}
+			}
+			body, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+			if err != nil || string(body) != "AYE_CAPTAIN_CANARY\n" {
+				t.Errorf("AGENTS.md body after restore = %q err=%v", body, err)
+			}
+		})
+	}
+}
+
+func TestAcpxAgent_Run_CursorRestoresOnAgentError(t *testing.T) {
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "acpx")
+	script := `#!/bin/sh
+echo boom >&2
+exit 1
+`
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("must-restore\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a, err := NewWithOptions(types.AgentCursor, stub, nil, Options{DisableProjectSettings: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, runErr := a.Run(context.Background(), RunOpts{Prompt: "x", CWD: dir})
+	if runErr == nil {
+		t.Fatal("expected agent error")
+	}
+	body, err := os.ReadFile(filepath.Join(dir, "AGENTS.md"))
+	if err != nil || string(body) != "must-restore\n" {
+		t.Fatalf("AGENTS.md not restored after error: body=%q err=%v", body, err)
+	}
+}
+
+func TestAcpxAgent_Run_NoQuarantineWithoutOptOut(t *testing.T) {
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "argv.txt")
+	t.Setenv("NM_TEST_ACPX_ARGS_FILE", argsFile)
+	// Stub that requires AGENTS.md to still be present (no quarantine).
+	stub := filepath.Join(dir, "acpx")
+	script := `#!/bin/sh
+cwd=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "--cwd" ]; then cwd="$arg"; break; fi
+  prev="$arg"
+done
+if [ ! -f "$cwd/AGENTS.md" ]; then
+  echo "AGENTS.md missing without opt-out" >&2
+  exit 1
+fi
+printf '%s\n' "$@" > "$NM_TEST_ACPX_ARGS_FILE"
+printf '{"method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","text":"visible"}}}\n'
+`
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("keep\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a, err := NewWithOptions(types.AgentCursor, stub, nil, Options{}) // opt-out off
+	if err != nil {
+		t.Fatal(err)
+	}
+	if NeutralizesGateInstructions(a) {
+		t.Fatal("cursor must not claim neutralization without opt-out")
+	}
+	res, err := a.Run(context.Background(), RunOpts{Prompt: "ping", CWD: dir})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Text != "visible" {
+		t.Errorf("text = %q", res.Text)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "AGENTS.md")); err != nil {
+		t.Errorf("AGENTS.md missing: %v", err)
+	}
+}
+
+func TestAcpxAgent_GenericACP_DoesNotNeutralizeOrQuarantine(t *testing.T) {
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "argv.txt")
+	t.Setenv("NM_TEST_ACPX_ARGS_FILE", argsFile)
+	stub := writeStubAcpx(t, dir) // records argv; does not require quarantine
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("stay\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	a, err := NewWithOptions(types.AgentName("acp:gemini"), stub, nil, Options{DisableProjectSettings: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if NeutralizesGateInstructions(a) {
+		t.Fatal("generic acp target must not neutralize under opt-out")
+	}
+	if err := EnsureGateNeutralized(a); err == nil {
+		t.Fatal("EnsureGateNeutralized must refuse generic acp under opt-out")
+	} else if !strings.Contains(err.Error(), "cursor") {
+		t.Errorf("refusal should mention cursor among verified harnesses, got: %v", err)
+	}
+
+	// Even if somehow Run is called, AGENTS.md must remain (no quarantine).
+	_, _ = a.Run(context.Background(), RunOpts{Prompt: "x", CWD: dir})
+	if _, err := os.Stat(filepath.Join(dir, "AGENTS.md")); err != nil {
+		t.Errorf("generic ACP must not quarantine AGENTS.md: %v", err)
+	}
+}

--- a/internal/agent/cursor_quarantine_test.go
+++ b/internal/agent/cursor_quarantine_test.go
@@ -131,6 +131,68 @@ func TestBeginCursorInstructionQuarantine_RestoreAfterSimulatedFailure(t *testin
 	}
 }
 
+func TestCursorInstructionQuarantine_RestoreDisplacesRecreatedDestination(t *testing.T) {
+	cwd := t.TempDir()
+	ruleBody := []byte("parked-rules-canary\n")
+	agentsBody := []byte("parked-agents-canary\n")
+	rulesDir := filepath.Join(cwd, ".cursor", "rules")
+	if err := os.MkdirAll(rulesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rulesDir, "gate.mdc"), ruleBody, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cwd, "AGENTS.md"), agentsBody, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	q, err := beginCursorInstructionQuarantine(cwd)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if len(q.items) != 2 {
+		t.Fatalf("expected two quarantined surfaces, got %d", len(q.items))
+	}
+
+	// Agent recreates instruction surfaces during the run.
+	if err := os.MkdirAll(rulesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rulesDir, "agent.mdc"), []byte("recreated\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cwd, "AGENTS.md"), []byte("recreated-agents\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := q.Restore(); err != nil {
+		t.Fatalf("restore with recreated destinations: %v", err)
+	}
+	gotRule, err := os.ReadFile(filepath.Join(rulesDir, "gate.mdc"))
+	if err != nil || string(gotRule) != string(ruleBody) {
+		t.Fatalf("rules after restore = %q err=%v, want %q", gotRule, err, ruleBody)
+	}
+	if _, err := os.Stat(filepath.Join(rulesDir, "agent.mdc")); !os.IsNotExist(err) {
+		t.Fatalf("recreated agent.mdc must be displaced by parked rules, err=%v", err)
+	}
+	gotAgents, err := os.ReadFile(filepath.Join(cwd, "AGENTS.md"))
+	if err != nil || string(gotAgents) != string(agentsBody) {
+		t.Fatalf("AGENTS.md after restore = %q err=%v, want %q", gotAgents, err, agentsBody)
+	}
+	if len(q.items) != 0 || q.dir != "" {
+		t.Fatalf("successful restore must clear items and dir; items=%d dir=%q", len(q.items), q.dir)
+	}
+	entries, err := os.ReadDir(cwd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), cursorQuarantineDirPrefix) {
+			t.Errorf("quarantine dir %q left behind after restore", e.Name())
+		}
+	}
+}
+
 func TestCursorInstructionQuarantine_RestoreKeepsParkedOnPartialFailure(t *testing.T) {
 	cwd := t.TempDir()
 	ruleBody := []byte("parked-rules-canary\n")
@@ -150,46 +212,25 @@ func TestCursorInstructionQuarantine_RestoreKeepsParkedOnPartialFailure(t *testi
 		t.Fatalf("expected one quarantined surface, got %d", len(q.items))
 	}
 	parked := q.items[0].parked
+	quarantineDir := q.dir
 
-	// Agent recreates .cursor/rules during the run; rename-back then fails (EEXIST for dirs).
-	if err := os.MkdirAll(rulesDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(rulesDir, "agent.mdc"), []byte("recreated\n"), 0o644); err != nil {
+	// Parked path gone: rename cannot succeed; items and quarantine dir must remain.
+	if err := os.RemoveAll(parked); err != nil {
 		t.Fatal(err)
 	}
 
 	err = q.Restore()
 	if err == nil {
-		t.Fatal("expected restore error when destination directory blocks rename")
+		t.Fatal("expected restore error when parked path is missing")
 	}
 	if len(q.items) == 0 {
 		t.Fatal("failed restore must retain parked items for retry")
 	}
-	got, readErr := os.ReadFile(filepath.Join(parked, "gate.mdc"))
-	if readErr != nil || string(got) != string(ruleBody) {
-		t.Fatalf("parked rules destroyed after failed restore: got %q err=%v", got, readErr)
-	}
 	if q.dir == "" {
 		t.Fatal("quarantine dir must remain until every item is restored")
 	}
-	if _, statErr := os.Stat(q.dir); statErr != nil {
+	if _, statErr := os.Stat(quarantineDir); statErr != nil {
 		t.Fatalf("quarantine dir removed while parked items remain: %v", statErr)
-	}
-
-	// Clear the blocking destination and retry — bytes must come back.
-	if err := os.RemoveAll(rulesDir); err != nil {
-		t.Fatal(err)
-	}
-	if err := q.Restore(); err != nil {
-		t.Fatalf("retry restore: %v", err)
-	}
-	got, readErr = os.ReadFile(filepath.Join(rulesDir, "gate.mdc"))
-	if readErr != nil || string(got) != string(ruleBody) {
-		t.Fatalf("rules after retry = %q err=%v, want %q", got, readErr, ruleBody)
-	}
-	if len(q.items) != 0 || q.dir != "" {
-		t.Fatalf("successful restore must clear items and dir; items=%d dir=%q", len(q.items), q.dir)
 	}
 }
 

--- a/internal/agent/cursor_quarantine_test.go
+++ b/internal/agent/cursor_quarantine_test.go
@@ -131,6 +131,68 @@ func TestBeginCursorInstructionQuarantine_RestoreAfterSimulatedFailure(t *testin
 	}
 }
 
+func TestCursorInstructionQuarantine_RestoreKeepsParkedOnPartialFailure(t *testing.T) {
+	cwd := t.TempDir()
+	ruleBody := []byte("parked-rules-canary\n")
+	rulesDir := filepath.Join(cwd, ".cursor", "rules")
+	if err := os.MkdirAll(rulesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rulesDir, "gate.mdc"), ruleBody, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	q, err := beginCursorInstructionQuarantine(cwd)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if len(q.items) != 1 {
+		t.Fatalf("expected one quarantined surface, got %d", len(q.items))
+	}
+	parked := q.items[0].parked
+
+	// Agent recreates .cursor/rules during the run; rename-back then fails (EEXIST for dirs).
+	if err := os.MkdirAll(rulesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rulesDir, "agent.mdc"), []byte("recreated\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err = q.Restore()
+	if err == nil {
+		t.Fatal("expected restore error when destination directory blocks rename")
+	}
+	if len(q.items) == 0 {
+		t.Fatal("failed restore must retain parked items for retry")
+	}
+	got, readErr := os.ReadFile(filepath.Join(parked, "gate.mdc"))
+	if readErr != nil || string(got) != string(ruleBody) {
+		t.Fatalf("parked rules destroyed after failed restore: got %q err=%v", got, readErr)
+	}
+	if q.dir == "" {
+		t.Fatal("quarantine dir must remain until every item is restored")
+	}
+	if _, statErr := os.Stat(q.dir); statErr != nil {
+		t.Fatalf("quarantine dir removed while parked items remain: %v", statErr)
+	}
+
+	// Clear the blocking destination and retry — bytes must come back.
+	if err := os.RemoveAll(rulesDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := q.Restore(); err != nil {
+		t.Fatalf("retry restore: %v", err)
+	}
+	got, readErr = os.ReadFile(filepath.Join(rulesDir, "gate.mdc"))
+	if readErr != nil || string(got) != string(ruleBody) {
+		t.Fatalf("rules after retry = %q err=%v, want %q", got, readErr, ruleBody)
+	}
+	if len(q.items) != 0 || q.dir != "" {
+		t.Fatalf("successful restore must clear items and dir; items=%d dir=%q", len(q.items), q.dir)
+	}
+}
+
 func TestIsCursorGateTarget(t *testing.T) {
 	if !isCursorGateTarget("cursor") {
 		t.Error("cursor target must qualify")

--- a/internal/agent/cursor_quarantine_test.go
+++ b/internal/agent/cursor_quarantine_test.go
@@ -1,0 +1,144 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBeginCursorInstructionQuarantine_MovesAndRestores(t *testing.T) {
+	cwd := t.TempDir()
+	agentsBody := []byte("AYE_CAPTAIN_CANARY\n")
+	claudeBody := []byte("# CLAUDE\n")
+	if err := os.WriteFile(filepath.Join(cwd, "AGENTS.md"), agentsBody, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cwd, "CLAUDE.md"), claudeBody, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rulesDir := filepath.Join(cwd, ".cursor", "rules")
+	if err := os.MkdirAll(rulesDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ruleBody := []byte("rule-canary\n")
+	if err := os.WriteFile(filepath.Join(rulesDir, "gate.mdc"), ruleBody, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Unrelated .cursor content must stay put.
+	mcpBody := []byte(`{"mcpServers":{}}`)
+	if err := os.WriteFile(filepath.Join(cwd, ".cursor", "mcp.json"), mcpBody, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	q, err := beginCursorInstructionQuarantine(cwd)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	for _, rel := range cursorInstructionSurfaces() {
+		if _, err := os.Lstat(filepath.Join(cwd, rel)); !os.IsNotExist(err) {
+			t.Errorf("%s still visible at CWD during quarantine (err=%v)", rel, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(cwd, ".cursor", "mcp.json")); err != nil {
+		t.Errorf("unrelated .cursor/mcp.json must remain: %v", err)
+	}
+	entries, err := os.ReadDir(cwd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundQuarantine := false
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), cursorQuarantineDirPrefix) {
+			foundQuarantine = true
+			break
+		}
+	}
+	if !foundQuarantine {
+		t.Error("expected a private quarantine directory under CWD")
+	}
+
+	if err := q.Restore(); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	gotAgents, err := os.ReadFile(filepath.Join(cwd, "AGENTS.md"))
+	if err != nil || string(gotAgents) != string(agentsBody) {
+		t.Errorf("AGENTS.md restore = %q err=%v, want %q", gotAgents, err, agentsBody)
+	}
+	gotClaude, err := os.ReadFile(filepath.Join(cwd, "CLAUDE.md"))
+	if err != nil || string(gotClaude) != string(claudeBody) {
+		t.Errorf("CLAUDE.md restore = %q err=%v, want %q", gotClaude, err, claudeBody)
+	}
+	gotRule, err := os.ReadFile(filepath.Join(rulesDir, "gate.mdc"))
+	if err != nil || string(gotRule) != string(ruleBody) {
+		t.Errorf("rules restore = %q err=%v, want %q", gotRule, err, ruleBody)
+	}
+	gotMCP, err := os.ReadFile(filepath.Join(cwd, ".cursor", "mcp.json"))
+	if err != nil || string(gotMCP) != string(mcpBody) {
+		t.Errorf("mcp.json disturbed: %q err=%v", gotMCP, err)
+	}
+	entries, err = os.ReadDir(cwd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), cursorQuarantineDirPrefix) {
+			t.Errorf("quarantine dir %q left behind after restore", e.Name())
+		}
+	}
+}
+
+func TestBeginCursorInstructionQuarantine_MissingSurfacesOK(t *testing.T) {
+	cwd := t.TempDir()
+	q, err := beginCursorInstructionQuarantine(cwd)
+	if err != nil {
+		t.Fatalf("begin with no surfaces: %v", err)
+	}
+	if err := q.Restore(); err != nil {
+		t.Fatalf("restore empty: %v", err)
+	}
+}
+
+func TestBeginCursorInstructionQuarantine_RestoreAfterSimulatedFailure(t *testing.T) {
+	cwd := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cwd, "AGENTS.md"), []byte("keep-me\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cwd, "CLAUDE.md"), []byte("claude\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	rulesParent := filepath.Join(cwd, ".cursor")
+	if err := os.MkdirAll(filepath.Join(rulesParent, "rules"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	q, err := beginCursorInstructionQuarantine(cwd)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	// Caller must restore even when the subsequent agent Run fails.
+	if err := q.Restore(); err != nil {
+		t.Fatalf("restore after simulated error path: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cwd, "AGENTS.md")); err != nil {
+		t.Errorf("AGENTS.md missing after restore-on-error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cwd, "CLAUDE.md")); err != nil {
+		t.Errorf("CLAUDE.md missing after restore-on-error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(rulesParent, "rules")); err != nil {
+		t.Errorf(".cursor/rules missing after restore-on-error: %v", err)
+	}
+}
+
+func TestIsCursorGateTarget(t *testing.T) {
+	if !isCursorGateTarget("cursor") {
+		t.Error("cursor target must qualify")
+	}
+	if isCursorGateTarget("gemini") {
+		t.Error("generic ACP target must not qualify")
+	}
+	if isCursorGateTarget("") {
+		t.Error("empty target must not qualify")
+	}
+}

--- a/internal/agent/gateneutralize_test.go
+++ b/internal/agent/gateneutralize_test.go
@@ -19,12 +19,12 @@ func optOutAgent(t *testing.T, name types.AgentName, extraArgs []string) Agent {
 }
 
 // TestNeutralizesGateInstructions_OnlyVerifiedHarnessesUnderOptOut is the core
-// fail-closed contract: under the opt-out, only codex and claude (whose
-// suppression knobs are empirically verified) neutralize the target repo's
+// fail-closed contract: under the opt-out, only codex, claude, and cursor (whose
+// suppression paths are empirically verified) neutralize the target repo's
 // project agent settings/instructions; every other harness reports false and is
 // refused rather than launched with project instructions loaded.
 func TestNeutralizesGateInstructions_OnlyVerifiedHarnessesUnderOptOut(t *testing.T) {
-	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude} {
+	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentCursor, "acp:cursor"} {
 		if !NeutralizesGateInstructions(optOutAgent(t, name, nil)) {
 			t.Errorf("%s must neutralize under the opt-out with its default knob", name)
 		}
@@ -40,7 +40,7 @@ func TestNeutralizesGateInstructions_OnlyVerifiedHarnessesUnderOptOut(t *testing
 		t.Fatalf("acp NewWithOptions: %v", err)
 	}
 	if NeutralizesGateInstructions(acp) {
-		t.Error("acp adapter must NOT report neutralized")
+		t.Error("generic acp adapter must NOT report neutralized")
 	}
 	if NeutralizesGateInstructions(NewNoop()) {
 		t.Error("noop agent must NOT report neutralized")
@@ -50,11 +50,11 @@ func TestNeutralizesGateInstructions_OnlyVerifiedHarnessesUnderOptOut(t *testing
 	}
 }
 
-// TestNeutralizesGateInstructions_FalseWithoutOptOut proves codex/claude do NOT
-// claim neutralization when the repo did not opt out - the gate only consults
+// TestNeutralizesGateInstructions_FalseWithoutOptOut proves verified harnesses do
+// NOT claim neutralization when the repo did not opt out - the gate only consults
 // this under the opt-out, but the value must be honest.
 func TestNeutralizesGateInstructions_FalseWithoutOptOut(t *testing.T) {
-	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude} {
+	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentCursor, "acp:cursor"} {
 		a, err := NewWithOptions(name, string(name), nil, Options{}) // no opt-out
 		if err != nil {
 			t.Fatalf("NewWithOptions(%s): %v", name, err)
@@ -66,13 +66,12 @@ func TestNeutralizesGateInstructions_FalseWithoutOptOut(t *testing.T) {
 }
 
 // TestEnsureGateNeutralized_RefusesUnsupportedUnderOptOut proves the gate fails
-// closed for an unsupported harness with a clear error, and admits codex/claude.
+// closed for an unsupported harness with a clear error, and admits verified ones.
 func TestEnsureGateNeutralized_RefusesUnsupportedUnderOptOut(t *testing.T) {
-	if err := EnsureGateNeutralized(optOutAgent(t, types.AgentCodex, nil)); err != nil {
-		t.Errorf("codex must pass the gate under opt-out: %v", err)
-	}
-	if err := EnsureGateNeutralized(optOutAgent(t, types.AgentClaude, nil)); err != nil {
-		t.Errorf("claude must pass the gate under opt-out: %v", err)
+	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentCursor, "acp:cursor"} {
+		if err := EnsureGateNeutralized(optOutAgent(t, name, nil)); err != nil {
+			t.Errorf("%s must pass the gate under opt-out: %v", name, err)
+		}
 	}
 	err := EnsureGateNeutralized(optOutAgent(t, types.AgentOpenCode, nil))
 	if err == nil {
@@ -80,6 +79,9 @@ func TestEnsureGateNeutralized_RefusesUnsupportedUnderOptOut(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "does not neutralize") || !strings.Contains(err.Error(), "opencode") {
 		t.Errorf("refusal error should name the harness and reason, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "cursor") {
+		t.Errorf("refusal error should mention cursor among verified harnesses, got: %v", err)
 	}
 	if err := EnsureGateNeutralized(nil); err == nil {
 		t.Error("a nil agent must be refused")
@@ -94,15 +96,19 @@ func TestNeutralizesGateInstructions_ThroughProductionWrapping(t *testing.T) {
 	if !NeutralizesGateInstructions(WithSteering(optOutAgent(t, types.AgentCodex, nil))) {
 		t.Error("WithSteering(codex) must remain neutralized under opt-out")
 	}
+	if !NeutralizesGateInstructions(WithSteering(optOutAgent(t, types.AgentCursor, nil))) {
+		t.Error("WithSteering(cursor) must remain neutralized under opt-out")
+	}
 	if NeutralizesGateInstructions(WithSteering(optOutAgent(t, types.AgentOpenCode, nil))) {
 		t.Error("WithSteering(opencode) must remain non-neutralized")
 	}
 	allVerified := NewFallback([]Agent{
 		WithSteering(optOutAgent(t, types.AgentCodex, nil)),
 		WithSteering(optOutAgent(t, types.AgentClaude, nil)),
+		WithSteering(optOutAgent(t, types.AgentCursor, nil)),
 	})
 	if err := EnsureGateNeutralized(allVerified); err != nil {
-		t.Errorf("fallback [codex, claude] must pass under opt-out: %v", err)
+		t.Errorf("fallback [codex, claude, cursor] must pass under opt-out: %v", err)
 	}
 	oneUnverified := NewFallback([]Agent{
 		WithSteering(optOutAgent(t, types.AgentCodex, nil)),
@@ -110,6 +116,13 @@ func TestNeutralizesGateInstructions_ThroughProductionWrapping(t *testing.T) {
 	})
 	if err := EnsureGateNeutralized(oneUnverified); err == nil {
 		t.Error("fallback [codex, opencode] must be refused under opt-out")
+	}
+	cursorPlusUnverified := NewFallback([]Agent{
+		WithSteering(optOutAgent(t, types.AgentCursor, nil)),
+		WithSteering(optOutAgent(t, types.AgentPi, nil)),
+	})
+	if err := EnsureGateNeutralized(cursorPlusUnverified); err == nil {
+		t.Error("fallback [cursor, pi] must be refused under opt-out")
 	}
 }
 

--- a/internal/daemon/gateneutralize_test.go
+++ b/internal/daemon/gateneutralize_test.go
@@ -18,7 +18,7 @@ func fakeLookPath(bin string) (string, error) { return "/fake/bin/" + bin, nil }
 // opt-out (disable_project_settings=true), a verified harness passes the gate and
 // its pipeline agent reports neutralized.
 func TestNewPipelineAgent_OptOut_AdmitsVerifiedHarness(t *testing.T) {
-	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude} {
+	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentCursor, "acp:cursor"} {
 		cfg := &config.Config{Agent: name, DisableProjectSettings: true}
 		ag, err := newPipelineAgent(context.Background(), cfg, fakeLookPath)
 		if err != nil {
@@ -36,7 +36,7 @@ func TestNewPipelineAgent_OptOut_AdmitsVerifiedHarness(t *testing.T) {
 // verified neutralization knob is refused rather than launched with project
 // instructions loaded.
 func TestNewPipelineAgent_OptOut_RefusesUnverifiedHarness(t *testing.T) {
-	for _, name := range []types.AgentName{types.AgentOpenCode, types.AgentPi, types.AgentCopilot} {
+	for _, name := range []types.AgentName{types.AgentOpenCode, types.AgentPi, types.AgentCopilot, "acp:gemini"} {
 		cfg := &config.Config{Agent: name, DisableProjectSettings: true}
 		if _, err := newPipelineAgent(context.Background(), cfg, fakeLookPath); err == nil {
 			t.Fatalf("%s must be refused under opt-out", name)
@@ -53,7 +53,7 @@ func TestNewPipelineAgent_NoOptOut_AdmitsEveryHarness(t *testing.T) {
 	// rovodev is omitted: its resolution runs a real version probe that a fake
 	// binary path cannot satisfy. opencode/pi/copilot already prove that an
 	// unverified adapter is admitted when the repo did not opt out.
-	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentOpenCode, types.AgentPi, types.AgentCopilot} {
+	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentOpenCode, types.AgentPi, types.AgentCopilot, types.AgentCursor} {
 		cfg := &config.Config{Agent: name} // DisableProjectSettings defaults false
 		ag, err := newPipelineAgent(context.Background(), cfg, fakeLookPath)
 		if err != nil {
@@ -85,7 +85,7 @@ func TestNewPipelineAgent_OptOut_FallbackRefusesAnyUnverifiedMember(t *testing.T
 	if _, err := newPipelineAgent(context.Background(), cfg, fakeLookPath); err == nil {
 		t.Fatal("a fallback list containing an unverified harness must be refused under opt-out")
 	}
-	cfg = &config.Config{Agents: []types.AgentName{types.AgentCodex, types.AgentClaude}, DisableProjectSettings: true}
+	cfg = &config.Config{Agents: []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentCursor}, DisableProjectSettings: true}
 	if ag, err := newPipelineAgent(context.Background(), cfg, fakeLookPath); err != nil {
 		t.Fatalf("a fallback list of only verified harnesses must pass under opt-out, got: %v", err)
 	} else {

--- a/internal/daemon/startup_scale_log_test.go
+++ b/internal/daemon/startup_scale_log_test.go
@@ -1,0 +1,36 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Parent IPC readiness can observe ServeReady before the child emits
+// phase=ipc_health. This pins the poll helper so that race cannot flake CI.
+func TestWaitForDaemonLogFragments_AcceptsLateIpcHealth(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "daemon.log")
+	early := []byte("phase=ipc_bind duration_ms=0\n")
+	if err := os.WriteFile(logPath, early, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	late := append(early, []byte(
+		"phase=ipc_health duration_ms=1\nmsg=\"daemon ready\" pid=1\n",
+	)...)
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		_ = os.WriteFile(logPath, late, 0o644)
+	}()
+
+	got := waitForDaemonLogFragments(t, logPath, []string{
+		"phase=ipc_bind",
+		"phase=ipc_health",
+		`msg="daemon ready"`,
+	}, time.Second)
+	if string(got) != string(late) {
+		t.Fatalf("log = %q, want late contents", got)
+	}
+}

--- a/internal/daemon/startup_scale_test.go
+++ b/internal/daemon/startup_scale_test.go
@@ -120,21 +120,21 @@ func startColdDetachedFixture(t *testing.T, gateCount int, delayedGit bool) time
 			shutdownIsolatedDaemon(t, p, pid)
 		}
 	})
-	// The caller's health response can arrive just before the daemon appends
-	// its post-health phase and ready summaries. Wait for that explicit log
-	// contract instead of racing the final writes after readiness.
-	var logData []byte
-	logDeadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(logDeadline) {
-		logData, err = os.ReadFile(p.DaemonLog())
-		if err == nil && strings.Contains(string(logData), `msg="daemon ready"`) {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
+	// Parent readiness observes ServeReady before the child finishes its own
+	// confirmLocalIPCHealth and emits phase=ipc_health / "daemon ready". Poll
+	// so a fast parent cannot race the log assertion.
+	requiredFragments := []string{
+		"phase=environment",
+		"phase=database",
+		"phase=gate_migration",
+		fmt.Sprintf("gate_count=%d", gateCount),
+		"phase=stale_runs",
+		"phase=worktree_cleanup",
+		"phase=ipc_bind",
+		"phase=ipc_health",
+		"msg=\"daemon ready\"",
 	}
-	if err != nil {
-		t.Fatalf("read isolated daemon log: %v", err)
-	}
+	logData := waitForDaemonLogFragments(t, p.DaemonLog(), requiredFragments, 2*time.Second)
 	if evidenceDir := os.Getenv("NM_TEST_STARTUP_EVIDENCE_DIR"); evidenceDir != "" {
 		if err := os.MkdirAll(evidenceDir, 0o755); err != nil {
 			t.Fatalf("create startup evidence directory: %v", err)
@@ -145,22 +145,36 @@ func startColdDetachedFixture(t *testing.T, gateCount int, delayedGit bool) time
 		}
 		t.Logf("startup evidence: %s", evidencePath)
 	}
-	for _, fragment := range []string{
-		"phase=environment",
-		"phase=database",
-		"phase=gate_migration",
-		fmt.Sprintf("gate_count=%d", gateCount),
-		"phase=stale_runs",
-		"phase=worktree_cleanup",
-		"phase=ipc_bind",
-		"phase=ipc_health",
-		"msg=\"daemon ready\"",
-	} {
-		if !strings.Contains(string(logData), fragment) {
-			t.Fatalf("startup log with %d gates missing %q:\n%s", gateCount, fragment, logData)
-		}
-	}
 	shutdownIsolatedDaemon(t, p, pid)
 	stopped = true
 	return elapsed
+}
+
+func waitForDaemonLogFragments(t *testing.T, logPath string, fragments []string, timeout time.Duration) []byte {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var last []byte
+	var lastErr error
+	for {
+		last, lastErr = os.ReadFile(logPath)
+		if lastErr == nil {
+			text := string(last)
+			missing := ""
+			for _, fragment := range fragments {
+				if !strings.Contains(text, fragment) {
+					missing = fragment
+					break
+				}
+			}
+			if missing == "" {
+				return last
+			}
+			if !time.Now().Before(deadline) {
+				t.Fatalf("startup log missing %q after %v:\n%s", missing, timeout, last)
+			}
+		} else if !time.Now().Before(deadline) {
+			t.Fatalf("read daemon log: %v", lastErr)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }


### PR DESCRIPTION
## Intent

Enable Cursor as a verified disable_project_settings neutralizer via instruction-file quarantine so Cursor-only fleets (including firstmate) can run the full pipeline.

Cursor CLI has no --no-project-instructions flag; empirical canary showed AGENTS.md auto-load is neutralized by ensuring those instruction files are absent from the agent workspace for the duration of the gate run. Approach: managed quarantine of root AGENTS.md, CLAUDE.md, and .cursor/rules (only rules under .cursor/, not unrelated content) with byte-exact restore after every Run including failure paths. NeutralizesGateInstructions is true only when disable_project_settings is on AND the agent is Cursor (cursor / acp:cursor); generic acp:<other> stays refused. Do not weaken Codex/Claude neutralization.

## What Changed
- Treats Cursor (`cursor` / `acp:cursor`) as a verified `disable_project_settings` neutralizer by quarantining auto-loaded instruction surfaces (`AGENTS.md`, `CLAUDE.md`, and `.cursor/rules`) for each gate `Run`, then restoring them byte-exact—including failure paths—by displacing recreated destinations and retaining parked copies until every restore succeeds.
- Wires `disableProjectSettings` into the ACP Cursor agent so `NeutralizesGateInstructions` is true only for Cursor under the opt-out; generic `acp:<other>` targets stay refused and Codex/Claude neutralization is unchanged.
- Documents the Cursor quarantine path in repo-config and agents guidance.

## Risk Assessment

✅ Low: Round-1/2 restore invariants are in place (parked retention plus displace-before-rename), Cursor neutralization matches the stated intent without weakening Codex/Claude, and generic ACP remains fail-closed.

## Testing

Focused agent/daemon quarantine and gate-neutralization tests all passed, and a Cursor Run transcript shows instruction surfaces absent during the agent invocation then restored byte-exact with mcp.json untouched; no UI surface so evidence is CLI/cwd listings rather than screenshots.

<details>
<summary>Evidence: End-to-end Cursor quarantine before/during/after transcript</summary>

<code>NeutralizesGateInstructions(cursor, opt-out=true): true&#10;EnsureGateNeutralized(cursor): admitted&#10;NeutralizesGateInstructions(acp:gemini, opt-out=true): false&#10;EnsureGateNeutralized(acp:gemini): REFUSED&#10;DURING RUN: AGENTS.md/CLAUDE.md/.cursor/rules absent; mcp.json present; .no-mistakes-cursor-quarantine-* present&#10;AFTER RUN: AGENTS.md=&#34;AYE_CAPTAIN_CANARY\n&#34; CLAUDE.md=&#34;# CLAUDE canary\n&#34; rules restored; quarantine dir gone</code>

```text
=== BEFORE RUN ===
CWD entries:
  .cursor
  AGENTS.md
  CLAUDE.md
.cursor entries:
  mcp.json
  rules
AGENTS.md bytes: "AYE_CAPTAIN_CANARY\n"
CLAUDE.md bytes: "# CLAUDE canary\n"
rules/gate.mdc: "rule-canary\n"
mcp.json: "{\"mcpServers\":{}}\n"
NeutralizesGateInstructions(cursor, opt-out=true): true
EnsureGateNeutralized(cursor): admitted
NeutralizesGateInstructions(acp:cursor, opt-out=true): true
EnsureGateNeutralized(acp:cursor): admitted
NeutralizesGateInstructions(acp:gemini, opt-out=true): false
EnsureGateNeutralized(acp:gemini): REFUSED: gate agent "acp:gemini" does not neutralize the target repository's project agent-instruction files (AGENTS.md/CLAUDE.md); refusing to launch it in the target checkout. Only codex, claude, and cursor have a verified neutralization path (and only when it is not overridden by agent_args_override for native agents); set 'agent' to codex, claude, or cursor in ~/.no-mistakes/config.yaml
NeutralizesGateInstructions(cursor, opt-out=false): false

=== INVOKING cursor Run (disable_project_settings=true) ===
agent text: "quarantine-ok"

=== DURING RUN (agent CWD listing) ===
total 0
drwxr-xr-x. 4 diegomacias diegomacias  80 Jul 23 13:23 .
drwxr-xr-x. 3 diegomacias diegomacias 220 Jul 23 13:23 ..
drwxr-xr-x. 2 diegomacias diegomacias  60 Jul 23 13:23 .cursor
drwx------. 3 diegomacias diegomacias 100 Jul 23 13:23 .no-mistakes-cursor-quarantine-659824996
=== .cursor listing during run ===
total 4
drwxr-xr-x. 2 diegomacias diegomacias 60 Jul 23 13:23 .
drwxr-xr-x. 4 diegomacias diegomacias 80 Jul 23 13:23 ..
-rw-r--r--. 1 diegomacias diegomacias 18 Jul 23 13:23 mcp.json
=== quarantine dirs during run ===
drwx------. 3 diegomacias diegomacias 100 Jul 23 13:23 /tmp/no-mistakes-evidence/01KY82FKXPXSKPNJ96JMN7PXTN/demo-workspace/.no-mistakes-cursor-quarantine-659824996
OK: AGENTS.md/CLAUDE.md/.cursor/rules absent; mcp.json present

=== AFTER RUN (byte-exact restore) ===
CWD entries:
  .cursor
  AGENTS.md
  CLAUDE.md
.cursor entries:
  mcp.json
  rules
AGENTS.md bytes: "AYE_CAPTAIN_CANARY\n"
CLAUDE.md bytes: "# CLAUDE canary\n"
rules/gate.mdc: "rule-canary\n"
mcp.json: "{\"mcpServers\":{}}\n"
OK: no quarantine dir left behind; AGENTS.md/CLAUDE.md/.cursor/rules restored byte-exact; mcp.json undisturbed
```
</details>
<details>
<summary>Evidence: During-run agent CWD listing (instruction surfaces quarantined)</summary>

```text
=== DURING RUN (agent CWD listing) ===
total 0
drwxr-xr-x. 4 diegomacias diegomacias  80 Jul 23 13:23 .
drwxr-xr-x. 3 diegomacias diegomacias 220 Jul 23 13:23 ..
drwxr-xr-x. 2 diegomacias diegomacias  60 Jul 23 13:23 .cursor
drwx------. 3 diegomacias diegomacias 100 Jul 23 13:23 .no-mistakes-cursor-quarantine-659824996
=== .cursor listing during run ===
total 4
drwxr-xr-x. 2 diegomacias diegomacias 60 Jul 23 13:23 .
drwxr-xr-x. 4 diegomacias diegomacias 80 Jul 23 13:23 ..
-rw-r--r--. 1 diegomacias diegomacias 18 Jul 23 13:23 mcp.json
=== quarantine dirs during run ===
drwx------. 3 diegomacias diegomacias 100 Jul 23 13:23 /tmp/no-mistakes-evidence/01KY82FKXPXSKPNJ96JMN7PXTN/demo-workspace/.no-mistakes-cursor-quarantine-659824996
OK: AGENTS.md/CLAUDE.md/.cursor/rules absent; mcp.json present
```
</details>
<details>
<summary>Evidence: Persisted workspace after byte-exact restore</summary>

```text
=== Persisted workspace after successful Cursor gate Run ===
/tmp/no-mistakes-evidence/01KY82FKXPXSKPNJ96JMN7PXTN/demo-workspace/.cursor/mcp.json
  bytes="{\"mcpServers\":{}}\n"
/tmp/no-mistakes-evidence/01KY82FKXPXSKPNJ96JMN7PXTN/demo-workspace/.cursor/rules/gate.mdc
  bytes="rule-canary\n"
/tmp/no-mistakes-evidence/01KY82FKXPXSKPNJ96JMN7PXTN/demo-workspace/AGENTS.md
  bytes="AYE_CAPTAIN_CANARY\n"
/tmp/no-mistakes-evidence/01KY82FKXPXSKPNJ96JMN7PXTN/demo-workspace/CLAUDE.md
  bytes="# CLAUDE canary\n"
```
</details>
<details>
<summary>Evidence: Focused agent quarantine/neutralization test log</summary>

```text
=== RUN   TestAcpxAgent_Run_CursorSpawnsDefaultCommandWithoutOverrides
=== RUN   TestAcpxAgent_Run_CursorSpawnsDefaultCommandWithoutOverrides/cursor_alias
    acpx_spawn_test.go:76: spawned: acpx --agent cursor-agent acp --cwd /tmp/TestAcpxAgent_Run_CursorSpawnsDefaultCommandWithoutOverridescur2574083882/001 --format json --json-strict --approve-all --non-interactive-permissions deny --suppress-reads exec review this change
=== RUN   TestAcpxAgent_Run_CursorSpawnsDefaultCommandWithoutOverrides/explicit_acp:cursor_target
    acpx_spawn_test.go:76: spawned: acpx --agent cursor-agent acp --cwd /tmp/TestAcpxAgent_Run_CursorSpawnsDefaultCommandWithoutOverridesexp1615916960/001 --format json --json-strict --approve-all --non-interactive-permissions deny --suppress-reads exec review this change
--- PASS: TestAcpxAgent_Run_CursorSpawnsDefaultCommandWithoutOverrides (0.02s)
    --- PASS: TestAcpxAgent_Run_CursorSpawnsDefaultCommandWithoutOverrides/cursor_alias (0.01s)
    --- PASS: TestAcpxAgent_Run_CursorSpawnsDefaultCommandWithoutOverrides/explicit_acp:cursor_target (0.01s)
=== RUN   TestAcpxAgent_Run_CursorQuarantinesInstructionFilesUnderOptOut
=== RUN   TestAcpxAgent_Run_CursorQuarantinesInstructionFilesUnderOptOut/cursor_alias
=== RUN   TestAcpxAgent_Run_CursorQuarantinesInstructionFilesUnderOptOut/acp:cursor
--- PASS: TestAcpxAgent_Run_CursorQuarantinesInstructionFilesUnderOptOut (0.02s)
    --- PASS: TestAcpxAgent_Run_CursorQuarantinesInstructionFilesUnderOptOut/cursor_alias (0.01s)
    --- PASS: TestAcpxAgent_Run_CursorQuarantinesInstructionFilesUnderOptOut/acp:cursor (0.01s)
=== RUN   TestAcpxAgent_Run_CursorRestoresOnAgentError
--- PASS: TestAcpxAgent_Run_CursorRestoresOnAgentError (0.01s)
=== RUN   TestAcpxAgent_GenericACP_DoesNotNeutralizeOrQuarantine
--- PASS: TestAcpxAgent_GenericACP_DoesNotNeutralizeOrQuarantine (0.01s)
=== RUN   TestBeginCursorInstructionQuarantine_MovesAndRestores
--- PASS: TestBeginCursorInstructionQuarantine_MovesAndRestores (0.00s)
=== RUN   TestBeginCursorInstructionQuarantine_MissingSurfacesOK
--- PASS: TestBeginCursorInstructionQuarantine_MissingSurfacesOK (0.00s)
=== RUN   TestBeginCursorInstructionQuarantine_RestoreAfterSimulatedFailure
--- PASS: TestBeginCursorInstructionQuarantine_RestoreAfterSimulatedFailure (0.00s)
=== RUN   TestIsCursorGateTarget
--- PASS: TestIsCursorGateTarget (0.00s)
=== RUN   TestNeutralizesGateInstructions_OnlyVerifiedHarnessesUnderOptOut
--- PASS: TestNeutralizesGateInstructions_OnlyVerifiedHarnessesUnderOptOut (0.00s)
=== RUN   TestNeutralizesGateInstructions_FalseWithoutOptOut
--- PASS: TestNeutralizesGateInstructions_FalseWithoutOptOut (0.00s)
=== RUN   TestEnsureGateNeutralized_RefusesUnsupportedUnderOptOut
--- PASS: TestEnsureGateNeutralized_RefusesUnsupportedUnderOptOut (0.00s)
=== RUN   TestNeutralizesGateInstructions_ThroughProductionWrapping
--- PASS: TestNeutralizesGateInstructions_ThroughProductionWrapping (0.00s)
=== RUN   TestNeutralizesGateInstructions_HonestOnEffectiveOverride
--- PASS: TestNeutralizesGateInstructions_HonestOnEffectiveOverride (0.00s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/agent	1.349s
```
</details>
<details>
<summary>Evidence: Daemon opt-out admission test log</summary>

```text
=== RUN   TestNewPipelineAgent_OptOut_AdmitsVerifiedHarness
--- PASS: TestNewPipelineAgent_OptOut_AdmitsVerifiedHarness (0.00s)
=== RUN   TestNewPipelineAgent_OptOut_RefusesUnverifiedHarness
--- PASS: TestNewPipelineAgent_OptOut_RefusesUnverifiedHarness (0.00s)
=== RUN   TestNewPipelineAgent_OptOut_RefusesDefeatedKnob
--- PASS: TestNewPipelineAgent_OptOut_RefusesDefeatedKnob (0.00s)
=== RUN   TestNewPipelineAgent_OptOut_FallbackRefusesAnyUnverifiedMember
--- PASS: TestNewPipelineAgent_OptOut_FallbackRefusesAnyUnverifiedMember (0.00s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/daemon	1.044s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `internal/agent/cursor_quarantine.go:117` - Restore always clears q.items and os.RemoveAll(q.dir) even when some renames/mkdirs failed. Reachable sequence: beginCursorInstructionQuarantine moves .cursor/rules (a directory) into the quarantine dir → during Run the agent recreates .cursor/rules (or any restore rename fails for permissions/EEXIST) → os.Rename(parked, original) fails for that directory → RemoveAll deletes the parked original. That permanently destroys the only remaining copy of quarantined instruction surfaces and violates the required byte-exact restore-on-failure-path invariant. Fix at this shared Restore boundary: track per-item success; never RemoveAll (and never drop failed items) while any parked path still needs restore; only remove the quarantine dir after every item is restored (or leave it in place and return a clear error so the bytes remain recoverable).

🔧 Fix: Keep parked quarantine files until restore succeeds
1 error still open:
- 🚨 `internal/agent/cursor_quarantine.go:112` - Required intent: &#34;byte-exact restore after every Run including failure paths&#34;. Reachable miss: beginCursorInstructionQuarantine renames `.cursor/rules` (a directory) into the quarantine dir → during Run the Cursor agent recreates `.cursor/rules` → Restore&#39;s os.Rename(parked, original) fails (EEXIST for dirs) and returns without restoring → acpx.Run&#39;s defer (acpx.go:53-59) turns that into a hard Run error. Production never clears the blocking destination and never retries Restore (only the unit test does RemoveAll then retry). Round-1 parked retention correctly avoids deleting the only copy, but the surfaces still are not restored to their original paths after the Run. Earliest shared boundary: in Restore, when original exists, remove/displace that blocker (parked bytes are authoritative), then Rename; keep &#34;do not RemoveAll the quarantine dir / drop items until every parked surface is restored&#34;.

🔧 Fix: Displace blockers before restoring quarantined Cursor surfaces
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./internal/agent/ -run 'TestAcpxAgent_Run_CursorQuarantinesInstructionFilesUnderOptOut|TestAcpxAgent_Run_CursorRestoresOnAgentError|TestAcpxAgent_Run_NoQuarantineWithoutOptOut|TestAcpxAgent_GenericACP_DoesNotNeutralizeOrQuarantine' -count=1 -v`
- `go test -race ./internal/agent/ -run 'TestBeginCursorInstructionQuarantine_|TestCursorInstructionQuarantine_Restore|TestIsCursorGateTarget' -count=1 -v`
- `go test -race ./internal/agent/ -run 'TestNeutralizesGateInstructions_|TestEnsureGateNeutralized_RefusesUnsupportedUnderOptOut' -count=1 -v`
- `go test -race ./internal/daemon/ -run 'TestNewPipelineAgent_OptOut' -count=1 -v`
- <code>Manual evidence harness: Cursor `Run` with stub acpx under `disable_project_settings=true`, capturing before/during/after CWD listings and NeutralizesGateInstructions/EnsureGateNeutralized for cursor, acp:cursor, and acp:gemini</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 2)

🔧 Fix: Confirm make lint clean with Go on PATH
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
