### PR TITLE
feat(agent): fall back when providers exhaust quota

### DIFF
--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -28,7 +28,7 @@ Testing prompts also ask agents to remove transient working-tree artifacts they 
 
 - Leave `agent: auto` if one good agent is already installed and you do not need repo-specific behavior.
 - Set a repo-level `agent` override when one codebase clearly works better with a different tool.
-- Use an ordered fallback list when you prefer one agent but want no-mistakes to try another if the first process is unavailable.
+- Use an ordered fallback list when you prefer one agent but want no-mistakes to try another if the first process is unavailable or reports quota exhaustion.
 - Set explicit `commands.lint` and a **targeted** `commands.test` if you want deterministic local baseline command execution regardless of agent choice; leave `commands.test` empty for agent-selected smallest relevant checks. Do not configure a complete-suite walk as local Test - remote CI owns broad regression.
 
 That last point matters: the agent helps fill in gaps, but explicit repo

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -96,11 +96,11 @@ The list is filtered to entries available to the daemon at run startup, and the 
 After resolving `auto`, entries that resolve to the same ACP target are deduplicated in list order, so `cursor` and `acp:cursor` provide one fallback and preserve whichever spelling appears first.
 If no entry is available, the gate fails before its first pipeline step.
 If a pipeline invocation fails because that agent process cannot start or exits with an error, no-mistakes retries that invocation with the next available fallback.
-An explicit quota, session-limit, or rate-limit signal is also eligible for the next configured agent after the current invocation has ended.
+After the current invocation has ended, positive explicit quota, session-limit, or rate-limit evidence from provider or process diagnostics is also eligible for the next configured agent; assistant prose is not quota evidence.
 Quota fallback starts the replacement agent cold and keeps the same run, step, branch custody, prior commits, finding decisions, and remaining retry budget.
 The replacement follows the resolved list order and the executable and adapter-support availability checks performed at run startup.
-A generic failure or silent exit does not become a quota fallback, and structured findings or schema/output validation problems do not trigger fallback.
-If the ordered path is exhausted, the run fails with a bounded agent-and-reason summary that does not include provider output or secrets.
+Generic invocation failures, successful processes that return no usable result, structured findings, and schema/output validation problems retain their existing behavior and do not become quota fallbacks.
+If the ordered quota/availability path is exhausted, the run fails with a bounded agent-and-reason summary that does not include provider output or secrets.
 When session reuse is enabled, a quota fallback discards the exhausted provider's session identity before recording or resuming the replacement provider's session.
 
 ### acpx_path

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -98,7 +98,7 @@ If no entry is available, the gate fails before its first pipeline step.
 If a pipeline invocation fails because that agent process cannot start or exits with an error, no-mistakes retries that invocation with the next available fallback.
 An explicit quota, session-limit, or rate-limit signal is also eligible for the next configured agent after the current invocation has ended.
 Quota fallback starts the replacement agent cold and keeps the same run, step, branch custody, prior commits, finding decisions, and remaining retry budget.
-The replacement follows the resolved list order and the normal availability and authentication checks from run startup.
+The replacement follows the resolved list order and the executable and adapter-support availability checks performed at run startup.
 A generic failure or silent exit does not become a quota fallback, and structured findings or schema/output validation problems do not trigger fallback.
 If the ordered path is exhausted, the run fails with a bounded agent-and-reason summary that does not include provider output or secrets.
 When session reuse is enabled, a quota fallback discards the exhausted provider's session identity before recording or resuming the replacement provider's session.

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -96,7 +96,12 @@ The list is filtered to entries available to the daemon at run startup, and the 
 After resolving `auto`, entries that resolve to the same ACP target are deduplicated in list order, so `cursor` and `acp:cursor` provide one fallback and preserve whichever spelling appears first.
 If no entry is available, the gate fails before its first pipeline step.
 If a pipeline invocation fails because that agent process cannot start or exits with an error, no-mistakes retries that invocation with the next available fallback.
-Structured findings and schema/output validation problems do not trigger fallback.
+An explicit quota, session-limit, or rate-limit signal is also eligible for the next configured agent after the current invocation has ended.
+Quota fallback starts the replacement agent cold and keeps the same run, step, branch custody, prior commits, finding decisions, and remaining retry budget.
+The replacement follows the resolved list order and the normal availability and authentication checks from run startup.
+A generic failure or silent exit does not become a quota fallback, and structured findings or schema/output validation problems do not trigger fallback.
+If the ordered path is exhausted, the run fails with a bounded agent-and-reason summary that does not include provider output or secrets.
+When session reuse is enabled, a quota fallback discards the exhausted provider's session identity before recording or resuming the replacement provider's session.
 
 ### acpx_path
 

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -104,8 +104,7 @@ agent: [codex, claude]
 The list is filtered to entries available to the daemon at run startup, and the first available entry becomes the primary agent.
 After resolving `auto`, entries that resolve to the same ACP target are deduplicated in list order, so `cursor` and `acp:cursor` provide one fallback and preserve whichever spelling appears first.
 If no entry is available, the gate fails before its first pipeline step.
-If a pipeline invocation fails because that agent process cannot start or exits with an error, no-mistakes retries that invocation with the next available fallback.
-Structured findings and schema/output validation problems do not trigger fallback.
+The [global `agent` field reference](/no-mistakes/reference/global-config/#agent) owns ordered-list retry, quota, session, and exhaustion semantics.
 This per-repo `agent` value, including every fallback entry, is still read from the trusted default-branch `.no-mistakes.yaml` unless `allow_repo_commands` is enabled there.
 
 ### allow_repo_commands

--- a/internal/agent/acpx.go
+++ b/internal/agent/acpx.go
@@ -67,7 +67,8 @@ func (a *acpxAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) 
 	waitErr := started.wait()
 	stderrWG.Wait()
 	if waitErr != nil {
-		retErr := fmt.Errorf("acpx exited: %w: %s", waitErr, acpxProcessErrorOutput(stderrBuf, stdoutErr))
+		diagnostic := acpxProcessErrorOutput(stderrBuf, stdoutErr)
+		retErr := ClassifyProviderError(fmt.Errorf("acpx exited: %w: %s", waitErr, diagnostic), diagnostic)
 		emitAgentExited(opts, a.Name(), pid, retErr)
 		return nil, retErr
 	}

--- a/internal/agent/acpx.go
+++ b/internal/agent/acpx.go
@@ -72,6 +72,10 @@ func (a *acpxAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) 
 		emitAgentExited(opts, a.Name(), pid, retErr)
 		return nil, retErr
 	}
+	if retErr := completedProviderQuotaError(a.Name(), stdoutErr); retErr != nil {
+		emitAgentExited(opts, a.Name(), pid, retErr)
+		return nil, retErr
+	}
 	if usage.OutputTokens == 0 {
 		usage.OutputTokens = estimateAcpxTokens(len(text))
 	}

--- a/internal/agent/acpx_test.go
+++ b/internal/agent/acpx_test.go
@@ -3,9 +3,37 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
+
+func TestAcpxAgent_ZeroExitJSONRPCQuotaIsClassified(t *testing.T) {
+	dir := t.TempDir()
+	name := "acpx"
+	script := "#!/bin/sh\nprintf '%s\\n' '{\"error\":{\"message\":\"session limit reached provider-secret\"}}'\n"
+	if runtime.GOOS == "windows" {
+		name = "acpx.cmd"
+		script = "@echo off\r\necho {\"error\":{\"message\":\"session limit reached provider-secret\"}}\r\n"
+	}
+	bin := filepath.Join(dir, name)
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake acpx: %v", err)
+	}
+
+	_, err := (&acpxAgent{bin: bin, target: "gemini"}).Run(context.Background(), RunOpts{Prompt: "review", CWD: dir})
+	if err == nil {
+		t.Fatal("quota response unexpectedly succeeded")
+	}
+	if _, ok := quotaErrorReason(err); !ok {
+		t.Fatalf("error = %v, want provider quota classification", err)
+	}
+	if strings.Contains(err.Error(), "provider-secret") {
+		t.Fatalf("classified error leaked provider diagnostic: %v", err)
+	}
+}
 
 func TestAcpxFirstPositive(t *testing.T) {
 	cases := []struct {

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -119,6 +119,12 @@ func (a *claudeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error
 		emitAgentExited(opts, "claude", pid, retErr)
 		return nil, retErr
 	}
+	if result.IsError || result.Subtype != "success" {
+		if retErr := completedProviderQuotaError("claude", result.diagnostic); retErr != nil {
+			emitAgentExited(opts, "claude", pid, retErr)
+			return nil, retErr
+		}
+	}
 
 	res, err := finalizeClaudeResult(result, opts.JSONSchema, usage)
 	if res != nil {
@@ -270,6 +276,7 @@ type claudeEvent struct {
 	Subtype          string          `json:"subtype,omitempty"`
 	IsError          bool            `json:"is_error,omitempty"`
 	StructuredOutput json.RawMessage `json:"structured_output,omitempty"`
+	Result           json.RawMessage `json:"result,omitempty"`
 	Usage            *claudeUsage    `json:"usage,omitempty"`
 }
 
@@ -280,6 +287,7 @@ type claudeResult struct {
 	StructuredOutput json.RawMessage
 	text             string // accumulated text from assistant events
 	rawEvent         json.RawMessage
+	diagnostic       string
 	sessionID        string // durable session identity from the event stream
 	model            string // model reported by assistant events
 }
@@ -361,12 +369,17 @@ func parseClaudeEvents(ctx context.Context, r io.Reader, onChunk func(string), u
 			if result != nil {
 				raw := make(json.RawMessage, len(line))
 				copy(raw, line)
+				var diagnostic string
+				if event.IsError || event.Subtype != "success" {
+					_ = json.Unmarshal(event.Result, &diagnostic)
+				}
 				*result = &claudeResult{
 					Subtype:          event.Subtype,
 					IsError:          event.IsError,
 					StructuredOutput: event.StructuredOutput,
 					text:             textBuf,
 					rawEvent:         raw,
+					diagnostic:       diagnostic,
 					sessionID:        lastSessionID,
 					model:            lastModel,
 				}

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -109,7 +109,11 @@ func (a *claudeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error
 	waitErr := started.wait()
 	stderrWG.Wait()
 	if waitErr != nil {
-		retErr := ClassifyProviderError(fmt.Errorf("claude exited: %w: %s", waitErr, string(stderrBuf)), string(stderrBuf))
+		resultDiagnostic := ""
+		if result != nil && (result.IsError || result.Subtype != "success") {
+			resultDiagnostic = result.diagnostic
+		}
+		retErr := ClassifyProviderError(fmt.Errorf("claude exited: %w: %s", waitErr, string(stderrBuf)), string(stderrBuf), resultDiagnostic)
 		emitAgentExited(opts, "claude", pid, retErr)
 		return nil, retErr
 	}

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -109,7 +109,7 @@ func (a *claudeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error
 	waitErr := started.wait()
 	stderrWG.Wait()
 	if waitErr != nil {
-		retErr := fmt.Errorf("claude exited: %w: %s", waitErr, string(stderrBuf))
+		retErr := ClassifyProviderError(fmt.Errorf("claude exited: %w: %s", waitErr, string(stderrBuf)), string(stderrBuf))
 		emitAgentExited(opts, "claude", pid, retErr)
 		return nil, retErr
 	}

--- a/internal/agent/claude_test.go
+++ b/internal/agent/claude_test.go
@@ -573,18 +573,22 @@ func TestClaudeAgent_LargePromptUsesExactStdinForColdAndResumedRuns(t *testing.T
 }
 
 func TestClaudeAgent_QuotaResultIsClassifiedWithoutAssistantText(t *testing.T) {
-	t.Setenv("NM_CLAUDE_STDIN_HELPER", "quota-result")
-	a := newClaudeStdinHelperAgent(t)
+	for _, mode := range []string{"quota-result", "quota-result-nonzero"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Setenv("NM_CLAUDE_STDIN_HELPER", mode)
+			a := newClaudeStdinHelperAgent(t)
 
-	_, err := a.runOnce(context.Background(), RunOpts{Prompt: "review", CWD: t.TempDir()})
-	if err == nil {
-		t.Fatal("quota result unexpectedly succeeded")
-	}
-	if _, ok := quotaErrorReason(err); !ok {
-		t.Fatalf("error = %v, want provider quota classification", err)
-	}
-	if strings.Contains(err.Error(), "provider-secret") {
-		t.Fatalf("classified error leaked provider diagnostic: %v", err)
+			_, err := a.runOnce(context.Background(), RunOpts{Prompt: "review", CWD: t.TempDir()})
+			if err == nil {
+				t.Fatal("quota result unexpectedly succeeded")
+			}
+			if _, ok := quotaErrorReason(err); !ok {
+				t.Fatalf("error = %v, want provider quota classification", err)
+			}
+			if strings.Contains(err.Error(), "provider-secret") {
+				t.Fatalf("classified error leaked provider diagnostic: %v", err)
+			}
+		})
 	}
 }
 
@@ -688,9 +692,12 @@ func TestClaudeStdinHelper(t *testing.T) {
 		for {
 			time.Sleep(time.Second)
 		}
-	case "quota-result":
+	case "quota-result", "quota-result-nonzero":
 		_, _ = io.WriteString(os.Stdout, `{"type":"assistant","message":{"content":[{"type":"text","text":"ordinary assistant output"}]}}`+"\n")
 		_, _ = io.WriteString(os.Stdout, `{"type":"result","subtype":"error","is_error":true,"result":"usage limit reached provider-secret"}`+"\n")
+		if mode == "quota-result-nonzero" {
+			os.Exit(9)
+		}
 		return
 	case "read":
 		prompt, err := io.ReadAll(os.Stdin)

--- a/internal/agent/claude_test.go
+++ b/internal/agent/claude_test.go
@@ -572,6 +572,22 @@ func TestClaudeAgent_LargePromptUsesExactStdinForColdAndResumedRuns(t *testing.T
 	}
 }
 
+func TestClaudeAgent_QuotaResultIsClassifiedWithoutAssistantText(t *testing.T) {
+	t.Setenv("NM_CLAUDE_STDIN_HELPER", "quota-result")
+	a := newClaudeStdinHelperAgent(t)
+
+	_, err := a.runOnce(context.Background(), RunOpts{Prompt: "review", CWD: t.TempDir()})
+	if err == nil {
+		t.Fatal("quota result unexpectedly succeeded")
+	}
+	if _, ok := quotaErrorReason(err); !ok {
+		t.Fatalf("error = %v, want provider quota classification", err)
+	}
+	if strings.Contains(err.Error(), "provider-secret") {
+		t.Fatalf("classified error leaked provider diagnostic: %v", err)
+	}
+}
+
 func TestClaudeAgent_EarlyExitWithoutReadingLargeStdinDoesNotLeakGoroutines(t *testing.T) {
 	t.Setenv("NM_CLAUDE_STDIN_HELPER", "exit-early")
 	a := newClaudeStdinHelperAgent(t)
@@ -672,6 +688,10 @@ func TestClaudeStdinHelper(t *testing.T) {
 		for {
 			time.Sleep(time.Second)
 		}
+	case "quota-result":
+		_, _ = io.WriteString(os.Stdout, `{"type":"assistant","message":{"content":[{"type":"text","text":"ordinary assistant output"}]}}`+"\n")
+		_, _ = io.WriteString(os.Stdout, `{"type":"result","subtype":"error","is_error":true,"result":"usage limit reached provider-secret"}`+"\n")
+		return
 	case "read":
 		prompt, err := io.ReadAll(os.Stdin)
 		if err != nil {

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -135,7 +135,7 @@ func (a *codexAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error)
 		} else if detail == "" {
 			detail = stderr
 		}
-		retErr := fmt.Errorf("codex exited: %w: %s", waitErr, detail)
+		retErr := ClassifyProviderError(fmt.Errorf("codex exited: %w: %s", waitErr, detail), codexErr, string(stderrBuf))
 		emitAgentExited(opts, "codex", pid, retErr)
 		return nil, retErr
 	}

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -139,6 +139,10 @@ func (a *codexAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error)
 		emitAgentExited(opts, "codex", pid, retErr)
 		return nil, retErr
 	}
+	if retErr := completedProviderQuotaError("codex", codexErr); retErr != nil {
+		emitAgentExited(opts, "codex", pid, retErr)
+		return nil, retErr
+	}
 
 	res, err := finalizeTextResult("codex", lastMessage, validationSchema, usage)
 	if res != nil {

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -244,6 +244,27 @@ exit 1
 	}
 }
 
+func TestCodexAgent_ZeroExitQuotaEventIsClassified(t *testing.T) {
+	dir := t.TempDir()
+	bin := writeFakeCodex(t, dir, `#!/bin/sh
+printf '%s\n' '{"type":"error","message":"rate limit exceeded provider-secret"}'
+`, strings.Join([]string{
+		"@echo off",
+		"echo {\"type\":\"error\",\"message\":\"rate limit exceeded provider-secret\"}",
+	}, "\r\n"))
+
+	_, err := (&codexAgent{bin: bin}).Run(context.Background(), RunOpts{Prompt: "review", CWD: dir})
+	if err == nil {
+		t.Fatal("quota event unexpectedly succeeded")
+	}
+	if _, ok := quotaErrorReason(err); !ok {
+		t.Fatalf("error = %v, want provider quota classification", err)
+	}
+	if strings.Contains(err.Error(), "provider-secret") {
+		t.Fatalf("classified error leaked provider diagnostic: %v", err)
+	}
+}
+
 func TestCodexAgent_RunAcceptsNormalizedNullableFields(t *testing.T) {
 	dir := t.TempDir()
 	bin := writeFakeCodex(t, dir, `#!/bin/sh

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -95,6 +95,10 @@ func (a *copilotAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, erro
 		emitAgentExited(opts, "copilot", pid, retErr)
 		return nil, retErr
 	}
+	if retErr := completedProviderQuotaError("copilot", copilotErr); retErr != nil {
+		emitAgentExited(opts, "copilot", pid, retErr)
+		return nil, retErr
+	}
 
 	res, err := finalizeCopilotResult(messages, opts.JSONSchema, usage)
 	emitAgentExited(opts, "copilot", pid, err)

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -77,7 +77,7 @@ func (a *copilotAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, erro
 	detail := copilotErrorDetail(copilotErr, string(stderrBuf))
 	if waitErr != nil {
 		if detail != "" {
-			retErr := fmt.Errorf("copilot exited: %w: %s", waitErr, detail)
+			retErr := ClassifyProviderError(fmt.Errorf("copilot exited: %w: %s", waitErr, detail), copilotErr, string(stderrBuf))
 			emitAgentExited(opts, "copilot", pid, retErr)
 			return nil, retErr
 		}
@@ -87,7 +87,7 @@ func (a *copilotAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, erro
 	}
 	if exitCode != 0 {
 		if detail != "" {
-			retErr := fmt.Errorf("copilot reported exit code %d: %s", exitCode, detail)
+			retErr := ClassifyProviderError(fmt.Errorf("copilot reported exit code %d: %s", exitCode, detail), copilotErr, string(stderrBuf))
 			emitAgentExited(opts, "copilot", pid, retErr)
 			return nil, retErr
 		}

--- a/internal/agent/copilot_test.go
+++ b/internal/agent/copilot_test.go
@@ -318,6 +318,27 @@ func TestCopilotAgent_RunParsesJSONOutput(t *testing.T) {
 	}
 }
 
+func TestCopilotAgent_ZeroExitQuotaEventIsClassified(t *testing.T) {
+	dir := t.TempDir()
+	bin := writeFakeCopilot(t, dir, []string{
+		`{"type":"assistant.message","data":{"content":"ordinary assistant output"}}`,
+		`{"type":"assistant.abort","data":{"message":"rate limit exceeded provider-secret"}}`,
+		`{"type":"result","exitCode":0}`,
+	}, 0)
+
+	ca := &copilotAgent{bin: bin}
+	_, err := ca.Run(context.Background(), RunOpts{Prompt: "do work", CWD: t.TempDir()})
+	if err == nil {
+		t.Fatal("quota event unexpectedly succeeded")
+	}
+	if _, ok := quotaErrorReason(err); !ok {
+		t.Fatalf("error = %v, want provider quota classification", err)
+	}
+	if strings.Contains(err.Error(), "provider-secret") {
+		t.Fatalf("classified error leaked provider diagnostic: %v", err)
+	}
+}
+
 func TestCopilotAgent_RunReportsErrorOnNonZeroExit(t *testing.T) {
 	dir := t.TempDir()
 	bin := writeFakeCopilot(t, dir, []string{

--- a/internal/agent/fallback.go
+++ b/internal/agent/fallback.go
@@ -34,10 +34,17 @@ type providerQuotaError struct {
 	reason string
 }
 
+type quotaFallbackTransitionError struct {
+	err error
+}
+
 func (e *providerQuotaError) Error() string {
 	return fmt.Sprintf("provider quota unavailable: %s", e.reason)
 }
 func (e *providerQuotaError) Unwrap() error { return e.err }
+
+func (e *quotaFallbackTransitionError) Error() string { return e.err.Error() }
+func (e *quotaFallbackTransitionError) Unwrap() error { return e.err }
 
 func (e *quotaFallbackError) Error() string {
 	parts := make([]string, 0, len(e.attempts)+1)
@@ -67,6 +74,16 @@ func appendQuotaFallbackAttempt(attempts []quotaFallbackAttempt, omitted bool, a
 func IsQuotaFallbackError(err error) bool {
 	var quotaErr *quotaFallbackError
 	return errors.As(err, &quotaErr)
+}
+
+// HadQuotaFallback reports whether an invocation moved past a provider after
+// positive quota evidence, including when a later generic failure is returned.
+func HadQuotaFallback(err error) bool {
+	if IsQuotaFallbackError(err) {
+		return true
+	}
+	var transitionErr *quotaFallbackTransitionError
+	return errors.As(err, &transitionErr)
 }
 
 // NewFallback returns an Agent that tries each agent in order when an
@@ -217,7 +234,10 @@ func (a *fallbackAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) 
 		}
 
 		if quotaSeen {
-			if position == len(candidateIndexes)-1 || (!isAgentUnavailableError(err) && !isQuota) {
+			if !isQuota && !isAgentUnavailableError(err) {
+				return nil, &quotaFallbackTransitionError{err: err}
+			}
+			if position == len(candidateIndexes)-1 {
 				return nil, &quotaFallbackError{attempts: path, omitted: pathOmitted}
 			}
 		} else if position == len(candidateIndexes)-1 || !isAgentUnavailableError(err) {
@@ -286,27 +306,44 @@ func quotaErrorReason(err error) (string, bool) {
 
 func quotaDiagnosticReason(diagnostic string) (string, bool) {
 	msg := strings.ToLower(diagnostic)
-	if strings.Contains(msg, "session limit") ||
-		strings.Contains(msg, "session_limit") ||
-		strings.Contains(msg, "usage limit") ||
-		strings.Contains(msg, "weekly limit") ||
-		strings.Contains(msg, "monthly limit") ||
-		strings.Contains(msg, "daily limit") ||
-		strings.Contains(msg, "quota exceeded") ||
+	if strings.Contains(msg, "quota exceeded") ||
 		strings.Contains(msg, "quota exhausted") ||
-		strings.Contains(msg, "quota limit") {
+		strings.Contains(msg, "quota_exceeded") ||
+		strings.Contains(msg, "quota_exhausted") ||
+		strings.Contains(msg, "session_limit_error") ||
+		strings.Contains(msg, "usage_limit_error") ||
+		limitStatus(msg, "session limit") ||
+		limitStatus(msg, "session_limit") ||
+		limitStatus(msg, "usage limit") ||
+		limitStatus(msg, "weekly limit") ||
+		limitStatus(msg, "monthly limit") ||
+		limitStatus(msg, "daily limit") ||
+		limitStatus(msg, "quota limit") {
 		return "session/quota limit", true
 	}
-	if strings.Contains(msg, "rate limit") ||
-		strings.Contains(msg, "rate_limit") ||
+	if strings.Contains(msg, "rate_limit_error") ||
+		strings.Contains(msg, "rate_limit_exceeded") ||
 		strings.Contains(msg, "rate-limited") ||
 		strings.Contains(msg, "rate limited") ||
+		limitStatus(msg, "rate limit") ||
 		strings.Contains(msg, "too many requests") ||
 		strings.Contains(msg, "http 429") ||
 		strings.Contains(msg, "status 429") {
 		return "rate limit", true
 	}
 	return "", false
+}
+
+func limitStatus(msg, limit string) bool {
+	for _, status := range []string{"exceeded", "exhausted", "reached", "hit"} {
+		if strings.Contains(msg, limit+" "+status) ||
+			strings.Contains(msg, status+" "+limit) ||
+			strings.Contains(msg, status+" the "+limit) ||
+			strings.Contains(msg, status+" your "+limit) {
+			return true
+		}
+	}
+	return false
 }
 
 func fallbackFailureReason(err error) string {

--- a/internal/agent/fallback.go
+++ b/internal/agent/fallback.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -313,6 +314,8 @@ func quotaErrorReason(err error) (string, bool) {
 	return quotaErr.reason, true
 }
 
+var providerStatus429RE = regexp.MustCompile(`\b(?:http|status(?: code)?|failed with)\s*[:=]?\s*429\b`)
+
 func quotaDiagnosticReason(diagnostic string) (string, bool) {
 	msg := strings.ToLower(diagnostic)
 	if strings.Contains(msg, "quota exceeded") ||
@@ -336,8 +339,7 @@ func quotaDiagnosticReason(diagnostic string) (string, bool) {
 		strings.Contains(msg, "rate limited") ||
 		limitStatus(msg, "rate limit") ||
 		strings.Contains(msg, "too many requests") ||
-		strings.Contains(msg, "http 429") ||
-		strings.Contains(msg, "status 429") {
+		providerStatus429RE.MatchString(msg) {
 		return "rate limit", true
 	}
 	return "", false

--- a/internal/agent/fallback.go
+++ b/internal/agent/fallback.go
@@ -34,7 +34,9 @@ type providerQuotaError struct {
 	reason string
 }
 
-func (e *providerQuotaError) Error() string { return e.err.Error() }
+func (e *providerQuotaError) Error() string {
+	return fmt.Sprintf("provider quota unavailable: %s", e.reason)
+}
 func (e *providerQuotaError) Unwrap() error { return e.err }
 
 func (e *quotaFallbackError) Error() string {

--- a/internal/agent/fallback.go
+++ b/internal/agent/fallback.go
@@ -12,6 +12,13 @@ type fallbackAgent struct {
 	agents []Agent
 }
 
+const (
+	maxQuotaFallbackAttempts           = 8
+	maxQuotaFallbackAgentNameRunes     = 64
+	quotaFallbackTruncationMarker      = "..."
+	quotaFallbackAttemptsOmittedMarker = "additional attempts omitted"
+)
+
 type quotaFallbackAttempt struct {
 	agent  string
 	reason string
@@ -19,6 +26,7 @@ type quotaFallbackAttempt struct {
 
 type quotaFallbackError struct {
 	attempts []quotaFallbackAttempt
+	omitted  bool
 }
 
 type providerQuotaError struct {
@@ -30,11 +38,25 @@ func (e *providerQuotaError) Error() string { return e.err.Error() }
 func (e *providerQuotaError) Unwrap() error { return e.err }
 
 func (e *quotaFallbackError) Error() string {
-	parts := make([]string, 0, len(e.attempts))
+	parts := make([]string, 0, len(e.attempts)+1)
 	for _, attempt := range e.attempts {
 		parts = append(parts, fmt.Sprintf("%s (%s)", attempt.agent, attempt.reason))
 	}
+	if e.omitted {
+		parts = append(parts, quotaFallbackAttemptsOmittedMarker)
+	}
 	return fmt.Sprintf("configured agent fallback exhausted: %s", strings.Join(parts, "; "))
+}
+
+func appendQuotaFallbackAttempt(attempts []quotaFallbackAttempt, omitted bool, agent, reason string) ([]quotaFallbackAttempt, bool) {
+	if len(attempts) >= maxQuotaFallbackAttempts {
+		return attempts, true
+	}
+	name := []rune(agent)
+	if len(name) > maxQuotaFallbackAgentNameRunes {
+		agent = string(name[:maxQuotaFallbackAgentNameRunes]) + quotaFallbackTruncationMarker
+	}
+	return append(attempts, quotaFallbackAttempt{agent: agent, reason: reason}), omitted
 }
 
 // IsQuotaFallbackError reports whether an ordered fallback stopped after an
@@ -131,7 +153,8 @@ func (a *fallbackAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) 
 		scheduled[index] = true
 	}
 	attempted := make(map[int]bool, len(candidateIndexes))
-	path := make([]quotaFallbackAttempt, 0, len(a.agents))
+	path := make([]quotaFallbackAttempt, 0, min(len(a.agents), maxQuotaFallbackAttempts))
+	pathOmitted := false
 	quotaSeen := false
 	freshProvider := false
 	var lastErr error
@@ -176,7 +199,7 @@ func (a *fallbackAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) 
 		reason, isQuota := quotaErrorReason(err)
 		if isQuota {
 			quotaSeen = true
-			path = append(path, quotaFallbackAttempt{agent: current.Name(), reason: reason})
+			path, pathOmitted = appendQuotaFallbackAttempt(path, pathOmitted, current.Name(), reason)
 			freshProvider = true
 			// A quota signal from a resumed provider unlocks only the remaining
 			// configured order. This is still synchronous and only happens after
@@ -188,12 +211,12 @@ func (a *fallbackAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) 
 				}
 			}
 		} else {
-			path = append(path, quotaFallbackAttempt{agent: current.Name(), reason: fallbackFailureReason(err)})
+			path, pathOmitted = appendQuotaFallbackAttempt(path, pathOmitted, current.Name(), fallbackFailureReason(err))
 		}
 
 		if quotaSeen {
 			if position == len(candidateIndexes)-1 || (!isAgentUnavailableError(err) && !isQuota) {
-				return nil, &quotaFallbackError{attempts: path}
+				return nil, &quotaFallbackError{attempts: path, omitted: pathOmitted}
 			}
 		} else if position == len(candidateIndexes)-1 || !isAgentUnavailableError(err) {
 			return nil, err
@@ -202,7 +225,7 @@ func (a *fallbackAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) 
 		nextPosition := position + 1
 		if nextPosition >= len(candidateIndexes) {
 			if quotaSeen {
-				return nil, &quotaFallbackError{attempts: path}
+				return nil, &quotaFallbackError{attempts: path, omitted: pathOmitted}
 			}
 			return nil, err
 		}
@@ -216,7 +239,7 @@ func (a *fallbackAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) 
 		}
 	}
 	if quotaSeen {
-		return nil, &quotaFallbackError{attempts: path}
+		return nil, &quotaFallbackError{attempts: path, omitted: pathOmitted}
 	}
 	return nil, lastErr
 }

--- a/internal/agent/fallback.go
+++ b/internal/agent/fallback.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -11,8 +12,37 @@ type fallbackAgent struct {
 	agents []Agent
 }
 
+type quotaFallbackAttempt struct {
+	agent  string
+	reason string
+}
+
+type quotaFallbackError struct {
+	attempts []quotaFallbackAttempt
+}
+
+const fallbackEvidenceLimit = 8 * 1024
+
+func (e *quotaFallbackError) Error() string {
+	parts := make([]string, 0, len(e.attempts))
+	for _, attempt := range e.attempts {
+		parts = append(parts, fmt.Sprintf("%s (%s)", attempt.agent, attempt.reason))
+	}
+	return fmt.Sprintf("configured agent fallback exhausted: %s", strings.Join(parts, "; "))
+}
+
+// IsQuotaFallbackError reports whether an ordered fallback stopped after an
+// explicit quota, session-limit, or rate-limit signal. The error deliberately
+// contains only configured agent names and bounded classifications.
+func IsQuotaFallbackError(err error) bool {
+	var quotaErr *quotaFallbackError
+	return errors.As(err, &quotaErr)
+}
+
 // NewFallback returns an Agent that tries each agent in order when an
-// invocation fails because the current agent process is unavailable.
+// invocation fails because the current agent process is unavailable or returns
+// explicit quota, session-limit, or rate-limit evidence. Quota replacement is
+// synchronous and starts the next provider with no provider-native session.
 func NewFallback(agents []Agent) Agent {
 	switch len(agents) {
 	case 0:
@@ -71,25 +101,75 @@ func (a *fallbackAgent) NeutralizesGateInstructions() bool {
 }
 
 func (a *fallbackAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
-	candidates := a.agents
+	// A resumed session is owned by exactly one provider. Try that provider
+	// first, preserving the existing resume-failure contract. A quota signal is
+	// the only result that opens the ordered list after that provider; the next
+	// provider always starts a fresh session.
+	candidateIndexes := make([]int, 0, len(a.agents))
 	if opts.Session != nil && opts.Session.ID != "" && opts.Session.Agent != "" {
-		candidates = nil
-		for _, current := range a.agents {
+		providerIndex := -1
+		for i, current := range a.agents {
 			if SupportsSessionProvider(current, opts.Session.Agent) {
-				candidates = append(candidates, current)
+				providerIndex = i
 				break
 			}
 		}
-		if len(candidates) == 0 {
+		if providerIndex < 0 {
 			return nil, fmt.Errorf("session provider %q is not configured", opts.Session.Agent)
 		}
+		candidateIndexes = append(candidateIndexes, providerIndex)
+	} else {
+		for i := range a.agents {
+			candidateIndexes = append(candidateIndexes, i)
+		}
 	}
+
+	scheduled := make(map[int]bool, len(candidateIndexes))
+	for _, index := range candidateIndexes {
+		scheduled[index] = true
+	}
+	attempted := make(map[int]bool, len(candidateIndexes))
+	path := make([]quotaFallbackAttempt, 0, len(a.agents))
+	quotaSeen := false
+	freshProvider := false
 	var lastErr error
-	for i, current := range candidates {
+	for position := 0; position < len(candidateIndexes); position++ {
+		index := candidateIndexes[position]
+		if attempted[index] {
+			continue
+		}
+		attempted[index] = true
+		current := a.agents[index]
 		currentOpts := opts
+		if freshProvider {
+			// Never hand a provider-native session id to a different configured
+			// agent. An empty ref asks a capable replacement to start cold; an
+			// incapable replacement below clears it entirely.
+			if opts.Session != nil {
+				currentOpts.Session = &SessionRef{}
+			}
+			currentOpts.SessionFallback = false
+			currentOpts.SessionFallbackReason = ""
+		}
 		if currentOpts.Session != nil && currentOpts.Session.ID == "" && !SupportsSessionResume(current) {
 			currentOpts.Session = nil
 			currentOpts.SessionFallback = false
+		}
+		var streamed strings.Builder
+		previousChunk := currentOpts.OnChunk
+		currentOpts.OnChunk = func(text string) {
+			if previousChunk != nil {
+				previousChunk(text)
+			}
+			if text == "" {
+				return
+			}
+			streamed.WriteString(text)
+			if streamed.Len() > fallbackEvidenceLimit {
+				text := streamed.String()
+				streamed.Reset()
+				streamed.WriteString(text[len(text)-fallbackEvidenceLimit:])
+			}
 		}
 		startedAt := time.Now()
 		result, err := current.Run(ctx, currentOpts)
@@ -103,13 +183,54 @@ func (a *fallbackAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) 
 			return result, nil
 		}
 		lastErr = err
-		if i == len(candidates)-1 || !isAgentUnavailableError(err) {
+		if ctx.Err() != nil {
 			return nil, err
 		}
-		next := candidates[i+1]
-		if opts.OnChunk != nil {
-			opts.OnChunk(fmt.Sprintf("\nagent %s failed (%s); falling back to %s\n", current.Name(), fallbackReason(err), next.Name()))
+
+		reason, isQuota := quotaErrorReason(err, streamed.String())
+		if isQuota {
+			quotaSeen = true
+			path = append(path, quotaFallbackAttempt{agent: current.Name(), reason: reason})
+			freshProvider = true
+			// A quota signal from a resumed provider unlocks only the remaining
+			// configured order. This is still synchronous and only happens after
+			// the current adapter returned.
+			for next := index + 1; next < len(a.agents); next++ {
+				if !scheduled[next] {
+					candidateIndexes = append(candidateIndexes, next)
+					scheduled[next] = true
+				}
+			}
+		} else {
+			path = append(path, quotaFallbackAttempt{agent: current.Name(), reason: fallbackFailureReason(err)})
 		}
+
+		if quotaSeen {
+			if position == len(candidateIndexes)-1 || (!isAgentUnavailableError(err) && !isQuota) {
+				return nil, &quotaFallbackError{attempts: path}
+			}
+		} else if position == len(candidateIndexes)-1 || !isAgentUnavailableError(err) {
+			return nil, err
+		}
+
+		nextPosition := position + 1
+		if nextPosition >= len(candidateIndexes) {
+			if quotaSeen {
+				return nil, &quotaFallbackError{attempts: path}
+			}
+			return nil, err
+		}
+		next := a.agents[candidateIndexes[nextPosition]]
+		if opts.OnChunk != nil {
+			if isQuota {
+				opts.OnChunk(fmt.Sprintf("\nagent %s exhausted (%s); falling back to %s\n", current.Name(), reason, next.Name()))
+			} else {
+				opts.OnChunk(fmt.Sprintf("\nagent %s failed (%s); falling back to %s\n", current.Name(), fallbackReason(err), next.Name()))
+			}
+		}
+	}
+	if quotaSeen {
+		return nil, &quotaFallbackError{attempts: path}
 	}
 	return nil, lastErr
 }
@@ -125,6 +246,48 @@ func (a *fallbackAgent) Close() error {
 		return fmt.Errorf("close fallback agents: %s", strings.Join(errs, "; "))
 	}
 	return nil
+}
+
+func quotaErrorReason(err error, evidence ...string) (string, bool) {
+	if err == nil {
+		return "", false
+	}
+	message := err.Error()
+	if len(evidence) > 0 {
+		message += "\n" + evidence[0]
+	}
+	msg := strings.ToLower(message)
+	if strings.Contains(msg, "session limit") ||
+		strings.Contains(msg, "session_limit") ||
+		strings.Contains(msg, "usage limit") ||
+		strings.Contains(msg, "weekly limit") ||
+		strings.Contains(msg, "monthly limit") ||
+		strings.Contains(msg, "daily limit") ||
+		strings.Contains(msg, "quota exceeded") ||
+		strings.Contains(msg, "quota exhausted") ||
+		strings.Contains(msg, "quota limit") {
+		return "session/quota limit", true
+	}
+	if strings.Contains(msg, "rate limit") ||
+		strings.Contains(msg, "rate_limit") ||
+		strings.Contains(msg, "rate-limited") ||
+		strings.Contains(msg, "rate limited") ||
+		strings.Contains(msg, "too many requests") ||
+		strings.Contains(msg, "http 429") ||
+		strings.Contains(msg, "status 429") {
+		return "rate limit", true
+	}
+	return "", false
+}
+
+func fallbackFailureReason(err error) string {
+	if _, ok := quotaErrorReason(err); ok {
+		return "quota limit"
+	}
+	if isAgentUnavailableError(err) {
+		return "agent unavailable"
+	}
+	return "invocation failed"
 }
 
 func isAgentUnavailableError(err error) bool {

--- a/internal/agent/fallback.go
+++ b/internal/agent/fallback.go
@@ -21,7 +21,13 @@ type quotaFallbackError struct {
 	attempts []quotaFallbackAttempt
 }
 
-const fallbackEvidenceLimit = 8 * 1024
+type providerQuotaError struct {
+	err    error
+	reason string
+}
+
+func (e *providerQuotaError) Error() string { return e.err.Error() }
+func (e *providerQuotaError) Unwrap() error { return e.err }
 
 func (e *quotaFallbackError) Error() string {
 	parts := make([]string, 0, len(e.attempts))
@@ -44,16 +50,12 @@ func IsQuotaFallbackError(err error) bool {
 // explicit quota, session-limit, or rate-limit evidence. Quota replacement is
 // synchronous and starts the next provider with no provider-native session.
 func NewFallback(agents []Agent) Agent {
-	switch len(agents) {
-	case 0:
+	if len(agents) == 0 {
 		return nil
-	case 1:
-		return agents[0]
-	default:
-		copied := make([]Agent, len(agents))
-		copy(copied, agents)
-		return &fallbackAgent{agents: copied}
 	}
+	copied := make([]Agent, len(agents))
+	copy(copied, agents)
+	return &fallbackAgent{agents: copied}
 }
 
 func (a *fallbackAgent) Name() string {
@@ -155,22 +157,6 @@ func (a *fallbackAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) 
 			currentOpts.Session = nil
 			currentOpts.SessionFallback = false
 		}
-		var streamed strings.Builder
-		previousChunk := currentOpts.OnChunk
-		currentOpts.OnChunk = func(text string) {
-			if previousChunk != nil {
-				previousChunk(text)
-			}
-			if text == "" {
-				return
-			}
-			streamed.WriteString(text)
-			if streamed.Len() > fallbackEvidenceLimit {
-				text := streamed.String()
-				streamed.Reset()
-				streamed.WriteString(text[len(text)-fallbackEvidenceLimit:])
-			}
-		}
 		startedAt := time.Now()
 		result, err := current.Run(ctx, currentOpts)
 		if !ReportsAgentAttempts(current) {
@@ -187,7 +173,7 @@ func (a *fallbackAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) 
 			return nil, err
 		}
 
-		reason, isQuota := quotaErrorReason(err, streamed.String())
+		reason, isQuota := quotaErrorReason(err)
 		if isQuota {
 			quotaSeen = true
 			path = append(path, quotaFallbackAttempt{agent: current.Name(), reason: reason})
@@ -236,6 +222,9 @@ func (a *fallbackAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) 
 }
 
 func (a *fallbackAgent) Close() error {
+	if len(a.agents) == 1 {
+		return a.agents[0].Close()
+	}
 	var errs []string
 	for _, ag := range a.agents {
 		if err := ag.Close(); err != nil {
@@ -248,15 +237,30 @@ func (a *fallbackAgent) Close() error {
 	return nil
 }
 
-func quotaErrorReason(err error, evidence ...string) (string, bool) {
+// ClassifyProviderError marks an invocation error using only provider or
+// process diagnostics captured separately from assistant output.
+func ClassifyProviderError(err error, diagnostics ...string) error {
 	if err == nil {
+		return nil
+	}
+	for _, diagnostic := range diagnostics {
+		if reason, ok := quotaDiagnosticReason(diagnostic); ok {
+			return &providerQuotaError{err: err, reason: reason}
+		}
+	}
+	return err
+}
+
+func quotaErrorReason(err error) (string, bool) {
+	var quotaErr *providerQuotaError
+	if !errors.As(err, &quotaErr) {
 		return "", false
 	}
-	message := err.Error()
-	if len(evidence) > 0 {
-		message += "\n" + evidence[0]
-	}
-	msg := strings.ToLower(message)
+	return quotaErr.reason, true
+}
+
+func quotaDiagnosticReason(diagnostic string) (string, bool) {
+	msg := strings.ToLower(diagnostic)
 	if strings.Contains(msg, "session limit") ||
 		strings.Contains(msg, "session_limit") ||
 		strings.Contains(msg, "usage limit") ||
@@ -281,9 +285,6 @@ func quotaErrorReason(err error, evidence ...string) (string, bool) {
 }
 
 func fallbackFailureReason(err error) string {
-	if _, ok := quotaErrorReason(err); ok {
-		return "quota limit"
-	}
 	if isAgentUnavailableError(err) {
 		return "agent unavailable"
 	}

--- a/internal/agent/fallback.go
+++ b/internal/agent/fallback.go
@@ -296,6 +296,15 @@ func ClassifyProviderError(err error, diagnostics ...string) error {
 	return err
 }
 
+func completedProviderQuotaError(provider, diagnostic string) error {
+	base := fmt.Errorf("%s provider error", provider)
+	classified := ClassifyProviderError(base, diagnostic)
+	if _, ok := quotaErrorReason(classified); ok {
+		return classified
+	}
+	return nil
+}
+
 func quotaErrorReason(err error) (string, bool) {
 	var quotaErr *providerQuotaError
 	if !errors.As(err, &quotaErr) {

--- a/internal/agent/fallback_test.go
+++ b/internal/agent/fallback_test.go
@@ -122,7 +122,7 @@ func TestFallbackAgent_ForwardsSessionCapability(t *testing.T) {
 }
 
 func TestClassifyProviderErrorSanitizesLifecycleDiagnostics(t *testing.T) {
-	const secretDiagnostic = "weekly limit; token=raw-provider-secret"
+	const secretDiagnostic = "weekly limit reached; token=raw-provider-secret"
 	classified := ClassifyProviderError(errors.New("provider failed: "+secretDiagnostic), secretDiagnostic)
 
 	var event LifecycleEvent
@@ -169,7 +169,7 @@ func TestFallbackAgentFallsBackOnExplicitQuotaExit(t *testing.T) {
 }
 
 func TestFallbackAgentIgnoresAssistantQuotaLanguage(t *testing.T) {
-	invocationErr := errors.New("claude exited: exit status 1")
+	invocationErr := errors.New("provider returned invalid response")
 	first := &fallbackTestAgent{
 		name: "claude",
 		runWithOpts: func(opts RunOpts) (*Result, error) {
@@ -195,8 +195,8 @@ func TestFallbackAgentReportsAllQuotaExhaustionWithoutSecrets(t *testing.T) {
 	first := &fallbackTestAgent{
 		name: "claude",
 		run: func() (*Result, error) {
-			err := errors.New("claude exited: exit status 1: weekly limit; token=secret-one")
-			return nil, ClassifyProviderError(err, "weekly limit; token=secret-one")
+			err := errors.New("claude exited: exit status 1: weekly limit reached; token=secret-one")
+			return nil, ClassifyProviderError(err, "weekly limit reached; token=secret-one")
 		},
 	}
 	second := &fallbackTestAgent{
@@ -231,8 +231,8 @@ func TestFallbackAgentQuotaExhaustionBoundsAttemptsAndAgentNames(t *testing.T) {
 		agents = append(agents, &fallbackTestAgent{
 			name: strings.Repeat(string(rune('a'+i)), maxQuotaFallbackAgentNameRunes+20),
 			run: func() (*Result, error) {
-				err := errors.New("provider rate limit; token=secret")
-				return nil, ClassifyProviderError(err, "provider rate limit; token=secret")
+				err := errors.New("provider rate limit exceeded; token=secret")
+				return nil, ClassifyProviderError(err, "provider rate limit exceeded; token=secret")
 			},
 		})
 	}
@@ -269,8 +269,8 @@ func TestFallbackAgentSingletonSanitizesQuotaExhaustion(t *testing.T) {
 	only := &fallbackTestAgent{
 		name: "claude",
 		run: func() (*Result, error) {
-			err := errors.New("claude exited: weekly limit; token=secret")
-			return nil, ClassifyProviderError(err, "weekly limit; token=secret")
+			err := errors.New("claude exited: weekly limit reached; token=secret")
+			return nil, ClassifyProviderError(err, "weekly limit reached; token=secret")
 		},
 	}
 
@@ -280,6 +280,50 @@ func TestFallbackAgentSingletonSanitizesQuotaExhaustion(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "secret") || !strings.Contains(err.Error(), "claude (session/quota limit)") {
 		t.Fatalf("error = %q, want bounded classification without diagnostic", err)
+	}
+}
+
+func TestFallbackAgentPreservesGenericErrorAfterQuotaTransition(t *testing.T) {
+	quota := &fallbackTestAgent{
+		name: "claude",
+		run: func() (*Result, error) {
+			return nil, ClassifyProviderError(errors.New("quota detail"), "rate_limit_error")
+		},
+	}
+	terminal := errors.New("structured output validation failed")
+	generic := &fallbackTestAgent{
+		name: "pi",
+		run:  func() (*Result, error) { return nil, terminal },
+	}
+
+	_, err := NewFallback([]Agent{quota, generic}).Run(context.Background(), RunOpts{})
+	if !errors.Is(err, terminal) {
+		t.Fatalf("Run() error = %v, want terminal generic error", err)
+	}
+	var exhausted *quotaFallbackError
+	if errors.As(err, &exhausted) {
+		t.Fatalf("Run() error = %v, must not replace generic error with exhaustion summary", err)
+	}
+	if !HadQuotaFallback(err) {
+		t.Fatalf("Run() error = %v, want quota-transition signal", err)
+	}
+}
+
+func TestClassifyProviderErrorRequiresExhaustionEvidence(t *testing.T) {
+	generic := errors.New("provider failed")
+	for _, diagnostic := range []string{
+		"unknown option rate_limit",
+		"configuration field: rate limit",
+		"quota limit setting is invalid",
+	} {
+		if got := ClassifyProviderError(generic, diagnostic); got != generic {
+			t.Fatalf("diagnostic %q classified as quota exhaustion: %v", diagnostic, got)
+		}
+	}
+	for _, diagnostic := range []string{"rate_limit_error", "session_limit_error", "quota_exceeded", "rate limit exceeded", "HTTP 429 Too Many Requests"} {
+		if got := ClassifyProviderError(generic, diagnostic); got == generic {
+			t.Fatalf("diagnostic %q was not classified", diagnostic)
+		}
 	}
 }
 
@@ -315,8 +359,8 @@ func TestFallbackAgentNeverSwitchesWhileInvocationIsActive(t *testing.T) {
 		runWithOpts: func(RunOpts) (*Result, error) {
 			close(started)
 			<-release
-			err := errors.New("claude exited: exit status 1: rate limit")
-			return nil, ClassifyProviderError(err, "rate limit")
+			err := errors.New("claude exited: exit status 1: rate limit exceeded")
+			return nil, ClassifyProviderError(err, "rate limit exceeded")
 		},
 	}
 	second := &fallbackTestAgent{

--- a/internal/agent/fallback_test.go
+++ b/internal/agent/fallback_test.go
@@ -5,19 +5,24 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 )
 
 type fallbackTestAgent struct {
-	name      string
-	run       func() (*Result, error)
-	calls     int
-	resumable bool
+	name        string
+	run         func() (*Result, error)
+	runWithOpts func(RunOpts) (*Result, error)
+	calls       int
+	resumable   bool
 }
 
 func (a *fallbackTestAgent) Name() string { return a.name }
 
-func (a *fallbackTestAgent) Run(context.Context, RunOpts) (*Result, error) {
+func (a *fallbackTestAgent) Run(_ context.Context, opts RunOpts) (*Result, error) {
 	a.calls++
+	if a.runWithOpts != nil {
+		return a.runWithOpts(opts)
+	}
 	return a.run()
 }
 
@@ -113,6 +118,155 @@ func TestFallbackAgent_ForwardsSessionCapability(t *testing.T) {
 	second := &fallbackTestAgent{name: "claude", resumable: true, run: func() (*Result, error) { return &Result{}, nil }}
 	if !SupportsSessionResume(NewFallback([]Agent{WithSteering(first), WithSteering(second)})) {
 		t.Fatal("fallback's primary resumable agent must retain session support")
+	}
+}
+
+func TestFallbackAgentFallsBackOnExplicitQuotaExit(t *testing.T) {
+	first := &fallbackTestAgent{
+		name: "claude",
+		run: func() (*Result, error) {
+			return nil, errors.New("claude exited: exit status 1: You've hit your session limit")
+		},
+	}
+	second := &fallbackTestAgent{
+		name: "pi",
+		run: func() (*Result, error) {
+			return &Result{Text: "recovered"}, nil
+		},
+	}
+
+	result, err := NewFallback([]Agent{first, second}).Run(context.Background(), RunOpts{})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result == nil || result.Text != "recovered" || result.Provider != "pi" {
+		t.Fatalf("Run() result = %+v, want pi recovery", result)
+	}
+	if first.calls != 1 || second.calls != 1 {
+		t.Fatalf("calls = first %d second %d, want 1/1", first.calls, second.calls)
+	}
+}
+
+func TestFallbackAgentUsesExplicitStreamedQuotaEvidenceAfterExit(t *testing.T) {
+	first := &fallbackTestAgent{
+		name: "claude",
+		runWithOpts: func(opts RunOpts) (*Result, error) {
+			opts.OnChunk("You've hit your weekly limit · resets later")
+			return nil, errors.New("claude exited: exit status 1: ")
+		},
+	}
+	second := &fallbackTestAgent{
+		name: "pi",
+		run:  func() (*Result, error) { return &Result{Text: "recovered"}, nil },
+	}
+
+	result, err := NewFallback([]Agent{first, second}).Run(context.Background(), RunOpts{OnChunk: func(string) {}})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result == nil || result.Text != "recovered" {
+		t.Fatalf("Run() result = %+v, want recovery", result)
+	}
+}
+
+func TestFallbackAgentReportsAllQuotaExhaustionWithoutSecrets(t *testing.T) {
+	first := &fallbackTestAgent{
+		name: "claude",
+		run: func() (*Result, error) {
+			return nil, errors.New("claude exited: exit status 1: weekly limit; token=secret-one")
+		},
+	}
+	second := &fallbackTestAgent{
+		name: "pi",
+		run: func() (*Result, error) {
+			return nil, errors.New("pi exited: exit status 1: rate_limit_error; token=secret-two")
+		},
+	}
+
+	_, err := NewFallback([]Agent{first, second}).Run(context.Background(), RunOpts{})
+	if !IsQuotaFallbackError(err) {
+		t.Fatalf("error = %v, want quota fallback error", err)
+	}
+	message := err.Error()
+	for _, want := range []string{"claude", "pi", "session/quota limit", "rate limit"} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("error %q does not contain %q", message, want)
+		}
+	}
+	for _, secret := range []string{"secret-one", "secret-two"} {
+		if strings.Contains(message, secret) {
+			t.Fatalf("error leaked secret %q: %s", secret, message)
+		}
+	}
+}
+
+func TestFallbackAgentDoesNotFallbackForGenericFailureOrSilence(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "generic", err: errors.New("provider failed")},
+		{name: "silent exit without quota evidence", err: errors.New("claude returned no result event")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			first := &fallbackTestAgent{name: "claude", run: func() (*Result, error) { return nil, tt.err }}
+			second := &fallbackTestAgent{name: "pi", run: func() (*Result, error) { return &Result{Text: "must not run"}, nil }}
+			_, err := NewFallback([]Agent{first, second}).Run(context.Background(), RunOpts{})
+			if !errors.Is(err, tt.err) {
+				t.Fatalf("error = %v, want %v", err, tt.err)
+			}
+			if first.calls != 1 || second.calls != 0 {
+				t.Fatalf("calls = first %d second %d, want 1/0", first.calls, second.calls)
+			}
+		})
+	}
+}
+
+func TestFallbackAgentNeverSwitchesWhileInvocationIsActive(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	secondStarted := make(chan struct{})
+	first := &fallbackTestAgent{
+		name: "claude",
+		runWithOpts: func(RunOpts) (*Result, error) {
+			close(started)
+			<-release
+			return nil, errors.New("claude exited: exit status 1: rate limit")
+		},
+	}
+	second := &fallbackTestAgent{
+		name: "pi",
+		runWithOpts: func(RunOpts) (*Result, error) {
+			close(secondStarted)
+			return &Result{Text: "ok"}, nil
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := NewFallback([]Agent{first, second}).Run(context.Background(), RunOpts{})
+		done <- err
+	}()
+	<-started
+	select {
+	case <-secondStarted:
+		t.Fatal("fallback agent started before the active invocation ended")
+	case <-time.After(25 * time.Millisecond):
+	}
+	close(release)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("fallback did not complete")
+	}
+	select {
+	case <-secondStarted:
+	default:
+		t.Fatal("fallback agent never started after the first invocation ended")
 	}
 }
 

--- a/internal/agent/fallback_test.go
+++ b/internal/agent/fallback_test.go
@@ -204,6 +204,47 @@ func TestFallbackAgentReportsAllQuotaExhaustionWithoutSecrets(t *testing.T) {
 	}
 }
 
+func TestFallbackAgentQuotaExhaustionBoundsAttemptsAndAgentNames(t *testing.T) {
+	const agentCount = maxQuotaFallbackAttempts + 4
+	agents := make([]Agent, 0, agentCount)
+	for i := 0; i < agentCount; i++ {
+		agents = append(agents, &fallbackTestAgent{
+			name: strings.Repeat(string(rune('a'+i)), maxQuotaFallbackAgentNameRunes+20),
+			run: func() (*Result, error) {
+				err := errors.New("provider rate limit; token=secret")
+				return nil, ClassifyProviderError(err, "provider rate limit; token=secret")
+			},
+		})
+	}
+
+	_, err := NewFallback(agents).Run(context.Background(), RunOpts{})
+	var quotaErr *quotaFallbackError
+	if !errors.As(err, &quotaErr) {
+		t.Fatalf("error = %v, want quota fallback error", err)
+	}
+	if got := len(quotaErr.attempts); got != maxQuotaFallbackAttempts {
+		t.Fatalf("recorded attempts = %d, want %d", got, maxQuotaFallbackAttempts)
+	}
+	if !quotaErr.omitted {
+		t.Fatal("quota fallback error did not record omitted attempts")
+	}
+	for _, attempt := range quotaErr.attempts {
+		if got := len([]rune(attempt.agent)); got > maxQuotaFallbackAgentNameRunes+len([]rune(quotaFallbackTruncationMarker)) {
+			t.Fatalf("recorded agent name length = %d, want bounded name", got)
+		}
+	}
+	message := err.Error()
+	if !strings.Contains(message, quotaFallbackAttemptsOmittedMarker) {
+		t.Fatalf("error = %q, want omitted-attempt marker", message)
+	}
+	if strings.Contains(message, "secret") {
+		t.Fatalf("error leaked provider diagnostic: %q", message)
+	}
+	if len(message) > 1024 {
+		t.Fatalf("error length = %d, want fixed bound", len(message))
+	}
+}
+
 func TestFallbackAgentSingletonSanitizesQuotaExhaustion(t *testing.T) {
 	only := &fallbackTestAgent{
 		name: "claude",

--- a/internal/agent/fallback_test.go
+++ b/internal/agent/fallback_test.go
@@ -320,9 +320,25 @@ func TestClassifyProviderErrorRequiresExhaustionEvidence(t *testing.T) {
 			t.Fatalf("diagnostic %q classified as quota exhaustion: %v", diagnostic, got)
 		}
 	}
-	for _, diagnostic := range []string{"rate_limit_error", "session_limit_error", "quota_exceeded", "rate limit exceeded", "HTTP 429 Too Many Requests"} {
+	for _, diagnostic := range []string{
+		"rate_limit_error",
+		"session_limit_error",
+		"quota_exceeded",
+		"rate limit exceeded",
+		"HTTP 429 Too Many Requests",
+		"request failed with 429: provider unavailable",
+	} {
 		if got := ClassifyProviderError(generic, diagnostic); got == generic {
 			t.Fatalf("diagnostic %q was not classified", diagnostic)
+		}
+	}
+	for _, diagnostic := range []string{
+		"request failed with 1429",
+		"processed 429 tokens",
+		"provider error 429",
+	} {
+		if got := ClassifyProviderError(generic, diagnostic); got != generic {
+			t.Fatalf("diagnostic %q classified without a bounded status signal: %v", diagnostic, got)
 		}
 	}
 }

--- a/internal/agent/fallback_test.go
+++ b/internal/agent/fallback_test.go
@@ -121,6 +121,26 @@ func TestFallbackAgent_ForwardsSessionCapability(t *testing.T) {
 	}
 }
 
+func TestClassifyProviderErrorSanitizesLifecycleDiagnostics(t *testing.T) {
+	const secretDiagnostic = "weekly limit; token=raw-provider-secret"
+	classified := ClassifyProviderError(errors.New("provider failed: "+secretDiagnostic), secretDiagnostic)
+
+	var event LifecycleEvent
+	emitAgentExited(RunOpts{OnLifecycle: func(got LifecycleEvent) { event = got }}, "claude", 42, classified)
+	if strings.Contains(classified.Error(), secretDiagnostic) || strings.Contains(event.Message, secretDiagnostic) {
+		t.Fatalf("classified quota diagnostic leaked: error=%q event=%q", classified, event.Message)
+	}
+	if !strings.Contains(classified.Error(), "session/quota limit") {
+		t.Fatalf("classified error = %q, want bounded quota reason", classified)
+	}
+
+	generic := errors.New("provider failed: diagnostic retained")
+	emitAgentExited(RunOpts{OnLifecycle: func(got LifecycleEvent) { event = got }}, "claude", 42, ClassifyProviderError(generic, "diagnostic retained"))
+	if !strings.Contains(event.Message, generic.Error()) {
+		t.Fatalf("generic lifecycle event = %q, want original diagnostic", event.Message)
+	}
+}
+
 func TestFallbackAgentFallsBackOnExplicitQuotaExit(t *testing.T) {
 	first := &fallbackTestAgent{
 		name: "claude",

--- a/internal/agent/fallback_test.go
+++ b/internal/agent/fallback_test.go
@@ -90,7 +90,7 @@ func TestFallbackAgentDoesNotFallBackOnFindingsResult(t *testing.T) {
 }
 
 func TestFallbackAgentDoesNotFallBackOnStructuredOutputError(t *testing.T) {
-	parseErr := errors.New(`codex output parse: invalid JSON (output snippet: "not json")`)
+	parseErr := errors.New(`codex output parse: invalid JSON (output snippet: "rate limit")`)
 	first := &fallbackTestAgent{
 		name: "codex",
 		run: func() (*Result, error) {
@@ -125,7 +125,8 @@ func TestFallbackAgentFallsBackOnExplicitQuotaExit(t *testing.T) {
 	first := &fallbackTestAgent{
 		name: "claude",
 		run: func() (*Result, error) {
-			return nil, errors.New("claude exited: exit status 1: You've hit your session limit")
+			err := errors.New("claude exited: exit status 1: You've hit your session limit")
+			return nil, ClassifyProviderError(err, "You've hit your session limit")
 		},
 	}
 	second := &fallbackTestAgent{
@@ -147,25 +148,26 @@ func TestFallbackAgentFallsBackOnExplicitQuotaExit(t *testing.T) {
 	}
 }
 
-func TestFallbackAgentUsesExplicitStreamedQuotaEvidenceAfterExit(t *testing.T) {
+func TestFallbackAgentIgnoresAssistantQuotaLanguage(t *testing.T) {
+	invocationErr := errors.New("claude exited: exit status 1")
 	first := &fallbackTestAgent{
 		name: "claude",
 		runWithOpts: func(opts RunOpts) (*Result, error) {
-			opts.OnChunk("You've hit your weekly limit · resets later")
-			return nil, errors.New("claude exited: exit status 1: ")
+			opts.OnChunk("The review mentions a rate limit")
+			return nil, invocationErr
 		},
 	}
 	second := &fallbackTestAgent{
 		name: "pi",
-		run:  func() (*Result, error) { return &Result{Text: "recovered"}, nil },
+		run:  func() (*Result, error) { return &Result{Text: "must not run"}, nil },
 	}
 
-	result, err := NewFallback([]Agent{first, second}).Run(context.Background(), RunOpts{OnChunk: func(string) {}})
-	if err != nil {
-		t.Fatalf("Run() error = %v", err)
+	_, err := NewFallback([]Agent{first, second}).Run(context.Background(), RunOpts{OnChunk: func(string) {}})
+	if !errors.Is(err, invocationErr) {
+		t.Fatalf("Run() error = %v, want original invocation error", err)
 	}
-	if result == nil || result.Text != "recovered" {
-		t.Fatalf("Run() result = %+v, want recovery", result)
+	if second.calls != 0 {
+		t.Fatalf("fallback calls = %d, want 0", second.calls)
 	}
 }
 
@@ -173,13 +175,15 @@ func TestFallbackAgentReportsAllQuotaExhaustionWithoutSecrets(t *testing.T) {
 	first := &fallbackTestAgent{
 		name: "claude",
 		run: func() (*Result, error) {
-			return nil, errors.New("claude exited: exit status 1: weekly limit; token=secret-one")
+			err := errors.New("claude exited: exit status 1: weekly limit; token=secret-one")
+			return nil, ClassifyProviderError(err, "weekly limit; token=secret-one")
 		},
 	}
 	second := &fallbackTestAgent{
 		name: "pi",
 		run: func() (*Result, error) {
-			return nil, errors.New("pi exited: exit status 1: rate_limit_error; token=secret-two")
+			err := errors.New("pi exited: exit status 1: rate_limit_error; token=secret-two")
+			return nil, ClassifyProviderError(err, "rate_limit_error; token=secret-two")
 		},
 	}
 
@@ -197,6 +201,24 @@ func TestFallbackAgentReportsAllQuotaExhaustionWithoutSecrets(t *testing.T) {
 		if strings.Contains(message, secret) {
 			t.Fatalf("error leaked secret %q: %s", secret, message)
 		}
+	}
+}
+
+func TestFallbackAgentSingletonSanitizesQuotaExhaustion(t *testing.T) {
+	only := &fallbackTestAgent{
+		name: "claude",
+		run: func() (*Result, error) {
+			err := errors.New("claude exited: weekly limit; token=secret")
+			return nil, ClassifyProviderError(err, "weekly limit; token=secret")
+		},
+	}
+
+	_, err := NewFallback([]Agent{only}).Run(context.Background(), RunOpts{})
+	if !IsQuotaFallbackError(err) {
+		t.Fatalf("error = %v, want quota fallback error", err)
+	}
+	if strings.Contains(err.Error(), "secret") || !strings.Contains(err.Error(), "claude (session/quota limit)") {
+		t.Fatalf("error = %q, want bounded classification without diagnostic", err)
 	}
 }
 
@@ -232,7 +254,8 @@ func TestFallbackAgentNeverSwitchesWhileInvocationIsActive(t *testing.T) {
 		runWithOpts: func(RunOpts) (*Result, error) {
 			close(started)
 			<-release
-			return nil, errors.New("claude exited: exit status 1: rate limit")
+			err := errors.New("claude exited: exit status 1: rate limit")
+			return nil, ClassifyProviderError(err, "rate limit")
 		},
 	}
 	second := &fallbackTestAgent{

--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -43,13 +43,13 @@ func (a *opencodeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, err
 	// Start server on first invocation (synchronized)
 	baseURL, err := a.ensureServer(ctx, opts.CWD)
 	if err != nil {
-		return nil, err
+		return nil, ClassifyProviderError(err, err.Error())
 	}
 
 	// Create session with blanket permissions
 	sessionID, err := a.createSession(ctx, baseURL, opts.CWD)
 	if err != nil {
-		return nil, err
+		return nil, ClassifyProviderError(err, err.Error())
 	}
 	defer a.deleteSession(baseURL, sessionID)
 
@@ -65,7 +65,7 @@ func (a *opencodeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, err
 
 	eventBody, err := a.connectEventStream(streamCtx, baseURL)
 	if err != nil {
-		return nil, err
+		return nil, ClassifyProviderError(err, err.Error())
 	}
 	defer eventBody.Close()
 
@@ -97,18 +97,21 @@ func (a *opencodeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, err
 		select {
 		case mr := <-msgCh:
 			if mr.err != nil {
-				return nil, fmt.Errorf("opencode message: %w", mr.err)
+				err := fmt.Errorf("opencode message: %w", mr.err)
+				return nil, ClassifyProviderError(err, mr.err.Error())
 			}
 		default:
 		}
 		a.abortSession(baseURL, sessionID)
-		return nil, fmt.Errorf("opencode events: %w", err)
+		streamErr := fmt.Errorf("opencode events: %w", err)
+		return nil, ClassifyProviderError(streamErr, err.Error())
 	}
 
 	// Wait for message response
 	mr := <-msgCh
 	if mr.err != nil {
-		return nil, fmt.Errorf("opencode message: %w", mr.err)
+		err := fmt.Errorf("opencode message: %w", mr.err)
+		return nil, ClassifyProviderError(err, mr.err.Error())
 	}
 
 	// Update usage and text from message response

--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -113,6 +113,14 @@ func (a *opencodeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, err
 		err := fmt.Errorf("opencode message: %w", mr.err)
 		return nil, ClassifyProviderError(err, mr.err.Error())
 	}
+	if mr.resp != nil && mr.resp.Info != nil && mr.resp.Info.Error != nil &&
+		!mr.resp.Info.Error.IsStructuredOutput() && mr.resp.Info.Error.Message != "" {
+		responseErr := fmt.Errorf("opencode response %s: %s", mr.resp.Info.Error.Name, mr.resp.Info.Error.Message)
+		classified := ClassifyProviderError(responseErr, mr.resp.Info.Error.Message)
+		if _, isQuota := quotaErrorReason(classified); isQuota {
+			return nil, classified
+		}
+	}
 
 	// Update usage and text from message response
 	responseText := ""

--- a/internal/agent/opencode_test.go
+++ b/internal/agent/opencode_test.go
@@ -453,6 +453,34 @@ func TestOpencodeAgent_FinalAnswerPreferred(t *testing.T) {
 	}
 }
 
+func TestOpencodeAgent_HTTP429ResponseIsClassified(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/session" && r.Method == http.MethodPost:
+			fmt.Fprint(w, `{"id":"s1"}`)
+		case r.URL.Path == "/global/event" && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "text/event-stream")
+			fmt.Fprint(w, "data: {\"payload\":{\"type\":\"session.idle\"}}\n\n")
+		case r.URL.Path == "/session/s1/message" && r.Method == http.MethodPost:
+			http.Error(w, "provider unavailable", http.StatusTooManyRequests)
+		case r.URL.Path == "/session/s1" && r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	a := &opencodeAgent{bin: "opencode", server: &managedServer{port: mustParsePort(server.URL)}}
+	result, err := a.Run(context.Background(), RunOpts{Prompt: "review", CWD: t.TempDir()})
+	if err == nil {
+		t.Fatalf("expected quota error, got result %+v", result)
+	}
+	if reason, ok := quotaErrorReason(err); !ok || reason != "rate limit" {
+		t.Fatalf("quotaErrorReason(%v) = %q, %v, want rate limit, true", err, reason, ok)
+	}
+}
+
 func TestOpencodeAgent_QuotaErrorInSuccessfulResponseIsClassified(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {

--- a/internal/agent/opencode_test.go
+++ b/internal/agent/opencode_test.go
@@ -453,6 +453,37 @@ func TestOpencodeAgent_FinalAnswerPreferred(t *testing.T) {
 	}
 }
 
+func TestOpencodeAgent_QuotaErrorInSuccessfulResponseIsClassified(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/session" && r.Method == http.MethodPost:
+			fmt.Fprint(w, `{"id":"s1"}`)
+		case r.URL.Path == "/global/event" && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "text/event-stream")
+			fmt.Fprint(w, "data: {\"payload\":{\"type\":\"session.idle\"}}\n\n")
+		case r.URL.Path == "/session/s1/message" && r.Method == http.MethodPost:
+			fmt.Fprint(w, `{"info":{"id":"msg1","role":"assistant","error":{"name":"APIError","message":"Provider rate limit exceeded; token=secret"}},"parts":[{"type":"text","text":"rate limit in assistant output"}]}`)
+		case r.URL.Path == "/session/s1" && r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	a := &opencodeAgent{bin: "opencode", server: &managedServer{port: mustParsePort(server.URL)}}
+	result, err := a.Run(context.Background(), RunOpts{Prompt: "review", CWD: t.TempDir()})
+	if err == nil {
+		t.Fatalf("expected quota error, got result %+v", result)
+	}
+	if result != nil {
+		t.Fatalf("result = %+v, want nil", result)
+	}
+	if reason, ok := quotaErrorReason(err); !ok || reason != "rate limit" {
+		t.Fatalf("quotaErrorReason(%v) = %q, %v, want rate limit, true", err, reason, ok)
+	}
+}
+
 // TestOpencodeAgent_StructuredOutputError asserts that when opencode returns
 // an info.error with name=StructuredOutputError, the agent surfaces a
 // precise error and does NOT fall through to text-parsing the streamed

--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -96,7 +96,7 @@ func (a *piAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 	if waitErr != nil {
 		stderr := strings.TrimSpace(string(stderrBuf))
 		if stderr != "" {
-			retErr := fmt.Errorf("pi exited: %w: %s", waitErr, stderr)
+			retErr := ClassifyProviderError(fmt.Errorf("pi exited: %w: %s", waitErr, stderr), stderr)
 			emitAgentExited(opts, "pi", pid, retErr)
 			return nil, retErr
 		}
@@ -106,7 +106,7 @@ func (a *piAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 	}
 
 	if pp.assistantError != "" {
-		retErr := fmt.Errorf("pi reported error: %s", pp.assistantError)
+		retErr := ClassifyProviderError(fmt.Errorf("pi reported error: %s", pp.assistantError), pp.assistantError)
 		emitAgentExited(opts, "pi", pid, retErr)
 		return nil, retErr
 	}

--- a/internal/agent/rovodev.go
+++ b/internal/agent/rovodev.go
@@ -48,13 +48,13 @@ func (a *rovodevAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, erro
 	// Start server on first invocation (synchronized)
 	baseURL, err := a.ensureServer(ctx, opts.CWD)
 	if err != nil {
-		return nil, err
+		return nil, ClassifyProviderError(err, err.Error())
 	}
 
 	// Create session
 	sessionID, err := a.createSession(ctx, baseURL)
 	if err != nil {
-		return nil, err
+		return nil, ClassifyProviderError(err, err.Error())
 	}
 	defer a.deleteSession(baseURL, sessionID)
 
@@ -62,13 +62,13 @@ func (a *rovodevAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, erro
 	if len(opts.JSONSchema) > 0 {
 		prompt := buildRovodevSystemPrompt(opts.JSONSchema)
 		if err := a.setSystemPrompt(ctx, baseURL, sessionID, prompt); err != nil {
-			return nil, err
+			return nil, ClassifyProviderError(err, err.Error())
 		}
 	}
 
 	// Send chat message
 	if err := a.setChatMessage(ctx, baseURL, sessionID, opts.Prompt); err != nil {
-		return nil, err
+		return nil, ClassifyProviderError(err, err.Error())
 	}
 
 	// Stream chat response
@@ -77,7 +77,7 @@ func (a *rovodevAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, erro
 	if err != nil {
 		// Best-effort cancel on error
 		a.cancelSession(baseURL, sessionID)
-		return nil, err
+		return nil, ClassifyProviderError(err, err.Error())
 	}
 
 	return finalizeTextResult("rovodev", text, opts.JSONSchema, usage)

--- a/internal/agent/rovodev_test.go
+++ b/internal/agent/rovodev_test.go
@@ -516,6 +516,33 @@ func TestRovodevAgent_FullFlow(t *testing.T) {
 	}
 }
 
+func TestRovodevAgent_HTTP429ResponseIsClassified(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v3/sessions/create":
+			fmt.Fprint(w, `{"session_id":"s1"}`)
+		case r.URL.Path == "/v3/set_chat_message":
+			w.WriteHeader(http.StatusOK)
+		case r.URL.Path == "/v3/stream_chat":
+			http.Error(w, "provider unavailable", http.StatusTooManyRequests)
+		case r.URL.Path == "/v3/sessions/s1", r.URL.Path == "/v3/cancel":
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	a := &rovodevAgent{bin: "acli", server: &managedServer{port: mustParsePort(server.URL)}}
+	result, err := a.Run(context.Background(), RunOpts{Prompt: "review", CWD: t.TempDir()})
+	if err == nil {
+		t.Fatalf("expected quota error, got result %+v", result)
+	}
+	if reason, ok := quotaErrorReason(err); !ok || reason != "rate limit" {
+		t.Fatalf("quotaErrorReason(%v) = %q, %v, want rate limit, true", err, reason, ok)
+	}
+}
+
 // TestRovodevAgent_NoSchema tests that system prompt is skipped when no schema.
 func TestRovodevAgent_NoSchema(t *testing.T) {
 	calledPaths := make(map[string]bool)

--- a/internal/pipeline/executor_quota_fallback_test.go
+++ b/internal/pipeline/executor_quota_fallback_test.go
@@ -31,7 +31,8 @@ func (a *quotaFixAgent) Run(_ context.Context, _ agent.RunOpts) (*agent.Result, 
 		}
 		quotaTestGit(a.workDir, "add", "prior-fix.txt")
 		quotaTestGit(a.workDir, "commit", "-m", "prior pipeline fix")
-		return nil, errors.New("claude exited: exit status 1: session limit")
+		err := errors.New("claude exited: exit status 1: session limit")
+		return nil, agent.ClassifyProviderError(err, "session limit")
 	}
 	return &agent.Result{Text: "validated"}, nil
 }
@@ -146,7 +147,7 @@ func (a *quotaOnceAgent) Run(context.Context, agent.RunOpts) (*agent.Result, err
 
 func TestExecutor_QuotaFallbackAppliesToOtherAgentDrivenSteps(t *testing.T) {
 	database, p, run, repo := setupTest(t)
-	first := &quotaOnceAgent{name: "claude", err: errors.New("claude exited: exit status 1: rate_limit_error")}
+	first := &quotaOnceAgent{name: "claude", err: agent.ClassifyProviderError(errors.New("claude exited: exit status 1: rate_limit_error"), "rate_limit_error")}
 	second := &quotaFixAgent{name: "pi"}
 	step := &adaptiveCallStep{
 		name: types.StepTest,

--- a/internal/pipeline/executor_quota_fallback_test.go
+++ b/internal/pipeline/executor_quota_fallback_test.go
@@ -31,8 +31,8 @@ func (a *quotaFixAgent) Run(_ context.Context, _ agent.RunOpts) (*agent.Result, 
 		}
 		quotaTestGit(a.workDir, "add", "prior-fix.txt")
 		quotaTestGit(a.workDir, "commit", "-m", "prior pipeline fix")
-		err := errors.New("claude exited: exit status 1: session limit")
-		return nil, agent.ClassifyProviderError(err, "session limit")
+		err := errors.New("claude exited: exit status 1: session limit reached")
+		return nil, agent.ClassifyProviderError(err, "session limit reached")
 	}
 	return &agent.Result{Text: "validated"}, nil
 }

--- a/internal/pipeline/executor_quota_fallback_test.go
+++ b/internal/pipeline/executor_quota_fallback_test.go
@@ -1,0 +1,175 @@
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/agent"
+	"github.com/kunchenguid/no-mistakes/internal/config"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+type quotaFixAgent struct {
+	name    string
+	workDir string
+	calls   int
+}
+
+func (a *quotaFixAgent) Name() string { return a.name }
+func (a *quotaFixAgent) Close() error { return nil }
+
+func (a *quotaFixAgent) Run(_ context.Context, _ agent.RunOpts) (*agent.Result, error) {
+	a.calls++
+	if a.name == "claude" && a.calls == 2 {
+		if err := os.WriteFile(filepath.Join(a.workDir, "prior-fix.txt"), []byte("preserve this fix\n"), 0o644); err != nil {
+			return nil, err
+		}
+		quotaTestGit(a.workDir, "add", "prior-fix.txt")
+		quotaTestGit(a.workDir, "commit", "-m", "prior pipeline fix")
+		return nil, errors.New("claude exited: exit status 1: session limit")
+	}
+	return &agent.Result{Text: "validated"}, nil
+}
+
+func quotaTestGit(dir string, args ...string) string {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@example.com",
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		panic("git " + strings.Join(args, " ") + ": " + string(output) + ": " + err.Error())
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func initQuotaTestRepo(t *testing.T, dir string) {
+	t.Helper()
+	quotaTestGit(dir, "init", "-b", "main")
+	quotaTestGit(dir, "config", "user.name", "test")
+	quotaTestGit(dir, "config", "user.email", "test@example.com")
+	if err := os.WriteFile(filepath.Join(dir, "base.txt"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	quotaTestGit(dir, "add", "base.txt")
+	quotaTestGit(dir, "commit", "-m", "base")
+}
+
+func TestExecutor_QuotaFallbackPreservesActiveFixRoundAndPriorCommit(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	workDir := t.TempDir()
+	initQuotaTestRepo(t, workDir)
+
+	claude := &quotaFixAgent{name: "claude", workDir: workDir}
+	pi := &quotaFixAgent{name: "pi", workDir: workDir}
+	fallback := agent.NewFallback([]agent.Agent{claude, pi})
+	findings := `{"findings":[{"id":"keep-me","severity":"error","description":"fix it","action":"ask-user"}],"summary":"one finding"}`
+	step := &adaptiveCallStep{
+		name: types.StepReview,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			if _, err := sctx.RunAgentSession(SessionRoleReviewer, agent.RunOpts{Prompt: "review"}); err != nil {
+				return nil, err
+			}
+			if !sctx.Fixing {
+				return &StepOutcome{NeedsApproval: true, Findings: findings}, nil
+			}
+			return &StepOutcome{Findings: `{"findings":[],"summary":"fixed"}`}, nil
+		},
+	}
+	cfg := &config.Config{Agent: types.AgentClaude, SessionReuse: false}
+	exec := NewExecutor(database, p, cfg, fallback, []Step{step}, nil)
+
+	done := make(chan error, 1)
+	go func() { done <- exec.Execute(context.Background(), run, repo, workDir) }()
+	waitForStepStatus(t, database, run.ID, types.StepReview, types.StepStatusAwaitingApproval)
+	if err := exec.Respond(types.StepReview, types.ActionFix, []string{"keep-me"}); err != nil {
+		t.Fatalf("respond with fix: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	gotRun, err := database.GetRun(run.ID)
+	if err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if gotRun.ID != run.ID || gotRun.Status != types.RunCompleted {
+		t.Fatalf("run = %+v, want same completed run", gotRun)
+	}
+	steps, err := database.GetStepsByRun(run.ID)
+	if err != nil {
+		t.Fatalf("get steps: %v", err)
+	}
+	if len(steps) != 1 || steps[0].StepName != types.StepReview || steps[0].Status != types.StepStatusCompleted {
+		t.Fatalf("steps = %+v, want one completed review step", steps)
+	}
+	rounds, err := database.GetRoundsByStep(steps[0].ID)
+	if err != nil {
+		t.Fatalf("get rounds: %v", err)
+	}
+	if len(rounds) != 2 || rounds[0].FindingsJSON == nil || !strings.Contains(*rounds[0].FindingsJSON, "keep-me") {
+		t.Fatalf("rounds = %+v, want original finding and one fix round", rounds)
+	}
+	if claude.calls != 2 || pi.calls != 1 {
+		t.Fatalf("agent calls = claude %d pi %d, want quota during fix then one fallback", claude.calls, pi.calls)
+	}
+	if message := quotaTestGit(workDir, "log", "-1", "--pretty=%s"); message != "prior pipeline fix" {
+		t.Fatalf("prior fix commit = %q, want it preserved", message)
+	}
+}
+
+type quotaOnceAgent struct {
+	name  string
+	err   error
+	calls int
+}
+
+func (a *quotaOnceAgent) Name() string { return a.name }
+func (a *quotaOnceAgent) Close() error { return nil }
+
+func (a *quotaOnceAgent) Run(context.Context, agent.RunOpts) (*agent.Result, error) {
+	a.calls++
+	if a.calls == 1 {
+		return nil, a.err
+	}
+	return &agent.Result{Text: "validated"}, nil
+}
+
+func TestExecutor_QuotaFallbackAppliesToOtherAgentDrivenSteps(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	first := &quotaOnceAgent{name: "claude", err: errors.New("claude exited: exit status 1: rate_limit_error")}
+	second := &quotaFixAgent{name: "pi"}
+	step := &adaptiveCallStep{
+		name: types.StepTest,
+		fn: func(sctx *StepContext) (*StepOutcome, error) {
+			if _, err := sctx.Agent.Run(sctx.Ctx, agent.RunOpts{Prompt: "collect targeted evidence"}); err != nil {
+				return nil, err
+			}
+			return &StepOutcome{}, nil
+		},
+	}
+
+	exec := NewExecutor(database, p, &config.Config{Agent: types.AgentClaude}, agent.NewFallback([]agent.Agent{first, second}), []Step{step}, nil)
+	if err := exec.Execute(context.Background(), run, repo, t.TempDir()); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if first.calls != 1 || second.calls != 1 {
+		t.Fatalf("agent calls = claude %d pi %d, want 1/1", first.calls, second.calls)
+	}
+	steps, err := database.GetStepsByRun(run.ID)
+	if err != nil {
+		t.Fatalf("get steps: %v", err)
+	}
+	if len(steps) != 1 || steps[0].StepName != types.StepTest || steps[0].Status != types.StepStatusCompleted {
+		t.Fatalf("steps = %+v, want one completed test step", steps)
+	}
+}

--- a/internal/pipeline/sessions.go
+++ b/internal/pipeline/sessions.go
@@ -91,7 +91,11 @@ func (rs *RunSessions) Run(ctx context.Context, a agent.Agent, role SessionRole,
 		rs.remember(role, result.SessionID, provider)
 		return result, nil
 	}
-	if storedID == "" || ctx.Err() != nil || agent.IsQuotaFallbackError(err) {
+	if ctx.Err() != nil || storedID == "" {
+		return nil, err
+	}
+	if agent.HadQuotaFallback(err) {
+		rs.forget(role)
 		return nil, err
 	}
 

--- a/internal/pipeline/sessions.go
+++ b/internal/pipeline/sessions.go
@@ -81,10 +81,17 @@ func (rs *RunSessions) Run(ctx context.Context, a agent.Agent, role SessionRole,
 	opts.Session = &stored
 	result, err := a.Run(ctx, opts)
 	if err == nil {
-		rs.remember(role, result.SessionID, sessionProvider(a, result))
+		provider := sessionProvider(a, result)
+		// An ordered quota fallback may have moved this role to a different
+		// provider. The old provider-native identity is no longer safe to
+		// resume, even when the replacement did not mint a durable session.
+		if storedID != "" && stored.Agent != "" && provider != "" && provider != stored.Agent {
+			rs.forget(role)
+		}
+		rs.remember(role, result.SessionID, provider)
 		return result, nil
 	}
-	if storedID == "" || ctx.Err() != nil {
+	if storedID == "" || ctx.Err() != nil || agent.IsQuotaFallbackError(err) {
 		return nil, err
 	}
 

--- a/internal/pipeline/sessions_test.go
+++ b/internal/pipeline/sessions_test.go
@@ -368,6 +368,56 @@ func TestRunSessions_FallbackResumesWithItsActualProvider(t *testing.T) {
 
 // TestRunSessions_AgentChangeDiscardsStoredSession proves a stored identity
 // from a different adapter is never fed to the current one.
+func TestRunSessions_QuotaFallbackResetsSessionAtAgentBoundary(t *testing.T) {
+	d, run := sessionTestDB(t)
+	claude := newFakeSessionAgent()
+	claude.name = "claude"
+	pi := newFakeSessionAgent()
+	pi.name = "pi"
+	fallback := agent.NewFallback([]agent.Agent{claude, pi})
+
+	rs := NewRunSessions(d, run.ID, fallback, true)
+	if _, err := rs.Run(context.Background(), fallback, SessionRoleReviewer, agent.RunOpts{Prompt: "initial review"}, nil); err != nil {
+		t.Fatalf("initial review: %v", err)
+	}
+	claude.failResumes["sess-1"] = errors.New("claude exited: exit status 1: session limit")
+
+	result, err := rs.Run(context.Background(), fallback, SessionRoleReviewer, agent.RunOpts{Prompt: "quota review"}, nil)
+	if err != nil {
+		t.Fatalf("quota review: %v", err)
+	}
+	if result.Provider != "pi" || result.SessionID == "" {
+		t.Fatalf("fallback result = %+v, want pi session", result)
+	}
+	if len(claude.calls) != 2 || len(pi.calls) != 1 {
+		t.Fatalf("calls = claude %d pi %d, want 2/1", len(claude.calls), len(pi.calls))
+	}
+	if claude.calls[1].session == nil || claude.calls[1].session.ID != "sess-1" {
+		t.Fatalf("quota must be observed while resuming claude, got %+v", claude.calls[1].session)
+	}
+	if pi.calls[0].session == nil || pi.calls[0].session.ID != "" {
+		t.Fatalf("fallback identity must start a fresh pi session, got %+v", pi.calls[0].session)
+	}
+
+	if _, err := rs.Run(context.Background(), fallback, SessionRoleReviewer, agent.RunOpts{Prompt: "rereview"}, nil); err != nil {
+		t.Fatalf("rereview: %v", err)
+	}
+	if len(claude.calls) != 2 {
+		t.Fatalf("claude was retried after quota identity switch: %d calls", len(claude.calls))
+	}
+	last := pi.calls[len(pi.calls)-1]
+	if last.session == nil || last.session.ID == "" {
+		t.Fatalf("rereview must resume pi's replacement session, got %+v", last.session)
+	}
+	stored, err := d.GetRunAgentSessions(run.ID)
+	if err != nil {
+		t.Fatalf("stored sessions: %v", err)
+	}
+	if len(stored) != 1 || stored[0].Agent != "pi" {
+		t.Fatalf("stored session after fallback = %+v, want pi only", stored)
+	}
+}
+
 func TestRunSessions_AgentChangeDiscardsStoredSession(t *testing.T) {
 	d, run := sessionTestDB(t)
 	if err := d.UpsertRunAgentSession(run.ID, string(SessionRoleReviewer), "codex", "codex-thread"); err != nil {

--- a/internal/pipeline/sessions_test.go
+++ b/internal/pipeline/sessions_test.go
@@ -380,7 +380,7 @@ func TestRunSessions_QuotaFallbackResetsSessionAtAgentBoundary(t *testing.T) {
 	if _, err := rs.Run(context.Background(), fallback, SessionRoleReviewer, agent.RunOpts{Prompt: "initial review"}, nil); err != nil {
 		t.Fatalf("initial review: %v", err)
 	}
-	claude.failResumes["sess-1"] = errors.New("claude exited: exit status 1: session limit")
+	claude.failResumes["sess-1"] = agent.ClassifyProviderError(errors.New("claude exited: exit status 1: session limit reached"), "session limit reached")
 
 	result, err := rs.Run(context.Background(), fallback, SessionRoleReviewer, agent.RunOpts{Prompt: "quota review"}, nil)
 	if err != nil {
@@ -415,6 +415,60 @@ func TestRunSessions_QuotaFallbackResetsSessionAtAgentBoundary(t *testing.T) {
 	}
 	if len(stored) != 1 || stored[0].Agent != "pi" {
 		t.Fatalf("stored session after fallback = %+v, want pi only", stored)
+	}
+}
+
+func TestRunSessions_QuotaTerminalFailureForgetsExhaustedSession(t *testing.T) {
+	tests := []struct {
+		name      string
+		secondErr error
+		wantQuota bool
+	}{
+		{
+			name:      "all providers exhausted",
+			secondErr: agent.ClassifyProviderError(errors.New("pi quota detail"), "rate_limit_error"),
+			wantQuota: true,
+		},
+		{
+			name:      "replacement generic failure",
+			secondErr: errors.New("structured output validation failed"),
+			wantQuota: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, run := sessionTestDB(t)
+			claude := newFakeSessionAgent()
+			claude.name = "claude"
+			pi := newFakeSessionAgent()
+			pi.name = "pi"
+			fallback := agent.NewFallback([]agent.Agent{claude, pi})
+			rs := NewRunSessions(d, run.ID, fallback, true)
+
+			if _, err := rs.Run(context.Background(), fallback, SessionRoleReviewer, agent.RunOpts{}, nil); err != nil {
+				t.Fatalf("initial: %v", err)
+			}
+			claude.failResumes["sess-1"] = agent.ClassifyProviderError(errors.New("claude quota detail"), "session limit reached")
+			pi.failNext = tt.secondErr
+
+			_, err := rs.Run(context.Background(), fallback, SessionRoleReviewer, agent.RunOpts{}, nil)
+			if err == nil {
+				t.Fatal("quota fallback terminal failure returned nil")
+			}
+			if got := agent.IsQuotaFallbackError(err); got != tt.wantQuota {
+				t.Fatalf("IsQuotaFallbackError() = %v, want %v: %v", got, tt.wantQuota, err)
+			}
+			if !agent.HadQuotaFallback(err) {
+				t.Fatalf("HadQuotaFallback() = false: %v", err)
+			}
+			stored, dbErr := d.GetRunAgentSessions(run.ID)
+			if dbErr != nil {
+				t.Fatalf("stored sessions: %v", dbErr)
+			}
+			if len(stored) != 0 {
+				t.Fatalf("stored exhausted session = %+v, want none", stored)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What Changed

- Detect explicit quota, session-limit, and rate-limit diagnostics across agent adapters and advance to the next configured fallback.
- Start replacement providers cold while preserving run state and retry budgets, clearing incompatible provider session identities.
- Bound and sanitize fallback exhaustion errors and document the ordered quota fallback lifecycle.

## Risk Assessment

✅ Low: The quota fallback behavior is well-bounded, preserves session ownership and existing failure contracts, sanitizes diagnostics, and includes focused coverage across adapters and pipeline integration.

## Testing

Verified provider quota classification across adapters, ordered synchronous fallback, bounded/redacted exhaustion behavior, session handoff, and preservation of the active run, fix round, and prior commit; all targeted checks passed, and a user-visible fallback transcript was captured.

<details>
<summary>Evidence: User-visible ordered quota fallback transcript</summary>

```text
=== RUN   TestQuotaFallbackUserTranscript

agent claude exhausted (session/quota limit); falling back to pi
final provider=pi result="review completed by replacement"
--- PASS: TestQuotaFallbackUserTranscript (0.00s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/agent	0.460s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Initial targeted `go test` commands could not start because `go` was absent from PATH; retried using the available Nix Go 1.26.4 binary.</code>
- `go test ./internal/agent -run '<quota classification and fallback selectors>' -count=1 -v`
- `go test ./internal/pipeline -run 'Test(Executor_QuotaFallback...|RunSessions_Quota...)$' -count=1 -v`
- <code>Temporary focused `TestQuotaFallbackUserTranscript` manual evidence check, removed after execution</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 2)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
