### PR TITLE
docs: add workflow-scope push failure troubleshooting

### DIFF
--- a/docs/src/content/docs/guides/provider-integration.md
+++ b/docs/src/content/docs/guides/provider-integration.md
@@ -100,6 +100,20 @@ Re-running `no-mistakes init` later preserves the stored fork URL unless you pas
 Fork routing currently requires both `origin` and `--fork-url` to be GitHub remotes with owner/repo paths.
 GitLab, Forgejo, Bitbucket, and Azure DevOps fork MR/PR routing are not implemented yet; if a legacy or manually edited repo record has `fork_url` set for those providers, PR creation skips instead of opening an unsafe self PR.
 
+#### Workflow-file changes require the `workflow` scope
+
+If your branch touches `.github/workflows/*.yml`, the push to your fork requires a GitHub credential with the `workflow` scope.
+GitHub rejects the push with `refusing to allow an OAuth App to create or update workflow ... without workflow scope` if the stored token lacks it.
+Add the scope before pushing through `no-mistakes`:
+
+```sh
+gh auth refresh -s workflow    # OAuth flow
+gh auth setup-git
+```
+
+If you authenticated `gh` with a PAT, its scopes are immutable — create a new PAT that includes `workflow` at `https://github.com/settings/tokens`, then re-authenticate with `gh auth login --with-token`.
+See [Troubleshooting](/no-mistakes/guides/troubleshooting/#push-fails-with-refusing-to-allow-an-oauth-app-to-create-or-update-workflow--without-workflow-scope) for the full recovery steps.
+
 ## GitLab
 
 Install the GitLab CLI and authenticate:

--- a/docs/src/content/docs/guides/provider-integration.md
+++ b/docs/src/content/docs/guides/provider-integration.md
@@ -102,7 +102,7 @@ GitLab, Forgejo, Bitbucket, and Azure DevOps fork MR/PR routing are not implemen
 
 #### Workflow-file changes require the `workflow` scope
 
-If your branch touches `.github/workflows/*.yml`, the push to your fork requires a GitHub credential with the `workflow` scope; GitHub rejects it with `refusing to allow an OAuth App to create or update workflow ... without workflow scope` when the stored token lacks it.
+If your branch touches a `.github/workflows/*.yml` or `*.yaml` file, the push to your fork requires a GitHub credential with the `workflow` scope; GitHub rejects it with `refusing to allow an OAuth App to create or update workflow ... without workflow scope` when the stored token lacks it.
 See [Troubleshooting](/no-mistakes/guides/troubleshooting/#push-fails-with-refusing-to-allow-an-oauth-app-to-create-or-update-workflow--without-workflow-scope) for the recovery steps.
 
 ## GitLab

--- a/docs/src/content/docs/guides/provider-integration.md
+++ b/docs/src/content/docs/guides/provider-integration.md
@@ -102,17 +102,8 @@ GitLab, Forgejo, Bitbucket, and Azure DevOps fork MR/PR routing are not implemen
 
 #### Workflow-file changes require the `workflow` scope
 
-If your branch touches `.github/workflows/*.yml`, the push to your fork requires a GitHub credential with the `workflow` scope.
-GitHub rejects the push with `refusing to allow an OAuth App to create or update workflow ... without workflow scope` if the stored token lacks it.
-Add the scope before pushing through `no-mistakes`:
-
-```sh
-gh auth refresh -s workflow    # OAuth flow
-gh auth setup-git
-```
-
-If you authenticated `gh` with a PAT, its scopes are immutable — create a new PAT that includes `workflow` at `https://github.com/settings/tokens`, then re-authenticate with `gh auth login --with-token`.
-See [Troubleshooting](/no-mistakes/guides/troubleshooting/#push-fails-with-refusing-to-allow-an-oauth-app-to-create-or-update-workflow--without-workflow-scope) for the full recovery steps.
+If your branch touches `.github/workflows/*.yml`, the push to your fork requires a GitHub credential with the `workflow` scope; GitHub rejects it with `refusing to allow an OAuth App to create or update workflow ... without workflow scope` when the stored token lacks it.
+See [Troubleshooting](/no-mistakes/guides/troubleshooting/#push-fails-with-refusing-to-allow-an-oauth-app-to-create-or-update-workflow--without-workflow-scope) for the recovery steps.
 
 ## GitLab
 

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -199,8 +199,22 @@ gh auth login --with-token < new-pat.txt
 gh auth setup-git
 ```
 
-If your push target's HTTPS remote embeds the PAT in its URL (for example `https://<token>@github.com/...`), `gh auth setup-git` updates only the credential helper.
-no-mistakes pushes using the token in the remote URL, so update that URL with the refreshed credential too.
+If your push target's HTTPS remote embeds the PAT in its URL (for example `https://<token>@github.com/...`), `gh auth setup-git` updates only the credential helper — no-mistakes pushes using the token in the remote URL, so that URL must be refreshed too.
+
+no-mistakes keeps its own copy of the push target's URL on the gate's bare repo, so updating the URL in your checkout alone is not enough: re-run `no-mistakes init` afterward so the gate picks up the refreshed URL.
+
+```sh
+git remote set-url origin https://<new-token>@github.com/<owner>/<repo>.git
+no-mistakes init
+```
+
+If you push to a fork (see [GitHub fork contributions](/no-mistakes/guides/provider-integration/#github-fork-contributions)), the fork URL is stored separately and a bare `no-mistakes init` preserves it. Pass the refreshed URL explicitly:
+
+```sh
+no-mistakes init --fork-url https://<new-token>@github.com/<fork-owner>/<repo>.git
+```
+
+Prefer authenticating through the credential helper (`gh auth setup-git`) over embedding a PAT in the URL — a clean URL with no embedded token needs no `init` after a credential refresh.
 
 This only affects branches that modify workflow files.
 A branch that touches no `.github/workflows/*.yml` or `*.yaml` pushes normally with a standard `repo`-scoped token.

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -176,7 +176,7 @@ If the overwrite is intentional, push manually to the actual remote after review
 
 ### Push fails with `refusing to allow an OAuth App to create or update workflow ... without workflow scope`
 
-This means the branch touches `.github/workflows/*.yml` and the push credential (a GitHub OAuth token or PAT stored for the push target's host) lacks the `workflow` scope.
+This means the branch touches a `.github/workflows/*.yml` or `*.yaml` file and the push credential (a GitHub OAuth token or PAT stored for the push target's host) lacks the `workflow` scope.
 GitHub rejects the push before the pipeline can open or update the PR.
 
 Resolve it by adding the `workflow` scope to your GitHub credential before pushing through `no-mistakes` again:
@@ -185,17 +185,25 @@ Resolve it by adding the `workflow` scope to your GitHub credential before pushi
 # If you authenticated gh via OAuth (web browser):
 gh auth refresh -s workflow
 
-# If you authenticated gh with a PAT, its scopes are immutable —
-# create a new PAT that includes the workflow scope at
+# If you authenticated gh with a classic PAT, its scopes are immutable —
+# create a new classic PAT that includes the workflow scope at
 # https://github.com/settings/tokens, then re-authenticate:
 gh auth login --with-token < new-pat.txt
 
-# Either way, configure git to use the refreshed credential:
+# If you authenticated gh with a fine-grained PAT, its repository
+# permissions are editable — set Workflows to Read and write at
+# https://github.com/settings/personal-access-tokens (the token value
+# stays the same, so no re-authentication is needed).
+
+# Then configure git to use the refreshed credential:
 gh auth setup-git
 ```
 
+If your push target's HTTPS remote embeds the PAT in its URL (for example `https://<token>@github.com/...`), `gh auth setup-git` updates only the credential helper.
+no-mistakes pushes using the token in the remote URL, so update that URL with the refreshed credential too.
+
 This only affects branches that modify workflow files.
-A branch that touches no `.github/workflows/*.yml` pushes normally with a standard `repo`-scoped token.
+A branch that touches no `.github/workflows/*.yml` or `*.yaml` pushes normally with a standard `repo`-scoped token.
 
 ### Rebase pauses because the branch carries unpushed default-branch commits
 

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -176,8 +176,8 @@ If the overwrite is intentional, push manually to the actual remote after review
 
 ### Push fails with `refusing to allow an OAuth App to create or update workflow ... without workflow scope`
 
-This means the branch touches `.github/workflows/*.yml` and the push credential (a GitHub OAuth token or PAT stored for the fork host) lacks the `workflow` scope.
-GitHub rejects the push to the fork before the pipeline can open or update the PR.
+This means the branch touches `.github/workflows/*.yml` and the push credential (a GitHub OAuth token or PAT stored for the push target's host) lacks the `workflow` scope.
+GitHub rejects the push before the pipeline can open or update the PR.
 
 Resolve it by adding the `workflow` scope to your GitHub credential before pushing through `no-mistakes` again:
 

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -174,6 +174,29 @@ This means the live remote branch changed after the pipeline's last observed hea
 Fetch and inspect the configured push target, then rebase or merge the remote work into your branch before pushing through `no-mistakes` again.
 If the overwrite is intentional, push manually to the actual remote after reviewing the commits that would be discarded.
 
+### Push fails with `refusing to allow an OAuth App to create or update workflow ... without workflow scope`
+
+This means the branch touches `.github/workflows/*.yml` and the push credential (a GitHub OAuth token or PAT stored for the fork host) lacks the `workflow` scope.
+GitHub rejects the push to the fork before the pipeline can open or update the PR.
+
+Resolve it by adding the `workflow` scope to your GitHub credential before pushing through `no-mistakes` again:
+
+```sh
+# If you authenticated gh via OAuth (web browser):
+gh auth refresh -s workflow
+
+# If you authenticated gh with a PAT, its scopes are immutable —
+# create a new PAT that includes the workflow scope at
+# https://github.com/settings/tokens, then re-authenticate:
+gh auth login --with-token < new-pat.txt
+
+# Either way, configure git to use the refreshed credential:
+gh auth setup-git
+```
+
+This only affects branches that modify workflow files.
+A branch that touches no `.github/workflows/*.yml` pushes normally with a standard `repo`-scoped token.
+
 ### Rebase pauses because the branch carries unpushed default-branch commits
 
 This means a local default branch ahead of `origin/<default_branch>` is a strict ancestor of your branch, so the branch may contain unrelated local-default work.

--- a/internal/scm/gitlab/gitlab_test.go
+++ b/internal/scm/gitlab/gitlab_test.go
@@ -508,8 +508,8 @@ func TestFetchFailedCheckTargetLogsReturnsPartialLogsWithRetrievalError(t *testi
 	host := New(gitlabTestCmdFactory(map[string]gitlabTestResponse{
 		"glab mr view 123 --output json":                                {stdout: `{"head_pipeline":{"id":77}}` + "\n"},
 		"glab ci get --pipeline-id 77 --output json --with-job-details": {stdout: `{"jobs":[{"id":55,"name":"build","status":"failed"},{"id":56,"name":"lint","status":"failed"}]}` + "\n"},
-		"glab ci trace 55": {stdout: "build failed\n"},
-		"glab ci trace 56": {stderr: "expired", code: 1},
+		"glab ci trace 55":                                              {stdout: "build failed\n"},
+		"glab ci trace 56":                                              {stderr: "expired", code: 1},
 	}), nil, "", "")
 
 	logs, err := host.FetchFailedCheckTargetLogs(context.Background(), &scm.PR{Number: "123"}, "", "", []scm.CheckTarget{{ProviderID: "gitlab-job:55"}, {ProviderID: "gitlab-job:56"}})

--- a/internal/scm/gitlab/gitlab_test.go
+++ b/internal/scm/gitlab/gitlab_test.go
@@ -508,8 +508,8 @@ func TestFetchFailedCheckTargetLogsReturnsPartialLogsWithRetrievalError(t *testi
 	host := New(gitlabTestCmdFactory(map[string]gitlabTestResponse{
 		"glab mr view 123 --output json":                                {stdout: `{"head_pipeline":{"id":77}}` + "\n"},
 		"glab ci get --pipeline-id 77 --output json --with-job-details": {stdout: `{"jobs":[{"id":55,"name":"build","status":"failed"},{"id":56,"name":"lint","status":"failed"}]}` + "\n"},
-		"glab ci trace 55":                                              {stdout: "build failed\n"},
-		"glab ci trace 56":                                              {stderr: "expired", code: 1},
+		"glab ci trace 55": {stdout: "build failed\n"},
+		"glab ci trace 56": {stderr: "expired", code: 1},
 	}), nil, "", "")
 
 	logs, err := host.FetchFailedCheckTargetLogs(context.Background(), &scm.PR{Number: "123"}, "", "", []scm.CheckTarget{{ProviderID: "gitlab-job:55"}, {ProviderID: "gitlab-job:56"}})


### PR DESCRIPTION
## Intent

Re-apply the linux gofmt alignment fix for gitlab_test.go map keys that was reverted by the previous pipeline CI fix round (which ran darwin gofmt). The two map keys 'glab ci trace 55' and 'glab ci trace 56' need to be aligned with the longer keys above them for linux gofmt 1.25.0. This is the same fix as before, re-applied because the pipeline's CI fix agent reverted it by running darwin gofmt.

## What Changed

- Added a troubleshooting entry for the `refusing to allow an OAuth App to create or update workflow ... without workflow scope` push failure, with recovery steps covering `gh auth refresh -s workflow` for OAuth, classic PAT replacement (scopes immutable), and fine-grained PAT `Workflows` permission editing, plus the note that `gh auth setup-git` only updates the credential helper so HTTPS remote URLs embedding the PAT must be refreshed separately.
- Added a cross-reference in the provider-integration fork-contributions guide pointing to the new troubleshooting section for branches that touch `.github/workflows/*.yml` or `*.yaml`.
- Re-applied the linux gofmt 1.25.0 alignment for the `glab ci trace 55` and `glab ci trace 56` map keys in `internal/scm/gitlab/gitlab_test.go`, which a prior CI fix round had reverted by running darwin gofmt.

## Risk Assessment

✅ Low: The net code change is zero — gitlab_test.go is restored to its base-commit linux-gofmt-aligned state — and the only net diff is straightforward, accurate documentation additions.

## Testing

Drove the affected gitlab test and the full gitlab package live against the built product (go1.27.1 darwin/amd64); both pass. Verified the two realigned map keys now share column 68 with the longer keys above them, and confirmed darwin gofmt would revert the alignment — the precise conflict the change resolves in favor of linux CI. No findings.

- Live validation: ✅ go - 3 of 4 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Affected test still passes after the alignment change (behavior preserved) | ✅ pass | live | go test ./internal/scm/gitlab/ -run TestFetchFailedCheckTargetLogsReturnsPartialLogsWithRetrievalError -v — PASS (0.35s) |
| Full gitlab package passes (no regression from the whitespace change) | ✅ pass | live | go test ./internal/scm/gitlab/ — ok |
| Two realigned map keys share the same brace column as the longer keys above (linux gofmt alignment) | ✅ pass | live | awk column check: lines 509-512 all place &#39;{&#39; at column 68 |
| linux gofmt 1.25.0 accepts the file as clean | ⏸️ untested | no | linux gofmt 1.25.0 is not available on this macOS host; only darwin gofmt is installed. The alignment pattern (all braces at col 68) matches linux gofmt output, and darwin gofmt&#39;s opposing diff confir… |

<details>
<summary>Evidence: gitlab_test gofmt alignment evidence</summary>

`go1.27.1 darwin/amd64 — TestFetchFailedCheckTargetLogsReturnsPartialLogsWithRetrievalError PASS; full gitlab package ok; all four map keys (lines 509-512) align brace at col 68; darwin gofmt -d would collapse the two short keys back to single-space (the revert this change fixes).`

```text
=== go version ===
go version go1.27.1 darwin/amd64

=== TestFetchFailedCheckTargetLogsReturnsPartialLogsWithRetrievalError ===
=== RUN   TestFetchFailedCheckTargetLogsReturnsPartialLogsWithRetrievalError
=== PAUSE TestFetchFailedCheckTargetLogsReturnsPartialLogsWithRetrievalError
=== CONT  TestFetchFailedCheckTargetLogsReturnsPartialLogsWithRetrievalError
--- PASS: TestFetchFailedCheckTargetLogsReturnsPartialLogsWithRetrievalError (0.35s)
PASS
ok  	github.com/kunchenguid/no-mistakes/internal/scm/gitlab	(cached)

=== full gitlab package ===
ok  	github.com/kunchenguid/no-mistakes/internal/scm/gitlab	(cached)

=== map key brace columns (lines 509-512) ===
line 509: brace at col 68
line 510: brace at col 68
line 511: brace at col 68
line 512: brace at col 68

=== darwin gofmt -d (shows darwin would revert the alignment) ===
diff internal/scm/gitlab/gitlab_test.go.orig internal/scm/gitlab/gitlab_test.go
--- internal/scm/gitlab/gitlab_test.go.orig
+++ internal/scm/gitlab/gitlab_test.go
@@ -508,8 +508,8 @@
 	host := New(gitlabTestCmdFactory(map[string]gitlabTestResponse{
 		"glab mr view 123 --output json":                                {stdout: `{"head_pipeline":{"id":77}}` + "\n"},
 		"glab ci get --pipeline-id 77 --output json --with-job-details": {stdout: `{"jobs":[{"id":55,"name":"build","status":"failed"},{"id":56,"name":"lint","status":"failed"}]}` + "\n"},
-		"glab ci trace 55":                                              {stdout: "build failed\n"},
-		"glab ci trace 56":                                              {stderr: "expired", code: 1},
+		"glab ci trace 55": {stdout: "build failed\n"},
+		"glab ci trace 56": {stderr: "expired", code: 1},
 	}), nil, "", "")
 
 	logs, err := host.FetchFailedCheckTargetLogs(context.Background(), &scm.PR{Number: "123"}, "", "", []scm.CheckTarget{{ProviderID: "gitlab-job:55"}, {ProviderID: "gitlab-job:56"}})
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"2d2215a7b5f6b68089246fdc609204bfa07b38e4","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 3 of 4 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| Affected test still passes after the alignment change (behavior preserved) | ✅ pass | live | go test ./internal/scm/gitlab/ -run TestFetchFailedCheckTargetLogsReturnsPartialLogsWithRetrievalError -v — PASS (0.35s) |
| Full gitlab package passes (no regression from the whitespace change) | ✅ pass | live | go test ./internal/scm/gitlab/ — ok |
| Two realigned map keys share the same brace column as the longer keys above (linux gofmt alignment) | ✅ pass | live | awk column check: lines 509-512 all place &#39;{&#39; at column 68 |
| linux gofmt 1.25.0 accepts the file as clean | ⏸️ untested | no | linux gofmt 1.25.0 is not available on this macOS host; only darwin gofmt is installed. The alignment pattern (all braces at col 68) matches linux gofmt output, and darwin gofmt&#39;s opposing diff confir… |

- `go test ./internal/scm/gitlab/ -run TestFetchFailedCheckTargetLogsReturnsPartialLogsWithRetrievalError -v`
- `go test ./internal/scm/gitlab/`
- `awk column check: all four map keys (lines 509-512) align brace at col 68`
- `gofmt -d internal/scm/gitlab/gitlab_test.go (darwin gofmt opposes the alignment, confirming linux-favoring direction)`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
