### PR TITLE
fix(pipeline): separate mixed evidence blocks in PR summaries

### DIFF
--- a/internal/pipeline/steps/prsummary.go
+++ b/internal/pipeline/steps/prsummary.go
@@ -221,15 +221,20 @@ func buildTestingSummary(steps []*db.StepResult, rounds map[string][]*db.StepRou
 			}
 		}
 		renderState := testingArtifactRenderState{remainingEmbeddedBytes: maxEmbeddedArtifactsTotalBytes}
+		previousArtifact := ""
 		for _, artifact := range artifacts {
 			rendered := renderTestingArtifact(artifact, opts, &renderState)
 			if rendered == "" {
 				continue
 			}
+			if needsArtifactBlockSeparator(previousArtifact, rendered) {
+				b.WriteString("\n")
+			}
 			b.WriteString(rendered)
 			if !strings.HasSuffix(rendered, "\n") {
 				b.WriteString("\n")
 			}
+			previousArtifact = rendered
 		}
 		if outcome := buildTestingOutcomeLine(line, stepRounds); shouldRenderTestingOutcome(opts, wroteSummary, outcome) {
 			b.WriteString("- ")
@@ -241,6 +246,16 @@ func buildTestingSummary(steps []*db.StepResult, rounds map[string][]*db.StepRou
 	}
 
 	return ""
+}
+
+func needsArtifactBlockSeparator(previous, current string) bool {
+	previous = strings.TrimSpace(previous)
+	current = strings.TrimSpace(current)
+	previousIsDetails := strings.HasPrefix(previous, "<details>")
+	currentIsDetails := strings.HasPrefix(current, "<details>")
+	previousIsBullet := strings.HasPrefix(previous, "- Evidence:")
+	currentIsBullet := strings.HasPrefix(current, "- Evidence:")
+	return previousIsDetails && currentIsBullet || previousIsBullet && currentIsDetails
 }
 
 func shouldRenderTestingOutcome(opts testingSummaryOptions, wroteSummary bool, outcome string) bool {

--- a/internal/pipeline/steps/prsummary_test.go
+++ b/internal/pipeline/steps/prsummary_test.go
@@ -701,6 +701,30 @@ func TestBuildTestingSummaryForPR_RendersEvidenceArtifactsCompactly(t *testing.T
 	}
 }
 
+func TestBuildTestingSummaryForPR_SeparatesMixedEvidenceBlocks(t *testing.T) {
+	t.Parallel()
+	findings := `{"findings":[],"summary":"","testing_summary":"Evidence was collected.","artifacts":[{"kind":"log","label":"Inline first","content":"first output"},{"kind":"log","label":"Linked first","url":"https://example.com/first.log"},{"kind":"log","label":"Inline second","content":"second output"},{"kind":"log","label":"Linked second","url":"https://example.com/second.log"},{"kind":"log","label":"Linked third","url":"https://example.com/third.log"}]}`
+	steps := []*db.StepResult{
+		{ID: "s1", StepName: types.StepTest, Status: types.StepStatusCompleted, FindingsJSON: &findings},
+	}
+	rounds := map[string][]*db.StepRound{
+		"s1": {{Round: 1, Trigger: "initial", FindingsJSON: &findings, DurationMS: 300}},
+	}
+
+	md := BuildTestingSummaryForPR(steps, rounds, "git@github.com:example/widgets.git", "abc123", t.TempDir(), "", nil)
+
+	for _, want := range []string{
+		"</details>\n\n- Evidence: [Linked first]",
+		"- Evidence: [Linked first](https://example.com/first.log)\n\n<details>",
+		"</details>\n\n- Evidence: [Linked second]",
+		"- Evidence: [Linked second](https://example.com/second.log)\n- Evidence: [Linked third]",
+	} {
+		if !strings.Contains(md, want) {
+			t.Errorf("expected mixed evidence boundary %q, got:\n%s", want, md)
+		}
+	}
+}
+
 func TestBuildTestingSummaryForPR_BitbucketCloudOmitsHTMLAndKeepsEvidence(t *testing.T) {
 	t.Parallel()
 	evidenceRoot := filepath.Join(t.TempDir(), "evidence", "run-123")


### PR DESCRIPTION
## Intent

Fix issue #723 so generated pull request Testing sections reliably separate collapsible HTML evidence blocks from adjacent Markdown evidence-list bullets. Preserve consecutive Markdown evidence bullets as one list, normalize spacing in both HTML-to-Markdown and Markdown-to-HTML directions, and add behavioral regression coverage for the mixed sequence.

## What Changed

- Add blank-line separators when generated Testing evidence transitions between collapsible HTML blocks and Markdown bullets in either direction.
- Preserve consecutive Markdown evidence bullets as a single list.
- Add regression coverage for mixed inline and linked evidence sequences.

## Risk Assessment

✅ Low: The change is narrowly scoped and correctly inserts blank lines at both HTML-to-Markdown and Markdown-to-HTML evidence boundaries while preserving consecutive evidence bullets as one list; behavioral regression coverage exercises both transitions.

## Testing

Focused behavioral regressions passed, and generated end-user PR Markdown directly demonstrated normalized spacing in both mixed directions while retaining consecutive evidence bullets as one list.

<details>
<summary>Evidence: Generated mixed-evidence PR Testing section</summary>

```text
## Testing

Evidence was collected.

<details>
<summary>Evidence: Inline first</summary>

`` `text
first output
`` `
</details>

- Evidence: [Linked first](https://example.com/first.log)

<details>
<summary>Evidence: Inline second</summary>

`` `text
second output
`` `
</details>

- Evidence: [Linked second](https://example.com/second.log)
- Evidence: [Linked third](https://example.com/third.log)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"45e1cd56a92766ee51dce3a8e405650f288d31a8","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/pipeline/steps -run 'TestBuildTestingSummaryForPR_(SeparatesMixedEvidenceBlocks|RendersEvidenceArtifactsCompactly|BitbucketCloudOmitsHTMLAndKeepsEvidence)$' -count=1 -v`
- <code>Generated `BuildTestingSummaryForPR` output for an inline → linked → inline → linked → linked evidence sequence and inspected the resulting Markdown artifact</code>
- <code>Removed the temporary evidence harness and confirmed `git status --short` was clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
