### PR TITLE
ci: require completed review, test, and document attestation

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -50,26 +50,124 @@ jobs:
       - name: Verify no-mistakes signature in PR body
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -eu
           marker='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
-          if printf '%s' "${PR_BODY:-}" | grep -qF -- "$marker"; then
-            echo "Found no-mistakes signature in PR #${PR_NUMBER} body."
-            exit 0
+          if ! printf '%s' "${PR_BODY:-}" | grep -qF -- "$marker"; then
+            {
+              echo "::error::This PR was not raised through no-mistakes."
+              echo
+              echo "Contributions to this repository must be submitted via 'git push no-mistakes'."
+              echo "That pipeline runs the required review/test/lint/CI steps and writes a"
+              echo "deterministic '## Pipeline' section into the PR body containing:"
+              echo
+              echo "    $marker"
+              echo
+              echo "See CONTRIBUTING.md for setup and the full workflow."
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
           fi
-          {
-            echo "::error::This PR was not raised through no-mistakes."
-            echo
-            echo "Contributions to this repository must be submitted via 'git push no-mistakes'."
-            echo "That pipeline runs the required review/test/lint/CI steps and writes a"
-            echo "deterministic '## Pipeline' section into the PR body containing:"
-            echo
-            echo "    $marker"
-            echo
-            echo "See CONTRIBUTING.md for setup and the full workflow."
-            echo
-            echo "PR author: ${PR_AUTHOR}"
-          } >&2
-          exit 1
+          echo "Found no-mistakes signature in PR #${PR_NUMBER} body."
+          if command -v python3 >/dev/null 2>&1; then
+            PY=python3
+          elif command -v python >/dev/null 2>&1; then
+            PY=python
+          else
+            echo "::error::python interpreter not found; cannot parse pipeline attestation." >&2
+            exit 1
+          fi
+          "$PY" <<'PY'
+          import json
+          import os
+          import sys
+
+          body = os.environ.get("PR_BODY") or ""
+          pr_head_sha = os.environ.get("PR_HEAD_SHA") or ""
+          prefix = "<!-- no-mistakes-pipeline-attestation:v1 "
+          closing = " -->"
+          required_steps = ("review", "test", "document")
+          author = os.environ.get("PR_AUTHOR") or ""
+
+          def fail_missing_attestation() -> None:
+              sys.stderr.write(
+                  "::error::This PR is missing structured pipeline step attestation.\n\n"
+                  "This repository requires no-mistakes >= 1.46.0 "
+                  "(https://github.com/kunchenguid/no-mistakes/pull/670). "
+                  "Older no-mistakes that only writes the signature line is not enough.\n\n"
+                  "The PR body must include a comment of the form:\n"
+                  '    <!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"...","steps":[...]} -->\n\n'
+                  "Contributions to this repository must be submitted via 'git push no-mistakes'.\n"
+                  "See CONTRIBUTING.md for setup and the full workflow.\n\n"
+                  f"PR author: {author}\n"
+              )
+              raise SystemExit(1)
+
+          start = body.find(prefix)
+          if start < 0:
+              fail_missing_attestation()
+          start += len(prefix)
+          end = body.find(closing, start)
+          if end < 0:
+              fail_missing_attestation()
+          raw = body[start:end]
+          try:
+              payload = json.loads(raw)
+          except json.JSONDecodeError:
+              fail_missing_attestation()
+          if not isinstance(payload, dict):
+              fail_missing_attestation()
+          head_sha = payload.get("head_sha")
+          steps = payload.get("steps")
+          if not isinstance(head_sha, str) or not isinstance(steps, list):
+              fail_missing_attestation()
+          if head_sha == "" or pr_head_sha == "" or head_sha != pr_head_sha:
+              sys.stderr.write(
+                  "::error::Pipeline attestation head_sha does not match the current PR head.\n\n"
+                  f"attestation.head_sha: {head_sha or '(missing)'}\n"
+                  f"PR head: {pr_head_sha or '(missing)'}\n\n"
+                  "A later push must not pass on an older attestation. "
+                  "Re-run 'git push no-mistakes' so the PR body attestation binds to the current head.\n\n"
+                  "See CONTRIBUTING.md for setup and the full workflow.\n\n"
+                  f"PR author: {author}\n"
+              )
+              raise SystemExit(1)
+
+          status_by_step = {}
+          for item in steps:
+              if not isinstance(item, dict):
+                  fail_missing_attestation()
+              name = item.get("step")
+              status = item.get("status")
+              if not isinstance(name, str) or name == "" or not isinstance(status, str):
+                  fail_missing_attestation()
+              status_by_step[name] = status
+
+          incomplete = []
+          for name in required_steps:
+              status = status_by_step.get(name)
+              if status == "completed":
+                  continue
+              if status is None:
+                  incomplete.append(f"{name} (missing)")
+              else:
+                  incomplete.append(f"{name} (status={status})")
+
+          if incomplete:
+              listed = ", ".join(incomplete)
+              sys.stderr.write(
+                  f"::error::Required no-mistakes pipeline steps are not completed: {listed}.\n\n"
+                  "This repository requires review, test, and document to have status=completed. "
+                  "Quota skips and agent skips are not compliant.\n\n"
+                  "Contributions to this repository must be submitted via 'git push no-mistakes'.\n"
+                  "See CONTRIBUTING.md for setup and the full workflow.\n\n"
+                  f"PR author: {author}\n"
+              )
+              raise SystemExit(1)
+
+          print("Found compliant pipeline step attestation.")
+          PY

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,14 +5,14 @@ Thanks for wanting to contribute. One rule up front:
 **All pull requests to this repository must be raised through `no-mistakes`.**
 
 This repo _is_ no-mistakes. Contributions should be done using the tool itself, which reduces the maintainer's burden of reviewing and merging contributions.
-The `Require no-mistakes` GitHub Actions workflow runs on every PR and fails if the body is missing the deterministic signature that no-mistakes writes. PRs without it will not be reviewed or merged.
-If you revise the PR description after no-mistakes creates it, preserve the generated `## Pipeline` section. Replacing the whole body removes the signature and makes the required check fail until no-mistakes writes the section again.
+The `Require no-mistakes` GitHub Actions workflow runs on every PR and fails if the body is missing the deterministic signature and structured pipeline step attestation that no-mistakes writes. PRs without them will not be reviewed or merged.
+If you revise the PR description after no-mistakes creates it, preserve the generated `## Pipeline` section. Replacing the whole body removes the signature or attestation and makes the required check fail until no-mistakes writes the section again.
 
 Every `opened` or `edited` event gets an independent run, including first-time-fork runs that become actionable through GitHub's normal approval process. The integration contract for consumers such as Wheelhouse is:
 
 - The stable check name is `PR must be raised via no-mistakes`.
 - The workflow run's `display_title` identifies the PR number, event action, `run_number`, and immutable `run_id`. For a PR, increasing `run_number` orders distinct events; a re-run retains that event identity and increments `run_attempt`.
-- The run's `head_sha` binds the evidence to the reviewed commit. After the latest `opened` or `edited` run reaches `status: completed`, `conclusion: success` means that event's body contained the signature and `conclusion: failure` means it did not. `action_required` or `cancelled` is not compliance evidence and must be handled conservatively.
+- The run's `head_sha` binds the evidence to the reviewed commit. After the latest `opened` or `edited` run reaches `status: completed`, `conclusion: success` means that event's body contained the signature and a parseable v1 pipeline attestation whose `head_sha` matches `github.event.pull_request.head.sha` and whose `review`, `test`, and `document` steps are `completed`. `conclusion: failure` means it did not. `action_required` or `cancelled` is not compliance evidence and must be handled conservatively.
 - Fork runs stay on the `pull_request` boundary with read-only contents permission, no repository secrets, and no checkout or execution of fork code. Approval permits only this body check; it does not grant write authority.
 
 ## Workflow

--- a/workflow_no_mistakes_required_test.go
+++ b/workflow_no_mistakes_required_test.go
@@ -11,7 +11,16 @@ import (
 	"testing"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/pipeline/steps"
+	"github.com/kunchenguid/no-mistakes/internal/types"
 )
+
+// requiredWorkflowTestHeadSHA is the commit the generated pipeline summary
+// attestation binds to. Tests that execute the workflow script pass the same
+// value as PR_HEAD_SHA unless they are asserting a mismatch.
+const requiredWorkflowTestHeadSHA = "0123456789abcdef0123456789abcdef01234567"
 
 // TestNoMistakesRequiredWorkflowExemptsReleaseAutomation pins the exemption
 // logic so the release pipeline (release-please via GITHUB_TOKEN) and
@@ -73,6 +82,9 @@ func TestNoMistakesRequiredWorkflowReadsPRBodyViaEnv(t *testing.T) {
 	if !strings.Contains(content, "PR_BODY: ${{ github.event.pull_request.body }}") {
 		t.Errorf("workflow must expose PR body via the PR_BODY env var")
 	}
+	if !strings.Contains(content, "PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}") {
+		t.Errorf("workflow must expose PR head SHA via the PR_HEAD_SHA env var")
+	}
 	if strings.Contains(content, "${{ github.event.pull_request.body }}\n          run:") {
 		t.Errorf("workflow must not interpolate PR body directly into run: script (injection risk)")
 	}
@@ -82,10 +94,8 @@ func TestNoMistakesRequiredWorkflowReadsPRBodyViaEnv(t *testing.T) {
 // re-runs when the PR body is edited so a contributor cannot bypass by opening
 // clean then editing the body.
 //
-// It also pins the deliberate absence of "synchronize". The verdict is a pure
-// function of pull_request.body, and a push never changes that body, so a
-// synchronize run can only restate the last body-event verdict. What it does
-// change is the head SHA: the pipeline pushes (Push step) before it writes the
+// It also pins the deliberate absence of "synchronize". A push never changes
+// the PR body, and the pipeline pushes (Push step) before it writes the
 // deterministic "## Pipeline" section (PR step), so on any PR whose body is not
 // yet compliant - every PR the pipeline adopts rather than opens itself - the
 // synchronize run pins a FAILURE check run to the new head for a body the same
@@ -94,7 +104,8 @@ func TestNoMistakesRequiredWorkflowReadsPRBodyViaEnv(t *testing.T) {
 // check runs by startedAt alone, so the pipeline's own CI monitor can read the
 // stale failure and park the run red with no push able to clear it (PR #773
 // carried check runs 96017425510 FAILURE and 96017420271 SUCCESS on one head).
-// No ruleset requires this status, so no head SHA needs a run of its own.
+// Body-bearing events still bind attestation.head_sha to the PR head at that
+// event. No ruleset requires this status, so no head SHA needs a run of its own.
 func TestNoMistakesRequiredWorkflowTriggersOnRelevantPREvents(t *testing.T) {
 	types := requiredWorkflowPullRequestTypes(t, loadRequiredWorkflow(t))
 
@@ -138,11 +149,11 @@ func requiredWorkflowPullRequestTypes(t *testing.T, workflow requiredWorkflow) [
 // that survives scheduling.
 func TestNoMistakesRequiredWorkflowExecutesEveryBodyEvent(t *testing.T) {
 	workflow := loadRequiredWorkflow(t)
-	marker := "Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)"
+	compliant := pipelineSummaryWithStatuses(t, types.StepStatusCompleted, types.StepStatusCompleted, types.StepStatusCompleted)
 	events := []requiredWorkflowEvent{
-		{Action: "opened", Body: "## Pipeline\n\n" + marker, HeadSHA: "same-head", PRNumber: 549, RunID: 29962844999, RunNumber: 586},
-		{Action: "edited", Body: "signature removed", HeadSHA: "same-head", PRNumber: 549, RunID: 29962943078, RunNumber: 587},
-		{Action: "edited", Body: "## Pipeline\n\n" + marker, HeadSHA: "same-head", PRNumber: 549, RunID: 29965243268, RunNumber: 588},
+		{Action: "opened", Body: compliant, HeadSHA: requiredWorkflowTestHeadSHA, PRNumber: 549, RunID: 29962844999, RunNumber: 586},
+		{Action: "edited", Body: "signature removed", HeadSHA: requiredWorkflowTestHeadSHA, PRNumber: 549, RunID: 29962943078, RunNumber: 587},
+		{Action: "edited", Body: compliant, HeadSHA: requiredWorkflowTestHeadSHA, PRNumber: 549, RunID: 29965243268, RunNumber: 588},
 	}
 
 	got := executeRequiredWorkflowFixture(t, workflow, events)
@@ -153,6 +164,167 @@ func TestNoMistakesRequiredWorkflowExecutesEveryBodyEvent(t *testing.T) {
 	}
 	if !slices.Equal(got, want) {
 		t.Fatalf("same-head body-event results =\n  %v\nwant every event executed to its own terminal result:\n  %v", got, want)
+	}
+}
+
+func TestNoMistakesRequiredWorkflowEnforcesPipelineAttestation(t *testing.T) {
+	workflow := loadRequiredWorkflow(t)
+	script := requiredWorkflowRunScript(t, workflow)
+	signature := "Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)"
+
+	tests := []struct {
+		name       string
+		body       string
+		headSHA    string
+		want       string
+		wantOut    []string
+		notWantOut []string
+	}{
+		{
+			name:    "missing signature",
+			body:    "a regular pull request",
+			want:    "failure",
+			wantOut: []string{"This PR was not raised through no-mistakes.", "git push no-mistakes", "CONTRIBUTING.md"},
+			notWantOut: []string{
+				">= 1.46.0",
+			},
+		},
+		{
+			name: "signature without attestation",
+			body: "## Pipeline\n\n" + signature + "\n",
+			want: "failure",
+			wantOut: []string{
+				">= 1.46.0",
+				"https://github.com/kunchenguid/no-mistakes/pull/670",
+				"only writes the signature",
+			},
+		},
+		{
+			name: "unparseable attestation JSON",
+			body: "## Pipeline\n\n" + signature + "\n\n<!-- no-mistakes-pipeline-attestation:v1 {not-json} -->\n",
+			want: "failure",
+			wantOut: []string{
+				">= 1.46.0",
+				"https://github.com/kunchenguid/no-mistakes/pull/670",
+				"only writes the signature",
+			},
+		},
+		{
+			name: "attestation missing required JSON fields",
+			body: "## Pipeline\n\n" + signature + "\n\n<!-- no-mistakes-pipeline-attestation:v1 {\"steps\":[]} -->\n",
+			want: "failure",
+			wantOut: []string{
+				">= 1.46.0",
+				"https://github.com/kunchenguid/no-mistakes/pull/670",
+			},
+		},
+		{
+			name: "quota skip on document is non-compliant",
+			body: pipelineSummaryWithStatuses(t, types.StepStatusCompleted, types.StepStatusCompleted, types.StepStatusSkipped),
+			want: "failure",
+			wantOut: []string{
+				"document",
+				"skipped",
+			},
+			notWantOut: []string{
+				">= 1.46.0",
+			},
+		},
+		{
+			name: "failed test is non-compliant",
+			body: pipelineSummaryWithStatuses(t, types.StepStatusCompleted, types.StepStatusFailed, types.StepStatusCompleted),
+			want: "failure",
+			wantOut: []string{
+				"test",
+				"failed",
+			},
+			notWantOut: []string{
+				">= 1.46.0",
+			},
+		},
+		{
+			name:    "missing review step is non-compliant",
+			body:    "## Pipeline\n\n" + signature + "\n\n<!-- no-mistakes-pipeline-attestation:v1 {\"head_sha\":\"abc\",\"steps\":[{\"step\":\"test\",\"status\":\"completed\"},{\"step\":\"document\",\"status\":\"completed\"}]} -->\n",
+			headSHA: "abc",
+			want:    "failure",
+			wantOut: []string{
+				"review",
+				"missing",
+			},
+			notWantOut: []string{
+				">= 1.46.0",
+			},
+		},
+		{
+			name: "pending review is non-compliant",
+			body: pipelineSummaryWithStatuses(t, types.StepStatusPending, types.StepStatusCompleted, types.StepStatusCompleted),
+			want: "failure",
+			wantOut: []string{
+				"review",
+				"pending",
+			},
+		},
+		{
+			name: "running test is non-compliant",
+			body: pipelineSummaryWithStatuses(t, types.StepStatusCompleted, types.StepStatusRunning, types.StepStatusCompleted),
+			want: "failure",
+			wantOut: []string{
+				"test",
+				"running",
+			},
+		},
+		{
+			name:    "generated compliant attestation passes",
+			body:    pipelineSummaryWithStatuses(t, types.StepStatusCompleted, types.StepStatusCompleted, types.StepStatusCompleted),
+			want:    "success",
+			wantOut: []string{"Found no-mistakes signature"},
+		},
+		{
+			name: "empty attestation head_sha is non-compliant",
+			body: "## Pipeline\n\n" + signature + "\n\n<!-- no-mistakes-pipeline-attestation:v1 {\"head_sha\":\"\",\"steps\":[{\"step\":\"review\",\"status\":\"completed\"},{\"step\":\"test\",\"status\":\"completed\"},{\"step\":\"document\",\"status\":\"completed\"}]} -->\n",
+			want: "failure",
+			wantOut: []string{
+				"head_sha",
+				"does not match",
+			},
+			notWantOut: []string{
+				">= 1.46.0",
+			},
+		},
+		{
+			name:    "attestation head_sha that does not match the PR head is non-compliant",
+			body:    pipelineSummaryWithStatuses(t, types.StepStatusCompleted, types.StepStatusCompleted, types.StepStatusCompleted),
+			headSHA: "ffffffffffffffffffffffffffffffffffffffff",
+			want:    "failure",
+			wantOut: []string{
+				"head_sha",
+				"does not match",
+				requiredWorkflowTestHeadSHA,
+				"ffffffffffffffffffffffffffffffffffffffff",
+			},
+			notWantOut: []string{
+				">= 1.46.0",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			conclusion, output := runRequiredWorkflowStep(t, script, tc.body, tc.headSHA)
+			if conclusion != tc.want {
+				t.Fatalf("conclusion = %q, want %q\n%s", conclusion, tc.want, output)
+			}
+			for _, want := range tc.wantOut {
+				if !strings.Contains(output, want) {
+					t.Errorf("output does not contain %q:\n%s", want, output)
+				}
+			}
+			for _, notWant := range tc.notWantOut {
+				if strings.Contains(output, notWant) {
+					t.Errorf("output unexpectedly contains %q:\n%s", notWant, output)
+				}
+			}
+		})
 	}
 }
 
@@ -320,7 +492,7 @@ func executeRequiredWorkflowFixture(t *testing.T, workflow requiredWorkflow, eve
 		}
 	}
 
-	step := workflow.Jobs["check"].Steps[0]
+	script := requiredWorkflowRunScript(t, workflow)
 	results := make([]requiredWorkflowResult, len(events))
 	for i, event := range events {
 		result := requiredWorkflowResult{RunID: event.RunID, RunNumber: event.RunNumber, Action: event.Action}
@@ -330,27 +502,70 @@ func executeRequiredWorkflowFixture(t *testing.T, workflow requiredWorkflow, eve
 			continue
 		}
 
-		cmd := exec.Command("bash", "-c", step.Run)
-		cmd.Env = append(os.Environ(),
-			"PR_BODY="+event.Body,
-			"PR_AUTHOR=first-time-fork-contributor",
-			"PR_NUMBER="+strconv.FormatInt(event.PRNumber, 10),
-		)
-		var output bytes.Buffer
-		cmd.Stdout = &output
-		cmd.Stderr = &output
-		err := cmd.Run()
+		conclusion, output := runRequiredWorkflowStep(t, script, event.Body, event.HeadSHA)
 		result.Executed = true
-		if err == nil {
-			result.Conclusion = "success"
-		} else if _, ok := err.(*exec.ExitError); ok {
-			result.Conclusion = "failure"
-		} else {
-			t.Fatalf("execute compliance step for run %d: %v\n%s", event.RunID, err, output.String())
+		result.Conclusion = conclusion
+		if conclusion != "success" && conclusion != "failure" {
+			t.Fatalf("execute compliance step for run %d: unexpected conclusion %q\n%s", event.RunID, conclusion, output)
 		}
 		results[i] = result
 	}
 	return results
+}
+
+func requiredWorkflowRunScript(t *testing.T, workflow requiredWorkflow) string {
+	t.Helper()
+	job, ok := workflow.Jobs["check"]
+	if !ok || len(job.Steps) == 0 || job.Steps[0].Run == "" {
+		t.Fatal("required workflow is missing the check job run script")
+	}
+	return job.Steps[0].Run
+}
+
+func runRequiredWorkflowStep(t *testing.T, runScript, body, headSHA string) (conclusion, output string) {
+	t.Helper()
+	if headSHA == "" {
+		headSHA = requiredWorkflowTestHeadSHA
+	}
+	cmd := exec.Command("bash", "-c", runScript)
+	cmd.Env = append(os.Environ(),
+		"PR_BODY="+body,
+		"PR_HEAD_SHA="+headSHA,
+		"PR_AUTHOR=first-time-fork-contributor",
+		"PR_NUMBER=549",
+	)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	if err == nil {
+		return "success", buf.String()
+	}
+	if _, ok := err.(*exec.ExitError); ok {
+		return "failure", buf.String()
+	}
+	t.Fatalf("execute compliance step: %v\n%s", err, buf.String())
+	return "", ""
+}
+
+func pipelineSummaryWithStatuses(t *testing.T, review, testStep, document types.StepStatus) string {
+	t.Helper()
+	stepResults := []*db.StepResult{
+		{ID: "review", StepName: types.StepReview, Status: review},
+		{ID: "test", StepName: types.StepTest, Status: testStep},
+		{ID: "document", StepName: types.StepDocument, Status: document},
+		{ID: "pr", StepName: types.StepPR, Status: types.StepStatusRunning},
+		{ID: "ci", StepName: types.StepCI, Status: types.StepStatusPending},
+	}
+	rounds := make(map[string][]*db.StepRound, len(stepResults))
+	for _, sr := range stepResults {
+		rounds[sr.ID] = []*db.StepRound{{Round: 1, Trigger: "initial", DurationMS: 1}}
+	}
+	md, _ := steps.BuildPipelineSummary(stepResults, rounds, requiredWorkflowTestHeadSHA)
+	if md == "" {
+		t.Fatal("BuildPipelineSummary returned empty markdown")
+	}
+	return md
 }
 
 func renderRequiredWorkflowTemplate(t *testing.T, template string, event requiredWorkflowEvent) string {


### PR DESCRIPTION
## Summary
- The `PR must be raised via no-mistakes` check still requires the existing signature line.
- It now also requires a parseable `<!-- no-mistakes-pipeline-attestation:v1 ... -->` comment with JSON `head_sha` and `steps`.
- `review`, `test`, and `document` must be `status=completed`. Missing attestation names the no-mistakes >= 1.46.0 floor (https://github.com/kunchenguid/no-mistakes/pull/670); skipped/failed/pending/running/missing required steps fail with the recorded status.

## Test plan
- [x] `go test -race -run TestNoMistakesRequiredWorkflow .` covers missing signature, missing/unparseable attestation, skipped/failed/pending/running/missing required steps, and a producer-generated compliant body.
- [x] `make lint`
- [ ] Confirm the GitHub Action still uses job name `PR must be raised via no-mistakes` and keeps existing exemptions/triggers/concurrency.