### PR TITLE
feat(agent): neutralize Pi project context files

### DIFF
--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -40,7 +40,7 @@ By default that directory is temporary and local to the machine; repos can opt i
 ## Supported agents
 
 | Agent | Binary | Protocol |
-|---|---|---|
+| --- | --- | --- |
 | Claude | `claude` | Subprocess per invocation, JSONL streaming |
 | Codex | `codex` | Subprocess per invocation, JSONL events |
 | Rovo Dev | `acli` | Persistent HTTP server, SSE streaming |
@@ -57,7 +57,7 @@ The daemon resolves the effective agent before creating pipeline step records, a
 This refusal also applies when deterministic test or lint commands are configured because review and documentation always require agent judgment, while rebase, PR, and CI paths may need an agent to resolve conflicts, generate content, or fix failures.
 
 | Surface or capability | Works without a runnable pipeline agent? | Behavior |
-|---|---:|---|
+| --- | ---: | --- |
 | Install, `init`, daemon lifecycle, `status`, `runs`, and `doctor` | Yes | Local setup and diagnostics remain available. `doctor` reports that gate validation is unavailable. |
 | Start or rerun a validation gate | No | The run fails before any pipeline step starts. |
 | Review | No | Requires agent judgment and structured findings. |
@@ -274,7 +274,7 @@ Starts a persistent HTTP server (`opencode serve`) on first use and reuses it ac
 ## Pi
 
 Spawns a `pi` subprocess for each invocation with `--mode json --no-session`.
-Any `agent_args_override.pi` flags are inserted before no-mistakes' managed flags.
+See [`agent_args_override`](/no-mistakes/reference/global-config/#agent_args_override) for Pi override precedence.
 Reads JSONL events from stdout and streams incremental text deltas to the TUI.
 When structured output is requested, no-mistakes injects the JSON schema into the prompt and validates the final text response.
 

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -161,7 +161,7 @@ Use this to set model selection, service tier, reasoning effort, permission mode
 | Keys    | `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot` |
 | Default | Empty (no extra flags)                                    |
 
-User-supplied flags are inserted ahead of no-mistakes' managed flags, so your choices usually take precedence. A few flags are reserved because no-mistakes depends on them to communicate with the agent - setting any of these returns a config error on load:
+User-supplied flags are normally inserted ahead of no-mistakes' managed flags, so your choices usually take precedence. Security suppression selected by trusted [`disable_project_settings`](/no-mistakes/reference/repo-config/#disable_project_settings) may be placed first while preserving a compatible operator pin. A few flags are reserved because no-mistakes depends on them to communicate with the agent - setting any of these returns a config error on load:
 
 | Agent      | Reserved flags                                                                                              |
 | ---------- | ----------------------------------------------------------------------------------------------------------- |
@@ -317,14 +317,14 @@ These are global defaults. Per-repo config can override individual steps.
 Template for the subject of commits created by the shared Review, Test, Document, and Lint fix path.
 
 | | |
-|---|---|
+| --- | --- |
 | Type | `string` |
 | Default | `no-mistakes({{.Step}}): {{.Summary}}` |
 
 The template supports literal text and two Go-style placeholders:
 
 | Variable | Value |
-|---|---|
+| --- | --- |
 | `{{.Step}}` | Pipeline step name, such as `review`, `test`, `document`, or `lint` |
 | `{{.Summary}}` | Sanitized one-line summary returned by the fix agent, or the step's deterministic fallback summary |
 

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -71,7 +71,7 @@ test:
 Override the default agent for this repo and its setup-wizard suggestions.
 
 | | |
-|---|---|
+| --- | --- |
 | Type | `string` or `string[]` |
 | Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `cursor`, `acp:<target>` |
 | Default | Inherits from global config |
@@ -102,7 +102,7 @@ This per-repo `agent` value, including every fallback entry, is still read from 
 Opt in to honoring the code-executing selection fields (`commands.{test,lint,format}` and `agent`) from a contributor's pushed branch instead of the trusted default-branch copy.
 
 | | |
-|---|---|
+| --- | --- |
 | Type | `bool` |
 | Default | `false` |
 
@@ -113,13 +113,13 @@ This field is itself read **only from the trusted default-branch copy** of `.no-
 Suppress project-level agent settings and instructions for every gate-agent start and resumed session.
 
 | | |
-|---|---|
+| --- | --- |
 | Type | `bool` |
 | Default | `false` |
 
 This opt-in is intended for agent-orchestration repositories whose `AGENTS.md`, `CLAUDE.md`, or harness-specific project settings would give a validation agent an operator identity and authority that it must not adopt.
 When enabled, no-mistakes suppresses the target checkout's project settings for every agent-driven gate step while preserving user-level agent configuration.
-Codex and Claude are the currently verified agents: Codex receives `project_doc_max_bytes=0` and `--ignore-rules`, while Claude loads only its user setting source.
+Codex, Claude, and Pi are the currently verified agents: Codex receives `project_doc_max_bytes=0` and `--ignore-rules`, Claude loads only its user setting source, and Pi runs with `--no-context-files` (preserving a pinned `--no-context-files` or `-nc` spelling).
 The setting applies to both new and resumed sessions.
 
 The gate fails before launching an agent if any resolved agent or fallback lacks a verified suppression mechanism.
@@ -135,7 +135,7 @@ If the trusted commit or its present config file cannot be read and parsed, the 
 Explicit **targeted** local test command. Run via the platform shell - `sh -c` on POSIX, `cmd.exe /c` on Windows.
 
 | | |
-|---|---|
+| --- | --- |
 | Type | `string` |
 | Default | Empty (agent selects the smallest relevant tests and evidence checks) |
 
@@ -152,7 +152,7 @@ When user intent is available, the agent may still run after a successful baseli
 Explicit lint command. Run via the platform shell - `sh -c` on POSIX, `cmd.exe /c` on Windows.
 
 | | |
-|---|---|
+| --- | --- |
 | Type | `string` |
 | Default | Empty (agent auto-detects) |
 
@@ -165,7 +165,7 @@ Neither responsibility is skipped: when the document step has nothing to run aga
 Formatter command run before the push step commits agent fixes.
 
 | | |
-|---|---|
+| --- | --- |
 | Type | `string` |
 | Default | Empty (no separate push-step formatter) |
 
@@ -176,7 +176,7 @@ This does not prevent empty `commands.lint` from detecting and running formatter
 Repository-specific documentation ownership policy for the document step.
 
 | | |
-|---|---|
+| --- | --- |
 | Type | `string` (multiline) |
 | Default | Empty (built-in placement policy only) |
 
@@ -197,14 +197,14 @@ Do not rely on a configured command to leave a background server or watcher runn
 Paths to exclude from review and documentation checks.
 
 | | |
-|---|---|
+| --- | --- |
 | Type | `string[]` |
 | Default | Empty (no ignores) |
 
 Pattern matching rules:
 
 | Pattern | Rule |
-|---|---|
+| --- | --- |
 | `*.generated.go` | No slash - matches by basename |
 | `vendor/**` | Ends with `/**` - matches entire subtree |
 | `some/path/file.go` | Contains a slash - full path glob |
@@ -218,7 +218,7 @@ Override auto-fix attempt limits for specific steps. Fields not set here inherit
 | Type | `object` |
 
 | Field | Type | Default |
-|---|---|---|
+| --- | --- | --- |
 | `auto_fix.rebase` | `int` | Inherits from global (default `3`) |
 | `auto_fix.review` | `int` | Inherits from global (default `0`) |
 | `auto_fix.test` | `int` | Inherits from global (default `3`) |
@@ -239,7 +239,7 @@ Legacy alias: `auto_fix.babysit`.
 Override the auto-fix commit subject template for this repository.
 
 | | |
-|---|---|
+| --- | --- |
 | Type | `string` |
 | Default | Inherits from global config, whose default is `no-mistakes({{.Step}}): {{.Summary}}` |
 
@@ -255,7 +255,7 @@ Override transcript-based user-intent extraction settings for this repo.
 Fields not set here inherit from global config and then the built-in defaults.
 
 | Field | Type | Default |
-|---|---|---|
+| --- | --- | --- |
 | `intent.enabled` | `bool` | Inherits from global (default `true`) |
 | `intent.threshold` | `float` | Inherits from global (default `0.2`) |
 | `intent.slack_days` | `int` | Inherits from global (default `3`) |
@@ -269,7 +269,7 @@ Override where evidence artifacts from the test step are stored.
 Fields not set here inherit from global config and then the built-in defaults.
 
 | Field | Type | Default |
-|---|---|---|
+| --- | --- | --- |
 | `test.evidence.store_in_repo` | `bool` | Inherits from global (default `false`) |
 | `test.evidence.dir` | `string` | Inherits from global (default `.no-mistakes/evidence`) |
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -156,7 +156,7 @@ func NeutralizesGateInstructions(a Agent) bool {
 // the target checkout does not neutralize that checkout's project
 // agent-instruction files. Callers must invoke it before launching any gate
 // agent so an unverified harness is refused with a clear error rather than run
-// unneutralized in the target checkout. Only codex and claude have a verified
+// unneutralized in the target checkout. Only codex, claude, and pi have a verified
 // neutralization knob today.
 func EnsureGateNeutralized(a Agent) error {
 	if a == nil {
@@ -167,8 +167,8 @@ func EnsureGateNeutralized(a Agent) error {
 	}
 	return fmt.Errorf("gate agent %q does not neutralize the target repository's project "+
 		"agent-instruction files (AGENTS.md/CLAUDE.md); refusing to launch it in the target "+
-		"checkout. Only codex and claude have a verified neutralization knob (and only when it "+
-		"is not overridden by agent_args_override); set 'agent' to codex or claude in "+
+		"checkout. Only codex, claude, and pi have a verified neutralization knob (and only when it "+
+		"is not overridden by agent_args_override); set 'agent' to codex, claude, or pi in "+
 		"~/.no-mistakes/config.yaml", a.Name())
 }
 
@@ -248,7 +248,7 @@ type InvocationWorkload struct {
 type Options struct {
 	ACPRegistryOverrides map[string]string
 	// DisableProjectSettings, when true, asks a supported adapter (codex,
-	// claude) to launch with the target repo's project-level agent
+	// claude, pi) to launch with the target repo's project-level agent
 	// settings/instructions suppressed. It is the resolved, trusted-only opt-out
 	// from config.Config; adapters without a verified suppression knob ignore it
 	// and are refused separately by EnsureGateNeutralized when the opt-out is on.
@@ -805,7 +805,7 @@ func NewWithOptions(name types.AgentName, bin string, extraArgs []string, opts O
 	case types.AgentOpenCode:
 		return &opencodeAgent{bin: bin, extraArgs: extraArgs}, nil
 	case types.AgentPi:
-		return &piAgent{bin: bin, extraArgs: extraArgs}, nil
+		return &piAgent{bin: bin, extraArgs: extraArgs, disableProjectSettings: opts.DisableProjectSettings}, nil
 	case types.AgentCopilot:
 		return &copilotAgent{bin: bin, extraArgs: extraArgs}, nil
 	default:

--- a/internal/agent/gateneutralize_test.go
+++ b/internal/agent/gateneutralize_test.go
@@ -50,8 +50,8 @@ func TestNeutralizesGateInstructions_OnlyVerifiedHarnessesUnderOptOut(t *testing
 	}
 }
 
-// TestNeutralizesGateInstructions_FalseWithoutOptOut proves codex/claude do NOT
-// claim neutralization when the repo did not opt out - the gate only consults
+// TestNeutralizesGateInstructions_FalseWithoutOptOut proves codex, claude, and pi
+// do NOT claim neutralization when the repo did not opt out - the gate only consults
 // this under the opt-out, but the value must be honest.
 func TestNeutralizesGateInstructions_FalseWithoutOptOut(t *testing.T) {
 	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentPi} {
@@ -66,7 +66,7 @@ func TestNeutralizesGateInstructions_FalseWithoutOptOut(t *testing.T) {
 }
 
 // TestEnsureGateNeutralized_RefusesUnsupportedUnderOptOut proves the gate fails
-// closed for an unsupported harness with a clear error, and admits codex/claude.
+// closed for an unsupported harness and admits codex, claude, and pi.
 func TestEnsureGateNeutralized_RefusesUnsupportedUnderOptOut(t *testing.T) {
 	if err := EnsureGateNeutralized(optOutAgent(t, types.AgentCodex, nil)); err != nil {
 		t.Errorf("codex must pass the gate under opt-out: %v", err)
@@ -117,8 +117,8 @@ func TestNeutralizesGateInstructions_ThroughProductionWrapping(t *testing.T) {
 }
 
 // TestNeutralizesGateInstructions_HonestOnEffectiveOverride proves the capability
-// is honest about the EFFECTIVE knob value: a preserving operator override is
-// admitted; a defeating one fails closed - even for codex/claude.
+// is honest about the EFFECTIVE knob value: preserving operator overrides are
+// admitted, while available defeating overrides fail closed.
 func TestNeutralizesGateInstructions_HonestOnEffectiveOverride(t *testing.T) {
 	// codex: project_doc_max_bytes=0 preserves suppression -> admitted.
 	if !NeutralizesGateInstructions(optOutAgent(t, types.AgentCodex, []string{"-c", "project_doc_max_bytes=0"})) {

--- a/internal/agent/gateneutralize_test.go
+++ b/internal/agent/gateneutralize_test.go
@@ -19,17 +19,17 @@ func optOutAgent(t *testing.T, name types.AgentName, extraArgs []string) Agent {
 }
 
 // TestNeutralizesGateInstructions_OnlyVerifiedHarnessesUnderOptOut is the core
-// fail-closed contract: under the opt-out, only codex and claude (whose
+// fail-closed contract: under the opt-out, only codex, claude, and pi (whose
 // suppression knobs are empirically verified) neutralize the target repo's
 // project agent settings/instructions; every other harness reports false and is
 // refused rather than launched with project instructions loaded.
 func TestNeutralizesGateInstructions_OnlyVerifiedHarnessesUnderOptOut(t *testing.T) {
-	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude} {
+	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentPi} {
 		if !NeutralizesGateInstructions(optOutAgent(t, name, nil)) {
 			t.Errorf("%s must neutralize under the opt-out with its default knob", name)
 		}
 	}
-	unverified := []types.AgentName{types.AgentOpenCode, types.AgentPi, types.AgentCopilot, types.AgentRovoDev}
+	unverified := []types.AgentName{types.AgentOpenCode, types.AgentCopilot, types.AgentRovoDev}
 	for _, name := range unverified {
 		if NeutralizesGateInstructions(optOutAgent(t, name, nil)) {
 			t.Errorf("%s has no verified knob; must NOT report neutralized", name)
@@ -54,7 +54,7 @@ func TestNeutralizesGateInstructions_OnlyVerifiedHarnessesUnderOptOut(t *testing
 // claim neutralization when the repo did not opt out - the gate only consults
 // this under the opt-out, but the value must be honest.
 func TestNeutralizesGateInstructions_FalseWithoutOptOut(t *testing.T) {
-	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude} {
+	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentPi} {
 		a, err := NewWithOptions(name, string(name), nil, Options{}) // no opt-out
 		if err != nil {
 			t.Fatalf("NewWithOptions(%s): %v", name, err)
@@ -73,6 +73,9 @@ func TestEnsureGateNeutralized_RefusesUnsupportedUnderOptOut(t *testing.T) {
 	}
 	if err := EnsureGateNeutralized(optOutAgent(t, types.AgentClaude, nil)); err != nil {
 		t.Errorf("claude must pass the gate under opt-out: %v", err)
+	}
+	if err := EnsureGateNeutralized(optOutAgent(t, types.AgentPi, nil)); err != nil {
+		t.Errorf("pi must pass the gate under opt-out: %v", err)
 	}
 	err := EnsureGateNeutralized(optOutAgent(t, types.AgentOpenCode, nil))
 	if err == nil {
@@ -138,5 +141,12 @@ func TestNeutralizesGateInstructions_HonestOnEffectiveOverride(t *testing.T) {
 	}
 	if err := EnsureGateNeutralized(optOutAgent(t, types.AgentClaude, []string{"--setting-sources", "user,local"})); err == nil {
 		t.Error("claude re-adding local must be refused by the gate")
+	}
+	// pi: explicit -nc/--no-context-files preserves suppression -> admitted.
+	if !NeutralizesGateInstructions(optOutAgent(t, types.AgentPi, []string{"--no-context-files"})) {
+		t.Error("pi with an explicit --no-context-files must stay neutralized")
+	}
+	if !NeutralizesGateInstructions(optOutAgent(t, types.AgentPi, []string{"-nc"})) {
+		t.Error("pi with an explicit -nc must stay neutralized")
 	}
 }

--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -19,11 +19,26 @@ import (
 type piAgent struct {
 	bin       string
 	extraArgs []string
+	// disableProjectSettings is the resolved, trusted-only opt-out. When true,
+	// buildArgs suppresses pi's project-level AGENTS.md/CLAUDE.md discovery.
+	disableProjectSettings bool
 }
 
 func (a *piAgent) Name() string { return "pi" }
 
 func (a *piAgent) ReportsAgentAttempts() bool { return true }
+
+// NeutralizesGateInstructions reports whether pi is currently launched with the
+// target repo's project agent-instruction files suppressed. It is meaningful
+// only under the opt-out (disableProjectSettings): the gate only consults it
+// when the repo opted out. Pi's --no-context-files (-nc) disables AGENTS.md and
+// CLAUDE.md discovery for the session. buildArgs appends --no-context-files when
+// the operator did not pin their own -nc/--no-context-files. Verified against
+// current pi --help: "--no-context-files, -nc Disable AGENTS.md and CLAUDE.md
+// discovery and loading".
+func (a *piAgent) NeutralizesGateInstructions() bool {
+	return a.disableProjectSettings && piEffectiveContextFilesSuppressed(a.extraArgs)
+}
 
 func (a *piAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
 	return runWithRetry(ctx, "pi", opts, claudeMaxRetries, classifyTransient, nil, func() (*Result, error) {
@@ -106,10 +121,43 @@ func (a *piAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 // (so user --provider/--model take effect), then the managed flags that
 // no-mistakes requires for JSONL parsing.
 func (a *piAgent) buildArgs() []string {
-	args := make([]string, 0, len(a.extraArgs)+3)
+	args := make([]string, 0, len(a.extraArgs)+5)
 	args = append(args, a.extraArgs...)
+	// Project-settings opt-out (trusted-only; see config.DisableProjectSettings):
+	// disable AGENTS.md/CLAUDE.md discovery so an agent-orchestration target
+	// (firstmate) cannot install a fleet-captain identity on the gate agent.
+	// Suppressed only when the operator did not pin their own -nc/--no-context-files.
+	// When the repo did not opt out, nothing is added and pi loads project
+	// instruction files exactly as before (backward-compat).
+	if a.disableProjectSettings && !piUserSetNoContextFiles(a.extraArgs) {
+		args = append(args, "--no-context-files")
+	}
 	args = append(args, "--mode", "json", "--no-session")
 	return args
+}
+
+// piUserSetNoContextFiles reports whether extraArgs already pin the context-file
+// suppression flag (-nc or --no-context-files), in which case buildArgs does not
+// add its own.
+func piUserSetNoContextFiles(extraArgs []string) bool {
+	for _, arg := range extraArgs {
+		if arg == "--no-context-files" || arg == "-nc" {
+			return true
+		}
+	}
+	return false
+}
+
+// piEffectiveContextFilesSuppressed reports whether the EFFECTIVE pi argv will
+// suppress AGENTS.md/CLAUDE.md discovery: true when the operator did not pin
+// -nc/--no-context-files (buildArgs appends --no-context-files) or pinned either
+// form of the flag.
+func piEffectiveContextFilesSuppressed(extraArgs []string) bool {
+	// Pi has no re-enable flag that defeats -nc once present. Under the opt-out
+	// buildArgs always ensures the flag is present (appended, or already pinned
+	// by the operator), so the effective surface is suppressed.
+	_ = extraArgs
+	return true
 }
 
 // buildPiPrompt appends a JSON-output contract to the user prompt when a

--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -32,12 +32,12 @@ func (a *piAgent) ReportsAgentAttempts() bool { return true }
 // target repo's project agent-instruction files suppressed. It is meaningful
 // only under the opt-out (disableProjectSettings): the gate only consults it
 // when the repo opted out. Pi's --no-context-files (-nc) disables AGENTS.md and
-// CLAUDE.md discovery for the session. buildArgs appends --no-context-files when
-// the operator did not pin their own -nc/--no-context-files. Verified against
-// current pi --help: "--no-context-files, -nc Disable AGENTS.md and CLAUDE.md
-// discovery and loading".
+// CLAUDE.md discovery for the session. buildArgs places the suppression flag
+// before user arguments so it cannot be consumed as another flag's value.
+// Verified against current pi --help: "--no-context-files, -nc Disable AGENTS.md
+// and CLAUDE.md discovery and loading".
 func (a *piAgent) NeutralizesGateInstructions() bool {
-	return a.disableProjectSettings && piEffectiveContextFilesSuppressed(a.extraArgs)
+	return a.disableProjectSettings
 }
 
 func (a *piAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
@@ -117,47 +117,38 @@ func (a *piAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 	return res, err
 }
 
-// buildArgs returns the Pi argv for one invocation. User extras come first
-// (so user --provider/--model take effect), then the managed flags that
-// no-mistakes requires for JSONL parsing.
+// buildArgs returns the Pi argv for one invocation. Under the project-settings
+// opt-out, the context-file suppression flag comes first. User extras otherwise
+// precede the managed flags that no-mistakes requires for JSONL parsing.
 func (a *piAgent) buildArgs() []string {
 	args := make([]string, 0, len(a.extraArgs)+5)
-	args = append(args, a.extraArgs...)
 	// Project-settings opt-out (trusted-only; see config.DisableProjectSettings):
 	// disable AGENTS.md/CLAUDE.md discovery so an agent-orchestration target
 	// (firstmate) cannot install a fleet-captain identity on the gate agent.
-	// Suppressed only when the operator did not pin their own -nc/--no-context-files.
-	// When the repo did not opt out, nothing is added and pi loads project
+	// Preserve an operator-pinned -nc/--no-context-files spelling, but place it
+	// first. When the repo did not opt out, nothing is added and pi loads project
 	// instruction files exactly as before (backward-compat).
-	if a.disableProjectSettings && !piUserSetNoContextFiles(a.extraArgs) {
-		args = append(args, "--no-context-files")
+	if a.disableProjectSettings {
+		contextFlag := "--no-context-files"
+		for _, arg := range a.extraArgs {
+			if piNoContextFilesArg(arg) {
+				contextFlag = arg
+				break
+			}
+		}
+		args = append(args, contextFlag)
+	}
+	for _, arg := range a.extraArgs {
+		if !a.disableProjectSettings || !piNoContextFilesArg(arg) {
+			args = append(args, arg)
+		}
 	}
 	args = append(args, "--mode", "json", "--no-session")
 	return args
 }
 
-// piUserSetNoContextFiles reports whether extraArgs already pin the context-file
-// suppression flag (-nc or --no-context-files), in which case buildArgs does not
-// add its own.
-func piUserSetNoContextFiles(extraArgs []string) bool {
-	for _, arg := range extraArgs {
-		if arg == "--no-context-files" || arg == "-nc" {
-			return true
-		}
-	}
-	return false
-}
-
-// piEffectiveContextFilesSuppressed reports whether the EFFECTIVE pi argv will
-// suppress AGENTS.md/CLAUDE.md discovery: true when the operator did not pin
-// -nc/--no-context-files (buildArgs appends --no-context-files) or pinned either
-// form of the flag.
-func piEffectiveContextFilesSuppressed(extraArgs []string) bool {
-	// Pi has no re-enable flag that defeats -nc once present. Under the opt-out
-	// buildArgs always ensures the flag is present (appended, or already pinned
-	// by the operator), so the effective surface is suppressed.
-	_ = extraArgs
-	return true
+func piNoContextFilesArg(arg string) bool {
+	return arg == "--no-context-files" || arg == "-nc"
 }
 
 // buildPiPrompt appends a JSON-output contract to the user prompt when a

--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -128,18 +128,17 @@ func (a *piAgent) buildArgs() []string {
 	// Preserve an operator-pinned -nc/--no-context-files spelling, but place it
 	// first. When the repo did not opt out, nothing is added and pi loads project
 	// instruction files exactly as before (backward-compat).
+	pinIndex := -1
 	if a.disableProjectSettings {
+		pinIndex = piNoContextFilesArgIndex(a.extraArgs)
 		contextFlag := "--no-context-files"
-		for _, arg := range a.extraArgs {
-			if piNoContextFilesArg(arg) {
-				contextFlag = arg
-				break
-			}
+		if pinIndex >= 0 {
+			contextFlag = a.extraArgs[pinIndex]
 		}
 		args = append(args, contextFlag)
 	}
-	for _, arg := range a.extraArgs {
-		if !a.disableProjectSettings || !piNoContextFilesArg(arg) {
+	for i, arg := range a.extraArgs {
+		if i != pinIndex {
 			args = append(args, arg)
 		}
 	}
@@ -147,8 +146,33 @@ func (a *piAgent) buildArgs() []string {
 	return args
 }
 
+func piNoContextFilesArgIndex(args []string) int {
+	for i := 0; i < len(args); i++ {
+		if piNoContextFilesArg(args[i]) {
+			return i
+		}
+		if piArgTakesValue(args[i]) {
+			i++
+		}
+	}
+	return -1
+}
+
 func piNoContextFilesArg(arg string) bool {
 	return arg == "--no-context-files" || arg == "-nc"
+}
+
+func piArgTakesValue(arg string) bool {
+	switch arg {
+	case "--mode", "--provider", "--model", "--api-key", "--system-prompt",
+		"--append-system-prompt", "--name", "-n", "--session", "--session-id",
+		"--fork", "--session-dir", "--models", "--tools", "-t", "--exclude-tools",
+		"-xt", "--thinking", "--export", "--extension", "-e", "--skill",
+		"--prompt-template", "--theme":
+		return true
+	default:
+		return false
+	}
 }
 
 // buildPiPrompt appends a JSON-output contract to the user prompt when a

--- a/internal/agent/pi_test.go
+++ b/internal/agent/pi_test.go
@@ -58,9 +58,23 @@ func TestPiAgent_BuildArgs_OptOutAddsNoContextFiles(t *testing.T) {
 }
 
 func TestPiAgent_BuildArgs_OptOutDoesNotDuplicateNoContextFiles(t *testing.T) {
+	pa := &piAgent{bin: "pi", extraArgs: []string{"--provider", "google", "-nc"}, disableProjectSettings: true}
+	args := pa.buildArgs()
+	expected := []string{"-nc", "--provider", "google", "--mode", "json", "--no-session"}
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("arg[%d]: expected %q, got %q", i, want, args[i])
+		}
+	}
+}
+
+func TestPiAgent_BuildArgs_OptOutPreservesNoContextFilesOptionValue(t *testing.T) {
 	pa := &piAgent{bin: "pi", extraArgs: []string{"--system-prompt", "-nc"}, disableProjectSettings: true}
 	args := pa.buildArgs()
-	expected := []string{"-nc", "--system-prompt", "--mode", "json", "--no-session"}
+	expected := []string{"--no-context-files", "--system-prompt", "-nc", "--mode", "json", "--no-session"}
 	if len(args) != len(expected) {
 		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
 	}

--- a/internal/agent/pi_test.go
+++ b/internal/agent/pi_test.go
@@ -44,9 +44,9 @@ func TestPiAgent_BuildArgs_PrependsExtraArgs(t *testing.T) {
 }
 
 func TestPiAgent_BuildArgs_OptOutAddsNoContextFiles(t *testing.T) {
-	pa := &piAgent{bin: "pi", disableProjectSettings: true}
+	pa := &piAgent{bin: "pi", extraArgs: []string{"--system-prompt"}, disableProjectSettings: true}
 	args := pa.buildArgs()
-	expected := []string{"--no-context-files", "--mode", "json", "--no-session"}
+	expected := []string{"--no-context-files", "--system-prompt", "--mode", "json", "--no-session"}
 	if len(args) != len(expected) {
 		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
 	}
@@ -58,9 +58,9 @@ func TestPiAgent_BuildArgs_OptOutAddsNoContextFiles(t *testing.T) {
 }
 
 func TestPiAgent_BuildArgs_OptOutDoesNotDuplicateNoContextFiles(t *testing.T) {
-	pa := &piAgent{bin: "pi", extraArgs: []string{"-nc"}, disableProjectSettings: true}
+	pa := &piAgent{bin: "pi", extraArgs: []string{"--system-prompt", "-nc"}, disableProjectSettings: true}
 	args := pa.buildArgs()
-	expected := []string{"-nc", "--mode", "json", "--no-session"}
+	expected := []string{"-nc", "--system-prompt", "--mode", "json", "--no-session"}
 	if len(args) != len(expected) {
 		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
 	}

--- a/internal/agent/pi_test.go
+++ b/internal/agent/pi_test.go
@@ -43,6 +43,43 @@ func TestPiAgent_BuildArgs_PrependsExtraArgs(t *testing.T) {
 	}
 }
 
+func TestPiAgent_BuildArgs_OptOutAddsNoContextFiles(t *testing.T) {
+	pa := &piAgent{bin: "pi", disableProjectSettings: true}
+	args := pa.buildArgs()
+	expected := []string{"--no-context-files", "--mode", "json", "--no-session"}
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("arg[%d]: expected %q, got %q", i, want, args[i])
+		}
+	}
+}
+
+func TestPiAgent_BuildArgs_OptOutDoesNotDuplicateNoContextFiles(t *testing.T) {
+	pa := &piAgent{bin: "pi", extraArgs: []string{"-nc"}, disableProjectSettings: true}
+	args := pa.buildArgs()
+	expected := []string{"-nc", "--mode", "json", "--no-session"}
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("arg[%d]: expected %q, got %q", i, want, args[i])
+		}
+	}
+}
+
+func TestPiAgent_NeutralizesGateInstructions(t *testing.T) {
+	if NeutralizesGateInstructions(&piAgent{bin: "pi"}) {
+		t.Error("pi must not report neutralized without the opt-out")
+	}
+	if !NeutralizesGateInstructions(&piAgent{bin: "pi", disableProjectSettings: true}) {
+		t.Error("pi must report neutralized under the opt-out")
+	}
+}
+
 func TestPiAgent_BuildPromptIncludesSchema(t *testing.T) {
 	schema := json.RawMessage(`{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"]}`)
 	prompt := buildPiPrompt("do a thing", schema)

--- a/internal/agent/pi_test.go
+++ b/internal/agent/pi_test.go
@@ -132,6 +132,40 @@ func writeFakePi(t *testing.T, dir, posixScript, windowsScript string) string {
 	return bin
 }
 
+func TestPiAgent_RunOptOutPassesNoContextFilesToCLI(t *testing.T) {
+	workDir := t.TempDir()
+	bin := writeFakePi(t, t.TempDir(), `#!/bin/sh
+printf '%s\n' "$*" > pi-argv.txt
+cat > /dev/null
+printf '%s\n' '{"type":"agent_end","messages":[{"role":"assistant","content":"ok"}]}'
+`, strings.Join([]string{
+		"@echo off",
+		"echo %* > pi-argv.txt",
+		"more > nul",
+		"echo {\"type\":\"agent_end\",\"messages\":[{\"role\":\"assistant\",\"content\":\"ok\"}]}",
+	}, "\r\n"))
+
+	pa := &piAgent{
+		bin:                    bin,
+		extraArgs:              []string{"--provider", "google"},
+		disableProjectSettings: true,
+	}
+	if _, err := pa.Run(context.Background(), RunOpts{Prompt: "review", CWD: workDir}); err != nil {
+		t.Fatalf("run pi: %v", err)
+	}
+
+	argv, err := os.ReadFile(filepath.Join(workDir, "pi-argv.txt"))
+	if err != nil {
+		t.Fatalf("read captured pi argv: %v", err)
+	}
+	got := strings.TrimSpace(string(argv))
+	want := "--no-context-files --provider google --mode json --no-session"
+	if got != want {
+		t.Fatalf("pi argv = %q, want %q", got, want)
+	}
+	t.Logf("pi received argv: %s", got)
+}
+
 func TestPiAgent_RunParsesAssistantContentAndUsage(t *testing.T) {
 	dir := t.TempDir()
 	// Fake pi that emits a streaming text_delta plus a final message_end with

--- a/internal/daemon/gateneutralize_test.go
+++ b/internal/daemon/gateneutralize_test.go
@@ -18,7 +18,7 @@ func fakeLookPath(bin string) (string, error) { return "/fake/bin/" + bin, nil }
 // opt-out (disable_project_settings=true), a verified harness passes the gate and
 // its pipeline agent reports neutralized.
 func TestNewPipelineAgent_OptOut_AdmitsVerifiedHarness(t *testing.T) {
-	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude} {
+	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentPi} {
 		cfg := &config.Config{Agent: name, DisableProjectSettings: true}
 		ag, err := newPipelineAgent(context.Background(), cfg, fakeLookPath)
 		if err != nil {
@@ -36,7 +36,7 @@ func TestNewPipelineAgent_OptOut_AdmitsVerifiedHarness(t *testing.T) {
 // verified neutralization knob is refused rather than launched with project
 // instructions loaded.
 func TestNewPipelineAgent_OptOut_RefusesUnverifiedHarness(t *testing.T) {
-	for _, name := range []types.AgentName{types.AgentOpenCode, types.AgentPi, types.AgentCopilot} {
+	for _, name := range []types.AgentName{types.AgentOpenCode, types.AgentCopilot} {
 		cfg := &config.Config{Agent: name, DisableProjectSettings: true}
 		if _, err := newPipelineAgent(context.Background(), cfg, fakeLookPath); err == nil {
 			t.Fatalf("%s must be refused under opt-out", name)

--- a/internal/pipeline/steps/pr_test.go
+++ b/internal/pipeline/steps/pr_test.go
@@ -54,6 +54,13 @@ func TestPRStep_UpdatesExistingPR(t *testing.T) {
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Env = env
+	reviewStep, err := sctx.DB.InsertStepResult(sctx.Run.ID, types.StepReview)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sctx.DB.UpdateStepStatus(reviewStep.ID, types.StepStatusCompleted); err != nil {
+		t.Fatal(err)
+	}
 
 	step := &PRStep{}
 	outcome, err := step.Execute(sctx)
@@ -75,6 +82,9 @@ func TestPRStep_UpdatesExistingPR(t *testing.T) {
 	}
 	if !strings.Contains(ghLog, "--body") {
 		t.Errorf("expected --body flag in gh pr edit, got:\n%s", ghLog)
+	}
+	if !strings.Contains(ghLog, noMistakesPRSignature) {
+		t.Errorf("expected updated PR body to include no-mistakes signature, got:\n%s", ghLog)
 	}
 
 	// Verify PR URL was stored


### PR DESCRIPTION
## Intent

Re-submit the already-validated pi gate neutralization branch through no-mistakes so the existing upstream PR https://github.com/kunchenguid/no-mistakes/pull/586 receives the deterministic ## Pipeline body section required by the 'PR must be raised via no-mistakes' policy check. Tracking issue https://github.com/kunchenguid/no-mistakes/issues/587. Feature already landed: under disable_project_settings, pi gets --no-context-files, implements NeutralizesGateInstructions, admitted with codex/claude; review hardenings for argv ordering and option-value pin safety included. Do not redesign.

## What Changed
- Pass Pi's `--no-context-files` flag when trusted `disable_project_settings` is enabled and report verified gate-instruction neutralization.
- Order suppression before user arguments while preserving pinned flag spellings and option values.
- Expand agent and daemon coverage and document Pi opt-out behavior.

## Risk Assessment

✅ Low: The change is well-bounded, satisfies the source-verifiable Pi neutralization and argv-safety criteria, and leaves only the deferred pipeline-owned PR body update.

## Testing

No separate baseline output was supplied; targeted agent, daemon, and PR-step tests passed, a fake Pi invocation confirmed `--no-context-files` is first without corrupting option values, and rendered markdown confirmed the deterministic `## Pipeline` section used by the existing-PR update path. Actual PR mutation remains owned by the outer PR phase.

<details>
<summary>Evidence: Captured Pi CLI invocation</summary>

<code>Captured fake Pi CLI invocation under disable_project_settings=true:&#10;pi --no-context-files --provider google --mode json --no-session</code>

```text
Captured fake Pi CLI invocation under disable_project_settings=true:
pi --no-context-files --provider google --mode json --no-session
Expected: suppression flag is first, provider value remains paired, managed JSON flags follow.
```
</details>
<details>
<summary>Evidence: Deterministic Pipeline PR body section</summary>

<code>## Pipeline&#10;&#10;Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)&#10;&#10;&lt;details&gt;&#10;&lt;summary&gt;✅ **Review** - passed&lt;/summary&gt;&#10;&#10;✅ No issues found.&#10;&#10;&lt;/details&gt;&#10;&#10;&lt;details&gt;&#10;&lt;summary&gt;✅ **Test** - passed&lt;/summary&gt;&#10;&#10;✅ No issues found.&#10;&#10;&lt;/details&gt;</code>

```text
## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.

</details>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/agent -run '^(TestPiAgent_BuildArgs_OptOutAddsNoContextFiles|TestPiAgent_BuildArgs_OptOutDoesNotDuplicateNoContextFiles|TestPiAgent_BuildArgs_OptOutPreservesNoContextFilesOptionValue|TestPiAgent_NeutralizesGateInstructions|TestPiAgent_RunOptOutPassesNoContextFilesToCLI|TestNeutralizesGateInstructions_OnlyVerifiedHarnessesUnderOptOut|TestNeutralizesGateInstructions_FalseWithoutOptOut|TestEnsureGateNeutralized_RefusesUnsupportedUnderOptOut|TestNeutralizesGateInstructions_ThroughProductionWrapping|TestNeutralizesGateInstructions_HonestOnEffectiveOverride)$' -v`
- `go test ./internal/daemon -run '^(TestNewPipelineAgent_OptOut_AdmitsVerifiedHarness|TestNewPipelineAgent_OptOut_RefusesUnverifiedHarness|TestNewPipelineAgent_NoOptOut_AdmitsEveryHarness|TestNewPipelineAgent_OptOut_RefusesDefeatedKnob|TestNewPipelineAgent_OptOut_FallbackRefusesAnyUnverifiedMember)$' -v`
- `go test ./internal/pipeline/steps -run '^(TestPRStep_UpdatesExistingPR|TestAppendGeneratedSections_StripsAgentGeneratedSections|TestBuildPipelineSummary_AllClean)$' -v`
- <code>Generated `pipeline-body.md` through an ephemeral harness calling the production `BuildPipelineSummary`; removed the harness afterward and confirmed the worktree remained clean.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
