### PR TITLE
fix(gate): support local-origin GitHub targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,10 +16,11 @@ Safest local verification sequence after non-trivial changes:
 
 **Fork Routing**
 
-- `repos.upstream_url` is the parent repository used for PR base routing; `repos.fork_url` is an optional GitHub fork push target.
+- `repos.upstream_url` is the fetch/default-branch authority and, for normal GitHub fork routing, the parent repository used for PR base routing; `repos.fork_url` is an optional GitHub fork or authenticated push target.
 - `no-mistakes init --fork-url <url>` expects `origin` to point at the GitHub parent repository and `<url>` at the contributor fork; plain `no-mistakes init` preserves an existing fork URL on idempotent refresh.
 - Push and CI auto-fix push code must resolve the push URL via `resolvePushURL` (`internal/pipeline/steps/common_git.go`) so configured forks still receive branch updates; the non-fork path recovers the credentialled upstream from the worktree's `origin` remote at run time because the DB `upstream_url` is stored redacted (see Credential Redaction below). `Repo.PushURL()` remains correct only for fork-only callers (e.g. `rebase.go`), since fork URLs carry no embedded credentials.
-- GitHub PR code must keep `--repo` pointed at the parent and use `--head <fork_owner>:<branch>` when `fork_url` is set; existing-PR lookup must list by the bare branch and filter head-owner fields, never pass `<owner>:<branch>` to `gh pr list --head`.
+- For normal GitHub parent/fork routing, PR code must keep `--repo` pointed at the parent and use `--head <fork_owner>:<branch>` when `fork_url` is set; existing-PR lookup must list by the bare branch and filter head-owner fields, never pass `<owner>:<branch>` to `gh pr list --head`.
+- When `upstream_url` is a local filesystem fetch origin and `fork_url` is the authenticated GitHub push target, provider and GitHub PR host resolution must fall back to that push target without rewriting the preserved local origin.
 - GitLab and Bitbucket fork MR/PR routing is intentionally out of scope until implemented end to end; if a legacy row has `fork_url` for those hosts, PR creation must skip instead of opening a self PR.
 - Every new run best-effort refreshes registered upstream/fork URLs from the working clone through `gate.RefreshRepoURLs`: origin is the upstream authority, an existing fork requires one uniquely matching clone remote, both DB fields replace atomically, and every discovery/validation/write failure logs only a bounded reason and continues with the exact old registration. The refresh never rewrites clone or gate remotes; `Repo.URLsVerified` is run-scoped evidence that trusted fetch/push may use the refreshed DB URL instead of an inherited stale gate origin.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Safest local verification sequence after non-trivial changes:
 - When `upstream_url` is a local filesystem fetch origin and `fork_url` is the authenticated GitHub push target, provider and GitHub PR host resolution must fall back to that push target without rewriting the preserved local origin.
 - GitLab and Bitbucket fork MR/PR routing is intentionally out of scope until implemented end to end; if a legacy row has `fork_url` for those hosts, PR creation must skip instead of opening a self PR.
 - Every new run best-effort refreshes registered upstream/fork URLs from the working clone through `gate.RefreshRepoURLs`: origin is the upstream authority, an existing fork requires one uniquely matching clone remote, both DB fields replace atomically, and every discovery/validation/write failure logs only a bounded reason and continues with the exact old registration. The refresh never rewrites clone or gate remotes; `Repo.URLsVerified` is run-scoped evidence that trusted fetch/push may use the refreshed DB URL instead of an inherited stale gate origin.
+- Regressions: `TestPRStep_LocalFetchOriginCreatesGitHubTargetPR`, `TestPRStep_UnknownNonLocalOriginDoesNotUseGitHubPushTarget`, `TestDetectProvider_LocalFilesystemRemoteWithProviderMarker`.
 
 **Credential Redaction in Stored URLs and Errors (security)**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Safest local verification sequence after non-trivial changes:
 **Fork Routing**
 
 - `repos.upstream_url` is the fetch/default-branch authority and, for normal GitHub fork routing, the parent repository used for PR base routing; `repos.fork_url` is an optional GitHub fork or authenticated push target.
-- `no-mistakes init --fork-url <url>` expects `origin` to point at the GitHub parent repository and `<url>` at the contributor fork; plain `no-mistakes init` preserves an existing fork URL on idempotent refresh.
+- For normal GitHub fork routing, `no-mistakes init --fork-url <url>` expects `origin` to point at the GitHub parent repository and `<url>` at the contributor fork; plain `no-mistakes init` preserves an existing fork URL on idempotent refresh.
 - Push and CI auto-fix push code must resolve the push URL via `resolvePushURL` (`internal/pipeline/steps/common_git.go`) so configured forks still receive branch updates; the non-fork path recovers the credentialled upstream from the worktree's `origin` remote at run time because the DB `upstream_url` is stored redacted (see Credential Redaction below). `Repo.PushURL()` remains correct only for fork-only callers (e.g. `rebase.go`), since fork URLs carry no embedded credentials.
 - For normal GitHub parent/fork routing, PR code must keep `--repo` pointed at the parent and use `--head <fork_owner>:<branch>` when `fork_url` is set; existing-PR lookup must list by the bare branch and filter head-owner fields, never pass `<owner>:<branch>` to `gh pr list --head`.
 - When `upstream_url` is a local filesystem fetch origin and `fork_url` is the authenticated GitHub push target, provider and GitHub PR host resolution must fall back to that push target without rewriting the preserved local origin.

--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -36,7 +36,7 @@ When you run `no-mistakes init` in a repo:
 3. It enables Git push options for the gate repo.
 4. It best-effort isolates the gate repo's hooks path from shared local Git config writes when Git supports `config --worktree`.
 5. It adds a `no-mistakes` remote to your working repo that points at the gate.
-6. When `--fork-url` is supplied, it records that GitHub fork as the branch push target while keeping `origin` as the parent repository used for PR bases.
+6. When `--fork-url` is supplied, it records that GitHub URL as the branch push target while keeping `origin` as the fetch/default-branch authority. With a GitHub parent `origin`, PRs are based on the parent; with a local filesystem `origin`, PR and CI routing use the GitHub target.
 7. It installs or refreshes the `/no-mistakes` agent skill at user level, into `~/.claude/skills/no-mistakes/SKILL.md` and `~/.agents/skills/no-mistakes/SKILL.md`, on a best-effort basis, following existing symlinks between the home `.claude` and `.agents` skill directories. It writes no skill files into the repo; if the repo still carries a vendored copy from an older version, `init` prints a notice that the copy can be removed.
 8. It makes sure the daemon is running so incoming pushes can start runs.
 
@@ -47,7 +47,7 @@ If the working repo was copied and the original path still exists, `init` treats
 If daemon startup fails during a refresh, `init` reports the error but does not eject the pre-existing gate.
 
 After init, your original `origin` still points at the real upstream remote.
-With `--fork-url`, that `origin` should be the parent repository, and the fork URL is stored separately for branch pushes.
+With `--fork-url`, that `origin` should be either the GitHub parent repository or a local filesystem fetch origin, and the GitHub URL is stored separately for branch pushes.
 That is a core design choice, not an implementation detail.
 
 ## How a push flows
@@ -63,7 +63,7 @@ That is a core design choice, not an implementation detail.
    AXI run objects show `awaiting_agent: parked <duration>` while a non-terminal run is parked at that gate, so a supervising agent can distinguish a waiting run from active work in one status read.
    While a step is actively running or fixing, AXI run objects can also show `active_steps` with the active duration, latest activity, native agent PID, and current execution or fix round.
 8. After local checks pass, the push step forwards the branch to the configured push target only after verifying that the update will not discard unincorporated commits already on that target, and the PR step creates or updates the pull request.
-   For GitHub fork routing, the push target is the fork and the PR base repository is the parent from `origin`.
+   For GitHub parent/fork routing, the push target is the fork and the PR base repository is the parent from `origin`; for local-origin GitHub routing, the GitHub push target is also the PR target.
 9. The CI step keeps watching the open PR until it is merged, closed, or its configured idle timeout elapses with no base-branch movement, and can auto-fix failures or merge conflicts when supported.
    While it watches, the TUI and terminal title surface a `Checks passed` signal once checks are green and the PR is mergeable, and `no-mistakes axi` returns `outcome: checks-passed` with instructions to summarize the run and list any pipeline fixes, so agents stop and ask you to review and merge it.
 
@@ -186,7 +186,7 @@ Legacy `user_fix` rounds are still read as `auto-fix` for backward compatibility
 Run records also store the nullable `awaiting_agent_since` timestamp used only to render the AXI parked signal while a gate is waiting for the driving agent, plus accumulated `parked_ms` for local performance reporting.
 Each agent invocation records local-only purpose, provider/model metadata, session mode and a truncated session-identity hash, timing, failure category, and token usage; prompts, outputs, diffs, and credentials are never stored there.
 Use `no-mistakes stats --agents` for aggregates or `no-mistakes stats --run <id>` for a run timeline and parked time.
-Repo records store the parent `upstream_url` and an optional `fork_url`; branch pushes use `fork_url` when present, while PR and CI provider context stays anchored to the parent.
+Repo records store the `upstream_url` fetch/default-branch authority and an optional `fork_url`; branch pushes use `fork_url` when present, while PR and CI provider context stays anchored to the GitHub parent for normal fork routing or to the GitHub target for local-origin routing.
 At the start of each run, no-mistakes best-effort refreshes those URLs from the working clone without changing any clone or gate remote.
 `origin` is the upstream authority, and an existing fork registration is refreshed only when exactly one other clone remote identifies the same fork repository.
 The two registered URLs are replaced atomically after validation; an unreadable, invalid, credential-bearing, or ambiguous remote, or a database failure, leaves the exact prior registration in place and does not stop the run.

--- a/docs/src/content/docs/guides/provider-integration.md
+++ b/docs/src/content/docs/guides/provider-integration.md
@@ -87,7 +87,8 @@ With this setup, the push and CI auto-fix push steps update the fork, while the 
 The GitHub PR step opens PRs with a fork-qualified head such as `your-user:feature-branch`.
 Re-running `no-mistakes init` later preserves the stored fork URL unless you pass a new `--fork-url`.
 
-Fork routing currently requires both `origin` and `--fork-url` to be GitHub remotes with owner/repo paths.
+When `origin` is a local filesystem remote, `--fork-url` may instead be a canonical GitHub repository URL. no-mistakes keeps the local fetch origin and uses the GitHub target for branch pushes, PR creation, and CI monitoring.
+Fork routing currently requires `--fork-url` to be a GitHub remote with an owner/repo path, and `origin` must be either a GitHub parent remote with an owner/repo path or a local filesystem remote.
 GitLab and Bitbucket fork MR/PR routing are not implemented yet; if a legacy or manually edited repo record has `fork_url` set for those providers, PR creation skips instead of opening an unsafe self PR.
 
 ## GitLab

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -34,7 +34,7 @@ no-mistakes init --fork-url git@github.com:you/my-repo.git
 
 | Flag         | Type     | Default | Description                                                                   |
 | ------------ | -------- | ------- | ----------------------------------------------------------------------------- |
-| `--fork-url` | `string` | (none)  | GitHub fork remote URL to push branches to while opening PRs against `origin` |
+| `--fork-url` | `string` | (none)  | GitHub push target URL used for fork routing or local-origin GitHub PR routing |
 
 Creates or refreshes a local bare repo, installs the managed pre-receive admission and post-receive notification hooks, best-effort isolates the gate repo's hook path from shared git config changes when Git supports `config --worktree`, adds or repairs the `no-mistakes` git remote, detects the default branch, records or updates the repo in SQLite, installs the `/no-mistakes` agent skill at user level into `~/.claude/skills/no-mistakes/SKILL.md` and `~/.agents/skills/no-mistakes/SKILL.md`, and ensures the daemon is running, installing the managed service when available and falling back to a detached daemon otherwise.
 `init` writes no skill files into the repo; the user-level copies cover every supported agent (`~/.claude/skills` for Claude Code, `~/.agents/skills` for Codex, OpenCode, Rovo Dev, and Pi) across all repos.
@@ -44,7 +44,8 @@ The gate advertises Git push-option support, so you can skip steps for one push 
 
 For GitHub fork contributions, keep `origin` pointed at the parent repository and pass `--fork-url` with your fork remote URL.
 The push, rebase branch-sync, and CI auto-fix pushes use the fork, while GitHub PR and CI commands stay scoped to the parent repository and create PRs with `--head <fork-owner>:<branch>`.
-Fork routing currently requires both `origin` and `--fork-url` to be GitHub remotes with owner/repo paths.
+When `origin` is a local filesystem remote, `--fork-url` may instead be a canonical GitHub repository URL; no-mistakes preserves the local fetch origin and uses the GitHub target for push, PR, and CI provider routing.
+Fork routing currently requires `--fork-url` to be a GitHub remote with an owner/repo path, and `origin` must be either a GitHub parent remote with an owner/repo path or a local filesystem remote.
 
 Re-running `init` on an already-initialized repo succeeds and reports `Gate already initialized (refreshed)`.
 It refreshes managed gate wiring, origin/default-branch metadata, hook-path isolation, and the installed agent skill, overwriting any stale `SKILL.md` content from an older binary.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -25,7 +25,7 @@ Valid step names are `intent`, `rebase`, `review`, `test`, `document`, `lint`, `
 
 Initialize or refresh the gate for the current repository.
 
-`init` requires an `origin` remote to identify the upstream repository: later pipeline steps push validated branches to the configured target and open pull requests against that upstream. If `origin` is missing, add it with `git remote add origin <url>`, replacing `<url>` with the upstream repository's URL, then re-run `init`.
+`init` requires an `origin` remote to identify the fetch/default-branch authority: later pipeline steps push validated branches to the configured target and open pull requests against the provider-backed PR target. If `origin` is missing, add it with `git remote add origin <url>`, replacing `<url>` with the upstream repository's URL, then re-run `init`.
 
 ```sh
 no-mistakes init

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -210,6 +210,7 @@ Stores the PR URL in the database and streams it to the TUI.
 Monitors PR health after creation and auto-fixes CI failures. Mergeability polling and merge-conflict handling now apply to GitHub, GitLab, and Azure DevOps.
 
 **Active for GitHub, GitLab, Bitbucket Cloud (`bitbucket.org`), and Azure DevOps (`dev.azure.com` / `*.visualstudio.com`)**.
+Provider detection uses the same PR target URL as the PR step, so a local filesystem fetch origin with a configured GitHub push target is monitored through GitHub.
 
 - GitHub requires `gh` CLI, installed and authenticated.
 - GitLab requires `glab` CLI, installed and authenticated.

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -181,7 +181,7 @@ Creates or updates a pull request.
 
 **Skipped when:**
 - The branch is the default branch
-- The upstream host is not GitHub, GitLab, Bitbucket Cloud (`bitbucket.org`), or Azure DevOps (`dev.azure.com` / `*.visualstudio.com`)
+- The detected PR target host is not GitHub, GitLab, Bitbucket Cloud (`bitbucket.org`), or Azure DevOps (`dev.azure.com` / `*.visualstudio.com`)
 - The provider CLI (`gh` or `glab`) is not installed for GitHub or GitLab
 - The provider CLI is not authenticated for GitHub or GitLab
 - Bitbucket Cloud credentials are missing (`NO_MISTAKES_BITBUCKET_EMAIL` or `NO_MISTAKES_BITBUCKET_API_TOKEN`)
@@ -192,7 +192,8 @@ Creates or updates a pull request.
 - Checks for an existing PR on the branch
 - If one exists, updates it. If not, creates a new one.
 - Uses the provider CLI for GitHub/GitLab, the `az` CLI for Azure DevOps, and the Bitbucket API for Bitbucket Cloud
-- For GitHub fork routing, keeps `gh --repo` pointed at the parent repository from `origin`, checks existing PRs with the bare branch name, filters matching PRs by head owner, and creates PRs with `--head <fork-owner>:<branch>`
+- For GitHub fork routing with a GitHub parent `origin`, keeps `gh --repo` pointed at the parent repository, checks existing PRs with the bare branch name, filters matching PRs by head owner, and creates PRs with `--head <fork-owner>:<branch>`
+- If the fetch origin is a local filesystem remote and the configured push target is GitHub, uses that GitHub target for provider detection and `gh --repo` while preserving the local origin remote
 - PR title: agent-generated with user intent when available, in conventional commit format (`type(scope): description` or `type: description`); user-facing product impact should use `feat` or `fix` so release automation can pick it up; when a scope is used, it should be the primary affected real module/package from the changed paths and kept broad rather than file-level
 - PR body includes a `## Intent` section when user intent is available, an agent-authored `## What Changed`, and regenerated `## Risk Assessment`, `## Testing`, and `## Pipeline` sections from recorded step results and rounds; auto-fix results in `## Pipeline` render as an issue -> fix -> verification narrative using captured fix summaries, re-check success text, and any still-open findings
 - Generated PR bodies are capped at 63,488 bytes, leaving a 2 KB safety buffer below GitHub's 65,536-character body limit.

--- a/docs/src/content/docs/start-here/quick-start.md
+++ b/docs/src/content/docs/start-here/quick-start.md
@@ -65,7 +65,8 @@ $ no-mistakes init
 
 `origin` is unchanged.
 Without fork routing, you can bypass the gate for a specific push with `git push origin <branch>`.
-With `--fork-url`, bypassing the gate means pushing to your fork URL yourself.
+With GitHub parent/fork routing, bypassing the gate means pushing to your fork URL yourself.
+With a local filesystem `origin`, bypassing the gate means pushing to the configured GitHub target yourself.
 
 You can safely re-run `no-mistakes init` later to refresh gate wiring or update the installed agent skill after an upgrade.
 If you rename or move the repo directory, re-run `no-mistakes init` from the new path to reattach the existing gate and keep its run history.

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -90,6 +90,6 @@ func newInitCmd() *cobra.Command {
 			})
 		},
 	}
-	cmd.Flags().StringVar(&forkURL, "fork-url", "", "GitHub fork remote URL to push branches to while opening PRs against origin")
+	cmd.Flags().StringVar(&forkURL, "fork-url", "", "GitHub fork push target, or GitHub push/PR target when origin is a local filesystem path")
 	return cmd
 }

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -46,9 +46,11 @@ func Init(ctx context.Context, d *db.DB, p *paths.Paths, workDir string) (*db.Re
 	return InitWithFork(ctx, d, p, workDir, "")
 }
 
-// InitWithFork is Init plus an optional GitHub fork push URL. The origin remote
-// remains the parent repository used for PRs. When forkURL is empty, an
-// existing fork setting is preserved across idempotent refreshes.
+// InitWithFork is Init plus an optional GitHub push target. The origin remote
+// remains the fetch/default-branch authority; GitHub origins use forkURL as the
+// fork push target, and local filesystem origins use forkURL as the GitHub
+// push/PR target. When forkURL is empty, an existing fork setting is preserved
+// across idempotent refreshes.
 func InitWithFork(ctx context.Context, d *db.DB, p *paths.Paths, workDir, forkURL string) (*db.Repo, bool, error) {
 	if classified, err := (gatecontext.Inspector{DB: d, Paths: p}).Inspect(ctx, gatecontext.Request{CWD: workDir, MarkerPresent: gatecontext.MarkerPresent()}); err != nil {
 		return nil, false, err

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -169,13 +169,19 @@ func InitWithFork(ctx context.Context, d *db.DB, p *paths.Paths, workDir, forkUR
 func validateForkRouting(ctx context.Context, upstreamURL, forkURL string) error {
 	parentProvider := scm.DetectProviderContext(ctx, upstreamURL)
 	forkProvider := scm.DetectProviderContext(ctx, forkURL)
+	if forkProvider == scm.ProviderGitHub && scm.IsLocalFilesystemRemote(upstreamURL) {
+		if github.RepoSlug(forkURL) == "" {
+			return fmt.Errorf("fork URL routing requires a GitHub target with an owner/repo path")
+		}
+		return nil
+	}
 	if parentProvider == scm.ProviderGitHub && forkProvider == scm.ProviderGitHub {
 		if github.RepoSlug(upstreamURL) == "" || github.RepoSlug(forkURL) == "" {
 			return fmt.Errorf("fork URL routing requires GitHub parent and fork remotes with owner/repo paths")
 		}
 		return nil
 	}
-	return fmt.Errorf("fork URL routing is currently supported only for GitHub parent and fork remotes (parent provider: %s, fork provider: %s)", parentProvider, forkProvider)
+	return fmt.Errorf("fork URL routing requires a GitHub parent or local filesystem origin and a GitHub fork target (parent provider: %s, fork provider: %s)", parentProvider, forkProvider)
 }
 
 // provisionGate creates or repairs the on-disk gate for a repo: the bare repo,

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -363,6 +363,32 @@ func TestInitIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestInitWithForkAllowsLocalParentAndGitHubTarget(t *testing.T) {
+	workDir := setupTestRepo(t)
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	d := openTestDB(t, p)
+	ctx := context.Background()
+	origin, err := gitpkg.GetConfiguredRemoteURL(ctx, workDir, "origin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	forkURL := "https://github.com/RooseveltAdvisors/firstmate.git"
+
+	repo, created, err := InitWithFork(ctx, d, p, workDir, forkURL)
+	if err != nil {
+		t.Fatalf("init local parent with GitHub target: %v", err)
+	}
+	if !created || repo.UpstreamURL != origin || repo.ForkURL != forkURL {
+		t.Fatalf("repo = %+v, created = %v", repo, created)
+	}
+	if got, err := gitpkg.GetConfiguredRemoteURL(ctx, workDir, "origin"); err != nil || got != origin {
+		t.Fatalf("origin = %q, %v; want preserved %q", got, err, origin)
+	}
+}
+
 func TestInitWithForkPreservesForkOnPlainReinit(t *testing.T) {
 	workDir := setupTestRepo(t)
 	nmRoot := t.TempDir()

--- a/internal/pipeline/steps/ci.go
+++ b/internal/pipeline/steps/ci.go
@@ -60,7 +60,7 @@ func (s *CIStep) ReconcileApprovalGate(sctx *pipeline.StepContext) (bool, error)
 	if err := sctx.Ctx.Err(); err != nil {
 		return false, err
 	}
-	provider := scm.DetectProviderContext(sctx.Ctx, sctx.Repo.UpstreamURL)
+	provider := scm.DetectProviderContext(sctx.Ctx, providerURL(sctx))
 	if provider == scm.ProviderUnknown && sctx.Run.PRURL != nil {
 		provider = scm.DetectProviderContext(sctx.Ctx, *sctx.Run.PRURL)
 	}
@@ -129,7 +129,7 @@ func (s *CIStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	provider := scm.DetectProviderContext(ctx, sctx.Repo.UpstreamURL)
+	provider := scm.DetectProviderContext(ctx, providerURL(sctx))
 	if provider == scm.ProviderUnknown && sctx.Run.PRURL != nil {
 		provider = scm.DetectProviderContext(ctx, *sctx.Run.PRURL)
 	}

--- a/internal/pipeline/steps/host.go
+++ b/internal/pipeline/steps/host.go
@@ -17,6 +17,9 @@ func providerURL(sctx *pipeline.StepContext) string {
 	if scm.DetectProviderContext(sctx.Ctx, sctx.Repo.UpstreamURL) != scm.ProviderUnknown {
 		return sctx.Repo.UpstreamURL
 	}
+	if !scm.IsLocalFilesystemRemote(sctx.Repo.UpstreamURL) {
+		return sctx.Repo.UpstreamURL
+	}
 	return sctx.Repo.PushURL()
 }
 

--- a/internal/pipeline/steps/host.go
+++ b/internal/pipeline/steps/host.go
@@ -13,10 +13,6 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/scm/gitlab"
 )
 
-// buildHost returns a scm.Host for the given provider, wired to sctx's
-// working directory and environment. When the host cannot be constructed
-// (unknown provider, missing Bitbucket config, etc) it returns nil and a
-// human-readable skip reason suitable for logging.
 func providerURL(sctx *pipeline.StepContext) string {
 	if scm.DetectProviderContext(sctx.Ctx, sctx.Repo.UpstreamURL) != scm.ProviderUnknown {
 		return sctx.Repo.UpstreamURL
@@ -24,6 +20,12 @@ func providerURL(sctx *pipeline.StepContext) string {
 	return sctx.Repo.PushURL()
 }
 
+// buildHost returns a scm.Host for the given provider, wired to sctx's working
+// directory and environment. If the fetch origin is local and the configured
+// push target is provider-backed, GitHub host resolution uses that push target
+// without rewriting the preserved fetch origin. When the host cannot be
+// constructed (unknown provider, missing Bitbucket config, etc) it returns nil
+// and a human-readable skip reason suitable for logging.
 func buildHost(sctx *pipeline.StepContext, provider scm.Provider) (scm.Host, string) {
 	cmdFactory := func(_ context.Context, name string, args ...string) *exec.Cmd {
 		return stepCmd(sctx, name, args...)

--- a/internal/pipeline/steps/host.go
+++ b/internal/pipeline/steps/host.go
@@ -17,6 +17,13 @@ import (
 // working directory and environment. When the host cannot be constructed
 // (unknown provider, missing Bitbucket config, etc) it returns nil and a
 // human-readable skip reason suitable for logging.
+func providerURL(sctx *pipeline.StepContext) string {
+	if scm.DetectProviderContext(sctx.Ctx, sctx.Repo.UpstreamURL) != scm.ProviderUnknown {
+		return sctx.Repo.UpstreamURL
+	}
+	return sctx.Repo.PushURL()
+}
+
 func buildHost(sctx *pipeline.StepContext, provider scm.Provider) (scm.Host, string) {
 	cmdFactory := func(_ context.Context, name string, args ...string) *exec.Cmd {
 		return stepCmd(sctx, name, args...)
@@ -30,8 +37,9 @@ func buildHost(sctx *pipeline.StepContext, provider scm.Provider) (scm.Host, str
 		// the upstream remote URL is unavailable. The hostname also scopes
 		// the auth-status check so a stale token on any other configured gh
 		// host cannot make this repo look unauthenticated.
-		host := scm.ResolveHost(sctx.Ctx, sctx.Repo.UpstreamURL)
-		repo := github.HostPrefixedSlugForHost(sctx.Repo.UpstreamURL, host)
+		targetURL := providerURL(sctx)
+		host := scm.ResolveHost(sctx.Ctx, targetURL)
+		repo := github.HostPrefixedSlugForHost(targetURL, host)
 		if repo == "" && sctx.Run.PRURL != nil {
 			prHost := scm.ResolveHost(sctx.Ctx, *sctx.Run.PRURL)
 			repo = github.HostPrefixedSlugForHost(*sctx.Run.PRURL, prHost)
@@ -40,7 +48,7 @@ func buildHost(sctx *pipeline.StepContext, provider scm.Provider) (scm.Host, str
 			}
 		}
 		forkRepo := ""
-		if sctx.Repo.ForkURL != "" {
+		if sctx.Repo.ForkURL != "" && targetURL == sctx.Repo.UpstreamURL {
 			// forkRepo is only used to extract the fork owner for --head owner:branch;
 			// the plain slug (without host prefix) is correct here.
 			forkRepo = github.RepoSlug(sctx.Repo.ForkURL)

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -64,7 +64,7 @@ func (s *PRStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 		sctx.Log(fmt.Sprintf("skipping PR creation on default branch %s", branch))
 		return &pipeline.StepOutcome{Skipped: true}, nil
 	}
-	provider := scm.DetectProviderContext(ctx, sctx.Repo.UpstreamURL)
+	provider := scm.DetectProviderContext(ctx, providerURL(sctx))
 	host, skipReason := buildHost(sctx, provider)
 	if host == nil {
 		sctx.Log(fmt.Sprintf("skipping PR creation: %s", skipReason))

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -229,7 +229,7 @@ func (s *PRStep) buildPipelineSection(sctx *pipeline.StepContext) (string, strin
 	}
 
 	pipelineMD, riskLine := BuildPipelineSummary(steps, rounds)
-	testingMD := BuildTestingSummaryForPR(steps, rounds, sctx.Repo.UpstreamURL, sctx.Run.HeadSHA, sctx.WorkDir)
+	testingMD := BuildTestingSummaryForPR(steps, rounds, providerURL(sctx), sctx.Run.HeadSHA, sctx.WorkDir)
 	return pipelineMD, riskLine, testingMD
 }
 

--- a/internal/pipeline/steps/pr_test.go
+++ b/internal/pipeline/steps/pr_test.go
@@ -349,6 +349,31 @@ func TestPRStep_LocalFetchOriginCreatesGitHubTargetPR(t *testing.T) {
 	}
 }
 
+func TestPRStep_UnknownNonLocalOriginDoesNotUseGitHubPushTarget(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	env, logFile := fakeGH(t, "")
+	sctx := newTestContextWithDBRecords(t, &mockAgent{name: "test"}, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Repo.UpstreamURL = "https://code.example.com/org/repo.git"
+	sctx.Repo.ForkURL = "https://github.com/RooseveltAdvisors/firstmate.git"
+
+	outcome, err := (&PRStep{}).Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome == nil || !outcome.Skipped {
+		t.Fatalf("expected PR step to skip unknown non-local upstream, got %#v", outcome)
+	}
+	logData, err := os.ReadFile(logFile)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(logData), "pr create") {
+		t.Fatalf("expected unknown non-local upstream to avoid GitHub PR creation, got:\n%s", logData)
+	}
+}
+
 func TestPRStep_GitHubForkCreatesParentPRWithForkHead(t *testing.T) {
 	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)

--- a/internal/pipeline/steps/pr_test.go
+++ b/internal/pipeline/steps/pr_test.go
@@ -299,6 +299,35 @@ func TestPRStep_CreatesNewPR(t *testing.T) {
 	}
 }
 
+func TestPRStep_LocalFetchOriginCreatesGitHubTargetPR(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	env, logFile := fakeGH(t, "")
+	sctx := newTestContextWithDBRecords(t, &mockAgent{name: "test"}, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Env = env
+	sctx.Repo.UpstreamURL = dir
+	sctx.Repo.ForkURL = "https://github.com/RooseveltAdvisors/firstmate.git"
+	sctx.Run.Branch = "refs/heads/feature"
+	if got := resolvePushURL(sctx); got != sctx.Repo.ForkURL {
+		t.Fatalf("push target = %q, want %q", got, sctx.Repo.ForkURL)
+	}
+
+	if _, err := (&PRStep{}).Execute(sctx); err != nil {
+		t.Fatal(err)
+	}
+	logData, err := os.ReadFile(logFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ghLog := string(logData)
+	if !strings.Contains(ghLog, "pr create --head feature --base main --repo RooseveltAdvisors/firstmate") {
+		t.Fatalf("expected canonical PR against the GitHub push target, got:\n%s", ghLog)
+	}
+	if !strings.Contains(ghLog, "## What Changed") {
+		t.Fatalf("expected canonical generated PR body, got:\n%s", ghLog)
+	}
+}
+
 func TestPRStep_GitHubForkCreatesParentPRWithForkHead(t *testing.T) {
 	t.Parallel()
 	dir, baseSHA, headSHA := setupGitRepo(t)

--- a/internal/pipeline/steps/pr_test.go
+++ b/internal/pipeline/steps/pr_test.go
@@ -305,7 +305,7 @@ func TestPRStep_LocalFetchOriginCreatesGitHubTargetPR(t *testing.T) {
 	env, logFile := fakeGH(t, "")
 	sctx := newTestContextWithDBRecords(t, &mockAgent{name: "test"}, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Env = env
-	sctx.Repo.UpstreamURL = dir
+	sctx.Repo.UpstreamURL = filepath.Join(t.TempDir(), "github.com", "mirror.git")
 	sctx.Repo.ForkURL = "https://github.com/RooseveltAdvisors/firstmate.git"
 	sctx.Run.Branch = "refs/heads/feature"
 	if got := resolvePushURL(sctx); got != sctx.Repo.ForkURL {

--- a/internal/pipeline/steps/pr_test.go
+++ b/internal/pipeline/steps/pr_test.go
@@ -311,6 +311,20 @@ func TestPRStep_LocalFetchOriginCreatesGitHubTargetPR(t *testing.T) {
 	if got := resolvePushURL(sctx); got != sctx.Repo.ForkURL {
 		t.Fatalf("push target = %q, want %q", got, sctx.Repo.ForkURL)
 	}
+	testFindings := `{"findings":[],"summary":"","testing_summary":"Evidence was collected.","artifacts":[{"kind":"screenshot","label":"Checkout screenshot","path":"artifacts/checkout.png"}]}`
+	testStep, err := sctx.DB.InsertStepResult(sctx.Run.ID, types.StepTest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sctx.DB.UpdateStepStatus(testStep.ID, types.StepStatusCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if err := sctx.DB.SetStepFindings(testStep.ID, testFindings); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sctx.DB.InsertStepRound(testStep.ID, 1, "initial", &testFindings, nil, 100); err != nil {
+		t.Fatal(err)
+	}
 
 	if _, err := (&PRStep{}).Execute(sctx); err != nil {
 		t.Fatal(err)
@@ -325,6 +339,13 @@ func TestPRStep_LocalFetchOriginCreatesGitHubTargetPR(t *testing.T) {
 	}
 	if !strings.Contains(ghLog, "## What Changed") {
 		t.Fatalf("expected canonical generated PR body, got:\n%s", ghLog)
+	}
+	wantArtifactLink := "https://github.com/RooseveltAdvisors/firstmate/blob/" + headSHA + "/artifacts/checkout.png"
+	if !strings.Contains(ghLog, wantArtifactLink) {
+		t.Fatalf("expected PR body evidence to link to canonical GitHub target %q, got:\n%s", wantArtifactLink, ghLog)
+	}
+	if strings.Contains(ghLog, sctx.Repo.UpstreamURL) {
+		t.Fatalf("expected PR body evidence to avoid local fetch origin %q, got:\n%s", sctx.Repo.UpstreamURL, ghLog)
 	}
 }
 

--- a/internal/scm/scm.go
+++ b/internal/scm/scm.go
@@ -142,7 +142,7 @@ func isLocalFilesystemRemote(remote string) bool {
 		return true
 	case filepath.IsAbs(remote):
 		return true
-	case len(remote) >= 3 && ((remote[0] >= 'a' && remote[0] <= 'z') || (remote[0] >= 'A' && remote[0] <= 'Z')) && remote[1] == ':' && (remote[2] == '/' || remote[2] == '\\'):
+	case len(remote) >= 2 && ((remote[0] >= 'a' && remote[0] <= 'z') || (remote[0] >= 'A' && remote[0] <= 'Z')) && remote[1] == ':':
 		return true
 	case remote == "." || remote == ".." || strings.HasPrefix(remote, "./") || strings.HasPrefix(remote, "../") || strings.HasPrefix(remote, `.\\`) || strings.HasPrefix(remote, `..\\`) || strings.HasPrefix(remote, "~/") || strings.HasPrefix(remote, `~\\`):
 		return true

--- a/internal/scm/scm.go
+++ b/internal/scm/scm.go
@@ -44,7 +44,7 @@ func detectProvider(ctx context.Context, url string, lookup sshHostnameLookup) P
 }
 
 func detectProviderForGOOS(ctx context.Context, url string, lookup sshHostnameLookup, goos string) Provider {
-	if isLocalFilesystemRemote(url, goos) {
+	if isLocalFilesystemRemoteForGOOS(url, goos) {
 		return ProviderUnknown
 	}
 	if provider := detectProviderWithoutSSH(url); provider != ProviderUnknown {
@@ -138,7 +138,11 @@ func isSSHRemote(remote string) bool {
 	return slash < 0 || colon < slash
 }
 
-func isLocalFilesystemRemote(remote, goos string) bool {
+func IsLocalFilesystemRemote(remote string) bool {
+	return isLocalFilesystemRemoteForGOOS(remote, runtime.GOOS)
+}
+
+func isLocalFilesystemRemoteForGOOS(remote, goos string) bool {
 	remote = strings.TrimSpace(remote)
 	lower := strings.ToLower(remote)
 	switch {

--- a/internal/scm/scm.go
+++ b/internal/scm/scm.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -38,7 +39,11 @@ func DetectProviderContext(ctx context.Context, url string) Provider {
 }
 
 func detectProvider(ctx context.Context, url string, lookup sshHostnameLookup) Provider {
-	if isLocalFilesystemRemote(url) {
+	return detectProviderForGOOS(ctx, url, lookup, runtime.GOOS)
+}
+
+func detectProviderForGOOS(ctx context.Context, url string, lookup sshHostnameLookup, goos string) Provider {
+	if isLocalFilesystemRemote(url, goos) {
 		return ProviderUnknown
 	}
 	if provider := detectProviderWithoutSSH(url); provider != ProviderUnknown {
@@ -132,7 +137,7 @@ func isSSHRemote(remote string) bool {
 	return slash < 0 || colon < slash
 }
 
-func isLocalFilesystemRemote(remote string) bool {
+func isLocalFilesystemRemote(remote, goos string) bool {
 	remote = strings.TrimSpace(remote)
 	lower := strings.ToLower(remote)
 	switch {
@@ -142,7 +147,9 @@ func isLocalFilesystemRemote(remote string) bool {
 		return true
 	case filepath.IsAbs(remote):
 		return true
-	case len(remote) >= 2 && ((remote[0] >= 'a' && remote[0] <= 'z') || (remote[0] >= 'A' && remote[0] <= 'Z')) && remote[1] == ':':
+	case len(remote) >= 3 && ((remote[0] >= 'a' && remote[0] <= 'z') || (remote[0] >= 'A' && remote[0] <= 'Z')) && remote[1] == ':' && (remote[2] == '/' || remote[2] == '\\'):
+		return true
+	case goos == "windows" && len(remote) >= 2 && ((remote[0] >= 'a' && remote[0] <= 'z') || (remote[0] >= 'A' && remote[0] <= 'Z')) && remote[1] == ':':
 		return true
 	case remote == "." || remote == ".." || strings.HasPrefix(remote, "./") || strings.HasPrefix(remote, "../") || strings.HasPrefix(remote, `.\\`) || strings.HasPrefix(remote, `..\\`) || strings.HasPrefix(remote, "~/") || strings.HasPrefix(remote, `~\\`):
 		return true

--- a/internal/scm/scm.go
+++ b/internal/scm/scm.go
@@ -38,6 +38,9 @@ func DetectProviderContext(ctx context.Context, url string) Provider {
 }
 
 func detectProvider(ctx context.Context, url string, lookup sshHostnameLookup) Provider {
+	if isLocalFilesystemRemote(url) {
+		return ProviderUnknown
+	}
 	if provider := detectProviderWithoutSSH(url); provider != ProviderUnknown {
 		return provider
 	}
@@ -127,6 +130,26 @@ func isSSHRemote(remote string) bool {
 	}
 	slash := strings.IndexAny(remote, `/\\`)
 	return slash < 0 || colon < slash
+}
+
+func isLocalFilesystemRemote(remote string) bool {
+	remote = strings.TrimSpace(remote)
+	lower := strings.ToLower(remote)
+	switch {
+	case remote == "":
+		return false
+	case strings.HasPrefix(lower, "file://"):
+		return true
+	case filepath.IsAbs(remote):
+		return true
+	case len(remote) >= 3 && ((remote[0] >= 'a' && remote[0] <= 'z') || (remote[0] >= 'A' && remote[0] <= 'Z')) && remote[1] == ':' && (remote[2] == '/' || remote[2] == '\\'):
+		return true
+	case remote == "." || remote == ".." || strings.HasPrefix(remote, "./") || strings.HasPrefix(remote, "../") || strings.HasPrefix(remote, `.\\`) || strings.HasPrefix(remote, `..\\`) || strings.HasPrefix(remote, "~/") || strings.HasPrefix(remote, `~\\`):
+		return true
+	case strings.Contains(remote, "://"):
+		return false
+	}
+	return !isSSHRemote(remote)
 }
 
 func lookupSSHHostname(ctx context.Context, alias string) (string, error) {

--- a/internal/scm/scm.go
+++ b/internal/scm/scm.go
@@ -26,9 +26,10 @@ const (
 
 type sshHostnameLookup func(context.Context, string) (string, error)
 
-// DetectProvider identifies the SCM provider for url. SSH host aliases are
-// resolved through the user's SSH configuration before detection falls back to
-// ProviderUnknown.
+// DetectProvider identifies the SCM provider for url. Local filesystem remotes
+// always resolve to ProviderUnknown, even when their path contains provider-like
+// host text. SSH host aliases are resolved through the user's SSH configuration
+// before detection falls back to ProviderUnknown.
 func DetectProvider(url string) Provider {
 	return DetectProviderContext(context.Background(), url)
 }

--- a/internal/scm/scm_test.go
+++ b/internal/scm/scm_test.go
@@ -42,6 +42,7 @@ func TestDetectProvider_LocalFilesystemRemoteWithProviderMarker(t *testing.T) {
 
 	tests := []string{
 		filepath.Join(t.TempDir(), "github.com", "mirror.git"),
+		`C:github.com\mirror.git`,
 		"../gitlab.com/mirror.git",
 		"file:///tmp/bitbucket.org/mirror.git",
 	}

--- a/internal/scm/scm_test.go
+++ b/internal/scm/scm_test.go
@@ -42,7 +42,7 @@ func TestDetectProvider_LocalFilesystemRemoteWithProviderMarker(t *testing.T) {
 
 	tests := []string{
 		filepath.Join(t.TempDir(), "github.com", "mirror.git"),
-		`C:github.com\mirror.git`,
+		`C:\github.com\mirror.git`,
 		"../gitlab.com/mirror.git",
 		"file:///tmp/bitbucket.org/mirror.git",
 	}
@@ -50,6 +50,16 @@ func TestDetectProvider_LocalFilesystemRemoteWithProviderMarker(t *testing.T) {
 		if got := DetectProvider(remote); got != ProviderUnknown {
 			t.Fatalf("DetectProvider(%q) = %q, want %q", remote, got, ProviderUnknown)
 		}
+	}
+}
+
+func TestDetectProvider_WindowsDriveRelativeRemoteWithProviderMarker(t *testing.T) {
+	t.Setenv("GLAB_CONFIG_DIR", t.TempDir())
+	t.Setenv("GH_CONFIG_DIR", t.TempDir())
+
+	got := detectProviderForGOOS(context.Background(), `C:github.com\mirror.git`, nil, "windows")
+	if got != ProviderUnknown {
+		t.Fatalf("detectProviderForGOOS(windows drive-relative) = %q, want %q", got, ProviderUnknown)
 	}
 }
 
@@ -66,6 +76,12 @@ func TestDetectProvider_SSHHostAlias(t *testing.T) {
 		{
 			name:     "GitHub scp remote",
 			url:      "git@github-personal:owner/repo.git",
+			hostname: "github.com",
+			want:     ProviderGitHub,
+		},
+		{
+			name:     "GitHub single-letter scp alias",
+			url:      "g:owner/repo.git",
 			hostname: "github.com",
 			want:     ProviderGitHub,
 		},

--- a/internal/scm/scm_test.go
+++ b/internal/scm/scm_test.go
@@ -36,6 +36,22 @@ func TestDetectProvider(t *testing.T) {
 	}
 }
 
+func TestDetectProvider_LocalFilesystemRemoteWithProviderMarker(t *testing.T) {
+	t.Setenv("GLAB_CONFIG_DIR", t.TempDir())
+	t.Setenv("GH_CONFIG_DIR", t.TempDir())
+
+	tests := []string{
+		filepath.Join(t.TempDir(), "github.com", "mirror.git"),
+		"../gitlab.com/mirror.git",
+		"file:///tmp/bitbucket.org/mirror.git",
+	}
+	for _, remote := range tests {
+		if got := DetectProvider(remote); got != ProviderUnknown {
+			t.Fatalf("DetectProvider(%q) = %q, want %q", remote, got, ProviderUnknown)
+		}
+	}
+}
+
 func TestDetectProvider_SSHHostAlias(t *testing.T) {
 	t.Setenv("GLAB_CONFIG_DIR", t.TempDir())
 	t.Setenv("GH_CONFIG_DIR", t.TempDir())


### PR DESCRIPTION
## Intent

Support no-mistakes init when the parent origin is a local filesystem path and --fork-url is a canonical GitHub repository. Preserve the local fetch origin, configured GitHub push/PR target, existing true GitHub parent/fork behavior, fail-closed validation for unsafe or unsupported targets, and gate ownership. Add a focused regression for local-path parent plus GitHub fork URL, then deliver only through the captain-owned RooseveltAdvisors/no-mistakes fork.

## What Changed

- Allowed `no-mistakes init --fork-url` to pair a local filesystem `origin` with a canonical GitHub push/PR target while preserving existing GitHub parent/fork routing.
- Updated provider detection and PR/CI routing so local fetch origins fail closed unless the configured target is a valid GitHub repo.
- Added focused regressions and documentation for local-origin GitHub routing, unsafe target handling, SSH aliases, and local path provider detection.

## Risk Assessment

✅ Low: The change is narrowly scoped to detecting local filesystem remotes as non-provider origins and routing local-origin GitHub PR/CI surfaces through the configured GitHub target, with focused regressions covering the intended path and non-local fail-closed behavior.

## Testing

Exercised the targeted init, provider-detection, and PR-routing regressions; transcripts were saved as evidence, all focused tests passed, and the worktree was clean after testing.

<details>
<summary>Evidence: Init local parent transcript</summary>

```text
=== RUN   TestInitWithForkAllowsLocalParentAndGitHubTarget
2026/07/26 09:52:52 INFO gate initialized repo_id=c4d1e2b4dc98 path=/tmp/TestInitWithForkAllowsLocalParentAndGitHubTarget3622653352/002/work upstream=/tmp/TestInitWithForkAllowsLocalParentAndGitHubTarget3622653352/001/upstream.git
--- PASS: TestInitWithForkAllowsLocalParentAndGitHubTarget (0.07s)
=== RUN   TestInitWithForkPreservesForkOnPlainReinit
2026/07/26 09:52:52 INFO gate initialized repo_id=1bc4a4403eca path=/tmp/TestInitWithForkPreservesForkOnPlainReinit1076981621/002/work upstream=https://github.com/parent/project.git
2026/07/26 09:52:52 INFO gate refreshed repo_id=1bc4a4403eca path=/tmp/TestInitWithForkPreservesForkOnPlainReinit1076981621/002/work
--- PASS: TestInitWithForkPreservesForkOnPlainReinit (0.08s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/gate	0.155s
```
</details>
<details>
<summary>Evidence: PR routing transcript</summary>

```text
=== RUN   TestPRStep_LocalFetchOriginCreatesGitHubTargetPR
=== PAUSE TestPRStep_LocalFetchOriginCreatesGitHubTargetPR
=== RUN   TestPRStep_UnknownNonLocalOriginDoesNotUseGitHubPushTarget
=== PAUSE TestPRStep_UnknownNonLocalOriginDoesNotUseGitHubPushTarget
=== RUN   TestPRStep_GitHubForkCreatesParentPRWithForkHead
=== PAUSE TestPRStep_GitHubForkCreatesParentPRWithForkHead
=== CONT  TestPRStep_LocalFetchOriginCreatesGitHubTargetPR
=== CONT  TestPRStep_GitHubForkCreatesParentPRWithForkHead
=== CONT  TestPRStep_UnknownNonLocalOriginDoesNotUseGitHubPushTarget
--- PASS: TestPRStep_UnknownNonLocalOriginDoesNotUseGitHubPushTarget (0.11s)
--- PASS: TestPRStep_GitHubForkCreatesParentPRWithForkHead (0.12s)
--- PASS: TestPRStep_LocalFetchOriginCreatesGitHubTargetPR (0.13s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/pipeline/steps	0.142s
```
</details>
<details>
<summary>Evidence: Provider detection transcript</summary>

```text
=== RUN   TestDetectProvider_LocalFilesystemRemoteWithProviderMarker
--- PASS: TestDetectProvider_LocalFilesystemRemoteWithProviderMarker (0.00s)
=== RUN   TestDetectProvider_WindowsDriveRelativeRemoteWithProviderMarker
--- PASS: TestDetectProvider_WindowsDriveRelativeRemoteWithProviderMarker (0.00s)
=== RUN   TestDetectProvider_SSHHostAlias
=== RUN   TestDetectProvider_SSHHostAlias/GitHub_scp_remote
=== RUN   TestDetectProvider_SSHHostAlias/GitHub_single-letter_scp_alias
=== RUN   TestDetectProvider_SSHHostAlias/GitLab_SSH_URL
--- PASS: TestDetectProvider_SSHHostAlias (0.00s)
    --- PASS: TestDetectProvider_SSHHostAlias/GitHub_scp_remote (0.00s)
    --- PASS: TestDetectProvider_SSHHostAlias/GitHub_single-letter_scp_alias (0.00s)
    --- PASS: TestDetectProvider_SSHHostAlias/GitLab_SSH_URL (0.00s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/scm	0.002s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/gate -run 'TestInitWithForkAllowsLocalParentAndGitHubTarget|TestInitWithForkPreservesForkOnPlainReinit' -count=1 -v`
- `go test ./internal/pipeline/steps -run 'TestPRStep_LocalFetchOriginCreatesGitHubTargetPR|TestPRStep_UnknownNonLocalOriginDoesNotUseGitHubPushTarget|TestPRStep_GitHubForkCreatesParentPRWithForkHead' -count=1 -v`
- `go test ./internal/scm -run 'TestDetectProvider_LocalFilesystemRemoteWithProviderMarker|TestDetectProvider_WindowsDriveRelativeRemoteWithProviderMarker|TestDetectProvider_SSHHostAlias' -count=1 -v`
- `git status --short`

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `internal/cli/init.go:93` - `--fork-url` CLI help still describes only a GitHub fork remote opening PRs against `origin`; the new local-filesystem-origin plus GitHub target path also needs reflected there, but the help string is executable Go code rather than a documentation file or doc comment.

🔧 Fix: Clarify local-origin routing docs
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
