### PR TITLE
fix(scm): resolve GitHub targets for local fetch origins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,10 +16,11 @@ Safest local verification sequence after non-trivial changes:
 
 **Fork Routing**
 
-- `repos.upstream_url` is the parent repository used for PR base routing; `repos.fork_url` is an optional GitHub fork push target.
+- `repos.upstream_url` is the fetch/default-branch authority and, for normal GitHub fork routing, the parent repository used for PR base routing; `repos.fork_url` is an optional GitHub fork or authenticated push target.
 - `no-mistakes init --fork-url <url>` expects `origin` to point at the GitHub parent repository and `<url>` at the contributor fork; plain `no-mistakes init` preserves an existing fork URL on idempotent refresh.
 - Push and CI auto-fix push code must resolve the push URL via `resolvePushURL` (`internal/pipeline/steps/common_git.go`) so configured forks still receive branch updates; the non-fork path recovers the credentialled upstream from the worktree's `origin` remote at run time because the DB `upstream_url` is stored redacted (see Credential Redaction below). `Repo.PushURL()` remains correct only for fork-only callers (e.g. `rebase.go`), since fork URLs carry no embedded credentials.
-- GitHub PR code must keep `--repo` pointed at the parent and use `--head <fork_owner>:<branch>` when `fork_url` is set; existing-PR lookup must list by the bare branch and filter head-owner fields, never pass `<owner>:<branch>` to `gh pr list --head`.
+- For normal GitHub parent/fork routing, PR code must keep `--repo` pointed at the parent and use `--head <fork_owner>:<branch>` when `fork_url` is set; existing-PR lookup must list by the bare branch and filter head-owner fields, never pass `<owner>:<branch>` to `gh pr list --head`.
+- When `upstream_url` is a local filesystem fetch origin and `fork_url` is the authenticated GitHub push target, provider and GitHub PR host resolution must fall back to that push target without rewriting the preserved local origin.
 - GitLab and Bitbucket fork MR/PR routing is intentionally out of scope until implemented end to end; if a legacy row has `fork_url` for those hosts, PR creation must skip instead of opening a self PR.
 - Every new run best-effort refreshes registered upstream/fork URLs from the working clone through `gate.RefreshRepoURLs`: origin is the upstream authority, an existing fork requires one uniquely matching clone remote, both DB fields replace atomically, and every discovery/validation/write failure logs only a bounded reason and continues with the exact old registration. The refresh never rewrites clone or gate remotes; `Repo.URLsVerified` is run-scoped evidence that trusted fetch/push may use the refreshed DB URL instead of an inherited stale gate origin.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Safest local verification sequence after non-trivial changes:
 - When `upstream_url` is a local filesystem fetch origin and `fork_url` is the authenticated GitHub push target, provider and GitHub PR host resolution must fall back to that push target without rewriting the preserved local origin.
 - GitLab and Bitbucket fork MR/PR routing is intentionally out of scope until implemented end to end; if a legacy row has `fork_url` for those hosts, PR creation must skip instead of opening a self PR.
 - Every new run best-effort refreshes registered upstream/fork URLs from the working clone through `gate.RefreshRepoURLs`: origin is the upstream authority, an existing fork requires one uniquely matching clone remote, both DB fields replace atomically, and every discovery/validation/write failure logs only a bounded reason and continues with the exact old registration. The refresh never rewrites clone or gate remotes; `Repo.URLsVerified` is run-scoped evidence that trusted fetch/push may use the refreshed DB URL instead of an inherited stale gate origin.
+- Regressions: `TestPRStep_LocalFetchOriginCreatesGitHubTargetPR`, `TestPRStep_UnknownNonLocalOriginDoesNotUseGitHubPushTarget`, `TestDetectProvider_LocalFilesystemRemoteWithProviderMarker`.
 
 **Credential Redaction in Stored URLs and Errors (security)**
 

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -210,6 +210,7 @@ Stores the PR URL in the database and streams it to the TUI.
 Monitors PR health after creation and auto-fixes CI failures. Mergeability polling and merge-conflict handling now apply to GitHub, GitLab, and Azure DevOps.
 
 **Active for GitHub, GitLab, Bitbucket Cloud (`bitbucket.org`), and Azure DevOps (`dev.azure.com` / `*.visualstudio.com`)**.
+Provider detection uses the same PR target URL as the PR step, so a local filesystem fetch origin with a configured GitHub push target is monitored through GitHub.
 
 - GitHub requires `gh` CLI, installed and authenticated.
 - GitLab requires `glab` CLI, installed and authenticated.

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -181,7 +181,7 @@ Creates or updates a pull request.
 
 **Skipped when:**
 - The branch is the default branch
-- The upstream host is not GitHub, GitLab, Bitbucket Cloud (`bitbucket.org`), or Azure DevOps (`dev.azure.com` / `*.visualstudio.com`)
+- The detected PR target host is not GitHub, GitLab, Bitbucket Cloud (`bitbucket.org`), or Azure DevOps (`dev.azure.com` / `*.visualstudio.com`)
 - The provider CLI (`gh` or `glab`) is not installed for GitHub or GitLab
 - The provider CLI is not authenticated for GitHub or GitLab
 - Bitbucket Cloud credentials are missing (`NO_MISTAKES_BITBUCKET_EMAIL` or `NO_MISTAKES_BITBUCKET_API_TOKEN`)
@@ -192,7 +192,8 @@ Creates or updates a pull request.
 - Checks for an existing PR on the branch
 - If one exists, updates it. If not, creates a new one.
 - Uses the provider CLI for GitHub/GitLab, the `az` CLI for Azure DevOps, and the Bitbucket API for Bitbucket Cloud
-- For GitHub fork routing, keeps `gh --repo` pointed at the parent repository from `origin`, checks existing PRs with the bare branch name, filters matching PRs by head owner, and creates PRs with `--head <fork-owner>:<branch>`
+- For GitHub fork routing with a GitHub parent `origin`, keeps `gh --repo` pointed at the parent repository, checks existing PRs with the bare branch name, filters matching PRs by head owner, and creates PRs with `--head <fork-owner>:<branch>`
+- If the fetch origin is a local filesystem remote and the configured push target is GitHub, uses that GitHub target for provider detection and `gh --repo` while preserving the local origin remote
 - PR title: agent-generated with user intent when available, in conventional commit format (`type(scope): description` or `type: description`); user-facing product impact should use `feat` or `fix` so release automation can pick it up; when a scope is used, it should be the primary affected real module/package from the changed paths and kept broad rather than file-level
 - PR body includes a `## Intent` section when user intent is available, an agent-authored `## What Changed`, and regenerated `## Risk Assessment`, `## Testing`, and `## Pipeline` sections from recorded step results and rounds; auto-fix results in `## Pipeline` render as an issue -> fix -> verification narrative using captured fix summaries, re-check success text, and any still-open findings
 - Generated PR bodies are capped at 63,488 bytes, leaving a 2 KB safety buffer below GitHub's 65,536-character body limit.

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -60,7 +60,7 @@ func (s *CIStep) ReconcileApprovalGate(sctx *pipeline.StepContext) (bool, error)
 	if err := sctx.Ctx.Err(); err != nil {
 		return false, err
 	}
-	provider := scm.DetectProviderContext(sctx.Ctx, sctx.Repo.UpstreamURL)
+	provider := scm.DetectProviderContext(sctx.Ctx, providerURL(sctx))
 	if provider == scm.ProviderUnknown && sctx.Run.PRURL != nil {
 		provider = scm.DetectProviderContext(sctx.Ctx, *sctx.Run.PRURL)
 	}
@@ -129,7 +129,7 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	provider := scm.DetectProviderContext(ctx, sctx.Repo.UpstreamURL)
+	provider := scm.DetectProviderContext(ctx, providerURL(sctx))
 	if provider == scm.ProviderUnknown && sctx.Run.PRURL != nil {
 		provider = scm.DetectProviderContext(ctx, *sctx.Run.PRURL)
 	}

--- a/internal/pipeline/steps/host.go
+++ b/internal/pipeline/steps/host.go
@@ -17,6 +17,9 @@ func providerURL(sctx *pipeline.StepContext) string {
 	if scm.DetectProviderContext(sctx.Ctx, sctx.Repo.UpstreamURL) != scm.ProviderUnknown {
 		return sctx.Repo.UpstreamURL
 	}
+	if !scm.IsLocalFilesystemRemote(sctx.Repo.UpstreamURL) {
+		return sctx.Repo.UpstreamURL
+	}
 	return sctx.Repo.PushURL()
 }
 

--- a/internal/pipeline/steps/host.go
+++ b/internal/pipeline/steps/host.go
@@ -13,10 +13,6 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/scm/gitlab"
 )
 
-// buildHost returns a scm.Host for the given provider, wired to sctx's
-// working directory and environment. When the host cannot be constructed
-// (unknown provider, missing Bitbucket config, etc) it returns nil and a
-// human-readable skip reason suitable for logging.
 func providerURL(sctx *pipeline.StepContext) string {
 	if scm.DetectProviderContext(sctx.Ctx, sctx.Repo.UpstreamURL) != scm.ProviderUnknown {
 		return sctx.Repo.UpstreamURL
@@ -24,6 +20,12 @@ func providerURL(sctx *pipeline.StepContext) string {
 	return sctx.Repo.PushURL()
 }
 
+// buildHost returns a scm.Host for the given provider, wired to sctx's working
+// directory and environment. If the fetch origin is local and the configured
+// push target is provider-backed, GitHub host resolution uses that push target
+// without rewriting the preserved fetch origin. When the host cannot be
+// constructed (unknown provider, missing Bitbucket config, etc) it returns nil
+// and a human-readable skip reason suitable for logging.
 func buildHost(sctx *pipeline.StepContext, provider scm.Provider) (scm.Host, string) {
 	cmdFactory := func(_ context.Context, name string, args ...string) *exec.Cmd {
 		return stepCmd(sctx, name, args...)

--- a/internal/pipeline/steps/host.go
+++ b/internal/pipeline/steps/host.go
@@ -17,6 +17,13 @@ import (
 // working directory and environment. When the host cannot be constructed
 // (unknown provider, missing Bitbucket config, etc) it returns nil and a
 // human-readable skip reason suitable for logging.
+func providerURL(sctx *pipeline.StepContext) string {
+	if scm.DetectProviderContext(sctx.Ctx, sctx.Repo.UpstreamURL) != scm.ProviderUnknown {
+		return sctx.Repo.UpstreamURL
+	}
+	return sctx.Repo.PushURL()
+}
+
 func buildHost(sctx *pipeline.StepContext, provider scm.Provider) (scm.Host, string) {
 	cmdFactory := func(_ context.Context, name string, args ...string) *exec.Cmd {
 		return stepCmd(sctx, name, args...)
@@ -30,8 +37,9 @@ func buildHost(sctx *pipeline.StepContext, provider scm.Provider) (scm.Host, str
 		// the upstream remote URL is unavailable. The hostname also scopes
 		// the auth-status check so a stale token on any other configured gh
 		// host cannot make this repo look unauthenticated.
-		host := scm.ResolveHost(sctx.Ctx, sctx.Repo.UpstreamURL)
-		repo := github.HostPrefixedSlugForHost(sctx.Repo.UpstreamURL, host)
+		targetURL := providerURL(sctx)
+		host := scm.ResolveHost(sctx.Ctx, targetURL)
+		repo := github.HostPrefixedSlugForHost(targetURL, host)
 		if repo == "" && sctx.Run.PRURL != nil {
 			prHost := scm.ResolveHost(sctx.Ctx, *sctx.Run.PRURL)
 			repo = github.HostPrefixedSlugForHost(*sctx.Run.PRURL, prHost)
@@ -40,7 +48,7 @@ func buildHost(sctx *pipeline.StepContext, provider scm.Provider) (scm.Host, str
 			}
 		}
 		forkRepo := ""
-		if sctx.Repo.ForkURL != "" {
+		if sctx.Repo.ForkURL != "" && targetURL == sctx.Repo.UpstreamURL {
 			// forkRepo is only used to extract the fork owner for --head owner:branch;
 			// the plain slug (without host prefix) is correct here.
 			forkRepo = github.RepoSlug(sctx.Repo.ForkURL)

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -64,7 +64,7 @@ func (s *PRStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 		sctx.Log(fmt.Sprintf("skipping PR creation on default branch %s", branch))
 		return &pipeline.StepOutcome{Skipped: true}, nil
 	}
-	provider := scm.DetectProviderContext(ctx, sctx.Repo.UpstreamURL)
+	provider := scm.DetectProviderContext(ctx, providerURL(sctx))
 	host, skipReason := buildHost(sctx, provider)
 	if host == nil {
 		sctx.Log(fmt.Sprintf("skipping PR creation: %s", skipReason))

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -229,7 +229,7 @@ func (s *PRStep) buildPipelineSection(sctx *pipeline.StepContext) (string, strin
 	}
 
 	pipelineMD, riskLine := BuildPipelineSummary(steps, rounds)
-	testingMD := BuildTestingSummaryForPR(steps, rounds, sctx.Repo.UpstreamURL, sctx.Run.HeadSHA, sctx.WorkDir)
+	testingMD := BuildTestingSummaryForPR(steps, rounds, providerURL(sctx), sctx.Run.HeadSHA, sctx.WorkDir)
 	return pipelineMD, riskLine, testingMD
 }
 

--- a/internal/pipeline/steps/pr_test.go
+++ b/internal/pipeline/steps/pr_test.go
@@ -349,6 +349,31 @@ func TestPRStep_LocalFetchOriginCreatesGitHubTargetPR(t *testing.T) {
 	}
 }
 
+func TestPRStep_UnknownNonLocalOriginDoesNotUseGitHubPushTarget(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	env, logFile := fakeGH(t, "")
+	sctx := newTestContextWithDBRecords(t, &mockAgent{name: "test"}, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Repo.UpstreamURL = "https://code.example.com/org/repo.git"
+	sctx.Repo.ForkURL = "https://github.com/RooseveltAdvisors/firstmate.git"
+
+	outcome, err := (&PRStep{}).Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome == nil || !outcome.Skipped {
+		t.Fatalf("expected PR step to skip unknown non-local upstream, got %#v", outcome)
+	}
+	logData, err := os.ReadFile(logFile)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(logData), "pr create") {
+		t.Fatalf("expected unknown non-local upstream to avoid GitHub PR creation, got:\n%s", logData)
+	}
+}
+
 func TestPRStep_GitHubForkCreatesParentPRWithForkHead(t *testing.T) {
 	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)

--- a/internal/pipeline/steps/pr_test.go
+++ b/internal/pipeline/steps/pr_test.go
@@ -299,6 +299,35 @@ func TestPRStep_CreatesNewPR(t *testing.T) {
 	}
 }
 
+func TestPRStep_LocalFetchOriginCreatesGitHubTargetPR(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	env, logFile := fakeGH(t, "")
+	sctx := newTestContextWithDBRecords(t, &mockAgent{name: "test"}, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Repo.UpstreamURL = dir
+	sctx.Repo.ForkURL = "https://github.com/RooseveltAdvisors/firstmate.git"
+	sctx.Run.Branch = "refs/heads/feature"
+	if got := resolvePushURL(sctx); got != sctx.Repo.ForkURL {
+		t.Fatalf("push target = %q, want %q", got, sctx.Repo.ForkURL)
+	}
+
+	if _, err := (&PRStep{}).Execute(sctx); err != nil {
+		t.Fatal(err)
+	}
+	logData, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ghLog := string(logData)
+	if !strings.Contains(ghLog, "pr create --head feature --base main --repo RooseveltAdvisors/firstmate") {
+		t.Fatalf("expected canonical PR against the GitHub push target, got:\n%s", ghLog)
+	}
+	if !strings.Contains(ghLog, "## What Changed") {
+		t.Fatalf("expected canonical generated PR body, got:\n%s", ghLog)
+	}
+}
+
 func TestPRStep_GitHubForkCreatesParentPRWithForkHead(t *testing.T) {
 	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)

--- a/internal/pipeline/steps/pr_test.go
+++ b/internal/pipeline/steps/pr_test.go
@@ -305,7 +305,7 @@ func TestPRStep_LocalFetchOriginCreatesGitHubTargetPR(t *testing.T) {
 	env, logFile := fakeGH(t, "")
 	sctx := newTestContextWithDBRecords(t, &mockAgent{name: "test"}, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Env = env
-	sctx.Repo.UpstreamURL = dir
+	sctx.Repo.UpstreamURL = filepath.Join(t.TempDir(), "github.com", "mirror.git")
 	sctx.Repo.ForkURL = "https://github.com/RooseveltAdvisors/firstmate.git"
 	sctx.Run.Branch = "refs/heads/feature"
 	if got := resolvePushURL(sctx); got != sctx.Repo.ForkURL {

--- a/internal/pipeline/steps/pr_test.go
+++ b/internal/pipeline/steps/pr_test.go
@@ -311,6 +311,20 @@ func TestPRStep_LocalFetchOriginCreatesGitHubTargetPR(t *testing.T) {
 	if got := resolvePushURL(sctx); got != sctx.Repo.ForkURL {
 		t.Fatalf("push target = %q, want %q", got, sctx.Repo.ForkURL)
 	}
+	testFindings := `{"findings":[],"summary":"","testing_summary":"Evidence was collected.","artifacts":[{"kind":"screenshot","label":"Checkout screenshot","path":"artifacts/checkout.png"}]}`
+	testStep, err := sctx.DB.InsertStepResult(sctx.Run.ID, types.StepTest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sctx.DB.UpdateStepStatus(testStep.ID, types.StepStatusCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if err := sctx.DB.SetStepFindings(testStep.ID, testFindings); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sctx.DB.InsertStepRound(testStep.ID, 1, "initial", &testFindings, nil, 100); err != nil {
+		t.Fatal(err)
+	}
 
 	if _, err := (&PRStep{}).Execute(sctx); err != nil {
 		t.Fatal(err)
@@ -325,6 +339,13 @@ func TestPRStep_LocalFetchOriginCreatesGitHubTargetPR(t *testing.T) {
 	}
 	if !strings.Contains(ghLog, "## What Changed") {
 		t.Fatalf("expected canonical generated PR body, got:\n%s", ghLog)
+	}
+	wantArtifactLink := "https://github.com/RooseveltAdvisors/firstmate/blob/" + headSHA + "/artifacts/checkout.png"
+	if !strings.Contains(ghLog, wantArtifactLink) {
+		t.Fatalf("expected PR body evidence to link to canonical GitHub target %q, got:\n%s", wantArtifactLink, ghLog)
+	}
+	if strings.Contains(ghLog, sctx.Repo.UpstreamURL) {
+		t.Fatalf("expected PR body evidence to avoid local fetch origin %q, got:\n%s", sctx.Repo.UpstreamURL, ghLog)
 	}
 }
 

--- a/internal/scm/scm.go
+++ b/internal/scm/scm.go
@@ -142,7 +142,7 @@ func isLocalFilesystemRemote(remote string) bool {
 		return true
 	case filepath.IsAbs(remote):
 		return true
-	case len(remote) >= 3 && ((remote[0] >= 'a' && remote[0] <= 'z') || (remote[0] >= 'A' && remote[0] <= 'Z')) && remote[1] == ':' && (remote[2] == '/' || remote[2] == '\\'):
+	case len(remote) >= 2 && ((remote[0] >= 'a' && remote[0] <= 'z') || (remote[0] >= 'A' && remote[0] <= 'Z')) && remote[1] == ':':
 		return true
 	case remote == "." || remote == ".." || strings.HasPrefix(remote, "./") || strings.HasPrefix(remote, "../") || strings.HasPrefix(remote, `.\\`) || strings.HasPrefix(remote, `..\\`) || strings.HasPrefix(remote, "~/") || strings.HasPrefix(remote, `~\\`):
 		return true

--- a/internal/scm/scm.go
+++ b/internal/scm/scm.go
@@ -44,7 +44,7 @@ func detectProvider(ctx context.Context, url string, lookup sshHostnameLookup) P
 }
 
 func detectProviderForGOOS(ctx context.Context, url string, lookup sshHostnameLookup, goos string) Provider {
-	if isLocalFilesystemRemote(url, goos) {
+	if isLocalFilesystemRemoteForGOOS(url, goos) {
 		return ProviderUnknown
 	}
 	if provider := detectProviderWithoutSSH(url); provider != ProviderUnknown {
@@ -138,7 +138,11 @@ func isSSHRemote(remote string) bool {
 	return slash < 0 || colon < slash
 }
 
-func isLocalFilesystemRemote(remote, goos string) bool {
+func IsLocalFilesystemRemote(remote string) bool {
+	return isLocalFilesystemRemoteForGOOS(remote, runtime.GOOS)
+}
+
+func isLocalFilesystemRemoteForGOOS(remote, goos string) bool {
 	remote = strings.TrimSpace(remote)
 	lower := strings.ToLower(remote)
 	switch {

--- a/internal/scm/scm.go
+++ b/internal/scm/scm.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -38,7 +39,11 @@ func DetectProviderContext(ctx context.Context, url string) Provider {
 }
 
 func detectProvider(ctx context.Context, url string, lookup sshHostnameLookup) Provider {
-	if isLocalFilesystemRemote(url) {
+	return detectProviderForGOOS(ctx, url, lookup, runtime.GOOS)
+}
+
+func detectProviderForGOOS(ctx context.Context, url string, lookup sshHostnameLookup, goos string) Provider {
+	if isLocalFilesystemRemote(url, goos) {
 		return ProviderUnknown
 	}
 	if provider := detectProviderWithoutSSH(url); provider != ProviderUnknown {
@@ -132,7 +137,7 @@ func isSSHRemote(remote string) bool {
 	return slash < 0 || colon < slash
 }
 
-func isLocalFilesystemRemote(remote string) bool {
+func isLocalFilesystemRemote(remote, goos string) bool {
 	remote = strings.TrimSpace(remote)
 	lower := strings.ToLower(remote)
 	switch {
@@ -142,7 +147,9 @@ func isLocalFilesystemRemote(remote string) bool {
 		return true
 	case filepath.IsAbs(remote):
 		return true
-	case len(remote) >= 2 && ((remote[0] >= 'a' && remote[0] <= 'z') || (remote[0] >= 'A' && remote[0] <= 'Z')) && remote[1] == ':':
+	case len(remote) >= 3 && ((remote[0] >= 'a' && remote[0] <= 'z') || (remote[0] >= 'A' && remote[0] <= 'Z')) && remote[1] == ':' && (remote[2] == '/' || remote[2] == '\\'):
+		return true
+	case goos == "windows" && len(remote) >= 2 && ((remote[0] >= 'a' && remote[0] <= 'z') || (remote[0] >= 'A' && remote[0] <= 'Z')) && remote[1] == ':':
 		return true
 	case remote == "." || remote == ".." || strings.HasPrefix(remote, "./") || strings.HasPrefix(remote, "../") || strings.HasPrefix(remote, `.\\`) || strings.HasPrefix(remote, `..\\`) || strings.HasPrefix(remote, "~/") || strings.HasPrefix(remote, `~\\`):
 		return true

--- a/internal/scm/scm.go
+++ b/internal/scm/scm.go
@@ -38,6 +38,9 @@ func DetectProviderContext(ctx context.Context, url string) Provider {
 }
 
 func detectProvider(ctx context.Context, url string, lookup sshHostnameLookup) Provider {
+	if isLocalFilesystemRemote(url) {
+		return ProviderUnknown
+	}
 	if provider := detectProviderWithoutSSH(url); provider != ProviderUnknown {
 		return provider
 	}
@@ -127,6 +130,26 @@ func isSSHRemote(remote string) bool {
 	}
 	slash := strings.IndexAny(remote, `/\\`)
 	return slash < 0 || colon < slash
+}
+
+func isLocalFilesystemRemote(remote string) bool {
+	remote = strings.TrimSpace(remote)
+	lower := strings.ToLower(remote)
+	switch {
+	case remote == "":
+		return false
+	case strings.HasPrefix(lower, "file://"):
+		return true
+	case filepath.IsAbs(remote):
+		return true
+	case len(remote) >= 3 && ((remote[0] >= 'a' && remote[0] <= 'z') || (remote[0] >= 'A' && remote[0] <= 'Z')) && remote[1] == ':' && (remote[2] == '/' || remote[2] == '\\'):
+		return true
+	case remote == "." || remote == ".." || strings.HasPrefix(remote, "./") || strings.HasPrefix(remote, "../") || strings.HasPrefix(remote, `.\\`) || strings.HasPrefix(remote, `..\\`) || strings.HasPrefix(remote, "~/") || strings.HasPrefix(remote, `~\\`):
+		return true
+	case strings.Contains(remote, "://"):
+		return false
+	}
+	return !isSSHRemote(remote)
 }
 
 func lookupSSHHostname(ctx context.Context, alias string) (string, error) {

--- a/internal/scm/scm.go
+++ b/internal/scm/scm.go
@@ -26,9 +26,10 @@ const (
 
 type sshHostnameLookup func(context.Context, string) (string, error)
 
-// DetectProvider identifies the SCM provider for url. SSH host aliases are
-// resolved through the user's SSH configuration before detection falls back to
-// ProviderUnknown.
+// DetectProvider identifies the SCM provider for url. Local filesystem remotes
+// always resolve to ProviderUnknown, even when their path contains provider-like
+// host text. SSH host aliases are resolved through the user's SSH configuration
+// before detection falls back to ProviderUnknown.
 func DetectProvider(url string) Provider {
 	return DetectProviderContext(context.Background(), url)
 }

--- a/internal/scm/scm_test.go
+++ b/internal/scm/scm_test.go
@@ -42,6 +42,7 @@ func TestDetectProvider_LocalFilesystemRemoteWithProviderMarker(t *testing.T) {
 
 	tests := []string{
 		filepath.Join(t.TempDir(), "github.com", "mirror.git"),
+		`C:github.com\mirror.git`,
 		"../gitlab.com/mirror.git",
 		"file:///tmp/bitbucket.org/mirror.git",
 	}

--- a/internal/scm/scm_test.go
+++ b/internal/scm/scm_test.go
@@ -42,7 +42,7 @@ func TestDetectProvider_LocalFilesystemRemoteWithProviderMarker(t *testing.T) {
 
 	tests := []string{
 		filepath.Join(t.TempDir(), "github.com", "mirror.git"),
-		`C:github.com\mirror.git`,
+		`C:\github.com\mirror.git`,
 		"../gitlab.com/mirror.git",
 		"file:///tmp/bitbucket.org/mirror.git",
 	}
@@ -50,6 +50,16 @@ func TestDetectProvider_LocalFilesystemRemoteWithProviderMarker(t *testing.T) {
 		if got := DetectProvider(remote); got != ProviderUnknown {
 			t.Fatalf("DetectProvider(%q) = %q, want %q", remote, got, ProviderUnknown)
 		}
+	}
+}
+
+func TestDetectProvider_WindowsDriveRelativeRemoteWithProviderMarker(t *testing.T) {
+	t.Setenv("GLAB_CONFIG_DIR", t.TempDir())
+	t.Setenv("GH_CONFIG_DIR", t.TempDir())
+
+	got := detectProviderForGOOS(context.Background(), `C:github.com\mirror.git`, nil, "windows")
+	if got != ProviderUnknown {
+		t.Fatalf("detectProviderForGOOS(windows drive-relative) = %q, want %q", got, ProviderUnknown)
 	}
 }
 
@@ -66,6 +76,12 @@ func TestDetectProvider_SSHHostAlias(t *testing.T) {
 		{
 			name:     "GitHub scp remote",
 			url:      "git@github-personal:owner/repo.git",
+			hostname: "github.com",
+			want:     ProviderGitHub,
+		},
+		{
+			name:     "GitHub single-letter scp alias",
+			url:      "g:owner/repo.git",
 			hostname: "github.com",
 			want:     ProviderGitHub,
 		},

--- a/internal/scm/scm_test.go
+++ b/internal/scm/scm_test.go
@@ -36,6 +36,22 @@ func TestDetectProvider(t *testing.T) {
 	}
 }
 
+func TestDetectProvider_LocalFilesystemRemoteWithProviderMarker(t *testing.T) {
+	t.Setenv("GLAB_CONFIG_DIR", t.TempDir())
+	t.Setenv("GH_CONFIG_DIR", t.TempDir())
+
+	tests := []string{
+		filepath.Join(t.TempDir(), "github.com", "mirror.git"),
+		"../gitlab.com/mirror.git",
+		"file:///tmp/bitbucket.org/mirror.git",
+	}
+	for _, remote := range tests {
+		if got := DetectProvider(remote); got != ProviderUnknown {
+			t.Fatalf("DetectProvider(%q) = %q, want %q", remote, got, ProviderUnknown)
+		}
+	}
+}
+
 func TestDetectProvider_SSHHostAlias(t *testing.T) {
 	t.Setenv("GLAB_CONFIG_DIR", t.TempDir())
 	t.Setenv("GH_CONFIG_DIR", t.TempDir())


### PR DESCRIPTION
## Intent

Fix no-mistakes provider and PR target resolution when the fetch origin is a local filesystem path but the distinct authenticated push and PR target is GitHub. Preserve the local fetch origin and configured push target without rewriting origins, bypassing ownership, weakening checks, or hand-editing PR markers. Ensure push routing still uses the configured target, provider detection falls back to that target, and canonical GitHub PR/body creation targets it; retain existing true parent/fork behavior and add one focused regression.

## What Changed

- Added provider detection fallback so local filesystem fetch origins can resolve GitHub metadata from the configured push target while non-local unknown origins still fail closed.
- Updated PR and CI routing to use the resolved PR target for GitHub PR creation, checks, and evidence links without rewriting the preserved local origin.
- Documented the local-origin GitHub target routing behavior and added focused regressions for local, drive-relative, unknown, and fork routing cases.

## Risk Assessment

✅ Low: The provider fallback is now narrowly gated to local filesystem remotes, the PR body evidence link target follows the resolved PR target, and existing GitHub parent/fork behavior remains covered by focused regressions.

## Testing

Ran the focused SCM/provider and PR-step regressions, then exercised the local-fetch-origin-to-GitHub-push-target path with an evidence-producing temporary test; the generated `gh` transcript confirms PR lookup/create and artifact links target GitHub while the working tree was restored clean afterward.

<details>
<summary>Evidence: GitHub PR target transcript</summary>

<code>auth status --hostname github.com&#10;pr list --head feature --base main --repo RooseveltAdvisors/firstmate --state open --json number,url&#10;pr create --head feature --base main --repo RooseveltAdvisors/firstmate --title feat: add feature --body-file -&#10;stdin --body ## What Changed&#10;&#10;43e1b94 add feature&#10;&#10;## Testing&#10;&#10;Evidence was collected.&#10;&#10;- Evidence: [Checkout screenshot](https://github.com/RooseveltAdvisors/firstmate/blob/43e1b94a7a639beaff4e53b900cdba5ab2defcf3/artifacts/checkout.png)</code>

```text
auth status --hostname github.com
pr list --head feature --base main --repo RooseveltAdvisors/firstmate --state open --json number,url
pr create --head feature --base main --repo RooseveltAdvisors/firstmate --title feat: add feature --body-file -
stdin --body ## What Changed

43e1b94 add feature

## Testing

Evidence was collected.

- Evidence: [Checkout screenshot](https://github.com/RooseveltAdvisors/firstmate/blob/43e1b94a7a639beaff4e53b900cdba5ab2defcf3/artifacts/checkout.png)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.

</details>
```
</details>
<details>
<summary>Evidence: Focused regression test output</summary>

```text
=== RUN   TestDetectProvider_LocalFilesystemRemoteWithProviderMarker
--- PASS: TestDetectProvider_LocalFilesystemRemoteWithProviderMarker (0.00s)
=== RUN   TestDetectProvider_WindowsDriveRelativeRemoteWithProviderMarker
--- PASS: TestDetectProvider_WindowsDriveRelativeRemoteWithProviderMarker (0.00s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/scm	0.002s
=== RUN   TestPRStep_LocalFetchOriginCreatesGitHubTargetPR
=== PAUSE TestPRStep_LocalFetchOriginCreatesGitHubTargetPR
=== RUN   TestPRStep_UnknownNonLocalOriginDoesNotUseGitHubPushTarget
=== PAUSE TestPRStep_UnknownNonLocalOriginDoesNotUseGitHubPushTarget
=== RUN   TestPRStep_GitHubForkCreatesParentPRWithForkHead
=== PAUSE TestPRStep_GitHubForkCreatesParentPRWithForkHead
=== CONT  TestPRStep_LocalFetchOriginCreatesGitHubTargetPR
=== CONT  TestPRStep_UnknownNonLocalOriginDoesNotUseGitHubPushTarget
=== CONT  TestPRStep_GitHubForkCreatesParentPRWithForkHead
--- PASS: TestPRStep_UnknownNonLocalOriginDoesNotUseGitHubPushTarget (0.12s)
--- PASS: TestPRStep_GitHubForkCreatesParentPRWithForkHead (0.12s)
--- PASS: TestPRStep_LocalFetchOriginCreatesGitHubTargetPR (0.13s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/pipeline/steps	0.142s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `internal/pipeline/steps/pr.go:232` - Intent requires: &#34;canonical GitHub PR/body creation targets it&#34;, but PR body testing/evidence rendering still passes `sctx.Repo.UpstreamURL` into `BuildTestingSummaryForPR`. In the local-fetch/GitHub-push case that upstream is a filesystem path, so repo-relative evidence artifacts do not get canonical GitHub blob/raw links for the configured GitHub PR target.

🔧 Fix: Use PR target for evidence links
1 error still open:
- 🚨 `internal/pipeline/steps/host.go:20` - Intent scopes the fallback to &#34;when the fetch origin is a local filesystem path&#34; and forbids &#34;bypassing ownership&#34;, but `providerURL` falls back to `Repo.PushURL()` for every `ProviderUnknown` upstream. A non-local but unrecognized upstream such as `https://code.example.com/org/repo.git` with a configured GitHub push target would now run GitHub PR/CI against the push target instead of skipping or preserving the upstream ownership boundary.

🔧 Fix: Scope provider fallback to local origins
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/scm ./internal/pipeline/steps -run 'TestDetectProvider_LocalFilesystemRemoteWithProviderMarker|TestDetectProvider_WindowsDriveRelativeRemoteWithProviderMarker|TestPRStep_LocalFetchOriginCreatesGitHubTargetPR|TestPRStep_UnknownNonLocalOriginDoesNotUseGitHubPushTarget|TestPRStep_GitHubForkCreatesParentPRWithForkHead' -v`
- `NM_EVIDENCE_DIR=/tmp/no-mistakes-evidence/01KYF92B8A2SPRRDQDHY816V2Y go test ./internal/pipeline/steps -run TestEvidence_LocalFetchOriginTargetsGitHubPushRepo -count=1 -v`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
