### PR TITLE
fix(scm): support GitHub checks on gh versions before 2.50.0

### DIFF
--- a/docs/src/content/docs/guides/provider-integration.md
+++ b/docs/src/content/docs/guides/provider-integration.md
@@ -63,7 +63,7 @@ Verify:
 gh auth status
 ```
 
-`no-mistakes doctor` also checks for `gh` availability.
+`no-mistakes doctor` also checks `gh` availability and reports when the supported compatibility path will be used; the [CI step reference](/no-mistakes/reference/pipeline-steps/#ci) owns the polling details.
 For PR and workflow-run commands, no-mistakes passes the repository slug from the recorded upstream remote or PR URL to `gh`, so daemon-run commands do not depend on the daemon's current working directory.
 
 **What you get:**

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -401,6 +401,8 @@ Checks:
 
 Uses indicators: `✓` (available), `–` (not found, optional), `✗` (problem detected).
 
+When `gh` is installed but older than 2.50.0, `doctor` shows an informational warning that CI monitoring will use the structured `statusCheckRollup` compatibility path. The fallback remains supported; the warning makes the active path visible before a run.
+
 The standalone runner rows inspect default binary names; the `cursor` row reports whichever of `cursor-agent` and `acpx` are missing.
 The [Global Config Reference](/no-mistakes/reference/global-config/) owns ACP gate-validation availability and probing semantics.
 Each validation run performs the authoritative agent resolution again after applying any trusted repository-level override.

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -217,6 +217,8 @@ Monitors PR health after creation and auto-fixes CI failures. Mergeability polli
 **Active for GitHub, GitLab, Bitbucket Cloud (`bitbucket.org`), and Azure DevOps (`dev.azure.com` / `*.visualstudio.com`)**.
 
 - GitHub requires `gh` CLI, installed and authenticated.
+- GitHub prefers `gh pr checks --json` on gh 2.50.0 and newer. Older gh releases use the structured `gh pr view --json statusCheckRollup` fallback, with the exact PR and repository passed explicitly on both paths.
+- GitHub check states that are empty or unknown remain pending instead of being counted as successful. Poll errors preserve the first non-empty gh stderr line so authentication and API failures remain diagnosable in the CI step log.
 - GitLab requires `glab` CLI, installed and authenticated.
 - Bitbucket Cloud requires `NO_MISTAKES_BITBUCKET_EMAIL` and `NO_MISTAKES_BITBUCKET_API_TOKEN`.
 - Azure DevOps requires the `az` CLI with the `azure-devops` extension, authenticated with a PAT.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/config"
@@ -18,6 +20,22 @@ import (
 type doctorAgentCheck struct {
 	name     string
 	binaries []string
+}
+
+var ghVersionRE = regexp.MustCompile(`gh version (\d+)\.(\d+)\.(\d+)`)
+
+// ghVersionPredatesChecksJSON identifies gh releases that need the structured
+// statusCheckRollup compatibility path. Unknown vendor/version formats do not
+// warn because the CI monitor detects support from the actual command result.
+func ghVersionPredatesChecksJSON(raw string) (version string, predates bool) {
+	match := ghVersionRE.FindStringSubmatch(raw)
+	if match == nil {
+		return "", false
+	}
+	version = strings.Join(match[1:4], ".")
+	major, _ := strconv.Atoi(match[1])
+	minor, _ := strconv.Atoi(match[2])
+	return version, major < 2 || (major == 2 && minor < 50)
 }
 
 func newDoctorCmd() *cobra.Command {
@@ -61,6 +79,15 @@ func newDoctorCmd() *cobra.Command {
 					warn("gh            ", "not found "+sDim.Render("(optional, needed for PR/CI)"))
 				} else {
 					ok("gh            ", "ok")
+					ghCmd := exec.Command("gh", "--version")
+					winproc.Harden(ghCmd)
+					if out, err := ghCmd.Output(); err == nil {
+						if version, predates := ghVersionPredatesChecksJSON(string(out)); predates {
+							warn("gh version    ", fmt.Sprintf(
+								"%s: pr checks --json is unavailable before 2.50.0; CI monitoring will use statusCheckRollup",
+								version))
+						}
+					}
 				}
 
 				if _, err := exec.LookPath("az"); err != nil {

--- a/internal/cli/doctor_version_test.go
+++ b/internal/cli/doctor_version_test.go
@@ -1,0 +1,32 @@
+package cli
+
+import "testing"
+
+func TestGhVersionPredatesChecksJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		raw          string
+		wantVersion  string
+		wantPredates bool
+	}{
+		{"host reproduction", "gh version 2.45.0 (2024-01-16)\n", "2.45.0", true},
+		{"older major", "gh version 1.14.0 (2021-01-01)\n", "1.14.0", true},
+		{"boundary", "gh version 2.50.0 (2024-05-29)\n", "2.50.0", false},
+		{"newer", "gh version 3.1.2 (2026-01-01)\n", "3.1.2", false},
+		{"unknown vendor output", "gh vendor build\n", "", false},
+		{"empty", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			version, predates := ghVersionPredatesChecksJSON(tt.raw)
+			if version != tt.wantVersion || predates != tt.wantPredates {
+				t.Fatalf("ghVersionPredatesChecksJSON(%q) = (%q, %v), want (%q, %v)",
+					tt.raw, version, predates, tt.wantVersion, tt.wantPredates)
+			}
+		})
+	}
+}

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"sync/atomic"
 	"time"
+	"unicode/utf8"
 
 	"github.com/kunchenguid/no-mistakes/internal/scm"
 )
@@ -23,6 +25,12 @@ type Host struct {
 	host         string // repo's GitHub hostname; scopes the auth check
 	repo         string // "owner/name" slug for --repo; empty when unknown
 	forkOwner    string // fork owner for cross-repository PR heads
+
+	// checksJSONUnsupported records that the resolved gh binary predates
+	// `gh pr checks --json`. Hosts are scoped to a pipeline run, so detecting
+	// the unsupported flag once avoids repeating a known-bad command on every
+	// CI poll without persisting assumptions across runs or binary upgrades.
+	checksJSONUnsupported atomic.Bool
 }
 
 // New builds a Host. cliAvailable reports whether the gh binary is
@@ -286,7 +294,7 @@ func (h *Host) GetPRState(ctx context.Context, pr *scm.PR) (scm.PRState, error) 
 	cmd := h.cmd(ctx, "gh", args...)
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("gh pr view: %w", err)
+		return "", ghCLIError("gh pr view", err)
 	}
 	return normalizePRState(strings.TrimSpace(string(out))), nil
 }
@@ -296,16 +304,84 @@ func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
 	if err != nil {
 		return nil, err
 	}
+	if !h.checksJSONUnsupported.Load() {
+		checks, err, unsupported := h.getChecksViaJSONFlag(ctx, selector)
+		if !unsupported {
+			return checks, err
+		}
+		h.checksJSONUnsupported.Store(true)
+	}
+	return h.getChecksViaStatusRollup(ctx, selector)
+}
+
+// getChecksViaJSONFlag uses the preferred gh >= 2.50.0 command. gh returns a
+// non-zero status when checks are pending or failing even though stdout still
+// contains valid JSON, so a parseable payload remains authoritative. The one
+// fallback signal is gh's explicit rejection of the --json flag.
+func (h *Host) getChecksViaJSONFlag(ctx context.Context, selector string) (checks []scm.Check, err error, unsupported bool) {
 	args := append([]string{"pr", "checks", selector}, h.repoArgs()...)
 	args = append(args, "--json", "name,state,bucket,completedAt")
 	cmd := h.cmd(ctx, "gh", args...)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		if strings.Contains(string(out), "no checks reported") {
-			return nil, nil
+	out, cmdErr := cmd.Output()
+	if cmdErr != nil {
+		stderr := exitStderr(cmdErr)
+		detail := string(stderr)
+		if strings.Contains(string(out), "no checks reported") || strings.Contains(detail, "no checks reported") {
+			return nil, nil, false
 		}
-		return nil, fmt.Errorf("gh pr checks: %w", err)
+		if strings.Contains(detail, "unknown flag: --json") {
+			return nil, nil, true
+		}
+		if len(strings.TrimSpace(string(out))) == 0 {
+			return nil, ghCLIError("gh pr checks", cmdErr), false
+		}
 	}
+	checks, err = parseChecksJSON(out)
+	if err != nil && cmdErr != nil {
+		return nil, ghCLIError("gh pr checks", cmdErr), false
+	}
+	return checks, err, false
+}
+
+// getChecksViaStatusRollup supports gh versions that predate `pr checks
+// --json`. It keeps both the exact PR selector and --repo argument, so daemon
+// polling from a detached bare gate never falls back to cwd branch inference.
+func (h *Host) getChecksViaStatusRollup(ctx context.Context, selector string) ([]scm.Check, error) {
+	args := append([]string{"pr", "view", selector}, h.repoArgs()...)
+	args = append(args, "--json", "statusCheckRollup")
+	cmd := h.cmd(ctx, "gh", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, ghCLIError("gh pr view statusCheckRollup", err)
+	}
+	var payload struct {
+		StatusCheckRollup []struct {
+			Typename    string `json:"__typename"`
+			Name        string `json:"name"`
+			Context     string `json:"context"`
+			Conclusion  string `json:"conclusion"`
+			Status      string `json:"status"`
+			State       string `json:"state"`
+			CompletedAt string `json:"completedAt"`
+		} `json:"statusCheckRollup"`
+	}
+	if err := json.Unmarshal(out, &payload); err != nil {
+		return nil, fmt.Errorf("parse CI checks: %w", err)
+	}
+	checks := make([]scm.Check, 0, len(payload.StatusCheckRollup))
+	for _, item := range payload.StatusCheckRollup {
+		name, state := item.Name, item.Conclusion
+		if item.Typename == "StatusContext" {
+			name, state = item.Context, item.State
+		} else if state == "" {
+			state = item.Status
+		}
+		checks = append(checks, newCheck(name, state, "", item.CompletedAt))
+	}
+	return checks, nil
+}
+
+func parseChecksJSON(out []byte) ([]scm.Check, error) {
 	var raw []struct {
 		Name        string `json:"name"`
 		State       string `json:"state"`
@@ -317,15 +393,23 @@ func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
 	}
 	checks := make([]scm.Check, 0, len(raw))
 	for _, r := range raw {
-		var completedAt time.Time
-		if r.CompletedAt != "" {
-			if parsed, parseErr := time.Parse(time.RFC3339, r.CompletedAt); parseErr == nil {
-				completedAt = parsed
-			}
-		}
-		checks = append(checks, scm.Check{Name: r.Name, Bucket: normalizeCheckBucket(r.Bucket, r.State), CompletedAt: completedAt})
+		checks = append(checks, newCheck(r.Name, r.State, r.Bucket, r.CompletedAt))
 	}
 	return checks, nil
+}
+
+func newCheck(name, state, bucket, completedAtRaw string) scm.Check {
+	var completedAt time.Time
+	if completedAtRaw != "" {
+		if parsed, err := time.Parse(time.RFC3339, completedAtRaw); err == nil {
+			completedAt = parsed
+		}
+	}
+	return scm.Check{
+		Name:        name,
+		Bucket:      normalizeCheckBucket(bucket, state),
+		CompletedAt: completedAt,
+	}
 }
 
 func (h *Host) GetMergeableState(ctx context.Context, pr *scm.PR) (scm.MergeableState, error) {
@@ -338,9 +422,46 @@ func (h *Host) GetMergeableState(ctx context.Context, pr *scm.PR) (scm.Mergeable
 	cmd := h.cmd(ctx, "gh", args...)
 	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("gh pr view mergeable: %w", err)
+		return "", ghCLIError("gh pr view mergeable", err)
 	}
 	return normalizeMergeableState(strings.TrimSpace(string(out))), nil
+}
+
+// ghCLIError preserves the first useful gh stderr line while keeping repeated
+// CI-poll warnings bounded and single-line. Output populates ExitError.Stderr
+// when the command did not have an explicit stderr writer.
+func ghCLIError(op string, err error) error {
+	if detail := compactCLIError(exitStderr(err)); detail != "" {
+		return fmt.Errorf("%s: %w: %s", op, err, detail)
+	}
+	return fmt.Errorf("%s: %w", op, err)
+}
+
+func exitStderr(err error) []byte {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.Stderr
+	}
+	return nil
+}
+
+func compactCLIError(stderr []byte) string {
+	const maxBytes = 200
+	for _, raw := range strings.Split(string(stderr), "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+		if len(line) > maxBytes {
+			cut := maxBytes
+			for cut > 0 && !utf8.RuneStart(line[cut]) {
+				cut--
+			}
+			line = line[:cut]
+		}
+		return line
+	}
+	return ""
 }
 
 func (h *Host) FetchFailedCheckLogs(ctx context.Context, _ *scm.PR, branch, headSHA string, failingNames []string) (string, error) {
@@ -488,7 +609,9 @@ func normalizeMergeableState(raw string) scm.MergeableState {
 }
 
 func normalizeCheckBucket(bucket, state string) scm.CheckBucket {
-	if normalized := scm.CheckBucket(strings.TrimSpace(bucket)); normalized != "" {
+	switch normalized := scm.CheckBucket(strings.TrimSpace(bucket)); normalized {
+	case scm.CheckBucketPass, scm.CheckBucketFail, scm.CheckBucketPending,
+		scm.CheckBucketCancel, scm.CheckBucketSkip:
 		return normalized
 	}
 
@@ -504,6 +627,6 @@ func normalizeCheckBucket(bucket, state string) scm.CheckBucket {
 	case "SKIPPED", "NEUTRAL", "STALE":
 		return scm.CheckBucketSkip
 	default:
-		return ""
+		return scm.CheckBucketPending
 	}
 }

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/kunchenguid/no-mistakes/internal/scm"
 )
@@ -240,6 +241,199 @@ func TestGetChecksFallsBackToStateWhenBucketMissing(t *testing.T) {
 	}
 	if checks[1].Name != "tests" || checks[1].Bucket != scm.CheckBucketPending {
 		t.Fatalf("checks[1] = %+v, want pending tests check", checks[1])
+	}
+}
+
+func TestGetChecksFallsBackForOldGhWithExactPRAndRepo(t *testing.T) {
+	t.Parallel()
+
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		"gh pr checks 123 --repo test/repo --json name,state,bucket,completedAt": {
+			stderr: "unknown flag: --json\n",
+			code:   1,
+		},
+		"gh pr view 123 --repo test/repo --json statusCheckRollup": {
+			stdout: `{"statusCheckRollup":[` +
+				`{"__typename":"CheckRun","name":"build","conclusion":"SUCCESS","completedAt":"2026-04-24T04:15:00Z"},` +
+				`{"__typename":"CheckRun","name":"deploy","conclusion":"","status":"IN_PROGRESS"},` +
+				`{"__typename":"StatusContext","context":"ci/legacy","state":"FAILURE"}` +
+				`]}` + "\n",
+		},
+	}), nil, "", "test/repo")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
+	if err != nil {
+		t.Fatalf("GetChecks() error = %v", err)
+	}
+	if len(checks) != 3 {
+		t.Fatalf("checks = %+v, want 3 checks", checks)
+	}
+	if checks[0].Name != "build" || checks[0].Bucket != scm.CheckBucketPass {
+		t.Fatalf("checks[0] = %+v, want passing build", checks[0])
+	}
+	if checks[1].Name != "deploy" || checks[1].Bucket != scm.CheckBucketPending {
+		t.Fatalf("checks[1] = %+v, want pending deploy", checks[1])
+	}
+	if checks[2].Name != "ci/legacy" || checks[2].Bucket != scm.CheckBucketFail {
+		t.Fatalf("checks[2] = %+v, want failing legacy status", checks[2])
+	}
+	wantCompletedAt := time.Date(2026, 4, 24, 4, 15, 0, 0, time.UTC)
+	if !checks[0].CompletedAt.Equal(wantCompletedAt) {
+		t.Fatalf("checks[0].CompletedAt = %v, want %v", checks[0].CompletedAt, wantCompletedAt)
+	}
+}
+
+func TestGetChecksOldGhGreenWithSkippedJob(t *testing.T) {
+	t.Parallel()
+
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		"gh pr checks 42 --repo test/repo --json name,state,bucket,completedAt": {
+			stderr: "unknown flag: --json\n",
+			code:   1,
+		},
+		"gh pr view 42 --repo test/repo --json statusCheckRollup": {
+			stdout: `{"statusCheckRollup":[` +
+				`{"__typename":"CheckRun","name":"test","conclusion":"SUCCESS"},` +
+				`{"__typename":"CheckRun","name":"optional","conclusion":"SKIPPED"}` +
+				`]}` + "\n",
+		},
+	}), nil, "", "test/repo")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "42"})
+	if err != nil {
+		t.Fatalf("GetChecks() error = %v", err)
+	}
+	if len(checks) != 2 || checks[0].Bucket != scm.CheckBucketPass || checks[1].Bucket != scm.CheckBucketSkip {
+		t.Fatalf("checks = %+v, want pass plus skipped", checks)
+	}
+}
+
+func TestGetChecksParsesFailingJSONDespiteGhExitStatus(t *testing.T) {
+	t.Parallel()
+
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		"gh pr checks 123 --repo test/repo --json name,state,bucket,completedAt": {
+			stdout: `[{"name":"build","state":"FAILURE","bucket":"fail"}]` + "\n",
+			code:   1,
+		},
+	}), nil, "", "test/repo")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
+	if err != nil {
+		t.Fatalf("GetChecks() error = %v", err)
+	}
+	if len(checks) != 1 || checks[0].Bucket != scm.CheckBucketFail {
+		t.Fatalf("checks = %+v, want one failing check", checks)
+	}
+}
+
+func TestGetChecksSurfacesFirstNonEmptyStderrLine(t *testing.T) {
+	t.Parallel()
+
+	host := New(githubTestCmdFactory(map[string]githubTestResponse{
+		"gh pr checks 123 --repo test/repo --json name,state,bucket,completedAt": {
+			stderr: "\n  authentication required; run gh auth login  \nsecond diagnostic\n",
+			code:   1,
+		},
+	}), nil, "", "test/repo")
+
+	_, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
+	if err == nil {
+		t.Fatal("GetChecks() error = nil, want CLI failure")
+	}
+	if !strings.Contains(err.Error(), "authentication required; run gh auth login") {
+		t.Fatalf("GetChecks() error = %q, want first non-empty stderr line", err)
+	}
+	if strings.Contains(err.Error(), "second diagnostic") {
+		t.Fatalf("GetChecks() error = %q, want only first non-empty stderr line", err)
+	}
+}
+
+func TestGetChecksUnknownAndEmptyStatesStayPending(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		responses map[string]githubTestResponse
+	}{
+		{
+			name: "preferred JSON path",
+			responses: map[string]githubTestResponse{
+				"gh pr checks 123 --repo test/repo --json name,state,bucket,completedAt": {
+					stdout: `[{"name":"future","state":"NEW_STATE","bucket":"exotic"},{"name":"empty","state":"","bucket":""}]` + "\n",
+				},
+			},
+		},
+		{
+			name: "old gh rollup path",
+			responses: map[string]githubTestResponse{
+				"gh pr checks 123 --repo test/repo --json name,state,bucket,completedAt": {
+					stderr: "unknown flag: --json\n",
+					code:   1,
+				},
+				"gh pr view 123 --repo test/repo --json statusCheckRollup": {
+					stdout: `{"statusCheckRollup":[{"__typename":"CheckRun","name":"future","conclusion":"NEW_STATE"},{"__typename":"CheckRun","name":"empty"}]}` + "\n",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			host := New(githubTestCmdFactory(tt.responses), nil, "", "test/repo")
+			checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
+			if err != nil {
+				t.Fatalf("GetChecks() error = %v", err)
+			}
+			if len(checks) != 2 {
+				t.Fatalf("checks = %+v, want 2 checks", checks)
+			}
+			for _, check := range checks {
+				if check.Bucket != scm.CheckBucketPending {
+					t.Errorf("check %q bucket = %q, want pending", check.Name, check.Bucket)
+				}
+			}
+		})
+	}
+}
+
+func TestGetChecksMemoizesOldGhFallback(t *testing.T) {
+	t.Parallel()
+
+	counts := map[string]int{}
+	host := New(countingGithubTestCmdFactory(map[string]githubTestResponse{
+		"gh pr checks 123 --repo test/repo --json name,state,bucket,completedAt": {
+			stderr: "unknown flag: --json\n",
+			code:   1,
+		},
+		"gh pr view 123 --repo test/repo --json statusCheckRollup": {
+			stdout: `{"statusCheckRollup":[]}` + "\n",
+		},
+	}, counts), nil, "", "test/repo")
+
+	for i := 0; i < 2; i++ {
+		if _, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"}); err != nil {
+			t.Fatalf("GetChecks() call %d error = %v", i+1, err)
+		}
+	}
+	if got := counts["gh pr checks 123 --repo test/repo --json name,state,bucket,completedAt"]; got != 1 {
+		t.Fatalf("preferred command called %d times, want 1", got)
+	}
+	if got := counts["gh pr view 123 --repo test/repo --json statusCheckRollup"]; got != 2 {
+		t.Fatalf("fallback command called %d times, want 2", got)
+	}
+}
+
+func TestCompactCLIErrorBoundsUTF8(t *testing.T) {
+	t.Parallel()
+
+	got := compactCLIError([]byte("\n" + strings.Repeat("a", 199) + "é" + strings.Repeat("b", 20) + "\nignored"))
+	if got != strings.Repeat("a", 199) {
+		t.Fatalf("compactCLIError() = %q, want 199 ASCII bytes before split rune", got)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("compactCLIError() = %q, want valid UTF-8", got)
 	}
 }
 
@@ -557,6 +751,15 @@ func githubTestCmdFactory(responses map[string]githubTestResponse) CmdFactory {
 			fmt.Sprintf("GITHUB_TEST_EXIT_CODE=%d", response.code),
 		)
 		return cmd
+	}
+}
+
+func countingGithubTestCmdFactory(responses map[string]githubTestResponse, counts map[string]int) CmdFactory {
+	inner := githubTestCmdFactory(responses)
+	return func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		key := strings.TrimSpace(name + " " + strings.Join(args, " "))
+		counts[key]++
+		return inner(ctx, name, args...)
 	}
 }
 


### PR DESCRIPTION
## What

`GetChecks` in `internal/scm/github` now detects when the installed `gh` rejects `pr checks --json` (added in gh 2.50.0) and falls back to `gh pr view --json statusCheckRollup`, memoizing the unsupported-flag result per run. The fallback:

- keeps the exact PR selector and `--repo` targeting, so daemon polling from a detached bare gate repo never falls back to cwd-branch inference
- maps both check runs and legacy status contexts, treating empty or unknown states as pending
- surfaces the first non-empty `gh` stderr line (bounded, UTF-8 safe) in CI poll errors instead of a bare exit status, while a parseable JSON payload stays authoritative even when `gh` exits non-zero for pending or failing checks

`no-mistakes doctor` now warns when the installed `gh` predates 2.50.0, noting CI monitoring will use the `statusCheckRollup` path; provider and CLI docs mention the compatibility behavior.

## Why

Older `gh` installs (pre-2.50.0) don't support `pr checks --json`, so CI monitoring silently breaks on those hosts with no diagnostic. This restores compatibility and gives an explicit `doctor` signal instead of a confusing failure.

## Relation to #393

This supersedes #393 (closed, went stale), by @TheIanLi, which first identified this compatibility gap. This PR is an independent re-port targeted at current `main`, scoped only to the checks-polling fallback, stderr surfacing, and the doctor signal — it deliberately excludes the unrelated required-workflow polling change from the original PR. Credit to @TheIanLi for identifying the issue.

## Testing

- `go test -race ./internal/scm/github/...` (full package) — PASS
- `go test -race ./internal/cli/... -run TestGhVersionPredatesChecksJSON` — PASS
- `gofmt -l .` — clean

This fix previously landed and validated in our fork (sentania/no-mistakes#1) against fork main; this PR re-ports the identical fix onto current upstream `main` (upstream gained 7 unrelated commits since the fork diverged; none of them touch checks polling or gh-version handling, so no duplicate fix exists upstream).
