### PR TITLE
fix(branchsync): preserve aborted detached heads

### DIFF
--- a/internal/branchsync/recover_test.go
+++ b/internal/branchsync/recover_test.go
@@ -20,6 +20,10 @@ type cancellationRaceStep struct {
 	committed chan string
 }
 
+type unreferencedCancellationStep struct {
+	committed chan string
+}
+
 type unreachedCancellationStep struct{}
 
 type skippedDeliveryStep struct {
@@ -55,6 +59,27 @@ func (s *cancellationRaceStep) Execute(sctx *pipelinepkg.StepContext) (*pipeline
 		return nil, err
 	}
 	if _, err := gitpkg.Run(sctx.Ctx, sctx.WorkDir, "update-ref", "refs/heads/feature/recover", head); err != nil {
+		return nil, err
+	}
+	s.committed <- head
+	<-sctx.Ctx.Done()
+	return nil, context.Cause(sctx.Ctx)
+}
+
+func (s *unreferencedCancellationStep) Name() types.StepName { return types.StepReview }
+
+func (s *unreferencedCancellationStep) Execute(sctx *pipelinepkg.StepContext) (*pipelinepkg.StepOutcome, error) {
+	if err := os.WriteFile(filepath.Join(sctx.WorkDir, "fix.txt"), []byte("pipeline fix\n"), 0o644); err != nil {
+		return nil, err
+	}
+	if _, err := gitpkg.Run(sctx.Ctx, sctx.WorkDir, "add", "fix.txt"); err != nil {
+		return nil, err
+	}
+	if _, err := gitpkg.Run(sctx.Ctx, sctx.WorkDir, "commit", "-m", "no-mistakes(review): fix"); err != nil {
+		return nil, err
+	}
+	head, err := gitpkg.HeadSHA(sctx.Ctx, sctx.WorkDir)
+	if err != nil {
 		return nil, err
 	}
 	s.committed <- head
@@ -689,6 +714,76 @@ func TestCancellationReconcilesCommittedWorktreeHeadBeforeReleaseClassification(
 	}
 	if state.NextAction == nil || state.NextAction.Code != "recover_custody" {
 		t.Fatalf("cancelled committed next action = %#v", state.NextAction)
+	}
+}
+
+// TestCancellationMakesCommittedDetachedHeadReachableBeforeTerminalRecord
+// reproduces the abort custody gap: a review agent can commit in the detached
+// run worktree without moving the gate branch ref, then abort can terminalize
+// the run after reading that worktree HEAD. The recorded preserved head must be
+// reachable from the gate before branch-sync advertises custody recovery.
+func TestCancellationMakesCommittedDetachedHeadReachableBeforeTerminalRecord(t *testing.T) {
+	f := newUnmovedRecoverFixture(t, types.RunCancelled)
+	if err := f.db.UpdateRunStatus(f.run.ID, types.RunPending); err != nil {
+		t.Fatal(err)
+	}
+	f.run.Status = types.RunPending
+
+	managed := filepath.Join(t.TempDir(), "managed")
+	if err := gitpkg.WorktreeAdd(f.ctx, f.gate, managed, f.submitted); err != nil {
+		t.Fatal(err)
+	}
+	configureIdentity(t, managed)
+
+	p := paths.WithRoot(t.TempDir())
+	if err := p.EnsureDirs(); err != nil {
+		t.Fatal(err)
+	}
+	step := &unreferencedCancellationStep{committed: make(chan string, 1)}
+	executor := pipelinepkg.NewExecutor(f.db, p, nil, nil, []pipelinepkg.Step{step}, nil)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- executor.Execute(ctx, f.run, f.repo, managed)
+	}()
+
+	committed := <-step.committed
+	cancel(errors.New(types.RunCancelReasonAbortedByUser))
+	if err := <-done; err == nil {
+		t.Fatal("cancelled executor returned nil")
+	}
+
+	terminal, err := f.db.GetRun(f.run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if terminal.HeadSHA != committed {
+		t.Fatalf("terminal run head = %s, want committed detached head %s", terminal.HeadSHA, committed)
+	}
+	if got := mustRun(t, f.gate, "rev-parse", "refs/heads/feature/recover"); got != committed {
+		t.Fatalf("gate branch = %s, want committed detached head %s", got, committed)
+	}
+	state := f.service.InspectCached(f.ctx)
+	if state.State != StatePipelineOwned || state.Safety != "blocked_pipeline_owned_recoverable" {
+		t.Fatalf("cancelled committed state = %#v", state)
+	}
+	if state.NextAction == nil || state.NextAction.Code != "recover_custody" {
+		t.Fatalf("cancelled committed next action = %#v", state.NextAction)
+	}
+}
+
+func TestInspectRefusesCustodyRecoveryForUnreachableVerifiedHead(t *testing.T) {
+	f := newRecoverFixture(t, types.RunCancelled)
+	if _, err := gitpkg.Run(f.ctx, f.gate, "update-ref", "-d", "refs/heads/feature/recover"); err != nil {
+		t.Fatal(err)
+	}
+
+	state := f.service.InspectCached(f.ctx)
+	if state.State != StatePipelineOwned || state.Safety != "blocked_pipeline_owned_unreachable" {
+		t.Fatalf("unreachable verified head state = %#v", state)
+	}
+	if state.NextAction != nil {
+		t.Fatalf("unreachable verified head advertised next action = %#v", state.NextAction)
 	}
 }
 

--- a/internal/branchsync/sync.go
+++ b/internal/branchsync/sync.go
@@ -1336,6 +1336,12 @@ func (s *Service) classifyPipelineOwned(ctx context.Context, state *State, run *
 	state.Pipeline.Phase = "pre_push"
 	state.Relation = relationBetween(ctx, s.workDir(), state.Local.Head, run.HeadSHA)
 	if terminalRunStatus(run.Status) {
+		if !s.terminalHeadReachable(ctx, *state, run) {
+			state.Safety = "blocked_pipeline_owned_unreachable"
+			state.Error = "the terminal run recorded a preserved pipeline head that is not reachable from the local repository or gate; custody recovery is unavailable and no local follow-up commit is safe"
+			state.NextAction = nil
+			return
+		}
 		state.Safety = "blocked_pipeline_owned_recoverable"
 		state.Error = "the run finished " + string(run.Status) + " with unpublished pipeline commits preserved in the local gate; recover custody before any local follow-up commit"
 		state.NextAction = &NextAction{Code: "recover_custody", Command: "no-mistakes axi sync --recover"}
@@ -1344,6 +1350,24 @@ func (s *Service) classifyPipelineOwned(ctx context.Context, state *State, run *
 	state.Safety = "blocked_pipeline_owned"
 	state.Error = activeMessage
 	state.NextAction = &NextAction{Code: "continue_active_run", Command: "no-mistakes axi status"}
+}
+
+// terminalHeadReachable is the read-only custody proof used before advertising
+// recover_custody. A verified terminal head must still be reachable from the
+// invoking branch or from the gate branch that recovery will read.
+func (s *Service) terminalHeadReachable(ctx context.Context, state State, run *db.Run) bool {
+	if run == nil || strings.TrimSpace(run.HeadSHA) == "" {
+		return false
+	}
+	if objectExists(ctx, s.workDir(), run.HeadSHA) &&
+		(state.Local.Head == run.HeadSHA || isAncestor(ctx, s.workDir(), run.HeadSHA, state.Local.Head)) {
+		return true
+	}
+	if strings.TrimSpace(s.GateDir) == "" {
+		return false
+	}
+	gateHead, err := git.Run(ctx, s.GateDir, "rev-parse", "refs/heads/"+state.Local.Branch+"^{commit}")
+	return err == nil && gateHead == run.HeadSHA
 }
 
 // classifyUserOwned reports a branch released by its terminal outcome: the

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -1277,13 +1277,59 @@ func (e *Executor) reconcileTerminalRunHead(run *db.Run) (string, bool) {
 		return "", false
 	}
 	if observed == recorded {
+		if !e.preserveTerminalHead(ctx, run, observed) {
+			return "", false
+		}
 		return recorded, true
 	}
 	if _, err := git.Run(ctx, e.workDir, "merge-base", "--is-ancestor", recorded, observed); err != nil {
 		slog.Warn("worktree head is not a verified descendant before terminalization", "run", run.ID, "error", err)
 		return "", false
 	}
+	if !e.preserveTerminalHead(ctx, run, observed) {
+		return "", false
+	}
 	return observed, true
+}
+
+// preserveTerminalHead makes the head recorded during terminalization
+// reachable from the gate branch before the database records it. A pipeline
+// agent can commit while the run worktree is detached; observing that HEAD is
+// not enough because worktree cleanup can leave the commit without a durable
+// branch reference. The compare-and-swap keeps a concurrent branch change
+// fail-closed instead of overwriting it.
+func (e *Executor) preserveTerminalHead(ctx context.Context, run *db.Run, observed string) bool {
+	if run == nil || strings.TrimSpace(e.workDir) == "" || strings.TrimSpace(observed) == "" {
+		return false
+	}
+	branch := strings.TrimSpace(run.Branch)
+	branch = strings.TrimPrefix(branch, "refs/heads/")
+	if branch == "" {
+		slog.Warn("cannot preserve terminal head without a branch", "run", run.ID)
+		return false
+	}
+	ref := "refs/heads/" + branch
+	gateHead, err := git.Run(ctx, e.workDir, "rev-parse", ref+"^{commit}")
+	if err != nil {
+		slog.Warn("cannot resolve gate branch before terminalization", "run", run.ID, "branch", branch, "error", err)
+		return false
+	}
+	if gateHead != observed {
+		if _, err := git.Run(ctx, e.workDir, "merge-base", "--is-ancestor", gateHead, observed); err != nil {
+			slog.Warn("gate branch does not precede terminal worktree head", "run", run.ID, "branch", branch, "error", err)
+			return false
+		}
+		if _, err := git.Run(ctx, e.workDir, "update-ref", ref, observed, gateHead); err != nil {
+			slog.Warn("failed to preserve terminal worktree head in gate branch", "run", run.ID, "branch", branch, "error", err)
+			return false
+		}
+	}
+	verified, err := git.Run(ctx, e.workDir, "rev-parse", ref+"^{commit}")
+	if err != nil || verified != observed {
+		slog.Warn("terminal worktree head was not durably reachable from gate branch", "run", run.ID, "branch", branch, "error", err)
+		return false
+	}
+	return true
 }
 
 // --- event helpers ---


### PR DESCRIPTION
## Summary

Terminalization now makes a detached run-worktree HEAD reachable from the gate branch before recording terminal head evidence. Branch-sync also refuses to advertise `recover_custody` when a verified preserved head is unreachable from both the local branch and the gate.

Disclosure: this is an AI-assisted contribution. The task owner explicitly requested a direct PR for this custody fix, so the no-mistakes pipeline was not run.

## What changed

- `internal/pipeline/executor.go`: atomically advances the gate branch to a verified terminal worktree descendant before storing the terminal head.
- `internal/branchsync/sync.go`: checks local-or-gate reachability before exposing custody recovery and emits a blocking diagnostic otherwise.
- `internal/branchsync/recover_test.go`: covers the detached-commit abort reproduction and the unreachable-head refusal polarity.

## Verification

- `go test ./internal/branchsync ./internal/pipeline ./internal/daemon ./internal/cli -count=1` → passed.
- `go test -tags=e2e ./internal/e2e -run TestAxiCustodyRecoveryJourney -count=1 -v` → passed.
- `make lint` → passed (`genskill --check`, `go vet ./...`).
- `go test -race ./...` → passed.
- `go build -o ./bin/no-mistakes ./cmd/no-mistakes` → passed.
- `make fmt` and `git diff --check` → passed.

## Not covered / follow-ups

- The full `make e2e` suite was not run; the focused real-binary custody journey passed.
- The live provider push path was not exercised; the fix is covered by local gate and detached-worktree tests.
- The repository-required no-mistakes PR signature is not present because this task explicitly required direct PR delivery.

## Test plan

- [x] Run the focused branch-sync and pipeline tests.
- [x] Run the real-binary custody recovery journey.
- [x] Run lint, race tests, formatting, and build checks.
- [ ] Run the full `make e2e` suite in CI.
