### PR TITLE
fix(cli): make untracked-file guidance safe

### DIFF
--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	toon "github.com/toon-format/toon-go"
 
@@ -237,11 +239,22 @@ func untrackedHint(untracked []string) string {
 	if len(shown) > maxUntrackedPaths {
 		shown = shown[:maxUntrackedPaths]
 	}
-	rendered := strings.Join(shown, sep)
+	renderedPaths := make([]string, len(shown))
+	for i, path := range shown {
+		renderedPaths[i] = displayUntrackedPath(path)
+	}
+	rendered := strings.Join(renderedPaths, sep)
 	if dropped := len(untracked) - len(shown); dropped > 0 {
 		rendered += fmt.Sprintf("%s(+%d more)", sep, dropped)
 	}
 	return fmt.Sprintf("Untracked files (not in git yet): %s", rendered)
+}
+
+func displayUntrackedPath(path string) string {
+	if strings.TrimSpace(path) != path || strings.IndexFunc(path, func(r rune) bool { return !unicode.IsGraphic(r) }) >= 0 {
+		return strconv.QuoteToGraphic(path)
+	}
+	return path
 }
 
 // branchOwnershipError carries the shared branch-sync classification that

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -213,13 +213,35 @@ func preflightGuard(ctx context.Context, env *axiEnv, branch string) func(*cobra
 		}
 	}
 	if dirty {
+		help := []string{
+			"Commit the files that belong to this change (`git add <path> && git commit`), or gitignore / add the rest to `.git/info/exclude`",
+			"Run `git status` to see what is uncommitted",
+		}
+		if untracked, err := git.UntrackedFiles(ctx, "."); err == nil && len(untracked) > 0 {
+			help = append([]string{untrackedHint(untracked)}, help...)
+		}
 		return func(cmd *cobra.Command) error {
-			return emitError(cmd, 1, "uncommitted changes in the working tree",
-				"Commit your work before validating: `git add -A && git commit -m \"...\"`, then re-run",
-				"Run `git status` to see what is uncommitted")
+			return emitError(cmd, 1, "uncommitted changes in the working tree", help...)
 		}
 	}
 	return nil
+}
+
+// untrackedHint renders the untracked paths named in the dirty-worktree error,
+// bounded so a large untracked tree cannot bloat the error document. Paths stay
+// in git's order and the hint states how many were left out.
+func untrackedHint(untracked []string) string {
+	const maxUntrackedPaths = 5
+	const sep = ", "
+	shown := untracked
+	if len(shown) > maxUntrackedPaths {
+		shown = shown[:maxUntrackedPaths]
+	}
+	rendered := strings.Join(shown, sep)
+	if dropped := len(untracked) - len(shown); dropped > 0 {
+		rendered += fmt.Sprintf("%s(+%d more)", sep, dropped)
+	}
+	return fmt.Sprintf("Untracked files (not in git yet): %s", rendered)
 }
 
 // branchOwnershipError carries the shared branch-sync classification that

--- a/internal/cli/axi_test.go
+++ b/internal/cli/axi_test.go
@@ -524,6 +524,106 @@ func TestPreflightGuardReportsWorkingTreeCheckError(t *testing.T) {
 	}
 }
 
+func TestPreflightGuardDirtyTreeNamesUntrackedFiles(t *testing.T) {
+	dir := t.TempDir()
+	run(t, dir, "git", "init")
+	run(t, dir, "git", "config", "user.email", "test@test.com")
+	run(t, dir, "git", "config", "user.name", "Test")
+	run(t, dir, "git", "commit", "--allow-empty", "-m", "initial")
+	run(t, dir, "git", "checkout", "-b", "feature/x")
+	if err := os.MkdirAll(filepath.Join(dir, "docs", "plans"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "docs", "plans", "spec.md"), []byte("spec\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".git", "info", "exclude"), []byte("scratch/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "scratch"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "scratch", "notes.md"), []byte("scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	chdir(t, dir)
+	guard := preflightGuard(context.Background(), &axiEnv{repo: &db.Repo{DefaultBranch: "main"}}, "feature/x")
+	if guard == nil {
+		t.Fatal("expected guard for uncommitted changes")
+	}
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&out)
+	if err := guard(cmd); err == nil {
+		t.Fatal("expected structured preflight error")
+	}
+	got := out.String()
+	for _, want := range []string{
+		"uncommitted changes in the working tree",
+		"Untracked files (not in git yet): docs/plans/spec.md",
+		"git add <path>",
+		"`.git/info/exclude`",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected hint %q in:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "git add -A") {
+		t.Fatalf("hint must never recommend `git add -A`, got:\n%s", got)
+	}
+	if strings.Contains(got, "scratch") {
+		t.Fatalf("hint must not name ignored files, got:\n%s", got)
+	}
+}
+
+func TestPreflightGuardDirtyTreeTrackedOnlyHasNoUntrackedList(t *testing.T) {
+	dir := t.TempDir()
+	run(t, dir, "git", "init")
+	run(t, dir, "git", "config", "user.email", "test@test.com")
+	run(t, dir, "git", "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(t, dir, "git", "add", ".")
+	run(t, dir, "git", "commit", "-m", "initial")
+	run(t, dir, "git", "checkout", "-b", "feature/x")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# changed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	chdir(t, dir)
+	guard := preflightGuard(context.Background(), &axiEnv{repo: &db.Repo{DefaultBranch: "main"}}, "feature/x")
+	if guard == nil {
+		t.Fatal("expected guard for uncommitted changes")
+	}
+
+	var out bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&out)
+	if err := guard(cmd); err == nil {
+		t.Fatal("expected structured preflight error")
+	}
+	got := out.String()
+	if !strings.Contains(got, "uncommitted changes in the working tree") {
+		t.Fatalf("expected dirty-tree error, got:\n%s", got)
+	}
+	for _, forbidden := range []string{"Untracked files", "git add -A"} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("tracked-only hint must not contain %q, got:\n%s", forbidden, got)
+		}
+	}
+}
+
+func TestUntrackedHintBoundsLongLists(t *testing.T) {
+	paths := []string{"a.txt", "b.txt", "c.txt", "d.txt", "e.txt", "f.txt", "g.txt"}
+	hint := untrackedHint(paths)
+	if !strings.Contains(hint, "e.txt") || !strings.Contains(hint, "(+2 more)") {
+		t.Fatalf("expected first five paths and (+2 more), got:\n%s", hint)
+	}
+	if strings.Contains(hint, "f.txt") {
+		t.Fatalf("hint must not list the sixth path, got:\n%s", hint)
+	}
+}
+
 func TestStatusEmptyHelpIncludesRequiredIntent(t *testing.T) {
 	out := axiDoc(
 		toon.Field{Key: "runs", Value: "0 runs yet in this repository"},

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -565,18 +565,18 @@ func HasUncommittedChanges(ctx context.Context, dir string) (bool, error) {
 // UntrackedFiles returns each untracked path in git's order. Ignored files
 // are not included.
 func UntrackedFiles(ctx context.Context, dir string) ([]string, error) {
-	out, err := Run(ctx, dir, "status", "--porcelain", "--untracked-files=all")
+	out, err := RunRaw(ctx, dir, "status", "--porcelain", "-z", "--untracked-files=all")
 	if err != nil {
 		return nil, err
 	}
 	var files []string
-	for _, line := range strings.Split(out, "\n") {
-		if len(line) < 4 {
+	for _, entry := range strings.Split(string(out), "\x00") {
+		if len(entry) < 3 {
 			continue
 		}
-		// Porcelain format: XY <path> where XY is a 2-char status code + space
-		if line[:2] == "??" {
-			files = append(files, strings.TrimSpace(line[3:]))
+		// Porcelain format: XY <path>\0 where XY is a 2-char status code + space.
+		if entry[:2] == "??" {
+			files = append(files, entry[3:])
 		}
 	}
 	return files, nil

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -562,6 +562,26 @@ func HasUncommittedChanges(ctx context.Context, dir string) (bool, error) {
 	return out != "", nil
 }
 
+// UntrackedFiles returns each untracked path in git's order. Ignored files
+// are not included.
+func UntrackedFiles(ctx context.Context, dir string) ([]string, error) {
+	out, err := Run(ctx, dir, "status", "--porcelain", "--untracked-files=all")
+	if err != nil {
+		return nil, err
+	}
+	var files []string
+	for _, line := range strings.Split(out, "\n") {
+		if len(line) < 4 {
+			continue
+		}
+		// Porcelain format: XY <path> where XY is a 2-char status code + space
+		if line[:2] == "??" {
+			files = append(files, strings.TrimSpace(line[3:]))
+		}
+	}
+	return files, nil
+}
+
 // CreateBranch creates a new branch with the given name and switches to it.
 // Fails if the branch already exists.
 func CreateBranch(ctx context.Context, dir, name string) error {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -272,7 +273,11 @@ func TestUntrackedFilesPreservesRawPaths(t *testing.T) {
 	dir := initTestRepo(t)
 	ctx := context.Background()
 
-	for _, name := range []string{" plain ", "café.txt", "tab\tname"} {
+	names := []string{"café.txt", "name with space.txt"}
+	if runtime.GOOS != "windows" {
+		names = []string{" plain ", "café.txt", "name with space.txt", "tab\tname"}
+	}
+	for _, name := range names {
 		writeFile(t, filepath.Join(dir, name), "new\n")
 	}
 
@@ -280,7 +285,7 @@ func TestUntrackedFilesPreservesRawPaths(t *testing.T) {
 	if err != nil {
 		t.Fatalf("UntrackedFiles failed: %v", err)
 	}
-	want := []string{" plain ", "café.txt", "tab\tname"}
+	want := names
 	if len(files) != len(want) {
 		t.Fatalf("UntrackedFiles = %#v, want %#v", files, want)
 	}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -268,6 +268,29 @@ func TestHasUncommittedChangesUntrackedFile(t *testing.T) {
 	}
 }
 
+func TestUntrackedFilesPreservesRawPaths(t *testing.T) {
+	dir := initTestRepo(t)
+	ctx := context.Background()
+
+	for _, name := range []string{" plain ", "café.txt", "tab\tname"} {
+		writeFile(t, filepath.Join(dir, name), "new\n")
+	}
+
+	files, err := UntrackedFiles(ctx, dir)
+	if err != nil {
+		t.Fatalf("UntrackedFiles failed: %v", err)
+	}
+	want := []string{" plain ", "café.txt", "tab\tname"}
+	if len(files) != len(want) {
+		t.Fatalf("UntrackedFiles = %#v, want %#v", files, want)
+	}
+	for i, path := range files {
+		if path != want[i] {
+			t.Fatalf("UntrackedFiles[%d] = %q, want %q", i, path, want[i])
+		}
+	}
+}
+
 func TestHasUncommittedChangesStagedOnly(t *testing.T) {
 	dir := initTestRepo(t)
 	ctx := context.Background()


### PR DESCRIPTION
## What Changed

- Kept the dirty-worktree precondition and names untracked files in its error.
- Replaced the blanket `git add -A` instruction with scoped-add and ignore guidance.

## Why

An agent following the preflight output should not stage unrelated scratch files.

## Testing

- `make lint`
- `go test ./internal/cli ./internal/git -run '^(TestPreflightGuardDirtyTreeNamesUntrackedFiles|TestPreflightGuardDirtyTreeTrackedOnlyHasNoUntrackedList|TestUntrackedHintBoundsLongLists|TestHasUncommittedChangesUntrackedFile)$' -count=1`

## Intent

Corrective CLI guidance only. Untracked files still block `axi run`.

## Risk Assessment

Low. The precondition remains unchanged; only its diagnostic guidance gains the untracked paths.

## Bug Fixes

Fixes #866
