### PR TITLE
fix(agent): take the terminal bare JSON object for ACP agents

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -282,7 +282,7 @@ func finalizeTextResult(agentName, text string, schema json.RawMessage, usage To
 		return &Result{Text: text, Usage: usage, UsageReported: usage.Reported, CacheCreationReported: usage.CacheCreationReported}, nil
 	}
 
-	output, err := parseStructuredTextOutput(text, schema)
+	output, err := parseStructuredTextOutput(text, schema, strings.HasPrefix(agentName, "acp:"))
 	if err != nil {
 		return nil, fmt.Errorf("%s output parse: %w (output snippet: %q)", agentName, err, outputSnippet(text))
 	}
@@ -303,7 +303,7 @@ func outputSnippet(text string) string {
 	return trimmed
 }
 
-func parseStructuredTextOutput(text string, schema json.RawMessage) (json.RawMessage, error) {
+func parseStructuredTextOutput(text string, schema json.RawMessage, preferTerminal bool) (json.RawMessage, error) {
 	validationSchema, err := textValidationSchema(schema)
 	if err != nil {
 		return nil, err
@@ -354,7 +354,10 @@ func parseStructuredTextOutput(text string, schema json.RawMessage) (json.RawMes
 
 	bareParsed, bareErr := bareJSONObjects(text, validationSchema)
 	if len(bareParsed) > 1 {
-		return nil, fmt.Errorf("multiple bare JSON objects found in output")
+		if !preferTerminal {
+			return nil, fmt.Errorf("multiple bare JSON objects found in output")
+		}
+		bareParsed = bareParsed[len(bareParsed)-1:]
 	}
 	if fenced != nil && len(bareParsed) == 1 {
 		if !jsonEqual(fenced, bareParsed[0]) {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -523,6 +523,29 @@ func TestFinalizeTextResult_WithSchemaRejectsAmbiguousBareJSON(t *testing.T) {
 	}
 }
 
+func TestFinalizeTextResult_ACPAgentTakesTerminalBareJSON(t *testing.T) {
+	text := `Draft: {"findings":["a"],"summary":"draft"}. Final: {"findings":["a"],"summary":"final"}`
+	schema := json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"findings":{"type":"array"},
+			"summary":{"type":"string"}
+		},
+		"required":["findings","summary"]
+	}`)
+	result, err := finalizeTextResult("acp:omp", text, schema, TokenUsage{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var output map[string]any
+	if err := json.Unmarshal(result.Output, &output); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+	if output["summary"] != "final" {
+		t.Errorf("expected summary=final, got %v", output["summary"])
+	}
+}
+
 func TestFinalizeTextResult_WithSchemaRejectsBareJSONMissingRequiredKeys(t *testing.T) {
 	text := `I inspected the diff and found no issues. {"foo":"bar"}`
 	schema := json.RawMessage(`{


### PR DESCRIPTION
Fixes #930.

Since v1.59.1 (#844), an ACP agent that emits its verdict object more than once fails with `multiple bare JSON objects found in output`. `acp:omp` (a thinking model) does this routinely: in the run behind #930 it emitted `{"findings":...}` three times. ACP has no terminal result field (the `session/prompt` response carries only a `stopReason`; output is free-text `agent_message_chunk`s), so the last object in the stream is the agent's final answer.

For `acp:` agents, keep the last bare object when several validate and fall through to the existing fence reconciliation. Native agents are unchanged, including the #844 ambiguity test. Same "terminal answer is authoritative" rule the agy adapter applies (#808).

`go build ./...`, `go vet`, `gofmt`, and `go test ./internal/agent/` pass.
