### PR TITLE
fix(agent): bound pi startup, stderr, and event-size growth and add ready/tool lifecycle events

### DIFF
--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -216,7 +216,7 @@ All agents implement the same interface. Each invocation receives:
 - **Environment** - the daemon environment plus non-interactive Git overrides (`GIT_EDITOR=true`, `GIT_SEQUENCE_EDITOR=true`, and `GIT_TERMINAL_PROMPT=0`) so agent-invoked Git commands do not hang on editors or credential prompts
 - **JSONSchema** - optional structured output schema for typed responses
 - **OnChunk** - callback for streaming text output to the TUI
-- **OnLifecycle** - callback for native subprocess start, exit, retry, fallback, and output-liveness activity; control events reach step logs and AXI active-step status, while throttled output liveness updates status without flooding the log
+- **OnLifecycle** - callback for native subprocess start, ready, tool, exit, retry, fallback, and output-liveness activity; control events reach step logs and AXI active-step status, while throttled output liveness updates status without flooding the log. Ready and tool events are bounded diagnostics: they carry only a phase label and (for tool events) the tool name and outcome, never arguments or output.
 - **Session** - optional no-mistakes-owned native session identity for review-fixer reuse
 - **Purpose** - local performance label for the pipeline duty served
 
@@ -295,6 +295,8 @@ Starts a persistent HTTP server (`opencode serve`) on first use and reuses it ac
 Spawns a `pi` subprocess for each invocation with `--mode json`. Cold invocations add `--no-session`; with `session_reuse: true`, review-fixer turns instead create and resume one Pi session per run via `--session <UUID>`.
 Model and reasoning effort come from [`agent_config.pi`](/no-mistakes/reference/global-config/#agent_config), rendered as `--model` and `--thinking`. See [`agent_args_override`](/no-mistakes/reference/global-config/#agent_args_override) for Pi override precedence.
 Reads JSONL events from stdout and streams incremental text deltas to the TUI.
+Pi's local startup is bounded: if Pi has not emitted its first JSON event within 30 seconds of launch, no-mistakes stops the subprocess and fails the invocation with that timeout plus the captured stderr tail.
+Diagnostic stderr is retained only as a bounded 32 KiB tail, and a single JSON event larger than 16 MiB fails the invocation instead of growing daemon memory without bound.
 When structured output is requested, no-mistakes injects the JSON schema into the prompt and validates the final text response with the common text fallback described above.
 
 ## Copilot CLI

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -338,4 +338,4 @@ When a non-terminal run has a step in `awaiting_approval` or `fix_review`, AXI r
 The signal clears as soon as the approval wait ends, including `axi respond` and cancellation, and does not change how gates resolve.
 When a step is `running` or `fixing`, AXI run objects expose an `active_steps` table with active duration, latest activity, native subprocess PID when present, and the current round such as `round 1`, `auto-fix 1/3`, or `fix 2`.
 If the latest activity is older than `step_quiet_warning`, AXI prefixes it with `quiet` to make possible wedges visible without changing the run state.
-Step logs also record native subprocess start, exit, and retry lifecycle lines plus explicit auto-fix and user-fix round markers.
+Step logs also record native subprocess start, ready, tool, exit, and retry lifecycle lines plus explicit auto-fix and user-fix round markers.

--- a/internal/agent/lifecycle.go
+++ b/internal/agent/lifecycle.go
@@ -16,6 +16,14 @@ const (
 	// LifecyclePhaseFallback marks any fallback before a fresh agent attempt,
 	// including provider, session-resume, and structured-output fallbacks.
 	LifecyclePhaseFallback = "fallback"
+	// LifecyclePhaseReady marks the point where a native agent has completed
+	// local startup and begun emitting its machine-readable protocol.
+	LifecyclePhaseReady = "ready"
+	// LifecyclePhaseToolStarted and LifecyclePhaseToolFinished are bounded
+	// diagnostics for a tool invocation. They deliberately carry only the tool
+	// name and outcome, never arguments or output.
+	LifecyclePhaseToolStarted  = "tool_started"
+	LifecyclePhaseToolFinished = "tool_finished"
 	// LifecyclePhaseActivity marks observed liveness of a running native
 	// subprocess: bytes arrived on its stdout or stderr.
 	//

--- a/internal/agent/native_command.go
+++ b/internal/agent/native_command.go
@@ -24,6 +24,60 @@ type nativeAgentCommand struct {
 	pipesDone      chan struct{}
 }
 
+// nativeAgentStderrLimit keeps a noisy native CLI or one of its inherited
+// children from growing the daemon without bound. Stderr is diagnostic output,
+// so retaining the tail preserves the failure nearest process exit while the
+// reader continues draining the pipe and cannot deadlock the child.
+const nativeAgentStderrLimit = 32 * 1024
+
+type boundedTailBuffer struct {
+	buf       []byte
+	limit     int
+	discarded int64
+}
+
+func newBoundedTailBuffer(limit int) *boundedTailBuffer {
+	return &boundedTailBuffer{limit: limit}
+}
+
+func (b *boundedTailBuffer) Write(p []byte) (int, error) {
+	n := len(p)
+	if b.limit <= 0 {
+		b.discarded += int64(n)
+		return n, nil
+	}
+	if len(p) >= b.limit {
+		b.discarded += int64(len(b.buf) + len(p) - b.limit)
+		b.buf = append(b.buf[:0], p[len(p)-b.limit:]...)
+		return n, nil
+	}
+	overflow := len(b.buf) + len(p) - b.limit
+	if overflow > 0 {
+		copy(b.buf, b.buf[overflow:])
+		b.buf = b.buf[:len(b.buf)-overflow]
+		b.discarded += int64(overflow)
+	}
+	b.buf = append(b.buf, p...)
+	return n, nil
+}
+
+func (b *boundedTailBuffer) bytes() []byte {
+	if b.discarded == 0 {
+		return append([]byte(nil), b.buf...)
+	}
+	prefix := []byte(fmt.Sprintf("[discarded %d earlier stderr bytes]\n", b.discarded))
+	out := make([]byte, 0, len(prefix)+len(b.buf))
+	out = append(out, prefix...)
+	out = append(out, b.buf...)
+	return out
+}
+
+func captureNativeAgentStderr(r io.Reader) []byte {
+	tail := newBoundedTailBuffer(nativeAgentStderrLimit)
+	_, _ = io.Copy(tail, r)
+	return tail.bytes()
+}
+
 func writeNativeAgentStdin(stdin io.WriteCloser, prompt string) <-chan error {
 	errCh := make(chan error, 1)
 	go func() {

--- a/internal/agent/native_command_stdin_test.go
+++ b/internal/agent/native_command_stdin_test.go
@@ -25,3 +25,19 @@ func TestWriteNativeAgentStdinReportsWriteAndCloseFailures(t *testing.T) {
 		t.Fatalf("error = %q, want both failure diagnostics", got)
 	}
 }
+
+func TestCaptureNativeAgentStderrKeepsBoundedTail(t *testing.T) {
+	prefix := strings.Repeat("a", nativeAgentStderrLimit)
+	tail := "LAST-PI-DIAGNOSTIC"
+	got := string(captureNativeAgentStderr(strings.NewReader(prefix + tail)))
+
+	if !strings.Contains(got, "discarded") {
+		t.Fatalf("captured stderr did not report truncation: %q", got[:min(len(got), 120)])
+	}
+	if !strings.HasSuffix(got, tail) {
+		t.Fatalf("captured stderr lost diagnostic tail: suffix=%q", got[max(0, len(got)-64):])
+	}
+	if len(got) > nativeAgentStderrLimit+128 {
+		t.Fatalf("captured stderr length = %d, want bounded near %d", len(got), nativeAgentStderrLimit)
+	}
+}

--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/shellenv"
 )
@@ -20,11 +21,21 @@ import (
 type piAgent struct {
 	bin       string
 	extraArgs []string
+	// localStartupTimeout bounds the phase before Pi emits its first valid
+	// JSON event. Tests shorten it; production uses defaultPiLocalStartupTimeout.
+	localStartupTimeout time.Duration
 	// disableProjectSettings is the resolved, trusted-only opt-out. When true,
 	// buildArgs suppresses pi's project-level AGENTS.md/CLAUDE.md discovery.
 	disableProjectSettings bool
 	subprocessContext
 }
+
+const (
+	defaultPiLocalStartupTimeout = 30 * time.Second
+	maxPiEventBytes              = 16 * 1024 * 1024
+)
+
+var errPiLocalStartupTimeout = errors.New("pi local startup timeout")
 
 func (a *piAgent) Name() string { return "pi" }
 
@@ -61,8 +72,22 @@ func (a *piAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 		// turn a recovery attempt into an arbitrary session-file selection.
 		return nil, fmt.Errorf("invalid pi session identity")
 	}
+	startupTimeout := a.localStartupTimeout
+	if startupTimeout <= 0 {
+		startupTimeout = defaultPiLocalStartupTimeout
+	}
+	commandCtx, cancelCommand := context.WithCancelCause(ctx)
+	defer cancelCommand(nil)
+	var startupResolved sync.Once
+	startupTimer := time.AfterFunc(startupTimeout, func() {
+		startupResolved.Do(func() {
+			cancelCommand(errPiLocalStartupTimeout)
+		})
+	})
+	defer startupTimer.Stop()
+
 	args := a.buildArgs(opts.Session)
-	cmd := exec.CommandContext(ctx, a.bin, args...)
+	cmd := exec.CommandContext(commandCtx, a.bin, args...)
 	cmd.Dir = opts.CWD
 	cmd.Env = a.gitSafeEnv(opts.CWD, opts.Env)
 	shellenv.ConfigureShellCommand(cmd)
@@ -89,14 +114,43 @@ func (a *piAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 	stderrWG.Add(1)
 	go func() {
 		defer stderrWG.Done()
-		stderrBuf, _ = io.ReadAll(started.stderr)
+		stderrBuf = captureNativeAgentStderr(started.stderr)
 	}()
 
-	pp := &piParser{onChunk: opts.OnChunk}
-	if err := pp.parse(ctx, started.stdout); err != nil {
+	pp := &piParser{
+		onChunk: opts.OnChunk,
+		onFirstEvent: func() {
+			startupResolved.Do(func() {})
+			startupTimer.Stop()
+			emitLifecycle(opts, LifecycleEvent{
+				Agent:   "pi",
+				Phase:   LifecyclePhaseReady,
+				Message: "pi initialized JSON stream",
+			})
+		},
+		onToolEvent: func(phase, tool string, failed bool) {
+			message := fmt.Sprintf("pi tool %s: %s", phase, piToolLabel(tool))
+			lifecyclePhase := LifecyclePhaseToolStarted
+			if phase == "finished" && failed {
+				message += " status=error"
+			}
+			if phase == "finished" {
+				lifecyclePhase = LifecyclePhaseToolFinished
+			}
+			emitLifecycle(opts, LifecycleEvent{
+				Agent:   "pi",
+				Phase:   lifecyclePhase,
+				Message: message,
+			})
+		},
+	}
+	if err := pp.parse(commandCtx, started.stdout); err != nil {
 		err = started.waitAfterParseError(err)
 		stderrWG.Wait()
 		err = errors.Join(err, piStdinError(<-stdinErrCh))
+		if errors.Is(context.Cause(commandCtx), errPiLocalStartupTimeout) {
+			err = piLocalStartupError(startupTimeout, strings.TrimSpace(string(stderrBuf)))
+		}
 		retErr := fmt.Errorf("pi parse events: %w", err)
 		emitAgentExited(opts, "pi", pid, retErr)
 		return nil, retErr
@@ -106,6 +160,11 @@ func (a *piAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 	stderrWG.Wait()
 	stdinErr := piStdinError(<-stdinErrCh)
 	stderr := strings.TrimSpace(string(stderrBuf))
+	if errors.Is(context.Cause(commandCtx), errPiLocalStartupTimeout) {
+		retErr := piLocalStartupError(startupTimeout, stderr)
+		emitAgentExited(opts, "pi", pid, retErr)
+		return nil, retErr
+	}
 	if waitErr != nil {
 		if stderr != "" {
 			retErr := fmt.Errorf("pi exited: %w: %s", errors.Join(waitErr, stdinErr), stderr)
@@ -153,6 +212,14 @@ func (a *piAgent) runOnce(ctx context.Context, opts RunOpts) (*Result, error) {
 	}
 	emitAgentExited(opts, "pi", pid, err)
 	return res, err
+}
+
+func piLocalStartupError(timeout time.Duration, stderr string) error {
+	err := fmt.Errorf("pi did not initialize within %s before its first JSON event: %w", timeout, errPiLocalStartupTimeout)
+	if stderr != "" {
+		err = fmt.Errorf("%w: %s", err, stderr)
+	}
+	return err
 }
 
 func piStdinError(err error) error {
@@ -270,7 +337,10 @@ func buildPiPrompt(prompt string, schema json.RawMessage) string {
 // deltas, captures the final assistant text and usage, and surfaces any
 // reported assistant error.
 type piParser struct {
-	onChunk func(string)
+	onChunk      func(string)
+	onFirstEvent func()
+	onToolEvent  func(phase, tool string, failed bool)
+	firstEvent   sync.Once
 
 	streamText     map[int]string
 	completeText   map[int]string
@@ -285,7 +355,7 @@ type piParser struct {
 
 func (p *piParser) parse(ctx context.Context, r io.Reader) error {
 	scanner := bufio.NewScanner(r)
-	scanner.Buffer(make([]byte, 0, 64*1024), 256*1024*1024)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxPiEventBytes)
 
 	p.streamText = make(map[int]string)
 	p.completeText = make(map[int]string)
@@ -307,10 +377,21 @@ func (p *piParser) parse(ctx context.Context, r io.Reader) error {
 		if err := json.Unmarshal(line, &event); err != nil {
 			continue
 		}
+		p.firstEvent.Do(func() {
+			if p.onFirstEvent != nil {
+				p.onFirstEvent()
+			}
+		})
 		p.handleEvent(event)
 	}
 
-	return scanner.Err()
+	if err := scanner.Err(); err != nil {
+		if strings.Contains(err.Error(), "token too long") {
+			return fmt.Errorf("pi JSON event exceeded %d MiB limit: %w", maxPiEventBytes/(1024*1024), err)
+		}
+		return err
+	}
+	return nil
 }
 
 func (p *piParser) handleEvent(event map[string]any) {
@@ -332,7 +413,33 @@ func (p *piParser) handleEvent(event map[string]any) {
 		p.recordAssistantUsage(event["message"])
 	case "agent_end":
 		p.rememberAgentEnd(event["messages"])
+	case "tool_execution_start":
+		p.reportToolEvent("started", event, false)
+	case "tool_execution_end":
+		failed, _ := event["isError"].(bool)
+		p.reportToolEvent("finished", event, failed)
 	}
+}
+
+func (p *piParser) reportToolEvent(phase string, event map[string]any, failed bool) {
+	if p.onToolEvent == nil {
+		return
+	}
+	tool := piFirstString(event, "toolName", "tool")
+	if tool == "" {
+		tool = "unknown"
+	}
+	p.onToolEvent(phase, tool, failed)
+}
+
+func piToolLabel(tool string) string {
+	tool = strings.Join(strings.Fields(tool), " ")
+	const maxRunes = 80
+	runes := []rune(tool)
+	if len(runes) > maxRunes {
+		tool = string(runes[:maxRunes]) + "..."
+	}
+	return tool
 }
 
 func (p *piParser) rememberAssistant(raw any) {

--- a/internal/agent/pi.go
+++ b/internal/agent/pi.go
@@ -386,7 +386,7 @@ func (p *piParser) parse(ctx context.Context, r io.Reader) error {
 	}
 
 	if err := scanner.Err(); err != nil {
-		if strings.Contains(err.Error(), "token too long") {
+		if errors.Is(err, bufio.ErrTooLong) {
 			return fmt.Errorf("pi JSON event exceeded %d MiB limit: %w", maxPiEventBytes/(1024*1024), err)
 		}
 		return err

--- a/internal/agent/pi_test.go
+++ b/internal/agent/pi_test.go
@@ -612,6 +612,34 @@ sleep 30
 	}
 }
 
+func TestPiAgent_LocalStartupTimeoutStopsSilentChild(t *testing.T) {
+	dir := t.TempDir()
+	bin := writeFakePi(t, dir, `#!/bin/sh
+sleep 30
+`, strings.Join([]string{
+		"@echo off",
+		"timeout /t 30 /nobreak > nul",
+	}, "\r\n"))
+
+	pa := &piAgent{bin: bin, localStartupTimeout: 100 * time.Millisecond}
+	started := time.Now()
+	_, err := pa.Run(context.Background(), RunOpts{Prompt: "review", CWD: dir})
+	if err == nil || !errors.Is(err, errPiLocalStartupTimeout) {
+		t.Fatalf("Run error = %v, want local startup timeout", err)
+	}
+	if elapsed := time.Since(started); elapsed > 5*time.Second {
+		t.Fatalf("local startup timeout returned after %s, want a bounded failure", elapsed)
+	}
+}
+
+func TestPiParser_RejectsOversizedJSONEvent(t *testing.T) {
+	line := strings.Repeat("x", maxPiEventBytes+1)
+	err := (&piParser{}).parse(context.Background(), strings.NewReader(line))
+	if err == nil || !strings.Contains(err.Error(), "pi JSON event exceeded 16 MiB limit") {
+		t.Fatalf("parse error = %v, want bounded event diagnostic", err)
+	}
+}
+
 // TestPiAgent_ToolOnlyStreamStillReportsSubprocessLiveness pins the proof of
 // life that separates a working native agent from a wedged one.
 //
@@ -639,13 +667,13 @@ printf '%s\n' '{"type":"agent_end","messages":[{"role":"assistant","content":[{"
 	}, "\r\n"))
 
 	var chunks []string
-	var phases []string
+	var events []LifecycleEvent
 	pa := &piAgent{bin: bin}
 	if _, err := pa.Run(context.Background(), RunOpts{
 		Prompt:      "fix ci",
 		CWD:         t.TempDir(),
 		OnChunk:     func(s string) { chunks = append(chunks, s) },
-		OnLifecycle: func(e LifecycleEvent) { phases = append(phases, e.Phase) },
+		OnLifecycle: func(e LifecycleEvent) { events = append(events, e) },
 	}); err != nil {
 		t.Fatalf("run pi: %v", err)
 	}
@@ -655,19 +683,34 @@ printf '%s\n' '{"type":"agent_end","messages":[{"role":"assistant","content":[{"
 	}
 	activityAt := -1
 	exitAt := -1
-	for i, phase := range phases {
-		if phase == LifecyclePhaseActivity && activityAt < 0 {
+	readyAt := -1
+	toolStartedAt := -1
+	toolFinishedAt := -1
+	for i, event := range events {
+		if event.Phase == LifecyclePhaseActivity && activityAt < 0 {
 			activityAt = i
 		}
-		if phase == LifecyclePhaseExit {
+		if event.Phase == LifecyclePhaseReady {
+			readyAt = i
+		}
+		if event.Phase == LifecyclePhaseToolStarted && event.Message == "pi tool started: bash" {
+			toolStartedAt = i
+		}
+		if event.Phase == LifecyclePhaseToolFinished && event.Message == "pi tool finished: bash" {
+			toolFinishedAt = i
+		}
+		if event.Phase == LifecyclePhaseExit {
 			exitAt = i
 		}
 	}
 	if activityAt < 0 {
-		t.Fatalf("lifecycle phases = %v, want subprocess liveness reported for a tool-only turn", phases)
+		t.Fatalf("lifecycle events = %v, want subprocess liveness reported for a tool-only turn", events)
 	}
 	if exitAt < 0 || activityAt > exitAt {
-		t.Fatalf("lifecycle phases = %v, want liveness reported while the agent was still running", phases)
+		t.Fatalf("lifecycle events = %v, want liveness reported while the agent was still running", events)
+	}
+	if readyAt < 0 || toolStartedAt < readyAt || toolFinishedAt < toolStartedAt || exitAt < toolFinishedAt {
+		t.Fatalf("lifecycle events = %v, want ready then bounded tool start/finish diagnostics before exit", events)
 	}
 }
 


### PR DESCRIPTION
## What Changed

- Add a 30-second pi local-startup timeout: if pi emits no first JSON event after launch, the subprocess is stopped and the invocation fails with the timeout plus a bounded stderr tail.

- Cap captured native-agent stderr to a 32 KiB tail (with a discarded-bytes marker) and reject any single pi JSON event larger than 16 MiB, so a noisy or wedged child cannot grow daemon memory without bound.

- Emit new bounded `ready`, `tool_started`, and `tool_finished` lifecycle events for pi (tool name and outcome only, never arguments or output) that surface in step logs and AXI active-step status; docs updated to match.

## Risk Assessment

✅ Low: The fix round applied exactly the one-line sentinel check the user authorized with no new machinery, and a full re-trace of the bounded stderr buffer, startup timeout cause attribution, and lifecycle event consumers found no reachable defect.

## Testing

Ran the targeted pi-adapter unit tests under -race (bounded stderr tail, local startup timeout, oversized-event rejection, tool-only lifecycle ordering) and then exercised piAgent.Run end-to-end against fake pi binaries in four scenarios, capturing the exact user-visible errors and lifecycle events the daemon would surface; all behaved as intended and the temporary demo test was removed, leaving the worktree clean.

<details>
<summary>Evidence: Curated transcript of the four end-user scenarios with exact surfaced errors and lifecycle events</summary>

```text
pi adapter native-invocation bounds - end-user-visible demonstration
branch fix/bound-native-invocations, commit cbeeb08
Each scenario ran piAgent.Run (the daemon's actual invocation path) against a fake pi binary; the lines below are the errors and lifecycle events exactly as the daemon would surface them (full raw log: pi-native-bounds-demo.log).

1) Noisy failing pi (40 KB of stderr noise + real diagnostic):
   surfaced error: pi exited: exit status 1: [discarded 7279 earlier stderr bytes]
   xxxxx...xxxxxFATAL: could not reach model provider endpoint
   -> stderr retained as a bounded 32 KiB tail; the final diagnostic nearest exit survives, memory cannot grow without bound.

2) Silent wedged pi (never emits its first JSON event):
   surfaced error after 228ms (startup timeout 200ms; production default 30s):
   pi did not initialize within 200ms before its first JSON event: pi local startup timeout
   lifecycle: start: pi started pid=3950919 / exit: pi exited pid=3950919 error=pi did not initialize within 200ms before its first JSON event: pi local startup timeout
   -> a stalled local startup is bounded instead of hanging the run forever.

3) Oversized JSON event (17 MiB single line):
   surfaced error: pi parse events: pi JSON event exceeded 16 MiB limit: bufio.Scanner: token too long
   -> per-event cap at 16 MiB, classified via errors.Is(err, bufio.ErrTooLong) with an explicit message.

4) Healthy tool-only turn - lifecycle transcript an operator sees (axi logs):
   start: pi started pid=3951645
   activity: pi producing output
   ready: pi initialized JSON stream
   tool_started: pi tool started: bash
   tool_finished: pi tool finished: bash
   exit: pi exited pid=3951645 status=success

Scope note (per recorded decisions): bounded stderr capture and the 16 MiB event cap are deliberately scoped to the Pi adapter; the errors.Is(bufio.ErrTooLong) classification replaced the previous string comparison.
```
</details>
<details>
<summary>Evidence: Raw go test -v output of the end-to-end demo scenarios</summary>

```text
=== RUN   TestEvidenceDemo_NoisyFailingPiKeepsBoundedTail
    zz_evidence_demo_test.go:49: [noisy-failure] surfaced error: pi exited: exit status 1: [discarded 7279 earlier stderr bytes]
        xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

... [17965 bytes truncated] ...

xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxFATAL: could not reach model provider endpoint
--- PASS: TestEvidenceDemo_NoisyFailingPiKeepsBoundedTail (0.03s)
=== RUN   TestEvidenceDemo_SilentPiHitsStartupTimeout
    zz_evidence_demo_test.go:73: [silent-wedge] surfaced error after 228ms: pi did not initialize within 200ms before its first JSON event: pi local startup timeout
    asm_amd64.s:1264: [silent-wedge] lifecycle start: pi started pid=3950919
    asm_amd64.s:1264: [silent-wedge] lifecycle exit: pi exited pid=3950919 error=pi did not initialize within 200ms before its first JSON event: pi local startup timeout
--- PASS: TestEvidenceDemo_SilentPiHitsStartupTimeout (0.23s)
=== RUN   TestEvidenceDemo_OversizedEventRejected
    zz_evidence_demo_test.go:87: [oversized-event] surfaced error: pi parse events: pi JSON event exceeded 16 MiB limit: bufio.Scanner: token too long
--- PASS: TestEvidenceDemo_OversizedEventRejected (1.03s)
=== RUN   TestEvidenceDemo_HealthyTurnLifecycleTranscript
    zz_evidence_demo_test.go:108: [healthy-turn] lifecycle transcript:
          start: pi started pid=3951645
          activity: pi producing output
          ready: pi initialized JSON stream
          tool_started: pi tool started: bash
          tool_finished: pi tool finished: bash
          exit: pi exited pid=3951645 status=success
--- PASS: TestEvidenceDemo_HealthyTurnLifecycleTranscript (0.01s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/agent	2.378s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"de59387e40d49bf48ade1c90b2ed79de59fc093d","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `internal/agent/native_command.go:53` - The commit claims a durable bound on &#39;retained stderr&#39;, but captureNativeAgentStderr is applied only to the pi adapter. The identical unbounded io.ReadAll(started.stderr) remains in six sibling native adapters (internal/agent/acpx.go:72, antigravity.go:131, claude.go:97, codex.go:113, copilot.go:60, grok.go:117), so a noisy or wedged child of any of those agents still grows daemon memory without bound - the exact failure this change claims to fix. The helper is already shared and generic; swapping each call site is mechanical and behavior-preserving (tail retained, truncation noted).
- ℹ️ `internal/agent/pi.go:358` - The commit also bounds &#39;individual event size&#39; (pi: 256MiB -&gt; 16MiB maxPiEventBytes), but the antigravity (antigravity.go:276), codex (codex.go:327), and sse (sse.go:20) scanners still allow 256MiB per event, so a single pathological event there can still allocate up to 256MiB. Whether to extend the 16MiB bound to those adapters (with their own legit-event-size verification) is a scope decision beyond pi&#39;s change.
- ℹ️ `internal/agent/pi.go:391` - scanner.Err() is classified via strings.Contains(err.Error(), &#34;token too long&#34;) instead of errors.Is(err, bufio.ErrTooLong). The sentinel exists and Scanner returns it directly, so errors.Is is the robust check and cannot misfire on a legitimate event whose text contains that phrase.

🔧 Fix: fix(agent): classify pi scanner overflow via errors.Is(bufio.ErrTooLong)
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -race -run 'TestCaptureNativeAgentStderrKeepsBoundedTail|TestPiAgent_LocalStartupTimeoutStopsSilentChild|TestPiParser_RejectsOversizedJSONEvent|TestPiAgent_ToolOnlyStreamStillReportsSubprocessLiveness' ./internal/agent/`
- <code>`go test -race -run &#39;TestPiAgent_&#39; ./internal/agent/` (full pi adapter package run after cleanup)</code>
- <code>Manual end-to-end demo (temporary test, removed afterward): ran `piAgent.Run` with fake pi binaries covering four scenarios - noisy failing child (40 KB stderr noise + real diagnostic, asserted bounded tail with `[discarded N earlier stderr bytes]` and the surviving FATAL line), silent wedged child (bounded `pi local startup timeout` error returned in ~0.2s instead of hanging), 17 MiB single JSON event (`pi JSON event exceeded 16 MiB limit: bufio.Scanner: token too long`), and a healthy tool-only turn (lifecycle transcript start/activity/ready/tool_started/tool_finished/exit)</code>
- <code>Confirmed no regression of the errors.Is classification: grep verified no `token too long` string comparison remains in `internal/agent/`, and the oversized-event demo error message is produced through the `errors.Is(err, bufio.ErrTooLong)` branch</code>
- <code>Verified worktree returned to clean state (`git status --porcelain` empty) after removing the temporary demo test</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ linter found issues (exit code 2)

🔧 Fix: Rerun lint clean; no source issues found
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>



## Follow-up scope

The same unbounded stderr-capture pattern exists in sibling native adapters, and other scanners including SSE retain larger per-event limits. Bounding those paths should be follow-up work with per-adapter verification of legitimate event sizes so a memory safeguard does not become a protocol truncation bug.
