### PR TITLE
fix(cli): clarify combined document and lint housekeeping attribution

### DIFF
--- a/docs/src/content/docs/guides/tui.md
+++ b/docs/src/content/docs/guides/tui.md
@@ -77,6 +77,7 @@ Step status icons:
 | `✗` | Failed |
 
 Completed steps show their duration.
+When no lint command is configured, the Document row is labeled `Document + Lint housekeeping`; its duration is the shared documentation-and-lint agent invocation, while Lint shows only its cached-result handoff duration.
 Steps with fixed findings, and steps currently fixing reported findings, show a right-aligned count such as `2/3 fixed` or `0/3 fixed`.
 The first number counts completed fixes, not findings selected for an in-progress fix.
 Connectors (`│`) between steps are hidden when the terminal height is under 30 lines.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -187,6 +187,7 @@ no-mistakes axi status --run <id>
 When the resolved run is parked at an `awaiting_approval` or `fix_review` gate, its top-level `run:` or `other_branch_run:` object includes `awaiting_agent: parked <duration>` immediately after `status`.
 The field disappears after that run's gate is answered, on cancel, and on terminal outcomes; use it to distinguish a run waiting for the driving agent from one actively running, fixing, or watching CI.
 Status offers branch-scoped `axi respond` commands only for the current branch's implicitly resolved run. An explicitly selected gate stays inspection-only even when its branch matches, because a newer active run on that branch could receive the bare response command instead; the gate remains visible and its log commands retain `--run <id>`.
+When a repository has no configured lint command and Document performs the combined Document/Lint housekeeping invocation, the run object includes `shared_work` evidence naming its `document+lint housekeeping` scope and the duration attributed to Document; Lint's own duration remains the cached-result handoff time.
 When the resolved run has a `running` or `fixing` step, the run object includes `active_steps`.
 Each row reports how long the step has been active, the latest meaningful log or native-agent lifecycle activity, the native agent PID if one is currently running, and the current round such as `round 1`, `auto-fix 1/3`, or `fix 2`.
 If no activity arrives for longer than `step_quiet_warning`, `last_activity` is prefixed with `quiet`; this is only a liveness signal and does not cancel the step.
@@ -421,6 +422,7 @@ Displays total changes, rescued changes, rescue rate, reported and fixed mistake
 
 Use `--agents` for local, per-purpose agent performance aggregates: duration and the subprocess-vs-model time split, session mode, errors, the token totals (input, output, cache-read, cache-creation, fresh input, reasoning), and the model round-trip and tool-category activity histogram, with a `METRICS` coverage count that tells a real zero apart from missing instrumentation.
 Use `--run <id>` to inspect the individual agent invocations for one run - including each invocation's per-round token deltas next to the raw counters (cumulative across a resumed session for codex; per-invocation for pi), tool-category breakdown, workload size, finding count, and fallback reason - plus the total time parked at approval gates; it implies `--agents`.
+The combined Document/Lint invocation is labeled `housekeeping (document+lint)` and attributed to `document+lint`, making its shared duration and tokens explicit without adding a second agent call.
 Nullable fields an adapter did not report render as `-` (unknown), which is distinct from a recorded `0`; the legacy raw input, output, and cache-read counters remain numeric.
 
 ```sh

--- a/internal/cli/axi.go
+++ b/internal/cli/axi.go
@@ -208,7 +208,7 @@ func runAxiHome(cmd *cobra.Command) (string, error) {
 	fingerprint := env.repo.ID + "|" + daemonState
 	if currentActive != nil {
 		steps, _ := env.d.GetStepsByRun(currentActive.ID)
-		rv := runViewFromDB(currentActive, steps)
+		rv := runViewFromDB(currentActive, steps, env.d)
 		annotateRunView(env, &rv)
 		fields = append(fields, runObjectFieldWithKey("active_run", rv))
 		if syncField := cachedBranchSyncField(cmd, currentActive.ID); syncField != nil {
@@ -222,7 +222,7 @@ func runAxiHome(cmd *cobra.Command) (string, error) {
 		fingerprint += "|" + runStateFingerprint(rv)
 	} else if otherActive != nil {
 		steps, _ := env.d.GetStepsByRun(otherActive.ID)
-		rv := runViewFromDB(otherActive, steps)
+		rv := runViewFromDB(otherActive, steps, env.d)
 		annotateRunView(env, &rv)
 		fields = append(fields, runObjectFieldWithKey("other_branch_active_run", rv))
 		fingerprint += "|other:" + runStateFingerprint(rv)

--- a/internal/cli/axi_query.go
+++ b/internal/cli/axi_query.go
@@ -80,7 +80,7 @@ func runAxiStatus(cmd *cobra.Command, runID string) (string, error) {
 	if err != nil {
 		return "", emitError(cmd, 1, fmt.Sprintf("load steps: %v", err))
 	}
-	rv := runViewFromDB(run, steps)
+	rv := runViewFromDB(run, steps, env.d)
 	annotateRunView(env, &rv)
 	var fields []toon.Field
 	// A run reached by an explicit --run may belong to another branch. Say so
@@ -289,7 +289,7 @@ func runAxiLogs(cmd *cobra.Command, step, runID string, full bool) (string, erro
 	if err != nil {
 		return "", emitError(cmd, 1, fmt.Sprintf("load steps: %v", err))
 	}
-	fingerprint := runStateFingerprint(runViewFromDB(run, steps)) + "|log:" + step
+	fingerprint := runStateFingerprint(runViewFromDB(run, steps, env.d)) + "|log:" + step
 
 	path := filepath.Join(env.p.RunLogDir(run.ID), step+".log")
 	data, err := os.ReadFile(path)

--- a/internal/cli/axi_render.go
+++ b/internal/cli/axi_render.go
@@ -35,6 +35,12 @@ type stepRow struct {
 	DurationMS int64  `toon:"duration_ms"`
 }
 
+type sharedWorkRow struct {
+	AttributedTo string `toon:"attributed_to"`
+	Scope        string `toon:"scope"`
+	DurationMS   int64  `toon:"duration_ms"`
+}
+
 type activeStepRow struct {
 	Step         string `toon:"step"`
 	Status       string `toon:"status"`
@@ -80,6 +86,7 @@ type stepView struct {
 	Name             string
 	Status           string
 	DurationMS       int64
+	WorkScope        string
 	FindingsJSON     string
 	FixSummaries     []string
 	StartedAt        *int64
@@ -141,6 +148,7 @@ func runViewFromIPC(r *ipc.RunInfo) runView {
 			FixRoundCount:    s.FixRoundCount,
 			AutoFixLimit:     s.AutoFixLimit,
 			PendingFixSource: s.PendingFixSource,
+			WorkScope:        s.WorkScope,
 		}
 		if s.LastActivity != nil {
 			sv.LastActivity = *s.LastActivity
@@ -156,7 +164,7 @@ func runViewFromIPC(r *ipc.RunInfo) runView {
 	return rv
 }
 
-func runViewFromDB(r *db.Run, steps []*db.StepResult) runView {
+func runViewFromDB(r *db.Run, steps []*db.StepResult, database *db.DB) runView {
 	rv := runView{
 		ID:                 r.ID,
 		Branch:             r.Branch,
@@ -184,6 +192,11 @@ func runViewFromDB(r *db.Run, steps []*db.StepResult) runView {
 		}
 		if s.DurationMS != nil {
 			sv.DurationMS = *s.DurationMS
+		}
+		if database != nil && s.StepName == types.StepDocument {
+			if combined, err := database.HasAgentInvocationPurpose(s.RunID, string(s.StepName), "housekeeping"); err == nil && combined {
+				sv.WorkScope = ipc.WorkScopeDocumentLintHousekeeping
+			}
 		}
 		if s.FindingsJSON != nil {
 			sv.FindingsJSON = *s.FindingsJSON
@@ -440,10 +453,17 @@ func runObjectFieldWithKey(key string, rv runView) toon.Field {
 	fields = append(fields, toon.Field{Key: "findings", Value: rv.findingsTally()})
 
 	rows := make([]stepRow, 0, len(rv.Steps))
+	sharedRows := make([]sharedWorkRow, 0, 1)
 	for _, s := range rv.Steps {
 		rows = append(rows, stepRow{Step: s.Name, Status: s.Status, Findings: s.findingCount(), DurationMS: s.DurationMS})
+		if s.WorkScope != "" {
+			sharedRows = append(sharedRows, sharedWorkRow{AttributedTo: s.Name, Scope: s.WorkScope, DurationMS: s.DurationMS})
+		}
 	}
 	fields = append(fields, toon.Field{Key: "steps", Value: rows})
+	if len(sharedRows) > 0 {
+		fields = append(fields, toon.Field{Key: "shared_work", Value: sharedRows})
+	}
 	if activeRows := rv.activeRows(); len(activeRows) > 0 {
 		fields = append(fields, toon.Field{Key: "active_steps", Value: activeRows})
 	}

--- a/internal/cli/axi_test.go
+++ b/internal/cli/axi_test.go
@@ -39,7 +39,7 @@ func TestRunViewFromDBAwaitingStep(t *testing.T) {
 		{StepName: types.StepReview, Status: types.StepStatusCompleted},
 		{StepName: types.StepTest, Status: types.StepStatusAwaitingApproval, FindingsJSON: strptr(`{"findings":[],"summary":"x"}`)},
 	}
-	rv := runViewFromDB(run, steps)
+	rv := runViewFromDB(run, steps, nil)
 	gate, ok := rv.awaitingStep()
 	if !ok {
 		t.Fatal("expected an awaiting step")
@@ -59,7 +59,7 @@ func TestRunViewFromDBCarriesCIOverrideReason(t *testing.T) {
 		{StepName: types.StepReview, Status: types.StepStatusCompleted},
 		{StepName: types.StepCI, Status: types.StepStatusCompleted, OverrideReason: strptr("live checks still failing: required-check")},
 	}
-	rv := runViewFromDB(run, steps)
+	rv := runViewFromDB(run, steps, nil)
 	if rv.CIOverrideReason != "live checks still failing: required-check" {
 		t.Errorf("CIOverrideReason = %q, want the step's override reason", rv.CIOverrideReason)
 	}
@@ -127,6 +127,31 @@ func TestWriteRunObjectShape(t *testing.T) {
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("run object missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunObjectRendersCombinedHousekeepingAttribution(t *testing.T) {
+	rv := runView{
+		ID:      "run-1",
+		Branch:  "feature/x",
+		Status:  string(types.RunRunning),
+		HeadSHA: "abcdef1234567890",
+		Steps: []stepView{{
+			Name:       string(types.StepDocument),
+			Status:     string(types.StepStatusCompleted),
+			DurationMS: 173_000,
+			WorkScope:  ipc.WorkScopeDocumentLintHousekeeping,
+		}},
+	}
+
+	out := axiDoc(runObjectField(rv))
+	for _, want := range []string{
+		"shared_work[1]{attributed_to,scope,duration_ms}:\n",
+		"document,document+lint housekeeping,173000\n",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("combined housekeeping attribution missing %q in:\n%s", want, out)
 		}
 	}
 }
@@ -250,7 +275,7 @@ func TestStatusRendersCurrentAutoFixAttemptWithPersistedLimit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load steps: %v", err)
 	}
-	rv := runViewFromDB(run, steps)
+	rv := runViewFromDB(run, steps, database)
 	reviewLimit := 9
 	annotateRunView(&axiEnv{
 		d: database,

--- a/internal/cli/stats.go
+++ b/internal/cli/stats.go
@@ -80,7 +80,7 @@ func renderAgentPerfReport(w io.Writer, database *db.DB, runID string) error {
 	fmt.Fprintln(tw, "PURPOSE\tCOUNT\tAVG\tTOTAL\tCOLD\tSTARTED\tRESUMED\tFALLBACK\tERRORS\tIN TOK\tOUT TOK\tCACHE READ TOK\tCACHE WRITE TOK\tFRESH IN TOK\tREASON TOK")
 	for _, a := range aggregates {
 		fmt.Fprintf(tw, "%s\t%d\t%s\t%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%s\t%s\t%s\n",
-			a.Purpose, a.Count,
+			invocationPurposeLabel(a.Purpose), a.Count,
 			formatMS(a.AvgDurationMS), formatMS(a.TotalDurationMS),
 			a.Cold, a.Started, a.Resumed, a.Fallback, a.Errors,
 			a.InputTokens, a.OutputTokens, a.CacheReadTokens, optInt64(a.CacheCreationTokens),
@@ -100,7 +100,7 @@ func renderAgentPerfReport(w io.Writer, database *db.DB, runID string) error {
 	for _, a := range aggregates {
 		metricsCov := fmt.Sprintf("%d/%d", a.MetricsRows, a.Count)
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			a.Purpose, metricsCov, optMS(a.SubprocessWaitMS),
+			invocationPurposeLabel(a.Purpose), metricsCov, optMS(a.SubprocessWaitMS),
 			optInt64(a.ModelRoundtrips), optInt64(a.ToolCalls),
 			optInt64(a.ToolWaitCalls), optInt64(a.ToolTestLintCalls), optInt64(a.ToolEditCalls), optInt64(a.ToolReadCalls), optInt64(a.ToolGitCalls), optInt64(a.ToolOtherCalls),
 		)
@@ -138,7 +138,7 @@ func renderRunAgentPerf(w io.Writer, database *db.DB, runID string) error {
 			exit += "/" + inv.FailureCategory
 		}
 		fmt.Fprintf(tw, "%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			inv.StepName, inv.Round, inv.Purpose, inv.Agent, orUnknown(inv.Model),
+			invocationStepLabel(inv), inv.Round, invocationPurposeLabel(inv.Purpose), inv.Agent, orUnknown(inv.Model),
 			inv.SessionMode, inv.SessionKey,
 			formatMS(inv.DurationMS), formatModelTime(inv), optMS(inv.SubprocessWaitMS),
 			optInt(inv.ModelRoundtrips), formatToolHistogram(inv), optInt(inv.FindingCount),
@@ -157,13 +157,27 @@ func renderRunAgentPerf(w io.Writer, database *db.DB, runID string) error {
 	fmt.Fprintln(tw, "STEP\tROUND\tPURPOSE\tSESSION\tΔ IN (round)\tΔ OUT\tΔ CACHE RD\tIN (raw)\tOUT (raw)\tCACHE RD (raw)\tCACHE WR\tFRESH IN\tREASON")
 	for _, inv := range invocations {
 		fmt.Fprintf(tw, "%s\t%d\t%s\t%s\t%s\t%s\t%s\t%d\t%d\t%d\t%s\t%s\t%s\n",
-			inv.StepName, inv.Round, inv.Purpose, inv.SessionMode,
+			invocationStepLabel(inv), inv.Round, invocationPurposeLabel(inv.Purpose), inv.SessionMode,
 			optInt(inv.DeltaInputTokens), optInt(inv.DeltaOutputTokens), optInt(inv.DeltaCacheReadTokens),
 			inv.InputTokens, inv.OutputTokens, inv.CacheReadTokens,
 			optInt(inv.CacheCreationTokens), optInt(inv.FreshInputTokens), optInt(inv.ReasoningTokens),
 		)
 	}
 	return tw.Flush()
+}
+
+func invocationPurposeLabel(purpose string) string {
+	if purpose == "housekeeping" {
+		return "housekeeping (document+lint)"
+	}
+	return purpose
+}
+
+func invocationStepLabel(inv db.AgentInvocation) string {
+	if inv.Purpose == "housekeeping" {
+		return "document+lint"
+	}
+	return inv.StepName
 }
 
 func formatMS(ms int64) string {

--- a/internal/cli/stats_agents_test.go
+++ b/internal/cli/stats_agents_test.go
@@ -33,6 +33,7 @@ func TestStatsAgentsReportsLocalPerformanceTelemetry(t *testing.T) {
 		{RunID: run.ID, StepName: "review", Round: 1, Purpose: "review", Agent: "codex", Model: "gpt-5.2", SessionMode: db.InvocationModeStarted, SessionKey: "deadbeef00000000", StartedAt: 1, CompletedAt: 2, DurationMS: 60_000, ExitStatus: "ok", InputTokens: 100, OutputTokens: 10, CacheReadTokens: 40, CacheCreationTokens: statsIntPtr(20)},
 		{RunID: run.ID, StepName: "review", Round: 2, Purpose: "review", Agent: "codex", Model: "gpt-5.2", SessionMode: db.InvocationModeResumed, SessionKey: "deadbeef00000000", StartedAt: 3, CompletedAt: 4, DurationMS: 30_000, ExitStatus: "ok", InputTokens: 50, OutputTokens: 5, CacheReadTokens: 45, CacheCreationTokens: statsIntPtr(25)},
 		{RunID: run.ID, StepName: "review", Round: 2, Purpose: "review-fix", Agent: "codex", Model: "gpt-5.2", SessionMode: db.InvocationModeStarted, SessionKey: "feedface00000000", StartedAt: 5, CompletedAt: 6, DurationMS: 45_000, ExitStatus: "ok"},
+		{RunID: run.ID, StepName: "document", Round: 1, Purpose: "housekeeping", Agent: "codex", Model: "gpt-5.2", SessionMode: db.InvocationModeCold, StartedAt: 7, CompletedAt: 8, DurationMS: 172_000, ExitStatus: "ok"},
 	}
 	for _, inv := range seed {
 		if _, err := d.InsertAgentInvocation(inv); err != nil {
@@ -48,7 +49,7 @@ func TestStatsAgentsReportsLocalPerformanceTelemetry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stats --agents: %v\n%s", err, out)
 	}
-	for _, want := range []string{"PURPOSE", "review", "review-fix", "RESUMED", "CACHE WRITE TOK", "45"} {
+	for _, want := range []string{"PURPOSE", "review", "review-fix", "housekeeping (document+lint)", "RESUMED", "CACHE WRITE TOK", "45"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("stats --agents missing %q in:\n%s", want, out)
 		}
@@ -58,7 +59,7 @@ func TestStatsAgentsReportsLocalPerformanceTelemetry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stats --run: %v\n%s", err, out)
 	}
-	for _, want := range []string{run.ID, "parked at gates 1m30s total", "resumed", "deadbeef00000000", "gpt-5.2", "CACHE WR", "20"} {
+	for _, want := range []string{run.ID, "parked at gates 1m30s total", "resumed", "deadbeef00000000", "gpt-5.2", "document+lint", "housekeeping (document+lint)", "CACHE WR", "20"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("stats --run missing %q in:\n%s", want, out)
 		}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1366,6 +1366,11 @@ func stepToInfo(d *db.DB, s *db.StepResult) ipc.StepResultInfo {
 		LastActivity:   s.LastActivity,
 		AgentPID:       s.AgentPID,
 	}
+	if s.StepName == types.StepDocument {
+		if combined, err := d.HasAgentInvocationPurpose(s.RunID, string(s.StepName), "housekeeping"); err == nil && combined {
+			info.WorkScope = ipc.WorkScopeDocumentLintHousekeeping
+		}
+	}
 	if s.OverrideReason != nil {
 		info.OverrideReason = *s.OverrideReason
 	}

--- a/internal/daemon/runinfo_test.go
+++ b/internal/daemon/runinfo_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
@@ -72,6 +73,39 @@ func TestStepToInfoIncludesFixSummaries(t *testing.T) {
 	info := stepToInfo(d, step)
 	if len(info.FixSummaries) != 1 || info.FixSummaries[0] != sum {
 		t.Errorf("fix summaries = %v, want [%q]", info.FixSummaries, sum)
+	}
+}
+
+func TestStepToInfoLabelsCombinedHousekeepingScope(t *testing.T) {
+	d, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer d.Close()
+
+	repo, err := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")
+	if err != nil {
+		t.Fatalf("insert repo: %v", err)
+	}
+	run, err := d.InsertRun(repo.ID, "feature", "abc", "def")
+	if err != nil {
+		t.Fatalf("insert run: %v", err)
+	}
+	step, err := d.InsertStepResult(run.ID, types.StepDocument)
+	if err != nil {
+		t.Fatalf("insert step: %v", err)
+	}
+	if _, err := d.InsertAgentInvocation(db.AgentInvocation{
+		RunID: run.ID, StepName: string(types.StepDocument), Round: 1,
+		Purpose: "housekeeping", Agent: "codex", SessionMode: db.InvocationModeCold,
+		StartedAt: 1, CompletedAt: 2, DurationMS: 1000, ExitStatus: "ok",
+	}); err != nil {
+		t.Fatalf("insert invocation: %v", err)
+	}
+
+	info := stepToInfo(d, step)
+	if info.WorkScope != ipc.WorkScopeDocumentLintHousekeeping {
+		t.Fatalf("work scope = %q, want combined housekeeping attribution", info.WorkScope)
 	}
 }
 

--- a/internal/db/agent_invocation.go
+++ b/internal/db/agent_invocation.go
@@ -156,6 +156,25 @@ func (d *DB) InsertAgentInvocation(inv AgentInvocation) (*AgentInvocation, error
 	return &inv, nil
 }
 
+// HasAgentInvocationPurpose reports whether a step recorded an invocation with
+// the given purpose. Presentation surfaces use this persisted evidence to
+// identify work shared across logical pipeline steps without changing the
+// pipeline's execution model.
+func (d *DB) HasAgentInvocationPurpose(runID, stepName, purpose string) (bool, error) {
+	var found bool
+	err := d.sql.QueryRow(
+		`SELECT EXISTS(
+			SELECT 1 FROM agent_invocations
+			WHERE run_id = ? AND step_name = ? AND purpose = ?
+		)`,
+		runID, stepName, purpose,
+	).Scan(&found)
+	if err != nil {
+		return false, fmt.Errorf("check agent invocation purpose: %w", err)
+	}
+	return found, nil
+}
+
 // GetAgentInvocationsByRun returns a run's invocations in execution order.
 func (d *DB) GetAgentInvocationsByRun(runID string) ([]AgentInvocation, error) {
 	rows, err := d.sql.Query(

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -284,18 +284,26 @@ type RunInfo struct {
 	UpdatedAt int64 `json:"updated_at"`
 }
 
+// WorkScopeDocumentLintHousekeeping identifies the one agent invocation that
+// performs both duties while its wall time is stored on the document step.
+const WorkScopeDocumentLintHousekeeping = "document+lint housekeeping"
+
 // StepResultInfo is the IPC representation of a step result.
 type StepResultInfo struct {
-	ID               string           `json:"id"`
-	RunID            string           `json:"run_id"`
-	StepName         types.StepName   `json:"step_name"`
-	StepOrder        int              `json:"step_order"`
-	Status           types.StepStatus `json:"status"`
-	ExitCode         *int             `json:"exit_code,omitempty"`
-	DurationMS       *int64           `json:"duration_ms,omitempty"`
-	FindingsJSON     *string          `json:"findings_json,omitempty"`
-	ReportedFindings int              `json:"reported_findings,omitempty"`
-	FixedFindings    int              `json:"fixed_findings,omitempty"`
+	ID         string           `json:"id"`
+	RunID      string           `json:"run_id"`
+	StepName   types.StepName   `json:"step_name"`
+	StepOrder  int              `json:"step_order"`
+	Status     types.StepStatus `json:"status"`
+	ExitCode   *int             `json:"exit_code,omitempty"`
+	DurationMS *int64           `json:"duration_ms,omitempty"`
+	// WorkScope names shared work whose wall time is recorded on this logical
+	// step. For example, the document step can own one combined document+lint
+	// housekeeping invocation while lint only records the cached handoff.
+	WorkScope        string  `json:"work_scope,omitempty"`
+	FindingsJSON     *string `json:"findings_json,omitempty"`
+	ReportedFindings int     `json:"reported_findings,omitempty"`
+	FixedFindings    int     `json:"fixed_findings,omitempty"`
 	// FixSummaries holds one entry per fix round the pipeline ran for this
 	// step, in round order: the agent's one-line fix summary, or "" when the
 	// round recorded none. Agent surfaces use it to report applied fixes.
@@ -352,6 +360,7 @@ type Event struct {
 	ReportedFindings *int            `json:"reported_findings,omitempty"`
 	FixedFindings    *int            `json:"fixed_findings,omitempty"`
 	DurationMS       *int64          `json:"duration_ms,omitempty"` // execution-only duration for step events
+	WorkScope        string          `json:"work_scope,omitempty"`  // shared work attributed to this step
 	PRURL            *string         `json:"pr_url,omitempty"`      // PR URL for run_updated/run_completed events
 	// StateRev is the daemon-assigned monotonic revision of the run state
 	// this event reflects, or zero for activity. A consumer applies a state

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -1617,6 +1617,15 @@ func (e *Executor) emitStepEventWithFindingsAndError(eventType ipc.EventType, ru
 		Status:     &status,
 		DurationMS: durationMS,
 	}
+	// The combined housekeeping invocation is recorded under Document because
+	// that is where it executes. Carry its broader scope on completion so an
+	// attached TUI does not temporarily present the shared wall time as
+	// documentation-only work while waiting for another snapshot.
+	if stepName == types.StepDocument {
+		if combined, err := e.db.HasAgentInvocationPurpose(run.ID, string(stepName), "housekeeping"); err == nil && combined {
+			event.WorkScope = ipc.WorkScopeDocumentLintHousekeeping
+		}
+	}
 	stats := e.findingStatsForStep(run.ID, stepName)
 	if stats.ReportedFindings > 0 || stats.FixedFindings > 0 {
 		reported := stats.ReportedFindings

--- a/internal/pipeline/executor_work_scope_test.go
+++ b/internal/pipeline/executor_work_scope_test.go
@@ -1,0 +1,36 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/ipc"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+func TestExecutor_DocumentCompletionCarriesCombinedHousekeepingScope(t *testing.T) {
+	database, p, run, repo := setupTest(t)
+	if _, err := database.InsertAgentInvocation(db.AgentInvocation{
+		RunID: run.ID, StepName: string(types.StepDocument), Round: 1,
+		Purpose: "housekeeping", Agent: "codex", SessionMode: db.InvocationModeCold,
+		StartedAt: 1, CompletedAt: 2, DurationMS: 1000, ExitStatus: "ok",
+	}); err != nil {
+		t.Fatalf("insert invocation: %v", err)
+	}
+
+	events := &eventCollector{}
+	executor := NewExecutor(database, p, nil, nil, nil, events.handler)
+	duration := int64(1200)
+	executor.emitStepEventWithFindingsAndError(
+		ipc.EventStepCompleted, run, repo, types.StepDocument,
+		string(types.StepStatusCompleted), "", "", &duration,
+	)
+
+	event := events.find(ipc.EventStepCompleted, types.StepDocument)
+	if event == nil {
+		t.Fatal("document completion event not emitted")
+	}
+	if event.WorkScope != ipc.WorkScopeDocumentLintHousekeeping {
+		t.Fatalf("work scope = %q, want combined housekeeping", event.WorkScope)
+	}
+}

--- a/internal/tui/events.go
+++ b/internal/tui/events.go
@@ -105,6 +105,9 @@ func (m *Model) applyEvent(event ipc.Event) bool {
 		if event.StepName != nil && event.ReportedFindings != nil {
 			m.setStepReportedFindings(*event.StepName, *event.ReportedFindings)
 		}
+		if event.StepName != nil && event.WorkScope != "" {
+			m.setStepWorkScope(*event.StepName, event.WorkScope)
+		}
 		// Persist duration so the step continues to display its elapsed time.
 		// Prefer the event's execution-only duration; fall back to local timing.
 		// For "fixing" status, clear the persisted duration and back-date the
@@ -402,6 +405,15 @@ func (m *Model) setStepDuration(name types.StepName, durationMS *int64) {
 	for i := range m.steps {
 		if m.steps[i].StepName == name {
 			m.steps[i].DurationMS = durationMS
+			return
+		}
+	}
+}
+
+func (m *Model) setStepWorkScope(name types.StepName, workScope string) {
+	for i := range m.steps {
+		if m.steps[i].StepName == name {
+			m.steps[i].WorkScope = workScope
 			return
 		}
 	}

--- a/internal/tui/events_test.go
+++ b/internal/tui/events_test.go
@@ -36,6 +36,30 @@ func TestModel_ApplyEvent_RunCompletedCarriesCIOverride(t *testing.T) {
 	}
 }
 
+func TestModel_ApplyEvent_StepCompletedCarriesCombinedWorkScope(t *testing.T) {
+	run := testRun()
+	run.Steps = append(run.Steps, ipc.StepResultInfo{StepName: types.StepDocument, Status: types.StepStatusPending})
+	m := NewModel("/tmp/sock", nil, run)
+	status := string(types.StepStatusCompleted)
+	m.applyEvent(ipc.Event{
+		Type:      ipc.EventStepCompleted,
+		RunID:     run.ID,
+		StepName:  ptr(types.StepDocument),
+		Status:    &status,
+		WorkScope: ipc.WorkScopeDocumentLintHousekeeping,
+	})
+
+	for _, step := range m.steps {
+		if step.StepName == types.StepDocument {
+			if step.WorkScope != ipc.WorkScopeDocumentLintHousekeeping {
+				t.Fatalf("work scope = %q, want combined housekeeping", step.WorkScope)
+			}
+			return
+		}
+	}
+	t.Fatal("document step not found")
+}
+
 func TestModel_ApplyEvent_LogChunk(t *testing.T) {
 	run := testRun()
 	m := NewModel("/tmp/sock", nil, run)

--- a/internal/tui/pipeline.go
+++ b/internal/tui/pipeline.go
@@ -151,6 +151,9 @@ func renderPipelineView(run *ipc.RunInfo, steps []ipc.StepResultInfo, width int,
 		icon := stepStatusIndicator(step.Status, spinnerFrame)
 		style := stepStatusStyle(step.Status)
 		label := stepLabel(step.StepName)
+		if step.WorkScope == ipc.WorkScopeDocumentLintHousekeeping {
+			label = "Document + Lint housekeeping"
+		}
 
 		line := style.Render(icon) + " " + label
 

--- a/internal/tui/pipeline_test.go
+++ b/internal/tui/pipeline_test.go
@@ -50,6 +50,21 @@ func TestStepLabel(t *testing.T) {
 	}
 }
 
+func TestRenderPipelineView_LabelsCombinedHousekeepingDuration(t *testing.T) {
+	run := testRun()
+	run.Steps = []ipc.StepResultInfo{{
+		StepName:   types.StepDocument,
+		Status:     types.StepStatusCompleted,
+		DurationMS: ptr(int64(173_000)),
+		WorkScope:  ipc.WorkScopeDocumentLintHousekeeping,
+	}}
+
+	out := stripANSI(renderPipelineView(run, run.Steps, 80, 0, 40))
+	if !strings.Contains(out, "Document + Lint housekeeping  173.0s") {
+		t.Fatalf("combined housekeeping duration was not explicit:\n%s", out)
+	}
+}
+
 func TestRenderPipelineView_NilRun(t *testing.T) {
 	out := renderPipelineView(nil, nil, 80, 0, 40)
 	if out != "No active run." {


### PR DESCRIPTION
## Intent

Implement upstream issue #915: preserve the existing single-agent combined Document/Lint housekeeping optimization when commands.lint is empty, but make its timing and token attribution explicit and understandable in AXI status, the TUI step dashboard, and local stats. Do not add or reorder pipeline steps or add a second agent invocation. Show that Document's recorded wall time covers document+lint housekeeping while Lint's own duration is only the cached-result handoff, and document the observable output.

## What Changed

- Surface persisted combined Document/Lint housekeeping work in AXI run views, IPC updates, and the TUI, attributing its wall time to Document.
- Label combined housekeeping entries as `document+lint` in local agent-performance stats while leaving Lint’s duration as the cached-result handoff.
- Document the combined-housekeeping timing shown in AXI status and the TUI dashboard.

## Risk Assessment

✅ Low: The change is presentation-only, preserves the existing execution path, and consistently derives and propagates combined-housekeeping attribution across AXI, TUI, and local stats.

## Testing

Reviewed the change and attempted targeted validation, but the host has no executable Go toolchain, so no automated tests or reviewer-visible AXI/TUI evidence could be produced.

- Outcome: ⚠️ 1 warning across 1 run (2m12s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b57b7e61a7354cdf27be1cce378cb7acbdede9f5","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ Targeted Go tests and executable AXI/TUI evidence could not run: `go` is absent from PATH and the standard local Go installation locations checked. Installing/configuring it is outside the permitted worktree boundary. Provide a Go toolchain in the execution environment, then rerun the focused tests.
- `Inspected the target diff and identified focused behavioral coverage for the preserved single Document/Lint invocation, AXI attribution, stats, daemon event propagation, and TUI rendering.`
- <code>Attempted `go test ./internal/pipeline/steps -run &#39;^TestPipeline_DocumentPlusLintIsOneAgentInvocation$&#39; -count=1` (the command could not start because `go` is not installed/available).</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
