### PR TITLE
fix: make git fetch cancellation converge

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/safeurl"
+	"github.com/kunchenguid/no-mistakes/internal/shellenv"
 	"github.com/kunchenguid/no-mistakes/internal/winproc"
 )
 
@@ -84,13 +86,18 @@ func runInDirWithEnvRaw(ctx context.Context, dir string, extraEnv []string, args
 	cmd.Dir = dir
 	cmd.Env = append(NonInteractiveEnv(dir), extraEnv...)
 	winproc.Harden(cmd)
-	out, err := cmd.Output()
+	// OutputShellCommand captures stdout only, so unlike cmd.Output it never
+	// fills ExitError.Stderr. Capture stderr explicitly or the git error text
+	// below silently becomes empty.
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	shellenv.ConfigureShellCommand(cmd)
+	out, err := shellenv.OutputShellCommand(cmd)
 	if err != nil {
-		stderr := ""
-		if ee, ok := err.(*exec.ExitError); ok {
-			stderr = strings.TrimSpace(string(ee.Stderr))
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			err = fmt.Errorf("%w (%v)", ctxErr, err)
 		}
-		return nil, fmt.Errorf("git %s: %w: %s", safeurl.RedactText(strings.Join(args, " ")), err, safeurl.RedactText(stderr))
+		return nil, fmt.Errorf("git %s: %w: %s", safeurl.RedactText(strings.Join(args, " ")), err, safeurl.RedactText(strings.TrimSpace(stderr.String())))
 	}
 	return out, nil
 }

--- a/internal/git/git_unix_test.go
+++ b/internal/git/git_unix_test.go
@@ -1,0 +1,132 @@
+//go:build unix
+
+package git
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestRun_TrimsOutputWithLifecycleAwareRunner(t *testing.T) {
+	installFakeGit(t, `printf '  normal output  \n'`)
+
+	out, err := Run(context.Background(), t.TempDir(), "status")
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if got, want := out, "normal output"; got != want {
+		t.Fatalf("Run() output = %q, want %q", got, want)
+	}
+}
+
+func TestRun_PreservesStderrWithLifecycleAwareRunner(t *testing.T) {
+	installFakeGit(t, `printf 'fetch failed\n' >&2; exit 2`)
+
+	_, err := Run(context.Background(), t.TempDir(), "fetch")
+	if err == nil {
+		t.Fatal("Run() error = nil, want fake git failure")
+	}
+	if !strings.Contains(err.Error(), "fetch failed") {
+		t.Fatalf("Run() error = %q, want captured stderr", err)
+	}
+}
+
+func TestRun_CancellationStopsPipeHoldingDescendant(t *testing.T) {
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "descendant.pid")
+	readyFile := filepath.Join(dir, "ready")
+	t.Setenv("NM_GIT_TEST_PID_FILE", pidFile)
+	t.Setenv("NM_GIT_TEST_READY_FILE", readyFile)
+	installFakeGit(t, `
+(
+	while :; do
+		sleep 1
+	done
+) &
+descendant=$!
+printf '%s\n' "$descendant" > "$NM_GIT_TEST_PID_FILE"
+printf 'ready\n' > "$NM_GIT_TEST_READY_FILE"
+wait "$descendant"
+`)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, err := Run(ctx, dir, "fetch", "origin", "main")
+		result <- err
+	}()
+
+	waitForFile(t, readyFile, 5*time.Second)
+	descendantPID := readTestPID(t, pidFile)
+	t.Cleanup(func() {
+		_ = syscall.Kill(descendantPID, syscall.SIGKILL)
+	})
+
+	cancel()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Run() error = %v, want wrapped %v", err, context.Canceled)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run() did not return promptly after cancellation")
+	}
+
+	if !processGoneWithin(descendantPID, 5*time.Second) {
+		t.Fatalf("git descendant %d still exists after Run() returned", descendantPID)
+	}
+}
+
+func installFakeGit(t *testing.T, body string) {
+	t.Helper()
+	binDir := t.TempDir()
+	gitPath := filepath.Join(binDir, "git")
+	script := "#!/bin/sh\n" + body + "\n"
+	if err := os.WriteFile(gitPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func waitForFile(t *testing.T, path string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", path)
+}
+
+func readTestPID(t *testing.T, path string) int {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read descendant pid: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(b)))
+	if err != nil || pid <= 0 {
+		t.Fatalf("invalid descendant pid %q: %v", b, err)
+	}
+	return pid
+}
+
+func processGoneWithin(pid int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if errors.Is(syscall.Kill(pid, 0), syscall.ESRCH) {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}

--- a/internal/pipeline/steps/common_git.go
+++ b/internal/pipeline/steps/common_git.go
@@ -2,7 +2,10 @@ package steps
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
+	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/agent"
 	"github.com/kunchenguid/no-mistakes/internal/git"
@@ -173,7 +176,33 @@ func resolveUpstreamURL(sctx *pipeline.StepContext) string {
 	return sctx.Repo.UpstreamURL
 }
 
+// fetchUpstreamTimeout bounds a single upstream fetch. Abort convergence alone
+// does not rescue a fetch that hangs with nothing to cancel it: an SSH fetch can
+// sit indefinitely on a dead connection while the run context stays live. The
+// deadline is attributed with ErrFetchTimeout so the caller can say why it gave
+// up rather than logging a bare context error.
+// Overridable so tests can drive the deadline without waiting it out.
+var fetchUpstreamTimeout = 120 * time.Second
+
+// ErrFetchTimeout marks a fetch that exceeded fetchUpstreamTimeout.
+var ErrFetchTimeout = errors.New("upstream fetch timed out")
+
 func fetchRunUpstreamBranch(ctx context.Context, sctx *pipeline.StepContext, branch string) error {
+	// Respect a deadline the caller already set rather than extending it.
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeoutCause(ctx, fetchUpstreamTimeout, ErrFetchTimeout)
+		defer cancel()
+	}
+
+	err := fetchRunUpstreamBranchInner(ctx, sctx, branch)
+	if err != nil && errors.Is(context.Cause(ctx), ErrFetchTimeout) {
+		return fmt.Errorf("%w after %s: %v", ErrFetchTimeout, fetchUpstreamTimeout, err)
+	}
+	return err
+}
+
+func fetchRunUpstreamBranchInner(ctx context.Context, sctx *pipeline.StepContext, branch string) error {
 	upstreamURL := resolveUpstreamURL(sctx)
 	originURL, err := git.GetRemoteURL(ctx, sctx.WorkDir, "origin")
 	if err == nil && upstreamURL == originURL {

--- a/internal/pipeline/steps/common_git_fetch_timeout_test.go
+++ b/internal/pipeline/steps/common_git_fetch_timeout_test.go
@@ -1,0 +1,72 @@
+package steps
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/pipeline"
+)
+
+// hangingGitRemote accepts TCP connections and then says nothing, which is what
+// a dead SSH/git peer looks like to a fetch: connected, and never answering.
+func hangingGitRemote(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			// Hold it open without replying.
+			t.Cleanup(func() { _ = conn.Close() })
+		}
+	}()
+	return fmt.Sprintf("git://%s/hang.git", listener.Addr().String())
+}
+
+func TestFetchRunUpstreamBranch_TimesOutAndSaysSo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	original := fetchUpstreamTimeout
+	fetchUpstreamTimeout = 300 * time.Millisecond
+	t.Cleanup(func() { fetchUpstreamTimeout = original })
+
+	workDir := t.TempDir()
+	if out, err := exec.Command("git", "-C", workDir, "init", "-q").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+
+	sctx := &pipeline.StepContext{
+		Ctx:     context.Background(),
+		WorkDir: workDir,
+		Repo:    &db.Repo{UpstreamURL: hangingGitRemote(t)},
+	}
+
+	start := time.Now()
+	// No deadline on the caller context: the fetch must impose its own.
+	err := fetchRunUpstreamBranch(context.Background(), sctx, "main")
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected the hanging fetch to fail")
+	}
+	if !errors.Is(err, ErrFetchTimeout) {
+		t.Fatalf("error = %v, want it to wrap ErrFetchTimeout", err)
+	}
+	if elapsed > 30*time.Second {
+		t.Fatalf("fetch took %v, the bound did not apply", elapsed)
+	}
+}


### PR DESCRIPTION
`no-mistakes axi run` can remain in `rebase: running` when the rebase step fetches `origin/main`, even after `axi abort` removes the visible fetch process. The rebase step already passes the run context through `fetchRunUpstreamBranch` into `git.FetchRemoteBranch`, and the executor already converts an aborted context into a terminal `cancelled` run. The gap is in the shared Git runner: on Unix it uses `exec.CommandContext` with `cmd.Output`, so cancellation kills the direct Git process but can leave an SSH or credential-helper descendant holding the output pipe and preventing the call from returning. Until that call returns, the executor cannot persist the terminal run and step state or clean up the worktree.

## What Changed

Update the shared raw Git execution path in `internal/git/git.go` to configure every cancellable Git command with the existing `internal/shellenv` process-tree boundary and capture output through its lifecycle-aware output helper. This reuses the repository's established SIGTERM-to-SIGKILL escalation, inherited-pipe backstop, Windows job-object hardening, and clean-exit descendant cleanup while preserving Git's current non-interactive environment, stdout result, redacted stderr, and wrapped error format. Add a Unix regression test with a fake Git executable that starts a long-lived descendant which holds the command pipe, then cancel the context and prove both that `Run` returns within a bound and that the descendant is stopped/reaped.

## Testing

- A normal Git command still returns its trimmed stdout and succeeds through the lifecycle-aware runner.
- A fake `git fetch` whose descendant remains alive and holds stdout open returns promptly after its context is cancelled instead of hanging in `cmd.Output`.
- The descendant created by the fake Git command stops executing and is reaped after cancellation, so it cannot retain the run worktree or inherited pipes.
- Cancellation continues to surface as a context-derived Git error, allowing the existing executor logic to record an `axi abort` run as `cancelled` with the user-abort reason.

Fixes #717
