### PR TITLE
fix: avoid GitHub API rate limits during installation

### DIFF
--- a/docs/install.sh
+++ b/docs/install.sh
@@ -29,7 +29,18 @@ case "$ARCH" in
   *) echo "Unsupported architecture: $ARCH"; exit 1 ;;
 esac
 
-VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+# GitHub's unauthenticated REST API is capped at 60 req/hr/IP; the HTML
+# /releases/latest redirect is not, and lands on /releases/tag/<tag>.
+latest_url="$(curl -fsSLI -o /dev/null -w '%{url_effective}' "https://github.com/${REPO}/releases/latest")"
+VERSION=""
+case "$latest_url" in
+  */releases/tag/*)
+    VERSION="${latest_url##*/releases/tag/}"
+    VERSION="${VERSION%%\?*}"
+    VERSION="${VERSION%%#*}"
+    VERSION="${VERSION%/}"
+    ;;
+esac
 if [ -z "$VERSION" ]; then
   echo "Could not determine latest release"
   exit 1

--- a/install_script_test.go
+++ b/install_script_test.go
@@ -119,6 +119,69 @@ func TestInstallScriptFailsWhenDaemonRestartFails(t *testing.T) {
 	}
 }
 
+func TestInstallScriptResolvesVersionFromLatestRedirect(t *testing.T) {
+	skipInstallScriptTestsOnWindows(t)
+
+	home := t.TempDir()
+	archivePath := filepath.Join(t.TempDir(), "no-mistakes-v1.2.3-darwin-arm64.tar.gz")
+	binaryScript := "#!/bin/sh\nexit 0\n"
+	makeInstallArchive(t, archivePath, binaryScript)
+	fakeBin := makeFakeInstallCommands(t)
+	localBin := filepath.Join(home, ".local", "bin")
+	if err := os.MkdirAll(localBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	curlLog := filepath.Join(t.TempDir(), "curl.log")
+
+	runInstallScript(t, home, fakeBin, map[string]string{
+		"FAKE_RELEASE_ARCHIVE":      archivePath,
+		"FAKE_CURL_LOG":             curlLog,
+		"FAKE_LATEST_EFFECTIVE_URL": "https://github.com/kunchenguid/no-mistakes/releases/tag/v1.2.3",
+	})
+
+	data, err := os.ReadFile(curlLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logged := string(data)
+	if strings.Contains(logged, "api.github.com") {
+		t.Fatalf("install.sh default path must not call api.github.com, got curl URLs:\n%s", logged)
+	}
+	if !strings.Contains(logged, "https://github.com/kunchenguid/no-mistakes/releases/latest") {
+		t.Fatalf("install.sh should resolve the latest tag via the /releases/latest redirect, got curl URLs:\n%s", logged)
+	}
+	if !strings.Contains(logged, "https://github.com/kunchenguid/no-mistakes/releases/download/v1.2.3/no-mistakes-v1.2.3-darwin-arm64.tar.gz") {
+		t.Fatalf("install.sh should download the versioned asset parsed from the redirect, got curl URLs:\n%s", logged)
+	}
+
+	realBin := filepath.Join(home, ".no-mistakes", "bin", "no-mistakes")
+	assertFileContent(t, realBin, binaryScript)
+}
+
+func TestInstallScriptFailsWhenLatestRedirectHasNoTag(t *testing.T) {
+	skipInstallScriptTestsOnWindows(t)
+
+	home := t.TempDir()
+	archivePath := filepath.Join(t.TempDir(), "no-mistakes-v1.2.3-darwin-arm64.tar.gz")
+	makeInstallArchive(t, archivePath, "#!/bin/sh\nexit 0\n")
+	fakeBin := makeFakeInstallCommands(t)
+	localBin := filepath.Join(home, ".local", "bin")
+	if err := os.MkdirAll(localBin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	output, err := runInstallScriptCommand(t, home, fakeBin, map[string]string{
+		"FAKE_RELEASE_ARCHIVE":      archivePath,
+		"FAKE_LATEST_EFFECTIVE_URL": "https://github.com/kunchenguid/no-mistakes/releases/latest",
+	})
+	if err == nil {
+		t.Fatalf("install.sh should fail when the latest URL has no tag\n%s", output)
+	}
+	if !strings.Contains(string(output), "Could not determine latest release") {
+		t.Fatalf("install.sh should keep the empty-version guard, got:\n%s", output)
+	}
+}
+
 func TestPowerShellInstallScriptChecksDaemonRestartFailure(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join("docs", "install.ps1"))
 	if err != nil {
@@ -233,16 +296,26 @@ out=""
 url=""
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    -o) out="$2"; shift 2 ;;
+    -o|--output) out="$2"; shift 2 ;;
+    -w|--write-out) shift 2 ;;
     -*) shift ;;
     *) url="$1"; shift ;;
   esac
 done
-if [ -n "$out" ]; then
+if [ -n "$FAKE_CURL_LOG" ]; then
+  printf '%s\n' "$url" >> "$FAKE_CURL_LOG"
+fi
+case "$url" in
+  */releases/latest)
+    printf '%s' "${FAKE_LATEST_EFFECTIVE_URL:-https://github.com/kunchenguid/no-mistakes/releases/tag/v1.2.3}"
+    exit 0
+    ;;
+esac
+if [ -n "$out" ] && [ "$out" != "/dev/null" ]; then
   cp "$FAKE_RELEASE_ARCHIVE" "$out"
   exit 0
 fi
-	printf '{"tag_name":"v1.2.3"}'
+exit 1
 `)
 	writeExecutable(t, filepath.Join(binDir, "sudo"), "#!/bin/sh\nexec \"$@\"\n")
 	return binDir


### PR DESCRIPTION
## Intent

Fix docs/install.sh so it no longer 403s for users who hit GitHub's unauthenticated REST API rate limit (60 requests/hour per IP). Resolve the latest release version from the github.com/<repo>/releases/latest HTML redirect (headers-only, follow to /releases/tag/<TAG>) instead of api.github.com/repos/.../releases/latest. Keep -f fail-on-error and the existing empty-version guard ("Could not determine latest release" -> exit 1). Do not change how the download URL or FILENAME are constructed (still github.com/${REPO}/releases/download/${VERSION}/${FILENAME}). Stay POSIX sh compatible; do not add a jq dependency. Default path must not require a token. Do not switch to a version-less latest/download filename because the asset filename currently embeds the version. Validate with a behavioral test of the version-parse: redirect-shaped input yields the correct tag, the default path does not call api.github.com, and a non-parseable response still hits the empty-version guard.

## What Changed

- Resolve the latest release tag from GitHub's headers-only `/releases/latest` redirect instead of the rate-limited REST API.
- Add behavioral coverage for redirect parsing, versioned asset downloads, avoiding `api.github.com`, and rejecting responses without a release tag.

## Risk Assessment

✅ Low: The change is narrowly scoped, preserves the required download construction and failure behavior, avoids the rate-limited API, and exercises the requested observable behaviors through the installer interface.

## Testing

Targeted installer tests and POSIX shell checks passed; controlled end-to-end execution parsed v9.8.7, used the unchanged versioned download URL without api.github.com, installed and linked the binary, and returned the required guard error for an unparseable response. A live unauthenticated headers-only GitHub request also resolved successfully to the current release tag. Reviewer-visible transcripts were captured, and the worktree remained clean.

<details>
<summary>Evidence: Controlled installer success and empty-version guard transcript</summary>

Source: [Controlled installer success and empty-version guard transcript](https://github.com/kunchenguid/no-mistakes/blob/245902afac06f7bbb811570c27b355f4e9fd3fb2/.no-mistakes/evidence/fm/nm-install-403-ratelimit-r1/install-latest-redirect-transcript.txt)

```text
=== successful end-to-end install from redirect-shaped effective URL ===
Downloading no-mistakes v9.8.7 for darwin/arm64...
no-mistakes v9.8.7 installed to <temp>~/bin/no-mistakes
Command path: <temp>/link/no-mistakes -> <temp>~/bin/no-mistakes
Add <temp>/link to your PATH and restart your terminal.

Observed curl invocations:
curl -fsSLI -o /dev/null -w %{url_effective} https://github.com/kunchenguid/no-mistakes/releases/latest
curl -fsSL https://github.com/kunchenguid/no-mistakes/releases/download/v9.8.7/no-mistakes-v9.8.7-darwin-arm64.tar.gz -o <download-temp>/no-mistakes-v9.8.7-darwin-arm64.tar.gz

Installed binary: executable (exit 0)
Installed symlink target: <temp>~/bin/no-mistakes

=== non-parseable effective URL ===
exit_status=1
Could not determine latest release
Observed curl invocations:
curl -fsSLI -o /dev/null -w %{url_effective} https://github.com/kunchenguid/no-mistakes/releases/latest
```
</details>
<details>
<summary>Evidence: Live GitHub latest-release redirect response</summary>

Source: [Live GitHub latest-release redirect response](https://github.com/kunchenguid/no-mistakes/blob/245902afac06f7bbb811570c27b355f4e9fd3fb2/.no-mistakes/evidence/fm/nm-install-403-ratelimit-r1/github-latest-live-redirect.txt)

```text
Live unauthenticated headers-only request:
effective_url=https://github.com/kunchenguid/no-mistakes/releases/tag/v1.60.2
http_code=200
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"0ee6e1be2e99d06f11aad3f96fd0c9e19983d0b8","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test . -run '^TestInstallScript(ResolvesVersionFromLatestRedirect|FailsWhenLatestRedirectHasNoTag|InstallsUserOwnedBinaryAndPathSymlink|ReplacesExistingPathEntryWithSymlink|RestartsDaemonAfterInstall|FailsWhenDaemonRestartFails)$' -count=1 -v`
- <code>`dash -n docs/install.sh` and `sh -n docs/install.sh`</code>
- <code>Executed `docs/install.sh` end-to-end with redirect-shaped curl responses and a versioned fake release archive; verified the installed executable, symlink, request URLs, and malformed-response exit behavior</code>
- `curl -fsSLI -o /dev/null -w '%{url_effective}\nhttp_code=%{http_code}\n' https://github.com/kunchenguid/no-mistakes/releases/latest`
- <code>`git status --short` and transient build-artifact directory check</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
