### PR TITLE
fix(gatecontext): tolerate pre-migration schema in active-agent-steps read

### DIFF
--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 )
@@ -361,5 +362,26 @@ func TestOpenWaitsForTransientMigrationLock(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("Open did not finish after the migration lock was released")
+	}
+}
+
+func TestMigrationColumnsDerivedFromMigrationStatements(t *testing.T) {
+	for _, col := range []string{"review_approved_head_sha", "submitted_head_sha", "awaiting_agent_since", "parked_ms"} {
+		if !slices.Contains(MigrationColumns("runs"), col) {
+			t.Fatalf("MigrationColumns(runs) missing %s", col)
+		}
+	}
+	for _, col := range []string{"last_activity_at", "last_activity", "agent_pid", "auto_fix_limit"} {
+		if !slices.Contains(MigrationColumns("step_results"), col) {
+			t.Fatalf("MigrationColumns(step_results) missing %s", col)
+		}
+	}
+	if slices.Contains(MigrationColumns("runs"), "status") {
+		t.Fatalf("MigrationColumns(runs) includes base-schema column status")
+	}
+
+	extended := append(append([]string{}, migrationStatements...), `ALTER TABLE runs ADD COLUMN future_probe INTEGER`)
+	if !slices.Contains(migrationAddedColumns(extended, "runs"), "future_probe") {
+		t.Fatalf("migrationAddedColumns does not extend with new migration statements")
 	}
 }

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -1,5 +1,7 @@
 package db
 
+import "strings"
+
 const schemaSQL = `
 CREATE TABLE IF NOT EXISTS repos (
     id             TEXT PRIMARY KEY,
@@ -206,4 +208,23 @@ var migrationStatements = []string{
 	`ALTER TABLE agent_invocations ADD COLUMN workload_files INTEGER`,
 	`ALTER TABLE agent_invocations ADD COLUMN workload_lines INTEGER`,
 	`ALTER TABLE agent_invocations ADD COLUMN finding_count INTEGER`,
+}
+
+// MigrationColumns returns the columns that migrationStatements add to the
+// named table. Read-side callers that must tolerate pre-migration schemas
+// derive their expected-missing-column allowlist from here instead of
+// hardcoding names, so a future migration extends the allowlist automatically.
+func MigrationColumns(table string) []string {
+	return migrationAddedColumns(migrationStatements, table)
+}
+
+func migrationAddedColumns(statements []string, table string) []string {
+	var cols []string
+	for _, stmt := range statements {
+		f := strings.Fields(stmt)
+		if len(f) >= 6 && f[0] == "ALTER" && f[1] == "TABLE" && f[2] == table && f[3] == "ADD" && f[4] == "COLUMN" {
+			cols = append(cols, f[5])
+		}
+	}
+	return cols
 }

--- a/internal/gatecontext/classifier.go
+++ b/internal/gatecontext/classifier.go
@@ -157,13 +157,13 @@ func (i Inspector) activeAgentSteps() ([]activeAgentStep, error) {
 	}
 	runs, err := i.DB.GetActiveRuns()
 	if err != nil {
-		// A DB created before the review_approved_head_sha migration (pre-v1.42.0)
-		// makes this read-side query fail with "no such column". This metadata is
-		// advisory (the refusal does not depend on it), and with the daemon down
-		// there is no live agent-step ancestry to detect. Degrade to empty so the
-		// daemon can start and its authoritative open can run the migration; still
+		// A DB created before the migrations that introduced columns read by this
+		// advisory query fails with "no such column". This metadata is advisory
+		// (the refusal does not depend on it), and with the daemon down there is
+		// no live agent-step ancestry to detect. Degrade to empty so the daemon
+		// can start and its authoritative open can run the migration; still
 		// propagate genuine DB errors.
-		if preMigrationSchemaError(err, "review_approved_head_sha") {
+		if preMigrationSchemaError(err, "runs") {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("gate execution context: list active runs: %w", err)
@@ -172,7 +172,7 @@ func (i Inspector) activeAgentSteps() ([]activeAgentStep, error) {
 	for _, run := range runs {
 		steps, err := i.DB.GetStepsByRun(run.ID)
 		if err != nil {
-			if preMigrationSchemaError(err, "last_activity_at", "last_activity", "agent_pid", "auto_fix_limit") {
+			if preMigrationSchemaError(err, "step_results") {
 				return nil, nil
 			}
 			return nil, fmt.Errorf("gate execution context: list steps for active run: %w", err)
@@ -191,14 +191,16 @@ func (i Inspector) activeAgentSteps() ([]activeAgentStep, error) {
 	return out, nil
 }
 
-func preMigrationSchemaError(err error, columns ...string) bool {
+func preMigrationSchemaError(err error, tables ...string) bool {
 	msg := err.Error()
 	if !strings.Contains(msg, "no such column: ") {
 		return false
 	}
-	for _, col := range columns {
-		if strings.Contains(msg, "no such column: "+col) {
-			return true
+	for _, table := range tables {
+		for _, col := range db.MigrationColumns(table) {
+			if strings.Contains(msg, "no such column: "+col) {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/gatecontext/classifier.go
+++ b/internal/gatecontext/classifier.go
@@ -157,6 +157,15 @@ func (i Inspector) activeAgentSteps() ([]activeAgentStep, error) {
 	}
 	runs, err := i.DB.GetActiveRuns()
 	if err != nil {
+		// A DB created before the review_approved_head_sha migration (pre-v1.42.0)
+		// makes this read-side query fail with "no such column". This metadata is
+		// advisory (the refusal does not depend on it), and with the daemon down
+		// there is no live agent-step ancestry to detect. Degrade to empty so the
+		// daemon can start and its authoritative open can run the migration; still
+		// propagate genuine DB errors.
+		if strings.Contains(err.Error(), "no such column") {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("gate execution context: list active runs: %w", err)
 	}
 	var out []activeAgentStep

--- a/internal/gatecontext/classifier.go
+++ b/internal/gatecontext/classifier.go
@@ -163,7 +163,7 @@ func (i Inspector) activeAgentSteps() ([]activeAgentStep, error) {
 		// there is no live agent-step ancestry to detect. Degrade to empty so the
 		// daemon can start and its authoritative open can run the migration; still
 		// propagate genuine DB errors.
-		if strings.Contains(err.Error(), "no such column") {
+		if preMigrationSchemaError(err, "review_approved_head_sha") {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("gate execution context: list active runs: %w", err)
@@ -172,6 +172,9 @@ func (i Inspector) activeAgentSteps() ([]activeAgentStep, error) {
 	for _, run := range runs {
 		steps, err := i.DB.GetStepsByRun(run.ID)
 		if err != nil {
+			if preMigrationSchemaError(err, "last_activity_at", "last_activity", "agent_pid", "auto_fix_limit") {
+				return nil, nil
+			}
 			return nil, fmt.Errorf("gate execution context: list steps for active run: %w", err)
 		}
 		for _, step := range steps {
@@ -186,6 +189,19 @@ func (i Inspector) activeAgentSteps() ([]activeAgentStep, error) {
 		}
 	}
 	return out, nil
+}
+
+func preMigrationSchemaError(err error, columns ...string) bool {
+	msg := err.Error()
+	if !strings.Contains(msg, "no such column: ") {
+		return false
+	}
+	for _, col := range columns {
+		if strings.Contains(msg, "no such column: "+col) {
+			return true
+		}
+	}
+	return false
 }
 
 func activeStepStatus(status types.StepStatus) bool {

--- a/internal/gatecontext/classifier_test.go
+++ b/internal/gatecontext/classifier_test.go
@@ -116,8 +116,29 @@ func TestInspectorPreMigrationSchemaDegradesActiveAgentSteps(t *testing.T) {
 			dropRuns: []string{"review_approved_head_sha"},
 		},
 		{
+			name:     "runs missing submitted_head_sha degrades to empty",
+			dropRuns: []string{"submitted_head_sha"},
+		},
+		{
+			name:     "runs missing awaiting_agent_since degrades to empty",
+			dropRuns: []string{"awaiting_agent_since"},
+		},
+		{
+			name:     "runs missing parked_ms degrades to empty",
+			dropRuns: []string{"parked_ms"},
+		},
+		{
+			name:     "runs missing any other migration column degrades to empty",
+			dropRuns: []string{"intent"},
+		},
+		{
 			name:      "step_results missing migration columns degrades to empty",
 			dropSteps: []string{"last_activity_at", "last_activity", "agent_pid", "auto_fix_limit"},
+			withRun:   true,
+		},
+		{
+			name:      "step_results missing single migration column degrades to empty",
+			dropSteps: []string{"auto_fix_limit"},
 			withRun:   true,
 		},
 		{

--- a/internal/gatecontext/classifier_test.go
+++ b/internal/gatecontext/classifier_test.go
@@ -2,11 +2,15 @@ package gatecontext_test
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
+
+	_ "modernc.org/sqlite"
 
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/gate"
@@ -96,6 +100,97 @@ func TestInspectorRejectsRelocatedAndSymlinkedManagedRoots(t *testing.T) {
 	}
 	if !got.Nested || !got.ManagedGit {
 		t.Fatalf("symlinked relocated root not rejected: %+v", got)
+	}
+}
+
+func TestInspectorPreMigrationSchemaDegradesActiveAgentSteps(t *testing.T) {
+	cases := []struct {
+		name      string
+		dropRuns  []string
+		dropSteps []string
+		withRun   bool
+		wantErr   string
+	}{
+		{
+			name:     "runs missing review_approved_head_sha degrades to empty",
+			dropRuns: []string{"review_approved_head_sha"},
+		},
+		{
+			name:      "step_results missing migration columns degrades to empty",
+			dropSteps: []string{"last_activity_at", "last_activity", "agent_pid", "auto_fix_limit"},
+			withRun:   true,
+		},
+		{
+			name:     "runs missing unrelated column propagates",
+			dropRuns: []string{"status"},
+			wantErr:  "no such column: status",
+		},
+		{
+			name:      "step_results missing unrelated column propagates",
+			dropSteps: []string{"status"},
+			withRun:   true,
+			wantErr:   "no such column: status",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dbPath := filepath.Join(t.TempDir(), "old.sqlite")
+			database, err := db.Open(dbPath)
+			if err != nil {
+				t.Fatalf("open db: %v", err)
+			}
+			if err := database.Close(); err != nil {
+				t.Fatalf("close db: %v", err)
+			}
+			raw, err := sql.Open("sqlite", dbPath)
+			if err != nil {
+				t.Fatalf("open raw db: %v", err)
+			}
+			for _, col := range tc.dropRuns {
+				if _, err := raw.Exec(`ALTER TABLE runs DROP COLUMN ` + col); err != nil {
+					raw.Close()
+					t.Fatalf("drop runs column %s: %v", col, err)
+				}
+			}
+			for _, col := range tc.dropSteps {
+				if _, err := raw.Exec(`ALTER TABLE step_results DROP COLUMN ` + col); err != nil {
+					raw.Close()
+					t.Fatalf("drop step_results column %s: %v", col, err)
+				}
+			}
+			if tc.withRun {
+				if _, err := raw.Exec(`INSERT INTO runs (id, repo_id, branch, head_sha, base_sha, status, created_at, updated_at) VALUES ('run-1', 'repo-1', 'feature', 'head', 'base', 'pending', 1, 1)`); err != nil {
+					raw.Close()
+					t.Fatalf("insert run: %v", err)
+				}
+			}
+			if err := raw.Close(); err != nil {
+				t.Fatalf("close raw db: %v", err)
+			}
+
+			readonly, err := db.OpenReadOnly(dbPath)
+			if err != nil {
+				t.Fatalf("open read-only: %v", err)
+			}
+			defer readonly.Close()
+			inspector := gatecontext.Inspector{DB: readonly, Paths: paths.WithRoot(t.TempDir())}
+			got, err := inspector.Inspect(context.Background(), gatecontext.Request{})
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("inspect = %+v, want error containing %q", got, tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("inspect error = %v, want containing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("inspect on pre-migration schema: %v", err)
+			}
+			if got.Nested {
+				t.Fatalf("pre-migration schema classified as nested: %+v", got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Intent

Let the daemon start on a pre-migration old-schema DB: the gate-context active-agent-steps advisory read must degrade safely when the DB predates the migrations that introduced columns it queries on runs/step_results (review_approved_head_sha, submitted_head_sha, awaiting_agent_since, parked_ms, and the step_results columns), so the daemon can start and its authoritative open can run the migration, while genuine non-schema errors still propagate. Use a maintainable, migration-derived expected-missing-column allowlist (from internal/db migrationStatements, the single source of truth) rather than a hardcoded list, scoped to the two advisory reads only; other errors keep propagating through the wrapped error path. Include the focused regression tests (each expected historical column degrades to empty, an unexpected missing column is returned not suppressed, and the allowlist derives from the migration statements). The branch is the existing PR #656 fm/migration-fix on fork vipentti/no-mistakes, base main; update that PR, do not open a new one.

## What Changed

- The gate-context `activeAgentSteps()` advisory read now degrades safely to empty when the runs/step_results tables predate the migrations that introduced queried columns, so the daemon can start on an old-schema DB and its authoritative open can run the migration.
- `preMigrationSchemaError` matches only `no such column` errors for columns derived from `db.MigrationColumns` (the migration statments), scoped to the two advisory reads; unrelated or genuine DB errors still propagate through the wrapped error path.
- Added a migration-derived expected-missing-column allowlist in `internal/db/schema.go` (`MigrationColumns`/`migrationAddedColumns`) sourced from `migrationStatements`, plus regression tests covering each historical column degrading to empty, unexpected missing columns being returned/not suppressed, and the allowlist deriving from the migration statements.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>
</details>
<details>
<summary>✅ **Rebase** - passed</summary>
</details>
<details>
<summary>✅ **Review** - completed</summary>
</details>
<details>
<summary>✅ **Test** - passed</summary>
</details>
<details>
<summary>✅ **Document** - passed</summary>
</details>
<details>
<summary>✅ **Lint** - passed</summary>
</details>
<details>
<summary>✅ **Push** - passed</summary>
</details>
