### PR TITLE
fix(daemon): preserve intent provenance across reruns

### DIFF
--- a/.no-mistakes/evidence/fm/nm-rerun-intent-inheritance-r1/rerun-help.txt
+++ b/.no-mistakes/evidence/fm/nm-rerun-intent-inheritance-r1/rerun-help.txt
@@ -1,0 +1,8 @@
+Rerun the pipeline for the current branch. By default, an explicit intent from the selected prior run is inherited; otherwise intent is inferred afresh. Use --intent to replace either with a new explicit intent.
+
+Usage:
+  no-mistakes rerun [flags]
+
+Flags:
+  -h, --help            help for rerun
+      --intent string   explicit intent for this rerun (overrides inherited intent or fresh inference)

--- a/.no-mistakes/evidence/fm/nm-rerun-intent-inheritance-r1/rerun-intent-cli-transcript.txt
+++ b/.no-mistakes/evidence/fm/nm-rerun-intent-inheritance-r1/rerun-intent-cli-transcript.txt
@@ -1,0 +1,18 @@
+=== RUN   TestRerunIntentProvenanceJourney
+    intent_rerun_journey_test.go:33: CLI rejected blank explicit intent: --intent must not be empty
+    intent_rerun_journey_test.go:35: CLI rerun --intent preserve the complete accepted requirements
+        including exclusions and acceptance criteria
+        without condensing them: ✓ Rerun started for feature/rerun-explicit 01KYXX1873VEB1CF0GQWNMAVB6
+    intent_rerun_journey_test.go:36: persisted run 01KYXX1873VEB1CF0GQWNMAVB6: intent_source="agent" intent="preserve the complete accepted requirements\nincluding exclusions and acceptance criteria\nwithout condensing them"
+    intent_rerun_journey_test.go:38: CLI rerun: ✓ Rerun started for feature/rerun-explicit 01KYXX19001V1S706AEGPWYXHE
+    intent_rerun_journey_test.go:39: persisted run 01KYXX19001V1S706AEGPWYXHE: intent_source="rerun" intent="preserve the complete accepted requirements\nincluding exclusions and acceptance criteria\nwithout condensing them"
+    intent_rerun_journey_test.go:44: CLI rerun --intent replace the canonical requirements explicitly: ✓ Rerun started for feature/rerun-explicit 01KYXX19S24G9H6C8K476Q30T4
+    intent_rerun_journey_test.go:45: persisted run 01KYXX19S24G9H6C8K476Q30T4: intent_source="agent" intent="replace the canonical requirements explicitly"
+    intent_rerun_journey_test.go:53: persisted run 01KYXX1APC1FB8GBHGJCZH8M2G: intent_source="claude" intent="user wanted Bar() helper added"
+    intent_rerun_journey_test.go:55: CLI rerun: ✓ Rerun started for feature/rerun-inferred 01KYXX1BFYHN2P5JGRABTS891Z
+    intent_rerun_journey_test.go:60: persisted run 01KYXX1BFYHN2P5JGRABTS891Z: intent_source="claude" intent="user wanted Bar() helper added"
+    intent_rerun_journey_test.go:65: CLI rerun --intent override inferred intent: ✓ Rerun started for feature/rerun-inferred 01KYXX1C99ETNBWDE3AF5R4832
+    intent_rerun_journey_test.go:66: persisted run 01KYXX1C99ETNBWDE3AF5R4832: intent_source="agent" intent="override inferred intent"
+--- PASS: TestRerunIntentProvenanceJourney (8.07s)
+PASS
+ok  	github.com/kunchenguid/no-mistakes/internal/e2e	8.377s

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -294,7 +294,9 @@ no-mistakes rerun --intent "the revised user goal"
 Starts a new pipeline run using the last-known head SHA on the current branch.
 If the selected prior run has explicit intent, rerun inherits it exactly by default;
 otherwise it performs fresh intent inference. `--intent` supplies a new canonical
-explicit intent in either case. If another run is active on that branch, rerun
+explicit intent in either case. Inherited intent keeps distinct rerun provenance;
+an override is recorded as newly supplied explicit intent, while fresh inference
+records the transcript source. If another run is active on that branch, rerun
 cancels it before starting over. Treat rerun as a between-runs action after a
 failed or cancelled outcome, or after you have committed a separate fix outside
 an active run; do not use it to bypass a gate.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -288,11 +288,20 @@ Rerun the pipeline for the current branch.
 
 ```sh
 no-mistakes rerun
+no-mistakes rerun --intent "the revised user goal"
 ```
 
 Starts a new pipeline run using the last-known head SHA on the current branch.
-If another run is active on that branch, rerun cancels it before starting over.
-Treat rerun as a between-runs action after a failed or cancelled outcome, or after you have committed a separate fix outside an active run; do not use it to bypass a gate.
+If the selected prior run has explicit intent, rerun inherits it exactly by default;
+otherwise it performs fresh intent inference. `--intent` supplies a new canonical
+explicit intent in either case. If another run is active on that branch, rerun
+cancels it before starting over. Treat rerun as a between-runs action after a
+failed or cancelled outcome, or after you have committed a separate fix outside
+an active run; do not use it to bypass a gate.
+
+| Flag | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `--intent` | `string` | (none) | Explicit intent overriding inherited intent or fresh inference |
 
 ## no-mistakes sync
 

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -24,11 +24,11 @@ Review flags every newly added violation and requires same-pattern tests encount
 
 ## Intent
 
-Uses agent-supplied intent when a run provides it, otherwise infers the author's intent from recent local Claude Code, Codex, OpenCode, Rovo Dev, Pi, or GitHub Copilot CLI transcripts.
+Uses explicit intent when a run provides it, including exact explicit intent inherited by a rerun, otherwise infers the author's intent from recent local Claude Code, Codex, OpenCode, Rovo Dev, Pi, or GitHub Copilot CLI transcripts.
 This is best-effort context, and when available it is included in rebase fixes, review checks and fixes, test detection, evidence validation, and fixes, documentation checks and fixes, lint detection and fixes, CI auto-fixes, and PR drafting.
 
 **Behavior:**
-- Uses run-supplied intent verbatim and skips transcript-based inference, even when `intent.enabled` is false
+- Treats newly supplied explicit intent (`agent`) and exact inherited rerun intent (`rerun`) as authoritative acceptance criteria, while preserving their distinct sources, and skips transcript-based inference even when `intent.enabled` is false
 - Runs transcript-based inference only when `intent.enabled` is true
 - Matches local agent transcripts against non-deleted changed files when present, falling back to all changed files for all-deletion diffs, may use the configured pipeline agent to disambiguate plausible matches, and summarizes the likely author intent with that agent
 - Stores the derived summary, source, session ID, and match score on the run

--- a/internal/cli/rerun.go
+++ b/internal/cli/rerun.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/daemon"
 	"github.com/kunchenguid/no-mistakes/internal/git"
@@ -11,11 +12,16 @@ import (
 )
 
 func newRerunCmd() *cobra.Command {
-	return &cobra.Command{
+	var intent string
+	cmd := &cobra.Command{
 		Use:   "rerun",
 		Short: "Rerun the pipeline for the current branch",
+		Long:  "Rerun the pipeline for the current branch. By default, an explicit intent from the selected prior run is inherited; otherwise intent is inferred afresh. Use --intent to replace either with a new explicit intent.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Flags().Changed("intent") && strings.TrimSpace(intent) == "" {
+				return fmt.Errorf("--intent must not be empty")
+			}
 			return trackCommand("rerun", func() error {
 				p, d, err := openResources()
 				if err != nil {
@@ -47,7 +53,7 @@ func newRerunCmd() *cobra.Command {
 				defer client.Close()
 
 				var result ipc.RerunResult
-				if err := client.Call(ipc.MethodRerun, &ipc.RerunParams{RepoID: repo.ID, Branch: branch}, &result); err != nil {
+				if err := client.Call(ipc.MethodRerun, &ipc.RerunParams{RepoID: repo.ID, Branch: branch, Intent: intent}, &result); err != nil {
 					return fmt.Errorf("rerun pipeline: %w", err)
 				}
 
@@ -56,4 +62,6 @@ func newRerunCmd() *cobra.Command {
 			})
 		},
 	}
+	cmd.Flags().StringVar(&intent, "intent", "", "explicit intent for this rerun (overrides inherited intent or fresh inference)")
+	return cmd
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -731,7 +731,7 @@ func registerHandlers(srv *ipc.Server, mgr *RunManager, d *db.DB, shutdown func(
 		if err := json.Unmarshal(params, &p); err != nil {
 			return nil, fmt.Errorf("invalid params: %w", err)
 		}
-		runID, err := mgr.HandleRerun(ctx, p.RepoID, p.Branch, p.SkipSteps, p.Intent)
+		runID, err := mgr.HandleRerun(ctx, p.RepoID, p.Branch, p.PreviousRunID, p.SkipSteps, p.Intent)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -544,7 +544,7 @@ func (m *RunManager) HandlePushReceived(ctx context.Context, params *ipc.PushRec
 // HandleRerun creates a new run for the latest gate head on a branch. An
 // explicit intent overrides the selected run. Otherwise an authoritative
 // intent is inherited byte-for-byte; runs without one infer intent afresh.
-func (m *RunManager) HandleRerun(ctx context.Context, repoID, branch string, skipSteps []types.StepName, intent string) (string, error) {
+func (m *RunManager) HandleRerun(ctx context.Context, repoID, branch, previousRunID string, skipSteps []types.StepName, intent string) (string, error) {
 	repo, err := m.db.GetRepo(repoID)
 	if err != nil {
 		return "", fmt.Errorf("get repo: %w", err)
@@ -581,6 +581,16 @@ func (m *RunManager) HandleRerun(ctx context.Context, repoID, branch string, ski
 	if latestForBranch == nil {
 		return "", fmt.Errorf("no previous run for branch %s", branch)
 	}
+	selectedRun := latestForBranch
+	if previousRunID != "" {
+		selectedRun, err = m.db.GetRun(previousRunID)
+		if err != nil {
+			return "", fmt.Errorf("get selected run: %w", err)
+		}
+		if selectedRun == nil || selectedRun.RepoID != repoID || selectedRun.Branch != branch {
+			return "", fmt.Errorf("selected run %s does not belong to repo %s branch %s", previousRunID, repoID, branch)
+		}
+	}
 
 	baseSHA := latestForBranch.BaseSHA
 	if matchingHead != nil {
@@ -590,12 +600,12 @@ func (m *RunManager) HandleRerun(ctx context.Context, repoID, branch string, ski
 	intentSource := db.RunIntentSourceAgent
 	if strings.TrimSpace(intent) == "" {
 		intentSource = ""
-		if latestForBranch.Intent != nil && latestForBranch.IntentSource != nil &&
-			db.IsAuthoritativeRunIntentSource(*latestForBranch.IntentSource) {
+		if selectedRun.Intent != nil && selectedRun.IntentSource != nil &&
+			db.IsAuthoritativeRunIntentSource(*selectedRun.IntentSource) {
 			// Do not normalize or regenerate this value. The selected run's
 			// persisted bytes are the canonical acceptance criteria for the
 			// replacement run.
-			intent = *latestForBranch.Intent
+			intent = *selectedRun.Intent
 			intentSource = db.RunIntentSourceRerun
 		}
 	}
@@ -665,32 +675,22 @@ func (m *RunManager) startRunWithIntentSource(ctx context.Context, repo *db.Repo
 	// Cancel any active run for this repo+branch.
 	m.cancelActiveRuns(repo.ID, branch)
 
-	// Create run record.
-	run, err := m.db.InsertRun(repo.ID, branch, headSHA, baseSHA)
-	if err != nil {
-		trackStartFailure("create_run")
-		return "", fmt.Errorf("create run: %w", err)
-	}
-
-	// Stamp an explicit or inherited intent onto the run before the pipeline
-	// starts, so the intent step skips transcript-based inference. Inherited
-	// intent is deliberately not trimmed: its persisted bytes are canonical.
 	storedIntent := intent
 	if source != db.RunIntentSourceRerun {
 		storedIntent = strings.TrimSpace(storedIntent)
 	}
+	var runIntent *db.RunIntent
 	if strings.TrimSpace(storedIntent) != "" {
 		if source == "" {
 			source = db.RunIntentSourceAgent
 		}
-		if err := m.db.UpdateRunIntent(run.ID, db.RunIntent{Summary: storedIntent, Source: source, Score: 1}); err != nil {
-			slog.Warn("failed to persist run intent", "run_id", run.ID, "error", err)
-		} else {
-			run.Intent = &storedIntent
-			run.IntentSource = &source
-			score := 1.0
-			run.IntentScore = &score
-		}
+		runIntent = &db.RunIntent{Summary: storedIntent, Source: source, Score: 1}
+	}
+
+	run, err := m.db.InsertRunWithIntent(repo.ID, branch, headSHA, baseSHA, runIntent)
+	if err != nil {
+		trackStartFailure("create_run")
+		return "", fmt.Errorf("create run: %w", err)
 	}
 
 	// Create worktree from the gate bare repo.

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -542,7 +542,8 @@ func (m *RunManager) HandlePushReceived(ctx context.Context, params *ipc.PushRec
 }
 
 // HandleRerun creates a new run for the latest gate head on a branch. An
-// optional intent is stamped onto the new run.
+// explicit intent overrides the selected run. Otherwise an authoritative
+// intent is inherited byte-for-byte; runs without one infer intent afresh.
 func (m *RunManager) HandleRerun(ctx context.Context, repoID, branch string, skipSteps []types.StepName, intent string) (string, error) {
 	repo, err := m.db.GetRepo(repoID)
 	if err != nil {
@@ -586,7 +587,20 @@ func (m *RunManager) HandleRerun(ctx context.Context, repoID, branch string, ski
 		baseSHA = matchingHead.BaseSHA
 	}
 
-	return m.startRun(ctx, repo, branch, headSHA, baseSHA, "rerun", skipSteps, intent)
+	intentSource := db.RunIntentSourceAgent
+	if strings.TrimSpace(intent) == "" {
+		intentSource = ""
+		if latestForBranch.Intent != nil && latestForBranch.IntentSource != nil &&
+			db.IsAuthoritativeRunIntentSource(*latestForBranch.IntentSource) {
+			// Do not normalize or regenerate this value. The selected run's
+			// persisted bytes are the canonical acceptance criteria for the
+			// replacement run.
+			intent = *latestForBranch.Intent
+			intentSource = db.RunIntentSourceRerun
+		}
+	}
+
+	return m.startRunWithIntentSource(ctx, repo, branch, headSHA, baseSHA, "rerun", skipSteps, intent, intentSource)
 }
 
 // fetchRunDefaultBranch fetches the trusted branch from the refreshed
@@ -607,6 +621,13 @@ func fetchRunDefaultBranch(ctx context.Context, workDir string, repo *db.Repo) e
 // A non-empty intent is stamped onto the run as agent-supplied, so the intent
 // step uses it instead of inferring from transcripts.
 func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSHA, baseSHA, trigger string, skipSteps []types.StepName, intent string) (string, error) {
+	return m.startRunWithIntentSource(ctx, repo, branch, headSHA, baseSHA, trigger, skipSteps, intent, db.RunIntentSourceAgent)
+}
+
+// startRunWithIntentSource is the common run-creation path. source is empty
+// when no intent is supplied, RunIntentSourceAgent for a new explicit
+// override, and RunIntentSourceRerun for inherited explicit intent.
+func (m *RunManager) startRunWithIntentSource(ctx context.Context, repo *db.Repo, branch, headSHA, baseSHA, trigger string, skipSteps []types.StepName, intent, source string) (string, error) {
 	branchRole := telemetryBranchRole(branch, repo.DefaultBranch)
 	trackStartFailure := func(stage string) {
 		telemetry.Track("run", telemetry.Fields{
@@ -651,16 +672,21 @@ func (m *RunManager) startRun(ctx context.Context, repo *db.Repo, branch, headSH
 		return "", fmt.Errorf("create run: %w", err)
 	}
 
-	// Stamp an agent-supplied intent onto the run before the pipeline starts,
-	// so the intent step finds it already present and skips transcript-based
-	// inference. A persist failure is non-fatal: the intent step would simply
-	// fall back to inference.
-	if trimmed := strings.TrimSpace(intent); trimmed != "" {
-		if err := m.db.UpdateRunIntent(run.ID, db.RunIntent{Summary: trimmed, Source: db.RunIntentSourceAgent, Score: 1}); err != nil {
-			slog.Warn("failed to persist agent-supplied intent", "run_id", run.ID, "error", err)
+	// Stamp an explicit or inherited intent onto the run before the pipeline
+	// starts, so the intent step skips transcript-based inference. Inherited
+	// intent is deliberately not trimmed: its persisted bytes are canonical.
+	storedIntent := intent
+	if source != db.RunIntentSourceRerun {
+		storedIntent = strings.TrimSpace(storedIntent)
+	}
+	if strings.TrimSpace(storedIntent) != "" {
+		if source == "" {
+			source = db.RunIntentSourceAgent
+		}
+		if err := m.db.UpdateRunIntent(run.ID, db.RunIntent{Summary: storedIntent, Source: source, Score: 1}); err != nil {
+			slog.Warn("failed to persist run intent", "run_id", run.ID, "error", err)
 		} else {
-			run.Intent = &trimmed
-			source := db.RunIntentSourceAgent
+			run.Intent = &storedIntent
 			run.IntentSource = &source
 			score := 1.0
 			run.IntentScore = &score

--- a/internal/daemon/manager_test.go
+++ b/internal/daemon/manager_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
@@ -359,6 +360,65 @@ func TestRerunSkipStepsConfiguresExecutor(t *testing.T) {
 		if step.StepName == types.StepReview && step.Status != types.StepStatusSkipped {
 			t.Fatalf("review status = %s, want %s", step.Status, types.StepStatusSkipped)
 		}
+	}
+}
+
+func TestRerunInheritsIntentFromSelectedRun(t *testing.T) {
+	step := &mockPassStep{name: types.StepReview}
+	p, d := startTestDaemonWithSteps(t, func() []pipeline.Step {
+		return []pipeline.Step{step}
+	})
+
+	_, headSHA := setupTestGitRepo(t, p, d, "selected-rerun-repo")
+	client, err := ipc.Dial(p.Socket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	var first ipc.PushReceivedResult
+	err = client.Call(ipc.MethodPushReceived, &ipc.PushReceivedParams{
+		Gate: p.RepoDir("selected-rerun-repo"),
+		Ref:  "refs/heads/main",
+		Old:  "0000000000000000000000000000000000000000",
+		New:  headSHA,
+	}, &first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	waitForRunTerminalState(t, d, first.RunID)
+	selectedIntent := "  selected exact requirements\n"
+	if err := d.UpdateRunIntent(first.RunID, db.RunIntent{Summary: selectedIntent, Source: db.RunIntentSourceAgent, Score: 1}); err != nil {
+		t.Fatal(err)
+	}
+
+	newer, err := d.InsertRunWithIntent("selected-rerun-repo", "main", headSHA, headSHA, &db.RunIntent{
+		Summary: "newer unrelated requirements",
+		Source:  db.RunIntentSourceAgent,
+		Score:   1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := d.UpdateRunStatus(newer.ID, types.RunFailed); err != nil {
+		t.Fatal(err)
+	}
+
+	var rerun ipc.RerunResult
+	err = client.Call(ipc.MethodRerun, &ipc.RerunParams{
+		RepoID:        "selected-rerun-repo",
+		Branch:        "main",
+		PreviousRunID: first.RunID,
+	}, &rerun)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := waitForRunTerminalState(t, d, rerun.RunID)
+	if got.Intent == nil || *got.Intent != selectedIntent {
+		t.Fatalf("intent = %v, want %q", got.Intent, selectedIntent)
+	}
+	if got.IntentSource == nil || *got.IntentSource != db.RunIntentSourceRerun {
+		t.Fatalf("intent source = %v, want %q", got.IntentSource, db.RunIntentSourceRerun)
 	}
 }
 

--- a/internal/db/run.go
+++ b/internal/db/run.go
@@ -76,6 +76,10 @@ func scanRun(row interface {
 
 // InsertRun creates a new run record.
 func (d *DB) InsertRun(repoID, branch, headSHA, baseSHA string) (*Run, error) {
+	return d.InsertRunWithIntent(repoID, branch, headSHA, baseSHA, nil)
+}
+
+func (d *DB) InsertRunWithIntent(repoID, branch, headSHA, baseSHA string, intent *RunIntent) (*Run, error) {
 	ts := now()
 	r := &Run{
 		ID:               newID(),
@@ -88,9 +92,15 @@ func (d *DB) InsertRun(repoID, branch, headSHA, baseSHA string) (*Run, error) {
 		CreatedAt:        ts,
 		UpdatedAt:        ts,
 	}
+	if intent != nil {
+		r.Intent = &intent.Summary
+		r.IntentSource = &intent.Source
+		r.IntentSessionID = &intent.SessionID
+		r.IntentScore = &intent.Score
+	}
 	_, err := d.sql.Exec(
-		`INSERT INTO runs (id, repo_id, branch, head_sha, base_sha, submitted_head_sha, status, pr_state, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, 'none', ?, ?)`,
-		r.ID, r.RepoID, r.Branch, r.HeadSHA, r.BaseSHA, headSHA, r.Status, r.CreatedAt, r.UpdatedAt,
+		`INSERT INTO runs (id, repo_id, branch, head_sha, base_sha, submitted_head_sha, status, pr_state, intent, intent_source, intent_session_id, intent_score, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, 'none', ?, ?, ?, ?, ?, ?)`,
+		r.ID, r.RepoID, r.Branch, r.HeadSHA, r.BaseSHA, headSHA, r.Status, r.Intent, r.IntentSource, r.IntentSessionID, r.IntentScore, r.CreatedAt, r.UpdatedAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("insert run: %w", err)

--- a/internal/db/run.go
+++ b/internal/db/run.go
@@ -450,6 +450,18 @@ func (d *DB) UpdateRunErrorStatus(id, errMsg string, status types.RunStatus) err
 // authoritative acceptance criteria rather than a low-confidence hint.
 const RunIntentSourceAgent = "agent"
 
+// RunIntentSourceRerun marks an authoritative intent inherited from the run
+// selected for a rerun. It remains authoritative, but the distinct value keeps
+// inherited intent inspectable instead of confusing it with a new override.
+const RunIntentSourceRerun = "rerun"
+
+// IsAuthoritativeRunIntentSource reports whether a run's intent came from an
+// explicit operator/agent contract, either directly or through rerun
+// inheritance.
+func IsAuthoritativeRunIntentSource(source string) bool {
+	return source == RunIntentSourceAgent || source == RunIntentSourceRerun
+}
+
 // RunIntent carries the four intent-related columns persisted on a run.
 type RunIntent struct {
 	Summary   string

--- a/internal/db/run_test.go
+++ b/internal/db/run_test.go
@@ -33,6 +33,27 @@ func TestRunInsertAndGet(t *testing.T) {
 	}
 }
 
+func TestInsertRunWithIntent(t *testing.T) {
+	d := openTestDB(t)
+	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")
+	intent := RunIntent{Summary: "  exact requirements\n", Source: RunIntentSourceRerun, Score: 1}
+
+	run, err := d.InsertRunWithIntent(repo.ID, "feature", "abc123", "def456", &intent)
+	if err != nil {
+		t.Fatalf("insert run with intent: %v", err)
+	}
+	got, err := d.GetRun(run.ID)
+	if err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if got.Intent == nil || *got.Intent != intent.Summary {
+		t.Fatalf("intent = %v, want %q", got.Intent, intent.Summary)
+	}
+	if got.IntentSource == nil || *got.IntentSource != intent.Source {
+		t.Fatalf("intent source = %v, want %q", got.IntentSource, intent.Source)
+	}
+}
+
 func TestRunAwaitingAgentSetAndClear(t *testing.T) {
 	d := openTestDB(t)
 	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")

--- a/internal/e2e/intent_rerun_journey_test.go
+++ b/internal/e2e/intent_rerun_journey_test.go
@@ -1,0 +1,95 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/ipc"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// TestRerunIntentProvenanceJourney drives the public CLI through both rerun
+// defaults and both explicit overrides. The assertions inspect the persisted
+// intent and the intent-step log so a rerun cannot silently switch from
+// inheritance to transcript inference.
+func TestRerunIntentProvenanceJourney(t *testing.T) {
+	h := NewHarness(t, SetupOpts{Agent: "claude", Scenario: writeIntentScenario(t)})
+	if out, err := h.Run("init"); err != nil {
+		t.Fatalf("nm init: %v\n%s", err, out)
+	}
+
+	explicit := "preserve the complete accepted requirements\nincluding exclusions and acceptance criteria\nwithout condensing them"
+	explicitBranch := "feature/rerun-explicit"
+	h.CommitChange(explicitBranch, "explicit.txt", "explicit\n", "add explicit fixture")
+	explicitWT := h.AddWorktree(explicitBranch)
+	h.PushToGate(explicitBranch)
+	h.WaitForRun(explicitBranch, 90*time.Second)
+	if out, err := h.RunInDir(explicitWT, "rerun", "--intent", " "); err == nil || !strings.Contains(out, "--intent must not be empty") {
+		t.Fatalf("blank rerun intent should be rejected, err=%v output=%s", err, out)
+	}
+	originalExplicit := runCLIAndWait(t, h, explicitWT, explicitBranch, "rerun", "--intent", explicit)
+	assertCompletedRerunFixture(t, h, originalExplicit, explicit, "agent")
+
+	inherited := runCLIAndWait(t, h, explicitWT, explicitBranch, "rerun")
+	assertCompletedRerunFixture(t, h, inherited, explicit, "rerun")
+	if log := readStepLog(t, h, inherited.ID, "intent"); !strings.Contains(log, "using intent supplied by the agent") {
+		t.Errorf("inherited explicit rerun should skip inference, log:\n%s", log)
+	}
+
+	overriddenExplicit := runCLIAndWait(t, h, explicitWT, explicitBranch, "rerun", "--intent", "replace the canonical requirements explicitly")
+	assertCompletedRerunFixture(t, h, overriddenExplicit, "replace the canonical requirements explicitly", "agent")
+
+	inferredBranch := "feature/rerun-inferred"
+	seedClaudeTranscript(t, h.HomeDir, h.WorkDir, "inferred.txt")
+	h.CommitChange(inferredBranch, "inferred.txt", "inferred\n", "add inferred fixture")
+	inferredWT := h.AddWorktree(inferredBranch)
+	h.PushToGate(inferredBranch)
+	originalInferred := h.WaitForRun(inferredBranch, 90*time.Second)
+	assertCompletedRerunFixture(t, h, originalInferred, "user wanted Bar() helper added", "claude")
+
+	fresh := runCLIAndWait(t, h, inferredWT, inferredBranch, "rerun")
+	originalInferredIntent := readRunIntent(t, h.NMHome, originalInferred.ID)
+	if originalInferredIntent.summary == nil {
+		t.Fatal("inferred original has no intent")
+	}
+	assertCompletedRerunFixture(t, h, fresh, *originalInferredIntent.summary, "claude")
+	if log := readStepLog(t, h, fresh.ID, "intent"); !strings.Contains(log, "scanning recent agent transcripts") {
+		t.Errorf("non-explicit rerun should perform fresh inference, log:\n%s", log)
+	}
+
+	overriddenInferred := runCLIAndWait(t, h, inferredWT, inferredBranch, "rerun", "--intent", "override inferred intent")
+	assertCompletedRerunFixture(t, h, overriddenInferred, "override inferred intent", "agent")
+}
+
+func runCLIAndWait(t *testing.T, h *Harness, dir, branch string, args ...string) *ipc.RunInfo {
+	t.Helper()
+	out, err := h.RunInDir(dir, args...)
+	if err != nil {
+		t.Fatalf("%s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	if !strings.Contains(out, "Rerun started") {
+		t.Fatalf("%s output missing rerun confirmation:\n%s", strings.Join(args, " "), out)
+	}
+	run := h.WaitForRun(branch, 90*time.Second)
+	if run.Status != types.RunCompleted {
+		t.Fatalf("%s status=%s error=%v", strings.Join(args, " "), run.Status, run.Error)
+	}
+	return run
+}
+
+func assertCompletedRerunFixture(t *testing.T, h *Harness, run *ipc.RunInfo, wantIntent, wantSource string) {
+	t.Helper()
+	if run.Status != types.RunCompleted {
+		t.Fatalf("run %s status=%s, want completed", run.ID, run.Status)
+	}
+	intent := readRunIntent(t, h.NMHome, run.ID)
+	if intent.summary == nil || *intent.summary != wantIntent {
+		t.Fatalf("run %s intent=%v, want %q", run.ID, intent.summary, wantIntent)
+	}
+	if intent.source == nil || *intent.source != wantSource {
+		t.Fatalf("run %s intent_source=%v, want %q", run.ID, intent.source, wantSource)
+	}
+}

--- a/internal/e2e/intent_rerun_journey_test.go
+++ b/internal/e2e/intent_rerun_journey_test.go
@@ -29,6 +29,8 @@ func TestRerunIntentProvenanceJourney(t *testing.T) {
 	h.WaitForRun(explicitBranch, 90*time.Second)
 	if out, err := h.RunInDir(explicitWT, "rerun", "--intent", " "); err == nil || !strings.Contains(out, "--intent must not be empty") {
 		t.Fatalf("blank rerun intent should be rejected, err=%v output=%s", err, out)
+	} else {
+		t.Logf("CLI rejected blank explicit intent: %s", strings.TrimSpace(out))
 	}
 	originalExplicit := runCLIAndWait(t, h, explicitWT, explicitBranch, "rerun", "--intent", explicit)
 	assertCompletedRerunFixture(t, h, originalExplicit, explicit, "agent")
@@ -73,6 +75,7 @@ func runCLIAndWait(t *testing.T, h *Harness, dir, branch string, args ...string)
 	if !strings.Contains(out, "Rerun started") {
 		t.Fatalf("%s output missing rerun confirmation:\n%s", strings.Join(args, " "), out)
 	}
+	t.Logf("CLI %s: %s", strings.Join(args, " "), strings.TrimSpace(out))
 	run := h.WaitForRun(branch, 90*time.Second)
 	if run.Status != types.RunCompleted {
 		t.Fatalf("%s status=%s error=%v", strings.Join(args, " "), run.Status, run.Error)
@@ -92,4 +95,5 @@ func assertCompletedRerunFixture(t *testing.T, h *Harness, run *ipc.RunInfo, wan
 	if intent.source == nil || *intent.source != wantSource {
 		t.Fatalf("run %s intent_source=%v, want %q", run.ID, intent.source, wantSource)
 	}
+	t.Logf("persisted run %s: intent_source=%q intent=%q", run.ID, *intent.source, *intent.summary)
 }

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -106,10 +106,11 @@ type GetActiveRunParams struct {
 // the daemon inherits authoritative intent from the selected prior run or
 // leaves the new run to perform fresh inference.
 type RerunParams struct {
-	RepoID    string           `json:"repo_id"`
-	Branch    string           `json:"branch"`
-	SkipSteps []types.StepName `json:"skip_steps,omitempty"`
-	Intent    string           `json:"intent,omitempty"`
+	RepoID        string           `json:"repo_id"`
+	Branch        string           `json:"branch"`
+	PreviousRunID string           `json:"previous_run_id,omitempty"`
+	SkipSteps     []types.StepName `json:"skip_steps,omitempty"`
+	Intent        string           `json:"intent,omitempty"`
 }
 
 // SubscribeParams starts an event stream for a run.

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -102,7 +102,9 @@ type GetActiveRunParams struct {
 }
 
 // RerunParams requests a new run for the latest gate head on a branch.
-// Intent, when set, is stamped onto the new run like PushReceivedParams.Intent.
+// Intent, when set, overrides inherited intent and fresh inference. When empty,
+// the daemon inherits authoritative intent from the selected prior run or
+// leaves the new run to perform fresh inference.
 type RerunParams struct {
 	RepoID    string           `json:"repo_id"`
 	Branch    string           `json:"branch"`

--- a/internal/ipc/protocol_test.go
+++ b/internal/ipc/protocol_test.go
@@ -181,7 +181,7 @@ func TestGetActiveRunParams(t *testing.T) {
 }
 
 func TestRerunParams(t *testing.T) {
-	params := RerunParams{RepoID: "repo456", Branch: "feature", SkipSteps: []types.StepName{types.StepReview}}
+	params := RerunParams{RepoID: "repo456", Branch: "feature", PreviousRunID: "run123", SkipSteps: []types.StepName{types.StepReview}}
 	data, _ := json.Marshal(params)
 	var got RerunParams
 	if err := json.Unmarshal(data, &got); err != nil {
@@ -192,6 +192,9 @@ func TestRerunParams(t *testing.T) {
 	}
 	if got.Branch != "feature" {
 		t.Errorf("branch = %q, want %q", got.Branch, "feature")
+	}
+	if got.PreviousRunID != "run123" {
+		t.Errorf("previous_run_id = %q, want %q", got.PreviousRunID, "run123")
 	}
 	if len(got.SkipSteps) != 1 || got.SkipSteps[0] != types.StepReview {
 		t.Errorf("skip_steps = %#v, want review", got.SkipSteps)

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -38,9 +38,10 @@ type StepContext struct {
 	UserIntent string
 	// IntentSource records the provenance of UserIntent so steps can weigh
 	// its authority. db.RunIntentSourceAgent ("agent") means the driving
-	// agent supplied it explicitly via `axi run --intent` (authoritative
-	// acceptance criteria); an agent name ("claude", "codex", ...) means it
-	// was inferred from a transcript (a hint). Empty when no intent exists.
+	// agent supplied it explicitly via `axi run --intent`; db.RunIntentSourceRerun
+	// ("rerun") means that authoritative intent was inherited. Both are
+	// authoritative acceptance criteria; an agent name ("claude", "codex", ...)
+	// means it was inferred from a transcript (a hint). Empty when no intent exists.
 	IntentSource string
 	// Sessions manages the run's durable review-loop agent sessions
 	// (reviewer and fixer roles). nil runs every invocation cold.

--- a/internal/pipeline/steps/intent_prompt.go
+++ b/internal/pipeline/steps/intent_prompt.go
@@ -14,7 +14,8 @@ import (
 //
 // The framing depends on provenance (sctx.IntentSource):
 //
-//   - An EXPLICIT intent (Source=="agent", supplied via `axi run --intent`) is
+//   - An EXPLICIT intent (Source=="agent", supplied via `axi run --intent`) or
+//     an inherited explicit intent (Source=="rerun") is
 //     the driving agent's own statement of the goal, in the same trust domain
 //     as the operator running the gate. It is framed as AUTHORITATIVE
 //     acceptance criteria: the change must satisfy the required constraints and
@@ -52,14 +53,16 @@ func userIntentPromptSection(sctx *pipeline.StepContext) string {
 
 // intentSourceIsAuthoritative reports whether the user intent was supplied
 // explicitly by the driving agent (`axi run --intent`, persisted with
-// Source==db.RunIntentSourceAgent) rather than inferred from a transcript. An
+// Source==db.RunIntentSourceAgent) or inherited from an explicit prior run
+// (Source==db.RunIntentSourceRerun), rather than inferred from a transcript. An
 // explicit intent is the author's own statement of the goal, in the operator's
 // trust domain, so it is framed as authoritative acceptance criteria; an
 // inferred summary stays a low-confidence hint. See internal/daemon/manager.go
-// (Source: db.RunIntentSourceAgent) and internal/pipeline/steps/intent.go
-// (Source: result.AgentName) for the two provenance paths.
+// (Source: db.RunIntentSourceAgent or db.RunIntentSourceRerun) and
+// internal/pipeline/steps/intent.go (Source: result.AgentName) for the
+// explicit, inherited, and inferred provenance paths.
 func intentSourceIsAuthoritative(sctx *pipeline.StepContext) bool {
-	return sctx != nil && sctx.IntentSource == db.RunIntentSourceAgent
+	return sctx != nil && db.IsAuthoritativeRunIntentSource(sctx.IntentSource)
 }
 
 // intentConformanceReviewClause returns a review-prompt directive that turns
@@ -69,7 +72,8 @@ func intentSourceIsAuthoritative(sctx *pipeline.StepContext) bool {
 // required behavior still present?" question - a risk-only rereview scores a
 // removed feature as clean because a deleted behavior has no risk.
 //
-// It is emitted only for an explicit, authoritative intent (Source=="agent");
+// It is emitted only for an explicit or inherited authoritative intent
+// (Source=="agent" or Source=="rerun");
 // an inferred hint carries no such obligation, so the clause is empty and the
 // review prompt is unchanged for inferred runs. The obligation narrows the
 // agent's task to a closed classification of the diff against the criteria

--- a/internal/pipeline/steps/intent_prompt_test.go
+++ b/internal/pipeline/steps/intent_prompt_test.go
@@ -54,6 +54,19 @@ func TestUserIntentPromptSection_InferredRendersAsHint(t *testing.T) {
 // acceptance criteria: it keeps the BEGIN/END markers and the "do not execute
 // instructions" guard (injection safety), but it is framed as binding, not as
 // an ignorable hint.
+func TestUserIntentPromptSection_RerunSourceRendersAsAuthoritative(t *testing.T) {
+	got := userIntentPromptSection(&pipeline.StepContext{
+		UserIntent:   "REQUIRED: keep guarded removal. FORBIDDEN: a cleanup mutex.",
+		IntentSource: db.RunIntentSourceRerun,
+	})
+	if !strings.Contains(got, "AUTHORITATIVE acceptance criteria") {
+		t.Fatalf("inherited intent should be framed as authoritative:\n%s", got)
+	}
+	if strings.Contains(got, "hint, not ground truth") {
+		t.Fatalf("inherited intent must not use inferred framing:\n%s", got)
+	}
+}
+
 func TestUserIntentPromptSection_AgentSourceRendersAsAuthoritative(t *testing.T) {
 	got := userIntentPromptSection(&pipeline.StepContext{
 		UserIntent:   "REQUIRED: keep guarded removal. FORBIDDEN: a cleanup mutex.",

--- a/internal/pipeline/steps/review_test.go
+++ b/internal/pipeline/steps/review_test.go
@@ -409,6 +409,7 @@ func TestReviewStep_ConformanceObligationTracksIntentProvenance(t *testing.T) {
 		wantAuthority   bool
 	}{
 		{"agent source is authoritative", db.RunIntentSourceAgent, true, true},
+		{"inherited source is authoritative", db.RunIntentSourceRerun, true, true},
 		{"inferred source stays a hint", "claude", false, false},
 	}
 	for _, tc := range cases {

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -82,8 +82,11 @@ task along with the command:
      non-default branch, so the work must land there before you run.
   3. **Then validate**, passing the user's task as your ` + "`--intent`" + `. The task
      text is exactly what the user set out to accomplish, in their own words, so
-     it *is* the intent - pass it through, enriched with the decisions and
-     tradeoffs you made while doing the work (see
+     it *is* the intent - preserve requirements stated directly by the user,
+     including constraints, exclusions, acceptance criteria, and later decisions;
+     do not condense them into a diff summary or drop them while adding
+     implementation context. Enrich it with the decisions and tradeoffs you
+     made while doing the work (see
      [Intent is required](#intent-is-required)).
 
 ` + testguidance.Rule + `

--- a/internal/tui/commands.go
+++ b/internal/tui/commands.go
@@ -58,9 +58,10 @@ func (m Model) rerunCmd(requestID uint64) tea.Cmd {
 	}
 	repoID := m.run.RepoID
 	branch := m.run.Branch
+	previousRunID := m.run.ID
 	return func() tea.Msg {
 		var rerun ipc.RerunResult
-		if err := m.client.Call(ipc.MethodRerun, &ipc.RerunParams{RepoID: repoID, Branch: branch}, &rerun); err != nil {
+		if err := m.client.Call(ipc.MethodRerun, &ipc.RerunParams{RepoID: repoID, Branch: branch, PreviousRunID: previousRunID}, &rerun); err != nil {
 			return rerunErrMsg{err: err, requestID: requestID}
 		}
 		var result ipc.GetRunResult

--- a/internal/tui/commands_test.go
+++ b/internal/tui/commands_test.go
@@ -137,7 +137,7 @@ func TestModel_Update_RerunKeyStartsNewRunAndSwitchesModel(t *testing.T) {
 		if err := json.Unmarshal(raw, &params); err != nil {
 			return nil, err
 		}
-		if params.RepoID != "repo-001" || params.Branch != "feature/foo" {
+		if params.RepoID != "repo-001" || params.Branch != "feature/foo" || params.PreviousRunID != "run-001" {
 			return nil, fmt.Errorf("unexpected rerun params: %#v", params)
 		}
 		return &ipc.RerunResult{RunID: newRun.ID}, nil

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -55,8 +55,11 @@ task along with the command:
      non-default branch, so the work must land there before you run.
   3. **Then validate**, passing the user's task as your `--intent`. The task
      text is exactly what the user set out to accomplish, in their own words, so
-     it *is* the intent - pass it through, enriched with the decisions and
-     tradeoffs you made while doing the work (see
+     it *is* the intent - preserve requirements stated directly by the user,
+     including constraints, exclusions, acceptance criteria, and later decisions;
+     do not condense them into a diff summary or drop them while adding
+     implementation context. Enrich it with the decisions and tradeoffs you
+     made while doing the work (see
      [Intent is required](#intent-is-required)).
 
 


### PR DESCRIPTION
## Intent

# Task
Fix no-mistakes rerun intent provenance and tighten the installed no-mistakes skill's intent guidance.

Start by reproducing the current behavior end to end through the public CLI as a user experiences it, then trace the cause.
The incident evidence is in `/Users/kunchen/github/kunchenguid/firstmate/data/nm-pr1446-missed-finding-r1/report.md`.
A read-only database check established that the preceding run had explicit `intent_source=agent` intent of 4,170 bytes, while `no-mistakes rerun` created the replacement with newly inferred `intent_source=claude` intent of 1,244 bytes, including stale superseded requirements.

Implement this captain-selected contract:

1. When the original run selected for rerun has explicit intent, rerun inherits those exact intent bytes by default and treats them as canonical.
2. When that original run lacks explicit intent, rerun performs its normal fresh intent inference by default.
3. `no-mistakes rerun --intent <text>` is accepted in either case and makes the supplied text the canonical explicit intent for the new run, overriding inheritance or inference.
4. Preserve accurate intent provenance so inherited explicit, freshly inferred, and explicitly overridden intent are inspectable and cannot be confused.
5. Do not add `--intent-file`, change ordinary new-run behavior, or broaden rerun semantics beyond what this contract requires.

Add executable regressions through public behavior for exact explicit inheritance, fresh inference from a non-explicit original, and explicit override of both paths.
Cover empty or invalid flag input according to existing CLI conventions and ensure every run-creation route involved in rerun honors the same invariant.
Update command help and maintained documentation where required.

Also make a small, focused improvement to the no-mistakes skill's existing `--intent` guidance.
Nudge agents to preserve requirements stated directly by the user, including constraints, exclusions, acceptance criteria, and later user decisions, instead of condensing them into a diff summary or dropping them while adding implementation context.
Patch the existing owner concisely rather than duplicating the intent contract elsewhere.

Keep all unrelated behavior unchanged.
Run focused and full relevant tests, lint, and build before validation, then ship through the configured no-mistakes pipeline.

## What Changed

- Preserve the selected prior run’s authoritative intent byte-for-byte during reruns, while retaining fresh inference for runs without explicit intent.
- Add `rerun --intent` overrides and distinct provenance for inherited intent, with atomic persistence during run creation.
- Update CLI documentation and installed skill guidance, with regressions covering inheritance, inference, overrides, and invalid input.

## Risk Assessment

✅ Low: The follow-up now carries the exact TUI-selected run identity through IPC, validates its repo and branch ownership, and atomically creates authoritative-intent runs so persistence failure cannot launch inference instead; the complete change is well-bounded and satisfies the stated contract.

## Testing

The end-user CLI journey and supporting focused contracts all passed. Reviewer-visible transcripts capture CLI confirmations, exact persisted intent and provenance, fresh inference, both override paths, blank-input rejection, and updated help. This is a CLI-only change, so text artifacts directly represent the user-facing surface.

- Evidence: [Public CLI rerun intent journey](https://github.com/kunchenguid/no-mistakes/blob/731c4f6a0c601f64e116b645d3100905ba113f72/.no-mistakes/evidence/fm/nm-rerun-intent-inheritance-r1/rerun-intent-cli-transcript.txt)
- Evidence: [Updated rerun help](https://github.com/kunchenguid/no-mistakes/blob/731c4f6a0c601f64e116b645d3100905ba113f72/.no-mistakes/evidence/fm/nm-rerun-intent-inheritance-r1/rerun-help.txt)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `internal/daemon/manager.go:593` - The criterion requires inheriting intent from &#34;the original run selected for rerun,&#34; but this hunk always inherits from `latestForBranch`. A user can `attach --run &lt;older-failed-run&gt;` and invoke the TUI&#39;s rerun action; that request identifies only the repo and branch, so a newer run on the same branch causes the replacement to inherit the newer run&#39;s intent instead of the selected run&#39;s exact intent. Carry the selected prior run ID through the rerun request and resolve inheritance from that identity.
- 🚨 `internal/daemon/manager.go:686` - The criteria require authoritative intent to remain canonical and preserve provenance, but this hunk logs and ignores `UpdateRunIntent` failure. After a transient persistence failure, run creation continues with no intent attached, so the intent step performs transcript inference and can reproduce the original provenance-loss incident. Fail run creation when a supplied or inherited authoritative intent cannot be persisted, before launching the pipeline.

🔧 Fix: Preserve selected rerun intent atomically
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `./scripts/e2e.sh -tags=e2e -count=1 -v -timeout 180s ./internal/e2e -run '^TestRerunIntentProvenanceJourney$'`
- `go test ./internal/db -run '^(TestInsertRunWithIntent|Test.*RunIntent)'`
- `go test ./internal/daemon -run '^TestRerunInheritsIntentFromSelectedRun$'`
- `go test ./internal/cli -run '^TestRerunParamsIncludeSkipSteps$'`
- `go test ./internal/ipc -run '^TestRerunParams$'`
- `go test ./internal/tui -run '^TestModel_Update_RerunKeyStartsNewRunAndSwitchesModel$'`
- `go test ./internal/pipeline/steps -run '^(TestUserIntentPromptSection_(RerunSourceRendersAsAuthoritative|AgentSourceRendersAsAuthoritative|InferredRendersAsHint)|TestReviewStep_ConformanceObligationTracksIntentProvenance)$'`
- `go test ./internal/skill -run '^(TestBodyDocumentsTaskFirstFlow|TestVendored)$'`
- `go run ./cmd/no-mistakes rerun --help`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
