### PR TITLE
fix: publish update channels after automated releases

### DIFF
--- a/.github/workflows/publish-channels.yml
+++ b/.github/workflows/publish-channels.yml
@@ -1,8 +1,16 @@
 name: publish-channels
 
 # Refreshes channels.json when a GitHub release is published or edited
-# (including a manual promote-to-latest) and on workflow_dispatch.
+# (including a manual promote-to-latest), on workflow_dispatch, and when the
+# release pipeline calls this workflow after finalize.
+#
+# workflow_call is the release-please path: GitHub does not cascade
+# GITHUB_TOKEN-triggered release events into other workflows, so on: release
+# never fires for those (pre)releases. workflow_dispatch and on: release stay
+# as backstops for a human- or PAT-published/edited release. Double-firing is
+# safe (idempotent rebuild; concurrency group serializes overlapping runs).
 on:
+  workflow_call:
   workflow_dispatch:
   release:
     types:
@@ -20,11 +28,11 @@ concurrency:
 jobs:
   publish-channels:
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event.release.tag_name != 'channels'
+    if: github.event_name != 'release' || github.event.release.tag_name != 'channels'
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.event.repository.default_branch || github.ref }}
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod

--- a/.github/workflows/publish-channels.yml
+++ b/.github/workflows/publish-channels.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.repository.default_branch || github.ref }}
+          ref: ${{ github.event.repository.default_branch }}
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,3 +345,20 @@ jobs:
           GH_REPO: ${{ github.repository }}
           TAG: ${{ needs.release-please.outputs.tag_name }}
         run: gh release edit "$TAG" --draft=false --prerelease=true
+
+  # GitHub does not cascade GITHUB_TOKEN-triggered release events (anti-recursion),
+  # so publish-channels' on: release never fires for release-please. Call it here
+  # after finalize so channels.json refreshes once the prerelease and every
+  # binary asset are live. EncodeChannelsManifest skips drafts, so this must not
+  # run earlier. A failure fails this release run instead of leaving the channel
+  # stale. publish-channels.yml keeps workflow_dispatch and on: release as
+  # backstops for human/PAT publishes.
+  publish-channels:
+    needs:
+      - finalize
+    if: |
+      !cancelled() &&
+      needs.finalize.result == 'success'
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-channels.yml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Safest local verification sequence after non-trivial changes:
 
 **Self-update channel manifest (`internal/update`)**
 
-- `no-mistakes update` reads version metadata exclusively from `channels.json` on the GitHub release-asset CDN (`releases/download/channels/channels.json`), not `api.github.com`; a token is never required. Publisher: `cmd/publish-channels`, invoked from `.github/workflows/publish-channels.yml`. Regressions: `internal/update/channels_test.go`.
+- `no-mistakes update` reads version metadata exclusively from `channels.json` on the GitHub release-asset CDN (`releases/download/channels/channels.json`), not `api.github.com`; a token is never required. Publisher: `cmd/publish-channels`, invoked from `.github/workflows/publish-channels.yml` (reusable `workflow_call`, plus `workflow_dispatch` / `on: release` backstops). `release.yml` calls it after `finalize` because GitHub does not cascade `GITHUB_TOKEN` `release` events, so release-please (pre)releases would otherwise leave the channel stale. Regressions: `internal/update/channels_test.go`, `workflow_publish_channels_test.go`, `TestReleaseWorkflowCallsPublishChannelsAfterFinalize`.
 
 **GitLab Backend (`internal/scm/gitlab`)**
 

--- a/workflow_condition_test.go
+++ b/workflow_condition_test.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+type workflowConditionContext struct {
+	EventName      string
+	ReleaseTagName string
+	Cancelled      bool
+	Needs          map[string]string
+}
+
+func evaluateWorkflowCondition(expression string, context workflowConditionContext) (bool, error) {
+	expression = strings.TrimSpace(expression)
+	if strings.HasPrefix(expression, "${{") && strings.HasSuffix(expression, "}}") {
+		expression = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(expression, "${{"), "}}"))
+	}
+	return evaluateWorkflowBoolean(expression, context)
+}
+
+func evaluateWorkflowBoolean(expression string, context workflowConditionContext) (bool, error) {
+	expression, err := trimWorkflowParentheses(strings.TrimSpace(expression))
+	if err != nil {
+		return false, err
+	}
+	if expression == "" {
+		return false, fmt.Errorf("empty workflow condition")
+	}
+
+	for _, operator := range []string{"||", "&&"} {
+		parts, found, err := splitWorkflowCondition(expression, operator)
+		if err != nil {
+			return false, err
+		}
+		if !found {
+			continue
+		}
+		result := operator == "&&"
+		for _, part := range parts {
+			value, err := evaluateWorkflowBoolean(part, context)
+			if err != nil {
+				return false, err
+			}
+			if operator == "||" {
+				result = result || value
+			} else {
+				result = result && value
+			}
+		}
+		return result, nil
+	}
+
+	if strings.HasPrefix(expression, "!") {
+		value, err := evaluateWorkflowBoolean(strings.TrimSpace(strings.TrimPrefix(expression, "!")), context)
+		return !value, err
+	}
+	if expression == "cancelled()" {
+		return context.Cancelled, nil
+	}
+
+	for _, operator := range []string{"==", "!="} {
+		parts, found, err := splitWorkflowCondition(expression, operator)
+		if err != nil {
+			return false, err
+		}
+		if !found {
+			continue
+		}
+		if len(parts) != 2 {
+			return false, fmt.Errorf("workflow comparison %q has %d operands", expression, len(parts))
+		}
+		left, err := workflowConditionValue(parts[0], context)
+		if err != nil {
+			return false, err
+		}
+		right, err := workflowConditionValue(parts[1], context)
+		if err != nil {
+			return false, err
+		}
+		if operator == "==" {
+			return left == right, nil
+		}
+		return left != right, nil
+	}
+
+	return false, fmt.Errorf("unsupported workflow condition %q", expression)
+}
+
+func workflowConditionValue(expression string, context workflowConditionContext) (string, error) {
+	expression = strings.TrimSpace(expression)
+	if len(expression) >= 2 && expression[0] == '\'' && expression[len(expression)-1] == '\'' {
+		return strings.ReplaceAll(expression[1:len(expression)-1], "''", "'"), nil
+	}
+	switch expression {
+	case "github.event_name":
+		return context.EventName, nil
+	case "github.event.release.tag_name":
+		return context.ReleaseTagName, nil
+	}
+	if strings.HasPrefix(expression, "needs.") && strings.HasSuffix(expression, ".result") {
+		name := strings.TrimSuffix(strings.TrimPrefix(expression, "needs."), ".result")
+		if name != "" && !strings.Contains(name, ".") {
+			return context.Needs[name], nil
+		}
+	}
+	return "", fmt.Errorf("unsupported workflow condition value %q", expression)
+}
+
+func trimWorkflowParentheses(expression string) (string, error) {
+	for strings.HasPrefix(expression, "(") {
+		depth := 0
+		quoted := false
+		closesAtEnd := false
+		for i := 0; i < len(expression); i++ {
+			switch expression[i] {
+			case '\'':
+				quoted = !quoted
+			case '(':
+				if !quoted {
+					depth++
+				}
+			case ')':
+				if !quoted {
+					depth--
+					if depth < 0 {
+						return "", fmt.Errorf("unbalanced workflow condition %q", expression)
+					}
+					if depth == 0 {
+						closesAtEnd = i == len(expression)-1
+						if !closesAtEnd {
+							return expression, nil
+						}
+					}
+				}
+			}
+		}
+		if quoted || depth != 0 {
+			return "", fmt.Errorf("unbalanced workflow condition %q", expression)
+		}
+		if !closesAtEnd {
+			return expression, nil
+		}
+		expression = strings.TrimSpace(expression[1 : len(expression)-1])
+	}
+	return expression, nil
+}
+
+func splitWorkflowCondition(expression, operator string) ([]string, bool, error) {
+	var parts []string
+	start := 0
+	depth := 0
+	quoted := false
+	for i := 0; i < len(expression); i++ {
+		switch expression[i] {
+		case '\'':
+			quoted = !quoted
+		case '(':
+			if !quoted {
+				depth++
+			}
+		case ')':
+			if !quoted {
+				depth--
+				if depth < 0 {
+					return nil, false, fmt.Errorf("unbalanced workflow condition %q", expression)
+				}
+			}
+		default:
+			if !quoted && depth == 0 && strings.HasPrefix(expression[i:], operator) {
+				parts = append(parts, strings.TrimSpace(expression[start:i]))
+				i += len(operator) - 1
+				start = i + 1
+			}
+		}
+	}
+	if quoted || depth != 0 {
+		return nil, false, fmt.Errorf("unbalanced workflow condition %q", expression)
+	}
+	if len(parts) == 0 {
+		return nil, false, nil
+	}
+	parts = append(parts, strings.TrimSpace(expression[start:]))
+	for _, part := range parts {
+		if part == "" {
+			return nil, false, fmt.Errorf("empty operand in workflow condition %q", expression)
+		}
+	}
+	return parts, true, nil
+}

--- a/workflow_publish_channels_test.go
+++ b/workflow_publish_channels_test.go
@@ -69,7 +69,7 @@ func TestPublishChannelsWorkflowRefreshesManifestWithoutRESTForEndUsers(t *testi
 	}{
 		{name: "channels release", context: workflowConditionContext{EventName: "release", ReleaseTagName: "channels"}, wantRun: false},
 		{name: "version release", context: workflowConditionContext{EventName: "release", ReleaseTagName: "v1.72.0"}, wantRun: true},
-		{name: "workflow call", context: workflowConditionContext{EventName: "workflow_call"}, wantRun: true},
+		{name: "release workflow call", context: workflowConditionContext{EventName: "push"}, wantRun: true},
 		{name: "workflow dispatch", context: workflowConditionContext{EventName: "workflow_dispatch"}, wantRun: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/workflow_publish_channels_test.go
+++ b/workflow_publish_channels_test.go
@@ -29,6 +29,9 @@ func TestPublishChannelsWorkflowRefreshesManifestWithoutRESTForEndUsers(t *testi
 	if err := yaml.Unmarshal(raw, &wf); err != nil {
 		t.Fatalf("parse workflow: %v", err)
 	}
+	if _, ok := wf.On["workflow_call"]; !ok {
+		t.Fatal("publish-channels must be a reusable workflow so release.yml can invoke it after finalize (GITHUB_TOKEN release events do not cascade)")
+	}
 	if _, ok := wf.On["workflow_dispatch"]; !ok {
 		t.Fatal("publish-channels workflow must allow workflow_dispatch so a manifest can be published without a new versioned release")
 	}
@@ -59,8 +62,8 @@ func TestPublishChannelsWorkflowRefreshesManifestWithoutRESTForEndUsers(t *testi
 	if !ok {
 		t.Fatal("missing publish-channels job")
 	}
-	if job.If != "github.event_name == 'workflow_dispatch' || github.event.release.tag_name != 'channels'" {
-		t.Fatalf("job if = %q, want a skip for the channels tag so uploading the manifest cannot recurse", job.If)
+	if job.If != "github.event_name != 'release' || github.event.release.tag_name != 'channels'" {
+		t.Fatalf("job if = %q, want a skip for the channels tag on release events so uploading the manifest cannot recurse, while workflow_call and workflow_dispatch still run", job.If)
 	}
 	var sawPublish bool
 	for _, step := range job.Steps {

--- a/workflow_publish_channels_test.go
+++ b/workflow_publish_channels_test.go
@@ -62,8 +62,25 @@ func TestPublishChannelsWorkflowRefreshesManifestWithoutRESTForEndUsers(t *testi
 	if !ok {
 		t.Fatal("missing publish-channels job")
 	}
-	if job.If != "github.event_name != 'release' || github.event.release.tag_name != 'channels'" {
-		t.Fatalf("job if = %q, want a skip for the channels tag on release events so uploading the manifest cannot recurse, while workflow_call and workflow_dispatch still run", job.If)
+	for _, tc := range []struct {
+		name    string
+		context workflowConditionContext
+		wantRun bool
+	}{
+		{name: "channels release", context: workflowConditionContext{EventName: "release", ReleaseTagName: "channels"}, wantRun: false},
+		{name: "version release", context: workflowConditionContext{EventName: "release", ReleaseTagName: "v1.72.0"}, wantRun: true},
+		{name: "workflow call", context: workflowConditionContext{EventName: "workflow_call"}, wantRun: true},
+		{name: "workflow dispatch", context: workflowConditionContext{EventName: "workflow_dispatch"}, wantRun: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := evaluateWorkflowCondition(job.If, tc.context)
+			if err != nil {
+				t.Fatalf("evaluate publish-channels condition: %v", err)
+			}
+			if got != tc.wantRun {
+				t.Fatalf("publish-channels runs = %t, want %t", got, tc.wantRun)
+			}
+		})
 	}
 	var sawPublish bool
 	for _, step := range job.Steps {

--- a/workflow_release_signing_test.go
+++ b/workflow_release_signing_test.go
@@ -49,13 +49,17 @@ type wfDoc struct {
 
 type wfJob struct {
 	name           string
-	RunsOn         any        `yaml:"runs-on"`
-	Environment    any        `yaml:"environment"`
-	Needs          any        `yaml:"needs"`
-	If             string     `yaml:"if"`
-	TimeoutMinutes int        `yaml:"timeout-minutes"`
-	Strategy       wfStrategy `yaml:"strategy"`
-	Steps          []wfStep   `yaml:"steps"`
+	RunsOn         any    `yaml:"runs-on"`
+	Environment    any    `yaml:"environment"`
+	Needs          any    `yaml:"needs"`
+	If             string `yaml:"if"`
+	TimeoutMinutes int    `yaml:"timeout-minutes"`
+	Permissions    struct {
+		Contents string `yaml:"contents"`
+	} `yaml:"permissions"`
+	Uses     string     `yaml:"uses"`
+	Strategy wfStrategy `yaml:"strategy"`
+	Steps    []wfStep   `yaml:"steps"`
 }
 
 type wfStrategy struct {

--- a/workflow_release_test.go
+++ b/workflow_release_test.go
@@ -215,14 +215,25 @@ func TestReleaseWorkflowCallsPublishChannelsAfterFinalize(t *testing.T) {
 		t.Fatalf("publish-channels needs = %v, want finalize so channels.json is not pointed at a still-draft release or a release missing binaries", job.needs())
 	}
 
-	ifExpr := strings.Join(strings.Fields(job.If), " ")
-	for _, req := range []string{"!cancelled()", "needs.finalize.result == 'success'"} {
-		if !strings.Contains(ifExpr, req) {
-			t.Fatalf("publish-channels if = %q, want %q so a skipped or failed finalize does not refresh channels", job.If, req)
-		}
-	}
-	if strings.Contains(job.allRun(), "gh workflow run") {
-		t.Fatal("publish-channels must not fire-and-forget via gh workflow run; call the reusable workflow so failures surface on the release run")
+	for _, tc := range []struct {
+		name    string
+		context workflowConditionContext
+		wantRun bool
+	}{
+		{name: "finalize succeeded", context: workflowConditionContext{Needs: map[string]string{"finalize": "success"}}, wantRun: true},
+		{name: "finalize failed", context: workflowConditionContext{Needs: map[string]string{"finalize": "failure"}}, wantRun: false},
+		{name: "finalize skipped", context: workflowConditionContext{Needs: map[string]string{"finalize": "skipped"}}, wantRun: false},
+		{name: "run cancelled", context: workflowConditionContext{Cancelled: true, Needs: map[string]string{"finalize": "success"}}, wantRun: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := evaluateWorkflowCondition(job.If, tc.context)
+			if err != nil {
+				t.Fatalf("evaluate publish-channels condition: %v", err)
+			}
+			if got != tc.wantRun {
+				t.Fatalf("publish-channels runs = %t, want %t", got, tc.wantRun)
+			}
+		})
 	}
 }
 

--- a/workflow_release_test.go
+++ b/workflow_release_test.go
@@ -187,6 +187,45 @@ func TestReleaseWorkflowPublishesPrereleaseOnlyAfterAssetsComplete(t *testing.T)
 	}
 }
 
+// TestReleaseWorkflowCallsPublishChannelsAfterFinalize pins that a
+// release-please cut refreshes channels.json from the same run, after the
+// prerelease and every binary asset are live. GitHub does not cascade
+// GITHUB_TOKEN release events, so on: release cannot cover this path.
+func TestReleaseWorkflowCallsPublishChannelsAfterFinalize(t *testing.T) {
+	wf := loadReleaseWorkflowDoc(t)
+	job := wf.Jobs["publish-channels"]
+	if job == nil {
+		t.Fatal("release workflow must call publish-channels as a job so a GITHUB_TOKEN-published release still refreshes the channel manifest")
+	}
+	if job.Uses != "./.github/workflows/publish-channels.yml" {
+		t.Fatalf("publish-channels uses = %q, want the reusable workflow so a failure fails this release run", job.Uses)
+	}
+	if len(job.Steps) != 0 {
+		t.Fatalf("publish-channels must be a reusable-workflow job with no steps, got %d (a gh workflow run fire-and-forget would not fail this run)", len(job.Steps))
+	}
+	if job.Permissions.Contents != "write" {
+		t.Fatalf("publish-channels contents permission = %q, want write to upload the channels asset", job.Permissions.Contents)
+	}
+
+	needed := map[string]bool{}
+	for _, dep := range job.needs() {
+		needed[dep] = true
+	}
+	if !needed["finalize"] {
+		t.Fatalf("publish-channels needs = %v, want finalize so channels.json is not pointed at a still-draft release or a release missing binaries", job.needs())
+	}
+
+	ifExpr := strings.Join(strings.Fields(job.If), " ")
+	for _, req := range []string{"!cancelled()", "needs.finalize.result == 'success'"} {
+		if !strings.Contains(ifExpr, req) {
+			t.Fatalf("publish-channels if = %q, want %q so a skipped or failed finalize does not refresh channels", job.If, req)
+		}
+	}
+	if strings.Contains(job.allRun(), "gh workflow run") {
+		t.Fatal("publish-channels must not fire-and-forget via gh workflow run; call the reusable workflow so failures surface on the release run")
+	}
+}
+
 func TestExtractJobBlockHandlesCRLF(t *testing.T) {
 	lf := "jobs:\n  foo:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo foo\n  bar:\n    runs-on: ubuntu-latest\n"
 	crlf := strings.ReplaceAll(lf, "\n", "\r\n")


### PR DESCRIPTION
## Intent

The captain wants the no-mistakes release process FULLY AUTOMATED so that channel publishing (the channels.json manifest the no-mistakes update client reads) refreshes on EVERY release with NO manual trigger.

The bug: release-please publishes each release using GITHUB_TOKEN, and GitHub deliberately does NOT cascade GITHUB_TOKEN-triggered release events into other workflows (anti-recursion). So the publish-channels workflow's on: release trigger never fires for release-please's (pre)releases, and channels.json (the update client's source of truth for latest stable/beta) stays stale until someone manually runs publish-channels via workflow_dispatch. This just bit us: v1.72.0's release was published but sat unpublished-to-channel for ~11 hours (the beta channel stuck at v1.71.0) until firstmate manually triggered publish-channels. Every release-please prerelease has this gap today.

Captain's requirement, verbatim intent: "get the release process fixed. it should be fully automated without extra manual trigger." Confirmed by the main firstmate.

## What Changed

- Invoke the reusable channel-publishing workflow after release finalization so `channels.json` refreshes for every release-please cut.
- Preserve manual and release-event triggers while preventing recursion from the `channels` release.
- Add semantic workflow tests covering invocation order, permissions, and trigger conditions.

## Risk Assessment

✅ Low: The change is narrowly scoped and correctly invokes channel publishing after successful release finalization while preserving existing release and manual backstops.

## Testing

The outer baseline preceded this phase; targeted typed workflow tests exercised successful, failed, skipped, cancelled, release, reusable-call, dispatch, and recursion-guard contexts and passed. No live release was created because the change is confined to GitHub Actions and requires repository release authority.

- Live validation: ⚠️ no-surface - 0 of 3 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Publishing a release-please prerelease automatically refreshes channels.json after finalization without a manual trigger | ⏸️ untested | no | This is a GitHub Actions-only surface requiring permission to create and publish a real repository release with contents:write. Provide an authorized GitHub release run and verify the channels release… |
| A failed, skipped, or cancelled finalize job cannot publish channels, while a successful finalize propagates publisher failure to the release run | ⏸️ untested | no | Observing job scheduling and failure propagation requires executing the workflow on GitHub with repository release and contents:write authority. Provide an authorized disposable release run, including… |
| Release and manual-dispatch backstops publish normally without recursively republishing the channels release | ⏸️ untested | no | The behavior exists only in GitHub Actions and cannot be driven through the local no-mistakes runtime. Provide authorized GitHub workflow_dispatch and release-event runs to observe scheduling and asse… |

- Outcome: ⚠️ 2 warnings across 1 run (1m20s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c77a1b8ea0660cf890d60dc3fd9b63ea33f8ac53","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"no-surface","live":0,"total":3}} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `.github/workflows/publish-channels.yml:35` - The new `|| github.ref` fallback is not required by the intent. Every supported trigger supplies `github.event.repository.default_branch`, including the intended workflow_call from release.yml, while falling back to an arbitrary event ref weakens the existing guarantee that publishing runs from the default branch. Remove the fallback and retain the default-branch checkout.
- ⚠️ `workflow_publish_channels_test.go:65` - This changed assertion treats the GitHub Actions `if` expression as an exact source string rather than asserting its behavior, contrary to the test-quality rule. Remove it or evaluate the parsed expression for release, workflow_call, and workflow_dispatch contexts.
- ⚠️ `workflow_release_test.go:218` - The new test checks workflow behavior through substrings in the raw `if` and `run` fields. An always-false expression containing both expected fragments would pass, and the `gh workflow run` check is redundant after asserting the reusable-workflow job has no steps. Remove these textual assertions or use a semantic expression evaluator with representative job contexts.

🔧 Fix applied.
1 warning still open:

- ⚠️ `workflow_publish_channels_test.go:76` - The `workflow call` case models `github.event_name` as `workflow_call`, but a reusable workflow inherits the caller&#39;s event context, so this release.yml invocation sees `push`. The test can therefore accept a condition that passes for the synthetic value but skips the real release invocation. Model this case with `EventName: &#34;push&#34;`.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>⚠️ **Test** - 2 warnings</summary>

- ⚠️ `.github/workflows/release.yml:349` - The automatic channel refresh can only be demonstrated by an actual GitHub release workflow run with contents:write authority. This test phase cannot create or publish a release, so live evidence requires running the workflow for a real release and confirming the channels release asset updates automatically.
- ⚠️ this change has no live-validatable surface; proceed without live validation? (0 of 3 scenarios were driven live against the product); Publishing a release-please prerelease automatically refreshes channels.json after finalization without a manual trigger: This is a GitHub Actions-only surface requiring permission to create and publish a real repository release with contents:write. Provide an authorized GitHub release run and verify the channels release asset changes without workflow_dispatch.; A failed, skipped, or cancelled finalize job cannot publish channels, while a successful finalize propagates publisher failure to the release run: Observing job scheduling and failure propagation requires executing the workflow on GitHub with repository release and contents:write authority. Provide an authorized disposable release run, including a controlled publisher failure.; Release and manual-dispatch backstops publish normally without recursively republishing the channels release: The behavior exists only in GitHub Actions and cannot be driven through the local no-mistakes runtime. Provide authorized GitHub workflow_dispatch and release-event runs to observe scheduling and asset publication.
- Live validation: ⚠️ no-surface - 0 of 3 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Publishing a release-please prerelease automatically refreshes channels.json after finalization without a manual trigger | ⏸️ untested | no | This is a GitHub Actions-only surface requiring permission to create and publish a real repository release with contents:write. Provide an authorized GitHub release run and verify the channels release… |
| A failed, skipped, or cancelled finalize job cannot publish channels, while a successful finalize propagates publisher failure to the release run | ⏸️ untested | no | Observing job scheduling and failure propagation requires executing the workflow on GitHub with repository release and contents:write authority. Provide an authorized disposable release run, including… |
| Release and manual-dispatch backstops publish normally without recursively republishing the channels release | ⏸️ untested | no | The behavior exists only in GitHub Actions and cannot be driven through the local no-mistakes runtime. Provide authorized GitHub workflow_dispatch and release-event runs to observe scheduling and asse… |

- `go test . -run '^(TestReleaseWorkflowCallsPublishChannelsAfterFinalize|TestPublishChannelsWorkflowRefreshesManifestWithoutRESTForEndUsers)$' -count=1 -v`
- <code>Verified the worktree remained clean after targeted testing with `git status --short`.</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
