### PR TITLE
feat: add nix flake for nix run installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,21 @@ jobs:
       - name: Build
         run: go build ./cmd/no-mistakes
 
+  nix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: cachix/install-nix-action@v31
+
+      # The flake pins a fixed-output vendorHash that every go.mod/go.sum
+      # change invalidates. Without this job the Go suite stays green while
+      # `nix run github:kunchenguid/no-mistakes` fails for every user with a
+      # hash mismatch until a human notices.
+      - name: Build flake
+        run: nix build --print-build-logs
+
   e2e:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,12 @@ jobs:
       - name: Build flake
         run: nix build --print-build-logs
 
+      # `nix build` only touches this runner's own system, so a system the
+      # flake advertises but nixpkgs cannot evaluate would surface first as a
+      # user's failed `nix run` on that platform.
+      - name: Check flake on every advertised system
+        run: nix flake check --all-systems
+
   e2e:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build output
 bin/
 tmp/
+result
 
 # Go
 *.exe

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,9 @@ Safest local verification sequence after non-trivial changes:
 **When Making Changes**
 
 - Whenever you must bring in new dependencies, check latest documentation for knowledge, and discuss with the user.
+- Any `go.mod`/`go.sum` change invalidates the fixed-output `vendorHash` pinned in `flake.nix`; recompute it in the same change or the `nix` CI job fails while the Go suite stays green.
+  `flake.nix` is also a release-please `extra-files` target, so its annotated `version` line is stamped at release and must keep matching `.release-please-manifest.json`.
+  Regressions: `TestCIWorkflowBuildsTheFlake`, `TestCIWorkflowChecksEveryAdvertisedFlakeSystem`, `TestReleasePleaseConfigBumpsFlakeVersion`, `TestFlakeVersionMatchesReleaseManifest`.
 - Always use test driven development for bug fixes and feature development.
 
 ## Maintaining this file

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Nothing reaches the configured push target until every check is green.
 curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh
 ```
 
-Windows, Go install, and build-from-source instructions are in the [installation guide](https://kunchenguid.github.io/no-mistakes/start-here/installation/).
+Windows, Go install, Nix, and build-from-source instructions are in the [installation guide](https://kunchenguid.github.io/no-mistakes/start-here/installation/).
 
 ## Quick Start
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -70,7 +70,7 @@
 curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh
 ```
 
-Windows、Go install 以及从源码构建的说明，见[安装指南](https://kunchenguid.github.io/no-mistakes/start-here/installation/)。
+Windows、Go install、Nix 以及从源码构建的说明，见[安装指南](https://kunchenguid.github.io/no-mistakes/start-here/installation/)。
 
 ## 快速上手
 

--- a/docs/src/content/docs/reference/environment.md
+++ b/docs/src/content/docs/reference/environment.md
@@ -154,7 +154,7 @@ Override or enable the telemetry website ID.
 |         |                                                                         |
 | ------- | ----------------------------------------------------------------------- |
 | Type    | `string`                                                                |
-| Default | embedded in Makefile and release builds; unset in unembedded dev builds |
+| Default | embedded in Makefile, flake, and release builds; unset in unembedded dev builds |
 
 When set, telemetry uses this website ID at runtime. If it is unset in a dev build, `no-mistakes` also checks a repo-local `.env` file for `NO_MISTAKES_UMAMI_WEBSITE_ID`. If no runtime value is found, it falls back to any website ID embedded at build time.
 

--- a/docs/src/content/docs/start-here/installation.md
+++ b/docs/src/content/docs/start-here/installation.md
@@ -40,6 +40,9 @@ nix run github:kunchenguid/no-mistakes -- --version
 nix profile install github:kunchenguid/no-mistakes
 ```
 
+The flake builds for `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin`.
+Intel macOS is not covered because nixpkgs dropped `x86_64-darwin`; use the install script or `go install` there.
+
 The flake embeds the default telemetry website ID, so a Nix-built binary reports to the default self-hosted host exactly like an official release binary.
 Disable telemetry with `NO_MISTAKES_TELEMETRY=0`, or override the host and website ID with `NO_MISTAKES_UMAMI_HOST` and `NO_MISTAKES_UMAMI_WEBSITE_ID`.
 

--- a/docs/src/content/docs/start-here/installation.md
+++ b/docs/src/content/docs/start-here/installation.md
@@ -33,6 +33,19 @@ go install github.com/kunchenguid/no-mistakes/cmd/no-mistakes@latest
 
 `go install` builds the CLI without an embedded telemetry website ID, so telemetry stays off by default unless you later set `NO_MISTAKES_UMAMI_WEBSITE_ID` at runtime.
 
+## Nix
+
+```sh
+nix run github:kunchenguid/no-mistakes -- --version
+nix profile install github:kunchenguid/no-mistakes
+```
+
+The flake embeds the default telemetry website ID, so a Nix-built binary reports to the default self-hosted host exactly like an official release binary.
+Disable telemetry with `NO_MISTAKES_TELEMETRY=0`, or override the host and website ID with `NO_MISTAKES_UMAMI_HOST` and `NO_MISTAKES_UMAMI_WEBSITE_ID`.
+
+`no-mistakes update` does not apply to a Nix install, because the binary lives in the read-only Nix store.
+Update the flake input and rebuild instead.
+
 ## From source
 
 ```sh

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1785141334,
+        "narHash": "sha256-kh35kIx7el4Jk8Ki3BH9/Pn1eZYSYLJ6LMALos0zOy0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "38a4887411571457d700c51c64a6e49ead2ed5ab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -11,9 +11,10 @@
       stamp = self.lastModifiedDate;
       inherit (nixpkgs.lib) substring;
       date = "${substring 0 4 stamp}-${substring 4 2 stamp}-${substring 6 2 stamp}T${substring 8 2 stamp}:${substring 10 2 stamp}:${substring 12 2 stamp}Z";
+      # Nixpkgs 26.11 dropped x86_64-darwin, so advertising it here would hand
+      # an Intel Mac user an evaluation throw instead of a binary.
       systems = [
         "aarch64-darwin"
-        "x86_64-darwin"
         "aarch64-linux"
         "x86_64-linux"
       ];

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,13 @@
   };
 
   outputs =
-    { nixpkgs, ... }:
+    { self, nixpkgs, ... }:
     let
       version = "1.41.2"; # x-release-please-version
+      commit = self.shortRev or self.dirtyShortRev or "unknown";
+      stamp = self.lastModifiedDate;
+      inherit (nixpkgs.lib) substring;
+      date = "${substring 0 4 stamp}-${substring 4 2 stamp}-${substring 6 2 stamp}T${substring 8 2 stamp}:${substring 10 2 stamp}:${substring 12 2 stamp}Z";
       systems = [
         "aarch64-darwin"
         "x86_64-darwin"
@@ -30,20 +34,13 @@
             subPackages = [ "cmd/no-mistakes" ];
             ldflags = [
               "-X github.com/kunchenguid/no-mistakes/internal/buildinfo.Version=v${version}"
+              "-X github.com/kunchenguid/no-mistakes/internal/buildinfo.Commit=${commit}"
+              "-X github.com/kunchenguid/no-mistakes/internal/buildinfo.Date=${date}"
               "-X github.com/kunchenguid/no-mistakes/internal/buildinfo.TelemetryWebsiteID=f959e889-92f5-4121-8a1f-571b10861198"
             ];
-            # go test ./... was run in the sandbox (nativeCheckInputs = [ pkgs.git
-            # pkgs.perl pkgs.procps ]; checkPhase overridden past the subPackages
-            # narrowing) and reduced most failures, but three are structural
-            # sandbox mismatches rather than code bugs: TestPRStep_GhNotAvailable
-            # needs a real .git directory (the flake source has none, since Nix
-            # only copies git-tracked files); TestDefaultShellCommandOutput_*
-            # and login-shell resolution need a real /bin/bash FHS path; and
-            # TestColdDetachedStartupProductionGateCardinality asserts a
-            # wall-clock deadline crossing calibrated for real hardware. Full
-            # regression coverage already runs in CI (.github/workflows/ci.yml)
-            # on ubuntu/macos/windows runners, so it is not skipped, only not
-            # duplicated inside this hermetic build.
+            # Parts of the suite need a real .git directory, an FHS /bin/bash,
+            # and real-hardware wall-clock timing, none of which the hermetic
+            # sandbox provides. Full regression runs in CI, not here.
             doCheck = false;
           };
         }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,52 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs =
+    { nixpkgs, ... }:
+    let
+      version = "1.41.2"; # x-release-please-version
+      systems = [
+        "aarch64-darwin"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.buildGoModule {
+            pname = "no-mistakes";
+            inherit version;
+            src = ./.;
+            vendorHash = "sha256-NZOYxNYvt4192uqKBdKRxdgrKFvWx3585psdCnRdPSM=";
+            subPackages = [ "cmd/no-mistakes" ];
+            ldflags = [
+              "-X github.com/kunchenguid/no-mistakes/internal/buildinfo.Version=v${version}"
+              "-X github.com/kunchenguid/no-mistakes/internal/buildinfo.TelemetryWebsiteID=f959e889-92f5-4121-8a1f-571b10861198"
+            ];
+            # go test ./... was run in the sandbox (nativeCheckInputs = [ pkgs.git
+            # pkgs.perl pkgs.procps ]; checkPhase overridden past the subPackages
+            # narrowing) and reduced most failures, but three are structural
+            # sandbox mismatches rather than code bugs: TestPRStep_GhNotAvailable
+            # needs a real .git directory (the flake source has none, since Nix
+            # only copies git-tracked files); TestDefaultShellCommandOutput_*
+            # and login-shell resolution need a real /bin/bash FHS path; and
+            # TestColdDetachedStartupProductionGateCardinality asserts a
+            # wall-clock deadline crossing calibrated for real hardware. Full
+            # regression coverage already runs in CI (.github/workflows/ci.yml)
+            # on ubuntu/macos/windows runners, so it is not skipped, only not
+            # duplicated inside this hermetic build.
+            doCheck = false;
+          };
+        }
+      );
+    };
+}

--- a/flake_test.go
+++ b/flake_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func readFlake(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile("flake.nix")
+	if err != nil {
+		t.Fatalf("read flake.nix: %v", err)
+	}
+	return string(data)
+}
+
+// The `# x-release-please-version` annotation in flake.nix is inert unless the
+// file is registered under extra-files. Without the registration the flake
+// keeps building the last hand-written version forever, so `nix run` misreports
+// `--version` and the CLI advertises an update it can never install from the
+// read-only Nix store.
+func TestReleasePleaseConfigBumpsFlakeVersion(t *testing.T) {
+	data, err := os.ReadFile("release-please-config.json")
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var cfg struct {
+		Packages map[string]struct {
+			ExtraFiles []string `json:"extra-files"`
+		} `json:"packages"`
+	}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	pkg, ok := cfg.Packages["."]
+	if !ok {
+		t.Fatalf("release-please config missing '.' package")
+	}
+	for _, f := range pkg.ExtraFiles {
+		if f == "flake.nix" {
+			return
+		}
+	}
+	t.Fatalf("release-please config must list flake.nix under extra-files; the x-release-please-version annotation is otherwise never applied, got %v", pkg.ExtraFiles)
+}
+
+func TestFlakeVersionMatchesReleaseManifest(t *testing.T) {
+	data, err := os.ReadFile(".release-please-manifest.json")
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var manifest map[string]string
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("parse manifest: %v", err)
+	}
+	want, ok := manifest["."]
+	if !ok {
+		t.Fatalf("manifest missing '.' entry")
+	}
+
+	match := regexp.MustCompile(`version = "([^"]+)"; # x-release-please-version`).FindStringSubmatch(readFlake(t))
+	if match == nil {
+		t.Fatalf("flake.nix must carry an annotated `version = \"...\"; # x-release-please-version` line")
+	}
+	if match[1] != want {
+		t.Fatalf("flake version %q does not match release manifest %q", match[1], want)
+	}
+}
+
+// The flake is a real install path, so it must stamp the same buildinfo
+// variables the Makefile and release workflow stamp; a missing one renders as
+// a placeholder in `no-mistakes --version`.
+func TestFlakeStampsBuildinfoLikeReleaseBuilds(t *testing.T) {
+	content := readFlake(t)
+	for _, name := range []string{"Version", "Commit", "Date", "TelemetryWebsiteID"} {
+		if !strings.Contains(content, "internal/buildinfo."+name+"=") {
+			t.Errorf("flake ldflags must set buildinfo.%s", name)
+		}
+	}
+}

--- a/internal/daemon/lifecycle_test.go
+++ b/internal/daemon/lifecycle_test.go
@@ -85,6 +85,28 @@ func TestDaemonStartTimeoutCoversColdProductionWork(t *testing.T) {
 	}
 }
 
+// The longer stop window compensates for the real Windows loopback IPC
+// transport, not for a service manager, so it must track the host and ignore
+// runtimeGOOS. Dozens of tests simulate systemd or launchd by assigning
+// runtimeGOOS; on a Windows runner that used to cut the budget to the Unix 5s
+// and kill the still-shutting-down daemon by PID.
+func TestDaemonStopTimeoutTracksHostNotSimulatedServiceOS(t *testing.T) {
+	t.Setenv("NM_TEST_DAEMON_STOP_TIMEOUT", "")
+	oldGOOS := runtimeGOOS
+	t.Cleanup(func() { runtimeGOOS = oldGOOS })
+
+	want := 5 * time.Second
+	if runtime.GOOS == "windows" {
+		want = 15 * time.Second
+	}
+	for _, simulated := range []string{"linux", "darwin", "windows"} {
+		runtimeGOOS = simulated
+		if got := daemonStopTimeout(); got != want {
+			t.Errorf("daemonStopTimeout() with runtimeGOOS=%q = %v, want %v", simulated, got, want)
+		}
+	}
+}
+
 func TestEnsureDaemonDoesNotStartWhenHealthCheckTimesOut(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "dtest")
 	if err != nil {

--- a/internal/daemon/selfexec.go
+++ b/internal/daemon/selfexec.go
@@ -37,9 +37,11 @@ func daemonStartTimeout() time.Duration {
 // pending/racing connections fail as immediately as a Unix domain socket
 // unlink does, so the health check can keep reporting an ambiguous error
 // for longer after a graceful shutdown request has already succeeded.
+// That transport is a property of the host, so this reads runtime.GOOS and not
+// runtimeGOOS, which tests reassign to simulate a service manager.
 func daemonStopTimeout() time.Duration {
 	fallback := 5 * time.Second
-	if runtimeGOOS == "windows" {
+	if runtime.GOOS == "windows" {
 		fallback = 15 * time.Second
 	}
 	return durationFromEnv("NM_TEST_DAEMON_STOP_TIMEOUT", fallback)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,10 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "draft": true,
-      "force-tag-creation": true
+      "force-tag-creation": true,
+      "extra-files": [
+        "flake.nix"
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"

--- a/workflow_ci_test.go
+++ b/workflow_ci_test.go
@@ -51,3 +51,18 @@ func TestCIWorkflowBuildsTheFlake(t *testing.T) {
 		t.Fatalf("CI workflow must run `nix build` to catch vendorHash drift")
 	}
 }
+
+// `nix build` and a plain `nix flake check` only touch the runner's own system,
+// so a system the flake advertises but nixpkgs cannot evaluate stays invisible
+// until a user on that platform runs `nix run`. Only `--all-systems` evaluates
+// every advertised system from the Linux runner.
+func TestCIWorkflowChecksEveryAdvertisedFlakeSystem(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/ci.yml")
+	if err != nil {
+		t.Fatalf("read workflow: %v", err)
+	}
+
+	if !strings.Contains(string(data), "run: nix flake check --all-systems") {
+		t.Fatalf("CI workflow must run `nix flake check --all-systems` so every system in flake.nix is evaluated")
+	}
+}

--- a/workflow_ci_test.go
+++ b/workflow_ci_test.go
@@ -34,3 +34,20 @@ func TestCIWorkflowUsesRaceTestsOnUnixRunners(t *testing.T) {
 		t.Fatalf("CI workflow must run the race-enabled suite on Unix runners")
 	}
 }
+
+// The flake's vendorHash is fixed-output and every go.mod/go.sum change
+// invalidates it. Only an actual nix build catches that drift before it ships.
+func TestCIWorkflowBuildsTheFlake(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/ci.yml")
+	if err != nil {
+		t.Fatalf("read workflow: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "install-nix-action") {
+		t.Fatalf("CI workflow must install nix so the flake can be built")
+	}
+	if !strings.Contains(content, "run: nix build") {
+		t.Fatalf("CI workflow must run `nix build` to catch vendorHash drift")
+	}
+}


### PR DESCRIPTION
Closes #237

## Summary

- New `flake.nix` builds only `cmd/no-mistakes` with `buildGoModule` and injects `internal/buildinfo` `Version`, `Commit`, and `Date` via ldflags matching the Makefile/release build, so `nix run github:kunchenguid/no-mistakes -- --version` prints a real version instead of `dev`/`unknown` (verified: `no-mistakes version v1.41.2 (871cfd4) 2026-07-28T04:44:09Z`).
- `TelemetryWebsiteID` is also injected (matching the Makefile's `DEFAULT_UMAMI_WEBSITE_ID`) so a Nix-built binary behaves like an official release binary rather than silently going untracked; this is documented in the new installation.md section alongside the existing `NO_MISTAKES_TELEMETRY=0` opt-out.
- `x86_64-darwin` is intentionally not advertised: pinned `nixpkgs-unstable` throws `Nixpkgs 26.11 has dropped support for x86_64-darwin` when that system is evaluated, which `nix flake check --all-systems` caught. The other three systems (`aarch64-darwin`, `aarch64-linux`, `x86_64-linux`) evaluate and build cleanly.
- `doCheck = false`: `go test ./...` was run inside the Nix sandbox (with `nativeCheckInputs = [ git perl procps ]` and a `checkPhase` override to escape `subPackages` narrowing checkPhase to `cmd/no-mistakes` alone). Only three sandbox-structural failures remain and none are code bugs: a test needing a real `.git` directory (Nix only copies git-tracked files), tests needing a real `/bin/bash` FHS path, and a wall-clock deadline test calibrated for real hardware. Full regression coverage already runs in CI on ubuntu/macos/windows runners.
- Drift guards added so this doesn't silently rot: `release-please-config.json` registers `flake.nix` as an `extra-files` target so the `# x-release-please-version` line gets stamped at release time, and a new `nix` CI job runs `nix build` plus `nix flake check --all-systems` so a `go.mod`/`go.sum` change that invalidates the pinned `vendorHash`, or a nixpkgs system that stops evaluating, fails CI instead of every user's `nix run`. Static tests pin the version/manifest match, the ldflags shape, and the CI job's system coverage.
- Docs: an installation.md entry for the Nix path, including that `no-mistakes update` does not apply to a read-only `/nix/store` binary.
- The CI step's own auto-fix loop additionally fixed an unrelated real Windows CI failure it hit while validating this branch: `daemonStopTimeout()` (`internal/daemon/selfexec.go`) was reading a test-injectable `runtimeGOOS` variable instead of `runtime.GOOS`, so a real Windows runner used the 5s Unix stop budget instead of the 15s Windows one. Flagging this explicitly since it's unrelated to the Nix flake itself but was bundled into the same branch by the mandated pipeline run.

One review item is left open rather than force-resolved: whether `doCheck` should be flipped on. Since `subPackages` narrows the actual checkPhase to `cmd/no-mistakes` alone, enabling it would pass but cover very little of the suite; the PR leaves it off with the reasoning above and welcomes a maintainer call either way.

## Test plan

All of these were run for real, not just asserted:

- `nix build .#default` on `x86_64-linux` — exit 0, binary at `result/bin/no-mistakes`.
- `nix flake check` and `nix flake check --all-systems` — pass on the three advertised systems (`x86_64-darwin` intentionally excluded, see above).
- `nix run .# -- --version` — printed `no-mistakes version v1.41.2 (871cfd4) 2026-07-28T04:44:09Z`, confirming ldflags actually took effect.
- `go test ./...` natively and inside the Nix sandbox — the sandbox run's only three failures are structural (no `.git`, no `/bin/bash`, real-hardware timing), not code bugs; see `doCheck = false` reasoning above.
- CI on this branch: 9/9 checks green, including the new `nix` job.
