### PR TITLE
feat(db): record build identity on run records

### DIFF
--- a/.no-mistakes/evidence/fm/nm-run-version-sha-r1/build-identity-on-run.md
+++ b/.no-mistakes/evidence/fm/nm-run-version-sha-r1/build-identity-on-run.md
@@ -1,0 +1,56 @@
+# Build identity recorded on SQLite run records
+
+Intent: every newly created and subsequently updated run record must retain durable
+version and build/git SHA fields, using the same identity users see via `--version`,
+via a safe additive nullable migration, proven behaviorally through the real SQLite
+write/read path.
+
+The binary and the DB write path were built with the same release-style `-ldflags`
+(`buildinfo.Version=v1.47.0`, `buildinfo.Commit=df002d9`) so the two surfaces are
+directly comparable.
+
+## 1) Identity a user sees via `--version`
+
+```
+$ no-mistakes --version
+no-mistakes version v1.47.0 (df002d9) 2026-08-07
+```
+
+## 2) Identity persisted on a real run row (InsertRun -> UpdateRunStatus -> raw SELECT)
+
+Exercised the real `db.InsertRun` + `db.UpdateRunStatus` path, then read the RAW
+persisted SQLite columns back directly (not through the scan helper):
+
+```
+binary --version identity : buildinfo.String() = "v1.47.0 (df002d9) 2026-08-07"
+  CurrentVersion()="v1.47.0"  Commit="df002d9"
+persisted runs row        : id=01KZFY870743W0BAA9KRAAQ6EG status=running
+  runs.no_mistakes_version   = v1.47.0
+  runs.no_mistakes_build_sha = df002d9
+MATCH: persisted DB identity == running binary --version identity
+```
+
+The version/SHA land on the run at insert and survive a status update; they are the
+exact identity `--version` reports.
+
+## 3) Backward-compatible additive nullable migration
+
+`TestOpenMigratesRunSyncProvenanceWithoutBackfillingMutableHead` confirms a legacy
+run row (predating these columns) reads back with `no_mistakes_version == NULL` and
+`no_mistakes_build_sha == NULL` - never backfilled from mutable head - while
+`TestOpenCreatesSchema` confirms both columns exist on a fresh schema.
+
+## Targeted tests run (all pass)
+
+```
+go test -race -run 'TestRunInsertAndUpdatePreserveBuildIdentity|TestOpenMigratesRunSyncProvenanceWithoutBackfillingMutableHead|TestOpenCreatesSchema|TestInsertRunWithIntent|TestRunInsertAndGet' ./internal/db/
+--- PASS: TestOpenCreatesSchema
+--- PASS: TestOpenMigratesRunSyncProvenanceWithoutBackfillingMutableHead
+--- PASS: TestRunInsertAndGet
+--- PASS: TestRunInsertAndUpdatePreserveBuildIdentity
+--- PASS: TestInsertRunWithIntent
+ok  github.com/kunchenguid/no-mistakes/internal/db
+```
+
+No secrets are stored: only the public version string and the short build SHA are
+recorded, the same values printed by `--version`.

--- a/docs/src/content/docs/concepts/gate-model.md
+++ b/docs/src/content/docs/concepts/gate-model.md
@@ -183,7 +183,7 @@ Intent stores the summary, source, session ID, and match score on each run when 
 An agent-supplied AXI intent is stored directly on the run.
 Raw transcript text is not stored in this database.
 Legacy `user_fix` rounds are still read as `auto-fix` for backward compatibility.
-Run records also store the nullable `awaiting_agent_since` timestamp used only to render the AXI parked signal while a gate is waiting for the driving agent, plus accumulated `parked_ms` for local performance reporting.
+Run records also store the nullable `awaiting_agent_since` timestamp used only to render the AXI parked signal while a gate is waiting for the driving agent, plus accumulated `parked_ms` for local performance reporting. For version-specific debugging, inspect `runs.no_mistakes_version` and `runs.no_mistakes_build_sha`: each new run records the version returned by `internal/buildinfo.CurrentVersion()` and the `internal/buildinfo.Commit` build SHA embedded through release `-ldflags`, the same identity shown by `no-mistakes --version`. Historical rows remain `NULL`.
 Each agent invocation records local-only purpose, provider/model metadata, session mode and a truncated session-identity hash, timing, failure category, and token usage; prompts, outputs, diffs, and credentials are never stored there.
 Use `no-mistakes stats --agents` for aggregates or `no-mistakes stats --run <id>` for a run timeline and parked time.
 Repo records store the parent `upstream_url` and an optional `fork_url`; branch pushes use `fork_url` when present, while PR and CI provider context stays anchored to the parent.

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -76,7 +76,7 @@ func TestOpenCreatesSchema(t *testing.T) {
 	if !hasColumn(t, d, "repos", "fork_url") {
 		t.Fatal("repos.fork_url column missing from fresh schema")
 	}
-	for _, column := range []string{"submitted_head_sha", "review_approved_head_sha", "last_pushed_sha", "push_target_fingerprint", "push_ref", "last_pushed_at", "push_generation", "push_active", "terminal_head_verified_at", "pr_state", "pr_state_observed_at", "ci_ready_at", "ci_ready_no_ci", "custody_returned_at"} {
+	for _, column := range []string{"submitted_head_sha", "no_mistakes_version", "no_mistakes_build_sha", "review_approved_head_sha", "last_pushed_sha", "push_target_fingerprint", "push_ref", "last_pushed_at", "push_generation", "push_active", "terminal_head_verified_at", "pr_state", "pr_state_observed_at", "ci_ready_at", "ci_ready_no_ci", "custody_returned_at"} {
 		if !hasColumn(t, d, "runs", column) {
 			t.Fatalf("runs.%s column missing from fresh schema", column)
 		}
@@ -122,8 +122,8 @@ func TestOpenMigratesRunSyncProvenanceWithoutBackfillingMutableHead(t *testing.T
 	if run == nil || run.HeadSHA != "mutable-head" {
 		t.Fatalf("migrated run = %#v", run)
 	}
-	if run.SubmittedHeadSHA != nil || run.ReviewApprovedHeadSHA != nil || run.LastPushedSHA != nil || run.PushGeneration != nil || run.PushTargetFingerprint != nil {
-		t.Fatalf("legacy provenance or review authority was inferred from mutable head: %#v", run)
+	if run.SubmittedHeadSHA != nil || run.NoMistakesVersion != nil || run.NoMistakesBuildSHA != nil || run.ReviewApprovedHeadSHA != nil || run.LastPushedSHA != nil || run.PushGeneration != nil || run.PushTargetFingerprint != nil {
+		t.Fatalf("legacy provenance, build identity, or review authority was inferred from mutable head: %#v", run)
 	}
 	if run.CustodyReturnedAt != nil {
 		t.Fatalf("legacy run gained a custody-return stamp: %#v", run)

--- a/internal/db/run.go
+++ b/internal/db/run.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/kunchenguid/no-mistakes/internal/buildinfo"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
@@ -17,6 +18,10 @@ type Run struct {
 	HeadSHA          string
 	BaseSHA          string
 	SubmittedHeadSHA *string
+	// NoMistakesVersion and NoMistakesBuildSHA identify the binary that created
+	// this run. They remain nil only for runs recorded before these fields.
+	NoMistakesVersion  *string
+	NoMistakesBuildSHA *string
 	// ReviewApprovedHeadSHA is the exact commit approved by the last
 	// successfully completed full review. It is nil for legacy runs and until
 	// review completes; mutable run/worktree heads never infer this authority.
@@ -61,13 +66,13 @@ type Run struct {
 	UpdatedAt       int64
 }
 
-const runColumns = `id, repo_id, branch, head_sha, base_sha, submitted_head_sha, review_approved_head_sha, status, pr_url, pr_state, pr_state_observed_at, ci_ready_at, COALESCE(ci_ready_no_ci, 0), last_pushed_sha, push_target_kind, push_target_fingerprint, push_ref, last_pushed_at, push_generation, COALESCE(push_active, 0), terminal_head_verified_at, custody_returned_at, error, awaiting_agent_since, COALESCE(parked_ms, 0), intent, intent_source, intent_session_id, intent_score, created_at, updated_at`
+const runColumns = `id, repo_id, branch, head_sha, base_sha, submitted_head_sha, no_mistakes_version, no_mistakes_build_sha, review_approved_head_sha, status, pr_url, pr_state, pr_state_observed_at, ci_ready_at, COALESCE(ci_ready_no_ci, 0), last_pushed_sha, push_target_kind, push_target_fingerprint, push_ref, last_pushed_at, push_generation, COALESCE(push_active, 0), terminal_head_verified_at, custody_returned_at, error, awaiting_agent_since, COALESCE(parked_ms, 0), intent, intent_source, intent_session_id, intent_score, created_at, updated_at`
 
 func scanRun(row interface {
 	Scan(...any) error
 }, r *Run) error {
 	return row.Scan(
-		&r.ID, &r.RepoID, &r.Branch, &r.HeadSHA, &r.BaseSHA, &r.SubmittedHeadSHA, &r.ReviewApprovedHeadSHA, &r.Status,
+		&r.ID, &r.RepoID, &r.Branch, &r.HeadSHA, &r.BaseSHA, &r.SubmittedHeadSHA, &r.NoMistakesVersion, &r.NoMistakesBuildSHA, &r.ReviewApprovedHeadSHA, &r.Status,
 		&r.PRURL, &r.PRState, &r.PRStateObservedAt, &r.CIReadyAt, &r.CIReadyNoCI,
 		&r.LastPushedSHA, &r.PushTargetKind, &r.PushTargetFingerprint, &r.PushRef,
 		&r.LastPushedAt, &r.PushGeneration, &r.PushActive, &r.TerminalHeadVerifiedAt,
@@ -84,16 +89,20 @@ func (d *DB) InsertRun(repoID, branch, headSHA, baseSHA string) (*Run, error) {
 
 func (d *DB) InsertRunWithIntent(repoID, branch, headSHA, baseSHA string, intent *RunIntent) (*Run, error) {
 	ts := now()
+	version := buildinfo.CurrentVersion()
+	buildSHA := buildinfo.Commit
 	r := &Run{
-		ID:               newID(),
-		RepoID:           repoID,
-		Branch:           branch,
-		HeadSHA:          headSHA,
-		BaseSHA:          baseSHA,
-		SubmittedHeadSHA: &headSHA,
-		Status:           types.RunPending,
-		CreatedAt:        ts,
-		UpdatedAt:        ts,
+		ID:                 newID(),
+		RepoID:             repoID,
+		Branch:             branch,
+		HeadSHA:            headSHA,
+		BaseSHA:            baseSHA,
+		SubmittedHeadSHA:   &headSHA,
+		NoMistakesVersion:  &version,
+		NoMistakesBuildSHA: &buildSHA,
+		Status:             types.RunPending,
+		CreatedAt:          ts,
+		UpdatedAt:          ts,
 	}
 	if intent != nil {
 		r.Intent = &intent.Summary
@@ -102,8 +111,8 @@ func (d *DB) InsertRunWithIntent(repoID, branch, headSHA, baseSHA string, intent
 		r.IntentScore = &intent.Score
 	}
 	_, err := d.sql.Exec(
-		`INSERT INTO runs (id, repo_id, branch, head_sha, base_sha, submitted_head_sha, status, pr_state, intent, intent_source, intent_session_id, intent_score, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, 'none', ?, ?, ?, ?, ?, ?)`,
-		r.ID, r.RepoID, r.Branch, r.HeadSHA, r.BaseSHA, headSHA, r.Status, r.Intent, r.IntentSource, r.IntentSessionID, r.IntentScore, r.CreatedAt, r.UpdatedAt,
+		`INSERT INTO runs (id, repo_id, branch, head_sha, base_sha, submitted_head_sha, no_mistakes_version, no_mistakes_build_sha, status, pr_state, intent, intent_source, intent_session_id, intent_score, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'none', ?, ?, ?, ?, ?, ?)`,
+		r.ID, r.RepoID, r.Branch, r.HeadSHA, r.BaseSHA, headSHA, r.NoMistakesVersion, r.NoMistakesBuildSHA, r.Status, r.Intent, r.IntentSource, r.IntentSessionID, r.IntentScore, r.CreatedAt, r.UpdatedAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("insert run: %w", err)

--- a/internal/db/run_test.go
+++ b/internal/db/run_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"testing"
 
+	"github.com/kunchenguid/no-mistakes/internal/buildinfo"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
@@ -30,6 +31,32 @@ func TestRunInsertAndGet(t *testing.T) {
 	}
 	if got.HeadSHA != "abc123" {
 		t.Errorf("head sha = %q, want %q", got.HeadSHA, "abc123")
+	}
+}
+
+func TestRunInsertAndUpdatePreserveBuildIdentity(t *testing.T) {
+	d := openTestDB(t)
+	repo, err := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")
+	if err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+
+	run, err := d.InsertRun(repo.ID, "feature", "abc123", "def456")
+	if err != nil {
+		t.Fatalf("insert run: %v", err)
+	}
+	if err := d.UpdateRunStatus(run.ID, types.RunRunning); err != nil {
+		t.Fatalf("update run: %v", err)
+	}
+	got, err := d.GetRun(run.ID)
+	if err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if got.NoMistakesVersion == nil || *got.NoMistakesVersion != buildinfo.CurrentVersion() {
+		t.Fatalf("no-mistakes version = %v, want %q", got.NoMistakesVersion, buildinfo.CurrentVersion())
+	}
+	if got.NoMistakesBuildSHA == nil || *got.NoMistakesBuildSHA != buildinfo.Commit {
+		t.Fatalf("no-mistakes build SHA = %v, want %q", got.NoMistakesBuildSHA, buildinfo.Commit)
 	}
 }
 

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -17,6 +17,8 @@ CREATE TABLE IF NOT EXISTS runs (
     head_sha                TEXT NOT NULL,
     base_sha                TEXT NOT NULL,
     submitted_head_sha      TEXT,
+    no_mistakes_version     TEXT,
+    no_mistakes_build_sha   TEXT,
     review_approved_head_sha TEXT,
     status                  TEXT NOT NULL DEFAULT 'pending',
     pr_url                  TEXT,
@@ -162,6 +164,10 @@ var migrationStatements = []string{
 	// Branch synchronization provenance is intentionally nullable. Historical
 	// rows stay unbound because mutable head_sha cannot prove a successful push.
 	`ALTER TABLE runs ADD COLUMN submitted_head_sha TEXT`,
+	// Build identity is nullable for historical records. New runs record the
+	// version and embedded build SHA used by the running binary.
+	`ALTER TABLE runs ADD COLUMN no_mistakes_version TEXT`,
+	`ALTER TABLE runs ADD COLUMN no_mistakes_build_sha TEXT`,
 	// Review authority is nullable and never backfilled. A historical mutable
 	// head_sha cannot prove which exact commit a completed review approved.
 	`ALTER TABLE runs ADD COLUMN review_approved_head_sha TEXT`,


### PR DESCRIPTION
## Intent

Record the running no-mistakes build identity on SQLite run records so issue debugging can answer which version was used. Every newly created and subsequently updated run record must retain durable version and build/git SHA fields: use the same package/version identity users see through --version or package metadata, and the binary build SHA with the existing embedded release build identity as the preferred source, documenting that exact source. Keep readers backward compatible through a safe additive nullable migration, without secrets in the local database. Exercise the real SQLite write/read path behaviorally to prove the version and SHA land on a run, and add a concise operator/debugging note identifying the fields.

## What Changed

- Added nullable `no_mistakes_version` and `no_mistakes_build_sha` columns to the `runs` table via an additive migration, and threaded the fields through `runColumns`, `scanRun`, and the insert path so every newly created run persists the running binary's version (`buildinfo.CurrentVersion()`) and embedded build SHA (`buildinfo.Commit`); legacy rows stay nil.
- Documented the fields as an operator/debugging aid in the gate-model concept doc and added a run-scoped evidence note describing the build-identity source.
- Extended `internal/db` tests to exercise the real SQLite write/read path, proving version and build SHA land on and read back from a run record.

## Risk Assessment

✅ Low: Small, additive, nullable-migration change with an idempotent migration runner, a single populated insert path, no UPDATE clobbering the new fields, no secrets stored, and a behavioral write/read test proving the fields persist; it fully satisfies the stated intent.

## Testing

Baseline targeted db tests (including the new TestRunInsertAndUpdatePreserveBuildIdentity and the legacy-migration/schema tests) pass under -race. For end-user-aligned evidence I built the binary with the same release-style -ldflags used at release, captured its `--version` output, then drove the real SQLite InsertRun/UpdateRunStatus path and read the raw persisted columns back, showing runs.no_mistakes_version and runs.no_mistakes_build_sha land on the run and exactly match the `--version` identity; the migration test confirms legacy rows stay NULL. This is a DB/CLI change with no rendered UI surface, so evidence is a CLI/DB transcript rather than a screenshot. Overall result: intent satisfied, no findings.

<details>
<summary>Evidence: Persisted DB identity matches --version (transcript)</summary>

Source: [Persisted DB identity matches --version (transcript)](https://github.com/kunchenguid/no-mistakes/blob/b6cb27211be3819cbb4c4788f8a280d921768121/.no-mistakes/evidence/fm/nm-run-version-sha-r1/build-identity-on-run.md)

```text
$ no-mistakes --version
no-mistakes version v1.47.0 (df002d9) 2026-08-07

persisted runs row: runs.no_mistakes_version = v1.47.0 | runs.no_mistakes_build_sha = df002d9
MATCH: persisted DB identity == running binary --version identity
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b6cb27211be3819cbb4c4788f8a280d921768121","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`go test -race -run &#39;TestRunInsertAndUpdatePreserveBuildIdentity|TestOpenMigratesRunSyncProvenanceWithoutBackfillingMutableHead|TestOpenCreatesSchema|TestInsertRunWithIntent|TestRunInsertAndGet&#39; ./internal/db/` (all pass)</code>
- <code>Built `./cmd/no-mistakes` with release-style `-ldflags` (Version=v1.47.0, Commit=df002d9) and ran `no-mistakes --version`</code>
- <code>Exercised `db.InsertRun` + `db.UpdateRunStatus` then read back the RAW persisted `no_mistakes_version` / `no_mistakes_build_sha` SQLite columns and confirmed they equal the `--version` identity</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
