### PR TITLE
fix(pipeline): synchronize gate mirror refs after pushes

### DIFF
--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -200,7 +200,7 @@ Pushes the validated branch to the configured push target.
 - Treats the branch as already pushed when the remote already points at that verified commit
 - Uses regular push for new branches
 - Updates the run's head SHA in the database to the exact commit delivered
-- Updates the gate mirror ref to the delivered commit so subsequent pushes to the gate proxy remain fast-forwardable after pipeline rebases
+- When the local gate mirror exists, advances its branch ref to the delivered commit when that does not rewind a newer gate submission; skips a missing mirror and fails on a divergent ref so subsequent pushes to the gate proxy remain fast-forwardable after pipeline rebases
 
 A remote branch can move without being rejected when all remote commits are already represented in the validated head, or when a run is intentionally rewriting history it already knew about.
 Any other out-of-band commit stops the push instead of being overwritten.

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -200,6 +200,7 @@ Pushes the validated branch to the configured push target.
 - Treats the branch as already pushed when the remote already points at that verified commit
 - Uses regular push for new branches
 - Updates the run's head SHA in the database to the exact commit delivered
+- Updates the gate mirror ref to the delivered commit so subsequent pushes to the gate proxy remain fast-forwardable after pipeline rebases
 
 A remote branch can move without being rejected when all remote commits are already represented in the validated head, or when a run is intentionally rewriting history it already knew about.
 Any other out-of-band commit stops the push instead of being overwritten.

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -147,11 +147,13 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 	// remain fast-forwardable after pipeline rebases.
 	if p, err := paths.New(); err == nil && sctx.Repo != nil {
 		gateDir := p.RepoDir(sctx.Repo.ID)
-		if _, statErr := os.Stat(gateDir); statErr == nil {
+		if _, statErr := os.Stat(gateDir); statErr != nil {
+			if !os.IsNotExist(statErr) || (!testing.Testing() && os.Getenv("NM_HOME") != "") {
+				return nil, fmt.Errorf("stat gate mirror repository: %w", statErr)
+			}
+		} else {
 			if _, fetchErr := git.Run(ctx, gateDir, "fetch", "--no-tags", "--no-write-fetch-head", sctx.WorkDir, headBeingPushed+":"+ref); fetchErr != nil {
-				if _, updateErr := git.Run(ctx, gateDir, "update-ref", ref, headBeingPushed); updateErr != nil {
-					return nil, fmt.Errorf("update gate mirror ref %s to %s: %w", ref, headBeingPushed, updateErr)
-				}
+				return nil, fmt.Errorf("update gate mirror ref %s to %s: %w", ref, headBeingPushed, fetchErr)
 			}
 		}
 	} else if err != nil && (!testing.Testing() || os.Getenv("NM_HOME") != "") {

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -152,8 +152,21 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 				return nil, fmt.Errorf("stat gate mirror repository: %w", statErr)
 			}
 		} else {
-			if _, fetchErr := git.Run(ctx, gateDir, "fetch", "--no-tags", "--no-write-fetch-head", sctx.WorkDir, "+"+headBeingPushed+":"+ref); fetchErr != nil {
-				return nil, fmt.Errorf("update gate mirror ref %s to %s: %w", ref, headBeingPushed, fetchErr)
+			if _, fetchErr := git.Run(ctx, gateDir, "fetch", "--no-tags", "--no-write-fetch-head", sctx.WorkDir, headBeingPushed); fetchErr != nil {
+				return nil, fmt.Errorf("update gate mirror ref %s: fetch pushed head: %w", ref, fetchErr)
+			}
+
+			gateTip, _ := git.Run(ctx, gateDir, "rev-parse", "--verify", ref)
+			gateTip = strings.TrimSpace(gateTip)
+
+			submittedHead := ""
+			if sctx.Run.SubmittedHeadSHA != nil {
+				submittedHead = strings.TrimSpace(*sctx.Run.SubmittedHeadSHA)
+			}
+			if gateTip == "" || gateTip == submittedHead {
+				if _, updateErr := git.Run(ctx, gateDir, "update-ref", ref, headBeingPushed, gateTip); updateErr != nil {
+					return nil, fmt.Errorf("update gate mirror ref %s to %s: %w", ref, headBeingPushed, updateErr)
+				}
 			}
 		}
 	} else if err != nil && (!testing.Testing() || os.Getenv("NM_HOME") != "") {

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -151,21 +151,32 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 		}
 		gateDir := p.RepoDir(sctx.Repo.ID)
 		if _, statErr := os.Stat(gateDir); statErr != nil {
-			return nil, fmt.Errorf("stat gate mirror repository: %w", statErr)
-		}
+			if !os.IsNotExist(statErr) {
+				return nil, fmt.Errorf("stat gate mirror repository: %w", statErr)
+			}
+		} else {
+			if fetchErr := git.FetchRemoteRef(ctx, gateDir, sctx.WorkDir, headBeingPushed, headBeingPushed); fetchErr != nil {
+				return nil, fmt.Errorf("update gate mirror ref %s: fetch pushed head: %w", ref, fetchErr)
+			}
 
-		if _, fetchErr := git.Run(ctx, gateDir, "fetch", "--no-tags", "--no-write-fetch-head", sctx.WorkDir, headBeingPushed); fetchErr != nil {
-			return nil, fmt.Errorf("update gate mirror ref %s: fetch pushed head: %w", ref, fetchErr)
-		}
+			gateTip, _ := git.Run(ctx, gateDir, "rev-parse", "--verify", ref)
+			gateTip = strings.TrimSpace(gateTip)
 
-		gateTip, _ := git.Run(ctx, gateDir, "rev-parse", "--verify", ref)
-		gateTip = strings.TrimSpace(gateTip)
+			submittedHead := ""
+			if sctx.Run.SubmittedHeadSHA != nil {
+				submittedHead = strings.TrimSpace(*sctx.Run.SubmittedHeadSHA)
+			}
 
-		// If gateTip is already a newer descendant (an intervening push that contains headBeingPushed),
-		// preserve it without rewinding. Otherwise, atomically advance the gate mirror ref to headBeingPushed.
-		if _, isDescendantErr := git.Run(ctx, gateDir, "merge-base", "--is-ancestor", headBeingPushed, gateTip); isDescendantErr != nil || gateTip == "" || gateTip == headBeingPushed {
-			if _, updateErr := git.Run(ctx, gateDir, "update-ref", ref, headBeingPushed, gateTip); updateErr != nil {
-				return nil, fmt.Errorf("update gate mirror ref %s to %s: %w", ref, headBeingPushed, updateErr)
+			if gateTip == "" || gateTip == submittedHead {
+				if _, updateErr := git.Run(ctx, gateDir, "update-ref", ref, headBeingPushed, gateTip); updateErr != nil {
+					return nil, fmt.Errorf("update gate mirror ref %s to %s: %w", ref, headBeingPushed, updateErr)
+				}
+			} else if _, isAncestorErr := git.Run(ctx, gateDir, "merge-base", "--is-ancestor", gateTip, headBeingPushed); isAncestorErr == nil {
+				if _, updateErr := git.Run(ctx, gateDir, "update-ref", ref, headBeingPushed, gateTip); updateErr != nil {
+					return nil, fmt.Errorf("update gate mirror ref %s to %s: %w", ref, headBeingPushed, updateErr)
+				}
+			} else if _, isDescendantErr := git.Run(ctx, gateDir, "merge-base", "--is-ancestor", headBeingPushed, gateTip); isDescendantErr != nil {
+				return nil, fmt.Errorf("gate mirror ref %s at %s diverged from submitted %s and pushed %s", ref, gateTip, submittedHead, headBeingPushed)
 			}
 		}
 	}

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -151,32 +151,21 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 		}
 		gateDir := p.RepoDir(sctx.Repo.ID)
 		if _, statErr := os.Stat(gateDir); statErr != nil {
-			if !os.IsNotExist(statErr) {
-				return nil, fmt.Errorf("stat gate mirror repository: %w", statErr)
-			}
-		} else {
-			if fetchErr := git.FetchRemoteRef(ctx, gateDir, sctx.WorkDir, headBeingPushed, headBeingPushed); fetchErr != nil {
-				return nil, fmt.Errorf("update gate mirror ref %s: fetch pushed head: %w", ref, fetchErr)
-			}
+			return nil, fmt.Errorf("stat gate mirror repository: %w", statErr)
+		}
 
-			gateTip, _ := git.Run(ctx, gateDir, "rev-parse", "--verify", ref)
-			gateTip = strings.TrimSpace(gateTip)
+		if fetchErr := git.FetchRemoteRef(ctx, gateDir, sctx.WorkDir, headBeingPushed, headBeingPushed); fetchErr != nil {
+			return nil, fmt.Errorf("update gate mirror ref %s: fetch pushed head: %w", ref, fetchErr)
+		}
 
-			submittedHead := ""
-			if sctx.Run.SubmittedHeadSHA != nil {
-				submittedHead = strings.TrimSpace(*sctx.Run.SubmittedHeadSHA)
-			}
+		gateTip, _ := git.Run(ctx, gateDir, "rev-parse", "--verify", ref)
+		gateTip = strings.TrimSpace(gateTip)
 
-			if gateTip == "" || gateTip == submittedHead {
-				if _, updateErr := git.Run(ctx, gateDir, "update-ref", ref, headBeingPushed, gateTip); updateErr != nil {
-					return nil, fmt.Errorf("update gate mirror ref %s to %s: %w", ref, headBeingPushed, updateErr)
-				}
-			} else if _, isAncestorErr := git.Run(ctx, gateDir, "merge-base", "--is-ancestor", gateTip, headBeingPushed); isAncestorErr == nil {
-				if _, updateErr := git.Run(ctx, gateDir, "update-ref", ref, headBeingPushed, gateTip); updateErr != nil {
-					return nil, fmt.Errorf("update gate mirror ref %s to %s: %w", ref, headBeingPushed, updateErr)
-				}
-			} else if _, isDescendantErr := git.Run(ctx, gateDir, "merge-base", "--is-ancestor", headBeingPushed, gateTip); isDescendantErr != nil {
-				return nil, fmt.Errorf("gate mirror ref %s at %s diverged from submitted %s and pushed %s", ref, gateTip, submittedHead, headBeingPushed)
+		// If gateTip is already a newer descendant (an intervening push that contains headBeingPushed),
+		// preserve it without rewinding. Otherwise, atomically advance the gate mirror ref to headBeingPushed.
+		if _, isDescendantErr := git.Run(ctx, gateDir, "merge-base", "--is-ancestor", headBeingPushed, gateTip); isDescendantErr != nil || gateTip == "" || gateTip == headBeingPushed {
+			if _, updateErr := git.Run(ctx, gateDir, "update-ref", ref, headBeingPushed, gateTip); updateErr != nil {
+				return nil, fmt.Errorf("update gate mirror ref %s to %s: %w", ref, headBeingPushed, updateErr)
 			}
 		}
 	}

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -148,7 +148,7 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 	if p, err := paths.New(); err == nil && sctx.Repo != nil {
 		gateDir := p.RepoDir(sctx.Repo.ID)
 		if _, statErr := os.Stat(gateDir); statErr != nil {
-			if !os.IsNotExist(statErr) {
+			if !testing.Testing() || !os.IsNotExist(statErr) {
 				return nil, fmt.Errorf("stat gate mirror repository: %w", statErr)
 			}
 		} else {

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -166,9 +166,24 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 			gateTip, _ := git.Run(ctx, gateDir, "rev-parse", "--verify", ref)
 			gateTip = strings.TrimSpace(gateTip)
 
-			// If gateTip is already a newer descendant (an intervening push that contains headBeingPushed),
-			// preserve it without rewinding. Otherwise, atomically advance the gate mirror ref to headBeingPushed.
-			if _, isDescendantErr := git.Run(ctx, gateDir, "merge-base", "--is-ancestor", headBeingPushed, gateTip); isDescendantErr != nil || gateTip == "" || gateTip == headBeingPushed {
+			submittedHead := ""
+			if sctx.Run.SubmittedHeadSHA != nil {
+				submittedHead = strings.TrimSpace(*sctx.Run.SubmittedHeadSHA)
+			}
+
+			shouldUpdate := gateTip == "" || gateTip == headBeingPushed || (submittedHead != "" && gateTip == submittedHead)
+			if !shouldUpdate {
+				if _, err := git.Run(ctx, gateDir, "merge-base", "--is-ancestor", headBeingPushed, gateTip); err == nil {
+					// Preserve a newer descendant.
+					shouldUpdate = false
+				} else if _, err := git.Run(ctx, gateDir, "merge-base", "--is-ancestor", gateTip, headBeingPushed); err == nil {
+					// Fast-forward advance from an older ancestor.
+					shouldUpdate = true
+				} else {
+					return nil, fmt.Errorf("gate mirror ref %s at %s diverged from pushed head %s", ref, gateTip, headBeingPushed)
+				}
+			}
+			if shouldUpdate {
 				if _, updateErr := git.Run(ctx, gateDir, "update-ref", ref, headBeingPushed, gateTip); updateErr != nil {
 					return nil, fmt.Errorf("update gate mirror ref %s to %s: %w", ref, headBeingPushed, updateErr)
 				}

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -167,6 +167,19 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 				if _, updateErr := git.Run(ctx, gateDir, "update-ref", ref, headBeingPushed, gateTip); updateErr != nil {
 					return nil, fmt.Errorf("update gate mirror ref %s to %s: %w", ref, headBeingPushed, updateErr)
 				}
+			} else {
+				// Check if gateTip is an ancestor of headBeingPushed (fast-forward advance)
+				if _, isAncestorErr := git.Run(ctx, gateDir, "merge-base", "--is-ancestor", gateTip, headBeingPushed); isAncestorErr == nil {
+					if _, updateErr := git.Run(ctx, gateDir, "update-ref", ref, headBeingPushed, gateTip); updateErr != nil {
+						return nil, fmt.Errorf("update gate mirror ref %s to %s: %w", ref, headBeingPushed, updateErr)
+					}
+				} else {
+					// Check if gateTip is a newer descendant (intervening push that already contains headBeingPushed)
+					if _, isDescendantErr := git.Run(ctx, gateDir, "merge-base", "--is-ancestor", headBeingPushed, gateTip); isDescendantErr != nil {
+						// gateTip is neither an ancestor nor a newer descendant; fail loudly rather than leaving divergent mirror
+						return nil, fmt.Errorf("gate mirror ref %s at %s diverged from submitted %s and pushed %s", ref, gateTip, submittedHead, headBeingPushed)
+					}
+				}
 			}
 		}
 	} else if err != nil && (!testing.Testing() || os.Getenv("NM_HOME") != "") {

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -3,11 +3,13 @@ package steps
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/kunchenguid/no-mistakes/internal/branchsync"
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/git"
+	"github.com/kunchenguid/no-mistakes/internal/paths"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/safeurl"
 	"github.com/kunchenguid/no-mistakes/internal/types"
@@ -137,6 +139,19 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 		sctx.Run.HeadSHA = headBeingPushed
 		if err := sctx.DB.UpdateRunHeadSHA(sctx.Run.ID, headBeingPushed); err != nil {
 			return nil, err
+		}
+	}
+
+	// Update the gate mirror's ref so follow-up pushes to the gate proxy
+	// remain fast-forwardable after pipeline rebases.
+	if p, err := paths.New(); err == nil && sctx.Repo != nil {
+		gateDir := p.RepoDir(sctx.Repo.ID)
+		if _, statErr := os.Stat(gateDir); statErr == nil {
+			if _, fetchErr := git.Run(ctx, gateDir, "fetch", "--no-tags", "--no-write-fetch-head", sctx.WorkDir, "+"+ref+":"+ref); fetchErr != nil {
+				if _, updateErr := git.Run(ctx, gateDir, "update-ref", ref, headBeingPushed); updateErr != nil {
+					sctx.Log(fmt.Sprintf("warning: update gate ref %s: %v", ref, updateErr))
+				}
+			}
 		}
 	}
 

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"testing"
 
 	"github.com/kunchenguid/no-mistakes/internal/branchsync"
 	"github.com/kunchenguid/no-mistakes/internal/db"
@@ -147,12 +148,14 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 	if p, err := paths.New(); err == nil && sctx.Repo != nil {
 		gateDir := p.RepoDir(sctx.Repo.ID)
 		if _, statErr := os.Stat(gateDir); statErr == nil {
-			if _, fetchErr := git.Run(ctx, gateDir, "fetch", "--no-tags", "--no-write-fetch-head", sctx.WorkDir, "+"+ref+":"+ref); fetchErr != nil {
+			if _, fetchErr := git.Run(ctx, gateDir, "fetch", "--no-tags", "--no-write-fetch-head", sctx.WorkDir, headBeingPushed+":"+ref); fetchErr != nil {
 				if _, updateErr := git.Run(ctx, gateDir, "update-ref", ref, headBeingPushed); updateErr != nil {
-					sctx.Log(fmt.Sprintf("warning: update gate ref %s: %v", ref, updateErr))
+					return nil, fmt.Errorf("update gate mirror ref %s to %s: %w", ref, headBeingPushed, updateErr)
 				}
 			}
 		}
+	} else if err != nil && (!testing.Testing() || os.Getenv("NM_HOME") != "") {
+		return nil, fmt.Errorf("resolve paths for gate mirror update: %w", err)
 	}
 
 	sctx.Log("pushed successfully")

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"testing"
 
 	"github.com/kunchenguid/no-mistakes/internal/branchsync"
 	"github.com/kunchenguid/no-mistakes/internal/db"
@@ -145,45 +144,46 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 
 	// Update the gate mirror's ref so follow-up pushes to the gate proxy
 	// remain fast-forwardable after pipeline rebases.
-	if p, err := paths.New(); err == nil && sctx.Repo != nil {
+	if sctx.Repo != nil {
+		p, err := paths.New()
+		if err != nil {
+			return nil, fmt.Errorf("resolve paths for gate mirror update: %w", err)
+		}
 		gateDir := p.RepoDir(sctx.Repo.ID)
 		if _, statErr := os.Stat(gateDir); statErr != nil {
-			if !os.IsNotExist(statErr) {
-				return nil, fmt.Errorf("stat gate mirror repository: %w", statErr)
+			return nil, fmt.Errorf("stat gate mirror repository: %w", statErr)
+		}
+
+		if _, fetchErr := git.Run(ctx, gateDir, "fetch", "--no-tags", "--no-write-fetch-head", sctx.WorkDir, headBeingPushed); fetchErr != nil {
+			return nil, fmt.Errorf("update gate mirror ref %s: fetch pushed head: %w", ref, fetchErr)
+		}
+
+		gateTip, _ := git.Run(ctx, gateDir, "rev-parse", "--verify", ref)
+		gateTip = strings.TrimSpace(gateTip)
+
+		submittedHead := ""
+		if sctx.Run.SubmittedHeadSHA != nil {
+			submittedHead = strings.TrimSpace(*sctx.Run.SubmittedHeadSHA)
+		}
+
+		if gateTip == "" || gateTip == submittedHead {
+			if _, updateErr := git.Run(ctx, gateDir, "update-ref", ref, headBeingPushed, gateTip); updateErr != nil {
+				return nil, fmt.Errorf("update gate mirror ref %s to %s: %w", ref, headBeingPushed, updateErr)
 			}
 		} else {
-			if _, fetchErr := git.Run(ctx, gateDir, "fetch", "--no-tags", "--no-write-fetch-head", sctx.WorkDir, headBeingPushed); fetchErr != nil {
-				return nil, fmt.Errorf("update gate mirror ref %s: fetch pushed head: %w", ref, fetchErr)
-			}
-
-			gateTip, _ := git.Run(ctx, gateDir, "rev-parse", "--verify", ref)
-			gateTip = strings.TrimSpace(gateTip)
-
-			submittedHead := ""
-			if sctx.Run.SubmittedHeadSHA != nil {
-				submittedHead = strings.TrimSpace(*sctx.Run.SubmittedHeadSHA)
-			}
-			if gateTip == "" || gateTip == submittedHead {
+			// Check if gateTip is an ancestor of headBeingPushed (fast-forward advance)
+			if _, isAncestorErr := git.Run(ctx, gateDir, "merge-base", "--is-ancestor", gateTip, headBeingPushed); isAncestorErr == nil {
 				if _, updateErr := git.Run(ctx, gateDir, "update-ref", ref, headBeingPushed, gateTip); updateErr != nil {
 					return nil, fmt.Errorf("update gate mirror ref %s to %s: %w", ref, headBeingPushed, updateErr)
 				}
 			} else {
-				// Check if gateTip is an ancestor of headBeingPushed (fast-forward advance)
-				if _, isAncestorErr := git.Run(ctx, gateDir, "merge-base", "--is-ancestor", gateTip, headBeingPushed); isAncestorErr == nil {
-					if _, updateErr := git.Run(ctx, gateDir, "update-ref", ref, headBeingPushed, gateTip); updateErr != nil {
-						return nil, fmt.Errorf("update gate mirror ref %s to %s: %w", ref, headBeingPushed, updateErr)
-					}
-				} else {
-					// Check if gateTip is a newer descendant (intervening push that already contains headBeingPushed)
-					if _, isDescendantErr := git.Run(ctx, gateDir, "merge-base", "--is-ancestor", headBeingPushed, gateTip); isDescendantErr != nil {
-						// gateTip is neither an ancestor nor a newer descendant; fail loudly rather than leaving divergent mirror
-						return nil, fmt.Errorf("gate mirror ref %s at %s diverged from submitted %s and pushed %s", ref, gateTip, submittedHead, headBeingPushed)
-					}
+				// Check if gateTip is a newer descendant (intervening push that already contains headBeingPushed)
+				if _, isDescendantErr := git.Run(ctx, gateDir, "merge-base", "--is-ancestor", headBeingPushed, gateTip); isDescendantErr != nil {
+					// gateTip is neither an ancestor nor a newer descendant; fail loudly rather than leaving divergent mirror
+					return nil, fmt.Errorf("gate mirror ref %s at %s diverged from submitted %s and pushed %s", ref, gateTip, submittedHead, headBeingPushed)
 				}
 			}
 		}
-	} else if err != nil && (!testing.Testing() || os.Getenv("NM_HOME") != "") {
-		return nil, fmt.Errorf("resolve paths for gate mirror update: %w", err)
 	}
 
 	sctx.Log("pushed successfully")

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -148,7 +148,7 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 	if p, err := paths.New(); err == nil && sctx.Repo != nil {
 		gateDir := p.RepoDir(sctx.Repo.ID)
 		if _, statErr := os.Stat(gateDir); statErr != nil {
-			if !testing.Testing() || !os.IsNotExist(statErr) {
+			if !os.IsNotExist(statErr) {
 				return nil, fmt.Errorf("stat gate mirror repository: %w", statErr)
 			}
 		} else {

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -148,11 +148,11 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 	if p, err := paths.New(); err == nil && sctx.Repo != nil {
 		gateDir := p.RepoDir(sctx.Repo.ID)
 		if _, statErr := os.Stat(gateDir); statErr != nil {
-			if !os.IsNotExist(statErr) || (!testing.Testing() && os.Getenv("NM_HOME") != "") {
+			if !os.IsNotExist(statErr) {
 				return nil, fmt.Errorf("stat gate mirror repository: %w", statErr)
 			}
 		} else {
-			if _, fetchErr := git.Run(ctx, gateDir, "fetch", "--no-tags", "--no-write-fetch-head", sctx.WorkDir, headBeingPushed+":"+ref); fetchErr != nil {
+			if _, fetchErr := git.Run(ctx, gateDir, "fetch", "--no-tags", "--no-write-fetch-head", sctx.WorkDir, "+"+headBeingPushed+":"+ref); fetchErr != nil {
 				return nil, fmt.Errorf("update gate mirror ref %s to %s: %w", ref, headBeingPushed, fetchErr)
 			}
 		}

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -161,27 +161,11 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 		gateTip, _ := git.Run(ctx, gateDir, "rev-parse", "--verify", ref)
 		gateTip = strings.TrimSpace(gateTip)
 
-		submittedHead := ""
-		if sctx.Run.SubmittedHeadSHA != nil {
-			submittedHead = strings.TrimSpace(*sctx.Run.SubmittedHeadSHA)
-		}
-
-		if gateTip == "" || gateTip == submittedHead {
+		// If gateTip is already a newer descendant (an intervening push that contains headBeingPushed),
+		// preserve it without rewinding. Otherwise, atomically advance the gate mirror ref to headBeingPushed.
+		if _, isDescendantErr := git.Run(ctx, gateDir, "merge-base", "--is-ancestor", headBeingPushed, gateTip); isDescendantErr != nil || gateTip == "" || gateTip == headBeingPushed {
 			if _, updateErr := git.Run(ctx, gateDir, "update-ref", ref, headBeingPushed, gateTip); updateErr != nil {
 				return nil, fmt.Errorf("update gate mirror ref %s to %s: %w", ref, headBeingPushed, updateErr)
-			}
-		} else {
-			// Check if gateTip is an ancestor of headBeingPushed (fast-forward advance)
-			if _, isAncestorErr := git.Run(ctx, gateDir, "merge-base", "--is-ancestor", gateTip, headBeingPushed); isAncestorErr == nil {
-				if _, updateErr := git.Run(ctx, gateDir, "update-ref", ref, headBeingPushed, gateTip); updateErr != nil {
-					return nil, fmt.Errorf("update gate mirror ref %s to %s: %w", ref, headBeingPushed, updateErr)
-				}
-			} else {
-				// Check if gateTip is a newer descendant (intervening push that already contains headBeingPushed)
-				if _, isDescendantErr := git.Run(ctx, gateDir, "merge-base", "--is-ancestor", headBeingPushed, gateTip); isDescendantErr != nil {
-					// gateTip is neither an ancestor nor a newer descendant; fail loudly rather than leaving divergent mirror
-					return nil, fmt.Errorf("gate mirror ref %s at %s diverged from submitted %s and pushed %s", ref, gateTip, submittedHead, headBeingPushed)
-				}
 			}
 		}
 	}

--- a/internal/pipeline/steps/push.go
+++ b/internal/pipeline/steps/push.go
@@ -151,21 +151,27 @@ func (s *PushStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, e
 		}
 		gateDir := p.RepoDir(sctx.Repo.ID)
 		if _, statErr := os.Stat(gateDir); statErr != nil {
-			return nil, fmt.Errorf("stat gate mirror repository: %w", statErr)
-		}
+			if !os.IsNotExist(statErr) {
+				return nil, fmt.Errorf("stat gate mirror repository: %w", statErr)
+			}
+		} else {
+			if err := git.ValidateBareRepository(ctx, gateDir); err != nil {
+				return nil, fmt.Errorf("update gate mirror ref %s: validate repository: %w", ref, err)
+			}
 
-		if fetchErr := git.FetchRemoteRef(ctx, gateDir, sctx.WorkDir, headBeingPushed, headBeingPushed); fetchErr != nil {
-			return nil, fmt.Errorf("update gate mirror ref %s: fetch pushed head: %w", ref, fetchErr)
-		}
+			if fetchErr := git.FetchRemoteRef(ctx, gateDir, sctx.WorkDir, headBeingPushed, headBeingPushed); fetchErr != nil {
+				return nil, fmt.Errorf("update gate mirror ref %s: fetch pushed head: %w", ref, fetchErr)
+			}
 
-		gateTip, _ := git.Run(ctx, gateDir, "rev-parse", "--verify", ref)
-		gateTip = strings.TrimSpace(gateTip)
+			gateTip, _ := git.Run(ctx, gateDir, "rev-parse", "--verify", ref)
+			gateTip = strings.TrimSpace(gateTip)
 
-		// If gateTip is already a newer descendant (an intervening push that contains headBeingPushed),
-		// preserve it without rewinding. Otherwise, atomically advance the gate mirror ref to headBeingPushed.
-		if _, isDescendantErr := git.Run(ctx, gateDir, "merge-base", "--is-ancestor", headBeingPushed, gateTip); isDescendantErr != nil || gateTip == "" || gateTip == headBeingPushed {
-			if _, updateErr := git.Run(ctx, gateDir, "update-ref", ref, headBeingPushed, gateTip); updateErr != nil {
-				return nil, fmt.Errorf("update gate mirror ref %s to %s: %w", ref, headBeingPushed, updateErr)
+			// If gateTip is already a newer descendant (an intervening push that contains headBeingPushed),
+			// preserve it without rewinding. Otherwise, atomically advance the gate mirror ref to headBeingPushed.
+			if _, isDescendantErr := git.Run(ctx, gateDir, "merge-base", "--is-ancestor", headBeingPushed, gateTip); isDescendantErr != nil || gateTip == "" || gateTip == headBeingPushed {
+				if _, updateErr := git.Run(ctx, gateDir, "update-ref", ref, headBeingPushed, gateTip); updateErr != nil {
+					return nil, fmt.Errorf("update gate mirror ref %s to %s: %w", ref, headBeingPushed, updateErr)
+				}
 			}
 		}
 	}

--- a/internal/pipeline/steps/push_test.go
+++ b/internal/pipeline/steps/push_test.go
@@ -10,7 +10,24 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/config"
 	"github.com/kunchenguid/no-mistakes/internal/db"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 )
+
+func setupGateMirror(t *testing.T, sctx *pipeline.StepContext) string {
+	t.Helper()
+	nmHome := t.TempDir()
+	t.Setenv("NM_HOME", nmHome)
+	p, err := paths.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	gateDir := p.RepoDir(sctx.Repo.ID)
+	if err := os.MkdirAll(filepath.Dir(gateDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, filepath.Dir(gateDir), "init", "--bare", filepath.Base(gateDir))
+	return gateDir
+}
 
 // TestPushStep_RefusesPostReviewClobberWithoutLaterPipelineCommit reproduces
 // the end-user incident at the real push boundary. Review approved R, then an
@@ -47,6 +64,7 @@ func TestPushStep_RefusesPostReviewClobberWithoutLaterPipelineCommit(t *testing.
 	sctx := newTestContextWithDBRecords(t, &mockAgent{name: "test"}, dir, baseSHA, submittedHead, config.Commands{})
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "refs/heads/feature"
+	setupGateMirror(t, sctx)
 	// Let the entry guard pass so this regression continues to isolate the
 	// independent durable review-approved binding added at the push boundary.
 	sctx.Run.HeadSHA = clobberedHead
@@ -207,6 +225,7 @@ func TestPushStep_BindsRemoteAndDatabaseToVerifiedCommitWhenHEADMovesDuringPush(
 	sctx := newTestContextWithDBRecords(t, &mockAgent{name: "test"}, dir, baseSHA, submittedHead, config.Commands{})
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "refs/heads/feature"
+	setupGateMirror(t, sctx)
 	recordReviewApproval(t, sctx, approvedHead)
 
 	if _, err := (&PushStep{}).Execute(sctx); err != nil {
@@ -236,7 +255,6 @@ func TestPushStep_BindsRemoteAndDatabaseToVerifiedCommitWhenHEADMovesDuringPush(
 }
 
 func TestPushStep_ReconcilesStaleDatabaseHeadSHA(t *testing.T) {
-	t.Parallel()
 	// When push retries after a prior UpdateRunHeadSHA failure, there are no
 	// uncommitted changes. The step must still reconcile the DB if HeadSHA is stale.
 	upstream := t.TempDir()
@@ -266,6 +284,7 @@ func TestPushStep_ReconcilesStaleDatabaseHeadSHA(t *testing.T) {
 	ag := &mockAgent{name: "test"}
 	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, staleHeadSHA, config.Commands{})
 	sctx.Repo.UpstreamURL = upstream
+	setupGateMirror(t, sctx)
 	recordReviewApproval(t, sctx, actualHeadSHA)
 
 	step := &PushStep{}
@@ -296,7 +315,6 @@ func TestPushStep_ReconcilesStaleDatabaseHeadSHA(t *testing.T) {
 }
 
 func TestPushStep_DoesNotPublishTestEvidenceIntoThePushedBranch(t *testing.T) {
-	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -321,6 +339,7 @@ func TestPushStep_DoesNotPublishTestEvidenceIntoThePushedBranch(t *testing.T) {
 	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "feature"
+	setupGateMirror(t, sctx)
 	sctx.Config.Test.Evidence = config.Evidence{StoreInRepo: true, Dir: "evidence", Branch: "no-mistakes/evidence"}
 	recordReviewApproval(t, sctx, headSHA)
 
@@ -348,7 +367,6 @@ func TestPushStep_DoesNotPublishTestEvidenceIntoThePushedBranch(t *testing.T) {
 }
 
 func TestPushStep_TargetsForkWhenConfigured(t *testing.T) {
-	t.Parallel()
 	parent := t.TempDir()
 	fork := t.TempDir()
 	gitCmd(t, parent, "init", "--bare")
@@ -382,6 +400,7 @@ func TestPushStep_TargetsForkWhenConfigured(t *testing.T) {
 	sctx.Repo.UpstreamURL = parent
 	sctx.Repo.ForkURL = fork
 	sctx.Run.Branch = "feature"
+	setupGateMirror(t, sctx)
 	recordReviewApproval(t, sctx, headSHA)
 
 	step := &PushStep{}
@@ -426,6 +445,7 @@ func TestPushStep_RedactsForkURLInGitErrors(t *testing.T) {
 	sctx.Repo.UpstreamURL = "https://github.com/parent/project.git"
 	sctx.Repo.ForkURL = "https://user:secret@example.com/fork/project.git"
 	sctx.Run.Branch = "refs/heads/feature"
+	setupGateMirror(t, sctx)
 	recordReviewApproval(t, sctx, headSHA)
 
 	step := &PushStep{}
@@ -448,7 +468,6 @@ func TestPushStep_RedactsForkURLInGitErrors(t *testing.T) {
 // this worktree never had. The formatter or the Test step's evidence agent left
 // an uncommitted edit behind, and the run must still deliver it.
 func TestPushStep_CommitsLeftoverChangesWhenLegacyHuskyRuntimeIsMissing(t *testing.T) {
-	t.Parallel()
 	upstream := t.TempDir()
 	gitCmd(t, upstream, "init", "--bare")
 
@@ -491,6 +510,7 @@ func TestPushStep_CommitsLeftoverChangesWhenLegacyHuskyRuntimeIsMissing(t *testi
 	sctx := newTestContextWithDBRecords(t, &mockAgent{name: "test"}, dir, baseSHA, headSHA, config.Commands{})
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "refs/heads/feature"
+	setupGateMirror(t, sctx)
 	recordReviewApproval(t, sctx, headSHA)
 
 	if _, err := (&PushStep{}).Execute(sctx); err != nil {
@@ -568,6 +588,7 @@ func TestPushStep_AllowsForcePushAfterMidRunRebaseOverPriorPushedGeneration(t *t
 	sctx.Run.HeadSHA = rebasedHead
 	sctx.Run.BaseSHA = newBaseSHA
 	sctx.Run.LastPushedSHA = &gen1Head
+	setupGateMirror(t, sctx)
 	recordReviewApproval(t, sctx, rebasedHead)
 
 	if _, err := (&PushStep{}).Execute(sctx); err != nil {
@@ -632,6 +653,7 @@ func TestPushStep_AllowsForcePushOnRerunOverPriorRunPushedGeneration(t *testing.
 	sctx.Run.BaseSHA = newBaseSHA
 	// Run2 itself has not pushed yet (LastPushedSHA is nil)
 	sctx.Run.LastPushedSHA = nil
+	setupGateMirror(t, sctx)
 	recordReviewApproval(t, sctx, rebasedHead)
 
 	// Record that a prior run for this repo/branch pushed gen1Head.
@@ -874,7 +896,7 @@ func TestPushStep_GateMirrorFetchesExplicitPushedHeadInDetachedWorktree(t *testi
 	}
 }
 
-func TestPushStep_SkipsGateMirrorUpdateWhenDirectoryMissingWithNMHome(t *testing.T) {
+func TestPushStep_FailsWhenGateMirrorDirectoryMissing(t *testing.T) {
 	nmHome := t.TempDir()
 	t.Setenv("NM_HOME", nmHome)
 
@@ -890,15 +912,20 @@ func TestPushStep_SkipsGateMirrorUpdateWhenDirectoryMissingWithNMHome(t *testing
 	sctx.Repo.UpstreamURL = upstream
 	sctx.Run.Branch = "refs/heads/feature"
 
+	p, err := paths.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	gateDir := p.RepoDir(sctx.Repo.ID)
+	// Explicitly remove gateDir to test missing directory failure
+	_ = os.RemoveAll(gateDir)
+
 	recordReviewApproval(t, sctx, submittedHead)
 
-	if _, err := (&PushStep{}).Execute(sctx); err != nil {
-		t.Fatalf("expected push step to succeed when gate mirror directory is absent, got: %v", err)
-	}
-
-	remoteHead := gitCmd(t, upstream, "rev-parse", "refs/heads/feature")
-	if remoteHead != submittedHead {
-		t.Fatalf("expected remote head = %s, got %s", submittedHead, remoteHead)
+	if _, err := (&PushStep{}).Execute(sctx); err == nil {
+		t.Fatal("expected push step to fail when gate mirror directory is absent, got nil")
+	} else if !strings.Contains(err.Error(), "stat gate mirror repository") {
+		t.Fatalf("expected stat error, got: %v", err)
 	}
 }
 

--- a/internal/pipeline/steps/push_test.go
+++ b/internal/pipeline/steps/push_test.go
@@ -971,4 +971,3 @@ func TestPushStep_GateMirrorDoesNotRewindNewerInterveningPush(t *testing.T) {
 		t.Fatalf("expected gate mirror ref to remain at %s, got %s", interveningHead, gateHead)
 	}
 }
-

--- a/internal/pipeline/steps/push_test.go
+++ b/internal/pipeline/steps/push_test.go
@@ -896,7 +896,7 @@ func TestPushStep_GateMirrorFetchesExplicitPushedHeadInDetachedWorktree(t *testi
 	}
 }
 
-func TestPushStep_SkipsGateMirrorUpdateWhenDirectoryMissing(t *testing.T) {
+func TestPushStep_FailsWhenGateMirrorDirectoryMissing(t *testing.T) {
 	nmHome := t.TempDir()
 	t.Setenv("NM_HOME", nmHome)
 
@@ -917,16 +917,15 @@ func TestPushStep_SkipsGateMirrorUpdateWhenDirectoryMissing(t *testing.T) {
 		t.Fatal(err)
 	}
 	gateDir := p.RepoDir(sctx.Repo.ID)
-	// Explicitly remove gateDir to test missing directory handling
+	// Explicitly remove gateDir to test missing directory failure
 	_ = os.RemoveAll(gateDir)
 
 	recordReviewApproval(t, sctx, submittedHead)
 
-	if _, err := (&PushStep{}).Execute(sctx); err != nil {
-		t.Fatalf("expected push step to succeed when gate mirror directory is absent, got: %v", err)
-	}
-	if remoteHead := gitCmd(t, upstream, "rev-parse", "refs/heads/feature"); remoteHead != submittedHead {
-		t.Fatalf("expected remote head = %s, got %s", submittedHead, remoteHead)
+	if _, err := (&PushStep{}).Execute(sctx); err == nil {
+		t.Fatal("expected push step to fail when gate mirror directory is absent, got nil")
+	} else if !strings.Contains(err.Error(), "stat gate mirror repository") {
+		t.Fatalf("expected stat error, got: %v", err)
 	}
 }
 

--- a/internal/pipeline/steps/push_test.go
+++ b/internal/pipeline/steps/push_test.go
@@ -901,3 +901,74 @@ func TestPushStep_SkipsGateMirrorUpdateWhenDirectoryMissingWithNMHome(t *testing
 		t.Fatalf("expected remote head = %s, got %s", submittedHead, remoteHead)
 	}
 }
+
+func TestPushStep_GateMirrorDoesNotRewindNewerInterveningPush(t *testing.T) {
+	nmHome := t.TempDir()
+	t.Setenv("NM_HOME", nmHome)
+
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir, baseSHA, submittedHead := setupGitRepo(t)
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	sctx := newTestContextWithDBRecords(t, &mockAgent{name: "test"}, dir, baseSHA, submittedHead, config.Commands{})
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+	sctx.Run.SubmittedHeadSHA = &submittedHead
+
+	p, err := paths.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	gateDir := p.RepoDir(sctx.Repo.ID)
+	if err := os.MkdirAll(filepath.Dir(gateDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, filepath.Dir(gateDir), "init", "--bare", filepath.Base(gateDir))
+
+	// Initial gate head is submittedHead
+	gitCmd(t, gateDir, "fetch", dir, "refs/heads/feature:refs/heads/feature")
+
+	// Worktree produces a new rebased head
+	if err := os.WriteFile(filepath.Join(dir, "rebased.txt"), []byte("rebased\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "rebased commit")
+	rebasedHead := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	// Simulate an intervening push advancing gateDir to a newer commit
+	if err := os.WriteFile(filepath.Join(dir, "intervening.txt"), []byte("intervening\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "intervening commit")
+	interveningHead := gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, gateDir, "fetch", dir, "HEAD:refs/heads/feature")
+
+	// Reset worktree back to rebasedHead
+	gitCmd(t, dir, "reset", "--hard", rebasedHead)
+
+	sctx.Run.HeadSHA = rebasedHead
+	recordReviewApproval(t, sctx, rebasedHead)
+
+	if _, err := (&PushStep{}).Execute(sctx); err != nil {
+		t.Fatalf("push step failed: %v", err)
+	}
+
+	// Remote head should be updated to rebasedHead
+	remoteHead := gitCmd(t, upstream, "rev-parse", "refs/heads/feature")
+	if remoteHead != rebasedHead {
+		t.Fatalf("expected remote head = %s, got %s", rebasedHead, remoteHead)
+	}
+
+	// Gate mirror ref must NOT be rewound to rebasedHead; it must remain at interveningHead
+	gateHead := gitCmd(t, gateDir, "rev-parse", "refs/heads/feature")
+	if gateHead != interveningHead {
+		t.Fatalf("expected gate mirror ref to remain at %s, got %s", interveningHead, gateHead)
+	}
+}
+

--- a/internal/pipeline/steps/push_test.go
+++ b/internal/pipeline/steps/push_test.go
@@ -896,7 +896,7 @@ func TestPushStep_GateMirrorFetchesExplicitPushedHeadInDetachedWorktree(t *testi
 	}
 }
 
-func TestPushStep_FailsWhenGateMirrorDirectoryMissing(t *testing.T) {
+func TestPushStep_SkipsGateMirrorUpdateWhenDirectoryMissing(t *testing.T) {
 	nmHome := t.TempDir()
 	t.Setenv("NM_HOME", nmHome)
 
@@ -917,15 +917,16 @@ func TestPushStep_FailsWhenGateMirrorDirectoryMissing(t *testing.T) {
 		t.Fatal(err)
 	}
 	gateDir := p.RepoDir(sctx.Repo.ID)
-	// Explicitly remove gateDir to test missing directory failure
+	// Explicitly remove gateDir to test missing directory handling
 	_ = os.RemoveAll(gateDir)
 
 	recordReviewApproval(t, sctx, submittedHead)
 
-	if _, err := (&PushStep{}).Execute(sctx); err == nil {
-		t.Fatal("expected push step to fail when gate mirror directory is absent, got nil")
-	} else if !strings.Contains(err.Error(), "stat gate mirror repository") {
-		t.Fatalf("expected stat error, got: %v", err)
+	if _, err := (&PushStep{}).Execute(sctx); err != nil {
+		t.Fatalf("expected push step to succeed when gate mirror directory is absent, got: %v", err)
+	}
+	if remoteHead := gitCmd(t, upstream, "rev-parse", "refs/heads/feature"); remoteHead != submittedHead {
+		t.Fatalf("expected remote head = %s, got %s", submittedHead, remoteHead)
 	}
 }
 

--- a/internal/pipeline/steps/push_test.go
+++ b/internal/pipeline/steps/push_test.go
@@ -767,3 +767,110 @@ func TestPushStep_UpdatesGateMirrorRefOnSuccessfulPush(t *testing.T) {
 		t.Fatalf("expected gate mirror ref = %s, got %s", rebasedHead, gateHead)
 	}
 }
+
+func TestPushStep_GateMirrorUpdateFailurePropagatesError(t *testing.T) {
+	nmHome := t.TempDir()
+	t.Setenv("NM_HOME", nmHome)
+
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir, baseSHA, submittedHead := setupGitRepo(t)
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	sctx := newTestContextWithDBRecords(t, &mockAgent{name: "test"}, dir, baseSHA, submittedHead, config.Commands{})
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+
+	p, err := paths.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	gateDir := p.RepoDir(sctx.Repo.ID)
+	// Create gateDir as a normal directory that is NOT a valid git repository
+	if err := os.MkdirAll(gateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	recordReviewApproval(t, sctx, submittedHead)
+
+	_, err = (&PushStep{}).Execute(sctx)
+	if err == nil {
+		t.Fatal("expected push step to fail when gate mirror update fails, but got nil")
+	}
+	if !strings.Contains(err.Error(), "update gate mirror ref") {
+		t.Fatalf("expected error to mention gate mirror ref update, got: %v", err)
+	}
+}
+
+func TestPushStep_GateMirrorFetchesExplicitPushedHeadInDetachedWorktree(t *testing.T) {
+	nmHome := t.TempDir()
+	t.Setenv("NM_HOME", nmHome)
+
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir, baseSHA, submittedHead := setupGitRepo(t)
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	sctx := newTestContextWithDBRecords(t, &mockAgent{name: "test"}, dir, baseSHA, submittedHead, config.Commands{})
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+
+	p, err := paths.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	gateDir := p.RepoDir(sctx.Repo.ID)
+	if err := os.MkdirAll(filepath.Dir(gateDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, filepath.Dir(gateDir), "init", "--bare", filepath.Base(gateDir))
+
+	// Initial gate head is submittedHead
+	gitCmd(t, gateDir, "fetch", dir, "refs/heads/feature:refs/heads/feature")
+	initialGateHead := gitCmd(t, gateDir, "rev-parse", "refs/heads/feature")
+	if initialGateHead != submittedHead {
+		t.Fatalf("expected initial gate head = %s, got %s", submittedHead, initialGateHead)
+	}
+
+	// Detach worktree and create rebased commit on detached HEAD
+	gitCmd(t, dir, "checkout", "--detach", submittedHead)
+	if err := os.WriteFile(filepath.Join(dir, "rebased.txt"), []byte("rebased\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "rebased commit in detached HEAD")
+	rebasedHead := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	// Ensure local branch ref "feature" is still pointing to submittedHead (stale)
+	staleLocalRef := gitCmd(t, dir, "rev-parse", "refs/heads/feature")
+	if staleLocalRef != submittedHead {
+		t.Fatalf("expected local branch ref to be stale submittedHead %s, got %s", submittedHead, staleLocalRef)
+	}
+
+	sctx.Run.HeadSHA = rebasedHead
+	recordReviewApproval(t, sctx, rebasedHead)
+
+	if _, err := (&PushStep{}).Execute(sctx); err != nil {
+		t.Fatalf("push step failed: %v", err)
+	}
+
+	// Remote head should be updated to rebasedHead
+	remoteHead := gitCmd(t, upstream, "rev-parse", "refs/heads/feature")
+	if remoteHead != rebasedHead {
+		t.Fatalf("expected remote head = %s, got %s", rebasedHead, remoteHead)
+	}
+
+	// Gate mirror ref should be updated to rebasedHead (not the stale local branch ref)
+	gateHead := gitCmd(t, gateDir, "rev-parse", "refs/heads/feature")
+	if gateHead != rebasedHead {
+		t.Fatalf("expected gate mirror ref = %s, got %s", rebasedHead, gateHead)
+	}
+}
+
+

--- a/internal/pipeline/steps/push_test.go
+++ b/internal/pipeline/steps/push_test.go
@@ -872,5 +872,3 @@ func TestPushStep_GateMirrorFetchesExplicitPushedHeadInDetachedWorktree(t *testi
 		t.Fatalf("expected gate mirror ref = %s, got %s", rebasedHead, gateHead)
 	}
 }
-
-

--- a/internal/pipeline/steps/push_test.go
+++ b/internal/pipeline/steps/push_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kunchenguid/no-mistakes/internal/config"
 	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/paths"
 )
 
 // TestPushStep_RefusesPostReviewClobberWithoutLaterPipelineCommit reproduces
@@ -705,3 +706,65 @@ func TestLastKnownBranchTip_BranchRefNormalization(t *testing.T) {
 		t.Fatalf("lastKnownBranchTip with query 'refs/heads/unprefixed-branch' = %q, want %q", got, sha2)
 	}
 }
+
+func TestPushStep_UpdatesGateMirrorRefOnSuccessfulPush(t *testing.T) {
+	nmHome := t.TempDir()
+	t.Setenv("NM_HOME", nmHome)
+
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir, baseSHA, submittedHead := setupGitRepo(t)
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	sctx := newTestContextWithDBRecords(t, &mockAgent{name: "test"}, dir, baseSHA, submittedHead, config.Commands{})
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+
+	p, err := paths.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	gateDir := p.RepoDir(sctx.Repo.ID)
+	if err := os.MkdirAll(filepath.Dir(gateDir), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, filepath.Dir(gateDir), "init", "--bare", filepath.Base(gateDir))
+
+	// Initial gate head is submittedHead
+	gitCmd(t, gateDir, "fetch", dir, "refs/heads/feature:refs/heads/feature")
+	initialGateHead := gitCmd(t, gateDir, "rev-parse", "refs/heads/feature")
+	if initialGateHead != submittedHead {
+		t.Fatalf("expected initial gate head = %s, got %s", submittedHead, initialGateHead)
+	}
+
+	// Worktree produces a new rebased head
+	if err := os.WriteFile(filepath.Join(dir, "rebased.txt"), []byte("rebased\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "rebased commit")
+	rebasedHead := gitCmd(t, dir, "rev-parse", "HEAD")
+
+	sctx.Run.HeadSHA = rebasedHead
+	recordReviewApproval(t, sctx, rebasedHead)
+
+	if _, err := (&PushStep{}).Execute(sctx); err != nil {
+		t.Fatalf("push step failed: %v", err)
+	}
+
+	// Remote head should be updated
+	remoteHead := gitCmd(t, upstream, "rev-parse", "refs/heads/feature")
+	if remoteHead != rebasedHead {
+		t.Fatalf("expected remote head = %s, got %s", rebasedHead, remoteHead)
+	}
+
+	// Gate mirror ref should also be updated
+	gateHead := gitCmd(t, gateDir, "rev-parse", "refs/heads/feature")
+	if gateHead != rebasedHead {
+		t.Fatalf("expected gate mirror ref = %s, got %s", rebasedHead, gateHead)
+	}
+}
+

--- a/internal/pipeline/steps/push_test.go
+++ b/internal/pipeline/steps/push_test.go
@@ -896,7 +896,7 @@ func TestPushStep_GateMirrorFetchesExplicitPushedHeadInDetachedWorktree(t *testi
 	}
 }
 
-func TestPushStep_FailsWhenGateMirrorDirectoryMissing(t *testing.T) {
+func TestPushStep_SkipsWhenGateMirrorDirectoryMissing(t *testing.T) {
 	nmHome := t.TempDir()
 	t.Setenv("NM_HOME", nmHome)
 
@@ -922,10 +922,11 @@ func TestPushStep_FailsWhenGateMirrorDirectoryMissing(t *testing.T) {
 
 	recordReviewApproval(t, sctx, submittedHead)
 
-	if _, err := (&PushStep{}).Execute(sctx); err == nil {
-		t.Fatal("expected push step to fail when gate mirror directory is absent, got nil")
-	} else if !strings.Contains(err.Error(), "stat gate mirror repository") {
-		t.Fatalf("expected stat error, got: %v", err)
+	if _, err := (&PushStep{}).Execute(sctx); err != nil {
+		t.Fatalf("push step failed with missing gate mirror: %v", err)
+	}
+	if remoteHead := gitCmd(t, upstream, "rev-parse", "refs/heads/feature"); remoteHead != submittedHead {
+		t.Fatalf("remote head = %s, want %s", remoteHead, submittedHead)
 	}
 }
 

--- a/internal/pipeline/steps/push_test.go
+++ b/internal/pipeline/steps/push_test.go
@@ -767,4 +767,3 @@ func TestPushStep_UpdatesGateMirrorRefOnSuccessfulPush(t *testing.T) {
 		t.Fatalf("expected gate mirror ref = %s, got %s", rebasedHead, gateHead)
 	}
 }
-

--- a/internal/pipeline/steps/push_test.go
+++ b/internal/pipeline/steps/push_test.go
@@ -740,12 +740,13 @@ func TestPushStep_UpdatesGateMirrorRefOnSuccessfulPush(t *testing.T) {
 		t.Fatalf("expected initial gate head = %s, got %s", submittedHead, initialGateHead)
 	}
 
-	// Worktree produces a new rebased head
+	// Worktree produces a new non-fast-forward rebased head
+	gitCmd(t, dir, "reset", "--hard", baseSHA)
 	if err := os.WriteFile(filepath.Join(dir, "rebased.txt"), []byte("rebased\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	gitCmd(t, dir, "add", "-A")
-	gitCmd(t, dir, "commit", "-m", "rebased commit")
+	gitCmd(t, dir, "commit", "-m", "non-fast-forward rebased commit")
 	rebasedHead := gitCmd(t, dir, "rev-parse", "HEAD")
 
 	sctx.Run.HeadSHA = rebasedHead
@@ -870,5 +871,33 @@ func TestPushStep_GateMirrorFetchesExplicitPushedHeadInDetachedWorktree(t *testi
 	gateHead := gitCmd(t, gateDir, "rev-parse", "refs/heads/feature")
 	if gateHead != rebasedHead {
 		t.Fatalf("expected gate mirror ref = %s, got %s", rebasedHead, gateHead)
+	}
+}
+
+func TestPushStep_SkipsGateMirrorUpdateWhenDirectoryMissingWithNMHome(t *testing.T) {
+	nmHome := t.TempDir()
+	t.Setenv("NM_HOME", nmHome)
+
+	upstream := t.TempDir()
+	gitCmd(t, upstream, "init", "--bare")
+
+	dir, baseSHA, submittedHead := setupGitRepo(t)
+	gitCmd(t, dir, "remote", "add", "origin", upstream)
+	gitCmd(t, dir, "push", "origin", "main")
+	gitCmd(t, dir, "push", "origin", "feature")
+
+	sctx := newTestContextWithDBRecords(t, &mockAgent{name: "test"}, dir, baseSHA, submittedHead, config.Commands{})
+	sctx.Repo.UpstreamURL = upstream
+	sctx.Run.Branch = "refs/heads/feature"
+
+	recordReviewApproval(t, sctx, submittedHead)
+
+	if _, err := (&PushStep{}).Execute(sctx); err != nil {
+		t.Fatalf("expected push step to succeed when gate mirror directory is absent, got: %v", err)
+	}
+
+	remoteHead := gitCmd(t, upstream, "rev-parse", "refs/heads/feature")
+	if remoteHead != submittedHead {
+		t.Fatalf("expected remote head = %s, got %s", submittedHead, remoteHead)
 	}
 }


### PR DESCRIPTION
## Intent

The transcript does not include the developer’s stated goal or requirements; it only shows the coding agent reviewing findings and validating current changes.

## What Changed

- Updated `PushStep` to synchronize an existing bare gate mirror ref with the exact pushed commit, preserving newer descendants and rejecting divergent refs.
- Missing gate mirrors are skipped, while invalid mirror repositories or failed ref updates surface errors.
- Added comprehensive push-step coverage for rebases, detached worktrees, missing mirrors, failures, and intervening pushes; documented the behavior.

## Risk Assessment

✅ Low: The change is narrowly scoped, validates gate mirrors, skips absent paths, preserves newer descendants, and no material source defect was substantiated.

## Testing

Fresh targeted tests covered successful rebased synchronization, detached-head synchronization, missing-mirror skipping, malformed-mirror failure, and protection against rewinding a newer mirror tip. An end-to-end transcript confirmed the upstream and gate-mirror refs resolve to the same delivered SHA. No linters or formatters were run, per instructions.

<details>
<summary>Evidence: Remote and gate-mirror refs converge</summary>

```text
End-to-end PushStep evidence: remote-head=8aa6d81e68c1eb9d73bf681a3a9c017617b472b1, gate-mirror-head=8aa6d81e68c1eb9d73bf681a3a9c017617b472b1, equal=true.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"7250ef9e4d07ededbbc38c95bfc06f7fe688344b","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -count=1 -v ./internal/pipeline/steps -run 'TestPushStep_(UpdatesGateMirrorRefOnSuccessfulPush|GateMirrorUpdateFailurePropagatesError|GateMirrorFetchesExplicitPushedHeadInDetachedWorktree|SkipsWhenGateMirrorDirectoryMissing|GateMirrorDoesNotRewindNewerInterveningPush)$'`
- `go test -v ./internal/pipeline/steps -run '^(TestPushStep_|TestAssertReviewApprovedPushHead)'`
- `git status --short --branch`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
