### PR TITLE
feat(scm): support opening pull requests as drafts (pr.draft)

### DIFF
--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -425,7 +425,7 @@ Open every pull/merge request the pipeline creates as a draft.
 | Type    | `bool`  |
 | Default | `false` |
 
-Global-only: draft-vs-ready is the operator's own workflow preference, not a property of the repository being contributed to.
+This is the machine-wide default. A repository's own `.no-mistakes.yaml` [`pr.draft`](/reference/repo-config/#prdraft) overrides it, so a shared work repo can open PRs draft-first while a solo repo goes straight to ready-for-review.
 It applies to PR creation only, so no-mistakes never flips a PR you already marked ready-for-review back to draft.
 Supported on GitHub (`gh pr create --draft`), GitLab (`glab mr create --draft`), and Azure DevOps (`az repos pr create --draft true`); Bitbucket has no draft concept and ignores it.
 

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -416,6 +416,19 @@ Enabling this pushes a branch to your remote, so pick a `branch` name your CI wo
 
 These are global defaults. Per-repo config can override each field, except `branch`, which is read only from the trusted default branch.
 
+### pr.draft
+
+Open every pull/merge request the pipeline creates as a draft.
+
+|         |         |
+| ------- | ------- |
+| Type    | `bool`  |
+| Default | `false` |
+
+Global-only: draft-vs-ready is the operator's own workflow preference, not a property of the repository being contributed to.
+It applies to PR creation only, so no-mistakes never flips a PR you already marked ready-for-review back to draft.
+Supported on GitHub (`gh pr create --draft`), GitLab (`glab mr create --draft`), and Azure DevOps (`az repos pr create --draft true`); Bitbucket has no draft concept and ignores it.
+
 ## Environment variables
 
 See [Environment Variables](/no-mistakes/reference/environment/) for `NM_HOME`, `NM_DAEMON_CONNECT_TIMEOUT`, Bitbucket Cloud credentials, and update-check suppression.

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -12,7 +12,7 @@ The daemon also reads `document.instructions`, `review.path_instructions`, `disa
 If the default branch cannot be fetched and resolved to a readable commit, or its present `.no-mistakes.yaml` cannot be read and parsed, the run aborts before launching an agent.
 A readable default-branch tree with no `.no-mistakes.yaml` is valid and uses defaults.
 Commit the gate-control settings you want to your default branch.
-Non-executing fields (`ignore_patterns`, `auto_fix`, `commit`, `intent`, `test`) are still read from the pushed branch, except `test.evidence.branch`, which names a git ref the daemon pushes to.
+Non-executing fields (`ignore_patterns`, `auto_fix`, `commit`, `intent`, `test`, `pr`) are still read from the pushed branch, except `test.evidence.branch`, which names a git ref the daemon pushes to.
 
 If you genuinely want per-branch `commands` and `agent` (for example, a single-developer repo where you trust your own feature branches), opt in with [`allow_repo_commands: true`](#allow_repo_commands) in this same file on your default branch. This re-enables the previous behavior with eyes open. The switch is read only from the trusted default-branch copy, so a contributor cannot self-enable it from a pushed branch.
 :::
@@ -82,6 +82,10 @@ test:
     store_in_repo: true
     dir: .no-mistakes/evidence
     branch: no-mistakes/evidence
+
+# Open every pull/merge request for this repo as a draft. Unset inherits global.
+pr:
+  draft: true
 ```
 
 ## Fields
@@ -407,6 +411,34 @@ Fields not set here inherit from global config and then the built-in defaults.
 | `intent.disabled_readers` | `string[]` | Adds to globally disabled readers |
 
 Valid `disabled_readers` values are `claude`, `codex`, `opencode`, `rovodev`, `pi`, and `copilot`.
+
+### pr.draft
+
+Open every pull/merge request the pipeline creates for this repo as a draft.
+Unset inherits the global value; setting it here (to `true` **or** `false`) overrides global.
+
+| Field      | Type   | Default                              |
+| ---------- | ------ | ------------------------------------ |
+| `pr.draft` | `bool` | Inherits from global (default `false`) |
+
+Draft-vs-ready is a property of the repository being contributed to, so it belongs here.
+A shared work repo can open every PR draft-first for review while a solo repo goes straight to ready-for-review:
+
+```yaml
+# shared work repo: review before anyone is pinged
+pr:
+  draft: true
+```
+
+```yaml
+# solo repo, global default is draft: true - go straight to ready
+pr:
+  draft: false
+```
+
+It applies to PR creation only, so no-mistakes never flips a PR you already marked ready-for-review back to draft.
+Supported on GitHub, GitLab, and Azure DevOps; Bitbucket has no draft concept and ignores it.
+See [global config `pr.draft`](/reference/global-config/#prdraft) for the machine-wide default.
 
 ### test.evidence
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,6 +87,16 @@ type GlobalConfig struct {
 	Commit CommitRaw
 	Intent IntentRaw
 	Test   TestRaw
+	// PR carries pull/merge-request creation preferences (currently pr.draft).
+	PR PR
+}
+
+// PR is the pull/merge-request creation config. Draft opens every PR the
+// pipeline creates as a draft; it is global-only because it is the operator's
+// own workflow preference, not a property of the repository being contributed
+// to. Default false preserves the previous ready-for-review behavior.
+type PR struct {
+	Draft bool `yaml:"draft"`
 }
 
 // globalConfigRaw is the on-disk YAML representation with duration as string.
@@ -107,6 +117,7 @@ type globalConfigRaw struct {
 	Commit               CommitRaw           `yaml:"commit"`
 	Intent               IntentRaw           `yaml:"intent"`
 	Test                 TestRaw             `yaml:"test"`
+	PR                   PR                  `yaml:"pr"`
 }
 
 // RepoConfig represents .no-mistakes.yaml in a repo root.
@@ -393,6 +404,8 @@ type Config struct {
 	Test                 Test
 	Document             Document
 	Review               Review
+	// PR is the resolved pull/merge-request creation config (global-only).
+	PR PR
 	// DisableProjectSettings is the resolved, trusted-only opt-out (see the
 	// RepoConfig field). When true, gate agents are launched with their
 	// project-level settings/instructions suppressed; the daemon fails the run
@@ -641,6 +654,10 @@ intent:
   threshold: 0.2
   slack_days: 3
   # disabled_readers: [codex]
+
+# Open every pull/merge request the pipeline creates as a draft. Default false.
+# pr:
+#   draft: true
 
 # Test-step evidence artifacts (screenshots, recordings, logs the test step
 # gathers to demonstrate the change works). By default they are kept in a
@@ -1214,6 +1231,7 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 	cfg.Commit = raw.Commit
 	cfg.Intent = raw.Intent
 	cfg.Test = raw.Test
+	cfg.PR = raw.PR
 
 	return cfg, nil
 }
@@ -1667,6 +1685,7 @@ func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 		Commit:               commit,
 		Intent:               intent,
 		Test:                 test,
+		PR:                   global.PR,
 		Document:             Document{Instructions: strings.TrimSpace(repo.Document.Instructions)},
 		Review:               Review{PathInstructions: resolvePathInstructions(repo.Review.PathInstructions)},
 		// repo is the EffectiveRepoConfig result, so this value is already

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,15 +88,24 @@ type GlobalConfig struct {
 	Intent IntentRaw
 	Test   TestRaw
 	// PR carries pull/merge-request creation preferences (currently pr.draft).
-	PR PR
+	PR PRRaw
 }
 
-// PR is the pull/merge-request creation config. Draft opens every PR the
-// pipeline creates as a draft; it is global-only because it is the operator's
-// own workflow preference, not a property of the repository being contributed
-// to. Default false preserves the previous ready-for-review behavior.
+// PRRaw is the on-disk pull/merge-request creation config, settable both
+// globally and per repository. Draft is a pointer so an unset repo value is
+// distinguishable from an explicit `draft: false`: unset falls through to the
+// global default, while either explicit value overrides it. A repository is a
+// legitimate owner of this choice - a shared work repo can open every PR
+// draft-first for review while a solo repo goes straight to ready.
+type PRRaw struct {
+	Draft *bool `yaml:"draft"`
+}
+
+// PR is the resolved pull/merge-request creation config. Draft opens every PR
+// the pipeline creates as a draft. Default false preserves ready-for-review
+// behavior.
 type PR struct {
-	Draft bool `yaml:"draft"`
+	Draft bool
 }
 
 // globalConfigRaw is the on-disk YAML representation with duration as string.
@@ -117,7 +126,7 @@ type globalConfigRaw struct {
 	Commit               CommitRaw           `yaml:"commit"`
 	Intent               IntentRaw           `yaml:"intent"`
 	Test                 TestRaw             `yaml:"test"`
-	PR                   PR                  `yaml:"pr"`
+	PR                   PRRaw               `yaml:"pr"`
 }
 
 // RepoConfig represents .no-mistakes.yaml in a repo root.
@@ -138,6 +147,11 @@ type RepoConfig struct {
 	Commit            CommitRaw  `yaml:"commit"`
 	Intent            IntentRaw  `yaml:"intent"`
 	Test              TestRaw    `yaml:"test"`
+	// PR overrides the global pull/merge-request creation config for this
+	// repository. It selects nothing executable and spends no maintainer
+	// resources, so it is read from the pushed branch like the other
+	// non-executing fields.
+	PR PRRaw `yaml:"pr"`
 	// Document carries the repository's documentation placement policy. It
 	// steers the document step's gate prompt, so it is honored ONLY from the
 	// trusted default-branch copy of .no-mistakes.yaml (see
@@ -311,6 +325,7 @@ func (c *RepoConfig) UnmarshalYAML(value *yaml.Node) error {
 		Commit                 CommitRaw   `yaml:"commit"`
 		Intent                 IntentRaw   `yaml:"intent"`
 		Test                   TestRaw     `yaml:"test"`
+		PR                     PRRaw       `yaml:"pr"`
 		Document               DocumentRaw `yaml:"document"`
 		Review                 ReviewRaw   `yaml:"review"`
 		DisableProjectSettings bool        `yaml:"disable_project_settings"`
@@ -330,6 +345,7 @@ func (c *RepoConfig) UnmarshalYAML(value *yaml.Node) error {
 	c.Commit = raw.Commit
 	c.Intent = raw.Intent
 	c.Test = raw.Test
+	c.PR = raw.PR
 	c.Document = raw.Document
 	c.Review = raw.Review
 	c.DisableProjectSettings = raw.DisableProjectSettings
@@ -404,7 +420,8 @@ type Config struct {
 	Test                 Test
 	Document             Document
 	Review               Review
-	// PR is the resolved pull/merge-request creation config (global-only).
+	// PR is the resolved pull/merge-request creation config (global default,
+	// overridable by the repo's own .no-mistakes.yaml).
 	PR PR
 	// DisableProjectSettings is the resolved, trusted-only opt-out (see the
 	// RepoConfig field). When true, gate agents are launched with their
@@ -656,6 +673,7 @@ intent:
   # disabled_readers: [codex]
 
 # Open every pull/merge request the pipeline creates as a draft. Default false.
+# A repository's own .no-mistakes.yaml pr.draft overrides this value.
 # pr:
 #   draft: true
 
@@ -1659,6 +1677,17 @@ func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 	applyTestOverrides(&test, &global.Test)
 	applyTestOverrides(&test, &repo.Test)
 
+	// An unset repo pr.draft inherits the global value; an explicit repo value
+	// (true or false) wins, so a repository can force draft-first or ready-first
+	// regardless of the operator's default.
+	var pr PR
+	if global.PR.Draft != nil {
+		pr.Draft = *global.PR.Draft
+	}
+	if repo.PR.Draft != nil {
+		pr.Draft = *repo.PR.Draft
+	}
+
 	commit := Commit{FixMessage: DefaultFixMessageTemplate}
 	if global.Commit.FixMessage != nil {
 		commit.FixMessage = *global.Commit.FixMessage
@@ -1685,7 +1714,7 @@ func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 		Commit:               commit,
 		Intent:               intent,
 		Test:                 test,
-		PR:                   global.PR,
+		PR:                   pr,
 		Document:             Document{Instructions: strings.TrimSpace(repo.Document.Instructions)},
 		Review:               Review{PathInstructions: resolvePathInstructions(repo.Review.PathInstructions)},
 		// repo is the EffectiveRepoConfig result, so this value is already

--- a/internal/config/config_global_test.go
+++ b/internal/config/config_global_test.go
@@ -520,3 +520,24 @@ func TestLoadGlobal_AutoFixPartial(t *testing.T) {
 		t.Errorf("test = %v, want nil", cfg.AutoFix.Test)
 	}
 }
+
+// pr.draft is global-only, defaults false, and survives Merge.
+func TestLoadGlobal_PRDraft(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("pr:\n  draft: true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadGlobal(path)
+	if err != nil {
+		t.Fatalf("LoadGlobal: %v", err)
+	}
+	if !cfg.PR.Draft {
+		t.Fatal("pr.draft = false, want true")
+	}
+	if !Merge(cfg, &RepoConfig{}).PR.Draft {
+		t.Fatal("Merge dropped pr.draft")
+	}
+	if DefaultGlobalConfig().PR.Draft {
+		t.Fatal("default pr.draft = true, want false (preserve ready-for-review default)")
+	}
+}

--- a/internal/config/config_global_test.go
+++ b/internal/config/config_global_test.go
@@ -521,7 +521,7 @@ func TestLoadGlobal_AutoFixPartial(t *testing.T) {
 	}
 }
 
-// pr.draft is global-only, defaults false, and survives Merge.
+// pr.draft parses globally, defaults false, and survives Merge.
 func TestLoadGlobal_PRDraft(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	if err := os.WriteFile(path, []byte("pr:\n  draft: true\n"), 0o644); err != nil {
@@ -531,13 +531,74 @@ func TestLoadGlobal_PRDraft(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadGlobal: %v", err)
 	}
-	if !cfg.PR.Draft {
-		t.Fatal("pr.draft = false, want true")
+	if cfg.PR.Draft == nil || !*cfg.PR.Draft {
+		t.Fatalf("pr.draft = %v, want true", cfg.PR.Draft)
 	}
 	if !Merge(cfg, &RepoConfig{}).PR.Draft {
 		t.Fatal("Merge dropped pr.draft")
 	}
-	if DefaultGlobalConfig().PR.Draft {
-		t.Fatal("default pr.draft = true, want false (preserve ready-for-review default)")
+	if DefaultGlobalConfig().PR.Draft != nil {
+		t.Fatal("default pr.draft is set, want unset (ready-for-review default)")
+	}
+	if Merge(DefaultGlobalConfig(), &RepoConfig{}).PR.Draft {
+		t.Fatal("resolved default pr.draft = true, want false")
 	}
 }
+
+// A repo's pr.draft overrides the global default in either direction; unset in
+// the repo inherits global. The pointer is what makes "explicitly false" and
+// "unset" distinguishable.
+func TestMerge_PRDraftRepoOverridesGlobal(t *testing.T) {
+	yes, no := true, false
+	for _, tc := range []struct {
+		name   string
+		global *bool
+		repo   *bool
+		want   bool
+	}{
+		{"repo true over global false", &no, &yes, true},
+		{"repo false over global true", &yes, &no, false},
+		{"repo unset inherits global true", &yes, nil, true},
+		{"repo unset inherits global false", &no, nil, false},
+		{"both unset defaults false", nil, nil, false},
+		{"repo true with global unset", nil, &yes, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			global := DefaultGlobalConfig()
+			global.PR = PRRaw{Draft: tc.global}
+			got := Merge(global, &RepoConfig{PR: PRRaw{Draft: tc.repo}}).PR.Draft
+			if got != tc.want {
+				t.Fatalf("PR.Draft = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A repo's .no-mistakes.yaml parses pr.draft, including an explicit false.
+func TestLoadRepo_PRDraft(t *testing.T) {
+	for _, tc := range []struct {
+		yaml string
+		want *bool
+	}{
+		{"pr:\n  draft: true\n", ptrBool(true)},
+		{"pr:\n  draft: false\n", ptrBool(false)},
+		{"agent: codex\n", nil},
+	} {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, ".no-mistakes.yaml"), []byte(tc.yaml), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		cfg, err := LoadRepo(dir)
+		if err != nil {
+			t.Fatalf("LoadRepo(%q): %v", tc.yaml, err)
+		}
+		switch {
+		case tc.want == nil && cfg.PR.Draft != nil:
+			t.Errorf("%q: pr.draft = %v, want unset", tc.yaml, *cfg.PR.Draft)
+		case tc.want != nil && (cfg.PR.Draft == nil || *cfg.PR.Draft != *tc.want):
+			t.Errorf("%q: pr.draft = %v, want %v", tc.yaml, cfg.PR.Draft, *tc.want)
+		}
+	}
+}
+
+func ptrBool(b bool) *bool { return &b }

--- a/internal/config/config_repo_trust_test.go
+++ b/internal/config/config_repo_trust_test.go
@@ -492,3 +492,15 @@ func TestMerge_CarriesDisableProjectSettings(t *testing.T) {
 		t.Error("Merge must leave DisableProjectSettings false by default")
 	}
 }
+
+// pr.draft selects nothing executable and spends no maintainer resources, so
+// it stays a pushed-branch field like the other non-executing settings.
+func TestEffectiveRepoConfig_PRDraftComesFromPushedBranch(t *testing.T) {
+	t.Parallel()
+
+	draft := true
+	eff := EffectiveRepoConfig(&RepoConfig{PR: PRRaw{Draft: &draft}}, &RepoConfig{}, false)
+	if eff.PR.Draft == nil || !*eff.PR.Draft {
+		t.Fatalf("pushed pr.draft = %v, want true", eff.PR.Draft)
+	}
+}

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -89,7 +89,9 @@ func (s *PRStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 	}
 	if existing != nil {
 		sctx.Log(fmt.Sprintf("pull request already exists: %s, updating...", describePR(existing)))
-		updated, err := host.UpdatePR(ctx, existing, scm.PRContent(content))
+		// No Draft on update: the pipeline must never flip a PR a human
+		// already marked ready-for-review back to draft.
+		updated, err := host.UpdatePR(ctx, existing, scm.PRContent{Title: content.Title, Body: content.Body})
 		if err != nil {
 			sctx.Log(fmt.Sprintf("warning: failed to update PR: %v", err))
 			updated = existing
@@ -104,7 +106,11 @@ func (s *PRStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 	}
 
 	sctx.Log("creating pull request...")
-	created, err := host.CreatePR(ctx, branch, sctx.Repo.DefaultBranch, scm.PRContent(content))
+	created, err := host.CreatePR(ctx, branch, sctx.Repo.DefaultBranch, scm.PRContent{
+		Title: content.Title,
+		Body:  content.Body,
+		Draft: draftPRs(sctx),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -116,6 +122,11 @@ func (s *PRStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 		slog.Warn("failed to persist PR URL", "run", sctx.Run.ID, "url", created.URL, "err", err)
 	}
 	return &pipeline.StepOutcome{PRURL: created.URL}, nil
+}
+
+// draftPRs reports whether new PRs open as drafts (global config pr.draft).
+func draftPRs(sctx *pipeline.StepContext) bool {
+	return sctx != nil && sctx.Config != nil && sctx.Config.PR.Draft
 }
 
 func describePR(pr *scm.PR) string {

--- a/internal/pipeline/steps/pr_test.go
+++ b/internal/pipeline/steps/pr_test.go
@@ -2028,3 +2028,20 @@ func TestPRStep_PromptGuidesScopeToRealModule(t *testing.T) {
 		t.Errorf("expected PR prompt to convey typical module count heuristic, got:\n%s", capturedPrompt)
 	}
 }
+
+// The PR step reads pr.draft from the merged config; a nil config or unset
+// value keeps PRs ready-for-review.
+func TestDraftPRsReadsConfig(t *testing.T) {
+	if draftPRs(nil) {
+		t.Error("nil sctx should not request a draft PR")
+	}
+	if draftPRs(&pipeline.StepContext{}) {
+		t.Error("nil config should not request a draft PR")
+	}
+	if draftPRs(&pipeline.StepContext{Config: &config.Config{}}) {
+		t.Error("unset pr.draft should not request a draft PR")
+	}
+	if !draftPRs(&pipeline.StepContext{Config: &config.Config{PR: config.PR{Draft: true}}}) {
+		t.Error("pr.draft: true should request a draft PR")
+	}
+}

--- a/internal/scm/azuredevops/azuredevops.go
+++ b/internal/scm/azuredevops/azuredevops.go
@@ -189,6 +189,9 @@ func (h *Host) CreatePR(ctx context.Context, branch, base string, content scm.PR
 			"--title", content.Title,
 			"--description", descArg,
 		}
+		if content.Draft {
+			args = append(args, "--draft", "true")
+		}
 		args = append(args, h.scopeArgs()...)
 		return append(args, "--output", "json")
 	})

--- a/internal/scm/azuredevops/azuredevops_test.go
+++ b/internal/scm/azuredevops/azuredevops_test.go
@@ -534,3 +534,34 @@ func TestAzdoHelperProcess(t *testing.T) {
 	}
 	os.Exit(0)
 }
+
+// pr.draft passes --draft true to az repos pr create; unset omits it.
+func TestCreatePRAppendsDraftFlagOnlyWhenRequested(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		draft bool
+		want  bool
+	}{
+		{"draft", true, true},
+		{"ready", false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var rec []capturedCmd
+			h := newCapturingHost(&rec, azdoTestResponse{stdout: `{"pullRequestId":7}` + "\n"})
+
+			if _, err := h.CreatePR(context.Background(), "feature", "main", scm.PRContent{Title: "T", Body: "B", Draft: tc.draft}); err != nil {
+				t.Fatalf("CreatePR() error = %v", err)
+			}
+			if len(rec) != 1 {
+				t.Fatalf("recorded %d commands, want 1", len(rec))
+			}
+			got := strings.Join(rec[0].args, " ")
+			if strings.Contains(got, "--draft true") != tc.want {
+				t.Fatalf("command = %q, draft flag present = %v, want %v", got, !tc.want, tc.want)
+			}
+		})
+	}
+}

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -248,6 +248,9 @@ func (h *Host) CreatePR(ctx context.Context, branch, base string, content scm.PR
 		"--base", base,
 	}, h.repoArgs()...)
 	args = append(args, "--title", content.Title, "--body-file", "-")
+	if content.Draft {
+		args = append(args, "--draft")
+	}
 	cmd := h.cmd(ctx, "gh", args...)
 	cmd.Stdin = strings.NewReader(content.Body)
 	out, err := cmd.CombinedOutput()

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -746,3 +746,37 @@ func TestGitHubHelperProcess(t *testing.T) {
 	}
 	os.Exit(0)
 }
+
+// pr.draft appends --draft to gh pr create; unset keeps the previous
+// ready-for-review argv. The exact-command test factory fails any other argv.
+func TestCreatePRAppendsDraftFlagOnlyWhenRequested(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name  string
+		draft bool
+		key   string
+	}{
+		{"draft", true, "gh pr create --head feature --base main --repo test/repo --title t --body-file - --draft"},
+		{"ready", false, "gh pr create --head feature --base main --repo test/repo --title t --body-file -"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			host := New(githubTestCmdFactory(map[string]githubTestResponse{
+				tc.key: {stdout: "https://github.com/test/repo/pull/42\n"},
+			}), nil, "", "test/repo")
+
+			pr, err := host.CreatePR(context.Background(), "feature", "main", scm.PRContent{
+				Title: "t",
+				Body:  "b",
+				Draft: tc.draft,
+			})
+			if err != nil {
+				t.Fatalf("CreatePR() error = %v", err)
+			}
+			if pr.Number != "42" {
+				t.Fatalf("CreatePR() = %+v, want #42", pr)
+			}
+		})
+	}
+}

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -191,13 +191,17 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 }
 
 func (h *Host) CreatePR(ctx context.Context, branch, base string, content scm.PRContent) (*scm.PR, error) {
-	cmd := h.cmd(ctx, "glab", "mr", "create",
+	args := []string{"mr", "create",
 		"--source-branch", branch,
 		"--target-branch", base,
 		"--title", content.Title,
 		"--description", content.Body,
 		"--yes",
-	)
+	}
+	if content.Draft {
+		args = append(args, "--draft")
+	}
+	cmd := h.cmd(ctx, "glab", args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("glab mr create: %s: %w", strings.TrimSpace(string(out)), err)

--- a/internal/scm/gitlab/gitlab_test.go
+++ b/internal/scm/gitlab/gitlab_test.go
@@ -635,3 +635,37 @@ func TestGitlabHelperProcess(t *testing.T) {
 	}
 	os.Exit(0)
 }
+
+// pr.draft appends --draft to glab mr create; unset keeps the previous argv.
+func TestCreateMRAppendsDraftFlagOnlyWhenRequested(t *testing.T) {
+	t.Parallel()
+
+	base := "glab mr create --source-branch feature --target-branch main --title t --description b --yes"
+	for _, tc := range []struct {
+		name  string
+		draft bool
+		key   string
+	}{
+		{"draft", true, base + " --draft"},
+		{"ready", false, base},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			host := New(gitlabTestCmdFactory(map[string]gitlabTestResponse{
+				tc.key: {stdout: "https://gitlab.com/group/project/-/merge_requests/7\n"},
+			}), nil, "", "group/project")
+
+			pr, err := host.CreatePR(context.Background(), "feature", "main", scm.PRContent{
+				Title: "t",
+				Body:  "b",
+				Draft: tc.draft,
+			})
+			if err != nil {
+				t.Fatalf("CreatePR() error = %v", err)
+			}
+			if pr.Number != "7" {
+				t.Fatalf("CreatePR() = %+v, want #7", pr)
+			}
+		})
+	}
+}

--- a/internal/scm/host.go
+++ b/internal/scm/host.go
@@ -95,6 +95,10 @@ type PR struct {
 type PRContent struct {
 	Title string
 	Body  string
+	// Draft opens the PR/MR as a draft (config pr.draft). Providers that have
+	// no draft concept ignore it, and it is ignored when updating an existing
+	// PR so the pipeline never flips a ready PR back to draft.
+	Draft bool
 }
 
 // PRState is the normalized lifecycle state of a PR.


### PR DESCRIPTION
Resolves #530.

Adds a `pr.draft` config option that opens every pull/merge request the pipeline creates as a draft. Settable globally and overridable per repository.

## What changed

- `scm.PRContent` gains a `Draft bool`, set by the PR step from the merged config.
- GitHub: appends `--draft` to `gh pr create`.
- GitLab: appends `--draft` to `glab mr create`.
- Azure DevOps: appends `--draft true` to `az repos pr create`.
- Bitbucket has no draft concept and ignores the field.
- Draft is applied on **creation only**: `UpdatePR` never sends it, so a PR a human already marked ready-for-review is never flipped back to draft.
- Default false preserves current behavior exactly.

## Global default, per-repo override

`pr.draft` is a `*bool` in both `~/.no-mistakes/config.yaml` and a repo's `.no-mistakes.yaml`, so an unset repo value falls through to the global default while an explicit repo value (`true` **or** `false`) wins. That makes the common mixed setup work: a shared repo opens PRs draft-first for review, a solo repo goes straight to ready.

It selects nothing executable and spends no maintainer resources, so it is read from the pushed branch like the other non-executing fields (`ignore_patterns`, `auto_fix`, `commit`, `intent`, `test`) rather than joining the trusted-only set.

Documented in `docs/src/content/docs/reference/global-config.md` and `docs/src/content/docs/reference/repo-config.md`.

## Tests

- `TestCreatePRAppendsDraftFlagOnlyWhenRequested` for GitHub, GitLab, and Azure DevOps (flag present when draft, absent when not).
- `TestMerge_PRDraftRepoOverridesGlobal`: repo true over global false, repo false over global true, unset inherits, both unset defaults false.
- `TestLoadGlobal_PRDraft` / `TestLoadRepo_PRDraft`: parsing, including an explicit `false`.
- `TestEffectiveRepoConfig_PRDraftComesFromPushedBranch`.
- `TestDraftPRsReadsConfig`: the step reads the merged config and fails safe on nil.

`gofmt -l .`, `make lint`, `go build ./...`, and `go test -race ./...` are clean.
