### PR TITLE
feat(eval): add local review evaluation toolkit

### DIFF
--- a/.no-mistakes/evidence/fm/nm-eval-mvp-build-r1/eval-journey.txt
+++ b/.no-mistakes/evidence/fm/nm-eval-mvp-build-r1/eval-journey.txt
@@ -1,0 +1,30 @@
+=== RUN   TestEvalJourney
+    eval_test.go:68: eval capture output:
+        captured 1 local review case(s)
+          01KZPZ30A0VBN01FMS6FV8YZD1-01KZPZ30TZZF4755NJ26J92C0B  run 01KZPZ30A0VBN01FMS6FV8YZD1 round 01KZPZ30TZZF4755NJ26J92C0B
+    eval_test.go:77: eval sets output:
+        LOCAL-ONLY EVAL CASE SETS
+        
+        all: 1 cases, 1 verdict labels (park 0, pass 1), 0 candidate findings queued
+          1  repo=a1cddd92e3aa, language=go, size=tiny, severity=warning
+        
+        labeled: 1 cases, 1 verdict labels (park 0, pass 1), 0 candidate findings queued
+          1  repo=a1cddd92e3aa, language=go, size=tiny, severity=warning
+        
+        diversified: 1 cases, 1 verdict labels (park 0, pass 1), 0 candidate findings queued
+          1  repo=a1cddd92e3aa, language=go, size=tiny, severity=warning
+    eval_test.go:87: eval run output:
+        local eval session 1786403456457907000-4b71a9a43b137d00: 1 replay(s), candidate claude+claude-opus-4-7, repeats 1
+    eval_test.go:104: eval report output:
+        LOCAL-ONLY EVAL REPORT
+        
+        claude+claude-opus-4-7 (cohort f4ba77fa98425e45)
+          replays: 1 across 1 repeat(s); labeled: 1; failures: 0
+          confirmed verdict agreement: 0.0% (0/0); conservative lower bound: 0.0%
+          queued unexpected parks: 1 (not scored wrong pending finding-level adjudication)
+          token cost: 28 fresh-input + output tokens per reported replay
+          wall time: 0.0s average
+          accuracy-vs-cost frontier: true
+--- PASS: TestEvalJourney (3.70s)
+PASS
+ok  	github.com/kunchenguid/no-mistakes/internal/e2e	4.024s

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -48,6 +48,7 @@ export default defineConfig({
           label: "Reference",
           items: [
             { label: "CLI Commands", slug: "reference/cli" },
+            { label: "Evaluation toolkit", slug: "reference/eval" },
             { label: "Pipeline Steps", slug: "reference/pipeline-steps" },
             { label: "Global Config", slug: "reference/global-config" },
             { label: "Repo Config", slug: "reference/repo-config" },

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -369,6 +369,12 @@ no-mistakes runs [--limit <n>]
 
 Shows runs newest-first with branch, status (styled), short SHA, timestamp, and PR URL if set.
 
+## no-mistakes eval
+
+Capture local review-round cases, inspect case sets before spending tokens, replay an explicit agent and model in isolation, and report verdict accuracy, token cost, wall time, and the accuracy-versus-cost frontier.
+
+See [Evaluation toolkit](/no-mistakes/reference/eval/) for the local-only boundary, capture prerequisite, command flags, label policy, and reporting semantics.
+
 ## no-mistakes stats
 
 Show historical usage stats across all repos.

--- a/docs/src/content/docs/reference/environment.md
+++ b/docs/src/content/docs/reference/environment.md
@@ -21,6 +21,7 @@ When set, everything else moves under this root:
 - Database: `$NM_HOME/state.sqlite`
 - Socket / PID / singleton lock: `$NM_HOME/socket`, `$NM_HOME/daemon.pid`, and `$NM_HOME/daemon.lock`
 - Managed agent server PID records: `$NM_HOME/servers/`
+- Opt-in evaluation cases and registry: `$NM_HOME/eval/` (created only by an explicit `no-mistakes eval` command)
 - Managed service names get a short stable suffix derived from `$NM_HOME` so multiple installs don't collide.
 
 ## `NM_DAEMON_CONNECT_TIMEOUT`
@@ -105,10 +106,10 @@ See [`GITHUB_TOKEN`](#github_token) for the updater's authentication behavior an
 
 Opt source runs into recording the immutable local configuration provenance required by `no-mistakes eval capture`.
 
-|         |                                                      |
-| ------- | ---------------------------------------------------- |
-| Type    | `1` to enable, anything else to leave disabled       |
-| Default | unset (normal pipeline rounds record no eval data)   |
+|         |                                                          |
+| ------- | -------------------------------------------------------- |
+| Type    | `1` to enable, anything else to leave disabled           |
+| Default | unset (normal pipeline rounds record no eval provenance) |
 
 Set this in the daemon environment before starting a source run that you intend to capture. It does not enable replay, send data, or change pipeline decisions. See [Evaluation toolkit](/no-mistakes/reference/eval/).
 

--- a/docs/src/content/docs/reference/environment.md
+++ b/docs/src/content/docs/reference/environment.md
@@ -101,6 +101,17 @@ Fallback GitHub token used by `no-mistakes update` when `GITHUB_TOKEN` is unset 
 
 See [`GITHUB_TOKEN`](#github_token) for the updater's authentication behavior and precedence.
 
+## `NO_MISTAKES_EVAL_CAPTURE_PROVENANCE`
+
+Opt source runs into recording the immutable local configuration provenance required by `no-mistakes eval capture`.
+
+|         |                                                      |
+| ------- | ---------------------------------------------------- |
+| Type    | `1` to enable, anything else to leave disabled       |
+| Default | unset (normal pipeline rounds record no eval data)   |
+
+Set this in the daemon environment before starting a source run that you intend to capture. It does not enable replay, send data, or change pipeline decisions. See [Evaluation toolkit](/no-mistakes/reference/eval/).
+
 ## `NO_MISTAKES_NO_UPDATE_CHECK`
 
 Disable background update checks.

--- a/docs/src/content/docs/reference/eval.md
+++ b/docs/src/content/docs/reference/eval.md
@@ -12,10 +12,10 @@ It is separate from normal pipeline operation. It does not start or use the shar
 no-mistakes eval capture <run-id>
 ```
 
-Capture exports one case for each persisted Review pass in the run. A case includes:
+Capture exports one case for each persisted Review pass in the run. If Review is still parked, capture waits for its gate decision to be recorded rather than freezing an incomplete label. A case includes:
 
-- a self-contained Git bundle for the reviewed commit, base, and pinned trusted-config commit
-- agent-neutral global configuration and the effective repository configuration
+- a self-contained Git bundle for the reviewed commit, base, and trusted-config commit pinned at capture
+- agent-neutral global configuration and the effective repository configuration frozen at capture
 - the original run, step, review-round, decision, and local invocation-metric records
 - a manifest with commit pins, changed-file counts, build identity, and a hash of the redacted remote URL
 - a local `labels.json` file that can grow in later evaluation phases
@@ -72,7 +72,7 @@ The report groups all local replays by candidate and shows:
 - a 95% Wilson score confidence interval over cases, with repeats averaged inside each case
 - whether a candidate lies on the observed accuracy-versus-token-cost frontier
 
-The report is deliberately cautious. It never treats an unadjudicated candidate finding as a false positive, and it distinguishes missing token instrumentation from a real zero.
+The report is deliberately cautious. It never treats an unadjudicated candidate finding as a false positive, excludes candidates with failed replays from the frontier, and distinguishes missing token instrumentation from a real zero.
 
 ## MVP boundary
 

--- a/docs/src/content/docs/reference/eval.md
+++ b/docs/src/content/docs/reference/eval.md
@@ -12,7 +12,7 @@ It is separate from normal pipeline operation. It does not start or use the shar
 no-mistakes eval capture <run-id>
 ```
 
-Capture exports one case for each persisted Review pass in the run. If Review is still parked without a recorded gate decision, capture returns an error rather than freezing an incomplete label; retry after the decision is recorded. A case includes:
+Capture exports one case for each persisted Review pass in the run. The source daemon must have started with [`NO_MISTAKES_EVAL_CAPTURE_PROVENANCE=1`](/no-mistakes/reference/environment/#no_mistakes_eval_capture_provenance); normal pipeline runs do not record eval provenance. If Review is still parked without a recorded gate decision, capture returns an error rather than freezing an incomplete label; retry after the decision is recorded. A case includes:
 
 - a self-contained Git bundle for the reviewed commit, base, and trusted-config commit pinned at capture
 - agent-neutral global configuration and the effective repository configuration frozen at capture

--- a/docs/src/content/docs/reference/eval.md
+++ b/docs/src/content/docs/reference/eval.md
@@ -69,7 +69,7 @@ The report groups all local replays by candidate and shows:
 - queued unexpected parks and failed candidate invocations
 - reported fresh-input plus output token cost
 - average wall time
-- a 95% paired bootstrap confidence interval over cases, with repeats averaged inside each case
+- a 95% Wilson score confidence interval over cases, with repeats averaged inside each case
 - whether a candidate lies on the observed accuracy-versus-token-cost frontier
 
 The report is deliberately cautious. It never treats an unadjudicated candidate finding as a false positive, and it distinguishes missing token instrumentation from a real zero.

--- a/docs/src/content/docs/reference/eval.md
+++ b/docs/src/content/docs/reference/eval.md
@@ -12,7 +12,7 @@ It is separate from normal pipeline operation. It does not start or use the shar
 no-mistakes eval capture <run-id>
 ```
 
-Capture exports one case for each persisted Review pass in the run. If Review is still parked, capture waits for its gate decision to be recorded rather than freezing an incomplete label. A case includes:
+Capture exports one case for each persisted Review pass in the run. If Review is still parked without a recorded gate decision, capture returns an error rather than freezing an incomplete label; retry after the decision is recorded. A case includes:
 
 - a self-contained Git bundle for the reviewed commit, base, and trusted-config commit pinned at capture
 - agent-neutral global configuration and the effective repository configuration frozen at capture

--- a/docs/src/content/docs/reference/eval.md
+++ b/docs/src/content/docs/reference/eval.md
@@ -1,0 +1,79 @@
+---
+title: Evaluation toolkit
+---
+
+`no-mistakes eval` is an opt-in, **local-only** toolkit for comparing review candidates against review passes your own pipeline has already recorded.
+
+It is separate from normal pipeline operation. It does not start or use the shared daemon, alter a gate, add configuration, emit remote telemetry, push a branch, open a PR, or run CI. Case bundles, source findings, decisions, candidate outputs, and metrics stay under `<NM_HOME>/eval/`.
+
+## Capture a run
+
+```sh
+no-mistakes eval capture <run-id>
+```
+
+Capture exports one case for each persisted Review pass in the run. A case includes:
+
+- a self-contained Git bundle for the reviewed commit, base, and pinned trusted-config commit
+- agent-neutral global configuration and the effective repository configuration
+- the original run, step, review-round, decision, and local invocation-metric records
+- a manifest with commit pins, changed-file counts, build identity, and a hash of the redacted remote URL
+- a local `labels.json` file that can grow in later evaluation phases
+
+The manifest never stores a remote URL. Capture is read-only against the existing local database and gate. It does not fetch from the network.
+
+## Inspect case sets before spending tokens
+
+```sh
+no-mistakes eval sets
+```
+
+The command shows counts, verdict-label coverage, queued candidate findings, and composition by repository fingerprint, dominant language, change-size bucket, and source severity.
+
+Three logical sets are available to replay:
+
+- `all` - every captured review pass
+- `labeled` - only cases with a verdict label derived from a recorded human gate decision
+- `diversified` - a deterministic representative, retaining one earliest case per repository, language, size, and expected-verdict bucket
+
+## Replay a candidate
+
+```sh
+no-mistakes eval run \
+  --cases diversified \
+  --candidate codex+gpt-5.4 \
+  --repeats 3
+```
+
+A candidate is always explicit: `agent+model`. The replay restores each case into a fresh temporary bare gate and worktree, then invokes only the existing Review step. Push, PR, CI, test, lint, document, and fix loops are outside this MVP.
+
+The captured human gate decision supplies the verdict policy:
+
+- a recorded user-selected fix means the candidate should park
+- a recorded human approval or skip means the candidate should pass
+- incomplete or ambiguous historical decisions are left unlabeled and excluded from verdict scoring
+
+If a candidate parks on a human-pass case, the finding is queued locally for later adjudication. It is not automatically called wrong. This protects potentially good, unexpected findings until finding-level labeling exists.
+
+`--repeats` defaults to `3` and must be at least `1`. Replays are intentionally isolated from the production `NM_HOME`; they do not contact the shared no-mistakes daemon. The selected agent still communicates with its configured model provider in the normal way.
+
+## Report results
+
+```sh
+no-mistakes eval report
+```
+
+The report groups all local replays by candidate and shows:
+
+- confirmed verdict agreement and its conservative lower bound
+- queued unexpected parks and failed candidate invocations
+- reported fresh-input plus output token cost
+- average wall time
+- a 95% paired bootstrap confidence interval over cases, with repeats averaged inside each case
+- whether a candidate lies on the observed accuracy-versus-token-cost frontier
+
+The report is deliberately cautious. It never treats an unadjudicated candidate finding as a false positive, and it distinguishes missing token instrumentation from a real zero.
+
+## MVP boundary
+
+The MVP measures verdict-level agreement only. Finding-level valid/invalid labels, an adjudication CLI, matching candidate findings to labels, PR-comment miss scanning, precision/recall/F1, holdouts, sharing, sync, and full-pipeline replay are not part of this command surface.

--- a/docs/src/content/docs/reference/eval.md
+++ b/docs/src/content/docs/reference/eval.md
@@ -4,7 +4,9 @@ title: Evaluation toolkit
 
 `no-mistakes eval` is an opt-in, **local-only** toolkit for comparing review candidates against review passes your own pipeline has already recorded.
 
-It is separate from normal pipeline operation. It does not start or use the shared daemon, alter a gate, add configuration, emit remote telemetry, push a branch, open a PR, or run CI. Case bundles, source findings, decisions, candidate outputs, and metrics stay under `<NM_HOME>/eval/`.
+It is separate from normal pipeline operation. It does not start or use the shared daemon, alter a gate, add configuration, emit remote telemetry, push a branch, open a PR, or run CI. Case bundles, source findings, decisions, candidate outputs, and metrics are stored only under `<NM_HOME>/eval/`; there is no export, sharing, synchronization, or remote case store.
+
+Replay does invoke the selected agent normally, so that agent may send the restored code and review context to its configured model provider. The local-only guarantee concerns eval storage and transport added by no-mistakes, not the selected agent's ordinary provider traffic.
 
 ## Capture a run
 
@@ -47,15 +49,15 @@ no-mistakes eval run \
 
 A candidate is always explicit: `agent+model`. The replay restores each case into a fresh temporary bare gate and worktree, then invokes only the existing Review step. Push, PR, CI, test, lint, document, and fix loops are outside this MVP.
 
-The captured human gate decision supplies the verdict policy:
+The captured human gate evidence supplies the verdict policy:
 
-- a recorded user-selected fix means the candidate should park
-- a recorded human approval or skip means the candidate should pass
-- incomplete or ambiguous historical decisions are left unlabeled and excluded from verdict scoring
+- a user selection recorded for a fix means the candidate should park
+- a skipped Review gate, or a completed gate whose recorded findings required a user decision, means the candidate should pass
+- clean completions, approvals that cannot be established from the persisted round, and other incomplete or ambiguous historical decisions remain unlabeled and are excluded from verdict scoring
 
 If a candidate parks on a human-pass case, the finding is queued locally for later adjudication. It is not automatically called wrong. This protects potentially good, unexpected findings until finding-level labeling exists.
 
-`--repeats` defaults to `3` and must be at least `1`. Replays are intentionally isolated from the production `NM_HOME`; they do not contact the shared no-mistakes daemon. The selected agent still communicates with its configured model provider in the normal way.
+`--repeats` defaults to `3` and must be at least `1`. Candidates must use an agent that can enforce an explicit model; ACP targets such as `cursor` and `acp:<target>` are rejected. Replays are intentionally isolated from the production `NM_HOME`; they do not contact the shared no-mistakes daemon. The selected agent still communicates with its configured model provider in the normal way.
 
 ## Report results
 
@@ -63,7 +65,7 @@ If a candidate parks on a human-pass case, the finding is queued locally for lat
 no-mistakes eval report
 ```
 
-The report groups all local replays by candidate and shows:
+The report groups local replays by candidate and cohort. A cohort pins the selected case IDs and repeat count, so frontier comparisons only compare candidates run over the same corpus and repeat plan. It shows:
 
 - confirmed verdict agreement and its conservative lower bound
 - queued unexpected parks and failed candidate invocations

--- a/internal/agent/acpx.go
+++ b/internal/agent/acpx.go
@@ -36,7 +36,7 @@ func (a *acpxAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) 
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD
 	cmd.Stdin = nil
-	cmd.Env = gitSafeEnv(opts.CWD)
+	cmd.Env = gitSafeEnv(opts.CWD, opts.Env)
 	shellenv.ConfigureShellCommand(cmd)
 
 	started, err := startNativeAgentCommand(cmd)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -22,7 +22,10 @@ type Agent interface {
 
 // RunOpts configures a single agent invocation.
 type RunOpts struct {
-	Prompt      string
+	Prompt string
+	// Env appends invocation-scoped environment entries to the agent process.
+	// Entries later in the slice override inherited values.
+	Env         []string
 	CWD         string
 	JSONSchema  json.RawMessage      // structured output schema (optional)
 	OnChunk     func(text string)    // streaming text callback (optional)

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -77,7 +77,7 @@ func (a *claudeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error
 	// bytes out of argv and lets Cmd own the bounded concurrent copy, including
 	// EOF, early-child-exit, cancellation, and WaitDelay cleanup paths.
 	cmd.Stdin = strings.NewReader(opts.Prompt)
-	cmd.Env = gitSafeEnv(opts.CWD)
+	cmd.Env = gitSafeEnv(opts.CWD, opts.Env)
 	shellenv.ConfigureShellCommand(cmd)
 
 	var stderrBuf []byte

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -93,7 +93,7 @@ func (a *codexAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error)
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD
 	cmd.Stdin = nil
-	cmd.Env = gitSafeEnv(opts.CWD)
+	cmd.Env = gitSafeEnv(opts.CWD, opts.Env)
 	shellenv.ConfigureShellCommand(cmd)
 
 	var stderrBuf []byte

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -40,7 +40,7 @@ func (a *copilotAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, erro
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD
 	cmd.Stdin = nil
-	cmd.Env = gitSafeEnv(opts.CWD)
+	cmd.Env = gitSafeEnv(opts.CWD, opts.Env)
 	shellenv.ConfigureShellCommand(cmd)
 
 	var stderrBuf []byte

--- a/internal/agent/env.go
+++ b/internal/agent/env.go
@@ -28,6 +28,10 @@ const GateRoleEnvVar = "NO_MISTAKES_GATE"
 //
 // dir must be the value assigned to cmd.Dir so PWD stays coupled to the working
 // directory; see git.NonInteractiveEnv for why this matters.
-func gitSafeEnv(dir string) []string {
-	return append(git.NonInteractiveEnv(dir), GateRoleEnvVar+"=1")
+func gitSafeEnv(dir string, extra ...[]string) []string {
+	env := append(git.NonInteractiveEnv(dir), GateRoleEnvVar+"=1")
+	if len(extra) > 0 {
+		env = append(env, extra[0]...)
+	}
+	return env
 }

--- a/internal/agent/env.go
+++ b/internal/agent/env.go
@@ -29,9 +29,9 @@ const GateRoleEnvVar = "NO_MISTAKES_GATE"
 // dir must be the value assigned to cmd.Dir so PWD stays coupled to the working
 // directory; see git.NonInteractiveEnv for why this matters.
 func gitSafeEnv(dir string, extra ...[]string) []string {
-	env := append(git.NonInteractiveEnv(dir), GateRoleEnvVar+"=1")
+	env := git.NonInteractiveEnv(dir)
 	if len(extra) > 0 {
 		env = append(env, extra[0]...)
 	}
-	return env
+	return append(env, GateRoleEnvVar+"=1")
 }

--- a/internal/agent/env_test.go
+++ b/internal/agent/env_test.go
@@ -1,7 +1,9 @@
 package agent
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 	"runtime"
 	"strings"
 	"testing"
@@ -68,32 +70,23 @@ func TestGitSafeEnv_StampsGateRoleMarker(t *testing.T) {
 	}
 }
 
-// TestGitSafeEnv_GateMarkerWinsOverAmbient guards that a target repo (or a
-// confused parent) cannot pre-empt the marker with its own ambient value: the
-// stamp is appended last, and exec resolves duplicate keys to the last
-// occurrence.
-func TestEverySupportedAdapterPropagatesGateMarkerThroughCanonicalEnv(t *testing.T) {
-	// Native one-shot adapters own their command in the named file. OpenCode
-	// and Rovo Dev use the shared managed-server launcher, while Cursor and
-	// arbitrary ACP targets use acpx. Every route must stay on gitSafeEnv so
-	// marker propagation cannot drift adapter by adapter.
-	owners := map[string]string{
-		"claude":                          "claude.go",
-		"codex":                           "codex.go",
-		"copilot":                         "copilot.go",
-		"pi":                              "pi.go",
-		"cursor/acp":                      "acpx.go",
-		"opencode/rovodev managed server": "server.go",
+func TestGitSafeEnvIsObservedBySpawnedProcess(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=^TestAgentEnvProbe$")
+	cmd.Env = gitSafeEnv(t.TempDir(), []string{"NM_HOME=/isolated/eval", GateRoleEnvVar + "=0", "NM_TEST_ENV_PROBE=1"})
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("run environment probe: %v", err)
 	}
-	for adapter, path := range owners {
-		data, err := os.ReadFile(path)
-		if err != nil {
-			t.Fatalf("read %s owner %s: %v", adapter, path, err)
-		}
-		if !strings.Contains(string(data), ".Env = gitSafeEnv(") {
-			t.Errorf("%s no longer propagates the gate marker through gitSafeEnv (%s)", adapter, path)
-		}
+	if got := string(output); !strings.HasPrefix(got, "/isolated/eval|1") {
+		t.Fatalf("spawned environment = %q, want isolated home and gate marker", got)
 	}
+}
+
+func TestAgentEnvProbe(t *testing.T) {
+	if os.Getenv("NM_TEST_ENV_PROBE") != "1" {
+		return
+	}
+	fmt.Printf("%s|%s", os.Getenv("NM_HOME"), os.Getenv(GateRoleEnvVar))
 }
 
 func TestGitSafeEnv_GateMarkerWinsOverAmbient(t *testing.T) {

--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -41,7 +41,7 @@ func (a *opencodeAgent) recoverTransientRetry(label string) {
 
 func (a *opencodeAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 	// Start server on first invocation (synchronized)
-	baseURL, err := a.ensureServer(ctx, opts.CWD)
+	baseURL, err := a.ensureServer(ctx, opts.CWD, opts.Env)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/opencode_http.go
+++ b/internal/agent/opencode_http.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-func (a *opencodeAgent) ensureServer(ctx context.Context, cwd string) (string, error) {
+func (a *opencodeAgent) ensureServer(ctx context.Context, cwd string, env []string) (string, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if a.server != nil {
@@ -21,7 +21,7 @@ func (a *opencodeAgent) ensureServer(ctx context.Context, cwd string) (string, e
 		return "", fmt.Errorf("opencode port: %w", err)
 	}
 	args := buildOpencodeServeArgs(a.extraArgs, port)
-	srv, err := startServerWithPort(ctx, "opencode", a.bin, args, cwd, "/global/health", port)
+	srv, err := startServerWithPort(ctx, "opencode", a.bin, args, cwd, "/global/health", port, env)
 	if err != nil {
 		return "", fmt.Errorf("opencode server: %w", err)
 	}

--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -52,7 +52,7 @@ func (a *piAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 	args := a.buildArgs()
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD
-	cmd.Env = gitSafeEnv(opts.CWD)
+	cmd.Env = gitSafeEnv(opts.CWD, opts.Env)
 	shellenv.ConfigureShellCommand(cmd)
 
 	stdin, err := cmd.StdinPipe()

--- a/internal/agent/rovodev.go
+++ b/internal/agent/rovodev.go
@@ -46,7 +46,7 @@ func (a *rovodevAgent) recoverTransientRetry(label string) {
 
 func (a *rovodevAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 	// Start server on first invocation (synchronized)
-	baseURL, err := a.ensureServer(ctx, opts.CWD)
+	baseURL, err := a.ensureServer(ctx, opts.CWD, opts.Env)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func (a *rovodevAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, erro
 	return finalizeTextResult("rovodev", text, opts.JSONSchema, usage)
 }
 
-func (a *rovodevAgent) ensureServer(ctx context.Context, cwd string) (string, error) {
+func (a *rovodevAgent) ensureServer(ctx context.Context, cwd string, env []string) (string, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if a.server != nil {
@@ -94,7 +94,7 @@ func (a *rovodevAgent) ensureServer(ctx context.Context, cwd string) (string, er
 		return "", fmt.Errorf("rovodev port: %w", err)
 	}
 	args := buildRovodevServeArgs(a.extraArgs, port)
-	srv, err := startServerWithPort(ctx, "rovodev", a.bin, args, cwd, "/healthcheck", port)
+	srv, err := startServerWithPort(ctx, "rovodev", a.bin, args, cwd, "/healthcheck", port, env)
 	if err != nil {
 		return "", fmt.Errorf("rovodev server: %w", err)
 	}

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -73,11 +73,15 @@ func getAvailablePort() (int, error) {
 // The process is not tied to ctx - it outlives individual Run calls and is stopped via shutdown().
 // ctx is only used for the health check timeout.
 // agentName tags the PID tracking file so crash-recovery can identify orphans.
-func startServerWithPort(ctx context.Context, agentName, bin string, args []string, cwd string, healthPath string, port int) (*managedServer, error) {
+func startServerWithPort(ctx context.Context, agentName, bin string, args []string, cwd string, healthPath string, port int, extraEnv ...[]string) (*managedServer, error) {
 	cmd := exec.Command(bin, args...)
 	cmd.Dir = cwd
 	cmd.Stdin = nil
-	cmd.Env = gitSafeEnv(cwd)
+	var env []string
+	if len(extraEnv) > 0 {
+		env = extraEnv[0]
+	}
+	cmd.Env = gitSafeEnv(cwd, env)
 	out := currentManagedServerOutput()
 	cmd.Stdout = out // server stdout goes to the configured sink for debugging
 	cmd.Stderr = out

--- a/internal/cli/eval.go
+++ b/internal/cli/eval.go
@@ -1,0 +1,143 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/kunchenguid/no-mistakes/internal/eval"
+	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/spf13/cobra"
+)
+
+// newEvalCmd deliberately does not call trackCommand. Eval case bundles and
+// candidate results are local code data, so this opt-in surface has no remote
+// telemetry event and no dependency on the daemon.
+func newEvalCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "eval",
+		Short: "Capture and locally replay review evaluation cases",
+		Long:  "Capture review passes and compare agent+model candidates using local-only case bundles. Eval never starts or uses the shared daemon.",
+		Args:  cobra.NoArgs,
+	}
+	cmd.AddCommand(newEvalCaptureCmd())
+	cmd.AddCommand(newEvalRunCmd())
+	cmd.AddCommand(newEvalSetsCmd())
+	cmd.AddCommand(newEvalReportCmd())
+	return cmd
+}
+
+func newEvalCaptureCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "capture <run>",
+		Short: "Capture every review pass from a run into local portable cases",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			p, database, err := openResources()
+			if err != nil {
+				return err
+			}
+			defer database.Close()
+			store, err := eval.Open(p.EvalDir())
+			if err != nil {
+				return err
+			}
+			defer store.Close()
+			cases, err := eval.Capture(cmd.Context(), store, p, database, args[0])
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "captured %d local review case(s)\n", len(cases))
+			for _, c := range cases {
+				fmt.Fprintf(cmd.OutOrStdout(), "  %s  run %s round %s\n", c.ID, c.SourceRunID, c.SourceRoundID)
+			}
+			return nil
+		},
+	}
+}
+
+func newEvalRunCmd() *cobra.Command {
+	var cases string
+	var candidateRaw string
+	var repeats int
+	cmd := &cobra.Command{
+		Use:   "run --cases <all|labeled|diversified> --candidate <agent+model>",
+		Short: "Replay captured review passes in an isolated local sandbox",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			candidate, err := eval.ParseCandidate(candidateRaw)
+			if err != nil {
+				return err
+			}
+			p, err := paths.New()
+			if err != nil {
+				return fmt.Errorf("resolve eval paths: %w", err)
+			}
+			store, err := eval.Open(p.EvalDir())
+			if err != nil {
+				return err
+			}
+			defer store.Close()
+			session, evaluations, runErr := eval.Replay(cmd.Context(), store, eval.ReplayOptions{Set: cases, Candidate: candidate, Repeats: repeats})
+			fmt.Fprintf(cmd.OutOrStdout(), "local eval session %s: %d replay(s), candidate %s, repeats %d\n", session.ID, len(evaluations), candidate, repeats)
+			if runErr != nil {
+				return runErr
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&cases, "cases", "", "case set: all, labeled, or diversified")
+	cmd.Flags().StringVar(&candidateRaw, "candidate", "", "candidate as agent+model (for example codex+gpt-5.4)")
+	cmd.Flags().IntVar(&repeats, "repeats", 3, "replays per case (minimum 1)")
+	_ = cmd.MarkFlagRequired("cases")
+	_ = cmd.MarkFlagRequired("candidate")
+	return cmd
+}
+
+func newEvalSetsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "sets",
+		Short: "Inspect local case-set size, labels, and diversified composition",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			p, err := paths.New()
+			if err != nil {
+				return fmt.Errorf("resolve eval paths: %w", err)
+			}
+			store, err := eval.Open(p.EvalDir())
+			if err != nil {
+				return err
+			}
+			defer store.Close()
+			summaries, err := eval.InspectSets(store)
+			if err != nil {
+				return err
+			}
+			fmt.Fprint(cmd.OutOrStdout(), eval.RenderSets(summaries))
+			return nil
+		},
+	}
+}
+
+func newEvalReportCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "report",
+		Short: "Report local verdict accuracy, tokens, time, and cost frontier",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			p, err := paths.New()
+			if err != nil {
+				return fmt.Errorf("resolve eval paths: %w", err)
+			}
+			store, err := eval.Open(p.EvalDir())
+			if err != nil {
+				return err
+			}
+			defer store.Close()
+			reports, err := eval.Report(store)
+			if err != nil {
+				return err
+			}
+			fmt.Fprint(cmd.OutOrStdout(), eval.RenderReport(reports))
+			return nil
+		},
+	}
+}

--- a/internal/cli/eval_test.go
+++ b/internal/cli/eval_test.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/telemetry"
+)
+
+func TestEvalSetsIsLocalOnlyAndEmitsNoTelemetry(t *testing.T) {
+	t.Setenv("NM_HOME", t.TempDir())
+	chdir(t, t.TempDir())
+
+	recorder := &telemetryRecorder{}
+	restore := telemetry.SetDefaultForTesting(recorder)
+	defer restore()
+
+	out, err := executeCmd("eval", "sets")
+	if err != nil {
+		t.Fatalf("eval sets: %v", err)
+	}
+	if !strings.Contains(out, "LOCAL-ONLY EVAL CASE SETS") {
+		t.Fatalf("output = %q", out)
+	}
+	if recorder.count("command") != 0 || recorder.count("pageview") != 0 {
+		t.Fatalf("eval emitted remote telemetry: %#v", recorder.events)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -94,6 +94,7 @@ func newRootCmd() *cobra.Command {
 	cmd.AddCommand(newRunsCmd())
 	cmd.AddCommand(newStatsCmd())
 	cmd.AddCommand(newDoctorCmd())
+	cmd.AddCommand(newEvalCmd())
 	cmd.AddCommand(newAxiCmd())
 
 	return cmd

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -375,28 +375,29 @@ type AutoFix struct {
 
 // Config is the merged result of global + per-repo configuration.
 type Config struct {
-	ReplayGlobalYAML     []byte
-	ReplayRepoYAML       []byte
-	TrustedConfigSHA     string
-	Agent                types.AgentName
-	Agents               []types.AgentName
-	ACPXPath             string
-	ACPRegistryOverrides map[string]string
-	AgentPathOverride    map[string]string
-	AgentArgsOverride    map[string][]string
-	CITimeout            time.Duration
-	StepQuietWarning     time.Duration
-	LogLevel             string
-	SessionReuse         bool
-	Commands             Commands
-	IgnorePatterns       []string
-	AutoFix              AutoFix
-	CI                   CI
-	Commit               Commit
-	Intent               Intent
-	Test                 Test
-	Document             Document
-	Review               Review
+	ReplayGlobalYAML      []byte
+	ReplayRepoYAML        []byte
+	TrustedConfigSHA      string
+	CaptureEvalProvenance bool
+	Agent                 types.AgentName
+	Agents                []types.AgentName
+	ACPXPath              string
+	ACPRegistryOverrides  map[string]string
+	AgentPathOverride     map[string]string
+	AgentArgsOverride     map[string][]string
+	CITimeout             time.Duration
+	StepQuietWarning      time.Duration
+	LogLevel              string
+	SessionReuse          bool
+	Commands              Commands
+	IgnorePatterns        []string
+	AutoFix               AutoFix
+	CI                    CI
+	Commit                Commit
+	Intent                Intent
+	Test                  Test
+	Document              Document
+	Review                Review
 	// DisableProjectSettings is the resolved, trusted-only opt-out (see the
 	// RepoConfig field). When true, gate agents are launched with their
 	// project-level settings/instructions suppressed; the daemon fails the run
@@ -1658,10 +1659,7 @@ func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 		commit.FixMessage = *repo.Commit.FixMessage
 	}
 
-	repoYAML, _ := yaml.Marshal(repo)
 	cfg := &Config{
-		ReplayGlobalYAML:     append([]byte(nil), global.SourceYAML...),
-		ReplayRepoYAML:       repoYAML,
 		Agent:                global.Agent,
 		Agents:               copyAgents(global.Agents),
 		ACPXPath:             global.ACPXPath,
@@ -1696,4 +1694,18 @@ func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 	}
 
 	return cfg
+}
+
+func (c *Config) EnableEvalProvenance(global *GlobalConfig, repo *RepoConfig) error {
+	if c == nil || global == nil || repo == nil {
+		return fmt.Errorf("eval provenance requires merged, global, and repository configuration")
+	}
+	repoYAML, err := yaml.Marshal(repo)
+	if err != nil {
+		return fmt.Errorf("serialize eval repository configuration: %w", err)
+	}
+	c.ReplayGlobalYAML = append([]byte(nil), global.SourceYAML...)
+	c.ReplayRepoYAML = repoYAML
+	c.CaptureEvalProvenance = true
+	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1131,16 +1131,25 @@ func DefaultGlobalConfig() *GlobalConfig {
 
 // LoadGlobal reads global config from path. Returns defaults if file doesn't exist.
 func LoadGlobal(path string) (*GlobalConfig, error) {
-	cfg := DefaultGlobalConfig()
+	cfg, _, err := LoadGlobalSnapshot(path)
+	return cfg, err
+}
 
+func LoadGlobalSnapshot(path string) (*GlobalConfig, []byte, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			return cfg, nil
+			data = []byte("{}\n")
+		} else {
+			return nil, nil, fmt.Errorf("read global config: %w", err)
 		}
-		return nil, fmt.Errorf("read global config: %w", err)
 	}
+	cfg, err := LoadGlobalFromBytes(data)
+	return cfg, data, err
+}
 
+func LoadGlobalFromBytes(data []byte) (*GlobalConfig, error) {
+	cfg := DefaultGlobalConfig()
 	var raw globalConfigRaw
 	dec := yaml.NewDecoder(bytes.NewReader(data))
 	dec.KnownFields(true)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1131,21 +1131,15 @@ func DefaultGlobalConfig() *GlobalConfig {
 
 // LoadGlobal reads global config from path. Returns defaults if file doesn't exist.
 func LoadGlobal(path string) (*GlobalConfig, error) {
-	cfg, _, err := LoadGlobalSnapshot(path)
-	return cfg, err
-}
-
-func LoadGlobalSnapshot(path string) (*GlobalConfig, []byte, error) {
+	cfg := DefaultGlobalConfig()
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
-			data = []byte("{}\n")
-		} else {
-			return nil, nil, fmt.Errorf("read global config: %w", err)
+			return cfg, nil
 		}
+		return nil, fmt.Errorf("read global config: %w", err)
 	}
-	cfg, err := LoadGlobalFromBytes(data)
-	return cfg, data, err
+	return LoadGlobalFromBytes(data)
 }
 
 func LoadGlobalFromBytes(data []byte) (*GlobalConfig, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,6 +62,7 @@ const (
 
 // GlobalConfig represents ~/.no-mistakes/config.yaml.
 type GlobalConfig struct {
+	SourceYAML           []byte              `yaml:"-"`
 	Agent                types.AgentName     `yaml:"agent"`
 	Agents               []types.AgentName   `yaml:"-"`
 	ACPXPath             string              `yaml:"acpx_path"`
@@ -374,6 +375,9 @@ type AutoFix struct {
 
 // Config is the merged result of global + per-repo configuration.
 type Config struct {
+	ReplayGlobalYAML     []byte
+	ReplayRepoYAML       []byte
+	TrustedConfigSHA     string
 	Agent                types.AgentName
 	Agents               []types.AgentName
 	ACPXPath             string
@@ -1135,6 +1139,7 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
+			cfg.SourceYAML = []byte("{}\n")
 			return cfg, nil
 		}
 		return nil, fmt.Errorf("read global config: %w", err)
@@ -1144,6 +1149,7 @@ func LoadGlobal(path string) (*GlobalConfig, error) {
 
 func LoadGlobalFromBytes(data []byte) (*GlobalConfig, error) {
 	cfg := DefaultGlobalConfig()
+	cfg.SourceYAML = append([]byte(nil), data...)
 	var raw globalConfigRaw
 	dec := yaml.NewDecoder(bytes.NewReader(data))
 	dec.KnownFields(true)
@@ -1652,7 +1658,10 @@ func Merge(global *GlobalConfig, repo *RepoConfig) *Config {
 		commit.FixMessage = *repo.Commit.FixMessage
 	}
 
+	repoYAML, _ := yaml.Marshal(repo)
 	cfg := &Config{
+		ReplayGlobalYAML:     append([]byte(nil), global.SourceYAML...),
+		ReplayRepoYAML:       repoYAML,
 		Agent:                global.Agent,
 		Agents:               copyAgents(global.Agents),
 		ACPXPath:             global.ACPXPath,

--- a/internal/config/config_merge_test.go
+++ b/internal/config/config_merge_test.go
@@ -24,6 +24,21 @@ func TestMerge_GlobalOnly(t *testing.T) {
 	}
 }
 
+func TestMergeLeavesEvalProvenanceDisabledUntilExplicitlyEnabled(t *testing.T) {
+	global := &GlobalConfig{SourceYAML: []byte("agent: claude\n"), Agent: types.AgentClaude}
+	repo := &RepoConfig{IgnorePatterns: []string{"vendor/**"}}
+	cfg := Merge(global, repo)
+	if cfg.CaptureEvalProvenance || len(cfg.ReplayGlobalYAML) != 0 || len(cfg.ReplayRepoYAML) != 0 {
+		t.Fatalf("ordinary merged config contains eval provenance: %#v", cfg)
+	}
+	if err := cfg.EnableEvalProvenance(global, repo); err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.CaptureEvalProvenance || string(cfg.ReplayGlobalYAML) != "agent: claude\n" || len(cfg.ReplayRepoYAML) == 0 {
+		t.Fatalf("enabled eval provenance = %#v", cfg)
+	}
+}
+
 func TestMerge_RepoOverridesAgent(t *testing.T) {
 	global := &GlobalConfig{
 		Agent:             types.AgentClaude,

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -225,7 +225,9 @@ func (m *RunManager) loadRecoveredConfig(ctx context.Context, run *db.Run, repo 
 	}
 	trustedRepoCfg := loadTrustedRepoConfig(ctx, workDir, trustedSHA, run.ID)
 	allowRepoCommands := trustedRepoCfg != nil && trustedRepoCfg.AllowRepoCommands
-	return config.Merge(globalCfg, config.EffectiveRepoConfig(repoCfg, trustedRepoCfg, allowRepoCommands)), nil
+	cfg := config.Merge(globalCfg, config.EffectiveRepoConfig(repoCfg, trustedRepoCfg, allowRepoCommands))
+	cfg.TrustedConfigSHA = trustedSHA
+	return cfg, nil
 }
 
 func newPipelineAgent(ctx context.Context, cfg *config.Config, lookPath func(string) (string, error)) (agent.Agent, error) {
@@ -862,6 +864,7 @@ func (m *RunManager) startRunWithIntentSource(ctx context.Context, repo *db.Repo
 		slog.Info("repo commands/agent loaded from default branch, not pushed branch", "run_id", run.ID, "branch", branch, "default_branch", repo.DefaultBranch)
 	}
 	cfg := config.Merge(globalCfg, effectiveRepoCfg)
+	cfg.TrustedConfigSHA = trustedSHA
 
 	// Create agent. In demo mode, skip resolution and use a no-op agent.
 	var ag agent.Agent

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -198,13 +198,7 @@ func validateRecoveredSessionProviders(database *db.DB, runID string, ag agent.A
 }
 
 func (m *RunManager) loadRecoveredConfig(ctx context.Context, run *db.Run, repo *db.Repo, workDir string) (*config.Config, error) {
-	var globalCfg *config.GlobalConfig
-	var err error
-	if run.GlobalConfigYAML != nil {
-		globalCfg, err = config.LoadGlobalFromBytes([]byte(*run.GlobalConfigYAML))
-	} else {
-		globalCfg, err = config.LoadGlobal(m.paths.ConfigFile())
-	}
+	globalCfg, err := config.LoadGlobal(m.paths.ConfigFile())
 	if err != nil {
 		return nil, fmt.Errorf("load global config: %w", err)
 	}
@@ -213,15 +207,13 @@ func (m *RunManager) loadRecoveredConfig(ctx context.Context, run *db.Run, repo 
 		return nil, fmt.Errorf("load repo config: %w", err)
 	}
 	var trustedSHA string
-	if run.TrustedConfigSHA != nil {
-		trustedSHA = strings.TrimSpace(*run.TrustedConfigSHA)
-	} else if repo.DefaultBranch != "" {
+	if repo.DefaultBranch != "" {
 		fetchCtx, cancel := context.WithTimeout(ctx, recoveredConfigFetchTimeout)
 		defer cancel()
 		if err := fetchRecoveredRemoteBranch(fetchCtx, workDir, "origin", repo.DefaultBranch); err != nil {
-			slog.Warn("failed to fetch default branch while recovering legacy run; trusted config disabled", "run_id", run.ID, "branch", repo.DefaultBranch, "error", err)
+			slog.Warn("failed to fetch default branch while recovering run; trusted config disabled", "run_id", run.ID, "branch", repo.DefaultBranch, "error", err)
 		} else if sha, err := git.ResolveRef(ctx, workDir, "refs/remotes/origin/"+repo.DefaultBranch); err != nil {
-			slog.Warn("failed to resolve default branch while recovering legacy run; trusted config disabled", "run_id", run.ID, "branch", repo.DefaultBranch, "error", err)
+			slog.Warn("failed to resolve default branch while recovering run; trusted config disabled", "run_id", run.ID, "branch", repo.DefaultBranch, "error", err)
 		} else {
 			trustedSHA = sha
 		}
@@ -825,7 +817,7 @@ func (m *RunManager) startRunWithIntentSource(ctx context.Context, repo *db.Repo
 		}
 	}()
 
-	globalCfg, globalConfigBytes, err := config.LoadGlobalSnapshot(m.paths.ConfigFile())
+	globalCfg, err := config.LoadGlobal(m.paths.ConfigFile())
 	if err != nil {
 		m.db.UpdateRunError(run.ID, fmt.Sprintf("load config: %s", err))
 		trackStartFailure("load_global_config")
@@ -858,9 +850,6 @@ func (m *RunManager) startRunWithIntentSource(ctx context.Context, repo *db.Repo
 		trackStartFailure("trusted_config_unreadable")
 		return "", err
 	}
-	run.TrustedConfigSHA = &trustedSHA
-	globalConfigYAML := string(globalConfigBytes)
-	run.GlobalConfigYAML = &globalConfigYAML
 	trustedRepoCfg := loadTrustedRepoConfig(ctx, wtDir, trustedSHA, run.ID)
 	allowRepoCommands := trustedRepoCfg != nil && trustedRepoCfg.AllowRepoCommands
 	effectiveRepoCfg := config.EffectiveRepoConfig(repoCfg, trustedRepoCfg, allowRepoCommands)

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -225,8 +225,14 @@ func (m *RunManager) loadRecoveredConfig(ctx context.Context, run *db.Run, repo 
 	}
 	trustedRepoCfg := loadTrustedRepoConfig(ctx, workDir, trustedSHA, run.ID)
 	allowRepoCommands := trustedRepoCfg != nil && trustedRepoCfg.AllowRepoCommands
-	cfg := config.Merge(globalCfg, config.EffectiveRepoConfig(repoCfg, trustedRepoCfg, allowRepoCommands))
+	effectiveRepoCfg := config.EffectiveRepoConfig(repoCfg, trustedRepoCfg, allowRepoCommands)
+	cfg := config.Merge(globalCfg, effectiveRepoCfg)
 	cfg.TrustedConfigSHA = trustedSHA
+	if os.Getenv("NO_MISTAKES_EVAL_CAPTURE_PROVENANCE") == "1" {
+		if err := cfg.EnableEvalProvenance(globalCfg, effectiveRepoCfg); err != nil {
+			return nil, err
+		}
+	}
 	return cfg, nil
 }
 
@@ -865,6 +871,13 @@ func (m *RunManager) startRunWithIntentSource(ctx context.Context, repo *db.Repo
 	}
 	cfg := config.Merge(globalCfg, effectiveRepoCfg)
 	cfg.TrustedConfigSHA = trustedSHA
+	if os.Getenv("NO_MISTAKES_EVAL_CAPTURE_PROVENANCE") == "1" {
+		if err := cfg.EnableEvalProvenance(globalCfg, effectiveRepoCfg); err != nil {
+			m.db.UpdateRunError(run.ID, err.Error())
+			trackStartFailure("eval_provenance")
+			return "", err
+		}
+	}
 
 	// Create agent. In demo mode, skip resolution and use a no-op agent.
 	var ag agent.Agent

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -198,7 +198,13 @@ func validateRecoveredSessionProviders(database *db.DB, runID string, ag agent.A
 }
 
 func (m *RunManager) loadRecoveredConfig(ctx context.Context, run *db.Run, repo *db.Repo, workDir string) (*config.Config, error) {
-	globalCfg, err := config.LoadGlobal(m.paths.ConfigFile())
+	var globalCfg *config.GlobalConfig
+	var err error
+	if run.GlobalConfigYAML != nil {
+		globalCfg, err = config.LoadGlobalFromBytes([]byte(*run.GlobalConfigYAML))
+	} else {
+		globalCfg, err = config.LoadGlobal(m.paths.ConfigFile())
+	}
 	if err != nil {
 		return nil, fmt.Errorf("load global config: %w", err)
 	}
@@ -207,13 +213,15 @@ func (m *RunManager) loadRecoveredConfig(ctx context.Context, run *db.Run, repo 
 		return nil, fmt.Errorf("load repo config: %w", err)
 	}
 	var trustedSHA string
-	if repo.DefaultBranch != "" {
+	if run.TrustedConfigSHA != nil {
+		trustedSHA = strings.TrimSpace(*run.TrustedConfigSHA)
+	} else if repo.DefaultBranch != "" {
 		fetchCtx, cancel := context.WithTimeout(ctx, recoveredConfigFetchTimeout)
 		defer cancel()
 		if err := fetchRecoveredRemoteBranch(fetchCtx, workDir, "origin", repo.DefaultBranch); err != nil {
-			slog.Warn("failed to fetch default branch while recovering run; trusted config disabled", "run_id", run.ID, "branch", repo.DefaultBranch, "error", err)
+			slog.Warn("failed to fetch default branch while recovering legacy run; trusted config disabled", "run_id", run.ID, "branch", repo.DefaultBranch, "error", err)
 		} else if sha, err := git.ResolveRef(ctx, workDir, "refs/remotes/origin/"+repo.DefaultBranch); err != nil {
-			slog.Warn("failed to resolve default branch while recovering run; trusted config disabled", "run_id", run.ID, "branch", repo.DefaultBranch, "error", err)
+			slog.Warn("failed to resolve default branch while recovering legacy run; trusted config disabled", "run_id", run.ID, "branch", repo.DefaultBranch, "error", err)
 		} else {
 			trustedSHA = sha
 		}
@@ -817,7 +825,7 @@ func (m *RunManager) startRunWithIntentSource(ctx context.Context, repo *db.Repo
 		}
 	}()
 
-	globalCfg, err := config.LoadGlobal(m.paths.ConfigFile())
+	globalCfg, globalConfigBytes, err := config.LoadGlobalSnapshot(m.paths.ConfigFile())
 	if err != nil {
 		m.db.UpdateRunError(run.ID, fmt.Sprintf("load config: %s", err))
 		trackStartFailure("load_global_config")
@@ -850,12 +858,9 @@ func (m *RunManager) startRunWithIntentSource(ctx context.Context, repo *db.Repo
 		trackStartFailure("trusted_config_unreadable")
 		return "", err
 	}
-	if err := m.db.UpdateRunTrustedConfigSHA(run.ID, trustedSHA); err != nil {
-		m.db.UpdateRunError(run.ID, fmt.Sprintf("record trusted config SHA: %s", err))
-		trackStartFailure("record_trusted_config")
-		return "", fmt.Errorf("record trusted config SHA: %w", err)
-	}
 	run.TrustedConfigSHA = &trustedSHA
+	globalConfigYAML := string(globalConfigBytes)
+	run.GlobalConfigYAML = &globalConfigYAML
 	trustedRepoCfg := loadTrustedRepoConfig(ctx, wtDir, trustedSHA, run.ID)
 	allowRepoCommands := trustedRepoCfg != nil && trustedRepoCfg.AllowRepoCommands
 	effectiveRepoCfg := config.EffectiveRepoConfig(repoCfg, trustedRepoCfg, allowRepoCommands)

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -850,6 +850,12 @@ func (m *RunManager) startRunWithIntentSource(ctx context.Context, repo *db.Repo
 		trackStartFailure("trusted_config_unreadable")
 		return "", err
 	}
+	if err := m.db.UpdateRunTrustedConfigSHA(run.ID, trustedSHA); err != nil {
+		m.db.UpdateRunError(run.ID, fmt.Sprintf("record trusted config SHA: %s", err))
+		trackStartFailure("record_trusted_config")
+		return "", fmt.Errorf("record trusted config SHA: %w", err)
+	}
+	run.TrustedConfigSHA = &trustedSHA
 	trustedRepoCfg := loadTrustedRepoConfig(ctx, wtDir, trustedSHA, run.ID)
 	allowRepoCommands := trustedRepoCfg != nil && trustedRepoCfg.AllowRepoCommands
 	effectiveRepoCfg := config.EffectiveRepoConfig(repoCfg, trustedRepoCfg, allowRepoCommands)

--- a/internal/db/round.go
+++ b/internal/db/round.go
@@ -9,12 +9,16 @@ const (
 
 // StepRound represents one execution round within a pipeline step.
 type StepRound struct {
-	ID              string
-	StepResultID    string
-	Round           int
-	Trigger         string  // "initial", "auto_fix"; legacy "user_fix" is treated as "auto_fix"
-	FindingsJSON    *string // nullable - findings produced by this round
-	ReviewedHeadSHA *string // non-authoritative commit candidate captured by a review round
+	ID               string
+	StepResultID     string
+	Round            int
+	Trigger          string  // "initial", "auto_fix"; legacy "user_fix" is treated as "auto_fix"
+	FindingsJSON     *string // nullable - findings produced by this round
+	ReviewedHeadSHA  *string // non-authoritative commit candidate captured by a review round
+	StartingHeadSHA  *string
+	TrustedConfigSHA *string
+	GlobalConfigYAML []byte
+	RepoConfigYAML   []byte
 	// UserFindingsJSON, when non-nil, is the merged finding list that was
 	// dispatched to the fix agent after the user edited per-finding
 	// instructions or added their own findings. It includes both the
@@ -118,35 +122,49 @@ func (d *DB) StepRoundStats(stepResultID string) (StepRoundStats, error) {
 // InsertStepRound creates a new round record for a step result. fixSummary may
 // be nil for non-fix rounds or when the agent produced no summary.
 func (d *DB) InsertStepRound(stepResultID string, round int, trigger string, findingsJSON *string, fixSummary *string, durationMS int64) (*StepRound, error) {
-	return d.insertStepRound(stepResultID, round, trigger, findingsJSON, fixSummary, nil, durationMS)
+	return d.insertStepRound(stepResultID, round, trigger, findingsJSON, fixSummary, nil, nil, nil, nil, nil, durationMS)
 }
 
 // InsertReviewStepRound persists a review round's examined commit as a
 // non-authoritative candidate. A recovered parked gate can promote this exact
 // candidate only after approval; merely storing it grants no push authority.
 func (d *DB) InsertReviewStepRound(stepResultID string, round int, trigger string, findingsJSON *string, fixSummary *string, reviewedHeadSHA string, durationMS int64) (*StepRound, error) {
-	var reviewed *string
+	return d.InsertReviewStepRoundWithProvenance(stepResultID, round, trigger, findingsJSON, fixSummary, reviewedHeadSHA, "", "", nil, nil, durationMS)
+}
+
+func (d *DB) InsertReviewStepRoundWithProvenance(stepResultID string, round int, trigger string, findingsJSON *string, fixSummary *string, reviewedHeadSHA, startingHeadSHA, trustedConfigSHA string, globalConfigYAML, repoConfigYAML []byte, durationMS int64) (*StepRound, error) {
+	var reviewed, starting, trusted *string
 	if reviewedHeadSHA != "" {
 		reviewed = &reviewedHeadSHA
 	}
-	return d.insertStepRound(stepResultID, round, trigger, findingsJSON, fixSummary, reviewed, durationMS)
+	if startingHeadSHA != "" {
+		starting = &startingHeadSHA
+	}
+	if trustedConfigSHA != "" {
+		trusted = &trustedConfigSHA
+	}
+	return d.insertStepRound(stepResultID, round, trigger, findingsJSON, fixSummary, reviewed, starting, trusted, globalConfigYAML, repoConfigYAML, durationMS)
 }
 
-func (d *DB) insertStepRound(stepResultID string, round int, trigger string, findingsJSON *string, fixSummary, reviewedHeadSHA *string, durationMS int64) (*StepRound, error) {
+func (d *DB) insertStepRound(stepResultID string, round int, trigger string, findingsJSON *string, fixSummary, reviewedHeadSHA, startingHeadSHA, trustedConfigSHA *string, globalConfigYAML, repoConfigYAML []byte, durationMS int64) (*StepRound, error) {
 	r := &StepRound{
-		ID:              newID(),
-		StepResultID:    stepResultID,
-		Round:           round,
-		Trigger:         trigger,
-		FindingsJSON:    findingsJSON,
-		ReviewedHeadSHA: reviewedHeadSHA,
-		FixSummary:      fixSummary,
-		DurationMS:      durationMS,
-		CreatedAt:       now(),
+		ID:               newID(),
+		StepResultID:     stepResultID,
+		Round:            round,
+		Trigger:          trigger,
+		FindingsJSON:     findingsJSON,
+		ReviewedHeadSHA:  reviewedHeadSHA,
+		StartingHeadSHA:  startingHeadSHA,
+		TrustedConfigSHA: trustedConfigSHA,
+		GlobalConfigYAML: append([]byte(nil), globalConfigYAML...),
+		RepoConfigYAML:   append([]byte(nil), repoConfigYAML...),
+		FixSummary:       fixSummary,
+		DurationMS:       durationMS,
+		CreatedAt:        now(),
 	}
 	_, err := d.sql.Exec(
-		`INSERT INTO step_rounds (id, step_result_id, round, trigger_type, findings_json, reviewed_head_sha, user_findings_json, selected_finding_ids, selection_source, fix_summary, duration_ms, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		r.ID, r.StepResultID, r.Round, r.Trigger, r.FindingsJSON, r.ReviewedHeadSHA, r.UserFindingsJSON, r.SelectedFindingIDs, r.SelectionSource, r.FixSummary, r.DurationMS, r.CreatedAt,
+		`INSERT INTO step_rounds (id, step_result_id, round, trigger_type, findings_json, reviewed_head_sha, starting_head_sha, trusted_config_sha, global_config_yaml, repo_config_yaml, user_findings_json, selected_finding_ids, selection_source, fix_summary, duration_ms, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		r.ID, r.StepResultID, r.Round, r.Trigger, r.FindingsJSON, r.ReviewedHeadSHA, r.StartingHeadSHA, r.TrustedConfigSHA, r.GlobalConfigYAML, r.RepoConfigYAML, r.UserFindingsJSON, r.SelectedFindingIDs, r.SelectionSource, r.FixSummary, r.DurationMS, r.CreatedAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("insert step round: %w", err)
@@ -194,7 +212,7 @@ func (d *DB) SetStepRoundUserFindings(id string, userFindingsJSON *string) error
 // GetRoundsByStep returns all rounds for a step result, ordered by round number.
 func (d *DB) GetRoundsByStep(stepResultID string) ([]*StepRound, error) {
 	rows, err := d.sql.Query(
-		`SELECT id, step_result_id, round, trigger_type, findings_json, reviewed_head_sha, user_findings_json, selected_finding_ids, selection_source, fix_summary, duration_ms, created_at FROM step_rounds WHERE step_result_id = ? ORDER BY round`,
+		`SELECT id, step_result_id, round, trigger_type, findings_json, reviewed_head_sha, starting_head_sha, trusted_config_sha, global_config_yaml, repo_config_yaml, user_findings_json, selected_finding_ids, selection_source, fix_summary, duration_ms, created_at FROM step_rounds WHERE step_result_id = ? ORDER BY round`,
 		stepResultID,
 	)
 	if err != nil {
@@ -204,7 +222,7 @@ func (d *DB) GetRoundsByStep(stepResultID string) ([]*StepRound, error) {
 	var rounds []*StepRound
 	for rows.Next() {
 		r := &StepRound{}
-		if err := rows.Scan(&r.ID, &r.StepResultID, &r.Round, &r.Trigger, &r.FindingsJSON, &r.ReviewedHeadSHA, &r.UserFindingsJSON, &r.SelectedFindingIDs, &r.SelectionSource, &r.FixSummary, &r.DurationMS, &r.CreatedAt); err != nil {
+		if err := rows.Scan(&r.ID, &r.StepResultID, &r.Round, &r.Trigger, &r.FindingsJSON, &r.ReviewedHeadSHA, &r.StartingHeadSHA, &r.TrustedConfigSHA, &r.GlobalConfigYAML, &r.RepoConfigYAML, &r.UserFindingsJSON, &r.SelectedFindingIDs, &r.SelectionSource, &r.FixSummary, &r.DurationMS, &r.CreatedAt); err != nil {
 			return nil, fmt.Errorf("scan step round: %w", err)
 		}
 		rounds = append(rounds, r)

--- a/internal/db/round_test.go
+++ b/internal/db/round_test.go
@@ -28,6 +28,25 @@ func TestInsertReviewStepRoundPersistsNonAuthoritativeCandidate(t *testing.T) {
 	}
 }
 
+func TestReviewRoundPersistsExactReplayProvenance(t *testing.T) {
+	d := openTestDB(t)
+	repo, _ := d.InsertRepo("/tmp/review-provenance", "https://example.com/repo.git", "main")
+	run, _ := d.InsertRun(repo.ID, "feature", "reviewed", "base")
+	step, _ := d.InsertStepResult(run.ID, types.StepReview)
+	_, err := d.InsertReviewStepRoundWithProvenance(step.ID, 1, "auto_fix", nil, nil, "reviewed", "starting", "trusted", []byte("agent: claude\n"), []byte("ignore_patterns: ['vendor']\n"), 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rounds, err := d.GetRoundsByStep(step.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := rounds[0]
+	if got.StartingHeadSHA == nil || *got.StartingHeadSHA != "starting" || got.TrustedConfigSHA == nil || *got.TrustedConfigSHA != "trusted" || string(got.GlobalConfigYAML) != "agent: claude\n" || string(got.RepoConfigYAML) != "ignore_patterns: ['vendor']\n" {
+		t.Fatalf("review provenance = %#v", got)
+	}
+}
+
 func TestStepRoundInsertAndGet(t *testing.T) {
 	d := openTestDB(t)
 	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")

--- a/internal/db/run.go
+++ b/internal/db/run.go
@@ -23,6 +23,7 @@ type Run struct {
 	NoMistakesVersion  *string
 	NoMistakesBuildSHA *string
 	TrustedConfigSHA   *string
+	GlobalConfigYAML   *string
 	// ReviewApprovedHeadSHA is the exact commit approved by the last
 	// successfully completed full review. It is nil for legacy runs and until
 	// review completes; mutable run/worktree heads never infer this authority.
@@ -67,13 +68,13 @@ type Run struct {
 	UpdatedAt       int64
 }
 
-const runColumns = `id, repo_id, branch, head_sha, base_sha, submitted_head_sha, no_mistakes_version, no_mistakes_build_sha, trusted_config_sha, review_approved_head_sha, status, pr_url, pr_state, pr_state_observed_at, ci_ready_at, COALESCE(ci_ready_no_ci, 0), last_pushed_sha, push_target_kind, push_target_fingerprint, push_ref, last_pushed_at, push_generation, COALESCE(push_active, 0), terminal_head_verified_at, custody_returned_at, error, awaiting_agent_since, COALESCE(parked_ms, 0), intent, intent_source, intent_session_id, intent_score, created_at, updated_at`
+const runColumns = `id, repo_id, branch, head_sha, base_sha, submitted_head_sha, no_mistakes_version, no_mistakes_build_sha, trusted_config_sha, global_config_yaml, review_approved_head_sha, status, pr_url, pr_state, pr_state_observed_at, ci_ready_at, COALESCE(ci_ready_no_ci, 0), last_pushed_sha, push_target_kind, push_target_fingerprint, push_ref, last_pushed_at, push_generation, COALESCE(push_active, 0), terminal_head_verified_at, custody_returned_at, error, awaiting_agent_since, COALESCE(parked_ms, 0), intent, intent_source, intent_session_id, intent_score, created_at, updated_at`
 
 func scanRun(row interface {
 	Scan(...any) error
 }, r *Run) error {
 	return row.Scan(
-		&r.ID, &r.RepoID, &r.Branch, &r.HeadSHA, &r.BaseSHA, &r.SubmittedHeadSHA, &r.NoMistakesVersion, &r.NoMistakesBuildSHA, &r.TrustedConfigSHA, &r.ReviewApprovedHeadSHA, &r.Status,
+		&r.ID, &r.RepoID, &r.Branch, &r.HeadSHA, &r.BaseSHA, &r.SubmittedHeadSHA, &r.NoMistakesVersion, &r.NoMistakesBuildSHA, &r.TrustedConfigSHA, &r.GlobalConfigYAML, &r.ReviewApprovedHeadSHA, &r.Status,
 		&r.PRURL, &r.PRState, &r.PRStateObservedAt, &r.CIReadyAt, &r.CIReadyNoCI,
 		&r.LastPushedSHA, &r.PushTargetKind, &r.PushTargetFingerprint, &r.PushRef,
 		&r.LastPushedAt, &r.PushGeneration, &r.PushActive, &r.TerminalHeadVerifiedAt,
@@ -449,6 +450,14 @@ func (d *DB) UpdateRunTrustedConfigSHA(id, trustedSHA string) error {
 		return fmt.Errorf("trusted config SHA is required")
 	}
 	_, err := d.sql.Exec(`UPDATE runs SET trusted_config_sha = ?, updated_at = ? WHERE id = ?`, trustedSHA, now(), id)
+	return err
+}
+
+func (d *DB) UpdateRunStatusWithConfig(id string, status types.RunStatus, trustedSHA, globalConfigYAML string) error {
+	if strings.TrimSpace(trustedSHA) == "" {
+		return fmt.Errorf("trusted config SHA is required")
+	}
+	_, err := d.sql.Exec(`UPDATE runs SET status = ?, trusted_config_sha = ?, global_config_yaml = ?, updated_at = ? WHERE id = ?`, status, trustedSHA, globalConfigYAML, now(), id)
 	return err
 }
 

--- a/internal/db/run.go
+++ b/internal/db/run.go
@@ -22,6 +22,7 @@ type Run struct {
 	// this run. They remain nil only for runs recorded before these fields.
 	NoMistakesVersion  *string
 	NoMistakesBuildSHA *string
+	TrustedConfigSHA   *string
 	// ReviewApprovedHeadSHA is the exact commit approved by the last
 	// successfully completed full review. It is nil for legacy runs and until
 	// review completes; mutable run/worktree heads never infer this authority.
@@ -66,13 +67,13 @@ type Run struct {
 	UpdatedAt       int64
 }
 
-const runColumns = `id, repo_id, branch, head_sha, base_sha, submitted_head_sha, no_mistakes_version, no_mistakes_build_sha, review_approved_head_sha, status, pr_url, pr_state, pr_state_observed_at, ci_ready_at, COALESCE(ci_ready_no_ci, 0), last_pushed_sha, push_target_kind, push_target_fingerprint, push_ref, last_pushed_at, push_generation, COALESCE(push_active, 0), terminal_head_verified_at, custody_returned_at, error, awaiting_agent_since, COALESCE(parked_ms, 0), intent, intent_source, intent_session_id, intent_score, created_at, updated_at`
+const runColumns = `id, repo_id, branch, head_sha, base_sha, submitted_head_sha, no_mistakes_version, no_mistakes_build_sha, trusted_config_sha, review_approved_head_sha, status, pr_url, pr_state, pr_state_observed_at, ci_ready_at, COALESCE(ci_ready_no_ci, 0), last_pushed_sha, push_target_kind, push_target_fingerprint, push_ref, last_pushed_at, push_generation, COALESCE(push_active, 0), terminal_head_verified_at, custody_returned_at, error, awaiting_agent_since, COALESCE(parked_ms, 0), intent, intent_source, intent_session_id, intent_score, created_at, updated_at`
 
 func scanRun(row interface {
 	Scan(...any) error
 }, r *Run) error {
 	return row.Scan(
-		&r.ID, &r.RepoID, &r.Branch, &r.HeadSHA, &r.BaseSHA, &r.SubmittedHeadSHA, &r.NoMistakesVersion, &r.NoMistakesBuildSHA, &r.ReviewApprovedHeadSHA, &r.Status,
+		&r.ID, &r.RepoID, &r.Branch, &r.HeadSHA, &r.BaseSHA, &r.SubmittedHeadSHA, &r.NoMistakesVersion, &r.NoMistakesBuildSHA, &r.TrustedConfigSHA, &r.ReviewApprovedHeadSHA, &r.Status,
 		&r.PRURL, &r.PRState, &r.PRStateObservedAt, &r.CIReadyAt, &r.CIReadyNoCI,
 		&r.LastPushedSHA, &r.PushTargetKind, &r.PushTargetFingerprint, &r.PushRef,
 		&r.LastPushedAt, &r.PushGeneration, &r.PushActive, &r.TerminalHeadVerifiedAt,
@@ -443,6 +444,14 @@ func (d *DB) SetRunCIReadyWithReason(id string, ready, declaredNoCI bool) error 
 
 // UpdateRunReviewApprovedHeadSHA replaces the run's review authority with the
 // exact commit approved by the latest successfully completed full review.
+func (d *DB) UpdateRunTrustedConfigSHA(id, trustedSHA string) error {
+	if strings.TrimSpace(trustedSHA) == "" {
+		return fmt.Errorf("trusted config SHA is required")
+	}
+	_, err := d.sql.Exec(`UPDATE runs SET trusted_config_sha = ?, updated_at = ? WHERE id = ?`, trustedSHA, now(), id)
+	return err
+}
+
 func (d *DB) UpdateRunReviewApprovedHeadSHA(id, headSHA string) error {
 	_, err := d.sql.Exec(`UPDATE runs SET review_approved_head_sha = ?, updated_at = ? WHERE id = ?`, headSHA, now(), id)
 	if err != nil {

--- a/internal/db/run.go
+++ b/internal/db/run.go
@@ -22,8 +22,6 @@ type Run struct {
 	// this run. They remain nil only for runs recorded before these fields.
 	NoMistakesVersion  *string
 	NoMistakesBuildSHA *string
-	TrustedConfigSHA   *string
-	GlobalConfigYAML   *string
 	// ReviewApprovedHeadSHA is the exact commit approved by the last
 	// successfully completed full review. It is nil for legacy runs and until
 	// review completes; mutable run/worktree heads never infer this authority.
@@ -68,13 +66,13 @@ type Run struct {
 	UpdatedAt       int64
 }
 
-const runColumns = `id, repo_id, branch, head_sha, base_sha, submitted_head_sha, no_mistakes_version, no_mistakes_build_sha, trusted_config_sha, global_config_yaml, review_approved_head_sha, status, pr_url, pr_state, pr_state_observed_at, ci_ready_at, COALESCE(ci_ready_no_ci, 0), last_pushed_sha, push_target_kind, push_target_fingerprint, push_ref, last_pushed_at, push_generation, COALESCE(push_active, 0), terminal_head_verified_at, custody_returned_at, error, awaiting_agent_since, COALESCE(parked_ms, 0), intent, intent_source, intent_session_id, intent_score, created_at, updated_at`
+const runColumns = `id, repo_id, branch, head_sha, base_sha, submitted_head_sha, no_mistakes_version, no_mistakes_build_sha, review_approved_head_sha, status, pr_url, pr_state, pr_state_observed_at, ci_ready_at, COALESCE(ci_ready_no_ci, 0), last_pushed_sha, push_target_kind, push_target_fingerprint, push_ref, last_pushed_at, push_generation, COALESCE(push_active, 0), terminal_head_verified_at, custody_returned_at, error, awaiting_agent_since, COALESCE(parked_ms, 0), intent, intent_source, intent_session_id, intent_score, created_at, updated_at`
 
 func scanRun(row interface {
 	Scan(...any) error
 }, r *Run) error {
 	return row.Scan(
-		&r.ID, &r.RepoID, &r.Branch, &r.HeadSHA, &r.BaseSHA, &r.SubmittedHeadSHA, &r.NoMistakesVersion, &r.NoMistakesBuildSHA, &r.TrustedConfigSHA, &r.GlobalConfigYAML, &r.ReviewApprovedHeadSHA, &r.Status,
+		&r.ID, &r.RepoID, &r.Branch, &r.HeadSHA, &r.BaseSHA, &r.SubmittedHeadSHA, &r.NoMistakesVersion, &r.NoMistakesBuildSHA, &r.ReviewApprovedHeadSHA, &r.Status,
 		&r.PRURL, &r.PRState, &r.PRStateObservedAt, &r.CIReadyAt, &r.CIReadyNoCI,
 		&r.LastPushedSHA, &r.PushTargetKind, &r.PushTargetFingerprint, &r.PushRef,
 		&r.LastPushedAt, &r.PushGeneration, &r.PushActive, &r.TerminalHeadVerifiedAt,
@@ -445,22 +443,6 @@ func (d *DB) SetRunCIReadyWithReason(id string, ready, declaredNoCI bool) error 
 
 // UpdateRunReviewApprovedHeadSHA replaces the run's review authority with the
 // exact commit approved by the latest successfully completed full review.
-func (d *DB) UpdateRunTrustedConfigSHA(id, trustedSHA string) error {
-	if strings.TrimSpace(trustedSHA) == "" {
-		return fmt.Errorf("trusted config SHA is required")
-	}
-	_, err := d.sql.Exec(`UPDATE runs SET trusted_config_sha = ?, updated_at = ? WHERE id = ?`, trustedSHA, now(), id)
-	return err
-}
-
-func (d *DB) UpdateRunStatusWithConfig(id string, status types.RunStatus, trustedSHA, globalConfigYAML string) error {
-	if strings.TrimSpace(trustedSHA) == "" {
-		return fmt.Errorf("trusted config SHA is required")
-	}
-	_, err := d.sql.Exec(`UPDATE runs SET status = ?, trusted_config_sha = ?, global_config_yaml = ?, updated_at = ? WHERE id = ?`, status, trustedSHA, globalConfigYAML, now(), id)
-	return err
-}
-
 func (d *DB) UpdateRunReviewApprovedHeadSHA(id, headSHA string) error {
 	_, err := d.sql.Exec(`UPDATE runs SET review_approved_head_sha = ?, updated_at = ? WHERE id = ?`, headSHA, now(), id)
 	if err != nil {

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -67,6 +67,10 @@ CREATE TABLE IF NOT EXISTS step_rounds (
     trigger_type         TEXT NOT NULL,
     findings_json        TEXT,
     reviewed_head_sha    TEXT,
+    starting_head_sha    TEXT,
+    trusted_config_sha   TEXT,
+    global_config_yaml   BLOB,
+    repo_config_yaml     BLOB,
     user_findings_json   TEXT,
     selected_finding_ids TEXT,
     selection_source     TEXT,
@@ -149,6 +153,10 @@ var migrationStatements = []string{
 	// A parked round may retain the reviewed commit as a non-authoritative
 	// candidate. Only atomic review completion promotes it onto the run.
 	`ALTER TABLE step_rounds ADD COLUMN reviewed_head_sha TEXT`,
+	`ALTER TABLE step_rounds ADD COLUMN starting_head_sha TEXT`,
+	`ALTER TABLE step_rounds ADD COLUMN trusted_config_sha TEXT`,
+	`ALTER TABLE step_rounds ADD COLUMN global_config_yaml BLOB`,
+	`ALTER TABLE step_rounds ADD COLUMN repo_config_yaml BLOB`,
 	`ALTER TABLE runs ADD COLUMN intent TEXT`,
 	`ALTER TABLE runs ADD COLUMN intent_source TEXT`,
 	`ALTER TABLE runs ADD COLUMN intent_session_id TEXT`,

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS runs (
     submitted_head_sha      TEXT,
     no_mistakes_version     TEXT,
     no_mistakes_build_sha   TEXT,
+    trusted_config_sha      TEXT,
     review_approved_head_sha TEXT,
     status                  TEXT NOT NULL DEFAULT 'pending',
     pr_url                  TEXT,
@@ -168,6 +169,7 @@ var migrationStatements = []string{
 	// version and embedded build SHA used by the running binary.
 	`ALTER TABLE runs ADD COLUMN no_mistakes_version TEXT`,
 	`ALTER TABLE runs ADD COLUMN no_mistakes_build_sha TEXT`,
+	`ALTER TABLE runs ADD COLUMN trusted_config_sha TEXT`,
 	// Review authority is nullable and never backfilled. A historical mutable
 	// head_sha cannot prove which exact commit a completed review approved.
 	`ALTER TABLE runs ADD COLUMN review_approved_head_sha TEXT`,

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS runs (
     no_mistakes_version     TEXT,
     no_mistakes_build_sha   TEXT,
     trusted_config_sha      TEXT,
+    global_config_yaml      TEXT,
     review_approved_head_sha TEXT,
     status                  TEXT NOT NULL DEFAULT 'pending',
     pr_url                  TEXT,
@@ -170,6 +171,7 @@ var migrationStatements = []string{
 	`ALTER TABLE runs ADD COLUMN no_mistakes_version TEXT`,
 	`ALTER TABLE runs ADD COLUMN no_mistakes_build_sha TEXT`,
 	`ALTER TABLE runs ADD COLUMN trusted_config_sha TEXT`,
+	`ALTER TABLE runs ADD COLUMN global_config_yaml TEXT`,
 	// Review authority is nullable and never backfilled. A historical mutable
 	// head_sha cannot prove which exact commit a completed review approved.
 	`ALTER TABLE runs ADD COLUMN review_approved_head_sha TEXT`,

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -19,8 +19,6 @@ CREATE TABLE IF NOT EXISTS runs (
     submitted_head_sha      TEXT,
     no_mistakes_version     TEXT,
     no_mistakes_build_sha   TEXT,
-    trusted_config_sha      TEXT,
-    global_config_yaml      TEXT,
     review_approved_head_sha TEXT,
     status                  TEXT NOT NULL DEFAULT 'pending',
     pr_url                  TEXT,
@@ -170,8 +168,6 @@ var migrationStatements = []string{
 	// version and embedded build SHA used by the running binary.
 	`ALTER TABLE runs ADD COLUMN no_mistakes_version TEXT`,
 	`ALTER TABLE runs ADD COLUMN no_mistakes_build_sha TEXT`,
-	`ALTER TABLE runs ADD COLUMN trusted_config_sha TEXT`,
-	`ALTER TABLE runs ADD COLUMN global_config_yaml TEXT`,
 	// Review authority is nullable and never backfilled. A historical mutable
 	// head_sha cannot prove which exact commit a completed review approved.
 	`ALTER TABLE runs ADD COLUMN review_approved_head_sha TEXT`,

--- a/internal/e2e/eval_test.go
+++ b/internal/e2e/eval_test.go
@@ -65,6 +65,7 @@ func TestEvalJourney(t *testing.T) {
 	if !strings.Contains(out, "captured 1 local review case") {
 		t.Fatalf("capture output = %q", out)
 	}
+	t.Logf("eval capture output:\n%s", out)
 
 	out, err = h.Run("eval", "sets")
 	if err != nil {
@@ -73,14 +74,17 @@ func TestEvalJourney(t *testing.T) {
 	if !strings.Contains(out, "LOCAL-ONLY EVAL CASE SETS") || !strings.Contains(out, "diversified:") {
 		t.Fatalf("sets output = %q", out)
 	}
+	t.Logf("eval sets output:\n%s", out)
 
-	out, err = h.Run("eval", "run", "--cases", "all", "--candidate", "claude+fake-model", "--repeats", "1")
+	out, err = h.Run("eval", "run", "--cases", "all", "--candidate", "claude+claude-opus-4-7", "--repeats", "1")
 	if err != nil {
-		t.Fatalf("eval run: %v\n%s", err, out)
+		report, reportErr := h.Run("eval", "report")
+		t.Fatalf("eval run: %v\n%s\neval report after failure (%v):\n%s", err, out, reportErr, report)
 	}
 	if !strings.Contains(out, "local eval session") {
 		t.Fatalf("run output = %q", out)
 	}
+	t.Logf("eval run output:\n%s", out)
 	invocations := h.AgentInvocations()
 	if len(invocations) == 0 {
 		t.Fatal("expected replay agent invocation")
@@ -94,7 +98,8 @@ func TestEvalJourney(t *testing.T) {
 	if err != nil {
 		t.Fatalf("eval report: %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "LOCAL-ONLY EVAL REPORT") || !strings.Contains(out, "claude+fake-model") || !strings.Contains(out, "queued unexpected parks: 1") {
+	if !strings.Contains(out, "LOCAL-ONLY EVAL REPORT") || !strings.Contains(out, "claude+claude-opus-4-7") || !strings.Contains(out, "queued unexpected parks: 1") {
 		t.Fatalf("report output = %q", out)
 	}
+	t.Logf("eval report output:\n%s", out)
 }

--- a/internal/e2e/eval_test.go
+++ b/internal/e2e/eval_test.go
@@ -17,6 +17,7 @@ import (
 // the source daemon; eval itself must create its own temporary sandbox and
 // never reuse it.
 func TestEvalJourney(t *testing.T) {
+	t.Setenv("NO_MISTAKES_EVAL_CAPTURE_PROVENANCE", "1")
 	scenario := filepath.Join(t.TempDir(), "eval-scenario.yaml")
 	if err := os.WriteFile(scenario, []byte(`actions:
   - match: "Review the code changes and return structured findings with a risk assessment."

--- a/internal/e2e/eval_test.go
+++ b/internal/e2e/eval_test.go
@@ -1,0 +1,99 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// TestEvalJourney drives the public CLI through a real captured pipeline run
+// and replays its review with a fakeagent scenario. The harness's NM_HOME owns
+// the source daemon; eval itself must create its own temporary sandbox and
+// never reuse it.
+func TestEvalJourney(t *testing.T) {
+	scenario := filepath.Join(t.TempDir(), "eval-scenario.yaml")
+	if err := os.WriteFile(scenario, []byte(`actions:
+  - match: "Review the code changes and return structured findings with a risk assessment."
+    structured:
+      findings:
+        - id: review-warning
+          severity: warning
+          file: eval.go
+          line: 3
+          description: "review scenario finding"
+          action: ask-user
+          review_scope: source
+      risk_level: medium
+      risk_rationale: "scenario review finding"
+      risk_scope: source-or-external
+  - structured:
+      findings: []
+      summary: "clean"
+      tested: ["fakeagent"]
+      testing_summary: "simulated"
+      artifacts: []
+      risk_level: low
+      risk_rationale: "clean"
+      risk_scope: source-or-external
+      title: "fake"
+      body: "fake"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h := NewHarness(t, SetupOpts{Agent: "claude", Scenario: scenario})
+	if out, err := h.Run("init"); err != nil {
+		t.Fatalf("init: %v\n%s", err, out)
+	}
+
+	h.CommitChange("eval-journey", "eval.go", "package e2e\n\nfunc EvalJourney() {}\n", "add eval journey change")
+	h.PushToGate("eval-journey")
+	gated := waitForStepStatus(t, h, "eval-journey", types.StepReview, types.StepStatusAwaitingApproval, 45*time.Second)
+	h.Respond(gated.ID, types.StepReview, types.ActionApprove)
+	run := h.WaitForRun("eval-journey", 45*time.Second)
+
+	out, err := h.Run("eval", "capture", run.ID)
+	if err != nil {
+		t.Fatalf("eval capture: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "captured 1 local review case") {
+		t.Fatalf("capture output = %q", out)
+	}
+
+	out, err = h.Run("eval", "sets")
+	if err != nil {
+		t.Fatalf("eval sets: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "LOCAL-ONLY EVAL CASE SETS") || !strings.Contains(out, "diversified:") {
+		t.Fatalf("sets output = %q", out)
+	}
+
+	out, err = h.Run("eval", "run", "--cases", "all", "--candidate", "claude+fake-model", "--repeats", "1")
+	if err != nil {
+		t.Fatalf("eval run: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "local eval session") {
+		t.Fatalf("run output = %q", out)
+	}
+	invocations := h.AgentInvocations()
+	if len(invocations) == 0 {
+		t.Fatal("expected replay agent invocation")
+	}
+	replayCWD := invocations[len(invocations)-1].CWD
+	if !strings.Contains(replayCWD, "nm-eval-replay-") || strings.HasPrefix(replayCWD, h.NMHome) {
+		t.Fatalf("replay used non-isolated worktree %q (source NM_HOME %q)", replayCWD, h.NMHome)
+	}
+
+	out, err = h.Run("eval", "report")
+	if err != nil {
+		t.Fatalf("eval report: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "LOCAL-ONLY EVAL REPORT") || !strings.Contains(out, "claude+fake-model") || !strings.Contains(out, "queued unexpected parks: 1") {
+		t.Fatalf("report output = %q", out)
+	}
+}

--- a/internal/e2edaemon/doc.go
+++ b/internal/e2edaemon/doc.go
@@ -1,9 +1,9 @@
-// Package e2edaemon owns temporary E2E daemon lifecycle: exact inventory,
-// a reaper with bounded ownership checks, and a concurrency slot cap.
+// Package e2edaemon owns isolated temporary no-mistakes process lifecycle:
+// exact inventory, a reaper with bounded ownership checks, and a concurrency
+// slot cap.
 //
-// Scope is temporary E2E daemons only (NM_TEST_START_DAEMON detached starts
-// under harness temp roots). The shared production daemon and external
-// sleep-loop keepalive shells are out of scope.
+// Scope includes temporary E2E daemons and eval candidate roots. The shared
+// production daemon and external sleep-loop keepalive shells are out of scope.
 //
 // Recovery boundary (honest):
 //   - t.Cleanup and package TestMain reapers cover normal completion and

--- a/internal/e2edaemon/inventory.go
+++ b/internal/e2edaemon/inventory.go
@@ -34,6 +34,7 @@ type Entry struct {
 	NMHome       string    `json:"nm_home"`
 	PID          int       `json:"pid"`
 	NMBin        string    `json:"nm_bin,omitempty"`
+	ProcessHash  string    `json:"process_hash,omitempty"`
 	OwnerPID     int       `json:"owner_pid"`
 	RegisteredAt time.Time `json:"registered_at"`
 }
@@ -149,6 +150,10 @@ func (inv *Inventory) Register(id, nmHome, nmBin string, pid, ownerPID int) erro
 
 // UpdatePID sets the recorded pid for id (or nmHome match).
 func (inv *Inventory) UpdatePID(id string, pid int) error {
+	return inv.updateProcess(id, pid, "")
+}
+
+func (inv *Inventory) updateProcess(id string, pid int, processHash string) error {
 	if inv == nil {
 		return fmt.Errorf("e2edaemon: nil inventory")
 	}
@@ -161,6 +166,7 @@ func (inv *Inventory) UpdatePID(id string, pid int) error {
 		for i := range file.Entries {
 			if file.Entries[i].ID == id {
 				file.Entries[i].PID = pid
+				file.Entries[i].ProcessHash = processHash
 				return nil
 			}
 		}

--- a/internal/e2edaemon/process_unix.go
+++ b/internal/e2edaemon/process_unix.go
@@ -97,3 +97,25 @@ func terminateDaemonPID(pid int) error {
 	}
 	return fmt.Errorf("pid %d still alive after SIGKILL", pid)
 }
+
+func terminateProcessTree(pid int) error {
+	if err := syscall.Kill(-pid, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return err
+	}
+	if waitProcessExit(pid, 2*time.Second) {
+		return nil
+	}
+	if command, err := processCommandLine(pid); err != nil || strings.Contains(command, "<defunct>") {
+		return nil
+	}
+	if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return err
+	}
+	if waitProcessExit(pid, 2*time.Second) {
+		return nil
+	}
+	if command, err := processCommandLine(pid); err != nil || strings.Contains(command, "<defunct>") {
+		return nil
+	}
+	return fmt.Errorf("process group %d still alive after SIGKILL", pid)
+}

--- a/internal/e2edaemon/process_windows.go
+++ b/internal/e2edaemon/process_windows.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 	"unsafe"
@@ -118,4 +120,15 @@ func terminateDaemonPID(pid int) error {
 		return nil
 	}
 	return fmt.Errorf("pid %d still alive after kill", pid)
+}
+
+func terminateProcessTree(pid int) error {
+	cmd := exec.Command("taskkill", "/PID", strconv.Itoa(pid), "/T", "/F")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("taskkill %d: %w: %s", pid, err, strings.TrimSpace(string(output)))
+	}
+	if waitProcessExit(pid, 2*time.Second) {
+		return nil
+	}
+	return fmt.Errorf("process tree %d still alive after kill", pid)
 }

--- a/internal/e2edaemon/reaper.go
+++ b/internal/e2edaemon/reaper.go
@@ -248,9 +248,25 @@ func (o *Ownership) SyncProcess(pid int) error {
 	if pid <= 0 {
 		return nil
 	}
-	command, err := processCommandLine(pid)
+	var command string
+	var err error
+	for attempt := 0; attempt < 3; attempt++ {
+		command, err = processCommandLine(pid)
+		if err == nil {
+			break
+		}
+		alive, aliveErr := processAlive(pid)
+		if aliveErr == nil && !alive {
+			// A short-lived candidate can exit before its synchronous start
+			// callback inspects it. It no longer needs reaper ownership.
+			return nil
+		}
+		if attempt < 2 {
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
 	if err != nil {
-		_ = terminateProcessTree(pid)
+		// Never signal a PID whose identity could not be established.
 		return fmt.Errorf("e2edaemon: inspect candidate process: %w", err)
 	}
 	if err := o.Inv.updateProcess(o.ID, pid, processHash(command)); err != nil {

--- a/internal/e2edaemon/reaper.go
+++ b/internal/e2edaemon/reaper.go
@@ -115,6 +115,7 @@ func isAllowedTempRoot(nmHome string) bool {
 	// tests use nmh-*; suite labs use nm-e2e-keepalive / private/tmp prefixes.
 	lower := strings.ToLower(nmHome)
 	if strings.Contains(lower, string(filepath.Separator)+"nm-e2e") ||
+		strings.Contains(lower, string(filepath.Separator)+"nm-eval-") ||
 		strings.Contains(lower, string(filepath.Separator)+"nmh-") ||
 		strings.Contains(lower, "/tmp/") ||
 		strings.Contains(lower, "/private/tmp/") ||

--- a/internal/e2edaemon/reaper.go
+++ b/internal/e2edaemon/reaper.go
@@ -2,6 +2,8 @@ package e2edaemon
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"os/exec"
@@ -59,32 +61,40 @@ func (inv *Inventory) reapEntry(e Entry, result *ReapResult) error {
 		result.Stopped++
 	}
 
-	// Kill only PIDs that still match daemon run --root <exact home>.
-	targets := map[int]struct{}{}
-	if e.PID > 0 && MatchesDaemonRoot(e.PID, e.NMHome) {
-		targets[e.PID] = struct{}{}
-	}
-	if found, err := inv.daemonsForRoot(e.NMHome); err == nil {
-		for _, pid := range found {
-			targets[pid] = struct{}{}
+	if e.ProcessHash != "" {
+		if processMatchesHash(e.PID, e.ProcessHash) {
+			if err := terminateProcessTree(e.PID); err != nil {
+				return fmt.Errorf("kill candidate %d: %w", e.PID, err)
+			}
+			result.Killed++
 		}
-	}
-	for pid := range targets {
-		if !MatchesDaemonRoot(pid, e.NMHome) {
-			continue
+	} else {
+		targets := map[int]struct{}{}
+		if e.PID > 0 && MatchesDaemonRoot(e.PID, e.NMHome) {
+			targets[e.PID] = struct{}{}
 		}
-		if err := terminateMatched(pid); err != nil {
-			result.Errors = append(result.Errors, fmt.Sprintf("kill %d: %v", pid, err))
-			continue
+		if found, err := inv.daemonsForRoot(e.NMHome); err == nil {
+			for _, pid := range found {
+				targets[pid] = struct{}{}
+			}
 		}
-		result.Killed++
-	}
-	found, err := inv.daemonsForRoot(e.NMHome)
-	if err != nil {
-		return fmt.Errorf("confirm daemon exit: %w", err)
-	}
-	if len(found) > 0 {
-		return fmt.Errorf("matching daemon processes remain: %v", found)
+		for pid := range targets {
+			if !MatchesDaemonRoot(pid, e.NMHome) {
+				continue
+			}
+			if err := terminateMatched(pid); err != nil {
+				result.Errors = append(result.Errors, fmt.Sprintf("kill %d: %v", pid, err))
+				continue
+			}
+			result.Killed++
+		}
+		found, err := inv.daemonsForRoot(e.NMHome)
+		if err != nil {
+			return fmt.Errorf("confirm daemon exit: %w", err)
+		}
+		if len(found) > 0 {
+			return fmt.Errorf("matching daemon processes remain: %v", found)
+		}
 	}
 
 	if err := inv.Unregister(e.ID); err != nil {
@@ -171,6 +181,16 @@ func terminateMatched(pid int) error {
 	return terminateDaemonPID(pid)
 }
 
+func processHash(command string) string {
+	sum := sha256.Sum256([]byte(command))
+	return hex.EncodeToString(sum[:])
+}
+
+func processMatchesHash(pid int, expected string) bool {
+	command, err := processCommandLine(pid)
+	return err == nil && expected != "" && processHash(command) == expected
+}
+
 // Ownership tracks one harness's inventory entry and concurrency slot.
 type Ownership struct {
 	Inv    *Inventory
@@ -219,6 +239,25 @@ func (o *Ownership) SyncPID(pid int) error {
 		return nil
 	}
 	return o.Inv.UpdatePID(o.ID, pid)
+}
+
+func (o *Ownership) SyncProcess(pid int) error {
+	if o == nil || o.Inv == nil {
+		return fmt.Errorf("e2edaemon: nil ownership")
+	}
+	if pid <= 0 {
+		return nil
+	}
+	command, err := processCommandLine(pid)
+	if err != nil {
+		_ = terminateProcessTree(pid)
+		return fmt.Errorf("e2edaemon: inspect candidate process: %w", err)
+	}
+	if err := o.Inv.updateProcess(o.ID, pid, processHash(command)); err != nil {
+		_ = terminateProcessTree(pid)
+		return err
+	}
+	return nil
 }
 
 // StopBestEffort runs daemon stop for this home when a binary is known.

--- a/internal/e2edaemon/reaper_test.go
+++ b/internal/e2edaemon/reaper_test.go
@@ -158,6 +158,36 @@ func safetyReap(t *testing.T) {
 	})
 }
 
+func TestReapAll_OwnedCandidateProcess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix process model")
+	}
+	lab := labRoot(t)
+	t.Setenv(EnvInventory, filepath.Join(lab, "inv"))
+	safetyReap(t)
+	nmHome := filepath.Join(lab, "nm-eval-owned", "nmhome")
+	ownership, err := Acquire(nmHome, "", time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("sh", "-c", "sleep 60 & wait")
+	detachTestProcess(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := ownership.SyncProcess(cmd.Process.Pid); err != nil {
+		t.Fatal(err)
+	}
+	result := ownership.Inv.ReapAll()
+	if result.Killed != 1 || result.Removed != 1 {
+		t.Fatalf("reap result = %+v", result)
+	}
+	_ = cmd.Wait()
+	if alive, _ := ProcessAlive(cmd.Process.Pid); alive {
+		t.Fatalf("candidate pid %d remains alive", cmd.Process.Pid)
+	}
+}
+
 func TestReapAll_NormalCompletion(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("unix process model")

--- a/internal/e2edaemon/reaper_test.go
+++ b/internal/e2edaemon/reaper_test.go
@@ -158,6 +158,24 @@ func safetyReap(t *testing.T) {
 	})
 }
 
+func TestSyncProcessAllowsCandidateThatAlreadyExited(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvInventory, filepath.Join(root, "inventory"))
+	ownership, err := Acquire(filepath.Join(root, "nm-eval-finished", "nmhome"), "", time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ownership.Release()
+
+	cmd := exec.Command(os.Args[0], "-test.run=^$")
+	if err := cmd.Run(); err != nil {
+		t.Fatal(err)
+	}
+	if err := ownership.SyncProcess(cmd.Process.Pid); err != nil {
+		t.Fatalf("SyncProcess rejected a candidate that had already exited: %v", err)
+	}
+}
+
 func TestReapAll_OwnedCandidateProcess(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("unix process model")

--- a/internal/eval/capture.go
+++ b/internal/eval/capture.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kunchenguid/no-mistakes/internal/agent"
 	"github.com/kunchenguid/no-mistakes/internal/config"
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/git"
@@ -444,14 +445,14 @@ func baselineForRound(invocations []db.AgentInvocation, round int) BaselineMetri
 			continue
 		}
 		baseline.DurationMS += inv.DurationMS
-		if inv.DeltaInputTokens == nil || inv.DeltaOutputTokens == nil || inv.DeltaCacheReadTokens == nil || inv.FreshInputTokens == nil {
+		if inv.DeltaInputTokens == nil || inv.DeltaOutputTokens == nil || inv.DeltaCacheReadTokens == nil {
 			continue
 		}
 		seen = true
 		baseline.InputTokens += int64(*inv.DeltaInputTokens)
 		baseline.OutputTokens += int64(*inv.DeltaOutputTokens)
 		baseline.CacheReadTokens += int64(*inv.DeltaCacheReadTokens)
-		baseline.FreshInputTokens += int64(*inv.FreshInputTokens)
+		baseline.FreshInputTokens += int64(agent.FreshInputTokens(*inv.DeltaInputTokens, *inv.DeltaCacheReadTokens))
 	}
 	baseline.TokensReported = seen
 	return baseline

--- a/internal/eval/capture.go
+++ b/internal/eval/capture.go
@@ -146,18 +146,22 @@ func Capture(ctx context.Context, store *Store, p *paths.Paths, database *db.DB,
 	if err := git.ValidateBareRepository(ctx, gateDir); err != nil {
 		return nil, fmt.Errorf("source gate is unavailable for capture: %w", err)
 	}
-	if run.TrustedConfigSHA == nil || strings.TrimSpace(*run.TrustedConfigSHA) == "" {
-		return nil, fmt.Errorf("run %q predates SHA-pinned trusted configuration capture", run.ID)
+	trustedSHA, err := git.ResolveRef(ctx, gateDir, "refs/heads/"+repo.DefaultBranch)
+	if err != nil {
+		return nil, fmt.Errorf("resolve capture-time trusted configuration: %w", err)
 	}
-	trustedSHA := strings.TrimSpace(*run.TrustedConfigSHA)
+	trustedSHA = strings.TrimSpace(trustedSHA)
 	trustedConfig, err := repoConfigAt(ctx, gateDir, trustedSHA)
 	if err != nil {
-		return nil, fmt.Errorf("read source run trusted configuration at %s: %w", trustedSHA, err)
+		return nil, fmt.Errorf("read capture-time trusted configuration at %s: %w", trustedSHA, err)
 	}
-	if run.GlobalConfigYAML == nil {
-		return nil, fmt.Errorf("run %q predates pinned global configuration capture", run.ID)
+	globalConfigBytes, err := os.ReadFile(p.ConfigFile())
+	if errors.Is(err, os.ErrNotExist) {
+		globalConfigBytes = []byte("{}\n")
+	} else if err != nil {
+		return nil, fmt.Errorf("read capture-time global configuration: %w", err)
 	}
-	globalConfig, err := agentNeutralGlobalConfig([]byte(*run.GlobalConfigYAML))
+	globalConfig, err := agentNeutralGlobalConfig(globalConfigBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -176,6 +180,11 @@ func Capture(ctx context.Context, store *Store, p *paths.Paths, database *db.DB,
 			// partial record, not a replayable review pass. Refuse rather than
 			// silently grade a fabricated clean result.
 			return nil, fmt.Errorf("review round %q has no recorded findings", round.ID)
+		}
+		decision := decisionForRound(round, reviewStep)
+		labels := Labels{Version: labelsVersion, Verdict: verdictFromDecision(round, decision)}
+		if !labels.Verdict.Known && (reviewStep.Status == types.StepStatusAwaitingApproval || reviewStep.Status == types.StepStatusFixReview) {
+			return nil, fmt.Errorf("review round %q has no recorded gate decision", round.ID)
 		}
 		reviewedSHA := run.HeadSHA
 		if round.ReviewedHeadSHA != nil && strings.TrimSpace(*round.ReviewedHeadSHA) != "" {
@@ -218,8 +227,6 @@ func Capture(ctx context.Context, store *Store, p *paths.Paths, database *db.DB,
 			return nil, fmt.Errorf("inspect case destination: %w", err)
 		}
 
-		decision := decisionForRound(round, reviewStep)
-		labels := Labels{Version: labelsVersion, Verdict: verdictFromDecision(round, decision)}
 		manifest := Manifest{
 			Version: manifestVersion, ID: caseID, SourceRunID: run.ID, SourceRoundID: round.ID,
 			CapturedAt: time.Now().Unix(), RepoFingerprint: fingerprint(repo.UpstreamURL),

--- a/internal/eval/capture.go
+++ b/internal/eval/capture.go
@@ -431,21 +431,29 @@ func sourceInvocationsFor(invocations []db.AgentInvocation) []sourceInvocation {
 func baselineForRound(invocations []db.AgentInvocation, round int) BaselineMetrics {
 	var baseline BaselineMetrics
 	seen := false
+	complete := true
 	for _, inv := range invocations {
-		if inv.StepName != string(types.StepReview) || inv.Round != round {
-			continue
-		}
-		baseline.DurationMS += inv.DurationMS
-		if inv.DeltaInputTokens == nil || inv.DeltaOutputTokens == nil || inv.DeltaCacheReadTokens == nil {
+		if inv.StepName != string(types.StepReview) || inv.Round != round || inv.Purpose != "review" {
 			continue
 		}
 		seen = true
+		baseline.DurationMS += inv.DurationMS
+		if inv.DeltaInputTokens == nil || inv.DeltaOutputTokens == nil || inv.DeltaCacheReadTokens == nil {
+			complete = false
+			continue
+		}
 		baseline.InputTokens += int64(*inv.DeltaInputTokens)
 		baseline.OutputTokens += int64(*inv.DeltaOutputTokens)
 		baseline.CacheReadTokens += int64(*inv.DeltaCacheReadTokens)
 		baseline.FreshInputTokens += int64(agent.FreshInputTokens(*inv.DeltaInputTokens, *inv.DeltaCacheReadTokens))
 	}
-	baseline.TokensReported = seen
+	baseline.TokensReported = seen && complete
+	if !baseline.TokensReported {
+		baseline.InputTokens = 0
+		baseline.OutputTokens = 0
+		baseline.CacheReadTokens = 0
+		baseline.FreshInputTokens = 0
+	}
 	return baseline
 }
 

--- a/internal/eval/capture.go
+++ b/internal/eval/capture.go
@@ -28,6 +28,7 @@ import (
 // prompts, remote URLs, or agent session identities.
 type sourceRound struct {
 	ID                 string  `json:"id"`
+	StepName           string  `json:"step_name,omitempty"`
 	Round              int     `json:"round"`
 	Trigger            string  `json:"trigger"`
 	FindingsJSON       *string `json:"findings_json,omitempty"`
@@ -40,9 +41,9 @@ type sourceRound struct {
 	CreatedAt          int64   `json:"created_at"`
 }
 
-func portableRound(round *db.StepRound) sourceRound {
+func portableRound(round *db.StepRound, stepName types.StepName) sourceRound {
 	return sourceRound{
-		ID: round.ID, Round: round.Round, Trigger: round.Trigger,
+		ID: round.ID, StepName: string(stepName), Round: round.Round, Trigger: round.Trigger,
 		FindingsJSON: round.FindingsJSON, ReviewedHeadSHA: round.ReviewedHeadSHA,
 		UserFindingsJSON: round.UserFindingsJSON, SelectedFindingIDs: round.SelectedFindingIDs,
 		SelectionSource: round.SelectionSource, FixSummary: round.FixSummary,
@@ -123,7 +124,7 @@ func Capture(ctx context.Context, store *Store, p *paths.Paths, database *db.DB,
 			return nil, fmt.Errorf("read source rounds: %w", err)
 		}
 		for _, round := range rounds {
-			allRounds = append(allRounds, portableRound(round))
+			allRounds = append(allRounds, portableRound(round, step.StepName))
 		}
 		if step.StepName == types.StepReview {
 			reviewStep = step
@@ -144,9 +145,13 @@ func Capture(ctx context.Context, store *Store, p *paths.Paths, database *db.DB,
 	if err := git.ValidateBareRepository(ctx, gateDir); err != nil {
 		return nil, fmt.Errorf("source gate is unavailable for capture: %w", err)
 	}
-	trustedSHA, trustedConfig, err := captureTrustedConfig(ctx, gateDir, repo.DefaultBranch)
+	if run.TrustedConfigSHA == nil || strings.TrimSpace(*run.TrustedConfigSHA) == "" {
+		return nil, fmt.Errorf("run %q predates SHA-pinned trusted configuration capture", run.ID)
+	}
+	trustedSHA := strings.TrimSpace(*run.TrustedConfigSHA)
+	trustedConfig, err := repoConfigAt(ctx, gateDir, trustedSHA)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("read source run trusted configuration at %s: %w", trustedSHA, err)
 	}
 	globalConfig, err := agentNeutralGlobalConfig(p.ConfigFile())
 	if err != nil {
@@ -232,7 +237,7 @@ func Capture(ctx context.Context, store *Store, p *paths.Paths, database *db.DB,
 		}
 		baseline := baselineForRound(invocations, round.Round)
 		c := Case{Manifest: manifest, Labels: labels, Decision: decision, Baseline: baseline, Dir: caseDir}
-		if err := writeCase(ctx, store, gateDir, c, globalConfig, repoConfigBytes, sourceRunFor(run), sourceStepsFor(steps), allRounds, sourceInvocationsFor(invocations), portableRound(round), changedPaths); err != nil {
+		if err := writeCase(ctx, store, gateDir, c, globalConfig, repoConfigBytes, sourceRunFor(run), sourceStepsFor(steps), allRounds, sourceInvocationsFor(invocations), portableRound(round, types.StepReview), changedPaths); err != nil {
 			return nil, err
 		}
 		c, err = loadCase(caseDir)
@@ -262,29 +267,6 @@ func effectiveReplayBase(ctx context.Context, gateDir, recordedBase, head, trust
 		}
 	}
 	return "", fmt.Errorf("derive replay base: reviewed head and trusted default branch have no readable merge base")
-}
-
-func captureTrustedConfig(ctx context.Context, gateDir, branch string) (string, *config.RepoConfig, error) {
-	branch = strings.TrimSpace(branch)
-	if branch == "" {
-		return "", nil, fmt.Errorf("source repository has no default branch")
-	}
-	var trustedSHA string
-	var err error
-	for _, ref := range []string{"refs/remotes/origin/" + branch, "refs/heads/" + branch} {
-		trustedSHA, err = git.ResolveRef(ctx, gateDir, ref)
-		if err == nil {
-			break
-		}
-	}
-	if trustedSHA == "" || err != nil {
-		return "", nil, fmt.Errorf("trusted default branch %q is unavailable in the gate", branch)
-	}
-	trusted, err := repoConfigAt(ctx, gateDir, trustedSHA)
-	if err != nil {
-		return "", nil, fmt.Errorf("read trusted repository config: %w", err)
-	}
-	return trustedSHA, trusted, nil
 }
 
 func repoConfigAt(ctx context.Context, gateDir, sha string) (*config.RepoConfig, error) {

--- a/internal/eval/capture.go
+++ b/internal/eval/capture.go
@@ -146,42 +146,12 @@ func Capture(ctx context.Context, store *Store, p *paths.Paths, database *db.DB,
 	if err := git.ValidateBareRepository(ctx, gateDir); err != nil {
 		return nil, fmt.Errorf("source gate is unavailable for capture: %w", err)
 	}
-	trustedSHA, err := trustedConfigSHAAtReview(ctx, gateDir, repo.DefaultBranch, reviewRounds[0].CreatedAt)
-	if err != nil {
-		return nil, err
-	}
-	trustedConfig, err := repoConfigAt(ctx, gateDir, trustedSHA)
-	if err != nil {
-		return nil, fmt.Errorf("read source trusted configuration at %s: %w", trustedSHA, err)
-	}
-	globalConfigBytes, err := os.ReadFile(p.ConfigFile())
-	if errors.Is(err, os.ErrNotExist) {
-		globalConfigBytes = []byte("{}\n")
-	} else if err != nil {
-		return nil, fmt.Errorf("read source global configuration: %w", err)
-	} else {
-		info, statErr := os.Stat(p.ConfigFile())
-		if statErr != nil {
-			return nil, fmt.Errorf("stat source global configuration: %w", statErr)
-		}
-		if info.ModTime().Unix() > reviewRounds[0].CreatedAt {
-			return nil, fmt.Errorf("global configuration changed after the source review; its original configuration is unavailable")
-		}
-	}
-	globalConfig, err := agentNeutralGlobalConfig(globalConfigBytes)
-	if err != nil {
-		return nil, err
-	}
 	invocations, err := database.GetAgentInvocationsByRun(run.ID)
 	if err != nil {
 		return nil, fmt.Errorf("read source invocation metrics: %w", err)
 	}
-	replayBaseSHA, err := effectiveReplayBase(ctx, gateDir, run.BaseSHA, run.HeadSHA, trustedSHA)
-	if err != nil {
-		return nil, err
-	}
 	captured := make([]Case, 0, len(reviewRounds))
-	for roundIndex, round := range reviewRounds {
+	for _, round := range reviewRounds {
 		if round.FindingsJSON == nil {
 			// A persisted round with no findings was an interrupted or legacy
 			// partial record, not a replayable review pass. Refuse rather than
@@ -197,12 +167,22 @@ func Capture(ctx context.Context, store *Store, p *paths.Paths, database *db.DB,
 		if round.ReviewedHeadSHA != nil && strings.TrimSpace(*round.ReviewedHeadSHA) != "" {
 			reviewedSHA = strings.TrimSpace(*round.ReviewedHeadSHA)
 		}
-		startingSHA := reviewedSHA
-		if round.IsFixRound() {
-			if roundIndex == 0 || reviewRounds[roundIndex-1].ReviewedHeadSHA == nil || strings.TrimSpace(*reviewRounds[roundIndex-1].ReviewedHeadSHA) == "" {
-				return nil, fmt.Errorf("review fix round %q has no preceding reviewed head", round.ID)
-			}
-			startingSHA = strings.TrimSpace(*reviewRounds[roundIndex-1].ReviewedHeadSHA)
+		if round.StartingHeadSHA == nil || strings.TrimSpace(*round.StartingHeadSHA) == "" || round.TrustedConfigSHA == nil || strings.TrimSpace(*round.TrustedConfigSHA) == "" || len(round.GlobalConfigYAML) == 0 || len(round.RepoConfigYAML) == 0 {
+			return nil, fmt.Errorf("review round %q predates exact eval configuration provenance", round.ID)
+		}
+		startingSHA := strings.TrimSpace(*round.StartingHeadSHA)
+		trustedSHA := strings.TrimSpace(*round.TrustedConfigSHA)
+		globalConfig, err := agentNeutralGlobalConfig(round.GlobalConfigYAML)
+		if err != nil {
+			return nil, fmt.Errorf("read review round %q global configuration: %w", round.ID, err)
+		}
+		if _, err := config.LoadRepoFromBytes(round.RepoConfigYAML); err != nil {
+			return nil, fmt.Errorf("read review round %q repository configuration: %w", round.ID, err)
+		}
+		repoConfigBytes := append([]byte(nil), round.RepoConfigYAML...)
+		replayBaseSHA, err := effectiveReplayBase(ctx, gateDir, run.BaseSHA, reviewedSHA, trustedSHA)
+		if err != nil {
+			return nil, err
 		}
 		if _, err := git.ResolveRef(ctx, gateDir, reviewedSHA); err != nil {
 			return nil, fmt.Errorf("review round %q commit is unavailable for capture: %w", round.ID, err)
@@ -215,16 +195,6 @@ func Capture(ctx context.Context, store *Store, p *paths.Paths, database *db.DB,
 		if err != nil {
 			return nil, fmt.Errorf("read review changed files for round %q: %w", round.ID, err)
 		}
-		pushedConfig, err := repoConfigAt(ctx, gateDir, reviewedSHA)
-		if err != nil {
-			return nil, fmt.Errorf("read review config for round %q: %w", round.ID, err)
-		}
-		effectiveRepoConfig := config.EffectiveRepoConfig(pushedConfig, trustedConfig, trustedConfig.AllowRepoCommands)
-		repoConfigBytes, err := yaml.Marshal(effectiveRepoConfig)
-		if err != nil {
-			return nil, fmt.Errorf("serialize replay config: %w", err)
-		}
-
 		caseID := run.ID + "-" + round.ID
 		caseDir := store.caseDir(caseID)
 		if existing, err := os.Stat(caseDir); err == nil && existing.IsDir() {
@@ -275,19 +245,6 @@ func Capture(ctx context.Context, store *Store, p *paths.Paths, database *db.DB,
 		captured = append(captured, c)
 	}
 	return captured, nil
-}
-
-func trustedConfigSHAAtReview(ctx context.Context, gateDir, defaultBranch string, reviewedAt int64) (string, error) {
-	ref := "refs/heads/" + defaultBranch
-	sha, err := git.Run(ctx, gateDir, "rev-list", "-1", "--first-parent", fmt.Sprintf("--before=@%d", reviewedAt), ref)
-	if err != nil {
-		return "", fmt.Errorf("resolve source trusted configuration: %w", err)
-	}
-	sha = strings.TrimSpace(sha)
-	if sha == "" {
-		return "", fmt.Errorf("source trusted configuration commit is unavailable at review time")
-	}
-	return sha, nil
 }
 
 // effectiveReplayBase reproduces ReviewStep's branch-scoped base: the merge

--- a/internal/eval/capture.go
+++ b/internal/eval/capture.go
@@ -1,0 +1,549 @@
+package eval
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/config"
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/git"
+	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/safeurl"
+	"github.com/kunchenguid/no-mistakes/internal/shellenv"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+	"gopkg.in/yaml.v3"
+)
+
+// sourceRound is a portable, JSON-stable export of a review round. It keeps
+// the findings and human-decision evidence needed by the MVP but no logs,
+// prompts, remote URLs, or agent session identities.
+type sourceRound struct {
+	ID                 string  `json:"id"`
+	Round              int     `json:"round"`
+	Trigger            string  `json:"trigger"`
+	FindingsJSON       *string `json:"findings_json,omitempty"`
+	ReviewedHeadSHA    *string `json:"reviewed_head_sha,omitempty"`
+	UserFindingsJSON   *string `json:"user_findings_json,omitempty"`
+	SelectedFindingIDs *string `json:"selected_finding_ids,omitempty"`
+	SelectionSource    *string `json:"selection_source,omitempty"`
+	FixSummary         *string `json:"fix_summary,omitempty"`
+	DurationMS         int64   `json:"duration_ms"`
+	CreatedAt          int64   `json:"created_at"`
+}
+
+func portableRound(round *db.StepRound) sourceRound {
+	return sourceRound{
+		ID: round.ID, Round: round.Round, Trigger: round.Trigger,
+		FindingsJSON: round.FindingsJSON, ReviewedHeadSHA: round.ReviewedHeadSHA,
+		UserFindingsJSON: round.UserFindingsJSON, SelectedFindingIDs: round.SelectedFindingIDs,
+		SelectionSource: round.SelectionSource, FixSummary: round.FixSummary,
+		DurationMS: round.DurationMS, CreatedAt: round.CreatedAt,
+	}
+}
+
+type sourceRun struct {
+	ID                 string `json:"id"`
+	Branch             string `json:"branch"`
+	HeadSHA            string `json:"head_sha"`
+	BaseSHA            string `json:"base_sha"`
+	Status             string `json:"status"`
+	Intent             string `json:"intent,omitempty"`
+	IntentSource       string `json:"intent_source,omitempty"`
+	NoMistakesVersion  string `json:"no_mistakes_version,omitempty"`
+	NoMistakesBuildSHA string `json:"no_mistakes_build_sha,omitempty"`
+	CreatedAt          int64  `json:"created_at"`
+	UpdatedAt          int64  `json:"updated_at"`
+}
+
+type sourceStep struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Status       string `json:"status"`
+	FindingsJSON string `json:"findings_json,omitempty"`
+	DurationMS   *int64 `json:"duration_ms,omitempty"`
+}
+
+type sourceInvocation struct {
+	StepName             string `json:"step_name"`
+	Round                int    `json:"round"`
+	Purpose              string `json:"purpose"`
+	Agent                string `json:"agent"`
+	Model                string `json:"model,omitempty"`
+	DurationMS           int64  `json:"duration_ms"`
+	InputTokens          int    `json:"input_tokens"`
+	OutputTokens         int    `json:"output_tokens"`
+	CacheReadTokens      int    `json:"cache_read_tokens"`
+	FreshInputTokens     *int   `json:"fresh_input_tokens,omitempty"`
+	DeltaInputTokens     *int   `json:"delta_input_tokens,omitempty"`
+	DeltaOutputTokens    *int   `json:"delta_output_tokens,omitempty"`
+	DeltaCacheReadTokens *int   `json:"delta_cache_read_tokens,omitempty"`
+	ExitStatus           string `json:"exit_status"`
+	FailureCategory      string `json:"failure_category,omitempty"`
+}
+
+// Capture exports every persisted review pass from one real run. It reads the
+// production state only; it never starts the daemon, changes a gate, fetches,
+// or sends data anywhere.
+func Capture(ctx context.Context, store *Store, p *paths.Paths, database *db.DB, runID string) ([]Case, error) {
+	if store == nil || p == nil || database == nil {
+		return nil, fmt.Errorf("eval capture requires a store, paths, and database")
+	}
+	run, err := database.GetRun(strings.TrimSpace(runID))
+	if err != nil {
+		return nil, fmt.Errorf("read source run: %w", err)
+	}
+	if run == nil {
+		return nil, fmt.Errorf("run %q not found", runID)
+	}
+	repo, err := database.GetRepo(run.RepoID)
+	if err != nil {
+		return nil, fmt.Errorf("read source repository: %w", err)
+	}
+	if repo == nil {
+		return nil, fmt.Errorf("source repository for run %q not found", runID)
+	}
+	steps, err := database.GetStepsByRun(run.ID)
+	if err != nil {
+		return nil, fmt.Errorf("read source steps: %w", err)
+	}
+	var reviewStep *db.StepResult
+	allRounds := make([]sourceRound, 0)
+	for _, step := range steps {
+		rounds, err := database.GetRoundsByStep(step.ID)
+		if err != nil {
+			return nil, fmt.Errorf("read source rounds: %w", err)
+		}
+		for _, round := range rounds {
+			allRounds = append(allRounds, portableRound(round))
+		}
+		if step.StepName == types.StepReview {
+			reviewStep = step
+		}
+	}
+	if reviewStep == nil {
+		return nil, fmt.Errorf("run %q has no review step to capture", run.ID)
+	}
+	reviewRounds, err := database.GetRoundsByStep(reviewStep.ID)
+	if err != nil {
+		return nil, fmt.Errorf("read review rounds: %w", err)
+	}
+	if len(reviewRounds) == 0 {
+		return nil, fmt.Errorf("run %q has no review passes to capture", run.ID)
+	}
+
+	gateDir := p.RepoDir(repo.ID)
+	if err := git.ValidateBareRepository(ctx, gateDir); err != nil {
+		return nil, fmt.Errorf("source gate is unavailable for capture: %w", err)
+	}
+	trustedSHA, trustedConfig, err := captureTrustedConfig(ctx, gateDir, repo.DefaultBranch)
+	if err != nil {
+		return nil, err
+	}
+	globalConfig, err := agentNeutralGlobalConfig(p.ConfigFile())
+	if err != nil {
+		return nil, err
+	}
+	invocations, err := database.GetAgentInvocationsByRun(run.ID)
+	if err != nil {
+		return nil, fmt.Errorf("read source invocation metrics: %w", err)
+	}
+	replayBaseSHA, err := effectiveReplayBase(ctx, gateDir, run.BaseSHA, run.HeadSHA, trustedSHA)
+	if err != nil {
+		return nil, err
+	}
+	captured := make([]Case, 0, len(reviewRounds))
+	for _, round := range reviewRounds {
+		if round.FindingsJSON == nil {
+			// A persisted round with no findings was an interrupted or legacy
+			// partial record, not a replayable review pass. Refuse rather than
+			// silently grade a fabricated clean result.
+			return nil, fmt.Errorf("review round %q has no recorded findings", round.ID)
+		}
+		reviewedSHA := run.HeadSHA
+		if round.ReviewedHeadSHA != nil && strings.TrimSpace(*round.ReviewedHeadSHA) != "" {
+			reviewedSHA = strings.TrimSpace(*round.ReviewedHeadSHA)
+		}
+		if _, err := git.ResolveRef(ctx, gateDir, reviewedSHA); err != nil {
+			return nil, fmt.Errorf("review round %q commit is unavailable for capture: %w", round.ID, err)
+		}
+		changedFiles, changedLines, err := git.DiffStat(ctx, gateDir, replayBaseSHA, reviewedSHA)
+		if err != nil {
+			return nil, fmt.Errorf("read review diff stat for round %q: %w", round.ID, err)
+		}
+		changedPaths, err := git.DiffNameOnly(ctx, gateDir, replayBaseSHA, reviewedSHA)
+		if err != nil {
+			return nil, fmt.Errorf("read review changed files for round %q: %w", round.ID, err)
+		}
+		pushedConfig, err := repoConfigAt(ctx, gateDir, reviewedSHA)
+		if err != nil {
+			return nil, fmt.Errorf("read review config for round %q: %w", round.ID, err)
+		}
+		effectiveRepoConfig := config.EffectiveRepoConfig(pushedConfig, trustedConfig, trustedConfig.AllowRepoCommands)
+		repoConfigBytes, err := yaml.Marshal(effectiveRepoConfig)
+		if err != nil {
+			return nil, fmt.Errorf("serialize replay config: %w", err)
+		}
+
+		caseID := run.ID + "-" + round.ID
+		caseDir := store.caseDir(caseID)
+		if existing, err := os.Stat(caseDir); err == nil && existing.IsDir() {
+			c, err := loadCase(caseDir)
+			if err != nil {
+				return nil, fmt.Errorf("read existing case %q: %w", caseID, err)
+			}
+			if err := store.registerCase(c); err != nil {
+				return nil, err
+			}
+			captured = append(captured, c)
+			continue
+		} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("inspect case destination: %w", err)
+		}
+
+		decision := decisionForRound(round, reviewStep)
+		labels := Labels{Version: labelsVersion, Verdict: verdictFromDecision(round, decision)}
+		manifest := Manifest{
+			Version: manifestVersion, ID: caseID, SourceRunID: run.ID, SourceRoundID: round.ID,
+			CapturedAt: time.Now().Unix(), RepoFingerprint: fingerprint(repo.UpstreamURL),
+			Branch: run.Branch, DefaultBranch: repo.DefaultBranch, BaseSHA: replayBaseSHA,
+			HeadSHA: run.HeadSHA, ReviewedHeadSHA: reviewedSHA, TrustedConfigSHA: trustedSHA,
+			ChangedFiles: changedFiles, ChangedLines: changedLines,
+		}
+		if run.Intent != nil {
+			manifest.Intent = *run.Intent
+		}
+		if run.IntentSource != nil {
+			manifest.IntentSource = *run.IntentSource
+		}
+		if run.NoMistakesVersion != nil {
+			manifest.VersionAtCapture = *run.NoMistakesVersion
+		}
+		if run.NoMistakesBuildSHA != nil {
+			manifest.BuildSHA = *run.NoMistakesBuildSHA
+		}
+		baseline := baselineForRound(invocations, round.Round)
+		c := Case{Manifest: manifest, Labels: labels, Decision: decision, Baseline: baseline, Dir: caseDir}
+		if err := writeCase(ctx, store, gateDir, c, globalConfig, repoConfigBytes, sourceRunFor(run), sourceStepsFor(steps), allRounds, sourceInvocationsFor(invocations), portableRound(round), changedPaths); err != nil {
+			return nil, err
+		}
+		c, err = loadCase(caseDir)
+		if err != nil {
+			return nil, fmt.Errorf("read captured case: %w", err)
+		}
+		if err := store.registerCase(c); err != nil {
+			return nil, err
+		}
+		captured = append(captured, c)
+	}
+	return captured, nil
+}
+
+// effectiveReplayBase reproduces ReviewStep's branch-scoped base: the merge
+// base of the reviewed head and the pinned default branch. Run.BaseSHA is the
+// received-push old SHA, which may be a previous feature tip rather than the
+// review base. It is only a legacy fallback when the merge-base cannot be
+// recovered from an older gate.
+func effectiveReplayBase(ctx context.Context, gateDir, recordedBase, head, trustedSHA string) (string, error) {
+	if base, err := git.Run(ctx, gateDir, "merge-base", head, trustedSHA); err == nil && strings.TrimSpace(base) != "" {
+		return strings.TrimSpace(base), nil
+	}
+	if recordedBase != "" && !git.IsZeroSHA(recordedBase) {
+		if _, err := git.ResolveRef(ctx, gateDir, recordedBase); err == nil {
+			return recordedBase, nil
+		}
+	}
+	return "", fmt.Errorf("derive replay base: reviewed head and trusted default branch have no readable merge base")
+}
+
+func captureTrustedConfig(ctx context.Context, gateDir, branch string) (string, *config.RepoConfig, error) {
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return "", nil, fmt.Errorf("source repository has no default branch")
+	}
+	var trustedSHA string
+	var err error
+	for _, ref := range []string{"refs/remotes/origin/" + branch, "refs/heads/" + branch} {
+		trustedSHA, err = git.ResolveRef(ctx, gateDir, ref)
+		if err == nil {
+			break
+		}
+	}
+	if trustedSHA == "" || err != nil {
+		return "", nil, fmt.Errorf("trusted default branch %q is unavailable in the gate", branch)
+	}
+	trusted, err := repoConfigAt(ctx, gateDir, trustedSHA)
+	if err != nil {
+		return "", nil, fmt.Errorf("read trusted repository config: %w", err)
+	}
+	return trustedSHA, trusted, nil
+}
+
+func repoConfigAt(ctx context.Context, gateDir, sha string) (*config.RepoConfig, error) {
+	if _, err := git.ResolveRef(ctx, gateDir, sha); err != nil {
+		return nil, err
+	}
+	entry, err := git.Run(ctx, gateDir, "ls-tree", sha, "--", ".no-mistakes.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("inspect repository config: %w", err)
+	}
+	if strings.TrimSpace(entry) == "" {
+		return &config.RepoConfig{}, nil
+	}
+	content, err := git.ShowFile(ctx, gateDir, sha, ".no-mistakes.yaml")
+	if err != nil {
+		return nil, fmt.Errorf("read repository config: %w", err)
+	}
+	return config.LoadRepoFromBytes([]byte(content))
+}
+
+func agentNeutralGlobalConfig(path string) ([]byte, error) {
+	if _, err := config.LoadGlobal(path); err != nil {
+		return nil, fmt.Errorf("read global config for capture: %w", err)
+	}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return []byte("{}\n"), nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read global config bytes: %w", err)
+	}
+	var raw map[string]any
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parse global config bytes: %w", err)
+	}
+	if raw == nil {
+		raw = map[string]any{}
+	}
+	// The candidate selects agent and model explicitly. Do not accidentally
+	// inherit a captured default model or agent list into a comparison.
+	delete(raw, "agent")
+	delete(raw, "agent_args_override")
+	out, err := yaml.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("serialize agent-neutral global config: %w", err)
+	}
+	return out, nil
+}
+
+func writeCase(ctx context.Context, store *Store, gateDir string, c Case, globalConfig, repoConfig []byte, run sourceRun, steps []sourceStep, rounds []sourceRound, invocations []sourceInvocation, selectedRound sourceRound, changedFiles []string) error {
+	tmp, err := os.MkdirTemp(store.cases, ".capture-")
+	if err != nil {
+		return fmt.Errorf("create temporary case: %w", err)
+	}
+	defer os.RemoveAll(tmp)
+	for _, dir := range []string{filepath.Join(tmp, "config"), filepath.Join(tmp, "original"), filepath.Join(tmp, "evals")} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	bundlePath := filepath.Join(tmp, "branch.bundle")
+	if err := createBundle(ctx, gateDir, bundlePath, c); err != nil {
+		return err
+	}
+	bundle, err := os.ReadFile(bundlePath)
+	if err != nil {
+		return err
+	}
+	digest := sha256.Sum256(bundle)
+	c.BundleSHA256 = hex.EncodeToString(digest[:])
+	if err := os.WriteFile(filepath.Join(tmp, "config", "global.yaml"), globalConfig, 0o644); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "config", "repo-config.yaml"), repoConfig, 0o644); err != nil {
+		return err
+	}
+	for _, item := range []struct {
+		path  string
+		value any
+	}{
+		{"manifest.json", c.Manifest},
+		{"labels.json", c.Labels},
+		{filepath.Join("original", "run.json"), run},
+		{filepath.Join("original", "steps.json"), steps},
+		{filepath.Join("original", "rounds.json"), rounds},
+		{filepath.Join("original", "round.json"), selectedRound},
+		{filepath.Join("original", "decision.json"), c.Decision},
+		{filepath.Join("original", "baseline.json"), c.Baseline},
+		{filepath.Join("original", "changed-files.json"), changedFiles},
+		{filepath.Join("original", "invocations.json"), invocations},
+	} {
+		if err := writeJSON(filepath.Join(tmp, item.path), item.value); err != nil {
+			return fmt.Errorf("write case %s: %w", item.path, err)
+		}
+	}
+	if err := os.Rename(tmp, c.Dir); err != nil {
+		return fmt.Errorf("publish captured case: %w", err)
+	}
+	return nil
+}
+
+func createBundle(ctx context.Context, gateDir, bundlePath string, c Case) error {
+	tmp, err := os.MkdirTemp("", "nm-eval-bundle-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmp)
+	clone := filepath.Join(tmp, "source.git")
+	cmd := exec.CommandContext(ctx, "git", "clone", "--bare", gateDir, clone)
+	shellenv.ConfigureShellCommand(cmd)
+	if err := shellenv.RunShellCommand(cmd); err != nil {
+		return fmt.Errorf("clone source gate for bundle: %w", err)
+	}
+	prefix := "refs/no-mistakes/eval/" + c.ID + "/"
+	refs := []struct {
+		name string
+		sha  string
+	}{
+		{"head", c.ReviewedHeadSHA},
+		{"source-head", c.HeadSHA},
+		{"base", c.BaseSHA},
+		{"trusted-config", c.TrustedConfigSHA},
+	}
+	bundleRefs := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		if _, err := git.Run(ctx, clone, "update-ref", prefix+ref.name, ref.sha); err != nil {
+			return fmt.Errorf("pin bundle %s: %w", ref.name, err)
+		}
+		bundleRefs = append(bundleRefs, prefix+ref.name)
+	}
+	if _, err := git.Run(ctx, clone, append([]string{"bundle", "create", bundlePath}, bundleRefs...)...); err != nil {
+		return fmt.Errorf("create review bundle: %w", err)
+	}
+	return nil
+}
+
+func sourceRunFor(run *db.Run) sourceRun {
+	out := sourceRun{ID: run.ID, Branch: run.Branch, HeadSHA: run.HeadSHA, BaseSHA: run.BaseSHA, Status: string(run.Status), CreatedAt: run.CreatedAt, UpdatedAt: run.UpdatedAt}
+	if run.Intent != nil {
+		out.Intent = *run.Intent
+	}
+	if run.IntentSource != nil {
+		out.IntentSource = *run.IntentSource
+	}
+	if run.NoMistakesVersion != nil {
+		out.NoMistakesVersion = *run.NoMistakesVersion
+	}
+	if run.NoMistakesBuildSHA != nil {
+		out.NoMistakesBuildSHA = *run.NoMistakesBuildSHA
+	}
+	return out
+}
+
+func sourceStepsFor(steps []*db.StepResult) []sourceStep {
+	out := make([]sourceStep, 0, len(steps))
+	for _, step := range steps {
+		item := sourceStep{ID: step.ID, Name: string(step.StepName), Status: string(step.Status), DurationMS: step.DurationMS}
+		if step.FindingsJSON != nil {
+			item.FindingsJSON = *step.FindingsJSON
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+func sourceInvocationsFor(invocations []db.AgentInvocation) []sourceInvocation {
+	out := make([]sourceInvocation, 0, len(invocations))
+	for _, inv := range invocations {
+		out = append(out, sourceInvocation{StepName: inv.StepName, Round: inv.Round, Purpose: inv.Purpose, Agent: inv.Agent, Model: inv.Model, DurationMS: inv.DurationMS, InputTokens: inv.InputTokens, OutputTokens: inv.OutputTokens, CacheReadTokens: inv.CacheReadTokens, FreshInputTokens: inv.FreshInputTokens, DeltaInputTokens: inv.DeltaInputTokens, DeltaOutputTokens: inv.DeltaOutputTokens, DeltaCacheReadTokens: inv.DeltaCacheReadTokens, ExitStatus: inv.ExitStatus, FailureCategory: inv.FailureCategory})
+	}
+	return out
+}
+
+func baselineForRound(invocations []db.AgentInvocation, round int) BaselineMetrics {
+	var baseline BaselineMetrics
+	seen := false
+	for _, inv := range invocations {
+		if inv.StepName != string(types.StepReview) || inv.Round != round {
+			continue
+		}
+		baseline.DurationMS += inv.DurationMS
+		if inv.DeltaInputTokens == nil || inv.DeltaOutputTokens == nil || inv.DeltaCacheReadTokens == nil || inv.FreshInputTokens == nil {
+			continue
+		}
+		seen = true
+		baseline.InputTokens += int64(*inv.DeltaInputTokens)
+		baseline.OutputTokens += int64(*inv.DeltaOutputTokens)
+		baseline.CacheReadTokens += int64(*inv.DeltaCacheReadTokens)
+		baseline.FreshInputTokens += int64(*inv.FreshInputTokens)
+	}
+	baseline.TokensReported = seen
+	return baseline
+}
+
+func decisionForRound(round *db.StepRound, step *db.StepResult) Decision {
+	decision := Decision{Action: "unknown"}
+	if round.SelectionSource != nil {
+		decision.SelectionSource = *round.SelectionSource
+	}
+	if round.SelectedFindingIDs != nil {
+		_ = json.Unmarshal([]byte(*round.SelectedFindingIDs), &decision.SelectedFindingIDs)
+	}
+	if round.UserFindingsJSON != nil && strings.TrimSpace(*round.UserFindingsJSON) != "" {
+		decision.HasUserFindings = true
+	}
+	if len(decision.SelectedFindingIDs) > 0 {
+		decision.Action = "fix"
+		return decision
+	}
+	if step == nil {
+		return decision
+	}
+	if step.Status == types.StepStatusSkipped {
+		decision.Action = "skip"
+		return decision
+	}
+	if step.Status == types.StepStatusFailed && step.Error != nil && strings.Contains(*step.Error, "aborted by user") {
+		decision.Action = "abort"
+		return decision
+	}
+	if round.FindingsJSON != nil {
+		findings, err := types.ParseFindingsJSON(*round.FindingsJSON)
+		if err == nil && types.HasAskUserFindings(findings) && step.Status == types.StepStatusCompleted {
+			decision.Action = "approve"
+		}
+	}
+	return decision
+}
+
+func verdictFromDecision(round *db.StepRound, decision Decision) VerdictLabel {
+	if decision.SelectionSource == db.RoundSelectionSourceUser && (len(decision.SelectedFindingIDs) > 0 || decision.HasUserFindings) {
+		return VerdictLabel{Known: true, ShouldPark: true, Source: "recorded-user-fix"}
+	}
+	if decision.Action == "approve" || decision.Action == "skip" {
+		return VerdictLabel{Known: true, ShouldPark: false, Source: "recorded-human-pass"}
+	}
+	return VerdictLabel{Source: "unlabeled"}
+}
+
+func fingerprint(rawURL string) string {
+	value := safeurl.Redact(rawURL)
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}
+
+func highestSeverity(raw *string) string {
+	if raw == nil {
+		return "none"
+	}
+	findings, err := types.ParseFindingsJSON(*raw)
+	if err != nil {
+		return "unknown"
+	}
+	rank := map[string]int{"none": 0, "info": 1, "warning": 2, "error": 3}
+	highest := "none"
+	for _, finding := range findings.Items {
+		if rank[finding.Severity] > rank[highest] {
+			highest = finding.Severity
+		}
+	}
+	return highest
+}

--- a/internal/eval/capture.go
+++ b/internal/eval/capture.go
@@ -146,20 +146,27 @@ func Capture(ctx context.Context, store *Store, p *paths.Paths, database *db.DB,
 	if err := git.ValidateBareRepository(ctx, gateDir); err != nil {
 		return nil, fmt.Errorf("source gate is unavailable for capture: %w", err)
 	}
-	trustedSHA, err := git.ResolveRef(ctx, gateDir, "refs/heads/"+repo.DefaultBranch)
+	trustedSHA, err := trustedConfigSHAAtReview(ctx, gateDir, repo.DefaultBranch, reviewRounds[0].CreatedAt)
 	if err != nil {
-		return nil, fmt.Errorf("resolve capture-time trusted configuration: %w", err)
+		return nil, err
 	}
-	trustedSHA = strings.TrimSpace(trustedSHA)
 	trustedConfig, err := repoConfigAt(ctx, gateDir, trustedSHA)
 	if err != nil {
-		return nil, fmt.Errorf("read capture-time trusted configuration at %s: %w", trustedSHA, err)
+		return nil, fmt.Errorf("read source trusted configuration at %s: %w", trustedSHA, err)
 	}
 	globalConfigBytes, err := os.ReadFile(p.ConfigFile())
 	if errors.Is(err, os.ErrNotExist) {
 		globalConfigBytes = []byte("{}\n")
 	} else if err != nil {
-		return nil, fmt.Errorf("read capture-time global configuration: %w", err)
+		return nil, fmt.Errorf("read source global configuration: %w", err)
+	} else {
+		info, statErr := os.Stat(p.ConfigFile())
+		if statErr != nil {
+			return nil, fmt.Errorf("stat source global configuration: %w", statErr)
+		}
+		if info.ModTime().Unix() > reviewRounds[0].CreatedAt {
+			return nil, fmt.Errorf("global configuration changed after the source review; its original configuration is unavailable")
+		}
 	}
 	globalConfig, err := agentNeutralGlobalConfig(globalConfigBytes)
 	if err != nil {
@@ -174,7 +181,7 @@ func Capture(ctx context.Context, store *Store, p *paths.Paths, database *db.DB,
 		return nil, err
 	}
 	captured := make([]Case, 0, len(reviewRounds))
-	for _, round := range reviewRounds {
+	for roundIndex, round := range reviewRounds {
 		if round.FindingsJSON == nil {
 			// A persisted round with no findings was an interrupted or legacy
 			// partial record, not a replayable review pass. Refuse rather than
@@ -189,6 +196,13 @@ func Capture(ctx context.Context, store *Store, p *paths.Paths, database *db.DB,
 		reviewedSHA := run.HeadSHA
 		if round.ReviewedHeadSHA != nil && strings.TrimSpace(*round.ReviewedHeadSHA) != "" {
 			reviewedSHA = strings.TrimSpace(*round.ReviewedHeadSHA)
+		}
+		startingSHA := reviewedSHA
+		if round.IsFixRound() {
+			if roundIndex == 0 || reviewRounds[roundIndex-1].ReviewedHeadSHA == nil || strings.TrimSpace(*reviewRounds[roundIndex-1].ReviewedHeadSHA) == "" {
+				return nil, fmt.Errorf("review fix round %q has no preceding reviewed head", round.ID)
+			}
+			startingSHA = strings.TrimSpace(*reviewRounds[roundIndex-1].ReviewedHeadSHA)
 		}
 		if _, err := git.ResolveRef(ctx, gateDir, reviewedSHA); err != nil {
 			return nil, fmt.Errorf("review round %q commit is unavailable for capture: %w", round.ID, err)
@@ -231,7 +245,7 @@ func Capture(ctx context.Context, store *Store, p *paths.Paths, database *db.DB,
 			Version: manifestVersion, ID: caseID, SourceRunID: run.ID, SourceRoundID: round.ID,
 			CapturedAt: time.Now().Unix(), RepoFingerprint: fingerprint(repo.UpstreamURL),
 			Branch: run.Branch, DefaultBranch: repo.DefaultBranch, BaseSHA: replayBaseSHA,
-			HeadSHA: run.HeadSHA, ReviewedHeadSHA: reviewedSHA, TrustedConfigSHA: trustedSHA,
+			HeadSHA: run.HeadSHA, StartingHeadSHA: startingSHA, ReviewedHeadSHA: reviewedSHA, TrustedConfigSHA: trustedSHA,
 			ChangedFiles: changedFiles, ChangedLines: changedLines,
 		}
 		if run.Intent != nil {
@@ -261,6 +275,19 @@ func Capture(ctx context.Context, store *Store, p *paths.Paths, database *db.DB,
 		captured = append(captured, c)
 	}
 	return captured, nil
+}
+
+func trustedConfigSHAAtReview(ctx context.Context, gateDir, defaultBranch string, reviewedAt int64) (string, error) {
+	ref := "refs/heads/" + defaultBranch
+	sha, err := git.Run(ctx, gateDir, "rev-list", "-1", "--first-parent", fmt.Sprintf("--before=@%d", reviewedAt), ref)
+	if err != nil {
+		return "", fmt.Errorf("resolve source trusted configuration: %w", err)
+	}
+	sha = strings.TrimSpace(sha)
+	if sha == "" {
+		return "", fmt.Errorf("source trusted configuration commit is unavailable at review time")
+	}
+	return sha, nil
 }
 
 // effectiveReplayBase reproduces ReviewStep's branch-scoped base: the merge

--- a/internal/eval/capture.go
+++ b/internal/eval/capture.go
@@ -153,7 +153,10 @@ func Capture(ctx context.Context, store *Store, p *paths.Paths, database *db.DB,
 	if err != nil {
 		return nil, fmt.Errorf("read source run trusted configuration at %s: %w", trustedSHA, err)
 	}
-	globalConfig, err := agentNeutralGlobalConfig(p.ConfigFile())
+	if run.GlobalConfigYAML == nil {
+		return nil, fmt.Errorf("run %q predates pinned global configuration capture", run.ID)
+	}
+	globalConfig, err := agentNeutralGlobalConfig([]byte(*run.GlobalConfigYAML))
 	if err != nil {
 		return nil, err
 	}
@@ -287,16 +290,9 @@ func repoConfigAt(ctx context.Context, gateDir, sha string) (*config.RepoConfig,
 	return config.LoadRepoFromBytes([]byte(content))
 }
 
-func agentNeutralGlobalConfig(path string) ([]byte, error) {
-	if _, err := config.LoadGlobal(path); err != nil {
-		return nil, fmt.Errorf("read global config for capture: %w", err)
-	}
-	data, err := os.ReadFile(path)
-	if errors.Is(err, os.ErrNotExist) {
-		return []byte("{}\n"), nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("read global config bytes: %w", err)
+func agentNeutralGlobalConfig(data []byte) ([]byte, error) {
+	if _, err := config.LoadGlobalFromBytes(data); err != nil {
+		return nil, fmt.Errorf("read pinned global config for capture: %w", err)
 	}
 	var raw map[string]any
 	if err := yaml.Unmarshal(data, &raw); err != nil {

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -67,7 +67,39 @@ func TestCaptureCreatesPortableReviewCaseWithoutRecordingRemoteURL(t *testing.T)
 	}
 }
 
-func TestCaptureUsesSourceRunsPinnedTrustedConfiguration(t *testing.T) {
+func TestCaptureRejectsReviewRoundBeforeGateDecision(t *testing.T) {
+	ctx := context.Background()
+	p, sourceDB, run, _, reviewRound := setupCapturedRun(t, ctx)
+	defer sourceDB.Close()
+	if err := sourceDB.SetStepRoundSelection(reviewRound.ID, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	steps, err := sourceDB.GetStepsByRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sourceDB.UpdateStepStatus(steps[0].ID, types.StepStatusAwaitingApproval); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := Open(p.EvalDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if _, err := Capture(ctx, store, p, sourceDB, run.ID); err == nil || !strings.Contains(err.Error(), "no recorded gate decision") {
+		t.Fatalf("capture error = %v, want missing gate decision", err)
+	}
+	cases, err := store.ListCases("all")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cases) != 0 {
+		t.Fatalf("premature capture registered %d cases", len(cases))
+	}
+}
+
+func TestCapturePinsConfigurationAtCapture(t *testing.T) {
 	ctx := context.Background()
 	p, sourceDB, run, _, _ := setupCapturedRun(t, ctx)
 	defer sourceDB.Close()
@@ -93,15 +125,9 @@ func TestCaptureUsesSourceRunsPinnedTrustedConfiguration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(cases) != 1 || cases[0].TrustedConfigSHA != *run.TrustedConfigSHA {
-		t.Fatalf("trusted config pin = %#v, want %s", cases, *run.TrustedConfigSHA)
-	}
-	repoConfig, err := os.ReadFile(filepath.Join(cases[0].Dir, "config", "repo-config.yaml"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if strings.Contains(string(repoConfig), "advanced-only") {
-		t.Fatalf("capture used advanced default-branch config: %s", repoConfig)
+	advancedSHA := mustGit(t, ctx, workDir, "rev-parse", "HEAD")
+	if len(cases) != 1 || cases[0].TrustedConfigSHA != advancedSHA {
+		t.Fatalf("trusted config pin = %#v, want capture-time SHA %s", cases, advancedSHA)
 	}
 }
 
@@ -121,10 +147,6 @@ func TestReplayRestoresCaseIntoAnIsolatedWorktree(t *testing.T) {
 	if err := os.WriteFile(p.ConfigFile(), []byte(globalConfig), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := sourceDB.UpdateRunStatusWithConfig(run.ID, run.Status, *run.TrustedConfigSHA, globalConfig); err != nil {
-		t.Fatal(err)
-	}
-	run.GlobalConfigYAML = &globalConfig
 	store, err := Open(p.EvalDir())
 	if err != nil {
 		t.Fatal(err)
@@ -172,6 +194,22 @@ func TestReportQueuesUnexpectedParksInsteadOfScoringThemWrong(t *testing.T) {
 	}
 	if got := summary.LowerBoundAccuracy(); got != 0.5 {
 		t.Fatalf("lower-bound accuracy = %v, want 0.5", got)
+	}
+}
+
+func TestFailedLabeledReplayCountsAgainstAccuracyAndFrontier(t *testing.T) {
+	summary := SummarizeEvaluations([]Evaluation{
+		{Candidate: "claude+test", Status: "completed", ExpectedPark: boolPtr(true), CandidateParked: true},
+		{Candidate: "claude+test", Status: "failed", ExpectedPark: boolPtr(true)},
+	})
+	if summary.Labeled != 2 || summary.Conclusive != 2 || summary.Correct != 1 || summary.Misses != 1 || summary.ConfirmedAccuracy() != 0.5 {
+		t.Fatalf("summary = %#v, want failed labeled replay scored conservatively", summary)
+	}
+	cost := 10.0
+	reports := []CandidateReport{{Cohort: "same", Summary: summary, AverageTokens: &cost}}
+	markFrontier(reports)
+	if reports[0].OnFrontier {
+		t.Fatal("candidate with failed replay was marked frontier-eligible")
 	}
 }
 
@@ -343,12 +381,6 @@ func setupCapturedRun(t *testing.T, ctx context.Context) (*paths.Paths, *db.DB, 
 	if err != nil {
 		t.Fatal(err)
 	}
-	globalConfig := "{}\n"
-	if err := database.UpdateRunStatusWithConfig(run.ID, run.Status, baseSHA, globalConfig); err != nil {
-		t.Fatal(err)
-	}
-	run.TrustedConfigSHA = &baseSHA
-	run.GlobalConfigYAML = &globalConfig
 	step, err := database.InsertStepResult(run.ID, types.StepReview)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -170,6 +170,47 @@ func TestReportQueuesUnexpectedParksInsteadOfScoringThemWrong(t *testing.T) {
 	}
 }
 
+func TestPersistEvaluationQueuesEveryUnexpectedCandidateFinding(t *testing.T) {
+	store, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	caseDir := store.caseDir("candidate-findings")
+	if err := os.MkdirAll(caseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	labels := Labels{Version: 1, Verdict: VerdictLabel{Known: true}}
+	if err := writeJSON(filepath.Join(caseDir, "labels.json"), labels); err != nil {
+		t.Fatal(err)
+	}
+	c := Case{Manifest: Manifest{ID: "candidate-findings", SourceRunID: "run", SourceRoundID: "round"}, Labels: labels, Dir: caseDir}
+	if err := store.registerCase(c); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.persistEvaluation(c, Evaluation{
+		ID:              "evaluation",
+		SessionID:       "session",
+		CaseID:          c.ID,
+		Candidate:       "claude+test",
+		Repeat:          1,
+		Status:          "completed",
+		ExpectedPark:    boolPtr(false),
+		CandidateParked: true,
+		FindingCount:    3,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := readJSON(filepath.Join(caseDir, "labels.json"), &labels); err != nil {
+		t.Fatal(err)
+	}
+	if labels.QueuedCandidateFindings != 3 {
+		t.Fatalf("queued candidate findings = %d, want 3", labels.QueuedCandidateFindings)
+	}
+}
+
 func TestConfidenceIntervalRequiresMultipleIndependentCases(t *testing.T) {
 	rows := []Evaluation{{CaseID: "only", Candidate: "claude+test", Status: "completed", ExpectedPark: boolPtr(true), CandidateParked: true}}
 	if got := confidenceInterval("claude+test", rows); got != nil {

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -216,6 +216,26 @@ func TestPersistEvaluationQueuesEveryUnexpectedCandidateFinding(t *testing.T) {
 	}
 }
 
+func TestBaselineForRoundDerivesFreshTokensFromPerRoundDeltas(t *testing.T) {
+	deltaInput, deltaOutput, deltaCache := 100, 20, 40
+	cumulativeFresh := 900
+	got := baselineForRound([]db.AgentInvocation{
+		{
+			StepName:             string(types.StepReview),
+			Round:                2,
+			DurationMS:           50,
+			FreshInputTokens:     &cumulativeFresh,
+			DeltaInputTokens:     &deltaInput,
+			DeltaOutputTokens:    &deltaOutput,
+			DeltaCacheReadTokens: &deltaCache,
+		},
+	}, 2)
+
+	if !got.TokensReported || got.InputTokens != 100 || got.OutputTokens != 20 || got.CacheReadTokens != 40 || got.FreshInputTokens != 60 {
+		t.Fatalf("baseline = %#v, want per-round token metrics", got)
+	}
+}
+
 func TestConfidenceIntervalRequiresMultipleIndependentCases(t *testing.T) {
 	rows := []Evaluation{{CaseID: "only", Candidate: "claude+test", Status: "completed", ExpectedPark: boolPtr(true), CandidateParked: true}}
 	if got := confidenceInterval("claude+test", rows); got != nil {
@@ -231,6 +251,19 @@ func TestConfidenceIntervalRepresentsUniformSampleUncertainty(t *testing.T) {
 	got := confidenceInterval("claude+test", rows)
 	if got == nil || got.Lower <= 0 || got.Lower >= 1 || got.Upper < 0.999 {
 		t.Fatalf("uniform-success confidence interval = %#v, want finite-sample uncertainty ending at 1", got)
+	}
+}
+
+func TestRenderReportNamesWilsonScoreInterval(t *testing.T) {
+	output := RenderReport([]CandidateReport{
+		{
+			Cohort:     "cohort",
+			Summary:    EvaluationSummary{Candidate: "claude+test", Total: 2, Labeled: 2, Conclusive: 2, Correct: 2},
+			Confidence: &Interval{Lower: 0.34, Upper: 1, Cases: 2},
+		},
+	})
+	if !strings.Contains(output, "95% Wilson score CI: 34.0%-100.0% over 2 case(s)") {
+		t.Fatalf("report confidence interval = %q", output)
 	}
 }
 

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -1,0 +1,220 @@
+package eval
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/git"
+	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+func TestCaptureCreatesPortableReviewCaseWithoutRecordingRemoteURL(t *testing.T) {
+	ctx := context.Background()
+	p, sourceDB, run, repo, reviewRound := setupCapturedRun(t, ctx)
+	defer sourceDB.Close()
+
+	store, err := Open(p.EvalDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	cases, err := Capture(ctx, store, p, sourceDB, run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cases) != 1 {
+		t.Fatalf("captured cases = %d, want 1", len(cases))
+	}
+	captured := cases[0]
+	if captured.SourceRunID != run.ID || captured.SourceRoundID != reviewRound.ID {
+		t.Fatalf("capture provenance = %#v, want run %q round %q", captured, run.ID, reviewRound.ID)
+	}
+	if !captured.Labels.Verdict.Known || !captured.Labels.Verdict.ShouldPark {
+		t.Fatalf("verdict label = %#v, want recorded user-fix park label", captured.Labels.Verdict)
+	}
+	if _, err := os.Stat(filepath.Join(captured.Dir, "branch.bundle")); err != nil {
+		t.Fatalf("case bundle missing: %v", err)
+	}
+
+	manifestBytes, err := os.ReadFile(filepath.Join(captured.Dir, "manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(manifestBytes), repo.UpstreamURL) || strings.Contains(string(manifestBytes), "secret-token") {
+		t.Fatalf("manifest leaked source remote credential: %s", manifestBytes)
+	}
+	var manifest Manifest
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	if manifest.TrustedConfigSHA == "" || manifest.ReviewedHeadSHA == "" {
+		t.Fatalf("manifest did not pin replay inputs: %#v", manifest)
+	}
+
+	listed, err := store.ListCases("all")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listed) != 1 || listed[0].ID != captured.ID {
+		t.Fatalf("registry cases = %#v, want captured case", listed)
+	}
+}
+
+func TestReplayRestoresCaseIntoAnIsolatedWorktree(t *testing.T) {
+	ctx := context.Background()
+	p, sourceDB, run, _, _ := setupCapturedRun(t, ctx)
+	defer sourceDB.Close()
+
+	fake := filepath.Join(t.TempDir(), "claude")
+	const reply = `{"type":"assistant","message":{"usage":{"input_tokens":12,"output_tokens":3},"content":[{"type":"text","text":"clean"}]}}
+{"type":"result","subtype":"success","is_error":false,"structured_output":{"findings":[],"risk_level":"low","risk_rationale":"clean","risk_scope":"source-or-external"},"usage":{"input_tokens":12,"output_tokens":3}}
+`
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\ncat >/dev/null\ncat <<'EOF'\n"+reply+"EOF\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p.ConfigFile(), []byte("agent_path_override:\n  claude: "+fake+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	store, err := Open(p.EvalDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if _, err := Capture(ctx, store, p, sourceDB, run.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	session, evaluations, err := Replay(ctx, store, ReplayOptions{Set: "all", Candidate: Candidate{Agent: types.AgentClaude, Model: "test"}, Repeats: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.ID == "" || len(evaluations) != 1 {
+		t.Fatalf("replay = session %#v evaluations %#v", session, evaluations)
+	}
+	got := evaluations[0]
+	if got.Status != "completed" || got.CandidateParked {
+		t.Fatalf("replay outcome = %#v, want completed non-parked review", got)
+	}
+	if !got.TokensReported || got.FreshInputTokens != 12 || got.OutputTokens != 3 {
+		t.Fatalf("replay metrics = %#v", got)
+	}
+	if strings.Contains(got.Error, p.Root()) {
+		t.Fatalf("replay error leaked production root: %q", got.Error)
+	}
+}
+
+func TestReportQueuesUnexpectedParksInsteadOfScoringThemWrong(t *testing.T) {
+	summary := SummarizeEvaluations([]Evaluation{
+		{CaseID: "must-park", Candidate: "claude+test", Status: "completed", ExpectedPark: boolPtr(true), CandidateParked: true},
+		{CaseID: "must-park", Candidate: "claude+test", Status: "completed", ExpectedPark: boolPtr(true), CandidateParked: false},
+		{CaseID: "human-passed", Candidate: "claude+test", Status: "completed", ExpectedPark: boolPtr(false), CandidateParked: true},
+		{CaseID: "human-passed", Candidate: "claude+test", Status: "completed", ExpectedPark: boolPtr(false), CandidateParked: false},
+	})
+
+	if summary.Conclusive != 3 || summary.Correct != 2 || summary.UnexpectedParks != 1 {
+		t.Fatalf("summary = %#v, want 3 conclusive, 2 correct, 1 queued unexpected park", summary)
+	}
+	if got := summary.ConfirmedAccuracy(); got != 2.0/3.0 {
+		t.Fatalf("confirmed accuracy = %v, want %v", got, 2.0/3.0)
+	}
+	if got := summary.LowerBoundAccuracy(); got != 0.5 {
+		t.Fatalf("lower-bound accuracy = %v, want 0.5", got)
+	}
+}
+
+func TestParseCandidateRequiresAgentAndModel(t *testing.T) {
+	for _, input := range []string{"claude", "+model", "claude+", "claude+model+extra"} {
+		if _, err := ParseCandidate(input); err == nil {
+			t.Errorf("ParseCandidate(%q) succeeded, want error", input)
+		}
+	}
+	candidate, err := ParseCandidate("codex+gpt-5.4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if candidate.Agent != types.AgentCodex || candidate.Model != "gpt-5.4" {
+		t.Fatalf("candidate = %#v", candidate)
+	}
+}
+
+func setupCapturedRun(t *testing.T, ctx context.Context) (*paths.Paths, *db.DB, *db.Run, *db.Repo, *db.StepRound) {
+	t.Helper()
+	root := t.TempDir()
+	p := paths.WithRoot(root)
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	database, err := db.Open(p.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gateDir := p.RepoDir("eval-repo")
+	if err := git.InitBare(ctx, gateDir); err != nil {
+		t.Fatal(err)
+	}
+	workDir := filepath.Join(root, "source")
+	mustGit(t, ctx, root, "clone", gateDir, workDir)
+	mustGit(t, ctx, workDir, "config", "user.email", "eval@example.test")
+	mustGit(t, ctx, workDir, "config", "user.name", "Eval Test")
+	if err := os.WriteFile(filepath.Join(workDir, ".no-mistakes.yaml"), []byte("review:\n  path_instructions:\n    - path: '*.go'\n      instructions: review error paths\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, "main.go"), []byte("package sample\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, ctx, workDir, "add", ".")
+	mustGit(t, ctx, workDir, "commit", "-m", "base")
+	mustGit(t, ctx, workDir, "branch", "-M", "main")
+	mustGit(t, ctx, workDir, "push", "origin", "main")
+	baseSHA := mustGit(t, ctx, workDir, "rev-parse", "HEAD")
+	mustGit(t, ctx, workDir, "checkout", "-b", "feature/eval")
+	if err := os.WriteFile(filepath.Join(workDir, "main.go"), []byte("package sample\n\nfunc Changed() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, ctx, workDir, "add", "main.go")
+	mustGit(t, ctx, workDir, "commit", "-m", "change")
+	mustGit(t, ctx, workDir, "push", "origin", "feature/eval")
+	headSHA := mustGit(t, ctx, workDir, "rev-parse", "HEAD")
+
+	repo, err := database.InsertRepoWithID("eval-repo", workDir, "https://secret-token@example.test/org/repo", "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := database.InsertRun(repo.ID, "feature/eval", headSHA, baseSHA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	step, err := database.InsertStepResult(run.ID, types.StepReview)
+	if err != nil {
+		t.Fatal(err)
+	}
+	findings := `{"findings":[{"id":"real-bug","severity":"error","file":"main.go","line":3,"description":"bug","action":"ask-user","review_scope":"source"}],"risk_level":"high","risk_rationale":"bug","risk_scope":"source-or-external"}`
+	reviewRound, err := database.InsertReviewStepRound(step.ID, 1, "initial", &findings, nil, headSHA, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	selected := `["real-bug"]`
+	if err := database.SetStepRoundSelection(reviewRound.ID, &selected, db.RoundSelectionSourceUser); err != nil {
+		t.Fatal(err)
+	}
+	return p, database, run, repo, reviewRound
+}
+
+func mustGit(t *testing.T, ctx context.Context, dir string, args ...string) string {
+	t.Helper()
+	out, err := git.Run(ctx, dir, args...)
+	if err != nil {
+		t.Fatalf("git %v: %v", args, err)
+	}
+	return out
+}
+
+func boolPtr(v bool) *bool { return &v }

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -211,6 +211,24 @@ func TestReplayRestoresCaseIntoAnIsolatedWorktree(t *testing.T) {
 	}
 }
 
+func TestBaselineForRoundIncludesOnlyCompleteReviewInvocationMetrics(t *testing.T) {
+	input, output, cache := 100, 20, 30
+	invocations := []db.AgentInvocation{
+		{StepName: string(types.StepReview), Round: 2, Purpose: "review-fix", DurationMS: 900, DeltaInputTokens: &input, DeltaOutputTokens: &output, DeltaCacheReadTokens: &cache},
+		{StepName: string(types.StepReview), Round: 2, Purpose: "review", DurationMS: 100, DeltaInputTokens: &input, DeltaOutputTokens: &output, DeltaCacheReadTokens: &cache},
+	}
+	baseline := baselineForRound(invocations, 2)
+	if baseline.DurationMS != 100 || !baseline.TokensReported || baseline.InputTokens != 100 || baseline.OutputTokens != 20 || baseline.CacheReadTokens != 30 || baseline.FreshInputTokens != 70 {
+		t.Fatalf("review baseline = %#v", baseline)
+	}
+
+	invocations = append(invocations, db.AgentInvocation{StepName: string(types.StepReview), Round: 2, Purpose: "review", DurationMS: 50})
+	baseline = baselineForRound(invocations, 2)
+	if baseline.DurationMS != 150 || baseline.TokensReported || baseline.InputTokens != 0 || baseline.OutputTokens != 0 || baseline.CacheReadTokens != 0 || baseline.FreshInputTokens != 0 {
+		t.Fatalf("incomplete review baseline = %#v", baseline)
+	}
+}
+
 func TestReportQueuesUnexpectedParksInsteadOfScoringThemWrong(t *testing.T) {
 	summary := SummarizeEvaluations([]Evaluation{
 		{CaseID: "must-park", Candidate: "claude+test", Status: "completed", ExpectedPark: boolPtr(true), CandidateParked: true},

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -172,11 +173,19 @@ func TestReplayRestoresCaseIntoAnIsolatedWorktree(t *testing.T) {
 	p, sourceDB, run, _, _ := setupCapturedRun(t, ctx)
 	defer sourceDB.Close()
 
-	fake := filepath.Join(t.TempDir(), "claude")
+	fakeDir := t.TempDir()
+	fake := filepath.Join(fakeDir, "claude")
 	const reply = `{"type":"assistant","message":{"usage":{"input_tokens":12,"output_tokens":3},"content":[{"type":"text","text":"clean"}]}}
 {"type":"result","subtype":"success","is_error":false,"structured_output":{"findings":[],"risk_level":"low","risk_rationale":"clean","risk_scope":"source-or-external"},"usage":{"input_tokens":12,"output_tokens":3}}
 `
-	if err := os.WriteFile(fake, []byte("#!/bin/sh\n[ \"$NM_HOME\" = \""+p.Root()+"\" ] && touch \""+p.Root()+"/shared-home-used\"\ncat >/dev/null\ncat <<'EOF'\n"+reply+"EOF\n"), 0o755); err != nil {
+	var script string
+	if runtime.GOOS == "windows" {
+		fake += ".cmd"
+		script = "@echo off\r\nmore >nul\r\necho " + strings.ReplaceAll(strings.TrimSpace(reply), "\n", "\r\necho ") + "\r\n"
+	} else {
+		script = "#!/bin/sh\n[ \"$NM_HOME\" = \"" + p.Root() + "\" ] && touch \"" + p.Root() + "/shared-home-used\"\ncat >/dev/null\ncat <<'EOF'\n" + reply + "EOF\n"
+	}
+	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", filepath.Dir(fake)+string(os.PathListSeparator)+os.Getenv("PATH"))

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -312,6 +312,7 @@ func TestBaselineForRoundDerivesFreshTokensFromPerRoundDeltas(t *testing.T) {
 		{
 			StepName:             string(types.StepReview),
 			Round:                2,
+			Purpose:              "review",
 			DurationMS:           50,
 			FreshInputTokens:     &cumulativeFresh,
 			DeltaInputTokens:     &deltaInput,

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -67,6 +67,44 @@ func TestCaptureCreatesPortableReviewCaseWithoutRecordingRemoteURL(t *testing.T)
 	}
 }
 
+func TestCaptureUsesSourceRunsPinnedTrustedConfiguration(t *testing.T) {
+	ctx := context.Background()
+	p, sourceDB, run, _, _ := setupCapturedRun(t, ctx)
+	defer sourceDB.Close()
+	gateDir := p.RepoDir(run.RepoID)
+	workDir := filepath.Join(p.Root(), "advance-main")
+	mustGit(t, ctx, p.Root(), "clone", gateDir, workDir)
+	mustGit(t, ctx, workDir, "config", "user.email", "eval@example.test")
+	mustGit(t, ctx, workDir, "config", "user.name", "Eval Test")
+	mustGit(t, ctx, workDir, "checkout", "main")
+	if err := os.WriteFile(filepath.Join(workDir, ".no-mistakes.yaml"), []byte("ignore_patterns: ['advanced-only']\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, ctx, workDir, "add", ".no-mistakes.yaml")
+	mustGit(t, ctx, workDir, "commit", "-m", "advance trusted config")
+	mustGit(t, ctx, workDir, "push", "origin", "main")
+
+	store, err := Open(p.EvalDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	cases, err := Capture(ctx, store, p, sourceDB, run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cases) != 1 || cases[0].TrustedConfigSHA != *run.TrustedConfigSHA {
+		t.Fatalf("trusted config pin = %#v, want %s", cases, *run.TrustedConfigSHA)
+	}
+	repoConfig, err := os.ReadFile(filepath.Join(cases[0].Dir, "config", "repo-config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(repoConfig), "advanced-only") {
+		t.Fatalf("capture used advanced default-branch config: %s", repoConfig)
+	}
+}
+
 func TestReplayRestoresCaseIntoAnIsolatedWorktree(t *testing.T) {
 	ctx := context.Background()
 	p, sourceDB, run, _, _ := setupCapturedRun(t, ctx)
@@ -76,7 +114,7 @@ func TestReplayRestoresCaseIntoAnIsolatedWorktree(t *testing.T) {
 	const reply = `{"type":"assistant","message":{"usage":{"input_tokens":12,"output_tokens":3},"content":[{"type":"text","text":"clean"}]}}
 {"type":"result","subtype":"success","is_error":false,"structured_output":{"findings":[],"risk_level":"low","risk_rationale":"clean","risk_scope":"source-or-external"},"usage":{"input_tokens":12,"output_tokens":3}}
 `
-	if err := os.WriteFile(fake, []byte("#!/bin/sh\ncat >/dev/null\ncat <<'EOF'\n"+reply+"EOF\n"), 0o755); err != nil {
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\n[ \"$NM_HOME\" = \""+p.Root()+"\" ] && touch \""+p.Root()+"/shared-home-used\"\ncat >/dev/null\ncat <<'EOF'\n"+reply+"EOF\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(p.ConfigFile(), []byte("agent_path_override:\n  claude: "+fake+"\n"), 0o644); err != nil {
@@ -108,6 +146,9 @@ func TestReplayRestoresCaseIntoAnIsolatedWorktree(t *testing.T) {
 	if strings.Contains(got.Error, p.Root()) {
 		t.Fatalf("replay error leaked production root: %q", got.Error)
 	}
+	if _, err := os.Stat(filepath.Join(p.Root(), "shared-home-used")); !os.IsNotExist(err) {
+		t.Fatalf("candidate used production NM_HOME: %v", err)
+	}
 }
 
 func TestReportQueuesUnexpectedParksInsteadOfScoringThemWrong(t *testing.T) {
@@ -129,8 +170,28 @@ func TestReportQueuesUnexpectedParksInsteadOfScoringThemWrong(t *testing.T) {
 	}
 }
 
+func TestConfidenceIntervalRequiresMultipleIndependentCases(t *testing.T) {
+	rows := []Evaluation{{CaseID: "only", Candidate: "claude+test", Status: "completed", ExpectedPark: boolPtr(true), CandidateParked: true}}
+	if got := confidenceInterval("claude+test", rows); got != nil {
+		t.Fatalf("single-case confidence interval = %#v, want unavailable", got)
+	}
+}
+
+func TestFrontierDoesNotCompareDifferentCohorts(t *testing.T) {
+	cheap := 10.0
+	expensive := 100.0
+	reports := []CandidateReport{
+		{Cohort: "a", Summary: EvaluationSummary{Labeled: 1, Correct: 1}, AverageTokens: &expensive},
+		{Cohort: "b", Summary: EvaluationSummary{Labeled: 1, Correct: 1}, AverageTokens: &cheap},
+	}
+	markFrontier(reports)
+	if !reports[0].OnFrontier || !reports[1].OnFrontier {
+		t.Fatalf("different cohorts dominated each other: %#v", reports)
+	}
+}
+
 func TestParseCandidateRequiresAgentAndModel(t *testing.T) {
-	for _, input := range []string{"claude", "+model", "claude+", "claude+model+extra"} {
+	for _, input := range []string{"claude", "+model", "claude+", "claude+model+extra", "cursor+model", "acp:custom+model"} {
 		if _, err := ParseCandidate(input); err == nil {
 			t.Errorf("ParseCandidate(%q) succeeded, want error", input)
 		}
@@ -192,6 +253,10 @@ func setupCapturedRun(t *testing.T, ctx context.Context) (*paths.Paths, *db.DB, 
 	if err != nil {
 		t.Fatal(err)
 	}
+	if err := database.UpdateRunTrustedConfigSHA(run.ID, baseSHA); err != nil {
+		t.Fatal(err)
+	}
+	run.TrustedConfigSHA = &baseSHA
 	step, err := database.InsertStepResult(run.ID, types.StepReview)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/git"
@@ -99,9 +100,9 @@ func TestCaptureRejectsReviewRoundBeforeGateDecision(t *testing.T) {
 	}
 }
 
-func TestCapturePinsConfigurationAtCapture(t *testing.T) {
+func TestCapturePinsConfigurationFromSourceReview(t *testing.T) {
 	ctx := context.Background()
-	p, sourceDB, run, _, _ := setupCapturedRun(t, ctx)
+	p, sourceDB, run, _, reviewRound := setupCapturedRun(t, ctx)
 	defer sourceDB.Close()
 	gateDir := p.RepoDir(run.RepoID)
 	workDir := filepath.Join(p.Root(), "advance-main")
@@ -113,6 +114,8 @@ func TestCapturePinsConfigurationAtCapture(t *testing.T) {
 		t.Fatal(err)
 	}
 	mustGit(t, ctx, workDir, "add", ".no-mistakes.yaml")
+	t.Setenv("GIT_AUTHOR_DATE", time.Unix(reviewRound.CreatedAt+60, 0).Format(time.RFC3339))
+	t.Setenv("GIT_COMMITTER_DATE", time.Unix(reviewRound.CreatedAt+60, 0).Format(time.RFC3339))
 	mustGit(t, ctx, workDir, "commit", "-m", "advance trusted config")
 	mustGit(t, ctx, workDir, "push", "origin", "main")
 
@@ -125,15 +128,48 @@ func TestCapturePinsConfigurationAtCapture(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	advancedSHA := mustGit(t, ctx, workDir, "rev-parse", "HEAD")
-	if len(cases) != 1 || cases[0].TrustedConfigSHA != advancedSHA {
-		t.Fatalf("trusted config pin = %#v, want capture-time SHA %s", cases, advancedSHA)
+	if len(cases) != 1 || cases[0].TrustedConfigSHA != run.BaseSHA {
+		t.Fatalf("trusted config pin = %#v, want source-review SHA %s", cases, run.BaseSHA)
+	}
+}
+
+func TestCapturePreservesFixRoundStartingHead(t *testing.T) {
+	ctx := context.Background()
+	p, sourceDB, run, repo, firstRound := setupCapturedRun(t, ctx)
+	defer sourceDB.Close()
+	if err := os.WriteFile(filepath.Join(repo.WorkingPath, "main.go"), []byte("package sample\n\nfunc Fixed() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, ctx, repo.WorkingPath, "add", "main.go")
+	mustGit(t, ctx, repo.WorkingPath, "commit", "-m", "fix review finding")
+	mustGit(t, ctx, repo.WorkingPath, "push", "origin", "feature/eval")
+	fixedSHA := mustGit(t, ctx, repo.WorkingPath, "rev-parse", "HEAD")
+	steps, err := sourceDB.GetStepsByRun(run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clean := `{"findings":[],"risk_level":"low","risk_rationale":"fixed","risk_scope":"source-or-external"}`
+	secondRound, err := sourceDB.InsertReviewStepRound(steps[0].ID, 2, "auto_fix", &clean, nil, fixedSHA, 25)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := Open(p.EvalDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	cases, err := Capture(ctx, store, p, sourceDB, run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cases) != 2 || cases[1].SourceRoundID != secondRound.ID || cases[1].StartingHeadSHA != stringValue(firstRound.ReviewedHeadSHA) || cases[1].ReviewedHeadSHA != fixedSHA {
+		t.Fatalf("captured fix-round provenance = %#v", cases)
 	}
 }
 
 func TestReplayRestoresCaseIntoAnIsolatedWorktree(t *testing.T) {
 	ctx := context.Background()
-	p, sourceDB, run, _, _ := setupCapturedRun(t, ctx)
+	p, sourceDB, run, _, reviewRound := setupCapturedRun(t, ctx)
 	defer sourceDB.Close()
 
 	fake := filepath.Join(t.TempDir(), "claude")
@@ -145,6 +181,10 @@ func TestReplayRestoresCaseIntoAnIsolatedWorktree(t *testing.T) {
 	}
 	globalConfig := "agent_path_override:\n  claude: " + fake + "\n"
 	if err := os.WriteFile(p.ConfigFile(), []byte(globalConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	configTime := time.Unix(reviewRound.CreatedAt-1, 0)
+	if err := os.Chtimes(p.ConfigFile(), configTime, configTime); err != nil {
 		t.Fatal(err)
 	}
 	store, err := Open(p.EvalDir())
@@ -289,6 +329,17 @@ func TestConfidenceIntervalRepresentsUniformSampleUncertainty(t *testing.T) {
 	got := confidenceInterval("claude+test", rows)
 	if got == nil || got.Lower <= 0 || got.Lower >= 1 || got.Upper < 0.999 {
 		t.Fatalf("uniform-success confidence interval = %#v, want finite-sample uncertainty ending at 1", got)
+	}
+}
+
+func TestConfidenceIntervalIncludesFailedLabeledReplays(t *testing.T) {
+	rows := []Evaluation{
+		{CaseID: "passed", Status: "completed", ExpectedPark: boolPtr(true), CandidateParked: true},
+		{CaseID: "failed", Status: "failed", ExpectedPark: boolPtr(true)},
+	}
+	got := confidenceInterval("claude+test", rows)
+	if got == nil || got.Cases != 2 || got.Lower >= 0.5 || got.Upper <= 0.5 {
+		t.Fatalf("confidence interval with scored failure = %#v, want interval around 50%% over two cases", got)
 	}
 }
 

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -117,9 +117,14 @@ func TestReplayRestoresCaseIntoAnIsolatedWorktree(t *testing.T) {
 	if err := os.WriteFile(fake, []byte("#!/bin/sh\n[ \"$NM_HOME\" = \""+p.Root()+"\" ] && touch \""+p.Root()+"/shared-home-used\"\ncat >/dev/null\ncat <<'EOF'\n"+reply+"EOF\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(p.ConfigFile(), []byte("agent_path_override:\n  claude: "+fake+"\n"), 0o644); err != nil {
+	globalConfig := "agent_path_override:\n  claude: " + fake + "\n"
+	if err := os.WriteFile(p.ConfigFile(), []byte(globalConfig), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := sourceDB.UpdateRunStatusWithConfig(run.ID, run.Status, *run.TrustedConfigSHA, globalConfig); err != nil {
+		t.Fatal(err)
+	}
+	run.GlobalConfigYAML = &globalConfig
 	store, err := Open(p.EvalDir())
 	if err != nil {
 		t.Fatal(err)
@@ -218,6 +223,17 @@ func TestConfidenceIntervalRequiresMultipleIndependentCases(t *testing.T) {
 	}
 }
 
+func TestConfidenceIntervalRepresentsUniformSampleUncertainty(t *testing.T) {
+	rows := []Evaluation{
+		{CaseID: "one", Status: "completed", ExpectedPark: boolPtr(true), CandidateParked: true},
+		{CaseID: "two", Status: "completed", ExpectedPark: boolPtr(true), CandidateParked: true},
+	}
+	got := confidenceInterval("claude+test", rows)
+	if got == nil || got.Lower <= 0 || got.Lower >= 1 || got.Upper < 0.999 {
+		t.Fatalf("uniform-success confidence interval = %#v, want finite-sample uncertainty ending at 1", got)
+	}
+}
+
 func TestFrontierDoesNotCompareDifferentCohorts(t *testing.T) {
 	cheap := 10.0
 	expensive := 100.0
@@ -294,10 +310,12 @@ func setupCapturedRun(t *testing.T, ctx context.Context) (*paths.Paths, *db.DB, 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := database.UpdateRunTrustedConfigSHA(run.ID, baseSHA); err != nil {
+	globalConfig := "{}\n"
+	if err := database.UpdateRunStatusWithConfig(run.ID, run.Status, baseSHA, globalConfig); err != nil {
 		t.Fatal(err)
 	}
 	run.TrustedConfigSHA = &baseSHA
+	run.GlobalConfigYAML = &globalConfig
 	step, err := database.InsertStepResult(run.ID, types.StepReview)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -149,7 +149,7 @@ func TestCapturePreservesFixRoundStartingHead(t *testing.T) {
 		t.Fatal(err)
 	}
 	clean := `{"findings":[],"risk_level":"low","risk_rationale":"fixed","risk_scope":"source-or-external"}`
-	secondRound, err := sourceDB.InsertReviewStepRound(steps[0].ID, 2, "auto_fix", &clean, nil, fixedSHA, 25)
+	secondRound, err := sourceDB.InsertReviewStepRoundWithProvenance(steps[0].ID, 2, "auto_fix", &clean, nil, fixedSHA, stringValue(firstRound.ReviewedHeadSHA), stringValue(firstRound.TrustedConfigSHA), firstRound.GlobalConfigYAML, firstRound.RepoConfigYAML, 25)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +169,7 @@ func TestCapturePreservesFixRoundStartingHead(t *testing.T) {
 
 func TestReplayRestoresCaseIntoAnIsolatedWorktree(t *testing.T) {
 	ctx := context.Background()
-	p, sourceDB, run, _, reviewRound := setupCapturedRun(t, ctx)
+	p, sourceDB, run, _, _ := setupCapturedRun(t, ctx)
 	defer sourceDB.Close()
 
 	fake := filepath.Join(t.TempDir(), "claude")
@@ -179,14 +179,7 @@ func TestReplayRestoresCaseIntoAnIsolatedWorktree(t *testing.T) {
 	if err := os.WriteFile(fake, []byte("#!/bin/sh\n[ \"$NM_HOME\" = \""+p.Root()+"\" ] && touch \""+p.Root()+"/shared-home-used\"\ncat >/dev/null\ncat <<'EOF'\n"+reply+"EOF\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	globalConfig := "agent_path_override:\n  claude: " + fake + "\n"
-	if err := os.WriteFile(p.ConfigFile(), []byte(globalConfig), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	configTime := time.Unix(reviewRound.CreatedAt-1, 0)
-	if err := os.Chtimes(p.ConfigFile(), configTime, configTime); err != nil {
-		t.Fatal(err)
-	}
+	t.Setenv("PATH", filepath.Dir(fake)+string(os.PathListSeparator)+os.Getenv("PATH"))
 	store, err := Open(p.EvalDir())
 	if err != nil {
 		t.Fatal(err)
@@ -356,6 +349,16 @@ func TestRenderReportNamesWilsonScoreInterval(t *testing.T) {
 	}
 }
 
+func TestAverageTokensRequiresCompleteReplayCoverage(t *testing.T) {
+	rows := []Evaluation{
+		{TokensReported: true, FreshInputTokens: 10, OutputTokens: 2},
+		{TokensReported: false},
+	}
+	if cost, ok := averageTokens(rows); ok {
+		t.Fatalf("partial token cost = %v, want unknown", cost)
+	}
+}
+
 func TestFrontierDoesNotCompareDifferentCohorts(t *testing.T) {
 	cheap := 10.0
 	expensive := 100.0
@@ -437,7 +440,11 @@ func setupCapturedRun(t *testing.T, ctx context.Context) (*paths.Paths, *db.DB, 
 		t.Fatal(err)
 	}
 	findings := `{"findings":[{"id":"real-bug","severity":"error","file":"main.go","line":3,"description":"bug","action":"ask-user","review_scope":"source"}],"risk_level":"high","risk_rationale":"bug","risk_scope":"source-or-external"}`
-	reviewRound, err := database.InsertReviewStepRound(step.ID, 1, "initial", &findings, nil, headSHA, 50)
+	repoConfigYAML, err := os.ReadFile(filepath.Join(workDir, ".no-mistakes.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	reviewRound, err := database.InsertReviewStepRoundWithProvenance(step.ID, 1, "initial", &findings, nil, headSHA, headSHA, baseSHA, []byte("{}\n"), repoConfigYAML, 50)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/eval/model.go
+++ b/internal/eval/model.go
@@ -40,7 +40,11 @@ func ParseCandidate(raw string) (Candidate, error) {
 	if agentName == "" || model == "" {
 		return Candidate{}, fmt.Errorf("candidate must include both an agent and model")
 	}
-	return Candidate{Agent: types.AgentName(agentName), Model: model}, nil
+	name := types.AgentName(agentName)
+	if _, ok := types.ACPTargetFor(name); ok {
+		return Candidate{}, fmt.Errorf("candidate agent %q cannot enforce an explicit model", name)
+	}
+	return Candidate{Agent: name, Model: model}, nil
 }
 
 // Manifest pins every input needed to recreate a review pass without storing a
@@ -121,6 +125,7 @@ type Evaluation struct {
 	SessionID        string `json:"session_id"`
 	CaseID           string `json:"case_id"`
 	Candidate        string `json:"candidate"`
+	Cohort           string `json:"cohort"`
 	Repeat           int    `json:"repeat"`
 	StartedAt        int64  `json:"started_at"`
 	CompletedAt      int64  `json:"completed_at"`

--- a/internal/eval/model.go
+++ b/internal/eval/model.go
@@ -198,6 +198,11 @@ func SummarizeEvaluations(evaluations []Evaluation) EvaluationSummary {
 		}
 		if evaluation.Status != "completed" {
 			summary.Failures++
+			if evaluation.ExpectedPark != nil {
+				summary.Labeled++
+				summary.Conclusive++
+				summary.Misses++
+			}
 			continue
 		}
 		if evaluation.ExpectedPark == nil {

--- a/internal/eval/model.go
+++ b/internal/eval/model.go
@@ -1,0 +1,217 @@
+// Package eval implements the opt-in, local-only review evaluation toolkit.
+//
+// It deliberately owns a separate registry under <NM_HOME>/eval. The normal
+// pipeline database, daemon, configuration, telemetry, and command output do
+// not observe or depend on this package.
+package eval
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+const (
+	manifestVersion = 1
+	labelsVersion   = 1
+)
+
+// Candidate identifies one agent and model combination under evaluation. The
+// canonical command-line spelling is agent+model, for example codex+gpt-5.4.
+type Candidate struct {
+	Agent types.AgentName `json:"agent"`
+	Model string          `json:"model"`
+}
+
+func (c Candidate) String() string { return string(c.Agent) + "+" + c.Model }
+
+// ParseCandidate accepts exactly agent+model. Keeping the model explicit makes
+// comparison records self-describing rather than silently inheriting a user's
+// current agent default.
+func ParseCandidate(raw string) (Candidate, error) {
+	value := strings.TrimSpace(raw)
+	if strings.Count(value, "+") != 1 {
+		return Candidate{}, fmt.Errorf("candidate must be agent+model (for example codex+gpt-5.4)")
+	}
+	agentName, model, _ := strings.Cut(value, "+")
+	agentName = strings.TrimSpace(agentName)
+	model = strings.TrimSpace(model)
+	if agentName == "" || model == "" {
+		return Candidate{}, fmt.Errorf("candidate must include both an agent and model")
+	}
+	return Candidate{Agent: types.AgentName(agentName), Model: model}, nil
+}
+
+// Manifest pins every input needed to recreate a review pass without storing a
+// remote URL. Case content stays local in the adjacent bundle and config files.
+type Manifest struct {
+	Version          int    `json:"version"`
+	ID               string `json:"id"`
+	SourceRunID      string `json:"source_run_id"`
+	SourceRoundID    string `json:"source_round_id"`
+	CapturedAt       int64  `json:"captured_at"`
+	RepoFingerprint  string `json:"repo_fingerprint"`
+	Branch           string `json:"branch"`
+	DefaultBranch    string `json:"default_branch"`
+	BaseSHA          string `json:"base_sha"`
+	HeadSHA          string `json:"head_sha"`
+	ReviewedHeadSHA  string `json:"reviewed_head_sha"`
+	TrustedConfigSHA string `json:"trusted_config_sha"`
+	Intent           string `json:"intent,omitempty"`
+	IntentSource     string `json:"intent_source,omitempty"`
+	VersionAtCapture string `json:"no_mistakes_version,omitempty"`
+	BuildSHA         string `json:"no_mistakes_build_sha,omitempty"`
+	ChangedFiles     int    `json:"changed_files"`
+	ChangedLines     int    `json:"changed_lines"`
+	BundleSHA256     string `json:"bundle_sha256"`
+}
+
+// Decision records the human gate evidence available for the exported review
+// pass. Approval actions were not persisted in historical rows, so Action can
+// be "unknown". The original selections themselves are never guessed.
+type Decision struct {
+	Action             string   `json:"action"`
+	SelectionSource    string   `json:"selection_source,omitempty"`
+	SelectedFindingIDs []string `json:"selected_finding_ids,omitempty"`
+	HasUserFindings    bool     `json:"has_user_findings"`
+}
+
+// VerdictLabel is intentionally only verdict-level in the MVP. Finding-level
+// valid/invalid labels and their adjudication UI belong to phase 1.
+type VerdictLabel struct {
+	Known      bool   `json:"known"`
+	ShouldPark bool   `json:"should_park"`
+	Source     string `json:"source,omitempty"`
+}
+
+// Labels is a local, growing label file. Queued candidate findings are kept as
+// evidence for a future adjudication pass, never scored as false positives.
+type Labels struct {
+	Version                 int          `json:"version"`
+	Verdict                 VerdictLabel `json:"verdict"`
+	QueuedCandidateFindings int          `json:"queued_candidate_findings"`
+}
+
+// BaselineMetrics is the recorded source-review performance baseline. A false
+// TokensReported means the adapter did not surface trustworthy token usage.
+type BaselineMetrics struct {
+	InputTokens      int64 `json:"input_tokens"`
+	OutputTokens     int64 `json:"output_tokens"`
+	CacheReadTokens  int64 `json:"cache_read_tokens"`
+	FreshInputTokens int64 `json:"fresh_input_tokens"`
+	DurationMS       int64 `json:"duration_ms"`
+	TokensReported   bool  `json:"tokens_reported"`
+}
+
+// Case is one frozen review pass. Dir is local bookkeeping and never enters a
+// manifest or report payload.
+type Case struct {
+	Manifest
+	Labels   Labels          `json:"labels"`
+	Decision Decision        `json:"decision"`
+	Baseline BaselineMetrics `json:"baseline"`
+	Dir      string          `json:"-"`
+}
+
+// Evaluation is one candidate replay over one case. Status is "completed" or
+// "failed"; failures remain visible in reports and are not silently scored.
+type Evaluation struct {
+	ID               string `json:"id"`
+	SessionID        string `json:"session_id"`
+	CaseID           string `json:"case_id"`
+	Candidate        string `json:"candidate"`
+	Repeat           int    `json:"repeat"`
+	StartedAt        int64  `json:"started_at"`
+	CompletedAt      int64  `json:"completed_at"`
+	Status           string `json:"status"`
+	Error            string `json:"error,omitempty"`
+	ExpectedPark     *bool  `json:"expected_park,omitempty"`
+	CandidateParked  bool   `json:"candidate_parked"`
+	FindingsJSON     string `json:"findings_json,omitempty"`
+	FindingCount     int    `json:"finding_count"`
+	InputTokens      int64  `json:"input_tokens"`
+	OutputTokens     int64  `json:"output_tokens"`
+	CacheReadTokens  int64  `json:"cache_read_tokens"`
+	FreshInputTokens int64  `json:"fresh_input_tokens"`
+	TokensReported   bool   `json:"tokens_reported"`
+	DurationMS       int64  `json:"duration_ms"`
+	Model            string `json:"model,omitempty"`
+}
+
+// EvaluationSummary is deliberately three-valued for a human-pass label:
+// an unexpected candidate park is queued rather than declared wrong before
+// finding-level adjudication exists.
+type EvaluationSummary struct {
+	Candidate        string
+	Total            int
+	Labeled          int
+	Conclusive       int
+	Correct          int
+	Misses           int
+	UnexpectedParks  int
+	Failures         int
+	InputTokens      int64
+	OutputTokens     int64
+	FreshInputTokens int64
+	TokensReported   int
+	DurationMS       int64
+}
+
+func (s EvaluationSummary) ConfirmedAccuracy() float64 {
+	if s.Conclusive == 0 {
+		return 0
+	}
+	return float64(s.Correct) / float64(s.Conclusive)
+}
+
+// LowerBoundAccuracy counts a queued unexpected park in the denominator but
+// not the numerator. It is the conservative number suitable for comparing
+// candidates before phase-1 finding adjudication is available.
+func (s EvaluationSummary) LowerBoundAccuracy() float64 {
+	if s.Labeled == 0 {
+		return 0
+	}
+	return float64(s.Correct) / float64(s.Labeled)
+}
+
+// SummarizeEvaluations applies the MVP verdict policy without inferring that a
+// new finding is invalid merely because the original human passed the run.
+func SummarizeEvaluations(evaluations []Evaluation) EvaluationSummary {
+	var summary EvaluationSummary
+	for _, evaluation := range evaluations {
+		if summary.Candidate == "" {
+			summary.Candidate = evaluation.Candidate
+		}
+		summary.Total++
+		summary.InputTokens += evaluation.InputTokens
+		summary.OutputTokens += evaluation.OutputTokens
+		summary.FreshInputTokens += evaluation.FreshInputTokens
+		summary.DurationMS += evaluation.DurationMS
+		if evaluation.TokensReported {
+			summary.TokensReported++
+		}
+		if evaluation.Status != "completed" {
+			summary.Failures++
+			continue
+		}
+		if evaluation.ExpectedPark == nil {
+			continue
+		}
+		summary.Labeled++
+		switch {
+		case *evaluation.ExpectedPark && evaluation.CandidateParked:
+			summary.Conclusive++
+			summary.Correct++
+		case *evaluation.ExpectedPark && !evaluation.CandidateParked:
+			summary.Conclusive++
+			summary.Misses++
+		case !*evaluation.ExpectedPark && !evaluation.CandidateParked:
+			summary.Conclusive++
+			summary.Correct++
+		case !*evaluation.ExpectedPark && evaluation.CandidateParked:
+			summary.UnexpectedParks++
+		}
+	}
+	return summary
+}

--- a/internal/eval/model.go
+++ b/internal/eval/model.go
@@ -60,6 +60,7 @@ type Manifest struct {
 	DefaultBranch    string `json:"default_branch"`
 	BaseSHA          string `json:"base_sha"`
 	HeadSHA          string `json:"head_sha"`
+	StartingHeadSHA  string `json:"starting_head_sha"`
 	ReviewedHeadSHA  string `json:"reviewed_head_sha"`
 	TrustedConfigSHA string `json:"trusted_config_sha"`
 	Intent           string `json:"intent,omitempty"`

--- a/internal/eval/replay.go
+++ b/internal/eval/replay.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/agent"
 	"github.com/kunchenguid/no-mistakes/internal/config"
 	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/e2edaemon"
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
@@ -126,6 +127,19 @@ func replayOne(ctx context.Context, c Case, session Session, candidate Candidate
 		evaluation.CompletedAt = time.Now().Unix()
 		return evaluation
 	}
+	isolatedHome := filepath.Join(root, "home")
+	if err := os.MkdirAll(isolatedHome, 0o755); err != nil {
+		evaluation.Error = safeurl.RedactText(fmt.Sprintf("create isolated eval home: %v", err))
+		evaluation.CompletedAt = time.Now().Unix()
+		return evaluation
+	}
+	ownership, err := e2edaemon.Acquire(isolatedPaths.Root(), "", 2*time.Minute)
+	if err != nil {
+		evaluation.Error = safeurl.RedactText(fmt.Sprintf("acquire isolated eval ownership: %v", err))
+		evaluation.CompletedAt = time.Now().Unix()
+		return evaluation
+	}
+	defer ownership.Release()
 
 	workDir, err := restoreCase(ctx, c, root)
 	if err != nil {
@@ -172,7 +186,7 @@ func replayOne(ctx context.Context, c Case, session Session, candidate Candidate
 	if startingHeadSHA == "" {
 		startingHeadSHA = c.ReviewedHeadSHA
 	}
-	replayRun := &db.Run{ID: "eval-" + evaluation.ID, Branch: c.Branch, HeadSHA: startingHeadSHA, BaseSHA: c.BaseSHA}
+	replayRun := &db.Run{ID: "eval-" + evaluation.ID, Branch: c.Branch, HeadSHA: c.ReviewedHeadSHA, BaseSHA: c.BaseSHA}
 	if c.Intent != "" {
 		intent := c.Intent
 		replayRun.Intent = &intent
@@ -188,23 +202,24 @@ func replayOne(ctx context.Context, c Case, session Session, candidate Candidate
 	replayRepo := &db.Repo{ID: "eval", WorkingPath: workDir, DefaultBranch: defaultBranch}
 	step := &steps.ReviewStep{}
 	outcome, err := step.Execute(&pipeline.StepContext{
-		Ctx:              ctx,
-		Run:              replayRun,
-		Repo:             replayRepo,
-		WorkDir:          workDir,
-		Agent:            observed,
-		Config:           cfg,
-		DB:               replayDB,
-		StepResultID:     stepResultID,
-		Fixing:           fixing,
-		SkipFixExecution: fixing,
-		PreviousFindings: previousFindings,
-		Env:              []string{"NM_HOME=" + isolatedPaths.Root()},
-		Log:              func(string) {},
-		LogChunk:         func(string) {},
-		LogFile:          func(string) {},
-		UserIntent:       c.Intent,
-		IntentSource:     c.IntentSource,
+		Ctx:                   ctx,
+		Run:                   replayRun,
+		Repo:                  replayRepo,
+		WorkDir:               workDir,
+		Agent:                 observed,
+		Config:                cfg,
+		DB:                    replayDB,
+		StepResultID:          stepResultID,
+		Fixing:                fixing,
+		SkipFixExecution:      fixing,
+		ReviewStartingHeadSHA: startingHeadSHA,
+		PreviousFindings:      previousFindings,
+		Env:                   []string{"NM_HOME=" + isolatedPaths.Root(), "HOME=" + isolatedHome},
+		Log:                   func(string) {},
+		LogChunk:              func(string) {},
+		LogFile:               func(string) {},
+		UserIntent:            c.Intent,
+		IntentSource:          c.IntentSource,
 	})
 	// Candidate wall time is the actual review invocation, matching the local
 	// agent-invocation metric rather than charging bundle restoration setup.

--- a/internal/eval/replay.go
+++ b/internal/eval/replay.go
@@ -168,7 +168,11 @@ func replayOne(ctx context.Context, c Case, session Session, candidate Candidate
 	}
 	defer replayDB.Close()
 
-	replayRun := &db.Run{ID: "eval-" + evaluation.ID, Branch: c.Branch, HeadSHA: c.ReviewedHeadSHA, BaseSHA: c.BaseSHA}
+	startingHeadSHA := c.StartingHeadSHA
+	if startingHeadSHA == "" {
+		startingHeadSHA = c.ReviewedHeadSHA
+	}
+	replayRun := &db.Run{ID: "eval-" + evaluation.ID, Branch: c.Branch, HeadSHA: startingHeadSHA, BaseSHA: c.BaseSHA}
 	if c.Intent != "" {
 		intent := c.Intent
 		replayRun.Intent = &intent

--- a/internal/eval/replay.go
+++ b/internal/eval/replay.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
@@ -172,7 +173,7 @@ func replayOne(ctx context.Context, c Case, session Session, candidate Candidate
 		return evaluation
 	}
 	defer baseAgent.Close()
-	observed := &observedAgent{inner: agent.WithSteering(baseAgent)}
+	observed := &observedAgent{inner: agent.WithSteering(baseAgent), ownership: ownership}
 
 	replayDB, stepResultID, fixing, previousFindings, err := replayRoundContext(isolatedPaths, c, workDir)
 	if err != nil {
@@ -383,18 +384,42 @@ func candidateModelArgs(candidate Candidate) ([]string, error) {
 }
 
 type observedAgent struct {
-	inner      agent.Agent
-	result     *agent.Result
-	durationMS int64
+	inner        agent.Agent
+	ownership    *e2edaemon.Ownership
+	result       *agent.Result
+	durationMS   int64
+	ownershipErr error
+	mu           sync.Mutex
 }
 
 func (a *observedAgent) Name() string { return a.inner.Name() }
 func (a *observedAgent) Close() error { return a.inner.Close() }
 func (a *observedAgent) Run(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+	previousLifecycle := opts.OnLifecycle
+	opts.OnLifecycle = func(event agent.LifecycleEvent) {
+		if event.Phase == "start" && event.PID > 0 {
+			if syncErr := a.ownership.SyncProcess(event.PID); syncErr != nil {
+				a.mu.Lock()
+				if a.ownershipErr == nil {
+					a.ownershipErr = syncErr
+				}
+				a.mu.Unlock()
+			}
+		}
+		if previousLifecycle != nil {
+			previousLifecycle(event)
+		}
+	}
 	started := time.Now()
 	result, err := a.inner.Run(ctx, opts)
 	a.durationMS += time.Since(started).Milliseconds()
 	a.result = result
+	a.mu.Lock()
+	ownershipErr := a.ownershipErr
+	a.mu.Unlock()
+	if ownershipErr != nil {
+		return result, ownershipErr
+	}
 	return result, err
 }
 

--- a/internal/eval/replay.go
+++ b/internal/eval/replay.go
@@ -3,10 +3,12 @@ package eval
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -36,6 +38,7 @@ type Session struct {
 	Candidate string    `json:"candidate"`
 	Repeats   int       `json:"repeats"`
 	CaseIDs   []string  `json:"case_ids"`
+	Cohort    string    `json:"cohort"`
 }
 
 // Replay runs exactly the captured review pass. It does not start a daemon or
@@ -56,10 +59,14 @@ func Replay(ctx context.Context, store *Store, opts ReplayOptions) (Session, []E
 	if len(cases) == 0 {
 		return Session{}, nil, fmt.Errorf("case set %q is empty", opts.Set)
 	}
+	if _, err := candidateModelArgs(opts.Candidate); err != nil {
+		return Session{}, nil, err
+	}
 	session := Session{ID: newSessionID(), StartedAt: time.Now().UTC(), Set: opts.Set, Candidate: opts.Candidate.String(), Repeats: opts.Repeats}
 	for _, c := range cases {
 		session.CaseIDs = append(session.CaseIDs, c.ID)
 	}
+	session.Cohort = cohortID(session.CaseIDs, session.Repeats)
 	sessionsDir := filepath.Join(store.root, "sessions")
 	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
 		return Session{}, nil, fmt.Errorf("create eval sessions directory: %w", err)
@@ -95,6 +102,7 @@ func replayOne(ctx context.Context, c Case, session Session, candidate Candidate
 		SessionID: session.ID,
 		CaseID:    c.ID,
 		Candidate: candidate.String(),
+		Cohort:    session.Cohort,
 		Repeat:    repeat,
 		StartedAt: started.Unix(),
 		Status:    "failed",
@@ -112,6 +120,13 @@ func replayOne(ctx context.Context, c Case, session Session, candidate Candidate
 	}
 	defer os.RemoveAll(root)
 
+	isolatedPaths := paths.WithRoot(filepath.Join(root, "nmhome"))
+	if err := isolatedPaths.EnsureDirs(); err != nil {
+		evaluation.Error = safeurl.RedactText(fmt.Sprintf("create isolated eval state: %v", err))
+		evaluation.CompletedAt = time.Now().Unix()
+		return evaluation
+	}
+
 	workDir, err := restoreCase(ctx, c, root)
 	if err != nil {
 		evaluation.Error = safeurl.RedactText(err.Error())
@@ -127,7 +142,13 @@ func replayOne(ctx context.Context, c Case, session Session, candidate Candidate
 	cfg.Agent = candidate.Agent
 	cfg.Agents = []types.AgentName{candidate.Agent}
 
-	baseAgent, err := agent.NewWithOptions(candidate.Agent, cfg.AgentPathFor(candidate.Agent), candidateModelArgs(candidate), agent.Options{
+	modelArgs, err := candidateModelArgs(candidate)
+	if err != nil {
+		evaluation.Error = safeurl.RedactText(err.Error())
+		evaluation.CompletedAt = time.Now().Unix()
+		return evaluation
+	}
+	baseAgent, err := agent.NewWithOptions(candidate.Agent, cfg.AgentPathFor(candidate.Agent), modelArgs, agent.Options{
 		ACPRegistryOverrides:   cfg.ACPRegistryOverrides,
 		DisableProjectSettings: cfg.DisableProjectSettings,
 	})
@@ -138,6 +159,14 @@ func replayOne(ctx context.Context, c Case, session Session, candidate Candidate
 	}
 	defer baseAgent.Close()
 	observed := &observedAgent{inner: agent.WithSteering(baseAgent)}
+
+	replayDB, stepResultID, fixing, previousFindings, err := replayRoundContext(isolatedPaths, c, workDir)
+	if err != nil {
+		evaluation.Error = safeurl.RedactText(err.Error())
+		evaluation.CompletedAt = time.Now().Unix()
+		return evaluation
+	}
+	defer replayDB.Close()
 
 	replayRun := &db.Run{ID: "eval-" + evaluation.ID, Branch: c.Branch, HeadSHA: c.ReviewedHeadSHA, BaseSHA: c.BaseSHA}
 	if c.Intent != "" {
@@ -155,17 +184,23 @@ func replayOne(ctx context.Context, c Case, session Session, candidate Candidate
 	replayRepo := &db.Repo{ID: "eval", WorkingPath: workDir, DefaultBranch: defaultBranch}
 	step := &steps.ReviewStep{}
 	outcome, err := step.Execute(&pipeline.StepContext{
-		Ctx:          ctx,
-		Run:          replayRun,
-		Repo:         replayRepo,
-		WorkDir:      workDir,
-		Agent:        observed,
-		Config:       cfg,
-		Log:          func(string) {},
-		LogChunk:     func(string) {},
-		LogFile:      func(string) {},
-		UserIntent:   c.Intent,
-		IntentSource: c.IntentSource,
+		Ctx:              ctx,
+		Run:              replayRun,
+		Repo:             replayRepo,
+		WorkDir:          workDir,
+		Agent:            observed,
+		Config:           cfg,
+		DB:               replayDB,
+		StepResultID:     stepResultID,
+		Fixing:           fixing,
+		SkipFixExecution: fixing,
+		PreviousFindings: previousFindings,
+		Env:              []string{"NM_HOME=" + isolatedPaths.Root()},
+		Log:              func(string) {},
+		LogChunk:         func(string) {},
+		LogFile:          func(string) {},
+		UserIntent:       c.Intent,
+		IntentSource:     c.IntentSource,
 	})
 	// Candidate wall time is the actual review invocation, matching the local
 	// agent-invocation metric rather than charging bundle restoration setup.
@@ -178,6 +213,9 @@ func replayOne(ctx context.Context, c Case, session Session, candidate Candidate
 		evaluation.Model = observed.result.Model
 		if evaluation.Model == "" {
 			evaluation.Model = candidate.Model
+		} else if evaluation.Model != candidate.Model {
+			evaluation.Error = safeurl.RedactText(fmt.Sprintf("candidate served model %q, requested %q", evaluation.Model, candidate.Model))
+			return evaluation
 		}
 		if observed.result.UsageReported {
 			evaluation.TokensReported = true
@@ -202,15 +240,80 @@ func replayOne(ctx context.Context, c Case, session Session, candidate Candidate
 	return evaluation
 }
 
-func restoreCase(ctx context.Context, c Case, root string) (string, error) {
-	// The temp Paths root is intentionally created even though this MVP invokes
-	// ReviewStep directly. It documents and enforces the same isolated-root
-	// boundary used by the e2e daemon harness, while never setting process-wide
-	// NM_HOME or touching the shared daemon.
-	p := paths.WithRoot(filepath.Join(root, "nmhome"))
-	if err := p.EnsureDirs(); err != nil {
-		return "", fmt.Errorf("create isolated eval state: %w", err)
+func replayRoundContext(p *paths.Paths, c Case, workDir string) (*db.DB, string, bool, string, error) {
+	var selected sourceRound
+	if err := readJSON(filepath.Join(c.Dir, "original", "round.json"), &selected); err != nil {
+		return nil, "", false, "", fmt.Errorf("read captured review round: %w", err)
 	}
+	var rounds []sourceRound
+	if err := readJSON(filepath.Join(c.Dir, "original", "rounds.json"), &rounds); err != nil {
+		return nil, "", false, "", fmt.Errorf("read captured round history: %w", err)
+	}
+	database, err := db.Open(p.DB())
+	if err != nil {
+		return nil, "", false, "", fmt.Errorf("open isolated replay database: %w", err)
+	}
+	fail := func(err error) (*db.DB, string, bool, string, error) {
+		database.Close()
+		return nil, "", false, "", err
+	}
+	repo, err := database.InsertRepoWithID("eval-repo", workDir, "local://eval", c.DefaultBranch)
+	if err != nil {
+		return fail(fmt.Errorf("create isolated replay repository: %w", err))
+	}
+	run, err := database.InsertRun(repo.ID, c.Branch, c.ReviewedHeadSHA, c.BaseSHA)
+	if err != nil {
+		return fail(fmt.Errorf("create isolated replay run: %w", err))
+	}
+	step, err := database.InsertStepResult(run.ID, types.StepReview)
+	if err != nil {
+		return fail(fmt.Errorf("create isolated replay step: %w", err))
+	}
+	var previousFindings string
+	for _, round := range rounds {
+		if round.StepName != "" && round.StepName != string(types.StepReview) {
+			continue
+		}
+		if round.Round >= selected.Round {
+			continue
+		}
+		inserted, err := database.InsertReviewStepRound(step.ID, round.Round, round.Trigger, round.FindingsJSON, round.FixSummary, stringValue(round.ReviewedHeadSHA), round.DurationMS)
+		if err != nil {
+			return fail(fmt.Errorf("restore captured review history: %w", err))
+		}
+		if round.UserFindingsJSON != nil {
+			if err := database.SetStepRoundUserFindings(inserted.ID, round.UserFindingsJSON); err != nil {
+				return fail(fmt.Errorf("restore captured user findings: %w", err))
+			}
+		}
+		if round.SelectedFindingIDs != nil {
+			source := stringValue(round.SelectionSource)
+			if err := database.SetStepRoundSelection(inserted.ID, round.SelectedFindingIDs, source); err != nil {
+				return fail(fmt.Errorf("restore captured gate decision: %w", err))
+			}
+		}
+		if round.Round == selected.Round-1 {
+			previousFindings = stringValue(round.UserFindingsJSON)
+			if previousFindings == "" {
+				previousFindings = stringValue(round.FindingsJSON)
+			}
+		}
+	}
+	fixing := selected.Trigger == "auto_fix" || selected.Trigger == "user_fix"
+	if fixing && previousFindings == "" {
+		return fail(fmt.Errorf("captured fix round %d has no previous findings", selected.Round))
+	}
+	return database, step.ID, fixing, previousFindings, nil
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func restoreCase(ctx context.Context, c Case, root string) (string, error) {
 	gateDir := filepath.Join(root, "gate.git")
 	if err := git.InitBare(ctx, gateDir); err != nil {
 		return "", fmt.Errorf("create isolated eval gate: %w", err)
@@ -250,11 +353,14 @@ func replayConfig(c Case) (*config.Config, error) {
 	return config.Merge(global, repo), nil
 }
 
-func candidateModelArgs(candidate Candidate) []string {
-	if candidate.Agent == types.AgentCodex {
-		return []string{"-m", candidate.Model}
+func candidateModelArgs(candidate Candidate) ([]string, error) {
+	if _, ok := types.ACPTargetFor(candidate.Agent); ok {
+		return nil, fmt.Errorf("candidate agent %q cannot enforce an explicit model", candidate.Agent)
 	}
-	return []string{"--model", candidate.Model}
+	if candidate.Agent == types.AgentCodex {
+		return []string{"-m", candidate.Model}, nil
+	}
+	return []string{"--model", candidate.Model}, nil
 }
 
 type observedAgent struct {
@@ -357,6 +463,13 @@ func candidatePathPart(candidate string) string {
 		return "candidate"
 	}
 	return b.String()
+}
+
+func cohortID(caseIDs []string, repeats int) string {
+	ids := append([]string(nil), caseIDs...)
+	sort.Strings(ids)
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%d\x00%s", repeats, strings.Join(ids, "\x00"))))
+	return hex.EncodeToString(sum[:8])
 }
 
 func newSessionID() string {

--- a/internal/eval/replay.go
+++ b/internal/eval/replay.go
@@ -431,19 +431,22 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		return fmt.Errorf("record eval result: %w", err)
 	}
 	if evaluation.Status == "completed" && evaluation.ExpectedPark != nil && !*evaluation.ExpectedPark && evaluation.CandidateParked {
-		if err := incrementQueuedFindings(c.Dir); err != nil {
+		if err := incrementQueuedFindings(c.Dir, evaluation.FindingCount); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func incrementQueuedFindings(caseDir string) error {
+func incrementQueuedFindings(caseDir string, count int) error {
+	if count <= 0 {
+		return nil
+	}
 	var labels Labels
 	if err := readJSON(filepath.Join(caseDir, "labels.json"), &labels); err != nil {
 		return fmt.Errorf("read local labels queue: %w", err)
 	}
-	labels.QueuedCandidateFindings++
+	labels.QueuedCandidateFindings += count
 	if err := writeJSON(filepath.Join(caseDir, "labels.json"), labels); err != nil {
 		return fmt.Errorf("update local labels queue: %w", err)
 	}

--- a/internal/eval/replay.go
+++ b/internal/eval/replay.go
@@ -1,0 +1,368 @@
+package eval
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/agent"
+	"github.com/kunchenguid/no-mistakes/internal/config"
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/git"
+	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/pipeline"
+	"github.com/kunchenguid/no-mistakes/internal/pipeline/steps"
+	"github.com/kunchenguid/no-mistakes/internal/safeurl"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// ReplayOptions controls one isolated candidate comparison.
+type ReplayOptions struct {
+	Set       string
+	Candidate Candidate
+	Repeats   int
+}
+
+// Session records the immutable local plan used for one replay batch.
+type Session struct {
+	ID        string    `json:"id"`
+	StartedAt time.Time `json:"started_at"`
+	Set       string    `json:"set"`
+	Candidate string    `json:"candidate"`
+	Repeats   int       `json:"repeats"`
+	CaseIDs   []string  `json:"case_ids"`
+}
+
+// Replay runs exactly the captured review pass. It does not start a daemon or
+// use the production NM_HOME: every case is restored into a fresh temp gate and
+// worktree. Push, PR, CI, and all fix loops are intentionally absent from the
+// MVP subject under test.
+func Replay(ctx context.Context, store *Store, opts ReplayOptions) (Session, []Evaluation, error) {
+	if store == nil {
+		return Session{}, nil, fmt.Errorf("eval replay requires a store")
+	}
+	if opts.Repeats <= 0 {
+		return Session{}, nil, fmt.Errorf("repeats must be at least 1")
+	}
+	cases, err := store.ListCases(opts.Set)
+	if err != nil {
+		return Session{}, nil, err
+	}
+	if len(cases) == 0 {
+		return Session{}, nil, fmt.Errorf("case set %q is empty", opts.Set)
+	}
+	session := Session{ID: newSessionID(), StartedAt: time.Now().UTC(), Set: opts.Set, Candidate: opts.Candidate.String(), Repeats: opts.Repeats}
+	for _, c := range cases {
+		session.CaseIDs = append(session.CaseIDs, c.ID)
+	}
+	sessionsDir := filepath.Join(store.root, "sessions")
+	if err := os.MkdirAll(sessionsDir, 0o755); err != nil {
+		return Session{}, nil, fmt.Errorf("create eval sessions directory: %w", err)
+	}
+	if err := writeJSON(filepath.Join(sessionsDir, session.ID+".json"), session); err != nil {
+		return Session{}, nil, fmt.Errorf("write eval session: %w", err)
+	}
+
+	evaluations := make([]Evaluation, 0, len(cases)*opts.Repeats)
+	var failed int
+	for repeat := 1; repeat <= opts.Repeats; repeat++ {
+		for _, c := range cases {
+			evaluation := replayOne(ctx, c, session, opts.Candidate, repeat)
+			if evaluation.Status != "completed" {
+				failed++
+			}
+			if err := store.persistEvaluation(c, evaluation); err != nil {
+				return session, evaluations, err
+			}
+			evaluations = append(evaluations, evaluation)
+		}
+	}
+	if failed > 0 {
+		return session, evaluations, fmt.Errorf("%d replay invocation(s) failed; inspect eval report for the local failure count", failed)
+	}
+	return session, evaluations, nil
+}
+
+func replayOne(ctx context.Context, c Case, session Session, candidate Candidate, repeat int) Evaluation {
+	started := time.Now()
+	evaluation := Evaluation{
+		ID:        newSessionID(),
+		SessionID: session.ID,
+		CaseID:    c.ID,
+		Candidate: candidate.String(),
+		Repeat:    repeat,
+		StartedAt: started.Unix(),
+		Status:    "failed",
+	}
+	if c.Labels.Verdict.Known {
+		expected := c.Labels.Verdict.ShouldPark
+		evaluation.ExpectedPark = &expected
+	}
+
+	root, err := os.MkdirTemp("", "nm-eval-replay-")
+	if err != nil {
+		evaluation.Error = safeurl.RedactText(fmt.Sprintf("create isolated replay root: %v", err))
+		evaluation.CompletedAt = time.Now().Unix()
+		return evaluation
+	}
+	defer os.RemoveAll(root)
+
+	workDir, err := restoreCase(ctx, c, root)
+	if err != nil {
+		evaluation.Error = safeurl.RedactText(err.Error())
+		evaluation.CompletedAt = time.Now().Unix()
+		return evaluation
+	}
+	cfg, err := replayConfig(c)
+	if err != nil {
+		evaluation.Error = safeurl.RedactText(err.Error())
+		evaluation.CompletedAt = time.Now().Unix()
+		return evaluation
+	}
+	cfg.Agent = candidate.Agent
+	cfg.Agents = []types.AgentName{candidate.Agent}
+
+	baseAgent, err := agent.NewWithOptions(candidate.Agent, cfg.AgentPathFor(candidate.Agent), candidateModelArgs(candidate), agent.Options{
+		ACPRegistryOverrides:   cfg.ACPRegistryOverrides,
+		DisableProjectSettings: cfg.DisableProjectSettings,
+	})
+	if err != nil {
+		evaluation.Error = safeurl.RedactText(fmt.Sprintf("create candidate agent: %v", err))
+		evaluation.CompletedAt = time.Now().Unix()
+		return evaluation
+	}
+	defer baseAgent.Close()
+	observed := &observedAgent{inner: agent.WithSteering(baseAgent)}
+
+	replayRun := &db.Run{ID: "eval-" + evaluation.ID, Branch: c.Branch, HeadSHA: c.ReviewedHeadSHA, BaseSHA: c.BaseSHA}
+	if c.Intent != "" {
+		intent := c.Intent
+		replayRun.Intent = &intent
+	}
+	if c.IntentSource != "" {
+		source := c.IntentSource
+		replayRun.IntentSource = &source
+	}
+	defaultBranch := c.DefaultBranch
+	if defaultBranch == "" {
+		defaultBranch = "main"
+	}
+	replayRepo := &db.Repo{ID: "eval", WorkingPath: workDir, DefaultBranch: defaultBranch}
+	step := &steps.ReviewStep{}
+	outcome, err := step.Execute(&pipeline.StepContext{
+		Ctx:          ctx,
+		Run:          replayRun,
+		Repo:         replayRepo,
+		WorkDir:      workDir,
+		Agent:        observed,
+		Config:       cfg,
+		Log:          func(string) {},
+		LogChunk:     func(string) {},
+		LogFile:      func(string) {},
+		UserIntent:   c.Intent,
+		IntentSource: c.IntentSource,
+	})
+	// Candidate wall time is the actual review invocation, matching the local
+	// agent-invocation metric rather than charging bundle restoration setup.
+	evaluation.DurationMS = observed.durationMS
+	if evaluation.DurationMS == 0 && observed.result == nil {
+		evaluation.DurationMS = time.Since(started).Milliseconds()
+	}
+	evaluation.CompletedAt = time.Now().Unix()
+	if observed.result != nil {
+		evaluation.Model = observed.result.Model
+		if evaluation.Model == "" {
+			evaluation.Model = candidate.Model
+		}
+		if observed.result.UsageReported {
+			evaluation.TokensReported = true
+			evaluation.InputTokens = int64(observed.result.Usage.InputTokens)
+			evaluation.OutputTokens = int64(observed.result.Usage.OutputTokens)
+			evaluation.CacheReadTokens = int64(observed.result.Usage.CacheReadTokens)
+			evaluation.FreshInputTokens = int64(agent.FreshInputTokens(observed.result.Usage.InputTokens, observed.result.Usage.CacheReadTokens))
+		}
+	}
+	if err != nil {
+		evaluation.Error = safeurl.RedactText(fmt.Sprintf("replay review: %v", err))
+		return evaluation
+	}
+	if outcome == nil {
+		evaluation.Error = "replay review returned no outcome"
+		return evaluation
+	}
+	evaluation.Status = "completed"
+	evaluation.CandidateParked = outcome.NeedsApproval || hasAskUserFindings(outcome.Findings)
+	evaluation.FindingsJSON = outcome.Findings
+	evaluation.FindingCount = findingCount(outcome.Findings)
+	return evaluation
+}
+
+func restoreCase(ctx context.Context, c Case, root string) (string, error) {
+	// The temp Paths root is intentionally created even though this MVP invokes
+	// ReviewStep directly. It documents and enforces the same isolated-root
+	// boundary used by the e2e daemon harness, while never setting process-wide
+	// NM_HOME or touching the shared daemon.
+	p := paths.WithRoot(filepath.Join(root, "nmhome"))
+	if err := p.EnsureDirs(); err != nil {
+		return "", fmt.Errorf("create isolated eval state: %w", err)
+	}
+	gateDir := filepath.Join(root, "gate.git")
+	if err := git.InitBare(ctx, gateDir); err != nil {
+		return "", fmt.Errorf("create isolated eval gate: %w", err)
+	}
+	prefix := "refs/no-mistakes/eval/" + c.ID + "/*"
+	bundle := filepath.Join(c.Dir, "branch.bundle")
+	if _, err := git.Run(ctx, gateDir, "fetch", bundle, "+"+prefix+":"+prefix); err != nil {
+		return "", fmt.Errorf("restore case bundle: %w", err)
+	}
+	defaultBranch := c.DefaultBranch
+	if defaultBranch == "" {
+		defaultBranch = "main"
+	}
+	if _, err := git.Run(ctx, gateDir, "update-ref", "refs/remotes/origin/"+defaultBranch, c.TrustedConfigSHA); err != nil {
+		return "", fmt.Errorf("restore trusted default branch: %w", err)
+	}
+	workDir := filepath.Join(root, "worktree")
+	if err := git.WorktreeAdd(ctx, gateDir, workDir, c.ReviewedHeadSHA); err != nil {
+		return "", fmt.Errorf("restore review worktree: %w", err)
+	}
+	return workDir, nil
+}
+
+func replayConfig(c Case) (*config.Config, error) {
+	global, err := config.LoadGlobal(filepath.Join(c.Dir, "config", "global.yaml"))
+	if err != nil {
+		return nil, fmt.Errorf("load captured global config: %w", err)
+	}
+	repoBytes, err := os.ReadFile(filepath.Join(c.Dir, "config", "repo-config.yaml"))
+	if err != nil {
+		return nil, fmt.Errorf("read captured repo config: %w", err)
+	}
+	repo, err := config.LoadRepoFromBytes(repoBytes)
+	if err != nil {
+		return nil, fmt.Errorf("load captured repo config: %w", err)
+	}
+	return config.Merge(global, repo), nil
+}
+
+func candidateModelArgs(candidate Candidate) []string {
+	if candidate.Agent == types.AgentCodex {
+		return []string{"-m", candidate.Model}
+	}
+	return []string{"--model", candidate.Model}
+}
+
+type observedAgent struct {
+	inner      agent.Agent
+	result     *agent.Result
+	durationMS int64
+}
+
+func (a *observedAgent) Name() string { return a.inner.Name() }
+func (a *observedAgent) Close() error { return a.inner.Close() }
+func (a *observedAgent) Run(ctx context.Context, opts agent.RunOpts) (*agent.Result, error) {
+	started := time.Now()
+	result, err := a.inner.Run(ctx, opts)
+	a.durationMS += time.Since(started).Milliseconds()
+	a.result = result
+	return result, err
+}
+
+func hasAskUserFindings(raw string) bool {
+	findings, err := types.ParseFindingsJSON(raw)
+	return err == nil && types.HasAskUserFindings(findings)
+}
+
+func findingCount(raw string) int {
+	findings, err := types.ParseFindingsJSON(raw)
+	if err != nil {
+		return 0
+	}
+	return len(findings.Items)
+}
+
+func (s *Store) persistEvaluation(c Case, evaluation Evaluation) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("eval registry is closed")
+	}
+	candidateDir := candidatePathPart(evaluation.Candidate)
+	resultDir := filepath.Join(c.Dir, "evals", evaluation.SessionID, candidateDir)
+	if err := os.MkdirAll(resultDir, 0o755); err != nil {
+		return fmt.Errorf("create eval result directory: %w", err)
+	}
+	path := filepath.Join(resultDir, fmt.Sprintf("repeat-%03d.json", evaluation.Repeat))
+	if err := writeJSON(path, evaluation); err != nil {
+		return fmt.Errorf("write eval result: %w", err)
+	}
+	var expected any
+	if evaluation.ExpectedPark != nil {
+		if *evaluation.ExpectedPark {
+			expected = 1
+		} else {
+			expected = 0
+		}
+	}
+	parked := 0
+	if evaluation.CandidateParked {
+		parked = 1
+	}
+	reported := 0
+	if evaluation.TokensReported {
+		reported = 1
+	}
+	_, err := s.db.Exec(`INSERT INTO evaluations
+(id, session_id, case_id, candidate, repeat_number, started_at, completed_at, status, expected_park, candidate_parked, tokens_reported, input_tokens, output_tokens, fresh_input_tokens, duration_ms, path)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		evaluation.ID, evaluation.SessionID, evaluation.CaseID, evaluation.Candidate, evaluation.Repeat,
+		evaluation.StartedAt, evaluation.CompletedAt, evaluation.Status, expected, parked, reported,
+		evaluation.InputTokens, evaluation.OutputTokens, evaluation.FreshInputTokens, evaluation.DurationMS, path)
+	if err != nil {
+		return fmt.Errorf("record eval result: %w", err)
+	}
+	if evaluation.Status == "completed" && evaluation.ExpectedPark != nil && !*evaluation.ExpectedPark && evaluation.CandidateParked {
+		if err := incrementQueuedFindings(c.Dir); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func incrementQueuedFindings(caseDir string) error {
+	var labels Labels
+	if err := readJSON(filepath.Join(caseDir, "labels.json"), &labels); err != nil {
+		return fmt.Errorf("read local labels queue: %w", err)
+	}
+	labels.QueuedCandidateFindings++
+	if err := writeJSON(filepath.Join(caseDir, "labels.json"), labels); err != nil {
+		return fmt.Errorf("update local labels queue: %w", err)
+	}
+	return nil
+}
+
+func candidatePathPart(candidate string) string {
+	var b strings.Builder
+	for _, r := range candidate {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '.' || r == '-' || r == '_' {
+			b.WriteRune(r)
+			continue
+		}
+		b.WriteByte('_')
+	}
+	if b.Len() == 0 {
+		return "candidate"
+	}
+	return b.String()
+}
+
+func newSessionID() string {
+	var bytes [8]byte
+	if _, err := rand.Read(bytes[:]); err != nil {
+		return fmt.Sprintf("%d", time.Now().UnixNano())
+	}
+	return fmt.Sprintf("%d-%s", time.Now().UnixNano(), hex.EncodeToString(bytes[:]))
+}

--- a/internal/eval/report.go
+++ b/internal/eval/report.go
@@ -117,19 +117,17 @@ func averageWallMS(rows []Evaluation) float64 {
 }
 
 func averageTokens(rows []Evaluation) (float64, bool) {
-	var total int64
-	count := 0
-	for _, row := range rows {
-		if !row.TokensReported {
-			continue
-		}
-		total += row.FreshInputTokens + row.OutputTokens
-		count++
-	}
-	if count == 0 {
+	if len(rows) == 0 {
 		return 0, false
 	}
-	return float64(total) / float64(count), true
+	var total int64
+	for _, row := range rows {
+		if !row.TokensReported {
+			return 0, false
+		}
+		total += row.FreshInputTokens + row.OutputTokens
+	}
+	return float64(total) / float64(len(rows)), true
 }
 
 func confidenceInterval(_ string, rows []Evaluation) *Interval {
@@ -301,7 +299,7 @@ func RenderReport(reports []CandidateReport) string {
 			}
 		}
 		if report.AverageTokens == nil {
-			b.WriteString("  token cost: unknown (candidate did not report token usage)\n")
+			b.WriteString("  token cost: unknown (token usage was not reported for every replay)\n")
 		} else {
 			fmt.Fprintf(&b, "  token cost: %.0f fresh-input + output tokens per reported replay\n", *report.AverageTokens)
 		}

--- a/internal/eval/report.go
+++ b/internal/eval/report.go
@@ -20,6 +20,7 @@ type Interval struct {
 
 // CandidateReport is one locally observed candidate slice.
 type CandidateReport struct {
+	Cohort        string
 	Summary       EvaluationSummary
 	RepeatCount   int
 	Confidence    *Interval
@@ -35,15 +36,22 @@ func Report(store *Store) ([]CandidateReport, error) {
 	if err != nil {
 		return nil, err
 	}
-	byCandidate := make(map[string][]Evaluation)
+	byCandidateCohort := make(map[string][]Evaluation)
 	for _, evaluation := range evaluations {
-		byCandidate[evaluation.Candidate] = append(byCandidate[evaluation.Candidate], evaluation)
+		cohort := evaluation.Cohort
+		if cohort == "" {
+			cohort = "legacy-unmatched"
+		}
+		key := cohort + "\x00" + evaluation.Candidate
+		byCandidateCohort[key] = append(byCandidateCohort[key], evaluation)
 	}
-	reports := make([]CandidateReport, 0, len(byCandidate))
-	for candidate, rows := range byCandidate {
+	reports := make([]CandidateReport, 0, len(byCandidateCohort))
+	for key, rows := range byCandidateCohort {
+		cohort, candidate, _ := strings.Cut(key, "\x00")
 		summary := SummarizeEvaluations(rows)
 		repeats := repeatCount(rows)
 		report := CandidateReport{
+			Cohort:        cohort,
 			Summary:       summary,
 			RepeatCount:   repeats,
 			Confidence:    confidenceInterval(candidate, rows),
@@ -54,7 +62,12 @@ func Report(store *Store) ([]CandidateReport, error) {
 		}
 		reports = append(reports, report)
 	}
-	sort.Slice(reports, func(i, j int) bool { return reports[i].Summary.Candidate < reports[j].Summary.Candidate })
+	sort.Slice(reports, func(i, j int) bool {
+		if reports[i].Cohort != reports[j].Cohort {
+			return reports[i].Cohort < reports[j].Cohort
+		}
+		return reports[i].Summary.Candidate < reports[j].Summary.Candidate
+	})
 	markFrontier(reports)
 	return reports, nil
 }
@@ -158,8 +171,8 @@ func confidenceInterval(candidate string, rows []Evaluation) *Interval {
 		return nil
 	}
 	sort.Float64s(values)
-	if len(values) == 1 {
-		return &Interval{Lower: values[0], Upper: values[0], Cases: 1}
+	if len(values) < 2 {
+		return nil
 	}
 	const samples = 2000
 	sum := sha256.Sum256([]byte(candidate))
@@ -201,7 +214,7 @@ func markFrontier(reports []CandidateReport) {
 		}
 		dominated := false
 		for j := range reports {
-			if i == j || reports[j].AverageTokens == nil || reports[j].Summary.Labeled == 0 {
+			if i == j || reports[i].Cohort != reports[j].Cohort || reports[j].AverageTokens == nil || reports[j].Summary.Labeled == 0 {
 				continue
 			}
 			betterAccuracy := reports[j].Summary.LowerBoundAccuracy() >= reports[i].Summary.LowerBoundAccuracy()
@@ -292,7 +305,7 @@ func RenderReport(reports []CandidateReport) string {
 	b.WriteString("LOCAL-ONLY EVAL REPORT\n")
 	for _, report := range reports {
 		s := report.Summary
-		fmt.Fprintf(&b, "\n%s\n", s.Candidate)
+		fmt.Fprintf(&b, "\n%s (cohort %s)\n", s.Candidate, report.Cohort)
 		fmt.Fprintf(&b, "  replays: %d across %d repeat(s); labeled: %d; failures: %d\n", s.Total, report.RepeatCount, s.Labeled, s.Failures)
 		if s.Labeled == 0 {
 			b.WriteString("  verdict agreement: no human-confirmed verdict labels yet\n")

--- a/internal/eval/report.go
+++ b/internal/eval/report.go
@@ -1,0 +1,319 @@
+package eval
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"math"
+	"math/rand"
+	"sort"
+	"strings"
+)
+
+// Interval is a two-sided 95% bootstrap confidence interval over cases. Cases
+// are the independent unit; repeats are averaged inside each case before
+// resampling so a noisy provider does not inflate apparent sample size.
+type Interval struct {
+	Lower float64
+	Upper float64
+	Cases int
+}
+
+// CandidateReport is one locally observed candidate slice.
+type CandidateReport struct {
+	Summary       EvaluationSummary
+	RepeatCount   int
+	Confidence    *Interval
+	AverageTokens *float64
+	AverageWallMS float64
+	OnFrontier    bool
+}
+
+// Report loads every local evaluation result grouped by candidate. It never
+// contacts a forge, agent provider, telemetry endpoint, or remote case store.
+func Report(store *Store) ([]CandidateReport, error) {
+	evaluations, err := store.evaluations()
+	if err != nil {
+		return nil, err
+	}
+	byCandidate := make(map[string][]Evaluation)
+	for _, evaluation := range evaluations {
+		byCandidate[evaluation.Candidate] = append(byCandidate[evaluation.Candidate], evaluation)
+	}
+	reports := make([]CandidateReport, 0, len(byCandidate))
+	for candidate, rows := range byCandidate {
+		summary := SummarizeEvaluations(rows)
+		repeats := repeatCount(rows)
+		report := CandidateReport{
+			Summary:       summary,
+			RepeatCount:   repeats,
+			Confidence:    confidenceInterval(candidate, rows),
+			AverageWallMS: averageWallMS(rows),
+		}
+		if cost, ok := averageTokens(rows); ok {
+			report.AverageTokens = &cost
+		}
+		reports = append(reports, report)
+	}
+	sort.Slice(reports, func(i, j int) bool { return reports[i].Summary.Candidate < reports[j].Summary.Candidate })
+	markFrontier(reports)
+	return reports, nil
+}
+
+func (s *Store) evaluations() ([]Evaluation, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("eval registry is closed")
+	}
+	rows, err := s.db.Query(`SELECT path FROM evaluations ORDER BY completed_at, id`)
+	if err != nil {
+		return nil, fmt.Errorf("list eval results: %w", err)
+	}
+	defer rows.Close()
+	var result []Evaluation
+	for rows.Next() {
+		var path string
+		if err := rows.Scan(&path); err != nil {
+			return nil, fmt.Errorf("scan eval result: %w", err)
+		}
+		var evaluation Evaluation
+		if err := readJSON(path, &evaluation); err != nil {
+			return nil, fmt.Errorf("read eval result: %w", err)
+		}
+		result = append(result, evaluation)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list eval results: %w", err)
+	}
+	return result, nil
+}
+
+func repeatCount(rows []Evaluation) int {
+	seen := map[int]bool{}
+	for _, row := range rows {
+		seen[row.Repeat] = true
+	}
+	return len(seen)
+}
+
+func averageWallMS(rows []Evaluation) float64 {
+	if len(rows) == 0 {
+		return 0
+	}
+	var total int64
+	for _, row := range rows {
+		total += row.DurationMS
+	}
+	return float64(total) / float64(len(rows))
+}
+
+func averageTokens(rows []Evaluation) (float64, bool) {
+	var total int64
+	count := 0
+	for _, row := range rows {
+		if !row.TokensReported {
+			continue
+		}
+		total += row.FreshInputTokens + row.OutputTokens
+		count++
+	}
+	if count == 0 {
+		return 0, false
+	}
+	return float64(total) / float64(count), true
+}
+
+func confidenceInterval(candidate string, rows []Evaluation) *Interval {
+	// First turn each case into a mean over CONCLUSIVE repeats. A pending
+	// unexpected park stays out of this conditional interval and is surfaced
+	// separately in every report as a queue count and a lower-bound accuracy.
+	perCase := map[string][]float64{}
+	for _, row := range rows {
+		if row.Status != "completed" || row.ExpectedPark == nil {
+			continue
+		}
+		var score *float64
+		switch {
+		case *row.ExpectedPark && row.CandidateParked:
+			v := 1.0
+			score = &v
+		case *row.ExpectedPark && !row.CandidateParked:
+			v := 0.0
+			score = &v
+		case !*row.ExpectedPark && !row.CandidateParked:
+			v := 1.0
+			score = &v
+		}
+		if score != nil {
+			perCase[row.CaseID] = append(perCase[row.CaseID], *score)
+		}
+	}
+	values := make([]float64, 0, len(perCase))
+	for _, scores := range perCase {
+		var total float64
+		for _, score := range scores {
+			total += score
+		}
+		values = append(values, total/float64(len(scores)))
+	}
+	if len(values) == 0 {
+		return nil
+	}
+	sort.Float64s(values)
+	if len(values) == 1 {
+		return &Interval{Lower: values[0], Upper: values[0], Cases: 1}
+	}
+	const samples = 2000
+	sum := sha256.Sum256([]byte(candidate))
+	seed := int64(0)
+	for _, b := range sum[:8] {
+		seed = seed<<8 | int64(b)
+	}
+	rng := rand.New(rand.NewSource(seed))
+	boot := make([]float64, samples)
+	for i := range boot {
+		var total float64
+		for range values {
+			total += values[rng.Intn(len(values))]
+		}
+		boot[i] = total / float64(len(values))
+	}
+	sort.Float64s(boot)
+	return &Interval{Lower: percentile(boot, 0.025), Upper: percentile(boot, 0.975), Cases: len(values)}
+}
+
+func percentile(values []float64, p float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	index := int(math.Round(p * float64(len(values)-1)))
+	if index < 0 {
+		index = 0
+	}
+	if index >= len(values) {
+		index = len(values) - 1
+	}
+	return values[index]
+}
+
+func markFrontier(reports []CandidateReport) {
+	for i := range reports {
+		if reports[i].AverageTokens == nil || reports[i].Summary.Labeled == 0 {
+			continue
+		}
+		dominated := false
+		for j := range reports {
+			if i == j || reports[j].AverageTokens == nil || reports[j].Summary.Labeled == 0 {
+				continue
+			}
+			betterAccuracy := reports[j].Summary.LowerBoundAccuracy() >= reports[i].Summary.LowerBoundAccuracy()
+			cheaper := *reports[j].AverageTokens <= *reports[i].AverageTokens
+			strict := reports[j].Summary.LowerBoundAccuracy() > reports[i].Summary.LowerBoundAccuracy() || *reports[j].AverageTokens < *reports[i].AverageTokens
+			if betterAccuracy && cheaper && strict {
+				dominated = true
+				break
+			}
+		}
+		reports[i].OnFrontier = !dominated
+	}
+}
+
+// SetSummary lets users inspect corpus coverage before an eval consumes tokens.
+type SetSummary struct {
+	Name           string
+	Cases          int
+	VerdictLabels  int
+	ShouldPark     int
+	ShouldPass     int
+	QueuedFindings int
+	Composition    map[string]int
+}
+
+// InspectSets summarizes all logical MVP sets and their diversified mix.
+func InspectSets(store *Store) ([]SetSummary, error) {
+	sets := []string{"all", "labeled", "diversified"}
+	result := make([]SetSummary, 0, len(sets))
+	for _, name := range sets {
+		cases, err := store.ListCases(name)
+		if err != nil {
+			return nil, err
+		}
+		summary := SetSummary{Name: name, Cases: len(cases), Composition: map[string]int{}}
+		for _, c := range cases {
+			if c.Labels.Verdict.Known {
+				summary.VerdictLabels++
+				if c.Labels.Verdict.ShouldPark {
+					summary.ShouldPark++
+				} else {
+					summary.ShouldPass++
+				}
+			}
+			summary.QueuedFindings += c.Labels.QueuedCandidateFindings
+			language, size, severity := caseComposition(c)
+			summary.Composition["repo="+shortFingerprint(c.RepoFingerprint)+", language="+language+", size="+size+", severity="+severity]++
+		}
+		result = append(result, summary)
+	}
+	return result, nil
+}
+
+func shortFingerprint(value string) string {
+	if len(value) <= 12 {
+		return value
+	}
+	return value[:12]
+}
+
+// RenderSets is a stable human-readable preflight. It intentionally contains
+// counts and buckets only, never source paths, URLs, diffs, or findings.
+func RenderSets(summaries []SetSummary) string {
+	var b strings.Builder
+	b.WriteString("LOCAL-ONLY EVAL CASE SETS\n")
+	for _, summary := range summaries {
+		fmt.Fprintf(&b, "\n%s: %d cases, %d verdict labels (park %d, pass %d), %d candidate findings queued\n", summary.Name, summary.Cases, summary.VerdictLabels, summary.ShouldPark, summary.ShouldPass, summary.QueuedFindings)
+		keys := make([]string, 0, len(summary.Composition))
+		for key := range summary.Composition {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			fmt.Fprintf(&b, "  %d  %s\n", summary.Composition[key], key)
+		}
+	}
+	return b.String()
+}
+
+// RenderReport is a stable human-readable local comparison. Confidence
+// intervals are conditional on conclusive verdicts; the lower-bound metric
+// includes queued unexpected parks so the uncertainty is explicit.
+func RenderReport(reports []CandidateReport) string {
+	if len(reports) == 0 {
+		return "LOCAL-ONLY EVAL REPORT\nno candidate replays recorded yet\n"
+	}
+	var b strings.Builder
+	b.WriteString("LOCAL-ONLY EVAL REPORT\n")
+	for _, report := range reports {
+		s := report.Summary
+		fmt.Fprintf(&b, "\n%s\n", s.Candidate)
+		fmt.Fprintf(&b, "  replays: %d across %d repeat(s); labeled: %d; failures: %d\n", s.Total, report.RepeatCount, s.Labeled, s.Failures)
+		if s.Labeled == 0 {
+			b.WriteString("  verdict agreement: no human-confirmed verdict labels yet\n")
+		} else {
+			fmt.Fprintf(&b, "  confirmed verdict agreement: %.1f%% (%d/%d); conservative lower bound: %.1f%%\n", 100*s.ConfirmedAccuracy(), s.Correct, s.Conclusive, 100*s.LowerBoundAccuracy())
+			if report.Confidence != nil {
+				fmt.Fprintf(&b, "  95%% bootstrap CI: %.1f%%-%.1f%% over %d case(s)\n", 100*report.Confidence.Lower, 100*report.Confidence.Upper, report.Confidence.Cases)
+			}
+			if s.UnexpectedParks > 0 {
+				fmt.Fprintf(&b, "  queued unexpected parks: %d (not scored wrong pending finding-level adjudication)\n", s.UnexpectedParks)
+			}
+		}
+		if report.AverageTokens == nil {
+			b.WriteString("  token cost: unknown (candidate did not report token usage)\n")
+		} else {
+			fmt.Fprintf(&b, "  token cost: %.0f fresh-input + output tokens per reported replay\n", *report.AverageTokens)
+		}
+		fmt.Fprintf(&b, "  wall time: %.1fs average\n", report.AverageWallMS/1000)
+		if report.AverageTokens != nil {
+			fmt.Fprintf(&b, "  accuracy-vs-cost frontier: %t\n", report.OnFrontier)
+		}
+	}
+	return b.String()
+}

--- a/internal/eval/report.go
+++ b/internal/eval/report.go
@@ -1,17 +1,15 @@
 package eval
 
 import (
-	"crypto/sha256"
 	"fmt"
 	"math"
-	"math/rand"
 	"sort"
 	"strings"
 )
 
-// Interval is a two-sided 95% bootstrap confidence interval over cases. Cases
-// are the independent unit; repeats are averaged inside each case before
-// resampling so a noisy provider does not inflate apparent sample size.
+// Interval is a two-sided 95% Wilson score interval over cases. Cases are the
+// independent unit; repeats are averaged inside each case so a noisy provider
+// does not inflate apparent sample size.
 type Interval struct {
 	Lower float64
 	Upper float64
@@ -134,7 +132,7 @@ func averageTokens(rows []Evaluation) (float64, bool) {
 	return float64(total) / float64(count), true
 }
 
-func confidenceInterval(candidate string, rows []Evaluation) *Interval {
+func confidenceInterval(_ string, rows []Evaluation) *Interval {
 	// First turn each case into a mean over CONCLUSIVE repeats. A pending
 	// unexpected park stays out of this conditional interval and is surfaced
 	// separately in every report as a queue count and a lower-bound accuracy.
@@ -170,41 +168,21 @@ func confidenceInterval(candidate string, rows []Evaluation) *Interval {
 	if len(values) == 0 {
 		return nil
 	}
-	sort.Float64s(values)
 	if len(values) < 2 {
 		return nil
 	}
-	const samples = 2000
-	sum := sha256.Sum256([]byte(candidate))
-	seed := int64(0)
-	for _, b := range sum[:8] {
-		seed = seed<<8 | int64(b)
+	var total float64
+	for _, value := range values {
+		total += value
 	}
-	rng := rand.New(rand.NewSource(seed))
-	boot := make([]float64, samples)
-	for i := range boot {
-		var total float64
-		for range values {
-			total += values[rng.Intn(len(values))]
-		}
-		boot[i] = total / float64(len(values))
-	}
-	sort.Float64s(boot)
-	return &Interval{Lower: percentile(boot, 0.025), Upper: percentile(boot, 0.975), Cases: len(values)}
-}
-
-func percentile(values []float64, p float64) float64 {
-	if len(values) == 0 {
-		return 0
-	}
-	index := int(math.Round(p * float64(len(values)-1)))
-	if index < 0 {
-		index = 0
-	}
-	if index >= len(values) {
-		index = len(values) - 1
-	}
-	return values[index]
+	n := float64(len(values))
+	proportion := total / n
+	const z = 1.959963984540054
+	z2 := z * z
+	denominator := 1 + z2/n
+	center := (proportion + z2/(2*n)) / denominator
+	halfWidth := z * math.Sqrt((proportion*(1-proportion)+z2/(4*n))/n) / denominator
+	return &Interval{Lower: center - halfWidth, Upper: center + halfWidth, Cases: len(values)}
 }
 
 func markFrontier(reports []CandidateReport) {

--- a/internal/eval/report.go
+++ b/internal/eval/report.go
@@ -138,7 +138,11 @@ func confidenceInterval(_ string, rows []Evaluation) *Interval {
 	// separately in every report as a queue count and a lower-bound accuracy.
 	perCase := map[string][]float64{}
 	for _, row := range rows {
-		if row.Status != "completed" || row.ExpectedPark == nil {
+		if row.ExpectedPark == nil {
+			continue
+		}
+		if row.Status != "completed" {
+			perCase[row.CaseID] = append(perCase[row.CaseID], 0)
 			continue
 		}
 		var score *float64

--- a/internal/eval/report.go
+++ b/internal/eval/report.go
@@ -187,12 +187,12 @@ func confidenceInterval(_ string, rows []Evaluation) *Interval {
 
 func markFrontier(reports []CandidateReport) {
 	for i := range reports {
-		if reports[i].AverageTokens == nil || reports[i].Summary.Labeled == 0 {
+		if reports[i].AverageTokens == nil || reports[i].Summary.Labeled == 0 || reports[i].Summary.Failures > 0 {
 			continue
 		}
 		dominated := false
 		for j := range reports {
-			if i == j || reports[i].Cohort != reports[j].Cohort || reports[j].AverageTokens == nil || reports[j].Summary.Labeled == 0 {
+			if i == j || reports[i].Cohort != reports[j].Cohort || reports[j].AverageTokens == nil || reports[j].Summary.Labeled == 0 || reports[j].Summary.Failures > 0 {
 				continue
 			}
 			betterAccuracy := reports[j].Summary.LowerBoundAccuracy() >= reports[i].Summary.LowerBoundAccuracy()

--- a/internal/eval/report.go
+++ b/internal/eval/report.go
@@ -290,7 +290,7 @@ func RenderReport(reports []CandidateReport) string {
 		} else {
 			fmt.Fprintf(&b, "  confirmed verdict agreement: %.1f%% (%d/%d); conservative lower bound: %.1f%%\n", 100*s.ConfirmedAccuracy(), s.Correct, s.Conclusive, 100*s.LowerBoundAccuracy())
 			if report.Confidence != nil {
-				fmt.Fprintf(&b, "  95%% bootstrap CI: %.1f%%-%.1f%% over %d case(s)\n", 100*report.Confidence.Lower, 100*report.Confidence.Upper, report.Confidence.Cases)
+				fmt.Fprintf(&b, "  95%% Wilson score CI: %.1f%%-%.1f%% over %d case(s)\n", 100*report.Confidence.Lower, 100*report.Confidence.Upper, report.Confidence.Cases)
 			}
 			if s.UnexpectedParks > 0 {
 				fmt.Fprintf(&b, "  queued unexpected parks: %d (not scored wrong pending finding-level adjudication)\n", s.UnexpectedParks)

--- a/internal/eval/store.go
+++ b/internal/eval/store.go
@@ -1,0 +1,314 @@
+package eval
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	_ "modernc.org/sqlite"
+)
+
+// Store is the opt-in sqlite-first local registry. It is intentionally a
+// separate database so merely opening the normal pipeline DB never creates an
+// eval table or runs an eval migration.
+type Store struct {
+	root  string
+	cases string
+	db    *sql.DB
+}
+
+// Open creates the local eval registry. Nothing calls this outside an explicit
+// eval subcommand.
+func Open(root string) (*Store, error) {
+	if strings.TrimSpace(root) == "" {
+		return nil, fmt.Errorf("eval root is empty")
+	}
+	root = filepath.Clean(root)
+	cases := filepath.Join(root, "cases")
+	if err := os.MkdirAll(cases, 0o755); err != nil {
+		return nil, fmt.Errorf("create eval cases directory: %w", err)
+	}
+	database, err := sql.Open("sqlite", filepath.Join(root, "registry.sqlite")+"?_pragma=journal_mode(wal)&_pragma=foreign_keys(on)&_pragma=busy_timeout(5000)")
+	if err != nil {
+		return nil, fmt.Errorf("open eval registry: %w", err)
+	}
+	database.SetMaxOpenConns(1)
+	store := &Store{root: root, cases: cases, db: database}
+	if err := store.migrate(); err != nil {
+		_ = database.Close()
+		return nil, err
+	}
+	return store, nil
+}
+
+func (s *Store) migrate() error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("eval registry is closed")
+	}
+	_, err := s.db.Exec(`
+CREATE TABLE IF NOT EXISTS cases (
+    id TEXT PRIMARY KEY,
+    source_run_id TEXT NOT NULL,
+    source_round_id TEXT NOT NULL UNIQUE,
+    captured_at INTEGER NOT NULL,
+    repo_fingerprint TEXT NOT NULL,
+    branch TEXT NOT NULL,
+    language TEXT NOT NULL,
+    size_bucket TEXT NOT NULL,
+    severity TEXT NOT NULL,
+    verdict_known INTEGER NOT NULL,
+    verdict_should_park INTEGER NOT NULL,
+    path TEXT NOT NULL UNIQUE
+);
+CREATE TABLE IF NOT EXISTS evaluations (
+    id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    case_id TEXT NOT NULL REFERENCES cases(id) ON DELETE CASCADE,
+    candidate TEXT NOT NULL,
+    repeat_number INTEGER NOT NULL,
+    started_at INTEGER NOT NULL,
+    completed_at INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    expected_park INTEGER,
+    candidate_parked INTEGER NOT NULL,
+    tokens_reported INTEGER NOT NULL,
+    input_tokens INTEGER NOT NULL,
+    output_tokens INTEGER NOT NULL,
+    fresh_input_tokens INTEGER NOT NULL,
+    duration_ms INTEGER NOT NULL,
+    path TEXT NOT NULL UNIQUE
+);
+CREATE INDEX IF NOT EXISTS idx_eval_evaluations_candidate ON evaluations(candidate, completed_at, id);
+CREATE INDEX IF NOT EXISTS idx_eval_evaluations_case ON evaluations(case_id, completed_at, id);
+`)
+	if err != nil {
+		return fmt.Errorf("migrate eval registry: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) Close() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	err := s.db.Close()
+	s.db = nil
+	return err
+}
+
+func (s *Store) caseDir(id string) string { return filepath.Join(s.cases, id) }
+
+func (s *Store) registerCase(c Case) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("eval registry is closed")
+	}
+	language, size, severity := caseComposition(c)
+	known, shouldPark := 0, 0
+	if c.Labels.Verdict.Known {
+		known = 1
+	}
+	if c.Labels.Verdict.ShouldPark {
+		shouldPark = 1
+	}
+	_, err := s.db.Exec(`INSERT OR IGNORE INTO cases
+(id, source_run_id, source_round_id, captured_at, repo_fingerprint, branch, language, size_bucket, severity, verdict_known, verdict_should_park, path)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		c.ID, c.SourceRunID, c.SourceRoundID, c.CapturedAt, c.RepoFingerprint, c.Branch, language, size, severity, known, shouldPark, c.Dir)
+	if err != nil {
+		return fmt.Errorf("register eval case: %w", err)
+	}
+	return nil
+}
+
+// ListCases resolves the three MVP logical sets. Diversified is deterministic:
+// it retains the lexicographically first case in each repo/language/size/verdict
+// bucket, making its composition visible and stable before a user spends tokens.
+func (s *Store) ListCases(set string) ([]Case, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("eval registry is closed")
+	}
+	set = strings.TrimSpace(strings.ToLower(set))
+	if set == "" {
+		set = "all"
+	}
+	if set != "all" && set != "labeled" && set != "diversified" {
+		return nil, fmt.Errorf("unknown case set %q (use all, labeled, or diversified)", set)
+	}
+	rows, err := s.db.Query(`SELECT id, path FROM cases ORDER BY captured_at, id`)
+	if err != nil {
+		return nil, fmt.Errorf("list eval cases: %w", err)
+	}
+	defer rows.Close()
+	var all []Case
+	for rows.Next() {
+		var id, dir string
+		if err := rows.Scan(&id, &dir); err != nil {
+			return nil, fmt.Errorf("scan eval case: %w", err)
+		}
+		c, err := loadCase(dir)
+		if err != nil {
+			return nil, fmt.Errorf("load eval case %s: %w", id, err)
+		}
+		all = append(all, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list eval cases: %w", err)
+	}
+
+	switch set {
+	case "all":
+		return all, nil
+	case "labeled":
+		out := make([]Case, 0, len(all))
+		for _, c := range all {
+			if c.Labels.Verdict.Known {
+				out = append(out, c)
+			}
+		}
+		return out, nil
+	case "diversified":
+		seen := make(map[string]bool, len(all))
+		out := make([]Case, 0, len(all))
+		for _, c := range all {
+			key := diversifiedKey(c)
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, c)
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("unknown case set %q", set)
+	}
+}
+
+func loadCase(dir string) (Case, error) {
+	var manifest Manifest
+	if err := readJSON(filepath.Join(dir, "manifest.json"), &manifest); err != nil {
+		return Case{}, err
+	}
+	if manifest.Version != manifestVersion {
+		return Case{}, fmt.Errorf("unsupported case manifest version %d", manifest.Version)
+	}
+	var labels Labels
+	if err := readJSON(filepath.Join(dir, "labels.json"), &labels); err != nil {
+		return Case{}, err
+	}
+	if labels.Version != labelsVersion {
+		return Case{}, fmt.Errorf("unsupported case labels version %d", labels.Version)
+	}
+	var decision Decision
+	if err := readJSON(filepath.Join(dir, "original", "decision.json"), &decision); err != nil {
+		return Case{}, err
+	}
+	var baseline BaselineMetrics
+	if err := readJSON(filepath.Join(dir, "original", "baseline.json"), &baseline); err != nil {
+		return Case{}, err
+	}
+	return Case{Manifest: manifest, Labels: labels, Decision: decision, Baseline: baseline, Dir: dir}, nil
+}
+
+func readJSON(path string, dest any) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, dest); err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeJSON(path string, value any) error {
+	data, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return err
+	}
+	return nil
+}
+
+func diversifiedKey(c Case) string {
+	language, size, _ := caseComposition(c)
+	verdict := "unlabeled"
+	if c.Labels.Verdict.Known {
+		verdict = "pass"
+		if c.Labels.Verdict.ShouldPark {
+			verdict = "park"
+		}
+	}
+	return strings.Join([]string{c.RepoFingerprint, language, size, verdict}, "\x00")
+}
+
+func caseComposition(c Case) (language, size, severity string) {
+	language = "other"
+	if c.ChangedFiles > 1 {
+		language = "mixed"
+	}
+	switch {
+	case c.ChangedLines <= 25:
+		size = "tiny"
+	case c.ChangedLines <= 100:
+		size = "small"
+	case c.ChangedLines <= 500:
+		size = "medium"
+	default:
+		size = "large"
+	}
+	severity = "none"
+	if raw, err := os.ReadFile(filepath.Join(c.Dir, "original", "round.json")); err == nil {
+		var record sourceRound
+		if json.Unmarshal(raw, &record) == nil {
+			severity = highestSeverity(record.FindingsJSON)
+		}
+	}
+	if raw, err := os.ReadFile(filepath.Join(c.Dir, "original", "changed-files.json")); err == nil {
+		var files []string
+		if json.Unmarshal(raw, &files) == nil {
+			language = dominantLanguage(files, language)
+		}
+	}
+	return language, size, severity
+}
+
+func dominantLanguage(files []string, fallback string) string {
+	counts := map[string]int{}
+	for _, file := range files {
+		ext := strings.ToLower(filepath.Ext(file))
+		name := map[string]string{
+			".go": "go", ".py": "python", ".js": "javascript", ".jsx": "javascript", ".ts": "typescript", ".tsx": "typescript", ".rs": "rust", ".java": "java", ".rb": "ruby", ".php": "php", ".c": "c", ".h": "c", ".cc": "cpp", ".cpp": "cpp", ".cs": "csharp", ".swift": "swift", ".kt": "kotlin", ".sh": "shell",
+		}[ext]
+		if name != "" {
+			counts[name]++
+		}
+	}
+	if len(counts) == 0 {
+		return fallback
+	}
+	type entry struct {
+		name  string
+		count int
+	}
+	entries := make([]entry, 0, len(counts))
+	for name, count := range counts {
+		entries = append(entries, entry{name, count})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].count == entries[j].count {
+			return entries[i].name < entries[j].name
+		}
+		return entries[i].count > entries[j].count
+	})
+	if len(entries) > 1 && entries[0].count == entries[1].count {
+		return "mixed"
+	}
+	return entries[0].name
+}

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -57,6 +57,11 @@ func (p *Paths) TelemetryGateFile() string {
 	return filepath.Join(p.root, "telemetry-gate.json")
 }
 
+// EvalDir holds opt-in local evaluation cases and their separate registry.
+// EnsureDirs deliberately does not create it, so users who never invoke eval
+// see no new filesystem state.
+func (p *Paths) EvalDir() string { return filepath.Join(p.root, "eval") }
+
 func (p *Paths) ReposDir() string { return filepath.Join(p.root, "repos") }
 func (p *Paths) RepoDir(repoID string) string {
 	return filepath.Join(p.root, "repos", repoID+".git")

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -723,6 +723,8 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 
 	// Execute with possible fix loop
 	for {
+		reviewStartingHeadSHA := run.HeadSHA
+		sctx.ReviewStartingHeadSHA = reviewStartingHeadSHA
 		outcome, err := step.Execute(sctx)
 		roundNum++
 		roundDuration := time.Since(phaseStart).Milliseconds()
@@ -774,7 +776,14 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 		var inserted *db.StepRound
 		var dbErr error
 		if stepName == types.StepReview {
-			inserted, dbErr = e.db.InsertReviewStepRound(sr.ID, roundNum, nextTrigger, findingsPtr, fixSummaryPtr, reviewApprovedHeadSHA, roundDuration)
+			var trustedConfigSHA string
+			var globalConfigYAML, repoConfigYAML []byte
+			if e.config != nil {
+				trustedConfigSHA = e.config.TrustedConfigSHA
+				globalConfigYAML = e.config.ReplayGlobalYAML
+				repoConfigYAML = e.config.ReplayRepoYAML
+			}
+			inserted, dbErr = e.db.InsertReviewStepRoundWithProvenance(sr.ID, roundNum, nextTrigger, findingsPtr, fixSummaryPtr, reviewApprovedHeadSHA, reviewStartingHeadSHA, trustedConfigSHA, globalConfigYAML, repoConfigYAML, roundDuration)
 		} else {
 			inserted, dbErr = e.db.InsertStepRound(sr.ID, roundNum, nextTrigger, findingsPtr, fixSummaryPtr, roundDuration)
 		}

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -150,14 +150,8 @@ func (e *Executor) Execute(ctx context.Context, run *db.Run, repo *db.Repo, work
 	// Mark run as running. Route write failures through failRun so the
 	// in-memory lifecycle and subscriber stream still become terminal instead
 	// of leaving a silent pending run.
-	var startErr error
-	if run.TrustedConfigSHA != nil && run.GlobalConfigYAML != nil {
-		startErr = e.db.UpdateRunStatusWithConfig(run.ID, types.RunRunning, *run.TrustedConfigSHA, *run.GlobalConfigYAML)
-	} else {
-		startErr = e.db.UpdateRunStatus(run.ID, types.RunRunning)
-	}
-	if startErr != nil {
-		return e.failRun(run, repo, fmt.Errorf("update run status: %w", startErr))
+	if err := e.db.UpdateRunStatus(run.ID, types.RunRunning); err != nil {
+		return e.failRun(run, repo, fmt.Errorf("update run status: %w", err))
 	}
 	run.Status = types.RunRunning
 	e.emitRunEvent(ipc.EventRunUpdated, run, repo)

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -150,8 +150,14 @@ func (e *Executor) Execute(ctx context.Context, run *db.Run, repo *db.Repo, work
 	// Mark run as running. Route write failures through failRun so the
 	// in-memory lifecycle and subscriber stream still become terminal instead
 	// of leaving a silent pending run.
-	if err := e.db.UpdateRunStatus(run.ID, types.RunRunning); err != nil {
-		return e.failRun(run, repo, fmt.Errorf("update run status: %w", err))
+	var startErr error
+	if run.TrustedConfigSHA != nil && run.GlobalConfigYAML != nil {
+		startErr = e.db.UpdateRunStatusWithConfig(run.ID, types.RunRunning, *run.TrustedConfigSHA, *run.GlobalConfigYAML)
+	} else {
+		startErr = e.db.UpdateRunStatus(run.ID, types.RunRunning)
+	}
+	if startErr != nil {
+		return e.failRun(run, repo, fmt.Errorf("update run status: %w", startErr))
 	}
 	run.Status = types.RunRunning
 	e.emitRunEvent(ipc.EventRunUpdated, run, repo)

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -776,14 +776,11 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 		var inserted *db.StepRound
 		var dbErr error
 		if stepName == types.StepReview {
-			var trustedConfigSHA string
-			var globalConfigYAML, repoConfigYAML []byte
-			if e.config != nil {
-				trustedConfigSHA = e.config.TrustedConfigSHA
-				globalConfigYAML = e.config.ReplayGlobalYAML
-				repoConfigYAML = e.config.ReplayRepoYAML
+			if e.config != nil && e.config.CaptureEvalProvenance {
+				inserted, dbErr = e.db.InsertReviewStepRoundWithProvenance(sr.ID, roundNum, nextTrigger, findingsPtr, fixSummaryPtr, reviewApprovedHeadSHA, reviewStartingHeadSHA, e.config.TrustedConfigSHA, e.config.ReplayGlobalYAML, e.config.ReplayRepoYAML, roundDuration)
+			} else {
+				inserted, dbErr = e.db.InsertReviewStepRound(sr.ID, roundNum, nextTrigger, findingsPtr, fixSummaryPtr, reviewApprovedHeadSHA, roundDuration)
 			}
-			inserted, dbErr = e.db.InsertReviewStepRoundWithProvenance(sr.ID, roundNum, nextTrigger, findingsPtr, fixSummaryPtr, reviewApprovedHeadSHA, reviewStartingHeadSHA, trustedConfigSHA, globalConfigYAML, repoConfigYAML, roundDuration)
 		} else {
 			inserted, dbErr = e.db.InsertStepRound(sr.ID, roundNum, nextTrigger, findingsPtr, fixSummaryPtr, roundDuration)
 		}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -14,19 +14,20 @@ var ErrFatalGateReconciliation = errors.New("fatal gate reconciliation")
 
 // StepContext provides shared resources to pipeline steps during execution.
 type StepContext struct {
-	Ctx              context.Context
-	Run              *db.Run
-	Repo             *db.Repo
-	WorkDir          string
-	Agent            agent.Agent
-	Config           *config.Config
-	DB               *db.DB
-	Log              func(string) // discrete log line (newline-terminated, user-visible + file)
-	LogChunk         func(string) // raw streaming chunk (user-visible + file)
-	LogFile          func(string) // file-only log callback (not shown to user)
-	Fixing           bool         // true when re-executing after a "fix" action
-	SkipFixExecution bool         // replay an already-completed fix round's review turn only
-	PreviousFindings string       // JSON findings from the previous execution (set during fix loop)
+	Ctx                   context.Context
+	Run                   *db.Run
+	Repo                  *db.Repo
+	WorkDir               string
+	Agent                 agent.Agent
+	Config                *config.Config
+	DB                    *db.DB
+	Log                   func(string) // discrete log line (newline-terminated, user-visible + file)
+	LogChunk              func(string) // raw streaming chunk (user-visible + file)
+	LogFile               func(string) // file-only log callback (not shown to user)
+	Fixing                bool         // true when re-executing after a "fix" action
+	SkipFixExecution      bool         // replay an already-completed fix round's review turn only
+	ReviewStartingHeadSHA string
+	PreviousFindings      string // JSON findings from the previous execution (set during fix loop)
 	// StepResultID is the DB row ID of the current step's step_results record.
 	// Steps use it to query their own round history for multi-round prompts.
 	StepResultID string

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -25,6 +25,7 @@ type StepContext struct {
 	LogChunk         func(string) // raw streaming chunk (user-visible + file)
 	LogFile          func(string) // file-only log callback (not shown to user)
 	Fixing           bool         // true when re-executing after a "fix" action
+	SkipFixExecution bool         // replay an already-completed fix round's review turn only
 	PreviousFindings string       // JSON findings from the previous execution (set during fix loop)
 	// StepResultID is the DB row ID of the current step's step_results record.
 	// Steps use it to query their own round history for multi-round prompts.

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -28,7 +28,11 @@ func (s *ReviewStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome,
 
 	reviewScope := fmt.Sprintf("branch changes between %s and %s", baseSHA, sctx.Run.HeadSHA)
 	if sctx.Fixing {
-		reviewScope = fmt.Sprintf("current worktree and HEAD changes relative to base commit %s (starting head %s)", baseSHA, sctx.Run.HeadSHA)
+		startingHeadSHA := sctx.ReviewStartingHeadSHA
+		if startingHeadSHA == "" {
+			startingHeadSHA = sctx.Run.HeadSHA
+		}
+		reviewScope = fmt.Sprintf("current worktree and HEAD changes relative to base commit %s (starting head %s)", baseSHA, startingHeadSHA)
 	}
 
 	// Bounded workload size (changed files + net lines) for local telemetry, so

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -54,7 +54,7 @@ func (s *ReviewStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome,
 	// not an enforced sandbox - the agent has free shell access - so the pinned
 	// regression tests guard the wording, not the runtime.
 	var fixSummary string
-	if sctx.Fixing {
+	if sctx.Fixing && !sctx.SkipFixExecution {
 		previousFindings := sanitizedPreviousFindingsForPrompt(sctx.PreviousFindings)
 		historySection := executionContextPromptSection() + roundHistoryPromptSection(sctx) + userIntentPromptSection(sctx) + testguidance.Rule
 		fixPrompt := fmt.Sprintf(
@@ -247,6 +247,7 @@ Risk assessment (after listing all findings):
 	result, err := sctx.Agent.Run(ctx, agent.RunOpts{
 		Prompt:     prompt,
 		CWD:        sctx.WorkDir,
+		Env:        sctx.Env,
 		JSONSchema: reviewFindingsSchema,
 		OnChunk:    sctx.LogChunk,
 		Purpose:    "review",


### PR DESCRIPTION
## Intent

Build the no-mistakes eval toolkit MVP. Add no-mistakes eval capture <run>, run --cases <set> --candidate <agent+model>, sets, and report. Capture every source run review pass as a portable local review-round case containing a git bundle, SHA-pinned configuration, original findings and gate decisions, baseline metrics, and verdict labels. Replay review only against an isolated candidate using the existing e2edaemon isolation model, never the shared production NM_HOME, and skip push, PR, and CI. Provide corpus inspection before token spend plus per-candidate verdict-level accuracy, token cost, wall time, accuracy-versus-cost frontier, repeats, and honest confidence intervals. Gate decisions are the primary label; the future fixed-PR-comments miss sensor and finding-level labeling/adjudication are phase 1 and must not be built now. Unexpected good candidate findings must be queued, not automatically scored wrong. This must be purely additive and invisible to users who do not use eval: zero changes to default pipeline behavior, daemon critical path, existing CLI output, config requirements, or remote telemetry shape. Eval case data must remain local-only forever: add no export, sharing, synchronization, or remote case-data path, including scaffolding. Honor repository rules: use e2edaemon isolation for replay, safeurl redaction for recorded URLs, a sqlite-first registry, and preserve validation with make lint plus go test -race ./.... Add behavioral tests including fakeagent e2e scenarios and a documentation page under docs/src/content/docs.

## What Changed

- Add opt-in commands to capture portable, local-only review cases and inspect labeled or diversified case sets.
- Replay explicit agent and model candidates against SHA-pinned cases in isolated environments with configurable repeats, without running delivery phases.
- Report verdict agreement, queued unexpected findings, token cost, wall time, confidence intervals, and accuracy-versus-cost frontiers.

## Risk Assessment

🚨 High: Several required eval guarantees remain broken, including candidate process ownership, model enforcement, trusted instruction suppression, and gate-decision labeling.

## Testing

Focused race tests and the fakeagent E2E CLI journey passed, demonstrating portable capture, corpus inspection, isolated review replay, local reporting, and non-penalized unexpected findings; the full user-facing transcript was saved as evidence.

- Evidence: [Eval capture, sets, isolated replay, and report CLI journey](https://github.com/kunchenguid/no-mistakes/blob/61683c9ef772a748a24b6a55c551dabcd95f49d2/.no-mistakes/evidence/fm/nm-eval-mvp-build-r1/eval-journey.txt)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"61683c9ef772a748a24b6a55c551dabcd95f49d2","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 6 issues (5 errors, 1 warning)</summary>

- 🚨 `internal/eval/replay.go:130` - This contradicts the required &#34;never the shared production NM_HOME&#34; isolation. The temporary Paths root at lines 205-213 is unused by the agent launch, while agent subprocesses inherit os.Environ(), including the caller&#39;s production NM_HOME. A candidate can therefore access or mutate shared daemon state. Launch replay through an isolated process/environment boundary with NM_HOME set to the temporary root.
- 🚨 `internal/eval/capture.go:147` - The required &#34;SHA-pinned configuration&#34; is resolved from the gate&#39;s current default-branch ref at capture time, not the SHA used by the source run. If the default branch advances after review, capture records different trusted rules and even derives a different replay base. Persist the trusted SHA/effective configuration when the source run starts and capture that immutable value.
- 🚨 `internal/eval/replay.go:157` - Every captured round is replayed with an initial-review StepContext: Fixing, PreviousFindings, DB, and StepResultID are absent. A source rereview actually received fix provenance, selected/ignored findings, and prior-round history, so the candidate can produce a different verdict merely because its prompt is not the captured review pass. Replay the captured round context without executing the fixer loop.
- 🚨 `internal/eval/replay.go:130` - The required agent+model candidate is not enforced for ACP candidates such as cursor or acp:&lt;target&gt;: NewWithOptions explicitly ignores extraArgs for ACP, so candidateModelArgs never selects the requested model. Line 180 then attributes the requested model when none is reported, concealing the mismatch. Reject unsupported combinations or route model selection through a verified adapter capability.
- 🚨 `internal/eval/report.go:38` - Reports aggregate all historical sessions solely by candidate and then compute one frontier. Candidates run against different sets, corpus versions, or repeat counts are therefore compared as if they shared the same cases, making the required accuracy-versus-cost frontier invalid. Group reports by immutable case cohort/session plan or compare only common case IDs.
- 🚨 `internal/eval/report.go:161` - The required &#34;honest confidence intervals&#34; are not met for a one-case corpus: the code reports a 95% interval of exactly [0,0] or [1,1], implying certainty from one observation. Suppress the interval when uncertainty cannot be estimated or use an interval method that represents finite-sample uncertainty.

🔧 Fix: Fix eval isolation, fidelity, and reporting
4 issues (3 errors, 1 warning) still open:
- 🚨 `internal/daemon/manager.go:853` - The persisted trusted SHA is not honored by loadRecoveredConfig. If a daemon stops after recording SHA A, the default branch advances to B, and the run resumes, recovery fetches and uses B while capture later records A. The replay therefore still cannot reproduce the source review. Recovery must load the persisted run.TrustedConfigSHA rather than repinning from the live branch.
- 🚨 `internal/eval/capture.go:156` - Capture reads the current global config, not the configuration used by the source run. Changing ignore patterns or other review-affecting global settings between execution and capture changes the replay prompt, contradicting the required SHA-pinned original configuration. Persist the source run&#39;s effective review configuration when the run starts and capture that immutable snapshot.
- 🚨 `internal/eval/report.go:193` - The single-case guard does not make the interval honest: two or more uniformly successful or failed cases still bootstrap to [1,1] or [0,0], implying certainty from a finite sample. Use a finite-sample interval that represents uncertainty, or suppress intervals when this bootstrap cannot estimate it.
- ⚠️ `internal/eval/replay.go:446` - QueuedCandidateFindings increments once per unexpected parked replay regardless of evaluation.FindingCount, so a replay with multiple findings is reported by eval sets as only one queued finding. Increment by the persisted finding count or rename the metric and output to queued parks.

🔧 Fix: Count every queued candidate finding
4 errors still open:
- 🚨 `internal/daemon/manager.go:853` - The intent requires &#34;zero changes to ... daemon critical path,&#34; but every normal run now performs a new blocking database write and fails startup if it fails. Persisting eval provenance on the default run path directly contradicts the required opt-in invisibility. Confirm the intended tradeoff or move provenance capture outside the normal run critical path.
- 🚨 `internal/daemon/manager.go:213` - Recovery ignores run.TrustedConfigSHA and repins trusted configuration from the current default branch. If a run records SHA A, the daemon stops, and the branch advances to B, the recovered review uses B while eval capture records A. This violates the required &#34;SHA-pinned configuration.&#34; Recovery must use the persisted SHA for the run.
- 🚨 `internal/eval/capture.go:156` - The intent requires each case to contain &#34;SHA-pinned configuration,&#34; but capture reads the current global config rather than the configuration used by the source review. Changing review-affecting global settings before capture produces a different replay prompt. Persist or otherwise immutably identify the source run&#39;s effective global review configuration.
- 🚨 `internal/eval/report.go:193` - The required &#34;honest confidence intervals&#34; remain unmet for two or more uniformly successful or failed cases: empirical bootstrap resampling returns [1,1] or [0,0], implying certainty from a finite sample. Use a finite-sample interval that represents uncertainty, or suppress intervals when this bootstrap cannot estimate it.

🔧 Fix: Pin replay configuration and correct confidence intervals
4 issues (2 errors, 2 warnings) still open:
- 🚨 `internal/pipeline/executor.go:154` - This still contradicts the required &#34;zero changes to default pipeline behavior, daemon critical path.&#34; Every ordinary run now persists the full global configuration during its mandatory pending-to-running transition, and recovered ordinary runs use that snapshot instead of the current configuration at internal/daemon/manager.go:203. Coalescing the writes does not make this eval provenance invisible to non-eval runs. Move provenance capture outside the normal pipeline path or obtain explicit approval for this behavior change.
- 🚨 `internal/eval/capture.go:206` - Capturing a parked run creates an unlabeled case before the user decides; after approval or fix selection is recorded, a second capture returns the existing case unchanged. The required original gate decision and verdict label therefore remain permanently absent. Either reject capture until the relevant decision is durable or refresh the mutable decision and label when recapturing.
- ⚠️ `internal/eval/capture.go:454` - For resumed Codex sessions, FreshInputTokens is calculated from cumulative raw usage, while the other baseline fields correctly use per-round deltas. Later review rounds therefore overstate their fresh-input baseline. Derive fresh input from DeltaInputTokens minus DeltaCacheReadTokens, bounded at zero.
- ⚠️ `internal/eval/report.go:293` - The implementation now computes a Wilson score interval, but the report still calls it a bootstrap interval and docs/src/content/docs/reference/eval.md:72 promises a paired bootstrap interval. Update both owned outputs to describe the actual Wilson interval so users do not misinterpret the statistic.

🔧 Fix: Correct eval token baselines and interval labeling
3 errors still open:
- 🚨 `internal/pipeline/executor.go:154` - The required &#34;zero changes to default pipeline behavior, daemon critical path&#34; remains violated. Every ordinary run now stores eval provenance during its mandatory running transition, and recovery uses the snapshot instead of current global configuration. Move provenance capture outside normal pipeline execution or obtain explicit approval for this behavior change.
- 🚨 `internal/eval/capture.go:207` - Capturing while a review is parked freezes an unlabeled case before the required original gate decision exists. A later recapture returns that directory unchanged after the user responds, permanently omitting the decision and verdict label. Reject premature capture or refresh decision and label state on recapture.
- 🚨 `internal/eval/model.go:199` - Failed candidate invocations are excluded from the labeled accuracy denominator, so a candidate with one successful replay and many failures can report 100% agreement and dominate the accuracy-versus-cost frontier. Count labeled failures conservatively or make frontier eligibility require complete comparable coverage.

🔧 Fix: Keep eval opt-in and correct capture reporting
4 issues (3 errors, 1 warning) still open:
- 🚨 `internal/eval/capture.go:149` - The required portable case with &#34;SHA-pinned configuration&#34; still does not preserve the source review&#39;s configuration. If the default branch or global config changes after review, capture records the new values and even recomputes the replay base from the new trusted SHA, so the candidate reviews a different prompt and potentially a different diff. Preserving the source pass requires immutable run-time provenance or explicit approval to weaken this criterion.
- 🚨 `internal/eval/replay.go:171` - Fix-round cases are not replayed as the original rereview. The original Review step constructs its review scope before the fixer advances Run.HeadSHA, so &#34;starting head&#34; is the pre-fix commit; replay initializes Run.HeadSHA to ReviewedHeadSHA while skipping the fixer, making the starting head equal the post-fix commit. This changes the provenance prompt and contradicts the requirement to replay each source review pass. Restore the pre-fix head separately from the reviewed worktree head.
- 🚨 `internal/eval/report.go:141` - Failed labeled replays are now scored as misses in verdict accuracy, but the required &#34;honest confidence intervals&#34; still omit them. A candidate with successful completed cases and failed labeled cases therefore gets a Wilson interval calculated from only its successes, inconsistent with its reported accuracy. Include failed labeled repeats as zero scores when constructing per-case values.
- ⚠️ `docs/src/content/docs/reference/eval.md:15` - The documentation says capture waits for a parked review&#39;s gate decision, but Capture immediately returns a &#34;no recorded gate decision&#34; error. Describe the actual retry-after-decision behavior or implement the documented wait.

🔧 Fix: Correct eval capture retry documentation
4 issues (3 errors, 1 warning) still open:
- 🚨 `internal/eval/capture.go:149` - The required cases must contain &#34;SHA-pinned configuration&#34; for the original review pass, but capture resolves the current default-branch ref and reads the current global config. If either changes after review, replay uses a different prompt and potentially a different base diff. Preserve immutable source-review configuration provenance or obtain approval to weaken this criterion.
- 🚨 `internal/eval/replay.go:171` - The requirement to capture every source review pass is still violated for fix rounds. The original rereview&#39;s starting head is the pre-fix commit, while replay sets it to ReviewedHeadSHA, the post-fix commit. This changes the review-scope provenance and workload presented to the candidate. Restore the pre-fix head separately, such as from the preceding review round, while keeping the worktree at the reviewed commit.
- 🚨 `internal/eval/report.go:141` - The required &#34;honest confidence intervals&#34; remain inconsistent with reported accuracy: SummarizeEvaluations counts failed labeled replays as misses, but confidenceInterval drops them. A candidate with failures can therefore receive an interval calculated only from successful invocations. Include failed labeled repeats as zero scores in their cases.
- ⚠️ `internal/agent/env_test.go:74` - TestEverySupportedAdapterPropagatesGateMarkerThroughCanonicalEnv only reads adapter source files and searches for an implementation string. This is directly within the changed environment-propagation surface and violates the test-quality rule because dead or behaviorally incorrect code can satisfy it. Replace it with executable adapter or subprocess assertions that observe the child environment.

🔧 Fix: Preserve eval provenance and confidence accuracy
4 errors still open:
- 🚨 `internal/eval/capture.go:149` - The required &#34;SHA-pinned configuration&#34; for the original review is still reconstructed heuristically. A default-branch commit can land while the review agent is running and still precede the round&#39;s completion timestamp, so rev-list selects configuration the review never used. Global configuration can likewise change during the review or be deleted afterward without the mtime check detecting it. Capture cannot reconstruct exact source configuration from these timestamps; preserve immutable provenance at the configuration-use boundary or obtain approval to weaken this requirement.
- 🚨 `internal/eval/replay.go:175` - Setting Run.HeadSHA to StartingHeadSHA fixes the rereview scope text but makes the prompt&#39;s target commit the pre-fix commit. In the original Review execution, reviewScope is computed before the fixer runs, while target commit is formatted after executeFixMode advances Run.HeadSHA to the post-fix commit. Replay therefore still does not reproduce the captured pass. Preserve separate starting and reviewed heads in the Review context instead of overloading Run.HeadSHA.
- 🚨 `internal/eval/replay.go:115` - The intent explicitly requires replay to use the existing e2edaemon isolation model, but replay creates an ad hoc temporary directory and never registers e2edaemon ownership. It also overrides only NM_HOME at line 202, leaving HOME and candidate user state shared. Route replay through the required isolation boundary, including an isolated home and its lifecycle ownership.
- 🚨 `internal/eval/report.go:194` - A candidate is frontier-eligible whenever any replay reports tokens: averageTokens silently averages only reported rows, while markFrontier does not require complete token coverage. A candidate with one reported replay and several completed uninstrumented replays can therefore receive an understated cost and appear on the required accuracy-versus-cost frontier. Treat cost as unknown for frontier purposes unless all comparable replays report usage, or explicitly model partial coverage.

🔧 Fix: Preserve exact replay provenance and isolation
3 errors still open:
- 🚨 `internal/pipeline/executor.go:786` - This contradicts the required &#34;zero changes to default pipeline behavior, daemon critical path.&#34; Every ordinary Review round now serializes and persists the full global and effective repository configurations in the mandatory step-round write, even when eval is never used. Move provenance collection outside normal pipeline execution or obtain explicit approval for this tradeoff.
- 🚨 `internal/eval/replay.go:136` - The required e2edaemon isolation model is only nominally acquired. The entry records no candidate PID, and e2edaemon&#39;s reaper only recognizes `daemon run --root` processes, so an eval process killed during a candidate invocation leaves that candidate untracked and unrecoverable. Add candidate-aware process ownership at the launch boundary so inventory recovery can identify and terminate the exact eval process tree.
- 🚨 `internal/eval/capture.go:435` - Fix-round baseline metrics include every Review-step invocation for the round, including the `review-fix` agent that replay intentionally skips. The captured baseline therefore does not describe the source review pass being replayed and can substantially overstate its tokens and wall time. Aggregate only `Purpose == &#34;review&#34;` invocations, and mark token usage unavailable if any included invocation lacks trustworthy deltas.

🔧 Fix: Isolate eval provenance, ownership, and baseline metrics
6 issues (5 errors, 1 warning) still open:
- 🚨 `internal/eval/replay.go:399` - The required e2edaemon ownership remains unreachable for managed OpenCode and Rovo Dev candidates. observedAgent records only lifecycle start events, but startServerWithPort emits none, so their inventory PID remains zero. If eval is killed while either server runs, ReapAll unregisters the entry without terminating the server. Register managed-server startup at its shared launch boundary.
- 🚨 `internal/e2edaemon/process_unix.go:100` - The claimed durable process ownership still does not isolate the complete candidate tree. A candidate tool descendant that calls setsid or setpgid leaves the candidate process group; terminateProcessTree kills only -pid, then declares success when the parent exits and unregisters ownership while the detached descendant remains. Use the existing worktree-identity procreap boundary, or equivalent identity-based cleanup, before releasing eval ownership.
- 🚨 `internal/eval/replay.go:383` - The required agent+model candidate path is not implemented for OpenCode. candidateModelArgs passes --model into `opencode serve`, whose supported serve flags do not include model selection, so every OpenCode replay fails at server startup. Select the model through OpenCode&#39;s message/session API or reject this unsupported candidate before token spend.
- 🚨 `internal/eval/replay.go:166` - Replay constructs the candidate directly but omits the normal EnsureGateNeutralized check. For a captured configuration with disable_project_settings enabled, unsupported candidates such as OpenCode can therefore launch with restored repository instructions active, violating both the trusted configuration and isolated-candidate requirement. Apply the same fail-closed guard used by newPipelineAgent.
- 🚨 `internal/eval/capture.go:488` - The required gate-decision label is lost when a user approves a parked warning/error whose action is auto-fix after the fix budget is exhausted. The executor parks based on severity, but decisionForRound recognizes completed approval only when findings contain ask-user, leaving this recorded human pass unlabeled. Persist approval against the exact round at the approval transition and derive the verdict from that durable decision.
- ⚠️ `internal/eval/report.go:100` - Running the same candidate and cohort twice merges both sessions, but repeatCount deduplicates repeat numbers. Two 3-repeat sessions are therefore reported as six replays across three repeats even though confidence and averages consume all six observations per case. Report total per-case repetitions or distinguish sessions explicitly.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./internal/eval ./internal/cli ./internal/e2edaemon ./internal/config ./internal/db ./internal/agent`
- `bash scripts/e2e.sh -tags=e2e -count=1 -timeout 180s -run '^TestEvalJourney$' -v ./internal/e2e`
- `Public CLI journey: captured a review case, inspected sets, replayed an isolated candidate, and generated a local-only report with queued unexpected findings and cost-frontier metrics`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
