### PR TITLE
fix(scm/gitlab): drop unsupported --yes flag from glab mr update

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Safest local verification sequence after non-trivial changes:
 
 **GitLab Backend (`internal/scm/gitlab`)**
 
-- The backend is pinned against `glab v1.5x`, whose flag surface drifts between versions: the auth check must be host-scoped (`--hostname <host>`, falling back to unscoped only when the host is unknown), `glab mr list` no longer accepts `--state opened`, and the daemon's detached-HEAD worktree breaks `glab ci get`, so pipeline jobs are read via the branch-independent `glab api .../pipelines/<id>/jobs` REST endpoint.
+- The backend is pinned against `glab v1.5x`, whose flag surface drifts between versions: the auth check must be host-scoped (`--hostname <host>`, falling back to unscoped only when the host is unknown), `glab mr list` no longer accepts `--state opened`, `glab mr update` has no `-y`/`--yes` flag at all (unlike `mr create`, which does, so `UpdatePR` must not pass it), and the daemon's detached-HEAD worktree breaks `glab ci get`, so pipeline jobs are read via the branch-independent `glab api .../pipelines/<id>/jobs` REST endpoint.
 - The comments in `internal/scm/gitlab/gitlab.go` own the full rationale for each trap; extend them there when you hit new glab version drift.
 
 **Gitea Backend (`internal/scm/gitea`)**

--- a/internal/scm/gitlab/gitlab.go
+++ b/internal/scm/gitlab/gitlab.go
@@ -282,10 +282,12 @@ func (h *Host) UpdatePR(ctx context.Context, pr *scm.PR, content scm.PRContent) 
 	if id == "" && pr != nil {
 		id = pr.URL
 	}
+	// Unlike `glab mr create`, `glab mr update` (glab v1.5x) has no
+	// -y/--yes confirmation-skip flag at all; passing it fails the whole
+	// command with "unknown flag: --yes", so every UpdatePR call errored.
 	cmd := h.cmd(ctx, "glab", "mr", "update", id,
 		"--title", content.Title,
 		"--description", content.Body,
-		"--yes",
 	)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return nil, fmt.Errorf("glab mr update: %s: %w", strings.TrimSpace(string(out)), err)

--- a/internal/scm/gitlab/gitlab_test.go
+++ b/internal/scm/gitlab/gitlab_test.go
@@ -226,7 +226,7 @@ func TestFindPRWithoutIIDKeepsNumberEmptyAndUpdatesByNumberFromURL(t *testing.T)
 		"glab mr list --source-branch " + branch + " --target-branch main --output json": {
 			stdout: fmt.Sprintf(`[{"web_url":%q}]`+"\n", url),
 		},
-		"glab mr update 42 --title updated --description body --yes": {
+		"glab mr update 42 --title updated --description body": {
 			stdout: "updated\n",
 		},
 	}), nil, "", "")
@@ -245,6 +245,31 @@ func TestFindPRWithoutIIDKeepsNumberEmptyAndUpdatesByNumberFromURL(t *testing.T)
 		t.Fatalf("FindPR() URL = %q, want %q", pr.URL, url)
 	}
 
+	updated, err := host.UpdatePR(context.Background(), pr, scm.PRContent{Title: "updated", Body: "body"})
+	if err != nil {
+		t.Fatalf("UpdatePR() error = %v", err)
+	}
+	if updated != pr {
+		t.Fatalf("UpdatePR() returned unexpected PR: %+v", updated)
+	}
+}
+
+// TestUpdatePRDoesNotPassUnsupportedYesFlag guards against reintroducing
+// -y/--yes on `glab mr update`: unlike `glab mr create`, glab v1.5x's
+// `mr update` has no such flag, so passing it fails the whole command with
+// "unknown flag: --yes" and every UpdatePR call errors. The fake CmdFactory
+// below matches by exact command string, so a regression here would hit the
+// "unexpected command" fallback and surface as an UpdatePR error.
+func TestUpdatePRDoesNotPassUnsupportedYesFlag(t *testing.T) {
+	t.Parallel()
+
+	host := New(gitlabTestCmdFactory(map[string]gitlabTestResponse{
+		"glab mr update 7 --title updated --description body": {
+			stdout: "updated\n",
+		},
+	}), nil, "", "")
+
+	pr := &scm.PR{Number: "7"}
 	updated, err := host.UpdatePR(context.Background(), pr, scm.PRContent{Title: "updated", Body: "body"})
 	if err != nil {
 		t.Fatalf("UpdatePR() error = %v", err)


### PR DESCRIPTION
## Summary

`glab mr update` (glab v1.5x) has no `-y`/`--yes` confirmation-skip flag - unlike `glab mr create`, which does support it.
The GitLab `Host.UpdatePR` implementation passed `--yes` unconditionally, so every call to `glab mr update` failed with `unknown flag: --yes`, and every GitLab-backed PR-content update errored.

Verified against the pinned `glab v1.53.0` CLI: `glab mr update --help` lists no `--yes`/`-y` flag, while `glab mr create --help` does.

## Changes

- Drop the unsupported `--yes` flag from the `glab mr update` invocation in `internal/scm/gitlab/gitlab.go`, with a comment recording the flag-surface drift (matching the existing documented traps for `glab mr list --state opened` and `glab ci get` in a detached-HEAD worktree).
- Update the existing `UpdatePR` test's expected command string, and add a dedicated regression test (`TestUpdatePRDoesNotPassUnsupportedYesFlag`) that fails if `--yes` is ever reintroduced.

## Test plan

- [x] `go test ./internal/scm/gitlab/...` - all tests pass, including the new regression test
- [x] `go vet ./...` / `make lint`
- [x] `go build ./cmd/no-mistakes`
- [x] Verified live against the pinned `glab v1.53.0` CLI that `mr update --help` has no `--yes`/`-y` flag
