### PR TITLE
feat(scm): add Gitea as a fifth SCM provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ Safest local verification sequence after non-trivial changes:
 - `tea pulls create` has no `--output json` flag and echoes the PR body into its human-readable stdout, so a body containing an `http(s)://` URL can defeat a naive "first URL line" scrape. `CreatePR` re-lists the PR by head branch via `tea pulls list` for a structured result instead of parsing create's own output; scraping stdout is only a last-resort fallback.
 - tea infers "which Gitea instance" from the current directory's git remote, which the daemon's detached bare-gate repo never has, so every invocation carries `--login <name>` explicitly. The login name is resolved from tea's own `config.yml` by host (`scm.ResolveGiteaLogin`), mirroring `glabKnowsHost`/`ghKnowsHost` for detection.
 - `Capabilities().MergeableState` is declined (matching Bitbucket): Gitea's PR `mergeable` field has a documented upstream bug (go-gitea/gitea#25849) that can stick `false` after a conflict is actually resolved.
+- `tea actions runs list`'s array order is not documented as newest-first, and a branch can have more than one run sharing the same head SHA (e.g. a manual UI re-run), so `GetChecks`/`FetchFailedCheckLogs` select the run via `mostRecentRun` (highest numeric run ID) rather than trusting list order or index `[0]`.
 - The comments in `internal/scm/gitea/gitea.go` own the full rationale for each trap.
 
 **Documentation**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,16 @@ Safest local verification sequence after non-trivial changes:
 - The backend is pinned against `glab v1.5x`, whose flag surface drifts between versions: the auth check must be host-scoped (`--hostname <host>`, falling back to unscoped only when the host is unknown), `glab mr list` no longer accepts `--state opened`, and the daemon's detached-HEAD worktree breaks `glab ci get`, so pipeline jobs are read via the branch-independent `glab api .../pipelines/<id>/jobs` REST endpoint.
 - The comments in `internal/scm/gitlab/gitlab.go` own the full rationale for each trap; extend them there when you hit new glab version drift.
 
+**Gitea Backend (`internal/scm/gitea`)**
+
+- Verified empirically against a real `tea 0.15.1` CLI and a real Gitea 1.27.2 + Actions instance (Docker/Podman `gitea/gitea` + `gitea/act_runner`), not guessed from docs. `tea whoami` has no `--login` flag (unlike every other tea entity subcommand), so `Host.Available` scopes its check through `tea api --login <name> /user` instead - the same host-scoping purpose as glab's `--hostname`.
+- `tea actions runs view --jobs --output json` does NOT emit clean structured JSON: `--output json` renders the run header as plain text and only the trailing jobs array is real JSON, and that array carries `status` (queued/in_progress/completed) but no `conclusion` (success/failure/...) at the job level. Job-level pass/fail is read from the REST endpoint (`GET /repos/{owner}/{repo}/actions/runs/{run}/jobs`, which does carry `status` + `conclusion`) reached through `tea api`, which reuses tea's own stored login/token - no separate HTTP client or credential needed.
+- `tea pulls list --output json` renders every field (including `index` and `mergeable`) as a JSON *string*, while `tea pulls <idx> --output json` (single-PR view) renders the same fields with native JSON types (`index` an int, `mergeable`/`hasMerged` bools). The two response shapes are genuinely different structs in `gitea.go`; do not unify them.
+- `tea pulls create` has no `--output json` flag and echoes the PR body into its human-readable stdout, so a body containing an `http(s)://` URL can defeat a naive "first URL line" scrape. `CreatePR` re-lists the PR by head branch via `tea pulls list` for a structured result instead of parsing create's own output; scraping stdout is only a last-resort fallback.
+- tea infers "which Gitea instance" from the current directory's git remote, which the daemon's detached bare-gate repo never has, so every invocation carries `--login <name>` explicitly. The login name is resolved from tea's own `config.yml` by host (`scm.ResolveGiteaLogin`), mirroring `glabKnowsHost`/`ghKnowsHost` for detection.
+- `Capabilities().MergeableState` is declined (matching Bitbucket): Gitea's PR `mergeable` field has a documented upstream bug (go-gitea/gitea#25849) that can stick `false` after a conflict is actually resolved.
+- The comments in `internal/scm/gitea/gitea.go` own the full rationale for each trap.
+
 **Documentation**
 
 - Keep `README.md` concise and high-level; the bar needs to be extremely high for what shows up there.

--- a/cmd/fakeagent/main.go
+++ b/cmd/fakeagent/main.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -49,6 +50,8 @@ func run(argv []string) int {
 		return runOpencode(args, scenario)
 	case "gh":
 		return runGhStub(args)
+	case "tea":
+		return runTeaStub(args)
 	default:
 		fmt.Fprintf(os.Stderr, "fakeagent: invoked under unknown name %q (argv[0]=%q)\n", name, argv[0])
 		return 2
@@ -146,6 +149,88 @@ func recordGhStubInvocation(args []string) {
 	if hasArgValue(args, "--body-file", "-") {
 		body, _ := io.ReadAll(os.Stdin)
 		inv.Body = string(body)
+	}
+	_ = json.NewEncoder(f).Encode(inv)
+}
+
+// runTeaStub shadows any system-installed tea during the Gitea provider e2e
+// journey. It is a stateless canned-response stub, mirroring
+// runGhForkPRStub: `pulls list` always reports no existing PR (so the PR
+// step exercises CreatePR), `pulls create` fabricates a plausible PR URL
+// from its own human-readable output (real tea has no --output json on
+// create; the pipeline's CreatePR falls back to scanning that output because
+// this stub's stateless `pulls list` can never re-find the PR it just
+// created), and `pulls <idx>` (view) reports the PR as already merged so the
+// CI step's GetPRState short-circuits on the first poll without needing to
+// model Gitea Actions runs at all.
+func runTeaStub(args []string) int {
+	recordTeaStubInvocation(args)
+
+	if len(args) >= 1 && args[0] == "api" && args[len(args)-1] == "/user" {
+		fmt.Println(`{"login":"e2e-tea-user"}`)
+		return 0
+	}
+	if len(args) >= 2 && args[0] == "pulls" && args[1] == "list" {
+		fmt.Println("[]")
+		return 0
+	}
+	if len(args) >= 2 && args[0] == "pulls" && args[1] == "create" {
+		repo := argAfter(args, "--repo")
+		if repo == "" {
+			repo = "owner/repo"
+		}
+		host := os.Getenv("FAKEAGENT_TEA_HOST")
+		if host == "" {
+			host = "gitea.example.com"
+		}
+		fmt.Printf("  # #99 stub PR (open)\n\n  http://%s/%s/pulls/99\n", host, strings.TrimSuffix(repo, ".git"))
+		return 0
+	}
+	if len(args) >= 2 && args[0] == "pulls" && args[1] == "edit" {
+		fmt.Println("updated")
+		return 0
+	}
+	if len(args) >= 2 && args[0] == "pulls" {
+		// `tea pulls <idx> --output json` (view a single PR by index). Merged
+		// on the first poll so the CI step's GetPRState exits without needing
+		// to model Gitea Actions runs.
+		if _, err := strconv.Atoi(args[1]); err == nil {
+			fmt.Println(`{"index":99,"state":"closed","hasMerged":true,"head":"","base":"main"}`)
+			return 0
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "fakeagent tea: subcommand not implemented in e2e stub: %v\n", args)
+	return 1
+}
+
+type teaStubInvocation struct {
+	Time  string   `json:"time"`
+	Args  []string `json:"args"`
+	Repo  string   `json:"repo,omitempty"`
+	Login string   `json:"login,omitempty"`
+	Head  string   `json:"head,omitempty"`
+	Base  string   `json:"base,omitempty"`
+}
+
+func recordTeaStubInvocation(args []string) {
+	logPath := os.Getenv("FAKEAGENT_TEA_LOG")
+	if logPath == "" {
+		return
+	}
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	inv := teaStubInvocation{
+		Time:  time.Now().Format(time.RFC3339Nano),
+		Args:  append([]string(nil), args...),
+		Repo:  argAfter(args, "--repo"),
+		Login: argAfter(args, "--login"),
+		Head:  argAfter(args, "--head"),
+		Base:  argAfter(args, "--base"),
 	}
 	_ = json.NewEncoder(f).Encode(inv)
 }

--- a/docs/src/content/docs/guides/provider-integration.md
+++ b/docs/src/content/docs/guides/provider-integration.md
@@ -1,12 +1,13 @@
 ---
 title: Provider Integration
-description: Set up GitHub, GitLab, Forgejo, Bitbucket Cloud, or Azure DevOps for PR creation and CI monitoring.
+description: Set up GitHub, GitLab, Forgejo, Bitbucket Cloud, Azure DevOps, or Gitea for PR creation and CI monitoring.
 ---
 
-The PR and CI steps need to talk to your git host. Five hosts are supported:
-GitHub, GitLab, Forgejo, Bitbucket Cloud (`bitbucket.org`), and Azure DevOps
-(`dev.azure.com` and legacy `*.visualstudio.com`). Everything else
-short-circuits the PR and CI steps with `skipped`.
+The PR and CI steps need to talk to your git host. Six hosts are supported:
+GitHub, GitLab, Forgejo, Bitbucket Cloud (`bitbucket.org`), Azure DevOps
+(`dev.azure.com` and legacy `*.visualstudio.com`), and Gitea (almost always
+self-hosted). Everything else short-circuits the PR and CI steps with
+`skipped`.
 
 Provider integration is optional for the local gate. You only need it for the
 steps that happen after validation: opening or updating the PR, watching hosted
@@ -25,14 +26,14 @@ What you do not get is PR automation and CI monitoring.
 
 ## What each step needs
 
-| Step | GitHub | GitLab | Forgejo | Bitbucket Cloud | Azure DevOps |
-| --- | --- | --- | --- | --- | --- |
-| **PR** (create/update) | `gh` CLI, authenticated | `glab` CLI, authenticated | `forgejo-axi`, authenticated | `NO_MISTAKES_BITBUCKET_EMAIL` + `NO_MISTAKES_BITBUCKET_API_TOKEN` | `az` CLI + `azure-devops` extension, authenticated |
-| **CI** (polling, auto-fix) | `gh` CLI | `glab` CLI | `forgejo-axi` | same env vars | `az` CLI |
-| **Merge conflict auto-fix** | `gh` CLI | `glab` CLI | `forgejo-axi` | not supported | `az` CLI |
-| **Mergeability polling** | `gh` CLI | `glab` CLI | `forgejo-axi` | not supported | `az` CLI |
-| **Failed check log fetching** | `gh` CLI | `glab` CLI | `forgejo-axi` when runtime routes are available | supported | not yet |
-| **[Cancelled-check rerun](/no-mistakes/reference/repo-config/#cirerun_transient)** | `gh` CLI | not supported | not supported | not supported | not supported |
+| Step | GitHub | GitLab | Forgejo | Bitbucket Cloud | Azure DevOps | Gitea |
+| --- | --- | --- | --- | --- | --- | --- |
+| **PR** (create/update) | `gh` CLI, authenticated | `glab` CLI, authenticated | `forgejo-axi`, authenticated | `NO_MISTAKES_BITBUCKET_EMAIL` + `NO_MISTAKES_BITBUCKET_API_TOKEN` | `az` CLI + `azure-devops` extension, authenticated | `tea` CLI, authenticated |
+| **CI** (polling, auto-fix) | `gh` CLI | `glab` CLI | `forgejo-axi` | same env vars | `az` CLI | `tea` CLI |
+| **Merge conflict auto-fix** | `gh` CLI | `glab` CLI | `forgejo-axi` | not supported | `az` CLI | not supported |
+| **Mergeability polling** | `gh` CLI | `glab` CLI | `forgejo-axi` | not supported | `az` CLI | not supported |
+| **Failed check log fetching** | `gh` CLI | `glab` CLI | `forgejo-axi` when runtime routes are available | supported | not yet | supported |
+| **[Cancelled-check rerun](/no-mistakes/reference/repo-config/#cirerun_transient)** | `gh` CLI | not supported | not supported | not supported | not supported | not supported |
 
 ## What changes when provider wiring is present
 
@@ -203,6 +204,46 @@ well as their SSH forms (`git@ssh.dev.azure.com:v3/...`).
   first-class build-log command)
 - Fork PR routing (same as GitLab, Forgejo, and Bitbucket)
 
+## Gitea
+
+Gitea uses `tea`, its official CLI. Install it and log in with a token:
+
+```sh
+# see https://gitea.com/gitea/tea for install options (Homebrew, packages, or a release binary)
+
+tea logins add --url https://your-gitea.example.com --token your-token --name your-instance
+```
+
+Create a token from **Settings → Applications → Manage Access Tokens** on your Gitea instance, with read/write `repository` and `issue` scopes.
+
+Verify:
+
+```sh
+tea logins list
+```
+
+**What you get:**
+
+- PR creation and update (`tea pulls create`/`edit`)
+- CI status polling through Gitea Actions until the PR is merged or closed, or the configured `ci_timeout` idle window elapses. Job-level pass/fail comes from Gitea's Actions REST API (`GET .../actions/runs/{run}/jobs`), reached through `tea api` (which reuses the same stored login/token, so no separate HTTP client or credential is needed) - `tea`'s own `--output json` on `actions runs view --jobs` reports each job's run/queued/completed status but not its pass/fail conclusion.
+- Failed job log fetching (`tea actions runs logs`) for the CI auto-fix step
+
+**What you don't get (yet):**
+
+- PR mergeability polling and merge-conflict auto-fix. Gitea's PR `mergeable` field has a documented upstream reliability bug ([go-gitea/gitea#25849](https://github.com/go-gitea/gitea/issues/25849)) that can stick `false` after a conflict is actually resolved, so no-mistakes declines the capability rather than trust it - the same posture as Bitbucket Cloud.
+- Fork PR routing (same as GitLab, Bitbucket Cloud, and Azure DevOps)
+- [Cancelled-check rerun](/no-mistakes/reference/repo-config/#cirerun_transient)
+
+Gitea Actions shipped in Gitea 1.19 (2023); older instances have no Actions API to poll. As with any repository with no CI, declare `no_ci: true` on the trusted default branch so the CI step does not wait for checks that will never appear - see the [CI step reference](/no-mistakes/reference/pipeline-steps/#ci).
+
+### Self-hosted Gitea
+
+Nearly every real Gitea instance is self-hosted at an arbitrary hostname with no `gitea` marker in it at all, so detection cannot use a substring match the way `gitlab.com`/`github.com` do. Instead, `no-mistakes` consults `tea`'s own login config (`config.yml`, under `$XDG_CONFIG_HOME/tea` or `~/.config/tea`) and treats the upstream as Gitea if its host matches a configured login's `url` or `ssh_host`.
+
+Running `tea logins add --url https://your-gitea.example.com --token <token> --name <name>` is enough to make detection succeed; if `tea` has no login for the host, detection fails closed and the upstream is treated as unsupported.
+
+Because `tea` infers "which instance" from the current directory's git remote - context the daemon's detached worktree does not have - every `tea` invocation `no-mistakes` makes carries `--login <name>` explicitly, resolved from the matched login's name at request time.
+
 ## Self-hosted GitHub/GitLab
 
 Self-hosted GitHub Enterprise and self-hosted GitLab instances work through the same `gh` and `glab` CLIs. Authenticate the CLI against your instance (`gh auth login --hostname your-ghe.example.com`, `glab auth login --hostname gitlab.example.com`) and `no-mistakes` will route through the CLI as usual.
@@ -233,7 +274,7 @@ If `ssh -G` is unavailable or the alias does not resolve, detection falls back t
 
 ## Unsupported hosts
 
-If your upstream isn't GitHub, GitLab, Forgejo, Bitbucket Cloud, or Azure DevOps:
+If your upstream isn't GitHub, GitLab, Forgejo, Bitbucket Cloud, Azure DevOps, or Gitea:
 
 - The **push** step still runs - `no-mistakes` pushes through git to the configured target like any other remote.
 - The **PR** step marks itself as `skipped`.
@@ -247,7 +288,7 @@ Everything before push (rebase, review, test, document, lint) still works regard
 no-mistakes doctor
 ```
 
-`doctor` checks `gh` and `az` availability. For GitLab, confirm `glab` is installed and authenticated. For Forgejo, run `FORGEJO_BASE_URL=<host> forgejo-axi status --json` from the daemon's environment. For Bitbucket Cloud, confirm the two env vars are set in that environment. For Azure DevOps, confirm the `azure-devops` extension is installed (`az extension show --name azure-devops`) and a PAT is available.
+`doctor` checks `gh` and `az` availability. For GitLab, confirm `glab` is installed and authenticated. For Forgejo, run `FORGEJO_BASE_URL=<host> forgejo-axi status --json` from the daemon's environment. For Bitbucket Cloud, confirm the two env vars are set in that environment. For Azure DevOps, confirm the `azure-devops` extension is installed (`az extension show --name azure-devops`) and a PAT is available. For Gitea, confirm `tea` is installed and has a login configured for your instance (`tea logins list`).
 
 :::note
 When the daemon runs through a managed service (launchd, systemd, Task Scheduler), it reloads environment from your login shell on macOS and Linux so CLI auth and provider token variables are picked up, and it augments `PATH` with common binary directories. If credentials or PATH-derived tools are missing, check `~/.no-mistakes/logs/daemon.log` for a login-shell environment resolution warning. On Windows it reuses the current process environment.

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -227,12 +227,13 @@ Symptom: pipeline completes but the PR step shows `skipped`.
 
 Check the [Provider Integration](/no-mistakes/guides/provider-integration/) requirements. Most common causes:
 
-- `gh`, `glab`, or `forgejo-axi` not installed
+- `gh`, `glab`, `forgejo-axi`, or `tea` not installed
 - The provider CLI reports that it is not authenticated
 - Bitbucket env vars not set in the daemon's environment
 - Upstream is not one of the hosts listed in Provider Integration
 - Self-hosted GitHub Enterprise on a hostname that is not `github.com` isn't detected because `gh` isn't configured for the host; run `gh auth login --hostname your-ghe.example.com` so detection finds it. Once detection succeeds, the availability check is host-scoped (`gh auth status --hostname your-ghe.example.com`), so a stale token on `github.com` or any other configured gh host can no longer falsely mark the GHE repo as unauthenticated.
 - Self-hosted GitLab on a hostname with no `gitlab` marker isn't detected because `glab` isn't configured for the host; run `glab auth login --hostname your-gitlab.example.com` so detection finds it. Once detection succeeds, the availability check is host-scoped (`glab auth status --hostname your-gitlab.example.com`), so a stale token on `gitlab.com` or any other configured glab host can no longer falsely mark the self-hosted repo as unauthenticated.
+- Self-hosted Gitea isn't detected because `tea` has no login configured for the host; run `tea logins add --url https://your-gitea.example.com --token <token> --name <name>` so detection finds it. See [Self-hosted Gitea](/no-mistakes/guides/provider-integration/#self-hosted-gitea).
 - A non-GitHub repo record has a fork URL set; fork MR/PR routing is currently GitHub-only
 - You pushed the PR base branch (PR step always skips there; this is the repository's default branch, or the configured [`pr.base_branch`](/no-mistakes/reference/repo-config/#prbase_branch) when set)
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -441,7 +441,9 @@ The standalone runner rows inspect default binary names; the `cursor` row report
 The [Global Config Reference](/no-mistakes/reference/global-config/) owns ACP gate-validation availability and probing semantics.
 Each validation run performs the authoritative agent resolution again after applying any trusted repository-level override.
 
-`doctor` checks `gh` and `az` availability. [Provider Integration](/no-mistakes/guides/provider-integration/) owns the separate setup checks for GitLab, Forgejo, Bitbucket Cloud, and the Azure DevOps extension and PAT.
+`doctor` checks `gh` and `az` availability. [Provider Integration](/no-mistakes/guides/provider-integration/) owns the separate setup checks for GitLab, Forgejo, Bitbucket Cloud, Gitea, and the Azure DevOps extension and PAT.
+
+`tea` stays docs-only like `glab`, `forgejo-axi`, and Bitbucket's env vars, rather than an active `doctor` check like `gh`/`az`: Gitea is almost always self-hosted, so a bare "`tea` not found" row would be a near-universal, low-value warning for the vast majority of users who have no Gitea instance at all.
 
 ## no-mistakes update
 

--- a/docs/src/content/docs/reference/environment.md
+++ b/docs/src/content/docs/reference/environment.md
@@ -204,7 +204,7 @@ When the upstream hostname is not `github.com`, no-mistakes reads gh's configure
 
 ## `XDG_CONFIG_HOME`
 
-Config directory used to locate glab's `config.yml` for self-hosted GitLab detection and gh's `hosts.yml` for self-hosted GitHub Enterprise detection.
+Config directory used to locate glab's `config.yml` for self-hosted GitLab detection, gh's `hosts.yml` for self-hosted GitHub Enterprise detection, and tea's `config.yml` for Gitea detection.
 
 |         |             |
 | ------- | ----------- |
@@ -213,6 +213,7 @@ Config directory used to locate glab's `config.yml` for self-hosted GitLab detec
 
 When `GLAB_CONFIG_DIR` is unset, no-mistakes looks for glab's configured hosts at `$XDG_CONFIG_HOME/glab-cli/config.yml`, falling back to `~/.config/glab-cli/config.yml` when `XDG_CONFIG_HOME` is unset.
 When `GH_CONFIG_DIR` is unset, no-mistakes looks for gh's configured hosts at `$XDG_CONFIG_HOME/gh/hosts.yml`, falling back to `~/.config/gh/hosts.yml` when `XDG_CONFIG_HOME` is unset.
+tea has no CLI-specific override env var (unlike `GLAB_CONFIG_DIR`/`GH_CONFIG_DIR`); no-mistakes always looks for its configured logins at `$XDG_CONFIG_HOME/tea/config.yml`, falling back to `~/.config/tea/config.yml` when `XDG_CONFIG_HOME` is unset. See [Provider Integration](/no-mistakes/guides/provider-integration/#self-hosted-gitea).
 
 ## `NO_MISTAKES_UMAMI_HOST`
 

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -213,9 +213,9 @@ Creates or updates a pull request.
 
 **Skipped when:**
 - The branch is the [PR base branch](/no-mistakes/reference/repo-config/#prbase_branch) (the repository's forge default branch, or the trusted `pr.base_branch` when configured)
-- The upstream host is not GitHub, GitLab, Forgejo, Bitbucket Cloud (`bitbucket.org`), or Azure DevOps (`dev.azure.com` / `*.visualstudio.com`)
-- The provider CLI (`gh`, `glab`, or `forgejo-axi`) is not installed for GitHub, GitLab, or Forgejo
-- The provider CLI is not authenticated for GitHub, GitLab, or Forgejo
+- The upstream host is not GitHub, GitLab, Forgejo, Bitbucket Cloud (`bitbucket.org`), Azure DevOps (`dev.azure.com` / `*.visualstudio.com`), or Gitea
+- The provider CLI (`gh`, `glab`, `forgejo-axi`, or `tea`) is not installed for GitHub, GitLab, Forgejo, or Gitea
+- The provider CLI is not authenticated for GitHub, GitLab, Forgejo, or Gitea
 - Bitbucket Cloud credentials are missing (`NO_MISTAKES_BITBUCKET_EMAIL` or `NO_MISTAKES_BITBUCKET_API_TOKEN`)
 - The `az` CLI with the `azure-devops` extension is not installed or not authenticated for Azure DevOps
 - A legacy or manually edited non-GitHub repo record has `fork_url` set, because fork MR/PR routing is currently GitHub-only
@@ -224,7 +224,7 @@ Creates or updates a pull request.
 - Checks for an existing PR on the branch, matching by branch alone rather than filtering by base, so a still-open PR against a since-changed [`pr.base_branch`](/no-mistakes/reference/repo-config/#prbase_branch) is found and updated instead of orphaned behind a duplicate
 - If one exists, updates it. If not, creates a new one against the configured base branch.
 - If existing-PR discovery fails or its provider response cannot be decoded and validated as a PR listing for the configured repository, stops instead of treating the result as no PR and creating a duplicate.
-- Uses `gh` for GitHub, `glab` for GitLab, `forgejo-axi` for Forgejo, the Bitbucket API for Bitbucket Cloud, and `az` for Azure DevOps
+- Uses `gh` for GitHub, `glab` for GitLab, `forgejo-axi` for Forgejo, `tea` for Gitea, the Bitbucket API for Bitbucket Cloud, and `az` for Azure DevOps
 - For GitHub fork routing, keeps `gh --repo` pointed at the parent repository from `origin`, checks existing PRs with the bare branch name, filters matching PRs by head owner, and creates PRs with `--head <fork-owner>:<branch>`
 - PR title: agent-generated from the final branch delta with user intent when available, in conventional commit format (`type(scope): description` or `type: description`); user-facing product impact should use `feat` or `fix` so release automation can pick it up; when a scope is used, it should be the primary affected real module/package from the changed paths and kept broad rather than file-level. If drafting fails, the fallback uses the neutral title `chore: update pull request` rather than inferring scope from earlier commits.
 - Bounds the PR-drafting agent with [`agent_timeout`](/no-mistakes/reference/global-config/#agent_timeout): an expired budget cancels the agent and uses that same fallback rather than leaving the run active indefinitely; a late successful title after the deadline is not used
@@ -264,13 +264,14 @@ The comment is intentionally data only. It does not declare any step required, p
 
 Monitors PR health after creation and auto-fixes CI failures. Mergeability polling and merge-conflict handling apply to GitHub, GitLab, Forgejo, and Azure DevOps.
 
-**Active for GitHub, GitLab, Forgejo, Bitbucket Cloud (`bitbucket.org`), and Azure DevOps (`dev.azure.com` / `*.visualstudio.com`)**.
+**Active for GitHub, GitLab, Forgejo, Bitbucket Cloud (`bitbucket.org`), Azure DevOps (`dev.azure.com` / `*.visualstudio.com`), and Gitea**.
 
 - GitHub requires `gh` CLI, installed and authenticated.
 - GitLab requires `glab` CLI, installed and authenticated.
 - Forgejo requires `forgejo-axi`, installed and authenticated.
 - Bitbucket Cloud requires `NO_MISTAKES_BITBUCKET_EMAIL` and `NO_MISTAKES_BITBUCKET_API_TOKEN`.
 - Azure DevOps requires the `az` CLI with the `azure-devops` extension, authenticated with a PAT.
+- Gitea requires `tea` CLI, installed with a login configured for the instance.
 
 **Behavior:**
 

--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -404,7 +404,7 @@ Answering that gate with `fix` is still honored, and the fix round you asked for
 
 Reruns are skipped when:
 
-- The provider has no rerun API (only GitHub implements one today; GitLab, Forgejo, Bitbucket Cloud, and Azure DevOps reach the approval gate without a rerun).
+- The provider has no rerun API (only GitHub implements one today; GitLab, Forgejo, Bitbucket Cloud, Azure DevOps, and Gitea reach the approval gate without a rerun).
 - The check's details link names nothing the provider can re-run, for example a third-party status pointing at an external dashboard, or a link under a workflow run that names no job the API accepts. A link naming one job re-runs that job; a cancelled check naming only the workflow run re-runs the whole workflow, while other run-only links re-run failed jobs; an unrecognized link is widened into neither.
 - The published branch head no longer equals the commit the run delivered. That case terminates with the expected and observed commits instead: re-running checks against a different head would certify a revision this run never produced. See [pipeline steps: CI](/no-mistakes/reference/pipeline-steps/#ci).
 

--- a/docs/src/content/docs/start-here/installation.md
+++ b/docs/src/content/docs/start-here/installation.md
@@ -53,6 +53,7 @@ make install
   - `glab` CLI (GitLab)
   - `NO_MISTAKES_BITBUCKET_EMAIL` and `NO_MISTAKES_BITBUCKET_API_TOKEN` (Bitbucket Cloud)
   - `az` CLI with the `azure-devops` extension (Azure DevOps)
+  - `tea` CLI (Gitea)
 
 Run `no-mistakes doctor` to check native agents, ACP aliases such as `cursor`, provider tools, and whether the configured global runner can start a validation gate.
 Every validation gate requires a runnable pipeline agent and otherwise fails before its first pipeline step.

--- a/docs/src/content/docs/start-here/quick-start.md
+++ b/docs/src/content/docs/start-here/quick-start.md
@@ -25,7 +25,7 @@ You need:
 
 - `git`
 - One supported agent runner (`claude`, `codex`, `grok`, `acli` for Rovo Dev, `opencode`, `pi`, `copilot`, or `agy` for Antigravity), or a configured Cursor/ACP runner such as `agent: cursor`; see [Global Config](/no-mistakes/reference/global-config/) for ACP requirements
-- For PRs and CI: `gh` (GitHub), `glab` (GitLab), `forgejo-axi` (Forgejo), Bitbucket Cloud credentials, or `az` with the `azure-devops` extension (Azure DevOps)
+- For PRs and CI: `gh` (GitHub), `glab` (GitLab), `forgejo-axi` (Forgejo), Bitbucket Cloud credentials, `az` with the `azure-devops` extension (Azure DevOps), or `tea` (Gitea)
 
 `no-mistakes doctor` reports whether the configured global runner can start a validation gate.
 Every validation gate requires a runnable pipeline agent and otherwise fails before its first pipeline step.

--- a/internal/e2e/gitea_provider_test.go
+++ b/internal/e2e/gitea_provider_test.go
@@ -1,0 +1,144 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+// TestGiteaProviderJourney exercises the Gitea provider end to end through
+// the real pipeline: self-hosted-host detection via tea's own config.yml
+// (Gitea carries no distinguishing hostname substring the way gitlab.com or
+// github.com do), buildHost wiring the gitea.Host, PR creation, and the CI
+// step reading PR state back through the same host. It mirrors
+// TestForkRouting's shape (a git URL rewrite standing in for the real
+// provider, a stubbed CLI shadowing the real one), using the tea stub added
+// to cmd/fakeagent alongside the existing gh stub.
+func TestGiteaProviderJourney(t *testing.T) {
+	h := NewHarness(t, SetupOpts{Agent: "claude"})
+
+	const (
+		giteaHost  = "gitea.example.com"
+		repoSlug   = "owner/repo"
+		loginName  = "e2e"
+		remoteURL  = "https://" + giteaHost + "/" + repoSlug + ".git"
+		branchName = "feature/gitea-provider-e2e"
+	)
+
+	configureGitURLRewrite(t, h, remoteURL, h.UpstreamDir)
+	if out, err := h.runGit(t.Context(), h.WorkDir, "remote", "set-url", "origin", remoteURL); err != nil {
+		t.Fatalf("set gitea origin: %v\n%s", err, out)
+	}
+
+	// tea has no distinguishing hostname substring to detect by (unlike
+	// gitlab.com/github.com); scm.DetectProvider falls back to consulting
+	// tea's own config.yml for a login matching the remote's host. Isolate
+	// XDG_CONFIG_HOME explicitly rather than relying on the harness's HOME
+	// fallback, so an ambient XDG_CONFIG_HOME on the test host can never leak
+	// into this assertion.
+	xdgConfigHome := filepath.Join(h.HomeDir, ".config")
+	t.Setenv("XDG_CONFIG_HOME", xdgConfigHome)
+	teaConfigDir := filepath.Join(xdgConfigHome, "tea")
+	if err := os.MkdirAll(teaConfigDir, 0o755); err != nil {
+		t.Fatalf("mkdir tea config dir: %v", err)
+	}
+	teaConfig := "logins:\n" +
+		"    - name: " + loginName + "\n" +
+		"      url: https://" + giteaHost + "\n" +
+		"      ssh_host: " + giteaHost + "\n" +
+		"      user: e2e-tea-user\n" +
+		"      token: xxx\n"
+	if err := os.WriteFile(filepath.Join(teaConfigDir, "config.yml"), []byte(teaConfig), 0o644); err != nil {
+		t.Fatalf("write tea config: %v", err)
+	}
+
+	teaLog := filepath.Join(filepath.Dir(h.AgentLog), "tea-provider.log")
+	t.Setenv("FAKEAGENT_TEA_LOG", teaLog)
+	t.Setenv("FAKEAGENT_TEA_HOST", giteaHost)
+
+	if out, err := h.Run("init"); err != nil {
+		t.Fatalf("init: %v\n%s", err, out)
+	}
+
+	h.CommitChange(branchName, "gitea.txt", "gitea provider e2e\n", "add gitea provider e2e file")
+	h.PushToGate(branchName)
+
+	run := h.WaitForRun(branchName, 90*time.Second)
+	if run.Status != types.RunCompleted {
+		t.Fatalf("run did not complete: status=%s error=%v", run.Status, deref(run.Error))
+	}
+	if run.PRURL == nil || !strings.HasPrefix(*run.PRURL, "http://"+giteaHost+"/"+repoSlug+"/pulls/") {
+		t.Fatalf("PR URL = %v, want a Gitea pull URL under %s/%s", run.PRURL, giteaHost, repoSlug)
+	}
+
+	invocations := readTeaStubInvocations(t, teaLog)
+	if len(invocations) == 0 {
+		t.Fatal("no tea invocations recorded; the pipeline never called the Gitea host")
+	}
+
+	var sawAuthCheck, sawCreate, sawWrongLogin bool
+	for _, inv := range invocations {
+		if len(inv.Args) >= 1 && inv.Args[0] == "api" && inv.Args[len(inv.Args)-1] == "/user" {
+			sawAuthCheck = true
+		}
+		if len(inv.Args) >= 2 && inv.Args[0] == "pulls" && inv.Args[1] == "create" {
+			sawCreate = true
+			if inv.Repo != repoSlug {
+				t.Fatalf("pulls create --repo = %q, want %q: %+v", inv.Repo, repoSlug, inv)
+			}
+			if inv.Head != branchName {
+				t.Fatalf("pulls create --head = %q, want %q: %+v", inv.Head, branchName, inv)
+			}
+		}
+		if inv.Login != "" && inv.Login != loginName {
+			sawWrongLogin = true
+			t.Errorf("tea invocation used login %q, want the configured %q: %+v", inv.Login, loginName, inv)
+		}
+	}
+	if !sawAuthCheck {
+		t.Fatalf("Host.Available never called `tea api --login <name> /user`: %+v", invocations)
+	}
+	if !sawCreate {
+		t.Fatalf("PR step never called `tea pulls create`: %+v", invocations)
+	}
+	if sawWrongLogin {
+		t.Fatalf("a tea invocation targeted the wrong login: %+v", invocations)
+	}
+}
+
+type teaStubInvocation struct {
+	Args  []string `json:"args"`
+	Repo  string   `json:"repo"`
+	Login string   `json:"login"`
+	Head  string   `json:"head"`
+	Base  string   `json:"base"`
+}
+
+func readTeaStubInvocations(t *testing.T, path string) []teaStubInvocation {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read tea log: %v", err)
+	}
+	var invocations []teaStubInvocation
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var inv teaStubInvocation
+		if err := json.Unmarshal(line, &inv); err != nil {
+			t.Fatalf("parse tea log line: %v\n%s", err, line)
+		}
+		invocations = append(invocations, inv)
+	}
+	return invocations
+}

--- a/internal/e2e/harness.go
+++ b/internal/e2e/harness.go
@@ -113,13 +113,14 @@ func NewHarness(t *testing.T, opts SetupOpts) *Harness {
 
 	// Symlink each agent name to the same fake binary. Native agents dispatch
 	// by argv[0] basename; opencode does the same. Symlinks (not
-	// copies) keep the build cheap on subsequent tests. The `gh` symlink
-	// is a guard rail: BinDir is prepended to PATH, so any stray invocation
-	// of gh by the pipeline (e.g. PR/CI on a misconfigured origin) hits
-	// the fakeagent stub instead of a real, authenticated system gh.
-	// antigravity gets a second link under its probed binary name "agy"
-	// (internal/cli/doctor.go searches that name, not the agent name).
-	for _, name := range []string{"claude", "codex", "grok", "opencode", "antigravity", "agy", "gh"} {
+	// copies) keep the build cheap on subsequent tests. The `gh` and `tea`
+	// symlinks are a guard rail: BinDir is prepended to PATH, so any stray
+	// invocation of gh/tea by the pipeline (e.g. PR/CI on a misconfigured
+	// origin) hits the fakeagent stub instead of a real, authenticated
+	// system CLI. antigravity gets a second link under its probed binary
+	// name "agy" (internal/cli/doctor.go searches that name, not the agent
+	// name).
+	for _, name := range []string{"claude", "codex", "grok", "opencode", "antigravity", "agy", "gh", "tea"} {
 		linkPath := filepath.Join(h.BinDir, executableName(name))
 		if err := os.Symlink(fakeBin, linkPath); err != nil {
 			t.Fatalf("symlink %s: %v", linkPath, err)

--- a/internal/pipeline/steps/host.go
+++ b/internal/pipeline/steps/host.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/scm"
 	"github.com/kunchenguid/no-mistakes/internal/scm/azuredevops"
 	"github.com/kunchenguid/no-mistakes/internal/scm/forgejo"
+	"github.com/kunchenguid/no-mistakes/internal/scm/gitea"
 	"github.com/kunchenguid/no-mistakes/internal/scm/github"
 	"github.com/kunchenguid/no-mistakes/internal/scm/gitlab"
 )
@@ -122,6 +123,24 @@ func buildHost(sctx *pipeline.StepContext, provider scm.Provider) (scm.Host, str
 			TokenEnv:       tokenEnv,
 			Secrets:        forgejoTokenValuesForStep(sctx),
 		}), ""
+	case scm.ProviderGitea:
+		if sctx.Repo.ForkURL != "" {
+			// Fork PR routing for Gitea is intentionally not half-wired,
+			// mirroring GitLab, Bitbucket, and Azure DevOps: cross-repository
+			// routing needs distinct source/destination handling this
+			// provider does not implement yet.
+			return nil, "fork PR routing for Gitea is not implemented"
+		}
+		host := scm.ResolveHost(sctx.Ctx, sctx.Repo.UpstreamURL)
+		repoSlug := scm.RepoPath(sctx.Repo.UpstreamURL)
+		if repoSlug == "" {
+			return nil, "could not resolve Gitea owner/repo from the remote URL"
+		}
+		// login comes from tea's own config.yml (see scm.ResolveGiteaLogin); an
+		// empty login is tolerated here and surfaces as an actionable error
+		// from Host.Available instead of failing host construction outright.
+		login := scm.ResolveGiteaLogin(host)
+		return gitea.New(cmdFactory, func() bool { return stepCLIAvailable(sctx, provider) }, host, login, repoSlug), ""
 	default:
 		return nil, fmt.Sprintf("provider %s is not supported yet", provider)
 	}

--- a/internal/scm/auth_test.go
+++ b/internal/scm/auth_test.go
@@ -16,6 +16,7 @@ func TestAuthCheckCommand(t *testing.T) {
 		{ProviderGitLab, []string{"glab", "auth", "status"}},
 		{ProviderBitbucket, []string{"bb", "profile", "which"}},
 		{ProviderAzureDevOps, []string{"az", "account", "show"}},
+		{ProviderGitea, []string{"tea", "whoami"}},
 	}
 
 	for _, tt := range tests {

--- a/internal/scm/gitea/gitea.go
+++ b/internal/scm/gitea/gitea.go
@@ -117,9 +117,17 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 	if err != nil {
 		return nil, fmt.Errorf("tea pulls list: %s: %w", strings.TrimSpace(string(out)), err)
 	}
+	if strings.TrimSpace(string(out)) == "" {
+		return nil, nil
+	}
 	trimmed := bytesTrimToJSON(out)
 	if len(trimmed) == 0 {
-		return nil, nil
+		// Nonempty output with no JSON delimiter is not a legitimate "no
+		// open PRs" response (an empty list still prints "[]", which has a
+		// delimiter) - it must surface as an error rather than be read as
+		// absence, which would otherwise cause the PR step to attempt a
+		// duplicate create or report a misleading creation failure.
+		return nil, fmt.Errorf("tea pulls list: invalid JSON output: %s", strings.TrimSpace(string(out)))
 	}
 	var items []giteaPRListItem
 	if err := json.Unmarshal(trimmed, &items); err != nil {

--- a/internal/scm/gitea/gitea.go
+++ b/internal/scm/gitea/gitea.go
@@ -1,0 +1,498 @@
+// Package gitea implements scm.Host backed by the tea CLI (Gitea's official
+// CLI).
+//
+// Unlike gh/glab, tea has no notion of "the current instance": it infers
+// context from the working directory's git remote, which the daemon's
+// detached bare-gate repo does not have. Every invocation here therefore
+// carries --login and --repo explicitly (see the New doc comment).
+//
+// `tea actions runs view --jobs --output json` was empirically verified
+// (against a real tea 0.15.1 CLI and a real Gitea 1.27.2 + Actions instance)
+// to NOT emit clean structured per-job JSON: --output json only formats the
+// run-level header block as JSON-ish text mixed with a genuine JSON jobs
+// array, and that jobs array carries no `conclusion` field (only `status`),
+// so pass/fail cannot be read from it. The REST job endpoint
+// (GET /repos/{owner}/{repo}/actions/runs/{run}/jobs) does carry a `status` +
+// `conclusion` pair (mirroring GitHub Actions' schema) and is reachable
+// through `tea api`, which reuses tea's own stored login/token - no separate
+// HTTP client or token configuration is needed. GetChecks and
+// FetchFailedCheckLogs therefore go through `tea api` for job-level detail
+// while every other operation (PR lifecycle, auth, run discovery) uses tea's
+// own porcelain subcommands.
+package gitea
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/scm"
+)
+
+// CmdFactory builds an exec.Cmd in the caller's workdir with the caller's env.
+type CmdFactory func(ctx context.Context, name string, args ...string) *exec.Cmd
+
+// Host talks to Gitea through the tea CLI.
+type Host struct {
+	cmd          CmdFactory
+	cliAvailable func() bool
+	host         string // repo's Gitea hostname; used only for error messages
+	login        string // tea login name configured for this host; scopes every tea invocation
+	repoSlug     string // "owner/repo" slug tea's --repo flag expects
+}
+
+// New builds a Host. cliAvailable reports whether the tea binary is
+// resolvable on the caller's PATH. host is the repo's Gitea hostname, used
+// only to produce an actionable error message. login is the name of the tea
+// login (from tea's own config.yml, see scm.ResolveGiteaLogin) configured for
+// that host: tea requires --login on every command run outside a directory
+// whose git remote it recognizes, which the daemon's detached bare-gate repo
+// never is. repoSlug is the "owner/repo" path tea's --repo flag expects (no
+// host prefix; --login already disambiguates the instance). All are optional;
+// an empty login makes Available fail closed with a setup hint instead of
+// silently falling back to tea's own default-login guessing.
+func New(cmd CmdFactory, cliAvailable func() bool, host, login, repoSlug string) *Host {
+	return &Host{
+		cmd:          cmd,
+		cliAvailable: cliAvailable,
+		host:         strings.TrimSpace(host),
+		login:        strings.TrimSpace(login),
+		repoSlug:     strings.TrimSpace(repoSlug),
+	}
+}
+
+func (h *Host) Provider() scm.Provider { return scm.ProviderGitea }
+
+func (h *Host) Capabilities() scm.Capabilities {
+	// MergeableState is declined: Gitea's PR `mergeable` field has a
+	// documented upstream reliability bug (go-gitea/gitea#25849) that can
+	// stick `false` after a conflict is actually resolved. Trusting it is
+	// worse than declining the capability, matching Bitbucket's posture.
+	return scm.Capabilities{MergeableState: false, FailedCheckLogs: true}
+}
+
+func (h *Host) Available(ctx context.Context) error {
+	if h.cliAvailable != nil && !h.cliAvailable() {
+		return errors.New("tea CLI is not installed")
+	}
+	if h.login == "" {
+		host := h.host
+		if host == "" {
+			host = "<gitea-host>"
+		}
+		return fmt.Errorf("no tea login configured for %s; run `tea logins add --url https://%s --token <token> --name <name>`", host, host)
+	}
+	// `tea whoami` has no --login flag, so it cannot be scoped to a specific
+	// host the way `glab auth status --hostname` can. `tea api` accepts
+	// --login on every call, so an authenticated GET /user through it is the
+	// host-scoped equivalent: it fails when this login's token is missing or
+	// invalid without being influenced by any other configured tea login.
+	cmd := h.cmd(ctx, "tea", "api", "--login", h.login, "/user")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("tea CLI is not authenticated for login %q", h.login)
+	}
+	return nil
+}
+
+type giteaPRListItem struct {
+	Index string `json:"index"`
+	State string `json:"state"`
+	URL   string `json:"url"`
+	Head  string `json:"head"`
+	Base  string `json:"base"`
+}
+
+func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error) {
+	// tea pulls list has no --head/--base filter; the requested fields are
+	// filtered client-side. --state is left at its default (open), matching
+	// every other provider's FindPR: only an open PR for the branch counts.
+	args := []string{"pulls", "list", "--repo", h.repoSlug, "--login", h.login, "--fields", "index,title,state,url,head,base", "--output", "json"}
+	out, err := h.cmd(ctx, "tea", args...).CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("tea pulls list: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	trimmed := bytesTrimToJSON(out)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+	var items []giteaPRListItem
+	if err := json.Unmarshal(trimmed, &items); err != nil {
+		return nil, nil
+	}
+	base = strings.TrimSpace(base)
+	for _, item := range items {
+		if item.Head != branch {
+			continue
+		}
+		if base != "" && item.Base != base {
+			continue
+		}
+		return &scm.PR{Number: item.Index, URL: item.URL}, nil
+	}
+	return nil, nil
+}
+
+func (h *Host) CreatePR(ctx context.Context, branch, base string, content scm.PRContent) (*scm.PR, error) {
+	args := []string{"pulls", "create",
+		"--repo", h.repoSlug,
+		"--login", h.login,
+		"--head", branch,
+		"--base", base,
+		"--title", content.Title,
+		"--description", content.Body,
+	}
+	out, err := h.cmd(ctx, "tea", args...).CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("tea pulls create: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	// tea pulls create has no --output json flag, so the robust path is to
+	// re-list the PR by head branch rather than scrape the human-readable
+	// create output, which echoes the PR body and can itself contain
+	// http(s) URLs that would confuse a naive "first URL line" scan.
+	if pr, ferr := h.FindPR(ctx, branch, base); ferr == nil && pr != nil {
+		return pr, nil
+	}
+	url := extractGiteaPRURL(out)
+	if url == "" {
+		return nil, fmt.Errorf("tea pulls create: could not determine PR URL from output: %s", strings.TrimSpace(string(out)))
+	}
+	pr := &scm.PR{URL: url}
+	if num, nerr := scm.ExtractPRNumber(url); nerr == nil {
+		pr.Number = num
+	}
+	return pr, nil
+}
+
+func (h *Host) UpdatePR(ctx context.Context, pr *scm.PR, content scm.PRContent) (*scm.PR, error) {
+	id := ""
+	if pr != nil {
+		id = pr.Number
+		if id == "" {
+			if num, err := scm.ExtractPRNumber(pr.URL); err == nil {
+				id = num
+			}
+		}
+		if id == "" {
+			id = pr.URL
+		}
+	}
+	args := []string{"pulls", "edit", id,
+		"--repo", h.repoSlug,
+		"--login", h.login,
+		"--title", content.Title,
+		"--description", content.Body,
+	}
+	if out, err := h.cmd(ctx, "tea", args...).CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("tea pulls edit: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return pr, nil
+}
+
+type giteaPRView struct {
+	Index     int    `json:"index"`
+	State     string `json:"state"`
+	URL       string `json:"url"`
+	Head      string `json:"head"`
+	Base      string `json:"base"`
+	HeadSHA   string `json:"headSha"`
+	Mergeable bool   `json:"mergeable"`
+	HasMerged bool   `json:"hasMerged"`
+}
+
+func (h *Host) viewPR(ctx context.Context, number string) (giteaPRView, error) {
+	args := []string{"pulls", strings.TrimSpace(number), "--repo", h.repoSlug, "--login", h.login, "--output", "json"}
+	out, err := h.cmd(ctx, "tea", args...).CombinedOutput()
+	if err != nil {
+		return giteaPRView{}, fmt.Errorf("tea pulls view: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	trimmed := bytesTrimToJSON(out)
+	if len(trimmed) == 0 {
+		return giteaPRView{}, fmt.Errorf("tea pulls view: invalid JSON output: %s", strings.TrimSpace(string(out)))
+	}
+	var view giteaPRView
+	if err := json.Unmarshal(trimmed, &view); err != nil {
+		return giteaPRView{}, fmt.Errorf("tea pulls view: invalid JSON output: %s", strings.TrimSpace(string(out)))
+	}
+	return view, nil
+}
+
+func (h *Host) GetPRState(ctx context.Context, pr *scm.PR) (scm.PRState, error) {
+	view, err := h.viewPR(ctx, pr.Number)
+	if err != nil {
+		return "", err
+	}
+	// Gitea reports state="closed" AND hasMerged=true for a merged PR; check
+	// hasMerged first so a merged PR is never read as plain CLOSED.
+	if view.HasMerged {
+		return scm.PRStateMerged, nil
+	}
+	return normalizeGiteaPRState(view.State), nil
+}
+
+// GetMergeableState is unsupported: see the Capabilities doc comment.
+func (h *Host) GetMergeableState(ctx context.Context, pr *scm.PR) (scm.MergeableState, error) {
+	return "", scm.ErrUnsupported
+}
+
+type giteaRunSummary struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+	Branch string `json:"branch"`
+	Event  string `json:"event"`
+}
+
+func (h *Host) listRuns(ctx context.Context, branch string) ([]giteaRunSummary, error) {
+	args := []string{"actions", "runs", "list", "--repo", h.repoSlug, "--login", h.login, "--branch", branch, "--output", "json"}
+	out, err := h.cmd(ctx, "tea", args...).CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("tea actions runs list: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	trimmed := bytesTrimToJSON(out)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+	var runs []giteaRunSummary
+	if err := json.Unmarshal(trimmed, &runs); err != nil {
+		return nil, fmt.Errorf("tea actions runs list: invalid JSON output: %s", strings.TrimSpace(string(out)))
+	}
+	return runs, nil
+}
+
+type giteaJob struct {
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	Status      string `json:"status"`
+	Conclusion  string `json:"conclusion"`
+	HeadSHA     string `json:"head_sha"`
+	HTMLURL     string `json:"html_url"`
+	CompletedAt string `json:"completed_at"`
+}
+
+// completedAt parses the job's completed_at timestamp (RFC3339, GitHub-Actions-
+// schema style), returning the zero time when absent or unparseable.
+func (j giteaJob) completedAt() time.Time {
+	if strings.TrimSpace(j.CompletedAt) == "" {
+		return time.Time{}
+	}
+	if parsed, err := time.Parse(time.RFC3339, j.CompletedAt); err == nil {
+		return parsed
+	}
+	return time.Time{}
+}
+
+func (h *Host) runJobs(ctx context.Context, runID string) ([]giteaJob, error) {
+	owner, repo, ok := splitOwnerRepo(h.repoSlug)
+	if !ok {
+		return nil, fmt.Errorf("gitea: invalid repo slug %q", h.repoSlug)
+	}
+	endpoint := fmt.Sprintf("/repos/%s/%s/actions/runs/%s/jobs", owner, repo, runID)
+	out, err := h.cmd(ctx, "tea", "api", "--login", h.login, endpoint).CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("tea api actions runs jobs: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	trimmed := bytesTrimToJSON(out)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+	var resp struct {
+		Jobs []giteaJob `json:"jobs"`
+	}
+	if err := json.Unmarshal(trimmed, &resp); err != nil {
+		return nil, fmt.Errorf("tea api actions runs jobs: invalid JSON output: %s", strings.TrimSpace(string(out)))
+	}
+	return resp.Jobs, nil
+}
+
+func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
+	view, err := h.viewPR(ctx, pr.Number)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(view.Head) == "" {
+		return nil, nil
+	}
+	runs, err := h.listRuns(ctx, view.Head)
+	if err != nil {
+		return nil, err
+	}
+	if len(runs) == 0 {
+		return nil, nil
+	}
+	jobs, err := h.runJobs(ctx, runs[0].ID)
+	if err != nil {
+		return nil, err
+	}
+	if len(jobs) == 0 {
+		return nil, nil
+	}
+	// CI has not caught up with the latest push yet: the most recent run on
+	// this branch belongs to an older commit than the PR's current head. That
+	// stale run's checks must not be attributed to the new commit - it could
+	// misreport an all-green old commit as the current one's verdict.
+	if view.HeadSHA != "" && !anyJobMatchesHeadSHA(jobs, view.HeadSHA) {
+		return nil, nil
+	}
+	return jobsToChecks(jobs), nil
+}
+
+func anyJobMatchesHeadSHA(jobs []giteaJob, sha string) bool {
+	for _, j := range jobs {
+		if j.HeadSHA == sha {
+			return true
+		}
+	}
+	return false
+}
+
+func jobsToChecks(jobs []giteaJob) []scm.Check {
+	checks := make([]scm.Check, 0, len(jobs))
+	for _, job := range jobs {
+		checks = append(checks, scm.Check{
+			Name:        job.Name,
+			Bucket:      giteaStatusBucket(job.Status, job.Conclusion),
+			CompletedAt: job.completedAt(),
+			Link:        job.HTMLURL,
+		})
+	}
+	return checks
+}
+
+func (h *Host) FetchFailedCheckLogs(ctx context.Context, pr *scm.PR, _ string, _ string, failingNames []string) (string, error) {
+	if len(failingNames) == 0 {
+		return "", nil
+	}
+	view, err := h.viewPR(ctx, pr.Number)
+	if err != nil || strings.TrimSpace(view.Head) == "" {
+		return "", nil
+	}
+	runs, err := h.listRuns(ctx, view.Head)
+	if err != nil || len(runs) == 0 {
+		return "", nil
+	}
+	jobs, err := h.runJobs(ctx, runs[0].ID)
+	if err != nil {
+		return "", nil
+	}
+	jobID := findFailedGiteaJobID(jobs, failingNames)
+	if jobID == 0 {
+		return "", nil
+	}
+	logsCmd := h.cmd(ctx, "tea", "actions", "runs", "logs", runs[0].ID,
+		"--job", strconv.Itoa(jobID),
+		"--repo", h.repoSlug,
+		"--login", h.login,
+	)
+	out, _ := logsCmd.Output()
+	return stripGiteaLogsHeader(string(out)), nil
+}
+
+func findFailedGiteaJobID(jobs []giteaJob, failingNames []string) int {
+	targets := map[string]struct{}{}
+	for _, name := range failingNames {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			targets[name] = struct{}{}
+		}
+	}
+	for _, job := range jobs {
+		if giteaStatusBucket(job.Status, job.Conclusion) != scm.CheckBucketFail {
+			continue
+		}
+		if _, ok := targets[job.Name]; ok || len(targets) == 0 {
+			return job.ID
+		}
+	}
+	return 0
+}
+
+// stripGiteaLogsHeader removes the "Logs for job N:\n---\n" banner that `tea
+// actions runs logs` prints before the actual log body.
+func stripGiteaLogsHeader(s string) string {
+	if idx := strings.Index(s, "---\n"); idx >= 0 {
+		return strings.TrimSpace(s[idx+len("---\n"):])
+	}
+	return strings.TrimSpace(s)
+}
+
+// splitOwnerRepo splits a "owner/repo" slug (Gitea has no nested subgroups,
+// unlike GitLab) into its two path segments.
+func splitOwnerRepo(slug string) (owner, repo string, ok bool) {
+	slug = strings.Trim(strings.TrimSpace(slug), "/")
+	if slug == "" {
+		return "", "", false
+	}
+	parts := strings.SplitN(slug, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}
+
+// bytesTrimToJSON skips any banner text before the first '{' or '[', mirroring
+// the same defensive scan the gitlab CLI-shelled Host uses: a version-check
+// notice or similar stray line before the JSON payload must not break parsing.
+func bytesTrimToJSON(out []byte) []byte {
+	idx := -1
+	for i, b := range out {
+		if b == '{' || b == '[' {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return nil
+	}
+	return out[idx:]
+}
+
+// extractGiteaPRURL scans out (tea pulls create's human-readable stdout) from
+// the end for the last line that is a bare http(s) URL - the trailing summary
+// line `tea` always prints after creating a PR. It is a fallback for
+// CreatePR only; the primary path re-lists the PR for a structured result.
+func extractGiteaPRURL(out []byte) string {
+	lines := strings.Split(string(out), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		if (strings.HasPrefix(line, "http://") || strings.HasPrefix(line, "https://")) && !strings.ContainsAny(line, " \t") {
+			return line
+		}
+	}
+	return ""
+}
+
+func giteaStatusBucket(status, conclusion string) scm.CheckBucket {
+	if strings.ToLower(strings.TrimSpace(status)) != "completed" {
+		return scm.CheckBucketPending
+	}
+	switch strings.ToLower(strings.TrimSpace(conclusion)) {
+	case "success":
+		return scm.CheckBucketPass
+	case "failure":
+		return scm.CheckBucketFail
+	case "cancelled", "canceled":
+		return scm.CheckBucketCancel
+	case "skipped":
+		return scm.CheckBucketSkip
+	default:
+		return ""
+	}
+}
+
+func normalizeGiteaPRState(raw string) scm.PRState {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "open":
+		return scm.PRStateOpen
+	case "closed":
+		return scm.PRStateClosed
+	default:
+		return scm.PRState(strings.ToUpper(raw))
+	}
+}

--- a/internal/scm/gitea/gitea.go
+++ b/internal/scm/gitea/gitea.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -122,7 +123,7 @@ func (h *Host) FindPR(ctx context.Context, branch, base string) (*scm.PR, error)
 	}
 	var items []giteaPRListItem
 	if err := json.Unmarshal(trimmed, &items); err != nil {
-		return nil, nil
+		return nil, fmt.Errorf("tea pulls list: invalid JSON output: %s", strings.TrimSpace(string(out)))
 	}
 	base = strings.TrimSpace(base)
 	for _, item := range items {
@@ -323,44 +324,63 @@ func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
 	if len(runs) == 0 {
 		return nil, nil
 	}
-	run := mostRecentRun(runs)
-	jobs, err := h.runJobs(ctx, run.ID)
+	_, jobs, err := h.runJobsMatchingHeadSHA(ctx, runs, view.HeadSHA)
 	if err != nil {
 		return nil, err
 	}
 	if len(jobs) == 0 {
 		return nil, nil
 	}
-	// CI has not caught up with the latest push yet: the most recent run on
-	// this branch belongs to an older commit than the PR's current head. That
-	// stale run's checks must not be attributed to the new commit - it could
-	// misreport an all-green old commit as the current one's verdict.
-	if view.HeadSHA != "" && !anyJobMatchesHeadSHA(jobs, view.HeadSHA) {
-		return nil, nil
-	}
 	return jobsToChecks(jobs), nil
 }
 
-// mostRecentRun selects the run with the highest numeric ID rather than
-// trusting `tea actions runs list`'s array order. Gitea assigns run IDs
-// monotonically, but the list order is not documented as newest-first, and a
-// branch can have more than one run sharing the same head_sha (e.g. a manual
-// UI re-run) - trusting order alone could silently read a stale run's
-// checks. A run whose ID does not parse as an integer sorts last so it can
-// never mask a numerically comparable run.
-func mostRecentRun(runs []giteaRunSummary) giteaRunSummary {
-	best := runs[0]
-	bestID, bestOK := parseGiteaRunID(best.ID)
-	for _, run := range runs[1:] {
-		id, ok := parseGiteaRunID(run.ID)
-		if !ok {
-			continue
+// runsByIDDesc orders runs by highest numeric ID first rather than trusting
+// `tea actions runs list`'s array order, which is not documented as
+// newest-first. A run whose ID does not parse as an integer sorts last so it
+// can never mask a numerically comparable run.
+func runsByIDDesc(runs []giteaRunSummary) []giteaRunSummary {
+	ordered := make([]giteaRunSummary, len(runs))
+	copy(ordered, runs)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		idI, okI := parseGiteaRunID(ordered[i].ID)
+		idJ, okJ := parseGiteaRunID(ordered[j].ID)
+		if okI && okJ {
+			return idI > idJ
 		}
-		if !bestOK || id > bestID {
-			best, bestID, bestOK = run, id, true
+		return okI && !okJ
+	})
+	return ordered
+}
+
+// runJobsMatchingHeadSHA finds the run (and its jobs) whose jobs belong to
+// headSHA, searching candidate runs from highest ID to lowest. A branch can
+// have more than one run - e.g. a manual re-run of an older commit can land a
+// higher run ID than a newer commit's own run - so trusting the highest-ID
+// run alone (or list order) could silently attribute a stale or unrelated
+// commit's checks/logs to the PR's current head, or miss a matching lower-ID
+// run entirely. When headSHA is empty there is nothing to match against, so
+// only the highest-ID run is considered, preserving prior best-effort
+// behavior.
+func (h *Host) runJobsMatchingHeadSHA(ctx context.Context, runs []giteaRunSummary, headSHA string) (giteaRunSummary, []giteaJob, error) {
+	ordered := runsByIDDesc(runs)
+	headSHA = strings.TrimSpace(headSHA)
+	if headSHA == "" {
+		run := ordered[0]
+		jobs, err := h.runJobs(ctx, run.ID)
+		return run, jobs, err
+	}
+	for _, run := range ordered {
+		jobs, err := h.runJobs(ctx, run.ID)
+		if err != nil {
+			return giteaRunSummary{}, nil, err
+		}
+		if anyJobMatchesHeadSHA(jobs, headSHA) {
+			return run, jobs, nil
 		}
 	}
-	return best
+	// No run yet matches the PR's current head commit: CI has not caught up
+	// with the latest push, or only stale/unrelated runs exist so far.
+	return giteaRunSummary{}, nil, nil
 }
 
 func parseGiteaRunID(id string) (int64, bool) {
@@ -393,7 +413,7 @@ func jobsToChecks(jobs []giteaJob) []scm.Check {
 	return checks
 }
 
-func (h *Host) FetchFailedCheckLogs(ctx context.Context, pr *scm.PR, _ string, _ string, failingNames []string) (string, error) {
+func (h *Host) FetchFailedCheckLogs(ctx context.Context, pr *scm.PR, _ string, headSHA string, failingNames []string) (string, error) {
 	if len(failingNames) == 0 {
 		return "", nil
 	}
@@ -405,9 +425,12 @@ func (h *Host) FetchFailedCheckLogs(ctx context.Context, pr *scm.PR, _ string, _
 	if err != nil || len(runs) == 0 {
 		return "", nil
 	}
-	run := mostRecentRun(runs)
-	jobs, err := h.runJobs(ctx, run.ID)
-	if err != nil {
+	matchSHA := strings.TrimSpace(headSHA)
+	if matchSHA == "" {
+		matchSHA = view.HeadSHA
+	}
+	run, jobs, err := h.runJobsMatchingHeadSHA(ctx, runs, matchSHA)
+	if err != nil || run.ID == "" {
 		return "", nil
 	}
 	jobID := findFailedGiteaJobID(jobs, failingNames)

--- a/internal/scm/gitea/gitea.go
+++ b/internal/scm/gitea/gitea.go
@@ -323,7 +323,8 @@ func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
 	if len(runs) == 0 {
 		return nil, nil
 	}
-	jobs, err := h.runJobs(ctx, runs[0].ID)
+	run := mostRecentRun(runs)
+	jobs, err := h.runJobs(ctx, run.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -338,6 +339,36 @@ func (h *Host) GetChecks(ctx context.Context, pr *scm.PR) ([]scm.Check, error) {
 		return nil, nil
 	}
 	return jobsToChecks(jobs), nil
+}
+
+// mostRecentRun selects the run with the highest numeric ID rather than
+// trusting `tea actions runs list`'s array order. Gitea assigns run IDs
+// monotonically, but the list order is not documented as newest-first, and a
+// branch can have more than one run sharing the same head_sha (e.g. a manual
+// UI re-run) - trusting order alone could silently read a stale run's
+// checks. A run whose ID does not parse as an integer sorts last so it can
+// never mask a numerically comparable run.
+func mostRecentRun(runs []giteaRunSummary) giteaRunSummary {
+	best := runs[0]
+	bestID, bestOK := parseGiteaRunID(best.ID)
+	for _, run := range runs[1:] {
+		id, ok := parseGiteaRunID(run.ID)
+		if !ok {
+			continue
+		}
+		if !bestOK || id > bestID {
+			best, bestID, bestOK = run, id, true
+		}
+	}
+	return best
+}
+
+func parseGiteaRunID(id string) (int64, bool) {
+	n, err := strconv.ParseInt(strings.TrimSpace(id), 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
 }
 
 func anyJobMatchesHeadSHA(jobs []giteaJob, sha string) bool {
@@ -374,7 +405,8 @@ func (h *Host) FetchFailedCheckLogs(ctx context.Context, pr *scm.PR, _ string, _
 	if err != nil || len(runs) == 0 {
 		return "", nil
 	}
-	jobs, err := h.runJobs(ctx, runs[0].ID)
+	run := mostRecentRun(runs)
+	jobs, err := h.runJobs(ctx, run.ID)
 	if err != nil {
 		return "", nil
 	}
@@ -382,7 +414,7 @@ func (h *Host) FetchFailedCheckLogs(ctx context.Context, pr *scm.PR, _ string, _
 	if jobID == 0 {
 		return "", nil
 	}
-	logsCmd := h.cmd(ctx, "tea", "actions", "runs", "logs", runs[0].ID,
+	logsCmd := h.cmd(ctx, "tea", "actions", "runs", "logs", run.ID,
 		"--job", strconv.Itoa(jobID),
 		"--repo", h.repoSlug,
 		"--login", h.login,

--- a/internal/scm/gitea/gitea_test.go
+++ b/internal/scm/gitea/gitea_test.go
@@ -1,0 +1,558 @@
+package gitea
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/scm"
+)
+
+func TestSplitOwnerRepo(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in        string
+		wantOwner string
+		wantRepo  string
+		wantOK    bool
+	}{
+		{"testadmin/testrepo", "testadmin", "testrepo", true},
+		{"/testadmin/testrepo/", "testadmin", "testrepo", true},
+		{"testadmin", "", "", false},
+		{"", "", "", false},
+		{"testadmin/", "", "", false},
+	}
+	for _, tc := range cases {
+		owner, repo, ok := splitOwnerRepo(tc.in)
+		if owner != tc.wantOwner || repo != tc.wantRepo || ok != tc.wantOK {
+			t.Errorf("splitOwnerRepo(%q) = (%q, %q, %v), want (%q, %q, %v)", tc.in, owner, repo, ok, tc.wantOwner, tc.wantRepo, tc.wantOK)
+		}
+	}
+}
+
+func TestGiteaStatusBucket(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		status     string
+		conclusion string
+		want       scm.CheckBucket
+	}{
+		{"completed", "success", scm.CheckBucketPass},
+		{"completed", "failure", scm.CheckBucketFail},
+		{"completed", "cancelled", scm.CheckBucketCancel},
+		{"completed", "canceled", scm.CheckBucketCancel},
+		{"completed", "skipped", scm.CheckBucketSkip},
+		{"completed", "unknown-conclusion", ""},
+		{"queued", "", scm.CheckBucketPending},
+		{"in_progress", "", scm.CheckBucketPending},
+		{"pending", "", scm.CheckBucketPending},
+		{"waiting", "", scm.CheckBucketPending},
+		{"", "", scm.CheckBucketPending},
+	}
+	for _, tc := range cases {
+		if got := giteaStatusBucket(tc.status, tc.conclusion); got != tc.want {
+			t.Errorf("giteaStatusBucket(%q, %q) = %q, want %q", tc.status, tc.conclusion, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeGiteaPRState(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		raw  string
+		want scm.PRState
+	}{
+		{"open", scm.PRStateOpen},
+		{"Open", scm.PRStateOpen},
+		{"closed", scm.PRStateClosed},
+	}
+	for _, tc := range cases {
+		if got := normalizeGiteaPRState(tc.raw); got != tc.want {
+			t.Errorf("normalizeGiteaPRState(%q) = %q, want %q", tc.raw, got, tc.want)
+		}
+	}
+}
+
+func TestCapabilitiesDeclinesMergeableState(t *testing.T) {
+	t.Parallel()
+
+	// Gitea's PR `mergeable` field has a documented upstream reliability bug
+	// (go-gitea/gitea#25849): it can stick `false` after a conflict is
+	// actually resolved. Trusting it is worse than declining the capability.
+	host := New(nil, nil, "", "", "")
+	caps := host.Capabilities()
+	if caps.MergeableState {
+		t.Fatal("Capabilities().MergeableState = true, want false")
+	}
+	if !caps.FailedCheckLogs {
+		t.Fatal("Capabilities().FailedCheckLogs = false, want true")
+	}
+}
+
+func TestGetMergeableStateReturnsErrUnsupported(t *testing.T) {
+	t.Parallel()
+
+	host := New(nil, nil, "", "", "")
+	if _, err := host.GetMergeableState(context.Background(), &scm.PR{Number: "1"}); err != scm.ErrUnsupported {
+		t.Fatalf("GetMergeableState() error = %v, want scm.ErrUnsupported", err)
+	}
+}
+
+func TestAvailableFailsClosedWithoutConfiguredLogin(t *testing.T) {
+	t.Parallel()
+
+	host := New(giteaTestCmdFactory(nil), func() bool { return true }, "gitea.example.com", "", "owner/repo")
+	if err := host.Available(context.Background()); err == nil {
+		t.Fatal("Available() error = nil, want error when no tea login is configured for the host")
+	}
+}
+
+func TestAvailableScopesToConfiguredLogin(t *testing.T) {
+	t.Parallel()
+
+	host := New(giteaTestCmdFactory(map[string]giteaTestResponse{
+		"tea api --login work /user": {stdout: `{"login":"someuser"}`},
+	}), func() bool { return true }, "gitea.example.com", "work", "owner/repo")
+
+	if err := host.Available(context.Background()); err != nil {
+		t.Fatalf("Available() error = %v, want nil", err)
+	}
+}
+
+func TestAvailableReturnsErrorOnAuthFailure(t *testing.T) {
+	t.Parallel()
+
+	host := New(giteaTestCmdFactory(map[string]giteaTestResponse{
+		"tea api --login work /user": {stderr: "invalid username, password or token\n", code: 1},
+	}), func() bool { return true }, "gitea.example.com", "work", "owner/repo")
+
+	if err := host.Available(context.Background()); err == nil {
+		t.Fatal("Available() error = nil, want error on auth failure")
+	}
+}
+
+func TestAvailableReturnsErrorWhenCLIMissing(t *testing.T) {
+	t.Parallel()
+
+	host := New(giteaTestCmdFactory(nil), func() bool { return false }, "gitea.example.com", "work", "owner/repo")
+	if err := host.Available(context.Background()); err == nil {
+		t.Fatal("Available() error = nil, want error when tea CLI is missing")
+	}
+}
+
+func TestFindPRMatchesByHeadBranch(t *testing.T) {
+	t.Parallel()
+
+	host := New(giteaTestCmdFactory(map[string]giteaTestResponse{
+		"tea pulls list --repo owner/repo --login work --fields index,title,state,url,head,base --output json": {
+			stdout: `[{"index":"3","title":"other","state":"open","url":"https://gitea.example.com/owner/repo/pulls/3","head":"other-branch","base":"main"},` +
+				`{"index":"7","title":"mine","state":"open","url":"https://gitea.example.com/owner/repo/pulls/7","head":"feature/x","base":"main"}]`,
+		},
+	}), nil, "gitea.example.com", "work", "owner/repo")
+
+	pr, err := host.FindPR(context.Background(), "feature/x", "main")
+	if err != nil {
+		t.Fatalf("FindPR() error = %v", err)
+	}
+	if pr == nil {
+		t.Fatal("FindPR() = nil, want PR")
+	}
+	if pr.Number != "7" || pr.URL != "https://gitea.example.com/owner/repo/pulls/7" {
+		t.Fatalf("FindPR() = %+v, want PR #7", pr)
+	}
+}
+
+func TestFindPRFiltersByBaseBranch(t *testing.T) {
+	t.Parallel()
+
+	host := New(giteaTestCmdFactory(map[string]giteaTestResponse{
+		"tea pulls list --repo owner/repo --login work --fields index,title,state,url,head,base --output json": {
+			stdout: `[{"index":"1","title":"a","state":"open","url":"https://gitea.example.com/owner/repo/pulls/1","head":"feature/x","base":"release/1.0"}]`,
+		},
+	}), nil, "gitea.example.com", "work", "owner/repo")
+
+	pr, err := host.FindPR(context.Background(), "feature/x", "main")
+	if err != nil {
+		t.Fatalf("FindPR() error = %v", err)
+	}
+	if pr != nil {
+		t.Fatalf("FindPR() = %+v, want nil (base branch mismatch)", pr)
+	}
+}
+
+func TestFindPRReturnsNilWhenNoneOpen(t *testing.T) {
+	t.Parallel()
+
+	host := New(giteaTestCmdFactory(map[string]giteaTestResponse{
+		"tea pulls list --repo owner/repo --login work --fields index,title,state,url,head,base --output json": {
+			stdout: `[]`,
+		},
+	}), nil, "gitea.example.com", "work", "owner/repo")
+
+	pr, err := host.FindPR(context.Background(), "feature/x", "main")
+	if err != nil {
+		t.Fatalf("FindPR() error = %v", err)
+	}
+	if pr != nil {
+		t.Fatalf("FindPR() = %+v, want nil", pr)
+	}
+}
+
+func TestFindPRReturnsCLIError(t *testing.T) {
+	t.Parallel()
+
+	host := New(giteaTestCmdFactory(map[string]giteaTestResponse{
+		"tea pulls list --repo owner/repo --login work --fields index,title,state,url,head,base --output json": {
+			stderr: "gitea unavailable\n",
+			code:   1,
+		},
+	}), nil, "gitea.example.com", "work", "owner/repo")
+
+	pr, err := host.FindPR(context.Background(), "feature/x", "main")
+	if err == nil {
+		t.Fatal("FindPR() error = nil, want CLI error")
+	}
+	if !strings.Contains(err.Error(), "tea pulls list") {
+		t.Fatalf("FindPR() error = %v, want tea pulls list context", err)
+	}
+	if pr != nil {
+		t.Fatalf("FindPR() PR = %+v, want nil", pr)
+	}
+}
+
+func TestCreatePRUsesFindPRForStructuredResult(t *testing.T) {
+	t.Parallel()
+
+	// `tea pulls create` has no --output json flag; the robust path is to
+	// re-list the PR by head branch after creating it rather than trust a
+	// text-scrape of the human-readable create output (which can itself
+	// contain http(s) URLs inside the PR body).
+	host := New(giteaTestCmdFactory(map[string]giteaTestResponse{
+		"tea pulls create --repo owner/repo --login work --head feature/x --base main --title t --description See http://example.com/evidence for details": {
+			stdout: "  # #9 t (open)\n\n  See http://example.com/evidence for details\n\n  http://gitea.example.com/owner/repo/pulls/9\n",
+		},
+		"tea pulls list --repo owner/repo --login work --fields index,title,state,url,head,base --output json": {
+			stdout: `[{"index":"9","title":"t","state":"open","url":"http://gitea.example.com/owner/repo/pulls/9","head":"feature/x","base":"main"}]`,
+		},
+	}), nil, "gitea.example.com", "work", "owner/repo")
+
+	pr, err := host.CreatePR(context.Background(), "feature/x", "main", scm.PRContent{Title: "t", Body: "See http://example.com/evidence for details"})
+	if err != nil {
+		t.Fatalf("CreatePR() error = %v", err)
+	}
+	if pr == nil || pr.Number != "9" || pr.URL != "http://gitea.example.com/owner/repo/pulls/9" {
+		t.Fatalf("CreatePR() = %+v, want PR #9", pr)
+	}
+}
+
+func TestCreatePRFallsBackToOutputScanWhenRelistFails(t *testing.T) {
+	t.Parallel()
+
+	host := New(giteaTestCmdFactory(map[string]giteaTestResponse{
+		"tea pulls create --repo owner/repo --login work --head feature/x --base main --title t --description body": {
+			stdout: "  # #9 t (open)\n\n  body\n\n  http://gitea.example.com/owner/repo/pulls/9\n",
+		},
+		"tea pulls list --repo owner/repo --login work --fields index,title,state,url,head,base --output json": {
+			stderr: "boom\n",
+			code:   1,
+		},
+	}), nil, "gitea.example.com", "work", "owner/repo")
+
+	pr, err := host.CreatePR(context.Background(), "feature/x", "main", scm.PRContent{Title: "t", Body: "body"})
+	if err != nil {
+		t.Fatalf("CreatePR() error = %v", err)
+	}
+	if pr == nil || pr.URL != "http://gitea.example.com/owner/repo/pulls/9" || pr.Number != "9" {
+		t.Fatalf("CreatePR() = %+v, want PR #9 from output scan fallback", pr)
+	}
+}
+
+func TestCreatePRReturnsCLIError(t *testing.T) {
+	t.Parallel()
+
+	host := New(giteaTestCmdFactory(map[string]giteaTestResponse{
+		"tea pulls create --repo owner/repo --login work --head feature/x --base main --title t --description body": {
+			stderr: "gitea unavailable\n",
+			code:   1,
+		},
+	}), nil, "gitea.example.com", "work", "owner/repo")
+
+	pr, err := host.CreatePR(context.Background(), "feature/x", "main", scm.PRContent{Title: "t", Body: "body"})
+	if err == nil {
+		t.Fatal("CreatePR() error = nil, want CLI error")
+	}
+	if !strings.Contains(err.Error(), "tea pulls create") {
+		t.Fatalf("CreatePR() error = %v, want tea pulls create context", err)
+	}
+	if pr != nil {
+		t.Fatalf("CreatePR() PR = %+v, want nil", pr)
+	}
+}
+
+func TestUpdatePRUsesNumberWhenPresent(t *testing.T) {
+	t.Parallel()
+
+	host := New(giteaTestCmdFactory(map[string]giteaTestResponse{
+		"tea pulls edit 7 --repo owner/repo --login work --title updated --description body": {
+			stdout: "updated\n",
+		},
+	}), nil, "gitea.example.com", "work", "owner/repo")
+
+	pr := &scm.PR{Number: "7", URL: "http://gitea.example.com/owner/repo/pulls/7"}
+	updated, err := host.UpdatePR(context.Background(), pr, scm.PRContent{Title: "updated", Body: "body"})
+	if err != nil {
+		t.Fatalf("UpdatePR() error = %v", err)
+	}
+	if updated != pr {
+		t.Fatalf("UpdatePR() returned unexpected PR: %+v", updated)
+	}
+}
+
+func TestUpdatePRFallsBackToNumberFromURL(t *testing.T) {
+	t.Parallel()
+
+	host := New(giteaTestCmdFactory(map[string]giteaTestResponse{
+		"tea pulls edit 7 --repo owner/repo --login work --title updated --description body": {
+			stdout: "updated\n",
+		},
+	}), nil, "gitea.example.com", "work", "owner/repo")
+
+	pr := &scm.PR{URL: "http://gitea.example.com/owner/repo/pulls/7"}
+	if _, err := host.UpdatePR(context.Background(), pr, scm.PRContent{Title: "updated", Body: "body"}); err != nil {
+		t.Fatalf("UpdatePR() error = %v", err)
+	}
+}
+
+func TestGetPRStateReportsMergedBeforeClosed(t *testing.T) {
+	t.Parallel()
+
+	// Gitea reports state="closed" AND hasMerged=true for a merged PR; a
+	// merged PR must never be reported as plain CLOSED.
+	host := New(giteaTestCmdFactory(map[string]giteaTestResponse{
+		"tea pulls 7 --repo owner/repo --login work --output json": {
+			stdout: `{"index":7,"state":"closed","hasMerged":true}`,
+		},
+	}), nil, "gitea.example.com", "work", "owner/repo")
+
+	state, err := host.GetPRState(context.Background(), &scm.PR{Number: "7"})
+	if err != nil {
+		t.Fatalf("GetPRState() error = %v", err)
+	}
+	if state != scm.PRStateMerged {
+		t.Fatalf("GetPRState() = %q, want %q", state, scm.PRStateMerged)
+	}
+}
+
+func TestGetPRStateReportsClosedWhenNotMerged(t *testing.T) {
+	t.Parallel()
+
+	host := New(giteaTestCmdFactory(map[string]giteaTestResponse{
+		"tea pulls 7 --repo owner/repo --login work --output json": {
+			stdout: `{"index":7,"state":"closed","hasMerged":false}`,
+		},
+	}), nil, "gitea.example.com", "work", "owner/repo")
+
+	state, err := host.GetPRState(context.Background(), &scm.PR{Number: "7"})
+	if err != nil {
+		t.Fatalf("GetPRState() error = %v", err)
+	}
+	if state != scm.PRStateClosed {
+		t.Fatalf("GetPRState() = %q, want %q", state, scm.PRStateClosed)
+	}
+}
+
+func TestGetPRStateReportsOpen(t *testing.T) {
+	t.Parallel()
+
+	host := New(giteaTestCmdFactory(map[string]giteaTestResponse{
+		"tea pulls 7 --repo owner/repo --login work --output json": {
+			stdout: `{"index":7,"state":"open","hasMerged":false}`,
+		},
+	}), nil, "gitea.example.com", "work", "owner/repo")
+
+	state, err := host.GetPRState(context.Background(), &scm.PR{Number: "7"})
+	if err != nil {
+		t.Fatalf("GetPRState() error = %v", err)
+	}
+	if state != scm.PRStateOpen {
+		t.Fatalf("GetPRState() = %q, want %q", state, scm.PRStateOpen)
+	}
+}
+
+func TestGetChecksFetchesJobsForMatchingHeadRun(t *testing.T) {
+	t.Parallel()
+
+	host := New(giteaTestCmdFactory(map[string]giteaTestResponse{
+		"tea pulls 7 --repo owner/repo --login work --output json": {
+			stdout: `{"index":7,"state":"open","head":"feature/x","headSha":"abc123"}`,
+		},
+		"tea actions runs list --repo owner/repo --login work --branch feature/x --output json": {
+			stdout: `[{"id":"10","status":"completed","branch":"feature/x","event":"push"}]`,
+		},
+		"tea api --login work /repos/owner/repo/actions/runs/10/jobs": {
+			stdout: `{"jobs":[{"id":10,"name":"build","status":"completed","conclusion":"failure","head_sha":"abc123","html_url":"http://gitea.example.com/owner/repo/actions/runs/10/jobs/10","completed_at":"2026-08-20T06:34:50Z"},` +
+				`{"id":11,"name":"build2","status":"completed","conclusion":"success","head_sha":"abc123","html_url":"http://gitea.example.com/owner/repo/actions/runs/10/jobs/11","completed_at":"2026-08-20T06:34:51Z"}]}`,
+		},
+	}), nil, "gitea.example.com", "work", "owner/repo")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "7"})
+	if err != nil {
+		t.Fatalf("GetChecks() error = %v", err)
+	}
+	if len(checks) != 2 {
+		t.Fatalf("len(checks) = %d, want 2: %+v", len(checks), checks)
+	}
+	byName := map[string]scm.Check{}
+	for _, c := range checks {
+		byName[c.Name] = c
+	}
+	if byName["build"].Bucket != scm.CheckBucketFail {
+		t.Fatalf("build bucket = %q, want fail", byName["build"].Bucket)
+	}
+	if byName["build2"].Bucket != scm.CheckBucketPass {
+		t.Fatalf("build2 bucket = %q, want pass", byName["build2"].Bucket)
+	}
+	wantCompletedAt := time.Date(2026, 8, 20, 6, 34, 50, 0, time.UTC)
+	if !byName["build"].CompletedAt.Equal(wantCompletedAt) {
+		t.Fatalf("build CompletedAt = %v, want %v", byName["build"].CompletedAt, wantCompletedAt)
+	}
+	if byName["build"].Link != "http://gitea.example.com/owner/repo/actions/runs/10/jobs/10" {
+		t.Fatalf("build Link = %q, want job html_url", byName["build"].Link)
+	}
+}
+
+func TestGetChecksReturnsNilWhenLatestRunPredatesTheCurrentHeadSHA(t *testing.T) {
+	t.Parallel()
+
+	// The branch-filtered run's jobs belong to an older commit than the PR's
+	// current head: CI has not caught up with the latest push yet, so this
+	// must not be reported as the (possibly all-green) old commit's checks.
+	host := New(giteaTestCmdFactory(map[string]giteaTestResponse{
+		"tea pulls 7 --repo owner/repo --login work --output json": {
+			stdout: `{"index":7,"state":"open","head":"feature/x","headSha":"newsha"}`,
+		},
+		"tea actions runs list --repo owner/repo --login work --branch feature/x --output json": {
+			stdout: `[{"id":"10","status":"completed","branch":"feature/x","event":"push"}]`,
+		},
+		"tea api --login work /repos/owner/repo/actions/runs/10/jobs": {
+			stdout: `{"jobs":[{"id":10,"name":"build","status":"completed","conclusion":"success","head_sha":"oldsha"}]}`,
+		},
+	}), nil, "gitea.example.com", "work", "owner/repo")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "7"})
+	if err != nil {
+		t.Fatalf("GetChecks() error = %v", err)
+	}
+	if checks != nil {
+		t.Fatalf("GetChecks() = %+v, want nil (stale run)", checks)
+	}
+}
+
+func TestGetChecksReturnsNilWhenNoRunsExistYet(t *testing.T) {
+	t.Parallel()
+
+	host := New(giteaTestCmdFactory(map[string]giteaTestResponse{
+		"tea pulls 7 --repo owner/repo --login work --output json": {
+			stdout: `{"index":7,"state":"open","head":"feature/x","headSha":"abc123"}`,
+		},
+		"tea actions runs list --repo owner/repo --login work --branch feature/x --output json": {
+			stdout: `[]`,
+		},
+	}), nil, "gitea.example.com", "work", "owner/repo")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "7"})
+	if err != nil {
+		t.Fatalf("GetChecks() error = %v", err)
+	}
+	if checks != nil {
+		t.Fatalf("GetChecks() = %+v, want nil", checks)
+	}
+}
+
+func TestFetchFailedCheckLogsStripsHeaderAndTargetsFailedJob(t *testing.T) {
+	t.Parallel()
+
+	host := New(giteaTestCmdFactory(map[string]giteaTestResponse{
+		"tea pulls 7 --repo owner/repo --login work --output json": {
+			stdout: `{"index":7,"state":"open","head":"feature/x","headSha":"abc123"}`,
+		},
+		"tea actions runs list --repo owner/repo --login work --branch feature/x --output json": {
+			stdout: `[{"id":"10","status":"completed","branch":"feature/x","event":"push"}]`,
+		},
+		"tea api --login work /repos/owner/repo/actions/runs/10/jobs": {
+			stdout: `{"jobs":[{"id":10,"name":"build","status":"completed","conclusion":"failure","head_sha":"abc123"}]}`,
+		},
+		"tea actions runs logs 10 --job 10 --repo owner/repo --login work": {
+			stdout: "Logs for job 10:\n---\nexit status 1\nJob 'build' failed\n",
+		},
+	}), nil, "gitea.example.com", "work", "owner/repo")
+
+	logs, err := host.FetchFailedCheckLogs(context.Background(), &scm.PR{Number: "7"}, "", "", []string{"build"})
+	if err != nil {
+		t.Fatalf("FetchFailedCheckLogs() error = %v", err)
+	}
+	if logs != "exit status 1\nJob 'build' failed" {
+		t.Fatalf("FetchFailedCheckLogs() = %q, want stripped log body", logs)
+	}
+}
+
+func TestFetchFailedCheckLogsReturnsEmptyForNoFailingNames(t *testing.T) {
+	t.Parallel()
+
+	host := New(giteaTestCmdFactory(nil), nil, "gitea.example.com", "work", "owner/repo")
+	logs, err := host.FetchFailedCheckLogs(context.Background(), &scm.PR{Number: "7"}, "", "", nil)
+	if err != nil {
+		t.Fatalf("FetchFailedCheckLogs() error = %v", err)
+	}
+	if logs != "" {
+		t.Fatalf("FetchFailedCheckLogs() = %q, want empty", logs)
+	}
+}
+
+type giteaTestResponse struct {
+	stdout string
+	stderr string
+	code   int
+}
+
+func giteaTestCmdFactory(responses map[string]giteaTestResponse) CmdFactory {
+	return func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		key := strings.TrimSpace(name + " " + strings.Join(args, " "))
+		response, ok := responses[key]
+		if !ok {
+			response = giteaTestResponse{stderr: "unexpected command: " + key, code: 1}
+		}
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestGiteaHelperProcess", "--", key)
+		cmd.Env = append(os.Environ(),
+			"GITEA_TEST_HELPER=1",
+			"GITEA_TEST_STDOUT="+response.stdout,
+			"GITEA_TEST_STDERR="+response.stderr,
+			fmt.Sprintf("GITEA_TEST_EXIT_CODE=%d", response.code),
+		)
+		return cmd
+	}
+}
+
+func TestGiteaHelperProcess(t *testing.T) {
+	if os.Getenv("GITEA_TEST_HELPER") != "1" {
+		return
+	}
+
+	if _, err := fmt.Fprint(os.Stdout, os.Getenv("GITEA_TEST_STDOUT")); err != nil {
+		os.Exit(1)
+	}
+	if _, err := fmt.Fprint(os.Stderr, os.Getenv("GITEA_TEST_STDERR")); err != nil {
+		os.Exit(1)
+	}
+	if code := os.Getenv("GITEA_TEST_EXIT_CODE"); code != "" && code != "0" {
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/internal/scm/gitea/gitea_test.go
+++ b/internal/scm/gitea/gitea_test.go
@@ -476,6 +476,37 @@ func TestGetChecksReturnsNilWhenNoRunsExistYet(t *testing.T) {
 	}
 }
 
+func TestGetChecksSelectsHighestIDRunWhenListOrderIsNotNewestFirst(t *testing.T) {
+	t.Parallel()
+
+	// Both runs share the PR's current head_sha (e.g. a manual UI re-run), and
+	// the list response deliberately puts the higher-ID (newer) run second, so
+	// only explicit ID selection - not array order - can find it.
+	host := New(giteaTestCmdFactory(map[string]giteaTestResponse{
+		"tea pulls 7 --repo owner/repo --login work --output json": {
+			stdout: `{"index":7,"state":"open","head":"feature/x","headSha":"abc123"}`,
+		},
+		"tea actions runs list --repo owner/repo --login work --branch feature/x --output json": {
+			stdout: `[{"id":"10","status":"completed","branch":"feature/x","event":"push"},` +
+				`{"id":"25","status":"completed","branch":"feature/x","event":"push"}]`,
+		},
+		"tea api --login work /repos/owner/repo/actions/runs/10/jobs": {
+			stdout: `{"jobs":[{"id":10,"name":"build","status":"completed","conclusion":"failure","head_sha":"abc123"}]}`,
+		},
+		"tea api --login work /repos/owner/repo/actions/runs/25/jobs": {
+			stdout: `{"jobs":[{"id":25,"name":"build","status":"completed","conclusion":"success","head_sha":"abc123"}]}`,
+		},
+	}), nil, "gitea.example.com", "work", "owner/repo")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "7"})
+	if err != nil {
+		t.Fatalf("GetChecks() error = %v", err)
+	}
+	if len(checks) != 1 || checks[0].Bucket != scm.CheckBucketPass {
+		t.Fatalf("GetChecks() = %+v, want the newer run's passing check", checks)
+	}
+}
+
 func TestFetchFailedCheckLogsStripsHeaderAndTargetsFailedJob(t *testing.T) {
 	t.Parallel()
 
@@ -500,6 +531,34 @@ func TestFetchFailedCheckLogsStripsHeaderAndTargetsFailedJob(t *testing.T) {
 	}
 	if logs != "exit status 1\nJob 'build' failed" {
 		t.Fatalf("FetchFailedCheckLogs() = %q, want stripped log body", logs)
+	}
+}
+
+func TestFetchFailedCheckLogsSelectsHighestIDRunWhenListOrderIsNotNewestFirst(t *testing.T) {
+	t.Parallel()
+
+	host := New(giteaTestCmdFactory(map[string]giteaTestResponse{
+		"tea pulls 7 --repo owner/repo --login work --output json": {
+			stdout: `{"index":7,"state":"open","head":"feature/x","headSha":"abc123"}`,
+		},
+		"tea actions runs list --repo owner/repo --login work --branch feature/x --output json": {
+			stdout: `[{"id":"10","status":"completed","branch":"feature/x","event":"push"},` +
+				`{"id":"25","status":"completed","branch":"feature/x","event":"push"}]`,
+		},
+		"tea api --login work /repos/owner/repo/actions/runs/25/jobs": {
+			stdout: `{"jobs":[{"id":25,"name":"build","status":"completed","conclusion":"failure","head_sha":"abc123"}]}`,
+		},
+		"tea actions runs logs 25 --job 25 --repo owner/repo --login work": {
+			stdout: "Logs for job 25:\n---\nexit status 1\nJob 'build' failed\n",
+		},
+	}), nil, "gitea.example.com", "work", "owner/repo")
+
+	logs, err := host.FetchFailedCheckLogs(context.Background(), &scm.PR{Number: "7"}, "", "", []string{"build"})
+	if err != nil {
+		t.Fatalf("FetchFailedCheckLogs() error = %v", err)
+	}
+	if logs != "exit status 1\nJob 'build' failed" {
+		t.Fatalf("FetchFailedCheckLogs() = %q, want stripped log body from the higher-ID run", logs)
 	}
 }
 

--- a/internal/scm/gitea/gitea_test.go
+++ b/internal/scm/gitea/gitea_test.go
@@ -227,6 +227,28 @@ func TestFindPRReturnsErrorOnMalformedJSON(t *testing.T) {
 	}
 }
 
+func TestFindPRReturnsErrorOnNonJSONOutput(t *testing.T) {
+	t.Parallel()
+
+	// Nonempty stdout that exits 0 but contains neither '[' nor '{' (e.g. a
+	// stray banner or plain-text notice) must also surface as an error, not
+	// be swallowed into a "not found" result via bytesTrimToJSON's empty
+	// return - the same duplicate-create hazard as malformed JSON.
+	host := New(giteaTestCmdFactory(map[string]giteaTestResponse{
+		"tea pulls list --repo owner/repo --login work --fields index,title,state,url,head,base --output json": {
+			stdout: "a new release of tea is available\n",
+		},
+	}), nil, "gitea.example.com", "work", "owner/repo")
+
+	pr, err := host.FindPR(context.Background(), "feature/x", "main")
+	if err == nil {
+		t.Fatalf("FindPR() error = nil, want error for non-JSON output; pr = %+v", pr)
+	}
+	if pr != nil {
+		t.Fatalf("FindPR() = %+v, want nil PR alongside the error", pr)
+	}
+}
+
 func TestFindPRReturnsCLIError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scm/gitea/gitea_test.go
+++ b/internal/scm/gitea/gitea_test.go
@@ -205,6 +205,28 @@ func TestFindPRReturnsNilWhenNoneOpen(t *testing.T) {
 	}
 }
 
+func TestFindPRReturnsErrorOnMalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	// A decoding failure on nonempty output must surface as an error, not be
+	// swallowed into a "not found" result: otherwise the PR step reads a
+	// provider response failure as an absent PR and attempts a duplicate
+	// create, or reports a misleading creation error.
+	host := New(giteaTestCmdFactory(map[string]giteaTestResponse{
+		"tea pulls list --repo owner/repo --login work --fields index,title,state,url,head,base --output json": {
+			stdout: `[{"index":"7","title":"mine"`,
+		},
+	}), nil, "gitea.example.com", "work", "owner/repo")
+
+	pr, err := host.FindPR(context.Background(), "feature/x", "main")
+	if err == nil {
+		t.Fatalf("FindPR() error = nil, want error for malformed JSON output; pr = %+v", pr)
+	}
+	if pr != nil {
+		t.Fatalf("FindPR() = %+v, want nil PR alongside the error", pr)
+	}
+}
+
 func TestFindPRReturnsCLIError(t *testing.T) {
 	t.Parallel()
 
@@ -507,6 +529,39 @@ func TestGetChecksSelectsHighestIDRunWhenListOrderIsNotNewestFirst(t *testing.T)
 	}
 }
 
+func TestGetChecksSearchesPastAHigherIDRunForAnotherCommit(t *testing.T) {
+	t.Parallel()
+
+	// Run 25 has a higher ID than run 10 but belongs to a different commit
+	// (e.g. a manual re-run of an older push landed after the PR's real head
+	// commit triggered run 10). Selecting the highest-ID run alone would find
+	// no match for the PR's current head SHA and wrongly report no checks;
+	// the matching lower-ID run must still be found.
+	host := New(giteaTestCmdFactory(map[string]giteaTestResponse{
+		"tea pulls 7 --repo owner/repo --login work --output json": {
+			stdout: `{"index":7,"state":"open","head":"feature/x","headSha":"abc123"}`,
+		},
+		"tea actions runs list --repo owner/repo --login work --branch feature/x --output json": {
+			stdout: `[{"id":"10","status":"completed","branch":"feature/x","event":"push"},` +
+				`{"id":"25","status":"completed","branch":"feature/x","event":"push"}]`,
+		},
+		"tea api --login work /repos/owner/repo/actions/runs/25/jobs": {
+			stdout: `{"jobs":[{"id":25,"name":"build","status":"completed","conclusion":"success","head_sha":"zzz999"}]}`,
+		},
+		"tea api --login work /repos/owner/repo/actions/runs/10/jobs": {
+			stdout: `{"jobs":[{"id":10,"name":"build","status":"completed","conclusion":"failure","head_sha":"abc123"}]}`,
+		},
+	}), nil, "gitea.example.com", "work", "owner/repo")
+
+	checks, err := host.GetChecks(context.Background(), &scm.PR{Number: "7"})
+	if err != nil {
+		t.Fatalf("GetChecks() error = %v", err)
+	}
+	if len(checks) != 1 || checks[0].Bucket != scm.CheckBucketFail {
+		t.Fatalf("GetChecks() = %+v, want run 10's failing check (the run matching the PR head SHA)", checks)
+	}
+}
+
 func TestFetchFailedCheckLogsStripsHeaderAndTargetsFailedJob(t *testing.T) {
 	t.Parallel()
 
@@ -559,6 +614,41 @@ func TestFetchFailedCheckLogsSelectsHighestIDRunWhenListOrderIsNotNewestFirst(t 
 	}
 	if logs != "exit status 1\nJob 'build' failed" {
 		t.Fatalf("FetchFailedCheckLogs() = %q, want stripped log body from the higher-ID run", logs)
+	}
+}
+
+func TestFetchFailedCheckLogsSearchesPastAHigherIDRunForAnotherCommit(t *testing.T) {
+	t.Parallel()
+
+	// Same trap as TestGetChecksSearchesPastAHigherIDRunForAnotherCommit: run
+	// 25 (higher ID) belongs to a different commit than the run's head SHA,
+	// so logs must come from run 10, the run that actually matches - never
+	// another commit's same-named job logs sent to the auto-fix agent.
+	host := New(giteaTestCmdFactory(map[string]giteaTestResponse{
+		"tea pulls 7 --repo owner/repo --login work --output json": {
+			stdout: `{"index":7,"state":"open","head":"feature/x","headSha":"abc123"}`,
+		},
+		"tea actions runs list --repo owner/repo --login work --branch feature/x --output json": {
+			stdout: `[{"id":"10","status":"completed","branch":"feature/x","event":"push"},` +
+				`{"id":"25","status":"completed","branch":"feature/x","event":"push"}]`,
+		},
+		"tea api --login work /repos/owner/repo/actions/runs/25/jobs": {
+			stdout: `{"jobs":[{"id":25,"name":"build","status":"completed","conclusion":"failure","head_sha":"zzz999"}]}`,
+		},
+		"tea api --login work /repos/owner/repo/actions/runs/10/jobs": {
+			stdout: `{"jobs":[{"id":10,"name":"build","status":"completed","conclusion":"failure","head_sha":"abc123"}]}`,
+		},
+		"tea actions runs logs 10 --job 10 --repo owner/repo --login work": {
+			stdout: "Logs for job 10:\n---\nexit status 1\nJob 'build' failed\n",
+		},
+	}), nil, "gitea.example.com", "work", "owner/repo")
+
+	logs, err := host.FetchFailedCheckLogs(context.Background(), &scm.PR{Number: "7"}, "", "abc123", []string{"build"})
+	if err != nil {
+		t.Fatalf("FetchFailedCheckLogs() error = %v", err)
+	}
+	if logs != "exit status 1\nJob 'build' failed" {
+		t.Fatalf("FetchFailedCheckLogs() = %q, want stripped log body from run 10 (the run matching the head SHA)", logs)
 	}
 }
 

--- a/internal/scm/scm.go
+++ b/internal/scm/scm.go
@@ -27,6 +27,7 @@ const (
 	ProviderBitbucket   Provider = "bitbucket"
 	ProviderAzureDevOps Provider = "azuredevops"
 	ProviderForgejo     Provider = "forgejo"
+	ProviderGitea       Provider = "gitea"
 	ProviderUnknown     Provider = "unknown"
 )
 
@@ -76,6 +77,13 @@ func detectProviderWithForgejoBaseURL(ctx context.Context, remoteURL, forgejoBas
 	}
 	if ghKnowsHost(host) {
 		return ProviderGitHub
+	}
+	// Fallback for Gitea, which is nearly always self-hosted at an arbitrary
+	// hostname with no distinguishing substring at all: consult the tea CLI's
+	// own login config. If the remote's host is one tea is configured to talk
+	// to, treat it as Gitea.
+	if teaKnowsHost(host) {
+		return ProviderGitea
 	}
 	if strings.EqualFold(host, originalHost) {
 		if forgejoBaseMatchesRemote(forgejoBaseURL, remoteURL) {
@@ -417,6 +425,71 @@ func ghConfigPath() string {
 	return filepath.Join(home, ".config", "gh", "hosts.yml")
 }
 
+// teaKnowsHost reports whether host appears as a login's url (or ssh_host) in
+// tea's own config.yml. Any read/parse error is treated as "not configured" so
+// detection fails closed to ProviderUnknown.
+func teaKnowsHost(host string) bool {
+	_, ok := teaLoginForHost(host)
+	return ok
+}
+
+// ResolveGiteaLogin returns the name of the tea login configured for host, or
+// "" when tea has no login matching it. The gitea Host implementation needs
+// the login name itself (not just a yes/no match): unlike gh/glab, tea infers
+// "which instance" from the working directory's git remote, which the
+// daemon's detached bare-gate repo does not have, so every tea invocation
+// must carry --login <name> explicitly.
+func ResolveGiteaLogin(host string) string {
+	name, _ := teaLoginForHost(host)
+	return name
+}
+
+func teaLoginForHost(host string) (string, bool) {
+	path := teaConfigPath()
+	if path == "" {
+		return "", false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	var cfg struct {
+		Logins []struct {
+			Name    string `yaml:"name"`
+			URL     string `yaml:"url"`
+			SSHHost string `yaml:"ssh_host"`
+		} `yaml:"logins"`
+	}
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return "", false
+	}
+	host = strings.ToLower(host)
+	for _, login := range cfg.Logins {
+		if url := strings.ToLower(strings.TrimSpace(login.URL)); url != "" && ExtractHost(url) == host {
+			return login.Name, true
+		}
+		if sshHost := strings.ToLower(strings.TrimSpace(stripPort(login.SSHHost))); sshHost != "" && sshHost == host {
+			return login.Name, true
+		}
+	}
+	return "", false
+}
+
+// teaConfigPath resolves tea's config file location. tea has no CLI-specific
+// override env var (unlike glab's GLAB_CONFIG_DIR or gh's GH_CONFIG_DIR); it
+// persists to $XDG_CONFIG_HOME/tea, falling back to ~/.config/tea. It returns
+// "" when no home/config directory can be determined.
+func teaConfigPath() string {
+	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
+		return filepath.Join(dir, "tea", "config.yml")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".config", "tea", "config.yml")
+}
+
 func (p Provider) CLIName() string {
 	switch p {
 	case ProviderGitHub:
@@ -429,6 +502,8 @@ func (p Provider) CLIName() string {
 		return "az"
 	case ProviderForgejo:
 		return "forgejo-axi"
+	case ProviderGitea:
+		return "tea"
 	default:
 		return ""
 	}
@@ -446,6 +521,8 @@ func (p Provider) AuthCheckCommand() []string {
 		return []string{"az", "account", "show"}
 	case ProviderForgejo:
 		return []string{"forgejo-axi", "status", "--json"}
+	case ProviderGitea:
+		return []string{"tea", "whoami"}
 	default:
 		return nil
 	}

--- a/internal/scm/scm_test.go
+++ b/internal/scm/scm_test.go
@@ -9,10 +9,11 @@ import (
 )
 
 func TestDetectProvider(t *testing.T) {
-	// Point glab and gh configs at empty temp dirs so a real CLI install on the
-	// host cannot influence the substring-based assertions below.
+	// Point glab, gh, and tea configs at empty temp dirs so a real CLI install
+	// on the host cannot influence the substring-based assertions below.
 	t.Setenv("GLAB_CONFIG_DIR", t.TempDir())
 	t.Setenv("GH_CONFIG_DIR", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
 	tests := []struct {
 		url  string
@@ -45,6 +46,7 @@ func TestDetectProvider_SSHHostAlias(t *testing.T) {
 	t.Setenv("GLAB_CONFIG_DIR", t.TempDir())
 	t.Setenv("GH_CONFIG_DIR", t.TempDir())
 	t.Setenv("FORGEJO_BASE_URL", "https://github.com")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
 	tests := []struct {
 		name     string
@@ -263,6 +265,7 @@ func writeGlabConfig(t *testing.T, body string) {
 func TestDetectProvider_SelfHostedGitLabViaGlabConfig(t *testing.T) {
 	t.Setenv("GH_CONFIG_DIR", t.TempDir())
 	t.Setenv("FORGEJO_BASE_URL", "https://gitlab.example.com")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	writeGlabConfig(t, `hosts:
     gitlab.example.com:
         token: xxx
@@ -289,6 +292,7 @@ func TestDetectProvider_SelfHostedGitLabViaGlabConfig(t *testing.T) {
 
 func TestDetectProvider_SelfHostedGitLabViaAPIHost(t *testing.T) {
 	t.Setenv("GH_CONFIG_DIR", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	// The remote host differs from the config key but matches api_host.
 	writeGlabConfig(t, `hosts:
     git.example.com:
@@ -305,9 +309,10 @@ func TestDetectProvider_SelfHostedGitLabViaAPIHost(t *testing.T) {
 }
 
 func TestDetectProvider_GlabConfigMissingFailsClosed(t *testing.T) {
-	// Both CLI configs point at empty dirs: no config files present.
+	// All CLI configs point at empty dirs: no config files present.
 	t.Setenv("GLAB_CONFIG_DIR", t.TempDir())
 	t.Setenv("GH_CONFIG_DIR", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	if got := DetectProvider("https://selfhosted.example.com/group/repo.git"); got != ProviderUnknown {
 		t.Errorf("DetectProvider(no glab config) = %q, want %q", got, ProviderUnknown)
 	}
@@ -315,6 +320,7 @@ func TestDetectProvider_GlabConfigMissingFailsClosed(t *testing.T) {
 
 func TestDetectProvider_GlabConfigMalformedFailsClosed(t *testing.T) {
 	t.Setenv("GH_CONFIG_DIR", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	writeGlabConfig(t, "this: is: not: valid: yaml: ::::\n\t- broken")
 	if got := DetectProvider("https://selfhosted.example.com/group/repo.git"); got != ProviderUnknown {
 		t.Errorf("DetectProvider(malformed glab config) = %q, want %q", got, ProviderUnknown)
@@ -335,6 +341,7 @@ func writeGhConfig(t *testing.T, body string) {
 func TestDetectProvider_GHEViaGhConfig(t *testing.T) {
 	t.Setenv("GLAB_CONFIG_DIR", t.TempDir())
 	t.Setenv("FORGEJO_BASE_URL", "https://bbgithub.dev.bloomberg.com")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	writeGhConfig(t, `bbgithub.dev.bloomberg.com:
     user: someuser
     oauth_token: xxx
@@ -361,6 +368,7 @@ func TestDetectProvider_GHEViaGhConfig(t *testing.T) {
 func TestDetectProvider_GhConfigMissingFailsClosed(t *testing.T) {
 	t.Setenv("GLAB_CONFIG_DIR", t.TempDir())
 	t.Setenv("GH_CONFIG_DIR", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	if got := DetectProvider("https://ghe.example.com/org/repo.git"); got != ProviderUnknown {
 		t.Errorf("DetectProvider(no gh config) = %q, want %q", got, ProviderUnknown)
 	}
@@ -368,8 +376,125 @@ func TestDetectProvider_GhConfigMissingFailsClosed(t *testing.T) {
 
 func TestDetectProvider_GhConfigMalformedFailsClosed(t *testing.T) {
 	t.Setenv("GLAB_CONFIG_DIR", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	writeGhConfig(t, "this: is: not: valid: yaml: ::::\n\t- broken")
 	if got := DetectProvider("https://ghe.example.com/org/repo.git"); got != ProviderUnknown {
 		t.Errorf("DetectProvider(malformed gh config) = %q, want %q", got, ProviderUnknown)
+	}
+}
+
+// writeTeaConfig writes a synthetic tea config.yml into a temp dir and points
+// XDG_CONFIG_HOME at it. The host names are placeholders only.
+func writeTeaConfig(t *testing.T, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "tea"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "tea", "config.yml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", dir)
+}
+
+func TestDetectProvider_SelfHostedGiteaViaTeaConfig(t *testing.T) {
+	t.Setenv("GLAB_CONFIG_DIR", t.TempDir())
+	t.Setenv("GH_CONFIG_DIR", t.TempDir())
+	writeTeaConfig(t, `logins:
+    - name: work
+      url: https://git.example.com
+      ssh_host: git.example.com
+      user: someuser
+      token: xxx
+`)
+
+	cases := []string{
+		"https://git.example.com/group/repo.git",
+		"git@git.example.com:group/repo.git",
+		"ssh://git@git.example.com:22/group/repo.git",
+	}
+	for _, url := range cases {
+		if got := DetectProvider(url); got != ProviderGitea {
+			t.Errorf("DetectProvider(%q) = %q, want %q", url, got, ProviderGitea)
+		}
+	}
+
+	// A host not in the config still resolves to unknown.
+	if got := DetectProvider("https://other.example.org/group/repo.git"); got != ProviderUnknown {
+		t.Errorf("DetectProvider(unconfigured host) = %q, want %q", got, ProviderUnknown)
+	}
+}
+
+func TestDetectProvider_SelfHostedGiteaViaSSHHost(t *testing.T) {
+	t.Setenv("GLAB_CONFIG_DIR", t.TempDir())
+	t.Setenv("GH_CONFIG_DIR", t.TempDir())
+	// The remote host differs from the login's url but matches ssh_host.
+	writeTeaConfig(t, `logins:
+    - name: work
+      url: https://gitea.internal:3000
+      ssh_host: git.internal
+      user: someuser
+      token: xxx
+`)
+
+	if got := DetectProvider("https://gitea.internal/group/repo.git"); got != ProviderGitea {
+		t.Errorf("DetectProvider(url host match) = %q, want %q", got, ProviderGitea)
+	}
+	if got := DetectProvider("git@git.internal:group/repo.git"); got != ProviderGitea {
+		t.Errorf("DetectProvider(ssh_host match) = %q, want %q", got, ProviderGitea)
+	}
+}
+
+func TestDetectProvider_TeaConfigMissingFailsClosed(t *testing.T) {
+	// All CLI configs point at empty dirs: no config files present.
+	t.Setenv("GLAB_CONFIG_DIR", t.TempDir())
+	t.Setenv("GH_CONFIG_DIR", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	if got := DetectProvider("https://selfhosted.example.com/group/repo.git"); got != ProviderUnknown {
+		t.Errorf("DetectProvider(no tea config) = %q, want %q", got, ProviderUnknown)
+	}
+}
+
+func TestDetectProvider_TeaConfigMalformedFailsClosed(t *testing.T) {
+	t.Setenv("GLAB_CONFIG_DIR", t.TempDir())
+	t.Setenv("GH_CONFIG_DIR", t.TempDir())
+	writeTeaConfig(t, "this: is: not: valid: yaml: ::::\n\t- broken")
+	if got := DetectProvider("https://selfhosted.example.com/group/repo.git"); got != ProviderUnknown {
+		t.Errorf("DetectProvider(malformed tea config) = %q, want %q", got, ProviderUnknown)
+	}
+}
+
+func TestResolveGiteaLogin(t *testing.T) {
+	writeTeaConfig(t, `logins:
+    - name: work
+      url: https://gitea.internal:3000
+      ssh_host: git.internal
+      user: someuser
+      token: xxx
+    - name: personal
+      url: https://gitea.example.org
+      ssh_host: gitea.example.org
+      user: otheruser
+      token: yyy
+`)
+
+	if got := ResolveGiteaLogin("gitea.internal"); got != "work" {
+		t.Errorf("ResolveGiteaLogin(url host match) = %q, want %q", got, "work")
+	}
+	if got := ResolveGiteaLogin("git.internal"); got != "work" {
+		t.Errorf("ResolveGiteaLogin(ssh_host match) = %q, want %q", got, "work")
+	}
+	if got := ResolveGiteaLogin("gitea.example.org"); got != "personal" {
+		t.Errorf("ResolveGiteaLogin(second login) = %q, want %q", got, "personal")
+	}
+	if got := ResolveGiteaLogin("unconfigured.example.net"); got != "" {
+		t.Errorf("ResolveGiteaLogin(unconfigured host) = %q, want empty", got)
+	}
+}
+
+func TestResolveGiteaLogin_NoConfigFailsClosed(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	if got := ResolveGiteaLogin("gitea.internal"); got != "" {
+		t.Errorf("ResolveGiteaLogin(no config) = %q, want empty", got)
 	}
 }


### PR DESCRIPTION
## Intent

Add Gitea as a fifth SCM provider to no-mistakes' PR/CI pipeline steps, alongside GitHub, GitLab, Bitbucket Cloud, and Azure DevOps. Provider abstraction is additive (no existing provider's code changes): internal/scm/scm.go gets a 'gitea' Provider enum value plus CLIName/AuthCheckCommand cases and a teaKnowsHost fallback (mirroring glabKnowsHost/ghKnowsHost) that reads tea's own login config to recognize a self-hosted Gitea remote host. internal/scm/gitea implements the Host interface mirroring internal/scm/gitlab/gitlab.go's shape (CLI-shelled, JSON-parsed via 'tea --output json'), not Bitbucket's or Azure DevOps's. internal/pipeline/steps/host.go buildHost gets one new case scm.ProviderGitea, GitLab-shaped (no fork-PR support). Auth is token-based via 'tea logins add', Available() scoped to the configured instance (mirroring glab auth status --hostname). PR ops via tea pulls create/list/edit --repo <slug> --login <name> --output json. CI polling/GetChecks via tea actions runs list/view, selecting the run by highest numeric run ID (not list order or index [0], since list order is undocumented and a branch can have multiple runs sharing a head SHA). Failed log fetching via tea actions runs logs <run-id>. Capabilities decline MergeableState (matching Bitbucket's posture, due to a documented Gitea upstream bug go-gitea/gitea#25849) and set FailedCheckLogs true. Skip fork-PR routing, CheckRerunner, and evidence-branch-link publication for v1 (optional interfaces already skipped by other providers). PR body length cap (MaxPRBodyChars) defaults to 0 (unlimited) for Gitea. The empirical open question (whether 'tea actions runs view --jobs --output json' emits structured per-job JSON) must be resolved against a real tea CLI and real/Dockerized Gitea+Actions instance before committing to a shape, not guessed. Docs: guides/provider-integration.md gets a new## Gitea section mirroring the existing provider sections plus a 'Self-hosted Gitea' subsection; reference/environment.md gets any new env vars; reference/cli.md documents whether tea becomes an active 'no-mistakes doctor' check or stays docs-only, with reasoning. Testing follows this repo's TDD convention: unit tests for internal/scm/gitea (JSON parsing, status-bucket mapping, URL/slug extraction), a TestDetectProvider...Gitea case in internal/scm/scm_test.go, and an e2e journey test exercising a fake tea binary mirroring how gh/glab are faked in the e2e harness. This work is being validated and shipped as a PR from a fork: origin remains kunchenguid/no-mistakes (PR base), fork_url is https://github.com/babbarc/no-mistakes.git (push target), configured via 'no-mistakes init --fork-url'.

## What Changed

- Added `internal/scm/gitea`, a `tea`-CLI-shelled, JSON-parsed `Host` implementation (mirroring `internal/scm/gitlab`'s shape) covering PR create/list/edit, CI status polling and per-job pass/fail via the Actions REST endpoint (`tea api .../actions/runs/{run}/jobs`), and failed-log fetching (`tea actions runs logs`); it selects the active run by highest numeric run ID rather than list order or index `[0]`, since Gitea does not document run-list ordering and a branch can have multiple runs sharing a head SHA. `MergeableState` is declined (matching Bitbucket, due to go-gitea/gitea#25849) and fork-PR routing, `CheckRerunner`, and evidence-branch-link publication are skipped for v1.
- Extended `internal/scm/scm.go` with a `gitea` provider enum value, CLI name/auth-check cases, and a `teaKnowsHost` detection fallback that reads `tea`'s own login config to recognize a self-hosted Gitea remote host (mirroring `glabKnowsHost`/`ghKnowsHost`); `internal/pipeline/steps/host.go` wires `buildHost` to construct the GitLab-shaped Gitea host (no fork-PR support).
- Added a fake `tea` binary to `cmd/fakeagent` and `internal/e2e/harness.go`, plus a new e2e journey test (`internal/e2e/gitea_provider_test.go`) exercising the provider end to end, alongside unit tests for JSON parsing, status-bucket mapping, and URL/slug extraction in `internal/scm/gitea/gitea_test.go` and a `TestDetectProvider...Gitea` case in `internal/scm/scm_test.go`.
- Documented Gitea across `guides/provider-integration.md` (new "Gitea" section plus a "Self-hosted Gitea" subsection), `reference/cli.md` (`tea` stays a docs-only `doctor` reference rather than an active check, since Gitea is almost always self-hosted and a bare "not found" warning would be low-value for most users), `reference/environment.md`, `reference/pipeline-steps.md`, `reference/repo-config.md`, `guides/troubleshooting.md`, and the installation/quick-start guides.

## Risk Assessment

✅ Low: The change is additive and self-contained (new provider package plus one new switch case in buildHost), faithfully mirrors the existing, already-hardened GitLab backend's shape, is backed by thorough behavioral unit tests (real subprocess-based CLI stubbing) and a genuine e2e journey test through a fake tea binary, correctly declines unsupported capabilities (MergeableState, fork routing, CheckRerunner) rather than half-wiring them, and a real bug found during this run's own review loop (selecting the run by list order instead of highest ID) was already fixed and tested in a later commit on this branch.

## Testing

`All targeted tests pass: the internal/scm/gitea package unit suite, scm.DetectProvider's new Gitea self-hosted-detection cases, the CLIName/AuthCheckCommand auth test, and the e2e TestGiteaProviderJourney which exercises the complete user-facing flow (push -> pipeline run -> Gitea PR creation -> CI read-back) against a fake tea CLI binary, verifying the produced PR URL, the exact tea pulls create --repo/--login/--head arguments, and login-scoped auth. No failures or flakiness observed; no findings to report.`

<details>
<summary>Evidence: e2e Gitea provider journey test output</summary>

<code>=== RUN TestGiteaProviderJourney&#10;--- PASS: TestGiteaProviderJourney (2.52s)&#10;PASS&#10;ok github.com/kunchenguid/no-mistakes/internal/e2e 3.539s</code>

```text
=== RUN   TestGiteaProviderJourney
--- PASS: TestGiteaProviderJourney (2.52s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/e2e	(cached)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"495487427a40b6eb4df7aa4869a56c4ca8758865","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go build ./...`
- `go test -race -v ./internal/scm/gitea/... (all gitea unit tests: status bucket mapping, PR find/create/update, GetChecks/FetchFailedCheckLogs run-selection-by-highest-ID, Available login scoping)`
- `go test -race -run 'TestDetectProvider|Gitea' ./internal/scm/... -v (provider detection incl. TestDetectProvider_SelfHostedGiteaViaTeaConfig, TestDetectProvider_SelfHostedGiteaViaSSHHost, TestDetectProvider_TeaConfigMissingFailsClosed/Malformed, TestResolveGiteaLogin*)`
- `go test -race -run TestAuth ./internal/scm/... -v (TestAuthCheckCommand covering new gitea CLIName/AuthCheckCommand case)`
- `go test -tags e2e -race -run TestGiteaProviderJourney -v ./internal/e2e/... (full pipeline journey: init, push, PR creation, CI check read-back via fake tea binary)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
