### PR TITLE
chore(agents): use @AGENTS.md import instead of CLAUDE.md symlink

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,2 @@
-AGENTS.md
+<!-- Points Claude at AGENTS.md via import; edit AGENTS.md, not this file. -->
+@AGENTS.md


### PR DESCRIPTION
Replaces the `CLAUDE.md` symlink with a real one-line pointer file that uses Claude Code's native `@AGENTS.md` import.

The symlink is a footgun: an agent writing to `CLAUDE.md` follows the link and overwrites `AGENTS.md`, destroying project memory. The `@AGENTS.md` import loads the same content at load time with no extra turns, and a stray write only clobbers a recoverable two-line file.

Account-wide convention change.