### PR TITLE
fix(rebase): refuse to rewrite a shared integration branch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,12 @@ Safest local verification sequence after non-trivial changes:
 - Agent-driving guidance is owned by the skill body and the live `axi` output strings (`internal/cli/axi*.go`); `docs/src/content/docs/guides/agents.md` carries only the canonical invariant sentences pinned by `internal/cli/axi_guidance_test.go` plus a pointer to the skill. When you change driving guidance, change the skill body and the point-of-use `axi` strings together; that drift test is the sync check.
 - Review auto-fix is disabled by default (`auto_fix.review: 0` in `config.go` `autoFixDefaults`), so blocking and ask-user review findings park for an agent decision; keep the skill, the live `axi` gate `note`, and docs qualified if you touch review auto-fix.
 
+**Per-Step Agent Arg Profiles**
+
+- The daemon builds one agent per run (`internal/daemon/manager.go` `startRun`), so per-step model/effort selection is carried per invocation, not per process: `Config.AgentArgsForStep` feeds the `stepArgsAgent` decorator in `internal/pipeline/executor.go` (alongside the existing gate-boundary/lifecycle/perf wrappers), which sets `agent.RunOpts.StepArgsOverride`, and each argv-per-invocation adapter swaps in its own entry via `withStepArgs`. There is no IPC or protocol change.
+- The map is keyed step -> agent so a fallback provider the profile does not name keeps its global args, and a listed entry REPLACES `agent_args_override` for that step rather than appending. `--setting-sources` (claude) and `project_doc_max_bytes` (codex) are rejected per step because `agent.EnsureGateNeutralized` verifies `disable_project_settings` once per run against the run-level args.
+- Global config is parsed with `KnownFields(true)`, so a config carrying `agent_args_override_per_step` fails to load on a binary that predates it: install the binary before adding the key. Docs owner is `docs/src/content/docs/reference/global-config.md`; regressions are `internal/config/config_step_args_override_test.go`, `internal/agent/step_args_test.go`, `internal/pipeline/executor_step_args_test.go`, and e2e `TestPerStepAgentArgsProfile`.
+
 **Context, Concurrency, and Processes**
 
 - Thread `context.Context` through long-running, subprocess, and networked work; prefer `exec.CommandContext`; use derived contexts and timeouts for cleanup and HTTP calls.

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -190,10 +190,11 @@ The [CLI reference](/no-mistakes/reference/cli/) documents each `axi` command an
 When the daemon is running through a managed service, its `PATH` comes from your login shell environment on macOS and Linux plus common user, Homebrew, and system binary directories; on Windows it reuses the current process environment.
 If native agent discovery does not resolve the binary you expect, check `~/.no-mistakes/logs/daemon.log` and set an explicit override; [Environment the daemon sees](/no-mistakes/reference/environment/#environment-the-daemon-sees) owns the full resolution story.
 
-Five global config fields tune resolution and invocation, and the [Global Config Reference](/no-mistakes/reference/global-config/) owns each one:
+Six global config fields tune resolution and invocation, and the [Global Config Reference](/no-mistakes/reference/global-config/) owns each one:
 
 - [`agent_path_override`](/no-mistakes/reference/global-config/#agent_path_override) - custom binary paths per native agent, plus the default native binary-name table.
 - [`agent_args_override`](/no-mistakes/reference/global-config/#agent_args_override) - extra CLI flags per native agent for model selection, service tier, reasoning depth, or permission mode, including the reserved-flag rules and smart defaults. Keep it global-only; it reflects your local agent setup rather than repo policy.
+- [`agent_args_override_per_step`](/no-mistakes/reference/global-config/#agent_args_override_per_step) - per-pipeline-step flag profiles that replace the global flags for one step, so an expensive step such as review can run on a strong model while housekeeping steps run on a cheap one.
 - [`acpx_path`](/no-mistakes/reference/global-config/#acpx_path) - the bridge binary path for explicit ACP targets and first-class ACP aliases.
 - [`acp_registry_overrides`](/no-mistakes/reference/global-config/#acp_registry_overrides) - raw ACP target commands, including replacements for alias defaults such as `cursor-agent acp`, plus their availability-probing rules.
 - [`agent`](/no-mistakes/reference/global-config/#agent) - the `auto` resolution order and ordered fallback-list semantics.

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -54,9 +54,9 @@ The rest of this page covers only the cross-cutting rules that involve both file
 ## Precedence
 
 - Repo config overrides global config field by field: repo `agent` replaces the global `agent` (including a full ordered fallback list), while `auto_fix`, `commit`, `intent`, and `test.evidence` overlay individual fields and fall through to the global default for anything unset (`intent.disabled_readers` adds to the globally disabled readers instead of replacing them).
-- `agent_path_override`, `agent_args_override`, `acpx_path`, `acp_registry_overrides`, `ci_timeout`, `daemon_connect_timeout`, `step_quiet_warning`, `log_level`, and `session_reuse` are global-only fields.
+- `agent_path_override`, `agent_args_override`, `agent_args_override_per_step`, `acpx_path`, `acp_registry_overrides`, `ci_timeout`, `daemon_connect_timeout`, `step_quiet_warning`, `log_level`, and `session_reuse` are global-only fields.
 - `commands`, `ignore_patterns`, `document.instructions`, `allow_repo_commands`, and `disable_project_settings` are repo-only fields. By default, `commands` and `agent` are read from the trusted default branch; a trusted `allow_repo_commands: true` opt-in instead honors their pushed-branch values. The other gate-control fields always come from the trusted default branch. See the [Repo Config Reference](/no-mistakes/reference/repo-config/) security note.
-- no-mistakes reloads global config while setting up each run, so edits made before starting a run apply to it. For repeatable profiles (for example fast versus deep Codex settings), use separately initialized `NM_HOME` roots; `NM_HOME` moves all no-mistakes state, not just config.
+- no-mistakes reloads global config while setting up each run, so edits made before starting a run apply to it. To vary the profile between steps of one run (for example a deep review and a cheap document pass), use [`agent_args_override_per_step`](/no-mistakes/reference/global-config/#agent_args_override_per_step); for whole separate profiles, use separately initialized `NM_HOME` roots, which move all no-mistakes state, not just config.
 
 ## Explicit commands versus agent detection
 

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -210,7 +210,57 @@ agent_args_override:
     - google
 ```
 
-For Codex, `service_tier` and `model_reasoning_effort` tune different things: `service_tier` selects the speed or priority lane, while `model_reasoning_effort` selects reasoning depth. no-mistakes reloads global config while setting up each run, so edits made before `no-mistakes axi run` apply to that run. For repeatable profiles, use separately initialized `NM_HOME` directories; each has its own `config.yaml` and no-mistakes state.
+For Codex, `service_tier` and `model_reasoning_effort` tune different things: `service_tier` selects the speed or priority lane, while `model_reasoning_effort` selects reasoning depth. no-mistakes reloads global config while setting up each run, so edits made before `no-mistakes axi run` apply to that run. To vary the profile per pipeline step within one run, use [`agent_args_override_per_step`](#agent_args_override_per_step).
+
+### agent_args_override_per_step
+
+Per-pipeline-step agent flag profiles.
+Use this to pay for a strong model where the work is hard, such as review, while cheap housekeeping steps such as document and lint run on a small one.
+
+|         |                                                          |
+| ------- | -------------------------------------------------------- |
+| Type    | `map[string]map[string][]string` (step -> agent -> flags) |
+| Steps   | `intent`, `rebase`, `review`, `test`, `document`, `lint`, `push`, `pr`, `ci` |
+| Agents  | `claude`, `codex`, `pi`, `copilot`                        |
+| Default | Empty (every step uses `agent_args_override`)             |
+
+A listed step and agent **replaces** that agent's `agent_args_override` entry for the duration of that step; it is not appended to it, so each profile must list every flag that step needs.
+Steps that are not listed, and agents that a listed step does not name, keep their global `agent_args_override` flags.
+That per-agent keying matters when several `agent` values are configured as a fallback chain: a profile for `codex` does not leak onto a `claude` fallback invocation.
+
+Only agents whose command line is rebuilt on every invocation are accepted.
+`rovodev` and `opencode` start one persistent server per run and fix their flags there, and ACP targets ignore extra flags entirely, so naming them here is a config error rather than a silently ignored setting.
+
+The reserved-flag rules from [`agent_args_override`](#agent_args_override) apply unchanged.
+Two more flags are rejected here because they participate in the [`disable_project_settings`](/no-mistakes/reference/repo-config/#disable_project_settings) security boundary, which the daemon verifies once per run against the global flags: `--setting-sources` for `claude` and `project_doc_max_bytes` for `codex`.
+Set those in `agent_args_override` instead.
+
+Example:
+
+```yaml
+agent_args_override:
+  codex:
+    - -m
+    - gpt-5.4-mini
+
+agent_args_override_per_step:
+  review:
+    codex:
+      - -m
+      - gpt-5.4
+      - -c
+      - model_reasoning_effort="high"
+  test:
+    codex:
+      - -m
+      - gpt-5.4
+  document:
+    codex:
+      - -m
+      - gpt-5.4-mini
+```
+
+In that example review and test run on the strong profile, document runs on the cheap one, and every other step falls back to the global `gpt-5.4-mini`.
 
 ### ci_timeout
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -52,6 +52,41 @@ type RunOpts struct {
 	// fallback-provider attempts, after it completes. It is instrumentation
 	// only and must not change invocation behavior.
 	OnAttempt func(Attempt)
+	// StepArgsOverride carries the per-pipeline-step agent flag profile for
+	// this invocation, keyed by agent name (see config
+	// agent_args_override_per_step). An adapter that finds its OWN name in the
+	// map uses those args INSTEAD of the extraArgs it was constructed with;
+	// every other adapter (notably a fallback provider that is not the one the
+	// profile names) keeps its constructed args. Adapters whose argv is fixed
+	// when a persistent server starts, and ACP targets, ignore it.
+	StepArgsOverride map[string][]string
+}
+
+// resolveExtraArgs returns the extra CLI args an adapter named name should use
+// for this invocation: the per-step profile when the caller supplied one for
+// that agent, otherwise the args the adapter was constructed with.
+func (o RunOpts) resolveExtraArgs(name string, configured []string) []string {
+	if o.StepArgsOverride == nil {
+		return configured
+	}
+	args, ok := o.StepArgsOverride[name]
+	if !ok {
+		return configured
+	}
+	return args
+}
+
+// sameArgs reports whether two arg lists are element-wise equal.
+func sameArgs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // Attempt describes one completed concrete adapter attempt for an agent

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -64,7 +64,23 @@ func (a *claudeAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
 	})
 }
 
+// withStepArgs returns the adapter to build this invocation's argv from: the
+// receiver, or a copy carrying the per-step arg profile (see
+// RunOpts.StepArgsOverride). The adapter is an immutable value holder, so the
+// copy keeps every extraArgs-derived decision in buildArgs consistent with the
+// args actually passed, without threading a parameter through each helper.
+func (a *claudeAgent) withStepArgs(opts RunOpts) *claudeAgent {
+	args := opts.resolveExtraArgs("claude", a.extraArgs)
+	if sameArgs(args, a.extraArgs) {
+		return a
+	}
+	next := *a
+	next.extraArgs = args
+	return &next
+}
+
 func (a *claudeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
+	a = a.withStepArgs(opts)
 	resumeID := ""
 	if opts.Session != nil {
 		resumeID = opts.Session.ID

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -57,7 +57,22 @@ func (a *codexAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
 	})
 }
 
+// withStepArgs returns the adapter to build this invocation's argv from: the
+// receiver, or a copy carrying the per-step arg profile (see
+// RunOpts.StepArgsOverride). See the claude adapter's withStepArgs for why a
+// copy is used instead of a buildArgs parameter.
+func (a *codexAgent) withStepArgs(opts RunOpts) *codexAgent {
+	args := opts.resolveExtraArgs("codex", a.extraArgs)
+	if sameArgs(args, a.extraArgs) {
+		return a
+	}
+	next := *a
+	next.extraArgs = args
+	return &next
+}
+
 func (a *codexAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
+	a = a.withStepArgs(opts)
 	schemaPath := ""
 	validationSchema := opts.JSONSchema
 	if len(opts.JSONSchema) > 0 {

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -34,7 +34,21 @@ func (a *copilotAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
 
 func (a *copilotAgent) Close() error { return nil }
 
+// withStepArgs returns the adapter to build this invocation's argv from: the
+// receiver, or a copy carrying the per-step arg profile (see
+// RunOpts.StepArgsOverride).
+func (a *copilotAgent) withStepArgs(opts RunOpts) *copilotAgent {
+	args := opts.resolveExtraArgs("copilot", a.extraArgs)
+	if sameArgs(args, a.extraArgs) {
+		return a
+	}
+	next := *a
+	next.extraArgs = args
+	return &next
+}
+
 func (a *copilotAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
+	a = a.withStepArgs(opts)
 	prompt := buildCopilotPrompt(opts.Prompt, opts.JSONSchema)
 	args := a.buildArgs(prompt)
 	cmd := exec.CommandContext(ctx, a.bin, args...)

--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -33,7 +33,21 @@ func (a *piAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
 
 func (a *piAgent) Close() error { return nil }
 
+// withStepArgs returns the adapter to build this invocation's argv from: the
+// receiver, or a copy carrying the per-step arg profile (see
+// RunOpts.StepArgsOverride).
+func (a *piAgent) withStepArgs(opts RunOpts) *piAgent {
+	args := opts.resolveExtraArgs("pi", a.extraArgs)
+	if sameArgs(args, a.extraArgs) {
+		return a
+	}
+	next := *a
+	next.extraArgs = args
+	return &next
+}
+
 func (a *piAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
+	a = a.withStepArgs(opts)
 	args := a.buildArgs()
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD

--- a/internal/agent/step_args_test.go
+++ b/internal/agent/step_args_test.go
@@ -1,0 +1,115 @@
+package agent
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestResolveExtraArgs_FallsBackToConfiguredArgs(t *testing.T) {
+	configured := []string{"-m", "gpt-5.4"}
+	tests := []struct {
+		name string
+		opts RunOpts
+	}{
+		{"no per-step profile", RunOpts{}},
+		{"profile names another agent", RunOpts{StepArgsOverride: map[string][]string{"claude": {"--model", "haiku"}}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.opts.resolveExtraArgs("codex", configured); !reflect.DeepEqual(got, configured) {
+				t.Errorf("resolveExtraArgs = %v, want the configured args %v", got, configured)
+			}
+		})
+	}
+}
+
+func TestResolveExtraArgs_ProfileReplacesConfiguredArgs(t *testing.T) {
+	opts := RunOpts{StepArgsOverride: map[string][]string{"codex": {"-m", "gpt-5.4-mini"}}}
+	if got := opts.resolveExtraArgs("codex", []string{"-m", "gpt-5.4"}); !reflect.DeepEqual(got, []string{"-m", "gpt-5.4-mini"}) {
+		t.Errorf("resolveExtraArgs = %v, want the per-step profile to replace the global args", got)
+	}
+	// An explicit empty profile clears the global args for this step rather
+	// than silently falling back to them.
+	if got := opts.resolveExtraArgs("codex", nil); !reflect.DeepEqual(got, []string{"-m", "gpt-5.4-mini"}) {
+		t.Errorf("resolveExtraArgs with no configured args = %v", got)
+	}
+}
+
+func TestCodexBuildArgs_UsesPerStepProfile(t *testing.T) {
+	a := &codexAgent{bin: "codex", extraArgs: []string{"-m", "gpt-5.4-mini"}}
+	stepped := a.withStepArgs(RunOpts{StepArgsOverride: map[string][]string{
+		"codex": {"-m", "gpt-5.4", "-c", `model_reasoning_effort="high"`},
+	}})
+	args := stepped.buildArgs("review the diff", "", "")
+	if !argsContainPair(args, "-m", "gpt-5.4") {
+		t.Errorf("buildArgs = %v, want the per-step model", args)
+	}
+	if !argsContainPair(args, "-c", `model_reasoning_effort="high"`) {
+		t.Errorf("buildArgs = %v, want the per-step reasoning effort", args)
+	}
+	if strings.Contains(strings.Join(args, " "), "gpt-5.4-mini") {
+		t.Errorf("buildArgs = %v, must not keep the global model when a per-step profile applies", args)
+	}
+	// The receiver is untouched, so the next step without a profile gets the
+	// globally configured args back.
+	if !argsContainPair(a.buildArgs("p", "", ""), "-m", "gpt-5.4-mini") {
+		t.Error("withStepArgs must not mutate the shared adapter")
+	}
+}
+
+func TestCodexBuildArgs_PerStepProfileKeepsManagedFlags(t *testing.T) {
+	a := &codexAgent{bin: "codex", disableProjectSettings: true}
+	args := a.withStepArgs(RunOpts{StepArgsOverride: map[string][]string{"codex": {"-m", "gpt-5.4"}}}).
+		buildArgs("review", "", "")
+	if !argsContainPair(args, "-c", "project_doc_max_bytes=0") {
+		t.Errorf("buildArgs = %v, want project-settings suppression preserved under a per-step profile", args)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--dangerously-bypass-approvals-and-sandbox") || !strings.Contains(joined, "--json") {
+		t.Errorf("buildArgs = %v, want the managed flags preserved", args)
+	}
+}
+
+func TestClaudeBuildArgs_UsesPerStepProfile(t *testing.T) {
+	a := &claudeAgent{bin: "claude", extraArgs: []string{"--model", "haiku"}}
+	args := a.withStepArgs(RunOpts{StepArgsOverride: map[string][]string{"claude": {"--model", "opus"}}}).
+		buildArgs(nil, "")
+	if !argsContainPair(args, "--model", "opus") {
+		t.Errorf("buildArgs = %v, want the per-step model", args)
+	}
+	if !strings.Contains(strings.Join(args, " "), "--dangerously-skip-permissions") {
+		t.Errorf("buildArgs = %v, want the managed permission flag preserved", args)
+	}
+}
+
+func TestClaudeWithStepArgs_IgnoresAnotherAgentsProfile(t *testing.T) {
+	a := &claudeAgent{bin: "claude", extraArgs: []string{"--model", "haiku"}}
+	stepped := a.withStepArgs(RunOpts{StepArgsOverride: map[string][]string{"codex": {"-m", "gpt-5.4"}}})
+	if stepped != a {
+		t.Fatal("an unrelated agent's profile must not produce a modified adapter")
+	}
+	if !argsContainPair(stepped.buildArgs(nil, ""), "--model", "haiku") {
+		t.Error("claude must keep its global args when the profile names only codex")
+	}
+}
+
+func TestCopilotBuildArgs_UsesPerStepProfile(t *testing.T) {
+	a := &copilotAgent{bin: "copilot", extraArgs: []string{"--model", "cheap"}}
+	args := a.withStepArgs(RunOpts{StepArgsOverride: map[string][]string{"copilot": {"--model", "strong", "--effort", "high"}}}).
+		buildArgs("p")
+	if !argsContainPair(args, "--model", "strong") || !argsContainPair(args, "--effort", "high") {
+		t.Errorf("buildArgs = %v, want the per-step profile", args)
+	}
+}
+
+func TestPiBuildArgs_UsesPerStepProfile(t *testing.T) {
+	a := &piAgent{bin: "pi", extraArgs: []string{"--model", "cheap"}}
+	args := a.withStepArgs(RunOpts{StepArgsOverride: map[string][]string{"pi": {"--model", "strong"}}}).buildArgs()
+	if !argsContainPair(args, "--model", "strong") {
+		t.Errorf("buildArgs = %v, want the per-step profile", args)
+	}
+	if !argsContainPair(args, "--mode", "json") {
+		t.Errorf("buildArgs = %v, want the managed flags preserved", args)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,10 +53,14 @@ type GlobalConfig struct {
 	ACPRegistryOverrides map[string]string   `yaml:"acp_registry_overrides"`
 	AgentPathOverride    map[string]string   `yaml:"agent_path_override"`
 	AgentArgsOverride    map[string][]string `yaml:"agent_args_override"`
-	CITimeout            time.Duration       `yaml:"-"`
-	StepQuietWarning     time.Duration       `yaml:"-"`
-	DaemonConnectTimeout time.Duration       `yaml:"-"`
-	LogLevel             string              `yaml:"log_level"`
+	// AgentArgsOverrideStep is the per-pipeline-step profile map, keyed
+	// step -> agent -> args. An entry REPLACES AgentArgsOverride for that
+	// step and agent; steps and agents without an entry keep the global one.
+	AgentArgsOverrideStep map[string]map[string][]string `yaml:"agent_args_override_per_step"`
+	CITimeout             time.Duration                  `yaml:"-"`
+	StepQuietWarning      time.Duration                  `yaml:"-"`
+	DaemonConnectTimeout  time.Duration                  `yaml:"-"`
+	LogLevel              string                         `yaml:"log_level"`
 	// SessionReuse controls per-run, per-role agent session reuse in the
 	// review loop (one durable reviewer session across full reviews, a
 	// separate durable fixer session across fix turns). Default true; set
@@ -70,21 +74,22 @@ type GlobalConfig struct {
 
 // globalConfigRaw is the on-disk YAML representation with duration as string.
 type globalConfigRaw struct {
-	Agent                agentList           `yaml:"agent"`
-	ACPXPath             string              `yaml:"acpx_path"`
-	ACPRegistryOverrides map[string]string   `yaml:"acp_registry_overrides"`
-	AgentPathOverride    map[string]string   `yaml:"agent_path_override"`
-	AgentArgsOverride    map[string][]string `yaml:"agent_args_override"`
-	CITimeout            string              `yaml:"ci_timeout"`
-	DaemonConnectTimeout string              `yaml:"daemon_connect_timeout"`
-	BabysitTimeout       string              `yaml:"babysit_timeout"`
-	StepQuietWarning     string              `yaml:"step_quiet_warning"`
-	LogLevel             string              `yaml:"log_level"`
-	SessionReuse         *bool               `yaml:"session_reuse"`
-	AutoFix              AutoFixRaw          `yaml:"auto_fix"`
-	Commit               CommitRaw           `yaml:"commit"`
-	Intent               IntentRaw           `yaml:"intent"`
-	Test                 TestRaw             `yaml:"test"`
+	Agent                 agentList                      `yaml:"agent"`
+	ACPXPath              string                         `yaml:"acpx_path"`
+	ACPRegistryOverrides  map[string]string              `yaml:"acp_registry_overrides"`
+	AgentPathOverride     map[string]string              `yaml:"agent_path_override"`
+	AgentArgsOverride     map[string][]string            `yaml:"agent_args_override"`
+	AgentArgsOverrideStep map[string]map[string][]string `yaml:"agent_args_override_per_step"`
+	CITimeout             string                         `yaml:"ci_timeout"`
+	DaemonConnectTimeout  string                         `yaml:"daemon_connect_timeout"`
+	BabysitTimeout        string                         `yaml:"babysit_timeout"`
+	StepQuietWarning      string                         `yaml:"step_quiet_warning"`
+	LogLevel              string                         `yaml:"log_level"`
+	SessionReuse          *bool                          `yaml:"session_reuse"`
+	AutoFix               AutoFixRaw                     `yaml:"auto_fix"`
+	Commit                CommitRaw                      `yaml:"commit"`
+	Intent                IntentRaw                      `yaml:"intent"`
+	Test                  TestRaw                        `yaml:"test"`
 }
 
 // RepoConfig represents .no-mistakes.yaml in a repo root.
@@ -200,17 +205,20 @@ type Config struct {
 	ACPRegistryOverrides map[string]string
 	AgentPathOverride    map[string]string
 	AgentArgsOverride    map[string][]string
-	CITimeout            time.Duration
-	StepQuietWarning     time.Duration
-	LogLevel             string
-	SessionReuse         bool
-	Commands             Commands
-	IgnorePatterns       []string
-	AutoFix              AutoFix
-	Commit               Commit
-	Intent               Intent
-	Test                 Test
-	Document             Document
+	// AgentArgsOverrideStep carries per-step agent arg profiles, keyed
+	// step -> agent -> args. Read it through AgentArgsForStep.
+	AgentArgsOverrideStep map[string]map[string][]string
+	CITimeout             time.Duration
+	StepQuietWarning      time.Duration
+	LogLevel              string
+	SessionReuse          bool
+	Commands              Commands
+	IgnorePatterns        []string
+	AutoFix               AutoFix
+	Commit                Commit
+	Intent                Intent
+	Test                  Test
+	Document              Document
 	// DisableProjectSettings is the resolved, trusted-only opt-out (see the
 	// RepoConfig field). When true, gate agents are launched with their
 	// project-level settings/instructions suppressed; the daemon fails the run
@@ -378,6 +386,24 @@ log_level: info
 #     - service_tier="priority"
 #     - -c
 #     - model_reasoning_effort="low"
+#
+# Per-step agent flag profiles (optional, global only). Keyed step -> agent ->
+# flags; a listed step/agent REPLACES its agent_args_override entry for that
+# step only, so you can pay for a strong model where it matters and a cheap one
+# elsewhere. Steps and agents without an entry keep the global flags.
+# Supported for claude, codex, pi, and copilot (agents whose argv is rebuilt on
+# every invocation).
+# agent_args_override_per_step:
+#   review:
+#     codex:
+#       - -m
+#       - gpt-5.4
+#       - -c
+#       - model_reasoning_effort="high"
+#   document:
+#     codex:
+#       - -m
+#       - gpt-5.4-mini
 #
 # Maximum follow-up auto-fix attempts per step (0 = disabled after the initial pass)
 # Document fixes are attempted during the initial document pass.
@@ -771,6 +797,25 @@ func (c *Config) AgentArgsFor(name types.AgentName) []string {
 	return c.AgentArgsOverride[string(name)]
 }
 
+// AgentArgsForStep returns the per-step agent arg profile for step, keyed by
+// agent name. A present entry REPLACES the global agent_args_override entry for
+// that agent for the duration of that step; agents absent from the returned map
+// keep their global args. Returns nil when the step has no profile.
+func (c *Config) AgentArgsForStep(step types.StepName) map[string][]string {
+	if c == nil || c.AgentArgsOverrideStep == nil {
+		return nil
+	}
+	byAgent := c.AgentArgsOverrideStep[string(step)]
+	if len(byAgent) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(byAgent))
+	for name, args := range byAgent {
+		out[name] = append([]string(nil), args...)
+	}
+	return out
+}
+
 // agentArgsOverrideAgents lists native agent names accepted as keys in
 // agent_args_override.
 var agentArgsOverrideAgents = map[string]bool{
@@ -859,6 +904,77 @@ func validateAgentArgsOverride(override map[string][]string) error {
 	return nil
 }
 
+// perStepArgsOverrideAgents lists the agents whose argv is rebuilt on every
+// invocation, so a per-step profile can actually take effect. Server-backed
+// adapters (rovodev, opencode) bake their extra args into a persistent server
+// started once per run, and ACP targets ignore extra args entirely; accepting a
+// per-step key for them would silently do nothing, so it is rejected instead.
+var perStepArgsOverrideAgents = map[string]bool{
+	string(types.AgentClaude):  true,
+	string(types.AgentCodex):   true,
+	string(types.AgentPi):      true,
+	string(types.AgentCopilot): true,
+}
+
+// projectSettingsPinnedArgs lists, per agent, the flags that participate in the
+// trusted disable_project_settings opt-out. The daemon verifies suppression once
+// per run against the run-level agent args (agent.EnsureGateNeutralized), so a
+// per-step profile must never be able to re-enable a project-instruction surface
+// after that check has passed. Pinning them per step is rejected; the adapters
+// still add their own suppression flags when the opt-out is active.
+var projectSettingsPinnedArgs = map[string]map[string]bool{
+	string(types.AgentClaude): {"--setting-sources": true},
+	string(types.AgentCodex):  {"project_doc_max_bytes": true},
+}
+
+// validateAgentArgsOverridePerStep ensures each key is a known pipeline step,
+// each nested key is an agent that supports per-invocation args, and each arg
+// clears the same reserved-flag rules as the global override.
+func validateAgentArgsOverridePerStep(override map[string]map[string][]string) error {
+	validSteps := make(map[string]bool, len(types.AllSteps()))
+	for _, step := range types.AllSteps() {
+		validSteps[string(step)] = true
+	}
+	for step, byAgent := range override {
+		if !validSteps[step] {
+			return fmt.Errorf("invalid step name in agent_args_override_per_step: %q (valid: %s)", step, stepNameList())
+		}
+		for name, args := range byAgent {
+			if !perStepArgsOverrideAgents[name] {
+				return fmt.Errorf("invalid agent name in agent_args_override_per_step.%s: %q (valid: claude, codex, pi, copilot)", step, name)
+			}
+			reserved := reservedAgentArgs[name]
+			pinned := projectSettingsPinnedArgs[name]
+			for i, arg := range args {
+				if strings.TrimSpace(arg) == "" {
+					return fmt.Errorf("invalid agent_args_override_per_step.%s.%s[%d]: empty arg", step, name, i)
+				}
+				base := arg
+				if idx := strings.Index(arg, "="); idx > 0 {
+					base = arg[:idx]
+				}
+				if reserved[base] {
+					return fmt.Errorf("invalid agent_args_override_per_step.%s.%s[%d]: %q is managed by no-mistakes and cannot be overridden", step, name, i, arg)
+				}
+				for flag := range pinned {
+					if base == flag || strings.Contains(arg, flag) {
+						return fmt.Errorf("invalid agent_args_override_per_step.%s.%s[%d]: %q affects project-settings suppression and can only be set in agent_args_override", step, name, i, arg)
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func stepNameList() string {
+	names := make([]string, 0, len(types.AllSteps()))
+	for _, step := range types.AllSteps() {
+		names = append(names, string(step))
+	}
+	return strings.Join(names, ", ")
+}
+
 // EnsureDefaultGlobalConfig writes the default config file at path if it does
 // not already exist. Failures are logged at debug level and silently ignored.
 func EnsureDefaultGlobalConfig(path string) {
@@ -930,6 +1046,12 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 			return nil, err
 		}
 		cfg.AgentArgsOverride = raw.AgentArgsOverride
+	}
+	if raw.AgentArgsOverrideStep != nil {
+		if err := validateAgentArgsOverridePerStep(raw.AgentArgsOverrideStep); err != nil {
+			return nil, err
+		}
+		cfg.AgentArgsOverrideStep = raw.AgentArgsOverrideStep
 	}
 	timeoutValue := raw.CITimeout
 	if timeoutValue == "" {
@@ -1259,17 +1381,20 @@ func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 		ACPRegistryOverrides: global.ACPRegistryOverrides,
 		AgentPathOverride:    global.AgentPathOverride,
 		AgentArgsOverride:    global.AgentArgsOverride,
-		CITimeout:            global.CITimeout,
-		StepQuietWarning:     global.StepQuietWarning,
-		LogLevel:             global.LogLevel,
-		SessionReuse:         global.SessionReuse,
-		Commands:             repo.Commands,
-		IgnorePatterns:       repo.IgnorePatterns,
-		AutoFix:              af,
-		Commit:               commit,
-		Intent:               intent,
-		Test:                 test,
-		Document:             Document{Instructions: strings.TrimSpace(repo.Document.Instructions)},
+		// Per-step profiles are global-only, like agent_args_override: they
+		// describe the operator's local agent setup, not repo policy.
+		AgentArgsOverrideStep: global.AgentArgsOverrideStep,
+		CITimeout:             global.CITimeout,
+		StepQuietWarning:      global.StepQuietWarning,
+		LogLevel:              global.LogLevel,
+		SessionReuse:          global.SessionReuse,
+		Commands:              repo.Commands,
+		IgnorePatterns:        repo.IgnorePatterns,
+		AutoFix:               af,
+		Commit:                commit,
+		Intent:                intent,
+		Test:                  test,
+		Document:              Document{Instructions: strings.TrimSpace(repo.Document.Instructions)},
 		// repo is the EffectiveRepoConfig result, so this value is already
 		// trusted-only (EffectiveRepoConfig sourced it from the trusted copy).
 		DisableProjectSettings: repo.DisableProjectSettings,

--- a/internal/config/config_step_args_override_test.go
+++ b/internal/config/config_step_args_override_test.go
@@ -1,0 +1,156 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+func writeGlobalConfig(t *testing.T, data string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+func TestLoadGlobal_AgentArgsOverridePerStep(t *testing.T) {
+	path := writeGlobalConfig(t, `agent_args_override:
+  codex:
+    - -m
+    - gpt-5.4
+agent_args_override_per_step:
+  review:
+    codex:
+      - -m
+      - gpt-5.4
+      - -c
+      - model_reasoning_effort="high"
+  document:
+    codex:
+      - -m
+      - gpt-5.4-mini
+`)
+	cfg, err := LoadGlobal(path)
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	merged := Merge(cfg, &RepoConfig{})
+
+	want := map[string][]string{"codex": {"-m", "gpt-5.4", "-c", `model_reasoning_effort="high"`}}
+	if got := merged.AgentArgsForStep(types.StepReview); !reflect.DeepEqual(got, want) {
+		t.Errorf("AgentArgsForStep(review) = %v, want %v", got, want)
+	}
+	if got := merged.AgentArgsForStep(types.StepDocument); !reflect.DeepEqual(got, map[string][]string{"codex": {"-m", "gpt-5.4-mini"}}) {
+		t.Errorf("AgentArgsForStep(document) = %v", got)
+	}
+	// A step with no profile falls back to the global override, which the
+	// adapters keep using when no per-step entry names them.
+	if got := merged.AgentArgsForStep(types.StepTest); got != nil {
+		t.Errorf("AgentArgsForStep(test) = %v, want nil so the global args apply", got)
+	}
+	if got := merged.AgentArgsFor(types.AgentCodex); !reflect.DeepEqual(got, []string{"-m", "gpt-5.4"}) {
+		t.Errorf("global AgentArgsFor(codex) = %v, want the global override untouched", got)
+	}
+}
+
+func TestAgentArgsForStep_NilConfigAndMissingMap(t *testing.T) {
+	var nilCfg *Config
+	if got := nilCfg.AgentArgsForStep(types.StepReview); got != nil {
+		t.Errorf("nil config AgentArgsForStep = %v, want nil", got)
+	}
+	if got := (&Config{}).AgentArgsForStep(types.StepReview); got != nil {
+		t.Errorf("empty config AgentArgsForStep = %v, want nil", got)
+	}
+}
+
+func TestAgentArgsForStep_ReturnsCopy(t *testing.T) {
+	cfg := &Config{AgentArgsOverrideStep: map[string]map[string][]string{
+		"review": {"codex": {"-m", "gpt-5.4"}},
+	}}
+	got := cfg.AgentArgsForStep(types.StepReview)
+	got["codex"][0] = "mutated"
+	got["claude"] = []string{"injected"}
+	if cfg.AgentArgsOverrideStep["review"]["codex"][0] != "-m" {
+		t.Error("AgentArgsForStep must not alias the config's arg slices")
+	}
+	if _, ok := cfg.AgentArgsOverrideStep["review"]["claude"]; ok {
+		t.Error("AgentArgsForStep must not alias the config's map")
+	}
+}
+
+func TestLoadGlobal_AgentArgsOverridePerStep_Rejects(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    string
+		wantErr string
+	}{
+		{
+			name:    "unknown step",
+			data:    "agent_args_override_per_step:\n  deploy:\n    codex:\n      - -m\n",
+			wantErr: "invalid step name",
+		},
+		{
+			name:    "unknown agent",
+			data:    "agent_args_override_per_step:\n  review:\n    gpt:\n      - -m\n",
+			wantErr: "invalid agent name",
+		},
+		{
+			// Server-backed adapters fix their argv when the per-run server
+			// starts, so a per-step entry could never take effect.
+			name:    "server-backed agent",
+			data:    "agent_args_override_per_step:\n  review:\n    opencode:\n      - --model\n",
+			wantErr: "invalid agent name",
+		},
+		{
+			name:    "reserved flag",
+			data:    "agent_args_override_per_step:\n  review:\n    codex:\n      - --json\n",
+			wantErr: "managed by no-mistakes",
+		},
+		{
+			name:    "empty arg",
+			data:    "agent_args_override_per_step:\n  review:\n    codex:\n      - \"  \"\n",
+			wantErr: "empty arg",
+		},
+		{
+			// The daemon verifies project-settings suppression once per run
+			// against the run-level args; a per-step profile must not be able
+			// to re-open that surface afterwards.
+			name:    "codex project doc pin",
+			data:    "agent_args_override_per_step:\n  review:\n    codex:\n      - -c\n      - project_doc_max_bytes=8192\n",
+			wantErr: "project-settings suppression",
+		},
+		{
+			name:    "claude setting sources pin",
+			data:    "agent_args_override_per_step:\n  review:\n    claude:\n      - --setting-sources\n      - project\n",
+			wantErr: "project-settings suppression",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := LoadGlobal(writeGlobalConfig(t, tt.data))
+			if err == nil {
+				t.Fatalf("expected error for %s", tt.name)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %v, want it to mention %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMerge_PreservesAgentArgsOverridePerStep(t *testing.T) {
+	global := &GlobalConfig{AgentArgsOverrideStep: map[string]map[string][]string{
+		"lint": {"claude": {"--model", "haiku"}},
+	}}
+	cfg := Merge(global, &RepoConfig{})
+	if got := cfg.AgentArgsForStep(types.StepLint); !reflect.DeepEqual(got, map[string][]string{"claude": {"--model", "haiku"}}) {
+		t.Errorf("merged AgentArgsForStep(lint) = %v", got)
+	}
+}

--- a/internal/e2e/per_step_agent_args_test.go
+++ b/internal/e2e/per_step_agent_args_test.go
@@ -1,0 +1,110 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// TestPerStepAgentArgsProfile is the end-user proof for
+// agent_args_override_per_step: a real daemon run launches each step's agent
+// process with that step's flags, and a step with no profile still gets the
+// global agent_args_override flags. The assertion reads the fake agent's
+// recorded argv, which is the actual command line the daemon executed.
+func TestPerStepAgentArgsProfile(t *testing.T) {
+	h := NewHarness(t, SetupOpts{Agent: "claude"})
+
+	const (
+		globalModel   = "global-model"
+		reviewModel   = "review-model"
+		documentModel = "document-model"
+	)
+
+	globalConfig := filepath.Join(h.NMHome, "config.yaml")
+	data, err := os.ReadFile(globalConfig)
+	if err != nil {
+		t.Fatalf("read global config: %v", err)
+	}
+	source := string(data) + fmt.Sprintf(`agent_args_override:
+  claude:
+    - --model
+    - %s
+agent_args_override_per_step:
+  review:
+    claude:
+      - --model
+      - %s
+  document:
+    claude:
+      - --model
+      - %s
+`, globalModel, reviewModel, documentModel)
+	if err := os.WriteFile(globalConfig, []byte(source), 0o644); err != nil {
+		t.Fatalf("write global config: %v", err)
+	}
+
+	if out, err := h.Run("init"); err != nil {
+		t.Fatalf("init: %v\n%s", err, out)
+	}
+
+	const branch = "feature/per-step-agent-args"
+	h.CommitChange(branch, "feature.txt", "per-step profile\n", "add feature")
+	h.PushToGate(branch)
+
+	run := h.WaitForRun(branch, 120*time.Second)
+	if run.Status != types.RunCompleted {
+		t.Fatalf("run status = %s, want completed (error=%v)", run.Status, run.Error)
+	}
+
+	// Every invocation carries its phase boundary in the prompt, so the
+	// recorded argv can be attributed back to the step that made the call.
+	byStep := map[types.StepName][][]string{}
+	for _, inv := range h.AgentInvocations() {
+		for _, step := range types.AllSteps() {
+			if strings.Contains(inv.Prompt, fmt.Sprintf("You are the %s phase", step)) {
+				byStep[step] = append(byStep[step], inv.Args)
+				break
+			}
+		}
+	}
+
+	assertModel := func(step types.StepName, want string) {
+		t.Helper()
+		invocations := byStep[step]
+		if len(invocations) == 0 {
+			t.Fatalf("no agent invocation recorded for the %s step", step)
+		}
+		for i, args := range invocations {
+			if !argvHasPair(args, "--model", want) {
+				t.Errorf("%s invocation %d argv = %v, want --model %s", step, i, args, want)
+			}
+			for _, other := range []string{globalModel, reviewModel, documentModel} {
+				if other != want && argvHasPair(args, "--model", other) {
+					t.Errorf("%s invocation %d argv = %v, must not carry --model %s", step, i, args, other)
+				}
+			}
+		}
+		t.Logf("%s step launched with --model %s (argv: %v)", step, want, invocations[0])
+	}
+
+	assertModel(types.StepReview, reviewModel)
+	assertModel(types.StepDocument, documentModel)
+	// Test has no profile, so it falls back to the global override.
+	assertModel(types.StepTest, globalModel)
+}
+
+func argvHasPair(args []string, flag, value string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -671,6 +671,9 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 
 	stepAgent := e.agent
 	if stepAgent != nil {
+		if stepArgs := e.config.AgentArgsForStep(stepName); len(stepArgs) > 0 {
+			stepAgent = &stepArgsAgent{inner: stepAgent, args: stepArgs}
+		}
 		stepAgent = &gateStepBoundaryAgent{inner: stepAgent, phase: stepName}
 		stepAgent = &lifecycleAgent{inner: stepAgent, onLifecycle: onAgentLifecycle}
 		stepAgent = &perfRecordingAgent{
@@ -984,6 +987,42 @@ func roundInsertID(_ string, inserted *db.StepRound, err error) string {
 		return ""
 	}
 	return inserted.ID
+}
+
+// stepArgsAgent applies the operator's per-step agent flag profile (global
+// config agent_args_override_per_step) to every invocation made by one step, so
+// an expensive step such as review can run on a strong model while cheap
+// housekeeping steps run on a small one. The map is keyed by agent name and
+// each adapter picks out its own entry, so a fallback provider the profile does
+// not name keeps its globally configured args.
+type stepArgsAgent struct {
+	inner agent.Agent
+	args  map[string][]string
+}
+
+func (a *stepArgsAgent) Name() string { return a.inner.Name() }
+
+func (a *stepArgsAgent) Run(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+	opts.StepArgsOverride = a.args
+	return a.inner.Run(ctx, opts)
+}
+
+func (a *stepArgsAgent) Close() error { return a.inner.Close() }
+
+func (a *stepArgsAgent) SupportsSessionResume() bool {
+	return agent.SupportsSessionResume(a.inner)
+}
+
+func (a *stepArgsAgent) SupportsSessionProvider(provider string) bool {
+	return agent.SupportsSessionProvider(a.inner, provider)
+}
+
+func (a *stepArgsAgent) ReportsAgentAttempts() bool {
+	return agent.ReportsAgentAttempts(a.inner)
+}
+
+func (a *stepArgsAgent) NeutralizesGateInstructions() bool {
+	return agent.NeutralizesGateInstructions(a.inner)
 }
 
 type gateStepBoundaryAgent struct {

--- a/internal/pipeline/executor_step_args_test.go
+++ b/internal/pipeline/executor_step_args_test.go
@@ -1,0 +1,107 @@
+package pipeline
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/agent"
+	"github.com/kunchenguid/no-mistakes/internal/config"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// stepArgsCaptureAgent records the per-step arg profile each invocation carried,
+// keyed by the step that made it (the prompt is the step name).
+type stepArgsCaptureAgent struct {
+	mu   sync.Mutex
+	seen map[string]map[string][]string
+}
+
+func (a *stepArgsCaptureAgent) Name() string { return "capture" }
+
+func (a *stepArgsCaptureAgent) Run(_ context.Context, opts agent.RunOpts) (*agent.Result, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.seen == nil {
+		a.seen = map[string]map[string][]string{}
+	}
+	a.seen[opts.Purpose] = opts.StepArgsOverride
+	return &agent.Result{}, nil
+}
+
+func (a *stepArgsCaptureAgent) Close() error { return nil }
+
+func (a *stepArgsCaptureAgent) argsFor(step types.StepName) map[string][]string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.seen[string(step)]
+}
+
+// agentInvokingStep makes exactly one agent invocation labelled with its own
+// step name.
+type agentInvokingStep struct{ name types.StepName }
+
+func (s *agentInvokingStep) Name() types.StepName { return s.name }
+
+func (s *agentInvokingStep) Execute(sctx *StepContext) (*StepOutcome, error) {
+	if _, err := sctx.Agent.Run(sctx.Ctx, agent.RunOpts{Purpose: string(s.name), Prompt: "work"}); err != nil {
+		return nil, err
+	}
+	return &StepOutcome{ExitCode: 0}, nil
+}
+
+// TestExecutor_AppliesPerStepAgentArgs is the end-to-end contract for
+// agent_args_override_per_step: each step's agent invocation carries that
+// step's profile, and a step with no profile carries none, so the adapter falls
+// back to its globally configured args.
+func TestExecutor_AppliesPerStepAgentArgs(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+
+	cfg := &config.Config{
+		AgentArgsOverride: map[string][]string{"codex": {"-m", "gpt-5.4-mini"}},
+		AgentArgsOverrideStep: map[string]map[string][]string{
+			"review": {"codex": {"-m", "gpt-5.4", "-c", `model_reasoning_effort="high"`}},
+			"lint":   {"codex": {"-m", "gpt-5.4-nano"}},
+		},
+	}
+	capture := &stepArgsCaptureAgent{}
+
+	exec := NewExecutor(database, p, cfg, capture, []Step{
+		&agentInvokingStep{name: types.StepReview},
+		&agentInvokingStep{name: types.StepTest},
+		&agentInvokingStep{name: types.StepLint},
+	}, nil)
+
+	if err := exec.Execute(context.Background(), run, repo, workDir); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	wantReview := map[string][]string{"codex": {"-m", "gpt-5.4", "-c", `model_reasoning_effort="high"`}}
+	if got := capture.argsFor(types.StepReview); !reflect.DeepEqual(got, wantReview) {
+		t.Errorf("review invocation profile = %v, want %v", got, wantReview)
+	}
+	if got := capture.argsFor(types.StepLint); !reflect.DeepEqual(got, map[string][]string{"codex": {"-m", "gpt-5.4-nano"}}) {
+		t.Errorf("lint invocation profile = %v", got)
+	}
+	if got := capture.argsFor(types.StepTest); got != nil {
+		t.Errorf("test invocation profile = %v, want none so the global args apply", got)
+	}
+}
+
+func TestStepArgsAgent_SetsProfileAndForwardsCapabilities(t *testing.T) {
+	inner := &usageAgent{resumable: true}
+	args := map[string][]string{"codex": {"-m", "gpt-5.4"}}
+	wrapped := &stepArgsAgent{inner: inner, args: args}
+
+	if !agent.SupportsSessionResume(wrapped) {
+		t.Error("stepArgsAgent must not hide the inner adapter's session-resume capability")
+	}
+	if wrapped.Name() != inner.Name() {
+		t.Errorf("Name() = %q, want the inner adapter's name %q", wrapped.Name(), inner.Name())
+	}
+	if _, err := wrapped.Run(context.Background(), agent.RunOpts{}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+}

--- a/internal/pipeline/steps/rebase.go
+++ b/internal/pipeline/steps/rebase.go
@@ -79,6 +79,9 @@ func (s *RebaseStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome,
 	if outcome := detectBundledLocalDefaultCommits(ctx, sctx, branch, defaultBranch); outcome != nil {
 		return outcome, nil
 	}
+	if outcome := detectSharedBranchRewrite(ctx, sctx, branch, defaultBranch); outcome != nil {
+		return outcome, nil
+	}
 	if forcePush && branch == defaultBranch && remoteDefaultBranchAdvanced(ctx, sctx.WorkDir, defaultBranch, sctx.Run.BaseSHA) {
 		findingsJSON, _ := json.Marshal(Findings{
 			Items: []Finding{{
@@ -242,6 +245,88 @@ func detectBundledLocalDefaultCommits(ctx context.Context, sctx *pipeline.StepCo
 			Action: types.ActionAskUser,
 		}},
 		Summary: fmt.Sprintf("branch bundles %d unpushed %s commit(s)", len(commits), defaultBranch),
+	})
+	return &pipeline.StepOutcome{
+		NeedsApproval: true,
+		AutoFixable:   false,
+		Findings:      string(findingsJSON),
+	}
+}
+
+// detectSharedBranchRewrite refuses to rewrite a branch the run does not own.
+//
+// The pipeline rebases the gated branch onto the fresh default branch and then
+// force-pushes the result. That is safe for an ordinary single-author feature
+// branch, whose history is linear and whose recorded base sits on the default
+// branch's own advancing lineage. It is destructive for a shared integration
+// branch that a worker deliberately assembled from several merge commits on a
+// specific base: the rebase linearizes those merges, replays the work onto a
+// different lineage that no longer contains the recorded base, and the
+// force-push then rewrites the shared ref - discarding an integration history
+// nobody chose to discard, and validating a base different from the one the
+// worker built on (the incident this guard exists to stop).
+//
+// The guard fails loudly, naming the branch, only when BOTH signals of that
+// shape are present, so ordinary gating is untouched:
+//   - the recorded BaseSHA is a real commit that is NOT an ancestor of the new
+//     base (origin/<default>), so the rebase would move the work onto a
+//     different lineage and drop the base from HEAD's ancestry; and
+//   - the range the rewrite would rewrite (BaseSHA..HEAD) carries merge commits,
+//     which the run itself never authors (it rebases, i.e. linearizes) and which
+//     mark a deliberately assembled integration history.
+//
+// A linear single-author feature branch fails the second check. A branch based
+// on the default branch's own advancing lineage fails the first (the old base is
+// still an ancestor of the newer default). Both must hold, which is exactly the
+// shared-integration-branch case. Returns nil to let the run proceed.
+func detectSharedBranchRewrite(ctx context.Context, sctx *pipeline.StepContext, branch, defaultBranch string) *pipeline.StepOutcome {
+	if branch == "" || branch == defaultBranch {
+		return nil
+	}
+	baseSHA := strings.TrimSpace(sctx.Run.BaseSHA)
+	if baseSHA == "" || git.IsZeroSHA(baseSHA) {
+		return nil
+	}
+	// The recorded base must be a real commit and a real ancestor of HEAD for
+	// the range and the lineage comparison to mean anything.
+	if _, err := git.Run(ctx, sctx.WorkDir, "rev-parse", "--verify", "--quiet", baseSHA+"^{commit}"); err != nil {
+		return nil
+	}
+	if !isAncestor(ctx, sctx.WorkDir, baseSHA, "HEAD") {
+		return nil
+	}
+	newBase := "origin/" + defaultBranch
+	if _, err := git.Run(ctx, sctx.WorkDir, "rev-parse", "--verify", "--quiet", newBase+"^{commit}"); err != nil {
+		return nil
+	}
+	// Same-lineage advance: the recorded base is still an ancestor of the new
+	// default, so rebasing keeps it in ancestry - ordinary gating, do not refuse.
+	if isAncestor(ctx, sctx.WorkDir, baseSHA, newBase) {
+		return nil
+	}
+	// Cross-lineage rebase. Refuse only when the branch carries merge commits the
+	// rebase would linearize - the fingerprint of a deliberately assembled
+	// integration branch the run does not own.
+	merges, err := git.Run(ctx, sctx.WorkDir, "rev-list", "--merges", baseSHA+"..HEAD")
+	if err != nil || strings.TrimSpace(merges) == "" {
+		return nil
+	}
+	mergeCommits := strings.Split(strings.TrimSpace(merges), "\n")
+
+	description := fmt.Sprintf(
+		"refusing to rewrite branch %q: it carries %d merge commit(s) on base %s, and rebasing onto %s would linearize those merges and drop that base from history (the new base is on a different lineage). This branch was assembled by a worker and is not this run's to rewrite; rebasing and force-pushing it would silently validate a different base than the work was built on and discard the integration history. Rebase the branch yourself onto the intended base, or gate a single-author branch instead.",
+		branch, len(mergeCommits), shortSHA(baseSHA), newBase,
+	)
+	findingsJSON, _ := json.Marshal(Findings{
+		Items: []Finding{{
+			Severity:    "error",
+			File:        filepath.Join("internal", "pipeline", "steps", "rebase.go"),
+			Description: description,
+			// Rewriting a shared integration branch is a workflow decision only a
+			// human can make; the pipeline must never auto-resolve it.
+			Action: types.ActionAskUser,
+		}},
+		Summary: fmt.Sprintf("refusing to rewrite shared branch %q (carries merge commits, base changes lineage)", branch),
 	})
 	return &pipeline.StepOutcome{
 		NeedsApproval: true,

--- a/internal/pipeline/steps/rebase_shared_branch_test.go
+++ b/internal/pipeline/steps/rebase_shared_branch_test.go
@@ -1,0 +1,163 @@
+package steps
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/config"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// Reproduces the incident: a worker assembled several tickets onto a shared
+// integration branch as deliberate --no-ff merges on a specific base, then ran
+// the pipeline. origin/<default> had meanwhile advanced onto a different
+// lineage that does not contain that base. The rebase step rebased the shared
+// branch onto that newer default, linearized the merges, dropped the recorded
+// base from ancestry, and force-pushed the shared ref - validating a base
+// nobody built on and discarding the integration history.
+//
+// The rebase step must refuse loudly, naming the branch, and must not rewrite
+// or force-push it.
+func TestRebaseStep_RefusesToRewriteSharedIntegrationBranch(t *testing.T) {
+	t.Parallel()
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	os.WriteFile(filepath.Join(dir, "root.txt"), []byte("root\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "root")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	// Integration base B: where the worker started assembling tickets.
+	gitCmd(t, dir, "checkout", "-b", "integration")
+	os.WriteFile(filepath.Join(dir, "integration_base.txt"), []byte("integration base\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "integration base")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	// Assemble four tickets as deliberate --no-ff merges onto base B.
+	for _, ticket := range []string{"t1", "t2", "t3", "t4"} {
+		gitCmd(t, dir, "checkout", "-b", ticket, baseSHA)
+		os.WriteFile(filepath.Join(dir, ticket+".txt"), []byte(ticket+"\n"), 0o644)
+		gitCmd(t, dir, "add", "-A")
+		gitCmd(t, dir, "commit", "-m", ticket+" work")
+		gitCmd(t, dir, "checkout", "integration")
+		gitCmd(t, dir, "merge", "--no-ff", "-m", "merge "+ticket, ticket)
+	}
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "integration") // pre-existing shared branch
+
+	// origin/main advances onto a DIFFERENT lineage that does not contain B.
+	gitCmd(t, dir, "checkout", "main")
+	os.WriteFile(filepath.Join(dir, "engine_a.txt"), []byte("engine a\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "engine work a")
+	os.WriteFile(filepath.Join(dir, "engine_b.txt"), []byte("engine b\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "engine work b")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "integration")
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Run.Branch = "refs/heads/integration"
+	sctx.Repo.UpstreamURL = upstream
+
+	step := &RebaseStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome == nil || !outcome.NeedsApproval {
+		t.Fatalf("expected the rebase step to refuse rewriting the shared integration branch, got outcome=%#v", outcome)
+	}
+	if outcome.AutoFixable {
+		t.Fatalf("rewriting a shared integration branch is never safely auto-fixable")
+	}
+	if !strings.Contains(outcome.Findings, "integration") {
+		t.Fatalf("expected findings to name the branch, got: %s", outcome.Findings)
+	}
+	findings, err := types.ParseFindingsJSON(outcome.Findings)
+	if err != nil {
+		t.Fatalf("parse findings: %v", err)
+	}
+	if len(findings.Items) != 1 || findings.Items[0].Action != types.ActionAskUser {
+		t.Fatalf("expected one ask-user finding, got: %#v", findings.Items)
+	}
+
+	// The branch must not have been rewritten: HEAD unchanged, merge commits
+	// still present, recorded base still an ancestor.
+	if got := gitCmd(t, dir, "rev-parse", "HEAD"); got != headSHA {
+		t.Fatalf("branch HEAD was rewritten: got %s, want %s", got, headSHA)
+	}
+	merges := gitCmd(t, dir, "rev-list", "--merges", baseSHA+"..HEAD")
+	if strings.TrimSpace(merges) == "" {
+		t.Fatalf("expected the four merge commits to survive, but the range is linear")
+	}
+	// gitCmd fatals on a non-zero exit; --is-ancestor exits 0 only when true, so
+	// this asserts the recorded base is still reachable from HEAD after refusal.
+	gitCmd(t, dir, "merge-base", "--is-ancestor", baseSHA, "HEAD")
+}
+
+// Ordinary gating on a fresh single-author branch must still work: the guard
+// must not fire, and the rebase onto the advanced default branch must apply.
+func TestRebaseStep_OrdinaryFeatureBranchStillRebases(t *testing.T) {
+	t.Parallel()
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir := t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	os.WriteFile(filepath.Join(dir, "base.txt"), []byte("base\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "base commit")
+	baseSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	// Fresh linear single-author feature branch off the base.
+	gitCmd(t, dir, "checkout", "-b", "feature")
+	os.WriteFile(filepath.Join(dir, "feature.txt"), []byte("feature\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature change")
+	headSHA := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	// Default advances on its own lineage (base stays an ancestor).
+	gitCmd(t, dir, "checkout", "main")
+	os.WriteFile(filepath.Join(dir, "other.txt"), []byte("main update\n"), 0o644)
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "main update")
+	gitCmd(t, dir, "push", "origin", "main")
+	gitCmd(t, dir, "checkout", "feature")
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Repo.UpstreamURL = upstream
+
+	step := &RebaseStep{}
+	outcome, err := step.Execute(sctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome != nil && outcome.NeedsApproval {
+		t.Fatalf("guard must not fire on an ordinary single-author feature branch, got findings: %s", outcome.Findings)
+	}
+	// Rebase onto the advanced default must have applied.
+	headLog := gitCmd(t, dir, "log", "--oneline")
+	if !strings.Contains(headLog, "main update") {
+		t.Fatalf("expected HEAD to include the advanced default after rebase; git log:\n%s", headLog)
+	}
+}


### PR DESCRIPTION
## The incident

A worker assembled four tickets onto a shared integration branch as four deliberate `--no-ff` merges on base `d2341a7d`, then ran this pipeline. The rebase step rebased the shared branch onto a newer `origin/<default>` from a different lineage: it pulled in roughly thirty files nobody chose, linearized the four merge commits, dropped the original base from ancestry, and force-pushed the shared branch. The force-push safety check passed because the rebased head incorporated the remote commits by patch identity. The run reported `passed` even though its pass rested on a base invariant nobody had checked; downstream this broke a cross-repository byte-identity invariant on the money path.

## Two defects

1. **No branch-ownership concept.** `RebaseStep` treated any run branch as its own to rewrite.
2. **The base changed under the validated work and it still passed.** The pipeline validated a base different from the one the worker built on, and nothing detected it.

## Fix

`detectSharedBranchRewrite` runs in `RebaseStep.Execute` before target selection (so it covers both the normal and force-push paths). It refuses, naming the branch, only when **both** signals of the incident are present:

- the recorded `BaseSHA` is not an ancestor of `origin/<default>`, so the rebase would move the work onto a different lineage and drop the base from ancestry; and
- the `BaseSHA..HEAD` range carries merge commits, which the run itself never authors (it rebases, i.e. linearizes) and which mark a deliberately assembled integration branch.

A linear single-author feature branch fails the second check. A branch based on the default branch's own advancing lineage fails the first (the old base is still an ancestor of the newer default). Both must hold, which is exactly the shared-integration-branch case, so ordinary single-author gating is untouched. The refusal parks as an `ask-user` finding with `AutoFixable=false` - rewriting a shared branch is a human workflow decision.

## Second defect: fixed for this shape

Refusing the base-changing rewrite also closes the second half: because the base can no longer silently change to a different lineage when the branch carries merges, the pipeline can no longer validate a different base than the worker built on for the incident shape. Left open, as noted in the code TODO seam, is a fully general defense-in-depth assertion that `BaseSHA` is an ancestor of the validated `HeadSHA` at the pass/CI gate; that would also cover hypothetical base drift without merge commits, but a purely linear branch whose base changes lineage is legitimate rebase behavior, so a blanket assertion was deliberately not added here to avoid breaking normal gating. Scoped narrowly and intentionally.

## Tests

Built test-first. `TestRebaseStep_RefusesToRewriteSharedIntegrationBranch` reproduces the incident (four `--no-ff` merges on a base, default advanced to a divergent lineage) and asserts the branch is not rewritten and the finding is `ask-user`; verified it fails without the guard. `TestRebaseStep_OrdinaryFeatureBranchStillRebases` covers normal single-author gating. Unit-level only (no e2e); the rebase step's existing coverage is unit/integration in-package, matching this change. `go test -race ./internal/pipeline/...` and `make lint` are green.