### PR TITLE
fix(scm/github): target checks repository explicitly

### DIFF
--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -121,6 +121,23 @@ func (h *Host) repoArgs() []string {
 	return []string{"--repo", h.repo}
 }
 
+// repoArgsForPR keeps PR commands independent of cwd even when the host was
+// constructed without a repository slug. The PR URL is an authoritative
+// repository identity, so it is safe to derive the --repo value from it. If
+// neither source identifies a repository, it fails closed rather than
+// allowing gh to infer one from cwd.
+func (h *Host) repoArgsForPR(pr *scm.PR) ([]string, error) {
+	if args := h.repoArgs(); len(args) != 0 {
+		return args, nil
+	}
+	if pr != nil {
+		if repo := HostPrefixedSlug(pr.URL); repo != "" {
+			return []string{"--repo", repo}, nil
+		}
+	}
+	return nil, errors.New("no repository known; refusing to run gh with cwd-inferred repository")
+}
+
 // prSelector returns the explicit gh PR selector for pr, preferring the numeric
 // PR number and falling back to the canonical PR URL; both name the exact pull
 // request to gh regardless of the process working directory. It fails closed
@@ -297,7 +314,11 @@ func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
 	if err != nil {
 		return nil, err
 	}
-	args := append([]string{"pr", "checks", selector}, h.repoArgs()...)
+	repoArgs, err := h.repoArgsForPR(pr)
+	if err != nil {
+		return nil, err
+	}
+	args := append([]string{"pr", "checks", selector}, repoArgs...)
 	args = append(args, "--json", "name,state,bucket,completedAt,link")
 	cmd := h.cmd(ctx, "gh", args...)
 	out, err := cmd.CombinedOutput()

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -223,10 +223,10 @@ func TestGetChecksFallsBackToStateWhenBucketMissing(t *testing.T) {
 	t.Parallel()
 
 	host := New(githubTestCmdFactory(map[string]githubTestResponse{
-		"gh pr checks 123 --json name,state,bucket,completedAt,link": {
+		"gh pr checks 123 --repo test/repo --json name,state,bucket,completedAt,link": {
 			stdout: `[{"name":"build","state":"FAILURE","bucket":""},{"name":"tests","state":"PENDING","bucket":""}]` + "\n",
 		},
-	}), nil, "", "")
+	}), nil, "", "test/repo")
 
 	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
 	if err != nil {
@@ -307,6 +307,48 @@ func TestGetChecksTargetsKnownPRByURLWhenNumberMissing(t *testing.T) {
 	}
 }
 
+// GetChecks must carry both identities when the daemon invokes gh outside a
+// repository. A PR selector alone does not give gh repository context.
+func TestGetChecksFromNonGitCWDPassesRepoAndPR(t *testing.T) {
+	t.Parallel()
+
+	var recorded [][]string
+	record := recordingCmdFactory("[]\n", &recorded)
+	nonGitDir := t.TempDir()
+	host := New(func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		cmd := record(ctx, name, args...)
+		cmd.Dir = nonGitDir
+		return cmd
+	}, nil, "", "")
+
+	prURL := "https://github.com/test/repo/pull/123"
+	if _, err := host.GetChecks(context.Background(), &scm.PR{URL: prURL}); err != nil {
+		t.Fatalf("GetChecks() error = %v", err)
+	}
+	if len(recorded) != 1 {
+		t.Fatalf("expected exactly one gh invocation, got %d: %v", len(recorded), recorded)
+	}
+	got := recorded[0]
+	if len(got) < 6 || got[1] != "pr" || got[2] != "checks" {
+		t.Fatalf("unexpected argv: %v", got)
+	}
+	if got[3] != prURL {
+		t.Fatalf("check selector = %q, want %q", got[3], prURL)
+	}
+	if got[4] != "--repo" || got[5] != "test/repo" {
+		t.Fatalf("repository targeting = %v, want --repo test/repo", got[4:])
+	}
+}
+
+func TestGetChecksFailsClosedWithoutRepository(t *testing.T) {
+	t.Parallel()
+
+	host := New(failIfInvokedCmdFactory(t), nil, "", "")
+	if _, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"}); err == nil {
+		t.Fatal("GetChecks() with no repository: expected error, got nil")
+	}
+}
+
 // Compare with the proven explicit-PR invocation: when the number is known it is
 // passed verbatim as the selector, exactly as before.
 func TestGetChecksTargetsKnownPRByNumber(t *testing.T) {
@@ -376,10 +418,10 @@ func TestGetChecksParsesCompletedAt(t *testing.T) {
 	t.Parallel()
 
 	host := New(githubTestCmdFactory(map[string]githubTestResponse{
-		"gh pr checks 123 --json name,state,bucket,completedAt,link": {
+		"gh pr checks 123 --repo test/repo --json name,state,bucket,completedAt,link": {
 			stdout: `[{"name":"build","state":"FAILURE","bucket":"fail","completedAt":"2026-04-24T04:15:00Z"},{"name":"tests","state":"SUCCESS","bucket":"pass","completedAt":"not-a-time"}]` + "\n",
 		},
-	}), nil, "", "")
+	}), nil, "", "test/repo")
 
 	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
 	if err != nil {
@@ -403,10 +445,10 @@ func TestGetChecksParsesStateAndLink(t *testing.T) {
 
 	const link = "https://github.com/test/repo/actions/runs/900/job/901"
 	host := New(githubTestCmdFactory(map[string]githubTestResponse{
-		"gh pr checks 123 --json name,state,bucket,completedAt,link": {
+		"gh pr checks 123 --repo test/repo --json name,state,bucket,completedAt,link": {
 			stdout: `[{"name":"build","state":"cancelled","bucket":"cancel","link":"` + link + `"}]` + "\n",
 		},
-	}), nil, "", "")
+	}), nil, "", "test/repo")
 
 	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "123"})
 	if err != nil {


### PR DESCRIPTION
## Summary
- derive and pass an explicit `--repo` for GitHub CI checks when the host lacks a slug
- fail closed when neither configured repository nor PR URL identifies a repository
- add regression coverage running `gh pr checks` from a non-Git cwd and asserting both exact PR and repository

## Reproduction
The daemon invokes `gh` from `/home/jlubrano/.no-mistakes`, which is not a Git repository. The existing v1.46.0 fix supplied the PR selector but could still omit `--repo`; this left `gh` without usable repository context and CI polling stayed active despite green checks. The regression asserts the complete argv: explicit PR URL and `--repo test/repo` from a temporary non-Git cwd. Fork owner routing and URL redaction behavior are unchanged.