### PR TITLE
fix: replace the running executable during Windows self-update

### DIFF
--- a/cmd/no-mistakes/main.go
+++ b/cmd/no-mistakes/main.go
@@ -17,11 +17,16 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/update"
 )
 
+var cleanupOldExecutable = update.CleanupOldExecutable
+var maybeHandleBackgroundCheck = update.MaybeHandleBackgroundCheck
+
 func main() {
 	os.Exit(run())
 }
 
 func run() int {
+	_ = cleanupOldExecutable()
+
 	if root, ok, err := daemonLogSinkRootFromArgs(os.Args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
@@ -53,7 +58,7 @@ func run() int {
 		return 0
 	}
 
-	if handled, err := update.MaybeHandleBackgroundCheck(os.Args[1:]); handled {
+	if handled, err := maybeHandleBackgroundCheck(os.Args[1:]); handled {
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return 1

--- a/cmd/no-mistakes/main_test.go
+++ b/cmd/no-mistakes/main_test.go
@@ -35,6 +35,66 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
+func TestRunAttemptsOldExecutableCleanupBeforeEarlyRoutes(t *testing.T) {
+	originalArgs := os.Args
+	originalCleanup := cleanupOldExecutable
+	originalBackground := maybeHandleBackgroundCheck
+	t.Cleanup(func() {
+		os.Args = originalArgs
+		cleanupOldExecutable = originalCleanup
+		maybeHandleBackgroundCheck = originalBackground
+	})
+
+	t.Run("daemon", func(t *testing.T) {
+		called := false
+		cleanupOldExecutable = func() error {
+			called = true
+			return nil
+		}
+		os.Args = []string{"no-mistakes", "daemon", "log-sink", "--root", ""}
+		if code := run(); code != 1 {
+			t.Fatalf("run code = %d, want 1", code)
+		}
+		if !called {
+			t.Fatal("cleanup was not attempted before daemon routing")
+		}
+	})
+
+	t.Run("background update", func(t *testing.T) {
+		cleanupFinished := false
+		cleanupOldExecutable = func() error {
+			cleanupFinished = true
+			return fmt.Errorf("executable is still locked")
+		}
+		maybeHandleBackgroundCheck = func([]string) (bool, error) {
+			if !cleanupFinished {
+				t.Fatal("background routing ran before cleanup")
+			}
+			return true, nil
+		}
+		os.Args = []string{"no-mistakes", "--update-check", "v1.2.3"}
+		if code := run(); code != 0 {
+			t.Fatalf("run code = %d, want 0", code)
+		}
+	})
+
+	t.Run("interactive", func(t *testing.T) {
+		called := false
+		cleanupOldExecutable = func() error {
+			called = true
+			return nil
+		}
+		maybeHandleBackgroundCheck = originalBackground
+		os.Args = []string{"no-mistakes", "--version"}
+		if code := run(); code != 0 {
+			t.Fatalf("run code = %d, want 0", code)
+		}
+		if !called {
+			t.Fatal("cleanup was not attempted before interactive routing")
+		}
+	})
+}
+
 func TestCLILogWriterReturnsDiscardWhenLogsDirMissing(t *testing.T) {
 	nmHome := t.TempDir()
 	t.Setenv("NM_HOME", nmHome)

--- a/internal/update/replace.go
+++ b/internal/update/replace.go
@@ -1,11 +1,14 @@
 package update
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 )
+
+var renameFile = os.Rename
+var removeFile = os.Remove
 
 func replaceExecutable(target string, binaryData []byte) error {
 	resolved, err := filepath.EvalSymlinks(target)
@@ -17,10 +20,13 @@ func replaceExecutable(target string, binaryData []byte) error {
 		return fmt.Errorf("stat executable: %w", err)
 	}
 	perm := info.Mode().Perm()
+	if currentGOOS == "windows" {
+		return replaceExecutableOnWindows(target, binaryData, perm)
+	}
 	if err := replaceExecutableAtomically(target, binaryData, perm); err == nil {
 		removeQuarantine(target)
 		return nil
-	} else if runtime.GOOS == "darwin" {
+	} else if currentGOOS == "darwin" {
 		return fmt.Errorf("self-update requires an atomic replace on macOS; reinstall no-mistakes so the PATH entry points at a user-owned binary, then retry update: %w", err)
 	}
 	if err := overwriteExecutable(target, binaryData, perm); err != nil {
@@ -30,30 +36,89 @@ func replaceExecutable(target string, binaryData []byte) error {
 	return nil
 }
 
-func replaceExecutableAtomically(target string, binaryData []byte, perm os.FileMode) error {
-	dir := filepath.Dir(target)
-	tmp, err := os.CreateTemp(dir, filepath.Base(target)+"-new-*")
+func replaceExecutableOnWindows(target string, binaryData []byte, perm os.FileMode) error {
+	tmpPath, cleanup, err := stageExecutable(target, binaryData, perm)
 	if err != nil {
-		return fmt.Errorf("create temp executable: %w", err)
+		return err
 	}
-	tmpPath := tmp.Name()
-	defer func() {
-		_ = tmp.Close()
-		_ = os.Remove(tmpPath)
-	}()
-	if _, err := tmp.Write(binaryData); err != nil {
-		return fmt.Errorf("write temp executable: %w", err)
+	defer cleanup()
+
+	backupPath := target + ".old"
+	if err := removeFile(backupPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove stale executable backup: %w", err)
 	}
-	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("close temp executable: %w", err)
+	if err := renameFile(target, backupPath); err != nil {
+		return fmt.Errorf("move running executable to backup: %w", err)
 	}
-	if err := os.Chmod(tmpPath, perm); err != nil {
-		return fmt.Errorf("chmod temp executable: %w", err)
+	if err := renameFile(tmpPath, target); err != nil {
+		installErr := fmt.Errorf("install staged executable: %w", err)
+		if restoreErr := renameFile(backupPath, target); restoreErr != nil {
+			return errors.Join(installErr, fmt.Errorf("restore previous executable: %w", restoreErr))
+		}
+		return installErr
 	}
-	if err := os.Rename(tmpPath, target); err != nil {
+	return nil
+}
+
+// CleanupOldExecutable removes the backup left by a successful Windows update.
+// The running process no longer holds that image open on the next startup.
+func CleanupOldExecutable() error {
+	if currentGOOS != "windows" {
+		return nil
+	}
+	target, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve executable for update cleanup: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(target); err == nil {
+		target = resolved
+	}
+	return cleanupOldExecutable(target)
+}
+
+func cleanupOldExecutable(target string) error {
+	if err := removeFile(target + ".old"); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove old executable backup: %w", err)
+	}
+	return nil
+}
+
+func replaceExecutableAtomically(target string, binaryData []byte, perm os.FileMode) error {
+	tmpPath, cleanup, err := stageExecutable(target, binaryData, perm)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	if err := renameFile(tmpPath, target); err != nil {
 		return fmt.Errorf("rename temp executable: %w", err)
 	}
 	return nil
+}
+
+func stageExecutable(target string, binaryData []byte, perm os.FileMode) (string, func(), error) {
+	dir := filepath.Dir(target)
+	tmp, err := os.CreateTemp(dir, filepath.Base(target)+"-new-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("create temp executable: %w", err)
+	}
+	tmpPath := tmp.Name()
+	cleanup := func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+	}
+	if _, err := tmp.Write(binaryData); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("write temp executable: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("close temp executable: %w", err)
+	}
+	if err := os.Chmod(tmpPath, perm); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("chmod temp executable: %w", err)
+	}
+	return tmpPath, cleanup, nil
 }
 
 func overwriteExecutable(path string, binaryData []byte, perm os.FileMode) error {

--- a/internal/update/replace_test.go
+++ b/internal/update/replace_test.go
@@ -1,12 +1,151 @@
 package update
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 )
+
+func TestReplaceExecutableWindowsMovesRunningImageAside(t *testing.T) {
+	setReplaceTestGOOS(t, "windows")
+
+	execPath := filepath.Join(t.TempDir(), "no-mistakes.exe")
+	if err := os.WriteFile(execPath, []byte("old-binary"), 0o751); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := replaceExecutable(execPath, []byte("new-binary")); err != nil {
+		t.Fatal(err)
+	}
+	assertFileContents(t, execPath, "new-binary")
+	assertFileContents(t, execPath+".old", "old-binary")
+	info, err := os.Stat(execPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o751 {
+		t.Fatalf("replacement permissions = %o, want 751", got)
+	}
+}
+
+func TestReplaceExecutableWindowsRemovesStaleBackup(t *testing.T) {
+	setReplaceTestGOOS(t, "windows")
+
+	execPath := filepath.Join(t.TempDir(), "no-mistakes.exe")
+	if err := os.WriteFile(execPath, []byte("current-binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(execPath+".old", []byte("stale-binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := replaceExecutable(execPath, []byte("new-binary")); err != nil {
+		t.Fatal(err)
+	}
+	assertFileContents(t, execPath, "new-binary")
+	assertFileContents(t, execPath+".old", "current-binary")
+}
+
+func TestReplaceExecutableWindowsRestoresTargetWhenInstallFails(t *testing.T) {
+	setReplaceTestGOOS(t, "windows")
+
+	execPath := filepath.Join(t.TempDir(), "no-mistakes.exe")
+	if err := os.WriteFile(execPath, []byte("old-binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	originalRename := renameFile
+	renameCalls := 0
+	renameFile = func(oldPath, newPath string) error {
+		renameCalls++
+		if renameCalls == 2 {
+			return errors.New("injected install failure")
+		}
+		return os.Rename(oldPath, newPath)
+	}
+	t.Cleanup(func() { renameFile = originalRename })
+
+	err := replaceExecutable(execPath, []byte("new-binary"))
+	if err == nil || !strings.Contains(err.Error(), "injected install failure") {
+		t.Fatalf("replaceExecutable error = %v", err)
+	}
+	assertFileContents(t, execPath, "old-binary")
+	if _, err := os.Stat(execPath + ".old"); !os.IsNotExist(err) {
+		t.Fatalf("backup should have been restored, stat err = %v", err)
+	}
+}
+
+func TestCleanupOldExecutable(t *testing.T) {
+	setReplaceTestGOOS(t, "windows")
+
+	execPath := filepath.Join(t.TempDir(), "no-mistakes.exe")
+	if err := os.WriteFile(execPath+".old", []byte("old-binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := cleanupOldExecutable(execPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(execPath + ".old"); !os.IsNotExist(err) {
+		t.Fatalf("backup should be removed, stat err = %v", err)
+	}
+	if err := cleanupOldExecutable(execPath); err != nil {
+		t.Fatalf("absent backup should be a no-op: %v", err)
+	}
+}
+
+func TestCleanupOldExecutableReturnsDeletionFailure(t *testing.T) {
+	setReplaceTestGOOS(t, "windows")
+	originalRemove := removeFile
+	removeFile = func(string) error { return errors.New("executable still locked") }
+	t.Cleanup(func() { removeFile = originalRemove })
+
+	err := cleanupOldExecutable(`C:\bin\no-mistakes.exe`)
+	if err == nil || !strings.Contains(err.Error(), "executable still locked") {
+		t.Fatalf("cleanupOldExecutable error = %v", err)
+	}
+}
+
+func TestReplaceExecutableNonWindowsUsesAtomicReplacement(t *testing.T) {
+	setReplaceTestGOOS(t, "linux")
+
+	execPath := filepath.Join(t.TempDir(), "no-mistakes")
+	if err := os.WriteFile(execPath, []byte("old-binary"), 0o751); err != nil {
+		t.Fatal(err)
+	}
+	if err := replaceExecutable(execPath, []byte("new-binary")); err != nil {
+		t.Fatal(err)
+	}
+	assertFileContents(t, execPath, "new-binary")
+	if _, err := os.Stat(execPath + ".old"); !os.IsNotExist(err) {
+		t.Fatalf("non-Windows replacement should not create a backup, stat err = %v", err)
+	}
+}
+
+func TestReplaceExecutableNonWindowsFallsBackToOverwrite(t *testing.T) {
+	setReplaceTestGOOS(t, "linux")
+
+	execPath := filepath.Join(t.TempDir(), "no-mistakes")
+	if err := os.WriteFile(execPath, []byte("old-binary"), 0o751); err != nil {
+		t.Fatal(err)
+	}
+	originalRename := renameFile
+	renameFile = func(string, string) error { return errors.New("atomic rename unavailable") }
+	t.Cleanup(func() { renameFile = originalRename })
+
+	if err := replaceExecutable(execPath, []byte("new-binary")); err != nil {
+		t.Fatal(err)
+	}
+	assertFileContents(t, execPath, "new-binary")
+	info, err := os.Stat(execPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o751 {
+		t.Fatalf("replacement permissions = %o, want 751", got)
+	}
+}
 
 func TestReplaceExecutableDarwinRequiresAtomicReplace(t *testing.T) {
 	if runtime.GOOS != "darwin" {
@@ -41,5 +180,23 @@ func TestReplaceExecutableDarwinRequiresAtomicReplace(t *testing.T) {
 	}
 	if string(content) != "old-binary" {
 		t.Fatalf("executable content = %q", string(content))
+	}
+}
+
+func setReplaceTestGOOS(t *testing.T, goos string) {
+	t.Helper()
+	original := currentGOOS
+	currentGOOS = goos
+	t.Cleanup(func() { currentGOOS = original })
+}
+
+func assertFileContents(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Fatalf("%s contents = %q, want %q", path, got, want)
 	}
 }

--- a/internal/update/replace_test.go
+++ b/internal/update/replace_test.go
@@ -26,8 +26,12 @@ func TestReplaceExecutableWindowsMovesRunningImageAside(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := info.Mode().Perm(); got != 0o751 {
-		t.Fatalf("replacement permissions = %o, want 751", got)
+	wantPerm := os.FileMode(0o751)
+	if runtime.GOOS == "windows" {
+		wantPerm = 0o666
+	}
+	if got := info.Mode().Perm(); got != wantPerm {
+		t.Fatalf("replacement permissions = %o, want %o", got, wantPerm)
 	}
 }
 
@@ -142,8 +146,12 @@ func TestReplaceExecutableNonWindowsFallsBackToOverwrite(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := info.Mode().Perm(); got != 0o751 {
-		t.Fatalf("replacement permissions = %o, want 751", got)
+	wantPerm := os.FileMode(0o751)
+	if runtime.GOOS == "windows" {
+		wantPerm = 0o666
+	}
+	if got := info.Mode().Perm(); got != wantPerm {
+		t.Fatalf("replacement permissions = %o, want %o", got, wantPerm)
 	}
 }
 


### PR DESCRIPTION
On Windows, `no-mistakes update` cannot replace the executable that is currently running because the existing fallback opens that loaded image with `O_TRUNC`. The atomic temp-file rename attempted first also cannot replace an existing Windows executable, so the updater consistently reaches the failing overwrite path even when the daemon is stopped. The reporter verified the lock follows the updater's own executable path, and the current implementation in `internal/update/replace.go` still has that behavior. The separate request to clarify non-interactive use of `-y` is already covered by the current flag help and CLI documentation, so this plan does not duplicate that work.

## What Changed

Give Windows a replacement path that stages the verified binary beside the target, renames the running executable to a deterministic `.old` sibling, and then moves the staged binary into the original path without ever opening the loaded image for truncation. Preserve the executable's mode and make failures safe: if installing the staged binary fails after the old image moves, restore the original target where possible and return an error that retains the replacement failure context. Add a best-effort startup cleanup entry point that removes the now-unlocked `.old` sibling, and invoke it at the beginning of `cmd/no-mistakes` startup so daemon, background-check, and interactive execution paths all participate.

## Testing

- Windows replacement flow: starting with an existing target, install new bytes at the original path, retain the target permissions, and leave the previous bytes at the `.old` path until cleanup.
- Existing stale backup: remove an unlocked `.old` sibling before moving the current target so a prior interrupted cleanup does not block the next update.
- Install failure after the target is renamed: restore the prior executable at the original path and report the failure instead of leaving the installation missing or silently corrupted.
- Cleanup behavior: remove a present `.old` sibling, treat an absent sibling as a no-op, and keep startup non-fatal when Windows still refuses deletion.
- Startup wiring: verify cleanup is attempted before command routing, including routes that return early for daemon or background-update modes.
- Non-Windows regression: retain the current atomic replacement, overwrite fallback, and macOS atomic-only failure semantics.

Fixes #373
