### PR TITLE
fix(eval): prevent display state mutations and clipped strata

### DIFF
--- a/docs/src/content/docs/reference/eval.md
+++ b/docs/src/content/docs/reference/eval.md
@@ -10,6 +10,8 @@ The `eval` commands do not start or use the shared daemon, alter a gate, emit re
 
 Replay does invoke the selected agent normally, so that agent may send the restored code and review context to its configured model provider. The local-only guarantee concerns eval storage and transport added by no-mistakes, not the selected agent's ordinary provider traffic.
 
+When `eval sets`, `eval report`, or `eval run` resolves repository fingerprints into display names, it consults `state.sqlite` only if that pipeline database already exists and opens it read-only. The display lookup never creates or migrates pipeline state; without a readable database, the dashboards fall back to fingerprints.
+
 ## How cases are collected
 
 Cases arrive on their own. When an eligible run finishes, its decided Review passes are frozen into the local corpus - one case per pass. Collection happens after the pipeline has already reported its outcome, so it can never change or fail the run; a problem is logged and nothing else.

--- a/docs/src/content/docs/reference/eval.md
+++ b/docs/src/content/docs/reference/eval.md
@@ -34,6 +34,8 @@ no-mistakes eval miss ingest <run-id> \
 
 `--finding` is repeatable. The command captures the run if needed (recapture is a no-op, so existing labels survive), then writes false-negative gold onto the last completed non-blocking review pass. Duplicate finding IDs are no-ops. A parked or blocking review is refused: that class found something, so it is not a post-PR miss.
 
+`id` and `description` are required. `severity` defaults to `error` and must be one of `error`, `warning`, or `info` - it becomes gold and then a composition stratum, so an unrecognized value is refused rather than shown as an invented finding type. `action`, if given, must be one of `auto-fix`, `ask-user`, or `no-op`; gold carries no action, so a valid one is accepted and dropped rather than silently changing what is stored.
+
 The ingest payload is the source of truth. Eval does not scrape GitHub review comments and does not read an external markdown ledger. The curator (a human, or an automation that already vetted the miss) supplies the structured finding.
 
 Automatic collection and `eval capture` do the same freeze, so a case is equally trustworthy either way. Capturing a run that was already collected relabels gold from later merge evidence and otherwise leaves the frozen case in place. `eval miss ingest` can still attach confirmed post-PR-miss gold afterwards.

--- a/internal/cli/eval.go
+++ b/internal/cli/eval.go
@@ -53,8 +53,15 @@ func openEvalStore() (*paths.Paths, *eval.Store, error) {
 // display-only: when the pipeline database cannot be read, the dashboards fall
 // back to the fingerprint rather than failing an eval command that otherwise
 // needs no database at all.
+//
+// The read goes through db.OpenReadOnly, never db.Open. db.Open creates the
+// database and runs every migration, so routing a display lookup through it
+// made `eval sets`, `eval report`, and `eval run` initialize pipeline state on
+// a machine that has none, and migrate the schema of a database a running
+// daemon owns. A missing database is the ordinary case here (os.IsNotExist),
+// not an error worth reporting: the dashboards simply show fingerprints.
 func evalRepoNames(p *paths.Paths) map[string]string {
-	database, err := db.Open(p.DB())
+	database, err := db.OpenReadOnly(p.DB())
 	if err != nil {
 		return nil
 	}
@@ -145,7 +152,7 @@ func newEvalMissIngestCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringArrayVar(&findings, "finding", nil, "confirmed miss as JSON finding object (repeatable)")
+	cmd.Flags().StringArrayVar(&findings, "finding", nil, "confirmed miss as JSON finding object with id and description, optional file, line, severity (error|warning|info, default error) and action (auto-fix|ask-user|no-op) (repeatable)")
 	return cmd
 }
 

--- a/internal/cli/eval_render.go
+++ b/internal/cli/eval_render.go
@@ -92,6 +92,14 @@ func renderEvalSetsDashboard(summaries []eval.SetSummary) string {
 // table, so every row shows the same kind of identity: full "owner/name" when
 // they all fit, otherwise the short repository name (the convention the stats
 // dashboard already uses) rather than a name cut mid-word.
+//
+// The table has two variable axes, and both have to fit. Sizing only the
+// repository column is not enough: a finding type carrying a non-canonical
+// severity or action can make the fixed strata wider than the room the box
+// has, at which point the repository column hits minCompositionRepoWidth and
+// has nothing left to give. The strata are then shortened to the space that
+// actually remains, so the composed line always fits the box content width and
+// the box renderer never silently cuts the finding type off the end of a row.
 func compositionLines(rows []eval.CompositionRow) []string {
 	widest := 0
 	for _, row := range rows {
@@ -110,10 +118,17 @@ func compositionLines(rows []eval.CompositionRow) []string {
 			column = width
 		}
 	}
+	// Measured against the column the names actually occupy, not the budget
+	// they were offered, so a table of short names keeps its strata intact.
+	strataWidth := evalCompositionWidth - column - lipgloss.Width(compositionSeparator)
+	if strataWidth < 1 {
+		strataWidth = 1
+	}
 	lines := make([]string, 0, len(rows))
 	for i, row := range rows {
 		padded := names[i] + strings.Repeat(" ", column-lipgloss.Width(names[i]))
-		lines = append(lines, fmt.Sprintf("  %4d  %s", row.Cases, padded+compositionSeparator+compositionStrata(row)))
+		strata := truncateStatsLine(compositionStrata(row), strataWidth)
+		lines = append(lines, fmt.Sprintf("  %4d  %s", row.Cases, padded+compositionSeparator+strata))
 	}
 	return lines
 }

--- a/internal/cli/eval_render.go
+++ b/internal/cli/eval_render.go
@@ -15,13 +15,11 @@ import (
 // lines, progress bars) but are wider: composition strata and warnings carry
 // more text than the stats counters do.
 const (
-	evalBoxWidth = 79
-	evalBarWidth = 20
-	// evalCompositionWidth is the room one stratum line has for its repository
-	// and strata columns: the box content minus the "  NNNN  " count prefix.
-	evalCompositionWidth    = evalBoxWidth - 4 - 8
-	minCompositionRepoWidth = 8
-	compositionSeparator    = " · "
+	evalBoxWidth                = 79
+	evalBarWidth                = 20
+	evalCompositionContentWidth = evalBoxWidth - 4
+	minCompositionRepoWidth     = 8
+	compositionSeparator        = " · "
 )
 
 // renderEvalSetsDashboard renders `eval sets` with the diversified holdout as
@@ -93,21 +91,26 @@ func renderEvalSetsDashboard(summaries []eval.SetSummary) string {
 // they all fit, otherwise the short repository name (the convention the stats
 // dashboard already uses) rather than a name cut mid-word.
 //
-// The table has two variable axes, and both have to fit. Sizing only the
+// The table has three variable axes, and all have to fit. Sizing only the
 // repository column is not enough: a finding type carrying a non-canonical
 // severity or action can make the fixed strata wider than the room the box
-// has, at which point the repository column hits minCompositionRepoWidth and
-// has nothing left to give. The strata are then shortened to the space that
-// actually remains, so the composed line always fits the box content width and
-// the box renderer never silently cuts the finding type off the end of a row.
+// has, and large case counts can expand their prefix. The strata are shortened
+// to the space that actually remains, so the composed line always fits the box
+// content width and the box renderer never silently cuts the finding type off
+// the end of a row.
 func compositionLines(rows []eval.CompositionRow) []string {
 	widest := 0
+	countPrefixWidth := 0
 	for _, row := range rows {
 		if width := lipgloss.Width(compositionStrata(row)); width > widest {
 			widest = width
 		}
+		if width := lipgloss.Width(fmt.Sprintf("  %4d  ", row.Cases)); width > countPrefixWidth {
+			countPrefixWidth = width
+		}
 	}
-	repoWidth := evalCompositionWidth - widest - lipgloss.Width(compositionSeparator)
+	compositionWidth := evalCompositionContentWidth - countPrefixWidth
+	repoWidth := compositionWidth - widest - lipgloss.Width(compositionSeparator)
 	if repoWidth < minCompositionRepoWidth {
 		repoWidth = minCompositionRepoWidth
 	}
@@ -120,7 +123,7 @@ func compositionLines(rows []eval.CompositionRow) []string {
 	}
 	// Measured against the column the names actually occupy, not the budget
 	// they were offered, so a table of short names keeps its strata intact.
-	strataWidth := evalCompositionWidth - column - lipgloss.Width(compositionSeparator)
+	strataWidth := compositionWidth - column - lipgloss.Width(compositionSeparator)
 	if strataWidth < 1 {
 		strataWidth = 1
 	}

--- a/internal/cli/eval_test.go
+++ b/internal/cli/eval_test.go
@@ -463,6 +463,22 @@ func TestEvalCompositionFitsTheBoxWhenTheStrataAreOversized(t *testing.T) {
 	}
 }
 
+func TestEvalCompositionFitsTheBoxWhenCaseCountsExpand(t *testing.T) {
+	rows := []eval.CompositionRow{
+		{Repo: "owner/abcdefghijklmnopqrstuvwxyz", Language: "go", Size: "large", Severity: "warning", FindingType: "warning/auto-fix", Cases: 9999},
+		{Repo: "owner/zyxwvutsrqponmlkjihgfedcba", Language: "go", Size: "large", Severity: "warning", FindingType: "warning/auto-fix", Cases: 10000},
+	}
+	box := renderTitledBox(" eval case sets ", evalBoxWidth, compositionLines(rows))
+	for _, line := range strings.Split(box, "\n") {
+		if width := lipgloss.Width(line); width != evalBoxWidth {
+			t.Fatalf("rendered box line %q is %d wide, want exactly %d", line, width, evalBoxWidth)
+		}
+	}
+	if got := strings.Count(box, "warning/auto-fix"); got != len(rows) {
+		t.Fatalf("rendered box contains %d complete finding types, want %d:\n%s", got, len(rows), box)
+	}
+}
+
 // nmHomeTree lists every path under root, relative and sorted, so a test can
 // assert that a command left the app root's shape untouched.
 func nmHomeTree(t *testing.T, root string) []string {

--- a/internal/cli/eval_test.go
+++ b/internal/cli/eval_test.go
@@ -2,9 +2,12 @@ package cli
 
 import (
 	"context"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
+	"sort"
 	"strings"
 	"testing"
 
@@ -136,8 +139,10 @@ func TestEvalMissIngestLabelsFalseNegativeGold(t *testing.T) {
 
 // Every read-or-converging eval subcommand must be idempotent at the CLI: the
 // second identical invocation prints the same output and leaves the same
-// state. (eval run is additive by design and is covered separately; eval miss
-// ingest's duplicate no-op is covered above.)
+// state. Both halves are asserted - stdout equality alone let a command that
+// created a new file under the app root pass as idempotent. (eval run is
+// additive by design and is covered separately; eval miss ingest's duplicate
+// no-op is covered above.)
 func TestEvalCaptureSetsReportAndRelabelAreIdempotentAtTheCLI(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()
@@ -166,12 +171,16 @@ func TestEvalCaptureSetsReportAndRelabelAreIdempotentAtTheCLI(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v (first): %v\n%s", command, err, first)
 		}
+		treeBefore := nmHomeTree(t, root)
 		second, err := executeCmd(command...)
 		if err != nil {
 			t.Fatalf("%v (second): %v\n%s", command, err, second)
 		}
 		if first != second {
 			t.Fatalf("%v is not idempotent:\nfirst: %s\nsecond: %s", command, first, second)
+		}
+		if treeAfter := nmHomeTree(t, root); !slices.Equal(treeBefore, treeAfter) {
+			t.Fatalf("%v changed the app root's shape:\nbefore: %v\nafter:  %v", command, treeBefore, treeAfter)
 		}
 	}
 }
@@ -413,5 +422,137 @@ func TestEvalCompositionRepoColumnIsUniformAndFitsTheBox(t *testing.T) {
 	}
 	if got := compositionLines(nil); len(got) != 0 {
 		t.Fatalf("compositionLines(nil) = %q, want no lines", got)
+	}
+}
+
+// The composition table must fit the dashboard box on BOTH of its variable
+// axes. The repository column is only one of them: the strata are the other,
+// and a finding type carrying a non-canonical severity or action can push the
+// fixed strata past the room the box has, at which point clamping the
+// repository column to its minimum is not enough and the box renderer silently
+// cuts the finding type off the end of the row.
+func TestEvalCompositionFitsTheBoxWhenTheStrataAreOversized(t *testing.T) {
+	rows := []eval.CompositionRow{
+		{Repo: "kunchenguid/no-mistakes", Language: "javascript", Size: "medium", Severity: "warning", FindingType: "blocking-correctness-defect/requires-human-review", Cases: 3},
+		{Repo: "another-organization/service", Language: "typescript", Size: "large", Severity: "error", FindingType: "error/ask-user", Cases: 1},
+	}
+	lines := compositionLines(rows)
+	if len(lines) != len(rows) {
+		t.Fatalf("compositionLines returned %d line(s), want %d", len(lines), len(rows))
+	}
+	for _, line := range lines {
+		if width := lipgloss.Width(line); width > evalBoxWidth-4 {
+			t.Fatalf("composition line %q is %d wide, want at most %d", line, width, evalBoxWidth-4)
+		}
+	}
+
+	// The rendered box is the surface the reader sees: nothing may be cut off
+	// there either, and every row must still start with its case count and
+	// repository identity.
+	box := renderTitledBox(" eval case sets ", evalBoxWidth, lines)
+	for _, line := range strings.Split(box, "\n") {
+		if width := lipgloss.Width(line); width != evalBoxWidth {
+			t.Fatalf("rendered box line %q is %d wide, want exactly %d", line, width, evalBoxWidth)
+		}
+	}
+	if !strings.Contains(lines[0], "no-mista") || !strings.Contains(lines[1], "service") {
+		t.Fatalf("lines = %q, want every row to keep a repository identity", lines)
+	}
+	if !strings.Contains(lines[0], "javascript") || !strings.Contains(lines[1], "typescript") {
+		t.Fatalf("lines = %q, want the leading strata preserved when the trailing ones are shortened", lines)
+	}
+}
+
+// nmHomeTree lists every path under root, relative and sorted, so a test can
+// assert that a command left the app root's shape untouched.
+func nmHomeTree(t *testing.T, root string) []string {
+	t.Helper()
+	var out []string
+	if err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		if rel != "." {
+			out = append(out, filepath.ToSlash(rel))
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// The eval dashboards are display surfaces over the local corpus: they resolve
+// repository names from the pipeline database only if one already exists, and
+// must never bring that database into being. db.Open creates the file and runs
+// every migration, so a display-only lookup routed through it turned `eval
+// sets`, `eval report`, and `eval run` into commands that initialize pipeline
+// state on a machine that has none.
+func TestEvalDisplayCommandsDoNotCreateThePipelineDatabase(t *testing.T) {
+	tests := []struct {
+		command []string
+		// eval run legitimately refuses an empty case set; the filesystem
+		// effect under test is the same either way.
+		allowError bool
+	}{
+		{command: []string{"eval", "sets"}},
+		{command: []string{"eval", "report"}},
+		{command: []string{"eval", "run", "--cases", "labeled", "--candidate", "claude+test", "--repeats", "1"}, allowError: true},
+	}
+	for _, tt := range tests {
+		command := tt.command
+		t.Run(strings.Join(command, "-"), func(t *testing.T) {
+			root := t.TempDir()
+			t.Setenv("NM_HOME", root)
+			chdir(t, t.TempDir())
+
+			out, err := executeCmd(command...)
+			if err != nil && !tt.allowError {
+				t.Fatalf("%v: %v\n%s", command, err, out)
+			}
+
+			p, err := paths.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, suffix := range []string{"", "-wal", "-shm"} {
+				if _, statErr := os.Stat(p.DB() + suffix); !os.IsNotExist(statErr) {
+					t.Fatalf("%v created pipeline database file %q (stat err %v); a display-only repository-name lookup must not create or migrate pipeline state",
+						command, p.DB()+suffix, statErr)
+				}
+			}
+		})
+	}
+}
+
+// A pre-existing pipeline database still resolves repository names: opening it
+// read-only removes the side effect, not the feature.
+func TestEvalSetsStillNamesRepositoriesFromAnExistingDatabase(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	t.Setenv("NM_HOME", root)
+	chdir(t, t.TempDir())
+
+	findings := `{"findings":[{"id":"real-bug","severity":"error","file":"main.go","line":3,"description":"bug","action":"ask-user","review_scope":"source"}],"risk_level":"high","risk_rationale":"bug","risk_scope":"source-or-external"}`
+	fixture := setupEvalCLIFixture(t, ctx, root, findings)
+	selected := `["real-bug"]`
+	if err := fixture.db.SetStepRoundSelection(fixture.round.ID, &selected, db.RoundSelectionSourceUser); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := executeCmd("eval", "capture", fixture.run.ID); err != nil {
+		t.Fatalf("eval capture: %v\n%s", err, out)
+	}
+
+	out, err := executeCmd("eval", "sets")
+	if err != nil {
+		t.Fatalf("eval sets: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "org/repo") {
+		t.Fatalf("sets output = %q, want the repository name resolved from the existing pipeline database", out)
 	}
 }

--- a/internal/eval/miss.go
+++ b/internal/eval/miss.go
@@ -29,6 +29,15 @@ type IngestResult struct {
 // required; they are the eval matcher keys. This is the typed source of truth
 // for a confirmed post-PR miss. no-mistakes does not read firstmate ledgers
 // or scrape GitHub review comments.
+//
+// Severity and action are checked against the finding vocabulary that
+// internal/types owns. A hand-written miss is the one place a finding's
+// severity reaches the corpus without passing through a pipeline agent, and
+// that severity becomes gold and then a composition stratum on the dashboards,
+// so free text here would surface as an invented finding type. Action is
+// validated and then deliberately dropped: gold carries no action, and
+// silently ignoring a value the caller believed was meaningful is worse than
+// refusing one that is not part of the vocabulary.
 func ParsePostPRMissFinding(raw string) (FindingGold, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -43,9 +52,17 @@ func ParsePostPRMissFinding(raw string) (FindingGold, error) {
 	if id == "" || description == "" {
 		return FindingGold{}, fmt.Errorf("finding requires id and description")
 	}
-	severity := strings.TrimSpace(finding.Severity)
+	severity := types.NormalizeFindingSeverity(finding.Severity)
 	if severity == "" {
-		severity = "error"
+		severity = types.FindingSeverityError
+	}
+	if !types.IsKnownFindingSeverity(severity) {
+		return FindingGold{}, fmt.Errorf("finding severity %q is not one of: %s",
+			strings.TrimSpace(finding.Severity), strings.Join(types.KnownFindingSeverities(), ", "))
+	}
+	if action := types.NormalizeFindingAction(finding.Action); action != "" && !types.IsKnownFindingAction(action) {
+		return FindingGold{}, fmt.Errorf("finding action %q is not one of: %s",
+			strings.TrimSpace(finding.Action), strings.Join(types.KnownFindingActions(), ", "))
 	}
 	return FindingGold{
 		ID:          id,

--- a/internal/eval/miss_test.go
+++ b/internal/eval/miss_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/kunchenguid/no-mistakes/internal/types"
@@ -187,5 +189,51 @@ func TestParsePostPRMissFindingRequiresIDAndDescription(t *testing.T) {
 	raw, _ := json.Marshal(got)
 	if got.Kind != GoldFalseNegative || got.Source != goldSourcePostPRMiss || got.ID != "fn-1" {
 		t.Fatalf("parsed = %s", raw)
+	}
+}
+
+// An ingested miss's severity becomes gold and then a composition stratum, so
+// free text reaches the dashboards. Accept only the review vocabulary, and
+// reject an action the caller believes is meaningful rather than dropping an
+// unrecognized one silently.
+func TestParsePostPRMissFindingValidatesSeverityAndAction(t *testing.T) {
+	for _, severity := range []string{"error", "warning", "info", "  Warning  "} {
+		raw := `{"id":"fn-1","description":"a miss","severity":` + strconv.Quote(severity) + `}`
+		got, err := ParsePostPRMissFinding(raw)
+		if err != nil {
+			t.Fatalf("severity %q: %v", severity, err)
+		}
+		if got.Severity != strings.ToLower(strings.TrimSpace(severity)) {
+			t.Fatalf("severity %q parsed to %q, want the normalized vocabulary value", severity, got.Severity)
+		}
+	}
+
+	for _, raw := range []string{
+		`{"id":"fn-1","description":"a miss","severity":"blocking-correctness-defect"}`,
+		`{"id":"fn-1","description":"a miss","severity":"none"}`,
+		`{"id":"fn-1","description":"a miss","severity":"P1"}`,
+	} {
+		if _, err := ParsePostPRMissFinding(raw); err == nil {
+			t.Fatalf("%s: expected an error for a severity outside the review vocabulary", raw)
+		}
+	}
+
+	for _, action := range []string{"auto-fix", "ask-user", "no-op"} {
+		raw := `{"id":"fn-1","description":"a miss","action":` + strconv.Quote(action) + `}`
+		if _, err := ParsePostPRMissFinding(raw); err != nil {
+			t.Fatalf("action %q: %v", action, err)
+		}
+	}
+	if _, err := ParsePostPRMissFinding(`{"id":"fn-1","description":"a miss","action":"requires-human-review"}`); err == nil {
+		t.Fatal("expected an error for an action outside the finding vocabulary")
+	}
+
+	// A blank severity still defaults, and a blank action stays absent.
+	got, err := ParsePostPRMissFinding(`{"id":"fn-1","description":"a miss"}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Severity != "error" || got.Action != "" {
+		t.Fatalf("parsed = %+v, want the default error severity and no action", got)
 	}
 }

--- a/internal/types/findings.go
+++ b/internal/types/findings.go
@@ -3,6 +3,7 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -12,6 +13,56 @@ const (
 	ActionAutoFix = "auto-fix"
 	ActionAskUser = "ask-user"
 )
+
+// Finding severity constants: the vocabulary the review prompt instructs
+// agents to use, ordered most to least severe.
+const (
+	FindingSeverityError   = "error"
+	FindingSeverityWarning = "warning"
+	FindingSeverityInfo    = "info"
+)
+
+// This package owns the finding severity and action vocabularies. Callers that
+// accept a severity or action from outside a pipeline agent - a hand-written
+// eval miss, an IPC payload - validate against these rather than keeping their
+// own copy of the list.
+var (
+	knownFindingSeverities = []string{FindingSeverityError, FindingSeverityWarning, FindingSeverityInfo}
+	knownFindingActions    = []string{ActionAutoFix, ActionAskUser, ActionNoOp}
+)
+
+// NormalizeFindingSeverity trims and lower-cases one severity so equivalent
+// spellings compare equal. It does not check membership; see
+// IsKnownFindingSeverity.
+func NormalizeFindingSeverity(severity string) string {
+	return strings.ToLower(strings.TrimSpace(severity))
+}
+
+// NormalizeFindingAction trims and lower-cases one action. It does not check
+// membership; see IsKnownFindingAction.
+func NormalizeFindingAction(action string) string {
+	return strings.ToLower(strings.TrimSpace(action))
+}
+
+// IsKnownFindingSeverity reports whether severity, once normalized, is part of
+// the review severity vocabulary.
+func IsKnownFindingSeverity(severity string) bool {
+	return slices.Contains(knownFindingSeverities, NormalizeFindingSeverity(severity))
+}
+
+// IsKnownFindingAction reports whether action, once normalized, is part of the
+// finding action vocabulary.
+func IsKnownFindingAction(action string) bool {
+	return slices.Contains(knownFindingActions, NormalizeFindingAction(action))
+}
+
+// KnownFindingSeverities returns the severity vocabulary, for error messages
+// that have to name what they accept.
+func KnownFindingSeverities() []string { return slices.Clone(knownFindingSeverities) }
+
+// KnownFindingActions returns the action vocabulary, for error messages that
+// have to name what they accept.
+func KnownFindingActions() []string { return slices.Clone(knownFindingActions) }
 
 // Finding source constants. An empty Source is treated as agent-produced.
 const (


### PR DESCRIPTION
## Intent

Fix the two real defects that no-mistakes' own review passed green on PR #784, both confirmed by Greptile and independently reproduced in a scout investigation the captain has since approved for ship. Scope is exactly the two fixes plus their regression tests; the broader systemic review-sampling remedies from the investigation are deliberately NOT in scope and remain an open captain decision.

Defect 1 - display-only eval commands mutated pipeline state. evalRepoNames (internal/cli/eval.go) resolved repository fingerprints to names through db.Open, which creates the SQLite database and runs all 57 migration statements. Because openEvalStore is shared by `eval sets`, `eval report`, and `eval run`, those three read-only display surfaces created <NM_HOME>/state.sqlite on a machine that had none, and applied ALTER TABLE migrations to a database a running daemon owns. Reproduced end to end: a fresh NM_HOME gained an 86KB state.sqlite with all 8 pipeline tables in WAL mode, and after deliberately dropping two migrated columns a single `eval sets` re-added them. Verified new in PR #784 by building the pre-PR commit f41b730, where the same command creates nothing. Fix: use db.OpenReadOnly, which exists in internal/db/db.go documented for exactly this case ("even schema repair would be an unacceptable side effect"); a missing database is the ordinary case and still falls back to rendering fingerprints, so the existing best-effort nil-map fallback already handles it.

Defect 2 - the composition table could be clipped. compositionLines (internal/cli/eval_render.go) sized only the repository column, clamping it to minCompositionRepoWidth (8). Once the fixed strata grew wider than 56 columns the clamp fired, the composed line exceeded the 75-column box content width, and renderTitledBox truncated from the right, cutting the finding type off the end of the row. Reproduced with a unit test at 80 columns vs a 75-column budget. Fix: shorten the strata to the space that actually remains. Design decision: the remaining space is measured against the column the fitted repository names actually occupy, not the width they were offered, so a table of short names reclaims the leftover and keeps its strata fully intact - only a genuinely oversized table loses anything. The hard cut (truncateStatsLine) is deliberate rather than an ellipsis, to stay consistent with how fitRepoNames already shortens repository names in the same table.

Why the input validation is part of this change: with canonical values the strata top out at 48 columns, so defect 2 is unreachable through the pipeline's own output. The one reachable source is `eval miss ingest --finding`, whose severity was accepted as free text and flowed into gold, then into findingType, then into the composition column. So ParsePostPRMissFinding now validates severity against error/warning/info and action against auto-fix/ask-user/no-op. Design decision: action is validated and then still dropped, exactly as before - gold carries no action, and changing that would alter the stratification key of every already-ingested miss and churn the diversified pins - but silently ignoring an action the caller believed was meaningful is worse than refusing one outside the vocabulary. The vocabularies are placed in internal/types, which owns the finding schema, rather than as a private list in internal/eval, so there is one owner; the severity constants are new there because none existed.

Tests were written first and each was confirmed failing for the right reason before the fix. TestEvalDisplayCommandsDoNotCreateThePipelineDatabase runs all three display commands on a fresh NM_HOME and asserts state.sqlite and its -wal/-shm siblings are absent; `eval run` legitimately errors on an empty case set, so that row tolerates the error because the filesystem effect is what is under test. TestEvalSetsStillNamesRepositoriesFromAnExistingDatabase guards that removing the side effect did not remove the feature. TestEvalCompositionFitsTheBoxWhenTheStrataAreOversized varies the STRATA axis, which the pre-existing width test held fixed while varying only repository names, and asserts on the rendered box so the assertion matches what a reader actually sees. TestParsePostPRMissFindingValidatesSeverityAndAction covers the accepted vocabulary, normalization, rejection, and the unchanged blank-severity default.

Also deliberately tightened: TestEvalCaptureSetsReportAndRelabelAreIdempotentAtTheCLI asserted stdout equality only while its comment claimed it also checked state, and every fixture in that file pre-created the pipeline database - which is precisely why the #784 regression escaped a suite that ran double-run idempotency tests on every eval subcommand. It now also asserts the app root's path set is unchanged across the second invocation.

docs/src/content/docs/reference/eval.md is the documentation owner for the eval miss ingest payload contract and was updated for the new validation; the --finding flag help now names the accepted values too. Manually verified with the built binary: a fresh NM_HOME stays free of state.sqlite, repository names still resolve against a real WAL-mode database with a live -wal file, and both invalid severity and invalid action are refused with a message naming the accepted values. gofmt, make lint, and go test -race ./... are all clean.

## What Changed

- Open pipeline state read-only when resolving repository names for eval dashboards, falling back to fingerprints without creating or migrating the database.
- Fit oversized composition strata within the rendered dashboard while reclaiming unused repository-column space.
- Validate and normalize post-PR miss severity and action values against the shared finding vocabulary, with updated CLI help, documentation, and regression coverage.

## Risk Assessment

✅ Low: The changes are well-bounded, satisfy the stated intent, and preserve the required display, validation, and width-budget invariants.

## Testing

Focused race-enabled tests and end-user CLI checks verified all three display commands remain database-side-effect-free, existing repository names still resolve, oversized composition rows fit the rendered box, and miss severity/action validation behaves as documented. All checks passed.

<details>
<summary>Evidence: End-user eval display safety and finding validation transcript</summary>

Source: [End-user eval display safety and finding validation transcript](https://github.com/kunchenguid/no-mistakes/blob/4e25c00c61ca8dad1140cb35ac3f6c517a0ace75/.no-mistakes/evidence/fm/nm-eval784-fn-gap-investigation-s1/eval-display-and-validation.txt)

```text
End-user verification of eval display safety and ingest validation
==============================================================

$ NM_HOME=<fresh> no-mistakes eval sets
╭─ eval case sets ────────────────────────────────────────────────────────────╮
│                                                                             │
│   Diversified holdout (official gold-only set)                              │
│   Cases                0   pins 0 · cap 32                                  │
│   Gold findings        0   across 0 gold case(s)                            │
│                                                                             │
│   Self-score: the recorded reviews scored against their own gold            │
│     unlabeled / pending (no finding-level gold yet)                         │
│                                                                             │
│   Other sets                                                                │
│   all         0 case(s) · 0 gold · 0 unlabeled / pending · 0 queued         │
│   labeled     0 case(s) · 0 gold · 0 unlabeled / pending · 0 queued         │
│   tune        0 case(s) · 0 gold · 0 unlabeled / pending · 0 queued         │
│                                                                             │
│   ⚠ diversified is empty: no labeled gold (unlabeled cases are not filled)  │
│                                                                             │
│   local-only: cases, gold, and scores never leave this machine              │
│                                                                             │
╰─────────────────────────────────────────────────────────────────────────────╯
pipeline database files after eval sets: NONE

$ NM_HOME=<fresh> no-mistakes eval report
LOCAL-ONLY EVAL REPORT
no candidate replays recorded yet
pipeline database files after eval report: NONE

$ NM_HOME=<fresh> no-mistakes eval run --cases labeled --candidate claude+test --repeats 1
local eval session : 0 replay(s), candidate claude+test, repeats 1
case set "labeled" is empty
exit status: 1
pipeline database files after eval run: NONE

$ NM_HOME=<fresh> no-mistakes eval miss ingest demo-run --finding {"id":"fn-1","description":"miss","severity":"blocking"}
finding severity "blocking" is not one of: error, warning, info
exit status: 1

$ NM_HOME=<fresh> no-mistakes eval miss ingest demo-run --finding {"id":"fn-1","description":"miss","action":"requires-human-review"}
finding action "requires-human-review" is not one of: auto-fix, ask-user, no-op
exit status: 1

$ no-mistakes eval miss ingest --help (finding contract excerpt)
Reads confirmed post-PR misses from --finding JSON (repeatable), not from GitHub comments or an external ledger. Captures the named run if needed, then writes false-negative gold onto the last completed non-blocking review pass.
  no-mistakes eval miss ingest <run> --finding <json> [flags]
      --finding stringArray   confirmed miss as JSON finding object with id and description, optional file, line, severity (error|warning|info, default error) and action (auto-fix|ask-user|no-op) (repeatable)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"610bb0798065b518db4f1af11d07b7b3e436373a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `internal/cli/eval_render.go:123` - The width budget still assumes the case-count prefix is exactly 8 columns, but `%4d` expands for 10,000+ cases. This is reachable because `eval.max_cases: 0` permits an unlimited corpus and protected cases may exceed the configured target. A 5-digit `row.Cases` makes the composed line exceed the box by one column, so `renderTitledBox` again clips the finding type. Include the widest formatted case count in the shared column budget before truncating strata.

🔧 Fix: Handle expanding eval composition case counts
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race ./internal/cli -run 'TestEval(DisplayCommandsDoNotCreateThePipelineDatabase|SetsStillNamesRepositoriesFromAnExistingDatabase|CompositionFitsTheBoxWhenTheStrataAreOversized|CompositionFitsTheBoxWhenCaseCountsExpand|CaptureSetsReportAndRelabelAreIdempotentAtTheCLI)$'`
- `go test -race ./internal/eval -run 'TestParsePostPRMissFinding(RequiresIDAndDescription|ValidatesSeverityAndAction)$'`
- `go test -race ./internal/types -run 'Test.*Finding'`
- <code>Built `./cmd/no-mistakes` and ran `eval sets`, `eval report`, and `eval run` against a fresh `NM_HOME`, confirming no `state.sqlite`, WAL, or SHM files appeared.</code>
- <code>Ran the built CLI with invalid `eval miss ingest --finding` severity and action values, confirming user-facing errors list the accepted vocabularies and help documents the contract.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
