### PR TITLE
fix(cli): show elapsed time for the active review round

### DIFF
--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -272,7 +272,7 @@ no-mistakes axi status
 no-mistakes axi logs --step <step> --full
 ```
 
-The `active_steps` table shows how long the step has been active, the latest activity, the native subprocess PID when one is running, and the current round such as `round 1`, `auto-fix 1/3`, or `fix 2`.
+The `active_steps` table distinguishes the whole step's `active_for` from the displayed round's `round_active_for`, then shows the latest activity, the native subprocess PID when one is running, and the current round such as `round 1`, `auto-fix 1/3`, or `fix 2`.
 The step log records native subprocess start, exit, and retry lines plus markers for automatic and user-triggered fix rounds.
 If the step is parked at a gate, use `no-mistakes axi respond` instead of waiting.
 If the run is genuinely stuck and you want to discard it, use `no-mistakes axi abort`.

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -272,7 +272,7 @@ no-mistakes axi status
 no-mistakes axi logs --step <step> --full
 ```
 
-The `active_steps` table distinguishes the whole step's `active_for` from the displayed round's `round_active_for`, then shows the latest activity, the native subprocess PID when one is running, and the current round such as `round 1`, `auto-fix 1/3`, or `fix 2`.
+See the [`axi status` reference](/no-mistakes/reference/cli/#no-mistakes-axi-status) for active-step timing, activity, PID, and round fields.
 The step log records native subprocess start, exit, and retry lines plus markers for automatic and user-triggered fix rounds.
 If the step is parked at a gate, use `no-mistakes axi respond` instead of waiting.
 If the run is genuinely stuck and you want to discard it, use `no-mistakes axi abort`.

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -104,7 +104,7 @@ With no subcommand, shows the executable path, description, repo, current branch
 When the current branch has an active run, that run appears as `active_run` with any approval gate and help for `axi respond` when it is parked or `axi status` when it is still running.
 If an active run object is parked at a decision gate, it includes `awaiting_agent: parked <duration>` immediately after `status`.
 That field is observability only; the `gate:` object still tells the agent which response to send.
-If a step is actively `running` or `fixing`, the run object can also include an `active_steps` table with `active_for`, `last_activity`, native `agent_pid` when one is currently running, and the current execution or fix round.
+If a step is actively `running` or `fixing`, the run object can also include an `active_steps` table with step-scoped `active_for`, current-round `round_active_for`, `last_activity`, native `agent_pid` when one is currently running, and the current execution or fix round.
 When only another branch has an active run, that run appears as `other_branch_active_run`; the help tells agents to leave it alone and start validation for the current branch.
 AXI help and outputs always repeat the preserve-prior-gate-progress contract: after a gate round has already produced fix commits, additional fixes belong on the same branch.
 When a relevant `branch_sync` object is present, they also include version-matched synchronization guidance to follow before a post-pipeline local commit or fresh run.
@@ -243,7 +243,8 @@ The field disappears after that run's gate is answered, on cancel, and on termin
 Status offers branch-scoped `axi respond` commands only for the current branch's implicitly resolved run. An explicitly selected gate stays inspection-only even when its branch matches, because a newer active run on that branch could receive the bare response command instead; the gate remains visible and its log commands retain `--run <id>`.
 When a repository has no configured lint command and Document performs the combined Document/Lint housekeeping invocation, the run object includes `shared_work` evidence naming its `document+lint housekeeping` scope and the duration attributed to Document; Lint's own duration remains the cached-result handoff time.
 When the resolved run has a `running` or `fixing` step, the run object includes `active_steps`.
-Each row reports how long the step has been active, the latest meaningful log or native-agent lifecycle activity, the native agent PID if one is currently running, and the current round such as `round 1`, `auto-fix 1/3`, or `fix 2`.
+Each row reports the whole step's elapsed time as `active_for`, the displayed execution or fix round's elapsed time as `round_active_for`, the latest meaningful log or native-agent lifecycle activity, the native agent PID if one is currently running, and the current round such as `round 1`, `auto-fix 1/3`, or `fix 2`.
+`round_active_for` resets when a fix round starts; older active runs created before this timing was recorded show it as empty.
 If no activity arrives for longer than `step_quiet_warning`, `last_activity` is prefixed with `quiet`; this is only a liveness signal and does not cancel the step.
 For older active runs with no recorded activity timestamp, AXI falls back to the step log file modification time.
 Gate summaries and finding descriptions are bounded in this default status view; truncated values disclose their original length, and the gate help points to `no-mistakes axi logs --step <step> --full` for an implicitly resolved run or `no-mistakes axi logs --run <id> --step <step> --full` for an explicitly selected run.

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -350,6 +350,6 @@ Each step progresses through these statuses:
 
 When a non-terminal run has a step in `awaiting_approval` or `fix_review`, AXI run objects also expose `awaiting_agent: parked <duration>` as a run-level observability signal.
 The signal clears as soon as the approval wait ends, including `axi respond` and cancellation, and does not change how gates resolve.
-When a step is `running` or `fixing`, AXI run objects expose an `active_steps` table. `active_for` is the elapsed enclosing step duration; `round_active_for` is the displayed execution or fix round duration and resets when a fix round begins. Older runs without recorded round timing leave `round_active_for` empty. The table also includes latest activity, native subprocess PID when present, and the current round such as `round 1`, `auto-fix 1/3`, or `fix 2`.
+For the `active_steps` status fields, including active-round timing and compatibility with older runs, see [`axi status`](/no-mistakes/reference/cli/#no-mistakes-axi-status).
 If the latest activity is older than `step_quiet_warning`, AXI prefixes it with `quiet` to make possible wedges visible without changing the run state.
 Step logs also record native subprocess start, exit, and retry lifecycle lines plus explicit auto-fix and user-fix round markers.

--- a/docs/src/content/docs/reference/pipeline-steps.md
+++ b/docs/src/content/docs/reference/pipeline-steps.md
@@ -350,6 +350,6 @@ Each step progresses through these statuses:
 
 When a non-terminal run has a step in `awaiting_approval` or `fix_review`, AXI run objects also expose `awaiting_agent: parked <duration>` as a run-level observability signal.
 The signal clears as soon as the approval wait ends, including `axi respond` and cancellation, and does not change how gates resolve.
-When a step is `running` or `fixing`, AXI run objects expose an `active_steps` table with active duration, latest activity, native subprocess PID when present, and the current round such as `round 1`, `auto-fix 1/3`, or `fix 2`.
+When a step is `running` or `fixing`, AXI run objects expose an `active_steps` table. `active_for` is the elapsed enclosing step duration; `round_active_for` is the displayed execution or fix round duration and resets when a fix round begins. Older runs without recorded round timing leave `round_active_for` empty. The table also includes latest activity, native subprocess PID when present, and the current round such as `round 1`, `auto-fix 1/3`, or `fix 2`.
 If the latest activity is older than `step_quiet_warning`, AXI prefixes it with `quiet` to make possible wedges visible without changing the run state.
 Step logs also record native subprocess start, exit, and retry lifecycle lines plus explicit auto-fix and user-fix round markers.

--- a/internal/cli/axi_render.go
+++ b/internal/cli/axi_render.go
@@ -48,12 +48,13 @@ type sharedWorkRow struct {
 }
 
 type activeStepRow struct {
-	Step         string `toon:"step"`
-	Status       string `toon:"status"`
-	ActiveFor    string `toon:"active_for"`
-	LastActivity string `toon:"last_activity"`
-	AgentPID     string `toon:"agent_pid"`
-	Round        string `toon:"round"`
+	Step           string `toon:"step"`
+	Status         string `toon:"status"`
+	ActiveFor      string `toon:"active_for"`
+	RoundActiveFor string `toon:"round_active_for"`
+	LastActivity   string `toon:"last_activity"`
+	AgentPID       string `toon:"agent_pid"`
+	Round          string `toon:"round"`
 }
 
 type findingRow struct {
@@ -96,6 +97,7 @@ type stepView struct {
 	FindingsJSON     string
 	FixSummaries     []string
 	StartedAt        *int64
+	RoundStartedAt   *int64
 	LastActivityAt   *int64
 	LastActivity     string
 	AgentPID         *int
@@ -149,6 +151,7 @@ func runViewFromIPC(r *ipc.RunInfo) runView {
 			Status:           string(s.Status),
 			FixSummaries:     s.FixSummaries,
 			StartedAt:        s.StartedAt,
+			RoundStartedAt:   s.RoundStartedAt,
 			LastActivityAt:   s.LastActivityAt,
 			AgentPID:         s.AgentPID,
 			RoundCount:       s.RoundCount,
@@ -189,6 +192,7 @@ func runViewFromDB(r *db.Run, steps []*db.StepResult, database *db.DB) runView {
 			Name:           string(s.StepName),
 			Status:         string(s.Status),
 			StartedAt:      s.StartedAt,
+			RoundStartedAt: s.RoundStartedAt,
 			LastActivityAt: s.LastActivityAt,
 			AgentPID:       s.AgentPID,
 		}
@@ -340,12 +344,13 @@ func (rv runView) activeRows() []activeStepRow {
 			continue
 		}
 		rows = append(rows, activeStepRow{
-			Step:         s.Name,
-			Status:       s.Status,
-			ActiveFor:    s.activeFor(),
-			LastActivity: s.lastActivitySummary(),
-			AgentPID:     s.agentPIDString(),
-			Round:        s.roundSummary(),
+			Step:           s.Name,
+			Status:         s.Status,
+			ActiveFor:      s.activeFor(),
+			RoundActiveFor: s.roundActiveFor(),
+			LastActivity:   s.lastActivitySummary(),
+			AgentPID:       s.agentPIDString(),
+			Round:          s.roundSummary(),
 		})
 	}
 	return rows
@@ -356,6 +361,13 @@ func (s stepView) activeFor() string {
 		return ""
 	}
 	return formatDurationSince(*s.StartedAt)
+}
+
+func (s stepView) roundActiveFor() string {
+	if s.RoundStartedAt == nil {
+		return ""
+	}
+	return formatDurationSince(*s.RoundStartedAt)
 }
 
 func (s stepView) lastActivitySummary() string {

--- a/internal/cli/axi_test.go
+++ b/internal/cli/axi_test.go
@@ -203,6 +203,7 @@ func TestRunObjectRendersActiveStepDiagnostics(t *testing.T) {
 	defer func() { nowUnix = restore }()
 
 	started := int64(1_000_000 - 20*60)
+	roundStarted := int64(1_000_000 - 30)
 	last := int64(1_000_000 - 11*60)
 	pid := 4242
 	rv := runView{
@@ -215,6 +216,7 @@ func TestRunObjectRendersActiveStepDiagnostics(t *testing.T) {
 				Name:             "review",
 				Status:           string(types.StepStatusFixing),
 				StartedAt:        &started,
+				RoundStartedAt:   &roundStarted,
 				LastActivityAt:   &last,
 				LastActivity:     "codex started pid=4242",
 				AgentPID:         &pid,
@@ -228,8 +230,8 @@ func TestRunObjectRendersActiveStepDiagnostics(t *testing.T) {
 	out := axiDoc(runObjectField(rv))
 
 	for _, want := range []string{
-		"active_steps[1]{step,status,active_for,last_activity,agent_pid,round}:\n",
-		"review,fixing,20m0s",
+		"active_steps[1]{step,status,active_for,round_active_for,last_activity,agent_pid,round}:\n",
+		"review,fixing,20m0s,30s",
 		"quiet 11m0s ago: codex started pid=4242",
 		`,"4242",auto-fix 1/3`,
 	} {

--- a/internal/cli/axi_test.go
+++ b/internal/cli/axi_test.go
@@ -241,6 +241,30 @@ func TestRunObjectRendersActiveStepDiagnostics(t *testing.T) {
 	}
 }
 
+func TestRunObjectRendersLegacyActiveStepWithoutRoundClock(t *testing.T) {
+	restore := nowUnix
+	nowUnix = func() int64 { return 1_000_000 }
+	defer func() { nowUnix = restore }()
+
+	started := int64(1_000_000 - 2*60)
+	rv := runView{
+		ID:      "legacy-run",
+		Branch:  "feature/legacy",
+		Status:  string(types.RunRunning),
+		HeadSHA: "abcdef1234567890",
+		Steps: []stepView{{
+			Name:      "review",
+			Status:    string(types.StepStatusRunning),
+			StartedAt: &started,
+		}},
+	}
+
+	out := axiDoc(runObjectField(rv))
+	if !strings.Contains(out, `review,running,2m0s,"",unknown,"",starting`) {
+		t.Fatalf("legacy active step should retain its step clock and leave the unavailable round clock blank:\n%s", out)
+	}
+}
+
 func TestStatusRendersCurrentAutoFixAttemptWithPersistedLimit(t *testing.T) {
 	database := openTestDB(t)
 	repo, err := database.InsertRepo(t.TempDir(), "origin", "main")

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1447,6 +1447,7 @@ func stepToInfo(d *db.DB, s *db.StepResult) ipc.StepResultInfo {
 		FindingsJSON:   s.FindingsJSON,
 		Error:          s.Error,
 		StartedAt:      s.StartedAt,
+		RoundStartedAt: s.RoundStartedAt,
 		CompletedAt:    s.CompletedAt,
 		LastActivityAt: s.LastActivityAt,
 		LastActivity:   s.LastActivity,

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -89,7 +89,7 @@ func TestOpenCreatesSchema(t *testing.T) {
 	if !hasColumn(t, d, "step_rounds", "reviewed_head_sha") {
 		t.Fatal("step_rounds.reviewed_head_sha column missing from fresh schema")
 	}
-	for _, column := range []string{"last_activity_at", "last_activity", "agent_pid", "ci_fix_attempts"} {
+	for _, column := range []string{"round_started_at", "last_activity_at", "last_activity", "agent_pid", "ci_fix_attempts"} {
 		if !hasColumn(t, d, "step_results", column) {
 			t.Fatalf("step_results.%s column missing from fresh schema", column)
 		}
@@ -446,7 +446,7 @@ func TestOpenMigratesStepActivityColumns(t *testing.T) {
 	}
 	t.Cleanup(func() { d.Close() })
 
-	for _, column := range []string{"last_activity_at", "last_activity", "agent_pid"} {
+	for _, column := range []string{"round_started_at", "last_activity_at", "last_activity", "agent_pid"} {
 		if !hasColumn(t, d, "step_results", column) {
 			t.Fatalf("expected migrated column %q", column)
 		}

--- a/internal/db/schema.go
+++ b/internal/db/schema.go
@@ -59,6 +59,7 @@ CREATE TABLE IF NOT EXISTS step_results (
     findings_json    TEXT,
     error            TEXT,
     started_at       INTEGER,
+    round_started_at INTEGER,
     completed_at     INTEGER,
     last_activity_at INTEGER,
     last_activity    TEXT,
@@ -274,6 +275,9 @@ var migrationStatements = []string{
 	// --base-branch). Nullable: absent means fall back to repo config and the
 	// forge default branch.
 	`ALTER TABLE runs ADD COLUMN pr_base_branch TEXT`,
+	// The start of the currently displayed execution/fix round is separate
+	// from started_at, which remains the whole-step clock.
+	`ALTER TABLE step_results ADD COLUMN round_started_at INTEGER`,
 	`ALTER TABLE step_results ADD COLUMN last_activity_at INTEGER`,
 	`ALTER TABLE step_results ADD COLUMN last_activity TEXT`,
 	`ALTER TABLE step_results ADD COLUMN agent_pid INTEGER`,

--- a/internal/db/step.go
+++ b/internal/db/step.go
@@ -209,10 +209,11 @@ func (d *DB) StartStepWithAutoFixLimit(id string, autoFixLimit int) error {
 }
 
 // StartStepFixRound marks the beginning of a distinct fix execution while
-// preserving started_at as the clock for the enclosing step.
-func (d *DB) StartStepFixRound(id string) error {
+// preserving started_at as the clock for the enclosing step. It also backfills
+// the effective auto-fix limit for runs started before that value was stored.
+func (d *DB) StartStepFixRound(id string, autoFixLimit int) error {
 	ts := now()
-	_, err := d.sql.Exec(`UPDATE step_results SET status = ?, round_started_at = ?, last_activity_at = ?, last_activity = ? WHERE id = ?`, types.StepStatusFixing, ts, ts, fmt.Sprintf("status: %s", types.StepStatusFixing), id)
+	_, err := d.sql.Exec(`UPDATE step_results SET status = ?, round_started_at = ?, last_activity_at = ?, last_activity = ?, auto_fix_limit = COALESCE(auto_fix_limit, ?) WHERE id = ?`, types.StepStatusFixing, ts, ts, fmt.Sprintf("status: %s", types.StepStatusFixing), autoFixLimitDBValue(autoFixLimit), id)
 	if err != nil {
 		return fmt.Errorf("start step fix round: %w", err)
 	}

--- a/internal/db/step.go
+++ b/internal/db/step.go
@@ -20,6 +20,7 @@ type StepResult struct {
 	FindingsJSON   *string
 	Error          *string
 	StartedAt      *int64
+	RoundStartedAt *int64
 	CompletedAt    *int64
 	LastActivityAt *int64
 	LastActivity   *string
@@ -40,6 +41,11 @@ const stepResultColumns = `id, run_id, step_name, step_order, status, exit_code,
 
 func (d *DB) readableStepResultColumns() string {
 	columns := stepResultColumns
+	if d.hasColumn("step_results", "round_started_at") {
+		columns += ", round_started_at"
+	} else {
+		columns += ", NULL AS round_started_at"
+	}
 	if d.hasColumn("step_results", "ci_fix_attempts") {
 		columns += ", ci_fix_attempts"
 	} else {
@@ -82,7 +88,7 @@ func (d *DB) GetStepResult(id string) (*StepResult, error) {
 	s := &StepResult{}
 	err := d.sql.QueryRow(
 		`SELECT `+d.readableStepResultColumns()+` FROM step_results WHERE id = ?`, id,
-	).Scan(&s.ID, &s.RunID, &s.StepName, &s.StepOrder, &s.Status, &s.ExitCode, &s.DurationMS, &s.LogPath, &s.FindingsJSON, &s.Error, &s.StartedAt, &s.CompletedAt, &s.LastActivityAt, &s.LastActivity, &s.AgentPID, &s.AutoFixLimit, &s.CIFixAttempts, &s.OverrideReason, &s.SkipReason)
+	).Scan(&s.ID, &s.RunID, &s.StepName, &s.StepOrder, &s.Status, &s.ExitCode, &s.DurationMS, &s.LogPath, &s.FindingsJSON, &s.Error, &s.StartedAt, &s.CompletedAt, &s.LastActivityAt, &s.LastActivity, &s.AgentPID, &s.AutoFixLimit, &s.RoundStartedAt, &s.CIFixAttempts, &s.OverrideReason, &s.SkipReason)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -104,7 +110,7 @@ func (d *DB) GetStepsByRun(runID string) ([]*StepResult, error) {
 	var steps []*StepResult
 	for rows.Next() {
 		s := &StepResult{}
-		if err := rows.Scan(&s.ID, &s.RunID, &s.StepName, &s.StepOrder, &s.Status, &s.ExitCode, &s.DurationMS, &s.LogPath, &s.FindingsJSON, &s.Error, &s.StartedAt, &s.CompletedAt, &s.LastActivityAt, &s.LastActivity, &s.AgentPID, &s.AutoFixLimit, &s.CIFixAttempts, &s.OverrideReason, &s.SkipReason); err != nil {
+		if err := rows.Scan(&s.ID, &s.RunID, &s.StepName, &s.StepOrder, &s.Status, &s.ExitCode, &s.DurationMS, &s.LogPath, &s.FindingsJSON, &s.Error, &s.StartedAt, &s.CompletedAt, &s.LastActivityAt, &s.LastActivity, &s.AgentPID, &s.AutoFixLimit, &s.RoundStartedAt, &s.CIFixAttempts, &s.OverrideReason, &s.SkipReason); err != nil {
 			return nil, fmt.Errorf("scan step result: %w", err)
 		}
 		steps = append(steps, s)
@@ -117,7 +123,7 @@ func (d *DB) ResetStepsFrom(runID string, stepOrder int) error {
 		UPDATE step_results
 		SET status = ?, exit_code = NULL, duration_ms = NULL, log_path = NULL,
 			findings_json = NULL, error = NULL, started_at = NULL,
-			completed_at = NULL, last_activity_at = NULL, last_activity = NULL,
+			round_started_at = NULL, completed_at = NULL, last_activity_at = NULL, last_activity = NULL,
 			agent_pid = NULL, auto_fix_limit = NULL
 		WHERE run_id = ? AND step_order >= ? AND status != ?`, types.StepStatusPending, runID, stepOrder, types.StepStatusSkipped)
 	if err != nil {
@@ -195,9 +201,20 @@ func (d *DB) StartStep(id string) error {
 // auto-fix limit that status surfaces use while the step is active.
 func (d *DB) StartStepWithAutoFixLimit(id string, autoFixLimit int) error {
 	ts := now()
-	_, err := d.sql.Exec(`UPDATE step_results SET status = ?, started_at = ?, last_activity_at = ?, last_activity = ?, agent_pid = NULL, auto_fix_limit = ? WHERE id = ?`, types.StepStatusRunning, ts, ts, "step started", autoFixLimitDBValue(autoFixLimit), id)
+	_, err := d.sql.Exec(`UPDATE step_results SET status = ?, started_at = ?, round_started_at = ?, last_activity_at = ?, last_activity = ?, agent_pid = NULL, auto_fix_limit = ? WHERE id = ?`, types.StepStatusRunning, ts, ts, ts, "step started", autoFixLimitDBValue(autoFixLimit), id)
 	if err != nil {
 		return fmt.Errorf("start step: %w", err)
+	}
+	return nil
+}
+
+// StartStepFixRound marks the beginning of a distinct fix execution while
+// preserving started_at as the clock for the enclosing step.
+func (d *DB) StartStepFixRound(id string) error {
+	ts := now()
+	_, err := d.sql.Exec(`UPDATE step_results SET status = ?, round_started_at = ?, last_activity_at = ?, last_activity = ? WHERE id = ?`, types.StepStatusFixing, ts, ts, fmt.Sprintf("status: %s", types.StepStatusFixing), id)
+	if err != nil {
+		return fmt.Errorf("start step fix round: %w", err)
 	}
 	return nil
 }

--- a/internal/db/step.go
+++ b/internal/db/step.go
@@ -209,11 +209,12 @@ func (d *DB) StartStepWithAutoFixLimit(id string, autoFixLimit int) error {
 }
 
 // StartStepFixRound marks the beginning of a distinct fix execution while
-// preserving started_at as the clock for the enclosing step. It also backfills
-// the effective auto-fix limit for runs started before that value was stored.
+// preserving started_at as the clock for the enclosing step. Recovery can use
+// a newly loaded trusted configuration, so its supplied limit replaces the
+// one recorded by an earlier execution.
 func (d *DB) StartStepFixRound(id string, autoFixLimit int) error {
 	ts := now()
-	_, err := d.sql.Exec(`UPDATE step_results SET status = ?, round_started_at = ?, last_activity_at = ?, last_activity = ?, auto_fix_limit = COALESCE(auto_fix_limit, ?) WHERE id = ?`, types.StepStatusFixing, ts, ts, fmt.Sprintf("status: %s", types.StepStatusFixing), autoFixLimitDBValue(autoFixLimit), id)
+	_, err := d.sql.Exec(`UPDATE step_results SET status = ?, round_started_at = ?, last_activity_at = ?, last_activity = ?, auto_fix_limit = ? WHERE id = ?`, types.StepStatusFixing, ts, ts, fmt.Sprintf("status: %s", types.StepStatusFixing), autoFixLimitDBValue(autoFixLimit), id)
 	if err != nil {
 		return fmt.Errorf("start step fix round: %w", err)
 	}

--- a/internal/db/step_test.go
+++ b/internal/db/step_test.go
@@ -182,7 +182,7 @@ func TestStartStepFixRoundResetsOnlyRoundClock(t *testing.T) {
 	if _, err := d.sql.Exec(`UPDATE step_results SET started_at = ?, round_started_at = ? WHERE id = ?`, stepStarted, stepStarted, step.ID); err != nil {
 		t.Fatal(err)
 	}
-	if err := d.StartStepFixRound(step.ID); err != nil {
+	if err := d.StartStepFixRound(step.ID, 2); err != nil {
 		t.Fatalf("start fix round: %v", err)
 	}
 	got, err := d.GetStepResult(step.ID)
@@ -197,6 +197,9 @@ func TestStartStepFixRoundResetsOnlyRoundClock(t *testing.T) {
 	}
 	if got.RoundStartedAt == nil || *got.RoundStartedAt == stepStarted {
 		t.Errorf("round_started_at = %v, want reset", got.RoundStartedAt)
+	}
+	if got.AutoFixLimit == nil || *got.AutoFixLimit != 2 {
+		t.Errorf("auto-fix limit = %v, want 2", got.AutoFixLimit)
 	}
 }
 

--- a/internal/db/step_test.go
+++ b/internal/db/step_test.go
@@ -172,14 +172,15 @@ func TestStartStep(t *testing.T) {
 	}
 }
 
-func TestStartStepFixRoundResetsOnlyRoundClock(t *testing.T) {
+func TestStartStepFixRoundResetsRoundClockAndUpdatesLimit(t *testing.T) {
 	d := openTestDB(t)
 	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")
 	run, _ := d.InsertRun(repo.ID, "feature", "abc", "def")
 	step, _ := d.InsertStepResult(run.ID, types.StepReview)
 
 	const stepStarted = int64(123)
-	if _, err := d.sql.Exec(`UPDATE step_results SET started_at = ?, round_started_at = ? WHERE id = ?`, stepStarted, stepStarted, step.ID); err != nil {
+	const priorAutoFixLimit = 1
+	if _, err := d.sql.Exec(`UPDATE step_results SET started_at = ?, round_started_at = ?, auto_fix_limit = ? WHERE id = ?`, stepStarted, stepStarted, priorAutoFixLimit, step.ID); err != nil {
 		t.Fatal(err)
 	}
 	if err := d.StartStepFixRound(step.ID, 2); err != nil {
@@ -199,7 +200,7 @@ func TestStartStepFixRoundResetsOnlyRoundClock(t *testing.T) {
 		t.Errorf("round_started_at = %v, want reset", got.RoundStartedAt)
 	}
 	if got.AutoFixLimit == nil || *got.AutoFixLimit != 2 {
-		t.Errorf("auto-fix limit = %v, want 2", got.AutoFixLimit)
+		t.Errorf("auto-fix limit = %v, want newly configured 2 instead of prior %d", got.AutoFixLimit, priorAutoFixLimit)
 	}
 }
 

--- a/internal/db/step_test.go
+++ b/internal/db/step_test.go
@@ -161,11 +161,42 @@ func TestStartStep(t *testing.T) {
 	if got.StartedAt == nil {
 		t.Error("expected non-nil started_at")
 	}
+	if got.RoundStartedAt == nil {
+		t.Error("expected non-nil round_started_at")
+	}
 	if got.LastActivityAt == nil {
 		t.Error("expected non-nil last_activity_at")
 	}
 	if got.LastActivity == nil || *got.LastActivity != "step started" {
 		t.Errorf("last_activity = %v, want step started", got.LastActivity)
+	}
+}
+
+func TestStartStepFixRoundResetsOnlyRoundClock(t *testing.T) {
+	d := openTestDB(t)
+	repo, _ := d.InsertRepo("/home/user/project", "git@github.com:user/project.git", "main")
+	run, _ := d.InsertRun(repo.ID, "feature", "abc", "def")
+	step, _ := d.InsertStepResult(run.ID, types.StepReview)
+
+	const stepStarted = int64(123)
+	if _, err := d.sql.Exec(`UPDATE step_results SET started_at = ?, round_started_at = ? WHERE id = ?`, stepStarted, stepStarted, step.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.StartStepFixRound(step.ID); err != nil {
+		t.Fatalf("start fix round: %v", err)
+	}
+	got, err := d.GetStepResult(step.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != types.StepStatusFixing {
+		t.Errorf("status = %q, want %q", got.Status, types.StepStatusFixing)
+	}
+	if got.StartedAt == nil || *got.StartedAt != stepStarted {
+		t.Errorf("started_at = %v, want preserved %d", got.StartedAt, stepStarted)
+	}
+	if got.RoundStartedAt == nil || *got.RoundStartedAt == stepStarted {
+		t.Errorf("round_started_at = %v, want reset", got.RoundStartedAt)
 	}
 }
 

--- a/internal/ipc/protocol.go
+++ b/internal/ipc/protocol.go
@@ -372,6 +372,7 @@ type StepResultInfo struct {
 	PendingFixSource string   `json:"pending_fix_source,omitempty"`
 	Error            *string  `json:"error,omitempty"`
 	StartedAt        *int64   `json:"started_at,omitempty"`
+	RoundStartedAt   *int64   `json:"round_started_at,omitempty"`
 	CompletedAt      *int64   `json:"completed_at,omitempty"`
 	LastActivityAt   *int64   `json:"last_activity_at,omitempty"`
 	LastActivity     *string  `json:"last_activity,omitempty"`

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -510,7 +510,7 @@ func (e *Executor) Resume(ctx context.Context, run *db.Run, repo *db.Repo, workD
 				}
 			}
 		}
-		if dbErr := e.db.UpdateStepStatus(gate.stepResult.ID, types.StepStatusFixing); dbErr != nil {
+		if dbErr := e.db.StartStepFixRound(gate.stepResult.ID); dbErr != nil {
 			return e.failRun(run, repo, fmt.Errorf("mark recovered step %s fixing: %w", gate.step.Name(), dbErr), ctx)
 		}
 		e.emitStepEventWithFindingsAndError(ipc.EventStepCompleted, run, repo, gate.step.Name(), string(types.StepStatusFixing), "", "", nil)
@@ -978,8 +978,8 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 				executionMS += time.Since(phaseStart).Milliseconds()
 				fixCount := findingsCount(fixableFindings)
 				writeLog(fmt.Sprintf("auto-fix round %d/%d starting after round %d (%d %s)", autoFixAttempts, autoFixLimit, roundNum, fixCount, pluralize(fixCount, "finding", "findings")))
-				if dbErr := e.db.UpdateStepStatus(sr.ID, types.StepStatusFixing); dbErr != nil {
-					slog.Warn("failed to update step status in db", "step", stepName, "status", "fixing", "error", dbErr)
+				if dbErr := e.db.StartStepFixRound(sr.ID); dbErr != nil {
+					slog.Warn("failed to start step fix round in db", "step", stepName, "error", dbErr)
 				}
 				if currentRoundID != "" {
 					if idsJSON := findingIDsJSON(fixableFindings); idsJSON != "" {
@@ -1111,8 +1111,8 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			phaseStart = time.Now()
 			selectedCount := selectedFindingCount(outcome.Findings, response.findingIDs)
 			writeLog(fmt.Sprintf("user-fix round starting after round %d (%d %s selected)", roundNum, selectedCount, pluralize(selectedCount, "finding", "findings")))
-			if dbErr := e.db.UpdateStepStatus(sr.ID, types.StepStatusFixing); dbErr != nil {
-				slog.Warn("failed to update step status in db", "step", stepName, "status", "fixing", "error", dbErr)
+			if dbErr := e.db.StartStepFixRound(sr.ID); dbErr != nil {
+				slog.Warn("failed to start step fix round in db", "step", stepName, "error", dbErr)
 			}
 			sctx.Fixing = true
 			selectedFindings := filterFindingsJSON(outcome.Findings, response.findingIDs)

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -510,7 +510,7 @@ func (e *Executor) Resume(ctx context.Context, run *db.Run, repo *db.Repo, workD
 				}
 			}
 		}
-		if dbErr := e.db.StartStepFixRound(gate.stepResult.ID); dbErr != nil {
+		if dbErr := e.db.StartStepFixRound(gate.stepResult.ID, e.autoFixLimit(gate.step.Name())); dbErr != nil {
 			return e.failRun(run, repo, fmt.Errorf("mark recovered step %s fixing: %w", gate.step.Name(), dbErr), ctx)
 		}
 		e.emitStepEventWithFindingsAndError(ipc.EventStepCompleted, run, repo, gate.step.Name(), string(types.StepStatusFixing), "", "", nil)
@@ -692,6 +692,13 @@ func recoveredLogPath(step *db.StepResult) string {
 	return ""
 }
 
+func (e *Executor) autoFixLimit(stepName types.StepName) int {
+	if e.config == nil {
+		return 0
+	}
+	return e.config.AutoFixLimit(stepName)
+}
+
 // executeStep runs a single step with approval coordination.
 // Returns whether to skip the remainder, an optional earlier restart step,
 // and any execution error.
@@ -699,10 +706,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 	stepName := step.Name()
 	logPath := filepath.Join(logDir, string(stepName)+".log")
 	finalExitCode := 0
-	autoFixLimit := 0
-	if e.config != nil {
-		autoFixLimit = e.config.AutoFixLimit(stepName)
-	}
+	autoFixLimit := e.autoFixLimit(stepName)
 
 	if !state.fixing {
 		if err := e.db.StartStepWithAutoFixLimit(sr.ID, autoFixLimit); err != nil {
@@ -979,7 +983,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 				executionMS += time.Since(phaseStart).Milliseconds()
 				fixCount := findingsCount(fixableFindings)
 				writeLog(fmt.Sprintf("auto-fix round %d/%d starting after round %d (%d %s)", autoFixAttempts, autoFixLimit, roundNum, fixCount, pluralize(fixCount, "finding", "findings")))
-				if dbErr := e.db.StartStepFixRound(sr.ID); dbErr != nil {
+				if dbErr := e.db.StartStepFixRound(sr.ID, autoFixLimit); dbErr != nil {
 					slog.Warn("failed to start step fix round in db", "step", stepName, "error", dbErr)
 				}
 				if currentRoundID != "" {
@@ -1112,7 +1116,7 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 			phaseStart = time.Now()
 			selectedCount := selectedFindingCount(outcome.Findings, response.findingIDs)
 			writeLog(fmt.Sprintf("user-fix round starting after round %d (%d %s selected)", roundNum, selectedCount, pluralize(selectedCount, "finding", "findings")))
-			if dbErr := e.db.StartStepFixRound(sr.ID); dbErr != nil {
+			if dbErr := e.db.StartStepFixRound(sr.ID, autoFixLimit); dbErr != nil {
 				slog.Warn("failed to start step fix round in db", "step", stepName, "error", dbErr)
 			}
 			sctx.Fixing = true

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -704,11 +704,12 @@ func (e *Executor) executeStep(ctx context.Context, step Step, sr *db.StepResult
 		autoFixLimit = e.config.AutoFixLimit(stepName)
 	}
 
-	// Mark step as running
-	if err := e.db.StartStepWithAutoFixLimit(sr.ID, autoFixLimit); err != nil {
-		return false, "", fmt.Errorf("start step %s: %w", stepName, err)
+	if !state.fixing {
+		if err := e.db.StartStepWithAutoFixLimit(sr.ID, autoFixLimit); err != nil {
+			return false, "", fmt.Errorf("start step %s: %w", stepName, err)
+		}
+		e.emitStepEvent(ipc.EventStepStarted, run, repo, stepName, string(types.StepStatusRunning))
 	}
-	e.emitStepEvent(ipc.EventStepStarted, run, repo, stepName, string(types.StepStatusRunning))
 
 	// Track execution-only time, excluding approval wait periods.
 	phaseStart := time.Now()

--- a/internal/pipeline/executor_approval_test.go
+++ b/internal/pipeline/executor_approval_test.go
@@ -135,6 +135,11 @@ func TestExecutor_ResumeRestoresParkedGateAndReviewSessions(t *testing.T) {
 	if err := database.StartStep(stepResult.ID); err != nil {
 		t.Fatal(err)
 	}
+	initial, err := database.GetStepResult(stepResult.ID)
+	if err != nil || initial == nil || initial.StartedAt == nil {
+		t.Fatalf("read initial step timing: step=%+v err=%v", initial, err)
+	}
+	initialStartedAt := *initial.StartedAt
 	findings := `{"findings":[{"id":"review-1","severity":"warning","description":"needs a fix","action":"ask-user"}],"summary":"one issue"}`
 	if err := database.SetStepFindings(stepResult.ID, findings); err != nil {
 		t.Fatal(err)
@@ -160,12 +165,16 @@ func TestExecutor_ResumeRestoresParkedGateAndReviewSessions(t *testing.T) {
 	}
 
 	fake := newFakeSessionAgent()
+	fixStarted := make(chan struct{})
+	releaseFix := make(chan struct{})
 	step := &adaptiveCallStep{
 		name: types.StepReview,
 		fn: func(sctx *StepContext) (*StepOutcome, error) {
 			if !sctx.Fixing {
 				return nil, fmt.Errorf("recovered gate must not rerun its completed review pass")
 			}
+			close(fixStarted)
+			<-releaseFix
 			if _, err := sctx.RunAgentSession(SessionRoleFixer, agent.RunOpts{Prompt: "fix"}); err != nil {
 				return nil, err
 			}
@@ -179,6 +188,25 @@ func TestExecutor_ResumeRestoresParkedGateAndReviewSessions(t *testing.T) {
 	}
 	exec := NewExecutor(database, p, &config.Config{SessionReuse: true}, fake, []Step{step}, nil)
 	done := make(chan error, 1)
+	released := false
+	defer func() {
+		if !released {
+			close(releaseFix)
+		}
+		select {
+		case err := <-done:
+			if err != nil && !t.Failed() {
+				t.Errorf("resume: %v", err)
+			}
+		case <-time.After(5 * time.Second):
+			if !t.Failed() {
+				t.Error("recovered executor timed out")
+			}
+		}
+	}()
+	for time.Now().Unix() <= initialStartedAt {
+		time.Sleep(10 * time.Millisecond)
+	}
 	go func() {
 		done <- exec.Resume(context.Background(), run, repo, t.TempDir())
 	}()
@@ -195,13 +223,25 @@ func TestExecutor_ResumeRestoresParkedGateAndReviewSessions(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	select {
-	case err := <-done:
-		if err != nil {
-			t.Fatalf("resume: %v", err)
-		}
+	case <-fixStarted:
 	case <-time.After(5 * time.Second):
-		t.Fatal("recovered executor timed out")
+		t.Fatal("recovered fix did not start")
 	}
+	fixing, err := database.GetStepResult(stepResult.ID)
+	if err != nil || fixing == nil {
+		t.Fatalf("read recovered fixing step: step=%+v err=%v", fixing, err)
+	}
+	if fixing.Status != types.StepStatusFixing {
+		t.Errorf("recovered fixing step status = %s, want %s", fixing.Status, types.StepStatusFixing)
+	}
+	if fixing.StartedAt == nil || *fixing.StartedAt != initialStartedAt {
+		t.Errorf("recovered fixing step started_at = %v, want preserved %d", fixing.StartedAt, initialStartedAt)
+	}
+	if fixing.RoundStartedAt == nil || *fixing.RoundStartedAt <= initialStartedAt {
+		t.Errorf("recovered fixing round_started_at = %v, want after %d", fixing.RoundStartedAt, initialStartedAt)
+	}
+	close(releaseFix)
+	released = true
 
 	if len(fake.calls) != 2 {
 		t.Fatalf("agent invocations = %d, want fixer and rereviewer", len(fake.calls))

--- a/internal/pipeline/executor_approval_test.go
+++ b/internal/pipeline/executor_approval_test.go
@@ -186,7 +186,10 @@ func TestExecutor_ResumeRestoresParkedGateAndReviewSessions(t *testing.T) {
 			return &StepOutcome{ReviewApprovedHeadSHA: "2222222222222222222222222222222222222222"}, nil
 		},
 	}
-	exec := NewExecutor(database, p, &config.Config{SessionReuse: true}, fake, []Step{step}, nil)
+	exec := NewExecutor(database, p, &config.Config{
+		SessionReuse: true,
+		AutoFix:      config.AutoFix{Review: 2},
+	}, fake, []Step{step}, nil)
 	done := make(chan error, 1)
 	released := false
 	finished := false
@@ -243,6 +246,9 @@ func TestExecutor_ResumeRestoresParkedGateAndReviewSessions(t *testing.T) {
 	}
 	if fixing.RoundStartedAt == nil || *fixing.RoundStartedAt <= initialStartedAt {
 		t.Errorf("recovered fixing round_started_at = %v, want after %d", fixing.RoundStartedAt, initialStartedAt)
+	}
+	if fixing.AutoFixLimit == nil || *fixing.AutoFixLimit != 2 {
+		t.Errorf("recovered fixing auto-fix limit = %v, want 2", fixing.AutoFixLimit)
 	}
 	close(releaseFix)
 	released = true

--- a/internal/pipeline/executor_approval_test.go
+++ b/internal/pipeline/executor_approval_test.go
@@ -189,9 +189,13 @@ func TestExecutor_ResumeRestoresParkedGateAndReviewSessions(t *testing.T) {
 	exec := NewExecutor(database, p, &config.Config{SessionReuse: true}, fake, []Step{step}, nil)
 	done := make(chan error, 1)
 	released := false
+	finished := false
 	defer func() {
 		if !released {
 			close(releaseFix)
+		}
+		if finished {
+			return
 		}
 		select {
 		case err := <-done:
@@ -242,6 +246,15 @@ func TestExecutor_ResumeRestoresParkedGateAndReviewSessions(t *testing.T) {
 	}
 	close(releaseFix)
 	released = true
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("resume: %v", err)
+		}
+		finished = true
+	case <-time.After(5 * time.Second):
+		t.Fatal("recovered executor timed out")
+	}
 
 	if len(fake.calls) != 2 {
 		t.Fatalf("agent invocations = %d, want fixer and rereviewer", len(fake.calls))

--- a/internal/pipeline/executor_fix_test.go
+++ b/internal/pipeline/executor_fix_test.go
@@ -112,11 +112,33 @@ func TestExecutor_FixEmitsFixingStatusImmediately(t *testing.T) {
 	}()
 
 	waitForStepStatus(t, database, run.ID, types.StepReview, types.StepStatusAwaitingApproval)
+	beforeFix, err := database.GetStepsByRun(run.ID)
+	if err != nil || len(beforeFix) != 1 || beforeFix[0].RoundStartedAt == nil {
+		t.Fatalf("read initial round start: steps=%+v err=%v", beforeFix, err)
+	}
+	initialRoundStartedAt := *beforeFix[0].RoundStartedAt
+	// DB clocks use whole seconds. Cross the next tick so this regression can
+	// prove the fix transition resets the round clock rather than retaining the
+	// enclosing step's start.
+	for time.Now().Unix() <= initialRoundStartedAt {
+		time.Sleep(10 * time.Millisecond)
+	}
 	if err := exec.Respond(types.StepReview, types.ActionFix, nil); err != nil {
 		t.Fatal(err)
 	}
 
 	waitForStepStatus(t, database, run.ID, types.StepReview, types.StepStatusFixing)
+	fixing, err := database.GetStepsByRun(run.ID)
+	if err != nil || len(fixing) != 1 || fixing[0].RoundStartedAt == nil {
+		close(releaseFix)
+		<-done
+		t.Fatalf("read fix round start: steps=%+v err=%v", fixing, err)
+	}
+	if *fixing[0].RoundStartedAt <= initialRoundStartedAt {
+		close(releaseFix)
+		<-done
+		t.Fatalf("fix round start = %d, want after initial round start %d", *fixing[0].RoundStartedAt, initialRoundStartedAt)
+	}
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -164,8 +164,8 @@ Run the pipeline and decide on its findings as they come up:
    send ` + "`axi respond`" + `. The field is observability only: it does not change
    gate resolution, auto-resume the run, or make ` + "`--yes`" + ` the default.
    While a step is actively ` + "`running`" + ` or ` + "`fixing`" + `, ` + "`axi status`" + ` may include
-   ` + "`active_steps`" + ` with ` + "`active_for`" + `, ` + "`last_activity`" + `, a native ` + "`agent_pid`" + ` when
-   a subprocess agent is running, and the current round such as ` + "`round 1`" + `,
+   ` + "`active_steps`" + ` with step-scoped ` + "`active_for`" + `, current-round ` + "`round_active_for`" + `,
+   ` + "`last_activity`" + `, a native ` + "`agent_pid`" + ` when a subprocess agent is running, and the current round such as ` + "`round 1`" + `,
    ` + "`auto-fix 1/3`" + `, or ` + "`fix 2`" + `. If ` + "`last_activity`" + ` is prefixed with
    ` + "`quiet`" + `, no step log or native-agent lifecycle activity has arrived for
    longer than ` + "`step_quiet_warning`" + `. Treat that as a liveness clue, not as
@@ -348,7 +348,7 @@ no-mistakes axi abort --run <id>   # cancel a specific run by id (works outside 
 - Output is TOON: ` + "`key: value`" + ` pairs, ` + "`name[N]{cols}:`" + ` tables, and ` + "`help[N]:`" + ` hints.
 - ` + "`axi status`" + ` is scoped to your current branch when ` + "`--run`" + ` is omitted: with a known current branch, an implicitly resolved ` + "`run:`" + ` is this branch's. A run under ` + "`other_branch_run:`" + ` is one you named with ` + "`--run <id>`" + ` that belongs to another branch - never read its status or outcome as your own work. An explicit ` + "`--run <id>`" + ` rendered under ` + "`run:`" + ` while the current branch is unknown (detached ` + "`HEAD`" + ` or a branch-lookup failure) encodes no branch relationship. In a successful status response, no run object at all means this branch has no run yet, whatever the recent-runs table lists; an ` + "`error:`" + ` response proves nothing about run ownership, so act on the error instead of concluding the branch is idle.
 - A non-terminal run object may include ` + "`awaiting_agent: parked <duration>`" + ` immediately after ` + "`status`" + `; that means the run is parked at a gate. Only an implicitly resolved current-branch gate offers ` + "`axi respond`" + `; an explicit ` + "`--run <id>`" + ` status is inspection-only even when its branch matches, because the branch may have a newer active run. Follow the response's ` + "`help`" + `.
-- A run object with a ` + "`running`" + ` or ` + "`fixing`" + ` step may include an ` + "`active_steps`" + ` table. Use it to see the active duration, latest activity, native agent PID, and current execution or fix round.
+- A run object with a ` + "`running`" + ` or ` + "`fixing`" + ` step may include an ` + "`active_steps`" + ` table. ` + "`active_for`" + ` is the enclosing step duration; ` + "`round_active_for`" + ` is the displayed execution or fix round duration and resets for a fix round. Older runs without round timing leave ` + "`round_active_for`" + ` empty.
 - The ` + "`help`" + ` list at the bottom of most responses tells you the next commands to run.
 - Errors are printed as ` + "`error: ...`" + ` on stdout with a ` + "`help`" + ` list; act on the suggestion.
 - Exit codes: ` + "`0`" + ` success, no-op, or normal decision gates, ` + "`1`" + ` failed or cancelled final outcomes, ` + "`2`" + ` bad usage.

--- a/skills/no-mistakes/SKILL.md
+++ b/skills/no-mistakes/SKILL.md
@@ -164,8 +164,8 @@ Run the pipeline and decide on its findings as they come up:
    send `axi respond`. The field is observability only: it does not change
    gate resolution, auto-resume the run, or make `--yes` the default.
    While a step is actively `running` or `fixing`, `axi status` may include
-   `active_steps` with `active_for`, `last_activity`, a native `agent_pid` when
-   a subprocess agent is running, and the current round such as `round 1`,
+   `active_steps` with step-scoped `active_for`, current-round `round_active_for`,
+   `last_activity`, a native `agent_pid` when a subprocess agent is running, and the current round such as `round 1`,
    `auto-fix 1/3`, or `fix 2`. If `last_activity` is prefixed with
    `quiet`, no step log or native-agent lifecycle activity has arrived for
    longer than `step_quiet_warning`. Treat that as a liveness clue, not as
@@ -348,7 +348,7 @@ no-mistakes axi abort --run <id>   # cancel a specific run by id (works outside 
 - Output is TOON: `key: value` pairs, `name[N]{cols}:` tables, and `help[N]:` hints.
 - `axi status` is scoped to your current branch when `--run` is omitted: with a known current branch, an implicitly resolved `run:` is this branch's. A run under `other_branch_run:` is one you named with `--run <id>` that belongs to another branch - never read its status or outcome as your own work. An explicit `--run <id>` rendered under `run:` while the current branch is unknown (detached `HEAD` or a branch-lookup failure) encodes no branch relationship. In a successful status response, no run object at all means this branch has no run yet, whatever the recent-runs table lists; an `error:` response proves nothing about run ownership, so act on the error instead of concluding the branch is idle.
 - A non-terminal run object may include `awaiting_agent: parked <duration>` immediately after `status`; that means the run is parked at a gate. Only an implicitly resolved current-branch gate offers `axi respond`; an explicit `--run <id>` status is inspection-only even when its branch matches, because the branch may have a newer active run. Follow the response's `help`.
-- A run object with a `running` or `fixing` step may include an `active_steps` table. Use it to see the active duration, latest activity, native agent PID, and current execution or fix round.
+- A run object with a `running` or `fixing` step may include an `active_steps` table. `active_for` is the enclosing step duration; `round_active_for` is the displayed execution or fix round duration and resets for a fix round. Older runs without round timing leave `round_active_for` empty.
 - The `help` list at the bottom of most responses tells you the next commands to run.
 - Errors are printed as `error: ...` on stdout with a `help` list; act on the suggestion.
 - Exit codes: `0` success, no-op, or normal decision gates, `1` failed or cancelled final outcomes, `2` bad usage.


### PR DESCRIPTION
## Intent

Implement issue #914: make AXI status distinguish the elapsed time of the currently displayed Review execution or fix round from the total enclosing step duration. Preserve the existing step-scoped active_for contract for compatibility, add a companion round_active_for that resets when each fix round begins, persist and expose that timing across database and daemon IPC status paths, retain safe behavior for older runs without round timing, and update behavioral tests and operator documentation.

## What Changed

- Added persistent per-round start timestamps and expose them through daemon IPC while preserving the existing step-wide `active_for` clock.
- Reset round timing whenever review or fix execution begins, including recovered approval flows.
- Render `round_active_for` in AXI status and document its behavior, including empty output for older runs without recorded round timing.

## Risk Assessment

✅ Low: The bounded timing change preserves step-scoped active_for, resets the nullable round clock on live and recovered fix transitions, and exposes it through DB and IPC status rendering with a legacy-safe empty fallback.

## Testing

The host lacked `go` on PATH, so focused tests ran in an existing Go container. Database persistence, CLI rendering including legacy null round timing, live fix-round transition, and daemon-restart resume behavior all passed after the test synchronization correction; the captured AXI transcript shows the 20-minute enclosing Review clock separately from the 31-second fix-round clock.

<details>
<summary>Evidence: AXI status transcript</summary>

Source: AXI status transcript (local file: <code>~\.no-mistakes\evidence\01M1X68DMNM1FG2NAACJAZNQEG\axi-status-round-active-for.toon</code>)

```text
active_steps[1]{step,status,active_for,round_active_for,last_activity,agent_pid,round}:
review,fixing,20m1s,31s,"6s ago: fix round executing","",fixing
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"de962b4996081b097fa7b8532a6c534e67ccb78c","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `internal/pipeline/executor.go:513` - After a daemon restart, a user Fix response calls `StartStepFixRound`, but the immediately-following `executeStep` unconditionally calls `StartStepWithAutoFixLimit` and overwrites both `started_at` and `round_started_at`. Thus AXI reports `active_for` from the post-restart fix instead of the enclosing Review step, violating the required step-scoped compatibility contract. Preserve `started_at` when resuming an already-started fixing step.

🔧 Fix: Preserve recovered fix-round step timing
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`go test ./internal/db -run &#39;Test(StartStepFixRoundResetsOnlyRoundClock|OpenMigratesStepResultActivityColumns)&#39; -count=1` (via preinstalled `golang:1.25` container)</code>
- <code>`go test ./internal/cli -run &#39;TestRunObjectRenders(ActiveStepDiagnostics|LegacyActiveStepWithoutRoundClock)&#39; -count=1` (container)</code>
- <code>`go test ./internal/pipeline -run &#39;TestExecutor_(FixEmitsFixingStatusImmediately|ResumeRestoresParkedGateAndReviewSessions)&#39; -count=1` (container)</code>
- <code>Built the CLI, seeded a disposable evidence-only SQLite run, and ran `no-mistakes axi status --run run-914` to capture the rendered status contract.</code>
</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `skills/no-mistakes/SKILL.md:167` - The generated skill remains stale because this environment has neither `make` nor `go`; run `make skill` in a Go-equipped environment to regenerate it from the updated source.

🔧 Fix: Regenerate round timing guidance
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Lint** - 1 warning</summary>

- ⚠️ linter found issues (exit code 1)
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
