### PR TITLE
feat(agent): make opencode a verified gate-agent instruction neutralizer

### DIFF
--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -139,7 +139,7 @@ Suppress project-level agent settings and instructions for every gate-agent star
 
 This opt-in is intended for agent-orchestration repositories whose `AGENTS.md`, `CLAUDE.md`, or harness-specific project settings would give a validation agent an operator identity and authority that it must not adopt.
 When enabled, no-mistakes suppresses the target checkout's project settings for every agent-driven gate step while preserving user-level agent configuration.
-Codex, Claude, and Pi are the currently verified agents: Codex receives `project_doc_max_bytes=0` and `--ignore-rules`, Claude loads only its user setting source, and Pi runs with `--no-context-files` (preserving a pinned `--no-context-files` or `-nc` spelling).
+Codex, Claude, Pi, and Opencode are the currently verified agents: Codex receives `project_doc_max_bytes=0` and `--ignore-rules`, Claude loads only its user setting source, Pi runs with `--no-context-files` (preserving a pinned `--no-context-files` or `-nc` spelling), and Opencode runs with `OPENCODE_DISABLE_PROJECT_CONFIG=1` exported to its serve process.
 The setting applies to both new and resumed sessions.
 
 The gate fails before launching an agent if any resolved agent or fallback lacks a verified suppression mechanism.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -159,8 +159,8 @@ func NeutralizesGateInstructions(a Agent) bool {
 // the target checkout does not neutralize that checkout's project
 // agent-instruction files. Callers must invoke it before launching any gate
 // agent so an unverified harness is refused with a clear error rather than run
-// unneutralized in the target checkout. Only codex, claude, and pi have a verified
-// neutralization knob today.
+// unneutralized in the target checkout. Only codex, claude, pi, and opencode have
+// a verified neutralization knob today.
 func EnsureGateNeutralized(a Agent) error {
 	if a == nil {
 		return fmt.Errorf("no gate agent configured")
@@ -170,9 +170,9 @@ func EnsureGateNeutralized(a Agent) error {
 	}
 	return fmt.Errorf("gate agent %q does not neutralize the target repository's project "+
 		"agent-instruction files (AGENTS.md/CLAUDE.md); refusing to launch it in the target "+
-		"checkout. Only codex, claude, and pi have a verified neutralization knob (and only when it "+
-		"is not overridden by agent_args_override); set 'agent' to codex, claude, or pi in "+
-		"~/.no-mistakes/config.yaml", a.Name())
+		"checkout. Only codex, claude, pi, and opencode have a verified neutralization knob "+
+		"(and only when it is not overridden by agent_args_override); set 'agent' to codex, "+
+		"claude, pi, or opencode in ~/.no-mistakes/config.yaml", a.Name())
 }
 
 // LifecycleEvent describes process-level activity for an agent invocation.
@@ -251,7 +251,7 @@ type InvocationWorkload struct {
 type Options struct {
 	ACPRegistryOverrides map[string]string
 	// DisableProjectSettings, when true, asks a supported adapter (codex,
-	// claude, pi) to launch with the target repo's project-level agent
+	// claude, pi, opencode) to launch with the target repo's project-level agent
 	// settings/instructions suppressed. It is the resolved, trusted-only opt-out
 	// from config.Config; adapters without a verified suppression knob ignore it
 	// and are refused separately by EnsureGateNeutralized when the opt-out is on.
@@ -806,7 +806,7 @@ func NewWithOptions(name types.AgentName, bin string, extraArgs []string, opts O
 	case types.AgentRovoDev:
 		return &rovodevAgent{bin: bin, extraArgs: extraArgs}, nil
 	case types.AgentOpenCode:
-		return &opencodeAgent{bin: bin, extraArgs: extraArgs}, nil
+		return &opencodeAgent{bin: bin, extraArgs: extraArgs, disableProjectSettings: opts.DisableProjectSettings}, nil
 	case types.AgentPi:
 		return &piAgent{bin: bin, extraArgs: extraArgs, disableProjectSettings: opts.DisableProjectSettings}, nil
 	case types.AgentCopilot:

--- a/internal/agent/gateneutralize_test.go
+++ b/internal/agent/gateneutralize_test.go
@@ -19,17 +19,17 @@ func optOutAgent(t *testing.T, name types.AgentName, extraArgs []string) Agent {
 }
 
 // TestNeutralizesGateInstructions_OnlyVerifiedHarnessesUnderOptOut is the core
-// fail-closed contract: under the opt-out, only codex, claude, and pi (whose
-// suppression knobs are empirically verified) neutralize the target repo's
+// fail-closed contract: under the opt-out, only codex, claude, pi, and opencode
+// (whose suppression knobs are empirically verified) neutralize the target repo's
 // project agent settings/instructions; every other harness reports false and is
 // refused rather than launched with project instructions loaded.
 func TestNeutralizesGateInstructions_OnlyVerifiedHarnessesUnderOptOut(t *testing.T) {
-	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentPi} {
+	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentPi, types.AgentOpenCode} {
 		if !NeutralizesGateInstructions(optOutAgent(t, name, nil)) {
 			t.Errorf("%s must neutralize under the opt-out with its default knob", name)
 		}
 	}
-	unverified := []types.AgentName{types.AgentOpenCode, types.AgentCopilot, types.AgentRovoDev}
+	unverified := []types.AgentName{types.AgentCopilot, types.AgentRovoDev}
 	for _, name := range unverified {
 		if NeutralizesGateInstructions(optOutAgent(t, name, nil)) {
 			t.Errorf("%s has no verified knob; must NOT report neutralized", name)
@@ -50,11 +50,11 @@ func TestNeutralizesGateInstructions_OnlyVerifiedHarnessesUnderOptOut(t *testing
 	}
 }
 
-// TestNeutralizesGateInstructions_FalseWithoutOptOut proves codex, claude, and pi
-// do NOT claim neutralization when the repo did not opt out - the gate only consults
-// this under the opt-out, but the value must be honest.
+// TestNeutralizesGateInstructions_FalseWithoutOptOut proves codex, claude, pi, and
+// opencode do NOT claim neutralization when the repo did not opt out - the gate only
+// consults this under the opt-out, but the value must be honest.
 func TestNeutralizesGateInstructions_FalseWithoutOptOut(t *testing.T) {
-	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentPi} {
+	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentPi, types.AgentOpenCode} {
 		a, err := NewWithOptions(name, string(name), nil, Options{}) // no opt-out
 		if err != nil {
 			t.Fatalf("NewWithOptions(%s): %v", name, err)
@@ -66,7 +66,7 @@ func TestNeutralizesGateInstructions_FalseWithoutOptOut(t *testing.T) {
 }
 
 // TestEnsureGateNeutralized_RefusesUnsupportedUnderOptOut proves the gate fails
-// closed for an unsupported harness and admits codex, claude, and pi.
+// closed for an unsupported harness and admits codex, claude, pi, and opencode.
 func TestEnsureGateNeutralized_RefusesUnsupportedUnderOptOut(t *testing.T) {
 	if err := EnsureGateNeutralized(optOutAgent(t, types.AgentCodex, nil)); err != nil {
 		t.Errorf("codex must pass the gate under opt-out: %v", err)
@@ -77,11 +77,14 @@ func TestEnsureGateNeutralized_RefusesUnsupportedUnderOptOut(t *testing.T) {
 	if err := EnsureGateNeutralized(optOutAgent(t, types.AgentPi, nil)); err != nil {
 		t.Errorf("pi must pass the gate under opt-out: %v", err)
 	}
-	err := EnsureGateNeutralized(optOutAgent(t, types.AgentOpenCode, nil))
-	if err == nil {
-		t.Fatal("opencode must be refused by the gate under opt-out")
+	if err := EnsureGateNeutralized(optOutAgent(t, types.AgentOpenCode, nil)); err != nil {
+		t.Errorf("opencode must pass the gate under opt-out: %v", err)
 	}
-	if !strings.Contains(err.Error(), "does not neutralize") || !strings.Contains(err.Error(), "opencode") {
+	err := EnsureGateNeutralized(optOutAgent(t, types.AgentCopilot, nil))
+	if err == nil {
+		t.Fatal("copilot must be refused by the gate under opt-out")
+	}
+	if !strings.Contains(err.Error(), "does not neutralize") || !strings.Contains(err.Error(), "copilot") {
 		t.Errorf("refusal error should name the harness and reason, got: %v", err)
 	}
 	if err := EnsureGateNeutralized(nil); err == nil {
@@ -97,8 +100,11 @@ func TestNeutralizesGateInstructions_ThroughProductionWrapping(t *testing.T) {
 	if !NeutralizesGateInstructions(WithSteering(optOutAgent(t, types.AgentCodex, nil), "/evidence")) {
 		t.Error("WithSteering(codex) must remain neutralized under opt-out")
 	}
-	if NeutralizesGateInstructions(WithSteering(optOutAgent(t, types.AgentOpenCode, nil), "/evidence")) {
-		t.Error("WithSteering(opencode) must remain non-neutralized")
+	if !NeutralizesGateInstructions(WithSteering(optOutAgent(t, types.AgentOpenCode, nil), "/evidence")) {
+		t.Error("WithSteering(opencode) must remain neutralized under opt-out")
+	}
+	if NeutralizesGateInstructions(WithSteering(optOutAgent(t, types.AgentCopilot, nil), "/evidence")) {
+		t.Error("WithSteering(copilot) must remain non-neutralized")
 	}
 	allVerified := NewFallback([]Agent{
 		WithSteering(optOutAgent(t, types.AgentCodex, nil), "/evidence"),
@@ -109,10 +115,10 @@ func TestNeutralizesGateInstructions_ThroughProductionWrapping(t *testing.T) {
 	}
 	oneUnverified := NewFallback([]Agent{
 		WithSteering(optOutAgent(t, types.AgentCodex, nil), "/evidence"),
-		WithSteering(optOutAgent(t, types.AgentOpenCode, nil), "/evidence"),
+		WithSteering(optOutAgent(t, types.AgentCopilot, nil), "/evidence"),
 	})
 	if err := EnsureGateNeutralized(oneUnverified); err == nil {
-		t.Error("fallback [codex, opencode] must be refused under opt-out")
+		t.Error("fallback [codex, copilot] must be refused under opt-out")
 	}
 }
 

--- a/internal/agent/opencode.go
+++ b/internal/agent/opencode.go
@@ -12,11 +12,25 @@ import (
 type opencodeAgent struct {
 	bin       string
 	extraArgs []string
-	mu        sync.Mutex
-	server    *managedServer
+	// disableProjectSettings is the resolved, trusted-only opt-out. When true,
+	// ensureServer exports OPENCODE_DISABLE_PROJECT_CONFIG on the serve process
+	// so sessions skip the target checkout's AGENTS.md/CLAUDE.md/CONTEXT.md.
+	disableProjectSettings bool
+	mu                     sync.Mutex
+	server                 *managedServer
 }
 
 func (a *opencodeAgent) Name() string { return "opencode" }
+
+// NeutralizesGateInstructions reports whether opencode is currently launched
+// with the target repo's project agent-instruction files suppressed. It is
+// meaningful only under the opt-out (disableProjectSettings): the gate only
+// consults it when the repo opted out. The suppression is an environment
+// variable on the serve process, so there is no operator argv surface that can
+// defeat it and no extraArgs inspection is needed (pi-style).
+func (a *opencodeAgent) NeutralizesGateInstructions() bool {
+	return a.disableProjectSettings
+}
 
 func (a *opencodeAgent) ReportsAgentAttempts() bool { return true }
 

--- a/internal/agent/opencode_http.go
+++ b/internal/agent/opencode_http.go
@@ -21,7 +21,17 @@ func (a *opencodeAgent) ensureServer(ctx context.Context, cwd string, env []stri
 		return "", fmt.Errorf("opencode port: %w", err)
 	}
 	args := buildOpencodeServeArgs(a.extraArgs, port)
-	srv, err := startServerWithPort(ctx, "opencode", a.bin, args, cwd, "/global/health", port, env)
+	serveEnv := env
+	if a.disableProjectSettings {
+		// OPENCODE_DISABLE_PROJECT_CONFIG is opencode's internal (undocumented)
+		// flag to skip project-level AGENTS.md/CLAUDE.md/CONTEXT.md discovery. It
+		// is read from process.env by `opencode serve`; sessions inherit it.
+		// Appended here (gitSafeEnv keeps the last occurrence) so an inherited
+		// value cannot re-enable project settings. User-level global config
+		// (~/.config/opencode/AGENTS.md) still loads, which is correct.
+		serveEnv = append(append([]string(nil), env...), "OPENCODE_DISABLE_PROJECT_CONFIG=1")
+	}
+	srv, err := startServerWithPort(ctx, "opencode", a.bin, args, cwd, "/global/health", port, serveEnv)
 	if err != nil {
 		return "", fmt.Errorf("opencode server: %w", err)
 	}

--- a/internal/agent/opencode_test.go
+++ b/internal/agent/opencode_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -14,6 +16,45 @@ func TestOpencodeAgent_CloseWithoutServer(t *testing.T) {
 	a := &opencodeAgent{bin: "opencode"}
 	if err := a.Close(); err != nil {
 		t.Errorf("Close without server should not error: %v", err)
+	}
+}
+
+// TestOpencodeAgent_ServeEnvCarriesProjectSettingsKnob is the gate-neutralization
+// regression: under the opt-out, ensureServer must export
+// OPENCODE_DISABLE_PROJECT_CONFIG=1 to the `opencode serve` process (sessions
+// inherit it), and it must win over an inherited value. The fake bin exits before
+// becoming healthy, but it dumps the knob it was launched with first.
+func TestOpencodeAgent_ServeEnvCarriesProjectSettingsKnob(t *testing.T) {
+	script := filepath.Join(t.TempDir(), "fake-opencode")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nprintf '%s' \"${OPENCODE_DISABLE_PROJECT_CONFIG-}\" > \"$NM_TEST_ENV_DUMP\"\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// An ambient value of 0 is inherited by the child in both cases; only the
+	// opt-out must override it to 1.
+	t.Setenv("OPENCODE_DISABLE_PROJECT_CONFIG", "0")
+	for _, tc := range []struct {
+		name    string
+		disable bool
+		want    string
+	}{
+		{name: "opt-out on wins over inherited value", disable: true, want: "1"},
+		{name: "no opt-out leaves the inherited value untouched", disable: false, want: "0"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dump := filepath.Join(t.TempDir(), "env")
+			a := &opencodeAgent{bin: script, disableProjectSettings: tc.disable}
+			if _, err := a.ensureServer(context.Background(), t.TempDir(), []string{"NM_TEST_ENV_DUMP=" + dump}); err == nil {
+				t.Fatal("expected early-exit error from the fake bin")
+			}
+			got, err := os.ReadFile(dump)
+			if err != nil {
+				t.Fatalf("read env dump: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("serve process saw OPENCODE_DISABLE_PROJECT_CONFIG=%q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/daemon/gateneutralize_test.go
+++ b/internal/daemon/gateneutralize_test.go
@@ -18,7 +18,7 @@ func fakeLookPath(bin string) (string, error) { return "/fake/bin/" + bin, nil }
 // opt-out (disable_project_settings=true), a verified harness passes the gate and
 // its pipeline agent reports neutralized.
 func TestNewPipelineAgent_OptOut_AdmitsVerifiedHarness(t *testing.T) {
-	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentPi} {
+	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentPi, types.AgentOpenCode} {
 		cfg := &config.Config{Agent: name, DisableProjectSettings: true}
 		ag, err := newPipelineAgent(context.Background(), cfg, t.TempDir(), fakeLookPath)
 		if err != nil {
@@ -36,7 +36,7 @@ func TestNewPipelineAgent_OptOut_AdmitsVerifiedHarness(t *testing.T) {
 // verified neutralization knob is refused rather than launched with project
 // instructions loaded.
 func TestNewPipelineAgent_OptOut_RefusesUnverifiedHarness(t *testing.T) {
-	for _, name := range []types.AgentName{types.AgentOpenCode, types.AgentCopilot} {
+	for _, name := range []types.AgentName{types.AgentCopilot} {
 		cfg := &config.Config{Agent: name, DisableProjectSettings: true}
 		if _, err := newPipelineAgent(context.Background(), cfg, t.TempDir(), fakeLookPath); err == nil {
 			t.Fatalf("%s must be refused under opt-out", name)
@@ -51,8 +51,8 @@ func TestNewPipelineAgent_OptOut_RefusesUnverifiedHarness(t *testing.T) {
 // no suppression knob - is admitted and runs exactly as before.
 func TestNewPipelineAgent_NoOptOut_AdmitsEveryHarness(t *testing.T) {
 	// rovodev is omitted: its resolution runs a real version probe that a fake
-	// binary path cannot satisfy. opencode/pi/copilot already prove that an
-	// unverified adapter is admitted when the repo did not opt out.
+	// binary path cannot satisfy. copilot already proves that an unverified
+	// adapter is admitted when the repo did not opt out.
 	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentOpenCode, types.AgentPi, types.AgentCopilot} {
 		cfg := &config.Config{Agent: name} // DisableProjectSettings defaults false
 		ag, err := newPipelineAgent(context.Background(), cfg, t.TempDir(), fakeLookPath)
@@ -81,7 +81,7 @@ func TestNewPipelineAgent_OptOut_RefusesDefeatedKnob(t *testing.T) {
 // TestNewPipelineAgent_OptOut_FallbackRefusesAnyUnverifiedMember proves an
 // ordered fallback list fails closed under opt-out if any member is unverified.
 func TestNewPipelineAgent_OptOut_FallbackRefusesAnyUnverifiedMember(t *testing.T) {
-	cfg := &config.Config{Agents: []types.AgentName{types.AgentCodex, types.AgentOpenCode}, DisableProjectSettings: true}
+	cfg := &config.Config{Agents: []types.AgentName{types.AgentCodex, types.AgentCopilot}, DisableProjectSettings: true}
 	if _, err := newPipelineAgent(context.Background(), cfg, t.TempDir(), fakeLookPath); err == nil {
 		t.Fatal("a fallback list containing an unverified harness must be refused under opt-out")
 	}


### PR DESCRIPTION
## What

Makes `opencode` a verified gate-agent instruction neutralizer, so repositories that opt out of project agent-instruction files (`disable_project_settings: true`) can use opencode as the gate agent. This unlocks opencode as a default gate agent for AGENTS.md/CLAUDE.md repos.

## Why

The gate check (`GateInstructionNeutralizer` / `EnsureGateNeutralized`) runs only under the trusted `disable_project_settings` opt-out. opencode did not implement the capability: it spawns `opencode serve` with `cmd.Dir` set to the target checkout and creates sessions with `"directory": cwd`, so opencode discovers and loads the checkout's AGENTS.md/CLAUDE.md — the exact hazard the gate exists to prevent.

## What changed

- `internal/agent/opencode.go`: add `disableProjectSettings bool` field (mirroring the pi agent) and implement `NeutralizesGateInstructions() bool { return a.disableProjectSettings }` — pi-style, with no operator argv surface that could defeat the knob, so no `extraArgs` inspection is needed.
- `internal/agent/opencode_http.go`: in `ensureServer`, export `OPENCODE_DISABLE_PROJECT_CONFIG=1` to the `opencode serve` process when the opt-out is on. The env on the serve process matters — sessions inherit it and the flag is read from `process.env`. The var is appended through `gitSafeEnv` (which appends last so the last occurrence wins), so an inherited value cannot re-enable project settings.
- `internal/agent/agent.go`: thread `opts.DisableProjectSettings` into the agent for `types.AgentOpenCode` in `NewWithOptions`; update the capability doc/error copy to include opencode.
- Tests: move opencode into the verified set in `internal/agent/gateneutralize_test.go` and `internal/daemon/gateneutralize_test.go`, and add a regression (`TestOpencodeAgent_ServeEnvCarriesProjectSettingsKnob`) proving the knob reaches the serve process only under the opt-out and wins over an inherited value.

## Empirical basis

opencode's `OPENCODE_DISABLE_PROJECT_CONFIG` env knob was verified in the installed opencode v1.18.18 source (`packages/core/src/flag/flag.ts` and `packages/opencode/src/session/instruction.ts`): when set on the serve process, it skips project-level AGENTS.md/CLAUDE.md/CONTEXT.md discovery entirely, while user-level global files (`~/.config/opencode/AGENTS.md`) still load, which is correct. The knob is an internal opencode flag, not a public API — the code comments pin that semantic.

## Behavior

- Opt-out on: opencode serve runs with `OPENCODE_DISABLE_PROJECT_CONFIG=1`; the gate admits opencode.
- Opt-out off: nothing changes; opencode loads project instruction files exactly as before.

## Verification

- `go test ./internal/agent/...` passes (incl. `-race`).
- Daemon gate tests (`internal/daemon`, `TestNewPipelineAgent_OptOut_*`) pass.
- `make lint` passes (skill drift + `go vet`).
