### PR TITLE
feat: add run-scoped agent routing

### DIFF
--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -114,6 +114,25 @@ Repo config takes precedence over global config.
 agent: [codex, claude]
 ```
 
+### One-run route override
+
+An orchestrator can replace one resolved agent for a single run without changing
+global or repository configuration:
+
+```sh
+no-mistakes axi run --intent "the user's goal" \
+  --agent-route claude=pi \
+  --agent-route-arg=--model \
+  --agent-route-arg=kimi-coding/k3 \
+  --agent-route-arg=--thinking \
+  --agent-route-arg=high
+```
+
+The route is applied after normal resolution, so `auto` is replaced only when
+it resolved to the source agent, and entries for other agents stay unchanged.
+The selected route and arguments are stored with the run so a daemon restart
+uses the same pipeline agent.
+
 ### Optional ACP target
 
 If you install `acpx` separately, you can opt into any ACP target with the `acp:` prefix, for example `agent: acp:gemini`.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -88,6 +88,7 @@ An active run on another branch does not block starting validation for the curre
 no-mistakes axi run --intent "the user's goal"
 no-mistakes axi run --intent "the user's goal" --skip test,lint
 no-mistakes axi run --intent "the user's goal" --yes
+no-mistakes axi run --intent "the user's goal" --agent-route claude=pi --agent-route-arg=--model --agent-route-arg=kimi-coding/k3
 ```
 
 | Flag          | Type     | Default | Description                                                      |
@@ -95,6 +96,8 @@ no-mistakes axi run --intent "the user's goal" --yes
 | `--intent`    | `string` | (none)  | What the user set out to accomplish; required to start a new run |
 | `-y`, `--yes` | `bool`   | `false` | Auto-resolve every gate until a decision point or outcome        |
 | `--skip`      | `string` | (none)  | Comma-separated pipeline steps to skip                           |
+| `--agent-route` | `string` | (none) | Replace one resolved pipeline agent for this run, as `from=to` |
+| `--agent-route-arg` | `string[]` | (none) | Append a CLI argument to the routed agent; repeat as needed |
 
 `--intent` is not a description of the diff.
 It is the user's goal or request, and no-mistakes uses it verbatim instead of transcript inference.

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -59,6 +59,8 @@ func newAxiRunCmd() *cobra.Command {
 	var autoYes bool
 	var skipValue string
 	var intent string
+	var agentRouteSpec string
+	var agentRouteArgs []string
 
 	cmd := &cobra.Command{
 		Use:   "run",
@@ -90,17 +92,23 @@ func newAxiRunCmd() *cobra.Command {
 					return emitError(cmd, 2, err.Error(),
 						"Valid steps: intent, rebase, review, test, document, lint, push, pr, ci")
 				}
-				return runAxiRun(cmd, autoYes, skipSteps, intent)
+				agentRoute, err := parseAgentRoute(agentRouteSpec, agentRouteArgs)
+				if err != nil {
+					return emitError(cmd, 2, err.Error())
+				}
+				return runAxiRun(cmd, autoYes, skipSteps, intent, agentRoute)
 			})
 		},
 	}
 	cmd.Flags().BoolVarP(&autoYes, "yes", "y", false, "auto-resolve every gate (fix findings, then accept) until a decision point or outcome")
 	cmd.Flags().StringVar(&skipValue, "skip", "", "comma-separated pipeline steps to skip")
 	cmd.Flags().StringVar(&intent, "intent", "", "what the user set out to accomplish (not a description of the diff); used instead of inferring from transcripts (required to start a run)")
+	cmd.Flags().StringVar(&agentRouteSpec, "agent-route", "", "replace one resolved pipeline agent for this run, as from=to")
+	cmd.Flags().StringArrayVar(&agentRouteArgs, "agent-route-arg", nil, "append one CLI argument to the routed agent (repeatable; use --agent-route-arg=<value> for flags)")
 	return cmd
 }
 
-func runAxiRun(cmd *cobra.Command, autoYes bool, skipSteps []types.StepName, intent string) error {
+func runAxiRun(cmd *cobra.Command, autoYes bool, skipSteps []types.StepName, intent string, agentRoute *types.AgentRouteOverride) error {
 	ctx := cmd.Context()
 	env, err := openAxiRunEnv()
 	if err != nil {
@@ -143,7 +151,7 @@ func runAxiRun(cmd *cobra.Command, autoYes bool, skipSteps []types.StepName, int
 			return guard(cmd)
 		}
 		var err error
-		runID, err = triggerRun(ctx, env, branch, headSHA, skipSteps, intent)
+		runID, err = triggerRun(ctx, env, branch, headSHA, skipSteps, intent, agentRoute)
 		if err != nil {
 			if ownershipErr, ok := err.(*branchOwnershipError); ok {
 				return emitBranchOwnershipError(cmd, ownershipErr)
@@ -278,9 +286,14 @@ func freshRunBranchOwnershipState(ctx context.Context, env *axiEnv) *branchsync.
 // the gate to trigger a pipeline, and falls back to a rerun when the push was a
 // no-op (the gate already had this commit). Callers must check for an existing
 // active run first (see activeRunID) and apply pre-flight guards.
-func triggerRun(ctx context.Context, env *axiEnv, branch, headSHA string, skipSteps []types.StepName, intent string) (string, error) {
+func triggerRun(ctx context.Context, env *axiEnv, branch, headSHA string, skipSteps []types.StepName, intent string, agentRoute *types.AgentRouteOverride) (string, error) {
 	pushOptions := formatSkipPushOptions(skipSteps)
 	if opt := formatIntentPushOption(intent); opt != "" {
+		pushOptions = append(pushOptions, opt)
+	}
+	if opt, err := formatAgentRoutePushOption(agentRoute); err != nil {
+		return "", err
+	} else if opt != "" {
 		pushOptions = append(pushOptions, opt)
 	}
 	priorRunIDs, err := runIDsForHead(env.client, env.repo.ID, branch, headSHA)
@@ -312,7 +325,7 @@ func triggerRun(ctx context.Context, env *axiEnv, branch, headSHA string, skipSt
 	// No run appeared: the push was likely up-to-date. Rerun the latest gate
 	// head so `axi run` is still useful when there are no new commits.
 	var rr ipc.RerunResult
-	if err := env.client.Call(ipc.MethodRerun, rerunParams(env.repo.ID, branch, skipSteps, intent), &rr); err != nil {
+	if err := env.client.Call(ipc.MethodRerun, rerunParams(env.repo.ID, branch, skipSteps, intent, agentRoute), &rr); err != nil {
 		return "", fmt.Errorf("no run started for %q: %v", branch, err)
 	}
 	return rr.RunID, nil
@@ -396,8 +409,26 @@ func activeRunLookupParams(repoID, branch string) *ipc.GetActiveRunParams {
 	return &ipc.GetActiveRunParams{RepoID: repoID, Branch: branch}
 }
 
-func rerunParams(repoID, branch string, skipSteps []types.StepName, intent string) *ipc.RerunParams {
-	return &ipc.RerunParams{RepoID: repoID, Branch: branch, SkipSteps: skipSteps, Intent: intent}
+func rerunParams(repoID, branch string, skipSteps []types.StepName, intent string, agentRoute *types.AgentRouteOverride) *ipc.RerunParams {
+	return &ipc.RerunParams{RepoID: repoID, Branch: branch, SkipSteps: skipSteps, Intent: intent, AgentRoute: agentRoute}
+}
+
+func parseAgentRoute(spec string, args []string) (*types.AgentRouteOverride, error) {
+	if strings.TrimSpace(spec) == "" {
+		if len(args) > 0 {
+			return nil, fmt.Errorf("--agent-route-arg requires --agent-route")
+		}
+		return nil, nil
+	}
+	from, to, ok := strings.Cut(spec, "=")
+	if !ok || strings.TrimSpace(from) == "" || strings.TrimSpace(to) == "" || strings.Contains(to, "=") {
+		return nil, fmt.Errorf("--agent-route must be from=to")
+	}
+	return &types.AgentRouteOverride{
+		From: types.AgentName(strings.TrimSpace(from)),
+		To:   types.AgentName(strings.TrimSpace(to)),
+		Args: append([]string(nil), args...),
+	}, nil
 }
 
 // driveRun subscribes to a run and reconciles authoritative state on transition

--- a/internal/cli/axi_test.go
+++ b/internal/cli/axi_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -496,12 +497,31 @@ func TestConfigErrorForFreshAxiRunAllowsReattach(t *testing.T) {
 }
 
 func TestRerunParamsIncludeSkipSteps(t *testing.T) {
-	params := rerunParams("repo-1", "feature/x", []types.StepName{types.StepReview}, "user goal")
+	params := rerunParams("repo-1", "feature/x", []types.StepName{types.StepReview}, "user goal", nil)
 	if params.RepoID != "repo-1" || params.Branch != "feature/x" || params.Intent != "user goal" {
 		t.Fatalf("unexpected rerun params: %#v", params)
 	}
 	if len(params.SkipSteps) != 1 || params.SkipSteps[0] != types.StepReview {
 		t.Fatalf("SkipSteps = %#v, want review", params.SkipSteps)
+	}
+}
+
+func TestParseAgentRoute(t *testing.T) {
+	route, err := parseAgentRoute("claude=pi", []string{"--model", "kimi-coding/k3", "--thinking", "high"})
+	if err != nil {
+		t.Fatalf("parseAgentRoute: %v", err)
+	}
+	if route.From != types.AgentClaude || route.To != types.AgentPi {
+		t.Fatalf("route = %q=%q, want claude=pi", route.From, route.To)
+	}
+	if got, want := route.Args, []string{"--model", "kimi-coding/k3", "--thinking", "high"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("route args = %v, want %v", got, want)
+	}
+}
+
+func TestParseAgentRouteArgsRequireRoute(t *testing.T) {
+	if _, err := parseAgentRoute("", []string{"--model"}); err == nil {
+		t.Fatal("expected args without --agent-route to fail")
 	}
 }
 
@@ -826,7 +846,7 @@ func TestAxiRunReportsInvalidGlobalConfig(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.SetContext(context.Background())
 	cmd.SetOut(&out)
-	if err := runAxiRun(cmd, false, nil, "user goal"); err == nil {
+	if err := runAxiRun(cmd, false, nil, "user goal", nil); err == nil {
 		t.Fatalf("axi run should fail on invalid global config:\n%s", out.String())
 	}
 	got := out.String()

--- a/internal/cli/daemon_cmd.go
+++ b/internal/cli/daemon_cmd.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -106,6 +107,10 @@ func newDaemonNotifyPushCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			agentRoute, err := parseAgentRoutePushOptions(pushOptions)
+			if err != nil {
+				return err
+			}
 			gatePath, err := normalizeNotifyGatePath(gate)
 			if err != nil {
 				return err
@@ -124,12 +129,13 @@ func newDaemonNotifyPushCmd() *cobra.Command {
 
 			var result ipc.PushReceivedResult
 			return client.Call(ipc.MethodPushReceived, &ipc.PushReceivedParams{
-				Gate:      gatePath,
-				Ref:       ref,
-				Old:       oldSHA,
-				New:       newSHA,
-				SkipSteps: skipSteps,
-				Intent:    intent,
+				Gate:       gatePath,
+				Ref:        ref,
+				Old:        oldSHA,
+				New:        newSHA,
+				SkipSteps:  skipSteps,
+				Intent:     intent,
+				AgentRoute: agentRoute,
 			}, &result)
 		},
 	}
@@ -193,6 +199,7 @@ func parseSkipSteps(value string) ([]types.StepName, error) {
 // The value is base64-encoded so multi-line or special-character intents
 // survive the push-option transport (which is line-oriented).
 const intentPushOptionPrefix = "no-mistakes.intent="
+const agentRoutePushOptionPrefix = "no-mistakes.agent-route="
 
 // formatIntentPushOption encodes intent as a single push option, or returns ""
 // when there is no intent to carry.
@@ -219,6 +226,37 @@ func parseIntentPushOptions(options []string) (string, error) {
 		intent = string(decoded)
 	}
 	return intent, nil
+}
+
+func formatAgentRoutePushOption(route *types.AgentRouteOverride) (string, error) {
+	if route == nil {
+		return "", nil
+	}
+	encoded, err := json.Marshal(route)
+	if err != nil {
+		return "", fmt.Errorf("encode agent route push option: %w", err)
+	}
+	return agentRoutePushOptionPrefix + base64.StdEncoding.EncodeToString(encoded), nil
+}
+
+func parseAgentRoutePushOptions(options []string) (*types.AgentRouteOverride, error) {
+	var route *types.AgentRouteOverride
+	for _, option := range options {
+		encoded, ok := strings.CutPrefix(option, agentRoutePushOptionPrefix)
+		if !ok {
+			continue
+		}
+		decoded, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			return nil, fmt.Errorf("decode agent route push option: %w", err)
+		}
+		var parsed types.AgentRouteOverride
+		if err := json.Unmarshal(decoded, &parsed); err != nil {
+			return nil, fmt.Errorf("parse agent route push option: %w", err)
+		}
+		route = &parsed
+	}
+	return route, nil
 }
 
 func formatSkipPushOptions(steps []types.StepName) []string {

--- a/internal/cli/daemon_cmd_test.go
+++ b/internal/cli/daemon_cmd_test.go
@@ -100,6 +100,25 @@ func TestFormatIntentPushOptionEmpty(t *testing.T) {
 	}
 }
 
+func TestAgentRoutePushOptionRoundTrip(t *testing.T) {
+	want := &types.AgentRouteOverride{
+		From: types.AgentClaude,
+		To:   types.AgentPi,
+		Args: []string{"--model", "kimi-coding/k3", "--thinking", "high"},
+	}
+	option, err := formatAgentRoutePushOption(want)
+	if err != nil {
+		t.Fatalf("formatAgentRoutePushOption: %v", err)
+	}
+	got, err := parseAgentRoutePushOptions([]string{"no-mistakes.skip=test", option})
+	if err != nil {
+		t.Fatalf("parseAgentRoutePushOptions: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("route = %#v, want %#v", got, want)
+	}
+}
+
 func TestParseIntentPushOptionsNone(t *testing.T) {
 	got, err := parseIntentPushOptions([]string{"no-mistakes.skip=test", "ci.skip"})
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -771,6 +771,53 @@ func (c *Config) AgentArgsFor(name types.AgentName) []string {
 	return c.AgentArgsOverride[string(name)]
 }
 
+// ApplyResolvedAgentRoute replaces From only after normal trusted config and
+// availability resolution. This makes `auto` and fallback lists behave
+// naturally: a route from Claude changes only the entries that actually
+// resolved to Claude, while configured Codex entries remain untouched.
+func (c *Config) ApplyResolvedAgentRoute(route *types.AgentRouteOverride) (bool, error) {
+	if route == nil {
+		return false, nil
+	}
+	if route.From == "" || route.To == "" || route.From == types.AgentAuto || route.To == types.AgentAuto {
+		return false, fmt.Errorf("agent route requires concrete non-auto from and to agents")
+	}
+	if !agentArgsOverrideAgents[string(route.From)] || !agentArgsOverrideAgents[string(route.To)] {
+		return false, fmt.Errorf("agent route supports native agents only")
+	}
+	if err := validateAgentArgsOverride(map[string][]string{string(route.To): route.Args}); err != nil {
+		return false, err
+	}
+
+	agents := c.Agents
+	if len(agents) == 0 {
+		agents = []types.AgentName{c.Agent}
+	}
+	matched := false
+	routed := make([]types.AgentName, len(agents))
+	for i, name := range agents {
+		routed[i] = name
+		if name == route.From {
+			routed[i] = route.To
+			matched = true
+		}
+	}
+	if !matched {
+		return false, nil
+	}
+	c.Agent = routed[0]
+	c.Agents = routed
+	if len(route.Args) > 0 {
+		overrides := make(map[string][]string, len(c.AgentArgsOverride)+1)
+		for name, args := range c.AgentArgsOverride {
+			overrides[name] = append([]string(nil), args...)
+		}
+		overrides[string(route.To)] = append(overrides[string(route.To)], route.Args...)
+		c.AgentArgsOverride = overrides
+	}
+	return true, nil
+}
+
 // agentArgsOverrideAgents lists native agent names accepted as keys in
 // agent_args_override.
 var agentArgsOverrideAgents = map[string]bool{

--- a/internal/config/config_agent_route_test.go
+++ b/internal/config/config_agent_route_test.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+func TestApplyResolvedAgentRouteChangesOnlyMatchingAgent(t *testing.T) {
+	cfg := &Config{
+		Agent:  types.AgentCodex,
+		Agents: []types.AgentName{types.AgentCodex, types.AgentClaude},
+		AgentArgsOverride: map[string][]string{
+			"pi": {"--existing"},
+		},
+	}
+	route := &types.AgentRouteOverride{
+		From: types.AgentClaude,
+		To:   types.AgentPi,
+		Args: []string{"--model", "kimi-coding/k3", "--thinking", "high"},
+	}
+
+	matched, err := cfg.ApplyResolvedAgentRoute(route)
+	if err != nil {
+		t.Fatalf("ApplyResolvedAgentRoute: %v", err)
+	}
+	if !matched {
+		t.Fatal("Claude route did not match")
+	}
+	if want := []types.AgentName{types.AgentCodex, types.AgentPi}; !reflect.DeepEqual(cfg.Agents, want) {
+		t.Fatalf("Agents = %v, want %v", cfg.Agents, want)
+	}
+	if cfg.Agent != types.AgentCodex {
+		t.Fatalf("primary Agent = %q, want Codex unchanged", cfg.Agent)
+	}
+	wantArgs := []string{"--existing", "--model", "kimi-coding/k3", "--thinking", "high"}
+	if got := cfg.AgentArgsFor(types.AgentPi); !reflect.DeepEqual(got, wantArgs) {
+		t.Fatalf("Pi args = %v, want %v", got, wantArgs)
+	}
+}
+
+func TestApplyResolvedAgentRouteDoesNothingWithoutSource(t *testing.T) {
+	cfg := &Config{Agent: types.AgentCodex, Agents: []types.AgentName{types.AgentCodex}}
+	route := &types.AgentRouteOverride{
+		From: types.AgentClaude,
+		To:   types.AgentPi,
+		Args: []string{"--model", "kimi-coding/k3"},
+	}
+
+	matched, err := cfg.ApplyResolvedAgentRoute(route)
+	if err != nil {
+		t.Fatalf("ApplyResolvedAgentRoute: %v", err)
+	}
+	if matched {
+		t.Fatal("Claude route matched a Codex-only configuration")
+	}
+	if cfg.Agent != types.AgentCodex || len(cfg.Agents) != 1 || cfg.Agents[0] != types.AgentCodex {
+		t.Fatalf("Codex-only configuration changed: Agent=%q Agents=%v", cfg.Agent, cfg.Agents)
+	}
+	if got := cfg.AgentArgsFor(types.AgentPi); got != nil {
+		t.Fatalf("Pi args were installed without a matching route: %v", got)
+	}
+}
+
+func TestApplyResolvedAgentRouteRejectsManagedArgs(t *testing.T) {
+	cfg := &Config{Agent: types.AgentClaude, Agents: []types.AgentName{types.AgentClaude}}
+	route := &types.AgentRouteOverride{
+		From: types.AgentClaude,
+		To:   types.AgentPi,
+		Args: []string{"--mode", "json"},
+	}
+	if _, err := cfg.ApplyResolvedAgentRoute(route); err == nil {
+		t.Fatal("expected managed Pi flag to be rejected")
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -731,7 +731,7 @@ func registerHandlers(srv *ipc.Server, mgr *RunManager, d *db.DB, shutdown func(
 		if err := json.Unmarshal(params, &p); err != nil {
 			return nil, fmt.Errorf("invalid params: %w", err)
 		}
-		runID, err := mgr.HandleRerun(ctx, p.RepoID, p.Branch, p.SkipSteps, p.Intent)
+		runID, err := mgr.HandleRerun(ctx, p.RepoID, p.Branch, p.SkipSteps, p.Intent, p.AgentRoute)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/daemon/gateneutralize_test.go
+++ b/internal/daemon/gateneutralize_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 
@@ -60,6 +61,39 @@ func TestNewPipelineAgent_NoOptOut_AdmitsEveryHarness(t *testing.T) {
 			t.Fatalf("%s must be admitted when the repo did not opt out, got: %v", name, err)
 		}
 		_ = ag.Close()
+	}
+}
+
+func TestNewPipelineAgentWithRouteMapsResolvedAutoClaudeToPi(t *testing.T) {
+	cfg := &config.Config{Agent: types.AgentAuto}
+	route := &types.AgentRouteOverride{
+		From: types.AgentClaude,
+		To:   types.AgentPi,
+		Args: []string{"--model", "kimi-coding/k3", "--thinking", "high"},
+	}
+	ag, err := newPipelineAgentWithRoute(context.Background(), cfg, route, fakeLookPath)
+	if err != nil {
+		t.Fatalf("newPipelineAgentWithRoute: %v", err)
+	}
+	defer ag.Close()
+	if ag.Name() != "pi" {
+		t.Fatalf("pipeline agent = %q, want pi", ag.Name())
+	}
+}
+
+func TestNewPipelineAgentWithRouteLeavesCodexFallbackPrimary(t *testing.T) {
+	cfg := &config.Config{Agents: []types.AgentName{types.AgentCodex, types.AgentClaude}}
+	route := &types.AgentRouteOverride{From: types.AgentClaude, To: types.AgentPi}
+	ag, err := newPipelineAgentWithRoute(context.Background(), cfg, route, fakeLookPath)
+	if err != nil {
+		t.Fatalf("newPipelineAgentWithRoute: %v", err)
+	}
+	defer ag.Close()
+	if ag.Name() != "codex" {
+		t.Fatalf("pipeline primary = %q, want codex unchanged", ag.Name())
+	}
+	if got, want := cfg.Agents, []types.AgentName{types.AgentCodex, types.AgentPi}; !slices.Equal(got, want) {
+		t.Fatalf("resolved agents = %v, want %v", got, want)
 	}
 }
 

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -142,7 +143,11 @@ func (m *RunManager) prepareRecoveredRun(ctx context.Context, run *db.Run) (*rec
 	if err != nil {
 		return nil, err
 	}
-	ag, err := newPipelineAgent(ctx, cfg, exec.LookPath)
+	route, err := agentRouteForRun(run)
+	if err != nil {
+		return nil, err
+	}
+	ag, err := newPipelineAgentWithRoute(ctx, cfg, route, exec.LookPath)
 	if err != nil {
 		return nil, err
 	}
@@ -214,11 +219,22 @@ func (m *RunManager) loadRecoveredConfig(ctx context.Context, run *db.Run, repo 
 }
 
 func newPipelineAgent(ctx context.Context, cfg *config.Config, lookPath func(string) (string, error)) (agent.Agent, error) {
+	return newPipelineAgentWithRoute(ctx, cfg, nil, lookPath)
+}
+
+func newPipelineAgentWithRoute(ctx context.Context, cfg *config.Config, route *types.AgentRouteOverride, lookPath func(string) (string, error)) (agent.Agent, error) {
 	if steps.IsDemoMode() {
 		return agent.NewNoop(), nil
 	}
 	if err := cfg.ResolveAgent(ctx, lookPath); err != nil {
 		return nil, err
+	}
+	if matched, err := cfg.ApplyResolvedAgentRoute(route); err != nil {
+		return nil, err
+	} else if matched {
+		if err := cfg.ResolveAgent(ctx, lookPath); err != nil {
+			return nil, err
+		}
 	}
 	agents := cfg.Agents
 	if len(agents) == 0 {
@@ -249,6 +265,17 @@ func newPipelineAgent(ctx context.Context, cfg *config.Config, lookPath func(str
 		}
 	}
 	return ag, nil
+}
+
+func agentRouteForRun(run *db.Run) (*types.AgentRouteOverride, error) {
+	if run == nil || run.AgentRouteJSON == nil || strings.TrimSpace(*run.AgentRouteJSON) == "" {
+		return nil, nil
+	}
+	var route types.AgentRouteOverride
+	if err := json.Unmarshal([]byte(*run.AgentRouteJSON), &route); err != nil {
+		return nil, fmt.Errorf("decode run agent route: %w", err)
+	}
+	return &route, nil
 }
 
 func resolveGitPath(workDir, value string) string {
@@ -538,12 +565,12 @@ func (m *RunManager) HandlePushReceived(ctx context.Context, params *ipc.PushRec
 	}
 
 	branch := branchFromRef(params.Ref)
-	return m.startRun(ctx, repo, branch, params.New, params.Old, "push", params.SkipSteps, params.Intent)
+	return m.startRun(ctx, repo, branch, params.New, params.Old, "push", params.SkipSteps, params.Intent, params.AgentRoute)
 }
 
 // HandleRerun creates a new run for the latest gate head on a branch. An
 // optional intent is stamped onto the new run.
-func (m *RunManager) HandleRerun(ctx context.Context, repoID, branch string, skipSteps []types.StepName, intent string) (string, error) {
+func (m *RunManager) HandleRerun(ctx context.Context, repoID, branch string, skipSteps []types.StepName, intent string, agentRoute *types.AgentRouteOverride) (string, error) {
 	repo, err := m.db.GetRepo(repoID)
 	if err != nil {
 		return "", fmt.Errorf("get repo: %w", err)
@@ -586,7 +613,7 @@ func (m *RunManager) HandleRerun(ctx context.Context, repoID, branch string, ski
 		baseSHA = matchingHead.BaseSHA
 	}
 
-	return m.startRun(ctx, repo, branch, headSHA, baseSHA, "rerun", skipSteps, intent)
+	return m.startRun(ctx, repo, branch, headSHA, baseSHA, "rerun", skipSteps, intent, agentRoute)
 }
 
 // fetchRunDefaultBranch fetches the trusted branch from the refreshed
@@ -606,7 +633,7 @@ func fetchRunDefaultBranch(ctx context.Context, workDir string, repo *db.Repo) e
 // startRun creates a run, sets up a worktree, and launches pipeline execution.
 // A non-empty intent is stamped onto the run as agent-supplied, so the intent
 // step uses it instead of inferring from transcripts.
-func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSHA, baseSHA, trigger string, skipSteps []types.StepName, intent string) (string, error) {
+func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSHA, baseSHA, trigger string, skipSteps []types.StepName, intent string, agentRoute *types.AgentRouteOverride) (string, error) {
 	branchRole := telemetryBranchRole(branch, repo.DefaultBranch)
 	trackStartFailure := func(stage string) {
 		telemetry.Track("run", telemetry.Fields{
@@ -649,6 +676,19 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 	if err != nil {
 		trackStartFailure("create_run")
 		return "", fmt.Errorf("create run: %w", err)
+	}
+	if agentRoute != nil {
+		encoded, marshalErr := json.Marshal(agentRoute)
+		if marshalErr != nil {
+			trackStartFailure("encode_agent_route")
+			return "", fmt.Errorf("encode agent route: %w", marshalErr)
+		}
+		if err := m.db.UpdateRunAgentRoute(run.ID, string(encoded)); err != nil {
+			trackStartFailure("persist_agent_route")
+			return "", err
+		}
+		routeJSON := string(encoded)
+		run.AgentRouteJSON = &routeJSON
 	}
 
 	// Stamp an agent-supplied intent onto the run before the pipeline starts,
@@ -767,6 +807,17 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 			m.db.UpdateRunError(run.ID, err.Error())
 			trackStartFailure("resolve_agent")
 			return "", err
+		}
+		if matched, err := cfg.ApplyResolvedAgentRoute(agentRoute); err != nil {
+			m.db.UpdateRunError(run.ID, err.Error())
+			trackStartFailure("apply_agent_route")
+			return "", err
+		} else if matched {
+			if err := cfg.ResolveAgent(ctx, exec.LookPath); err != nil {
+				m.db.UpdateRunError(run.ID, err.Error())
+				trackStartFailure("resolve_routed_agent")
+				return "", err
+			}
 		}
 		agents := cfg.Agents
 		if len(agents) == 0 {

--- a/internal/daemon/manager_repo_refresh_test.go
+++ b/internal/daemon/manager_repo_refresh_test.go
@@ -35,7 +35,7 @@ func TestRunStartRefreshesCloneURLWithoutMutatingRemotes(t *testing.T) {
 		return []pipeline.Step{&captureRefreshRepoStep{seen: seen}}
 	})
 	t.Cleanup(manager.Shutdown)
-	runID, err := manager.startRun(context.Background(), repo, "main", head, refreshTestZeroSHA, "test", nil, "refresh repository URL")
+	runID, err := manager.startRun(context.Background(), repo, "main", head, refreshTestZeroSHA, "test", nil, "refresh repository URL", nil)
 	if err != nil {
 		t.Fatalf("start run: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestRunStartURLRefreshFailuresWarnSafelyAndContinueWithOldRegistration(t *t
 				return []pipeline.Step{&captureRefreshRepoStep{seen: seen}}
 			})
 			t.Cleanup(manager.Shutdown)
-			runID, err := manager.startRun(context.Background(), before, "main", head, refreshTestZeroSHA, "test", nil, "refresh failure must fail open")
+			runID, err := manager.startRun(context.Background(), before, "main", head, refreshTestZeroSHA, "test", nil, "refresh failure must fail open", nil)
 			if err != nil {
 				t.Fatalf("ordinary run did not continue: %v\nlogs: %s", err, logs.String())
 			}

--- a/internal/db/run.go
+++ b/internal/db/run.go
@@ -54,11 +54,12 @@ type Run struct {
 	IntentSource    *string
 	IntentSessionID *string
 	IntentScore     *float64
+	AgentRouteJSON  *string
 	CreatedAt       int64
 	UpdatedAt       int64
 }
 
-const runColumns = `id, repo_id, branch, head_sha, base_sha, submitted_head_sha, review_approved_head_sha, status, pr_url, pr_state, pr_state_observed_at, ci_ready_at, last_pushed_sha, push_target_kind, push_target_fingerprint, push_ref, last_pushed_at, push_generation, COALESCE(push_active, 0), custody_returned_at, error, awaiting_agent_since, COALESCE(parked_ms, 0), intent, intent_source, intent_session_id, intent_score, created_at, updated_at`
+const runColumns = `id, repo_id, branch, head_sha, base_sha, submitted_head_sha, review_approved_head_sha, status, pr_url, pr_state, pr_state_observed_at, ci_ready_at, last_pushed_sha, push_target_kind, push_target_fingerprint, push_ref, last_pushed_at, push_generation, COALESCE(push_active, 0), custody_returned_at, error, awaiting_agent_since, COALESCE(parked_ms, 0), intent, intent_source, intent_session_id, intent_score, agent_route_json, created_at, updated_at`
 
 func scanRun(row interface {
 	Scan(...any) error
@@ -69,9 +70,19 @@ func scanRun(row interface {
 		&r.LastPushedSHA, &r.PushTargetKind, &r.PushTargetFingerprint, &r.PushRef,
 		&r.LastPushedAt, &r.PushGeneration, &r.PushActive,
 		&r.CustodyReturnedAt, &r.Error, &r.AwaitingAgentSince, &r.ParkedMS,
-		&r.Intent, &r.IntentSource, &r.IntentSessionID, &r.IntentScore,
+		&r.Intent, &r.IntentSource, &r.IntentSessionID, &r.IntentScore, &r.AgentRouteJSON,
 		&r.CreatedAt, &r.UpdatedAt,
 	)
+}
+
+// UpdateRunAgentRoute persists the run-scoped route before the pipeline agent
+// is created so daemon recovery reconstructs the same provider and arguments.
+func (d *DB) UpdateRunAgentRoute(id, routeJSON string) error {
+	_, err := d.sql.Exec(`UPDATE runs SET agent_route_json = ?, updated_at = ? WHERE id = ?`, routeJSON, now(), id)
+	if err != nil {
+		return fmt.Errorf("update run agent route: %w", err)
+	}
+	return nil
 }
 
 // InsertRun creates a new run record.

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -33,6 +33,7 @@ CREATE TABLE IF NOT EXISTS runs (
     error                   TEXT,
     awaiting_agent_since INTEGER,
     parked_ms            INTEGER,
+    agent_route_json     TEXT,
     created_at           INTEGER NOT NULL,
     updated_at           INTEGER NOT NULL
 );
@@ -151,6 +152,7 @@ var migrationStatements = []string{
 	`ALTER TABLE runs ADD COLUMN intent_score REAL`,
 	`ALTER TABLE runs ADD COLUMN awaiting_agent_since INTEGER`,
 	`ALTER TABLE runs ADD COLUMN parked_ms INTEGER`,
+	`ALTER TABLE runs ADD COLUMN agent_route_json TEXT`,
 	// Branch synchronization provenance is intentionally nullable. Historical
 	// rows stay unbound because mutable head_sha cannot prove a successful push.
 	`ALTER TABLE runs ADD COLUMN submitted_head_sha TEXT`,

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -66,12 +66,13 @@ func (e *RPCError) Error() string { return e.Message }
 // intent from local transcripts.
 type PushReceivedParams struct {
 	// Gate is the absolute path to the gate bare repo.
-	Gate      string           `json:"gate"`
-	Ref       string           `json:"ref"`
-	Old       string           `json:"old"`
-	New       string           `json:"new"`
-	SkipSteps []types.StepName `json:"skip_steps,omitempty"`
-	Intent    string           `json:"intent,omitempty"`
+	Gate       string                    `json:"gate"`
+	Ref        string                    `json:"ref"`
+	Old        string                    `json:"old"`
+	New        string                    `json:"new"`
+	SkipSteps  []types.StepName          `json:"skip_steps,omitempty"`
+	Intent     string                    `json:"intent,omitempty"`
+	AgentRoute *types.AgentRouteOverride `json:"agent_route,omitempty"`
 }
 
 // GetRunParams requests a single run by ID.
@@ -104,10 +105,11 @@ type GetActiveRunParams struct {
 // RerunParams requests a new run for the latest gate head on a branch.
 // Intent, when set, is stamped onto the new run like PushReceivedParams.Intent.
 type RerunParams struct {
-	RepoID    string           `json:"repo_id"`
-	Branch    string           `json:"branch"`
-	SkipSteps []types.StepName `json:"skip_steps,omitempty"`
-	Intent    string           `json:"intent,omitempty"`
+	RepoID     string                    `json:"repo_id"`
+	Branch     string                    `json:"branch"`
+	SkipSteps  []types.StepName          `json:"skip_steps,omitempty"`
+	Intent     string                    `json:"intent,omitempty"`
+	AgentRoute *types.AgentRouteOverride `json:"agent_route,omitempty"`
 }
 
 // SubscribeParams starts an event stream for a run.

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -144,6 +144,15 @@ const (
 	AgentCursor   AgentName = "cursor"
 )
 
+// AgentRouteOverride replaces one resolved pipeline agent with another for a
+// single run. Args are appended only when From is present in the resolved
+// configuration, so unrelated agents and fallback routes stay unchanged.
+type AgentRouteOverride struct {
+	From AgentName `json:"from"`
+	To   AgentName `json:"to"`
+	Args []string  `json:"args,omitempty"`
+}
+
 // ACPAlias describes a first-class agent name that resolves to an ACP target.
 type ACPAlias struct {
 	Name           AgentName


### PR DESCRIPTION
## Summary

Add a run-scoped agent route to `no-mistakes axi run`, so an orchestrator can replace one resolved native agent without changing shared global or repository configuration.

The new `--agent-route from=to` and repeatable `--agent-route-arg` flags travel through the push/rerun IPC path, are stored on the run, and are restored after a daemon restart. Routing happens after normal agent resolution, which means `auto` can be redirected based on what it selected, while unrelated fallback entries such as Codex remain unchanged.

This is needed by Fleet's `pi-k3` launch profile. Fleet can route only pipeline entries that resolve to Claude through Pi/Kimi K3 while concurrent normal Fleet runs continue using the daemon's ordinary configuration.

## Verification

- `env -u GIT_CONFIG_COUNT -u GIT_CONFIG_KEY_0 -u GIT_CONFIG_VALUE_0 go test ./...`
- Added coverage for CLI parsing, push-option transport, resolved-agent replacement, routed arguments, Codex fallback preservation, and daemon agent construction.

The three Git variables are injected by Fleet's disposable task worktree to install a status hook. Removing them from the test process lets upstream branch-sync tests exercise their own repository-local hooks.
