### PR TITLE
fix(agent): isolate Pi validation from extensions and project context

### DIFF
--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -275,7 +275,7 @@ Starts a persistent HTTP server (`opencode serve`) on first use and reuses it ac
 
 Spawns a `pi` subprocess for each invocation with `--mode json --no-session --no-extensions` so unrelated discovered extensions cannot affect validation.
 Any `agent_args_override.pi` flags are inserted before no-mistakes' managed flags; see [`agent_args_override`](/no-mistakes/reference/global-config/#agent_args_override) for Pi override precedence.
-When trusted repo configuration sets `disable_project_settings`, no-mistakes also adds `--no-context-files` to suppress project-level `AGENTS.md` and `CLAUDE.md` discovery.
+When trusted repo configuration sets `disable_project_settings`, no-mistakes pins `--no-context-files` before those extras so target `AGENTS.md` and `CLAUDE.md` files are not loaded.
 Reads JSONL events from stdout and streams incremental text deltas to the TUI.
 When structured output is requested, no-mistakes injects the JSON schema into the prompt and validates the final text response.
 

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -275,7 +275,7 @@ Starts a persistent HTTP server (`opencode serve`) on first use and reuses it ac
 
 Spawns a `pi` subprocess for each invocation with `--mode json --no-session --no-extensions` so unrelated discovered extensions cannot affect validation.
 Any `agent_args_override.pi` flags are inserted before no-mistakes' managed flags; see [`agent_args_override`](/no-mistakes/reference/global-config/#agent_args_override) for Pi override precedence.
-When trusted repository configuration sets `disable_project_settings`, no-mistakes also adds `--no-context-files` so Pi does not discover project instruction files.
+When trusted repo configuration sets `disable_project_settings`, no-mistakes also adds `--no-context-files` to suppress project-level `AGENTS.md` and `CLAUDE.md` discovery.
 Reads JSONL events from stdout and streams incremental text deltas to the TUI.
 When structured output is requested, no-mistakes injects the JSON schema into the prompt and validates the final text response.
 

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -273,8 +273,9 @@ Starts a persistent HTTP server (`opencode serve`) on first use and reuses it ac
 
 ## Pi
 
-Spawns a `pi` subprocess for each invocation with `--mode json --no-session`.
-See [`agent_args_override`](/no-mistakes/reference/global-config/#agent_args_override) for Pi override precedence.
+Spawns a `pi` subprocess for each invocation with `--mode json --no-session --no-extensions` so unrelated discovered extensions cannot affect validation.
+Any `agent_args_override.pi` flags are inserted before no-mistakes' managed flags; see [`agent_args_override`](/no-mistakes/reference/global-config/#agent_args_override) for Pi override precedence.
+When trusted repository configuration sets `disable_project_settings`, no-mistakes also adds `--no-context-files` so Pi does not discover project instruction files.
 Reads JSONL events from stdout and streams incremental text deltas to the TUI.
 When structured output is requested, no-mistakes injects the JSON schema into the prompt and validates the final text response.
 

--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -119,9 +119,9 @@ func (a *piAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 
 // buildArgs returns the Pi argv for one invocation. Under the project-settings
 // opt-out, the context-file suppression flag comes first. User extras otherwise
-// precede the managed flags that no-mistakes requires for JSONL parsing.
+// precede the managed flags that no-mistakes requires for isolated JSONL parsing.
 func (a *piAgent) buildArgs() []string {
-	args := make([]string, 0, len(a.extraArgs)+5)
+	args := make([]string, 0, len(a.extraArgs)+6)
 	// Project-settings opt-out (trusted-only; see config.DisableProjectSettings):
 	// disable AGENTS.md/CLAUDE.md discovery so an agent-orchestration target
 	// (firstmate) cannot install a fleet-captain identity on the gate agent.
@@ -142,7 +142,7 @@ func (a *piAgent) buildArgs() []string {
 			args = append(args, arg)
 		}
 	}
-	args = append(args, "--mode", "json", "--no-session")
+	args = append(args, "--mode", "json", "--no-session", "--no-extensions")
 	return args
 }
 

--- a/internal/agent/pi_test.go
+++ b/internal/agent/pi_test.go
@@ -46,7 +46,7 @@ func TestPiAgent_BuildArgs_PrependsExtraArgs(t *testing.T) {
 func TestPiAgent_BuildArgs_OptOutAddsNoContextFiles(t *testing.T) {
 	pa := &piAgent{bin: "pi", extraArgs: []string{"--system-prompt"}, disableProjectSettings: true}
 	args := pa.buildArgs()
-	expected := []string{"--no-context-files", "--system-prompt", "--mode", "json", "--no-session"}
+	expected := []string{"--no-context-files", "--system-prompt", "--mode", "json", "--no-session", "--no-extensions"}
 	if len(args) != len(expected) {
 		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
 	}
@@ -60,7 +60,7 @@ func TestPiAgent_BuildArgs_OptOutAddsNoContextFiles(t *testing.T) {
 func TestPiAgent_BuildArgs_OptOutDoesNotDuplicateNoContextFiles(t *testing.T) {
 	pa := &piAgent{bin: "pi", extraArgs: []string{"--provider", "google", "-nc"}, disableProjectSettings: true}
 	args := pa.buildArgs()
-	expected := []string{"-nc", "--provider", "google", "--mode", "json", "--no-session"}
+	expected := []string{"-nc", "--provider", "google", "--mode", "json", "--no-session", "--no-extensions"}
 	if len(args) != len(expected) {
 		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
 	}
@@ -74,7 +74,7 @@ func TestPiAgent_BuildArgs_OptOutDoesNotDuplicateNoContextFiles(t *testing.T) {
 func TestPiAgent_BuildArgs_OptOutPreservesNoContextFilesOptionValue(t *testing.T) {
 	pa := &piAgent{bin: "pi", extraArgs: []string{"--system-prompt", "-nc"}, disableProjectSettings: true}
 	args := pa.buildArgs()
-	expected := []string{"--no-context-files", "--system-prompt", "-nc", "--mode", "json", "--no-session"}
+	expected := []string{"--no-context-files", "--system-prompt", "-nc", "--mode", "json", "--no-session", "--no-extensions"}
 	if len(args) != len(expected) {
 		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
 	}
@@ -159,7 +159,7 @@ printf '%s\n' '{"type":"agent_end","messages":[{"role":"assistant","content":"ok
 		t.Fatalf("read captured pi argv: %v", err)
 	}
 	got := strings.TrimSpace(string(argv))
-	want := "--no-context-files --provider google --mode json --no-session"
+	want := "--no-context-files --provider google --mode json --no-session --no-extensions"
 	if got != want {
 		t.Fatalf("pi argv = %q, want %q", got, want)
 	}

--- a/internal/agent/pi_test.go
+++ b/internal/agent/pi_test.go
@@ -15,7 +15,7 @@ func TestPiAgent_BuildArgs(t *testing.T) {
 	pa := &piAgent{bin: "pi"}
 	args := pa.buildArgs()
 
-	expected := []string{"--mode", "json", "--no-session"}
+	expected := []string{"--mode", "json", "--no-session", "--no-extensions"}
 
 	if len(args) != len(expected) {
 		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
@@ -31,7 +31,7 @@ func TestPiAgent_BuildArgs_PrependsExtraArgs(t *testing.T) {
 	pa := &piAgent{bin: "pi", extraArgs: []string{"--provider", "google"}}
 	args := pa.buildArgs()
 
-	expected := []string{"--provider", "google", "--mode", "json", "--no-session"}
+	expected := []string{"--provider", "google", "--mode", "json", "--no-session", "--no-extensions"}
 
 	if len(args) != len(expected) {
 		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)

--- a/internal/daemon/helpers_test.go
+++ b/internal/daemon/helpers_test.go
@@ -109,14 +109,7 @@ func startTestDaemon(t *testing.T) (*paths.Paths, *db.DB) {
 		errCh <- RunWithResources(p, d)
 	}()
 
-	// Wait for socket to appear.
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		if _, err := os.Stat(p.Socket()); err == nil {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
+	waitForTestDaemonReady(t, p)
 
 	t.Cleanup(func() {
 		// Ensure daemon stops.
@@ -216,13 +209,7 @@ func startTestDaemonWithSteps(t *testing.T, sf StepFactory) (*paths.Paths, *db.D
 		errCh <- RunWithOptions(p, d, sf)
 	}()
 
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		if _, err := os.Stat(p.Socket()); err == nil {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
+	waitForTestDaemonReady(t, p)
 
 	t.Cleanup(func() {
 		client, err := ipc.Dial(p.Socket())
@@ -238,6 +225,25 @@ func startTestDaemonWithSteps(t *testing.T, sf StepFactory) (*paths.Paths, *db.D
 	})
 
 	return p, d
+}
+
+func waitForTestDaemonReady(t *testing.T, p *paths.Paths) {
+	t.Helper()
+
+	deadline := time.Now().Add(3 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		alive, err := daemonHealthCheck(p)
+		if err == nil && alive {
+			return
+		}
+		lastErr = err
+		time.Sleep(20 * time.Millisecond)
+	}
+	if lastErr != nil {
+		t.Fatalf("daemon did not become ready: %v", lastErr)
+	}
+	t.Fatal("daemon did not become ready")
 }
 
 // setupTestGitRepo creates a git repo with one commit, pushes to a bare repo


### PR DESCRIPTION
## Intent

Update existing PR #584 on RooseveltAdvisors:fm/no-mistakes-pi-observational-memory-crash so it rebases cleanly onto the latest kunchenguid/no-mistakes main without creating a replacement PR. Preserve Pi extension isolation alongside merged #586 behavior by unioning always-on --no-extensions with the trusted disable_project_settings --no-context-files logic, keeping argument precedence and option-value protections. Update every affected Pi argv/evidence expectation, merge both documentation statements, retain the daemon readiness test helper if applicable, validate locally and through no-mistakes, and leave the PR unmerged with all expected GitHub checks green.

## What Changed

- Always launch Pi validation with `--no-extensions` while preserving managed flag precedence and option-value handling.
- Combine extension isolation with trusted `disable_project_settings` context-file suppression, and update Pi argv tests and agent documentation accordingly.
- Make daemon test setup wait for a successful health check instead of socket creation alone.

## Risk Assessment

✅ Low: The change cleanly preserves trusted Pi context-file suppression, argument ordering and option-value protections while adding always-on discovered-extension isolation and retaining the daemon readiness helper.

## Testing

No pre-supplied baseline commands were reported; targeted argument-construction tests passed across default, extra-argument, trusted opt-out, deduplication, and option-value cases, the fake Pi subprocess captured the required combined argv and produced reviewer-visible evidence, and the retained health-based daemon readiness helper successfully reached a responsive daemon during the focused singleton test.

<details>
<summary>Evidence: End-user Pi subprocess argv transcript</summary>

`Pi received argv: --no-context-files --provider google --mode json --no-session --no-extensions`

```text
=== RUN   TestPiAgent_RunOptOutPassesNoContextFilesToCLI
    pi_test.go:166: pi received argv: --no-context-files --provider google --mode json --no-session --no-extensions
--- PASS: TestPiAgent_RunOptOutPassesNoContextFilesToCLI (0.00s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/agent	0.002s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `docs/src/content/docs/guides/agents.md` - merge conflict rebasing onto refs/remotes/no-mistakes-push/fm/no-mistakes-pi-observational-memory-crash
- ⚠️ `internal/agent/pi.go` - merge conflict rebasing onto refs/remotes/no-mistakes-push/fm/no-mistakes-pi-observational-memory-crash

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 829ee34703bdc1d7cb216e6c33166803944f6f85..dc6f9b221a0856625d0369b65a0d3f11acf65cd8` for Pi argv, documentation, expectations, and daemon readiness changes.</code>
- `go test ./internal/agent -run '^(TestPiAgent_BuildArgs|TestPiAgent_BuildArgs_PrependsExtraArgs|TestPiAgent_BuildArgs_OptOutAddsNoContextFiles|TestPiAgent_BuildArgs_OptOutDoesNotDuplicateNoContextFiles|TestPiAgent_BuildArgs_OptOutPreservesNoContextFilesOptionValue|TestPiAgent_RunOptOutPassesNoContextFilesToCLI)$' -v`
- `go test ./internal/agent -run '^TestPiAgent_RunOptOutPassesNoContextFilesToCLI$' -v | tee /tmp/no-mistakes-evidence/01KYPVZWWGS8Z13WTZ67TSP33N/pi-argv-transcript.txt`
- `go test ./internal/daemon -run '^TestRunWithResources_SecondDaemonForSameRootFailsWithoutStealingSocket$' -v`
- <code>Verified `git status --short` remained empty after testing.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
