### PR TITLE
fix(pipeline): enforce post-review HEAD continuity

### DIFF
--- a/.no-mistakes/evidence/fm/nm-headcontinuity-stepassert/head-continuity-transcript.txt
+++ b/.no-mistakes/evidence/fm/nm-headcontinuity-stepassert/head-continuity-transcript.txt
@@ -1,0 +1,95 @@
+=== RUN   TestPostReviewStepsRefuseHeadClobberAtEntry
+=== RUN   TestPostReviewStepsRefuseHeadClobberAtEntry/test/backward_reset
+    headcontinuity_repro_test.go:266: test refused backward_reset before agent, HEAD, or recorded-head mutation: refusing to run test step: worktree HEAD 07d0009294854d302fc99d114ac3ad6723dae7e2 is not a descendant of the pipeline's recorded head 80131f5010905adb451f33ba99c16766991b8b2a; the reviewed change was rewritten out-of-band and would be lost - aborting to protect it
+=== RUN   TestPostReviewStepsRefuseHeadClobberAtEntry/test/sibling_reset
+    headcontinuity_repro_test.go:266: test refused sibling_reset before agent, HEAD, or recorded-head mutation: refusing to run test step: worktree HEAD d09d15ce25c1fefa6626da6ffaca0f6bf1c46d82 is not a descendant of the pipeline's recorded head 80131f5010905adb451f33ba99c16766991b8b2a; the reviewed change was rewritten out-of-band and would be lost - aborting to protect it
+=== RUN   TestPostReviewStepsRefuseHeadClobberAtEntry/document/backward_reset
+    headcontinuity_repro_test.go:266: document refused backward_reset before agent, HEAD, or recorded-head mutation: refusing to run document step: worktree HEAD 07d0009294854d302fc99d114ac3ad6723dae7e2 is not a descendant of the pipeline's recorded head 80131f5010905adb451f33ba99c16766991b8b2a; the reviewed change was rewritten out-of-band and would be lost - aborting to protect it
+=== RUN   TestPostReviewStepsRefuseHeadClobberAtEntry/document/sibling_reset
+    headcontinuity_repro_test.go:266: document refused sibling_reset before agent, HEAD, or recorded-head mutation: refusing to run document step: worktree HEAD d09d15ce25c1fefa6626da6ffaca0f6bf1c46d82 is not a descendant of the pipeline's recorded head 80131f5010905adb451f33ba99c16766991b8b2a; the reviewed change was rewritten out-of-band and would be lost - aborting to protect it
+=== RUN   TestPostReviewStepsRefuseHeadClobberAtEntry/lint/backward_reset
+    headcontinuity_repro_test.go:266: lint refused backward_reset before agent, HEAD, or recorded-head mutation: refusing to run lint step: worktree HEAD 07d0009294854d302fc99d114ac3ad6723dae7e2 is not a descendant of the pipeline's recorded head 80131f5010905adb451f33ba99c16766991b8b2a; the reviewed change was rewritten out-of-band and would be lost - aborting to protect it
+=== RUN   TestPostReviewStepsRefuseHeadClobberAtEntry/lint/sibling_reset
+    headcontinuity_repro_test.go:266: lint refused sibling_reset before agent, HEAD, or recorded-head mutation: refusing to run lint step: worktree HEAD d09d15ce25c1fefa6626da6ffaca0f6bf1c46d82 is not a descendant of the pipeline's recorded head 80131f5010905adb451f33ba99c16766991b8b2a; the reviewed change was rewritten out-of-band and would be lost - aborting to protect it
+=== RUN   TestPostReviewStepsRefuseHeadClobberAtEntry/push/backward_reset
+    headcontinuity_repro_test.go:266: push refused backward_reset before agent, HEAD, or recorded-head mutation: refusing to run push step: worktree HEAD 07d0009294854d302fc99d114ac3ad6723dae7e2 is not a descendant of the pipeline's recorded head 80131f5010905adb451f33ba99c16766991b8b2a; the reviewed change was rewritten out-of-band and would be lost - aborting to protect it
+=== RUN   TestPostReviewStepsRefuseHeadClobberAtEntry/push/sibling_reset
+    headcontinuity_repro_test.go:266: push refused sibling_reset before agent, HEAD, or recorded-head mutation: refusing to run push step: worktree HEAD d09d15ce25c1fefa6626da6ffaca0f6bf1c46d82 is not a descendant of the pipeline's recorded head 80131f5010905adb451f33ba99c16766991b8b2a; the reviewed change was rewritten out-of-band and would be lost - aborting to protect it
+=== RUN   TestPostReviewStepsRefuseHeadClobberAtEntry/pr/backward_reset
+    headcontinuity_repro_test.go:266: pr refused backward_reset before agent, HEAD, or recorded-head mutation: refusing to run pr step: worktree HEAD 07d0009294854d302fc99d114ac3ad6723dae7e2 is not a descendant of the pipeline's recorded head 80131f5010905adb451f33ba99c16766991b8b2a; the reviewed change was rewritten out-of-band and would be lost - aborting to protect it
+=== RUN   TestPostReviewStepsRefuseHeadClobberAtEntry/pr/sibling_reset
+    headcontinuity_repro_test.go:266: pr refused sibling_reset before agent, HEAD, or recorded-head mutation: refusing to run pr step: worktree HEAD d09d15ce25c1fefa6626da6ffaca0f6bf1c46d82 is not a descendant of the pipeline's recorded head 80131f5010905adb451f33ba99c16766991b8b2a; the reviewed change was rewritten out-of-band and would be lost - aborting to protect it
+=== RUN   TestPostReviewStepsRefuseHeadClobberAtEntry/ci/backward_reset
+    headcontinuity_repro_test.go:266: ci refused backward_reset before agent, HEAD, or recorded-head mutation: refusing to run ci step: worktree HEAD 07d0009294854d302fc99d114ac3ad6723dae7e2 is not a descendant of the pipeline's recorded head 80131f5010905adb451f33ba99c16766991b8b2a; the reviewed change was rewritten out-of-band and would be lost - aborting to protect it
+=== RUN   TestPostReviewStepsRefuseHeadClobberAtEntry/ci/sibling_reset
+    headcontinuity_repro_test.go:266: ci refused sibling_reset before agent, HEAD, or recorded-head mutation: refusing to run ci step: worktree HEAD d09d15ce25c1fefa6626da6ffaca0f6bf1c46d82 is not a descendant of the pipeline's recorded head 80131f5010905adb451f33ba99c16766991b8b2a; the reviewed change was rewritten out-of-band and would be lost - aborting to protect it
+--- PASS: TestPostReviewStepsRefuseHeadClobberAtEntry (0.69s)
+    --- PASS: TestPostReviewStepsRefuseHeadClobberAtEntry/test/backward_reset (0.13s)
+    --- PASS: TestPostReviewStepsRefuseHeadClobberAtEntry/test/sibling_reset (0.06s)
+    --- PASS: TestPostReviewStepsRefuseHeadClobberAtEntry/document/backward_reset (0.04s)
+    --- PASS: TestPostReviewStepsRefuseHeadClobberAtEntry/document/sibling_reset (0.06s)
+    --- PASS: TestPostReviewStepsRefuseHeadClobberAtEntry/lint/backward_reset (0.03s)
+    --- PASS: TestPostReviewStepsRefuseHeadClobberAtEntry/lint/sibling_reset (0.06s)
+    --- PASS: TestPostReviewStepsRefuseHeadClobberAtEntry/push/backward_reset (0.04s)
+    --- PASS: TestPostReviewStepsRefuseHeadClobberAtEntry/push/sibling_reset (0.06s)
+    --- PASS: TestPostReviewStepsRefuseHeadClobberAtEntry/pr/backward_reset (0.04s)
+    --- PASS: TestPostReviewStepsRefuseHeadClobberAtEntry/pr/sibling_reset (0.06s)
+    --- PASS: TestPostReviewStepsRefuseHeadClobberAtEntry/ci/backward_reset (0.04s)
+    --- PASS: TestPostReviewStepsRefuseHeadClobberAtEntry/ci/sibling_reset (0.06s)
+=== RUN   TestPostReviewStepsRefuseUnverifiableRecordedHeadAtEntry
+=== RUN   TestPostReviewStepsRefuseUnverifiableRecordedHeadAtEntry/test
+    headcontinuity_repro_test.go:301: test failed closed before agent or HEAD mutation: refusing to run test step: worktree HEAD 80131f5010905adb451f33ba99c16766991b8b2a is not a descendant of the pipeline's recorded head ffffffffffffffffffffffffffffffffffffffff; the reviewed change was rewritten out-of-band and would be lost - aborting to protect it
+=== RUN   TestPostReviewStepsRefuseUnverifiableRecordedHeadAtEntry/document
+    headcontinuity_repro_test.go:301: document failed closed before agent or HEAD mutation: refusing to run document step: worktree HEAD 80131f5010905adb451f33ba99c16766991b8b2a is not a descendant of the pipeline's recorded head ffffffffffffffffffffffffffffffffffffffff; the reviewed change was rewritten out-of-band and would be lost - aborting to protect it
+=== RUN   TestPostReviewStepsRefuseUnverifiableRecordedHeadAtEntry/lint
+    headcontinuity_repro_test.go:301: lint failed closed before agent or HEAD mutation: refusing to run lint step: worktree HEAD 80131f5010905adb451f33ba99c16766991b8b2a is not a descendant of the pipeline's recorded head ffffffffffffffffffffffffffffffffffffffff; the reviewed change was rewritten out-of-band and would be lost - aborting to protect it
+=== RUN   TestPostReviewStepsRefuseUnverifiableRecordedHeadAtEntry/push
+    headcontinuity_repro_test.go:301: push failed closed before agent or HEAD mutation: refusing to run push step: worktree HEAD 80131f5010905adb451f33ba99c16766991b8b2a is not a descendant of the pipeline's recorded head ffffffffffffffffffffffffffffffffffffffff; the reviewed change was rewritten out-of-band and would be lost - aborting to protect it
+=== RUN   TestPostReviewStepsRefuseUnverifiableRecordedHeadAtEntry/pr
+    headcontinuity_repro_test.go:301: pr failed closed before agent or HEAD mutation: refusing to run pr step: worktree HEAD 80131f5010905adb451f33ba99c16766991b8b2a is not a descendant of the pipeline's recorded head ffffffffffffffffffffffffffffffffffffffff; the reviewed change was rewritten out-of-band and would be lost - aborting to protect it
+=== RUN   TestPostReviewStepsRefuseUnverifiableRecordedHeadAtEntry/ci
+    headcontinuity_repro_test.go:301: ci failed closed before agent or HEAD mutation: refusing to run ci step: worktree HEAD 80131f5010905adb451f33ba99c16766991b8b2a is not a descendant of the pipeline's recorded head ffffffffffffffffffffffffffffffffffffffff; the reviewed change was rewritten out-of-band and would be lost - aborting to protect it
+--- PASS: TestPostReviewStepsRefuseUnverifiableRecordedHeadAtEntry (0.16s)
+    --- PASS: TestPostReviewStepsRefuseUnverifiableRecordedHeadAtEntry/test (0.03s)
+    --- PASS: TestPostReviewStepsRefuseUnverifiableRecordedHeadAtEntry/document (0.03s)
+    --- PASS: TestPostReviewStepsRefuseUnverifiableRecordedHeadAtEntry/lint (0.03s)
+    --- PASS: TestPostReviewStepsRefuseUnverifiableRecordedHeadAtEntry/push (0.03s)
+    --- PASS: TestPostReviewStepsRefuseUnverifiableRecordedHeadAtEntry/pr (0.03s)
+    --- PASS: TestPostReviewStepsRefuseUnverifiableRecordedHeadAtEntry/ci (0.03s)
+=== RUN   TestCIGateReconciliationRefusesHeadClobberAtEntry
+--- PASS: TestCIGateReconciliationRefusesHeadClobberAtEntry (0.03s)
+=== RUN   TestPostReviewStepEntryAllowsEqualAndPipelineDescendantHeads
+    headcontinuity_repro_test.go:342: test allowed HEAD equal to recorded head 80131f5010905adb451f33ba99c16766991b8b2a
+    headcontinuity_repro_test.go:342: document allowed HEAD equal to recorded head 80131f5010905adb451f33ba99c16766991b8b2a
+    headcontinuity_repro_test.go:342: lint allowed HEAD equal to recorded head 80131f5010905adb451f33ba99c16766991b8b2a
+    headcontinuity_repro_test.go:342: push allowed HEAD equal to recorded head 80131f5010905adb451f33ba99c16766991b8b2a
+    headcontinuity_repro_test.go:342: pr allowed HEAD equal to recorded head 80131f5010905adb451f33ba99c16766991b8b2a
+    headcontinuity_repro_test.go:342: ci allowed HEAD equal to recorded head 80131f5010905adb451f33ba99c16766991b8b2a
+    headcontinuity_repro_test.go:354: test allowed descendant HEAD while preserving recorded ancestor 80131f5010905adb451f33ba99c16766991b8b2a
+    headcontinuity_repro_test.go:354: document allowed descendant HEAD while preserving recorded ancestor 80131f5010905adb451f33ba99c16766991b8b2a
+    headcontinuity_repro_test.go:354: lint allowed descendant HEAD while preserving recorded ancestor 80131f5010905adb451f33ba99c16766991b8b2a
+    headcontinuity_repro_test.go:354: push allowed descendant HEAD while preserving recorded ancestor 80131f5010905adb451f33ba99c16766991b8b2a
+    headcontinuity_repro_test.go:354: pr allowed descendant HEAD while preserving recorded ancestor 80131f5010905adb451f33ba99c16766991b8b2a
+    headcontinuity_repro_test.go:354: ci allowed descendant HEAD while preserving recorded ancestor 80131f5010905adb451f33ba99c16766991b8b2a
+--- PASS: TestPostReviewStepEntryAllowsEqualAndPipelineDescendantHeads (0.13s)
+=== RUN   TestPushStep_RefusesPostReviewClobberWithoutLaterPipelineCommit
+    push_test.go:68: review-approved=9b06fdf86a76a3d953ffaf0406c6452ab0942b3e clobbered-HEAD=f14eb7b26da7f18d7e193247449932c95fa3d939 push-refused="refusing to push: proposed head f14eb7b26da7 violates continuity with review-approved head 9b06fdf86a76 (it is not an equal or descendant commit)" remote-still=80131f5010905adb451f33ba99c16766991b8b2a unreviewed-file-shipped=false
+--- PASS: TestPushStep_RefusesPostReviewClobberWithoutLaterPipelineCommit (0.24s)
+PASS
+ok  	github.com/kunchenguid/no-mistakes/internal/pipeline/steps	1.927s
+=== RUN   TestExecutor_FatalReconcileErrorFailsRun
+--- PASS: TestExecutor_FatalReconcileErrorFailsRun (0.01s)
+=== RUN   TestExecutor_ResumeFatalReconcileErrorFailsRun
+--- PASS: TestExecutor_ResumeFatalReconcileErrorFailsRun (0.01s)
+PASS
+ok  	github.com/kunchenguid/no-mistakes/internal/pipeline	0.397s
+=== RUN   TestPushStep_BindsRemoteAndDatabaseToVerifiedCommitWhenHEADMovesDuringPush
+    push_test.go:226: review-approved=d1e0a55ec43e43674cb37866c0b0c93aa17c417f concurrent-HEAD=294dd287a0c8ffa886fc4072e1c00afe448833b4 remote-delivered=d1e0a55ec43e43674cb37866c0b0c93aa17c417f durable-head=d1e0a55ec43e43674cb37866c0b0c93aa17c417f durable-last-pushed=d1e0a55ec43e43674cb37866c0b0c93aa17c417f
+--- PASS: TestPushStep_BindsRemoteAndDatabaseToVerifiedCommitWhenHEADMovesDuringPush (0.65s)
+PASS
+ok  	github.com/kunchenguid/no-mistakes/internal/pipeline/steps	0.976s
+=== RUN   TestExecutor_FullRereviewReplacesApprovalWithoutAuthorizingParkedRound
+2026/07/24 01:56:50 INFO step fix requested, re-executing step=review
+--- PASS: TestExecutor_FullRereviewReplacesApprovalWithoutAuthorizingParkedRound (0.02s)
+PASS
+ok  	github.com/kunchenguid/no-mistakes/internal/pipeline	0.529s

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,8 +181,9 @@ Safest local verification sequence after non-trivial changes:
   The full relation matrix and fail-safe rules live in the `Recover` doc comment in `internal/branchsync/sync.go`.
 - Public guidance is owned by `internal/skill/skill.go` plus live AXI strings, then regenerated with `make skill`. Core regressions live in `internal/branchsync` (incl. `recover_test.go`), `internal/cli/sync_test.go`, `internal/tui/branch_sync_test.go`, and e2e `TestAxiBranchSyncJourney` / `TestAxiCustodyRecoveryJourney`.
 
-**Review-to-Push Head Binding**
+**Post-Review Head Continuity and Push Binding**
 
+- Every step after Review in the fixed pipeline order (Test, Document, Lint, Push, PR, CI) calls `assertPipelineHeadContinuity` at entry. The helper is the single semantic owner: equal or descendant live heads continue; backward, sibling, and unverifiable heads fail before the step performs work. Regression: `TestPostReviewStepsRefuseHeadClobberAtEntry`.
 - A successfully completed full review atomically records `runs.review_approved_head_sha`; parked, failed, skipped, and legacy reviews carry no inferred authority. Push reads that durable binding, permits only the exact commit or a descendant, and pushes the verified immutable SHA rather than mutable `HEAD`. Never infer approval from `runs.head_sha`, a worktree, gate ref, or remote branch. Regressions: `TestPushStep_RefusesPostReviewClobberWithoutLaterPipelineCommit`, `TestPushStep_BindsRemoteAndDatabaseToVerifiedCommitWhenHEADMovesDuringPush`, `TestExecutor_FullRereviewReplacesApprovalWithoutAuthorizingParkedRound`.
 
 **Rebase Base & Force-Push Safety (data-loss prevention)**

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -86,6 +86,10 @@ Follow-up review passes use the history to avoid re-reporting user-ignored findi
 
 **Default auto-fix limit:** `0`.
 
+### Post-review HEAD continuity
+
+At entry to every remaining step in the fixed pipeline order - Test, Document, Lint, Push, PR, and CI - no-mistakes compares the live worktree `HEAD` with the pipeline-recorded head. An equal head or a pipeline-descendant commit continues. A backward reset, divergent sibling, or unverifiable relationship fails the run before that step performs work, including for steps that would not create a commit.
+
 ## Test
 
 Runs **targeted** local validation of the change and requested intent, then gathers evidence for that intent.

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -313,6 +313,9 @@ func (e *Executor) Resume(ctx context.Context, run *db.Run, repo *db.Repo, workD
 		return completeReconciledGate()
 	} else if reconcileErr != nil && ctx.Err() == nil {
 		if errors.Is(reconcileErr, ErrFatalGateReconciliation) {
+			if dbErr := e.db.CompleteRunAwaitingAgent(run.ID, time.Since(parkStart).Milliseconds()); dbErr != nil {
+				return e.failRun(run, repo, fmt.Errorf("complete fatal reconciliation awaiting-agent state: %w", dbErr), ctx)
+			}
 			if dbErr := e.db.FailStep(gate.stepResult.ID, reconcileErr.Error(), duration); dbErr != nil {
 				slog.Warn("failed to mark recovered step as failed in db", "step", gate.step.Name(), "error", dbErr)
 			}

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -311,6 +312,13 @@ func (e *Executor) Resume(ctx context.Context, run *db.Run, repo *db.Repo, workD
 		}
 		return completeReconciledGate()
 	} else if reconcileErr != nil && ctx.Err() == nil {
+		if errors.Is(reconcileErr, ErrFatalGateReconciliation) {
+			if dbErr := e.db.FailStep(gate.stepResult.ID, reconcileErr.Error(), duration); dbErr != nil {
+				slog.Warn("failed to mark recovered step as failed in db", "step", gate.step.Name(), "error", dbErr)
+			}
+			e.emitStepEventWithFindingsDiffAndError(ipc.EventStepCompleted, run, repo, gate.step.Name(), string(types.StepStatusFailed), "", "", reconcileErr.Error(), &duration)
+			return e.failRun(run, repo, fmt.Errorf("step %s: reconcile approval gate: %w", gate.step.Name(), reconcileErr), ctx)
+		}
 		slog.Warn("could not reconcile recovered approval gate; preserving it", "run_id", run.ID, "step", gate.step.Name(), "error", reconcileErr)
 	}
 
@@ -1135,6 +1143,9 @@ func (e *Executor) waitForApprovalOrReconcile(ctx context.Context, step Step, sc
 					return approvalResponse{}, true, nil
 				}
 				return <-e.approvalCh, false, nil
+			}
+			if errors.Is(err, ErrFatalGateReconciliation) {
+				return approvalResponse{}, false, err
 			}
 			if err != nil && ctx.Err() == nil {
 				if sctx != nil && sctx.Log != nil {

--- a/internal/pipeline/executor_reconcile_test.go
+++ b/internal/pipeline/executor_reconcile_test.go
@@ -253,8 +253,8 @@ func TestExecutor_ResumeFatalReconcileErrorFailsRun(t *testing.T) {
 	if dbErr != nil {
 		t.Fatal(dbErr)
 	}
-	if got.Status != types.RunFailed {
-		t.Fatalf("recovered run status = %s, want %s", got.Status, types.RunFailed)
+	if got.Status != types.RunFailed || got.AwaitingAgentSince != nil || got.ParkedMS <= 0 {
+		t.Fatalf("recovered run after fatal reconciliation = status %s awaiting %v parked_ms %d", got.Status, got.AwaitingAgentSince, got.ParkedMS)
 	}
 	steps, dbErr := database.GetStepsByRun(run.ID)
 	if dbErr != nil {

--- a/internal/pipeline/executor_reconcile_test.go
+++ b/internal/pipeline/executor_reconcile_test.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -182,6 +183,85 @@ func TestExecutor_ReconcileErrorPreservesGateFailClosed(t *testing.T) {
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("approval did not complete preserved gate")
+	}
+}
+
+func TestExecutor_FatalReconcileErrorFailsRun(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	step := &reconcilingApprovalStep{name: types.StepCI}
+	reconcileErr := error(fmt.Errorf("%w: head continuity lost", ErrFatalGateReconciliation))
+	step.err.Store(&reconcileErr)
+	exec := NewExecutor(database, p, nil, nil, []Step{step}, nil)
+	exec.SetGateReconcileTimings(time.Millisecond, 50*time.Millisecond)
+
+	err := exec.Execute(context.Background(), run, repo, t.TempDir())
+	if !errors.Is(err, ErrFatalGateReconciliation) {
+		t.Fatalf("Execute() error = %v, want fatal reconciliation error", err)
+	}
+	got, dbErr := database.GetRun(run.ID)
+	if dbErr != nil {
+		t.Fatal(dbErr)
+	}
+	if got.Status != types.RunFailed || got.AwaitingAgentSince != nil {
+		t.Fatalf("run after fatal reconciliation = status %s awaiting %v", got.Status, got.AwaitingAgentSince)
+	}
+	if err := exec.Respond(types.StepCI, types.ActionApprove, nil); err == nil {
+		t.Fatal("fatal reconciliation left the gate approvable")
+	}
+}
+
+func TestExecutor_ResumeFatalReconcileErrorFailsRun(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	if err := database.UpdateRunStatus(run.ID, types.RunRunning); err != nil {
+		t.Fatal(err)
+	}
+	stepResult, err := database.InsertStepResult(run.ID, types.StepCI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.StartStep(stepResult.ID); err != nil {
+		t.Fatal(err)
+	}
+	findings := `{"findings":[{"id":"ci-1","severity":"warning","description":"waiting","action":"ask-user"}],"summary":"waiting"}`
+	if err := database.SetStepFindings(stepResult.ID, findings); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := database.InsertStepRound(stepResult.ID, 1, "initial", &findings, nil, 10); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.UpdateStepStatusWithDuration(stepResult.ID, types.StepStatusAwaitingApproval, 10); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.SetRunAwaitingAgent(run.ID); err != nil {
+		t.Fatal(err)
+	}
+	run, err = database.GetRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	step := &reconcilingApprovalStep{name: types.StepCI}
+	reconcileErr := error(fmt.Errorf("%w: head continuity lost", ErrFatalGateReconciliation))
+	step.err.Store(&reconcileErr)
+	exec := NewExecutor(database, p, nil, nil, []Step{step}, nil)
+
+	err = exec.Resume(context.Background(), run, repo, t.TempDir())
+	if !errors.Is(err, ErrFatalGateReconciliation) {
+		t.Fatalf("Resume() error = %v, want fatal reconciliation error", err)
+	}
+	got, dbErr := database.GetRun(run.ID)
+	if dbErr != nil {
+		t.Fatal(dbErr)
+	}
+	if got.Status != types.RunFailed {
+		t.Fatalf("recovered run status = %s, want %s", got.Status, types.RunFailed)
+	}
+	steps, dbErr := database.GetStepsByRun(run.ID)
+	if dbErr != nil {
+		t.Fatal(dbErr)
+	}
+	if len(steps) != 1 || steps[0].Status != types.StepStatusFailed {
+		t.Fatalf("recovered steps after fatal reconciliation = %+v", steps)
 	}
 }
 

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -2,12 +2,15 @@ package pipeline
 
 import (
 	"context"
+	"errors"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
 	"github.com/kunchenguid/no-mistakes/internal/config"
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
+
+var ErrFatalGateReconciliation = errors.New("fatal gate reconciliation")
 
 // StepContext provides shared resources to pipeline steps during execution.
 type StepContext struct {

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -54,6 +54,9 @@ func (s *CIStep) Name() types.StepName { return types.StepCI }
 // the normal CI polling loop. Open, unknown, and provider-error states remain
 // parked so reconciliation never guesses success.
 func (s *CIStep) ReconcileApprovalGate(sctx *pipeline.StepContext) (bool, error) {
+	if err := assertPipelineHeadContinuity(sctx, s.Name()); err != nil {
+		return false, err
+	}
 	if err := sctx.Ctx.Err(); err != nil {
 		return false, err
 	}

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -119,6 +119,9 @@ func (s *CIStep) gracePeriod() time.Duration {
 }
 
 func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, error) {
+	if err := assertPipelineHeadContinuity(sctx, s.Name()); err != nil {
+		return nil, err
+	}
 	ctx := sctx.Ctx
 	if err := ctx.Err(); err != nil {
 		return nil, err

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -55,7 +55,7 @@ func (s *CIStep) Name() types.StepName { return types.StepCI }
 // parked so reconciliation never guesses success.
 func (s *CIStep) ReconcileApprovalGate(sctx *pipeline.StepContext) (bool, error) {
 	if err := assertPipelineHeadContinuity(sctx, s.Name()); err != nil {
-		return false, err
+		return false, fmt.Errorf("%w: %w", pipeline.ErrFatalGateReconciliation, err)
 	}
 	if err := sctx.Ctx.Err(); err != nil {
 		return false, err

--- a/internal/pipeline/steps/ci_bitbucket_test.go
+++ b/internal/pipeline/steps/ci_bitbucket_test.go
@@ -270,7 +270,9 @@ func TestCIStep_BitbucketAutoFixUsesLivePRHeadSHAForLogs(t *testing.T) {
 	api.stepLog = "error log output"
 	api.prSourceSHA = headSHA
 
-	staleHeadSHA := strings.Repeat("a", 40)
+	// Keep the recorded head stale enough to prove CI uses the live PR source,
+	// but on the valid pipeline lineage so the post-review entry guard permits it.
+	staleHeadSHA := baseSHA
 	var capturedPrompt string
 	ag := &mockAgent{
 		name: "test",

--- a/internal/pipeline/steps/ci_test.go
+++ b/internal/pipeline/steps/ci_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -79,7 +80,14 @@ func TestCIStep_PendingChecksUseAdaptivePollIntervals(t *testing.T) {
 func TestCIStep_UsesStepEnvForCLIStartupChecks(t *testing.T) {
 	dir, baseSHA, headSHA := setupGitRepo(t)
 
-	hiddenPath := t.TempDir()
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	hiddenPath := fakeCLIBinDir(t)
+	linkTestBinary(t, hiddenPath, "git")
+	t.Setenv("FAKE_CLI_MODE", "git-passthrough")
+	t.Setenv("FAKE_CLI_REAL_GIT", realGit)
 	t.Setenv("PATH", hiddenPath)
 
 	env := fakeCIGH(t, "MERGED", "[]")

--- a/internal/pipeline/steps/common_fix.go
+++ b/internal/pipeline/steps/common_fix.go
@@ -58,14 +58,16 @@ func hasBlockingFindings(items []Finding) bool {
 }
 
 // assertPipelineHeadContinuity fails closed when the worktree HEAD is no longer
-// a descendant of the head the pipeline itself last recorded (sctx.Run.HeadSHA).
+// equal to or a descendant of the head the pipeline itself last recorded
+// (sctx.Run.HeadSHA). Every post-review step calls this guard at entry, and
+// commitAgentFixes calls it around commits that advance the recorded head.
 //
 // The pipeline advances HEAD only through its own commits, each of which updates
 // sctx.Run.HeadSHA in lockstep. If HEAD has diverged from that recorded head -
 // e.g. a concurrent process reset the shared worktree to a different commit -
 // then the reviewed change the pipeline approved is no longer in HEAD's history,
-// and committing on top of it would ship an unreviewed tree. The whole job of
-// this tool is to not lose people's code, so we refuse rather than proceed.
+// and continuing would ship an unreviewed tree. The whole job of this tool is
+// to not lose people's code, so we refuse rather than proceed.
 //
 // Anchor integrity: sctx.Run.HeadSHA is the correct, un-clobberable anchor. It
 // is the *recorded* head the pipeline itself produced at its last commit - held
@@ -76,11 +78,11 @@ func hasBlockingFindings(items []Finding) bool {
 // point the anchor still holds the reviewed head even after a clobber. The guard
 // deliberately compares the *recorded* head against the *live* worktree HEAD
 // (git.HeadSHA); it never derives the anchor from the mutable worktree, which
-// would be circular and defeatable. Because the guard sits at the very top of
-// commitAgentFixes - before any commit that would advance sctx.Run.HeadSHA - the
-// first pipeline commit after a clobber is caught while the anchor is still the
-// pre-clobber reviewed head; the anchor can never be advanced into a clobbered
-// lineage without first passing this check.
+// would be circular and defeatable. Because the guard runs at every post-review
+// step entry and at the very top of commitAgentFixes - before any commit that
+// would advance sctx.Run.HeadSHA - the next pipeline boundary after a clobber is
+// caught while the anchor is still the pre-clobber reviewed head; the anchor can
+// never be advanced into a clobbered lineage without first passing this check.
 //
 // This is what happened in run 01KXC3SD5NZYMERGDS68Z1C8ER: the review step
 // committed a correct fix, a sibling worktree sharing the bare repo reset HEAD
@@ -88,8 +90,8 @@ func hasBlockingFindings(items []Finding) bool {
 // clobber and shipped it. A forward-only agent commit (git rebase --continue,
 // etc.) keeps the recorded head as an ancestor and is allowed; a divergent
 // (sibling) reset or a backward reset both trip this guard. On any failure the
-// error propagates out of commitAgentFixes, so the step and the whole run abort
-// (executor.failRun) before push - nothing is committed or shipped.
+// step and the whole run abort (executor.failRun) before doing more work -
+// nothing is committed or shipped.
 func assertPipelineHeadContinuity(sctx *pipeline.StepContext, stepName types.StepName) error {
 	recorded := strings.TrimSpace(sctx.Run.HeadSHA)
 	if recorded == "" {
@@ -97,7 +99,7 @@ func assertPipelineHeadContinuity(sctx *pipeline.StepContext, stepName types.Ste
 	}
 	currentHead, err := git.HeadSHA(sctx.Ctx, sctx.WorkDir)
 	if err != nil {
-		return fmt.Errorf("resolve head before %s commit: %w", stepName, err)
+		return fmt.Errorf("resolve head before %s step: %w", stepName, err)
 	}
 	if currentHead == recorded {
 		return nil
@@ -106,7 +108,7 @@ func assertPipelineHeadContinuity(sctx *pipeline.StepContext, stepName types.Ste
 	// live HEAD (a legitimate forward move). A non-ancestor result OR any git error
 	// (e.g. an unknown recorded object) aborts rather than proceeds.
 	if _, err := git.Run(sctx.Ctx, sctx.WorkDir, "merge-base", "--is-ancestor", recorded, currentHead); err != nil {
-		return fmt.Errorf("refusing to commit %s changes: worktree HEAD %s is not a descendant of the pipeline's recorded head %s; "+
+		return fmt.Errorf("refusing to run %s step: worktree HEAD %s is not a descendant of the pipeline's recorded head %s; "+
 			"the reviewed change was rewritten out-of-band and would be lost - aborting to protect it",
 			stepName, currentHead, recorded)
 	}

--- a/internal/pipeline/steps/document.go
+++ b/internal/pipeline/steps/document.go
@@ -86,6 +86,9 @@ var housekeepingFindingsSchema = json.RawMessage(`{
 }`)
 
 func (s *DocumentStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, error) {
+	if err := assertPipelineHeadContinuity(sctx, s.Name()); err != nil {
+		return nil, err
+	}
 	ctx := sctx.Ctx
 	baseSHA := resolveBranchBaseSHA(ctx, sctx.WorkDir, sctx.Run.BaseSHA, sctx.Repo.DefaultBranch)
 

--- a/internal/pipeline/steps/headcontinuity_repro_test.go
+++ b/internal/pipeline/steps/headcontinuity_repro_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kunchenguid/no-mistakes/internal/config"
 	"github.com/kunchenguid/no-mistakes/internal/git"
+	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
@@ -192,6 +193,107 @@ func TestCommitAgentFixes_AllowsForwardAgentCommit(t *testing.T) {
 	}
 	if _, err := git.Run(sctx.Ctx, dir, "merge-base", "--is-ancestor", forward, sctx.Run.HeadSHA); err != nil {
 		t.Fatalf("expected forward commit %s to be an ancestor of new head %s", forward, sctx.Run.HeadSHA)
+	}
+}
+
+func TestPostReviewStepsRefuseHeadClobberAtEntry(t *testing.T) {
+	postReviewSteps := []pipeline.Step{
+		&TestStep{},
+		&DocumentStep{},
+		&LintStep{},
+		&PushStep{},
+		&PRStep{},
+		&CIStep{},
+	}
+	allSteps := types.AllSteps()
+	if len(postReviewSteps) != len(allSteps)-types.StepReview.Order() {
+		t.Fatalf("covered post-review steps = %d, want %d from fixed pipeline order", len(postReviewSteps), len(allSteps)-types.StepReview.Order())
+	}
+	for i, step := range postReviewSteps {
+		want := allSteps[types.StepReview.Order()+i]
+		if step.Name() != want {
+			t.Fatalf("covered post-review step %d = %s, want %s from fixed pipeline order", i, step.Name(), want)
+		}
+	}
+
+	resetHeads := []struct {
+		name string
+		move func(t *testing.T, dir, baseSHA string) string
+	}{
+		{
+			name: "backward_reset",
+			move: func(t *testing.T, dir, baseSHA string) string {
+				gitCmd(t, dir, "reset", "--hard", baseSHA)
+				return baseSHA
+			},
+		},
+		{
+			name: "sibling_reset",
+			move: func(t *testing.T, dir, baseSHA string) string {
+				gitCmd(t, dir, "reset", "--hard", baseSHA)
+				if err := os.WriteFile(filepath.Join(dir, "sibling.txt"), []byte("out-of-band sibling\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				gitCmd(t, dir, "add", "-A")
+				gitCmd(t, dir, "commit", "-m", "out-of-band sibling")
+				return gitCmd(t, dir, "rev-parse", "HEAD")
+			},
+		},
+	}
+
+	for _, step := range postReviewSteps {
+		for _, reset := range resetHeads {
+			t.Run(string(step.Name())+"/"+reset.name, func(t *testing.T) {
+				dir, baseSHA, reviewedHead := setupGitRepo(t)
+				ag := &mockAgent{name: "codex"}
+				sctx := newTestContext(t, ag, dir, baseSHA, reviewedHead, config.Commands{})
+				clobberedHead := reset.move(t, dir, baseSHA)
+
+				_, err := step.Execute(sctx)
+				if err == nil || !strings.Contains(err.Error(), "not a descendant") {
+					t.Fatalf("%s must reject %s at entry, got %v", step.Name(), reset.name, err)
+				}
+				if len(ag.calls) != 0 {
+					t.Fatalf("%s invoked an agent before rejecting %s", step.Name(), reset.name)
+				}
+				if got := gitCmd(t, dir, "rev-parse", "HEAD"); got != clobberedHead {
+					t.Fatalf("%s performed work before rejecting %s: HEAD moved from %s to %s", step.Name(), reset.name, clobberedHead, got)
+				}
+				if sctx.Run.HeadSHA != reviewedHead {
+					t.Fatalf("%s changed recorded reviewed head before rejecting %s: got %s, want %s", step.Name(), reset.name, sctx.Run.HeadSHA, reviewedHead)
+				}
+			})
+		}
+	}
+}
+
+func TestPostReviewStepEntryAllowsEqualAndPipelineDescendantHeads(t *testing.T) {
+	dir, baseSHA, recordedHead := setupGitRepo(t)
+	sctx := newTestContext(t, &mockAgent{name: "codex"}, dir, baseSHA, recordedHead, config.Commands{})
+	postReviewSteps := []types.StepName{
+		types.StepTest,
+		types.StepDocument,
+		types.StepLint,
+		types.StepPush,
+		types.StepPR,
+		types.StepCI,
+	}
+
+	for _, stepName := range postReviewSteps {
+		if err := assertPipelineHeadContinuity(sctx, stepName); err != nil {
+			t.Fatalf("%s rejected equal HEAD: %v", stepName, err)
+		}
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "pipeline-descendant.txt"), []byte("pipeline work\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "pipeline descendant")
+	for _, stepName := range postReviewSteps {
+		if err := assertPipelineHeadContinuity(sctx, stepName); err != nil {
+			t.Fatalf("%s rejected pipeline-descendant HEAD: %v", stepName, err)
+		}
 	}
 }
 

--- a/internal/pipeline/steps/headcontinuity_repro_test.go
+++ b/internal/pipeline/steps/headcontinuity_repro_test.go
@@ -263,8 +263,43 @@ func TestPostReviewStepsRefuseHeadClobberAtEntry(t *testing.T) {
 				if sctx.Run.HeadSHA != reviewedHead {
 					t.Fatalf("%s changed recorded reviewed head before rejecting %s: got %s, want %s", step.Name(), reset.name, sctx.Run.HeadSHA, reviewedHead)
 				}
+				t.Logf("%s refused %s before agent, HEAD, or recorded-head mutation: %v", step.Name(), reset.name, err)
 			})
 		}
+	}
+}
+
+func TestPostReviewStepsRefuseUnverifiableRecordedHeadAtEntry(t *testing.T) {
+	postReviewSteps := []pipeline.Step{
+		&TestStep{},
+		&DocumentStep{},
+		&LintStep{},
+		&PushStep{},
+		&PRStep{},
+		&CIStep{},
+	}
+
+	for _, step := range postReviewSteps {
+		t.Run(string(step.Name()), func(t *testing.T) {
+			dir, baseSHA, currentHead := setupGitRepo(t)
+			ag := &mockAgent{name: "codex"}
+			sctx := newTestContext(t, ag, dir, baseSHA, strings.Repeat("f", 40), config.Commands{})
+
+			_, err := step.Execute(sctx)
+			if err == nil || !strings.Contains(err.Error(), "not a descendant") {
+				t.Fatalf("%s must reject an unverifiable recorded head at entry, got %v", step.Name(), err)
+			}
+			if len(ag.calls) != 0 {
+				t.Fatalf("%s invoked an agent before rejecting an unverifiable recorded head", step.Name())
+			}
+			if got := gitCmd(t, dir, "rev-parse", "HEAD"); got != currentHead {
+				t.Fatalf("%s performed work before rejecting an unverifiable recorded head: HEAD moved from %s to %s", step.Name(), currentHead, got)
+			}
+			if sctx.Run.HeadSHA != strings.Repeat("f", 40) {
+				t.Fatalf("%s changed the unverifiable recorded head on refusal: got %s", step.Name(), sctx.Run.HeadSHA)
+			}
+			t.Logf("%s failed closed before agent or HEAD mutation: %v", step.Name(), err)
+		})
 	}
 }
 
@@ -304,6 +339,7 @@ func TestPostReviewStepEntryAllowsEqualAndPipelineDescendantHeads(t *testing.T) 
 		if err := assertPipelineHeadContinuity(sctx, stepName); err != nil {
 			t.Fatalf("%s rejected equal HEAD: %v", stepName, err)
 		}
+		t.Logf("%s allowed HEAD equal to recorded head %s", stepName, recordedHead)
 	}
 
 	if err := os.WriteFile(filepath.Join(dir, "pipeline-descendant.txt"), []byte("pipeline work\n"), 0o644); err != nil {
@@ -315,6 +351,7 @@ func TestPostReviewStepEntryAllowsEqualAndPipelineDescendantHeads(t *testing.T) 
 		if err := assertPipelineHeadContinuity(sctx, stepName); err != nil {
 			t.Fatalf("%s rejected pipeline-descendant HEAD: %v", stepName, err)
 		}
+		t.Logf("%s allowed descendant HEAD while preserving recorded ancestor %s", stepName, recordedHead)
 	}
 }
 

--- a/internal/pipeline/steps/headcontinuity_repro_test.go
+++ b/internal/pipeline/steps/headcontinuity_repro_test.go
@@ -267,6 +267,23 @@ func TestPostReviewStepsRefuseHeadClobberAtEntry(t *testing.T) {
 	}
 }
 
+func TestCIGateReconciliationRefusesHeadClobberAtEntry(t *testing.T) {
+	dir, baseSHA, reviewedHead := setupGitRepo(t)
+	sctx := newTestContext(t, &mockAgent{name: "codex"}, dir, baseSHA, reviewedHead, config.Commands{})
+	gitCmd(t, dir, "reset", "--hard", baseSHA)
+
+	reconciled, err := (&CIStep{}).ReconcileApprovalGate(sctx)
+	if err == nil || !strings.Contains(err.Error(), "not a descendant") {
+		t.Fatalf("CI gate reconciliation must reject a backward reset at entry, got reconciled=%v err=%v", reconciled, err)
+	}
+	if reconciled {
+		t.Fatal("CI gate reconciliation reported success after a backward reset")
+	}
+	if sctx.Run.HeadSHA != reviewedHead {
+		t.Fatalf("CI gate reconciliation changed recorded reviewed head: got %s, want %s", sctx.Run.HeadSHA, reviewedHead)
+	}
+}
+
 func TestPostReviewStepEntryAllowsEqualAndPipelineDescendantHeads(t *testing.T) {
 	dir, baseSHA, recordedHead := setupGitRepo(t)
 	sctx := newTestContext(t, &mockAgent{name: "codex"}, dir, baseSHA, recordedHead, config.Commands{})

--- a/internal/pipeline/steps/headcontinuity_repro_test.go
+++ b/internal/pipeline/steps/headcontinuity_repro_test.go
@@ -1,6 +1,7 @@
 package steps
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -275,6 +276,9 @@ func TestCIGateReconciliationRefusesHeadClobberAtEntry(t *testing.T) {
 	reconciled, err := (&CIStep{}).ReconcileApprovalGate(sctx)
 	if err == nil || !strings.Contains(err.Error(), "not a descendant") {
 		t.Fatalf("CI gate reconciliation must reject a backward reset at entry, got reconciled=%v err=%v", reconciled, err)
+	}
+	if !errors.Is(err, pipeline.ErrFatalGateReconciliation) {
+		t.Fatalf("CI gate reconciliation error = %v, want fatal classification", err)
 	}
 	if reconciled {
 		t.Fatal("CI gate reconciliation reported success after a backward reset")

--- a/internal/pipeline/steps/lint.go
+++ b/internal/pipeline/steps/lint.go
@@ -16,6 +16,9 @@ type LintStep struct{}
 func (s *LintStep) Name() types.StepName { return types.StepLint }
 
 func (s *LintStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, error) {
+	if err := assertPipelineHeadContinuity(sctx, s.Name()); err != nil {
+		return nil, err
+	}
 	ctx := sctx.Ctx
 	baseSHA := resolveBranchBaseSHA(ctx, sctx.WorkDir, sctx.Run.BaseSHA, sctx.Repo.DefaultBranch)
 	lintCmd := sctx.Config.Commands.Lint

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -51,6 +51,9 @@ type pipelineUpdateGroup struct {
 func (s *PRStep) Name() types.StepName { return types.StepPR }
 
 func (s *PRStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, error) {
+	if err := assertPipelineHeadContinuity(sctx, s.Name()); err != nil {
+		return nil, err
+	}
 	ctx := sctx.Ctx
 
 	branch := sctx.Run.Branch

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -20,6 +20,9 @@ type PushStep struct{}
 func (s *PushStep) Name() types.StepName { return types.StepPush }
 
 func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, error) {
+	if err := assertPipelineHeadContinuity(sctx, s.Name()); err != nil {
+		return nil, err
+	}
 	ctx := sctx.Ctx
 	newHeadSHA := ""
 	if err := sctx.DB.SetRunPushActive(sctx.Run.ID, true); err != nil {

--- a/internal/pipeline/steps/push_test.go
+++ b/internal/pipeline/steps/push_test.go
@@ -45,8 +45,9 @@ func TestPushStep_RefusesPostReviewClobberWithoutLaterPipelineCommit(t *testing.
 	sctx := newTestContextWithDBRecords(t, &mockAgent{name: "test"}, dir, baseSHA, submittedHead, config.Commands{})
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "refs/heads/feature"
-	// This models the current in-memory run state left by the review-fix commit.
-	sctx.Run.HeadSHA = reviewedHead
+	// Let the entry guard pass so this regression continues to isolate the
+	// independent durable review-approved binding added at the push boundary.
+	sctx.Run.HeadSHA = clobberedHead
 	recordReviewApproval(t, sctx, reviewedHead)
 
 	_, err := (&PushStep{}).Execute(sctx)

--- a/internal/pipeline/steps/test.go
+++ b/internal/pipeline/steps/test.go
@@ -29,6 +29,9 @@ func gitIgnoresPath(ctx context.Context, workDir, target string) bool {
 }
 
 func (s *TestStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, error) {
+	if err := assertPipelineHeadContinuity(sctx, s.Name()); err != nil {
+		return nil, err
+	}
 	ctx := sctx.Ctx
 	baseSHA := resolveBranchBaseSHA(ctx, sctx.WorkDir, sctx.Run.BaseSHA, sctx.Repo.DefaultBranch)
 


### PR DESCRIPTION
## Intent

Add defense-in-depth HEAD continuity checks at entry to every fixed-order pipeline step after Review: Test, Document, Lint, Push, PR, and CI. Reuse assertPipelineHeadContinuity as the single semantic owner so equal and pipeline-descendant heads continue while backward resets, divergent siblings, and unverifiable relationships fail closed before any step work, including non-committing paths. Preserve PR 573's durable review-approved head binding and immutable push behavior. Keep scope limited to focused regressions and concise documentation, without repository URL refresh, schema or approval changes, rebase or CI routing, force-push policy, or unrelated refactoring.

## What Changed

- Enforce recorded-to-live HEAD continuity before Test, Document, Lint, Push, PR, and CI work, allowing equal or pipeline-descendant heads while rejecting resets, divergence, and unverifiable history.
- Treat CI continuity failures during parked or recovered gate reconciliation as fatal and clear awaiting-agent state when terminating the run.
- Add focused regression coverage and document the post-review continuity safeguards.

## Risk Assessment

✅ Low: The final change guards all requested post-review entry paths, propagates fatal CI reconciliation failures through live and recovered execution, and now clears recovered parked state before terminalizing the run without disturbing the durable push binding.

## Testing

Focused real-Git tests passed for all six post-Review steps: equal and descendant heads continued, backward, sibling, and unverifiable relationships failed before work, fatal parked-CI reconciliation failed the run, and the durable review-approved push binding delivered only the verified immutable commit.

- Evidence: [HEAD continuity behavior transcript](https://github.com/kunchenguid/no-mistakes/blob/bac7256522313f4607fbc1776fe1df0da212b0fb/.no-mistakes/evidence/fm/nm-headcontinuity-stepassert/head-continuity-transcript.txt)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (3) ✅</summary>

- 🚨 `internal/pipeline/steps/ci.go:122` - The required criterion says backward resets must &#34;fail closed before any step work, including non-committing paths,&#34; but the new guard only covers Execute. A parked or recovered CI gate enters ReconcileApprovalGate directly; if HEAD is reset while parked or during daemon downtime, that method can query the provider, update PR state, and complete the CI step/run without asserting continuity. Call assertPipelineHeadContinuity at the start of ReconcileApprovalGate as the earliest shared CI boundary.

🔧 Fix: Guard CI reconciliation against HEAD clobbers
1 error still open:
- 🚨 `internal/pipeline/steps/ci.go:57` - The reconciliation guard still does not satisfy the required &#34;fail closed&#34; behavior. After a parked or recovered CI run is clobbered, this new hunk returns an error, but waitForApprovalOrReconcile and Resume deliberately treat every reconciliation error as transient and preserve the gate. The user can then approve it, completing CI and the run without another continuity check. Make continuity failures distinguishable from provider errors and propagate them through the reconciliation caller to failRun; keep transient provider errors parked.

🔧 Fix: Fail runs on fatal gate reconciliation
1 error still open:
- 🚨 `internal/pipeline/executor.go:315` - The recovered fatal-reconciliation branch fails the step and run without calling CompleteRunAwaitingAgent. FailStep and failRun do not clear awaiting_agent_since, so the terminal failed run remains marked as parked and its parked duration is not accumulated, violating the invariant that this field is non-nil only while actually awaiting approval. Clear the awaiting-agent state before terminalizing this branch, as the neighboring recovered reconciliation paths do.

🔧 Fix: Clear parked state on fatal reconciliation
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `Inspected the target diff and continuity entry points for Test, Document, Lint, Push, PR, and CI.`
- `go test ./internal/pipeline/steps ./internal/pipeline -run 'Test(PostReviewStepsRefuseHeadClobberAtEntry|PostReviewStepsRefuseUnverifiableRecordedHeadAtEntry|CIGateReconciliationRefusesHeadClobberAtEntry|PostReviewStepEntryAllowsEqualAndPipelineDescendantHeads|PushStep_RefusesPostReviewClobberWithoutLaterPipelineCommit|Executor_FatalReconcileErrorFailsRun|Executor_ResumeFatalReconcileErrorFailsRun)$' -count=1 -v`
- `go test ./internal/pipeline/steps ./internal/pipeline -run 'Test(PushStep_BindsRemoteAndDatabaseToVerifiedCommitWhenHEADMovesDuringPush|Executor_FullRereviewReplacesApprovalWithoutAuthorizingParkedRound)$' -count=1 -v`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
