### PR TITLE
feat: add verify skill and runtime verifier script

### DIFF
--- a/.agents/skills/verify/SKILL.md
+++ b/.agents/skills/verify/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: verify
+description: Prove no-mistakes through its maintained checks and real CLI runtime.
+user_invocable: true
+---
+
+# /verify — prove the task before the PR
+
+This is the independent runtime-proof layer for no-mistakes. It complements,
+and never replaces, the existing Go tests, lint, build, no-mistakes review, or
+CI gates.
+
+Run it from this repository on a feature branch with committed changes:
+
+```sh
+scripts/verify.sh
+```
+
+The verifier first records a local machine inventory, then runs the maintained
+race-enabled test suite, generated-skill lint check, and production build. It
+finishes by invoking the built binary's real `--version`, `--help`, and
+read-only `doctor` commands against a throwaway `NM_HOME`, so the smoke never
+reads or writes shared app state and never reaches the shared daemon that other
+lanes depend on. `doctor` exits `0` even when its own checks fail, so the
+verifier gates on the verdict it prints rather than on its exit code.
+
+Evidence is written under `.no-mistakes/evidence/`, which is gitignored. Keep
+credentials, tokens, PHI, and raw provider payloads out of evidence and
+reports. The verifier does not contact production services or push, open, merge,
+or modify a PR.
+
+A failing verifier is a failure even when another gate passes: fix the task,
+commit it, and run `scripts/verify.sh` again from a fresh invocation. Report the
+exact commands, result, first actionable failure, and evidence paths. Only
+after this proof passes should `/no-mistakes` drive its authoritative review,
+fix, push, PR, and CI gates with the complete task intent.

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -2,12 +2,23 @@
 set -Eeuo pipefail
 
 repo=$(git rev-parse --show-toplevel)
-test "$repo" = "$PWD"
+if [ "$repo" != "$PWD" ]; then
+  printf 'verify must run from the repository root (%s), not a subdirectory\n' "$repo" >&2
+  exit 1
+fi
 branch=$(git branch --show-current)
-test -n "$branch"
-test "$branch" != main
-test "$branch" != master
-test -z "$(git status --porcelain)"
+if [ -z "$branch" ]; then
+  printf 'detached HEAD: no current branch to verify\n' >&2
+  exit 1
+fi
+if [ "$branch" = main ] || [ "$branch" = master ]; then
+  printf 'refusing to verify the default branch (%s); run on a feature branch\n' "$branch" >&2
+  exit 1
+fi
+if [ -n "$(git status --porcelain)" ]; then
+  printf 'working tree is dirty; commit or stash before verifying\n' >&2
+  exit 1
+fi
 
 for tool in git go make; do
   command -v "$tool" >/dev/null 2>&1 || {
@@ -18,7 +29,10 @@ done
 
 evidence=.no-mistakes/evidence
 mkdir -p "$evidence"
-git check-ignore -q "$evidence/verify.log"
+if ! git check-ignore -q "$evidence/verify.log"; then
+  printf '%s is not gitignored; add it to .gitignore before verifying\n' "$evidence" >&2
+  exit 1
+fi
 exec > >(tee "$evidence/verify.log") 2>&1
 
 printf '== inventory ==\n'

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+repo=$(git rev-parse --show-toplevel)
+test "$repo" = "$PWD"
+branch=$(git branch --show-current)
+test -n "$branch"
+test "$branch" != main
+test "$branch" != master
+test -z "$(git status --porcelain)"
+
+for tool in git go make; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    printf 'missing required command: %s\n' "$tool" >&2
+    exit 1
+  }
+done
+
+evidence=.no-mistakes/evidence
+mkdir -p "$evidence"
+git check-ignore -q "$evidence/verify.log"
+exec > >(tee "$evidence/verify.log") 2>&1
+
+printf '== inventory ==\n'
+printf 'repo: %s\nbranch: %s\ncommit: %s\n' "$repo" "$branch" "$(git rev-parse --short HEAD)"
+git --version
+go version
+uname -a
+
+printf '\n== race-enabled tests ==\n'
+go test -race ./...
+
+printf '\n== lint and generated-skill check ==\n'
+make lint
+
+printf '\n== production build ==\n'
+make build
+
+printf '\n== real CLI smoke ==\n'
+# Throwaway NM_HOME: the smoke never reads or writes the shared app state, and
+# never reaches the shared daemon that other lanes depend on.
+nm_home=$(mktemp -d)
+trap 'rm -rf "$nm_home"' EXIT
+export NM_HOME="$nm_home" NO_MISTAKES_NO_UPDATE_CHECK=1 NO_MISTAKES_TELEMETRY=off
+./bin/no-mistakes --version
+./bin/no-mistakes --help >/dev/null
+doctor_out=$(./bin/no-mistakes doctor)
+printf '%s\n' "$doctor_out"
+# doctor exits 0 even when its own checks fail, so gate on the verdict it prints.
+# ponytail: string match on the summary line; replace when doctor grows an exit code.
+case "$doctor_out" in
+  *'some checks failed'*)
+    printf 'doctor reported failing checks\n' >&2
+    exit 1
+    ;;
+esac
+
+printf '\nverification passed; evidence: %s\n' "$evidence/verify.log"


### PR DESCRIPTION
## Intent

Captain 2026-08-31: all top 30 repositories get a real verifier. For no-mistakes, inventory first, wire /verify, and prove it on a real Linux machine. Never claim completion without that proof. Look at the Choco verifier pilot for the skill shape. Keep the implementation minimal with Ponytail full, do not weaken existing gates, and keep PHI and secrets out. The no-mistakes repository ships through its no-mistakes path with autonomous merge authority, but the house fork must be proven first; do not publish this fleet-specific rollout as an upstream contribution without a separate later decision.

## What Changed

- Add `/verify` skill (`.agents/skills/verify/SKILL.md`) describing the runtime-proof layer that complements, never replaces, the existing Go test, lint, build, no-mistakes review, and CI gates.
- Add `scripts/verify.sh`, which records a machine inventory, runs `go test -race ./...`, `make lint`, and `make build`, then smokes the built binary's `--version`, `--help`, and read-only `doctor` commands against a throwaway `NM_HOME`, gating on the verdict `doctor` prints since its exit code is always 0.
- Guard the verifier with root-only, feature-branch, clean-tree, and required-tool preconditions; write evidence to gitignored `.no-mistakes/evidence/verify.log` (refusing to run if that path is not gitignored) and never contact production services or touch PRs.

## Risk Assessment

✅ Low: The fix round is a minimal, behavior-preserving error-message addition to shell preflight guards, verified guard-by-guard against concrete inputs, with no new logic, state, or scope beyond the original skill.

## Testing

I validated the reviewed fix by exercising all six preflight guards of scripts/verify.sh and confirming each now prints a one-line stderr reason before exiting 1 (previously silent set -e exits), then proved the whole /verify skill end-to-end on this real Linux machine by running scripts/verify.sh on a temporary feature branch at the target commit: the full race-enabled suite, make lint with the generated-skill drift check, the production build, and the real CLI smoke with a throwaway NM_HOME all passed with 'verification passed' and exit 0. The full evidence log is preserved as an artifact; the worktree was restored to detached HEAD at the target commit and transient build/evidence artifacts were cleaned from the tree.

<details>
<summary>Evidence: verify.sh full end-to-end run on real Linux machine (race tests, lint, build, CLI smoke, verification passed)</summary>

```text
== inventory ==
repo: ~/.no-mistakes/worktrees/58bde5a5eb74/01M22QHYCMHCX939P2BN7MR585
branch: fm-verify-e2e-tmp
commit: a3913dd
git version 2.43.0
go version go1.26.1 linux/amd64
Linux gpu 6.17.0-35-generic #35~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Tue May 26 19:30:42 UTC 2 x86_64 x86_64 x86_64 GNU/Linux

== race-enabled tests ==
ok  	github.com/kunchenguid/no-mistakes	2.583s
ok  	github.com/kunchenguid/no-mistakes/cmd/fakeagent	1.038s
?   	github.com/kunchenguid/no-mistakes/cmd/genskill	[no test files]
ok  	github.com/kunchenguid/no-mistakes/cmd/no-mistakes	1.013s
ok  	github.com/kunchenguid/no-mistakes/cmd/publish-channels	1.017s
ok  	github.com/kunchenguid/no-mistakes/cmd/recordfixture	3.455s
ok  	github.com/kunchenguid/no-mistakes/internal/agent	36.790s
ok  	github.com/kunchenguid/no-mistakes/internal/agentcfg	1.009s
ok  	github.com/kunchenguid/no-mistakes/internal/bitbucket	1.021s
ok  	github.com/kunchenguid/no-mistakes/internal/branchsync	15.326s
?   	github.com/kunchenguid/no-mistakes/internal/buildinfo	[no test files]
ok  	github.com/kunchenguid/no-mistakes/internal/cimonitor	1.007s
ok  	github.com/kunchenguid/no-mistakes/internal/cli	87.683s
ok  	github.com/kunchenguid/no-mistakes/internal/config	1.140s
ok  	github.com/kunchenguid/no-mistakes/internal/conventional	1.021s
ok  	github.com/kunchenguid/no-mistakes/internal/custody	1.124s
ok  	github.com/kunchenguid/no-mistakes/internal/daemon	92.650s
ok  	github.com/kunchenguid/no-mistakes/internal/db	25.027s
?   	github.com/kunchenguid/no-mistakes/internal/e2e	[no test files]
ok  	github.com/kunchenguid/no-mistakes/internal/e2edaemon	9.107s
ok  	github.com/kunchenguid/no-mistakes/internal/eval	28.681s
ok  	github.com/kunchenguid/no-mistakes/internal/evidence	1.606s
ok  	github.com/kunchenguid/no-mistakes/internal/forgecontext	1.025s
ok  	github.com/kunchenguid/no-mistakes/internal/gate	8.341s
ok  	github.com/kunchenguid/no-mistakes/internal/gatecontext	2.632s
ok  	github.com/kunchenguid/no-mistakes/internal/gateguidance	1.016s
ok  	github.com/kunchenguid/no-mistakes/internal/git	2.263s
ok  	github.com/kunchenguid/no-mistakes/internal/intent	2.156s
ok  	github.com/kunchenguid/no-mistakes/internal/ipc	1.360s
?   	github.com/kunchenguid/no-mistakes/internal/lifecycle	[no test files]
ok  	github.com/kunchenguid/no-mistakes/internal/logstore	2.558s
ok  	github.com/kunchenguid/no-mistakes/internal/paths	1.019s
ok  	github.com/kunchenguid/no-mistakes/internal/pipeline	34.111s
?   	github.com/kunchenguid/no-mistakes/internal/pipeline/fakecli	[no test files]
ok  	github.com/kunchenguid/no-mistakes/internal/pipeline/steps	81.622s
ok  	github.com/kunchenguid/no-mistakes/internal/pipeline/steps/citest	3.611s
?   	github.com/kunchenguid/no-mistakes/internal/pipeline/steps/internal/stepstest	[no test files]
ok  	github.com/kunchenguid/no-mistakes/internal/procreap	3.383s
ok  	github.com/kunchenguid/no-mistakes/internal/runenv	1.012s
ok  	github.com/kunchenguid/no-mistakes/internal/safepath	1.043s
ok  	github.com/kunchenguid/no-mistakes/internal/safeurl	1.017s
ok  	github.com/kunchenguid/no-mistakes/internal/scm	1.102s
ok  	github.com/kunchenguid/no-mistakes/internal/scm/azuredevops	12.135s
ok  	github.com/kunchenguid/no-mistakes/internal/scm/forgejo	152.281s
ok  	github.com/kunchenguid/no-mistakes/internal/scm/gitea	6.082s
ok  	github.com/kunchenguid/no-mistakes/internal/scm/github	12.118s
ok  	github.com/kunchenguid/no-mistakes/internal/scm/gitlab	6.100s
ok  	github.com/kunchenguid/no-mistakes/internal/shellenv	10.470s
ok  	github.com/kunchenguid/no-mistakes/internal/skill	1.038s
ok  	github.com/kunchenguid/no-mistakes/internal/telemetry	1.039s
?   	github.com/kunchenguid/no-mistakes/internal/testguidance	[no test files]
ok  	github.com/kunchenguid/no-mistakes/internal/tui	1.350s
ok  	github.com/kunchenguid/no-mistakes/internal/types	1.019s
ok  	github.com/kunchenguid/no-mistakes/internal/update	1.663s
?   	github.com/kunchenguid/no-mistakes/internal/winproc	[no test files]
ok  	github.com/kunchenguid/no-mistakes/internal/wizard	9.445s
ok  	github.com/kunchenguid/no-mistakes/internal/worktrees	1.014s

== lint and generated-skill check ==
go run ./cmd/genskill --check
genskill: skills/no-mistakes/SKILL.md is up to date
go vet ./...

== production build ==
go build -ldflags "-X github.com/kunchenguid/no-mistakes/internal/buildinfo.Version=a3913dd -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Commit=a3913dd -X github.com/kunchenguid/no-mistakes/internal/buildinfo.Date=2026-09-09T09:42:18Z -X github.com/kunchenguid/no-mistakes/internal/buildinfo.TelemetryHost=https://a.kunchenguid.com -X github.com/kunchenguid/no-mistakes/internal/buildinfo.TelemetryWebsiteID=f959e889-92f5-4121-8a1f-571b10861198" -o bin/no-mistakes ./cmd/no-mistakes

== real CLI smoke ==
no-mistakes version a3913dd (a3913dd) 2026-09-09T09:42:18Z
  System
  ✓ git             git version 2.43.0
  ✓ gh              ok
  – az              not found (optional, needed for Azure DevOps PR/CI)
  ✓ data directory  /tmp/tmp.ZGOmAXnWdW
  – database        not found (will be created on first use)
  – daemon          stopped

  Agents
  ✓ claude          ~/.local/bin/claude
  ✓ codex           ~/.bun/bin/codex
  ✓ grok            ~/.local/bin/grok
  – rovodev         not found
  – opencode        not found
  ✓ pi              ~/.npm-global/bin/pi
  – copilot         not found
  ✓ antigravity     ~/.local/bin/agy
  ✓ acpx            ~/.npm-global/bin/acpx
  ✓ cursor          ~/.local/bin/cursor-agent, ~/.npm-global/bin/acpx
  ✓ gate validation  claude is runnable

verification passed; evidence: .no-mistakes/evidence/verify.log
```
</details>
<details>
<summary>Evidence: Preflight guard stderr messages (all six failure modes, each exit 1)</summary>

```text
verify must run from the repository root (...), not a subdirectory
detached HEAD: no current branch to verify
refusing to verify the default branch (main); run on a feature branch
working tree is dirty; commit or stash before verifying
.no-mistakes/evidence is not gitignored; add it to .gitignore before verifying
missing required command: go
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"36c9315a0ac48627ae96e3181c368be3f5b5852a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `scripts/verify.sh:4` - The preflight guards (test &#34;$repo&#34; = &#34;$PWD&#34;, test -z &#34;$(git status --porcelain)&#34;, git check-ignore -q) abort under set -e with exit code 1 and zero output, so a run on a dirty tree, from a subdirectory, or in a repo without the evidence gitignore looks like an unexplained crash. The SKILL.md promises the user will &#39;report ... the first actionable failure&#39;, which the script itself cannot do for its own guards. Remedy is mechanical: print a one-line reason to stderr before each guard exits; no behavior change.

🔧 Fix: verify.sh preflight guards now print a stderr reason before exiting
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`bash ../scripts/verify.sh` from internal/ subdirectory of the worktree: prints &#39;verify must run from the repository root (...), not a subdirectory&#39; to stderr, exit 1</code>
- <code>`scripts/verify.sh` with the worktree&#39;s own detached HEAD: prints &#39;detached HEAD: no current branch to verify&#39; to stderr, exit 1 (real environment reproduction)</code>
- `Throwaway /tmp git repo with the target commit's verify.sh on 'main': prints 'refusing to verify the default branch (main); run on a feature branch', exit 1`
- `Throwaway /tmp git repo, detached HEAD: prints 'detached HEAD: no current branch to verify', exit 1`
- `Throwaway /tmp git repo, feature branch, clean, .no-mistakes/evidence not gitignored: prints '.no-mistakes/evidence is not gitignored; add it to .gitignore before verifying', exit 1`
- `Throwaway /tmp git repo, feature branch with uncommitted file: prints 'working tree is dirty; commit or stash before verifying', exit 1`
- `Throwaway /tmp git repo, PATH containing git+make but no go: prints 'missing required command: go', exit 1`
- <code>End-to-end real run: created temporary feature branch fm-verify-e2e-tmp at the target commit in the worktree and ran `bash scripts/verify.sh` - full race suite (go test -race ./...), `make lint` (genskill --check + go vet), `make build`, and the real CLI smoke against a throwaway NM_HOME all passed, ending &#39;verification passed; evidence: .no-mistakes/evidence/verify.log&#39;, exit 0; then restored detached HEAD at a3913dd and deleted the temp branch</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
