### PR TITLE
fix: recover active CI monitors from remote truth

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -329,13 +329,13 @@ func recoverOnStartup(d *db.DB, p *paths.Paths, mgr *RunManager) {
 		"failed", gateStats.Failed,
 	)
 
-	parkedStarted := time.Now()
-	plans := mgr.recoverableParkedRuns(context.Background())
+	recoveryPlanStarted := time.Now()
+	plans := mgr.recoverableRuns(context.Background())
 	preserved := make(map[string]struct{}, len(plans))
 	for _, plan := range plans {
 		preserved[plan.run.ID] = struct{}{}
 	}
-	logStartupPhase("parked_runs", parkedStarted, "preserved", len(plans))
+	logStartupPhase("recoverable_runs", recoveryPlanStarted, "preserved", len(plans))
 
 	staleStarted := time.Now()
 	count, err := d.RecoverStaleRunsExcept("daemon crashed during execution", preserved)

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -78,7 +78,7 @@ type recoveredRunPlan struct {
 	steps   []pipeline.Step
 }
 
-func (m *RunManager) recoverableParkedRuns(ctx context.Context) []recoveredRunPlan {
+func (m *RunManager) recoverableRuns(ctx context.Context) []recoveredRunPlan {
 	runs, err := m.db.GetActiveRuns()
 	if err != nil {
 		slog.Error("failed to list active runs for recovery", "error", err)
@@ -105,8 +105,8 @@ func (m *RunManager) recoverableParkedRuns(ctx context.Context) []recoveredRunPl
 }
 
 func (m *RunManager) prepareRecoveredRun(ctx context.Context, run *db.Run) (*recoveredRunPlan, error) {
-	if run == nil || run.Status != types.RunRunning || run.AwaitingAgentSince == nil || run.Branch == "" {
-		return nil, fmt.Errorf("run is not a parked running run")
+	if run == nil || run.Status != types.RunRunning || run.Branch == "" {
+		return nil, fmt.Errorf("run is not an active running run")
 	}
 	repo, err := m.db.GetRepo(run.RepoID)
 	if err != nil {

--- a/internal/daemon/subscribe_recover_test.go
+++ b/internal/daemon/subscribe_recover_test.go
@@ -561,6 +561,238 @@ func TestRecoverOnStartup_ReconcilesHistoricalCIGateFromCurrentPRState(t *testin
 	}
 }
 
+func TestRecoverOnStartup_ResumesActiveCIMonitorBeforeFailingRun(t *testing.T) {
+	for _, state := range []string{"MERGED", "CLOSED"} {
+		t.Run(state, func(t *testing.T) {
+			assertActiveCIMonitorRecoveryState(t, state)
+		})
+	}
+}
+
+func assertActiveCIMonitorRecoveryState(t *testing.T, state string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	p := paths.WithRoot(tmpDir)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	mockClaude := writeMockClaude(t, t.TempDir())
+	if err := os.WriteFile(p.ConfigFile(), []byte("agent: claude\nagent_path_override:\n  claude: "+mockClaude+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	repo, headSHA := setupTestGitRepo(t, p, d, "resume-active-ci-monitor")
+	run, err := d.InsertRun(repo.ID, "feature", headSHA, headSHA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := d.UpdateRunStatus(run.ID, types.RunRunning); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.UpdateRunPRURL(run.ID, "https://github.com/test/repo/pull/42"); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.UpdateRunPushBinding(run.ID, db.PushBinding{
+		HeadSHA:           headSHA,
+		TargetKind:        "upstream",
+		TargetFingerprint: "test-target",
+		Ref:               "refs/heads/feature",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.SetRunCIReady(run.ID, true); err != nil {
+		t.Fatal(err)
+	}
+	prURL := "https://github.com/test/repo/pull/42"
+	run.PRURL = &prURL
+
+	worktree := p.WorktreeDir(repo.ID, run.ID)
+	if err := gitpkg.WorktreeAdd(context.Background(), p.RepoDir(repo.ID), worktree, headSHA); err != nil {
+		t.Fatal(err)
+	}
+	step, err := d.InsertStepResult(run.ID, types.StepCI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := d.StartStep(step.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	ghDir, ghLog := writeMockGHState(t, t.TempDir(), state)
+	t.Setenv("PATH", ghDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- RunWithOptions(p, d, func() []pipeline.Step { return []pipeline.Step{&steps.CIStep{}} })
+	}()
+	defer func() {
+		client, dialErr := ipc.Dial(p.Socket())
+		if dialErr == nil {
+			_ = client.Call(ipc.MethodShutdown, &ipc.ShutdownParams{}, nil)
+			_ = client.Close()
+		}
+		select {
+		case <-errCh:
+		case <-time.After(3 * time.Second):
+			t.Error("daemon did not stop")
+		}
+	}()
+
+	completed := waitForRunTerminalState(t, d, run.ID)
+	if completed.Status != types.RunCompleted {
+		t.Fatalf("active CI monitor recovery status = %s, want completed; error = %v", completed.Status, completed.Error)
+	}
+	wantPRState := strings.ToLower(state)
+	if completed.PRState == nil || *completed.PRState != wantPRState {
+		t.Fatalf("active CI monitor recovery PR state = %v, want %s", completed.PRState, wantPRState)
+	}
+	logData, err := os.ReadFile(ghLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(logData), "pr view 42") {
+		t.Fatalf("active CI monitor recovery did not read current PR state: %s", logData)
+	}
+}
+
+func TestRecoverOnStartup_ActiveCIMonitorFailsClosedWhenPRStateUnavailable(t *testing.T) {
+	tmpDir := t.TempDir()
+	p := paths.WithRoot(tmpDir)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	mockClaude := writeMockClaude(t, t.TempDir())
+	if err := os.WriteFile(p.ConfigFile(), []byte("agent: claude\nagent_path_override:\n  claude: "+mockClaude+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	repo, headSHA := setupTestGitRepo(t, p, d, "unavailable-active-ci-monitor")
+	run, err := d.InsertRun(repo.ID, "feature", headSHA, headSHA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := d.UpdateRunStatus(run.ID, types.RunRunning); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.UpdateRunPRURL(run.ID, "https://github.com/test/repo/pull/42"); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.UpdateRunPushBinding(run.ID, db.PushBinding{
+		HeadSHA:           headSHA,
+		TargetKind:        "upstream",
+		TargetFingerprint: "test-target",
+		Ref:               "refs/heads/feature",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	prURL := "https://github.com/test/repo/pull/42"
+	run.PRURL = &prURL
+
+	worktree := p.WorktreeDir(repo.ID, run.ID)
+	if err := gitpkg.WorktreeAdd(context.Background(), p.RepoDir(repo.ID), worktree, headSHA); err != nil {
+		t.Fatal(err)
+	}
+	step, err := d.InsertStepResult(run.ID, types.StepCI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := d.StartStep(step.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	ghDir := t.TempDir()
+	ghLog := filepath.Join(ghDir, "gh.log")
+	ghPath := filepath.Join(ghDir, "gh.bat")
+	ghScript := "@echo off\r\necho %*>>\"" + ghLog + "\"\r\nexit /b 1\r\n"
+	if err := os.WriteFile(ghPath, []byte(ghScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", ghDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- RunWithOptions(p, d, func() []pipeline.Step { return []pipeline.Step{&steps.CIStep{}} })
+	}()
+	defer func() {
+		client, dialErr := ipc.Dial(p.Socket())
+		if dialErr == nil {
+			_ = client.Call(ipc.MethodShutdown, &ipc.ShutdownParams{}, nil)
+			_ = client.Close()
+		}
+		select {
+		case <-errCh:
+		case <-time.After(5 * time.Second):
+			t.Error("daemon did not stop")
+		}
+	}()
+
+	failed := waitForRunTerminalState(t, d, run.ID)
+	if failed.Status != types.RunFailed {
+		t.Fatalf("unavailable active CI monitor recovery status = %s, want failed", failed.Status)
+	}
+	if failed.Error == nil || !strings.Contains(*failed.Error, "reconcile recovered active CI monitor") {
+		t.Fatalf("unavailable active CI monitor recovery error = %v", failed.Error)
+	}
+}
+
+func TestValidateRecoveredRun_ActiveCIMonitorRequiresExactPushedHead(t *testing.T) {
+	tmpDir := t.TempDir()
+	p := paths.WithRoot(tmpDir)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	d, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	repo, headSHA := setupTestGitRepo(t, p, d, "mismatched-active-ci-monitor")
+	run, err := d.InsertRun(repo.ID, "feature", headSHA, headSHA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := d.UpdateRunStatus(run.ID, types.RunRunning); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.UpdateRunPRURL(run.ID, "https://github.com/test/repo/pull/42"); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.UpdateRunPushBinding(run.ID, db.PushBinding{
+		HeadSHA:           strings.Repeat("f", len(headSHA)),
+		TargetKind:        "upstream",
+		TargetFingerprint: "test-target",
+		Ref:               "refs/heads/feature",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	step, err := d.InsertStepResult(run.ID, types.StepCI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := d.StartStep(step.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	current, err := d.GetRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = pipeline.ValidateRecoveredRun(d, current, []pipeline.Step{&steps.CIStep{}})
+	if err == nil || !strings.Contains(err.Error(), "exact successful push binding") {
+		t.Fatalf("mismatched active CI monitor recovery validation error = %v", err)
+	}
+}
+
 func TestRecoverCleansUpOrphanedWorktrees(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "dtest")
 	if err != nil {

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -236,23 +236,43 @@ type recoveredGate struct {
 	lastRoundID string
 }
 
+type recoveredCIMonitor struct {
+	index      int
+	step       Step
+	stepResult *db.StepResult
+}
+
 func ValidateRecoveredRun(database *db.DB, run *db.Run, steps []Step) error {
-	if run == nil || run.Status != types.RunRunning || run.AwaitingAgentSince == nil {
-		return fmt.Errorf("run is not a recoverable parked run")
+	if run == nil || run.Status != types.RunRunning {
+		return fmt.Errorf("run is not recoverable")
 	}
-	_, err := (&Executor{db: database, steps: steps}).recoveredGate(run.ID)
+	executor := &Executor{db: database, steps: steps}
+	if run.AwaitingAgentSince != nil {
+		_, err := executor.recoveredGate(run.ID)
+		return err
+	}
+	if run.PRURL == nil || strings.TrimSpace(*run.PRURL) == "" {
+		return fmt.Errorf("active CI monitor has no PR URL")
+	}
+	if run.LastPushedSHA == nil || strings.TrimSpace(*run.LastPushedSHA) == "" || *run.LastPushedSHA != run.HeadSHA {
+		return fmt.Errorf("active CI monitor has no exact successful push binding")
+	}
+	_, err := executor.recoveredCIMonitor(run.ID)
 	return err
 }
 
-// Resume restores a run that was durably parked at an approval gate when the
-// daemon stopped. It only accepts a fully recorded gate and otherwise returns
-// an error so startup recovery can fail the run rather than guessing.
+// Resume restores either a run that was durably parked at an approval gate or
+// an active post-push CI monitor. Both paths require a complete durable record;
+// otherwise startup recovery fails the run rather than guessing.
 func (e *Executor) Resume(ctx context.Context, run *db.Run, repo *db.Repo, workDir string) error {
 	if repo == nil {
 		return fmt.Errorf("recovered run has no repository")
 	}
 	if err := ValidateRecoveredRun(e.db, run, e.steps); err != nil {
 		return err
+	}
+	if run.AwaitingAgentSince == nil {
+		return e.resumeRecoveredCIMonitor(ctx, run, repo, workDir)
 	}
 	gate, err := e.recoveredGate(run.ID)
 	if err != nil {
@@ -401,6 +421,63 @@ func (e *Executor) Resume(ctx context.Context, run *db.Run, repo *db.Repo, workD
 	}
 }
 
+func (e *Executor) resumeRecoveredCIMonitor(ctx context.Context, run *db.Run, repo *db.Repo, workDir string) error {
+	monitor, err := e.recoveredCIMonitor(run.ID)
+	if err != nil {
+		return err
+	}
+	logDir := e.paths.RunLogDir(run.ID)
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		return e.failRun(run, repo, fmt.Errorf("create log dir: %w", err))
+	}
+	e.initializeRunScopes(run.ID)
+	reconcileCtx := &StepContext{
+		Ctx:      ctx,
+		Run:      run,
+		Repo:     repo,
+		WorkDir:  workDir,
+		Config:   e.config,
+		DB:       e.db,
+		Agent:    e.agent,
+		Sessions: e.sessions,
+		Shared:   e.shared,
+		Log: func(message string) {
+			slog.Info("recovered active CI monitor reconciliation", "run_id", run.ID, "message", message)
+		},
+		LogChunk: func(string) {},
+		LogFile:  func(string) {},
+	}
+	reconciled, reconcileErr := e.reconcileApprovalGate(ctx, monitor.step, reconcileCtx)
+	if reconcileErr != nil {
+		return e.failRun(run, repo, fmt.Errorf("reconcile recovered active CI monitor: %w", reconcileErr), ctx)
+	}
+	if reconciled {
+		fresh, dbErr := e.db.GetRun(run.ID)
+		if dbErr != nil {
+			return e.failRun(run, repo, fmt.Errorf("read reconciled active CI monitor: %w", dbErr), ctx)
+		}
+		if fresh != nil && fresh.PRState != nil && *fresh.PRState == "merged" && fresh.CIReadyAt == nil {
+			return e.failRun(run, repo, fmt.Errorf("reconciled merged PR lacks durable checks-passed evidence"), ctx)
+		}
+		duration := recoveredStepDuration(monitor.stepResult)
+		if dbErr := e.db.CompleteStepWithStatus(monitor.stepResult.ID, types.StepStatusCompleted, recoveredExitCode(monitor.stepResult), duration, recoveredLogPath(monitor.stepResult)); dbErr != nil {
+			return e.failRun(run, repo, fmt.Errorf("complete reconciled active CI monitor: %w", dbErr), ctx)
+		}
+		e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, monitor.step.Name(), string(types.StepStatusCompleted), "", "", "", &duration)
+		return e.executeRecoveredRemainder(ctx, run, repo, workDir, logDir, monitor.index+1)
+	}
+	skipRemaining, err := e.executeStep(ctx, monitor.step, monitor.stepResult, run, repo, workDir, logDir, stepExecutionState{
+		executionMS: recoveredStepDuration(monitor.stepResult),
+	})
+	if err != nil {
+		return e.failRun(run, repo, err, ctx)
+	}
+	if skipRemaining {
+		return e.skipRecoveredRemainder(run, repo, monitor.index+1)
+	}
+	return e.executeRecoveredRemainder(ctx, run, repo, workDir, logDir, monitor.index+1)
+}
+
 func (e *Executor) recoveredGate(runID string) (*recoveredGate, error) {
 	results, err := e.db.GetStepsByRun(runID)
 	if err != nil {
@@ -458,6 +535,47 @@ func (e *Executor) recoveredGate(runID string) (*recoveredGate, error) {
 		return nil, fmt.Errorf("recovered run has no approval gate")
 	}
 	return gate, nil
+}
+
+func (e *Executor) recoveredCIMonitor(runID string) (*recoveredCIMonitor, error) {
+	results, err := e.db.GetStepsByRun(runID)
+	if err != nil {
+		return nil, fmt.Errorf("get recovered steps: %w", err)
+	}
+	if len(results) != len(e.steps) {
+		return nil, fmt.Errorf("recovered run has %d step records for %d steps", len(results), len(e.steps))
+	}
+
+	var monitor *recoveredCIMonitor
+	for index, result := range results {
+		if result.StepName != e.steps[index].Name() {
+			return nil, fmt.Errorf("recovered step %d is %q, want %q", index, result.StepName, e.steps[index].Name())
+		}
+		if result.Status == types.StepStatusRunning {
+			if monitor != nil || result.StepName != types.StepCI || result.StartedAt == nil || result.AgentPID != nil {
+				return nil, fmt.Errorf("recovered active CI monitor is incomplete")
+			}
+			monitor = &recoveredCIMonitor{
+				index:      index,
+				step:       e.steps[index],
+				stepResult: result,
+			}
+			continue
+		}
+		if monitor == nil {
+			if result.Status != types.StepStatusCompleted && result.Status != types.StepStatusSkipped {
+				return nil, fmt.Errorf("recovered step %s is %s before active CI monitor", result.StepName, result.Status)
+			}
+			continue
+		}
+		if result.Status != types.StepStatusPending {
+			return nil, fmt.Errorf("recovered step %s is %s after active CI monitor", result.StepName, result.Status)
+		}
+	}
+	if monitor == nil {
+		return nil, fmt.Errorf("recovered run has no active CI monitor")
+	}
+	return monitor, nil
 }
 
 func (e *Executor) executeRecoveredRemainder(ctx context.Context, run *db.Run, repo *db.Repo, workDir, logDir string, start int) error {


### PR DESCRIPTION
## Summary

- recover active post-push CI monitors instead of classifying every non-gated running run as a daemon crash
- refresh authoritative PR state before choosing a terminal result
- require an exact durable push binding and fail closed when remote state is unavailable
- preserve existing approval-gate recovery behavior

## Recovery contract

- merged: complete only when durable checks-passed evidence exists
- closed: complete from the refreshed remote state
- open: resume the existing CI monitor, including base-branch advance handling
- unavailable provider/network: fail closed with an explicit reconciliation error
- mismatched pushed head: reject recovery instead of guessing

## Verification

- recovery regression set, three consecutive runs: PASS
- base-branch advance re-arm test, three consecutive runs: PASS
- `go vet ./internal/daemon ./internal/pipeline`: PASS
- full `go test ./... -count=1`: all packages passed except three timing-sensitive tests under parallel load; the recovery timeout passed on the serial three-run rerun, while two existing 30-second CI retry tests timed out

No production daemon was restarted for this change.
