### PR TITLE
fix(pipeline): sign off pipeline auto-fix commits

### DIFF
--- a/docs/src/content/docs/concepts/auto-fix.md
+++ b/docs/src/content/docs/concepts/auto-fix.md
@@ -90,6 +90,10 @@ It allows a legitimate forward commit made by an agent, but aborts the run if an
 The template does not control commits created by the Rebase, CI, or Push steps.
 The CI step uses `no-mistakes: apply CI fixes`, and the Push step uses `no-mistakes: apply agent fixes` for remaining uncommitted changes.
 
+Every fix commit the pipeline authors - across the Review, Test, Document, Lint, CI, and Push steps - is created with `git commit -s`, adding a `Signed-off-by` trailer derived from the committing identity.
+A [DCO](https://developercertificate.org/)-gated repository therefore accepts these commits directly, without a follow-up remediation commit that only adds the trailer.
+The trailer always matches the commit author, so it is harmless on repositories that do not require DCO.
+
 ## Step rounds
 
 Each execution of a step (initial run or follow-up auto-fix run) is recorded as a "round" in the database.

--- a/internal/pipeline/steps/ci_commit_test.go
+++ b/internal/pipeline/steps/ci_commit_test.go
@@ -63,6 +63,12 @@ func TestCIStep_CommitAndPush(t *testing.T) {
 	if upstreamSHA == headSHA {
 		t.Error("upstream should have a new commit with CI fixes")
 	}
+
+	// The CI-fix commit is signed off so DCO-gated repositories accept it without
+	// a follow-up Signed-off-by remediation commit.
+	if body := gitCmd(t, dir, "log", "-1", "--pretty=%B"); !strings.Contains(body, "Signed-off-by: test <test@test.com>") {
+		t.Errorf("CI-fix commit body = %q, want a Signed-off-by trailer", body)
+	}
 	dbRun, err := sctx.DB.GetRun(sctx.Run.ID)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/pipeline/steps/ci_fix.go
+++ b/internal/pipeline/steps/ci_fix.go
@@ -137,7 +137,9 @@ func (s *CIStep) commitAndPush(sctx *pipeline.StepContext) (bool, error) {
 	if _, err := stepGitRun(sctx, "add", "-A"); err != nil {
 		return false, fmt.Errorf("stage CI changes: %w", err)
 	}
-	if _, err := stepGitRun(sctx, "commit", "-m", "no-mistakes: apply CI fixes"); err != nil {
+	// Sign off (see commitAgentFixes) so DCO-gated repositories accept the CI-fix
+	// commit without a follow-up Signed-off-by remediation commit.
+	if _, err := stepGitRun(sctx, "commit", "-s", "-m", "no-mistakes: apply CI fixes"); err != nil {
 		return false, fmt.Errorf("commit: %w", err)
 	}
 	headSHA, err := stepGitHeadSHA(sctx)

--- a/internal/pipeline/steps/common_fix.go
+++ b/internal/pipeline/steps/common_fix.go
@@ -138,7 +138,12 @@ func commitAgentFixes(sctx *pipeline.StepContext, stepName types.StepName, summa
 	if _, err := git.Run(ctx, sctx.WorkDir, "add", "-A"); err != nil {
 		return fmt.Errorf("stage %s changes: %w", stepName, err)
 	}
-	if _, err := git.Run(ctx, sctx.WorkDir, "commit", "-m", commitMessage); err != nil {
+	// Sign off pipeline-authored fixes so DCO-gated repositories accept them
+	// directly, without a follow-up remediation commit that only adds the
+	// Signed-off-by trailer. The trailer is derived from the committer identity,
+	// so it always matches the commit author; it is harmless on repositories
+	// that do not require DCO.
+	if _, err := git.Run(ctx, sctx.WorkDir, "commit", "-s", "-m", commitMessage); err != nil {
 		return fmt.Errorf("commit %s changes: %w", stepName, err)
 	}
 	headSHA, err := git.HeadSHA(ctx, sctx.WorkDir)

--- a/internal/pipeline/steps/common_test.go
+++ b/internal/pipeline/steps/common_test.go
@@ -730,6 +730,30 @@ func TestCommitAgentFixes_UsesFallbackSummary(t *testing.T) {
 	}
 }
 
+func TestCommitAgentFixes_SignsOffCommit(t *testing.T) {
+	t.Parallel()
+	dir, baseSHA, headSHA := setupGitRepo(t)
+	gitCmd(t, dir, "checkout", "--detach", headSHA)
+
+	ag := &mockAgent{name: "test"}
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
+
+	os.WriteFile(filepath.Join(dir, "agent-change.txt"), []byte("change"), 0o644)
+	if err := commitAgentFixes(sctx, types.StepDocument, "add signoff", "fallback"); err != nil {
+		t.Fatal(err)
+	}
+
+	// The pipeline signs off its own auto-fix commits so DCO-gated repositories
+	// accept them without a follow-up Signed-off-by remediation commit. The
+	// trailer must match the committing identity (test <test@test.com> from
+	// setupGitRepo) or DCO would reject it.
+	body := gitCmd(t, dir, "log", "-1", "--pretty=%B")
+	want := "Signed-off-by: test <test@test.com>"
+	if !strings.Contains(body, want) {
+		t.Errorf("commit body = %q, want it to contain %q", body, want)
+	}
+}
+
 func TestMatchIgnorePattern(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -51,7 +51,9 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 		if _, err := git.Run(ctx, sctx.WorkDir, "add", "-A"); err != nil {
 			return nil, fmt.Errorf("stage agent changes: %w", err)
 		}
-		_, err := git.Run(ctx, sctx.WorkDir, "commit", "-m", "no-mistakes: apply agent fixes")
+		// Sign off (see commitAgentFixes) so DCO-gated repositories accept the
+		// agent-fix commit without a follow-up Signed-off-by remediation commit.
+		_, err := git.Run(ctx, sctx.WorkDir, "commit", "-s", "-m", "no-mistakes: apply agent fixes")
 		if err != nil {
 			return nil, fmt.Errorf("commit agent changes: %w", err)
 		}


### PR DESCRIPTION
## Summary

The pipeline's auto-fix steps (Review, Test, Document, Lint, CI, Push) create their commits with `git commit -m`, without a `Signed-off-by` trailer. On a repository that enforces [DCO](https://developercertificate.org/), those commits fail the DCO check, so the pipeline then lands a separate remediation commit whose only content is the standard fixup ("I, ..., hereby add my Signed-off-by to this commit: <sha>"). DCO ends up green, but every no-mistakes PR against a DCO-gated repo accumulates one remediation commit per auto-fix commit.

This authors the pipeline's own auto-fix commits with `git commit -s` instead, so DCO passes on the first commit and no remediation commit is produced.

## Changes

- `internal/pipeline/steps/common_fix.go` - `commitAgentFixes` (Review/Test/Document/Lint) now commits with `-s`.
- `internal/pipeline/steps/ci_fix.go` - the `no-mistakes: apply CI fixes` commit now uses `-s`.
- `internal/pipeline/steps/push.go` - the `no-mistakes: apply agent fixes` commit now uses `-s`.
- Tests: `TestCommitAgentFixes_SignsOffCommit` plus a Signed-off-by assertion in the CI commit-and-push test.
- Docs: `docs/concepts/auto-fix.md` documents the sign-off behavior.

The trailer is derived from the committing identity, so it always matches the commit author and satisfies DCO; it is harmless on repositories that do not require DCO. Scope is limited to pipeline-authored auto-fix commits - the wizard's user-initiated `CommitAll` config-setup commit is intentionally left unsigned.

Closes #620

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

- rebase: completed
- review: completed
- test: completed
- document: completed
- lint: completed
- push: completed
