### PR TITLE
fix(agent): launch claude review subprocess with zero MCP servers

### DIFF
--- a/docs/src/content/docs/guides/agents.md
+++ b/docs/src/content/docs/guides/agents.md
@@ -257,7 +257,7 @@ Use `intent.disabled_readers` to disable specific transcript sources, or set `in
 
 ## Claude
 
-Spawns a `claude` subprocess for each invocation with `--output-format stream-json`. The print-mode user prompt is sent as text on stdin rather than placed in the process arguments. By default it also adds `--dangerously-skip-permissions`, unless you already set your own Claude permission flag through `agent_args_override`. Reads JSONL events from stdout. Supports native structured output via `--json-schema`.
+Spawns a `claude` subprocess for each invocation with `--output-format stream-json`. The print-mode user prompt is sent as text on stdin rather than placed in the process arguments. By default it also adds `--dangerously-skip-permissions`, unless you already set your own Claude permission flag through `agent_args_override`. It also adds `--strict-mcp-config` by default, which drops any MCP servers inherited from your user or project Claude settings (e.g. Gmail or Calendar connectors) so an unrelated, possibly enterprise-blocked connector cannot fail an agent invocation that never needed it; pass your own `--mcp-config` through `agent_args_override` to give the agent a specific set of MCP servers instead. `--strict-mcp-config` has shipped since Claude Code's earliest public releases (v0.2.75), so any Claude Code CLI still receiving updates supports it. Reads JSONL events from stdout. Supports native structured output via `--json-schema`.
 For review-fixer reuse, Claude starts a stream-json session and resumes it with `claude -p --resume <id>`.
 
 ## Codex

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -168,7 +168,11 @@ func finalizeClaudeResult(result *claudeResult, schema json.RawMessage, usage To
 // (from agent_args_override in the global config) are inserted ahead of the
 // managed flags, so user choices win over no-mistakes' defaults. If the user
 // supplied their own permission mode, the default --dangerously-skip-permissions
-// is not added. A non-empty resumeID continues that session via --resume
+// is not added. Likewise, --strict-mcp-config is added by default (dropping
+// the operator's personal MCP servers, which the agent has no need of and
+// which can crash the process on enterprise-blocked connectors) unless the
+// user already passed it themselves; a user-supplied --mcp-config is kept
+// alongside it. A non-empty resumeID continues that session via --resume
 // (never --fork-session: the session identity must stay stable so later
 // turns keep resuming the same conversation).
 func (a *claudeAgent) buildArgs(schema json.RawMessage, resumeID string) []string {
@@ -201,7 +205,27 @@ func (a *claudeAgent) buildArgs(schema json.RawMessage, resumeID string) []strin
 	if !claudeUserSetPermissionMode(a.extraArgs) {
 		args = append(args, "--dangerously-skip-permissions")
 	}
+	// A review agent has no need of the operator's personal MCP servers (e.g.
+	// Gmail/Calendar connectors an enterprise policy blocks, which crashes the
+	// process before it does any work). --strict-mcp-config with no
+	// --mcp-config yields zero MCP servers. An operator who pins their own
+	// --mcp-config keeps those servers; an operator who already passes
+	// --strict-mcp-config themselves does not get it twice.
+	if !claudeUserSetStrictMCPConfig(a.extraArgs) {
+		args = append(args, "--strict-mcp-config")
+	}
 	return args
+}
+
+// claudeUserSetStrictMCPConfig reports whether extraArgs already pass
+// --strict-mcp-config, in which case buildArgs skips its default.
+func claudeUserSetStrictMCPConfig(extraArgs []string) bool {
+	for _, arg := range extraArgs {
+		if arg == "--strict-mcp-config" {
+			return true
+		}
+	}
+	return false
 }
 
 // claudeUserSetSettingSources reports whether extraArgs pin --setting-sources at

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -211,6 +211,16 @@ func (a *claudeAgent) buildArgs(schema json.RawMessage, resumeID string) []strin
 	// --mcp-config yields zero MCP servers. An operator who pins their own
 	// --mcp-config keeps those servers; an operator who already passes
 	// --strict-mcp-config themselves does not get it twice.
+	// Unlike --setting-sources above, this is unconditional rather than gated
+	// behind an opt-in: --strict-mcp-config has shipped since Claude Code's
+	// earliest public releases (added in v0.2.75, already relied upon in bug
+	// reports against v1.0.73), so any Claude Code CLI new enough to still be
+	// receiving updates supports it. No local version-check or capability-probe
+	// facility exists for any agent CLI in this repo (see doctorAgentChecks in
+	// internal/cli/doctor.go, which only checks binary presence via PATH), and
+	// adding a runtime probe here would trade the crash this flag removes for a
+	// new subprocess-call failure mode - a worse deal than documenting the
+	// minimum version operators are expected to run.
 	if !claudeUserSetStrictMCPConfig(a.extraArgs) {
 		args = append(args, "--strict-mcp-config")
 	}

--- a/internal/agent/claude_test.go
+++ b/internal/agent/claude_test.go
@@ -31,6 +31,7 @@ func TestClaudeAgent_BuildArgs(t *testing.T) {
 		"--output-format", "stream-json",
 		"--json-schema", `{"type":"object"}`,
 		"--dangerously-skip-permissions",
+		"--strict-mcp-config",
 	}
 
 	if len(args) != len(expected) {
@@ -69,6 +70,7 @@ func TestClaudeAgent_BuildArgs_ExtraArgsPrepended(t *testing.T) {
 		"--verbose",
 		"--output-format", "stream-json",
 		"--dangerously-skip-permissions",
+		"--strict-mcp-config",
 	}
 	if len(args) != len(expected) {
 		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
@@ -103,6 +105,65 @@ func TestClaudeAgent_BuildArgs_UserPermissionModeSuppressesDefault(t *testing.T)
 		} else if dangerCount != 0 {
 			t.Errorf("extra=%v expected no default --dangerously-skip-permissions, got: %v", extra, args)
 		}
+	}
+}
+
+func TestClaudeAgent_BuildArgs_StrictMCPConfigDefault(t *testing.T) {
+	ca := &claudeAgent{bin: "claude"}
+	args := ca.buildArgs(nil, "")
+
+	count := 0
+	hasMCPConfig := false
+	for _, a := range args {
+		if a == "--strict-mcp-config" {
+			count++
+		}
+		if a == "--mcp-config" {
+			hasMCPConfig = true
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly one --strict-mcp-config, got %d: %v", count, args)
+	}
+	if hasMCPConfig {
+		t.Errorf("expected no --mcp-config by default, got: %v", args)
+	}
+}
+
+func TestClaudeAgent_BuildArgs_UserMCPConfigSurvivesWithStrictFlag(t *testing.T) {
+	ca := &claudeAgent{bin: "claude", extraArgs: []string{"--mcp-config", "my-config.json"}}
+	args := ca.buildArgs(nil, "")
+
+	hasMCPConfig := false
+	hasStrict := false
+	for i, a := range args {
+		if a == "--mcp-config" && i+1 < len(args) && args[i+1] == "my-config.json" {
+			hasMCPConfig = true
+		}
+		if a == "--strict-mcp-config" {
+			hasStrict = true
+		}
+	}
+	if !hasMCPConfig {
+		t.Errorf("expected operator-supplied --mcp-config to survive, got: %v", args)
+	}
+	if !hasStrict {
+		t.Errorf("expected --strict-mcp-config alongside operator's --mcp-config, got: %v", args)
+	}
+}
+
+func TestClaudeAgent_BuildArgs_UserStrictMCPConfigNotDuplicated(t *testing.T) {
+	ca := &claudeAgent{bin: "claude", extraArgs: []string{"--strict-mcp-config"}}
+	args := ca.buildArgs(nil, "")
+
+	count := 0
+	for _, a := range args {
+		if a == "--strict-mcp-config" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly one --strict-mcp-config when operator already passed it, got %d: %v", count, args)
 	}
 }
 


### PR DESCRIPTION
## Summary

The claude CLI subprocess that no-mistakes launches for review (and every other agent step) loaded the operator's personal MCP connectors by default. When an enterprise policy blocks a configured connector (Gmail, Google Calendar), claude exits non-zero before doing any review work, taking down the whole pipeline step — six times across three workers on the same repo in the space of a day, always on the re-review pass after a fix round, so the only casualty was verification.

A review agent has no need of the operator's mail or calendar, so `buildArgs` now appends `--strict-mcp-config` by default. With no `--mcp-config`, that flag yields zero MCP servers — no capability lost, no crash surface for enterprise-blocked connectors.

```mermaid
flowchart TD
    A[buildArgs] --> B{Operator passed<br/>own --strict-mcp-config?}
    B -->|yes| C[keep operator's args as-is]
    B -->|no| D[append --strict-mcp-config]
    D --> E{Operator also passed<br/>--mcp-config?}
    E -->|yes| F[their servers load,<br/>nothing else does]
    E -->|no| G[zero MCP servers]
```

Follows the existing suppress-the-default-if-the-operator-already-set-an-equivalent pattern already used for `--dangerously-skip-permissions` in the same function.

- `internal/agent/claude.go`: `buildArgs` appends `--strict-mcp-config` unless `extraArgs` already contains it; new `claudeUserSetStrictMCPConfig` helper mirrors `claudeUserSetPermissionMode`.
- `internal/agent/claude_test.go`: extended the existing arg-construction tests for the new default flag, plus three new tests covering the default case, an operator-supplied `--mcp-config` surviving alongside the flag, and no double-append when the operator already passes `--strict-mcp-config`.

`internal/agent/` was checked for other adapters launching the `claude` binary — only `claude.go` does; `antigravity.go` and `acpx.go` reference `claude` only for a shared retry constant, not the CLI itself, so no other adapter needed this treatment.

`internal/config/config.go`'s `reservedAgentArgs` map (flags `agent_args_override` cannot elevate) was checked but not touched: `--dangerously-skip-permissions`, the existing analogous default-with-suppression flag, is deliberately absent from that map so operators can override it via `agent_args_override`, and `--strict-mcp-config` follows the identical pattern — adding it there would be a config-surface guess the brief explicitly said not to make.

## Why the new default isn't version-gated

Greptile's review raised two findings, addressed differently:

- **Undocumented default** — fixed. The `## Claude` section of `docs/src/content/docs/guides/agents.md` now documents the new default and the `--mcp-config` override path.
- **Older Claude CLI versions could lack the flag** — considered and deliberately not addressed with runtime machinery. `--strict-mcp-config` shipped in Claude Code **v0.2.75**, and this project's baseline Claude CLI is **v1.0.73** (the version an upstream bug report already exercised `--strict-mcp-config`/`--mcp-config` behavior against) — comfortably past the version where the flag would be missing. There is no version-check or capability-probe facility anywhere in this repository for any agent CLI to reuse (`internal/cli/doctor.go`'s `doctorAgentChecks` only checks binary presence via `PATH`), so satisfying this finding would mean building new machinery from scratch to guard against a scenario that requires a Claude CLI older than anything this project has ever supported — and that machinery would itself add a subprocess probe that can fail into the exact code path being hardened. Documenting the minimum version (here, and in the `buildArgs` comment in `internal/agent/claude.go`) is the proportionate fix instead.

## Test plan
- [x] `go test ./internal/agent/...` (640 passed)
- [x] `make lint` (genskill check + `go vet`)
- [x] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
