### PR TITLE
test(pipeline): use real git repo setup in gh-unavailable PR step test

### DIFF
--- a/internal/pipeline/steps/pr_test.go
+++ b/internal/pipeline/steps/pr_test.go
@@ -32,9 +32,9 @@ func TestPRStep_GhNotAvailable(t *testing.T) {
 		t.Skip("gh is available, skipping unavailable test")
 	}
 
-	dir := t.TempDir()
+	dir, baseSHA, headSHA := setupGitRepo(t)
 	ag := &mockAgent{name: "test"}
-	sctx := newTestContextWithDBRecords(t, ag, dir, "abc", "def", config.Commands{})
+	sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, config.Commands{})
 
 	step := &PRStep{}
 	outcome, err := step.Execute(sctx)


### PR DESCRIPTION
## What Changed

- Replaced the hardcoded `"abc"`/`"def"` base and head SHAs in `TestPRStep_GhNotAvailable` with a real git repo from the shared `setupGitRepo` helper, passing actual base and head SHAs to the step context.

## Risk Assessment

✅ Low: A two-line test-fixture correction that restores an existing test to pass under the newly-added head-continuity guard, with no production-code or behavior change.

## Testing

This is a test-only change: it fixes the TestPRStep_GhNotAvailable fixture so the missing-gh PR-step test provides a real git repo with matching recorded/actual head SHAs for the head-continuity guard. I reproduced the original failure at the base commit (the bare-tempdir fixture tripped the guard with 'not a git repository'), then ran the fixed test against the real PRStep.Execute on a real git repo with /usr/bin/gh genuinely removed from PATH - it executed (not skipped) and passed, including under -race. The head-continuity guard boundary and the sibling PR-step tests still pass, so the fixture change does not weaken the guard. No failures, no open issues.

- Live validation: ✅ go - 1 of 3 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| gh not installed: PR step resolves the worktree HEAD and skips gracefully instead of aborting | ✅ pass | live | PATH=/usr/local/go/bin:/tmp/opencode/bin-nogh CGO_ENABLED=1 go test -race ./internal/pipeline/steps/ -run TestPRStep_GhNotAvailable -v -count=1 -&gt; PASS (test executed, not skipped) |
| head-continuity guard still aborts a divergent worktree HEAD (boundary the fixture change must not weaken) | ⏸️ untested | no | Not established as live: the prior payload recorded live=false and cited only the unit test TestAssertPipelineHeadContinuity, which exercises the guard in-process rather than driving the real running… |
| regression reproduced: pre-fix bare-tempdir fixture trips the guard, post-fix real-repo fixture passes | ⏸️ untested | no | Not established as live: the prior payload recorded live=false and cited only a go test regression reproduction (running the old and new test fixtures), which is not driving the real running product.… |

<details>
<summary>Evidence: gh-not-available test transcript (regression + fix + guard boundary)</summary>

```text
Evidence: TestPRStep_GhNotAvailable fixture fix for head-continuity guard
Branch: fix/pr-step-gh-not-available
Base commit: ccf66403f683dfc7b08839e36780b5fd5e13dd11
Target commit: 3e9f74dbcce7fd2124fad56a7b2acfa2a8e57aa1

Change under test (internal/pipeline/steps/pr_test.go):
-  dir := t.TempDir()                                             ->  dir, baseSHA, headSHA := setupGitRepo(t)
-  sctx := newTestContextWithDBRecords(t, ag, dir, "abc", "def", ...) ->  sctx := newTestContextWithDBRecords(t, ag, dir, baseSHA, headSHA, ...)

The PR step (pr.go:61) runs assertPipelineHeadContinuity at entry, which calls
git.HeadSHA (git rev-parse HEAD) on sctx.WorkDir. The old fixture used a bare
temp dir (not a git repo) and fake SHAs "abc"/"def", so the guard errored with
"not a git repository" and the test failed on machines without gh.

1) Regression reproduction (base commit, gh removed from PATH):
$ git checkout ccf6640 -- internal/pipeline/steps/pr_test.go
$ PATH=/usr/local/go/bin:/tmp/opencode/bin-nogh go test ./internal/pipeline/steps/ -run TestPRStep_GhNotAvailable -v -count=1
--- FAIL: TestPRStep_GhNotAvailable (0.01s)
    pr_test.go:42: expected skip when gh is unavailable, got: resolve head before pr step:
    git rev-parse HEAD: exit status 128: fatal: not a git repository (or any parent up to mount point /)

2) Fixed behavior (target commit, gh removed from PATH, executed not skipped):
$ git checkout HEAD -- internal/pipeline/steps/pr_test.go
$ PATH=/usr/local/go/bin:/tmp/opencode/bin-nogh CGO_ENABLED=1 go test -race ./internal/pipeline/steps/ -run TestPRStep_GhNotAvailable -v -count=1
=== RUN   TestPRStep_GhNotAvailable
=== CONT  TestPRStep_GhNotAvailable
--- PASS: TestPRStep_GhNotAvailable (0.10s)
ok  github.com/kunchenguid/no-mistakes/internal/pipeline/steps  1.452s

The test actually executed (not skipped): /usr/bin/gh was removed from PATH via a
bin shim dir containing only git/gcc/cc symlinks, so exec.LookPath("gh") fails and
the missing-CLI path runs against the real PRStep.Execute on a real git repo.

3) Sibling PR-step tests (gh available, default PATH):
$ go test ./internal/pipeline/steps/ -run 'TestPRStep_' -count=1
ok  github.com/kunchenguid/no-mistakes/internal/pipeline/steps  1.494s

4) Head-continuity guard boundary (unchanged by this diff, still fails closed):
$ go test ./internal/pipeline/steps/ -run 'TestAssertPipelineHeadContinuity' -v -count=1
--- PASS: TestAssertPipelineHeadContinuity_AnchorIsRecordedReviewedHead (0.09s)
```
</details>
<details>
<summary>Evidence: Fixed test executed with gh absent (-race)</summary>

```text
=== RUN TestPRStep_GhNotAvailable
=== CONT TestPRStep_GhNotAvailable
--- PASS: TestPRStep_GhNotAvailable (0.10s)
ok github.com/kunchenguid/no-mistakes/internal/pipeline/steps 1.452s
```
</details>
<details>
<summary>Evidence: Pre-fix failure reproduced at base commit</summary>

```text
--- FAIL: TestPRStep_GhNotAvailable (0.01s)
pr_test.go:42: expected skip when gh is unavailable, got: resolve head before pr step: git rev-parse HEAD: exit status 128: fatal: not a git repository (or any parent up to mount point /)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"3e9f74dbcce7fd2124fad56a7b2acfa2a8e57aa1","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}],"live_validation":{"verdict":"go","live":1,"total":3}} -->

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 1 of 3 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| gh not installed: PR step resolves the worktree HEAD and skips gracefully instead of aborting | ✅ pass | live | PATH=/usr/local/go/bin:/tmp/opencode/bin-nogh CGO_ENABLED=1 go test -race ./internal/pipeline/steps/ -run TestPRStep_GhNotAvailable -v -count=1 -&gt; PASS (test executed, not skipped) |
| head-continuity guard still aborts a divergent worktree HEAD (boundary the fixture change must not weaken) | ⏸️ untested | no | Not established as live: the prior payload recorded live=false and cited only the unit test TestAssertPipelineHeadContinuity, which exercises the guard in-process rather than driving the real running… |
| regression reproduced: pre-fix bare-tempdir fixture trips the guard, post-fix real-repo fixture passes | ⏸️ untested | no | Not established as live: the prior payload recorded live=false and cited only a go test regression reproduction (running the old and new test fixtures), which is not driving the real running product.… |

- `git checkout ccf6640 -- internal/pipeline/steps/pr_test.go && PATH=/usr/local/go/bin:/tmp/opencode/bin-nogh go test ./internal/pipeline/steps/ -run TestPRStep_GhNotAvailable -v -count=1 (reproduced pre-fix FAIL: 'not a git repository')`
- `git checkout HEAD -- internal/pipeline/steps/pr_test.go && PATH=/usr/local/go/bin:/tmp/opencode/bin-nogh CGO_ENABLED=1 go test -race ./internal/pipeline/steps/ -run TestPRStep_GhNotAvailable -v -count=1 (post-fix PASS, test executed not skipped)`
- `go test ./internal/pipeline/steps/ -run 'TestPRStep_' -count=1 (sibling PR-step tests)`
- `go test ./internal/pipeline/steps/ -run 'TestAssertPipelineHeadContinuity' -v -count=1 (head-continuity guard boundary still fails closed)`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
