### PR TITLE
fix(agent): harden stdin prompt delivery

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -3,7 +3,17 @@ run-name: "PR #${{ github.event.pull_request.number }} body compliance - ${{ git
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    # Body-bearing events only. The verdict is a pure function of
+    # pull_request.body, so a push carries no new body to judge - but it does
+    # move the head SHA. The pipeline pushes (Push step) before it writes the
+    # deterministic "## Pipeline" section (PR step), so a `synchronize` trigger
+    # pinned a FAILURE check run to the new head for a body the same run was
+    # about to fix. GitHub keeps that failure next to the later `edited` SUCCESS
+    # rather than replacing it, and `gh pr checks` collapses same-named check
+    # runs by startedAt alone, so the pipeline's own CI monitor could read the
+    # stale failure and park the run red forever (PR #773). No ruleset requires
+    # this status check, so no head SHA needs a run of its own.
+    types: [opened, edited, reopened]
     branches:
       - main
     # Never create a run for a release-please PR. The job-level author exemption
@@ -19,7 +29,7 @@ permissions:
 # GitHub concurrency groups retain at most one pending run, replacing older
 # pending runs even when cancel-in-progress is false. Give body-bearing events
 # an immutable per-event group so first-time-fork approvals can never collapse
-# opened/edited checks. Keep synchronize/reopened coalescing as before.
+# opened/edited checks. Keep reopened coalescing as before.
 concurrency:
   group: no-mistakes-required-${{ github.event.pull_request.number }}-${{ (github.event.action == 'opened' || github.event.action == 'edited') && github.run_id || 'head-change' }}
   cancel-in-progress: true

--- a/cmd/fakeagent/codex.go
+++ b/cmd/fakeagent/codex.go
@@ -4,12 +4,17 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 )
 
-func runCodex(args []string, scenario *Scenario) int {
-	prompt := extractCodexPrompt(args)
+func runCodex(args []string, promptReader io.Reader, scenario *Scenario) int {
+	prompt, err := extractCodexPrompt(args, promptReader)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fakeagent: codex prompt: %v\n", err)
+		return 1
+	}
 	logInvocation("codex", prompt, args)
 
 	action := scenario.Match(prompt)
@@ -172,19 +177,19 @@ func filterStructuredToSchema(structured map[string]any, schemaPath string) (map
 	return filtered, nil
 }
 
-// extractCodexPrompt finds the prompt positional. Real codex argv is
-// `codex exec [user-flags...] <prompt> --json [...]` for a fresh session and
-// `codex exec resume [user-flags...] <session-id> <prompt> --json [...]` for
-// a session-resume turn, so on resume the prompt is the positional after the
-// session id.
-func extractCodexPrompt(args []string) string {
+// extractCodexPrompt mirrors Codex's stdin prompt contract. Real codex argv is
+// `codex exec [user-flags...] - --json [...]` for a fresh session and
+// `codex exec resume [user-flags...] <session-id> - --json [...]` for a
+// resumed session; in both cases the complete prompt is read to EOF from stdin.
+func extractCodexPrompt(args []string, promptReader io.Reader) (string, error) {
 	flagsWithValues := map[string]bool{
 		"-m": true, "--model": true,
 		"--sandbox": true, "--ask-for-approval": true,
 		"--config": true, "--profile": true,
 		"--output-schema":    true,
 		"--reasoning-effort": true, "--reasoning-summary": true,
-		"-c": true, "--cd": true,
+		"--color": true,
+		"-c":      true, "--cd": true,
 	}
 	start := 0
 	for i, a := range args {
@@ -200,19 +205,24 @@ func extractCodexPrompt(args []string) string {
 			i++
 			continue
 		}
-		if len(a) > 0 && a[0] == '-' {
+		if len(a) > 1 && a[0] == '-' {
 			continue
 		}
 		positionals = append(positionals, a)
 	}
 	if len(positionals) == 0 {
-		return ""
+		return "", fmt.Errorf("missing stdin prompt marker")
 	}
 	if positionals[0] == "resume" {
-		if len(positionals) >= 3 {
-			return positionals[2] // resume <session-id> <prompt>
+		if len(positionals) != 3 || positionals[2] != "-" {
+			return "", fmt.Errorf("resume missing stdin prompt marker")
 		}
-		return "" // resume without id+prompt is not a shape no-mistakes emits
+	} else if len(positionals) != 1 || positionals[0] != "-" {
+		return "", fmt.Errorf("missing stdin prompt marker")
 	}
-	return positionals[0]
+	prompt, err := io.ReadAll(promptReader)
+	if err != nil {
+		return "", fmt.Errorf("read stdin: %w", err)
+	}
+	return string(prompt), nil
 }

--- a/cmd/fakeagent/codex_test.go
+++ b/cmd/fakeagent/codex_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -181,18 +182,37 @@ func TestExtractCodexOutputSchemaPath(t *testing.T) {
 	}
 }
 
-func TestExtractCodexPromptSkipsOutputSchemaValue(t *testing.T) {
-	t.Helper()
-
-	args := []string{
-		"exec",
-		"--output-schema", "/tmp/schema.json",
-		"--model", "gpt-5.4",
-		"review this diff",
-		"--json",
+func TestExtractCodexPromptReadsStdin(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "fresh",
+			args: []string{"exec", "--output-schema", "/tmp/schema.json", "--model", "gpt-5.4", "-", "--json", "--color", "never"},
+		},
+		{
+			name: "resume",
+			args: []string{"exec", "resume", "--model", "gpt-5.4", "thread-123", "-", "--json"},
+		},
 	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			const prompt = "review this diff"
+			got, err := extractCodexPrompt(tc.args, strings.NewReader(prompt))
+			if err != nil {
+				t.Fatalf("extractCodexPrompt: %v", err)
+			}
+			if got != prompt {
+				t.Fatalf("prompt = %q, want %q", got, prompt)
+			}
+		})
+	}
+}
 
-	if got := extractCodexPrompt(args); got != "review this diff" {
-		t.Fatalf("prompt = %q, want %q", got, "review this diff")
+func TestExtractCodexPromptRejectsArgvPrompt(t *testing.T) {
+	_, err := extractCodexPrompt([]string{"exec", "prompt in argv", "--json"}, strings.NewReader(""))
+	if err == nil {
+		t.Fatal("expected argv prompt to be rejected")
 	}
 }

--- a/cmd/fakeagent/main.go
+++ b/cmd/fakeagent/main.go
@@ -39,7 +39,7 @@ func run(argv []string) int {
 	case "claude":
 		return runClaude(args, os.Stdin, scenario)
 	case "codex":
-		return runCodex(args, scenario)
+		return runCodex(args, os.Stdin, scenario)
 	case "opencode":
 		return runOpencode(args, scenario)
 	case "gh":

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -306,6 +306,7 @@ When the target matches a first-class alias such as `acp:cursor`, no-mistakes su
 Configure custom target commands in the [Global Config Reference](/no-mistakes/reference/global-config/#acp_registry_overrides).
 
 no-mistakes invokes acpx with JSON output, approve-all permissions, denied non-interactive permission prompts, and the repo worktree as `--cwd`.
+The prompt is written to the bridge's stdin (`exec --file -`) instead of being passed as a command-line argument, so a large pipeline prompt cannot exceed the operating system's argument-length limit; this requires an `acpx` build that accepts `exec --file -`.
 Structured output is handled by appending the requested JSON schema to the prompt and validating the final assistant text.
 
 ## Checking agent availability

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -306,7 +306,6 @@ When the target matches a first-class alias such as `acp:cursor`, no-mistakes su
 Configure custom target commands in the [Global Config Reference](/no-mistakes/reference/global-config/#acp_registry_overrides).
 
 no-mistakes invokes acpx with JSON output, approve-all permissions, denied non-interactive permission prompts, and the repo worktree as `--cwd`.
-The prompt is written to the bridge's stdin (`exec --file -`) instead of being passed as a command-line argument, so a large pipeline prompt cannot exceed the operating system's argument-length limit; this requires an `acpx` build that accepts `exec --file -`.
 Structured output is handled by appending the requested JSON schema to the prompt and validating the final assistant text.
 
 ## Checking agent availability

--- a/internal/agent/acpx.go
+++ b/internal/agent/acpx.go
@@ -43,6 +43,8 @@ func (a *acpxAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) 
 	cmd.Env = gitSafeEnv(opts.CWD, opts.Env)
 	shellenv.ConfigureShellCommand(cmd)
 
+	// The prompt travels on stdin (`exec --file -`), never argv: pipeline prompts
+	// routinely exceed the OS argument-length limit, which fails the spawn outright.
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return nil, fmt.Errorf("acpx stdin pipe: %w", err)

--- a/internal/agent/acpx.go
+++ b/internal/agent/acpx.go
@@ -90,6 +90,9 @@ func (a *acpxAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) 
 		return nil, retErr
 	}
 	if stdinErr != nil {
+		if out := acpxProcessErrorOutput(stderrBuf, stdoutErr); out != "" {
+			stdinErr = fmt.Errorf("%w: %s", stdinErr, out)
+		}
 		emitAgentExited(opts, a.Name(), pid, stdinErr)
 		return nil, stdinErr
 	}

--- a/internal/agent/acpx.go
+++ b/internal/agent/acpx.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
@@ -32,20 +33,35 @@ func (a *acpxAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
 }
 
 func (a *acpxAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
+	prompt := opts.Prompt
+	if len(opts.JSONSchema) > 0 {
+		prompt = buildACPStructuredPrompt(prompt, opts.JSONSchema)
+	}
 	args := a.buildArgs(opts)
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD
-	cmd.Stdin = nil
 	cmd.Env = gitSafeEnv(opts.CWD, opts.Env)
 	shellenv.ConfigureShellCommand(cmd)
 
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("acpx stdin pipe: %w", err)
+	}
 	started, err := startNativeAgentCommand(cmd)
 	if err != nil {
+		_ = stdin.Close()
 		return nil, fmt.Errorf("acpx start: %w", err)
 	}
 	defer started.closePipes()
 	pid := started.pid()
 	emitAgentStarted(opts, a.Name(), pid)
+
+	stdinErrCh := make(chan error, 1)
+	go func() {
+		_, writeErr := io.WriteString(stdin, prompt)
+		closeErr := stdin.Close()
+		stdinErrCh <- errors.Join(writeErr, closeErr)
+	}()
 
 	var stderrBuf []byte
 	var stderrWG sync.WaitGroup
@@ -60,16 +76,22 @@ func (a *acpxAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) 
 	if err != nil {
 		err = started.waitAfterParseError(err)
 		stderrWG.Wait()
+		err = errors.Join(err, acpxStdinError(<-stdinErrCh))
 		retErr := fmt.Errorf("acpx parse events: %w", err)
 		emitAgentExited(opts, a.Name(), pid, retErr)
 		return nil, retErr
 	}
 	waitErr := started.wait()
 	stderrWG.Wait()
+	stdinErr := acpxStdinError(<-stdinErrCh)
 	if waitErr != nil {
-		retErr := fmt.Errorf("acpx exited: %w: %s", waitErr, acpxProcessErrorOutput(stderrBuf, stdoutErr))
+		retErr := fmt.Errorf("acpx exited: %w: %s", errors.Join(waitErr, stdinErr), acpxProcessErrorOutput(stderrBuf, stdoutErr))
 		emitAgentExited(opts, a.Name(), pid, retErr)
 		return nil, retErr
+	}
+	if stdinErr != nil {
+		emitAgentExited(opts, a.Name(), pid, stdinErr)
+		return nil, stdinErr
 	}
 	if usage.OutputTokens == 0 {
 		usage.OutputTokens = estimateAcpxTokens(len(text))
@@ -82,11 +104,6 @@ func (a *acpxAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) 
 func (a *acpxAgent) Close() error { return nil }
 
 func (a *acpxAgent) buildArgs(opts RunOpts) []string {
-	prompt := opts.Prompt
-	if len(opts.JSONSchema) > 0 {
-		prompt = buildACPStructuredPrompt(prompt, opts.JSONSchema)
-	}
-
 	args := make([]string, 0, 12)
 	if a.rawCommand != "" {
 		args = append(args, "--agent", a.rawCommand)
@@ -104,8 +121,15 @@ func (a *acpxAgent) buildArgs(opts RunOpts) []string {
 	if a.rawCommand == "" {
 		args = append(args, a.target)
 	}
-	args = append(args, "exec", prompt)
+	args = append(args, "exec", "--file", "-")
 	return args
+}
+
+func acpxStdinError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("acpx stdin: %w", err)
 }
 
 func acpxProcessErrorOutput(stderr []byte, stdoutErr string) string {

--- a/internal/agent/acpx.go
+++ b/internal/agent/acpx.go
@@ -56,12 +56,7 @@ func (a *acpxAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) 
 	pid := started.pid()
 	emitAgentStarted(opts, a.Name(), pid)
 
-	stdinErrCh := make(chan error, 1)
-	go func() {
-		_, writeErr := io.WriteString(stdin, prompt)
-		closeErr := stdin.Close()
-		stdinErrCh <- errors.Join(writeErr, closeErr)
-	}()
+	stdinErrCh := writeNativeAgentStdin(stdin, prompt)
 
 	var stderrBuf []byte
 	var stderrWG sync.WaitGroup

--- a/internal/agent/acpx.go
+++ b/internal/agent/acpx.go
@@ -43,8 +43,6 @@ func (a *acpxAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) 
 	cmd.Env = gitSafeEnv(opts.CWD, opts.Env)
 	shellenv.ConfigureShellCommand(cmd)
 
-	// The prompt travels on stdin (`exec --file -`), never argv: pipeline prompts
-	// routinely exceed the OS argument-length limit, which fails the spawn outright.
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return nil, fmt.Errorf("acpx stdin pipe: %w", err)

--- a/internal/agent/acpx_spawn_test.go
+++ b/internal/agent/acpx_spawn_test.go
@@ -4,23 +4,29 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
 // writeStubAcpx writes a stub acpx binary that records its argv (one arg per
-// line) to the file named by NM_TEST_ACPX_ARGS_FILE and emits a minimal valid
-// acpx JSON event stream.
+// line) and stdin, then emits a minimal valid acpx JSON event stream.
 func writeStubAcpx(t *testing.T, dir string) string {
 	t.Helper()
 	path := filepath.Join(dir, "acpx")
 	script := `#!/bin/sh
 printf '%s\n' "$@" > "$NM_TEST_ACPX_ARGS_FILE"
-printf '{"method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","text":"cursor stub reply"}}}\n'
+cat > "$NM_TEST_ACPX_STDIN_FILE"
+if [ -n "$NM_TEST_ACPX_EVENT" ]; then
+  printf '%s\n' "$NM_TEST_ACPX_EVENT"
+else
+  printf '{"method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","text":"cursor stub reply"}}}\n'
+fi
 `
 	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
 		t.Fatal(err)
@@ -43,6 +49,7 @@ func TestAcpxAgent_Run_CursorSpawnsDefaultCommandWithoutOverrides(t *testing.T) 
 			dir := t.TempDir()
 			argsFile := filepath.Join(dir, "argv.txt")
 			t.Setenv("NM_TEST_ACPX_ARGS_FILE", argsFile)
+			t.Setenv("NM_TEST_ACPX_STDIN_FILE", filepath.Join(dir, "stdin.txt"))
 			stub := writeStubAcpx(t, dir)
 
 			a, err := New(tc.agent, stub, nil)
@@ -65,8 +72,8 @@ func TestAcpxAgent_Run_CursorSpawnsDefaultCommandWithoutOverrides(t *testing.T) 
 			if len(argv) < 2 || argv[0] != "--agent" || argv[1] != "cursor-agent acp" {
 				t.Errorf("spawned argv = %q, want leading --agent \"cursor-agent acp\"", argv)
 			}
-			if len(argv) < 2 || argv[len(argv)-2] != "exec" || argv[len(argv)-1] != "review this change" {
-				t.Errorf("spawned argv = %q, want trailing exec <prompt>", argv)
+			if len(argv) < 3 || strings.Join(argv[len(argv)-3:], "\x00") != "exec\x00--file\x00-" {
+				t.Errorf("spawned argv = %q, want trailing exec --file -", argv)
 			}
 			for _, arg := range argv {
 				if arg == "cursor" {
@@ -75,5 +82,75 @@ func TestAcpxAgent_Run_CursorSpawnsDefaultCommandWithoutOverrides(t *testing.T) 
 			}
 			t.Logf("spawned: acpx %s", strings.Join(argv, " "))
 		})
+	}
+}
+
+func TestAcpxAgent_Run_SendsLargePromptOnlyOnStdin(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		schema json.RawMessage
+	}{
+		{name: "plain prompt"},
+		{name: "structured prompt", schema: json.RawMessage(`{"type":"object"}`)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			argsFile := filepath.Join(dir, "argv.txt")
+			stdinFile := filepath.Join(dir, "stdin.txt")
+			t.Setenv("NM_TEST_ACPX_ARGS_FILE", argsFile)
+			t.Setenv("NM_TEST_ACPX_STDIN_FILE", stdinFile)
+
+			prompt := strings.Repeat("x", 4096)
+			wantPrompt := prompt
+			if len(tc.schema) > 0 {
+				wantPrompt = buildACPStructuredPrompt(prompt, tc.schema)
+				t.Setenv("NM_TEST_ACPX_EVENT", `{"method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","text":"{\"ok\":true}"}}}`)
+			}
+			a := &acpxAgent{bin: writeStubAcpx(t, dir), target: "gemini"}
+			if _, err := a.Run(context.Background(), RunOpts{Prompt: prompt, CWD: dir, JSONSchema: tc.schema}); err != nil {
+				t.Fatalf("Run: %v", err)
+			}
+
+			argsData, err := os.ReadFile(argsFile)
+			if err != nil {
+				t.Fatalf("read argv: %v", err)
+			}
+			argv := strings.Split(strings.TrimRight(string(argsData), "\n"), "\n")
+			if len(argv) < 3 || strings.Join(argv[len(argv)-3:], "\x00") != "exec\x00--file\x00-" {
+				t.Fatalf("spawned argv = %q, want trailing exec --file -", argv)
+			}
+			for _, arg := range argv {
+				if arg == wantPrompt {
+					t.Fatalf("spawned argv contains the prompt")
+				}
+			}
+
+			stdinData, err := os.ReadFile(stdinFile)
+			if err != nil {
+				t.Fatalf("read stdin: %v", err)
+			}
+			if got := string(stdinData); got != wantPrompt {
+				t.Fatalf("stdin prompt mismatch: got %d bytes, want %d", len(got), len(wantPrompt))
+			}
+		})
+	}
+}
+
+func TestAcpxAgent_Run_SurfacesStdinWriteFailure(t *testing.T) {
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "acpx")
+	script := `#!/bin/sh
+printf '{"method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","text":"early reply"}}}\n'
+`
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	a := &acpxAgent{bin: stub, target: "gemini"}
+	_, err := a.Run(ctx, RunOpts{Prompt: strings.Repeat("x", 2*1024*1024), CWD: dir})
+	if err == nil || !strings.Contains(err.Error(), "acpx stdin") {
+		t.Fatalf("Run error = %v, want acpx stdin write failure", err)
 	}
 }

--- a/internal/agent/acpx_spawn_test.go
+++ b/internal/agent/acpx_spawn_test.go
@@ -141,6 +141,7 @@ func TestAcpxAgent_Run_SurfacesStdinWriteFailure(t *testing.T) {
 	stub := filepath.Join(dir, "acpx")
 	script := `#!/bin/sh
 printf '{"method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","text":"early reply"}}}\n'
+printf 'acpx: unknown option --file\n' >&2
 `
 	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
 		t.Fatal(err)
@@ -152,5 +153,8 @@ printf '{"method":"session/update","params":{"update":{"sessionUpdate":"agent_me
 	_, err := a.Run(ctx, RunOpts{Prompt: strings.Repeat("x", 2*1024*1024), CWD: dir})
 	if err == nil || !strings.Contains(err.Error(), "acpx stdin") {
 		t.Fatalf("Run error = %v, want acpx stdin write failure", err)
+	}
+	if !strings.Contains(err.Error(), "unknown option --file") {
+		t.Fatalf("Run error = %v, want child stderr in stdin write failure", err)
 	}
 }

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -152,7 +152,7 @@ func TestACPAgentBuildArgsUsesExecMode(t *testing.T) {
 	a := &acpxAgent{target: "gemini"}
 	args := a.buildArgs(RunOpts{Prompt: "do work"})
 
-	if got, want := args[len(args)-3:], []string{"gemini", "exec", "do work"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+	if got, want := args[len(args)-4:], []string{"gemini", "exec", "--file", "-"}; strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("trailing args = %q, want %q", got, want)
 	}
 }
@@ -256,9 +256,12 @@ func TestACPAgentRunParsesAcpxJSONOutput(t *testing.T) {
 	dir := t.TempDir()
 	script := filepath.Join(dir, "acpx")
 	argLog := filepath.Join(dir, "args.txt")
+	stdinLog := filepath.Join(dir, "stdin.txt")
 	t.Setenv("ARG_LOG", argLog)
+	t.Setenv("STDIN_LOG", stdinLog)
 	contents := `#!/bin/sh
 printf '%s\n' "$@" > "$ARG_LOG"
+cat > "$STDIN_LOG"
 printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"usage_update","used":123,"size":1000}}}'
 printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"{\"done\":true}"}}}}'
 `
@@ -271,10 +274,11 @@ printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"s
 		t.Fatalf("New() error = %v", err)
 	}
 	var chunks []string
+	schema := json.RawMessage(`{"type":"object"}`)
 	result, err := a.Run(context.Background(), RunOpts{
 		Prompt:     "do work",
 		CWD:        dir,
-		JSONSchema: json.RawMessage(`{"type":"object"}`),
+		JSONSchema: schema,
 		OnChunk:    func(text string) { chunks = append(chunks, text) },
 	})
 	if err != nil {
@@ -298,10 +302,20 @@ printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"update":{"s
 		t.Fatalf("read args: %v", err)
 	}
 	argsText := string(argsData)
-	for _, want := range []string{"--cwd\n" + dir, "--format\njson", "--json-strict", "gemini", "do work"} {
+	for _, want := range []string{"--cwd\n" + dir, "--format\njson", "--json-strict", "gemini", "exec\n--file\n-"} {
 		if !strings.Contains(argsText, want) {
 			t.Errorf("args missing %q in:\n%s", want, argsText)
 		}
+	}
+	if strings.Contains(argsText, "do work") {
+		t.Errorf("args contain prompt:\n%s", argsText)
+	}
+	stdinData, err := os.ReadFile(stdinLog)
+	if err != nil {
+		t.Fatalf("read stdin: %v", err)
+	}
+	if got, want := string(stdinData), buildACPStructuredPrompt("do work", schema); got != want {
+		t.Errorf("stdin = %q, want %q", got, want)
 	}
 }
 

--- a/internal/agent/codex.go
+++ b/internal/agent/codex.go
@@ -30,7 +30,7 @@ func (a *codexAgent) Name() string { return "codex" }
 
 // SupportsSessionResume reports codex's native durable-session capability:
 // `codex exec --json` emits thread.started with a thread_id, and
-// `codex exec resume <id> <prompt>` continues that thread.
+// `codex exec resume <id> -` continues that thread with the prompt on stdin.
 func (a *codexAgent) SupportsSessionResume() bool { return true }
 
 func (a *codexAgent) ReportsAgentAttempts() bool { return true }
@@ -89,10 +89,10 @@ func (a *codexAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error)
 	if opts.Session != nil {
 		resumeID = opts.Session.ID
 	}
-	args := a.buildArgs(opts.Prompt, schemaPath, resumeID)
+	args := a.buildArgs(schemaPath, resumeID)
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD
-	cmd.Stdin = nil
+	cmd.Stdin = strings.NewReader(opts.Prompt)
 	cmd.Env = gitSafeEnv(opts.CWD, opts.Env)
 	shellenv.ConfigureShellCommand(cmd)
 
@@ -159,14 +159,14 @@ func (a *codexAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error)
 func (a *codexAgent) Close() error { return nil }
 
 // buildArgs constructs the codex CLI arguments. User-supplied extraArgs are
-// inserted between "exec" and the prompt so user flags (e.g. -m, --sandbox)
+// inserted between "exec" and the stdin prompt marker so user flags (e.g. -m, --sandbox)
 // take effect. If the user declared their own execution-mode flag, the
 // default --dangerously-bypass-approvals-and-sandbox is not added.
-// A non-empty resumeID routes through `codex exec resume <id> <prompt>`,
+// A non-empty resumeID routes through `codex exec resume <id> -`,
 // which exposes a narrower flag surface than `codex exec` (no --color, no
 // -s/--sandbox as of codex 0.144): unsupported user extraArgs make the
 // invocation fail fast and the caller's cold fallback preserves correctness.
-func (a *codexAgent) buildArgs(prompt, schemaPath, resumeID string) []string {
+func (a *codexAgent) buildArgs(schemaPath, resumeID string) []string {
 	args := make([]string, 0, len(a.extraArgs)+11)
 	args = append(args, "exec")
 	if resumeID != "" {
@@ -176,7 +176,7 @@ func (a *codexAgent) buildArgs(prompt, schemaPath, resumeID string) []string {
 	if resumeID != "" {
 		args = append(args, resumeID)
 	}
-	args = append(args, prompt, "--json")
+	args = append(args, "-", "--json")
 	if schemaPath != "" {
 		args = append(args, "--output-schema", schemaPath)
 	}
@@ -193,7 +193,7 @@ func (a *codexAgent) buildArgs(prompt, schemaPath, resumeID string) []string {
 	// (AGENTS.md) plus project execpolicy `.rules`; codex config itself is
 	// user-level ($CODEX_HOME), not project. Both knobs are global overrides
 	// accepted by `codex exec` AND `codex exec resume`, appended last so they
-	// never disturb codex's `[resume] <id> <prompt>` positionals:
+	// never disturb codex's `[resume] <id> -` positionals:
 	//   - `-c project_doc_max_bytes=0` makes codex read zero bytes of AGENTS.md
 	//     (the identity-bearing surface). Skipped only when the operator pinned
 	//     their own project_doc_max_bytes (their choice wins; NeutralizesGate-

--- a/internal/agent/codex_test.go
+++ b/internal/agent/codex_test.go
@@ -12,12 +12,12 @@ import (
 
 func TestCodexAgent_BuildArgs(t *testing.T) {
 	ca := &codexAgent{bin: "codex"}
-	args := ca.buildArgs("fix the bug", "", "")
+	args := ca.buildArgs("", "")
 
 	// Default (no opt-out): pristine args, no project-doc suppression - ordinary
 	// repos keep loading AGENTS.md (backward-compat).
 	expected := []string{
-		"exec", "fix the bug",
+		"exec", "-",
 		"--json",
 		"--dangerously-bypass-approvals-and-sandbox",
 		"--color", "never",
@@ -35,12 +35,12 @@ func TestCodexAgent_BuildArgs(t *testing.T) {
 
 func TestCodexAgent_BuildArgs_ExtraArgsAfterExec(t *testing.T) {
 	ca := &codexAgent{bin: "codex", extraArgs: []string{"-m", "gpt-5.4"}}
-	args := ca.buildArgs("fix it", "", "")
+	args := ca.buildArgs("", "")
 
 	expected := []string{
 		"exec",
 		"-m", "gpt-5.4",
-		"fix it",
+		"-",
 		"--json",
 		"--dangerously-bypass-approvals-and-sandbox",
 		"--color", "never",
@@ -64,7 +64,7 @@ func TestCodexAgent_BuildArgs_UserExecutionModeSuppressesBypass(t *testing.T) {
 	}
 	for _, extra := range tests {
 		ca := &codexAgent{bin: "codex", extraArgs: extra}
-		args := ca.buildArgs("p", "", "")
+		args := ca.buildArgs("", "")
 
 		bypassCount := 0
 		for _, a := range args {
@@ -84,10 +84,10 @@ func TestCodexAgent_BuildArgs_UserExecutionModeSuppressesBypass(t *testing.T) {
 
 func TestCodexAgent_BuildArgs_WithOutputSchema(t *testing.T) {
 	ca := &codexAgent{bin: "codex"}
-	args := ca.buildArgs("review", "/tmp/schema.json", "")
+	args := ca.buildArgs("/tmp/schema.json", "")
 
 	want := []string{
-		"exec", "review",
+		"exec", "-",
 		"--json",
 		"--output-schema", "/tmp/schema.json",
 		"--dangerously-bypass-approvals-and-sandbox",
@@ -118,6 +118,38 @@ func writeFakeCodex(t *testing.T, dir, posixScript, windowsScript string) string
 		t.Fatalf("write fake codex: %v", err)
 	}
 	return bin
+}
+
+func TestCodexAgent_RunSendsLargePromptOnlyOnStdin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-only")
+	}
+	dir := t.TempDir()
+	bin := writeFakeCodex(t, dir, `#!/bin/sh
+printf '%s\n' "$@" > argv.txt
+cat > stdin.txt
+printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"done"}}'
+printf '%s\n' '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}'
+`, "")
+	prompt := strings.Repeat("codex-prompt-", 512)
+	ca := &codexAgent{bin: bin}
+	if _, err := ca.Run(context.Background(), RunOpts{Prompt: prompt, CWD: dir}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	argv, err := os.ReadFile(filepath.Join(dir, "argv.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(argv), prompt) || !strings.Contains(string(argv), "\n-\n") {
+		t.Fatalf("argv must contain stdin marker, not prompt: %q", argv)
+	}
+	stdin, err := os.ReadFile(filepath.Join(dir, "stdin.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(stdin) != prompt {
+		t.Fatalf("stdin prompt mismatch: got %d bytes, want %d", len(stdin), len(prompt))
+	}
 }
 
 func TestCodexAgent_RunWritesOutputSchemaFile(t *testing.T) {
@@ -485,7 +517,7 @@ func TestParseCodexEvents_SkipsMalformedLines(t *testing.T) {
 // suppression knobs are emitted under the opt-out.
 func TestCodexAgent_BuildArgs_SuppressesProjectDocUnderOptOut(t *testing.T) {
 	ca := &codexAgent{bin: "codex", disableProjectSettings: true}
-	args := ca.buildArgs("review the diff", "", "")
+	args := ca.buildArgs("", "")
 	if !argsContainPair(args, "-c", "project_doc_max_bytes=0") {
 		t.Errorf("buildArgs = %v, want a `-c project_doc_max_bytes=0` pair", args)
 	}
@@ -499,7 +531,7 @@ func TestCodexAgent_BuildArgs_SuppressesProjectDocUnderOptOut(t *testing.T) {
 // exactly as before.
 func TestCodexAgent_BuildArgs_NoSuppressionWithoutOptOut(t *testing.T) {
 	ca := &codexAgent{bin: "codex"}
-	args := ca.buildArgs("review the diff", "", "")
+	args := ca.buildArgs("", "")
 	if argsContainPair(args, "-c", "project_doc_max_bytes=0") || argsContain(args, "--ignore-rules") {
 		t.Errorf("buildArgs = %v, must add no suppression when the repo did not opt out", args)
 	}
@@ -510,7 +542,7 @@ func TestCodexAgent_BuildArgs_NoSuppressionWithoutOptOut(t *testing.T) {
 // but still accepts the global -c and --ignore-rules.
 func TestCodexAgent_BuildArgs_SuppressesOnResumeUnderOptOut(t *testing.T) {
 	ca := &codexAgent{bin: "codex", disableProjectSettings: true}
-	args := ca.buildArgs("rereview", "", "thread-123")
+	args := ca.buildArgs("", "thread-123")
 	if args[0] != "exec" || args[1] != "resume" || args[2] != "thread-123" {
 		t.Fatalf("resume positional prefix disturbed: %v", args)
 	}
@@ -523,7 +555,7 @@ func TestCodexAgent_BuildArgs_SuppressesOnResumeUnderOptOut(t *testing.T) {
 // pinned their own project_doc_max_bytes is not double-set even under opt-out.
 func TestCodexAgent_BuildArgs_UserProjectDocOverrideWins(t *testing.T) {
 	ca := &codexAgent{bin: "codex", disableProjectSettings: true, extraArgs: []string{"-c", "project_doc_max_bytes=4096"}}
-	args := ca.buildArgs("p", "", "")
+	args := ca.buildArgs("", "")
 	if argsContainPair(args, "-c", "project_doc_max_bytes=0") {
 		t.Errorf("buildArgs = %v, must not add project_doc_max_bytes=0 over a user pin", args)
 	}

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -14,7 +14,7 @@ import (
 )
 
 // copilotAgent spawns the GitHub Copilot CLI for each invocation. Copilot
-// runs non-interactively with `copilot -p <prompt> --output-format json`,
+// runs non-interactively with the prompt on stdin and `--output-format json`,
 // emitting JSONL events on stdout. The lifecycle is codex/pi-shaped: one
 // process per Run, no managed server.
 type copilotAgent struct {
@@ -36,10 +36,10 @@ func (a *copilotAgent) Close() error { return nil }
 
 func (a *copilotAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 	prompt := buildCopilotPrompt(opts.Prompt, opts.JSONSchema)
-	args := a.buildArgs(prompt)
+	args := a.buildArgs()
 	cmd := exec.CommandContext(ctx, a.bin, args...)
 	cmd.Dir = opts.CWD
-	cmd.Stdin = nil
+	cmd.Stdin = strings.NewReader(prompt)
 	cmd.Env = gitSafeEnv(opts.CWD, opts.Env)
 	shellenv.ConfigureShellCommand(cmd)
 
@@ -143,11 +143,10 @@ func copilotErrorDetail(copilotErr, stderr string) string {
 // supplied their own permission flag, the default --allow-all-tools is not
 // added; --no-ask-user is always added so the agent never blocks waiting for
 // interactive input.
-func (a *copilotAgent) buildArgs(prompt string) []string {
-	args := make([]string, 0, len(a.extraArgs)+8)
+func (a *copilotAgent) buildArgs() []string {
+	args := make([]string, 0, len(a.extraArgs)+6)
 	args = append(args, a.extraArgs...)
 	args = append(args,
-		"-p", prompt,
 		"--output-format", "json",
 		"--no-color",
 	)

--- a/internal/agent/copilot_test.go
+++ b/internal/agent/copilot_test.go
@@ -12,10 +12,9 @@ import (
 
 func TestCopilotAgent_BuildArgs(t *testing.T) {
 	ca := &copilotAgent{bin: "copilot"}
-	args := ca.buildArgs("fix the bug")
+	args := ca.buildArgs()
 
 	expected := []string{
-		"-p", "fix the bug",
 		"--output-format", "json",
 		"--no-color",
 		"--no-ask-user",
@@ -33,11 +32,10 @@ func TestCopilotAgent_BuildArgs(t *testing.T) {
 
 func TestCopilotAgent_BuildArgs_ExtraArgsFirst(t *testing.T) {
 	ca := &copilotAgent{bin: "copilot", extraArgs: []string{"--model", "gpt-5.4"}}
-	args := ca.buildArgs("fix it")
+	args := ca.buildArgs()
 
 	expected := []string{
 		"--model", "gpt-5.4",
-		"-p", "fix it",
 		"--output-format", "json",
 		"--no-color",
 		"--no-ask-user",
@@ -72,7 +70,7 @@ func TestCopilotAgent_BuildArgs_UserPermissionSuppressesDefault(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ca := &copilotAgent{bin: "copilot", extraArgs: tt.extra}
-			args := ca.buildArgs("p")
+			args := ca.buildArgs()
 
 			count := 0
 			for _, a := range args {
@@ -99,7 +97,7 @@ func TestCopilotAgent_BuildArgs_UserPermissionSuppressesDefault(t *testing.T) {
 
 func TestCopilotAgent_BuildArgs_UserAskUserSuppressesDefault(t *testing.T) {
 	ca := &copilotAgent{bin: "copilot", extraArgs: []string{"--no-ask-user"}}
-	args := ca.buildArgs("p")
+	args := ca.buildArgs()
 
 	count := 0
 	for _, a := range args {
@@ -257,6 +255,42 @@ func writeFakeCopilot(t *testing.T, dir string, jsonlLines []string, exitCode in
 		t.Fatalf("write fake copilot: %v", err)
 	}
 	return bin
+}
+
+func TestCopilotAgent_RunSendsLargePromptOnlyOnStdin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture is Unix-only")
+	}
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "copilot")
+	script := `#!/bin/sh
+printf '%s\n' "$@" > argv.txt
+cat > stdin.txt
+printf '%s\n' '{"type":"assistant.message","data":{"content":"done","outputTokens":1}}'
+printf '%s\n' '{"type":"result","exitCode":0}'
+`
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	prompt := strings.Repeat("copilot-prompt-", 512)
+	ca := &copilotAgent{bin: bin}
+	if _, err := ca.Run(context.Background(), RunOpts{Prompt: prompt, CWD: dir}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	argv, err := os.ReadFile(filepath.Join(dir, "argv.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(argv), prompt) || strings.Contains(string(argv), "-p\n") {
+		t.Fatalf("argv must not contain prompt mode or prompt: %q", argv)
+	}
+	stdin, err := os.ReadFile(filepath.Join(dir, "stdin.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(stdin) != prompt {
+		t.Fatalf("stdin prompt mismatch: got %d bytes, want %d", len(stdin), len(prompt))
+	}
 }
 
 func itoa(n int) string { return strings.TrimSpace(jsonNumber(n)) }

--- a/internal/agent/native_command.go
+++ b/internal/agent/native_command.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"sync"
@@ -21,6 +22,16 @@ type nativeAgentCommand struct {
 	pipeMu         sync.Mutex
 	remainingPipes int
 	pipesDone      chan struct{}
+}
+
+func writeNativeAgentStdin(stdin io.WriteCloser, prompt string) <-chan error {
+	errCh := make(chan error, 1)
+	go func() {
+		_, writeErr := io.WriteString(stdin, prompt)
+		closeErr := stdin.Close()
+		errCh <- errors.Join(writeErr, closeErr)
+	}()
+	return errCh
 }
 
 type nativeAgentPipe struct {

--- a/internal/agent/native_command_stdin_test.go
+++ b/internal/agent/native_command_stdin_test.go
@@ -1,0 +1,27 @@
+package agent
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+type failingWriteCloser struct {
+	writeErr error
+	closeErr error
+}
+
+func (w failingWriteCloser) Write([]byte) (int, error) { return 0, w.writeErr }
+func (w failingWriteCloser) Close() error              { return w.closeErr }
+
+func TestWriteNativeAgentStdinReportsWriteAndCloseFailures(t *testing.T) {
+	writeErr := errors.New("write failed")
+	closeErr := errors.New("close failed")
+	err := <-writeNativeAgentStdin(failingWriteCloser{writeErr: writeErr, closeErr: closeErr}, "prompt")
+	if !errors.Is(err, writeErr) || !errors.Is(err, closeErr) {
+		t.Fatalf("error = %v, want joined write and close failures", err)
+	}
+	if got := err.Error(); !strings.Contains(got, "write failed") || !strings.Contains(got, "close failed") {
+		t.Fatalf("error = %q, want both failure diagnostics", got)
+	}
+}

--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
@@ -62,6 +63,7 @@ func (a *piAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 
 	started, err := startNativeAgentCommand(cmd)
 	if err != nil {
+		_ = stdin.Close()
 		return nil, fmt.Errorf("pi start: %w", err)
 	}
 	defer started.closePipes()
@@ -69,10 +71,7 @@ func (a *piAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 	emitAgentStarted(opts, "pi", pid)
 
 	prompt := buildPiPrompt(opts.Prompt, opts.JSONSchema)
-	go func() {
-		defer stdin.Close()
-		_, _ = io.WriteString(stdin, prompt)
-	}()
+	stdinErrCh := writeNativeAgentStdin(stdin, prompt)
 
 	var stderrBuf []byte
 	var stderrWG sync.WaitGroup
@@ -86,6 +85,7 @@ func (a *piAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 	if err := pp.parse(ctx, started.stdout); err != nil {
 		err = started.waitAfterParseError(err)
 		stderrWG.Wait()
+		err = errors.Join(err, piStdinError(<-stdinErrCh))
 		retErr := fmt.Errorf("pi parse events: %w", err)
 		emitAgentExited(opts, "pi", pid, retErr)
 		return nil, retErr
@@ -93,16 +93,24 @@ func (a *piAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 
 	waitErr := started.wait()
 	stderrWG.Wait()
+	stdinErr := piStdinError(<-stdinErrCh)
+	stderr := strings.TrimSpace(string(stderrBuf))
 	if waitErr != nil {
-		stderr := strings.TrimSpace(string(stderrBuf))
 		if stderr != "" {
-			retErr := fmt.Errorf("pi exited: %w: %s", waitErr, stderr)
+			retErr := fmt.Errorf("pi exited: %w: %s", errors.Join(waitErr, stdinErr), stderr)
 			emitAgentExited(opts, "pi", pid, retErr)
 			return nil, retErr
 		}
-		retErr := fmt.Errorf("pi exited: %w", waitErr)
+		retErr := fmt.Errorf("pi exited: %w", errors.Join(waitErr, stdinErr))
 		emitAgentExited(opts, "pi", pid, retErr)
 		return nil, retErr
+	}
+	if stdinErr != nil {
+		if stderr != "" {
+			stdinErr = fmt.Errorf("%w: %s", stdinErr, stderr)
+		}
+		emitAgentExited(opts, "pi", pid, stdinErr)
+		return nil, stdinErr
 	}
 
 	if pp.assistantError != "" {
@@ -115,6 +123,13 @@ func (a *piAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 	res, err := finalizeTextResult("pi", text, opts.JSONSchema, pp.usage)
 	emitAgentExited(opts, "pi", pid, err)
 	return res, err
+}
+
+func piStdinError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("pi stdin: %w", err)
 }
 
 // buildArgs returns the Pi argv for one invocation. Under the project-settings

--- a/internal/agent/pi_test.go
+++ b/internal/agent/pi_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestPiAgent_BuildArgs(t *testing.T) {
@@ -358,6 +359,28 @@ exit 2
 	}
 	if !strings.Contains(err.Error(), "boom") {
 		t.Errorf("expected stderr in error message, got: %v", err)
+	}
+}
+
+func TestPiAgent_RunSurfacesStdinWriteFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fixture relies on a child exiting without reading stdin")
+	}
+	dir := t.TempDir()
+	bin := writeFakePi(t, dir, `#!/bin/sh
+printf '%s\n' '{"type":"agent_end","messages":[{"role":"assistant","content":"early reply"}]}'
+printf 'pi rejected the prompt\n' >&2
+`, "")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	pa := &piAgent{bin: bin}
+	_, err := pa.Run(ctx, RunOpts{Prompt: strings.Repeat("x", 2*1024*1024), CWD: dir})
+	if err == nil || !strings.Contains(err.Error(), "pi stdin") {
+		t.Fatalf("Run error = %v, want pi stdin write failure", err)
+	}
+	if !strings.Contains(err.Error(), "pi rejected the prompt") {
+		t.Fatalf("Run error = %v, want child stderr in stdin write failure", err)
 	}
 }
 

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -101,7 +101,7 @@ func TestParseClaudeEvents_SessionIDFallsBackToLastSeen(t *testing.T) {
 
 func TestCodexAgent_BuildArgs_Resume(t *testing.T) {
 	ca := &codexAgent{bin: "codex"}
-	args := ca.buildArgs("re-review the branch", "/tmp/schema.json", "thread-99")
+	args := ca.buildArgs("/tmp/schema.json", "thread-99")
 
 	joined := strings.Join(args, " ")
 	if !strings.HasPrefix(joined, "exec resume thread-99 ") {
@@ -116,6 +116,9 @@ func TestCodexAgent_BuildArgs_Resume(t *testing.T) {
 	if !strings.Contains(joined, "--dangerously-bypass-approvals-and-sandbox") {
 		t.Fatalf("resume args must keep the sandbox bypass: %v", args)
 	}
+	if !strings.Contains(joined, "thread-99 -") {
+		t.Fatalf("resume prompt must use stdin marker after the session id: %v", args)
+	}
 	// codex exec resume (0.144) does not accept --color; passing it fails the
 	// whole invocation.
 	if strings.Contains(joined, "--color") {
@@ -125,10 +128,10 @@ func TestCodexAgent_BuildArgs_Resume(t *testing.T) {
 
 func TestCodexAgent_BuildArgs_ResumeKeepsExtraArgs(t *testing.T) {
 	ca := &codexAgent{bin: "codex", extraArgs: []string{"-m", "gpt-5.2-codex"}}
-	args := ca.buildArgs("prompt", "", "thread-1")
+	args := ca.buildArgs("", "thread-1")
 
 	joined := strings.Join(args, " ")
-	if !strings.HasPrefix(joined, "exec resume -m gpt-5.2-codex thread-1 prompt") {
+	if !strings.HasPrefix(joined, "exec resume -m gpt-5.2-codex thread-1 -") {
 		t.Fatalf("resume args must interleave user extraArgs before the session id: %v", args)
 	}
 }

--- a/internal/e2e/recursive_run_prevention_test.go
+++ b/internal/e2e/recursive_run_prevention_test.go
@@ -208,7 +208,7 @@ func installRecursiveIncidentAgent(t *testing.T, h *Harness, agentName, executab
 		execAgent = fmt.Sprintf(`exec %s "$@"`, shellQuote(filepath.Join(realDir, executable)))
 	}
 	switch agentName {
-	case "claude":
+	case "claude", "codex":
 		promptSource = `prompt=$(cat)`
 		execAgent = fmt.Sprintf(`printf '%%s' "$prompt" | exec %s "$@"`, shellQuote(filepath.Join(realDir, executable)))
 	case "opencode":

--- a/workflow_no_mistakes_required_test.go
+++ b/workflow_no_mistakes_required_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"slices"
@@ -80,18 +81,51 @@ func TestNoMistakesRequiredWorkflowReadsPRBodyViaEnv(t *testing.T) {
 // TestNoMistakesRequiredWorkflowTriggersOnRelevantPREvents ensures the check
 // re-runs when the PR body is edited so a contributor cannot bypass by opening
 // clean then editing the body.
+//
+// It also pins the deliberate absence of "synchronize". The verdict is a pure
+// function of pull_request.body, and a push never changes that body, so a
+// synchronize run can only restate the last body-event verdict. What it does
+// change is the head SHA: the pipeline pushes (Push step) before it writes the
+// deterministic "## Pipeline" section (PR step), so on any PR whose body is not
+// yet compliant - every PR the pipeline adopts rather than opens itself - the
+// synchronize run pins a FAILURE check run to the new head for a body the same
+// run is about to fix. GitHub keeps that failure alongside the later `edited`
+// SUCCESS instead of replacing it, and `gh pr checks` collapses same-named
+// check runs by startedAt alone, so the pipeline's own CI monitor can read the
+// stale failure and park the run red with no push able to clear it (PR #773
+// carried check runs 96017425510 FAILURE and 96017420271 SUCCESS on one head).
+// No ruleset requires this status, so no head SHA needs a run of its own.
 func TestNoMistakesRequiredWorkflowTriggersOnRelevantPREvents(t *testing.T) {
-	data, err := os.ReadFile(".github/workflows/no-mistakes-required.yml")
-	if err != nil {
-		t.Fatalf("read workflow: %v", err)
-	}
-	content := string(data)
+	types := requiredWorkflowPullRequestTypes(t, loadRequiredWorkflow(t))
 
-	for _, typ := range []string{"opened", "edited", "synchronize", "reopened"} {
-		if !strings.Contains(content, typ) {
-			t.Errorf("workflow must trigger on pull_request type %q", typ)
+	for _, typ := range []string{"opened", "edited", "reopened"} {
+		if !slices.Contains(types, typ) {
+			t.Errorf("workflow must trigger on pull_request type %q, got %v", typ, types)
 		}
 	}
+	if slices.Contains(types, "synchronize") {
+		t.Errorf("workflow must not judge PR-body compliance on synchronize, got %v", types)
+	}
+}
+
+// requiredWorkflowPullRequestTypes reads the workflow's pull_request event
+// types from the parsed document, so a type named only in a comment cannot
+// satisfy a trigger assertion.
+func requiredWorkflowPullRequestTypes(t *testing.T, workflow requiredWorkflow) []string {
+	t.Helper()
+	pullRequest, ok := workflow.On["pull_request"].(map[string]any)
+	if !ok {
+		t.Fatalf("workflow on.pull_request = %T, want a mapping", workflow.On["pull_request"])
+	}
+	raw, ok := pullRequest["types"].([]any)
+	if !ok {
+		t.Fatalf("workflow on.pull_request.types = %T, want a sequence", pullRequest["types"])
+	}
+	types := make([]string, 0, len(raw))
+	for _, entry := range raw {
+		types = append(types, fmt.Sprint(entry))
+	}
+	return types
 }
 
 // TestNoMistakesRequiredWorkflowExecutesEveryBodyEvent reproduces the
@@ -128,8 +162,8 @@ func TestNoMistakesRequiredWorkflowPreservesHeadEventCoalescing(t *testing.T) {
 		{Action: "opened", PRNumber: 549, RunID: 1001},
 		{Action: "edited", PRNumber: 549, RunID: 1002},
 		{Action: "edited", PRNumber: 549, RunID: 1003},
-		{Action: "synchronize", PRNumber: 549, RunID: 1004},
 		{Action: "reopened", PRNumber: 549, RunID: 1005},
+		{Action: "reopened", PRNumber: 549, RunID: 1006},
 	}
 	groups := make([]string, len(events))
 	for i, event := range events {
@@ -139,11 +173,11 @@ func TestNoMistakesRequiredWorkflowPreservesHeadEventCoalescing(t *testing.T) {
 		t.Fatalf("body-bearing event groups must be unique: %v", groups[:3])
 	}
 	if groups[3] != groups[4] {
-		t.Fatalf("synchronize/reopened groups = %q and %q, want preserved coalescing", groups[3], groups[4])
+		t.Fatalf("reopened groups = %q and %q, want preserved coalescing", groups[3], groups[4])
 	}
 	for _, bodyGroup := range groups[:3] {
 		if bodyGroup == groups[3] {
-			t.Fatalf("body event group %q can be canceled by a head event", bodyGroup)
+			t.Fatalf("body event group %q can be canceled by a reopen", bodyGroup)
 		}
 	}
 }


### PR DESCRIPTION
**Requirement:** Deliver every process-backed agent prompt outside argv, and never accept a successful result after stdin delivery was truncated.

## What changed

The acpx transport remains `exec --file -`; Pi now shares its checked stdin writer, which reports both write and close failures with child stderr attached. The sibling sweep also moved Codex cold/resume prompts and Copilot prompts from argv to their documented stdin transports. Claude was already safe, and the remaining adapters send prompts in HTTP request bodies rather than process argv.

```mermaid
flowchart LR
  prompt["complete prompt bytes"] --> transport["stdin transport"]
  transport --> child["agent child process"]
  transport --> delivery["write and close result"]
  child --> diagnostics["stdout and stderr diagnostics"]
  delivery --> verdict["adapter verdict"]
  diagnostics --> verdict
  argv["fixed argv without prompt content"] --> child
```

## How it works

Given a 2 MiB Pi prompt and a child that emits `early reply`, writes `pi rejected the prompt` to stderr, and exits 0 without reading stdin, the pipe write fails. Previously Pi returned `early reply` as success even though the child received only a prefix. It now returns a `pi stdin: ...` error containing `pi rejected the prompt`. A close failure is joined with any write failure by the same helper used by acpx. Codex uses `exec -` (and `exec resume <thread> -`) with the prompt on stdin; Copilot enters programmatic mode from piped stdin without `-p <prompt>`.

## Evidence

Testing suite:

| Suite | What it guards | Result | Command |
|---|---|---|---|
| agent race suite | Pi/acpx write and close failures, prompt transport, parsing, session resume, and adapter regressions | pass | `go test -race -count=1 ./internal/agent/` |
| focused failure and transport tests | Pi early-exit diagnostics, joined write/close errors, and Codex/Copilot prompt absence from argv | pass | `go test ./internal/agent -run 'Test(WriteNativeAgentStdin|PiAgent_RunSurfacesStdinWriteFailure|CodexAgent_RunSendsLargePromptOnlyOnStdin|CopilotAgent_RunSendsLargePromptOnlyOnStdin)' -count=1` |
| repository lint | generated-skill drift and Go vet | pass | `make lint` |
| repository build | CLI compilation through the project-owned target | pass | `make build` |
| full repository suite | not used as the verification gate because of the documented unrelated macOS fork/pre-exec hang | not run | `make test` |

Sibling sweep result: no process-backed adapter still places the task prompt in argv. Acpx and Pi use the checked pipe helper; Claude, Codex, and Copilot use `os/exec` stdin copying; OpenCode and Rovo Dev carry prompts in HTTP bodies; the managed-server launcher has no task prompt.

## Risks

Codex and Copilot now rely on their documented stdin modes. Transport tests pin exact prompt bytes and fixed argv, including Codex resume placement. Pi and acpx retain concurrent stdin writes so large prompts cannot deadlock stdout/stderr collection; every post-start return path drains the buffered delivery result.

## Links

- Closes #485
- Closes the outstanding Pi sibling-adapter review finding on this PR.
- [Codex `exec` stdin contract](https://developers.openai.com/codex/cli/reference/#codex-exec)
- [GitHub Copilot CLI programmatic stdin usage](https://docs.github.com/en/copilot/how-tos/copilot-cli/automate-copilot-cli/run-cli-programmatically)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `internal/agent/acpx.go:92` - When the stdin write is the only failure (child exited 0 but never drained the prompt), the returned error is the bare `acpx stdin: ...` and both `stderrBuf` and `stdoutErr` are discarded. That is exactly the diagnostic needed for the launch-time class of failure this change exists to fix: an acpx build that rejects `--file` and prints usage to stderr while exiting 0, or an endpoint agent that kills the node child, would surface only &#34;write |1: broken pipe&#34; with the child&#39;s own explanation thrown away. The non-zero-exit branch two lines above already formats this correctly via `acpxProcessErrorOutput(stderrBuf, stdoutErr)`; reuse it here so both failure branches carry the child&#39;s output.
- ℹ️ `internal/agent/acpx.go:124` - `exec --file -` is now a hard requirement on the installed acpx binary, but nothing records a minimum version: `internal/cli/doctor.go:169` only checks that the `acpx` binary exists, and `docs/src/content/docs/guides/agents.md` tells users to install acpx without a version floor. A user on an acpx build predating the `--file` option will have every ACP-backed run fail (diagnosably, via the child&#39;s stderr on the non-zero-exit path, but on every run). Consider recording the minimum acpx version in the agents guide, and/or having the doctor acpx row probe `exec --help` for `--file`.
- ℹ️ `internal/agent/pi.go:74` - `pi.go` already uses the identical stdin-pipe-plus-goroutine transport this change added to acpx, but discards both the write and close errors (`_, _ = io.WriteString(stdin, prompt)` with `defer stdin.Close()`). The hazard the acpx change just closed is therefore still open one file over: if the pi child exits early or the pipe breaks mid-write, pi receives a truncated prompt and whatever it emits on stdout is accepted as a valid `Result`. The PR&#39;s sibling audit covered codex, copilot, and server but not pi. The two writers are now near-identical, so a small shared helper returning a `&lt;-chan error` would fix pi and remove the duplication in one move - flagging rather than auto-fixing because it changes when pi runs fail.

🔧 Fix: surface child stderr on acpx stdin write failure
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`go test -race -count=1 ./internal/agent/` (affected package, all pass)</code>
- <code>`go test -race -run &#39;TestAcpxAgent_Run&#39; ./internal/agent/ -v` — covers `TestAcpxAgent_Run_SendsLargePromptOnlyOnStdin` (plain + structured), `TestAcpxAgent_Run_SurfacesStdinWriteFailure`, `TestAcpxAgent_Run_CursorSpawnsDefaultCommandWithoutOverrides`</code>
- <code>`go test -race -run &#39;Acpx|ACPAgent|ACPX&#39; ./internal/agent/ -v` — includes `TestACPAgentBuildArgsUsesExecMode` and `TestACPAgentRunParsesAcpxJSONOutput` (exact stdin bytes equal `buildACPStructuredPrompt` output, prompt absent from argv)</code>
- <code>End-to-end before/after through the real adapter with a 1,572,864-byte prompt and a Node stub acpx: `go test -overlay overlay_before.json -run TestEndpointReproAcpxPromptTransport ./internal/agent/` (pre-fix acpx.go from base 6859d1e) vs `go test -overlay overlay_after.json ...` (shipped 58232ec)</code>
- `Manual probe of the reported endpoint trigger: launched node with argv payloads of 936 / 1,423 / 4,096 / 65,536 / 200,000 bytes — no SIGKILL on this host today`
- <code>`/usr/bin/log show --last 3h --predicate &#39;eventMessage CONTAINS &#34;Blocking execution&#34;&#39;` — no endpoint block events; `sentineld` pathhelper argv-as-path scanning is visible in the log, confirming the mechanism is live even though the blocking policy is not firing</code>
- <code>Verified the upstream acpx CLI contract that the fix depends on: `exec` supports prompt text from `--file -` (stdin), per openclaw/acpx `docs/CLI.md`</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `docs/src/content/docs/guides/agents.md:308` - The acpx bridge now requires a build that supports `exec --file -`, but no documentation states a minimum acpx version. I documented the requirement in docs/src/content/docs/guides/agents.md, but could not name the version that introduced `exec --file -` from this repository alone. A follow-up could pin the minimum acpx version in that section and in guides/troubleshooting.md&#39;s symptom list (`acpx: unknown option --file`) once the upstream version is confirmed.

🔧 Fix: drop speculative acpx argv-limit doc and comment
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 2)

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>