### PR TITLE
test(pipeline): add material policy ambiguity fixture

### DIFF
--- a/internal/pipeline/steps/testdata/authorization_privacy_review/README.md
+++ b/internal/pipeline/steps/testdata/authorization_privacy_review/README.md
@@ -12,6 +12,7 @@ expectation.
 | `missing-tenant-filter.diff` | Invoices are private to their tenant. | Finding: the query accepts tenant context but does not constrain by tenant, exposing another tenant's invoices. |
 | `public-projection-leak.diff` | `InternalNotes` is staff-only; profile responses are public. | Finding: the public serializer projects the staff-only field. |
 | `secondary-log-disclosure.diff` | Password-reset tokens are secret and must not be logged. | Finding: the new log statement discloses the token to log readers. |
+| `material-policy-ambiguity.diff` | No repository policy establishes who may view invoices. | `ask-user` finding: the changed handler discloses an invoice through a caller-controlled ID, but the permitted audience is undefined. Name the missing policy decision rather than inventing an access rule. |
 | `shared-boundary-authorized.diff` | Users may change only their own email; administrators may change any user's email. | No authorization finding: every caller reaches the service-owned authorization check. |
 | `intentionally-public-data.diff` | Display names are intentionally public. | No privacy finding: the response exposes only data explicitly defined as public. |
 

--- a/internal/pipeline/steps/testdata/authorization_privacy_review/material-policy-ambiguity.diff
+++ b/internal/pipeline/steps/testdata/authorization_privacy_review/material-policy-ambiguity.diff
@@ -1,0 +1,17 @@
+diff --git a/billing/http.go b/billing/http.go
+index 1111111..2222222 100644
+--- a/billing/http.go
++++ b/billing/http.go
+@@ -1 +1,12 @@
+ package billing
++
++func GetInvoice(w http.ResponseWriter, r *http.Request) {
++	invoiceID := r.PathValue("invoiceID")
++	invoice, err := store.InvoiceByID(r.Context(), invoiceID)
++	if err != nil {
++		http.Error(w, "not found", http.StatusNotFound)
++		return
++	}
++	w.Header().Set("Content-Type", "application/json")
++	_ = json.NewEncoder(w).Encode(invoice)
++}


### PR DESCRIPTION
## Intent

Follow up on merged PR #946 and issue #940 by committing the omitted development-only material access-policy ambiguity evaluation fixture. The fixture should exercise a changed invoice response whose permitted audience is not established by source or repository policy, and its expected outcome must be an ask-user finding that names the missing policy decision rather than inventing access policy. Keep this follow-up limited to the fixture and its README catalog entry; do not change runtime prompt behavior, schemas, gates, or configuration.

## What Changed

- Add a material-policy-ambiguity authorization/privacy review fixture for an invoice handler that returns a caller-selected invoice.
- Catalog the fixture with an expected `ask-user` finding when repository policy does not define the permitted invoice audience.

## Risk Assessment

✅ Low: The commit is limited to the requested development-only ambiguity fixture and README entry, and both accurately describe an ask-user outcome without changing runtime behavior.

## Testing

Verified the commit scope, applied the fixture cleanly to an evidence-only baseline, and replayed it through a live read-only Review prompt; the result is the required ask-user policy-decision finding. The targeted Go regression could not run because this environment lacks the Go toolchain.

<details>
<summary>Evidence: Live Review replay result</summary>

```text
{"findings":[{"file":"billing/http.go","line":4,"severity":"high","action":"ask-user","description":"GetInvoice accepts a caller-controlled invoiceID, retrieves the corresponding invoice, and returns the complete invoice as JSON without any visible authentication or authorization check. Invoices and their fields are potentially protected billing/user data, but repository policy does not establish who may view them. Define the intended invoice-viewing policy and enforce it here before disclosure."}],"summary":"The new HTTP handler creates a concrete invoice-disclosure path, but the repository does not define which callers are authorized to use it."}
```
</details>
<details>
<summary>Evidence: Fixture applicability and outcome verification</summary>

```text
Fixture patch: applies cleanly to a CRLF baseline repository whose billing/http.go contains only package billing.
Review result: action=ask-user; file=billing/http.go; line=4
Review description: GetInvoice accepts a caller-controlled invoiceID, retrieves the corresponding invoice, and returns the complete invoice as JSON without any visible authentication or authorization check. Invoices and their fields are potentially protected billing/user data, but repository policy does not establish who may view them. Define the intended invoice-viewing policy and enforce it here before disclosure.
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (5m24s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d32f0454660e5c74f0ff2b8f39767163e4474ffb","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ Targeted Go test execution is unavailable: no Go executable is installed or available on PATH. Live fixture replay and patch applicability evidence were completed successfully.
- `git diff --name-status 961fbfb699f968a290351e7977afd78b48f01694 d32f0454660e5c74f0ff2b8f39767163e4474ffb`
- <code>`codex exec --ephemeral --ignore-user-config --ignore-rules -s read-only ...` using the fixture diff and catalog policy</code>
- <code>`git apply --check material-policy-ambiguity.diff`, `git apply`, and `git diff --check` against an evidence-only baseline repository</code>
- <code>`go test ./internal/pipeline/steps -run &#39;^TestReviewStep_AuthorizationPrivacyTracingContract$&#39; -count=1` (blocked: `go` unavailable)</code>
- `git diff --check 961fbfb699f968a290351e7977afd78b48f01694 d32f0454660e5c74f0ff2b8f39767163e4474ffb`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
