### PR TITLE
fix(branchsync): prefer newer pushed descendants over stale custody

### DIFF
--- a/.no-mistakes/evidence/fm/nm-branchsync-descendant-custody-f1/axi-sync-public-path.txt
+++ b/.no-mistakes/evidence/fm/nm-branchsync-descendant-custody-f1/axi-sync-public-path.txt
@@ -1,0 +1,84 @@
+Public AXI branch synchronization evidence
+==========================================
+
+Command exercised:
+  go test ./internal/cli -run 'TestAxiSyncOlderUnpublished(RunSelectsNewerPushedDescendant|NonAncestorStillRefuses|MissingGateDoesNotSupersede)$' -count=1 -v
+
+1. Older unpublished U is an ancestor of newer exact pushed P
+
+The public `axi sync` output selected the completed pushed run and moved the
+clean local branch to P:
+
+  branch_sync:
+    state: synchronized
+    changed: true
+    local:
+      branch: feature/sync
+      head: 3958850354ed52675e6daeecca3d8c7cb58107d2
+      clean: true
+    pipeline:
+      status: completed
+      current_head: 3958850354ed52675e6daeecca3d8c7cb58107d2
+      pushed_head: 3958850354ed52675e6daeecca3d8c7cb58107d2
+    target:
+      kind: upstream
+      ref: refs/heads/feature/sync
+    relation: equal
+    safety: already_synchronized
+
+The focused regression also verified the operator HEAD became P and the gate
+remained unchanged at P.
+
+2. U and P are not ancestor-related
+
+The public `axi sync` path retained the older failed run's custody and made no
+change:
+
+  branch_sync:
+    state: pipeline_owned
+    changed: false
+    local:
+      branch: feature/sync
+      clean: true
+    pipeline:
+      status: failed
+      phase: pre_push
+      current_head: d24a322a96d44da58b3bed57f03a46b00af10990
+    safety: blocked_pipeline_owned_recoverable
+    next_action:
+      code: recover_custody
+      command: no-mistakes axi sync --recover
+
+The attempted public recovery remained fail-closed:
+
+  branch_sync:
+    state: pipeline_owned
+    changed: false
+    safety: blocked_recover_gate_diverged
+    note: "the gate branch is at 637c2709fdd42eac088d982cd2a582c27173b1c1, not the preserved pipeline head d24a322a96d44da58b3bed57f03a46b00af10990 recorded for this run; no files or refs were changed"
+
+The regression verified that neither the operator HEAD nor gate branch moved.
+
+3. Gate branch ancestry evidence is missing
+
+After deleting the gate's feature branch, public `axi sync` retained the older
+failed run's custody and made no change:
+
+  branch_sync:
+    state: pipeline_owned
+    changed: false
+    local:
+      branch: feature/sync
+      clean: true
+    pipeline:
+      status: failed
+      phase: pre_push
+      current_head: d81cbb82b6b146d82cb13bd195a6917049560767
+    safety: blocked_pipeline_owned_recoverable
+    next_action:
+      code: recover_custody
+      command: no-mistakes axi sync --recover
+
+The regression verified that the operator HEAD did not move.
+
+All three focused public-path regressions passed.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -194,7 +194,7 @@ The ordinary worktree mutation is either a strict fast-forward of the invoking c
 When a clean local branch and the pipeline-pushed head are diverged but the local unique work is content-equivalent to work already represented in the live pipeline head, `sync` reports `safety: safe_equivalent_advance`, anchors the pre-sync head under `refs/no-mistakes/sync-anchor/<run>`, and moves to the pipeline head with reset semantics.
 Genuine divergence still reports `safety: blocked_diverged` and changes nothing.
 Under `--recover`, the possible worktree mutation is a strict fast-forward to the preserved pipeline head after relation-specific preservation checks.
-When a newer same-branch exact pushed binding is proven to contain an older terminal run's unpublished preserved head, branch synchronization selects the newer binding; missing, divergent, or otherwise ambiguous ancestry remains blocked.
+When the local gate branch is exactly at a newer same-branch pushed binding and Git proves that an older terminal run's unpublished preserved head is its ancestor, branch synchronization selects the newer binding; missing gate evidence, non-ancestor heads, or different or ambiguous target provenance remain blocked.
 Fork configurations verify the configured fork URL and exact feature ref rather than assuming `origin`.
 Dirty, in-progress, ahead, genuinely diverged, detached, wrong-branch, offline, changed-target, rewritten, deleted, legacy, or retired states fail closed without destructive recovery.
 Run `axi sync` only when structured output offers `next_action.code: sync`; process any blocked state instead of substituting reset, stash, merge, rebase, force, or branch replacement.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -194,6 +194,7 @@ The ordinary worktree mutation is either a strict fast-forward of the invoking c
 When a clean local branch and the pipeline-pushed head are diverged but the local unique work is content-equivalent to work already represented in the live pipeline head, `sync` reports `safety: safe_equivalent_advance`, anchors the pre-sync head under `refs/no-mistakes/sync-anchor/<run>`, and moves to the pipeline head with reset semantics.
 Genuine divergence still reports `safety: blocked_diverged` and changes nothing.
 Under `--recover`, the possible worktree mutation is a strict fast-forward to the preserved pipeline head after relation-specific preservation checks.
+When a newer same-branch exact pushed binding is proven to contain an older terminal run's unpublished preserved head, branch synchronization selects the newer binding; missing, divergent, or otherwise ambiguous ancestry remains blocked.
 Fork configurations verify the configured fork URL and exact feature ref rather than assuming `origin`.
 Dirty, in-progress, ahead, genuinely diverged, detached, wrong-branch, offline, changed-target, rewritten, deleted, legacy, or retired states fail closed without destructive recovery.
 Run `axi sync` only when structured output offers `next_action.code: sync`; process any blocked state instead of substituting reset, stash, merge, rebase, force, or branch replacement.

--- a/internal/branchsync/sync.go
+++ b/internal/branchsync/sync.go
@@ -1018,7 +1018,7 @@ func exactPushedBinding(repo *db.Repo, run *db.Run, branch string) bool {
 // missing or conflicting evidence leaves the older run authoritative.
 func (s *Service) supersededUnpublishedRun(ctx context.Context, older, newer *db.Run, branch string) bool {
 	if older == nil || newer == nil || !terminalRunStatus(older.Status) || !unpublishedPipelineHead(older) ||
-		strings.TrimSpace(s.GateDir) == "" || older.HeadSHA == "" || newer.LastPushedSHA == nil {
+		!samePushTargetBinding(older, newer) || strings.TrimSpace(s.GateDir) == "" || older.HeadSHA == "" || newer.LastPushedSHA == nil {
 		return false
 	}
 	pushed := ptr(newer.LastPushedSHA)
@@ -1027,6 +1027,13 @@ func (s *Service) supersededUnpublishedRun(ctx context.Context, older, newer *db
 		return false
 	}
 	return isAncestor(ctx, s.GateDir, older.HeadSHA, pushed)
+}
+
+func samePushTargetBinding(older, newer *db.Run) bool {
+	return older != nil && newer != nil &&
+		older.PushTargetKind != nil && newer.PushTargetKind != nil && ptr(older.PushTargetKind) == ptr(newer.PushTargetKind) &&
+		older.PushTargetFingerprint != nil && newer.PushTargetFingerprint != nil && ptr(older.PushTargetFingerprint) == ptr(newer.PushTargetFingerprint) &&
+		older.PushRef != nil && newer.PushRef != nil && ptr(older.PushRef) == ptr(newer.PushRef)
 }
 
 func terminalRunStatus(status types.RunStatus) bool {

--- a/internal/branchsync/sync.go
+++ b/internal/branchsync/sync.go
@@ -119,8 +119,9 @@ func CanApply(state State) bool {
 
 // Service synchronizes only the invoking worktree. Repo is the registered
 // repository record, while WorkDir may be its main or a linked worktree.
-// GateDir is the repo's local bare gate; Recover reads preserved pipeline
-// heads from it and is the only method that touches it.
+// GateDir is the repo's local bare gate; selection may read its exact branch
+// head and ancestry as provenance evidence, while Recover is the only method
+// that mutates it.
 type Service struct {
 	DB      *db.DB
 	Repo    *db.Repo
@@ -198,8 +199,9 @@ func displayTarget(raw string) string {
 	return safeurl.Redact(raw)
 }
 
-// InspectCached reads local Git and persisted provenance without fetching or
-// mutating refs, the index, or the worktree.
+// InspectCached reads local Git, persisted provenance, and read-only gate
+// ancestry evidence without fetching or mutating refs, the index, or the
+// worktree.
 func (s *Service) InspectCached(ctx context.Context) State {
 	state, _, _ := s.inspect(ctx)
 	return state
@@ -697,13 +699,23 @@ func (s *Service) inspect(ctx context.Context) (State, *db.Run, bool) {
 		return state, nil, false
 	}
 	var run *db.Run
+	var newerPushed *db.Run
 	for _, candidate := range runs {
 		if candidate.Branch != branch {
 			continue
 		}
 		if candidate.Status == types.RunPending || candidate.Status == types.RunRunning || unpublishedPipelineHead(candidate) {
+			// A terminal unpublished run can be superseded only by a newer
+			// exact binding whose pushed head is proven, in the local gate, to
+			// contain the preserved head. Active ownership remains absolute.
+			if unpublishedPipelineHead(candidate) && s.supersededUnpublishedRun(ctx, candidate, newerPushed, branch) {
+				continue
+			}
 			run = candidate
 			break
+		}
+		if newerPushed == nil && exactPushedBinding(s.Repo, candidate, branch) {
+			newerPushed = candidate
 		}
 		// Custody-returned runs stay selectable so a recovered branch reports
 		// custody_returned (or its ordinary post-push classification) instead
@@ -988,6 +1000,33 @@ func unpublishedPipelineHead(run *db.Run) bool {
 		return run.HeadSHA != ptr(run.SubmittedHeadSHA)
 	}
 	return run.HeadSHA != ptr(run.LastPushedSHA)
+}
+
+func exactPushedBinding(repo *db.Repo, run *db.Run, branch string) bool {
+	return repo != nil && run != nil && run.Branch == branch && !run.PushActive && run.HeadSHA != "" &&
+		run.LastPushedSHA != nil && run.HeadSHA == ptr(run.LastPushedSHA) &&
+		run.PushTargetKind != nil && ptr(run.PushTargetKind) == targetKind(repo) &&
+		run.PushTargetFingerprint != nil && ptr(run.PushTargetFingerprint) == TargetFingerprint(repo.PushURL()) &&
+		run.PushRef != nil && ptr(run.PushRef) == "refs/heads/"+branch &&
+		run.PushGeneration != nil
+}
+
+// supersededUnpublishedRun proves the narrow rerun relationship needed to
+// ignore an older terminal unpublished head during branch selection. The gate
+// is read-only evidence: its exact branch head must equal the newer push
+// binding, and Git must prove the older preserved head is its ancestor. Any
+// missing or conflicting evidence leaves the older run authoritative.
+func (s *Service) supersededUnpublishedRun(ctx context.Context, older, newer *db.Run, branch string) bool {
+	if older == nil || newer == nil || !terminalRunStatus(older.Status) || !unpublishedPipelineHead(older) ||
+		strings.TrimSpace(s.GateDir) == "" || older.HeadSHA == "" || newer.LastPushedSHA == nil {
+		return false
+	}
+	pushed := ptr(newer.LastPushedSHA)
+	gateHead, err := git.Run(ctx, s.GateDir, "rev-parse", "refs/heads/"+branch+"^{commit}")
+	if err != nil || gateHead != pushed {
+		return false
+	}
+	return isAncestor(ctx, s.GateDir, older.HeadSHA, pushed)
 }
 
 func terminalRunStatus(status types.RunStatus) bool {

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -433,16 +433,29 @@ type cliStaleUnpublishedFixture struct {
 	local, gate, base, localHead, unpublished, pushed string
 }
 
+type olderTargetProvenance int
+
+const (
+	olderTargetMatching olderTargetProvenance = iota
+	olderTargetConflicting
+	olderTargetMissing
+)
+
 // newCLIStaleUnpublishedFixture builds the exact same-branch provenance race:
 // an older terminal run owns U, while a newer run has an exact pushed
 // descendant P. The gate and remote are both at P, and the clean worktree is
 // still at L, the ancestor before U.
 func newCLIStaleUnpublishedFixture(t *testing.T) cliStaleUnpublishedFixture {
 	t.Helper()
-	return newCLIStaleUnpublishedFixtureWithRelation(t, true)
+	return newCLIStaleUnpublishedFixtureWithOptions(t, true, olderTargetMatching)
 }
 
 func newCLIStaleUnpublishedFixtureWithRelation(t *testing.T, pushedDescendant bool) cliStaleUnpublishedFixture {
+	t.Helper()
+	return newCLIStaleUnpublishedFixtureWithOptions(t, pushedDescendant, olderTargetMatching)
+}
+
+func newCLIStaleUnpublishedFixtureWithOptions(t *testing.T, pushedDescendant bool, provenance olderTargetProvenance) cliStaleUnpublishedFixture {
 	t.Helper()
 	nmHome := filepath.Join(t.TempDir(), "nm-home")
 	t.Setenv("NM_HOME", nmHome)
@@ -504,6 +517,15 @@ func newCLIStaleUnpublishedFixtureWithRelation(t *testing.T, pushedDescendant bo
 	older, err := database.InsertRun(repo.ID, "feature/sync", localHead, base)
 	if err != nil {
 		t.Fatal(err)
+	}
+	if provenance != olderTargetMissing {
+		fingerprint := branchsync.TargetFingerprint(remote)
+		if provenance == olderTargetConflicting {
+			fingerprint = branchsync.TargetFingerprint(remote + "-previous")
+		}
+		if err := database.UpdateRunPushBinding(older.ID, db.PushBinding{HeadSHA: localHead, TargetKind: "upstream", TargetFingerprint: fingerprint, Ref: "refs/heads/feature/sync"}); err != nil {
+			t.Fatal(err)
+		}
 	}
 	if err := database.UpdateRunHeadSHA(older.ID, unpublished); err != nil {
 		t.Fatal(err)
@@ -567,7 +589,7 @@ func TestAxiSyncOlderUnpublishedRunSelectsNewerPushedDescendant(t *testing.T) {
 	if err != nil {
 		t.Fatalf("descendant sync: %v\n%s", err, out)
 	}
-	for _, want := range []string{"state: synchronized", "status: completed", "current_head: " + f.pushed, "pushed_head: " + f.pushed, "changed: true"} {
+	for _, want := range []string{"state: synchronized", "status: completed", f.pushed, "changed: true"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("descendant sync missing %q:\n%s", want, out)
 		}
@@ -627,6 +649,36 @@ func TestAxiSyncOlderUnpublishedMissingGateDoesNotSupersede(t *testing.T) {
 	}
 	if got := cliGit(t, f.local, "rev-parse", "HEAD"); got != f.localHead {
 		t.Fatalf("missing-gate refusal moved HEAD to %s", got)
+	}
+}
+
+func TestAxiSyncOlderUnpublishedTargetProvenanceRefusesTakeover(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		provenance olderTargetProvenance
+	}{
+		{name: "conflicting", provenance: olderTargetConflicting},
+		{name: "missing", provenance: olderTargetMissing},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newCLIStaleUnpublishedFixtureWithOptions(t, true, tc.provenance)
+			out, err := executeCmd("axi", "sync")
+			var ee *exitError
+			if err == nil || !asExitError(err, &ee) || ee.code != 1 {
+				t.Fatalf("%s target provenance should refuse, got %#v\n%s", tc.name, err, out)
+			}
+			for _, want := range []string{"state: pipeline_owned", "status: failed", f.unpublished} {
+				if !strings.Contains(out, want) {
+					t.Errorf("%s target provenance missing refusal evidence %q:\n%s", tc.name, want, out)
+				}
+			}
+			if got := cliGit(t, f.local, "rev-parse", "HEAD"); got != f.localHead {
+				t.Fatalf("refused %s target provenance moved HEAD to %s", tc.name, got)
+			}
+			if got := cliGit(t, f.gate, "rev-parse", "refs/heads/feature/sync"); got != f.pushed {
+				t.Fatalf("refused %s target provenance moved gate to %s", tc.name, got)
+			}
+		})
 	}
 }
 

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/branchsync"
 	"github.com/kunchenguid/no-mistakes/internal/db"
@@ -426,6 +427,207 @@ func newCLIRecoverFixture(t *testing.T) cliRecoverFixture {
 	}
 	chdir(t, local)
 	return cliRecoverFixture{local: local, gate: gate, submitted: submitted, preserved: preserved}
+}
+
+type cliStaleUnpublishedFixture struct {
+	local, gate, base, localHead, unpublished, pushed string
+}
+
+// newCLIStaleUnpublishedFixture builds the exact same-branch provenance race:
+// an older terminal run owns U, while a newer run has an exact pushed
+// descendant P. The gate and remote are both at P, and the clean worktree is
+// still at L, the ancestor before U.
+func newCLIStaleUnpublishedFixture(t *testing.T) cliStaleUnpublishedFixture {
+	t.Helper()
+	return newCLIStaleUnpublishedFixtureWithRelation(t, true)
+}
+
+func newCLIStaleUnpublishedFixtureWithRelation(t *testing.T, pushedDescendant bool) cliStaleUnpublishedFixture {
+	t.Helper()
+	nmHome := filepath.Join(t.TempDir(), "nm-home")
+	t.Setenv("NM_HOME", nmHome)
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote.git")
+	cliGit(t, root, "init", "--bare", remote)
+	local := filepath.Join(root, "operator")
+	cliGit(t, root, "init", "-b", "main", local)
+	cliGit(t, local, "config", "user.name", "Test")
+	cliGit(t, local, "config", "user.email", "test@example.com")
+	if err := os.WriteFile(filepath.Join(local, "file.txt"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cliGit(t, local, "add", "file.txt")
+	cliGit(t, local, "commit", "-m", "base")
+	base := cliGit(t, local, "rev-parse", "HEAD")
+	cliGit(t, local, "checkout", "-b", "feature/sync")
+	if err := os.WriteFile(filepath.Join(local, "file.txt"), []byte("feature\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cliGit(t, local, "commit", "-am", "feature")
+	localHead := cliGit(t, local, "rev-parse", "HEAD")
+
+	p, err := paths.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	database, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+	registeredRoot, err := git.FindGitRoot(local)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo, err := database.InsertRepo(registeredRoot, remote, "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gate := p.RepoDir(repo.ID)
+	cliGit(t, filepath.Dir(gate), "init", "--bare", gate)
+
+	pipeline := filepath.Join(root, "pipeline-old")
+	cliGit(t, root, "-c", "core.autocrlf=false", "clone", local, pipeline)
+	cliGit(t, pipeline, "config", "user.name", "Pipeline")
+	cliGit(t, pipeline, "config", "user.email", "pipeline@example.com")
+	cliGit(t, pipeline, "checkout", "feature/sync")
+	if err := os.WriteFile(filepath.Join(pipeline, "older-fix.txt"), []byte("older\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cliGit(t, pipeline, "add", "older-fix.txt")
+	cliGit(t, pipeline, "commit", "-m", "older pipeline fix")
+	unpublished := cliGit(t, pipeline, "rev-parse", "HEAD")
+	cliGit(t, pipeline, "push", gate, "HEAD:refs/heads/feature/sync")
+
+	older, err := database.InsertRun(repo.ID, "feature/sync", localHead, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.UpdateRunHeadSHA(older.ID, unpublished); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.UpdateRunStatus(older.ID, types.RunFailed); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure the database's created_at ordering cannot depend on ULID tie
+	// breaking: the pushed rerun is definitively newer than the failed run.
+	time.Sleep(1100 * time.Millisecond)
+	newer := filepath.Join(root, "pipeline-new")
+	pipelineSource := gate
+	if !pushedDescendant {
+		pipelineSource = local
+	}
+	cliGit(t, root, "-c", "core.autocrlf=false", "clone", pipelineSource, newer)
+	cliGit(t, newer, "config", "user.name", "Pipeline")
+	cliGit(t, newer, "config", "user.email", "pipeline@example.com")
+	cliGit(t, newer, "checkout", "feature/sync")
+	if err := os.WriteFile(filepath.Join(newer, "newer-fix.txt"), []byte("newer\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cliGit(t, newer, "add", "newer-fix.txt")
+	cliGit(t, newer, "commit", "-m", "newer pipeline fix")
+	pushed := cliGit(t, newer, "rev-parse", "HEAD")
+	cliGit(t, newer, "push", remote, "HEAD:refs/heads/feature/sync")
+	gatePushArgs := []string{"push", gate, "HEAD:refs/heads/feature/sync"}
+	if !pushedDescendant {
+		gatePushArgs = []string{"push", "--force", gate, "HEAD:refs/heads/feature/sync"}
+	}
+	cliGit(t, newer, gatePushArgs...)
+
+	latestSubmitted := unpublished
+	if !pushedDescendant {
+		latestSubmitted = localHead
+	}
+	latest, err := database.InsertRun(repo.ID, "feature/sync", latestSubmitted, base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.UpdateRunHeadSHA(latest.ID, pushed); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.UpdateRunPushBinding(latest.ID, db.PushBinding{HeadSHA: pushed, TargetKind: "upstream", TargetFingerprint: branchsync.TargetFingerprint(remote), Ref: "refs/heads/feature/sync"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.UpdateRunStatus(latest.ID, types.RunCompleted); err != nil {
+		t.Fatal(err)
+	}
+	if err := database.Close(); err != nil {
+		t.Fatal(err)
+	}
+	chdir(t, local)
+	return cliStaleUnpublishedFixture{local: local, gate: gate, base: base, localHead: localHead, unpublished: unpublished, pushed: pushed}
+}
+
+func TestAxiSyncOlderUnpublishedRunSelectsNewerPushedDescendant(t *testing.T) {
+	f := newCLIStaleUnpublishedFixture(t)
+	out, err := executeCmd("axi", "sync")
+	if err != nil {
+		t.Fatalf("descendant sync: %v\n%s", err, out)
+	}
+	for _, want := range []string{"state: synchronized", "status: completed", "current_head: " + f.pushed, "pushed_head: " + f.pushed, "changed: true"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("descendant sync missing %q:\n%s", want, out)
+		}
+	}
+	if got := cliGit(t, f.local, "rev-parse", "HEAD"); got != f.pushed {
+		t.Fatalf("sync HEAD = %s, want pushed descendant %s", got, f.pushed)
+	}
+	if got := cliGit(t, f.gate, "rev-parse", "refs/heads/feature/sync"); got != f.pushed {
+		t.Fatalf("sync moved gate to %s, want unchanged pushed head %s", got, f.pushed)
+	}
+}
+
+func TestAxiSyncOlderUnpublishedNonAncestorStillRefuses(t *testing.T) {
+	f := newCLIStaleUnpublishedFixtureWithRelation(t, false)
+	out, err := executeCmd("axi", "sync")
+	var ee *exitError
+	if err == nil || !asExitError(err, &ee) || ee.code != 1 {
+		t.Fatalf("non-ancestor sync should refuse, got %#v\n%s", err, out)
+	}
+	for _, want := range []string{"state: pipeline_owned", "status: failed", f.unpublished} {
+		if !strings.Contains(out, want) {
+			t.Errorf("non-ancestor sync missing refusal evidence %q:\n%s", want, out)
+		}
+	}
+	if got := cliGit(t, f.local, "rev-parse", "HEAD"); got != f.localHead {
+		t.Fatalf("refused non-ancestor sync moved HEAD to %s", got)
+	}
+
+	out, err = executeCmd("axi", "sync", "--recover")
+	if err == nil || !asExitError(err, &ee) || ee.code != 1 {
+		t.Fatalf("non-ancestor recovery should refuse, got %#v\n%s", err, out)
+	}
+	if !strings.Contains(out, "safety: blocked_recover_gate_diverged") {
+		t.Fatalf("non-ancestor recovery did not remain fail-closed:\n%s", out)
+	}
+	if got := cliGit(t, f.local, "rev-parse", "HEAD"); got != f.localHead {
+		t.Fatalf("refused non-ancestor recovery moved HEAD to %s", got)
+	}
+	if got := cliGit(t, f.gate, "rev-parse", "refs/heads/feature/sync"); got != f.pushed {
+		t.Fatalf("refused non-ancestor recovery moved gate to %s", got)
+	}
+}
+
+func TestAxiSyncOlderUnpublishedMissingGateDoesNotSupersede(t *testing.T) {
+	f := newCLIStaleUnpublishedFixture(t)
+	cliGit(t, f.gate, "update-ref", "-d", "refs/heads/feature/sync")
+
+	out, err := executeCmd("axi", "sync")
+	var ee *exitError
+	if err == nil || !asExitError(err, &ee) || ee.code != 1 {
+		t.Fatalf("missing-gate sync should refuse, got %#v\n%s", err, out)
+	}
+	for _, want := range []string{"state: pipeline_owned", "status: failed", f.unpublished} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing-gate sync missing refusal evidence %q:\n%s", want, out)
+		}
+	}
+	if got := cliGit(t, f.local, "rev-parse", "HEAD"); got != f.localHead {
+		t.Fatalf("missing-gate refusal moved HEAD to %s", got)
+	}
 }
 
 func TestAxiSyncCheckSurfacesRecoveryForTerminalPrePushRun(t *testing.T) {


### PR DESCRIPTION
## Intent

Fix no-mistakes branch synchronization so an older terminal same-branch run with unpublished preserved head U cannot override a newer exact pushed descendant P. When the local gate is exactly at P and Git proves U is an ancestor of P, branch synchronization must select the newer pushed binding so a clean local ancestor can safely fast-forward to P. Preserve fail-closed behavior when heads are non-ancestor-related, the gate or ancestry proof is unavailable, the target or branch identity differs, or provenance is ambiguous; do not add manual escapes, discard preserved heads, or broaden custody takeover semantics. Validate this through the public AXI sync path with regression coverage for descendant selection, non-ancestor refusal, and missing-gate refusal. Do not touch Firstmate PR 1446, shared daemon state, installed binaries, or live fleet state.

## What Changed

- Select a newer exact pushed binding when its gate head contains an older terminal run’s unpublished preserved head.
- Require matching target provenance and fail closed when gate, ancestry, branch, or target evidence is missing or conflicting.
- Document the descendant-aware sync behavior and add public AXI regression coverage for descendant selection and refusal cases.

## Risk Assessment

✅ Low: The follow-up now requires complete matching target kind, fingerprint, and ref before descendant supersession, while preserving the intended ancestry, gate, branch, and mutation safeguards.

## Testing

Exercised descendant selection, non-ancestor and recovery refusal, missing-gate refusal, and conflicting or missing provenance through public AXI sync; all focused regressions passed, refusal cases preserved local and gate heads, and the CLI transcript was saved as evidence.

- Evidence: [Public AXI sync transcript](https://github.com/kunchenguid/no-mistakes/blob/3a34b7cc8d37c76c111948377a584b935e8aea5a/.no-mistakes/evidence/fm/nm-branchsync-descendant-custody-f1/axi-sync-public-path.txt)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `internal/branchsync/sync.go:1020` - The intent requires fail-closed behavior when &#34;the target ... identity differs,&#34; but this supersession proof checks only the newer run against the current target and never compares an older run&#39;s existing push target provenance. A reachable sequence is: the older run pushes Q to target A, advances to unpublished U, the repo changes to target B, and a newer run pushes descendant P to B while the gate reaches P. This code then suppresses the older custody and syncs to P despite the target mismatch. Require any recorded older target kind, fingerprint, and ref to agree with the newer binding at this shared selection boundary, failing closed on conflicting or partial provenance.

🔧 Fix: Require matching target provenance for descendant custody
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/cli -run 'TestAxiSyncOlderUnpublished(RunSelectsNewerPushedDescendant|NonAncestorStillRefuses|MissingGateDoesNotSupersede|TargetProvenanceRefusesTakeover)$' -count=1 -v`
- <code>`go test ./internal/cli -run &#39;TestAxiSyncOlderUnpublished(RunSelectsNewerPushedDescendant|NonAncestorStillRefuses|MissingGateDoesNotSupersede)$&#39; -count=1 -v` (evidence-producing public AXI transcript run)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
