### PR TITLE
fix(pipeline): bind pushes to the reviewed commit

### DIFF
--- a/.no-mistakes/evidence/fm/nm-headcontinuity-pushbind/review-to-push-real-git.txt
+++ b/.no-mistakes/evidence/fm/nm-headcontinuity-pushbind/review-to-push-real-git.txt
@@ -1,0 +1,8 @@
+=== RUN   TestPushStep_RefusesPostReviewClobberWithoutLaterPipelineCommit
+    push_test.go:67: review-approved=130c0bf016e3d72522cc0b4982340636a81a94a9 clobbered-HEAD=94c5ba36861e0597874d8e5f42710857c2bb34fa push-refused="refusing to push: proposed head 94c5ba36861e violates continuity with review-approved head 130c0bf016e3 (it is not an equal or descendant commit)" remote-still=6bb42d4319449af8815b10ef44e9edca1e6848d4 unreviewed-file-shipped=false
+--- PASS: TestPushStep_RefusesPostReviewClobberWithoutLaterPipelineCommit (0.54s)
+=== RUN   TestPushStep_BindsRemoteAndDatabaseToVerifiedCommitWhenHEADMovesDuringPush
+    push_test.go:233: review-approved=0882e38b189c5a36775d3cc8c1201c951499f3e6 concurrent-HEAD=e80706f499d0164797189774fbc410cfb002cf10 remote-delivered=0882e38b189c5a36775d3cc8c1201c951499f3e6 durable-head=0882e38b189c5a36775d3cc8c1201c951499f3e6 durable-last-pushed=0882e38b189c5a36775d3cc8c1201c951499f3e6
+--- PASS: TestPushStep_BindsRemoteAndDatabaseToVerifiedCommitWhenHEADMovesDuringPush (0.70s)
+PASS
+ok  	github.com/kunchenguid/no-mistakes/internal/pipeline/steps	1.580s

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,10 @@ Safest local verification sequence after non-trivial changes:
   The full relation matrix and fail-safe rules live in the `Recover` doc comment in `internal/branchsync/sync.go`.
 - Public guidance is owned by `internal/skill/skill.go` plus live AXI strings, then regenerated with `make skill`. Core regressions live in `internal/branchsync` (incl. `recover_test.go`), `internal/cli/sync_test.go`, `internal/tui/branch_sync_test.go`, and e2e `TestAxiBranchSyncJourney` / `TestAxiCustodyRecoveryJourney`.
 
+**Review-to-Push Head Binding**
+
+- A successfully completed full review atomically records `runs.review_approved_head_sha`; parked, failed, skipped, and legacy reviews carry no inferred authority. Push reads that durable binding, permits only the exact commit or a descendant, and pushes the verified immutable SHA rather than mutable `HEAD`. Never infer approval from `runs.head_sha`, a worktree, gate ref, or remote branch. Regressions: `TestPushStep_RefusesPostReviewClobberWithoutLaterPipelineCommit`, `TestPushStep_BindsRemoteAndDatabaseToVerifiedCommitWhenHEADMovesDuringPush`, `TestExecutor_FullRereviewReplacesApprovalWithoutAuthorizingParkedRound`.
+
 **Rebase Base & Force-Push Safety (data-loss prevention)**
 
 - The whole job of this tool is to not lose people's code; favor refusing the push and surfacing a finding over any clever recovery. The comments in `internal/pipeline/steps/forcepush.go` own the full reasoning; the invariants are the next three bullets.

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -75,6 +75,7 @@ AI code review of your diff.
 - Also returns a `risk_level` (`low`, `medium`, `high`) and `risk_rationale`
 - With the default `session_reuse: true`, Claude and Codex reuse one reviewer session across the initial review and every full rereview, and a separate fixer session across review-fix turns
 - A resume failure retries the same turn in a fresh session for that role, never skips the full rereview, and unsupported agents run cold
+- Atomically records the exact commit examined when a full review completes successfully; a parked review retains its candidate only for recovery, while failed, skipped, superseded, and legacy reviews grant no inferred approval authority
 
 **Approval:** required if any finding has severity `error` or `warning`. Findings with `action: ask-user` pause for approval instead of entering the normal auto-fix loop. This is for findings that challenge the author's intent, not routine correctness, reliability, or security fixes that may need to re-add a small amount of deleted logic. With the default `auto_fix.review: 0`, blocking review findings park for approval even when their action is `auto-fix`; setting repo or global `auto_fix.review` above `0` re-enables the automatic review fix loop for eligible `auto-fix` findings. Findings with `action: no-op` are informational only. The shared [finding-action model](/no-mistakes/concepts/auto-fix/#finding-actions) owns the behavior for a missing `action`.
 
@@ -153,16 +154,20 @@ Pushes the validated branch to the configured push target.
 - Commits any uncommitted agent changes with message `no-mistakes: apply agent fixes`
 - Without fork routing, the push target is the credentialled upstream URL resolved from the worktree's `origin` remote at run time (the DB stores a redacted copy)
 - With GitHub fork routing, the push target is `repos.fork_url`
+- Immediately before remote mutation, reloads the durable review-approved commit and refuses to push when that binding is missing, malformed, or unreachable
+- Requires the commit proposed for push to equal or descend from the review-approved commit, allowing commits made by later pipeline steps without authorizing unrelated history
 - Re-reads the push target via `git ls-remote` before pushing
 - For existing branches, refuses to force-push when the live remote carries commits the pipeline has not incorporated by patch-id
 - Fails closed when the remote safety check cannot verify whether the push would discard existing remote work
 - Uses `--force-with-lease=<ref>:<sha>` with an explicit SHA anchor for allowed existing-branch rewrites
-- Treats the branch as already pushed when the remote already points at the validated head
+- Pushes the exact verified commit SHA instead of mutable worktree `HEAD`
+- Treats the branch as already pushed when the remote already points at that verified commit
 - Uses regular push for new branches
-- Updates the run's head SHA in the database after push
+- Updates the run's head SHA in the database to the exact commit delivered
 
 A remote branch can move without being rejected when all remote commits are already represented in the validated head, or when a run is intentionally rewriting history it already knew about.
 Any other out-of-band commit stops the push instead of being overwritten.
+Pre-skipping or later skipping Review leaves no approval binding, so Push fails closed unless Push is also skipped.
 
 This step never requires approval - it runs automatically after review, test, document, and lint pass.
 

--- a/internal/daemon/subscribe_recover_test.go
+++ b/internal/daemon/subscribe_recover_test.go
@@ -476,7 +476,7 @@ func TestRecoverOnStartup_ResumesParkedRun(t *testing.T) {
 	if err := d.SetStepFindings(step.ID, findings); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := d.InsertStepRound(step.ID, 1, "initial", &findings, nil, 1); err != nil {
+	if _, err := d.InsertReviewStepRound(step.ID, 1, "initial", &findings, nil, headSHA, 1); err != nil {
 		t.Fatal(err)
 	}
 	if err := d.UpdateStepStatusWithDuration(step.ID, types.StepStatusAwaitingApproval, 1); err != nil {
@@ -537,6 +537,9 @@ func TestRecoverOnStartup_ResumesParkedRun(t *testing.T) {
 	}
 	if completed.AwaitingAgentSince != nil {
 		t.Fatal("recovered run remained parked after approval")
+	}
+	if completed.ReviewApprovedHeadSHA == nil || *completed.ReviewApprovedHeadSHA != headSHA {
+		t.Fatalf("recovered review approval = %#v, want %s", completed.ReviewApprovedHeadSHA, headSHA)
 	}
 	// The executor marks the run terminal before its owner goroutine performs
 	// worktree cleanup. Wait for that cleanup rather than assuming it completed

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -76,10 +76,13 @@ func TestOpenCreatesSchema(t *testing.T) {
 	if !hasColumn(t, d, "repos", "fork_url") {
 		t.Fatal("repos.fork_url column missing from fresh schema")
 	}
-	for _, column := range []string{"submitted_head_sha", "last_pushed_sha", "push_target_fingerprint", "push_ref", "last_pushed_at", "push_generation", "push_active", "pr_state", "pr_state_observed_at", "ci_ready_at", "custody_returned_at"} {
+	for _, column := range []string{"submitted_head_sha", "review_approved_head_sha", "last_pushed_sha", "push_target_fingerprint", "push_ref", "last_pushed_at", "push_generation", "push_active", "pr_state", "pr_state_observed_at", "ci_ready_at", "custody_returned_at"} {
 		if !hasColumn(t, d, "runs", column) {
 			t.Fatalf("runs.%s column missing from fresh schema", column)
 		}
+	}
+	if !hasColumn(t, d, "step_rounds", "reviewed_head_sha") {
+		t.Fatal("step_rounds.reviewed_head_sha column missing from fresh schema")
 	}
 	for _, column := range []string{"last_activity_at", "last_activity", "agent_pid"} {
 		if !hasColumn(t, d, "step_results", column) {
@@ -119,8 +122,8 @@ func TestOpenMigratesRunSyncProvenanceWithoutBackfillingMutableHead(t *testing.T
 	if run == nil || run.HeadSHA != "mutable-head" {
 		t.Fatalf("migrated run = %#v", run)
 	}
-	if run.SubmittedHeadSHA != nil || run.LastPushedSHA != nil || run.PushGeneration != nil || run.PushTargetFingerprint != nil {
-		t.Fatalf("legacy provenance was inferred from mutable head: %#v", run)
+	if run.SubmittedHeadSHA != nil || run.ReviewApprovedHeadSHA != nil || run.LastPushedSHA != nil || run.PushGeneration != nil || run.PushTargetFingerprint != nil {
+		t.Fatalf("legacy provenance or review authority was inferred from mutable head: %#v", run)
 	}
 	if run.CustodyReturnedAt != nil {
 		t.Fatalf("legacy run gained a custody-return stamp: %#v", run)
@@ -189,7 +192,7 @@ func TestOpenMigratesExistingStepRoundsColumns(t *testing.T) {
 		t.Fatalf("iterate table_info: %v", err)
 	}
 
-	for _, name := range []string{"selected_finding_ids", "selection_source", "fix_summary"} {
+	for _, name := range []string{"selected_finding_ids", "selection_source", "fix_summary", "reviewed_head_sha"} {
 		if !columns[name] {
 			t.Fatalf("expected migrated column %q to exist", name)
 		}

--- a/internal/db/round.go
+++ b/internal/db/round.go
@@ -9,11 +9,12 @@ const (
 
 // StepRound represents one execution round within a pipeline step.
 type StepRound struct {
-	ID           string
-	StepResultID string
-	Round        int
-	Trigger      string  // "initial", "auto_fix"; legacy "user_fix" is treated as "auto_fix"
-	FindingsJSON *string // nullable - findings produced by this round
+	ID              string
+	StepResultID    string
+	Round           int
+	Trigger         string  // "initial", "auto_fix"; legacy "user_fix" is treated as "auto_fix"
+	FindingsJSON    *string // nullable - findings produced by this round
+	ReviewedHeadSHA *string // non-authoritative commit candidate captured by a review round
 	// UserFindingsJSON, when non-nil, is the merged finding list that was
 	// dispatched to the fix agent after the user edited per-finding
 	// instructions or added their own findings. It includes both the
@@ -117,19 +118,35 @@ func (d *DB) StepRoundStats(stepResultID string) (StepRoundStats, error) {
 // InsertStepRound creates a new round record for a step result. fixSummary may
 // be nil for non-fix rounds or when the agent produced no summary.
 func (d *DB) InsertStepRound(stepResultID string, round int, trigger string, findingsJSON *string, fixSummary *string, durationMS int64) (*StepRound, error) {
+	return d.insertStepRound(stepResultID, round, trigger, findingsJSON, fixSummary, nil, durationMS)
+}
+
+// InsertReviewStepRound persists a review round's examined commit as a
+// non-authoritative candidate. A recovered parked gate can promote this exact
+// candidate only after approval; merely storing it grants no push authority.
+func (d *DB) InsertReviewStepRound(stepResultID string, round int, trigger string, findingsJSON *string, fixSummary *string, reviewedHeadSHA string, durationMS int64) (*StepRound, error) {
+	var reviewed *string
+	if reviewedHeadSHA != "" {
+		reviewed = &reviewedHeadSHA
+	}
+	return d.insertStepRound(stepResultID, round, trigger, findingsJSON, fixSummary, reviewed, durationMS)
+}
+
+func (d *DB) insertStepRound(stepResultID string, round int, trigger string, findingsJSON *string, fixSummary, reviewedHeadSHA *string, durationMS int64) (*StepRound, error) {
 	r := &StepRound{
-		ID:           newID(),
-		StepResultID: stepResultID,
-		Round:        round,
-		Trigger:      trigger,
-		FindingsJSON: findingsJSON,
-		FixSummary:   fixSummary,
-		DurationMS:   durationMS,
-		CreatedAt:    now(),
+		ID:              newID(),
+		StepResultID:    stepResultID,
+		Round:           round,
+		Trigger:         trigger,
+		FindingsJSON:    findingsJSON,
+		ReviewedHeadSHA: reviewedHeadSHA,
+		FixSummary:      fixSummary,
+		DurationMS:      durationMS,
+		CreatedAt:       now(),
 	}
 	_, err := d.sql.Exec(
-		`INSERT INTO step_rounds (id, step_result_id, round, trigger_type, findings_json, user_findings_json, selected_finding_ids, selection_source, fix_summary, duration_ms, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		r.ID, r.StepResultID, r.Round, r.Trigger, r.FindingsJSON, r.UserFindingsJSON, r.SelectedFindingIDs, r.SelectionSource, r.FixSummary, r.DurationMS, r.CreatedAt,
+		`INSERT INTO step_rounds (id, step_result_id, round, trigger_type, findings_json, reviewed_head_sha, user_findings_json, selected_finding_ids, selection_source, fix_summary, duration_ms, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		r.ID, r.StepResultID, r.Round, r.Trigger, r.FindingsJSON, r.ReviewedHeadSHA, r.UserFindingsJSON, r.SelectedFindingIDs, r.SelectionSource, r.FixSummary, r.DurationMS, r.CreatedAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("insert step round: %w", err)
@@ -177,7 +194,7 @@ func (d *DB) SetStepRoundUserFindings(id string, userFindingsJSON *string) error
 // GetRoundsByStep returns all rounds for a step result, ordered by round number.
 func (d *DB) GetRoundsByStep(stepResultID string) ([]*StepRound, error) {
 	rows, err := d.sql.Query(
-		`SELECT id, step_result_id, round, trigger_type, findings_json, user_findings_json, selected_finding_ids, selection_source, fix_summary, duration_ms, created_at FROM step_rounds WHERE step_result_id = ? ORDER BY round`,
+		`SELECT id, step_result_id, round, trigger_type, findings_json, reviewed_head_sha, user_findings_json, selected_finding_ids, selection_source, fix_summary, duration_ms, created_at FROM step_rounds WHERE step_result_id = ? ORDER BY round`,
 		stepResultID,
 	)
 	if err != nil {
@@ -187,7 +204,7 @@ func (d *DB) GetRoundsByStep(stepResultID string) ([]*StepRound, error) {
 	var rounds []*StepRound
 	for rows.Next() {
 		r := &StepRound{}
-		if err := rows.Scan(&r.ID, &r.StepResultID, &r.Round, &r.Trigger, &r.FindingsJSON, &r.UserFindingsJSON, &r.SelectedFindingIDs, &r.SelectionSource, &r.FixSummary, &r.DurationMS, &r.CreatedAt); err != nil {
+		if err := rows.Scan(&r.ID, &r.StepResultID, &r.Round, &r.Trigger, &r.FindingsJSON, &r.ReviewedHeadSHA, &r.UserFindingsJSON, &r.SelectedFindingIDs, &r.SelectionSource, &r.FixSummary, &r.DurationMS, &r.CreatedAt); err != nil {
 			return nil, fmt.Errorf("scan step round: %w", err)
 		}
 		rounds = append(rounds, r)

--- a/internal/db/round_test.go
+++ b/internal/db/round_test.go
@@ -6,6 +6,28 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
+func TestInsertReviewStepRoundPersistsNonAuthoritativeCandidate(t *testing.T) {
+	d := openTestDB(t)
+	repo, _ := d.InsertRepo("/tmp/review-round", "https://example.com/repo.git", "main")
+	run, _ := d.InsertRun(repo.ID, "feature", "head", "base")
+	step, _ := d.InsertStepResult(run.ID, types.StepReview)
+	const reviewedHead = "1111111111111111111111111111111111111111"
+	if _, err := d.InsertReviewStepRound(step.ID, 1, "initial", nil, nil, reviewedHead, 10); err != nil {
+		t.Fatal(err)
+	}
+	rounds, err := d.GetRoundsByStep(step.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rounds) != 1 || rounds[0].ReviewedHeadSHA == nil || *rounds[0].ReviewedHeadSHA != reviewedHead {
+		t.Fatalf("reviewed candidate round = %#v", rounds)
+	}
+	gotRun, _ := d.GetRun(run.ID)
+	if gotRun.ReviewApprovedHeadSHA != nil {
+		t.Fatalf("round candidate granted approval authority: %#v", gotRun.ReviewApprovedHeadSHA)
+	}
+}
+
 func TestStepRoundInsertAndGet(t *testing.T) {
 	d := openTestDB(t)
 	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")

--- a/internal/db/run.go
+++ b/internal/db/run.go
@@ -10,12 +10,16 @@ import (
 
 // Run represents a pipeline run.
 type Run struct {
-	ID                    string
-	RepoID                string
-	Branch                string
-	HeadSHA               string
-	BaseSHA               string
-	SubmittedHeadSHA      *string
+	ID               string
+	RepoID           string
+	Branch           string
+	HeadSHA          string
+	BaseSHA          string
+	SubmittedHeadSHA *string
+	// ReviewApprovedHeadSHA is the exact commit approved by the last
+	// successfully completed full review. It is nil for legacy runs and until
+	// review completes; mutable run/worktree heads never infer this authority.
+	ReviewApprovedHeadSHA *string
 	Status                types.RunStatus
 	PRURL                 *string
 	PRState               *string
@@ -54,13 +58,13 @@ type Run struct {
 	UpdatedAt       int64
 }
 
-const runColumns = `id, repo_id, branch, head_sha, base_sha, submitted_head_sha, status, pr_url, pr_state, pr_state_observed_at, ci_ready_at, last_pushed_sha, push_target_kind, push_target_fingerprint, push_ref, last_pushed_at, push_generation, COALESCE(push_active, 0), custody_returned_at, error, awaiting_agent_since, COALESCE(parked_ms, 0), intent, intent_source, intent_session_id, intent_score, created_at, updated_at`
+const runColumns = `id, repo_id, branch, head_sha, base_sha, submitted_head_sha, review_approved_head_sha, status, pr_url, pr_state, pr_state_observed_at, ci_ready_at, last_pushed_sha, push_target_kind, push_target_fingerprint, push_ref, last_pushed_at, push_generation, COALESCE(push_active, 0), custody_returned_at, error, awaiting_agent_since, COALESCE(parked_ms, 0), intent, intent_source, intent_session_id, intent_score, created_at, updated_at`
 
 func scanRun(row interface {
 	Scan(...any) error
 }, r *Run) error {
 	return row.Scan(
-		&r.ID, &r.RepoID, &r.Branch, &r.HeadSHA, &r.BaseSHA, &r.SubmittedHeadSHA, &r.Status,
+		&r.ID, &r.RepoID, &r.Branch, &r.HeadSHA, &r.BaseSHA, &r.SubmittedHeadSHA, &r.ReviewApprovedHeadSHA, &r.Status,
 		&r.PRURL, &r.PRState, &r.PRStateObservedAt, &r.CIReadyAt,
 		&r.LastPushedSHA, &r.PushTargetKind, &r.PushTargetFingerprint, &r.PushRef,
 		&r.LastPushedAt, &r.PushGeneration, &r.PushActive,
@@ -401,6 +405,16 @@ func (d *DB) SetRunCIReady(id string, ready bool) error {
 	_, err := d.sql.Exec(`UPDATE runs SET ci_ready_at = ?, updated_at = ? WHERE id = ? AND ((ci_ready_at IS NULL AND ? = 1) OR (ci_ready_at IS NOT NULL AND ? = 0))`, readyAt, now(), id, ready, ready)
 	if err != nil {
 		return fmt.Errorf("set run CI ready: %w", err)
+	}
+	return nil
+}
+
+// UpdateRunReviewApprovedHeadSHA replaces the run's review authority with the
+// exact commit approved by the latest successfully completed full review.
+func (d *DB) UpdateRunReviewApprovedHeadSHA(id, headSHA string) error {
+	_, err := d.sql.Exec(`UPDATE runs SET review_approved_head_sha = ?, updated_at = ? WHERE id = ?`, headSHA, now(), id)
+	if err != nil {
+		return fmt.Errorf("update run review-approved head sha: %w", err)
 	}
 	return nil
 }

--- a/internal/db/run_test.go
+++ b/internal/db/run_test.go
@@ -510,6 +510,31 @@ func TestReconcileTerminalPRRunsFinalizesLegacyActiveRows(t *testing.T) {
 	}
 }
 
+func TestUpdateRunReviewApprovedHeadSHAReplacesAuthority(t *testing.T) {
+	d := openTestDB(t)
+	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")
+	run, _ := d.InsertRun(repo.ID, "feature", "mutable", "base")
+	if run.ReviewApprovedHeadSHA != nil {
+		t.Fatalf("new run inferred review authority: %#v", run.ReviewApprovedHeadSHA)
+	}
+	if err := d.UpdateRunReviewApprovedHeadSHA(run.ID, "reviewed-1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.UpdateRunReviewApprovedHeadSHA(run.ID, "reviewed-2"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := d.GetRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ReviewApprovedHeadSHA == nil || *got.ReviewApprovedHeadSHA != "reviewed-2" {
+		t.Fatalf("review-approved head = %#v, want reviewed-2", got.ReviewApprovedHeadSHA)
+	}
+	if got.HeadSHA != "mutable" {
+		t.Fatalf("review authority update mutated run head to %s", got.HeadSHA)
+	}
+}
+
 func TestUpdateRunHeadSHA(t *testing.T) {
 	d := openTestDB(t)
 	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS runs (
     head_sha                TEXT NOT NULL,
     base_sha                TEXT NOT NULL,
     submitted_head_sha      TEXT,
+    review_approved_head_sha TEXT,
     status                  TEXT NOT NULL DEFAULT 'pending',
     pr_url                  TEXT,
     pr_state                TEXT,
@@ -61,6 +62,7 @@ CREATE TABLE IF NOT EXISTS step_rounds (
     round                INTEGER NOT NULL,
     trigger_type         TEXT NOT NULL,
     findings_json        TEXT,
+    reviewed_head_sha    TEXT,
     user_findings_json   TEXT,
     selected_finding_ids TEXT,
     selection_source     TEXT,
@@ -140,6 +142,9 @@ var migrationStatements = []string{
 	`ALTER TABLE step_rounds ADD COLUMN selection_source TEXT`,
 	`ALTER TABLE step_rounds ADD COLUMN fix_summary TEXT`,
 	`ALTER TABLE step_rounds ADD COLUMN user_findings_json TEXT`,
+	// A parked round may retain the reviewed commit as a non-authoritative
+	// candidate. Only atomic review completion promotes it onto the run.
+	`ALTER TABLE step_rounds ADD COLUMN reviewed_head_sha TEXT`,
 	`ALTER TABLE runs ADD COLUMN intent TEXT`,
 	`ALTER TABLE runs ADD COLUMN intent_source TEXT`,
 	`ALTER TABLE runs ADD COLUMN intent_session_id TEXT`,
@@ -149,6 +154,9 @@ var migrationStatements = []string{
 	// Branch synchronization provenance is intentionally nullable. Historical
 	// rows stay unbound because mutable head_sha cannot prove a successful push.
 	`ALTER TABLE runs ADD COLUMN submitted_head_sha TEXT`,
+	// Review authority is nullable and never backfilled. A historical mutable
+	// head_sha cannot prove which exact commit a completed review approved.
+	`ALTER TABLE runs ADD COLUMN review_approved_head_sha TEXT`,
 	`ALTER TABLE runs ADD COLUMN last_pushed_sha TEXT`,
 	`ALTER TABLE runs ADD COLUMN push_target_kind TEXT`,
 	`ALTER TABLE runs ADD COLUMN push_target_fingerprint TEXT`,

--- a/internal/db/step.go
+++ b/internal/db/step.go
@@ -148,6 +148,41 @@ func (d *DB) CompleteStepWithStatus(id string, status types.StepStatus, exitCode
 	return nil
 }
 
+// CompleteReviewStep atomically completes a successful review and replaces
+// the run's exact review-approved head. Neither write survives if the other
+// fails, so a failed completion cannot create approval authority and a
+// completed review cannot lack it.
+func (d *DB) CompleteReviewStep(id, runID, approvedHeadSHA string, exitCode int, durationMS int64, logPath string) error {
+	tx, err := d.sql.Begin()
+	if err != nil {
+		return fmt.Errorf("begin complete review step: %w", err)
+	}
+	defer tx.Rollback()
+
+	ts := now()
+	result, err := tx.Exec(
+		`UPDATE step_results SET status = ?, exit_code = ?, duration_ms = ?, log_path = ?, completed_at = ?, last_activity_at = ?, last_activity = ?, agent_pid = NULL WHERE id = ?`,
+		types.StepStatusCompleted, exitCode, durationMS, logPath, ts, ts, fmt.Sprintf("status: %s", types.StepStatusCompleted), id,
+	)
+	if err != nil {
+		return fmt.Errorf("complete review step: %w", err)
+	}
+	if rows, err := result.RowsAffected(); err != nil || rows != 1 {
+		return fmt.Errorf("complete review step: step row not found")
+	}
+	result, err = tx.Exec(`UPDATE runs SET review_approved_head_sha = ?, updated_at = ? WHERE id = ?`, approvedHeadSHA, ts, runID)
+	if err != nil {
+		return fmt.Errorf("record review-approved head: %w", err)
+	}
+	if rows, err := result.RowsAffected(); err != nil || rows != 1 {
+		return fmt.Errorf("record review-approved head: run row not found")
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit completed review: %w", err)
+	}
+	return nil
+}
+
 // FailStep marks a step as failed with an error message and duration.
 func (d *DB) FailStep(id string, errMsg string, durationMS int64) error {
 	_, err := d.sql.Exec(

--- a/internal/db/step_test.go
+++ b/internal/db/step_test.go
@@ -234,6 +234,37 @@ func TestUpdateStepStatusWithDuration(t *testing.T) {
 	}
 }
 
+func TestCompleteReviewStepIsAtomic(t *testing.T) {
+	d := openTestDB(t)
+	repo, _ := d.InsertRepo("/tmp/review-atomic", "https://example.com/repo.git", "main")
+	run, _ := d.InsertRun(repo.ID, "feature", "head", "base")
+	step, _ := d.InsertStepResult(run.ID, types.StepReview)
+	if err := d.StartStep(step.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := d.CompleteReviewStep(step.ID, "missing-run", "approved", 0, 10, "review.log"); err == nil {
+		t.Fatal("expected missing run to roll back review completion")
+	}
+	gotStep, _ := d.GetStepResult(step.ID)
+	if gotStep.Status != types.StepStatusRunning || gotStep.CompletedAt != nil {
+		t.Fatalf("failed transaction partially completed review: %#v", gotStep)
+	}
+	gotRun, _ := d.GetRun(run.ID)
+	if gotRun.ReviewApprovedHeadSHA != nil {
+		t.Fatalf("failed transaction created review authority: %#v", gotRun.ReviewApprovedHeadSHA)
+	}
+
+	if err := d.CompleteReviewStep(step.ID, run.ID, "approved", 0, 10, "review.log"); err != nil {
+		t.Fatal(err)
+	}
+	gotStep, _ = d.GetStepResult(step.ID)
+	gotRun, _ = d.GetRun(run.ID)
+	if gotStep.Status != types.StepStatusCompleted || gotRun.ReviewApprovedHeadSHA == nil || *gotRun.ReviewApprovedHeadSHA != "approved" {
+		t.Fatalf("atomic review completion = step %#v run %#v", gotStep, gotRun)
+	}
+}
+
 func TestFailStep(t *testing.T) {
 	d := openTestDB(t)
 	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -429,14 +429,24 @@ func FetchRemoteBranchToPrivateRef(ctx context.Context, dir, remote, branch, loc
 	return err
 }
 
-// Push pushes a ref to a remote. If forceWithLease is true, uses
-// --force-with-lease with the expectedSHA for safe force-push.
+// Push pushes HEAD to a remote ref. If forceWithLease is true, it uses an
+// explicit expected remote SHA for safe force-push.
 func Push(ctx context.Context, dir, remote, ref, expectedSHA string, forceWithLease bool) error {
 	return PushWithOptions(ctx, dir, remote, ref, expectedSHA, forceWithLease, nil)
 }
 
-// PushWithOptions pushes a ref to a remote with per-push options.
+// PushCommit pushes one immutable commit object to a remote ref. Unlike Push,
+// a concurrent worktree HEAD move cannot change the source selected by git.
+func PushCommit(ctx context.Context, dir, remote, commitSHA, ref, expectedSHA string, forceWithLease bool) error {
+	return pushSourceWithOptions(ctx, dir, remote, commitSHA, ref, expectedSHA, forceWithLease, nil)
+}
+
+// PushWithOptions pushes HEAD to a remote with per-push options.
 func PushWithOptions(ctx context.Context, dir, remote, ref, expectedSHA string, forceWithLease bool, pushOptions []string) error {
+	return pushSourceWithOptions(ctx, dir, remote, "HEAD", ref, expectedSHA, forceWithLease, pushOptions)
+}
+
+func pushSourceWithOptions(ctx context.Context, dir, remote, source, ref, expectedSHA string, forceWithLease bool, pushOptions []string) error {
 	args := []string{"push"}
 	for _, option := range pushOptions {
 		args = append(args, "-o", option)
@@ -449,7 +459,7 @@ func PushWithOptions(ctx context.Context, dir, remote, ref, expectedSHA string, 
 			args = append(args, "--force-with-lease")
 		}
 	}
-	args = append(args, "HEAD:"+ref)
+	args = append(args, source+":"+ref)
 	_, err := Run(ctx, dir, args...)
 	return err
 }

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -228,13 +228,14 @@ type stepExecutionState struct {
 }
 
 type recoveredGate struct {
-	index       int
-	step        Step
-	stepResult  *db.StepResult
-	findings    string
-	round       int
-	autoFixes   int
-	lastRoundID string
+	index           int
+	step            Step
+	stepResult      *db.StepResult
+	findings        string
+	round           int
+	autoFixes       int
+	lastRoundID     string
+	reviewedHeadSHA string
 }
 
 func ValidateRecoveredRun(database *db.DB, run *db.Run, steps []Step) error {
@@ -267,8 +268,22 @@ func (e *Executor) Resume(ctx context.Context, run *db.Run, repo *db.Repo, workD
 
 	parkStart := time.Unix(*run.AwaitingAgentSince, 0)
 	duration := recoveredStepDuration(gate.stepResult)
+	completeRecoveredGate := func() error {
+		if gate.step.Name() == types.StepReview {
+			if gate.reviewedHeadSHA == "" {
+				return fmt.Errorf("recovered review has no durable reviewed head candidate")
+			}
+			if err := e.db.CompleteReviewStep(gate.stepResult.ID, run.ID, gate.reviewedHeadSHA, recoveredExitCode(gate.stepResult), duration, recoveredLogPath(gate.stepResult)); err != nil {
+				return err
+			}
+			reviewedHead := gate.reviewedHeadSHA
+			run.ReviewApprovedHeadSHA = &reviewedHead
+			return nil
+		}
+		return e.db.CompleteStepWithStatus(gate.stepResult.ID, types.StepStatusCompleted, recoveredExitCode(gate.stepResult), duration, recoveredLogPath(gate.stepResult))
+	}
 	completeReconciledGate := func() error {
-		if err := e.db.CompleteStepWithStatus(gate.stepResult.ID, types.StepStatusCompleted, recoveredExitCode(gate.stepResult), duration, recoveredLogPath(gate.stepResult)); err != nil {
+		if err := completeRecoveredGate(); err != nil {
 			return e.failRun(run, repo, fmt.Errorf("complete reconciled step %s: %w", gate.step.Name(), err), ctx)
 		}
 		e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, gate.step.Name(), string(types.StepStatusCompleted), "", "", "", &duration)
@@ -344,7 +359,7 @@ func (e *Executor) Resume(ctx context.Context, run *db.Run, repo *db.Repo, workD
 	telemetry.Track("approval", approvalFields)
 	switch response.action {
 	case types.ActionApprove:
-		if err := e.db.CompleteStepWithStatus(gate.stepResult.ID, types.StepStatusCompleted, recoveredExitCode(gate.stepResult), duration, recoveredLogPath(gate.stepResult)); err != nil {
+		if err := completeRecoveredGate(); err != nil {
 			return e.failRun(run, repo, fmt.Errorf("complete recovered step %s: %w", gate.step.Name(), err), ctx)
 		}
 		e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, gate.step.Name(), string(types.StepStatusCompleted), "", "", "", &duration)
@@ -442,6 +457,9 @@ func (e *Executor) recoveredGate(runID string) (*recoveredGate, error) {
 				round:       latest.Round,
 				autoFixes:   autoFixes,
 				lastRoundID: latest.ID,
+			}
+			if latest.ReviewedHeadSHA != nil {
+				gate.reviewedHeadSHA = *latest.ReviewedHeadSHA
 			}
 			continue
 		}
@@ -682,6 +700,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 	skipRemaining := false
 	stepSkipped := false
 	currentRoundID := state.currentRoundID
+	var reviewApprovedHeadSHA string
 
 	// Execute with possible fix loop
 	for {
@@ -706,6 +725,9 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			return false, fmt.Errorf("step %s failed: %s", stepName, redactedErr)
 		}
 
+		if stepName == types.StepReview {
+			reviewApprovedHeadSHA = outcome.ReviewApprovedHeadSHA
+		}
 		outcome.Findings = normalizeFindingsJSON(outcome.Findings, string(stepName))
 		finalExitCode = outcome.ExitCode
 		durationOverrideMS += outcome.DurationOverrideMS
@@ -730,7 +752,14 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			s := outcome.FixSummary
 			fixSummaryPtr = &s
 		}
-		if inserted, dbErr := e.db.InsertStepRound(sr.ID, roundNum, nextTrigger, findingsPtr, fixSummaryPtr, roundDuration); dbErr != nil {
+		var inserted *db.StepRound
+		var dbErr error
+		if stepName == types.StepReview {
+			inserted, dbErr = e.db.InsertReviewStepRound(sr.ID, roundNum, nextTrigger, findingsPtr, fixSummaryPtr, reviewApprovedHeadSHA, roundDuration)
+		} else {
+			inserted, dbErr = e.db.InsertStepRound(sr.ID, roundNum, nextTrigger, findingsPtr, fixSummaryPtr, roundDuration)
+		}
+		if dbErr != nil {
 			currentRoundID = roundInsertID(currentRoundID, inserted, dbErr)
 			slog.Warn("failed to insert step round", "step", stepName, "round", roundNum, "error", dbErr)
 		} else {
@@ -922,7 +951,17 @@ done:
 	if stepSkipped {
 		status = types.StepStatusSkipped
 	}
-	if err := e.db.CompleteStepWithStatus(sr.ID, status, finalExitCode, durationMS, logPath); err != nil {
+	// A review round's captured head becomes authority only when the review
+	// actually completes. Parked outcomes stay in the loop above, failures
+	// return earlier, and skipped reviews deliberately leave the binding empty.
+	// Completion and authority replacement are one DB transaction.
+	if stepName == types.StepReview && status == types.StepStatusCompleted && reviewApprovedHeadSHA != "" {
+		if err := e.db.CompleteReviewStep(sr.ID, run.ID, reviewApprovedHeadSHA, finalExitCode, durationMS, logPath); err != nil {
+			return false, fmt.Errorf("complete step %s: %w", stepName, err)
+		}
+		reviewedHead := reviewApprovedHeadSHA
+		run.ReviewApprovedHeadSHA = &reviewedHead
+	} else if err := e.db.CompleteStepWithStatus(sr.ID, status, finalExitCode, durationMS, logPath); err != nil {
 		return false, fmt.Errorf("complete step %s: %w", stepName, err)
 	}
 	e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, stepName, string(status), "", "", "", &durationMS)

--- a/internal/pipeline/executor_approval_test.go
+++ b/internal/pipeline/executor_approval_test.go
@@ -139,7 +139,7 @@ func TestExecutor_ResumeRestoresParkedGateAndReviewSessions(t *testing.T) {
 	if err := database.SetStepFindings(stepResult.ID, findings); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := database.InsertStepRound(stepResult.ID, 1, "initial", &findings, nil, 25); err != nil {
+	if _, err := database.InsertReviewStepRound(stepResult.ID, 1, "initial", &findings, nil, "1111111111111111111111111111111111111111", 25); err != nil {
 		t.Fatal(err)
 	}
 	if err := database.UpdateStepStatusWithDuration(stepResult.ID, types.StepStatusAwaitingApproval, 25); err != nil {
@@ -172,7 +172,7 @@ func TestExecutor_ResumeRestoresParkedGateAndReviewSessions(t *testing.T) {
 			if _, err := sctx.RunAgentSession(SessionRoleReviewer, agent.RunOpts{Prompt: "rereview"}); err != nil {
 				return nil, err
 			}
-			return &StepOutcome{}, nil
+			return &StepOutcome{ReviewApprovedHeadSHA: "2222222222222222222222222222222222222222"}, nil
 		},
 	}
 	exec := NewExecutor(database, p, &config.Config{SessionReuse: true}, fake, []Step{step}, nil)
@@ -216,6 +216,66 @@ func TestExecutor_ResumeRestoresParkedGateAndReviewSessions(t *testing.T) {
 	}
 	if resumed.Status != types.RunCompleted || resumed.AwaitingAgentSince != nil {
 		t.Fatalf("recovered run = status %s awaiting %v, want completed and unparked", resumed.Status, resumed.AwaitingAgentSince)
+	}
+	if resumed.ReviewApprovedHeadSHA == nil || *resumed.ReviewApprovedHeadSHA != "2222222222222222222222222222222222222222" {
+		t.Fatalf("recovered rereview approval = %#v", resumed.ReviewApprovedHeadSHA)
+	}
+}
+
+func TestExecutor_ResumePromotesDurableReviewedCandidateOnApproval(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	if err := database.UpdateRunStatus(run.ID, types.RunRunning); err != nil {
+		t.Fatal(err)
+	}
+	stepResult, err := database.InsertStepResult(run.ID, types.StepReview)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.StartStep(stepResult.ID); err != nil {
+		t.Fatal(err)
+	}
+	findings := `{"findings":[{"id":"review-1","severity":"warning","description":"decision","action":"ask-user"}]}`
+	const reviewedHead = "3333333333333333333333333333333333333333"
+	if err := database.SetStepFindings(stepResult.ID, findings); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.InsertReviewStepRound(stepResult.ID, 1, "initial", &findings, nil, reviewedHead, 10); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.UpdateStepStatusWithDuration(stepResult.ID, types.StepStatusAwaitingApproval, 10); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.SetRunAwaitingAgent(run.ID); err != nil {
+		t.Fatal(err)
+	}
+	run, err = database.GetRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exec := NewExecutor(database, p, &config.Config{}, nil, []Step{newApprovalStep(types.StepReview, findings)}, nil)
+	workDir := t.TempDir()
+	done := make(chan error, 1)
+	go func() { done <- exec.Resume(context.Background(), run, repo, workDir) }()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if err := exec.Respond(types.StepReview, types.ActionApprove, nil); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("recovered review never accepted approval")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	got, err := database.GetRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ReviewApprovedHeadSHA == nil || *got.ReviewApprovedHeadSHA != reviewedHead {
+		t.Fatalf("recovered approval = %#v, want %s", got.ReviewApprovedHeadSHA, reviewedHead)
 	}
 }
 

--- a/internal/pipeline/executor_review_approval_test.go
+++ b/internal/pipeline/executor_review_approval_test.go
@@ -1,0 +1,130 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/config"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+func TestExecutor_RecordsCompletedReviewApprovedHead(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	const reviewedHead = "1111111111111111111111111111111111111111"
+	step := &mockStep{name: types.StepReview, outcome: &StepOutcome{ReviewApprovedHeadSHA: reviewedHead}}
+	exec := NewExecutor(database, p, &config.Config{}, nil, []Step{step}, nil)
+
+	if err := exec.Execute(context.Background(), run, repo, t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	got, err := database.GetRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ReviewApprovedHeadSHA == nil || *got.ReviewApprovedHeadSHA != reviewedHead {
+		t.Fatalf("review-approved head = %#v, want %s", got.ReviewApprovedHeadSHA, reviewedHead)
+	}
+}
+
+func TestExecutor_FullRereviewReplacesApprovalWithoutAuthorizingParkedRound(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	const firstReviewedHead = "1111111111111111111111111111111111111111"
+	const rereviewedHead = "2222222222222222222222222222222222222222"
+	calls := 0
+	step := &adaptiveCallStep{name: types.StepReview, fn: func(sctx *StepContext) (*StepOutcome, error) {
+		calls++
+		if calls == 1 {
+			return &StepOutcome{
+				NeedsApproval:         true,
+				Findings:              `{"findings":[{"id":"r1","severity":"error","description":"fix me","action":"auto-fix"}]}`,
+				ReviewApprovedHeadSHA: firstReviewedHead,
+			}, nil
+		}
+		return &StepOutcome{ReviewApprovedHeadSHA: rereviewedHead}, nil
+	}}
+	exec := NewExecutor(database, p, &config.Config{}, nil, []Step{step}, nil)
+	workDir := t.TempDir()
+
+	done := make(chan error, 1)
+	go func() { done <- exec.Execute(context.Background(), run, repo, workDir) }()
+	waitForStepStatus(t, database, run.ID, types.StepReview, types.StepStatusAwaitingApproval)
+
+	parked, err := database.GetRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parked.ReviewApprovedHeadSHA != nil {
+		t.Fatalf("parked review gained approval authority: %#v", parked.ReviewApprovedHeadSHA)
+	}
+	if err := exec.Respond(types.StepReview, types.ActionFix, nil); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("rereview did not complete")
+	}
+
+	got, err := database.GetRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ReviewApprovedHeadSHA == nil || *got.ReviewApprovedHeadSHA != rereviewedHead {
+		t.Fatalf("rereview approval = %#v, want %s", got.ReviewApprovedHeadSHA, rereviewedHead)
+	}
+}
+
+func TestExecutor_ParkedOrFailedReviewDoesNotAdvanceExistingApproval(t *testing.T) {
+	const existingHead = "1111111111111111111111111111111111111111"
+	const unapprovedHead = "2222222222222222222222222222222222222222"
+
+	t.Run("parked then aborted", func(t *testing.T) {
+		database, p, run, repo := setupTest(t)
+		if err := database.UpdateRunReviewApprovedHeadSHA(run.ID, existingHead); err != nil {
+			t.Fatal(err)
+		}
+		step := &mockStep{name: types.StepReview, outcome: &StepOutcome{
+			NeedsApproval:         true,
+			Findings:              `{"findings":[{"id":"r1","severity":"error","description":"blocked","action":"ask-user"}]}`,
+			ReviewApprovedHeadSHA: unapprovedHead,
+		}}
+		exec := NewExecutor(database, p, &config.Config{}, nil, []Step{step}, nil)
+		workDir := t.TempDir()
+		done := make(chan error, 1)
+		go func() { done <- exec.Execute(context.Background(), run, repo, workDir) }()
+		waitForStepStatus(t, database, run.ID, types.StepReview, types.StepStatusAwaitingApproval)
+		got, _ := database.GetRun(run.ID)
+		if got.ReviewApprovedHeadSHA == nil || *got.ReviewApprovedHeadSHA != existingHead {
+			t.Fatalf("parked review advanced approval: %#v", got.ReviewApprovedHeadSHA)
+		}
+		if err := exec.Respond(types.StepReview, types.ActionAbort, nil); err != nil {
+			t.Fatal(err)
+		}
+		<-done
+		got, _ = database.GetRun(run.ID)
+		if got.ReviewApprovedHeadSHA == nil || *got.ReviewApprovedHeadSHA != existingHead {
+			t.Fatalf("aborted review advanced approval: %#v", got.ReviewApprovedHeadSHA)
+		}
+	})
+
+	t.Run("failed", func(t *testing.T) {
+		database, p, run, repo := setupTest(t)
+		if err := database.UpdateRunReviewApprovedHeadSHA(run.ID, existingHead); err != nil {
+			t.Fatal(err)
+		}
+		step := newFailStep(types.StepReview, errors.New("review agent failed"))
+		exec := NewExecutor(database, p, &config.Config{}, nil, []Step{step}, nil)
+		if err := exec.Execute(context.Background(), run, repo, t.TempDir()); err == nil {
+			t.Fatal("expected failed review")
+		}
+		got, _ := database.GetRun(run.ID)
+		if got.ReviewApprovedHeadSHA == nil || *got.ReviewApprovedHeadSHA != existingHead {
+			t.Fatalf("failed review advanced approval: %#v", got.ReviewApprovedHeadSHA)
+		}
+	})
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -72,6 +72,10 @@ type StepOutcome struct {
 	// mode so the executor can persist it on the round record and later
 	// rounds can reference what was previously attempted.
 	FixSummary string
+	// ReviewApprovedHeadSHA is set only by a successfully executed full review
+	// round. The executor durably records it only when the review step actually
+	// completes, never while that outcome is parked or after a failed round.
+	ReviewApprovedHeadSHA string
 
 	// DurationOverrideMS, when positive, replaces the wall-clock duration
 	// reported for this step. Used by demo mode to show realistic durations

--- a/internal/pipeline/steps/forcepush_safety_test.go
+++ b/internal/pipeline/steps/forcepush_safety_test.go
@@ -145,6 +145,7 @@ func TestPushStep_RefusesToClobberAdvancedUpstreamBranch(t *testing.T) {
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "refs/heads/feature"
 	sctx.Run.HeadSHA = h3
+	recordReviewApproval(t, sctx, h3)
 
 	step := &PushStep{}
 	_, err := step.Execute(sctx)
@@ -231,6 +232,7 @@ func TestForcePushRun_RefusesToClobberOutOfBandBranchCommit(t *testing.T) {
 	if rebaseOutcome != nil && rebaseOutcome.NeedsApproval {
 		t.Fatalf("unexpected approval from rebase on a clean force push: %s", rebaseOutcome.Findings)
 	}
+	recordReviewApproval(t, sctx, gitCmd(t, dir, "rev-parse", "HEAD"))
 
 	// Push step must refuse: origin/feature carries a commit the rewrite dropped.
 	_, err = (&PushStep{}).Execute(sctx)

--- a/internal/pipeline/steps/helpers_test.go
+++ b/internal/pipeline/steps/helpers_test.go
@@ -393,6 +393,15 @@ func fakeGlab(t *testing.T, mrViewJSON string) (env []string, logFile string) {
 
 // newTestContextWithDBRecords is like newTestContext but also inserts
 // repo and run records into the database so GetRun works after updates.
+func recordReviewApproval(t *testing.T, sctx *pipeline.StepContext, headSHA string) {
+	t.Helper()
+	if err := sctx.DB.UpdateRunReviewApprovedHeadSHA(sctx.Run.ID, headSHA); err != nil {
+		t.Fatal(err)
+	}
+	approved := headSHA
+	sctx.Run.ReviewApprovedHeadSHA = &approved
+}
+
 func newTestContextWithDBRecords(t *testing.T, ag agent.Agent, workDir, baseSHA, headSHA string, cmds config.Commands) *pipeline.StepContext {
 	t.Helper()
 	sctx := newTestContext(t, ag, workDir, baseSHA, headSHA, cmds)

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -76,6 +76,9 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 	if err != nil {
 		return nil, fmt.Errorf("resolve head before push: %w", err)
 	}
+	if err := assertReviewApprovedPushHead(sctx, headBeingPushed); err != nil {
+		return nil, err
+	}
 
 	// Decide whether force-pushing would discard commits the pipeline never saw.
 	// The lease is anchored to the remote-tracking ref the rebase step freshly
@@ -92,7 +95,7 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 	switch {
 	case decision.newBranch:
 		// New branch: regular push (no force needed).
-		if err := git.Push(ctx, sctx.WorkDir, pushURL, ref, "", false); err != nil {
+		if err := git.PushCommit(ctx, sctx.WorkDir, pushURL, headBeingPushed, ref, "", false); err != nil {
 			return nil, fmt.Errorf("push to %s: %w", pushTarget, err)
 		}
 	case decision.upToDate:
@@ -100,7 +103,7 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 		// successful binding even though no objects needed to move.
 	default:
 		// Existing branch: force-with-lease anchored to the verified remote head.
-		if err := git.Push(ctx, sctx.WorkDir, pushURL, ref, decision.remoteSHA, true); err != nil {
+		if err := git.PushCommit(ctx, sctx.WorkDir, pushURL, headBeingPushed, ref, decision.remoteSHA, true); err != nil {
 			return nil, fmt.Errorf("push to %s: %w", pushTarget, err)
 		}
 	}
@@ -126,19 +129,60 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 		}
 	}
 
-	headSHA, err := git.HeadSHA(ctx, sctx.WorkDir)
-	if err != nil {
-		return nil, fmt.Errorf("resolve HEAD after push: %w", err)
-	}
-	if headSHA != sctx.Run.HeadSHA {
-		sctx.Run.HeadSHA = headSHA
-		if err := sctx.DB.UpdateRunHeadSHA(sctx.Run.ID, headSHA); err != nil {
+	// Persist the immutable source that was verified and delivered, never a
+	// fresh read of mutable worktree HEAD after the push.
+	if headBeingPushed != sctx.Run.HeadSHA {
+		sctx.Run.HeadSHA = headBeingPushed
+		if err := sctx.DB.UpdateRunHeadSHA(sctx.Run.ID, headBeingPushed); err != nil {
 			return nil, err
 		}
 	}
 
 	sctx.Log("pushed successfully")
 	return &pipeline.StepOutcome{}, nil
+}
+
+func assertReviewApprovedPushHead(sctx *pipeline.StepContext, proposedHead string) error {
+	run, err := sctx.DB.GetRun(sctx.Run.ID)
+	if err != nil {
+		return fmt.Errorf("load durable review approval before push: %w", err)
+	}
+	if run == nil || run.ReviewApprovedHeadSHA == nil || strings.TrimSpace(*run.ReviewApprovedHeadSHA) == "" {
+		return fmt.Errorf("refusing to push: run has no durably recorded review-approved head")
+	}
+	approvedHead := strings.TrimSpace(*run.ReviewApprovedHeadSHA)
+	if !isFullGitObjectID(approvedHead) {
+		return fmt.Errorf("refusing to push: durable review-approved head is malformed")
+	}
+	resolved, err := git.Run(sctx.Ctx, sctx.WorkDir, "rev-parse", "--verify", approvedHead+"^{commit}")
+	if err != nil || !strings.EqualFold(strings.TrimSpace(resolved), approvedHead) {
+		return fmt.Errorf("refusing to push: durable review-approved head is unreachable")
+	}
+	if proposedHead != approvedHead {
+		if _, err := git.Run(sctx.Ctx, sctx.WorkDir, "merge-base", "--is-ancestor", approvedHead, proposedHead); err != nil {
+			return fmt.Errorf("refusing to push: proposed head %s violates continuity with review-approved head %s (it is not an equal or descendant commit)", shortObjectID(proposedHead), shortObjectID(approvedHead))
+		}
+	}
+	return nil
+}
+
+func isFullGitObjectID(value string) bool {
+	if len(value) != 40 && len(value) != 64 {
+		return false
+	}
+	for _, r := range value {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')) {
+			return false
+		}
+	}
+	return true
+}
+
+func shortObjectID(value string) string {
+	if len(value) > 12 {
+		return value[:12]
+	}
+	return value
 }
 
 func (s *PushStep) stageInRepoEvidence(sctx *pipeline.StepContext) error {

--- a/internal/pipeline/steps/push_test.go
+++ b/internal/pipeline/steps/push_test.go
@@ -64,6 +64,13 @@ func TestPushStep_RefusesPostReviewClobberWithoutLaterPipelineCommit(t *testing.
 	if fileAtRef(t, upstream, "refs/heads/feature", "unreviewed.txt") {
 		t.Fatal("remote contains the unreviewed replacement")
 	}
+	t.Logf(
+		"review-approved=%s clobbered-HEAD=%s push-refused=%q remote-still=%s unreviewed-file-shipped=false",
+		reviewedHead,
+		clobberedHead,
+		err,
+		remoteHead,
+	)
 }
 
 func TestAssertReviewApprovedPushHead(t *testing.T) {
@@ -223,6 +230,14 @@ exec "$NM_TEST_REAL_GIT" "$@"
 	if dbRun.HeadSHA != approvedHead || dbRun.LastPushedSHA == nil || *dbRun.LastPushedSHA != approvedHead {
 		t.Fatalf("durable push binding did not retain verified commit %s: %#v", approvedHead, dbRun)
 	}
+	t.Logf(
+		"review-approved=%s concurrent-HEAD=%s remote-delivered=%s durable-head=%s durable-last-pushed=%s",
+		approvedHead,
+		replacementHead,
+		gitCmd(t, upstream, "rev-parse", "refs/heads/feature"),
+		dbRun.HeadSHA,
+		*dbRun.LastPushedSHA,
+	)
 }
 
 func TestPushStep_ReconcilesStaleDatabaseHeadSHA(t *testing.T) {

--- a/internal/pipeline/steps/push_test.go
+++ b/internal/pipeline/steps/push_test.go
@@ -10,6 +10,221 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/config"
 )
 
+// TestPushStep_RefusesPostReviewClobberWithoutLaterPipelineCommit reproduces
+// the end-user incident at the real push boundary. Review approved R, then an
+// out-of-band reset replaced HEAD with divergent D and no pipeline-owned commit
+// ran afterward. Push must refuse before changing the remote.
+func TestPushStep_RefusesPostReviewClobberWithoutLaterPipelineCommit(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir, baseSHA, submittedHead := setupGitRepo(t)
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	// R is the exact tree the completed review approved.
+	if err := os.WriteFile(filepath.Join(dir, "reviewed.txt"), []byte("reviewed fix\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "reviewed fix")
+	reviewedHead := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	// D is a divergent replacement built from the submitted head. There is no
+	// later pipeline commit, so the existing commit-time continuity guard never
+	// runs.
+	gitCmd(t, dir, "reset", "--hard", submittedHead)
+	if err := os.WriteFile(filepath.Join(dir, "unreviewed.txt"), []byte("unreviewed replacement\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "out-of-band replacement")
+	clobberedHead := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	sctx := newTestContextWithDBRecords(t, &mockAgent{name: "test"}, dir, baseSHA, submittedHead, config.Commands{})
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+	// This models the current in-memory run state left by the review-fix commit.
+	sctx.Run.HeadSHA = reviewedHead
+	recordReviewApproval(t, sctx, reviewedHead)
+
+	_, err := (&PushStep{}).Execute(sctx)
+	if err == nil {
+		t.Fatal("expected push to refuse a divergent post-review HEAD replacement")
+	}
+	if !strings.Contains(err.Error(), "review-approved head") {
+		t.Fatalf("expected review continuity error, got %v", err)
+	}
+
+	remoteHead := gitCmd(t, upstream, "rev-parse", "refs/heads/feature")
+	if remoteHead != submittedHead {
+		t.Fatalf("remote changed from %s to %s; clobbered head %s must not ship", submittedHead, remoteHead, clobberedHead)
+	}
+	if fileAtRef(t, upstream, "refs/heads/feature", "unreviewed.txt") {
+		t.Fatal("remote contains the unreviewed replacement")
+	}
+}
+
+func TestAssertReviewApprovedPushHead(t *testing.T) {
+	tests := []struct {
+		name      string
+		approval  string
+		proposed  func(t *testing.T, dir, baseSHA, headSHA string) string
+		wantError string
+	}{
+		{
+			name: "equal",
+			proposed: func(t *testing.T, dir, baseSHA, headSHA string) string {
+				return headSHA
+			},
+		},
+		{
+			name: "legitimate descendant",
+			proposed: func(t *testing.T, dir, baseSHA, headSHA string) string {
+				if err := os.WriteFile(filepath.Join(dir, "docs.md"), []byte("docs\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				gitCmd(t, dir, "add", "-A")
+				gitCmd(t, dir, "commit", "-m", "document approved change")
+				return gitCmd(t, dir, "rev-parse", "HEAD")
+			},
+		},
+		{
+			name: "backward replacement",
+			proposed: func(t *testing.T, dir, baseSHA, headSHA string) string {
+				gitCmd(t, dir, "reset", "--hard", baseSHA)
+				return baseSHA
+			},
+			wantError: "not an equal or descendant",
+		},
+		{
+			name: "divergent replacement",
+			proposed: func(t *testing.T, dir, baseSHA, headSHA string) string {
+				gitCmd(t, dir, "reset", "--hard", baseSHA)
+				if err := os.WriteFile(filepath.Join(dir, "other.txt"), []byte("other\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				gitCmd(t, dir, "add", "-A")
+				gitCmd(t, dir, "commit", "-m", "divergent replacement")
+				return gitCmd(t, dir, "rev-parse", "HEAD")
+			},
+			wantError: "not an equal or descendant",
+		},
+		{
+			name:      "malformed approval",
+			approval:  "HEAD",
+			proposed:  func(t *testing.T, dir, baseSHA, headSHA string) string { return headSHA },
+			wantError: "malformed",
+		},
+		{
+			name:      "unreachable approval",
+			approval:  strings.Repeat("a", 40),
+			proposed:  func(t *testing.T, dir, baseSHA, headSHA string) string { return headSHA },
+			wantError: "unreachable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir, baseSHA, headSHA := setupGitRepo(t)
+			sctx := newTestContextWithDBRecords(t, &mockAgent{name: "test"}, dir, baseSHA, headSHA, config.Commands{})
+			approval := tt.approval
+			if approval == "" {
+				approval = headSHA
+			}
+			recordReviewApproval(t, sctx, approval)
+			proposed := tt.proposed(t, dir, baseSHA, headSHA)
+			err := assertReviewApprovedPushHead(sctx, proposed)
+			if tt.wantError == "" {
+				if err != nil {
+					t.Fatalf("expected continuity approval, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("error = %v, want substring %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestAssertReviewApprovedPushHead_RefusesMissingLegacyState(t *testing.T) {
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	sctx := newTestContextWithDBRecords(t, &mockAgent{name: "test"}, dir, baseSHA, headSHA, config.Commands{})
+	err := assertReviewApprovedPushHead(sctx, headSHA)
+	if err == nil || !strings.Contains(err.Error(), "no durably recorded review-approved head") {
+		t.Fatalf("expected missing legacy approval refusal, got %v", err)
+	}
+}
+
+func TestPushStep_BindsRemoteAndDatabaseToVerifiedCommitWhenHEADMovesDuringPush(t *testing.T) {
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir, baseSHA, submittedHead := setupGitRepo(t)
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	if err := os.WriteFile(filepath.Join(dir, "approved.txt"), []byte("approved descendant\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "approved descendant")
+	approvedHead := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	gitCmd(t, dir, "checkout", "--detach", baseSHA)
+	if err := os.WriteFile(filepath.Join(dir, "replacement.txt"), []byte("replacement\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "concurrent replacement")
+	replacementHead := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "checkout", "--detach", approvedHead)
+
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	binDir := t.TempDir()
+	shim := filepath.Join(binDir, "git")
+	shimBody := `#!/bin/sh
+if [ "$1" = "push" ]; then
+  "$NM_TEST_REAL_GIT" reset --hard "$NM_TEST_REPLACEMENT_HEAD" >/dev/null
+fi
+exec "$NM_TEST_REAL_GIT" "$@"
+`
+	if err := os.WriteFile(shim, []byte(shimBody), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("NM_TEST_REAL_GIT", realGit)
+	t.Setenv("NM_TEST_REPLACEMENT_HEAD", replacementHead)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	sctx := newTestContextWithDBRecords(t, &mockAgent{name: "test"}, dir, baseSHA, submittedHead, config.Commands{})
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+	recordReviewApproval(t, sctx, approvedHead)
+
+	if _, err := (&PushStep{}).Execute(sctx); err != nil {
+		t.Fatal(err)
+	}
+	if liveHead := gitCmd(t, dir, "rev-parse", "HEAD"); liveHead != replacementHead {
+		t.Fatalf("test shim did not move HEAD: got %s, want %s", liveHead, replacementHead)
+	}
+	if remoteHead := gitCmd(t, upstream, "rev-parse", "refs/heads/feature"); remoteHead != approvedHead {
+		t.Fatalf("remote received mutable HEAD %s instead of verified commit %s", remoteHead, approvedHead)
+	}
+	dbRun, err := sctx.DB.GetRun(sctx.Run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dbRun.HeadSHA != approvedHead || dbRun.LastPushedSHA == nil || *dbRun.LastPushedSHA != approvedHead {
+		t.Fatalf("durable push binding did not retain verified commit %s: %#v", approvedHead, dbRun)
+	}
+}
+
 func TestPushStep_ReconcilesStaleDatabaseHeadSHA(t *testing.T) {
 	t.Parallel()
 	// When push retries after a prior UpdateRunHeadSHA failure, there are no
@@ -41,6 +256,7 @@ func TestPushStep_ReconcilesStaleDatabaseHeadSHA(t *testing.T) {
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, staleHeadSHA, config.Commands{})
 	sctx.Repo.UpstreamURL = upstream
+	recordReviewApproval(t, sctx, actualHeadSHA)
 
 	step := &PushStep{}
 	_, err := step.Execute(sctx)
@@ -106,6 +322,7 @@ func TestPushStep_ForceAddsInRepoEvidenceArtifacts(t *testing.T) {
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "feature"
 	sctx.Config.Test.Evidence = config.Evidence{StoreInRepo: true, Dir: "evidence"}
+	recordReviewApproval(t, sctx, headSHA)
 
 	step := &PushStep{}
 	if _, err := step.Execute(sctx); err != nil {
@@ -154,6 +371,7 @@ func TestPushStep_TargetsForkWhenConfigured(t *testing.T) {
 	sctx.Repo.UpstreamURL = parent
 	sctx.Repo.ForkURL = fork
 	sctx.Run.Branch = "feature"
+	recordReviewApproval(t, sctx, headSHA)
 
 	step := &PushStep{}
 	if _, err := step.Execute(sctx); err != nil {
@@ -197,6 +415,7 @@ func TestPushStep_RedactsForkURLInGitErrors(t *testing.T) {
 	sctx.Repo.UpstreamURL = "https://github.com/parent/project.git"
 	sctx.Repo.ForkURL = "https://user:secret@example.com/fork/project.git"
 	sctx.Run.Branch = "refs/heads/feature"
+	recordReviewApproval(t, sctx, headSHA)
 
 	step := &PushStep{}
 	_, err = step.Execute(sctx)

--- a/internal/pipeline/steps/push_test.go
+++ b/internal/pipeline/steps/push_test.go
@@ -194,19 +194,11 @@ func TestPushStep_BindsRemoteAndDatabaseToVerifiedCommitWhenHEADMovesDuringPush(
 	if err != nil {
 		t.Fatal(err)
 	}
-	binDir := t.TempDir()
-	shim := filepath.Join(binDir, "git")
-	shimBody := `#!/bin/sh
-if [ "$1" = "push" ]; then
-  "$NM_TEST_REAL_GIT" reset --hard "$NM_TEST_REPLACEMENT_HEAD" >/dev/null
-fi
-exec "$NM_TEST_REAL_GIT" "$@"
-`
-	if err := os.WriteFile(shim, []byte(shimBody), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("NM_TEST_REAL_GIT", realGit)
-	t.Setenv("NM_TEST_REPLACEMENT_HEAD", replacementHead)
+	binDir := fakeCLIBinDir(t)
+	linkTestBinary(t, binDir, "git")
+	t.Setenv("FAKE_CLI_MODE", "git-move-head-passthrough")
+	t.Setenv("FAKE_CLI_REAL_GIT", realGit)
+	t.Setenv("FAKE_CLI_REPLACEMENT_HEAD", replacementHead)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	sctx := newTestContextWithDBRecords(t, &mockAgent{name: "test"}, dir, baseSHA, submittedHead, config.Commands{})

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -148,10 +148,10 @@ Previous review findings to address:
 			RiskRationale: "no reviewable changes",
 		}
 		findingsJSON, _ := json.Marshal(noChangeFindings)
-		return &pipeline.StepOutcome{
+		return approvedReviewOutcome(sctx, &pipeline.StepOutcome{
 			Findings:   string(findingsJSON),
 			FixSummary: fixSummary,
-		}, nil
+		})
 	}
 
 	// Ask agent to review
@@ -271,12 +271,25 @@ Risk assessment (after listing all findings):
 	needsApproval := hasBlockingFindings(findings.Items)
 	findingsJSON, _ := json.Marshal(findings)
 
-	return &pipeline.StepOutcome{
+	return approvedReviewOutcome(sctx, &pipeline.StepOutcome{
 		NeedsApproval: needsApproval,
 		AutoFixable:   len(findings.Items) > 0,
 		Findings:      string(findingsJSON),
 		FixSummary:    fixSummary,
-	}, nil
+	})
+}
+
+// approvedReviewOutcome captures the immutable commit examined by this full
+// review round. The executor persists it only if this outcome ultimately
+// completes the review step, so parked, failed, skipped, and superseded rounds
+// cannot gain or advance approval authority.
+func approvedReviewOutcome(sctx *pipeline.StepContext, outcome *pipeline.StepOutcome) (*pipeline.StepOutcome, error) {
+	headSHA, err := git.HeadSHA(sctx.Ctx, sctx.WorkDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve review-approved head: %w", err)
+	}
+	outcome.ReviewApprovedHeadSHA = headSHA
+	return outcome, nil
 }
 
 func sanitizedPreviousFindingsForPrompt(raw string) string {

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -109,6 +109,7 @@ Previous review findings to address:
 		}
 		fixSummary = summary
 	}
+	reviewTargetSHA := sctx.Run.HeadSHA
 
 	// Check whether there are any reviewable changed files after applying ignore patterns.
 	var args []string
@@ -148,7 +149,7 @@ Previous review findings to address:
 			RiskRationale: "no reviewable changes",
 		}
 		findingsJSON, _ := json.Marshal(noChangeFindings)
-		return approvedReviewOutcome(sctx, &pipeline.StepOutcome{
+		return approvedReviewOutcome(reviewTargetSHA, &pipeline.StepOutcome{
 			Findings:   string(findingsJSON),
 			FixSummary: fixSummary,
 		})
@@ -271,7 +272,7 @@ Risk assessment (after listing all findings):
 	needsApproval := hasBlockingFindings(findings.Items)
 	findingsJSON, _ := json.Marshal(findings)
 
-	return approvedReviewOutcome(sctx, &pipeline.StepOutcome{
+	return approvedReviewOutcome(reviewTargetSHA, &pipeline.StepOutcome{
 		NeedsApproval: needsApproval,
 		AutoFixable:   len(findings.Items) > 0,
 		Findings:      string(findingsJSON),
@@ -283,12 +284,8 @@ Risk assessment (after listing all findings):
 // review round. The executor persists it only if this outcome ultimately
 // completes the review step, so parked, failed, skipped, and superseded rounds
 // cannot gain or advance approval authority.
-func approvedReviewOutcome(sctx *pipeline.StepContext, outcome *pipeline.StepOutcome) (*pipeline.StepOutcome, error) {
-	headSHA, err := git.HeadSHA(sctx.Ctx, sctx.WorkDir)
-	if err != nil {
-		return nil, fmt.Errorf("resolve review-approved head: %w", err)
-	}
-	outcome.ReviewApprovedHeadSHA = headSHA
+func approvedReviewOutcome(reviewTargetSHA string, outcome *pipeline.StepOutcome) (*pipeline.StepOutcome, error) {
+	outcome.ReviewApprovedHeadSHA = reviewTargetSHA
 	return outcome, nil
 }
 

--- a/internal/pipeline/steps/review_test.go
+++ b/internal/pipeline/steps/review_test.go
@@ -111,6 +111,9 @@ func TestReviewStep_FixMode(t *testing.T) {
 	if branchSHA := gitCmd(t, dir, "rev-parse", "refs/heads/feature"); branchSHA != sctx.Run.HeadSHA {
 		t.Fatalf("branch SHA = %s, want %s", branchSHA, sctx.Run.HeadSHA)
 	}
+	if outcome.ReviewApprovedHeadSHA != sctx.Run.HeadSHA {
+		t.Fatalf("rereview captured approved head %s, want %s", outcome.ReviewApprovedHeadSHA, sctx.Run.HeadSHA)
+	}
 }
 
 // The review fixer must apply every fix first, then run one focused

--- a/internal/pipeline/steps/review_test.go
+++ b/internal/pipeline/steps/review_test.go
@@ -116,6 +116,34 @@ func TestReviewStep_FixMode(t *testing.T) {
 	}
 }
 
+func TestReviewStep_ConcurrentHeadResetCannotGainApproval(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, reviewedHead := setupGitRepo(t)
+	tree := gitCmd(t, dir, "rev-parse", baseSHA+"^{tree}")
+	divergentHead := gitCmd(t, dir, "commit-tree", tree, "-p", baseSHA, "-m", "divergent replacement")
+
+	ag := &mockAgent{
+		name: "test",
+		runFn: func(_ context.Context, _ agent.RunOpts) (*agent.Result, error) {
+			gitCmd(t, dir, "reset", "--hard", divergentHead)
+			findings, _ := json.Marshal(Findings{Summary: "all clear"})
+			return &agent.Result{Output: findings}, nil
+		},
+	}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, reviewedHead, config.Commands{})
+
+	outcome, err := (&ReviewStep{}).Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := gitCmd(t, dir, "rev-parse", "HEAD"); got != divergentHead {
+		t.Fatalf("HEAD = %s, want concurrent replacement %s", got, divergentHead)
+	}
+	if outcome.ReviewApprovedHeadSHA != reviewedHead {
+		t.Fatalf("approved head = %s, want review target %s", outcome.ReviewApprovedHeadSHA, reviewedHead)
+	}
+}
+
 // The review fixer must apply every fix first, then run one focused
 // verification of the changed area, and must NOT re-run the whole repository
 // test/lint suite in the fix round. A forensic audit measured the old

--- a/internal/pipeline/steps/steps_test.go
+++ b/internal/pipeline/steps/steps_test.go
@@ -48,6 +48,8 @@ func handleFakeCLI(mode string) {
 		fakeRecordSuccessHandler()
 	case "git-passthrough":
 		fakeGitPassthroughHandler(args)
+	case "git-move-head-passthrough":
+		fakeGitMoveHeadPassthroughHandler(args)
 	case "git-require-noninteractive-env":
 		fakeGitRequireNonInteractiveEnvHandler(args)
 	case "git-status-error":
@@ -151,6 +153,25 @@ func fakeGitStatusErrorHandler(args []string) {
 
 func fakeGitPassthroughHandler(args []string) {
 	realGit := os.Getenv("FAKE_CLI_REAL_GIT")
+	fakeGitForward(args, realGit)
+}
+
+func fakeGitMoveHeadPassthroughHandler(args []string) {
+	realGit := os.Getenv("FAKE_CLI_REAL_GIT")
+	if len(args) > 0 && args[0] == "push" {
+		replacementHead := os.Getenv("FAKE_CLI_REPLACEMENT_HEAD")
+		if replacementHead == "" {
+			fmt.Fprintln(os.Stderr, "missing FAKE_CLI_REPLACEMENT_HEAD")
+			os.Exit(1)
+		}
+		cmd := exec.Command(realGit, "reset", "--hard", replacementHead)
+		cmd.Stdout = io.Discard
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+	}
 	fakeGitForward(args, realGit)
 }
 

--- a/internal/pipeline/steps/upstream_test.go
+++ b/internal/pipeline/steps/upstream_test.go
@@ -49,6 +49,9 @@ func TestResolveUpstreamURL_PreservesCredential(t *testing.T) {
 	if !strings.Contains(got, token) {
 		t.Errorf("resolveUpstreamURL stripped the credential: got %q", got)
 	}
+	if pushURL := resolvePushURL(sctx); pushURL != credURL {
+		t.Errorf("resolvePushURL = %q, want credential-preserving upstream route %q", pushURL, credURL)
+	}
 }
 
 // TestResolveUpstreamURL_FallsBackToRecordedURL verifies that when a worktree


### PR DESCRIPTION
## Intent

Ship the selected Phase 2 defense-in-depth change that durably binds Push to the exact commit approved by the successful full Review. A successful review or rereview must atomically record its exact approved head, while parked, failed, skipped, malformed, unreachable, and legacy-missing approval state must not gain inferred authority. Immediately before remote mutation, Push must read that durable binding and refuse unless the proposed commit is equal to or a descendant of it, then deliver the exact verified immutable SHA so a concurrent mutable HEAD move cannot change what ships. Preserve existing fork routing, credential recovery and redaction, branch targeting, and force-push safety. Keep scope strictly to this review-to-push binding, schema and legacy safety, recovery of parked review candidates, and focused real-git regressions. Do not implement the separate per-step continuity phase, repository URL refresh, rebase or CI routing, registry hygiene, or broader credential policy.

## What Changed

- Persist the exact commit examined by each full review and atomically promote it as authoritative only when Review completes successfully, including safe recovery for parked approvals.
- Make Push fail closed for missing, malformed, unreachable, or divergent review bindings, then push and record the exact verified immutable commit SHA.
- Add focused database, executor, review, push, and real-git regressions, plus documentation for the review-to-push binding.

## Risk Assessment

✅ Low: The targeted fix closes the concurrent-reset authorization path by persisting the immutable pre-review target, and the aggregate change remains bounded with fail-closed legacy and push behavior.

## Testing

Targeted database, executor, migration, recovery, credential, fork-routing, force-push-safety, and real-git push checks all passed; the captured transcript directly demonstrates fail-closed divergent replacement and immutable reviewed-SHA delivery under concurrent HEAD movement.

- Evidence: [Real-git review-to-push evidence](https://github.com/kunchenguid/no-mistakes/blob/7cf37c7ac514c607bb74ec500cde22f05b320608/.no-mistakes/evidence/fm/nm-headcontinuity-pushbind/review-to-push-real-git.txt)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `internal/db/run_test.go` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `internal/pipeline/steps/review.go:287` - This contradicts the required criterion that review must record the &#34;exact commit approved&#34;. The reviewer is instructed to inspect `sctx.Run.HeadSHA`, but after it returns this hunk rereads mutable worktree `HEAD`. If review starts for R, a concurrent reset moves HEAD to divergent D, and the reviewer then finishes, D is recorded as approved; Push accepts D as equal and ships it. Bind the immutable review target captured before the reviewer invocation, rather than rereading HEAD afterward.

🔧 Fix: Bind review approval to captured target
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected the intent and diff from `62ab9899d7cd0ef0c0f1e171bc65ad916bcfa613` to `56065ea0f5b51e36ab4c7c44127d93a071a0e9a2`.</code>
- `go test ./internal/db -run 'Test(InsertReviewStepRoundPersistsNonAuthoritativeCandidate|UpdateRunReviewApprovedHeadSHAReplacesAuthority|CompleteReviewStepIsAtomic)$' -count=1`
- `go test ./internal/db -run 'Test(OpenCreatesSchema|OpenMigratesRunSyncProvenanceWithoutBackfillingMutableHead|OpenMigratesExistingStepRoundsColumns)$' -count=1`
- `go test ./internal/pipeline -run 'TestExecutor_(ResumePromotesDurableReviewedCandidateOnApproval|RecordsCompletedReviewApprovedHead|FullRereviewReplacesApprovalWithoutAuthorizingParkedRound|ParkedOrFailedReviewDoesNotAdvanceExistingApproval)$' -count=1`
- `go test ./internal/pipeline/steps -run 'Test(ReviewStep_ConcurrentHeadResetCannotGainApproval|PushStep_(TargetsForkWhenConfigured|RedactsForkURLInGitErrors|RefusesToClobberAdvancedUpstreamBranch)|AssertReviewApprovedPushHead)$' -count=1`
- `go test ./internal/pipeline/steps -run 'TestResolve(UpstreamURL_(PreservesCredential|FallsBackToRecordedURL)|PushURL_ForkWinsOverCredential)$' -count=1`
- `go test -v ./internal/pipeline/steps -run 'TestPushStep_(RefusesPostReviewClobberWithoutLaterPipelineCommit|BindsRemoteAndDatabaseToVerifiedCommitWhenHEADMovesDuringPush)$' -count=1 | tee .no-mistakes/evidence/fm/nm-headcontinuity-pushbind/review-to-push-real-git.txt`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
