### PR TITLE
fix(daemon): refuse reruns that differ from the clean caller HEAD

### DIFF
--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -155,7 +155,7 @@ When the pipeline applied fixes, successful outcomes include a `fixes` table lis
 If that PR later falls behind the default branch or hits a merge conflict - commonly because another PR merged first - the agent runs no command and must never hand-rebase.
 The CI monitor stays live in the background after checks pass, and when it sees an actual conflict it rebases onto the base, resolves it, revalidates from Review because rebasing cannot prove continuity with the reviewed head, and re-pushes the branch through Push, so no agent or user action is needed.
 A PR that is merely behind but still clean needs nothing either, since the platform merges it.
-The one exception is when that monitor is no longer running - the PR was closed, the run was aborted or superseded, it idle-timed-out, or its auto-fix attempts were exhausted - in which case the agent recovers with `no-mistakes rerun`, which cancels the stale monitor and re-runs the full pipeline including a deterministic rebase step.
+The one exception is when that monitor is no longer running - the PR was closed, the run was aborted or superseded, it idle-timed-out, or its auto-fix attempts were exhausted - in which case see [`no-mistakes rerun`](/no-mistakes/reference/cli/#no-mistakes-rerun) for the restart conditions.
 The agent must not use `no-mistakes axi run` to refresh a still-active PR: after `checks-passed` it reattaches to the running monitor with HEAD unchanged and returns the monitor output without rebasing.
 
 In task-first mode, if the repo is on the default branch, the skill tells the agent to create a feature branch before committing because the gate validates committed history on a non-default branch.
@@ -177,7 +177,7 @@ no-mistakes axi abort --run <id>
 
 Before any post-pipeline local commit or fresh run, read `branch_sync` and follow its exact `next_action.command`.
 A `sync` action runs `no-mistakes axi sync` first.
-A `recover_custody` action is ordinary `no-mistakes axi sync --recover` to take a still-available preserved head, or `no-mistakes axi sync --recover --keep-local` when that head is unavailable and you are discarding the missing commits, or when a bound archive preserves divergent later work while custody returns at the reported required head; never substitute one action for the other. `no-mistakes rerun` resumes validating a still-available preserved head.
+A `recover_custody` action is ordinary `no-mistakes axi sync --recover` to take a still-available preserved head, or `no-mistakes axi sync --recover --keep-local` when that head is unavailable and you are discarding the missing commits, or when a bound archive preserves divergent later work while custody returns at the reported required head; never substitute one action for the other. See [`no-mistakes rerun`](/no-mistakes/reference/cli/#no-mistakes-rerun) for the alternative validation path and its refusal conditions.
 A `branch_sync.state` of `user_owned` means the run went terminal before changing the submitted head and cancellation released the branch: it is immediately usable and needs no sync action.
 When `next_action.code` is `continue_active_run`, run the reported command and keep driving the active run.
 If synchronization is blocked, process that state instead of improvising reset, stash, merge, rebase, force, or branch replacement.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -252,7 +252,7 @@ Status uses the same `recoverySourceAvailable` classification as recovery and ac
 
 A verified archive plan reports its evidence in `branch_sync.recovery`, keeps `next_action.code: recover_custody`, and sets the command to exactly `no-mistakes axi sync --recover --keep-local`. That action leaves the worktree and local branch at `recovery.required_head`, leaves the divergent archive at `recovery.preserved_head`, and never merges, replays, fast-forwards, resets to, or otherwise selects the archived history. Running plain `--recover` against this plan refuses without adding an anchor or moving a ref.
 
-`no-mistakes rerun` is the alternative exit for ordinary preserved-head recovery that resumes validating the preserved head instead of taking the branch back; it is not offered for the archive-backed keep-local plan.
+For the alternative validation path and its refusal conditions, see [`no-mistakes rerun`](#no-mistakes-rerun); it is not offered for the archive-backed keep-local plan.
 A recovered never-pushed run reports `state: custody_returned`; a recovered pushed run reports its ordinary classification against the last push binding, typically `local_ahead`.
 On a `user_owned` branch, `--recover` is an idempotent no-op success: nothing pipeline-created exists to recover, and no file, ref, or database row changes.
 
@@ -349,10 +349,14 @@ the run-specific recovery ref is conflicting, invalid, or the recorded head is
 unavailable. Use `no-mistakes axi status` and reconcile custody first in that
 case.
 When invoked from a clean worktree, `rerun` also refuses if that worktree's HEAD
-differs from the selected gate or preserved head. The error names both heads;
+differs from the selected gate or preserved head, before starting or superseding
+any run. The error names both full commit SHAs;
 inspect `no-mistakes axi status` and follow its custody guidance, then use
-`no-mistakes axi run` to submit local commits. Rerun never replaces its selected
-head with the caller's head. Dirty worktrees retain the existing selection behavior.
+`no-mistakes axi run` to submit local commits. The refusal leaves both branches
+unchanged; rerun never replaces its selected head with the caller's head.
+The same check applies to `axi run`'s rerun fallback after an up-to-date push.
+Dirty worktrees and callers without clean-head evidence, including TUI reruns,
+retain the existing selection behavior.
 If the selected prior run has explicit intent, rerun inherits it exactly by default;
 otherwise it performs fresh intent inference. `--intent` supplies a new canonical
 explicit intent in either case. Inherited intent keeps distinct rerun provenance;

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -133,7 +133,7 @@ When the CI step is still monitoring an open PR and checks are green - or the tr
 Treat that as the agent stopping point: ask the user to review and merge the PR from the `help` line.
 If that PR later falls behind the default branch or hits a merge conflict, do not run `axi run`, `rerun`, or a manual rebase while the CI monitor is still running.
 The monitor auto-rebases onto the base, resolves actual conflicts, revalidates from Review because rebasing cannot prove continuity with the reviewed head, and re-pushes the branch through Push; a PR that is merely behind but clean needs no command.
-Use `no-mistakes rerun` only after that monitor is no longer running, such as a closed PR, aborted or superseded run, idle timeout, or exhausted CI auto-fix attempts.
+After that monitor ends, see [`no-mistakes rerun`](#no-mistakes-rerun) for the restart conditions.
 Successful outcomes (`checks-passed`, `passed`, and `passed-with-override`) also carry `help` instructions telling the agent to summarize the run.
 `passed-with-override` is a completed run whose CI approval gate was approved by a human while a live check was still failing; it stays a success but reads distinctly from a genuinely green `passed`, and its `help` names the failure the operator approved past.
 When the pipeline applied fixes, they include a `fixes` table and a `help` instruction to acknowledge the misses and list those fixes for the user's review.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -348,14 +348,19 @@ is stale. The command refuses instead of falling back to the gate branch when
 the run-specific recovery ref is conflicting, invalid, or the recorded head is
 unavailable. Use `no-mistakes axi status` and reconcile custody first in that
 case.
+When invoked from a clean worktree, `rerun` also refuses if that worktree's HEAD
+differs from the selected gate or preserved head. The error names both heads;
+inspect `no-mistakes axi status` and follow its custody guidance, then use
+`no-mistakes axi run` to submit local commits. Rerun never replaces its selected
+head with the caller's head. Dirty worktrees retain the existing selection behavior.
 If the selected prior run has explicit intent, rerun inherits it exactly by default;
 otherwise it performs fresh intent inference. `--intent` supplies a new canonical
 explicit intent in either case. Inherited intent keeps distinct rerun provenance;
 an override is recorded as newly supplied explicit intent, while fresh inference
 records the transcript source. If another run is active on that branch, rerun
 cancels it before starting over. Treat rerun as a between-runs action after a
-failed or cancelled outcome, or after you have committed a separate fix outside
-an active run; do not use it to bypass a gate.
+failed or cancelled outcome; use `axi run` for separate local fixes, and do not
+use rerun to bypass a gate.
 
 | Flag | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |

--- a/internal/branchsync/sync.go
+++ b/internal/branchsync/sync.go
@@ -645,8 +645,7 @@ func (s *Service) BindRecoveryArchive(ctx context.Context, archiveRef string) St
 // Recovery ends with persisted custody-return stamps on the recovered run or
 // stranded stack; inspection then reports custody_returned (never-pushed runs)
 // or the ordinary classification against the last push binding (pushed runs),
-// both pointing at run_pipeline as the next step. `no-mistakes rerun` remains the alternative
-// exit that resumes validating the preserved head instead of taking it back.
+// both pointing at run_pipeline as the next step.
 func (s *Service) Recover(ctx context.Context, keepLocal bool) State {
 	if refusal, blocked := s.gateContextRefusal(ctx); blocked {
 		return refusal

--- a/internal/branchsync/sync.go
+++ b/internal/branchsync/sync.go
@@ -593,7 +593,7 @@ func (s *Service) BindRecoveryArchive(ctx context.Context, archiveRef string) St
 //	all local
 //	work
 //	diverged   any       refuse (anchor named, manual   custody at local head;
-//	                     reconcile / rerun offered)     gate reset to it (CAS)
+//	                     reconcile / guarded rerun)     gate reset to it (CAS)
 //	P missing  any       refuse                         custody at local head;
 //	                                                    gate reset to it (CAS)
 //
@@ -842,7 +842,7 @@ func (s *Service) Recover(ctx context.Context, keepLocal bool) State {
 			return s.recoverAdoptPreserved(ctx, run, state, preserved)
 		}
 		state.Relation = RelationDiverged
-		blocked := blockedPlan(state, StatePipelineOwned, "blocked_recover_diverged", fmt.Sprintf("the local branch and the preserved pipeline head have diverged; the preserved commits are anchored at %s - reconcile manually and re-run the recovery, run `no-mistakes rerun` to resume validating the preserved head, or use --keep-local to keep the current head; no files or refs were changed", anchorRef))
+		blocked := blockedPlan(state, StatePipelineOwned, "blocked_recover_diverged", fmt.Sprintf("the local branch and the preserved pipeline head have diverged; the preserved commits are anchored at %s - reconcile manually and re-run the recovery, or use --keep-local to keep the current head. `no-mistakes rerun` resumes validating the selected preserved head, but refuses a known clean caller HEAD mismatch. If heads differ, inspect `no-mistakes axi status` and follow its exact `branch_sync.next_action.command` for custody or synchronization, then submit intended local commits with a fresh `no-mistakes axi run` once custody permits; no files or refs were changed", anchorRef))
 		blocked.NextAction = &NextAction{Code: "inspect_and_reconcile_manually", Command: "git log --oneline --left-right HEAD..." + anchorRef}
 		return blocked
 	}

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -439,7 +439,9 @@ func triggerRun(ctx context.Context, env *axiEnv, branch, headSHA string, skipSt
 	// No run appeared: the push was likely up-to-date. Rerun the latest gate
 	// head so `axi run` is still useful when there are no new commits.
 	var rr ipc.RerunResult
-	if err := env.client.Call(ipc.MethodRerun, rerunParams(env.repo.ID, branch, skipSteps, intent, baseBranch), &rr); err != nil {
+	params := rerunParams(env.repo.ID, branch, skipSteps, intent, baseBranch)
+	params.CallerHeadSHA = headSHA
+	if err := env.client.Call(ipc.MethodRerun, params, &rr); err != nil {
 		return "", fmt.Errorf("no run started for %q: %v", branch, err)
 	}
 	return rr.RunID, nil

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -436,8 +436,8 @@ func triggerRun(ctx context.Context, env *axiEnv, branch, headSHA string, skipSt
 		return "", fmt.Errorf("push %q to gate: %v", branch, pushErr)
 	}
 
-	// No run appeared: the push was likely up-to-date. Rerun the latest gate
-	// head so `axi run` is still useful when there are no new commits.
+	// No run appeared: the push was likely up-to-date. Bind the fallback to
+	// AXI's clean head so a different gate or preserved head is refused.
 	var rr ipc.RerunResult
 	params := rerunParams(env.repo.ID, branch, skipSteps, intent, baseBranch)
 	params.CallerHeadSHA = headSHA

--- a/internal/cli/axi_drive.go
+++ b/internal/cli/axi_drive.go
@@ -436,11 +436,14 @@ func triggerRun(ctx context.Context, env *axiEnv, branch, headSHA string, skipSt
 		return "", fmt.Errorf("push %q to gate: %v", branch, pushErr)
 	}
 
-	// No run appeared: the push was likely up-to-date. Bind the fallback to
-	// AXI's clean head so a different gate or preserved head is refused.
+	// No run appeared: the push was likely up-to-date. Refresh the caller's
+	// clean-head evidence because it may have changed while waiting above.
 	var rr ipc.RerunResult
 	params := rerunParams(env.repo.ID, branch, skipSteps, intent, baseBranch)
-	params.CallerHeadSHA = headSHA
+	params.CallerHeadSHA, err = rerunCallerHead(ctx)
+	if err != nil {
+		return "", err
+	}
 	if err := env.client.Call(ipc.MethodRerun, params, &rr); err != nil {
 		return "", fmt.Errorf("no run started for %q: %v", branch, err)
 	}

--- a/internal/cli/axi_guidance.go
+++ b/internal/cli/axi_guidance.go
@@ -6,13 +6,14 @@ package cli
 // PR merged first). The live CI monitor keeps running after checks pass and
 // auto-rebases onto the base, resolves the conflict, revalidates from Review,
 // and re-pushes itself, so the agent runs no command and never hand-rebases. `no-mistakes
-// rerun` is only the recovery for a monitor that is no longer running.
+// rerun` is only the recovery for a monitor that is no longer running, and a
+// known clean caller head must match the head rerun already selects.
 //
-// This same guidance is mirrored in the skill body (internal/skill/skill.go)
-// and the published agents guide (docs/.../guides/agents.md); the repo treats
-// agent-driving guidance as a multi-surface contract, and
-// TestStaleMonitorGuidance_SyncedAcrossSurfaces keeps the three in sync.
-const staleMonitorGuidance = "If this PR later falls behind the default branch or hits a merge conflict, the CI monitor rebases onto the base, resolves it, revalidates from Review because rebasing cannot prove continuity with the reviewed head, and re-pushes it through Push automatically - run no command and never hand-rebase. Only when that monitor is no longer running (PR closed, run aborted, idle-timeout, or auto-fix exhausted) recover with `no-mistakes rerun`."
+// The skill body (internal/skill/skill.go) owns the full driving guidance; the
+// agents guide (docs/.../guides/agents.md) keeps the monitor invariant and links
+// to the CLI reference for restart conditions.
+// TestStaleMonitorGuidance_SyncedAcrossSurfaces guards that contract.
+const staleMonitorGuidance = "If this PR later falls behind the default branch or hits a merge conflict, the CI monitor rebases onto the base, resolves it, revalidates from Review because rebasing cannot prove continuity with the reviewed head, and re-pushes it through Push automatically - run no command and never hand-rebase. Only when that monitor is no longer running (PR closed, run aborted, idle-timeout, or auto-fix exhausted) use `no-mistakes rerun` to validate the selected gate or preserved head; it refuses a known clean caller HEAD mismatch. If heads differ, inspect `no-mistakes axi status` and follow its exact `branch_sync.next_action.command` for custody or synchronization, then submit intended local commits with a fresh `no-mistakes axi run` once custody permits."
 
 // preserveGateFixCommitsGuidance is the canonical, point-of-use guidance an
 // agent reads when it needs to make another fix after a gate round already

--- a/internal/cli/axi_guidance_test.go
+++ b/internal/cli/axi_guidance_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/kunchenguid/no-mistakes/internal/branchsync"
 	"github.com/kunchenguid/no-mistakes/internal/gatecontext"
 	"github.com/kunchenguid/no-mistakes/internal/gateguidance"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
@@ -20,13 +21,24 @@ import (
 // canonicalStaleMonitorPhrases are the load-bearing claims of the corrected
 // "PR fell behind / conflicted after checks pass" guidance: the live CI monitor
 // auto-rebases and re-pushes such a PR, so the agent runs no command and never
-// hand-rebases, and `no-mistakes rerun` is only the dead-monitor recovery.
+// hand-rebases, and `no-mistakes rerun` is only the dead-monitor recovery,
+// subject to its clean caller-head check.
 var canonicalStaleMonitorPhrases = []string{
 	"never hand-rebase",
 	"revalidates from Review",
 	"cannot prove continuity with the reviewed head",
 	"re-pushes",
 	"no-mistakes rerun",
+}
+
+var canonicalRerunRecoveryPhrases = []string{
+	"known clean caller",
+	"selected",
+	"refuses",
+	"no-mistakes axi status",
+	"next_action.command",
+	"no-mistakes axi run",
+	"custody",
 }
 
 var canonicalPreserveGateFixPhrases = []string{
@@ -64,6 +76,22 @@ func TestStaleMonitorGuidance_SyncedAcrossSurfaces(t *testing.T) {
 			t.Errorf("%s still carries the discarded 'rebase step integrates the latest default branch' wording", name)
 		}
 	}
+
+	// Detailed rerun conditions belong to the skill and live guidance; the
+	// agents guide links to the CLI reference instead of duplicating them.
+	for name, content := range map[string]string{
+		"skill body":      skill.Markdown(),
+		"axi help string": staleMonitorGuidance,
+		"human recovery summary": humanSyncSummary(branchsync.State{
+			State: branchsync.StatePipelineOwned, Safety: "blocked_pipeline_owned_recoverable",
+		}),
+	} {
+		for _, phrase := range canonicalRerunRecoveryPhrases {
+			if !strings.Contains(content, phrase) {
+				t.Errorf("%s is missing rerun recovery guidance %q", name, phrase)
+			}
+		}
+	}
 }
 
 // TestStaleMonitorGuidance_InChecksPassedOutput ensures the guidance reaches the
@@ -89,7 +117,7 @@ func TestStaleMonitorGuidance_InChecksPassedOutput(t *testing.T) {
 	}
 
 	got := out.String()
-	for _, phrase := range canonicalStaleMonitorPhrases {
+	for _, phrase := range append(canonicalStaleMonitorPhrases, canonicalRerunRecoveryPhrases...) {
 		if !strings.Contains(got, phrase) {
 			t.Errorf("checks-passed output missing stale-monitor guidance phrase %q in:\n%s", phrase, got)
 		}
@@ -184,7 +212,10 @@ func TestGateStepBoundaryGuidance_SyncedAcrossSurfaces(t *testing.T) {
 
 func TestNormalDriveOutputDoesNotFloodBranchSyncGuidance(t *testing.T) {
 	got := renderDriveResultForGuidanceTest(t, true, types.RunRunning)
-	if strings.Contains(got, branchSyncAgentGuidance) || strings.Contains(got, "branch_sync.next_action") {
+	// Stale-monitor recovery help may name custody actions for a future head
+	// mismatch; ordinary runs still must not emit unrelated sync guidance.
+	withoutMonitorHelp := strings.ReplaceAll(got, staleMonitorGuidance, "")
+	if strings.Contains(got, branchSyncAgentGuidance) || strings.Contains(withoutMonitorHelp, "branch_sync.next_action") {
 		t.Fatalf("ordinary drive output included irrelevant branch-sync guidance:\n%s", got)
 	}
 }

--- a/internal/cli/rerun.go
+++ b/internal/cli/rerun.go
@@ -42,18 +42,6 @@ func newRerunCmd() *cobra.Command {
 				if branch == "HEAD" {
 					return fmt.Errorf("not on a branch")
 				}
-				var callerHead string
-				dirty, err := git.HasUncommittedChanges(context.Background(), ".")
-				if err != nil {
-					return fmt.Errorf("check working tree: %w", err)
-				}
-				if !dirty {
-					callerHead, err = git.HeadSHA(context.Background(), ".")
-					if err != nil {
-						return fmt.Errorf("get caller head: %w", err)
-					}
-				}
-
 				if err := daemon.EnsureDaemon(p); err != nil {
 					return fmt.Errorf("start daemon: %w", err)
 				}
@@ -64,6 +52,10 @@ func newRerunCmd() *cobra.Command {
 				}
 				defer client.Close()
 
+				callerHead, err := rerunCallerHead(cmd.Context())
+				if err != nil {
+					return err
+				}
 				var result ipc.RerunResult
 				if err := client.Call(ipc.MethodRerun, &ipc.RerunParams{RepoID: repo.ID, Branch: branch, Intent: intent, PRBaseBranch: baseBranch, CallerHeadSHA: callerHead}, &result); err != nil {
 					return fmt.Errorf("rerun pipeline: %w", err)
@@ -77,4 +69,22 @@ func newRerunCmd() *cobra.Command {
 	cmd.Flags().StringVar(&intent, "intent", "", "explicit intent for this rerun (overrides inherited intent or fresh inference)")
 	cmd.Flags().StringVar(&baseBranch, "base-branch", "", "integration branch for the PR for this rerun only (overrides inherited per-run base branch)")
 	return cmd
+}
+
+// rerunCallerHead captures clean-head evidence at the request boundary, after
+// any daemon startup or post-push wait. Dirty callers retain the existing
+// behavior by omitting that evidence.
+func rerunCallerHead(ctx context.Context) (string, error) {
+	dirty, err := git.HasUncommittedChanges(ctx, ".")
+	if err != nil {
+		return "", fmt.Errorf("check working tree: %w", err)
+	}
+	if dirty {
+		return "", nil
+	}
+	head, err := git.HeadSHA(ctx, ".")
+	if err != nil {
+		return "", fmt.Errorf("get caller head: %w", err)
+	}
+	return head, nil
 }

--- a/internal/cli/rerun.go
+++ b/internal/cli/rerun.go
@@ -42,6 +42,17 @@ func newRerunCmd() *cobra.Command {
 				if branch == "HEAD" {
 					return fmt.Errorf("not on a branch")
 				}
+				var callerHead string
+				dirty, err := git.HasUncommittedChanges(context.Background(), ".")
+				if err != nil {
+					return fmt.Errorf("check working tree: %w", err)
+				}
+				if !dirty {
+					callerHead, err = git.HeadSHA(context.Background(), ".")
+					if err != nil {
+						return fmt.Errorf("get caller head: %w", err)
+					}
+				}
 
 				if err := daemon.EnsureDaemon(p); err != nil {
 					return fmt.Errorf("start daemon: %w", err)
@@ -54,7 +65,7 @@ func newRerunCmd() *cobra.Command {
 				defer client.Close()
 
 				var result ipc.RerunResult
-				if err := client.Call(ipc.MethodRerun, &ipc.RerunParams{RepoID: repo.ID, Branch: branch, Intent: intent, PRBaseBranch: baseBranch}, &result); err != nil {
+				if err := client.Call(ipc.MethodRerun, &ipc.RerunParams{RepoID: repo.ID, Branch: branch, Intent: intent, PRBaseBranch: baseBranch, CallerHeadSHA: callerHead}, &result); err != nil {
 					return fmt.Errorf("rerun pipeline: %w", err)
 				}
 

--- a/internal/cli/rerun.go
+++ b/internal/cli/rerun.go
@@ -75,16 +75,22 @@ func newRerunCmd() *cobra.Command {
 // any daemon startup or post-push wait. Dirty callers retain the existing
 // behavior by omitting that evidence.
 func rerunCallerHead(ctx context.Context) (string, error) {
-	dirty, err := git.HasUncommittedChanges(ctx, ".")
+	// Read both facts from one status observation: a subsequent HEAD lookup
+	// could name a different commit whose index or worktree was never clean.
+	out, err := git.Run(ctx, ".", "status", "--porcelain=v2", "--branch", "-z")
 	if err != nil {
 		return "", fmt.Errorf("check working tree: %w", err)
 	}
-	if dirty {
-		return "", nil
+	var head string
+	for _, entry := range strings.Split(out, "\x00") {
+		if oid, ok := strings.CutPrefix(entry, "# branch.oid "); ok {
+			head = oid
+		} else if entry != "" && !strings.HasPrefix(entry, "# ") {
+			return "", nil
+		}
 	}
-	head, err := git.HeadSHA(ctx, ".")
-	if err != nil {
-		return "", fmt.Errorf("get caller head: %w", err)
+	if head == "" || head == "(initial)" {
+		return "", fmt.Errorf("get caller head: no HEAD commit")
 	}
 	return head, nil
 }

--- a/internal/cli/rerun_test.go
+++ b/internal/cli/rerun_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kunchenguid/no-mistakes/internal/daemon"
 	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
 )
@@ -37,7 +38,7 @@ func TestRerunSendsOnlyCleanCallerHead(t *testing.T) {
 			cliGit(t, dir, "init", "-b", "main")
 			cliGit(t, dir, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "--allow-empty", "-m", "initial")
 			chdir(t, dir)
-			root, err := os.Getwd()
+			root, err := git.FindGitRoot(dir)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/cli/rerun_test.go
+++ b/internal/cli/rerun_test.go
@@ -10,11 +10,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kunchenguid/no-mistakes/internal/config"
+	"github.com/kunchenguid/no-mistakes/internal/custody"
 	"github.com/kunchenguid/no-mistakes/internal/daemon"
 	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/gate"
 	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/paths"
+	"github.com/kunchenguid/no-mistakes/internal/types"
 )
 
 func TestRerunSendsOnlyCleanCallerHead(t *testing.T) {
@@ -57,6 +61,12 @@ func TestRerunSendsOnlyCleanCallerHead(t *testing.T) {
 			srv.Handle(ipc.MethodHealth, func(context.Context, json.RawMessage) (interface{}, error) {
 				return &ipc.HealthResult{Status: "ok"}, nil
 			})
+			srv.Handle(ipc.MethodGetRunsForHead, func(context.Context, json.RawMessage) (interface{}, error) {
+				return &ipc.GetRunsResult{}, nil
+			})
+			srv.Handle(ipc.MethodGetActiveRun, func(context.Context, json.RawMessage) (interface{}, error) {
+				return &ipc.GetActiveRunResult{}, nil
+			})
 			requests := make(chan map[string]string, 1)
 			srv.Handle(ipc.MethodRerun, func(_ context.Context, raw json.RawMessage) (interface{}, error) {
 				var params map[string]string
@@ -93,6 +103,118 @@ func TestRerunSendsOnlyCleanCallerHead(t *testing.T) {
 			if !strings.Contains(out.String(), "Rerun started") {
 				t.Fatalf("missing rerun confirmation: %s", out.String())
 			}
+			if _, present := params["caller_head_sha"]; dirty && present {
+				t.Fatal("dirty caller must omit caller_head_sha from the wire request")
+			}
+			t.Logf("CLI output: %sIPC request: %v", out.String(), params)
+			if !dirty {
+				// Exercise AXI's real no-op Git push and rerun fallback too.
+				gateDir := p.RepoDir(repo.ID)
+				cliGit(t, dir, "clone", "--bare", dir, gateDir)
+				cliGit(t, gateDir, "config", "receive.advertisePushOptions", "true")
+				cliGit(t, dir, "remote", "add", gate.RemoteName, gateDir)
+				client, err := ipc.Dial(p.Socket())
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer client.Close()
+				env := &axiEnv{p: p, d: d, repo: repo, cfg: config.DefaultGlobalConfig(), client: client}
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
+				runID, err := triggerRun(ctx, env, "main", wantHead, nil, "keep the caller's changes", "")
+				if err != nil || runID != "rerun-1" {
+					t.Fatalf("no-op push fallback: run=%s err=%v", runID, err)
+				}
+				params = <-requests
+				if params["caller_head_sha"] != wantHead {
+					t.Fatalf("AXI omitted known head: %v", params)
+				}
+				t.Logf("AXI no-op push fallback IPC request: %v; run_id=%s", params, runID)
+			}
+		})
+	}
+}
+
+func TestRerunRefusesDifferentCleanHeadCLI(t *testing.T) {
+	for _, selection := range []string{"gate", "preserved"} {
+		t.Run(selection, func(t *testing.T) {
+			dir := t.TempDir()
+			p := paths.WithRoot(makeSocketSafeTempDir(t))
+			t.Setenv("NM_HOME", p.Root())
+			if err := p.EnsureDirs(); err != nil {
+				t.Fatal(err)
+			}
+			d, err := db.Open(p.DB())
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { d.Close() })
+			startTestDaemon(t, p, d)
+			cliGit(t, dir, "init", "-b", "main")
+			cliGit(t, dir, "config", "user.name", "Test")
+			cliGit(t, dir, "config", "user.email", "test@example.com")
+			cliGit(t, dir, "commit", "--allow-empty", "-m", "submitted")
+			chdir(t, dir)
+			root, err := git.FindGitRoot(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			repo, err := d.InsertRepo(root, "https://example.com/repo.git", "main")
+			if err != nil {
+				t.Fatal(err)
+			}
+			gateDir := p.RepoDir(repo.ID)
+			cliGit(t, dir, "clone", "--bare", dir, gateDir)
+			submitted := cliGit(t, dir, "rev-parse", "HEAD")
+			prior, err := d.InsertRun(repo.ID, "main", submitted, submitted)
+			if err != nil {
+				t.Fatal(err)
+			}
+			selected := submitted
+			if selection == "preserved" {
+				cliGit(t, dir, "commit", "--allow-empty", "-m", "pipeline rewrite")
+				selected = cliGit(t, dir, "rev-parse", "HEAD")
+				cliGit(t, dir, "push", gateDir, selected+":"+custody.RecoveryRef(prior.ID))
+			}
+			if err := d.UpdateRunStatusWithVerifiedHead(prior.ID, types.RunFailed, selected); err != nil {
+				t.Fatal(err)
+			}
+			cliGit(t, dir, "commit", "--allow-empty", "--amend", "-m", "corrected local head")
+			callerHead := cliGit(t, dir, "rev-parse", "HEAD")
+			callerRefs := cliGit(t, dir, "show-ref")
+			gateRefs := cliGit(t, gateDir, "show-ref")
+			if status := cliGit(t, dir, "status", "--porcelain"); status != "" {
+				t.Fatalf("caller is dirty: %s", status)
+			}
+			var output bytes.Buffer
+			cmd := newRerunCmd()
+			cmd.SetArgs([]string{})
+			cmd.SetOut(&output)
+			cmd.SetErr(&output)
+			err = cmd.Execute()
+			if err == nil {
+				t.Fatalf("CLI accepted differing clean head: %s", output.String())
+			}
+			for _, want := range []string{"refusing rerun", selected, callerHead, "no-mistakes axi status", "no-mistakes axi run"} {
+				if !strings.Contains(err.Error(), want) || !strings.Contains(output.String(), want) {
+					t.Fatalf("CLI refusal missing %q: err=%v output=%s", want, err, output.String())
+				}
+			}
+			if strings.Contains(output.String(), "Rerun started") {
+				t.Fatalf("CLI falsely confirmed a rerun: %s", output.String())
+			}
+			t.Logf("CLI output:\n%s", output.String())
+			runs, err := d.GetRunsByRepo(repo.ID)
+			if err != nil || len(runs) != 1 || runs[0].ID != prior.ID || runs[0].Status != types.RunFailed {
+				t.Fatalf("refusal changed run history: runs=%+v err=%v", runs, err)
+			}
+			if got := cliGit(t, dir, "show-ref"); got != callerRefs {
+				t.Fatalf("caller refs changed: before=%s after=%s", callerRefs, got)
+			}
+			if got := cliGit(t, gateDir, "show-ref"); got != gateRefs {
+				t.Fatalf("gate refs changed: before=%s after=%s", gateRefs, got)
+			}
+			t.Logf("persisted runs=%d; prior status=%s; caller and gate refs unchanged\ncaller refs:\n%s\ngate refs:\n%s", len(runs), runs[0].Status, callerRefs, gateRefs)
 		})
 	}
 }

--- a/internal/cli/rerun_test.go
+++ b/internal/cli/rerun_test.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kunchenguid/no-mistakes/internal/daemon"
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/ipc"
+	"github.com/kunchenguid/no-mistakes/internal/paths"
+)
+
+func TestRerunSendsOnlyCleanCallerHead(t *testing.T) {
+	for _, dirty := range []bool{false, true} {
+		name := "clean"
+		if dirty {
+			name = "dirty"
+		}
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			p := paths.WithRoot(makeSocketSafeTempDir(t))
+			t.Setenv("NM_HOME", p.Root())
+			if err := p.EnsureDirs(); err != nil {
+				t.Fatal(err)
+			}
+			d, err := db.Open(p.DB())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer d.Close()
+			cliGit(t, dir, "init", "-b", "main")
+			cliGit(t, dir, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "--allow-empty", "-m", "initial")
+			chdir(t, dir)
+			root, err := os.Getwd()
+			if err != nil {
+				t.Fatal(err)
+			}
+			repo, err := d.InsertRepo(root, "https://example.com/repo.git", "main")
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantHead := cliGit(t, dir, "rev-parse", "HEAD")
+			if dirty {
+				if err := os.WriteFile(filepath.Join(dir, "untracked.txt"), []byte("local edits"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				wantHead = ""
+			}
+			srv := ipc.NewServer()
+			srv.Handle(ipc.MethodHealth, func(context.Context, json.RawMessage) (interface{}, error) {
+				return &ipc.HealthResult{Status: "ok"}, nil
+			})
+			requests := make(chan map[string]string, 1)
+			srv.Handle(ipc.MethodRerun, func(_ context.Context, raw json.RawMessage) (interface{}, error) {
+				var params map[string]string
+				if err := json.Unmarshal(raw, &params); err != nil {
+					return nil, err
+				}
+				requests <- params
+				return &ipc.RerunResult{RunID: "rerun-1"}, nil
+			})
+			done := make(chan error, 1)
+			go func() { done <- srv.Serve(p.Socket()) }()
+			t.Cleanup(func() { srv.Close(); <-done })
+			deadline := time.Now().Add(3 * time.Second)
+			for {
+				if alive, _ := daemon.IsRunning(p); alive {
+					break
+				}
+				if time.Now().After(deadline) {
+					t.Fatal("test IPC server did not become ready")
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+			cmd := newRerunCmd()
+			cmd.SetArgs([]string{"--intent", "keep the caller's changes"})
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			if err := cmd.Execute(); err != nil {
+				t.Fatal(err)
+			}
+			params := <-requests
+			if params["caller_head_sha"] != wantHead || params["repo_id"] != repo.ID || params["intent"] != "keep the caller's changes" {
+				t.Fatalf("rerun request = %v, want caller head %q and original repo/intent", params, wantHead)
+			}
+			if !strings.Contains(out.String(), "Rerun started") {
+				t.Fatalf("missing rerun confirmation: %s", out.String())
+			}
+		})
+	}
+}

--- a/internal/cli/rerun_test.go
+++ b/internal/cli/rerun_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -20,6 +22,127 @@ import (
 	"github.com/kunchenguid/no-mistakes/internal/paths"
 	"github.com/kunchenguid/no-mistakes/internal/types"
 )
+
+func TestRerunCallerHeadDoesNotCombineDifferentGitStates(t *testing.T) {
+	dir := t.TempDir()
+	cliGit(t, dir, "init", "-b", "main")
+	cliGit(t, dir, "config", "user.name", "Test")
+	cliGit(t, dir, "config", "user.email", "test@example.com")
+	if err := os.WriteFile(filepath.Join(dir, "tracked.txt"), []byte("original\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cliGit(t, dir, "add", "tracked.txt")
+	cliGit(t, dir, "commit", "-m", "original")
+	original := cliGit(t, dir, "rev-parse", "HEAD")
+	cliGit(t, dir, "commit", "--allow-empty", "-m", "concurrent commit")
+	next := cliGit(t, dir, "rev-parse", "HEAD")
+	cliGit(t, dir, "reset", "--hard", original)
+	chdir(t, dir)
+
+	realGit, err := exec.LookPath("git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("NM_RERUN_REAL_GIT", realGit)
+	t.Setenv("NM_RERUN_NEXT_HEAD", next)
+	t.Setenv("NM_RERUN_ORIGINAL_HEAD", original)
+	// Let real Git collect status, then stage an edit and move HEAD before
+	// returning. The new HEAD is never clean during this capture.
+	binDir := t.TempDir()
+	name := "git"
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	const source = `package main
+import ("fmt"; "os"; "os/exec")
+func check(err error) {
+  if err != nil { fmt.Fprintln(os.Stderr, err); os.Exit(1) }
+}
+func run(args ...string) {
+  cmd := exec.Command(os.Getenv("NM_RERUN_REAL_GIT"), args...)
+  cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+  check(cmd.Run())
+}
+func main() {
+  run(os.Args[1:]...)
+  if os.Args[1] == "status" {
+    check(os.WriteFile("tracked.txt", []byte("edited\n"), 0644))
+    run("add", "tracked.txt")
+    run("update-ref", "HEAD", os.Getenv("NM_RERUN_NEXT_HEAD"), os.Getenv("NM_RERUN_ORIGINAL_HEAD"))
+  }
+}
+`
+	file := filepath.Join(binDir, "main.go")
+	if err := os.WriteFile(file, []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Build a native, non-race helper so the same test runs on Windows too.
+	build := exec.Command("go", "build", "-o", filepath.Join(binDir, name), file)
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build Git wrapper: %v\n%s", err, out)
+	}
+	path := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+path)
+	head, err := rerunCallerHead(context.Background())
+	t.Setenv("PATH", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if current := cliGit(t, dir, "rev-parse", "HEAD"); current != next {
+		t.Fatalf("fixture did not move HEAD: got %s, want %s", current, next)
+	}
+	if staged := cliGit(t, dir, "diff", "--cached", "--name-only"); staged != "tracked.txt" {
+		t.Fatalf("fixture did not dirty the index: %q", staged)
+	}
+	if head != original {
+		t.Fatalf("clean-head evidence = %s, want observed clean head %s; later dirty head = %s", head, original, next)
+	}
+}
+
+func TestRerunCallerHeadGitStates(t *testing.T) {
+	for _, state := range []string{"clean", "detached", "unstaged", "staged", "renamed", "untracked", "unborn", "dirty_unborn", "not_repo"} {
+		t.Run(state, func(t *testing.T) {
+			dir := t.TempDir()
+			chdir(t, dir)
+			if state != "not_repo" {
+				cliGit(t, dir, "init", "-b", "main")
+			}
+			want := ""
+			if state != "unborn" && state != "dirty_unborn" && state != "not_repo" {
+				if err := os.WriteFile("tracked.txt", []byte("original\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				cliGit(t, dir, "add", "tracked.txt")
+				cliGit(t, dir, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "initial")
+				if state == "clean" || state == "detached" {
+					want = cliGit(t, dir, "rev-parse", "HEAD")
+				}
+			}
+			switch state {
+			case "detached":
+				cliGit(t, dir, "checkout", "--detach")
+			case "unstaged", "staged":
+				if err := os.WriteFile("tracked.txt", []byte("edited\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				if state == "staged" {
+					cliGit(t, dir, "add", "tracked.txt")
+				}
+			case "renamed":
+				cliGit(t, dir, "mv", "tracked.txt", "# branch.oid misleading.txt")
+			case "untracked", "dirty_unborn":
+				if err := os.WriteFile("# branch.oid misleading.txt", []byte("untracked\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			head, err := rerunCallerHead(context.Background())
+			wantError := state == "unborn" || state == "not_repo"
+			if (err != nil) != wantError || head != want {
+				t.Fatalf("caller head = %q, err = %v; want %q, error = %v", head, err, want, wantError)
+			}
+		})
+	}
+}
 
 func TestRerunSendsOnlyCleanCallerHead(t *testing.T) {
 	for _, dirty := range []bool{false, true} {

--- a/internal/cli/rerun_test.go
+++ b/internal/cli/rerun_test.go
@@ -58,13 +58,21 @@ func TestRerunSendsOnlyCleanCallerHead(t *testing.T) {
 				wantHead = ""
 			}
 			srv := ipc.NewServer()
+			commitDuringWait := make(chan struct{}, 1)
 			srv.Handle(ipc.MethodHealth, func(context.Context, json.RawMessage) (interface{}, error) {
 				return &ipc.HealthResult{Status: "ok"}, nil
 			})
 			srv.Handle(ipc.MethodGetRunsForHead, func(context.Context, json.RawMessage) (interface{}, error) {
 				return &ipc.GetRunsResult{}, nil
 			})
-			srv.Handle(ipc.MethodGetActiveRun, func(context.Context, json.RawMessage) (interface{}, error) {
+			srv.Handle(ipc.MethodGetActiveRun, func(ctx context.Context, _ json.RawMessage) (interface{}, error) {
+				select {
+				case <-commitDuringWait:
+					if _, err := git.Run(ctx, dir, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "--allow-empty", "-m", "concurrent local commit"); err != nil {
+						return nil, err
+					}
+				default:
+				}
 				return &ipc.GetActiveRunResult{}, nil
 			})
 			requests := make(chan map[string]string, 1)
@@ -130,6 +138,39 @@ func TestRerunSendsOnlyCleanCallerHead(t *testing.T) {
 					t.Fatalf("AXI omitted known head: %v", params)
 				}
 				t.Logf("AXI no-op push fallback IPC request: %v; run_id=%s", params, runID)
+
+				for _, phase := range []string{"during_wait", "before_push"} {
+					t.Run("commit_"+phase, func(t *testing.T) {
+						// Advance HEAD during the first trigger's post-push wait.
+						// The next trigger starts with the same stale snapshot but
+						// pushes the already-advanced branch.
+						if phase == "during_wait" {
+							commitDuringWait <- struct{}{}
+						}
+						ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+						defer cancel()
+						if _, err := triggerRun(ctx, env, "main", wantHead, nil, "keep the caller's changes", ""); err != nil {
+							t.Fatal(err)
+						}
+						params := <-requests
+						currentHead := cliGit(t, dir, "rev-parse", "HEAD")
+						if currentHead == wantHead {
+							t.Fatal("fixture did not advance the caller HEAD")
+						}
+						if params["caller_head_sha"] != currentHead {
+							t.Errorf("fallback sent stale caller head %s, want current clean head %s", params["caller_head_sha"], currentHead)
+						}
+						gateHead := cliGit(t, gateDir, "rev-parse", "refs/heads/main")
+						wantGate := wantHead
+						if phase == "before_push" {
+							wantGate = currentHead
+						}
+						if gateHead != wantGate {
+							t.Fatalf("gate head = %s, want %s", gateHead, wantGate)
+						}
+						t.Logf("startup=%s current=%s gate=%s request=%s", wantHead, currentHead, gateHead, params["caller_head_sha"])
+					})
+				}
 			}
 		})
 	}

--- a/internal/cli/rerun_test.go
+++ b/internal/cli/rerun_test.go
@@ -141,11 +141,12 @@ func TestRerunSendsOnlyCleanCallerHead(t *testing.T) {
 
 				for _, phase := range []string{"during_wait", "before_push"} {
 					t.Run("commit_"+phase, func(t *testing.T) {
-						// Advance HEAD during the first trigger's post-push wait.
-						// The next trigger starts with the same stale snapshot but
-						// pushes the already-advanced branch.
+						// Change HEAD on either side of the push without changing
+						// the startup snapshot passed to triggerRun.
 						if phase == "during_wait" {
 							commitDuringWait <- struct{}{}
+						} else {
+							cliGit(t, dir, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "--allow-empty", "-m", "commit before push")
 						}
 						ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 						defer cancel()

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -335,7 +335,7 @@ func humanSyncSummary(state branchsync.State) string {
 			if state.Recovery != nil && state.Recovery.KeepLocal {
 				return "later pipeline work is preserved by a verified archive; recover custody at the exact required head with `no-mistakes sync --recover --keep-local`"
 			}
-			return "run ended without publishing its pipeline commits; recover custody with `no-mistakes sync --recover` (or `no-mistakes rerun` to resume validation)"
+			return "run ended without publishing its pipeline commits; recover custody with `no-mistakes sync --recover`. `no-mistakes rerun` resumes validating the selected preserved head, but refuses a known clean caller HEAD mismatch. If heads differ, inspect `no-mistakes axi status` and follow its exact `branch_sync.next_action.command` for custody or synchronization, then submit intended local commits with a fresh `no-mistakes axi run` once custody permits"
 		}
 		if state.Safety == "blocked_recover_preserved_head_missing" {
 			return "run ended without a recoverable preserved head; recover custody with `no-mistakes sync --recover --keep-local` to keep the current local head"
@@ -415,7 +415,7 @@ func runAxiSync(cmd *cobra.Command, check, recover, keepLocal bool, bindArchiveR
 		help = append(help, "Run `"+state.NextAction.Command+"`")
 	}
 	if state.Safety == "blocked_pipeline_owned_recoverable" && (state.Recovery == nil || !state.Recovery.KeepLocal) {
-		help = append(help, "Run `no-mistakes rerun` instead to resume validating the preserved pipeline head")
+		help = append(help, "Run `no-mistakes rerun` instead to resume validating the selected preserved pipeline head; it refuses a known clean caller HEAD mismatch. If heads differ, inspect `no-mistakes axi status` and follow its exact `branch_sync.next_action.command` for custody or synchronization, then submit intended local commits with a fresh `no-mistakes axi run` once custody permits")
 	}
 	if len(help) > 0 {
 		fields = append(fields, toON.Field{Key: "help", Value: help})

--- a/internal/cli/sync_test.go
+++ b/internal/cli/sync_test.go
@@ -1055,14 +1055,14 @@ func TestAxiSyncCheckSurfacesRecoveryForTerminalPrePushRun(t *testing.T) {
 	if err == nil || !asExitError(err, &ee) || ee.code != 1 {
 		t.Fatalf("stranded check should exit 1, got %#v\n%s", err, out)
 	}
-	for _, want := range []string{
+	for _, want := range append([]string{
 		"state: pipeline_owned",
 		"status: cancelled",
 		"safety: blocked_pipeline_owned_recoverable",
 		"code: recover_custody",
 		"command: no-mistakes axi sync --recover",
 		"no-mistakes rerun",
-	} {
+	}, canonicalRerunRecoveryPhrases...) {
 		if !strings.Contains(out, want) {
 			t.Errorf("stranded check missing %q:\n%s", want, out)
 		}
@@ -1115,7 +1115,7 @@ func TestAxiSyncRecoverDivergedRefusesThenKeepLocalSucceeds(t *testing.T) {
 	if err == nil || !asExitError(err, &ee) || ee.code != 1 {
 		t.Fatalf("diverged recover should exit 1, got %#v\n%s", err, out)
 	}
-	for _, want := range []string{"safety: blocked_recover_diverged", "refs/no-mistakes/recover/", "--keep-local"} {
+	for _, want := range append([]string{"safety: blocked_recover_diverged", "refs/no-mistakes/recover/", "--keep-local"}, canonicalRerunRecoveryPhrases...) {
 		if !strings.Contains(out, want) {
 			t.Errorf("diverged refusal missing %q:\n%s", want, out)
 		}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1194,7 +1194,7 @@ func registerHandlers(srv *ipc.Server, mgr *RunManager, d *db.DB, shutdown func(
 		if err := json.Unmarshal(params, &p); err != nil {
 			return nil, fmt.Errorf("invalid params: %w", err)
 		}
-		runID, err := mgr.HandleRerun(ctx, p.RepoID, p.Branch, p.PreviousRunID, p.SkipSteps, p.Intent, p.PRBaseBranch)
+		runID, err := mgr.HandleRerun(ctx, p.RepoID, p.Branch, p.PreviousRunID, p.SkipSteps, p.Intent, p.PRBaseBranch, p.CallerHeadSHA)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/daemon/manager.go
+++ b/internal/daemon/manager.go
@@ -720,7 +720,9 @@ func (m *RunManager) HandlePushReceived(ctx context.Context, params *ipc.PushRec
 // runs without one infer intent afresh. The selected run's PR URL is inherited
 // when that PR is not already merged or closed, so a later --base-branch
 // retarget can prove it is moving the same still-open review object.
-func (m *RunManager) HandleRerun(ctx context.Context, repoID, branch, previousRunID string, skipSteps []types.StepName, intent, prBaseBranch string) (string, error) {
+// A supplied clean caller head must match the selected head before any run
+// starts or is superseded. It never changes head selection.
+func (m *RunManager) HandleRerun(ctx context.Context, repoID, branch, previousRunID string, skipSteps []types.StepName, intent, prBaseBranch, callerHeadSHA string) (string, error) {
 	repo, err := m.db.GetRepo(repoID)
 	if err != nil {
 		return "", fmt.Errorf("get repo: %w", err)
@@ -760,6 +762,9 @@ func (m *RunManager) HandleRerun(ctx context.Context, repoID, branch, previousRu
 	headSHA, err := resolveRerunHead(ctx, gateDir, branch, latestForBranch)
 	if err != nil {
 		return "", err
+	}
+	if callerHeadSHA != "" && callerHeadSHA != headSHA {
+		return "", fmt.Errorf("refusing rerun: selected head %s differs from clean local head %s; inspect `no-mistakes axi status` and reconcile custody before using `no-mistakes axi run` to submit the local head", headSHA, callerHeadSHA)
 	}
 	selectedRun := latestForBranch
 	if previousRunID != "" {

--- a/internal/daemon/rerun_head_test.go
+++ b/internal/daemon/rerun_head_test.go
@@ -2,11 +2,13 @@ package daemon
 
 import (
 	"context"
-	"github.com/kunchenguid/no-mistakes/internal/git"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/custody"
+	"github.com/kunchenguid/no-mistakes/internal/db"
+	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/kunchenguid/no-mistakes/internal/ipc"
 	"github.com/kunchenguid/no-mistakes/internal/pipeline"
 	"github.com/kunchenguid/no-mistakes/internal/types"
@@ -18,17 +20,17 @@ func TestRerunChecksCallerHeadAgainstSelectedHead(t *testing.T) {
 		if preserved {
 			name = "preserved"
 		}
-		for _, matches := range []bool{false, true} {
-			relation := "differs"
-			if matches {
-				relation = "matches"
-			}
+		for _, relation := range []string{"differs", "matches", "omitted"} {
 			t.Run(name+"/"+relation, func(t *testing.T) {
 				step := &mockPassStep{name: types.StepReview}
 				p, d := startTestDaemonWithSteps(t, func() []pipeline.Step { return []pipeline.Step{step} })
 				repo, submitted := setupTestGitRepo(t, p, d, "rerun-head-repo")
 				prior, err := d.InsertRun(repo.ID, "main", submitted, submitted)
 				if err != nil {
+					t.Fatal(err)
+				}
+				intent := "  preserve these exact requirements\n"
+				if err := d.UpdateRunIntent(prior.ID, db.RunIntent{Summary: intent, Source: db.RunIntentSourceAgent, Score: 1}); err != nil {
 					t.Fatal(err)
 				}
 				selected := submitted
@@ -40,7 +42,7 @@ func TestRerunChecksCallerHeadAgainstSelectedHead(t *testing.T) {
 				if err := d.UpdateRunStatusWithVerifiedHead(prior.ID, types.RunFailed, selected); err != nil {
 					t.Fatal(err)
 				}
-				if !matches {
+				if relation != "matches" {
 					gitCmd(t, repo.WorkingPath, "commit", "--allow-empty", "--amend", "-m", "corrected local head")
 				}
 				callerHead := gitOutput(t, repo.WorkingPath, "rev-parse", "HEAD")
@@ -54,10 +56,14 @@ func TestRerunChecksCallerHeadAgainstSelectedHead(t *testing.T) {
 				defer client.Close()
 				var result ipc.RerunResult
 				// Use the wire shape so the regression runs on the pre-fix protocol.
-				err = client.Call(ipc.MethodRerun, map[string]string{
+				params := map[string]string{
 					"repo_id": repo.ID, "branch": "main", "caller_head_sha": callerHead,
-				}, &result)
-				if matches {
+				}
+				if relation == "omitted" {
+					delete(params, "caller_head_sha")
+				}
+				err = client.Call(ipc.MethodRerun, params, &result)
+				if relation != "differs" {
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -65,6 +71,10 @@ func TestRerunChecksCallerHeadAgainstSelectedHead(t *testing.T) {
 					if run.SubmittedHeadSHA == nil || *run.SubmittedHeadSHA != selected || run.Status != types.RunCompleted {
 						t.Fatalf("matching rerun did not complete at selected head %s: %+v", selected, run)
 					}
+					if run.Intent == nil || *run.Intent != intent || run.IntentSource == nil || *run.IntentSource != db.RunIntentSourceRerun {
+						t.Fatalf("rerun lost exact intent or provenance: %+v", run)
+					}
+					t.Logf("rerun response: run_id=%s; persisted status=%s submitted_head_sha=%s intent=%q intent_source=%s", result.RunID, run.Status, *run.SubmittedHeadSHA, *run.Intent, *run.IntentSource)
 				} else {
 					if err == nil {
 						t.Fatalf("rerun started %s at selected head %s despite clean caller head %s", result.RunID, selected, callerHead)
@@ -74,10 +84,12 @@ func TestRerunChecksCallerHeadAgainstSelectedHead(t *testing.T) {
 							t.Errorf("refusal %q missing %q", err, want)
 						}
 					}
+					t.Logf("rerun response: %v", err)
 					runs, err := d.GetRunsByRepo(repo.ID)
 					if err != nil || len(runs) != 1 || step.execCnt.Load() != 0 {
 						t.Fatalf("refused rerun performed work: runs=%d executions=%d err=%v", len(runs), step.execCnt.Load(), err)
 					}
+					t.Logf("persisted runs=%d; step executions=%d", len(runs), step.execCnt.Load())
 				}
 				if got := gitOutput(t, p.RepoDir(repo.ID), "rev-parse", "refs/heads/main"); got != submitted {
 					t.Fatalf("gate branch moved to %s, want %s", got, submitted)
@@ -85,7 +97,59 @@ func TestRerunChecksCallerHeadAgainstSelectedHead(t *testing.T) {
 				if got := gitOutput(t, repo.WorkingPath, "rev-parse", "HEAD"); got != callerHead {
 					t.Fatalf("caller head moved to %s, want %s", got, callerHead)
 				}
+				t.Logf("unchanged gate branch=%s; unchanged caller HEAD=%s", submitted, callerHead)
 			})
 		}
 	}
+}
+
+func TestRerunRefusalDoesNotSupersedeActiveRun(t *testing.T) {
+	started := make(chan struct{})
+	step := &mockSlowStep{name: types.StepReview, started: started}
+	p, d := startTestDaemonWithSteps(t, func() []pipeline.Step { return []pipeline.Step{step} })
+	repo, selected := setupTestGitRepo(t, p, d, "active-rerun-head-repo")
+	client, err := ipc.Dial(p.Socket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	var first ipc.PushReceivedResult
+	if err := client.Call(ipc.MethodPushReceived, &ipc.PushReceivedParams{
+		Gate: p.RepoDir(repo.ID), Ref: "refs/heads/main", New: selected, Old: selected,
+		Intent: "keep the active run alive",
+	}, &first); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("original run did not start")
+	}
+	gitCmd(t, repo.WorkingPath, "commit", "--allow-empty", "--amend", "-m", "corrected local head")
+	callerHead := gitOutput(t, repo.WorkingPath, "rev-parse", "HEAD")
+	gateRefs := gitOutput(t, p.RepoDir(repo.ID), "show-ref")
+	callerRefs := gitOutput(t, repo.WorkingPath, "show-ref")
+	var result ipc.RerunResult
+	err = client.Call(ipc.MethodRerun, map[string]string{
+		"repo_id": repo.ID, "branch": "main", "caller_head_sha": callerHead,
+	}, &result)
+	if err == nil || !strings.Contains(err.Error(), "refusing rerun") || !strings.Contains(err.Error(), selected) || !strings.Contains(err.Error(), callerHead) {
+		t.Fatalf("expected head mismatch refusal, got result=%+v err=%v", result, err)
+	}
+	t.Logf("rerun response: %v", err)
+	active, err := d.GetActiveRun(repo.ID, "main")
+	if err != nil || active == nil || active.ID != first.RunID || active.Status != types.RunRunning {
+		t.Fatalf("original run was superseded: active=%+v err=%v", active, err)
+	}
+	runs, err := d.GetRunsByRepo(repo.ID)
+	if err != nil || len(runs) != 1 {
+		t.Fatalf("refusal created a run: runs=%d err=%v", len(runs), err)
+	}
+	if got := gitOutput(t, p.RepoDir(repo.ID), "show-ref"); got != gateRefs {
+		t.Fatalf("gate refs changed: before=%s after=%s", gateRefs, got)
+	}
+	if got := gitOutput(t, repo.WorkingPath, "show-ref"); got != callerRefs {
+		t.Fatalf("caller refs changed: before=%s after=%s", callerRefs, got)
+	}
+	t.Logf("original run_id=%s remains %s; persisted runs=%d; caller and gate refs unchanged", active.ID, active.Status, len(runs))
 }

--- a/internal/daemon/rerun_head_test.go
+++ b/internal/daemon/rerun_head_test.go
@@ -1,0 +1,91 @@
+package daemon
+
+import (
+	"context"
+	"github.com/kunchenguid/no-mistakes/internal/git"
+	"strings"
+	"testing"
+
+	"github.com/kunchenguid/no-mistakes/internal/custody"
+	"github.com/kunchenguid/no-mistakes/internal/ipc"
+	"github.com/kunchenguid/no-mistakes/internal/pipeline"
+	"github.com/kunchenguid/no-mistakes/internal/types"
+)
+
+func TestRerunChecksCallerHeadAgainstSelectedHead(t *testing.T) {
+	for _, preserved := range []bool{false, true} {
+		name := "gate"
+		if preserved {
+			name = "preserved"
+		}
+		for _, matches := range []bool{false, true} {
+			relation := "differs"
+			if matches {
+				relation = "matches"
+			}
+			t.Run(name+"/"+relation, func(t *testing.T) {
+				step := &mockPassStep{name: types.StepReview}
+				p, d := startTestDaemonWithSteps(t, func() []pipeline.Step { return []pipeline.Step{step} })
+				repo, submitted := setupTestGitRepo(t, p, d, "rerun-head-repo")
+				prior, err := d.InsertRun(repo.ID, "main", submitted, submitted)
+				if err != nil {
+					t.Fatal(err)
+				}
+				selected := submitted
+				if preserved {
+					gitCmd(t, repo.WorkingPath, "commit", "--allow-empty", "-m", "pipeline rewrite")
+					selected = gitOutput(t, repo.WorkingPath, "rev-parse", "HEAD")
+					gitCmd(t, repo.WorkingPath, "push", "gate", selected+":"+custody.RecoveryRef(prior.ID))
+				}
+				if err := d.UpdateRunStatusWithVerifiedHead(prior.ID, types.RunFailed, selected); err != nil {
+					t.Fatal(err)
+				}
+				if !matches {
+					gitCmd(t, repo.WorkingPath, "commit", "--allow-empty", "--amend", "-m", "corrected local head")
+				}
+				callerHead := gitOutput(t, repo.WorkingPath, "rev-parse", "HEAD")
+				if dirty, err := git.HasUncommittedChanges(context.Background(), repo.WorkingPath); err != nil || dirty {
+					t.Fatalf("caller worktree is dirty: %v, err=%v", dirty, err)
+				}
+				client, err := ipc.Dial(p.Socket())
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer client.Close()
+				var result ipc.RerunResult
+				// Use the wire shape so the regression runs on the pre-fix protocol.
+				err = client.Call(ipc.MethodRerun, map[string]string{
+					"repo_id": repo.ID, "branch": "main", "caller_head_sha": callerHead,
+				}, &result)
+				if matches {
+					if err != nil {
+						t.Fatal(err)
+					}
+					run := waitForRunTerminalState(t, d, result.RunID)
+					if run.SubmittedHeadSHA == nil || *run.SubmittedHeadSHA != selected || run.Status != types.RunCompleted {
+						t.Fatalf("matching rerun did not complete at selected head %s: %+v", selected, run)
+					}
+				} else {
+					if err == nil {
+						t.Fatalf("rerun started %s at selected head %s despite clean caller head %s", result.RunID, selected, callerHead)
+					}
+					for _, want := range []string{selected, callerHead, "no-mistakes axi status", "no-mistakes axi run"} {
+						if !strings.Contains(err.Error(), want) {
+							t.Errorf("refusal %q missing %q", err, want)
+						}
+					}
+					runs, err := d.GetRunsByRepo(repo.ID)
+					if err != nil || len(runs) != 1 || step.execCnt.Load() != 0 {
+						t.Fatalf("refused rerun performed work: runs=%d executions=%d err=%v", len(runs), step.execCnt.Load(), err)
+					}
+				}
+				if got := gitOutput(t, p.RepoDir(repo.ID), "rev-parse", "refs/heads/main"); got != submitted {
+					t.Fatalf("gate branch moved to %s, want %s", got, submitted)
+				}
+				if got := gitOutput(t, repo.WorkingPath, "rev-parse", "HEAD"); got != callerHead {
+					t.Fatalf("caller head moved to %s, want %s", got, callerHead)
+				}
+			})
+		}
+	}
+}

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -132,6 +132,9 @@ type RerunParams struct {
 	SkipSteps     []types.StepName `json:"skip_steps,omitempty"`
 	Intent        string           `json:"intent,omitempty"`
 	PRBaseBranch  string           `json:"pr_base_branch,omitempty"`
+	// CallerHeadSHA is a clean caller worktree's HEAD, when known. It guards
+	// the daemon's selected head; it never supplies a replacement run head.
+	CallerHeadSHA string `json:"caller_head_sha,omitempty"`
 }
 
 // SubscribeParams starts an event stream for a run.

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -224,20 +224,28 @@ Run the pipeline and decide on its findings as they come up:
      configured idle timeout elapses, so a human can watch it in the TUI.
    - ` + "`passed`" + ` - the changes cleared the gate and the PR was merged or closed.
    - ` + "`failed`" + ` or ` + "`cancelled`" + ` - they did not; read the output and address it.
-     Fix whatever the output points at (a failing test, a lint error, a finding
-     you skipped), commit the fix on the same feature branch, then drive the
-     pipeline again - ` + "`no-mistakes axi run --intent \"...\"`" + ` starts a fresh run,
-     or ` + "`no-mistakes rerun`" + ` re-runs the pipeline for the current branch. This
-     is the right place to start over: a fresh run or ` + "`rerun`" + ` is a
+     Follow the custody guidance below before fixing whatever the output
+     points at (a failing test, a lint error, a finding you skipped). Commit the
+     fix on the same feature branch, then submit it with
+     ` + "`no-mistakes axi run --intent \"...\"`" + `. A fresh run or ` + "`rerun`" + ` is a
      *between-runs* action, correct only after a terminal outcome like this -
      never mid-run to circumvent a gate. Do not leave the user at a ` + "`failed`" + `
      outcome without either retrying or explaining what blocks it.
+
+` + "`no-mistakes rerun`" + ` keeps its existing head selection: the gate head, or the
+latest terminal run's verified unpublished preserved head while custody remains
+outstanding. If a known clean caller ` + "`HEAD`" + ` differs from that selected head,
+it refuses before starting or superseding any run and reports both full SHAs.
+It never substitutes the caller head or moves either branch to make them match.
+On refusal, inspect ` + "`no-mistakes axi status`" + ` and follow the custody guidance
+below. Dirty callers and callers without clean-head evidence retain existing
+selection behavior.
 
 Before any post-pipeline local commit or fresh run, read the structured ` + "`branch_sync`" + ` object returned by AXI home, status, or a drive result.
 Only when its ` + "`next_action.code`" + ` is ` + "`sync`" + `, run ` + "`no-mistakes axi sync`" + ` first.
 That guarded sync may be a strict fast-forward or a content-equivalent diverged advance that anchors the pre-sync head before moving the branch with reset semantics; genuine divergence stays blocked.
 If it reports ` + "`next_action.code`" + ` is ` + "`continue_active_run`" + `, the pipeline still owns the branch: run the reported command, keep driving the active run, and do not make local follow-up commits.
-When ` + "`next_action.code`" + ` is ` + "`recover_custody`" + `, run its exact ` + "`next_action.command`" + ` rather than reconstructing one. That is ` + "`no-mistakes axi sync --recover`" + ` to take a still-available preserved pipeline head, or ` + "`no-mistakes axi sync --recover --keep-local`" + ` in two keep-local cases: when an accessible gate confirms the verified preserved head is missing and you are explicitly discarding those unpublished commits, or when a bound archive proves divergent later work remains preserved while recovery keeps the branch at the exact reported required head and never selects, merges, or replays the archive. Do not substitute plain ` + "`--recover`" + ` or ` + "`rerun`" + ` for a reported keep-local action. ` + "`no-mistakes rerun`" + ` resumes validating a still-available ordinary preserved head instead.
+When ` + "`next_action.code`" + ` is ` + "`recover_custody`" + `, run its exact ` + "`next_action.command`" + ` rather than reconstructing one. That is ` + "`no-mistakes axi sync --recover`" + ` to take a still-available preserved pipeline head, or ` + "`no-mistakes axi sync --recover --keep-local`" + ` in two keep-local cases: when an accessible gate confirms the verified preserved head is missing and you are explicitly discarding those unpublished commits, or when a bound archive proves divergent later work remains preserved while recovery keeps the branch at the exact reported required head and never selects, merges, or replays the archive. Do not substitute plain ` + "`--recover`" + ` or ` + "`rerun`" + ` for a reported keep-local action. ` + "`no-mistakes rerun`" + ` can resume validating a still-available ordinary preserved head instead, subject to the clean-head check above.
 Ordinary recovery takes that head by fast-forward, or by adopting a diverged preserved head proven to carry every local change - the ordinary result of the pipeline rebasing your commits onto a newer base - after anchoring your pre-recovery head under ` + "`refs/no-mistakes/recover-local/<run>`" + `.
 The ordinary containment proof is deliberately narrow, so a rebase whose fix rounds also rewrote your own lines refuses instead of being adopted: when nothing can tell a deliberate pipeline fix from a dropped change, the decision is yours.
 A ` + "`branch_sync.state`" + ` of ` + "`user_owned`" + ` means the run went terminal before changing the submitted head and cancellation released the branch: the exact branch and head are yours and immediately usable for whichever delivery path is authorized - no sync action is needed, and a repeated ` + "`--recover`" + ` there is a harmless no-op.
@@ -261,8 +269,9 @@ the branch through Push**; a PR that is merely behind but still clean needs noth
 either, since the platform merges it. The one exception is when that monitor is
 no longer running - the PR was closed, the run was aborted or superseded, it
 idle-timed-out, or its auto-fix attempts were exhausted - in which case recover
-with ` + "`no-mistakes rerun`" + `, which cancels the stale monitor and re-runs the full
-pipeline including a deterministic rebase step. Do **not** reach for
+with ` + "`no-mistakes rerun`" + `, subject to the clean-head check above. An accepted
+rerun cancels the stale monitor and re-runs the full pipeline including a
+deterministic rebase step. Do **not** reach for
 ` + "`no-mistakes axi run`" + ` to refresh a still-active PR: after ` + "`checks-passed`" + ` it
 reattaches to the running monitor (HEAD unchanged) and returns its output
 without rebasing.

--- a/internal/tui/branch_sync.go
+++ b/internal/tui/branch_sync.go
@@ -139,7 +139,7 @@ func renderRecoverConfirmation(state branchsync.State, width int) string {
 		fmt.Fprintf(&b, "Required HEAD:  %s\n\n", state.Recovery.RequiredHead)
 		b.WriteString("Any changed archive, head, branch, run, repository, or gate evidence makes recovery refuse without selecting the divergent head.")
 	} else {
-		b.WriteString("\nDirty worktrees and divergence that cannot be proven contained refuse without changes; `no-mistakes sync --recover --keep-local` keeps the current head instead. `no-mistakes rerun` resumes validation.")
+		b.WriteString("\nDirty worktrees and divergence that cannot be proven contained refuse without changes; `no-mistakes sync --recover --keep-local` keeps the current head instead.")
 	}
 	return renderBoxWithFooter("Confirm custody recovery", b.String(), width, "u/enter recover  ·  esc cancel")
 }

--- a/internal/tui/branch_sync_test.go
+++ b/internal/tui/branch_sync_test.go
@@ -221,7 +221,7 @@ func TestRecoverableCustodyActionFlowsThroughConfirmationAndRecoverService(t *te
 		t.Fatalf("u must open confirmation without acting: confirm=%v calls=%d", m.recoverConfirm, recoverCalls)
 	}
 	plain := stripANSI(m.View())
-	for _, want := range []string{"custody", strings.Repeat("a", 40), strings.Repeat("c", 40), "u/enter recover", "--keep-local", "rerun"} {
+	for _, want := range []string{"custody", strings.Repeat("a", 40), strings.Repeat("c", 40), "u/enter recover", "--keep-local"} {
 		if !strings.Contains(plain, want) {
 			t.Errorf("recover confirmation missing %q:\n%s", want, plain)
 		}

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -224,20 +224,28 @@ Run the pipeline and decide on its findings as they come up:
      configured idle timeout elapses, so a human can watch it in the TUI.
    - `passed` - the changes cleared the gate and the PR was merged or closed.
    - `failed` or `cancelled` - they did not; read the output and address it.
-     Fix whatever the output points at (a failing test, a lint error, a finding
-     you skipped), commit the fix on the same feature branch, then drive the
-     pipeline again - `no-mistakes axi run --intent "..."` starts a fresh run,
-     or `no-mistakes rerun` re-runs the pipeline for the current branch. This
-     is the right place to start over: a fresh run or `rerun` is a
+     Follow the custody guidance below before fixing whatever the output
+     points at (a failing test, a lint error, a finding you skipped). Commit the
+     fix on the same feature branch, then submit it with
+     `no-mistakes axi run --intent "..."`. A fresh run or `rerun` is a
      *between-runs* action, correct only after a terminal outcome like this -
      never mid-run to circumvent a gate. Do not leave the user at a `failed`
      outcome without either retrying or explaining what blocks it.
+
+`no-mistakes rerun` keeps its existing head selection: the gate head, or the
+latest terminal run's verified unpublished preserved head while custody remains
+outstanding. If a known clean caller `HEAD` differs from that selected head,
+it refuses before starting or superseding any run and reports both full SHAs.
+It never substitutes the caller head or moves either branch to make them match.
+On refusal, inspect `no-mistakes axi status` and follow the custody guidance
+below. Dirty callers and callers without clean-head evidence retain existing
+selection behavior.
 
 Before any post-pipeline local commit or fresh run, read the structured `branch_sync` object returned by AXI home, status, or a drive result.
 Only when its `next_action.code` is `sync`, run `no-mistakes axi sync` first.
 That guarded sync may be a strict fast-forward or a content-equivalent diverged advance that anchors the pre-sync head before moving the branch with reset semantics; genuine divergence stays blocked.
 If it reports `next_action.code` is `continue_active_run`, the pipeline still owns the branch: run the reported command, keep driving the active run, and do not make local follow-up commits.
-When `next_action.code` is `recover_custody`, run its exact `next_action.command` rather than reconstructing one. That is `no-mistakes axi sync --recover` to take a still-available preserved pipeline head, or `no-mistakes axi sync --recover --keep-local` in two keep-local cases: when an accessible gate confirms the verified preserved head is missing and you are explicitly discarding those unpublished commits, or when a bound archive proves divergent later work remains preserved while recovery keeps the branch at the exact reported required head and never selects, merges, or replays the archive. Do not substitute plain `--recover` or `rerun` for a reported keep-local action. `no-mistakes rerun` resumes validating a still-available ordinary preserved head instead.
+When `next_action.code` is `recover_custody`, run its exact `next_action.command` rather than reconstructing one. That is `no-mistakes axi sync --recover` to take a still-available preserved pipeline head, or `no-mistakes axi sync --recover --keep-local` in two keep-local cases: when an accessible gate confirms the verified preserved head is missing and you are explicitly discarding those unpublished commits, or when a bound archive proves divergent later work remains preserved while recovery keeps the branch at the exact reported required head and never selects, merges, or replays the archive. Do not substitute plain `--recover` or `rerun` for a reported keep-local action. `no-mistakes rerun` can resume validating a still-available ordinary preserved head instead, subject to the clean-head check above.
 Ordinary recovery takes that head by fast-forward, or by adopting a diverged preserved head proven to carry every local change - the ordinary result of the pipeline rebasing your commits onto a newer base - after anchoring your pre-recovery head under `refs/no-mistakes/recover-local/<run>`.
 The ordinary containment proof is deliberately narrow, so a rebase whose fix rounds also rewrote your own lines refuses instead of being adopted: when nothing can tell a deliberate pipeline fix from a dropped change, the decision is yours.
 A `branch_sync.state` of `user_owned` means the run went terminal before changing the submitted head and cancellation released the branch: the exact branch and head are yours and immediately usable for whichever delivery path is authorized - no sync action is needed, and a repeated `--recover` there is a harmless no-op.
@@ -261,8 +269,9 @@ the branch through Push**; a PR that is merely behind but still clean needs noth
 either, since the platform merges it. The one exception is when that monitor is
 no longer running - the PR was closed, the run was aborted or superseded, it
 idle-timed-out, or its auto-fix attempts were exhausted - in which case recover
-with `no-mistakes rerun`, which cancels the stale monitor and re-runs the full
-pipeline including a deterministic rebase step. Do **not** reach for
+with `no-mistakes rerun`, subject to the clean-head check above. An accepted
+rerun cancels the stale monitor and re-runs the full pipeline including a
+deterministic rebase step. Do **not** reach for
 `no-mistakes axi run` to refresh a still-active PR: after `checks-passed` it
 reattaches to the running monitor (HEAD unchanged) and returns its output
 without rebasing.


### PR DESCRIPTION
Refs #867.

`rerun` could start validation at a stale gate or preserved terminal head even when the caller had a different clean local HEAD. It now refuses before creating or superseding a run, names both full SHAs, and points to `axi status`, its custody/synchronization action, and a fresh `axi run` for the intended local commits. Matching requests retain the existing selection and intent inheritance; dirty or headless requests retain existing behavior.

Both CLI paths capture clean-head evidence immediately before sending rerun IPC. This also fixes the review finding where AXI reused its startup SHA after the post-push wait. Regression tests exercise commits before the push and during the wait independently. A second review fix reads cleanliness and the full SHA from one Git porcelain v2 status response, avoiding a later HEAD lookup that could mix repository states. Live recovery messages and the canonical/generated agent guidance now describe the refusal.

The motivating incident is historical: on August 8, the gate remained pinned at `3f4bcbece2` while corrected local head `10f6944c04` could not push; rerun selected the superseded code and the operator aborted it. This change does not reproduce that production incident or add gate repair. The original baseline already inherited explicit intent and could select a verified preserved terminal head; the guard compares against that final selection.

Validation:

- Red first on `origin/main` at `cba4572ff8da24d395abab0bebbff95d042716bf`: `GIT_CONFIG_GLOBAL=/dev/null go test ./internal/cli ./internal/daemon -run '^TestRerun(SendsOnlyCleanCallerHead|ChecksCallerHeadAgainstSelectedHead)$' -count=1`. The CLI omitted caller evidence and both differing-head cases incorrectly started runs; matching cases passed.
- The AXI timing regressions failed on `f9bd7581` and passed after refreshing evidence at the request boundary. The `commit_before_push` subtest also passes when run by itself.
- `TestRerunCallerHeadDoesNotCombineDifferentGitStates` failed before the snapshot correction at `6dd857fa` and passed afterward at `959f42c0`; staged edits, renames, and unborn HEADs retain their prior behavior.
- Real Git, IPC, and persisted-state tests cover matching/differing gate and preserved heads, exact intent inheritance, omitted evidence, and refusal without replacing an active run or changing refs. The pipeline evidence below records its measured commands and limitations.
- On final head `959f42c04ed0f9d758e2b437e45a99fff1816d91`, `make lint`, formatting checks, and the CLI build passed locally. [Hosted CI](https://github.com/kunchenguid/no-mistakes/actions/runs/33949928609) passed Linux/macOS race suites, both Windows test shards, and e2e. Greptile and the head-bound no-mistakes attestation check also passed. The motivating production incident was not recreated.

<details>
<summary>Evidence: CLI refusals with both SHAs and unchanged Git/run state</summary>

```text
=== RUN   TestStaleMonitorGuidance_SyncedAcrossSurfaces
--- PASS: TestStaleMonitorGuidance_SyncedAcrossSurfaces (0.00s)
=== RUN   TestStaleMonitorGuidance_InChecksPassedOutput
--- PASS: TestStaleMonitorGuidance_InChecksPassedOutput (0.16s)
=== RUN   TestNormalDriveOutputDoesNotFloodBranchSyncGuidance
--- PASS: TestNormalDriveOutputDoesNotFloodBranchSyncGuidance (0.09s)
=== RUN   TestTriggerRunDoesNotRerunAfterFailedPush
--- PASS: TestTriggerRunDoesNotRerunAfterFailedPush (0.00s)
=== RUN   TestRerunParamsIncludeSkipSteps
--- PASS: TestRerunParamsIncludeSkipSteps (0.00s)
=== RUN   TestRerunSendsOnlyCleanCallerHead
=== RUN   TestRerunSendsOnlyCleanCallerHead/clean
2026/09/05 02:53:38 INFO ipc request method=rerun
    rerun_test.go:117: CLI output:   ^[^[[32m✓^[^[[0m Rerun started for main ^[^[[90mrerun-1^[^[[0m
        IPC request: map[branch:main caller_head_sha:7f71615ccb54b1cdc9447530c4b9d4f374055de3 intent:keep the caller's changes repo_id:01M1R22CEZ1NN4M7AW5136PRYP]
2026/09/05 02:53:44 INFO ipc request method=rerun
    rerun_test.go:140: AXI no-op push fallback IPC request: map[branch:main caller_head_sha:7f71615ccb54b1cdc9447530c4b9d4f374055de3 intent:keep the caller's changes repo_id:01M1R22CEZ1NN4M7AW5136PRYP]; run_id=rerun-1
=== RUN   TestRerunSendsOnlyCleanCallerHead/clean/commit_during_wait
2026/09/05 02:53:49 INFO ipc request method=rerun
    rerun_test.go:172: startup=7f71615ccb54b1cdc9447530c4b9d4f374055de3 current=f94f3db349cb6f3b7f74116cb3faeaf1e558c373 gate=7f71615ccb54b1cdc9447530c4b9d4f374055de3 request=f94f3db349cb6f3b7f74116cb3faeaf1e558c373
=== RUN   TestRerunSendsOnlyCleanCallerHead/clean/commit_before_push
2026/09/05 02:53:54 INFO ipc request method=rerun
    rerun_test.go:172: startup=7f71615ccb54b1cdc9447530c4b9d4f374055de3 current=4f279be682526c39dab480251726e7063521b496 gate=4f279be682526c39dab480251726e7063521b496 request=4f279be682526c39dab480251726e7063521b496
=== RUN   TestRerunSendsOnlyCleanCallerHead/dirty
2026/09/05 02:53:55 INFO ipc request method=rerun
    rerun_test.go:117: CLI output:   ^[^[[32m✓^[^[[0m Rerun started for main ^[^[[90mrerun-1^[^[[0m
        IPC request: map[branch:main intent:keep the caller's changes repo_id:01M1R22W8NF6DFP2ZEKMGF9VWH]
--- PASS: TestRerunSendsOnlyCleanCallerHead (16.31s)
    --- PASS: TestRerunSendsOnlyCleanCallerHead/clean (16.20s)
        --- PASS: TestRerunSendsOnlyCleanCallerHead/clean/commit_during_wait (5.40s)
        --- PASS: TestRerunSendsOnlyCleanCallerHead/clean/commit_before_push (5.26s)
    --- PASS: TestRerunSendsOnlyCleanCallerHead/dirty (0.11s)
=== RUN   TestRerunRefusesDifferentCleanHeadCLI
=== RUN   TestRerunRefusesDifferentCleanHeadCLI/gate
2026/09/05 02:53:55 INFO daemon process launched pid=93896
2026/09/05 02:53:55 INFO daemon startup phase complete phase=orphan_servers duration_ms=0
2026/09/05 02:53:55 INFO daemon startup phase complete phase=gate_migration duration_ms=0 gate_count=0 current=0 migrated=0 rejected=0 failed=0
2026/09/05 02:53:55 INFO daemon startup phase complete phase=terminal_pr_runs duration_ms=0 reconciled=0
2026/09/05 02:53:55 INFO daemon startup phase complete phase=parked_runs duration_ms=0 preserved=0
2026/09/05 02:53:55 INFO daemon startup phase complete phase=stale_runs duration_ms=0 recovered=0
2026/09/05 02:53:55 INFO daemon startup phase complete phase=orphan_processes duration_ms=223
2026/09/05 02:53:55 INFO daemon startup phase complete phase=worktree_cleanup duration_ms=0
2026/09/05 02:53:55 INFO daemon startup phase complete phase=evidence_cleanup duration_ms=0
2026/09/05 02:53:55 INFO daemon startup phase complete phase=ipc_bind duration_ms=0
2026/09/05 02:53:55 INFO daemon startup phase complete phase=ipc_health duration_ms=0
2026/09/05 02:53:55 INFO daemon ready socket=/tmp/nmh-1063358348/socket pid=93896 startup_ms=243
2026/09/05 02:53:55 WARN ipc request failed method=rerun error="refusing rerun: selected head c04f8bc79f2fb94b1a4e63a9a4ef3b7802209425 differs from clean local head 9b819c6322a7d8f85bc63f1066dd9c86d9dda5c5; inspect `no-mistakes axi status` and reconcile custody before using `no-mistakes axi run` to submit the local head"
    rerun_test.go:248: CLI output:
        Error: rerun pipeline: refusing rerun: selected head c04f8bc79f2fb94b1a4e63a9a4ef3b7802209425 differs from clean local head 9b819c6322a7d8f85bc63f1066dd9c86d9dda5c5; inspect `no-mistakes axi status` and reconcile custody before using `no-mistakes axi run` to submit the local head
        Usage:
          rerun [flags]
        
        Flags:
              --base-branch string   integration branch for the PR for this rerun only (overrides inherited per-run base branch)
          -h, --help                 help for rerun
              --intent string        explicit intent for this rerun (overrides inherited intent or fresh inference)
        
    rerun_test.go:259: persisted runs=1; prior status=failed; caller and gate refs unchanged
        caller refs:
        9b819c6322a7d8f85bc63f1066dd9c86d9dda5c5 refs/heads/main
        gate refs:
        c04f8bc79f2fb94b1a4e63a9a4ef3b7802209425 refs/heads/main
2026/09/05 02:53:55 INFO ipc request method=shutdown
2026/09/05 02:53:55 INFO shutting down reason="ipc request"
2026/09/05 02:53:55 INFO daemon stopped gracefully
2026/09/05 02:53:55 INFO daemon stopped
=== RUN   TestRerunRefusesDifferentCleanHeadCLI/preserved
2026/09/05 02:53:55 INFO daemon process launched pid=93896
2026/09/05 02:53:55 INFO daemon startup phase complete phase=orphan_servers duration_ms=0
2026/09/05 02:53:55 INFO daemon startup phase complete phase=gate_migration duration_ms=0 gate_count=0 current=0 migrated=0 rejected=0 failed=0
2026/09/05 02:53:55 INFO daemon startup phase complete phase=terminal_pr_runs duration_ms=0 reconciled=0
2026/09/05 02:53:55 INFO daemon startup phase complete phase=parked_runs duration_ms=0 preserved=0
2026/09/05 02:53:55 INFO daemon startup phase complete phase=stale_runs duration_ms=0 recovered=0
2026/09/05 02:53:55 INFO daemon startup phase complete phase=orphan_processes duration_ms=224
2026/09/05 02:53:55 INFO daemon startup phase complete phase=worktree_cleanup duration_ms=0
2026/09/05 02:53:55 INFO daemon startup phase complete phase=evidence_cleanup duration_ms=0
2026/09/05 02:53:55 INFO daemon startup phase complete phase=ipc_bind duration_ms=0
2026/09/05 02:53:55 INFO daemon startup phase complete phase=ipc_health duration_ms=0
2026/09/05 02:53:55 INFO daemon ready socket=/tmp/nmh-1661426262/socket pid=93896 startup_ms=236
2026/09/05 02:53:56 WARN ipc request failed method=rerun error="refusing rerun: selected head 1bd2534e068b7290e8e63bf3f320af952f2ee077 differs from clean local head fb87cd7de3aac06a2e1e4bce28a8e2a35c1fe2af; inspect `no-mistakes axi status` and reconcile custody before using `no-mistakes axi run` to submit the local head"
    rerun_test.go:248: CLI output:
        Error: rerun pipeline: refusing rerun: selected head 1bd2534e068b7290e8e63bf3f320af952f2ee077 differs from clean local head fb87cd7de3aac06a2e1e4bce28a8e2a35c1fe2af; inspect `no-mistakes axi status` and reconcile custody before using `no-mistakes axi run` to submit the local head
        Usage:
          rerun [flags]
        
        Flags:
              --base-branch string   integration branch for the PR for this rerun only (overrides inherited per-run base branch)
          -h, --help                 help for rerun
              --intent string        explicit intent for this rerun (overrides inherited intent or fresh inference)
        
    rerun_test.go:259: persisted runs=1; prior status=failed; caller and gate refs unchanged
        caller refs:
        fb87cd7de3aac06a2e1e4bce28a8e2a35c1fe2af refs/heads/main
        gate refs:
        c04f8bc79f2fb94b1a4e63a9a4ef3b7802209425 refs/heads/main
        1bd2534e068b7290e8e63bf3f320af952f2ee077 refs/no-mistakes/recover/01M1R22X6D5XK42N62T0RRKVG8
2026/09/05 02:53:56 INFO ipc request method=shutdown
2026/09/05 02:53:56 INFO shutting down reason="ipc request"
2026/09/05 02:53:56 INFO daemon stopped gracefully
2026/09/05 02:53:56 INFO daemon stopped
--- PASS: TestRerunRefusesDifferentCleanHeadCLI (1.16s)
    --- PASS: TestRerunRefusesDifferentCleanHeadCLI/gate (0.54s)
    --- PASS: TestRerunRefusesDifferentCleanHeadCLI/preserved (0.63s)
=== RUN   TestAxiSyncCheckSurfacesRecoveryForTerminalPrePushRun
--- PASS: TestAxiSyncCheckSurfacesRecoveryForTerminalPrePushRun (0.69s)
=== RUN   TestAxiSyncRecoverDivergedRefusesThenKeepLocalSucceeds
--- PASS: TestAxiSyncRecoverDivergedRefusesThenKeepLocalSucceeds (2.61s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/cli	21.504s
```
</details>
<details>
<summary>Evidence: Selected-head checks, intent inheritance, and active-run preservation</summary>

```text
=== RUN   TestRerunInheritsIntentFromSelectedRun
2026/09/05 02:53:38 INFO daemon process launched pid=93367
2026/09/05 02:53:38 INFO daemon startup phase complete phase=orphan_servers duration_ms=0
2026/09/05 02:53:38 INFO daemon startup phase complete phase=gate_migration duration_ms=0 gate_count=0 current=0 migrated=0 rejected=0 failed=0
2026/09/05 02:53:38 INFO daemon startup phase complete phase=terminal_pr_runs duration_ms=0 reconciled=0
2026/09/05 02:53:38 INFO daemon startup phase complete phase=parked_runs duration_ms=0 preserved=0
2026/09/05 02:53:38 INFO daemon startup phase complete phase=stale_runs duration_ms=0 recovered=0
2026/09/05 02:53:38 INFO daemon startup phase complete phase=orphan_processes duration_ms=248
2026/09/05 02:53:38 INFO daemon startup phase complete phase=worktree_cleanup duration_ms=0
2026/09/05 02:53:38 INFO daemon startup phase complete phase=evidence_cleanup duration_ms=0
2026/09/05 02:53:38 INFO daemon startup phase complete phase=ipc_bind duration_ms=0
2026/09/05 02:53:38 INFO daemon startup phase complete phase=ipc_health duration_ms=0
2026/09/05 02:53:38 INFO daemon ready socket=/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/dtest1671074915/socket pid=93367 startup_ms=277
2026/09/05 02:53:38 INFO push received ref=refs/heads/main old=0000000000000000000000000000000000000000 new=ad27ea707e00e48609be9345284d888c3d263d12 gate=/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/dtest1671074915/repos/selected-rerun-repo.git
2026/09/05 02:53:38 WARN repository URL refresh skipped; continuing with existing registration repo_id=selected-rerun-repo reason=remote_unreadable
2026/09/05 02:53:38 INFO ipc request method=push_received
2026/09/05 02:53:38 INFO pipeline completed run_id=01M1R22CB747NRG81E6KSAQCJ0
2026/09/05 02:53:39 WARN repository URL refresh skipped; continuing with existing registration repo_id=selected-rerun-repo reason=remote_unreadable
2026/09/05 02:53:39 INFO ipc request method=rerun
2026/09/05 02:53:39 INFO pipeline completed run_id=01M1R22CRQG42SDWBH8ANB5FK7
2026/09/05 02:53:39 INFO ipc request method=shutdown
2026/09/05 02:53:39 INFO shutting down reason="ipc request"
2026/09/05 02:53:39 INFO cancelled run on shutdown run_id=01M1R22CRQG42SDWBH8ANB5FK7
2026/09/05 02:53:39 INFO daemon stopped
--- PASS: TestRerunInheritsIntentFromSelectedRun (1.60s)
=== RUN   TestResolveRerunHeadUsesPreservedTerminalHeadInsteadOfStaleGateBranch
=== PAUSE TestResolveRerunHeadUsesPreservedTerminalHeadInsteadOfStaleGateBranch
=== RUN   TestResolveRerunHeadUsesAdvancedGateWhenSubmittedHeadWasTerminal
=== PAUSE TestResolveRerunHeadUsesAdvancedGateWhenSubmittedHeadWasTerminal
=== RUN   TestRerunChecksCallerHeadAgainstSelectedHead
=== RUN   TestRerunChecksCallerHeadAgainstSelectedHead/gate/differs
2026/09/05 02:53:39 INFO daemon process launched pid=93367
2026/09/05 02:53:39 INFO daemon startup phase complete phase=orphan_servers duration_ms=0
2026/09/05 02:53:39 INFO daemon startup phase complete phase=gate_migration duration_ms=0 gate_count=0 current=0 migrated=0 rejected=0 failed=0
2026/09/05 02:53:39 INFO daemon startup phase complete phase=terminal_pr_runs duration_ms=0 reconciled=0
2026/09/05 02:53:39 INFO daemon startup phase complete phase=parked_runs duration_ms=0 preserved=0
2026/09/05 02:53:39 INFO daemon startup phase complete phase=stale_runs duration_ms=0 recovered=0
2026/09/05 02:53:39 INFO daemon startup phase complete phase=orphan_processes duration_ms=244
2026/09/05 02:53:39 INFO daemon startup phase complete phase=worktree_cleanup duration_ms=0
2026/09/05 02:53:39 INFO daemon startup phase complete phase=evidence_cleanup duration_ms=0
2026/09/05 02:53:39 INFO daemon startup phase complete phase=ipc_bind duration_ms=0
2026/09/05 02:53:39 INFO daemon startup phase complete phase=ipc_health duration_ms=0
2026/09/05 02:53:39 INFO daemon ready socket=/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/dtest3753888828/socket pid=93367 startup_ms=253
2026/09/05 02:53:40 WARN ipc request failed method=rerun error="refusing rerun: selected head e6e9c717f1805575f3dfab261059f841a82d3590 differs from clean local head e59b57fb47df303606bacc7d33b70ce73f2ad1da; inspect `no-mistakes axi status` and reconcile custody before using `no-mistakes axi run` to submit the local head"
    rerun_head_test.go:87: rerun response: refusing rerun: selected head e6e9c717f1805575f3dfab261059f841a82d3590 differs from clean local head e59b57fb47df303606bacc7d33b70ce73f2ad1da; inspect `no-mistakes axi status` and reconcile custody before using `no-mistakes axi run` to submit the local head
    rerun_head_test.go:92: persisted runs=1; step executions=0
    rerun_head_test.go:100: unchanged gate branch=e6e9c717f1805575f3dfab261059f841a82d3590; unchanged caller HEAD=e59b57fb47df303606bacc7d33b70ce73f2ad1da
2026/09/05 02:53:40 INFO ipc request method=shutdown
2026/09/05 02:53:40 INFO shutting down reason="ipc request"
2026/09/05 02:53:40 INFO daemon stopped
=== RUN   TestRerunChecksCallerHeadAgainstSelectedHead/gate/matches
2026/09/05 02:53:40 INFO daemon process launched pid=93367
2026/09/05 02:53:40 INFO daemon startup phase complete phase=orphan_servers duration_ms=0
2026/09/05 02:53:40 INFO daemon startup phase complete phase=gate_migration duration_ms=0 gate_count=0 current=0 migrated=0 rejected=0 failed=0
2026/09/05 02:53:40 INFO daemon startup phase complete phase=terminal_pr_runs duration_ms=0 reconciled=0
2026/09/05 02:53:40 INFO daemon startup phase complete phase=parked_runs duration_ms=0 preserved=0
2026/09/05 02:53:40 INFO daemon startup phase complete phase=stale_runs duration_ms=0 recovered=0
2026/09/05 02:53:40 INFO daemon startup phase complete phase=orphan_processes duration_ms=233
2026/09/05 02:53:40 INFO daemon startup phase complete phase=worktree_cleanup duration_ms=0
2026/09/05 02:53:40 INFO daemon startup phase complete phase=evidence_cleanup duration_ms=0
2026/09/05 02:53:40 INFO daemon startup phase complete phase=ipc_bind duration_ms=0
2026/09/05 02:53:40 INFO daemon startup phase complete phase=ipc_health duration_ms=0
2026/09/05 02:53:40 INFO daemon ready socket=/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/dtest1946137784/socket pid=93367 startup_ms=243
2026/09/05 02:53:40 WARN repository URL refresh skipped; continuing with existing registration repo_id=rerun-head-repo reason=remote_unreadable
2026/09/05 02:53:40 INFO ipc request method=rerun
2026/09/05 02:53:41 INFO pipeline completed run_id=01M1R22EDP8XRYX1XD2GPTXK8R
    rerun_head_test.go:77: rerun response: run_id=01M1R22EDP8XRYX1XD2GPTXK8R; persisted status=completed submitted_head_sha=e6e9c717f1805575f3dfab261059f841a82d3590 intent="  preserve these exact requirements\n" intent_source=rerun
    rerun_head_test.go:100: unchanged gate branch=e6e9c717f1805575f3dfab261059f841a82d3590; unchanged caller HEAD=e6e9c717f1805575f3dfab261059f841a82d3590
2026/09/05 02:53:41 INFO ipc request method=shutdown
2026/09/05 02:53:41 INFO shutting down reason="ipc request"
2026/09/05 02:53:41 INFO cancelled run on shutdown run_id=01M1R22EDP8XRYX1XD2GPTXK8R
2026/09/05 02:53:41 INFO daemon stopped
=== RUN   TestRerunChecksCallerHeadAgainstSelectedHead/gate/omitted
2026/09/05 02:53:41 INFO daemon process launched pid=93367
2026/09/05 02:53:41 INFO daemon startup phase complete phase=orphan_servers duration_ms=0
2026/09/05 02:53:41 INFO daemon startup phase complete phase=gate_migration duration_ms=0 gate_count=0 current=0 migrated=0 rejected=0 failed=0
2026/09/05 02:53:41 INFO daemon startup phase complete phase=terminal_pr_runs duration_ms=0 reconciled=0
2026/09/05 02:53:41 INFO daemon startup phase complete phase=parked_runs duration_ms=0 preserved=0
2026/09/05 02:53:41 INFO daemon startup phase complete phase=stale_runs duration_ms=0 recovered=0
2026/09/05 02:53:41 INFO daemon startup phase complete phase=orphan_processes duration_ms=241
2026/09/05 02:53:41 INFO daemon startup phase complete phase=worktree_cleanup duration_ms=0
2026/09/05 02:53:41 INFO daemon startup phase complete phase=evidence_cleanup duration_ms=0
2026/09/05 02:53:41 INFO daemon startup phase complete phase=ipc_bind duration_ms=0
2026/09/05 02:53:41 INFO daemon startup phase complete phase=ipc_h

... [3261 bytes truncated] ...

c request"
2026/09/05 02:53:43 INFO daemon stopped
=== RUN   TestRerunChecksCallerHeadAgainstSelectedHead/preserved/matches
2026/09/05 02:53:43 INFO daemon process launched pid=93367
2026/09/05 02:53:43 INFO daemon startup phase complete phase=orphan_servers duration_ms=0
2026/09/05 02:53:43 INFO daemon startup phase complete phase=gate_migration duration_ms=0 gate_count=0 current=0 migrated=0 rejected=0 failed=0
2026/09/05 02:53:43 INFO daemon startup phase complete phase=terminal_pr_runs duration_ms=0 reconciled=0
2026/09/05 02:53:43 INFO daemon startup phase complete phase=parked_runs duration_ms=0 preserved=0
2026/09/05 02:53:43 INFO daemon startup phase complete phase=stale_runs duration_ms=0 recovered=0
2026/09/05 02:53:43 INFO daemon startup phase complete phase=orphan_processes duration_ms=343
2026/09/05 02:53:43 INFO daemon startup phase complete phase=worktree_cleanup duration_ms=0
2026/09/05 02:53:43 INFO daemon startup phase complete phase=evidence_cleanup duration_ms=0
2026/09/05 02:53:43 INFO daemon startup phase complete phase=ipc_bind duration_ms=0
2026/09/05 02:53:43 INFO daemon startup phase complete phase=ipc_health duration_ms=0
2026/09/05 02:53:43 INFO daemon ready socket=/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/dtest221234127/socket pid=93367 startup_ms=355
2026/09/05 02:53:44 WARN repository URL refresh skipped; continuing with existing registration repo_id=rerun-head-repo reason=remote_unreadable
2026/09/05 02:53:44 INFO ipc request method=rerun
2026/09/05 02:53:44 INFO pipeline completed run_id=01M1R22J1XNYX2X6VYFTWCZXFJ
    rerun_head_test.go:77: rerun response: run_id=01M1R22J1XNYX2X6VYFTWCZXFJ; persisted status=completed submitted_head_sha=7e10524a74d6fc4b3b04cb1313e2ceb6849e8192 intent="  preserve these exact requirements\n" intent_source=rerun
    rerun_head_test.go:100: unchanged gate branch=021b0211535724af4e0fc6168ba54d7b167a7038; unchanged caller HEAD=7e10524a74d6fc4b3b04cb1313e2ceb6849e8192
2026/09/05 02:53:45 INFO ipc request method=shutdown
2026/09/05 02:53:45 INFO shutting down reason="ipc request"
2026/09/05 02:53:45 INFO cancelled run on shutdown run_id=01M1R22J1XNYX2X6VYFTWCZXFJ
2026/09/05 02:53:45 INFO daemon stopped
=== RUN   TestRerunChecksCallerHeadAgainstSelectedHead/preserved/omitted
2026/09/05 02:53:45 INFO daemon process launched pid=93367
2026/09/05 02:53:45 INFO daemon startup phase complete phase=orphan_servers duration_ms=0
2026/09/05 02:53:45 INFO daemon startup phase complete phase=gate_migration duration_ms=0 gate_count=0 current=0 migrated=0 rejected=0 failed=0
2026/09/05 02:53:45 INFO daemon startup phase complete phase=terminal_pr_runs duration_ms=0 reconciled=0
2026/09/05 02:53:45 INFO daemon startup phase complete phase=parked_runs duration_ms=0 preserved=0
2026/09/05 02:53:45 INFO daemon startup phase complete phase=stale_runs duration_ms=0 recovered=0
2026/09/05 02:53:45 INFO daemon startup phase complete phase=orphan_processes duration_ms=259
2026/09/05 02:53:45 INFO daemon startup phase complete phase=worktree_cleanup duration_ms=0
2026/09/05 02:53:45 INFO daemon startup phase complete phase=evidence_cleanup duration_ms=0
2026/09/05 02:53:45 INFO daemon startup phase complete phase=ipc_bind duration_ms=0
2026/09/05 02:53:45 INFO daemon startup phase complete phase=ipc_health duration_ms=1
2026/09/05 02:53:45 INFO daemon ready socket=/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/dtest2912690015/socket pid=93367 startup_ms=272
2026/09/05 02:53:46 WARN repository URL refresh skipped; continuing with existing registration repo_id=rerun-head-repo reason=remote_unreadable
2026/09/05 02:53:46 INFO ipc request method=rerun
2026/09/05 02:53:46 INFO pipeline completed run_id=01M1R22KNGW2G18VARZ0SGRE9R
    rerun_head_test.go:77: rerun response: run_id=01M1R22KNGW2G18VARZ0SGRE9R; persisted status=completed submitted_head_sha=ab1af372d9ad3c3267506ffc88bf80b2f25dabf7 intent="  preserve these exact requirements\n" intent_source=rerun
    rerun_head_test.go:100: unchanged gate branch=7b1ce6a2573a6b65eab1de08d53c243d43ca829d; unchanged caller HEAD=a06539775b8c370efe284937121f0bd7b1befcf3
2026/09/05 02:53:46 INFO ipc request method=shutdown
2026/09/05 02:53:46 INFO shutting down reason="ipc request"
2026/09/05 02:53:46 INFO cancelled run on shutdown run_id=01M1R22KNGW2G18VARZ0SGRE9R
2026/09/05 02:53:46 INFO daemon stopped
--- PASS: TestRerunChecksCallerHeadAgainstSelectedHead (7.14s)
    --- PASS: TestRerunChecksCallerHeadAgainstSelectedHead/gate/differs (0.58s)
    --- PASS: TestRerunChecksCallerHeadAgainstSelectedHead/gate/matches (1.02s)
    --- PASS: TestRerunChecksCallerHeadAgainstSelectedHead/gate/omitted (1.30s)
    --- PASS: TestRerunChecksCallerHeadAgainstSelectedHead/preserved/differs (0.92s)
    --- PASS: TestRerunChecksCallerHeadAgainstSelectedHead/preserved/matches (1.80s)
    --- PASS: TestRerunChecksCallerHeadAgainstSelectedHead/preserved/omitted (1.52s)
=== RUN   TestRerunRefusalDoesNotSupersedeActiveRun
2026/09/05 02:53:46 INFO daemon process launched pid=93367
2026/09/05 02:53:46 INFO daemon startup phase complete phase=orphan_servers duration_ms=0
2026/09/05 02:53:46 INFO daemon startup phase complete phase=gate_migration duration_ms=0 gate_count=0 current=0 migrated=0 rejected=0 failed=0
2026/09/05 02:53:46 INFO daemon startup phase complete phase=terminal_pr_runs duration_ms=0 reconciled=0
2026/09/05 02:53:46 INFO daemon startup phase complete phase=parked_runs duration_ms=0 preserved=0
2026/09/05 02:53:46 INFO daemon startup phase complete phase=stale_runs duration_ms=0 recovered=0
2026/09/05 02:53:47 INFO daemon startup phase complete phase=orphan_processes duration_ms=241
2026/09/05 02:53:47 INFO daemon startup phase complete phase=worktree_cleanup duration_ms=0
2026/09/05 02:53:47 INFO daemon startup phase complete phase=evidence_cleanup duration_ms=0
2026/09/05 02:53:47 INFO daemon startup phase complete phase=ipc_bind duration_ms=0
2026/09/05 02:53:47 INFO daemon startup phase complete phase=ipc_health duration_ms=0
2026/09/05 02:53:47 INFO daemon ready socket=/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/dtest3469047069/socket pid=93367 startup_ms=255
2026/09/05 02:53:47 INFO push received ref=refs/heads/main old=cf50f03fecffd6dd6ee5e02c252285766dcb9591 new=cf50f03fecffd6dd6ee5e02c252285766dcb9591 gate=/var/folders/r8/cylyt7xd7t50y9x5wc05my380000gn/T/dtest3469047069/repos/active-rerun-head-repo.git
2026/09/05 02:53:47 WARN repository URL refresh skipped; continuing with existing registration repo_id=active-rerun-head-repo reason=remote_unreadable
2026/09/05 02:53:47 INFO ipc request method=push_received
2026/09/05 02:53:47 WARN ipc request failed method=rerun error="refusing rerun: selected head cf50f03fecffd6dd6ee5e02c252285766dcb9591 differs from clean local head 12f52c376ef10e781141e2cb4e4d2562cd01ff71; inspect `no-mistakes axi status` and reconcile custody before using `no-mistakes axi run` to submit the local head"
    rerun_head_test.go:139: rerun response: refusing rerun: selected head cf50f03fecffd6dd6ee5e02c252285766dcb9591 differs from clean local head 12f52c376ef10e781141e2cb4e4d2562cd01ff71; inspect `no-mistakes axi status` and reconcile custody before using `no-mistakes axi run` to submit the local head
    rerun_head_test.go:154: original run_id=01M1R22MS8K916GHVA26EJAFTD remains running; persisted runs=1; caller and gate refs unchanged
2026/09/05 02:53:47 INFO ipc request method=shutdown
2026/09/05 02:53:47 INFO shutting down reason="ipc request"
2026/09/05 02:53:47 INFO cancelled run on shutdown run_id=01M1R22MS8K916GHVA26EJAFTD
2026/09/05 02:53:47 ERROR pipeline failed run_id=01M1R22MS8K916GHVA26EJAFTD error="step review failed: context canceled"
2026/09/05 02:53:47 INFO daemon stopped
--- PASS: TestRerunRefusalDoesNotSupersedeActiveRun (1.11s)
=== CONT  TestResolveRerunHeadUsesPreservedTerminalHeadInsteadOfStaleGateBranch
=== CONT  TestResolveRerunHeadUsesAdvancedGateWhenSubmittedHeadWasTerminal
--- PASS: TestResolveRerunHeadUsesAdvancedGateWhenSubmittedHeadWasTerminal (0.30s)
--- PASS: TestResolveRerunHeadUsesPreservedTerminalHeadInsteadOfStaleGateBranch (0.48s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/daemon	10.716s
```
</details>
<details>
<summary>Evidence: Independent regression: commit during AXI wait</summary>

```text
=== RUN   TestRerunSendsOnlyCleanCallerHead
=== RUN   TestRerunSendsOnlyCleanCallerHead/clean
2026/09/05 02:54:33 INFO ipc request method=rerun
    rerun_test.go:117: CLI output:   ^[^[[32m✓^[^[[0m Rerun started for main ^[^[[90mrerun-1^[^[[0m
        IPC request: map[branch:main caller_head_sha:b88755f322ab3de829ea5c22ce7ce3a54af23d23 intent:keep the caller's changes repo_id:01M1R2429CNYYFSGFFBA58NYPT]
2026/09/05 02:54:39 INFO ipc request method=rerun
    rerun_test.go:140: AXI no-op push fallback IPC request: map[branch:main caller_head_sha:b88755f322ab3de829ea5c22ce7ce3a54af23d23 intent:keep the caller's changes repo_id:01M1R2429CNYYFSGFFBA58NYPT]; run_id=rerun-1
=== RUN   TestRerunSendsOnlyCleanCallerHead/clean/commit_during_wait
2026/09/05 02:54:44 INFO ipc request method=rerun
    rerun_test.go:172: startup=b88755f322ab3de829ea5c22ce7ce3a54af23d23 current=a85c714403e8109b3fac4209e1c683b5c03ec2b0 gate=b88755f322ab3de829ea5c22ce7ce3a54af23d23 request=a85c714403e8109b3fac4209e1c683b5c03ec2b0
--- PASS: TestRerunSendsOnlyCleanCallerHead (10.56s)
    --- PASS: TestRerunSendsOnlyCleanCallerHead/clean (10.56s)
        --- PASS: TestRerunSendsOnlyCleanCallerHead/clean/commit_during_wait (5.17s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/cli	11.100s
```
</details>
<details>
<summary>Evidence: Independent regression: commit before push</summary>

```text
=== RUN   TestRerunSendsOnlyCleanCallerHead
=== RUN   TestRerunSendsOnlyCleanCallerHead/clean
2026/09/05 02:54:33 INFO ipc request method=rerun
    rerun_test.go:117: CLI output:   ^[^[[32m✓^[^[[0m Rerun started for main ^[^[[90mrerun-1^[^[[0m
        IPC request: map[branch:main caller_head_sha:b88755f322ab3de829ea5c22ce7ce3a54af23d23 intent:keep the caller's changes repo_id:01M1R2422DKAXERKTR0TZP7Z7B]
2026/09/05 02:54:39 INFO ipc request method=rerun
    rerun_test.go:140: AXI no-op push fallback IPC request: map[branch:main caller_head_sha:b88755f322ab3de829ea5c22ce7ce3a54af23d23 intent:keep the caller's changes repo_id:01M1R2422DKAXERKTR0TZP7Z7B]; run_id=rerun-1
=== RUN   TestRerunSendsOnlyCleanCallerHead/clean/commit_before_push
2026/09/05 02:54:44 INFO ipc request method=rerun
    rerun_test.go:172: startup=b88755f322ab3de829ea5c22ce7ce3a54af23d23 current=dcb74b953717cd1087dbb59e0b132688c9d88ad1 gate=dcb74b953717cd1087dbb59e0b132688c9d88ad1 request=dcb74b953717cd1087dbb59e0b132688c9d88ad1
--- PASS: TestRerunSendsOnlyCleanCallerHead (10.67s)
    --- PASS: TestRerunSendsOnlyCleanCallerHead/clean (10.67s)
        --- PASS: TestRerunSendsOnlyCleanCallerHead/clean/commit_before_push (5.25s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/cli	10.985s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"959f42c04ed0f9d758e2b437e45a99fff1816d91","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go test -vet=off -count=1 -timeout=3m -v ./internal/cli -run '^(TestRerun|TestTriggerRunDoesNotRerunAfterFailedPush|TestStaleMonitorGuidance|TestNormalDriveOutputDoesNotFloodBranchSyncGuidance|TestAxiSyncCheckSurfacesRecoveryForTerminalPrePushRun|TestAxiSyncRecoverDivergedRefusesThenKeepLocalSucceeds)'`
- `go test -vet=off -count=1 -timeout=3m -v ./internal/daemon -run '^(TestRerunChecksCallerHeadAgainstSelectedHead|TestRerunRefusalDoesNotSupersedeActiveRun|TestRerunInheritsIntentFromSelectedRun|TestResolveRerunHead)'`
- `go test -vet=off -count=1 -timeout=1m -v ./internal/cli -run '^TestRerunSendsOnlyCleanCallerHead$/^clean$/^commit_during_wait$'`
- `go test -vet=off -count=1 -timeout=1m -v ./internal/cli -run '^TestRerunSendsOnlyCleanCallerHead$/^clean$/^commit_before_push$'`
- `go test -vet=off -count=1 -timeout=1m -v ./internal/tui ./internal/branchsync -run '^(TestModel_Update_RerunKeyStartsNewRunAndSwitchesModel|TestRecoverableCustodyActionFlowsThroughConfirmationAndRecoverService|TestRecoverDivergedRefusesButKeepLocalReturnsCustody)$'`
- `All tests ran with telemetry and update checks disabled; captured actual CLI/IPC output, Git refs, and persisted run-state observations from isolated fixtures in the evidence logs.`
- <code>`git status --short` and `git rev-parse HEAD` confirmed no worktree changes and the authoritative starting head.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
