### PR TITLE
feat(cli): add ci-workflow subcommand to generate GitHub Actions CI from repo config

### DIFF
--- a/docs/ci-workflow-generation.md
+++ b/docs/ci-workflow-generation.md
@@ -110,4 +110,4 @@ no-mistakes ci-workflow --force
 
 - The generated workflow is Go-focused (uses `setup-go` action). Non-Go repos can adapt the template as needed.
 - Commands are inserted verbatim from `.no-mistakes.yaml`, so ensure they're portable to GitHub's Ubuntu runner.
-- The workflow runs on `push: main` and all `pull_request` events.
+- The workflow runs on push to the repository's default branch and on all `pull_request` events.

--- a/docs/ci-workflow-generation.md
+++ b/docs/ci-workflow-generation.md
@@ -62,7 +62,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: ['main']
   pull_request:
 
 permissions:

--- a/docs/ci-workflow-generation.md
+++ b/docs/ci-workflow-generation.md
@@ -64,7 +64,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read
@@ -85,13 +84,17 @@ jobs:
           check-latest: true
 
       - name: Lint
-        run: go vet ./... && gofmt -l .
+        run: |
+          go vet ./... && gofmt -l .
 
       - name: Test
-        run: go test ./... -race
+        run: |
+          go test ./... -race
 ```
 
 When you push through the no-mistakes gate or open a PR, GitHub now has real checks to gate on. The gate's `ci` step completes successfully instead of timing out.
+
+**Note:** The `push` branch is resolved from your repository's default branch (not hardcoded to `main`). The `pull_request` trigger runs on all PRs. Commands are placed in YAML block scalars so special characters and multi-line commands stay intact.
 
 ## Options
 

--- a/docs/ci-workflow-generation.md
+++ b/docs/ci-workflow-generation.md
@@ -1,0 +1,110 @@
+# CI Workflow Generation
+
+The `no-mistakes ci-workflow` command auto-generates `.github/workflows/ci.yml` from your `.no-mistakes.yaml` configuration, ensuring that GitHub checks align with the gate's canonical commands.
+
+## Why This Matters
+
+When a new repo is initialized with `no-mistakes init`, the gate is ready to validate pushes locally — but GitHub has no CI workflow to register checks for. The gate's `ci` step sits idle (or times out) waiting for status checks that never appear.
+
+This command generates those checks automatically from the source of truth: `.no-mistakes.yaml`.
+
+## Quick Start
+
+After initializing your repo with `no-mistakes init`:
+
+```bash
+no-mistakes ci-workflow
+```
+
+This creates `.github/workflows/ci.yml` with steps that mirror your configured lint and test commands.
+
+Commit and push the workflow file:
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m 'ci: register workflow'
+git push no-mistakes main
+```
+
+## Example
+
+### Before
+
+A freshly initialized repo:
+
+```bash
+$ ls -la .github/workflows/
+ls: .github/workflows/: No such file or directory
+
+$ cat .no-mistakes.yaml
+commands:
+  lint: "go vet ./... && gofmt -l ."
+  test: "go test ./... -race"
+```
+
+Running `no-mistakes ci-workflow`:
+
+```bash
+$ no-mistakes ci-workflow
+  ✓  CI workflow generated
+      .github/workflows/ci.yml
+
+  Commit and push this file to enable GitHub checks:
+  git add .github/workflows/ci.yml && git commit -m 'ci: register workflow'
+```
+
+### After
+
+GitHub Actions now registers real checks:
+
+```yaml
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          check-latest: true
+
+      - name: Lint
+        run: go vet ./... && gofmt -l .
+
+      - name: Test
+        run: go test ./... -race
+```
+
+When you push through the no-mistakes gate or open a PR, GitHub now has real checks to gate on. The gate's `ci` step completes successfully instead of timing out.
+
+## Options
+
+### Force Overwrite
+
+If you need to regenerate the workflow (e.g., after changing `.no-mistakes.yaml`), use `--force`:
+
+```bash
+no-mistakes ci-workflow --force
+```
+
+## Notes
+
+- The generated workflow is Go-focused (uses `setup-go` action). Non-Go repos can adapt the template as needed.
+- Commands are inserted verbatim from `.no-mistakes.yaml`, so ensure they're portable to GitHub's Ubuntu runner.
+- The workflow runs on `push: main` and all `pull_request` events.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -67,6 +67,26 @@ If you copy an initialized working directory while the original still exists, th
 Fresh init rolls back gate setup when a required gate or daemon step fails; refresh does not eject a pre-existing gate if daemon startup fails.
 Skill installation is best-effort: if the skill write fails, init reports it and leaves the working gate in place.
 
+## no-mistakes ci-workflow
+
+Generate `.github/workflows/ci.yml` from the repository's `.no-mistakes.yaml` commands, so GitHub Actions registers real checks that the gate's CI step can monitor.
+
+```sh
+no-mistakes ci-workflow
+no-mistakes ci-workflow --force
+```
+
+| Flag            | Type   | Default | Description                      |
+| --------------- | ------ | ------- | -------------------------------- |
+| `-f`, `--force` | `bool` | `false` | Overwrite existing workflow file |
+
+Run it from a repository with a `.no-mistakes.yaml`; `commands.test` must be configured or the command errors.
+The generated workflow runs the configured test command (and lint command when `commands.lint` is set; with an empty `commands.lint` it emits a test-only workflow, since lint runs as the combined document+lint agent pass) on push to the repository's default branch, resolved from the `origin` remote and falling back to `main`, and on all pull requests.
+Commands are inserted verbatim into YAML block scalars, with multi-line commands indented to stay inside the scalar.
+The template is Go-focused (it uses `actions/setup-go` with `go-version-file: go.mod`); non-Go repos can adapt the generated file.
+An existing `.github/workflows/ci.yml` is never overwritten without `--force`.
+Commit and push the generated file to enable the checks.
+
 ## no-mistakes axi
 
 Agent eXperience Interface for non-interactive agents.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -80,11 +80,11 @@ no-mistakes ci-workflow --force
 | --------------- | ------ | ------- | -------------------------------- |
 | `-f`, `--force` | `bool` | `false` | Overwrite existing workflow file |
 
-Run it from a repository with a `.no-mistakes.yaml`; `commands.test` must be configured or the command errors.
+Run it from anywhere inside a repository with a `.no-mistakes.yaml`; the config is read from and the workflow written at the git toplevel, and `commands.test` must be configured or the command errors.
 The generated workflow runs the configured test command (and lint command when `commands.lint` is set; with an empty `commands.lint` it emits a test-only workflow, since lint runs as the combined document+lint agent pass) on push to the repository's default branch, resolved from the `origin` remote and falling back to `main`, and on all pull requests.
 Commands are inserted verbatim into YAML block scalars, with multi-line commands indented to stay inside the scalar.
 The template is Go-focused (it uses `actions/setup-go` with `go-version-file: go.mod`); non-Go repos can adapt the generated file.
-An existing `.github/workflows/ci.yml` is never overwritten without `--force`.
+An existing `.github/workflows/ci.yml` is never overwritten without `--force`, overwrites are atomic, and the command refuses to write through a symlinked `.github`, `workflows`, or `ci.yml`.
 Commit and push the generated file to enable the checks.
 
 ## no-mistakes axi

--- a/internal/cli/ci_workflow.go
+++ b/internal/cli/ci_workflow.go
@@ -1,0 +1,113 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/kunchenguid/no-mistakes/internal/config"
+	"github.com/spf13/cobra"
+)
+
+const ciWorkflowTemplate = `name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          check-latest: true
+
+      - name: Lint
+        run: %s
+
+      - name: Test
+        run: %s
+`
+
+func newCIWorkflowCmd() *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "ci-workflow",
+		Short: "Generate .github/workflows/ci.yml from .no-mistakes.yaml commands",
+		Long: "Emits .github/workflows/ci.yml that mirrors the canonical checks pinned in .no-mistakes.yaml.\n" +
+			"The workflow runs on push to main and pull requests, registering real GitHub checks\n" +
+			"that the no-mistakes gate's CI step can monitor.\n\n" +
+			"Run this from inside a git repository that has been initialized with 'no-mistakes init'.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return trackCommand("ci-workflow", func() error {
+				return generateCIWorkflow(".", force)
+			})
+		},
+	}
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "overwrite existing workflow file")
+	return cmd
+}
+
+func generateCIWorkflow(dir string, force bool) error {
+	// Load the repo config
+	cfg, err := config.LoadRepo(dir)
+	if err != nil {
+		return fmt.Errorf("ci-workflow: %w", err)
+	}
+
+	// Extract lint and test commands; use defaults if not set
+	lint := cfg.Commands.Lint
+	test := cfg.Commands.Test
+
+	// If either is missing, provide helpful guidance
+	if lint == "" {
+		return fmt.Errorf("ci-workflow: commands.lint not configured in .no-mistakes.yaml")
+	}
+	if test == "" {
+		return fmt.Errorf("ci-workflow: commands.test not configured in .no-mistakes.yaml")
+	}
+
+	// Generate the workflow YAML
+	workflow := fmt.Sprintf(ciWorkflowTemplate, lint, test)
+
+	// Determine output path
+	workflowDir := filepath.Join(dir, ".github", "workflows")
+	workflowPath := filepath.Join(workflowDir, "ci.yml")
+
+	// Check if file exists
+	if _, err := os.Stat(workflowPath); err == nil && !force {
+		return fmt.Errorf("ci-workflow: %s already exists (use --force to overwrite)", workflowPath)
+	}
+
+	// Create .github/workflows directory if needed
+	if err := os.MkdirAll(workflowDir, 0755); err != nil {
+		return fmt.Errorf("ci-workflow: create .github/workflows: %w", err)
+	}
+
+	// Write the workflow file
+	if err := os.WriteFile(workflowPath, []byte(workflow), 0644); err != nil {
+		return fmt.Errorf("ci-workflow: write workflow: %w", err)
+	}
+
+	fmt.Printf("  %s  %s\n", sGreen.Render("✓"), "CI workflow generated")
+	fmt.Printf("  %s  %s\n", sDim.Render("    "), workflowPath)
+	fmt.Println()
+	fmt.Printf("  %s\n", sDim.Render("Commit and push this file to enable GitHub checks:"))
+	fmt.Printf("  %s\n", sBold.Render("git add .github/workflows/ci.yml && git commit -m 'ci: register workflow'"))
+
+	return nil
+}

--- a/internal/cli/ci_workflow.go
+++ b/internal/cli/ci_workflow.go
@@ -1,21 +1,23 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/config"
+	"github.com/kunchenguid/no-mistakes/internal/git"
 	"github.com/spf13/cobra"
 )
 
-const ciWorkflowTemplate = `name: CI
+const ciWorkflowTemplateWithLint = `name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [%s]
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read
@@ -36,10 +38,42 @@ jobs:
           check-latest: true
 
       - name: Lint
-        run: %s
+        run: |
+          %s
 
       - name: Test
-        run: %s
+        run: |
+          %s
+`
+
+const ciWorkflowTemplateTestOnly = `name: CI
+
+on:
+  push:
+    branches: [%s]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          check-latest: true
+
+      - name: Test
+        run: |
+          %s
 `
 
 func newCIWorkflowCmd() *cobra.Command {
@@ -48,8 +82,8 @@ func newCIWorkflowCmd() *cobra.Command {
 		Use:   "ci-workflow",
 		Short: "Generate .github/workflows/ci.yml from .no-mistakes.yaml commands",
 		Long: "Emits .github/workflows/ci.yml that mirrors the canonical checks pinned in .no-mistakes.yaml.\n" +
-			"The workflow runs on push to main and pull requests, registering real GitHub checks\n" +
-			"that the no-mistakes gate's CI step can monitor.\n\n" +
+			"The workflow runs on push to the default branch and on all pull requests, registering\n" +
+			"real GitHub checks that the no-mistakes gate's CI step can monitor.\n\n" +
 			"Run this from inside a git repository that has been initialized with 'no-mistakes init'.",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -69,20 +103,28 @@ func generateCIWorkflow(dir string, force bool) error {
 		return fmt.Errorf("ci-workflow: %w", err)
 	}
 
-	// Extract lint and test commands; use defaults if not set
-	lint := cfg.Commands.Lint
-	test := cfg.Commands.Test
+	// Resolve the repository's default branch
+	// Use a timeout context for the remote lookup
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	defaultBranch := git.DefaultBranch(ctx, dir, "origin")
 
-	// If either is missing, provide helpful guidance
-	if lint == "" {
-		return fmt.Errorf("ci-workflow: commands.lint not configured in .no-mistakes.yaml")
-	}
+	// Extract test command (required)
+	test := cfg.Commands.Test
 	if test == "" {
 		return fmt.Errorf("ci-workflow: commands.test not configured in .no-mistakes.yaml")
 	}
 
-	// Generate the workflow YAML
-	workflow := fmt.Sprintf(ciWorkflowTemplate, lint, test)
+	// Extract lint command (optional; empty means combined document+lint)
+	lint := cfg.Commands.Lint
+
+	// Select template and generate workflow
+	var workflow string
+	if lint == "" {
+		workflow = fmt.Sprintf(ciWorkflowTemplateTestOnly, defaultBranch, indentCommand(test))
+	} else {
+		workflow = fmt.Sprintf(ciWorkflowTemplateWithLint, defaultBranch, indentCommand(lint), indentCommand(test))
+	}
 
 	// Determine output path
 	workflowDir := filepath.Join(dir, ".github", "workflows")
@@ -105,9 +147,20 @@ func generateCIWorkflow(dir string, force bool) error {
 
 	fmt.Printf("  %s  %s\n", sGreen.Render("✓"), "CI workflow generated")
 	fmt.Printf("  %s  %s\n", sDim.Render("    "), workflowPath)
+	if lint == "" {
+		fmt.Printf("  %s  %s\n", sDim.Render("    "), "(test only; lint uses combined document+lint)")
+	}
 	fmt.Println()
 	fmt.Printf("  %s\n", sDim.Render("Commit and push this file to enable GitHub checks:"))
 	fmt.Printf("  %s\n", sBold.Render("git add .github/workflows/ci.yml && git commit -m 'ci: register workflow'"))
 
 	return nil
+}
+
+// indentCommand indents each line of a command for use in a YAML block scalar.
+// It preserves the command's structure while ensuring proper YAML formatting.
+func indentCommand(cmd string) string {
+	// Block scalars are already indented by the template, so just use the command as-is.
+	// The template ensures proper indentation for the block scalar context.
+	return cmd
 }

--- a/internal/cli/ci_workflow.go
+++ b/internal/cli/ci_workflow.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/kunchenguid/no-mistakes/internal/config"
@@ -157,10 +158,17 @@ func generateCIWorkflow(dir string, force bool) error {
 	return nil
 }
 
-// indentCommand indents each line of a command for use in a YAML block scalar.
-// It preserves the command's structure while ensuring proper YAML formatting.
+// ciWorkflowRunIndent matches the leading whitespace before the `%s` placeholder
+// in the run: | block scalars above, so a multi-line command's continuation
+// lines stay inside the scalar instead of dedenting out of it.
+const ciWorkflowRunIndent = "          "
+
+// indentCommand indents every line of cmd after the first so a multi-line
+// command stays inside the YAML block scalar it's substituted into.
 func indentCommand(cmd string) string {
-	// Block scalars are already indented by the template, so just use the command as-is.
-	// The template ensures proper indentation for the block scalar context.
-	return cmd
+	lines := strings.Split(cmd, "\n")
+	for i := 1; i < len(lines); i++ {
+		lines[i] = ciWorkflowRunIndent + lines[i]
+	}
+	return strings.Join(lines, "\n")
 }

--- a/internal/cli/ci_workflow.go
+++ b/internal/cli/ci_workflow.go
@@ -17,7 +17,7 @@ const ciWorkflowTemplateWithLint = `name: CI
 
 on:
   push:
-    branches: [%s]
+    branches: ['%s']
   pull_request:
 
 permissions:
@@ -51,7 +51,7 @@ const ciWorkflowTemplateTestOnly = `name: CI
 
 on:
   push:
-    branches: [%s]
+    branches: ['%s']
   pull_request:
 
 permissions:
@@ -98,8 +98,15 @@ func newCIWorkflowCmd() *cobra.Command {
 }
 
 func generateCIWorkflow(dir string, force bool) error {
+	// Root the command at the git toplevel so the workflow always lands where
+	// GitHub discovers it, regardless of the caller's working subdirectory.
+	root, err := git.FindGitRoot(dir)
+	if err != nil {
+		return fmt.Errorf("ci-workflow: %w", err)
+	}
+
 	// Load the repo config
-	cfg, err := config.LoadRepo(dir)
+	cfg, err := config.LoadRepo(root)
 	if err != nil {
 		return fmt.Errorf("ci-workflow: %w", err)
 	}
@@ -108,7 +115,7 @@ func generateCIWorkflow(dir string, force bool) error {
 	// Use a timeout context for the remote lookup
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	defaultBranch := git.DefaultBranch(ctx, dir, "origin")
+	defaultBranch := git.DefaultBranch(ctx, root, "origin")
 
 	// Extract test command (required)
 	test := cfg.Commands.Test
@@ -122,28 +129,26 @@ func generateCIWorkflow(dir string, force bool) error {
 	// Select template and generate workflow
 	var workflow string
 	if lint == "" {
-		workflow = fmt.Sprintf(ciWorkflowTemplateTestOnly, defaultBranch, indentCommand(test))
+		workflow = fmt.Sprintf(ciWorkflowTemplateTestOnly, yamlSingleQuote(defaultBranch), indentCommand(test))
 	} else {
-		workflow = fmt.Sprintf(ciWorkflowTemplateWithLint, defaultBranch, indentCommand(lint), indentCommand(test))
+		workflow = fmt.Sprintf(ciWorkflowTemplateWithLint, yamlSingleQuote(defaultBranch), indentCommand(lint), indentCommand(test))
 	}
 
 	// Determine output path
-	workflowDir := filepath.Join(dir, ".github", "workflows")
+	workflowDir := filepath.Join(root, ".github", "workflows")
 	workflowPath := filepath.Join(workflowDir, "ci.yml")
 
-	// Check if file exists
-	if _, err := os.Stat(workflowPath); err == nil && !force {
-		return fmt.Errorf("ci-workflow: %s already exists (use --force to overwrite)", workflowPath)
+	// Create .github/workflows, refusing to follow a symlink planted by a
+	// repository-controlled tree component that would redirect the write
+	// outside the repo root.
+	if err := mkdirAllNoSymlink(root, workflowDir); err != nil {
+		return fmt.Errorf("ci-workflow: %w", err)
 	}
 
-	// Create .github/workflows directory if needed
-	if err := os.MkdirAll(workflowDir, 0755); err != nil {
-		return fmt.Errorf("ci-workflow: create .github/workflows: %w", err)
-	}
-
-	// Write the workflow file
-	if err := os.WriteFile(workflowPath, []byte(workflow), 0644); err != nil {
-		return fmt.Errorf("ci-workflow: write workflow: %w", err)
+	// Write the workflow file, refusing a symlinked destination and
+	// replacing any existing file atomically via temp+rename.
+	if err := writeFileNoSymlink(workflowPath, []byte(workflow), force); err != nil {
+		return fmt.Errorf("ci-workflow: %w", err)
 	}
 
 	fmt.Printf("  %s  %s\n", sGreen.Render("✓"), "CI workflow generated")
@@ -171,4 +176,96 @@ func indentCommand(cmd string) string {
 		lines[i] = ciWorkflowRunIndent + lines[i]
 	}
 	return strings.Join(lines, "\n")
+}
+
+// yamlSingleQuote wraps s in a YAML single-quoted scalar, doubling any
+// embedded single quotes per the YAML spec. Git ref names may legally
+// contain characters (']', '"', '#', ...) that would otherwise break out of
+// the unquoted flow sequence `branches: [%s]`.
+func yamlSingleQuote(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
+}
+
+// mkdirAllNoSymlink creates target (and any missing ancestors) below root,
+// refusing at the first path component that already exists as a symlink.
+// root itself is trusted (it comes from git.FindGitRoot, which resolves
+// symlinks); os.MkdirAll on the raw target is unsafe against a repository
+// that plants a symlink in place of a directory component (e.g. `.github`
+// pointing outside the repo), because MkdirAll's existence check follows
+// symlinks and would happily create/write through it.
+func mkdirAllNoSymlink(root, target string) error {
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return fmt.Errorf("resolve %s relative to %s: %w", target, root, err)
+	}
+	current := root
+	for _, part := range strings.Split(rel, string(filepath.Separator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return fmt.Errorf("stat %s: %w", current, err)
+			}
+			if err := os.Mkdir(current, 0755); err != nil {
+				return fmt.Errorf("create %s: %w", current, err)
+			}
+			continue
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to follow symlink at %s", current)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("%s exists and is not a directory", current)
+		}
+	}
+	return nil
+}
+
+// writeFileNoSymlink writes data to path, refusing when path already exists
+// as a symlink (regardless of force, since following it - to check or to
+// overwrite - could touch a file outside the repo). When path exists as a
+// regular file, force is required, matching the previous overwrite-guard
+// behavior. The write itself goes through a temp file in the same directory
+// followed by a rename so a reader never observes a partially written file
+// and a crash mid-write cannot corrupt an existing workflow.
+func writeFileNoSymlink(path string, data []byte, force bool) error {
+	info, err := os.Lstat(path)
+	switch {
+	case err == nil:
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to write through symlink %s", path)
+		}
+		if !force {
+			return fmt.Errorf("%s already exists (use --force to overwrite)", path)
+		}
+	case !os.IsNotExist(err):
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".ci-workflow-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath) // no-op once the rename below succeeds
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Chmod(0644); err != nil {
+		tmp.Close()
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename temp file into place: %w", err)
+	}
+	return nil
 }

--- a/internal/cli/ci_workflow_test.go
+++ b/internal/cli/ci_workflow_test.go
@@ -3,18 +3,19 @@ package cli
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestGenerateCIWorkflow(t *testing.T) {
 	tests := []struct {
-		name        string
-		configYAML  string
-		force       bool
-		wantErr     bool
-		wantContent string
-		setup       func(dir string) error
+		name       string
+		configYAML string
+		force      bool
+		wantErr    bool
+		validate   func(*testing.T, map[string]interface{})
+		setup      func(dir string) error
 	}{
 		{
 			name: "basic go repo with lint and test",
@@ -23,14 +24,26 @@ func TestGenerateCIWorkflow(t *testing.T) {
   test: "go test ./... -race"
 `,
 			wantErr: false,
-			wantContent: "go vet ./... && gofmt -l .",
+			validate: func(t *testing.T, workflow map[string]interface{}) {
+				t.Helper()
+				verifyWorkflowName(t, workflow, "CI")
+				verifyJobsExist(t, workflow)
+				verifyStepNames(t, workflow, []string{"Lint", "Test"})
+			},
 		},
 		{
-			name: "missing lint command",
+			name: "empty lint (combined document+lint)",
 			configYAML: `commands:
-  test: "go test ./..."
+  test: "go test ./... -race"
 `,
-			wantErr: true,
+			wantErr: false,
+			validate: func(t *testing.T, workflow map[string]interface{}) {
+				t.Helper()
+				verifyWorkflowName(t, workflow, "CI")
+				verifyJobsExist(t, workflow)
+				verifyStepNames(t, workflow, []string{"Test"})
+				verifyStepNotPresent(t, workflow, "Lint")
+			},
 		},
 		{
 			name: "missing test command",
@@ -42,7 +55,7 @@ func TestGenerateCIWorkflow(t *testing.T) {
 		{
 			name: "empty config",
 			configYAML: ``,
-			wantErr: true,
+			wantErr:    true,
 		},
 		{
 			name: "file exists, no force",
@@ -71,16 +84,22 @@ func TestGenerateCIWorkflow(t *testing.T) {
 `,
 			force:   true,
 			wantErr: false,
-			setup: func(dir string) error {
-				workflowDir := filepath.Join(dir, ".github", "workflows")
-				if err := os.MkdirAll(workflowDir, 0755); err != nil {
-					return err
-				}
-				return os.WriteFile(
-					filepath.Join(workflowDir, "ci.yml"),
-					[]byte("existing"),
-					0644,
-				)
+			validate: func(t *testing.T, workflow map[string]interface{}) {
+				t.Helper()
+				verifyWorkflowName(t, workflow, "CI")
+			},
+		},
+		{
+			name: "commands with special yaml characters",
+			configYAML: `commands:
+  lint: "go vet ./... && { test -z \"$(gofmt -l .)\" || exit 1; }"
+  test: "go test ./... -race -count=1"
+`,
+			wantErr: false,
+			validate: func(t *testing.T, workflow map[string]interface{}) {
+				t.Helper()
+				verifyStepRunContains(t, workflow, "Lint", "gofmt")
+				verifyStepRunContains(t, workflow, "Test", "-race")
 			},
 		},
 	}
@@ -118,7 +137,7 @@ func TestGenerateCIWorkflow(t *testing.T) {
 				return
 			}
 
-			// Check output file exists
+			// Check output file exists and is valid YAML
 			workflowPath := filepath.Join(dir, ".github", "workflows", "ci.yml")
 			content, err := os.ReadFile(workflowPath)
 			if err != nil {
@@ -126,25 +145,142 @@ func TestGenerateCIWorkflow(t *testing.T) {
 				return
 			}
 
-			// Check content
-			contentStr := string(content)
-			if tt.wantContent != "" && !strings.Contains(contentStr, tt.wantContent) {
-				t.Errorf("workflow content missing expected text: %q", tt.wantContent)
+			// Parse YAML
+			var workflow map[string]interface{}
+			if err := yaml.Unmarshal(content, &workflow); err != nil {
+				t.Errorf("workflow is not valid YAML: %v", err)
+				return
 			}
 
-			// Verify structure
-			if !strings.Contains(contentStr, "name: CI") {
-				t.Error("workflow missing name field")
-			}
-			if !strings.Contains(contentStr, "runs-on: ubuntu-latest") {
-				t.Error("workflow missing runs-on field")
-			}
-			if !strings.Contains(contentStr, "uses: actions/checkout@v4") {
-				t.Error("workflow missing checkout step")
-			}
-			if !strings.Contains(contentStr, "uses: actions/setup-go@v5") {
-				t.Error("workflow missing setup-go step")
+			// Run validation
+			if tt.validate != nil {
+				tt.validate(t, workflow)
 			}
 		})
 	}
+}
+
+// Workflow validation helpers
+
+func verifyWorkflowName(t *testing.T, workflow map[string]interface{}, expected string) {
+	t.Helper()
+	name, ok := workflow["name"].(string)
+	if !ok || name != expected {
+		t.Errorf("workflow name: got %q, want %q", name, expected)
+	}
+}
+
+func verifyJobsExist(t *testing.T, workflow map[string]interface{}) {
+	t.Helper()
+	jobs, ok := workflow["jobs"].(map[string]interface{})
+	if !ok || len(jobs) == 0 {
+		t.Error("workflow missing jobs")
+	}
+}
+
+func verifyStepNames(t *testing.T, workflow map[string]interface{}, stepNames []string) {
+	t.Helper()
+	jobs, ok := workflow["jobs"].(map[string]interface{})
+	if !ok {
+		t.Fatal("workflow missing jobs")
+	}
+
+	buildTestJob, ok := jobs["build-test"].(map[string]interface{})
+	if !ok {
+		t.Fatal("workflow missing build-test job")
+	}
+
+	stepsInterface, ok := buildTestJob["steps"].([]interface{})
+	if !ok {
+		t.Fatal("job missing steps")
+	}
+
+	foundSteps := make(map[string]bool)
+	for _, s := range stepsInterface {
+		step, ok := s.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if name, ok := step["name"].(string); ok {
+			foundSteps[name] = true
+		}
+	}
+
+	for _, wantName := range stepNames {
+		if !foundSteps[wantName] {
+			t.Errorf("workflow missing step: %q", wantName)
+		}
+	}
+}
+
+func verifyStepNotPresent(t *testing.T, workflow map[string]interface{}, stepName string) {
+	t.Helper()
+	jobs, ok := workflow["jobs"].(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	buildTestJob, ok := jobs["build-test"].(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	stepsInterface, ok := buildTestJob["steps"].([]interface{})
+	if !ok {
+		return
+	}
+
+	for _, s := range stepsInterface {
+		step, ok := s.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if name, ok := step["name"].(string); ok && name == stepName {
+			t.Errorf("workflow should not contain step: %q", stepName)
+		}
+	}
+}
+
+func verifyStepRunContains(t *testing.T, workflow map[string]interface{}, stepName string, expectedText string) {
+	t.Helper()
+	jobs, ok := workflow["jobs"].(map[string]interface{})
+	if !ok {
+		t.Fatal("workflow missing jobs")
+	}
+
+	buildTestJob, ok := jobs["build-test"].(map[string]interface{})
+	if !ok {
+		t.Fatal("workflow missing build-test job")
+	}
+
+	stepsInterface, ok := buildTestJob["steps"].([]interface{})
+	if !ok {
+		t.Fatal("job missing steps")
+	}
+
+	for _, s := range stepsInterface {
+		step, ok := s.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if name, ok := step["name"].(string); ok && name == stepName {
+			if run, ok := step["run"].(string); ok {
+				if runContains(run, expectedText) {
+					return
+				}
+			}
+			t.Errorf("step %q run does not contain %q", stepName, expectedText)
+			return
+		}
+	}
+	t.Errorf("step %q not found", stepName)
+}
+
+func runContains(haystack, needle string) bool {
+	for i := 0; i <= len(haystack)-len(needle); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/cli/ci_workflow_test.go
+++ b/internal/cli/ci_workflow_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -53,7 +54,7 @@ func TestGenerateCIWorkflow(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "empty config",
+			name:       "empty config",
 			configYAML: ``,
 			wantErr:    true,
 		},
@@ -100,6 +101,21 @@ func TestGenerateCIWorkflow(t *testing.T) {
 				t.Helper()
 				verifyStepRunContains(t, workflow, "Lint", "gofmt")
 				verifyStepRunContains(t, workflow, "Test", "-race")
+			},
+		},
+		{
+			name: "multi-line test command stays inside the block scalar",
+			configYAML: `commands:
+  lint: "go vet ./..."
+  test: |-
+    go build ./...
+    go test ./... -race
+`,
+			wantErr: false,
+			validate: func(t *testing.T, workflow map[string]interface{}) {
+				t.Helper()
+				verifyStepRunContains(t, workflow, "Test", "go build ./...")
+				verifyStepRunContains(t, workflow, "Test", "go test ./... -race")
 			},
 		},
 	}
@@ -265,7 +281,7 @@ func verifyStepRunContains(t *testing.T, workflow map[string]interface{}, stepNa
 		}
 		if name, ok := step["name"].(string); ok && name == stepName {
 			if run, ok := step["run"].(string); ok {
-				if runContains(run, expectedText) {
+				if strings.Contains(run, expectedText) {
 					return
 				}
 			}
@@ -274,13 +290,4 @@ func verifyStepRunContains(t *testing.T, workflow map[string]interface{}, stepNa
 		}
 	}
 	t.Errorf("step %q not found", stepName)
-}
-
-func runContains(haystack, needle string) bool {
-	for i := 0; i <= len(haystack)-len(needle); i++ {
-		if haystack[i:i+len(needle)] == needle {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/cli/ci_workflow_test.go
+++ b/internal/cli/ci_workflow_test.go
@@ -1,0 +1,150 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGenerateCIWorkflow(t *testing.T) {
+	tests := []struct {
+		name        string
+		configYAML  string
+		force       bool
+		wantErr     bool
+		wantContent string
+		setup       func(dir string) error
+	}{
+		{
+			name: "basic go repo with lint and test",
+			configYAML: `commands:
+  lint: "go vet ./... && gofmt -l ."
+  test: "go test ./... -race"
+`,
+			wantErr: false,
+			wantContent: "go vet ./... && gofmt -l .",
+		},
+		{
+			name: "missing lint command",
+			configYAML: `commands:
+  test: "go test ./..."
+`,
+			wantErr: true,
+		},
+		{
+			name: "missing test command",
+			configYAML: `commands:
+  lint: "go vet ./..."
+`,
+			wantErr: true,
+		},
+		{
+			name: "empty config",
+			configYAML: ``,
+			wantErr: true,
+		},
+		{
+			name: "file exists, no force",
+			configYAML: `commands:
+  lint: "go vet ./..."
+  test: "go test ./..."
+`,
+			wantErr: true,
+			setup: func(dir string) error {
+				workflowDir := filepath.Join(dir, ".github", "workflows")
+				if err := os.MkdirAll(workflowDir, 0755); err != nil {
+					return err
+				}
+				return os.WriteFile(
+					filepath.Join(workflowDir, "ci.yml"),
+					[]byte("existing"),
+					0644,
+				)
+			},
+		},
+		{
+			name: "file exists, force overwrite",
+			configYAML: `commands:
+  lint: "go vet ./..."
+  test: "go test ./... -race"
+`,
+			force:   true,
+			wantErr: false,
+			setup: func(dir string) error {
+				workflowDir := filepath.Join(dir, ".github", "workflows")
+				if err := os.MkdirAll(workflowDir, 0755); err != nil {
+					return err
+				}
+				return os.WriteFile(
+					filepath.Join(workflowDir, "ci.yml"),
+					[]byte("existing"),
+					0644,
+				)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			// Setup
+			if tt.setup != nil {
+				if err := tt.setup(dir); err != nil {
+					t.Fatalf("setup failed: %v", err)
+				}
+			}
+
+			// Write config file
+			if err := os.WriteFile(
+				filepath.Join(dir, ".no-mistakes.yaml"),
+				[]byte(tt.configYAML),
+				0644,
+			); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+
+			// Run
+			err := generateCIWorkflow(dir, tt.force)
+
+			// Check error
+			if (err != nil) != tt.wantErr {
+				t.Errorf("generateCIWorkflow() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			// Check output file exists
+			workflowPath := filepath.Join(dir, ".github", "workflows", "ci.yml")
+			content, err := os.ReadFile(workflowPath)
+			if err != nil {
+				t.Errorf("workflow file not created: %v", err)
+				return
+			}
+
+			// Check content
+			contentStr := string(content)
+			if tt.wantContent != "" && !strings.Contains(contentStr, tt.wantContent) {
+				t.Errorf("workflow content missing expected text: %q", tt.wantContent)
+			}
+
+			// Verify structure
+			if !strings.Contains(contentStr, "name: CI") {
+				t.Error("workflow missing name field")
+			}
+			if !strings.Contains(contentStr, "runs-on: ubuntu-latest") {
+				t.Error("workflow missing runs-on field")
+			}
+			if !strings.Contains(contentStr, "uses: actions/checkout@v4") {
+				t.Error("workflow missing checkout step")
+			}
+			if !strings.Contains(contentStr, "uses: actions/setup-go@v5") {
+				t.Error("workflow missing setup-go step")
+			}
+		})
+	}
+}

--- a/internal/cli/ci_workflow_test.go
+++ b/internal/cli/ci_workflow_test.go
@@ -2,12 +2,24 @@ package cli
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
 )
+
+// initGitRepo makes dir a minimal git repository so generateCIWorkflow's
+// git.FindGitRoot resolution (added to root the command at the repo
+// toplevel) succeeds against it.
+func initGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	cmd := exec.Command("git", "init", "--quiet", dir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+}
 
 func TestGenerateCIWorkflow(t *testing.T) {
 	tests := []struct {
@@ -123,6 +135,7 @@ func TestGenerateCIWorkflow(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
+			initGitRepo(t, dir)
 
 			// Setup
 			if tt.setup != nil {
@@ -173,6 +186,108 @@ func TestGenerateCIWorkflow(t *testing.T) {
 				tt.validate(t, workflow)
 			}
 		})
+	}
+}
+
+func TestGenerateCIWorkflow_RootsAtGitToplevel(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+
+	if err := os.WriteFile(
+		filepath.Join(dir, ".no-mistakes.yaml"),
+		[]byte("commands:\n  test: \"go test ./...\"\n"),
+		0644,
+	); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	subdir := filepath.Join(dir, "cmd", "sub")
+	if err := os.MkdirAll(subdir, 0755); err != nil {
+		t.Fatalf("mkdir subdir: %v", err)
+	}
+
+	// Run from a subdirectory: the workflow must land at the repo root's
+	// .github/workflows, not under the subdirectory, so GitHub discovers it.
+	if err := generateCIWorkflow(subdir, false); err != nil {
+		t.Fatalf("generateCIWorkflow() error = %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, ".github", "workflows", "ci.yml")); err != nil {
+		t.Errorf("workflow not created at repo root: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(subdir, ".github")); !os.IsNotExist(err) {
+		t.Errorf("workflow should not be created under the subdirectory, stat err = %v", err)
+	}
+}
+
+func TestGenerateCIWorkflow_RefusesSymlinkedWorkflowsDir(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+
+	outside := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".github"), 0755); err != nil {
+		t.Fatalf("mkdir .github: %v", err)
+	}
+	// A repository-controlled symlink standing in for the workflows
+	// directory must not be followed to write outside the repo.
+	if err := os.Symlink(outside, filepath.Join(dir, ".github", "workflows")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if err := os.WriteFile(
+		filepath.Join(dir, ".no-mistakes.yaml"),
+		[]byte("commands:\n  test: \"go test ./...\"\n"),
+		0644,
+	); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	err := generateCIWorkflow(dir, false)
+	if err == nil {
+		t.Fatal("generateCIWorkflow() expected error for symlinked workflows dir, got nil")
+	}
+	if _, statErr := os.Stat(filepath.Join(outside, "ci.yml")); !os.IsNotExist(statErr) {
+		t.Errorf("workflow should not have been written through the symlink, stat err = %v", statErr)
+	}
+}
+
+func TestGenerateCIWorkflow_RefusesSymlinkedWorkflowFile(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+
+	outsideFile := filepath.Join(t.TempDir(), "evil.yml")
+	if err := os.WriteFile(outsideFile, []byte("original"), 0644); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+
+	workflowDir := filepath.Join(dir, ".github", "workflows")
+	if err := os.MkdirAll(workflowDir, 0755); err != nil {
+		t.Fatalf("mkdir workflows: %v", err)
+	}
+	if err := os.Symlink(outsideFile, filepath.Join(workflowDir, "ci.yml")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if err := os.WriteFile(
+		filepath.Join(dir, ".no-mistakes.yaml"),
+		[]byte("commands:\n  test: \"go test ./...\"\n"),
+		0644,
+	); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// force=true must still refuse: overwriting the symlink destination
+	// would write attacker-chosen content to a path outside the repo.
+	err := generateCIWorkflow(dir, true)
+	if err == nil {
+		t.Fatal("generateCIWorkflow() expected error for symlinked workflow file, got nil")
+	}
+	content, readErr := os.ReadFile(outsideFile)
+	if readErr != nil {
+		t.Fatalf("read outside file: %v", readErr)
+	}
+	if string(content) != "original" {
+		t.Errorf("outside file was overwritten through the symlink: %q", content)
 	}
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -84,6 +84,7 @@ func newRootCmd() *cobra.Command {
 	cmd.Flags().StringVar(&skipValue, "skip", "", "comma-separated pipeline steps to skip for a new run")
 
 	cmd.AddCommand(newInitCmd())
+	cmd.AddCommand(newCIWorkflowCmd())
 	cmd.AddCommand(newEjectCmd())
 	cmd.AddCommand(newUpdateCmd())
 	cmd.AddCommand(newDaemonCmd())


### PR DESCRIPTION
## What Changed

- New `no-mistakes ci-workflow` subcommand (`internal/cli/ci_workflow.go`, wired into `root.go`) emits `.github/workflows/ci.yml` mirroring the `commands.test`/`commands.lint` checks pinned in `.no-mistakes.yaml`, selecting a test-only template when no lint command is configured and quoting the resolved default branch in the push trigger.
- Writes are hardened: the output path is anchored at the git toplevel regardless of the caller's subdirectory, `.github/workflows` creation refuses to follow planted symlinks, the file is written atomically, existing workflows are only overwritten with `--force`, and multi-line commands are properly indented inside YAML block scalars.
- Added `internal/cli/ci_workflow_test.go` coverage plus documentation: a `ci-workflow` entry in the CLI reference and a new `docs/ci-workflow-generation.md` design doc.

## Risk Assessment

✅ Low: A purely additive, well-tested CLI subcommand with symlink-safe atomic writes and semantic YAML assertions; the only residual issues are a one-character docs example drift and a documented best-effort branch fallback.

## Testing

Ran the focused ci-workflow unit tests under -race (all pass, including the symlink-safety and multi-line-indentation regressions), then exercised the feature end-to-end with the built binary in a scratch repo — generation, overwrite refusal, and --force overwrite all behaved as documented, and the generated workflow was validated semantically with an independent YAML parser; no visual evidence applies since this is a CLI/file-generation surface, covered instead by the transcript and generated-file artifacts.

<details>
<summary>Evidence: Generated .github/workflows/ci.yml (from end-to-end run)</summary>

```text
name: CI

on:
  push:
    branches: ['main']
  pull_request:

permissions:
  contents: read

concurrency:
  group: ci-${{ github.ref }}
  cancel-in-progress: true

jobs:
  build-test:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4

      - uses: actions/setup-go@v5
        with:
          go-version-file: go.mod
          check-latest: true

      - name: Lint
        run: |
          go vet ./... && test -z "$(gofmt -l .)"

      - name: Test
        run: |
          go build ./...
          go test ./... -race
```
</details>
<details>
<summary>Evidence: CLI transcript: generate, overwrite refusal, --force overwrite, semantic validation</summary>

<code>$ no-mistakes ci-workflow&#10;✓ CI workflow generated&#10;&lt;repo&gt;/.github/workflows/ci.yml&#10;&#10;$ no-mistakes ci-workflow # file already exists&#10;ci-workflow: &lt;repo&gt;/.github/workflows/ci.yml already exists (use --force to overwrite)&#10;(exit 1)&#10;&#10;$ no-mistakes ci-workflow --force # overwrite succeeds&#10;✓ CI workflow generated&#10;&#10;Semantic validation: Test run parses as &#39;go build ./...\ngo test ./... -race\n&#39; — multi-line command intact inside block scalar; on.push.branches == [&#39;main&#39;]</code>

```text
$ no-mistakes ci-workflow
  ✓  CI workflow generated
        <repo>/.github/workflows/ci.yml

  Commit and push this file to enable GitHub checks:
  git add .github/workflows/ci.yml && git commit -m 'ci: register workflow'

$ no-mistakes ci-workflow          # file already exists
ci-workflow: <repo>/.github/workflows/ci.yml already exists (use --force to overwrite)
(exit 1)

$ no-mistakes ci-workflow --force  # overwrite succeeds
  ✓  CI workflow generated
        <repo>/.github/workflows/ci.yml

Config used (.no-mistakes.yaml):
commands:
  lint: "go vet ./... && test -z \"$(gofmt -l .)\""
  test: |-
    go build ./...
    go test ./... -race

Semantic validation (python3 yaml.safe_load of generated file):
  jobs.build-test steps: Lint + Test
  Test run parses as: 'go build ./...\ngo test ./... -race\n'  (multi-line command intact inside block scalar)
  on.push.branches == ['main']
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"19314195035d98367e9b1fd16c522456a926e0d4","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `docs/ci-workflow-generation.md:63` - The &#34;After&#34; example shows `branches: [main]`, but commit 150dc83 (which landed after the docs example was regenerated in 5be68ab) changed the template to emit a single-quoted scalar, so real output is `branches: [&#39;main&#39;]`. Semantically equivalent YAML, but the example claims to mirror real output so users can compare their generated file against it; update the example to match.
- ℹ️ `internal/cli/ci_workflow.go:116` - git.DefaultBranch resolves the default branch via a network ls-remote to origin and silently falls back to &#34;main&#34; on any failure (offline, no origin remote, 5s timeout). In a repo whose default branch is e.g. master, an offline run reports success while emitting a push trigger that never fires. The fallback is documented in the CLI reference and the unfiltered pull_request trigger still registers checks, so this is informational; a future improvement could warn when the fallback is used or consult origin/HEAD locally.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`go test -race -run &#39;TestGenerateCIWorkflow&#39; ./internal/cli/` — all 12 tests pass, covering lint+test / test-only templates, missing-config errors, force/no-force overwrite, YAML-special characters, multi-line block-scalar indentation, git-toplevel anchoring, and symlinked dir/file refusal</code>
- <code>Manual end-to-end: built the binary, ran `no-mistakes ci-workflow` in a fresh `git init` repo with a `.no-mistakes.yaml` containing a multi-line test command; captured the CLI transcript and generated `.github/workflows/ci.yml`</code>
- <code>Manual: re-ran without `--force` (refused with exit 1 and a clear message) and with `--force` (overwrote successfully)</code>
- <code>Independent semantic validation: parsed the generated ci.yml with python3 yaml.safe_load and asserted job/step structure, `on.push.branches == [&#39;main&#39;]`, and that the multi-line Test run round-trips as `go build ./...\ngo test ./... -race\n`</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
