### PR TITLE
fix(agent): retry claude runs that drop the API connection mid-response

### DIFF
--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -98,7 +98,10 @@ func (a *claudeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error
 
 	var usage TokenUsage
 	var result *claudeResult
-	if err := parseClaudeEvents(ctx, started.stdout, opts.OnChunk, &usage, &result); err != nil {
+	// Claude Code writes its API-error diagnostics to stdout as assistant text
+	// and leaves stderr empty, so keep a copy for the exit path below.
+	var apiErrors claudeAPIErrorSniffer
+	if err := parseClaudeEvents(ctx, io.TeeReader(started.stdout, &apiErrors), opts.OnChunk, &usage, &result); err != nil {
 		err = started.waitAfterParseError(err)
 		stderrWG.Wait()
 		retErr := fmt.Errorf("claude parse events: %w", err)
@@ -109,7 +112,7 @@ func (a *claudeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error
 	waitErr := started.wait()
 	stderrWG.Wait()
 	if waitErr != nil {
-		retErr := fmt.Errorf("claude exited: %w: %s", waitErr, string(stderrBuf))
+		retErr := fmt.Errorf("claude exited: %w: %s", waitErr, claudeExitDiagnostic(stderrBuf, apiErrors.LastAPIError()))
 		emitAgentExited(opts, "claude", pid, retErr)
 		return nil, retErr
 	}

--- a/internal/agent/claude_diagnostic.go
+++ b/internal/agent/claude_diagnostic.go
@@ -23,6 +23,14 @@ const claudeAPIErrorMaxPending = 64 * 1024
 // evidence of a transient failure discarded. The sniffer matches the raw line,
 // which covers both the stream-json assistant event that normally carries the
 // text and any plain text claude writes directly.
+//
+// The marker only counts when it BEGINS the diagnostic: claude emits its API
+// error as its own assistant content block, so the text opens the JSON string
+// value ("text":"API Error: ...) or, for plain output, the line itself. A line
+// that merely quotes the marker mid-text is not a diagnostic - pipeline agents
+// routinely read and echo log files holding those exact strings, and retaining
+// one would let a later, permanent, non-zero exit be misclassified as transient
+// and burn the full retry budget.
 type claudeAPIErrorSniffer struct {
 	pending string
 	last    string
@@ -59,17 +67,9 @@ func (s *claudeAPIErrorSniffer) LastAPIError() string {
 }
 
 func (s *claudeAPIErrorSniffer) consume(line string) {
-	idx := strings.LastIndex(line, claudeAPIErrorMarker)
-	if idx < 0 {
+	diag, ok := claudeAPIErrorDiagnostic(line)
+	if !ok {
 		return
-	}
-	diag := line[idx:]
-	// A stream-json event carries the text inside a JSON string, so stop at the
-	// closing quote instead of trailing the rest of the envelope into the error.
-	if strings.HasPrefix(strings.TrimSpace(line), "{") {
-		if end := strings.IndexByte(diag, '"'); end >= 0 {
-			diag = diag[:end]
-		}
 	}
 	if len(diag) > claudeAPIErrorMaxLen {
 		diag = diag[:claudeAPIErrorMaxLen]
@@ -77,6 +77,45 @@ func (s *claudeAPIErrorSniffer) consume(line string) {
 	if diag = strings.TrimSpace(diag); diag != "" {
 		s.last = diag
 	}
+}
+
+// claudeAPIErrorDiagnostic reports the diagnostic a raw stdout line carries, if
+// the marker begins it.
+func claudeAPIErrorDiagnostic(line string) (string, bool) {
+	if strings.HasPrefix(strings.TrimSpace(line), "{") {
+		idx := claudeAPIErrorJSONValueStart(line)
+		if idx < 0 {
+			return "", false
+		}
+		diag := line[idx:]
+		// A stream-json event carries the text inside a JSON string, so stop at
+		// the closing quote instead of trailing the rest of the envelope into
+		// the error.
+		if end := strings.IndexByte(diag, '"'); end >= 0 {
+			diag = diag[:end]
+		}
+		return diag, true
+	}
+	trimmed := strings.TrimLeft(line, " \t\r")
+	if !strings.HasPrefix(trimmed, claudeAPIErrorMarker) {
+		return "", false
+	}
+	return trimmed, true
+}
+
+// claudeAPIErrorJSONValueStart returns the index of the last marker that opens a
+// JSON string value, i.e. one immediately preceded by an unescaped quote, or -1.
+func claudeAPIErrorJSONValueStart(line string) int {
+	for i := strings.LastIndex(line, claudeAPIErrorMarker); i > 0; i = strings.LastIndex(line[:i], claudeAPIErrorMarker) {
+		if line[i-1] != '"' {
+			continue
+		}
+		if i >= 2 && line[i-2] == '\\' {
+			continue
+		}
+		return i
+	}
+	return -1
 }
 
 // claudeExitDiagnostic joins the evidence available after a non-zero exit.

--- a/internal/agent/claude_diagnostic.go
+++ b/internal/agent/claude_diagnostic.go
@@ -1,0 +1,95 @@
+package agent
+
+import "strings"
+
+// claudeAPIErrorMarker is the prefix Claude Code uses for its own API-error
+// diagnostics, e.g. "API Error: Connection closed mid-response. The response
+// above may be incomplete."
+const claudeAPIErrorMarker = "API Error:"
+
+// claudeAPIErrorMaxLen bounds how much of a diagnostic is retained so a
+// pathological stdout line can never blow up the error the agent returns.
+const claudeAPIErrorMaxLen = 512
+
+// claudeAPIErrorMaxPending bounds the buffer holding an unterminated line.
+const claudeAPIErrorMaxPending = 64 * 1024
+
+// claudeAPIErrorSniffer watches a copy of claude's stdout for the CLI's own
+// "API Error: ..." diagnostic.
+//
+// Claude Code reports API transport failures as assistant text on stdout and
+// leaves stderr empty, so an exit error composed from stderr alone is handed to
+// the retry classifier as a bare "claude exited: exit status 1: " with the only
+// evidence of a transient failure discarded. The sniffer matches the raw line,
+// which covers both the stream-json assistant event that normally carries the
+// text and any plain text claude writes directly.
+type claudeAPIErrorSniffer struct {
+	pending string
+	last    string
+}
+
+// Write implements io.Writer for use with io.TeeReader. It never fails: a line
+// holding no diagnostic simply leaves the retained value unchanged.
+func (s *claudeAPIErrorSniffer) Write(p []byte) (int, error) {
+	s.pending += string(p)
+	for {
+		i := strings.IndexByte(s.pending, '\n')
+		if i < 0 {
+			break
+		}
+		s.consume(s.pending[:i])
+		s.pending = s.pending[i+1:]
+	}
+	if len(s.pending) > claudeAPIErrorMaxPending {
+		// An unterminated line this long is not a stream-json event; take any
+		// diagnostic it already holds and drop it rather than growing.
+		s.consume(s.pending)
+		s.pending = ""
+	}
+	return len(p), nil
+}
+
+// LastAPIError returns the most recent diagnostic seen, including one on a
+// trailing line claude never terminated with a newline. Call it only after the
+// stdout copy is complete.
+func (s *claudeAPIErrorSniffer) LastAPIError() string {
+	s.consume(s.pending)
+	s.pending = ""
+	return s.last
+}
+
+func (s *claudeAPIErrorSniffer) consume(line string) {
+	idx := strings.LastIndex(line, claudeAPIErrorMarker)
+	if idx < 0 {
+		return
+	}
+	diag := line[idx:]
+	// A stream-json event carries the text inside a JSON string, so stop at the
+	// closing quote instead of trailing the rest of the envelope into the error.
+	if strings.HasPrefix(strings.TrimSpace(line), "{") {
+		if end := strings.IndexByte(diag, '"'); end >= 0 {
+			diag = diag[:end]
+		}
+	}
+	if len(diag) > claudeAPIErrorMaxLen {
+		diag = diag[:claudeAPIErrorMaxLen]
+	}
+	if diag = strings.TrimSpace(diag); diag != "" {
+		s.last = diag
+	}
+}
+
+// claudeExitDiagnostic joins the evidence available after a non-zero exit.
+// stderr stays first because that is where claude reports its own process-level
+// failures; the stdout API-error diagnostic is appended because API transport
+// failures land there instead, with stderr empty.
+func claudeExitDiagnostic(stderr []byte, apiErr string) string {
+	parts := make([]string, 0, 2)
+	if s := strings.TrimSpace(string(stderr)); s != "" {
+		parts = append(parts, s)
+	}
+	if apiErr != "" && !strings.Contains(string(stderr), apiErr) {
+		parts = append(parts, apiErr)
+	}
+	return strings.Join(parts, "; ")
+}

--- a/internal/agent/claude_diagnostic_test.go
+++ b/internal/agent/claude_diagnostic_test.go
@@ -44,6 +44,33 @@ func TestClaudeAPIErrorSniffer_ExtractsDiagnostic(t *testing.T) {
 			},
 			want: "API Error: second",
 		},
+		{
+			// A pipeline agent that reads or greps a log holding the marker
+			// echoes it back mid-text. Retaining that plants a stale diagnostic
+			// that makes a later permanent exit look transient.
+			name:   "quoted mid-text in an assistant event is not a diagnostic",
+			writes: []string{`{"type":"assistant","message":{"content":[{"type":"text","text":"the log line reads API Error: Connection closed mid-response."}]}}` + "\n"},
+		},
+		{
+			name:   "escaped quote before the marker is not a value opening",
+			writes: []string{`{"type":"assistant","message":{"content":[{"type":"text","text":"it printed \"API Error: Connection closed mid-response.\""}]}}` + "\n"},
+		},
+		{
+			name:   "tool result echoing a log file is not a diagnostic",
+			writes: []string{`{"type":"user","message":{"content":[{"type":"tool_result","content":"logs/agent.log:42: API Error: Unable to connect to API (ENOTIMP)"}]}}` + "\n"},
+		},
+		{
+			name:   "plain line quoting the marker mid-text is not a diagnostic",
+			writes: []string{"grep found: API Error: Connection closed mid-response.\n"},
+		},
+		{
+			name: "a stale echo does not survive as the retained diagnostic",
+			writes: []string{
+				`{"type":"assistant","message":{"content":[{"type":"text","text":"API Error: real"}]}}` + "\n",
+				"grep found: API Error: echoed\n",
+			},
+			want: "API Error: real",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var s claudeAPIErrorSniffer

--- a/internal/agent/claude_diagnostic_test.go
+++ b/internal/agent/claude_diagnostic_test.go
@@ -1,0 +1,90 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestClaudeAPIErrorSniffer_ExtractsDiagnostic(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		writes []string
+		want   string
+	}{
+		{
+			name:   "no diagnostic",
+			writes: []string{`{"type":"assistant","message":{"content":[{"type":"text","text":"all good"}]}}` + "\n"},
+		},
+		{
+			name:   "stream-json assistant event stops at the closing quote",
+			writes: []string{`{"type":"assistant","message":{"content":[{"type":"text","text":"API Error: Connection closed mid-response. The response above may be incomplete."}]}}` + "\n"},
+			want:   "API Error: Connection closed mid-response. The response above may be incomplete.",
+		},
+		{
+			name:   "plain text line",
+			writes: []string{"API Error: Unable to connect to API (ENOTIMP)\n"},
+			want:   "API Error: Unable to connect to API (ENOTIMP)",
+		},
+		{
+			name:   "unterminated trailing line",
+			writes: []string{"API Error: Unable to connect to API (ENOTIMP)"},
+			want:   "API Error: Unable to connect to API (ENOTIMP)",
+		},
+		{
+			name:   "split across writes",
+			writes: []string{"API Er", "ror: Connection closed mid-r", "esponse.\n"},
+			want:   "API Error: Connection closed mid-response.",
+		},
+		{
+			name: "last diagnostic wins",
+			writes: []string{
+				"API Error: first\n",
+				`{"type":"assistant","message":{"content":[{"type":"text","text":"thinking"}]}}` + "\n",
+				"API Error: second\n",
+			},
+			want: "API Error: second",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var s claudeAPIErrorSniffer
+			for _, w := range tc.writes {
+				n, err := s.Write([]byte(w))
+				if err != nil || n != len(w) {
+					t.Fatalf("Write(%q) = %d, %v", w, n, err)
+				}
+			}
+			if got := s.LastAPIError(); got != tc.want {
+				t.Errorf("LastAPIError = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClaudeAPIErrorSniffer_BoundsRetainedAndBufferedBytes(t *testing.T) {
+	var s claudeAPIErrorSniffer
+	line := "API Error: " + strings.Repeat("x", 4*claudeAPIErrorMaxLen)
+	if _, err := s.Write([]byte(line + "\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if got := len(s.LastAPIError()); got != claudeAPIErrorMaxLen {
+		t.Errorf("retained %d bytes, want the %d-byte bound", got, claudeAPIErrorMaxLen)
+	}
+
+	// A stream that never emits a newline must not grow the pending buffer
+	// without bound, and must still surrender a diagnostic it already saw.
+	var unterminated claudeAPIErrorSniffer
+	if _, err := unterminated.Write([]byte("API Error: dropped stream ")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	for i := 0; i < 4; i++ {
+		if _, err := unterminated.Write([]byte(strings.Repeat("y", claudeAPIErrorMaxPending))); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+		if got := len(unterminated.pending); got > claudeAPIErrorMaxPending {
+			t.Fatalf("pending grew to %d bytes, want at most %d", got, claudeAPIErrorMaxPending)
+		}
+	}
+	if !strings.HasPrefix(unterminated.LastAPIError(), "API Error: dropped stream") {
+		t.Errorf("LastAPIError = %q, want the diagnostic seen before the flood", unterminated.LastAPIError())
+	}
+}

--- a/internal/agent/claude_test.go
+++ b/internal/agent/claude_test.go
@@ -629,6 +629,76 @@ func TestClaudeAgent_CancellationWithBlockedStdinAndInheritedPipesIsBounded(t *t
 	}
 }
 
+// TestClaudeAgent_StdoutAPIErrorIsRetriedWithEmptyStderr pins the transport that
+// carries claude's API-error diagnostic. Claude Code reports a dropped API
+// response stream as assistant text on stdout and writes nothing to stderr, so
+// an exit error composed from stderr alone reached the classifier as a bare
+// "claude exited: exit status 1: " and the transient failure was never retried.
+func TestClaudeAgent_StdoutAPIErrorIsRetriedWithEmptyStderr(t *testing.T) {
+	defer withFastBackoff(t)()
+
+	t.Setenv("NM_CLAUDE_STDIN_HELPER", "api-error-stdout")
+	a := newClaudeStdinHelperAgent(t)
+	var attempts []Attempt
+	opts := RunOpts{
+		Prompt:    "run the tests",
+		CWD:       t.TempDir(),
+		OnAttempt: func(attempt Attempt) { attempts = append(attempts, attempt) },
+	}
+
+	_, err := a.Run(context.Background(), opts)
+	if err == nil {
+		t.Fatal("expected an error after the transient API failure exhausts retries")
+	}
+	if !strings.Contains(err.Error(), "Connection closed mid-response") {
+		t.Fatalf("error %q must carry the stdout API-error diagnostic", err)
+	}
+	if label, retry := claudeRetryClassifier(err); !retry {
+		t.Fatalf("error %q classified as permanent (label %q), want transient", err, label)
+	}
+	if len(attempts) != claudeMaxRetries+1 {
+		t.Fatalf("attempts = %d, want %d (initial + %d retries)", len(attempts), claudeMaxRetries+1, claudeMaxRetries)
+	}
+}
+
+// TestClaudeAgent_ExitDiagnosticPrefersStderrAndAppendsStdout documents the
+// composed diagnostic: stderr keeps its leading position, and the stdout
+// API-error text is appended rather than replacing it.
+func TestClaudeAgent_ExitDiagnosticPrefersStderrAndAppendsStdout(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		stderr string
+		apiErr string
+		want   string
+	}{
+		{name: "stderr only", stderr: "boom\n", want: "boom"},
+		{
+			name:   "stdout only",
+			apiErr: "API Error: Connection closed mid-response.",
+			want:   "API Error: Connection closed mid-response.",
+		},
+		{
+			name:   "both",
+			stderr: "boom",
+			apiErr: "API Error: Unable to connect to API (ENOTIMP)",
+			want:   "boom; API Error: Unable to connect to API (ENOTIMP)",
+		},
+		{
+			name:   "no duplication when stderr already carries it",
+			stderr: "API Error: Connection closed mid-response.",
+			apiErr: "API Error: Connection closed mid-response.",
+			want:   "API Error: Connection closed mid-response.",
+		},
+		{name: "neither"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := claudeExitDiagnostic([]byte(tc.stderr), tc.apiErr); got != tc.want {
+				t.Errorf("claudeExitDiagnostic = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func newClaudeStdinHelperAgent(t *testing.T) *claudeAgent {
 	t.Helper()
 	exe, err := os.Executable()
@@ -651,6 +721,11 @@ func TestClaudeStdinHelper(t *testing.T) {
 	switch mode {
 	case "exit-early":
 		os.Exit(0)
+	case "api-error-stdout":
+		// Claude Code reports a dropped API response stream as assistant text
+		// on stdout, writes nothing to stderr, and exits non-zero.
+		_, _ = io.WriteString(os.Stdout, `{"type":"assistant","session_id":"helper-session","message":{"model":"helper-model","usage":{"input_tokens":1,"output_tokens":1},"content":[{"type":"text","text":"API Error: Connection closed mid-response. The response above may be incomplete."}]}}`+"\n")
+		os.Exit(1)
 	case "block":
 		_ = os.WriteFile(os.Getenv("NM_CLAUDE_STDIN_READY"), []byte("ready"), 0o644)
 		for {

--- a/internal/agent/retry.go
+++ b/internal/agent/retry.go
@@ -139,9 +139,18 @@ var transientNeedles = []struct {
 	{"service_unavailable", "service_unavailable"},
 	{"connection refused", "connection refused"},
 	{"connection reset", "connection reset"},
+	// Claude Code's own text when the API response stream ends early: "API
+	// Error: Connection closed mid-response. The response above may be
+	// incomplete." The second needle also covers phrasings that drop the
+	// "connection closed" prefix.
+	{"connection closed", "connection closed"},
+	{"mid-response", "connection closed mid-response"},
 	{"i/o timeout", "i/o timeout"},
 	{"no such host", "dns lookup failed"},
 	{"temporary failure in name resolution", "dns temporary failure"},
+	// A resolver that refuses the query surfaces as ENOTIMP, which Claude Code
+	// reports as "API Error: Unable to connect to API (ENOTIMP)".
+	{"enotimp", "enotimp"},
 	{"tls handshake", "tls handshake failure"},
 	{"unexpected eof", "unexpected eof"},
 }

--- a/internal/agent/retry_test.go
+++ b/internal/agent/retry_test.go
@@ -51,6 +51,19 @@ func TestClassifyTransient_Positive(t *testing.T) {
 			wantSub: "connection reset",
 		},
 		{
+			// Claude Code writes this to stdout as assistant text, so the
+			// error carries it only once runOnce stops composing from stderr
+			// alone.
+			name:    "connection closed mid-response on stdout",
+			errMsg:  `claude exited: exit status 1: API Error: Connection closed mid-response. The response above may be incomplete.`,
+			wantSub: "connection closed",
+		},
+		{
+			name:    "unable to connect ENOTIMP",
+			errMsg:  `claude exited: exit status 1: API Error: Unable to connect to API (ENOTIMP)`,
+			wantSub: "enotimp",
+		},
+		{
 			name:    "io timeout",
 			errMsg:  `Post "https://api.anthropic.com/v1/messages": context deadline exceeded (i/o timeout)`,
 			wantSub: "i/o timeout",


### PR DESCRIPTION
## Intent

Fix a defect where a dropped Anthropic API connection during a claude agent invocation fails a pipeline step that should have been retried: claudeMaxRetries is 3 and zero retries fire. There are two independent causes, either one alone sufficient to cause the bug, so both are fixed.

Cause 1: internal/agent/claude.go composed the error runOnce returns from the process wait status plus stderr only, but Claude Code reports 'API Error: Connection closed mid-response. The response above may be incomplete.' as assistant text on stdout and leaves stderr empty. The retry classifier therefore received the bare string 'claude exited: exit status 1: ' with the diagnosis discarded. The negative test cases in internal/agent/retry_test.go are all of the form 'claude exited: exit status 1: API Error: {...}', which shows the stderr-only transport was an unstated assumption rather than a deliberate design choice.

Cause 2: transientNeedles in internal/agent/retry.go held connection refused, connection reset, unexpected eof and i/o timeout, but not connection closed, mid-response, or enotimp. So even with the text present nothing matched.

Deliberate decisions made while implementing, which a reviewer reading only the diff would not know: capture the CLI's own 'API Error: ...' diagnostic through a bounded io.TeeReader sniffer in a new file internal/agent/claude_diagnostic.go rather than changing parseClaudeEvents' signature, because a signature change would have churned roughly fifteen existing test call sites for no behavioural gain; match the raw stdout line so that both the stream-json assistant event that normally carries the text and any plain text claude writes directly are covered by one check; append the diagnostic after stderr rather than replacing it, and skip it when stderr already carries the same text, so existing stderr-based diagnostics keep their leading position; bound the retained diagnostic to 512 bytes and the pending-line buffer to 64 KiB so a pathological stdout line can neither blow up the returned error nor grow memory without bound; and deliberately extend only the non-zero-exit path, not the parse-error path, because a dropped API stream makes claude exit non-zero after a clean stdout EOF rather than failing the scanner.

Scope was kept deliberately tight because this is a bug-fix contribution from an outside contributor: no refactor of the retry machinery, no change to claudeMaxRetries, no change to any existing needle or label, and no documentation restructuring.

The risk is bounded by design: classifyTransient still refuses context.Canceled and context.DeadlineExceeded, and runWithRetry still caps at four attempts with exponential backoff, so this widens which errors are retried without creating an unbounded retry path.

Each cause has a regression test proven to fail without its own fix. Reverting only the error composition makes TestClaudeAgent_StdoutAPIErrorIsRetriedWithEmptyStderr fail with the exact production string 'claude exited: exit status 1: '. Reverting only the needles makes that same test fail as permanent-classified, plus the two new classifyTransient table cases. The stdout test drives the real claudeAgent.Run through the repository's existing re-exec helper-binary pattern with a new api-error-stdout helper mode (assistant text on stdout, empty stderr, exit 1) and asserts four attempts, so it is an end-to-end regression test rather than a needle-list check.

Observed impact across 244 runs on one installation: 31 agent invocations logged an API error, 17 'Connection closed mid-response' plus 14 'Unable to connect to API (ENOTIMP)', about 1.2 percent of agent invocations, and every one of them failed its step without a single retry.

make fmt, make lint, make test (the full -race suite) and make e2e all pass locally. CHANGELOG.md and .release-please-manifest.json are deliberately untouched, per CONTRIBUTING.md.

## What Changed

- `internal/agent/claude.go` now composes the non-zero-exit error from stderr **plus** the CLI's own `API Error: ...` diagnostic, which Claude Code writes to stdout while leaving stderr empty. The diagnostic is captured by a new bounded `io.TeeReader` sniffer in `internal/agent/claude_diagnostic.go` (512-byte retained diagnostic, 64 KiB pending-line buffer), so `parseClaudeEvents`' signature is untouched; it is appended after stderr and skipped when stderr already carries the same text.
- The sniffer only retains a marker that begins a raw stdout line or opens a JSON string value, so tool output or assistant text merely echoing `API Error:` mid-line cannot plant a stale diagnostic (review flagged the broader "anywhere in the line" match; a narrower residual for content starting exactly with the marker is noted as open info).
- `transientNeedles` in `internal/agent/retry.go` gains `connection closed`, `mid-response`, and `enotimp`, so these transport drops now classify transient. `claudeMaxRetries`, the backoff, and the existing needles are unchanged, and `classifyTransient` still refuses `context.Canceled`/`context.DeadlineExceeded`, so the four-attempt cap still bounds retries.

## Risk Assessment

✅ Low: The fix round tightens the marker match exactly as instructed, preserves every constraint the intent marks as required, adds five negative regression cases, and leaves only a narrow residual false-positive path whose cost stays bounded by the existing four-attempt retry cap.

## Testing

I reproduced the reported production failure end-to-end by driving the real claude adapter against a claude that reports "API Error: Connection closed mid-response." as assistant text on stdout with an empty stderr and exits non-zero, and captured the step-log lines a user actually sees: before the fix the step failed after a single attempt with the bare error "claude exited: exit status 1: ", and after the fix the same failure is logged as transient and retried to the full four attempts with label "connection closed". I also confirmed each cause is independently sufficient by reverting the error composition alone (reproduces the exact bare production string and fails the new stdout regression test) and the needle list alone (diagnostic text present but still classified permanent, failing both new classifyTransient cases), then ran the changed package's targeted tests and the full internal/agent package under -race, all passing, and left the worktree clean.

<details>
<summary>Evidence: Step log before the fix (production behaviour: 1 attempt, diagnostic discarded)</summary>

<code>[step log] claude started pid=377185&#10;[step log] claude exited pid=377185 error=claude exited: exit status 1:&#10;&#10;claude subprocess attempts: 1 (claudeMaxRetries=3)&#10;classifier verdict: transient=false label=&#34;&#34;&#10;final step error: claude exited: exit status 1:</code>

```text
[step log] claude started pid=377185
[step log] claude exited pid=377185 error=claude exited: exit status 1: 

claude subprocess attempts: 1 (claudeMaxRetries=3)
classifier verdict: transient=false label=""
final step error: claude exited: exit status 1: 
```
</details>
<details>
<summary>Evidence: Step log after the fix (diagnostic carried, 4 attempts, transient label)</summary>

<code>[step log] claude started pid=370368&#10;[step log] claude exited pid=370368 error=claude exited: exit status 1: API Error: Connection closed mid-response. The response above may be incomplete.&#10;[step log] claude retrying after transient error &#34;connection closed&#34; (attempt 2/4)&#10;[step log] claude started pid=370378&#10;[step log] claude exited pid=370378 error=claude exited: exit status 1: API Error: Connection closed mid-response. The response above may be incomplete.&#10;[step log] claude retrying after transient error &#34;connection closed&#34; (attempt 3/4)&#10;[step log] claude started pid=370387&#10;[step log] claude exited pid=370387 error=claude exited: exit status 1: API Error: Connection closed mid-response. The response above may be incomplete.&#10;[step log] claude retrying after transient error &#34;connection closed&#34; (attempt 4/4)&#10;[step log] claude started pid=370403&#10;[step log] claude exited pid=370403 error=claude exited: exit status 1: API Error: Connection closed mid-response. The response above may be incomplete.&#10;&#10;claude subprocess attempts: 4 (claudeMaxRetries=3)&#10;classifier verdict: transient=true label=&#34;connection closed&#34;&#10;final step error: claude exited: exit status 1: API Error: Connection closed mid-response. The response above may be incomplete.</code>

```text
[step log] claude started pid=370368
[step log] claude exited pid=370368 error=claude exited: exit status 1: API Error: Connection closed mid-response. The response above may be incomplete.
[step log] claude retrying after transient error "connection closed" (attempt 2/4)
[step log] claude started pid=370378
[step log] claude exited pid=370378 error=claude exited: exit status 1: API Error: Connection closed mid-response. The response above may be incomplete.
[step log] claude retrying after transient error "connection closed" (attempt 3/4)
[step log] claude started pid=370387
[step log] claude exited pid=370387 error=claude exited: exit status 1: API Error: Connection closed mid-response. The response above may be incomplete.
[step log] claude retrying after transient error "connection closed" (attempt 4/4)
[step log] claude started pid=370403
[step log] claude exited pid=370403 error=claude exited: exit status 1: API Error: Connection closed mid-response. The response above may be incomplete.

claude subprocess attempts: 4 (claudeMaxRetries=3)
classifier verdict: transient=true label="connection closed"
final step error: claude exited: exit status 1: API Error: Connection closed mid-response. The response above may be incomplete.
```
</details>
<details>
<summary>Evidence: Cause isolation: each fix reverted alone reproduces the bug</summary>

<code>--- CAUSE 1 ONLY REVERTED (stderr-only error composition) ---&#10;[step log] claude exited pid=384932 error=claude exited: exit status 1:&#10;claude subprocess attempts: 1 (claudeMaxRetries=3) transient=false&#10;FAIL TestClaudeAgent_StdoutAPIErrorIsRetriedWithEmptyStderr&#10;claude_test.go:654: error &#34;claude exited: exit status 1: &#34; must carry the stdout API-error diagnostic&#10;&#10;--- CAUSE 2 ONLY REVERTED (missing transientNeedles) ---&#10;[step log] claude exited pid=386306 error=claude exited: exit status 1: API Error: Connection closed mid-response. The response above may be incomplete.&#10;claude subprocess attempts: 1 (claudeMaxRetries=3) transient=false&#10;FAIL TestClassifyTransient_Positive/connection_closed_mid-response_on_stdout&#10;FAIL TestClassifyTransient_Positive/unable_to_connect_ENOTIMP</code>

```text
Each cause independently reproduces the bug (real claudeAgent.Run, claude emits
"API Error: Connection closed mid-response." on stdout, empty stderr, exit 1).

--- CAUSE 1 ONLY REVERTED (stderr-only error composition) ---
[step log] claude exited pid=384932 error=claude exited: exit status 1: 
claude subprocess attempts: 1 (claudeMaxRetries=3)
classifier verdict: transient=false label=""
FAIL TestClaudeAgent_StdoutAPIErrorIsRetriedWithEmptyStderr
  claude_test.go:654: error "claude exited: exit status 1: " must carry the stdout API-error diagnostic

--- CAUSE 2 ONLY REVERTED (missing transientNeedles) ---
[step log] claude exited pid=386306 error=claude exited: exit status 1: API Error: Connection closed mid-response. The response above may be incomplete.
claude subprocess attempts: 1 (claudeMaxRetries=3)
classifier verdict: transient=false label=""
FAIL TestClassifyTransient_Positive/connection_closed_mid-response_on_stdout
FAIL TestClassifyTransient_Positive/unable_to_connect_ENOTIMP
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `internal/agent/claude_diagnostic.go:62` - claudeAPIErrorSniffer.consume retains any stdout line containing &#34;API Error:&#34; anywhere in the stream, not just a terminal diagnostic. Claude&#39;s stdout carries tool_result and assistant text, so an agent that reads/greps a log containing that marker (this repo&#39;s own agent logs hold those exact strings, per the reported 31 invocations) leaves a stale &#34;Connection closed mid-response&#34; in the sniffer. If the process then exits non-zero for an unrelated permanent reason, claudeExitDiagnostic (claude.go:115) appends it and classifyTransient reports transient, so a permanent failure is retried three extra times with full agent invocations and surfaces a misleading error string. Bounded by the four-attempt cap, but the false-positive path is concrete. Consider narrowing capture (e.g. only retain a diagnostic seen with no later successful assistant/result event, or clear s.last when a subsequent result event arrives) — flagged rather than auto-fixed because the intent states raw-line matching was a deliberate choice.

🔧 Fix: require API Error marker to begin the diagnostic line
1 info still open:
- ℹ️ `internal/agent/claude_diagnostic.go:108` - claudeAPIErrorJSONValueStart accepts the marker opening any JSON string value, not specifically a &#34;text&#34;: value as the fix instruction described (&#34;the marker immediately follows the opening quote of a JSON text value&#34;). A tool_result whose captured output begins exactly with the marker — e.g. an agent running `grep -oh &#34;API Error: .*&#34; logs/agent.log`, whose stream-json event is {&#34;type&#34;:&#34;user&#34;,...,&#34;content&#34;:&#34;API Error: Connection closed mid-response...&#34;} — still plants a diagnostic. The existing &#34;tool result echoing a log file&#34; test case only passes because its content carries a &#34;logs/agent.log:42: &#34; prefix. This is a much narrower residual than the mid-text echo that was closed, and the four-attempt cap still bounds the cost; anchoring the match to a preceding &#34;text&#34;: key would close it if you want the last of it.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./internal/agent/ -run 'TestClaudeAgent_StdoutAPIErrorIsRetriedWithEmptyStderr|TestClaudeAgent_ExitDiagnosticPrefersStderrAndAppendsStdout|TestClassifyTransient|TestClaudeAPIError|TestClaudeStdinHelper' -v`
- <code>`go test -race ./internal/agent/` (whole changed package)</code>
- <code>Manual end-to-end step-log transcript: drove the real `claudeAgent.Run` through the re-exec `api-error-stdout` helper mode (assistant text on stdout, empty stderr, exit 1) with an `OnLifecycle` hook mirroring `executor.go` `onAgentLifecycle` -&gt; `writeLog`, capturing the retry lines a user sees in `axi logs`</code>
- <code>Cause-isolation reverts: restored `internal/agent/claude.go` from base only, then `internal/agent/retry.go` from base only, re-running the transcript harness plus `TestClaudeAgent_StdoutAPIErrorIsRetriedWithEmptyStderr` and `TestClassifyTransient_Positive` under each</code>
- <code>Verified the temporary evidence harness file was deleted and `git status --porcelain` is clean</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/src/content/docs/guides/agents.md:234` - Judgment call, no edit made: docs/src/content/docs/guides/agents.md:234 states transient API and network failures are retried up to three times with exponential backoff. That sentence remains true after this change (claudeMaxRetries and the backoff are untouched) and it deliberately does not enumerate which error strings classify as transient, so adding the new Claude stdout &#39;API Error:&#39; cases there would duplicate an implementation detail whose owner is internal/agent/retry.go and the comments in internal/agent/claude_diagnostic.go. Left unchanged on purpose.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
