### PR TITLE
feat(agent): add grok as a first-class native pipeline agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,10 @@ Safest local verification sequence after non-trivial changes:
 - The shared default test-quality rule lives in `internal/testguidance`; render it only into the task-first skill and pipeline roles that can author, repair, or review tests. Its fake-agent prompt tests are the intentional generated-interface contract, not source-text checks.
 - Review auto-fix is disabled by default (`auto_fix.review: 0` in `config.go` `autoFixDefaults`), so blocking and ask-user review findings park for an agent decision; keep the skill, the live `axi` gate `note`, and docs qualified if you touch review auto-fix.
 
+**Grok Native Adapter (`internal/agent/grok.go`)**
+
+- One process per `Run` (`grok -p --always-approve --output-format json`). Isolation is `--cwd` = the invocation checkout, a unique `--leader-socket` under the process temp dir (never `~/.grok/leader.sock`), and stripping `GROK_AGENT` / `GROK_SESSION_ID` / `GROK_WORKSPACE_ROOT` from the child env so a live Grok TUI cannot steal the project. `grok --help` has no AGENTS.md/CLAUDE.md suppression flag, so grok must not implement `NeutralizesGateInstructions`; `disable_project_settings` refuses it. Regressions: `internal/agent/grok_test.go`, `TestResolveAgent_AutoPicksGrokWhenOnlyGrokIsOnPATH`, `TestDoctorListsGrokAgent`.
+
 **Context, Concurrency, and Processes**
 
 - Thread `context.Context` through long-running, subprocess, and networked work; prefer `exec.CommandContext`; use derived contexts and timeouts for cleanup and HTTP calls.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 Push to `no-mistakes` instead of `origin`, and it spins up a disposable worktree, runs an AI-driven validation pipeline, forwards the branch to the configured push target only after every check passes, and opens a clean PR automatically.
 
 - **Non-blocking** - the pipeline runs in an isolated worktree without disrupting your work.
-- **Agent-agnostic** - `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, or `cursor` / `acp:<target>` via `acpx`, with ordered fallbacks; every gate requires a runnable configured pipeline agent.
+- **Agent-agnostic** - `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `grok`, or `cursor` / `acp:<target>` via `acpx`, with ordered fallbacks; every gate requires a runnable configured pipeline agent.
 - **Agent-native** - `/no-mistakes` lets your coding agent do a task and gate it, or gate existing committed work: it runs the pipeline, has the pipeline apply safe fixes, and escalates the rest to you.
 - **Human stays in charge** - auto-fix or review findings, your call.
 - **Clean PRs by default** - push, open PR, watch CI, and auto-fix failures in one shot.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -38,7 +38,7 @@
 把分支推给 `no-mistakes` 而不是 `origin`，它会拉起一个用完即弃的 worktree，跑一条 AI 驱动的校验流水线，**只有每一项检查都通过后**才把分支转发到配置的推送目标，并自动开出一个干净的 PR。
 
 - **不阻塞** —— 流水线在隔离的 worktree 里跑，不打断你手头的工作。
-- **不挑 agent** —— 支持 `claude`、`codex`、`rovodev`、`opencode`、`pi`、`copilot`，也可通过 `acpx` 使用 `cursor` / `acp:<target>`，并支持有序 fallback。
+- **不挑 agent** —— 支持 `claude`、`codex`、`rovodev`、`opencode`、`pi`、`copilot`、`grok`，也可通过 `acpx` 使用 `cursor` / `acp:<target>`，并支持有序 fallback。
 - **agent 原生** —— `/no-mistakes` 既能让编码 agent 完成一个任务再过网关，也能直接为已提交的工作过网关：它跑完流水线、让流水线应用安全的修复，剩下的升级给你。
 - **人始终说了算** —— 自动修复，还是逐条审查 findings，你决定。
 - **默认就是干净 PR** —— 推送、开 PR、盯 CI、自动修复失败，一气呵成。

--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -47,6 +47,7 @@ That directory is always outside the worktree and is reaped by no-mistakes on a 
 | OpenCode | `opencode` | Persistent HTTP server, SSE streaming |
 | Pi | `pi` | Subprocess per invocation, JSONL events |
 | Copilot | `copilot` | Subprocess per invocation, JSONL events |
+| Grok | `grok` | Subprocess per invocation, headless `-p` JSON |
 | Cursor | `cursor-agent` + `acpx` | `cursor-agent acp` through the ACP bridge |
 | ACP target | `acpx` | Optional user-installed ACP bridge |
 
@@ -288,6 +289,14 @@ Any `agent_args_override.copilot` flags are inserted before no-mistakes' managed
 Reads JSONL events from stdout, streaming incremental `assistant.message_delta` text to the TUI and capturing the final `assistant.message` content.
 The Copilot CLI has no output-schema flag, so when structured output is requested no-mistakes injects the JSON schema into the prompt and validates the final text response with the same JSON fence and bare-object fallback used by Pi and Rovo Dev.
 
+## Grok
+
+Spawns a `grok` subprocess for each invocation with `-p <prompt> --output-format json --always-approve`.
+Each spawn also pins `--cwd` to the invocation checkout and a unique `--leader-socket` under the process temp directory, and unsets `GROK_AGENT`, `GROK_SESSION_ID`, and `GROK_WORKSPACE_ROOT` in the child environment so a live Grok TUI (for example firstmate) cannot steal the project.
+`grok --help` has no flag that disables `AGENTS.md`/`CLAUDE.md` discovery, so grok does not implement gate-instruction neutralization; `disable_project_settings` refuses it rather than pretending the checkout's project rules are suppressed.
+When structured output is requested, no-mistakes passes `--json-schema` and validates the headless JSON `text` field with the same `finalizeTextResult` fallback used by other text-output adapters.
+Any `agent_args_override.grok` flags are inserted before no-mistakes' managed flags, so user choices such as `--model` take effect.
+
 ## ACP aliases
 
 ACP aliases are first-class agent names that resolve to ACP targets.
@@ -325,6 +334,7 @@ $ no-mistakes doctor
   – opencode (not found)
   – pi (not found)
   – copilot (not found)
+  – grok (not found)
   – acpx (not found)
   – cursor (not found (cursor-agent, acpx))
   ✓ gate validation claude is runnable

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -413,7 +413,7 @@ Checks:
 - Data directory (`~/.no-mistakes/`)
 - SQLite database
 - Daemon status
-- Agent runners: native binaries `claude`, `codex`, `acli`, `opencode`, `pi`, and `copilot`, plus the optional ACP bridge `acpx`
+- Agent runners: native binaries `claude`, `codex`, `acli`, `opencode`, `pi`, `copilot`, and `grok`, plus the optional ACP bridge `acpx`
 - ACP alias default binaries: `cursor-agent` plus `acpx` for `cursor`
 - Effective global agent configuration, reported as `gate validation`; an unavailable configured runner is a failed check because the gate cannot validate without it
 

--- a/docs/src/content/docs/reference/global-config.md
+++ b/docs/src/content/docs/reference/global-config.md
@@ -22,6 +22,7 @@ agent_path_override:
   opencode: /usr/local/bin/opencode
   pi: /usr/local/bin/pi
   copilot: /usr/local/bin/copilot
+  grok: /usr/local/bin/grok
 
 agent_args_override:
   codex:
@@ -80,10 +81,10 @@ Default agent for all repos and setup-wizard suggestions. Can be overridden per-
 |         |                                                                                             |
 | ------- | ------------------------------------------------------------------------------------------- |
 | Type    | `string` or `string[]`                                                                      |
-| Values  | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `cursor`, `acp:<target>` |
+| Values  | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `grok`, `cursor`, `acp:<target>` |
 | Default | `auto`                                                                                      |
 
-`auto` resolves to the first supported native agent or ACP alias in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, `pi`, `copilot`, then `cursor`.
+`auto` resolves to the first supported native agent or ACP alias in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, `pi`, `copilot`, `grok`, then `cursor`.
 `cursor` is an ACP alias for the `cursor` target with default command `cursor-agent acp`.
 With default paths, `auto` only selects it when both `cursor-agent` and `acpx` resolve; `acp_registry_overrides.cursor` and `acpx_path` replace those respective defaults during availability checks.
 `acp:<target>` uses the user-installed `acpx` binary to run an ACP target, for example `acp:gemini`; `acp:cursor` uses the same default command as `cursor`.
@@ -155,6 +156,7 @@ Default native binary names when no override is set:
 | `opencode` | `opencode` |
 | `pi`       | `pi`       |
 | `copilot`  | `copilot`  |
+| `grok`     | `grok`     |
 
 ### agent_args_override
 
@@ -164,7 +166,7 @@ Use this to set model selection, service tier, reasoning effort, permission mode
 |         |                                                           |
 | ------- | --------------------------------------------------------- |
 | Type    | `map[string][]string`                                     |
-| Keys    | `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot` |
+| Keys    | `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `grok` |
 | Default | Empty (no extra flags)                                    |
 
 User-supplied flags are normally inserted ahead of no-mistakes' managed flags, so your choices usually take precedence. Security suppression selected by trusted [`disable_project_settings`](/no-mistakes/reference/repo-config/#disable_project_settings) may be placed first while preserving a compatible operator pin. A few flags are reserved because no-mistakes depends on them to communicate with the agent - setting any of these returns a config error on load:
@@ -177,6 +179,7 @@ User-supplied flags are normally inserted ahead of no-mistakes' managed flags, s
 | `opencode` | `serve`, `--hostname`, `--port`, `--print-logs`                                                             |
 | `pi`       | `--mode`, `--no-session`                                                                                    |
 | `copilot`  | `-p`, `--prompt`, `--output-format`, `--no-color`                                                          |
+| `grok`     | `-p`, `--single`, `--output-format`, `--json-schema`, `--cwd`, `--leader-socket`, `-c`, `--continue`, `-r`, `--resume`, `-s`, `--session-id`, `--fork-session`, `--prompt-file`, `--prompt-json`, `--worktree`, `-w` |
 
 For structured `codex` runs, no-mistakes also appends its own `--output-schema <tempfile>` after your overrides. Treat that flag as managed even though config validation does not currently reject it.
 The Claude and Codex session-control forms are reserved so no-mistakes can keep review-loop conversations deterministic: review turns stay session-free while the fixer keeps its own isolated durable session.

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -93,10 +93,10 @@ Override the default agent for this repo and its setup-wizard suggestions.
 | | |
 | --- | --- |
 | Type | `string` or `string[]` |
-| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `cursor`, `acp:<target>` |
+| Values | `auto`, `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `grok`, `cursor`, `acp:<target>` |
 | Default | Inherits from global config |
 
-`auto` resolves to the first supported native agent or ACP alias in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, `pi`, `copilot`, then `cursor`.
+`auto` resolves to the first supported native agent or ACP alias in this order: `claude`, `codex`, `opencode`, `acli` with `rovodev` support, `pi`, `copilot`, `grok`, then `cursor`.
 `cursor` is an ACP alias for the `cursor` target with default command `cursor-agent acp`.
 Its availability uses the global `acpx_path` and `acp_registry_overrides.cursor` settings when present.
 `acp:<target>` uses the user-installed `acpx` binary configured in global config; `acp:cursor` uses the same default command as `cursor`.
@@ -140,6 +140,7 @@ Suppress project-level agent settings and instructions for every gate-agent star
 This opt-in is intended for agent-orchestration repositories whose `AGENTS.md`, `CLAUDE.md`, or harness-specific project settings would give a validation agent an operator identity and authority that it must not adopt.
 When enabled, no-mistakes suppresses the target checkout's project settings for every agent-driven gate step while preserving user-level agent configuration.
 Codex, Claude, and Pi are the currently verified agents: Codex receives `project_doc_max_bytes=0` and `--ignore-rules`, Claude loads only its user setting source, and Pi runs with `--no-context-files` (preserving a pinned `--no-context-files` or `-nc` spelling).
+Grok has no documented flag that disables `AGENTS.md`/`CLAUDE.md` discovery; its adapter isolates each spawn with `--cwd` and a unique `--leader-socket` instead of claiming neutralization.
 The setting applies to both new and resumed sessions.
 
 The gate fails before launching an agent if any resolved agent or fallback lacks a verified suppression mechanism.

--- a/docs/src/content/docs/start-here/installation.md
+++ b/docs/src/content/docs/start-here/installation.md
@@ -47,7 +47,7 @@ make install
 ## Prerequisites
 
 - **git** - required
-- **One supported agent runner** - `claude`, `codex`, `acli` (Rovo Dev), `opencode`, `pi`, or `copilot`, or a configured Cursor/ACP runner such as `agent: cursor`; see [Global Config](/no-mistakes/reference/global-config/) for ACP requirements
+- **One supported agent runner** - `claude`, `codex`, `acli` (Rovo Dev), `opencode`, `pi`, `copilot`, or `grok`, or a configured Cursor/ACP runner such as `agent: cursor`; see [Global Config](/no-mistakes/reference/global-config/) for ACP requirements
 - **Optional, for PRs and CI:**
   - `gh` CLI (GitHub)
   - `glab` CLI (GitLab)

--- a/docs/src/content/docs/start-here/introduction.md
+++ b/docs/src/content/docs/start-here/introduction.md
@@ -72,7 +72,7 @@ When a branch passes the gate, it means:
 ## What you get
 
 - A fixed, opinionated pipeline: `intent → rebase → review → test → document → lint → push → pr → ci`. Order is not configurable; what each step runs is.
-- Choice of agent: `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, or `cursor` / `acp:<target>` via `acpx`, with per-repo override and ordered fallbacks; every gate requires a runnable configured pipeline agent.
+- Choice of agent: `claude`, `codex`, `rovodev`, `opencode`, `pi`, `copilot`, `grok`, or `cursor` / `acp:<target>` via `acpx`, with per-repo override and ordered fallbacks; every gate requires a runnable configured pipeline agent.
 - A TUI to watch, approve, fix, skip, or abort any step.
 - A `/no-mistakes` agent skill so a coding agent can do a task and gate it, or gate existing committed work, backed by a non-interactive `no-mistakes axi` interface.
 - A setup wizard when you run bare `no-mistakes` with no active run on the current branch - it walks you through creating a branch, committing, and pushing through the gate, then attaches if the daemon registers the new run.

--- a/docs/src/content/docs/start-here/quick-start.md
+++ b/docs/src/content/docs/start-here/quick-start.md
@@ -24,7 +24,7 @@ no-mistakes doctor
 You need:
 
 - `git`
-- One supported agent runner (`claude`, `codex`, `acli` for Rovo Dev, `opencode`, `pi`, or `copilot`), or a configured Cursor/ACP runner such as `agent: cursor`; see [Global Config](/no-mistakes/reference/global-config/) for ACP requirements
+- One supported agent runner (`claude`, `codex`, `acli` for Rovo Dev, `opencode`, `pi`, `copilot`, or `grok`), or a configured Cursor/ACP runner such as `agent: cursor`; see [Global Config](/no-mistakes/reference/global-config/) for ACP requirements
 - For PRs and CI: `gh` (GitHub), `glab` (GitLab), Bitbucket Cloud credentials, or `az` with the `azure-devops` extension (Azure DevOps)
 
 `no-mistakes doctor` reports whether the configured global runner can start a validation gate.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -160,7 +160,8 @@ func NeutralizesGateInstructions(a Agent) bool {
 // agent-instruction files. Callers must invoke it before launching any gate
 // agent so an unverified harness is refused with a clear error rather than run
 // unneutralized in the target checkout. Only codex, claude, and pi have a verified
-// neutralization knob today.
+// neutralization knob today. grok isolates via --cwd and a unique --leader-socket
+// but has no verified AGENTS.md suppression flag.
 func EnsureGateNeutralized(a Agent) error {
 	if a == nil {
 		return fmt.Errorf("no gate agent configured")
@@ -811,8 +812,10 @@ func NewWithOptions(name types.AgentName, bin string, extraArgs []string, opts O
 		return &piAgent{bin: bin, extraArgs: extraArgs, disableProjectSettings: opts.DisableProjectSettings}, nil
 	case types.AgentCopilot:
 		return &copilotAgent{bin: bin, extraArgs: extraArgs}, nil
+	case types.AgentGrok:
+		return &grokAgent{bin: bin, extraArgs: extraArgs}, nil
 	default:
-		return nil, fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, copilot, cursor, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
+		return nil, fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, copilot, grok, cursor, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
 	}
 }
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -25,6 +25,7 @@ func TestNew_KnownAgents(t *testing.T) {
 		{name: "opencode", agent: types.AgentOpenCode, bin: "opencode", wantName: "opencode"},
 		{name: "pi", agent: types.AgentPi, bin: "pi", wantName: "pi"},
 		{name: "copilot", agent: types.AgentCopilot, bin: "copilot", wantName: "copilot"},
+		{name: "grok", agent: types.AgentGrok, bin: "grok", wantName: "grok"},
 		{name: "cursor alias", agent: types.AgentCursor, bin: "acpx", wantName: "acp:cursor"},
 	}
 

--- a/internal/agent/gateneutralize_test.go
+++ b/internal/agent/gateneutralize_test.go
@@ -29,7 +29,7 @@ func TestNeutralizesGateInstructions_OnlyVerifiedHarnessesUnderOptOut(t *testing
 			t.Errorf("%s must neutralize under the opt-out with its default knob", name)
 		}
 	}
-	unverified := []types.AgentName{types.AgentOpenCode, types.AgentCopilot, types.AgentRovoDev}
+	unverified := []types.AgentName{types.AgentOpenCode, types.AgentCopilot, types.AgentRovoDev, types.AgentGrok}
 	for _, name := range unverified {
 		if NeutralizesGateInstructions(optOutAgent(t, name, nil)) {
 			t.Errorf("%s has no verified knob; must NOT report neutralized", name)

--- a/internal/agent/grok.go
+++ b/internal/agent/grok.go
@@ -1,0 +1,251 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/kunchenguid/no-mistakes/internal/shellenv"
+)
+
+// grokIsolationEnvKeys are firstmate/session identity variables that a live
+// Grok TUI stamps into its environment. A child grok that inherits them
+// attaches to that session's project even when --cwd points at the invocation
+// checkout. Unset them on every spawn.
+var grokIsolationEnvKeys = []string{
+	"GROK_AGENT",
+	"GROK_SESSION_ID",
+	"GROK_WORKSPACE_ROOT",
+}
+
+// grokAgent spawns the Grok Build TUI CLI (`grok`) for each invocation.
+// The lifecycle is pi/copilot-shaped: one process per Run, no managed server.
+//
+// Isolation is hard. A live firstmate grok session will steal the project
+// unless each spawn pins:
+//   - --cwd = opts.CWD (the invocation checkout, never firstmate)
+//   - a unique --leader-socket under the process temp dir (never
+//     ~/.grok/leader.sock)
+//   - GROK_AGENT / GROK_SESSION_ID / GROK_WORKSPACE_ROOT stripped from the
+//     child env
+//
+// Headless invoke uses documented grok --help flags only: -p/--single with
+// --always-approve and --output-format json. grok --help has no flag that
+// disables AGENTS.md/CLAUDE.md discovery, so grokAgent does not implement
+// GateInstructionNeutralizer. Isolation is --cwd + unique socket, not a
+// verified neutralization knob. EnsureGateNeutralized therefore refuses grok
+// when disable_project_settings is on.
+type grokAgent struct {
+	bin       string
+	extraArgs []string
+}
+
+func (a *grokAgent) Name() string { return "grok" }
+
+func (a *grokAgent) ReportsAgentAttempts() bool { return true }
+
+func (a *grokAgent) Close() error { return nil }
+
+func (a *grokAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
+	return runWithRetry(ctx, "grok", opts, claudeMaxRetries, classifyTransient, nil, func() (*Result, error) {
+		return a.runOnce(ctx, opts)
+	})
+}
+
+func (a *grokAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
+	sockDir, err := os.MkdirTemp("", "nm-grok-leader-*")
+	if err != nil {
+		return nil, fmt.Errorf("grok leader socket dir: %w", err)
+	}
+	defer os.RemoveAll(sockDir)
+	leaderSocket := filepath.Join(sockDir, "leader.sock")
+
+	args := a.buildArgs(opts, leaderSocket)
+	cmd := exec.CommandContext(ctx, a.bin, args...)
+	cmd.Dir = opts.CWD
+	cmd.Stdin = nil
+	cmd.Env = grokSafeEnv(opts.CWD, opts.Env)
+	shellenv.ConfigureShellCommand(cmd)
+
+	var stderrBuf []byte
+	var stderrWG sync.WaitGroup
+	started, err := startNativeAgentCommand(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("grok start: %w", err)
+	}
+	defer started.closePipes()
+	pid := started.pid()
+	emitAgentStarted(opts, "grok", pid)
+
+	stderrWG.Add(1)
+	go func() {
+		defer stderrWG.Done()
+		stderrBuf, _ = io.ReadAll(started.stderr)
+	}()
+
+	stdout, readErr := io.ReadAll(started.stdout)
+	waitErr := started.wait()
+	stderrWG.Wait()
+	if readErr != nil {
+		retErr := fmt.Errorf("grok read stdout: %w", readErr)
+		emitAgentExited(opts, "grok", pid, retErr)
+		return nil, retErr
+	}
+	if waitErr != nil {
+		detail := grokErrorDetail(stdout, string(stderrBuf))
+		if detail != "" {
+			retErr := fmt.Errorf("grok exited: %w: %s", waitErr, detail)
+			emitAgentExited(opts, "grok", pid, retErr)
+			return nil, retErr
+		}
+		retErr := fmt.Errorf("grok exited: %w", waitErr)
+		emitAgentExited(opts, "grok", pid, retErr)
+		return nil, retErr
+	}
+
+	text, usage, err := parseGrokJSONOutput(stdout)
+	if err != nil {
+		retErr := fmt.Errorf("grok output: %w", err)
+		emitAgentExited(opts, "grok", pid, retErr)
+		return nil, retErr
+	}
+	if opts.OnChunk != nil && text != "" {
+		opts.OnChunk(text)
+	}
+	res, err := finalizeTextResult("grok", text, opts.JSONSchema, usage)
+	emitAgentExited(opts, "grok", pid, err)
+	return res, err
+}
+
+// buildArgs returns the grok argv for one invocation. User extras lead so
+// operator flags such as --model take effect. Managed isolation and headless
+// flags follow so --cwd, --leader-socket, --output-format, and -p cannot be
+// displaced by extraArgs (those flags are also reserved in
+// agent_args_override).
+func (a *grokAgent) buildArgs(opts RunOpts, leaderSocket string) []string {
+	args := make([]string, 0, len(a.extraArgs)+12)
+	args = append(args, a.extraArgs...)
+	args = append(args,
+		"--cwd", opts.CWD,
+		"--leader-socket", leaderSocket,
+	)
+	if !grokUserSetAlwaysApprove(a.extraArgs) {
+		args = append(args, "--always-approve")
+	}
+	args = append(args, "--output-format", "json")
+	if len(opts.JSONSchema) > 0 {
+		args = append(args, "--json-schema", string(opts.JSONSchema))
+	}
+	args = append(args, "-p", opts.Prompt)
+	return args
+}
+
+func grokUserSetAlwaysApprove(extraArgs []string) bool {
+	for _, arg := range extraArgs {
+		switch arg {
+		case "--always-approve", "--yolo":
+			return true
+		}
+	}
+	return false
+}
+
+func grokSafeEnv(dir string, extra []string) []string {
+	return stripEnvKeys(gitSafeEnv(dir, extra), grokIsolationEnvKeys...)
+}
+
+func stripEnvKeys(env []string, keys ...string) []string {
+	drop := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		if runtime.GOOS == "windows" {
+			drop[strings.ToUpper(key)] = struct{}{}
+		} else {
+			drop[key] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		k, _, _ := strings.Cut(kv, "=")
+		lookup := k
+		if runtime.GOOS == "windows" {
+			lookup = strings.ToUpper(k)
+		}
+		if _, skip := drop[lookup]; skip {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
+type grokJSONResult struct {
+	Type    string         `json:"type"`
+	Message string         `json:"message"`
+	Text    string         `json:"text"`
+	Usage   *grokJSONUsage `json:"usage"`
+}
+
+type grokJSONUsage struct {
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	ReasoningTokens          int `json:"reasoning_tokens"`
+}
+
+func parseGrokJSONOutput(stdout []byte) (string, TokenUsage, error) {
+	trimmed := bytes.TrimSpace(stdout)
+	if len(trimmed) == 0 {
+		return "", TokenUsage{}, fmt.Errorf("empty stdout")
+	}
+	var result grokJSONResult
+	if err := json.Unmarshal(trimmed, &result); err != nil {
+		return "", TokenUsage{}, fmt.Errorf("parse json: %w (output snippet: %q)", err, outputSnippet(string(trimmed)))
+	}
+	if result.Type == "error" {
+		msg := strings.TrimSpace(result.Message)
+		if msg == "" {
+			msg = "error"
+		}
+		return "", TokenUsage{}, fmt.Errorf("%s", msg)
+	}
+	text := strings.TrimSpace(result.Text)
+	if text == "" {
+		return "", TokenUsage{}, fmt.Errorf("no text output")
+	}
+	var usage TokenUsage
+	if result.Usage != nil {
+		usage = TokenUsage{
+			InputTokens:           result.Usage.InputTokens,
+			OutputTokens:          result.Usage.OutputTokens,
+			CacheReadTokens:       result.Usage.CacheReadInputTokens,
+			CacheCreationTokens:   result.Usage.CacheCreationInputTokens,
+			ReasoningTokens:       result.Usage.ReasoningTokens,
+			Reported:              true,
+			CacheCreationReported: true,
+		}
+	}
+	return text, usage, nil
+}
+
+func grokErrorDetail(stdout []byte, stderr string) string {
+	if _, _, err := parseGrokJSONOutput(stdout); err != nil {
+		msg := strings.TrimSpace(err.Error())
+		if msg != "" && msg != "empty stdout" && !strings.HasPrefix(msg, "parse json:") && msg != "no text output" {
+			stderr = strings.TrimSpace(stderr)
+			if stderr != "" {
+				return msg + "; " + stderr
+			}
+			return msg
+		}
+	}
+	return strings.TrimSpace(stderr)
+}

--- a/internal/agent/grok_test.go
+++ b/internal/agent/grok_test.go
@@ -1,0 +1,327 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+func TestGrokAgent_Name(t *testing.T) {
+	ga := &grokAgent{bin: "grok"}
+	if ga.Name() != "grok" {
+		t.Fatalf("Name() = %q, want grok", ga.Name())
+	}
+}
+
+func TestGrokAgent_DoesNotNeutralizeGateInstructions(t *testing.T) {
+	// grok --help has no flag that disables AGENTS.md/CLAUDE.md discovery.
+	// Isolation is --cwd + a unique --leader-socket, not a verified
+	// neutralization knob. Do not report neutralized.
+	if NeutralizesGateInstructions(&grokAgent{bin: "grok"}) {
+		t.Fatal("grok must not report neutralized; no verified suppression flag exists")
+	}
+	a, err := NewWithOptions(types.AgentGrok, "grok", nil, Options{DisableProjectSettings: true})
+	if err != nil {
+		t.Fatalf("NewWithOptions(grok): %v", err)
+	}
+	if NeutralizesGateInstructions(a) {
+		t.Fatal("grok must not report neutralized under disable_project_settings either")
+	}
+	if err := EnsureGateNeutralized(a); err == nil {
+		t.Fatal("EnsureGateNeutralized must refuse grok; neutralization is unverified")
+	}
+}
+
+func TestGrokAgent_BuildArgs_HeadlessIsolationFlags(t *testing.T) {
+	ga := &grokAgent{bin: "grok"}
+	cwd := "/work/checkout"
+	sock := filepath.Join(t.TempDir(), "leader.sock")
+	args := ga.buildArgs(RunOpts{Prompt: "review the diff", CWD: cwd}, sock)
+
+	assertArgPair(t, args, "--cwd", cwd)
+	assertArgPair(t, args, "--leader-socket", sock)
+	if !containsArg(args, "--always-approve") {
+		t.Fatalf("args missing --always-approve: %v", args)
+	}
+	if !containsArgPair(args, "--output-format", "json") {
+		t.Fatalf("args missing --output-format json: %v", args)
+	}
+	if !containsArgPair(args, "-p", "review the diff") {
+		t.Fatalf("args missing -p prompt: %v", args)
+	}
+	if containsArg(args, "agent") {
+		t.Fatalf("headless invoke must not start grok agent TUI/subcommand: %v", args)
+	}
+}
+
+func TestGrokAgent_BuildArgs_ExtraArgsFirst(t *testing.T) {
+	ga := &grokAgent{bin: "grok", extraArgs: []string{"--model", "grok-4"}}
+	sock := filepath.Join(t.TempDir(), "leader.sock")
+	args := ga.buildArgs(RunOpts{Prompt: "fix it", CWD: "/repo"}, sock)
+	if len(args) < 2 || args[0] != "--model" || args[1] != "grok-4" {
+		t.Fatalf("extraArgs should lead argv, got %v", args)
+	}
+}
+
+func TestGrokAgent_BuildArgs_PassesJSONSchema(t *testing.T) {
+	ga := &grokAgent{bin: "grok"}
+	schema := json.RawMessage(`{"type":"object","properties":{"ok":{"type":"boolean"}}}`)
+	sock := filepath.Join(t.TempDir(), "leader.sock")
+	args := ga.buildArgs(RunOpts{Prompt: "review", CWD: "/repo", JSONSchema: schema}, sock)
+	if !containsArgPair(args, "--json-schema", string(schema)) {
+		t.Fatalf("args missing --json-schema: %v", args)
+	}
+}
+
+func TestGrokAgent_BuildArgs_UserYoloSuppressesAlwaysApprove(t *testing.T) {
+	ga := &grokAgent{bin: "grok", extraArgs: []string{"--yolo"}}
+	args := ga.buildArgs(RunOpts{Prompt: "p", CWD: "/repo"}, filepath.Join(t.TempDir(), "leader.sock"))
+	count := 0
+	for _, a := range args {
+		if a == "--always-approve" {
+			count++
+		}
+	}
+	if count != 0 {
+		t.Fatalf("expected no default --always-approve when --yolo is set, got %v", args)
+	}
+}
+
+func TestParseGrokJSONOutput_TextAndUsage(t *testing.T) {
+	raw := []byte(`{
+		"text": "{\"ok\":true}",
+		"stopReason": "end_turn",
+		"usage": {
+			"input_tokens": 11,
+			"output_tokens": 7,
+			"cache_read_input_tokens": 3,
+			"cache_creation_input_tokens": 1,
+			"reasoning_tokens": 2
+		}
+	}`)
+	text, usage, err := parseGrokJSONOutput(raw)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if text != `{"ok":true}` {
+		t.Fatalf("text = %q, want {\"ok\":true}", text)
+	}
+	want := TokenUsage{
+		InputTokens:           11,
+		OutputTokens:          7,
+		CacheReadTokens:       3,
+		CacheCreationTokens:   1,
+		ReasoningTokens:       2,
+		Reported:              true,
+		CacheCreationReported: true,
+	}
+	if usage != want {
+		t.Fatalf("usage = %+v, want %+v", usage, want)
+	}
+}
+
+func TestParseGrokJSONOutput_ErrorObject(t *testing.T) {
+	raw := []byte(`{"type":"error","message":"Couldn't start session: auth failed"}`)
+	_, _, err := parseGrokJSONOutput(raw)
+	if err == nil {
+		t.Fatal("expected error object to fail")
+	}
+	if !strings.Contains(err.Error(), "auth failed") {
+		t.Fatalf("error = %v, want auth failed", err)
+	}
+}
+
+func TestParseGrokJSONOutput_RejectsEmptyText(t *testing.T) {
+	_, _, err := parseGrokJSONOutput([]byte(`{"text":"   ","stopReason":"end_turn"}`))
+	if err == nil {
+		t.Fatal("expected empty text to fail")
+	}
+}
+
+func TestGrokAgent_Run_PinsCwdAndUniqueLeaderSocket(t *testing.T) {
+	workDir := t.TempDir()
+	bin := writeFakeGrok(t, t.TempDir(), `#!/bin/sh
+printf '%s\n' "$@" > grok-argv.txt
+printf '%s\n' '{"text":"ok","stopReason":"end_turn"}'
+`, strings.Join([]string{
+		"@echo off",
+		"echo %* > grok-argv.txt",
+		"echo {\"text\":\"ok\",\"stopReason\":\"end_turn\"}",
+	}, "\r\n"))
+
+	ga := &grokAgent{bin: bin}
+	if _, err := ga.Run(context.Background(), RunOpts{Prompt: "review", CWD: workDir}); err != nil {
+		t.Fatalf("run grok: %v", err)
+	}
+	first := readArgv(t, workDir)
+	cwd := argValue(first, "--cwd")
+	if cwd != workDir {
+		t.Fatalf("--cwd = %q, want %q in %v", cwd, workDir, first)
+	}
+	sock1 := argValue(first, "--leader-socket")
+	if sock1 == "" {
+		t.Fatalf("missing --leader-socket in %v", first)
+	}
+	home, _ := os.UserHomeDir()
+	defaultSock := filepath.Join(home, ".grok", "leader.sock")
+	if sock1 == defaultSock {
+		t.Fatal("leader socket must not be the default ~/.grok/leader.sock")
+	}
+
+	workDir2 := t.TempDir()
+	if _, err := ga.Run(context.Background(), RunOpts{Prompt: "review", CWD: workDir2}); err != nil {
+		t.Fatalf("second run grok: %v", err)
+	}
+	sock2 := argValue(readArgv(t, workDir2), "--leader-socket")
+	if sock1 == sock2 {
+		t.Fatalf("leader sockets must be unique per invocation, both %q", sock1)
+	}
+}
+
+func TestGrokAgent_Run_UnsetsFirstmateEnv(t *testing.T) {
+	t.Setenv("GROK_AGENT", "firstmate")
+	t.Setenv("GROK_SESSION_ID", "sess-stolen")
+	t.Setenv("GROK_WORKSPACE_ROOT", "/home/rick/projects/firstmate")
+
+	workDir := t.TempDir()
+	bin := writeFakeGrok(t, t.TempDir(), `#!/bin/sh
+env | grep -E '^(GROK_AGENT|GROK_SESSION_ID|GROK_WORKSPACE_ROOT)=' > grok-env.txt || true
+printf '%s\n' '{"text":"ok","stopReason":"end_turn"}'
+`, strings.Join([]string{
+		"@echo off",
+		"set GROK_AGENT>grok-env.txt 2>nul",
+		"set GROK_SESSION_ID>>grok-env.txt 2>nul",
+		"set GROK_WORKSPACE_ROOT>>grok-env.txt 2>nul",
+		"echo {\"text\":\"ok\",\"stopReason\":\"end_turn\"}",
+	}, "\r\n"))
+
+	ga := &grokAgent{bin: bin}
+	if _, err := ga.Run(context.Background(), RunOpts{Prompt: "review", CWD: workDir}); err != nil {
+		t.Fatalf("run grok: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(workDir, "grok-env.txt"))
+	if err != nil {
+		t.Fatalf("read grok-env.txt: %v", err)
+	}
+	text := string(got)
+	for _, key := range []string{"GROK_AGENT", "GROK_SESSION_ID", "GROK_WORKSPACE_ROOT"} {
+		if strings.Contains(text, key+"=") {
+			t.Errorf("child env still has %s: %s", key, text)
+		}
+	}
+}
+
+func TestGrokAgent_Run_ParsesJSONText(t *testing.T) {
+	bin := writeFakeGrok(t, t.TempDir(), `#!/bin/sh
+printf '%s\n' '{"text":"{\"ok\":true}","stopReason":"end_turn","usage":{"input_tokens":4,"output_tokens":2,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}'
+`, strings.Join([]string{
+		"@echo off",
+		"echo {\"text\":\"{\\\"ok\\\":true}\",\"stopReason\":\"end_turn\",\"usage\":{\"input_tokens\":4,\"output_tokens\":2,\"cache_read_input_tokens\":0,\"cache_creation_input_tokens\":0}}",
+	}, "\r\n"))
+
+	schema := json.RawMessage(`{"type":"object","properties":{"ok":{"type":"boolean"}},"required":["ok"]}`)
+	ga := &grokAgent{bin: bin}
+	var chunks []string
+	result, err := ga.Run(context.Background(), RunOpts{
+		Prompt:     "review",
+		CWD:        t.TempDir(),
+		JSONSchema: schema,
+		OnChunk:    func(s string) { chunks = append(chunks, s) },
+	})
+	if err != nil {
+		t.Fatalf("run grok: %v", err)
+	}
+	if string(result.Output) != `{"ok":true}` {
+		t.Fatalf("output = %s, want {\"ok\":true}", result.Output)
+	}
+	if result.Usage.InputTokens != 4 || result.Usage.OutputTokens != 2 {
+		t.Fatalf("usage = %+v", result.Usage)
+	}
+	if len(chunks) == 0 {
+		t.Fatal("expected OnChunk to receive final text")
+	}
+}
+
+func TestGrokAgent_Run_SurfacesNonZeroExit(t *testing.T) {
+	bin := writeFakeGrok(t, t.TempDir(), `#!/bin/sh
+echo boom >&2
+exit 1
+`, strings.Join([]string{
+		"@echo off",
+		"echo boom 1>&2",
+		"exit /b 1",
+	}, "\r\n"))
+
+	ga := &grokAgent{bin: bin}
+	_, err := ga.Run(context.Background(), RunOpts{Prompt: "review", CWD: t.TempDir()})
+	if err == nil {
+		t.Fatal("expected non-zero exit error")
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("expected stderr in error, got: %v", err)
+	}
+}
+
+func writeFakeGrok(t *testing.T, dir, posixScript, windowsScript string) string {
+	t.Helper()
+	name := "grok"
+	script := posixScript
+	if runtime.GOOS == "windows" {
+		name = "grok.cmd"
+		script = windowsScript
+	}
+	bin := filepath.Join(dir, name)
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake grok: %v", err)
+	}
+	return bin
+}
+
+func readArgv(t *testing.T, workDir string) []string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(workDir, "grok-argv.txt"))
+	if err != nil {
+		t.Fatalf("read grok-argv.txt: %v", err)
+	}
+	return strings.Fields(strings.TrimSpace(string(raw)))
+}
+
+func argValue(args []string, flag string) string {
+	for i, a := range args {
+		if a == flag && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+func containsArg(args []string, flag string) bool {
+	for _, a := range args {
+		if a == flag {
+			return true
+		}
+	}
+	return false
+}
+
+func containsArgPair(args []string, flag, value string) bool {
+	for i, a := range args {
+		if a == flag && i+1 < len(args) && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+func assertArgPair(t *testing.T, args []string, flag, value string) {
+	t.Helper()
+	if !containsArgPair(args, flag, value) {
+		t.Fatalf("args missing %s %s: %v", flag, value, args)
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -166,6 +166,7 @@ func doctorAgentChecks() []doctorAgentCheck {
 		{"opencode", []string{"opencode"}},
 		{"pi", []string{"pi"}},
 		{"copilot", []string{"copilot"}},
+		{"grok", []string{"grok"}},
 		{"acpx", []string{"acpx"}},
 	}
 	for _, alias := range types.ACPAliases() {

--- a/internal/cli/doctor_grok_test.go
+++ b/internal/cli/doctor_grok_test.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/telemetry"
+)
+
+// TestDoctorListsGrokAgent exercises the user-facing `no-mistakes doctor`
+// report and verifies the Grok Build TUI CLI appears in the Agents section
+// and is detected (LookPath) when its binary is on PATH.
+func TestDoctorListsGrokAgent(t *testing.T) {
+	restore := telemetry.SetDefaultForTesting(&telemetryRecorder{})
+	defer restore()
+
+	nmHome := t.TempDir()
+	t.Setenv("NM_HOME", nmHome)
+
+	binDir := t.TempDir()
+	grokPath := writeFakeGrokBinary(t, binDir)
+
+	sep := string(os.PathListSeparator)
+	t.Setenv("PATH", binDir+sep+os.Getenv("PATH"))
+
+	out, err := executeCmd("doctor")
+	if err != nil {
+		t.Fatalf("doctor failed: %v\n%s", err, out)
+	}
+
+	t.Logf("rendered `no-mistakes doctor` report:\n%s", out)
+
+	if !strings.Contains(out, "grok") {
+		t.Fatalf("doctor report missing grok agent entry:\n%s", out)
+	}
+	if !strings.Contains(out, grokPath) {
+		t.Fatalf("doctor did not detect grok at %q:\n%s", grokPath, out)
+	}
+}
+
+func writeFakeGrokBinary(t *testing.T, dir string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		dst := filepath.Join(dir, "grok.cmd")
+		if err := os.WriteFile(dst, []byte("@echo off\r\nexit /b 0\r\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return dst
+	}
+	dst := filepath.Join(dir, "grok")
+	if err := os.WriteFile(dst, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dst
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -635,7 +635,7 @@ const defaultConfigYAML = `# no-mistakes global configuration
 
 # Agent to use for code generation. This may also be an ordered fallback list,
 # for example: agent: [codex, claude]
-# Options: auto, claude, codex, rovodev, opencode, pi, copilot, cursor, acp:<target>
+# Options: auto, claude, codex, rovodev, opencode, pi, copilot, grok, cursor, acp:<target>
 # "auto" detects the first available native agent or ACP alias on your system
 # "cursor" is an ACP alias for acp:cursor using cursor-agent acp via acpx
 # "acp:cursor" also uses that Cursor default command
@@ -783,6 +783,7 @@ var defaultBinary = map[types.AgentName]string{
 	types.AgentOpenCode: "opencode",
 	types.AgentPi:       "pi",
 	types.AgentCopilot:  "copilot",
+	types.AgentGrok:     "grok",
 }
 
 // nativeAgentProbeOrder is the priority order for auto-detecting native agents.
@@ -793,6 +794,7 @@ var nativeAgentProbeOrder = []types.AgentName{
 	types.AgentRovoDev,
 	types.AgentPi,
 	types.AgentCopilot,
+	types.AgentGrok,
 }
 
 func isACPAgent(name types.AgentName) bool {
@@ -978,7 +980,7 @@ func (c *Config) resolveConfiguredAgent(ctx context.Context, name types.AgentNam
 		return resolved, err == nil, "auto", err
 	}
 	if _, ok := defaultBinary[name]; !ok && !isACPAgent(name) {
-		return "", false, string(name), fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, copilot, cursor, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
+		return "", false, string(name), fmt.Errorf("unknown agent %q; valid options: auto, claude, codex, rovodev, opencode, pi, copilot, grok, cursor, acp:<target> (set 'agent' in ~/.no-mistakes/config.yaml)", name)
 	}
 	if isACPAgent(name) {
 		available, bins, err := c.acpAvailable(name, lookPath)
@@ -1139,6 +1141,7 @@ var agentArgsOverrideAgents = map[string]bool{
 	string(types.AgentOpenCode): true,
 	string(types.AgentPi):       true,
 	string(types.AgentCopilot):  true,
+	string(types.AgentGrok):     true,
 }
 
 // reservedAgentArgs lists flags that no-mistakes manages internally and that
@@ -1191,6 +1194,25 @@ var reservedAgentArgs = map[string]map[string]bool{
 		"--output-format": true,
 		"--no-color":      true,
 	},
+	string(types.AgentGrok): {
+		"-p":              true,
+		"--single":        true,
+		"--output-format": true,
+		"--json-schema":   true,
+		"--cwd":           true,
+		"--leader-socket": true,
+		"-c":              true,
+		"--continue":      true,
+		"-r":              true,
+		"--resume":        true,
+		"-s":              true,
+		"--session-id":    true,
+		"--fork-session":  true,
+		"--prompt-file":   true,
+		"--prompt-json":   true,
+		"--worktree":      true,
+		"-w":              true,
+	},
 }
 
 // validateAgentArgsOverride ensures each agent key is a known agent name and
@@ -1199,7 +1221,7 @@ var reservedAgentArgs = map[string]map[string]bool{
 func validateAgentArgsOverride(override map[string][]string) error {
 	for name, args := range override {
 		if !agentArgsOverrideAgents[name] {
-			return fmt.Errorf("invalid agent name in agent_args_override: %q (valid: claude, codex, rovodev, opencode, pi, copilot)", name)
+			return fmt.Errorf("invalid agent name in agent_args_override: %q (valid: claude, codex, rovodev, opencode, pi, copilot, grok)", name)
 		}
 		reserved := reservedAgentArgs[name]
 		for i, arg := range args {

--- a/internal/config/config_agent_test.go
+++ b/internal/config/config_agent_test.go
@@ -36,6 +36,7 @@ func TestAgentPath_DefaultBinaries(t *testing.T) {
 		{types.AgentOpenCode, "opencode"},
 		{types.AgentPi, "pi"},
 		{types.AgentCopilot, "copilot"},
+		{types.AgentGrok, "grok"},
 	}
 	for _, tt := range tests {
 		cfg := &Config{Agent: tt.agent}
@@ -350,7 +351,7 @@ func TestResolveAgent_AutoSkipsRovoDevWithoutSubcommand(t *testing.T) {
 
 	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
 		switch bin {
-		case "claude", "codex", "opencode", "pi", "copilot", "cursor-agent", "acpx":
+		case "claude", "codex", "opencode", "pi", "copilot", "grok", "cursor-agent", "acpx":
 			return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
 		case "acli":
 			return "/usr/bin/acli", nil
@@ -420,6 +421,22 @@ func TestResolveAgent_AutoReturnsOverrideProbeError(t *testing.T) {
 	}
 	if cfg.Agent != types.AgentAuto {
 		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentAuto)
+	}
+}
+
+func TestResolveAgent_AutoPicksGrokWhenOnlyGrokIsOnPATH(t *testing.T) {
+	cfg := &Config{Agent: types.AgentAuto}
+	err := cfg.ResolveAgent(context.Background(), func(bin string) (string, error) {
+		if bin == "grok" {
+			return "/home/rick/.local/bin/grok", nil
+		}
+		return "", &exec.Error{Name: bin, Err: exec.ErrNotFound}
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Agent != types.AgentGrok {
+		t.Errorf("agent = %q, want %q", cfg.Agent, types.AgentGrok)
 	}
 }
 

--- a/internal/config/config_args_override_test.go
+++ b/internal/config/config_args_override_test.go
@@ -118,6 +118,23 @@ func TestLoadGlobal_AgentArgsOverride_ReservedArgsRejected(t *testing.T) {
 		{"opencode", "--hostname"},
 		{"opencode", "--port"},
 		{"opencode", "--print-logs"},
+		{"grok", "-p"},
+		{"grok", "--single"},
+		{"grok", "--output-format"},
+		{"grok", "--json-schema"},
+		{"grok", "--cwd"},
+		{"grok", "--leader-socket"},
+		{"grok", "-c"},
+		{"grok", "--continue"},
+		{"grok", "-r"},
+		{"grok", "--resume"},
+		{"grok", "-s"},
+		{"grok", "--session-id"},
+		{"grok", "--fork-session"},
+		{"grok", "--prompt-file"},
+		{"grok", "--prompt-json"},
+		{"grok", "--worktree"},
+		{"grok", "-w"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.agent+"_"+tt.arg, func(t *testing.T) {

--- a/internal/daemon/gateneutralize_test.go
+++ b/internal/daemon/gateneutralize_test.go
@@ -36,7 +36,7 @@ func TestNewPipelineAgent_OptOut_AdmitsVerifiedHarness(t *testing.T) {
 // verified neutralization knob is refused rather than launched with project
 // instructions loaded.
 func TestNewPipelineAgent_OptOut_RefusesUnverifiedHarness(t *testing.T) {
-	for _, name := range []types.AgentName{types.AgentOpenCode, types.AgentCopilot} {
+	for _, name := range []types.AgentName{types.AgentOpenCode, types.AgentCopilot, types.AgentGrok} {
 		cfg := &config.Config{Agent: name, DisableProjectSettings: true}
 		if _, err := newPipelineAgent(context.Background(), cfg, t.TempDir(), fakeLookPath); err == nil {
 			t.Fatalf("%s must be refused under opt-out", name)
@@ -53,7 +53,7 @@ func TestNewPipelineAgent_NoOptOut_AdmitsEveryHarness(t *testing.T) {
 	// rovodev is omitted: its resolution runs a real version probe that a fake
 	// binary path cannot satisfy. opencode/pi/copilot already prove that an
 	// unverified adapter is admitted when the repo did not opt out.
-	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentOpenCode, types.AgentPi, types.AgentCopilot} {
+	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentOpenCode, types.AgentPi, types.AgentCopilot, types.AgentGrok} {
 		cfg := &config.Config{Agent: name} // DisableProjectSettings defaults false
 		ag, err := newPipelineAgent(context.Background(), cfg, t.TempDir(), fakeLookPath)
 		if err != nil {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -141,6 +141,7 @@ const (
 	AgentOpenCode AgentName = "opencode"
 	AgentPi       AgentName = "pi"
 	AgentCopilot  AgentName = "copilot"
+	AgentGrok     AgentName = "grok"
 	AgentCursor   AgentName = "cursor"
 )
 


### PR DESCRIPTION
## Why

A machine that only has Grok Build TUI (`grok`) currently fails `no-mistakes doctor` with no runnable agent. `agent: auto` probes claude, codex, opencode, rovodev, pi, and copilot — never grok. That blocks validation on grok-only hosts.

## What

Register `types.AgentGrok = "grok"` as a native one-process-per-`Run` adapter, modeled on pi/copilot:

- Headless invoke: documented `grok -p --always-approve --output-format json` (plus `--json-schema` when structured output is requested). Parses the headless JSON `text` field through `finalizeTextResult`. Does not start the interactive TUI.
- Isolation (hard): every spawn pins `--cwd` to the invocation checkout, uses a unique `--leader-socket` under the process temp dir (never `~/.grok/leader.sock`), and unsets `GROK_AGENT` / `GROK_SESSION_ID` / `GROK_WORKSPACE_ROOT` so a live Grok TUI cannot steal the project.
- Auto-detect: `LookPath("grok")` is last in `nativeAgentProbeOrder`, so `agent: auto` works on a grok-only PATH without changing preference for machines that already have claude/codex/etc.
- Doctor, default binary map, config comments, and `agent_args_override` allowlist include grok.

## Gate neutralization (unverified)

`grok --help` has no flag that disables AGENTS.md/CLAUDE.md discovery. This adapter does **not** implement `NeutralizesGateInstructions`. Isolation is `--cwd` + unique leader socket only. `disable_project_settings` continues to fail closed for grok, same as copilot/opencode.

## Tests

Construction, argv (`--cwd`, unique leader socket, not the default `leader.sock`), firstmate env stripping, JSON parse, auto-detect finds grok on PATH, doctor lists grok, reserved `agent_args_override` flags, and opt-out refuse.

`gofmt`, `make lint`, and `go test ./internal/agent ./internal/config ./internal/types ./internal/cli` are green. One unrelated `internal/daemon` flaky (`TestWaitForManagedDaemonStartDetectsPublishedChildExit`) was observed once; grok-specific daemon gate-neutralize tests pass.

Do not merge from this PR unless the configured merge authority says so. Direct-PR because the pipeline cannot review itself until grok exists.