### PR TITLE
fix(cli): support file input for axi respond

### DIFF
--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -139,8 +139,8 @@ Answer the current approval gate and continue until the next gate, CI-ready deci
 
 ```sh
 no-mistakes axi respond --action approve
-no-mistakes axi respond --action fix --findings F1,F2 --instructions "optional guidance"
-no-mistakes axi respond --action fix --add-finding '{"description":"...","action":"auto-fix"}'
+no-mistakes axi respond --action fix --findings F1,F2 --instructions-file guidance.txt
+no-mistakes axi respond --action fix --add-finding-file finding.json
 no-mistakes axi respond --action skip
 ```
 
@@ -155,6 +155,7 @@ no-mistakes axi respond --action skip
 | `--add-finding-file` | `string` | (none)   | Read the finding JSON verbatim from a file; use `-` to read from stdin, so the text never transits the caller shell (no command substitution). Mutually exclusive with `--add-finding`. |
 | `-y`, `--yes`    | `bool`   | `false`       | Auto-resolve every subsequent gate until a decision point or outcome |
 
+Only one file flag can use `-` in a response, because stdin can be consumed only once; write one value to a file when supplying both guidance and a finding.
 After the explicit response, `--yes` uses the same auto-resolution behavior as `axi run --yes`: have the pipeline fix `auto-fix` and `ask-user` findings once, approve the fix review, approve gates that only contain non-actionable `no-op` findings, and stop at `outcome: checks-passed` when the CI monitor reports readiness but the PR still needs a human merge.
 Each `axi respond` blocks until the next gate, CI-ready decision point, or final outcome.
 If it returns another `gate:`, answer that gate; do not idle-wait for the run to move forward by itself.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -149,8 +149,10 @@ no-mistakes axi respond --action skip
 | `--action`       | `string` | (none)        | `approve`, `fix`, or `skip`; required                                |
 | `--step`         | `string` | awaiting step | Step to respond to                                                   |
 | `--findings`     | `string` | (none)        | Comma-separated finding IDs for `--action fix`                       |
-| `--instructions` | `string` | (none)        | Guidance applied to selected findings                                |
-| `--add-finding`  | `string` | (none)        | JSON finding object to add and fix                                   |
+| `--instructions` | `string` | (none)        | Guidance applied to selected findings. **Shell-substitution pitfall:** this is passed on the command line, so your shell runs command substitution on it first and silently replaces backticked spans and `$(...)` before no-mistakes sees them; prefer `--instructions-file` (or `-` for stdin) when guidance contains backticks or `$(...)`.                            |
+| `--instructions-file` | `string` | (none)   | Read guidance verbatim from a file; use `-` to read from stdin, so the text never transits the caller shell (no command substitution). Mutually exclusive with `--instructions`. |
+| `--add-finding`  | `string` | (none)        | JSON finding object to add and fix. **Shell-substitution pitfall:** like `--instructions`, this is passed on the command line and subject to the caller shell's command substitution; prefer `--add-finding-file` (or `-` for stdin) when the JSON contains backticks or `$(...)`. |
+| `--add-finding-file` | `string` | (none)   | Read the finding JSON verbatim from a file; use `-` to read from stdin, so the text never transits the caller shell (no command substitution). Mutually exclusive with `--add-finding`. |
 | `-y`, `--yes`    | `bool`   | `false`       | Auto-resolve every subsequent gate until a decision point or outcome |
 
 After the explicit response, `--yes` uses the same auto-resolution behavior as `axi run --yes`: have the pipeline fix `auto-fix` and `ask-user` findings once, approve the fix review, approve gates that only contain non-actionable `no-op` findings, and stop at `outcome: checks-passed` when the CI monitor reports readiness but the PR still needs a human merge.

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -862,7 +862,7 @@ func runAxiRespond(cmd *cobra.Command, ra respondArgs) error {
 // inline with a non-empty path is an error. The returned error is the whole
 // story - the caller wraps it in emitError.
 func resolveRespondText(cmd *cobra.Command, flag, inline, path string) (string, error) {
-	if inline != "" && path != "" {
+	if path != "" && (inline != "" || cmd.Flags().Changed(flag)) {
 		return "", fmt.Errorf("--%s and --%s-file are mutually exclusive; supply exactly one", flag, flag)
 	}
 	if path == "" {

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -858,11 +858,10 @@ func runAxiRespond(cmd *cobra.Command, ra respondArgs) error {
 // respond text flag. It enforces that the inline and file/stdin forms are
 // mutually exclusive, reads the file (or stdin, when path is "-") verbatim,
 // and returns the effective text that feeds the exact same downstream path as
-// the inline flag. An empty path means the inline form is in use; a non-empty
-// inline with a non-empty path is an error. The returned error is the whole
-// story - the caller wraps it in emitError.
+// the inline flag. The returned error is the whole story - the caller wraps it
+// in emitError.
 func resolveRespondText(cmd *cobra.Command, flag, inline, path string) (string, error) {
-	if path != "" && (inline != "" || cmd.Flags().Changed(flag)) {
+	if cmd.Flags().Changed(flag) && cmd.Flags().Changed(flag+"-file") {
 		return "", fmt.Errorf("--%s and --%s-file are mutually exclusive; supply exactly one", flag, flag)
 	}
 	if path == "" {

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -688,6 +689,7 @@ func successReportHelp(fixes []fixRow) []string {
 
 func newAxiRespondCmd() *cobra.Command {
 	var action, step, findings, instructions, addFinding string
+	var instructionsFile, addFindingFile string
 	var autoYes bool
 
 	cmd := &cobra.Command{
@@ -705,12 +707,14 @@ func newAxiRespondCmd() *cobra.Command {
 				"auto_yes": autoYes,
 			}, func() error {
 				return runAxiRespond(cmd, respondArgs{
-					action:       action,
-					step:         step,
-					findings:     findings,
-					instructions: instructions,
-					addFinding:   addFinding,
-					autoYes:      autoYes,
+					action:           action,
+					step:             step,
+					findings:         findings,
+					instructions:     instructions,
+					instructionsFile: instructionsFile,
+					addFinding:       addFinding,
+					addFindingFile:   addFindingFile,
+					autoYes:          autoYes,
 				})
 			})
 		},
@@ -718,23 +722,48 @@ func newAxiRespondCmd() *cobra.Command {
 	cmd.Flags().StringVar(&action, "action", "", "approve | fix | skip (required)")
 	cmd.Flags().StringVar(&step, "step", "", "step to respond to (default: the step awaiting approval)")
 	cmd.Flags().StringVar(&findings, "findings", "", "comma-separated finding IDs to fix (with --action fix)")
-	cmd.Flags().StringVar(&instructions, "instructions", "", "guidance applied to the selected findings (with --action fix)")
-	cmd.Flags().StringVar(&addFinding, "add-finding", "", "JSON finding object to add and fix (with --action fix)")
+	cmd.Flags().StringVar(&instructions, "instructions", "", "guidance applied to the selected findings (with --action fix). "+
+		"CAUTION: this text is passed on the command line, so your shell runs command substitution on it first - "+
+		"backticked spans and $(...) are executed and silently replaced before no-mistakes sees them. "+
+		"Prefer --instructions-file for guidance containing backticks or $(...).")
+	cmd.Flags().StringVar(&addFinding, "add-finding", "", "JSON finding object to add and fix (with --action fix). "+
+		"CAUTION: like --instructions, this text is passed on the command line and so is subject to the "+
+		"caller shell's command substitution. Prefer --add-finding-file for JSON containing backticks or $(...).")
+	cmd.Flags().StringVar(&instructionsFile, "instructions-file", "", "read --instructions guidance verbatim from a file; use - to read from stdin, so the text never transits "+
+		"the caller shell (no command substitution). Mutually exclusive with --instructions.")
+	cmd.Flags().StringVar(&addFindingFile, "add-finding-file", "", "read --add-finding JSON verbatim from a file; use - to read from stdin, so the text never transits "+
+		"the caller shell (no command substitution). Mutually exclusive with --add-finding.")
 	cmd.Flags().BoolVarP(&autoYes, "yes", "y", false, "auto-resolve every subsequent gate until a decision point or outcome")
 	return cmd
 }
 
 type respondArgs struct {
-	action       string
-	step         string
-	findings     string
-	instructions string
-	addFinding   string
-	autoYes      bool
+	action           string
+	step             string
+	findings         string
+	instructions     string
+	instructionsFile string
+	addFinding       string
+	addFindingFile   string
+	autoYes          bool
 }
 
 func runAxiRespond(cmd *cobra.Command, ra respondArgs) error {
 	ctx := cmd.Context()
+
+	// Resolve inline vs file/stdin text before anything else, so flag-usage
+	// errors (mutual exclusion, unreadable file, double stdin) surface without
+	// needing a daemon and before any other validation runs.
+	if ra.instructionsFile == "-" && ra.addFindingFile == "-" {
+		return emitError(cmd, 2, "stdin can only be read once: --instructions-file - and --add-finding-file - cannot both read from stdin")
+	}
+	var err error
+	if ra.instructions, err = resolveRespondText(cmd, "instructions", ra.instructions, ra.instructionsFile); err != nil {
+		return emitError(cmd, 2, err.Error())
+	}
+	if ra.addFinding, err = resolveRespondText(cmd, "add-finding", ra.addFinding, ra.addFindingFile); err != nil {
+		return emitError(cmd, 2, err.Error())
+	}
 
 	act := types.ApprovalAction(strings.TrimSpace(ra.action))
 	switch act {
@@ -823,6 +852,36 @@ func runAxiRespond(cmd *cobra.Command, ra respondArgs) error {
 		return emitError(cmd, 1, fmt.Sprintf("drive run: %v", err))
 	}
 	return renderDriveResult(cmd, final, ciReady)
+}
+
+// resolveRespondText reconciles the inline and file/stdin forms of an axi
+// respond text flag. It enforces that the inline and file/stdin forms are
+// mutually exclusive, reads the file (or stdin, when path is "-") verbatim,
+// and returns the effective text that feeds the exact same downstream path as
+// the inline flag. An empty path means the inline form is in use; a non-empty
+// inline with a non-empty path is an error. The returned error is the whole
+// story - the caller wraps it in emitError.
+func resolveRespondText(cmd *cobra.Command, flag, inline, path string) (string, error) {
+	if inline != "" && path != "" {
+		return "", fmt.Errorf("--%s and --%s-file are mutually exclusive; supply exactly one", flag, flag)
+	}
+	if path == "" {
+		return inline, nil
+	}
+	r := cmd.InOrStdin()
+	if path != "-" {
+		f, err := os.Open(path)
+		if err != nil {
+			return "", err
+		}
+		defer f.Close()
+		r = f
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return "", fmt.Errorf("read --%s-file %s: %v", flag, path, err)
+	}
+	return string(data), nil
 }
 
 // gateStatusFor returns the current status of step in rv, defaulting to the

--- a/internal/cli/axi_respond_file_test.go
+++ b/internal/cli/axi_respond_file_test.go
@@ -88,6 +88,31 @@ func TestRunAxiRespond_MutualExclusionAddFindingAndFile(t *testing.T) {
 	assertExitCode(t, err, 2)
 }
 
+func TestAxiRespond_EmptyInlineAndFileAreMutuallyExclusive(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "respond.txt")
+	if err := os.WriteFile(p, []byte("from file"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		inlineFlag string
+		fileFlag   string
+	}{
+		{name: "instructions", inlineFlag: "--instructions=", fileFlag: "--instructions-file=" + p},
+		{name: "add finding", inlineFlag: "--add-finding=", fileFlag: "--add-finding-file=" + p},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := executeCmd("axi", "respond", "--action", "fix", tt.inlineFlag, tt.fileFlag)
+			assertExitCode(t, err, 2)
+			if !strings.Contains(out, "mutually exclusive") {
+				t.Fatalf("expected a clear mutual-exclusion error, got %q", out)
+			}
+		})
+	}
+}
+
 func TestRunAxiRespond_StdinOnlyReadOnce(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.SetOut(io.Discard)

--- a/internal/cli/axi_respond_file_test.go
+++ b/internal/cli/axi_respond_file_test.go
@@ -58,58 +58,43 @@ func TestResolveRespondText_MissingFile(t *testing.T) {
 	}
 }
 
-func TestRunAxiRespond_MutualExclusionInlineAndFile(t *testing.T) {
-	p := filepath.Join(t.TempDir(), "instructions.txt")
-	if err := os.WriteFile(p, []byte("from file"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	cmd := &cobra.Command{}
-	cmd.SetOut(io.Discard)
-	err := runAxiRespond(cmd, respondArgs{
-		action:           "fix",
-		instructions:     "inline note",
-		instructionsFile: p,
-	})
-	assertExitCode(t, err, 2)
-}
-
-func TestRunAxiRespond_MutualExclusionAddFindingAndFile(t *testing.T) {
-	p := filepath.Join(t.TempDir(), "finding.json")
-	if err := os.WriteFile(p, []byte(`{"description":"x"}`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	cmd := &cobra.Command{}
-	cmd.SetOut(io.Discard)
-	err := runAxiRespond(cmd, respondArgs{
-		action:         "fix",
-		addFinding:     `{"description":"inline"}`,
-		addFindingFile: p,
-	})
-	assertExitCode(t, err, 2)
-}
-
-func TestAxiRespond_EmptyInlineAndFileAreMutuallyExclusive(t *testing.T) {
+func TestAxiRespond_InlineAndFileAreMutuallyExclusive(t *testing.T) {
 	p := filepath.Join(t.TempDir(), "respond.txt")
 	if err := os.WriteFile(p, []byte("from file"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	tests := []struct {
+	flagPairs := []struct {
 		name       string
 		inlineFlag string
 		fileFlag   string
 	}{
-		{name: "instructions", inlineFlag: "--instructions=", fileFlag: "--instructions-file=" + p},
-		{name: "add finding", inlineFlag: "--add-finding=", fileFlag: "--add-finding-file=" + p},
+		{name: "instructions", inlineFlag: "instructions", fileFlag: "instructions-file"},
+		{name: "add finding", inlineFlag: "add-finding", fileFlag: "add-finding-file"},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			out, err := executeCmd("axi", "respond", "--action", "fix", tt.inlineFlag, tt.fileFlag)
-			assertExitCode(t, err, 2)
-			if !strings.Contains(out, "mutually exclusive") {
-				t.Fatalf("expected a clear mutual-exclusion error, got %q", out)
-			}
-		})
+	values := []struct {
+		name        string
+		inlineValue string
+		fileValue   string
+	}{
+		{name: "both nonempty", inlineValue: "inline", fileValue: p},
+		{name: "empty inline", inlineValue: "", fileValue: p},
+		{name: "empty file", inlineValue: "inline", fileValue: ""},
+	}
+	for _, pair := range flagPairs {
+		for _, value := range values {
+			t.Run(pair.name+"/"+value.name, func(t *testing.T) {
+				out, err := executeCmd(
+					"axi", "respond", "--action", "fix",
+					"--"+pair.inlineFlag+"="+value.inlineValue,
+					"--"+pair.fileFlag+"="+value.fileValue,
+				)
+				assertExitCode(t, err, 2)
+				if !strings.Contains(out, "mutually exclusive") {
+					t.Fatalf("expected a clear mutual-exclusion error, got %q", out)
+				}
+			})
+		}
 	}
 }
 

--- a/internal/cli/axi_respond_file_test.go
+++ b/internal/cli/axi_respond_file_test.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestResolveRespondText_VerbatimFilePreservation(t *testing.T) {
+	content := "run `git checkout `main`` and avoid $(rm -rf .)\n  quoted \"paths\" here"
+	p := filepath.Join(t.TempDir(), "instructions.txt")
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := &cobra.Command{}
+	got, err := resolveRespondText(cmd, "instructions", "", p)
+	if err != nil {
+		t.Fatalf("resolveRespondText returned error: %v", err)
+	}
+	if got != content {
+		t.Fatalf("verbatim preservation failed\n got: %q\nwant: %q", got, content)
+	}
+}
+
+func TestResolveRespondText_Stdin(t *testing.T) {
+	content := "fix the backticked `command` and $(literal) exactly"
+	cmd := &cobra.Command{}
+	cmd.SetIn(strings.NewReader(content))
+	got, err := resolveRespondText(cmd, "add-finding", "", "-")
+	if err != nil {
+		t.Fatalf("resolveRespondText returned error: %v", err)
+	}
+	if got != content {
+		t.Fatalf("stdin preservation failed\n got: %q\nwant: %q", got, content)
+	}
+}
+
+func TestResolveRespondText_InlinePassedThrough(t *testing.T) {
+	cmd := &cobra.Command{}
+	got, err := resolveRespondText(cmd, "instructions", "inline note", "")
+	if err != nil {
+		t.Fatalf("resolveRespondText returned error: %v", err)
+	}
+	if got != "inline note" {
+		t.Fatalf("inline pass-through failed: got %q", got)
+	}
+}
+
+func TestResolveRespondText_MissingFile(t *testing.T) {
+	cmd := &cobra.Command{}
+	if _, err := resolveRespondText(cmd, "instructions", "", filepath.Join(t.TempDir(), "nope.txt")); err == nil {
+		t.Fatal("expected an error for a missing file")
+	}
+}
+
+func TestRunAxiRespond_MutualExclusionInlineAndFile(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "instructions.txt")
+	if err := os.WriteFile(p, []byte("from file"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := &cobra.Command{}
+	cmd.SetOut(io.Discard)
+	err := runAxiRespond(cmd, respondArgs{
+		action:           "fix",
+		instructions:     "inline note",
+		instructionsFile: p,
+	})
+	assertExitCode(t, err, 2)
+}
+
+func TestRunAxiRespond_MutualExclusionAddFindingAndFile(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "finding.json")
+	if err := os.WriteFile(p, []byte(`{"description":"x"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := &cobra.Command{}
+	cmd.SetOut(io.Discard)
+	err := runAxiRespond(cmd, respondArgs{
+		action:         "fix",
+		addFinding:     `{"description":"inline"}`,
+		addFindingFile: p,
+	})
+	assertExitCode(t, err, 2)
+}
+
+func TestRunAxiRespond_StdinOnlyReadOnce(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetOut(io.Discard)
+	cmd.SetIn(strings.NewReader("shared"))
+	err := runAxiRespond(cmd, respondArgs{
+		action:           "fix",
+		instructionsFile: "-",
+		addFindingFile:   "-",
+	})
+	assertExitCode(t, err, 2)
+}
+
+func assertExitCode(t *testing.T, err error, want int) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected an error, got nil")
+	}
+	var ee *exitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("expected *exitError, got %T: %v", err, err)
+	}
+	if ee.code != want {
+		t.Fatalf("expected exit code %d, got %d (err=%v)", want, ee.code, err)
+	}
+}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -187,7 +187,7 @@ Run the pipeline and decide on its findings as they come up:
    no-mistakes axi respond --action approve
 
    # have the pipeline fix specific findings, then continue
-   no-mistakes axi respond --action fix --findings <id1,id2> --instructions "<optional guidance>"
+   no-mistakes axi respond --action fix --findings <id1,id2> --instructions-file <guidance-file>
 
    # skip this step
    no-mistakes axi respond --action skip
@@ -204,8 +204,15 @@ Run the pipeline and decide on its findings as they come up:
 
     Each ` + "`respond`" + ` blocks until the next ` + "`gate:`" + `, ` + "`checks-passed`" + ` decision point, or final outcome.
 
+    Put nontrivial guidance or finding JSON in a file and pass it with
+    ` + "`--instructions-file <path>`" + ` or ` + "`--add-finding-file <path>`" + `. Use ` + "`-`" + ` as the
+    path to read that value from stdin. This preserves literal backticks and ` + "`$(...)`" + `;
+    the inline ` + "`--instructions`" + ` and ` + "`--add-finding`" + ` forms are subject to command
+    substitution by the caller shell. The inline and file forms of each flag
+    are mutually exclusive, and only one file flag can read stdin in a response.
+
     Two extra flags are available on ` + "`respond`" + ` when you need them:
-    - ` + "`--add-finding '<json>'`" + ` (with ` + "`--action fix`" + `) folds a finding you
+    - ` + "`--add-finding-file <path>`" + ` (with ` + "`--action fix`" + `) folds a finding you
       spotted yourself - one the pipeline did not surface - into the fix round,
       as a JSON finding object. Use it for a problem you noticed that is not in
       the gate's own ` + "`findings`" + ` table.

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -187,7 +187,7 @@ Run the pipeline and decide on its findings as they come up:
    no-mistakes axi respond --action approve
 
    # have the pipeline fix specific findings, then continue
-   no-mistakes axi respond --action fix --findings <id1,id2> --instructions "<optional guidance>"
+   no-mistakes axi respond --action fix --findings <id1,id2> --instructions-file <guidance-file>
 
    # skip this step
    no-mistakes axi respond --action skip
@@ -204,8 +204,15 @@ Run the pipeline and decide on its findings as they come up:
 
     Each `respond` blocks until the next `gate:`, `checks-passed` decision point, or final outcome.
 
+    Put nontrivial guidance or finding JSON in a file and pass it with
+    `--instructions-file <path>` or `--add-finding-file <path>`. Use `-` as the
+    path to read that value from stdin. This preserves literal backticks and `$(...)`;
+    the inline `--instructions` and `--add-finding` forms are subject to command
+    substitution by the caller shell. The inline and file forms of each flag
+    are mutually exclusive, and only one file flag can read stdin in a response.
+
     Two extra flags are available on `respond` when you need them:
-    - `--add-finding '<json>'` (with `--action fix`) folds a finding you
+    - `--add-finding-file <path>` (with `--action fix`) folds a finding you
       spotted yourself - one the pipeline did not surface - into the fix round,
       as a JSON finding object. Use it for a problem you noticed that is not in
       the gate's own `findings` table.


### PR DESCRIPTION
## Intent

Implement GitHub issue ironerumi/no-mistakes#1: axi respond today accepts instruction and finding text ONLY as inline flags (--instructions, --add-finding). Because that text is passed on the command line, the caller shell runs command-substitution first: backticked spans and $(...) in the text are executed and silently replaced by their output, corrupting review guidance without any error. Fix it by letting the text come from a file or stdin, which never transits the shell.

Add to the axi respond command:
1. --instructions-file <path> and --add-finding-file <path> that read the text verbatim from a file and feed the exact same downstream code path as the inline flags.
2. Support '-' as the value to read that flag's text from stdin.
3. Make the inline and file/stdin forms of the same flag mutually exclusive; error clearly if both are supplied.
4. Update --help for those flags to warn that the inline --instructions/--add-finding are subject to the caller shell's command substitution, and point to the file/stdin flags.

Acceptance criteria:
- --instructions-file/--add-finding-file read text verbatim from a file into the same path as the inline flags.
- '-' reads that flag's text from stdin.
- File/stdin content containing backticks and $(...) is preserved byte-for-byte.
- Inline and file/stdin forms of the same flag are mutually exclusive with a clear error.
- --help documents the shell-substitution pitfall and the new flags.
- Tests colocated with the existing test pattern cover verbatim preservation (incl. backticks), stdin, and the mutual-exclusion error.

Scope discipline: stay within this change; do NOT alter what respond does with the text once it has it, touch unrelated flags, or refactor beyond what this fix needs.

Implementation decisions made while doing the work (what a reviewer reading only the diff would not know): added a resolveRespondText helper in internal/cli/axi_drive.go that enforces mutual exclusion, reads the file (or stdin via '-') verbatim, and feeds the exact same downstream path as the inline flags; resolution happens at the top of runAxiRespond before daemon access so usage errors surface early and are unit-testable. Also added a deliberate guard erroring if both --instructions-file - and --add-finding-file - are supplied, because stdin can only be consumed once and without it the second read would silently return empty text. Updated the --help strings and docs/src/content/docs/reference/cli.md, and added unit tests in internal/cli/axi_respond_file_test.go covering verbatim preservation (incl. backticks and $(...)), stdin reading, inline pass-through, missing file, both mutual-exclusion errors, and the double-stdin guard.

## What Changed

- Add `--instructions-file` and `--add-finding-file` support to `axi respond`, including `-` for verbatim stdin input.
- Reject inline/file conflicts and attempts to consume stdin for both values, with validation before daemon access.
- Document the shell-substitution risk and add coverage for file, stdin, verbatim preservation, and error cases.

## Risk Assessment

✅ Low: The change is well-bounded, satisfies the file/stdin and help requirements, and correctly enforces mutual exclusion by flag presence for both explicitly empty and non-empty values.

## Testing

Focused CLI tests verified verbatim file/stdin preservation—including backticks and `$(...)`—inline pass-through, missing-file handling, all instructions/add-finding mutual-exclusion variants, and the double-stdin guard; real executable transcripts confirmed the documented help and exit-code-2 user experience. This is a text-only CLI change, so command transcripts are the appropriate reviewer-visible evidence rather than screenshots.

<details>
<summary>Evidence: axi respond help showing shell-substitution warning and new file/stdin flags</summary>

```text
Sends approve/fix/skip for the step currently awaiting approval, then
blocks until the next gate, CI-ready decision point, or final outcome.

Commit post-pipeline follow-up work on top of the existing branch so every pipeline fix commit remains present. Never abort-and-restart, reset, or replace the branch in a way that drops prior gate-fix commits.

Usage:
  no-mistakes axi respond [flags]

Flags:
      --action string              approve | fix | skip (required)
      --add-finding string         JSON finding object to add and fix (with --action fix). CAUTION: like --instructions, this text is passed on the command line and so is subject to the caller shell's command substitution. Prefer --add-finding-file for JSON containing backticks or $(...).
      --add-finding-file string    read --add-finding JSON verbatim from a file; use - to read from stdin, so the text never transits the caller shell (no command substitution). Mutually exclusive with --add-finding.
      --findings string            comma-separated finding IDs to fix (with --action fix)
  -h, --help                       help for respond
      --instructions string        guidance applied to the selected findings (with --action fix). CAUTION: this text is passed on the command line, so your shell runs command substitution on it first - backticked spans and $(...) are executed and silently replaced before no-mistakes sees them. Prefer --instructions-file for guidance containing backticks or $(...).
      --instructions-file string   read --instructions guidance verbatim from a file; use - to read from stdin, so the text never transits the caller shell (no command substitution). Mutually exclusive with --instructions.
      --step string                step to respond to (default: the step awaiting approval)
  -y, --yes                        auto-resolve every subsequent gate until a decision point or outcome
```
</details>
<details>
<summary>Evidence: CLI transcript showing empty-inline and empty-file mutual-exclusion errors with exit code 2</summary>

```text
$ .test-tmp/no-mistakes axi respond --action fix --instructions= --instructions-file=notes.txt
error: "--instructions and --instructions-file are mutually exclusive; supply exactly one"
exit_code: 2

$ .test-tmp/no-mistakes axi respond --action fix --instructions=x --instructions-file=
error: "--instructions and --instructions-file are mutually exclusive; supply exactly one"
exit_code: 2
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"9a122f3618ee69968b506292dac074229766477b","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `internal/cli/axi_drive.go:865` - The required criterion says “inline and file/stdin forms of the same flag are mutually exclusive; error clearly if both are supplied,” but this check uses decoded string values rather than flag presence. For example, `--instructions= --instructions-file=notes.txt` supplies both forms yet `inline != &#34;&#34;` is false, so the file is accepted without an error; the same applies to `--add-finding=`. Enforce exclusivity using Cobra&#39;s `Changed`/mutually-exclusive flag semantics (or carry explicit presence booleans) and cover the empty-inline case.

🔧 Fix: Enforce respond text mutual exclusion by flag presence
1 error still open:

- 🚨 `internal/cli/axi_drive.go:865` - The required criterion says the inline and file forms must be mutually exclusive by flag presence, but this condition still requires the decoded file path to be non-empty. `axi respond --instructions=x --instructions-file=` (and the equivalent add-finding flags) supplies both forms yet bypasses the mutual-exclusion error. Check `Changed(flag)` and `Changed(flag+&#34;-file&#34;)` at the command boundary, independent of either decoded value.

🔧 Fix: Enforce respond flag exclusivity by presence
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test ./internal/cli -run 'TestResolveRespondText_|TestAxiRespond_InlineAndFileAreMutuallyExclusive|TestRunAxiRespond_StdinOnlyReadOnce' -count=1`
- <code>Built `./cmd/no-mistakes` and captured `axi respond --help` from the real executable.</code>
- <code>Ran the real CLI with `--instructions= --instructions-file=notes.txt`; confirmed a clear mutual-exclusion error and exit code 2.</code>
- <code>Ran the real CLI with `--instructions=x --instructions-file=`; confirmed presence-based mutual exclusion and exit code 2.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>

