### PR TITLE
feat(pipeline): add structured step attestations to PR bodies

### DIFF
--- a/.no-mistakes/evidence/fm/nm-pipeline-step-attestation-r1/pipeline-section.md
+++ b/.no-mistakes/evidence/fm/nm-pipeline-step-attestation-r1/pipeline-section.md
@@ -1,0 +1,33 @@
+## Pipeline
+
+Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)
+
+<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2c0baa438938e718a393680224ccba53e092893a","steps":[{"step":"review","status":"completed"},{"step":"test","status":"failed"},{"step":"document","status":"skipped"},{"step":"lint","status":"awaiting_approval"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->
+
+<details>
+<summary>❌ **Test** - failed</summary>
+
+Step failed.
+
+</details>
+
+<details>
+<summary>⚠️ **Review** - findings unavailable</summary>
+
+No round details recorded.
+
+</details>
+
+<details>
+<summary>⏭️ **Document** - skipped</summary>
+
+Step was skipped.
+
+</details>
+
+<details>
+<summary>⏸️ **Lint** - awaiting approval</summary>
+
+Waiting for user approval.
+
+</details>

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -218,15 +218,18 @@ Stores the PR URL in the database and streams it to the TUI.
 Immediately after the existing `Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)` signature, no-mistakes writes one stable HTML comment:
 
 ```html
-<!-- no-mistakes-pipeline-attestation:v1 {"steps":[{"step":"review","status":"completed"}]} -->
+<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"0123456789abcdef0123456789abcdef01234567","steps":[{"step":"review","status":"completed"}]} -->
 ```
 
-The `v1` payload is compact JSON with one required `steps` array. Every item has exactly these fields:
+The `v1` payload is compact JSON with these required fields:
+
+- `head_sha`: the exact git commit SHA recorded for the run when no-mistakes writes the PR body
+- `steps`: the ordered pipeline step snapshot; every item has exactly the fields below
 
 - `step`: the raw pipeline step name, such as `intent`, `rebase`, `review`, `test`, `document`, `lint`, `push`, `pr`, or `ci`
 - `status`: the raw [step status](#step-statuses) recorded for that step, such as `completed`, `skipped`, or `failed`
 
-Items are ordered by the fixed pipeline order and represent the exact database snapshot when no-mistakes creates or updates the PR body. The attestation includes `pr` and `ci` records even though their human-readable details are not shown in `## Pipeline`; at the normal PR write point those records are commonly `running` and `pending`. It is not refreshed after the PR step unless no-mistakes writes the body again.
+Items are ordered by the fixed pipeline order and represent the exact database snapshot when no-mistakes creates or updates the PR body. The attestation includes `pr` and `ci` records even though their human-readable details are not shown in `## Pipeline`; at the normal PR write point those records are commonly `running` and `pending`. The `head_sha` binds that snapshot to the commit it describes, so consumers can detect when a later push has made the comment stale. It is not refreshed after the PR step unless no-mistakes writes the body again.
 
 The comment is intentionally data only. It does not declare any step required, passed for a policy, compliant, or mergeable. Consumers can parse the versioned JSON without scraping prose and apply their own policy. The comment stays with the Pipeline header when no-mistakes truncates older human-readable update details to fit a PR-body limit.
 

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -203,6 +203,7 @@ Creates or updates a pull request.
 - PR title: agent-generated from the final branch delta with user intent when available, in conventional commit format (`type(scope): description` or `type: description`); user-facing product impact should use `feat` or `fix` so release automation can pick it up; when a scope is used, it should be the primary affected real module/package from the changed paths and kept broad rather than file-level. If drafting fails, the fallback uses the neutral title `chore: update pull request` rather than inferring scope from earlier commits.
 - The PR stage exclusively owns the complete branch-scope description. It drafts `## What Changed` from the actual final diff after local mutating stages finish, and its fallback lists the final changed paths and statuses.
 - PR body includes a `## Intent` section when user intent is available, the final-diff `## What Changed`, and regenerated `## Risk Assessment`, `## Testing`, and `## Pipeline` sections from recorded step results and rounds. Only `## What Changed` describes the complete final branch scope; the deterministic sections remain evidence for the commit each step inspected. Auto-fix results in `## Pipeline` render as an issue -> fix -> verification narrative using captured fix summaries, re-check success text, and any still-open findings; Test details also list the recorded commands.
+- `## Pipeline` keeps the existing human-readable signature and includes the stable structured step attestation documented below.
 - Generated PR bodies are capped at 63,488 bytes, leaving a 2 KB safety buffer below GitHub's 65,536-character body limit.
 - When a body would exceed that cap, the PR step first omits older `## Pipeline` update rounds at clean update boundaries, keeps the newest rounds when possible, and points reviewers to the run log for the full pipeline history.
 - Intent, `## What Changed`, risk, and testing sections are kept ahead of pipeline history; if those sections or the newest pipeline update are still too large, the PR step truncates at line or section boundaries and adds an explicit marker.
@@ -211,6 +212,23 @@ Creates or updates a pull request.
 - For Azure DevOps, the PR description is capped at 4000 characters (UTF-16 code units, matching .NET's measurement): the agent is told about the cap and asked to keep the `## What Changed` section compact; if the assembled body still overruns, the `## Testing` section is dropped first because it can embed artifact and log content, preferentially preserving Intent, What Changed, Risk Assessment, and Pipeline; a final connector-level clamp truncates with a visible marker as a last-resort backstop
 
 Stores the PR URL in the database and streams it to the TUI.
+
+### Pipeline step attestation
+
+Immediately after the existing `Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)` signature, no-mistakes writes one stable HTML comment:
+
+```html
+<!-- no-mistakes-pipeline-attestation:v1 {"steps":[{"step":"review","status":"completed"}]} -->
+```
+
+The `v1` payload is compact JSON with one required `steps` array. Every item has exactly these fields:
+
+- `step`: the raw pipeline step name, such as `intent`, `rebase`, `review`, `test`, `document`, `lint`, `push`, `pr`, or `ci`
+- `status`: the raw [step status](#step-statuses) recorded for that step, such as `completed`, `skipped`, or `failed`
+
+Items are ordered by the fixed pipeline order and represent the exact database snapshot when no-mistakes creates or updates the PR body. The attestation includes `pr` and `ci` records even though their human-readable details are not shown in `## Pipeline`; at the normal PR write point those records are commonly `running` and `pending`. It is not refreshed after the PR step unless no-mistakes writes the body again.
+
+The comment is intentionally data only. It does not declare any step required, passed for a policy, compliant, or mergeable. Consumers can parse the versioned JSON without scraping prose and apply their own policy. The comment stays with the Pipeline header when no-mistakes truncates older human-readable update details to fit a PR-body limit.
 
 ## CI
 

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -538,6 +538,18 @@ func splitPipelineSectionHeader(pipelineMD string) (string, string) {
 	}
 
 	headerEnd := len(heading) + introEnd + len("\n\n")
+	// The generated attestation is data, not an update detail. Keep it in the
+	// fixed header so PR-body truncation never drops the machine-readable
+	// snapshot while omitting older human-readable update rounds.
+	rest = pipelineMD[headerEnd:]
+	if strings.HasPrefix(rest, pipelineAttestationCommentPrefix) {
+		if end := strings.Index(rest, pipelineAttestationCommentClosingToken); end >= 0 {
+			headerEnd += end + len(pipelineAttestationCommentClosingToken)
+			if strings.HasPrefix(pipelineMD[headerEnd:], "\n\n") {
+				headerEnd += len("\n\n")
+			}
+		}
+	}
 	return pipelineMD[:headerEnd], pipelineMD[headerEnd:]
 }
 

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -280,38 +280,53 @@ func assemblePRBody(sctx *pipeline.StepContext, whatChanged, riskLine, testingMD
 			return core
 		}
 	}
-	return prependIntentSectionWithinLimit(sections, sctx, bodyLimit, false)
+	return assemblePRBodyCoreWithinLimit(sctx, whatChanged, riskLine, pipelineMD, bodyLimit)
 }
 
-func prependIntentSectionWithinLimit(body string, sctx *pipeline.StepContext, bodyLimit int, byteLimit bool) string {
-	if bodyLimit <= 0 {
-		return prependIntentSection(body, sctx)
+func assemblePRBodyCoreWithinLimit(sctx *pipeline.StepContext, whatChanged, riskLine, pipelineMD string, bodyLimit int) string {
+	prefix := prependIntentSection(appendGeneratedSections(whatChanged, riskLine, "", ""), sctx)
+	if pipelineMD == "" {
+		return scm.ClampPRBody(prefix, bodyLimit)
 	}
-	bodyLen := scm.PRBodyLen(body)
-	separatorLen := scm.PRBodyLen("\n\n")
-	if byteLimit {
-		bodyLen = len(body)
-		separatorLen = len("\n\n")
+
+	header, _ := splitPipelineSectionHeader(pipelineMD)
+	headerLen := scm.PRBodyLen(header)
+	if header == "" || headerLen > bodyLimit {
+		return scm.ClampPRBody(prefix+"\n\n"+pipelineMD, bodyLimit)
 	}
-	if bodyLen >= bodyLimit {
-		if byteLimit {
-			return truncateTextAtLineBoundary(body, bodyLimit, essentialPRBodyTruncationMarker())
-		}
-		return scm.ClampPRBody(body, bodyLimit)
+
+	separator := "\n\n"
+	prefixBudget := bodyLimit - headerLen - scm.PRBodyLen(separator)
+	if prefixBudget <= 0 {
+		return header
 	}
-	cleaned := cleanedUserIntent(sctx)
-	if cleaned == "" {
-		return body
+	prefix = scm.ClampPRBody(prefix, prefixBudget)
+	if scm.PRBodyLen(prefix) > prefixBudget {
+		prefix = ""
+		separator = ""
 	}
-	intent := "## Intent\n\n" + cleaned
-	intentBudget := bodyLimit - bodyLen - separatorLen
-	if intentBudget <= 0 {
-		return body
+	pipelineBudget := bodyLimit - scm.PRBodyLen(prefix) - scm.PRBodyLen(separator)
+	pipeline := clampPipelineSectionWithinLimit(pipelineMD, pipelineBudget)
+	return prefix + separator + pipeline
+}
+
+func clampPipelineSectionWithinLimit(pipelineMD string, bodyLimit int) string {
+	if scm.PRBodyLen(pipelineMD) <= bodyLimit {
+		return pipelineMD
 	}
-	if byteLimit {
-		return truncateTextAtLineBoundary(intent, intentBudget, essentialPRBodyTruncationMarker()) + "\n\n" + body
+	header, updates := splitPipelineSectionHeader(pipelineMD)
+	if header == "" || scm.PRBodyLen(header) > bodyLimit {
+		return scm.ClampPRBody(pipelineMD, bodyLimit)
 	}
-	return scm.ClampPRBody(intent, intentBudget) + "\n\n" + body
+	updateBudget := bodyLimit - scm.PRBodyLen(header)
+	if updateBudget <= 0 {
+		return header
+	}
+	updates = scm.ClampPRBody(updates, updateBudget)
+	if scm.PRBodyLen(updates) > updateBudget {
+		return header
+	}
+	return header + updates
 }
 
 func appendGeneratedSections(body, riskLine, testingMD, pipelineMD string) string {
@@ -333,7 +348,8 @@ func buildPRBody(body, riskLine, testingMD, pipelineMD string, sctx *pipeline.St
 		return intent + separator + sections
 	}
 	sectionsBudget := maxPullRequestBodyBytes - len(separator) - len(intent)
-	if sectionsBudget > 0 {
+	minimumSectionsBytes := len(pipelineSectionHeader(pipelineMD))
+	if sectionsBudget > 0 && (minimumSectionsBytes == 0 || sectionsBudget >= minimumSectionsBytes) {
 		sections = appendGeneratedSectionsToCleanBodyWithinLimit(body, riskLine, testingMD, pipelineMD, sectionsBudget)
 		return intent + separator + sections
 	}
@@ -387,19 +403,22 @@ func essentialPRBodyWithinLimit(body, generatedSections string) string {
 
 func essentialPRBodyWithinPipelineBudget(body, generatedSections, pipelineMD string, maxBytes int) string {
 	minPipeline := minimumPipelineRetainingLatestUpdate(pipelineMD)
-	if minPipeline == "" {
+	if minPipeline == "" || len(minPipeline) > maxBytes {
 		minPipeline = minimumPipelineOmissionSection(pipelineMD)
-		if minPipeline == "" {
-			return essentialPRBodyWithinBudget(body, generatedSections, maxBytes)
-		}
+	}
+	if minPipeline == "" || len(minPipeline) > maxBytes {
+		minPipeline = pipelineSectionHeader(pipelineMD)
+	}
+	if minPipeline == "" || len(minPipeline) > maxBytes {
+		return essentialPRBodyWithinBudget(body, generatedSections, maxBytes)
 	}
 
 	prefixBudget := maxBytes - len(minPipeline)
 	if body != "" || generatedSections != "" {
 		prefixBudget -= len("\n\n")
 	}
-	if prefixBudget <= 0 || len(generatedSections) > prefixBudget {
-		return essentialPRBodyWithinBudget(body, generatedSections, maxBytes)
+	if prefixBudget <= 0 {
+		return ""
 	}
 	return essentialPRBodyWithinBudget(body, generatedSections, prefixBudget)
 }
@@ -522,7 +541,15 @@ func pipelineOmissionSectionWithinLimit(header string, omitted, maxBytes int) st
 	if len(markerOnly) <= maxBytes {
 		return markerOnly
 	}
+	if len(header) <= maxBytes {
+		return header
+	}
 	return ""
+}
+
+func pipelineSectionHeader(pipelineMD string) string {
+	header, _ := splitPipelineSectionHeader(pipelineMD)
+	return header
 }
 
 func splitPipelineSectionHeader(pipelineMD string) (string, string) {

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -224,7 +224,7 @@ func (s *PRStep) buildPipelineSection(sctx *pipeline.StepContext) (pipelineMD, r
 		rounds[sr.ID] = r
 	}
 
-	pipelineMD, riskLine = BuildPipelineSummary(steps, rounds)
+	pipelineMD, riskLine = BuildPipelineSummary(steps, rounds, sctx.Run.HeadSHA)
 	testingMD = BuildTestingSummaryForPR(steps, rounds, sctx.Repo.UpstreamURL, sctx.Run.HeadSHA, sctx.WorkDir)
 	return pipelineMD, riskLine, testingMD
 }

--- a/internal/pipeline/steps/pr_test.go
+++ b/internal/pipeline/steps/pr_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
 	"github.com/kunchenguid/no-mistakes/internal/config"
+	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/scm"
 	"github.com/kunchenguid/no-mistakes/internal/types"
@@ -883,6 +884,23 @@ func TestAppendGeneratedSections_TruncatesPipelineUpdatesBeforeGitHubLimit(t *te
 	assertNoPartialRoundLinesForTest(t, got, rounds)
 	if strings.Count(got, "<details>") != strings.Count(got, "</details>") {
 		t.Fatalf("expected details tags to remain balanced, got:\n%s", got)
+	}
+}
+
+func TestAppendGeneratedSections_RetainsPipelineAttestationWhenTruncated(t *testing.T) {
+	steps := []*db.StepResult{
+		{StepName: types.StepReview, Status: types.StepStatusCompleted},
+		{StepName: types.StepTest, Status: types.StepStatusSkipped},
+	}
+	attestation := buildPipelineAttestation(steps)
+	pipelineMD := pipelineMarkdownForTest(strings.Repeat("review round - "+strings.Repeat("x", 1000), 100))
+	pipelineMD = strings.Replace(pipelineMD, noMistakesPRSignature+"\n\n", noMistakesPRSignature+"\n\n"+attestation+"\n\n", 1)
+
+	got := appendGeneratedSections("## What Changed\n\n- summary", "", "", pipelineMD)
+
+	assertGitHubBodyLimitForTest(t, got)
+	if !strings.Contains(got, attestation) {
+		t.Fatalf("expected truncated PR body to retain the pipeline attestation, got:\n%s", got)
 	}
 }
 

--- a/internal/pipeline/steps/pr_test.go
+++ b/internal/pipeline/steps/pr_test.go
@@ -801,6 +801,30 @@ func TestAssemblePRBody_ClampsWhenCoreAloneExceedsCap(t *testing.T) {
 	}
 }
 
+func TestAssemblePRBody_RetainsAttestationWhenCoreExceedsAzureCap(t *testing.T) {
+	t.Parallel()
+	sctx := &pipeline.StepContext{UserIntent: strings.Repeat("intent 😀 ", 1000)}
+	limit := scm.MaxPRBodyChars(scm.ProviderAzureDevOps)
+	steps := []*db.StepResult{
+		{StepName: types.StepReview, Status: types.StepStatusCompleted},
+		{StepName: types.StepTest, Status: types.StepStatusFailed},
+	}
+	attestation := buildPipelineAttestation(steps)
+	pipelineMD := pipelineMarkdownForTest(strings.Repeat("review detail 😀 ", 1000))
+	pipelineMD = strings.Replace(pipelineMD, noMistakesPRSignature+"\n\n", noMistakesPRSignature+"\n\n"+attestation+"\n\n", 1)
+
+	got := assemblePRBody(sctx, "## What Changed\n\n"+strings.Repeat("change 😀 ", 1000), strings.Repeat("risk 😀 ", 1000), "", pipelineMD, limit)
+
+	if scm.PRBodyLen(got) > limit {
+		t.Fatalf("assembled body = %d units, want <= %d", scm.PRBodyLen(got), limit)
+	}
+	for _, want := range []string{"## Pipeline", noMistakesPRSignature, attestation} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("budgeted body dropped required pipeline content %q:\n%s", want, got)
+		}
+	}
+}
+
 func prTruncationTail() string {
 	// Mirror of scm's truncation marker for assertions; kept here so the test
 	// reads naturally without exporting the constant.
@@ -901,6 +925,30 @@ func TestAppendGeneratedSections_RetainsPipelineAttestationWhenTruncated(t *test
 	assertGitHubBodyLimitForTest(t, got)
 	if !strings.Contains(got, attestation) {
 		t.Fatalf("expected truncated PR body to retain the pipeline attestation, got:\n%s", got)
+	}
+}
+
+func TestAppendGeneratedSections_RetainsAttestationWhenEssentialSectionsOverflow(t *testing.T) {
+	steps := []*db.StepResult{
+		{StepName: types.StepReview, Status: types.StepStatusCompleted},
+		{StepName: types.StepTest, Status: types.StepStatusFailed},
+	}
+	attestation := buildPipelineAttestation(steps)
+	pipelineMD := pipelineMarkdownForTest("review round 001")
+	pipelineMD = strings.Replace(pipelineMD, noMistakesPRSignature+"\n\n", noMistakesPRSignature+"\n\n"+attestation+"\n\n", 1)
+
+	got := appendGeneratedSections(
+		"## What Changed\n\n"+strings.Repeat("change detail\n", 5000),
+		strings.Repeat("risk detail ", 5000),
+		"## Testing\n\n"+strings.Repeat("test detail\n", 5000),
+		pipelineMD,
+	)
+
+	assertGitHubBodyLimitForTest(t, got)
+	for _, want := range []string{"## Pipeline", noMistakesPRSignature, attestation} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("budgeted body dropped required pipeline content %q:\n%s", want, got)
+		}
 	}
 }
 

--- a/internal/pipeline/steps/pr_test.go
+++ b/internal/pipeline/steps/pr_test.go
@@ -809,7 +809,7 @@ func TestAssemblePRBody_RetainsAttestationWhenCoreExceedsAzureCap(t *testing.T) 
 		{StepName: types.StepReview, Status: types.StepStatusCompleted},
 		{StepName: types.StepTest, Status: types.StepStatusFailed},
 	}
-	attestation := buildPipelineAttestation(steps)
+	attestation := buildPipelineAttestation(steps, testPipelineHeadSHA)
 	pipelineMD := pipelineMarkdownForTest(strings.Repeat("review detail 😀 ", 1000))
 	pipelineMD = strings.Replace(pipelineMD, noMistakesPRSignature+"\n\n", noMistakesPRSignature+"\n\n"+attestation+"\n\n", 1)
 
@@ -916,7 +916,7 @@ func TestAppendGeneratedSections_RetainsPipelineAttestationWhenTruncated(t *test
 		{StepName: types.StepReview, Status: types.StepStatusCompleted},
 		{StepName: types.StepTest, Status: types.StepStatusSkipped},
 	}
-	attestation := buildPipelineAttestation(steps)
+	attestation := buildPipelineAttestation(steps, testPipelineHeadSHA)
 	pipelineMD := pipelineMarkdownForTest(strings.Repeat("review round - "+strings.Repeat("x", 1000), 100))
 	pipelineMD = strings.Replace(pipelineMD, noMistakesPRSignature+"\n\n", noMistakesPRSignature+"\n\n"+attestation+"\n\n", 1)
 
@@ -933,7 +933,7 @@ func TestAppendGeneratedSections_RetainsAttestationWhenEssentialSectionsOverflow
 		{StepName: types.StepReview, Status: types.StepStatusCompleted},
 		{StepName: types.StepTest, Status: types.StepStatusFailed},
 	}
-	attestation := buildPipelineAttestation(steps)
+	attestation := buildPipelineAttestation(steps, testPipelineHeadSHA)
 	pipelineMD := pipelineMarkdownForTest("review round 001")
 	pipelineMD = strings.Replace(pipelineMD, noMistakesPRSignature+"\n\n", noMistakesPRSignature+"\n\n"+attestation+"\n\n", 1)
 
@@ -1275,6 +1275,10 @@ func TestPRStep_CreateKeepsGeneratedSectionsAfterOversizedIntent(t *testing.T) {
 
 	body := readFakeGHBodyArg(t, logFile)
 	assertGitHubBodyLimitForTest(t, body)
+	attestation := parsePipelineAttestationForTest(t, body)
+	if attestation.HeadSHA != headSHA {
+		t.Fatalf("attested head = %q, want created PR head %q", attestation.HeadSHA, headSHA)
+	}
 	for _, want := range []string{
 		"## Intent",
 		"Keep generated sections visible.",
@@ -1464,6 +1468,24 @@ func pipelineMarkdownForTest(rounds ...string) string {
 	}
 	b.WriteString("</details>\n")
 	return b.String()
+}
+
+func parsePipelineAttestationForTest(t *testing.T, body string) pipelineAttestation {
+	t.Helper()
+	start := strings.Index(body, pipelineAttestationCommentPrefix)
+	if start < 0 {
+		t.Fatalf("PR body missing pipeline attestation:\n%s", body)
+	}
+	start += len(pipelineAttestationCommentPrefix)
+	end := strings.Index(body[start:], pipelineAttestationCommentClosingToken)
+	if end < 0 {
+		t.Fatalf("PR body contains unclosed pipeline attestation:\n%s", body)
+	}
+	var attestation pipelineAttestation
+	if err := json.Unmarshal([]byte(body[start:start+end]), &attestation); err != nil {
+		t.Fatalf("parse pipeline attestation: %v", err)
+	}
+	return attestation
 }
 
 func readFakeGHBodyArg(t *testing.T, logFile string) string {

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -2,12 +2,14 @@ package steps
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"html"
 	"net/url"
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -17,10 +19,21 @@ import (
 )
 
 const (
-	maxEmbeddedArtifactBytes       = 16 * 1024
-	maxEmbeddedArtifactsTotalBytes = 32 * 1024
-	noMistakesPRSignature          = "Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)"
+	maxEmbeddedArtifactBytes               = 16 * 1024
+	maxEmbeddedArtifactsTotalBytes         = 32 * 1024
+	noMistakesPRSignature                  = "Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)"
+	pipelineAttestationCommentPrefix       = "<!-- no-mistakes-pipeline-attestation:v1 "
+	pipelineAttestationCommentClosingToken = " -->"
 )
+
+type pipelineAttestation struct {
+	Steps []pipelineAttestationStep `json:"steps"`
+}
+
+type pipelineAttestationStep struct {
+	Step   types.StepName   `json:"step"`
+	Status types.StepStatus `json:"status"`
+}
 
 type testingArtifactRenderState struct {
 	remainingEmbeddedBytes int
@@ -63,6 +76,8 @@ func BuildPipelineSummary(steps []*db.StepResult, rounds map[string][]*db.StepRo
 	b.WriteString("## Pipeline\n\n")
 	b.WriteString(noMistakesPRSignature)
 	b.WriteString("\n\n")
+	b.WriteString(buildPipelineAttestation(steps))
+	b.WriteString("\n\n")
 	for i, detail := range detailBlocks {
 		if i > 0 {
 			b.WriteString("\n")
@@ -72,6 +87,34 @@ func BuildPipelineSummary(steps []*db.StepResult, rounds map[string][]*db.StepRo
 
 	riskLine := extractRiskLine(steps, rounds)
 	return b.String(), riskLine
+}
+
+// buildPipelineAttestation records the exact step lifecycle snapshot available
+// when no-mistakes writes the PR body. Its compact JSON is deliberately data
+// only: consumers decide their own policy from the step names and statuses.
+func buildPipelineAttestation(steps []*db.StepResult) string {
+	attestation := pipelineAttestation{Steps: make([]pipelineAttestationStep, 0, len(steps))}
+	for _, sr := range steps {
+		if sr == nil {
+			continue
+		}
+		attestation.Steps = append(attestation.Steps, pipelineAttestationStep{
+			Step:   sr.StepName,
+			Status: sr.Status,
+		})
+	}
+	sort.SliceStable(attestation.Steps, func(i, j int) bool {
+		left, right := attestation.Steps[i].Step, attestation.Steps[j].Step
+		if left.Order() != right.Order() {
+			return left.Order() < right.Order()
+		}
+		return left < right
+	})
+	payload, err := json.Marshal(attestation)
+	if err != nil {
+		return ""
+	}
+	return pipelineAttestationCommentPrefix + string(payload) + pipelineAttestationCommentClosingToken
 }
 
 // BuildTestingSummary extracts a deterministic Testing section from the test step.

--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -27,7 +27,8 @@ const (
 )
 
 type pipelineAttestation struct {
-	Steps []pipelineAttestationStep `json:"steps"`
+	HeadSHA string                    `json:"head_sha"`
+	Steps   []pipelineAttestationStep `json:"steps"`
 }
 
 type pipelineAttestationStep struct {
@@ -50,7 +51,7 @@ type testingSummaryOptions struct {
 }
 
 // BuildPipelineSummary produces a deterministic markdown section from step results and rounds.
-func BuildPipelineSummary(steps []*db.StepResult, rounds map[string][]*db.StepRound) (string, string) {
+func BuildPipelineSummary(steps []*db.StepResult, rounds map[string][]*db.StepRound, headSHA string) (string, string) {
 	if len(steps) == 0 {
 		return "", ""
 	}
@@ -76,7 +77,7 @@ func BuildPipelineSummary(steps []*db.StepResult, rounds map[string][]*db.StepRo
 	b.WriteString("## Pipeline\n\n")
 	b.WriteString(noMistakesPRSignature)
 	b.WriteString("\n\n")
-	b.WriteString(buildPipelineAttestation(steps))
+	b.WriteString(buildPipelineAttestation(steps, headSHA))
 	b.WriteString("\n\n")
 	for i, detail := range detailBlocks {
 		if i > 0 {
@@ -92,8 +93,11 @@ func BuildPipelineSummary(steps []*db.StepResult, rounds map[string][]*db.StepRo
 // buildPipelineAttestation records the exact step lifecycle snapshot available
 // when no-mistakes writes the PR body. Its compact JSON is deliberately data
 // only: consumers decide their own policy from the step names and statuses.
-func buildPipelineAttestation(steps []*db.StepResult) string {
-	attestation := pipelineAttestation{Steps: make([]pipelineAttestationStep, 0, len(steps))}
+func buildPipelineAttestation(steps []*db.StepResult, headSHA string) string {
+	attestation := pipelineAttestation{
+		HeadSHA: headSHA,
+		Steps:   make([]pipelineAttestationStep, 0, len(steps)),
+	}
 	for _, sr := range steps {
 		if sr == nil {
 			continue

--- a/internal/pipeline/steps/prsummary_risk_test.go
+++ b/internal/pipeline/steps/prsummary_risk_test.go
@@ -17,7 +17,7 @@ func TestBuildPipelineSummary_ReviewWithRisk(t *testing.T) {
 	rounds := map[string][]*db.StepRound{
 		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 1000}},
 	}
-	md, risk := BuildPipelineSummary(steps, rounds)
+	md, risk := BuildPipelineSummary(steps, rounds, testPipelineHeadSHA)
 
 	if !strings.Contains(md, "⚠️ **Review** - 1 warning") {
 		t.Errorf("expected findings count in review line, got:\n%s", md)
@@ -44,7 +44,7 @@ func TestBuildPipelineSummary_EscapesFindingDescriptionsInDetails(t *testing.T) 
 		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 1000}},
 	}
 
-	md, _ := BuildPipelineSummary(steps, rounds)
+	md, _ := BuildPipelineSummary(steps, rounds, testPipelineHeadSHA)
 
 	if !strings.Contains(md, "break &lt;/details&gt;&lt;summary&gt;oops&lt;/summary&gt; after") {
 		t.Errorf("expected finding description to be HTML-escaped, got:\n%s", md)
@@ -67,7 +67,7 @@ func TestBuildPipelineSummary_ReviewUsesFinalCleanState(t *testing.T) {
 			{Round: 2, Trigger: "auto_fix", FindingsJSON: &finalFindings, DurationMS: 700},
 		},
 	}
-	md, risk := BuildPipelineSummary(steps, rounds)
+	md, risk := BuildPipelineSummary(steps, rounds, testPipelineHeadSHA)
 
 	if !strings.Contains(md, "🔧 **Review**") {
 		t.Errorf("expected fixed review status, got:\n%s", md)
@@ -104,7 +104,7 @@ func TestBuildPipelineSummary_ReviewShowsWarningForUnresolvedRiskWithoutFindings
 	rounds := map[string][]*db.StepRound{
 		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 1000}},
 	}
-	md, risk := BuildPipelineSummary(steps, rounds)
+	md, risk := BuildPipelineSummary(steps, rounds, testPipelineHeadSHA)
 
 	if !strings.Contains(md, "⚠️ **Review** - medium risk") {
 		t.Errorf("expected medium-risk review status when no findings, got:\n%s", md)
@@ -129,7 +129,7 @@ func TestBuildPipelineSummary_ShowsParseFailureForInvalidRoundFindings(t *testin
 	rounds := map[string][]*db.StepRound{
 		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &invalidFindings, DurationMS: 1000}},
 	}
-	md, _ := BuildPipelineSummary(steps, rounds)
+	md, _ := BuildPipelineSummary(steps, rounds, testPipelineHeadSHA)
 
 	if !strings.Contains(md, "failed to parse findings") {
 		t.Errorf("expected parse failure message for invalid round findings, got:\n%s", md)
@@ -158,7 +158,7 @@ func TestBuildPipelineSummary_DoesNotClaimFixedWhenFinalFindingsUnreadable(t *te
 			{Round: 2, Trigger: "auto_fix", FindingsJSON: &invalidFinalFindings, DurationMS: 600},
 		},
 	}
-	md, _ := BuildPipelineSummary(steps, rounds)
+	md, _ := BuildPipelineSummary(steps, rounds, testPipelineHeadSHA)
 
 	if strings.Contains(md, "🔧 **Lint**") {
 		t.Errorf("did not expect fixed status when final findings are unreadable, got:\n%s", md)
@@ -184,7 +184,7 @@ func TestBuildPipelineSummary_ReviewDoesNotReuseInitialRiskWhenFinalUnreadable(t
 			{Round: 2, Trigger: "auto_fix", FindingsJSON: &invalidFinalFindings, DurationMS: 700},
 		},
 	}
-	md, risk := BuildPipelineSummary(steps, rounds)
+	md, risk := BuildPipelineSummary(steps, rounds, testPipelineHeadSHA)
 
 	if !strings.Contains(md, "⚠️ **Review** - findings unavailable") {
 		t.Errorf("expected unavailable review status when final findings are unreadable, got:\n%s", md)
@@ -206,7 +206,7 @@ func TestBuildPipelineSummary_FindingSeverityEmoji(t *testing.T) {
 	rounds := map[string][]*db.StepRound{
 		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 1000}},
 	}
-	md, risk := BuildPipelineSummary(steps, rounds)
+	md, risk := BuildPipelineSummary(steps, rounds, testPipelineHeadSHA)
 
 	if !strings.Contains(md, "🚨") {
 		t.Errorf("expected error emoji in details, got:\n%s", md)
@@ -237,7 +237,7 @@ func TestBuildPipelineSummary_ReviewUsesLatestRoundNotFirst(t *testing.T) {
 			{Round: 2, Trigger: "auto_fix", FindingsJSON: &latestFindings, DurationMS: 700},
 		},
 	}
-	_, risk := BuildPipelineSummary(steps, rounds)
+	_, risk := BuildPipelineSummary(steps, rounds, testPipelineHeadSHA)
 
 	if strings.Contains(risk, "initial concern") {
 		t.Errorf("expected latest round risk, not stale first round, got: %q", risk)

--- a/internal/pipeline/steps/prsummary_rounds_test.go
+++ b/internal/pipeline/steps/prsummary_rounds_test.go
@@ -20,7 +20,7 @@ func TestBuildPipelineSummary_AutoFix(t *testing.T) {
 			{Round: 2, Trigger: "auto_fix", DurationMS: 600},
 		},
 	}
-	md, _ := BuildPipelineSummary(steps, rounds)
+	md, _ := BuildPipelineSummary(steps, rounds, testPipelineHeadSHA)
 
 	// Should show wrench emoji for auto-fixed
 	if !strings.Contains(md, "🔧") {
@@ -59,7 +59,7 @@ func TestBuildPipelineSummary_AutoFixShowsFixSummary(t *testing.T) {
 			{Round: 2, Trigger: "auto_fix", FixSummary: &fixSummary, DurationMS: 600},
 		},
 	}
-	md, _ := BuildPipelineSummary(steps, rounds)
+	md, _ := BuildPipelineSummary(steps, rounds, testPipelineHeadSHA)
 
 	// The fix the agent actually applied must be surfaced - this is the data
 	// the old round-by-round layout dropped on the floor.
@@ -94,7 +94,7 @@ func TestBuildPipelineSummary_MultiRoundWithFollowUpFix(t *testing.T) {
 			{Round: 3, Trigger: "auto_fix", DurationMS: 700},
 		},
 	}
-	md, _ := BuildPipelineSummary(steps, rounds)
+	md, _ := BuildPipelineSummary(steps, rounds, testPipelineHeadSHA)
 
 	// Two fix attempts, the first leaving one issue open before the second
 	// cleared it - the narrative should show that chain.
@@ -127,7 +127,7 @@ func TestBuildPipelineSummary_LegacyUserFixRoundsRenderAsAutoFix(t *testing.T) {
 			{Round: 2, Trigger: "user_fix", DurationMS: 700},
 		},
 	}
-	md, _ := BuildPipelineSummary(steps, rounds)
+	md, _ := BuildPipelineSummary(steps, rounds, testPipelineHeadSHA)
 
 	if !strings.Contains(md, "auto-fixed") {
 		t.Errorf("expected legacy user_fix round to render as auto-fixed, got:\n%s", md)
@@ -155,7 +155,7 @@ func TestBuildPipelineSummary_MultiRoundStillFailing(t *testing.T) {
 			{Round: 2, Trigger: "auto_fix", FindingsJSON: &findings2, DurationMS: 600},
 		},
 	}
-	md, _ := BuildPipelineSummary(steps, rounds)
+	md, _ := BuildPipelineSummary(steps, rounds, testPipelineHeadSHA)
 
 	if strings.Contains(md, "auto-fixed") {
 		t.Errorf("did not expect fixed status when final round still has findings, got:\n%s", md)
@@ -179,7 +179,7 @@ func TestBuildPipelineSummary_UsesFinalFindingsWithoutInitialRoundData(t *testin
 			{Round: 1, Trigger: "initial", DurationMS: 1000},
 		},
 	}
-	md, _ := BuildPipelineSummary(steps, rounds)
+	md, _ := BuildPipelineSummary(steps, rounds, testPipelineHeadSHA)
 
 	if strings.Contains(md, "passed") {
 		t.Errorf("did not expect passed status when step result still has findings, got:\n%s", md)
@@ -207,7 +207,7 @@ func TestBuildPipelineSummary_FailedTestRoundIncludesTestedDetails(t *testing.T)
 		},
 	}
 
-	md, _ := BuildPipelineSummary(steps, rounds)
+	md, _ := BuildPipelineSummary(steps, rounds, testPipelineHeadSHA)
 
 	if !strings.Contains(md, "- `go test ./internal/cli -run '^TestDoctorBasic$' -count=1`") {
 		t.Fatalf("expected failed test round to include tested command details, got:\n%s", md)

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -1,6 +1,7 @@
 package steps
 
 import (
+	"encoding/json"
 	"fmt"
 	"html"
 	"os"
@@ -59,6 +60,75 @@ func TestBuildPipelineSummary_AllClean(t *testing.T) {
 	}
 	if risk != "" {
 		t.Errorf("expected empty risk for clean run, got: %q", risk)
+	}
+}
+
+func TestBuildPipelineSummary_EmitsStructuredStepAttestation(t *testing.T) {
+	t.Parallel()
+
+	steps := []*db.StepResult{
+		{ID: "ci", StepName: types.StepCI, Status: types.StepStatusPending},
+		{ID: "document", StepName: types.StepDocument, Status: types.StepStatusSkipped},
+		{ID: "review", StepName: types.StepReview, Status: types.StepStatusCompleted},
+		{ID: "test", StepName: types.StepTest, Status: types.StepStatusFailed},
+		{ID: "rebase", StepName: types.StepRebase, Status: types.StepStatusCompleted},
+		{ID: "lint", StepName: types.StepLint, Status: types.StepStatusAwaitingApproval},
+		{ID: "push", StepName: types.StepPush, Status: types.StepStatusCompleted},
+		{ID: "pr", StepName: types.StepPR, Status: types.StepStatusRunning},
+		{ID: "intent", StepName: types.StepIntent, Status: types.StepStatusSkipped},
+	}
+
+	got, _ := BuildPipelineSummary(steps, nil)
+	repeated, _ := BuildPipelineSummary(steps, nil)
+	if got != repeated {
+		t.Fatalf("attestation must be deterministic:\nfirst:\n%s\nsecond:\n%s", got, repeated)
+	}
+
+	const prefix = "<!-- no-mistakes-pipeline-attestation:v1 "
+	start := strings.Index(got, prefix)
+	if start < 0 {
+		t.Fatalf("pipeline summary missing attestation comment:\n%s", got)
+	}
+	end := strings.Index(got[start:], " -->")
+	if end < 0 {
+		t.Fatalf("attestation comment is not closed:\n%s", got)
+	}
+	var attestation struct {
+		Steps []struct {
+			Step   types.StepName   `json:"step"`
+			Status types.StepStatus `json:"status"`
+		} `json:"steps"`
+	}
+	payload := got[start+len(prefix) : start+end]
+	if err := json.Unmarshal([]byte(payload), &attestation); err != nil {
+		t.Fatalf("attestation payload must be JSON: %v\n%s", err, payload)
+	}
+
+	want := []struct {
+		step   types.StepName
+		status types.StepStatus
+	}{
+		{types.StepIntent, types.StepStatusSkipped},
+		{types.StepRebase, types.StepStatusCompleted},
+		{types.StepReview, types.StepStatusCompleted},
+		{types.StepTest, types.StepStatusFailed},
+		{types.StepDocument, types.StepStatusSkipped},
+		{types.StepLint, types.StepStatusAwaitingApproval},
+		{types.StepPush, types.StepStatusCompleted},
+		{types.StepPR, types.StepStatusRunning},
+		{types.StepCI, types.StepStatusPending},
+	}
+	if len(attestation.Steps) != len(want) {
+		t.Fatalf("attested %d steps, want %d: %+v", len(attestation.Steps), len(want), attestation.Steps)
+	}
+	for i, wantStep := range want {
+		if gotStep := attestation.Steps[i]; gotStep.Step != wantStep.step || gotStep.Status != wantStep.status {
+			t.Errorf("attested step %d = (%q, %q), want (%q, %q)", i, gotStep.Step, gotStep.Status, wantStep.step, wantStep.status)
+		}
+	}
+
+	if signatureAt, attestationAt := strings.Index(got, noMistakesPRSignature), strings.Index(got, prefix); signatureAt < 0 || attestationAt < signatureAt {
+		t.Fatalf("attestation must follow the existing signature:\n%s", got)
 	}
 }
 

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
+const testPipelineHeadSHA = "0123456789abcdef0123456789abcdef01234567"
+
 func TestNoMistakesRequiredWorkflowChecksPipelineSignature(t *testing.T) {
 	t.Parallel()
 
@@ -37,7 +39,7 @@ func TestBuildPipelineSummary_AllClean(t *testing.T) {
 		"s2": {{Round: 1, Trigger: "initial", DurationMS: 300}},
 		"s3": {{Round: 1, Trigger: "initial", DurationMS: 200}},
 	}
-	md, risk := BuildPipelineSummary(steps, rounds)
+	md, risk := BuildPipelineSummary(steps, rounds, testPipelineHeadSHA)
 
 	if !strings.Contains(md, "## Pipeline") {
 		t.Error("missing Pipeline heading")
@@ -78,8 +80,8 @@ func TestBuildPipelineSummary_EmitsStructuredStepAttestation(t *testing.T) {
 		{ID: "intent", StepName: types.StepIntent, Status: types.StepStatusSkipped},
 	}
 
-	got, _ := BuildPipelineSummary(steps, nil)
-	repeated, _ := BuildPipelineSummary(steps, nil)
+	got, _ := BuildPipelineSummary(steps, nil, testPipelineHeadSHA)
+	repeated, _ := BuildPipelineSummary(steps, nil, testPipelineHeadSHA)
 	if got != repeated {
 		t.Fatalf("attestation must be deterministic:\nfirst:\n%s\nsecond:\n%s", got, repeated)
 	}
@@ -94,7 +96,8 @@ func TestBuildPipelineSummary_EmitsStructuredStepAttestation(t *testing.T) {
 		t.Fatalf("attestation comment is not closed:\n%s", got)
 	}
 	var attestation struct {
-		Steps []struct {
+		HeadSHA string `json:"head_sha"`
+		Steps   []struct {
 			Step   types.StepName   `json:"step"`
 			Status types.StepStatus `json:"status"`
 		} `json:"steps"`
@@ -102,6 +105,9 @@ func TestBuildPipelineSummary_EmitsStructuredStepAttestation(t *testing.T) {
 	payload := got[start+len(prefix) : start+end]
 	if err := json.Unmarshal([]byte(payload), &attestation); err != nil {
 		t.Fatalf("attestation payload must be JSON: %v\n%s", err, payload)
+	}
+	if attestation.HeadSHA != testPipelineHeadSHA {
+		t.Fatalf("attested head = %q, want %q", attestation.HeadSHA, testPipelineHeadSHA)
 	}
 
 	want := []struct {
@@ -152,7 +158,7 @@ func TestBuildPipelineSummary_IncludesAllPipelineSteps(t *testing.T) {
 		"s6": {{Round: 1, Trigger: "initial", DurationMS: 700}},
 	}
 
-	md, _ := BuildPipelineSummary(steps, rounds)
+	md, _ := BuildPipelineSummary(steps, rounds, testPipelineHeadSHA)
 
 	for _, want := range []string{
 		"<summary>✅ **Rebase** - passed</summary>",
@@ -186,7 +192,7 @@ func TestBuildPipelineSummary_SkippedStep(t *testing.T) {
 		"s1": {},
 		"s2": {{Round: 1, Trigger: "initial", DurationMS: 300}},
 	}
-	md, _ := BuildPipelineSummary(steps, rounds)
+	md, _ := BuildPipelineSummary(steps, rounds, testPipelineHeadSHA)
 
 	if !strings.Contains(md, "⏭️") {
 		t.Errorf("expected skip emoji for skipped step, got:\n%s", md)
@@ -210,7 +216,7 @@ func TestBuildPipelineSummary_ExcludesPushPRCI(t *testing.T) {
 		"s3": {{Round: 1, Trigger: "initial", DurationMS: 200}},
 		"s4": {{Round: 1, Trigger: "initial", DurationMS: 300}},
 	}
-	md, _ := BuildPipelineSummary(steps, rounds)
+	md, _ := BuildPipelineSummary(steps, rounds, testPipelineHeadSHA)
 
 	for _, want := range []string{"**Push**"} {
 		if !strings.Contains(md, want) {
@@ -226,7 +232,7 @@ func TestBuildPipelineSummary_ExcludesPushPRCI(t *testing.T) {
 
 func TestBuildPipelineSummary_EmptySteps(t *testing.T) {
 	t.Parallel()
-	md, risk := BuildPipelineSummary(nil, nil)
+	md, risk := BuildPipelineSummary(nil, nil, testPipelineHeadSHA)
 	if md != "" {
 		t.Errorf("expected empty string for nil steps, got: %q", md)
 	}
@@ -244,7 +250,7 @@ func TestBuildPipelineSummary_RebaseWithConflicts(t *testing.T) {
 	rounds := map[string][]*db.StepRound{
 		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 2000}},
 	}
-	md, _ := BuildPipelineSummary(steps, rounds)
+	md, _ := BuildPipelineSummary(steps, rounds, testPipelineHeadSHA)
 
 	if !strings.Contains(md, "**Rebase**") {
 		t.Errorf("expected Rebase in output, got:\n%s", md)


### PR DESCRIPTION
## Intent

Ship structured pipeline step attestation in no-mistakes PR bodies. When no-mistakes writes or updates the PR body Pipeline section, emit a stable HTML comment containing faithful structured metadata about pipeline steps, including what ran and each step status plus any existing facts a later compliance consumer needs. This is data only: do not encode any opinion that a PR is compliant, required, passed by policy, or mergeable, and do not add a policy engine or hard-coded required-step list. Keep the existing human-readable ## Pipeline section and existing git push no-mistakes signature behavior, except for a minimal deterministic placement change if needed. Make the format stable and document its contract in the correct owned documentation. Add unit coverage that the comment is emitted, deterministic, and accurately distinguishes skipped, completed/passed, failed, and other real step-result statuses. Prefer extending BuildPipelineSummary and existing PR body writers. This is public product work with no fleet-private behavior. Do not change no-mistakes-required.yml pass/fail rules, require Review/Test/Document, roll out reusable workflows, or change Wheelhouse compliance policy.

## What Changed

- Add a stable, versioned HTML comment to PR Pipeline sections containing the recorded head SHA and deterministically ordered step names and raw statuses.
- Preserve the structured attestation alongside the existing human-readable pipeline signature when PR bodies are updated or truncated.
- Document the attestation contract and cover status fidelity, deterministic output, and body-size handling with unit tests.

## Risk Assessment

✅ Low: The stable, data-only attestation is commit-bound, preserves raw ordered step statuses, remains intact across supported PR-body truncation paths, and is documented with behavioral coverage.

## Testing

No baseline command was supplied; focused tests and executable-interface verification confirmed PR creation and updates emit deterministic, head-bound structured metadata, preserve the existing human-readable Pipeline section and signature, accurately retain real statuses, and keep the attestation through GitHub and Azure body truncation.

- Evidence: [Rendered PR Pipeline section with structured attestation](https://github.com/kunchenguid/no-mistakes/blob/af3cc01cef5f8b33e22ba8ddb3ca59a87ee9b95b/.no-mistakes/evidence/fm/nm-pipeline-step-attestation-r1/pipeline-section.md)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `internal/pipeline/steps/prsummary.go:79` - The required stable attestation is not preserved by every PR-body limit path. For example, an Azure DevOps body whose core exceeds 4,000 UTF-16 units reaches `prependIntentSectionWithinLimit`, where `scm.ClampPRBody` truncates from the beginning and can omit or cut this trailing comment mid-JSON. The GitHub path can likewise drop the Pipeline section when generated risk/testing content consumes its budget. This contradicts the requirement to emit a stable comment when writing the Pipeline section. Reserve the complete Pipeline header, signature, and attestation at the shared body-budget boundary before truncating other content.

🔧 Fix: Preserve pipeline attestations across PR body truncation
1 error still open:
- 🚨 `internal/pipeline/steps/prsummary.go:29` - The required &#34;faithful structured metadata ... plus any existing facts a later compliance consumer needs&#34; is not commit-bound: the v1 payload contains only `steps`. A normal CI auto-fix can push head B after this body was written for head A, and the documented non-refresh behavior leaves consumers unable to determine which commit those statuses attest. Include the run&#39;s head SHA in the versioned payload at the shared PR-summary assembly boundary and document that binding.

🔧 Fix: Bind pipeline attestations to recorded head SHA
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `git diff 0c58eb7110427cfc1d716641ae4b878e7f8582ac..2c0baa438938e718a393680224ccba53e092893a` for the PR writer, attestation contract, documentation, and tests.</code>
- `go test ./internal/pipeline/steps -run '^(TestBuildPipelineSummary_EmitsStructuredStepAttestation|TestPRStep_UpdatesExistingPR|TestPRStep_CreatesNewPR|TestPRStep_CreateKeepsGeneratedSectionsAfterOversizedIntent|TestAssemblePRBody_RetainsAttestationWhenCoreExceedsAzureCap|TestAppendGeneratedSections_RetainsPipelineAttestationWhenTruncated|TestAppendGeneratedSections_RetainsAttestationWhenEssentialSectionsOverflow)$' -count=1`
- <code>Executed `BuildPipelineSummary` through a temporary Go driver with completed, failed, skipped, awaiting-approval, running, and pending records, then captured its exact Markdown output as evidence.</code>
- `git diff --check -- .no-mistakes/evidence/fm/nm-pipeline-step-attestation-r1/pipeline-section.md`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
