### PR TITLE
fix(opencode): surface streamed text when StructuredOutputError has empty Message

### DIFF
--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -186,8 +186,44 @@ func (a *opencodeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, err
 		if mr.resp.Info.Error.Retries != nil {
 			retries = *mr.resp.Info.Error.Retries
 		}
+		errMsg := strings.TrimSpace(mr.resp.Info.Error.Message)
+		emptyMessage := errMsg == ""
+		if emptyMessage {
+			// opencode's StructuredOutputError sometimes arrives with an
+			// empty Message field — the wedge symptom where the model
+			// produced JSON-shaped prose but never invoked the
+			// StructuredOutput tool. Without a fallback the formatted error
+			// carries no diagnostic content (and the run's last_activity
+			// stays frozen on the cold-session notice while operators
+			// stare at it). Surface a stable explanation and pin the
+			// retries value so the operator can tell opencode already
+			// re-asked the model once.
+			errMsg = fmt.Sprintf("the model produced prose but did not call the StructuredOutput tool (opencode retryCount=%d in the message request body)", retries)
+		}
+		if emptyMessage && opts.OnLifecycle != nil {
+			// Send the streamed text opencode did receive as a lifecycle
+			// event. The pipeline's lifecycle wrapper routes default-phase
+			// events through TouchStepActivity, which updates last_activity
+			// and writes the line to the step log so the operator can see
+			// what the model actually produced before the
+			// StructuredOutput tool dropped its call.
+			streamed := state.lastFinalText
+			if streamed == "" {
+				streamed = state.lastText
+			}
+			excerpt := outputSnippet(streamed)
+			activity := "opencode structured output error: " + errMsg
+			if excerpt != "" {
+				activity += " - model output: " + excerpt
+			}
+			opts.OnLifecycle(LifecycleEvent{
+				Agent:   "opencode",
+				Phase:   LifecyclePhaseRetry,
+				Message: activity,
+			})
+		}
 		return nil, fmt.Errorf("opencode structured output failed after %d internal retries: %s",
-			retries, mr.resp.Info.Error.Message)
+			retries, errMsg)
 	}
 
 	// Fall back to parsing JSON from text

--- a/internal/agent/opencode_test.go
+++ b/internal/agent/opencode_test.go
@@ -520,3 +520,100 @@ func TestOpencodeAgent_StructuredOutputError(t *testing.T) {
 		t.Errorf("error must not embed the reasoning prose snippet, got %q", msg)
 	}
 }
+
+// TestOpencodeAgent_StructuredOutputErrorEmptyMessage guards the wedge
+// symptom where opencode reports info.error.name=StructuredOutputError
+// with an empty Message (the model produced prose but never invoked the
+// StructuredOutput tool). The agent must:
+//
+//  1. surface a non-empty fallback explanation in the error so the
+//     operator can tell what failed without digging through the run
+//     log, and
+//  2. fire a lifecycle activity event carrying an excerpt of the
+//     streamed text so no-mistakes axi status does not stay frozen on
+//     the cold-session notice while the run actually completed one
+//     tool-free model turn.
+func TestOpencodeAgent_StructuredOutputErrorEmptyMessage(t *testing.T) {
+	const streamedText = `{"action":"retry","reason":"prose"}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/session" && r.Method == http.MethodPost:
+			fmt.Fprint(w, `{"id":"s1"}`)
+
+		case r.URL.Path == "/global/event" && r.Method == http.MethodGet:
+			// Intentionally no text/message part updates: this mirrors
+			// the wedge condition where the SSE stream ends before the
+			// message is classified as assistant, so no OnChunk fires
+			// and last_activity would otherwise stay at the cold-session
+			// notice. The message response below seeds state.lastText
+			// from the response parts; the activity-event assertion
+			// checks that excerpt reaches OnLifecycle.
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, "data: {\"payload\":{\"type\":\"session.idle\"}}\n\n")
+
+		case r.URL.Path == "/session/s1/message" && r.Method == http.MethodPost:
+			// info.error.message is empty: the opencode wedge symptom.
+			fmt.Fprintf(w, `{"info":{"id":"msg1","role":"assistant","error":{"name":"StructuredOutputError","message":"","retries":0}},"parts":[{"type":"text","text":%q}]}`, streamedText)
+
+		case r.URL.Path == "/session/s1" && r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	a := &opencodeAgent{
+		bin:    "opencode",
+		server: &managedServer{port: mustParsePort(server.URL)},
+	}
+
+	var lifecycle []LifecycleEvent
+	result, err := a.Run(context.Background(), RunOpts{
+		Prompt:     "fix the failing tests",
+		CWD:        t.TempDir(),
+		JSONSchema: json.RawMessage(`{"type":"object","properties":{"summary":{"type":"string"}},"required":["summary"]}`),
+		OnLifecycle: func(ev LifecycleEvent) {
+			lifecycle = append(lifecycle, ev)
+		},
+	})
+	if err == nil {
+		t.Fatalf("expected error, got result %+v", result)
+	}
+	if result != nil {
+		t.Fatalf("expected nil result on error, got %+v", result)
+	}
+
+	msg := err.Error()
+	if !strings.Contains(msg, "structured output failed") {
+		t.Errorf("expected error to mention structured output failure, got %q", msg)
+	}
+	if !strings.Contains(msg, "model produced prose but did not call the StructuredOutput tool") {
+		t.Errorf("expected fallback explanation in error, got %q", msg)
+	}
+	if !strings.Contains(msg, "0 internal retries") {
+		t.Errorf("expected error to surface retry count, got %q", msg)
+	}
+	if strings.Contains(msg, streamedText) {
+		t.Errorf("error must not embed the streamed prose snippet, got %q", msg)
+	}
+
+	if len(lifecycle) == 0 {
+		t.Fatalf("expected OnLifecycle event carrying streamed text excerpt, got none")
+	}
+	var activityForError LifecycleEvent
+	for _, ev := range lifecycle {
+		if ev.Agent == "opencode" && strings.Contains(ev.Message, streamedText) && strings.Contains(ev.Message, "structured output error") {
+			activityForError = ev
+			break
+		}
+	}
+	if activityForError.Message == "" {
+		t.Fatalf("expected OnLifecycle activity event from opencode with streamed text excerpt, got %+v", lifecycle)
+	}
+	if !strings.Contains(activityForError.Message, "- model output: ") {
+		t.Errorf("expected activity event to label the streamed excerpt, got %q", activityForError.Message)
+	}
+}


### PR DESCRIPTION
fix(opencode): surface streamed text when StructuredOutputError has empty Message

The opencode `StructuredOutputError` wedge shows up as a step failure with
no diagnostic content and a frozen `last_activity`, because opencode returns
`info.error.name = StructuredOutputError` with an empty `Message` field when
the model emits JSON-shaped prose but never invokes the `StructuredOutput`
tool after the configured retries. Operators see "opencode structured
output failed after N internal retries: " followed by nothing, and
`no-mistakes axi status` stays parked on the cold-session notice while the
run actually completed one tool-free model turn.

The path is guarded to fire only on that combination: existing
`StructuredOutputError` handling stays unchanged when `Message` is
non-empty. When `Message` is empty:

- Replace it with a stable fallback explanation so the formatted step
  error carries diagnostic content (no more "...0 internal retries: ").
  Pins the opencode retry count so the operator can tell opencode already
  re-asked the model once.
- Fire `opts.OnLifecycle` with a default-phase event whose `Message`
  embeds the excerpt opencode did stream. The pipeline's lifecycle
  wrapper routes default-phase events through `TouchStepActivity`, which
  writes the line to the step log and updates `last_activity` so
  `no-mistakes axi status` does not stay frozen on the cold-session
  notice.

Reuses `outputSnippet` (already in the `agent` package) for the excerpt
cap. No new public API surface, no signature changes. Local-only tooling
change shipped direct-PR per the captain-approved option 1.

### Test plan

- Existing `TestOpencodeAgent_StructuredOutputError` (non-empty
  `Message`) still passes; verifies the guard does not fire.
- New `TestOpencodeAgent_StructuredOutputErrorEmptyMessage` synthesises
  `info.error = {name: "StructuredOutputError", retries: 0, message: ""}`
  with empty SSE text and asserts both the fallback string in the error
  and the streamed text excerpt reaching `OnLifecycle`.
- `go test -race ./internal/agent/...` and
  `go test -race ./internal/pipeline/...` pass.
