### PR TITLE
fix(eval): compare replay model names only

### DIFF
--- a/docs/src/content/docs/reference/eval.md
+++ b/docs/src/content/docs/reference/eval.md
@@ -116,7 +116,7 @@ no-mistakes eval run \
 
 A candidate is `agent,model=<model>[,effort=<level>]`. The fields are the same harness-neutral knobs [`agent_config`](/no-mistakes/reference/global-config/#agent_config) exposes to the pipeline, and they resolve through the same per-harness mapping, so a candidate can express exactly what a real run can. `model` is mandatory - a comparison that inherited whatever default the harness happened to resolve would not be reproducible - while `effort` is optional and one of `minimal`, `low`, `medium`, `high`, `xhigh`, `max`.
 
-When a harness reports the model it served, replay verifies that identity against the requested candidate. Provider-qualified identities are normalized across adapter reporting shapes: for example, Pi may report model `grok-4.6` and provider `xai` for a candidate requested as `xai/grok-4.6`. That is a match; a different model or provider fails the replay. Keep the provider-qualified candidate rather than reducing it to a bare-model workaround.
+When a harness reports the model it served, replay verifies the model name against the requested candidate. Only the final segment after `/` is compared; provider metadata and preceding path segments are ignored. For example, Pi may report model `grok-4.6` and provider `xai` for a candidate requested as `openai/grok-4.6`. That is a match, while a different model name fails the replay. Keep the provider-qualified candidate rather than reducing it to a bare-model workaround.
 
 Effort is part of the candidate identity, so `codex,model=gpt-5.4,effort=low` and `codex,model=gpt-5.4,effort=high` are reported as two candidates rather than collapsing into one.
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -209,8 +209,8 @@ type Result struct {
 	// against the requested candidate.
 	Model string
 	// ModelProvider is the provider that served the model (e.g. "openai",
-	// "anthropic"), when the adapter can report it. Eval replay uses it to
-	// normalize provider-qualified candidate identities.
+	// "anthropic"), when the adapter can report it. Instrumentation records it
+	// as telemetry; eval model identity matching deliberately ignores it.
 	ModelProvider string
 	// Provider is the adapter provider that served this invocation. It lets
 	// fallback wrappers persist a session against the provider that minted it.

--- a/internal/agentcfg/agentcfg.go
+++ b/internal/agentcfg/agentcfg.go
@@ -231,30 +231,20 @@ func SplitProviderModel(model string) (provider, id string, ok bool) {
 }
 
 // ServedMatchesRequested reports whether an adapter's served model is the same
-// model identity the operator requested. Identity is the model id alone - the
-// part after a provider/model spelling's final "/" - never the provider: Pi
-// commonly serves a requested model through a different provider sidecar than
-// the one named in the request (or than the one it reports alongside the
-// served model), and that must still count as a match. servedProvider is
-// accepted for call-site compatibility and error-message context only; it is
-// never compared.
+// model identity the operator requested. Identity is the final path segment of
+// the model id; provider metadata is never compared.
 func ServedMatchesRequested(requested, served, servedProvider string) bool {
-	requested = strings.TrimSpace(requested)
-	served = strings.TrimSpace(served)
-	if requested == "" || served == "" {
-		return requested == served
+	modelName := func(model string) string {
+		model = strings.TrimSpace(model)
+		if slash := strings.LastIndexByte(model, '/'); slash >= 0 {
+			model = strings.TrimSpace(model[slash+1:])
+		}
+		return model
 	}
 
-	_, reqID, requestedQualified := SplitProviderModel(requested)
-	if !requestedQualified {
-		reqID = requested
-	}
-	_, servedID, servedQualified := SplitProviderModel(served)
-	if !servedQualified {
-		servedID = served
-	}
-
-	return servedID == reqID
+	requestedName := modelName(requested)
+	servedName := modelName(served)
+	return requestedName != "" && requestedName == servedName
 }
 
 // harnesses is the whole mapping. Every native flag here was read off the

--- a/internal/agentcfg/agentcfg.go
+++ b/internal/agentcfg/agentcfg.go
@@ -231,34 +231,30 @@ func SplitProviderModel(model string) (provider, id string, ok bool) {
 }
 
 // ServedMatchesRequested reports whether an adapter's served model is the same
-// identity the operator requested. Pi reports a bare model id plus a separate
-// provider while candidates commonly use the provider/model spelling
-// (xai/grok-4.6). A different model id or provider is a mismatch, including
-// contradictory provider metadata; an empty provider cannot satisfy a
-// qualified request when the served model is bare.
+// model identity the operator requested. Identity is the model id alone - the
+// part after a provider/model spelling's final "/" - never the provider: Pi
+// commonly serves a requested model through a different provider sidecar than
+// the one named in the request (or than the one it reports alongside the
+// served model), and that must still count as a match. servedProvider is
+// accepted for call-site compatibility and error-message context only; it is
+// never compared.
 func ServedMatchesRequested(requested, served, servedProvider string) bool {
 	requested = strings.TrimSpace(requested)
 	served = strings.TrimSpace(served)
-	servedProvider = strings.TrimSpace(servedProvider)
 	if requested == "" || served == "" {
 		return requested == served
 	}
 
-	reqProvider, reqID, requestedQualified := SplitProviderModel(requested)
-	embeddedProvider, servedID, servedQualified := SplitProviderModel(served)
-	if servedQualified {
-		if servedProvider != "" && servedProvider != embeddedProvider {
-			return false
-		}
-		servedProvider = embeddedProvider
-	} else {
+	_, reqID, requestedQualified := SplitProviderModel(requested)
+	if !requestedQualified {
+		reqID = requested
+	}
+	_, servedID, servedQualified := SplitProviderModel(served)
+	if !servedQualified {
 		servedID = served
 	}
 
-	if requestedQualified {
-		return servedID == reqID && servedProvider == reqProvider
-	}
-	return servedID == requested
+	return servedID == reqID
 }
 
 // harnesses is the whole mapping. Every native flag here was read off the

--- a/internal/agentcfg/agentcfg_test.go
+++ b/internal/agentcfg/agentcfg_test.go
@@ -320,6 +320,7 @@ func TestServedMatchesRequested(t *testing.T) {
 		{name: "bare request matches qualified served id", requested: "grok-4.6", served: "xai/grok-4.6", want: true},
 		{name: "bare request matches despite contradictory provider metadata", requested: "grok-4.6", served: "xai/grok-4.6", servedProvider: "openai", want: true},
 		{name: "meta contributor model matches across provider sidecars", requested: "meta/muse-spark-1.3-contributor", served: "meta/muse-spark-1.3-contributor", servedProvider: "different-sidecar", want: true},
+		{name: "multi-segment model ids compare final segment", requested: "openrouter/meta-llama/llama-3", served: "meta-llama/llama-3", servedProvider: "openrouter", want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/agentcfg/agentcfg_test.go
+++ b/internal/agentcfg/agentcfg_test.go
@@ -313,12 +313,13 @@ func TestServedMatchesRequested(t *testing.T) {
 		{name: "bare request matches bare served", requested: "grok-4.6", served: "grok-4.6", servedProvider: "xai", want: true},
 		{name: "qualified request matches pi split fields", requested: "xai/grok-4.6", served: "grok-4.6", servedProvider: "xai", want: true},
 		{name: "true mismatch different model", requested: "xai/grok-4.6", served: "grok-4.5", servedProvider: "xai", want: false},
-		{name: "true mismatch different provider", requested: "openai/grok-4.6", served: "grok-4.6", servedProvider: "xai", want: false},
-		{name: "qualified request rejects empty provider", requested: "xai/grok-4.6", served: "grok-4.6", servedProvider: "", want: false},
+		{name: "different provider spelling with same model id still matches", requested: "openai/grok-4.6", served: "grok-4.6", servedProvider: "xai", want: true},
+		{name: "qualified request matches even with empty served provider", requested: "xai/grok-4.6", served: "grok-4.6", servedProvider: "", want: true},
 		{name: "qualified served matches qualified request", requested: "xai/grok-4.6", served: "xai/grok-4.6", want: true},
-		{name: "qualified served rejects contradictory provider metadata", requested: "xai/grok-4.6", served: "xai/grok-4.6", servedProvider: "openai", want: false},
+		{name: "qualified served matches despite contradictory provider metadata", requested: "xai/grok-4.6", served: "xai/grok-4.6", servedProvider: "openai", want: true},
 		{name: "bare request matches qualified served id", requested: "grok-4.6", served: "xai/grok-4.6", want: true},
-		{name: "bare request rejects contradictory provider metadata", requested: "grok-4.6", served: "xai/grok-4.6", servedProvider: "openai", want: false},
+		{name: "bare request matches despite contradictory provider metadata", requested: "grok-4.6", served: "xai/grok-4.6", servedProvider: "openai", want: true},
+		{name: "meta contributor model matches across provider sidecars", requested: "meta/muse-spark-1.3-contributor", served: "meta/muse-spark-1.3-contributor", servedProvider: "different-sidecar", want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/eval/replay_model_test.go
+++ b/internal/eval/replay_model_test.go
@@ -17,6 +17,10 @@ const piServedGrok46Reply = `{"type":"message_end","message":{"role":"assistant"
 {"type":"agent_end","messages":[]}
 `
 
+const piServedMuseReply = `{"type":"message_end","message":{"role":"assistant","provider":"different-sidecar","model":"meta/muse-spark-1.3-contributor","content":[{"type":"text","text":"{\"findings\":[],\"risk_level\":\"low\",\"risk_rationale\":\"clean\",\"risk_scope\":\"source-or-external\"}"}]}}
+{"type":"agent_end","messages":[]}
+`
+
 func TestReplayPiModelIdentityComparison(t *testing.T) {
 	ctx := context.Background()
 	p, sourceDB, run, _, _ := setupCapturedRun(t, ctx)
@@ -72,6 +76,43 @@ func TestReplayPiModelIdentityComparison(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReplayPiAcceptsRequestedModelWithDifferentProviderSidecar(t *testing.T) {
+	ctx := context.Background()
+	p, sourceDB, run, _, _ := setupCapturedRun(t, ctx)
+	defer sourceDB.Close()
+
+	fakeDir := t.TempDir()
+	installFakePiJSONL(t, fakeDir, piServedMuseReply)
+	t.Setenv("PATH", fakeDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	store, err := Open(p.EvalDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if _, err := Capture(ctx, store, p, sourceDB, run.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	const requested = "meta/muse-spark-1.3-contributor"
+	_, evaluations, err := Replay(ctx, store, ReplayOptions{
+		Set:       "all",
+		Candidate: Candidate{Agent: types.AgentPi, Model: requested},
+		Repeats:   1,
+	})
+	if err != nil {
+		t.Fatalf("Replay: %v (evaluations=%#v)", err, evaluations)
+	}
+	if len(evaluations) != 1 {
+		t.Fatalf("evaluations = %#v, want one persisted replay result", evaluations)
+	}
+	got := evaluations[0]
+	if got.Status != "completed" || got.Model != "meta/muse-spark-1.3-contributor" {
+		t.Fatalf("evaluation = %#v, want completed replay under the served model", got)
+	}
+	t.Logf("replay accepted requested model %q as served model %q with Pi provider sidecar %q; persisted status=%s", requested, got.Model, "different-sidecar", got.Status)
 }
 
 func installFakePiJSONL(t *testing.T, fakeDir, reply string) {


### PR DESCRIPTION
## Intent

The eval model-identity check is way too rigid. It must ONLY check the model name (the part after "/") and must not require any other metadata (provider) to match. Concretely: requesting `meta/muse-spark-1.3-contributor` while Pi serves model `meta/muse-spark-1.3-contributor` with a different provider sidecar must PASS, not fail.

## What Changed

- Match requested and served models by the final path segment only, ignoring provider metadata and preceding path segments.
- Document the relaxed identity rules and add coverage for Pi responses with differing provider sidecars.

## Risk Assessment

✅ Low: The change is narrowly scoped, implements final-segment model identity comparison, ignores provider metadata as required, and updates behavioral tests and documentation consistently.

## Testing

Targeted unit and full replay-path tests passed, including an actual fake Pi response serving `meta/muse-spark-1.3-contributor` with provider `different-sidecar`; the replay persisted `status=completed`, and the reviewer-visible transcript was saved as evidence.

<details>
<summary>Evidence: Pi model identity replay transcript</summary>

Source: [Pi model identity replay transcript](https://github.com/kunchenguid/no-mistakes/blob/ef5305075ad8cc5f400a28dd175365e2dd1f8b25/.no-mistakes/evidence/fm/nm-eval-identity-model-only-r1/pi-model-identity-replay.txt)

`replay accepted requested model "meta/muse-spark-1.3-contributor" as served model "meta/muse-spark-1.3-contributor" with Pi provider sidecar "different-sidecar"; persisted status=completed`

```text
=== RUN   TestReplayPiModelIdentityComparison
=== RUN   TestReplayPiModelIdentityComparison/bare_request
=== RUN   TestReplayPiModelIdentityComparison/qualified_request
=== RUN   TestReplayPiModelIdentityComparison/true_mismatch
--- PASS: TestReplayPiModelIdentityComparison (1.58s)
    --- PASS: TestReplayPiModelIdentityComparison/bare_request (0.49s)
    --- PASS: TestReplayPiModelIdentityComparison/qualified_request (0.17s)
    --- PASS: TestReplayPiModelIdentityComparison/true_mismatch (0.19s)
=== RUN   TestReplayPiAcceptsRequestedModelWithDifferentProviderSidecar
    replay_model_test.go:115: replay accepted requested model "meta/muse-spark-1.3-contributor" as served model "meta/muse-spark-1.3-contributor" with Pi provider sidecar "different-sidecar"; persisted status=completed
--- PASS: TestReplayPiAcceptsRequestedModelWithDifferentProviderSidecar (1.17s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/eval	3.082s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"460723b1a834487a922d6b09787f565776e9663f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `internal/agentcfg/agentcfg.go:248` - The implementation claims to compare the segment after the final slash, but SplitProviderModel splits at the first slash. A supported Pi candidate such as requested `openrouter/meta-llama/llama-3` with served model `meta-llama/llama-3` and provider sidecar `openrouter` incorrectly fails because the compared IDs become `meta-llama/llama-3` and `llama-3`. Extract the final segment consistently as required by the new identity rule.
- ⚠️ `docs/src/content/docs/reference/eval.md:119` - The eval reference still says that a different provider fails replay, directly contradicting the new provider-independent model identity behavior. Update it to state that only the model name is compared and provider metadata is ignored.

🔧 Fix: Compare model identity by final segment only
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected the target diff against `50c76c30e7c952798291f87c03838dfd0cc64a9e`.</code>
- `go test ./internal/agentcfg -run 'TestServedMatchesRequested$' -count=1`
- `go test -v ./internal/eval -run 'TestReplayPi(ModelIdentityComparison|AcceptsRequestedModelWithDifferentProviderSidecar)$' -count=1`
- <code>Captured the verbose replay transcript with `tee` and verified the persisted evaluation completed despite the differing provider sidecar.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
