### PR TITLE
feat(agent): accept Copilot as a disable_project_settings gate agent

### DIFF
--- a/docs/src/content/docs/reference/repo-config.md
+++ b/docs/src/content/docs/reference/repo-config.md
@@ -145,7 +145,7 @@ Suppress project-level agent settings and instructions for every gate-agent star
 
 This opt-in is intended for agent-orchestration repositories whose `AGENTS.md`, `CLAUDE.md`, or harness-specific project settings would give a validation agent an operator identity and authority that it must not adopt.
 When enabled, no-mistakes suppresses the target checkout's project settings for every agent-driven gate step while preserving user-level agent configuration.
-Codex, Claude, and Pi are the currently verified agents: Codex receives `project_doc_max_bytes=0` and `--ignore-rules`, Claude loads only its user setting source, and Pi runs with `--no-context-files` (preserving a pinned `--no-context-files` or `-nc` spelling).
+Codex, Claude, Pi, and Copilot are the currently verified agents: Codex receives `project_doc_max_bytes=0` and `--ignore-rules`, Claude loads only its user setting source, Pi runs with `--no-context-files` (preserving a pinned `--no-context-files` or `-nc` spelling), and Copilot runs with `--no-custom-instructions` (preserving a pinned `--no-custom-instructions` spelling; a `--custom-instructions` override fails closed).
 Grok 1.0.5 still discovers native project instructions and `.grok` project surfaces, so it is not a verified agent for this boundary. A configuration that resolves Grok while this option is enabled therefore fails closed before launch.
 The setting applies to both new and resumed sessions.
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -163,8 +163,8 @@ func NeutralizesGateInstructions(a Agent) bool {
 // the target checkout does not neutralize that checkout's project
 // agent-instruction files. Callers must invoke it before launching any gate
 // agent so an unverified harness is refused with a clear error rather than run
-// unneutralized in the target checkout. Only codex, claude, and pi have a verified
-// neutralization knob today.
+// unneutralized in the target checkout. Only codex, claude, pi, and copilot have a
+// verified neutralization knob today.
 func EnsureGateNeutralized(a Agent) error {
 	if a == nil {
 		return fmt.Errorf("no gate agent configured")
@@ -174,8 +174,8 @@ func EnsureGateNeutralized(a Agent) error {
 	}
 	return fmt.Errorf("gate agent %q does not neutralize the target repository's project "+
 		"agent-instruction files (AGENTS.md/CLAUDE.md); refusing to launch it in the target "+
-		"checkout. Only codex, claude, and pi have a verified neutralization knob (and only when it "+
-		"is not overridden by agent_args_override); set 'agent' to codex, claude, or pi in "+
+		"checkout. Only codex, claude, pi, and copilot have a verified neutralization knob (and only when it "+
+		"is not overridden by agent_args_override); set 'agent' to codex, claude, pi, or copilot in "+
 		"~/.no-mistakes/config.yaml", a.Name())
 }
 
@@ -1084,7 +1084,7 @@ func NewWithOptions(name types.AgentName, bin string, extraArgs []string, opts O
 			subprocessContext:      newSubprocessContext(opts.Environment),
 		}, nil
 	case types.AgentCopilot:
-		return &copilotAgent{bin: bin, extraArgs: extraArgs, subprocessContext: newSubprocessContext(opts.Environment)}, nil
+		return &copilotAgent{bin: bin, extraArgs: extraArgs, disableProjectSettings: opts.DisableProjectSettings, subprocessContext: newSubprocessContext(opts.Environment)}, nil
 	case types.AgentAntigravity:
 		return &antigravityAgent{bin: bin, extraArgs: extraArgs, subprocessContext: newSubprocessContext(opts.Environment)}, nil
 	default:

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -21,11 +21,31 @@ type copilotAgent struct {
 	bin       string
 	extraArgs []string
 	subprocessContext
+	// disableProjectSettings is the resolved, trusted-only opt-out. When true,
+	// buildArgs suppresses copilot's project-level custom-instructions surface.
+	disableProjectSettings bool
 }
 
 func (a *copilotAgent) Name() string { return "copilot" }
 
 func (a *copilotAgent) ReportsAgentAttempts() bool { return true }
+
+// NeutralizesGateInstructions reports whether copilot is currently launched with
+// the target repo's custom instructions (AGENTS.md and related files) suppressed.
+// It is meaningful only under the opt-out (disableProjectSettings): the gate only
+// consults it when the repo opted out. It is honest about the EFFECTIVE launch -
+// copilot's documented `--no-custom-instructions` flag ("Disable loading of custom
+// instructions from AGENTS.md and related files") is in effect iff the operator
+// did not re-enable the surface. buildArgs appends `--no-custom-instructions`
+// when the operator did not pin the surface themselves; an operator override
+// that re-enables custom instructions (`--custom-instructions`) defeats
+// neutralization, so this returns false and the gate fails closed rather than
+// running with repo instructions loaded. The flag is documented by Copilot CLI
+// 1.0.80 (`copilot --help`); live verification against a signed-in Copilot is
+// pending.
+func (a *copilotAgent) NeutralizesGateInstructions() bool {
+	return a.disableProjectSettings && copilotEffectiveCustomInstructionsSuppressed(a.extraArgs)
+}
 
 func (a *copilotAgent) Run(ctx context.Context, opts RunOpts) (*Result, error) {
 	return runWithRetry(ctx, "copilot", opts, claudeMaxRetries, classifyTransient, nil, func() (*Result, error) {
@@ -145,7 +165,7 @@ func copilotErrorDetail(copilotErr, stderr string) string {
 // added; --no-ask-user is always added so the agent never blocks waiting for
 // interactive input.
 func (a *copilotAgent) buildArgs() []string {
-	args := make([]string, 0, len(a.extraArgs)+6)
+	args := make([]string, 0, len(a.extraArgs)+7)
 	args = append(args, a.extraArgs...)
 	args = append(args,
 		"--output-format", "json",
@@ -156,6 +176,18 @@ func (a *copilotAgent) buildArgs() []string {
 	}
 	if !copilotUserSetPermissionMode(a.extraArgs) {
 		args = append(args, "--allow-all-tools")
+	}
+	// Project-settings opt-out (trusted-only; see config.DisableProjectSettings):
+	// disable loading of custom instructions from AGENTS.md and related files so
+	// an agent-orchestration target cannot install a fleet-captain identity on
+	// the gate agent. Copilot CLI documents `--no-custom-instructions` for this
+	// surface. Skipped only when the operator already controlled the surface
+	// (their choice wins; NeutralizesGateInstructions then fails closed if that
+	// value re-enables custom instructions). When the repo did not opt out,
+	// nothing is added and copilot loads custom instructions exactly as before
+	// (backward-compat). Live verification against a signed-in Copilot is pending.
+	if a.disableProjectSettings && !copilotUserSetCustomInstructions(a.extraArgs) {
+		args = append(args, "--no-custom-instructions")
 	}
 	return args
 }
@@ -191,6 +223,45 @@ func copilotUserSetAskUser(extraArgs []string) bool {
 		}
 	}
 	return false
+}
+
+// copilotUserSetCustomInstructions reports whether extraArgs already control
+// Copilot's custom-instructions surface, in which case buildArgs skips its
+// default --no-custom-instructions.
+func copilotUserSetCustomInstructions(extraArgs []string) bool {
+	_, pinned := copilotUserCustomInstructions(extraArgs)
+	return pinned
+}
+
+// copilotUserCustomInstructions returns whether extraArgs pin the custom-
+// instructions surface (last occurrence wins) and whether that pin suppresses
+// AGENTS.md. `--no-custom-instructions` suppresses; `--custom-instructions`
+// re-enables. Handles both bare flags and `--flag=` forms.
+func copilotUserCustomInstructions(extraArgs []string) (suppressed bool, pinned bool) {
+	for _, arg := range extraArgs {
+		switch {
+		case arg == "--no-custom-instructions", strings.HasPrefix(arg, "--no-custom-instructions="):
+			suppressed = true
+			pinned = true
+		case arg == "--custom-instructions", strings.HasPrefix(arg, "--custom-instructions="):
+			suppressed = false
+			pinned = true
+		}
+	}
+	return suppressed, pinned
+}
+
+// copilotEffectiveCustomInstructionsSuppressed reports whether the EFFECTIVE
+// copilot launch suppresses custom instructions from AGENTS.md and related
+// files: true when the operator did not pin the surface (buildArgs appends
+// --no-custom-instructions) or pinned --no-custom-instructions themselves, and
+// false when the operator re-enabled custom instructions.
+func copilotEffectiveCustomInstructionsSuppressed(extraArgs []string) bool {
+	suppressed, pinned := copilotUserCustomInstructions(extraArgs)
+	if !pinned {
+		return true // buildArgs appends --no-custom-instructions
+	}
+	return suppressed
 }
 
 // buildCopilotPrompt appends a JSON-output contract to the user prompt when a

--- a/internal/agent/copilot.go
+++ b/internal/agent/copilot.go
@@ -40,9 +40,12 @@ func (a *copilotAgent) ReportsAgentAttempts() bool { return true }
 // when the operator did not pin the surface themselves; an operator override
 // that re-enables custom instructions (`--custom-instructions`) defeats
 // neutralization, so this returns false and the gate fails closed rather than
-// running with repo instructions loaded. The flag is documented by Copilot CLI
-// 1.0.80 (`copilot --help`); live verification against a signed-in Copilot is
-// pending.
+// running with repo instructions loaded. Verified empirically against Copilot
+// CLI 1.0.80: with AGENTS.md loaded copilot adopts the target identity; with
+// --no-custom-instructions it does not. The flag stops AGENTS.md being loaded
+// automatically; an agent explicitly told to go find instruction files can still
+// read one off disk with its own tools. That is outside what this knob claims,
+// and the same is true of the other adapters.
 func (a *copilotAgent) NeutralizesGateInstructions() bool {
 	return a.disableProjectSettings && copilotEffectiveCustomInstructionsSuppressed(a.extraArgs)
 }
@@ -185,7 +188,7 @@ func (a *copilotAgent) buildArgs() []string {
 	// (their choice wins; NeutralizesGateInstructions then fails closed if that
 	// value re-enables custom instructions). When the repo did not opt out,
 	// nothing is added and copilot loads custom instructions exactly as before
-	// (backward-compat). Live verification against a signed-in Copilot is pending.
+	// (backward-compat).
 	if a.disableProjectSettings && !copilotUserSetCustomInstructions(a.extraArgs) {
 		args = append(args, "--no-custom-instructions")
 	}

--- a/internal/agent/copilot_test.go
+++ b/internal/agent/copilot_test.go
@@ -112,9 +112,9 @@ func TestCopilotAgent_BuildArgs_UserAskUserSuppressesDefault(t *testing.T) {
 
 // TestCopilotAgent_BuildArgs_SuppressesCustomInstructionsUnderOptOut locks in
 // the copilot project-settings contract UNDER the trusted opt-out: copilot is
-// told not to load AGENTS.md and related files. The flag is documented by
-// Copilot CLI (`--no-custom-instructions`); live verification against a
-// signed-in Copilot is pending.
+// told not to load AGENTS.md and related files. Verified empirically against
+// Copilot CLI 1.0.80: with AGENTS.md loaded copilot adopts the target identity;
+// with --no-custom-instructions it does not.
 func TestCopilotAgent_BuildArgs_SuppressesCustomInstructionsUnderOptOut(t *testing.T) {
 	ca := &copilotAgent{bin: "copilot", disableProjectSettings: true}
 	args := ca.buildArgs()

--- a/internal/agent/copilot_test.go
+++ b/internal/agent/copilot_test.go
@@ -110,6 +110,85 @@ func TestCopilotAgent_BuildArgs_UserAskUserSuppressesDefault(t *testing.T) {
 	}
 }
 
+// TestCopilotAgent_BuildArgs_SuppressesCustomInstructionsUnderOptOut locks in
+// the copilot project-settings contract UNDER the trusted opt-out: copilot is
+// told not to load AGENTS.md and related files. The flag is documented by
+// Copilot CLI (`--no-custom-instructions`); live verification against a
+// signed-in Copilot is pending.
+func TestCopilotAgent_BuildArgs_SuppressesCustomInstructionsUnderOptOut(t *testing.T) {
+	ca := &copilotAgent{bin: "copilot", disableProjectSettings: true}
+	args := ca.buildArgs()
+	if !copilotArgsContain(args, "--no-custom-instructions") {
+		t.Errorf("buildArgs = %v, want --no-custom-instructions", args)
+	}
+}
+
+// TestCopilotAgent_BuildArgs_NoSuppressionWithoutOptOut is the backward-compat
+// guarantee: without the opt-out, copilot adds no suppression and loads custom
+// instructions exactly as before.
+func TestCopilotAgent_BuildArgs_NoSuppressionWithoutOptOut(t *testing.T) {
+	ca := &copilotAgent{bin: "copilot"}
+	args := ca.buildArgs()
+	if copilotArgsContain(args, "--no-custom-instructions") {
+		t.Errorf("buildArgs = %v, must add no suppression when the repo did not opt out", args)
+	}
+}
+
+// TestCopilotAgent_BuildArgs_UserCustomInstructionsOverrideWins ensures an
+// operator who pinned the custom-instructions surface is not double-set even
+// under opt-out, and that re-enabling the surface defeats neutralization.
+func TestCopilotAgent_BuildArgs_UserCustomInstructionsOverrideWins(t *testing.T) {
+	ca := &copilotAgent{bin: "copilot", disableProjectSettings: true, extraArgs: []string{"--custom-instructions"}}
+	args := ca.buildArgs()
+	if copilotArgsContain(args, "--no-custom-instructions") {
+		t.Errorf("buildArgs = %v, must not add --no-custom-instructions over a user --custom-instructions", args)
+	}
+	if ca.NeutralizesGateInstructions() {
+		t.Error("copilot with --custom-instructions must not report neutralized")
+	}
+}
+
+func TestCopilotAgent_NeutralizesGateInstructions(t *testing.T) {
+	if NeutralizesGateInstructions(&copilotAgent{bin: "copilot"}) {
+		t.Error("copilot must not report neutralized without the opt-out")
+	}
+	if !NeutralizesGateInstructions(&copilotAgent{bin: "copilot", disableProjectSettings: true}) {
+		t.Error("copilot must report neutralized under the opt-out")
+	}
+	if !NeutralizesGateInstructions(&copilotAgent{bin: "copilot", disableProjectSettings: true, extraArgs: []string{"--no-custom-instructions"}}) {
+		t.Error("copilot with an explicit --no-custom-instructions must stay neutralized")
+	}
+	if NeutralizesGateInstructions(&copilotAgent{bin: "copilot", disableProjectSettings: true, extraArgs: []string{"--custom-instructions"}}) {
+		t.Error("copilot with --custom-instructions must fail closed")
+	}
+}
+
+func TestCopilotAgent_BuildArgs_DoesNotDuplicateNoCustomInstructions(t *testing.T) {
+	ca := &copilotAgent{bin: "copilot", disableProjectSettings: true, extraArgs: []string{"--no-custom-instructions"}}
+	args := ca.buildArgs()
+	count := 0
+	for _, a := range args {
+		if a == "--no-custom-instructions" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected single --no-custom-instructions, got %d: %v", count, args)
+	}
+	if !ca.NeutralizesGateInstructions() {
+		t.Error("copilot with an explicit --no-custom-instructions must stay neutralized")
+	}
+}
+
+func copilotArgsContain(args []string, flag string) bool {
+	for _, a := range args {
+		if a == flag {
+			return true
+		}
+	}
+	return false
+}
+
 func TestBuildCopilotPrompt_InlinesSchema(t *testing.T) {
 	schema := json.RawMessage(`{"type":"object","properties":{"ok":{"type":"boolean"}}}`)
 	prompt := buildCopilotPrompt("do the thing", schema)

--- a/internal/agent/gateneutralize_test.go
+++ b/internal/agent/gateneutralize_test.go
@@ -22,9 +22,8 @@ func optOutAgent(t *testing.T, name types.AgentName, extraArgs []string) Agent {
 // fail-closed contract: under the opt-out, only codex, claude, pi, and copilot
 // neutralize the target repo's project agent settings/instructions; every other
 // harness reports false and is refused rather than launched with project
-// instructions loaded. Codex, claude, and pi knobs are empirically verified;
-// copilot's --no-custom-instructions is documented by the CLI (live verification
-// pending).
+// instructions loaded. Codex, claude, pi, and copilot knobs are empirically
+// verified.
 func TestNeutralizesGateInstructions_OnlyVerifiedHarnessesUnderOptOut(t *testing.T) {
 	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentPi, types.AgentCopilot} {
 		if !NeutralizesGateInstructions(optOutAgent(t, name, nil)) {

--- a/internal/agent/gateneutralize_test.go
+++ b/internal/agent/gateneutralize_test.go
@@ -19,17 +19,19 @@ func optOutAgent(t *testing.T, name types.AgentName, extraArgs []string) Agent {
 }
 
 // TestNeutralizesGateInstructions_OnlyVerifiedHarnessesUnderOptOut is the core
-// fail-closed contract: under the opt-out, only codex, claude, and pi (whose
-// suppression knobs are empirically verified) neutralize the target repo's
-// project agent settings/instructions; every other harness reports false and is
-// refused rather than launched with project instructions loaded.
+// fail-closed contract: under the opt-out, only codex, claude, pi, and copilot
+// neutralize the target repo's project agent settings/instructions; every other
+// harness reports false and is refused rather than launched with project
+// instructions loaded. Codex, claude, and pi knobs are empirically verified;
+// copilot's --no-custom-instructions is documented by the CLI (live verification
+// pending).
 func TestNeutralizesGateInstructions_OnlyVerifiedHarnessesUnderOptOut(t *testing.T) {
-	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentPi} {
+	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentPi, types.AgentCopilot} {
 		if !NeutralizesGateInstructions(optOutAgent(t, name, nil)) {
 			t.Errorf("%s must neutralize under the opt-out with its default knob", name)
 		}
 	}
-	unverified := []types.AgentName{types.AgentGrok, types.AgentOpenCode, types.AgentCopilot, types.AgentRovoDev}
+	unverified := []types.AgentName{types.AgentGrok, types.AgentOpenCode, types.AgentRovoDev}
 	for _, name := range unverified {
 		if NeutralizesGateInstructions(optOutAgent(t, name, nil)) {
 			t.Errorf("%s has no verified knob; must NOT report neutralized", name)
@@ -50,11 +52,11 @@ func TestNeutralizesGateInstructions_OnlyVerifiedHarnessesUnderOptOut(t *testing
 	}
 }
 
-// TestNeutralizesGateInstructions_FalseWithoutOptOut proves codex, claude, and pi
-// do NOT claim neutralization when the repo did not opt out - the gate only consults
-// this under the opt-out, but the value must be honest.
+// TestNeutralizesGateInstructions_FalseWithoutOptOut proves codex, claude, pi,
+// and copilot do NOT claim neutralization when the repo did not opt out - the
+// gate only consults this under the opt-out, but the value must be honest.
 func TestNeutralizesGateInstructions_FalseWithoutOptOut(t *testing.T) {
-	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentPi, types.AgentGrok} {
+	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentPi, types.AgentCopilot, types.AgentGrok} {
 		a, err := NewWithOptions(name, string(name), nil, Options{}) // no opt-out
 		if err != nil {
 			t.Fatalf("NewWithOptions(%s): %v", name, err)
@@ -66,7 +68,7 @@ func TestNeutralizesGateInstructions_FalseWithoutOptOut(t *testing.T) {
 }
 
 // TestEnsureGateNeutralized_RefusesUnsupportedUnderOptOut proves the gate fails
-// closed for an unsupported harness and admits codex, claude, and pi.
+// closed for an unsupported harness and admits codex, claude, pi, and copilot.
 func TestEnsureGateNeutralized_RefusesUnsupportedUnderOptOut(t *testing.T) {
 	if err := EnsureGateNeutralized(optOutAgent(t, types.AgentCodex, nil)); err != nil {
 		t.Errorf("codex must pass the gate under opt-out: %v", err)
@@ -76,6 +78,9 @@ func TestEnsureGateNeutralized_RefusesUnsupportedUnderOptOut(t *testing.T) {
 	}
 	if err := EnsureGateNeutralized(optOutAgent(t, types.AgentPi, nil)); err != nil {
 		t.Errorf("pi must pass the gate under opt-out: %v", err)
+	}
+	if err := EnsureGateNeutralized(optOutAgent(t, types.AgentCopilot, nil)); err != nil {
+		t.Errorf("copilot must pass the gate under opt-out: %v", err)
 	}
 	if err := EnsureGateNeutralized(optOutAgent(t, types.AgentGrok, nil)); err == nil {
 		t.Error("grok must remain refused until project-setting isolation is empirically verified")
@@ -151,5 +156,16 @@ func TestNeutralizesGateInstructions_HonestOnEffectiveOverride(t *testing.T) {
 	}
 	if !NeutralizesGateInstructions(optOutAgent(t, types.AgentPi, []string{"-nc"})) {
 		t.Error("pi with an explicit -nc must stay neutralized")
+	}
+	// copilot: --no-custom-instructions preserves suppression -> admitted.
+	if !NeutralizesGateInstructions(optOutAgent(t, types.AgentCopilot, []string{"--no-custom-instructions"})) {
+		t.Error("copilot with an explicit --no-custom-instructions must stay neutralized")
+	}
+	// copilot: --custom-instructions re-enables AGENTS.md -> fails closed.
+	if NeutralizesGateInstructions(optOutAgent(t, types.AgentCopilot, []string{"--custom-instructions"})) {
+		t.Error("copilot with --custom-instructions must fail closed")
+	}
+	if err := EnsureGateNeutralized(optOutAgent(t, types.AgentCopilot, []string{"--custom-instructions"})); err == nil {
+		t.Error("copilot with the knob defeated must be refused by the gate")
 	}
 }

--- a/internal/daemon/gateneutralize_test.go
+++ b/internal/daemon/gateneutralize_test.go
@@ -19,7 +19,7 @@ func fakeLookPath(bin string) (string, error) { return "/fake/bin/" + bin, nil }
 // opt-out (disable_project_settings=true), a verified harness passes the gate and
 // its pipeline agent reports neutralized.
 func TestNewPipelineAgent_OptOut_AdmitsVerifiedHarness(t *testing.T) {
-	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentPi} {
+	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentPi, types.AgentCopilot} {
 		cfg := &config.Config{Agent: name, DisableProjectSettings: true}
 		ag, err := newPipelineAgent(context.Background(), cfg, t.TempDir(), fakeLookPath, runenv.Overlay{})
 		if err != nil {
@@ -37,7 +37,7 @@ func TestNewPipelineAgent_OptOut_AdmitsVerifiedHarness(t *testing.T) {
 // verified neutralization knob is refused rather than launched with project
 // instructions loaded.
 func TestNewPipelineAgent_OptOut_RefusesUnverifiedHarness(t *testing.T) {
-	for _, name := range []types.AgentName{types.AgentGrok, types.AgentOpenCode, types.AgentCopilot} {
+	for _, name := range []types.AgentName{types.AgentGrok, types.AgentOpenCode} {
 		cfg := &config.Config{Agent: name, DisableProjectSettings: true}
 		if _, err := newPipelineAgent(context.Background(), cfg, t.TempDir(), fakeLookPath, runenv.Overlay{}); err == nil {
 			t.Fatalf("%s must be refused under opt-out", name)
@@ -52,8 +52,8 @@ func TestNewPipelineAgent_OptOut_RefusesUnverifiedHarness(t *testing.T) {
 // no suppression knob - is admitted and runs exactly as before.
 func TestNewPipelineAgent_NoOptOut_AdmitsEveryHarness(t *testing.T) {
 	// rovodev is omitted: its resolution runs a real version probe that a fake
-	// binary path cannot satisfy. opencode/pi/copilot already prove that an
-	// unverified adapter is admitted when the repo did not opt out.
+	// binary path cannot satisfy. opencode already proves that an unverified
+	// adapter is admitted when the repo did not opt out.
 	for _, name := range []types.AgentName{types.AgentCodex, types.AgentClaude, types.AgentGrok, types.AgentOpenCode, types.AgentPi, types.AgentCopilot} {
 		cfg := &config.Config{Agent: name} // DisableProjectSettings defaults false
 		ag, err := newPipelineAgent(context.Background(), cfg, t.TempDir(), fakeLookPath, runenv.Overlay{})


### PR DESCRIPTION
## Summary

The `disable_project_settings` gate refuses any review/gate agent that cannot suppress the target repository's AGENTS.md, CLAUDE.md, and related project instruction files. A repo's own instructions must not be able to influence the agent judging it. Copilot was previously in the unverified set and was refused under that opt-out.

Copilot CLI 1.0.80 documents `--no-custom-instructions` as: "Disable loading of custom instructions from AGENTS.md and related files". This change teaches no-mistakes about that knob so Copilot is admitted as a validation-gate agent when the trusted opt-out is on.

## What was tested

Controlled A/B in a scratch directory containing an AGENTS.md that instructed the agent to prefix every reply with PURPLE-BADGER, on Copilot CLI 1.0.80:

- control, no flag: `copilot -C <dir> -p "Say hello in exactly five words." --allow-all-tools` replied "PURPLE-BADGER Hello there dear friend." - identity adopted.
- treatment, with `--no-custom-instructions`: same prompt replied "Hello there, wishing you well." - identity NOT adopted.

That is the automatic-load surface the flag documents. It was not tested against an agent that was explicitly told to go find instruction files on disk, and Copilot was not otherwise exercised as a live gate agent in this change.

## Behaviour

- Under the trusted `disable_project_settings` opt-out, Copilot is launched with `--no-custom-instructions` and `NeutralizesGateInstructions` returns true, so the gate admits it.
- An operator `agent_args_override` that re-enables custom instructions (`--custom-instructions`) makes `NeutralizesGateInstructions` return false, so the gate fails closed rather than running with repo instructions loaded.
- Repos that have not opted in see no change: Copilot still loads custom instructions exactly as before.

## Scope note

The flag stops AGENTS.md being loaded automatically, but an agent explicitly told to go find instruction files can still read one off disk with its own tools. That is outside what this knob claims, and the same is true of the other adapters (Codex, Claude, Pi).
