### PR TITLE
fix(agent): recover schema-valid JSON from Pi responses with unclosed json fences or malformed backtick prose

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -462,6 +462,12 @@ func lastBareJSONObject(text string, schema json.RawMessage) (json.RawMessage, e
 	for i := 0; i < len(text); i++ {
 		if strings.HasPrefix(text[i:], "```") {
 			contentStart, info := fenceContentStart(text, i)
+			// A prose mention such as "an unclosed ``` code fence" is not an
+			// opening fence. Treating it as one would hide a later final JSON
+			// object when there is no matching closing marker.
+			if strings.ContainsAny(strings.TrimSpace(info), " \t`") {
+				continue
+			}
 			next := skipFenceBlock(text[contentStart:])
 			if next < 0 {
 				// A Pi response can prefix its final JSON with ```json but omit

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -377,6 +377,13 @@ func indexJSONFenceOpen(text string) int {
 		}
 		i += searchStart
 		contentStart, info := fenceContentStart(text, i)
+		if !isFenceInfo(info) {
+			// This can be a prose mention such as "an unclosed ``` code fence"
+			// or a malformed four-backtick inline-code delimiter. Advance only one
+			// byte so overlapping backtick runs are examined correctly.
+			searchStart = i + 1
+			continue
+		}
 		if strings.EqualFold(strings.TrimSpace(info), "json") {
 			return contentStart
 		}
@@ -387,6 +394,14 @@ func indexJSONFenceOpen(text string) int {
 		searchStart = contentStart + next
 	}
 	return -1
+}
+
+// isFenceInfo reports whether text after three backticks can be a fence info
+// string. Backticks or whitespace within a nonempty info string indicate prose
+// (or malformed inline-code markup), not a fenced block.
+func isFenceInfo(info string) bool {
+	info = strings.TrimSpace(info)
+	return !strings.ContainsAny(info, " \t`")
 }
 
 func fenceContentStart(text string, fenceStart int) (int, string) {
@@ -465,7 +480,7 @@ func lastBareJSONObject(text string, schema json.RawMessage) (json.RawMessage, e
 			// A prose mention such as "an unclosed ``` code fence" is not an
 			// opening fence. Treating it as one would hide a later final JSON
 			// object when there is no matching closing marker.
-			if strings.ContainsAny(strings.TrimSpace(info), " \t`") {
+			if !isFenceInfo(info) {
 				continue
 			}
 			next := skipFenceBlock(text[contentStart:])

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -461,9 +461,16 @@ func lastBareJSONObject(text string, schema json.RawMessage) (json.RawMessage, e
 	var lastErr error
 	for i := 0; i < len(text); i++ {
 		if strings.HasPrefix(text[i:], "```") {
-			contentStart, _ := fenceContentStart(text, i)
+			contentStart, info := fenceContentStart(text, i)
 			next := skipFenceBlock(text[contentStart:])
 			if next < 0 {
+				// A Pi response can prefix its final JSON with ```json but omit
+				// the closing fence. Do not discard a schema-valid final object
+				// in that malformed fence; continue scanning its body.
+				if strings.EqualFold(strings.TrimSpace(info), "json") {
+					i = contentStart - 1
+					continue
+				}
 				break
 			}
 			i = contentStart + next - 1

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -432,6 +432,25 @@ func TestFinalizeTextResult_WithSchemaIgnoresProseBackticksBeforeJSON(t *testing
 	}
 }
 
+func TestFinalizeTextResult_WithSchemaIgnoresMalformedFourBacktickProse(t *testing.T) {
+	// Pi can discuss a literal ```json fence inside malformed inline-code markup
+	// before producing its normal final fenced result. The prose must not consume
+	// that later result as part of an unterminated fence.
+	text := "The missing closer was an unclosed ````json` fence.\n\n```json\n{\"summary\":\"recover the final result\"}\n```"
+	schema := json.RawMessage(`{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"]}`)
+	result, err := finalizeTextResult("pi", text, schema, TokenUsage{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var output map[string]any
+	if err := json.Unmarshal(result.Output, &output); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+	if output["summary"] != "recover the final result" {
+		t.Errorf("summary = %v, want recovered JSON value", output["summary"])
+	}
+}
+
 func TestFinalizeTextResult_WithSchemaParsesInlineOpenFence(t *testing.T) {
 	// Codex/GPT-5 sometimes glues the opening ```json fence to the end of
 	// the prior reasoning line, with no newline between text and backticks.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -414,6 +414,24 @@ func TestFinalizeTextResult_WithSchemaRecoversJSONFromUnclosedFence(t *testing.T
 	}
 }
 
+func TestFinalizeTextResult_WithSchemaIgnoresProseBackticksBeforeJSON(t *testing.T) {
+	// A prose mention of backticks is not a fence. It must not prevent the
+	// fallback from reaching the final schema-valid object.
+	text := "An unclosed ``` code fence is the bug being fixed.\n\n{\"summary\":\"recover the final result\"}"
+	schema := json.RawMessage(`{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"]}`)
+	result, err := finalizeTextResult("pi", text, schema, TokenUsage{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var output map[string]any
+	if err := json.Unmarshal(result.Output, &output); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+	if output["summary"] != "recover the final result" {
+		t.Errorf("summary = %v, want recovered JSON value", output["summary"])
+	}
+}
+
 func TestFinalizeTextResult_WithSchemaParsesInlineOpenFence(t *testing.T) {
 	// Codex/GPT-5 sometimes glues the opening ```json fence to the end of
 	// the prior reasoning line, with no newline between text and backticks.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -396,6 +396,24 @@ func TestFinalizeTextResult_WithSchemaParsesFencedJSON(t *testing.T) {
 	}
 }
 
+func TestFinalizeTextResult_WithSchemaRecoversJSONFromUnclosedFence(t *testing.T) {
+	// Pi sometimes emits prose and an opening JSON fence but omits the closing
+	// fence. The final balanced object is still a valid schema-compliant result.
+	text := "The fix is verified. Let me now return the structured result.\n\n```json\n{\"summary\":\"Add missing State import\"}"
+	schema := json.RawMessage(`{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"]}`)
+	result, err := finalizeTextResult("pi", text, schema, TokenUsage{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var output map[string]any
+	if err := json.Unmarshal(result.Output, &output); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+	if output["summary"] != "Add missing State import" {
+		t.Errorf("summary = %v, want recovered JSON value", output["summary"])
+	}
+}
+
 func TestFinalizeTextResult_WithSchemaParsesInlineOpenFence(t *testing.T) {
 	// Codex/GPT-5 sometimes glues the opening ```json fence to the end of
 	// the prior reasoning line, with no newline between text and backticks.


### PR DESCRIPTION
## Intent

Recover schema-valid final JSON from Pi responses with unclosed json fences or malformed backtick prose, without accepting non-JSON fenced content.

## What Changed

- Added `isFenceInfo` helper to distinguish real code-fence info strings from prose mentions of backticks or malformed inline-code markup, so incidental backtick sequences in agent responses are not treated as opening fences.
- Updated `indexJSONFenceOpen` and `lastBareJSONObject` to skip non-fence backtick sequences, preventing them from hiding a later schema-valid final JSON object.
- When a `json`-tagged fence opens but never closes (as Pi sometimes emits), the scanner now falls back to searching the fence body for a schema-valid JSON object instead of discarding it entirely.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>
</details>
<details>
<summary>✅ **Rebase** - passed</summary>
</details>
<details>
<summary>✅ **Review** - completed</summary>
</details>
<details>
<summary>✅ **Test** - passed</summary>
</details>
<details>
<summary>✅ **Document** - passed</summary>
</details>
<details>
<summary>✅ **Lint** - passed</summary>
</details>
<details>
<summary>✅ **Push** - passed</summary>
</details>
