### PR TITLE
fix(agent): parse pi JSONL fences glued to body on the same line

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -359,6 +359,12 @@ func fencedJSONCandidates(text string) []string {
 		body := rest[start:]
 		end, next := indexJSONFenceClose(body)
 		if end < 0 {
+			// No closing fence: some agents (notably pi JSONL streams) emit an
+			// opening ```json fence glued to a JSON body that runs to the end
+			// of the output with no closing fence. Take everything after the
+			// opener as a candidate; parseStructuredCandidate validates it
+			// later and only adopts it when it is actually valid JSON.
+			candidates = append(candidates, body)
 			return candidates
 		}
 		candidates = append(candidates, body[:end])
@@ -392,10 +398,38 @@ func indexJSONFenceOpen(text string) int {
 func fenceContentStart(text string, fenceStart int) (int, string) {
 	after := text[fenceStart+3:]
 	lineEnd := strings.IndexByte(after, '\n')
-	if lineEnd < 0 {
-		return fenceStart + 3 + len(after), after
+	if lineEnd >= 0 {
+		after = after[:lineEnd]
 	}
-	return fenceStart + 3 + lineEnd + 1, after[:lineEnd]
+	info, rest := fenceInfoToken(after)
+	start := fenceStart + 3 + rest
+	if start < len(text) && text[start] == '\n' {
+		start++
+	}
+	return start, info
+}
+
+// fenceInfoToken returns the leading info token of a fence line (the part
+// after ```) together with its end offset within s. The token is a word
+// made of letters/digits/`-`/`_`; anything else (whitespace, `{`, `[`, …)
+// terminates it. This tolerates ```json glued directly to a JSON body on
+// the same line (e.g. ```json{"findings":[]}) — a shape real pi JSONL
+// streams produce when content blocks are concatenated without separators.
+func fenceInfoToken(s string) (string, int) {
+	i := 0
+	for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
+		i++
+	}
+	start := i
+	for i < len(s) {
+		c := s[i]
+		isWord := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_'
+		if !isWord {
+			break
+		}
+		i++
+	}
+	return s[start:i], i
 }
 
 func skipFenceBlock(text string) int {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -662,3 +662,37 @@ func TestOutputSnippet_TruncatesLongText(t *testing.T) {
 		t.Errorf("expected 200 runes plus ellipsis, got %d runes", len(runes))
 	}
 }
+
+func TestFinalizeTextResult_WithSchemaParsesPiSameLineFence(t *testing.T) {
+	// Regression: pi JSONL output concatenates content blocks without
+	// separators, producing ```json glued to the JSON body on the same line
+	// (no newline after the fence info token). The fence parser must still
+	// recognize the ```json fence and extract the body.
+	text := "The change is docs-only: 3 lines appended to README.md.```json{  \"findings\": [],  \"summary\": \"docs-only change\"}"
+	result, err := finalizeTextResult("pi", text, json.RawMessage(`{"type":"object"}`), TokenUsage{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var output struct {
+		Findings []any  `json:"findings"`
+		Summary  string `json:"summary"`
+	}
+	if err := json.Unmarshal(result.Output, &output); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+	if output.Summary != "docs-only change" {
+		t.Errorf("expected summary=docs-only change, got %q", output.Summary)
+	}
+}
+
+func TestFenceContentStart_InfoTokenWithSameLineBody(t *testing.T) {
+	// fence info token followed immediately by content on the same line.
+	start, info := fenceContentStart("```json{\"findings\":[]}", 0)
+	if info != "json" {
+		t.Errorf("expected info=json, got %q", info)
+	}
+	want := `{"findings":[]}`
+	if got := "```json{\"findings\":[]}"[start:]; got != want {
+		t.Errorf("content start = %d (got %q), want %q", start, got, want)
+	}
+}


### PR DESCRIPTION
## Summary

pi (the coding agent) emits its final structured answer as a JSONL assistant message whose content blocks are concatenated without separators. The result is an opening ```json fence glued directly to the JSON body on the same line — ```json{"findings":[]} — with **no closing fence** (the JSON runs to end of output).

The fence parser in `internal/agent/agent.go` only recognized:
- a ```json fence followed by a newline, and
- a **closed** fence (a ``` on its own line or at end of text).

So `finalizeTextResult` failed with `pi output parse: invalid character '`' looking for beginning of value` whenever pi was the pipeline agent and its answer contained a fenced JSON block.

## What's in the package

- `fenceContentStart` now takes the fence info token up to the first non-word character, tolerating ```json{...} glued on one line (via a new `fenceInfoToken` helper).
- `fencedJSONCandidates` treats an unclosed fence as running to end of text; `parseStructuredCandidate` still validates the candidate and only adopts it when it is actually valid JSON, so no new false positives.
- Both changes are backward compatible: newline-separated closed fences (codex/claude shape) still parse identically — the existing test suite covers them.

## Verification snapshot

- New regression tests:
  - `TestFinalizeTextResult_WithSchemaParsesPiSameLineFence` — the exact pi shape: prose glued to ```json{...} with no closing fence.
  - `TestFenceContentStart_InfoTokenWithSameLineBody` — info-token boundary unit test.
- Full `internal/agent` package: all tests pass (14 relevant tests green, no regressions).
- End-to-end: a real gate pipeline run with **pi as the pipeline agent** previously failed at the `test` step with the exact parse error; after this fix the same pipeline completed all 9 steps to `checks-passed` (review auto-fixed one finding, PR opened).

## What's NOT in this PR

- No change to the pi agent adapter itself (the concatenation behavior is pi's output contract).
- No change to review/ci step logic.

Signed-off-by: onyx
