### PR TITLE
docs: add review authority policy page and sidebar registration test

### DIFF
--- a/.no-mistakes.yaml
+++ b/.no-mistakes.yaml
@@ -26,6 +26,11 @@ document:
     docs/src/content/docs/reference/environment.md.
     The daemon lifecycle model (singleton lock, lifecycle guard, crash recovery)
     is owned by docs/src/content/docs/concepts/daemon.md.
+    The authority-band policy (how much authority a gate may exercise on its own,
+    the non-negotiables, and the measurement loop) is owned by
+    docs/src/content/docs/concepts/review-authority.md; the auto_fix and
+    finding-action mechanics it builds on stay with their reference and concept
+    owners.
     Agent-driving guidance is owned by the skill body in internal/skill/skill.go
     and the live axi output strings; docs/src/content/docs/guides/agents.md keeps
     only the canonical invariant sentences pinned by internal/cli/axi_guidance_test.go.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ Safest local verification sequence after non-trivial changes:
 
 - Keep `README.md` concise and high-level; the bar needs to be extremely high for what shows up there.
 - Most documentation lives in `docs/`, the published docs site.
+- A new page under `docs/src/content/docs` must also be registered in the `docs/astro.config.mjs` sidebar (the splash `index.mdx` is the only exemption): an unregistered page still builds and answers its URL, so nothing fails except navigation. Regressions: `TestDocsSidebarRegistersEveryAuthoredPage`, `TestDocsSidebarHasNoEntryWithoutAPage`.
 - One owner per fact: `docs/src/content/docs/reference/global-config.md` and `docs/src/content/docs/reference/repo-config.md` own configuration keys, `docs/src/content/docs/reference/environment.md` owns environment variables and the telemetry local/remote split, `docs/src/content/docs/concepts/daemon.md` owns the daemon lifecycle model, `docs/src/content/docs/concepts/review-authority.md` owns the authority-band policy (how much authority a gate may exercise, the non-negotiables, and the measurement loop) while the `auto_fix` and finding-action mechanics stay with their reference and concept owners, and guides pages explain purpose and link to those owners instead of restating tables and examples.
 - The `document.instructions` block in `.no-mistakes.yaml` states this ownership map for the pipeline's document step; update it when ownership moves.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Safest local verification sequence after non-trivial changes:
 
 - Keep `README.md` concise and high-level; the bar needs to be extremely high for what shows up there.
 - Most documentation lives in `docs/`, the published docs site.
-- One owner per fact: `docs/src/content/docs/reference/global-config.md` and `docs/src/content/docs/reference/repo-config.md` own configuration keys, `docs/src/content/docs/reference/environment.md` owns environment variables and the telemetry local/remote split, `docs/src/content/docs/concepts/daemon.md` owns the daemon lifecycle model, and guides pages explain purpose and link to those owners instead of restating tables and examples.
+- One owner per fact: `docs/src/content/docs/reference/global-config.md` and `docs/src/content/docs/reference/repo-config.md` own configuration keys, `docs/src/content/docs/reference/environment.md` owns environment variables and the telemetry local/remote split, `docs/src/content/docs/concepts/daemon.md` owns the daemon lifecycle model, `docs/src/content/docs/concepts/review-authority.md` owns the authority-band policy (how much authority a gate may exercise, the non-negotiables, and the measurement loop) while the `auto_fix` and finding-action mechanics stay with their reference and concept owners, and guides pages explain purpose and link to those owners instead of restating tables and examples.
 - The `document.instructions` block in `.no-mistakes.yaml` states this ownership map for the pipeline's document step; update it when ownership moves.
 
 **Agent-Guidance Surfaces**

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -30,6 +30,7 @@ export default defineConfig({
             { label: "The Gate Model", slug: "concepts/gate-model" },
             { label: "Pipeline", slug: "concepts/pipeline" },
             { label: "Auto-Fix Loop", slug: "concepts/auto-fix" },
+            { label: "Review Authority", slug: "concepts/review-authority" },
             { label: "Daemon & Worktrees", slug: "concepts/daemon" },
           ],
         },

--- a/docs/src/content/docs/concepts/review-authority.md
+++ b/docs/src/content/docs/concepts/review-authority.md
@@ -33,14 +33,12 @@ risk posture — never something a single run can escalate on its own.
 | **L3 — Scoped full-auto** | Full autonomy inside a bounded, measured, reversible domain (e.g. generated docs, dependency bumps, lint normalization). | Explicit repo policy declaring the domain; still never for irreversible actions. |
 
 **The shipped default sits between L0 and L1.** Out of the box `auto_fix.review`
-is `0`, so every review finding parks for a decision, while the Test, CI,
-Rebase, and — when `commands.lint` is configured — Lint steps each auto-fix
-within their attempt limits. The Document step applies its fixes during its own
-pass rather than through a follow-up loop, and unresolved documentation findings
-pause for approval. A repository that wants strict L0 must set the looping steps
-to zero explicitly; the
+is `0`, so every review finding parks for a decision, while the remaining
+looping steps fix within their attempt limits. A repository that wants strict L0
+must set those steps to zero explicitly. The
 [`auto_fix` field reference](/no-mistakes/reference/global-config/#auto_fix)
-owns the per-step defaults and which steps the limit applies to.
+owns the per-step defaults, which steps the limit applies to, and the steps that
+fix during their own pass instead of through a follow-up loop.
 
 **Never in any band:** data deletion, credential changes, publishing
 artifacts, or force-pushing over unincorporated upstream commits. The remote
@@ -53,9 +51,11 @@ non-reversible actions.
    instructs agents to stop and ask for review and merge. Keep it that way.
    Automation may *prepare* a merge; it never *performs* one.
 2. **Unclassified findings fail closed.** A finding without an `action` is
-   treated as `ask-user`. Preserve this invariant in every step that emits
-   findings, and treat any change that would make the default permissive as a
-   security regression.
+   treated as `ask-user` — the
+   [finding-action model](/no-mistakes/concepts/auto-fix/#finding-actions) owns
+   that behavior. Preserve this invariant in every step that emits findings, and
+   treat any change that would make the default permissive as a security
+   regression.
 3. **`ask-user` is not auto-fixable.** Intent-sensitive findings exist
    precisely because judgment is required. No `auto_fix` limit may convert an
    `ask-user` finding into an unattended fix.

--- a/docs/src/content/docs/concepts/review-authority.md
+++ b/docs/src/content/docs/concepts/review-authority.md
@@ -59,10 +59,12 @@ non-reversible actions.
 3. **`ask-user` is not auto-fixable.** Intent-sensitive findings exist
    precisely because judgment is required. No `auto_fix` limit may convert an
    `ask-user` finding into an unattended fix. Two overrides do resolve
-   `ask-user` findings unattended — TUI yolo mode and
-   `no-mistakes axi run --yes` — and both are deliberate per-run consent given
-   before the run starts. The invariant is that unattended resolution of an
-   `ask-user` finding always requires explicit consent, never the default.
+   `ask-user` findings unattended: `no-mistakes axi run --yes`, explicit
+   consent given before the run starts, and TUI yolo mode, a live toggle
+   pressed with `y` while a run is being watched. The invariant is that
+   unattended resolution of an `ask-user` finding always requires explicit,
+   active consent — before the run or live while watching — and is never the
+   default.
 4. **Escalation is frictionless.** A human can pause, respond to, or abort
    any run at any point (`no-mistakes axi respond` / TUI / `axi abort`).
    Override must never require blaming the requester.

--- a/docs/src/content/docs/concepts/review-authority.md
+++ b/docs/src/content/docs/concepts/review-authority.md
@@ -1,0 +1,108 @@
+---
+title: Review Authority Policy
+description: When the gate may act on its own, when it must escalate, and how to measure the outcome.
+---
+
+# Review Authority Policy
+
+This policy defines **how much authority a no-mistakes gate may exercise on
+its own** — which findings it may auto-fix, which must pause for a human, and
+how to measure whether the authority granted is earning its keep.
+
+It is the policy layer over the mechanics documented in
+[auto-fix](/no-mistakes/concepts/auto-fix) and the
+[gate model](/no-mistakes/concepts/gate-model). The mechanics are
+authority-agnostic: `auto_fix` limits, finding `action` classes, yolo consent.
+This page decides what a given repository *should* configure, and what the
+gate must never do regardless of configuration.
+
+The model is adapted from Intercom's AI PR-approval operating system
+(19.2% of PRs auto-approved with zero reverts in pilot, ~10x lower revert
+rate on AI-authored code), generalized to this gate's vocabulary.
+
+## The authority bands
+
+Every gate run operates in one of four bands. The band is a *repository
+policy choice*, expressed through `.no-mistakes.yaml` and the repo's own
+risk posture — never something a single run can escalate on its own.
+
+| Band | What the gate may do | Mechanism |
+|---|---|---|
+| **L0 — Advisory** | Review, comment, report. Every finding parks for a decision; nothing is fixed or pushed without a human action. | `auto_fix` all zero; review step always pauses. Default for new repos. |
+| **L1 — Human-clicks** | The gate may fix findings, but the merge decision stays with a human; `ask-user` findings always pause; yolo is explicit per-run consent, not standing authority. | `auto_fix.review` > 0 only for findings classed `auto-fix`; `ask-user` always pauses; yolo documented as consent, never default. |
+| **L2 — Conditional auto** | Within hard caps (change size, scope, finding class), the gate may fix, re-verify, and push unattended; anything above a cap or outside the class pauses. | Per-repo `auto_fix` bands + size/scope caps; review step auto-fixes only within class; caps enforced by the gate, not the prompt. |
+| **L3 — Scoped full-auto** | Full autonomy inside a bounded, measured, reversible domain (e.g. generated docs, dependency bumps, lint normalization). | Explicit repo policy declaring the domain; still never for irreversible actions. |
+
+**Never in any band:** data deletion, credential changes, publishing
+artifacts, or force-pushing over unincorporated upstream commits. The remote
+data-loss guard is the floor; this policy extends the same logic to
+non-reversible actions.
+
+## Non-negotiables
+
+1. **The merge decision stays human.** The gate's `checks-passed` outcome
+   instructs agents to stop and ask for review and merge. Keep it that way.
+   Automation may *prepare* a merge; it never *performs* one.
+2. **Unclassified findings fail closed.** A finding without an `action` is
+   treated as `ask-user`. Preserve this invariant in every step that emits
+   findings, and treat any change that would make the default permissive as a
+   security regression.
+3. **`ask-user` is not auto-fixable.** Intent-sensitive findings exist
+   precisely because judgment is required. No `auto_fix` limit may convert an
+   `ask-user` finding into an unattended fix.
+4. **Escalation is frictionless.** A human can pause, respond to, or abort
+   any run at any point (`no-mistakes axi respond` / TUI / `axi abort`).
+   Override must never require blaming the requester.
+5. **Evidence parity.** A run's record — findings, fix commits, step logs,
+   PR link, intent — must be reconstructable for an auditor without any
+   human in the loop having been the AI. The gate's SQLite state plus the PR
+   trail is the audit surface; keep it complete.
+6. **Shrink before you investigate.** Any revert or incident attributable to
+   a change the gate auto-approved or auto-fixed drops the repository's band
+   by one immediately. Investigate after shrinking, never before.
+
+## The measurement loop
+
+Authority is granted on evidence and shrinks on evidence. For each
+repository running above L0, track:
+
+- **Revert rate of gated PRs** (the outcome currency — same class of metric
+  as Intercom's 0.53% vs 5.39%)
+- **Finding classes by step** (auto-fix / ask-user / no-op counts; rising
+  ask-user rate in a step = the step's guidance is degrading or the work is
+  getting harder)
+- **Auto-fix success rate** (fixes that survive re-verification vs fixes
+  that re-fail)
+- **Parked duration** (how long runs wait on human decisions; growing
+  duration = the gate is becoming the bottleneck again)
+- **Incidents touching gated branches** (the hardening signal)
+
+Expansion rules: raise a band only after a measured interval with the
+current band's adverse signals at or below baseline. There is no time-based
+promotion; there is only evidence-based promotion.
+
+## Per-repo risk tiers
+
+`.no-mistakes.yaml` is where the band is declared. Suggested posture:
+
+| Repo class | Band | Notes |
+|---|---|---|
+| Docs, generated files, dependency bumps | L2 | Small diffs, reversible, CI-verified |
+| Application code, library code | L1 | Auto-fix within class; ask-user pauses |
+| Security-sensitive, data-critical, public-facing | L0–L1 | Any change touching auth, payments, or data paths escalates regardless of band |
+
+Size caps belong in the review step's own guidance: a diff beyond a declared
+threshold pauses for a human even inside L2. The cap is a gate rule, not a
+prompt preference — it must be enforced where the decision is made.
+
+## Known gaps (deferred)
+
+- No built-in outcome telemetry (revert/incident tracking per gated PR).
+  Until it exists, the measurement loop is a manual or external process; the
+  policy should be adopted in repos that can run it.
+- Review-lens decomposition (specialist sub-reviews: intent alignment,
+  safety, logic, best practices) is prompt/agent territory today, not a gate
+  mechanism. The policy treats it as a future review-step capability.
+- A helpfulness flywheel (engineers flag whether review comments were
+  useful; the feedback sharpens review guidance) needs a feedback capture
+  surface that does not exist yet.

--- a/docs/src/content/docs/concepts/review-authority.md
+++ b/docs/src/content/docs/concepts/review-authority.md
@@ -3,20 +3,19 @@ title: Review Authority Policy
 description: When the gate may act on its own, when it must escalate, and how to measure the outcome.
 ---
 
-# Review Authority Policy
-
 This policy defines **how much authority a no-mistakes gate may exercise on
 its own** — which findings it may auto-fix, which must pause for a human, and
 how to measure whether the authority granted is earning its keep.
 
 It is the policy layer over the mechanics documented in
-[auto-fix](/no-mistakes/concepts/auto-fix) and the
-[gate model](/no-mistakes/concepts/gate-model). The mechanics are
+[auto-fix](/no-mistakes/concepts/auto-fix/) and the
+[gate model](/no-mistakes/concepts/gate-model/). The mechanics are
 authority-agnostic: `auto_fix` limits, finding `action` classes, yolo consent.
 This page decides what a given repository *should* configure, and what the
 gate must never do regardless of configuration.
 
-The model is adapted from Intercom's AI PR-approval operating system
+The model is adapted from Intercom's
+[AI PR-approval operating system](https://www.intercom.com/blog/ai-is-approving-our-pull-requests-heres-how-we-made-it-safe/)
 (19.2% of PRs auto-approved with zero reverts in pilot, ~10x lower revert
 rate on AI-authored code), generalized to this gate's vocabulary.
 
@@ -28,10 +27,17 @@ risk posture — never something a single run can escalate on its own.
 
 | Band | What the gate may do | Mechanism |
 |---|---|---|
-| **L0 — Advisory** | Review, comment, report. Every finding parks for a decision; nothing is fixed or pushed without a human action. | `auto_fix` all zero; review step always pauses. Default for new repos. |
+| **L0 — Advisory** | Review, comment, report. Every finding parks for a decision; nothing is fixed or pushed without a human action. | Every `auto_fix` step set to zero. This is an opt-in posture, not the shipped default. |
 | **L1 — Human-clicks** | The gate may fix findings, but the merge decision stays with a human; `ask-user` findings always pause; yolo is explicit per-run consent, not standing authority. | `auto_fix.review` > 0 only for findings classed `auto-fix`; `ask-user` always pauses; yolo documented as consent, never default. |
-| **L2 — Conditional auto** | Within hard caps (change size, scope, finding class), the gate may fix, re-verify, and push unattended; anything above a cap or outside the class pauses. | Per-repo `auto_fix` bands + size/scope caps; review step auto-fixes only within class; caps enforced by the gate, not the prompt. |
+| **L2 — Conditional auto** | Within hard caps (change size, scope, finding class), the gate may fix, re-verify, and push unattended; anything above a cap or outside the class pauses. | Per-step `auto_fix` limits; review step auto-fixes only within class. Size and scope caps are not implemented yet — see [Known gaps](#known-gaps-deferred). |
 | **L3 — Scoped full-auto** | Full autonomy inside a bounded, measured, reversible domain (e.g. generated docs, dependency bumps, lint normalization). | Explicit repo policy declaring the domain; still never for irreversible actions. |
+
+**The shipped default sits between L0 and L1.** Out of the box `auto_fix.review`
+is `0`, so every review finding parks for a decision, while the Lint, Test,
+Document, CI, and Rebase steps each auto-fix within their attempt limits. A
+repository that wants strict L0 must set those steps to zero explicitly; the
+[`auto_fix` field reference](/no-mistakes/reference/global-config/#auto_fix)
+owns the per-step defaults.
 
 **Never in any band:** data deletion, credential changes, publishing
 artifacts, or force-pushing over unincorporated upstream commits. The remote
@@ -67,7 +73,8 @@ Authority is granted on evidence and shrinks on evidence. For each
 repository running above L0, track:
 
 - **Revert rate of gated PRs** (the outcome currency — same class of metric
-  as Intercom's 0.53% vs 5.39%)
+  as Intercom's
+  [0.53% vs 5.39%](https://www.intercom.com/blog/the-safety-of-speed-shipping-code-at-intercom/))
 - **Finding classes by step** (auto-fix / ask-user / no-op counts; rising
   ask-user rate in a step = the step's guidance is degrading or the work is
   getting harder)
@@ -83,7 +90,9 @@ promotion; there is only evidence-based promotion.
 
 ## Per-repo risk tiers
 
-`.no-mistakes.yaml` is where the band is declared. Suggested posture:
+There is no dedicated band key today. A band is expressed through the per-step
+`auto_fix` limits in `.no-mistakes.yaml` plus the repository's own written
+policy. Suggested posture:
 
 | Repo class | Band | Notes |
 |---|---|---|
@@ -91,12 +100,15 @@ promotion; there is only evidence-based promotion.
 | Application code, library code | L1 | Auto-fix within class; ask-user pauses |
 | Security-sensitive, data-critical, public-facing | L0–L1 | Any change touching auth, payments, or data paths escalates regardless of band |
 
-Size caps belong in the review step's own guidance: a diff beyond a declared
-threshold pauses for a human even inside L2. The cap is a gate rule, not a
-prompt preference — it must be enforced where the decision is made.
-
 ## Known gaps (deferred)
 
+- No dedicated band key. Declaring `L2` in `.no-mistakes.yaml` is not
+  possible today; a repository approximates its band with per-step `auto_fix`
+  limits and records the intent outside the config.
+- No size or scope caps. A diff beyond a declared threshold should pause for a
+  human even inside L2, and that cap must be a gate rule enforced where the
+  decision is made rather than a prompt preference — but no such threshold
+  exists in the config schema or the review step yet.
 - No built-in outcome telemetry (revert/incident tracking per gated PR).
   Until it exists, the measurement loop is a manual or external process; the
   policy should be adopted in repos that can run it.

--- a/docs/src/content/docs/concepts/review-authority.md
+++ b/docs/src/content/docs/concepts/review-authority.md
@@ -33,11 +33,14 @@ risk posture — never something a single run can escalate on its own.
 | **L3 — Scoped full-auto** | Full autonomy inside a bounded, measured, reversible domain (e.g. generated docs, dependency bumps, lint normalization). | Explicit repo policy declaring the domain; still never for irreversible actions. |
 
 **The shipped default sits between L0 and L1.** Out of the box `auto_fix.review`
-is `0`, so every review finding parks for a decision, while the Lint, Test,
-Document, CI, and Rebase steps each auto-fix within their attempt limits. A
-repository that wants strict L0 must set those steps to zero explicitly; the
+is `0`, so every review finding parks for a decision, while the Test, CI,
+Rebase, and — when `commands.lint` is configured — Lint steps each auto-fix
+within their attempt limits. The Document step applies its fixes during its own
+pass rather than through a follow-up loop, and unresolved documentation findings
+pause for approval. A repository that wants strict L0 must set the looping steps
+to zero explicitly; the
 [`auto_fix` field reference](/no-mistakes/reference/global-config/#auto_fix)
-owns the per-step defaults.
+owns the per-step defaults and which steps the limit applies to.
 
 **Never in any band:** data deletion, credential changes, publishing
 artifacts, or force-pushing over unincorporated upstream commits. The remote

--- a/docs/src/content/docs/concepts/review-authority.md
+++ b/docs/src/content/docs/concepts/review-authority.md
@@ -27,7 +27,7 @@ risk posture — never something a single run can escalate on its own.
 
 | Band | What the gate may do | Mechanism |
 |---|---|---|
-| **L0 — Advisory** | Review, comment, report. Every finding parks for a decision; nothing is fixed or pushed without a human action. | Every `auto_fix` step set to zero. This is an opt-in posture, not the shipped default. |
+| **L0 — Advisory** | Review, comment, report. No follow-up auto-fix loops: every finding parks for a human decision, and nothing is auto-fixed in a follow-up round. | Every `auto_fix` step set to zero. That disables the follow-up fix loops only — the document step still applies its fixes during its own initial pass, and Push, PR, and CI still run unattended when nothing blocks. This is an opt-in posture, not the shipped default. |
 | **L1 — Human-clicks** | The gate may fix findings, but the merge decision stays with a human; `ask-user` findings always pause; yolo is explicit per-run consent, not standing authority. | `auto_fix.review` > 0 only for findings classed `auto-fix`; `ask-user` always pauses; yolo documented as consent, never default. |
 | **L2 — Conditional auto** | Within hard caps (change size, scope, finding class), the gate may fix, re-verify, and push unattended; anything above a cap or outside the class pauses. | Per-step `auto_fix` limits; review step auto-fixes only within class. Size and scope caps are not implemented yet — see [Known gaps](#known-gaps-deferred). |
 | **L3 — Scoped full-auto** | Full autonomy inside a bounded, measured, reversible domain (e.g. generated docs, dependency bumps, lint normalization). | Explicit repo policy declaring the domain; still never for irreversible actions. |
@@ -58,14 +58,18 @@ non-reversible actions.
    regression.
 3. **`ask-user` is not auto-fixable.** Intent-sensitive findings exist
    precisely because judgment is required. No `auto_fix` limit may convert an
-   `ask-user` finding into an unattended fix.
+   `ask-user` finding into an unattended fix. Two overrides do resolve
+   `ask-user` findings unattended — TUI yolo mode and
+   `no-mistakes axi run --yes` — and both are deliberate per-run consent given
+   before the run starts. The invariant is that unattended resolution of an
+   `ask-user` finding always requires explicit consent, never the default.
 4. **Escalation is frictionless.** A human can pause, respond to, or abort
    any run at any point (`no-mistakes axi respond` / TUI / `axi abort`).
    Override must never require blaming the requester.
 5. **Evidence parity.** A run's record — findings, fix commits, step logs,
-   PR link, intent — must be reconstructable for an auditor without any
-   human in the loop having been the AI. The gate's SQLite state plus the PR
-   trail is the audit surface; keep it complete.
+   PR link, intent — must stand on its own for an auditor, without relying on
+   a human having supervised any AI-authored step. The gate's SQLite state
+   plus the PR trail is the audit surface; keep it complete.
 6. **Shrink before you investigate.** Any revert or incident attributable to
    a change the gate auto-approved or auto-fixed drops the repository's band
    by one immediately. Investigate after shrinking, never before.

--- a/docs_sidebar_registration_test.go
+++ b/docs_sidebar_registration_test.go
@@ -8,6 +8,39 @@ import (
 	"testing"
 )
 
+// docsContentRoot is the authored-page tree; every slug in the sidebar resolves
+// under it.
+var docsContentRoot = filepath.Join("docs", "src", "content", "docs")
+
+var sidebarSlugPattern = regexp.MustCompile(`slug:\s*"([^"]+)"`)
+
+// registeredSidebarSlugs reads the sidebar registration out of
+// docs/astro.config.mjs. Starlight accepts several entry forms; this reads only
+// the explicit double-quoted `slug:` form the config uses today, so it also
+// asserts that no other form has appeared. Without that assertion a page
+// registered by an `autogenerate` group or a `link:` entry would silently read
+// as unregistered, and the reachability check below would fail with a
+// misleading "no sidebar entry" message for a page that is in fact reachable.
+func registeredSidebarSlugs(t *testing.T) []string {
+	t.Helper()
+
+	config, err := os.ReadFile(filepath.Join("docs", "astro.config.mjs"))
+	if err != nil {
+		t.Fatalf("read astro config: %v", err)
+	}
+	for _, form := range []string{"autogenerate", "link:"} {
+		if strings.Contains(string(config), form) {
+			t.Fatalf("docs/astro.config.mjs uses the %q sidebar form, which these tests do not parse; teach registeredSidebarSlugs to read it before using it, or the reachability check will report registered pages as unregistered", form)
+		}
+	}
+
+	var slugs []string
+	for _, match := range sidebarSlugPattern.FindAllStringSubmatch(string(config), -1) {
+		slugs = append(slugs, match[1])
+	}
+	return slugs
+}
+
 // A docs page that is not registered in the Starlight sidebar still builds and
 // still answers its URL, so nothing fails - it is simply unreachable by
 // navigation, and only someone who already knows the slug can find it. This
@@ -16,18 +49,12 @@ import (
 // The splash homepage (index.mdx) is deliberately exempt; it is the site root,
 // reached through the logo and the hero, never through a sidebar item.
 func TestDocsSidebarRegistersEveryAuthoredPage(t *testing.T) {
-	config, err := os.ReadFile(filepath.Join("docs", "astro.config.mjs"))
-	if err != nil {
-		t.Fatalf("read astro config: %v", err)
-	}
-
 	registered := map[string]bool{}
-	for _, match := range regexp.MustCompile(`slug:\s*"([^"]+)"`).FindAllStringSubmatch(string(config), -1) {
-		registered[match[1]] = true
+	for _, slug := range registeredSidebarSlugs(t) {
+		registered[slug] = true
 	}
 
-	root := filepath.Join("docs", "src", "content", "docs")
-	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(docsContentRoot, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -38,7 +65,7 @@ func TestDocsSidebarRegistersEveryAuthoredPage(t *testing.T) {
 		if ext != ".md" && ext != ".mdx" {
 			return nil
 		}
-		slug, err := filepath.Rel(root, path)
+		slug, err := filepath.Rel(docsContentRoot, path)
 		if err != nil {
 			return err
 		}
@@ -59,15 +86,8 @@ func TestDocsSidebarRegistersEveryAuthoredPage(t *testing.T) {
 // The mirror direction: a sidebar entry pointing at a slug with no page behind
 // it renders a broken navigation link.
 func TestDocsSidebarHasNoEntryWithoutAPage(t *testing.T) {
-	config, err := os.ReadFile(filepath.Join("docs", "astro.config.mjs"))
-	if err != nil {
-		t.Fatalf("read astro config: %v", err)
-	}
-
-	root := filepath.Join("docs", "src", "content", "docs")
-	for _, match := range regexp.MustCompile(`slug:\s*"([^"]+)"`).FindAllStringSubmatch(string(config), -1) {
-		slug := match[1]
-		base := filepath.Join(root, filepath.FromSlash(slug))
+	for _, slug := range registeredSidebarSlugs(t) {
+		base := filepath.Join(docsContentRoot, filepath.FromSlash(slug))
 		if fileExists(base+".md") || fileExists(base+".mdx") {
 			continue
 		}

--- a/docs_sidebar_registration_test.go
+++ b/docs_sidebar_registration_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// A docs page that is not registered in the Starlight sidebar still builds and
+// still answers its URL, so nothing fails - it is simply unreachable by
+// navigation, and only someone who already knows the slug can find it. This
+// test is the reachability check: every authored page under
+// docs/src/content/docs must have a sidebar entry in docs/astro.config.mjs.
+// The splash homepage (index.mdx) is deliberately exempt; it is the site root,
+// reached through the logo and the hero, never through a sidebar item.
+func TestDocsSidebarRegistersEveryAuthoredPage(t *testing.T) {
+	config, err := os.ReadFile(filepath.Join("docs", "astro.config.mjs"))
+	if err != nil {
+		t.Fatalf("read astro config: %v", err)
+	}
+
+	registered := map[string]bool{}
+	for _, match := range regexp.MustCompile(`slug:\s*"([^"]+)"`).FindAllStringSubmatch(string(config), -1) {
+		registered[match[1]] = true
+	}
+
+	root := filepath.Join("docs", "src", "content", "docs")
+	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		ext := filepath.Ext(path)
+		if ext != ".md" && ext != ".mdx" {
+			return nil
+		}
+		slug, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		slug = filepath.ToSlash(strings.TrimSuffix(slug, ext))
+		if slug == "index" {
+			return nil
+		}
+		if !registered[slug] {
+			t.Errorf("docs page %q has no sidebar entry in docs/astro.config.mjs, so readers can only reach it by typing its URL", slug)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk docs content: %v", err)
+	}
+}
+
+// The mirror direction: a sidebar entry pointing at a slug with no page behind
+// it renders a broken navigation link.
+func TestDocsSidebarHasNoEntryWithoutAPage(t *testing.T) {
+	config, err := os.ReadFile(filepath.Join("docs", "astro.config.mjs"))
+	if err != nil {
+		t.Fatalf("read astro config: %v", err)
+	}
+
+	root := filepath.Join("docs", "src", "content", "docs")
+	for _, match := range regexp.MustCompile(`slug:\s*"([^"]+)"`).FindAllStringSubmatch(string(config), -1) {
+		slug := match[1]
+		base := filepath.Join(root, filepath.FromSlash(slug))
+		if fileExists(base+".md") || fileExists(base+".mdx") {
+			continue
+		}
+		t.Errorf("sidebar entry %q has no page under docs/src/content/docs", slug)
+	}
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}


### PR DESCRIPTION
## Intent

Add the review authority policy page (docs/src/content/docs/concepts/review-authority.md) to the no-mistakes docs site, registered in the sidebar, with the regression test and ownership-map updates the gate added

## What Changed

- Adds `docs/src/content/docs/concepts/review-authority.md`, a new Concepts page defining the authority bands a gate may exercise on its own, the non-negotiables, and the measurement loop; it links to `concepts/auto-fix.md` and `reference/global-config.md` for the `auto_fix` and finding-action mechanics rather than restating them, and registers the page in the `docs/astro.config.mjs` Starlight sidebar.
- Adds `docs_sidebar_registration_test.go` with `TestDocsSidebarRegistersEveryAuthoredPage` and `TestDocsSidebarHasNoEntryWithoutAPage`, which parse the sidebar slugs out of `docs/astro.config.mjs` through one shared helper and check both directions against the authored pages under `docs/src/content/docs` (the splash `index.mdx` is exempt).
- Records the new page as the owner of the authority-band policy in the `AGENTS.md` documentation ownership map and the `document.instructions` block of `.no-mistakes.yaml`, and states the sidebar-registration requirement in `AGENTS.md` since an unregistered page still builds and only loses navigation.

## Risk Assessment

✅ Low: Docs-and-static-test-only change with every prior finding now correctly addressed and no runtime behavior involved.

## Testing

I ran the change's own targeted tests (`go test -run TestDocsSidebar .`, both passing) and confirmed the new registration test is a real guard by deleting the sidebar entry and watching it fail with an actionable message before restoring the config. For end-user evidence I built and served the Starlight docs site and captured browser screenshots showing the Review Authority Policy page rendering with the "Review Authority" entry in the Concepts sidebar marked as the current page, verified it is reachable by clicking that entry from a neighbouring page, and confirmed every cross-page link and anchor the page introduces resolves in the built output. The AGENTS.md and .no-mistakes.yaml ownership-map edits agree on the new owner. All checks passed and the transient node_modules/dist build output was removed, leaving the worktree clean.

- Evidence: Rendered docs page: Review Authority Policy with sidebar entry highlighted (local file: <code>/tmp/no-mistakes-evidence/01M01CTMY828Q10BWHVTQ4H48P/review-authority-page-top.png</code>)
- Evidence: Full-page render of the Review Authority Policy page (local file: <code>/tmp/no-mistakes-evidence/01M01CTMY828Q10BWHVTQ4H48P/review-authority-page-full.png</code>)
- Evidence: Docs sidebar: &#34;Review Authority&#34; registered under Concepts (local file: <code>/tmp/no-mistakes-evidence/01M01CTMY828Q10BWHVTQ4H48P/sidebar-concepts-group.png</code>)
<details>
<summary>Evidence: Test + rendered-site transcript (pass, negative check, served URLs)</summary>

<code>$ go test -run TestDocsSidebar -v .&#10;--- PASS: TestDocsSidebarRegistersEveryAuthoredPage (0.00s)&#10;--- PASS: TestDocsSidebarHasNoEntryWithoutAPage (0.00s)&#10;ok github.com/kunchenguid/no-mistakes&#10;&#10;# Negative check: temporarily delete the sidebar entry for the new page&#10;$ go test -run TestDocsSidebarRegistersEveryAuthoredPage .&#10;--- FAIL: TestDocsSidebarRegistersEveryAuthoredPage (0.00s)&#10;docs_sidebar_registration_test.go:77: docs page &#34;concepts/review-authority&#34; has no sidebar entry in docs/astro.config.mjs, so readers can only reach it by typing its URL&#10;&#10;# Rendered site (astro build + preview at /no-mistakes)&#10;/no-mistakes/concepts/review-authority/ -&gt; 200&#10;/no-mistakes/concepts/auto-fix/ -&gt; 200&#10;/no-mistakes/concepts/gate-model/ -&gt; 200&#10;/no-mistakes/reference/global-config/ -&gt; 200&#10;# sidebar entry &#34;Review Authority&#34; renders with aria-current=&#34;page&#34;; clicking it from /concepts/auto-fix/ lands on &#34;Review Authority Policy&#34;</code>

```text
$ go test -run TestDocsSidebar -v .
=== RUN   TestDocsSidebarRegistersEveryAuthoredPage
--- PASS: TestDocsSidebarRegistersEveryAuthoredPage (0.00s)
=== RUN   TestDocsSidebarHasNoEntryWithoutAPage
--- PASS: TestDocsSidebarHasNoEntryWithoutAPage (0.00s)
PASS
ok  	github.com/kunchenguid/no-mistakes	0.002s

# Negative check: temporarily delete the sidebar entry for the new page
$ go test -run TestDocsSidebarRegistersEveryAuthoredPage .
--- FAIL: TestDocsSidebarRegistersEveryAuthoredPage (0.00s)
    docs_sidebar_registration_test.go:77: docs page "concepts/review-authority" has no sidebar entry in docs/astro.config.mjs, so readers can only reach it by typing its URL
FAIL
FAIL	github.com/kunchenguid/no-mistakes	0.002s
FAIL

# Rendered site (astro build + preview at /no-mistakes)
$ curl -o /dev/null -w "%{http_code}" http://localhost:4321/no-mistakes/concepts/review-authority/  -> 200
$ curl -o /dev/null -w "%{http_code}" http://localhost:4321/no-mistakes/concepts/auto-fix/  -> 200
$ curl -o /dev/null -w "%{http_code}" http://localhost:4321/no-mistakes/concepts/gate-model/  -> 200
$ curl -o /dev/null -w "%{http_code}" http://localhost:4321/no-mistakes/reference/global-config/  -> 200
# sidebar entry "Review Authority" renders with aria-current="page"; clicking it from /concepts/auto-fix/ lands on "Review Authority Policy"
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 5 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `docs/src/content/docs/concepts/review-authority.md:30` - The L0 row claims &#34;Every finding parks for a decision; nothing is fixed or pushed without a human action&#34; with the mechanism &#34;Every `auto_fix` step set to zero&#34;, but zeroed `auto_fix` limits only disable follow-up fix loops. With all steps at zero and no blocking findings, the pipeline still runs Push, PR, and CI unattended, and the document step (plus the combined housekeeping lint pass when `commands.lint` is empty) still applies fixes during its own pass — `auto_fix.document` is documented as &#34;Not used by the automatic document pass&#34;, and lines 40-41 of this same page acknowledge &#34;the steps that fix during their own pass instead of through a follow-up loop&#34;. A reader configuring L0 for a security-sensitive repo (per the tier table at line 104) would get pushed branches, an opened PR, and agent-applied doc/lint fixes with zero human action.
- ℹ️ `docs/src/content/docs/concepts/review-authority.md:61` - Non-negotiable 3 states &#34;`ask-user` is not auto-fixable&#34; and scopes the guarantee to `auto_fix` limits, but the product ships two explicit-consent overrides that do resolve `ask-user` findings unattended: TUI yolo mode (mentioned only in the L1 row) and `axi run --yes` (documented in the finding-actions section of concepts/auto-fix.md as consent to resolve gates unattended). A reader treating this as an absolute invariant would be surprised that an agent driving AXI with `--yes` fixes `ask-user` findings without pausing; naming both overrides here keeps the non-negotiable accurate.
- ℹ️ `docs/src/content/docs/concepts/review-authority.md:66` - The evidence-parity clause &#34;must be reconstructable for an auditor without any human in the loop having been the AI&#34; is not parseable as written, so the actual audit requirement is undefined. A reader implementing this non-negotiable cannot tell what must be reconstructable or by whom (likely intended: the run record must stand on its own for an auditor, without relying on a human having supervised any AI-authored step).
- ℹ️ `docs_sidebar_registration_test.go:24` - Registration is detected only via the regex `slug:\s*&#34;([^&#34;]+)&#34;`, so any other valid Starlight sidebar form silently counts as unregistered: an `autogenerate: { directory: &#34;concepts&#34; }` group, a `link:` entry, or single-quoted slugs after a formatter change. A future contributor who registers a page by autogenerating the Concepts group would see TestDocsSidebarRegistersEveryAuthoredPage fail on every page in that group with the misleading message &#34;has no sidebar entry&#34;. Failing on the recognized-forms assumption (e.g. asserting the config contains no `autogenerate`/`link` sidebar forms) would make the limitation explicit instead of silent.
- ℹ️ `docs_sidebar_registration_test.go:60` - Both tests independently read docs/astro.config.mjs, compile the same `slug:\s*&#34;([^&#34;]+)&#34;` regex, and rebuild the same docs-content root path, so the parsing contract lives in two places and a change to the sidebar syntax must be made twice. Extracting a single `registeredSidebarSlugs(t) []string` helper (plus a shared root constant) keeps the two directions of the check reading the config the same way.

🔧 Fix: correct review-authority claims and share sidebar test parsing
1 info still open:
- ℹ️ `docs/src/content/docs/concepts/review-authority.md:63` - The new sentence in non-negotiable 3 says the two overrides &#34;are deliberate per-run consent given before the run starts&#34;, but that is only true of `no-mistakes axi run --yes`. TUI yolo mode is a live toggle pressed while a run is being watched — guides/tui.md:194 (&#34;`y` | Toggle yolo mode&#34;) and :215 (&#34;Press `y` to toggle yolo mode when you want paused approval gates to resolve automatically&#34;), with the footer switching to `y end yolo` while it is on. A reader auditing consent provenance would look for a pre-run flag and not find one for yolo. The invariant the sentence is protecting (unattended resolution always requires explicit consent, never the default) holds either way; dropping &#34;given before the run starts&#34; or splitting it (&#34;`--yes` before the run starts, yolo toggled live in the TUI&#34;) keeps it accurate.

🔧 Fix: correct yolo consent-timing claim in review-authority doc
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`go test -run TestDocsSidebar -v .` (TestDocsSidebarRegistersEveryAuthoredPage, TestDocsSidebarHasNoEntryWithoutAPage) — both pass</code>
- <code>Negative regression check: temporarily removed the `{ label: &#34;Review Authority&#34;, slug: &#34;concepts/review-authority&#34; }` entry from docs/astro.config.mjs and re-ran `go test -run TestDocsSidebarRegistersEveryAuthoredPage .` — fails with the unreachable-page message; config restored and `git status` clean</code>
- <code>`npm install &amp;&amp; npm run build &amp;&amp; npm run preview` in `docs/` — Starlight site builds (22 pages) and serves the new page at http://localhost:4321/no-mistakes/concepts/review-authority/ (HTTP 200)</code>
- <code>Playwright screenshots at 1440x1000 of the rendered page and the Concepts sidebar group; asserted the sidebar link text is &#34;Review Authority&#34; with `aria-current=&#34;page&#34;`</code>
- `Browser navigation check: from /no-mistakes/concepts/auto-fix/, clicked the sidebar "Review Authority" entry and landed on the page with h1 "Review Authority Policy"`
- <code>Cross-link and anchor resolution: `curl` on /concepts/auto-fix/, /concepts/gate-model/, /reference/global-config/ (all 200) plus presence of `id=&#34;finding-actions&#34;`, `id=&#34;auto_fix&#34;`, and `id=&#34;known-gaps-deferred&#34;` in the built HTML</code>
- <code>Reviewed the diff of AGENTS.md and the `document.instructions` block in .no-mistakes.yaml for a consistent ownership-map statement</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/src/content/docs/concepts/review-authority.md:35` - docs/src/content/docs/concepts/review-authority.md restates two facts owned elsewhere - the shipped `auto_fix.review: 0` default (owned by reference/global-config.md) and the unclassified-finding-fails-closed-to-ask-user rule (owned by concepts/auto-fix.md). Both restatements link to their owner and the policy narrative needs them to say where the shipped default lands, so I left them; flagging as a judgment call because they are a second copy that must be rechecked if either default changes. No follow-up edit recommended unless those defaults move.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
