### PR TITLE
fix(db): finalize runs on terminal PR outcomes

### DIFF
--- a/.no-mistakes/evidence/fm/nm-stale-run-reconcile-z3/terminal-pr-active-listing.md
+++ b/.no-mistakes/evidence/fm/nm-stale-run-reconcile-z3/terminal-pr-active-listing.md
@@ -1,0 +1,28 @@
+# Terminal PR lifecycle CLI evidence
+
+The isolated end-to-end regression created an authoritative `running` run,
+applied the terminal PR observation, and then invoked the real
+`no-mistakes runs` CLI against its isolated daemon and home.
+
+Command:
+
+```console
+$ ./scripts/e2e.sh -tags=e2e -count=1 -timeout 120s ./internal/e2e -run '^TestTerminalPRRunDisappearsFromActiveListing$' -v
+```
+
+Merged PR observation:
+
+```console
+$ no-mistakes runs
+  completed    feature/terminal-pr  01234567  2026-07-23 23:58  https://github.com/test/repo/pull/42
+```
+
+Closed PR observation:
+
+```console
+$ no-mistakes runs
+  completed    feature/terminal-pr  01234567  2026-07-23 23:58  https://github.com/test/repo/pull/42
+```
+
+Both E2E subtests passed, and their direct database check found zero active
+runs after the CLI observation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,7 @@ Safest local verification sequence after non-trivial changes:
 
 - `ci_timeout` is an idle timeout, not an absolute deadline: only `timeoutAnchor` re-arms when the upstream default-branch tip advances, `started` stays fixed for poll pacing, and re-arm only ever extends the deadline (fail-safe on transient base-tip failures). Value semantics (`0` unset, negative unlimited sentinel, keyword parsing) live in `config.go`; keep `config.DefaultCITimeout` and `defaultConfigYAML` in sync (`TestDefaultConfigYAML_MatchesGoDefaults`). User-facing semantics are owned by `docs/src/content/docs/reference/global-config.md`.
 - Reap an orphaned monitor from outside its worktree with `no-mistakes axi abort --run <id>`; it needs only `NM_HOME` plus the daemon, and an unknown id or stopped daemon is an idempotent no-op, not an error. Bare `axi abort` stays worktree/branch-scoped.
+- A merged or closed PR observation transactionally completes an active run and its CI step; PR lifecycle state is monotonic, so duplicate or delayed observations cannot reactivate or regress a terminal run. Startup reconciles legacy `pending` or `running` rows that already hold terminal PR state before parked-run planning and generic crash recovery. Regressions: `TestUpdateRunPRStateFinalizesActiveTerminalOutcomes`, `TestUpdateRunPRStateIgnoresDuplicateAndDelayedRegressions`, `TestReconcileTerminalPRRunsFinalizesLegacyActiveRows`, `TestRecoverOnStartup_FinalizesLegacyTerminalPRRun`, e2e `TestTerminalPRRunDisappearsFromActiveListing`.
 
 **Parked / Awaiting-Agent Signal**
 

--- a/docs/src/content/docs/concepts/daemon.md
+++ b/docs/src/content/docs/concepts/daemon.md
@@ -108,6 +108,7 @@ reason about in one long-lived process than inside independent hook invocations.
 
 On startup, the daemon checks for runs that were left in `pending` or `running` status (which means the daemon crashed while they were active):
 
+- Completes legacy active rows whose persisted PR state is already `merged` or `closed`, including their CI step, before active-run recovery and parked-run planning
 - Resumes only fully recorded parked approval gates whose worktree and step history can be validated; incomplete or ambiguous active runs fail closed
 - Before resuming a parked CI gate, re-checks its persisted PR URL through the configured provider; a currently merged or closed PR completes the stale gate, while an open, unknown, or unreachable PR remains parked
 - Marks every other stale active run as `failed` with the message "daemon crashed during execution"

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -89,7 +89,7 @@ First inspect each listed run with `no-mistakes axi status --run <id>`.
 A parked CI gate can clear itself after its PR becomes terminal, including after a daemon restart.
 The [`ci_timeout` reference](/no-mistakes/reference/global-config/#ci_timeout) owns the exact fail-closed reconciliation rules, and [Daemon & Worktrees](/no-mistakes/concepts/daemon/#crash-recovery) owns restart behavior.
 
-When upgrading from an older release that left a merged/closed PR at a stale CI gate, verify the PR state independently, check out the matching branch, and run `no-mistakes axi respond --action approve --step ci` before retrying the update.
+After upgrading from an older release, starting the daemon automatically completes stale active rows that already have a persisted merged or closed PR state.
 Do not edit `state.sqlite` directly.
 
 Only when you have confirmed it is acceptable for every remaining listed active run to fail, force the lifecycle operation:

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -366,6 +366,18 @@ func recoverOnStartup(d *db.DB, p *paths.Paths, mgr *RunManager) {
 		"failed", gateStats.Failed,
 	)
 
+	terminalPRStarted := time.Now()
+	terminalPRCount, err := d.ReconcileTerminalPRRuns()
+	if err != nil {
+		slog.Error("failed to reconcile terminal PR runs", "error", err)
+		logStartupPhase("terminal_pr_runs", terminalPRStarted, "failed", true)
+	} else {
+		if terminalPRCount > 0 {
+			slog.Info("reconciled terminal PR runs", "count", terminalPRCount)
+		}
+		logStartupPhase("terminal_pr_runs", terminalPRStarted, "reconciled", terminalPRCount)
+	}
+
 	parkedStarted := time.Now()
 	plans := mgr.recoverableParkedRuns(context.Background())
 	preserved := make(map[string]struct{}, len(plans))

--- a/internal/daemon/subscribe_recover_test.go
+++ b/internal/daemon/subscribe_recover_test.go
@@ -340,6 +340,100 @@ func TestRecoverStaleRunsOnStartup(t *testing.T) {
 	}
 }
 
+func TestRecoverOnStartup_FinalizesLegacyTerminalPRRun(t *testing.T) {
+	for _, state := range []string{"merged", "closed"} {
+		t.Run(state, func(t *testing.T) {
+			root, err := os.MkdirTemp("", "dtest")
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = os.RemoveAll(root) })
+			p := paths.WithRoot(root)
+			if err := p.EnsureDirs(); err != nil {
+				t.Fatal(err)
+			}
+			database, err := db.Open(p.DB())
+			if err != nil {
+				t.Fatal(err)
+			}
+			repo, err := database.InsertRepoWithID("terminal-pr-"+state, t.TempDir(), "https://github.com/test/repo", "main")
+			if err != nil {
+				t.Fatal(err)
+			}
+			run, err := database.InsertRun(repo.ID, "feature", "abc123", "def456")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := database.UpdateRunPRState(run.ID, state); err != nil {
+				t.Fatal(err)
+			}
+			// Recreate a legacy interrupted row after the current writer has run:
+			// terminal PR truth was durable, but status was still running.
+			if err := database.UpdateRunStatus(run.ID, types.RunRunning); err != nil {
+				t.Fatal(err)
+			}
+			ci, err := database.InsertStepResult(run.ID, types.StepCI)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := database.StartStep(ci.ID); err != nil {
+				t.Fatal(err)
+			}
+
+			errCh := make(chan error, 1)
+			go func() {
+				errCh <- RunWithOptions(p, database, func() []pipeline.Step { return []pipeline.Step{&mockPassStep{name: types.StepCI}} })
+			}()
+			defer func() {
+				client, dialErr := ipc.Dial(p.Socket())
+				if dialErr == nil {
+					_ = client.Call(ipc.MethodShutdown, &ipc.ShutdownParams{}, nil)
+					_ = client.Close()
+				}
+				select {
+				case <-errCh:
+				case <-time.After(3 * time.Second):
+					t.Error("isolated daemon did not stop")
+				}
+				_ = database.Close()
+			}()
+
+			deadline := time.Now().Add(5 * time.Second)
+			for {
+				if _, statErr := os.Stat(p.Socket()); statErr == nil {
+					break
+				}
+				if time.Now().After(deadline) {
+					t.Fatal("isolated daemon did not become ready")
+				}
+				time.Sleep(20 * time.Millisecond)
+			}
+
+			got, err := database.GetRun(run.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Status != types.RunCompleted || got.PRState == nil || *got.PRState != state {
+				t.Fatalf("startup reconciliation = status %s pr_state %v, want completed/%s", got.Status, got.PRState, state)
+			}
+			gotCI, err := database.GetStepResult(ci.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if gotCI.Status != types.StepStatusCompleted {
+				t.Fatalf("startup reconciliation CI status = %s, want completed", gotCI.Status)
+			}
+			active, err := lifecycle.ActiveRuns(p)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(active) != 0 {
+				t.Fatalf("startup reconciliation retained active runs: %+v", active)
+			}
+		})
+	}
+}
+
 func TestRecoverOnStartup_ResumesParkedRun(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "dtest")
 	if err != nil {

--- a/internal/db/run.go
+++ b/internal/db/run.go
@@ -206,9 +206,11 @@ func (d *DB) UpdateRunStatus(id string, status types.RunStatus) error {
 	return nil
 }
 
-// UpdateRunPRURL sets the PR URL on a run.
+// UpdateRunPRURL sets the PR URL on a run. A delayed PR-step write must not
+// regress terminal lifecycle truth already observed by the CI monitor.
 func (d *DB) UpdateRunPRURL(id, prURL string) error {
-	_, err := d.sql.Exec(`UPDATE runs SET pr_url = ?, pr_state = 'open', pr_state_observed_at = ?, updated_at = ? WHERE id = ?`, prURL, now(), now(), id)
+	ts := now()
+	_, err := d.sql.Exec(`UPDATE runs SET pr_url = ?, pr_state = CASE WHEN pr_state IN ('merged', 'closed') THEN pr_state ELSE 'open' END, pr_state_observed_at = ?, updated_at = ? WHERE id = ?`, prURL, ts, ts, id)
 	if err != nil {
 		return fmt.Errorf("update run pr url: %w", err)
 	}
@@ -264,11 +266,127 @@ func (d *DB) SetRunPushActive(id string, active bool) error {
 }
 
 // UpdateRunPRState persists normalized lifecycle truth independently of logs.
+// A merged or closed PR is also the terminal outcome of the final CI monitor
+// step, so the PR observation and active-run finalization are committed in one
+// transaction. This makes the database authoritative even if execution stops
+// before the executor's ordinary follow-up completion write.
 func (d *DB) UpdateRunPRState(id, state string) error {
+	state = strings.ToLower(strings.TrimSpace(state))
 	ts := now()
-	_, err := d.sql.Exec(`UPDATE runs SET pr_state = ?, pr_state_observed_at = ?, updated_at = ? WHERE id = ?`, state, ts, ts, id)
+	tx, err := d.sql.Begin()
 	if err != nil {
+		return fmt.Errorf("update run PR state: begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	var current sql.NullString
+	if err := tx.QueryRow(`SELECT pr_state FROM runs WHERE id = ?`, id).Scan(&current); err != nil {
+		if err == sql.ErrNoRows {
+			return nil
+		}
+		return fmt.Errorf("update run PR state: read current state: %w", err)
+	}
+	state = monotonicPRState(current.String, state)
+	if _, err := tx.Exec(`UPDATE runs SET pr_state = ?, pr_state_observed_at = ?, updated_at = ? WHERE id = ?`, state, ts, ts, id); err != nil {
 		return fmt.Errorf("update run PR state: %w", err)
+	}
+	if terminalPRState(state) {
+		if err := finalizeTerminalPRRun(tx, id, ts); err != nil {
+			return fmt.Errorf("update run PR state: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("update run PR state: commit: %w", err)
+	}
+	return nil
+}
+
+// ReconcileTerminalPRRuns repairs active rows written by an older or
+// interrupted daemon after terminal PR truth became durable but before the
+// separate run completion write. It is called during exclusive daemon startup
+// before parked-run planning and generic crash recovery.
+func (d *DB) ReconcileTerminalPRRuns() (int, error) {
+	ts := now()
+	tx, err := d.sql.Begin()
+	if err != nil {
+		return 0, fmt.Errorf("reconcile terminal PR runs: begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	rows, err := tx.Query(`SELECT id FROM runs WHERE status IN (?, ?) AND pr_state IN ('merged', 'closed')`, types.RunPending, types.RunRunning)
+	if err != nil {
+		return 0, fmt.Errorf("reconcile terminal PR runs: list runs: %w", err)
+	}
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			_ = rows.Close()
+			return 0, fmt.Errorf("reconcile terminal PR runs: scan run: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Close(); err != nil {
+		return 0, fmt.Errorf("reconcile terminal PR runs: close rows: %w", err)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("reconcile terminal PR runs: list runs: %w", err)
+	}
+
+	for _, id := range ids {
+		if err := finalizeTerminalPRRun(tx, id, ts); err != nil {
+			return 0, fmt.Errorf("reconcile terminal PR runs: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("reconcile terminal PR runs: commit: %w", err)
+	}
+	return len(ids), nil
+}
+
+func monotonicPRState(current, observed string) string {
+	current = strings.ToLower(strings.TrimSpace(current))
+	observed = strings.ToLower(strings.TrimSpace(observed))
+	switch {
+	case current == "merged":
+		return current
+	case observed == "merged":
+		return observed
+	case current == "closed":
+		return current
+	default:
+		return observed
+	}
+}
+
+func terminalPRState(state string) bool {
+	return state == "merged" || state == "closed"
+}
+
+func finalizeTerminalPRRun(tx *sql.Tx, id string, ts int64) error {
+	if _, err := tx.Exec(
+		`UPDATE step_results SET status = ?, exit_code = COALESCE(exit_code, 0), completed_at = COALESCE(completed_at, ?),
+			last_activity_at = ?, last_activity = ?, agent_pid = NULL
+		 WHERE run_id = ? AND step_name = ? AND status IN (?, ?, ?, ?)
+		   AND EXISTS (SELECT 1 FROM runs WHERE id = ? AND status IN (?, ?))`,
+		types.StepStatusCompleted, ts, ts, "status: completed", id, types.StepCI,
+		types.StepStatusRunning, types.StepStatusAwaitingApproval, types.StepStatusFixing, types.StepStatusFixReview,
+		id, types.RunPending, types.RunRunning,
+	); err != nil {
+		return fmt.Errorf("complete terminal CI step: %w", err)
+	}
+	if _, err := tx.Exec(
+		`UPDATE runs SET
+			status = CASE WHEN status IN (?, ?) THEN ? ELSE status END,
+			push_active = 0,
+			parked_ms = COALESCE(parked_ms, 0) + CASE
+				WHEN awaiting_agent_since IS NOT NULL AND ? > awaiting_agent_since
+				THEN (? - awaiting_agent_since) * 1000 ELSE 0 END,
+			awaiting_agent_since = NULL, updated_at = ?
+		 WHERE id = ?`,
+		types.RunPending, types.RunRunning, types.RunCompleted, ts, ts, ts, id,
+	); err != nil {
+		return fmt.Errorf("finalize terminal PR run: %w", err)
 	}
 	return nil
 }
@@ -381,7 +499,9 @@ func (d *DB) CompleteRunAwaitingAgent(id string, ms int64) error {
 		ms = 0
 	}
 	_, err := d.sql.Exec(
-		`UPDATE runs SET awaiting_agent_since = NULL, parked_ms = COALESCE(parked_ms, 0) + ?, updated_at = ? WHERE id = ?`,
+		`UPDATE runs SET awaiting_agent_since = NULL,
+			parked_ms = COALESCE(parked_ms, 0) + CASE WHEN awaiting_agent_since IS NOT NULL THEN ? ELSE 0 END,
+			updated_at = ? WHERE id = ?`,
 		ms, now(), id,
 	)
 	if err != nil {

--- a/internal/db/run_test.go
+++ b/internal/db/run_test.go
@@ -347,6 +347,169 @@ func TestUpdateRunPRURL(t *testing.T) {
 	}
 }
 
+func TestUpdateRunPRStateFinalizesActiveTerminalOutcomes(t *testing.T) {
+	for _, state := range []string{"merged", "closed"} {
+		t.Run(state, func(t *testing.T) {
+			d := openTestDB(t)
+			repo, _ := d.InsertRepo("/home/user/pr-terminal-"+state, "git@github.com:user/project.git", "main")
+			run, _ := d.InsertRun(repo.ID, "feature", "abc", "def")
+			if err := d.UpdateRunStatus(run.ID, types.RunRunning); err != nil {
+				t.Fatal(err)
+			}
+			if err := d.SetRunAwaitingAgent(run.ID); err != nil {
+				t.Fatal(err)
+			}
+			if err := d.SetRunPushActive(run.ID, true); err != nil {
+				t.Fatal(err)
+			}
+			ci, _ := d.InsertStepResult(run.ID, types.StepCI)
+			if err := d.StartStep(ci.ID); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := d.UpdateRunPRState(run.ID, state); err != nil {
+				t.Fatal(err)
+			}
+
+			got, _ := d.GetRun(run.ID)
+			if got.Status != types.RunCompleted || got.PRState == nil || *got.PRState != state {
+				t.Fatalf("terminal PR run = status %s pr_state %v, want completed/%s", got.Status, got.PRState, state)
+			}
+			if got.AwaitingAgentSince != nil || got.PushActive {
+				t.Fatalf("terminal PR run retained active markers: awaiting=%v push_active=%t", got.AwaitingAgentSince, got.PushActive)
+			}
+			parkedMS := got.ParkedMS
+			if err := d.CompleteRunAwaitingAgent(run.ID, 1234); err != nil {
+				t.Fatal(err)
+			}
+			got, _ = d.GetRun(run.ID)
+			if got.ParkedMS != parkedMS {
+				t.Fatalf("duplicate gate completion changed parked_ms from %d to %d", parkedMS, got.ParkedMS)
+			}
+			gotCI, _ := d.GetStepResult(ci.ID)
+			if gotCI.Status != types.StepStatusCompleted {
+				t.Fatalf("CI status = %s, want completed", gotCI.Status)
+			}
+			active, err := d.GetActiveRuns()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(active) != 0 {
+				t.Fatalf("terminal PR remains active: %+v", active)
+			}
+		})
+	}
+}
+
+func TestUpdateRunPRStateKeepsOpenRunActive(t *testing.T) {
+	d := openTestDB(t)
+	repo, _ := d.InsertRepo("/home/user/pr-open", "git@github.com:user/project.git", "main")
+	run, _ := d.InsertRun(repo.ID, "feature", "abc", "def")
+	if err := d.UpdateRunStatus(run.ID, types.RunRunning); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.UpdateRunPRState(run.ID, "open"); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := d.GetRun(run.ID)
+	if got.Status != types.RunRunning || got.PRState == nil || *got.PRState != "open" {
+		t.Fatalf("open PR run = status %s pr_state %v, want running/open", got.Status, got.PRState)
+	}
+}
+
+func TestUpdateRunPRStateIgnoresDuplicateAndDelayedRegressions(t *testing.T) {
+	d := openTestDB(t)
+	repo, _ := d.InsertRepo("/home/user/pr-notifications", "git@github.com:user/project.git", "main")
+	run, _ := d.InsertRun(repo.ID, "feature", "abc", "def")
+	if err := d.UpdateRunStatus(run.ID, types.RunRunning); err != nil {
+		t.Fatal(err)
+	}
+	for _, state := range []string{"merged", "merged", "open", "closed"} {
+		if err := d.UpdateRunPRState(run.ID, state); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := d.UpdateRunPRURL(run.ID, "https://github.com/user/project/pull/1"); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := d.GetRun(run.ID)
+	if got.Status != types.RunCompleted || got.PRState == nil || *got.PRState != "merged" {
+		t.Fatalf("duplicate/delayed PR observations regressed run: status=%s pr_state=%v", got.Status, got.PRState)
+	}
+	active, _ := d.GetActiveRuns()
+	if len(active) != 0 {
+		t.Fatalf("duplicate/delayed PR observations reactivated run: %+v", active)
+	}
+}
+
+func TestUpdateRunPRStateDoesNotRewriteAlreadyTerminalStatus(t *testing.T) {
+	for _, status := range []types.RunStatus{types.RunCompleted, types.RunFailed, types.RunCancelled} {
+		t.Run(string(status), func(t *testing.T) {
+			d := openTestDB(t)
+			repo, _ := d.InsertRepo("/home/user/pr-idempotent-"+string(status), "git@github.com:user/project.git", "main")
+			run, _ := d.InsertRun(repo.ID, "feature", "abc", "def")
+			if err := d.UpdateRunErrorStatus(run.ID, "original terminal outcome", status); err != nil {
+				t.Fatal(err)
+			}
+			if err := d.UpdateRunPRState(run.ID, "closed"); err != nil {
+				t.Fatal(err)
+			}
+			got, _ := d.GetRun(run.ID)
+			if got.Status != status {
+				t.Fatalf("status = %s, want preserved %s", got.Status, status)
+			}
+			if got.Error == nil || *got.Error != "original terminal outcome" {
+				t.Fatalf("terminal error changed: %v", got.Error)
+			}
+		})
+	}
+}
+
+func TestReconcileTerminalPRRunsFinalizesLegacyActiveRows(t *testing.T) {
+	for _, state := range []string{"merged", "closed"} {
+		t.Run(state, func(t *testing.T) {
+			d := openTestDB(t)
+			repo, _ := d.InsertRepo("/home/user/pr-recovery-"+state, "git@github.com:user/project.git", "main")
+			run, _ := d.InsertRun(repo.ID, "feature", "abc", "def")
+			if err := d.UpdateRunStatus(run.ID, types.RunRunning); err != nil {
+				t.Fatal(err)
+			}
+			ci, _ := d.InsertStepResult(run.ID, types.StepCI)
+			if err := d.StartStep(ci.ID); err != nil {
+				t.Fatal(err)
+			}
+			if err := d.SetRunAwaitingAgent(run.ID); err != nil {
+				t.Fatal(err)
+			}
+			// Simulate a row written by an older daemon after it observed a terminal
+			// PR but before its separate run-status finalization write.
+			if _, err := d.sql.Exec(`UPDATE runs SET pr_state = ? WHERE id = ?`, state, run.ID); err != nil {
+				t.Fatal(err)
+			}
+
+			count, err := d.ReconcileTerminalPRRuns()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if count != 1 {
+				t.Fatalf("reconciled count = %d, want 1", count)
+			}
+			got, _ := d.GetRun(run.ID)
+			if got.Status != types.RunCompleted || got.AwaitingAgentSince != nil {
+				t.Fatalf("reconciled run = status %s awaiting %v", got.Status, got.AwaitingAgentSince)
+			}
+			gotCI, _ := d.GetStepResult(ci.ID)
+			if gotCI.Status != types.StepStatusCompleted {
+				t.Fatalf("reconciled CI status = %s, want completed", gotCI.Status)
+			}
+			count, err = d.ReconcileTerminalPRRuns()
+			if err != nil || count != 0 {
+				t.Fatalf("idempotent reconciliation = count %d err %v, want 0/nil", count, err)
+			}
+		})
+	}
+}
+
 func TestUpdateRunHeadSHA(t *testing.T) {
 	d := openTestDB(t)
 	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")

--- a/internal/e2e/pr_terminal_lifecycle_test.go
+++ b/internal/e2e/pr_terminal_lifecycle_test.go
@@ -1,0 +1,75 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// TestTerminalPRRunDisappearsFromActiveListing reproduces the operator-visible
+// defect with a real CLI and an isolated daemon/home. A terminal PR observation
+// is the initiating trigger. The normal executor's immediate follow-up status
+// write usually masks the defect, so this fixture stops at the durable
+// observation boundary where an interruption used to leave status=running.
+func TestTerminalPRRunDisappearsFromActiveListing(t *testing.T) {
+	for _, state := range []string{"merged", "closed"} {
+		t.Run(state, func(t *testing.T) {
+			h := NewHarness(t, SetupOpts{Agent: "claude"})
+			if out, err := h.Run("init"); err != nil {
+				t.Fatalf("init: %v\n%s", err, out)
+			}
+
+			p := paths.WithRoot(h.NMHome)
+			database, err := db.Open(p.DB())
+			if err != nil {
+				t.Fatal(err)
+			}
+			run, err := database.InsertRun(h.repoID(), "feature/terminal-pr", "0123456789abcdef", "fedcba9876543210")
+			if err != nil {
+				_ = database.Close()
+				t.Fatal(err)
+			}
+			if err := database.UpdateRunStatus(run.ID, types.RunRunning); err != nil {
+				_ = database.Close()
+				t.Fatal(err)
+			}
+			if err := database.UpdateRunPRURL(run.ID, "https://github.com/test/repo/pull/42"); err != nil {
+				_ = database.Close()
+				t.Fatal(err)
+			}
+			if err := database.UpdateRunPRState(run.ID, state); err != nil {
+				_ = database.Close()
+				t.Fatal(err)
+			}
+			if err := database.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			out, err := h.Run("runs")
+			if err != nil {
+				t.Fatalf("runs: %v\n%s", err, out)
+			}
+			if !strings.Contains(out, "completed") || strings.Contains(out, "running") {
+				t.Fatalf("terminal PR remained visibly active:\n%s", out)
+			}
+
+			activeDB, err := db.Open(p.DB())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer activeDB.Close()
+			active, err := activeDB.GetActiveRuns()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(active) != 0 {
+				t.Fatalf("authoritative DB still lists terminal PR run as active: %+v", active)
+			}
+		})
+	}
+}

--- a/internal/e2e/pr_terminal_lifecycle_test.go
+++ b/internal/e2e/pr_terminal_lifecycle_test.go
@@ -54,6 +54,7 @@ func TestTerminalPRRunDisappearsFromActiveListing(t *testing.T) {
 			if err != nil {
 				t.Fatalf("runs: %v\n%s", err, out)
 			}
+			t.Logf("no-mistakes runs after %s PR observation:\n%s", state, out)
 			if !strings.Contains(out, "completed") || strings.Contains(out, "running") {
 				t.Fatalf("terminal PR remained visibly active:\n%s", out)
 			}


### PR DESCRIPTION
## Intent

Fix the no-mistakes run-lifecycle defect where a run with a terminal pull-request outcome remains marked running in the authoritative database and appears active indefinitely. Keep the change narrowly in the existing run-lifecycle finalization and startup reconciliation ownership: merged and closed outcomes must become terminal, legacy interrupted rows must reconcile on restart, duplicate or delayed PR observations and already-terminal runs must be idempotent, and active-run listing must reflect reality. Preserve normal checks-passed monitoring, parked-run recovery, cancellation, and active-run safety. Include an isolated end-to-end regression plus focused merge, close, restart/recovery, duplicate or delayed observation, and idempotence coverage. Do not expand into repository URL refresh, gate-ref custody, AXI reattachment, foreign-key cleanup, or adjacent concerns.

## What Changed

- Finalize active runs and their CI steps transactionally when a merged or closed PR is observed, while preserving monotonic, idempotent PR state.
- Reconcile legacy active rows with terminal PR outcomes during daemon startup before parked-run planning and stale-run recovery.
- Add focused database and daemon coverage plus an isolated end-to-end regression confirming terminal PR runs disappear from active listings.

## Risk Assessment

✅ Low: The change narrowly and transactionally finalizes active runs on terminal PR outcomes, reconciles legacy rows before startup recovery, preserves existing terminal states, and includes focused lifecycle and isolated end-to-end coverage.

## Testing

No prior baseline output was supplied; all focused lifecycle, monitoring, recovery, cancellation, race, and isolated E2E checks passed, with CLI evidence showing merged and closed runs as completed and absent from the authoritative active-run list.

- Evidence: [Terminal PR lifecycle CLI evidence](https://github.com/kunchenguid/no-mistakes/blob/fbf266a90232b4c24d58d0e7d78f5282fd96d969/.no-mistakes/evidence/fm/nm-stale-run-reconcile-z3/terminal-pr-active-listing.md)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/db -run 'Test(UpdateRunPRStateFinalizesActiveTerminalOutcomes|UpdateRunPRStateKeepsOpenRunActive|UpdateRunPRStateIgnoresDuplicateAndDelayedRegressions|UpdateRunPRStateDoesNotRewriteAlreadyTerminalStatus|ReconcileTerminalPRRunsFinalizesLegacyActiveRows)$' -count=1`
- `go test ./internal/daemon -run 'TestRecoverOnStartup_(FinalizesLegacyTerminalPRRun|ResumesParkedRun)$' -count=1`
- `go test ./internal/pipeline/steps -run 'Test(CIGateReconciliationClearsActiveRunAfterPRBecomesTerminal|CIGateReconciliationPreservesOpenErrorAndUnknownStates|CIStep_AllChecksPassingKeepsMonitoringOpenPR|CIStep_OpenPRKeepsMonitoringAfterChecksPass|CIStep_ContextCancelled)$' -count=1`
- `go test ./internal/pipeline -run 'TestExecutor_(ContextCancellation|ContextCancelCause|ContextCancelCauseBetweenSteps|ReconcilesParkedGateThroughNormalCompletionPath|GateRecheckStopsAfterApprovalCancelAndShutdown)$' -count=1`
- `./scripts/e2e.sh -tags=e2e -count=1 -timeout 120s ./internal/e2e -run '^TestTerminalPRRunDisappearsFromActiveListing$' -v`
- `go test -race ./internal/db -run 'Test(UpdateRunPRStateFinalizesActiveTerminalOutcomes|UpdateRunPRStateKeepsOpenRunActive|UpdateRunPRStateIgnoresDuplicateAndDelayedRegressions|UpdateRunPRStateDoesNotRewriteAlreadyTerminalStatus|ReconcileTerminalPRRunsFinalizesLegacyActiveRows)$' -count=1`
- `go test -race ./internal/daemon -run 'TestRecoverOnStartup_(FinalizesLegacyTerminalPRRun|ResumesParkedRun)$' -count=1`
- <code>Enhanced the isolated E2E regression to emit the real `no-mistakes runs` transcript, then recorded merged and closed results in the evidence artifact.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
