### PR TITLE
fix(review): use configured PR base branch

### DIFF
--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -77,11 +77,13 @@ The integration branch used below is the [PR base branch](/no-mistakes/reference
 
 ## Review
 
-AI code review of your diff.
+AI code review of your diff against the run's integration branch.
 
 **Behavior:**
 
-- Diffs the base commit against head
+- Resolves the integration branch as trusted `pr.base_branch` when configured, otherwise the repository's forge default branch
+- Fetches that branch before calculating the merge-base and fails with an actionable error if the configured target is unavailable; it never silently substitutes the forge default
+- Diffs the effective base commit against head
 - Filters out files matching `ignore_patterns` from the repo config
 - Sends the filtered diff to the agent with structured review instructions and a structured output schema
 - Appends the [`review.path_instructions`](/no-mistakes/reference/repo-config/#reviewpath_instructions) blocks whose glob matches at least one changed file, in configured order, each labelled with its own `path` and the files it matched so a scoped rule cannot read as a repository-wide instruction; a change that matches nothing, or a repo with none configured, gets the prompt unchanged

--- a/internal/pipeline/steps/common_git.go
+++ b/internal/pipeline/steps/common_git.go
@@ -25,6 +25,27 @@ func reviewWorkload(ctx context.Context, workDir, base, head string) *agent.Invo
 	return &agent.InvocationWorkload{Files: files, Lines: lines}
 }
 
+// effectivePRBaseBranch resolves the single integration branch used by the
+// pipeline's rebase, review, and PR steps. The effective Config has already
+// applied the trusted-config boundary: a pushed repository config can select a
+// target only through the existing allow_repo_commands opt-in.
+func effectivePRBaseBranch(sctx *pipeline.StepContext) string {
+	if sctx != nil && sctx.Config != nil {
+		if branch := strings.TrimSpace(sctx.Config.PR.BaseBranch); branch != "" {
+			return branch
+		}
+	}
+	if sctx != nil && sctx.Repo != nil {
+		if branch := strings.TrimSpace(sctx.Repo.DefaultBranch); branch != "" {
+			return branch
+		}
+	}
+	// Preserve the existing git default when neither registration nor config
+	// provides a branch. This is only a last-resort compatibility fallback; a
+	// configured non-empty PR base is never replaced by it.
+	return "main"
+}
+
 // resolveBaseSHA returns a usable base SHA for diff/log operations.
 // When baseSHA is the zero ref (new branch push), it tries git merge-base
 // against the default branch, falling back to the empty tree SHA.
@@ -47,6 +68,35 @@ func resolveBranchBaseSHA(ctx context.Context, workDir, fallbackBaseSHA, default
 		return mb
 	}
 	return resolveBaseSHA(ctx, workDir, fallbackBaseSHA, defaultBranch)
+}
+
+// resolveReviewBaseSHA fetches and resolves the effective integration branch
+// before calculating the review merge-base. Review must not fall back to the
+// run's recorded base SHA when a configured target cannot be fetched: that SHA
+// may belong to the forge default branch and would make the reviewer inspect a
+// different integration target while the prompt claims otherwise.
+//
+// A zero base SHA retains the existing empty-tree behavior when the fetched
+// target has no common ancestor with the new branch. A non-zero run with no
+// common ancestor fails closed because there is no safe target-relative scope.
+func resolveReviewBaseSHA(ctx context.Context, sctx *pipeline.StepContext) (string, error) {
+	baseBranch := effectivePRBaseBranch(sctx)
+	if err := fetchRunUpstreamBranch(ctx, sctx, baseBranch); err != nil {
+		return "", fmt.Errorf("review integration base %q unavailable: fetch failed; ensure the branch exists on the upstream remote: %w", baseBranch, err)
+	}
+
+	ref := "origin/" + baseBranch
+	if _, err := git.Run(ctx, sctx.WorkDir, "rev-parse", "--verify", ref+"^{commit}"); err != nil {
+		return "", fmt.Errorf("review integration base %q unavailable after fetch: resolve %s: %w", baseBranch, ref, err)
+	}
+	mergeBase, err := git.Run(ctx, sctx.WorkDir, "merge-base", "HEAD", ref)
+	if err == nil && strings.TrimSpace(mergeBase) != "" {
+		return strings.TrimSpace(mergeBase), nil
+	}
+	if sctx.Run != nil && git.IsZeroSHA(sctx.Run.BaseSHA) {
+		return git.EmptyTreeSHA, nil
+	}
+	return "", fmt.Errorf("review integration base %q has no common ancestor with run head; refusing to review against another branch", baseBranch)
 }
 
 func resolveDefaultBranchTipSHA(ctx context.Context, workDir, upstreamURL, fallbackBaseSHA, defaultBranch string) string {

--- a/internal/pipeline/steps/pr.go
+++ b/internal/pipeline/steps/pr.go
@@ -61,10 +61,7 @@ func (s *PRStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome, err
 	if strings.HasPrefix(branch, "refs/heads/") {
 		branch = strings.TrimPrefix(branch, "refs/heads/")
 	}
-	baseBranch := sctx.Repo.DefaultBranch
-	if sctx.Config != nil && strings.TrimSpace(sctx.Config.PR.BaseBranch) != "" {
-		baseBranch = strings.TrimSpace(sctx.Config.PR.BaseBranch)
-	}
+	baseBranch := effectivePRBaseBranch(sctx)
 	if branch == baseBranch {
 		sctx.Log(fmt.Sprintf("skipping PR creation on base branch %s", branch))
 		return &pipeline.StepOutcome{Skipped: true}, nil

--- a/internal/pipeline/steps/rebase.go
+++ b/internal/pipeline/steps/rebase.go
@@ -166,20 +166,6 @@ func forcePushRebaseTargets(branch, defaultBranch string) []string {
 	return []string{"origin/" + defaultBranch}
 }
 
-// effectivePRBaseBranch resolves the branch used as the integration base for
-// rebases. The repository default remains the fallback for configurations that
-// do not select a separate PR target branch.
-func effectivePRBaseBranch(sctx *pipeline.StepContext) string {
-	defaultBranch := strings.TrimSpace(sctx.Repo.DefaultBranch)
-	if sctx.Config != nil && strings.TrimSpace(sctx.Config.PR.BaseBranch) != "" {
-		defaultBranch = strings.TrimSpace(sctx.Config.PR.BaseBranch)
-	}
-	if defaultBranch == "" {
-		defaultBranch = "main"
-	}
-	return defaultBranch
-}
-
 // detectBundledLocalDefaultCommits returns a blocking finding when the gated
 // branch carries commits that exist on the contributor's local default branch
 // but were never pushed to origin/<default>. In multi-session / monorepo setups

--- a/internal/pipeline/steps/review.go
+++ b/internal/pipeline/steps/review.go
@@ -43,7 +43,11 @@ func (s *ReviewStep) Execute(sctx *pipeline.StepContext) (*pipeline.StepOutcome,
 			restoreContext()
 		}
 	}()
-	baseSHA := resolveBranchBaseSHA(ctx, sctx.WorkDir, sctx.Run.BaseSHA, sctx.Repo.DefaultBranch)
+	baseBranch := effectivePRBaseBranch(sctx)
+	baseSHA, err := resolveReviewBaseSHA(ctx, sctx)
+	if err != nil {
+		return nil, err
+	}
 	branch := sctx.Run.Branch
 	ignorePatterns := "none"
 	if len(sctx.Config.IgnorePatterns) > 0 {
@@ -96,7 +100,7 @@ Context:
 - base commit: %s
 - target commit: %s
 - review scope: %s
-- default branch: %s
+- integration base branch: %s
 - ignore patterns: %s
 
 Rules:
@@ -118,7 +122,7 @@ Previous review findings to address:
 			baseSHA,
 			sctx.Run.HeadSHA,
 			reviewScope,
-			sctx.Repo.DefaultBranch,
+			baseBranch,
 			ignorePatterns,
 			historySection,
 			previousFindings,
@@ -213,7 +217,7 @@ Context:
 - base commit: %s
 - target commit: %s
 - review scope: %s
-- default branch: %s
+- integration base branch: %s
 - ignore patterns: %s
 
 Task:
@@ -258,7 +262,7 @@ Risk assessment (after listing all findings):
 		baseSHA,
 		sctx.Run.HeadSHA,
 		reviewScope,
-		sctx.Repo.DefaultBranch,
+		baseBranch,
 		ignorePatterns,
 		historySection,
 		pathInstructions,

--- a/internal/pipeline/steps/review_base_test.go
+++ b/internal/pipeline/steps/review_base_test.go
@@ -1,0 +1,234 @@
+package steps
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/agent"
+	"github.com/kunchenguid/no-mistakes/internal/config"
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/pipeline"
+)
+
+// setupReviewBaseRepo creates the graph that exposed the review-base defect:
+// main and feature/hardware diverge, while the run branch is based on the
+// configured integration branch. The hardware file is inherited from the
+// configured branch and must not be presented as a change to review.
+func setupReviewBaseRepo(t *testing.T) (dir, integrationSHA, headSHA string) {
+	t.Helper()
+
+	dir = t.TempDir()
+	gitCmd(t, dir, "init")
+	gitCmd(t, dir, "config", "user.name", "test")
+	gitCmd(t, dir, "config", "user.email", "test@test.com")
+	gitCmd(t, dir, "checkout", "-b", "main")
+	gitCmd(t, dir, "remote", "add", "origin", dir)
+
+	writeReviewBaseFile(t, dir, "root.txt", "root\n")
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "root")
+	gitCmd(t, dir, "push", "origin", "main")
+
+	gitCmd(t, dir, "checkout", "-b", "feature/hardware")
+	writeReviewBaseFile(t, dir, "hardware-base.txt", "hardware baseline\n")
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "hardware integration base")
+	integrationSHA = gitCmd(t, dir, "rev-parse", "HEAD")
+	gitCmd(t, dir, "push", "origin", "feature/hardware")
+
+	gitCmd(t, dir, "checkout", "-b", "feature/review-base", "feature/hardware")
+	writeReviewBaseFile(t, dir, "feature-change.txt", "feature change\n")
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "feature change")
+	headSHA = gitCmd(t, dir, "rev-parse", "HEAD")
+
+	gitCmd(t, dir, "checkout", "main")
+	writeReviewBaseFile(t, dir, filepath.Join("application", "unrelated.go"), "package application\n")
+	gitCmd(t, dir, "add", "-A")
+	gitCmd(t, dir, "commit", "-m", "unrelated application history")
+	gitCmd(t, dir, "push", "origin", "main")
+	gitCmd(t, dir, "checkout", "feature/review-base")
+
+	return dir, integrationSHA, headSHA
+}
+
+func writeReviewBaseFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func cleanReviewFindings() *agent.Result {
+	return &agent.Result{Output: json.RawMessage(`{"findings":[],"risk_level":"low","risk_rationale":"clean","risk_scope":"source-or-external"}`)}
+}
+
+func reviewBaseContext(t *testing.T, ag agent.Agent, dir, integrationSHA, headSHA string) *pipeline.StepContext {
+	t.Helper()
+	sctx := newTestContextWithDBRecords(t, ag, dir, integrationSHA, headSHA, config.Commands{})
+	sctx.Run.Branch = "refs/heads/feature/review-base"
+	sctx.Repo.DefaultBranch = "main"
+	return sctx
+}
+
+func reviewBaseRules() []config.PathInstruction {
+	return []config.PathInstruction{
+		{Path: "hardware-base.txt", Instructions: "hardware inherited rule must not be selected"},
+		{Path: "feature-change.txt", Instructions: "feature changed rule is selected"},
+	}
+}
+
+func TestReviewStep_UsesConfiguredIntegrationBaseForScopeAndWorkload(t *testing.T) {
+	t.Parallel()
+	dir, integrationSHA, headSHA := setupReviewBaseRepo(t)
+	ag := &mockAgent{name: "review", runFn: func(context.Context, agent.RunOpts) (*agent.Result, error) {
+		return cleanReviewFindings(), nil
+	}}
+	sctx := reviewBaseContext(t, ag, dir, integrationSHA, headSHA)
+	// A new branch has no prior push base. The review must still derive its
+	// merge-base from the configured target rather than treating the zero SHA
+	// as a usable commit.
+	sctx.Run.BaseSHA = strings.Repeat("0", 40)
+	sctx.Config.PR.BaseBranch = "feature/hardware"
+	sctx.Config.Review.PathInstructions = reviewBaseRules()
+
+	if _, err := (&ReviewStep{}).Execute(sctx); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if len(ag.calls) != 1 {
+		t.Fatalf("agent calls = %d, want 1", len(ag.calls))
+	}
+	call := ag.calls[0]
+	if !strings.Contains(call.Prompt, "base commit: "+integrationSHA) {
+		t.Fatalf("review prompt does not use configured integration base %s:\n%s", integrationSHA, call.Prompt)
+	}
+	if !strings.Contains(call.Prompt, "integration base branch: feature/hardware") {
+		t.Fatalf("review prompt does not name configured integration branch:\n%s", call.Prompt)
+	}
+	if !strings.Contains(call.Prompt, "feature changed rule is selected") {
+		t.Fatalf("review prompt omitted the configured branch's changed path:\n%s", call.Prompt)
+	}
+	if strings.Contains(call.Prompt, "hardware inherited rule must not be selected") {
+		t.Fatalf("review prompt included a path inherited from the configured base:\n%s", call.Prompt)
+	}
+	if call.Workload == nil {
+		t.Fatal("review workload is nil")
+	}
+	if call.Workload.Files != 1 || call.Workload.Lines != 1 {
+		t.Fatalf("review workload = %+v, want one changed file and line", *call.Workload)
+	}
+}
+
+func TestReviewStep_DefaultsToRepositoryDefaultBranch(t *testing.T) {
+	t.Parallel()
+	dir, integrationSHA, headSHA := setupReviewBaseRepo(t)
+	ag := &mockAgent{name: "review", runFn: func(context.Context, agent.RunOpts) (*agent.Result, error) {
+		return cleanReviewFindings(), nil
+	}}
+	sctx := reviewBaseContext(t, ag, dir, integrationSHA, headSHA)
+	sctx.Config.Review.PathInstructions = reviewBaseRules()
+
+	if _, err := (&ReviewStep{}).Execute(sctx); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if len(ag.calls) != 1 {
+		t.Fatalf("agent calls = %d, want 1", len(ag.calls))
+	}
+	call := ag.calls[0]
+	mainSHA := gitCmd(t, dir, "merge-base", "HEAD", "main")
+	if !strings.Contains(call.Prompt, "base commit: "+mainSHA) {
+		t.Fatalf("review prompt does not fall back to repository default merge-base %s:\n%s", mainSHA, call.Prompt)
+	}
+	if !strings.Contains(call.Prompt, "hardware inherited rule must not be selected") {
+		t.Fatalf("default-branch review did not include the inherited hardware path:\n%s", call.Prompt)
+	}
+	if call.Workload == nil || call.Workload.Files != 2 {
+		t.Fatalf("default-branch workload = %+v, want two changed files", call.Workload)
+	}
+}
+
+func TestReviewStep_FixingAndRereviewUseConfiguredIntegrationBase(t *testing.T) {
+	t.Parallel()
+	dir, integrationSHA, headSHA := setupReviewBaseRepo(t)
+	calls := 0
+	ag := &mockAgent{name: "review", runFn: func(_ context.Context, opts agent.RunOpts) (*agent.Result, error) {
+		calls++
+		if calls == 1 {
+			writeReviewBaseFile(t, dir, "review-fix.txt", "fix\n")
+			return &agent.Result{Output: json.RawMessage(`{"summary":"apply review fix"}`)}, nil
+		}
+		return cleanReviewFindings(), nil
+	}}
+	sctx := reviewBaseContext(t, ag, dir, integrationSHA, headSHA)
+	sctx.Config.PR.BaseBranch = "feature/hardware"
+	sctx.Config.Review.PathInstructions = reviewBaseRules()
+	sctx.Fixing = true
+	sctx.PreviousFindings = `{"findings":[{"severity":"warning","action":"auto-fix","file":"feature-change.txt","description":"fix it"}],"summary":"one finding"}`
+
+	if _, err := (&ReviewStep{}).Execute(sctx); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("agent calls = %d, want fix and rereview", calls)
+	}
+	for i, call := range ag.calls {
+		if !strings.Contains(call.Prompt, "base commit: "+integrationSHA) {
+			t.Errorf("call %d does not use configured integration base %s:\n%s", i+1, integrationSHA, call.Prompt)
+		}
+		if !strings.Contains(call.Prompt, "feature/hardware") {
+			t.Errorf("call %d does not name configured integration branch:\n%s", i+1, call.Prompt)
+		}
+		if strings.Contains(call.Prompt, "hardware inherited rule must not be selected") {
+			t.Errorf("call %d included inherited hardware scope:\n%s", i+1, call.Prompt)
+		}
+	}
+	if ag.calls[1].Workload == nil || ag.calls[1].Workload.Files != 1 {
+		t.Fatalf("rereview workload = %+v, want original one-file workload", ag.calls[1].Workload)
+	}
+}
+
+func TestReviewStep_ConfiguredIntegrationBaseResolutionFailureIsActionable(t *testing.T) {
+	t.Parallel()
+	dir, integrationSHA, headSHA := setupReviewBaseRepo(t)
+	ag := &mockAgent{name: "review", runFn: func(context.Context, agent.RunOpts) (*agent.Result, error) {
+		t.Fatal("review agent should not run when its integration base is unavailable")
+		return nil, nil
+	}}
+	sctx := reviewBaseContext(t, ag, dir, integrationSHA, headSHA)
+	sctx.Config.PR.BaseBranch = "feature/missing"
+
+	_, err := (&ReviewStep{}).Execute(sctx)
+	if err == nil {
+		t.Fatal("expected configured integration base resolution to fail")
+	}
+	message := err.Error()
+	if !strings.Contains(message, "feature/missing") || !strings.Contains(message, "review integration base") {
+		t.Fatalf("error = %q, want actionable configured-base failure", message)
+	}
+	if strings.Contains(message, "reviewing against main") {
+		t.Fatalf("error claims an unsafe fallback: %q", message)
+	}
+}
+
+func TestEffectivePRBaseBranch_UsesTheSameSelectionAsRebaseAndPR(t *testing.T) {
+	t.Parallel()
+	sctx := &pipeline.StepContext{
+		Repo:   &db.Repo{DefaultBranch: "main"},
+		Config: &config.Config{PR: config.PR{BaseBranch: "feature/hardware"}},
+	}
+	if got := effectivePRBaseBranch(sctx); got != "feature/hardware" {
+		t.Fatalf("effective base = %q, want feature/hardware", got)
+	}
+	sctx.Config.PR.BaseBranch = ""
+	if got := effectivePRBaseBranch(sctx); got != "main" {
+		t.Fatalf("fallback effective base = %q, want main", got)
+	}
+}

--- a/internal/pipeline/steps/review_session_test.go
+++ b/internal/pipeline/steps/review_session_test.go
@@ -85,6 +85,7 @@ func (a *sessionFallbackTimeoutAgent) Run(ctx context.Context, opts agent.RunOpt
 func reviewSessionHarness(t *testing.T, mock *sessionMockAgent, steps []pipeline.Step) (*pipeline.Executor, *db.DB, *db.Run, *db.Repo, string) {
 	t.Helper()
 	workDir, baseSHA, headSHA := setupGitRepo(t)
+	gitCmd(t, workDir, "remote", "add", "origin", workDir)
 
 	database, err := db.Open(filepath.Join(t.TempDir(), "state.sqlite"))
 	if err != nil {


### PR DESCRIPTION
## Summary

- Review now resolves and fetches the effective trusted PR integration base before computing merge-base, changed paths, workload, and prompts.
- Rebase and PR routing share the same effective base selector; regression coverage includes configured/default/zero-SHA, fix-rereview, failure, and consistency cases.

## Validation

- `make lint`
- `go test ./...`
- `go test -race ./internal/pipeline/steps -count=1`
- `go build -o ./bin/no-mistakes-dev ./cmd/no-mistakes`

Full `go test -race ./...` was attempted; unrelated macOS `internal/branchsync` tests timed out at 10 minutes while the rest of the suite passed.
