### PR TITLE
fix(agent): prefer closed JSON fences over unclosed pi tails

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -298,25 +298,37 @@ func parseStructuredTextOutput(text string, schema json.RawMessage) (json.RawMes
 		return output, nil
 	}
 
-	candidates := fencedJSONCandidates(text)
-	var parsed []json.RawMessage
+	closed, openCands := fencedJSONCandidates(text)
+
 	var candidateErr error
-	for _, candidate := range candidates {
-		fenced, err := parseStructuredCandidate([]byte(candidate), validationSchema)
-		if err == nil {
-			parsed = append(parsed, fenced)
-			continue
+	parseCandidates := func(cands []string) []json.RawMessage {
+		var parsed []json.RawMessage
+		for _, candidate := range cands {
+			fenced, err := parseStructuredCandidate([]byte(candidate), validationSchema)
+			if err == nil {
+				parsed = append(parsed, fenced)
+				continue
+			}
+			if candidateErr == nil {
+				candidateErr = err
+			}
 		}
-		if candidateErr == nil {
-			candidateErr = err
-		}
+		return parsed
 	}
-	switch len(parsed) {
-	case 0:
-	case 1:
-		return parsed[0], nil
-	default:
+	// Closed fences are the canonical structured-output shape and win over
+	// open (unclosed, pi JSONL) candidates: prose that quotes ```json as an
+	// inline example never shadows a real trailing block, and an unclosed
+	// fence never competes with a closed one. Only when no closed fence
+	// parses do we consult the open candidates.
+	if parsed := parseCandidates(closed); len(parsed) > 1 {
 		return nil, fmt.Errorf("multiple JSON code fences found in output")
+	} else if len(parsed) == 1 {
+		return parsed[0], nil
+	}
+	if parsed := parseCandidates(openCands); len(parsed) > 1 {
+		return nil, fmt.Errorf("multiple JSON code fences found in output")
+	} else if len(parsed) == 1 {
+		return parsed[0], nil
 	}
 
 	if bare, err := lastBareJSONObject(text, validationSchema); err == nil && bare != nil {
@@ -348,53 +360,52 @@ func textValidationSchema(schema json.RawMessage) (json.RawMessage, error) {
 // Fence markers may appear anywhere in the text, including glued to the end
 // of a preceding line (e.g. "...behavior.```json"), which is a shape real
 // codex/GPT-5 output regularly produces.
-func fencedJSONCandidates(text string) []string {
-	var candidates []string
+//
+// Candidates are split into two groups. closed holds bodies of fences with
+// a matching closing fence (the canonical shape); open holds bodies of
+// fences with no closing fence, where the body runs to the end of the text
+// (the pi JSONL shape). The scan never stops at the first opener: an opener
+// whose candidate spans unrelated prose (e.g. prose quoting ```json as an
+// inline example) must not swallow a later, real fence block.
+func fencedJSONCandidates(text string) (closed, open []string) {
 	rest := text
 	for {
-		start := indexJSONFenceOpen(rest)
-		if start < 0 {
-			return candidates
+		marker := strings.Index(rest, "```")
+		if marker < 0 {
+			return closed, open
 		}
-		body := rest[start:]
-		end, next := indexJSONFenceClose(body)
+		contentStart, info := fenceContentStart(rest, marker)
+		if !strings.EqualFold(strings.TrimSpace(info), "json") {
+			// Not a JSON fence: skip it (or its whole block) and keep
+			// scanning for a real opener.
+			after := skipFenceBlock(rest[contentStart:])
+			if after < 0 {
+				after = 0
+			}
+			rest = rest[contentStart+after:]
+			continue
+		}
+		body := rest[contentStart:]
+		end, _ := indexJSONFenceClose(body)
 		if end < 0 {
-			// No closing fence: some agents (notably pi JSONL streams) emit an
-			// opening ```json fence glued to a JSON body that runs to the end
-			// of the output with no closing fence. Take everything after the
-			// opener as a candidate; parseStructuredCandidate validates it
-			// later and only adopts it when it is actually valid JSON.
-			candidates = append(candidates, body)
-			return candidates
+			// No closing fence: the JSON body runs to the end of the output
+			// (pi JSONL shape). Take everything after the opener as an open
+			// candidate; parseStructuredCandidate validates it later and
+			// only adopts it when it is actually valid JSON.
+			open = append(open, body)
+			return closed, open
 		}
-		candidates = append(candidates, body[:end])
-		rest = body[next:]
+		closed = append(closed, body[:end])
+		// Resume after the opener marker, not after this candidate's closing
+		// fence: an unvalidated candidate may span unrelated text, and a
+		// later real block must still be discovered on its own.
+		rest = rest[marker+3:]
 	}
 }
 
-// indexJSONFenceOpen returns the byte offset of the content immediately
-// following an opening ```json fence (the char after the info line's
-// newline), or -1 if no opener exists.
-func indexJSONFenceOpen(text string) int {
-	for searchStart := 0; searchStart < len(text); {
-		i := strings.Index(text[searchStart:], "```")
-		if i < 0 {
-			return -1
-		}
-		i += searchStart
-		contentStart, info := fenceContentStart(text, i)
-		if strings.EqualFold(strings.TrimSpace(info), "json") {
-			return contentStart
-		}
-		next := skipFenceBlock(text[contentStart:])
-		if next < 0 {
-			return -1
-		}
-		searchStart = contentStart + next
-	}
-	return -1
-}
-
+// fenceContentStart returns the byte offset where a fence's content begins
+// (immediately after the info token and any following newline) plus the
+// parsed info token itself.
 func fenceContentStart(text string, fenceStart int) (int, string) {
 	after := text[fenceStart+3:]
 	lineEnd := strings.IndexByte(after, '\n')
@@ -498,7 +509,11 @@ func lastBareJSONObject(text string, schema json.RawMessage) (json.RawMessage, e
 			contentStart, _ := fenceContentStart(text, i)
 			next := skipFenceBlock(text[contentStart:])
 			if next < 0 {
-				break
+				// An unpaired fence marker (e.g. ```json quoted inside prose)
+				// must not abort the scan of the whole output; skip the marker
+				// itself and keep looking for a bare object.
+				i += 2
+				continue
 			}
 			i = contentStart + next - 1
 			continue

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -359,6 +359,12 @@ func fencedJSONCandidates(text string) []string {
 		body := rest[start:]
 		end, next := indexJSONFenceClose(body)
 		if end < 0 {
+			// No closing fence: some agents (notably pi JSONL streams) emit an
+			// opening ```json fence glued to a JSON body that runs to the end
+			// of the output with no closing fence. Take everything after the
+			// opener as a candidate; parseStructuredCandidate validates it
+			// later and only adopts it when it is actually valid JSON.
+			candidates = append(candidates, body)
 			return candidates
 		}
 		candidates = append(candidates, body[:end])
@@ -392,10 +398,38 @@ func indexJSONFenceOpen(text string) int {
 func fenceContentStart(text string, fenceStart int) (int, string) {
 	after := text[fenceStart+3:]
 	lineEnd := strings.IndexByte(after, '\n')
-	if lineEnd < 0 {
-		return fenceStart + 3 + len(after), after
+	if lineEnd >= 0 {
+		after = after[:lineEnd]
 	}
-	return fenceStart + 3 + lineEnd + 1, after[:lineEnd]
+	info, rest := fenceInfoToken(after)
+	start := fenceStart + 3 + rest
+	if start < len(text) && text[start] == '\n' {
+		start++
+	}
+	return start, info
+}
+
+// fenceInfoToken returns the leading info token of a fence line (the part
+// after ```) together with its end offset within s. The token is a word
+// made of letters/digits/`-`/`_`; anything else (whitespace, `{`, `[`, …)
+// terminates it. This tolerates ```json glued directly to a JSON body on
+// the same line (e.g. ```json{"findings":[]}) — a shape real pi JSONL
+// streams produce when content blocks are concatenated without separators.
+func fenceInfoToken(s string) (string, int) {
+	i := 0
+	for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
+		i++
+	}
+	start := i
+	for i < len(s) {
+		c := s[i]
+		isWord := (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_'
+		if !isWord {
+			break
+		}
+		i++
+	}
+	return s[start:i], i
 }
 
 func skipFenceBlock(text string) int {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -662,3 +662,37 @@ func TestOutputSnippet_TruncatesLongText(t *testing.T) {
 		t.Errorf("expected 200 runes plus ellipsis, got %d runes", len(runes))
 	}
 }
+
+func TestFinalizeTextResult_WithSchemaParsesPiSameLineFence(t *testing.T) {
+	// Regression: pi JSONL output concatenates content blocks without
+	// separators, producing ```json glued to the JSON body on the same line
+	// (no newline after the fence info token). The fence parser must still
+	// recognize the ```json fence and extract the body.
+	text := "The change is docs-only: 3 lines appended to README.md.```json{  \"findings\": [],  \"summary\": \"docs-only change\"}"
+	result, err := finalizeTextResult("pi", text, json.RawMessage(`{"type":"object"}`), TokenUsage{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var output struct {
+		Findings []any  `json:"findings"`
+		Summary  string `json:"summary"`
+	}
+	if err := json.Unmarshal(result.Output, &output); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+	if output.Summary != "docs-only change" {
+		t.Errorf("expected summary=docs-only change, got %q", output.Summary)
+	}
+}
+
+func TestFenceContentStart_InfoTokenWithSameLineBody(t *testing.T) {
+	// fence info token followed immediately by content on the same line.
+	start, info := fenceContentStart("```json{\"findings\":[]}", 0)
+	if info != "json" {
+		t.Errorf("expected info=json, got %q", info)
+	}
+	want := `{"findings":[]}`
+	if got := "```json{\"findings\":[]}"[start:]; got != want {
+		t.Errorf("content start = %d (got %q), want %q", start, got, want)
+	}
+}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -593,26 +593,32 @@ func TestFinalizeTextResult_WithSchemaRejectsAmbiguousFencedJSON(t *testing.T) {
 func TestFencedJSONCandidates_IgnoreBackticksInsideJSONString(t *testing.T) {
 	text := "review complete\n```json\n{\"summary\":\"quoted ```snippet``` in markdown\",\"findings\":[]}\n```\npostlude"
 
-	got := fencedJSONCandidates(text)
-	if len(got) != 1 {
-		t.Fatalf("expected 1 candidate, got %d", len(got))
+	closed, open := fencedJSONCandidates(text)
+	if len(open) != 0 {
+		t.Fatalf("expected no open candidates, got %d", len(open))
+	}
+	if len(closed) != 1 {
+		t.Fatalf("expected 1 closed candidate, got %d", len(closed))
 	}
 	want := "{\"summary\":\"quoted ```snippet``` in markdown\",\"findings\":[]}\n"
-	if got[0] != want {
-		t.Fatalf("candidate = %q, want %q", got[0], want)
+	if closed[0] != want {
+		t.Fatalf("candidate = %q, want %q", closed[0], want)
 	}
 }
 
 func TestFencedJSONCandidates_AllowIndentedClosingFence(t *testing.T) {
 	text := "review complete\n```json\n{\"summary\":\"ok\",\"findings\":[]}\n   ```\nnext paragraph"
 
-	got := fencedJSONCandidates(text)
-	if len(got) != 1 {
-		t.Fatalf("expected 1 candidate, got %d", len(got))
+	closed, open := fencedJSONCandidates(text)
+	if len(open) != 0 {
+		t.Fatalf("expected no open candidates, got %d", len(open))
+	}
+	if len(closed) != 1 {
+		t.Fatalf("expected 1 closed candidate, got %d", len(closed))
 	}
 	want := "{\"summary\":\"ok\",\"findings\":[]}\n"
-	if got[0] != want {
-		t.Fatalf("candidate = %q, want %q", got[0], want)
+	if closed[0] != want {
+		t.Fatalf("candidate = %q, want %q", closed[0], want)
 	}
 }
 
@@ -628,8 +634,9 @@ func TestFinalizeTextResult_WithSchemaIgnoresJSONInsideNonJSONFence(t *testing.T
 		"Final answer: not valid JSON",
 	}, "\n")
 
-	if got := fencedJSONCandidates(text); len(got) != 0 {
-		t.Fatalf("expected no fenced JSON candidates, got %q", got)
+	closed, open := fencedJSONCandidates(text)
+	if len(closed) != 0 || len(open) != 0 {
+		t.Fatalf("expected no fenced JSON candidates, got closed=%q open=%q", closed, open)
 	}
 
 	_, err := finalizeTextResult("codex", text, json.RawMessage(`{"type":"object"}`), TokenUsage{})
@@ -694,5 +701,39 @@ func TestFenceContentStart_InfoTokenWithSameLineBody(t *testing.T) {
 	want := `{"findings":[]}`
 	if got := "```json{\"findings\":[]}"[start:]; got != want {
 		t.Errorf("content start = %d (got %q), want %q", start, got, want)
+	}
+}
+
+func TestFinalizeTextResult_WithSchemaParsesProseQuotingFenceExampleThenClosedBlock(t *testing.T) {
+	// Regression (upstream PR review failure): pi review output quotes
+	// ```json{...} as an inline example inside prose (an unclosed fence),
+	// then ends with a real closed ```json block. The quoted example must
+	// not shadow the trailing block, and must not fail the whole parse.
+	text := strings.Join([]string{
+		"The fix: ` ```json{\"findings\":[]}` glued to the body on the same line.",
+		"I traced the old fence parser in internal/agent/agent.go.",
+		"```json",
+		`{"findings":[{"id":"F1","severity":"warning"}],"summary":"one issue"}`,
+		"```",
+	}, "\n")
+	result, err := finalizeTextResult("pi", text, json.RawMessage(`{"type":"object"}`), TokenUsage{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var output struct {
+		Findings []struct {
+			ID       string `json:"id"`
+			Severity string `json:"severity"`
+		} `json:"findings"`
+		Summary string `json:"summary"`
+	}
+	if err := json.Unmarshal(result.Output, &output); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+	if len(output.Findings) != 1 || output.Findings[0].ID != "F1" {
+		t.Errorf("expected trailing block findings F1, got %+v", output.Findings)
+	}
+	if output.Summary != "one issue" {
+		t.Errorf("expected summary=one issue, got %q", output.Summary)
 	}
 }


### PR DESCRIPTION
## What Changed

Final changed paths and statuses:

```text
M	internal/agent/agent.go
M	internal/agent/agent_test.go
```

## Risk Assessment

✅ Low: 对报告的 pi/codex 围栏形状的解析器宽松性修复边界良好：闭合围栏保持优先，扫描跳过未验证候选，因此散文引用的示例不能遮蔽真实尾随闭合块（通过追踪回归测试验证），所有预先存在的闭合围栏流程行为相同，唯一的残余风险是文档化的、schema 把关的尾随未闭合引用示例静默采纳，这很窄且是预期 JSONL 形状所固有的。

## Testing

验证 pi JSONL fence 解析修复端到端工作：3 个新回归测试在基础提交确认失败、在修复提交全部通过；用生产 review schema 驱动真实解析路径，5 种 pi 输出形态（同行粘连 ```json、散文引用内联示例+尾部闭合块、标准闭合块、未闭合 tail、未配对 marker+裸 JSON）全部正确提取结构化结果，关键场景 prose-quote-then-closed-block（上游 PR review 失败用例）的尾部闭合块正确胜出并提取出 F1 finding；internal/agent 包全套测试通过，工作树保持干净。

<details>
<summary>Evidence: pi JSONL fence 端到端解析证据（生产 review schema，5 种真实输出形态）</summary>

<code>EVIDENCE [same-line-glue] OK: risk_level=low risk_scope=source-or-external testing_summary=&#34;all green&#34; findings=0&#10;EVIDENCE [prose-quote-then-closed-block] OK: risk_level=medium risk_scope=source-or-external testing_summary=&#34;focused tests pass&#34; findings=1&#10;EVIDENCE [canonical-closed-fence] OK: risk_level=low risk_scope=source-or-external testing_summary=&#34;ok&#34; findings=0&#10;EVIDENCE [open-tail-at-end] OK: risk_level=low risk_scope=source-or-external testing_summary=&#34;ok&#34; findings=0&#10;EVIDENCE [unpaired-marker-then-bare-object] OK: risk_level=low risk_scope=source-or-external testing_summary=&#34;ok&#34; findings=0&#10;--- PASS: TestZZEvidence_PiJSONLFenceEndToEnd (0.00s)</code>

```text
=== RUN   TestZZEvidence_PiJSONLFenceEndToEnd
=== RUN   TestZZEvidence_PiJSONLFenceEndToEnd/unpaired-marker-then-bare-object
EVIDENCE [unpaired-marker-then-bare-object] OK: risk_level=low risk_scope=source-or-external testing_summary="ok" findings=0
=== RUN   TestZZEvidence_PiJSONLFenceEndToEnd/open-tail-at-end
EVIDENCE [open-tail-at-end] OK: risk_level=low risk_scope=source-or-external testing_summary="ok" findings=0
=== RUN   TestZZEvidence_PiJSONLFenceEndToEnd/same-line-glue
EVIDENCE [same-line-glue] OK: risk_level=low risk_scope=source-or-external testing_summary="all green" findings=0
=== RUN   TestZZEvidence_PiJSONLFenceEndToEnd/prose-quote-then-closed-block
EVIDENCE [prose-quote-then-closed-block] OK: risk_level=medium risk_scope=source-or-external testing_summary="focused tests pass" findings=1
=== RUN   TestZZEvidence_PiJSONLFenceEndToEnd/canonical-closed-fence
EVIDENCE [canonical-closed-fence] OK: risk_level=low risk_scope=source-or-external testing_summary="ok" findings=0
--- PASS: TestZZEvidence_PiJSONLFenceEndToEnd (0.00s)
    --- PASS: TestZZEvidence_PiJSONLFenceEndToEnd/unpaired-marker-then-bare-object (0.00s)
    --- PASS: TestZZEvidence_PiJSONLFenceEndToEnd/open-tail-at-end (0.00s)
    --- PASS: TestZZEvidence_PiJSONLFenceEndToEnd/same-line-glue (0.00s)
    --- PASS: TestZZEvidence_PiJSONLFenceEndToEnd/prose-quote-then-closed-block (0.00s)
    --- PASS: TestZZEvidence_PiJSONLFenceEndToEnd/canonical-closed-fence (0.00s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/agent	0.452s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"cdf49ec03244458de483adca470972e76057088e","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Rebase** - 1 warning</summary>

- ⚠️ `.release-please-manifest.json` - branch carries 1 commit(s) that exist on your local main branch but were never pushed to origin/main; rebasing would bundle this unrelated work (49 file(s)) into the PR:
- d701ef8 fix(agent): parse pi JSONL fences glued to body on the same line

Push main to origin, or rebase your branch onto origin/main, before gating.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `internal/agent/agent.go:389` - Open-candidate (未闭合的 ```json 一直延伸至文本末尾) 与新的 lastBareJSONObject 继续扫描 (第 515 行, `i += 2`) 现在可能静默地将散文引用中的内联 ```json 示例当作结构化输出来采纳，而旧代码则会在解析错误时大声失败。例如：一个 agent 的最终消息以 &#34;the shape is ```json{\&#34;findings\&#34;:[],\&#34;summary\&#34;:\&#34;docs-only change\&#34;}&#34; (加引号的示例，后面没有内容) 结尾，现在如果该示例通过 schema 校验，则会被作为运行的 Output，而非抛出解析失败。这是 pi JSONL 宽松处理的文档化权衡（优先闭合围栏，schema 校验把关采纳），从文本上看真实 pi 答案和加引号的示例无法区分，因此不存在精确的判别器。仅标记以记录行为变化：对于这一窄形状，失败模式从大声转为静默。若对 review schema（其 `findings: []` 形状常被引用）需要更严格的行为，可考虑仅在未闭合尾随围栏是输出中最后内容时才优先处理，或无条件让位于闭合围栏组——但这是增强，而非本修复中的缺陷。

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`go test ./internal/agent/ -run &#39;TestFinalizeTextResult|TestFencedJSONCandidates|TestFenceContentStart|TestOutputSnippet&#39; -v` — 全部目标测试通过（含 3 个新回归测试）</code>
- <code>基础提交回归验证：`git show 5a36f2b:internal/agent/{agent.go,agent_test.go}` 换回基础版 + 追加 3 个新测试 → `TestFinalizeTextResult_WithSchemaParsesPiSameLineFence` / `TestFenceContentStart_InfoTokenWithSameLineBody` / `TestFinalizeTextResult_WithSchemaParsesProseQuotingFenceExampleThenClosedBlock` 全部 FAIL（invalid character &#39;T&#39;），随后恢复工作树</code>
- <code>端到端证据：临时测试 `TestZZEvidence_PiJSONLFenceEndToEnd` 用生产 reviewFindingsSchema 驱动 `finalizeTextResult`，5 种形态（same-line-glue / prose-quote-then-closed-block / canonical-closed-fence / open-tail-at-end / unpaired-marker-then-bare-object）全部解析出正确结构化输出，临时测试文件已删除</code>
- <code>`go test ./internal/agent/` — 整个 agent 包套件通过（ok 8.065s）</code>
- <code>`git status --short` + `git diff --stat` — 验证临时文件清理后工作树干净</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
