### PR TITLE
fix(agent): recover Pi JSON from unclosed fence

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -458,9 +458,16 @@ func lastBareJSONObject(text string, schema json.RawMessage) (json.RawMessage, e
 	var lastErr error
 	for i := 0; i < len(text); i++ {
 		if strings.HasPrefix(text[i:], "```") {
-			contentStart, _ := fenceContentStart(text, i)
+			contentStart, info := fenceContentStart(text, i)
 			next := skipFenceBlock(text[contentStart:])
 			if next < 0 {
+				// A Pi response can prefix its final JSON with ```json but omit
+				// the closing fence. Do not discard a schema-valid final object
+				// in that malformed fence; continue scanning its body.
+				if strings.EqualFold(strings.TrimSpace(info), "json") {
+					i = contentStart - 1
+					continue
+				}
 				break
 			}
 			i = contentStart + next - 1

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -459,6 +459,12 @@ func lastBareJSONObject(text string, schema json.RawMessage) (json.RawMessage, e
 	for i := 0; i < len(text); i++ {
 		if strings.HasPrefix(text[i:], "```") {
 			contentStart, info := fenceContentStart(text, i)
+			// A prose mention such as "an unclosed ``` code fence" is not an
+			// opening fence. Treating it as one would hide a later final JSON
+			// object when there is no matching closing marker.
+			if strings.ContainsAny(strings.TrimSpace(info), " \t`") {
+				continue
+			}
 			next := skipFenceBlock(text[contentStart:])
 			if next < 0 {
 				// A Pi response can prefix its final JSON with ```json but omit

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -414,6 +414,24 @@ func TestFinalizeTextResult_WithSchemaRecoversJSONFromUnclosedFence(t *testing.T
 	}
 }
 
+func TestFinalizeTextResult_WithSchemaIgnoresProseBackticksBeforeJSON(t *testing.T) {
+	// A prose mention of backticks is not a fence. It must not prevent the
+	// fallback from reaching the final schema-valid object.
+	text := "An unclosed ``` code fence is the bug being fixed.\n\n{\"summary\":\"recover the final result\"}"
+	schema := json.RawMessage(`{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"]}`)
+	result, err := finalizeTextResult("pi", text, schema, TokenUsage{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var output map[string]any
+	if err := json.Unmarshal(result.Output, &output); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+	if output["summary"] != "recover the final result" {
+		t.Errorf("summary = %v, want recovered JSON value", output["summary"])
+	}
+}
+
 func TestFinalizeTextResult_WithSchemaParsesInlineOpenFence(t *testing.T) {
 	// Codex/GPT-5 sometimes glues the opening ```json fence to the end of
 	// the prior reasoning line, with no newline between text and backticks.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -396,6 +396,24 @@ func TestFinalizeTextResult_WithSchemaParsesFencedJSON(t *testing.T) {
 	}
 }
 
+func TestFinalizeTextResult_WithSchemaRecoversJSONFromUnclosedFence(t *testing.T) {
+	// Pi sometimes emits prose and an opening JSON fence but omits the closing
+	// fence. The final balanced object is still a valid schema-compliant result.
+	text := "The fix is verified. Let me now return the structured result.\n\n```json\n{\"summary\":\"Add missing State import\"}"
+	schema := json.RawMessage(`{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"]}`)
+	result, err := finalizeTextResult("pi", text, schema, TokenUsage{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var output map[string]any
+	if err := json.Unmarshal(result.Output, &output); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+	if output["summary"] != "Add missing State import" {
+		t.Errorf("summary = %v, want recovered JSON value", output["summary"])
+	}
+}
+
 func TestFinalizeTextResult_WithSchemaParsesInlineOpenFence(t *testing.T) {
 	// Codex/GPT-5 sometimes glues the opening ```json fence to the end of
 	// the prior reasoning line, with no newline between text and backticks.


### PR DESCRIPTION
## Summary
- recover a schema-valid final JSON object when Pi prefixes it with ` ```json` but omits the closing fence
- keep ignoring unclosed non-JSON fences, preserving the existing guard against parsing unrelated fenced examples
- add a regression from a real no-mistakes Pi auto-fix failure

## Reproduction
A Pi fixer emitted prose followed by an unclosed ` ```json` block containing `{"summary":"..."}`. `lastBareJSONObject` stopped at the unclosed fence, then parsing the full response failed at the leading prose.

## Testing
- `go test ./internal/agent`
- `go test -race ./internal/agent`

Related: kunchenguid/gnhf#154 and kunchenguid/gnhf#164